### PR TITLE
fix(lint): resolve flake8 line-length violations in NIST AI RMF module

### DIFF
--- a/src/licensing/nist_ai_rmf.py
+++ b/src/licensing/nist_ai_rmf.py
@@ -116,7 +116,12 @@ class ComplianceReport:
                     "total": len(self.by_function(f)),
                     "passed": sum(1 for c in self.by_function(f) if c.status == "PASS"),
                 }
-                for f in [RMFFunction.GOVERN, RMFFunction.MAP, RMFFunction.MEASURE, RMFFunction.MANAGE]
+                for f in [
+                    RMFFunction.GOVERN,
+                    RMFFunction.MAP,
+                    RMFFunction.MEASURE,
+                    RMFFunction.MANAGE,
+                ]
             },
         }
 
@@ -142,7 +147,10 @@ def generate_compliance_report() -> ComplianceReport:
             category="Policies",
             description="Legal and regulatory requirements are understood and inform AI risk management",
             scbe_mapping="CUSTOMER_LICENSE_AGREEMENT.md, docs/05-industry-guides/",
-            evidence="Dual-license model with explicit regulatory mapping for banking, healthcare, defense, SaaS verticals",
+            evidence=(
+                "Dual-license model with explicit regulatory mapping"
+                " for banking, healthcare, defense, SaaS verticals"
+            ),
         )
     )
 
@@ -164,7 +172,9 @@ def generate_compliance_report() -> ComplianceReport:
             category="Accountability",
             description="Roles and responsibilities for AI risk management are defined",
             scbe_mapping="src/governance/, src/fleet/ (shepherd/flock roles)",
-            evidence="Layer 13 governance with ALLOW/QUARANTINE/ESCALATE/DENY decisions requiring explicit authorization",
+            evidence=(
+                "Layer 13 governance with ALLOW/QUARANTINE/ESCALATE/DENY" " decisions requiring explicit authorization"
+            ),
         )
     )
 
@@ -264,7 +274,9 @@ def generate_compliance_report() -> ComplianceReport:
             category="Third-Party Components",
             description="Third-party AI components and their risks are identified",
             scbe_mapping="package.json (dependencies), src/pyproject.toml",
-            evidence="Explicit dependency list with PQC libraries (@noble/post-quantum), MCP SDK, and crypto primitives",
+            evidence=(
+                "Explicit dependency list with PQC libraries" " (@noble/post-quantum), MCP SDK, and crypto primitives"
+            ),
         )
     )
 


### PR DESCRIPTION
## Summary
- Fix 3 flake8 E501 violations (lines exceeding 120 chars) in `src/licensing/nist_ai_rmf.py`
- Apply black formatting to `summary_dict()` comprehension for consistency with PR #740
- All linters pass: `flake8 src/ tests/` clean, `black --check` clean

## Context
After PR #740 applied black formatting to 236 Python files, this file was missed because it had implicit string concatenation that needed manual line breaking first.

## Test plan
- [x] `npm run lint:python` — clean (0 violations)
- [x] `black --check src/` — 437 files unchanged
- [x] `npm run build` — clean compile
- [x] `npx vitest run` — 5863 passed, 8 skipped, 0 failures

https://claude.ai/code/session_01UxfaBAQ9KijuYg9TRci2yg