### PR TITLE
fix(ci): fix YAML parse error — '> 0' misread as fold indicator

### DIFF
--- a/.github/workflows/ci-auto-fix.yml
+++ b/.github/workflows/ci-auto-fix.yml
@@ -104,13 +104,13 @@ jobs:
           python -m black --target-version py311 --line-length 120 src/ tests/
 
       - name: Apply npm audit fix
-        if: steps.detect.outputs.failure_count > 0
+        if: steps.detect.outputs.failure_count != '0'
         continue-on-error: true
         run: npm audit fix
 
       # -- Create PR if changes were made --
       - name: Create fix PR
-        if: steps.detect.outputs.failure_count > 0
+        if: steps.detect.outputs.failure_count != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Replace `failure_count > 0` with `failure_count != '0'` on lines 107 and 113. The `>` was being parsed as a YAML block scalar indicator, causing "An expression was expected" error at line 116.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Affected Layers

<!-- Check all that apply -->
- [ ] L1-2: Context realification
- [ ] L3-4: Weighted transform / Poincare embedding
- [ ] L5-6: Hyperbolic distance / breathing transform
- [ ] L7-8: Mobius phase / Hamiltonian CFI
- [ ] L9-10: Spectral / spin coherence
- [ ] L11-12: Temporal distance / harmonic wall
- [ ] L13-14: Risk decision / audio axis
- [ ] Infrastructure / CI / Docker

## Axiom Compliance

<!-- Which axioms does this change satisfy or affect? -->
- [ ] A1: Unitarity (norm preservation)
- [ ] A2: Locality (spatial bounds)
- [ ] A3: Causality (time-ordering)
- [ ] A4: Symmetry (gauge invariance)
- [ ] A5: Composition (pipeline integrity)
- [ ] N/A

## Test Plan

- [ ] TypeScript tests pass (`npm test`)
- [ ] Python tests pass (`python -m pytest tests/ -v`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Lint passes (`npm run lint`)

## Cross-Language Parity

- [ ] TypeScript updated
- [ ] Python updated to match
- [ ] N/A (single-language change)
