### PR TITLE
fix(logging): migrate console.log/error to structured logger in 3 core modules

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -9,6 +9,7 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 import { govern, listPolicies, GovernanceRequest, GovernanceResponse } from './govern.js';
+import { logger } from '../utils/logger.js';
 
 // ============================================================================
 // Types
@@ -46,7 +47,7 @@ function requestLogger(req: Request, res: Response, next: NextFunction): void {
   const start = Date.now();
   res.on('finish', () => {
     const duration = Date.now() - start;
-    console.log(`${req.method} ${req.path} ${res.statusCode} ${duration}ms`);
+    logger.info(`${req.method} ${req.path} ${res.statusCode} ${duration}ms`, { module: 'api' });
   });
   next();
 }
@@ -183,7 +184,7 @@ export function createApp(): express.Application {
 
       res.json(response);
     } catch (error) {
-      console.error('Governance error:', error);
+      logger.error('Governance error', { module: 'api', error: String(error) });
       res.status(500).json({
         error: 'Internal Server Error',
         message: 'Governance engine error',
@@ -234,7 +235,7 @@ export function createApp(): express.Application {
 
       res.json({ decisions });
     } catch (error) {
-      console.error('Batch governance error:', error);
+      logger.error('Batch governance error', { module: 'api', error: String(error) });
       res.status(500).json({
         error: 'Internal Server Error',
         message: 'Batch processing error',
@@ -342,12 +343,13 @@ export function startServer(port = 8080): void {
   const app = createApp();
 
   app.listen(port, () => {
-    console.log(`🛡️  SCBE Governance API running on http://localhost:${port}`);
-    console.log(`   POST /v1/govern       - Request governance decision`);
-    console.log(`   POST /v1/govern/batch - Batch governance decisions`);
-    console.log(`   GET  /v1/policies     - List active policies`);
-    console.log(`   GET  /v1/audit        - Get audit log`);
-    console.log(`   GET  /v1/stats        - Get statistics`);
+    logger.info(`SCBE Governance API running on http://localhost:${port}`, { module: 'api' });
+    logger.info(
+      'Routes: POST /v1/govern, POST /v1/govern/batch, GET /v1/policies, GET /v1/audit, GET /v1/stats',
+      {
+        module: 'api',
+      }
+    );
   });
 }
 

--- a/src/browser/cdp-backend.ts
+++ b/src/browser/cdp-backend.ts
@@ -17,6 +17,7 @@
 import { request as httpRequest } from 'http';
 import { BrowserBackend } from './agent.js';
 import { WSClient } from './ws-client.js';
+import { logger } from '../utils/logger.js';
 import {
   BrowserSessionConfig,
   PageObservation,
@@ -196,7 +197,7 @@ export class CDPBackend implements BrowserBackend {
       this.connected = false;
     });
     this.ws.on('error', (err: Error) => {
-      if (this.debug) console.error('[CDP] WebSocket error:', err.message);
+      if (this.debug) logger.error(`WebSocket error: ${err.message}`, { module: 'cdp-backend' });
     });
 
     await this.ws.connect();
@@ -239,7 +240,7 @@ export class CDPBackend implements BrowserBackend {
     }
 
     if (this.debug) {
-      console.log(`[CDP] Connected to "${target.title}" (${target.url})`);
+      logger.info(`Connected to "${target.title}" (${target.url})`, { module: 'cdp-backend' });
     }
   }
 
@@ -869,7 +870,9 @@ export class CDPBackend implements BrowserBackend {
       const message = JSON.stringify({ id, method, params: params ?? {} });
 
       if (this.debug) {
-        console.log(`[CDP →] ${method}`, params ? JSON.stringify(params).slice(0, 200) : '');
+        logger.debug(`CDP → ${method} ${params ? JSON.stringify(params).slice(0, 200) : ''}`, {
+          module: 'cdp-backend',
+        });
       }
 
       this.ws.send(message);
@@ -896,7 +899,9 @@ export class CDPBackend implements BrowserBackend {
           pending.reject(new Error(`CDP error: ${resp.error.message} (${resp.error.code})`));
         } else {
           if (this.debug) {
-            console.log(`[CDP ←] #${resp.id}`, JSON.stringify(resp.result ?? {}).slice(0, 200));
+            logger.debug(`CDP ← #${resp.id} ${JSON.stringify(resp.result ?? {}).slice(0, 200)}`, {
+              module: 'cdp-backend',
+            });
           }
           pending.resolve(resp.result ?? {});
         }
@@ -914,7 +919,9 @@ export class CDPBackend implements BrowserBackend {
             handler(event.params);
           } catch (err) {
             if (this.debug) {
-              console.error(`[CDP] Event handler error for ${event.method}:`, err);
+              logger.error(`Event handler error for ${event.method}: ${err}`, {
+                module: 'cdp-backend',
+              });
             }
           }
         }

--- a/src/spiralverse/spiralverse-sdk.ts
+++ b/src/spiralverse/spiralverse-sdk.ts
@@ -10,6 +10,7 @@
  */
 
 import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
 
 // ========== TYPES ==========
 
@@ -118,19 +119,19 @@ export class SpiralverseProtocol {
     for (const tongue of requiredTongues) {
       const sig = envelope.signatures[tongue];
       if (!sig) {
-        console.error(`Missing signature for required tongue: ${tongue}`);
+        logger.error(`Missing signature for required tongue: ${tongue}`, { module: 'spiralverse' });
         return false;
       }
 
       const secret = this.secrets.get(tongue);
       if (!secret) {
-        console.error(`Missing secret for tongue: ${tongue}`);
+        logger.error(`Missing secret for tongue: ${tongue}`, { module: 'spiralverse' });
         return false;
       }
 
       const expected = this.sign(canonical, secret, tongue);
       if (sig !== expected) {
-        console.error(`Invalid signature for tongue: ${tongue}`);
+        logger.error(`Invalid signature for tongue: ${tongue}`, { module: 'spiralverse' });
         return false;
       }
     }
@@ -138,7 +139,7 @@ export class SpiralverseProtocol {
     // Check timestamp freshness (5 minute window)
     const age = Date.now() - new Date(envelope.ts).getTime();
     if (age > 5 * 60 * 1000) {
-      console.error('Envelope expired');
+      logger.error('Envelope expired', { module: 'spiralverse' });
       return false;
     }
 


### PR DESCRIPTION
## Summary

- **src/api/server.ts** — Replace 6 `console.log`/`console.error` calls with `logger.info`/`logger.error` (request logging, governance errors, startup banner)
- **src/browser/cdp-backend.ts** — Replace 6 conditional `console.log`/`console.error` calls with `logger.debug`/`logger.info`/`logger.error` (CDP traffic, connection, event handler errors)
- **src/spiralverse/spiralverse-sdk.ts** — Replace 4 `console.error` calls with `logger.error` (envelope verification failures)

Follows the pattern established in PR #789 (sheaf cohomology logger migration). All calls now use the structured logger from `src/utils/logger.ts` with proper module context tags.

## Test plan

- [x] `npm run build` — clean compilation
- [x] `npm test` — 5,530 passed, 43 skipped, 0 failures (155 files)
- [x] `npm run lint` — all Prettier checks pass
- [x] `npm audit` — 0 vulnerabilities

https://claude.ai/code/session_019DnfHELAHEQHDGPPz4zbSp