### PR TITLE
Fix TypeScript compilation blockers in hyperbolicRAG and duplicate export conflicts

### DIFF
--- a/src/ai_brain/index.ts
+++ b/src/ai_brain/index.ts
@@ -357,7 +357,7 @@ export {
   phaseDeviation,
   quantize as braidQuantize,
   quantizeVector as braidQuantizeVector,
-  refactorAlign,
+  refactorAlign as braidRefactorAlign,
   ternaryCenter,
   zeroGravityDistance,
   type BraidConfig,

--- a/src/ai_brain/unified-kernel.ts
+++ b/src/ai_brain/unified-kernel.ts
@@ -419,6 +419,7 @@ export function computeMetrics(
     decision: combinedRiskScore > 0.7 ? 'DENY' : combinedRiskScore > 0.4 ? 'QUARANTINE' : 'ALLOW',
     anyFlagged: combinedRiskScore > 0.5,
     flagCount: combinedRiskScore > 0.5 ? 1 : 0,
+    timestamp: Date.now(),
   };
 
   return {

--- a/src/fleet/polly-pads/index.ts
+++ b/src/fleet/polly-pads/index.ts
@@ -62,6 +62,7 @@ export {
 } from './specialist-modes.js';
 
 // Specialist Modes (Refactored Mode Classes & Types)
+export {
   type SpecialistMode as LegacySpecialistMode,
   type ModeTool as LegacyModeTool,
   type ModeState as LegacyModeState,
@@ -116,42 +117,6 @@ export {
   type ModeConfig,
   MODE_CONFIGS,
 } from './modes/index.js';
-
-// Closed Network (Air-Gapped Communications)
-// Specialist Mode Registry (legacy/alternate implementation)
-// Note: its internal type names conflict with ./modes/types, so we only export
-// the registry wrapper + id type here.
-export {
-  ModeRegistry,
-  ALL_MODE_IDS,
-  type SpecialistModeId,
-} from './specialist-modes.js';
-
-// Closed Network (Air-Gapped)
-export {
-  ClosedNetwork,
-  DEFAULT_CLOSED_CONFIG,
-  BLOCKED_NETWORKS,
-  type NetworkChannel,
-  type BlockedCategory,
-  type NetworkMessage,
-  type ClosedNetworkConfig,
-} from './closed-network.js';
-
-// Squad Coordination (Byzantine Consensus)
-export {
-  Squad,
-  type ConsensusDecision,
-  type SquadProposal,
-  type SquadConfig,
-} from './squad.js';
-
-// Mission Coordinator
-export {
-  MissionCoordinator,
-  type MissionPhase,
-  type CrisisAssessment,
-} from './mission-coordinator.js';
 
 // Voxel Record Types (6D addressing + Byzantine quorum)
 export {

--- a/src/harmonic/hyperbolicRAG.ts
+++ b/src/harmonic/hyperbolicRAG.ts
@@ -24,12 +24,13 @@ import {
   hyperbolicDistance6D,
   poincareNorm,
   projectIntoBall,
-  accessCost,
+  accessCost as chsfnAccessCost,
   tongueImpedanceAt,
   type CHSFNState,
   type TongueImpedance,
   DEFAULT_IMPEDANCE,
 } from './chsfn.js';
+/**
  * @layer Layer 5, Layer 7, Layer 12, Layer 13
  * @component HyperbolicRAG — Poincaré Ball Retrieval-Augmented Generation
  * @version 3.2.4
@@ -357,8 +358,8 @@ export function proximityScore(
   const dist = hyperbolicDistance6D(queryPos, chunkPos);
   if (dist > maxDist) return 0;
   // Use access cost for exponential decay, but normalize
-  const cost = accessCost(dist);
-  const baseCost = accessCost(0);
+  const cost = chsfnAccessCost(dist);
+  const baseCost = chsfnAccessCost(0);
   return baseCost / cost; // Ratio: cost at origin / cost at d → decays exponentially
 }
 
@@ -574,6 +575,8 @@ export function quarantineReport(
       quarantineRate: chunks.length > 0 ? quarantined.length / chunks.length : 0,
     },
   };
+}
+
 /** A document embedded in the Poincaré ball for retrieval. */
 export interface RAGDocument {
   /** Unique identifier */

--- a/src/harmonic/index.ts
+++ b/src/harmonic/index.ts
@@ -284,7 +284,7 @@ export {
   type IntrusionResult,
   type Point6D,
   // Types
-  type FluxState,
+  type FluxState as PHDMFluxState,
   type Polyhedron,
   type PolyhedronFamily,
 } from './phdm.js';


### PR DESCRIPTION
### Motivation
- A malformed comment/import region and a missing brace in `src/harmonic/hyperbolicRAG.ts` caused parse errors and cascaded into many TypeScript failures in the daily review workflow.
- Duplicate re-exports and conflicting exported identifiers across several barrel files produced `Duplicate identifier` errors during typechecking.
- A `CombinedAssessment` object was missing its required `timestamp` field, causing a type error in the unified kernel metrics path.

### Description
- Restored/cleaned JSDoc and fixed the parse break in `src/harmonic/hyperbolicRAG.ts`, aliased the CHSFN `accessCost` import to `chsfnAccessCost`, and closed the `quarantineReport` function properly so subsequent declarations parse.
- Removed duplicated re-export blocks and repaired export syntax in `src/fleet/polly-pads/index.ts` to eliminate repeated identifiers.
- Aliased conflicting barrel exports to avoid name collisions by exporting `FluxState` from `phdm` as `PHDMFluxState` in `src/harmonic/index.ts` and `refactorAlign` from `hamiltonian-braid` as `braidRefactorAlign` in `src/ai_brain/index.ts`.
- Added the required `timestamp: Date.now()` field to the `CombinedAssessment` object in `src/ai_brain/unified-kernel.ts` to satisfy the `CombinedAssessment` interface.

### Testing
- Ran TypeScript typecheck with `npm run -s typecheck`, which completed successfully after the fixes.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9e10de6083229d193b24639a255a)