### PR TITLE
fix(build): resolve TS 5.8 type errors and fix CI workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,6 @@ jobs:
         include:
         - language: actions
           build-mode: none
-        - language: java-kotlin
-          build-mode: none # This mode only analyzes Java. Set this to 'autobuild' or 'manual' to analyze Kotlin too.
         - language: javascript-typescript
           build-mode: none
         - language: python

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -30,23 +30,35 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Install ESLint
         run: |
           npm install eslint@8.10.0
           npm install @microsoft/eslint-formatter-sarif@3.1.0
+          npm install @typescript-eslint/parser@5 @typescript-eslint/eslint-plugin@5
 
       - name: Run ESLint
         env:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
-        run: npx eslint .
-          --config .eslintrc.js
-          --ext .js,.jsx,.ts,.tsx
-          --format @microsoft/eslint-formatter-sarif
-          --output-file eslint-results.sarif
+        run: |
+          npx eslint . \
+            --no-eslintrc \
+            --parser @typescript-eslint/parser \
+            --plugin @typescript-eslint \
+            --ext .js,.jsx,.ts,.tsx \
+            --rule '{"no-unused-vars": "off", "@typescript-eslint/no-unused-vars": "warn"}' \
+            --format @microsoft/eslint-formatter-sarif \
+            --output-file eslint-results.sarif \
+            --ignore-pattern "node_modules" \
+            --ignore-pattern "dist"
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true

--- a/packages/kernel/src/sacredEggs.ts
+++ b/packages/kernel/src/sacredEggs.ts
@@ -366,7 +366,7 @@ export async function predicateCrypto(
     const key = await deriveKey(state.sharedSecret, egg, state);
 
     // Import key for AES-GCM
-    const aesKey = await crypto.subtle.importKey('raw', key as ArrayBuffer, { name: 'AES-GCM' }, false, [
+    const aesKey = await crypto.subtle.importKey('raw', new Uint8Array(key).buffer, { name: 'AES-GCM' }, false, [
       'decrypt',
     ]);
 
@@ -378,7 +378,7 @@ export async function predicateCrypto(
         tagLength: 128,
       },
       aesKey,
-      egg.ciphertext as ArrayBuffer
+      new Uint8Array(egg.ciphertext).buffer
     );
 
     return new Uint8Array(plaintext);
@@ -490,7 +490,9 @@ export async function createEgg(
   const key = await deriveKey(sharedSecret, partialEgg, expectedState);
 
   // Import key for AES-GCM
-  const aesKey = await crypto.subtle.importKey('raw', key as ArrayBuffer, { name: 'AES-GCM' }, false, ['encrypt']);
+  const aesKey = await crypto.subtle.importKey('raw', new Uint8Array(key).buffer, { name: 'AES-GCM' }, false, [
+    'encrypt',
+  ]);
 
   // Encrypt
   const ciphertext = await crypto.subtle.encrypt(
@@ -500,7 +502,7 @@ export async function createEgg(
       tagLength: 128,
     },
     aesKey,
-    plaintext as ArrayBuffer
+    new Uint8Array(plaintext).buffer
   );
 
   partialEgg.ciphertext = new Uint8Array(ciphertext);

--- a/src/crypto/platform.ts
+++ b/src/crypto/platform.ts
@@ -196,7 +196,10 @@ export async function platformSHA256Async(data: string | Uint8Array): Promise<st
     typeof globalThis.crypto !== 'undefined' &&
     typeof globalThis.crypto.subtle !== 'undefined'
   ) {
-    const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', bytes as ArrayBuffer);
+    const hashBuffer = await globalThis.crypto.subtle.digest(
+      'SHA-256',
+      new Uint8Array(bytes).buffer
+    );
     return Array.from(new Uint8Array(hashBuffer))
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('');


### PR DESCRIPTION
## Summary\n- Fix 5 remaining `Uint8Array<ArrayBufferLike>` to `ArrayBuffer` cast errors in `packages/kernel/src/sacredEggs.ts` (4 errors) and `src/crypto/platform.ts` (1 error) — same `.buffer` pattern used in #683\n- Fix `eslint.yml`: replace reference to nonexistent `.eslintrc.js` with inline `--no-eslintrc` config, add `setup-node` step, upgrade `upload-sarif` from v3 to v4\n- Fix `codeql.yml`: remove `java-kotlin` language from matrix (not used in this project)\n\n## Details\n\n**Build errors** — TypeScript 5.8 made `Uint8Array` and `ArrayBuffer` types stricter. The Web Crypto API expects `ArrayBuffer`, so we use `new Uint8Array(data).buffer` to safely extract it.\n\n**eslint.yml** — The workflow referenced `.eslintrc.js` which doesn't exist in the repo. Fixed to use `--no-eslintrc` with inline parser/plugin config so it's self-contained.\n\n**codeql.yml** — Removed `java-kotlin` from the analysis matrix since this is a TypeScript/Python/Rust project.\n\n## Test plan\n- [x] `npm run build` — 0 errors\n- [x] `npm run lint` — clean\n- [x] `npm test` — 5663 passed, 0 failures\n- [ ] CI pipeline green\n\nhttps://claude.ai/code/session_01YU4Zd9LdiNk7hgGUyZ4zd1