### PR TITLE
Add lightweight tenant metering and monthly billable usage export

### DIFF
--- a/api/metering.py
+++ b/api/metering.py
@@ -1,0 +1,146 @@
+"""Lightweight tenant metering for billable usage exports."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import date, datetime
+from threading import Lock
+from typing import Dict, List, Optional
+
+GOVERNANCE_EVALUATIONS = "governance_evaluations"
+WORKFLOW_EXECUTIONS = "workflow_executions"
+AUDIT_REPORT_GENERATIONS = "audit_report_generations"
+
+BILLABLE_METRICS = {
+    GOVERNANCE_EVALUATIONS,
+    WORKFLOW_EXECUTIONS,
+    AUDIT_REPORT_GENERATIONS,
+}
+
+
+@dataclass(frozen=True)
+class MonthlyUsageRow:
+    tenant_id: str
+    month: str
+    metric_name: str
+    count: int
+
+
+class MeteringStore:
+    """SQLite-backed daily aggregate store keyed by tenant/date/metric."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self.db_path = db_path or os.getenv("SCBE_METERING_DB_PATH", "./scbe_metering.db")
+        self._lock = Lock()
+        self._ensure_schema()
+
+    @contextmanager
+    def _connect(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tenant_daily_usage (
+                    tenant_id TEXT NOT NULL,
+                    usage_date TEXT NOT NULL,
+                    metric_name TEXT NOT NULL,
+                    count INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (tenant_id, usage_date, metric_name)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_tenant_daily_usage_month
+                ON tenant_daily_usage (usage_date, tenant_id, metric_name)
+                """
+            )
+            conn.commit()
+
+    def increment_metric(
+        self,
+        tenant_id: str,
+        metric_name: str,
+        when: Optional[datetime] = None,
+        amount: int = 1,
+    ) -> None:
+        if metric_name not in BILLABLE_METRICS:
+            raise ValueError(f"Unsupported billing metric: {metric_name}")
+        if amount <= 0:
+            raise ValueError("amount must be > 0")
+
+        usage_date = (when or datetime.utcnow()).date().isoformat()
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO tenant_daily_usage (tenant_id, usage_date, metric_name, count)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(tenant_id, usage_date, metric_name)
+                    DO UPDATE SET count = count + excluded.count
+                    """,
+                    (tenant_id, usage_date, metric_name, amount),
+                )
+                conn.commit()
+
+    def export_monthly_usage(
+        self,
+        year: int,
+        month: int,
+        tenant_id: Optional[str] = None,
+    ) -> List[MonthlyUsageRow]:
+        month_prefix = date(year, month, 1).strftime("%Y-%m")
+        params = [f"{month_prefix}%"]
+        query = (
+            """
+            SELECT tenant_id, metric_name, COALESCE(SUM(count), 0) as total_count
+            FROM tenant_daily_usage
+            WHERE usage_date LIKE ?
+            """
+        )
+        if tenant_id:
+            query += " AND tenant_id = ?"
+            params.append(tenant_id)
+
+        query += " GROUP BY tenant_id, metric_name ORDER BY tenant_id, metric_name"
+
+        with self._connect() as conn:
+            cursor = conn.execute(query, tuple(params))
+            rows = cursor.fetchall()
+
+        return [
+            MonthlyUsageRow(
+                tenant_id=row[0],
+                month=month_prefix,
+                metric_name=row[1],
+                count=int(row[2]),
+            )
+            for row in rows
+        ]
+
+
+metering_store = MeteringStore()
+
+
+def export_monthly_billable_usage(year: int, month: int, tenant_id: Optional[str] = None) -> Dict[str, object]:
+    rows = metering_store.export_monthly_usage(year=year, month=month, tenant_id=tenant_id)
+    totals = {metric: 0 for metric in sorted(BILLABLE_METRICS)}
+    for row in rows:
+        totals[row.metric_name] = totals.get(row.metric_name, 0) + row.count
+
+    return {
+        "month": f"{year:04d}-{month:02d}",
+        "tenant_id": tenant_id,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "rows": [row.__dict__ for row in rows],
+        "totals": totals,
+    }

--- a/docs/BILLING_METRICS.md
+++ b/docs/BILLING_METRICS.md
@@ -1,0 +1,40 @@
+# Billing Metrics
+
+SCBE-AETHERMOORE uses lightweight tenant metering for billable usage reporting.
+
+## Metered metrics
+
+Daily usage is stored as `(tenant_id, date, metric_name, count)` for these metric names:
+
+- `governance_evaluations`
+  - Incremented once per successful `/v1/authorize` request.
+  - Represents a single governance evaluation through the 14-layer pipeline.
+
+- `workflow_executions`
+  - Incremented once per successful `/v1/fleet/run-scenario` request.
+  - Represents execution of one fleet workflow scenario.
+
+- `audit_report_generations`
+  - Incremented once per successful `/v1/audit/report` request.
+  - Represents generation of an audit summary report for a tenant.
+
+## Monthly billable usage exports
+
+Two internal mechanisms are available:
+
+1. API endpoint: `GET /v1/internal/billing/monthly-usage?year=YYYY&month=MM`
+   - Returns tenant monthly totals by metric.
+   - By default, results are scoped to the authenticated tenant.
+   - Use `include_all_tenants=true` for cross-tenant finance exports.
+
+2. Report command:
+
+```bash
+python scripts/export_monthly_billable_usage.py --year 2026 --month 1 --pretty
+```
+
+Optional tenant scope:
+
+```bash
+python scripts/export_monthly_billable_usage.py --year 2026 --month 1 --tenant-id tenant_0 --pretty
+```

--- a/scripts/export_monthly_billable_usage.py
+++ b/scripts/export_monthly_billable_usage.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Export SCBE monthly billable usage from the metering store."""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from api.metering import export_monthly_billable_usage
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export monthly billable usage")
+    parser.add_argument("--year", type=int, default=datetime.utcnow().year)
+    parser.add_argument("--month", type=int, default=datetime.utcnow().month)
+    parser.add_argument("--tenant-id", type=str, default=None)
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = export_monthly_billable_usage(
+        year=args.year,
+        month=args.month,
+        tenant_id=args.tenant_id,
+    )
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/api/test_metering.py
+++ b/tests/api/test_metering.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+from api.metering import (
+    AUDIT_REPORT_GENERATIONS,
+    GOVERNANCE_EVALUATIONS,
+    WORKFLOW_EXECUTIONS,
+    MeteringStore,
+)
+
+
+def test_metering_store_daily_aggregate_upsert(tmp_path):
+    store = MeteringStore(str(tmp_path / "metering.db"))
+
+    when = datetime(2026, 1, 15, 10, 30)
+    store.increment_metric("tenant_a", GOVERNANCE_EVALUATIONS, when=when)
+    store.increment_metric("tenant_a", GOVERNANCE_EVALUATIONS, when=when, amount=2)
+
+    rows = store.export_monthly_usage(2026, 1, tenant_id="tenant_a")
+    assert len(rows) == 1
+    assert rows[0].metric_name == GOVERNANCE_EVALUATIONS
+    assert rows[0].count == 3
+
+
+def test_metering_store_exports_multiple_metrics(tmp_path):
+    store = MeteringStore(str(tmp_path / "metering.db"))
+
+    store.increment_metric("tenant_a", GOVERNANCE_EVALUATIONS, when=datetime(2026, 1, 2))
+    store.increment_metric("tenant_a", WORKFLOW_EXECUTIONS, when=datetime(2026, 1, 3), amount=4)
+    store.increment_metric("tenant_b", AUDIT_REPORT_GENERATIONS, when=datetime(2026, 1, 4), amount=2)
+
+    jan_rows = store.export_monthly_usage(2026, 1)
+    actual = {(r.tenant_id, r.metric_name): r.count for r in jan_rows}
+
+    assert actual[("tenant_a", GOVERNANCE_EVALUATIONS)] == 1
+    assert actual[("tenant_a", WORKFLOW_EXECUTIONS)] == 4
+    assert actual[("tenant_b", AUDIT_REPORT_GENERATIONS)] == 2


### PR DESCRIPTION
### Motivation

- Provide lightweight per-tenant metering for billing by tracking key billable operations (governance evaluations, workflow executions, audit report generations) and enabling monthly exports for finance/reporting.

### Description

- Add a new SQLite-backed metering module `api/metering.py` that stores daily aggregates keyed by `(tenant_id, usage_date, metric_name)` and exposes `MeteringStore`, `metering_store`, and `export_monthly_billable_usage`.
- Instrument core API flows to record metrics by calling `metering_store.increment_metric(...)` in `POST /v1/authorize` (governance evaluations) and `POST /v1/fleet/run-scenario` (workflow executions), and add a metered `GET /v1/audit/report` endpoint (audit report generations).
- Add an internal export endpoint `GET /v1/internal/billing/monthly-usage` which returns monthly totals (tenant-scoped by default, with `include_all_tenants=true` for cross-tenant exports) using `export_monthly_billable_usage`.
- Add a CLI report command `scripts/export_monthly_billable_usage.py` to print JSON monthly usage, document metric definitions and usage in `docs/BILLING_METRICS.md`, and include unit tests in `tests/api/test_metering.py` validating upsert aggregation and monthly exports.

### Testing

- Ran unit tests: `pytest -q tests/api/test_metering.py` (2 tests) and they passed (`2 passed`).
- Verified Python syntax: `python -m py_compile api/metering.py api/main.py scripts/export_monthly_billable_usage.py` succeeded.
- Executed the CLI exporter: `python scripts/export_monthly_billable_usage.py --year 2026 --month 1 --pretty` and it produced a JSON report (empty totals in a clean environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e88d2393083228bc0f10d884172bc)