### PR TITLE
feat(browser): provider health UI, command planning, zone gating, e2e tests

### DIFF
--- a/content/articles/2026-03-17-bounded-ai-is-the-shipping-pattern.md
+++ b/content/articles/2026-03-17-bounded-ai-is-the-shipping-pattern.md
@@ -1,0 +1,135 @@
+# Bounded AI Is the Shipping Pattern
+
+**By Issac Davis** | March 17, 2026
+
+---
+
+There is a weird argument happening around AI systems right now.
+
+One camp keeps selling the idea of a free agent that can do everything: browse the web, make decisions, run workflows, write code, play games, talk to customers, and somehow stay safe through vibes and a checkbox that says "human in the loop."
+
+The systems that are actually shipping do not look like that.
+
+The pattern I keep seeing across official product docs and studio engineering writeups is much narrower and much more useful:
+
+**bounded AI inside governed loops.**
+
+Not one agent running everything.
+Not blind autonomy.
+Not "just trust the model."
+
+Instead:
+
+- tightly scoped actions
+- supervised steps
+- explicit handoff points
+- isolated runtimes
+- telemetry and logs
+- training from constrained data loops
+
+That pattern shows up in browser agents, research agents, teammate AI, QA agents, and game-writing tools.
+
+## Browser Agents Already Ship With Checkpoints
+
+Anthropic's computer use documentation is unusually direct about the risk model. It recommends running computer use in a **container or virtual machine**, warns that **prompt injection can override instructions**, and tells builders to keep the tool away from sensitive accounts without strict oversight.
+
+That is not a "trust the model" posture. That is a containment posture.
+
+OpenAI's Operator documentation points in the same direction. Operator uses a remote browser, pauses for **take over mode** when passwords or sensitive inputs are involved, and adds **user confirmations**, **prompt injection monitoring**, and **watch mode** on higher-risk sites.
+
+Again: bounded system, explicit checkpoint, supervised execution.
+
+Even OpenAI's deep research docs show the same instinct on the read-heavy side. They emphasize source restriction, citations, and limiting research to trusted sites when needed. The tool is agentic, but the work is still happening inside a constrained evidence model.
+
+## Game Studios Are Doing the Same Thing
+
+If you move over to game AI, the structure barely changes.
+
+Ubisoft's Ghostwriter is a clean example. The company's official explanation is not "AI writes the game now." The tool generates **first drafts of NPC barks** so writers can spend time polishing narrative work that actually matters. The AI handles a repetitive subtask inside a human-authored pipeline.
+
+Ubisoft's Rainbow Six Siege bot work is even clearer. The official writeup describes **two parallel frameworks**: traditional AI and machine learning. The traditional framework helps them ship faster and more predictably; the machine learning lane improves behavior using replay data and reinforcement-style loops over time. That is hybrid architecture on purpose, not a free model improvising the whole game.
+
+EA SEED says the same thing from the testing side. Its official research notes that Battlefield V would have required around **0.5 million hours of manual testing** in one case study. So the company explored reinforcement learning, imitation learning, and curiosity-driven testing agents for hard QA problems. It did not say "replace production with one autonomous super-agent." It used AI where the pain was specific and measurable.
+
+NVIDIA's ACE for Games work also fits the pattern. The pitch is not "let the model run the world." It is specialized runtime pieces for speech, behavior, and character interaction that plug into a larger authored system.
+
+## The Pattern Is Converging
+
+Across all of those official sources, the same structure keeps reappearing:
+
+1. AI is used on a hard, narrow loop.
+2. The loop sits inside authored constraints.
+3. There are pause points, reviews, or confirmations.
+4. The runtime is isolated or at least strongly mediated.
+5. Logs, telemetry, or replay data feed the next iteration.
+
+That is the real product pattern.
+
+The blocked actions matter as much as the successful ones. A denied navigation, a quarantined prompt, or a takeover request is not wasted data. It is a trace of intent before execution fully bloomed. Those unbloomed buds are often the cleanest evidence you get about where the model would have gone without a rail in place.
+
+The browser-agent version of this is:
+
+- trusted-site routing
+- confirmation before high-impact actions
+- session isolation
+- evidence capture
+- reviewable logs
+
+The game-AI version is:
+
+- authored world rules
+- narrow NPC or QA roles
+- replay and telemetry data
+- difficulty buckets or persona buckets
+- human designers still owning the final experience
+
+Same architecture. Different surface.
+
+## Why This Matters
+
+The public conversation about agents keeps getting pulled toward theatrical autonomy. People want the demo where the AI does everything without supervision.
+
+But the systems that survive contact with production have to answer uglier questions:
+
+- What happens when a webpage lies to the model?
+- What happens when a user asks the agent to do something high-impact?
+- What happens when the model drifts?
+- What happens when the environment changes?
+- What happens when you need to explain the decision later?
+
+Free agents are exciting in a demo.
+Governed loops are what you can actually keep alive.
+
+## What I'm Building From This
+
+That is also the design direction I keep coming back to in SCBE-AETHERMOORE and AetherBrowse:
+
+- browser-first operator lanes
+- explicit checkpoints
+- append-only evidence
+- cross-talk packets instead of vague agent chat
+- role-bounded relays instead of one model trying to be everything
+
+The design goal is not "smarter chaos."
+
+It is:
+
+**make useful AI move through rails that are clear enough to audit, repair, and train on later.**
+
+That is not a compromise.
+It is the shipping pattern.
+
+## Official Sources
+
+- Anthropic, *Computer use tool*: https://docs.anthropic.com/en/docs/build-with-claude/computer-use
+- OpenAI, *Introducing Operator*: https://openai.com/index/introducing-operator/
+- OpenAI Help, *Operator*: https://help.openai.com/en/articles/10421097-operator
+- OpenAI Help, *Deep Research*: https://help.openai.com/en/articles/10500283-deep-research
+- Ubisoft, *The Convergence of AI and Creativity: Introducing Ghostwriter*: https://news.ubisoft.com/en-gb/article/7Cm07zbBGy4Xml6WgYi25d/the-convergence-of-ai-and-creativity-introducing-ghostwriter
+- Ubisoft, *How Rainbow Six Siege Developed AI That Acts Like Real Players*: https://news.ubisoft.com/en-au/article/1MlKnolSLJFuJDnATWiorr/how-rainbow-six-siege-developed-ai-that-acts-like-real-players
+- EA SEED, *SEED Applies ML Research to the Growing Demands of AAA Game Testing*: https://www.ea.com/seed/news/seed-ml-research-aaa-game-testing
+- NVIDIA, *Generative AI Sparks Life Into Virtual Characters With ACE for Games*: https://developer.nvidia.com/blog/generative-ai-sparks-life-into-virtual-characters-with-ace-for-games/
+
+---
+
+*Repo: https://github.com/issdandavis/SCBE-AETHERMOORE*

--- a/content/articles/buffer_thread_2026-03-17-governed-agent-loops.md
+++ b/content/articles/buffer_thread_2026-03-17-governed-agent-loops.md
@@ -1,0 +1,52 @@
+# Buffer Thread: Governed Agent Loops Win
+
+## 1/5
+
+The real shipping pattern for AI is not "one free agent doing everything."
+
+It is bounded AI inside governed loops.
+
+That is what the official product and game-industry examples keep showing.
+
+## 2/5
+
+Anthropic computer use and OpenAI Operator both expose the same shape:
+
+- screen-level control
+- scoped environments
+- explicit safety precautions
+- user takeover when risk rises
+
+Useful autonomy, but fenced.
+
+## 3/5
+
+Ubisoft does it on the creative and gameplay sides.
+
+Ghostwriter generates first-draft NPC barks for writers to edit.
+
+Rainbow Six Siege used traditional AI plus machine learning together so player-like bots could ship without throwing away reliability.
+
+## 4/5
+
+EA SEED and NVIDIA ACE point the same direction.
+
+EA uses ML and RL inside testing and validation loops.
+
+NVIDIA ACE breaks NPC intelligence into modules like speech, conversation, and animation.
+
+Both approaches are structured systems, not free-range agents.
+
+## 5/5
+
+If you are building agents, copy the pattern that already ships:
+
+- bounded task scope
+- checkpoints
+- telemetry
+- human override
+- modular subsystems
+
+Governed loops are not the compromise.
+
+They are the product.

--- a/content/articles/devto_2026-03-17-what-browser-agents-can-learn-from-game-ai.md
+++ b/content/articles/devto_2026-03-17-what-browser-agents-can-learn-from-game-ai.md
@@ -1,0 +1,157 @@
+---
+title: "What Browser Agents Can Learn From Game AI"
+published: true
+tags: [ai, webdev, security, opensource]
+---
+
+# What Browser Agents Can Learn From Game AI
+
+The browser-agent conversation is making the same mistake game AI learned to avoid years ago.
+
+Too many people are chasing the fantasy of a single free agent that can do everything:
+
+- browse anywhere
+- click anything
+- log into any service
+- make purchases
+- complete workflows
+- somehow stay safe because the prompt said "be careful"
+
+That is not how the systems that actually ship are built.
+
+The systems that ship tend to use **bounded AI inside governed loops**.
+
+If you look at current browser-agent docs and then look at official game-AI writeups, the architecture starts to rhyme.
+
+## 1. Browser Agents Already Use Checkpoints
+
+Anthropic's computer-use docs tell builders to run the tool in a **container or virtual machine**, warn that **prompt injection may override instructions**, and recommend avoiding sensitive accounts without strict oversight.
+
+OpenAI's Operator docs describe the same basic shape:
+
+- the agent uses a remote browser
+- it pauses when it needs help
+- it enters **take over mode** for sensitive steps
+- it uses **user confirmations** for high-impact actions
+- it applies **watch mode** on certain sites
+
+That is not autonomous freedom. That is constrained execution.
+
+## 2. Game Studios Already Solved the Product Question
+
+Game teams have been dealing with the same product question for years:
+
+> How do we use AI to reduce pain without letting it wreck the authored experience?
+
+Ubisoft's **Ghostwriter** is a perfect example. It generates **first drafts of NPC barks** so writers can focus on higher-value narrative work. The AI is not the writer. It is a bounded assistant inside the writing pipeline.
+
+Ubisoft's **Rainbow Six Siege** AI work uses **parallel frameworks**: traditional AI to ship something reliable, plus machine learning to improve player-like behavior using replay data. The team explicitly chose a hybrid model instead of betting everything on one ML lane.
+
+EA SEED's official research says the same thing from a QA angle. In one case study, Battlefield V would have needed around **0.5 million hours** of manual testing. So SEED explored reinforcement learning, imitation learning, and curiosity-driven agents for testing. Again, the AI is assigned to a painful loop, not crowned king of the whole system.
+
+## 3. The Shared Design Pattern
+
+The browser-agent world and the game-AI world are converging on the same structure:
+
+### Bounded role
+
+Do one hard thing well.
+
+Examples:
+
+- generate bark variations
+- test a map path
+- navigate a research workflow
+- fill out a form with supervision
+
+### Isolation
+
+Do not give the system broad, ambient access if you can help it.
+
+Examples:
+
+- VM or container execution
+- remote browser sessions
+- persona/difficulty buckets
+- replay-based training data instead of raw production access
+
+### Human checkpoint
+
+Pause when the decision becomes sensitive, expensive, or hard to verify.
+
+Examples:
+
+- take over mode
+- user confirmations
+- writer selection and polish
+- design QA pass before promotion
+
+### Logs and feedback
+
+Make the loop reviewable and trainable.
+
+Examples:
+
+- screenshots and evidence artifacts
+- replays and telemetry
+- training data from constrained interactions
+- policy records and decision traces
+
+## 4. What This Means for Builders
+
+If you are building browser agents, the lesson is simple:
+
+Do not productize a free agent.
+Productize a **governed lane**.
+
+That means:
+
+- trusted-site routing
+- explicit action classes
+- confirmation before high-impact actions
+- isolated sessions
+- evidence capture
+- replayable logs
+
+If you are building AI for games, the lesson is the same:
+
+Do not try to make the whole world autonomous on day one.
+Make one loop better:
+
+- teammate support
+- QA exploration
+- bark drafting
+- NPC memory
+- navigation assistance
+
+Then constrain it hard enough that the humans still own the experience.
+
+## 5. My Take
+
+This is why I keep thinking in terms of:
+
+- rails
+- checkpoints
+- ledgers
+- scoreboards
+- handoff packets
+
+That sounds less magical than "autonomous agent."
+
+It is also much closer to what real systems can survive.
+
+The product is not the illusion of total autonomy.
+The product is the loop you can trust enough to run again tomorrow.
+
+## Sources
+
+- Anthropic, *Computer use tool*: https://docs.anthropic.com/en/docs/build-with-claude/computer-use
+- OpenAI, *Introducing Operator*: https://openai.com/index/introducing-operator/
+- OpenAI Help, *Operator*: https://help.openai.com/en/articles/10421097-operator
+- Ubisoft, *The Convergence of AI and Creativity: Introducing Ghostwriter*: https://news.ubisoft.com/en-gb/article/7Cm07zbBGy4Xml6WgYi25d/the-convergence-of-ai-and-creativity-introducing-ghostwriter
+- Ubisoft, *How Rainbow Six Siege Developed AI That Acts Like Real Players*: https://news.ubisoft.com/en-au/article/1MlKnolSLJFuJDnATWiorr/how-rainbow-six-siege-developed-ai-that-acts-like-real-players
+- EA SEED, *SEED Applies ML Research to the Growing Demands of AAA Game Testing*: https://www.ea.com/seed/news/seed-ml-research-aaa-game-testing
+
+---
+
+*If you're building agent systems, I think the most important design choice is not how autonomous they look. It's where they pause, what they can touch, and what evidence they leave behind.*

--- a/content/articles/huggingface_2026-03-17-constrained-traces-make-better-datasets.md
+++ b/content/articles/huggingface_2026-03-17-constrained-traces-make-better-datasets.md
@@ -1,0 +1,45 @@
+# Constrained Traces Make Better Datasets
+
+**By Issac Davis** | March 17, 2026
+
+---
+
+If you want better agent datasets, stop chasing giant free-form autonomy logs.
+
+The higher-signal data usually comes from constrained loops:
+
+- one task
+- one allowed tool surface
+- explicit checkpoints
+- clear success or failure
+- replayable context
+
+That is the same pattern the official browser-agent and game-AI docs keep reinforcing.
+
+Anthropic recommends isolated computer-use environments and warns about prompt injection. OpenAI's Operator uses takeover and confirmation points. Ubisoft's Ghostwriter keeps AI inside first-draft bark generation. Rainbow Six Siege combined traditional AI and ML instead of pretending one lane should do everything. EA SEED uses learned agents for specific testing problems.
+
+Why this matters for datasets:
+
+- narrow traces are easier to label
+- negative examples are cleaner
+- policy violations are easier to spot
+- evaluation becomes less ambiguous
+
+And the blocked traces matter too.
+
+Denied, quarantined, or redirected actions are not useless exhaust. They are the highest-signal examples of where intent was heading before it was allowed to bloom into execution. They are unbloomed buds: evidence of what the system wanted to do, what policy caught, and what the next training pass should understand better.
+
+The glamorous story is autonomous agents.
+
+The useful data story is governed loops.
+
+That is the direction I want for SCBE training sets: browser traces, relay packets, approvals, denials, and recoveries that are structured enough to train on later.
+
+Useful references:
+
+- Anthropic computer use: https://docs.anthropic.com/en/docs/build-with-claude/computer-use
+- OpenAI Operator: https://help.openai.com/en/articles/10421097-operator
+- Ubisoft Ghostwriter: https://news.ubisoft.com/en-gb/article/7Cm07zbBGy4Xml6WgYi25d/the-convergence-of-ai-and-creativity-introducing-ghostwriter
+- EA SEED game testing: https://www.ea.com/seed/news/seed-ml-research-aaa-game-testing
+
+Repo: https://github.com/issdandavis/SCBE-AETHERMOORE

--- a/content/articles/huggingface_2026-03-17-game-ai-shows-how-agents-should-ship.md
+++ b/content/articles/huggingface_2026-03-17-game-ai-shows-how-agents-should-ship.md
@@ -1,0 +1,43 @@
+# Game AI Already Shows How Agents Should Ship
+
+**By Issac Davis** | March 17, 2026
+
+---
+
+One reason I keep looking at game AI when thinking about agent systems:
+
+game teams have already spent years learning where autonomy helps and where it becomes expensive chaos.
+
+The official pattern is not mysterious:
+
+- hybrid systems
+- modular roles
+- replay and telemetry
+- authored constraints
+- human polish on top
+
+Ubisoft Ghostwriter scopes AI to first-draft bark generation.
+Rainbow Six Siege used traditional AI plus machine learning together.
+EA SEED applies learning systems to testing loops.
+NVIDIA ACE breaks character intelligence into modules rather than betting everything on one omnipotent NPC brain.
+
+That maps directly onto how I think agent systems should ship:
+
+- browser agents with confirmation gates
+- relay systems with role-bounded tasks
+- training loops built from approved traces
+- memory systems that live inside clear constraints
+
+The product lesson is simple:
+
+free agents make good demos.
+bounded systems make good operations.
+
+References:
+
+- Ubisoft Ghostwriter: https://news.ubisoft.com/en-gb/article/7Cm07zbBGy4Xml6WgYi25d/the-convergence-of-ai-and-creativity-introducing-ghostwriter
+- Ubisoft Rainbow Six Siege AI: https://news.ubisoft.com/en-au/article/1MlKnolSLJFuJDnATWiorr/how-rainbow-six-siege-developed-ai-that-acts-like-real-players
+- EA SEED game testing: https://www.ea.com/seed/news/seed-ml-research-aaa-game-testing
+- NVIDIA ACE for Games: https://developer.nvidia.com/blog/generative-ai-sparks-life-into-virtual-characters-with-ace-for-games/
+
+Repo: https://github.com/issdandavis/SCBE-AETHERMOORE

--- a/content/articles/huggingface_2026-03-17-governed-loops-train-better-agents.md
+++ b/content/articles/huggingface_2026-03-17-governed-loops-train-better-agents.md
@@ -1,0 +1,52 @@
+# Governed Loops Train Better Agents
+
+**By Issac Davis** | March 17, 2026
+
+---
+
+I keep seeing the same argument in agent tooling:
+
+people want one model to do everything.
+
+That is not just hard to govern. It also produces worse training data.
+
+The official product pattern across browser agents and game AI keeps pointing the other way:
+
+**bounded AI inside governed loops.**
+
+Why that matters for model and dataset work:
+
+- scoped tasks produce cleaner traces
+- checkpoints give you better positive and negative examples
+- replay and telemetry are easier to label than vague autonomous runs
+- handoff points make failure modes legible
+
+Anthropic's computer-use docs recommend isolation and strict precautions. OpenAI's Operator docs describe takeover and confirmation points. Ubisoft's Ghostwriter uses AI for first-draft bark generation, not end-to-end narrative authorship. Rainbow Six Siege combines traditional AI and ML. EA SEED uses learning systems for testing loops that are expensive to do by hand.
+
+That pattern matters for training.
+
+If you want better SFT pairs, DPO pairs, eval traces, and policy artifacts, you usually do not want one giant free-form transcript where the model improvised across ten roles.
+
+You want:
+
+- narrow task ownership
+- clear objectives
+- explicit accept/reject outcomes
+- replayable context
+- structured logs
+
+That is how the data gets better.
+
+It is also how the product gets safer.
+
+Useful sources:
+
+- Anthropic computer use: https://docs.anthropic.com/en/docs/build-with-claude/computer-use
+- OpenAI Operator: https://help.openai.com/en/articles/10421097-operator
+- Ubisoft Ghostwriter: https://news.ubisoft.com/en-gb/article/7Cm07zbBGy4Xml6WgYi25d/the-convergence-of-ai-and-creativity-introducing-ghostwriter
+- Ubisoft Rainbow Six Siege AI: https://news.ubisoft.com/en-au/article/1MlKnolSLJFuJDnATWiorr/how-rainbow-six-siege-developed-ai-that-acts-like-real-players
+- EA SEED game testing: https://www.ea.com/seed/news/seed-ml-research-aaa-game-testing
+
+I'm building around that pattern in SCBE-AETHERMOORE: governed browser lanes, explicit cross-talk packets, evidence trails, and model-training loops built from constrained operations instead of theatrical autonomy.
+
+Repo: https://github.com/issdandavis/SCBE-AETHERMOORE

--- a/content/articles/x_thread_2026-03-17-bounded-ai-shipping-pattern.md
+++ b/content/articles/x_thread_2026-03-17-bounded-ai-shipping-pattern.md
@@ -1,0 +1,88 @@
+# X Thread: Bounded AI Is the Shipping Pattern
+
+---
+
+## 1/8
+
+The market keeps talking about "autonomous agents."
+
+But the official shipping pattern is much narrower:
+
+bounded AI inside governed loops.
+
+Not free agents.
+
+## 2/8
+
+Anthropic's computer use docs are explicit about the shape.
+
+Claude can see screenshots, move a cursor, click, and type.
+
+But Anthropic frames it as a beta tool with security precautions:
+- use a dedicated VM or container
+- keep privileges minimal
+- avoid exposing sensitive data
+
+That is a rail system, not unconstrained autonomy.
+
+## 3/8
+
+OpenAI's Operator followed the same pattern.
+
+Officially, it was a research preview with its own browser, takeover flow, and handoff points when login, payment, or CAPTCHA steps needed a human.
+
+The model acts inside a bounded browser loop and yields when risk rises.
+
+## 4/8
+
+Ubisoft's Ghostwriter is another clean example.
+
+It does not replace writers.
+
+It generates first-draft NPC barks so scriptwriters can select, edit, reject, and polish them.
+
+The AI is scoped to one painful task inside a human-controlled production pipeline.
+
+## 5/8
+
+Ubisoft's Rainbow Six Siege bot work shows the same thing on the gameplay side.
+
+They built parallel frameworks:
+- traditional AI for shipping reliability
+- machine learning for more player-like behavior
+
+Hybrid rails beat ideology.
+
+## 6/8
+
+EA SEED uses AI the same way for testing.
+
+Their official game-testing research points at a brutal reality: AAA testing volume is too large to hand-script forever.
+
+So they use imitation learning, RL, and curiosity-based agents inside validation loops, not as one free model "running the game."
+
+## 7/8
+
+NVIDIA ACE for Games is modular for the same reason.
+
+Speech, conversation, and facial animation are separate pieces that can be tuned and deployed together.
+
+That means NPC intelligence ships as an orchestrated stack of bounded subsystems, not one magical omnibrain.
+
+## 8/8
+
+The lesson is stable across labs and studios:
+
+- bounded tools
+- explicit checkpoints
+- human takeover points
+- telemetry and audit trails
+- narrow task ownership
+
+That is how real AI systems get deployed.
+
+Not vibes. Not "just let the agent cook."
+
+---
+
+*Thread by @issdandavis | March 2026*

--- a/docs/research/2026-03-17-global-agent-senses-choice-monitoring.md
+++ b/docs/research/2026-03-17-global-agent-senses-choice-monitoring.md
@@ -1,0 +1,377 @@
+# Global Research Note: Agent Senses, Choice Monitoring, and World Models
+
+Last updated: 2026-03-17
+
+## Scope
+
+This note examines a global pattern across military/autonomy research, MIT, Harvard, Chinese research institutions, and Swiss robotics research:
+
+- multimodal perception
+- world models
+- situational awareness
+- bounded action loops
+- assurance and monitoring
+
+The question behind the note is not just "what can an AI sense?" but:
+
+1. how does it fuse those channels into awareness
+2. how does it monitor choices while they are forming
+3. how should those traces become trainable data
+
+## Executive read
+
+The user intuition is mostly correct, but the clean structure is:
+
+- senses/channels
+- fused world state
+- planner/policy
+- action monitoring
+- recovery/override
+- trace capture for learning
+
+Rational thought is not a sense. It is the thing that reads and weights the sensed channels.
+
+The institutions surveyed are not converging on a formal "7 senses" doctrine. They are converging on a practical stack:
+
+- more than the human five senses
+- explicit self-state and tool-state awareness
+- motion and time awareness
+- world models or simulation-backed prediction
+- assurance/monitoring before and during action
+- bounded autonomy with human or system checkpoints
+
+## What the official/global sources actually show
+
+### 1. Military / DARPA
+
+DARPA's work is not framed as "make one free agent." It is framed as:
+
+- multi-source sensing
+- autonomy in support of humans
+- assurance and evidence
+
+Two useful anchors:
+
+- `Squad X` emphasizes multi-source data fusion, autonomous threat detection, and real-time knowledge of friendly positions in GPS-denied environments. It explicitly combines physical, electromagnetic, and cyber awareness.
+- `ANSR` emphasizes trustworthy autonomy through hybrid AI, assurance evidence, predictability, robustness, and runtime monitoring/recovery.
+
+Operational takeaway:
+
+- military research treats situational awareness as fused state across multiple domains
+- trust is not assumed from capability alone; assurance artifacts matter
+
+Sources:
+
+- DARPA Squad X: https://www.darpa.mil/research/programs/squad-x
+- DARPA ANSR: https://www.darpa.mil/research/programs/assured-neuro-symbolic-learning-and-reasoning
+
+### 2. MIT
+
+MIT's official research and news surfaces point toward:
+
+- language-grounded perception
+- multimodal task learning
+- physically intelligent robotics
+- simulation and synthetic data expansion
+
+Useful anchors:
+
+- MIT CSAIL's `F3RM` uses 2D images plus foundation model features to build 3D feature fields, letting robots handle open-ended language prompts about unfamiliar objects.
+- MIT CSAIL's `GenSim2` expands robot training data with multimodal and reasoning models.
+- MIT CSAIL's 2025 physically intelligent robots initiative explicitly combines tactile sensing, multimodal perception, and AI-driven control.
+
+Operational takeaway:
+
+- MIT is pushing perception beyond classic camera-only pipelines into language + geometry + task context
+- the emerging stack is not "see -> act"; it is "build a richer scene representation -> reason over affordances -> act"
+
+Sources:
+
+- MIT News, F3RM: https://news.mit.edu/2023/using-language-give-robots-better-grasp-open-ended-world-1102
+- MIT CSAIL, GenSim2: https://csail-live-2025.csail.mit.edu/news/multimodal-and-reasoning-llms-supersize-training-data-dexterous-robotic-tasks
+- MIT CSAIL, physically intelligent robots: https://www.csail.mit.edu/news/mit-csail-and-pegatron-launch-five-year-initiative-pioneer-physically-intelligent-robots
+
+### 3. Harvard
+
+Harvard surfaces are especially relevant for:
+
+- multi-agent coordination in uncertain/adversarial settings
+- situational awareness
+- trust modeling
+- robot world models grounded in video, not just text
+
+Useful anchors:
+
+- Stephanie Gil's Harvard/Kempner profile explicitly centers situational awareness, trust, and real-time decision-making in dynamic, partially observable environments.
+- Yilun Du's Kempner work trains robots using video-derived world models so they can "envision" future actions before moving.
+
+Operational takeaway:
+
+- Harvard's strongest signal here is that perception is not enough; agents need trust-aware coordination and predictive internal models
+- video/world-model approaches are being used to move beyond language as the sole substrate for physical intelligence
+
+Sources:
+
+- Harvard Kempner, Stephanie Gil: https://kempnerinstitute.harvard.edu/people/our-people/stephanie-gil/
+- Harvard Kempner, visual imagination/world model: https://kempnerinstitute.harvard.edu/news/a-new-kind-of-ai-model-gives-robots-a-visual-imagination/
+
+### 4. China / native-language signals
+
+Chinese official and semi-official research signals are very strong around:
+
+- 具身智能 (embodied intelligence)
+- 可进化智能体 (evolvable agents)
+- 世界模型 (world models)
+- 强化学习 (reinforcement learning) as a decision-training backbone
+
+Useful anchors:
+
+- Tsinghua AIR explicitly describes `可进化智能体` as dynamic agents that evolve through interaction, feedback absorption, and experience summarization rather than one-shot static training.
+- Tsinghua EE + CAICT's embodied intelligence report frames RL as a core path toward `具身决策智能` (embodied decision intelligence), with hardware and infrastructure co-evolving with training.
+- Tsinghua/Alibaba AIR work explicitly describes a systematic lane for `基于大模型可进化智能体` research, focused on multilingual/multimodal capability and persistent evolution.
+- BAAI/智源 ecosystem material repeatedly treats world models as the bridge between embodiment and intelligence and highlights environment/simulator building as strategic infrastructure.
+
+Operational takeaway:
+
+- Chinese research is strongly oriented toward agent evolution over time, not just static capability
+- the stack is becoming: embodiment + world model + RL + infrastructure + continuous feedback loop
+
+Sources:
+
+- Tsinghua AIR, evolvable agents seminar: https://air.tsinghua.edu.cn/info/1008/2483.htm
+- Tsinghua EE, embodied decision intelligence / RL: https://www.ee.tsinghua.edu.cn/info/1076/4984.htm
+- Tsinghua AIR + Alibaba, evolvable agent research: https://air.tsinghua.edu.cn/info/1007/2130.htm
+- BAAI community embodied intelligence knowledge base: https://hub.baai.ac.cn/view/44356
+
+### 5. Switzerland / ETH Zurich
+
+Swiss research signals are useful because they are less hype-heavy and more system-heavy:
+
+- controlled testing before deployment
+- autonomy in real environments
+- language-informed world models
+- real-world robotics with reinforcement learning and imitation learning
+
+Useful anchors:
+
+- ETH's 2025 German-language note on mini-labs explicitly argues for controlled test environments where AI systems are verified before real-world operation.
+- ETH's `LIMT` work uses pre-trained language models to extract semantically meaningful task representations for multi-task visual world models.
+- ETH autonomy and robotics labs consistently frame autonomy as perception + abstraction + mapping + planning in uncertain environments.
+
+Operational takeaway:
+
+- the Swiss pattern is not just "more capability"
+- it is strong verification plus language-informed, model-based control
+
+Sources:
+
+- ETH Zurich, controlled mini-labs for AI verification (German): https://ethz.ch/de/news-und-veranstaltungen/eth-news/news/2025/03/ki-im-mini-labor-oder-die-praezision-auf-dem-pruefstand.html
+- ETH research collection, LIMT: https://www.research-collection.ethz.ch/items/9dce525a-a24d-4b43-985d-e5c4a95930ee
+- ETH Autonomous Systems Lab: https://asl.ethz.ch/the-lab.html
+
+## Synthesis: what "AI senses" should mean in practice
+
+The five human senses are not enough as a system model.
+
+For agents, a better practical set is:
+
+1. `external perception`
+   vision, text, audio, events, nearby entities
+
+2. `self-state`
+   location, internal variables, tool state, battery, memory budget, session state
+
+3. `motion / trajectory`
+   what is moving, where the agent is going, what changed over time
+
+4. `social / relational awareness`
+   who is nearby, friend/foe/team/authority, crowd or multi-agent state
+
+5. `affordance awareness`
+   what actions are even possible here: buttons, APIs, tools, code exec, manipulators, routes
+
+6. `memory / phase awareness`
+   what just happened, what stage of the task we are in, what earlier context matters now
+
+7. `risk / policy awareness`
+   what is allowed, what is costly, what requires approval, what must be denied or quarantined
+
+These are not all "senses" in a biological sense. But they are all required input channels for reliable action.
+
+## Choice monitoring: where the system should watch action formation
+
+Choice monitoring should happen in three windows:
+
+### Before action
+
+- what state does the system think it is in
+- what options does it believe are available
+- what risks are already visible
+- what policy class applies
+
+### During action
+
+- is the agent deviating from the approved path
+- is uncertainty rising
+- has the environment changed
+- does the system need takeover, pause, or downgrade
+
+### After action
+
+- what happened
+- was the result safe
+- was the result useful
+- what trace becomes training data
+
+The blocked actions matter here. Denied or quarantined actions are high-signal evidence of intent before it fully blooms into execution.
+
+## Why this matters for Everweave / Six Tongues / long-form logs
+
+The Everweave logs are potentially valuable because they contain:
+
+- long-horizon human/AI interaction
+- role and relationship continuity
+- lore, humor, family structure, anger, control, negotiation
+- shifting task context over time
+- naturally occurring semantics rather than sterile synthetic prompts
+
+That can be useful as a seed for tokenizer growth or lexicon bootstrapping.
+
+But the research above suggests not using it alone.
+
+The better stack is:
+
+### Layer A: semantic seed
+
+Everweave logs provide:
+
+- expressive language
+- persistent motifs
+- natural phrase recurrence
+- role-conditioned meaning
+
+### Layer B: operational traces
+
+System logs provide:
+
+- actions attempted
+- actions denied
+- actions approved
+- monitoring state
+- recovery paths
+
+### Layer C: controlled evaluation batches
+
+Run long-form logs through:
+
+- sense extraction
+- world-state reconstruction
+- policy/risk labeling
+- action affordance labeling
+- memory-phase labeling
+
+This is where your pivot/Colab work should expand.
+
+## Recommended controlled test batches
+
+### Batch 1: Perception-to-state reconstruction
+
+Goal:
+
+- from long conversation turns, reconstruct the implied world state
+
+Labels:
+
+- entities
+- relations
+- motion
+- time/phase
+- emotional tone
+- implied constraints
+
+### Batch 2: Choice-formation traces
+
+Goal:
+
+- label where the decision became likely before the action happened
+
+Labels:
+
+- option set
+- trigger
+- hesitation
+- override request
+- blocked path
+- final action
+
+### Batch 3: Unbloomed buds
+
+Goal:
+
+- explicitly preserve denied/quarantined action traces
+
+Labels:
+
+- disallowed action
+- reason for block
+- confidence
+- alternate safe action
+- whether the agent persisted or yielded
+
+### Batch 4: Growing lexicon
+
+Goal:
+
+- allow vocabulary/phrase growth without destroying the base semantic map
+
+Method:
+
+- keep a stable core lexicon
+- add extension lexicons with provenance
+- require cross-mapping between new lexical clusters and existing Six Tongues anchors
+
+### Batch 5: Multimodal action affordances
+
+Goal:
+
+- map language to executable/tool-level affordances
+
+Examples:
+
+- browser click path
+- code execution path
+- query/search path
+- navigation/robotics action path
+
+## Best current interpretation
+
+The broad convergence is:
+
+- military research -> multi-domain situational awareness + assurance
+- MIT/Harvard -> multimodal/world-model perception + coordination + predictive action
+- China -> evolvable agents + embodied intelligence + RL/infrastructure co-design
+- Switzerland -> controlled evaluation + language-informed world models + real-world robotics
+
+Your intuition that AI needs "more than five senses" is directionally right.
+
+The cleaner technical framing is:
+
+- multimodal channels
+- fused situational model
+- affordance layer
+- policy/risk layer
+- monitored choice formation
+- replayable traces for learning
+
+## Notes on access
+
+This pass did not require a VPN. Official U.S., Chinese university, BAAI community, and ETH sources were accessible directly from this environment.
+
+If you want a deeper China-specific pass later, the next layer would be:
+
+- official lab pages behind WeChat posts
+- university seminar archives
+- Chinese patent and standards materials
+- more specialized embodied-intelligence company ecosystems
+
+That may benefit from alternate network routing, but it was not necessary for this first pass.

--- a/docs/specs/AETHER_REALTIME_VOICE_CALL_OPTIONS.md
+++ b/docs/specs/AETHER_REALTIME_VOICE_CALL_OPTIONS.md
@@ -1,0 +1,255 @@
+# Aether Realtime Voice Call Options
+
+Last updated: 2026-03-17
+
+## Goal
+
+Answer the practical question: can Aether/SCBE call Issac on a real phone, and can it support realtime spoken conversation like a voice assistant?
+
+Short answer: yes, but there are two different implementation lanes:
+
+1. browser/app realtime voice
+2. phone-number / PSTN calling
+
+They share some logic, but they are not the same product.
+
+## Current local repo state
+
+What already exists in this repo:
+
+- Source voice material lives under `artifacts/voice/`
+- Local recording path exists via `scripts/voice_record.py` (referenced by `artifacts/voice/README.md`)
+- Emulator/phone preview lane exists via:
+  - `scripts/system/hydra_browser_phone_bridge.py`
+  - `scripts/system/phone_eye.py`
+- Audio-governance experiment lane now exists via:
+  - `src/harmonic/voxelRecord.ts`
+  - `scripts/audio_gate_spectrum_report.py`
+
+What does not appear to exist yet:
+
+- no active telephony provider integration
+- no PSTN/SIP call ingress
+- no production realtime voice session server
+- no phone-number routing or call control layer
+
+So today the repo has `voice assets + phone preview + audio analysis`, but not a true call stack.
+
+## Option A: Browser or app realtime voice
+
+Best first prototype if the goal is "talk to the system live."
+
+Use a browser or mobile app mic, connect directly to a realtime model, and keep tool logic on the application server.
+
+Why this is the easiest first win:
+
+- lower operational complexity than phone-number telephony
+- easier to debug
+- keeps the user inside Aether surfaces
+- maps directly to the existing AetherBrowse / phone lane direction
+
+Official basis:
+
+- OpenAI recommends WebRTC for browser/mobile realtime clients
+- OpenAI supports a sideband server connection for monitoring, tool calls, and instruction updates
+
+## Option B: Real phone number that can call or answer
+
+Best if the goal is "give the system a phone identity."
+
+This requires a telecom layer. The clean shapes are:
+
+- SIP trunk -> OpenAI Realtime SIP
+- Twilio Media Streams / ConversationRelay -> your app server
+- full-stack telecom provider such as SignalWire or Telnyx
+
+This is more powerful, but it adds:
+
+- phone numbers
+- telecom billing
+- call routing
+- webhooks
+- compliance/recording concerns
+- latency and failover work
+
+## Recommended architecture order
+
+### Phase 1: Realtime app voice
+
+Build:
+
+- browser/app mic input
+- OpenAI Realtime WebRTC session
+- server-side tool and policy sideband
+- local transcript + event logging
+- optional SCBE audio telemetry overlay
+
+Outcome:
+
+- user can talk to Aether in realtime
+- easier training and iteration loop
+- easiest place to test persona, latency, interruption handling, and tool use
+
+### Phase 2: Phone call lane
+
+Add:
+
+- telecom provider
+- inbound/outbound phone number
+- SIP or streaming bridge
+- call event logging
+- safety/consent prompts if recording
+
+Outcome:
+
+- the system can answer or place real phone calls
+- same core assistant logic can be reused
+
+## Best provider patterns
+
+### OpenAI Realtime + WebRTC
+
+Best for:
+
+- browser/mobile voice assistant
+- low-latency speech-to-speech
+- tool-calling with server-side monitoring
+
+Notes:
+
+- strong fit for AetherBrowse / phone-app lane
+- not by itself a phone-number solution
+
+### OpenAI Realtime + SIP
+
+Best for:
+
+- direct phone/SIP integration
+- keeping the model on the OpenAI realtime side
+
+Notes:
+
+- still needs a SIP trunking provider
+- good if you want the shortest "real phone number to realtime model" path
+
+### Twilio Media Streams
+
+Best for:
+
+- maximum control
+- custom STT/TTS or custom model routing
+
+Notes:
+
+- you manage more of the stack
+- good when you want raw audio and your own orchestration
+
+### Twilio ConversationRelay
+
+Best for:
+
+- faster phone-agent MVP
+- Twilio handling STT/TTS/session details while your app handles logic
+
+Notes:
+
+- cleaner than raw streams for many assistants
+- useful if you want a phone number quickly without owning every media detail
+
+### SignalWire
+
+Best for:
+
+- telecom-native AI voice stack
+- multi-agent call routing
+- Python-friendly voice agent flows
+
+Notes:
+
+- attractive if the long-term vision is many agents and call routing
+- heavier platform decision than a simple MVP
+
+## What I would do here
+
+### If the goal is "Cortana for me"
+
+Start with:
+
+1. realtime browser/app voice
+2. persistent session memory
+3. server-side tool lane
+4. transcripts + traces
+5. later add phone-number calling
+
+This gets the conversation quality right before telecom complexity.
+
+### If the goal is "it has its own phone number"
+
+Start with:
+
+1. Twilio ConversationRelay or OpenAI Realtime SIP
+2. one inbound number
+3. one simple persona/tool loop
+4. no outbound calling until the inbound loop is stable
+
+## Training implications
+
+Realtime conversation training is not the same as normal chat SFT.
+
+You will want to capture:
+
+- turn timing
+- interruptions / barge-in
+- ASR uncertainty
+- tool latency
+- hesitation / correction moments
+- failed actions and handoff requests
+
+Those are part of the "choice monitoring" lane, not just the content lane.
+
+Good training artifacts:
+
+- transcript
+- timestamps
+- audio features
+- policy events
+- tool events
+- interruption markers
+- final satisfaction or correction label
+
+## SCBE-specific fit
+
+The clean SCBE mapping is:
+
+- realtime mic / phone audio = perception channel
+- session state = fused world state
+- tool sideband = affordance / execution sense
+- policy gate = risk sense
+- interrupt + barge-in handling = reflex/recovery loop
+- saved traces = unbloomed buds + post-action learning
+
+## MVP recommendation
+
+Build this first:
+
+1. `voice-chat` web route or phone-side panel
+2. OpenAI Realtime WebRTC session
+3. server-side sideband control
+4. transcript/event logger
+5. optional `audio_gate_spectrum_report` post-analysis
+
+Do not start with:
+
+- full outbound phone automation
+- multi-agent live call routing
+- custom telecom stack
+- large-scale training before the realtime loop is stable
+
+## Sources
+
+- OpenAI Realtime WebRTC: `https://developers.openai.com/api/docs/guides/realtime-webrtc`
+- OpenAI Realtime SIP: `https://developers.openai.com/api/docs/guides/realtime-sip`
+- OpenAI server-side controls: `https://developers.openai.com/api/docs/guides/realtime-server-controls`
+- Twilio Media Streams: `https://www.twilio.com/docs/voice/media-streams`
+- Twilio ConversationRelay: `https://www.twilio.com/docs/voice/twiml/connect/conversationrelay`
+- SignalWire AI voice stack: `https://signalwire.com/c/telecom-stack-ai-voice`

--- a/docs/specs/SCBE_AUDIO_GATE_SPECTRUM_EXPERIMENT.md
+++ b/docs/specs/SCBE_AUDIO_GATE_SPECTRUM_EXPERIMENT.md
@@ -1,0 +1,298 @@
+# SCBE Audio Gate Spectrum Experiment
+
+Last updated: 2026-03-17
+
+## Why this note exists
+
+The repo already has real audio and acoustics primitives:
+
+- [audioAxis.ts](/C:/Users/issda/SCBE-AETHERMOORE/packages/kernel/src/audioAxis.ts)
+- [vacuumAcoustics.ts](/C:/Users/issda/SCBE-AETHERMOORE/packages/kernel/src/vacuumAcoustics.ts)
+- [temporalIntent.ts](/C:/Users/issda/SCBE-AETHERMOORE/packages/kernel/src/temporalIntent.ts)
+
+But it does **not** yet have a full production audio-generation engine.
+
+So the right move is:
+
+1. state what is already real
+2. define what "expand the gate to a spectrum" actually means
+3. run controlled tests before claiming voice-quality gains
+
+## What is already real
+
+### Audio Axis
+
+[audioAxis.ts](/C:/Users/issda/SCBE-AETHERMOORE/packages/kernel/src/audioAxis.ts) already computes frame-level features:
+
+- `energy`
+- `centroid`
+- `flux`
+- `hfRatio`
+- `stability`
+
+This is a telemetry layer, not a synthesizer.
+
+### Vacuum Acoustics
+
+[vacuumAcoustics.ts](/C:/Users/issda/SCBE-AETHERMOORE/packages/kernel/src/vacuumAcoustics.ts) already provides:
+
+- nodal surface calculations
+- cymatic resonance checks
+- bottle-beam intensity
+- flux redistribution
+- standing-wave amplitude
+- cavity resonance
+
+This is a spatial/acoustic math layer, not a DAW.
+
+### Harmonic / Temporal layers
+
+[packages/kernel/src/index.ts](/C:/Users/issda/SCBE-AETHERMOORE/packages/kernel/src/index.ts) exposes:
+
+- hyperbolic distance
+- breath transform
+- phase modulation
+- multi-well potential
+- harmonic scaling
+
+That is enough to define an audio-governance experiment, not enough to claim "physics-based natural speech rendering" yet.
+
+## Clean interpretation of the idea
+
+"Expand the gate to a spectrum" should mean:
+
+- move from one scalar allow/quarantine/deny score
+- to a **banded audio quality/risk profile** across time and frequency
+
+Instead of:
+
+- one final gate score for the whole utterance
+
+Use:
+
+- per-frame spectral telemetry
+- per-band drift
+- per-band stability
+- per-band harmonic-wall pressure
+- per-scene spatial resonance checks
+
+## Proposed model
+
+### 1. Audio state vector
+
+For each frame `t`, compute:
+
+`A_t = [energy, centroid, flux, hfRatio, stability, breathPhase, temporalDrift, harmonicCost]`
+
+Where:
+
+- first five come from `audioAxis`
+- `breathPhase` comes from Layer 6/7 modulation
+- `temporalDrift` comes from timing mismatch
+- `harmonicCost` comes from the wall
+
+### 2. Spectrum gate
+
+For each frame, split the spectrum into bands:
+
+- `B1` low / body
+- `B2` low-mid / warmth
+- `B3` mid / intelligibility
+- `B4` upper-mid / presence
+- `B5` high / air
+- `B6` sibilant / instability edge
+
+Then compute:
+
+`Gate_t = [g1, g2, g3, g4, g5, g6]`
+
+Each `g_i` is not just "good/bad." It is:
+
+- stable
+- pressured
+- near-break
+- quarantined
+
+This matches the intuition that real voices live near boundaries in some bands without collapsing globally.
+
+## Practical meaning of the "vibrato edge"
+
+The earlier conversation is directionally right but too poetic if left ungrounded.
+
+A better engineering interpretation is:
+
+- some bands can approach instability without making the whole frame invalid
+- controlled oscillation near a boundary may be desirable
+- global failure happens when too many bands cross the threshold together or when the wrong bands destabilize
+
+So:
+
+- `allowed edge` != `failure`
+- `spectral pressure` can be a feature
+- but it needs bounded monitoring
+
+## Voxel rotation idea
+
+The useful version of "rotate sound through the voxel thing" is:
+
+- map frame-level audio state into a 6D addressable representation
+- rotate or traverse that representation under controlled transforms
+- compare output coherence before and after rotation
+
+Not:
+
+- "spin sound because it feels right"
+
+Candidate 6D voxel mapping:
+
+`V = [body, clarity, air, phase, pressure, semanticIntent]`
+
+Example:
+
+- `body` from low-band energy
+- `clarity` from mid-band intelligibility
+- `air` from high-band ratio
+- `phase` from temporal phase transform
+- `pressure` from drift/harmonic-wall cost
+- `semanticIntent` from tongue-weight or prompt class
+
+Then test:
+
+- fixed rotation
+- slow phase rotation
+- resonance-aligned rotation
+
+Measure:
+
+- stability delta
+- intelligibility delta
+- coherence delta
+- perceived realism delta
+
+## Controlled test batches
+
+Do not jump straight to novel scenes. Use three controls first.
+
+### Control A: Known clean human speech
+
+Input:
+
+- short clean spoken samples
+- multiple speakers
+
+Goal:
+
+- establish baseline feature ranges
+
+Measures:
+
+- centroid variance
+- flux variance
+- hfRatio profile
+- frame stability histogram
+
+### Control B: Known synthetic TTS
+
+Input:
+
+- flat TTS
+- emotional TTS
+- multi-speaker TTS
+
+Goal:
+
+- measure where synthetic speech diverges from the clean human baseline
+
+### Control C: Processed synthetic TTS through SCBE audio stack
+
+Input:
+
+- same TTS samples
+- add SCBE band gate, breath/phase modulation, optional voxel rotation
+
+Goal:
+
+- determine whether the processed output moves closer to the human baseline or just becomes stranger
+
+## Evaluation criteria
+
+Use both machine and human checks.
+
+### Machine-side
+
+- word error rate / Whisper re-transcription
+- spectral coherence drift
+- per-band gate profile
+- timing regularity
+- resonance consistency
+
+### Human-side
+
+- intelligibility
+- emotional plausibility
+- room believability
+- "sounds alive" rating
+- "sounds broken" rating
+
+## Pivot log integration
+
+The pivot or long-form conversation logs should not go directly into audio generation.
+
+Use them for:
+
+- emotional state labeling
+- relationship context
+- pause/hesitation patterns
+- control vs collapse patterns
+- recurring lexical and semantic motifs
+
+Then derive:
+
+- intent labels
+- scene-phase labels
+- allowed edge-pressure ranges
+- per-character temporal pacing priors
+
+That is the safe bridge from lore logs to audio experiments.
+
+## What not to claim yet
+
+Do not claim yet that:
+
+- the 14-layer pipeline is already a complete audio engine
+- harmonic wall alone creates natural vibrato
+- voxel rotation improves voice realism
+
+Those are hypotheses until tested.
+
+## Immediate next implementation
+
+1. Add a small TS or Python experiment runner that:
+   - loads WAV
+   - computes audioAxis features per frame
+   - derives 6 band metrics
+   - emits JSON telemetry
+
+2. Add an "audio gate spectrum" report:
+   - per-band state over time
+   - flagged instability windows
+   - recommended corrective action
+
+3. Add optional voxel projection:
+   - map frame to 6D
+   - apply deterministic rotation
+   - compare before/after telemetry
+
+4. Run the three-control experiment set before touching full narrative scenes
+
+## Bottom line
+
+The strong version of the idea is not:
+
+- "SCBE is secretly already a DAW"
+
+It is:
+
+- SCBE already has enough signal-processing, harmonic, and spatial primitives to support a serious controlled audio-governance experiment.
+
+That is worth building.

--- a/kindle-app/www/browse.html
+++ b/kindle-app/www/browse.html
@@ -47,7 +47,8 @@ body {
 /* Homepage */
 .homepage {
   flex: 1; display: flex; flex-direction: column;
-  align-items: center; padding: 32px 16px;
+  align-items: stretch; width: min(100%, 980px);
+  margin: 0 auto; padding: 24px 16px;
 }
 .homepage h1 {
   font-size: 28px; font-weight: 700; margin-bottom: 4px;
@@ -59,7 +60,7 @@ body {
 /* Quick links grid */
 .quick-links {
   display: grid; grid-template-columns: repeat(4, 1fr);
-  gap: 12px; width: 100%; max-width: 400px; margin-bottom: 24px;
+  gap: 12px; width: 100%; margin-bottom: 24px;
 }
 .qlink {
   display: flex; flex-direction: column; align-items: center;
@@ -73,14 +74,14 @@ body {
 
 /* Section headers */
 .section-head {
-  width: 100%; max-width: 400px; font-size: 11px; font-weight: 600;
+  width: 100%; font-size: 11px; font-weight: 600;
   color: #6c5ce7; text-transform: uppercase; letter-spacing: 1px;
   margin: 16px 0 8px; padding-left: 4px;
 }
 
 /* Recent / frequent list */
 .recent-list {
-  width: 100%; max-width: 400px; display: flex; flex-direction: column; gap: 2px;
+  width: 100%; display: flex; flex-direction: column; gap: 2px;
 }
 .recent-item {
   display: flex; align-items: center; gap: 10px;
@@ -320,6 +321,27 @@ document.getElementById("backBtn").addEventListener("click", () => {
   activeTabId = null;
   showActive();
 });
+
+// =========================================================
+// Android back button (Capacitor)
+// =========================================================
+// Intercept the hardware back button so it returns to the Home tab
+// instead of navigating the WebView history (which causes a white screen).
+if (window.Capacitor && window.Capacitor.Plugins && window.Capacitor.Plugins.App) {
+  window.Capacitor.Plugins.App.addListener("backButton", (ev) => {
+    if (activeTabId) {
+      // Active tab is open — go back to homepage
+      activeTabId = null;
+      showActive();
+    } else if (ev.canGoBack) {
+      // On homepage but there's WebView history (came back from external site)
+      window.history.back();
+    } else {
+      // On homepage, no history — minimize / exit
+      window.Capacitor.Plugins.App.minimizeApp();
+    }
+  });
+}
 
 // =========================================================
 // Init

--- a/kindle-app/www/device-shell.html
+++ b/kindle-app/www/device-shell.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<title>AI Device Shell</title>
+<link rel="manifest" href="./manifest.json">
+<link rel="icon" href="./static/icons/icon-192.png">
+<meta name="theme-color" content="#17c6cf">
+<link rel="stylesheet" href="./static/phone-shell.css">
+</head>
+<body>
+<div class="phone-shell has-primary-surface">
+  <section class="hero">
+    <div class="hero-top">
+      <span class="eyebrow">AI Device Shell</span>
+      <div class="actions">
+        <a class="btn-link" href="./polly-pad.html">Launcher</a>
+        <a class="btn-link" href="./browse.html">Browse</a>
+      </div>
+    </div>
+    <h1>One device. One main surface. One assistant surface.</h1>
+    <p class="lede">
+      This is the owned phone/tablet shell for the agent lane. The main panel stays large. The assistant panel stays visible.
+      Headless jobs can run in parallel, but this page preserves one readable live screen.
+    </p>
+    <div class="actions">
+      <span class="pill" id="runtimePill">Runtime: loading</span>
+      <span class="pill" id="mainPill">Main: loading</span>
+      <span class="pill" id="assistantPill">Assistant: loading</span>
+    </div>
+  </section>
+
+  <section class="section surface-primary">
+    <div class="section-head">
+      <div>
+        <h2>Main Surface</h2>
+        <p class="section-copy">Keep the real working screen here. Reader, Browse, Test, or another local route.</p>
+      </div>
+      <div class="actions">
+        <button class="btn" type="button" id="swapBtn">Swap Panels</button>
+      </div>
+    </div>
+    <div class="tab-row" id="mainPresetRow"></div>
+    <div class="iframe-shell">
+      <div class="iframe-toolbar">
+        <input id="mainRouteInput" type="text" placeholder="./browse.html">
+        <button class="btn primary" type="button" id="mainLoadBtn">Load Main</button>
+        <a class="btn-link secondary" id="mainOpenLink" target="_blank" rel="noopener">Open Full</a>
+      </div>
+      <iframe class="frame" id="mainFrame" title="Main Device Surface" referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-top-navigation"></iframe>
+    </div>
+  </section>
+
+  <section class="section surface-support">
+    <div class="section-head">
+      <div>
+        <h2>Assistant Surface</h2>
+        <p class="section-copy">Keep Ops, Test, or another helper lane visible without stealing the main panel.</p>
+      </div>
+    </div>
+    <div class="tab-row" id="assistantPresetRow"></div>
+    <div class="iframe-shell">
+      <div class="iframe-toolbar">
+        <input id="assistantRouteInput" type="text" placeholder="./ops.html">
+        <button class="btn primary" type="button" id="assistantLoadBtn">Load Assistant</button>
+        <a class="btn-link secondary" id="assistantOpenLink" target="_blank" rel="noopener">Open Full</a>
+      </div>
+      <iframe class="frame" id="assistantFrame" title="Assistant Device Surface" referrerpolicy="no-referrer" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-top-navigation"></iframe>
+    </div>
+  </section>
+
+  <section class="section surface-support">
+    <div class="section-head">
+      <div>
+        <h2>Operating Pattern</h2>
+        <p class="section-copy">This page is the live shell. Background agents stay off-screen; the visible agent keeps one coherent device state.</p>
+      </div>
+    </div>
+    <div class="card-grid">
+      <article class="card">
+        <h3>Main panel</h3>
+        <p class="small-note">Put the browser, reader, or target lane here. It should stay the biggest visible surface.</p>
+      </article>
+      <article class="card">
+        <h3>Assistant panel</h3>
+        <p class="small-note">Keep Ops or Test here for synthesis, diagnostics, and command relay.</p>
+      </article>
+      <article class="card">
+        <h3>Headless lanes</h3>
+        <p class="small-note">Use background browser or workflow agents for extra work without destroying the live screen.</p>
+      </article>
+    </div>
+  </section>
+</div>
+
+<script src="./static/phone-shell.js"></script>
+<script>
+const STATE_KEY = "scbe.device.shell.v1";
+const PRESETS = [
+  { label: "Browse", route: "./browse.html" },
+  { label: "Reader", route: "./reader.html?chapter=ch01&variant=generated" },
+  { label: "Test", route: "./test.html" },
+  { label: "Ops", route: "./ops.html" },
+  { label: "Pad", route: "./polly-pad.html" }
+];
+
+function readState() {
+  return PhoneShell.readStorageJson(STATE_KEY, {
+    main: "./browse.html",
+    assistant: "./ops.html"
+  });
+}
+
+function writeState(state) {
+  PhoneShell.writeStorageJson(STATE_KEY, state);
+}
+
+function resolveRoute(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "./browse.html";
+  return raw;
+}
+
+function renderPresetRow(containerId, targetKey) {
+  const container = document.getElementById(containerId);
+  const state = readState();
+  container.innerHTML = PRESETS.map((preset) => {
+    const active = state[targetKey] === preset.route ? " active" : "";
+    return `<button class="tab-chip${active}" type="button" data-surface="${targetKey}" data-route="${PhoneShell.escapeHtml(preset.route)}">${PhoneShell.escapeHtml(preset.label)}</button>`;
+  }).join("");
+}
+
+function renderShell() {
+  const state = readState();
+  const mainRoute = resolveRoute(state.main);
+  const assistantRoute = resolveRoute(state.assistant);
+  document.getElementById("runtimePill").textContent = `Runtime: ${PhoneShell.runtimeLabel()}`;
+  document.getElementById("mainPill").textContent = `Main: ${mainRoute}`;
+  document.getElementById("assistantPill").textContent = `Assistant: ${assistantRoute}`;
+  document.getElementById("mainRouteInput").value = mainRoute;
+  document.getElementById("assistantRouteInput").value = assistantRoute;
+  document.getElementById("mainFrame").src = mainRoute;
+  document.getElementById("assistantFrame").src = assistantRoute;
+  document.getElementById("mainOpenLink").href = mainRoute;
+  document.getElementById("assistantOpenLink").href = assistantRoute;
+  renderPresetRow("mainPresetRow", "main");
+  renderPresetRow("assistantPresetRow", "assistant");
+  document.querySelectorAll("[data-surface]").forEach((node) => {
+    node.addEventListener("click", () => {
+      const next = readState();
+      next[node.dataset.surface] = node.dataset.route;
+      writeState(next);
+      renderShell();
+    });
+  });
+}
+
+function loadSurface(targetKey) {
+  const state = readState();
+  state[targetKey] = resolveRoute(document.getElementById(`${targetKey}RouteInput`).value);
+  writeState(state);
+  renderShell();
+}
+
+document.getElementById("mainLoadBtn").addEventListener("click", () => loadSurface("main"));
+document.getElementById("assistantLoadBtn").addEventListener("click", () => loadSurface("assistant"));
+document.getElementById("swapBtn").addEventListener("click", () => {
+  const state = readState();
+  const next = { main: state.assistant, assistant: state.main };
+  writeState(next);
+  renderShell();
+});
+document.getElementById("mainRouteInput").addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    loadSurface("main");
+  }
+});
+document.getElementById("assistantRouteInput").addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    loadSurface("assistant");
+  }
+});
+
+renderShell();
+</script>
+</body>
+</html>

--- a/kindle-app/www/ops.html
+++ b/kindle-app/www/ops.html
@@ -1,0 +1,384 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<title>Ops Lane</title>
+<link rel="manifest" href="./manifest.json">
+<link rel="icon" href="./static/icons/icon-192.png">
+<meta name="theme-color" content="#17c6cf">
+<link rel="stylesheet" href="./static/phone-shell.css">
+</head>
+<body>
+<div class="phone-shell has-primary-surface">
+  <section class="hero">
+    <div class="hero-top">
+      <span class="eyebrow">Ops Lane</span>
+      <div class="actions">
+        <a class="btn-link" href="./polly-pad.html">Launcher</a>
+        <a class="btn-link" href="./test.html">Test</a>
+      </div>
+    </div>
+    <h1>Chat, bridge control, and diagnostics.</h1>
+    <p class="lede">
+      This is the ops surface for the phone shell: one threaded chat, one bridge config, and lightweight diagnostics that confirm whether the backend is alive.
+    </p>
+    <div class="actions">
+      <span class="pill" id="runtimePill">Runtime: loading</span>
+      <span class="pill" id="providerPill">Provider: none</span>
+      <span class="status-pill" id="statusPill">Idle</span>
+    </div>
+  </section>
+
+  <section class="section surface-support">
+    <div class="section-head">
+      <div>
+        <h2>Bridge Settings</h2>
+        <p class="section-copy">Chat uses the bridge base. Diagnostics also use the bridge key because the integration status route is protected.</p>
+      </div>
+    </div>
+    <div class="field-grid">
+      <div class="field">
+        <label for="apiBaseInput">Bridge API base</label>
+        <input id="apiBaseInput" type="text">
+      </div>
+      <div class="field">
+        <label for="apiKeyInput">Bridge API key</label>
+        <input id="apiKeyInput" type="text" placeholder="scbe-dev-key">
+      </div>
+      <div class="field" style="grid-column:1/-1">
+        <label for="systemPromptInput">System prompt</label>
+        <input id="systemPromptInput" type="text" value="You are AetherCode Ops. Be concise, practical, and honest about limits.">
+      </div>
+    </div>
+    <div class="actions">
+      <button class="btn" type="button" id="saveSettingsBtn">Save</button>
+      <button class="btn secondary" type="button" id="refreshDiagBtn">Refresh Diagnostics</button>
+    </div>
+  </section>
+
+  <section class="section surface-support" id="sharedSection" hidden>
+    <div class="section-head">
+      <div>
+        <h2>Shared Target</h2>
+        <p class="section-copy">Browse and Test can push a URL here so you can immediately ask the backend about it.</p>
+      </div>
+    </div>
+    <div class="card">
+      <div class="small-note" id="sharedMeta"></div>
+      <h3 id="sharedTitle">Untitled</h3>
+      <div class="small-note mono" id="sharedUrl"></div>
+      <div class="actions" style="margin-top:10px">
+        <button class="btn primary" type="button" id="injectSharedBtn">Inject into Composer</button>
+        <a class="btn-link" href="./browse.html">Back to Browse</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="section surface-support">
+    <div class="section-head">
+      <div>
+        <h2>Diagnostics</h2>
+        <p class="section-copy">Small checks only: health, providers, and browser integration reachability.</p>
+      </div>
+    </div>
+    <div class="card-grid" id="diagGrid"></div>
+  </section>
+
+  <section class="section surface-support">
+    <div class="section-head">
+      <div>
+        <h2>Providers</h2>
+        <p class="section-copy">These chips come from `v1/providers`. Pick one and keep the thread normal.</p>
+      </div>
+      <button class="btn" type="button" id="refreshProvidersBtn">Refresh Providers</button>
+    </div>
+    <div class="chip-row" id="providerChips"></div>
+  </section>
+
+  <section class="stack-card surface-primary">
+    <div class="stack-head">
+      <div class="meta-row">
+        <div>
+          <h2>Conversation</h2>
+          <p class="section-copy">Ops chat is a single clean thread over `v1/chat`.</p>
+        </div>
+        <button class="btn" type="button" id="clearThreadBtn">Clear</button>
+      </div>
+    </div>
+    <div class="stack-body">
+      <div class="thread" id="thread"></div>
+      <form id="composerForm">
+        <div class="composer">
+          <textarea id="composerInput" placeholder="Ask the backend to inspect the shared target, debug a route, or explain a failure. Shift+Enter makes a new line."></textarea>
+          <div class="actions">
+            <label class="small-note"><input id="keepThreadCheckbox" type="checkbox" checked> Keep thread memory</label>
+            <button class="btn primary" type="submit" id="sendBtn">Send</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </section>
+</div>
+
+<script src="./static/phone-shell.js"></script>
+<script>
+const STATE_KEY = "scbe.ops.settings.v1";
+const THREAD_KEY = "scbe.ops.thread.v1";
+const TENTACLE_KEY = "scbe.ops.tentacle.v1";
+let providers = [];
+let thread = PhoneShell.readStorageJson(THREAD_KEY, []);
+let pending = false;
+
+function settings() {
+  return {
+    apiBase: document.getElementById("apiBaseInput").value.trim(),
+    apiKey: document.getElementById("apiKeyInput").value.trim(),
+    systemPrompt: document.getElementById("systemPromptInput").value.trim(),
+  };
+}
+
+function saveSettings() {
+  const state = settings();
+  PhoneShell.writeStorageJson(STATE_KEY, state);
+  return state;
+}
+
+function selectedProvider() {
+  return localStorage.getItem(TENTACLE_KEY) || "";
+}
+
+function setSelectedProvider(value) {
+  localStorage.setItem(TENTACLE_KEY, value);
+  document.getElementById("providerPill").textContent = `Provider: ${value || "none"}`;
+}
+
+function setStatus(label, tone = "") {
+  const pill = document.getElementById("statusPill");
+  pill.textContent = label;
+  pill.className = `status-pill${tone ? ` ${tone}` : ""}`;
+}
+
+function renderThread() {
+  const target = document.getElementById("thread");
+  if (!thread.length) {
+    target.innerHTML = `<div class="card"><div class="small-note">No messages yet. Choose a provider, then ask about the active app lane, bridge health, or the shared target.</div></div>`;
+    return;
+  }
+  target.innerHTML = thread.map((item) => `
+    <article class="bubble ${PhoneShell.escapeHtml(item.role)}">
+      <div class="bubble-text">${PhoneShell.escapeHtml(item.content)}</div>
+      ${item.meta ? `<div class="bubble-meta">${PhoneShell.escapeHtml(item.meta)}</div>` : ""}
+    </article>
+  `).join("");
+  target.scrollTop = target.scrollHeight;
+}
+
+function storeThread() {
+  PhoneShell.writeStorageJson(THREAD_KEY, thread.slice(-24));
+}
+
+function normaliseProviders(data) {
+  if (Array.isArray(data?.tentacles)) return data.tentacles;
+  if (data?.providers && typeof data.providers === "object") {
+    return Object.entries(data.providers).map(([tentacle, row]) => ({ tentacle, ...row }));
+  }
+  if (data && typeof data === "object") {
+    return Object.entries(data).map(([tentacle, row]) => ({ tentacle, ...(typeof row === "object" ? row : { available: Boolean(row) }) }));
+  }
+  return [];
+}
+
+function renderProviders() {
+  const selected = selectedProvider();
+  const target = document.getElementById("providerChips");
+  if (!providers.length) {
+    target.innerHTML = `<span class="status-pill bad">No providers returned</span>`;
+    return;
+  }
+  target.innerHTML = providers.map((row) => {
+    const active = row.tentacle === selected ? " active" : "";
+    const disabled = row.available ? "" : " disabled";
+    const offline = row.available ? "" : " offline";
+    return `<button class="chip${active}${offline}" type="button" data-provider="${PhoneShell.escapeHtml(row.tentacle)}"${disabled}>${PhoneShell.escapeHtml((row.display_name || row.tentacle) + " · " + (row.model || "model?"))}</button>`;
+  }).join("");
+  document.querySelectorAll("[data-provider]").forEach((node) => {
+    node.addEventListener("click", () => {
+      setSelectedProvider(node.getAttribute("data-provider"));
+      renderProviders();
+    });
+  });
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  const payload = await PhoneShell.readJson(response);
+  if (!response.ok) {
+    throw new Error(typeof payload.detail === "string" ? payload.detail : JSON.stringify(payload.detail || payload));
+  }
+  return payload;
+}
+
+async function refreshProviders() {
+  const state = saveSettings();
+  try {
+    providers = normaliseProviders(await fetchJson(`${state.apiBase}/v1/providers`, { cache: "no-store" }));
+    if (!providers.some((row) => row.tentacle === selectedProvider() && row.available)) {
+      const first = providers.find((row) => row.available);
+      setSelectedProvider(first ? first.tentacle : "");
+    }
+    renderProviders();
+  } catch (error) {
+    providers = [];
+    renderProviders();
+    setStatus(String(error), "bad");
+  }
+}
+
+async function refreshDiagnostics() {
+  const state = saveSettings();
+  const cards = [];
+  try {
+    const health = await fetchJson(`${state.apiBase}/health`);
+    cards.push({ title: "Bridge Health", tone: "good", body: JSON.stringify(health, null, 2) });
+  } catch (error) {
+    cards.push({ title: "Bridge Health", tone: "bad", body: String(error) });
+  }
+  try {
+    const integration = await fetchJson(`${state.apiBase}/v1/integrations/status`, {
+      headers: { "X-API-Key": state.apiKey },
+    });
+    cards.push({ title: "Integration Status", tone: integration.browser_service?.reachable ? "good" : "warn", body: JSON.stringify(integration, null, 2) });
+  } catch (error) {
+    cards.push({ title: "Integration Status", tone: "bad", body: String(error) });
+  }
+  cards.push({
+    title: "Runtime",
+    tone: "warn",
+    body: JSON.stringify({ runtime: PhoneShell.runtimeLabel(), hostAlias: PhoneShell.runtimeHost }, null, 2),
+  });
+  document.getElementById("diagGrid").innerHTML = cards.map((card) => `
+    <article class="card">
+      <div class="meta-row">
+        <h3>${PhoneShell.escapeHtml(card.title)}</h3>
+        <span class="status-pill ${PhoneShell.escapeHtml(card.tone)}">${PhoneShell.escapeHtml(card.tone)}</span>
+      </div>
+      <pre class="artifact-pre">${PhoneShell.escapeHtml(card.body)}</pre>
+    </article>
+  `).join("");
+}
+
+function renderSharedTarget() {
+  const shared = PhoneShell.getSharedTarget();
+  if (!shared || !shared.url) return;
+  document.getElementById("sharedSection").hidden = false;
+  document.getElementById("sharedMeta").textContent = `${shared.source || "unknown"} · ${shared.savedAt || ""}`;
+  document.getElementById("sharedTitle").textContent = shared.title || "Shared target";
+  document.getElementById("sharedUrl").textContent = shared.url;
+  document.getElementById("injectSharedBtn").onclick = () => {
+    const prompt = `Inspect this target and tell me the fastest next action.\nURL: ${shared.url}\nNote: ${shared.note || "none"}`;
+    const composer = document.getElementById("composerInput");
+    composer.value = composer.value ? `${composer.value}\n\n${prompt}` : prompt;
+    composer.focus();
+  };
+}
+
+function buildContext() {
+  const ctx = [];
+  const state = saveSettings();
+  if (state.systemPrompt) {
+    ctx.push({ role: "system", content: state.systemPrompt });
+  }
+  if (document.getElementById("keepThreadCheckbox").checked) {
+    ctx.push(...thread.filter((item) => item.role === "user" || item.role === "assistant").slice(-12).map((item) => ({
+      role: item.role,
+      content: item.content,
+    })));
+  }
+  return ctx;
+}
+
+async function sendMessage(event) {
+  event.preventDefault();
+  if (pending) return;
+  const text = document.getElementById("composerInput").value.trim();
+  if (!text) return;
+  const provider = selectedProvider();
+  if (!provider) {
+    setStatus("Pick a provider first", "bad");
+    return;
+  }
+  const state = saveSettings();
+  thread.push({ role: "user", content: text });
+  storeThread();
+  renderThread();
+  document.getElementById("composerInput").value = "";
+  pending = true;
+  document.getElementById("sendBtn").disabled = true;
+  setStatus(`Sending to ${provider}...`, "warn");
+  try {
+    const data = await fetchJson(`${state.apiBase}/v1/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: text,
+        mode: "chat",
+        tentacle: provider,
+        context: buildContext(),
+      }),
+    });
+    thread.push({
+      role: "assistant",
+      content: data.response || "",
+      meta: `${data.tentacle || provider} / ${data.model || "model?"} / ${Math.round(data.latency_ms || 0)}ms`,
+    });
+    storeThread();
+    renderThread();
+    setStatus("Response received", "good");
+  } catch (error) {
+    thread.push({ role: "error", content: String(error) });
+    storeThread();
+    renderThread();
+    setStatus("Chat failed", "bad");
+  } finally {
+    pending = false;
+    document.getElementById("sendBtn").disabled = false;
+  }
+}
+
+const initial = PhoneShell.readStorageJson(STATE_KEY, {
+  apiBase: PhoneShell.bridgeBase(8001),
+  apiKey: "scbe-dev-key",
+  systemPrompt: "You are AetherCode Ops. Be concise, practical, and honest about limits.",
+});
+document.getElementById("apiBaseInput").value = initial.apiBase;
+document.getElementById("apiKeyInput").value = initial.apiKey;
+document.getElementById("systemPromptInput").value = initial.systemPrompt;
+document.getElementById("runtimePill").textContent = `Runtime: ${PhoneShell.runtimeLabel()}`;
+setSelectedProvider(selectedProvider());
+renderThread();
+renderSharedTarget();
+document.getElementById("saveSettingsBtn").addEventListener("click", () => {
+  saveSettings();
+  setStatus("Settings saved", "good");
+});
+document.getElementById("refreshDiagBtn").addEventListener("click", refreshDiagnostics);
+document.getElementById("refreshProvidersBtn").addEventListener("click", refreshProviders);
+document.getElementById("clearThreadBtn").addEventListener("click", () => {
+  thread = [];
+  storeThread();
+  renderThread();
+  setStatus("Thread cleared", "warn");
+});
+document.getElementById("composerForm").addEventListener("submit", sendMessage);
+document.getElementById("composerInput").addEventListener("keydown", (event) => {
+  if (event.key === "Enter" && !event.shiftKey) {
+    event.preventDefault();
+    document.getElementById("composerForm").requestSubmit();
+  }
+});
+refreshProviders();
+refreshDiagnostics();
+</script>
+</body>
+</html>

--- a/kindle-app/www/static/phone-shell.css
+++ b/kindle-app/www/static/phone-shell.css
@@ -1,0 +1,406 @@
+:root{
+  --bg:#07111d;
+  --bg2:#0e1a2c;
+  --surface:rgba(10,18,30,.94);
+  --surface-2:rgba(17,28,43,.84);
+  --card:rgba(255,255,255,.04);
+  --border:rgba(137,165,194,.22);
+  --text:#edf5ff;
+  --dim:#9bb2ca;
+  --accent:#17c6cf;
+  --accent-2:#ff9d5b;
+  --good:#2dd3a6;
+  --warn:#ffca68;
+  --bad:#ff7f7f;
+  --mono:"Cascadia Code","JetBrains Mono","Consolas",monospace;
+  --font:"Space Grotesk","Sora","Trebuchet MS",sans-serif;
+  --shadow:0 18px 42px rgba(0,0,0,.28);
+}
+
+*{box-sizing:border-box}
+html,body{
+  margin:0;
+  min-height:100%;
+  background:
+    radial-gradient(960px 540px at 8% -12%, rgba(23,198,207,.24), transparent 58%),
+    radial-gradient(740px 420px at 100% 0%, rgba(255,157,91,.18), transparent 55%),
+    linear-gradient(165deg, var(--bg), var(--bg2));
+  color:var(--text);
+  font-family:var(--font);
+}
+body{
+  padding-top:env(safe-area-inset-top);
+  padding-bottom:env(safe-area-inset-bottom);
+}
+a{color:inherit}
+button,input,select,textarea{font:inherit}
+button{cursor:pointer}
+
+.phone-shell{
+  max-width:980px;
+  margin:0 auto;
+  min-height:100vh;
+  padding:16px 14px 28px;
+  display:grid;
+  gap:14px;
+}
+
+.phone-shell.has-primary-surface{
+  align-items:start;
+}
+
+.surface-primary{
+  order:2;
+  min-height:58vh;
+}
+
+.surface-primary .thread,
+.surface-primary .artifact-log,
+.surface-primary .iframe-shell,
+.surface-primary .frame{
+  min-height:44vh;
+  max-height:none;
+}
+
+.surface-support{
+  order:3;
+}
+
+.hero,.section,.stack-card{
+  background:linear-gradient(180deg, rgba(11,19,31,.96), rgba(10,17,27,.88));
+  border:1px solid var(--border);
+  border-radius:24px;
+  box-shadow:var(--shadow);
+}
+
+.hero,.section{padding:16px}
+
+.hero-top,.section-head,.row,.chip-row,.actions,.lane-actions,.meta-row{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  flex-wrap:wrap;
+}
+
+.hero-top,.section-head,.meta-row{justify-content:space-between}
+
+.eyebrow,.pill,.status-pill,.chip,.btn,.btn-link,.tab-chip{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:999px;
+  font-size:12px;
+  font-weight:800;
+  letter-spacing:.03em;
+  text-decoration:none;
+}
+
+.eyebrow{
+  padding:5px 10px;
+  background:rgba(23,198,207,.14);
+  border:1px solid rgba(23,198,207,.32);
+  color:var(--accent);
+  text-transform:uppercase;
+}
+
+.pill,.status-pill,.chip,.btn,.btn-link,.tab-chip{
+  padding:9px 12px;
+  border:1px solid rgba(137,165,194,.22);
+  background:rgba(255,255,255,.03);
+  color:var(--text);
+}
+
+.chip.active{
+  background:rgba(23,198,207,.16);
+  border-color:rgba(23,198,207,.48);
+}
+
+.chip.offline{
+  opacity:.48;
+}
+
+.btn.primary,.btn-link.primary{
+  background:linear-gradient(135deg,var(--accent),#2f7dde);
+  color:#04121a;
+  border-color:rgba(23,198,207,.48);
+}
+
+.btn.secondary,.btn-link.secondary{
+  background:rgba(255,157,91,.1);
+  color:#ffd6c2;
+  border-color:rgba(255,157,91,.34);
+}
+
+.status-pill.good{color:var(--good);border-color:rgba(45,211,166,.24);background:rgba(45,211,166,.1)}
+.status-pill.warn{color:var(--warn);border-color:rgba(255,202,104,.24);background:rgba(255,202,104,.1)}
+.status-pill.bad{color:var(--bad);border-color:rgba(255,127,127,.24);background:rgba(255,127,127,.1)}
+
+h1{
+  margin:14px 0 8px;
+  font-size:32px;
+  line-height:1.04;
+  max-width:15ch;
+}
+h2{
+  margin:0;
+  font-size:18px;
+  line-height:1.15;
+}
+h3{
+  margin:0 0 8px;
+  font-size:17px;
+  line-height:1.2;
+}
+
+.lede,.section-copy,.meta-text,.small-note,.empty-state{
+  color:var(--dim);
+  font-size:14px;
+  line-height:1.58;
+}
+
+.stats,.grid-2,.grid-3,.card-grid,.lane-grid{
+  display:grid;
+  gap:12px;
+}
+
+.stats,.grid-3{grid-template-columns:repeat(3,minmax(0,1fr))}
+.grid-2,.lane-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+.card-grid{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+
+.card,.lane-card,.panel-card{
+  background:var(--card);
+  border:1px solid rgba(137,165,194,.16);
+  border-radius:20px;
+  padding:14px;
+}
+
+.lane-card{display:grid;gap:10px}
+.lane-meta{display:flex;justify-content:space-between;gap:8px;align-items:flex-start}
+.lane-zone{
+  display:inline-flex;
+  align-items:center;
+  padding:4px 9px;
+  border-radius:999px;
+  background:rgba(255,255,255,.05);
+  color:var(--dim);
+  font-size:11px;
+  font-weight:800;
+  text-transform:uppercase;
+}
+
+.field-grid{display:grid;gap:10px;grid-template-columns:repeat(2,minmax(0,1fr))}
+.field-grid.wide{grid-template-columns:2fr 1fr}
+.field{
+  display:grid;
+  gap:6px;
+}
+.field label{
+  font-size:12px;
+  color:var(--dim);
+  font-weight:700;
+}
+
+.field input,.field select,.field textarea,.composer textarea{
+  width:100%;
+  background:rgba(6,12,21,.82);
+  color:var(--text);
+  border:1px solid rgba(137,165,194,.24);
+  border-radius:16px;
+  padding:12px 14px;
+}
+
+.field textarea,.composer textarea{min-height:110px;resize:vertical}
+
+.stack-card{
+  padding:0;
+  overflow:hidden;
+}
+
+.stack-head{
+  padding:14px 14px 0;
+}
+
+.stack-body{
+  padding:14px;
+  display:grid;
+  gap:10px;
+}
+
+.thread{
+  min-height:300px;
+  max-height:56vh;
+  overflow:auto;
+  display:grid;
+  gap:10px;
+  align-content:start;
+}
+
+.bubble{
+  max-width:min(760px,100%);
+  padding:14px 14px 12px;
+  border-radius:18px;
+  border:1px solid rgba(137,165,194,.18);
+  background:rgba(255,255,255,.04);
+  justify-self:start;
+}
+.bubble.user{justify-self:end;background:rgba(23,198,207,.12);border-color:rgba(23,198,207,.25)}
+.bubble.error{background:rgba(255,127,127,.1);border-color:rgba(255,127,127,.25)}
+.bubble-meta{
+  margin-top:8px;
+  font-size:11px;
+  color:var(--dim);
+}
+.bubble-text{
+  white-space:pre-wrap;
+  font-size:14px;
+  line-height:1.6;
+}
+
+.iframe-shell{
+  border:1px solid rgba(137,165,194,.16);
+  border-radius:20px;
+  overflow:hidden;
+  background:rgba(6,12,21,.86);
+  min-height:58vh;
+}
+
+.iframe-toolbar{
+  display:flex;
+  gap:8px;
+  flex-wrap:wrap;
+  align-items:center;
+  padding:10px 12px;
+  border-bottom:1px solid rgba(137,165,194,.14);
+  background:rgba(255,255,255,.03);
+}
+
+.iframe-toolbar input{
+  flex:1 1 280px;
+  min-width:0;
+}
+
+.frame{
+  width:100%;
+  min-height:58vh;
+  border:0;
+  background:#fff;
+}
+
+.tab-row{
+  display:flex;
+  gap:8px;
+  overflow:auto;
+  padding-bottom:2px;
+}
+
+.tab-chip.active{
+  background:rgba(23,198,207,.16);
+  border-color:rgba(23,198,207,.5);
+}
+
+.mono{
+  font-family:var(--mono);
+}
+
+.artifact-log,.note-list,.slice-stack{
+  display:grid;
+  gap:10px;
+}
+
+.artifact-pre{
+  margin:0;
+  padding:12px;
+  border-radius:16px;
+  background:rgba(4,10,18,.9);
+  color:#d8ebff;
+  border:1px solid rgba(137,165,194,.16);
+  font-family:var(--mono);
+  font-size:12px;
+  line-height:1.55;
+  white-space:pre-wrap;
+  word-break:break-word;
+}
+
+.slice{
+  margin:0;
+  position:relative;
+  border-radius:18px;
+  overflow:hidden;
+  border:1px solid rgba(137,165,194,.14);
+  background:#f6f4ef;
+}
+.slice img{display:block;width:100%;height:auto;background:#fff}
+.slice figcaption{
+  position:absolute;
+  top:8px;
+  left:8px;
+  padding:4px 8px;
+  border-radius:999px;
+  font-size:11px;
+  font-weight:800;
+  background:rgba(7,17,29,.78);
+  color:var(--text);
+}
+
+.footer-note{
+  padding:0 4px 18px;
+  color:var(--dim);
+  font-size:12px;
+  line-height:1.58;
+}
+
+@media(min-width:920px){
+  .phone-shell.has-primary-surface{
+    grid-template-columns:minmax(0,1.45fr) minmax(280px,.95fr);
+  }
+  .phone-shell.has-primary-surface > .hero{
+    grid-column:1 / -1;
+  }
+  .phone-shell.has-primary-surface > .surface-primary{
+    grid-column:1;
+    grid-row:2 / span 4;
+  }
+  .phone-shell.has-primary-surface > .surface-support{
+    grid-column:2;
+  }
+}
+
+@media(max-width:760px){
+  .phone-shell{
+    padding:10px 10px 22px;
+    gap:10px;
+  }
+  .hero,.section{padding:14px}
+  h1{font-size:26px;max-width:none}
+  .stats,.grid-3,.grid-2,.field-grid,.field-grid.wide,.lane-grid{
+    grid-template-columns:1fr;
+  }
+  .frame,.iframe-shell{min-height:52vh}
+  .surface-primary{
+    min-height:54vh;
+  }
+  .surface-primary .thread,
+  .surface-primary .artifact-log,
+  .surface-primary .iframe-shell,
+  .surface-primary .frame{
+    min-height:40vh;
+  }
+}
+
+@media(max-width:520px){
+  .phone-shell{
+    padding:0;
+    gap:0;
+  }
+  .hero,.section,.stack-card{
+    border-radius:0;
+    border-left:0;
+    border-right:0;
+  }
+  .hero,.section{padding:12px}
+  .stack-head{padding:12px 12px 0}
+  .stack-body{padding:12px}
+  h1{font-size:23px}
+  .btn,.btn-link,.chip,.pill,.status-pill,.tab-chip{padding:8px 11px;font-size:11px}
+  .thread{max-height:none;min-height:38vh}
+}

--- a/kindle-app/www/static/polly-pad-mobile.json
+++ b/kindle-app/www/static/polly-pad-mobile.json
@@ -1,0 +1,123 @@
+{
+  "pad_id": "scbe-polly-pad-mobile-v2",
+  "title": "Polly Pad Phone Shell",
+  "updated_at": "2026-03-16T04:15:00Z",
+  "lanes": [
+    {
+      "id": "device-lane",
+      "zone": "device",
+      "status": "live",
+      "title": "Device Shell",
+      "summary": "One large main surface plus one visible assistant surface for the AI phone and tablet lane.",
+      "checks": [
+        "Main panel stays visually dominant so the owned device state is readable.",
+        "Assistant panel stays live for Ops, Test, or another helper lane while headless work runs elsewhere."
+      ],
+      "actions": [
+        {
+          "label": "Open Device Shell",
+          "href": "./device-shell.html",
+          "kind": "primary"
+        },
+        {
+          "label": "Open Browse",
+          "href": "./browse.html",
+          "kind": "secondary"
+        }
+      ]
+    },
+    {
+      "id": "reader-lane",
+      "zone": "reader",
+      "status": "ready",
+      "title": "Reader",
+      "summary": "Dedicated webtoon reading lane with saved position, chapter picker, and low chrome so phone rhythm is easy to judge.",
+      "checks": [
+        "Use text-overlay mode for pacing and clean mode for pure visual flow.",
+        "This page is for scroll reading only, not chat, test controls, or diagnostics."
+      ],
+      "actions": [
+        {
+          "label": "Open Reader",
+          "href": "./reader.html?chapter=ch01&variant=generated",
+          "kind": "primary"
+        },
+        {
+          "label": "Reader Home",
+          "href": "./reader.html",
+          "kind": "secondary"
+        }
+      ]
+    },
+    {
+      "id": "browse-lane",
+      "zone": "browse",
+      "status": "live",
+      "title": "Browse",
+      "summary": "Human mobile browsing lane with persistent tabs, URL state, and share-to-AI handoff.",
+      "checks": [
+        "Use this for actual browsing targets instead of stuffing them into the launcher.",
+        "Sites that block embedding can still live here as saved tab state."
+      ],
+      "actions": [
+        {
+          "label": "Open Browse",
+          "href": "./browse.html",
+          "kind": "primary"
+        },
+        {
+          "label": "Classic Arena",
+          "href": "./index.html?arena=1",
+          "kind": "secondary"
+        }
+      ]
+    },
+    {
+      "id": "test-lane",
+      "zone": "test",
+      "status": "watch",
+      "title": "Test",
+      "summary": "AI testing lane for target URL, task prompt, run mode, and artifact capture.",
+      "checks": [
+        "Use this for Playwright/browser bridge runs, not for human reading or normal chat.",
+        "Artifacts are stored locally on-device so each test pass leaves readable evidence."
+      ],
+      "actions": [
+        {
+          "label": "Open Test",
+          "href": "./test.html",
+          "kind": "primary"
+        }
+      ]
+    },
+    {
+      "id": "ops-lane",
+      "zone": "ops",
+      "status": "live",
+      "title": "Ops",
+      "summary": "Chat, bridge controls, provider chips, and diagnostics. This is the command lane, not the reader.",
+      "checks": [
+        "Shared targets from Browse and Test land here for quick backend analysis.",
+        "Provider selection and bridge diagnostics stay together so debugging is faster."
+      ],
+      "actions": [
+        {
+          "label": "Open Ops",
+          "href": "./ops.html",
+          "kind": "primary"
+        },
+        {
+          "label": "Legacy Chat Link",
+          "href": "./chat.html",
+          "kind": "secondary"
+        }
+      ]
+    }
+  ],
+  "notes": [
+    "Reader is for scroll rhythm only. Browse is for human tabs. Test is for AI runs. Ops is for chat and diagnostics.",
+    "Android emulator uses 10.0.2.2 to reach host services. Browser preview uses 127.0.0.1 instead.",
+    "The intended phone loop is Reader or Browse -> Test if needed -> Ops for synthesis or debugging.",
+    "Dev-side emulator prep still lives in scripts/system/start_polly_pad_emulator.ps1."
+  ]
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/*.smoke.test.ts',
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+  use: {
+    browserName: 'chromium',
+    headless: true,
+    viewport: { width: 400, height: 700 },
+  },
+  webServer: {
+    command: 'node tests/e2e/fixtures/serve-sidepanel.mjs',
+    port: 9222,
+    reuseExistingServer: true,
+    timeout: 10_000,
+  },
+});

--- a/scripts/audio_gate_spectrum_report.py
+++ b/scripts/audio_gate_spectrum_report.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Experimental WAV -> SCBE audio gate spectrum telemetry runner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import wave
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+VISIBLE_MIN_NM = 380.0
+VISIBLE_MAX_NM = 700.0
+EPSILON = 1e-10
+
+
+@dataclass
+class FrameFeatures:
+    index: int
+    start_sample: int
+    end_sample: int
+    energy: float
+    centroid: float
+    flux: float
+    hf_ratio: float
+    stability: float
+    overall_pressure: float
+    overall_wavelength_nm: float
+    overall_band: str
+    overall_state: str
+    band_pressures: list[float]
+    band_wavelengths_nm: list[float]
+    band_labels: list[str]
+    band_states: list[str]
+
+
+def clamp01(value: float) -> float:
+    return float(max(0.0, min(1.0, value)))
+
+
+def pressure_to_wavelength(pressure: float) -> float:
+    p = clamp01(pressure)
+    return VISIBLE_MIN_NM + p * (VISIBLE_MAX_NM - VISIBLE_MIN_NM)
+
+
+def wavelength_to_band(wavelength_nm: float) -> str:
+    if wavelength_nm < 450:
+        return "violet"
+    if wavelength_nm < 495:
+        return "blue"
+    if wavelength_nm < 570:
+        return "green"
+    if wavelength_nm < 590:
+        return "yellow"
+    if wavelength_nm < 620:
+        return "orange"
+    return "red"
+
+
+def pressure_to_state(pressure: float) -> str:
+    p = clamp01(pressure)
+    if p < 0.2:
+        return "stable"
+    if p < 0.5:
+        return "pressured"
+    if p < 0.8:
+        return "near_break"
+    return "breaking"
+
+
+def read_wav_mono(path: Path) -> tuple[np.ndarray, int]:
+    with wave.open(str(path), "rb") as wav:
+        channels = wav.getnchannels()
+        sample_width = wav.getsampwidth()
+        sample_rate = wav.getframerate()
+        frame_count = wav.getnframes()
+        raw = wav.readframes(frame_count)
+
+    if sample_width == 1:
+        data = np.frombuffer(raw, dtype=np.uint8).astype(np.float64)
+        data = (data - 128.0) / 128.0
+    elif sample_width == 2:
+        data = np.frombuffer(raw, dtype=np.int16).astype(np.float64) / 32768.0
+    elif sample_width == 4:
+        data = np.frombuffer(raw, dtype=np.int32).astype(np.float64) / 2147483648.0
+    else:
+        raise ValueError(f"Unsupported WAV sample width: {sample_width} bytes")
+
+    if channels > 1:
+        data = data.reshape(-1, channels).mean(axis=1)
+
+    return data.astype(np.float64), sample_rate
+
+
+def compute_power_spectrum(frame: np.ndarray) -> np.ndarray:
+    spectrum = np.fft.rfft(frame)
+    return (np.abs(spectrum) ** 2) / max(1, len(frame))
+
+
+def compute_audio_features(
+    frame: np.ndarray,
+    sample_rate: int,
+    previous_spectrum: np.ndarray | None,
+    hf_cutoff_ratio: float,
+) -> tuple[dict[str, float], np.ndarray]:
+    spectrum = compute_power_spectrum(frame)
+    freqs = np.fft.rfftfreq(len(frame), d=1.0 / sample_rate)
+
+    energy = float(np.log(EPSILON + np.sum(frame * frame)))
+
+    total_power = float(np.sum(spectrum)) + EPSILON
+    centroid = float(np.sum(freqs * spectrum) / total_power)
+
+    if previous_spectrum is None:
+        flux = 0.0
+    else:
+        use = min(len(previous_spectrum), len(spectrum))
+        delta = np.sqrt(spectrum[:use]) - np.sqrt(previous_spectrum[:use])
+        flux = float(np.sum(delta * delta) / max(1, use))
+
+    cutoff_bin = int(len(spectrum) * hf_cutoff_ratio)
+    hf_ratio = float(np.sum(spectrum[cutoff_bin:]) / total_power)
+    stability = float(1.0 - hf_ratio)
+
+    return {
+        "energy": energy,
+        "centroid": centroid,
+        "flux": flux,
+        "hf_ratio": hf_ratio,
+        "stability": stability,
+    }, spectrum
+
+
+def compute_band_pressures(
+    spectrum: np.ndarray, overall_pressure: float, band_count: int = 6
+) -> list[float]:
+    total_power = float(np.sum(spectrum)) + EPSILON
+    max_power = float(np.max(spectrum)) + EPSILON
+    band_pressures: list[float] = []
+
+    for band_index in range(band_count):
+        start = int((band_index / band_count) * len(spectrum))
+        end = int(((band_index + 1) / band_count) * len(spectrum))
+        if end <= start:
+            band_pressures.append(0.0)
+            continue
+        band_power = float(np.sum(spectrum[start:end]))
+        ratio = band_power / total_power
+        # Experimental pressure:
+        # - overall instability is authoritative
+        # - energetic bands carry more of that instability
+        # This prevents clean, narrow-band signals from looking "broken"
+        # just because one band dominates a stable frame.
+        dominance = band_power / max_power
+        contribution = (0.5 * ratio * band_count) + (0.5 * dominance)
+        pressure = clamp01(overall_pressure * contribution)
+        band_pressures.append(pressure)
+
+    return band_pressures
+
+
+def compute_overall_pressure(flux: float, hf_ratio: float) -> float:
+    # Experimental proxy for "mid-fall" audio instability.
+    flux_pressure = clamp01(math.sqrt(max(flux, 0.0)) * 4.0)
+    return clamp01((0.6 * hf_ratio) + (0.4 * flux_pressure))
+
+
+def analyze_wav(
+    signal: np.ndarray,
+    sample_rate: int,
+    frame_size: int = 2048,
+    hop_size: int = 1024,
+    hf_cutoff_ratio: float = 0.5,
+) -> dict[str, Any]:
+    frames: list[FrameFeatures] = []
+    previous_spectrum: np.ndarray | None = None
+
+    for start in range(0, max(1, len(signal) - frame_size + 1), hop_size):
+        end = start + frame_size
+        frame = signal[start:end]
+        if len(frame) < frame_size:
+            break
+
+        features, spectrum = compute_audio_features(frame, sample_rate, previous_spectrum, hf_cutoff_ratio)
+        previous_spectrum = spectrum
+
+        overall_pressure = compute_overall_pressure(features["flux"], features["hf_ratio"])
+        band_pressures = compute_band_pressures(spectrum, overall_pressure=overall_pressure, band_count=6)
+        band_wavelengths = [pressure_to_wavelength(p) for p in band_pressures]
+        band_labels = [wavelength_to_band(w) for w in band_wavelengths]
+        band_states = [pressure_to_state(p) for p in band_pressures]
+        overall_wavelength = pressure_to_wavelength(overall_pressure)
+
+        frames.append(
+            FrameFeatures(
+                index=len(frames),
+                start_sample=start,
+                end_sample=end,
+                energy=features["energy"],
+                centroid=features["centroid"],
+                flux=features["flux"],
+                hf_ratio=features["hf_ratio"],
+                stability=features["stability"],
+                overall_pressure=overall_pressure,
+                overall_wavelength_nm=overall_wavelength,
+                overall_band=wavelength_to_band(overall_wavelength),
+                overall_state=pressure_to_state(overall_pressure),
+                band_pressures=band_pressures,
+                band_wavelengths_nm=band_wavelengths,
+                band_labels=band_labels,
+                band_states=band_states,
+            )
+        )
+
+    if not frames:
+        raise ValueError("No complete frames could be extracted from the WAV input.")
+
+    avg = lambda key: float(np.mean([getattr(frame, key) for frame in frames]))
+    max_pressure_frame = max(frames, key=lambda frame: frame.overall_pressure)
+
+    return {
+        "sample_rate": sample_rate,
+        "frame_size": frame_size,
+        "hop_size": hop_size,
+        "frame_count": len(frames),
+        "summary": {
+            "avg_energy": avg("energy"),
+            "avg_centroid": avg("centroid"),
+            "avg_flux": avg("flux"),
+            "avg_hf_ratio": avg("hf_ratio"),
+            "avg_stability": avg("stability"),
+            "avg_overall_pressure": avg("overall_pressure"),
+            "max_overall_pressure": float(max(frame.overall_pressure for frame in frames)),
+            "peak_state": max_pressure_frame.overall_state,
+            "peak_band": max_pressure_frame.overall_band,
+            "peak_frame_index": max_pressure_frame.index,
+        },
+        "frames": [asdict(frame) for frame in frames],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate an SCBE audio gate spectrum report from a WAV file.")
+    parser.add_argument("--wav", required=True, help="Path to a PCM WAV file")
+    parser.add_argument("--frame-size", type=int, default=2048)
+    parser.add_argument("--hop-size", type=int, default=1024)
+    parser.add_argument("--hf-cutoff", type=float, default=0.5, help="High-frequency cutoff ratio [0,1]")
+    parser.add_argument("--output", default="", help="Optional JSON output path")
+    args = parser.parse_args()
+
+    wav_path = Path(args.wav).expanduser().resolve()
+    signal, sample_rate = read_wav_mono(wav_path)
+    report = analyze_wav(
+        signal=signal,
+        sample_rate=sample_rate,
+        frame_size=args.frame_size,
+        hop_size=args.hop_size,
+        hf_cutoff_ratio=args.hf_cutoff,
+    )
+    report["input_wav"] = str(wav_path)
+
+    if args.output:
+        output_path = Path(args.output).expanduser().resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(output_path)
+    else:
+        print(json.dumps(report, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hydra_command_center.ps1
+++ b/scripts/hydra_command_center.ps1
@@ -19,6 +19,8 @@ $script:IssacAetherbrowserSearchScript = Join-Path $script:IssacCommandCenterRoo
 $script:IssacGithubSweepScript = Join-Path $script:IssacCommandCenterRoot "scripts\system\run_github_sweep.py"
 $script:IssacGithubNavScript = Join-Path $script:IssacCommandCenterRoot "scripts\system\aetherbrowser_github_nav.py"
 $script:IssacYoutubeTranscriptScript = Join-Path $script:IssacCommandCenterRoot "scripts\system\youtube_transcript_pull.py"
+$script:IssacColabCatalogScript = Join-Path $script:IssacCommandCenterRoot "scripts\system\colab_workflow_catalog.py"
+$script:IssacColabBridgeScript = "C:\Users\issda\.codex\skills\scbe-n8n-colab-bridge\scripts\colab_n8n_bridge.py"
 $script:IssacDeepResearchLoop = Join-Path $script:IssacCommandCenterRoot "scripts\system\run_deep_research_self_healing.ps1"
 $script:IssacWorkflowVectorScript = Join-Path $script:IssacCommandCenterRoot "scripts\system\workflow_vector.py"
 $script:IssacPostAllScript = Join-Path $script:IssacCommandCenterRoot "scripts\publish\post_all.py"
@@ -218,6 +220,7 @@ BUILDFLOW
   buildflow-article <topic>        Article research loop scaffold
   buildflow-workflow <topic>       n8n/workflow mesh scaffold
   buildflow-training <topic>       HF specialist training scaffold
+  buildflow-colab <topic>          Colab notebook + training scaffold
 
 DAILY OPS
   gh-browse <q>            AetherBrowser GitHub search -> live vault
@@ -238,6 +241,14 @@ DAILY OPS
   hf-generate-sft          Generate specialist SFT pairs from modules
   hf-train-wave            Run daily training merge/upload wave
   hf-agent-loop            Run local HF agent training loop
+
+COLAB
+  colab-catalog            List repo Colab notebooks and purposes
+  colab-show <name>        Show one notebook entry and Colab URL
+  colab-url <name>         Print the direct Colab URL
+  colab-bridge-status      Show saved local Colab bridge profile
+  colab-bridge-env         Emit env exports for a saved bridge profile
+  colab-bridge-set         Save/update a Colab local bridge profile
 
 SERVICES
   scbe-bridge        Start n8n browser bridge (:8001)
@@ -494,7 +505,7 @@ function hmission {
 
 function Invoke-IssacBuildflow {
     param(
-        [ValidateSet("marketing", "research", "browser", "publish", "github", "youtube", "article", "workflow", "training", "story", "custom")]
+        [ValidateSet("marketing", "research", "browser", "publish", "github", "youtube", "article", "workflow", "training", "colab", "story", "custom")]
         [string]$Mode = "custom",
         [switch]$DryRun,
         [Parameter(ValueFromRemainingArguments = $true)][string[]]$Args
@@ -586,6 +597,14 @@ function Invoke-IssacBuildflow {
             Invoke-IssacCascadeStep "daily training wave" { hf-train-wave } -DryRun:$DryRun | Out-Null
             Invoke-IssacCascadeStep "training relay packet" { xtalk-send trainer "Buildflow training ready for '$topic'" } -DryRun:$DryRun | Out-Null
         }
+        "colab" {
+            Invoke-IssacCascadeStep "refresh skill synthesis" { hskills-refresh } -DryRun:$DryRun | Out-Null
+            Invoke-IssacCascadeStep "compose colab skill stack" { hstack "google colab training workflow for $topic" } -DryRun:$DryRun | Out-Null
+            Invoke-IssacCascadeStep "colab notebook catalog" { colab-catalog } -DryRun:$DryRun | Out-Null
+            Invoke-IssacCascadeStep "pivot notebook route" { colab-show pivot } -DryRun:$DryRun | Out-Null
+            Invoke-IssacCascadeStep "generate specialist sft" { hf-generate-sft } -DryRun:$DryRun | Out-Null
+            Invoke-IssacCascadeStep "colab relay packet" { xtalk-send trainer "Buildflow colab ready for '$topic'" } -DryRun:$DryRun | Out-Null
+        }
         "story" {
             Invoke-IssacCascadeStep "compose story skill stack" { hstack "story pipeline for $topic" } -DryRun:$DryRun | Out-Null
             Invoke-IssacCascadeStep "story relay packet" { xtalk-send storyteller "Buildflow story ready for '$topic'" } -DryRun:$DryRun | Out-Null
@@ -599,7 +618,7 @@ function Invoke-IssacBuildflow {
 
 function buildflow {
     param(
-        [ValidateSet("marketing", "research", "browser", "publish", "github", "youtube", "article", "workflow", "training", "story", "custom")]
+        [ValidateSet("marketing", "research", "browser", "publish", "github", "youtube", "article", "workflow", "training", "colab", "story", "custom")]
         [string]$Mode = "custom",
         [switch]$DryRun,
         [Parameter(ValueFromRemainingArguments = $true)][string[]]$Args
@@ -650,6 +669,72 @@ function buildflow-workflow {
 function buildflow-training {
     param([switch]$DryRun, [Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
     Invoke-IssacBuildflow -Mode "training" -DryRun:$DryRun @Args
+}
+
+function buildflow-colab {
+    param([switch]$DryRun, [Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+    Invoke-IssacBuildflow -Mode "colab" -DryRun:$DryRun @Args
+}
+
+function colab-catalog {
+    param([switch]$Json)
+    $scriptArgs = @("list")
+    if ($Json) {
+        $scriptArgs += "--json"
+    }
+    Invoke-IssacPythonFile $script:IssacColabCatalogScript @scriptArgs
+}
+
+function colab-show {
+    param([string]$Name, [switch]$Json)
+    Assert-IssacText $Name "Usage: colab-show <name> [-Json]"
+    $scriptArgs = @("show", $Name)
+    if ($Json) {
+        $scriptArgs += "--json"
+    }
+    Invoke-IssacPythonFile $script:IssacColabCatalogScript @scriptArgs
+}
+
+function colab-url {
+    param([string]$Name, [switch]$Json)
+    Assert-IssacText $Name "Usage: colab-url <name> [-Json]"
+    $scriptArgs = @("url", $Name)
+    if ($Json) {
+        $scriptArgs += "--json"
+    }
+    Invoke-IssacPythonFile $script:IssacColabCatalogScript @scriptArgs
+}
+
+function colab-bridge-status {
+    param([string]$Name = "pivot")
+    Invoke-IssacPythonFile $script:IssacColabBridgeScript --status --name $Name
+}
+
+function colab-bridge-env {
+    param([string]$Name = "pivot")
+    Invoke-IssacPythonFile $script:IssacColabBridgeScript --env --name $Name
+}
+
+function colab-bridge-set {
+    param(
+        [string]$Name = "pivot",
+        [string]$BackendUrl,
+        [string]$Token = "",
+        [string]$N8nWebhook = "",
+        [switch]$Probe
+    )
+    Assert-IssacText $BackendUrl "Usage: colab-bridge-set -BackendUrl <http://127.0.0.1:8888/?token=...> [-Name pivot] [-N8nWebhook <url>] [-Probe]"
+    $scriptArgs = @("--set", "--name", $Name, "--backend-url", $BackendUrl)
+    if (-not [string]::IsNullOrWhiteSpace($Token)) {
+        $scriptArgs += @("--token", $Token)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($N8nWebhook)) {
+        $scriptArgs += @("--n8n-webhook", $N8nWebhook)
+    }
+    if ($Probe) {
+        $scriptArgs += "--probe"
+    }
+    Invoke-IssacPythonFile $script:IssacColabBridgeScript @scriptArgs
 }
 
 function gh-browse {

--- a/scripts/publish/post_to_huggingface_discussion.py
+++ b/scripts/publish/post_to_huggingface_discussion.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Publish a markdown note as a Hugging Face Discussion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from huggingface_hub import HfApi
+except ImportError:  # pragma: no cover - handled at runtime
+    HfApi = None  # type: ignore[assignment]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE_DIR = REPO_ROOT / "artifacts" / "publish_browser"
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) >= 3:
+            meta: dict[str, str] = {}
+            for line in parts[1].strip().splitlines():
+                if ":" not in line:
+                    continue
+                key, _, value = line.partition(":")
+                meta[key.strip()] = value.strip().strip('"').strip("'")
+            return meta, parts[2].strip()
+    return {}, text
+
+
+def _extract_title(body: str) -> tuple[str, str]:
+    lines = body.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith("# "):
+            title = line[2:].strip()
+            remaining = "\n".join(lines[:index] + lines[index + 1 :]).strip()
+            return title, remaining
+    return "", body
+
+
+def _strip_byline(body: str) -> str:
+    return re.sub(r"^\*\*By[^*]*\*\*\s*\|[^\n]*\n+---\n*", "", body, count=1).strip()
+
+
+def publish_discussion(
+    file_path: Path,
+    repo_id: str,
+    repo_type: str | None = None,
+    title: str | None = None,
+    token: str | None = None,
+    dry_run: bool = False,
+) -> dict:
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    meta, body = _parse_frontmatter(raw)
+
+    if not title:
+        title = meta.get("title", "")
+    if not title:
+        title, body = _extract_title(body)
+    else:
+        _, body = _extract_title(body)
+    body = _strip_byline(body)
+
+    if not title:
+        return {"error": "Could not determine discussion title."}
+
+    payload = {
+        "repo_id": repo_id,
+        "repo_type": repo_type,
+        "title": title,
+        "description": body,
+    }
+
+    if dry_run:
+        print("[hf] DRY RUN — would create discussion:")
+        print(f"  Repo: {repo_id} ({repo_type or 'model'})")
+        print(f"  Title: {title}")
+        print(f"  Body length: {len(body)} chars")
+        return {"dry_run": True, "payload": payload}
+
+    if HfApi is None:
+        return {"error": "huggingface_hub is not installed."}
+
+    api = HfApi(token=token)
+    try:
+        created = api.create_discussion(
+            repo_id=repo_id,
+            repo_type=repo_type,
+            title=title,
+            description=body,
+        )
+    except Exception as exc:  # pragma: no cover - depends on remote API
+        return {"error": str(exc)}
+
+    return {
+        "id": getattr(created, "id", None),
+        "num": getattr(created, "num", None),
+        "title": getattr(created, "title", title),
+        "url": getattr(created, "url", None),
+        "status": getattr(created, "status", None),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Publish a markdown file as a Hugging Face Discussion.")
+    parser.add_argument("--file", required=True, help="Path to the markdown article file")
+    parser.add_argument("--repo-id", required=True, help="Hub repo id, e.g. issdandavis/phdm-21d-embedding")
+    parser.add_argument("--repo-type", choices=["model", "dataset", "space"], default="model")
+    parser.add_argument("--title", default="", help="Override discussion title")
+    parser.add_argument("--token", default="", help="Optional Hugging Face token override")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without publishing")
+    args = parser.parse_args()
+
+    file_path = Path(args.file).expanduser().resolve()
+    if not file_path.exists():
+        print(f"[hf] File not found: {file_path}", file=sys.stderr)
+        return 1
+
+    result = publish_discussion(
+        file_path=file_path,
+        repo_id=args.repo_id,
+        repo_type=args.repo_type,
+        title=args.title or None,
+        token=args.token or None,
+        dry_run=args.dry_run,
+    )
+
+    EVIDENCE_DIR.mkdir(parents=True, exist_ok=True)
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    evidence = {
+        "run_id": run_id,
+        "platform": "huggingface_discussion",
+        "file": str(file_path),
+        "repo_id": args.repo_id,
+        "repo_type": args.repo_type,
+        "dry_run": args.dry_run,
+        "result": result,
+    }
+    evidence_path = EVIDENCE_DIR / f"huggingface_discussion_{run_id}.json"
+    evidence_path.write_text(json.dumps(evidence, indent=2), encoding="utf-8")
+    print(f"[hf] Evidence saved: {evidence_path}")
+
+    return 0 if "error" not in result else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/system/colab_workflow_catalog.py
+++ b/scripts/system/colab_workflow_catalog.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Local catalog for SCBE Colab notebooks and training lanes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_REPO = "issdandavis/SCBE-AETHERMOORE"
+CANONICAL_BRANCH = "main"
+
+
+NOTEBOOKS: list[dict[str, Any]] = [
+    {
+        "name": "scbe-pivot-v2",
+        "aliases": ["pivot", "pivot-v2", "conversation-pivot"],
+        "path": "notebooks/scbe_pivot_training_v2.ipynb",
+        "category": "training",
+        "summary": "Pivot-conversation notebook for measured SFT and DPO preparation.",
+    },
+    {
+        "name": "scbe-finetune-free",
+        "aliases": ["finetune", "sft", "free-colab", "scbe-finetune"],
+        "path": "notebooks/scbe_finetune_colab.ipynb",
+        "category": "training",
+        "summary": "Free T4 LoRA fine-tuning lane for SCBE governance data.",
+    },
+    {
+        "name": "qlora-training",
+        "aliases": ["qlora", "colab-qlora", "trainer"],
+        "path": "notebooks/colab_qlora_training.ipynb",
+        "category": "training",
+        "summary": "QLoRA training notebook for compact Colab model adaptation.",
+    },
+    {
+        "name": "aethermoor-finetune",
+        "aliases": ["aethermoor", "aethermoor-finetune", "game-finetune"],
+        "path": "notebooks/colab_aethermoor_finetune.ipynb",
+        "category": "training",
+        "summary": "Aethermoor-focused fine-tuning notebook for game and world data.",
+    },
+    {
+        "name": "aethermoor-datagen",
+        "aliases": ["datagen", "game-datagen", "aethermoor-datagen"],
+        "path": "notebooks/colab_aethermoor_datagen.ipynb",
+        "category": "data",
+        "summary": "Generate or expand Aethermoor data on free Colab compute.",
+    },
+    {
+        "name": "spiralverse-federated",
+        "aliases": ["spiralverse", "federated", "spiralverse-federated"],
+        "path": "notebooks/spiralverse_federated_training_colab.ipynb",
+        "category": "training",
+        "summary": "Spiralverse federated training notebook spanning multiple model lanes.",
+    },
+    {
+        "name": "langues-metric",
+        "aliases": ["langues", "metric", "langues-metric"],
+        "path": "notebooks/scbe_langues_metric_colab.ipynb",
+        "category": "research",
+        "summary": "Interactive Langues metric and harmonic math exploration notebook.",
+    },
+    {
+        "name": "webtoon-panel",
+        "aliases": ["webtoon", "panel-gen", "manhwa"],
+        "path": "notebooks/webtoon_panel_generation_colab.ipynb",
+        "category": "generation",
+        "summary": "Remote-first panel generation notebook for prompt packs and GPU rendering.",
+    },
+    {
+        "name": "webtoon-panel-embedded",
+        "aliases": ["embedded-webtoon", "webtoon-embedded"],
+        "path": "notebooks/webtoon_panel_generation_embedded_colab.ipynb",
+        "category": "generation",
+        "summary": "Embedded Colab lane for webtoon generation with local handoff support.",
+    },
+    {
+        "name": "cloud-workspace",
+        "aliases": ["cloud", "workspace", "cloud-workspace"],
+        "path": "notebooks/scbe_cloud_workspace.ipynb",
+        "category": "ops",
+        "summary": "General cloud/Colab workspace notebook for SCBE experiments.",
+    },
+]
+
+
+def _normalize(value: str) -> str:
+    return "".join(ch for ch in value.strip().lower() if ch.isalnum() or ch in "-_")
+
+
+def _github_repo() -> str:
+    return str(Path(CANONICAL_REPO)) if CANONICAL_REPO else "issdandavis/SCBE-AETHERMOORE"
+
+
+def _github_branch() -> str:
+    return CANONICAL_BRANCH
+
+
+def _record_payload(row: dict[str, Any]) -> dict[str, Any]:
+    rel_path = row["path"].replace("\\", "/")
+    local_path = REPO_ROOT / row["path"]
+    return {
+        "name": row["name"],
+        "aliases": row["aliases"],
+        "category": row["category"],
+        "summary": row["summary"],
+        "path": rel_path,
+        "local_path": str(local_path),
+        "exists": local_path.exists(),
+        "colab_url": f"https://colab.research.google.com/github/{_github_repo()}/blob/{_github_branch()}/{rel_path}",
+    }
+
+
+def _resolve_notebook(query: str) -> dict[str, Any]:
+    term = _normalize(query)
+    if not term:
+        raise KeyError("notebook name required")
+
+    for row in NOTEBOOKS:
+        if term == _normalize(row["name"]):
+            return row
+        if any(term == _normalize(alias) for alias in row["aliases"]):
+            return row
+
+    for row in NOTEBOOKS:
+        haystack = [_normalize(row["name"]), *[_normalize(alias) for alias in row["aliases"]]]
+        if any(term in item for item in haystack):
+            return row
+
+    raise KeyError(f"unknown notebook: {query}")
+
+
+def _print_text_list() -> int:
+    print("# SCBE Colab Notebook Catalog")
+    for row in NOTEBOOKS:
+        payload = _record_payload(row)
+        aliases = ", ".join(row["aliases"])
+        exists = "yes" if payload["exists"] else "no"
+        print(f"- {payload['name']} [{row['category']}]")
+        print(f"  path: {payload['path']}")
+        print(f"  aliases: {aliases}")
+        print(f"  exists: {exists}")
+        print(f"  summary: {row['summary']}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Catalog SCBE Colab notebooks and derived Colab URLs")
+    parser.add_argument("action", nargs="?", default="list", choices=["list", "show", "url"])
+    parser.add_argument("name", nargs="?", default="")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    args = parser.parse_args()
+
+    if args.action == "list":
+        payload = [_record_payload(row) for row in NOTEBOOKS]
+        if args.json:
+            print(json.dumps(payload, indent=2))
+            return 0
+        return _print_text_list()
+
+    try:
+        row = _resolve_notebook(args.name)
+    except KeyError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2), file=sys.stderr)
+        return 1
+
+    payload = _record_payload(row)
+    if args.action == "url":
+        if args.json:
+            print(json.dumps({"name": payload["name"], "colab_url": payload["colab_url"]}, indent=2))
+        else:
+            print(payload["colab_url"])
+        return 0
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/system/phone_eye.py
+++ b/scripts/system/phone_eye.py
@@ -1,77 +1,139 @@
 #!/usr/bin/env python3
-"""Phone Eye — continuous screenshot capture for AI vision.
+"""Phone Eye - stable latest-frame wrapper around the Android hand observation lane."""
 
-Captures the emulator screen every N seconds to a fixed file path
-so the AI agent can read the latest frame anytime.
-
-Usage:
-    python scripts/system/phone_eye.py              # 2 sec interval
-    python scripts/system/phone_eye.py --interval 1 # 1 sec interval
-    python scripts/system/phone_eye.py --once        # single shot
-"""
+from __future__ import annotations
 
 import argparse
-import subprocess
+import json
+import shutil
 import sys
 import time
 from pathlib import Path
+from typing import Any, Dict
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-ADB = str(REPO_ROOT / "android-sdk" / "platform-tools" / "adb.exe")
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.system.phone_navigation_telemetry import build_navigation_telemetry
+from src.browser.hydra_android_hand import HydraAndroidHand
+
+
 OUT_DIR = REPO_ROOT / "artifacts" / "kindle" / "emulator"
 LATEST = OUT_DIR / "eye_latest.png"
+LATEST_XML = OUT_DIR / "eye_latest.xml"
+LATEST_NAV = OUT_DIR / "eye_latest.nav.json"
+LATEST_META = OUT_DIR / "eye_latest.json"
 HISTORY_DIR = OUT_DIR / "eye_history"
 
 
-def capture(save_history: bool = False) -> bool:
-    """Capture one screenshot. Returns True on success."""
+def build_capture_metadata(
+    *,
+    serial: str,
+    latest_path: Path,
+    latest_xml_path: Path,
+    latest_nav_path: Path,
+    session_dir: str,
+    status: Dict[str, Any],
+    history_path: str = "",
+) -> Dict[str, Any]:
+    return {
+        "captured_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "serial": serial,
+        "latest_path": str(latest_path),
+        "latest_xml_path": str(latest_xml_path),
+        "latest_nav_path": str(latest_nav_path),
+        "history_path": history_path,
+        "session_dir": session_dir,
+        "status": status,
+    }
+
+
+def capture(*, preferred_serial: str = "", save_history: bool = False) -> Dict[str, Any]:
+    """Capture screenshot, UI dump, and navigation telemetry into stable latest files."""
     OUT_DIR.mkdir(parents=True, exist_ok=True)
-    try:
-        result = subprocess.run(
-            [ADB, "exec-out", "screencap", "-p"],
-            capture_output=True, timeout=10,
-        )
-        if result.returncode == 0 and len(result.stdout) > 1000:
-            LATEST.write_bytes(result.stdout)
-            if save_history:
-                HISTORY_DIR.mkdir(parents=True, exist_ok=True)
-                ts = time.strftime("%Y%m%dT%H%M%S")
-                (HISTORY_DIR / f"frame_{ts}.png").write_bytes(result.stdout)
-            return True
-    except Exception as e:
-        print(f"Capture error: {e}", file=sys.stderr)
-    return False
+    hand = HydraAndroidHand(serial=preferred_serial)
+    observed = hand.observe(name="eye_latest", include_ui_dump=True)
+
+    screenshot_path = Path(observed["screenshot"]["artifact_path"])
+    ui_dump_path = Path(observed["ui_dump"]["artifact_path"])
+    status = observed.get("status", {})
+    serial = str(status.get("serial") or preferred_serial or "")
+
+    if not screenshot_path.exists():
+        raise RuntimeError(f"screenshot missing: {screenshot_path}")
+    if not ui_dump_path.exists():
+        raise RuntimeError(f"ui dump missing: {ui_dump_path}")
+
+    shutil.copyfile(screenshot_path, LATEST)
+    shutil.copyfile(ui_dump_path, LATEST_XML)
+
+    nav_payload = build_navigation_telemetry(
+        ui_dump_path,
+        screenshot_path=str(LATEST),
+        status=status,
+        source="phone_eye",
+    )
+    LATEST_NAV.write_text(json.dumps(nav_payload, indent=2), encoding="utf-8")
+    history_path = ""
+    if save_history:
+        HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+        timestamp = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
+        history_png = HISTORY_DIR / f"frame_{timestamp}.png"
+        history_xml = HISTORY_DIR / f"frame_{timestamp}.xml"
+        history_nav = HISTORY_DIR / f"frame_{timestamp}.nav.json"
+        shutil.copyfile(LATEST, history_png)
+        shutil.copyfile(LATEST_XML, history_xml)
+        shutil.copyfile(LATEST_NAV, history_nav)
+        history_path = str(history_png)
+
+    metadata = build_capture_metadata(
+        serial=serial,
+        latest_path=LATEST,
+        latest_xml_path=LATEST_XML,
+        latest_nav_path=LATEST_NAV,
+        session_dir=str(status.get("session_dir") or hand.session_dir),
+        status=status,
+        history_path=history_path,
+    )
+    LATEST_META.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    return metadata
 
 
-def run_loop(interval: float = 2.0, save_history: bool = False):
-    """Continuous capture loop."""
-    print(f"Phone Eye running — {interval}s interval — {LATEST}")
+def run_loop(interval: float = 2.0, *, preferred_serial: str = "", save_history: bool = False) -> None:
+    print(f"Phone Eye running - {interval}s interval - {LATEST}")
     print("Ctrl+C to stop")
     frames = 0
     while True:
-        if capture(save_history):
+        try:
+            metadata = capture(preferred_serial=preferred_serial, save_history=save_history)
             frames += 1
-            print(f"\rFrame {frames} captured", end="", flush=True)
+            print(f"\rFrame {frames} captured from {metadata['serial']}", end="", flush=True)
+        except Exception as exc:  # pragma: no cover - live loop guard
+            print(f"\rCapture error: {exc}", end="", flush=True)
         time.sleep(interval)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Phone Eye — continuous emulator screenshots")
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Phone Eye - continuous emulator/device screenshots")
     parser.add_argument("--interval", type=float, default=2.0, help="Seconds between captures")
     parser.add_argument("--once", action="store_true", help="Single capture then exit")
     parser.add_argument("--history", action="store_true", help="Save timestamped history frames")
+    parser.add_argument("--serial", default="", help="Preferred adb serial")
     args = parser.parse_args()
 
     if args.once:
-        if capture(args.history):
-            print(f"Saved: {LATEST}")
-        else:
-            print("Capture failed", file=sys.stderr)
+        try:
+            metadata = capture(preferred_serial=args.serial, save_history=args.history)
+        except Exception as exc:
+            print(f"Capture failed: {exc}", file=sys.stderr)
             return 1
+        print(json.dumps(metadata, indent=2))
         return 0
 
     try:
-        run_loop(args.interval, args.history)
+        run_loop(args.interval, preferred_serial=args.serial, save_history=args.history)
     except KeyboardInterrupt:
         print("\nStopped.")
     return 0

--- a/scripts/system/phone_navigation_telemetry.py
+++ b/scripts/system/phone_navigation_telemetry.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Build route/text/tap-target telemetry from Android UI dumps."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.browser.hydra_android_hand import HydraAndroidHand
+
+
+BOUNDS_RE = re.compile(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]")
+URL_RE = re.compile(r"^[a-z0-9.-]+(?::\d+)?/[^\s]+$", re.IGNORECASE)
+
+
+def parse_bounds(raw: str) -> Optional[Dict[str, int]]:
+    match = BOUNDS_RE.match((raw or "").strip())
+    if not match:
+        return None
+    x1, y1, x2, y2 = (int(part) for part in match.groups())
+    width = max(0, x2 - x1)
+    height = max(0, y2 - y1)
+    return {
+        "x1": x1,
+        "y1": y1,
+        "x2": x2,
+        "y2": y2,
+        "width": width,
+        "height": height,
+        "center_x": x1 + (width // 2),
+        "center_y": y1 + (height // 2),
+        "area": width * height,
+    }
+
+
+def _walk_nodes(node: ET.Element, depth: int = 0) -> Iterable[Dict[str, Any]]:
+    bounds = parse_bounds(node.attrib.get("bounds", ""))
+    summary = {
+        "depth": depth,
+        "text": (node.attrib.get("text") or "").strip(),
+        "content_desc": (node.attrib.get("content-desc") or "").strip(),
+        "resource_id": (node.attrib.get("resource-id") or "").strip(),
+        "class_name": (node.attrib.get("class") or "").strip(),
+        "package": (node.attrib.get("package") or "").strip(),
+        "clickable": node.attrib.get("clickable") == "true",
+        "enabled": node.attrib.get("enabled") != "false",
+        "focusable": node.attrib.get("focusable") == "true",
+        "focused": node.attrib.get("focused") == "true",
+        "scrollable": node.attrib.get("scrollable") == "true",
+        "selected": node.attrib.get("selected") == "true",
+        "bounds": bounds,
+    }
+    yield summary
+    for child in list(node):
+        yield from _walk_nodes(child, depth + 1)
+
+
+def _node_label(node: Dict[str, Any]) -> str:
+    for value in (node["text"], node["content_desc"]):
+        if value:
+            return value
+    resource_id = node["resource_id"]
+    if resource_id:
+        return resource_id.rsplit("/", 1)[-1]
+    class_name = node["class_name"]
+    return class_name.rsplit(".", 1)[-1] if class_name else "node"
+
+
+def _route_url(nodes: List[Dict[str, Any]]) -> str:
+    for node in nodes:
+        resource_id = node["resource_id"]
+        text = node["text"]
+        if resource_id.endswith("url_bar") and text:
+            return text
+    for node in nodes:
+        text = node["text"]
+        if text and URL_RE.match(text):
+            return text
+    return ""
+
+
+def _page_title(nodes: List[Dict[str, Any]]) -> str:
+    for node in nodes:
+        if node["class_name"] == "android.webkit.WebView" and node["text"]:
+            return node["text"]
+    return ""
+
+
+def _visible_text(nodes: List[Dict[str, Any]]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for node in nodes:
+        if not node["text"]:
+            continue
+        bounds = node["bounds"]
+        if not bounds or bounds["area"] <= 0:
+            continue
+        text = node["text"]
+        if text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
+def _tap_targets(nodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    targets: List[Dict[str, Any]] = []
+    for node in nodes:
+        if not node["enabled"] or not node["clickable"]:
+            continue
+        bounds = node["bounds"]
+        if not bounds or bounds["area"] <= 0:
+            continue
+        targets.append(
+            {
+                "label": _node_label(node),
+                "text": node["text"],
+                "content_desc": node["content_desc"],
+                "resource_id": node["resource_id"],
+                "class_name": node["class_name"],
+                "focused": node["focused"],
+                "bounds": bounds,
+            }
+        )
+    targets.sort(key=lambda item: (item["bounds"]["y1"], item["bounds"]["x1"], -item["bounds"]["area"]))
+    return targets
+
+
+def _scrollables(nodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    for node in nodes:
+        if not node["scrollable"]:
+            continue
+        bounds = node["bounds"]
+        if not bounds or bounds["area"] <= 0:
+            continue
+        items.append(
+            {
+                "label": _node_label(node),
+                "class_name": node["class_name"],
+                "resource_id": node["resource_id"],
+                "bounds": bounds,
+            }
+        )
+    items.sort(key=lambda item: item["bounds"]["area"], reverse=True)
+    return items
+
+
+def build_navigation_telemetry(
+    xml_path: Path,
+    *,
+    screenshot_path: str = "",
+    status: Optional[Dict[str, Any]] = None,
+    source: str = "xml",
+) -> Dict[str, Any]:
+    root = ET.fromstring(xml_path.read_text(encoding="utf-8"))
+    nodes = list(_walk_nodes(root))
+    package_name = next((node["package"] for node in nodes if node["package"]), "")
+    focused = next((node for node in nodes if node["focused"]), None)
+    telemetry = {
+        "source": source,
+        "xml_path": str(xml_path),
+        "screenshot_path": screenshot_path,
+        "rotation": int(root.attrib.get("rotation", "0") or 0),
+        "package_name": package_name,
+        "page_title": _page_title(nodes),
+        "route_url": _route_url(nodes),
+        "visible_text": _visible_text(nodes),
+        "tap_targets": _tap_targets(nodes),
+        "scrollables": _scrollables(nodes),
+        "focused_node": {
+            "label": _node_label(focused),
+            "resource_id": focused["resource_id"],
+            "class_name": focused["class_name"],
+            "bounds": focused["bounds"],
+        }
+        if focused
+        else None,
+        "status": status or {},
+    }
+    telemetry["summary"] = {
+        "visible_text_count": len(telemetry["visible_text"]),
+        "tap_target_count": len(telemetry["tap_targets"]),
+        "scrollable_count": len(telemetry["scrollables"]),
+    }
+    return telemetry
+
+
+def _default_output_path(xml_path: Path) -> Path:
+    return xml_path.with_suffix(".telemetry.json")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build navigation telemetry from an Android UI dump")
+    parser.add_argument("--xml", help="Existing UI dump XML path")
+    parser.add_argument("--observe", action="store_true", help="Capture a fresh screenshot and UI dump first")
+    parser.add_argument("--name", default="navigation", help="Observation base name when --observe is used")
+    parser.add_argument("--serial", default="", help="ADB serial to target when --observe is used")
+    parser.add_argument("--adb-path", default="", help="Explicit adb path when --observe is used")
+    parser.add_argument("--output", default="", help="Output telemetry JSON path")
+    args = parser.parse_args()
+
+    xml_path: Optional[Path] = Path(args.xml) if args.xml else None
+    screenshot_path = ""
+    status: Dict[str, Any] = {}
+    source = "xml"
+
+    if args.observe:
+        hand = HydraAndroidHand(serial=args.serial, adb_path=args.adb_path)
+        observed = hand.observe(name=args.name, include_ui_dump=True)
+        xml_path = Path(observed["ui_dump"]["artifact_path"])
+        screenshot_path = observed["screenshot"]["artifact_path"]
+        status = observed.get("status", {})
+        source = "observe"
+
+    if not xml_path:
+        raise SystemExit("--xml or --observe is required")
+
+    payload = build_navigation_telemetry(
+        xml_path,
+        screenshot_path=screenshot_path,
+        status=status,
+        source=source,
+    )
+    output_path = Path(args.output) if args.output else _default_output_path(xml_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps({"output": str(output_path), "route_url": payload["route_url"], "targets": payload["summary"]["tap_target_count"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/scbe-colab-training-ops/SKILL.md
+++ b/skills/scbe-colab-training-ops/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: scbe-colab-training-ops
+description: Operate SCBE Colab notebooks as a daily training and remote-compute lane using the Issac command center, local bridge profiles, notebook catalog, and Hugging Face training scripts. Use when the user wants to run or prepare Colab notebooks, wire local Colab URLs into SCBE, choose the right notebook for SFT or pivot work, or turn browser/compute sessions into repeatable training flows.
+---
+
+# SCBE Colab Training Ops
+
+Use this skill when Colab should become part of the normal SCBE operating surface instead of an ad hoc notebook tab.
+
+## Entry Surface
+
+- Start with `issac-help` and look at the `COLAB` section.
+- Use `colab-catalog` first to see what notebooks already exist.
+- Use `colab-show <name>` or `colab-url <name>` before guessing which notebook to run.
+- Use `colab-bridge-set` only when the user already has a Colab local-connection URL.
+
+## Core Lanes
+
+1. Notebook Selection
+- `colab-catalog`
+- `colab-show pivot`
+- `colab-show finetune`
+- `colab-show webtoon`
+
+2. Local Bridge / Session Reuse
+- `colab-bridge-set -BackendUrl <url> -Name pivot`
+- `colab-bridge-status -Name pivot`
+- `colab-bridge-env -Name pivot`
+
+3. Training Prep
+- `hf-generate-sft`
+- `hf-train-wave`
+- `hf-agent-loop`
+
+4. Guided Multi-Step Lane
+- `buildflow-colab <topic>`
+
+## What Exists Already
+
+- notebook catalog script: `scripts/system/colab_workflow_catalog.py`
+- bridge script: `C:\Users\issda\.codex\skills\scbe-n8n-colab-bridge\scripts\colab_n8n_bridge.py`
+- command-center surface: `scripts/hydra_command_center.ps1`
+- free T4 fine-tune notebook: `notebooks/scbe_finetune_colab.ipynb`
+- pivot notebook: `notebooks/scbe_pivot_training_v2.ipynb`
+
+Read `references/notebook-map.md` when you need the notebook-by-notebook breakdown.
+
+## Safety Gates
+
+1. Do not invent a new notebook if an existing one already matches the job.
+2. Do not store raw Colab tokens in repo files.
+3. Prefer bridge profiles and env exports over pasting secrets into notebooks.
+4. Keep notebook selection explicit: pivot, finetune, qlora, webtoon, or cloud workspace.
+5. Treat Colab as compute, not as the source of truth. The source of truth stays in repo files and datasets.
+
+## Output Contract
+
+Every Colab operation should leave:
+
+- the chosen notebook name and path
+- the Colab URL or local bridge profile name
+- any generated SFT/training artifacts
+- a note about whether compute stayed local, Colab-only, or crossed into HF push

--- a/skills/scbe-colab-training-ops/agents/openai.yaml
+++ b/skills/scbe-colab-training-ops/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SCBE Colab Training Ops"
+  short_description: "Run SCBE Colab notebooks and bridge them into daily training flows."
+  default_prompt: "Use the SCBE Colab notebook catalog, bridge profiles, and training commands to operate the remote compute lane."

--- a/skills/scbe-colab-training-ops/references/notebook-map.md
+++ b/skills/scbe-colab-training-ops/references/notebook-map.md
@@ -1,0 +1,47 @@
+# SCBE Colab Notebook Map
+
+## Training
+
+- `scbe-pivot-v2`
+  path: `notebooks/scbe_pivot_training_v2.ipynb`
+  use: pivot conversation traces, measured SFT/DPO prep
+
+- `scbe-finetune-free`
+  path: `notebooks/scbe_finetune_colab.ipynb`
+  use: free T4 LoRA fine-tune on SCBE governance data
+
+- `qlora-training`
+  path: `notebooks/colab_qlora_training.ipynb`
+  use: compact QLoRA experiments
+
+- `aethermoor-finetune`
+  path: `notebooks/colab_aethermoor_finetune.ipynb`
+  use: game and world-data fine-tuning
+
+- `spiralverse-federated`
+  path: `notebooks/spiralverse_federated_training_colab.ipynb`
+  use: multi-lane or federated model experiments
+
+## Data / Research
+
+- `aethermoor-datagen`
+  path: `notebooks/colab_aethermoor_datagen.ipynb`
+  use: generate or expand training/game data
+
+- `langues-metric`
+  path: `notebooks/scbe_langues_metric_colab.ipynb`
+  use: harmonic and metric exploration
+
+- `cloud-workspace`
+  path: `notebooks/scbe_cloud_workspace.ipynb`
+  use: general cloud/Colab workspace tasks
+
+## Generation
+
+- `webtoon-panel`
+  path: `notebooks/webtoon_panel_generation_colab.ipynb`
+  use: prompt-pack-driven panel generation on Colab GPU
+
+- `webtoon-panel-embedded`
+  path: `notebooks/webtoon_panel_generation_embedded_colab.ipynb`
+  use: embedded or hybrid local/remote webtoon generation

--- a/src/aetherbrowser/agents.py
+++ b/src/aetherbrowser/agents.py
@@ -69,7 +69,7 @@ class AgentSquad:
 
     def decompose(self, text: str, task_type: str | None = None) -> list[dict[str, Any]]:
         if task_type is None:
-            task_type = self._infer_task_type(text)
+            task_type = self.infer_task_type(text)
         roles = _TASK_ROLES.get(task_type, _TASK_ROLES["default"])
         assignments = []
         for role in roles:
@@ -79,7 +79,7 @@ class AgentSquad:
             })
         return assignments
 
-    def _infer_task_type(self, text: str) -> str:
+    def infer_task_type(self, text: str) -> str:
         words = set(text.lower().split())
         if words & _RESEARCH_KEYWORDS:
             return "research"

--- a/src/aetherbrowser/command_planner.py
+++ b/src/aetherbrowser/command_planner.py
@@ -1,0 +1,375 @@
+"""Deterministic command planning for AetherBrowser orchestration."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from src.aetherbrowser.agents import AgentSquad
+from src.aetherbrowser.router import ModelProvider, OctoArmorRouter, TaskComplexity
+
+
+_BROWSER_ACTION_KEYWORDS = {
+    "browser",
+    "click",
+    "fill",
+    "form",
+    "login",
+    "navigate",
+    "open",
+    "page",
+    "scroll",
+    "search",
+    "site",
+    "submit",
+    "tab",
+    "upload",
+}
+
+_READ_ONLY_KEYWORDS = {
+    "analyze",
+    "browse",
+    "extract",
+    "inspect",
+    "read",
+    "research",
+    "review",
+    "search",
+    "snapshot",
+    "summarize",
+    "title",
+}
+
+_AUTH_KEYWORDS = {
+    "auth",
+    "credential",
+    "login",
+    "logout",
+    "mfa",
+    "oauth",
+    "otp",
+    "password",
+    "signin",
+    "token",
+    "username",
+}
+
+_SIDE_EFFECT_KEYWORDS = {
+    "approve",
+    "buy",
+    "checkout",
+    "comment",
+    "commit",
+    "create",
+    "delete",
+    "deploy",
+    "download",
+    "fill",
+    "grant",
+    "install",
+    "merge",
+    "pay",
+    "post",
+    "publish",
+    "push",
+    "register",
+    "send",
+    "submit",
+    "transfer",
+    "type",
+    "update",
+    "upload",
+    "write",
+}
+
+_HIGH_RISK_KEYWORDS = {
+    "bank",
+    "billing",
+    "buy",
+    "checkout",
+    "credential",
+    "delete",
+    "deploy",
+    "password",
+    "payment",
+    "publish",
+    "push",
+    "submit",
+    "transfer",
+    "wallet",
+}
+
+_SERVICE_HINTS = {
+    "github": "github.com",
+    "huggingface": "huggingface.co",
+    "notion": "notion.so",
+    "arxiv": "arxiv.org",
+}
+
+
+@dataclass
+class RankedAction:
+    label: str
+    reason: str
+    risk_tier: str
+    requires_approval: bool = False
+    command_hint: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "reason": self.reason,
+            "risk_tier": self.risk_tier,
+            "requires_approval": self.requires_approval,
+            "command_hint": self.command_hint,
+        }
+
+
+@dataclass
+class CommandPlan:
+    text: str
+    task_type: str
+    intent: str
+    complexity: TaskComplexity
+    provider: str
+    selection_reason: str
+    fallback_chain: list[str]
+    browser_action_required: bool
+    escalation_ready: bool
+    preferred_engine: str
+    targets: list[str]
+    risk_tier: str
+    review_zone: str | None
+    approval_required: bool
+    required_approvals: list[str]
+    auto_cascade: bool
+    next_actions: list[RankedAction]
+    assignments: list[dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "task_type": self.task_type,
+            "intent": self.intent,
+            "complexity": self.complexity.value,
+            "provider": self.provider,
+            "selection_reason": self.selection_reason,
+            "fallback_chain": self.fallback_chain,
+            "browser_action_required": self.browser_action_required,
+            "escalation_ready": self.escalation_ready,
+            "preferred_engine": self.preferred_engine,
+            "targets": self.targets,
+            "risk_tier": self.risk_tier,
+            "review_zone": self.review_zone,
+            "approval_required": self.approval_required,
+            "required_approvals": self.required_approvals,
+            "auto_cascade": self.auto_cascade,
+            "next_actions": [action.to_dict() for action in self.next_actions],
+            "assignments": [
+                {
+                    **assignment,
+                    "role": assignment["role"].value if hasattr(assignment["role"], "value") else assignment["role"],
+                }
+                for assignment in self.assignments
+            ],
+        }
+
+def build_command_plan(
+    *,
+    text: str,
+    squad: AgentSquad,
+    router: OctoArmorRouter,
+    routing_preferences: dict[str, str | ModelProvider] | None = None,
+    auto_cascade: bool = True,
+) -> CommandPlan:
+    lowered = text.lower()
+    tokens = set(_tokenize(text))
+    task_type = squad.infer_task_type(text)
+    complexity = router.score_complexity(text)
+    assignments = squad.decompose(text, task_type=task_type)
+    browser_action_required = bool(tokens & _BROWSER_ACTION_KEYWORDS) or task_type == "page"
+    intent = _infer_intent(task_type=task_type, lowered=lowered, tokens=tokens)
+    targets = _infer_targets(lowered)
+    risk_tier, required_approvals = _infer_risk(
+        lowered=lowered,
+        tokens=tokens,
+        browser_action_required=browser_action_required,
+    )
+    preferred_engine = _select_engine(
+        intent=intent,
+        browser_action_required=browser_action_required,
+        risk_tier=risk_tier,
+    )
+    routing_complexity = complexity
+    if browser_action_required and risk_tier == "low":
+        routing_complexity = TaskComplexity.LOW
+    elif browser_action_required and risk_tier == "medium" and complexity == TaskComplexity.HIGH:
+        routing_complexity = TaskComplexity.MEDIUM
+    selection = router.select_model(
+        routing_complexity,
+        role="KO",
+        preference_overrides=routing_preferences,
+        allow_fallback=auto_cascade,
+    )
+    provider_status = router.provider_status_snapshot()
+    escalation_ready = any(
+        meta["available"] is True and name != "local" for name, meta in provider_status.items()
+    )
+    approval_required = bool(required_approvals)
+    review_zone = _review_zone_for_risk(risk_tier) if approval_required else None
+    next_actions = _build_next_actions(
+        task_type=task_type,
+        intent=intent,
+        preferred_engine=preferred_engine,
+        targets=targets,
+        risk_tier=risk_tier,
+        approval_required=approval_required,
+    )
+    return CommandPlan(
+        text=text,
+        task_type=task_type,
+        intent=intent,
+        complexity=complexity,
+        provider=selection.provider.value,
+        selection_reason=selection.selection_reason,
+        fallback_chain=[provider.value for provider in selection.fallback_chain],
+        browser_action_required=browser_action_required,
+        escalation_ready=escalation_ready,
+        preferred_engine=preferred_engine,
+        targets=targets,
+        risk_tier=risk_tier,
+        review_zone=review_zone,
+        approval_required=approval_required,
+        required_approvals=required_approvals,
+        auto_cascade=auto_cascade,
+        next_actions=next_actions,
+        assignments=assignments,
+    )
+
+
+def _tokenize(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", text.lower())
+
+
+def _infer_intent(*, task_type: str, lowered: str, tokens: set[str]) -> str:
+    if tokens & {"login", "signin", "auth"} or "sign in" in lowered:
+        return "authenticate"
+    if tokens & {"checkout", "payment", "pay", "buy"}:
+        return "checkout"
+    if tokens & {"publish", "post", "submit", "upload"}:
+        return "submit_changes"
+    if tokens & {"fill", "type", "update", "write", "create"}:
+        return "edit_page"
+    if task_type == "research":
+        return "research"
+    if task_type == "page":
+        return "analyze_page"
+    if tokens & {"open", "navigate", "browse"}:
+        return "navigate"
+    return "general_assist"
+
+
+def _infer_targets(lowered: str) -> list[str]:
+    targets: list[str] = []
+    for hint, domain in _SERVICE_HINTS.items():
+        if hint in lowered and domain not in targets:
+            targets.append(domain)
+    for match in re.findall(r"\b(?:[a-z0-9-]+\.)+[a-z]{2,}\b", lowered):
+        if match not in targets:
+            targets.append(match)
+    return targets
+
+
+def _infer_risk(*, lowered: str, tokens: set[str], browser_action_required: bool) -> tuple[str, list[str]]:
+    approvals: list[str] = []
+    if tokens & _AUTH_KEYWORDS or "sign in" in lowered or "log in" in lowered:
+        approvals.append("Uses authentication or credentials")
+    if tokens & _SIDE_EFFECT_KEYWORDS:
+        approvals.append("Performs a state-changing browser action")
+    if tokens & _HIGH_RISK_KEYWORDS:
+        approvals.append("Touches a high-impact flow such as payment, publish, deploy, push, or delete")
+
+    if not approvals and browser_action_required and not (tokens & _READ_ONLY_KEYWORDS):
+        approvals.append("Browser action is not clearly read-only")
+
+    unique_approvals = list(dict.fromkeys(approvals))
+    if any(token in _HIGH_RISK_KEYWORDS for token in tokens):
+        return "high", unique_approvals
+    if unique_approvals:
+        return "medium", unique_approvals
+    return "low", []
+
+
+def _select_engine(*, intent: str, browser_action_required: bool, risk_tier: str) -> str:
+    if intent in {"authenticate", "checkout", "submit_changes"}:
+        return "playwright"
+    if browser_action_required and risk_tier == "low":
+        return "playwright"
+    return "playwright"
+
+
+def _review_zone_for_risk(risk_tier: str) -> str | None:
+    if risk_tier == "high":
+        return "RED"
+    if risk_tier == "medium":
+        return "YELLOW"
+    return None
+
+
+def _build_next_actions(
+    *,
+    task_type: str,
+    intent: str,
+    preferred_engine: str,
+    targets: list[str],
+    risk_tier: str,
+    approval_required: bool,
+) -> list[RankedAction]:
+    target_text = targets[0] if targets else "the target surface"
+    route_hint = (
+        f"python scripts/system/browser_chain_dispatcher.py --domain {target_text} --task {intent} --engine {preferred_engine}"
+        if targets
+        else f"Route the task through the dispatcher with {preferred_engine}"
+    )
+    actions = [
+        RankedAction(
+            label="Route through the browser dispatcher",
+            reason=f"Start from the governed {preferred_engine} lane before touching a live page.",
+            risk_tier="low",
+            command_hint=route_hint,
+        ),
+        RankedAction(
+            label="Capture title and snapshot evidence",
+            reason="Preserve proof before deeper movement or extraction.",
+            risk_tier="low",
+        ),
+    ]
+
+    if task_type == "research":
+        actions.append(
+            RankedAction(
+                label="Use site-native search and gather approved sources",
+                reason="Research flows should start from the target service instead of unmanaged generic browsing.",
+                risk_tier="low",
+            )
+        )
+    elif approval_required:
+        actions.append(
+            RankedAction(
+                label="Hold state-changing action for review",
+                reason="The requested action changes state or touches credentials, so it should stay in the deliberate lane.",
+                risk_tier=risk_tier,
+                requires_approval=True,
+            )
+        )
+    else:
+        actions.append(
+            RankedAction(
+                label=f"Proceed with {intent.replace('_', ' ')}",
+                reason="The request appears read-only and can stay in the fast lane.",
+                risk_tier=risk_tier,
+            )
+        )
+
+    return actions

--- a/src/aetherbrowser/page_analyzer.py
+++ b/src/aetherbrowser/page_analyzer.py
@@ -21,9 +21,27 @@ _TOPIC_KEYWORDS: dict[str, list[str]] = {
     "Code": ["code", "programming", "developer", "api", "function", "class", "repository"],
 }
 
+_AUTH_HINTS = {"auth", "credential", "email", "login", "password", "sign in", "signin", "username"}
+_PAYMENT_HINTS = {"billing", "buy", "card", "checkout", "invoice", "order", "pay", "payment", "wallet"}
+_DESTRUCTIVE_HINTS = {"delete", "deploy", "merge", "publish", "push", "remove", "submit", "transfer"}
+
 
 class PageAnalyzer:
-    def analyze_sync(self, *, url: str, title: str, text: str) -> dict:
+    def analyze_sync(
+        self,
+        *,
+        url: str,
+        title: str,
+        text: str,
+        headings: list[dict] | None = None,
+        links: list[dict] | None = None,
+        forms: list[dict] | None = None,
+        buttons: list[dict] | None = None,
+        tabs: list[dict] | None = None,
+        selection: str = "",
+        page_type: str = "generic",
+        screenshot: str = "",
+    ) -> dict:
         truncated = False
         words = text.split()
         if len(words) > MAX_WORDS:
@@ -34,14 +52,64 @@ class PageAnalyzer:
         word_count = len(words)
         summary = self._extractive_summary(text) if word_count > 0 else ""
         topics = self._detect_topics(text)
+        headings = headings or []
+        links = links or []
+        forms = forms or []
+        buttons = buttons or []
+        tabs = tabs or []
+        selected_text = selection.strip()
+        if selected_text:
+            summary = f"Selected: {selected_text}\n\n{summary}".strip()
+        intent = self._infer_intent(url=url, title=title, text=text, page_type=page_type, forms=forms, buttons=buttons)
+        risk_tier, required_approvals = self._infer_risk(
+            title=title,
+            text=text,
+            page_type=page_type,
+            forms=forms,
+            buttons=buttons,
+        )
+        page_summary = self._build_page_summary(
+            title=title,
+            page_type=page_type,
+            headings=headings,
+            links=links,
+            forms=forms,
+            buttons=buttons,
+        )
+        next_actions = self._suggest_next_actions(
+            intent=intent,
+            risk_tier=risk_tier,
+            headings=headings,
+            links=links,
+            forms=forms,
+            buttons=buttons,
+            selected_text=selected_text,
+        )
 
         return {
             "url": url,
             "title": title,
             "word_count": word_count,
             "summary": summary,
+            "page_summary": page_summary,
             "topics": topics,
             "truncated": truncated,
+            "page_type": page_type,
+            "intent": intent,
+            "risk_tier": risk_tier,
+            "required_approvals": required_approvals,
+            "next_actions": next_actions,
+            "heading_count": len(headings),
+            "link_count": len(links),
+            "button_count": len(buttons),
+            "form_count": len(forms),
+            "tab_count": len(tabs),
+            "headings": headings[:8],
+            "links": links[:8],
+            "forms": forms[:4],
+            "tabs": tabs[:8],
+            "selected_text": selected_text,
+            "has_screenshot": bool(screenshot),
         }
 
     def _extractive_summary(self, text: str, max_sentences: int = 3) -> str:
@@ -64,3 +132,152 @@ class PageAnalyzer:
             if any(kw in text_lower for kw in keywords):
                 found.append(topic)
         return found
+
+    def _infer_intent(
+        self,
+        *,
+        url: str,
+        title: str,
+        text: str,
+        page_type: str,
+        forms: list[dict],
+        buttons: list[dict],
+    ) -> str:
+        combined = " ".join([url, title, text[:2000], page_type]).lower()
+        tokens = set(re.findall(r"[a-z0-9]+", combined))
+        if forms and (self._contains_hint(combined, _AUTH_HINTS) or self._buttons_match(buttons, _AUTH_HINTS)):
+            return "authenticate"
+        if forms and (self._contains_hint(combined, _PAYMENT_HINTS) or self._buttons_match(buttons, _PAYMENT_HINTS)):
+            return "checkout"
+        if "github.com" in url or "repository" in combined:
+            return "repository_review"
+        if {"query", "results", "search"} & tokens:
+            return "search_results"
+        if page_type == "form":
+            return "form_review"
+        if page_type == "article" or "article" in combined or "research" in combined:
+            return "read_article"
+        return "inspect_page"
+
+    def _infer_risk(
+        self,
+        *,
+        title: str,
+        text: str,
+        page_type: str,
+        forms: list[dict],
+        buttons: list[dict],
+    ) -> tuple[str, list[str]]:
+        combined = " ".join([title, text[:3000], page_type]).lower()
+        approvals: list[str] = []
+        if forms and (self._contains_hint(combined, _AUTH_HINTS) or self._buttons_match(buttons, _AUTH_HINTS)):
+            approvals.append("Page contains authentication or credential entry")
+        if forms and (self._contains_hint(combined, _PAYMENT_HINTS) or self._buttons_match(buttons, _PAYMENT_HINTS)):
+            approvals.append("Page contains payment or checkout flow")
+        if self._contains_hint(combined, _DESTRUCTIVE_HINTS) or self._buttons_match(buttons, _DESTRUCTIVE_HINTS):
+            approvals.append("Page exposes a high-impact state-changing action")
+        unique_approvals = list(dict.fromkeys(approvals))
+        if any("payment" in item.lower() or "high-impact" in item.lower() for item in unique_approvals):
+            return "high", unique_approvals
+        if unique_approvals or forms:
+            return "medium", unique_approvals
+        return "low", []
+
+    def _build_page_summary(
+        self,
+        *,
+        title: str,
+        page_type: str,
+        headings: list[dict],
+        links: list[dict],
+        forms: list[dict],
+        buttons: list[dict],
+    ) -> str:
+        parts = [title or "Untitled page"]
+        if page_type and page_type != "generic":
+            parts.append(page_type)
+        counts: list[str] = []
+        if headings:
+            counts.append(f"{len(headings)} headings")
+        if links:
+            counts.append(f"{len(links)} links")
+        if forms:
+            counts.append(f"{len(forms)} forms")
+        if buttons:
+            counts.append(f"{len(buttons)} buttons")
+        if counts:
+            parts.append(" | ".join(counts))
+        return " | ".join(parts)
+
+    def _suggest_next_actions(
+        self,
+        *,
+        intent: str,
+        risk_tier: str,
+        headings: list[dict],
+        links: list[dict],
+        forms: list[dict],
+        buttons: list[dict],
+        selected_text: str,
+    ) -> list[dict]:
+        actions: list[dict] = [
+            {
+                "label": "Capture page snapshot",
+                "reason": "Preserve evidence before navigating deeper or changing state.",
+                "risk_tier": "low",
+                "requires_approval": False,
+            }
+        ]
+        if selected_text:
+            actions.append(
+                {
+                    "label": "Ground analysis on the selected text",
+                    "reason": "The active selection usually marks the user’s immediate target.",
+                    "risk_tier": "low",
+                    "requires_approval": False,
+                }
+            )
+        elif headings:
+            heading = (headings[0].get("text") or "").strip()[:80]
+            if heading:
+                actions.append(
+                    {
+                        "label": f"Inspect heading: {heading}",
+                        "reason": "Lead with the main visible section before scanning the full page.",
+                        "risk_tier": "low",
+                        "requires_approval": False,
+                    }
+                )
+        elif links:
+            link = (links[0].get("text") or links[0].get("href") or "").strip()[:80]
+            if link:
+                actions.append(
+                    {
+                        "label": f"Inspect primary link: {link}",
+                        "reason": "Top links usually reveal the page’s next navigation branch.",
+                        "risk_tier": "low",
+                        "requires_approval": False,
+                    }
+                )
+        if forms or buttons:
+            actions.append(
+                {
+                    "label": f"Review {intent.replace('_', ' ')} controls before input",
+                    "reason": "Forms and action buttons should be validated before typing or clicking.",
+                    "risk_tier": risk_tier,
+                    "requires_approval": risk_tier != "low",
+                }
+            )
+        return actions[:3]
+
+    @staticmethod
+    def _contains_hint(text: str, hints: set[str]) -> bool:
+        return any(hint in text for hint in hints)
+
+    @staticmethod
+    def _buttons_match(buttons: list[dict], hints: set[str]) -> bool:
+        for button in buttons:
+            button_text = " ".join(str(button.get(key, "")) for key in ("text", "type", "name")).lower()
+            if any(hint in button_text for hint in hints):
+                return True
+        return False

--- a/src/aetherbrowser/provider_executor.py
+++ b/src/aetherbrowser/provider_executor.py
@@ -1,0 +1,317 @@
+"""Provider-backed execution for AetherBrowser command plans."""
+
+from __future__ import annotations
+
+from importlib.util import find_spec
+import os
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+from src.aetherbrowser.command_planner import CommandPlan
+from src.aetherbrowser.router import ModelProvider, PROVIDER_ENV_VARS, PROVIDER_FAMILY
+
+
+ProviderAdapter = Callable[[str, str], Awaitable[str]]
+
+
+@dataclass
+class ProviderExecutionResult:
+    provider: str
+    model_id: str
+    text: str
+    attempted: list[str]
+    fallback_used: bool
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "model_id": self.model_id,
+            "text": self.text,
+            "attempted": self.attempted,
+            "fallback_used": self.fallback_used,
+        }
+
+
+@dataclass
+class ProviderRuntimeStatus:
+    provider: ModelProvider
+    family: str
+    model_id: str
+    available: bool
+    reason: str
+    env_vars: tuple[str, ...]
+    packages: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "family": self.family,
+            "model_id": self.model_id,
+            "available": self.available,
+            "reason": self.reason,
+            "env_vars": list(self.env_vars),
+            "packages": list(self.packages),
+        }
+
+
+_MODEL_ID_DEFAULTS: dict[ModelProvider, tuple[str, str]] = {
+    ModelProvider.LOCAL: ("AETHERBROWSER_MODEL_LOCAL", "local-control"),
+    ModelProvider.HAIKU: ("AETHERBROWSER_MODEL_HAIKU", "claude-3-5-haiku-20241022"),
+    ModelProvider.SONNET: ("AETHERBROWSER_MODEL_SONNET", "claude-sonnet-4-20250514"),
+    ModelProvider.OPUS: ("AETHERBROWSER_MODEL_OPUS", "claude-opus-4-1-20250805"),
+    ModelProvider.FLASH: ("AETHERBROWSER_MODEL_FLASH", "gpt-4o-mini"),
+    ModelProvider.GROK: ("AETHERBROWSER_MODEL_GROK", "grok-3-mini"),
+}
+
+
+def _resolve_model_ids() -> dict[ModelProvider, str]:
+    """Resolve model IDs at call time so env vars set after import are picked up."""
+    return {
+        provider: os.environ.get(env_var, default)
+        for provider, (env_var, default) in _MODEL_ID_DEFAULTS.items()
+    }
+
+PROVIDER_PACKAGES: dict[ModelProvider, tuple[str, ...]] = {
+    ModelProvider.LOCAL: (),
+    ModelProvider.HAIKU: ("anthropic",),
+    ModelProvider.SONNET: ("anthropic",),
+    ModelProvider.OPUS: ("anthropic",),
+    ModelProvider.FLASH: ("openai",),
+    ModelProvider.GROK: ("openai",),
+}
+
+SYSTEM_PROMPT = (
+    "You are AetherBrowser's execution brain operating under SCBE governance. "
+    "Be concise, factual, and action-oriented. When a task is risky, acknowledge the gate. "
+    "When a browser action is required, describe the next concrete step."
+)
+
+
+class ProviderExecutor:
+    def __init__(
+        self,
+        *,
+        adapters: dict[ModelProvider, ProviderAdapter] | None = None,
+        model_ids: dict[ModelProvider, str] | None = None,
+    ) -> None:
+        self._model_id_overrides = dict(model_ids or {})
+        self._adapters: dict[ModelProvider, ProviderAdapter] = {
+            ModelProvider.LOCAL: self._call_local,
+            ModelProvider.HAIKU: self._call_anthropic,
+            ModelProvider.SONNET: self._call_anthropic,
+            ModelProvider.OPUS: self._call_anthropic,
+            ModelProvider.FLASH: self._call_openai,
+            ModelProvider.GROK: self._call_xai,
+        }
+        if adapters:
+            self._adapters.update(adapters)
+
+    @property
+    def _model_ids(self) -> dict[ModelProvider, str]:
+        return {**_resolve_model_ids(), **self._model_id_overrides}
+
+    def runtime_status(self) -> dict[ModelProvider, ProviderRuntimeStatus]:
+        return {
+            provider: self._provider_runtime_status(provider)
+            for provider in ModelProvider
+        }
+
+    def runtime_status_snapshot(self) -> dict[str, dict[str, object]]:
+        return {
+            provider.value: status.to_dict()
+            for provider, status in self.runtime_status().items()
+        }
+
+    async def execute(self, plan: CommandPlan) -> ProviderExecutionResult:
+        prompt = self._build_prompt(plan)
+        candidates = self._candidate_chain(plan)
+        attempted: list[str] = []
+        last_error: Exception | None = None
+
+        for provider in candidates:
+            model_id = self._model_ids[provider]
+            attempted.append(provider.value)
+            try:
+                text = await self._adapters[provider](model_id, prompt)
+                return ProviderExecutionResult(
+                    provider=provider.value,
+                    model_id=model_id,
+                    text=text.strip(),
+                    attempted=attempted,
+                    fallback_used=len(attempted) > 1,
+                )
+            except Exception as exc:
+                last_error = exc
+                if not plan.auto_cascade:
+                    break
+
+        raise RuntimeError(
+            f"Provider execution failed after attempting {', '.join(attempted)}: {last_error}"
+        ) from last_error
+
+    def _candidate_chain(self, plan: CommandPlan) -> list[ModelProvider]:
+        chain: list[ModelProvider] = []
+        for raw_provider in [plan.provider, *plan.fallback_chain]:
+            provider = ModelProvider(raw_provider)
+            if provider not in chain:
+                chain.append(provider)
+            if not plan.auto_cascade:
+                break
+        return chain
+
+    def _provider_runtime_status(self, provider: ModelProvider) -> ProviderRuntimeStatus:
+        env_vars = PROVIDER_ENV_VARS[provider]
+        packages = PROVIDER_PACKAGES[provider]
+
+        if not env_vars:
+            return ProviderRuntimeStatus(
+                provider=provider,
+                family=PROVIDER_FAMILY[provider],
+                model_id=self._model_ids[provider],
+                available=True,
+                reason="local_runtime",
+                env_vars=env_vars,
+                packages=packages,
+            )
+
+        if not any(os.environ.get(name, "").strip() for name in env_vars):
+            return ProviderRuntimeStatus(
+                provider=provider,
+                family=PROVIDER_FAMILY[provider],
+                model_id=self._model_ids[provider],
+                available=False,
+                reason=f"missing_env:{','.join(env_vars)}",
+                env_vars=env_vars,
+                packages=packages,
+            )
+
+        missing_packages = [name for name in packages if find_spec(name) is None]
+        if missing_packages:
+            return ProviderRuntimeStatus(
+                provider=provider,
+                family=PROVIDER_FAMILY[provider],
+                model_id=self._model_ids[provider],
+                available=False,
+                reason=f"missing_package:{','.join(missing_packages)}",
+                env_vars=env_vars,
+                packages=packages,
+            )
+
+        return ProviderRuntimeStatus(
+            provider=provider,
+            family=PROVIDER_FAMILY[provider],
+            model_id=self._model_ids[provider],
+            available=True,
+            reason="ready",
+            env_vars=env_vars,
+            packages=packages,
+        )
+
+    def _build_prompt(self, plan: CommandPlan) -> str:
+        assignment_lines = []
+        for assignment in plan.assignments[:6]:
+            role = assignment["role"].value if hasattr(assignment["role"], "value") else assignment["role"]
+            assignment_lines.append(f"- {role}: {assignment['task']}")
+
+        next_actions = [action.label for action in plan.next_actions[:3]]
+        prompt_parts = [
+            f"User request: {plan.text}",
+            f"Task type: {plan.task_type}",
+            f"Intent: {plan.intent}",
+            f"Complexity: {plan.complexity.value}",
+            f"Risk tier: {plan.risk_tier}",
+            f"Browser action required: {plan.browser_action_required}",
+            f"Approval required: {plan.approval_required}",
+            f"Preferred engine: {plan.preferred_engine}",
+            "Assignments:",
+            *assignment_lines,
+        ]
+        if next_actions:
+            prompt_parts.extend(["Next actions:", *[f"- {label}" for label in next_actions]])
+        prompt_parts.append("Respond to the operator with the current best next move.")
+        return "\n".join(prompt_parts)
+
+    async def _call_local(self, model_id: str, prompt: str) -> str:
+        del model_id
+        lines = prompt.splitlines()
+        request_line = next((line for line in lines if line.startswith("User request: ")), "User request: ")
+        task_line = next((line for line in lines if line.startswith("Task type: ")), "Task type: default")
+        risk_line = next((line for line in lines if line.startswith("Risk tier: ")), "Risk tier: low")
+        browser_line = next(
+            (line for line in lines if line.startswith("Browser action required: ")),
+            "Browser action required: False",
+        )
+        action_lines = [line[2:] for line in lines if line.startswith("- ")]
+        first_action = action_lines[0] if action_lines else "Begin with KO orchestration."
+        return (
+            f"Local execution lane active. {request_line.replace('User request: ', '')} "
+            f"({task_line.replace('Task type: ', '')}, {risk_line.replace('Risk tier: ', '')}). "
+            f"{browser_line.replace('Browser action required: ', 'Browser action required=')}. "
+            f"Next: {first_action}"
+        )
+
+    async def _call_anthropic(self, model_id: str, prompt: str) -> str:
+        try:
+            import anthropic  # type: ignore[import-untyped]
+        except Exception as exc:  # pragma: no cover - depends on local env
+            raise RuntimeError("anthropic package is not installed") from exc
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError("ANTHROPIC_API_KEY is not configured")
+
+        client = anthropic.AsyncAnthropic(api_key=api_key)
+        response = await client.messages.create(
+            model=model_id,
+            max_tokens=700,
+            temperature=0.2,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return "".join(block.text for block in response.content if hasattr(block, "text"))
+
+    async def _call_openai(self, model_id: str, prompt: str) -> str:
+        try:
+            import openai  # type: ignore[import-untyped]
+        except Exception as exc:  # pragma: no cover - depends on local env
+            raise RuntimeError("openai package is not installed") from exc
+
+        api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY is not configured")
+
+        client = openai.AsyncOpenAI(api_key=api_key)
+        response = await client.chat.completions.create(
+            model=model_id,
+            temperature=0.2,
+            max_tokens=700,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        return response.choices[0].message.content or ""
+
+    async def _call_xai(self, model_id: str, prompt: str) -> str:
+        try:
+            import openai  # type: ignore[import-untyped]
+        except Exception as exc:  # pragma: no cover - depends on local env
+            raise RuntimeError("openai package is required for the xAI lane") from exc
+
+        api_key = os.environ.get("XAI_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError("XAI_API_KEY is not configured")
+
+        client = openai.AsyncOpenAI(
+            api_key=api_key,
+            base_url=os.environ.get("XAI_BASE_URL", "https://api.x.ai/v1"),
+        )
+        response = await client.chat.completions.create(
+            model=model_id,
+            temperature=0.2,
+            max_tokens=700,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        return response.choices[0].message.content or ""

--- a/src/aetherbrowser/router.py
+++ b/src/aetherbrowser/router.py
@@ -12,9 +12,11 @@ Every model can play any role. Routing is a preference, not a lock.
 """
 from __future__ import annotations
 
+import os
 import time
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 
 class ModelProvider(str, Enum):
@@ -41,6 +43,24 @@ MODEL_COST_TIER: dict[ModelProvider, int] = {
     ModelProvider.OPUS: 4,
 }
 
+PROVIDER_ENV_VARS: dict[ModelProvider, tuple[str, ...]] = {
+    ModelProvider.LOCAL: (),
+    ModelProvider.HAIKU: ("ANTHROPIC_API_KEY",),
+    ModelProvider.SONNET: ("ANTHROPIC_API_KEY",),
+    ModelProvider.OPUS: ("ANTHROPIC_API_KEY",),
+    ModelProvider.FLASH: ("OPENAI_API_KEY",),
+    ModelProvider.GROK: ("XAI_API_KEY",),
+}
+
+PROVIDER_FAMILY: dict[ModelProvider, str] = {
+    ModelProvider.LOCAL: "local",
+    ModelProvider.HAIKU: "anthropic",
+    ModelProvider.SONNET: "anthropic",
+    ModelProvider.OPUS: "anthropic",
+    ModelProvider.FLASH: "openai",
+    ModelProvider.GROK: "xai",
+}
+
 COMPLEXITY_MIN_TIER: dict[TaskComplexity, int] = {
     TaskComplexity.LOW: 0,
     TaskComplexity.MEDIUM: 2,
@@ -65,15 +85,74 @@ class SelectedModel:
     provider: ModelProvider
     role: str
     complexity: TaskComplexity
+    selection_reason: str
+    fallback_chain: list[ModelProvider]
+
+
+@dataclass
+class ProviderStatus:
+    provider: ModelProvider
+    family: str
+    available: bool
+    reason: str
+    env_vars: tuple[str, ...]
+    tier: int
 
 
 class OctoArmorRouter:
-    def __init__(self, preferences: dict[str, ModelProvider] | None = None):
+    def __init__(
+        self,
+        preferences: dict[str, ModelProvider] | None = None,
+        enabled_providers: dict[ModelProvider, bool] | None = None,
+        local_first: bool = True,
+    ):
         self._prefs = {**DEFAULT_PREFERENCES, **(preferences or {})}
         self._rate_limits: dict[ModelProvider, float] = {}
+        self._enabled_overrides = dict(enabled_providers or {})
+        self._local_first = local_first
 
     def get_preferences(self) -> dict[str, ModelProvider]:
         return dict(self._prefs)
+
+    @staticmethod
+    def normalize_preferences(raw_preferences: dict[str, Any] | None) -> dict[str, ModelProvider]:
+        normalized: dict[str, ModelProvider] = {}
+        if not raw_preferences:
+            return normalized
+        for role, provider in raw_preferences.items():
+            try:
+                normalized[str(role)] = (
+                    provider if isinstance(provider, ModelProvider) else ModelProvider(str(provider))
+                )
+            except ValueError:
+                continue
+        return normalized
+
+    def provider_status_snapshot(self) -> dict[str, dict[str, object]]:
+        return {
+            provider.value: {
+                "available": status.available,
+                "family": status.family,
+                "reason": status.reason,
+                "env_vars": list(status.env_vars),
+                "tier": status.tier,
+            }
+            for provider, status in self.provider_status().items()
+        }
+
+    def provider_status(self) -> dict[ModelProvider, ProviderStatus]:
+        snapshot: dict[ModelProvider, ProviderStatus] = {}
+        for provider in ModelProvider:
+            available, reason = self._configured_available(provider)
+            snapshot[provider] = ProviderStatus(
+                provider=provider,
+                family=PROVIDER_FAMILY[provider],
+                available=available,
+                reason=reason,
+                env_vars=PROVIDER_ENV_VARS[provider],
+                tier=MODEL_COST_TIER[provider],
+            )
+        return snapshot
 
     def score_complexity(self, text: str) -> TaskComplexity:
         words = set(text.lower().split())
@@ -89,7 +168,21 @@ class OctoArmorRouter:
     def mark_rate_limited(self, provider: ModelProvider, window_sec: float = 60.0) -> None:
         self._rate_limits[provider] = time.monotonic() + window_sec
 
+    def _configured_available(self, provider: ModelProvider) -> tuple[bool, str]:
+        if provider in self._enabled_overrides:
+            enabled = self._enabled_overrides[provider]
+            return enabled, "override_enabled" if enabled else "override_disabled"
+        env_vars = PROVIDER_ENV_VARS[provider]
+        if not env_vars:
+            return True, "local_runtime"
+        if any(os.environ.get(name, "").strip() for name in env_vars):
+            return True, f"env:{env_vars[0]}"
+        return False, f"missing_env:{','.join(env_vars)}"
+
     def _is_available(self, provider: ModelProvider) -> bool:
+        configured, _ = self._configured_available(provider)
+        if not configured:
+            return False
         expiry = self._rate_limits.get(provider)
         if expiry is None:
             return True
@@ -98,15 +191,73 @@ class OctoArmorRouter:
             return True
         return False
 
-    def select_model(self, complexity: TaskComplexity, role: str) -> SelectedModel:
+    def select_model(
+        self,
+        complexity: TaskComplexity,
+        role: str,
+        *,
+        preference_overrides: dict[str, Any] | None = None,
+        allow_fallback: bool = True,
+        local_first: bool | None = None,
+    ) -> SelectedModel:
         min_tier = COMPLEXITY_MIN_TIER[complexity]
-        preferred = self._prefs.get(role, ModelProvider.SONNET)
-        if self._is_available(preferred) and MODEL_COST_TIER[preferred] >= min_tier:
-            return SelectedModel(provider=preferred, role=role, complexity=complexity)
-        candidates = sorted(
+        overrides = self.normalize_preferences(preference_overrides)
+        explicit_preference = role in overrides
+        preferred = overrides.get(role, self._prefs.get(role, ModelProvider.SONNET))
+        use_local_first = self._local_first if local_first is None else local_first
+
+        if (
+            use_local_first
+            and not explicit_preference
+            and complexity == TaskComplexity.LOW
+            and self._is_available(ModelProvider.LOCAL)
+        ):
+            fallback_chain = self._candidate_chain(min_tier=min_tier)
+            return SelectedModel(
+                provider=ModelProvider.LOCAL,
+                role=role,
+                complexity=complexity,
+                selection_reason="local_first_low_complexity",
+                fallback_chain=fallback_chain if allow_fallback else [ModelProvider.LOCAL],
+            )
+
+        if self._is_available(preferred):
+            if explicit_preference:
+                reason = (
+                    "preference_override"
+                    if MODEL_COST_TIER[preferred] >= min_tier
+                    else "preference_override_below_recommended_tier"
+                )
+            else:
+                reason = (
+                    "preferred_provider"
+                    if MODEL_COST_TIER[preferred] >= min_tier
+                    else "preferred_provider_below_recommended_tier"
+                )
+            return SelectedModel(
+                provider=preferred,
+                role=role,
+                complexity=complexity,
+                selection_reason=reason,
+                fallback_chain=self._candidate_chain(min_tier=min_tier) if allow_fallback else [preferred],
+            )
+
+        if not allow_fallback:
+            raise RuntimeError(f"Preferred provider '{preferred.value}' unavailable and auto-cascade disabled")
+
+        candidates = self._candidate_chain(min_tier=min_tier)
+        if not candidates:
+            raise RuntimeError("All models rate-limited or unavailable")
+        return SelectedModel(
+            provider=candidates[0],
+            role=role,
+            complexity=complexity,
+            selection_reason="fallback_chain",
+            fallback_chain=candidates,
+        )
+
+    def _candidate_chain(self, *, min_tier: int) -> list[ModelProvider]:
+        return sorted(
             [p for p in ModelProvider if self._is_available(p) and MODEL_COST_TIER[p] >= min_tier],
             key=lambda p: MODEL_COST_TIER[p],
         )
-        if not candidates:
-            raise RuntimeError("All models rate-limited")
-        return SelectedModel(provider=candidates[0], role=role, complexity=complexity)

--- a/src/aetherbrowser/serve.py
+++ b/src/aetherbrowser/serve.py
@@ -11,13 +11,17 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
+from typing import Any
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 
-from src.aetherbrowser.ws_feed import WsFeed, MsgType, Agent
+from src.aetherbrowser.ws_feed import WsFeed, MsgType, Agent, Zone
 from src.aetherbrowser.agents import AgentSquad, TongueRole, AgentState
+from src.aetherbrowser.command_planner import CommandPlan, build_command_plan
 from src.aetherbrowser.page_analyzer import PageAnalyzer
+from src.aetherbrowser.provider_executor import ProviderExecutor
 from src.aetherbrowser.router import OctoArmorRouter
 
 logger = logging.getLogger("aetherbrowser")
@@ -26,7 +30,7 @@ app = FastAPI(title="AetherBrowser", version="0.1.0")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["chrome-extension://*", "http://127.0.0.1:*", "http://localhost:*"],
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -36,6 +40,14 @@ feed = WsFeed()
 squad = AgentSquad(feed)
 analyzer = PageAnalyzer()
 router = OctoArmorRouter()
+executor = ProviderExecutor()
+pending_zone_requests: dict[int, "PendingCommandApproval"] = {}
+
+
+@dataclass
+class PendingCommandApproval:
+    plan: CommandPlan
+    assignments: list[dict[str, Any]]
 
 
 @app.get("/health")
@@ -44,6 +56,8 @@ def health():
         "status": "ok",
         "version": "0.1.0",
         "agents": squad.status_snapshot(),
+        "providers": router.provider_status_snapshot(),
+        "executor": executor.runtime_status_snapshot(),
     }
 
 
@@ -71,42 +85,60 @@ async def websocket_endpoint(ws: WebSocket):
                 await ws.send_json(feed.error(f"Unhandled message type: {msg_type}"))
 
     except WebSocketDisconnect:
+        pending_zone_requests.clear()
         logger.info("Client disconnected")
     except Exception as e:
         logger.error(f"WebSocket error: {e}")
 
 
 async def _handle_command(ws: WebSocket, msg: dict) -> None:
-    text = msg.get("payload", {}).get("text", "")
+    payload = msg.get("payload", {})
+    text = payload.get("text", "")
     if not text:
         await ws.send_json(feed.error("Empty command"))
         return
 
-    # Decompose task
-    assignments = squad.decompose(text)
+    routing = payload.get("routing", {}) if isinstance(payload.get("routing"), dict) else {}
+    routing_preferences = routing.get("preferences") if isinstance(routing.get("preferences"), dict) else None
+    auto_cascade = bool(routing.get("auto_cascade", routing.get("autoCascade", True)))
 
-    # Score complexity and pick model for KO
-    complexity = router.score_complexity(text)
-    model = router.select_model(complexity, role="KO")
+    plan = build_command_plan(
+        text=text,
+        squad=squad,
+        router=router,
+        routing_preferences=routing_preferences,
+        auto_cascade=auto_cascade,
+    )
+    assignments = plan.assignments
+    squad.set_state(TongueRole.KO, AgentState.WORKING, model=plan.provider)
+    await ws.send_json(feed.agent_status(Agent.KO, "working", model=plan.provider))
+    await ws.send_json(
+        feed.chat(
+            Agent.KO,
+            _format_command_summary(plan),
+            model=plan.provider,
+            payload={"plan": plan.to_dict()},
+        )
+    )
 
-    # Send KO's initial response
-    squad.set_state(TongueRole.KO, AgentState.WORKING, model=model.provider.value)
-    await ws.send_json(feed.agent_status(Agent.KO, "working", model=model.provider.value))
-    await ws.send_json(feed.chat(
-        Agent.KO,
-        f"Received: '{text}'. Complexity: {complexity.value}. "
-        f"Assigning {len(assignments)} agents. Model: {model.provider.value}.",
-        model=model.provider.value,
-    ))
+    if plan.approval_required and plan.review_zone:
+        squad.set_state(TongueRole.KO, AgentState.WAITING, model=plan.provider)
+        await ws.send_json(feed.agent_status(Agent.KO, "waiting", model=plan.provider))
+        zone_request = feed.zone_request(
+            Agent.RU,
+            Zone[plan.review_zone],
+            url=plan.targets[0] if plan.targets else "pending://browser-action",
+            action=plan.intent,
+            description="; ".join(plan.required_approvals),
+        )
+        pending_zone_requests[zone_request["seq"]] = PendingCommandApproval(
+            plan=plan,
+            assignments=assignments,
+        )
+        await ws.send_json(zone_request)
+        return
 
-    # Assign other agents
-    for a in assignments:
-        if a["role"] != TongueRole.KO:
-            role_agent = Agent[a["role"].value]
-            await ws.send_json(feed.agent_status(role_agent, "assigned"))
-
-    squad.set_state(TongueRole.KO, AgentState.DONE)
-    await ws.send_json(feed.agent_status(Agent.KO, "done"))
+    await _complete_command_flow(ws, plan, assignments)
 
 
 async def _handle_page_context(ws: WebSocket, msg: dict) -> None:
@@ -117,29 +149,135 @@ async def _handle_page_context(ws: WebSocket, msg: dict) -> None:
 
     await ws.send_json(feed.agent_status(Agent.CA, "analyzing"))
 
-    result = analyzer.analyze_sync(url=url, title=title, text=text)
+    result = analyzer.analyze_sync(
+        url=url,
+        title=title,
+        text=text,
+        headings=payload.get("headings") or [],
+        links=payload.get("links") or [],
+        forms=payload.get("forms") or [],
+        buttons=payload.get("buttons") or [],
+        tabs=payload.get("tabs") or [],
+        selection=payload.get("selection", ""),
+        page_type=payload.get("page_type", "generic"),
+        screenshot=payload.get("screenshot", ""),
+    )
 
     summary_text = (
         f"Page: {result['title']}\n"
         f"Words: {result['word_count']}\n"
-        f"Topics: {', '.join(result['topics']) or 'General'}\n\n"
+        f"Topics: {', '.join(result['topics']) or 'General'}\n"
+        f"Intent: {result['intent']}\n"
+        f"Risk: {result['risk_tier']}\n"
+        f"Type: {result['page_type']}\n"
+        f"Headings: {result['heading_count']} | Links: {result['link_count']} | Forms: {result['form_count']} | Tabs: {result['tab_count']}\n\n"
         f"{result['summary']}"
     )
-    await ws.send_json(feed.chat(Agent.CA, summary_text, model="local"))
+    await ws.send_json(
+        feed.chat(
+            Agent.CA,
+            summary_text,
+            model="local",
+            payload={"page_analysis": result},
+        )
+    )
     await ws.send_json(feed.agent_status(Agent.CA, "done"))
 
     if result["topics"]:
-        await ws.send_json(feed.chat(
-            Agent.DR,
-            f"Structured topics: {json.dumps(result['topics'])}",
-            model="local",
-        ))
+        next_action_labels = ", ".join(action["label"] for action in result["next_actions"]) or "none"
+        await ws.send_json(
+            feed.chat(
+                Agent.DR,
+                f"Structured topics: {json.dumps(result['topics'])}\nNext actions: {next_action_labels}",
+                model="local",
+                payload={"page_analysis": result},
+            )
+        )
 
 
 async def _handle_zone_response(ws: WebSocket, msg: dict) -> None:
     payload = msg.get("payload", {})
     decision = payload.get("decision", "deny")
-    await ws.send_json(feed.chat(
-        Agent.RU,
-        f"Zone decision received: {decision}",
-    ))
+    request_seq = payload.get("request_seq")
+    pending = pending_zone_requests.pop(request_seq, None)
+    if pending is None:
+        await ws.send_json(feed.error(f"Unknown zone request: {request_seq}", agent=Agent.RU))
+        return
+
+    if decision in {"allow", "allow_once", "add_yellow"}:
+        await ws.send_json(
+            feed.chat(
+                Agent.RU,
+                f"Zone decision received: {decision}. Releasing the held browser plan.",
+                payload={"plan": pending.plan.to_dict()},
+            )
+        )
+        await _complete_command_flow(ws, pending.plan, pending.assignments)
+        return
+
+    squad.set_state(TongueRole.KO, AgentState.ERROR, model=pending.plan.provider)
+    await ws.send_json(
+        feed.chat(
+            Agent.RU,
+            f"Zone decision received: {decision}. Browser plan denied.",
+            payload={"plan": pending.plan.to_dict()},
+        )
+    )
+    await ws.send_json(feed.agent_status(Agent.KO, "error", model=pending.plan.provider))
+
+
+async def _complete_command_flow(
+    ws: WebSocket,
+    plan: CommandPlan,
+    assignments: list[dict[str, Any]],
+) -> None:
+    for assignment in assignments:
+        if assignment["role"] == TongueRole.KO:
+            continue
+        role_agent = Agent[assignment["role"].value]
+        await ws.send_json(feed.agent_status(role_agent, "assigned"))
+
+    try:
+        execution = await executor.execute(plan)
+    except Exception as exc:
+        squad.set_state(TongueRole.KO, AgentState.ERROR, model=plan.provider)
+        await ws.send_json(feed.error(f"Command execution failed: {exc}", agent=Agent.KO))
+        await ws.send_json(feed.agent_status(Agent.KO, "error", model=plan.provider))
+        return
+
+    await ws.send_json(
+        feed.chat(
+            Agent.KO,
+            execution.text,
+            model=execution.model_id,
+            payload={"execution": execution.to_dict()},
+        )
+    )
+    await ws.send_json(
+        feed.chat(
+            Agent.DR,
+            (
+                f"Execution provider={execution.provider}, model={execution.model_id}, "
+                f"fallback_used={execution.fallback_used}, attempted={', '.join(execution.attempted)}."
+            ),
+            model="local",
+            payload={"execution": execution.to_dict()},
+        )
+    )
+
+    squad.set_state(TongueRole.KO, AgentState.DONE, model=execution.model_id)
+    await ws.send_json(feed.agent_status(Agent.KO, "done", model=execution.model_id))
+
+
+def _format_command_summary(plan: CommandPlan) -> str:
+    targets = ", ".join(plan.targets) if plan.targets else "generic browser lane"
+    approvals = ", ".join(plan.required_approvals) if plan.required_approvals else "none"
+    next_action = plan.next_actions[0].label if plan.next_actions else "review plan"
+    return (
+        f"Intent: {plan.intent}\n"
+        f"Task: {plan.task_type} | Complexity: {plan.complexity.value} | Risk: {plan.risk_tier}\n"
+        f"Engine: {plan.preferred_engine} | Target: {targets}\n"
+        f"Approvals: {approvals}\n"
+        f"Lead action: {next_action}\n"
+        f"Model: {plan.provider} ({plan.selection_reason}) | Auto-cascade: {plan.auto_cascade}"
+    )

--- a/src/aetherbrowser/ws_feed.py
+++ b/src/aetherbrowser/ws_feed.py
@@ -63,8 +63,17 @@ class WsFeed:
             "seq": self._next_seq(),
         }
 
-    def chat(self, agent: Agent, text: str, model: str | None = None) -> dict:
-        return self._base(MsgType.CHAT, agent, model=model, payload={"text": text})
+    def chat(
+        self,
+        agent: Agent,
+        text: str,
+        model: str | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> dict:
+        merged_payload = {"text": text}
+        if payload:
+            merged_payload.update(payload)
+        return self._base(MsgType.CHAT, agent, model=model, payload=merged_payload)
 
     def agent_status(self, agent: Agent, state: str, model: str | None = None) -> dict:
         return self._base(MsgType.AGENT_STATUS, agent, model=model, payload={"state": state})

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -5,3 +5,37 @@ chrome.action.onClicked.addListener((tab) => {
 
 chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
   .catch((e) => console.error('sidePanel.setPanelBehavior error:', e));
+
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+  if (request.action === 'captureVisibleTab') {
+    chrome.tabs.captureVisibleTab(undefined, { format: 'jpeg', quality: 70 }, (dataUrl) => {
+      if (chrome.runtime.lastError) {
+        sendResponse({ ok: false, error: chrome.runtime.lastError.message });
+        return;
+      }
+      sendResponse({ ok: true, dataUrl });
+    });
+    return true;
+  }
+
+  if (request.action === 'getOpenTabs') {
+    chrome.tabs.query({ currentWindow: true }, (tabs) => {
+      if (chrome.runtime.lastError) {
+        sendResponse({ ok: false, error: chrome.runtime.lastError.message });
+        return;
+      }
+      const payload = (tabs || []).map((tab) => ({
+        id: tab.id,
+        title: tab.title || '',
+        url: tab.url || '',
+        active: Boolean(tab.active),
+        pinned: Boolean(tab.pinned),
+        audible: Boolean(tab.audible),
+      }));
+      sendResponse({ ok: true, tabs: payload });
+    });
+    return true;
+  }
+
+  return false;
+});

--- a/src/extension/components/AgentGrid.js
+++ b/src/extension/components/AgentGrid.js
@@ -1,19 +1,33 @@
 const AGENTS = ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'];
+const PROVIDERS = ['local', 'flash', 'haiku', 'sonnet', 'opus', 'grok'];
 const AGENT_LABELS = {
   KO: 'Commander', AV: 'Navigator', RU: 'Policy',
   CA: 'Compute', UM: 'Shadow', DR: 'Schema',
+};
+const PROVIDER_LABELS = {
+  local: 'Local',
+  flash: 'Flash',
+  haiku: 'Haiku',
+  sonnet: 'Sonnet',
+  opus: 'Opus',
+  grok: 'Grok',
 };
 
 export function renderAgentGrid(container) {
   container.setAttribute('role', 'status');
   container.setAttribute('aria-label', 'Agent squad status');
-  container.innerHTML = AGENTS.map((id) => `
-    <div class="ab-agent-badge" id="badge-${id}" title="${AGENT_LABELS[id]}">
-      <span class="ab-agent-badge__dot"></span>
-      <span class="ab-agent-badge__name">${id}</span>
-      <span class="ab-agent-badge__model" id="model-${id}"></span>
+  container.innerHTML = `
+    <div class="ab-agent-grid__row" id="agent-grid-row">
+      ${AGENTS.map((id) => `
+        <div class="ab-agent-badge" id="badge-${id}" title="${AGENT_LABELS[id]}">
+          <span class="ab-agent-badge__dot"></span>
+          <span class="ab-agent-badge__name">${id}</span>
+          <span class="ab-agent-badge__model" id="model-${id}"></span>
+        </div>
+      `).join('')}
     </div>
-  `).join('');
+    <div class="ab-provider-strip" id="provider-strip" aria-live="polite"></div>
+  `;
 }
 
 export function updateAgentBadge(agentId, state, model) {
@@ -31,4 +45,65 @@ export function updateAgentBadge(agentId, state, model) {
 
 export function resetAllBadges() {
   AGENTS.forEach((id) => updateAgentBadge(id, 'idle'));
+}
+
+export function renderProviderHealth(snapshot = {}) {
+  const strip = document.getElementById('provider-strip');
+  if (!strip) return;
+  const keys = PROVIDERS.filter((provider) => snapshot[provider]);
+  if (!keys.length) {
+    strip.innerHTML = `
+      <div class="ab-provider-strip__label">Runtime</div>
+      <div class="ab-provider-pill ab-provider-pill--unknown">Awaiting backend health</div>
+    `;
+    return;
+  }
+
+  strip.innerHTML = `
+    <div class="ab-provider-strip__label">Runtime</div>
+    ${keys.map((provider) => renderProviderPill(provider, snapshot[provider])).join('')}
+  `;
+}
+
+export function clearProviderHealth() {
+  const strip = document.getElementById('provider-strip');
+  if (!strip) return;
+  strip.innerHTML = `
+    <div class="ab-provider-strip__label">Runtime</div>
+    <div class="ab-provider-pill ab-provider-pill--unknown">Disconnected</div>
+  `;
+}
+
+function renderProviderPill(provider, meta) {
+  const ready = meta?.available === true;
+  const reason = meta?.reason || 'unknown';
+  const modelId = meta?.model_id || '';
+  const statusClass = ready ? 'ready' : 'blocked';
+  const statusText = ready ? 'ready' : abbreviateReason(reason);
+  const title = [
+    `${PROVIDER_LABELS[provider] || provider}: ${reason}`,
+    modelId ? `model=${modelId}` : '',
+    Array.isArray(meta?.packages) && meta.packages.length ? `packages=${meta.packages.join(',')}` : '',
+  ].filter(Boolean).join(' | ');
+  return `
+    <div class="ab-provider-pill ab-provider-pill--${statusClass}" title="${escapeHtml(title)}">
+      <span class="ab-provider-pill__name">${escapeHtml(PROVIDER_LABELS[provider] || provider)}</span>
+      <span class="ab-provider-pill__status">${escapeHtml(statusText)}</span>
+    </div>
+  `;
+}
+
+function abbreviateReason(reason) {
+  if (!reason) return 'blocked';
+  if (reason === 'ready') return 'ready';
+  if (reason === 'local_runtime') return 'local';
+  if (reason.startsWith('missing_env:')) return 'env';
+  if (reason.startsWith('missing_package:')) return 'pkg';
+  return reason.replace(/^missing_/, '');
+}
+
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
 }

--- a/src/extension/components/ConversationFeed.js
+++ b/src/extension/components/ConversationFeed.js
@@ -11,7 +11,12 @@ export function initConversationFeed(container) {
 export function appendMessage(container, msg) {
   const agent = msg.agent || 'system';
   const model = msg.model || '';
-  const text = msg.payload?.text || msg.payload?.state || JSON.stringify(msg.payload);
+  const payload = msg.payload || {};
+  const text = getPrimaryText(payload);
+  const plan = payload.plan && typeof payload.plan === 'object' ? payload.plan : null;
+  const pageAnalysis = payload.page_analysis && typeof payload.page_analysis === 'object'
+    ? payload.page_analysis
+    : null;
 
   const el = document.createElement('div');
   el.className = `ab-message ab-message--${agent}`;
@@ -20,7 +25,9 @@ export function appendMessage(container, msg) {
       <span class="ab-message__agent">${AGENT_NAMES[agent] || agent}</span>
       ${model ? `<span class="ab-message__model">${model}</span>` : ''}
     </div>
-    <div class="ab-message__text">${escapeHtml(text)}</div>
+    ${text ? `<div class="ab-message__text">${escapeHtml(text)}</div>` : ''}
+    ${plan ? renderPlanSection(plan) : ''}
+    ${pageAnalysis ? renderPageAnalysisSection(pageAnalysis) : ''}
   `;
   container.appendChild(el);
   container.scrollTop = container.scrollHeight;
@@ -34,4 +41,264 @@ function escapeHtml(str) {
   const div = document.createElement('div');
   div.textContent = str;
   return div.innerHTML;
+}
+
+function getPrimaryText(payload) {
+  if (typeof payload.text === 'string' && payload.text.trim()) {
+    return payload.text;
+  }
+  if (typeof payload.state === 'string' && payload.state.trim()) {
+    return payload.state;
+  }
+  if (payload.plan || payload.page_analysis) {
+    return '';
+  }
+  return JSON.stringify(payload);
+}
+
+function renderPlanSection(plan) {
+  const badges = [
+    createBadge('Intent', plan.intent || plan.task_type),
+    createRiskBadge(plan.risk_tier || plan.zone),
+    createBadge('Provider', plan.provider),
+    boolBadge(plan.browser_action_required, 'Browser Action'),
+    boolBadge(plan.escalation_ready, 'Escalation Ready'),
+  ].filter(Boolean);
+  const approvals = normalizeStringList(plan.required_approvals);
+  const nextActions = normalizeActionList(plan.next_actions);
+  const assignments = normalizeAssignmentList(plan.assignments);
+
+  return `
+    <section class="ab-structured ab-structured--plan">
+      <div class="ab-structured__title">Command Plan</div>
+      ${badges.length ? `<div class="ab-pill-row">${badges.join('')}</div>` : ''}
+      ${renderKeyValueGrid([
+        ['Selection', plan.selection_reason],
+        ['Fallback', joinList(plan.fallback_chain)],
+      ])}
+      ${renderListSection('Next Actions', nextActions, { ordered: true })}
+      ${renderListSection('Required Approvals', approvals)}
+      ${renderListSection('Assignments', assignments)}
+    </section>
+  `;
+}
+
+function renderPageAnalysisSection(pageAnalysis) {
+  const badges = [
+    createBadge('Intent', pageAnalysis.intent || pageAnalysis.page_type),
+    createRiskBadge(pageAnalysis.risk_tier),
+    createBadge('Topics', countValue(pageAnalysis.topics)),
+  ].filter(Boolean);
+  const nextActions = normalizeActionList(pageAnalysis.next_actions);
+  const approvals = normalizeStringList(pageAnalysis.required_approvals);
+  const topics = normalizeStringList(pageAnalysis.topics);
+  const metrics = [
+    ['Words', pageAnalysis.word_count],
+    ['Headings', pageAnalysis.heading_count],
+    ['Links', pageAnalysis.link_count],
+    ['Forms', pageAnalysis.form_count],
+    ['Buttons', pageAnalysis.button_count],
+    ['Tabs', pageAnalysis.tab_count],
+  ].filter(([, value]) => Number.isFinite(value));
+
+  return `
+    <section class="ab-structured ab-structured--analysis">
+      <div class="ab-structured__title">Page Analysis</div>
+      ${pageAnalysis.page_summary || pageAnalysis.summary ? `
+        <div class="ab-structured__summary">
+          ${escapeHtml(pageAnalysis.page_summary || pageAnalysis.summary)}
+        </div>
+      ` : ''}
+      ${badges.length ? `<div class="ab-pill-row">${badges.join('')}</div>` : ''}
+      ${metrics.length ? renderMetricGrid(metrics) : ''}
+      ${topics.length ? renderListSection('Topics', topics) : ''}
+      ${renderListSection('Next Actions', nextActions, { ordered: true })}
+      ${renderListSection('Required Approvals', approvals)}
+    </section>
+  `;
+}
+
+function renderKeyValueGrid(rows) {
+  const safeRows = rows.filter(([, value]) => value);
+  if (!safeRows.length) {
+    return '';
+  }
+  return `
+    <div class="ab-key-grid">
+      ${safeRows.map(([label, value]) => `
+        <div class="ab-key-grid__item">
+          <div class="ab-key-grid__label">${escapeHtml(label)}</div>
+          <div class="ab-key-grid__value">${escapeHtml(String(value))}</div>
+        </div>
+      `).join('')}
+    </div>
+  `;
+}
+
+function renderMetricGrid(metrics) {
+  return `
+    <div class="ab-metric-grid">
+      ${metrics.map(([label, value]) => `
+        <div class="ab-metric">
+          <div class="ab-metric__value">${escapeHtml(String(value))}</div>
+          <div class="ab-metric__label">${escapeHtml(label)}</div>
+        </div>
+      `).join('')}
+    </div>
+  `;
+}
+
+// Items are pre-escaped HTML strings (may contain safe markup like <strong>).
+// All normalize*List() functions must escapeHtml() user-facing text before returning.
+function renderListSection(title, items, opts = {}) {
+  if (!items.length) {
+    return '';
+  }
+  const tag = opts.ordered ? 'ol' : 'ul';
+  return `
+    <div class="ab-structured__section">
+      <div class="ab-structured__section-title">${escapeHtml(title)}</div>
+      <${tag} class="ab-structured__list">
+        ${items.map((item) => `<li>${item}</li>`).join('')}
+      </${tag}>
+    </div>
+  `;
+}
+
+function normalizeStringList(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (typeof item === 'string') {
+          return escapeHtml(item);
+        }
+        if (item && typeof item === 'object') {
+          const label = item.label || item.reason || item.name;
+          return label ? escapeHtml(String(label)) : '';
+        }
+        return '';
+      })
+      .filter(Boolean);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return [escapeHtml(value)];
+  }
+  if (typeof value === 'number' && value > 0) {
+    return [escapeHtml(String(value))];
+  }
+  return [];
+}
+
+function normalizeActionList(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item, index) => {
+      if (typeof item === 'string') {
+        return escapeHtml(item);
+      }
+      if (!item || typeof item !== 'object') {
+        return '';
+      }
+      const label = item.label || item.title || item.action || item.task || `Step ${index + 1}`;
+      const reason = item.reason ? `<span class="ab-structured__detail">${escapeHtml(String(item.reason))}</span>` : '';
+      const meta = [
+        item.risk_tier ? createInlineBadge(item.risk_tier, 'risk') : '',
+        item.requires_approval ? createInlineBadge('approval', 'approval') : '',
+      ].filter(Boolean).join('');
+      return `
+        <div class="ab-structured__list-item">
+          <div class="ab-structured__list-main">
+            <span>${escapeHtml(String(label))}</span>
+            ${meta ? `<span class="ab-inline-pill-row">${meta}</span>` : ''}
+          </div>
+          ${reason}
+        </div>
+      `;
+    })
+    .filter(Boolean);
+}
+
+function normalizeAssignmentList(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item) => {
+      if (typeof item === 'string') {
+        return escapeHtml(item);
+      }
+      if (!item || typeof item !== 'object') {
+        return '';
+      }
+      const role = item.role || item.agent;
+      const task = item.task || item.description;
+      if (!role && !task) {
+        return '';
+      }
+      if (role && task) {
+        return `<strong>${escapeHtml(String(role))}</strong>: ${escapeHtml(String(task))}`;
+      }
+      return escapeHtml(String(role || task));
+    })
+    .filter(Boolean);
+}
+
+function createBadge(label, value) {
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+  return `
+    <span class="ab-pill">
+      <span class="ab-pill__label">${escapeHtml(label)}</span>
+      <span class="ab-pill__value">${escapeHtml(String(value))}</span>
+    </span>
+  `;
+}
+
+function createRiskBadge(value) {
+  if (!value) {
+    return '';
+  }
+  const normalized = toClassToken(value);
+  return `
+    <span class="ab-pill ab-pill--risk ab-pill--risk-${escapeHtml(normalized)}">
+      <span class="ab-pill__label">Risk</span>
+      <span class="ab-pill__value">${escapeHtml(String(value))}</span>
+    </span>
+  `;
+}
+
+function boolBadge(value, label) {
+  if (!value) {
+    return '';
+  }
+  return createBadge(label, 'Yes');
+}
+
+function createInlineBadge(value, variant) {
+  return `<span class="ab-inline-pill ab-inline-pill--${escapeHtml(variant)}">${escapeHtml(String(value))}</span>`;
+}
+
+function joinList(value) {
+  if (!Array.isArray(value) || !value.length) {
+    return '';
+  }
+  return value.join(', ');
+}
+
+function countValue(value) {
+  if (Array.isArray(value) && value.length) {
+    return String(value.length);
+  }
+  return '';
+}
+
+function toClassToken(value) {
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }

--- a/src/extension/components/DisconnectedBanner.js
+++ b/src/extension/components/DisconnectedBanner.js
@@ -1,0 +1,25 @@
+export function renderDisconnectedBanner(container, { port, onServerStarted }) {
+  container.innerHTML = `
+    <div class="ab-disconnected">
+      <div class="ab-disconnected__icon">&#x26A0;</div>
+      <div class="ab-disconnected__text">
+        <strong>Backend not connected</strong>
+        <div>Trying ws://127.0.0.1:${escapeHtml(String(port))}/ws&hellip;</div>
+      </div>
+      <button class="ab-btn ab-btn--secondary" id="btn-retry-connect">Retry</button>
+    </div>
+  `;
+
+  const retryBtn = container.querySelector('#btn-retry-connect');
+  if (retryBtn) {
+    retryBtn.addEventListener('click', () => {
+      if (onServerStarted) onServerStarted();
+    });
+  }
+}
+
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}

--- a/src/extension/content.js
+++ b/src/extension/content.js
@@ -6,6 +6,12 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
       url: window.location.href,
       title: document.title,
       text: text,
+      headings: extractHeadings(),
+      links: extractLinks(),
+      buttons: extractButtons(),
+      forms: extractForms(),
+      selection: window.getSelection()?.toString().trim() || '',
+      pageType: inferPageType(),
     });
   }
   return true;
@@ -45,4 +51,58 @@ function extractVisibleText() {
   }
 
   return text.slice(0, MAX_LENGTH).trim();
+}
+
+function extractHeadings() {
+  return Array.from(document.querySelectorAll('h1, h2, h3'))
+    .slice(0, 20)
+    .map((el) => ({
+      level: el.tagName,
+      text: el.textContent?.trim() || '',
+    }))
+    .filter((row) => row.text);
+}
+
+function extractLinks() {
+  return Array.from(document.querySelectorAll('a[href]'))
+    .slice(0, 40)
+    .map((el) => ({
+      text: (el.textContent || '').trim(),
+      href: el.href || '',
+    }))
+    .filter((row) => row.href);
+}
+
+function extractButtons() {
+  return Array.from(document.querySelectorAll('button, input[type="submit"], input[type="button"]'))
+    .slice(0, 20)
+    .map((el) => ({
+      text: (el.textContent || el.value || '').trim(),
+      type: el.getAttribute('type') || el.tagName.toLowerCase(),
+    }))
+    .filter((row) => row.text);
+}
+
+function extractForms() {
+  return Array.from(document.forms)
+    .slice(0, 10)
+    .map((form, index) => ({
+      index,
+      action: form.action || '',
+      method: (form.method || 'get').toLowerCase(),
+      fields: Array.from(form.elements)
+        .slice(0, 20)
+        .map((field) => ({
+          name: field.name || '',
+          type: field.type || field.tagName.toLowerCase(),
+        }))
+        .filter((field) => field.name || field.type),
+    }));
+}
+
+function inferPageType() {
+  if (document.forms.length > 0) return 'form';
+  if (document.querySelector('article')) return 'article';
+  if (document.querySelector('[role="main"]')) return 'app';
+  return 'generic';
 }

--- a/src/extension/lib/dom-reader.js
+++ b/src/extension/lib/dom-reader.js
@@ -21,3 +21,35 @@ export async function readActivePage() {
     });
   });
 }
+
+export async function getOpenTabs() {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage({ action: 'getOpenTabs' }, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      if (!response?.ok) {
+        reject(new Error(response?.error || 'Could not fetch tabs'));
+        return;
+      }
+      resolve(response.tabs || []);
+    });
+  });
+}
+
+export async function captureVisibleTab() {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage({ action: 'captureVisibleTab' }, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      if (!response?.ok) {
+        reject(new Error(response?.error || 'Could not capture visible tab'));
+        return;
+      }
+      resolve(response.dataUrl || '');
+    });
+  });
+}

--- a/src/extension/lib/ws-client.js
+++ b/src/extension/lib/ws-client.js
@@ -79,8 +79,20 @@ export class WsClient {
     return true;
   }
 
-  sendCommand(text) { return this.send('command', { text }); }
-  sendPageContext(url, title, text) { return this.send('page_context', { url, title, text }); }
+  sendCommand(text, routing = null) {
+    return this.send('command', {
+      text,
+      ...(routing ? { routing } : {}),
+    });
+  }
+
+  sendPageContext(payload, routing = null) {
+    return this.send('page_context', {
+      ...payload,
+      ...(routing ? { routing } : {}),
+    });
+  }
+
   sendZoneResponse(requestSeq, decision) { return this.send('zone_response', { request_seq: requestSeq, decision }); }
 
   disconnect() {

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "AetherBrowser",
   "version": "0.1.0",
   "description": "Multi-agent AI sidebar with governed browsing",
-  "permissions": ["activeTab", "sidePanel", "storage", "nativeMessaging"],
+  "permissions": ["activeTab", "sidePanel", "storage", "nativeMessaging", "tabs"],
   "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
   "side_panel": {
     "default_path": "sidepanel.html"

--- a/src/extension/sidepanel.css
+++ b/src/extension/sidepanel.css
@@ -54,13 +54,20 @@ body {
    -------------------------------------------------------------------------- */
 #agent-grid {
   display: flex;
-  flex-direction: row;
-  gap: 6px;
+  flex-direction: column;
+  gap: 8px;
   padding: 8px 10px;
   background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
-  overflow-x: auto;
   flex-shrink: 0;
+}
+
+.ab-agent-grid__row {
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  align-items: center;
+  overflow-x: auto;
 }
 
 /* --------------------------------------------------------------------------
@@ -96,6 +103,64 @@ body {
 .ab-agent-badge__model {
   color: var(--text-muted);
   font-size: 10px;
+}
+
+.ab-provider-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.ab-provider-strip__label {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ab-provider-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 10px;
+  color: var(--text);
+}
+
+.ab-provider-pill__name {
+  font-weight: 700;
+}
+
+.ab-provider-pill__status {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ab-provider-pill--ready {
+  border-color: rgba(63, 185, 80, 0.45);
+}
+
+.ab-provider-pill--ready .ab-provider-pill__status {
+  color: var(--green);
+}
+
+.ab-provider-pill--blocked {
+  border-color: rgba(248, 81, 73, 0.35);
+}
+
+.ab-provider-pill--blocked .ab-provider-pill__status {
+  color: var(--yellow);
+}
+
+.ab-provider-pill--unknown .ab-provider-pill__status,
+.ab-provider-pill--unknown {
+  color: var(--text-muted);
 }
 
 /* Badge state classes */
@@ -200,6 +265,7 @@ body {
   line-height: 1.6;
   color: var(--text);
   word-wrap: break-word;
+  white-space: pre-wrap;
 }
 
 .ab-message__text pre {
@@ -216,6 +282,170 @@ body {
   padding: 1px 4px;
   border-radius: 3px;
   font-size: 12px;
+}
+
+.ab-structured {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(139, 148, 158, 0.18);
+}
+
+.ab-structured__title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.ab-structured__summary {
+  padding: 10px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.ab-structured__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ab-structured__section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ab-structured__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-left: 18px;
+}
+
+.ab-structured__list li {
+  color: var(--text);
+}
+
+.ab-structured__list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ab-structured__list-main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.ab-structured__detail {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.ab-pill-row,
+.ab-inline-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ab-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid rgba(139, 148, 158, 0.25);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  font-size: 11px;
+}
+
+.ab-pill__label {
+  color: var(--text-muted);
+}
+
+.ab-pill--risk-low,
+.ab-pill--risk-green {
+  border-color: rgba(63, 185, 80, 0.45);
+}
+
+.ab-pill--risk-medium,
+.ab-pill--risk-yellow {
+  border-color: rgba(210, 153, 34, 0.45);
+}
+
+.ab-pill--risk-high,
+.ab-pill--risk-red {
+  border-color: rgba(248, 81, 73, 0.45);
+}
+
+.ab-inline-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ab-inline-pill--risk {
+  color: var(--yellow);
+}
+
+.ab-inline-pill--approval {
+  color: #ffb86b;
+}
+
+.ab-key-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+.ab-key-grid__item,
+.ab-metric {
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(139, 148, 158, 0.16);
+}
+
+.ab-key-grid__label,
+.ab-metric__label {
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ab-key-grid__value,
+.ab-metric__value {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+  margin-top: 4px;
+}
+
+.ab-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  gap: 8px;
 }
 
 /* --------------------------------------------------------------------------

--- a/src/extension/sidepanel.js
+++ b/src/extension/sidepanel.js
@@ -8,8 +8,8 @@
 
 import { WsClient } from './lib/ws-client.js';
 import { loadSettings } from './lib/storage.js';
-import { readActivePage } from './lib/dom-reader.js';
-import { renderAgentGrid, updateAgentBadge, resetAllBadges } from './components/AgentGrid.js';
+import { captureVisibleTab, getOpenTabs, readActivePage } from './lib/dom-reader.js';
+import { renderAgentGrid, updateAgentBadge, resetAllBadges, renderProviderHealth, clearProviderHealth } from './components/AgentGrid.js';
 import { initConversationFeed, appendMessage, appendUserMessage } from './components/ConversationFeed.js';
 import { renderZoneApproval } from './components/ZoneApproval.js';
 import { renderProgress } from './components/ProgressCard.js';
@@ -28,11 +28,21 @@ const researchBtn = document.getElementById('btn-research');
 const commandBar = document.getElementById('command-bar');
 
 let ws = null;
+let currentSettings = null;
+let healthPollHandle = null;
+
+function routingContext() {
+  return {
+    preferences: currentSettings?.preferences || {},
+    auto_cascade: Boolean(currentSettings?.autoCascade),
+  };
+}
 
 async function init() {
-  const settings = await loadSettings();
+  currentSettings = await loadSettings();
 
   renderAgentGrid(agentGridEl);
+  clearProviderHealth();
   initConversationFeed(feedEl);
 
   // Add settings gear to agent grid
@@ -44,6 +54,8 @@ async function init() {
   gearBtn.addEventListener('click', () => {
     renderSettingsPanel(settingsEl, async () => {
       const newSettings = await loadSettings();
+      currentSettings = newSettings;
+      stopHealthPolling();
       if (ws) {
         ws.disconnect();
         ws.url = `ws://127.0.0.1:${newSettings.port}/ws`;
@@ -51,11 +63,11 @@ async function init() {
       }
     });
   });
-  agentGridEl.appendChild(gearBtn);
+  document.getElementById('agent-grid-row')?.appendChild(gearBtn);
 
   // Connect WebSocket
   ws = new WsClient({
-    url: `ws://127.0.0.1:${settings.port}/ws`,
+    url: `ws://127.0.0.1:${currentSettings.port}/ws`,
     onMessage: handleWsMessage,
     onConnectionChange: handleConnectionChange,
   });
@@ -104,10 +116,14 @@ function handleConnectionChange(connected) {
     feedEl.classList.remove('hidden');
     commandBar.classList.remove('hidden');
     resetAllBadges();
+    refreshHealthStatus();
+    startHealthPolling();
   } else {
+    stopHealthPolling();
     feedEl.classList.add('hidden');
     commandBar.classList.add('hidden');
     disconnectedEl.classList.remove('hidden');
+    clearProviderHealth();
     renderDisconnectedBanner(disconnectedEl, {
       port: ws?.url ? parseInt(new URL(ws.url).port, 10) : 8002,
       onServerStarted: () => ws.connect(),
@@ -119,7 +135,7 @@ function handleSend() {
   const text = inputEl.value.trim();
   if (!text) return;
   appendUserMessage(feedEl, text);
-  ws.sendCommand(text);
+  ws.sendCommand(text, routingContext());
   inputEl.value = '';
   inputEl.focus();
 }
@@ -127,8 +143,27 @@ function handleSend() {
 async function handleThisPage() {
   try {
     appendUserMessage(feedEl, '[Analyzing current page...]');
-    const page = await readActivePage();
-    ws.sendPageContext(page.url, page.title, page.text);
+    const [page, tabs, screenshot] = await Promise.all([
+      readActivePage(),
+      getOpenTabs().catch(() => []),
+      captureVisibleTab().catch(() => ''),
+    ]);
+    ws.sendPageContext(
+      {
+        url: page.url,
+        title: page.title,
+        text: page.text,
+        headings: page.headings || [],
+        links: page.links || [],
+        buttons: page.buttons || [],
+        forms: page.forms || [],
+        selection: page.selection || '',
+        page_type: page.pageType || 'generic',
+        tabs,
+        screenshot,
+      },
+      routingContext(),
+    );
   } catch (err) {
     appendMessage(feedEl, {
       agent: 'system',
@@ -145,8 +180,38 @@ function handleResearch() {
     return;
   }
   appendUserMessage(feedEl, `[Research] ${text}`);
-  ws.sendCommand(text);
+  ws.sendCommand(text, routingContext());
   inputEl.value = '';
+}
+
+function healthUrl() {
+  return `http://127.0.0.1:${currentSettings?.port || 8002}/health`;
+}
+
+async function refreshHealthStatus() {
+  try {
+    const response = await fetch(healthUrl(), { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`health ${response.status}`);
+    }
+    const health = await response.json();
+    renderProviderHealth(health.executor || health.providers || {});
+  } catch {
+    renderProviderHealth({});
+  }
+}
+
+function startHealthPolling() {
+  if (healthPollHandle) return;
+  healthPollHandle = window.setInterval(() => {
+    refreshHealthStatus().catch(() => {});
+  }, 15000);
+}
+
+function stopHealthPolling() {
+  if (!healthPollHandle) return;
+  window.clearInterval(healthPollHandle);
+  healthPollHandle = null;
 }
 
 init().catch(console.error);

--- a/src/harmonic/voxelRecord.ts
+++ b/src/harmonic/voxelRecord.ts
@@ -54,6 +54,188 @@ export const DEFAULT_THRESHOLDS: Readonly<SCBEThresholds> = {
   quarantineMaxDrift: 2.2,
 };
 
+/** Visible-spectrum bounds used for continuous gate visualization. */
+const SPECTRUM_MIN_NM = 380;
+const SPECTRUM_MAX_NM = 700;
+
+/** Continuous spectrum band labels. */
+export type SpectrumBand = 'violet' | 'blue' | 'green' | 'yellow' | 'orange' | 'red';
+
+/** Continuous spectrum state labels for pressure near the decision wall. */
+export type SpectrumState = 'stable' | 'pressured' | 'near_break' | 'breaking';
+
+/** Component pressures that feed the continuous spectrum overlay. */
+export interface SpectrumPressureComponents {
+  coherencePressure: number;
+  driftPressure: number;
+  costPressure: number;
+}
+
+/**
+ * Continuous gate overlay that sits beside the discrete L13 decision.
+ *
+ * This does not replace ALLOW / QUARANTINE / DENY. It exposes where the
+ * current state sits on a continuous pressure spectrum so downstream systems
+ * (audio, UI, telemetry) can reason about edge behavior without weakening
+ * deterministic enforcement.
+ */
+export interface SpectrumGate {
+  /** The authoritative discrete governance result from scbeDecide(). */
+  discreteDecision: Decision;
+  /** Continuous pressure ০ [0,1], where 0=safe center and 1=break point. */
+  pressure: number;
+  /** Visible-spectrum projection of pressure in nanometers. */
+  wavelengthNm: number;
+  /** Coarse color band for the projected wavelength. */
+  band: SpectrumBand;
+  /** Human-readable state label for the pressure region. */
+  state: SpectrumState;
+  /** Component-level contribution to the final pressure. */
+  components: SpectrumPressureComponents;
+}
+
+/** Per-band projection helper for audio or multi-channel overlays. */
+export interface SpectrumBandProjection {
+  bandIndex: number;
+  pressure: number;
+  wavelengthNm: number;
+  band: SpectrumBand;
+  state: SpectrumState;
+}
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function risingPressure(value: number, safeMax: number, dangerMax: number): number {
+  if (value <= safeMax) return 0;
+  if (value >= dangerMax) return 1;
+  return clamp01((value - safeMax) / (dangerMax - safeMax));
+}
+
+function fallingPressure(value: number, safeMin: number, dangerMin: number): number {
+  if (value >= safeMin) return 0;
+  if (value <= dangerMin) return 1;
+  return clamp01((safeMin - value) / (safeMin - dangerMin));
+}
+
+function logarithmicPressure(value: number, safeMax: number, dangerMax: number): number {
+  const v = Math.log10(Math.max(value, 1e-12));
+  const safe = Math.log10(Math.max(safeMax, 1e-12));
+  const danger = Math.log10(Math.max(dangerMax, 1e-12));
+  return risingPressure(v, safe, danger);
+}
+
+/** Convert normalized pressure into a visible-spectrum wavelength. */
+export function pressureToWavelength(pressure: number): number {
+  const p = clamp01(pressure);
+  return SPECTRUM_MIN_NM + p * (SPECTRUM_MAX_NM - SPECTRUM_MIN_NM);
+}
+
+/** Map wavelength to a coarse visible-spectrum band label. */
+export function wavelengthToBand(wavelengthNm: number): SpectrumBand {
+  if (wavelengthNm < 450) return 'violet';
+  if (wavelengthNm < 495) return 'blue';
+  if (wavelengthNm < 570) return 'green';
+  if (wavelengthNm < 590) return 'yellow';
+  if (wavelengthNm < 620) return 'orange';
+  return 'red';
+}
+
+/** Map normalized pressure to a state label near the wall. */
+export function pressureToSpectrumState(pressure: number): SpectrumState {
+  const p = clamp01(pressure);
+  if (p < 0.2) return 'stable';
+  if (p < 0.5) return 'pressured';
+  if (p < 0.8) return 'near_break';
+  return 'breaking';
+}
+
+/**
+ * Compute normalized component pressures from the existing SCBE thresholds.
+ *
+ * Cost uses a log scale because harmonic cost spans orders of magnitude.
+ */
+export function computeSpectrumPressure(
+  dStar: number,
+  coherence: number,
+  hEff: number,
+  thresholds: SCBEThresholds = DEFAULT_THRESHOLDS
+): SpectrumPressureComponents & { pressure: number } {
+  const coherencePressure = fallingPressure(
+    coherence,
+    thresholds.allowMinCoherence,
+    thresholds.quarantineMinCoherence
+  );
+  const driftPressure = risingPressure(dStar, thresholds.allowMaxDrift, thresholds.quarantineMaxDrift);
+  const costPressure = logarithmicPressure(
+    hEff,
+    thresholds.allowMaxCost,
+    thresholds.quarantineMaxCost
+  );
+
+  // Conservative blend: strongest failing component dominates, but retain
+  // some contribution from the average so the curve moves smoothly.
+  const pressure = clamp01(
+    Math.max(coherencePressure, driftPressure, costPressure) * 0.7 +
+      ((coherencePressure + driftPressure + costPressure) / 3) * 0.3
+  );
+
+  return { coherencePressure, driftPressure, costPressure, pressure };
+}
+
+/**
+ * Compute a continuous spectrum overlay beside the discrete L13 decision.
+ */
+export function computeSpectrumGate(
+  dStar: number,
+  coherence: number,
+  hEff: number,
+  thresholds: SCBEThresholds = DEFAULT_THRESHOLDS
+): SpectrumGate {
+  const discreteDecision = scbeDecide(dStar, coherence, hEff, thresholds);
+  const { pressure, coherencePressure, driftPressure, costPressure } = computeSpectrumPressure(
+    dStar,
+    coherence,
+    hEff,
+    thresholds
+  );
+  const wavelengthNm = pressureToWavelength(pressure);
+
+  return {
+    discreteDecision,
+    pressure,
+    wavelengthNm,
+    band: wavelengthToBand(wavelengthNm),
+    state: pressureToSpectrumState(pressure),
+    components: {
+      coherencePressure,
+      driftPressure,
+      costPressure,
+    },
+  };
+}
+
+/**
+ * Project arbitrary normalized per-band pressures into the visible spectrum.
+ *
+ * Useful for experimental audio-band gating without changing the core SCBE
+ * decision envelope.
+ */
+export function projectBandPressuresToSpectrum(pressures: number[]): SpectrumBandProjection[] {
+  return pressures.map((pressure, bandIndex) => {
+    const p = clamp01(pressure);
+    const wavelengthNm = pressureToWavelength(p);
+    return {
+      bandIndex,
+      pressure: p,
+      wavelengthNm,
+      band: wavelengthToBand(wavelengthNm),
+      state: pressureToSpectrumState(p),
+    };
+  });
+}
+
 // ═══════════════════════════════════════════════════════════════
 // CubeId + Digest (deterministic, canonical)
 // ═══════════════════════════════════════════════════════════════
@@ -65,12 +247,7 @@ export const DEFAULT_THRESHOLDS: Readonly<SCBEThresholds> = {
  *
  * Uses JCS (RFC 8785) canonicalization for stability.
  */
-export function computeCubeId(
-  lang: Lang,
-  voxel: Voxel6,
-  epoch: number,
-  padMode: PadMode
-): string {
+export function computeCubeId(lang: Lang, voxel: Voxel6, epoch: number, padMode: PadMode): string {
   const payload = { lang, voxel: Array.from(voxel), epoch, padMode };
   const canonical = canonicalize(payload);
   return createHash('sha256').update(canonical, 'utf-8').digest('hex');
@@ -272,10 +449,7 @@ export function buildVoxelRecord(params: VoxelRecordParams): VoxelRecord {
     kdf: 'pi_phi',
     dStar,
     coherence,
-    nonce: createHash('sha256')
-      .update(`${cubeId}:${Date.now()}`)
-      .digest('hex')
-      .slice(0, 24),
+    nonce: createHash('sha256').update(`${cubeId}:${Date.now()}`).digest('hex').slice(0, 24),
     aad: headerHash,
   };
 

--- a/tests/L2-unit/voxelRecord.unit.test.ts
+++ b/tests/L2-unit/voxelRecord.unit.test.ts
@@ -14,6 +14,12 @@ import {
   computeSignaturePayload,
   scbeDecide,
   harmonicCost,
+  computeSpectrumPressure,
+  computeSpectrumGate,
+  pressureToWavelength,
+  wavelengthToBand,
+  pressureToSpectrumState,
+  projectBandPressuresToSpectrum,
   validateQuorum,
   buildVoxelRecord,
   simulateQuorum,
@@ -166,6 +172,53 @@ describe('L2-UNIT: harmonicCost', () => {
     const c1 = harmonicCost(1);
     const c10 = harmonicCost(10);
     expect(c10).toBeGreaterThan(c1 * 1000);
+  });
+});
+
+// อออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออ
+// Continuous Spectrum Gate Tests
+// อออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออ
+
+describe('L2-UNIT: continuous spectrum gate overlay', () => {
+  it('should map zero pressure to the safe end of the spectrum', () => {
+    expect(pressureToWavelength(0)).toBe(380);
+    expect(wavelengthToBand(380)).toBe('violet');
+    expect(pressureToSpectrumState(0)).toBe('stable');
+  });
+
+  it('should map full pressure to the break end of the spectrum', () => {
+    expect(pressureToWavelength(1)).toBe(700);
+    expect(wavelengthToBand(700)).toBe('red');
+    expect(pressureToSpectrumState(1)).toBe('breaking');
+  });
+
+  it('should produce low pressure for a safe state', () => {
+    const result = computeSpectrumPressure(0.2, 0.9, 10.0);
+    expect(result.pressure).toBeLessThan(0.1);
+    expect(result.coherencePressure).toBe(0);
+    expect(result.driftPressure).toBe(0);
+  });
+
+  it('should produce high pressure when coherence collapses', () => {
+    const result = computeSpectrumPressure(0.2, 0.1, 10.0);
+    expect(result.coherencePressure).toBe(1);
+    expect(result.pressure).toBeGreaterThan(0.7);
+  });
+
+  it('should preserve the existing discrete decision while adding a spectrum overlay', () => {
+    const gate = computeSpectrumGate(1.5, 0.7, 100);
+    expect(gate.discreteDecision).toBe('QUARANTINE');
+    expect(gate.pressure).toBeGreaterThan(0);
+    expect(gate.wavelengthNm).toBeGreaterThanOrEqual(380);
+    expect(gate.wavelengthNm).toBeLessThanOrEqual(700);
+  });
+
+  it('should project per-band pressures for experimental audio routing', () => {
+    const projected = projectBandPressuresToSpectrum([0, 0.25, 0.5, 0.75, 1]);
+    expect(projected).toHaveLength(5);
+    expect(projected[0].band).toBe('violet');
+    expect(projected[4].band).toBe('red');
+    expect(projected[2].state).toBe('near_break');
   });
 });
 

--- a/tests/aetherbrowser/test_command_planner.py
+++ b/tests/aetherbrowser/test_command_planner.py
@@ -1,0 +1,89 @@
+"""Tests for command planning and orchestration signals."""
+
+from src.aetherbrowser.agents import AgentSquad
+from src.aetherbrowser.command_planner import build_command_plan
+from src.aetherbrowser.router import ModelProvider, OctoArmorRouter
+from src.aetherbrowser.ws_feed import WsFeed
+
+
+class TestCommandPlanner:
+    def test_build_command_plan_for_browser_task(self):
+        squad = AgentSquad(WsFeed())
+        router = OctoArmorRouter(enabled_providers={provider: True for provider in ModelProvider})
+
+        plan = build_command_plan(
+            text="Open the browser tab, fill the login form, and submit it",
+            squad=squad,
+            router=router,
+        )
+
+        assert plan.browser_action_required is True
+        assert plan.escalation_ready is True
+        assert plan.intent == "authenticate"
+        assert plan.provider == "opus"
+        assert plan.preferred_engine == "playwright"
+        assert plan.risk_tier == "high"
+        assert plan.approval_required is True
+        assert plan.review_zone == "RED"
+        assert plan.required_approvals
+        assert any(action.requires_approval for action in plan.next_actions)
+        assert plan.fallback_chain
+        assert any(item["role"].value == "KO" for item in plan.assignments)
+
+    def test_build_command_plan_without_cloud_escalation(self):
+        squad = AgentSquad(WsFeed())
+        router = OctoArmorRouter(enabled_providers={
+            ModelProvider.LOCAL: True,
+            ModelProvider.HAIKU: False,
+            ModelProvider.SONNET: False,
+            ModelProvider.OPUS: False,
+            ModelProvider.FLASH: False,
+            ModelProvider.GROK: False,
+        })
+
+        plan = build_command_plan(
+            text="Summarize this page",
+            squad=squad,
+            router=router,
+        )
+
+        assert plan.escalation_ready is False
+        assert plan.provider == "local"
+        assert plan.intent == "analyze_page"
+        assert plan.risk_tier == "low"
+        assert plan.approval_required is False
+        assert plan.next_actions
+
+    def test_to_dict_normalizes_assignments_and_actions(self):
+        squad = AgentSquad(WsFeed())
+        router = OctoArmorRouter(enabled_providers={provider: True for provider in ModelProvider})
+
+        plan = build_command_plan(
+            text="Research GitHub competitors",
+            squad=squad,
+            router=router,
+        )
+
+        payload = plan.to_dict()
+        assert payload["intent"] == "research"
+        assert payload["risk_tier"] == "low"
+        assert payload["targets"] == ["github.com"]
+        assert payload["assignments"][0]["role"] == "KO"
+        assert payload["next_actions"][0]["label"]
+
+    def test_build_command_plan_honors_request_preferences(self):
+        squad = AgentSquad(WsFeed())
+        router = OctoArmorRouter(enabled_providers={provider: True for provider in ModelProvider})
+
+        plan = build_command_plan(
+            text="Summarize this page",
+            squad=squad,
+            router=router,
+            routing_preferences={"KO": "sonnet"},
+            auto_cascade=False,
+        )
+
+        assert plan.provider == "sonnet"
+        assert plan.selection_reason == "preference_override"
+        assert plan.auto_cascade is False
+        assert plan.fallback_chain == ["sonnet"]

--- a/tests/e2e/fixtures/chrome-shim.js
+++ b/tests/e2e/fixtures/chrome-shim.js
@@ -1,0 +1,59 @@
+/**
+ * Chrome Extension API shim for testing the sidepanel outside a real extension.
+ *
+ * Provides chrome.storage.local, chrome.runtime, and chrome.tabs stubs
+ * so the sidepanel ES modules load and function in a normal browser page.
+ */
+
+const _store = {
+  // Pre-seed settings so the sidepanel connects to the fixture server port
+  aetherbrowser_settings: {
+    port: 9222,
+    preferences: { KO: 'opus', AV: 'flash', RU: 'local', CA: 'sonnet', UM: 'grok', DR: 'haiku' },
+    apiKeys: {},
+    autoCascade: true,
+  },
+};
+
+window.chrome = {
+  storage: {
+    local: {
+      get(key, cb) {
+        const result = typeof key === 'string' ? { [key]: _store[key] } : {};
+        setTimeout(() => cb(result), 0);
+      },
+      set(items, cb) {
+        Object.assign(_store, items);
+        if (cb) setTimeout(cb, 0);
+      },
+    },
+  },
+  runtime: {
+    lastError: null,
+    onMessage: {
+      addListener() {},
+      removeListener() {},
+    },
+    sendMessage(_msg, cb) {
+      // Stub: captureVisibleTab and getOpenTabs fallback to error so catch() paths fire
+      if (cb) {
+        setTimeout(() => cb({ ok: false, error: 'shim: not in extension context' }), 0);
+      }
+    },
+  },
+  action: {
+    onClicked: { addListener() {} },
+  },
+  sidePanel: {
+    open() {},
+    setPanelBehavior() { return Promise.resolve(); },
+  },
+  tabs: {
+    query(_opts, cb) {
+      setTimeout(() => cb([{ id: 1, title: 'Test Tab', url: 'about:blank', active: true }]), 0);
+    },
+    captureVisibleTab(_windowId, _opts, cb) {
+      setTimeout(() => cb('data:image/jpeg;base64,/9j/stub'), 0);
+    },
+  },
+};

--- a/tests/e2e/fixtures/serve-sidepanel.mjs
+++ b/tests/e2e/fixtures/serve-sidepanel.mjs
@@ -1,0 +1,223 @@
+/**
+ * Tiny static file server + mock WebSocket backend for e2e sidepanel tests.
+ *
+ * Serves the extension files from src/extension/ on HTTP port 9222.
+ * Injects the chrome-shim.js before sidepanel.js loads.
+ * Runs a WebSocket server on /ws that speaks the WsFeed protocol.
+ */
+
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { join, extname } from 'node:path';
+import { WebSocketServer } from 'ws';
+
+const PORT = 9222;
+const EXT_DIR = join(process.cwd(), 'src', 'extension');
+const FIXTURES_DIR = join(process.cwd(), 'tests', 'e2e', 'fixtures');
+
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+};
+
+// --------------------------------------------------------------------------
+// HTTP server — serves extension files + injects chrome shim into the HTML
+// --------------------------------------------------------------------------
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+
+  // Health endpoint — mirrors the real backend shape so health polling works
+  if (url.pathname === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      status: 'ok',
+      version: '0.1.0-test',
+      agents: {},
+      providers: {
+        local: { available: true, family: 'local', reason: 'local_runtime', tier: 0 },
+        haiku: { available: false, family: 'anthropic', reason: 'missing_env:ANTHROPIC_API_KEY', tier: 1 },
+        sonnet: { available: false, family: 'anthropic', reason: 'missing_env:ANTHROPIC_API_KEY', tier: 3 },
+        opus: { available: false, family: 'anthropic', reason: 'missing_env:ANTHROPIC_API_KEY', tier: 4 },
+        flash: { available: false, family: 'openai', reason: 'missing_env:OPENAI_API_KEY', tier: 2 },
+        grok: { available: false, family: 'xai', reason: 'missing_env:XAI_API_KEY', tier: 2 },
+      },
+      executor: {
+        local: { available: true, family: 'local', model_id: 'local-control', reason: 'local_runtime', env_vars: [], packages: [] },
+        haiku: { available: false, family: 'anthropic', model_id: 'claude-3-5-haiku-20241022', reason: 'missing_env:ANTHROPIC_API_KEY', env_vars: ['ANTHROPIC_API_KEY'], packages: ['anthropic'] },
+        sonnet: { available: false, family: 'anthropic', model_id: 'claude-sonnet-4-20250514', reason: 'missing_env:ANTHROPIC_API_KEY', env_vars: ['ANTHROPIC_API_KEY'], packages: ['anthropic'] },
+        opus: { available: false, family: 'anthropic', model_id: 'claude-opus-4-1-20250805', reason: 'missing_env:ANTHROPIC_API_KEY', env_vars: ['ANTHROPIC_API_KEY'], packages: ['anthropic'] },
+        flash: { available: false, family: 'openai', model_id: 'gpt-4o-mini', reason: 'missing_env:OPENAI_API_KEY', env_vars: ['OPENAI_API_KEY'], packages: ['openai'] },
+        grok: { available: false, family: 'xai', model_id: 'grok-3-mini', reason: 'missing_env:XAI_API_KEY', env_vars: ['XAI_API_KEY'], packages: ['openai'] },
+      },
+    }));
+    return;
+  }
+
+  let filePath = url.pathname === '/' ? '/sidepanel.html' : url.pathname;
+
+  // Serve chrome-shim from fixtures
+  if (filePath === '/chrome-shim.js') {
+    try {
+      const content = await readFile(join(FIXTURES_DIR, 'chrome-shim.js'), 'utf-8');
+      res.writeHead(200, { 'Content-Type': 'application/javascript' });
+      res.end(content);
+    } catch {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+    return;
+  }
+
+  const absPath = join(EXT_DIR, filePath);
+
+  try {
+    let content = await readFile(absPath, extname(absPath) === '.png' ? undefined : 'utf-8');
+
+    // Inject chrome shim before sidepanel.js loads
+    if (filePath === '/sidepanel.html') {
+      content = content.replace(
+        '<script type="module" src="sidepanel.js"></script>',
+        '<script src="/chrome-shim.js"></script>\n  <script type="module" src="sidepanel.js"></script>',
+      );
+    }
+
+    const mime = MIME[extname(absPath)] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': mime });
+    res.end(content);
+  } catch {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+// --------------------------------------------------------------------------
+// WebSocket server — mock WsFeed protocol
+// --------------------------------------------------------------------------
+
+const wss = new WebSocketServer({ server, path: '/ws' });
+let seq = 0;
+
+function makeMsg(type, agent, payload = {}, extra = {}) {
+  seq++;
+  return JSON.stringify({
+    type,
+    agent,
+    payload,
+    ts: new Date().toISOString(),
+    seq,
+    ...extra,
+  });
+}
+
+wss.on('connection', (ws) => {
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      ws.send(makeMsg('error', 'system', { reason: 'Invalid JSON' }));
+      return;
+    }
+
+    if (msg.type === 'command') {
+      const text = msg.payload?.text || '';
+
+      // Send KO working status
+      ws.send(makeMsg('agent_status', 'KO', { state: 'working' }, { model: 'local' }));
+
+      // If the command contains "login" or "delete", trigger a zone request
+      if (/login|delete|deploy/i.test(text)) {
+        seq++;
+        const zoneSeq = seq;
+        ws.send(JSON.stringify({
+          type: 'zone_request',
+          agent: 'RU',
+          zone: 'RED',
+          payload: {
+            url: 'https://example.com/login',
+            action: 'authenticate',
+            description: 'Page contains authentication or credential entry',
+          },
+          ts: new Date().toISOString(),
+          seq: zoneSeq,
+        }));
+        return;
+      }
+
+      // Normal response
+      ws.send(makeMsg('chat', 'KO', {
+        text: `Acknowledged: "${text}". Local execution lane active.`,
+        plan: {
+          intent: 'general_assist',
+          task_type: 'general',
+          complexity: 'low',
+          provider: 'local',
+          selection_reason: 'local_runtime',
+          risk_tier: 'low',
+          fallback_chain: [],
+          browser_action_required: false,
+          escalation_ready: false,
+          preferred_engine: 'playwright',
+          targets: [],
+          approval_required: false,
+          required_approvals: [],
+          auto_cascade: true,
+          next_actions: [
+            { label: 'Route through the browser dispatcher', reason: 'Start from the governed lane.', risk_tier: 'low', requires_approval: false },
+          ],
+          assignments: [
+            { role: 'KO', task: 'Orchestrate the response' },
+            { role: 'DR', task: 'Structure the output' },
+          ],
+        },
+      }, { model: 'local' }));
+
+      ws.send(makeMsg('agent_status', 'KO', { state: 'done' }, { model: 'local' }));
+    }
+
+    if (msg.type === 'page_context') {
+      ws.send(makeMsg('agent_status', 'CA', { state: 'analyzing' }));
+      ws.send(makeMsg('chat', 'CA', {
+        text: `Page: ${msg.payload?.title || 'Unknown'}\nWords: 42\nTopics: General`,
+        page_analysis: {
+          url: msg.payload?.url || '',
+          title: msg.payload?.title || '',
+          word_count: 42,
+          summary: 'Mock page analysis for e2e test.',
+          topics: ['General'],
+          intent: 'inspect_page',
+          risk_tier: 'low',
+          page_type: 'generic',
+          heading_count: 0,
+          link_count: 0,
+          form_count: 0,
+          button_count: 0,
+          tab_count: 0,
+          next_actions: [{ label: 'Capture page snapshot', reason: 'Preserve evidence.', risk_tier: 'low', requires_approval: false }],
+          required_approvals: [],
+        },
+      }, { model: 'local' }));
+      ws.send(makeMsg('agent_status', 'CA', { state: 'done' }));
+    }
+
+    if (msg.type === 'zone_response') {
+      const decision = msg.payload?.decision || 'deny';
+      ws.send(makeMsg('chat', 'RU', {
+        text: `Zone decision received: ${decision}. ${decision === 'deny' ? 'Browser plan denied.' : 'Releasing the held browser plan.'}`,
+      }));
+      ws.send(makeMsg('agent_status', 'KO', { state: decision === 'deny' ? 'error' : 'done' }, { model: 'local' }));
+    }
+  });
+});
+
+// --------------------------------------------------------------------------
+// Start
+// --------------------------------------------------------------------------
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`AetherBrowser e2e fixture server on http://127.0.0.1:${PORT}`);
+});

--- a/tests/e2e/sidepanel.smoke.test.ts
+++ b/tests/e2e/sidepanel.smoke.test.ts
@@ -1,0 +1,461 @@
+/**
+ * @file sidepanel.smoke.test.ts
+ * @module tests/e2e/sidepanel
+ *
+ * Real-browser smoke tests for the AetherBrowser sidepanel.
+ *
+ * These tests load the actual sidepanel HTML/CSS/JS in Chromium via a local
+ * fixture server that injects a chrome-shim and runs a mock WebSocket backend.
+ * They catch the class of bugs that mock-only unit tests cannot:
+ *   - Real DOM rendering (CSS layout, element visibility, scrolling)
+ *   - Real WebSocket connection lifecycle
+ *   - Real ES module loading and initialization
+ *   - Real user interaction (click, type, keyboard)
+ *
+ * Run:  npx playwright test
+ * Mark: slow (not part of the fast vitest CI gate)
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const BASE_URL = 'http://127.0.0.1:9222';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function waitForConnection(page: Page) {
+  // The feed becomes visible once WebSocket connects
+  await expect(page.locator('#conversation-feed')).toBeVisible({ timeout: 5_000 });
+}
+
+async function sendCommand(page: Page, text: string) {
+  await page.fill('#input-text', text);
+  await page.click('#btn-send');
+}
+
+// ---------------------------------------------------------------------------
+// A. Sidepanel loads and connects
+// ---------------------------------------------------------------------------
+
+test.describe('A — Bootstrap', () => {
+  test('A1: sidepanel HTML loads without console errors', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await page.goto(BASE_URL);
+    await page.waitForLoadState('networkidle');
+
+    expect(errors).toEqual([]);
+  });
+
+  test('A2: all critical DOM elements exist after init', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await expect(page.locator('#agent-grid')).toBeVisible();
+    await expect(page.locator('#conversation-feed')).toBeVisible();
+    await expect(page.locator('#command-bar')).toBeVisible();
+    await expect(page.locator('#input-text')).toBeVisible();
+    await expect(page.locator('#btn-send')).toBeVisible();
+    await expect(page.locator('#btn-this-page')).toBeVisible();
+    await expect(page.locator('#btn-research')).toBeVisible();
+  });
+
+  test('A3: disconnected banner hides once WebSocket connects', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await expect(page.locator('#disconnected-banner')).toBeHidden();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B. Agent grid renders correctly
+// ---------------------------------------------------------------------------
+
+test.describe('B — Agent Grid', () => {
+  test('B1: all 6 agent badges are visible', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    for (const agent of ['KO', 'AV', 'RU', 'CA', 'UM', 'DR']) {
+      await expect(page.locator(`#badge-${agent}`)).toBeVisible();
+    }
+  });
+
+  test('B2: agent badges show correct names', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    for (const agent of ['KO', 'AV', 'RU', 'CA', 'UM', 'DR']) {
+      const badge = page.locator(`#badge-${agent} .ab-agent-badge__name`);
+      await expect(badge).toHaveText(agent);
+    }
+  });
+
+  test('B3: settings gear button is present in the grid row', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    const gear = page.locator('#agent-grid-row button');
+    await expect(gear).toBeVisible();
+    await expect(gear).toHaveAttribute('title', 'Settings');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C. Provider health strip
+// ---------------------------------------------------------------------------
+
+test.describe('C — Provider Health', () => {
+  test('C1: provider strip appears after connection', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    const strip = page.locator('#provider-strip');
+    await expect(strip).toBeVisible();
+  });
+
+  test('C2: provider strip shows runtime label', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    const label = page.locator('.ab-provider-strip__label');
+    await expect(label).toHaveText('Runtime');
+  });
+
+  test('C3: provider pills render for available providers', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    // Wait for the health fetch to complete and pills to render
+    await expect(page.locator('.ab-provider-pill').first()).toBeVisible({ timeout: 5_000 });
+
+    const pills = page.locator('.ab-provider-pill');
+    const count = await pills.count();
+    // The mock /health returns 6 providers, at least local should show
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('C4: local provider shows ready status', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    // Wait for health poll to render pills
+    await expect(page.locator('.ab-provider-pill--ready').first()).toBeVisible({ timeout: 5_000 });
+
+    const localPill = page.locator('.ab-provider-pill--ready');
+    await expect(localPill.first()).toBeVisible();
+  });
+
+  test('C5: blocked providers show blocked status', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await expect(page.locator('.ab-provider-pill--blocked').first()).toBeVisible({ timeout: 5_000 });
+
+    const blockedPills = page.locator('.ab-provider-pill--blocked');
+    const count = await blockedPills.count();
+    // haiku, sonnet, opus, flash, grok — all missing env vars
+    expect(count).toBeGreaterThanOrEqual(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D. Command flow — send a message and get a response
+// ---------------------------------------------------------------------------
+
+test.describe('D — Command Flow', () => {
+  test('D1: sending a command shows user message in feed', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Hello squad');
+
+    const userMsg = page.locator('.ab-message--user');
+    await expect(userMsg.first()).toBeVisible();
+    await expect(userMsg.first()).toContainText('Hello squad');
+  });
+
+  test('D2: backend responds with KO chat message', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Summarize the current page');
+
+    const koMsg = page.locator('.ab-message--KO');
+    await expect(koMsg.first()).toBeVisible({ timeout: 3_000 });
+    await expect(koMsg.first()).toContainText('Acknowledged');
+  });
+
+  test('D3: command response renders structured plan section', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Summarize the current page');
+
+    const planSection = page.locator('.ab-structured--plan');
+    await expect(planSection.first()).toBeVisible({ timeout: 3_000 });
+
+    // Plan should show the "Command Plan" title
+    await expect(planSection.locator('.ab-structured__title').first()).toHaveText('Command Plan');
+  });
+
+  test('D4: plan section renders badges', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Research AI safety');
+
+    const pills = page.locator('.ab-structured--plan .ab-pill');
+    await expect(pills.first()).toBeVisible({ timeout: 3_000 });
+
+    const count = await pills.count();
+    expect(count).toBeGreaterThanOrEqual(2); // Intent + Provider at minimum
+  });
+
+  test('D5: Enter key sends command (no Shift)', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await page.fill('#input-text', 'Enter key test');
+    await page.press('#input-text', 'Enter');
+
+    const userMsg = page.locator('.ab-message--user');
+    await expect(userMsg.first()).toBeVisible();
+    await expect(userMsg.first()).toContainText('Enter key test');
+  });
+
+  test('D6: input clears after send', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Clear test');
+
+    await expect(page.locator('#input-text')).toHaveValue('');
+  });
+
+  test('D7: empty input does not send', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await page.click('#btn-send');
+
+    const messages = page.locator('.ab-message');
+    expect(await messages.count()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E. Zone approval gating
+// ---------------------------------------------------------------------------
+
+test.describe('E — Zone Approval', () => {
+  test('E1: risky command triggers zone approval card', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Login to github.com');
+
+    const zoneCard = page.locator('.ab-zone-card');
+    await expect(zoneCard.first()).toBeVisible({ timeout: 3_000 });
+  });
+
+  test('E2: zone card shows RED zone with correct content', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Login to github.com');
+
+    const zoneCard = page.locator('.ab-zone-card--RED');
+    await expect(zoneCard).toBeVisible({ timeout: 3_000 });
+    await expect(zoneCard).toContainText('Approval Required');
+    await expect(zoneCard).toContainText('authenticate');
+  });
+
+  test('E3: zone card has Allow and Deny buttons', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Login to github.com');
+
+    await expect(page.locator('.ab-zone-card')).toBeVisible({ timeout: 3_000 });
+
+    const allowBtn = page.locator('[data-decision="allow"]');
+    const denyBtn = page.locator('[data-decision="deny"]');
+    await expect(allowBtn).toBeVisible();
+    await expect(denyBtn).toBeVisible();
+  });
+
+  test('E4: RED zone shows Allow Once and Add to Yellow buttons', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Delete the repository');
+
+    await expect(page.locator('.ab-zone-card--RED')).toBeVisible({ timeout: 3_000 });
+
+    await expect(page.locator('[data-decision="allow_once"]')).toBeVisible();
+    await expect(page.locator('[data-decision="add_yellow"]')).toBeVisible();
+  });
+
+  test('E5: clicking Deny removes zone card and shows denial message', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Login to github.com');
+
+    await expect(page.locator('.ab-zone-card')).toBeVisible({ timeout: 3_000 });
+    await page.click('[data-decision="deny"]');
+
+    // Card should be removed
+    await expect(page.locator('.ab-zone-card')).toBeHidden();
+
+    // RU response should appear
+    const ruMsg = page.locator('.ab-message--RU');
+    await expect(ruMsg.first()).toBeVisible({ timeout: 3_000 });
+    await expect(ruMsg.first()).toContainText('denied');
+  });
+
+  test('E6: clicking Allow removes zone card and shows release message', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await sendCommand(page, 'Deploy to production');
+
+    await expect(page.locator('.ab-zone-card')).toBeVisible({ timeout: 3_000 });
+    await page.click('[data-decision="allow"]');
+
+    await expect(page.locator('.ab-zone-card')).toBeHidden();
+
+    const ruMsg = page.locator('.ab-message--RU');
+    await expect(ruMsg.first()).toBeVisible({ timeout: 3_000 });
+    await expect(ruMsg.first()).toContainText('Releasing');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F. Agent badge state transitions
+// ---------------------------------------------------------------------------
+
+test.describe('F — Badge State', () => {
+  test('F1: KO badge transitions to working then done on command', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    const koBadge = page.locator('#badge-KO');
+
+    await sendCommand(page, 'Quick status');
+
+    // Should eventually reach done state
+    await expect(koBadge).toHaveClass(/ab-agent-badge--done/, { timeout: 3_000 });
+  });
+
+  test('F2: badges reset to idle class on fresh connect', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    // All badges should be in idle state (no working/done/error class)
+    for (const agent of ['KO', 'AV', 'RU', 'CA', 'UM', 'DR']) {
+      const badge = page.locator(`#badge-${agent}`);
+      await expect(badge).not.toHaveClass(/ab-agent-badge--working/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// G. CSS rendering sanity
+// ---------------------------------------------------------------------------
+
+test.describe('G — Visual Sanity', () => {
+  test('G1: body uses dark theme background', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    const bg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+    // Should be dark — #0d1117 = rgb(13, 17, 23)
+    expect(bg).toMatch(/rgb\(13,\s*17,\s*23\)/);
+  });
+
+  test('G2: agent grid uses column layout with row inside', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    const gridDir = await page.evaluate(() =>
+      getComputedStyle(document.getElementById('agent-grid')!).flexDirection
+    );
+    expect(gridDir).toBe('column');
+
+    const rowDir = await page.evaluate(() =>
+      getComputedStyle(document.getElementById('agent-grid-row')!).flexDirection
+    );
+    expect(rowDir).toBe('row');
+  });
+
+  test('G3: command bar footer is visible at page bottom', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    const bar = page.locator('#command-bar');
+    await expect(bar).toBeVisible();
+
+    const box = await bar.boundingBox();
+    expect(box).not.toBeNull();
+    // Footer should be in the lower half of the viewport
+    expect(box!.y).toBeGreaterThan(300);
+  });
+
+  test('G4: provider pills have border-radius for pill shape', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await expect(page.locator('.ab-provider-pill').first()).toBeVisible({ timeout: 5_000 });
+
+    const radius = await page.evaluate(() => {
+      const pill = document.querySelector('.ab-provider-pill');
+      return pill ? getComputedStyle(pill).borderRadius : '';
+    });
+    expect(radius).toBe('999px');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H. Settings panel
+// ---------------------------------------------------------------------------
+
+test.describe('H — Settings', () => {
+  test('H1: clicking gear opens settings panel', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    const gear = page.locator('#agent-grid-row button[title="Settings"]');
+    await gear.click();
+
+    const panel = page.locator('#settings-panel');
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText('Model Routing');
+  });
+
+  test('H2: settings panel has dropdowns for all 6 roles', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await page.locator('#agent-grid-row button[title="Settings"]').click();
+
+    for (const role of ['KO', 'AV', 'RU', 'CA', 'UM', 'DR']) {
+      await expect(page.locator(`#pref-${role}`)).toBeVisible();
+    }
+  });
+
+  test('H3: closing settings panel hides it', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await waitForConnection(page);
+
+    await page.locator('#agent-grid-row button[title="Settings"]').click();
+    await expect(page.locator('#settings-panel')).toBeVisible();
+
+    await page.click('#settings-close');
+    await expect(page.locator('#settings-panel')).toBeHidden();
+  });
+});

--- a/tests/test_audio_gate_spectrum_report.py
+++ b/tests/test_audio_gate_spectrum_report.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import math
+import wave
+from pathlib import Path
+
+import numpy as np
+
+from scripts.audio_gate_spectrum_report import (
+    analyze_wav,
+    pressure_to_state,
+    pressure_to_wavelength,
+    read_wav_mono,
+    wavelength_to_band,
+)
+
+
+def _write_sine_wav(path: Path, frequency: float = 440.0, sample_rate: int = 44100, seconds: float = 0.12) -> None:
+    samples = int(sample_rate * seconds)
+    values = []
+    for n in range(samples):
+        value = int(0.6 * 32767 * math.sin((2 * math.pi * frequency * n) / sample_rate))
+        values.append(value)
+    data = np.array(values, dtype=np.int16)
+
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(data.tobytes())
+
+
+def test_visible_spectrum_helpers():
+    assert pressure_to_wavelength(0.0) == 380.0
+    assert pressure_to_wavelength(1.0) == 700.0
+    assert wavelength_to_band(380.0) == "violet"
+    assert wavelength_to_band(700.0) == "red"
+    assert pressure_to_state(0.0) == "stable"
+    assert pressure_to_state(1.0) == "breaking"
+
+
+def test_read_wav_and_analyze(tmp_path: Path):
+    wav_path = tmp_path / "tone.wav"
+    _write_sine_wav(wav_path)
+
+    signal, sample_rate = read_wav_mono(wav_path)
+    assert sample_rate == 44100
+    assert signal.ndim == 1
+    assert len(signal) > 0
+
+    report = analyze_wav(signal, sample_rate=sample_rate, frame_size=1024, hop_size=512)
+    assert report["sample_rate"] == 44100
+    assert report["frame_count"] >= 1
+    assert "summary" in report
+    assert "frames" in report
+
+    first = report["frames"][0]
+    assert len(first["band_pressures"]) == 6
+    assert len(first["band_wavelengths_nm"]) == 6
+    assert len(first["band_labels"]) == 6
+    assert len(first["band_states"]) == 6
+    assert 380.0 <= first["overall_wavelength_nm"] <= 700.0

--- a/tests/test_colab_workflow_catalog.py
+++ b/tests/test_colab_workflow_catalog.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "system" / "colab_workflow_catalog.py"
+
+
+def _run(*args: str) -> str:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"command failed: {args}\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}")
+    return proc.stdout
+
+
+def test_list_json_contains_pivot_and_finetune() -> None:
+    payload = json.loads(_run("list", "--json"))
+    names = {row["name"] for row in payload}
+    assert "scbe-pivot-v2" in names
+    assert "scbe-finetune-free" in names
+
+
+def test_show_resolves_alias() -> None:
+    payload = json.loads(_run("show", "pivot", "--json"))
+    assert payload["name"] == "scbe-pivot-v2"
+    assert payload["path"] == "notebooks/scbe_pivot_training_v2.ipynb"
+    assert payload["exists"] is True
+
+
+def test_url_points_to_colab() -> None:
+    out = _run("url", "finetune").strip()
+    assert out.startswith("https://colab.research.google.com/github/")
+    assert "notebooks/scbe_finetune_colab.ipynb" in out

--- a/tests/test_hydra_command_center.py
+++ b/tests/test_hydra_command_center.py
@@ -64,6 +64,8 @@ def test_help_lists_new_command_center_surface() -> None:
     assert "publish-dryrun" in out
     assert "voice-spec" in out
     assert "video-prompts" in out
+    assert "colab-catalog" in out
+    assert "buildflow-colab <topic>" in out
 
 
 def test_offline_command_wrappers_smoke() -> None:
@@ -116,6 +118,13 @@ def test_buildflow_training_supports_dry_run() -> None:
     assert "training relay packet" in out
 
 
+def test_buildflow_colab_supports_dry_run() -> None:
+    out = _run_powershell("buildflow-colab -DryRun 'pivot training on free colab'")
+    assert "colab notebook catalog" in out
+    assert "pivot notebook route" in out
+    assert "colab relay packet" in out
+
+
 def test_n8_template_commands_surface_local_workflows() -> None:
     out = _run_powershell("n8-templates")
     assert "asana_aetherbrowse_scheduler.workflow.json" in out
@@ -136,3 +145,15 @@ def test_publish_and_media_commands_surface_real_assets() -> None:
 
     voice_status = _run_powershell("voice-status")
     assert "\"summary\"" in voice_status
+
+
+def test_colab_catalog_commands_surface_repo_notebooks() -> None:
+    catalog = _run_powershell("colab-catalog")
+    assert "scbe-pivot-v2" in catalog
+    assert "scbe_finetune_colab.ipynb" in catalog
+
+    show = _run_powershell("colab-show pivot -Json")
+    assert "\"name\": \"scbe-pivot-v2\"" in show
+
+    url = _run_powershell("colab-url pivot")
+    assert "colab.research.google.com" in url

--- a/tests/test_phone_eye.py
+++ b/tests/test_phone_eye.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_build_capture_metadata_tracks_serial_and_paths(tmp_path):
+    from scripts.system.phone_eye import build_capture_metadata
+
+    payload = build_capture_metadata(
+        serial="emulator-5554",
+        latest_path=tmp_path / "eye_latest.png",
+        latest_xml_path=tmp_path / "eye_latest.xml",
+        latest_nav_path=tmp_path / "eye_latest.nav.json",
+        session_dir=str(tmp_path / "session"),
+        status={"top_activity": "chrome"},
+        history_path=str(tmp_path / "frame.png"),
+    )
+
+    assert payload["serial"] == "emulator-5554"
+    assert payload["latest_path"].endswith("eye_latest.png")
+    assert payload["latest_xml_path"].endswith("eye_latest.xml")
+    assert payload["latest_nav_path"].endswith("eye_latest.nav.json")
+    assert payload["history_path"].endswith("frame.png")
+    assert payload["status"]["top_activity"] == "chrome"
+
+
+def test_capture_writes_stable_latest_files(tmp_path, monkeypatch):
+    from scripts.system import phone_eye
+
+    screenshot = tmp_path / "raw.png"
+    screenshot.write_bytes(b"x" * 1200)
+    ui_dump = tmp_path / "raw.xml"
+    ui_dump.write_text(
+        """<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.android.chrome" clickable="false" enabled="true" focused="false" scrollable="false" bounds="[0,0][540,1200]">
+    <node index="0" text="Webtoon Viewer" resource-id="" class="android.webkit.WebView" package="com.android.chrome" clickable="false" enabled="true" focused="true" scrollable="true" bounds="[0,275][540,1139]" />
+    <node index="1" text="10.0.2.2:8088/polly-pad.html" resource-id="com.android.chrome:id/url_bar" class="android.widget.EditText" package="com.android.chrome" clickable="true" enabled="true" focused="false" scrollable="false" bounds="[210,136][267,267]" />
+  </node>
+</hierarchy>
+""",
+        encoding="utf-8",
+    )
+
+    class FakeHand:
+        def __init__(self, serial: str = ""):
+            self.serial = serial
+            self.session_dir = tmp_path / "session"
+            self.session_dir.mkdir(exist_ok=True)
+
+        def observe(self, name: str, include_ui_dump: bool = True):
+            return {
+                "screenshot": {"artifact_path": str(screenshot)},
+                "ui_dump": {"artifact_path": str(ui_dump)},
+                "status": {"serial": "emulator-5554", "session_dir": str(self.session_dir), "top_activity": "chrome"},
+            }
+
+    monkeypatch.setattr(phone_eye, "HydraAndroidHand", FakeHand)
+    monkeypatch.setattr(phone_eye, "OUT_DIR", tmp_path)
+    monkeypatch.setattr(phone_eye, "LATEST", tmp_path / "eye_latest.png")
+    monkeypatch.setattr(phone_eye, "LATEST_XML", tmp_path / "eye_latest.xml")
+    monkeypatch.setattr(phone_eye, "LATEST_NAV", tmp_path / "eye_latest.nav.json")
+    monkeypatch.setattr(phone_eye, "LATEST_META", tmp_path / "eye_latest.json")
+    monkeypatch.setattr(phone_eye, "HISTORY_DIR", tmp_path / "history")
+
+    payload = phone_eye.capture()
+
+    assert payload["serial"] == "emulator-5554"
+    assert (tmp_path / "eye_latest.png").exists()
+    assert (tmp_path / "eye_latest.xml").exists()
+    assert (tmp_path / "eye_latest.nav.json").exists()
+    assert "polly-pad.html" in (tmp_path / "eye_latest.nav.json").read_text(encoding="utf-8")

--- a/tests/test_phone_navigation_telemetry.py
+++ b/tests/test_phone_navigation_telemetry.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+SAMPLE_XML = """<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.android.chrome" clickable="false" enabled="true" focused="false" scrollable="false" bounds="[0,0][540,1200]">
+    <node index="0" text="Webtoon Viewer" resource-id="" class="android.webkit.WebView" package="com.android.chrome" clickable="false" enabled="true" focused="true" scrollable="true" bounds="[0,275][540,1139]">
+      <node index="0" text="Chapter 1: Protocol Handshake" resource-id="" class="android.widget.TextView" package="com.android.chrome" clickable="false" enabled="true" focused="false" scrollable="false" bounds="[23,275][446,359]" />
+      <node index="1" text="Tap once for controls" resource-id="" class="android.widget.TextView" package="com.android.chrome" clickable="false" enabled="true" focused="false" scrollable="false" bounds="[133,1007][406,1109]" />
+      <node index="2" text="STORY" resource-id="" class="android.widget.Button" package="com.android.chrome" clickable="true" enabled="true" focused="false" scrollable="false" bounds="[336,991][517,1083]" />
+    </node>
+    <node index="1" text="10.0.2.2:8088/reader.html?chapter=ch01&amp;variant=generated" resource-id="com.android.chrome:id/url_bar" class="android.widget.EditText" package="com.android.chrome" clickable="true" enabled="true" focused="false" scrollable="false" bounds="[210,136][267,267]" />
+    <node index="2" text="" resource-id="com.android.chrome:id/home_button" class="android.widget.ImageButton" package="com.android.chrome" content-desc="Open the home page" clickable="true" enabled="true" focused="false" scrollable="false" bounds="[0,128][126,275]" />
+    <node index="3" text="Ghost" resource-id="" class="android.widget.Button" package="com.android.chrome" clickable="true" enabled="true" focused="false" scrollable="false" bounds="[0,0][0,0]" />
+  </node>
+</hierarchy>
+"""
+
+
+def test_parse_bounds_extracts_geometry():
+    from scripts.system.phone_navigation_telemetry import parse_bounds
+
+    bounds = parse_bounds("[336,991][517,1083]")
+
+    assert bounds == {
+        "x1": 336,
+        "y1": 991,
+        "x2": 517,
+        "y2": 1083,
+        "width": 181,
+        "height": 92,
+        "center_x": 426,
+        "center_y": 1037,
+        "area": 16652,
+    }
+
+
+def test_build_navigation_telemetry_extracts_route_text_and_targets(tmp_path):
+    from scripts.system.phone_navigation_telemetry import build_navigation_telemetry
+
+    xml_path = tmp_path / "window_dump.xml"
+    xml_path.write_text(SAMPLE_XML, encoding="utf-8")
+
+    payload = build_navigation_telemetry(xml_path, screenshot_path="eye_latest.png", status={"top_activity": "chrome"})
+
+    assert payload["package_name"] == "com.android.chrome"
+    assert payload["page_title"] == "Webtoon Viewer"
+    assert payload["route_url"] == "10.0.2.2:8088/reader.html?chapter=ch01&variant=generated"
+    assert "Chapter 1: Protocol Handshake" in payload["visible_text"]
+    assert payload["scrollables"][0]["label"] == "Webtoon Viewer"
+    assert [target["label"] for target in payload["tap_targets"]] == [
+        "Open the home page",
+        "10.0.2.2:8088/reader.html?chapter=ch01&variant=generated",
+        "STORY",
+    ]
+    assert payload["summary"]["tap_target_count"] == 3
+    assert payload["status"]["top_activity"] == "chrome"

--- a/tests/test_post_to_huggingface_discussion.py
+++ b/tests/test_post_to_huggingface_discussion.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from scripts.publish.post_to_huggingface_discussion import publish_discussion
+
+
+def test_publish_discussion_dry_run(tmp_path: Path):
+    article = tmp_path / "article.md"
+    article.write_text(
+        "# Bounded AI Is the Shipping Pattern\n\n**By Issac Davis** | March 17, 2026\n\n---\n\nBody text.",
+        encoding="utf-8",
+    )
+
+    result = publish_discussion(
+        file_path=article,
+        repo_id="issdandavis/phdm-21d-embedding",
+        repo_type="model",
+        dry_run=True,
+    )
+
+    assert result["dry_run"] is True
+    assert result["payload"]["title"] == "Bounded AI Is the Shipping Pattern"
+    assert result["payload"]["repo_id"] == "issdandavis/phdm-21d-embedding"
+    assert "Body text." in result["payload"]["description"]


### PR DESCRIPTION
## Summary
- Sidepanel shows real-time provider availability (local/flash/haiku/sonnet/opus/grok) polled from `/health`
- Command planner decomposes user input into structured plans with risk tiers and approval gates
- Zone approval cards gate risky browser actions (auth, payment, deploy) through RED/YELLOW zones
- Provider executor dispatches to Anthropic, OpenAI, xAI, or local with auto-cascade fallback
- Extended page context: headings, links, forms, buttons, tabs, screenshot
- Created missing `DisconnectedBanner.js` component (was blocking extension load)
- 7 code review fixes: CORS lockdown, memory leak, frozen env vars, typo, indentation, trust contract doc

## Test plan
- [x] `python -m pytest tests/aetherbrowser -q` — 74 passed
- [x] `npx playwright test` — 33 e2e smoke tests passed (real Chromium)
- [ ] Live Chrome extension sidepanel smoke (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)