### PR TITLE
fix(ci): surface deploy health check failures as warnings

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -283,7 +283,9 @@ jobs:
         run: |
           sleep 5
           echo "Testing health endpoint..."
-          curl -s "${API_URL}/v1/health" | jq . || echo "Health check pending..."
+          if ! curl -sf --max-time 15 "${API_URL}/v1/health" | jq .; then
+            echo "::warning::Production health check failed — service may still be starting"
+          fi
 
       - name: Deployment summary
         run: |

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -104,9 +104,11 @@ jobs:
             -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
           if [ -n "$EXTERNAL_IP" ]; then
             echo "External IP: $EXTERNAL_IP"
-            curl -sf "http://$EXTERNAL_IP/v1/health" \
-              && echo " - Health OK" \
-              || echo " - Health check pending (service starting)"
+            if curl -sf --max-time 15 "http://$EXTERNAL_IP/v1/health"; then
+              echo " - Health OK"
+            else
+              echo "::warning::Health check failed for $EXTERNAL_IP — service may still be starting"
+            fi
             break
           fi
           echo "  Waiting for LoadBalancer IP... ($i/30)"

--- a/src/cognitive_governance/dimensional_space.py
+++ b/src/cognitive_governance/dimensional_space.py
@@ -273,8 +273,9 @@ class DimensionalSpace:
         weighted_diff_sq = 0.0
         num_valences = len(StateValence)
         num_spatial = 3
-        for idx in range(num_valences * num_spatial * len(TONGUE_NAMES)):
-            tongue = TONGUE_NAMES[idx % len(TONGUE_NAMES)]
+        num_tongues = len(TONGUE_NAMES)
+        for idx in range(num_valences * num_spatial * num_tongues):
+            tongue = TONGUE_NAMES[idx % num_tongues]
             w = TONGUES[tongue]["weight"]
             diff = v1[idx] - v2[idx]
             weighted_diff_sq += w * diff * diff


### PR DESCRIPTION
## Summary
- **deploy-aws.yml**: Replace `|| echo "Health check pending..."` with `::warning::` annotation so production health check failures surface in GitHub Actions summary instead of being silently swallowed
- **deploy-gke.yml**: Same fix — replace `|| echo` fallback with explicit `if/else` and `::warning::` annotation
- **dimensional_space.py**: Extract `num_tongues = len(TONGUE_NAMES)` for consistency with existing `num_valences` and `num_spatial` variables, resolving CodeQL unused-variable alert

Closes the 2 genuinely risky items from #868. Verification comment posted on #864 confirming PRs 1, 5, 6, 8 are already remediated.

## Test plan
- [ ] Verify `deploy-aws.yml` syntax is valid YAML
- [ ] Verify `deploy-gke.yml` syntax is valid YAML
- [ ] Verify `dimensional_space.py` smoke test passes (`tongue_weighted_distance` returns correct values)
- [ ] Confirm CI passes

https://claude.ai/code/session_01NdyJ1dyesYM5ADJ2kBQAbR