### PR TITLE
fix(cli): prevent NameError in six-tongues-cli when numpy unavailable

### DIFF
--- a/six-tongues-cli.py
+++ b/six-tongues-cli.py
@@ -28,6 +28,7 @@ Usage:
 @component Six Tongues + GeoSeal CLI
 @version 1.0.0
 """
+from __future__ import annotations
 
 import argparse
 import base64


### PR DESCRIPTION
## Summary
- Add `from __future__ import annotations` to `six-tongues-cli.py` to defer type annotation evaluation
- Fixes `NameError: name 'np' is not defined` when numpy is not installed — the `SemanticNavigator` class used `np.ndarray` in method signatures that were evaluated at class definition time

## Test plan
- [x] `python3 six-tongues-cli.py --help` works without numpy installed
- [x] TS test suite: failure count dropped from 3 to 2 (remaining 2 are `scbe-cli.py` needing numpy, separate issue)
- [x] 5512 tests pass, 156 test files pass

https://claude.ai/code/session_01PjRVjAwwukLo6jyEucUEme