### PR TITLE
Potential fix for code scanning alert no. 2234: Uncontrolled data used in path expression

### DIFF
--- a/scripts/system/ai_bridge.py
+++ b/scripts/system/ai_bridge.py
@@ -53,12 +53,16 @@ def _resolve_vault_root(vault_path: str) -> Path:
     if not raw:
         raise ValueError("vault_path is required")
 
-    resolved = Path(raw).expanduser().resolve(strict=False)
-    if not resolved.exists() or not resolved.is_dir():
+    # Resolve the user-provided path to an absolute, normalized directory.
+    # Using strict=True ensures the path exists and all symlinks are resolved.
+    resolved = Path(raw).expanduser().resolve(strict=True)
+    if not resolved.is_dir():
         raise ValueError(f"Vault path must be an existing directory: {resolved}")
 
     for allowed_root in _allowed_vault_roots():
-        if _is_relative_to(resolved, allowed_root):
+        # Ensure allowed roots are also normalized before comparison.
+        allowed_root_resolved = allowed_root.resolve(strict=False)
+        if _is_relative_to(resolved, allowed_root_resolved):
             return resolved
 
     roots = ", ".join(str(root) for root in _allowed_vault_roots())


### PR DESCRIPTION
Potential fix for [https://github.com/issdandavis/SCBE-AETHERMOORE/security/code-scanning/2234](https://github.com/issdandavis/SCBE-AETHERMOORE/security/code-scanning/2234)

In general, to fix uncontrolled path usage you should 1) resolve and normalize the user-provided path, 2) ensure the path points to an existing directory you intend to allow, and 3) verify that directory lies beneath a trusted root (or whitelist), using a robust containment check that accounts for symlinks and normalization. You should not rely solely on naïve string checks or on configuration that may itself be unconstrained.

In this codebase, the safest minimal fix is to make `_resolve_vault_root` explicitly enforce that the user-selected vault directory is a descendant of a well-defined set of allowed roots, using `Path.resolve(strict=True)` so that the directory must exist and any symlinks are fully resolved. We already have `_allowed_vault_roots()` and `_is_relative_to()`, so the main improvements are: (1) resolve `vault_path` strictly and normalize it, (2) resolve the allowed roots similarly before comparison to avoid mismatches, and (3) keep the rest of the behavior the same (still raising `ValueError` when the directory doesn’t exist or is outside allowed roots). This maintains existing functionality (user picks a vault dir; logs are written under `<vault>/SCBE-Hub/AI-Bridge/...`) while strengthening the validation and satisfying the static analysis expectation.

Concretely, in `scripts/system/ai_bridge.py`:

- Update `_resolve_vault_root` so that:
  - It calls `Path(raw).expanduser().resolve(strict=True)` instead of `strict=False` and separate existence checks.
  - It resolves each allowed root to an absolute, normalized path right before the `_is_relative_to` check, to ensure consistent semantics.
- The rest of the functions (`write_log`, `run_once`, etc.) can remain unchanged, as they already build fixed subpaths under the validated vault root.

No changes are necessary in `scripts/system/ai_bridge_streamlit.py`, because the validation should be centralized in `_resolve_vault_root`, which is already used for both CLI and Streamlit callers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
