### PR TITLE
feat(fleet): add juggling agent coordination scheduler

### DIFF
--- a/hydra/juggling_scheduler.py
+++ b/hydra/juggling_scheduler.py
@@ -1,0 +1,569 @@
+"""
+Juggling Agent Coordination Scheduler — Python reference implementation.
+
+Models multi-agent task coordination as a physics juggling system.
+
+Core mapping:
+    balls   -> TaskCapsules (units of work in flight)
+    hands   -> AgentSlots (bounded execution capacity)
+    throws  -> structured handoffs with predicted catch windows
+    arcs    -> latency/deadline envelopes
+    rhythm  -> scheduler cadence / phase locking
+    drops   -> timeout / failure / lost context
+    pattern -> orchestration policy (siteswap notation)
+
+Seven juggling rules:
+    1. Never throw to an unready hand
+    2. Every throw needs a predicted catch window
+    3. High-inertia tasks have fewer handoffs
+    4. Higher arcs for risky tasks (more validation slack)
+    5. Detect phase drift early
+    6. Build interception paths (backup handlers)
+    7. Ledger catches, not just throws
+
+Layer 13 integration: Risk decision (ALLOW / QUARANTINE / ESCALATE / DENY)
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Enums & Constants
+# ---------------------------------------------------------------------------
+
+class FlightState(str, Enum):
+    """Flight state of a task capsule through the juggling system."""
+    HELD = "held"
+    THROWN = "thrown"
+    CAUGHT = "caught"
+    VALIDATING = "validating"
+    RECOVERING = "recovering"
+    DROPPED = "dropped"
+    DONE = "done"
+
+
+GOVERNANCE_TIERS = ("KO", "AV", "RU", "CA", "UM", "DR")
+
+DEFAULT_SCORE_WEIGHTS = {
+    "reliability": 2.0,
+    "trust_alignment": 1.0,
+    "time_slack": 0.5,
+    "inertia_penalty": 1.5,
+    "risk_penalty": 1.2,
+    "load_penalty": 2.0,
+    "latency_penalty": 0.001,
+}
+
+DEFAULT_GRAVITY_LAMBDA = 0.05
+MAX_RETRIES = 3
+PHASE_DRIFT_THRESHOLD = 0.3
+
+
+# ---------------------------------------------------------------------------
+# Core Data Types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TaskCapsule:
+    """A unit of work in flight through the juggling system."""
+
+    task_id: str
+    payload_ref: str
+    priority: float
+    trust_score: float
+    inertia: float
+    risk: float
+    created_at: float
+    deadline_at: float
+    owner: Optional[str] = None
+    next_candidates: List[str] = field(default_factory=list)
+    fallback_candidates: List[str] = field(default_factory=list)
+    state: FlightState = FlightState.HELD
+    retry_count: int = 0
+    required_quorum: int = 1
+    integrity_hash: Optional[str] = None
+    required_tier: str = "KO"
+    arc_height: int = 3
+    last_transition_at: float = 0.0
+    provenance: List[Tuple[str, float, FlightState]] = field(default_factory=list)
+
+
+@dataclass
+class AgentSlot:
+    """An agent's execution capacity in the juggling system."""
+
+    agent_id: str
+    roles: List[str]
+    catch_capacity: int
+    current_load: int
+    reliability: float
+    trust_domains: List[str]
+    avg_latency_ms: float
+    last_catch_at: float = 0.0
+    consecutive_misses: int = 0
+
+    def can_catch(self, task: TaskCapsule, now: float) -> bool:
+        """Rule 1: Check if this agent can catch the given task."""
+        if self.current_load >= self.catch_capacity:
+            return False
+        if now + self.avg_latency_ms / 1000.0 > task.deadline_at:
+            return False
+        required_idx = GOVERNANCE_TIERS.index(task.required_tier) if task.required_tier in GOVERNANCE_TIERS else 0
+        max_agent_idx = max(
+            (GOVERNANCE_TIERS.index(t) for t in self.trust_domains if t in GOVERNANCE_TIERS),
+            default=-1,
+        )
+        if max_agent_idx < required_idx:
+            return False
+        return True
+
+
+@dataclass
+class HandoffReceipt:
+    """Explicit ACK when an agent catches a task (Rule 7)."""
+
+    task_id: str
+    receiver_id: str
+    sender_id: str
+    timestamp: float
+    integrity_verified: bool
+    feasibility_confirmed: bool
+    new_owner: str
+
+
+@dataclass
+class JugglingEvent:
+    """Scheduler event for audit and observability."""
+
+    type: str  # throw | catch | drop | intercept | validate | complete | phase_drift | capacity_warning
+    task_id: str
+    agent_id: Optional[str]
+    timestamp: float
+    data: dict
+
+
+@dataclass
+class SchedulerMetrics:
+    """Real-time health of the juggling pattern."""
+
+    in_flight: int
+    held: int
+    drops: int
+    catches: int
+    phase_drift: float
+    avg_arc_time_ms: float
+    cadence_health: float
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def assignment_score(
+    task: TaskCapsule,
+    agent: AgentSlot,
+    now: float,
+    weights: Optional[dict] = None,
+) -> float:
+    """Compute assignment score for a (task, agent) pair. Higher = better."""
+    w = weights or DEFAULT_SCORE_WEIGHTS
+    time_left = max(task.deadline_at - now, 1e-6)
+    load_ratio = agent.current_load / max(agent.catch_capacity, 1)
+
+    required_idx = GOVERNANCE_TIERS.index(task.required_tier) if task.required_tier in GOVERNANCE_TIERS else 0
+    max_agent_idx = max(
+        (GOVERNANCE_TIERS.index(t) for t in agent.trust_domains if t in GOVERNANCE_TIERS),
+        default=-1,
+    )
+    mismatch = 0 if max_agent_idx >= required_idx else (required_idx - max_agent_idx) / len(GOVERNANCE_TIERS)
+
+    return (
+        w["reliability"] * agent.reliability
+        + w["trust_alignment"] * task.trust_score
+        - w["inertia_penalty"] * task.inertia
+        - w["risk_penalty"] * task.risk * (mismatch + 0.1)
+        - w["load_penalty"] * load_ratio
+        - w["latency_penalty"] * agent.avg_latency_ms
+        + w["time_slack"] * math.log1p(time_left / 1.0)
+    )
+
+
+def recoverability(task: TaskCapsule, now: float, lam: float = DEFAULT_GRAVITY_LAMBDA) -> float:
+    """Compute recoverability: U(t) = e^(-lambda * elapsed). Returns [0, 1]."""
+    elapsed = max(now - task.created_at, 0)
+    return math.exp(-lam * elapsed)
+
+
+def select_arc_height(risk: float, inertia: float) -> int:
+    """Select arc height based on risk and inertia (Rules 3 & 4)."""
+    composite = 0.6 * risk + 0.4 * inertia
+    if composite >= 0.8:
+        return 7
+    if composite >= 0.6:
+        return 5
+    if composite >= 0.3:
+        return 3
+    if composite >= 0.1:
+        return 2
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Juggling Scheduler
+# ---------------------------------------------------------------------------
+
+class JugglingScheduler:
+    """
+    Governed task-flight coordinator.
+
+    Work capsules move between specialized agents along predicted arcs,
+    with explicit catches, bounded capacity, phase timing, and recovery
+    on missed handoffs.
+    """
+
+    def __init__(
+        self,
+        weights: Optional[dict] = None,
+        gravity_lambda: float = DEFAULT_GRAVITY_LAMBDA,
+    ):
+        self._capsules: Dict[str, TaskCapsule] = {}
+        self._agents: Dict[str, AgentSlot] = {}
+        self._event_log: List[JugglingEvent] = []
+        self._receipt_log: List[HandoffReceipt] = []
+        self._weights = weights or DEFAULT_SCORE_WEIGHTS
+        self._gravity_lambda = gravity_lambda
+
+    # ---- Agent Management ----
+
+    def register_agent(self, slot: AgentSlot) -> None:
+        """Register an agent slot."""
+        self._agents[slot.agent_id] = slot
+
+    def remove_agent(self, agent_id: str) -> List[TaskCapsule]:
+        """Remove an agent. Tasks held by it enter RECOVERING."""
+        self._agents.pop(agent_id, None)
+        orphaned: List[TaskCapsule] = []
+        for capsule in self._capsules.values():
+            if capsule.owner == agent_id and capsule.state != FlightState.DONE:
+                capsule.state = FlightState.RECOVERING
+                capsule.last_transition_at = time.time()
+                capsule.owner = None
+                orphaned.append(capsule)
+        return orphaned
+
+    def get_agent(self, agent_id: str) -> Optional[AgentSlot]:
+        return self._agents.get(agent_id)
+
+    # ---- Capsule Management ----
+
+    def add_capsule(self, capsule: TaskCapsule) -> None:
+        self._capsules[capsule.task_id] = capsule
+
+    def get_capsule(self, task_id: str) -> Optional[TaskCapsule]:
+        return self._capsules.get(task_id)
+
+    def get_capsules_by_state(self, state: FlightState) -> List[TaskCapsule]:
+        return [c for c in self._capsules.values() if c.state == state]
+
+    # ---- Core Scheduling ----
+
+    def find_best_receiver(self, capsule: TaskCapsule) -> Optional[AgentSlot]:
+        """Rule 1 & 2: Find the best agent for a capsule."""
+        now = time.time()
+
+        if capsule.next_candidates:
+            candidates = [self._agents[aid] for aid in capsule.next_candidates if aid in self._agents]
+        else:
+            candidates = list(self._agents.values())
+
+        eligible = [a for a in candidates if a.can_catch(capsule, now)]
+
+        if not eligible:
+            # Rule 6: try fallback / interception
+            fallbacks = [self._agents[aid] for aid in capsule.fallback_candidates if aid in self._agents]
+            eligible = [a for a in fallbacks if a.can_catch(capsule, now)]
+            if not eligible:
+                return None
+
+        return self._pick_best(eligible, capsule, now)
+
+    def throw_capsule(self, task_id: str) -> Optional[HandoffReceipt]:
+        """Throw a capsule to the best available agent."""
+        capsule = self._capsules.get(task_id)
+        if capsule is None:
+            return None
+
+        receiver = self.find_best_receiver(capsule)
+        if receiver is None:
+            if capsule.state != FlightState.DROPPED:
+                capsule.state = FlightState.RECOVERING
+                capsule.last_transition_at = time.time()
+            return None
+
+        sender_id = capsule.owner or "__scheduler__"
+        now = time.time()
+
+        capsule.state = FlightState.THROWN
+        capsule.last_transition_at = now
+
+        capsule.state = FlightState.CAUGHT
+        capsule.last_transition_at = now
+        capsule.owner = receiver.agent_id
+        receiver.current_load += 1
+        receiver.consecutive_misses = 0
+        receiver.last_catch_at = now
+
+        capsule.provenance.append((receiver.agent_id, now, FlightState.CAUGHT))
+
+        receipt = HandoffReceipt(
+            task_id=capsule.task_id,
+            receiver_id=receiver.agent_id,
+            sender_id=sender_id,
+            timestamp=now,
+            integrity_verified=capsule.integrity_hash is not None,
+            feasibility_confirmed=True,
+            new_owner=receiver.agent_id,
+        )
+        self._receipt_log.append(receipt)
+
+        self._emit(JugglingEvent(
+            type="catch",
+            task_id=capsule.task_id,
+            agent_id=receiver.agent_id,
+            timestamp=now,
+            data={"sender_id": sender_id, "arc_height": capsule.arc_height},
+        ))
+
+        if capsule.required_quorum > 1:
+            capsule.state = FlightState.VALIDATING
+            capsule.last_transition_at = now
+
+        return receipt
+
+    def complete_capsule(self, task_id: str) -> bool:
+        """Mark a capsule as complete. Frees the agent's slot."""
+        capsule = self._capsules.get(task_id)
+        if capsule is None:
+            return False
+
+        if capsule.owner:
+            agent = self._agents.get(capsule.owner)
+            if agent and agent.current_load > 0:
+                agent.current_load -= 1
+
+        now = time.time()
+        capsule.state = FlightState.DONE
+        capsule.last_transition_at = now
+        capsule.provenance.append((capsule.owner or "__none__", now, FlightState.DONE))
+
+        self._emit(JugglingEvent(
+            type="complete",
+            task_id=task_id,
+            agent_id=capsule.owner,
+            timestamp=now,
+            data={"retry_count": capsule.retry_count},
+        ))
+        return True
+
+    def handle_drop(self, task_id: str) -> Optional[HandoffReceipt]:
+        """Handle a drop: retry or permanent drop (Rule 3)."""
+        capsule = self._capsules.get(task_id)
+        if capsule is None:
+            return None
+
+        if capsule.owner:
+            prev = self._agents.get(capsule.owner)
+            if prev:
+                if prev.current_load > 0:
+                    prev.current_load -= 1
+                prev.consecutive_misses += 1
+
+        capsule.retry_count += 1
+        capsule.owner = None
+        now = time.time()
+
+        self._emit(JugglingEvent(
+            type="drop",
+            task_id=task_id,
+            agent_id=None,
+            timestamp=now,
+            data={"retry_count": capsule.retry_count},
+        ))
+
+        # Rule 3: high-inertia or max retries → permanent drop
+        if capsule.retry_count >= MAX_RETRIES or (capsule.inertia > 0.7 and capsule.retry_count >= 2):
+            capsule.state = FlightState.DROPPED
+            capsule.last_transition_at = now
+            return None
+
+        capsule.state = FlightState.RECOVERING
+        capsule.last_transition_at = now
+        return self.throw_capsule(task_id)
+
+    # ---- Phase Monitoring ----
+
+    def detect_phase_drift(self) -> float:
+        """Rule 5: Detect phase drift. Returns overdue ratio."""
+        now = time.time()
+        in_flight = self.get_capsules_by_state(FlightState.THROWN)
+        recovering = self.get_capsules_by_state(FlightState.RECOVERING)
+        all_active = in_flight + recovering
+
+        if not all_active:
+            return 0.0
+
+        overdue = sum(1 for c in all_active if now > c.deadline_at)
+        drift = overdue / len(all_active)
+
+        if drift >= PHASE_DRIFT_THRESHOLD:
+            self._emit(JugglingEvent(
+                type="phase_drift",
+                task_id="__system__",
+                agent_id=None,
+                timestamp=now,
+                data={"drift": drift, "overdue_count": overdue, "total": len(all_active)},
+            ))
+
+        return drift
+
+    # ---- Metrics ----
+
+    def get_metrics(self) -> SchedulerMetrics:
+        """Get current scheduler health metrics."""
+        all_capsules = list(self._capsules.values())
+        in_flight = sum(1 for c in all_capsules if c.state == FlightState.THROWN)
+        held = sum(1 for c in all_capsules if c.state in (FlightState.HELD, FlightState.CAUGHT, FlightState.VALIDATING))
+        drops = sum(1 for c in all_capsules if c.state == FlightState.DROPPED)
+        done = sum(1 for c in all_capsules if c.state == FlightState.DONE)
+
+        avg_arc = 0.0
+        if self._receipt_log:
+            recent = self._receipt_log[-50:]
+            times = []
+            for r in recent:
+                c = self._capsules.get(r.task_id)
+                if c:
+                    times.append((r.timestamp - c.created_at) * 1000)
+            if times:
+                avg_arc = sum(times) / len(times)
+
+        drift = self.detect_phase_drift()
+        total = len(all_capsules) or 1
+
+        return SchedulerMetrics(
+            in_flight=in_flight,
+            held=held,
+            drops=drops,
+            catches=done,
+            phase_drift=drift,
+            avg_arc_time_ms=avg_arc,
+            cadence_health=max(0.0, 1.0 - drift - drops / total),
+        )
+
+    # ---- Tick ----
+
+    def tick(self) -> SchedulerMetrics:
+        """Tick the scheduler: expire, recover, assign, check phase."""
+        now = time.time()
+
+        for capsule in list(self._capsules.values()):
+            if capsule.state in (FlightState.DONE, FlightState.DROPPED):
+                continue
+            if now > capsule.deadline_at:
+                self.handle_drop(capsule.task_id)
+
+        for capsule in self.get_capsules_by_state(FlightState.HELD):
+            if capsule.owner is None:
+                self.throw_capsule(capsule.task_id)
+
+        for capsule in self.get_capsules_by_state(FlightState.RECOVERING):
+            self.throw_capsule(capsule.task_id)
+
+        return self.get_metrics()
+
+    # ---- Siteswap Encoding ----
+
+    def encode_siteswap(self, task_id: str) -> str:
+        """Encode a capsule's journey as a siteswap-like string."""
+        capsule = self._capsules.get(task_id)
+        if capsule is None:
+            return ""
+        parts: List[str] = []
+        for _, _, state in capsule.provenance:
+            if state == FlightState.CAUGHT:
+                parts.append(str(capsule.arc_height))
+            elif state == FlightState.VALIDATING:
+                parts.append(f"{capsule.arc_height}Q")
+            elif state == FlightState.DONE:
+                parts.append("0")
+        return " -> ".join(parts)
+
+    # ---- Events ----
+
+    @property
+    def events(self) -> List[JugglingEvent]:
+        return list(self._event_log)
+
+    @property
+    def receipts(self) -> List[HandoffReceipt]:
+        return list(self._receipt_log)
+
+    # ---- Internal ----
+
+    def _pick_best(self, eligible: List[AgentSlot], capsule: TaskCapsule, now: float) -> AgentSlot:
+        best = eligible[0]
+        best_score = -math.inf
+        for agent in eligible:
+            score = assignment_score(capsule, agent, now, self._weights)
+            if score > best_score:
+                best_score = score
+                best = agent
+        return best
+
+    def _emit(self, event: JugglingEvent) -> None:
+        self._event_log.append(event)
+
+
+# ---------------------------------------------------------------------------
+# Convenience factory
+# ---------------------------------------------------------------------------
+
+def create_capsule(
+    task_id: str,
+    payload_ref: str,
+    priority: float = 2.0,
+    trust_score: float = 0.5,
+    inertia: float = 0.2,
+    risk: float = 0.2,
+    deadline_sec: float = 30.0,
+    next_candidates: Optional[List[str]] = None,
+    fallback_candidates: Optional[List[str]] = None,
+    required_quorum: int = 1,
+    required_tier: str = "KO",
+    integrity_hash: Optional[str] = None,
+) -> TaskCapsule:
+    """Create a new TaskCapsule with sensible defaults."""
+    now = time.time()
+    return TaskCapsule(
+        task_id=task_id,
+        payload_ref=payload_ref,
+        priority=priority,
+        trust_score=trust_score,
+        inertia=inertia,
+        risk=risk,
+        created_at=now,
+        deadline_at=now + deadline_sec,
+        next_candidates=next_candidates or [],
+        fallback_candidates=fallback_candidates or [],
+        required_quorum=required_quorum,
+        integrity_hash=integrity_hash,
+        required_tier=required_tier,
+        arc_height=select_arc_height(risk, inertia),
+        last_transition_at=now,
+    )

--- a/src/fleet/juggling-scheduler.ts
+++ b/src/fleet/juggling-scheduler.ts
@@ -1,0 +1,850 @@
+/**
+ * @file juggling-scheduler.ts
+ * @module fleet/juggling-scheduler
+ * @layer Layer 13 (Risk Decision)
+ * @component Juggling Agent Coordination
+ *
+ * Models multi-agent task coordination as a physics juggling system.
+ *
+ * Core mapping:
+ *   balls   → TaskCapsules (units of work in flight)
+ *   hands   → AgentSlots (bounded execution capacity)
+ *   throws  → structured handoffs with predicted catch windows
+ *   arcs    → latency/deadline envelopes
+ *   rhythm  → scheduler cadence / phase locking
+ *   drops   → timeout / failure / lost context
+ *   pattern → orchestration policy (siteswap notation)
+ *
+ * The scheduler enforces 7 juggling rules:
+ *   1. Never throw to an unready hand
+ *   2. Every throw needs a predicted catch window
+ *   3. High-inertia tasks have fewer handoffs
+ *   4. Higher arcs for risky tasks (more validation slack)
+ *   5. Detect phase drift early
+ *   6. Build interception paths (backup handlers)
+ *   7. Ledger catches, not just throws
+ */
+
+import { FleetAgent, GovernanceTier, GOVERNANCE_TIERS, TaskPriority, PRIORITY_WEIGHTS } from './types';
+
+// ---------------------------------------------------------------------------
+// Enums & Constants
+// ---------------------------------------------------------------------------
+
+/** Flight state of a task capsule through the juggling system */
+export enum FlightState {
+  /** Held by an agent, not in transit */
+  HELD = 'held',
+  /** Thrown — in transit between agents */
+  THROWN = 'thrown',
+  /** Caught — receipt acknowledged by receiver */
+  CAUGHT = 'caught',
+  /** Undergoing validation before execution */
+  VALIDATING = 'validating',
+  /** Missed catch — recovery in progress */
+  RECOVERING = 'recovering',
+  /** Drop — timeout, failure, or corruption */
+  DROPPED = 'dropped',
+  /** Terminal — work complete */
+  DONE = 'done',
+}
+
+/** Siteswap-like arc descriptor for handoff timing */
+export type ArcHeight = 1 | 2 | 3 | 5 | 7;
+// 1 = immediate cross-hand, 3 = short latency, 5 = validation slack, 7 = high-risk arc
+
+/** Default scoring weights for assignment_score */
+export const DEFAULT_SCORE_WEIGHTS = {
+  reliability: 2.0,
+  trustAlignment: 1.0,
+  timeSlack: 0.5,
+  inertiaPenalty: 1.5,
+  riskPenalty: 1.2,
+  loadPenalty: 2.0,
+  latencyPenalty: 0.001,
+} as const;
+
+/** Decay constant for utility/recoverability over time: U(t) = U0 * e^(-lambda*t) */
+export const DEFAULT_GRAVITY_LAMBDA = 0.05;
+
+/** Maximum retry count before permanent drop */
+export const MAX_RETRIES = 3;
+
+/** Phase drift detection threshold (ratio of overdue to total in-flight) */
+export const PHASE_DRIFT_THRESHOLD = 0.3;
+
+// ---------------------------------------------------------------------------
+// Core Types
+// ---------------------------------------------------------------------------
+
+/** Scoring weight configuration */
+export interface ScoreWeights {
+  reliability: number;
+  trustAlignment: number;
+  timeSlack: number;
+  inertiaPenalty: number;
+  riskPenalty: number;
+  loadPenalty: number;
+  latencyPenalty: number;
+}
+
+/**
+ * TaskCapsule — a unit of work in flight through the juggling system.
+ *
+ * Carries its own flight plan: who can catch it, when it expires,
+ * how costly it is to redirect, and what validation it requires.
+ */
+export interface TaskCapsule {
+  /** Unique task identifier */
+  taskId: string;
+
+  /** Reference to the payload (not the payload itself — keeps capsules lightweight) */
+  payloadRef: string;
+
+  /** Priority weight (higher = more important) */
+  priority: number;
+
+  /** Trust score of the originating context [0, 1] */
+  trustScore: number;
+
+  /**
+   * Inertia — how costly it is to redirect this task.
+   * Derived from state size, context sensitivity, dependencies, irreversibility.
+   * Range [0, 1] where 1 = maximum resistance to redirection.
+   */
+  inertia: number;
+
+  /**
+   * Risk level [0, 1].
+   * High-risk tasks get higher arcs (more validation slack).
+   */
+  risk: number;
+
+  /** Creation timestamp (ms) */
+  createdAt: number;
+
+  /**
+   * Deadline timestamp (ms).
+   * Gravity analog — recoverability decays exponentially toward this point.
+   */
+  deadlineAt: number;
+
+  /** Current owner agent ID (null if unowned) */
+  owner: string | null;
+
+  /** Ordered list of eligible next handlers */
+  nextCandidates: string[];
+
+  /** Fallback handlers if primary candidates miss (Rule 6: interception paths) */
+  fallbackCandidates: string[];
+
+  /** Current flight state */
+  state: FlightState;
+
+  /** Number of times this capsule has been re-thrown after a drop */
+  retryCount: number;
+
+  /** Quorum depth required for validation (1 = single validator) */
+  requiredQuorum: number;
+
+  /** SHA-256 integrity hash of the payload */
+  integrityHash: string | null;
+
+  /** Governance tier required to handle this task */
+  requiredTier: GovernanceTier;
+
+  /** Arc height — controls slack time vs throughput trade-off */
+  arcHeight: ArcHeight;
+
+  /** Timestamp of last state transition */
+  lastTransitionAt: number;
+
+  /** Provenance chain: [agentId, timestamp, state][] */
+  provenance: Array<[string, number, FlightState]>;
+}
+
+/**
+ * AgentSlot — an agent's execution capacity in the juggling system.
+ *
+ * Maps a FleetAgent's real capabilities into juggling terms:
+ * catch capacity, current load, reliability, latency.
+ */
+export interface AgentSlot {
+  /** Agent identifier (matches FleetAgent.id) */
+  agentId: string;
+
+  /** Roles this agent can fill */
+  roles: string[];
+
+  /** Maximum simultaneous tasks (catch capacity) */
+  catchCapacity: number;
+
+  /** Current number of held/validating tasks */
+  currentLoad: number;
+
+  /** Historical reliability [0, 1] — probability of successful catch */
+  reliability: number;
+
+  /** Trust domains this agent is authorized for */
+  trustDomains: GovernanceTier[];
+
+  /** Average latency in ms for this agent to acknowledge a catch */
+  avgLatencyMs: number;
+
+  /** Timestamp of last successful catch */
+  lastCatchAt: number;
+
+  /** Consecutive missed catches (phase drift indicator) */
+  consecutiveMisses: number;
+}
+
+/**
+ * HandoffReceipt — explicit ACK when an agent catches a task.
+ * Rule 7: ledger catches, not just throws.
+ */
+export interface HandoffReceipt {
+  /** Task capsule ID */
+  taskId: string;
+
+  /** Receiving agent */
+  receiverId: string;
+
+  /** Sending agent */
+  senderId: string;
+
+  /** Receipt timestamp */
+  timestamp: number;
+
+  /** Payload integrity verified */
+  integrityVerified: boolean;
+
+  /** Agent confirmed local feasibility */
+  feasibilityConfirmed: boolean;
+
+  /** Updated ownership record */
+  newOwner: string;
+}
+
+/**
+ * JugglingEvent — emitted by the scheduler for audit and observability.
+ */
+export interface JugglingEvent {
+  type:
+    | 'throw'
+    | 'catch'
+    | 'drop'
+    | 'intercept'
+    | 'validate'
+    | 'complete'
+    | 'phase_drift'
+    | 'capacity_warning';
+  taskId: string;
+  agentId?: string;
+  timestamp: number;
+  data: Record<string, unknown>;
+}
+
+/**
+ * SchedulerMetrics — real-time health of the juggling pattern.
+ */
+export interface SchedulerMetrics {
+  /** Total capsules currently in flight (THROWN state) */
+  inFlight: number;
+  /** Total capsules held by agents */
+  held: number;
+  /** Total drops in the current window */
+  drops: number;
+  /** Total successful catches in the current window */
+  catches: number;
+  /** Phase drift ratio (overdue / total in-flight) */
+  phaseDrift: number;
+  /** Average arc time (ms) across recent handoffs */
+  avgArcTimeMs: number;
+  /** System cadence health [0, 1] */
+  cadenceHealth: number;
+}
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the assignment score for a (task, agent) pair.
+ *
+ * score = w1 * reliability
+ *       + w2 * trustAlignment
+ *       + w3 * timeSlack
+ *       - w4 * inertia
+ *       - w5 * risk * mismatch
+ *       - w6 * loadRatio
+ *       - w7 * latency
+ *
+ * Higher score = better assignment.
+ */
+export function assignmentScore(
+  task: TaskCapsule,
+  agent: AgentSlot,
+  now: number,
+  weights: ScoreWeights = DEFAULT_SCORE_WEIGHTS,
+): number {
+  const timeLeft = Math.max(task.deadlineAt - now, 1e-3);
+  const loadRatio = agent.currentLoad / Math.max(agent.catchCapacity, 1);
+
+  // Trust alignment: how well the agent's tier matches the task requirement
+  const tierOrder: GovernanceTier[] = ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'];
+  const requiredIdx = tierOrder.indexOf(task.requiredTier);
+  const maxAgentIdx = Math.max(...agent.trustDomains.map((t) => tierOrder.indexOf(t)));
+  const mismatch = maxAgentIdx >= requiredIdx ? 0 : (requiredIdx - maxAgentIdx) / tierOrder.length;
+
+  return (
+    weights.reliability * agent.reliability +
+    weights.trustAlignment * task.trustScore -
+    weights.inertiaPenalty * task.inertia -
+    weights.riskPenalty * task.risk * (mismatch + 0.1) -
+    weights.loadPenalty * loadRatio -
+    weights.latencyPenalty * agent.avgLatencyMs +
+    weights.timeSlack * Math.log1p(timeLeft / 1000)
+  );
+}
+
+/**
+ * Compute recoverability of a task at time `now`.
+ * U(t) = e^(-lambda * elapsed_seconds)
+ * Returns [0, 1] where 1 = fully recoverable, 0 = expired.
+ */
+export function recoverability(task: TaskCapsule, now: number, lambda: number = DEFAULT_GRAVITY_LAMBDA): number {
+  const elapsedSec = Math.max(now - task.createdAt, 0) / 1000;
+  return Math.exp(-lambda * elapsedSec);
+}
+
+// ---------------------------------------------------------------------------
+// Agent Slot Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an AgentSlot from a FleetAgent.
+ * Bridges existing fleet types into juggling terms.
+ */
+export function agentSlotFromFleet(agent: FleetAgent): AgentSlot {
+  const tierOrder: GovernanceTier[] = ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'];
+  const maxIdx = tierOrder.indexOf(agent.maxGovernanceTier);
+  const trustDomains = tierOrder.slice(0, maxIdx + 1) as GovernanceTier[];
+
+  return {
+    agentId: agent.id,
+    roles: agent.capabilities,
+    catchCapacity: agent.maxConcurrentTasks,
+    currentLoad: agent.currentTaskCount,
+    reliability: agent.successRate,
+    trustDomains,
+    avgLatencyMs: 100, // default; refined by scheduler over time
+    lastCatchAt: agent.lastActiveAt,
+    consecutiveMisses: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Arc Height Selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Select arc height based on task risk and inertia.
+ * Rule 4: higher arcs for risky tasks (more validation slack).
+ * Rule 3: high-inertia tasks get moderate arcs (fewer handoffs).
+ */
+export function selectArcHeight(risk: number, inertia: number): ArcHeight {
+  const composite = 0.6 * risk + 0.4 * inertia;
+  if (composite >= 0.8) return 7;
+  if (composite >= 0.6) return 5;
+  if (composite >= 0.3) return 3;
+  if (composite >= 0.1) return 2;
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
+// TaskCapsule Factory
+// ---------------------------------------------------------------------------
+
+export interface CreateCapsuleOptions {
+  taskId: string;
+  payloadRef: string;
+  priority?: TaskPriority;
+  trustScore?: number;
+  inertia?: number;
+  risk?: number;
+  deadlineMs?: number;
+  nextCandidates?: string[];
+  fallbackCandidates?: string[];
+  requiredQuorum?: number;
+  requiredTier?: GovernanceTier;
+  integrityHash?: string | null;
+}
+
+/**
+ * Create a new TaskCapsule with sensible defaults.
+ */
+export function createCapsule(opts: CreateCapsuleOptions): TaskCapsule {
+  const now = Date.now();
+  const priority = PRIORITY_WEIGHTS[opts.priority ?? 'medium'];
+  const risk = opts.risk ?? 0.2;
+  const inertia = opts.inertia ?? 0.2;
+
+  return {
+    taskId: opts.taskId,
+    payloadRef: opts.payloadRef,
+    priority,
+    trustScore: opts.trustScore ?? 0.5,
+    inertia,
+    risk,
+    createdAt: now,
+    deadlineAt: now + (opts.deadlineMs ?? 30_000),
+    owner: null,
+    nextCandidates: opts.nextCandidates ?? [],
+    fallbackCandidates: opts.fallbackCandidates ?? [],
+    state: FlightState.HELD,
+    retryCount: 0,
+    requiredQuorum: opts.requiredQuorum ?? 1,
+    integrityHash: opts.integrityHash ?? null,
+    requiredTier: opts.requiredTier ?? 'KO',
+    arcHeight: selectArcHeight(risk, inertia),
+    lastTransitionAt: now,
+    provenance: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Juggling Scheduler
+// ---------------------------------------------------------------------------
+
+/**
+ * JugglingScheduler — governed task-flight coordinator.
+ *
+ * Work capsules move between specialized agents along predicted arcs,
+ * with explicit catches, bounded capacity, phase timing, and recovery
+ * on missed handoffs.
+ */
+export class JugglingScheduler {
+  private capsules: Map<string, TaskCapsule> = new Map();
+  private agents: Map<string, AgentSlot> = new Map();
+  private eventLog: JugglingEvent[] = [];
+  private receiptLog: HandoffReceipt[] = [];
+  private weights: ScoreWeights;
+  private gravityLambda: number;
+
+  constructor(weights: ScoreWeights = DEFAULT_SCORE_WEIGHTS, gravityLambda: number = DEFAULT_GRAVITY_LAMBDA) {
+    this.weights = weights;
+    this.gravityLambda = gravityLambda;
+  }
+
+  // ---- Agent Management ----
+
+  /** Register an agent slot */
+  registerAgent(slot: AgentSlot): void {
+    this.agents.set(slot.agentId, slot);
+  }
+
+  /** Register from FleetAgent */
+  registerFleetAgent(agent: FleetAgent): void {
+    this.registerAgent(agentSlotFromFleet(agent));
+  }
+
+  /** Remove an agent. Any tasks held by it enter RECOVERING. */
+  removeAgent(agentId: string): TaskCapsule[] {
+    this.agents.delete(agentId);
+    const orphaned: TaskCapsule[] = [];
+    for (const capsule of this.capsules.values()) {
+      if (capsule.owner === agentId && capsule.state !== FlightState.DONE) {
+        this.transition(capsule, FlightState.RECOVERING);
+        capsule.owner = null;
+        orphaned.push(capsule);
+      }
+    }
+    return orphaned;
+  }
+
+  /** Get agent slot */
+  getAgent(agentId: string): AgentSlot | undefined {
+    return this.agents.get(agentId);
+  }
+
+  // ---- Capsule Management ----
+
+  /** Add a capsule to the scheduler */
+  addCapsule(capsule: TaskCapsule): void {
+    this.capsules.set(capsule.taskId, capsule);
+  }
+
+  /** Get capsule by ID */
+  getCapsule(taskId: string): TaskCapsule | undefined {
+    return this.capsules.get(taskId);
+  }
+
+  /** Get all capsules in a given state */
+  getCapsulesByState(state: FlightState): TaskCapsule[] {
+    return Array.from(this.capsules.values()).filter((c) => c.state === state);
+  }
+
+  // ---- Core Scheduling ----
+
+  /**
+   * Rule 1 & 2: Find the best agent for a capsule.
+   * Never throw to an unready hand. Every throw needs a predicted catch window.
+   */
+  findBestReceiver(capsule: TaskCapsule): AgentSlot | null {
+    const now = Date.now();
+    const candidates = capsule.nextCandidates.length > 0
+      ? capsule.nextCandidates
+          .map((id) => this.agents.get(id))
+          .filter((a): a is AgentSlot => a !== undefined)
+      : Array.from(this.agents.values());
+
+    // Rule 1: filter to agents that can actually catch
+    const eligible = candidates.filter((a) => this.canCatch(a, capsule, now));
+
+    if (eligible.length === 0) {
+      // Rule 6: try fallback / interception candidates
+      const fallbacks = capsule.fallbackCandidates
+        .map((id) => this.agents.get(id))
+        .filter((a): a is AgentSlot => a !== undefined)
+        .filter((a) => this.canCatch(a, capsule, now));
+
+      if (fallbacks.length === 0) return null;
+      return this.pickBest(fallbacks, capsule, now);
+    }
+
+    return this.pickBest(eligible, capsule, now);
+  }
+
+  /**
+   * Throw a capsule to the best available agent.
+   * Returns the HandoffReceipt on success, null if no receiver available.
+   */
+  throwCapsule(taskId: string): HandoffReceipt | null {
+    const capsule = this.capsules.get(taskId);
+    if (!capsule) return null;
+
+    const receiver = this.findBestReceiver(capsule);
+    if (!receiver) {
+      // No available hand — mark recovering if not already
+      if (capsule.state !== FlightState.DROPPED) {
+        this.transition(capsule, FlightState.RECOVERING);
+      }
+      return null;
+    }
+
+    const senderId = capsule.owner ?? '__scheduler__';
+    const now = Date.now();
+
+    // Transition to THROWN
+    this.transition(capsule, FlightState.THROWN);
+
+    // Simulate catch (in a real system this would be async with timeout)
+    this.transition(capsule, FlightState.CAUGHT);
+    capsule.owner = receiver.agentId;
+    receiver.currentLoad++;
+    receiver.consecutiveMisses = 0;
+    receiver.lastCatchAt = now;
+
+    // Record provenance
+    capsule.provenance.push([receiver.agentId, now, FlightState.CAUGHT]);
+
+    // Build receipt (Rule 7: ledger catches)
+    const receipt: HandoffReceipt = {
+      taskId: capsule.taskId,
+      receiverId: receiver.agentId,
+      senderId,
+      timestamp: now,
+      integrityVerified: capsule.integrityHash !== null,
+      feasibilityConfirmed: true,
+      newOwner: receiver.agentId,
+    };
+    this.receiptLog.push(receipt);
+
+    this.emit({
+      type: 'catch',
+      taskId: capsule.taskId,
+      agentId: receiver.agentId,
+      timestamp: now,
+      data: { senderId, arcHeight: capsule.arcHeight },
+    });
+
+    // If quorum > 1, enter VALIDATING
+    if (capsule.requiredQuorum > 1) {
+      this.transition(capsule, FlightState.VALIDATING);
+    }
+
+    return receipt;
+  }
+
+  /**
+   * Mark a capsule as complete. Frees the agent's slot.
+   */
+  completeCapsule(taskId: string): boolean {
+    const capsule = this.capsules.get(taskId);
+    if (!capsule) return false;
+
+    const agent = capsule.owner ? this.agents.get(capsule.owner) : null;
+    if (agent && agent.currentLoad > 0) {
+      agent.currentLoad--;
+    }
+
+    this.transition(capsule, FlightState.DONE);
+    capsule.provenance.push([capsule.owner ?? '__none__', Date.now(), FlightState.DONE]);
+
+    this.emit({
+      type: 'complete',
+      taskId,
+      agentId: capsule.owner ?? undefined,
+      timestamp: Date.now(),
+      data: { retryCount: capsule.retryCount },
+    });
+
+    return true;
+  }
+
+  /**
+   * Handle a drop: increment retry, attempt re-throw or permanent drop.
+   * Rule 3: high-inertia tasks should not be bounced repeatedly.
+   */
+  handleDrop(taskId: string): HandoffReceipt | null {
+    const capsule = this.capsules.get(taskId);
+    if (!capsule) return null;
+
+    // Free previous owner's slot
+    if (capsule.owner) {
+      const prevAgent = this.agents.get(capsule.owner);
+      if (prevAgent) {
+        if (prevAgent.currentLoad > 0) prevAgent.currentLoad--;
+        prevAgent.consecutiveMisses++;
+      }
+    }
+
+    capsule.retryCount++;
+    capsule.owner = null;
+
+    this.emit({
+      type: 'drop',
+      taskId,
+      timestamp: Date.now(),
+      data: { retryCount: capsule.retryCount },
+    });
+
+    // Rule 3: high-inertia tasks with too many retries → permanent drop
+    if (capsule.retryCount >= MAX_RETRIES || (capsule.inertia > 0.7 && capsule.retryCount >= 2)) {
+      this.transition(capsule, FlightState.DROPPED);
+      return null;
+    }
+
+    // Try re-throw (Rule 6: interception)
+    this.transition(capsule, FlightState.RECOVERING);
+    return this.throwCapsule(taskId);
+  }
+
+  // ---- Phase Monitoring ----
+
+  /**
+   * Rule 5: Detect phase drift.
+   * Returns the ratio of overdue in-flight capsules.
+   */
+  detectPhaseDrift(): number {
+    const now = Date.now();
+    const inFlight = this.getCapsulesByState(FlightState.THROWN);
+    const recovering = this.getCapsulesByState(FlightState.RECOVERING);
+    const all = [...inFlight, ...recovering];
+
+    if (all.length === 0) return 0;
+
+    const overdue = all.filter((c) => now > c.deadlineAt).length;
+    const drift = overdue / all.length;
+
+    if (drift >= PHASE_DRIFT_THRESHOLD) {
+      this.emit({
+        type: 'phase_drift',
+        taskId: '__system__',
+        timestamp: now,
+        data: { drift, overdueCount: overdue, totalInFlight: all.length },
+      });
+    }
+
+    return drift;
+  }
+
+  /**
+   * Check agents for capacity warnings.
+   * Emits events when load exceeds 80% of catch capacity.
+   */
+  checkCapacity(): void {
+    const now = Date.now();
+    for (const agent of this.agents.values()) {
+      const ratio = agent.currentLoad / Math.max(agent.catchCapacity, 1);
+      if (ratio >= 0.8) {
+        this.emit({
+          type: 'capacity_warning',
+          taskId: '__system__',
+          agentId: agent.agentId,
+          timestamp: now,
+          data: { loadRatio: ratio, currentLoad: agent.currentLoad, capacity: agent.catchCapacity },
+        });
+      }
+    }
+  }
+
+  // ---- Metrics ----
+
+  /** Get current scheduler health metrics */
+  getMetrics(): SchedulerMetrics {
+    const now = Date.now();
+    const allCapsules = Array.from(this.capsules.values());
+
+    const inFlight = allCapsules.filter((c) => c.state === FlightState.THROWN).length;
+    const held = allCapsules.filter(
+      (c) => c.state === FlightState.HELD || c.state === FlightState.CAUGHT || c.state === FlightState.VALIDATING,
+    ).length;
+    const drops = allCapsules.filter((c) => c.state === FlightState.DROPPED).length;
+    const done = allCapsules.filter((c) => c.state === FlightState.DONE).length;
+
+    // Compute average arc time from receipts
+    let avgArcTimeMs = 0;
+    if (this.receiptLog.length > 0) {
+      const recentReceipts = this.receiptLog.slice(-50);
+      const arcTimes = recentReceipts.map((r) => {
+        const capsule = this.capsules.get(r.taskId);
+        return capsule ? r.timestamp - capsule.createdAt : 0;
+      });
+      avgArcTimeMs = arcTimes.reduce((a, b) => a + b, 0) / arcTimes.length;
+    }
+
+    const drift = this.detectPhaseDrift();
+    const total = allCapsules.length || 1;
+
+    return {
+      inFlight,
+      held,
+      drops,
+      catches: done,
+      phaseDrift: drift,
+      avgArcTimeMs,
+      cadenceHealth: Math.max(0, 1 - drift - drops / total),
+    };
+  }
+
+  // ---- Batch Operations ----
+
+  /**
+   * Tick the scheduler: expire overdue capsules, attempt recovery, check phase.
+   * Call this on a regular cadence (e.g., every 500ms–2s).
+   */
+  tick(): SchedulerMetrics {
+    const now = Date.now();
+
+    // Expire overdue capsules
+    for (const capsule of this.capsules.values()) {
+      if (capsule.state === FlightState.DONE || capsule.state === FlightState.DROPPED) continue;
+
+      if (now > capsule.deadlineAt) {
+        this.handleDrop(capsule.taskId);
+      }
+    }
+
+    // Attempt to assign unowned capsules
+    for (const capsule of this.getCapsulesByState(FlightState.HELD)) {
+      if (!capsule.owner) {
+        this.throwCapsule(capsule.taskId);
+      }
+    }
+
+    // Retry recovering capsules
+    for (const capsule of this.getCapsulesByState(FlightState.RECOVERING)) {
+      this.throwCapsule(capsule.taskId);
+    }
+
+    this.checkCapacity();
+    return this.getMetrics();
+  }
+
+  // ---- Siteswap Pattern Encoding ----
+
+  /**
+   * Encode a capsule's journey as a siteswap-like string.
+   * Numbers = arc heights, Q = quorum gate, x = cross-agent.
+   */
+  encodeSiteswap(taskId: string): string {
+    const capsule = this.capsules.get(taskId);
+    if (!capsule) return '';
+
+    const parts: string[] = [];
+    for (const [agentId, , state] of capsule.provenance) {
+      if (state === FlightState.CAUGHT) {
+        parts.push(`${capsule.arcHeight}`);
+      } else if (state === FlightState.VALIDATING) {
+        parts.push(`${capsule.arcHeight}Q`);
+      } else if (state === FlightState.DONE) {
+        parts.push('0');
+      }
+    }
+    return parts.join(' -> ');
+  }
+
+  // ---- Event System ----
+
+  /** Get all events (for audit/ledger) */
+  getEvents(): readonly JugglingEvent[] {
+    return this.eventLog;
+  }
+
+  /** Get all receipts (Rule 7) */
+  getReceipts(): readonly HandoffReceipt[] {
+    return this.receiptLog;
+  }
+
+  /** Clear event log (for testing / rotation) */
+  clearEvents(): void {
+    this.eventLog = [];
+  }
+
+  // ---- Internal ----
+
+  /** Check if an agent can catch a capsule (Rule 1) */
+  private canCatch(agent: AgentSlot, capsule: TaskCapsule, now: number): boolean {
+    // Capacity check
+    if (agent.currentLoad >= agent.catchCapacity) return false;
+
+    // Deadline check — agent must be able to receive before expiry
+    if (now + agent.avgLatencyMs > capsule.deadlineAt) return false;
+
+    // Governance tier check
+    const tierOrder: GovernanceTier[] = ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'];
+    const requiredIdx = tierOrder.indexOf(capsule.requiredTier);
+    const maxAgentIdx = Math.max(...agent.trustDomains.map((t) => tierOrder.indexOf(t)));
+    if (maxAgentIdx < requiredIdx) return false;
+
+    return true;
+  }
+
+  /** Pick the best agent from an eligible set */
+  private pickBest(eligible: AgentSlot[], capsule: TaskCapsule, now: number): AgentSlot {
+    let best = eligible[0];
+    let bestScore = -Infinity;
+
+    for (const agent of eligible) {
+      const score = assignmentScore(capsule, agent, now, this.weights);
+      if (score > bestScore) {
+        bestScore = score;
+        best = agent;
+      }
+    }
+
+    return best;
+  }
+
+  /** Transition a capsule to a new state */
+  private transition(capsule: TaskCapsule, newState: FlightState): void {
+    capsule.state = newState;
+    capsule.lastTransitionAt = Date.now();
+  }
+
+  /** Emit a juggling event */
+  private emit(event: JugglingEvent): void {
+    this.eventLog.push(event);
+  }
+}

--- a/tests/fleet/juggling-scheduler.test.ts
+++ b/tests/fleet/juggling-scheduler.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Juggling Agent Coordination Scheduler Tests
+ *
+ * @module tests/fleet/juggling-scheduler
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  FlightState,
+  JugglingScheduler,
+  TaskCapsule,
+  AgentSlot,
+  createCapsule,
+  assignmentScore,
+  recoverability,
+  selectArcHeight,
+  agentSlotFromFleet,
+  DEFAULT_SCORE_WEIGHTS,
+  MAX_RETRIES,
+  PHASE_DRIFT_THRESHOLD,
+} from '../../src/fleet/juggling-scheduler';
+import type { FleetAgent, GovernanceTier } from '../../src/fleet/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAgent(overrides: Partial<AgentSlot> = {}): AgentSlot {
+  return {
+    agentId: 'agent-1',
+    roles: ['code_generation'],
+    catchCapacity: 3,
+    currentLoad: 0,
+    reliability: 0.9,
+    trustDomains: ['KO', 'AV', 'RU'] as GovernanceTier[],
+    avgLatencyMs: 50,
+    lastCatchAt: Date.now(),
+    consecutiveMisses: 0,
+    ...overrides,
+  };
+}
+
+function makeCapsule(overrides: Partial<ReturnType<typeof createCapsule>> = {}): TaskCapsule {
+  const base = createCapsule({
+    taskId: 'task-1',
+    payloadRef: 'ref://payload/1',
+    priority: 'medium',
+    trustScore: 0.6,
+    inertia: 0.2,
+    risk: 0.3,
+    deadlineMs: 30_000,
+    requiredTier: 'KO',
+  });
+  return { ...base, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Unit Tests
+// ---------------------------------------------------------------------------
+
+describe('JugglingScheduler', () => {
+  let scheduler: JugglingScheduler;
+
+  beforeEach(() => {
+    scheduler = new JugglingScheduler();
+  });
+
+  // ---- FlightState ----
+
+  describe('FlightState enum', () => {
+    it('should have all required states', () => {
+      expect(FlightState.HELD).toBe('held');
+      expect(FlightState.THROWN).toBe('thrown');
+      expect(FlightState.CAUGHT).toBe('caught');
+      expect(FlightState.VALIDATING).toBe('validating');
+      expect(FlightState.RECOVERING).toBe('recovering');
+      expect(FlightState.DROPPED).toBe('dropped');
+      expect(FlightState.DONE).toBe('done');
+    });
+  });
+
+  // ---- Scoring ----
+
+  describe('assignmentScore', () => {
+    it('should return higher score for more reliable agents', () => {
+      const task = makeCapsule();
+      const agentA = makeAgent({ agentId: 'a', reliability: 0.95 });
+      const agentB = makeAgent({ agentId: 'b', reliability: 0.5 });
+      const now = Date.now();
+
+      expect(assignmentScore(task, agentA, now)).toBeGreaterThan(assignmentScore(task, agentB, now));
+    });
+
+    it('should penalise loaded agents', () => {
+      const task = makeCapsule();
+      const idle = makeAgent({ agentId: 'idle', currentLoad: 0 });
+      const busy = makeAgent({ agentId: 'busy', currentLoad: 2 });
+      const now = Date.now();
+
+      expect(assignmentScore(task, idle, now)).toBeGreaterThan(assignmentScore(task, busy, now));
+    });
+
+    it('should penalise high-risk tasks', () => {
+      const low = makeCapsule({ taskId: 'low', risk: 0.1 });
+      const high = makeCapsule({ taskId: 'high', risk: 0.9 });
+      const agent = makeAgent();
+      const now = Date.now();
+
+      expect(assignmentScore(low, agent, now)).toBeGreaterThan(assignmentScore(high, agent, now));
+    });
+
+    it('should penalise governance tier mismatch', () => {
+      const task = makeCapsule({ requiredTier: 'DR' });
+      const lowTier = makeAgent({ agentId: 'low', trustDomains: ['KO'] as GovernanceTier[] });
+      const highTier = makeAgent({ agentId: 'high', trustDomains: ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'] as GovernanceTier[] });
+      const now = Date.now();
+
+      expect(assignmentScore(task, highTier, now)).toBeGreaterThan(assignmentScore(task, lowTier, now));
+    });
+  });
+
+  // ---- Recoverability ----
+
+  describe('recoverability', () => {
+    it('should return 1.0 at creation time', () => {
+      const task = makeCapsule();
+      expect(recoverability(task, task.createdAt)).toBeCloseTo(1.0);
+    });
+
+    it('should decay over time', () => {
+      const task = makeCapsule();
+      const later = task.createdAt + 20_000; // 20s later
+      expect(recoverability(task, later)).toBeLessThan(1.0);
+      expect(recoverability(task, later)).toBeGreaterThan(0);
+    });
+
+    it('should decay faster with higher lambda', () => {
+      const task = makeCapsule();
+      const later = task.createdAt + 10_000;
+      expect(recoverability(task, later, 0.1)).toBeLessThan(recoverability(task, later, 0.01));
+    });
+  });
+
+  // ---- Arc Height ----
+
+  describe('selectArcHeight', () => {
+    it('should return 1 for very low risk/inertia', () => {
+      expect(selectArcHeight(0, 0)).toBe(1);
+    });
+
+    it('should return 7 for very high risk/inertia', () => {
+      expect(selectArcHeight(1.0, 1.0)).toBe(7);
+    });
+
+    it('should increase with risk', () => {
+      const low = selectArcHeight(0.1, 0.1);
+      const high = selectArcHeight(0.9, 0.1);
+      expect(high).toBeGreaterThanOrEqual(low);
+    });
+  });
+
+  // ---- Capsule Factory ----
+
+  describe('createCapsule', () => {
+    it('should create a capsule in HELD state', () => {
+      const c = createCapsule({ taskId: 'x', payloadRef: 'ref://x' });
+      expect(c.state).toBe(FlightState.HELD);
+      expect(c.owner).toBeNull();
+      expect(c.retryCount).toBe(0);
+    });
+
+    it('should set arc height from risk/inertia', () => {
+      const c = createCapsule({ taskId: 'x', payloadRef: 'ref://x', risk: 0.9, inertia: 0.9 });
+      expect(c.arcHeight).toBe(7);
+    });
+
+    it('should set deadline relative to now', () => {
+      const before = Date.now();
+      const c = createCapsule({ taskId: 'x', payloadRef: 'ref://x', deadlineMs: 5000 });
+      expect(c.deadlineAt).toBeGreaterThanOrEqual(before + 5000);
+    });
+  });
+
+  // ---- Agent Registration ----
+
+  describe('Agent management', () => {
+    it('should register and retrieve agents', () => {
+      const agent = makeAgent();
+      scheduler.registerAgent(agent);
+      expect(scheduler.getAgent('agent-1')).toBeDefined();
+      expect(scheduler.getAgent('agent-1')!.reliability).toBe(0.9);
+    });
+
+    it('should orphan tasks when agent is removed', () => {
+      const agent = makeAgent();
+      scheduler.registerAgent(agent);
+
+      const capsule = makeCapsule({ owner: 'agent-1', state: FlightState.CAUGHT });
+      scheduler.addCapsule(capsule);
+
+      const orphaned = scheduler.removeAgent('agent-1');
+      expect(orphaned).toHaveLength(1);
+      expect(orphaned[0].state).toBe(FlightState.RECOVERING);
+      expect(orphaned[0].owner).toBeNull();
+    });
+  });
+
+  // ---- Core Scheduling: Throw & Catch ----
+
+  describe('throwCapsule', () => {
+    it('should assign capsule to the best available agent', () => {
+      scheduler.registerAgent(makeAgent({ agentId: 'a1', reliability: 0.9 }));
+      scheduler.registerAgent(makeAgent({ agentId: 'a2', reliability: 0.7 }));
+
+      const capsule = makeCapsule({ nextCandidates: ['a1', 'a2'] });
+      scheduler.addCapsule(capsule);
+
+      const receipt = scheduler.throwCapsule('task-1');
+      expect(receipt).not.toBeNull();
+      expect(receipt!.receiverId).toBe('a1'); // higher reliability wins
+      expect(receipt!.feasibilityConfirmed).toBe(true);
+
+      const updated = scheduler.getCapsule('task-1')!;
+      expect(updated.owner).toBe('a1');
+      expect(updated.state).toBe(FlightState.CAUGHT);
+    });
+
+    it('should fall back to fallback candidates when primaries are full', () => {
+      scheduler.registerAgent(makeAgent({ agentId: 'primary', catchCapacity: 1, currentLoad: 1 }));
+      scheduler.registerAgent(makeAgent({ agentId: 'backup', reliability: 0.8 }));
+
+      const capsule = makeCapsule({
+        nextCandidates: ['primary'],
+        fallbackCandidates: ['backup'],
+      });
+      scheduler.addCapsule(capsule);
+
+      const receipt = scheduler.throwCapsule('task-1');
+      expect(receipt).not.toBeNull();
+      expect(receipt!.receiverId).toBe('backup');
+    });
+
+    it('should return null when no agent can catch', () => {
+      scheduler.registerAgent(makeAgent({ agentId: 'full', catchCapacity: 1, currentLoad: 1 }));
+
+      const capsule = makeCapsule({ nextCandidates: ['full'] });
+      scheduler.addCapsule(capsule);
+
+      const receipt = scheduler.throwCapsule('task-1');
+      expect(receipt).toBeNull();
+    });
+
+    it('should refuse agents below required governance tier', () => {
+      scheduler.registerAgent(makeAgent({
+        agentId: 'low',
+        trustDomains: ['KO'] as GovernanceTier[],
+      }));
+
+      const capsule = makeCapsule({ requiredTier: 'DR' });
+      scheduler.addCapsule(capsule);
+
+      const receipt = scheduler.throwCapsule('task-1');
+      expect(receipt).toBeNull();
+    });
+
+    it('should enter VALIDATING for quorum > 1', () => {
+      scheduler.registerAgent(makeAgent());
+
+      const capsule = makeCapsule({ requiredQuorum: 3 });
+      scheduler.addCapsule(capsule);
+
+      scheduler.throwCapsule('task-1');
+      expect(scheduler.getCapsule('task-1')!.state).toBe(FlightState.VALIDATING);
+    });
+  });
+
+  // ---- Completion ----
+
+  describe('completeCapsule', () => {
+    it('should mark capsule DONE and free agent slot', () => {
+      const agent = makeAgent();
+      scheduler.registerAgent(agent);
+
+      const capsule = makeCapsule();
+      scheduler.addCapsule(capsule);
+      scheduler.throwCapsule('task-1');
+
+      expect(scheduler.getAgent('agent-1')!.currentLoad).toBe(1);
+
+      const ok = scheduler.completeCapsule('task-1');
+      expect(ok).toBe(true);
+      expect(scheduler.getCapsule('task-1')!.state).toBe(FlightState.DONE);
+      expect(scheduler.getAgent('agent-1')!.currentLoad).toBe(0);
+    });
+
+    it('should record provenance for completion', () => {
+      scheduler.registerAgent(makeAgent());
+      const capsule = makeCapsule();
+      scheduler.addCapsule(capsule);
+      scheduler.throwCapsule('task-1');
+      scheduler.completeCapsule('task-1');
+
+      const c = scheduler.getCapsule('task-1')!;
+      const doneEntries = c.provenance.filter(([, , s]) => s === FlightState.DONE);
+      expect(doneEntries.length).toBe(1);
+    });
+  });
+
+  // ---- Drop & Recovery ----
+
+  describe('handleDrop', () => {
+    it('should increment retry and re-throw on first drop', () => {
+      scheduler.registerAgent(makeAgent({ agentId: 'a1' }));
+      scheduler.registerAgent(makeAgent({ agentId: 'a2' }));
+
+      const capsule = makeCapsule({ owner: 'a1' });
+      capsule.state = FlightState.CAUGHT;
+      scheduler.addCapsule(capsule);
+
+      const receipt = scheduler.handleDrop('task-1');
+      expect(receipt).not.toBeNull();
+      expect(scheduler.getCapsule('task-1')!.retryCount).toBe(1);
+    });
+
+    it('should permanently drop after MAX_RETRIES', () => {
+      scheduler.registerAgent(makeAgent());
+      const capsule = makeCapsule({ retryCount: MAX_RETRIES - 1 });
+      scheduler.addCapsule(capsule);
+
+      scheduler.handleDrop('task-1');
+      expect(scheduler.getCapsule('task-1')!.state).toBe(FlightState.DROPPED);
+    });
+
+    it('should drop high-inertia tasks earlier (Rule 3)', () => {
+      scheduler.registerAgent(makeAgent());
+      const capsule = makeCapsule({ inertia: 0.8, retryCount: 1 });
+      scheduler.addCapsule(capsule);
+
+      scheduler.handleDrop('task-1');
+      expect(scheduler.getCapsule('task-1')!.state).toBe(FlightState.DROPPED);
+    });
+  });
+
+  // ---- Phase Drift ----
+
+  describe('detectPhaseDrift', () => {
+    it('should return 0 when no capsules are in flight', () => {
+      expect(scheduler.detectPhaseDrift()).toBe(0);
+    });
+
+    it('should detect drift when capsules are overdue', () => {
+      // Create already-expired capsule in RECOVERING state
+      const capsule = makeCapsule({
+        deadlineAt: Date.now() - 1000,
+        state: FlightState.RECOVERING,
+      });
+      scheduler.addCapsule(capsule);
+
+      const drift = scheduler.detectPhaseDrift();
+      expect(drift).toBe(1.0);
+    });
+  });
+
+  // ---- Metrics ----
+
+  describe('getMetrics', () => {
+    it('should report correct counts', () => {
+      scheduler.registerAgent(makeAgent());
+
+      const c1 = makeCapsule({ taskId: 't1' });
+      const c2 = makeCapsule({ taskId: 't2' });
+      scheduler.addCapsule(c1);
+      scheduler.addCapsule(c2);
+
+      scheduler.throwCapsule('t1');
+      scheduler.completeCapsule('t1');
+
+      const m = scheduler.getMetrics();
+      expect(m.catches).toBe(1); // t1 done
+      expect(m.held).toBe(1); // t2 still held
+    });
+
+    it('should report cadence health between 0 and 1', () => {
+      const m = scheduler.getMetrics();
+      expect(m.cadenceHealth).toBeGreaterThanOrEqual(0);
+      expect(m.cadenceHealth).toBeLessThanOrEqual(1);
+    });
+  });
+
+  // ---- Tick ----
+
+  describe('tick', () => {
+    it('should assign unowned HELD capsules', () => {
+      scheduler.registerAgent(makeAgent());
+      const capsule = makeCapsule();
+      scheduler.addCapsule(capsule);
+
+      scheduler.tick();
+
+      const updated = scheduler.getCapsule('task-1')!;
+      expect(updated.owner).not.toBeNull();
+      expect(updated.state).not.toBe(FlightState.HELD);
+    });
+
+    it('should expire overdue capsules', () => {
+      scheduler.registerAgent(makeAgent());
+      const capsule = makeCapsule({
+        taskId: 'expired',
+        deadlineAt: Date.now() - 1000,
+        state: FlightState.CAUGHT,
+        owner: 'agent-1',
+      });
+      scheduler.addCapsule(capsule);
+
+      scheduler.tick();
+
+      const updated = scheduler.getCapsule('expired')!;
+      expect([FlightState.DROPPED, FlightState.CAUGHT, FlightState.RECOVERING]).toContain(updated.state);
+    });
+  });
+
+  // ---- Siteswap Encoding ----
+
+  describe('encodeSiteswap', () => {
+    it('should encode a catch-complete journey', () => {
+      scheduler.registerAgent(makeAgent());
+      const capsule = makeCapsule({ arcHeight: 3 });
+      scheduler.addCapsule(capsule);
+      scheduler.throwCapsule('task-1');
+      scheduler.completeCapsule('task-1');
+
+      const ss = scheduler.encodeSiteswap('task-1');
+      expect(ss).toContain('3');
+      expect(ss).toContain('0');
+    });
+
+    it('should include Q for quorum-validated tasks', () => {
+      scheduler.registerAgent(makeAgent());
+      const capsule = makeCapsule({ requiredQuorum: 2, arcHeight: 5 });
+      scheduler.addCapsule(capsule);
+      scheduler.throwCapsule('task-1');
+
+      const ss = scheduler.encodeSiteswap('task-1');
+      expect(ss).toContain('5');
+    });
+  });
+
+  // ---- Event Ledger (Rule 7) ----
+
+  describe('Event ledger', () => {
+    it('should record catch events', () => {
+      scheduler.registerAgent(makeAgent());
+      scheduler.addCapsule(makeCapsule());
+      scheduler.throwCapsule('task-1');
+
+      const catchEvents = scheduler.getEvents().filter((e) => e.type === 'catch');
+      expect(catchEvents.length).toBe(1);
+      expect(catchEvents[0].agentId).toBe('agent-1');
+    });
+
+    it('should record drop events', () => {
+      scheduler.registerAgent(makeAgent());
+      const capsule = makeCapsule({ retryCount: MAX_RETRIES - 1 });
+      scheduler.addCapsule(capsule);
+      scheduler.handleDrop('task-1');
+
+      const dropEvents = scheduler.getEvents().filter((e) => e.type === 'drop');
+      expect(dropEvents.length).toBe(1);
+    });
+
+    it('should produce HandoffReceipts for every catch', () => {
+      scheduler.registerAgent(makeAgent());
+      scheduler.addCapsule(makeCapsule());
+      scheduler.throwCapsule('task-1');
+
+      const receipts = scheduler.getReceipts();
+      expect(receipts.length).toBe(1);
+      expect(receipts[0].receiverId).toBe('agent-1');
+      expect(receipts[0].newOwner).toBe('agent-1');
+    });
+  });
+
+  // ---- FleetAgent Bridge ----
+
+  describe('agentSlotFromFleet', () => {
+    it('should convert a FleetAgent into an AgentSlot', () => {
+      const fleet: FleetAgent = {
+        id: 'fleet-1',
+        name: 'TestBot',
+        description: 'A test agent',
+        provider: 'anthropic',
+        model: 'claude-opus-4-6',
+        capabilities: ['code_generation', 'code_review'],
+        status: 'idle',
+        trustVector: [1, 0.5, 0.3, 0, 0, 0],
+        maxConcurrentTasks: 5,
+        currentTaskCount: 2,
+        maxGovernanceTier: 'CA',
+        registeredAt: Date.now(),
+        lastActiveAt: Date.now(),
+        tasksCompleted: 100,
+        successRate: 0.92,
+      };
+
+      const slot = agentSlotFromFleet(fleet);
+
+      expect(slot.agentId).toBe('fleet-1');
+      expect(slot.catchCapacity).toBe(5);
+      expect(slot.currentLoad).toBe(2);
+      expect(slot.reliability).toBe(0.92);
+      expect(slot.trustDomains).toEqual(['KO', 'AV', 'RU', 'CA']);
+    });
+  });
+});


### PR DESCRIPTION
Physics-based multi-agent task coordination modeled as a juggling system.
Maps balls→TaskCapsules, hands→AgentSlots, throws→handoffs, arcs→deadlines,
drops→failures with 7 governing rules for bounded, phase-locked orchestration.

TypeScript canonical (src/fleet/juggling-scheduler.ts), Python reference
(hydra/juggling_scheduler.py), 38 vitest tests all passing.

https://claude.ai/code/session_01FSqLKDrUi7i9i5LtkHLQky