### PR TITLE
fix(crypto,api): add JSDoc headers, consolidate API auth, add type hints

### DIFF
--- a/src/api/auth_config.py
+++ b/src/api/auth_config.py
@@ -1,0 +1,51 @@
+"""
+Shared API key configuration for SCBE API routes.
+
+Loads API keys from the SCBE_API_KEYS environment variable (JSON format).
+Falls back to demo keys only when SCBE_ENV is 'development' or 'test'.
+
+Environment variable format:
+    SCBE_API_KEYS='{"my_key": "user_id", "other_key": "other_user"}'
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+_DEMO_KEYS: Dict[str, str] = {
+    "demo_key_12345": "demo_user",
+    "pilot_key_67890": "pilot_customer",
+}
+
+
+def load_api_keys() -> Dict[str, str]:
+    """Load API keys from environment or fall back to demo keys in dev/test."""
+    env_keys = os.environ.get("SCBE_API_KEYS")
+    if env_keys:
+        try:
+            keys = json.loads(env_keys)
+            if isinstance(keys, dict) and keys:
+                return keys
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("SCBE_API_KEYS is set but not valid JSON; ignoring")
+
+    scbe_env = os.environ.get("SCBE_ENV", os.environ.get("NODE_ENV", "development"))
+    if scbe_env in ("development", "test"):
+        logger.debug("Using demo API keys (SCBE_ENV=%s)", scbe_env)
+        return dict(_DEMO_KEYS)
+
+    logger.warning(
+        "No SCBE_API_KEYS configured and SCBE_ENV=%s; "
+        "API authentication will reject all requests. "
+        "Set SCBE_API_KEYS or use SCBE_ENV=development for demo keys.",
+        scbe_env,
+    )
+    return {}
+
+
+VALID_API_KEYS: Dict[str, str] = load_api_keys()

--- a/src/api/hydra_routes.py
+++ b/src/api/hydra_routes.py
@@ -80,7 +80,7 @@ _spine = None
 _providers: Dict[str, Any] = {}
 
 
-def get_spine():
+def get_spine() -> Any:
     """Return the shared HydraSpine singleton, or raise if not initialized."""
     if _spine is None:
         raise HTTPException(500, "HYDRA spine not initialized")
@@ -93,13 +93,10 @@ def get_spine():
 
 # Import at module level is safe; the dict is defined in main.py and we
 # re-use the same validation logic here without coupling tightly.
-VALID_API_KEYS = {
-    "demo_key_12345": "demo_user",
-    "pilot_key_67890": "pilot_customer",
-}
+from src.api.auth_config import VALID_API_KEYS
 
 
-async def verify_api_key(x_api_key: str = Header(...)):
+async def verify_api_key(x_api_key: str = Header(...)) -> str:
     """Verify API key and return user identifier."""
     if x_api_key not in VALID_API_KEYS:
         raise HTTPException(401, "Invalid API key")

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -377,10 +377,7 @@ CONNECTOR_TEMPLATES: List[Dict[str, Any]] = [
 # AUTH
 # ============================================================================
 
-VALID_API_KEYS = {
-    "demo_key_12345": "demo_user",
-    "pilot_key_67890": "pilot_customer",
-}
+from src.api.auth_config import VALID_API_KEYS
 
 
 async def verify_api_key(x_api_key: str = Header(...)):

--- a/src/api/saas_routes.py
+++ b/src/api/saas_routes.py
@@ -24,10 +24,7 @@ from src.symphonic_cipher.scbe_aethermoore.flock_shepherd import (
 
 saas_router = APIRouter(prefix="/saas")
 
-VALID_API_KEYS = {
-    "demo_key_12345": "demo_user",
-    "pilot_key_67890": "pilot_customer",
-}
+from src.api.auth_config import VALID_API_KEYS
 
 PLAN_LIMITS: Dict[str, Dict[str, int]] = {
     "starter": {"flocks": 1, "agents": 8, "monthly_governance": 5000},

--- a/src/crypto/bloom.ts
+++ b/src/crypto/bloom.ts
@@ -1,3 +1,9 @@
+/**
+ * @file bloom.ts
+ * @module crypto/bloom
+ * @component Bloom Filter
+ */
+
 export class BloomFilter {
   private bits: Uint8Array;
   private k: number;

--- a/src/crypto/envelope.ts
+++ b/src/crypto/envelope.ts
@@ -1,3 +1,10 @@
+/**
+ * @file envelope.ts
+ * @module crypto/envelope
+ * @layer Layer 12
+ * @component Envelope Encryption
+ */
+
 import crypto from 'node:crypto';
 import { hkdfSha256 } from './hkdf.js';
 import { canonicalize, JsonValue } from './jcs.js';

--- a/src/crypto/hkdf.ts
+++ b/src/crypto/hkdf.ts
@@ -1,3 +1,9 @@
+/**
+ * @file hkdf.ts
+ * @module crypto/hkdf
+ * @component HKDF Key Derivation
+ */
+
 import crypto from 'node:crypto';
 
 /**

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1,8 +1,9 @@
 /**
- * SCBE Cryptographic Module
- * Core encryption and security primitives
+ * @file index.ts
+ * @module crypto
+ * @component SCBE Cryptographic Module
  *
- * Includes:
+ * Core encryption and security primitives including:
  * - Post-Quantum Cryptography (ML-KEM-768, ML-DSA-65)
  * - Envelope encryption
  * - Key management

--- a/src/crypto/jcs.ts
+++ b/src/crypto/jcs.ts
@@ -1,5 +1,9 @@
 /**
- * Minimal JCS (RFC 8785-like) canonicalization: UTF-8, lexicographic sorting of keys,
+ * @file jcs.ts
+ * @module crypto/jcs
+ * @component JSON Canonicalization Scheme (RFC 8785)
+ *
+ * Minimal JCS canonicalization: UTF-8, lexicographic sorting of keys,
  * no insignificant whitespace, stable numbers.
  */
 

--- a/src/crypto/kms.ts
+++ b/src/crypto/kms.ts
@@ -1,4 +1,8 @@
 /**
+ * @file kms.ts
+ * @module crypto/kms
+ * @component Key Management Service
+ *
  * KMS / HSM integration point.
  * Contract: getMasterKey(kid) returns a 32-byte key (Buffer).
  *

--- a/src/crypto/nonceManager.ts
+++ b/src/crypto/nonceManager.ts
@@ -1,3 +1,9 @@
+/**
+ * @file nonceManager.ts
+ * @module crypto/nonceManager
+ * @component Nonce Generation
+ */
+
 import crypto from 'node:crypto';
 
 /**

--- a/src/crypto/replayGuard.ts
+++ b/src/crypto/replayGuard.ts
@@ -1,3 +1,9 @@
+/**
+ * @file replayGuard.ts
+ * @module crypto/replayGuard
+ * @component Replay Attack Prevention
+ */
+
 import { ReplayStore, MemoryReplayStore, createReplayStore, RedisClient } from './replayStore.js';
 import { logger } from '../utils/logger.js';
 

--- a/src/crypto/replayStore.ts
+++ b/src/crypto/replayStore.ts
@@ -1,8 +1,10 @@
 /**
- * Replay Store Interface (MEDIUM-001 fix)
+ * @file replayStore.ts
+ * @module crypto/replayStore
+ * @component Replay Detection Storage
  *
  * Abstracts replay detection storage to support both single-process
- * and distributed deployments.
+ * and distributed deployments (MEDIUM-001 fix).
  */
 
 export interface ReplayEntry {

--- a/src/symphonic_cipher/qasi_core.py
+++ b/src/symphonic_cipher/qasi_core.py
@@ -31,7 +31,7 @@ def clamp_ball(u: np.ndarray, eps_ball: float = 1e-3) -> np.ndarray:
     return (r_max / r) * u
 
 
-def safe_arcosh(x):
+def safe_arcosh(x: "float | np.ndarray") -> "float | np.ndarray":
     """arcosh defined for x>=1."""
     if isinstance(x, float):
         return float(np.arccosh(max(1.0, x)))

--- a/src/symphonic_cipher/scbe_aethermoore/concept_blocks/web_agent/store_publishers.py
+++ b/src/symphonic_cipher/scbe_aethermoore/concept_blocks/web_agent/store_publishers.py
@@ -9,14 +9,14 @@ Automate product listing, updates, and storefront management for:
 Both use direct REST APIs — no browser needed, zero delays.
 
 Usage:
-    gumroad = GumroadPublisher(api_token="your_token")
+    gumroad = GumroadPublisher(api_token=os.environ["GUMROAD_API_TOKEN"])
     result = await gumroad.create_product(
         name="Spiralverse AI Training Pack",
         price=49_99,  # cents
         description="...",
     )
 
-    shopify = ShopifyPublisher(shop="your-store", token="your_token")
+    shopify = ShopifyPublisher(shop="your-store", token=os.environ["SHOPIFY_TOKEN"])
     result = await shopify.create_product(
         title="SCBE Governance Toolkit",
         body_html="<p>...</p>",


### PR DESCRIPTION
## Summary\n\n- **Crypto JSDoc headers**: Add missing `@file/@module/@component` headers to all 9 crypto files (`bloom.ts`, `envelope.ts`, `hkdf.ts`, `jcs.ts`, `kms.ts`, `nonceManager.ts`, `index.ts`, `replayGuard.ts`, `replayStore.ts`) per project code style\n- **API auth consolidation**: Replace hardcoded demo API keys duplicated across 3 files (`main.py`, `hydra_routes.py`, `saas_routes.py`) with shared `auth_config.py` that loads from `SCBE_API_KEYS` env var, falling back to demo keys only in dev/test mode\n- **Python type hints**: Add missing type annotations to `safe_arcosh()`, `get_spine()`, `verify_api_key()`\n- **Docstring security**: Fix `store_publishers.py` examples to use `os.environ[]` instead of placeholder token strings\n\n## Test plan\n\n- [x] Build: clean compile, zero errors\n- [x] TypeScript tests: 5957 passed, 8 skipped, 0 failures\n- [x] Prettier lint: clean\n- [x] flake8 lint on changed files: clean\n- [x] Circular dependencies: none (306 files)\n- [x] npm audit: 0 vulnerabilities\n\nRef: #729\n\nhttps://claude.ai/code/session_01HZgjHmJiP8w4bc6XzSWKdn