### PR TITLE
Add signed tenant audit export bundles and offline verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ curl -X POST https://YOUR_API/v1/authorize \
 }
 ```
 
+### Export Signed Audit Bundle
+```bash
+curl -G https://YOUR_API/audit/export \
+  -H "SCBE_api_key: your-key" \
+  --data-urlencode "from=2026-01-01T00:00:00Z" \
+  --data-urlencode "to=2026-01-31T23:59:59Z"
+```
+
+Returns a signed bundle (`bundle`) plus detached hash manifest (`manifest`) that auditors can verify offline. See `docs/audit-export-offline-verification.md` for verification steps.
+
 ### Run Fleet Scenario
 ```bash
 curl -X POST https://YOUR_API/v1/fleet/run-scenario \

--- a/api/audit_export.py
+++ b/api/audit_export.py
@@ -1,0 +1,126 @@
+"""Utilities for exporting signed audit bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def canonical_json(data: Any) -> str:
+    """Render stable JSON for hashing/signatures."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256_hex(value: str) -> str:
+    """SHA-256 helper for UTF-8 text."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def parse_iso8601(value: str) -> datetime:
+    """Parse an ISO-8601 datetime into UTC."""
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def filter_records_by_range(records: List[Dict[str, Any]], from_ts: str, to_ts: str) -> List[Dict[str, Any]]:
+    """Return records where timestamp is in [from_ts, to_ts]."""
+    start = parse_iso8601(from_ts)
+    end = parse_iso8601(to_ts)
+    selected: List[Dict[str, Any]] = []
+
+    for record in records:
+        raw_ts = record.get("timestamp")
+        if not raw_ts:
+            continue
+        try:
+            current = parse_iso8601(str(raw_ts))
+        except ValueError:
+            continue
+        if start <= current <= end:
+            selected.append(record)
+
+    selected.sort(key=lambda item: item.get("timestamp", ""))
+    return selected
+
+
+def build_signed_bundle(
+    tenant_id: str,
+    from_ts: str,
+    to_ts: str,
+    records: List[Dict[str, Any]],
+    signing_key: str,
+    signer: str = "hmac-sha256",
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Build bundle payload and detached hash manifest + signature."""
+    generated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    export_payload = {
+        "schema": "scbe.audit.export.v1",
+        "tenant_id": tenant_id,
+        "from": from_ts,
+        "to": to_ts,
+        "generated_at": generated_at,
+        "record_count": len(records),
+        "records": records,
+    }
+
+    canonical_payload = canonical_json(export_payload)
+    payload_hash = sha256_hex(canonical_payload)
+
+    record_hashes = [
+        {
+            "decision_id": record.get("decision_id"),
+            "record_hash": sha256_hex(canonical_json(record)),
+        }
+        for record in records
+    ]
+
+    manifest_body = {
+        "schema": "scbe.audit.manifest.v1",
+        "tenant_id": tenant_id,
+        "generated_at": generated_at,
+        "bundle_hash_sha256": payload_hash,
+        "record_hashes": record_hashes,
+        "chain_head": records[-1].get("chain_hash") if records else None,
+        "signature_algorithm": signer,
+    }
+
+    signature = hmac.new(
+        signing_key.encode("utf-8"),
+        canonical_json(manifest_body).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    manifest = {
+        **manifest_body,
+        "signature": signature,
+    }
+    return export_payload, manifest
+
+
+def verify_manifest(bundle: Dict[str, Any], manifest: Dict[str, Any], signing_key: str) -> bool:
+    """Offline verification helper for auditors."""
+    expected_bundle_hash = sha256_hex(canonical_json(bundle))
+    if expected_bundle_hash != manifest.get("bundle_hash_sha256"):
+        return False
+
+    manifest_body = dict(manifest)
+    signature = manifest_body.pop("signature", None)
+    if not signature:
+        return False
+
+    expected_sig = hmac.new(
+        signing_key.encode("utf-8"),
+        canonical_json(manifest_body).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return hmac.compare_digest(expected_sig, signature)

--- a/api/main.py
+++ b/api/main.py
@@ -27,7 +27,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI, HTTPException, Header, Depends, Security
+from fastapi import FastAPI, HTTPException, Header, Depends, Query, Security
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import APIKeyHeader
 from pydantic import BaseModel, Field
@@ -38,6 +38,7 @@ from api.metering import (
     export_monthly_billable_usage,
     metering_store,
 )
+from api.audit_export import build_signed_bundle, canonical_json, filter_records_by_range, sha256_hex
 
 # Import persistence layer
 try:
@@ -100,6 +101,8 @@ VALID_API_KEYS = _load_api_keys()
 AGENTS_STORE: Dict[str, dict] = {}
 DECISIONS_STORE: Dict[str, dict] = {}
 CONSENSUS_STORE: Dict[str, dict] = {}
+TENANT_CHAIN_HEAD: Dict[str, str] = {}
+POLICY_VERSION = os.getenv("SCBE_POLICY_VERSION", "scbe-policy-v1")
 
 # =============================================================================
 # Models
@@ -177,6 +180,11 @@ class HealthResponse(BaseModel):
     version: str
     timestamp: str
     checks: Dict[str, str]
+
+
+class AuditExportResponse(BaseModel):
+    bundle: Dict[str, Any]
+    manifest: Dict[str, Any]
 
 
 # =============================================================================
@@ -358,6 +366,40 @@ async def authorize(
         expires_at = (datetime.utcnow() + timedelta(minutes=5)).isoformat() + "Z"
 
     # Store decision for audit
+    input_material = {
+        "tenant": tenant,
+        "agent_id": request.agent_id,
+        "action": request.action,
+        "target": request.target,
+        "context": request.context or {},
+    }
+    decision_input_digest = sha256_hex(canonical_json(input_material))
+
+    layer_score_summary = {
+        "layer_01_context_integrity": round(float(trust_score), 3),
+        "layer_04_hyperbolic_embedding": round(float(explanation.get("distance", 0.0)), 3),
+        "layer_12_harmonic_score": round(float(score), 3),
+        "layer_13_risk_factor": round(float(explanation.get("risk_factor", 0.0)), 3),
+    }
+    reason_codes = [
+        f"DECISION_{decision.value}",
+        f"RISK_{'LOW' if score > 0.6 else ('MEDIUM' if score > 0.3 else 'HIGH')}",
+        f"ACTION_{request.action.upper()}",
+    ]
+
+    previous_chain_hash = TENANT_CHAIN_HEAD.get(tenant, "GENESIS")
+    chain_payload = {
+        "decision_id": decision_id,
+        "tenant": tenant,
+        "timestamp": datetime.utcnow().isoformat(),
+        "decision_input_digest": decision_input_digest,
+        "final_decision": decision.value,
+        "reason_codes": reason_codes,
+        "previous_chain_hash": previous_chain_hash,
+    }
+    chain_hash = sha256_hex(canonical_json(chain_payload))
+    TENANT_CHAIN_HEAD[tenant] = chain_hash
+
     DECISIONS_STORE[decision_id] = {
         "decision_id": decision_id,
         "tenant": tenant,
@@ -367,8 +409,15 @@ async def authorize(
         "decision": decision.value,
         "score": round(score, 3),
         "explanation": explanation,
-        "timestamp": datetime.utcnow().isoformat(),
-        "latency_ms": round((time.time() - start_time) * 1000, 2)
+        "timestamp": chain_payload["timestamp"],
+        "latency_ms": round((time.time() - start_time) * 1000, 2),
+        "decision_input_digest": decision_input_digest,
+        "policy_version": POLICY_VERSION,
+        "layer_score_summary": layer_score_summary,
+        "final_decision": decision.value,
+        "reason_codes": reason_codes,
+        "previous_chain_hash": previous_chain_hash,
+        "chain_hash": chain_hash,
     }
 
     # Update agent stats
@@ -773,6 +822,35 @@ async def list_audit_logs(
         limit=limit
     )
     return {"count": len(logs), "logs": logs}
+
+
+@app.get("/audit/export", response_model=AuditExportResponse, tags=["Audit"])
+async def export_audit_bundle(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+    tenant: str = Depends(verify_api_key),
+):
+    """Export a signed audit bundle for a tenant and UTC time range."""
+    signing_key = os.getenv("SCBE_AUDIT_EXPORT_SIGNING_KEY")
+    if not signing_key:
+        raise HTTPException(
+            status_code=503,
+            detail="SCBE_AUDIT_EXPORT_SIGNING_KEY is not configured",
+        )
+
+    tenant_records = [
+        record for record in DECISIONS_STORE.values() if record.get("tenant") == tenant
+    ]
+    filtered_records = filter_records_by_range(tenant_records, from_ts=from_, to_ts=to)
+
+    bundle, manifest = build_signed_bundle(
+        tenant_id=tenant,
+        from_ts=from_,
+        to_ts=to,
+        records=filtered_records,
+        signing_key=signing_key,
+    )
+    return AuditExportResponse(bundle=bundle, manifest=manifest)
 
 
 # =============================================================================

--- a/docs/audit-export-offline-verification.md
+++ b/docs/audit-export-offline-verification.md
@@ -1,0 +1,44 @@
+# Audit Export & Offline Integrity Verification
+
+SCBE-AETHERMOORE now exposes a signed audit export endpoint:
+
+```http
+GET /audit/export?from=2026-01-01T00:00:00Z&to=2026-01-31T23:59:59Z
+SCBE_api_key: <tenant-api-key>
+```
+
+The endpoint returns:
+
+- `bundle`: canonical audit records for the tenant and time range.
+- `manifest`: detached hash manifest with a signature.
+
+Each exported record includes:
+
+- `decision_input_digest`
+- `policy_version`
+- `layer_score_summary`
+- `final_decision`
+- `reason_codes`
+- `previous_chain_hash`
+- `chain_hash`
+
+## What gets signed
+
+The manifest includes:
+
+- `bundle_hash_sha256`: SHA-256 over canonical JSON of the full bundle.
+- `record_hashes`: SHA-256 for every record.
+- `chain_head`: final record chain hash.
+- `signature`: HMAC-SHA256 over the manifest body.
+
+## Offline verifier steps
+
+1. Save `bundle` and `manifest` as JSON files.
+2. Recompute the bundle SHA-256 hash using canonical JSON (`sort_keys=True` and compact separators).
+3. Confirm it matches `manifest.bundle_hash_sha256`.
+4. Recompute each per-record hash and compare to `manifest.record_hashes`.
+5. Verify chain continuity by checking each record's `previous_chain_hash` equals the prior record's `chain_hash` (first record may use `GENESIS`).
+6. Recompute the HMAC-SHA256 signature of the manifest body (all fields except `signature`) using the shared export key (`SCBE_AUDIT_EXPORT_SIGNING_KEY`).
+7. Compare signatures using constant-time comparison.
+
+A helper exists in `api/audit_export.py` (`verify_manifest`) to support offline audit workflows.

--- a/tests/test_audit_export_bundle.py
+++ b/tests/test_audit_export_bundle.py
@@ -1,0 +1,45 @@
+from api.audit_export import build_signed_bundle, filter_records_by_range, verify_manifest
+
+
+def test_signed_bundle_and_manifest_verification_roundtrip():
+    records = [
+        {
+            "decision_id": "dec_1",
+            "timestamp": "2026-01-01T00:10:00Z",
+            "decision_input_digest": "abc",
+            "policy_version": "scbe-policy-v1",
+            "layer_score_summary": {"layer_12_harmonic_score": 0.87},
+            "final_decision": "ALLOW",
+            "reason_codes": ["DECISION_ALLOW"],
+            "previous_chain_hash": "GENESIS",
+            "chain_hash": "hash1",
+        }
+    ]
+
+    bundle, manifest = build_signed_bundle(
+        tenant_id="tenant_0",
+        from_ts="2026-01-01T00:00:00Z",
+        to_ts="2026-01-01T01:00:00Z",
+        records=records,
+        signing_key="test-signing-key",
+    )
+
+    assert bundle["record_count"] == 1
+    assert manifest["chain_head"] == "hash1"
+    assert verify_manifest(bundle, manifest, "test-signing-key") is True
+
+
+def test_filter_records_by_range_inclusive():
+    records = [
+        {"decision_id": "dec_a", "timestamp": "2026-01-01T00:00:00Z"},
+        {"decision_id": "dec_b", "timestamp": "2026-01-01T01:00:00Z"},
+        {"decision_id": "dec_c", "timestamp": "2026-01-01T02:00:00Z"},
+    ]
+
+    selected = filter_records_by_range(
+        records,
+        from_ts="2026-01-01T00:30:00Z",
+        to_ts="2026-01-01T02:00:00Z",
+    )
+
+    assert [record["decision_id"] for record in selected] == ["dec_b", "dec_c"]


### PR DESCRIPTION
### Motivation
- Provide auditors a tamper-evident, verifiable export of governance decisions for a tenant and time range so integrity can be validated offline.

### Description
- Add a new `api/audit_export.py` utility that produces a canonical JSON `bundle`, computes SHA-256 for the bundle and per-record hashes, and signs a detached manifest with HMAC-SHA256 (`verify_manifest` helper included). 
- Enrich persisted decision records in `api/main.py` with `decision_input_digest`, `policy_version`, `layer_score_summary`, `final_decision`, `reason_codes`, `previous_chain_hash`, and `chain_hash`, and maintain a per-tenant chain head (`TENANT_CHAIN_HEAD`).
- Expose `GET /audit/export?from=...&to=...` (tenant-scoped via API key) which returns `{bundle, manifest}` and requires `SCBE_AUDIT_EXPORT_SIGNING_KEY` to be configured or returns HTTP 503. 
- Add offline verification docs (`docs/audit-export-offline-verification.md`), a README usage snippet, and focused unit tests (`tests/test_audit_export_bundle.py`) for bundle signing and time-range filtering.

### Testing
- `python -m py_compile api/main.py api/audit_export.py tests/test_audit_export_bundle.py` succeeded to validate syntax. 
- Direct functional check of signing/verification (`build_signed_bundle` + `verify_manifest`) succeeded locally. 
- `pytest tests/test_audit_export_bundle.py` could not complete in CI due to an unrelated environment bootstrap error for `liboqs`/`oqs` (external dependency installation failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699509bb9cbc83229db794718d478ce3)