### PR TITLE
docs(spec): add machine-science RFC, taxonomy map, and patent-safe abstract

### DIFF
--- a/docs/specs/MACHINE_SCIENCE_CONTROL_FRAMEWORK_RFC_0001.md
+++ b/docs/specs/MACHINE_SCIENCE_CONTROL_FRAMEWORK_RFC_0001.md
@@ -1,0 +1,173 @@
+# RFC-0001: Machine-Science Control Framework Core Spec
+
+Status: Draft  
+Version: 0.1  
+Authoring scope: SCBE-AETHERMOORE core
+
+## 1. Abstract
+
+This document defines the core behavior of SCBE-AETHERMOORE as a machine-science control framework.
+The framework does not model real-world physics. It uses tunable, physics-style invariants as machine constants
+to enforce deterministic behavior across heterogeneous systems.
+
+Time, intention, trust, risk, policy, and operational context are modeled as explicit dimensions in a shared
+control hyperspace. Tokens, agents, and actions are evaluated as state transitions in that space.
+
+## 2. Normative Language
+
+The keywords MUST, SHOULD, and MAY are normative.
+
+## 3. Scope
+
+This RFC specifies:
+
+- shared hyperspace axes
+- machine constants and update rules
+- policy fields and overlap behavior
+- token lifecycle and governance decisions
+- deterministic execution requirements
+
+This RFC does not specify:
+
+- UI or narrative presentation layers
+- specific cloud vendor deployment layouts
+- proprietary training data
+
+## 4. Core Definitions
+
+- Hyperspace: the multi-dimensional control space used for governance decisions.
+- Axis: one coordinate dimension in hyperspace.
+- Machine constant: a configurable invariant used to keep behavior stable across platforms.
+- Policy field: a function over hyperspace that adds cost, permission, or penalty.
+- Token: a stateful unit of work (request, packet, event, action, task).
+- Trajectory: a token's movement through hyperspace over time.
+- Governance result: `ALLOW`, `QUARANTINE`, `ESCALATE`, or `DENY`.
+
+## 5. Hyperspace Axes (Minimum Set)
+
+Implementations MUST expose these axes:
+
+1. `t`: time phase and sequence position
+2. `i`: intention class and confidence
+3. `p`: active policy vector
+4. `u`: trust state (agent/user/system)
+5. `r`: risk state
+6. `c`: context commitment (device, load, entropy, posture)
+
+Implementations MAY add domain axes (for example throughput pressure or jurisdiction domain), but MUST preserve
+the base six axes.
+
+## 6. Machine Constants
+
+Machine constants are framework-controlled values that define stable behavior and deterministic transitions.
+
+Minimum constant families:
+
+- `k_tick`: control loop tick rate
+- `k_decay`: trust and reinforcement decay rates
+- `k_gate`: decision thresholds for policy fields
+- `k_route`: cost multipliers for path selection
+- `k_crypto`: context-lock envelope parameters
+- `k_stability`: numeric stability bounds for iterative control
+
+Requirements:
+
+- Constants MUST be explicit and versioned.
+- Constant updates MUST be audited.
+- Runtime behavior MUST be reproducible for the same input stream and constant set.
+
+## 7. Policy Field Model
+
+Each policy field is a function:
+
+`F_j(x, k) -> (cost_j, permit_j, reason_j)`
+
+where:
+
+- `x` is current hyperspace state
+- `k` is current machine constant set
+
+Composite decision score:
+
+`S = sum(w_j * cost_j) + penalty(context_mismatch) + penalty(intent_conflict)`
+
+Decision mapping:
+
+- `ALLOW` when `S < theta_allow`
+- `QUARANTINE` when `theta_allow <= S < theta_escalate`
+- `ESCALATE` when `theta_escalate <= S < theta_deny`
+- `DENY` when `S >= theta_deny`
+
+Thresholds (`theta_*`) are machine constants.
+
+## 8. Token Model
+
+Minimum token envelope:
+
+```json
+{
+  "token_id": "uuid",
+  "issued_at": "iso8601",
+  "context_commitment": "hash",
+  "intent_class": "string",
+  "policy_vector": ["safety", "compliance", "resource"],
+  "trust_vector": {"ko": 0.0, "av": 0.0, "ru": 0.0, "ca": 0.0, "um": 0.0, "dr": 0.0},
+  "risk_score": 0.0,
+  "proposed_action": "string"
+}
+```
+
+Token processing MUST be fail-closed:
+
+- unresolved context commitment -> `QUARANTINE` or `DENY`
+- invalid signature -> `DENY`
+- missing policy metadata -> `ESCALATE`
+
+## 9. Control Loop
+
+Per tick, implementations MUST execute:
+
+1. Ingest token and current system context.
+2. Project token into hyperspace state.
+3. Evaluate policy fields.
+4. Compute decision score and governance result.
+5. Execute or constrain action path.
+6. Update trust and telemetry.
+7. Emit deterministic audit record.
+
+Pseudo-flow:
+
+```text
+for token in stream:
+  x = embed(token, context, constants)
+  fields = eval_fields(x, constants)
+  S = aggregate(fields, constants)
+  decision = map_score(S, constants)
+  apply(decision, token)
+  update_trust(token, decision, constants)
+  log(token, x, fields, S, decision, constants_version)
+```
+
+## 10. Determinism Requirements
+
+- Numeric operations SHOULD use fixed-point or deterministic bounded-precision mode in critical loops.
+- Time source MUST be monotonic for ordering.
+- Policy evaluation order MUST be stable.
+- Audit logs MUST include constants version and decision trace.
+
+## 11. Security Considerations
+
+- Context-bound cryptography SHOULD avoid oracle-style rejection signals when possible.
+- Quorum-protected actions SHOULD require role diversity for critical operations.
+- Trust decay and self-exclusion SHOULD be automatic under repeated divergence.
+- Replay defense MUST include nonce/time-window checks.
+
+## 12. Reference Surface (Current Repo Mapping)
+
+- Runtime governance and planning: `aetherbrowse/runtime/`
+- Worker execution membrane: `aetherbrowse/worker/`
+- Policy and trust logic: `src/` and `policies/`
+- Telemetry and artifacts: `artifacts/`
+
+This mapping is informative, not normative.
+

--- a/docs/specs/MACHINE_SCIENCE_TAXONOMY_MAP.md
+++ b/docs/specs/MACHINE_SCIENCE_TAXONOMY_MAP.md
@@ -1,0 +1,101 @@
+# Machine-Science Taxonomy Map
+
+This document formalizes:
+
+`axes -> constants -> fields -> actions`
+
+for SCBE-AETHERMOORE machine-science governance.
+
+## 1. Axes
+
+| Axis ID | Axis Name | Description | Typical Source |
+|---|---|---|---|
+| `t` | Time | Tick phase, sequence order, freshness, decay window | monotonic clock, scheduler |
+| `i` | Intention | Requested objective class and confidence | planner, user command parser |
+| `p` | Policy | Active policy regime and scope | governance profile, route policy |
+| `u` | Trust | Actor trust state and role weights | agent trust engine, quorum state |
+| `r` | Risk | Composite risk estimate | anomaly detector, rule engine |
+| `c` | Context | Device/load/entropy/posture commitment | runtime state, context hash |
+
+## 2. Machine Constants
+
+| Constant Family | Examples | Purpose |
+|---|---|---|
+| `k_tick` | `tick_hz`, `window_size` | deterministic update cadence |
+| `k_decay` | `trust_decay`, `reinforcement_decay` | bounded state drift and forgetting |
+| `k_gate` | `theta_allow`, `theta_escalate`, `theta_deny` | governance decision boundaries |
+| `k_route` | `risk_latency_multiplier`, `quarantine_path_cost` | risk-weighted route shaping |
+| `k_crypto` | `context_lock_strength`, `nonce_window` | context-bound crypto envelope behavior |
+| `k_stability` | `max_update_step`, `clip_bounds` | numerical stability in loops |
+
+## 3. Policy Fields
+
+Each field reads axis state and constants, then emits cost/permit signals.
+
+| Field ID | Inputs | Outputs | Behavior |
+|---|---|---|---|
+| `F_safety` | `i, r, c` | risk cost, allow bit | blocks unsafe intent-risk pairings |
+| `F_compliance` | `p, c, t` | policy cost, reason | enforces jurisdiction and procedural rules |
+| `F_resource` | `t, c, r` | pressure cost | throttles under load or anomaly pressure |
+| `F_trust` | `u, i, t` | trust cost | penalizes divergence from expected actor behavior |
+| `F_route` | `r, u, c` | path cost | increases path cost for suspicious trajectories |
+| `F_quorum` | `u, p, i` | quorum permit | requires role-diverse signatures for critical actions |
+
+## 4. Action Classes
+
+| Action Class | Trigger Pattern | Default Governance |
+|---|---|---|
+| `A_read` | search, fetch, inspect, snapshot | `ALLOW` unless policy conflict |
+| `A_write` | update content, post message, modify state | `QUARANTINE` or `ESCALATE` by policy |
+| `A_execute` | run task, invoke connector, deploy | `ESCALATE` for medium/high risk |
+| `A_destructive` | delete, revoke, reset, terminate | quorum-gated, often `DENY` without quorum |
+| `A_sensitive_transfer` | key material, credentialed publish, privileged routing | context-lock + quorum |
+
+## 5. Mapping: Axes -> Constants -> Fields -> Actions
+
+| Axis | Primary Constants | Primary Fields | Dominant Action Impact |
+|---|---|---|---|
+| `t` | `k_tick`, `k_decay` | `F_resource`, `F_compliance` | throttling, expiry, replay gating |
+| `i` | `k_gate` | `F_safety`, `F_trust` | intent-risk decision boundaries |
+| `p` | `k_gate`, `k_route` | `F_compliance`, `F_quorum` | required approvals and route restrictions |
+| `u` | `k_decay`, `k_gate` | `F_trust`, `F_quorum` | trust-based allow/quarantine/escalate |
+| `r` | `k_gate`, `k_route` | `F_safety`, `F_route` | routing penalties and deny thresholds |
+| `c` | `k_crypto`, `k_stability` | `F_safety`, `F_compliance` | context-lock validity and fail-closed behavior |
+
+## 6. Six Tongues Alignment (Policy Weight Layer)
+
+Treat Six Tongues as a structured trust-policy weighting vector, not a narrative-only artifact.
+
+| Tongue | Domain Role | Typical Field Weighting Emphasis |
+|---|---|---|
+| `KO` | orchestration/control | `F_quorum`, `F_compliance` |
+| `AV` | messaging/io | `F_safety`, `F_resource` |
+| `RU` | constraints/policy binding | `F_compliance`, `F_trust` |
+| `CA` | computation/logic | `F_route`, `F_safety` |
+| `UM` | security/privacy | `F_safety`, `F_quorum`, `F_crypto` |
+| `DR` | structure/ledger | `F_compliance`, deterministic audit |
+
+## 7. Minimal Deterministic Record Schema
+
+```json
+{
+  "token_id": "uuid",
+  "axes": {"t": 0.0, "i": 0.0, "p": 0.0, "u": 0.0, "r": 0.0, "c": 0.0},
+  "constants_version": "vX.Y.Z",
+  "field_outputs": {
+    "F_safety": {"cost": 0.0, "permit": true},
+    "F_compliance": {"cost": 0.0, "permit": true}
+  },
+  "decision_score": 0.0,
+  "governance_decision": "ALLOW",
+  "action_class": "A_read",
+  "timestamp": "iso8601"
+}
+```
+
+## 8. Operational Rule of Thumb
+
+- If context commitment or signature checks fail: prefer `QUARANTINE` or `DENY`.
+- If risk rises with low trust: increase route and execution costs before hard deny where safe.
+- If action class is destructive or sensitive: require quorum and explicit policy-field pass.
+

--- a/docs/specs/patent/MACHINE_SCIENCE_PATENT_SAFE_ABSTRACT.md
+++ b/docs/specs/patent/MACHINE_SCIENCE_PATENT_SAFE_ABSTRACT.md
@@ -1,0 +1,42 @@
+# Patent-Safe Abstract: Machine-Science Control Framework
+
+## Abstract
+
+Disclosed is a deterministic machine-science control framework for governing computational actions in distributed AI
+systems. The framework models requests, tasks, packets, and agent actions as tokenized state transitions in a shared
+multi-dimensional control space, where time, intention, policy, trust, risk, and context are explicit dimensions.
+The framework uses configurable machine constants to enforce stable behavior across heterogeneous execution targets
+including general-purpose processors, accelerators, and mixed infrastructure deployments.
+
+For each token, the framework computes a context commitment, projects state into the control space, evaluates
+overlapping policy fields, and generates a governance decision from a deterministic scoring function. The resulting
+decision controls execution by allowing, quarantining, escalating, or denying the proposed action. The same control
+loop updates trust scores, route costs, and scheduling priorities while emitting a reproducible audit trace bound to
+constant-set versioning.
+
+In some embodiments, context-bound cryptographic envelopes are coupled to control-space state so that invalid context
+or intent alignment produces non-useful outputs rather than actionable execution. In some embodiments, critical actions
+are additionally gated by role-diverse multi-agent quorum. In some embodiments, predictive digital-twin outputs adjust
+policy thresholds and routing weights in real time while preserving deterministic replay under fixed configuration.
+
+The invention is implementable as improved active queue management, route scoring, policy evaluation, and governance
+orchestration algorithms, with deterministic execution guarantees and cross-platform behavioral consistency.
+
+## Claim-Neutral Novelty Framing
+
+- unified dimensional governance model for tokenized actions
+- tunable machine constants as cross-platform invariants
+- deterministic policy-field composition and decisioning
+- context-locked cryptographic gating integrated with governance state
+- traceable multi-agent quorum overlays for high-risk actions
+- reproducible digital-twin-informed threshold adaptation
+
+## Non-Claim Language Guardrails
+
+Use these terms in filings and technical summaries:
+
+- "machine constants" instead of natural or physical constants
+- "policy fields" instead of physical forces
+- "control hyperspace" instead of spacetime simulation
+- "state transition trajectories" instead of physical motion
+


### PR DESCRIPTION
## Summary
- add RFC-style core machine-science control spec
- add taxonomy map (axes -> constants -> fields -> actions)
- add patent-safe abstract aligned to machine-science framing

## Files
- docs/specs/MACHINE_SCIENCE_CONTROL_FRAMEWORK_RFC_0001.md
- docs/specs/MACHINE_SCIENCE_TAXONOMY_MAP.md
- docs/specs/patent/MACHINE_SCIENCE_PATENT_SAFE_ABSTRACT.md

## Notes
- docs-only delta, no runtime code changes
- preserves framing: machine-science control with tunable invariants (not physical simulation)