### PR TITLE
fix(types): align quarantine assessment with CombinedAssessment interface

### DIFF
--- a/src/ai_brain/unified-kernel.ts
+++ b/src/ai_brain/unified-kernel.ts
@@ -581,9 +581,8 @@ export class UnifiedKernel {
           combinedScore: 1,
           decision: 'QUARANTINE',
           anyFlagged: true,
-          confidence: 1,
-          recommendation: 'QUARANTINE',
-          rationale: ['HUGGINGFACE_TOKEN missing at Score step'],
+          flagCount: 1,
+          timestamp: Date.now(),
         },
       };
 


### PR DESCRIPTION
## Summary

- Fixes the SCBE Gates CI typecheck failure (`TS2353: 'confidence' does not exist in type 'CombinedAssessment'`)
- Replaces non-existent `confidence`, `recommendation`, and `rationale` properties with the correct `flagCount` and `timestamp` fields
- The quarantine metrics in `unified-kernel.ts:584` now conform to the `CombinedAssessment` interface defined in `types.ts:244`

## Test plan

- [x] `tsc --noEmit` passes locally
- [ ] CI SCBE Gates workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)