### PR TITLE
fix(types): resolve TS 5.8 Uint8Array BufferSource incompatibility

### DIFF
--- a/packages/kernel/src/sacredEggs.ts
+++ b/packages/kernel/src/sacredEggs.ts
@@ -366,7 +366,7 @@ export async function predicateCrypto(
     const key = await deriveKey(state.sharedSecret, egg, state);
 
     // Import key for AES-GCM
-    const aesKey = await crypto.subtle.importKey('raw', key, { name: 'AES-GCM' }, false, [
+    const aesKey = await crypto.subtle.importKey('raw', key as ArrayBuffer, { name: 'AES-GCM' }, false, [
       'decrypt',
     ]);
 
@@ -378,7 +378,7 @@ export async function predicateCrypto(
         tagLength: 128,
       },
       aesKey,
-      egg.ciphertext
+      egg.ciphertext as ArrayBuffer
     );
 
     return new Uint8Array(plaintext);
@@ -490,7 +490,7 @@ export async function createEgg(
   const key = await deriveKey(sharedSecret, partialEgg, expectedState);
 
   // Import key for AES-GCM
-  const aesKey = await crypto.subtle.importKey('raw', key, { name: 'AES-GCM' }, false, ['encrypt']);
+  const aesKey = await crypto.subtle.importKey('raw', key as ArrayBuffer, { name: 'AES-GCM' }, false, ['encrypt']);
 
   // Encrypt
   const ciphertext = await crypto.subtle.encrypt(
@@ -500,7 +500,7 @@ export async function createEgg(
       tagLength: 128,
     },
     aesKey,
-    plaintext
+    plaintext as ArrayBuffer
   );
 
   partialEgg.ciphertext = new Uint8Array(ciphertext);

--- a/src/crypto/platform.ts
+++ b/src/crypto/platform.ts
@@ -196,7 +196,7 @@ export async function platformSHA256Async(data: string | Uint8Array): Promise<st
     typeof globalThis.crypto !== 'undefined' &&
     typeof globalThis.crypto.subtle !== 'undefined'
   ) {
-    const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+    const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', bytes as ArrayBuffer);
     return Array.from(new Uint8Array(hashBuffer))
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('');

--- a/src/governance/offline_mode.ts
+++ b/src/governance/offline_mode.ts
@@ -366,7 +366,7 @@ export class AuditLedger {
       const recomputed = PQCrypto.hash(concatBytes(expected_prev, evt.event_data));
       if (!bytesEqual(recomputed, evt.event_hash)) return false;
       if (!PQCrypto.verify(signerPublicKey, evt.event_hash, evt.signature)) return false;
-      expected_prev = evt.event_hash;
+      expected_prev = new Uint8Array(evt.event_hash);
     }
     return true;
   }


### PR DESCRIPTION
## Summary
- Cast `Uint8Array` to `ArrayBuffer` at Web Crypto API call sites in `sacredEggs.ts`, `platform.ts`, and `offline_mode.ts`
- Fixes CI typecheck failure caused by TypeScript 5.8's stricter `Uint8Array<ArrayBufferLike>` vs `BufferSource` typing

## Test plan
- [x] `npx tsc --noEmit` passes locally with zero errors
- [ ] CI SCBE Gates pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)