### PR TITLE
test(core,errors,rollout,memory,constants): add 84 tests for 6 uncovered modules

### DIFF
--- a/tests/crypto/nonceManager.test.ts
+++ b/tests/crypto/nonceManager.test.ts
@@ -7,7 +7,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { nextNonce, deriveNoncePrefix, resetSessionCounter } from '../../src/crypto/nonceManager.js';
+import {
+  nextNonce,
+  deriveNoncePrefix,
+  resetSessionCounter,
+} from '../../src/crypto/nonceManager.js';
 
 describe('nonceManager', () => {
   describe('nextNonce', () => {

--- a/tests/governance/immutable_laws.test.ts
+++ b/tests/governance/immutable_laws.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { createImmutableLaws, verifyImmutableLawsHash } from '../../src/governance/immutable_laws.js';
+import {
+  createImmutableLaws,
+  verifyImmutableLawsHash,
+} from '../../src/governance/immutable_laws.js';
 
 function samplePayload() {
   return {


### PR DESCRIPTION
## Summary
- **84 new tests** covering 6 previously untested src/ modules
- Fix Prettier formatting in 2 existing test files (`npm run lint` now clean)

### New test coverage:
| Module | Tests | What's covered |
|--------|-------|----------------|
| `src/core/Feistel` | 13 | Encrypt/decrypt roundtrip, determinism, custom round counts, edge cases |
| `src/core/ZBase32` | 12 | Encode/decode roundtrip, invalid input rejection, character set validation |
| `src/errors/` | 22 | Full error hierarchy, JSON serialization, `isSCBEError` type guard, `wrapError` |
| `src/rollout/` | 17 | CanaryManager level progression/soak/rollback, CircuitBreaker state machine |
| `src/memory/` | 8 | QuasicrystalLattice HF load gating, boundary decisions, determinism |
| `src/constants/` | 12 | Config invariants, threshold ordering, PHI golden ratio identity |

## Test plan
- [x] All 84 new tests pass
- [x] Full suite: 5,747 tests pass (up from 5,663), 0 failures
- [x] `npm run build` passes clean
- [x] `npm run lint` passes clean (0 issues)
- [x] `npm run lint:python` passes clean (0 errors)

https://claude.ai/code/session_01NGonjtCNzqtDdLE8wJcxgQ