### PR TITLE
feat(social): use Buffer as preferred live posting channel

### DIFF
--- a/.github/workflows/daily-social-updates.yml
+++ b/.github/workflows/daily-social-updates.yml
@@ -58,6 +58,8 @@ jobs:
         id: preflight
         env:
           SCBE_SOCIAL_LIVE: ${{ secrets.SCBE_SOCIAL_LIVE }}
+          BUFFER_ACCESS_TOKEN: ${{ secrets.BUFFER_ACCESS_TOKEN }}
+          BUFFER_PROFILE_IDS: ${{ secrets.BUFFER_PROFILE_IDS }}
           X_CLIENT_ID: ${{ secrets.X_CLIENT_ID }}
           X_CLIENT_SECRET: ${{ secrets.X_CLIENT_SECRET }}
           X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
@@ -75,8 +77,12 @@ jobs:
           fi
 
           X_READY=false
+          BUFFER_READY=false
           OAUTH2_READY=false
           OAUTH1_READY=false
+          if [ -n "${BUFFER_ACCESS_TOKEN}" ]; then
+            BUFFER_READY=true
+          fi
           if [ -n "${X_CLIENT_ID}" ] && [ -n "${X_CLIENT_SECRET}" ] && [ -n "${X_ACCESS_TOKEN}" ] && [ -n "${X_REFRESH_TOKEN}" ]; then
             OAUTH2_READY=true
           fi
@@ -89,10 +95,12 @@ jobs:
 
           echo "live_enabled=${LIVE_ENABLED}" >> "$GITHUB_OUTPUT"
           echo "x_ready=${X_READY}" >> "$GITHUB_OUTPUT"
+          echo "buffer_ready=${BUFFER_READY}" >> "$GITHUB_OUTPUT"
           echo "oauth2_ready=${OAUTH2_READY}" >> "$GITHUB_OUTPUT"
           echo "oauth1_ready=${OAUTH1_READY}" >> "$GITHUB_OUTPUT"
           echo "live_enabled=${LIVE_ENABLED}"
           echo "x_ready=${X_READY}"
+          echo "buffer_ready=${BUFFER_READY}"
           echo "oauth2_ready=${OAUTH2_READY}"
           echo "oauth1_ready=${OAUTH1_READY}"
 
@@ -104,8 +112,19 @@ jobs:
             --github-glob "${{ steps.generate.outputs.github_glob }}" \
             --github-limit 1
 
+      - name: Publish live Buffer (preferred for X distribution)
+        if: ${{ steps.preflight.outputs.live_enabled == 'true' && steps.preflight.outputs.buffer_ready == 'true' }}
+        env:
+          BUFFER_ACCESS_TOKEN: ${{ secrets.BUFFER_ACCESS_TOKEN }}
+          BUFFER_PROFILE_IDS: ${{ secrets.BUFFER_PROFILE_IDS }}
+        run: |
+          python scripts/publish/post_all.py \
+            --only buffer \
+            --x-article "${{ steps.generate.outputs.x_article }}" \
+            --github-limit 1
+
       - name: Publish live X
-        if: ${{ steps.preflight.outputs.live_enabled == 'true' && steps.preflight.outputs.x_ready == 'true' }}
+        if: ${{ steps.preflight.outputs.live_enabled == 'true' && steps.preflight.outputs.buffer_ready != 'true' && steps.preflight.outputs.x_ready == 'true' }}
         env:
           X_CLIENT_ID: ${{ secrets.X_CLIENT_ID }}
           X_CLIENT_SECRET: ${{ secrets.X_CLIENT_SECRET }}
@@ -120,10 +139,10 @@ jobs:
             --x-article "${{ steps.generate.outputs.x_article }}" \
             --github-limit 1
 
-      - name: Live X skipped notice
-        if: ${{ steps.preflight.outputs.live_enabled == 'true' && steps.preflight.outputs.x_ready != 'true' }}
+      - name: Live social skipped notice
+        if: ${{ steps.preflight.outputs.live_enabled == 'true' && steps.preflight.outputs.buffer_ready != 'true' && steps.preflight.outputs.x_ready != 'true' }}
         run: |
-          echo "Live X publish skipped: required X OAuth secrets are not all configured."
+          echo "Live social publish skipped: neither Buffer nor X credentials are fully configured."
 
       - name: Upload social evidence
         if: always()

--- a/docs/ops/DAILY_SOCIAL_UPDATES.md
+++ b/docs/ops/DAILY_SOCIAL_UPDATES.md
@@ -7,6 +7,7 @@ Workflow: `.github/workflows/daily-social-updates.yml`
 1. Generates daily update posts from recent commit activity.
 2. Runs `post_all.py` in dry-run mode and saves evidence.
 3. Optionally runs live publish for X + GitHub Discussions.
+4. Prefers Buffer for live X distribution when Buffer credentials are configured.
 
 ## Local Commands
 
@@ -20,14 +21,26 @@ python scripts/publish/post_all.py --dry-run --only x,github,linkedin --github-g
 Scheduled live publish is enabled only when repository secret `SCBE_SOCIAL_LIVE`
 is set to `true`.
 
-Required X secrets for live X posting:
+Preferred live social (Buffer) secrets:
+- `BUFFER_ACCESS_TOKEN`
+- `BUFFER_PROFILE_IDS` (optional, comma-separated profile IDs; if omitted the script tries auto-discovery)
+
+Fallback X secrets for direct X posting:
 - `X_CLIENT_ID`
 - `X_CLIENT_SECRET`
 - `X_ACCESS_TOKEN`
 - `X_REFRESH_TOKEN`
+- OR OAuth 1.0a set:
+  - `X_API_KEY`
+  - `X_API_SECRET`
+  - `X_ACCESS_TOKEN`
+  - `X_ACCESS_TOKEN_SECRET`
 
-If `SCBE_SOCIAL_LIVE=true` but X secrets are incomplete, the workflow still
-publishes GitHub Discussions live and logs a skip notice for X.
+If `SCBE_SOCIAL_LIVE=true`, live logic is:
+1. Publish GitHub Discussions.
+2. Publish via Buffer if Buffer secrets are configured.
+3. Otherwise, publish direct to X if X secrets are configured.
+4. Otherwise, log skip notice.
 
 Manual live run:
 - GitHub Actions → `Daily Social Updates` → `Run workflow` with `live_publish=true`.

--- a/scripts/publish/post_all.py
+++ b/scripts/publish/post_all.py
@@ -21,11 +21,13 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ARTICLES_DIR = REPO_ROOT / "content" / "articles"
 EVIDENCE_DIR = REPO_ROOT / "artifacts" / "publish_browser"
 POST_TO_X = REPO_ROOT / "scripts" / "publish" / "post_to_x.py"
+POST_TO_BUFFER = REPO_ROOT / "scripts" / "publish" / "post_to_buffer.py"
 POST_TO_GITHUB_DISCUSSIONS = REPO_ROOT / "scripts" / "publish" / "publish_discussions.py"
 
 PLATFORM_PREFIXES: dict[str, tuple[str, ...]] = {
     "x": ("x_thread_", "twitter_thread_"),
     "twitter": ("x_thread_", "twitter_thread_"),
+    "buffer": ("x_thread_", "twitter_thread_", "buffer_"),
     "linkedin": ("linkedin_",),
     "medium": ("medium_",),
     "devto": ("devto_",),
@@ -34,7 +36,7 @@ PLATFORM_PREFIXES: dict[str, tuple[str, ...]] = {
     "github": ("2026-",),
 }
 
-PLATFORM_ORDER = ["x", "github", "linkedin", "medium", "devto", "reddit", "hackernews"]
+PLATFORM_ORDER = ["x", "buffer", "github", "linkedin", "medium", "devto", "reddit", "hackernews"]
 
 
 def _normalize_platforms(raw_only: str | None) -> list[str]:
@@ -100,6 +102,34 @@ def _run_x_publish(article: Path, dry_run: bool) -> tuple[str, str]:
     return "error", ((proc.stderr or output) or "unknown error")[-4000:]
 
 
+def _run_buffer_publish(article: Path, dry_run: bool) -> tuple[str, str]:
+    if not POST_TO_BUFFER.exists():
+        return "error", f"missing publisher: {POST_TO_BUFFER}"
+
+    is_thread = "thread" in article.name.lower()
+    if is_thread:
+        cmd = [sys.executable, str(POST_TO_BUFFER), "--thread", str(article)]
+        if dry_run:
+            cmd.append("--dry-run")
+    else:
+        text = _extract_text_for_single_post(article)
+        cmd = [sys.executable, str(POST_TO_BUFFER), "--text", text]
+        if dry_run:
+            cmd.append("--dry-run")
+
+    proc = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": os.environ.get("PYTHONPATH", ".")},
+    )
+    output = ((proc.stdout or "") + "\n" + (proc.stderr or "")).strip()
+    if proc.returncode == 0:
+        return ("dry_run_ready" if dry_run else "posted"), output[-4000:]
+    return "error", output[-4000:] or "unknown error"
+
+
 def _run_github_publish(dry_run: bool, glob_pattern: str, limit: int) -> tuple[str, str]:
     if not POST_TO_GITHUB_DISCUSSIONS.exists():
         return "error", f"missing publisher: {POST_TO_GITHUB_DISCUSSIONS}"
@@ -130,7 +160,11 @@ def _run_github_publish(dry_run: bool, glob_pattern: str, limit: int) -> tuple[s
 def main() -> int:
     parser = argparse.ArgumentParser(description="Publish SCBE articles across supported platforms.")
     parser.add_argument("--dry-run", action="store_true", help="Do not publish; report what would be posted.")
-    parser.add_argument("--only", default="", help="Comma-separated platforms (x,linkedin,medium,devto,reddit,hackernews).")
+    parser.add_argument(
+        "--only",
+        default="",
+        help="Comma-separated platforms (x,buffer,github,linkedin,medium,devto,reddit,hackernews).",
+    )
     parser.add_argument("--browser-fallback", action="store_true", help="Record browser fallback mode in evidence.")
     parser.add_argument("--browser-publish", action="store_true", help="Record browser publish intent in evidence.")
     parser.add_argument(
@@ -160,7 +194,9 @@ def main() -> int:
     statuses: list[dict] = []
     explicit_articles: dict[str, Path] = {}
     if args.x_article.strip():
-        explicit_articles["x"] = Path(args.x_article).expanduser().resolve()
+        resolved_x = Path(args.x_article).expanduser().resolve()
+        explicit_articles["x"] = resolved_x
+        explicit_articles["buffer"] = resolved_x
     if args.linkedin_article.strip():
         explicit_articles["linkedin"] = Path(args.linkedin_article).expanduser().resolve()
 
@@ -201,6 +237,10 @@ def main() -> int:
 
         if platform == "x":
             status, detail = _run_x_publish(article, dry_run=args.dry_run)
+            row["status"] = status
+            row["detail"] = detail
+        elif platform == "buffer":
+            status, detail = _run_buffer_publish(article, dry_run=args.dry_run)
             row["status"] = status
             row["detail"] = detail
         else:

--- a/scripts/publish/post_to_buffer.py
+++ b/scripts/publish/post_to_buffer.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Post to Buffer using Buffer Publish API.
+
+Environment:
+    BUFFER_ACCESS_TOKEN  - Buffer access token (required)
+    BUFFER_PROFILE_IDS   - Comma-separated Buffer profile IDs (required)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import ssl
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+BUFFER_CREATE_URL = "https://api.bufferapp.com/1/updates/create.json"
+BUFFER_PROFILES_URL = "https://api.bufferapp.com/1/profiles.json"
+
+
+def _is_present(value: str) -> bool:
+    return bool(value and value != "REPLACE_ME")
+
+
+def _profiles_from_env(raw: str) -> list[str]:
+    return [p.strip() for p in (raw or "").split(",") if p.strip()]
+
+
+def _discover_profile_ids(token: str) -> list[str]:
+    params = urllib.parse.urlencode({"access_token": token})
+    req = urllib.request.Request(f"{BUFFER_PROFILES_URL}?{params}", method="GET")
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except Exception:
+        return []
+
+    if not isinstance(data, list):
+        return []
+    preferred = [p.get("id", "") for p in data if isinstance(p, dict) and p.get("service") in ("twitter", "x")]
+    fallback = [p.get("id", "") for p in data if isinstance(p, dict)]
+    values = preferred or fallback
+    return [v for v in values if v]
+
+
+def _load_credentials() -> tuple[str, list[str]]:
+    token = os.environ.get("BUFFER_ACCESS_TOKEN", "")
+    profiles = _profiles_from_env(os.environ.get("BUFFER_PROFILE_IDS", ""))
+    if _is_present(token) and not profiles:
+        profiles = _discover_profile_ids(token)
+    return token, profiles
+
+
+def _parse_thread_file(path: Path) -> list[str]:
+    content = path.read_text(encoding="utf-8", errors="replace")
+    parts = re.split(r"^## \d+/\d+\s*\n", content, flags=re.MULTILINE)
+    posts: list[str] = []
+    for part in parts:
+        part = part.strip()
+        if not part or part.startswith("---") or part.startswith("#"):
+            continue
+        text = re.sub(r"\s+", " ", part).strip()
+        if len(text) > 280:
+            text = text[:277].rstrip() + "..."
+        if text:
+            posts.append(text)
+    return posts
+
+
+def _buffer_create_update(text: str, token: str, profile_ids: list[str]) -> tuple[bool, str]:
+    payload = {
+        "access_token": token,
+        "text": text,
+        "profile_ids[]": profile_ids,
+        "now": "true",
+        "shorten": "true",
+    }
+    encoded = urllib.parse.urlencode(payload, doseq=True).encode("utf-8")
+    req = urllib.request.Request(BUFFER_CREATE_URL, data=encoded, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            return True, body
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        return False, f"HTTP {e.code}: {body}"
+    except Exception as e:
+        return False, str(e)
+
+
+def _post_text(text: str, dry_run: bool) -> int:
+    token, profile_ids = _load_credentials()
+    if not _is_present(token):
+        print("ERROR: BUFFER_ACCESS_TOKEN is not configured.")
+        return 1
+    if not profile_ids:
+        print("ERROR: BUFFER_PROFILE_IDS is not configured.")
+        return 1
+
+    if dry_run:
+        print(f"[DRY RUN] Buffer post to profiles={profile_ids}: {text[:120]}")
+        return 0
+
+    ok, detail = _buffer_create_update(text=text, token=token, profile_ids=profile_ids)
+    if ok:
+        print("Buffer post created.")
+        return 0
+    print(f"ERROR: Buffer post failed: {detail[:500]}")
+    return 1
+
+
+def _post_thread(path: Path, dry_run: bool) -> int:
+    posts = _parse_thread_file(path)
+    if not posts:
+        print("ERROR: no posts found in thread file.")
+        return 1
+    print(f"Thread: {len(posts)} posts")
+    for i, text in enumerate(posts, start=1):
+        print(f"--- Buffer post {i}/{len(posts)} ({len(text)} chars) ---")
+        rc = _post_text(text=text, dry_run=dry_run)
+        if rc != 0:
+            return rc
+        if not dry_run and i < len(posts):
+            time.sleep(2)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Post to Buffer.")
+    parser.add_argument("--text", default="", help="Single status text.")
+    parser.add_argument("--thread", default="", help="Thread markdown file path.")
+    parser.add_argument("--dry-run", action="store_true", help="Preview only.")
+    args = parser.parse_args()
+
+    if args.thread:
+        return _post_thread(Path(args.thread), dry_run=args.dry_run)
+    if args.text:
+        return _post_text(text=args.text, dry_run=args.dry_run)
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/publish/post_to_buffer.py` for Buffer API publishing
- add `buffer` platform support in `scripts/publish/post_all.py`
- update daily social workflow to prefer Buffer live publishing when Buffer token is configured
- keep direct X publish as fallback when Buffer is not configured
- update runbook docs for Buffer-first flow

## Validation
- `python -m py_compile scripts/publish/post_to_buffer.py scripts/publish/post_all.py scripts/publish/post_to_x.py`
- `python scripts/publish/post_to_buffer.py --text "buffer smoke" --dry-run`
- `python scripts/publish/post_all.py --dry-run --only buffer --x-article content/articles/x_thread_system_update_2026_03_06.md`
