### PR TITLE
fix: session reset in all benchmark scripts

### DIFF
--- a/scripts/benchmark/scbe_vs_industry.py
+++ b/scripts/benchmark/scbe_vs_industry.py
@@ -446,6 +446,7 @@ def run_full_benchmark():
         clean_traces = [fn(p["prompt"]) for p in BASELINE_CLEAN]
         fp_results[key] = sum(1 for t in clean_traces if t.decision == "BLOCK")
 
+    gate.reset_session()  # Prevent suspicion bleed from attack run into clean eval
     scbe_clean = [group_e_scbe(p["prompt"], gate) for p in BASELINE_CLEAN]
     fp_results["E"] = sum(1 for t in scbe_clean if t.decision == "BLOCK")
 

--- a/tests/adversarial/test_combined_attacks.py
+++ b/tests/adversarial/test_combined_attacks.py
@@ -44,6 +44,7 @@ class TestFullCorpusBenchmark:
         """Run full corpus and produce a JSON benchmark report."""
         corpus = get_full_corpus()
         attack_result = run_benchmark(gate, corpus["attacks"])
+        gate.reset_session()  # Prevent suspicion bleed into clean eval
         baseline_result = run_benchmark(gate, corpus["baseline"])
 
         report = {


### PR DESCRIPTION
60/60 adversarial tests pass. Codex can now rerun and get clean results.