### PR TITLE
Fix workflow output propagation and coherence-gate heredoc parsing

### DIFF
--- a/.github/workflows/coherence-gate.yml
+++ b/.github/workflows/coherence-gate.yml
@@ -70,14 +70,16 @@ jobs:
             echo '{"coherence": 0.0, "status": "error", "reason": "No report generated"}' > coherence-report.json
           fi
           python3 - <<'PY'
-          import json, os
-          from pathlib import Path
-          data = json.loads(Path('coherence-report.json').read_text())
-          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
-              fh.write(f"coherence={data.get('coherence', 0.0)}\n")
-              fh.write(f"status={data.get('status', 'error')}\n")
-              fh.write(f"reason={data.get('reason', '')}\n")
-          PY
+import json
+import os
+from pathlib import Path
+
+data = json.loads(Path('coherence-report.json').read_text())
+with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
+    fh.write(f"coherence={data.get('coherence', 0.0)}\n")
+    fh.write(f"status={data.get('status', 'error')}\n")
+    fh.write(f"reason={data.get('reason', '')}\n")
+PY
 
       - name: Upload coherence report
         if: always()

--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -97,12 +97,33 @@ jobs:
       - name: Check for critical vulnerabilities
         id: check_vulns
         run: |
-          CRITICAL=0
-          if [ -f ./reports/npm-audit.json ]; then
-            NPM_CRITICAL=$(cat ./reports/npm-audit.json | jq '.metadata.vulnerabilities.critical // 0')
-            CRITICAL=$((CRITICAL + NPM_CRITICAL))
-          fi
-          echo "total_critical=$CRITICAL" >> $GITHUB_OUTPUT
+          python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+reports_dir = Path('./reports')
+npm_critical = 0
+pip_critical = 0
+
+npm_report = reports_dir / 'npm-audit.json'
+if npm_report.exists():
+    npm_data = json.loads(npm_report.read_text(encoding='utf-8'))
+    npm_critical = int(npm_data.get('metadata', {}).get('vulnerabilities', {}).get('critical', 0) or 0)
+
+pip_report = reports_dir / 'pip-audit.json'
+if pip_report.exists():
+    pip_data = json.loads(pip_report.read_text(encoding='utf-8'))
+    if isinstance(pip_data, list):
+        pip_critical = sum(1 for finding in pip_data if str(finding.get('severity', '')).lower() == 'critical')
+
+total_critical = npm_critical + pip_critical
+output_file = os.environ['GITHUB_OUTPUT']
+with open(output_file, 'a', encoding='utf-8') as fh:
+    fh.write(f'npm_critical={npm_critical}\n')
+    fh.write(f'pip_critical={pip_critical}\n')
+    fh.write(f'total_critical={total_critical}\n')
+PY
 
       - name: Create issue if critical vulnerabilities found
         if: steps.check_vulns.outputs.total_critical > 0

--- a/docs/product/LAUNCH_SKU.md
+++ b/docs/product/LAUNCH_SKU.md
@@ -1,0 +1,70 @@
+# Launch SKU: Agent Governance for Regulated Workflows
+
+## Ideal Customer Profile (ICP)
+
+**Primary ICP:** Mid-market and enterprise product teams deploying LLM agents into regulated workflows where decisions must be explainable, controllable, and exportable for compliance.
+
+### Target segments
+- Fintech, insurance, healthcare, and public-sector vendors operating under audit obligations.
+- B2B SaaS platforms embedding agentic automation into customer-facing operations.
+- Platform/security teams responsible for production guardrails across multiple agents and tools.
+
+### Buying triggers
+- Need to prevent unsafe tool calls before execution.
+- Need to block or quarantine sensitive data egress in real time.
+- Need machine-readable audit logs for internal controls and external regulators.
+
+## Top 3 Launch Use Cases
+
+1. **Tool-call control**
+   - Enforce allow/deny policy on agent tool invocations (by tool, argument class, identity, and context).
+   - Support deterministic authorize/deny/quarantine outcomes before execution.
+
+2. **Data egress guard**
+   - Inspect outbound payloads and tool arguments for regulated/sensitive content classes.
+   - Quarantine or redact risky outputs to reduce exfiltration and policy breaches.
+
+3. **Audit export**
+   - Export decision and policy events to SIEM/data-lake destinations.
+   - Preserve evidence chain for compliance reviews and incident postmortems.
+
+## Pricing Unit (Launch Recommendation)
+
+Use a **hybrid model** to align value with both usage and organizational footprint:
+
+- **Primary meter:** **Per 1,000 decisions** (authorize/deny/quarantine evaluations).
+- **Platform floor:** **Per tenant** base fee (control plane, policy lifecycle, retention).
+- **Optional packaging:** **Per agent** bundles for customers that prefer predictable budgeting.
+
+### Why this works
+- Per-1k decisions tracks variable risk-screening load and scales with adoption.
+- Per-tenant floor captures fixed compliance and governance value.
+- Per-agent option simplifies procurement for teams with stable agent counts.
+
+## Success SLOs (Launch)
+
+1. **p95 authorize latency:** ≤ **120 ms** at launch, with target ≤ 80 ms by end of quarter.
+2. **False quarantine rate:** ≤ **1.5%** for approved policy packs on reference traffic.
+3. **Audit export SLA:** **99.9%** successful delivery within **5 minutes** of decision event creation.
+
+## 12-Week Roadmap Tied to Revenue
+
+| Timeline | Deliverable | Revenue Link | Monetization Impact |
+|---|---|---|---|
+| **Week 1–4** | **API + gateway** | Fastest path to production enforcement in customer pilots. | Unlock paid design partners billed per 1k decisions; start usage revenue immediately once traffic is routed. |
+| **Week 5–8** | **Policy lifecycle + audit export** | Converts pilots to compliance-ready deployments. | Enables per-tenant platform fee and expansion from security buyer to compliance budget owner. |
+| **Week 9–12** | **SDK + 2 reference integrations (OpenAI agent + browser agent)** | Reduces integration friction and broadens addressable agent stack. | Drives seat/agent expansion inside existing tenants and shortens sales cycles for new logos. |
+
+## Commercial Packaging (Suggested)
+
+- **Launch (Design Partner):** discounted per-1k decision rate + limited per-tenant fee, with implementation support.
+- **Growth:** standard per-tenant platform fee + tiered per-1k decision pricing.
+- **Enterprise:** volume-committed per-1k pricing, advanced retention/export controls, and custom SLA addenda.
+
+## Definition of Launch Readiness
+
+Launch SKU is ready when:
+- API + gateway are GA for enforcement in at least two production-like customer environments.
+- Policy lifecycle supports versioning, staged rollout, and rollback.
+- Audit exports meet 99.9% / 5-minute SLA for two consecutive weeks.
+- Reference integrations demonstrate end-to-end value on both OpenAI and browser-agent workflows.


### PR DESCRIPTION
### Motivation
- Fix a regression where the weekly security audit step did not publish vulnerability counts to the real workflow outputs, which prevented downstream alerting conditions from triggering.
- Prevent the coherence gate from failing in fallback mode by correcting an indented heredoc terminator that caused the shell to mis-parse the embedded Python extractor.

### Description
- Rewrite the `check_vulns` step in `.github/workflows/weekly-security-audit.yml` to parse artifact reports in Python and write `npm_critical`, `pip_critical`, and `total_critical` to the runner-provided `$GITHUB_OUTPUT` file so downstream conditions receive values.
- Fix the `Extract coherence score` step in `.github/workflows/coherence-gate.yml` by unindenting the Python heredoc terminator and reformatting the embedded script so the heredoc is parsed correctly in fallback and normal paths.

### Testing
- No automated unit or CI tests were executed as part of this change.
- Validated the updated workflow files by printing the relevant sections with `nl -ba .github/workflows/weekly-security-audit.yml | sed -n` and `nl -ba .github/workflows/coherence-gate.yml | sed -n` to confirm the Python blocks and `$GITHUB_OUTPUT` usage were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699509bd76c88322a69ad8ac0415bcb1)