### PR TITLE
fix(types): eliminate unsafe type casts and improve test quality

### DIFF
--- a/src/harmonic/sheafCohomology.ts
+++ b/src/harmonic/sheafCohomology.ts
@@ -1466,10 +1466,10 @@ export function analyseCohomology<T>(
   const h = lattice.height();
   let heightUtil = 0;
   if (h > 0 && typeof maxEl === 'number' && typeof minEl === 'number') {
-    const top = lattice.top as unknown as number;
-    const bot = lattice.bottom as unknown as number;
+    const top = Number(lattice.top);
+    const bot = Number(lattice.bottom);
     const range = top - bot;
-    heightUtil = range > 0 ? ((maxEl as number) - (minEl as number)) / range : 0;
+    heightUtil = range > 0 ? (Number(maxEl) - Number(minEl)) / range : 0;
   }
 
   return {
@@ -1533,9 +1533,8 @@ export function detectObstructions<T>(
       let severity = 0;
 
       if (typeof meetVal === 'number' && typeof joinVal === 'number') {
-        const range =
-          (edgeLattice.top as unknown as number) - (edgeLattice.bottom as unknown as number);
-        severity = range > 0 ? ((joinVal as number) - (meetVal as number)) / range : 1;
+        const range = Number(edgeLattice.top) - Number(edgeLattice.bottom);
+        severity = range > 0 ? (Number(joinVal) - Number(meetVal)) / range : 1;
       } else {
         severity = edgeLattice.eq(meetVal, edgeLattice.bottom) ? 1 : 0.5;
       }

--- a/src/security-engine/machine-constants.ts
+++ b/src/security-engine/machine-constants.ts
@@ -268,7 +268,8 @@ export class MachineConstantsRegistry {
   getQ16(category: keyof MachineConstants, key: string): number {
     const cat = this._active[category];
     if (typeof cat === 'object' && cat !== null && key in cat) {
-      const val = (cat as unknown as Record<string, unknown>)[key];
+      // All constant category interfaces contain only numeric values
+      const val = (cat as unknown as Readonly<Record<string, number>>)[key];
       if (typeof val === 'number') return toQ16(val);
     }
     throw new RangeError(`Unknown constant: ${String(category)}.${key}`);

--- a/tests/enterprise/quantum/setup_verification.test.ts
+++ b/tests/enterprise/quantum/setup_verification.test.ts
@@ -1,28 +1,55 @@
 /**
  * Setup Verification Test
  *
- * This test verifies that the enterprise testing infrastructure is properly configured.
+ * Verifies that the enterprise quantum testing infrastructure is properly
+ * configured: TestConfig thresholds are sane, fast-check runs property tests,
+ * and core pipeline modules are importable.
  */
 
 import fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
+import { TestConfig } from '../test.config';
+import { hyperbolicDistance } from '../../../src/harmonic/hyperbolic';
+import { harmonicScale } from '../../../src/harmonic/harmonicScaling';
 
-describe('Enterprise Testing Infrastructure Setup', () => {
-  it('should have vitest configured correctly', () => {
-    expect(true).toBe(true);
+describe('Enterprise Quantum Testing Infrastructure Setup', () => {
+  it('should have quantum test config with valid thresholds', () => {
+    expect(TestConfig.quantum.targetSecurityBits).toBeGreaterThanOrEqual(128);
+    expect(TestConfig.quantum.maxQubits).toBeGreaterThan(0);
+    expect(TestConfig.quantum.algorithms.shor.enabled).toBe(true);
+    expect(TestConfig.quantum.algorithms.grover.enabled).toBe(true);
   });
 
-  it('should have fast-check available for property-based testing', () => {
-    fc.assert(
-      fc.property(fc.integer(), (n) => {
-        return n === n; // Identity property
-      }),
-      { numRuns: 100 }
+  it('should have property-test iterations configured above minimum', () => {
+    expect(TestConfig.propertyTests.minIterations).toBeGreaterThanOrEqual(100);
+    expect(TestConfig.propertyTests.maxIterations).toBeGreaterThan(
+      TestConfig.propertyTests.minIterations
     );
   });
 
-  it('should support TypeScript types', () => {
-    const testValue: number = 42;
-    expect(typeof testValue).toBe('number');
+  it('should compute Poincare distance for valid ball points', () => {
+    const d = hyperbolicDistance([0, 0], [0.5, 0]);
+    expect(d).toBeGreaterThan(0);
+    expect(Number.isFinite(d)).toBe(true);
+  });
+
+  it('should produce bounded harmonic wall scores', () => {
+    fc.assert(
+      fc.property(
+        fc.float({ min: 0, max: 10, noNaN: true }),
+        fc.float({ min: 0, max: 1, noNaN: true }),
+        (distance, pDrift) => {
+          const score = harmonicScale(distance, pDrift);
+          return score > 0 && score <= 1 && Number.isFinite(score);
+        }
+      ),
+      { numRuns: TestConfig.propertyTests.minIterations }
+    );
+  });
+
+  it('should enforce distance monotonicity: farther points get lower wall scores', () => {
+    const near = harmonicScale(0.1, 0);
+    const far = harmonicScale(5.0, 0);
+    expect(near).toBeGreaterThan(far);
   });
 });

--- a/tests/gateway/authorize-service.unit.test.ts
+++ b/tests/gateway/authorize-service.unit.test.ts
@@ -26,6 +26,7 @@ const { createAuthorizeApp } = await import('../../src/gateway/authorize-service
 
 // Minimal supertest-like helper using the Express app directly
 import type { Express } from 'express';
+import type { IncomingMessage } from 'http';
 
 async function request(app: Express, method: 'get' | 'post', path: string, body?: unknown) {
   return new Promise<{ status: number; body: Record<string, unknown> }>((resolve) => {
@@ -46,12 +47,12 @@ async function request(app: Express, method: 'get' | 'post', path: string, body?
         },
       };
 
-      const req = http.request(options, (res: any) => {
+      const req = http.request(options, (res: IncomingMessage) => {
         let data = '';
         res.on('data', (chunk: string) => (data += chunk));
         res.on('end', () => {
           server.close();
-          resolve({ status: res.statusCode, body: JSON.parse(data) });
+          resolve({ status: res.statusCode ?? 500, body: JSON.parse(data) });
         });
       });
 


### PR DESCRIPTION
## Summary\n- Replace `as unknown as number` double casts in `sheafCohomology.ts` with runtime-safe `Number()` conversions (lines 1469-1472, 1537-1538)\n- Add explanatory comment to the unavoidable double cast in `machine-constants.ts` (readonly interfaces require it)\n- Replace skeletal `expect(true).toBe(true)` test in `setup_verification.test.ts` with 5 meaningful tests: TestConfig validation, hyperbolicDistance computation, harmonicScale property-based bounds, and distance monotonicity\n- Replace `res: any` with proper `IncomingMessage` type in gateway authorize-service test\n\n## Test plan\n- [x] Build: clean compile, zero errors\n- [x] All 14 affected tests pass (5 new setup_verification + 9 gateway)\n- [x] Prettier lint: clean on all 4 changed files\n- [x] No circular dependencies (306 files checked)\n\nhttps://claude.ai/code/session_01UpWgGarbjbfNyaeZa9hEBn