### PR TITLE
fix(ci): remove conflicting oqs pip package from PQC workflow

### DIFF
--- a/.github/workflows/pqc-python.yml
+++ b/.github/workflows/pqc-python.yml
@@ -46,16 +46,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-cov hypothesis oqs pqcrypto
+          pip install pytest pytest-cov hypothesis
 
       - name: Validate oqs import
         run: |
-          python - <<'PY'
+          python -c "
           import oqs
-          print("oqs version:", oqs.oqs_python_version())
-          print("kem count:", len(oqs.get_enabled_kem_mechanisms()))
-          print("sig count:", len(oqs.get_enabled_sig_mechanisms()))
-          PY
+          print('oqs version:', getattr(oqs, '__version__', 'unknown'))
+          print('liboqs version:', oqs.oqs_version())
+          print('kem count:', len(oqs.get_enabled_kem_mechanisms()))
+          print('sig count:', len(oqs.get_enabled_sig_mechanisms()))
+          "
 
       - name: Run PQC marker lane
         run: |


### PR DESCRIPTION
The `pip install oqs` installed a different PyPI package that conflicts
with `liboqs-python` (already in requirements.txt). Also replaced
heredoc-based validation with python -c and fixed API calls to match
the liboqs-python interface.

https://claude.ai/code/session_016JzTxNxvkU7J2qGzN6CCkk