### PR TITLE
fix(security): redact cleartext exit IP and replace empty except blocks

### DIFF
--- a/scripts/apollo/field_trip.py
+++ b/scripts/apollo/field_trip.py
@@ -294,8 +294,9 @@ def run_field_trip(route_name: str = "standard") -> FieldTripReport:
             exit_ips.add(hop.exit_ip)
 
         gov_sym = {"ALLOW": "OK", "QUARANTINE": "Q ", "DENY": "X "}
+        redacted_ip = hop.exit_ip[:3] + "***" if hop.exit_ip else "?"
         print(f"         [{gov_sym.get(hop.governance, '??')}] {hop.title[:50]} | "
-              f"{hop.content_length}B | {hop.latency_ms}ms | exit:{hop.exit_ip[:15]}")
+              f"{hop.content_length}B | {hop.latency_ms}ms | exit:{redacted_ip}")
 
         if hop.secrets_scrubbed > 0:
             print(f"         Scrubbed {hop.secrets_scrubbed} secrets")

--- a/scripts/apollo/tor_sweeper.py
+++ b/scripts/apollo/tor_sweeper.py
@@ -76,7 +76,7 @@ def check_tor() -> dict:
         )
         result["tor_running"] = "tor" in out.stdout.lower()
     except Exception:
-        pass
+        logger.debug("Tor process check failed", exc_info=True)
 
     # Check SOCKS proxy
     try:

--- a/scripts/apollo/youtube_transcript_collector.py
+++ b/scripts/apollo/youtube_transcript_collector.py
@@ -18,11 +18,14 @@ import argparse
 import datetime
 import hashlib
 import json
+import logging
 import os
 import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT))
@@ -78,9 +81,9 @@ def search_channel_videos(channel_name: str, max_results: int = 5, handle: str |
                         videos.append({"id": parts[0], "title": parts[1]})
             return videos[:max_results]
     except FileNotFoundError:
-        pass
+        logger.debug("yt-dlp not found, falling back to manual list")
     except Exception:
-        pass
+        logger.debug("yt-dlp search failed", exc_info=True)
 
     # Manual fallback: use known video IDs if yt-dlp not available
     return []

--- a/scripts/system/helix_merge.py
+++ b/scripts/system/helix_merge.py
@@ -23,7 +23,10 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
+import logging
 from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -116,7 +119,7 @@ def auto_resolve_conflict(filepath: str) -> ConflictReport:
             if in_theirs:
                 theirs_lines += 1
     except Exception:
-        pass
+        logger.debug("Could not parse conflict markers in %s", filepath, exc_info=True)
 
     # Determine resolution strategy based on file path
     resolution = "ours"


### PR DESCRIPTION
## Summary

- **Redact Tor exit IP** in `scripts/apollo/field_trip.py` — was printing full exit IP to console, now shows only first 3 chars + `***`
- **Replace empty `except: pass` blocks** with `logger.debug()` calls in:
  - `scripts/apollo/tor_sweeper.py` (Tor process check)
  - `scripts/apollo/youtube_transcript_collector.py` (yt-dlp fallback)
  - `scripts/system/helix_merge.py` (conflict marker parsing)

Addresses PR 4 and PR 11 items from #864.

## Audit Status on #864

After investigating all P0-P2 items, many have already been remediated in prior PRs (#872, #878, #879):
- **PR 1 (api_server.py)**: All exception info exposure fixed (generic messages), path traversal fixed (`_is_path_within`), empty excepts fixed (`logger.debug`), `active_file_content_preview` already scrubbed
- **PR 2 (kindle-app XSS)**: Fixed — uses `_escHtml()` on all dynamic innerHTML content
- **PR 3 (docs/demos HTML)**: Fixed — uses safe DOM methods (`createElement`, `textContent`)
- **PR 5 (video_review.py URL)**: Already uses `urllib.parse.urlparse()`, not substring check
- **PR 6 (exchange.py)**: False positive — `Denomination` is a valid iterable `str, Enum`
- **PR 4 (cleartext logging)**: **This PR** — fixes exit IP leak and empty excepts

## Test plan

- [ ] Verify `field_trip.py` output shows redacted IPs (e.g., `12.***`)
- [ ] Verify no regressions in `tor_sweeper.py`, `helix_merge.py`, `youtube_transcript_collector.py`
- [ ] Re-run CodeQL to confirm alert closure

https://claude.ai/code/session_01T1wEi9Q9sNh1cDH1jzbnL5