### PR TITLE
refactor(logging): replace remaining console.* with structured logger

### DIFF
--- a/src/agentic/platform.ts
+++ b/src/agentic/platform.ts
@@ -22,6 +22,7 @@ import {
 import { callProvider, getAvailableProviders, createProviderAttestation } from './providers';
 import { DecisionRoundabouts, GovernanceInput, RoundaboutDecision } from './roundabout-city';
 import { ExecutionDistrict } from './execution-district';
+import { logger } from '../utils/logger.js';
 
 /**
  * Task creation options
@@ -592,8 +593,9 @@ export class AgenticCoderPlatform {
 
       if (availableProviders.length === 0) {
         // Fallback to mock if no providers configured
-        console.warn('[SCBE] No AI providers configured. Using mock executor.');
-        console.warn('[SCBE] Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY in .env');
+        logger.warn('No AI providers configured. Using mock executor.', {
+          hint: 'Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY in .env',
+        });
         return {
           output: `[${agent.name}/${action}] Mock: No AI providers configured.\n\nContext length: ${context.length} chars`,
           confidence: 0.75, // Must meet minConfidence threshold (0.7)
@@ -641,7 +643,7 @@ Respond with clear, actionable output.`;
       } catch (error) {
         // All providers failed/timed out - degrade gracefully to deterministic local fallback.
         const errorMsg = error instanceof Error ? error.message : String(error);
-        console.warn('[SCBE] Provider chain failed, using local fallback:', errorMsg);
+        logger.warn('Provider chain failed, using local fallback', { error: errorMsg });
 
         return {
           output: `[${agent.name}/${action}] Local fallback due to provider failure.\n\n${errorMsg}\n\nContext length: ${context.length} chars`,
@@ -687,7 +689,7 @@ Respond with clear, actionable output.`;
       try {
         listener(event);
       } catch (e) {
-        console.error('Event listener error:', e);
+        logger.error('Event listener error', { error: e instanceof Error ? e.message : String(e) });
       }
     }
   }

--- a/src/browser/cdp-backend.ts
+++ b/src/browser/cdp-backend.ts
@@ -26,6 +26,7 @@ import {
   SensitiveFieldType,
   DialogObservation,
 } from './types.js';
+import { logger } from '../utils/logger.js';
 
 // =============================================================================
 // TYPES
@@ -196,7 +197,7 @@ export class CDPBackend implements BrowserBackend {
       this.connected = false;
     });
     this.ws.on('error', (err: Error) => {
-      if (this.debug) console.error('[CDP] WebSocket error:', err.message);
+      if (this.debug) logger.error('CDP WebSocket error', { error: err.message });
     });
 
     await this.ws.connect();
@@ -239,7 +240,7 @@ export class CDPBackend implements BrowserBackend {
     }
 
     if (this.debug) {
-      console.log(`[CDP] Connected to "${target.title}" (${target.url})`);
+      logger.debug('CDP connected', { title: target.title, url: target.url });
     }
   }
 
@@ -869,7 +870,9 @@ export class CDPBackend implements BrowserBackend {
       const message = JSON.stringify({ id, method, params: params ?? {} });
 
       if (this.debug) {
-        console.log(`[CDP →] ${method}`, params ? JSON.stringify(params).slice(0, 200) : '');
+        logger.debug(`CDP → ${method}`, {
+          params: params ? JSON.stringify(params).slice(0, 200) : '',
+        });
       }
 
       this.ws.send(message);
@@ -896,7 +899,9 @@ export class CDPBackend implements BrowserBackend {
           pending.reject(new Error(`CDP error: ${resp.error.message} (${resp.error.code})`));
         } else {
           if (this.debug) {
-            console.log(`[CDP ←] #${resp.id}`, JSON.stringify(resp.result ?? {}).slice(0, 200));
+            logger.debug(`CDP ← #${resp.id}`, {
+              result: JSON.stringify(resp.result ?? {}).slice(0, 200),
+            });
           }
           pending.resolve(resp.result ?? {});
         }
@@ -914,7 +919,10 @@ export class CDPBackend implements BrowserBackend {
             handler(event.params);
           } catch (err) {
             if (this.debug) {
-              console.error(`[CDP] Event handler error for ${event.method}:`, err);
+              logger.error('CDP event handler error', {
+                method: event.method,
+                error: err instanceof Error ? err.message : String(err),
+              });
             }
           }
         }

--- a/src/crypto/replayGuard.ts
+++ b/src/crypto/replayGuard.ts
@@ -1,4 +1,5 @@
 import { ReplayStore, MemoryReplayStore, createReplayStore, RedisClient } from './replayStore.js';
+import { logger } from '../utils/logger.js';
 
 /**
  * ReplayGuard - Prevents replay attacks on envelopes.
@@ -77,9 +78,8 @@ export class ReplayGuard {
 
     // For async stores (Redis, etc.), this sync API is not safe
     // Log warning and fail closed (reject as replay) for safety
-    console.warn(
-      'ReplayGuard: Sync checkAndSet called with async store. ' +
-        'Use checkAndSetAsync for distributed deployments.'
+    logger.warn(
+      'ReplayGuard: Sync checkAndSet called with async store. Use checkAndSetAsync for distributed deployments.'
     );
     return false; // Fail closed for safety
   }

--- a/src/memory/quasi_allocator.ts
+++ b/src/memory/quasi_allocator.ts
@@ -5,6 +5,8 @@
  * @component GeoSeal / Mixed-Curvature Access Kernel - HF model load gating
  */
 
+import { logger } from '../utils/logger.js';
+
 export type HFLoadDecision = 'ALLOW' | 'QUARANTINE';
 
 export interface HFLoadResult {
@@ -50,7 +52,7 @@ export class QuasicrystalLattice {
     const n = this.norm(point);
 
     // Audit traceability: norm only, never secrets/tokens.
-    console.info(`[L2][HF_LOAD] repo=${repo} lattice_norm=${n.toFixed(6)}`);
+    logger.info('HF model load gating', { layer: 'L2', repo, lattice_norm: n.toFixed(6) });
 
     if (n > this.boundary) {
       return {

--- a/src/metrics/telemetry.ts
+++ b/src/metrics/telemetry.ts
@@ -1,5 +1,5 @@
 import { performance } from 'node:perf_hooks';
-import { metricsLogger } from '../utils/logger.js';
+import { logger, metricsLogger } from '../utils/logger.js';
 
 type Tags = Record<string, string | number | boolean | undefined>;
 
@@ -10,10 +10,10 @@ let warnedUnsupportedBackend = false;
 function warnUnsupportedBackendOnce() {
   if (backend === 'stdout' || warnedUnsupportedBackend) return;
   warnedUnsupportedBackend = true;
-  console.warn(
-    `[metrics] Backend '${backend}' is configured but not implemented. ` +
-      'Metrics will be dropped. Use SCBE_METRICS_BACKEND=stdout or configure an exporter.'
-  );
+  logger.warn(`Backend '${backend}' is configured but not implemented. Metrics will be dropped.`, {
+    backend,
+    hint: 'Use SCBE_METRICS_BACKEND=stdout or configure an exporter',
+  });
 }
 
 /**

--- a/src/spaceTor/combat-network.ts
+++ b/src/spaceTor/combat-network.ts
@@ -12,6 +12,7 @@
 
 import { HybridSpaceCrypto } from './hybrid-crypto';
 import { RelayNode, SpaceTorRouter } from './space-tor-router';
+import { logger } from '../utils/logger.js';
 
 export interface TransmissionResult {
   success: boolean;
@@ -49,8 +50,10 @@ export class CombatNetwork {
       const pathA = this.router.calculatePath(origin, dest, 70);
       const pathB = this.generateDisjointPath(pathA, origin, dest, 70);
 
-      console.log(`[COMBAT] Routing via Primary: ${pathA.map((n) => n.id).join(' -> ')}`);
-      console.log(`[COMBAT] Routing via Backup:  ${pathB.map((n) => n.id).join(' -> ')}`);
+      logger.debug('Combat routing via disjoint paths', {
+        primary: pathA.map((n) => n.id).join(' -> '),
+        backup: pathB.map((n) => n.id).join(' -> '),
+      });
 
       // 2. Encrypt & Send Parallel
       const [onionA, onionB] = await Promise.all([
@@ -68,7 +71,7 @@ export class CombatNetwork {
     } else {
       // Standard Routing
       const path = this.router.calculatePath(origin, dest, 50);
-      console.log(`[STANDARD] Routing via: ${path.map((n) => n.id).join(' -> ')}`);
+      logger.debug('Standard routing', { path: path.map((n) => n.id).join(' -> ') });
 
       const onion = await this.crypto.buildOnion(payload, path);
       const result = await this.transmit(path[0], onion, 'STANDARD');
@@ -111,7 +114,7 @@ export class CombatNetwork {
     }
 
     // Fallback: return any valid path (better than failing)
-    console.warn('[COMBAT] Could not find fully disjoint path, using fallback');
+    logger.warn('Could not find fully disjoint path, using fallback');
     return this.router.calculatePath(origin, dest, minTrust);
   }
 
@@ -132,7 +135,11 @@ export class CombatNetwork {
 
     try {
       // Hardware interface mock
-      console.log(`[${pathId}] Transmitting ${packet.length} bytes to Entry Node: ${entryNode.id}`);
+      logger.debug('Transmitting packet', {
+        pathId,
+        bytes: packet.length,
+        entryNode: entryNode.id,
+      });
 
       // Simulate transmission delay based on distance
       // In production, this would interface with actual radio/laser comm hardware

--- a/src/spiralverse/spiralverse-sdk.ts
+++ b/src/spiralverse/spiralverse-sdk.ts
@@ -10,6 +10,7 @@
  */
 
 import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
 
 // ========== TYPES ==========
 
@@ -118,19 +119,19 @@ export class SpiralverseProtocol {
     for (const tongue of requiredTongues) {
       const sig = envelope.signatures[tongue];
       if (!sig) {
-        console.error(`Missing signature for required tongue: ${tongue}`);
+        logger.error('Missing signature for required tongue', { tongue });
         return false;
       }
 
       const secret = this.secrets.get(tongue);
       if (!secret) {
-        console.error(`Missing secret for tongue: ${tongue}`);
+        logger.error('Missing secret for tongue', { tongue });
         return false;
       }
 
       const expected = this.sign(canonical, secret, tongue);
       if (sig !== expected) {
-        console.error(`Invalid signature for tongue: ${tongue}`);
+        logger.error('Invalid signature for tongue', { tongue });
         return false;
       }
     }
@@ -138,7 +139,7 @@ export class SpiralverseProtocol {
     // Check timestamp freshness (5 minute window)
     const age = Date.now() - new Date(envelope.ts).getTime();
     if (age > 5 * 60 * 1000) {
-      console.error('Envelope expired');
+      logger.error('Envelope expired', { age_ms: age, max_ms: 5 * 60 * 1000 });
       return false;
     }
 

--- a/tests/crypto/replayGuard.test.ts
+++ b/tests/crypto/replayGuard.test.ts
@@ -11,6 +11,7 @@ import {
   RedisReplayStore,
   type RedisClient,
 } from '../../src/crypto/replayGuard.js';
+import { logger } from '../../src/utils/logger.js';
 
 describe('ReplayGuard', () => {
   describe('MemoryReplayStore (single-process)', () => {
@@ -187,11 +188,11 @@ describe('ReplayGuard', () => {
       const guard = ReplayGuard.create({ ttlSeconds: 60, redisClient: mockRedis });
 
       // Sync call with async store should fail closed (return false)
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const loggerSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
       const result = guard.checkAndSet('provider1', 'request1');
       expect(result).toBe(false);
-      expect(consoleSpy).toHaveBeenCalled();
-      consoleSpy.mockRestore();
+      expect(loggerSpy).toHaveBeenCalled();
+      loggerSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
- Continues PR #751 by migrating the last ~20 `console.log/warn/error` calls in production source files to the structured `logger` from `utils/logger.ts`
- Updates the `replayGuard` test to spy on `logger.warn` instead of `console.warn`
- After this PR, the only remaining `console.*` calls in `src/` are in `skills/tweet-cli.ts` (a CLI tool where console output is the intended interface) and JSDoc examples

## Files changed (7 source + 1 test)
| File | Changes |
|------|---------|
| `src/agentic/platform.ts` | 3 console.warn + 1 console.error → logger |
| `src/browser/cdp-backend.ts` | 5 console.log/error → logger (debug-gated) |
| `src/crypto/replayGuard.ts` | 1 console.warn → logger.warn |
| `src/memory/quasi_allocator.ts` | 1 console.info → logger.info |
| `src/metrics/telemetry.ts` | 1 console.warn → logger.warn |
| `src/spaceTor/combat-network.ts` | 5 console.log/warn → logger.debug/warn |
| `src/spiralverse/spiralverse-sdk.ts` | 4 console.error → logger.error |
| `tests/crypto/replayGuard.test.ts` | Updated spy target from console.warn to logger.warn |

## Test plan
- [x] TypeScript build: clean compile, zero errors
- [x] Tests: 5901 passed, 8 skipped, 0 failures
- [x] Lint (Prettier): clean
- [x] No circular dependencies (305 files checked)

Relates to #729 (codebase health improvements)

https://claude.ai/code/session_014swdaykYKRSnM5edatfdsL