### PR TITLE
feat(audit): signed export bundles + CI foundation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,16 @@ curl -X POST https://YOUR_API/v1/authorize \
 }
 ```
 
+### Export Signed Audit Bundle
+```bash
+curl -G https://YOUR_API/audit/export \
+  -H "SCBE_api_key: your-key" \
+  --data-urlencode "from=2026-01-01T00:00:00Z" \
+  --data-urlencode "to=2026-01-31T23:59:59Z"
+```
+
+Returns a signed bundle (`bundle`) plus detached hash manifest (`manifest`) that auditors can verify offline. See `docs/audit-export-offline-verification.md` for verification steps.
+
 ### Run Fleet Scenario
 ```bash
 curl -X POST https://YOUR_API/v1/fleet/run-scenario \

--- a/api/audit_export.py
+++ b/api/audit_export.py
@@ -1,0 +1,130 @@
+"""Utilities for exporting signed audit bundles.
+
+Provides canonical JSON serialization, SHA-256 hashing, HMAC-SHA256 signing,
+and time-range filtering for tamper-evident governance audit exports.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Tuple
+
+
+def canonical_json(data: Any) -> str:
+    """Render stable JSON for hashing/signatures."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256_hex(value: str) -> str:
+    """SHA-256 helper for UTF-8 text."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def parse_iso8601(value: str) -> datetime:
+    """Parse an ISO-8601 datetime into UTC."""
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def filter_records_by_range(records: List[Dict[str, Any]], from_ts: str, to_ts: str) -> List[Dict[str, Any]]:
+    """Return records where timestamp is in [from_ts, to_ts]."""
+    start = parse_iso8601(from_ts)
+    end = parse_iso8601(to_ts)
+    selected: List[Dict[str, Any]] = []
+
+    for record in records:
+        raw_ts = record.get("timestamp")
+        if not raw_ts:
+            continue
+        try:
+            current = parse_iso8601(str(raw_ts))
+        except ValueError:
+            continue
+        if start <= current <= end:
+            selected.append(record)
+
+    selected.sort(key=lambda item: item.get("timestamp", ""))
+    return selected
+
+
+def build_signed_bundle(
+    tenant_id: str,
+    from_ts: str,
+    to_ts: str,
+    records: List[Dict[str, Any]],
+    signing_key: str,
+    signer: str = "hmac-sha256",
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Build bundle payload and detached hash manifest + signature."""
+    generated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    export_payload = {
+        "schema": "scbe.audit.export.v1",
+        "tenant_id": tenant_id,
+        "from": from_ts,
+        "to": to_ts,
+        "generated_at": generated_at,
+        "record_count": len(records),
+        "records": records,
+    }
+
+    canonical_payload = canonical_json(export_payload)
+    payload_hash = sha256_hex(canonical_payload)
+
+    record_hashes = [
+        {
+            "decision_id": record.get("decision_id"),
+            "record_hash": sha256_hex(canonical_json(record)),
+        }
+        for record in records
+    ]
+
+    manifest_body = {
+        "schema": "scbe.audit.manifest.v1",
+        "tenant_id": tenant_id,
+        "generated_at": generated_at,
+        "bundle_hash_sha256": payload_hash,
+        "record_hashes": record_hashes,
+        "chain_head": records[-1].get("chain_hash") if records else None,
+        "signature_algorithm": signer,
+    }
+
+    signature = hmac.new(
+        signing_key.encode("utf-8"),
+        canonical_json(manifest_body).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    manifest = {
+        **manifest_body,
+        "signature": signature,
+    }
+    return export_payload, manifest
+
+
+def verify_manifest(bundle: Dict[str, Any], manifest: Dict[str, Any], signing_key: str) -> bool:
+    """Offline verification helper for auditors."""
+    expected_bundle_hash = sha256_hex(canonical_json(bundle))
+    if expected_bundle_hash != manifest.get("bundle_hash_sha256"):
+        return False
+
+    manifest_body = dict(manifest)
+    signature = manifest_body.pop("signature", None)
+    if not signature:
+        return False
+
+    expected_sig = hmac.new(
+        signing_key.encode("utf-8"),
+        canonical_json(manifest_body).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return hmac.compare_digest(expected_sig, signature)

--- a/api/main.py
+++ b/api/main.py
@@ -31,7 +31,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI, HTTPException, Header, Depends, Security
+from fastapi import FastAPI, HTTPException, Header, Depends, Query, Security
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import APIKeyHeader
 from pydantic import BaseModel, Field
@@ -42,6 +42,7 @@ from api.metering import (
     export_monthly_billable_usage,
     metering_store,
 )
+from api.audit_export import build_signed_bundle, canonical_json, filter_records_by_range, sha256_hex
 from api.validation import run_nextgen_action_validation
 
 try:
@@ -157,6 +158,8 @@ VALID_API_KEYS = _load_api_keys()
 AGENTS_STORE: Dict[str, dict] = {}
 DECISIONS_STORE: Dict[str, dict] = {}
 CONSENSUS_STORE: Dict[str, dict] = {}
+TENANT_CHAIN_HEAD: Dict[str, str] = {}
+POLICY_VERSION = os.getenv("SCBE_POLICY_VERSION", "scbe-policy-v1")
 ORCHESTRATOR: Optional[Any] = None
 SESSION_MANAGER: Optional[Any] = None
 
@@ -236,6 +239,11 @@ class HealthResponse(BaseModel):
     version: str
     timestamp: str
     checks: Dict[str, str]
+
+
+class AuditExportResponse(BaseModel):
+    bundle: Dict[str, Any]
+    manifest: Dict[str, Any]
 
 
 class SpiralverseMeshRequest(BaseModel):
@@ -461,6 +469,42 @@ async def authorize(
     if token:
         expires_at = (datetime.utcnow() + timedelta(minutes=5)).isoformat() + "Z"
 
+    # Build audit chain fields
+    input_material = {
+        "tenant": tenant,
+        "agent_id": request.agent_id,
+        "action": request.action,
+        "target": request.target,
+        "context": request.context or {},
+    }
+    decision_input_digest = sha256_hex(canonical_json(input_material))
+
+    layer_score_summary = {
+        "layer_01_context_integrity": round(float(trust_score), 3),
+        "layer_04_hyperbolic_embedding": round(float(explanation.get("distance", 0.0)), 3),
+        "layer_12_harmonic_score": round(float(score), 3),
+        "layer_13_risk_factor": round(float(explanation.get("risk_factor", 0.0)), 3),
+    }
+    reason_codes = [
+        f"DECISION_{decision.value}",
+        f"RISK_{'LOW' if score > 0.6 else ('MEDIUM' if score > 0.3 else 'HIGH')}",
+        f"ACTION_{request.action.upper()}",
+    ]
+
+    previous_chain_hash = TENANT_CHAIN_HEAD.get(tenant, "GENESIS")
+    record_timestamp = datetime.utcnow().isoformat()
+    chain_payload = {
+        "decision_id": decision_id,
+        "tenant": tenant,
+        "timestamp": record_timestamp,
+        "decision_input_digest": decision_input_digest,
+        "final_decision": decision.value,
+        "reason_codes": reason_codes,
+        "previous_chain_hash": previous_chain_hash,
+    }
+    chain_hash = sha256_hex(canonical_json(chain_payload))
+    TENANT_CHAIN_HEAD[tenant] = chain_hash
+
     # Store decision for audit
     DECISIONS_STORE[decision_id] = {
         "decision_id": decision_id,
@@ -471,8 +515,15 @@ async def authorize(
         "decision": decision.value,
         "score": round(score, 3),
         "explanation": explanation,
-        "timestamp": datetime.utcnow().isoformat(),
-        "latency_ms": round((time.time() - start_time) * 1000, 2)
+        "timestamp": record_timestamp,
+        "latency_ms": round((time.time() - start_time) * 1000, 2),
+        "decision_input_digest": decision_input_digest,
+        "policy_version": POLICY_VERSION,
+        "layer_score_summary": layer_score_summary,
+        "final_decision": decision.value,
+        "reason_codes": reason_codes,
+        "previous_chain_hash": previous_chain_hash,
+        "chain_hash": chain_hash,
     }
 
     # Update agent stats
@@ -1351,6 +1402,35 @@ async def generate_audit_report(
         total_decisions=len(decisions),
         decisions_by_outcome=by_outcome,
     )
+
+
+@app.get("/audit/export", response_model=AuditExportResponse, tags=["Audit"])
+async def export_audit_bundle(
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+    tenant: str = Depends(verify_api_key),
+):
+    """Export a signed audit bundle for a tenant and UTC time range."""
+    signing_key = os.getenv("SCBE_AUDIT_EXPORT_SIGNING_KEY")
+    if not signing_key:
+        raise HTTPException(
+            status_code=503,
+            detail="SCBE_AUDIT_EXPORT_SIGNING_KEY is not configured",
+        )
+
+    tenant_records = [
+        record for record in DECISIONS_STORE.values() if record.get("tenant") == tenant
+    ]
+    filtered_records = filter_records_by_range(tenant_records, from_ts=from_, to_ts=to)
+
+    bundle, manifest = build_signed_bundle(
+        tenant_id=tenant,
+        from_ts=from_,
+        to_ts=to,
+        records=filtered_records,
+        signing_key=signing_key,
+    )
+    return AuditExportResponse(bundle=bundle, manifest=manifest)
 
 
 @app.get("/v1/internal/billing/monthly-usage", response_model=MonthlyUsageExportResponse, tags=["Billing"])

--- a/docs/audit-export-offline-verification.md
+++ b/docs/audit-export-offline-verification.md
@@ -1,0 +1,44 @@
+# Audit Export & Offline Integrity Verification
+
+SCBE-AETHERMOORE now exposes a signed audit export endpoint:
+
+```http
+GET /audit/export?from=2026-01-01T00:00:00Z&to=2026-01-31T23:59:59Z
+SCBE_api_key: <tenant-api-key>
+```
+
+The endpoint returns:
+
+- `bundle`: canonical audit records for the tenant and time range.
+- `manifest`: detached hash manifest with a signature.
+
+Each exported record includes:
+
+- `decision_input_digest`
+- `policy_version`
+- `layer_score_summary`
+- `final_decision`
+- `reason_codes`
+- `previous_chain_hash`
+- `chain_hash`
+
+## What gets signed
+
+The manifest includes:
+
+- `bundle_hash_sha256`: SHA-256 over canonical JSON of the full bundle.
+- `record_hashes`: SHA-256 for every record.
+- `chain_head`: final record chain hash.
+- `signature`: HMAC-SHA256 over the manifest body.
+
+## Offline verifier steps
+
+1. Save `bundle` and `manifest` as JSON files.
+2. Recompute the bundle SHA-256 hash using canonical JSON (`sort_keys=True` and compact separators).
+3. Confirm it matches `manifest.bundle_hash_sha256`.
+4. Recompute each per-record hash and compare to `manifest.record_hashes`.
+5. Verify chain continuity by checking each record's `previous_chain_hash` equals the prior record's `chain_hash` (first record may use `GENESIS`).
+6. Recompute the HMAC-SHA256 signature of the manifest body (all fields except `signature`) using the shared export key (`SCBE_AUDIT_EXPORT_SIGNING_KEY`).
+7. Compare signatures using constant-time comparison.
+
+A helper exists in `api/audit_export.py` (`verify_manifest`) to support offline audit workflows.

--- a/hydra/ledger.py
+++ b/hydra/ledger.py
@@ -85,27 +85,71 @@ class Ledger:
         db_path: str = None,
         session_id: str = None
     ):
-        if db_path is None:
-            db_path = os.environ.get("HYDRA_LEDGER_DB")
-        if db_path is None:
-            hydra_home = os.environ.get("HYDRA_HOME")
-            if hydra_home:
-                db_path = os.path.join(hydra_home, "ledger.db")
-            else:
-                hydra_home = os.path.join(os.path.expanduser("~"), ".hydra")
-                db_path = os.path.join(hydra_home, "ledger.db")
-
-        resolved_db_path = os.path.abspath(db_path)
-        db_dir = os.path.dirname(resolved_db_path)
-        if db_dir:
-            os.makedirs(db_dir, exist_ok=True)
-
-        self.db_path = resolved_db_path
+        self.db_path = self._resolve_db_path(db_path)
         self.session_id = session_id or self._generate_session_id()
         self._lock = threading.Lock()
         self._secret = hashlib.sha256(f"hydra:{self.session_id}".encode()).hexdigest()
 
         self._init_db()
+
+    # ------------------------------------------------------------------
+    # Path resolution helpers (CI / sandbox safety)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _repo_fallback_db() -> str:
+        """Return a repo-local fallback path for the ledger DB."""
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        return os.path.join(repo_root, "artifacts", "runtime", "hydra", "ledger.db")
+
+    @staticmethod
+    def _default_db_path() -> str:
+        """Return the user's preferred DB path from env or ~/.hydra/."""
+        env_path = os.environ.get("HYDRA_LEDGER_DB")
+        if env_path:
+            return env_path
+        hydra_home = os.environ.get("HYDRA_HOME")
+        if hydra_home:
+            return os.path.join(hydra_home, "ledger.db")
+        return os.path.join(os.path.expanduser("~"), ".hydra", "ledger.db")
+
+    @staticmethod
+    def _can_write_path(directory: str) -> bool:
+        """Probe whether *directory* is writable by creating a temp file."""
+        try:
+            os.makedirs(directory, exist_ok=True)
+            probe = os.path.join(directory, ".hydra_write_probe")
+            with open(probe, "w") as f:
+                f.write("ok")
+            os.remove(probe)
+            return True
+        except OSError:
+            return False
+
+    @classmethod
+    def _resolve_db_path(cls, requested: str = None) -> str:
+        """Resolve to the requested path, falling back to repo-local if unwritable."""
+        path = os.path.abspath(requested) if requested else cls._default_db_path()
+        path = os.path.abspath(path)
+        db_dir = os.path.dirname(path)
+        if cls._can_write_path(db_dir):
+            return path
+        fallback = cls._repo_fallback_db()
+        fb_dir = os.path.dirname(fallback)
+        os.makedirs(fb_dir, exist_ok=True)
+        return fallback
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a SQLite connection with readonly-recovery fallback."""
+        try:
+            return sqlite3.connect(self.db_path)
+        except sqlite3.OperationalError as exc:
+            msg = str(exc).lower()
+            if "readonly" in msg or "unable to open" in msg:
+                self.db_path = self._repo_fallback_db()
+                os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+                return sqlite3.connect(self.db_path)
+            raise
 
     def _generate_session_id(self) -> str:
         """Generate unique session ID."""
@@ -116,7 +160,7 @@ class Ledger:
     def _init_db(self) -> None:
         """Initialize database schema."""
         with self._lock:
-            conn = sqlite3.connect(self.db_path)
+            conn = self._connect()
             cursor = conn.cursor()
 
             # Main ledger table
@@ -200,7 +244,7 @@ class Ledger:
 
     def _get_conn(self) -> sqlite3.Connection:
         """Get database connection."""
-        conn = sqlite3.connect(self.db_path)
+        conn = self._connect()
         conn.row_factory = sqlite3.Row
         return conn
 

--- a/src/crypto/pqc_liboqs.py
+++ b/src/crypto/pqc_liboqs.py
@@ -272,11 +272,6 @@ class MLDSA65:
                 self._secret_key = self._sig.export_secret_key()
 
         if not self._using_real:
-            # Use real liboqs
-            self._sig = oqs.Signature(_SIG_ALG)
-            self._public_key = self._sig.generate_keypair()
-            self._secret_key = self._sig.export_secret_key()
-        else:
             # Fallback: deterministic key derivation from seed
             self._public_key = hashlib.sha256(self._seed + b"mldsa65_pk").digest()
             self._public_key = self._public_key + os.urandom(MLDSA65_PK_LEN - 32)
@@ -345,7 +340,6 @@ class MLDSA65:
                 instance._using_real = False
             else:
                 instance._sig = oqs.Signature(instance._algorithm)
-            instance._sig = oqs.Signature(_SIG_ALG)
 
         return instance
 

--- a/tests/hydra/test_ledger_fallback.py
+++ b/tests/hydra/test_ledger_fallback.py
@@ -1,0 +1,38 @@
+"""Tests for HYDRA ledger readonly-fallback logic."""
+
+import os
+import tempfile
+from hydra.ledger import Ledger
+
+
+def test_resolve_db_path_uses_writable_requested_path():
+    """When the requested path is writable, use it directly."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "test.db")
+        resolved = Ledger._resolve_db_path(db_path)
+        assert resolved == os.path.abspath(db_path)
+
+
+def test_resolve_db_path_falls_back_when_unwritable():
+    """When the requested directory is not writable, fall back to repo-local."""
+    # /proc is not a real filesystem — even root cannot create dirs there
+    resolved = Ledger._resolve_db_path("/proc/fake_hydra_unwritable/sub/ledger.db")
+    assert "artifacts" in resolved and "runtime" in resolved
+
+
+def test_can_write_path_returns_true_for_temp():
+    """A temp directory should be writable."""
+    with tempfile.TemporaryDirectory() as tmp:
+        assert Ledger._can_write_path(tmp) is True
+
+
+def test_can_write_path_returns_false_for_nonexistent():
+    """A non-creatable path should return False."""
+    assert Ledger._can_write_path("/proc/fake_hydra_test") is False
+
+
+def test_repo_fallback_db_is_under_artifacts():
+    """The fallback path should be under artifacts/runtime/hydra/."""
+    path = Ledger._repo_fallback_db()
+    assert path.endswith("ledger.db")
+    assert "artifacts" in path

--- a/tests/test_audit_export_bundle.py
+++ b/tests/test_audit_export_bundle.py
@@ -1,0 +1,95 @@
+"""Tests for signed audit export bundles."""
+
+from api.audit_export import build_signed_bundle, filter_records_by_range, verify_manifest
+
+
+def test_signed_bundle_and_manifest_verification_roundtrip():
+    records = [
+        {
+            "decision_id": "dec_1",
+            "timestamp": "2026-01-01T00:10:00Z",
+            "decision_input_digest": "abc",
+            "policy_version": "scbe-policy-v1",
+            "layer_score_summary": {"layer_12_harmonic_score": 0.87},
+            "final_decision": "ALLOW",
+            "reason_codes": ["DECISION_ALLOW"],
+            "previous_chain_hash": "GENESIS",
+            "chain_hash": "hash1",
+        }
+    ]
+
+    bundle, manifest = build_signed_bundle(
+        tenant_id="tenant_0",
+        from_ts="2026-01-01T00:00:00Z",
+        to_ts="2026-01-01T01:00:00Z",
+        records=records,
+        signing_key="test-signing-key",
+    )
+
+    assert bundle["record_count"] == 1
+    assert manifest["chain_head"] == "hash1"
+    assert verify_manifest(bundle, manifest, "test-signing-key") is True
+
+
+def test_verify_manifest_rejects_wrong_key():
+    records = [
+        {
+            "decision_id": "dec_1",
+            "timestamp": "2026-01-01T00:10:00Z",
+            "chain_hash": "hash1",
+        }
+    ]
+
+    bundle, manifest = build_signed_bundle(
+        tenant_id="tenant_0",
+        from_ts="2026-01-01T00:00:00Z",
+        to_ts="2026-01-01T01:00:00Z",
+        records=records,
+        signing_key="correct-key",
+    )
+
+    assert verify_manifest(bundle, manifest, "wrong-key") is False
+
+
+def test_filter_records_by_range_inclusive():
+    records = [
+        {"decision_id": "dec_a", "timestamp": "2026-01-01T00:00:00Z"},
+        {"decision_id": "dec_b", "timestamp": "2026-01-01T01:00:00Z"},
+        {"decision_id": "dec_c", "timestamp": "2026-01-01T02:00:00Z"},
+    ]
+
+    selected = filter_records_by_range(
+        records,
+        from_ts="2026-01-01T00:30:00Z",
+        to_ts="2026-01-01T02:00:00Z",
+    )
+
+    assert [record["decision_id"] for record in selected] == ["dec_b", "dec_c"]
+
+
+def test_filter_records_empty_when_no_match():
+    records = [
+        {"decision_id": "dec_a", "timestamp": "2026-01-01T00:00:00Z"},
+    ]
+
+    selected = filter_records_by_range(
+        records,
+        from_ts="2026-02-01T00:00:00Z",
+        to_ts="2026-02-28T23:59:59Z",
+    )
+
+    assert selected == []
+
+
+def test_build_signed_bundle_empty_records():
+    bundle, manifest = build_signed_bundle(
+        tenant_id="tenant_empty",
+        from_ts="2026-01-01T00:00:00Z",
+        to_ts="2026-01-31T23:59:59Z",
+        records=[],
+        signing_key="test-key",
+    )
+
+    assert bundle["record_count"] == 0
+    assert manifest["chain_head"] is None
+    assert verify_manifest(bundle, manifest, "test-key") is True


### PR DESCRIPTION
## Summary
- **Signed audit export**: New `GET /audit/export` endpoint produces tamper-evident bundles with HMAC-SHA256 manifests for offline verification. Governance decisions now include chain hashing, input digests, layer score summaries, and reason codes.
- **HYDRA ledger readonly fallback**: Ledger auto-falls back to repo-local SQLite (`artifacts/runtime/hydra/ledger.db`) when the home directory is unwritable — fixes CI/sandbox failures (from PR #610).
- **PQC MLDSA65 bug fix**: Corrected inverted fallback logic that was calling real liboqs when unavailable instead of deterministic key derivation (from PR #610).

### Supersedes / resolves intent of
- PR #627 (audit export — rebased cleanly onto current main)
- Key fixes from PR #610 (CI foundation — HYDRA fallback + PQC bug)

### New files
- `api/audit_export.py` — Bundle signing, verification, time-range filtering
- `docs/audit-export-offline-verification.md` — Offline verifier steps
- `tests/test_audit_export_bundle.py` — 5 tests for bundle signing/verification
- `tests/hydra/test_ledger_fallback.py` — 5 tests for readonly fallback

## Test plan
- [x] All 157 TS test files pass (5514 tests, 0 failures)
- [x] All 10 new Python tests pass (audit export + ledger fallback)
- [x] `api/main.py` compiles cleanly
- [x] TypeScript build succeeds with no errors

https://claude.ai/code/session_01W8tPPcTkxLtJcnNX2fUctD