### PR TITLE
fix: session suspicion bleed between benchmark runs

### DIFF
--- a/tests/adversarial/scbe_harness.py
+++ b/tests/adversarial/scbe_harness.py
@@ -311,6 +311,13 @@ class SCBEDetectionGate:
         self._adv_signal_history: List[int] = []  # Track adversarial signals over time
         self._session_suspicion: float = 0.0  # Accumulated suspicion score
 
+    def reset_session(self):
+        """Reset session state without losing calibration.
+        Call between benchmark runs to prevent suspicion bleed."""
+        self._cost_history = []
+        self._adv_signal_history = []
+        self._session_suspicion = 0.0
+
     def calibrate(self, clean_texts: List[str]) -> None:
         """Establish baseline from known-clean text."""
         for text in clean_texts:

--- a/tests/adversarial/test_adversarial_benchmark.py
+++ b/tests/adversarial/test_adversarial_benchmark.py
@@ -154,6 +154,8 @@ class TestFullBenchmark:
 
         # Run attacks
         attack_result = run_benchmark(calibrated_gate, corpus["attacks"])
+        # Reset session state to prevent suspicion bleed into clean eval
+        calibrated_gate.reset_session()
         # Run baseline
         baseline_result = run_benchmark(calibrated_gate, corpus["baseline"])
 


### PR DESCRIPTION
Adds reset_session() to prevent FP contamination. 12/12 tests pass.