### PR TITLE
feat(publish): add PyPI OIDC publishing and clean npm tarball

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -65,8 +65,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   create-release:
     name: Create GitHub Release

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,10 +1,14 @@
-name: npm Publish
+name: npm Publish (DEPRECATED — use auto-publish.yml)
 
+# Disabled: auto-publish.yml now handles npm + PyPI + GitHub Release in one workflow.
+# Keeping this file for reference only.
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type CONFIRM to run this deprecated workflow'
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release CLI
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,23 @@
 # Source files (only ship dist/)
 src/
 tests/
-examples/
+agents/
+scripts/
+training/
+hydra/
+config/
+visual_system/
+electron/
+symphonic_cipher/
+packages/
+
+# Python — nothing Python ships in an npm package
+*.py
+*.pyc
+*.pyo
+__pycache__/
+.hypothesis/
+*.zip
 
 # Config files
 tsconfig*.json
@@ -9,6 +25,11 @@ vitest.config.ts
 .kiro/
 .vscode/
 .github/
+pytest.ini
+pyproject.toml
+Dockerfile*
+docker-compose*
+render.yaml
 
 # Development files
 *.test.ts
@@ -20,10 +41,12 @@ vitest.config.ts
 # Build artifacts
 node_modules/
 .pytest_cache/
-__pycache__/
-*.pyc
+artifacts/
+coverage/
+.nyc_output/
+*.tgz
 
-# Documentation (keep README.md)
+# Documentation (keep README.md and LICENSE)
 docs/
 *.md
 !README.md
@@ -37,3 +60,6 @@ hioujhn/
 # Misc
 *.log
 .DS_Store
+trust-policy.json
+compliance_report.json
+*.mermaid.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scbe-aethermoore",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "SCBE-AETHERMOORE: Hyperbolic Geometry-Based Security with 14-Layer Architecture",
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT",
@@ -58,11 +58,6 @@
     "dist/src",
     "README.md",
     "LICENSE",
-    "sixtongues-cli-v1.0.0.zip",
-    "packages/sixtongues",
-    "scbe-cli.py",
-    "scbe.js",
-    "sixtongues-cli-v1.1.0.zip",
     "examples/npm"
   ],
   "scripts": {
@@ -145,8 +140,5 @@
   "overrides": {
     "tar": ">=7.0.0",
     "esbuild": ">=0.25.0"
-  },
-  "bin": {
-    "scbe": "scbe.js"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.backends._legacy:_Backend"
+
+[project]
+name = "scbe-aethermoore"
+version = "3.3.0"
+description = "Hyperbolic Geometry AI Safety Framework with 14-Layer Architecture"
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.11"
+authors = [
+    {name = "Issac Daniel Davis", email = "issdandavis@gmail.com"},
+]
+keywords = [
+    "cryptography",
+    "security",
+    "hyperbolic-geometry",
+    "poincare-ball",
+    "ai-safety",
+    "governance",
+    "quantum-resistant",
+    "14-layer-architecture",
+    "harmonic-scaling",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Security :: Cryptography",
+    "Topic :: Scientific/Engineering :: Mathematics",
+]
+
+[project.urls]
+Homepage = "https://github.com/issdandavis/SCBE-AETHERMOORE"
+Repository = "https://github.com/issdandavis/SCBE-AETHERMOORE"
+Issues = "https://github.com/issdandavis/SCBE-AETHERMOORE/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = [
+    "symphonic_cipher*",
+    "api*",
+    "crypto*",
+    "harmonic*",
+    "spiralverse*",
+    "minimal*",
+    "storage*",
+]
+exclude = ["tests*", "scripts*", "agents*", "training*"]


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` for PyPI package building (v3.3.0)
- Remove `password: ${{ secrets.PYPI_API_TOKEN }}` from `auto-publish.yml` — now uses OIDC trusted publisher (no token needed)
- Deprecate `npm-publish.yml` (auto-publish.yml handles npm + PyPI + GitHub Release in one workflow)
- Make `release.yml` manual-only to avoid duplicate tag-trigger conflicts
- Clean `package.json`: remove broken `bin` entry, trim `files` field to `dist/src`, `README.md`, `LICENSE`, `examples/npm`
- Strengthen `.npmignore` to block `.py`, `.pyc`, `.zip`, `__pycache__/` from npm tarball

## Remaining setup (on PyPI)
Configure Trusted Publisher at https://pypi.org/manage/project/scbe-aethermoore/settings/publishing/:
- Owner: `issdandavis`
- Repository: `SCBE-AETHERMOORE`
- Workflow: `auto-publish.yml`
- Environment: *(leave blank)*

## Test plan
- [ ] Verify `pyproject.toml` builds: `python -m build`
- [ ] Verify npm tarball is clean: `npm pack --dry-run`
- [ ] After merge, push `v3.3.0` tag to trigger auto-publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)