### PR TITLE
fix(ci): add least-privilege workflow permissions

### DIFF
--- a/.github/workflows/arxiv-paper-gen.yml
+++ b/.github/workflows/arxiv-paper-gen.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'paper-v*'
 
+permissions:
+  contents: read
+
 jobs:
   build-arxiv:
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-repo-sync.yml
+++ b/.github/workflows/cross-repo-sync.yml
@@ -17,6 +17,9 @@ on:
           - from-gumroad
           - bidirectional
 
+permissions:
+  contents: read
+
 env:
   TARGET_REPO: issdandavis/gumroad-automation-demo
   SHARED_PATHS: |

--- a/.github/workflows/daily_ops.yml
+++ b/.github/workflows/daily_ops.yml
@@ -15,6 +15,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 env:
   VM_IP: "34.134.99.90"
   VM_PORT: "8001"

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -12,6 +12,9 @@ on:
           - production
           - staging
 
+permissions:
+  contents: read
+
 env:
   AWS_REGION: us-west-2
   PYTHON_VERSION: '3.11'

--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -12,6 +12,9 @@ on:
           - production
           - staging
 
+permissions:
+  contents: read
+
 env:
   AWS_REGION: us-west-2
   EKS_CLUSTER: scbe-test-cluster

--- a/.github/workflows/huggingface-sync.yml
+++ b/.github/workflows/huggingface-sync.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 6 * * 1'  # Weekly on Mondays (was daily)
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   PRIMARY_HF_REPO: issdandavis/spiralverse-ai-federated-v1
   BACKUP_HF_REPO: issdandavis/phdm-21d-embedding

--- a/.github/workflows/kindle-build.yml
+++ b/.github/workflows/kindle-build.yml
@@ -12,6 +12,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: 'true'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/scbe-gates.yml
+++ b/.github/workflows/scbe-gates.yml
@@ -18,6 +18,9 @@ on:
   push:
     branches: [ main, 'claude/**' ]
 
+permissions:
+  contents: read
+
 jobs:
   reusable-gates:
     uses: ./.github/workflows/scbe-reusable-gates.yml

--- a/.github/workflows/scbe-reusable-gates.yml
+++ b/.github/workflows/scbe-reusable-gates.yml
@@ -14,6 +14,9 @@ on:
         default: '3.11'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   core-gates:
     runs-on: ubuntu-latest

--- a/.github/workflows/scbe-tests.yml
+++ b/.github/workflows/scbe-tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/scbe.yml
+++ b/.github/workflows/scbe.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/six-tongues-tests.yml
+++ b/.github/workflows/six-tongues-tests.yml
@@ -14,6 +14,9 @@ on:
       - 'requirements*.txt'
       - '.github/workflows/six-tongues-tests.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Six Tongues Selftest
@@ -49,9 +52,4 @@ jobs:
 
       - name: Verify bijective mapping integrity
         run: |
-          python -c "
-import sys
-print('Python version:', sys.version)
-print('Six Tongues CI/CD pipeline ready')
-print('Bijective mapping tests will run when aethermoore.py is committed')
-"
+          python -c "import sys; print('Python version:', sys.version); print('Six Tongues CI/CD pipeline ready'); print('Bijective mapping tests will run when aethermoore.py is committed')"

--- a/.github/workflows/validate-layer-manifest.yml
+++ b/.github/workflows/validate-layer-manifest.yml
@@ -16,6 +16,9 @@ on:
       - scripts/validate_layer_manifest.py
       - .github/workflows/validate-layer-manifest.yml
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 9 * * 1'  # Every Monday at 9 AM UTC
   workflow_dispatch:  # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   npm-audit:
     runs-on: ubuntu-latest
@@ -183,33 +186,7 @@ jobs:
           echo "- pip-audit high: ${{ steps.check_vulns.outputs.pip_high }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Total critical: ${{ steps.check_vulns.outputs.total_critical }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Total high: ${{ steps.check_vulns.outputs.total_high }}" >> "$GITHUB_STEP_SUMMARY"
-          python3 - <<'PY'
-import json
-import os
-from pathlib import Path
-
-reports_dir = Path('./reports')
-npm_critical = 0
-pip_critical = 0
-
-npm_report = reports_dir / 'npm-audit.json'
-if npm_report.exists():
-    npm_data = json.loads(npm_report.read_text(encoding='utf-8'))
-    npm_critical = int(npm_data.get('metadata', {}).get('vulnerabilities', {}).get('critical', 0) or 0)
-
-pip_report = reports_dir / 'pip-audit.json'
-if pip_report.exists():
-    pip_data = json.loads(pip_report.read_text(encoding='utf-8'))
-    if isinstance(pip_data, list):
-        pip_critical = sum(1 for finding in pip_data if str(finding.get('severity', '')).lower() == 'critical')
-
-total_critical = npm_critical + pip_critical
-output_file = os.environ['GITHUB_OUTPUT']
-with open(output_file, 'a', encoding='utf-8') as fh:
-    fh.write(f'npm_critical={npm_critical}\n')
-    fh.write(f'pip_critical={pip_critical}\n')
-    fh.write(f'total_critical={total_critical}\n')
-PY
+          python3 -c "import json, os; from pathlib import Path; reports_dir = Path('./reports'); npm_report = reports_dir / 'npm-audit.json'; pip_report = reports_dir / 'pip-audit.json'; npm_critical = int(json.loads(npm_report.read_text(encoding='utf-8')).get('metadata', {}).get('vulnerabilities', {}).get('critical', 0) or 0) if npm_report.exists() else 0; pip_payload = json.loads(pip_report.read_text(encoding='utf-8')) if pip_report.exists() else []; pip_critical = sum(1 for finding in pip_payload if isinstance(pip_payload, list) and str(finding.get('severity', '')).lower() == 'critical'); total_critical = npm_critical + pip_critical; output_file = os.environ['GITHUB_OUTPUT']; open(output_file, 'a', encoding='utf-8').write(f'npm_critical={npm_critical}\\npip_critical={pip_critical}\\ntotal_critical={total_critical}\\n')"
 
       - name: Create issue if critical vulnerabilities found
         if: fromJSON(steps.check_vulns.outputs.total_critical) > 0


### PR DESCRIPTION
## What
- add explicit top-level `permissions: contents: read` to the currently flagged GitHub Actions workflows
- preserve existing job-level write permissions where release or issue creation already needs them
- fix two pre-existing YAML block issues in `six-tongues-tests.yml` and `weekly-security-audit.yml` so the touched workflows parse cleanly

## Why
GitHub code scanning currently reports a large `actions/missing-workflow-permissions` cluster. This batch applies least-privilege defaults to the affected workflows without changing their job logic.

## How
Updated these workflows:
- `.github/workflows/arxiv-paper-gen.yml`
- `.github/workflows/cross-repo-sync.yml`
- `.github/workflows/daily_ops.yml`
- `.github/workflows/deploy-aws.yml`
- `.github/workflows/deploy-eks.yml`
- `.github/workflows/huggingface-sync.yml`
- `.github/workflows/kindle-build.yml`
- `.github/workflows/release-and-deploy.yml`
- `.github/workflows/scbe-gates.yml`
- `.github/workflows/scbe-reusable-gates.yml`
- `.github/workflows/scbe-tests.yml`
- `.github/workflows/scbe.yml`
- `.github/workflows/six-tongues-tests.yml`
- `.github/workflows/validate-layer-manifest.yml`
- `.github/workflows/weekly-security-audit.yml`

## Test Evidence
- `python -c "import yaml, pathlib; files=[...] ; [yaml.safe_load((pathlib.Path('.github/workflows')/f).read_text(encoding='utf-8')) for f in files]; print('ok', len(files))"`
  - result: `ok 15`

## Rollback
- revert this PR; it only changes workflow metadata and two inline script blocks
