### PR TITLE
Add DistributedWorkflowService scaffold for tiny-LLM adapters and cross-brand workflows

### DIFF
--- a/docs/DISTRIBUTED_AGENTIC_WORKFLOW.md
+++ b/docs/DISTRIBUTED_AGENTIC_WORKFLOW.md
@@ -1,0 +1,54 @@
+# Distributed Agentic Workflow Service
+
+This document outlines a practical path from governance-only operation to a distributed workflow execution model where small/tiny LLMs can be plugged in and inherit SCBE controls immediately.
+
+## System Mind Map
+
+```mermaid
+mindmap
+  root((SCBE Distributed Agentic Service))
+    Governance Foundation
+      14-Layer risk scoring
+      Sacred Tongues trust alignment
+      ALLOW QUARANTINE DENY gate
+    Distributed Runtime
+      Workflow templates
+      Step-level capability routing
+      Adapter selection by context window
+      Tenant-isolated execution IDs
+    Tiny LLM Integration
+      Adapter interface generate input output
+      Local on-device models
+      Cloud model fallback
+      Capability registry
+    Cross Branding
+      Brand profiles
+      Prompt prefix per tenant
+      Voice and output tagline
+      White-label output formatting
+    Agent Roles
+      Architect planning
+      Coder implementation
+      Tester validation
+      Security hardening
+    Enterprise Outcomes
+      Faster onboarding of partner brands
+      Lower inference cost with tiny models
+      Auditable step outputs
+      Immediate portability across systems
+```
+
+## Execution Flow
+
+1. Register one or more `BrandProfile` records for tenant/partner identities.
+2. Register tiny-LLM adapters with capabilities (planning, implementation, testing, security, etc.).
+3. Register a workflow template that defines ordered steps.
+4. Execute the workflow for a tenant prompt.
+5. Collect step outputs with adapter IDs and token usage for auditability.
+
+## Why this helps your stated goal
+
+- **Beyond governance only:** the service executes multi-step workflows, not just policy decisions.
+- **Tiny LLM ready:** each step routes to lightweight adapters with explicit capability matching.
+- **Cross-branded:** tenant prompt-prefix/voice/tagline enables white-label reuse across partner systems.
+- **Composable:** existing SCBE agent roles map directly to distributed workflow steps.

--- a/src/agentic/distributed-workflow.ts
+++ b/src/agentic/distributed-workflow.ts
@@ -1,0 +1,258 @@
+/**
+ * Distributed Agentic Workflow Service
+ *
+ * Enables cross-branded, tenant-aware workflow execution where tiny LLM adapters
+ * can be plugged in and immediately inherit SCBE governance context.
+ *
+ * @module agentic/distributed-workflow
+ */
+
+import { AgentRole, BuiltInAgent, ROLE_TONGUE_MAP } from './types';
+
+export type TinyLLMCapability =
+  | 'planning'
+  | 'implementation'
+  | 'analysis'
+  | 'testing'
+  | 'security'
+  | 'deployment';
+
+export interface TinyLLMAdapter {
+  id: string;
+  provider: string;
+  model: string;
+  capabilities: TinyLLMCapability[];
+  maxContextTokens: number;
+  generate(input: TinyLLMInput): Promise<TinyLLMOutput>;
+}
+
+export interface TinyLLMInput {
+  tenantId: string;
+  workflowId: string;
+  stepId: string;
+  role: AgentRole;
+  systemPrompt: string;
+  userPrompt: string;
+  context: Record<string, unknown>;
+}
+
+export interface TinyLLMOutput {
+  text: string;
+  tokensUsed: number;
+  latencyMs: number;
+}
+
+export interface BrandProfile {
+  id: string;
+  displayName: string;
+  voice: 'formal' | 'neutral' | 'concise';
+  promptPrefix: string;
+  outputTagline?: string;
+}
+
+export interface WorkflowStep {
+  id: string;
+  name: string;
+  role: AgentRole;
+  capability: TinyLLMCapability;
+  promptTemplate: string;
+}
+
+export interface WorkflowTemplate {
+  id: string;
+  name: string;
+  description: string;
+  steps: WorkflowStep[];
+}
+
+export interface WorkflowExecutionRequest {
+  tenantId: string;
+  brandProfileId: string;
+  workflowTemplateId: string;
+  userPrompt: string;
+  context?: Record<string, unknown>;
+}
+
+export interface WorkflowStepResult {
+  stepId: string;
+  adapterId: string;
+  output: string;
+  tokensUsed: number;
+  latencyMs: number;
+}
+
+export interface WorkflowExecutionResult {
+  executionId: string;
+  workflowTemplateId: string;
+  brandProfileId: string;
+  outputs: WorkflowStepResult[];
+  totalTokens: number;
+}
+
+/**
+ * Core service for distributed execution across tiny LLM adapters.
+ */
+export class DistributedWorkflowService {
+  private brandProfiles = new Map<string, BrandProfile>();
+  private adapters = new Map<string, TinyLLMAdapter>();
+  private templates = new Map<string, WorkflowTemplate>();
+
+  public registerBrandProfile(profile: BrandProfile): void {
+    this.brandProfiles.set(profile.id, profile);
+  }
+
+  public registerAdapter(adapter: TinyLLMAdapter): void {
+    this.adapters.set(adapter.id, adapter);
+  }
+
+  public registerTemplate(template: WorkflowTemplate): void {
+    this.templates.set(template.id, template);
+  }
+
+  public getAdaptersByCapability(capability: TinyLLMCapability): TinyLLMAdapter[] {
+    return Array.from(this.adapters.values()).filter((adapter) =>
+      adapter.capabilities.includes(capability)
+    );
+  }
+
+  public static bootstrapAgentsAsProfiles(agents: BuiltInAgent[]): BrandProfile[] {
+    return agents.map((agent) => ({
+      id: `${agent.role}-profile`,
+      displayName: `${agent.name} Runtime`,
+      voice: 'neutral',
+      promptPrefix: `You are ${agent.name}, role=${agent.role}, tongue=${ROLE_TONGUE_MAP[agent.role]}.`,
+      outputTagline: 'Governed by SCBE-AETHERMOORE',
+    }));
+  }
+
+  public async executeWorkflow(request: WorkflowExecutionRequest): Promise<WorkflowExecutionResult> {
+    const profile = this.brandProfiles.get(request.brandProfileId);
+    if (!profile) {
+      throw new Error(`Unknown brand profile: ${request.brandProfileId}`);
+    }
+
+    const template = this.templates.get(request.workflowTemplateId);
+    if (!template) {
+      throw new Error(`Unknown workflow template: ${request.workflowTemplateId}`);
+    }
+
+    const executionId = this.newExecutionId();
+    const outputs: WorkflowStepResult[] = [];
+
+    for (const step of template.steps) {
+      const adapter = this.selectAdapter(step.capability);
+      const stepPrompt = this.renderPrompt(step.promptTemplate, request.userPrompt, outputs);
+      const systemPrompt = this.buildSystemPrompt(profile, step);
+
+      const response = await adapter.generate({
+        tenantId: request.tenantId,
+        workflowId: template.id,
+        stepId: step.id,
+        role: step.role,
+        systemPrompt,
+        userPrompt: stepPrompt,
+        context: request.context || {},
+      });
+
+      outputs.push({
+        stepId: step.id,
+        adapterId: adapter.id,
+        output: this.decorateOutput(profile, response.text),
+        tokensUsed: response.tokensUsed,
+        latencyMs: response.latencyMs,
+      });
+    }
+
+    const totalTokens = outputs.reduce((sum, out) => sum + out.tokensUsed, 0);
+
+    return {
+      executionId,
+      workflowTemplateId: template.id,
+      brandProfileId: profile.id,
+      outputs,
+      totalTokens,
+    };
+  }
+
+  private selectAdapter(capability: TinyLLMCapability): TinyLLMAdapter {
+    const candidates = this.getAdaptersByCapability(capability);
+    if (candidates.length === 0) {
+      throw new Error(`No adapters registered for capability: ${capability}`);
+    }
+
+    return candidates.sort((a, b) => b.maxContextTokens - a.maxContextTokens)[0];
+  }
+
+  private buildSystemPrompt(profile: BrandProfile, step: WorkflowStep): string {
+    return [
+      profile.promptPrefix,
+      `Brand voice: ${profile.voice}.`,
+      `Workflow step: ${step.name} (${step.id}).`,
+      `Agent role: ${step.role}.`,
+      `Capability: ${step.capability}.`,
+      'Comply with SCBE risk governance and produce deterministic, auditable output.',
+    ].join(' ');
+  }
+
+  private decorateOutput(profile: BrandProfile, output: string): string {
+    if (!profile.outputTagline) {
+      return output;
+    }
+
+    return `${output}\n\n— ${profile.outputTagline}`;
+  }
+
+  private renderPrompt(
+    template: string,
+    userPrompt: string,
+    previous: WorkflowStepResult[]
+  ): string {
+    const previousOutput = previous.length > 0 ? previous[previous.length - 1].output : 'None';
+
+    return template
+      .replaceAll('{{user_prompt}}', userPrompt)
+      .replaceAll('{{previous_output}}', previousOutput);
+  }
+
+  private newExecutionId(): string {
+    return `wf_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  }
+}
+
+export const DEFAULT_DISTRIBUTED_TEMPLATE: WorkflowTemplate = {
+  id: 'distributed-build-and-verify',
+  name: 'Distributed Build and Verify',
+  description: 'Plan, implement, test, and security-check with tiny LLM workers.',
+  steps: [
+    {
+      id: 'plan',
+      name: 'Planning',
+      role: 'architect',
+      capability: 'planning',
+      promptTemplate:
+        'Create an implementation plan for: {{user_prompt}}. Consider SCBE constraints.',
+    },
+    {
+      id: 'implement',
+      name: 'Implementation',
+      role: 'coder',
+      capability: 'implementation',
+      promptTemplate:
+        'Using this plan: {{previous_output}}, implement core logic for: {{user_prompt}}.',
+    },
+    {
+      id: 'test',
+      name: 'Testing',
+      role: 'tester',
+      capability: 'testing',
+      promptTemplate: 'Generate tests for implementation output: {{previous_output}}.',
+    },
+    {
+      id: 'security',
+      name: 'Security Review',
+      role: 'security',
+      capability: 'security',
+      promptTemplate: 'Review for vulnerabilities: {{previous_output}}.',
+    },
+  ],
+};

--- a/src/agentic/index.ts
+++ b/src/agentic/index.ts
@@ -20,3 +20,5 @@ export * from './collaboration';
 export * from './platform';
 export * from './task-group';
 export * from './types';
+
+export * from './distributed-workflow';

--- a/tests/agentic/distributed-workflow.test.ts
+++ b/tests/agentic/distributed-workflow.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DISTRIBUTED_TEMPLATE,
+  DistributedWorkflowService,
+  TinyLLMAdapter,
+} from '../../src/agentic/distributed-workflow';
+import { createBuiltInAgents } from '../../src/agentic/agents';
+
+function makeAdapter(
+  id: string,
+  capability: TinyLLMAdapter['capabilities'][number],
+  maxContextTokens = 4096
+): TinyLLMAdapter {
+  return {
+    id,
+    provider: 'local',
+    model: 'tiny-llm',
+    capabilities: [capability],
+    maxContextTokens,
+    async generate(input) {
+      return {
+        text: `[${id}] ${input.stepId}: ${input.userPrompt.slice(0, 40)}`,
+        tokensUsed: 42,
+        latencyMs: 10,
+      };
+    },
+  };
+}
+
+describe('DistributedWorkflowService', () => {
+  it('executes distributed template end-to-end with tiny adapters', async () => {
+    const svc = new DistributedWorkflowService();
+
+    svc.registerBrandProfile({
+      id: 'acme',
+      displayName: 'Acme Labs',
+      voice: 'formal',
+      promptPrefix: 'You represent Acme Labs engineering.',
+      outputTagline: 'Acme Secure Runtime',
+    });
+
+    svc.registerTemplate(DEFAULT_DISTRIBUTED_TEMPLATE);
+    svc.registerAdapter(makeAdapter('plan-adapter', 'planning'));
+    svc.registerAdapter(makeAdapter('impl-adapter', 'implementation'));
+    svc.registerAdapter(makeAdapter('test-adapter', 'testing'));
+    svc.registerAdapter(makeAdapter('sec-adapter', 'security'));
+
+    const result = await svc.executeWorkflow({
+      tenantId: 'tenant-1',
+      brandProfileId: 'acme',
+      workflowTemplateId: DEFAULT_DISTRIBUTED_TEMPLATE.id,
+      userPrompt: 'build a secure API endpoint for invoice creation',
+    });
+
+    expect(result.outputs).toHaveLength(4);
+    expect(result.totalTokens).toBe(168);
+    expect(result.outputs[0].adapterId).toBe('plan-adapter');
+    expect(result.outputs[3].output).toContain('Acme Secure Runtime');
+  });
+
+  it('prefers higher-context adapter when multiple satisfy capability', async () => {
+    const svc = new DistributedWorkflowService();
+
+    svc.registerBrandProfile({
+      id: 'brand',
+      displayName: 'Brand',
+      voice: 'neutral',
+      promptPrefix: 'Brand prompt',
+    });
+
+    svc.registerTemplate({
+      id: 'single-step',
+      name: 'Single',
+      description: 'single step test',
+      steps: [
+        {
+          id: 'plan',
+          name: 'Plan',
+          role: 'architect',
+          capability: 'planning',
+          promptTemplate: '{{user_prompt}}',
+        },
+      ],
+    });
+
+    svc.registerAdapter(makeAdapter('small-planner', 'planning', 1024));
+    svc.registerAdapter(makeAdapter('large-planner', 'planning', 8192));
+
+    const result = await svc.executeWorkflow({
+      tenantId: 't',
+      brandProfileId: 'brand',
+      workflowTemplateId: 'single-step',
+      userPrompt: 'plan this',
+    });
+
+    expect(result.outputs[0].adapterId).toBe('large-planner');
+  });
+
+  it('throws clear error when capability adapter is missing', async () => {
+    const svc = new DistributedWorkflowService();
+
+    svc.registerBrandProfile({
+      id: 'brand',
+      displayName: 'Brand',
+      voice: 'neutral',
+      promptPrefix: 'Brand prompt',
+    });
+
+    svc.registerTemplate(DEFAULT_DISTRIBUTED_TEMPLATE);
+
+    await expect(
+      svc.executeWorkflow({
+        tenantId: 'tenant',
+        brandProfileId: 'brand',
+        workflowTemplateId: DEFAULT_DISTRIBUTED_TEMPLATE.id,
+        userPrompt: 'missing adapters should fail',
+      })
+    ).rejects.toThrow('No adapters registered for capability: planning');
+  });
+
+  it('can bootstrap cross-brand profiles from built-in agents', () => {
+    const agents = createBuiltInAgents('openai');
+    const profiles = DistributedWorkflowService.bootstrapAgentsAsProfiles(agents);
+
+    expect(profiles).toHaveLength(6);
+    expect(profiles[0].promptPrefix).toContain('tongue=');
+    expect(profiles[0].outputTagline).toBe('Governed by SCBE-AETHERMOORE');
+  });
+});

--- a/tests/test_homebrew_quick.py
+++ b/tests/test_homebrew_quick.py
@@ -33,8 +33,11 @@ except ImportError:
 try:
     from src.crypto.rwp_v3 import RWPv3Protocol
 
+    # Import can succeed even when runtime crypto deps are missing.
+    # Instantiate once so skip markers reflect true availability.
+    RWPv3Protocol()
     RWP_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     RWP_AVAILABLE = False
 
 try:


### PR DESCRIPTION
### Motivation
- Provide a concrete execution layer that moves the project beyond governance-only checks into multi-step distributed workflows powered by tiny LLM workers.
- Enable tenant/brand white-labeling and audited, step-level outputs so lightweight models can be onboarded quickly while preserving SCBE governance context.
- Improve test resilience by ensuring optional runtime crypto dependencies do not cause spurious test failures in quick smoke suites.

### Description
- Add `DistributedWorkflowService` and related types in `src/agentic/distributed-workflow.ts`, including a `TinyLLMAdapter` interface, capability-based routing, adapter selection, prompt rendering, output decoration, and an exported `DEFAULT_DISTRIBUTED_TEMPLATE` (plan → implement → test → security).
- Export the new module from the `agentic` package surface via `src/agentic/index.ts` so consumers can import the distributed workflow API directly.
- Add targeted Vitest coverage in `tests/agentic/distributed-workflow.test.ts` to validate end-to-end execution, adapter selection by `maxContextTokens`, error behavior when capabilities are missing, and bootstrap profile generation from built-in agents.
- Add `docs/DISTRIBUTED_AGENTIC_WORKFLOW.md` with a system mind map and execution flow, and harden the homebrew smoke test `tests/test_homebrew_quick.py` so RWP runtime crypto dependency absence is skipped instead of failing test discovery.

### Testing
- Ran the relevant Vitest suites with `npm run test` for `tests/agentic/platform.test.ts` and `tests/agentic/distributed-workflow.test.ts`, and all agentic tests passed (33 tests passed).
- Ran the distributed-workflow-only Vitest run and the new tests passed (`4 tests` passed).
- Ran the Python quick smoke suite with `pytest -q tests/test_homebrew_quick.py -m homebrew`, resulting in `29 passed, 2 skipped` after hardening imports.
- Ran `npm run typecheck`, which currently fails due to pre-existing unrelated TypeScript syntax errors in other files (`src/fleet/polly-pads/index.ts` and `src/harmonic/hyperbolicRAG.ts`), so typecheck is not green in this branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d72a32b60832286be62bf81507d6f)