### PR TITLE
fix(lint): resolve Prettier formatting violation in entropySurface test

### DIFF
--- a/tests/harmonic/entropySurface.test.ts
+++ b/tests/harmonic/entropySurface.test.ts
@@ -542,7 +542,7 @@ describe('Anti-Extraction Property', () => {
       const pos = randomBallPoint(0.3);
       t += 5000 + Math.random() * 10000; // 5-15s apart (irregular)
       const assessment = tracker.observe(pos, 0.1, t);
-      expect(assessment.nullification.signalRetention).toBeGreaterThan(0.80);
+      expect(assessment.nullification.signalRetention).toBeGreaterThan(0.8);
     }
   });
 


### PR DESCRIPTION
The trailing zero in `0.80` violated Prettier's numeric literal style. This was the only remaining lint failure on main.

https://claude.ai/code/session_011Wfo7bvqe8XDTGvgiLneCc

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Affected Layers

<!-- Check all that apply -->
- [ ] L1-2: Context realification
- [ ] L3-4: Weighted transform / Poincare embedding
- [ ] L5-6: Hyperbolic distance / breathing transform
- [ ] L7-8: Mobius phase / Hamiltonian CFI
- [ ] L9-10: Spectral / spin coherence
- [ ] L11-12: Temporal distance / harmonic wall
- [ ] L13-14: Risk decision / audio axis
- [ ] Infrastructure / CI / Docker

## Axiom Compliance

<!-- Which axioms does this change satisfy or affect? -->
- [ ] A1: Unitarity (norm preservation)
- [ ] A2: Locality (spatial bounds)
- [ ] A3: Causality (time-ordering)
- [ ] A4: Symmetry (gauge invariance)
- [ ] A5: Composition (pipeline integrity)
- [ ] N/A

## Test Plan

- [ ] TypeScript tests pass (`npm test`)
- [ ] Python tests pass (`python -m pytest tests/ -v`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Lint passes (`npm run lint`)

## Cross-Language Parity

- [ ] TypeScript updated
- [ ] Python updated to match
- [ ] N/A (single-language change)
