### PR TITLE
fix(ts): add missing closing braces in sheafCohomology.ts to fix CI

### DIFF
--- a/src/harmonic/sheafCohomology.ts
+++ b/src/harmonic/sheafCohomology.ts
@@ -265,7 +265,11 @@ export function tarskiLaplacian0<V, E>(
     }
 
     result.set(v.id, accumulated);
- * @module harmonic/sheaf-cohomology
+  }
+  return result;
+}
+/**
+  * @module harmonic/sheaf-cohomology
  * @layer Layer 9, Layer 10, Layer 12
  * @component Sheaf Cohomology for Lattices — Tarski Laplacian
  * @version 3.2.4


### PR DESCRIPTION
## Summary\n\nFixes the root cause of all CI test failures (Lint, Node 20.x/22.x, Coherence Gate, Release Tests) by adding missing closing braces in `src/harmonic/sheafCohomology.ts`.\n\n## Problem\n\nThe file had two module implementations concatenated without proper closing braces, causing TypeScript compilation errors that broke all CI checks across the repo.\n\n## Changes\n\n- Added missing `}`, `return result;`, `}` and block comment separator before the second module implementation\n- This fixes the syntax errors that were present on `main` and causing all CI workflows to fail\n\n## Related\n\n- Follows PR #204 which fixed CI workflow configuration issues