### PR TITLE
fix(tests): deterministic governance imports in CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,8 +26,14 @@ except ImportError:
     np = None  # type: ignore[assignment]
     NUMPY_AVAILABLE = False
 
-# Add src to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# Ensure repo-local `src/` wins over any installed modules with the same names.
+# CI has observed an installed `governance` module being imported before tests,
+# which breaks imports like `from governance.*` even when tests later tweak sys.path.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC_ROOT = _REPO_ROOT / "src"
+sys.path.insert(0, str(_SRC_ROOT))
+sys.path.insert(0, str(_REPO_ROOT))
+sys.modules.pop("governance", None)
 
 # Keep pytest temp factories inside the repo workspace so Windows temp ACL issues
 # do not break tmp_path/tmpdir-based tests.


### PR DESCRIPTION
This is a guardrail fix to prevent recurring CI collection failures.

Problem:
- CI observed `ModuleNotFoundError: No module named governance.*; governance is not a package` during pytest collection.
- Root cause is an installed module named `governance` being imported before tests, and then shadowing the repo's `src/governance/` package.

Fix:
- Put `src/` and repo root first on `sys.path` for all tests.
- Clear any pre-imported `governance` module from `sys.modules` so repo-local package imports are deterministic.

Goal:
- Stop this class of failure from reappearing in new tests/workflows.