### PR TITLE
fix: remove orphan methods from polly_pads_runtime.py to fix syntax e…

### DIFF
--- a/src/polly_pads_runtime.py
+++ b/src/polly_pads_runtime.py
@@ -389,21 +389,6 @@ PAD_TOOL_MATRIX: Dict[PadMode, Dict[CodeZone, Tuple[str, ...]]] = {
         "HOT": ("plan_only", "goals"),
     },
 }
-                    out[ids[i]].append(ids[j])
-                    out[ids[j]].append(ids[i])
-        return out
-
-    def quorum_ok(self, votes: int, n: int = 6, threshold: int = 4) -> bool:
-        """Byzantine quorum check: n=6 tolerates f=1, needs >=4."""
-        return votes >= threshold and n >= 2 * threshold - n
-
-    def commit_voxel(self, record: VoxelRecord, quorum_votes: int) -> bool:
-        """Commit a VoxelRecord to shared space if quorum is met."""
-        if not self.quorum_ok(quorum_votes):
-            return False
-        self.voxels[record.cube_id] = record
-        return True
-
 
 # ---------------------------------------------------------------------------
 # Polly Pad (per-unit AI workspace)


### PR DESCRIPTION
…rrorThis PR removes orphaned method definitions (quorum_ok and commit_voxel) that were incorrectly placed at module level after the PAD_TOOL_MATRIX dictionary. These methods use `self` but weren't inside any class, causing Python's ast.parse() to fail with a syntax error.

The methods were duplicates of methods that already exist inside the SquadSpace class.