### PR TITLE
fix(deps): patch yaml stack overflow vulnerability (GHSA-48c2-rrv3-qjmp)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7211,9 +7211,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {


### PR DESCRIPTION
## Summary
- Bump `yaml` 2.8.2 → 2.8.3 to fix moderate severity stack overflow via deeply nested YAML collections
- Transitive dependency of `typedoc` and `vite` (via `vitest`)
- Advisory: https://github.com/advisories/GHSA-48c2-rrv3-qjmp
- `npm audit` now reports 0 vulnerabilities

## Test plan
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run build` — clean compile
- [x] `npx vitest run` — 5863 passed, 8 skipped, 0 failures

https://claude.ai/code/session_01UxfaBAQ9KijuYg9TRci2yg