### PR TITLE
fix(lint): apply Prettier formatting to combat-network.ts

### DIFF
--- a/src/spaceTor/combat-network.ts
+++ b/src/spaceTor/combat-network.ts
@@ -52,8 +52,16 @@ export class CombatNetwork {
       const pathA = this.router.calculatePath(origin, dest, 70);
       const pathB = this.generateDisjointPath(pathA, origin, dest, 70);
 
-      log.info('Routing via PRIMARY', { mode: 'COMBAT', pathId: 'PRIMARY', route: pathA.map((n) => n.id).join(' -> ') });
-      log.info('Routing via BACKUP-1', { mode: 'COMBAT', pathId: 'BACKUP-1', route: pathB.map((n) => n.id).join(' -> ') });
+      log.info('Routing via PRIMARY', {
+        mode: 'COMBAT',
+        pathId: 'PRIMARY',
+        route: pathA.map((n) => n.id).join(' -> '),
+      });
+      log.info('Routing via BACKUP-1', {
+        mode: 'COMBAT',
+        pathId: 'BACKUP-1',
+        route: pathB.map((n) => n.id).join(' -> '),
+      });
 
       // 2. Encrypt & Send Parallel
       const [onionA, onionB] = await Promise.all([
@@ -71,7 +79,10 @@ export class CombatNetwork {
     } else {
       // Standard Routing
       const path = this.router.calculatePath(origin, dest, 50);
-      log.info('Routing via STANDARD', { mode: 'STANDARD', route: path.map((n) => n.id).join(' -> ') });
+      log.info('Routing via STANDARD', {
+        mode: 'STANDARD',
+        route: path.map((n) => n.id).join(' -> '),
+      });
 
       const onion = await this.crypto.buildOnion(payload, path);
       const result = await this.transmit(path[0], onion, 'STANDARD');


### PR DESCRIPTION
## Summary

- Fix Prettier formatting violation in `src/spaceTor/combat-network.ts`
- Three log statements exceeded 100-char line limit; auto-formatted by Prettier

## Verified

- Build: clean
- Tests: 5,530 passed, 43 skipped, 0 failures (157 files)
- Lint: all Prettier checks pass
- Circular deps: none (300+ files checked)
- npm audit: 0 vulnerabilities

## Test plan

- [x] `npm run build` — clean compilation
- [x] `npm test` — all tests pass
- [x] `npm run lint` — no formatting issues
- [x] `npm run check:circular` — no circular deps

https://claude.ai/code/session_01JJE8Gvs7tKRPo6vB1LQSFf