### PR TITLE
fix(ci): harden security gates and standardize Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: ['20', '22']
 
     steps:
       - name: Checkout code
@@ -117,7 +117,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -140,7 +140,6 @@ jobs:
 
       - name: Run ruff (fast lint)
         run: ruff check --config ruff.toml
-        continue-on-error: true
 
       - name: Run flake8
         run: flake8 src/ tests/
@@ -155,17 +154,16 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
       - name: Run npm audit
         run: npm audit --audit-level=moderate
-        continue-on-error: true
 
       - name: Run Snyk security scan
         uses: snyk/actions/node@v3
-        continue-on-error: true
+        continue-on-error: true  # Requires SNYK_TOKEN secret; non-blocking if unconfigured
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -73,3 +73,24 @@ jobs:
           echo "- bandit: ${{ steps.bandit.outcome }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- npm audit: ${{ steps.npm_audit.outcome || 'skipped' }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- pip-audit: ${{ steps.pip_audit.outcome || 'skipped' }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if any security check failed
+        if: always()
+        run: |
+          failed=0
+          if [ "${{ steps.bandit.outcome }}" = "failure" ]; then
+            echo "::error::Bandit security scan found issues"
+            failed=1
+          fi
+          if [ "${{ steps.npm_audit.outcome }}" = "failure" ]; then
+            echo "::error::npm audit found vulnerabilities"
+            failed=1
+          fi
+          if [ "${{ steps.pip_audit.outcome }}" = "failure" ]; then
+            echo "::error::pip-audit found vulnerabilities"
+            failed=1
+          fi
+          if [ "$failed" -eq 1 ]; then
+            echo "::error::One or more security checks failed — see summary above"
+            exit 1
+          fi

--- a/src/governance/audit_ledger.ts
+++ b/src/governance/audit_ledger.ts
@@ -1,2 +1,8 @@
+/**
+ * @file audit_ledger.ts
+ * @module governance/audit-ledger
+ * @layer Layer 13
+ * @component Audit event ledger re-export
+ */
 export { AuditLedger } from './offline_mode.js';
 export type { AuditEvent } from './offline_mode.js';

--- a/src/governance/flux_manifest.ts
+++ b/src/governance/flux_manifest.ts
@@ -1,3 +1,9 @@
+/**
+ * @file flux_manifest.ts
+ * @module governance/flux-manifest
+ * @layer Layer 13
+ * @component Flux manifest validation
+ */
 import type { FluxManifest } from './offline_mode.js';
 import { isManifestStale, verifyManifest } from './offline_mode.js';
 

--- a/src/governance/governance_engine.ts
+++ b/src/governance/governance_engine.ts
@@ -1,3 +1,9 @@
+/**
+ * @file governance_engine.ts
+ * @module governance/governance-engine
+ * @layer Layer 13
+ * @component Governance decision engine
+ */
 import type { DecisionResult, EnforcementRequest, OfflineRuntime } from './offline_mode.js';
 import { DECIDE } from './offline_mode.js';
 

--- a/src/governance/index.ts
+++ b/src/governance/index.ts
@@ -1,3 +1,9 @@
+/**
+ * @file index.ts
+ * @module governance
+ * @layer Layer 13
+ * @component Governance barrel export
+ */
 export * from './offline_mode.js';
 export * from './immutable_laws.js';
 export * from './flux_manifest.js';

--- a/src/governance/mmx.ts
+++ b/src/governance/mmx.ts
@@ -1,3 +1,9 @@
+/**
+ * @file mmx.ts
+ * @module governance/mmx
+ * @layer Layer 13
+ * @component Multi-model matrix scalars
+ */
 import type { EnforcementContext, EnforcementRequest } from './offline_mode.js';
 
 export interface MMXScalars {

--- a/src/governance/pq_crypto.ts
+++ b/src/governance/pq_crypto.ts
@@ -1,2 +1,8 @@
+/**
+ * @file pq_crypto.ts
+ * @module governance/pq-crypto
+ * @layer Layer 13
+ * @component Post-quantum cryptography re-export
+ */
 export { PQCrypto } from './offline_mode.js';
 export type { LocalKeySet } from './offline_mode.js';


### PR DESCRIPTION
## Summary\n- **Remove `continue-on-error: true`** from ruff lint and npm audit in `ci.yml` — these were silently hiding lint and security failures\n- **Add fail-on-error step** to `security-checks.yml` — the workflow previously reported bandit/npm-audit/pip-audit results in a summary but never failed the job, so security issues could slip through unnoticed\n- **Standardize Node.js versions** to `'20'` across `ci.yml` and `docs.yml` (was mixed `20.x`/`20`)\n- **Add missing `@file/@module/@layer` headers** to 7 governance module files per project code style guidelines\n\n## Changes\n| File | Change |\n|------|--------|\n| `ci.yml` | Remove `continue-on-error` from ruff + npm audit; standardize Node `20` |\n| `security-checks.yml` | Add enforcement step that fails if any security scanner reports issues |\n| `docs.yml` | Standardize Node `20.x` → `20` |\n| `src/governance/*.ts` (7 files) | Add `@file/@module/@layer` JSDoc headers |\n\n## Context\nFollow-up to issue #729 (step 4 — CI workflow hardening). The `continue-on-error` removals ensure security and quality gates actually block PRs when they fail, rather than silently passing.\n\nSnyk scan keeps `continue-on-error: true` since it depends on a `SNYK_TOKEN` secret that may not be configured in all environments.\n\n## Test plan\n- [x] `npm run build` — clean compile, zero errors\n- [x] `npm test` — 5901 passed, 8 skipped, 0 failures\n- [x] `npm run lint` (Prettier) — clean\n- [x] `npm run lint:python` (flake8) — clean\n- [x] `npm run check:circular` — no circular dependencies (305 files)\n\nhttps://claude.ai/code/session_012rGNiwXwjfGFnbzUCD3tZ9