### PR TITLE
fix(ci): stop flaky crypto property + governance import shadowing

### DIFF
--- a/tests/crypto/test_rwp_v3_properties.py
+++ b/tests/crypto/test_rwp_v3_properties.py
@@ -257,7 +257,9 @@ class TestNonceUniqueness:
 
     @given(
         password=st.binary(min_size=1, max_size=32),
-        plaintext=st.binary(min_size=1, max_size=256),
+        # Avoid probabilistic collisions: with 1-byte plaintext, env1.ct can equal env2.ct with ~1/256 chance.
+        # Use longer plaintext so ct equality would be astronomically unlikely for a correct randomized AEAD.
+        plaintext=st.binary(min_size=32, max_size=256),
     )
     @settings(max_examples=50, deadline=None)
     def test_ciphertexts_differ_for_same_plaintext(self, password: bytes, plaintext: bytes):

--- a/tests/test_negative_tongue_lattice.py
+++ b/tests/test_negative_tongue_lattice.py
@@ -9,16 +9,11 @@ Coverage:
   - Zero-state: lattice object has no stored state after init
 """
 
-import sys
-import os
-
 import numpy as np
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-
-from governance.negative_tongue_lattice import NegativeTongueLattice
-from symphonic_cipher.scbe_aethermoore.qc_lattice.phason_secret import PhasonSecret
+from src.governance.negative_tongue_lattice import NegativeTongueLattice
+from src.symphonic_cipher.scbe_aethermoore.qc_lattice.phason_secret import PhasonSecret
 
 # =============================================================================
 # NEGATIVE TONGUE LATTICE TESTS
@@ -403,7 +398,7 @@ class TestRuntimeGateNegativeLattice:
 
     def test_default_lattice_energy_zero(self):
         """Default (no negative lattice) should have lattice_energy=0."""
-        from governance.runtime_gate import RuntimeGate
+        from src.governance.runtime_gate import RuntimeGate
 
         gate = RuntimeGate()
         # Run enough evaluations to get past calibration
@@ -413,7 +408,7 @@ class TestRuntimeGateNegativeLattice:
 
     def test_lattice_energy_nonzero_when_enabled(self):
         """With negative lattice enabled, lattice_energy should be > 0."""
-        from governance.runtime_gate import RuntimeGate
+        from src.governance.runtime_gate import RuntimeGate
 
         gate = RuntimeGate(use_negative_lattice=True)
         # Run past calibration
@@ -424,7 +419,7 @@ class TestRuntimeGateNegativeLattice:
 
     def test_lattice_modulates_cost(self):
         """With lattice enabled, cost should be >= cost without lattice."""
-        from governance.runtime_gate import RuntimeGate
+        from src.governance.runtime_gate import RuntimeGate
 
         gate_plain = RuntimeGate()
         gate_lattice = RuntimeGate(use_negative_lattice=True)


### PR DESCRIPTION
CI stability pass (tests).

Fixes:
- Make Negative Tongue Lattice tests import governance + runtime_gate via `src.*` to avoid collisions with any installed `governance` module.
- De-flake RWP v3 property test: require longer plaintext for the ciphertext-diff assertion (prevents probabilistic collisions from failing Hypothesis).

Goal:
- Stop recurring red CI from import shadowing and probabilistic crypto assertions.