### PR TITLE
docs: add Resources & Links section with cross-platform links

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,30 @@ curl -X POST https://YOUR_API/v1/fleet/run-scenario \
 
 ---
 
+## Resources & Links
+
+### Live Demo & Packages
+- **Live Demo**: [SCBE Swarm Coordinator](https://scbe-aethermoore-ezaociw8wy6t5rnaynzvzc.streamlit.app/) - Interactive Streamlit dashboard
+- **npm Package**: [scbe-aethermoore](https://www.npmjs.com/package/scbe-aethermoore) - `npm install scbe-aethermoore`
+- **GitHub Pages**: [Project Site](https://issdandavis.github.io/SCBE-AETHERMOORE/)
+
+### Documentation (Notion)
+- [SCBE-AETHERMOORE System State Report (Feb 2026)](https://aethermoorgames.notion.site/) - Production-ready docs
+- [SCBE + Sacred Eggs Integration Pack](https://aethermoorgames.notion.site/) - Complete integration guide
+- [Phase-Breath Hyperbolic Governance (14-Layer Core v1.2)](https://aethermoorgames.notion.site/) - Mathematical core mapping
+- [Polly Pads: Mode-Switching Architecture](https://aethermoorgames.notion.site/) - Autonomous AI architecture
+- [Topological Linearization for CFI](https://aethermoorgames.notion.site/) - Patent analysis & Hamiltonian paths
+
+### Products & Templates
+- **Gumroad**: [aethermoorgames.gumroad.com](https://aethermoorgames.gumroad.com) - Notion templates, AI workflow tools
+- **Ko-fi**: [ko-fi.com/izdandavis](https://ko-fi.com/izdandavis) - Support development
+
+### Social & Updates
+- **X/Twitter**: [@davisissac](https://x.com/davisissac)
+- **Substack**: [Issac "Izreal" Davis](https://substack.com/profile/153446638-issac-izreal-davis)
+
+---
+
 ## Contact
 
 **Issac Daniel Davis**


### PR DESCRIPTION
Add comprehensive Resources & Links section to README linking to:
- Streamlit live demo, npm package, GitHub Pages
- Published Notion documentation (System State Report, Integration Pack, Phase-Breath, Polly Pads, Topological Linearization)
- Gumroad products and Ko-fi support page
- X/Twitter and Substack social profiles

This improves discoverability across platforms and AI search tools.