### PR TITLE
fix(crypto,types): harden envelope salt validation and eliminate `any` types

### DIFF
--- a/src/crypto/envelope.ts
+++ b/src/crypto/envelope.ts
@@ -209,7 +209,11 @@ export async function verifyEnvelope(p: VerifyParams): Promise<{ body: EnvelopeB
   // 4) Key derivation (must bind env/provider/intent/session)
   // Session binding via key derivation (HIGH-001 fix: replaces nonce prefix binding)
   const ikm = await getMasterKey(envelope.kid);
-  const salt = envelope.salt ? fromB64u(envelope.salt) : Buffer.alloc(32, 0);
+  if (!envelope.salt) {
+    metrics.incr('envelope_missing_salt', 1);
+    throw new Error('invalid envelope: missing salt');
+  }
+  const salt = fromB64u(envelope.salt);
   const infoBase = Buffer.from(
     `scbe:derivation:v1|env=${envelope.aad.env}|provider=${envelope.aad.provider_id}|intent=${envelope.aad.intent_id}|session=${p.session_id}`
   );

--- a/src/crypto/octree.py
+++ b/src/crypto/octree.py
@@ -463,7 +463,7 @@ if __name__ == "__main__":
     for i in range(30):
         point = np.random.randn(3) * 0.3
         point = point / (np.linalg.norm(point) + 0.1) * 0.4
-        fp_hash = hashlib.md5(f"light_{i}".encode()).hexdigest()[:16]
+        fp_hash = hashlib.sha256(f"light_{i}".encode()).hexdigest()[:16]
         octree.insert_with_fingerprint(
             point,
             "light_realm",
@@ -478,7 +478,7 @@ if __name__ == "__main__":
     for i in range(30):
         point = np.random.randn(3)
         point = point / np.linalg.norm(point) * 0.85
-        fp_hash = hashlib.md5(f"shadow_{i}".encode()).hexdigest()[:16]
+        fp_hash = hashlib.sha256(f"shadow_{i}".encode()).hexdigest()[:16]
         octree.insert_with_fingerprint(
             point,
             "shadow_realm",
@@ -495,7 +495,7 @@ if __name__ == "__main__":
         norm = np.linalg.norm(point)
         if norm > 0:
             point = point / norm * min(0.7, norm)
-        fp_hash = hashlib.md5(f"path_{i}".encode()).hexdigest()[:16]
+        fp_hash = hashlib.sha256(f"path_{i}".encode()).hexdigest()[:16]
         octree.insert_with_fingerprint(
             point,
             "path",

--- a/src/fleet/polly-pads/drone-core.ts
+++ b/src/fleet/polly-pads/drone-core.ts
@@ -53,6 +53,17 @@ export interface DroneCoreConfig {
   initialTongue?: SacredTongue;
 }
 
+/** Serialized representation of a DroneCore (from toJSON) */
+export interface DroneCoreJSON {
+  id: string;
+  callsign: string;
+  class: DroneClass;
+  spectralIdentity: SpectralIdentity;
+  fluxState: FluxState;
+  loadout: Capability[];
+  maxLoadout: number;
+}
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -347,7 +358,7 @@ export class DroneCore {
   // Serialization
   // --------------------------------------------------------------------------
 
-  toJSON(): object {
+  toJSON(): DroneCoreJSON {
     return {
       id: this.id,
       callsign: this.callsign,
@@ -359,7 +370,7 @@ export class DroneCore {
     };
   }
 
-  static fromJSON(data: any): DroneCore {
+  static fromJSON(data: DroneCoreJSON): DroneCore {
     const drone = new DroneCore({
       id: data.id,
       callsign: data.callsign,

--- a/src/integrations/six-tongues.ts
+++ b/src/integrations/six-tongues.ts
@@ -33,7 +33,7 @@ export interface GeoSealOptions {
 
 export interface SixTonguesResult {
   success: boolean;
-  data?: any;
+  data?: unknown;
   error?: string;
   stderr?: string;
 }

--- a/src/spiralverse/types.ts
+++ b/src/spiralverse/types.ts
@@ -72,7 +72,7 @@ export interface PolicyMatrix {
 /**
  * Verification result
  */
-export interface VerificationResult {
+export interface VerificationResult<T = Record<string, unknown>> {
   /** Whether verification passed */
   valid: boolean;
 
@@ -83,7 +83,7 @@ export interface VerificationResult {
   error?: string;
 
   /** Decoded payload if verification passed */
-  payload?: any;
+  payload?: T;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Security hardening**: Reject envelopes with missing salt instead of falling back to zero-filled `Buffer.alloc(32, 0)`, which would weaken HKDF key derivation in edge cases (corrupt/truncated envelopes)
- **MD5 → SHA-256**: Replace `hashlib.md5()` with `hashlib.sha256()` in octree demo fingerprints for consistency with crypto standards
- **Type safety**: Eliminate 3 of 13 remaining `any` types across core modules:
  - `VerificationResult<T = Record<string, unknown>>` generic in `src/spiralverse/types.ts`
  - `DroneCoreJSON` interface for typed `toJSON()`/`fromJSON()` in `src/fleet/polly-pads/drone-core.ts`
  - `data?: unknown` replacing `data?: any` in `src/integrations/six-tongues.ts`

## Test plan
- [x] `npm run build:src` — clean compile, zero errors
- [x] `npm test` — 5863 passed, 8 skipped (env-conditional), 0 failures
- [x] `npm run lint` — Prettier passes
- [x] `npm run check:circular` — no circular dependencies
- [x] `npx vitest run tests/crypto/` — 254 passed, 8 skipped, 0 failures

https://claude.ai/code/session_018br5YwTbRA5Bu448PMjCW7