### PR TITLE
fix(tests): guard cryptography imports and add missing governance __init__.py

### DIFF
--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -1,0 +1,1 @@
+# SCBE-AETHERMOORE Governance Module

--- a/tests/test_api_header_compat.py
+++ b/tests/test_api_header_compat.py
@@ -4,8 +4,14 @@ import types
 
 import pytest
 
-from api import main as api_main
-from fastapi import HTTPException
+# The api.main module transitively imports cryptography via the GitHub App
+# routes.  When the cffi backend is missing (common in lightweight CI images)
+# the Rust binding panics (uncatchable).  Guard by checking for _cffi_backend
+# before any cryptography import.
+pytest.importorskip("_cffi_backend", reason="cffi backend unavailable — cryptography will panic")
+
+from api import main as api_main  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
 
 fake_mangum = types.ModuleType("mangum")
 

--- a/tests/test_proton_mail_ops.py
+++ b/tests/test_proton_mail_ops.py
@@ -4,7 +4,14 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
+
+# proton_mail_ops transitively imports cryptography.fernet which requires a
+# working cffi/rust backend.  The Rust binding panics (uncatchable) when cffi
+# is missing, so check for _cffi_backend first.
+pytest.importorskip("_cffi_backend", reason="cffi backend unavailable — cryptography will panic")
 
 
 def _load_module(name: str, relative_path: str):


### PR DESCRIPTION
## Summary
- Add `pytest.importorskip("_cffi_backend")` guards to `test_api_header_compat.py` and `test_proton_mail_ops.py` to prevent uncatchable Rust/pyo3 panics when the cffi backend is missing
- Create `src/governance/__init__.py` so Python recognizes the governance directory as a package
- These 3 collection errors were blocking the entire pytest suite, causing the daily coherence score to drop to 0.75

## Test plan
- [x] `pytest --co` collects all 5102 tests with 0 errors
- [x] Homebrew smoke tests pass (29/29)
- [ ] Full pytest suite passes in CI

Fixes #825

https://claude.ai/code/session_01YSVkBDyY6AhpGdNcNwDEXx