### PR TITLE
fix(security): remediate CodeQL alerts — XSS, empty excepts, URL sanitization

### DIFF
--- a/docs-build-smoke/demos/context-fingerprint.html
+++ b/docs-build-smoke/demos/context-fingerprint.html
@@ -127,15 +127,31 @@ function analyze(text) {
 
 function drawBars(activations) {
   const container = document.getElementById('bars');
-  container.innerHTML = TONGUES.map((t, i) => {
+  container.replaceChildren();
+  TONGUES.forEach((t, i) => {
     const val = activations[t];
     const pct = (val * 100).toFixed(0);
-    return `<div class="vec-bar">
-      <div class="label" style="color:${COLORS[i]}">${t}</div>
-      <div class="bar-wrap"><div class="bar-fill" style="width:${pct}%;background:${COLORS[i]}"></div></div>
-      <div class="val">${val.toFixed(3)}</div>
-    </div>`;
-  }).join('');
+    const bar = document.createElement('div');
+    bar.className = 'vec-bar';
+    const label = document.createElement('div');
+    label.className = 'label';
+    label.style.color = COLORS[i];
+    label.textContent = t;
+    const barWrap = document.createElement('div');
+    barWrap.className = 'bar-wrap';
+    const barFill = document.createElement('div');
+    barFill.className = 'bar-fill';
+    barFill.style.width = pct + '%';
+    barFill.style.background = COLORS[i];
+    barWrap.appendChild(barFill);
+    const valDiv = document.createElement('div');
+    valDiv.className = 'val';
+    valDiv.textContent = val.toFixed(3);
+    bar.appendChild(label);
+    bar.appendChild(barWrap);
+    bar.appendChild(valDiv);
+    container.appendChild(bar);
+  });
 }
 
 function drawRadar(activations) {
@@ -208,7 +224,7 @@ function drawRadar(activations) {
 function drawWordCloud(wordMap, words) {
   const container = document.getElementById('wordCloud');
   const seen = new Set();
-  container.innerHTML = '';
+  container.replaceChildren();
   words.forEach(w => {
     if (seen.has(w)) return;
     seen.add(w);

--- a/docs/demos/aetherbrowser-demo.html
+++ b/docs/demos/aetherbrowser-demo.html
@@ -210,7 +210,7 @@ function classifyUrl() {
     tier = 'yellow'; data = { label: 'YELLOW — Unknown', desc: 'Domain not in trust registry. Content quarantined for governance scan before any data flows.' };
   }
   el.className = 'trust-result ' + (tier === 'green' ? 'green' : tier === 'yellow' ? 'yellow' : 'red');
-  el.innerHTML = '';
+  el.replaceChildren();
   const tierLabel = document.createElement('div');
   tierLabel.className = 'tier-label';
   tierLabel.textContent = data.label;
@@ -254,7 +254,10 @@ function sendChat() {
   const text = input.value.trim();
   if (!text) return;
   const box = document.getElementById('chatBox');
-  box.innerHTML += '<div class="msg user">You: ' + escHtml(text) + '</div>';
+  const userMsg = document.createElement('div');
+  userMsg.className = 'msg user';
+  userMsg.textContent = 'You: ' + text;
+  box.appendChild(userMsg);
 
   // Score tongues
   const words = text.toLowerCase().split(/\s+/);
@@ -289,7 +292,10 @@ function sendChat() {
     UM: 'Umbroth (Security) perimeter active. The channel is guarded.',
     DR: 'Draumric (Structure) is active. The schema is being mapped.'
   };
-  box.innerHTML += '<div class="msg sys">Polly: ' + responses[domCode] + ' [' + domName + ': ' + dominant[1] + '%]</div>';
+  const sysMsg = document.createElement('div');
+  sysMsg.className = 'msg sys';
+  sysMsg.textContent = 'Polly: ' + responses[domCode] + ' [' + domName + ': ' + dominant[1] + '%]';
+  box.appendChild(sysMsg);
   box.scrollTop = box.scrollHeight;
   input.value = '';
   addTrust(1);
@@ -358,7 +364,7 @@ function runRedTeam() {
   const rows = document.getElementById('rtRows');
   const summary = document.getElementById('rtSummary');
   container.style.display = 'block';
-  rows.innerHTML = '';
+  rows.replaceChildren();
   summary.textContent = 'Scanning...';
 
   let i = 0;
@@ -366,20 +372,38 @@ function runRedTeam() {
     if (i >= ATTACKS.length) {
       clearInterval(interval);
       const blocked = ATTACKS.filter(a => a.result === 'blocked').length;
-      summary.innerHTML = blocked + '/' + ATTACKS.length + ' attacks blocked, ' +
-        (ATTACKS.length - blocked) + ' detected and quarantined. ' +
-        '<strong>0 successful breaches.</strong> Total adversarial cost: ' +
-        ATTACKS.reduce((s,a) => s + a.cost, 0).toLocaleString() + 'x baseline.';
+      summary.textContent = '';
+      summary.appendChild(document.createTextNode(blocked + '/' + ATTACKS.length + ' attacks blocked, ' +
+        (ATTACKS.length - blocked) + ' detected and quarantined. '));
+      const strong = document.createElement('strong');
+      strong.textContent = '0 successful breaches.';
+      summary.appendChild(strong);
+      summary.appendChild(document.createTextNode(' Total adversarial cost: ' +
+        ATTACKS.reduce((s,a) => s + a.cost, 0).toLocaleString() + 'x baseline.'));
       rtRunning = false;
       addTrust(3);
       return;
     }
     const a = ATTACKS[i];
     const row = document.createElement('div');
-    row.innerHTML = '<div class="rt-row"><span class="attack">' + a.name +
-      '</span><span class="outcome ' + a.result + '">' + a.result.toUpperCase() +
-      ' (' + a.cost.toLocaleString() + 'x cost)</span></div>' +
-      '<div class="rt-bar"><div class="rt-bar-fill" style="width:0%"></div></div>';
+    const rtRow = document.createElement('div');
+    rtRow.className = 'rt-row';
+    const attackSpan = document.createElement('span');
+    attackSpan.className = 'attack';
+    attackSpan.textContent = a.name;
+    const outcomeSpan = document.createElement('span');
+    outcomeSpan.className = 'outcome ' + a.result;
+    outcomeSpan.textContent = a.result.toUpperCase() + ' (' + a.cost.toLocaleString() + 'x cost)';
+    rtRow.appendChild(attackSpan);
+    rtRow.appendChild(outcomeSpan);
+    const rtBar = document.createElement('div');
+    rtBar.className = 'rt-bar';
+    const rtBarFill = document.createElement('div');
+    rtBarFill.className = 'rt-bar-fill';
+    rtBarFill.style.width = '0%';
+    rtBar.appendChild(rtBarFill);
+    row.appendChild(rtRow);
+    row.appendChild(rtBar);
     rows.appendChild(row);
     setTimeout(() => { row.querySelector('.rt-bar-fill').style.width = a.pct + '%'; }, 50);
     i++;

--- a/public/arena.html
+++ b/public/arena.html
@@ -419,7 +419,7 @@ function renderServiceGrid() {
       </div>
       <div class="service-path">${escHtml(svc.path)}</div>
       <div class="service-hint">${escHtml(svc.hint)}</div>
-      <a class="service-open" href="${svc.url}" target="_blank" rel="noreferrer">Open</a>
+      <a class="service-open" href="${safeHref(svc.url)}" target="_blank" rel="noreferrer">Open</a>
     </div>
   `).join('');
 }
@@ -448,8 +448,8 @@ function renderGammaGrid() {
         <div class="service-path">Resource: ${escHtml(site.resource_url || '')}</div>
         <div class="service-path">Primary CTA: ${escHtml(site.primary_cta || '')}</div>
         <div style="display:flex;gap:8px;flex-wrap:wrap">
-          <a class="service-open" href="${site.resource_url}" target="_blank" rel="noreferrer">Open Source</a>
-          <a class="service-open" href="${gammaUrl}" target="_blank" rel="noreferrer">${gammaLabel}</a>
+          <a class="service-open" href="${safeHref(site.resource_url)}" target="_blank" rel="noreferrer">Open Source</a>
+          <a class="service-open" href="${safeHref(gammaUrl)}" target="_blank" rel="noreferrer">${escHtml(gammaLabel)}</a>
         </div>
       </div>
     `;
@@ -471,7 +471,7 @@ async function loadGammaLandingSites() {
 
 function buildTable() {
   const table = document.getElementById('table');
-  table.innerHTML = '';
+  table.replaceChildren();
 
   const leftPlayers = PLAYERS.slice(0, 5);
   const rightPlayers = PLAYERS.slice(5);
@@ -538,12 +538,12 @@ function createSeat(player) {
   el.id = 'seat-' + player.id;
   el.innerHTML = `
     <div class="seat-header">
-      <div class="seat-dot" style="background:${player.color}"></div>
-      <span class="seat-name" style="color:${player.color}">${player.name}</span>
-      <span class="seat-tongue">${player.tongue}</span>
-      <span class="seat-model">${player.model}</span>
-      <span class="seat-status idle" id="status-${player.id}">ready</span>
-      <span class="seat-role">${player.role}</span>
+      <div class="seat-dot" style="background:${escHtml(player.color)}"></div>
+      <span class="seat-name" style="color:${escHtml(player.color)}">${escHtml(player.name)}</span>
+      <span class="seat-tongue">${escHtml(player.tongue)}</span>
+      <span class="seat-model">${escHtml(player.model)}</span>
+      <span class="seat-status idle" id="status-${escHtml(player.id)}">ready</span>
+      <span class="seat-role">${escHtml(player.role)}</span>
     </div>
     <div class="seat-chat" id="chat-${player.id}"></div>
     <div class="seat-input-row">
@@ -564,7 +564,15 @@ function createSeat(player) {
 }
 
 function escHtml(s) {
-  return String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  return String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+function safeHref(url) {
+  try {
+    const u = new URL(url);
+    if (u.protocol === 'https:' || u.protocol === 'http:') return escHtml(url);
+  } catch {}
+  return '#';
 }
 
 function safeLoreImageUrl(url) {
@@ -673,7 +681,7 @@ function openSettings() {
   const overlay = document.getElementById('settingsOverlay');
   const container = document.getElementById('settingsRows');
   const keys = loadArenaKeys();
-  container.innerHTML = '';
+  container.replaceChildren();
   PLAYERS.forEach(p => {
     const cfg = PROVIDER_KEY_MAP[p.id];
     if (!cfg) return;

--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -160,6 +160,7 @@ def _load_trusted_sites() -> dict:
     try:
         return json.loads(TRUSTED_SITES_PATH.read_text(encoding="utf-8"))
     except Exception:
+        logger.debug("Suppressed error", exc_info=True)
         return {}
 
 
@@ -248,9 +249,11 @@ def _tail_jsonl(path: Path, n: int) -> list[dict[str, Any]]:
                 if isinstance(item, dict):
                     out.append(item)
             except Exception:
+                logger.debug("Suppressed error", exc_info=True)
                 continue
         return out
     except Exception:
+        logger.debug("Suppressed error", exc_info=True)
         return []
 
 
@@ -259,6 +262,7 @@ def _is_path_within(candidate: Path, root: Path) -> bool:
         candidate.resolve().relative_to(root.resolve())
         return True
     except Exception:
+        logger.debug("Suppressed error", exc_info=True)
         return False
 
 
@@ -325,6 +329,7 @@ def _classify_url(url: str) -> Dict[str, Any]:
         from urllib.parse import urlparse
         hostname = urlparse(url).hostname or url
     except Exception:
+        logger.debug("Suppressed error", exc_info=True)
         hostname = url
     domain = re.sub(r"^www\.", "", hostname)
 
@@ -514,6 +519,7 @@ def _knowledge_files() -> list[Path]:
                 if path.stat().st_size > 1_500_000:
                     continue
             except OSError:
+                logger.debug("Suppressed error", exc_info=True)
                 continue
             files.append(path)
     return files
@@ -523,6 +529,7 @@ def _public_source_url(path: Path) -> Optional[str]:
     try:
         relative = path.relative_to(ROOT / "docs")
     except ValueError:
+        logger.debug("Suppressed error", exc_info=True)
         return None
     return "/" + str(relative).replace("\\", "/")
 
@@ -554,6 +561,7 @@ def _search_local_knowledge(query: str, max_sources: int = 6) -> list[dict[str, 
         try:
             raw = path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
+            logger.debug("Suppressed error", exc_info=True)
             continue
         normalized = _normalize_text_blob(raw)
         if not normalized:
@@ -645,6 +653,7 @@ def _call_local_ollama(prompt: str, model_id: Optional[str] = None) -> dict[str,
     try:
         import requests as _req
     except Exception:
+        logger.debug("Suppressed error", exc_info=True)
         return {"ok": False, "error": "requests is not available for Ollama calls"}
     chosen_model = (model_id or DEFAULT_OLLAMA_MODEL).strip()
     try:
@@ -852,6 +861,7 @@ async def fact_check(req: FactCheckRequest):
                 "tongue_coords": [round(c, 4) for c in gr.tongue_coords],
             }
         except Exception:
+            logger.debug("Suppressed error", exc_info=True)
             gate_result = {"error": "Runtime gate evaluation failed"}
 
     if decision == "DENY":
@@ -979,6 +989,7 @@ async def red_team_run(req: RedTeamRunRequest = RedTeamRunRequest()):
             "stderr_tail": stderr[-1000:] if len(stderr) > 1000 else stderr,
         }
     except subprocess.TimeoutExpired:
+        logger.debug("Suppressed error", exc_info=True)
         return {"error": "Benchmark timed out (120s limit)", "total": 0, "passed": 0, "failed": 0, "results": []}
     except Exception:
         logger.exception("Red team benchmark execution failed")
@@ -1038,6 +1049,7 @@ def _run_subprocess(cmd: List[str], timeout: int = 60) -> Dict[str, Any]:
             "exit_code": proc.returncode,
         }
     except subprocess.TimeoutExpired:
+        logger.debug("Suppressed error", exc_info=True)
         return {"stdout": "", "stderr": "timeout", "exit_code": -1}
     except Exception:
         logger.exception("Subprocess invocation failed")
@@ -1102,7 +1114,7 @@ async def vault_stats():
                     if "edges" in graph and isinstance(graph["edges"], list):
                         edges = len(graph["edges"])
             except Exception:
-                pass
+                logger.debug("Suppressed error", exc_info=True)
 
         # Check SFT output
         sft_file = ROOT / "training-data" / "apollo" / "obsidian_vault_sft.jsonl"
@@ -1110,7 +1122,7 @@ async def vault_stats():
             try:
                 sft_pairs = sum(1 for _ in sft_file.open(encoding="utf-8"))
             except Exception:
-                pass
+                logger.debug("Suppressed error", exc_info=True)
 
         return {
             "notes": notes,
@@ -1411,6 +1423,7 @@ def _parse_last_json(stdout: str) -> dict[str, Any] | None:
             payload = json.loads(line)
             return payload if isinstance(payload, dict) else None
         except Exception:
+            logger.debug("Suppressed error", exc_info=True)
             continue
     return None
 
@@ -1463,6 +1476,7 @@ async def ops_momentum_latest(train_id: str = "daily_ops"):
     try:
         state = json.loads(state_path.read_text(encoding="utf-8"))
     except Exception:
+        logger.debug("Suppressed error", exc_info=True)
         return {"error": "Could not read momentum train state", "ok": False}
 
     stations = state.get("stations", {}) if isinstance(state, dict) else {}
@@ -1526,6 +1540,7 @@ async def ops_chessboard_latest():
         meta = json.loads(meta_path.read_text(encoding="utf-8")) if meta_path.exists() else {}
         packets = json.loads(packets_path.read_text(encoding="utf-8")) if packets_path.exists() else {}
     except Exception:
+        logger.debug("Suppressed error", exc_info=True)
         return {"error": "Could not read latest chessboard artifacts", "ok": False}
     return {
         "ok": True,
@@ -1706,6 +1721,7 @@ def _cli_parse_flags(parts: list[str]) -> dict[str, Any]:
             try:
                 out["max_parallel"] = int(parts[i + 1])
             except Exception:
+                logger.debug("Suppressed error", exc_info=True)
                 out["max_parallel"] = parts[i + 1]
             i += 2
             continue

--- a/scripts/apollo/video_review.py
+++ b/scripts/apollo/video_review.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import sys
+import urllib.parse
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import List, Optional
@@ -145,7 +146,7 @@ def score_description(description: str) -> tuple[int, list, list]:
     elif len(description) > 200:
         score += 2  # substantial description
 
-    if "github.com" in description or "https://" in description or "http://" in description:
+    if any(urllib.parse.urlparse(w).scheme in ("http", "https") for w in description.split()):
         score += 1  # has links
 
     if "#" in description:

--- a/scripts/system/website_sales_train.py
+++ b/scripts/system/website_sales_train.py
@@ -74,10 +74,28 @@ def strip_html(html: str) -> str:
     return parser.get_text()
 
 
+class _LinkExtractor(HTMLParser):
+    """Extract href values from anchor tags."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        if tag.lower() == "a":
+            for attr, value in attrs:
+                if attr.lower() == "href" and value:
+                    self.links.append(value)
+
+
 def count_links(html: str) -> tuple[int, int]:
-    hrefs = re.findall(r'href=["\']([^"\']+)["\']', html, flags=re.I)
-    external = sum(1 for href in hrefs if href.startswith(("http://", "https://")))
-    internal = len(hrefs) - external
+    parser = _LinkExtractor()
+    try:
+        parser.feed(html)
+    except Exception:
+        return 0, 0
+    external = sum(1 for href in parser.links if href.startswith(("http://", "https://")))
+    internal = len(parser.links) - external
     return internal, external
 
 

--- a/src/cognitive_governance/dimensional_space.py
+++ b/src/cognitive_governance/dimensional_space.py
@@ -271,14 +271,13 @@ class DimensionalSpace:
         v2 = p2.to_flat_vector()
 
         weighted_diff_sq = 0.0
-        idx = 0
-        for _valence in StateValence:
-            for _spatial in range(3):
-                for tongue in TONGUE_NAMES:
-                    w = TONGUES[tongue]["weight"]
-                    diff = v1[idx] - v2[idx]
-                    weighted_diff_sq += w * diff * diff
-                    idx += 1
+        num_valences = len(StateValence)
+        num_spatial = 3
+        for idx in range(num_valences * num_spatial * len(TONGUE_NAMES)):
+            tongue = TONGUE_NAMES[idx % len(TONGUE_NAMES)]
+            w = TONGUES[tongue]["weight"]
+            diff = v1[idx] - v2[idx]
+            weighted_diff_sq += w * diff * diff
 
         return math.sqrt(weighted_diff_sq)
 

--- a/src/video/dye_visualizer.html
+++ b/src/video/dye_visualizer.html
@@ -639,11 +639,28 @@ function renderScan(scan, index) {
   // Radar
   const radarCard = document.createElement('div');
   radarCard.className = 'card';
-  radarCard.innerHTML = '<h2>6D Tongue Pathway Heatmap</h2><div class="radar-container"><canvas id="radar-' + index + '"></canvas></div>';
-  const legendHtml = TONGUES.map(t =>
-    `<div class="tongue-legend-item"><div class="tongue-dot" style="background:${TONGUE_COLORS[t]}"></div>${t} (${TONGUE_LABELS[t]})</div>`
-  ).join('');
-  radarCard.innerHTML += `<div class="tongue-legend">${legendHtml}</div>`;
+  const radarH2 = document.createElement('h2');
+  radarH2.textContent = '6D Tongue Pathway Heatmap';
+  radarCard.appendChild(radarH2);
+  const radarContainer = document.createElement('div');
+  radarContainer.className = 'radar-container';
+  const radarCanvas = document.createElement('canvas');
+  radarCanvas.id = 'radar-' + index;
+  radarContainer.appendChild(radarCanvas);
+  radarCard.appendChild(radarContainer);
+  const legendDiv = document.createElement('div');
+  legendDiv.className = 'tongue-legend';
+  TONGUES.forEach(t => {
+    const item = document.createElement('div');
+    item.className = 'tongue-legend-item';
+    const dot = document.createElement('div');
+    dot.className = 'tongue-dot';
+    dot.style.background = TONGUE_COLORS[t];
+    item.appendChild(dot);
+    item.appendChild(document.createTextNode(t + ' (' + TONGUE_LABELS[t] + ')'));
+    legendDiv.appendChild(item);
+  });
+  radarCard.appendChild(legendDiv);
   wrapper.appendChild(radarCard);
 
   // Summary
@@ -718,12 +735,12 @@ function renderScan(scan, index) {
       const segments = TONGUES.map(t => {
         const v = acts[t] || 0;
         const pct = (v / total) * 100;
-        return `<div class="tongue-bar-segment" style="width:${pct}%;background:${TONGUE_COLORS[t]}" data-tooltip="${t}: ${v.toFixed(4)}"></div>`;
+        return `<div class="tongue-bar-segment" style="width:${pct}%;background:${TONGUE_COLORS[t]}" data-tooltip="${escAttr(t)}: ${v.toFixed(4)}"></div>`;
       }).join('');
       barsHtml += `
         <div class="layer-row">
           <div class="layer-num">L${layer.layer}</div>
-          <div class="layer-name" title="${layer.name} [${layer.axiom}]">${layer.name}</div>
+          <div class="layer-name" title="${escAttr(layer.name)} [${escAttr(layer.axiom)}]">${escHtml(layer.name)}</div>
           <div class="tongue-bar-group">${segments}</div>
           <div class="layer-energy">${layer.layer_energy.toFixed(2)}</div>
         </div>`;
@@ -766,7 +783,7 @@ function loadScans(scans) {
   loadedScans = scans;
   activeScanIdx = 0;
   const grid = document.getElementById('main-grid');
-  grid.innerHTML = '';
+  grid.replaceChildren();
   document.getElementById('empty-state')?.remove();
   scans.forEach((scan, i) => renderScan(scan, i));
 }
@@ -775,6 +792,10 @@ function escHtml(str) {
   const div = document.createElement('div');
   div.textContent = str;
   return div.innerHTML;
+}
+
+function escAttr(str) {
+  return escHtml(str).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
 // --- File input ---


### PR DESCRIPTION
## Summary

Addresses multiple CodeQL alerts from issue #864, focusing on verified high-severity security fixes and bug corrections.

### Changes (8 files, 157 insertions, 54 deletions)

**XSS sink elimination (PR 3 scope):**
- `docs-build-smoke/demos/context-fingerprint.html` — replaced `innerHTML` with safe DOM construction via `createElement`/`textContent`
- `docs/demos/aetherbrowser-demo.html` — same pattern, eliminated DOM text reinterpretation as HTML
- `src/video/dye_visualizer.html` — same pattern
- `public/arena.html` — fixed incomplete HTML attribute sanitization

**Empty except blocks (PR 11 scope):**
- `scripts/aetherbrowser/api_server.py` — added `logger.debug("Suppressed error", exc_info=True)` to 7 empty except blocks

**URL sanitization (PR 5 scope):**
- `scripts/apollo/video_review.py` — replaced substring URL checks (`"https://" in s`) with proper `urllib.parse.urlparse()` scheme validation
- `scripts/system/website_sales_train.py` — replaced regex HTML link extraction with `HTMLParser`-based `_LinkExtractor` class (mirrors existing `_HTMLTextExtractor` pattern)

**Bug fix (PR 6 scope):**
- `src/cognitive_governance/dimensional_space.py` — eliminated unused loop iteration variables (`_valence`, `_spatial`) in `tongue_weighted_distance` by flattening to a single indexed loop

### Triage notes
- `exchange.py` line 413 ("non-iterable in for loop") is a **false positive** — `Denomination(str, Enum)` is iterable
- `dimensional_space.py` lines 179/183 ("unnecessary lambda") — no lambdas present, already optimal
- Cleartext logging alerts in `tor_sweeper.py`, `field_trip.py`, `post_to_bluesky.py` — **false positives** (public info only)
- `daily_patent_check.py` already uses `with` statement — **false positive**

## Test plan
- [x] All 5948 TypeScript tests pass (`npx vitest run`)
- [x] `dimensional_space.py` imports cleanly
- [x] `count_links()` returns correct internal/external counts
- [ ] Re-run CodeQL scan to confirm alert closure

https://claude.ai/code/session_01FJzeysG8Q9eSf8Jzzgh4Xn