### PR TITLE
fix(k8s): use nginx:alpine placeholder for agent images to fix Pending pods

### DIFF
--- a/k8s/agent-manifests/private-agents.yaml
+++ b/k8s/agent-manifests/private-agents.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: scbe-agent
       containers:
       - name: agent
-        image: scbe/agent:latest
+        image: nginx:alpine
         ports:
         - containerPort: 8080
           name: http
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: scbe-agent
       containers:
       - name: agent
-        image: scbe/agent:latest
+        image: nginx:alpine
         ports:
         - containerPort: 8080
           name: http
@@ -161,7 +161,7 @@ spec:
       serviceAccountName: scbe-agent
       containers:
       - name: agent
-        image: scbe/agent:latest
+        image: nginx:alpine
         ports:
         - containerPort: 8080
           name: http


### PR DESCRIPTION
Replaces scbe/agent:latest with nginx:alpine across all Private IP Tier agent deployments (AV, RU, CA) to resolve Pending pod status in scbe-test-cluster. The scbe/agent:latest image is not yet available in the registry, causing ImagePullBackOff errors. This temporary placeholder allows the pods to schedule and run while the actual agent images are being built.