### PR TITLE
fix(gateway): parameterize production decision-gateway port mapping

### DIFF
--- a/deploy/gateway/docker-compose.gateway.prod.yml
+++ b/deploy/gateway/docker-compose.gateway.prod.yml
@@ -7,7 +7,7 @@ services:
       context: ../..
       dockerfile: Dockerfile.gateway
     ports:
-      - '8081:8081'
+      - '${PORT:-8081}:${PORT:-8081}'
     environment:
       NODE_ENV: production
       PORT: ${PORT:-8081}

--- a/docs/gateway/AUTHORIZE_GATEWAY.md
+++ b/docs/gateway/AUTHORIZE_GATEWAY.md
@@ -26,4 +26,14 @@ docker compose -f docker-compose.gateway.local.yml --profile gateway-local up --
 docker compose -f deploy/gateway/docker-compose.gateway.prod.yml up --build -d
 ```
 
+
 The production compose file enforces required governance variables at compose-evaluation time.
+
+### Port override behavior
+
+`decision-gateway` now binds host/container ports from the same `PORT` value:
+
+- Default mapping: `8081:8081`
+- Override mapping: set `PORT` and Compose maps `${PORT}:${PORT}` (for example `PORT=9090` gives `9090:9090`).
+
+The container runtime, startup command, and Docker healthcheck all read the same `PORT` value, so the service and `/health` probe stay aligned when the port is overridden.


### PR DESCRIPTION
### Motivation

- Allow overriding the host/container port used by the production `decision-gateway` via a `PORT` environment variable while keeping the service runtime and healthcheck aligned.

### Description

- Replace the fixed `8081:8081` mapping with a parameterized mapping `- '${PORT:-8081}:${PORT:-8081}'` in `deploy/gateway/docker-compose.gateway.prod.yml` and add documentation about the override behavior to `docs/gateway/AUTHORIZE_GATEWAY.md`, including default and example override (`PORT=9090`).

### Testing

- Confirmed runtime port references with `rg` searches for `ports:` and `PORT: ${PORT:-8081}` (succeeded). 
- Attempted to validate with `PORT=9090 docker compose -f deploy/gateway/docker-compose.gateway.prod.yml config`, but `docker` is not available in this environment so that command could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae03eb816c83228a671f88fe60190d)