### PR TITLE
fix(security): redact sensitive script outputs

### DIFF
--- a/scripts/scbe-system-cli.py
+++ b/scripts/scbe-system-cli.py
@@ -13,6 +13,7 @@ Commands:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -31,6 +32,10 @@ DEFAULT_PAD_ROOT = Path(".scbe") / "polly-pads"
 DEFAULT_AGENT_REGISTRY = Path(".scbe") / "agent_squad.json"
 DEFAULT_NOTEBOOKLM_PAD_ID = "notebooklm-main"
 DEFAULT_NOTEBOOKLM_URL = "https://notebooklm.google.com/notebook/bf1e9a1b-b49c-4343-8f0e-8494546e4f24"
+BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-~+/=]+\b")
+KEY_VALUE_PATTERN = re.compile(
+    r"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)[A-Z0-9_]*)\s*[:=]\s*([^\s,;]+)"
+)
 
 
 def _run_script(script: Path, args: list[str]) -> int:
@@ -39,6 +44,38 @@ def _run_script(script: Path, args: list[str]) -> int:
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _redact_sensitive_text(value: str) -> str:
+    text = str(value)
+    text = BEARER_PATTERN.sub("Bearer [redacted]", text)
+    text = KEY_VALUE_PATTERN.sub(lambda match: f"{match.group(1)}=[redacted]", text)
+    return text
+
+
+def _sanitize_agent_result_for_disk(result: dict) -> dict:
+    sanitized = {
+        "ok": bool(result.get("ok", False)),
+        "agent_id": result.get("agent_id"),
+        "provider": result.get("provider"),
+    }
+    for key in ("model", "mode", "message", "notebook_url", "generated_at"):
+        if key in result:
+            sanitized[key] = result.get(key)
+
+    content = result.get("content")
+    if isinstance(content, str) and content:
+        sanitized["content_char_count"] = len(content)
+        sanitized["content_sha256"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+    error = result.get("error")
+    if error:
+        sanitized["error"] = _redact_sensitive_text(str(error))
+
+    if result.get("output_path"):
+        sanitized["output_path"] = result.get("output_path")
+
+    return sanitized
 
 
 def _pad_root(repo_root: Path) -> Path:
@@ -211,7 +248,6 @@ def _call_openai_agent(agent: dict, prompt: str, output_dir: Path, env_cache: di
             "agent_id": agent.get("agent_id"),
             "provider": provider,
             "model": model,
-            "raw": response_obj,
             "content": content,
             "output_path": str((output_dir / f"{agent.get('agent_id')}_openai.json").resolve()) if output_dir else None,
         }
@@ -235,7 +271,8 @@ def _call_openai_agent(agent: dict, prompt: str, output_dir: Path, env_cache: di
 def _write_agent_call_result(output_dir: Path, agent_id: str, result: dict) -> str:
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / f"{agent_id}_agent_call.json"
-    path.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+    sanitized = _sanitize_agent_result_for_disk(result)
+    path.write_text(json.dumps(sanitized, indent=2, sort_keys=True), encoding="utf-8")
     return str(path)
 
 
@@ -266,11 +303,14 @@ def _notebooklm_fallback(agent: dict, prompt: str, output_dir: Path) -> dict:
             "NotebookLM has no documented public REST API endpoint in this code path. "
             "Use the web UI with the notebook id and paste this prompt."
         ),
-        "prompt": prompt,
         "notebook_url": notebook_url,
         "generated_at": _now_iso(),
+        "content": prompt,
     }
-    path.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+    path.write_text(
+        json.dumps(_sanitize_agent_result_for_disk(result), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
     result["output_path"] = str(path)
     return result
 
@@ -893,11 +933,11 @@ def cmd_agent_call(args: argparse.Namespace) -> int:
             summary["succeeded"] += 1
             if args.show_output:
                 print(f"\n[{aid}]")
-                print(result.get("content", ""))
+                print(_redact_sensitive_text(result.get("content", "")))
         else:
             summary["failed"] += 1
             if args.show_output:
-                print(f"[{aid}] FAIL: {result.get('error')}")
+                print(f"[{aid}] FAIL: {_redact_sensitive_text(result.get('error', ''))}")
 
     summary_path = out_dir / "agent_call_summary.json"
     summary_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/system/sell_from_terminal.py
+++ b/scripts/system/sell_from_terminal.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -24,6 +25,12 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from src.security.secret_store import get_secret  # noqa: E402
+
+
+BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-~+/=]+\b")
+KEY_VALUE_PATTERN = re.compile(
+    r"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)[A-Z0-9_]*)\s*[:=]\s*([^\s,;]+)"
+)
 
 
 def _now_utc() -> str:
@@ -38,7 +45,30 @@ def _mask(value: str) -> str:
     return f"{value[:4]}...{value[-4:]}"
 
 
-def _load_secret_env() -> dict[str, str]:
+def _redact_sensitive_text(value: str) -> str:
+    text = str(value)
+    text = BEARER_PATTERN.sub("Bearer [redacted]", text)
+    text = KEY_VALUE_PATTERN.sub(lambda match: f"{match.group(1)}=[redacted]", text)
+    return text
+
+
+def _summarize_process_result(command: list[str], proc: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    stdout = _redact_sensitive_text(proc.stdout.strip())
+    stderr = _redact_sensitive_text(proc.stderr.strip())
+    summary: dict[str, Any] = {
+        "command": " ".join(command),
+        "returncode": proc.returncode,
+        "stdout_present": bool(stdout),
+        "stderr_present": bool(stderr),
+    }
+    if proc.returncode != 0 and stderr:
+        summary["error_excerpt"] = stderr[:240]
+    elif proc.returncode != 0 and stdout:
+        summary["error_excerpt"] = stdout[:240]
+    return summary
+
+
+def _load_secret_env() -> dict[str, int]:
     keys = [
         "SHOPIFY_SHOP",
         "SHOPIFY_SHOP_DOMAIN",
@@ -56,29 +86,34 @@ def _load_secret_env() -> dict[str, str]:
         "GITHUB_TOKEN",
         "NOTION_TOKEN",
     ]
-    status: dict[str, str] = {}
+    summary = {
+        "present_in_env": 0,
+        "loaded_from_store": 0,
+        "missing": 0,
+        "aliases_applied": 0,
+    }
 
     for key in keys:
         existing = os.getenv(key, "").strip()
         if existing:
-            status[key] = _mask(existing)
+            summary["present_in_env"] += 1
             continue
 
         stored = get_secret(key, "").strip()
         if stored:
             os.environ[key] = stored
-            status[key] = _mask(stored)
+            summary["loaded_from_store"] += 1
         else:
-            status[key] = "missing"
+            summary["missing"] += 1
 
     # Common Shopify alias fallback.
     if not os.getenv("SHOPIFY_SHOP", "").strip():
         alias = os.getenv("SHOPIFY_SHOP_DOMAIN", "").strip()
         if alias:
             os.environ["SHOPIFY_SHOP"] = alias
-            status["SHOPIFY_SHOP"] = _mask(alias)
+            summary["aliases_applied"] += 1
 
-    return status
+    return summary
 
 
 def _run_cmd(cmd: list[str], *, timeout: int = 180) -> dict[str, Any]:
@@ -90,12 +125,7 @@ def _run_cmd(cmd: list[str], *, timeout: int = 180) -> dict[str, Any]:
         timeout=timeout,
         check=False,
     )
-    return {
-        "command": " ".join(cmd),
-        "returncode": proc.returncode,
-        "stdout": proc.stdout.strip(),
-        "stderr": proc.stderr.strip(),
-    }
+    return _summarize_process_result(cmd, proc)
 
 
 def _connector_health() -> dict[str, Any]:
@@ -120,12 +150,18 @@ def _connector_health() -> dict[str, Any]:
         check=False,
         env=env,
     )
-    return {
-        "command": "python scripts/connector_health_check.py --checks github notion huggingface zapier",
-        "returncode": proc.returncode,
-        "stdout": proc.stdout.strip(),
-        "stderr": proc.stderr.strip(),
-    }
+    return _summarize_process_result(
+        [
+            "python",
+            "scripts/connector_health_check.py",
+            "--checks",
+            "github",
+            "notion",
+            "huggingface",
+            "zapier",
+        ],
+        proc,
+    )
 
 
 def main() -> int:
@@ -147,7 +183,7 @@ def main() -> int:
 
     report: dict[str, Any] = {
         "generated_at_utc": _now_utc(),
-        "secret_status": _load_secret_env(),
+        "secret_summary": _load_secret_env(),
         "actions": [],
     }
 
@@ -184,8 +220,8 @@ def main() -> int:
     out.write_text(json.dumps(report, indent=2), encoding="utf-8")
 
     print(f"report={out.resolve()}")
-    print("secret_status:")
-    for key, value in report["secret_status"].items():
+    print("secret_summary:")
+    for key, value in report["secret_summary"].items():
         print(f"  {key}={value}")
 
     for action in report["actions"]:

--- a/scripts/system/terminal_ai_router.py
+++ b/scripts/system/terminal_ai_router.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -46,6 +47,15 @@ DEFAULT_COMPLEXITY_TIERS = {
     "hard": ["cheap", "standard", "premium"],
 }
 
+SENSITIVE_KEY_PATTERN = re.compile(
+    r"(?i)(api[_-]?key|token|secret|password|authorization|bearer|cookie|session)"
+)
+BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._\-~+/=]+\b")
+KEY_VALUE_PATTERN = re.compile(
+    r"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD)[A-Z0-9_]*)\s*[:=]\s*([^\s,;]+)"
+)
+SECRET_DETAIL_KEYS = {"accepted_keys", "key_name", "key_source", "response", "response_excerpt", "raw"}
+
 
 if str(REPO_ROOT) not in os.sys.path:
     os.sys.path.insert(0, str(REPO_ROOT))
@@ -75,6 +85,64 @@ def _read_json(path: Path, default: Any) -> Any:
 def _write_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _redact_sensitive_text(value: str) -> str:
+    text = str(value)
+    text = BEARER_PATTERN.sub("Bearer [redacted]", text)
+    text = KEY_VALUE_PATTERN.sub(lambda match: f"{match.group(1)}=[redacted]", text)
+    return text
+
+
+def _sanitize_public_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for key, child in value.items():
+            if key in SECRET_DETAIL_KEYS:
+                continue
+            if SENSITIVE_KEY_PATTERN.search(key):
+                if isinstance(child, bool):
+                    sanitized[key] = child
+                elif child in (None, "", [], {}):
+                    sanitized[key] = child
+                else:
+                    sanitized[key] = "[redacted]"
+                continue
+            sanitized[key] = _sanitize_public_value(child)
+        return sanitized
+    if isinstance(value, list):
+        return [_sanitize_public_value(item) for item in value]
+    if isinstance(value, str):
+        return _redact_sensitive_text(value)
+    return value
+
+
+def _summarize_alias_sync(alias_sync: dict[str, Any]) -> dict[str, int]:
+    summary: dict[str, int] = {"set": 0, "synced": 0, "missing": 0}
+    for item in alias_sync.values():
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status", "")).strip().lower()
+        if status in summary:
+            summary[status] += 1
+    return summary
+
+
+def _build_public_health_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    public_payload = {
+        "generated_at_utc": payload.get("generated_at_utc"),
+        "config_path": payload.get("config_path"),
+        "checks": payload.get("checks", []),
+        "alias_sync_summary": _summarize_alias_sync(payload.get("alias_sync", {})),
+        "status": {},
+    }
+    status_map = payload.get("status", {})
+    if isinstance(status_map, dict):
+        public_payload["status"] = {
+            str(provider): _sanitize_public_value(result)
+            for provider, result in status_map.items()
+        }
+    return public_payload
 
 
 def _request_json(
@@ -312,8 +380,9 @@ def run_health(args: argparse.Namespace) -> int:
         "alias_sync": alias_sync,
         "status": status_map,
     }
-    _write_json(Path(args.output), payload)
-    print(json.dumps(payload, indent=2))
+    public_payload = _build_public_health_payload(payload)
+    _write_json(Path(args.output), public_payload)
+    print(json.dumps(public_payload, indent=2))
 
     if args.strict:
         failing = [name for name, val in status_map.items() if val.get("status") != "ok"]
@@ -574,7 +643,6 @@ def run_call(args: argparse.Namespace) -> int:
                         "model": model,
                         "status": "skipped",
                         "reason": "missing_api_key",
-                        "accepted_keys": key_candidates,
                     }
                 )
                 continue
@@ -650,11 +718,9 @@ def run_call(args: argparse.Namespace) -> int:
                     "provider": provider,
                     "tier": tier,
                     "model": model,
-                    "key_name": key_name,
-                    "key_source": key_source,
                     "status": "ok" if ok else "failed",
                     "http_status": http_status,
-                    "error": error,
+                    "error": _redact_sensitive_text(error),
                 }
             )
 
@@ -678,10 +744,13 @@ def run_call(args: argparse.Namespace) -> int:
                 final_text = text.strip()
                 break
 
-            # Keep the last raw error payload for troubleshooting without leaking keys.
-            attempts[-1]["response_excerpt"] = (
-                body if isinstance(body, (dict, list)) else str(body)
-            )
+            if body:
+                if isinstance(body, dict):
+                    excerpt = body.get("error") or body.get("message") or body.get("detail") or ""
+                else:
+                    excerpt = str(body)
+                if excerpt:
+                    attempts[-1]["error_detail"] = _redact_sensitive_text(str(excerpt))[:240]
         if selected:
             break
 
@@ -696,7 +765,7 @@ def run_call(args: argparse.Namespace) -> int:
         "tiers_tried": tiers,
         "selected": selected,
         "attempts": attempts,
-        "response": final_text,
+        "response": _redact_sensitive_text(final_text),
         "ledger_path": str(ledger_path.resolve()),
     }
     _write_json(Path(args.output), result)

--- a/tests/test_sensitive_output_redaction.py
+++ b/tests/test_sensitive_output_redaction.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+src_module = sys.modules.setdefault("src", types.ModuleType("src"))
+security_module = sys.modules.setdefault("src.security", types.ModuleType("src.security"))
+secret_store_module = types.ModuleType("src.security.secret_store")
+secret_store_module.get_secret = lambda key, default="": default
+secret_store_module.set_secret = lambda key, value, note="": None
+sys.modules["src.security.secret_store"] = secret_store_module
+setattr(src_module, "security", security_module)
+
+
+def _load_module(name: str, relative_path: str):
+    path = REPO_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+terminal_ai_router = _load_module("test_terminal_ai_router", "scripts/system/terminal_ai_router.py")
+sell_from_terminal = _load_module("test_sell_from_terminal", "scripts/system/sell_from_terminal.py")
+scbe_system_cli = _load_module("test_scbe_system_cli", "scripts/scbe-system-cli.py")
+
+
+def test_terminal_ai_router_public_payload_strips_secret_metadata() -> None:
+    payload = {
+        "generated_at_utc": "2026-03-14T00:00:00Z",
+        "config_path": "config.json",
+        "checks": ["openai"],
+        "alias_sync": {
+            "OPENAI_API_KEY": {"status": "synced", "source": "OPENAI_KEY"},
+            "ANTHROPIC_API_KEY": {"status": "missing", "source": None},
+        },
+        "status": {
+            "openai": {
+                "status": "degraded",
+                "detail": {
+                    "http_status": 401,
+                    "key_name": "OPENAI_API_KEY",
+                    "key_source": "env",
+                    "accepted_keys": ["OPENAI_API_KEY"],
+                    "error": "Authorization: Bearer super-secret-token",
+                },
+            }
+        },
+    }
+
+    public_payload = terminal_ai_router._build_public_health_payload(payload)
+
+    assert public_payload["alias_sync_summary"] == {"set": 0, "synced": 1, "missing": 1}
+    detail = public_payload["status"]["openai"]["detail"]
+    assert "key_name" not in detail
+    assert "key_source" not in detail
+    assert "accepted_keys" not in detail
+    assert "super-secret-token" not in detail["error"]
+    assert "[redacted]" in detail["error"]
+
+
+def test_sell_from_terminal_process_summary_omits_raw_streams() -> None:
+    class Proc:
+        returncode = 1
+        stdout = "OPENAI_API_KEY=abc123"
+        stderr = "Authorization: Bearer super-secret-token"
+
+    summary = sell_from_terminal._summarize_process_result(["python", "tool.py"], Proc())
+
+    assert summary["returncode"] == 1
+    assert summary["stdout_present"] is True
+    assert summary["stderr_present"] is True
+    assert "stdout" not in summary
+    assert "stderr" not in summary
+    assert "[redacted]" in summary["error_excerpt"]
+
+
+def test_scbe_system_cli_sanitize_agent_result_for_disk_omits_content() -> None:
+    result = {
+        "ok": True,
+        "agent_id": "codex",
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "content": "password=hunter2",
+        "raw": {"secret": "x"},
+        "prompt": "secret prompt",
+    }
+
+    sanitized = scbe_system_cli._sanitize_agent_result_for_disk(result)
+
+    assert sanitized["ok"] is True
+    assert sanitized["agent_id"] == "codex"
+    assert "content" not in sanitized
+    assert "raw" not in sanitized
+    assert "prompt" not in sanitized
+    assert sanitized["content_char_count"] == len("password=hunter2")
+    assert len(sanitized["content_sha256"]) == 64


### PR DESCRIPTION
## What
- stop writing secret-derived metadata into terminal AI router health/call reports
- replace per-key secret status output in `sell_from_terminal` with aggregated secret summaries
- stop persisting raw subprocess stdout/stderr in sell-lane reports
- sanitize `scbe-system-cli` agent result files and redact printed output/error text
- add focused regression tests for public output redaction

## Why
- GitHub code scanning still reports high-severity clear-text logging and storage alerts in these script surfaces
- the shared problem is that these tools were persisting or printing secret-adjacent metadata and raw outputs

## Verification
- `python -m py_compile scripts/system/terminal_ai_router.py scripts/system/sell_from_terminal.py scripts/scbe-system-cli.py tests/test_sensitive_output_redaction.py`
- `python -m pytest tests/test_sensitive_output_redaction.py -q`

## Expected alert impact
- high: `py/clear-text-logging-sensitive-data` in `scripts/system/terminal_ai_router.py`
- high: `py/clear-text-storage-sensitive-data` in `scripts/system/terminal_ai_router.py`
- high: `py/clear-text-logging-sensitive-data` in `scripts/system/sell_from_terminal.py`
- high: `py/clear-text-storage-sensitive-data` in `scripts/system/sell_from_terminal.py`
- high: `py/clear-text-logging-sensitive-data` in `scripts/scbe-system-cli.py`
- high: `py/clear-text-storage-sensitive-data` in `scripts/scbe-system-cli.py`
