### PR TITLE
fix(security,ci): XSS sinks, unused loop variable, daily review coherence (#864, #875)

### DIFF
--- a/kindle-app/www/aetherbrowser.html
+++ b/kindle-app/www/aetherbrowser.html
@@ -1539,7 +1539,8 @@ window.AetherBrowser = (function() {
     var level = result.trust_level || result.level || 'UNKNOWN';
     var domain = result.domain || '';
     var tier = result.tier || 'UNKNOWN';
-    var color = result.color || 'unknown';
+    var allowedColors = { core: 1, trusted: 1, provisional: 1, quarantine: 1, unknown: 1, blocked: 1 };
+    var color = allowedColors[String(result.color || 'unknown').toLowerCase()] ? String(result.color).toLowerCase() : 'unknown';
     var governance = result.governance_decision || 'QUARANTINE';
     var fillMap = { CORE: 100, TRUSTED: 75, PROVISIONAL: 50, QUARANTINE: 25, UNKNOWN: 10, BLOCKED: 0 };
 

--- a/public/arena.html
+++ b/public/arena.html
@@ -545,10 +545,10 @@ function createSeat(player) {
       <span class="seat-status idle" id="status-${escHtml(player.id)}">ready</span>
       <span class="seat-role">${escHtml(player.role)}</span>
     </div>
-    <div class="seat-chat" id="chat-${player.id}"></div>
+    <div class="seat-chat" id="chat-${escHtml(player.id)}"></div>
     <div class="seat-input-row">
-      <input class="seat-input" id="input-${player.id}" placeholder="Ask ${player.name}..." />
-      <button class="seat-send" onclick="askPlayer('${player.id}')">Ask</button>
+      <input class="seat-input" id="input-${escHtml(player.id)}" placeholder="Ask ${escHtml(player.name)}..." />
+      <button class="seat-send" onclick="askPlayer('${escHtml(player.id)}')">Ask</button>
     </div>
   `;
 

--- a/src/cognitive_governance/dimensional_space.py
+++ b/src/cognitive_governance/dimensional_space.py
@@ -336,7 +336,7 @@ class DimensionalSpace:
         idx = 0
         for valence in StateValence:
             for spatial in range(3):
-                for _i, tongue in enumerate(TONGUE_NAMES):
+                for tongue in TONGUE_NAMES:
                     # Use seed bytes to determine coordinate
                     byte_val = seed[idx % len(seed)] / 255.0
                     # Scale by radius and tongue weight


### PR DESCRIPTION
## Summary

**Security fixes (from #864):**
- **arena.html**: Escape `player.id` and `player.name` in `id=` attributes, `placeholder=`, and `onclick` handler to prevent XSS via attribute injection
- **aetherbrowser.html**: Allowlist-validate `color` variable before interpolating into CSS `var(--trust-<color>)` to prevent CSS injection
- **dimensional_space.py**: Remove unused `_i` from `enumerate(TONGUE_NAMES)` loop — the index was never used, only `idx` counter matters

**CI fix (from #875):**
- **daily-review.yml**: Treat "skipped" and "cancelled" step outcomes as neutral passes instead of failures. This caused coherence to score 0.25 when pytest was cancelled and lint/typecheck were skipped — all three counted as 0 even though the tools weren't actually failing.

## Test plan

- [x] All 5957 vitest tests pass (0 failures)
- [x] TypeScript typecheck clean (`tsc --noEmit`)
- [x] Python import of `dimensional_space` verified
- [ ] Re-run CodeQL scan to confirm alert closure
- [ ] Trigger daily review workflow to verify coherence score improves

https://claude.ai/code/session_01XvuSBVKTt5jkt949sn78eD