### PR TITLE
fix(ci): add missing deps to security audit and copilot build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
         with:
           node-version: '20.x'
 
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
       - name: Run npm audit
         run: npm audit --audit-level=moderate
         continue-on-error: true

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install
-          pip install numpy scipy pytest
+          pip install -r requirements.txt || pip install numpy scipy pytest
 
       - name: Type check
         run: npm run typecheck
@@ -54,4 +54,4 @@ jobs:
         run: npm test
 
       - name: Run Python tests
-        run: PYTHONPATH=. pytest tests/ -v --ignore=tests/node_modules -x --timeout=30
+        run: SCBE_FORCE_SKIP_LIBOQS=1 PYTHONPATH=. pytest tests/ -v --ignore=tests/node_modules -x --timeout=30


### PR DESCRIPTION
## Summary\n- **ci.yml security job**: Add `npm ci --ignore-scripts` before `npm audit` — the audit was running against empty `node_modules/` and failing instantly (2-second completion)\n- **copilot-setup-steps.yml**: Install full `requirements.txt` (with fallback) instead of just `numpy scipy pytest`, and add `SCBE_FORCE_SKIP_LIBOQS=1` to pytest to match the pattern in `scbe-reusable-gates.yml`\n\nThese fix the \"Security Audit\" and \"Build & Test\" CI failures seen on PR #741.\n\nRef: #729\n\n## Test plan\n- [x] CI should now install dependencies before auditing them\n- [x] Python tests should skip liboqs-dependent tests gracefully in copilot workflow\n- [x] Patterns match existing working workflows (`security-checks.yml`, `scbe-reusable-gates.yml`)\n\nhttps://claude.ai/code/session_016AW3bq4mubQrKe8PGWbfLu