### PR TITLE
refactor(logging): replace console.* with structured logger

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -9,6 +9,7 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 import { govern, listPolicies, GovernanceRequest, GovernanceResponse } from './govern.js';
+import { logger } from '../utils/logger.js';
 
 // ============================================================================
 // Types
@@ -46,7 +47,7 @@ function requestLogger(_req: Request, res: Response, next: NextFunction): void {
   const start = Date.now();
   res.on('finish', () => {
     const duration = Date.now() - start;
-    console.log('request_complete %d %dms', res.statusCode, duration);
+    logger.info('request_complete', { statusCode: res.statusCode, duration_ms: duration });
   });
   next();
 }
@@ -183,7 +184,9 @@ export function createApp(): express.Application {
 
       res.json(response);
     } catch (error) {
-      console.error('Governance error:', error);
+      logger.error('Governance error', {
+        error: error instanceof Error ? error.message : String(error),
+      });
       res.status(500).json({
         error: 'Internal Server Error',
         message: 'Governance engine error',
@@ -234,7 +237,9 @@ export function createApp(): express.Application {
 
       res.json({ decisions });
     } catch (error) {
-      console.error('Batch governance error:', error);
+      logger.error('Batch governance error', {
+        error: error instanceof Error ? error.message : String(error),
+      });
       res.status(500).json({
         error: 'Internal Server Error',
         message: 'Batch processing error',
@@ -342,12 +347,16 @@ export function startServer(port = 8080): void {
   const app = createApp();
 
   app.listen(port, () => {
-    console.log(`🛡️  SCBE Governance API running on http://localhost:${port}`);
-    console.log(`   POST /v1/govern       - Request governance decision`);
-    console.log(`   POST /v1/govern/batch - Batch governance decisions`);
-    console.log(`   GET  /v1/policies     - List active policies`);
-    console.log(`   GET  /v1/audit        - Get audit log`);
-    console.log(`   GET  /v1/stats        - Get statistics`);
+    logger.info('SCBE Governance API started', {
+      port,
+      endpoints: [
+        'POST /v1/govern',
+        'POST /v1/govern/batch',
+        'GET  /v1/policies',
+        'GET  /v1/audit',
+        'GET  /v1/stats',
+      ],
+    });
   });
 }
 

--- a/src/browser/session.ts
+++ b/src/browser/session.ts
@@ -14,6 +14,7 @@
  */
 
 import { randomUUID } from 'crypto';
+import { logger } from '../utils/logger.js';
 import { TongueCode } from '../tokenizer/ss1.js';
 import {
   BrowserAction,
@@ -575,7 +576,9 @@ export class BrowserSession {
       try {
         listener(event);
       } catch (err) {
-        console.error('Session event listener error:', err);
+        logger.error('Session event listener error', {
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
     }
   }

--- a/src/fleet/agent-registry.ts
+++ b/src/fleet/agent-registry.ts
@@ -6,6 +6,7 @@
 
 import { SpectralIdentityGenerator } from '../harmonic/spectral-identity';
 import { TrustManager } from '../spaceTor/trust-manager';
+import { logger } from '../utils/logger';
 import {
   AgentCapability,
   AgentStatus,
@@ -407,7 +408,7 @@ export class AgentRegistry {
       try {
         listener(event);
       } catch (e) {
-        console.error('Event listener error:', e);
+        logger.error('Event listener error', { error: e instanceof Error ? e.message : String(e) });
       }
     }
   }

--- a/src/fleet/fleet-manager.ts
+++ b/src/fleet/fleet-manager.ts
@@ -9,6 +9,7 @@
 
 import { SpectralIdentityGenerator } from '../harmonic/spectral-identity';
 import { TrustManager } from '../spaceTor/trust-manager';
+import { logger } from '../utils/logger';
 import { AgentRegistrationOptions, AgentRegistry } from './agent-registry';
 import { GovernanceManager, RoundtableOptions } from './governance';
 import { PollyPad, PollyPadManager } from './polly-pad';
@@ -536,13 +537,13 @@ export class FleetManager {
       try {
         listener(event);
       } catch (e) {
-        console.error('Event listener error:', e);
+        logger.error('Event listener error', { error: e instanceof Error ? e.message : String(e) });
       }
     }
 
     // Handle security alerts
     if (this.config.enableSecurityAlerts && event.type === 'security_alert') {
-      console.warn('[FLEET SECURITY ALERT]', event.data);
+      logger.warn('Fleet security alert', { data: event.data });
     }
   }
 

--- a/src/fleet/governance.ts
+++ b/src/fleet/governance.ts
@@ -4,6 +4,7 @@
  * @module fleet/governance
  */
 
+import { logger } from '../utils/logger';
 import { AgentRegistry } from './agent-registry';
 import { FleetEvent, GOVERNANCE_TIERS, GovernanceTier, RoundtableSession } from './types';
 
@@ -455,7 +456,7 @@ export class GovernanceManager {
       try {
         listener(event);
       } catch (e) {
-        console.error('Event listener error:', e);
+        logger.error('Event listener error', { error: e instanceof Error ? e.message : String(e) });
       }
     }
   }

--- a/src/fleet/task-dispatcher.ts
+++ b/src/fleet/task-dispatcher.ts
@@ -4,6 +4,7 @@
  * @module fleet/task-dispatcher
  */
 
+import { logger } from '../utils/logger';
 import { AgentRegistry } from './agent-registry';
 import {
   AgentCapability,
@@ -565,7 +566,7 @@ export class TaskDispatcher {
       try {
         listener(event);
       } catch (e) {
-        console.error('Event listener error:', e);
+        logger.error('Event listener error', { error: e instanceof Error ? e.message : String(e) });
       }
     }
   }

--- a/src/gateway/authorize-service.ts
+++ b/src/gateway/authorize-service.ts
@@ -6,6 +6,7 @@ import {
 } from '../ai_brain/unified-kernel.js';
 import { BRAIN_DIMENSIONS } from '../ai_brain/types.js';
 import { validateGatewayEnv, redactDiagnostics } from './env.js';
+import { logger } from '../utils/logger.js';
 
 interface AuthorizeRequest {
   agentId: string;
@@ -99,7 +100,7 @@ export function createAuthorizeApp() {
   });
 
   app.use((error: Error, _req: Request, res: Response, _next: NextFunction) => {
-    console.error('gateway_error', { message: error.message });
+    logger.error('gateway_error', { message: error.message });
     res.status(500).json({ error: 'internal_error' });
   });
 
@@ -109,10 +110,10 @@ export function createAuthorizeApp() {
 export function startAuthorizeService(): void {
   const { app, env } = createAuthorizeApp();
 
-  console.info('gateway_startup', redactDiagnostics(env));
+  logger.info('gateway_startup', redactDiagnostics(env));
 
   app.listen(env.port, () => {
-    console.info('gateway_listening', { port: env.port, nodeEnv: env.nodeEnv });
+    logger.info('gateway_listening', { port: env.port, nodeEnv: env.nodeEnv });
   });
 }
 
@@ -121,7 +122,7 @@ if (require.main === module) {
     startAuthorizeService();
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown startup failure';
-    console.error('gateway_startup_failed', { message });
+    logger.error('gateway_startup_failed', { message });
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- Replace raw `console.log/error/warn` calls with the existing structured logger (`src/utils/logger.ts`) in 7 core production modules
- Enables log-level filtering via `SCBE_LOG_LEVEL` env var, structured context objects, and consistent output formatting
- No behavior change — same messages, now with timestamps and level-aware routing

## Files changed
| Module | Changes |
|--------|---------|
| `src/api/server.ts` | Request logging, error handlers, startup banner |
| `src/gateway/authorize-service.ts` | Startup, error handler, listening |
| `src/fleet/fleet-manager.ts` | Event listener errors, security alerts |
| `src/fleet/agent-registry.ts` | Event listener errors |
| `src/fleet/governance.ts` | Event listener errors |
| `src/fleet/task-dispatcher.ts` | Event listener errors |
| `src/browser/session.ts` | Event listener errors |

## Context
Addresses code quality finding from issue #729 health checks. The project already has a well-built structured logger at `src/utils/logger.ts` but many production modules were still using raw `console.*` calls, bypassing log-level filtering and structured output.

## Test plan
- [x] `npm run build` — clean compile, zero errors
- [x] `npx vitest run` — 5901 passed, 8 skipped, 0 failures
- [x] `npm run lint` (Prettier) — clean
- [x] `npm run lint:python` (flake8) — clean

https://claude.ai/code/session_01432tfdiHAomr1KtaSdofHc