### PR TITLE
chore(ci): remove master branch refs from workflow triggers

### DIFF
--- a/config/.github/workflows/scbe-tests.yml
+++ b/config/.github/workflows/scbe-tests.yml
@@ -2,9 +2,9 @@ name: 'SCBE Axiom Compliance Tests'
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/scbe-visual-system/.github/workflows/build.yml
+++ b/scbe-visual-system/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build & Test
 
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, develop]
   pull_request:
-    branches: [main, master]
+    branches: [main]
   workflow_dispatch:
 
 env:

--- a/src/.github/workflows/scbe-tests.yml
+++ b/src/.github/workflows/scbe-tests.yml
@@ -2,9 +2,9 @@ name: SCBE-AETHERMOORE Tests
 
 on:
   push:
-    branches: [main, master, 'claude/**']
+    branches: [main, 'claude/**']
   pull_request:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary\n\n- Removes `master` from branch triggers in 3 workflow files (`src/.github/workflows/scbe-tests.yml`, `scbe-visual-system/.github/workflows/build.yml`, `config/.github/workflows/scbe-tests.yml`)\n- All CI workflows now target only `main` as the canonical default branch\n- Prevents accidental CI runs against the stale `master` branch\n\n## Context (Issue #729)\n\n`main` and `master` have completely diverged with **no common ancestor** — `main` has 82 commits, `master` has 21. A direct merge produces 798 conflicts across unrelated histories.\n\n**Recommended next steps after this PR merges:**\n1. Fast-forward `master` to `main`: `git push origin main:master --force`\n2. Or delete `master` entirely if it's no longer needed\n3. Add branch protection to prevent future PRs targeting `master`\n\nThe 21 commits unique to `master` are mostly dependency bumps (#595–#607) and workflow hardening that have been superseded by newer work on `main`. If any are still needed, they should be re-applied as individual PRs against `main`.\n\n## Test plan\n\n- [ ] Verify workflows no longer trigger on `master` pushes\n- [ ] Confirm `main` CI still triggers correctly\n\nCloses #729\n\nhttps://claude.ai/code/session_01Y5vi8NNEBc44p5EZbCN7dV