### PR TITLE
Track kernel model surface for Vertex training; add monorepo plan; improve browser Linux support; add distributed workflow

### DIFF
--- a/.github/workflows/vertex-training.yml
+++ b/.github/workflows/vertex-training.yml
@@ -67,6 +67,10 @@ jobs:
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
+      - name: Validate kernel manifest
+        run: |
+          python training/kernel_manifest.py --check --json
+
       - name: Run training (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
         env:

--- a/docs/DISTRIBUTED_AGENTIC_WORKFLOW.md
+++ b/docs/DISTRIBUTED_AGENTIC_WORKFLOW.md
@@ -1,0 +1,54 @@
+# Distributed Agentic Workflow Service
+
+This document outlines a practical path from governance-only operation to a distributed workflow execution model where small/tiny LLMs can be plugged in and inherit SCBE controls immediately.
+
+## System Mind Map
+
+```mermaid
+mindmap
+  root((SCBE Distributed Agentic Service))
+    Governance Foundation
+      14-Layer risk scoring
+      Sacred Tongues trust alignment
+      ALLOW QUARANTINE DENY gate
+    Distributed Runtime
+      Workflow templates
+      Step-level capability routing
+      Adapter selection by context window
+      Tenant-isolated execution IDs
+    Tiny LLM Integration
+      Adapter interface generate input output
+      Local on-device models
+      Cloud model fallback
+      Capability registry
+    Cross Branding
+      Brand profiles
+      Prompt prefix per tenant
+      Voice and output tagline
+      White-label output formatting
+    Agent Roles
+      Architect planning
+      Coder implementation
+      Tester validation
+      Security hardening
+    Enterprise Outcomes
+      Faster onboarding of partner brands
+      Lower inference cost with tiny models
+      Auditable step outputs
+      Immediate portability across systems
+```
+
+## Execution Flow
+
+1. Register one or more `BrandProfile` records for tenant/partner identities.
+2. Register tiny-LLM adapters with capabilities (planning, implementation, testing, security, etc.).
+3. Register a workflow template that defines ordered steps.
+4. Execute the workflow for a tenant prompt.
+5. Collect step outputs with adapter IDs and token usage for auditability.
+
+## Why this helps your stated goal
+
+- **Beyond governance only:** the service executes multi-step workflows, not just policy decisions.
+- **Tiny LLM ready:** each step routes to lightweight adapters with explicit capability matching.
+- **Cross-branded:** tenant prompt-prefix/voice/tagline enables white-label reuse across partner systems.
+- **Composable:** existing SCBE agent roles map directly to distributed workflow steps.

--- a/docs/MONOREPO_RESTRUCTURING_PLAN.md
+++ b/docs/MONOREPO_RESTRUCTURING_PLAN.md
@@ -1,0 +1,73 @@
+# SCBE Monorepo Restructuring Plan (Kernel-First)
+
+This plan turns SCBE-AETHERMOORE into a single monorepo with internal workspaces, while preserving one publishable npm package surface.
+
+## Target Package Layout
+
+1. **`packages/kernel`**
+   - Pure math/types seed.
+   - Zero runtime dependencies.
+   - Includes core geometry/scaling/types (`GovernanceTier`, `DimensionalState`) and invariant math.
+
+2. **`packages/crypto`**
+   - Cryptographic envelopes, KDF/HMAC, nonce/replay guards.
+   - Depends on `kernel` only.
+
+3. **`packages/brain`**
+   - 21D brain mapping and higher-order embedding logic.
+   - Depends on `kernel` and `crypto` where needed.
+
+4. **`packages/fleet`**
+   - Agent orchestration, governance tiers, roundtables, runtime coordination.
+   - Depends on `kernel` + `brain`.
+
+5. **`packages/api`**
+   - Gateway/Lambda/REST adapters.
+   - Depends on `fleet` + `crypto`.
+
+6. **`packages/app`**
+   - Catch-all integration layer for demos/UI/legacy adapters.
+
+> Tests remain rooted in `/tests` and are not relocated during migration.
+
+## Why Kernel Extraction Comes First
+
+Training and deployment provenance requires a deterministic answer to: **"which files ARE the model?"**
+
+To support that now, this repo includes a canonical kernel manifest used by CI/training:
+- `training/kernel_manifest.yaml`
+- `training/kernel_manifest.py`
+
+The Vertex workflow validates this manifest before training and injects a manifest SHA into training job args/labels for traceability.
+
+## Seven Migration Phases (One Commit Per Phase)
+
+1. **Kernel carve-out (lowest risk / highest leverage)**
+   - Move pure math/types into `packages/kernel`.
+   - Keep old imports via compatibility re-exports.
+
+2. **Crypto separation**
+   - Move crypto primitives to `packages/crypto`.
+   - Prohibit app-layer imports into crypto.
+
+3. **Brain modularization**
+   - Move brain/embedding modules to `packages/brain`.
+
+4. **Fleet extraction**
+   - Move governance/orchestration to `packages/fleet`.
+
+5. **API package formation**
+   - Isolate API transport/runtime concerns in `packages/api`.
+
+6. **App catch-all stabilization**
+   - Move demos/UI/integration glue into `packages/app`.
+
+7. **Workspace hardening + release path**
+   - Enforce dependency graph, lint boundaries, CI matrix.
+   - Keep one public npm package; internal packages remain workspace-private.
+
+## Non-Negotiables
+
+- Root tests continue to run during every phase.
+- No "big bang" move.
+- Every phase must preserve runtime behavior and pass targeted tests.

--- a/src/agentic/distributed-workflow.ts
+++ b/src/agentic/distributed-workflow.ts
@@ -1,0 +1,258 @@
+/**
+ * Distributed Agentic Workflow Service
+ *
+ * Enables cross-branded, tenant-aware workflow execution where tiny LLM adapters
+ * can be plugged in and immediately inherit SCBE governance context.
+ *
+ * @module agentic/distributed-workflow
+ */
+
+import { AgentRole, BuiltInAgent, ROLE_TONGUE_MAP } from './types';
+
+export type TinyLLMCapability =
+  | 'planning'
+  | 'implementation'
+  | 'analysis'
+  | 'testing'
+  | 'security'
+  | 'deployment';
+
+export interface TinyLLMAdapter {
+  id: string;
+  provider: string;
+  model: string;
+  capabilities: TinyLLMCapability[];
+  maxContextTokens: number;
+  generate(input: TinyLLMInput): Promise<TinyLLMOutput>;
+}
+
+export interface TinyLLMInput {
+  tenantId: string;
+  workflowId: string;
+  stepId: string;
+  role: AgentRole;
+  systemPrompt: string;
+  userPrompt: string;
+  context: Record<string, unknown>;
+}
+
+export interface TinyLLMOutput {
+  text: string;
+  tokensUsed: number;
+  latencyMs: number;
+}
+
+export interface BrandProfile {
+  id: string;
+  displayName: string;
+  voice: 'formal' | 'neutral' | 'concise';
+  promptPrefix: string;
+  outputTagline?: string;
+}
+
+export interface WorkflowStep {
+  id: string;
+  name: string;
+  role: AgentRole;
+  capability: TinyLLMCapability;
+  promptTemplate: string;
+}
+
+export interface WorkflowTemplate {
+  id: string;
+  name: string;
+  description: string;
+  steps: WorkflowStep[];
+}
+
+export interface WorkflowExecutionRequest {
+  tenantId: string;
+  brandProfileId: string;
+  workflowTemplateId: string;
+  userPrompt: string;
+  context?: Record<string, unknown>;
+}
+
+export interface WorkflowStepResult {
+  stepId: string;
+  adapterId: string;
+  output: string;
+  tokensUsed: number;
+  latencyMs: number;
+}
+
+export interface WorkflowExecutionResult {
+  executionId: string;
+  workflowTemplateId: string;
+  brandProfileId: string;
+  outputs: WorkflowStepResult[];
+  totalTokens: number;
+}
+
+/**
+ * Core service for distributed execution across tiny LLM adapters.
+ */
+export class DistributedWorkflowService {
+  private brandProfiles = new Map<string, BrandProfile>();
+  private adapters = new Map<string, TinyLLMAdapter>();
+  private templates = new Map<string, WorkflowTemplate>();
+
+  public registerBrandProfile(profile: BrandProfile): void {
+    this.brandProfiles.set(profile.id, profile);
+  }
+
+  public registerAdapter(adapter: TinyLLMAdapter): void {
+    this.adapters.set(adapter.id, adapter);
+  }
+
+  public registerTemplate(template: WorkflowTemplate): void {
+    this.templates.set(template.id, template);
+  }
+
+  public getAdaptersByCapability(capability: TinyLLMCapability): TinyLLMAdapter[] {
+    return Array.from(this.adapters.values()).filter((adapter) =>
+      adapter.capabilities.includes(capability)
+    );
+  }
+
+  public static bootstrapAgentsAsProfiles(agents: BuiltInAgent[]): BrandProfile[] {
+    return agents.map((agent) => ({
+      id: `${agent.role}-profile`,
+      displayName: `${agent.name} Runtime`,
+      voice: 'neutral',
+      promptPrefix: `You are ${agent.name}, role=${agent.role}, tongue=${ROLE_TONGUE_MAP[agent.role]}.`,
+      outputTagline: 'Governed by SCBE-AETHERMOORE',
+    }));
+  }
+
+  public async executeWorkflow(request: WorkflowExecutionRequest): Promise<WorkflowExecutionResult> {
+    const profile = this.brandProfiles.get(request.brandProfileId);
+    if (!profile) {
+      throw new Error(`Unknown brand profile: ${request.brandProfileId}`);
+    }
+
+    const template = this.templates.get(request.workflowTemplateId);
+    if (!template) {
+      throw new Error(`Unknown workflow template: ${request.workflowTemplateId}`);
+    }
+
+    const executionId = this.newExecutionId();
+    const outputs: WorkflowStepResult[] = [];
+
+    for (const step of template.steps) {
+      const adapter = this.selectAdapter(step.capability);
+      const stepPrompt = this.renderPrompt(step.promptTemplate, request.userPrompt, outputs);
+      const systemPrompt = this.buildSystemPrompt(profile, step);
+
+      const response = await adapter.generate({
+        tenantId: request.tenantId,
+        workflowId: template.id,
+        stepId: step.id,
+        role: step.role,
+        systemPrompt,
+        userPrompt: stepPrompt,
+        context: request.context || {},
+      });
+
+      outputs.push({
+        stepId: step.id,
+        adapterId: adapter.id,
+        output: this.decorateOutput(profile, response.text),
+        tokensUsed: response.tokensUsed,
+        latencyMs: response.latencyMs,
+      });
+    }
+
+    const totalTokens = outputs.reduce((sum, out) => sum + out.tokensUsed, 0);
+
+    return {
+      executionId,
+      workflowTemplateId: template.id,
+      brandProfileId: profile.id,
+      outputs,
+      totalTokens,
+    };
+  }
+
+  private selectAdapter(capability: TinyLLMCapability): TinyLLMAdapter {
+    const candidates = this.getAdaptersByCapability(capability);
+    if (candidates.length === 0) {
+      throw new Error(`No adapters registered for capability: ${capability}`);
+    }
+
+    return candidates.sort((a, b) => b.maxContextTokens - a.maxContextTokens)[0];
+  }
+
+  private buildSystemPrompt(profile: BrandProfile, step: WorkflowStep): string {
+    return [
+      profile.promptPrefix,
+      `Brand voice: ${profile.voice}.`,
+      `Workflow step: ${step.name} (${step.id}).`,
+      `Agent role: ${step.role}.`,
+      `Capability: ${step.capability}.`,
+      'Comply with SCBE risk governance and produce deterministic, auditable output.',
+    ].join(' ');
+  }
+
+  private decorateOutput(profile: BrandProfile, output: string): string {
+    if (!profile.outputTagline) {
+      return output;
+    }
+
+    return `${output}\n\n— ${profile.outputTagline}`;
+  }
+
+  private renderPrompt(
+    template: string,
+    userPrompt: string,
+    previous: WorkflowStepResult[]
+  ): string {
+    const previousOutput = previous.length > 0 ? previous[previous.length - 1].output : 'None';
+
+    return template
+      .replaceAll('{{user_prompt}}', userPrompt)
+      .replaceAll('{{previous_output}}', previousOutput);
+  }
+
+  private newExecutionId(): string {
+    return `wf_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  }
+}
+
+export const DEFAULT_DISTRIBUTED_TEMPLATE: WorkflowTemplate = {
+  id: 'distributed-build-and-verify',
+  name: 'Distributed Build and Verify',
+  description: 'Plan, implement, test, and security-check with tiny LLM workers.',
+  steps: [
+    {
+      id: 'plan',
+      name: 'Planning',
+      role: 'architect',
+      capability: 'planning',
+      promptTemplate:
+        'Create an implementation plan for: {{user_prompt}}. Consider SCBE constraints.',
+    },
+    {
+      id: 'implement',
+      name: 'Implementation',
+      role: 'coder',
+      capability: 'implementation',
+      promptTemplate:
+        'Using this plan: {{previous_output}}, implement core logic for: {{user_prompt}}.',
+    },
+    {
+      id: 'test',
+      name: 'Testing',
+      role: 'tester',
+      capability: 'testing',
+      promptTemplate: 'Generate tests for implementation output: {{previous_output}}.',
+    },
+    {
+      id: 'security',
+      name: 'Security Review',
+      role: 'security',
+      capability: 'security',
+      promptTemplate: 'Review for vulnerabilities: {{previous_output}}.',
+    },
+  ],
+};

--- a/src/agentic/index.ts
+++ b/src/agentic/index.ts
@@ -20,3 +20,5 @@ export * from './collaboration';
 export * from './platform';
 export * from './task-group';
 export * from './types';
+
+export * from './distributed-workflow';

--- a/tests/agentic/distributed-workflow.test.ts
+++ b/tests/agentic/distributed-workflow.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DISTRIBUTED_TEMPLATE,
+  DistributedWorkflowService,
+  TinyLLMAdapter,
+} from '../../src/agentic/distributed-workflow';
+import { createBuiltInAgents } from '../../src/agentic/agents';
+
+function makeAdapter(
+  id: string,
+  capability: TinyLLMAdapter['capabilities'][number],
+  maxContextTokens = 4096
+): TinyLLMAdapter {
+  return {
+    id,
+    provider: 'local',
+    model: 'tiny-llm',
+    capabilities: [capability],
+    maxContextTokens,
+    async generate(input) {
+      return {
+        text: `[${id}] ${input.stepId}: ${input.userPrompt.slice(0, 40)}`,
+        tokensUsed: 42,
+        latencyMs: 10,
+      };
+    },
+  };
+}
+
+describe('DistributedWorkflowService', () => {
+  it('executes distributed template end-to-end with tiny adapters', async () => {
+    const svc = new DistributedWorkflowService();
+
+    svc.registerBrandProfile({
+      id: 'acme',
+      displayName: 'Acme Labs',
+      voice: 'formal',
+      promptPrefix: 'You represent Acme Labs engineering.',
+      outputTagline: 'Acme Secure Runtime',
+    });
+
+    svc.registerTemplate(DEFAULT_DISTRIBUTED_TEMPLATE);
+    svc.registerAdapter(makeAdapter('plan-adapter', 'planning'));
+    svc.registerAdapter(makeAdapter('impl-adapter', 'implementation'));
+    svc.registerAdapter(makeAdapter('test-adapter', 'testing'));
+    svc.registerAdapter(makeAdapter('sec-adapter', 'security'));
+
+    const result = await svc.executeWorkflow({
+      tenantId: 'tenant-1',
+      brandProfileId: 'acme',
+      workflowTemplateId: DEFAULT_DISTRIBUTED_TEMPLATE.id,
+      userPrompt: 'build a secure API endpoint for invoice creation',
+    });
+
+    expect(result.outputs).toHaveLength(4);
+    expect(result.totalTokens).toBe(168);
+    expect(result.outputs[0].adapterId).toBe('plan-adapter');
+    expect(result.outputs[3].output).toContain('Acme Secure Runtime');
+  });
+
+  it('prefers higher-context adapter when multiple satisfy capability', async () => {
+    const svc = new DistributedWorkflowService();
+
+    svc.registerBrandProfile({
+      id: 'brand',
+      displayName: 'Brand',
+      voice: 'neutral',
+      promptPrefix: 'Brand prompt',
+    });
+
+    svc.registerTemplate({
+      id: 'single-step',
+      name: 'Single',
+      description: 'single step test',
+      steps: [
+        {
+          id: 'plan',
+          name: 'Plan',
+          role: 'architect',
+          capability: 'planning',
+          promptTemplate: '{{user_prompt}}',
+        },
+      ],
+    });
+
+    svc.registerAdapter(makeAdapter('small-planner', 'planning', 1024));
+    svc.registerAdapter(makeAdapter('large-planner', 'planning', 8192));
+
+    const result = await svc.executeWorkflow({
+      tenantId: 't',
+      brandProfileId: 'brand',
+      workflowTemplateId: 'single-step',
+      userPrompt: 'plan this',
+    });
+
+    expect(result.outputs[0].adapterId).toBe('large-planner');
+  });
+
+  it('throws clear error when capability adapter is missing', async () => {
+    const svc = new DistributedWorkflowService();
+
+    svc.registerBrandProfile({
+      id: 'brand',
+      displayName: 'Brand',
+      voice: 'neutral',
+      promptPrefix: 'Brand prompt',
+    });
+
+    svc.registerTemplate(DEFAULT_DISTRIBUTED_TEMPLATE);
+
+    await expect(
+      svc.executeWorkflow({
+        tenantId: 'tenant',
+        brandProfileId: 'brand',
+        workflowTemplateId: DEFAULT_DISTRIBUTED_TEMPLATE.id,
+        userPrompt: 'missing adapters should fail',
+      })
+    ).rejects.toThrow('No adapters registered for capability: planning');
+  });
+
+  it('can bootstrap cross-brand profiles from built-in agents', () => {
+    const agents = createBuiltInAgents('openai');
+    const profiles = DistributedWorkflowService.bootstrapAgentsAsProfiles(agents);
+
+    expect(profiles).toHaveLength(6);
+    expect(profiles[0].promptPrefix).toContain('tongue=');
+    expect(profiles[0].outputTagline).toBe('Governed by SCBE-AETHERMOORE');
+  });
+});

--- a/tests/test_browser_linux_support.py
+++ b/tests/test_browser_linux_support.py
@@ -1,0 +1,86 @@
+"""Tests for Linux Chrome support in browser backends."""
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module_from_path(module_name: str, file_path: str):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module spec for {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_resolve_chrome_binary_uses_env_override(monkeypatch):
+    module = importlib.import_module("agents.browsers.cdp_backend")
+    monkeypatch.setenv("SCBE_CHROME_PATH", "/opt/google/chrome/chrome")
+
+    path = module.resolve_chrome_binary(system="Linux")
+
+    assert path == "/opt/google/chrome/chrome"
+
+
+def test_resolve_chrome_binary_linux_checks_common_names(monkeypatch):
+    module = importlib.import_module("agents.browsers.cdp_backend")
+
+    monkeypatch.delenv("SCBE_CHROME_PATH", raising=False)
+
+    def fake_which(name):
+        if name == "google-chrome-stable":
+            return "/usr/bin/google-chrome-stable"
+        return None
+
+    monkeypatch.setattr(module.shutil, "which", fake_which)
+
+    path = module.resolve_chrome_binary(system="Linux")
+
+    assert path == "/usr/bin/google-chrome-stable"
+
+
+def test_get_chrome_launch_command_quotes_linux_path(monkeypatch):
+    module = importlib.import_module("agents.browsers.cdp_backend")
+
+    monkeypatch.setattr(module, "resolve_chrome_binary", lambda system=None: "/opt/Google Chrome/chrome")
+
+    cmd = module.get_chrome_launch_command(port=9333, user_data_dir="/tmp/scbe profile")
+
+    assert cmd.startswith('"/opt/Google Chrome/chrome" --remote-debugging-port=9333')
+    assert '--user-data-dir="/tmp/scbe profile"' in cmd
+
+
+def test_playwright_wrapper_prefers_linux_executable(monkeypatch):
+    module = _load_module_from_path(
+        "playwright_wrapper_under_test",
+        str(Path("agents/browser/playwright_wrapper.py")),
+    )
+
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/chromium" if name == "chromium" else None)
+
+    wrapper = module.PlaywrightWrapper(module.BrowserConfig(headless=True))
+    options = wrapper._build_launch_options()
+
+    assert options["headless"] is True
+    assert options["executable_path"] == "/usr/bin/chromium"
+
+
+def test_playwright_wrapper_respects_explicit_channel_over_linux_detection(monkeypatch):
+    module = _load_module_from_path(
+        "playwright_wrapper_under_test_2",
+        str(Path("agents/browser/playwright_wrapper.py")),
+    )
+
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(module.shutil, "which", lambda _name: "/usr/bin/google-chrome")
+
+    wrapper = module.PlaywrightWrapper(
+        module.BrowserConfig(headless=False, browser_channel="chrome")
+    )
+    options = wrapper._build_launch_options()
+
+    assert options == {"headless": False, "channel": "chrome"}

--- a/tests/test_homebrew_quick.py
+++ b/tests/test_homebrew_quick.py
@@ -33,8 +33,11 @@ except ImportError:
 try:
     from src.crypto.rwp_v3 import RWPv3Protocol
 
+    # Import can succeed even when runtime crypto deps are missing.
+    # Instantiate once so skip markers reflect true availability.
+    RWPv3Protocol()
     RWP_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     RWP_AVAILABLE = False
 
 try:

--- a/tests/test_kernel_manifest.py
+++ b/tests/test_kernel_manifest.py
@@ -1,0 +1,22 @@
+import importlib
+
+
+def test_kernel_manifest_load_and_validate():
+    mod = importlib.import_module("training.kernel_manifest")
+    manifest = mod.load_manifest()
+
+    missing = mod.validate_manifest_entries(manifest)
+
+    assert manifest["version"] == 1
+    assert len(manifest["kernel"]) >= 10
+    assert missing == []
+
+
+def test_kernel_manifest_summary_has_sha():
+    mod = importlib.import_module("training.kernel_manifest")
+    manifest = mod.load_manifest()
+
+    summary = mod.to_summary(manifest)
+
+    assert summary["kernel_file_count"] == len(manifest["kernel"])
+    assert len(summary["kernel_manifest_sha"]) == 64

--- a/training/kernel_manifest.py
+++ b/training/kernel_manifest.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Kernel manifest utilities for training provenance.
+
+This script validates and prints the canonical kernel file set so CI/training
+pipelines know exactly which files define the model surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_manifest(path: str | Path | None = None) -> dict[str, Any]:
+    manifest_path = Path(path) if path else Path(__file__).with_name("kernel_manifest.yaml")
+    with open(manifest_path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    if not isinstance(data, dict) or "kernel" not in data:
+        raise ValueError("Invalid manifest format: expected top-level 'kernel' list")
+
+    if not isinstance(data["kernel"], list):
+        raise ValueError("Invalid manifest format: 'kernel' must be a list")
+
+    return data
+
+
+def validate_manifest_entries(manifest: dict[str, Any], repo_root: str | Path = ".") -> list[str]:
+    root = Path(repo_root)
+    missing: list[str] = []
+    for entry in manifest["kernel"]:
+        if not isinstance(entry, str):
+            missing.append(str(entry))
+            continue
+        if not (root / entry).exists():
+            missing.append(entry)
+    return missing
+
+
+def compute_manifest_sha(manifest: dict[str, Any]) -> str:
+    payload = json.dumps(manifest["kernel"], sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def to_summary(manifest: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "version": manifest.get("version", 1),
+        "kernel_file_count": len(manifest["kernel"]),
+        "kernel_manifest_sha": compute_manifest_sha(manifest),
+        "kernel": manifest["kernel"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate/print SCBE kernel manifest")
+    parser.add_argument("--manifest", default=None, help="Path to manifest YAML")
+    parser.add_argument("--check", action="store_true", help="Validate file existence")
+    parser.add_argument("--json", action="store_true", help="Print JSON summary")
+    args = parser.parse_args()
+
+    manifest = load_manifest(args.manifest)
+
+    if args.check:
+        missing = validate_manifest_entries(manifest)
+        if missing:
+            print("Missing kernel files:")
+            for path in missing:
+                print(f" - {path}")
+            return 1
+
+    summary = to_summary(manifest)
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(f"Kernel manifest v{summary['version']}")
+        print(f"Files: {summary['kernel_file_count']}")
+        print(f"SHA: {summary['kernel_manifest_sha']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/training/kernel_manifest.yaml
+++ b/training/kernel_manifest.yaml
@@ -1,0 +1,17 @@
+# Canonical kernel manifest for model-defining source files.
+# These files are treated as the core mathematical model surface for training provenance.
+version: 1
+kernel:
+  - src/harmonic/constants.ts
+  - src/harmonic/hyperbolic.ts
+  - src/harmonic/harmonicScaling.ts
+  - src/harmonic/spectral-identity.ts
+  - src/harmonic/phdm.ts
+  - src/harmonic/temporalPhase.ts
+  - src/harmonic/languesMetric.ts
+  - src/harmonic/halAttention.ts
+  - src/harmonic/trustCone.ts
+  - src/harmonic/scbe_voxel_types.ts
+  - src/fleet/types.ts
+  - src/fleet/governance.ts
+  - src/fleet/fleet-manager.ts


### PR DESCRIPTION
### Motivation
- Ensure deterministic training provenance by explicitly declaring which source files constitute the model surface so CI and training pipelines can audit what was trained.
- Provide a clear, kernel-first monorepo migration plan to guide safe phased extraction of core math/types from application code.
- Improve browser automation reliability on Linux by resolving Chrome/Chromium binaries and allowing explicit executable/channel selection.
- Enable a distributed tiny-LLM workflow runtime to prototype multi-step, governed workflows that map to SCBE agent roles.

### Description
- Added a canonical kernel manifest and utilities: `training/kernel_manifest.yaml` (file list) and `training/kernel_manifest.py` (validation + SHA summary) and wired them into the training pipeline.
- Updated `training/trigger_vertex_training.py` to load the kernel summary, log `kernel_file_count` + `kernel_manifest_sha`, pass `--kernel-manifest-sha`/`--kernel-file-count` to the training container args, and add a `kernel_manifest_sha` label to Vertex `CustomJob` metadata.
- Updated GitHub Actions workflow `.github/workflows/vertex-training.yml` to run `python training/kernel_manifest.py --check --json` before training steps and added `docs/MONOREPO_RESTRUCTURING_PLAN.md` describing the 6-package, 7-phase kernel-first migration plan.
- Improved browser support by adding Linux Chrome/Chromium resolution to `agents/browser/playwright_wrapper.py` and `agents/browsers/cdp_backend.py` (introducing `resolve_chrome_binary` and safer quoting in `get_chrome_launch_command`) and exposing optional `browser_channel`/`executable_path` configuration.
- Added a distributed workflow service implementation in `src/agentic/distributed-workflow.ts` and re-exported it in `src/agentic/index.ts`, along with end-to-end tests `tests/agentic/distributed-workflow.test.ts` and browser/linux helper tests `tests/test_browser_linux_support.py`.
- Added unit tests for the kernel manifest `tests/test_kernel_manifest.py` and small test adjustments in `tests/test_homebrew_quick.py` to better reflect runtime availability.

### Testing
- Ran `python training/kernel_manifest.py --check --json` which printed the manifest summary JSON successfully (no missing files).
- Ran `pytest -q tests/test_kernel_manifest.py tests/test_browser_linux_support.py` and the test suite completed successfully with `7 passed`.
- Executed `python training/trigger_vertex_training.py --dry-run` which logged kernel metadata and printed the dry-run worker pool config including `--kernel-manifest-sha` and `--kernel-file-count`.
- Overall CI-facing validation commands used in the rollout (`pytest` and the training dry-run/manifest checks) all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d72a32b60832286be62bf81507d6f)