### PR TITLE
Quasicrystal voxel storage upgrades + intro materials

### DIFF
--- a/content/marketing/AI_VIDEO_PROMPTS_INTRO.md
+++ b/content/marketing/AI_VIDEO_PROMPTS_INTRO.md
@@ -1,0 +1,35 @@
+# AI Video Prompt Kit (Aethermoore Intro)
+
+Use these prompts in video generators (Runway, Pika, Kling, Sora-style tools, etc.).
+
+## Prompt 1: System Identity (15s)
+
+```
+Cinematic macro shot of a crystalline 6D lattice unfolding into a glowing 3D sphere, sacred glyphs orbiting in six color channels, futuristic AI governance dashboard holograms, high detail, volumetric light, smooth camera dolly, dramatic but clean, no text artifacts.
+```
+
+## Prompt 2: Security + Storage (15s)
+
+```
+Abstract data vault with Chladni wave patterns on metallic plates, nodal lines become encrypted voxel cubes, cubes route into three tiers (hot, warm, cold), cyber-architectural style, teal-gold palette, sharp contrast, smooth transitions, premium SaaS launch aesthetic.
+```
+
+## Prompt 3: Ritual Governance (15s)
+
+```
+Triadic guardians around a floating seal, manifold coordinates threading into a lock, failed attempts dissolve into harmless noise particles, success emits a verified sigil pulse, mythic-tech fusion style, cinematic depth of field, high-end motion graphics.
+```
+
+## Prompt 4: Product Close (10s)
+
+```
+Wide shot: Aethermoore command center, live metrics and trusted AI agents collaborating in real time, logo reveal with subtle particle spiral, polished startup trailer style, clean modern type-ready composition.
+```
+
+## Voiceover Draft
+
+```
+We built Aethermoore to make advanced AI systems governable, secure, and auditable by design.
+From quasicrystal voxel storage to ritual-grade validation gates, every layer is engineered for resilient execution.
+This is not a black box. This is controlled intelligence at scale.
+```

--- a/docs/GITHUB_ORDER_AND_NOTES_SYNC.md
+++ b/docs/GITHUB_ORDER_AND_NOTES_SYNC.md
@@ -1,0 +1,37 @@
+# GitHub Order And Notes Sync
+
+This checklist keeps local knowledge from being stranded.
+
+## Repository Order
+
+1. Keep `README.md` high-level only.
+2. Put executable architecture docs in `docs/`.
+3. Keep test-backed systems in `src/` + `tests/`.
+4. Keep launch/promotional assets in `content/marketing/`.
+
+## Local Notes To GitHub Flow
+
+1. Build a manifest from local markdown/text notes:
+
+```powershell
+python scripts/system/inventory_notes_for_github.py --root . --out artifacts/notes_manifest.json
+```
+
+2. Review candidates (size, path, modified date).
+3. Promote only high-signal notes into one of:
+   - `docs/`
+   - `notes/`
+   - `training/intake/`
+4. Commit promoted notes in focused batches by topic.
+
+## Suggested Priority Buckets
+
+- `P0`: architecture decisions and operating runbooks
+- `P1`: validated research notes
+- `P2`: rough brainstorms and drafts
+
+## Guardrails
+
+- Never commit secrets/API tokens from local notes.
+- Redact personal/sensitive text before push.
+- Keep one-topic-per-commit for traceable history.

--- a/docs/START_HERE_AETHERMOORE.md
+++ b/docs/START_HERE_AETHERMOORE.md
@@ -1,0 +1,33 @@
+# Aethermoore Start Here
+
+This is the shortest path to the core systems.
+
+## 1) Core Storage + Security
+
+- `src/knowledge/quasicrystal_voxel_drive.py`
+  - 6D sparse tensor drive
+  - Chladni access gating
+  - AEAD sealing with AAD-bound mode checks
+  - tier routing and metrics export
+
+## 2) Ritual Safety Lane
+
+- `src/sacred_eggs.py`
+  - ritual invocation surface
+  - triadic binding and manifold validation
+  - fail-to-noise behavior
+
+## 3) Tests You Can Run First
+
+- `tests/test_quasicrystal_voxel_drive.py`
+- `tests/test_sacred_eggs_rituals.py`
+
+```powershell
+python -m pytest tests/test_quasicrystal_voxel_drive.py tests/test_sacred_eggs_rituals.py -q
+```
+
+## 4) Why This Matters
+
+- Storage lane: secure, sparse, and test-gated.
+- Ritual lane: governance rules are explicit and enforceable.
+- Launch lane: these are demoable, documentable, and monetizable.

--- a/scripts/system/inventory_notes_for_github.py
+++ b/scripts/system/inventory_notes_for_github.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_GLOBS = ("**/*.md", "**/*.txt")
+DEFAULT_EXCLUDES = {
+    ".git",
+    "node_modules",
+    ".venv",
+    "__pycache__",
+    "dist",
+    "build",
+    "artifacts",
+}
+
+
+def iter_note_files(root: Path, globs: Iterable[str]) -> Iterable[Path]:
+    seen: set[Path] = set()
+    for pattern in globs:
+        for path in root.glob(pattern):
+            if not path.is_file():
+                continue
+            if any(part in DEFAULT_EXCLUDES for part in path.parts):
+                continue
+            resolved = path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            yield path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inventory local notes for GitHub promotion.")
+    parser.add_argument("--root", default=".", help="Root directory to scan.")
+    parser.add_argument("--out", default="artifacts/notes_manifest.json", help="Output JSON path.")
+    parser.add_argument("--max", type=int, default=5000, help="Maximum files to emit.")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    for idx, path in enumerate(iter_note_files(root, DEFAULT_GLOBS)):
+        if idx >= args.max:
+            break
+        stat = path.stat()
+        rows.append(
+            {
+                "path": str(path.relative_to(root)).replace("\\", "/"),
+                "bytes": stat.st_size,
+                "modified_utc": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+        )
+
+    rows.sort(key=lambda x: (x["path"]))
+    payload = {
+        "generated_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "root": str(root),
+        "total": len(rows),
+        "files": rows,
+    }
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"Wrote {len(rows)} entries to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/knowledge/quasicrystal_voxel_drive.py
+++ b/src/knowledge/quasicrystal_voxel_drive.py
@@ -1,0 +1,801 @@
+"""
+Quasi-Crystal Voxel Storage Drive - 6D Sparse Tensor Arrays
+
+This module fuses:
+- 6D quasi-crystal projection (3D physical + 3D perpendicular windows)
+- Cymatic/Chladni access gating from 6D vectors
+- Sacred Tongues weighting and phase-state routing
+- Fail-closed retrieval verification using stored content hash
+
+The drive is sparse: only touched 6D tensor coordinates are materialized.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+
+try:
+    import qutip as qt  # type: ignore
+
+    _QUTIP_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    qt = None
+    _QUTIP_AVAILABLE = False
+
+PHI = float((1 + np.sqrt(5)) / 2)
+TONGUE_NAMES = ["KO", "AV", "RU", "CA", "UM", "DR"]
+TONGUE_WEIGHTS = [PHI**i for i in range(6)]
+
+# Lower value means higher flow.
+TONGUE_VISCOSITY = {
+    "KO": 1 / (1 + 1.00 * PHI),
+    "AV": 1 / (1 + 0.80 * PHI),
+    "RU": 1 / (1 + 0.30 * PHI),
+    "CA": 1 / (1 + 0.40 * PHI),
+    "UM": 0.50,
+    "DR": 0.50,
+}
+
+RETENTION_POLICIES = {
+    "default": timedelta(days=30),
+    "ephemeral": timedelta(hours=1),
+    "persistent": timedelta(days=365),
+    "compliance": timedelta(days=2555),  # 7 years
+}
+
+TIER_LABELS = {0: "hot", 1: "warm", 2: "cold"}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utc_iso(ts: datetime) -> str:
+    return ts.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class VoxelCell:
+    """A single occupied cell in the 6D sparse tensor."""
+
+    cell_id: str
+    tongue_index: List[int]  # 6D tensor index
+    tongue_coords: List[float]  # 6D normalized coordinates in [-1, 1]
+    physical_projection: List[float]  # 3D
+    perpendicular_projection: List[float]  # 3D
+    chladni_mode: Tuple[int, int]
+    content_hash: str
+    content_size: int
+    category: str
+    depth: int = 0
+    parent_id: str = ""
+    children: List[str] = field(default_factory=list)
+    phase: str = "laminar"  # laminar | turbulent | emulsion
+    viscosity: float = 0.5
+    is_valid: bool = True
+    created_at_utc: str = ""
+    expires_at_utc: str = ""
+    storage_tier: int = 1
+    stored_phason_epoch: int = 0
+    cipher_scheme: str = "xor-v1"
+
+
+@dataclass
+class TensorSlab:
+    """A sparse slab focused on one dominant Sacred Tongue."""
+
+    tongue: str
+    tongue_index: int
+    cells: Dict[str, VoxelCell]
+    total_content_bytes: int = 0
+    phase_state: str = "laminar"
+
+
+class QuasiCrystalVoxelDrive:
+    """
+    6D sparse tensor storage with quasicrystal + cymatic access gating.
+
+    Fail-closed principles:
+    - Invalid 6D placements can be rejected on write.
+    - Retrieval returns None unless hash verification succeeds (strict mode).
+    - Expired cells are treated as absent.
+    """
+
+    def __init__(
+        self,
+        resolution: int = 64,
+        lattice_constant: float = 1.0,
+        default_retention_policy: str = "default",
+    ) -> None:
+        if not isinstance(resolution, int) or resolution <= 1:
+            raise ValueError("resolution must be an integer > 1")
+        if lattice_constant <= 0:
+            raise ValueError("lattice_constant must be > 0")
+        if default_retention_policy not in RETENTION_POLICIES:
+            raise ValueError(f"unknown retention policy: {default_retention_policy}")
+
+        self.resolution = resolution
+        self.lattice_constant = float(lattice_constant)
+        self.default_retention_policy = default_retention_policy
+
+        # 6D -> 3D projection matrices with icosahedral symmetry.
+        self.M_par, self.M_perp = self._build_projection_matrices()
+        self.acceptance_radius = 1.5 * self.lattice_constant
+        self._phason_strain = np.zeros(3, dtype=float)
+        self._phason_epoch = 0
+
+        self.cells: Dict[str, VoxelCell] = {}
+        self.tensor_slabs: Dict[str, TensorSlab] = {
+            name: TensorSlab(tongue=name, tongue_index=i, cells={})
+            for i, name in enumerate(TONGUE_NAMES)
+        }
+        self.depth_trees: Dict[str, List[str]] = {}
+
+        # Sparse tensor index map: (i0..i5) -> [cell_id...]
+        self.tensor_index_map: Dict[Tuple[int, int, int, int, int, int], List[str]] = {}
+
+        # Backward-compatible blob map:
+        # - legacy: bytes (xor-v1)
+        # - new: dict envelope (aead-v1)
+        self.content_store: Dict[str, Any] = {}
+        self.tier_content_store: Dict[int, Dict[str, Any]] = {0: {}, 1: {}, 2: {}}
+
+        # category -> preferred phase
+        self.phase_map: Dict[str, str] = {}
+
+        # Storage metrics for monitoring exports.
+        self._metrics: Dict[str, int] = {
+            "storage_size_bytes": 0,
+            "memory_count": 0,
+            "expired_total": 0,
+        }
+
+        # Runtime master key for AEAD wraps.
+        self._aead_master_key = hashlib.sha256(
+            f"qc-voxel-drive:{self.resolution}:{self.lattice_constant}".encode("utf-8")
+        ).digest()
+
+    @property
+    def phason_epoch(self) -> int:
+        return self._phason_epoch
+
+    @property
+    def phason_strain(self) -> np.ndarray:
+        return self._phason_strain.copy()
+
+    def _build_projection_matrices(self) -> Tuple[np.ndarray, np.ndarray]:
+        norm = 1 / np.sqrt(1 + PHI**2)
+        e_par = (
+            np.array(
+                [
+                    [1, PHI, 0],
+                    [-1, PHI, 0],
+                    [0, 1, PHI],
+                    [0, -1, PHI],
+                    [PHI, 0, 1],
+                    [PHI, 0, -1],
+                ],
+                dtype=float,
+            ).T
+            * norm
+        )
+        e_perp = (
+            np.array(
+                [
+                    [1, -1 / PHI, 0],
+                    [-1, -1 / PHI, 0],
+                    [0, 1, -1 / PHI],
+                    [0, -1, -1 / PHI],
+                    [-1 / PHI, 0, 1],
+                    [-1 / PHI, 0, -1],
+                ],
+                dtype=float,
+            ).T
+            * norm
+        )
+        return e_par, e_perp
+
+    def _validate_coords(self, coords: List[float]) -> List[float]:
+        if len(coords) != 6:
+            raise ValueError(f"tongue_coords must have length 6, got {len(coords)}")
+        if not all(np.isfinite(coords)):
+            raise ValueError("tongue_coords must be finite numbers")
+        # Normalize into bounded 6D range for deterministic tensor indexing.
+        return [float(np.tanh(c)) for c in coords]
+
+    def _project_6d(self, coords: List[float]) -> Tuple[List[float], List[float]]:
+        n = np.array(coords, dtype=float)
+        r_phys = (self.M_par @ n).tolist()
+        r_perp = (self.M_perp @ n).tolist()
+        return r_phys, r_perp
+
+    def _coords_to_chladni(self, coords: List[float]) -> Tuple[int, int]:
+        # Velocity axes: KO/AV/RU. Security axes: CA/UM/DR.
+        vel = np.linalg.norm(coords[:3])
+        sec = np.linalg.norm(coords[3:])
+        n = max(1, int(vel * 10) % 20 + 1)
+        m = max(1, int(sec * 10) % 20 + 1)
+        if n == m:
+            m += 1
+        return (n, m)
+
+    def _legacy_chladni_xor(self, data: bytes, n: int, m: int, phason_epoch: Optional[int] = None) -> bytes:
+        # Stateless stream generation tied to mode and phason epoch.
+        epoch = self._phason_epoch if phason_epoch is None else int(phason_epoch)
+        seed = hashlib.sha256(f"chladni:{n}:{m}:{epoch}".encode("utf-8")).digest()
+        key_stream = bytearray()
+        block = seed
+        while len(key_stream) < len(data):
+            block = hashlib.sha256(block).digest()
+            key_stream.extend(block)
+        return bytes(d ^ k for d, k in zip(data, key_stream[: len(data)]))
+
+    def _route_tier(self, dominant_tongue: str, phase: str) -> int:
+        token = f"{dominant_tongue}:{phase}:{self._phason_epoch}"
+        return int(hashlib.sha256(token.encode("utf-8")).digest()[0] % len(TIER_LABELS))
+
+    def _derive_cell_key(self, chunk_id: str, stored_phason_epoch: int, tier: int) -> bytes:
+        return hashlib.sha256(
+            self._aead_master_key + f"{chunk_id}:{stored_phason_epoch}:{tier}".encode("utf-8")
+        ).digest()
+
+    @staticmethod
+    def _chladni_aad(n: int, m: int) -> bytes:
+        return f"chladni:{n}:{m}".encode("utf-8")
+
+    def _aead_encrypt(self, plaintext: bytes, *, chunk_id: str, n: int, m: int, tier: int, epoch: int) -> Dict[str, Any]:
+        key = self._derive_cell_key(chunk_id=chunk_id, stored_phason_epoch=epoch, tier=tier)
+        nonce = os.urandom(12)
+        cipher = ChaCha20Poly1305(key)
+        ciphertext = cipher.encrypt(nonce, plaintext, self._chladni_aad(n, m))
+        return {
+            "scheme": "aead-v1",
+            "ciphertext": ciphertext,
+            "nonce": nonce,
+            "tier": tier,
+            "stored_phason_epoch": epoch,
+        }
+
+    def _aead_decrypt(self, envelope: Dict[str, Any], *, chunk_id: str, n: int, m: int) -> Optional[bytes]:
+        try:
+            key = self._derive_cell_key(
+                chunk_id=chunk_id,
+                stored_phason_epoch=int(envelope.get("stored_phason_epoch", self._phason_epoch)),
+                tier=int(envelope.get("tier", 1)),
+            )
+            cipher = ChaCha20Poly1305(key)
+            nonce = envelope["nonce"]
+            ciphertext = envelope["ciphertext"]
+            return cipher.decrypt(nonce, ciphertext, self._chladni_aad(n, m))
+        except (InvalidTag, KeyError, TypeError, ValueError):
+            return None
+
+    def _blob_size_bytes(self, blob: Any) -> int:
+        if isinstance(blob, bytes):
+            return len(blob)
+        if isinstance(blob, dict):
+            total = 0
+            for key in ("ciphertext", "nonce"):
+                val = blob.get(key)
+                if isinstance(val, (bytes, bytearray)):
+                    total += len(val)
+            return total
+        return 0
+
+    def _update_metrics(self) -> None:
+        size = 0
+        for tier_bucket in self.tier_content_store.values():
+            for blob in tier_bucket.values():
+                size += self._blob_size_bytes(blob)
+        self._metrics["storage_size_bytes"] = size
+        self._metrics["memory_count"] = len(self.cells)
+
+    def _apply_harmonic_modifier(self, coords: List[float], spin_coherence: Optional[List[float]]) -> List[float]:
+        if not spin_coherence:
+            return coords
+
+        vec = np.array(spin_coherence[:6], dtype=float)
+        if vec.size < 6:
+            vec = np.pad(vec, (0, 6 - vec.size), mode="constant")
+        norm = float(np.linalg.norm(vec))
+        if norm == 0:
+            return coords
+        vec = vec / norm
+
+        if _QUTIP_AVAILABLE and qt is not None:
+            # Layer-12 style hook: derive a bounded coherence signal from a simple qubit Hamiltonian.
+            hx = float(vec[0])
+            hz = float(vec[1])
+            H = hx * qt.sigmax() + hz * qt.sigmaz()
+            result = qt.mesolve(H, qt.basis(2, 0), [0, 0.5, 1.0], [])
+            psi = result.states[-1]
+            coherence = abs(complex(psi.full()[0, 0]))
+        else:
+            coherence = float((np.dot(vec[:3], vec[3:6]) + 1.0) / 2.0)
+
+        modifier = 1.0 + (coherence - 0.5) * 0.2  # bounded to +/-10%
+        return [float(np.tanh(c * modifier)) for c in coords]
+
+    def _dominant_tongue(self, coords: List[float]) -> Tuple[str, int, float]:
+        weighted = [abs(c) * w for c, w in zip(coords, TONGUE_WEIGHTS)]
+        dom_idx = weighted.index(max(weighted))
+        dom_name = TONGUE_NAMES[dom_idx]
+        return dom_name, dom_idx, TONGUE_VISCOSITY[dom_name]
+
+    def _tensor_index(self, coords: List[float]) -> List[int]:
+        out: List[int] = []
+        for c in coords:
+            idx = int(((c + 1.0) / 2.0) * (self.resolution - 1))
+            out.append(max(0, min(self.resolution - 1, idx)))
+        return out
+
+    def _determine_phase(self, category: str, viscosity: float, dominant_tongue: str) -> str:
+        # UM/DR are explicit emulsifier tongues in the design notes.
+        if dominant_tongue in {"UM", "DR"}:
+            return "emulsion"
+
+        existing = self.phase_map.get(category)
+        if existing:
+            return existing
+
+        if viscosity > 0.55:
+            phase = "laminar"
+        elif viscosity < 0.35 and len(self.cells) > 64:
+            phase = "turbulent"
+        else:
+            phase = "laminar"
+
+        self.phase_map[category] = phase
+        return phase
+
+    def _get_depth(self, cell_id: str) -> int:
+        cell = self.cells.get(cell_id)
+        return cell.depth if cell else 0
+
+    def _get_expiry(self, retention_policy: str, ttl_seconds: Optional[int]) -> datetime:
+        now = _utc_now()
+        if ttl_seconds is not None:
+            if ttl_seconds <= 0:
+                raise ValueError("ttl_seconds must be > 0")
+            return now + timedelta(seconds=ttl_seconds)
+        if retention_policy not in RETENTION_POLICIES:
+            raise ValueError(f"unknown retention policy: {retention_policy}")
+        return now + RETENTION_POLICIES[retention_policy]
+
+    def store(
+        self,
+        chunk_id: str,
+        content: bytes,
+        tongue_coords: List[float],
+        category: str = "general",
+        parent_id: str = "",
+        retention_policy: str = "default",
+        ttl_seconds: Optional[int] = None,
+        fail_closed: bool = True,
+        spin_coherence: Optional[List[float]] = None,
+    ) -> VoxelCell:
+        """
+        Store content under a 6D tongue coordinate.
+
+        If fail_closed=True, invalid quasicrystal window placement raises.
+        """
+        if not chunk_id.strip():
+            raise ValueError("chunk_id must not be empty")
+        if not isinstance(content, (bytes, bytearray)) or len(content) == 0:
+            raise ValueError("content must be non-empty bytes")
+
+        coords = self._validate_coords(tongue_coords)
+        coords = self._apply_harmonic_modifier(coords, spin_coherence)
+        phys, perp = self._project_6d(coords)
+        n, m = self._coords_to_chladni(coords)
+        t_index = self._tensor_index(coords)
+
+        dominant_tongue, _, viscosity = self._dominant_tongue(coords)
+        phase = self._determine_phase(category=category, viscosity=viscosity, dominant_tongue=dominant_tongue)
+        storage_tier = self._route_tier(dominant_tongue=dominant_tongue, phase=phase)
+
+        r_perp = np.array(perp, dtype=float)
+        distance = float(np.linalg.norm(r_perp - self._phason_strain))
+        is_valid = distance < self.acceptance_radius
+        if fail_closed and not is_valid:
+            raise PermissionError(
+                f"QUARANTINE: chunk '{chunk_id}' outside acceptance window at phason_epoch={self._phason_epoch}"
+            )
+
+        now = _utc_now()
+        expires_at = self._get_expiry(retention_policy=retention_policy, ttl_seconds=ttl_seconds)
+        content_hash = hashlib.sha256(bytes(content)).hexdigest()
+
+        depth = 0 if not parent_id else self._get_depth(parent_id) + 1
+        cell = VoxelCell(
+            cell_id=chunk_id,
+            tongue_index=t_index,
+            tongue_coords=coords,
+            physical_projection=phys,
+            perpendicular_projection=perp,
+            chladni_mode=(n, m),
+            content_hash=content_hash,
+            content_size=len(content),
+            category=category,
+            depth=depth,
+            parent_id=parent_id,
+            phase=phase,
+            viscosity=viscosity,
+            is_valid=is_valid,
+            created_at_utc=_utc_iso(now),
+            expires_at_utc=_utc_iso(expires_at),
+            storage_tier=storage_tier,
+            stored_phason_epoch=self._phason_epoch,
+            cipher_scheme="aead-v1",
+        )
+
+        encoded = self._aead_encrypt(
+            bytes(content),
+            chunk_id=chunk_id,
+            n=n,
+            m=m,
+            tier=storage_tier,
+            epoch=self._phason_epoch,
+        )
+
+        self.cells[chunk_id] = cell
+        self.content_store[chunk_id] = encoded
+        self.tier_content_store[storage_tier][chunk_id] = encoded
+        self.tensor_slabs[dominant_tongue].cells[chunk_id] = cell
+        self.tensor_slabs[dominant_tongue].total_content_bytes += len(content)
+
+        index_key = tuple(t_index)
+        self.tensor_index_map.setdefault(index_key, []).append(chunk_id)
+
+        if parent_id and parent_id in self.cells:
+            self.cells[parent_id].children.append(chunk_id)
+            self.depth_trees.setdefault(parent_id, []).append(chunk_id)
+
+        self._update_metrics()
+        return cell
+
+    def retrieve(
+        self,
+        chunk_id: str,
+        access_coords: List[float],
+        strict: bool = True,
+        spin_coherence: Optional[List[float]] = None,
+    ) -> Optional[bytes]:
+        """
+        Retrieve content with a 6D access vector.
+
+        strict=True:
+          - verify decoded hash matches stored hash
+          - return None on mismatch or expiry
+        """
+        cell = self.cells.get(chunk_id)
+        blob = self.content_store.get(chunk_id)
+        if cell is None or blob is None:
+            return None
+
+        # Expired cells are fail-closed hidden.
+        if datetime.strptime(cell.expires_at_utc, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc) < _utc_now():
+            self._remove_cell(chunk_id, expired=True)
+            return None
+
+        coords = self._validate_coords(access_coords)
+        coords = self._apply_harmonic_modifier(coords, spin_coherence)
+        n, m = self._coords_to_chladni(coords)
+        decoded: Optional[bytes] = None
+        if isinstance(blob, dict) and blob.get("scheme") == "aead-v1":
+            decoded = self._aead_decrypt(blob, chunk_id=chunk_id, n=n, m=m)
+        elif isinstance(blob, bytes):
+            # Legacy XOR compatibility.
+            decoded = self._legacy_chladni_xor(blob, n, m, phason_epoch=cell.stored_phason_epoch)
+        elif isinstance(blob, dict) and blob.get("scheme") == "xor-v1":
+            payload = blob.get("ciphertext")
+            if isinstance(payload, (bytes, bytearray)):
+                decoded = self._legacy_chladni_xor(
+                    bytes(payload), n, m, phason_epoch=int(blob.get("stored_phason_epoch", self._phason_epoch))
+                )
+
+        if decoded is None:
+            return None
+
+        if strict:
+            decoded_hash = hashlib.sha256(decoded).hexdigest()
+            if decoded_hash != cell.content_hash:
+                return None
+
+        return decoded
+
+    def phason_rekey(self, entropy: bytes) -> np.ndarray:
+        """Apply phason shift to rotate the acceptance window."""
+        h = hashlib.sha256(entropy).digest()
+        self._phason_strain = np.array(
+            [
+                int.from_bytes(h[0:4], "big") / (2**32) * 2 - 1,
+                int.from_bytes(h[4:8], "big") / (2**32) * 2 - 1,
+                int.from_bytes(h[8:12], "big") / (2**32) * 2 - 1,
+            ],
+            dtype=float,
+        ) * self.acceptance_radius * 2.0
+        self._phason_epoch += 1
+        return self._phason_strain.copy()
+
+    def _remove_cell(self, cell_id: str, *, expired: bool = False) -> None:
+        cell = self.cells.pop(cell_id, None)
+        blob = self.content_store.pop(cell_id, None)
+        if cell is None:
+            return
+
+        if blob is not None:
+            tier = cell.storage_tier if cell.storage_tier in self.tier_content_store else 1
+            self.tier_content_store[tier].pop(cell_id, None)
+        if expired:
+            self._metrics["expired_total"] += 1
+
+        index_key = tuple(cell.tongue_index)
+        ids = self.tensor_index_map.get(index_key, [])
+        if cell_id in ids:
+            ids.remove(cell_id)
+            if not ids:
+                self.tensor_index_map.pop(index_key, None)
+
+        tongue = self._dominant_tongue(cell.tongue_coords)[0]
+        self.tensor_slabs[tongue].cells.pop(cell_id, None)
+        self.tensor_slabs[tongue].total_content_bytes = max(
+            0, self.tensor_slabs[tongue].total_content_bytes - int(cell.content_size)
+        )
+
+        if cell.parent_id and cell.parent_id in self.depth_trees:
+            descendants = self.depth_trees[cell.parent_id]
+            if cell_id in descendants:
+                descendants.remove(cell_id)
+        if cell.parent_id and cell.parent_id in self.cells:
+            parent_children = self.cells[cell.parent_id].children
+            if cell_id in parent_children:
+                parent_children.remove(cell_id)
+
+        self._update_metrics()
+
+    def cleanup_expired(self) -> int:
+        """Drop expired cells from all indices and return removed count."""
+        now = _utc_now()
+        to_remove: List[str] = []
+        for cell_id, cell in self.cells.items():
+            expires_at = datetime.strptime(cell.expires_at_utc, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+            if expires_at < now:
+                to_remove.append(cell_id)
+
+        for cell_id in to_remove:
+            self._remove_cell(cell_id, expired=True)
+
+        return len(to_remove)
+
+    def get_slab(self, tongue: str) -> Dict[str, object]:
+        slab = self.tensor_slabs.get(tongue)
+        if not slab:
+            return {}
+        return {
+            "tongue": slab.tongue,
+            "total_cells": len(slab.cells),
+            "total_bytes": slab.total_content_bytes,
+            "phase_state": slab.phase_state,
+            "cells": list(slab.cells.keys()),
+        }
+
+    def query_nearby(self, coords: List[float], radius: float = 0.3) -> List[str]:
+        q = self._validate_coords(coords)
+        results: List[Tuple[str, float]] = []
+        weight_sum = float(sum(TONGUE_WEIGHTS))
+        for cell_id, cell in self.cells.items():
+            dist = math.sqrt(
+                sum((a - b) ** 2 * w for a, b, w in zip(q, cell.tongue_coords, TONGUE_WEIGHTS))
+            ) / weight_sum
+            if dist < radius:
+                results.append((cell_id, dist))
+        results.sort(key=lambda x: x[1])
+        return [cell_id for cell_id, _ in results]
+
+    @staticmethod
+    def _chladni_mode_similarity(mode_a: Tuple[int, int], mode_b: Tuple[int, int]) -> float:
+        # 1.0 is identical. Values near 1.0 are near-collision candidates.
+        va = np.array([mode_a[0], mode_a[1]], dtype=float)
+        vb = np.array([mode_b[0], mode_b[1]], dtype=float)
+        denom = float(np.linalg.norm(va) * np.linalg.norm(vb))
+        if denom == 0:
+            return 0.0
+        return float(np.dot(va, vb) / denom)
+
+    def red_team_probe_near_collision(
+        self,
+        chunk_id: str,
+        access_coords: List[float],
+        *,
+        attempts: int = 64,
+        similarity_min: float = 0.985,
+        noise_scale: float = 0.04,
+    ) -> Dict[str, Any]:
+        cell = self.cells.get(chunk_id)
+        if cell is None:
+            return {
+                "chunk_id": chunk_id,
+                "attempts": 0,
+                "near_collision_attempts": 0,
+                "unexpected_accepts": 0,
+                "max_similarity": 0.0,
+                "status": "missing",
+            }
+
+        base_coords = self._validate_coords(access_coords)
+        base_mode = self._coords_to_chladni(base_coords)
+        near_collision_attempts = 0
+        unexpected_accepts = 0
+        max_similarity = 0.0
+
+        for _ in range(max(1, attempts)):
+            candidate = np.array(base_coords, dtype=float) + np.random.normal(0, noise_scale, 6)
+            candidate_coords = [float(np.tanh(c)) for c in candidate.tolist()]
+            cand_mode = self._coords_to_chladni(candidate_coords)
+            if cand_mode == base_mode:
+                continue
+            similarity = self._chladni_mode_similarity(base_mode, cand_mode)
+            if similarity < similarity_min:
+                continue
+            near_collision_attempts += 1
+            max_similarity = max(max_similarity, similarity)
+            if self.retrieve(chunk_id, candidate_coords, strict=True) is not None:
+                unexpected_accepts += 1
+
+        return {
+            "chunk_id": chunk_id,
+            "attempts": attempts,
+            "near_collision_attempts": near_collision_attempts,
+            "unexpected_accepts": unexpected_accepts,
+            "max_similarity": round(max_similarity, 6),
+            "status": "ok" if unexpected_accepts == 0 else "alert",
+        }
+
+    def metrics(self) -> Dict[str, int]:
+        self._update_metrics()
+        return dict(self._metrics)
+
+    def export_metrics(self, path: Optional[str] = None) -> Dict[str, int]:
+        payload = self.metrics()
+        if path:
+            out = Path(path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return payload
+
+    def stats(self) -> Dict[str, object]:
+        categories: Dict[str, int] = {}
+        phase_distribution: Dict[str, int] = {}
+        for cell in self.cells.values():
+            categories[cell.category] = categories.get(cell.category, 0) + 1
+            phase_distribution[cell.phase] = phase_distribution.get(cell.phase, 0) + 1
+
+        return {
+            "total_cells": len(self.cells),
+            "total_content_bytes": sum(c.content_size for c in self.cells.values()),
+            "phason_epoch": self._phason_epoch,
+            "resolution": self.resolution,
+            "sparse_tensor_slots": len(self.tensor_index_map),
+            "slabs": {
+                name: {"cells": len(slab.cells), "bytes": slab.total_content_bytes}
+                for name, slab in self.tensor_slabs.items()
+            },
+            "categories": categories,
+            "max_depth": max((c.depth for c in self.cells.values()), default=0),
+            "phase_distribution": phase_distribution,
+            "tiers": {
+                TIER_LABELS[tier]: len(bucket) for tier, bucket in self.tier_content_store.items()
+            },
+            "metrics": self.metrics(),
+        }
+
+    def export(self, path: str) -> str:
+        data = {
+            "drive_type": "QuasiCrystalVoxelDrive",
+            "dimensions": 6,
+            "phason_epoch": self._phason_epoch,
+            "phason_strain": self._phason_strain.tolist(),
+            "tongue_names": TONGUE_NAMES,
+            "tongue_weights": [float(w) for w in TONGUE_WEIGHTS],
+            "tongue_viscosity": TONGUE_VISCOSITY,
+            "resolution": self.resolution,
+            "total_cells": len(self.cells),
+            "sparse_tensor_slots": len(self.tensor_index_map),
+            "metrics": self.metrics(),
+            "tiers": {TIER_LABELS[tier]: len(bucket) for tier, bucket in self.tier_content_store.items()},
+            "cells": {
+                cid: {
+                    "tongue_index": c.tongue_index,
+                    "tongue_coords": c.tongue_coords,
+                    "physical_3d": c.physical_projection,
+                    "perpendicular_3d": c.perpendicular_projection,
+                    "chladni_mode": list(c.chladni_mode),
+                    "content_hash": c.content_hash,
+                    "content_size": c.content_size,
+                    "category": c.category,
+                    "depth": c.depth,
+                    "parent_id": c.parent_id,
+                    "children": c.children,
+                    "phase": c.phase,
+                    "viscosity": c.viscosity,
+                    "is_valid": c.is_valid,
+                    "created_at_utc": c.created_at_utc,
+                    "expires_at_utc": c.expires_at_utc,
+                    "storage_tier": c.storage_tier,
+                    "stored_phason_epoch": c.stored_phason_epoch,
+                    "cipher_scheme": c.cipher_scheme,
+                }
+                for cid, c in self.cells.items()
+            },
+            "index_map": {",".join(map(str, k)): v for k, v in self.tensor_index_map.items()},
+            "slabs": {
+                name: {"cells": len(slab.cells), "bytes": slab.total_content_bytes}
+                for name, slab in self.tensor_slabs.items()
+            },
+        }
+
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return str(out)
+
+
+def demo() -> None:
+    print("=" * 60)
+    print("Quasi-Crystal Voxel Drive - 6D Sparse Tensor Storage")
+    print("=" * 60)
+
+    drive = QuasiCrystalVoxelDrive(resolution=64)
+    records = [
+        (
+            "chunk-001",
+            b"Hyperbolic geometry provides exponential cost scaling for adversarial behavior",
+            [0.3, 0.1, 0.2, 0.7, 0.1, 0.1],
+            "math",
+        ),
+        (
+            "chunk-002",
+            b"Post-quantum lattice cryptography resists Shor-type attacks",
+            [0.2, 0.1, 0.2, 0.8, 0.2, 0.3],
+            "security",
+        ),
+        (
+            "chunk-003",
+            b"Multi-agent governance consensus under Byzantine assumptions",
+            [0.8, 0.1, 0.3, 0.1, 0.1, 0.2],
+            "governance",
+        ),
+    ]
+
+    for cid, payload, coords, cat in records:
+        cell = drive.store(cid, payload, coords, category=cat)
+        print(
+            f"stored {cid} mode={cell.chladni_mode} phase={cell.phase} valid={cell.is_valid} "
+            f"index={tuple(cell.tongue_index)}"
+        )
+
+    ok = drive.retrieve("chunk-001", [0.3, 0.1, 0.2, 0.7, 0.1, 0.1], strict=True)
+    bad = drive.retrieve("chunk-001", [0.9, 0.9, 0.9, 0.1, 0.1, 0.1], strict=True)
+    print(f"correct retrieval ok={ok is not None}, wrong retrieval rejected={bad is None}")
+
+    print("stats:", json.dumps(drive.stats(), indent=2))
+    export_path = drive.export("training/intake/qc_voxel_drive.json")
+    print(f"exported {export_path}")
+
+
+if __name__ == "__main__":
+    demo()

--- a/src/sacred_eggs.py
+++ b/src/sacred_eggs.py
@@ -1,0 +1,218 @@
+"""
+Sacred Eggs ritual reference implementation.
+
+This module exposes a small ritual API compatible with the SCBE test harness:
+- `solitary_incubation`
+- `triadic_binding` / `manifold_binding`
+- `verify_binding`
+- `ring_descent`
+- `fail_to_noise`
+- `invoke_ritual` dispatcher
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+_GOOD_NOISE = b"fail-to-noise"
+
+
+def _safe_bytes(payload: Any) -> bytes:
+    if isinstance(payload, bytes):
+        return payload
+    if isinstance(payload, bytearray):
+        return bytes(payload)
+    if payload is None:
+        return b""
+    return str(payload).encode("utf-8", errors="ignore")
+
+
+def _distinct(values: Iterable[str]) -> bool:
+    items = list(values)
+    return len(items) == len(set(items))
+
+
+def _valid_manifold(manifold: Any) -> bool:
+    if not isinstance(manifold, (list, tuple)) or len(manifold) != 6:
+        return False
+    total = 0.0
+    for x in manifold:
+        if not isinstance(x, (int, float)):
+            return False
+        if x != x:  # nan
+            return False
+        if x == float("inf") or x == float("-inf"):
+            return False
+        total += float(x) ** 2
+    # Open Poincare ball: ||x|| < 1
+    return total < 1.0
+
+
+def _binding_token(participants: Iterable[str], threshold: int, payload: bytes, manifold: Tuple[float, ...]) -> str:
+    material = "|".join(sorted(participants)).encode("utf-8")
+    material += b"::" + str(int(threshold)).encode("utf-8")
+    material += b"::" + payload
+    material += b"::" + ",".join(f"{float(v):.12f}" for v in manifold).encode("utf-8")
+    return hashlib.sha256(material).hexdigest()
+
+
+@dataclass
+class SacredEgg:
+    egg_id: str = "egg"
+    payload: bytes = b""
+    manifold: Tuple[float, ...] = field(default_factory=lambda: (0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+    participants: Tuple[str, ...] = field(default_factory=tuple)
+    threshold: int = 3
+    latest_binding: Optional[str] = None
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.egg_id = str(kwargs.get("egg_id", kwargs.get("id", "egg")))
+        self.payload = _safe_bytes(kwargs.get("payload", b""))
+        m = kwargs.get("manifold", (0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+        if isinstance(m, (list, tuple)) and len(m) == 6:
+            self.manifold = tuple(float(x) for x in m)
+        else:
+            self.manifold = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        p = kwargs.get("participants", ())
+        self.participants = tuple(str(x) for x in p) if isinstance(p, (list, tuple)) else tuple()
+        self.threshold = int(kwargs.get("threshold", 3))
+        self.latest_binding = None
+
+    def invoke_ritual(self, ritual: str, **kwargs: Any) -> Dict[str, Any]:
+        r = (ritual or "").strip().lower()
+        if r in {"solitary_incubation", "begin_solitary_incubation", "incubate_solitary", "incubate"}:
+            return self.solitary_incubation(**kwargs)
+        if r in {"triadic_binding", "perform_triadic_binding", "triadic_bind", "bind_triad", "triad_bind"}:
+            return self.triadic_binding(**kwargs)
+        if r in {"manifold_binding", "bind_manifold", "bind_to_manifold", "manifold_bind", "lock_to_manifold"}:
+            return self.manifold_binding(**kwargs)
+        if r in {"ring_descent", "perform_ring_descent", "descend_ring", "descent"}:
+            return self.ring_descent(**kwargs)
+        if r in {"fail_to_noise", "noise_failover", "zeroize_to_noise", "obscure_to_noise"}:
+            return self.fail_to_noise(**kwargs)
+        return {"ok": False, "status": "rejected", "error": "unknown_ritual"}
+
+    def solitary_incubation(self, actor: Optional[str] = None, participants: Optional[Iterable[str]] = None, **_: Any) -> Dict[str, Any]:
+        member_list = list(participants) if participants is not None else ([actor] if actor else [])
+        if len(member_list) != 1:
+            return {"ok": False, "status": "rejected", "error": "requires_one_invoker"}
+        return {"ok": True, "status": "accepted", "mode": "solitary_incubation", "actor": str(member_list[0])}
+
+    def triadic_binding(
+        self,
+        participants: Optional[Iterable[str]] = None,
+        threshold: int = 3,
+        payload: Any = None,
+        manifold: Any = None,
+        **_: Any,
+    ) -> Dict[str, Any]:
+        parts = tuple(str(x) for x in (participants or self.participants))
+        k = int(threshold if threshold is not None else self.threshold)
+        if k <= 0 or len(parts) < k:
+            return {"ok": False, "status": "rejected", "error": "insufficient_participants"}
+        if not _distinct(parts):
+            return {"ok": False, "status": "rejected", "error": "participants_not_distinct"}
+
+        manifold_point = manifold if manifold is not None else self.manifold
+        if not _valid_manifold(manifold_point):
+            return {"ok": False, "status": "rejected", "error": "invalid_manifold"}
+
+        raw_payload = _safe_bytes(payload if payload is not None else self.payload)
+        token = _binding_token(parts, k, raw_payload, tuple(float(x) for x in manifold_point))
+        self.latest_binding = token
+        return {
+            "ok": True,
+            "status": "bound",
+            "binding": token,
+            "threshold": k,
+            "participants": list(parts),
+        }
+
+    def manifold_binding(self, **kwargs: Any) -> Dict[str, Any]:
+        return self.triadic_binding(**kwargs)
+
+    def verify_binding(
+        self,
+        binding: Any = None,
+        participants: Optional[Iterable[str]] = None,
+        threshold: int = 3,
+        payload: Any = None,
+        manifold: Any = None,
+        **_: Any,
+    ) -> Dict[str, Any]:
+        token = binding
+        if isinstance(binding, dict):
+            token = binding.get("binding")
+        if token is None:
+            return {"ok": False, "status": "rejected", "error": "missing_binding"}
+
+        parts = tuple(str(x) for x in (participants or self.participants))
+        k = int(threshold if threshold is not None else self.threshold)
+        manifold_point = manifold if manifold is not None else self.manifold
+        if not _valid_manifold(manifold_point):
+            return {"ok": False, "status": "rejected", "error": "invalid_manifold"}
+        if k <= 0 or len(parts) < k or not _distinct(parts):
+            return {"ok": False, "status": "rejected", "error": "invalid_participants"}
+
+        raw_payload = _safe_bytes(payload if payload is not None else self.payload)
+        expected = _binding_token(parts, k, raw_payload, tuple(float(x) for x in manifold_point))
+        if str(token) != expected:
+            return {"ok": False, "status": "rejected", "error": "binding_mismatch"}
+        return {"ok": True, "status": "verified", "binding": expected}
+
+    def ring_descent(self, ring: int = 0, source_ring: int = 0, target_ring: int = 0, **_: Any) -> Dict[str, Any]:
+        try:
+            current = int(source_ring if source_ring is not None else ring)
+            nxt = int(target_ring if target_ring is not None else ring)
+        except Exception:
+            return {"ok": False, "status": "rejected", "error": "invalid_ring"}
+        if current < 0 or nxt < 0:
+            return {"ok": False, "status": "rejected", "error": "negative_ring"}
+        return {"ok": True, "status": "accepted", "source_ring": current, "target_ring": nxt}
+
+    def fail_to_noise(self, **_: Any) -> Dict[str, Any]:
+        # Do not leak payload in any error surface.
+        noise = base64.urlsafe_b64encode(hashlib.sha256(_GOOD_NOISE + os.urandom(16)).digest()).decode("ascii")
+        return {"ok": False, "status": "rejected", "noise": noise}
+
+
+def create_sacred_egg(**kwargs: Any) -> SacredEgg:
+    return SacredEgg(**kwargs)
+
+
+def invoke_ritual(ritual: str, **kwargs: Any) -> Dict[str, Any]:
+    egg = kwargs.get("egg")
+    if isinstance(egg, SacredEgg):
+        return egg.invoke_ritual(ritual, **kwargs)
+    return SacredEgg(**kwargs).invoke_ritual(ritual, **kwargs)
+
+
+def solitary_incubation(**kwargs: Any) -> Dict[str, Any]:
+    return invoke_ritual("solitary_incubation", **kwargs)
+
+
+def triadic_binding(**kwargs: Any) -> Dict[str, Any]:
+    return invoke_ritual("triadic_binding", **kwargs)
+
+
+def manifold_binding(**kwargs: Any) -> Dict[str, Any]:
+    return invoke_ritual("manifold_binding", **kwargs)
+
+
+def verify_binding(**kwargs: Any) -> Dict[str, Any]:
+    egg = kwargs.get("egg")
+    if isinstance(egg, SacredEgg):
+        return egg.verify_binding(**kwargs)
+    return SacredEgg(**kwargs).verify_binding(**kwargs)
+
+
+def ring_descent(**kwargs: Any) -> Dict[str, Any]:
+    return invoke_ritual("ring_descent", **kwargs)
+
+
+def fail_to_noise(**kwargs: Any) -> Dict[str, Any]:
+    return invoke_ritual("fail_to_noise", **kwargs)

--- a/tests/test_quasicrystal_voxel_drive.py
+++ b/tests/test_quasicrystal_voxel_drive.py
@@ -1,0 +1,137 @@
+"""Tests for the 6D quasi-crystal voxel drive."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime, timedelta, timezone
+import tempfile
+
+import pytest
+
+from src.knowledge.quasicrystal_voxel_drive import QuasiCrystalVoxelDrive
+
+
+def test_store_and_retrieve_with_correct_vector() -> None:
+    drive = QuasiCrystalVoxelDrive(resolution=32)
+    payload = b"phase-safe-storage"
+    coords = [0.2, 0.1, 0.3, 0.7, 0.2, 0.1]
+
+    cell = drive.store("cell-a", payload, coords, category="security")
+    assert cell.is_valid is True
+
+    recovered = drive.retrieve("cell-a", coords, strict=True)
+    assert recovered == payload
+
+
+def test_wrong_vector_is_rejected_in_strict_mode() -> None:
+    drive = QuasiCrystalVoxelDrive(resolution=32)
+    payload = b"intent-bound-blob"
+    store_coords = [0.3, 0.1, 0.2, 0.8, 0.1, 0.1]
+    wrong_coords = [0.9, 0.9, 0.9, 0.1, 0.1, 0.1]
+
+    drive.store("cell-b", payload, store_coords, category="math")
+    recovered = drive.retrieve("cell-b", wrong_coords, strict=True)
+    assert recovered is None
+
+
+def test_fail_closed_when_outside_acceptance_window() -> None:
+    drive = QuasiCrystalVoxelDrive(resolution=32)
+    drive.phason_rekey(b"force-window-shift")
+
+    with pytest.raises(PermissionError):
+        drive.store(
+            "cell-c",
+            b"blocked-on-invalid-window",
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            fail_closed=True,
+        )
+
+
+def test_stats_and_sparse_tensor_indexing() -> None:
+    drive = QuasiCrystalVoxelDrive(resolution=16)
+    drive.store("c1", b"a", [0.1, 0.2, 0.3, 0.2, 0.1, 0.0], category="science")
+    drive.store("c2", b"b", [0.8, 0.1, 0.2, 0.1, 0.0, 0.0], category="governance")
+
+    stats = drive.stats()
+    assert stats["total_cells"] == 2
+    assert stats["sparse_tensor_slots"] >= 1
+    assert stats["categories"]["science"] == 1
+    assert stats["categories"]["governance"] == 1
+    assert "phase_distribution" in stats
+
+
+def test_export_writes_valid_json() -> None:
+    drive = QuasiCrystalVoxelDrive(resolution=16)
+    drive.store("c3", b"export-check", [0.1, 0.1, 0.1, 0.2, 0.3, 0.4], category="data")
+
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "qc_drive.json"
+        exported = drive.export(str(out_path))
+        assert Path(exported).exists()
+
+        parsed = json.loads(Path(exported).read_text(encoding="utf-8"))
+        assert parsed["drive_type"] == "QuasiCrystalVoxelDrive"
+        assert parsed["dimensions"] == 6
+        assert parsed["total_cells"] == 1
+        assert "metrics" in parsed
+        assert "tiers" in parsed
+
+
+def test_policy_routing_assigns_valid_storage_tier() -> None:
+    drive = QuasiCrystalVoxelDrive(resolution=24)
+    entries = [
+        ("t1", b"alpha", [0.9, 0.1, 0.1, 0.2, 0.1, 0.0], "ops"),
+        ("t2", b"beta", [0.1, 0.7, 0.1, 0.1, 0.1, 0.0], "transport"),
+        ("t3", b"gamma", [0.1, 0.1, 0.1, 0.9, 0.1, 0.0], "security"),
+    ]
+
+    for cid, payload, coords, category in entries:
+        cell = drive.store(cid, payload, coords, category=category)
+        assert 0 <= cell.storage_tier <= 2
+
+    stats = drive.stats()
+    assert "tiers" in stats
+    assert sum(stats["tiers"].values()) == 3
+
+
+def test_harmonic_modifier_spin_hook_changes_storage_projection() -> None:
+    drive = QuasiCrystalVoxelDrive(resolution=32)
+    coords = [0.25, 0.15, 0.2, 0.6, 0.1, 0.1]
+    spin = [0.9, 0.1, 0.0, 0.2, 0.1, 0.7]
+    cell = drive.store("spin-cell", b"spin-aware", coords, spin_coherence=spin)
+
+    normalized = drive._validate_coords(coords)
+    assert cell.tongue_coords != normalized
+    assert drive.retrieve("spin-cell", coords, strict=True, spin_coherence=spin) == b"spin-aware"
+
+
+def test_red_team_probe_reports_no_unexpected_accepts() -> None:
+    drive = QuasiCrystalVoxelDrive(resolution=32)
+    coords = [0.35, 0.2, 0.25, 0.75, 0.1, 0.05]
+    drive.store("probe-cell", b"probe-payload", coords, category="security")
+    report = drive.red_team_probe_near_collision("probe-cell", coords, attempts=48, similarity_min=0.98)
+
+    assert report["status"] in {"ok", "alert"}
+    assert report["unexpected_accepts"] == 0
+    assert report["near_collision_attempts"] >= 0
+
+
+def test_metrics_include_expiry_counters_and_export() -> None:
+    drive = QuasiCrystalVoxelDrive(resolution=16)
+    cell = drive.store("exp-cell", b"expiring", [0.2, 0.2, 0.2, 0.4, 0.2, 0.1], ttl_seconds=5)
+    # Force expiry and trigger fail-closed path.
+    expired = datetime.now(timezone.utc) - timedelta(seconds=2)
+    drive.cells["exp-cell"].expires_at_utc = expired.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert drive.retrieve("exp-cell", cell.tongue_coords, strict=True) is None
+
+    metrics = drive.metrics()
+    assert set(metrics.keys()) == {"storage_size_bytes", "memory_count", "expired_total"}
+    assert metrics["expired_total"] >= 1
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "metrics.json"
+        exported = drive.export_metrics(str(out))
+        assert out.exists()
+        parsed = json.loads(out.read_text(encoding="utf-8"))
+        assert parsed == exported

--- a/tests/test_sacred_eggs_rituals.py
+++ b/tests/test_sacred_eggs_rituals.py
@@ -1,0 +1,725 @@
+from __future__ import annotations
+
+import functools
+import importlib
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+for root in (REPO_ROOT, REPO_ROOT / "src"):
+    if root.exists() and str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+MODULE_CANDIDATES = (
+    "sacred_eggs",
+    "sacred_egg",
+    "scbe_sacred_eggs",
+    "scbe_eggs",
+    "src.sacred_eggs",
+    "src.sacred_egg",
+    "src.scbe_sacred_eggs",
+    "src.scbe_14layer_reference",
+    "scbe_14layer_reference",
+)
+
+FILE_CANDIDATES = (
+    REPO_ROOT / "src" / "sacred_eggs.py",
+    REPO_ROOT / "src" / "sacred_egg.py",
+    REPO_ROOT / "src" / "scbe_sacred_eggs.py",
+    REPO_ROOT / "src" / "scbe_eggs.py",
+    REPO_ROOT / "src" / "scbe_14layer_reference.py",
+    REPO_ROOT / "sacred_eggs.py",
+    REPO_ROOT / "sacred_egg.py",
+)
+
+INVOKE_ALIASES = ("invoke_ritual", "perform_ritual", "ritual_invoke", "invoke", "ritual")
+INCUBATION_ALIASES = (
+    "solitary_incubation",
+    "begin_solitary_incubation",
+    "incubate_solitary",
+    "solitaryIncubation",
+    "incubate",
+)
+TRIADIC_ALIASES = (
+    "triadic_binding",
+    "perform_triadic_binding",
+    "triadic_bind",
+    "bind_triad",
+    "triad_bind",
+    "triadicBinding",
+)
+MANIFOLD_BIND_ALIASES = (
+    "manifold_binding",
+    "bind_manifold",
+    "bind_to_manifold",
+    "manifold_bind",
+    "lock_to_manifold",
+    "attach_manifold",
+)
+MANIFOLD_RITUAL_ALIASES = MANIFOLD_BIND_ALIASES + TRIADIC_ALIASES
+VERIFY_ALIASES = (
+    "verify_binding",
+    "verify_manifold_binding",
+    "validate_manifold_binding",
+    "validate_binding",
+    "verify_seal",
+    "unlock",
+    "open",
+    "reveal",
+    "verify",
+)
+RING_DESCENT_ALIASES = (
+    "ring_descent",
+    "perform_ring_descent",
+    "descend_ring",
+    "ringDescent",
+    "descent",
+)
+FAIL_TO_NOISE_ALIASES = (
+    "fail_to_noise",
+    "noise_failover",
+    "zeroize_to_noise",
+    "obscure_to_noise",
+    "failToNoise",
+)
+
+PAYLOAD = b"SCBE::SacredEgg::payload"
+TRIAD = ("guardian-alpha", "guardian-beta", "guardian-gamma")
+SIX_GUARDIANS = (
+    "guardian-alpha",
+    "guardian-beta",
+    "guardian-gamma",
+    "guardian-delta",
+    "guardian-epsilon",
+    "guardian-zeta",
+)
+
+# Ordered manifold axes are assumed to be [X, Y, Z, V, P, S].
+# Points are assumed to live in an open Poincare ball, so ||x|| < 1.
+VALID_MANIFOLD = (0.12, -0.18, 0.11, 0.09, -0.07, 0.06)
+PERTURBED_MANIFOLD = (0.12, -0.18, 0.11, 0.09, -0.07, 0.065)
+PERMUTED_MANIFOLD = (0.11, 0.12, -0.18, 0.09, -0.07, 0.06)
+DIM_MISMATCH_MANIFOLD = (0.12, -0.18, 0.11)
+BOUNDARY_MANIFOLD = (1.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+OUTSIDE_MANIFOLD = (1.01, 0.0, 0.0, 0.0, 0.0, 0.0)
+NAN_MANIFOLD = (0.12, float("nan"), 0.11, 0.09, -0.07, 0.06)
+INF_MANIFOLD = (0.12, float("inf"), 0.11, 0.09, -0.07, 0.06)
+
+ALIASES = {
+    "egg": {"egg", "sacred_egg", "container", "state", "instance", "obj"},
+    "egg_id": {"egg_id", "id", "name", "label", "container_id"},
+    "payload": {
+        "payload",
+        "secret",
+        "data",
+        "seed",
+        "material",
+        "blob",
+        "plaintext",
+        "message",
+        "secret_payload",
+    },
+    "actor": {"actor", "invoker", "caller", "agent", "guardian", "binder", "participant"},
+    "participants": {
+        "participants",
+        "binders",
+        "agents",
+        "guardians",
+        "triad",
+        "members",
+        "signers",
+        "attestors",
+        "binder_ids",
+        "guardian_ids",
+    },
+    "threshold": {"threshold", "quorum", "min_signers", "required_signers", "k"},
+    "manifold": {
+        "manifold",
+        "coords",
+        "coordinates",
+        "point",
+        "vector",
+        "embedding",
+        "location",
+        "manifold_point",
+        "bind_point",
+    },
+    "binding": {"binding", "token", "seal", "proof", "attestation", "digest", "handle", "lock"},
+    "ritual": {"ritual", "ritual_name", "invocation", "action", "op", "mode", "name"},
+    "ring": {"ring", "ring_level", "depth", "level", "ring_index", "realm"},
+    "source_ring": {"source_ring", "from_ring", "current_ring", "src_ring", "ring_from"},
+    "target_ring": {"target_ring", "to_ring", "next_ring", "dst_ring", "ring_to"},
+}
+
+GOOD_STATUS = {
+    "ok",
+    "success",
+    "allowed",
+    "allow",
+    "accepted",
+    "bound",
+    "sealed",
+    "verified",
+    "complete",
+    "completed",
+    "pass",
+    "passed",
+    "true",
+}
+BAD_STATUS = {
+    "error",
+    "errors",
+    "fail",
+    "failed",
+    "deny",
+    "denied",
+    "reject",
+    "rejected",
+    "quarantine",
+    "invalid",
+    "unauthorized",
+    "unknown",
+    "false",
+}
+
+MISSING = object()
+
+
+def _norm_name(name: str) -> str:
+    return "".join(ch for ch in name.lower() if ch.isalnum())
+
+
+GOOD_STATUS_N = {_norm_name(x) for x in GOOD_STATUS}
+BAD_STATUS_N = {_norm_name(x) for x in BAD_STATUS}
+
+
+def _import_file(path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(f"_pytest_autoload_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to build import spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@functools.lru_cache(maxsize=1)
+def _load_sacred_eggs_module() -> Any:
+    errors: list[str] = []
+
+    for name in MODULE_CANDIDATES:
+        try:
+            return importlib.import_module(name)
+        except Exception as exc:  # pragma: no cover
+            errors.append(f"{name}: {exc.__class__.__name__}")
+
+    for path in FILE_CANDIDATES:
+        if not path.exists():
+            continue
+        try:
+            return _import_file(path)
+        except Exception as exc:  # pragma: no cover
+            errors.append(f"{path}: {exc.__class__.__name__}")
+
+    tried = ", ".join(MODULE_CANDIDATES)
+    details = "; ".join(errors[:8])
+    raise LookupError(
+        "Could not locate a Sacred Eggs implementation module. "
+        f"Tried imports [{tried}] and common file locations. "
+        f"First failures: {details}"
+    )
+
+
+def _status_to_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        norm = _norm_name(value)
+        if norm in GOOD_STATUS_N:
+            return True
+        if norm in BAD_STATUS_N:
+            return False
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return bool(value)
+    return None
+
+
+def _resolve_param_value(param_name: str, context: dict[str, Any]) -> Any:
+    lname = param_name.lower()
+
+    if lname in context:
+        return context[lname]
+
+    for canonical, aliases in ALIASES.items():
+        if lname == canonical or lname in aliases:
+            if canonical in context:
+                return context[canonical]
+
+    for canonical, aliases in ALIASES.items():
+        if canonical not in context:
+            continue
+        for alias in aliases:
+            if lname.startswith(f"{alias}_") or lname.endswith(f"_{alias}"):
+                return context[canonical]
+
+    return MISSING
+
+
+def _call_with_context(fn: Any, **context: Any) -> Any:
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):  # pragma: no cover
+        return fn()
+
+    kwargs: dict[str, Any] = {}
+    accepts_kwargs = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+
+    for param in sig.parameters.values():
+        if param.name in {"self", "cls"}:
+            continue
+        if param.kind == inspect.Parameter.VAR_POSITIONAL:
+            continue
+
+        value = _resolve_param_value(param.name, context)
+        if value is not MISSING:
+            kwargs[param.name] = value
+            continue
+
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            continue
+
+        if param.default is inspect._empty:
+            raise LookupError(f"Cannot satisfy required parameter '{param.name}' for {fn!r}")
+
+    if accepts_kwargs:
+        for canonical, value in context.items():
+            if value is not None:
+                kwargs.setdefault(canonical, value)
+
+    return fn(**kwargs)
+
+
+def _find_callable(targets: tuple[Any, ...], aliases: tuple[str, ...]) -> Any | None:
+    wanted = [_norm_name(alias) for alias in aliases]
+
+    for target in targets:
+        callables: dict[str, Any] = {}
+        for name in dir(target):
+            if name.startswith("_"):
+                continue
+            try:
+                attr = getattr(target, name)
+            except Exception:  # pragma: no cover
+                continue
+            if callable(attr):
+                callables[name] = attr
+
+        for want in wanted:
+            for name, attr in callables.items():
+                if _norm_name(name) == want:
+                    return attr
+
+        for want in wanted:
+            for name, attr in callables.items():
+                normalized = _norm_name(name)
+                if want in normalized or normalized in want:
+                    return attr
+
+    return None
+
+
+def _is_success(result: Any) -> bool:
+    status = _status_to_bool(result)
+    if status is not None:
+        return status
+
+    if result is None:
+        return True
+
+    if isinstance(result, dict):
+        for key in ("ok", "success", "allowed", "bound", "sealed", "verified", "accepted"):
+            if key in result:
+                status = _status_to_bool(result[key])
+                return bool(result[key]) if status is None else status
+        if "status" in result:
+            status = _status_to_bool(result["status"])
+            if status is not None:
+                return status
+        return True
+
+    for attr in ("ok", "success", "allowed", "bound", "sealed", "verified", "accepted"):
+        if hasattr(result, attr):
+            value = getattr(result, attr)
+            status = _status_to_bool(value)
+            return bool(value) if status is None else status
+
+    if hasattr(result, "status"):
+        status = _status_to_bool(getattr(result, "status"))
+        if status is not None:
+            return status
+
+    return True
+
+
+def _has_explicit_status(result: Any) -> bool:
+    if isinstance(result, dict):
+        return any(
+            key in result
+            for key in ("ok", "success", "allowed", "bound", "sealed", "verified", "accepted", "status")
+        )
+    return any(
+        hasattr(result, attr)
+        for attr in ("ok", "success", "allowed", "bound", "sealed", "verified", "accepted", "status")
+    )
+
+
+def _binding_fingerprint(result: Any) -> Any:
+    if isinstance(result, (str, bytes, bytearray, memoryview, int, float, bool)) or result is None:
+        return result
+
+    if isinstance(result, dict):
+        for key in ("binding", "digest", "seal", "token", "proof", "fingerprint", "id", "handle", "lock"):
+            if key in result:
+                return result[key]
+        return repr(sorted(result.items()))
+
+    for attr in ("binding", "digest", "seal", "token", "proof", "fingerprint", "id", "handle", "lock"):
+        if hasattr(result, attr):
+            return getattr(result, attr)
+
+    return repr(result)
+
+
+def assert_rejected(invocation) -> None:
+    try:
+        result = invocation()
+    except Exception:
+        return
+    assert not _is_success(result), f"Expected rejection, got success-like result: {result!r}"
+
+
+def assert_no_payload_leak(value: Any, payload: bytes = PAYLOAD) -> None:
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        raw = bytes(value)
+        assert raw != payload, "raw payload leaked directly"
+        assert payload not in raw, "payload bytes leaked inside noise output"
+
+    if isinstance(value, dict):
+        for inner in value.values():
+            assert_no_payload_leak(inner, payload)
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        for inner in value:
+            assert_no_payload_leak(inner, payload)
+
+    text = repr(value)
+    decoded = payload.decode("utf-8", errors="ignore")
+    assert payload.hex() not in text, "payload hex leaked through repr/exception text"
+    if decoded:
+        assert decoded not in text, "payload text leaked through repr/exception text"
+
+
+class SacredEggAPI:
+    FACTORY_NAMES = (
+        "SacredEgg",
+        "SacredEggContainer",
+        "SacredEggs",
+        "EggContainer",
+        "Egg",
+        "create_sacred_egg",
+        "new_sacred_egg",
+        "make_sacred_egg",
+        "build_sacred_egg",
+    )
+
+    def __init__(self, module: Any) -> None:
+        self.module = module
+        self.instance = self._make_instance()
+
+    @property
+    def targets(self) -> tuple[Any, ...]:
+        return tuple(target for target in (self.instance, self.module) if target is not None)
+
+    def available(self) -> list[str]:
+        names: set[str] = set()
+        for target in self.targets:
+            for name in dir(target):
+                if name.startswith("_"):
+                    continue
+                try:
+                    attr = getattr(target, name)
+                except Exception:
+                    continue
+                if callable(attr):
+                    names.add(name)
+        return sorted(names)
+
+    def _make_instance(self) -> Any | None:
+        for name in self.FACTORY_NAMES:
+            candidate = getattr(self.module, name, None)
+            if not callable(candidate):
+                continue
+            try:
+                return _call_with_context(
+                    candidate,
+                    payload=PAYLOAD,
+                    egg_id="pytest-sacred-egg",
+                    manifold=VALID_MANIFOLD,
+                    participants=TRIAD,
+                    threshold=3,
+                )
+            except Exception:
+                continue
+        return None
+
+    def find(self, aliases: tuple[str, ...]) -> Any | None:
+        return _find_callable(self.targets, aliases)
+
+    def call(self, fn: Any, **context: Any) -> Any:
+        context.setdefault("egg", self.instance)
+        return _call_with_context(fn, **context)
+
+    def ritual(self, ritual_name: str, aliases: tuple[str, ...], **context: Any) -> Any:
+        fn = self.find(aliases)
+        if fn is not None:
+            try:
+                return self.call(fn, ritual=ritual_name, **context)
+            except LookupError:
+                pass
+
+        invoker = self.find(INVOKE_ALIASES)
+        if invoker is None:
+            pytest.skip(
+                f"No callable found for ritual '{ritual_name}'. "
+                f"Discovered callables: {', '.join(self.available()) or '<none>'}"
+            )
+        return self.call(invoker, ritual=ritual_name, **context)
+
+    def verify(self, binding: Any, **context: Any) -> Any | None:
+        verifier = self.find(VERIFY_ALIASES)
+        if verifier is None:
+            return None
+        return self.call(verifier, binding=binding, **context)
+
+
+@pytest.fixture()
+def egg_api() -> SacredEggAPI:
+    try:
+        module = _load_sacred_eggs_module()
+    except LookupError as exc:
+        pytest.skip(str(exc))
+
+    api = SacredEggAPI(module)
+    if not any(
+        api.find(group) is not None
+        for group in (
+            INVOKE_ALIASES,
+            INCUBATION_ALIASES,
+            TRIADIC_ALIASES,
+            MANIFOLD_RITUAL_ALIASES,
+            RING_DESCENT_ALIASES,
+            FAIL_TO_NOISE_ALIASES,
+        )
+    ):
+        pytest.skip(
+            "Loaded a module but did not discover Sacred Eggs entry points. "
+            f"Callables found: {', '.join(api.available()) or '<none>'}"
+        )
+    return api
+
+
+def test_unknown_ritual_name_is_rejected(egg_api: SacredEggAPI) -> None:
+    invoker = egg_api.find(INVOKE_ALIASES)
+    if invoker is None:
+        pytest.skip("Generic ritual invoker is not exposed by this implementation")
+
+    assert_rejected(
+        lambda: egg_api.call(
+            invoker,
+            ritual="__not_a_real_sacred_ritual__",
+            actor=TRIAD[0],
+            participants=(TRIAD[0],),
+            payload=PAYLOAD,
+            manifold=VALID_MANIFOLD,
+        )
+    )
+
+
+def test_solitary_incubation_accepts_one_invoker(egg_api: SacredEggAPI) -> None:
+    result = egg_api.ritual(
+        "solitary_incubation",
+        INCUBATION_ALIASES,
+        actor=TRIAD[0],
+        participants=(TRIAD[0],),
+        payload=PAYLOAD,
+    )
+    assert _is_success(result), f"solitary incubation unexpectedly failed: {result!r}"
+
+
+@pytest.mark.parametrize(
+    "participants",
+    [
+        ("guardian-alpha", "guardian-beta"),
+        ("guardian-alpha", "guardian-alpha", "guardian-beta"),
+    ],
+)
+def test_triadic_binding_rejects_insufficient_or_non_distinct_binders(
+    egg_api: SacredEggAPI, participants: tuple[str, ...]
+) -> None:
+    assert_rejected(
+        lambda: egg_api.ritual(
+            "triadic_binding",
+            TRIADIC_ALIASES,
+            participants=participants,
+            threshold=3,
+            payload=PAYLOAD,
+            manifold=VALID_MANIFOLD,
+        )
+    )
+
+
+def test_triadic_binding_accepts_three_of_six_distinct_guardians(egg_api: SacredEggAPI) -> None:
+    result = egg_api.ritual(
+        "triadic_binding",
+        TRIADIC_ALIASES,
+        participants=SIX_GUARDIANS[:3],
+        threshold=3,
+        payload=PAYLOAD,
+        manifold=VALID_MANIFOLD,
+    )
+    assert _is_success(result), f"3-of-6 triadic binding should succeed, got {result!r}"
+
+
+def test_ring_descent_rejects_negative_target_ring(egg_api: SacredEggAPI) -> None:
+    assert_rejected(
+        lambda: egg_api.ritual(
+            "ring_descent",
+            RING_DESCENT_ALIASES,
+            actor=TRIAD[0],
+            payload=PAYLOAD,
+            ring=-1,
+            source_ring=0,
+            target_ring=-1,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "manifold",
+    [
+        DIM_MISMATCH_MANIFOLD,
+        BOUNDARY_MANIFOLD,
+        OUTSIDE_MANIFOLD,
+        NAN_MANIFOLD,
+        INF_MANIFOLD,
+    ],
+)
+def test_manifold_binding_rejects_invalid_points(
+    egg_api: SacredEggAPI, manifold: tuple[float, ...]
+) -> None:
+    assert_rejected(
+        lambda: egg_api.ritual(
+            "manifold_binding",
+            MANIFOLD_RITUAL_ALIASES,
+            participants=TRIAD,
+            threshold=3,
+            payload=PAYLOAD,
+            manifold=manifold,
+        )
+    )
+
+
+@pytest.mark.parametrize("wrong_manifold", [PERTURBED_MANIFOLD, PERMUTED_MANIFOLD])
+def test_manifold_binding_breaks_on_coordinate_change(
+    egg_api: SacredEggAPI, wrong_manifold: tuple[float, ...]
+) -> None:
+    binding = egg_api.ritual(
+        "manifold_binding",
+        MANIFOLD_RITUAL_ALIASES,
+        participants=TRIAD,
+        threshold=3,
+        payload=PAYLOAD,
+        manifold=VALID_MANIFOLD,
+    )
+    assert _is_success(binding), f"valid manifold binding failed: {binding!r}"
+
+    verified = egg_api.verify(
+        binding,
+        participants=TRIAD,
+        threshold=3,
+        payload=PAYLOAD,
+        manifold=VALID_MANIFOLD,
+    )
+    if verified is not None:
+        assert _is_success(verified), f"binding did not verify at original manifold: {verified!r}"
+        assert_rejected(
+            lambda: egg_api.verify(
+                binding,
+                participants=TRIAD,
+                threshold=3,
+                payload=PAYLOAD,
+                manifold=wrong_manifold,
+            )
+        )
+        return
+
+    rebound = egg_api.ritual(
+        "manifold_binding",
+        MANIFOLD_RITUAL_ALIASES,
+        participants=TRIAD,
+        threshold=3,
+        payload=PAYLOAD,
+        manifold=wrong_manifold,
+    )
+    assert _is_success(rebound), f"rebind on changed manifold unexpectedly failed: {rebound!r}"
+
+    fp_a = _binding_fingerprint(binding)
+    fp_b = _binding_fingerprint(rebound)
+    if fp_a in (True, False, None) or fp_b in (True, False, None):
+        pytest.skip(
+            "Need either a verify/open API or a structured binding token "
+            "to prove coordinate sensitivity for this implementation"
+        )
+    assert fp_a != fp_b, "changing manifold coordinates should change the binding token/fingerprint"
+
+
+def test_fail_to_noise_never_leaks_raw_payload(egg_api: SacredEggAPI) -> None:
+    fail_fn = egg_api.find(FAIL_TO_NOISE_ALIASES)
+
+    if fail_fn is not None:
+        result = egg_api.call(
+            fail_fn,
+            actor=TRIAD[0],
+            participants=("guardian-alpha", "guardian-alpha", "guardian-beta"),
+            payload=PAYLOAD,
+            manifold=OUTSIDE_MANIFOLD,
+        )
+        assert_no_payload_leak(result, PAYLOAD)
+        return
+
+    # Fallback: force a known-invalid binding path and ensure the surfaced error/result
+    # still does not contain the underlying secret material.
+    try:
+        result = egg_api.ritual(
+            "manifold_binding",
+            MANIFOLD_RITUAL_ALIASES,
+            participants=("guardian-alpha", "guardian-alpha", "guardian-beta"),
+            threshold=3,
+            payload=PAYLOAD,
+            manifold=OUTSIDE_MANIFOLD,
+        )
+    except Exception as exc:
+        assert_no_payload_leak(exc, PAYLOAD)
+        return
+
+    assert_no_payload_leak(result, PAYLOAD)
+    if _has_explicit_status(result):
+        assert not _is_success(result), (
+            "Invalid manifold + duplicate binders should not surface a success status; "
+            f"got {result!r}"
+        )


### PR DESCRIPTION
## What this ships\n- Quasicrystal voxel storage lane with AEAD-bound Chladni gating, tier routing, metrics export, harmonic hook, and red-team probe\n- Sacred Eggs ritual API surface and comprehensive ritual tests\n- Start-here docs, GitHub order/notes sync checklist, and AI intro video prompts\n- Notes inventory helper script for promoting local notes into GitHub\n\n## Validation\n- python -m pytest tests/test_quasicrystal_voxel_drive.py tests/test_sacred_eggs_rituals.py -q\n- 23 passed\n\n## Why\n- Move strongest local R&D into repo with tests and launch-ready intro assets.