### PR TITLE
feat(harmonic): export sheaf cohomology convenience API + fix selfHealing types

### DIFF
--- a/src/harmonic/sheafCohomology.ts
+++ b/src/harmonic/sheafCohomology.ts
@@ -1451,3 +1451,456 @@ export class SheafCohomologyEngine {
  * Default sheaf cohomology engine with standard configuration.
  */
 export const defaultSheafEngine = new SheafCohomologyEngine();
+
+// ═══════════════════════════════════════════════════════════════
+// Convenience API — String-based lattices, builders, and helpers
+// ═══════════════════════════════════════════════════════════════
+
+/** String-based risk decision type matching Layer 13 tiers */
+export type RiskDecision = 'ALLOW' | 'QUARANTINE' | 'ESCALATE' | 'DENY';
+
+/** Sacred Tongues governance tier */
+export type GovernanceTier = 'KO' | 'AV' | 'RU' | 'CA' | 'UM' | 'DR';
+
+/** Dimensional state for fleet/polly-pads */
+export type DimensionalState = 'COLLAPSED' | 'DEMI' | 'QUASI' | 'POLLY';
+
+/**
+ * Convenience lattice interface: uses properties instead of methods for
+ * top/bot/elements, and adds meetAll/joinAll helpers.
+ */
+export interface ConvenienceLattice<T> {
+  readonly top: T;
+  readonly bot: T;
+  readonly elements: readonly T[];
+  leq(a: T, b: T): boolean;
+  eq(a: T, b: T): boolean;
+  meet(a: T, b: T): T;
+  join(a: T, b: T): T;
+  meetAll(xs: T[]): T;
+  joinAll(xs: T[]): T;
+}
+
+function buildOrderedLattice<T>(elems: readonly T[]): ConvenienceLattice<T> {
+  return {
+    elements: elems,
+    top: elems[elems.length - 1],
+    bot: elems[0],
+    leq: (a, b) => elems.indexOf(a) <= elems.indexOf(b),
+    eq: (a, b) => a === b,
+    meet: (a, b) => (elems.indexOf(a) <= elems.indexOf(b) ? a : b),
+    join: (a, b) => (elems.indexOf(a) >= elems.indexOf(b) ? a : b),
+    meetAll(xs: T[]): T {
+      if (xs.length === 0) return this.top;
+      return xs.reduce((acc, x) => this.meet(acc, x), this.top);
+    },
+    joinAll(xs: T[]): T {
+      if (xs.length === 0) return this.bot;
+      return xs.reduce((acc, x) => this.join(acc, x), this.bot);
+    },
+  };
+}
+
+/** 4-level risk lattice: ALLOW < QUARANTINE < ESCALATE < DENY */
+export const RiskLattice: ConvenienceLattice<RiskDecision> = buildOrderedLattice<RiskDecision>([
+  'ALLOW',
+  'QUARANTINE',
+  'ESCALATE',
+  'DENY',
+]);
+
+/** 6-level governance lattice matching the Sacred Tongues: KO < AV < RU < CA < UM < DR */
+export const GovernanceLattice: ConvenienceLattice<GovernanceTier> =
+  buildOrderedLattice<GovernanceTier>(['KO', 'AV', 'RU', 'CA', 'UM', 'DR']);
+
+/** 4-level dimensional state lattice: COLLAPSED < DEMI < QUASI < POLLY */
+export const DimensionalLattice: ConvenienceLattice<DimensionalState> =
+  buildOrderedLattice<DimensionalState>(['COLLAPSED', 'DEMI', 'QUASI', 'POLLY']);
+
+/** Create a unit interval lattice with n evenly spaced points from 0 to 1 */
+export function createUnitIntervalLattice(n: number): ConvenienceLattice<number> {
+  const step = n > 1 ? 1 / (n - 1) : 0;
+  const elems = Array.from({ length: n }, (_, i) => Math.round(i * step * 1e10) / 1e10);
+  return {
+    elements: elems,
+    top: 1,
+    bot: 0,
+    leq: (a, b) => a <= b + 1e-12,
+    eq: (a, b) => Math.abs(a - b) < 1e-12,
+    meet: (a, b) => Math.min(a, b),
+    join: (a, b) => Math.max(a, b),
+    meetAll(xs: number[]): number {
+      if (xs.length === 0) return this.top;
+      return Math.min(...xs);
+    },
+    joinAll(xs: number[]): number {
+      if (xs.length === 0) return this.bot;
+      return Math.max(...xs);
+    },
+  };
+}
+
+// ── Cell complex builder ──
+
+/** Build a CellComplex from vertex ID strings and edge pairs */
+export function buildComplex(vertexIds: string[], edges: [string, string][]): CellComplex {
+  const vertices: CellVertex[] = vertexIds.map((id) => ({ id }));
+  const cellEdges: CellEdge[] = edges.map(([src, tgt], i) => ({
+    id: `e-${src}-${tgt}`,
+    source: src,
+    target: tgt,
+  }));
+  return { vertices, edges: cellEdges };
+}
+
+// ── Sheaf builders ──
+
+interface SimpleSheaf<T> {
+  lattice: ConvenienceLattice<T>;
+  complex: CellComplex;
+  restrict(vertexId: string, edgeId: string, value: T): T;
+  extend(edgeId: string, vertexId: string, value: T): T;
+}
+
+function toV1Lattice<T>(cl: ConvenienceLattice<T>): CompleteLattice<T> {
+  return {
+    top: () => cl.top,
+    bottom: () => cl.bot,
+    meet: (a, b) => cl.meet(a, b),
+    join: (a, b) => cl.join(a, b),
+    leq: (a, b) => cl.leq(a, b),
+    eq: (a, b) => cl.eq(a, b),
+    elements: () => [...cl.elements],
+  };
+}
+
+function toV1Sheaf<T>(simple: SimpleSheaf<T>): CellularSheaf<T, T> {
+  const lat = toV1Lattice(simple.lattice);
+  return {
+    complex: simple.complex,
+    vertexLattice: () => lat,
+    edgeLattice: () => lat,
+    sourceRestriction: (edgeId: string) => ({
+      lower: (v: T) => {
+        const edge = simple.complex.edges.find((e) => e.id === edgeId)!;
+        return simple.restrict(edge.source, edgeId, v);
+      },
+      upper: (e: T) => {
+        const edge = simple.complex.edges.find((ed) => ed.id === edgeId)!;
+        return simple.extend(edgeId, edge.source, e);
+      },
+    }),
+    targetRestriction: (edgeId: string) => ({
+      lower: (v: T) => {
+        const edge = simple.complex.edges.find((e) => e.id === edgeId)!;
+        return simple.restrict(edge.target, edgeId, v);
+      },
+      upper: (e: T) => {
+        const edge = simple.complex.edges.find((ed) => ed.id === edgeId)!;
+        return simple.extend(edgeId, edge.target, e);
+      },
+    }),
+  };
+}
+
+/** Create a constant sheaf (identity restrictions) over a convenience lattice */
+export function convConstantSheaf<T>(
+  lattice: ConvenienceLattice<T>,
+  complex: CellComplex
+): SimpleSheaf<T> {
+  return {
+    lattice,
+    complex,
+    restrict: (_vertexId, _edgeId, value) => value,
+    extend: (_edgeId, _vertexId, value) => value,
+  };
+}
+
+// Re-export constantSheaf to also accept ConvenienceLattice
+export { convConstantSheaf as convenienceConstantSheaf };
+
+/** Create a custom sheaf with per-edge Galois connections */
+export function customSheaf<T>(
+  lattice: ConvenienceLattice<T>,
+  complex: CellComplex,
+  restrictions: Map<string, GaloisConnection<T, T>>
+): SimpleSheaf<T> {
+  return {
+    lattice,
+    complex,
+    restrict: (vertexId, edgeId, value) => {
+      const conn = restrictions.get(edgeId);
+      return conn ? conn.lower(value) : value;
+    },
+    extend: (edgeId, _vertexId, value) => {
+      const conn = restrictions.get(edgeId);
+      return conn ? conn.upper(value) : value;
+    },
+  };
+}
+
+/** Create a Galois connection from explicit lower/upper map functions */
+export function galoisFromMaps<S, T>(
+  lower: (s: S) => T,
+  upper: (t: T) => S
+): GaloisConnection<S, T> {
+  return { lower, upper };
+}
+
+// ── Cochain helpers ──
+
+/** Create a 0-cochain from a record of vertex values */
+export function cochain0<T>(record: Record<string, T>): Cochain0<T> {
+  return new Map(Object.entries(record));
+}
+
+/** Create a constant 0-cochain assigning the same value to every vertex */
+export function constantCochain0<T>(complex: CellComplex, value: T): Cochain0<T> {
+  const m = new Map<string, T>();
+  for (const v of complex.vertices) m.set(v.id, value);
+  return m;
+}
+
+/** Create a 0-cochain with ⊤ at every vertex */
+export function topCochain0<T>(sheaf: SimpleSheaf<T>): Cochain0<T> {
+  return constantCochain0(sheaf.complex, sheaf.lattice.top);
+}
+
+// ── Operators ──
+
+/** Convenience tarskiLaplacian0 that works with SimpleSheaf */
+function convTarskiLaplacian0<T>(sheaf: SimpleSheaf<T>, x: Cochain0<T>): Cochain0<T> {
+  return tarskiLaplacian0(toV1Sheaf(sheaf), x);
+}
+
+/** Harmonic step: Φ(x) = x ∧ L₀(x) (pointwise meet of identity and Laplacian) */
+export function harmonicStep0<T>(sheaf: SimpleSheaf<T>, x: Cochain0<T>): Cochain0<T> {
+  const lx = convTarskiLaplacian0(sheaf, x);
+  const result = new Map<string, T>();
+  for (const v of sheaf.complex.vertices) {
+    const xv = x.get(v.id) ?? sheaf.lattice.bot;
+    const lxv = lx.get(v.id) ?? sheaf.lattice.bot;
+    result.set(v.id, sheaf.lattice.meet(xv, lxv));
+  }
+  return result;
+}
+
+interface HarmonicFlowResult<T> {
+  converged: boolean;
+  iterations: number;
+  fixedPoint: Cochain0<T>;
+}
+
+/** Iterate Φ = id ∧ L₀ until convergence (Tarski fixed-point) */
+export function harmonicFlow<T>(
+  sheaf: SimpleSheaf<T>,
+  initial: Cochain0<T>,
+  maxIter: number = 100
+): HarmonicFlowResult<T> {
+  let current = initial;
+  for (let i = 1; i <= maxIter; i++) {
+    const next = harmonicStep0(sheaf, current);
+    let changed = false;
+    for (const v of sheaf.complex.vertices) {
+      if (
+        !sheaf.lattice.eq(
+          current.get(v.id) ?? sheaf.lattice.bot,
+          next.get(v.id) ?? sheaf.lattice.bot
+        )
+      ) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) return { converged: true, iterations: i, fixedPoint: current };
+    current = next;
+  }
+  return { converged: false, iterations: maxIter, fixedPoint: current };
+}
+
+/** TH⁰: start from ⊤ cochain and flow to fixed point */
+function convTarskiCohomology0<T>(sheaf: SimpleSheaf<T>): HarmonicFlowResult<T> {
+  const top = topCochain0(sheaf);
+  return harmonicFlow(sheaf, top);
+}
+
+/** Pseudo-coboundary δ₀: maps 0-cochain to 1-cochain (edge values) via meet of restricted endpoints */
+function convPseudoCoboundary<T>(sheaf: SimpleSheaf<T>, x: Cochain0<T>): Map<string, T> {
+  const result = new Map<string, T>();
+  for (const edge of sheaf.complex.edges) {
+    const sv = x.get(edge.source) ?? sheaf.lattice.bot;
+    const tv = x.get(edge.target) ?? sheaf.lattice.bot;
+    const svr = sheaf.restrict(edge.source, edge.id, sv);
+    const tvr = sheaf.restrict(edge.target, edge.id, tv);
+    result.set(edge.id, sheaf.lattice.meet(svr, tvr));
+  }
+  return result;
+}
+
+/** 1-Laplacian on edge cochains */
+function convTarskiLaplacian1<T>(sheaf: SimpleSheaf<T>, y: Map<string, T>): Map<string, T> {
+  const result = new Map<string, T>();
+  for (const edge of sheaf.complex.edges) {
+    // For each edge, look at cofaces (faces sharing a vertex)
+    const neighbors = sheaf.complex.edges.filter(
+      (e2) =>
+        e2.id !== edge.id &&
+        (e2.source === edge.source ||
+          e2.source === edge.target ||
+          e2.target === edge.source ||
+          e2.target === edge.target)
+    );
+    if (neighbors.length === 0) {
+      result.set(edge.id, sheaf.lattice.top);
+    } else {
+      let acc = sheaf.lattice.top;
+      for (const nb of neighbors) {
+        acc = sheaf.lattice.meet(acc, y.get(nb.id) ?? sheaf.lattice.bot);
+      }
+      result.set(edge.id, acc);
+    }
+  }
+  return result;
+}
+
+/** TH¹: cohomology on 1-cochains */
+function convTarskiCohomology1<T>(sheaf: SimpleSheaf<T>): HarmonicFlowResult<T> {
+  // Start from ⊤ on all edges
+  let current = new Map<string, T>();
+  for (const edge of sheaf.complex.edges) current.set(edge.id, sheaf.lattice.top);
+
+  for (let i = 1; i <= 100; i++) {
+    const lx = convTarskiLaplacian1(sheaf, current);
+    const next = new Map<string, T>();
+    for (const edge of sheaf.complex.edges) {
+      const cv = current.get(edge.id) ?? sheaf.lattice.bot;
+      const lv = lx.get(edge.id) ?? sheaf.lattice.bot;
+      next.set(edge.id, sheaf.lattice.meet(cv, lv));
+    }
+    let changed = false;
+    for (const edge of sheaf.complex.edges) {
+      if (!sheaf.lattice.eq(current.get(edge.id)!, next.get(edge.id)!)) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) return { converged: true, iterations: i, fixedPoint: current };
+    current = next;
+  }
+  return { converged: false, iterations: 100, fixedPoint: current };
+}
+
+// ── Consensus analysis ──
+
+interface ConsensusAnalysis<T> {
+  hasConsensus: boolean;
+  isUnanimous: boolean;
+  unanimousValue?: T;
+  distinctValues: number;
+  disagreementEdges: string[];
+  consensusValues: Record<string, T>;
+  iterations: number;
+  obstructionDegree: number;
+}
+
+/** Analyze consensus on a sheaf by running harmonic flow from the given opinions */
+export function analyzeConsensus<T>(
+  sheaf: SimpleSheaf<T>,
+  opinions: Cochain0<T>
+): ConsensusAnalysis<T> {
+  const flow = harmonicFlow(sheaf, opinions);
+  const fp = flow.fixedPoint;
+
+  const values = new Set<string>();
+  const consensusValues: Record<string, T> = {};
+  for (const v of sheaf.complex.vertices) {
+    const val = fp.get(v.id)!;
+    values.add(String(val));
+    consensusValues[v.id] = val;
+  }
+
+  const isUnanimous = values.size === 1;
+  const unanimousValue = isUnanimous ? fp.get(sheaf.complex.vertices[0]?.id)! : undefined;
+
+  // Find disagreement edges (where endpoints differ after flow)
+  const disagreementEdges: string[] = [];
+  for (const edge of sheaf.complex.edges) {
+    const sv = fp.get(edge.source);
+    const tv = fp.get(edge.target);
+    if (sv !== undefined && tv !== undefined && !sheaf.lattice.eq(sv, tv)) {
+      disagreementEdges.push(edge.id);
+    }
+  }
+
+  // Compute obstruction via TH¹
+  const th1 = convTarskiCohomology1(sheaf);
+  let obstructionDegree = 0;
+  for (const edge of sheaf.complex.edges) {
+    const val = th1.fixedPoint.get(edge.id);
+    if (val !== undefined && !sheaf.lattice.eq(val, sheaf.lattice.bot)) {
+      obstructionDegree++;
+    }
+  }
+
+  return {
+    hasConsensus: flow.converged,
+    isUnanimous,
+    unanimousValue,
+    distinctValues: values.size,
+    disagreementEdges,
+    consensusValues,
+    iterations: flow.iterations,
+    obstructionDegree,
+  };
+}
+
+/** Build a risk consensus sheaf from agent IDs and communication edges */
+export function riskConsensusSheaf(
+  agentIds: string[],
+  edges: [string, string][]
+): SimpleSheaf<RiskDecision> {
+  return convConstantSheaf(RiskLattice, buildComplex(agentIds, edges));
+}
+
+/** Build a governance consensus sheaf */
+export function governanceConsensusSheaf(
+  agentIds: string[],
+  edges: [string, string][]
+): SimpleSheaf<GovernanceTier> {
+  return convConstantSheaf(GovernanceLattice, buildComplex(agentIds, edges));
+}
+
+/** High-level risk consensus: build sheaf, run flow, analyze */
+export function riskConsensus(
+  agentIds: string[],
+  edges: [string, string][],
+  opinions: Record<string, RiskDecision>
+): ConsensusAnalysis<RiskDecision> {
+  const sheaf = riskConsensusSheaf(agentIds, edges);
+  return analyzeConsensus(sheaf, cochain0(opinions));
+}
+
+/** Format a consensus analysis as a human-readable summary string */
+export function consensusSummary<T>(analysis: ConsensusAnalysis<T>): string {
+  const lines: string[] = [];
+  lines.push(`Consensus: ${analysis.hasConsensus ? 'YES' : 'NO'}`);
+  lines.push(
+    `Unanimous: ${analysis.isUnanimous ? 'YES' : 'NO'}${analysis.unanimousValue !== undefined ? ` (${analysis.unanimousValue})` : ''}`
+  );
+  lines.push(`Distinct values: ${analysis.distinctValues}`);
+  lines.push(`Iterations: ${analysis.iterations}`);
+  lines.push(`Obstruction (TH^1): ${analysis.obstructionDegree}`);
+  if (analysis.disagreementEdges.length > 0) {
+    lines.push(`Disagreement edges: ${analysis.disagreementEdges.join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+// Re-export the convenience wrappers under the names the tests expect
+export {
+  convTarskiLaplacian0 as convLaplacian0,
+  convTarskiCohomology0 as tarskiCohomology0,
+  convPseudoCoboundary as pseudoCoboundary,
+  convTarskiLaplacian1 as tarskiLaplacian1,
+  convTarskiCohomology1 as tarskiCohomology1,
+};

--- a/src/selfHealing/coordinator.ts
+++ b/src/selfHealing/coordinator.ts
@@ -1,14 +1,15 @@
 import { QuickFixBot } from './quickFixBot.js';
 import { DeepHealing } from './deepHealing.js';
+import { Failure } from './types.js';
 
 export class HealingCoordinator {
   private quick = new QuickFixBot();
   private deep = new DeepHealing();
 
-  async handleFailure(failure: any) {
+  async handleFailure(failure: Failure) {
     const quick = await this.quick.attemptFix(failure);
     const deep = await this.deep.diagnose(failure);
     // Coordination policy: prefer deep when available; cherry-pick quick successes
-    return { quick, deep, decision: 'prefer_deep_if_ready' };
+    return { quick, deep, decision: 'prefer_deep_if_ready' as const };
   }
 }

--- a/src/selfHealing/deepHealing.ts
+++ b/src/selfHealing/deepHealing.ts
@@ -1,5 +1,7 @@
+import { Failure } from './types.js';
+
 export class DeepHealing {
-  async diagnose(failure: any) {
+  async diagnose(failure: Failure) {
     // Multi-agent roundtable placeholder
     const approaches = ['refactor_logic', 'rewrite_integration', 'add_idempotency'];
     return { plan: approaches, branch: `fix/deep-${Math.random().toString(36).slice(2, 10)}` };

--- a/src/selfHealing/quickFixBot.ts
+++ b/src/selfHealing/quickFixBot.ts
@@ -1,5 +1,7 @@
+import { Failure } from './types.js';
+
 export class QuickFixBot {
-  async attemptFix(failure: any) {
+  async attemptFix(failure: Failure) {
     // Heuristics: increase retry, adjust params, flip fallback
     const actions = ['increase_retry', 'adjust_timeout', 'enable_fallback'];
     return { success: false, actions, branch: `hotfix/quick-${Date.now()}` };

--- a/src/selfHealing/types.ts
+++ b/src/selfHealing/types.ts
@@ -1,0 +1,23 @@
+/**
+ * @file types.ts
+ * @module selfHealing/types
+ * @component Self-Healing type definitions
+ */
+
+/** Structured failure information for self-healing diagnostics */
+export interface Failure {
+  /** Failure category (e.g., 'runtime', 'network', 'governance', 'crypto') */
+  type: string;
+  /** Human-readable error message */
+  message: string;
+  /** Stack trace, if available */
+  stack?: string;
+  /** Additional context for diagnostics */
+  context?: Record<string, unknown>;
+  /** Timestamp of failure occurrence */
+  timestamp?: number;
+  /** Layer where the failure originated (1-14) */
+  layer?: number;
+  /** Severity: how critical the failure is */
+  severity?: 'low' | 'medium' | 'high' | 'critical';
+}

--- a/tests/L2-unit/sheafCohomology.unit.test.ts
+++ b/tests/L2-unit/sheafCohomology.unit.test.ts
@@ -3,22 +3,13 @@
  * @module tests/L2-unit
  * @layer Layer 13, Layer 9-10
  * @component Tarski Sheaf Cohomology Tests
- * @version 1.0.0
+ * @version 2.0.0
  *
  * Tests for cellular sheaf cohomology with Tarski Laplacian, harmonic flow,
  * and consensus analysis over agent network lattices.
- *
- * NOTE: Skipped until the full Tarski sheaf API is exported from sheafCohomology.ts.
- * Many imports (RiskLattice, GovernanceLattice, buildComplex, etc.) reference
- * functions not yet exported from the source module.
  */
 
 import { describe, it, expect } from 'vitest';
-
-describe.skip('Tarski Sheaf Cohomology (pending API exports)', () => {
-  it('placeholder', () => {});
-});
-/*
 import {
   // Lattices
   RiskLattice,
@@ -28,7 +19,7 @@ import {
   // Cell complex
   buildComplex,
   // Sheaf
-  constantSheaf,
+  convConstantSheaf as constantSheaf,
   customSheaf,
   galoisFromMaps,
   identityConnection,
@@ -37,7 +28,7 @@ import {
   constantCochain0,
   topCochain0,
   // Operators
-  tarskiLaplacian0,
+  convLaplacian0 as tarskiLaplacian0,
   harmonicStep0,
   harmonicFlow,
   tarskiCohomology0,
@@ -54,7 +45,7 @@ import {
   type RiskDecision,
   type GovernanceTier,
   type DimensionalState,
-  type CompleteLattice,
+  type ConvenienceLattice,
 } from '../../src/harmonic/sheafCohomology.js';
 
 // =============================================================================
@@ -188,7 +179,13 @@ describe('UnitIntervalLattice', () => {
 
 describe('buildComplex', () => {
   it('builds vertices and edges', () => {
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ]
+    );
     expect(cx.vertices).toHaveLength(3);
     expect(cx.edges).toHaveLength(2);
     expect(cx.edges[0].source).toBe('A');
@@ -220,9 +217,6 @@ describe('GaloisConnection', () => {
   });
 
   it('custom Galois connection with floor/ceiling', () => {
-    // Example: map 4-level risk to 2-level {low, high}
-    // lower: ALLOW/QUARANTINE → 'ALLOW', ESCALATE/DENY → 'DENY'
-    // upper: 'ALLOW' → 'QUARANTINE', 'DENY' → 'DENY'
     const conn = galoisFromMaps<RiskDecision, RiskDecision>(
       (a) => (a === 'ALLOW' || a === 'QUARANTINE' ? 'ALLOW' : 'DENY'),
       (b) => (b === 'ALLOW' ? 'QUARANTINE' : 'DENY')
@@ -285,8 +279,13 @@ describe('cochains', () => {
 
 describe('tarskiLaplacian0', () => {
   it('on constant cochain with constant sheaf = identity', () => {
-    // All same value, identity restrictions → Laplacian preserves it
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ]
+    );
     const sheaf = constantSheaf(RiskLattice, cx);
     const x = constantCochain0(cx, 'ESCALATE' as RiskDecision);
 
@@ -297,9 +296,6 @@ describe('tarskiLaplacian0', () => {
   });
 
   it('on disagreeing cochain, diffuses via meet', () => {
-    // A=DENY, B=ALLOW on edge A-B
-    // L_0(A): edge A-B → restrict(A)=DENY, restrict(B)=ALLOW → meet=ALLOW → extend to A=ALLOW
-    // L_0(B): edge A-B → restrict(A)=DENY, restrict(B)=ALLOW → meet=ALLOW → extend to B=ALLOW
     const cx = buildComplex(['A', 'B'], [['A', 'B']]);
     const sheaf = constantSheaf(RiskLattice, cx);
     const x = cochain0({ A: 'DENY', B: 'ALLOW' } as Record<string, RiskDecision>);
@@ -319,8 +315,14 @@ describe('tarskiLaplacian0', () => {
   });
 
   it('triangle graph: all contribute to center vertex', () => {
-    // Triangle: A-B, B-C, A-C
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C'], ['A', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+        ['A', 'C'],
+      ]
+    );
     const sheaf = constantSheaf(RiskLattice, cx);
     const x = cochain0({
       A: 'DENY',
@@ -329,14 +331,8 @@ describe('tarskiLaplacian0', () => {
     } as Record<string, RiskDecision>);
 
     const lx = tarskiLaplacian0(sheaf, x);
-    // For vertex A: edges A-B (meet DENY,ESCALATE=ESCALATE), A-C (meet DENY,QUARANTINE=QUARANTINE)
-    // → meet of ESCALATE, QUARANTINE = QUARANTINE
     expect(lx.get('A')).toBe('QUARANTINE');
-    // For vertex B: edges A-B (meet DENY,ESCALATE=ESCALATE), B-C (meet ESCALATE,QUARANTINE=QUARANTINE)
-    // → meet of ESCALATE, QUARANTINE = QUARANTINE
     expect(lx.get('B')).toBe('QUARANTINE');
-    // For vertex C: edges A-C (meet DENY,QUARANTINE=QUARANTINE), B-C (meet ESCALATE,QUARANTINE=QUARANTINE)
-    // → meet of QUARANTINE, QUARANTINE = QUARANTINE
     expect(lx.get('C')).toBe('QUARANTINE');
   });
 });
@@ -363,7 +359,6 @@ describe('harmonicStep0', () => {
     const x = topCochain0(sheaf); // A=DENY, B=DENY
 
     const step = harmonicStep0(sheaf, x);
-    // Both get meet(DENY, meet(DENY,DENY)) = meet(DENY,DENY) = DENY
     expect(step.get('A')).toBe('DENY');
     expect(step.get('B')).toBe('DENY');
   });
@@ -375,7 +370,13 @@ describe('harmonicStep0', () => {
 
 describe('harmonicFlow', () => {
   it('converges immediately on constant sheaf with constant cochain', () => {
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ]
+    );
     const sheaf = constantSheaf(RiskLattice, cx);
     const initial = constantCochain0(cx, 'ESCALATE' as RiskDecision);
 
@@ -386,8 +387,13 @@ describe('harmonicFlow', () => {
   });
 
   it('converges to meet on disagreeing path graph', () => {
-    // Path: A - B - C, values DENY, QUARANTINE, ALLOW
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ]
+    );
     const sheaf = constantSheaf(RiskLattice, cx);
     const initial = cochain0({
       A: 'DENY',
@@ -397,8 +403,6 @@ describe('harmonicFlow', () => {
 
     const result = harmonicFlow(sheaf, initial);
     expect(result.converged).toBe(true);
-    // On a constant sheaf, the harmonic flow converges to the global meet
-    // because meet-based diffusion propagates the minimum value
     expect(result.fixedPoint.get('A')).toBe('ALLOW');
     expect(result.fixedPoint.get('B')).toBe('ALLOW');
     expect(result.fixedPoint.get('C')).toBe('ALLOW');
@@ -407,7 +411,11 @@ describe('harmonicFlow', () => {
   it('converges in ≤ |elements| iterations for finite lattice', () => {
     const cx = buildComplex(
       ['A', 'B', 'C', 'D'],
-      [['A', 'B'], ['B', 'C'], ['C', 'D']]
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+        ['C', 'D'],
+      ]
     );
     const sheaf = constantSheaf(RiskLattice, cx);
     const initial = cochain0({
@@ -419,7 +427,6 @@ describe('harmonicFlow', () => {
 
     const result = harmonicFlow(sheaf, initial);
     expect(result.converged).toBe(true);
-    // At most 4 iterations (lattice height)
     expect(result.iterations).toBeLessThanOrEqual(4);
   });
 
@@ -440,24 +447,28 @@ describe('harmonicFlow', () => {
 
 describe('tarskiCohomology0', () => {
   it('TH^0 from ⊤ on connected graph = ⊤ (constant sheaf)', () => {
-    // Constant sheaf: all restrictions are identity, so ⊤ is always a global section
     const cx = buildComplex(['A', 'B'], [['A', 'B']]);
     const sheaf = constantSheaf(RiskLattice, cx);
 
     const th0 = tarskiCohomology0(sheaf);
     expect(th0.converged).toBe(true);
-    // Starting from DENY,DENY with identity restrictions, DENY is a fixed point
     expect(th0.fixedPoint.get('A')).toBe('DENY');
     expect(th0.fixedPoint.get('B')).toBe('DENY');
   });
 
   it('TH^0 equals global sections (consensus)', () => {
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C'], ['A', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+        ['A', 'C'],
+      ]
+    );
     const sheaf = constantSheaf(GovernanceLattice, cx);
 
     const th0 = tarskiCohomology0(sheaf);
     expect(th0.converged).toBe(true);
-    // Constant sheaf starting from DR → all stay DR
     expect(th0.fixedPoint.get('A')).toBe('DR');
     expect(th0.fixedPoint.get('B')).toBe('DR');
     expect(th0.fixedPoint.get('C')).toBe('DR');
@@ -494,7 +505,13 @@ describe('pseudoCoboundary', () => {
 
 describe('tarskiCohomology1', () => {
   it('converges on simple graph', () => {
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ]
+    );
     const sheaf = constantSheaf(RiskLattice, cx);
 
     const th1 = tarskiCohomology1(sheaf);
@@ -502,12 +519,18 @@ describe('tarskiCohomology1', () => {
   });
 
   it('TH^1 on triangle = stable edge values', () => {
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C'], ['A', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+        ['A', 'C'],
+      ]
+    );
     const sheaf = constantSheaf(RiskLattice, cx);
 
     const th1 = tarskiCohomology1(sheaf);
     expect(th1.converged).toBe(true);
-    // All edges should stabilize to DENY (starting from ⊤)
     expect(th1.fixedPoint.get('e-A-B')).toBe('DENY');
     expect(th1.fixedPoint.get('e-B-C')).toBe('DENY');
     expect(th1.fixedPoint.get('e-A-C')).toBe('DENY');
@@ -520,7 +543,13 @@ describe('tarskiCohomology1', () => {
 
 describe('analyzeConsensus', () => {
   it('unanimous agreement detected', () => {
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ]
+    );
     const sheaf = constantSheaf(RiskLattice, cx);
     const opinions = cochain0({
       A: 'ALLOW',
@@ -551,10 +580,14 @@ describe('analyzeConsensus', () => {
   });
 
   it('multi-agent star topology converges', () => {
-    // Star: center C connected to A, B, D, E
     const cx = buildComplex(
       ['C', 'A', 'B', 'D', 'E'],
-      [['C', 'A'], ['C', 'B'], ['C', 'D'], ['C', 'E']]
+      [
+        ['C', 'A'],
+        ['C', 'B'],
+        ['C', 'D'],
+        ['C', 'E'],
+      ]
     );
     const sheaf = constantSheaf(RiskLattice, cx);
     const opinions = cochain0({
@@ -567,14 +600,18 @@ describe('analyzeConsensus', () => {
 
     const analysis = analyzeConsensus(sheaf, opinions);
     expect(analysis.hasConsensus).toBe(true);
-    // The center C is connected to everyone, so the meet propagates everywhere
     expect(analysis.isUnanimous).toBe(true);
-    expect(analysis.unanimousValue).toBe('ALLOW'); // global meet
+    expect(analysis.unanimousValue).toBe('ALLOW');
   });
 
   it('disconnected components have independent consensus', () => {
-    // Two disconnected pairs: A-B and C-D
-    const cx = buildComplex(['A', 'B', 'C', 'D'], [['A', 'B'], ['C', 'D']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C', 'D'],
+      [
+        ['A', 'B'],
+        ['C', 'D'],
+      ]
+    );
     const sheaf = constantSheaf(RiskLattice, cx);
     const opinions = cochain0({
       A: 'DENY',
@@ -589,7 +626,6 @@ describe('analyzeConsensus', () => {
     expect(analysis.consensusValues['B']).toBe('DENY');
     expect(analysis.consensusValues['C']).toBe('ALLOW');
     expect(analysis.consensusValues['D']).toBe('ALLOW');
-    // Not unanimous because components disagree
     expect(analysis.isUnanimous).toBe(false);
     expect(analysis.distinctValues).toBe(2);
   });
@@ -603,7 +639,11 @@ describe('riskConsensus', () => {
   it('3-agent triangle reaches consensus', () => {
     const result = riskConsensus(
       ['agent-1', 'agent-2', 'agent-3'],
-      [['agent-1', 'agent-2'], ['agent-2', 'agent-3'], ['agent-1', 'agent-3']],
+      [
+        ['agent-1', 'agent-2'],
+        ['agent-2', 'agent-3'],
+        ['agent-1', 'agent-3'],
+      ],
       { 'agent-1': 'DENY', 'agent-2': 'ESCALATE', 'agent-3': 'QUARANTINE' }
     );
 
@@ -615,7 +655,10 @@ describe('riskConsensus', () => {
   it('unanimous agents stay unanimous', () => {
     const result = riskConsensus(
       ['A', 'B', 'C'],
-      [['A', 'B'], ['B', 'C']],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ],
       { A: 'ESCALATE', B: 'ESCALATE', C: 'ESCALATE' }
     );
 
@@ -625,11 +668,7 @@ describe('riskConsensus', () => {
   });
 
   it('single-agent consensus is trivial', () => {
-    const result = riskConsensus(
-      ['solo'],
-      [],
-      { solo: 'DENY' }
-    );
+    const result = riskConsensus(['solo'], [], { solo: 'DENY' });
 
     expect(result.hasConsensus).toBe(true);
     expect(result.isUnanimous).toBe(true);
@@ -643,10 +682,7 @@ describe('riskConsensus', () => {
 
 describe('governanceConsensusSheaf', () => {
   it('builds a valid sheaf', () => {
-    const sheaf = governanceConsensusSheaf(
-      ['agent-KO', 'agent-DR'],
-      [['agent-KO', 'agent-DR']]
-    );
+    const sheaf = governanceConsensusSheaf(['agent-KO', 'agent-DR'], [['agent-KO', 'agent-DR']]);
     expect(sheaf.lattice).toBe(GovernanceLattice);
     expect(sheaf.complex.vertices).toHaveLength(2);
   });
@@ -654,7 +690,10 @@ describe('governanceConsensusSheaf', () => {
   it('governance consensus converges to meet of tiers', () => {
     const sheaf = governanceConsensusSheaf(
       ['low', 'mid', 'high'],
-      [['low', 'mid'], ['mid', 'high']]
+      [
+        ['low', 'mid'],
+        ['mid', 'high'],
+      ]
     );
     const opinions = cochain0({
       low: 'KO',
@@ -672,9 +711,10 @@ describe('governanceConsensusSheaf', () => {
 // CUSTOM SHEAF (TWISTED) TESTS
 // =============================================================================
 
+const RISK_ORDER: readonly RiskDecision[] = ['ALLOW', 'QUARANTINE', 'ESCALATE', 'DENY'];
+
 describe('customSheaf with twisted restrictions', () => {
   it('non-identity restriction changes consensus', () => {
-    // Edge A-B with restriction that lowers by one level
     const cx = buildComplex(['A', 'B'], [['A', 'B']]);
     const stepDown = galoisFromMaps<RiskDecision, RiskDecision>(
       (a) => {
@@ -690,19 +730,13 @@ describe('customSheaf with twisted restrictions', () => {
     const restrictions = new Map([['e-A-B', stepDown]]);
     const sheaf = customSheaf(RiskLattice, cx, restrictions);
 
-    // A=ESCALATE, B=ESCALATE
     const x = cochain0({ A: 'ESCALATE', B: 'ESCALATE' } as Record<string, RiskDecision>);
     const lx = tarskiLaplacian0(sheaf, x);
 
-    // Edge A-B: restrict(A)=QUARANTINE, restrict(B)=QUARANTINE → meet=QUARANTINE
-    // extend to A = upper(QUARANTINE) = ESCALATE
-    // extend to B = upper(QUARANTINE) = ESCALATE
     expect(lx.get('A')).toBe('ESCALATE');
     expect(lx.get('B')).toBe('ESCALATE');
   });
 });
-
-const RISK_ORDER: readonly RiskDecision[] = ['ALLOW', 'QUARANTINE', 'ESCALATE', 'DENY'];
 
 // =============================================================================
 // CONSENSUS SUMMARY TESTS
@@ -712,7 +746,10 @@ describe('consensusSummary', () => {
   it('produces readable output', () => {
     const result = riskConsensus(
       ['A', 'B', 'C'],
-      [['A', 'B'], ['B', 'C']],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ],
       { A: 'DENY', B: 'ALLOW', C: 'ESCALATE' }
     );
 
@@ -732,13 +769,18 @@ describe('consensusSummary', () => {
 describe('harmonicFlow with UnitIntervalLattice', () => {
   it('numeric consensus converges', () => {
     const UIL = createUnitIntervalLattice(101);
-    const cx = buildComplex(['A', 'B', 'C'], [['A', 'B'], ['B', 'C']]);
+    const cx = buildComplex(
+      ['A', 'B', 'C'],
+      [
+        ['A', 'B'],
+        ['B', 'C'],
+      ]
+    );
     const sheaf = constantSheaf(UIL, cx);
     const opinions = cochain0({ A: 0.9, B: 0.5, C: 0.1 });
 
     const result = harmonicFlow(sheaf, opinions);
     expect(result.converged).toBe(true);
-    // Should converge to min = 0.1
     expect(result.fixedPoint.get('A')).toBeCloseTo(0.1, 1);
     expect(result.fixedPoint.get('B')).toBeCloseTo(0.1, 1);
     expect(result.fixedPoint.get('C')).toBeCloseTo(0.1, 1);
@@ -756,11 +798,11 @@ describe('edge cases', () => {
     const x = cochain0({ A: 'ESCALATE' } as Record<string, RiskDecision>);
 
     const lx = tarskiLaplacian0(sheaf, x);
-    expect(lx.get('A')).toBe('ESCALATE'); // meet(ESCALATE, ESCALATE) = ESCALATE
+    expect(lx.get('A')).toBe('ESCALATE');
   });
 
   it('parallel edges between same vertices', () => {
-    const cx: ReturnType<typeof buildComplex> = {
+    const cx = {
       vertices: [{ id: 'A' }, { id: 'B' }],
       edges: [
         { id: 'e1', source: 'A', target: 'B' },
@@ -771,7 +813,6 @@ describe('edge cases', () => {
     const x = cochain0({ A: 'DENY', B: 'QUARANTINE' } as Record<string, RiskDecision>);
 
     const lx = tarskiLaplacian0(sheaf, x);
-    // Two edges both contribute same thing → result is the meet
     expect(lx.get('A')).toBe('QUARANTINE');
     expect(lx.get('B')).toBe('QUARANTINE');
   });
@@ -779,7 +820,14 @@ describe('edge cases', () => {
   it('complete graph K4 converges', () => {
     const cx = buildComplex(
       ['A', 'B', 'C', 'D'],
-      [['A', 'B'], ['A', 'C'], ['A', 'D'], ['B', 'C'], ['B', 'D'], ['C', 'D']]
+      [
+        ['A', 'B'],
+        ['A', 'C'],
+        ['A', 'D'],
+        ['B', 'C'],
+        ['B', 'D'],
+        ['C', 'D'],
+      ]
     );
     const sheaf = constantSheaf(RiskLattice, cx);
     const opinions = cochain0({
@@ -796,7 +844,6 @@ describe('edge cases', () => {
   });
 
   it('long chain propagates minimum', () => {
-    // Chain: 0-1-2-3-4-5-6-7-8-9
     const ids = Array.from({ length: 10 }, (_, i) => `v${i}`);
     const links: [string, string][] = [];
     for (let i = 0; i < 9; i++) links.push([`v${i}`, `v${i + 1}`]);
@@ -805,11 +852,10 @@ describe('edge cases', () => {
     const sheaf = constantSheaf(RiskLattice, cx);
     const opinions: Record<string, RiskDecision> = {};
     for (let i = 0; i < 10; i++) opinions[`v${i}`] = 'DENY';
-    opinions['v9'] = 'ALLOW'; // One dissenter at the end
+    opinions['v9'] = 'ALLOW';
 
     const result = harmonicFlow(sheaf, cochain0(opinions));
     expect(result.converged).toBe(true);
-    // ALLOW propagates through the entire chain
     for (let i = 0; i < 10; i++) {
       expect(result.fixedPoint.get(`v${i}`)).toBe('ALLOW');
     }
@@ -822,7 +868,7 @@ describe('edge cases', () => {
 // =============================================================================
 
 describe('lattice axioms', () => {
-  function verifyLatticeAxioms<T>(L: CompleteLattice<T>, name: string) {
+  function verifyLatticeAxioms<T>(L: ConvenienceLattice<T>, name: string) {
     describe(`${name} lattice axioms`, () => {
       const elems = L.elements;
 
@@ -908,4 +954,3 @@ describe('lattice axioms', () => {
   verifyLatticeAxioms(GovernanceLattice, 'Governance');
   verifyLatticeAxioms(DimensionalLattice, 'Dimensional');
 });
-*/


### PR DESCRIPTION
## Summary
- **Un-skip sheaf cohomology tests**: The L2-unit test suite for Tarski Sheaf Cohomology was fully commented out and skipped because the source module didn't export the convenience API the tests needed. Added 450+ lines of convenience wrappers to `sheafCohomology.ts` — **88 new passing tests** (lattices, cell complexes, Galois connections, Tarski Laplacian, harmonic flow, consensus analysis, lattice axiom verification)
- **Fix `any` types in selfHealing module**: Replaced all `any` parameters in `coordinator.ts`, `quickFixBot.ts`, and `deepHealing.ts` with a new structured `Failure` interface (`src/selfHealing/types.ts`) — improves type safety in the failure recovery pipeline

## New exports from `sheafCohomology.ts`
- `RiskLattice`, `GovernanceLattice`, `DimensionalLattice` — string-based convenience lattices
- `createUnitIntervalLattice` — numeric lattice builder
- `buildComplex` — cell complex from vertex IDs + edge pairs
- `convConstantSheaf`, `customSheaf`, `galoisFromMaps` — sheaf builders
- `cochain0`, `constantCochain0`, `topCochain0` — cochain helpers
- `harmonicStep0`, `harmonicFlow`, `tarskiCohomology0/1`, `pseudoCoboundary` — operators
- `analyzeConsensus`, `riskConsensus`, `riskConsensusSheaf`, `governanceConsensusSheaf`, `consensusSummary` — consensus analysis

## Test plan
- [x] 88 sheaf cohomology tests pass (was 0 — entire suite was skipped)
- [x] Full TS build passes (`tsc` clean)
- [x] Prettier lint passes
- [x] Full test suite: 5797 passed, 73 skipped, 0 failures (up from 5710)

https://claude.ai/code/session_019LE33xsPBvHtkM8Ttcy1bZ