### PR TITLE
fix(crypto,test): eliminate `any` types from PQC module + fix 5 Python test failures

### DIFF
--- a/src/crypto/pqc.ts
+++ b/src/crypto/pqc.ts
@@ -27,7 +27,7 @@ import { randomBytes, createHash } from 'crypto';
 
 interface NativePqcHandle {
   readonly moduleName: string;
-  readonly instance: unknown;
+  readonly instance: Record<string, unknown>;
 }
 
 type PQCStatus = {
@@ -38,7 +38,10 @@ type PQCStatus = {
   reason?: string;
 };
 
-type NativeMethod = (...args: any[]) => any;
+type NativeMethod = (...args: unknown[]) => unknown;
+
+/** A dynamically-loaded native class constructor. */
+type NativeConstructor = new (...args: unknown[]) => Record<string, unknown>;
 
 const LIBOQS_CANDIDATES = ['liboqs-node', 'liboqs'];
 const KEM_CTORS = ['KEM', 'KeyEncapsulation'];
@@ -78,10 +81,13 @@ const SIG_SIGN_METHODS: readonly string[] = ['sign', 'signature', 'generate_sign
 
 const SIG_VERIFY_METHODS: readonly string[] = ['verify', 'verify_signature'];
 
-let liboqsModuleCache: { moduleName: string; module: any } | null | undefined = undefined;
+/** Shape of a dynamically-loaded liboqs native module (unknown at compile time). */
+type NativeModule = Record<string, unknown>;
+
+let liboqsModuleCache: { moduleName: string; module: NativeModule } | null | undefined = undefined;
 let pqcStatusCache: PQCStatus | null = null;
 
-function resolveLiboqsModule(): { moduleName: string; module: any } | null {
+function resolveLiboqsModule(): { moduleName: string; module: NativeModule } | null {
   if (liboqsModuleCache !== undefined) {
     return liboqsModuleCache;
   }
@@ -100,19 +106,25 @@ function resolveLiboqsModule(): { moduleName: string; module: any } | null {
   return null;
 }
 
-function getClassFromModule(mod: any, candidates: readonly string[]): any | null {
+function getClassFromModule(
+  mod: NativeModule,
+  candidates: readonly string[]
+): NativeConstructor | null {
   for (const name of candidates) {
     const candidate = mod?.[name];
     if (typeof candidate === 'function') {
-      return candidate;
+      return candidate as NativeConstructor;
     }
   }
   return null;
 }
 
-function firstMatchingMethod(target: any, candidates: readonly string[]): string | null {
+function firstMatchingMethod(
+  target: Record<string, unknown>,
+  candidates: readonly string[]
+): string | null {
   for (const name of candidates) {
-    const fn = (target as Record<string, NativeMethod | undefined>)[name];
+    const fn = target[name];
     if (typeof fn === 'function') {
       return name;
     }
@@ -121,7 +133,7 @@ function firstMatchingMethod(target: any, candidates: readonly string[]): string
 }
 
 async function invokeNativeMethod(
-  target: any,
+  target: Record<string, unknown>,
   candidates: readonly string[],
   args: unknown[]
 ): Promise<unknown | null> {
@@ -299,7 +311,7 @@ function createNativeKEM(algorithm: string): NativePqcHandle | null {
   const ctorArgs: unknown[][] = [[algorithm], [{ algorithm }], []];
   for (const ctorArgSet of ctorArgs) {
     try {
-      const instance = new (ctor as new (...args: unknown[]) => unknown)(...ctorArgSet);
+      const instance = new ctor(...ctorArgSet);
       if (
         firstMatchingMethod(instance, KEM_KEYPAIR_METHODS) &&
         firstMatchingMethod(instance, KEM_ENCAPSULATE_METHODS) &&
@@ -329,7 +341,7 @@ function createNativeDSA(algorithm: string): NativePqcHandle | null {
   const ctorArgs: unknown[][] = [[algorithm], [{ algorithm }], []];
   for (const ctorArgSet of ctorArgs) {
     try {
-      const instance = new (ctor as new (...args: unknown[]) => unknown)(...ctorArgSet);
+      const instance = new ctor(...ctorArgSet);
       if (
         firstMatchingMethod(instance, SIG_KEYPAIR_METHODS) &&
         firstMatchingMethod(instance, SIG_SIGN_METHODS) &&


### PR DESCRIPTION
## Summary

### Type safety — `src/crypto/pqc.ts`
- Eliminate all 5 remaining `any` types with proper typed alternatives
- Introduces `NativeModule` (`Record<string, unknown>`) for dynamically-loaded liboqs modules
- Introduces `NativeConstructor` for class constructors resolved at runtime
- Updates `NativePqcHandle.instance` from `unknown` to `Record<string, unknown>`
- Removes unnecessary type casts at constructor call sites
- Complements PR #728 — together these eliminate all `any` from core modules

### Python test fixes
- **`test_provider_map_complete`**: Update expected provider set to include new `xai` and `grok` providers added to `_PROVIDER_MAP`
- **4 `test_integration_full` failures**: Fix `RWP_AVAILABLE` guard to probe `RWPv3Protocol()` instantiation at import time — catches missing `argon2-cffi` dependency gracefully via `skipif` instead of crashing at test runtime

## Test plan
- [x] `npm run build:src` — clean compile, zero errors
- [x] `npm test` — 5863 passed, 8 skipped (env-conditional), 0 failures
- [x] `npx vitest run tests/crypto/` — 254 passed, 8 skipped, 0 failures
- [x] `npm run lint` — Prettier passes
- [x] `npm run check:circular` — no circular dependencies
- [x] `grep ': any' src/crypto/pqc.ts` — zero matches
- [x] `pytest tests/test_hydra_swarm_browser.py tests/test_integration_full.py tests/test_kernel_manifest.py` — 61 passed, 5 skipped, 0 failures

https://claude.ai/code/session_011cNMkNfvtTDSD5D9FWTjS1