### PR TITLE
fix(crypto): lazy-load numpy-dependent modules to prevent CLI crash

### DIFF
--- a/src/crypto/__init__.py
+++ b/src/crypto/__init__.py
@@ -13,81 +13,18 @@ Modules:
 - signed_lattice_bridge: Integration layer connecting all three
 - h_lwe: Hyperbolic LWE vector encryption (Poincaré ball containment)
 
-Heavy modules (scipy, matplotlib) are lazy-loaded to avoid import hangs on Windows.
+Heavy modules (numpy, scipy, matplotlib) are lazy-loaded to avoid import failures
+when these dependencies are not installed.
 """
 
 import importlib as _importlib
 from typing import TYPE_CHECKING
 
 # ═══════════════════════════════════════════════════════════
-# Eager imports — lightweight modules (numpy, hashlib, math only)
+# Eager imports — modules with no heavy dependencies
 # ═══════════════════════════════════════════════════════════
 
-# Dual Lattice (Kyber/Dilithium + Sacred Tongues)
-from .dual_lattice import (
-    SacredTongue,
-    FluxState,
-    LatticeVector,
-    TongueContext,
-    CrossStitchPattern,
-    KyberTongueEncryptor,
-    DilithiumTongueSigner,
-    DualLatticeCrossStitch,
-    TongueLatticeGovernor,
-    TONGUE_PHASES,
-    TONGUE_WEIGHTS,
-    PHI,
-)
-
-# Symphonic Cipher (Signed Audio Frequency Mapping)
-from .symphonic_cipher import (
-    SymphonicToken,
-    TonguePolarity,
-    SACRED_TONGUE_VOCAB,
-    BASE_FREQ,
-    FREQ_STEP,
-    token_to_frequency,
-    id_to_frequency,
-    generate_tone,
-    generate_symphonic_sequence,
-    analyze_polarity_balance,
-)
-
-# GeoSeal (Hyperbolic Geometry + Signed Context)
-from .geo_seal import (
-    ContextVector,
-    SecurityPosture,
-    bytes_to_signed_signal,
-    signed_signal_to_bytes,
-    hyperbolic_distance,
-    hyperbolic_midpoint,
-    hyperbolic_angle,
-    compute_triangle_deficit,
-    harmonic_wall_cost,
-    trust_from_position,
-)
-
-# Signed Lattice Bridge (Integration Layer)
-from .signed_lattice_bridge import (
-    SignedGovernanceResult,
-    SignedLatticeBridge,
-)
-
-# Hyperbolic Octree (Sparse Voxel Storage + Spectral Clustering)
-from .octree import (
-    SpectralVoxel,
-    OctreeNode,
-    HyperbolicOctree,
-)
-
-# Hyperpath Finder (A* and Bidirectional A*)
-from .hyperpath_finder import (
-    HyperpathFinder,
-    PathResult,
-    hyperbolic_distance_safe,
-)
-
-# Sacred Eggs (Cryptographic Secret Containers)
+# Sacred Eggs (Cryptographic Secret Containers — no numpy)
 from .sacred_eggs import (
     SacredEgg,
     EggCarton,
@@ -109,6 +46,52 @@ from .sacred_eggs import (
 
 # Module-level lazy loader
 _LAZY_MODULES = {
+    # Dual Lattice (numpy — not always installed)
+    "SacredTongue": ".dual_lattice",
+    "FluxState": ".dual_lattice",
+    "LatticeVector": ".dual_lattice",
+    "TongueContext": ".dual_lattice",
+    "CrossStitchPattern": ".dual_lattice",
+    "KyberTongueEncryptor": ".dual_lattice",
+    "DilithiumTongueSigner": ".dual_lattice",
+    "DualLatticeCrossStitch": ".dual_lattice",
+    "TongueLatticeGovernor": ".dual_lattice",
+    "TONGUE_PHASES": ".dual_lattice",
+    "TONGUE_WEIGHTS": ".dual_lattice",
+    "PHI": ".dual_lattice",
+    # Symphonic Cipher (numpy)
+    "SymphonicToken": ".symphonic_cipher",
+    "TonguePolarity": ".symphonic_cipher",
+    "SACRED_TONGUE_VOCAB": ".symphonic_cipher",
+    "BASE_FREQ": ".symphonic_cipher",
+    "FREQ_STEP": ".symphonic_cipher",
+    "token_to_frequency": ".symphonic_cipher",
+    "id_to_frequency": ".symphonic_cipher",
+    "generate_tone": ".symphonic_cipher",
+    "generate_symphonic_sequence": ".symphonic_cipher",
+    "analyze_polarity_balance": ".symphonic_cipher",
+    # GeoSeal (numpy)
+    "ContextVector": ".geo_seal",
+    "SecurityPosture": ".geo_seal",
+    "bytes_to_signed_signal": ".geo_seal",
+    "signed_signal_to_bytes": ".geo_seal",
+    "hyperbolic_distance": ".geo_seal",
+    "hyperbolic_midpoint": ".geo_seal",
+    "hyperbolic_angle": ".geo_seal",
+    "compute_triangle_deficit": ".geo_seal",
+    "harmonic_wall_cost": ".geo_seal",
+    "trust_from_position": ".geo_seal",
+    # Signed Lattice Bridge (numpy)
+    "SignedGovernanceResult": ".signed_lattice_bridge",
+    "SignedLatticeBridge": ".signed_lattice_bridge",
+    # Hyperbolic Octree (numpy)
+    "SpectralVoxel": ".octree",
+    "OctreeNode": ".octree",
+    "HyperbolicOctree": ".octree",
+    # Hyperpath Finder (numpy)
+    "HyperpathFinder": ".hyperpath_finder",
+    "PathResult": ".hyperpath_finder",
+    "hyperbolic_distance_safe": ".hyperpath_finder",
     # Visualization (matplotlib)
     "classical_mds": ".hyperbolic_viz",
     "poincare_geodesic": ".hyperbolic_viz",
@@ -169,7 +152,7 @@ def __getattr__(name: str):
         except (ImportError, AttributeError) as e:
             raise ImportError(
                 f"Cannot import {name} from {module_path}: {e}. "
-                f"This module requires scipy or matplotlib."
+                f"This module may require numpy, scipy, or matplotlib."
             ) from e
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 


### PR DESCRIPTION
## Summary\n\n- **`src/crypto/__init__.py`** eagerly imported 6 modules (`dual_lattice`, `symphonic_cipher`, `geo_seal`, `signed_lattice_bridge`, `octree`, `hyperpath_finder`) that all require `numpy`. This caused `ModuleNotFoundError` when running CLI commands (`scbe-cli.py`, `six-tongues-cli.py`) in environments without numpy, even for commands that don't need it.\n- Moved all numpy-dependent imports to the existing `__getattr__` lazy-load mechanism (`_LAZY_MODULES` dict), so they only load on first access. `sacred_eggs` remains eagerly imported as it has no heavy dependencies.\n- Fixes 2 failing tests in `tests/L2-unit/cli.unit.test.ts` (Cross-CLI parity suite).\n\n## Test plan\n\n- [x] Full vitest suite: **157 passed, 0 failed** (was 156 passed, 1 failed)\n- [x] `tests/L2-unit/cli.unit.test.ts`: all 25 tests pass (was 23 pass, 2 fail)\n- [x] Manual: `python3 scbe-cli.py encode --tongue ko --text \"test\"` works without numpy\n- [x] Manual: `PYTHONPATH=src python3 -c \"from crypto.sacred_tongues import SacredTongueTokenizer\"` succeeds\n- [ ] CI: verify no regressions in Python tests (numpy is available in CI)\n\nhttps://claude.ai/code/session_015X118gsympejEvfFfAg7ts