### PR TITLE
Add SCBE Kernel v1 API contract docs and JSON schemas

### DIFF
--- a/docs/product/SCBE_KERNEL_V1_API.md
+++ b/docs/product/SCBE_KERNEL_V1_API.md
@@ -1,0 +1,208 @@
+# SCBE Kernel v1 API Contract
+
+This document defines stable request/response contracts for SCBE Kernel v1.
+
+## Global contract guarantees
+
+### Deterministic decision enum
+All decision-producing endpoints MUST use:
+
+- `ALLOW`
+- `QUARANTINE`
+- `DENY`
+
+### Stable error codes
+All error responses MUST use one of these stable values in `error.code`:
+
+- `HF_TOKEN_MISSING`
+- `HF_TOKEN_INVALID`
+- `POLICY_VIOLATION`
+- `REQUEST_INVALID`
+- `REQUEST_CONFLICT`
+- `DECISION_NOT_FOUND`
+- `RATE_LIMITED`
+- `INTERNAL_ERROR`
+
+### Idempotency and traceability
+- `request_id` is required in all mutating requests and echoed in all responses.
+- `correlation_id` is required in every response.
+- `audit_hash` is required in every response.
+
+---
+
+## `POST /authorize`
+
+Determines whether a request is permitted.
+
+### Request body schema
+`schemas/kernel-v1/post_authorize.request.schema.json`
+
+```json
+{
+  "request_id": "req_01J9X9ABCD1234",
+  "subject": {
+    "subject_id": "agent_42",
+    "roles": ["operator"]
+  },
+  "resource": {
+    "resource_id": "memory://tenant-alpha/shard-17",
+    "resource_type": "memory_shard"
+  },
+  "action": "seal",
+  "context": {
+    "hf_token": "hf_***",
+    "policy_tags": ["production"]
+  }
+}
+```
+
+### Success response schema
+`schemas/kernel-v1/post_authorize.response.schema.json`
+
+```json
+{
+  "request_id": "req_01J9X9ABCD1234",
+  "correlation_id": "corr_90f0e8f1-4ef3-4e07-b2e3-6f5afce1bd8f",
+  "audit_hash": "sha256:0f6a6b6d7f...",
+  "decision_id": "dec_01J9X9ANM8R8P",
+  "decision": "ALLOW",
+  "reason": "policy checks passed",
+  "policy_version": "kernel-v1.0.0",
+  "evaluated_at": "2026-02-18T12:00:00Z"
+}
+```
+
+### Error response schema
+`schemas/kernel-v1/error.response.schema.json`
+
+---
+
+## `POST /memory/seal`
+
+Seals a memory payload after authorization.
+
+### Request body schema
+`schemas/kernel-v1/post_memory_seal.request.schema.json`
+
+```json
+{
+  "request_id": "req_01J9X9AQWXYZ",
+  "decision_id": "dec_01J9X9ANM8R8P",
+  "memory": {
+    "memory_id": "mem_123",
+    "content": "sensitive payload",
+    "content_type": "text/plain"
+  },
+  "seal_options": {
+    "algorithm": "spiral-seal-v1",
+    "ttl_seconds": 3600
+  }
+}
+```
+
+### Success response schema
+`schemas/kernel-v1/post_memory_seal.response.schema.json`
+
+```json
+{
+  "request_id": "req_01J9X9AQWXYZ",
+  "correlation_id": "corr_37d18dc7-d3a9-41ec-b8a8-8df34aa4eb2b",
+  "audit_hash": "sha256:b89f2c4f2b...",
+  "decision_id": "dec_01J9X9ANM8R8P",
+  "decision": "ALLOW",
+  "memory_id": "mem_123",
+  "sealed": true,
+  "seal_id": "seal_88A",
+  "sealed_at": "2026-02-18T12:00:05Z"
+}
+```
+
+### Error response schema
+`schemas/kernel-v1/error.response.schema.json`
+
+---
+
+## `GET /audit/{decision_id}`
+
+Retrieves immutable audit details for a decision.
+
+### Request params schema
+`schemas/kernel-v1/get_audit_decision_id.request.schema.json`
+
+```json
+{
+  "request_id": "req_01J9X9AS",
+  "decision_id": "dec_01J9X9ANM8R8P"
+}
+```
+
+### Success response schema
+`schemas/kernel-v1/get_audit_decision_id.response.schema.json`
+
+```json
+{
+  "request_id": "req_01J9X9AS",
+  "correlation_id": "corr_8f7cc108-ef13-4d6a-b112-0c6471aa79a1",
+  "audit_hash": "sha256:8dd13f...",
+  "decision_id": "dec_01J9X9ANM8R8P",
+  "decision": "QUARANTINE",
+  "reason": "policy requires manual review",
+  "policy_version": "kernel-v1.0.0",
+  "recorded_at": "2026-02-18T12:00:00Z",
+  "evidence": {
+    "risk_score": 0.82,
+    "triggered_rules": ["restricted-domain"]
+  }
+}
+```
+
+### Error response schema
+`schemas/kernel-v1/error.response.schema.json`
+
+---
+
+## `GET /health`
+
+Liveness/readiness and compatibility signal.
+
+### Request params schema
+`schemas/kernel-v1/get_health.request.schema.json`
+
+```json
+{
+  "request_id": "req_health_01"
+}
+```
+
+### Success response schema
+`schemas/kernel-v1/get_health.response.schema.json`
+
+```json
+{
+  "request_id": "req_health_01",
+  "correlation_id": "corr_64782f59-fd7d-4e16-b4f7-4136e62d92bc",
+  "audit_hash": "sha256:14eac6...",
+  "status": "ok",
+  "service": "scbe-kernel",
+  "version": "1.0.0",
+  "uptime_seconds": 7342,
+  "timestamp": "2026-02-18T12:00:10Z"
+}
+```
+
+### Error response schema
+`schemas/kernel-v1/error.response.schema.json`
+
+---
+
+## Schema index
+
+- `schemas/kernel-v1/post_authorize.request.schema.json`
+- `schemas/kernel-v1/post_authorize.response.schema.json`
+- `schemas/kernel-v1/post_memory_seal.request.schema.json`
+- `schemas/kernel-v1/post_memory_seal.response.schema.json`
+- `schemas/kernel-v1/get_audit_decision_id.request.schema.json`
+- `schemas/kernel-v1/get_audit_decision_id.response.schema.json`
+- `schemas/kernel-v1/get_health.request.schema.json`
+- `schemas/kernel-v1/get_health.response.schema.json`
+- `schemas/kernel-v1/error.response.schema.json`

--- a/schemas/kernel-v1/error.response.schema.json
+++ b/schemas/kernel-v1/error.response.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scbe://schemas/kernel-v1/error.response.schema.json",
+  "title": "SCBE Kernel v1 Error Response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["request_id", "correlation_id", "audit_hash", "error"],
+  "properties": {
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "audit_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Fa-f0-9]{8,}$"
+    },
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "HF_TOKEN_MISSING",
+            "HF_TOKEN_INVALID",
+            "POLICY_VIOLATION",
+            "REQUEST_INVALID",
+            "REQUEST_CONFLICT",
+            "DECISION_NOT_FOUND",
+            "RATE_LIMITED",
+            "INTERNAL_ERROR"
+          ]
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/schemas/kernel-v1/get_audit_decision_id.request.schema.json
+++ b/schemas/kernel-v1/get_audit_decision_id.request.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scbe://schemas/kernel-v1/get_audit_decision_id.request.schema.json",
+  "title": "GET /audit/{decision_id} Request Parameters",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["request_id", "decision_id"],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "decision_id": { "type": "string", "minLength": 1 }
+  }
+}

--- a/schemas/kernel-v1/get_audit_decision_id.response.schema.json
+++ b/schemas/kernel-v1/get_audit_decision_id.response.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scbe://schemas/kernel-v1/get_audit_decision_id.response.schema.json",
+  "title": "GET /audit/{decision_id} Response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "request_id",
+    "correlation_id",
+    "audit_hash",
+    "decision_id",
+    "decision",
+    "reason",
+    "policy_version",
+    "recorded_at",
+    "evidence"
+  ],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "audit_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Fa-f0-9]{8,}$"
+    },
+    "decision_id": { "type": "string", "minLength": 1 },
+    "decision": {
+      "type": "string",
+      "enum": ["ALLOW", "QUARANTINE", "DENY"]
+    },
+    "reason": { "type": "string", "minLength": 1 },
+    "policy_version": { "type": "string", "minLength": 1 },
+    "recorded_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/kernel-v1/get_health.request.schema.json
+++ b/schemas/kernel-v1/get_health.request.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scbe://schemas/kernel-v1/get_health.request.schema.json",
+  "title": "GET /health Request Parameters",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["request_id"],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 }
+  }
+}

--- a/schemas/kernel-v1/get_health.response.schema.json
+++ b/schemas/kernel-v1/get_health.response.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scbe://schemas/kernel-v1/get_health.response.schema.json",
+  "title": "GET /health Response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "request_id",
+    "correlation_id",
+    "audit_hash",
+    "status",
+    "service",
+    "version",
+    "uptime_seconds",
+    "timestamp"
+  ],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "audit_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Fa-f0-9]{8,}$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "degraded", "error"]
+    },
+    "service": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "uptime_seconds": { "type": "integer", "minimum": 0 },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/kernel-v1/post_authorize.request.schema.json
+++ b/schemas/kernel-v1/post_authorize.request.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scbe://schemas/kernel-v1/post_authorize.request.schema.json",
+  "title": "POST /authorize Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["request_id", "subject", "resource", "action", "context"],
+  "properties": {
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject_id"],
+      "properties": {
+        "subject_id": { "type": "string", "minLength": 1 },
+        "roles": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resource_id", "resource_type"],
+      "properties": {
+        "resource_id": { "type": "string", "minLength": 1 },
+        "resource_type": { "type": "string", "minLength": 1 }
+      }
+    },
+    "action": {
+      "type": "string",
+      "minLength": 1
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_tags"],
+      "properties": {
+        "hf_token": { "type": "string", "minLength": 1 },
+        "policy_tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/schemas/kernel-v1/post_authorize.response.schema.json
+++ b/schemas/kernel-v1/post_authorize.response.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scbe://schemas/kernel-v1/post_authorize.response.schema.json",
+  "title": "POST /authorize Response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "request_id",
+    "correlation_id",
+    "audit_hash",
+    "decision_id",
+    "decision",
+    "reason",
+    "policy_version",
+    "evaluated_at"
+  ],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "audit_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Fa-f0-9]{8,}$"
+    },
+    "decision_id": { "type": "string", "minLength": 1 },
+    "decision": {
+      "type": "string",
+      "enum": ["ALLOW", "QUARANTINE", "DENY"]
+    },
+    "reason": { "type": "string", "minLength": 1 },
+    "policy_version": { "type": "string", "minLength": 1 },
+    "evaluated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/kernel-v1/post_memory_seal.request.schema.json
+++ b/schemas/kernel-v1/post_memory_seal.request.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scbe://schemas/kernel-v1/post_memory_seal.request.schema.json",
+  "title": "POST /memory/seal Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["request_id", "decision_id", "memory", "seal_options"],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "decision_id": { "type": "string", "minLength": 1 },
+    "memory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["memory_id", "content", "content_type"],
+      "properties": {
+        "memory_id": { "type": "string", "minLength": 1 },
+        "content": { "type": "string" },
+        "content_type": { "type": "string", "minLength": 1 }
+      }
+    },
+    "seal_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "ttl_seconds"],
+      "properties": {
+        "algorithm": { "type": "string", "minLength": 1 },
+        "ttl_seconds": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/schemas/kernel-v1/post_memory_seal.response.schema.json
+++ b/schemas/kernel-v1/post_memory_seal.response.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "scbe://schemas/kernel-v1/post_memory_seal.response.schema.json",
+  "title": "POST /memory/seal Response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "request_id",
+    "correlation_id",
+    "audit_hash",
+    "decision_id",
+    "decision",
+    "memory_id",
+    "sealed",
+    "seal_id",
+    "sealed_at"
+  ],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "correlation_id": { "type": "string", "minLength": 1 },
+    "audit_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Fa-f0-9]{8,}$"
+    },
+    "decision_id": { "type": "string", "minLength": 1 },
+    "decision": {
+      "type": "string",
+      "enum": ["ALLOW", "QUARANTINE", "DENY"]
+    },
+    "memory_id": { "type": "string", "minLength": 1 },
+    "sealed": { "type": "boolean" },
+    "seal_id": { "type": "string", "minLength": 1 },
+    "sealed_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Define a stable, machine-readable API contract for SCBE Kernel v1 so SDKs and automated tests can validate request/response compatibility. 
- Enforce deterministic decision semantics, idempotency, and traceability by mandating a decision enum, stable error codes, `request_id`, `correlation_id`, and `audit_hash` in responses.

### Description
- Add `docs/product/SCBE_KERNEL_V1_API.md` documenting `POST /authorize`, `POST /memory/seal`, `GET /audit/{decision_id}`, and `GET /health` with examples and a schema index. 
- Add JSON Schema files under `schemas/kernel-v1/` for each endpoint request/response plus a shared `error.response.schema.json` using JSON Schema Draft 2020-12 and explicit required fields. 
- Encode contract invariants in the schemas, including the deterministic decision enum (`ALLOW`, `QUARANTINE`, `DENY`), the stable error code set (e.g., `HF_TOKEN_MISSING`, `POLICY_VIOLATION`, etc.), required idempotency `request_id`, and required response traceability fields `correlation_id` and `audit_hash` (with a `^sha256:...` pattern).

### Testing
- Parsed all new JSON schema files with Python's `json` module to verify valid JSON syntax, reporting `validated 9 schema files`, and no parse errors were encountered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950885404483229ded2b4e1981bbab)