### PR TITLE
fix(lint): remove 18 unused Python imports flagged by ruff

### DIFF
--- a/src/lattice/triangulated_phdm.py
+++ b/src/lattice/triangulated_phdm.py
@@ -18,8 +18,8 @@ Patent relevant: extends USPTO #63/961,403
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
+from typing import List
 
 import numpy as np
 

--- a/src/notarize/service.py
+++ b/src/notarize/service.py
@@ -12,14 +12,12 @@ attested by this signer, encoded in this Sacred Tongue.
 """
 from __future__ import annotations
 
-import base64
 import hashlib
 import hmac
 import json
 import os
 import time
-from dataclasses import asdict, dataclass, field
-from typing import List, Optional
+from dataclasses import asdict, dataclass
 
 
 # ── Sacred Tongue token tables (subset for hash encoding) ──────────────────

--- a/src/primitives/phi_ternary.py
+++ b/src/primitives/phi_ternary.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List
 
 PHI = (1 + math.sqrt(5)) / 2  # 1.6180339887...
 

--- a/tests/test_notarize.py
+++ b/tests/test_notarize.py
@@ -1,14 +1,12 @@
 """Tests for SCBE Notarization Service."""
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-from notarize import notarize, verify, batch_notarize, cert_to_json, cert_from_json, NotarizationCert
+from notarize import notarize, verify, batch_notarize, cert_to_json, cert_from_json
 
 
 class TestNotarize:

--- a/tests/test_phi_ternary.py
+++ b/tests/test_phi_ternary.py
@@ -1,7 +1,6 @@
 """Tests for Phi-Ternary Primitive."""
 from __future__ import annotations
 
-import math
 import sys
 from pathlib import Path
 
@@ -9,7 +8,6 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from primitives import (
-    PhiTernary, DualPhiTernary,
     phi_ternary, dual_phi_ternary, tongue_phi_ternary,
     tongue_vector_to_phi_ternary,
     phi_ternary_energy, phi_ternary_center, phi_ternary_symmetry,

--- a/tests/test_triangulated_lattice.py
+++ b/tests/test_triangulated_lattice.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-from lattice import TriangulatedPHDMLattice, Triangle, TONGUE_DIMS, PHASE_DIMS, TELEMETRY_DIMS
+from lattice import TriangulatedPHDMLattice, Triangle, TONGUE_DIMS
 
 
 class TestConstruction:

--- a/tests/test_webtoon_catalog.py
+++ b/tests/test_webtoon_catalog.py
@@ -8,7 +8,6 @@ from scripts.build_webtoon_catalog import build_catalog
 
 
 def test_catalog_prefers_generated_panels_for_ch01(tmp_path: Path, monkeypatch: "pytest.MonkeyPatch") -> None:
-    import pytest  # noqa: F811
 
     # Set up a minimal prompts directory with a ch01 entry
     prompts_dir = tmp_path / "prompts"


### PR DESCRIPTION
## Summary

- Remove 18 unused Python imports across 7 files detected by `ruff check --select F401`
- Addresses the top CodeQL alert category (unused imports = 27 alerts)
- 5 additional F401 findings in `agents/browsers/` were left as-is — they're inside `try/except ImportError` blocks for intentional fallback re-exports

## Files changed

| File | Removed imports |
|------|----------------|
| `src/lattice/triangulated_phdm.py` | `field`, `Dict`, `Optional`, `Tuple` |
| `src/notarize/service.py` | `base64`, `field`, `List`, `Optional` |
| `src/primitives/phi_ternary.py` | `Tuple` |
| `tests/test_notarize.py` | `json`, `pytest`, `NotarizationCert` |
| `tests/test_phi_ternary.py` | `math`, `PhiTernary`, `DualPhiTernary` |
| `tests/test_triangulated_lattice.py` | `PHASE_DIMS`, `TELEMETRY_DIMS` |
| `tests/test_webtoon_catalog.py` | `pytest` (redundant re-import) |

## Test plan

- [x] `npm test` — 5,957 passed, 0 failed, 8 skipped
- [x] `ruff check --select F401` — 18 fixed, 5 remaining (intentional)
- [x] `npm run lint` — all files pass Prettier

https://claude.ai/code/session_01Mg9KGBtwM2afRL47PSNKMF