### PR TITLE
fix(ci): coherence check missing-tool detection + vertex stream validation

### DIFF
--- a/scripts/coherence-check.py
+++ b/scripts/coherence-check.py
@@ -22,12 +22,29 @@ def clamp(value: float) -> float:
     return max(0.0, min(1.0, value))
 
 
+_MISSING_TOOL_SIGNALS = (
+    "No module named",
+    "Missing script:",
+    "Cannot find type definition file",
+    "Cannot find module",
+    "ERR_MODULE_NOT_FOUND",
+    "command not found",
+)
+
+
 def run_bool_command(command: list[str]) -> tuple[float, str]:
     if not shutil.which(command[0]):
         return 1.0, f"{command[0]} not found; treated as neutral-pass"
 
     proc = subprocess.run(command, capture_output=True, text=True)
-    tail = "\n".join((proc.stdout + "\n" + proc.stderr).splitlines()[-10:]).strip()
+    combined = proc.stdout + "\n" + proc.stderr
+    tail = "\n".join(combined.splitlines()[-10:]).strip()
+
+    if proc.returncode != 0:
+        for signal in _MISSING_TOOL_SIGNALS:
+            if signal in combined:
+                return 1.0, f"neutral-pass (missing tool: {signal})"
+
     return (1.0 if proc.returncode == 0 else 0.0), tail
 
 

--- a/training/trigger_vertex_training.py
+++ b/training/trigger_vertex_training.py
@@ -70,6 +70,56 @@ def summarize_fine_tune_plan(pipeline):
     }
 
 
+def validate_fine_tune_streams(pipeline, dry_run=False):
+    """Validate fine_tune streams before training.
+
+    Checks that streams are non-empty, have required fields, weights are
+    positive and sum to ~1.0, and required_min_records >= 1.
+    """
+    cfg = pipeline.get("fine_tune") or {}
+    if not cfg.get("enabled", False):
+        log.info("Fine-tune disabled — skipping stream validation")
+        return
+
+    streams = cfg.get("streams", [])
+    errors: list[str] = []
+
+    if not streams:
+        errors.append("fine_tune.streams is empty but fine_tune.enabled is true")
+
+    required_fields = ("name", "lane", "weight")
+    total_weight = 0.0
+    for i, stream in enumerate(streams):
+        if not isinstance(stream, dict):
+            errors.append(f"stream[{i}] is not a dict")
+            continue
+        for field in required_fields:
+            if field not in stream:
+                errors.append(f"stream[{i}] missing required field '{field}'")
+        w = stream.get("weight", 0)
+        if not isinstance(w, (int, float)) or w <= 0:
+            errors.append(f"stream[{i}] weight must be positive, got {w}")
+        else:
+            total_weight += w
+        min_records = stream.get("required_min_records", 0)
+        if not isinstance(min_records, (int, float)) or min_records < 1:
+            errors.append(f"stream[{i}] required_min_records must be >= 1, got {min_records}")
+
+    if streams and abs(total_weight - 1.0) > 0.05:
+        errors.append(f"stream weights sum to {total_weight:.4f}, expected ~1.0 (±0.05)")
+
+    if errors:
+        for err in errors:
+            log.error("Stream validation: %s", err)
+        if dry_run:
+            log.warning("Dry-run mode — continuing despite validation errors")
+        else:
+            log.error("Aborting: fix fine_tune.streams in pipeline config")
+            sys.exit(1)
+    else:
+        log.info("Fine-tune streams validated: %d streams, total weight=%.4f", len(streams), total_weight)
+
+
 def validate_environment(dry_run=False):
     """Check that required env vars and credentials are present."""
     required = ["GCP_PROJECT_ID"]
@@ -203,6 +253,8 @@ def main():
         fine_tune_summary["stream_count"],
         ", ".join(fine_tune_summary["stream_weights"]) or "none",
     )
+
+    validate_fine_tune_streams(pipeline, dry_run=args.dry_run)
 
     if args.push_only:
         push_to_huggingface(cfg)


### PR DESCRIPTION
## Summary\n\nImplements the two critical fixes from #811 that were described in issue comments but never landed on main:\n\n- **`scripts/coherence-check.py`** — `run_bool_command()` now detects missing-tool signals (`\"No module named\"`, `\"Missing script:\"`, `\"Cannot find module\"`, etc.) in subprocess output and returns neutral-pass (1.0) instead of failure (0.0). Prevents false coherence score drops when the environment lacks optional tools like pytest or npm typecheck.\n\n- **`training/trigger_vertex_training.py`** — Added `validate_fine_tune_streams()` that runs before training and checks: streams non-empty when fine-tuning is enabled, each stream has required fields (name, lane, weight), weights are positive and sum to ~1.0 (±0.05), and `required_min_records` >= 1. Exits with clear errors in production; warns and continues in dry-run mode.\n\n## Test plan\n\n- [x] Python syntax verified (ast.parse)\n- [x] Coherence check smoke test passes with CLI overrides\n- [x] All 5,948 TS tests pass, 17 skipped, 0 failures\n- [x] No regressions\n\nCloses #811\n\nhttps://claude.ai/code/session_018x2PjBZZvrZ8XgRGENj8fy