### PR TITLE
Add go-to-market SKU documentation for SCBE offers

### DIFF
--- a/docs/GO_TO_MARKET_SKUS.md
+++ b/docs/GO_TO_MARKET_SKUS.md
@@ -1,0 +1,27 @@
+# Go-To-Market SKUs
+
+## 1) SCBE Gateway (SaaS/API)
+
+- **Target buyer:** Engineering and security teams shipping agentic applications.
+- **Problem solved:** Provides policy enforcement, audit logging, and per-action risk scoring so teams can ship faster with guardrails and clear accountability.
+- **Integration effort:** Low-to-moderate; integrate via API/SDK in the agent action pipeline, then configure policies and risk thresholds.
+- **Pricing metric:** Monthly subscription tiered by action volume and feature depth.
+  - **Starter:** **$499/month** for early-stage teams with a capped monthly action allowance.
+  - **Growth:** **$2,500/month** for production teams needing higher throughput and expanded controls.
+  - **Enterprise:** Custom pricing for high-scale, bespoke controls, and enterprise support.
+- **Success KPI:**
+  - % of agent actions evaluated by policy/risk engine
+  - Reduction in unsafe or non-compliant actions
+  - Mean time to investigate incidents (MTTI) using audit trails
+
+## 2) SCBE Assurance (Compliance package)
+
+- **Target buyer:** Regulated organizations (finance, healthcare, and defense-adjacent vendors) that need defensible AI governance.
+- **Problem solved:** Delivers compliance-ready artifacts including audit evidence, training provenance, and policy reports to simplify audits and procurement reviews.
+- **Integration effort:** Moderate; connect environments and data retention settings, then configure report scopes and evidence export cadence.
+- **Pricing metric:** Monthly subscription based on number of environments covered and retention/reporting requirements.
+  - **Range:** **$3,000–$10,000/month** depending on environments, retention period, and reporting needs.
+- **Success KPI:**
+  - Time to produce audit-ready evidence packages
+  - Audit/procurement pass rate without remediation
+  - Coverage of policies, environments, and model lineage artifacts


### PR DESCRIPTION
### Motivation
- Create a single, human-readable reference for commercial offers so product, sales, and engineering teams share the same SKU definitions and pricing guidance.

### Description
- Added `docs/GO_TO_MARKET_SKUS.md` containing two offers: **SCBE Gateway (SaaS/API)** and **SCBE Assurance (Compliance package)**.
- For each SKU included the target buyer, problem solved, integration effort, pricing metric (including Starter/Growth/Enterprise and a $3k–$10k range), and success KPIs.
- Committed the new file to the repository as `docs/GO_TO_MARKET_SKUS.md`.

### Testing
- Verified file contents with `sed -n '1,220p' docs/GO_TO_MARKET_SKUS.md`, which succeeded.
- Verified file lines with `nl -ba docs/GO_TO_MARKET_SKUS.md`, which succeeded.
- Confirmed repository status and commit via `git -C /workspace/SCBE-AETHERMOORE status --short` and the commit command, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e889446e883228ac45b4be2edc814)