### PR TITLE
fix(ci): pin GitHub Actions to stable versions for supply chain security

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -100,7 +100,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v4
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule'
     steps:
-      - uses: pozil/auto-assign-issue@v2
+      - uses: pozil/auto-assign-issue@v4
         with:
           assignees: issdandavis
           numOfAssignee: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Snyk security scan
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@v3
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Google Auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v4
         with:
           credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v4
 
       - name: Build and Push Container
         run: |-

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -38,12 +38,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v4
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v4
       with:
         project_id: ${{ env.PROJECT_ID }}
 
@@ -75,7 +75,7 @@ jobs:
         docker push "$IMAGE:latest"
 
     - name: Get GKE credentials
-      uses: google-github-actions/get-gke-credentials@v2
+      uses: google-github-actions/get-gke-credentials@v4
       with:
         cluster_name: ${{ env.GKE_CLUSTER }}
         location: ${{ env.GKE_ZONE }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -91,7 +91,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v4
         with:
           tag_name: v${{ steps.version_bump.outputs.version }}
           name: Release v${{ steps.version_bump.outputs.version }}

--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -78,7 +78,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
         
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v4
         with:
           name: SCBE-AETHERMOORE ${{ steps.version.outputs.VERSION }}
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           echo "Uploaded to Dropbox: ${DROPBOX_PATH}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v4
         with:
           tag_name: ${{ steps.version.outputs.VERSION }}
           name: Six Tongues Secure Tokenizer ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/vertex-training.yml
+++ b/.github/workflows/vertex-training.yml
@@ -55,7 +55,7 @@ jobs:
         if: |
           github.event_name == 'workflow_dispatch' &&
           github.event.inputs.mode == 'train'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v4
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -63,7 +63,7 @@ jobs:
         if: |
           github.event_name == 'workflow_dispatch' &&
           github.event.inputs.mode == 'train'
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v4
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 


### PR DESCRIPTION
## Summary\n\n- **Pins `snyk/actions/node@master` → `@v3`** — eliminates the last floating `master` ref in CI (relates to #729)\n- **Updates 4× `softprops/action-gh-release@v2` → `@v4`** across release/publish workflows\n- **Updates `gitleaks/gitleaks-action@v2` → `@v4`** in security scanning\n- **Updates `pozil/auto-assign-issue@v2` → `@v4`** in auto-triage\n- **Updates 7× Google Cloud actions `@v2` → `@v4`** (auth, setup-gcloud, get-gke-credentials) across deploy-cloudrun, deploy-gke, and vertex-training\n\n### Why\n\nFloating branch refs like `@master` are a supply chain security risk — a compromised upstream repo could inject malicious code into CI without any change on our side. Outdated `@v2` tags miss security patches and bug fixes available in current stable releases.\n\n### What's NOT changed\n\n- `actions/ai-inference@v1` — GitHub's own action, v1 is the only version available\n- `jfrog/frogbot@5d9c42...` — already SHA-pinned (gold standard)\n- All `actions/checkout@v4`, `actions/setup-node@v4`, `actions/setup-python@v5` — already current\n\n**10 files changed, 14 action refs updated.**\n\nRefs: #729\n\n## Test plan\n\n- [ ] CI pipeline passes (build, lint, test unchanged — only workflow action versions updated)\n- [ ] Verify no `@master` or `@v2` action refs remain in workflow triggers\n- [ ] Spot-check that release/deploy workflows still parse correctly\n\nhttps://claude.ai/code/session_012G6vcsMg1WmByQgah22FBc