### PR TITLE
fix(security): harden code scanning hotspots

### DIFF
--- a/conference-app/src/api/services/zoom.ts
+++ b/conference-app/src/api/services/zoom.ts
@@ -14,6 +14,8 @@
  * @see https://developers.zoom.us/docs/meeting-sdk/
  */
 
+import { randomBytes } from 'crypto';
+
 // ═══════════════════════════════════════════════════════════════
 // Types
 // ═══════════════════════════════════════════════════════════════
@@ -38,6 +40,17 @@ export interface ZoomMeeting {
 export interface ZoomTokenCache {
   accessToken: string;
   expiresAt: number;
+}
+
+const ZOOM_HOST_EMAIL_RE =
+  /^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$/i;
+
+function normalizeZoomHostEmail(hostEmail: string): string {
+  const normalized = hostEmail.trim().toLowerCase();
+  if (!normalized || normalized.length > 254 || !ZOOM_HOST_EMAIL_RE.test(normalized)) {
+    throw new Error('Invalid Zoom host email');
+  }
+  return normalized;
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -124,15 +137,17 @@ export class ZoomService {
     durationMinutes: number,
     hostEmail: string
   ): Promise<ZoomMeeting> {
+    const normalizedHostEmail = normalizeZoomHostEmail(hostEmail);
+
     // If Zoom isn't configured, return a simulated meeting for dev/demo
     if (!this.config) {
       const simulated: ZoomMeeting = {
         id: Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000,
         joinUrl: `https://zoom.us/j/simulated-${conferenceId.slice(0, 8)}`,
         startUrl: `https://zoom.us/s/simulated-${conferenceId.slice(0, 8)}`,
-        password: require('crypto').randomBytes(6).toString('hex'),
+        password: randomBytes(6).toString('hex'),
         topic,
-        hostEmail,
+        hostEmail: normalizedHostEmail,
         createdAt: new Date().toISOString(),
       };
       this.meetings.set(conferenceId, simulated);
@@ -140,7 +155,9 @@ export class ZoomService {
     }
 
     const token = await this.getAccessToken();
-    const res = await fetch(`https://api.zoom.us/v2/users/${hostEmail}/meetings`, {
+    const res = await fetch(
+      `https://api.zoom.us/v2/users/${encodeURIComponent(normalizedHostEmail)}/meetings`,
+      {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -160,7 +177,8 @@ export class ZoomService {
           auto_recording: 'cloud',
         },
       }),
-    });
+      }
+    );
 
     if (!res.ok) {
       const text = await res.text();
@@ -180,7 +198,7 @@ export class ZoomService {
       startUrl: data.start_url,
       password: data.password,
       topic,
-      hostEmail,
+      hostEmail: normalizedHostEmail,
       createdAt: new Date().toISOString(),
     };
 

--- a/dashboard/scbe_monitor.html
+++ b/dashboard/scbe_monitor.html
@@ -731,25 +731,45 @@
       setInterval(updateTime, 1000);
       updateTime();
 
-      // Format decision for display
-      function formatDecision(d) {
-        const time = d.timestamp ? d.timestamp.split('T')[1].slice(0, 12) : new Date().toISOString().split('T')[1].slice(0, 12);
-        let statusClass = 'status-allow';
-        if (d.decision === 'QUARANTINE') statusClass = 'status-quarantine';
-        if (d.decision === 'DENY') statusClass = 'status-deny';
+      function decisionStatusClass(decision) {
+        if (decision === 'QUARANTINE') return 'status-quarantine';
+        if (decision === 'DENY') return 'status-deny';
+        return 'status-allow';
+      }
 
-        return `<div class="p-1.5 bg-white/5 rounded flex items-center justify-between">
-          <span class="text-gray-500">${time}</span>
-          <span class="text-gray-400">${d.agent || 'unknown'}</span>
-          <span class="text-gray-500">${d.topic || 'query'}</span>
-          <span class="text-gray-400">d*=${(d.d_star || 0).toFixed(3)}</span>
-          <span class="${statusClass} font-bold">${d.decision}</span>
-        </div>`;
+      // Build a safe DOM row for the live feed
+      function buildDecisionRow(d) {
+        const time = d.timestamp ? d.timestamp.split('T')[1].slice(0, 12) : new Date().toISOString().split('T')[1].slice(0, 12);
+        const row = document.createElement('div');
+        row.className = 'p-1.5 bg-white/5 rounded flex items-center justify-between';
+
+        const fields = [
+          { className: 'text-gray-500', text: time },
+          { className: 'text-gray-400', text: d.agent || 'unknown' },
+          { className: 'text-gray-500', text: d.topic || 'query' },
+          {
+            className: 'text-gray-400',
+            text: `d*=${Number.isFinite(Number(d.d_star)) ? Number(d.d_star).toFixed(3) : '0.000'}`,
+          },
+          {
+            className: `${decisionStatusClass(d.decision)} font-bold`,
+            text: d.decision || 'ALLOW',
+          },
+        ];
+
+        fields.forEach((field) => {
+          const span = document.createElement('span');
+          span.className = field.className;
+          span.textContent = field.text;
+          row.appendChild(span);
+        });
+
+        return row;
       }
 
       // Add decision to feed
       function addDecision(d) {
-        feed.innerHTML = formatDecision(d) + feed.innerHTML;
+        feed.insertBefore(buildDecisionRow(d), feed.firstChild);
         while (feed.children.length > 50) {
           feed.removeChild(feed.lastChild);
         }
@@ -804,9 +824,9 @@
 
             if (msg.type === 'init') {
               // Initial state
-              if (msg.metrics) updateMetrics(msg.metrics);
-              if (msg.history) {
-                feed.innerHTML = '';
+            if (msg.metrics) updateMetrics(msg.metrics);
+            if (msg.history) {
+                feed.replaceChildren();
                 msg.history.reverse().forEach(d => addDecision(d));
               }
             } else if (msg.type === 'decision') {

--- a/hydra/lattice25d_ops.py
+++ b/hydra/lattice25d_ops.py
@@ -47,6 +47,20 @@ def _hash_unit(seed: str) -> float:
 _SAFE_NOTES_ROOT = Path(__file__).parent.parent.resolve()
 
 
+def _resolve_safe_glob_pattern(pattern: str) -> str:
+    normalized = (pattern or "").strip().replace("\\", "/")
+    if not normalized:
+        raise ValueError("notes_glob is required")
+    if normalized.startswith("/") or re.match(r"^[A-Za-z]:", normalized):
+        raise ValueError("notes_glob must be repo-relative")
+
+    parts = [part for part in normalized.split("/") if part]
+    if not parts or any(part == ".." for part in parts):
+        raise ValueError("notes_glob contains invalid path segments")
+
+    return str(_SAFE_NOTES_ROOT.joinpath(*parts))
+
+
 
 def load_notes_from_glob(
     pattern: str,
@@ -54,7 +68,8 @@ def load_notes_from_glob(
     source: str = "repo",
     authority: str = "public",
 ) -> List[NoteRecord]:
-    paths = sorted(glob.glob(pattern, recursive=True))
+    safe_pattern = _resolve_safe_glob_pattern(pattern)
+    paths = sorted(glob.glob(safe_pattern, recursive=True))
     notes: List[NoteRecord] = []
     for p in paths:
         if len(notes) >= max(0, max_notes):

--- a/mcp/scbe-server/server.mjs
+++ b/mcp/scbe-server/server.mjs
@@ -97,19 +97,110 @@ function sha256Hex(value) {
   return createHash('sha256').update(canonicalStringify(value)).digest('hex');
 }
 
-function stripHtml(html) {
-  // Iteratively strip tags to handle nested/malformed HTML
-  let text = String(html);
-  // Remove script and style blocks first (non-greedy, case-insensitive)
-  text = text.replace(/<script[\s\S]*?<\/script\s*>/gi, '');
-  text = text.replace(/<style[\s\S]*?<\/style\s*>/gi, '');
-  // Strip remaining tags iteratively until stable
-  let prev;
-  do {
-    prev = text;
-    text = text.replace(/<[^>]*>/g, ' ');
-  } while (text !== prev);
-  return text.replace(/\s+/g, ' ').trim();
+function startsWithInsensitive(source, index, needle) {
+  return source.slice(index, index + needle.length).toLowerCase() === needle.toLowerCase();
+}
+
+function appendNormalizedText(buffer, value, state) {
+  for (const ch of value) {
+    if (/\s/.test(ch)) {
+      if (!state.lastWasSpace && buffer.length > 0) {
+        buffer.push(' ');
+        state.lastWasSpace = true;
+      }
+      continue;
+    }
+    buffer.push(ch);
+    state.lastWasSpace = false;
+  }
+}
+
+function findTagEnd(source, startIndex) {
+  let quote = null;
+  for (let i = startIndex; i < source.length; i++) {
+    const ch = source[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === '>') return i;
+  }
+  return -1;
+}
+
+function readTagName(source, startIndex) {
+  let i = startIndex;
+  while (i < source.length && /\s/.test(source[i])) i += 1;
+  if (source[i] === '/') i += 1;
+  while (i < source.length && /\s/.test(source[i])) i += 1;
+  const begin = i;
+  while (i < source.length && /[A-Za-z0-9:-]/.test(source[i])) i += 1;
+  return source.slice(begin, i).toLowerCase();
+}
+
+export function stripHtml(html) {
+  const source = String(html ?? '');
+  const buffer = [];
+  const state = { lastWasSpace: true };
+  let mode = 'text';
+
+  for (let i = 0; i < source.length; i += 1) {
+    if (mode === 'comment') {
+      if (source.startsWith('-->', i)) {
+        mode = 'text';
+        i += 2;
+      }
+      continue;
+    }
+
+    if (mode === 'script' || mode === 'style') {
+      const closingTag = `</${mode}`;
+      if (startsWithInsensitive(source, i, closingTag)) {
+        const tagEnd = findTagEnd(source, i);
+        if (tagEnd >= 0) {
+          mode = 'text';
+          i = tagEnd;
+          appendNormalizedText(buffer, ' ', state);
+          continue;
+        }
+      }
+      continue;
+    }
+
+    const ch = source[i];
+    if (ch !== '<') {
+      appendNormalizedText(buffer, ch, state);
+      continue;
+    }
+
+    if (source.startsWith('<!--', i)) {
+      mode = 'comment';
+      i += 3;
+      continue;
+    }
+
+    const tagEnd = findTagEnd(source, i + 1);
+    if (tagEnd < 0) {
+      appendNormalizedText(buffer, source.slice(i), state);
+      break;
+    }
+
+    const tagName = readTagName(source, i + 1);
+    if (tagName === 'script' || tagName === 'style') {
+      mode = tagName;
+      i = tagEnd;
+      continue;
+    }
+
+    appendNormalizedText(buffer, ' ', state);
+    i = tagEnd;
+  }
+
+  return buffer.join('').trim();
 }
 
 function isTlsIssuerCertError(error) {

--- a/src/crypto/rwp_v3.py
+++ b/src/crypto/rwp_v3.py
@@ -93,6 +93,15 @@ ARGON2_PARAMS = {
     "type": Argon2Type.ID if ARGON2_AVAILABLE else None,  # Argon2id (hybrid mode)
 }
 
+SCRYPT_FALLBACK_PARAMS = {
+    "n": 1 << 14,
+    "r": 8,
+    "p": 1,
+    "dklen": 32,
+}
+
+PBKDF2_FALLBACK_ITERATIONS = 600_000
+
 
 # ============================================================
 # RWP v3.0 ENVELOPE STRUCTURE
@@ -203,8 +212,23 @@ class RWPv3Protocol:
                 type=ARGON2_PARAMS["type"],
             )
         except Exception:
-            # Lightweight fallback (deterministic and fast)
-            return hashlib.blake2s(password + salt, digest_size=32).digest()
+            try:
+                return hashlib.scrypt(
+                    password=password,
+                    salt=salt,
+                    n=SCRYPT_FALLBACK_PARAMS["n"],
+                    r=SCRYPT_FALLBACK_PARAMS["r"],
+                    p=SCRYPT_FALLBACK_PARAMS["p"],
+                    dklen=SCRYPT_FALLBACK_PARAMS["dklen"],
+                )
+            except (AttributeError, ValueError):
+                return hashlib.pbkdf2_hmac(
+                    "sha256",
+                    password,
+                    salt,
+                    PBKDF2_FALLBACK_ITERATIONS,
+                    dklen=ARGON2_PARAMS["hash_len"],
+                )
 
     def encrypt(
         self,

--- a/tests/conference/zoom.test.ts
+++ b/tests/conference/zoom.test.ts
@@ -5,7 +5,7 @@
  * Tests for Zoom integration and live event services.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ZoomService } from '../../conference-app/src/api/services/zoom';
 import { liveEventBus } from '../../conference-app/src/api/services/liveEvents';
 
@@ -18,6 +18,11 @@ describe('ZoomService', () => {
     delete process.env.ZOOM_CLIENT_ID;
     delete process.env.ZOOM_CLIENT_SECRET;
     service = new ZoomService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('reports not configured without env vars', () => {
@@ -64,6 +69,51 @@ describe('ZoomService', () => {
     expect(joinUrl).toContain('/j/');
     expect(startUrl).toContain('/s/');
     expect(joinUrl).not.toBe(startUrl);
+  });
+
+  it('rejects malformed host emails before building the Zoom path', async () => {
+    await expect(
+      service.createMeeting('conf-900', 'Test', '2026-03-15T14:00:00Z', 60, '../../users/me')
+    ).rejects.toThrow(/Invalid Zoom host email/);
+  });
+
+  it('encodes the validated host email in the Zoom API path', async () => {
+    process.env.ZOOM_ACCOUNT_ID = 'acct';
+    process.env.ZOOM_CLIENT_ID = 'client';
+    process.env.ZOOM_CLIENT_SECRET = 'secret';
+    service = new ZoomService();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'token', expires_in: 3600 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 123456789,
+          join_url: 'https://zoom.us/j/123456789',
+          start_url: 'https://zoom.us/s/123456789',
+          password: 'secretpw',
+        }),
+      });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+
+    const meeting = await service.createMeeting(
+      'conf-901',
+      'Encoded Test',
+      '2026-03-15T14:00:00Z',
+      60,
+      'Curator+Ops@Example.com'
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.zoom.us/v2/users/curator%2Bops%40example.com/meetings'
+    );
+    expect(meeting.hostEmail).toBe('curator+ops@example.com');
   });
 });
 

--- a/tests/crypto/test_rwp_v3.py
+++ b/tests/crypto/test_rwp_v3.py
@@ -9,6 +9,7 @@ Target: 95%+ coverage
 import pytest
 import json
 import secrets
+import hashlib
 from typing import Dict, Any
 
 # Import with fallback for missing dependencies
@@ -215,6 +216,20 @@ class TestRWPv3Protocol:
         envelope = protocol.encrypt(b"password", plaintext)
         decrypted = protocol.decrypt(b"password", envelope)
         assert decrypted == plaintext
+
+    def test_derive_key_fallback_is_not_fast_hashing(self, monkeypatch):
+        """Argon2 fallback should remain a real KDF, not a fast digest."""
+        protocol = object.__new__(RWPv3Protocol)
+
+        monkeypatch.setattr("src.crypto.rwp_v3.hash_secret_raw", lambda **_: (_ for _ in ()).throw(RuntimeError("boom")))
+
+        password = b"test-password"
+        salt = b"0123456789abcdef"
+        fallback_key = protocol._derive_key(password, salt)
+
+        assert len(fallback_key) == ARGON2_PARAMS["hash_len"]
+        assert fallback_key == protocol._derive_key(password, salt)
+        assert fallback_key != hashlib.blake2s(password + salt, digest_size=32).digest()
 
 
 class TestConvenienceAPI:

--- a/tests/mcp/scbe-server.phase1.test.ts
+++ b/tests/mcp/scbe-server.phase1.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { scbeSacredEggCreate, scbeSacredEggHatch, scbeStateEmit21D } from '../../mcp/scbe-server/server.mjs';
+import { scbeSacredEggCreate, scbeSacredEggHatch, scbeStateEmit21D, stripHtml } from '../../mcp/scbe-server/server.mjs';
 
 describe('SCBE MCP Server Phase 1 Tools', () => {
   it('emits canonical 21D state telemetry', () => {
@@ -108,6 +108,11 @@ describe('SCBE MCP Server Phase 1 Tools', () => {
     expect(pass.success).toBe(true);
     expect(pass.reason).toBe('hatched');
     expect(pass.payload_b64).toBe(payloadB64);
+  });
+
+  it('strips active HTML content without regex tag filtering', () => {
+    const html = '<div>Hello <script>alert(1)</script><style>.x{}</style><strong>world</strong><!--gone--></div>';
+    expect(stripHtml(html)).toBe('Hello world');
   });
 });
 

--- a/tests/test_lattice25d_ops.py
+++ b/tests/test_lattice25d_ops.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
 from hydra.lattice25d_ops import (
     NoteRecord,
     build_lattice25d_payload,
+    load_notes_from_glob,
     metric_tags,
     sample_notes,
     text_metrics,
@@ -66,3 +69,9 @@ def test_sample_notes_builder_count():
     notes = sample_notes(7)
     assert len(notes) == 7
     assert notes[0].note_id.startswith("sample-")
+
+
+@pytest.mark.parametrize("pattern", ["../**/*.md", "C:/Windows/**/*.md"])
+def test_load_notes_from_glob_rejects_unsafe_patterns(pattern: str):
+    with pytest.raises(ValueError, match="notes_glob"):
+        load_notes_from_glob(pattern)

--- a/tests/test_scbe_n8n_bridge_security.py
+++ b/tests/test_scbe_n8n_bridge_security.py
@@ -149,7 +149,10 @@ async def test_workflow_lattice25d_includes_notion_notes(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_workflow_lattice25d_hf_export_staged(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
-    out_path = tmp_path / "lattice_export.jsonl"
+    repo_root = tmp_path / "repo-root"
+    repo_root.mkdir()
+    monkeypatch.setattr(bridge, "_PROJECT", str(repo_root))
+    out_path = repo_root / "artifacts" / "hf" / "lattice_export.jsonl"
 
     req = bridge.Lattice25DRequest.model_validate(
         {
@@ -164,7 +167,7 @@ async def test_workflow_lattice25d_hf_export_staged(monkeypatch, tmp_path) -> No
                 }
             ],
             "include_repo_notes": False,
-            "hf_output_path": str(out_path),
+            "hf_output_path": "artifacts/hf/lattice_export.jsonl",
             "hf_dataset_repo": "issdandavis/scbe-lattice-notes",
             "hf_push": False,
         }
@@ -177,3 +180,76 @@ async def test_workflow_lattice25d_hf_export_staged(monkeypatch, tmp_path) -> No
     assert len(lines) == 1
     first = json.loads(lines[0])
     assert first["note_id"] == "n1"
+
+
+def test_resolve_repo_relative_output_path_rejects_absolute_path(tmp_path) -> None:
+    with pytest.raises(bridge.HTTPException) as exc:
+        bridge._resolve_repo_relative_output_path(str(tmp_path / "bad.jsonl"))
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_workflow_lattice25d_rejects_invalid_hf_dataset_repo(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
+    repo_root = tmp_path / "repo-root"
+    repo_root.mkdir()
+    monkeypatch.setattr(bridge, "_PROJECT", str(repo_root))
+
+    req = bridge.Lattice25DRequest.model_validate(
+        {
+            "notes": [
+                {
+                    "note_id": "n1",
+                    "text": "Export note",
+                    "tags": ["export"],
+                    "source": "repo",
+                    "authority": "internal",
+                    "tongue": "DR",
+                }
+            ],
+            "include_repo_notes": False,
+            "hf_output_path": "artifacts/hf/lattice_export.jsonl",
+            "hf_dataset_repo": "../../evil",
+            "hf_push": False,
+        }
+    )
+
+    with pytest.raises(bridge.HTTPException) as exc:
+        await bridge.workflow_lattice25d(req, x_api_key="test-key")
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_workflow_lattice25d_push_requires_allowlisted_repo(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
+    monkeypatch.setattr(bridge, "_HF_ALLOWED_DATASET_REPOS", set())
+    monkeypatch.setattr(bridge, "_HF_ROUTER_TOKEN", "hf_test_token")
+    repo_root = tmp_path / "repo-root"
+    repo_root.mkdir()
+    monkeypatch.setattr(bridge, "_PROJECT", str(repo_root))
+
+    req = bridge.Lattice25DRequest.model_validate(
+        {
+            "notes": [
+                {
+                    "note_id": "n1",
+                    "text": "Export note",
+                    "tags": ["export"],
+                    "source": "repo",
+                    "authority": "internal",
+                    "tongue": "DR",
+                }
+            ],
+            "include_repo_notes": False,
+            "hf_output_path": "artifacts/hf/lattice_export.jsonl",
+            "hf_dataset_repo": "issdandavis/scbe-lattice-notes",
+            "hf_push": True,
+        }
+    )
+
+    with pytest.raises(bridge.HTTPException) as exc:
+        await bridge.workflow_lattice25d(req, x_api_key="test-key")
+
+    assert exc.value.status_code == 403

--- a/workflows/n8n/scbe_n8n_bridge.py
+++ b/workflows/n8n/scbe_n8n_bridge.py
@@ -29,11 +29,12 @@ from __future__ import annotations
 import logging
 import json
 import os
-import subprocess
+import re
 import sys
 import threading
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 from urllib import error as urllib_error
 from urllib import request as urllib_request
@@ -125,6 +126,15 @@ _ANTHROPIC_DEFAULT_MODEL = os.environ.get(
 ).strip()
 _XAI_DEFAULT_MODEL = os.environ.get("SCBE_XAI_MODEL", "grok-beta").strip()
 _HF_DEFAULT_MODEL = os.environ.get("SCBE_HF_MODEL", "Qwen/Qwen2.5-7B-Instruct").strip()
+_HF_DATASET_REPO_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}/[A-Za-z0-9][A-Za-z0-9._-]{0,95}$"
+)
+_HF_ALLOWED_DATASET_REPOS = {
+    repo.strip().lower()
+    for repo in os.environ.get("SCBE_HF_ALLOWED_DATASET_REPOS", "").split(",")
+    if repo.strip()
+}
+_HF_COMMIT_MESSAGE_MAX_LEN = 120
 
 
 def _check_key(api_key: Optional[str] = None):
@@ -1272,19 +1282,27 @@ def _fetch_notion_notes(
     return notes
 
 
-def _write_lattice_jsonl(payload: Dict[str, Any], output_path: str) -> Dict[str, Any]:
-    from pathlib import Path
-
-    out = Path(output_path)
-    if not out.is_absolute():
-        out = Path(_PROJECT) / out
-    # Guard against path traversal
-    _safe_root = Path(_PROJECT).resolve()
-    out = out.resolve()
+def _resolve_repo_relative_output_path(output_path: str) -> Path:
+    candidate = Path((output_path or "").strip())
+    if candidate.is_absolute():
+        raise HTTPException(status_code=400, detail="Output path must be repo-relative")
+    if not candidate.parts:
+        raise HTTPException(status_code=400, detail="Output path is required")
+    if any(part in {"..", ""} for part in candidate.parts):
+        raise HTTPException(status_code=400, detail="Invalid output path")
+    safe_root = Path(_PROJECT).resolve()
+    out = safe_root.joinpath(*candidate.parts).resolve(strict=False)
     try:
-        out.relative_to(_safe_root)
+        out.relative_to(safe_root)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="Invalid output path") from exc
+    if out.suffix.lower() != ".jsonl":
+        raise HTTPException(status_code=400, detail="Output path must end with .jsonl")
+    return out
+
+
+def _write_lattice_jsonl(payload: Dict[str, Any], output_path: str) -> Dict[str, Any]:
+    out = _resolve_repo_relative_output_path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
 
     rows = payload.get("notes", []) if isinstance(payload.get("notes"), list) else []
@@ -1307,6 +1325,80 @@ def _write_lattice_jsonl(payload: Dict[str, Any], output_path: str) -> Dict[str,
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
             line_count += 1
     return {"path": str(out), "rows": line_count}
+
+
+def _validate_hf_dataset_repo(repo_id: str) -> str:
+    normalized = (repo_id or "").strip()
+    if not normalized or not _HF_DATASET_REPO_RE.fullmatch(normalized):
+        raise HTTPException(
+            status_code=400,
+            detail="hf_dataset_repo must match 'owner/name' using only letters, numbers, '.', '_' or '-'.",
+        )
+    return normalized
+
+
+def _sanitize_hf_commit_message(message: str) -> str:
+    normalized = " ".join(str(message or "").replace("\r", " ").replace("\n", " ").split())
+    if not normalized:
+        return "feat(dataset): lattice25d notes export"
+    if len(normalized) > _HF_COMMIT_MESSAGE_MAX_LEN:
+        raise HTTPException(
+            status_code=400,
+            detail=f"hf_commit_message must be {_HF_COMMIT_MESSAGE_MAX_LEN} characters or fewer.",
+        )
+    return normalized
+
+
+def _upload_lattice25d_export_to_hf(
+    *,
+    repo_id: str,
+    local_path: str,
+    commit_message: str,
+    create_pr: bool,
+) -> Dict[str, Any]:
+    allowed = _HF_ALLOWED_DATASET_REPOS
+    repo_id = _validate_hf_dataset_repo(repo_id)
+    if not allowed:
+        raise HTTPException(
+            status_code=403,
+            detail="HF push is disabled until SCBE_HF_ALLOWED_DATASET_REPOS is configured.",
+        )
+    if repo_id.lower() not in allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=f"HF push blocked for non-allowlisted dataset repo: {repo_id}",
+        )
+    if not _HF_ROUTER_TOKEN:
+        raise HTTPException(status_code=503, detail="HF token not configured for dataset upload.")
+
+    try:
+        from huggingface_hub import HfApi
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="huggingface_hub is required for dataset upload.",
+        ) from exc
+
+    remote_path = f"lattice25d/{Path(local_path).name}"
+    api = HfApi(token=_HF_ROUTER_TOKEN)
+    try:
+        api.upload_file(
+            path_or_fileobj=local_path,
+            path_in_repo=remote_path,
+            repo_id=repo_id,
+            repo_type="dataset",
+            commit_message=commit_message,
+            create_pr=create_pr,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"HF dataset upload failed: {exc}") from exc
+
+    return {
+        "status": "uploaded",
+        "dataset_repo": repo_id,
+        "path_in_repo": remote_path,
+        "create_pr": create_pr,
+    }
 
 
 @app.post("/v1/workflow/lattice25d")
@@ -1369,14 +1461,17 @@ async def workflow_lattice25d(
     if req.include_repo_notes:
         remaining = max(0, int(req.max_notes) - len(notes))
         if remaining > 0:
-            notes.extend(
-                load_notes_from_glob(
-                    pattern=req.notes_glob,
-                    max_notes=remaining,
-                    source="repo",
-                    authority="internal",
+            try:
+                notes.extend(
+                    load_notes_from_glob(
+                        pattern=req.notes_glob,
+                        max_notes=remaining,
+                        source="repo",
+                        authority="internal",
+                    )
                 )
-            )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     if not notes:
         raise HTTPException(
@@ -1406,32 +1501,17 @@ async def workflow_lattice25d(
         export_result["status"] = "written"
 
         if req.hf_dataset_repo:
-            export_result["dataset_repo"] = req.hf_dataset_repo
+            dataset_repo = _validate_hf_dataset_repo(req.hf_dataset_repo)
+            export_result["dataset_repo"] = dataset_repo
             if req.hf_push:
-                cmd = [
-                    "hf",
-                    "upload",
-                    req.hf_dataset_repo,
-                    export_result["path"],
-                    f"lattice25d/{os.path.basename(export_result['path'])}",
-                    "--repo-type",
-                    "dataset",
-                    "--commit-message",
-                    req.hf_commit_message,
-                ]
-                if req.hf_create_pr:
-                    cmd.append("--create-pr")
-                proc = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    timeout=180,
+                export_result.update(
+                    _upload_lattice25d_export_to_hf(
+                        repo_id=dataset_repo,
+                        local_path=export_result["path"],
+                        commit_message=_sanitize_hf_commit_message(req.hf_commit_message),
+                        create_pr=req.hf_create_pr,
+                    )
                 )
-                if proc.returncode == 0:
-                    export_result["status"] = "uploaded"
-                else:
-                    export_result["status"] = "upload_error"
-                    export_result["error"] = (proc.stderr or proc.stdout)[-2000:]
             else:
                 export_result["status"] = "staged"
         payload["hf_export"] = export_result


### PR DESCRIPTION
## What
- harden the n8n bridge HF export path and dataset push controls
- tighten lattice25d note loading and root-scoped glob handling
- validate and encode the Zoom host email before constructing API paths
- replace the MCP regex HTML stripper with a parser-style sanitizer
- remove the fast-hash password fallback in `rwp_v3`

## Why
- GitHub code scanning currently reports critical/high alerts in these surfaces on `main`
- this batch is the highest-value cluster with an already proven fix set

## Verification
- `python -m pytest tests/test_scbe_n8n_bridge_security.py tests/test_lattice25d_ops.py tests/crypto/test_rwp_v3.py -v`
- `npm run typecheck`
- `npx vitest run tests/conference/zoom.test.ts tests/mcp/scbe-server.phase1.test.ts`

## Expected alert impact
- critical: `js/request-forgery` in `conference-app/src/api/services/zoom.ts`
- critical/high: `py/command-line-injection` and `py/path-injection` in `workflows/n8n/scbe_n8n_bridge.py`
- high: `py/path-injection` in `hydra/lattice25d_ops.py`
- high: `js/bad-tag-filter` and `js/incomplete-multi-character-sanitization` in `mcp/scbe-server/server.mjs`
- high: `py/weak-sensitive-data-hashing` in `src/crypto/rwp_v3.py`
