### PR TITLE
fix(ci): add timeout-minutes to all 68 GitHub Actions workflows

### DIFF
--- a/.github/workflows/ai-issue-summary.yml
+++ b/.github/workflows/ai-issue-summary.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   summarize:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
       models: read

--- a/.github/workflows/arxiv-paper-gen.yml
+++ b/.github/workflows/arxiv-paper-gen.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build-arxiv:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/auto-approve-trusted.yml
+++ b/.github/workflows/auto-approve-trusted.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >-
       github.actor == 'dependabot[bot]' ||
       github.actor == 'copilot-swe-agent' ||

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, 'auto-update CHANGELOG')"
     permissions:
       contents: write

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >-
       github.actor == 'dependabot[bot]' ||
       github.actor == 'copilot-swe-agent' ||

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,6 +16,7 @@ jobs:
   auto-merge:
     name: Auto Merge
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: |
       github.event.review.state == 'approved' ||
       github.event.check_suite.conclusion == 'success' ||

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -15,6 +15,7 @@ jobs:
   publish-npm:
     name: Publish to NPM
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -47,6 +48,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -72,6 +74,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [publish-npm, publish-pypi]
     permissions:
       contents: write

--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   rebase-open-prs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Update all open PRs targeting main
         run: |

--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   resolve-conflicts:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -17,6 +17,7 @@ jobs:
   auto-label:
     name: Auto Label Issues and PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name != 'schedule'
     steps:
       - uses: actions/labeler@v5
@@ -41,6 +42,7 @@ jobs:
   auto-assign:
     name: Auto Assign
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name != 'schedule'
     steps:
       - uses: pozil/auto-assign-issue@v4
@@ -55,6 +57,7 @@ jobs:
   conflict-detection:
     name: Detect PR Conflicts
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request_target'
     steps:
       - uses: eps1lon/actions-label-merge-conflict@v3
@@ -65,6 +68,7 @@ jobs:
   auto-approve-dependabot:
     name: Auto Approve Dependabot PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.actor == 'dependabot[bot]' && github.event_name == 'pull_request_target'
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
   test:
     name: Test on Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -72,6 +73,7 @@ jobs:
   python-test:
     name: Test Python Components
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -109,6 +111,7 @@ jobs:
   lint:
     name: Lint and Format Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -147,6 +150,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/cloud-kernel-data-pipeline.yml
+++ b/.github/workflows/cloud-kernel-data-pipeline.yml
@@ -37,6 +37,7 @@ permissions:
 jobs:
   pipeline:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/code-prism-parity.yml
+++ b/.github/workflows/code-prism-parity.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   parity:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,7 @@ jobs:
   analyze-interpreted:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -47,6 +48,7 @@ jobs:
   analyze-android-java:
     name: Analyze (java-kotlin)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: 30
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/coherence-gate.yml
+++ b/.github/workflows/coherence-gate.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   coherence-gate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/conflict-marker-guard.yml
+++ b/.github/workflows/conflict-marker-guard.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   conflict-marker-guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cross-repo-sync.yml
+++ b/.github/workflows/cross-repo-sync.yml
@@ -30,6 +30,7 @@ env:
 jobs:
   sync-to-gumroad:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event.inputs.sync_direction != 'from-gumroad'
     outputs:
       has_token: ${{ steps.auth.outputs.has_token }}
@@ -124,6 +125,7 @@ jobs:
 
   create-sync-report:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [sync-to-gumroad]
     if: always()
 

--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   daily-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/daily-social-updates.yml
+++ b/.github/workflows/daily-social-updates.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   social-updates:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/daily_ops.yml
+++ b/.github/workflows/daily_ops.yml
@@ -29,6 +29,7 @@ jobs:
   # -------------------------------------------------------------------
   health-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.event_name == 'schedule' || inputs.run_health_check }}
     outputs:
       vm_status: ${{ steps.check.outputs.status }}
@@ -60,6 +61,7 @@ jobs:
   # -------------------------------------------------------------------
   training-data-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: ${{ github.event_name == 'schedule' || inputs.run_training_push }}
     steps:
       - name: Checkout repo
@@ -157,6 +159,7 @@ jobs:
   # -------------------------------------------------------------------
   arxiv-research:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -201,6 +204,7 @@ jobs:
   # -------------------------------------------------------------------
   governance-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -231,6 +235,7 @@ jobs:
     needs: [health-check, training-data-push, arxiv-research, governance-scan]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Generate Summary
         run: |

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -23,6 +23,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -44,6 +45,7 @@ jobs:
     name: Build Lambda Package
     needs: test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       artifact-name: ${{ steps.package.outputs.artifact-name }}
     steps:
@@ -86,6 +88,7 @@ jobs:
     needs: build
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment: staging
     steps:
       - uses: actions/checkout@v4
@@ -140,6 +143,7 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment: production
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -23,6 +23,7 @@ jobs:
   deploy:
     name: Deploy to EKS
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -29,6 +29,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy to GKE
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,7 @@ jobs:
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -120,6 +121,7 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build-docs
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -22,6 +22,7 @@ jobs:
   eslint:
     name: Run eslint scanning
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   create-fix-pull-requests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   greeting:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/huggingface-sync.yml
+++ b/.github/workflows/huggingface-sync.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   sync-to-huggingface:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,6 +63,7 @@ jobs:
 
   health-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: sync-to-huggingface
     steps:
       - name: Verify HF Repos Accessible

--- a/.github/workflows/interface-pr-ops-runner.yml
+++ b/.github/workflows/interface-pr-ops-runner.yml
@@ -22,6 +22,7 @@ jobs:
   validate-web-cursor:
     if: ${{ github.event_name == 'schedule' || inputs.validate_web_cursor_script == 'true' }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -42,6 +43,7 @@ jobs:
   export-pr-queue:
     if: ${{ github.event_name == 'schedule' || inputs.export_pr_queue == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
 

--- a/.github/workflows/kindle-build.yml
+++ b/.github/workflows/kindle-build.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       KEY_ALIAS: ${{ secrets.AETHERCODE_KEY_ALIAS }}
       KEYSTORE_PASSWORD: ${{ secrets.AETHERCODE_KEYSTORE_PASSWORD }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -31,6 +31,7 @@ on:
 jobs:
   manual-task:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/nightly-connector-health.yml
+++ b/.github/workflows/nightly-connector-health.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   health-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
 

--- a/.github/workflows/nightly-multicloud-training.yml
+++ b/.github/workflows/nightly-multicloud-training.yml
@@ -22,6 +22,7 @@ jobs:
   training-bootstrap:
     name: Nightly multi-cloud training
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:

--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   notion-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/notion-to-dataset.yml
+++ b/.github/workflows/notion-to-dataset.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   export-notion-to-dataset:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   deploy:
+    timeout-minutes: 15
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pqc-python.yml
+++ b/.github/workflows/pqc-python.yml
@@ -16,6 +16,7 @@ jobs:
   pqc-tests:
     name: PQC tests on Ubuntu with liboqs
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/premerge-triage.yml
+++ b/.github/workflows/premerge-triage.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/programmatic-hf-training.yml
+++ b/.github/workflows/programmatic-hf-training.yml
@@ -57,6 +57,7 @@ permissions:
 jobs:
   programmatic-hf-training:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish-content.yml
+++ b/.github/workflows/publish-content.yml
@@ -25,6 +25,7 @@ jobs:
   post-to-x:
     if: inputs.platform == 'x-twitter' || inputs.platform == 'all'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -30,6 +30,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       
@@ -68,6 +69,7 @@ jobs:
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -107,6 +109,7 @@ jobs:
     needs: test
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
 

--- a/.github/workflows/scbe-reusable-gates.yml
+++ b/.github/workflows/scbe-reusable-gates.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   core-gates:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/scbe-tests.yml
+++ b/.github/workflows/scbe-tests.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       contents: read
@@ -121,6 +122,7 @@ jobs:
 
   harmonic-scaling:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - name: Checkout repository
@@ -143,6 +145,7 @@ jobs:
 
   core-cipher:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/scbe.yml
+++ b/.github/workflows/scbe.yml
@@ -16,6 +16,7 @@ jobs:
   axiom-verification:
     name: "Axiom Compliance (A1-A12)"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -62,6 +63,7 @@ jobs:
   unit-tests:
     name: "Unit Tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -109,6 +111,7 @@ jobs:
   requirements-verification:
     name: "EARS Requirements (R1-R8)"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -209,6 +212,7 @@ jobs:
   patent-validation:
     name: "Patent Claims Validation"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/self-improvement-loop.yml
+++ b/.github/workflows/self-improvement-loop.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   run-self-improvement-loop:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/six-tongues-tests.yml
+++ b/.github/workflows/six-tongues-tests.yml
@@ -21,6 +21,7 @@ jobs:
   test:
     name: Run Six Tongues Selftest
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/validate-layer-manifest.yml
+++ b/.github/workflows/validate-layer-manifest.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/vertex-training.yml
+++ b/.github/workflows/vertex-training.yml
@@ -33,6 +33,7 @@ jobs:
   training:
     name: PHDM 21D Training Pipeline
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes` to every job across all 68 GitHub Actions workflow files
- 60 out of 68 workflows were missing job-level timeouts, which could cause hung jobs to consume GitHub Actions minutes indefinitely
- Applied appropriate limits based on job type:
  - **10 min**: simple triage, notification, and auto-merge jobs
  - **15 min**: lint, security audit, axiom verification, and formatting jobs
  - **20 min**: release and publish jobs
  - **30 min**: test, build, deploy, Docker, and CodeQL jobs
  - **60 min**: training pipelines, nightly ops, and data pipeline jobs

## Context
Relates to #729 (CI workflow hardening). This is the next step after PR #750 which addressed `continue-on-error` masking and Node.js version standardization.

## Verification
- All 68 workflow YAML files validated with `yaml.safe_load()`
- Build: clean compile, zero errors
- Tests: 5923 passed, 8 skipped, 0 failures
- Lint (Prettier + flake8): clean
- No functional changes — only `timeout-minutes` additions

## Test plan
- [x] All 68 `.yml` files parse as valid YAML
- [x] `npm run build` — clean
- [x] `npm test` — 5923 passed, 8 skipped
- [x] `npm run lint` — clean

https://claude.ai/code/session_01AVAnXXCjj3E7ASfgpG9uGk