### PR TITLE
fix(tests): graceful skip guards for broken/missing Python deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3507,13 +3507,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -3649,16 +3642,16 @@
       }
     },
     "node_modules/dependency-tree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.2.0.tgz",
-      "integrity": "sha512-+C1H3mXhcvMCeu5i2Jpg9dc0N29TWTuT6vJD7mHLAfVmAbo9zW8NlkvQ1tYd3PDMab0IRQM0ccoyX68EZtx9xw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.4.0.tgz",
+      "integrity": "sha512-r4wZ1pfv8eQrnoWbIGdrJTVmlb0dkXdwBjKsotKO4gmfqrOsAMG+0+cfA5EZ3NO8umc85twXOl1eO27E5pjTzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
-        "filing-cabinet": "^5.0.3",
+        "filing-cabinet": "^5.2.0",
         "precinct": "^12.2.0",
-        "typescript": "^5.8.3"
+        "typescript": "^5.9.3"
       },
       "bin": {
         "dependency-tree": "bin/cli.js"
@@ -3868,14 +3861,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.4",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -4244,23 +4237,23 @@
       }
     },
     "node_modules/filing-cabinet": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.0.3.tgz",
-      "integrity": "sha512-PlPcMwVWg60NQkhvfoxZs4wEHjhlOO/y7OAm4sKM60o1Z9nttRY4mcdQxp/iZ+kg/Vv6Hw1OAaTbYVM9DA9pYg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.2.0.tgz",
+      "integrity": "sha512-eNrCJGdYQY0tV+ACNesQ7vb2aMxD76NM7THayMn0Z5XBt1Tonr4vbVN+FbhHfekKGQG9O5UaciDDR7+dw8P9ZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "app-module-path": "^2.2.0",
         "commander": "^12.1.0",
-        "enhanced-resolve": "^5.18.0",
+        "enhanced-resolve": "^5.20.0",
         "module-definition": "^6.0.1",
-        "module-lookup-amd": "^9.0.3",
-        "resolve": "^1.22.10",
+        "module-lookup-amd": "^9.1.1",
+        "resolve": "^1.22.11",
         "resolve-dependency-path": "^4.0.1",
         "sass-lookup": "^6.1.0",
         "stylus-lookup": "^6.1.0",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.7.3"
+        "typescript": "^5.9.3"
       },
       "bin": {
         "filing-cabinet": "bin/cli.js"
@@ -4330,13 +4323,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4618,18 +4604,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -5512,15 +5486,14 @@
       }
     },
     "node_modules/module-lookup-amd": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.0.5.tgz",
-      "integrity": "sha512-Rs5FVpVcBYRHPLuhHOjgbRhosaQYLtEo3JIeDIbmNo7mSssi1CTzwMh8v36gAzpbzLGXI9wB/yHh+5+3fY1QVw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.1.1.tgz",
+      "integrity": "sha512-JzXhQvud8K3yT9l24XTDMXMQ4/LD9a9oXBcbLP0ubdvBpVrGFsybm5+2PDIl0negUYP1l88fCgjQzoMMg247+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
-        "glob": "^7.2.3",
-        "requirejs": "^2.3.7",
+        "requirejs": "^2.3.8",
         "requirejs-config-file": "^4.0.0"
       },
       "bin": {
@@ -5528,17 +5501,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/module-lookup-amd/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/module-lookup-amd/node_modules/commander": {
@@ -5549,41 +5511,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/module-lookup-amd/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/module-lookup-amd/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -5788,16 +5715,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -6394,14 +6311,14 @@
       "license": "MIT"
     },
     "node_modules/sass-lookup": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-6.1.0.tgz",
-      "integrity": "sha512-Zx+lVyoWqXZxHuYWlTA17Z5sczJ6braNT2C7rmClw+c4E7r/n911Zwss3h1uHI9reR5AgHZyNHF7c2+VIp5AUA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-6.1.1.tgz",
+      "integrity": "sha512-12dvZdQYTeKZ1ypjuiijZYuMZ1m0F+4+BkRX5yJi2WA9W3DBUrcdCt7bVuKlagHl11n8eYtalWDle+m98Ol2DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
-        "enhanced-resolve": "^5.18.0"
+        "enhanced-resolve": "^5.20.0"
       },
       "bin": {
         "sass-lookup": "bin/cli.js"
@@ -6771,9 +6688,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6993,9 +6910,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/tests/api/test_billing_public_checkout.py
+++ b/tests/api/test_billing_public_checkout.py
@@ -1,3 +1,10 @@
+import pytest
+
+try:
+    import stripe  # noqa: F401
+except ImportError:
+    pytest.skip("stripe not installed", allow_module_level=True)
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/tests/api/test_github_app_routes.py
+++ b/tests/api/test_github_app_routes.py
@@ -2,6 +2,13 @@ import hashlib
 import hmac
 import json
 
+import pytest
+
+try:
+    from cryptography.fernet import Fernet  # noqa: F401
+except BaseException:
+    pytest.skip("cryptography package not functional (cffi backend missing)", allow_module_level=True)
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/tests/crypto/test_dual_lattice_integration.py
+++ b/tests/crypto/test_dual_lattice_integration.py
@@ -14,9 +14,18 @@ Tests cover all 14 layers of the integration:
 """
 
 import pytest
-import numpy as np
 import sys
 import os
+
+try:
+    import numpy as np
+except ImportError:
+    pytest.skip("numpy not installed", allow_module_level=True)
+
+try:
+    import scipy  # noqa: F401
+except ImportError:
+    pytest.skip("scipy not installed", allow_module_level=True)
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))

--- a/tests/hydra/test_tenreary.py
+++ b/tests/hydra/test_tenreary.py
@@ -1,5 +1,12 @@
 import asyncio
 
+import pytest
+
+try:
+    from cryptography.fernet import Fernet  # noqa: F401
+except BaseException:
+    pytest.skip("cryptography package not functional (cffi backend missing)", allow_module_level=True)
+
 from hydra.tenreary import MCPTenreary, MCPTenrearyRunner
 
 

--- a/tests/test_aetherbrowser_live_smoke.py
+++ b/tests/test_aetherbrowser_live_smoke.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
+try:
+    import websockets  # noqa: F401
+except ImportError:
+    pytest.skip("websockets not installed", allow_module_level=True)
+
 from scripts.aetherbrowser_live_smoke import (
     summarize_page_flow,
     summarize_research_flow,

--- a/tests/test_colab_n8n_bridge_security.py
+++ b/tests/test_colab_n8n_bridge_security.py
@@ -6,6 +6,13 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
+try:
+    from cryptography.fernet import Fernet  # noqa: F401
+except BaseException:
+    pytest.skip("cryptography package not functional (cffi backend missing)", allow_module_level=True)
+
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:

--- a/tests/test_decision_envelope_v1.py
+++ b/tests/test_decision_envelope_v1.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import hashlib
 
+import pytest
+
+try:
+    import google.protobuf  # noqa: F401
+except ImportError:
+    pytest.skip("google.protobuf not installed", allow_module_level=True)
+
 from src.governance.decision_envelope_v1 import AUTO_ALLOW
 from src.governance.decision_envelope_v1 import CRITICAL
 from src.governance.decision_envelope_v1 import DENY

--- a/tests/test_industry_grade.py
+++ b/tests/test_industry_grade.py
@@ -35,10 +35,15 @@ from dataclasses import dataclass
 from enum import Enum
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+import pytest
+
+try:
+    from cryptography.fernet import Fernet  # noqa: F401
+except BaseException:
+    pytest.skip("cryptography package not functional (cffi backend missing)", allow_module_level=True)
+
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-
-import pytest
 
 # Import SpiralSeal components
 from symphonic_cipher.scbe_aethermoore.spiral_seal import (

--- a/tests/test_scbe_comprehensive.py
+++ b/tests/test_scbe_comprehensive.py
@@ -24,10 +24,16 @@ import hashlib
 import time
 import math
 
+import pytest
+
+try:
+    from cryptography.fernet import Fernet  # noqa: F401
+except BaseException:
+    pytest.skip("cryptography package not functional (cffi backend missing)", allow_module_level=True)
+
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-import pytest
 import numpy as np
 
 # Import SpiralSeal components

--- a/tests/test_sensitive_output_redaction.py
+++ b/tests/test_sensitive_output_redaction.py
@@ -6,6 +6,13 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
+try:
+    from cryptography.fernet import Fernet  # noqa: F401
+except BaseException:
+    pytest.skip("cryptography package not functional (cffi backend missing)", allow_module_level=True)
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:

--- a/tests/test_spiral_seal_comprehensive.py
+++ b/tests/test_spiral_seal_comprehensive.py
@@ -19,9 +19,14 @@ import time
 import hashlib
 import secrets
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-
 import pytest
+
+try:
+    from cryptography.fernet import Fernet  # noqa: F401
+except BaseException:
+    pytest.skip("cryptography package not functional (cffi backend missing)", allow_module_level=True)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from hypothesis import given, strategies as st, settings, assume
 
 from symphonic_cipher.scbe_aethermoore.spiral_seal import (

--- a/tests/test_system_script_security.py
+++ b/tests/test_system_script_security.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 import pytest
 
+try:
+    from cryptography.fernet import Fernet  # noqa: F401
+except BaseException:
+    pytest.skip("cryptography package not functional (cffi backend missing)", allow_module_level=True)
+
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:

--- a/tests/test_verify_aetherbrowser_extension_service.py
+++ b/tests/test_verify_aetherbrowser_extension_service.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
+try:
+    import websockets  # noqa: F401
+except ImportError:
+    pytest.skip("websockets not installed", allow_module_level=True)
+
 from scripts.verify_aetherbrowser_extension_service import build_service_report, classify_cdp_targets
 
 


### PR DESCRIPTION
## Summary

- **#676**: Add `except BaseException` guards in 8 test files that crash on `pyo3_runtime.PanicException` when `_cffi_backend` is missing from the `cryptography` package. `PanicException` inherits from `BaseException`, not `Exception`, so standard exception handlers miss it.
- **#677**: Add `pytest.importorskip()`-style guards in 5 test files for missing optional deps (`websockets`, `google.protobuf`, `stripe`, `numpy`, `scipy`). Tests now gracefully skip instead of crashing collection.
- **#678**: Update `dependency-tree` transitive deps (11.2.0 → 11.4.0) which pulls `filing-cabinet@5.2.0` → `module-lookup-amd@9.1.1` (no glob dependency). Eliminates deprecated `glob@7` and memory-leaking `inflight@1` entirely.

**Result**: pytest collection errors reduced from 30+ to 22 (remaining are pre-existing unrelated issues). `npm ls glob` now shows only `glob@13` (via rimraf).

## Test plan

- [x] `python3 -m pytest --collect-only` on all 13 affected test files — all skip gracefully
- [x] `npm ls glob` confirms no glob@7 or inflight in dependency tree
- [x] Full `pytest tests/ --collect-only` passes with 4495 tests collected, 22 pre-existing errors (down from 30+)

Closes #676, closes #677, closes #678

https://claude.ai/code/session_01VQ74F5mRmQG33jSamL8iyS