### PR TITLE
feat(harmonic): enable 13 remaining skipped sheaf cohomology tests

### DIFF
--- a/src/harmonic/sheafCohomology.ts
+++ b/src/harmonic/sheafCohomology.ts
@@ -343,16 +343,24 @@ export function harmonicFlow<V, E>(
 /**
  * Global sections TH⁰: greatest fixed point of harmonic flow,
  * starting from the top cochain (⊤ everywhere).
+ *
+ * Polymorphic: accepts V1 CellularSheaf or V2 CellularSheaf.
  */
 export function globalSections<V, E>(
-  sheaf: CellularSheaf<V, E>,
+  sheaf: CellularSheaf<V, E> | V2CellularSheaf<V>,
   opts?: { maxIter?: number }
-): { fixedPoint: Cochain0<V>; converged: boolean } {
-  const topCochain: Cochain0<V> = new Map();
-  for (const v of sheaf.complex.vertices) {
-    topCochain.set(v.id, sheaf.vertexLattice(v.id).top());
+): { fixedPoint: Cochain0<V>; converged: boolean } | CohomologyResult<V> {
+  // Detect V2 sheaf: has `stalk` method and complex with `cells()` function
+  if ('stalk' in sheaf && typeof (sheaf as V2CellularSheaf<V>).stalk === 'function') {
+    return v2GlobalSections(sheaf as V2CellularSheaf<V>);
   }
-  const { fixedPoint, converged } = harmonicFlow(sheaf, topCochain, opts);
+  // V1 path
+  const v1Sheaf = sheaf as CellularSheaf<V, E>;
+  const topCochain: Cochain0<V> = new Map();
+  for (const v of v1Sheaf.complex.vertices) {
+    topCochain.set(v.id, v1Sheaf.vertexLattice(v.id).top());
+  }
+  const { fixedPoint, converged } = harmonicFlow(v1Sheaf, topCochain, opts);
   return { fixedPoint, converged };
 }
 

--- a/tests/harmonic/sheafCohomology.test.ts
+++ b/tests/harmonic/sheafCohomology.test.ts
@@ -1274,7 +1274,7 @@ describe('Tarski Laplacian L_k', () => {
 // Tarski Cohomology
 // ═══════════════════════════════════════════════════════════════
 
-describe.skip('Tarski Cohomology TH^k (globalSections not exported)', () => {
+describe('Tarski Cohomology TH^k', () => {
   describe('TH^0 = global sections (constant sheaf)', () => {
     it('on connected graph: all cells converge to same value', () => {
       // Complete graph K3
@@ -1922,7 +1922,7 @@ describe('SheafCohomologyEngine', () => {
 // Property-Based Tests (lightweight, 20 iterations)
 // ═══════════════════════════════════════════════════════════════
 
-describe.skip('Property-based tests (globalSections not exported)', () => {
+describe('Property-based tests', () => {
   it('Tarski flow is non-increasing (monotone descent)', () => {
     for (let trial = 0; trial < 20; trial++) {
       const n = 3 + Math.floor(Math.random() * 3);


### PR DESCRIPTION
## Summary
- Make `globalSections()` polymorphic to handle both V1 `CellularSheaf` and V2 `CellularSheaf` types, detecting V2 sheaves via the `stalk` method and delegating to `v2GlobalSections()`
- Unskip 2 `describe.skip` blocks in `sheafCohomology.test.ts` that were gated on "globalSections not exported" — stale after #716 exported the function
- **Test results: 5863 passed (+13), 8 skipped (-13), 0 failures**

The remaining 8 skips are all environment-conditional (liboqs-node, WebCrypto, Python, Redis) — expected behavior.

## Test plan
- [x] `npx vitest run tests/harmonic/sheafCohomology.test.ts` — 155 passed, 0 skipped, 0 failed
- [x] `npm test` — full suite 5863 passed, 8 skipped, 0 failed
- [x] `npm run build:src` — clean compile
- [x] `npm run lint` — Prettier passes
- [x] `npm run lint:python` — flake8 passes

https://claude.ai/code/session_014v5HNcEcDYB2BSrSL7xbmZ