### PR TITLE
fix: force Pages cache refresh for Stripe buttons

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -582,3 +582,4 @@ async function startCheckout(plan) {
 </script>
 </body>
 </html>
+<!-- cache-bust: 1774317421 -->


### PR DESCRIPTION
Stripe buy links are in the code but CDN serves old version