### PR TITLE
fix: add step to make gradlew executable before build

### DIFF
--- a/.github/workflows/kindle-build.yml
+++ b/.github/workflows/kindle-build.yml
@@ -54,6 +54,9 @@ jobs:
             npx cap add android
           fi
           npx cap sync android
+  - name: Make gradlew executable
+              working-directory: kindle-app/android
+          run: chmod +x gradlew
 
       - name: Build debug APK
         working-directory: kindle-app/android


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Affected Layers

<!-- Check all that apply -->
- [ ] L1-2: Context realification
- [ ] L3-4: Weighted transform / Poincare embedding
- [ ] L5-6: Hyperbolic distance / breathing transform
- [ ] L7-8: Mobius phase / Hamiltonian CFI
- [ ] L9-10: Spectral / spin coherence
- [ ] L11-12: Temporal distance / harmonic wall
- [ ] L13-14: Risk decision / audio axis
- [ ] Infrastructure / CI / Docker

## Axiom Compliance

<!-- Which axioms does this change satisfy or affect? -->
- [ ] A1: Unitarity (norm preservation)
- [ ] A2: Locality (spatial bounds)
- [ ] A3: Causality (time-ordering)
- [ ] A4: Symmetry (gauge invariance)
- [ ] A5: Composition (pipeline integrity)
- [ ] N/A

## Test Plan

- [ ] TypeScript tests pass (`npm test`)
- [ ] Python tests pass (`python -m pytest tests/ -v`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Lint passes (`npm run lint`)

## Cross-Language Parity

- [ ] TypeScript updated
- [ ] Python updated to match
- [ ] N/A (single-language change)
