### PR TITLE
fix(ci): update outdated GitHub Action versions (round 2)

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -24,7 +24,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Label based on size
-        uses: codelytv/pr-size-labeler@v1.10.1
+        uses: codelytv/pr-size-labeler@v1.11.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/XS'

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,10 @@
 name: Greetings
 
-on: [pull_request_target, issues]
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
 
 jobs:
   greeting:
@@ -9,8 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@v1.3.0
+      - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: "👋 Welcome to SCBE-AETHERMOORE! Thanks for your first issue. Please review CONTRIBUTING.md and SECURITY.md. A maintainer will review soon."
-          pr-message: "🎉 Thanks for your first PR to SCBE-AETHERMOORE! Ensure CI passes and changes align with ARCHITECTURE.md. A maintainer will review shortly."
+          issue_message: "👋 Welcome to SCBE-AETHERMOORE! Thanks for your first issue. Please review CONTRIBUTING.md and SECURITY.md. A maintainer will review soon."
+          pr_message: "🎉 Thanks for your first PR to SCBE-AETHERMOORE! Ensure CI passes and changes align with ARCHITECTURE.md. A maintainer will review shortly."


### PR DESCRIPTION
## Summary\n- **`actions/first-interaction`** v1.3.0 → v3: Updated to latest major version with corrected input names (`repo-token` removed in favor of default, `issue-message` → `issue_message`, `pr-message` → `pr_message`), and added explicit `types: [opened]` event filters\n- **`codelytv/pr-size-labeler`** v1.10.1 → v1.11.0: Bug fixes including \"comment on PR only if XL label is new\"\n\nContinues the supply chain security hardening from PRs #736 and #730 (issue #729).\n\n### Actions audited but already current\n| Action | Version | Status |\n|--------|---------|--------|\n| `pascalgn/automerge-action` | v0.16.4 | Latest |\n| `actions/ai-inference` | v1 | Latest |\n| `pypa/gh-action-pypi-publish` | release/v1 | Recommended pattern |\n\n## Test plan\n- [x] YAML syntax validated\n- [x] No remaining `@v1` pins on actions with newer major versions\n- [x] Build passes, 5863 tests pass, lint clean\n\nCloses #729 (Step 4 follow-up)\n\nhttps://claude.ai/code/session_01TQsLQad43yVmMcJfELxWWN