### PR TITLE
docs: remove last master branch reference from system docs

### DIFF
--- a/docs/SCBE_COMPLETE_SYSTEM.md
+++ b/docs/SCBE_COMPLETE_SYSTEM.md
@@ -347,9 +347,9 @@ name: SCBE-AETHERMOORE Tests
 
 on:
   push:
-    branches: [ main, master, 'claude/**' ]
+    branches: [ main, 'claude/**' ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Removes the last `master` branch reference from `docs/SCBE_COMPLETE_SYSTEM.md` example workflow triggers
- After PRs #730, #736, #738 cleaned all 68 workflow files, this doc was the only remaining reference

Closes the documentation portion of #729.

## Verification
- Build: clean compile, zero errors
- Tests: 5901 passed, 8 skipped, 0 failures
- Lint (Prettier + flake8): clean
- Circular deps: none (305 files)

## Steps 1-3 reminder
The branch reconciliation (force-push or delete `master`) still requires admin action as noted in #729.

https://claude.ai/code/session_014Q1G58Q5wZmAYu7wQgrwjp