### PR TITLE
fix(tests): make httpx imports lazy to prevent pytest collection crashes

### DIFF
--- a/src/browser/toolkit.py
+++ b/src/browser/toolkit.py
@@ -40,7 +40,10 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set
 from urllib.parse import quote_plus, urljoin, urlparse
 
-import httpx
+try:
+    import httpx
+except ModuleNotFoundError:  # optional runtime dep
+    httpx = None  # type: ignore[assignment]
 
 logger = logging.getLogger("browser-toolkit")
 

--- a/src/fleet/connector_bridge.py
+++ b/src/fleet/connector_bridge.py
@@ -17,7 +17,10 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-import httpx
+try:
+    import httpx
+except ModuleNotFoundError:  # optional runtime dep
+    httpx = None  # type: ignore[assignment]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 NOTEBOOKLM_SCRIPT = REPO_ROOT / "scripts" / "system" / "notebooklm_connector.py"

--- a/src/symphonic_cipher/scbe_aethermoore/concept_blocks/web_agent/publishers.py
+++ b/src/symphonic_cipher/scbe_aethermoore/concept_blocks/web_agent/publishers.py
@@ -29,7 +29,10 @@ import uuid
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
-import httpx
+try:
+    import httpx
+except ModuleNotFoundError:  # optional runtime dep
+    httpx = None  # type: ignore[assignment]
 
 from .buffer_integration import (
     Platform,


### PR DESCRIPTION
## Summary
- Made `import httpx` lazy (try/except) in 3 source files that caused pytest collection to crash when httpx is not installed
- Same pattern as #859 — bare optional dependency imports crashing test collection
- Files fixed: `publishers.py`, `toolkit.py`, `connector_bridge.py`

## Test plan
- [x] `tests/test_homebrew_quick.py` — 23 passed, 0 failures
- [x] Test collection succeeds without httpx installed
- [ ] CI full test suite

Closes #825

https://claude.ai/code/session_01NutS4LU1gKz7KXBYVNLaB1