### PR TITLE
fix(ci): Kindle build Java 17 → 21

### DIFF
--- a/.github/workflows/kindle-build.yml
+++ b/.github/workflows/kindle-build.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Setup Java 17
+      - name: Setup Java 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3


### PR DESCRIPTION
Capacitor Android requires Java 21 source level. Build was failing with 'invalid source release: 21'.