### PR TITLE
fix(ci): fix pipefail bug and error-masking across 4 workflows

### DIFF
--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -49,7 +49,7 @@ jobs:
         continue-on-error: true
         run: |
           if command -v pytest &>/dev/null && [ -d tests/ ]; then
-            pytest tests/ -v --ignore=tests/node_modules 2>&1 || true
+            pytest tests/ -v --ignore=tests/node_modules 2>&1
           else
             echo "::notice::pytest not available or tests/ missing"
           fi

--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -48,7 +48,9 @@ jobs:
 
       - name: Deploy agent manifests
         run: |
-          kubectl apply -f k8s/agent-manifests/ || echo "Agent manifests applied with warnings"
+          if ! kubectl apply -f k8s/agent-manifests/; then
+            echo "::warning::Agent manifests applied with warnings — review kubectl output above"
+          fi
 
       - name: Wait for rollout
         run: |

--- a/.github/workflows/huggingface-sync.yml
+++ b/.github/workflows/huggingface-sync.yml
@@ -30,35 +30,52 @@ jobs:
         run: pip install huggingface_hub
 
       - name: Sync to Primary HF Datacenter
+        id: primary_sync
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           echo "Syncing to primary: $PRIMARY_HF_REPO"
-          huggingface-cli upload $PRIMARY_HF_REPO . . \
+          if huggingface-cli upload $PRIMARY_HF_REPO . . \
             --repo-type model \
             --include "src/**" "docs/**" "README.md" "package.json" \
             --exclude ".git/**" "node_modules/**" \
-            --token $HF_TOKEN || echo "Primary sync failed, continuing..."
+            --token $HF_TOKEN; then
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Primary sync to $PRIMARY_HF_REPO failed"
+            echo "status=failed" >> $GITHUB_OUTPUT
+          fi
 
       - name: Sync to Backup HF Datacenter
+        id: backup_sync
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           echo "Syncing to backup: $BACKUP_HF_REPO"
-          huggingface-cli upload $BACKUP_HF_REPO . . \
+          if huggingface-cli upload $BACKUP_HF_REPO . . \
             --repo-type model \
             --include "src/**" "docs/**" "README.md" \
             --exclude ".git/**" "node_modules/**" \
-            --token $HF_TOKEN || echo "Backup sync failed, continuing..."
+            --token $HF_TOKEN; then
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Backup sync to $BACKUP_HF_REPO failed"
+            echo "status=failed" >> $GITHUB_OUTPUT
+          fi
 
       - name: Generate Sync Report
         run: |
+          PRIMARY_STATUS="${{ steps.primary_sync.outputs.status }}"
+          BACKUP_STATUS="${{ steps.backup_sync.outputs.status }}"
           echo "## HuggingFace Sync Report" >> $GITHUB_STEP_SUMMARY
           echo "- **Date:** $(date -u)" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Primary:** $PRIMARY_HF_REPO" >> $GITHUB_STEP_SUMMARY
-          echo "- **Backup:** $BACKUP_HF_REPO" >> $GITHUB_STEP_SUMMARY
-          echo "- **Status:** Sync completed" >> $GITHUB_STEP_SUMMARY
+          echo "- **Primary ($PRIMARY_HF_REPO):** $PRIMARY_STATUS" >> $GITHUB_STEP_SUMMARY
+          echo "- **Backup ($BACKUP_HF_REPO):** $BACKUP_STATUS" >> $GITHUB_STEP_SUMMARY
+          if [ "$PRIMARY_STATUS" = "failed" ] && [ "$BACKUP_STATUS" = "failed" ]; then
+            echo "::error::Both primary and backup HuggingFace syncs failed"
+            exit 1
+          fi
 
   health-check:
     runs-on: ubuntu-latest
@@ -66,7 +83,22 @@ jobs:
     steps:
       - name: Verify HF Repos Accessible
         run: |
+          HEALTH_FAILURES=0
           echo "Checking primary datacenter..."
-          curl -sf https://huggingface.co/api/models/$PRIMARY_HF_REPO > /dev/null && echo "Primary: OK" || echo "Primary: UNREACHABLE"
+          if curl -sf https://huggingface.co/api/models/$PRIMARY_HF_REPO > /dev/null; then
+            echo "Primary: OK"
+          else
+            echo "::warning::Primary repo $PRIMARY_HF_REPO is unreachable"
+            HEALTH_FAILURES=$((HEALTH_FAILURES+1))
+          fi
           echo "Checking backup datacenter..."
-          curl -sf https://huggingface.co/api/models/$BACKUP_HF_REPO > /dev/null && echo "Backup: OK" || echo "Backup: UNREACHABLE"
+          if curl -sf https://huggingface.co/api/models/$BACKUP_HF_REPO > /dev/null; then
+            echo "Backup: OK"
+          else
+            echo "::warning::Backup repo $BACKUP_HF_REPO is unreachable"
+            HEALTH_FAILURES=$((HEALTH_FAILURES+1))
+          fi
+          if [ "$HEALTH_FAILURES" -eq 2 ]; then
+            echo "::error::Both HF repos are unreachable"
+            exit 1
+          fi

--- a/.github/workflows/overnight-pipeline.yml
+++ b/.github/workflows/overnight-pipeline.yml
@@ -98,19 +98,27 @@ jobs:
       - name: Full test suite
         id: test
         run: |
+          set -o pipefail
           mkdir -p artifacts
           TIER2_FAILURES=0
 
           echo "=== Full pytest ==="
-          python -m pytest tests/ -v --tb=short -x 2>&1 | tee artifacts/tier2_test_results.txt || TIER2_FAILURES=$((TIER2_FAILURES+1))
+          if ! python -m pytest tests/ -v --tb=short -x 2>&1 | tee artifacts/tier2_test_results.txt; then
+            echo "::error::Full test suite failed"
+            TIER2_FAILURES=$((TIER2_FAILURES+1))
+          fi
 
           echo "=== Property tests ==="
-          python -m pytest tests/ -m "property" -v --tb=short 2>&1 | tee -a artifacts/tier2_test_results.txt || TIER2_FAILURES=$((TIER2_FAILURES+1))
+          if ! python -m pytest tests/ -m "property" -v --tb=short 2>&1 | tee -a artifacts/tier2_test_results.txt; then
+            echo "::error::Property tests failed"
+            TIER2_FAILURES=$((TIER2_FAILURES+1))
+          fi
 
           if [ "$TIER2_FAILURES" -eq 0 ]; then
             echo "passed=true" >> $GITHUB_OUTPUT
           else
             echo "passed=false" >> $GITHUB_OUTPUT
+            echo "::error::Tier 2 had $TIER2_FAILURES failure(s)"
             exit 1
           fi
 
@@ -147,23 +155,39 @@ jobs:
 
       - name: Adversarial attack suite
         run: |
+          set -o pipefail
           mkdir -p artifacts
           TIER3_FAILURES=0
 
           echo "=== SCBE Adversarial Tests ==="
-          python -m pytest tests/adversarial/ -v --tb=short 2>&1 | tee artifacts/tier3_security_results.txt || TIER3_FAILURES=$((TIER3_FAILURES+1))
+          if ! python -m pytest tests/adversarial/ -v --tb=short 2>&1 | tee artifacts/tier3_security_results.txt; then
+            echo "::error::Adversarial tests failed"
+            TIER3_FAILURES=$((TIER3_FAILURES+1))
+          fi
 
           echo "=== HYDRA spine + ledger ==="
-          python -m pytest tests/hydra/ -v --tb=short 2>&1 | tee -a artifacts/tier3_security_results.txt || TIER3_FAILURES=$((TIER3_FAILURES+1))
+          if ! python -m pytest tests/hydra/ -v --tb=short 2>&1 | tee -a artifacts/tier3_security_results.txt; then
+            echo "::error::HYDRA tests failed"
+            TIER3_FAILURES=$((TIER3_FAILURES+1))
+          fi
 
           echo "=== Tamper detection ==="
-          python -m pytest tests/test_tamper_detection.py -v --tb=short 2>&1 | tee -a artifacts/tier3_security_results.txt || TIER3_FAILURES=$((TIER3_FAILURES+1))
+          if ! python -m pytest tests/test_tamper_detection.py -v --tb=short 2>&1 | tee -a artifacts/tier3_security_results.txt; then
+            echo "::error::Tamper detection tests failed"
+            TIER3_FAILURES=$((TIER3_FAILURES+1))
+          fi
 
           echo "=== Manifold validation ==="
-          python -m pytest tests/ -k "manifold or lattice or harmonic" -v --tb=short 2>&1 | tee -a artifacts/tier3_security_results.txt || TIER3_FAILURES=$((TIER3_FAILURES+1))
+          if ! python -m pytest tests/ -k "manifold or lattice or harmonic" -v --tb=short 2>&1 | tee -a artifacts/tier3_security_results.txt; then
+            echo "::error::Manifold validation failed"
+            TIER3_FAILURES=$((TIER3_FAILURES+1))
+          fi
 
           echo "=== Tier 3 complete (failures: $TIER3_FAILURES) ==="
-          if [ "$TIER3_FAILURES" -gt 0 ]; then exit 1; fi
+          if [ "$TIER3_FAILURES" -gt 0 ]; then
+            echo "::error::Tier 3 had $TIER3_FAILURES security test failure(s)"
+            exit 1
+          fi
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -424,3 +448,13 @@ jobs:
           echo "║  Tier 5 (Training):  ${{ needs.tier-5-training.result }}"
           echo "║  Tier 6 (Colab/HF):  ${{ needs.tier-6-colab.result }}"
           echo "╚══════════════════════════════════════════╝"
+
+      - name: Fail if critical tiers failed
+        if: >-
+          needs.tier-1-validate.result == 'failure' ||
+          needs.tier-2-test.result == 'failure' ||
+          needs.tier-3-security.result == 'failure' ||
+          needs.tier-4-build.result == 'failure'
+        run: |
+          echo "::error::Critical pipeline tier(s) failed — see above for details"
+          exit 1


### PR DESCRIPTION
## Summary

Closes #611 — Supersedes #621 (which has merge conflicts).

**Root cause found**: Prior fix attempts added `TIER_FAILURES` counters with `|| FAILURES+=1` on piped commands (`pytest ... | tee`), but without `set -o pipefail` the `||` only checked `tee`'s exit code (always 0). Test failures were **still silently masked** despite the counter pattern.

### Changes

| Workflow | Fix |
|----------|-----|
| **overnight-pipeline.yml** | Add `set -o pipefail` to Tier 2 and Tier 3 run blocks so `\| tee` propagates pytest exit codes. Use `if ! command; then` pattern with `::error::` annotations. Add summary job failure propagation for critical tiers (1-4). |
| **daily-review.yml** | Remove `\|\| true` inside pytest step — this made `steps.pytest.outcome` always report "success", so the `tests_failed` condition at line 121 could never trigger for Python failures. |
| **deploy-eks.yml** | Replace misleading `\|\| echo` with `if !` + `::warning::` annotation on kubectl apply. |
| **huggingface-sync.yml** | Track per-datacenter sync status via `$GITHUB_OUTPUT`. Report shows actual success/failure per target. Workflow fails if **both** syncs fail. Health check uses structured `::warning::`/`::error::` annotations. |

### What remains (intentional)

Only `|| true` on **dependency install fallback chains** (e.g., `pip install -r requirements.txt || pip install pytest numpy || true`) — these are by design since CI needs to proceed even if optional deps are unavailable.

## Test plan

- [x] YAML syntax validated locally with `yaml.safe_load` on all 4 files
- [ ] Trigger `overnight-pipeline.yml` via workflow_dispatch — verify tiers properly fail on test errors
- [ ] Trigger `daily-review.yml` — verify pytest failures are now detected in the summary
- [ ] Confirm deploy workflows still succeed when cloud resources exist (idempotent checks)

https://claude.ai/code/session_01JvrAuSEas2inciZmTQ5oGo