### PR TITLE
fix(crypto,types): harden envelope salt validation and eliminate remaining `any` types

### DIFF
--- a/src/crypto/envelope.ts
+++ b/src/crypto/envelope.ts
@@ -209,7 +209,11 @@ export async function verifyEnvelope(p: VerifyParams): Promise<{ body: EnvelopeB
   // 4) Key derivation (must bind env/provider/intent/session)
   // Session binding via key derivation (HIGH-001 fix: replaces nonce prefix binding)
   const ikm = await getMasterKey(envelope.kid);
-  const salt = envelope.salt ? fromB64u(envelope.salt) : Buffer.alloc(32, 0);
+  if (!envelope.salt) {
+    metrics.incr('envelope_missing_salt', 1);
+    throw new Error('invalid envelope: missing salt');
+  }
+  const salt = fromB64u(envelope.salt);
   const infoBase = Buffer.from(
     `scbe:derivation:v1|env=${envelope.aad.env}|provider=${envelope.aad.provider_id}|intent=${envelope.aad.intent_id}|session=${p.session_id}`
   );

--- a/src/crypto/octree.py
+++ b/src/crypto/octree.py
@@ -463,7 +463,7 @@ if __name__ == "__main__":
     for i in range(30):
         point = np.random.randn(3) * 0.3
         point = point / (np.linalg.norm(point) + 0.1) * 0.4
-        fp_hash = hashlib.md5(f"light_{i}".encode()).hexdigest()[:16]
+        fp_hash = hashlib.sha256(f"light_{i}".encode()).hexdigest()[:16]
         octree.insert_with_fingerprint(
             point,
             "light_realm",
@@ -478,7 +478,7 @@ if __name__ == "__main__":
     for i in range(30):
         point = np.random.randn(3)
         point = point / np.linalg.norm(point) * 0.85
-        fp_hash = hashlib.md5(f"shadow_{i}".encode()).hexdigest()[:16]
+        fp_hash = hashlib.sha256(f"shadow_{i}".encode()).hexdigest()[:16]
         octree.insert_with_fingerprint(
             point,
             "shadow_realm",
@@ -495,7 +495,7 @@ if __name__ == "__main__":
         norm = np.linalg.norm(point)
         if norm > 0:
             point = point / norm * min(0.7, norm)
-        fp_hash = hashlib.md5(f"path_{i}".encode()).hexdigest()[:16]
+        fp_hash = hashlib.sha256(f"path_{i}".encode()).hexdigest()[:16]
         octree.insert_with_fingerprint(
             point,
             "path",

--- a/src/spiralverse/rwp.ts
+++ b/src/spiralverse/rwp.ts
@@ -167,7 +167,7 @@ function verifySignature(input: string, signature: string, key: Buffer): boolean
  * );
  * ```
  */
-export function signRoundtable<T = any>(
+export function signRoundtable<T = Record<string, unknown>>(
   payload: T,
   primaryTongue: TongueID,
   aad: string,

--- a/src/spiralverse/spiralverse-sdk.ts
+++ b/src/spiralverse/spiralverse-sdk.ts
@@ -40,8 +40,8 @@ export interface SignatureSet {
 /** Action payload (before Base64URL encoding) */
 export interface ActionPayload {
   action: string;
-  params: Record<string, any>;
-  metadata?: Record<string, any>;
+  params: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
 }
 
 /** 6D Position vector */

--- a/src/spiralverse/types.ts
+++ b/src/spiralverse/types.ts
@@ -25,7 +25,7 @@ export type PolicyLevel = 'standard' | 'strict' | 'secret' | 'critical';
  *
  * @template T - Payload type (must be JSON-serializable)
  */
-export interface RWP2MultiEnvelope<T = any> {
+export interface RWP2MultiEnvelope<T = Record<string, unknown>> {
   /** Protocol version (always "2.1") */
   ver: '2.1';
 


### PR DESCRIPTION
## Summary\n- **Security hardening**: Reject envelopes with missing salt instead of falling back to zero-filled `Buffer.alloc(32, 0)`, which would weaken HKDF key derivation in edge cases (corrupt/truncated envelopes)\n- **MD5 → SHA-256**: Replace `hashlib.md5()` with `hashlib.sha256()` in octree demo fingerprints for consistency with crypto standards\n- **Type safety**: Eliminate last 3 `any` types in spiralverse modules (`RWP2MultiEnvelope`, `signRoundtable`, `ActionPayload`)\n\nThis is a clean rebase of the remaining changes from PR #728 — the type safety fixes in `drone-core.ts`, `six-tongues.ts`, and `spiralverse/types.ts:VerificationResult` were already landed in #735 and #737.\n\nRef: #728\n\n## Test plan\n- [x] `npm run build:src` — clean compile, zero errors\n- [x] `npm test` — 5863 passed, 8 skipped (env-conditional), 0 failures\n- [x] `npx vitest run tests/crypto/ tests/harmonic/ tests/spiralverse/` — 2095 passed, 8 skipped, 0 failures\n\nhttps://claude.ai/code/session_01Pxaae56n9hgKPcCch97Bc3