### PR TITLE
fix: add missing comma in package.json scripts section

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "prepublishOnly": "npm run build",
     "package": "npm pack",
     "publish:check": "bash scripts/npm_publish_check.sh",
-    "publish:dryrun": "npm pack --dry-run --json"
+    "publish:dryrun": "npm pack --dry-run --json",
     "notion:sync": "node scripts/notion-sync.js --all",
     "version:bump": "node scripts/version-bump.js",
     "precommit:check": "bash scripts/pre-commit-check.sh"


### PR DESCRIPTION
Fixes EJSONPARSE error on npm ci - missing comma after publish:dryrun script