### PR TITLE
fix(lint+security): resolve 82 lint errors, fix path traversal & session key leaks

### DIFF
--- a/kindle-app/www/ops.html
+++ b/kindle-app/www/ops.html
@@ -126,6 +126,11 @@
 const STATE_KEY = "scbe.ops.settings.v1";
 const THREAD_KEY = "scbe.ops.thread.v1";
 const TENTACLE_KEY = "scbe.ops.tentacle.v1";
+
+// Clear legacy session-stored API keys from pre-v3 builds
+const LEGACY_STATE_SESSION_KEY = "scbe.ops.state";
+sessionStorage.removeItem(LEGACY_STATE_SESSION_KEY);
+
 let providers = [];
 let thread = PhoneShell.readStorageJson(THREAD_KEY, []);
 let pending = false;

--- a/kindle-app/www/test.html
+++ b/kindle-app/www/test.html
@@ -86,6 +86,11 @@
 <script>
 const TEST_STATE_KEY = "scbe.testlane.state.v1";
 const ARTIFACTS_KEY = "scbe.testlane.artifacts.v1";
+
+// Clear legacy session-stored API keys from pre-v3 builds
+const LEGACY_TEST_STATE_SESSION_KEY = "scbe.testlane.state";
+sessionStorage.removeItem(LEGACY_TEST_STATE_SESSION_KEY);
+
 const defaultBase = PhoneShell.bridgeBase(8001);
 let artifacts = PhoneShell.readStorageJson(ARTIFACTS_KEY, []);
 

--- a/src/aetherbrowser/command_planner.py
+++ b/src/aetherbrowser/command_planner.py
@@ -326,7 +326,8 @@ def _build_next_actions(
 ) -> list[RankedAction]:
     target_text = targets[0] if targets else "the target surface"
     route_hint = (
-        f"python scripts/system/browser_chain_dispatcher.py --domain {target_text} --task {intent} --engine {preferred_engine}"
+        f"python scripts/system/browser_chain_dispatcher.py"
+        f" --domain {target_text} --task {intent} --engine {preferred_engine}"
         if targets
         else f"Route the task through the dispatcher with {preferred_engine}"
     )
@@ -356,7 +357,10 @@ def _build_next_actions(
         actions.append(
             RankedAction(
                 label="Hold state-changing action for review",
-                reason="The requested action changes state or touches credentials, so it should stay in the deliberate lane.",
+                reason=(
+                    "The requested action changes state or touches credentials,"
+                    " so it should stay in the deliberate lane."
+                ),
                 risk_tier=risk_tier,
                 requires_approval=True,
             )

--- a/src/aetherbrowser/serve.py
+++ b/src/aetherbrowser/serve.py
@@ -171,7 +171,8 @@ async def _handle_page_context(ws: WebSocket, msg: dict) -> None:
         f"Intent: {result['intent']}\n"
         f"Risk: {result['risk_tier']}\n"
         f"Type: {result['page_type']}\n"
-        f"Headings: {result['heading_count']} | Links: {result['link_count']} | Forms: {result['form_count']} | Tabs: {result['tab_count']}\n\n"
+        f"Headings: {result['heading_count']} | Links: {result['link_count']}"
+        f" | Forms: {result['form_count']} | Tabs: {result['tab_count']}\n\n"
         f"{result['summary']}"
     )
     await ws.send_json(

--- a/src/aetherbrowser/topology_engine.py
+++ b/src/aetherbrowser/topology_engine.py
@@ -229,7 +229,7 @@ def compute_langues_cost_gradient(n_samples: int = 20) -> list[dict]:
         d_h = 2 * math.atanh(clamped_r) if clamped_r > 0 else 0
 
         # Langues metric cost
-        cost = sum(LANGUES_WEIGHTS[l] * math.exp(LANGUES_BETA_BASE * PHI ** (l * 0.5) * min(d_h, 10)) for l in range(6))
+        cost = sum(LANGUES_WEIGHTS[lang] * math.exp(LANGUES_BETA_BASE * PHI ** (lang * 0.5) * min(d_h, 10)) for lang in range(6))
 
         stops.append(
             {

--- a/src/aetherbrowser/trilane_router.py
+++ b/src/aetherbrowser/trilane_router.py
@@ -91,7 +91,7 @@ class TriLaneResult:
         return {
             "task": self.task,
             "intent": self.intent.value,
-            "lanes_used": [l.value for l in self.lanes_used],
+            "lanes_used": [lang.value for lang in self.lanes_used],
             "success": self.success,
             "plan": self.plan,
             "results": [
@@ -408,7 +408,7 @@ class TriLaneRouter:
             "input": json.dumps(
                 {
                     "intent": result.intent.value,
-                    "lanes": [l.value for l in result.lanes_used],
+                    "lanes": [lang.value for lang in result.lanes_used],
                     "risk": result.plan.get("risk_tier") if result.plan else "unknown",
                     "targets": result.plan.get("targets", []) if result.plan else [],
                 }

--- a/src/ai_orchestration/orchestrator.py
+++ b/src/ai_orchestration/orchestrator.py
@@ -498,8 +498,8 @@ class Orchestrator:
                 "end": end_time.isoformat() if end_time else "now",
             },
             "total_entries": len(logs),
-            "by_category": {cat.value: sum(1 for l in logs if l.category == cat) for cat in LogCategory},
-            "by_level": {level.name: sum(1 for l in logs if l.level == level) for level in LogLevel},
+            "by_category": {cat.value: sum(1 for log in logs if log.category == cat) for cat in LogCategory},
+            "by_level": {level.name: sum(1 for log in logs if log.level == level) for level in LogLevel},
             "chain_integrity": self.audit_logger.verify_chain_integrity(),
             "workflow_summary": self.workflow_tracker.generate_report(start_time, end_time),
         }

--- a/src/ai_orchestration/security.py
+++ b/src/ai_orchestration/security.py
@@ -548,7 +548,7 @@ class SecurityGate:
         return {
             "total_events": len(events),
             "events_by_type": {t.value: sum(1 for e in events if e.threat_type == t) for t in ThreatType},
-            "events_by_level": {l.name: sum(1 for e in events if e.threat_level == l) for l in ThreatLevel},
+            "events_by_level": {lang.name: sum(1 for e in events if e.threat_level == lang) for lang in ThreatLevel},
             "blocked_events": sum(1 for e in events if e.blocked),
             "blocked_agents": list(self.blocked_agents),
             "recent_events": [

--- a/src/ai_orchestration/setup_assistant.py
+++ b/src/ai_orchestration/setup_assistant.py
@@ -532,7 +532,10 @@ All data is stored securely using SCBE encryption.
                 "portfolio_import": self.profile.portfolio_path is not None,
                 "cloud_backup": self.profile.cloud_backup,
             },
-            "estimated_disk_usage": f"{sum([5, 10, 15][['minimal', 'standard', 'maximum'].index(self.profile.security_level)])} MB base + packs",
+            "estimated_disk_usage": (
+                f"{sum([5, 10, 15][['minimal', 'standard', 'maximum'].index(self.profile.security_level)])}"
+                " MB base + packs"
+            ),
             "ready_to_install": True,
         }
 

--- a/src/ai_orchestration/tool_calling.py
+++ b/src/ai_orchestration/tool_calling.py
@@ -294,11 +294,11 @@ class AuditLogger:
         results = self.logs
 
         if agent_id:
-            results = [l for l in results if l["agent_id"] == agent_id]
+            results = [log for log in results if log["agent_id"] == agent_id]
         if tool_id:
-            results = [l for l in results if l["tool_id"] == tool_id]
+            results = [log for log in results if log["tool_id"] == tool_id]
         if status:
-            results = [l for l in results if l["status"] == status.value]
+            results = [log for log in results if log["status"] == status.value]
 
         return results[-limit:]
 

--- a/src/browser/basin.ts
+++ b/src/browser/basin.ts
@@ -367,12 +367,24 @@ export class Basin {
   }
 
   /**
+   * Guard against path traversal (../) in user-supplied path segments.
+   */
+  private assertNoTraversal(value: string, label: string): void {
+    const normalized = path.normalize(value);
+    if (normalized.startsWith('..') || normalized.includes(`..${path.sep}`) || path.isAbsolute(normalized)) {
+      throw new Error(`Path traversal detected in ${label}: ${value}`);
+    }
+  }
+
+  /**
    * Deposit data into the basin from a river.
    * Creates the directory structure: intake/{riverId}/{category}/
    */
   deposit(riverId: string, category: string, filename: string, data: string | Buffer): string {
     const river = this.rivers.get(riverId);
     if (!river) throw new Error(`Unknown river: ${riverId}`);
+    this.assertNoTraversal(category, 'category');
+    this.assertNoTraversal(filename, 'filename');
     this.assertCategoryAllowed(river, category);
 
     const depositDir = path.join(this.config.intakePath, riverId, category);
@@ -401,6 +413,7 @@ export class Basin {
       throw new Error(`Cannot pull from river: ${riverId}`);
     }
     this.assertRiverAccess(river, 'read');
+    this.assertNoTraversal(sourcePath, 'sourcePath');
     this.assertCategoryAllowed(river, category);
 
     const fullSource = path.join(river.localPath, sourcePath);
@@ -431,6 +444,7 @@ export class Basin {
       throw new Error(`Cannot push to river: ${riverId}`);
     }
     this.assertRiverAccess(river, 'write');
+    this.assertNoTraversal(destPath, 'destPath');
     this.assertCategoryAllowed(river, category);
 
     const sourceDir = path.join(this.config.intakePath, riverId, category);

--- a/src/browser/research_funnel.py
+++ b/src/browser/research_funnel.py
@@ -269,7 +269,10 @@ class ResearchFunnel:
                         {
                             "type": "text",
                             "text": {
-                                "content": f"Sources: {len(records)} | Topics: {', '.join(records[0].get('topics', []))}"
+                                "content": (
+                                    f"Sources: {len(records)}"
+                                    f" | Topics: {', '.join(records[0].get('topics', []))}"
+                                )
                             },
                         }
                     ]

--- a/src/cddm/morphism.py
+++ b/src/cddm/morphism.py
@@ -120,12 +120,18 @@ class Morphism:
                 )
 
         f1, f2 = self.func, other.func
-        composed_func = lambda x: f2(f1(x))
+
+        def composed_func(x):
+            return f2(f1(x))
 
         inv = None
         if self.invertible and other.invertible:
             g1, g2 = self.inverse_func, other.inverse_func
-            inv = lambda y: g1(g2(y))
+
+            def _inv(y):
+                return g1(g2(y))
+
+            inv = _inv
 
         return Morphism(
             src=self.src,

--- a/src/crypto/dual_lattice.py
+++ b/src/crypto/dual_lattice.py
@@ -31,7 +31,6 @@ import hashlib
 import struct
 import secrets
 
-
 # =============================================================================
 # Constants and Parameters
 # =============================================================================
@@ -427,7 +426,7 @@ class DilithiumTongueSigner:
             security_level: 2=Dilithium2, 3=Dilithium3, 5=Dilithium5
         """
         levels = {2: (4, 4), 3: (6, 5), 5: (8, 7)}
-        self.k, self.l = levels.get(security_level, (6, 5))
+        self.k, self.ell = levels.get(security_level, (6, 5))
         self.n = DILITHIUM_N
         self.q = DILITHIUM_Q
 
@@ -436,7 +435,7 @@ class DilithiumTongueSigner:
 
     def _generate_keypair(self):
         """Generate Dilithium keypair (simplified)."""
-        self.secret_key = secrets.token_bytes(32 + 32 * self.l)
+        self.secret_key = secrets.token_bytes(32 + 32 * self.ell)
         self.public_key = secrets.token_bytes(32 + 32 * self.k)
 
     def create_tongue_hash(self, vector: LatticeVector) -> bytes:
@@ -813,14 +812,12 @@ class TongueLatticeGovernor:
 
 def demo():
     """Demonstrate the dual lattice cross-stitch system."""
-    print(
-        """
+    print("""
 ╔═══════════════════════════════════════════════════════════════════════════════╗
 ║                    DUAL LATTICE CROSS-STITCH DEMO                             ║
 ║            Kyber + Dilithium + Sacred Tongues + Time + Intent                 ║
 ╚═══════════════════════════════════════════════════════════════════════════════╝
-    """
-    )
+    """)
 
     # Create governor
     governor = TongueLatticeGovernor()
@@ -846,7 +843,9 @@ def demo():
         print(f"  Vector Norm: {result['vector_norm']:.3f} (normalized: {result['normalized_norm']:.3f})")
         print(f"  Trust Score: {result['trust_score']:.3f}")
         print(
-            f"  Thresholds: ALLOW>{result['thresholds']['allow']:.2f} | QUAR>{result['thresholds']['quarantine']:.2f} | ESC>{result['thresholds']['escalate']:.2f}"
+            f"  Thresholds: ALLOW>{result['thresholds']['allow']:.2f}"
+            f" | QUAR>{result['thresholds']['quarantine']:.2f}"
+            f" | ESC>{result['thresholds']['escalate']:.2f}"
         )
         print(f"  Decision: {result['decision']}")
         print(f"  Kyber Level: {result['lattice_proof']['security']['kyber_level']}")
@@ -875,8 +874,7 @@ def demo():
 
     print("       └" + "─" * 50 + "┘")
 
-    print(
-        """
+    print("""
 
   Legend:
   ────────
@@ -885,8 +883,7 @@ def demo():
   • KO-I coupling: Strongest (intent binds to purpose)
   • Tongue-Phase: Sinusoidal based on phase angles
   • Flux (ν): Modulates all couplings
-    """
-    )
+    """)
 
 
 if __name__ == "__main__":

--- a/src/fleet/asymmetric_movement.py
+++ b/src/fleet/asymmetric_movement.py
@@ -224,7 +224,10 @@ def validate_movement(
             "human_cost": h_cost["lateral"],
             "ai_cost": ai_cost,
             "moved_axes": moved,
-            "reason": f"Vertical depth {vert_depth:.3f} exceeds auth tier {unit.human.auth_tier} limit {depth_limit:.3f}",
+            "reason": (
+                f"Vertical depth {vert_depth:.3f} exceeds auth tier"
+                f" {unit.human.auth_tier} limit {depth_limit:.3f}"
+            ),
         }
 
     if ai_cost < 0.05:

--- a/src/gateway/COMPUTATIONAL_IMMUNE_SYSTEM.py
+++ b/src/gateway/COMPUTATIONAL_IMMUNE_SYSTEM.py
@@ -337,7 +337,8 @@ class DriftSimulationEngine:
         print(f"   Elegance Score: {magic['elegance_score']:.2f}")
         print("\n📊 Formula:")
         print(
-            f"   vD = {magic['base_drift']} + 0.001×time^{magic['time_exponent']} + 0.001×dist^{magic['distance_exponent']}"
+            f"   vD = {magic['base_drift']} + 0.001×time^{magic['time_exponent']}"
+            f" + 0.001×dist^{magic['distance_exponent']}"
         )
 
         # Check if it's 'elegant' like E=mc²

--- a/src/gateway/DNA_MULTI_LAYER_ENCODING_TEST.py
+++ b/src/gateway/DNA_MULTI_LAYER_ENCODING_TEST.py
@@ -172,7 +172,11 @@ class EmotionalIntentVector:
 
     def to_hash_input(self) -> bytes:
         """Convert to bytes for key derivation"""
-        return f"{self.anchor_strength}{self.bridge_strength}{self.cut_strength}{self.paradox_strength}{self.joy_strength}{self.harmony_strength}{self.sender_intent}{self.purpose}{self.method}".encode()
+        return (
+            f"{self.anchor_strength}{self.bridge_strength}{self.cut_strength}"
+            f"{self.paradox_strength}{self.joy_strength}{self.harmony_strength}"
+            f"{self.sender_intent}{self.purpose}{self.method}"
+        ).encode()
 
 
 # ============================================================================
@@ -371,12 +375,13 @@ def test_attack_resistance():
     full_complexity = full_msg.compute_total_complexity()
     print(f"  DNA: {full_msg.dna_encoded}")
     print(f"  Temporal distance: {full_msg.temporal.compute_temporal_distance(TemporalVector(0, 0, 0, 0, 0)):.2f}")
-    print(
-        f"  Emotional distance: {full_msg.emotional.compute_emotional_distance(EmotionalIntentVector(0.5,0.5,0.5,0.5,0.5,0.5,'','','')):.2f}"
+    _neutral_emo = EmotionalIntentVector(
+        0.5, 0.5, 0.5, 0.5, 0.5, 0.5, '', '', ''
     )
-    print(
-        f"  Gravitational force: {full_msg.emotional.compute_gravitational_force(EmotionalIntentVector(0.5,0.5,0.5,0.5,0.5,0.5,'','',''), 1.0):.2e}"
-    )
+    _emo_dist = full_msg.emotional.compute_emotional_distance(_neutral_emo)
+    print(f"  Emotional distance: {_emo_dist:.2f}")
+    _grav = full_msg.emotional.compute_gravitational_force(_neutral_emo, 1.0)
+    print(f"  Gravitational force: {_grav:.2e}")
     print(f"  Total complexity score: {full_complexity:.2e}")
     print(f"  Search space: ~{full_complexity:.2e} operations")
 

--- a/src/governance/runtime_gate.py
+++ b/src/governance/runtime_gate.py
@@ -182,8 +182,8 @@ class RuntimeGate:
             centroid = self._centroid.tolist()
 
         spins = []
-        for l in range(6):
-            diff = coords[l] - centroid[l]
+        for lang in range(6):
+            diff = coords[lang] - centroid[lang]
             if diff > threshold:
                 spins.append(1)
             elif diff < -threshold:

--- a/src/harmonic/spectral_identity.py
+++ b/src/harmonic/spectral_identity.py
@@ -182,7 +182,7 @@ class SpectralIdentityGenerator:
             # Modulate with layer scores if available
             if layer_scores and len(layer_scores) >= 14:
                 band_layers = SPECTRAL_BANDS[band].layers
-                layer_avg = sum(layer_scores[l - 1] for l in band_layers) / len(band_layers)
+                layer_avg = sum(layer_scores[lang - 1] for lang in band_layers) / len(band_layers)
                 intensity = (intensity + layer_avg) / 2
 
             # Apply golden ratio modulation for uniqueness
@@ -319,10 +319,10 @@ class SpectralIdentityGenerator:
         """Convert HSL to RGB"""
         h = hsl.h / 360
         s = hsl.s / 100
-        l = hsl.l / 100
+        lum = hsl.l / 100
 
         if s == 0:
-            r = g = b = l
+            r = g = b = lum
         else:
 
             def hue2rgb(p: float, q: float, t: float) -> float:
@@ -338,8 +338,8 @@ class SpectralIdentityGenerator:
                     return p + (q - p) * (2 / 3 - t) * 6
                 return p
 
-            q = l * (1 + s) if l < 0.5 else l + s - l * s
-            p = 2 * l - q
+            q = lum * (1 + s) if lum < 0.5 else lum + s - lum * s
+            p = 2 * lum - q
             r = hue2rgb(p, q, h + 1 / 3)
             g = hue2rgb(p, q, h)
             b = hue2rgb(p, q, h - 1 / 3)

--- a/src/kernel/context_grid.py
+++ b/src/kernel/context_grid.py
@@ -553,7 +553,10 @@ class FederatedContextGrid:
                 messages=[
                     {
                         "role": "system",
-                        "content": "You are an AI agent in the SCBE-AETHERMOORE sphere grid. Answer using ONLY the provided context. Be concise.",
+                        "content": (
+                            "You are an AI agent in the SCBE-AETHERMOORE sphere grid."
+                            " Answer using ONLY the provided context. Be concise."
+                        ),
                     },
                     {"role": "user", "content": f"Context:\n{context_str}\n\nQuestion: {query}"},
                 ],

--- a/src/knowledge/scrapers/harvard_dataverse_scraper.py
+++ b/src/knowledge/scrapers/harvard_dataverse_scraper.py
@@ -49,7 +49,11 @@ def search_datasets(query: str, limit: int = 20) -> list[KnowledgeChunk]:
             source="harvard_dataverse",
             category=category,
             title=name,
-            content=f"# {name}\n\nAuthors: {', '.join(authors[:5])}\nPublished: {published_at}\nSubjects: {', '.join(subjects[:5])}\nDOI: {global_id}\n\n{description[:3000]}\n\nCitation: {citation}",
+            content=(
+                f"# {name}\n\nAuthors: {', '.join(authors[:5])}\n"
+                f"Published: {published_at}\nSubjects: {', '.join(subjects[:5])}\n"
+                f"DOI: {global_id}\n\n{description[:3000]}\n\nCitation: {citation}"
+            ),
             url=url_val,
             metadata={
                 "dataverse_id": global_id,

--- a/src/knowledge/scrapers/internet_archive_scraper.py
+++ b/src/knowledge/scrapers/internet_archive_scraper.py
@@ -58,7 +58,11 @@ def search_archive(query: str, media_type: str = "texts", limit: int = 25) -> li
             source="internet_archive",
             category=category,
             title=title,
-            content=f"# {title}\n\nCreator: {creator}\nDate: {date}\nDownloads: {downloads}\nSubjects: {', '.join(subjects[:5])}\n\n{str(description)[:3000]}",
+            content=(
+                f"# {title}\n\nCreator: {creator}\nDate: {date}\n"
+                f"Downloads: {downloads}\nSubjects: {', '.join(subjects[:5])}\n\n"
+                f"{str(description)[:3000]}"
+            ),
             url=f"https://archive.org/details/{identifier}",
             metadata={
                 "ia_identifier": identifier,

--- a/src/knowledge/scrapers/loc_scraper.py
+++ b/src/knowledge/scrapers/loc_scraper.py
@@ -53,7 +53,12 @@ def search_loc(query: str, collection: str = "", limit: int = 25) -> list[Knowle
             source="library_of_congress",
             category=category,
             title=title,
-            content=f"# {title}\n\nContributors: {', '.join(contributors[:5]) if contributors else 'N/A'}\nDate: {dates}\nSubjects: {', '.join(subjects[:5])}\n\n{description[:3000]}",
+            content=(
+                f"# {title}\n\nContributors: "
+                f"{', '.join(contributors[:5]) if contributors else 'N/A'}\n"
+                f"Date: {dates}\nSubjects: {', '.join(subjects[:5])}\n\n"
+                f"{description[:3000]}"
+            ),
             url=item_url,
             metadata={
                 "loc_collection": collection,

--- a/src/knowledge/scrapers/nist_nvd_scraper.py
+++ b/src/knowledge/scrapers/nist_nvd_scraper.py
@@ -72,7 +72,11 @@ def search_cves(keyword: str, limit: int = 20) -> list[KnowledgeChunk]:
             source="nist_nvd",
             category="security",
             title=f"{cve_id} — CVSS {cvss_score} ({severity})",
-            content=f"# {cve_id}\n\nCVSS Score: {cvss_score} ({severity})\nPublished: {published}\nCWEs: {', '.join(cwes)}\n\n{en_desc}\n\nReferences: {', '.join(ref_urls)}",
+            content=(
+                f"# {cve_id}\n\nCVSS Score: {cvss_score} ({severity})\n"
+                f"Published: {published}\nCWEs: {', '.join(cwes)}\n\n"
+                f"{en_desc}\n\nReferences: {', '.join(ref_urls)}"
+            ),
             url=f"https://nvd.nist.gov/vuln/detail/{cve_id}",
             metadata={
                 "cve_id": cve_id,

--- a/src/knowledge/scrapers/semantic_scholar_scraper.py
+++ b/src/knowledge/scrapers/semantic_scholar_scraper.py
@@ -76,7 +76,10 @@ def get_citations(paper_id: str, limit: int = 20) -> list[KnowledgeChunk]:
             source="semantic_scholar",
             category="citations",
             title=paper.get("title", ""),
-            content=f"# {paper.get('title', '')}\n\nAuthors: {', '.join(authors)}\nYear: {paper.get('year', '')}\n\n{paper.get('abstract', '') or ''}",
+            content=(
+                f"# {paper.get('title', '')}\n\nAuthors: {', '.join(authors)}\n"
+                f"Year: {paper.get('year', '')}\n\n{paper.get('abstract', '') or ''}"
+            ),
             url=paper.get("url", ""),
             metadata={
                 "s2_paper_id": paper.get("paperId", ""),

--- a/src/knowledge/scrapers/wikidata_scraper.py
+++ b/src/knowledge/scrapers/wikidata_scraper.py
@@ -47,7 +47,11 @@ def search_entities(query: str, limit: int = 20) -> list[KnowledgeChunk]:
             source="wikidata",
             category="research",
             title=f"{label} ({entity_id})",
-            content=f"# {label}\n\nWikidata ID: {entity_id}\nDescription: {description}\n\nStructured knowledge entity from Wikidata.",
+            content=(
+                f"# {label}\n\nWikidata ID: {entity_id}\n"
+                f"Description: {description}\n\n"
+                "Structured knowledge entity from Wikidata."
+            ),
             url=url_val,
             metadata={
                 "wikidata_id": entity_id,

--- a/src/licensing/nist_ai_rmf.py
+++ b/src/licensing/nist_ai_rmf.py
@@ -29,7 +29,6 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
-
 # ── AI RMF Functions ─────────────────────────────────────────────────────────
 
 
@@ -133,7 +132,10 @@ def generate_compliance_report() -> ComplianceReport:
             category="Policies",
             description="Legal and regulatory requirements are understood and inform AI risk management",
             scbe_mapping="CUSTOMER_LICENSE_AGREEMENT.md, docs/05-industry-guides/",
-            evidence="Dual-license model with explicit regulatory mapping for banking, healthcare, defense, SaaS verticals",
+            evidence=(
+                "Dual-license model with explicit regulatory mapping"
+                " for banking, healthcare, defense, SaaS verticals"
+            ),
         )
     )
 
@@ -155,7 +157,10 @@ def generate_compliance_report() -> ComplianceReport:
             category="Accountability",
             description="Roles and responsibilities for AI risk management are defined",
             scbe_mapping="src/governance/, src/fleet/ (shepherd/flock roles)",
-            evidence="Layer 13 governance with ALLOW/QUARANTINE/ESCALATE/DENY decisions requiring explicit authorization",
+            evidence=(
+                "Layer 13 governance with ALLOW/QUARANTINE/ESCALATE/DENY"
+                " decisions requiring explicit authorization"
+            ),
         )
     )
 
@@ -166,7 +171,10 @@ def generate_compliance_report() -> ComplianceReport:
             category="Risk Tolerance",
             description="Risk tolerance is determined and documented",
             scbe_mapping="src/symphonic_cipher/scbe_aethermoore/axiom_grouped/langues_metric.py",
-            evidence="Quantified risk thresholds: LOW (L<1.5×L_base→ALLOW), MEDIUM (→QUARANTINE), HIGH (→REVIEW), CRITICAL (→DENY)",
+            evidence=(
+                "Quantified risk thresholds: LOW (L<1.5×L_base→ALLOW),"
+                " MEDIUM (→QUARANTINE), HIGH (→REVIEW), CRITICAL (→DENY)"
+            ),
         )
     )
 
@@ -177,7 +185,10 @@ def generate_compliance_report() -> ComplianceReport:
             category="Oversight",
             description="Mechanisms are in place for human oversight of AI",
             scbe_mapping="src/symphonic_cipher/scbe_aethermoore/ai_brain/governance_adapter.py",
-            evidence="ESCALATE decision tier requires human governance approval; flux contraction pulls state toward safe origin",
+            evidence=(
+                "ESCALATE decision tier requires human governance approval;"
+                " flux contraction pulls state toward safe origin"
+            ),
         )
     )
 
@@ -213,7 +224,10 @@ def generate_compliance_report() -> ComplianceReport:
             category="Risk Categorization",
             description="AI risks are identified and categorized",
             scbe_mapping="14-layer pipeline (L1-L14), docs/CORE_AXIOMS_CANONICAL_INDEX.md",
-            evidence="ROME-Class Failure taxonomy; adversarial intent mapped to Poincare ball with exponential cost scaling",
+            evidence=(
+                "ROME-Class Failure taxonomy; adversarial intent mapped to"
+                " Poincare ball with exponential cost scaling"
+            ),
         )
     )
 
@@ -246,7 +260,10 @@ def generate_compliance_report() -> ComplianceReport:
             category="Third-Party Components",
             description="Third-party AI components and their risks are identified",
             scbe_mapping="package.json (dependencies), src/pyproject.toml",
-            evidence="Explicit dependency list with PQC libraries (@noble/post-quantum), MCP SDK, and crypto primitives",
+            evidence=(
+                "Explicit dependency list with PQC libraries"
+                " (@noble/post-quantum), MCP SDK, and crypto primitives"
+            ),
         )
     )
 
@@ -260,7 +277,10 @@ def generate_compliance_report() -> ComplianceReport:
             category="Performance Metrics",
             description="AI system performance is measured against stated objectives",
             scbe_mapping="docs/archive/compliance_report.md (150/150 tests)",
-            evidence="Coverage: HIPAA(23), NIST-800-53(74), FIPS-140-3(31), PCI-DSS(5), SOX(6), GDPR(5), ISO-27001(3), SOC2(17)",
+            evidence=(
+                "Coverage: HIPAA(23), NIST-800-53(74), FIPS-140-3(31),"
+                " PCI-DSS(5), SOX(6), GDPR(5), ISO-27001(3), SOC2(17)"
+            ),
         )
     )
 

--- a/src/physics_sim/core.py
+++ b/src/physics_sim/core.py
@@ -318,10 +318,10 @@ def electromagnetism(params: Dict[str, Any]) -> Dict[str, Any]:
 
     # Magnetic field from long straight wire: B = μ₀I/(2πr)
     if "current" in params and "distance" in params:
-        I = params["current"]
+        current = params["current"]
         r = params["distance"]
         if r > 0:
-            B = VACUUM_PERMEABILITY * I / (2 * math.pi * r)
+            B = VACUUM_PERMEABILITY * current / (2 * math.pi * r)
             results["magnetic_field_from_wire"] = B
 
     # Electromagnetic wave: c = fλ, E = cB

--- a/src/physics_sim/numerical.py
+++ b/src/physics_sim/numerical.py
@@ -639,16 +639,16 @@ def cubic_spline_coefficients(x_data: List[float], y_data: List[float]) -> List[
     for i in range(1, n):
         alpha[i] = 3 / h[i] * (y_data[i + 1] - y_data[i]) - 3 / h[i - 1] * (y_data[i] - y_data[i - 1])
 
-    l = [1.0] + [0.0] * n
+    diag = [1.0] + [0.0] * n
     mu = [0.0] * (n + 1)
     z = [0.0] * (n + 1)
 
     for i in range(1, n):
-        l[i] = 2 * (x_data[i + 1] - x_data[i - 1]) - h[i - 1] * mu[i - 1]
-        mu[i] = h[i] / l[i]
-        z[i] = (alpha[i] - h[i - 1] * z[i - 1]) / l[i]
+        diag[i] = 2 * (x_data[i + 1] - x_data[i - 1]) - h[i - 1] * mu[i - 1]
+        mu[i] = h[i] / diag[i]
+        z[i] = (alpha[i] - h[i - 1] * z[i - 1]) / diag[i]
 
-    l[n] = 1.0
+    diag[n] = 1.0
     z[n] = 0.0
     c = [0.0] * (n + 1)
 
@@ -875,8 +875,11 @@ def numerical_methods(params: Dict[str, Any]) -> Dict[str, Any]:
 
     if method == "root_finding":
         # Example: find root of x² - 2 (i.e., √2)
-        f = lambda x: x**2 - 2
-        df = lambda x: 2 * x
+        def f(x):
+            return x**2 - 2
+
+        def df(x):
+            return 2 * x
 
         root, iters = bisection(f, 1, 2)
         results["bisection_root"] = root
@@ -901,7 +904,9 @@ def numerical_methods(params: Dict[str, Any]) -> Dict[str, Any]:
         # Simple harmonic oscillator: x'' = -ω²x
         # State: [x, v], derivatives: [v, -ω²x]
         omega = params.get("omega", 1.0)
-        f = lambda t, y: [y[1], -(omega**2) * y[0]]
+
+        def f(t, y):
+            return [y[1], -(omega**2) * y[0]]
 
         y0 = [1.0, 0.0]  # x=1, v=0
         t_span = (0, 2 * math.pi / omega)  # One period

--- a/src/physics_sim/waves_optics.py
+++ b/src/physics_sim/waves_optics.py
@@ -707,20 +707,20 @@ def doppler_shift_moving_observer(
         return f_source * (v_sound - v_observer) / v_sound
 
 
-def sound_intensity_level(I: float, I_ref: float = 1e-12) -> float:
+def sound_intensity_level(intensity: float, intensity_ref: float = 1e-12) -> float:
     """
     Calculate sound intensity level in decibels.
 
     β = 10 * log₁₀(I/I₀)
 
     Args:
-        I: Sound intensity (W/m²)
-        I_ref: Reference intensity (default 1e-12 W/m², threshold of hearing)
+        intensity: Sound intensity (W/m²)
+        intensity_ref: Reference intensity (default 1e-12 W/m², threshold of hearing)
 
     Returns:
         Sound level (dB)
     """
-    return 10 * math.log10(I / I_ref)
+    return 10 * math.log10(intensity / intensity_ref)
 
 
 def beat_frequency(f1: float, f2: float) -> float:
@@ -841,20 +841,20 @@ def em_field_ratio(n: float = 1) -> float:
     return C / n
 
 
-def radiation_pressure(I: float, reflectivity: float = 0) -> float:
+def radiation_pressure(intensity: float, reflectivity: float = 0) -> float:
     """
     Calculate radiation pressure.
 
     P = I/c (absorbed) or P = 2I/c (reflected)
 
     Args:
-        I: Intensity (W/m²)
+        intensity: Intensity (W/m²)
         reflectivity: Fraction reflected (0 to 1)
 
     Returns:
         Radiation pressure (Pa)
     """
-    return I / C * (1 + reflectivity)
+    return intensity / C * (1 + reflectivity)
 
 
 def wavelength_to_frequency(wavelength: float) -> float:

--- a/src/science_packs/__init__.py
+++ b/src/science_packs/__init__.py
@@ -108,7 +108,10 @@ PHYSICAL_SCIENCES = {
     "physics_sim": SciencePack(
         name="Physics Simulation Engine",
         category="Physical Sciences",
-        description="Classical mechanics, quantum mechanics, thermodynamics, electromagnetism, relativity, and numerical methods",
+        description=(
+            "Classical mechanics, quantum mechanics, thermodynamics,"
+            " electromagnetism, relativity, and numerical methods"
+        ),
         version="2.0.0",
         status=PackStatus.INSTALLED,
         size_mb=2.5,

--- a/src/spiralverse/temporal_intent.py
+++ b/src/spiralverse/temporal_intent.py
@@ -47,7 +47,6 @@ from typing import Dict, Tuple
 from enum import Enum
 from collections import deque
 
-
 # =============================================================================
 # Constants
 # =============================================================================

--- a/src/storage/fusion_surfaces.py
+++ b/src/storage/fusion_surfaces.py
@@ -175,7 +175,7 @@ class CymaticCone:
             "compaction_score": round(
                 self._record_count / max(1, oct_stats["node_count"] + oct_stats["leaf_count"]), 6
             ),
-            "unique_chladni_modes": len({(l.chladni_n, l.chladni_m) for l in self.leaves.values()}),
+            "unique_chladni_modes": len({(leaf.chladni_n, leaf.chladni_m) for leaf in self.leaves.values()}),
         }
 
 

--- a/src/storage/langues_dispersal.py
+++ b/src/storage/langues_dispersal.py
@@ -81,7 +81,7 @@ class SpinVector:
 
     def metric_weighted_norm(self) -> float:
         """||s||_G = sqrt(Σ G_ll · s_l²)."""
-        return math.sqrt(sum(TONGUE_WEIGHTS[l] * self.spins[l] ** 2 for l in range(6)))
+        return math.sqrt(sum(TONGUE_WEIGHTS[lang] * self.spins[lang] ** 2 for lang in range(6)))
 
 
 def quantize_spin(
@@ -100,8 +100,8 @@ def quantize_spin(
         SpinVector with 6 trits
     """
     spins = []
-    for l in range(6):
-        diff = tongue_coords[l] - centroid[l]
+    for lang in range(6):
+        diff = tongue_coords[lang] - centroid[lang]
         if diff > threshold:
             spins.append(1)
         elif diff < -threshold:
@@ -165,15 +165,15 @@ def compute_dispersal(
     tongue_sums = [0.0] * 6
 
     for i, (tv, sv) in enumerate(zip(tongue_vectors, spins)):
-        for l in range(6):
-            contrib = G[l, l] * abs(sv.spins[l]) * abs(tv[l] - centroid[l])
+        for lang in range(6):
+            contrib = G[lang, lang] * abs(sv.spins[lang]) * abs(tv[lang] - centroid[lang])
             dispersal_sum += contrib
-            tongue_sums[l] += contrib
+            tongue_sums[lang] += contrib
 
     dispersal_rate = dispersal_sum / n
 
     # Per-tongue dispersal
-    tongue_dispersals = {TONGUE_NAMES[l]: round(tongue_sums[l] / n, 6) for l in range(6)}
+    tongue_dispersals = {TONGUE_NAMES[lang]: round(tongue_sums[lang] / n, 6) for lang in range(6)}
 
     # Dominant tongue: highest per-tongue dispersal
     dominant_idx = tongue_sums.index(max(tongue_sums))
@@ -198,9 +198,9 @@ def compute_dispersal(
     # Effective dimension: how many tongues have non-zero spin in most records
     tongue_active_counts = [0] * 6
     for sv in spins:
-        for l in range(6):
-            if sv.spins[l] != 0:
-                tongue_active_counts[l] += 1
+        for lang in range(6):
+            if sv.spins[lang] != 0:
+                tongue_active_counts[lang] += 1
     effective_dimension = sum(c / n for c in tongue_active_counts)
 
     return DispersalReport(
@@ -237,7 +237,7 @@ def dispersal_route(
     G = build_metric_tensor()
 
     # Per-record dispersal cost
-    cost = sum(G[l, l] * abs(sv.spins[l]) * abs(tongue_coords[l] - centroid[l]) for l in range(6))
+    cost = sum(G[lang, lang] * abs(sv.spins[lang]) * abs(tongue_coords[lang] - centroid[lang]) for lang in range(6))
 
     # Route decision: high magnitude → cone, low → hemisphere
     if sv.magnitude >= 4:
@@ -248,7 +248,7 @@ def dispersal_route(
         zone = "cone" if cost > 0.5 else "hemisphere"
 
     # Dominant tongue: highest weighted spin deviation
-    weighted_devs = [TONGUE_WEIGHTS[l] * abs(sv.spins[l]) * abs(tongue_coords[l] - centroid[l]) for l in range(6)]
+    weighted_devs = [TONGUE_WEIGHTS[lang] * abs(sv.spins[lang]) * abs(tongue_coords[lang] - centroid[lang]) for lang in range(6)]
     dominant_idx = weighted_devs.index(max(weighted_devs))
 
     return {

--- a/src/storage/lightning_query.py
+++ b/src/storage/lightning_query.py
@@ -454,9 +454,9 @@ class LightningQuery:
     def stats(self) -> Dict[str, Any]:
         total_records = len(self.records)
         total_zones = len(self.leaders)
-        total_charge = sum(l.effective_charge for l in self.leaders.values())
-        avg_conductivity = sum(l.conductivity for l in self.leaders.values()) / max(1, total_zones)
-        penalized_zones = sum(1 for l in self.leaders.values() if l.penalty > 0.01)
+        total_charge = sum(leader.effective_charge for leader in self.leaders.values())
+        avg_conductivity = sum(leader.conductivity for leader in self.leaders.values()) / max(1, total_zones)
+        penalized_zones = sum(1 for leader in self.leaders.values() if leader.penalty > 0.01)
 
         return {
             "type": "LightningQuery",

--- a/src/symphonic_cipher/scbe_aethermoore/_scipy_compat.py
+++ b/src/symphonic_cipher/scbe_aethermoore/_scipy_compat.py
@@ -88,13 +88,13 @@ except ImportError:
             c.append(c[-1] * (q - k + 1) / (k * (2 * q - k + 1)))
 
         # Compute U and V for Padé approximant
-        I = np.eye(n)
+        eye = np.eye(n)
         A2 = A_scaled @ A_scaled
 
-        U = c[1] * I
-        V = c[0] * I
+        U = c[1] * eye
+        V = c[0] * eye
 
-        A_power = I
+        A_power = eye
         for k in range(1, q // 2 + 1):
             A_power = A_power @ A2
             U = U + c[2 * k + 1] * A_power

--- a/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/benchmark_comparison.py
+++ b/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/benchmark_comparison.py
@@ -180,10 +180,10 @@ class SCBEHyperbolicDefense:
         mu = [0.0, 0.0, 0.9, 0.9, 0.1, 0.1]
 
         L = 0.0
-        for l in range(6):
-            w_l = TONGUE_WEIGHTS[l]
-            d_l = abs(x[l] - mu[l])
-            phi_l = TONGUE_PHASES[l]
+        for lang in range(6):
+            w_l = TONGUE_WEIGHTS[lang]
+            d_l = abs(x[lang] - mu[lang])
+            phi_l = TONGUE_PHASES[lang]
             beta_l = 1.0 + 0.1 * math.cos(phi_l)
 
             # Phase-shifted deviation
@@ -435,7 +435,8 @@ def run_benchmark():
             }
 
             print(
-                f"  {defense.name:40} | Caught: {caught:2}/{total_attacks:2} ({detection_rate:5.1f}%) | FP: {false_positives}"
+                f"  {defense.name:40} | Caught: {caught:2}/{total_attacks:2}"
+                f" ({detection_rate:5.1f}%) | FP: {false_positives}"
             )
 
     # Summary

--- a/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/causality_axiom.py
+++ b/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/causality_axiom.py
@@ -312,7 +312,6 @@ def quantum_fidelity(q1: complex, q2: complex) -> float:
     For non-identical amplitudes we clamp to [0, 1] for stability.
     """
     inner = np.conj(q1) * q2
-    raw_fidelity = float(np.abs(inner) ** 2)
     fidelity = float(np.abs(inner) ** 2)
 
     # Preserve legacy self-fidelity behavior for unnormalized amplitudes while

--- a/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/demo_for_elon.py
+++ b/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/demo_for_elon.py
@@ -85,7 +85,8 @@ def simulate_attack_scenario():
     print()
     print("-" * 70)
     print(
-        f"{'Time':>6} {'Deviation':>10} {'Coherence':>10} | {'Trad Risk':>10} {'Trad':>10} | {'SCBE Risk':>12} {'SCBE':>10}"
+        f"{'Time':>6} {'Deviation':>10} {'Coherence':>10} | "
+        f"{'Trad Risk':>10} {'Trad':>10} | {'SCBE Risk':>12} {'SCBE':>10}"
     )
     print("-" * 70)
 
@@ -135,7 +136,9 @@ def simulate_attack_scenario():
         attack_marker = " *ATTACK*" if is_attack else ""
 
         print(
-            f"{t:>6} {deviation:>10.3f} {coherence:>10.3f} | {trad_risk:>10.4f} {trad_decision:>10} | {scbe_risk_str:>12} {scbe_decision:>10}{attack_marker}"
+            f"{t:>6} {deviation:>10.3f} {coherence:>10.3f} | "
+            f"{trad_risk:>10.4f} {trad_decision:>10} | "
+            f"{scbe_risk_str:>12} {scbe_decision:>10}{attack_marker}"
         )
 
     print("-" * 70)
@@ -143,7 +146,8 @@ def simulate_attack_scenario():
     print("RESULTS:")
     print(f"  Total attack time steps: {attacks_happened}")
     print(
-        f"  Traditional system caught: {traditional_catches}/{attacks_happened} ({100*traditional_catches/max(1,attacks_happened):.0f}%)"
+        f"  Traditional system caught: {traditional_catches}/{attacks_happened}"
+        f" ({100*traditional_catches/max(1,attacks_happened):.0f}%)"
     )
     print(f"  SCBE system caught: {scbe_catches}/{attacks_happened} ({100*scbe_catches/max(1,attacks_happened):.0f}%)")
     print()

--- a/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/langues_metric.py
+++ b/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/langues_metric.py
@@ -142,7 +142,7 @@ class LanguesMetric:
         """Compute deviation d_l = |x_l - μ_l| for each dimension."""
         x_vec = x.to_vector()
         mu_vec = self.ideal.to_vector()
-        return [abs(x_vec[l] - mu_vec[l]) for l in range(6)]
+        return [abs(x_vec[lang] - mu_vec[lang]) for lang in range(6)]
 
     def compute(
         self,
@@ -164,18 +164,18 @@ class LanguesMetric:
         deviations = self.compute_deviations(x)
 
         L = 0.0
-        for l in range(6):
-            tongue = TONGUES[l]
+        for lang in range(6):
+            tongue = TONGUES[lang]
 
             # Skip if tongue not active
             if active_tongues and tongue not in active_tongues:
                 continue
 
-            w_l = TONGUE_WEIGHTS[l]
-            beta_l = self.betas[l]
-            omega_l = TONGUE_FREQUENCIES[l]
-            phi_l = TONGUE_PHASES[l]
-            d_l = deviations[l]
+            w_l = TONGUE_WEIGHTS[lang]
+            beta_l = self.betas[lang]
+            omega_l = TONGUE_FREQUENCIES[lang]
+            phi_l = TONGUE_PHASES[lang]
+            d_l = deviations[lang]
 
             # Phase-shifted deviation
             phase_shift = math.sin(omega_l * t + phi_l)
@@ -199,18 +199,18 @@ class LanguesMetric:
         mu_vec = self.ideal.to_vector()
 
         grad = []
-        for l in range(6):
-            w_l = TONGUE_WEIGHTS[l]
-            beta_l = self.betas[l]
-            omega_l = TONGUE_FREQUENCIES[l]
-            phi_l = TONGUE_PHASES[l]
-            d_l = deviations[l]
+        for lang in range(6):
+            w_l = TONGUE_WEIGHTS[lang]
+            beta_l = self.betas[lang]
+            omega_l = TONGUE_FREQUENCIES[lang]
+            phi_l = TONGUE_PHASES[lang]
+            d_l = deviations[lang]
 
             phase_shift = math.sin(omega_l * t + phi_l)
             shifted_d = d_l + 0.1 * phase_shift
 
             # Sign of deviation direction
-            sign = 1.0 if x_vec[l] >= mu_vec[l] else -1.0
+            sign = 1.0 if x_vec[lang] >= mu_vec[lang] else -1.0
 
             # ∂L/∂x_l = w_l * β_l * exp(β_l * d_l) * sign
             grad_l = w_l * beta_l * math.exp(beta_l * shifted_d) * sign
@@ -255,9 +255,9 @@ def langues_distance(
 
     # Weighted sum of squared differences
     d_sq = 0.0
-    for l in range(6):
-        w_l = TONGUE_WEIGHTS[l]
-        diff = v1[l] - v2[l]
+    for lang in range(6):
+        w_l = TONGUE_WEIGHTS[lang]
+        diff = v1[lang] - v2[lang]
         d_sq += w_l * diff**2
 
     return math.sqrt(d_sq)
@@ -394,13 +394,13 @@ class FluxingLanguesMetric:
         mu_vec = self.ideal.to_vector()
 
         L = 0.0
-        for l in range(6):
-            nu_l = self.flux.nu[l]  # Fractional dimension weight
-            w_l = TONGUE_WEIGHTS[l]
-            beta_l = self.betas[l]
-            omega_l = TONGUE_FREQUENCIES[l]
-            phi_l = TONGUE_PHASES[l]
-            d_l = abs(x_vec[l] - mu_vec[l])
+        for lang in range(6):
+            nu_l = self.flux.nu[lang]  # Fractional dimension weight
+            w_l = TONGUE_WEIGHTS[lang]
+            beta_l = self.betas[lang]
+            omega_l = TONGUE_FREQUENCIES[lang]
+            phi_l = TONGUE_PHASES[lang]
+            d_l = abs(x_vec[lang] - mu_vec[lang])
 
             phase_shift = math.sin(omega_l * t + phi_l)
             shifted_d = d_l + 0.1 * phase_shift
@@ -553,9 +553,9 @@ def verify_phase_bounded() -> bool:
     This ensures phase doesn't break monotonicity.
     """
     for t in range(1000):
-        for l in range(6):
-            omega_l = TONGUE_FREQUENCIES[l]
-            phi_l = TONGUE_PHASES[l]
+        for lang in range(6):
+            omega_l = TONGUE_FREQUENCIES[lang]
+            phi_l = TONGUE_PHASES[lang]
             phase = math.sin(omega_l * t + phi_l)
             if abs(phase) > 1.0 + 1e-10:
                 return False
@@ -568,8 +568,8 @@ def verify_tongue_weights() -> bool:
 
     w_{l+1} / w_l = φ for all l.
     """
-    for l in range(5):
-        ratio = TONGUE_WEIGHTS[l + 1] / TONGUE_WEIGHTS[l]
+    for lang in range(5):
+        ratio = TONGUE_WEIGHTS[lang + 1] / TONGUE_WEIGHTS[lang]
         if abs(ratio - PHI) > 1e-10:
             return False
     return True
@@ -582,8 +582,8 @@ def verify_six_fold_symmetry() -> bool:
     φ_{l+1} - φ_l = 60° = π/3 for all l.
     """
     expected_diff = TAU / 6  # 60°
-    for l in range(5):
-        diff = TONGUE_PHASES[l + 1] - TONGUE_PHASES[l]
+    for lang in range(5):
+        diff = TONGUE_PHASES[lang + 1] - TONGUE_PHASES[lang]
         if abs(diff - expected_diff) > 1e-10:
             return False
     return True

--- a/src/symphonic_cipher/scbe_aethermoore/concept_blocks/sense.py
+++ b/src/symphonic_cipher/scbe_aethermoore/concept_blocks/sense.py
@@ -168,9 +168,9 @@ class MultiDimKalmanFilter:
         K = _mat_mul(_mat_mul(self.P, Ht), S_inv)
         y = _mat_sub(z, _mat_mul(self.H, self.x))
         self.x = _mat_add(self.x, _mat_mul(K, y))
-        I = _mat_identity(self.dim)
+        eye = _mat_identity(self.dim)
         KH = _mat_mul(K, self.H)
-        self.P = _mat_mul(_mat_sub(I, KH), self.P)
+        self.P = _mat_mul(_mat_sub(eye, KH), self.P)
         return [row[0] for row in self.x]
 
     def step(self, measurement: List[float]) -> List[float]:

--- a/src/symphonic_cipher/scbe_aethermoore/game/companion.py
+++ b/src/symphonic_cipher/scbe_aethermoore/game/companion.py
@@ -41,7 +41,8 @@ class DerivedCombatStats:
 
 def derive_combat_stats(state: CanonicalState) -> DerivedCombatStats:
     """Derive combat stats from 21D canonical state. Never set directly."""
-    clamp = lambda x: max(0.0, min(100.0, x * 100))
+    def clamp(x):
+        return max(0.0, min(100.0, x * 100))
     return DerivedCombatStats(
         speed=clamp(state.flux),
         insight=clamp(state.coherence_s),

--- a/src/symphonic_cipher/scbe_aethermoore/kyber_orchestrator.py
+++ b/src/symphonic_cipher/scbe_aethermoore/kyber_orchestrator.py
@@ -619,7 +619,8 @@ def run_governance_test(steps: int = 50, verbose: bool = True) -> Dict[str, Any]
         if "QC" in results:
             qc = results["QC"]
             print(
-                f"\n[QC] Quasicrystal: {'✓ VALID' if qc['valid'] else '✗ INVALID'} (crystallinity={qc['crystallinity']:.2f})"
+                f"\n[QC] Quasicrystal: {'✓ VALID' if qc['valid'] else '✗ INVALID'}"
+                f" (crystallinity={qc['crystallinity']:.2f})"
             )
 
         # L13-L14

--- a/src/symphonic_cipher/scbe_aethermoore/layer_13.py
+++ b/src/symphonic_cipher/scbe_aethermoore/layer_13.py
@@ -266,13 +266,13 @@ def compute_composite_risk(
     B = components.behavioral_risk
     d_star = components.d_star
     T = components.time_multi.value
-    I = components.intent_multi.value
+    intent = components.intent_multi.value
 
     # Compute H(d*) per Lemma 13.1
     H = harmonic_H(d_star, harmonic_params)
 
     # Lemma 13.1: Risk' = B × H × T × I
-    risk_prime = B * H * T * I
+    risk_prime = B * H * T * intent
 
     # Property 1: Non-negativity (trivial: all factors ≥ 0)
     assert risk_prime >= 0, "Non-negativity violated"
@@ -305,9 +305,9 @@ def compute_composite_risk(
     # Property 4: Compute gradients for monotonicity verification
     dH_dd = harmonic_derivative(d_star, harmonic_params)
     gradients = {
-        "dRisk_dB": H * T * I,  # > 0
-        "dRisk_dd_star": B * T * I * dH_dd,  # > 0 (via chain rule)
-        "dRisk_dT": B * H * I,  # > 0
+        "dRisk_dB": H * T * intent,  # > 0
+        "dRisk_dd_star": B * T * intent * dH_dd,  # > 0 (via chain rule)
+        "dRisk_dT": B * H * intent,  # > 0
         "dRisk_dI": B * H * T,  # > 0
     }
 
@@ -315,7 +315,7 @@ def compute_composite_risk(
         behavioral_risk=B,
         H=H,
         time_multi=T,
-        intent_multi=I,
+        intent_multi=intent,
         risk_prime=risk_prime,
         risk_normalized=risk_normalized,
         decision=decision,
@@ -324,7 +324,7 @@ def compute_composite_risk(
             "behavioral_risk": B,
             "H_d_star": H,
             "time_multi": T,
-            "intent_multi": I,
+            "intent_multi": intent,
             "d_star": d_star,
         },
         gradients=gradients,

--- a/src/symphonic_cipher/scbe_aethermoore/rosetta/language_graph.py
+++ b/src/symphonic_cipher/scbe_aethermoore/rosetta/language_graph.py
@@ -177,5 +177,5 @@ class LanguageGraph:
             current = related.get(other, 0.0)
             related[other] = max(current, e.strength)
 
-        filtered = [(l, s) for l, s in related.items() if s >= min_strength]
+        filtered = [(lang, s) for lang, s in related.items() if s >= min_strength]
         return sorted(filtered, key=lambda x: x[1], reverse=True)

--- a/src/symphonic_cipher/scbe_aethermoore/rosetta/rosetta_core.py
+++ b/src/symphonic_cipher/scbe_aethermoore/rosetta/rosetta_core.py
@@ -316,7 +316,10 @@ class RosettaStone:
             record = {
                 "id": f"rosetta-cjk-{hashlib.md5(char.encode()).hexdigest()[:6]}",
                 "category": "rosetta-cognate",
-                "instruction": f"What are the readings of the CJK character '{char}' across Chinese, Japanese, and Korean?",
+                "instruction": (
+                    f"What are the readings of the CJK character '{char}'"
+                    " across Chinese, Japanese, and Korean?"
+                ),
                 "response": json.dumps(data, ensure_ascii=False),
                 "metadata": {
                     "source": "scbe_aethermoore",

--- a/src/symphonic_cipher/scbe_aethermoore/sacred_egg_integrator.py
+++ b/src/symphonic_cipher/scbe_aethermoore/sacred_egg_integrator.py
@@ -30,7 +30,10 @@ import dataclasses
 import hashlib
 import json
 import os
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from src.symphonic_cipher.scbe_aethermoore.cli_toolkit import CrossTokenizer
 
 
 def _cli_toolkit():

--- a/src/training/symphonic_governor.py
+++ b/src/training/symphonic_governor.py
@@ -197,7 +197,7 @@ class SymphonicGovernor:
 
     def _compute_deviations(self, x: List[float]) -> List[float]:
         """d_l = |x_l - μ_l| for each of 6 dimensions."""
-        return [abs(x[l] - self.ideal[l]) for l in range(6)]
+        return [abs(x[lang] - self.ideal[lang]) for lang in range(6)]
 
     def _compute_L(self, x: List[float], t: float) -> Tuple[float, List[StringVoice]]:
         """Compute L(x,t) and per-string state.
@@ -208,12 +208,12 @@ class SymphonicGovernor:
         voices: List[StringVoice] = []
         L_total = 0.0
 
-        for l in range(6):
-            w_l = TONGUE_WEIGHTS[l]
-            beta_l = self.betas[l]
-            omega_l = TONGUE_FREQUENCIES[l]
-            phi_l = TONGUE_PHASES[l]
-            d_l = deviations[l]
+        for lang in range(6):
+            w_l = TONGUE_WEIGHTS[lang]
+            beta_l = self.betas[lang]
+            omega_l = TONGUE_FREQUENCIES[lang]
+            phi_l = TONGUE_PHASES[lang]
+            d_l = deviations[lang]
 
             phase_shift = math.sin(omega_l * t + phi_l)
             shifted_d = d_l + 0.1 * phase_shift
@@ -231,8 +231,8 @@ class SymphonicGovernor:
 
             voices.append(
                 StringVoice(
-                    tongue=TONGUES[l],
-                    dimension=DIMENSIONS[l],
+                    tongue=TONGUES[lang],
+                    dimension=DIMENSIONS[lang],
                     weight=w_l,
                     frequency=omega_l,
                     phase=phi_l,


### PR DESCRIPTION
## Summary

- **Fix 2 real bugs**: undefined `CrossTokenizer` name (F821) that would crash at runtime, and unused duplicate variable in causality_axiom.py
- **Fix path traversal vulnerability** in `Basin.deposit/pull/push` — was silently accepting `../` paths, now throws on traversal attempts
- **Add legacy session key cleanup** to Kindle ops.html and test.html — prevents API key leakage from pre-v3 sessionStorage
- **Eliminate 82 Python lint errors** (133 → 51, 62% reduction): E741 ambiguous vars, E731 lambda assignments, E501 long lines, E122/E306/F811 formatting
- **All 5,520 TS tests pass** — 0 failures (fixed 5 pre-existing failures in basin + kindle lane security tests)

## Changes across 48 files

| Category | Count | Details |
|----------|-------|---------|
| F821 undefined name | 2 → 0 | `CrossTokenizer` TYPE_CHECKING import |
| F841 unused variable | 1 → 0 | Remove `raw_fidelity` duplicate |
| E741 ambiguous names | 43 → 0 | `l` → `lang`, `I` → contextual names |
| E731 lambda assigns | 6 → 0 | Convert to `def` in 3 files |
| E501 line too long | 33 → 3 | Black + manual wrapping |
| E122/E306/F811 | 4 → 0 | Formatting fixes |
| Security: path traversal | — | Basin `assertNoTraversal()` guard |
| Security: session keys | — | Legacy `sessionStorage.removeItem()` |

Remaining 51 errors are all E402 (intentional import ordering after sys.path/try-except) + 3 stubborn E501 in string literals.

## Test plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `npm test` — 5,520 pass, 0 fail (was 5,515 pass / 5 fail)
- [x] `py_compile` verification on all edited Python files
- [x] `flake8 --select=F821,F841,E731,E741` — all zero

https://claude.ai/code/session_01Jsw3GaCXo4tkvsBU7oy6R8