### PR TITLE
fix(hydra): guard spectral/research imports for missing deps

### DIFF
--- a/hydra/__init__.py
+++ b/hydra/__init__.py
@@ -43,12 +43,19 @@ except ImportError:
     AI2AIRetrievalService = None  # type: ignore[assignment,misc]
     ArxivAPIError = None  # type: ignore[assignment,misc]
 from .ledger import Ledger, LedgerEntry, EntryType
-from .spectral import (
-    GraphFourierAnalyzer,
-    ByzantineDetector,
-    SpectralAnomaly,
-    analyze_hydra_system,
-)
+try:
+    from .spectral import (
+        GraphFourierAnalyzer,
+        ByzantineDetector,
+        SpectralAnomaly,
+        analyze_hydra_system,
+    )
+except ImportError:
+    # numpy may not be installed; spectral analysis is optional
+    GraphFourierAnalyzer = None  # type: ignore[assignment,misc]
+    ByzantineDetector = None  # type: ignore[assignment,misc]
+    SpectralAnomaly = None  # type: ignore[assignment,misc]
+    analyze_hydra_system = None  # type: ignore[assignment,misc]
 from .consensus import (
     ByzantineConsensus,
     RoundtableConsensus,
@@ -77,13 +84,21 @@ from .swarm_governance import (
     simulate_swarm_attack,
 )
 from .switchboard import Switchboard
-from .research import (
-    ResearchOrchestrator,
-    ResearchConfig,
-    ResearchReport,
-    ResearchSubTask,
-    ResearchSource,
-)
+try:
+    from .research import (
+        ResearchOrchestrator,
+        ResearchConfig,
+        ResearchReport,
+        ResearchSubTask,
+        ResearchSource,
+    )
+except ImportError:
+    # httpx may not be installed; research orchestrator is optional
+    ResearchOrchestrator = None  # type: ignore[assignment,misc]
+    ResearchConfig = None  # type: ignore[assignment,misc]
+    ResearchReport = None  # type: ignore[assignment,misc]
+    ResearchSubTask = None  # type: ignore[assignment,misc]
+    ResearchSource = None  # type: ignore[assignment,misc]
 from .llm_providers import (
     LLMProvider,
     LLMResponse,


### PR DESCRIPTION
## Summary

- Wraps `spectral` (numpy) and `research` (httpx) imports in `try/except ImportError` guards in `hydra/__init__.py`
- Matches the existing pattern already used for `arxiv_retrieval` imports
- Prevents all 22 `swarm_governance` tests from failing when optional deps aren't installed

## Context

Issue #644's daily review showed 25 test failures in `tests/hydra/swarm_governance.test.ts`. Root cause: `hydra/__init__.py` unconditionally imports `spectral` (requires numpy) and `research` (requires httpx), so when those packages are missing, `import hydra` crashes — silently breaking all downstream test imports.

## Test plan

- [x] All 22 `swarm_governance` tests pass
- [x] Full vitest suite: 156 files, 5499 tests pass, 0 failures
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] flake8 clean on edited file
- [ ] CI passes

https://claude.ai/code/session_013sMqsPCNPRsWhhW1o5zf85