### PR TITLE
feat(ops): add AI terminal GitHub sweep workflow

### DIFF
--- a/docs/operations/AI_TERMINAL_GITHUB_MANAGEMENT.md
+++ b/docs/operations/AI_TERMINAL_GITHUB_MANAGEMENT.md
@@ -1,0 +1,193 @@
+# AI Terminal GitHub Management
+
+This is the terminal-first workflow for keeping one repo usable while still preserving evidence, outputs, and cloud state.
+
+## What This Solves
+
+- tells you where to run the sweep from
+- generates one sweep summary for local repo state
+- optionally captures GitHub repo inventory
+- gives AI agents one governed packet instead of letting them collide
+- keeps outputs and caches separate from source code
+
+## Where To Run It From
+
+Run from the repo root:
+
+```powershell
+cd C:\Users\issda\SCBE-AETHERMOORE
+python .\scripts\system\run_github_sweep.py --repo-root . --include-github
+```
+
+If you are in another shell location, this also works:
+
+```powershell
+python C:\Users\issda\SCBE-AETHERMOORE\scripts\system\run_github_sweep.py --repo-root C:\Users\issda\SCBE-AETHERMOORE --include-github
+```
+
+## What It Writes
+
+Outputs go to:
+
+- `artifacts/agent-sweeps/github_sweep_latest.json`
+- `artifacts/agent-sweeps/github_repo_inventory_latest.json` when `--include-github` is used
+- `artifacts/repo-hygiene/latest_report.json` when `repo_hygiene.py` exists in the target repo
+
+## Local Cleanup Loop
+
+Use this order:
+
+1. Sweep and classify
+
+```powershell
+python .\scripts\system\run_github_sweep.py --repo-root . --include-github
+```
+
+2. If present, run repo hygiene report
+
+```powershell
+python .\scripts\system\repo_hygiene.py report
+```
+
+3. Snapshot before pruning
+
+```powershell
+python .\scripts\system\repo_hygiene.py snapshot
+```
+
+4. Only prune safe untracked noise
+
+```powershell
+python .\scripts\system\repo_hygiene.py clean --apply
+```
+
+## How To Think About Dirty Files
+
+Dirty does not mean bad. It means your working tree differs from the last commit.
+
+There are four common classes:
+
+- source of truth
+  - code, docs, schemas, workflow templates
+- evidence and outputs
+  - artifacts, training records, reports
+- cache and local app state
+  - reproducible and usually not worth tracking
+- machine-local or temporary state
+  - useful on one PC, not useful as canonical repo history
+
+Examples:
+
+- `src/`, `tests/`, `docs/`, `scripts/` usually stay in repo
+- `artifacts/` and large `training/` outputs usually need archive/cloud strategy
+- `.n8n_local_iso/.cache/n8n/...` is cache, not canonical workflow knowledge
+
+## GitHub Management For AI Agents
+
+First confirm auth:
+
+```powershell
+gh auth status
+```
+
+List repos:
+
+```powershell
+gh repo list issdandavis --limit 100
+```
+
+Open PR queue:
+
+```powershell
+gh pr list --limit 50
+```
+
+Open issues:
+
+```powershell
+gh issue list --limit 50
+```
+
+The rule is:
+
+- do discovery first
+- classify second
+- assign agent lanes third
+- edit only after ownership is explicit
+
+## HYDRA Roundtable Rules
+
+Use the mirrored skill:
+
+- `skills/codex-mirror/scbe-github-sweep-sorter`
+
+Use it with:
+
+- `scbe-ai-to-ai-communication`
+
+Default patterns:
+
+- `scatter`
+  - discovery across many repos or many alerts
+- `hexagonal-ring`
+  - normal collaborative coding on one shared repo
+- `tetrahedral`
+  - smaller high-risk coding packets
+- `ring`
+  - ordered approvals and critical actions
+
+Default quorum guidance:
+
+- low-risk discovery: `3/6`
+- medium-risk changes: `4/6`
+- critical actions: `5/6`
+
+## Naming And Organization Rules
+
+Do not mass-rename the repo in one pass.
+
+Do this instead:
+
+1. classify
+2. move caches out of the way
+3. archive outputs to cloud or a dedicated data lane
+4. rename source paths only when a stable boundary is clear
+
+Good rename candidates are:
+
+- vague root names
+- legacy snapshot roots
+- duplicated app names
+- generated folders pretending to be source
+
+Bad rename candidates are:
+
+- active code paths with imports
+- public package names
+- workflow files currently in use
+
+## Cloud Organization
+
+Use GitHub for:
+
+- canonical source
+- issues, PRs, labels, role topics
+- private asset repos when needed
+
+Use cloud/archive storage for:
+
+- bulky artifacts
+- large training corpora
+- media outputs
+- reproducible reports that do not need to live in main source history
+
+## Current Reality
+
+This repo is not “bad.” It is overloaded.
+
+The fix is not deletion by panic. The fix is:
+
+- source in repo
+- outputs archived
+- cache ignored
+- agents routed through one packet lane

--- a/scripts/system/run_github_sweep.py
+++ b/scripts/system/run_github_sweep.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_ROOT = SCRIPT_REPO_ROOT / "skills" / "codex-mirror" / "scbe-github-sweep-sorter"
+CHOOSE_FORMATION = SKILL_ROOT / "scripts" / "choose_formation.py"
+BUILD_PACKET = SKILL_ROOT / "scripts" / "build_roundtable_packet.py"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run(cmd: list[str], cwd: Path) -> SimpleNamespace:
+    proc = subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=False, check=False)
+    return SimpleNamespace(
+        returncode=proc.returncode,
+        stdout=proc.stdout.decode("utf-8", errors="replace"),
+        stderr=proc.stderr.decode("utf-8", errors="replace"),
+    )
+
+
+def require_file(path: Path) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"Required file not found: {path}")
+
+
+def parse_json_output(raw: str) -> Any:
+    return json.loads(raw.strip())
+
+
+def git_branch(repo_root: Path) -> str:
+    proc = run(["git", "branch", "--show-current"], cwd=repo_root)
+    if proc.returncode != 0:
+        return "unknown"
+    return proc.stdout.strip() or "unknown"
+
+
+def dirty_count_fallback(repo_root: Path) -> int:
+    proc = run(["git", "status", "--short", "--untracked-files=all"], cwd=repo_root)
+    if proc.returncode != 0:
+        return 0
+    return len([line for line in proc.stdout.splitlines() if line.strip()])
+
+
+def risk_from_dirty_count(count: int) -> str:
+    if count >= 1000:
+        return "high"
+    if count >= 100:
+        return "medium"
+    return "low"
+
+
+def maybe_run_repo_hygiene(repo_root: Path) -> dict[str, Any]:
+    repo_hygiene = repo_root / "scripts" / "system" / "repo_hygiene.py"
+    if not repo_hygiene.exists():
+        return {
+            "mode": "fallback",
+            "total_dirty_entries": dirty_count_fallback(repo_root),
+            "latest_report": None,
+        }
+
+    proc = run(["python", str(repo_hygiene), "report"], cwd=repo_root)
+    latest = repo_root / "artifacts" / "repo-hygiene" / "latest_report.json"
+    payload: dict[str, Any] = {
+        "mode": "repo_hygiene",
+        "return_code": proc.returncode,
+        "stdout": proc.stdout[-2000:],
+        "stderr": proc.stderr[-2000:],
+        "latest_report": str(latest) if latest.exists() else None,
+    }
+    if latest.exists():
+        data = json.loads(latest.read_text(encoding="utf-8"))
+        payload["total_dirty_entries"] = int(data.get("total_dirty_entries", 0))
+        payload["counts_by_action"] = data.get("counts_by_action", {})
+        payload["top_tracked_generated_prefixes"] = data.get("tracked_generated_prefixes", [])[:10]
+        payload["top_safe_prune_prefixes"] = data.get("safe_prune_prefixes", [])[:10]
+    else:
+        payload["total_dirty_entries"] = dirty_count_fallback(repo_root)
+    return payload
+
+
+def maybe_collect_github(owner: str, output_dir: Path) -> dict[str, Any]:
+    proc = run(
+        [
+            "gh",
+            "repo",
+            "list",
+            owner,
+            "--limit",
+            "100",
+            "--json",
+            "name,nameWithOwner,isArchived,isPrivate,description,url,updatedAt",
+        ],
+        cwd=SCRIPT_REPO_ROOT,
+    )
+    result: dict[str, Any] = {
+        "enabled": proc.returncode == 0,
+        "return_code": proc.returncode,
+        "stderr": proc.stderr[-1200:],
+        "inventory_path": None,
+    }
+    if proc.returncode != 0:
+        return result
+
+    inventory_path = output_dir / "github_repo_inventory_latest.json"
+    inventory_path.write_text(proc.stdout, encoding="utf-8")
+    repos = json.loads(proc.stdout)
+    result["inventory_path"] = str(inventory_path)
+    result["repo_count"] = len(repos)
+    result["active_count"] = sum(1 for repo in repos if not repo.get("isArchived"))
+    result["archived_count"] = sum(1 for repo in repos if repo.get("isArchived"))
+    result["private_count"] = sum(1 for repo in repos if repo.get("isPrivate"))
+    result["public_count"] = sum(1 for repo in repos if not repo.get("isPrivate"))
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a GitHub/repo sweep using the mirrored SCBE sweep skill.")
+    parser.add_argument("--repo-root", default=".", help="Target repo root to sweep.")
+    parser.add_argument("--owner", default="issdandavis", help="GitHub owner/org for repo inventory.")
+    parser.add_argument("--include-github", action="store_true", help="Also collect GitHub repo inventory with gh.")
+    parser.add_argument("--task-id", default="ai-terminal-sweep", help="Task ID for the roundtable packet.")
+    args = parser.parse_args()
+
+    require_file(CHOOSE_FORMATION)
+    require_file(BUILD_PACKET)
+
+    target_repo_root = Path(args.repo_root).expanduser().resolve()
+    output_dir = target_repo_root / "artifacts" / "agent-sweeps"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    hygiene = maybe_run_repo_hygiene(target_repo_root)
+    dirty_entries = int(hygiene.get("total_dirty_entries", 0))
+    risk = risk_from_dirty_count(dirty_entries)
+
+    github = {"enabled": False}
+    if args.include_github:
+        github = maybe_collect_github(args.owner, output_dir)
+
+    choose_proc = run(
+        [
+            "python",
+            str(CHOOSE_FORMATION),
+            "--repo-count",
+            "1",
+            "--item-count",
+            str(dirty_entries),
+            "--risk",
+            risk,
+            "--needs-discovery",
+        ],
+        cwd=SCRIPT_REPO_ROOT,
+    )
+    if choose_proc.returncode != 0:
+        raise RuntimeError(choose_proc.stderr)
+    formation = parse_json_output(choose_proc.stdout)
+
+    branch = git_branch(target_repo_root)
+    packet_proc = run(
+        [
+            "python",
+            str(BUILD_PACKET),
+            "--repo",
+            target_repo_root.name,
+            "--branch",
+            branch,
+            "--task-id",
+            args.task_id,
+            "--formation",
+            str(formation["formation"]),
+            "--quorum-required",
+            str(formation["quorum_required"]),
+            "--summary",
+            "Classify local repo state and route owned cleanup lanes",
+            "--risk",
+            risk,
+        ],
+        cwd=SCRIPT_REPO_ROOT,
+    )
+    if packet_proc.returncode != 0:
+        raise RuntimeError(packet_proc.stderr)
+    packet = parse_json_output(packet_proc.stdout)
+
+    summary = {
+        "generated_at_utc": utc_now(),
+        "target_repo_root": str(target_repo_root),
+        "branch": branch,
+        "dirty_entries": dirty_entries,
+        "risk": risk,
+        "formation": formation,
+        "packet": packet,
+        "repo_hygiene": hygiene,
+        "github": github,
+    }
+
+    summary_path = output_dir / "github_sweep_latest.json"
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps({"ok": True, "summary_path": str(summary_path), "dirty_entries": dirty_entries, "formation": formation["formation"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex-mirror/README.md
+++ b/skills/codex-mirror/README.md
@@ -1,0 +1,13 @@
+# Codex Mirror
+
+This lane mirrors selected local Codex skills into the repo so terminal workflows can stay in one place.
+
+Current mirrored skill:
+
+- `scbe-github-sweep-sorter`
+
+Use repo-native wrapper:
+
+```powershell
+python .\scripts\system\run_github_sweep.py --repo-root . --include-github
+```

--- a/skills/codex-mirror/scbe-github-sweep-sorter/SKILL.md
+++ b/skills/codex-mirror/scbe-github-sweep-sorter/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: scbe-github-sweep-sorter
+description: Sort GitHub and local repo sweeps into governed agent lanes using HYDRA formations, roundtable role assignments, repo triage buckets, and deterministic handoff packets. Use when classifying repos, PRs, issues, security alerts, or dirty trees before assigning collaborative AI work in one shared codebase.
+---
+
+# SCBE GitHub Sweep Sorter
+
+Use this skill when a repo or org needs to be swept, sorted, and routed into explicit agent lanes before coding starts.
+
+Pair this skill with:
+- `scbe-ai-to-ai-communication` for packet delivery and handoff logging
+- `multi-agent-orchestrator` when the sweep turns into parallel execution
+
+## Quick Start
+
+1. Collect the sweep surface.
+   - Local: `git status`, repo hygiene reports, branch state, changed roots.
+   - GitHub: PRs, issues, alerts, repo inventory, review queues.
+2. Bucket items before fixing anything.
+   - `keep-in-repo`
+   - `archive-or-cloud`
+   - `ignore-or-cache`
+   - `security-now`
+   - `manual-review`
+3. Choose a HYDRA formation with `scripts/choose_formation.py`.
+4. Build one roundtable packet with `scripts/build_roundtable_packet.py`.
+5. Hand the packet to the communication lane instead of letting agents collide.
+
+## Formation Selection
+
+Read `references/formations.md` when the right formation is not obvious.
+
+Default formation rules:
+
+- `scatter`
+  - Use for discovery across many repos, many alerts, or broad org triage.
+  - Best when the work is mostly classification and evidence gathering.
+
+- `hexagonal-ring`
+  - Default coding and repo-governance formation for the six Sacred Tongues.
+  - Best when multiple agents collaborate on one shared codebase but ownership stays explicit.
+
+- `tetrahedral`
+  - Use for smaller, high-focus, higher-risk implementation packets.
+  - Best when four critical roles are enough and shared-file pressure is high.
+
+- `ring`
+  - Use when order matters.
+  - Best for approvals, critical security actions, release gates, and chain-of-custody decisions.
+
+## Role Map
+
+Read `references/role-map.md` for the full mapping.
+
+Default six-tongue roundtable:
+
+- `KO` architecture curator
+- `AV` transport and discovery
+- `RU` policy and governance
+- `CA` implementation engineer
+- `UM` security auditor
+- `DR` schema, release memory, and evidence keeper
+
+Optional spine role:
+
+- `SPINE` integration coordinator
+  - owns packet routing, status rollup, and conflict resolution
+  - does not compete with the six tongues for the same file edits
+
+## Governance Thresholds
+
+Read `references/governance-thresholds.md` when deciding quorum.
+
+Use risk-tiered thresholds, not one fixed quorum claim:
+
+- low-risk classification and discovery: `3/6`
+- medium-risk code or config changes: `4/6`
+- critical security, destructive, or release actions: `5/6`
+- ordered attestation path required: use `ring` and preserve signer order
+
+Use the corrected language:
+- prefer `BFT-informed threshold governance`
+- do not claim a single hard Byzantine quorum for every action
+
+## Sweep Workflow
+
+### 1. Collect
+
+Gather only what the sweep needs:
+
+- repo name and branch
+- dirty-tree summary
+- PR / issue / alert counts
+- high-risk roots or files
+- whether the task is discovery, implementation, review, or release
+
+### 2. Classify
+
+Use `scripts/classify_sweep_targets.py` for a first pass.
+
+The target buckets are:
+
+- `keep-in-repo`
+- `archive-or-cloud`
+- `ignore-or-cache`
+- `security-now`
+- `manual-review`
+
+The purpose is not deletion. The purpose is separating source, evidence, outputs, and cache so the repo stays readable.
+
+### 3. Choose Formation
+
+Use `scripts/choose_formation.py` to pick:
+
+- formation
+- quorum target
+- whether ordering is required
+- whether a shared-file collision risk exists
+
+### 4. Assign Work
+
+Every packet must declare:
+
+- `task_id`
+- `formation`
+- `quorum_required`
+- `owner_role`
+- `allowed_paths`
+- `blocked_paths`
+- `goal`
+- `done_criteria`
+
+Never let two agents edit the same mutable file without explicit ownership.
+
+### 5. Emit Packet
+
+Use `scripts/build_roundtable_packet.py` to create a machine-readable packet.
+
+If the work will be handed to another AI, route the packet through `scbe-ai-to-ai-communication`.
+
+## Output Contract
+
+Read `references/packet-schema.md` for the full packet.
+
+Minimum output:
+
+```json
+{
+  "task_id": "sweep-20260314-001",
+  "repo": "SCBE-AETHERMOORE",
+  "branch": "main",
+  "formation": "hexagonal-ring",
+  "quorum_required": "4/6",
+  "summary": "Sort security alerts and repo hygiene roots into owned lanes",
+  "work_packets": [
+    {
+      "tongue": "KO",
+      "role": "architecture-curator",
+      "goal": "Confirm boundaries and non-goals",
+      "allowed_paths": ["docs/", "schemas/"],
+      "blocked_paths": ["src/", "tests/"]
+    }
+  ]
+}
+```
+
+## Safety Rules
+
+- Keep one shared mission, not one shared file free-for-all.
+- Preserve evidence and artifacts; sort them before deciding whether they belong in repo or archive.
+- For critical actions, preserve ordered roundtable signatures.
+- Treat `Word`, `browser`, `workflow`, and `repo` clients as outer execution planes. The sweep packet governs them; it does not get replaced by them.
+- Do not confuse cache outputs with successful workflow templates.
+
+## References
+
+- `references/formations.md`
+- `references/role-map.md`
+- `references/governance-thresholds.md`
+- `references/packet-schema.md`
+
+## Scripts
+
+- `scripts/choose_formation.py`
+- `scripts/classify_sweep_targets.py`
+- `scripts/build_roundtable_packet.py`

--- a/skills/codex-mirror/scbe-github-sweep-sorter/agents/openai.yaml
+++ b/skills/codex-mirror/scbe-github-sweep-sorter/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SCBE GitHub Sweep Sorter"
+  short_description: "Sort GitHub sweeps into governed agent lanes"
+  default_prompt: "Use $scbe-github-sweep-sorter to classify repo sweep targets, choose a HYDRA formation, and emit roundtable packets."

--- a/skills/codex-mirror/scbe-github-sweep-sorter/references/formations.md
+++ b/skills/codex-mirror/scbe-github-sweep-sorter/references/formations.md
@@ -1,0 +1,72 @@
+# HYDRA Formations
+
+These formations are derived from the SCBE/HYDRA coordination notes and are intended for software collaboration, not literal military automation.
+
+## Scatter
+
+Use when:
+- sweeping many repos
+- classifying many issues or alerts
+- doing first-pass discovery
+
+Strengths:
+- broad coverage
+- low initial coupling
+- good for inventory and triage
+
+Weaknesses:
+- weak for ordered approvals
+- weak for shared-file implementation
+
+## Hexagonal Ring
+
+Default six-tongue collaborative formation.
+
+Use when:
+- one shared codebase needs parallel thought with explicit ownership
+- multiple roles are active at once
+- the team needs balanced collaboration rather than serial handoff
+
+Strengths:
+- symmetric
+- easy to visualize
+- good for balanced coding, docs, review, and governance
+
+Weaknesses:
+- not ideal when a strict temporal attestation path is required
+
+## Tetrahedral
+
+Use when:
+- the packet is smaller
+- risk is higher
+- fewer roles should touch the work
+
+Suggested roles:
+- KO architecture
+- CA implementation
+- UM security
+- DR release memory
+
+Strengths:
+- tight and focused
+- useful for risky refactors
+
+Weaknesses:
+- less breadth than the full six-tongue ring
+
+## Ring
+
+Use when:
+- order matters
+- chain of custody matters
+- the action is critical or destructive
+
+Suggested order:
+- `KO -> AV -> RU -> CA -> UM -> DR`
+
+This is the right formation for:
+- release approvals
+- security exceptions
+- privileged tool actions
+- critical governance decisions

--- a/skills/codex-mirror/scbe-github-sweep-sorter/references/governance-thresholds.md
+++ b/skills/codex-mirror/scbe-github-sweep-sorter/references/governance-thresholds.md
@@ -1,0 +1,46 @@
+# Governance Thresholds
+
+Use risk-tiered thresholds for repo and GitHub sweep actions.
+
+## Thresholds
+
+- `3/6`
+  - low-risk discovery
+  - sorting
+  - inventory
+  - report generation
+
+- `4/6`
+  - medium-risk code or workflow changes
+  - CI fixes
+  - integration wiring
+  - config edits
+
+- `5/6`
+  - destructive actions
+  - security-sensitive changes
+  - release or deploy gates
+  - permission and secrets surfaces
+
+## Ordered Attestation
+
+When the action needs chain of custody, use ordered signoff:
+
+- `KO -> AV -> RU -> CA -> UM -> DR`
+
+Use this for:
+- release gating
+- privileged tool execution
+- approval on security exceptions
+- destructive repo surgery
+
+## Language Discipline
+
+Prefer:
+- `BFT-informed threshold governance`
+- `risk-tiered quorum`
+- `ordered attestation path`
+
+Avoid:
+- claiming one universal quorum for every action
+- calling governance-path diversity a cryptographic multiplier

--- a/skills/codex-mirror/scbe-github-sweep-sorter/references/packet-schema.md
+++ b/skills/codex-mirror/scbe-github-sweep-sorter/references/packet-schema.md
@@ -1,0 +1,59 @@
+# Sweep Packet Schema
+
+Use one packet per sweep mission. Keep it small and grep-friendly.
+
+```json
+{
+  "packet_id": "sweep-20260314-001",
+  "created_at": "2026-03-14T22:00:00Z",
+  "sender": "codex",
+  "recipient": "claude",
+  "repo": "SCBE-AETHERMOORE",
+  "branch": "main",
+  "task_id": "repo-hygiene-batch-a",
+  "formation": "hexagonal-ring",
+  "quorum_required": "4/6",
+  "ordered_attestation": false,
+  "summary": "Sort repo hygiene roots and assign cleanup lanes",
+  "risk": "medium",
+  "buckets": [
+    "keep-in-repo",
+    "archive-or-cloud",
+    "ignore-or-cache"
+  ],
+  "work_packets": [
+    {
+      "tongue": "KO",
+      "role": "architecture-curator",
+      "goal": "Confirm the keep/archive boundaries",
+      "allowed_paths": ["docs/", "schemas/"],
+      "blocked_paths": ["src/", "tests/"],
+      "done_criteria": [
+        "Boundary doc updated",
+        "No source paths reassigned incorrectly"
+      ]
+    }
+  ],
+  "next_action": "Route to AI-to-AI packet lane",
+  "proof": [
+    "artifacts/repo-hygiene/latest_report.json"
+  ]
+}
+```
+
+## Required Fields
+
+- `packet_id`
+- `created_at`
+- `repo`
+- `task_id`
+- `formation`
+- `quorum_required`
+- `summary`
+- `work_packets`
+
+## Notes
+
+- `work_packets` should define ownership, not just intent.
+- Include file paths when possible.
+- Keep secrets and raw tokens out of packets.

--- a/skills/codex-mirror/scbe-github-sweep-sorter/references/role-map.md
+++ b/skills/codex-mirror/scbe-github-sweep-sorter/references/role-map.md
@@ -1,0 +1,36 @@
+# Role Map
+
+Use these roles for shared-codebase roundtables.
+
+## Six Tongues
+
+- `KO` / architecture-curator
+  - validates structure, boundaries, and doctrine
+  - best for specs, architecture, and design review
+
+- `AV` / transport-discovery
+  - gathers repo, PR, issue, and connector state
+  - best for search, inventory, routing, and reproduction steps
+
+- `RU` / policy-governance
+  - checks rules, permissions, rollout gates, and non-goals
+  - best for approval logic and action bounds
+
+- `CA` / implementation-engineer
+  - writes code in owned paths
+  - best for feature work and fixes
+
+- `UM` / security-auditor
+  - checks threat surfaces, alerts, secrets, permissions, and abuse paths
+  - best for high-risk reviews and security fixes
+
+- `DR` / schema-release-memory
+  - owns schemas, evidence, changelogs, release memory, and persistent records
+  - best for structured output and handoff durability
+
+## Spine
+
+- `SPINE` / integration-coordinator
+  - optional coordination lane
+  - tracks mission state, packet routing, conflicts, and completion
+  - should avoid taking overlapping edit ownership unless explicitly assigned

--- a/skills/codex-mirror/scbe-github-sweep-sorter/scripts/build_roundtable_packet.py
+++ b/skills/codex-mirror/scbe-github-sweep-sorter/scripts/build_roundtable_packet.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+
+
+ROLE_MAP = {
+    "KO": "architecture-curator",
+    "AV": "transport-discovery",
+    "RU": "policy-governance",
+    "CA": "implementation-engineer",
+    "UM": "security-auditor",
+    "DR": "schema-release-memory",
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def default_work_packets(formation: str) -> list[dict[str, object]]:
+    if formation == "tetrahedral":
+        tongues = ["KO", "CA", "UM", "DR"]
+    else:
+        tongues = ["KO", "AV", "RU", "CA", "UM", "DR"]
+
+    return [
+        {
+            "tongue": tongue,
+            "role": ROLE_MAP[tongue],
+            "goal": "Fill in the goal for this role.",
+            "allowed_paths": [],
+            "blocked_paths": [],
+            "done_criteria": [],
+        }
+        for tongue in tongues
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a roundtable sweep packet.")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--formation", required=True)
+    parser.add_argument("--quorum-required", required=True)
+    parser.add_argument("--summary", required=True)
+    parser.add_argument("--risk", choices=["low", "medium", "high", "critical"], default="medium")
+    parser.add_argument("--sender", default="codex")
+    parser.add_argument("--recipient", default="claude")
+    parser.add_argument("--ordered-attestation", action="store_true")
+    args = parser.parse_args()
+
+    packet = {
+        "packet_id": f"{args.task_id}-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}",
+        "created_at": utc_now(),
+        "sender": args.sender,
+        "recipient": args.recipient,
+        "repo": args.repo,
+        "branch": args.branch,
+        "task_id": args.task_id,
+        "formation": args.formation,
+        "quorum_required": args.quorum_required,
+        "ordered_attestation": args.ordered_attestation,
+        "summary": args.summary,
+        "risk": args.risk,
+        "work_packets": default_work_packets(args.formation),
+        "next_action": "Route through scbe-ai-to-ai-communication.",
+        "proof": [],
+    }
+    print(json.dumps(packet, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex-mirror/scbe-github-sweep-sorter/scripts/choose_formation.py
+++ b/skills/codex-mirror/scbe-github-sweep-sorter/scripts/choose_formation.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def choose_formation(
+    repo_count: int,
+    item_count: int,
+    risk: str,
+    shared_files: int,
+    needs_ordering: bool,
+    needs_discovery: bool,
+) -> dict[str, object]:
+    if needs_ordering or risk == "critical":
+        formation = "ring"
+    elif needs_discovery or repo_count > 1 or item_count > 20:
+        formation = "scatter"
+    elif shared_files > 0 and item_count <= 6 and risk in {"medium", "high"}:
+        formation = "tetrahedral"
+    else:
+        formation = "hexagonal-ring"
+
+    quorum = {
+        "low": "3/6",
+        "medium": "4/6",
+        "high": "4/6",
+        "critical": "5/6",
+    }[risk]
+
+    return {
+        "formation": formation,
+        "quorum_required": quorum,
+        "ordered_attestation": formation == "ring",
+        "rationale": {
+            "repo_count": repo_count,
+            "item_count": item_count,
+            "risk": risk,
+            "shared_files": shared_files,
+            "needs_ordering": needs_ordering,
+            "needs_discovery": needs_discovery,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Choose a HYDRA formation for a GitHub or repo sweep.")
+    parser.add_argument("--repo-count", type=int, default=1)
+    parser.add_argument("--item-count", type=int, default=1)
+    parser.add_argument("--risk", choices=["low", "medium", "high", "critical"], default="medium")
+    parser.add_argument("--shared-files", type=int, default=0)
+    parser.add_argument("--needs-ordering", action="store_true")
+    parser.add_argument("--needs-discovery", action="store_true")
+    args = parser.parse_args()
+
+    print(json.dumps(
+        choose_formation(
+            repo_count=args.repo_count,
+            item_count=args.item_count,
+            risk=args.risk,
+            shared_files=args.shared_files,
+            needs_ordering=args.needs_ordering,
+            needs_discovery=args.needs_discovery,
+        ),
+        indent=2,
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex-mirror/scbe-github-sweep-sorter/scripts/classify_sweep_targets.py
+++ b/skills/codex-mirror/scbe-github-sweep-sorter/scripts/classify_sweep_targets.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from pathlib import PurePosixPath
+
+
+KEEP_ROOTS = {"src", "tests", "docs", "scripts", "schemas", "config", ".github", "api", "agents", "packages"}
+ARCHIVE_ROOTS = {"artifacts", "training", "exports", "content"}
+IGNORE_NAMES = {
+    ".cache",
+    "__pycache__",
+    ".pytest_cache",
+    "node_modules",
+    "dist",
+    "build",
+    ".playwright-mcp",
+    ".playwright-cli",
+}
+
+
+def classify_path(path: str) -> str:
+    pure = PurePosixPath(path.replace("\\", "/"))
+    parts = pure.parts
+    if not parts:
+        return "manual-review"
+
+    if any(part in IGNORE_NAMES for part in parts):
+        return "ignore-or-cache"
+
+    root = parts[0]
+    if root in KEEP_ROOTS:
+        return "keep-in-repo"
+    if root in ARCHIVE_ROOTS:
+        return "archive-or-cloud"
+    if "security" in path.lower() or "auth" in path.lower():
+        return "security-now"
+    return "manual-review"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Classify sweep targets into repo buckets.")
+    parser.add_argument("paths", nargs="*", help="Paths to classify")
+    parser.add_argument("--from-json", help="JSON file containing a list of paths or objects with a path field")
+    args = parser.parse_args()
+
+    items: list[str] = list(args.paths)
+    if args.from_json:
+        data = json.loads(Path(args.from_json).read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, str):
+                    items.append(item)
+                elif isinstance(item, dict) and "path" in item:
+                    items.append(str(item["path"]))
+
+    results = [{"path": path, "bucket": classify_path(path)} for path in items]
+    print(json.dumps(results, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What\n- add a repo-native GitHub/repo sweep wrapper for terminal use\n- mirror the scbe-github-sweep-sorter skill into the repo\n- add a terminal-first README for cleanup and GitHub management\n\n## Why\n- keep local and cloud organization in one repeatable command lane\n- give AI agents one governed sweep packet instead of ad hoc repo edits\n\n## Test Evidence\n- python scripts/system/run_github_sweep.py --repo-root C:\\Users\\issda\\SCBE-AETHERMOORE --include-github\n- wrote rtifacts/agent-sweeps/github_sweep_latest.json\n- wrote rtifacts/agent-sweeps/github_repo_inventory_latest.json\n\n## Notes\n- current target repo sweep result: 3607 dirty entries, scatter formation, quorum 4/6\n- no destructive cleanup is performed by this workflow