### PR TITLE
fix(lint): apply Prettier formatting to juggling scheduler

### DIFF
--- a/src/fleet/juggling-scheduler.ts
+++ b/src/fleet/juggling-scheduler.ts
@@ -25,7 +25,13 @@
  *   7. Ledger catches, not just throws
  */
 
-import { FleetAgent, GovernanceTier, GOVERNANCE_TIERS, TaskPriority, PRIORITY_WEIGHTS } from './types';
+import {
+  FleetAgent,
+  GovernanceTier,
+  GOVERNANCE_TIERS,
+  TaskPriority,
+  PRIORITY_WEIGHTS,
+} from './types';
 
 // ---------------------------------------------------------------------------
 // Enums & Constants
@@ -285,7 +291,7 @@ export function assignmentScore(
   task: TaskCapsule,
   agent: AgentSlot,
   now: number,
-  weights: ScoreWeights = DEFAULT_SCORE_WEIGHTS,
+  weights: ScoreWeights = DEFAULT_SCORE_WEIGHTS
 ): number {
   const timeLeft = Math.max(task.deadlineAt - now, 1e-3);
   const loadRatio = agent.currentLoad / Math.max(agent.catchCapacity, 1);
@@ -312,7 +318,11 @@ export function assignmentScore(
  * U(t) = e^(-lambda * elapsed_seconds)
  * Returns [0, 1] where 1 = fully recoverable, 0 = expired.
  */
-export function recoverability(task: TaskCapsule, now: number, lambda: number = DEFAULT_GRAVITY_LAMBDA): number {
+export function recoverability(
+  task: TaskCapsule,
+  now: number,
+  lambda: number = DEFAULT_GRAVITY_LAMBDA
+): number {
   const elapsedSec = Math.max(now - task.createdAt, 0) / 1000;
   return Math.exp(-lambda * elapsedSec);
 }
@@ -431,7 +441,10 @@ export class JugglingScheduler {
   private weights: ScoreWeights;
   private gravityLambda: number;
 
-  constructor(weights: ScoreWeights = DEFAULT_SCORE_WEIGHTS, gravityLambda: number = DEFAULT_GRAVITY_LAMBDA) {
+  constructor(
+    weights: ScoreWeights = DEFAULT_SCORE_WEIGHTS,
+    gravityLambda: number = DEFAULT_GRAVITY_LAMBDA
+  ) {
     this.weights = weights;
     this.gravityLambda = gravityLambda;
   }
@@ -492,11 +505,12 @@ export class JugglingScheduler {
    */
   findBestReceiver(capsule: TaskCapsule): AgentSlot | null {
     const now = Date.now();
-    const candidates = capsule.nextCandidates.length > 0
-      ? capsule.nextCandidates
-          .map((id) => this.agents.get(id))
-          .filter((a): a is AgentSlot => a !== undefined)
-      : Array.from(this.agents.values());
+    const candidates =
+      capsule.nextCandidates.length > 0
+        ? capsule.nextCandidates
+            .map((id) => this.agents.get(id))
+            .filter((a): a is AgentSlot => a !== undefined)
+        : Array.from(this.agents.values());
 
     // Rule 1: filter to agents that can actually catch
     const eligible = candidates.filter((a) => this.canCatch(a, capsule, now));
@@ -698,7 +712,10 @@ export class JugglingScheduler {
 
     const inFlight = allCapsules.filter((c) => c.state === FlightState.THROWN).length;
     const held = allCapsules.filter(
-      (c) => c.state === FlightState.HELD || c.state === FlightState.CAUGHT || c.state === FlightState.VALIDATING,
+      (c) =>
+        c.state === FlightState.HELD ||
+        c.state === FlightState.CAUGHT ||
+        c.state === FlightState.VALIDATING
     ).length;
     const drops = allCapsules.filter((c) => c.state === FlightState.DROPPED).length;
     const done = allCapsules.filter((c) => c.state === FlightState.DONE).length;

--- a/tests/fleet/juggling-scheduler.test.ts
+++ b/tests/fleet/juggling-scheduler.test.ts
@@ -88,7 +88,9 @@ describe('JugglingScheduler', () => {
       const agentB = makeAgent({ agentId: 'b', reliability: 0.5 });
       const now = Date.now();
 
-      expect(assignmentScore(task, agentA, now)).toBeGreaterThan(assignmentScore(task, agentB, now));
+      expect(assignmentScore(task, agentA, now)).toBeGreaterThan(
+        assignmentScore(task, agentB, now)
+      );
     });
 
     it('should penalise loaded agents', () => {
@@ -112,10 +114,15 @@ describe('JugglingScheduler', () => {
     it('should penalise governance tier mismatch', () => {
       const task = makeCapsule({ requiredTier: 'DR' });
       const lowTier = makeAgent({ agentId: 'low', trustDomains: ['KO'] as GovernanceTier[] });
-      const highTier = makeAgent({ agentId: 'high', trustDomains: ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'] as GovernanceTier[] });
+      const highTier = makeAgent({
+        agentId: 'high',
+        trustDomains: ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'] as GovernanceTier[],
+      });
       const now = Date.now();
 
-      expect(assignmentScore(task, highTier, now)).toBeGreaterThan(assignmentScore(task, lowTier, now));
+      expect(assignmentScore(task, highTier, now)).toBeGreaterThan(
+        assignmentScore(task, lowTier, now)
+      );
     });
   });
 
@@ -251,10 +258,12 @@ describe('JugglingScheduler', () => {
     });
 
     it('should refuse agents below required governance tier', () => {
-      scheduler.registerAgent(makeAgent({
-        agentId: 'low',
-        trustDomains: ['KO'] as GovernanceTier[],
-      }));
+      scheduler.registerAgent(
+        makeAgent({
+          agentId: 'low',
+          trustDomains: ['KO'] as GovernanceTier[],
+        })
+      );
 
       const capsule = makeCapsule({ requiredTier: 'DR' });
       scheduler.addCapsule(capsule);
@@ -415,7 +424,9 @@ describe('JugglingScheduler', () => {
       scheduler.tick();
 
       const updated = scheduler.getCapsule('expired')!;
-      expect([FlightState.DROPPED, FlightState.CAUGHT, FlightState.RECOVERING]).toContain(updated.state);
+      expect([FlightState.DROPPED, FlightState.CAUGHT, FlightState.RECOVERING]).toContain(
+        updated.state
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix `npm run lint` failure introduced by PR #745 (juggling scheduler)
- Apply standard Prettier formatting to `src/fleet/juggling-scheduler.ts` and `tests/fleet/juggling-scheduler.test.ts`
- Changes are formatting-only (line breaks for long signatures, trailing comma style)

## Context
PR #745 added the juggling agent coordination scheduler but the files were not run through Prettier before merge, causing CI lint checks to fail.

## Test plan
- [x] `npm run lint` — clean (all files pass Prettier check)
- [x] `npm run build` — clean compile, zero errors
- [x] `npx vitest run` — 5901 passed, 8 skipped, 0 failures
- [x] `npm run check:circular` — no circular dependencies (305 files)
- [x] `npm audit` — 0 vulnerabilities

Fixes lint regression from #745. Related to #729 (codebase health).

https://claude.ai/code/session_01WLhD4Q7m4zj2Gu1SKXZ6gX