### PR TITLE
fix(tests): resolve pytest collection import collision

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,11 +29,29 @@ except ImportError:
 # Ensure repo-local `src/` wins over any installed modules with the same names.
 # CI has observed an installed `governance` module being imported before tests,
 # which breaks imports like `from governance.*` even when tests later tweak sys.path.
+# IMPORTANT: _SRC_ROOT must come BEFORE _REPO_ROOT on sys.path so that
+# `src/symphonic_cipher/` (safety-score variant with qc_lattice, governance, etc.)
+# is found before the root `symphonic_cipher/` (exponential-cost variant).
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SRC_ROOT = _REPO_ROOT / "src"
-sys.path.insert(0, str(_SRC_ROOT))
 sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_SRC_ROOT))
 sys.modules.pop("governance", None)
+# Purge ALL symphonic_cipher submodules so the src/ variant is cleanly imported.
+for _k in list(sys.modules):
+    if _k == "symphonic_cipher" or _k.startswith("symphonic_cipher."):
+        del sys.modules[_k]
+
+# Force-load the src/ variant immediately so collection-time imports find it.
+import symphonic_cipher as _sc_check
+if getattr(_sc_check, "_VARIANT", None) != "src":
+    # Wrong variant loaded — purge again and re-import with only src/ on path
+    for _k in list(sys.modules):
+        if _k == "symphonic_cipher" or _k.startswith("symphonic_cipher."):
+            del sys.modules[_k]
+    import importlib as _il
+    _sc_check = _il.import_module("symphonic_cipher")
+del _sc_check
 
 # Keep pytest temp factories inside the repo workspace so Windows temp ACL issues
 # do not break tmp_path/tmpdir-based tests.
@@ -103,6 +121,7 @@ def _register_ai_brain_aliases():
         "concept_blocks",
         "multimodal",
         "rosetta",
+        "qc_lattice",
         # Modules
         "trinary",
         "negabinary",

--- a/tests/test_code_scanning_batch3.py
+++ b/tests/test_code_scanning_batch3.py
@@ -14,18 +14,40 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def _load_module(relative_path: str, module_name: str, extra_paths: list[Path] | None = None):
+    added: list[str] = []
+    # Save and clear any cached modules that extra_paths might shadow
+    saved_mods: dict[str, object] = {}
     if extra_paths:
         for extra in extra_paths:
             extra_str = str(extra)
             if extra_str not in sys.path:
                 sys.path.insert(0, extra_str)
-    path = ROOT / relative_path
-    spec = importlib.util.spec_from_file_location(module_name, path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
+                added.append(extra_str)
+        # Clear cached governance so spiral-word-app/governance.py can be found
+        # during module execution (it would otherwise resolve to src/governance/)
+        gov = sys.modules.get("governance")
+        if gov is not None:
+            saved_mods["governance"] = gov
+            del sys.modules["governance"]
+    try:
+        path = ROOT / relative_path
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        # Remove temporary paths so they don't shadow packages in src/
+        for p in added:
+            try:
+                sys.path.remove(p)
+            except ValueError:
+                pass
+        # Restore original governance module if we cleared it
+        for k, v in saved_mods.items():
+            sys.modules.pop(k, None)  # remove spiral-word-app's governance
+            sys.modules[k] = v        # restore src/governance
 
 
 playwriter_lane_runner = _load_module(
@@ -84,14 +106,28 @@ def test_npc_and_training_sanitizers_strip_script_payloads() -> None:
 
 
 def test_spiralword_public_ai_errors_are_generic() -> None:
-    def boom_provider(prompt: str, options: dict | None = None) -> str:
-        raise RuntimeError("secret trace path")
+    # ai_ports.py lazily imports from spiral-word-app/governance.py at call time,
+    # so we must temporarily add spiral-word-app/ to sys.path for this test.
+    spiralword_dir = str(ROOT / "spiral-word-app")
+    sys.path.insert(0, spiralword_dir)
+    # Clear any cached governance module so the spiral-word-app version is found.
+    sys.modules.pop("governance", None)
+    try:
+        def boom_provider(prompt: str, options: dict | None = None) -> str:
+            raise RuntimeError("secret trace path")
 
-    registry = spiralword_ai_ports.AIPortRegistry()
-    registry.register("boom", boom_provider)
+        registry = spiralword_ai_ports.AIPortRegistry()
+        registry.register("boom", boom_provider)
 
-    result = registry.call("hello world", provider="boom")
-    payload = spiralword_app._public_ai_result_payload(result)
+        result = registry.call("hello world", provider="boom")
+        payload = spiralword_app._public_ai_result_payload(result)
 
-    assert result == "[ERROR] Provider boom failed"
-    assert payload == {"status": "error", "message": "AI provider request failed"}
+        assert result == "[ERROR] Provider boom failed"
+        assert payload == {"status": "error", "message": "AI provider request failed"}
+    finally:
+        try:
+            sys.path.remove(spiralword_dir)
+        except ValueError:
+            pass
+        # Remove the non-package governance so it doesn't break later imports.
+        sys.modules.pop("governance", None)

--- a/tests/test_negative_tongue_lattice.py
+++ b/tests/test_negative_tongue_lattice.py
@@ -14,8 +14,25 @@ import sys
 
 # Ensure local src/ wins over any installed `governance` module that may be
 # imported by plugins before we set up sys.path (GitHub Actions CI observed this).
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-sys.modules.pop("governance", None)
+# Also handles the case where spiral-word-app/governance.py (a plain .py file)
+# was imported earlier, which prevents sub-module imports.
+_src_dir = os.path.join(os.path.dirname(__file__), "..", "src")
+if _src_dir not in sys.path:
+    sys.path.insert(0, _src_dir)
+
+# Clear cached non-package governance (e.g. from spiral-word-app/governance.py)
+_prev_gov = sys.modules.get("governance")
+if _prev_gov is not None and not hasattr(_prev_gov, "__path__"):
+    sys.modules.pop("governance", None)
+
+# If the root symphonic_cipher variant was cached by an earlier test, clear it
+# so the src/ variant (which has qc_lattice, governance, etc.) can be found.
+_sc = sys.modules.get("symphonic_cipher")
+if _sc is not None and getattr(_sc, "_VARIANT", None) != "src":
+    # Purge root variant and all its sub-modules
+    for key in list(sys.modules):
+        if key == "symphonic_cipher" or key.startswith("symphonic_cipher."):
+            del sys.modules[key]
 
 import numpy as np
 import pytest


### PR DESCRIPTION
## Summary
- **Fixes pytest collection failures** caused by dual `symphonic_cipher` packages (root vs `src/`) and `spiral-word-app/governance.py` shadowing `src/governance/`
- Swaps `sys.path` insertion order in `conftest.py` so `src/` takes priority over repo root
- Force-loads the `src/` variant of `symphonic_cipher` at conftest startup, preventing the root (exponential-cost) variant from being cached during collection
- Adds `qc_lattice` to the `_SRC_ONLY_SUBPACKAGES` bridge list
- Makes `test_code_scanning_batch3.py`'s `_load_module` properly isolate temporary path/module changes
- Adds variant-aware cleanup in `test_negative_tongue_lattice.py`

**Before:** 4 collection errors (`test_negative_tongue_lattice`, `test_potato_head`, `test_quasicrystal_lattice`, `test_trinary_negabinary`) + 4 assertion failures in `test_aethermoore` from wrong math variant

**After:** 0 collection errors across 5591 tests, all targeted tests pass

Resolves #825 (Daily Review pytest failure + coherence drop)

## Test plan
- [x] `pytest tests/ --collect-only` — 5591 tests collected, 0 errors
- [x] All 4 previously-failing files pass together with `test_code_scanning_batch3`
- [x] `npm test` — 5957 TS tests pass (no regression)
- [x] `test_aethermoore.py` — 48 tests pass (fixed by correct variant loading)
- [x] Homebrew quick tests pass with full collection

https://claude.ai/code/session_01RCp4drb4oaj6wS4GMeuE5Y