### PR TITLE
chore: ignore .dbxignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ venv/
 .python-version
 
 # Editors / OS
+.dbxignore
 .vscode/
 .idea/
 .DS_Store


### PR DESCRIPTION
Ignore Dropbox .dbxignore to keep working trees clean.