### PR TITLE
fix(lint): resolve Prettier formatting violation in entropySurface test

### DIFF
--- a/tests/harmonic/entropySurface.test.ts
+++ b/tests/harmonic/entropySurface.test.ts
@@ -542,7 +542,7 @@ describe('Anti-Extraction Property', () => {
       const pos = randomBallPoint(0.3);
       t += 5000 + Math.random() * 10000; // 5-15s apart (irregular)
       const assessment = tracker.observe(pos, 0.1, t);
-      expect(assessment.nullification.signalRetention).toBeGreaterThan(0.80);
+      expect(assessment.nullification.signalRetention).toBeGreaterThan(0.8);
     }
   });
 


### PR DESCRIPTION
## Summary
- Fix the only remaining Prettier lint failure on `main` — a trailing zero in numeric literal `0.80` → `0.8` in `tests/harmonic/entropySurface.test.ts`

## Verification
- `npm run lint` — all files pass Prettier ✅
- `npm run typecheck` — clean ✅
- `npx vitest run` — 170 test files, 5798 passed, 0 failures ✅
- `python3 -m pytest tests/ -m homebrew` — 31 passed ✅
- `python3 -m pytest tests/ -m unit` — 121 passed ✅
- `npm run check:circular` — no circular deps ✅
- `npm run lint:python` (flake8) — clean ✅

## Test plan
- [x] Confirm `npm run lint` passes with no warnings
- [x] Confirm test suite still passes (no behavioral change)

https://claude.ai/code/session_011Wfo7bvqe8XDTGvgiLneCc