### PR TITLE
fix(ci): stabilize workflows (ruff/timeout/auto-merge/ci-auto-fix)

### DIFF
--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -18,7 +18,20 @@ jobs:
       github.actor == 'issdandavis'
     steps:
       - name: Enable auto-merge (squash)
-        run: gh pr merge --auto --squash "$PR_URL"
+        shell: bash
+        run: |
+          set -euo pipefail
+          rc=0
+          out="$(gh pr merge --auto --squash "$PR_URL" 2>&1)" || rc=$?
+          echo "$out"
+          if [ "$rc" -eq 0 ]; then
+            exit 0
+          fi
+          if echo "$out" | grep -q "Merge already in progress"; then
+            echo "Auto-merge already in progress; treating as success."
+            exit 0
+          fi
+          exit "$rc"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-auto-fix.yml
+++ b/.github/workflows/ci-auto-fix.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   auto-fix:
     # Only on failure, skip our own fix branches to prevent infinite loops
-    if: |
+    if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       !startsWith(github.event.workflow_run.head_branch, 'fix/ci-auto-fix')
     runs-on: ubuntu-latest

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Install dependencies
         run: |
           npm install
-          pip install -r requirements.txt || pip install numpy scipy pytest
+          python -m pip install -r requirements.txt || python -m pip install numpy scipy pytest pytest-timeout
+          python -m pip install pytest-timeout
 
       - name: Type check
         run: npm run typecheck

--- a/src/governance/chemical_bonds.py
+++ b/src/governance/chemical_bonds.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import List
 
 import numpy as np
 


### PR DESCRIPTION
CI stability pass 1.

Fixes:
- ruff: remove unused typing imports in src/governance/chemical_bonds.py
- copilot-setup-steps: install pytest-timeout so --timeout=30 works
- auto-merge-enable: treat "Merge already in progress" as success (avoid noisy red runs)
- ci-auto-fix: fold multiline job if expression (avoid workflow file issue)

Why:
- These failures were showing up as recurring daily blockages in Actions.
- Goal is green CI by default, and "optional" automation not causing red noise.