### PR TITLE
fix(ci): skip all matplotlib-dependent tests in CI

### DIFF
--- a/tests/test_combined_protocol.py
+++ b/tests/test_combined_protocol.py
@@ -19,8 +19,9 @@ import hashlib
 import base64
 from typing import Tuple, Set, List, Dict
 import numpy as np
-import matplotlib
+import pytest
 
+matplotlib = pytest.importorskip("matplotlib", reason="matplotlib not installed")
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 

--- a/tests/test_entropic_suite.py
+++ b/tests/test_entropic_suite.py
@@ -25,7 +25,7 @@ import math
 import numpy as np
 import pytest
 
-import matplotlib
+matplotlib = pytest.importorskip("matplotlib", reason="matplotlib not installed")
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
Applies pytest.importorskip to test_combined_protocol.py and test_entropic_suite.py.