### PR TITLE
fix: include research surfaces in Pages docs artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,17 @@ jobs:
       - name: Ensure docs-build directory exists
         run: mkdir -p docs-build/api docs-build/demo
 
+      - name: Copy static docs surfaces
+        run: |
+          if [ -d "docs/research" ]; then
+            mkdir -p docs-build/research
+            cp -R docs/research/. docs-build/research/
+          fi
+          if [ -d "docs/demos" ]; then
+            mkdir -p docs-build/demos
+            cp -R docs/demos/. docs-build/demos/
+          fi
+
       - name: Copy demo files
         run: |
           if [ -f "demo/index.html" ]; then


### PR DESCRIPTION
Copies docs/research and docs/demos into the docs-build Pages artifact so research routes do not 404 when the docs workflow publishes the site.