### PR TITLE
Add Notion-sync placeholder docs and README links

### DIFF
--- a/docs/AETHERAUTH_IMPLEMENTATION.md
+++ b/docs/AETHERAUTH_IMPLEMENTATION.md
@@ -1,0 +1,24 @@
+# AetherAuth Implementation (Notion & Perplexity Bridge)
+
+## Description
+Implementation placeholder for AetherAuth bridges, including Notion synchronization and Perplexity integration touchpoints.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Architecture
+_Content pending Notion sync._
+
+## Implementation Notes
+_Content pending Notion sync._
+
+## Usage
+_Content pending Notion sync._
+
+## API Reference
+_Content pending Notion sync._

--- a/docs/COMMERCIAL_AGREEMENT.md
+++ b/docs/COMMERCIAL_AGREEMENT.md
@@ -1,0 +1,24 @@
+# Commercial Agreement Technology Schedule
+
+## Description
+Documentation placeholder for the technical schedule associated with the commercial agreement framework.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Scope
+_Content pending Notion sync._
+
+## Technical Schedule
+_Content pending Notion sync._
+
+## Dependencies
+_Content pending Notion sync._
+
+## Change Control
+_Content pending Notion sync._

--- a/docs/DRONE_FLEET_UPGRADES.md
+++ b/docs/DRONE_FLEET_UPGRADES.md
@@ -1,0 +1,24 @@
+# Drone Fleet Architecture Upgrades for SCBE-AETHERMOORE Integration
+
+## Description
+Placeholder for drone fleet architecture upgrades and integration requirements with the SCBE-AETHERMOORE platform.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Architecture
+_Content pending Notion sync._
+
+## Implementation Notes
+_Content pending Notion sync._
+
+## Usage
+_Content pending Notion sync._
+
+## API Reference
+_Content pending Notion sync._

--- a/docs/GEOSEAL_ACCESS_CONTROL.md
+++ b/docs/GEOSEAL_ACCESS_CONTROL.md
@@ -1,0 +1,24 @@
+# GeoSeal Geometric Access Control Kernel - RAG Immune System
+
+## Description
+Reference placeholder for the GeoSeal geometric access control kernel and its role as a defensive RAG immune system layer.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Architecture
+_Content pending Notion sync._
+
+## Implementation Notes
+_Content pending Notion sync._
+
+## Usage
+_Content pending Notion sync._
+
+## API Reference
+_Content pending Notion sync._

--- a/docs/GOOGLE_CLOUD_SETUP.md
+++ b/docs/GOOGLE_CLOUD_SETUP.md
@@ -1,0 +1,24 @@
+# Google Cloud Infrastructure Setup for SCBE-AETHERMOORE
+
+## Description
+Setup placeholder for Google Cloud infrastructure, environment bootstrapping, and platform service configuration.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Prerequisites
+_Content pending Notion sync._
+
+## Infrastructure Architecture
+_Content pending Notion sync._
+
+## Setup Steps
+_Content pending Notion sync._
+
+## Operations
+_Content pending Notion sync._

--- a/docs/HYDRA_COORDINATION.md
+++ b/docs/HYDRA_COORDINATION.md
@@ -1,0 +1,24 @@
+# HYDRA Multi-Agent Coordination System
+
+## Description
+Architecture documentation for the HYDRA orchestration model that coordinates specialized agents, routing, and consensus behaviors across SCBE-AETHERMOORE.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Architecture
+_Content pending Notion sync._
+
+## Coordination Flows
+_Content pending Notion sync._
+
+## Operational Guidance
+_Content pending Notion sync._
+
+## Interfaces
+_Content pending Notion sync._

--- a/docs/MULTI_AI_COORDINATION.md
+++ b/docs/MULTI_AI_COORDINATION.md
@@ -1,0 +1,24 @@
+# Multi-AI Development Coordination System
+
+## Description
+Working placeholder for multi-AI collaboration flows, handoff mechanics, and governance controls.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Architecture
+_Content pending Notion sync._
+
+## Coordination Flows
+_Content pending Notion sync._
+
+## Operational Guidance
+_Content pending Notion sync._
+
+## Interfaces
+_Content pending Notion sync._

--- a/docs/PHDM_NOMENCLATURE.md
+++ b/docs/PHDM_NOMENCLATURE.md
@@ -1,0 +1,24 @@
+# PHDM Nomenclature Reference with Canonical Definitions
+
+## Description
+Reference placeholder for canonical PHDM terminology, definitions, and naming conventions.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Canonical Terms
+_Content pending Notion sync._
+
+## Definitions
+_Content pending Notion sync._
+
+## Usage Guidance
+_Content pending Notion sync._
+
+## Cross-References
+_Content pending Notion sync._

--- a/docs/QUASI_VECTOR_MAGNETICS.md
+++ b/docs/QUASI_VECTOR_MAGNETICS.md
@@ -1,0 +1,24 @@
+# Quasi-Vector Spin Voxels & Magnetics Integration
+
+## Description
+Implementation-oriented placeholder covering quasi-vector spin voxel concepts and magnetics integration pathways.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Architecture
+_Content pending Notion sync._
+
+## Implementation Notes
+_Content pending Notion sync._
+
+## Usage
+_Content pending Notion sync._
+
+## API Reference
+_Content pending Notion sync._

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,22 @@ docs/
 - [Architecture Overview](01-architecture/README.md) - System design
 - [Technical Reference](02-technical/README.md) - Deep technical docs
 
+### Notion Sync Placeholders
+- [HYDRA Multi-Agent Coordination System](HYDRA_COORDINATION.md)
+- [GeoSeal Geometric Access Control Kernel - RAG Immune System](GEOSEAL_ACCESS_CONTROL.md)
+- [Quasi-Vector Spin Voxels & Magnetics Integration](QUASI_VECTOR_MAGNETICS.md)
+- [SS1 Tokenizer Protocol for Sacred Tongue Integration](SS1_TOKENIZER_PROTOCOL.md)
+- [Multi-AI Development Coordination System](MULTI_AI_COORDINATION.md)
+- [Swarm Deployment Formations](SWARM_FORMATIONS.md)
+- [AetherAuth Implementation (Notion & Perplexity Bridge)](AETHERAUTH_IMPLEMENTATION.md)
+- [Google Cloud Infrastructure Setup for SCBE-AETHERMOORE](GOOGLE_CLOUD_SETUP.md)
+- [PHDM Nomenclature Reference with Canonical Definitions](PHDM_NOMENCLATURE.md)
+- [Commercial Agreement Technology Schedule](COMMERCIAL_AGREEMENT.md)
+- [Six Tongues + GeoSeal CLI Python Implementation Guide](SIX_TONGUES_CLI.md)
+- [SCBE-AETHERMOORE v3.0.0 Unified System Report](UNIFIED_SYSTEM_REPORT.md)
+- [Drone Fleet Architecture Upgrades for SCBE-AETHERMOORE Integration](DRONE_FLEET_UPGRADES.md)
+- [WorldForge Complete Worldbuilding & Conlang Template](WORLDFORGE_TEMPLATE.md)
+
 ---
 
 ## Key Features

--- a/docs/SIX_TONGUES_CLI.md
+++ b/docs/SIX_TONGUES_CLI.md
@@ -1,0 +1,24 @@
+# Six Tongues + GeoSeal CLI Python Implementation Guide
+
+## Description
+Guide placeholder for Python CLI implementation details spanning Six Tongues and GeoSeal workflows.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Architecture
+_Content pending Notion sync._
+
+## Installation
+_Content pending Notion sync._
+
+## Usage
+_Content pending Notion sync._
+
+## Command Reference
+_Content pending Notion sync._

--- a/docs/SS1_TOKENIZER_PROTOCOL.md
+++ b/docs/SS1_TOKENIZER_PROTOCOL.md
@@ -1,0 +1,24 @@
+# SS1 Tokenizer Protocol for Sacred Tongue Integration
+
+## Description
+Protocol placeholder for SS1 tokenization, sacred tongue parsing, and interoperability requirements.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Architecture
+_Content pending Notion sync._
+
+## Implementation Notes
+_Content pending Notion sync._
+
+## Usage
+_Content pending Notion sync._
+
+## API Reference
+_Content pending Notion sync._

--- a/docs/SWARM_FORMATIONS.md
+++ b/docs/SWARM_FORMATIONS.md
@@ -1,0 +1,24 @@
+# Swarm Deployment Formations
+
+## Description
+Placeholder for swarm deployment topology patterns, formation strategies, and operational constraints.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Formation Types
+_Content pending Notion sync._
+
+## Deployment Strategy
+_Content pending Notion sync._
+
+## Operational Constraints
+_Content pending Notion sync._
+
+## Telemetry
+_Content pending Notion sync._

--- a/docs/UNIFIED_SYSTEM_REPORT.md
+++ b/docs/UNIFIED_SYSTEM_REPORT.md
@@ -1,0 +1,24 @@
+# SCBE-AETHERMOORE v3.0.0 Unified System Report
+
+## Description
+Reporting placeholder for unified system status, architecture synthesis, and release-level findings for v3.0.0.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## System Architecture Snapshot
+_Content pending Notion sync._
+
+## Findings
+_Content pending Notion sync._
+
+## Recommendations
+_Content pending Notion sync._
+
+## Appendices
+_Content pending Notion sync._

--- a/docs/WORLDFORGE_TEMPLATE.md
+++ b/docs/WORLDFORGE_TEMPLATE.md
@@ -1,0 +1,24 @@
+# WorldForge Complete Worldbuilding & Conlang Template
+
+## Description
+Template placeholder for WorldForge worldbuilding assets and conlang design scaffolding.
+
+## Source
+This document is a placeholder and will be synced from Notion.
+
+- **Last Synced:** `TBD`
+
+## Overview
+_Content pending Notion sync._
+
+## Template Structure
+_Content pending Notion sync._
+
+## Customization Guidance
+_Content pending Notion sync._
+
+## Usage
+_Content pending Notion sync._
+
+## Reference
+_Content pending Notion sync._


### PR DESCRIPTION
### Motivation
- Provide repo-native placeholders for documentation that will be synced from Notion so topics are discoverable and scaffolded ahead of content import.
- Consolidate documentation index discoverability by adding a dedicated "Notion Sync Placeholders" section in `docs/README.md` linking each placeholder.

### Description
- Added 14 new placeholder files under `docs/` (e.g., `HYDRA_COORDINATION.md`, `GEOSEAL_ACCESS_CONTROL.md`, `QUASI_VECTOR_MAGNETICS.md`, etc.) each containing a title heading, brief description, a `Source` note stating it will be synced from Notion, a `- **Last Synced:** `TBD`` field, and topic-relevant scaffold sections (Overview, Architecture, Usage, API Reference variants).
- Updated `docs/README.md` to include a `Notion Sync Placeholders` section with links to all newly added documents for discoverability.
- Staged and committed the new files and README changes to the repository.

### Testing
- Verified presence of the placeholder indicators with `rg -n "Last Synced|This document is a placeholder and will be synced from Notion"` across all new `docs/*.md` files and confirmed the expected lines were found; the check succeeded.
- Sampled file contents using `sed -n` / `nl` to confirm each new document contains the title heading and scaffold sections; the inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8b000c9c8322b48af2a619d96ac1)