### PR TITLE
Add HF governance guards, Layer 2 HF load gating, and artifact/dataset upload scripts

### DIFF
--- a/packages/kernel/src/entropicLayer.ts
+++ b/packages/kernel/src/entropicLayer.ts
@@ -119,6 +119,18 @@ export interface TimeDilationResult {
 }
 
 /**
+ * Entropic anomaly record for runtime governance events.
+ */
+export interface EntropicAnomalyRecord {
+  /** Stable anomaly code */
+  code: string;
+  /** Epoch timestamp in milliseconds */
+  timestamp: number;
+  /** Optional redacted details */
+  details?: Record<string, unknown>;
+}
+
+/**
  * Configuration for the entropic layer.
  */
 export interface EntropicConfig {
@@ -153,6 +165,28 @@ export const DEFAULT_ENTROPIC_CONFIG: Readonly<EntropicConfig> = {
   loopWindowSize: 20,
   loopSimilarityThreshold: 0.95,
 };
+
+/**
+ * Emit a normalized entropic anomaly event.
+ *
+ * NOTE: Callers must pass only redacted details. This function never logs
+ * token values or secret material.
+ */
+export function entropicAnomaly(
+  code: string,
+  details?: Record<string, unknown>
+): EntropicAnomalyRecord {
+  const record: EntropicAnomalyRecord = {
+    code,
+    timestamp: Date.now(),
+    details,
+  };
+
+  // Minimal, redacted audit surface for runtime governance
+  // (no secrets, no tokens, no payloads).
+  console.warn(`[ENTROPIC] anomaly=${code}`);
+  return record;
+}
 
 // ═══════════════════════════════════════════════════════════════
 // 1. Escape Detection

--- a/phdm-21d-embedding/scripts/upload_model_artifacts.py
+++ b/phdm-21d-embedding/scripts/upload_model_artifacts.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Upload PHDM model artifacts to Hugging Face model repo."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Upload PHDM model artifacts")
+    parser.add_argument("--repo", default="issdandavis/phdm-21d-embedding", help="HF model repo id")
+    parser.add_argument("--model-dir", default=".", help="Directory containing model artifacts")
+    args = parser.parse_args()
+
+    token = os.environ.get("HUGGINGFACE_TOKEN")
+    if not token:
+        print("[QUARANTINE] HUGGINGFACE_TOKEN missing; refusing artifact upload.")
+        return 2
+
+    try:
+        from huggingface_hub import HfApi
+    except Exception as exc:  # pragma: no cover
+        print(f"[QUARANTINE] huggingface_hub unavailable: {exc}")
+        return 2
+
+    model_dir = Path(args.model_dir)
+    required = [model_dir / "config.json", model_dir / "pytorch_model.bin"]
+    missing = [p.name for p in required if not p.exists()]
+    if missing:
+        print(f"[QUARANTINE] Missing required artifacts: {', '.join(missing)}")
+        return 2
+
+    api = HfApi(token=token)
+    for artifact in required:
+        print(f"Uploading {artifact.name} -> {args.repo}")
+        api.upload_file(
+            path_or_fileobj=str(artifact),
+            path_in_repo=artifact.name,
+            repo_id=args.repo,
+            repo_type="model",
+            commit_message=f"Upload {artifact.name}",
+        )
+
+    print("Upload complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/push_jsonl_dataset.py
+++ b/scripts/push_jsonl_dataset.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Governed JSONL dataset push to Hugging Face datasets."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def governed_load_check(token: str | None, repo: str, files: list[Path]) -> tuple[bool, str]:
+    if not token:
+        return False, "HUGGINGFACE_TOKEN missing"
+    if not files:
+        return False, "no JSONL files found"
+    if any(not f.exists() for f in files):
+        return False, "one or more JSONL files do not exist"
+    if "/" not in repo:
+        return False, "repo must be namespaced like owner/name"
+    return True, "governed load check passed"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Push JSONL dataset files to HF")
+    parser.add_argument("--repo", required=True, help="HF dataset repo (owner/name)")
+    parser.add_argument("--input", default="training-data", help="Directory containing JSONL files")
+    args = parser.parse_args()
+
+    token = os.environ.get("HUGGINGFACE_TOKEN")
+    input_dir = Path(args.input)
+    files = sorted(input_dir.glob("*.jsonl"))
+
+    ok, reason = governed_load_check(token, args.repo, files)
+    if not ok:
+        print(f"[QUARANTINE] {reason}")
+        return 2
+
+    try:
+        from huggingface_hub import HfApi
+    except Exception as exc:  # pragma: no cover
+        print(f"[QUARANTINE] huggingface_hub unavailable: {exc}")
+        return 2
+
+    api = HfApi(token=token)
+    for file_path in files:
+        print(f"Uploading {file_path.name} -> {args.repo}")
+        api.upload_file(
+            path_or_fileobj=str(file_path),
+            path_in_repo=f"data/{file_path.name}",
+            repo_id=args.repo,
+            repo_type="dataset",
+            commit_message=f"Update dataset {file_path.name}",
+        )
+
+    print(f"Uploaded {len(files)} JSONL file(s) to {args.repo}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/crypto/h_lwe.py
+++ b/src/crypto/h_lwe.py
@@ -325,11 +325,6 @@ class HLWESymmetric:
             raise InvalidVector("ciphertext vector must be inside unit ball.")
         # Left-cancellation: (-k) (+) ct = (-k) (+) (k (+) (x (+) n)) = x (+) n
         x_hat = mobius_add(mobius_neg(key), ctv, c=self.c)
-            raise InvalidVector(f"ciphertext vector has wrong shape: {ctv.shape}")
-        if _norm(ctv) >= 1.0:
-            raise InvalidVector("ciphertext vector must be inside unit ball.")
-
-        x_hat = mobius_add(ctv, mobius_neg(key), c=self.c)
         r = _norm(x_hat)
         if r >= self.max_radius:
             raise ContainmentBreach(

--- a/src/memory/quasi_allocator.ts
+++ b/src/memory/quasi_allocator.ts
@@ -1,0 +1,71 @@
+/**
+ * @file quasi_allocator.ts
+ * @module memory/quasi_allocator
+ * @layer Layer 2
+ * @component GeoSeal / Mixed-Curvature Access Kernel - HF model load gating
+ */
+
+export type HFLoadDecision = 'ALLOW' | 'QUARANTINE';
+
+export interface HFLoadResult {
+  repo: string;
+  norm: number;
+  decision: HFLoadDecision;
+  reason: string;
+}
+
+/**
+ * Quasicrystal lattice helper for governed resource loading.
+ */
+export class QuasicrystalLattice {
+  private readonly boundary: number;
+
+  constructor(boundary: number = 0.95) {
+    this.boundary = boundary;
+  }
+
+  /**
+   * Embed a repo id as a deterministic quasi-point and compute its norm.
+   */
+  private embedRepo(repo: string): number[] {
+    const dims = 6;
+    const vec = new Array<number>(dims).fill(0);
+    for (let i = 0; i < repo.length; i++) {
+      const code = repo.charCodeAt(i);
+      vec[i % dims] += ((code % 32) - 15.5) / 31;
+    }
+    return vec.map((v) => Math.tanh(v / Math.max(1, repo.length / 4)));
+  }
+
+  private norm(v: number[]): number {
+    return Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+  }
+
+  /**
+   * Govern HF model downloads via quasi-point containment.
+   * If norm > 0.95, treat as missing-artifact risk and quarantine.
+   */
+  hfLoad(repo: string): HFLoadResult {
+    const point = this.embedRepo(repo);
+    const n = this.norm(point);
+
+    // Audit traceability: norm only, never secrets/tokens.
+    console.info(`[L2][HF_LOAD] repo=${repo} lattice_norm=${n.toFixed(6)}`);
+
+    if (n > this.boundary) {
+      return {
+        repo,
+        norm: n,
+        decision: 'QUARANTINE',
+        reason: `quasi-norm ${n.toFixed(6)} exceeds boundary ${this.boundary}`,
+      };
+    }
+
+    return {
+      repo,
+      norm: n,
+      decision: 'ALLOW',
+      reason: 'within quasi-lattice boundary',
+    };
+  }
+}

--- a/tests/ai_brain/unified-kernel.test.ts
+++ b/tests/ai_brain/unified-kernel.test.ts
@@ -12,7 +12,7 @@
  * Test F: Module contract verification
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
 import {
   UnifiedKernel,
   torusWriteGate,
@@ -26,6 +26,21 @@ import {
   type PipelineStepResult,
 } from '../../src/ai_brain/unified-kernel.js';
 import { BRAIN_DIMENSIONS, POINCARE_MAX_NORM } from '../../src/ai_brain/types.js';
+
+
+const ORIGINAL_HF_TOKEN = process.env.HUGGINGFACE_TOKEN;
+
+beforeAll(() => {
+  process.env.HUGGINGFACE_TOKEN = process.env.HUGGINGFACE_TOKEN || 'test-token-redacted';
+});
+
+afterAll(() => {
+  if (ORIGINAL_HF_TOKEN === undefined) {
+    delete process.env.HUGGINGFACE_TOKEN;
+  } else {
+    process.env.HUGGINGFACE_TOKEN = ORIGINAL_HF_TOKEN;
+  }
+});
 
 // ═══════════════════════════════════════════════════════════════
 // Helpers


### PR DESCRIPTION
### Motivation
- Tests revealed `HUGGINGFACE_TOKEN` was not accessible and HF interactions could fail or expose secrets, so the runtime must detect missing tokens and quarantine risky flows. 
- Model artifact uploads failed when required files were missing from `issdandavis/phdm-21d-embedding`, so a governed upload path with artifact checks is required. 
- A small syntax/indentation issue in `h_lwe` blocked linting and needed a fix so pipeline checks pass.

### Description
- Added a redaction-safe entropic anomaly API `entropicAnomaly` in `packages/kernel/src/entropicLayer.ts` to emit normalized anomaly records without logging secret material. 
- Implemented a Score-step HF token guard in `src/ai_brain/unified-kernel.ts` that checks `process.env.HUGGINGFACE_TOKEN`, calls `entropicAnomaly('HF_TOKEN_MISSING')` when missing, redacts token values in audit metadata, returns a `QUARANTINE` decision, and extended `KernelDecision` to include `QUARANTINE`. 
- Added Layer 2 quasi-lattice HF gating `src/memory/quasi_allocator.ts` with `QuasicrystalLattice.hfLoad(repo)` that deterministically embeds repo ids, logs lattice norms for audit traceability, and returns `QUARANTINE` when the quasi-norm exceeds the configured boundary (`> 0.95`). 
- Added artifact and dataset upload tooling: `phdm-21d-embedding/scripts/upload_model_artifacts.py` to upload `config.json` and `pytorch_model.bin` to a HF model repo, and `scripts/push_jsonl_dataset.py` to push JSONL dataset files, both validating `HUGGINGFACE_TOKEN` and required artifacts and printing `[QUARANTINE]` on governance failures. 
- Fixed `src/crypto/h_lwe.py` decryption indentation/duplicate block to remove the stray/duplicate raise and restore a correct decrypt flow so lint/compile checks succeed. 
- Updated `tests/ai_brain/unified-kernel.test.ts` to set/reset `HUGGINGFACE_TOKEN` during test execution so the new Score-step gate is deterministic under CI tests.

### Testing
- Ran the linter check `python scbe ai lint src/crypto/h_lwe.py`, which passed successfully. 
- Executed targeted test suite `npm test -- --run tests/L2-unit/cli.unit.test.ts tests/ai_brain/unified-kernel.test.ts`, and all tests passed. 
- Ran the governed scripts to validate quarantine behavior: `python scripts/push_jsonl_dataset.py --repo issdandavis/phdm-21d-embedding --input /tmp/does-not-exist` and `python phdm-21d-embedding/scripts/upload_model_artifacts.py --repo issdandavis/phdm-21d-embedding --model-dir .` both printed `[QUARANTINE]` and exited with code `2` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994fce4d1ec8322ac864724206922ff)