### PR TITLE
fix(ci): remove duplicate gradlew step in kindle-build

### DIFF
--- a/.github/workflows/kindle-build.yml
+++ b/.github/workflows/kindle-build.yml
@@ -54,9 +54,6 @@ jobs:
             npx cap add android
           fi
           npx cap sync android
-  - name: Make gradlew executable
-              working-directory: kindle-app/android
-          run: chmod +x gradlew
 
       - name: Make gradlew executable
         working-directory: kindle-app/android


### PR DESCRIPTION
Remove malformed duplicate 'Make gradlew executable' step from web edit PR #623. Keeps the correctly indented version.