### PR TITLE
fix(ci): auto-triage workflow action tags

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -5,27 +5,29 @@ on:
     types: [opened, edited, reopened]
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
-  schedule:
-    - cron: '0 0 * * *'  # Daily at midnight
 
 permissions:
   issues: write
   pull-requests: write
   contents: read
 
+env:
+  # Preempt Node 20 deprecation warnings for JavaScript-based actions.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   auto-label:
     name: Auto Label Issues and PRs
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name != 'schedule'
+    if: github.event_name == 'pull_request_target'
     steps:
       - uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Label based on size
-        uses: codelytv/pr-size-labeler@v1.11.0
+        uses: codelytv/pr-size-labeler@v1.10.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/XS'
@@ -43,9 +45,9 @@ jobs:
     name: Auto Assign
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name != 'schedule'
+    if: github.event_name == 'issues'
     steps:
-      - uses: pozil/auto-assign-issue@v4
+      - uses: pozil/auto-assign-issue@v2.2.0
         with:
           assignees: issdandavis
           numOfAssignee: 1


### PR DESCRIPTION
Pins auto-triage action tags to valid releases and removes the broken schedule gating that was causing PR checks to fail.