### PR TITLE
feat(market): add pilot conversion packet and evidence runner

### DIFF
--- a/docs/market/2026-03-06-outreach-cadence.md
+++ b/docs/market/2026-03-06-outreach-cadence.md
@@ -1,0 +1,76 @@
+# SCBE Outreach Cadence
+
+Date: 2026-03-06  
+Owner: Issac Daniel Davis
+
+## Cadence (10 Business Days)
+
+1. Day 0: initial outreach with mission-fit angle and pilot scope.
+2. Day 3: follow-up with one concrete technical artifact.
+3. Day 7: close loop with firm call-to-action and calendar link.
+
+## Day 0 Template (Initial)
+
+Subject: 60-90 day pilot for governed autonomous workflows
+
+Hello {{name}},
+
+I am reaching out with a focused pilot proposal for {{org}}: SCBE adds a
+governed interoperability layer on top of existing AI/autonomy systems so
+multi-agent workflows stay auditable and controllable.
+
+Pilot scope:
+- integrate one workflow lane in 15 days,
+- run controlled validation in 30-45 days,
+- deliver decision package in 60-90 days.
+
+If useful, I can send a one-page packet plus a reproducible demo command that
+generates audit artifacts in one run.
+
+Best,  
+Issac Daniel Davis
+
+## Day 3 Template (Evidence Follow-Up)
+
+Subject: Re: governed autonomy pilot for {{org}}
+
+Hello {{name}},
+
+Sharing the technical evidence path discussed:
+- 2.5D lattice command lane for deterministic note/task ingestion,
+- governance decision trail (ALLOW/QUARANTINE/DEFER/DENY),
+- generated evidence index for replay and review.
+
+I can walk your team through the exact command path in a 20-minute call and
+map it to one active mission workflow.
+
+Best,  
+Issac Daniel Davis
+
+## Day 7 Template (Decision Ask)
+
+Subject: Pilot decision checkpoint ({{org}})
+
+Hello {{name}},
+
+Closing the loop on the pilot option. If this is a fit, I suggest a short
+scoping call this week to pick one workflow lane and lock acceptance gates.
+
+If timing is not right, reply with the best quarter and I will re-time the
+packet.
+
+Best,  
+Issac Daniel Davis
+
+## Qualification Questions (Use in First Call)
+
+1. Which workflow lane has the highest failure cost today?
+2. Who signs off on automation risk in your environment?
+3. What evidence is required for pilot-to-production approval?
+4. What is the target timeline for a pilot decision?
+
+## Disqualification Signals
+
+1. No owner for risk/approval path.
+2. No realistic pilot environment or data access.
+3. Procurement cycle cannot start within 90 days.

--- a/docs/market/2026-03-06-pilot-conversion-packet.md
+++ b/docs/market/2026-03-06-pilot-conversion-packet.md
@@ -1,0 +1,61 @@
+# SCBE Pilot Conversion Packet
+
+Date: 2026-03-06  
+Owner: Issac Daniel Davis  
+Status: execution-ready
+
+## Objective
+
+Turn technical proof into paid pilot conversations by shipping a compact packet
+that buyers can evaluate in one pass.
+
+## Packet Contents
+
+1. Target pipeline (ranked): `docs/market/2026-03-06-target-pipeline.csv`
+2. Outreach cadence + templates: `docs/market/2026-03-06-outreach-cadence.md`
+3. Demo-to-decision evidence runner: `scripts/system/pilot_demo_to_decision.py`
+
+## 60-90 Day Pilot Scope (Template)
+
+### Phase 1 (Days 1-15): Integration Discovery
+- Confirm API boundary and auth model.
+- Wire SCBE lattice route into one customer workflow.
+- Define decision metrics and pass/fail criteria.
+
+### Phase 2 (Days 16-45): Controlled Prototype
+- Run 2.5D lattice ingestion and branch execution on customer-like inputs.
+- Apply governance decisions (ALLOW/QUARANTINE/DEFER/DENY) in pre-production.
+- Produce deterministic replay artifacts for each run.
+
+### Phase 3 (Days 46-75): Operational Validation
+- Stress test route and queue behavior under burst traffic.
+- Validate route-level failure handling and governance escalation.
+- Compare baseline workflow vs SCBE-governed workflow.
+
+### Phase 4 (Days 76-90): Decision Package
+- Deliver evidence index, metrics summary, and rollout recommendation.
+- Define follow-on scope (production lane or expanded mission lane).
+
+## Buyer-Facing Acceptance Gates
+
+1. Reproducibility: same input packet yields stable decision path.
+2. Safety posture: no unresolved critical findings in pilot scope.
+3. Performance: pilot SLA threshold met for designated workflow.
+4. Auditability: each decision links to traceable evidence output.
+
+## Demo-to-Decision Command Path
+
+```bash
+python scripts/system/pilot_demo_to_decision.py
+```
+
+Output artifacts:
+- `artifacts/pilot_demo/<run_id>/evidence_index.json`
+- `artifacts/pilot_demo/<run_id>/evidence_index.md`
+- `artifacts/pilot_demo/<run_id>/steps/*`
+
+## Positioning Statement (Short)
+
+SCBE is a governed interoperability layer for autonomous workflows. It does not
+replace customer models; it constrains, routes, and audits model behavior across
+multi-agent execution paths.

--- a/docs/market/2026-03-06-target-pipeline.csv
+++ b/docs/market/2026-03-06-target-pipeline.csv
@@ -1,0 +1,21 @@
+rank,account_name,segment,primary_need,entry_offer,owner,status,next_action,due_date,fit_score
+1,USSOCOM SOF ATL,DoD program office,Collaborative autonomy governance,90-day governed autonomy pilot,issac,targeted,send pilot one-pager and request intro,2026-03-10,98
+2,DEVCOM ARL C-UAS lane,Army RFI lane,Low-cost swarm detection software,2.5D lattice proximity demo,issac,targeted,submit RFI response brief,2026-03-25,96
+3,PMA-263 UCC,Navy UAS control lane,Multi-platform command coordination,semantic mesh + lattice control bridge,issac,targeted,deliver capability white paper,2026-03-23,95
+4,DARPA I2O BORDEAUX,DARPA cyber AI lane,Trusted AI security hardening,governed AI runtime control prototype,issac,researching,finalize technical annex,2026-03-14,92
+5,AFRL Rome mesh networking,AFRL BAA lane,Tactical mesh autonomy routing,hyperbolic lattice routing pilot,issac,researching,prepare 3-5 page white paper,2026-03-20,90
+6,DIU ALPV,DIU maritime autonomy lane,Autonomous vessel mission governance,maritime autonomy governance pilot,issac,targeted,submit solution package,2026-03-16,89
+7,NSWC PCD SLAM2ER,OTA consortium lane,Autonomy and littoral integration,subcontract-ready governance module,issac,researching,identify consortium partner lead,2026-03-13,88
+8,NSWC Corona cyber AI OTA,Naval prototyping lane,Cyber and AI prototype acceleration,governed multi-agent cyber workflow pilot,issac,researching,send nontraditional vendor brief,2026-03-18,86
+9,SSC S6 mission AI,Space operations lane,Mission AI reliability,hyperbolic intent-control stack pilot,issac,researching,submit capability statement,2026-03-22,84
+10,CPE ES2 JETMS,Enterprise DoD tasking lane,Large-scale AI task governance,multi-agent workflow governance pilot,issac,researching,submit 3-page concept and ROM,2026-03-09,83
+11,Booz Allen defense AI,Prime contractor,Governed orchestration for client missions,prime-sub governance integration module,issac,prospect,find practice lead and send intro,2026-03-12,82
+12,Leidos autonomy systems,Prime contractor,Swarm and autonomy control assurance,SCBE governance sidecar pilot,issac,prospect,request technical discovery call,2026-03-13,81
+13,SAIC mission software,Prime contractor,Program-safe AI automation,deterministic decision trail module,issac,prospect,share pilot packet and references,2026-03-14,80
+14,L3Harris autonomy division,Prime contractor,UAS mission software reliability,lattice route governance adapter,issac,prospect,request subcontract lane review,2026-03-15,79
+15,General Dynamics Mission Systems,Prime contractor,Secure autonomous mission workflows,post-quantum governed workflow pilot,issac,prospect,send integration architecture sheet,2026-03-16,78
+16,Anduril federal programs,Defense tech prime,Autonomy safety + mission controls,governed runtime containment pilot,issac,prospect,request technical fit meeting,2026-03-17,76
+17,Palantir FedStart ecosystem,Federal platform partner,Interoperable AI controls,audit-first governance connector,issac,prospect,identify platform partnership contact,2026-03-18,75
+18,Accenture Federal Services,Federal integrator,Responsible AI deployment controls,multi-model governance package,issac,prospect,share pilot outcomes deck,2026-03-19,74
+19,Deloitte Government and Public Services,Federal integrator,AI risk and compliance operations,decision traceability module,issac,prospect,request partner discovery session,2026-03-20,73
+20,ManTech mission solutions,Federal cyber contractor,Cyber mission automation governance,governed cyber workflow pilot,issac,prospect,send 2-page technical brief,2026-03-21,72

--- a/scripts/system/pilot_demo_to_decision.py
+++ b/scripts/system/pilot_demo_to_decision.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Run a compact SCBE pilot evidence path and emit a decision packet.
+
+This script is intentionally simple so it can be run by non-developers:
+
+    python scripts/system/pilot_demo_to_decision.py
+
+Artifacts are written to:
+    artifacts/pilot_demo/<run_id>/
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def utc_iso(ts: datetime) -> str:
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class Step:
+    id: str
+    name: str
+    command: list[str]
+    parse_json: bool = False
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run SCBE pilot demo and emit decision artifacts.")
+    parser.add_argument("--repo-root", default="", help="Repository root path (auto-detected if omitted).")
+    parser.add_argument("--output-dir", default="artifacts/pilot_demo", help="Artifact directory relative to repo root.")
+    parser.add_argument("--sample-count", type=int, default=16, help="Count for lattice25d sample command.")
+    parser.add_argument("--max-notes", type=int, default=24, help="Max notes for lattice25d notes command.")
+    parser.add_argument("--notes-glob", default="docs/**/*.md", help="Glob pattern for lattice notes import.")
+    parser.add_argument("--json", action="store_true", help="Print final evidence index JSON.")
+    return parser.parse_args()
+
+
+def run_step(step: Step, repo_root: Path, step_dir: Path, timeout_seconds: int = 240) -> dict[str, Any]:
+    started = utc_now()
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        step.command,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout_seconds,
+        check=False,
+    )
+    duration = round(time.perf_counter() - t0, 4)
+    ended = utc_now()
+
+    stdout_path = step_dir / f"{step.id}.stdout.txt"
+    stderr_path = step_dir / f"{step.id}.stderr.txt"
+    stdout_path.write_text(proc.stdout or "", encoding="utf-8")
+    stderr_path.write_text(proc.stderr or "", encoding="utf-8")
+
+    parsed_json_path = ""
+    parsed_payload: dict[str, Any] | None = None
+    if step.parse_json:
+        try:
+            parsed_payload = json.loads(proc.stdout)
+            parsed_json_path = str((step_dir / f"{step.id}.parsed.json").resolve())
+            Path(parsed_json_path).write_text(json.dumps(parsed_payload, indent=2), encoding="utf-8")
+        except Exception:
+            parsed_payload = None
+
+    return {
+        "id": step.id,
+        "name": step.name,
+        "command": step.command,
+        "return_code": proc.returncode,
+        "ok": proc.returncode == 0,
+        "started_at_utc": utc_iso(started),
+        "ended_at_utc": utc_iso(ended),
+        "duration_seconds": duration,
+        "stdout_path": str(stdout_path.resolve()),
+        "stderr_path": str(stderr_path.resolve()),
+        "parsed_json_path": parsed_json_path,
+        "parsed_payload": parsed_payload,
+    }
+
+
+def collect_metrics(step_results: list[dict[str, Any]]) -> dict[str, Any]:
+    sample_payload = next((s.get("parsed_payload") for s in step_results if s["id"] == "step01_lattice_sample"), None)
+    notes_payload = next((s.get("parsed_payload") for s in step_results if s["id"] == "step02_lattice_notes"), None)
+
+    metrics: dict[str, Any] = {
+        "sample_ingested_count": None,
+        "sample_overlap_cells": None,
+        "notes_ingested_count": None,
+        "notes_overlap_cells": None,
+        "notes_lace_edge_count": None,
+    }
+
+    if isinstance(sample_payload, dict):
+        metrics["sample_ingested_count"] = sample_payload.get("ingested_count")
+        overlap = sample_payload.get("overlap_cells")
+        metrics["sample_overlap_cells"] = len(overlap) if isinstance(overlap, list) else None
+
+    if isinstance(notes_payload, dict):
+        metrics["notes_ingested_count"] = notes_payload.get("ingested_count")
+        overlap = notes_payload.get("overlap_cells")
+        metrics["notes_overlap_cells"] = len(overlap) if isinstance(overlap, list) else None
+        metrics["notes_lace_edge_count"] = notes_payload.get("lace_edge_count")
+
+    return metrics
+
+
+def write_markdown_index(path: Path, index: dict[str, Any]) -> None:
+    lines = [
+        "# Pilot Demo Evidence Index",
+        "",
+        f"- run_id: `{index['run_id']}`",
+        f"- generated_at_utc: `{index['generated_at_utc']}`",
+        f"- ok: `{index['ok']}`",
+        f"- repo_root: `{index['repo_root']}`",
+        "",
+        "## Key Metrics",
+    ]
+    for key, value in index.get("key_metrics", {}).items():
+        lines.append(f"- {key}: `{value}`")
+
+    lines.extend(["", "## Steps"])
+    for step in index.get("steps", []):
+        lines.extend(
+            [
+                f"### {step['id']} - {step['name']}",
+                f"- ok: `{step['ok']}`",
+                f"- return_code: `{step['return_code']}`",
+                f"- duration_seconds: `{step['duration_seconds']}`",
+                f"- command: `{ ' '.join(step['command']) }`",
+                f"- stdout: `{step['stdout_path']}`",
+                f"- stderr: `{step['stderr_path']}`",
+            ]
+        )
+        if step.get("parsed_json_path"):
+            lines.append(f"- parsed_json: `{step['parsed_json_path']}`")
+        lines.append("")
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).expanduser().resolve() if args.repo_root else repo_root_from_script()
+
+    timestamp = utc_now()
+    run_id = timestamp.strftime("%Y%m%dT%H%M%SZ")
+    run_dir = (repo_root / args.output_dir / run_id).resolve()
+    step_dir = run_dir / "steps"
+    step_dir.mkdir(parents=True, exist_ok=True)
+
+    steps = [
+        Step(
+            id="step01_lattice_sample",
+            name="Generate lattice sample payload",
+            command=[
+                sys.executable,
+                "-m",
+                "hydra.cli",
+                "lattice25d",
+                "sample",
+                "--count",
+                str(args.sample_count),
+                "--json",
+            ],
+            parse_json=True,
+        ),
+        Step(
+            id="step02_lattice_notes",
+            name="Ingest markdown notes into lattice payload",
+            command=[
+                sys.executable,
+                "-m",
+                "hydra.cli",
+                "lattice25d",
+                "notes",
+                "--glob",
+                args.notes_glob,
+                "--max-notes",
+                str(args.max_notes),
+                "--json",
+            ],
+            parse_json=True,
+        ),
+        Step(
+            id="step03_regression_tests",
+            name="Run deterministic lattice regression tests",
+            command=[sys.executable, "-m", "pytest", "tests/test_lattice25d_ops.py", "-q"],
+            parse_json=False,
+        ),
+    ]
+
+    step_results = [run_step(step, repo_root, step_dir) for step in steps]
+    ok = all(bool(step["ok"]) for step in step_results)
+
+    index = {
+        "ok": ok,
+        "run_id": run_id,
+        "generated_at_utc": utc_iso(utc_now()),
+        "repo_root": str(repo_root),
+        "run_dir": str(run_dir),
+        "steps_dir": str(step_dir),
+        "steps": [
+            {k: v for k, v in step.items() if k != "parsed_payload"}
+            for step in step_results
+        ],
+        "key_metrics": collect_metrics(step_results),
+    }
+
+    index_json_path = run_dir / "evidence_index.json"
+    index_md_path = run_dir / "evidence_index.md"
+    index_json_path.write_text(json.dumps(index, indent=2), encoding="utf-8")
+    write_markdown_index(index_md_path, index)
+
+    if args.json:
+        print(json.dumps(index, indent=2))
+    else:
+        print(f"[pilot-demo] run_id={run_id}")
+        print(f"[pilot-demo] ok={ok}")
+        print(f"[pilot-demo] evidence_json={index_json_path}")
+        print(f"[pilot-demo] evidence_md={index_md_path}")
+
+    return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add pilot conversion packet with 60-90 day scope and acceptance gates
- add ranked 20-target pipeline CSV for contractor and prime outreach
- add outreach cadence templates (day 0/3/7)
- add scripts/system/pilot_demo_to_decision.py one-command evidence runner

## Validation
- python scripts/system/pilot_demo_to_decision.py
- python -m py_compile scripts/system/pilot_demo_to_decision.py

## Output Artifact Example
- rtifacts/pilot_demo/20260306T150211Z/evidence_index.json
