### PR TITLE
Clean remaining polly-pads merge artifacts on main

### DIFF
--- a/src/fleet/polly-pads/closed-network.ts
+++ b/src/fleet/polly-pads/closed-network.ts
@@ -1,5 +1,5 @@
 /**
-* @layer Layer 13, Layer 14
+ * @layer Layer 13, Layer 14
  * @component Polly Pads — Closed Network (Air-Gapped)
  * @version 1.0.0
  *

--- a/src/fleet/polly-pads/index.ts
+++ b/src/fleet/polly-pads/index.ts
@@ -49,11 +49,6 @@ export {
   type MemoryEntry,
 } from './mode-pad.js';
 
-// Specialist Modes (Original Mode Registry)
-// ============================================================================
-// Specialist Modes (Canonical: ./modes)
-// ============================================================================
-
 // Specialist Modes (Dynamic Mode Switching) — legacy registry
 export {
   ModeRegistry,

--- a/src/fleet/polly-pads/mission-coordinator.ts
+++ b/src/fleet/polly-pads/mission-coordinator.ts
@@ -10,7 +10,6 @@
  * does what during autonomous operations.
  */
 
-import { ModePad } from './mode-pad';
 import { Squad } from './squad';
 import {
   CrisisType,
@@ -293,7 +292,5 @@ export class MissionCoordinator {
    */
   getPhaseHistory(): Array<{ phase: MissionPhase; timestamp: number }> {
     return [...this.phaseHistory];
-          }
+  }
 }
-
- 


### PR DESCRIPTION
### Motivation
- Finish cleanup from a bad merge that introduced duplicate declarations and noisy merge artifacts in the `polly-pads` area so types and exports are consistent across the module. 
- Ensure `mission-coordinator.ts` has no leftover unused imports or malformed trailing formatting introduced by the merge. 
- Keep the barrel (`src/fleet/polly-pads/index.ts`) exports clear and free of redundant comment-noise that obscures the intended export groups.

### Description
- Normalized the header comment indentation in `src/fleet/polly-pads/closed-network.ts` to remove a leftover formatting artifact.  
- Removed an unused `ModePad` import and fixed malformed trailing method/class closure indentation in `src/fleet/polly-pads/mission-coordinator.ts` to restore clean syntax and structure.  
- Cleaned up the `src/fleet/polly-pads/index.ts` barrel by removing redundant specialist-mode section noise so export groups are focused and non-duplicative.

### Testing
- Ran `npm run typecheck` (i.e. `tsc --noEmit`) and the TypeScript typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de53b75688322b71c5ce81fec7bbf)