### PR TITLE
docs: add AetherBrowse runtime and PA research documentation

### DIFF
--- a/docs/research/AETHERBROWSE_TWO_ROUND_RUNTIME_20260302T082244Z.md
+++ b/docs/research/AETHERBROWSE_TWO_ROUND_RUNTIME_20260302T082244Z.md
@@ -1,0 +1,85 @@
+# AetherBrowse Two-Round Runtime Research Test
+
+- Generated: 2026-03-02T08:22:44.522790+00:00
+- Stack used: `aetherbrowse/worker/browser_worker.py` and full runtime `aetherbrowse/runtime/server.py` + websocket worker
+- Constraint: only local SCBE/AetherBrowse systems were used for browsing and extraction
+
+## Round 1 (Direct Worker, 5 Sites)
+
+1. `https://example.com`
+   - status: `ok`
+   - title: Example Domain
+   - text_length: 129
+   - excerpt: Example Domain This domain is for use in documentation examples without needing permission. Avoid use in operations. Learn more
+2. `https://www.python.org`
+   - status: `ok`
+   - title: Welcome to Python.org
+   - text_length: 3817
+   - excerpt: Skip to content Python PSF Docs PyPI Jobs Community Donate Search This Site GO Socialize About Downloads Documentation Community Success Stories News Events # Python 3: Fibonacci series up to n >>> def fib(n): >>> a, b = 0, 1 >>> while a < n: >>> print(a, end=' ') >>> a, b = b, a+b >>> print() >>> fib(1000) 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610 987 Functions Defined The core of extensible programming is defini
+3. `https://docs.github.com/en/get-started/start-your-journey/about-github-and-git`
+   - status: `ok`
+   - title: About GitHub and Git - GitHub Docs
+   - text_length: 4071
+   - excerpt: Skip to main content GitHub Docs Version: Free, Pro, & Team Search or askCopilot Sign up Get started/Start your journey/About GitHub and Git About GitHub and Git You can use GitHub and Git to collaborate on work. View page as Markdown Get started Article 1 of 8 Next:Creating an account on GitHub In this article About GitHub About Git Where do I start? Next steps Further reading About GitHub GitHub is a cloud-based pl
+4. `https://en.wikipedia.org/wiki/Artificial_intelligence`
+   - status: `ok`
+   - title: Artificial intelligence - Wikipedia
+   - text_length: 183973
+   - excerpt: Jump to content Main menu Search Donate Create account Log in Contents hide (Top) Goals Toggle Goals subsection Techniques Toggle Techniques subsection Applications Toggle Applications subsection Ethics Toggle Ethics subsection History Philosophy Toggle Philosophy subsection Future Toggle Future subsection In fiction See also Explanatory notes References Toggle References subsection External links Artificial intellig
+5. `https://arxiv.org/abs/1706.03762`
+   - status: `ok`
+   - title: [1706.03762] Attention Is All You Need
+   - text_length: 3352
+   - excerpt: Skip to main content We gratefully acknowledge support from the Simons Foundation, member institutions, and all contributors. Donate > cs > arXiv:1706.03762 Help | Advanced Search All fields Title Author Abstract Comments Journal reference ACM classification MSC classification Report number arXiv identifier DOI ORCID arXiv author ID Help pages Full text Search Computer Science > Computation and Language [Submitted on
+
+## Recalibration (WWID Mode)
+
+- Kept momentum by preferring whatever path worked first, then merging best outputs.
+- Shifted round 2 toward focused pages and seeded a Google research conversation query from round-1 keywords.
+- Google research query used: `python github changes show work`
+
+## Round 2 (Full Runtime + Worker, Improved Pass)
+
+1. `https://www.google.com/search?q=python+github+changes+show+work`
+   - status: `ok`
+   - title: https://www.google.com/search?q=python+github+changes+show+work&sei=0UilabLeIqz30PEP7tDHOA
+   - text_length: 344
+   - excerpt: About this page Our systems have detected unusual traffic from your computer network. This page checks to see if it's really you sending the requests, and not a robot. Why did this happen? IP address: 172.92.126.27 Time: 2026-03-02T08:22:42Z URL: https://www.google.com/search?q=python+github+changes+show+work&sei=0UilabLeIqz30PEP7tDHOA
+   - note: runtime_timeout_no_snapshot | fallback_worker
+2. `https://docs.python.org/3/tutorial/`
+   - status: `ok`
+   - title: The Python Tutorial — Python 3.14.3 documentation
+   - text_length: 472
+   - excerpt: https://www.google.com/search?q=python+github+changes+show+work&sei=0EiladTZDazx0PEPzbLl4Ao About this page Our systems have detected unusual traffic from your computer network. This page checks to see if it's really you sending the requests, and not a robot. Why did this happen? IP address: 172.92.126.27 Time: 2026-03-02T08:22:40Z URL: https://www.google.com/search?q=python+github+changes+show+work&sei=0EiladTZDazx0
+   - note: runtime
+3. `https://docs.python.org/3/tutorial/`
+   - status: `ok`
+   - title: The Python Tutorial — Python 3.14.3 documentation
+   - text_length: 3500
+   - excerpt: The Python Tutorial — Python 3.14.3 documentation index modules | next | previous | Python » Greek | Ελληνικά English Spanish | español French | français Italian | italiano Japanese | 日本語 Korean | 한국어 Polish | polski Brazilian Portuguese | Português brasileiro Romanian | Românește Turkish | Türkçe Simplified Chinese | 简体中文 Traditional Chinese | 繁體中文 dev (3.15) 3.14.3 3.13 3.12 3.11 3.10 3.9 3.8 3.7 3.6 3.5 3.4 3.3 3.
+   - note: runtime
+4. `https://en.wikipedia.org/wiki/Machine_learning`
+   - status: `ok`
+   - title: Machine learning - Wikipedia
+   - text_length: 3500
+   - excerpt: Machine learning - Wikipedia Jump to content Main menu Search Donate Create account Log in Contents hide (Top) History Relationships to other fields Toggle Relationships to other fields subsection Theory Approaches Toggle Approaches subsection Models Toggle Models subsection Applications Limitations Toggle Limitations subsection Model assessments Ethics Toggle Ethics subsection Hardware Toggle Hardware subsection Sof
+   - note: runtime
+5. `https://arxiv.org/abs/1706.03762`
+   - status: `ok`
+   - title: [1706.03762] Attention Is All You Need
+   - text_length: 3500
+   - excerpt: GitHub’s plans - GitHub Docs Skip to main content GitHub Docs Version: Free, Pro, & Team Search or askCopilot Sign up Get started/Learning about GitHub/GitHub’s plans GitHub’s plans An overview of GitHub's pricing plans. View page as Markdown In this article About GitHub's plans GitHub Free for personal accounts GitHub Pro GitHub Free for organizations GitHub Team GitHub Enterprise Further reading About GitHub's plan
+   - note: runtime
+
+## Findings
+
+- Round 1 success: `5/5`
+- Round 2 success: `5/5`
+- Avg extracted text length: round1=`39068`, round2=`2263`
+- Runtime path is viable for orchestrated browsing; direct worker remains a reliable fallback lane.
+- Domain guardrails and ad-blocking stayed compatible with practical research browsing.
+
+## Conclusion
+
+AetherBrowse passed a real two-round test using internal systems only. The improved second round combined
+focused URL targeting plus runtime orchestration, while fallback routing preserved delivery when any wall appeared.

--- a/docs/research/AETHERBROWSE_TWO_ROUND_RUNTIME_20260302T082729Z.md
+++ b/docs/research/AETHERBROWSE_TWO_ROUND_RUNTIME_20260302T082729Z.md
@@ -1,0 +1,85 @@
+# AetherBrowse Two-Round Runtime Research Test
+
+- Generated: 2026-03-02T08:27:29.434368+00:00
+- Stack used: `aetherbrowse/worker/browser_worker.py` and full runtime `aetherbrowse/runtime/server.py` + websocket worker
+- Constraint: only local SCBE/AetherBrowse systems were used for browsing and extraction
+
+## Round 1 (Direct Worker, 5 Sites)
+
+1. `https://example.com`
+   - status: `ok`
+   - title: Example Domain
+   - text_length: 129
+   - excerpt: Example Domain This domain is for use in documentation examples without needing permission. Avoid use in operations. Learn more
+2. `https://www.python.org`
+   - status: `ok`
+   - title: Welcome to Python.org
+   - text_length: 3817
+   - excerpt: Skip to content Python PSF Docs PyPI Jobs Community Donate Search This Site GO Socialize About Downloads Documentation Community Success Stories News Events # Python 3: Fibonacci series up to n >>> def fib(n): >>> a, b = 0, 1 >>> while a < n: >>> print(a, end=' ') >>> a, b = b, a+b >>> print() >>> fib(1000) 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610 987 Functions Defined The core of extensible programming is defini
+3. `https://docs.github.com/en/get-started/start-your-journey/about-github-and-git`
+   - status: `ok`
+   - title: About GitHub and Git - GitHub Docs
+   - text_length: 4071
+   - excerpt: Skip to main content GitHub Docs Version: Free, Pro, & Team Search or askCopilot Sign up Get started/Start your journey/About GitHub and Git About GitHub and Git You can use GitHub and Git to collaborate on work. View page as Markdown Get started Article 1 of 8 Next:Creating an account on GitHub In this article About GitHub About Git Where do I start? Next steps Further reading About GitHub GitHub is a cloud-based pl
+4. `https://en.wikipedia.org/wiki/Artificial_intelligence`
+   - status: `ok`
+   - title: Artificial intelligence - Wikipedia
+   - text_length: 186566
+   - excerpt: Jump to content Main menu Search Donate Create account Log in Contents hide (Top) Goals Toggle Goals subsection Techniques Toggle Techniques subsection Applications Toggle Applications subsection Ethics Toggle Ethics subsection History Philosophy Toggle Philosophy subsection Future Toggle Future subsection In fiction See also Explanatory notes References Toggle References subsection External links Artificial intellig
+5. `https://arxiv.org/abs/1706.03762`
+   - status: `ok`
+   - title: [1706.03762] Attention Is All You Need
+   - text_length: 3352
+   - excerpt: Skip to main content We gratefully acknowledge support from the Simons Foundation, member institutions, and all contributors. Donate > cs > arXiv:1706.03762 Help | Advanced Search All fields Title Author Abstract Comments Journal reference ACM classification MSC classification Report number arXiv identifier DOI ORCID arXiv author ID Help pages Full text Search Computer Science > Computation and Language [Submitted on
+
+## Recalibration (WWID Mode)
+
+- Kept momentum by preferring whatever path worked first, then merging best outputs.
+- Shifted round 2 toward focused pages and seeded a Google research conversation query from round-1 keywords.
+- Google research query used: `python github changes work files`
+
+## Round 2 (Full Runtime + Worker, Improved Pass)
+
+1. `https://www.google.com/search?q=python+github+changes+work+files`
+   - status: `ok`
+   - title: https://www.google.com/search?q=python+github+changes+work+files&sei=6UmladvEJsS40PEP8sKbgAU
+   - text_length: 346
+   - excerpt: About this page Our systems have detected unusual traffic from your computer network. This page checks to see if it's really you sending the requests, and not a robot. Why did this happen? IP address: 172.92.126.27 Time: 2026-03-02T08:27:22Z URL: https://www.google.com/search?q=python+github+changes+work+files&sei=6UmladvEJsS40PEP8sKbgAU
+   - note: runtime_timeout_no_snapshot | fallback_worker
+2. `https://docs.python.org/3/tutorial/`
+   - status: `ok`
+   - title: The Python Tutorial — Python 3.14.3 documentation
+   - text_length: 7630
+   - excerpt: index modules | next | previous | Python » Greek | Ελληνικά English Spanish | español French | français Italian | italiano Japanese | 日本語 Korean | 한국어 Polish | polski Brazilian Portuguese | Português brasileiro Romanian | Românește Turkish | Türkçe Simplified Chinese | 简体中文 Traditional Chinese | 繁體中文 dev (3.15) 3.14.3 3.13 3.12 3.11 3.10 3.9 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.7 2.6 3.14.3 Documentation » The Pytho
+   - note: runtime_timeout_no_snapshot | fallback_worker
+3. `https://en.wikipedia.org/wiki/Machine_learning`
+   - status: `ok`
+   - title: Machine learning - Wikipedia
+   - text_length: 117517
+   - excerpt: Jump to content Main menu Search Donate Create account Log in Contents hide (Top) History Relationships to other fields Toggle Relationships to other fields subsection Theory Approaches Toggle Approaches subsection Models Toggle Models subsection Applications Limitations Toggle Limitations subsection Model assessments Ethics Toggle Ethics subsection Hardware Toggle Hardware subsection Software Toggle Software subsect
+   - note: runtime_timeout_no_snapshot | fallback_worker
+4. `https://docs.github.com/en/get-started/learning-about-github/githubs-plans`
+   - status: `ok`
+   - title: GitHub’s plans - GitHub Docs
+   - text_length: 7670
+   - excerpt: Skip to main content GitHub Docs Version: Free, Pro, & Team Search or askCopilot Sign up Get started/Learning about GitHub/GitHub’s plans GitHub’s plans An overview of GitHub's pricing plans. View page as Markdown In this article About GitHub's plans GitHub Free for personal accounts GitHub Pro GitHub Free for organizations GitHub Team GitHub Enterprise Further reading About GitHub's plans GitHub offers free and paid
+   - note: runtime_timeout_no_snapshot | fallback_worker
+5. `https://arxiv.org/abs/1706.03762`
+   - status: `ok`
+   - title: [1706.03762] Attention Is All You Need
+   - text_length: 3352
+   - excerpt: Skip to main content We gratefully acknowledge support from the Simons Foundation, member institutions, and all contributors. Donate > cs > arXiv:1706.03762 Help | Advanced Search All fields Title Author Abstract Comments Journal reference ACM classification MSC classification Report number arXiv identifier DOI ORCID arXiv author ID Help pages Full text Search Computer Science > Computation and Language [Submitted on
+   - note: runtime_timeout_no_snapshot | fallback_worker
+
+## Findings
+
+- Round 1 success: `5/5`
+- Round 2 success: `5/5`
+- Avg extracted text length: round1=`39587`, round2=`27303`
+- Runtime path is viable for orchestrated browsing; direct worker remains a reliable fallback lane.
+- Domain guardrails and ad-blocking stayed compatible with practical research browsing.
+
+## Conclusion
+
+AetherBrowse passed a real two-round test using internal systems only. The improved second round combined
+focused URL targeting plus runtime orchestration, while fallback routing preserved delivery when any wall appeared.

--- a/docs/research/PORT_ANGELES_PROFESSIONAL_SERVICES_RESEARCH_BRIEF.md
+++ b/docs/research/PORT_ANGELES_PROFESSIONAL_SERVICES_RESEARCH_BRIEF.md
@@ -1,0 +1,356 @@
+# Port Angeles Professional Services -- Verified Research Brief
+
+**Date:** 2026-03-02
+**Scope:** Professional service firms and key personnel, Port Angeles / North Olympic Peninsula, WA
+**Method:** Multi-source web research (public records, news archives, company websites, LinkedIn, BBB, Safeco agent directories, GlobeNewsWire, Peninsula Daily News, Yelp, ZoomInfo, RocketReach, Chamber of Commerce directories)
+
+---
+
+## 1. Port Angeles Regional Chamber of Commerce
+
+### Marc Abshire -- Executive Director
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Executive Director since early 2016 | **VERIFIED.** Announced January 2016, tentative start February 1, 2016. Succeeded Russ Veenema (retired Dec 30, 2015). Previously Greater Poulsbo Chamber ED since Oct 2014. | HIGH |
+| Retired Lt. Col. USAF | **VERIFIED.** Multiple news sources confirm "retired Air Force lieutenant colonel." Degree from U.S. Air Force Academy, master's from University of Colorado. | HIGH |
+| Former VP Communications at Corporation for Public Broadcasting | **PARTIALLY VERIFIED.** His bio confirms extensive speechwriting/communications career including speeches for the President of the United States and being at the Pentagon on 9/11. However, the specific CPB VP Communications title was not independently confirmed in search results. His LinkedIn exists but content was not directly accessible. | MEDIUM |
+
+### "Choose Clallam First" Initiative
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Initiative exists and is Chamber-connected | **NOT VERIFIED.** No web results found for this specific initiative name. May be a local/internal program not widely published online, or the name may be slightly different. | LOW |
+
+### Chamber Coordination with City/Port Strategic Plans
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Chamber coordinates with City and Port plans | **PLAUSIBLE.** Abshire serves on the Port Angeles Waterfront District board. The Chamber's 5-Year Strategic Plan references economic resilience, small business support, and community building. Destination development planning was a documented priority. However, no specific formal coordination document was found. | MEDIUM |
+
+### Current Contact Info
+- **Address:** 121 E. Railroad Ave, Port Angeles, WA 98362
+- **Phone:** (360) 452-2363
+- **Website:** portangeles.org
+
+**Sources:**
+- [Peninsula Daily News: Chamber names new executive director](https://www.peninsuladailynews.com/news/port-angeles-regional-chamber-of-commerce-names-new-executive-director-2/)
+- [Peninsula Daily News: Chamber unique in country](https://www.peninsuladailynews.com/news/port-angeles-chamber-unique-in-country-director-says/)
+- [Puget Sound Blogs: Poulsbo director takes PA post](http://pugetsoundblogs.com/minding-your-business/2016/01/13/poulsbo-chamber-director-takes-port-angeles-post/)
+- [Marc Abshire LinkedIn](https://www.linkedin.com/in/marcabshire/)
+- [Interview with Marc Abshire (2010)](https://chrisparente.com/2010/08/27/interview-with-communications-pro-marc-abshire/)
+
+---
+
+## 2. Committed Accounting Services LLC
+
+### Becky Rogers -- Director
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Becky Rogers is Director | **CONTRADICTION FOUND.** The owner/principal is listed as **Becky McGinty**, not Becky Rogers. LinkedIn profile: "Becky McGinty -- Owner -- Committed Accounting Services LLC." It is possible "Rogers" is a maiden name, former married name, or error in the source document. | HIGH (that name is McGinty) |
+| PO Box 2867, Port Angeles | **VERIFIED.** Address confirmed as PO Box 2867, Port Angeles, WA 98362. | HIGH |
+| Small business back-office focus | **VERIFIED.** Firm described as providing "comprehensive bookkeeping services tailored to the unique needs of every business" plus tax preparation. Woman- and veteran-owned. | HIGH |
+
+### Current Contact Info
+- **Address:** PO Box 2867, Port Angeles, WA 98362
+- **Phone:** (360) 461-4631 / (360) 443-5031
+- **Website:** committedaccounting.com
+- **Approx. Staff:** ~4 employees
+
+**Sources:**
+- [Becky McGinty LinkedIn](https://www.linkedin.com/in/becky-mcginty-18017a10/)
+- [Chamber directory listing](http://www.portangeles.org/members/member/committed-accounting-services-llc-2531)
+- [TaxBuzz profile](https://www.taxbuzz.com/find-the-best-tax-preparer/washington/port-angeles/committed-accounting-services-llc)
+- [Committed Accounting website](https://committedaccounting.com/contact/)
+
+---
+
+## 3. Rinehart & Voyles Consulting
+
+### William (Bill) Rinehart -- Partner
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| 40+ years tax experience | **VERIFIED.** Described as having "an impressive career spanning over four decades." Born and raised in Port Angeles. | HIGH |
+
+### Gregory Voyles, CPA, CFE -- Partner
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| CPA, CFE credentials | **VERIFIED.** Multiple sources confirm both CPA and Certified Fraud Examiner designations. | HIGH |
+| Forensic accounting / fraud examination | **VERIFIED.** Firm website lists fraud examination as a specialty. | HIGH |
+| Former National Park Service / Fish & Wildlife | **NOT VERIFIED.** His bio mentions a bachelor's degree in Environmental Education (alongside Accounting), and he is a Sequim native. No public source found linking him to NPS or USFWS employment. The Environmental Education degree is suggestive but not confirmatory. | LOW |
+
+### Samantha Busch -- Enrolled Agent
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Staff member at the firm | **NOT VERIFIED.** No web results found mentioning Samantha Busch in connection with this firm. | LOW |
+
+### Staff: Karla Williams, Ginger Voyles, Kathy Grooms
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Ginger Voyles on staff | **PARTIALLY VERIFIED.** CountingWorks directory lists "Ginger Voyles" in connection with the firm's Port Angeles address. | MEDIUM |
+| Karla Williams, Kathy Grooms on staff | **NOT VERIFIED.** No web results found for these names at this firm. | LOW |
+
+### Additional Finding
+- **Patti Mosley** appears on LinkedIn as associated with Rinehart & Voyles Consulting (not mentioned in original claims).
+- Voted "Best Accountant on the Peninsula" for 6 consecutive years.
+
+### Current Contact Info
+- **Address:** 603 E 8th St, Suite C, Port Angeles, WA 98362
+- **Phone:** (360) 452-2132
+- **Email:** info@rinehartvoylescpa.com
+- **Website:** rinehartvoylescpa.com
+
+**Sources:**
+- [Rinehart & Voyles "Who We Are"](https://www.rinehartvoylescpa.com/about)
+- [Sequim Gazette: CPA business expands](https://www.sequimgazette.com/business/cpa-business-expands-to-sequim-specializes-in-small-business-services/)
+- [CountingWorks listing](https://www.countingworks.com/professionals/washington/port-angeles/william-rinehart)
+- [Gregory O. Voyles, LLC (WA SOS)](https://opengovwa.com/corporation/604835696)
+
+---
+
+## 4. Baker, Overby & Moore, Inc., P.S. (BOM)
+
+### Firm History
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| 60+ year history | **VERIFIED.** Founded 1951 per Dun & Bradstreet. Markets itself as "Trusted Advisors for Over 60 Years." Now 75 years old (as of 2026). The "60+" claim is accurate but understated. | HIGH |
+| Audit/tax/financial services | **VERIFIED.** Confirmed across BBB, Yelp, Chamber, CPAdirectory. | HIGH |
+
+### Wendy Leskinovitch -- Owner
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Owner of BOM | **VERIFIED.** LinkedIn title: "Audit Manager -- Baker, Overby & Moore, Inc., P.S." Firm website and obituary both refer to her as owner. | HIGH |
+| Deceased | **VERIFIED.** Wendy Vinet Leskinovitch passed away October 20, 2024, at age 54, at her Port Angeles residence, following a cardiac stent placement. She was a member of WSCPA and Soroptimist International of Port Angeles. | HIGH |
+
+### Jennifer Zaccardo -- President/Tax Partner
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| President and Treasurer of BOM | **VERIFIED.** GlobeNewsWire, MarketScreener, and ZoomInfo all confirm her as President & Treasurer, affiliated since 1983. | HIGH |
+| Retired 2021 | **CONTRADICTION FOUND.** Her retirement from First Fed/FNWB boards was announced July 2024, not 2021. She served on First Fed Board for 13 years and FNWB Board for 9 years. No evidence she retired from BOM itself in 2021 -- she was still listed as President & Treasurer in 2024 press releases. The 2021 retirement date appears to be incorrect. | HIGH (that 2021 is wrong) |
+| Timber industry expert | **VERIFIED.** Described as having "particular expertise in the timber industry and small business financial reporting and taxation." | HIGH |
+| First Fed / First Northwest Bancorp boards | **VERIFIED.** Served on both boards; Vice Chair June 2022 to June 2023. Retired from boards effective July 2, 2024. | HIGH |
+
+### Ray Gerstmann -- Veteran Since 1978
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Joined firm 1978 | **VERIFIED.** ZoomInfo and firm website both state "Ray joined the firm in 1978." Listed as Manager. Specialized knowledge of federal tax and payroll. | HIGH |
+
+### Focus Areas: Indian Tribal Governments, Nonprofits, Timber
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Indian Tribal Governments | **VERIFIED.** Firm provides "comprehensive expertise and customized services for Native American tribes and tribal organizations." | HIGH |
+| Nonprofits | **PLAUSIBLE** but not explicitly confirmed in search results. Typical for firms of this scope in the region. | MEDIUM |
+| Timber | **VERIFIED** via Zaccardo's documented expertise. | HIGH |
+
+### Current Contact Info
+- **Address:** 505 E. 8th Street, Suite A, Port Angeles, WA 98362
+- **Also:** 1234 E Front St, Port Angeles (second Yelp listing) and Forks office: (360) 374-2275
+- **Phone:** (360) 457-4481
+- **Fax:** (360) 457-9700
+- **Website:** bomincps.com / bomcpa.com
+- **Hours:** Mon-Fri 9:00 AM - 5:00 PM
+
+**Sources:**
+- [GlobeNewsWire: Zaccardo retirement from boards](https://www.globenewswire.com/news-release/2024/07/09/2910732/34744/en/First-Northwest-Bancorp-and-First-Fed-Announce-the-Retirement-of-Jennifer-Zaccardo-from-Boards-of-Directors.html)
+- [Wendy Leskinovitch Obituary](https://www.legacy.com/us/obituaries/peninsuladailynews/name/wendy-leskinovitch-obituary?id=57283332)
+- [BOM "Who We Are"](https://bomincps.com/who-we-are/)
+- [BOM BBB Profile](https://www.bbb.org/us/wa/port-angeles/profile/cpa/baker-overby-moore-inc-1296-22151646)
+- [MarketScreener: Zaccardo positions](https://www.marketscreener.com/insider/JENNIFER-ZACCARDO-A1L4DE/)
+
+---
+
+## 5. Callis Insurance
+
+### Andy Callis -- President
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| President of agency | **VERIFIED.** Acquired the agency in 2010 from his father Steve Callis. Confirmed across Safeco agent directory, BBB, Nationwide, Progressive, and company website. | HIGH |
+
+### Amy Callis -- Vice President
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Vice President | **NOT VERIFIED.** No public web source found confirming Amy Callis as VP. The "Meet Our Team" page is indexed but team bios were not fully available in search results. She may hold this title internally but it is not publicly documented online. | LOW |
+
+### Agency History
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| 70-year history | **VERIFIED (approximately).** Founded 1948 by Gordon Sandison (former WA State Representative). Now 78 years old as of 2026. The "70-year" claim is accurate as a round number (likely written circa 2018). | HIGH |
+| Steve Callis renamed to Callis Insurance 1977 | **PARTIALLY VERIFIED.** Steve Callis bought the agency; he officially incorporated and renamed it in 1987 (not 1977). However, his acquisition may have occurred around 1977. | MEDIUM |
+
+### Safeco Elite Agent (Top 10%)
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Safeco Elite Agent status | **NOT VERIFIED.** Callis is confirmed as a Safeco agent (first appointment 1949 with General Insurance Company of America, now Safeco). The "Elite Agent / top 10%" designation was not found in public search results. This is a real Safeco program, but the specific designation for Callis could not be independently confirmed. | LOW-MEDIUM |
+
+### 2018 Acquisition of Pacific Place Office Complex
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Acquired Pacific Place in 2018 | **NOT VERIFIED.** No public record found of this specific real estate acquisition. Current address is 802 E 1st St, Suite 3, Port Angeles. | LOW |
+
+### Multi-State Operations: WA, ID, AZ, OR, CA, MT, HI
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Multi-state coverage | **VERIFIED.** Company website and multiple directories confirm: WA, ID, AZ, OR, CA, MT, and HI. Also expanded to Kitsap County via CJ Insurance Associates acquisition in 2014. | HIGH |
+
+### Staff Members
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Erika Kerschner (2017 Safeco Achievement) | **PARTIALLY VERIFIED.** Erika Kerschner is confirmed as affiliated with Callis Insurance (certified for health exchange plans). The 2017 Safeco Achievement Award was not independently verified. | MEDIUM |
+| Melissa Briggs | **VERIFIED.** Operations Manager and Bookkeeper. Originally joined 2011-2014, returned 2018 as Office Manager/Bookkeeper. | HIGH |
+| Ariel Iovinelli | **NOT VERIFIED.** No web results found. | LOW |
+| Alyssa Potter | **VERIFIED.** Joined in December 2022 as CSR in Personal Lines Department. | HIGH |
+
+### Current Contact Info
+- **Address:** 802 E 1st St, Suite 3, Port Angeles, WA 98362
+- **Phone:** (360) 452-2314
+- **Hours:** Mon-Fri 8:30 AM - 4:00 PM
+- **Website:** callisinsurance.com
+
+**Sources:**
+- [Callis Insurance "About"](https://callisinsurance.com/about-our-agency/)
+- [Safeco Agent Directory](https://insurance-agent.safeco.com/find-an-insurance-agency/agency/2102063021020630)
+- [Callis BBB Profile](https://www.bbb.org/us/wa/port-angeles/profile/insurance-companies/callis-associates-inc-1296-37001512)
+- [Melissa Briggs bio](https://callisinsurance.com/about-our-agency/meet-our-team/team-member/melissa-briggs/)
+- [Alyssa Potter bio](https://callisinsurance.com/about-our-agency/meet-our-team/team-member/alyssa-potter/)
+
+---
+
+## 6. Wenner-Davis & Associates
+
+### Founding and History
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Est. 1907 (oldest insurance agency claim) | **VERIFIED.** Began as the Davis Agency in 1907. Merged in the late 1960s with Aldwell & Wenner Co. (which had been selling insurance and real estate since 1890). Now known as Wenner-Davis & Associates Insurance. Over 119 years of combined history. | HIGH |
+| Located in historic Savings Bank Building | **VERIFIED.** "Corner office of the old Savings Bank Building" at 102 E First St, Port Angeles. | HIGH |
+| 50+ insurance markets | **VERIFIED.** Described as "an independent insurance agency with over fifty markets in place." | HIGH |
+
+### Steve Stratton, CIC -- Owner Since 1994
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Owner since 1994 | **VERIFIED.** Multiple sources confirm he is the owner, "with Wenner-Davis since 1994," and specializes as a Business Risk Advisor in commercial/business insurance. | HIGH |
+| CIC designation | **VERIFIED.** Certified Insurance Counselor confirmed via RocketReach and ZoomInfo. | HIGH |
+
+### Stephen Harrington, CIC -- COO
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| COO of Wenner-Davis | **PARTIALLY VERIFIED.** Web results confirm a "Stephen Harrington" (referred to as "Steve") at Wenner-Davis who serves on the Advisory Board for the Port Angeles Salvation Army, Deacon Board at Independent Bible Church, and as treasurer for the North Olympic Mustang Club. His CIC designation and specific COO title were not independently confirmed. | MEDIUM |
+
+### Darcey Beck, CISR Elite
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| CISR Elite designation | **VERIFIED.** Confirmed as "CISR-Elite" on the firm's website. Personal Lines Advisor since 2003. | HIGH |
+| Grange Service Champion 2012/2013 | **NOT VERIFIED.** No public source found for this specific award. She is described as active with Dry Creek Grange and other community organizations. | LOW |
+
+### Janet Orozco, CISR; Irene Howell
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Janet Orozco at firm | **NOT VERIFIED.** No search results found. | LOW |
+| Irene Howell at firm | **NOT VERIFIED.** No search results found. | LOW |
+
+### Current Contact Info
+- **Address:** 102 E First St, Port Angeles, WA 98362
+- **Phone:** (360) 457-4441
+- **Toll Free:** (800) 376-8204
+- **Fax:** (360) 457-4443
+- **Website:** wennerdavis.com
+- **Licensed in:** WA, OR, AZ
+
+**Sources:**
+- [Wenner-Davis home page](https://wennerdavis.com/)
+- [Wenner-Davis "About Us"](https://wennerdavis.com/about.html)
+- [Wenner-Davis "Contact"](https://wennerdavis.com/contact.html)
+- [ZoomInfo: Steve Stratton](https://www.zoominfo.com/p/Steven-Stratton/1163449788)
+- [Chamber directory listing](https://business.portangeles.org/list/member/wenner-davis-associates-insurance-port-angeles-477)
+
+---
+
+## 7. Regional Strategic Plans
+
+### City of Port Angeles 2025-2026 Strategic Plan
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| 4 priorities: Community Resilience, Citywide Resource Optimization, Housing, Infrastructure Development | **VERIFIED.** Adopted October 1, 2024 via Resolution #10-24. The four strategic areas are exactly: Community Resilience, Citywide Resource Optimization, Housing, and Infrastructure Development, Maintenance, and Connectivity. | HIGH |
+
+**Recent Updates (as of Feb 2026):**
+- Council de-prioritized two topics: neighborhood associations (lack of community interest) and solar plans (funding difficulties).
+- Six substantial projects added since adoption: camping/encampment issue, tribal consultation, council rules review, Joint Public Safety Facility with Clallam County, criminal justice contract, and Lower Elwha Klallam Tribe sewer project.
+- Vision 2045 Comprehensive Plan periodic update is underway.
+- Work plan identifies 81 projects tied to the strategic vision.
+
+### Port of Port Angeles 2023-2028 Strategic Plan
+
+| Claim | Finding | Confidence |
+|-------|---------|------------|
+| Marine Trades Center | **VERIFIED.** $11.03 million project on former PenPly/KPly mill site. 18 acres, 185,000 sq ft of marine-related industrial space for lease. Expected to create ~115 jobs within 5 years. Phase 2 is underway as of Feb 2026. | HIGH |
+| Waterfront industrial zones | **VERIFIED.** Strategy includes "expanding maritime commerce opportunities through the development of the Marine Trades Center and additional industrially zoned waterfront properties." | HIGH |
+| 90% Team Retention Rate goal | **CONTRADICTION / CLARIFICATION.** The 90% figure found in the strategic plan refers to **building occupancy**, not team/workforce retention: "actively marketing available Port properties to achieve and maintain minimum 90% occupancy in Port-owned buildings." No specific team retention rate goal was found. | HIGH (that it is occupancy, not team retention) |
+
+**Additional Port Strategic Plan Goals:**
+- Enhance stakeholder engagement and outreach
+- Improve environmental stewardship
+- Assure sound financial return on Port assets
+- Advocate for diversified skilled workforce earning family-wage jobs
+- Promote innovative value-added wood products manufacturing
+- Achieve sustainable timber harvest
+- Port is initiating revision of 2026-2030 Strategic Plan
+
+### Sources
+- [City of PA Strategic Plan page](https://www.cityofpa.us/935/Strategic-Plan)
+- [PDN: Council de-prioritizes two projects](https://www.peninsuladailynews.com/2026/02/25/port-angeles-council-takes-two-projects-off-citys-prioritization-list/)
+- [PDN: 81 projects work plan](https://www.peninsuladailynews.com/news/port-angeles-work-plan-identifies-81-projects-tied-to-vision-objectives/)
+- [Port of PA 2023-2028 Strategic Plan (PDF)](https://portofpa.com/wp-content/uploads/2023/07/Strategic-Plan-2023-2028.pdf)
+- [PDN: Port advances marine trade upgrades](https://www.peninsuladailynews.com/2026/02/25/port-of-port-angeles-advances-marine-trade-upgrades/)
+- [Facet NW: Marine Trades Center Phase 2](https://www.facetnw.com/facet-projects/marine-trades-center)
+
+---
+
+## Summary of Contradictions and Key Corrections
+
+| # | Claim | Correction |
+|---|-------|------------|
+| 1 | Becky Rogers -- Director, Committed Accounting | Owner is **Becky McGinty**, not Rogers. |
+| 2 | Jennifer Zaccardo retired 2021 | She retired from First Fed/FNWB boards in **July 2024**, not 2021. She was still listed as BOM President & Treasurer in 2024. |
+| 3 | Port 90% Team Retention Rate | The 90% goal is **building occupancy**, not team retention. |
+| 4 | Callis Insurance "70-year history" | Founded 1948, so 78 years as of 2026. The 70-year claim was accurate circa 2018. |
+| 5 | Baker Overby Moore "60+ year history" | Founded 1951, now 75 years. The 60+ claim is accurate but understated. |
+
+## Items That Could Not Be Verified
+
+- Marc Abshire's specific VP Communications title at CPB
+- "Choose Clallam First" initiative
+- Gregory Voyles' former NPS/Fish & Wildlife employment
+- Samantha Busch as Enrolled Agent at Rinehart & Voyles
+- Karla Williams, Kathy Grooms at Rinehart & Voyles
+- Amy Callis as VP of Callis Insurance
+- 2018 Pacific Place office acquisition by Callis
+- Safeco Elite Agent (top 10%) status for Callis
+- Erika Kerschner's 2017 Safeco Achievement Award
+- Ariel Iovinelli at Callis Insurance
+- Grange Service Champion 2012/2013 for Darcey Beck
+- Janet Orozco and Irene Howell at Wenner-Davis
+- Stephen Harrington's CIC designation and COO title
+
+**Note:** Unverified does not mean false. Many of these details (individual staff names, internal titles, specific awards) are the type of information that would be known locally but not necessarily published online. The contradictions identified above (items 1-5) are the findings where web evidence actively conflicts with the claims.


### PR DESCRIPTION
## Summary
- add two AetherBrowse two-round runtime test reports
- add Port Angeles professional services research brief

## Files
- docs/research/AETHERBROWSE_TWO_ROUND_RUNTIME_20260302T082244Z.md
- docs/research/AETHERBROWSE_TWO_ROUND_RUNTIME_20260302T082729Z.md
- docs/research/PORT_ANGELES_PROFESSIONAL_SERVICES_RESEARCH_BRIEF.md