### PR TITLE
fix(crypto): remove stale mock PQC code causing roundtrip failures

### DIFF
--- a/six-tongues-cli.py
+++ b/six-tongues-cli.py
@@ -414,8 +414,6 @@ def kem_keygen() -> Tuple[bytes, bytes]:
     """Generate ML-KEM-768 keypair (pk, sk). Falls back to deterministic mock."""
     if _REAL_PQC:
         return _kem_keygen()
-    sk = os.urandom(32)
-    pk = hashlib.sha256(b"kem_pk:" + sk).digest()
     # Mock mode: derive pk deterministically from sk for encaps/decaps consistency.
     sk = secrets.token_bytes(32)
     pk = hashlib.sha256(b"ml-kem-mock:pk:" + sk).digest()
@@ -430,9 +428,6 @@ def kyber_encaps(pk: bytes) -> Tuple[bytes, bytes]:
     if _REAL_PQC:
         ct, ss = _kem_encrypt(pk)
         return ss, ct
-    nonce = os.urandom(32)
-    ct = nonce + hashlib.sha256(b"ct" + pk + nonce).digest()
-    ss = hashlib.sha256(b"ss" + pk + ct).digest()
     # Mock mode: ciphertext carries an ephemeral nonce; shared secret binds pk + nonce.
     ct = secrets.token_bytes(32)
     ss = hmac.new(pk, b"ml-kem-mock:ss:" + ct, hashlib.sha256).digest()
@@ -446,8 +441,6 @@ def kyber_decaps(sk: bytes, ct: bytes) -> bytes:
     """
     if _REAL_PQC:
         return _kem_decrypt(sk, ct)
-    pk = hashlib.sha256(b"kem_pk:" + sk).digest()
-    return hashlib.sha256(b"ss" + pk + ct).digest()
     pk = hashlib.sha256(b"ml-kem-mock:pk:" + sk).digest()
     return hmac.new(pk, b"ml-kem-mock:ss:" + ct, hashlib.sha256).digest()
 
@@ -456,8 +449,6 @@ def dsa_keygen() -> Tuple[bytes, bytes]:
     """Generate ML-DSA-65 keypair (pk, sk). Falls back to deterministic mock."""
     if _REAL_PQC:
         return _dsa_keygen()
-    sk = os.urandom(32)
-    pk = hashlib.sha256(b"dsa_pk:" + sk).digest()
     # Mock mode: derive pk deterministically from sk for sign/verify consistency.
     sk = secrets.token_bytes(32)
     pk = hashlib.sha256(b"ml-dsa-mock:pk:" + sk).digest()
@@ -468,8 +459,6 @@ def dsa_sign(sk: bytes, msg: bytes) -> bytes:
     """ML-DSA-65 sign. Uses real ML-DSA-65 when pqcrypto is available."""
     if _REAL_PQC:
         return _dsa_sign_real(sk, msg)
-    pk = hashlib.sha256(b"dsa_pk:" + sk).digest()
-    return hmac.new(pk, msg, hashlib.sha256).digest()
     pk = hashlib.sha256(b"ml-dsa-mock:pk:" + sk).digest()
     return hmac.new(pk, b"ml-dsa-mock:sig:" + msg, hashlib.sha256).digest()
 
@@ -483,7 +472,6 @@ def dsa_verify(pk: bytes, msg: bytes, sig: bytes) -> bool:
             return result is True or result is None
         except Exception:
             return False
-    expected = hmac.new(pk, msg, hashlib.sha256).digest()
     expected = hmac.new(pk, b"ml-dsa-mock:sig:" + msg, hashlib.sha256).digest()
     return hmac.compare_digest(expected, sig)
 


### PR DESCRIPTION
## Summary

- Removes leftover old mock PQC fallback code in `six-tongues-cli.py` that caused all 7 crypto roundtrip failures
- `kyber_decaps` and `dsa_sign` had early `return` statements before the correct updated code, making the new implementations **unreachable dead code**
- `dsa_verify` had a stale assignment immediately overwritten by the correct one, causing sign/verify formula mismatch
- `kem_keygen`, `kyber_encaps`, `dsa_keygen` had dead variable assignments overwritten on the next line

## Test plan

- [x] `TestCrypto::test_kyber_encaps_decaps_roundtrip` — PASSES
- [x] `TestCrypto::test_dsa_sign_verify_valid` — PASSES
- [x] `TestGeoSeal::test_encrypt_decrypt_roundtrip` — PASSES
- [x] `TestGeoSeal::test_large_payload` — PASSES
- [x] `TestEdgeCases::test_geoseal_with_minimal_context` — PASSES
- [x] `TestEdgeCases::test_geoseal_empty_payload` — PASSES
- [x] `TestIntegration::test_encode_xlate_blend_geoseal_pipeline` — PASSES
- [x] Full test suite: 135 passed, 13 skipped

Fixes #774

https://claude.ai/code/session_01FnUkCsfQBU6DWKm9Ha1Q14