### PR TITLE
feat(harmonic): implement V1 sheaf cohomology API, unblock 52 tests

### DIFF
--- a/src/harmonic/sheafCohomology.ts
+++ b/src/harmonic/sheafCohomology.ts
@@ -262,6 +262,280 @@ export function tarskiLaplacian0<V, E>(
   return result;
 }
 
+// ============================================================
+// HARMONIC FLOW (V1 API)
+// ============================================================
+
+/**
+ * Single harmonic flow step: x' = x ∧ L₀(x).
+ * Monotonically non-increasing in the lattice order.
+ */
+export function harmonicFlowStep<V, E>(
+  sheaf: CellularSheaf<V, E>,
+  cochain: Cochain0<V>
+): Cochain0<V> {
+  const laplacian = tarskiLaplacian0(sheaf, cochain);
+  const result: Cochain0<V> = new Map();
+  for (const v of sheaf.complex.vertices) {
+    const lat = sheaf.vertexLattice(v.id);
+    const xVal = cochain.get(v.id) ?? lat.bottom();
+    const lVal = laplacian.get(v.id) ?? lat.bottom();
+    result.set(v.id, lat.meet(xVal, lVal));
+  }
+  return result;
+}
+
+/**
+ * Harmonic flow: iterate x ← x ∧ L₀(x) until convergence.
+ * Guaranteed to converge by Tarski's fixed-point theorem on
+ * finite descending chains.
+ *
+ * @returns fixedPoint, converged flag, and iteration count
+ */
+export function harmonicFlow<V, E>(
+  sheaf: CellularSheaf<V, E>,
+  initial: Cochain0<V>,
+  maxIterations: number = 100
+): { fixedPoint: Cochain0<V>; converged: boolean; iterations: number } {
+  let current = initial;
+  for (let i = 0; i < maxIterations; i++) {
+    const next = harmonicFlowStep(sheaf, current);
+    // Check convergence: all values equal
+    let converged = true;
+    for (const v of sheaf.complex.vertices) {
+      const lat = sheaf.vertexLattice(v.id);
+      const cVal = current.get(v.id) ?? lat.bottom();
+      const nVal = next.get(v.id) ?? lat.bottom();
+      if (!lat.eq(cVal, nVal)) {
+        converged = false;
+        break;
+      }
+    }
+    if (converged) {
+      return { fixedPoint: current, converged: true, iterations: i };
+    }
+    current = next;
+  }
+  return { fixedPoint: current, converged: false, iterations: maxIterations };
+}
+
+// ============================================================
+// GLOBAL SECTIONS TH⁰ (V1 API)
+// ============================================================
+
+/**
+ * Compute global sections TH⁰(X; F) = greatest fixed point of (id ∧ L₀).
+ * Starts from ⊤ (top cochain) and flows down to the greatest post-fixpoint.
+ */
+export function globalSections<V, E>(
+  sheaf: CellularSheaf<V, E>
+): { fixedPoint: Cochain0<V>; converged: boolean; iterations: number } {
+  const topCochain: Cochain0<V> = new Map();
+  for (const v of sheaf.complex.vertices) {
+    topCochain.set(v.id, sheaf.vertexLattice(v.id).top());
+  }
+  return harmonicFlow(sheaf, topCochain);
+}
+
+// ============================================================
+// OBSTRUCTION MEASUREMENT (V1 API)
+// ============================================================
+
+/**
+ * Obstruction degree: measures how far a cochain is from being a global section.
+ * Returns a value in [0, 1] where 0 = consistent, 1 = maximally inconsistent.
+ *
+ * For each vertex, measures the rank drop from the original value to the
+ * value after one Laplacian step (meet with L₀), normalized by lattice height.
+ */
+export function obstructionDegree<V, E>(sheaf: CellularSheaf<V, E>, cochain: Cochain0<V>): number {
+  const stepped = harmonicFlowStep(sheaf, cochain);
+  let totalDrop = 0;
+  let count = 0;
+
+  for (const v of sheaf.complex.vertices) {
+    const lat = sheaf.vertexLattice(v.id);
+    const elems = lat.elements();
+    const maxRank = elems.length - 1;
+    if (maxRank <= 0) continue;
+
+    const original = cochain.get(v.id) ?? lat.bottom();
+    const after = stepped.get(v.id) ?? lat.bottom();
+
+    // Find rank of each value in the element ordering
+    const origRank = elems.findIndex((e) => lat.eq(e, original));
+    const afterRank = elems.findIndex((e) => lat.eq(e, after));
+
+    const drop = Math.max(0, origRank - afterRank) / maxRank;
+    totalDrop += drop;
+    count++;
+  }
+
+  return count > 0 ? totalDrop / count : 0;
+}
+
+/**
+ * Check whether a cochain is a global section (zero obstruction).
+ */
+export function isGlobalSection<V, E>(sheaf: CellularSheaf<V, E>, cochain: Cochain0<V>): boolean {
+  return obstructionDegree(sheaf, cochain) === 0;
+}
+
+// ============================================================
+// SCBE TEMPORAL COMPLEX (V1 API)
+// ============================================================
+
+/** Edge twist parameters for governance sheaf construction */
+export interface EdgeTwist {
+  raise: number;
+  lower: number;
+}
+
+/**
+ * Build a temporal cell complex for SCBE governance.
+ * - triadic: 3 vertices (immediate, memory, governance), 3 edges (triangle)
+ * - tetradic: 4 vertices (+ predictive), 6 edges (K₄ complete graph)
+ */
+export function buildTemporalComplex(mode: 'triadic' | 'tetradic' = 'triadic'): CellComplex {
+  const vertices: CellVertex[] = [
+    { id: 'immediate', label: 'Immediate T-variant' },
+    { id: 'memory', label: 'Memory T-variant' },
+    { id: 'governance', label: 'Governance T-variant' },
+  ];
+
+  const edges: CellEdge[] = [
+    { id: 'im-mem', source: 'immediate', target: 'memory', label: 'intent braid' },
+    { id: 'mem-gov', source: 'memory', target: 'governance', label: 'context braid' },
+    { id: 'gov-im', source: 'governance', target: 'immediate', label: 'forecast braid' },
+  ];
+
+  if (mode === 'tetradic') {
+    vertices.push({ id: 'predictive', label: 'Predictive T-variant' });
+    edges.push(
+      { id: 'im-pred', source: 'immediate', target: 'predictive', label: 'prediction braid' },
+      { id: 'mem-pred', source: 'memory', target: 'predictive', label: 'memory-prediction braid' },
+      {
+        id: 'gov-pred',
+        source: 'governance',
+        target: 'predictive',
+        label: 'governance-prediction braid',
+      }
+    );
+  }
+
+  return { vertices, edges };
+}
+
+/**
+ * Build a governance sheaf on a temporal complex.
+ * All stalks use RISK_LATTICE. Restrictions default to identity Galois connections,
+ * optionally modified by edge twists that raise/lower risk levels.
+ */
+export function buildGovernanceSheaf(
+  complex: CellComplex,
+  twists?: Map<string, EdgeTwist>
+): CellularSheaf<RiskLevel, RiskLevel> {
+  const riskElements = RISK_LATTICE.elements();
+  const maxRank = riskElements.length - 1;
+
+  function makeTwistedConnection(edgeId: string): GaloisConnection<RiskLevel, RiskLevel> {
+    const twist = twists?.get(edgeId);
+    if (!twist) return identityConnection<RiskLevel>();
+
+    return {
+      lower: (v: RiskLevel): RiskLevel => {
+        const raised = Math.min(maxRank, v + twist.raise) as RiskLevel;
+        return raised;
+      },
+      upper: (v: RiskLevel): RiskLevel => {
+        const lowered = Math.max(0, v - twist.lower) as RiskLevel;
+        return lowered;
+      },
+    };
+  }
+
+  return {
+    complex,
+    vertexLattice: () => RISK_LATTICE,
+    edgeLattice: () => RISK_LATTICE,
+    sourceRestriction: (edgeId: string) => makeTwistedConnection(edgeId),
+    targetRestriction: (edgeId: string) => makeTwistedConnection(edgeId),
+  };
+}
+
+// ============================================================
+// POLICY OBSTRUCTION DETECTION (V1 API)
+// ============================================================
+
+/** Result of policy obstruction detection */
+export interface PolicyObstructionResult {
+  obstruction: number;
+  consensus: RiskLevel;
+  converged: boolean;
+  noiseTriggered: boolean;
+}
+
+/** Input risk levels for temporal T-variants */
+export interface TemporalRiskInput {
+  immediate: RiskLevel;
+  memory: RiskLevel;
+  governance: RiskLevel;
+  predictive?: RiskLevel;
+}
+
+/** Options for policy obstruction detection */
+export interface PolicyObstructionOptions {
+  noiseThreshold?: number;
+  twists?: Map<string, EdgeTwist>;
+}
+
+/**
+ * Detect policy obstruction across temporal T-variants.
+ *
+ * Builds a temporal complex and governance sheaf from the input risk levels,
+ * runs harmonic flow to find consensus, and measures the obstruction degree.
+ * Triggers fail-to-noise when obstruction exceeds the threshold.
+ */
+export function detectPolicyObstruction(
+  input: TemporalRiskInput,
+  options: PolicyObstructionOptions = {}
+): PolicyObstructionResult {
+  const { noiseThreshold = 0.5, twists } = options;
+  const mode = input.predictive !== undefined ? 'tetradic' : 'triadic';
+
+  const complex = buildTemporalComplex(mode);
+  const sheaf = buildGovernanceSheaf(complex, twists);
+
+  // Build initial cochain from input
+  const initial: Cochain0<RiskLevel> = new Map([
+    ['immediate', input.immediate],
+    ['memory', input.memory],
+    ['governance', input.governance],
+  ]);
+  if (input.predictive !== undefined) {
+    initial.set('predictive', input.predictive);
+  }
+
+  // Measure obstruction before flow
+  const obstruction = obstructionDegree(sheaf, initial);
+
+  // Run harmonic flow to find consensus
+  const { fixedPoint, converged } = harmonicFlow(sheaf, initial);
+
+  // Consensus is the meet of all fixed-point values
+  let consensus = RISK_LATTICE.top();
+  for (const val of fixedPoint.values()) {
+    consensus = RISK_LATTICE.meet(consensus, val);
+  }
+
+  return {
+    obstruction,
+    consensus,
+    converged,
+    noiseTriggered: obstruction > noiseThreshold,
+  };
+}
+
 /**
  * @module harmonic/sheaf-cohomology
  * @layer Layer 9, Layer 10, Layer 12
@@ -1100,7 +1374,34 @@ export function v2ConstantSheaf<T>(
   };
 }
 
-export { v2ConstantSheaf as constantSheaf };
+/**
+ * Constant sheaf: builds a sheaf where every stalk is the same lattice
+ * and all restrictions are identity. Supports both V1 and V2 APIs.
+ *
+ * V1: constantSheaf(CellComplex, CompleteLattice) → CellularSheaf
+ * V2: constantSheaf(V2CellComplex, V2CompleteLattice) → V2CellularSheaf
+ */
+export function constantSheaf<V>(
+  complex: CellComplex | V2CellComplex,
+  lattice: CompleteLattice<V> | V2CompleteLattice<V>
+): CellularSheaf<V, V> | V2CellularSheaf<V> {
+  // Detect V2 types: V2CellComplex has .cells() method, V1 has .vertices array
+  const isV2 = typeof (complex as V2CellComplex).cells === 'function';
+  if (isV2) {
+    return v2ConstantSheaf(complex as V2CellComplex, lattice as V2CompleteLattice<V>);
+  }
+  // V1 path
+  const v1Complex = complex as CellComplex;
+  const v1Lattice = lattice as CompleteLattice<V>;
+  const id = identityConnection<V>();
+  return {
+    complex: v1Complex,
+    vertexLattice: () => v1Lattice,
+    edgeLattice: () => v1Lattice,
+    sourceRestriction: () => id,
+    targetRestriction: () => id,
+  };
+}
 
 /**
  * Threshold sheaf on a graph: edges enforce agreement above a threshold.

--- a/tests/harmonic/sheafCohomology.test.ts
+++ b/tests/harmonic/sheafCohomology.test.ts
@@ -211,7 +211,7 @@ describe('B · Galois connections', () => {
 // C. TARSKI LAPLACIAN on small graphs
 // ============================================================
 
-describe.skip('C · Tarski Laplacian L₀ (pending V1/V2 sheaf API alignment)', () => {
+describe('C · Tarski Laplacian L₀', () => {
   // Simple graph: v1 — e1 — v2
   const twoVertexGraph: CellComplex = {
     vertices: [{ id: 'v1' }, { id: 'v2' }],
@@ -278,7 +278,7 @@ describe.skip('C · Tarski Laplacian L₀ (pending V1/V2 sheaf API alignment)', 
 // D. HARMONIC FLOW
 // ============================================================
 
-describe.skip('D · Harmonic flow (pending V1/V2 sheaf API alignment)', () => {
+describe('D · Harmonic flow', () => {
   const twoVertexGraph: CellComplex = {
     vertices: [{ id: 'v1' }, { id: 'v2' }],
     edges: [{ id: 'e1', source: 'v1', target: 'v2' }],
@@ -339,7 +339,7 @@ describe.skip('D · Harmonic flow (pending V1/V2 sheaf API alignment)', () => {
 // E. GLOBAL SECTIONS (TH⁰)
 // ============================================================
 
-describe.skip('E · Global sections TH⁰ (pending V1/V2 sheaf API alignment)', () => {
+describe('E · Global sections TH⁰', () => {
   it('constant sheaf on connected graph: sections are constant cochains', () => {
     const triangle: CellComplex = {
       vertices: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
@@ -378,7 +378,7 @@ describe.skip('E · Global sections TH⁰ (pending V1/V2 sheaf API alignment)', 
 // F. OBSTRUCTION MEASUREMENT
 // ============================================================
 
-describe.skip('F · Obstruction degree (pending V1 API export)', () => {
+describe('F · Obstruction degree', () => {
   const twoVertexGraph: CellComplex = {
     vertices: [{ id: 'v1' }, { id: 'v2' }],
     edges: [{ id: 'e1', source: 'v1', target: 'v2' }],
@@ -438,7 +438,7 @@ describe.skip('F · Obstruction degree (pending V1 API export)', () => {
 // G. SCBE TEMPORAL COMPLEX
 // ============================================================
 
-describe.skip('G · Temporal complex builder (pending V1 API export)', () => {
+describe('G · Temporal complex builder', () => {
   it('triadic mode: 3 vertices, 3 edges (triangle)', () => {
     const c = buildTemporalComplex('triadic');
     expect(c.vertices).toHaveLength(3);
@@ -466,7 +466,7 @@ describe.skip('G · Temporal complex builder (pending V1 API export)', () => {
 // H. GOVERNANCE SHEAF
 // ============================================================
 
-describe.skip('H · Governance sheaf (pending V1 API export)', () => {
+describe('H · Governance sheaf', () => {
   it('builds with constant restrictions (no twist)', () => {
     const complex = buildTemporalComplex('triadic');
     const sheaf = buildGovernanceSheaf(complex);
@@ -506,7 +506,7 @@ describe.skip('H · Governance sheaf (pending V1 API export)', () => {
 // I. POLICY OBSTRUCTION DETECTION
 // ============================================================
 
-describe.skip('I · Policy obstruction detection (pending V1 API export)', () => {
+describe('I · Policy obstruction detection', () => {
   it('all agents agree → zero obstruction, no noise', () => {
     const result = detectPolicyObstruction({
       immediate: RiskLevel.QUARANTINE,
@@ -585,7 +585,7 @@ describe.skip('I · Policy obstruction detection (pending V1 API export)', () =>
 // J. FAIL-TO-NOISE
 // ============================================================
 
-describe.skip('J · Fail-to-noise (pending V1 API export)', () => {
+describe('J · Fail-to-noise', () => {
   it('produces fixed-size output', () => {
     const noise = failToNoise(0.7);
     expect(noise).toHaveLength(256);
@@ -630,7 +630,7 @@ describe.skip('J · Fail-to-noise (pending V1 API export)', () => {
 // K. BRAIDED TEMPORAL DISTANCE
 // ============================================================
 
-describe.skip('K · Braided temporal distance (pending V1 API export)', () => {
+describe('K · Braided temporal distance', () => {
   it('identical variants → zero distance', () => {
     expect(braidedTemporalDistance([0.5, 0.5, 0.5])).toBeCloseTo(0, 5);
   });
@@ -672,7 +672,7 @@ describe.skip('K · Braided temporal distance (pending V1 API export)', () => {
 // L. BRAIDED META-TIME
 // ============================================================
 
-describe.skip('L · Braided meta-time (pending V1 API export)', () => {
+describe('L · Braided meta-time', () => {
   it('basic computation: T^(t+2) * intent * context', () => {
     // T=2, t=1, intent=1.1, context=0.9
     const result = braidedMetaTime(2, 1, 1.1, 0.9);
@@ -703,7 +703,7 @@ describe.skip('L · Braided meta-time (pending V1 API export)', () => {
 // M. COHOMOLOGICAL HARMONIC WALL
 // ============================================================
 
-describe.skip('M · Cohomological harmonic wall (pending V1 API export)', () => {
+describe('M · Cohomological harmonic wall', () => {
   it('zero obstruction → wall = 1 (no amplification)', () => {
     expect(cohomologicalHarmonicWall(0)).toBeCloseTo(1, 10);
   });
@@ -744,7 +744,7 @@ describe.skip('M · Cohomological harmonic wall (pending V1 API export)', () => 
 // N. INTEGRATION SCENARIOS
 // ============================================================
 
-describe.skip('N · SCBE governance scenarios (pending V1 API export)', () => {
+describe('N · SCBE governance scenarios', () => {
   it('scenario: all temporal T-variants report safe → ALLOW consensus', () => {
     const result = detectPolicyObstruction({
       immediate: RiskLevel.ALLOW,


### PR DESCRIPTION
## Summary

- **Implement 9 missing V1 sheaf cohomology functions** that were blocking 12 `describe.skip` blocks (52 tests) in `sheafCohomology.test.ts`
- **Make `constantSheaf` dual-dispatch** (V1 `CellComplex` + V2 `V2CellComplex`) so existing V2 tests continue passing
- **Unskip 12 test blocks** (sections C through N) covering: Tarski Laplacian, harmonic flow, global sections, obstruction measurement, temporal complex, governance sheaf, policy obstruction detection, fail-to-noise, braided temporal distance, braided meta-time, cohomological harmonic wall, and SCBE governance scenarios

### New V1 API functions

| Function | Purpose |
|----------|---------|
| `harmonicFlowStep` | Single step x ∧ L₀(x) |
| `harmonicFlow` | Iterate to convergence (Tarski fixed-point) |
| `globalSections` | TH⁰ from top cochain |
| `obstructionDegree` | [0,1] measure of cochain inconsistency |
| `isGlobalSection` | Zero-obstruction check |
| `buildTemporalComplex` | Triadic/tetradic CellComplex builder |
| `buildGovernanceSheaf` | CellularSheaf with optional EdgeTwist |
| `detectPolicyObstruction` | Full pipeline: build → flow → measure → noise |

### Test results

| Metric | Before | After |
|--------|--------|-------|
| Tests passed | 5,465 | **5,517** |
| Tests skipped | 108 | **56** |
| Tests failed | 0 | **0** |

## Test plan

- [x] `npm run build` — clean compilation
- [x] `npm test` — 5,517 passed, 56 skipped, 0 failures
- [x] `npm run lint` — all Prettier checks pass
- [x] `npm run check:circular` — no circular dependencies
- [x] `npm run typecheck` — no type errors
- [ ] CI pipeline passes

## Affected Layers

- [x] L5-6: Hyperbolic distance / breathing transform
- [x] L9-10: Spectral / spin coherence
- [x] L11-12: Temporal distance / harmonic wall
- [x] L13-14: Risk decision / audio axis

## Axiom Compliance

- [x] A4: Symmetry (Galois connections preserve order structure)
- [x] A5: Composition (pipeline integrity via sheaf functoriality)

https://claude.ai/code/session_01VvwrbZy6xuwCC1XdNxRMhX