### PR TITLE
fix(ci): target master branch in all 20 workflows + fix Black config

### DIFF
--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -2,7 +2,7 @@ name: Auto-Rebase Open PRs
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
 
 permissions:
   contents: write

--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -2,7 +2,7 @@ name: Auto-Resolve Merge Conflicts
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, master ]
     paths-ignore:
       - 'CHANGELOG.md'
       - 'docs/**'
       - '*.md'
       - '.github/workflows/**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, master ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/code-prism-parity.yml
+++ b/.github/workflows/code-prism-parity.yml
@@ -2,7 +2,7 @@ name: Code Prism Parity
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, master ]
     paths:
       - "src/code_prism/**"
       - "tests/code_prism/**"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: CodeQL Analysis
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
   pull_request:
-    branches: [main]
+    branches: [main, master]
   workflow_dispatch:
   schedule:
     - cron: "22 9 * * 1"

--- a/.github/workflows/coherence-gate.yml
+++ b/.github/workflows/coherence-gate.yml
@@ -1,7 +1,7 @@
 name: Coherence Gate
 on:
   pull_request:
-    branches: [main]
+    branches: [main, master]
   workflow_dispatch:
     inputs:
       threshold:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,7 +5,7 @@ name: Copilot Setup Steps
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, master]
     paths:
       - "src/**"
       - "tests/**"

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -2,7 +2,7 @@ name: Deploy to Google Cloud Run (Free Tier)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "master" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -2,7 +2,7 @@ name: Deploy SCBE to GKE
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
     paths:
       - 'api/**'
       - 'src/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
     paths:
       - 'docs/**'
       - 'README.md'

--- a/.github/workflows/nightly-ops.yml
+++ b/.github/workflows/nightly-ops.yml
@@ -2,7 +2,7 @@ name: 'nightly-ops'
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, master]
 
 permissions:
   contents: read

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -3,7 +3,7 @@ name: Deploy GitHub Pages (Static HTML)
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "master"]
     paths:
       - 'docs/**'
       - 'public/**'

--- a/.github/workflows/pqc-python.yml
+++ b/.github/workflows/pqc-python.yml
@@ -2,7 +2,7 @@ name: PQC Python (liboqs)
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, master ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/premerge-triage.yml
+++ b/.github/workflows/premerge-triage.yml
@@ -2,7 +2,7 @@ name: Premerge Triage
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, master]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/scbe-gates.yml
+++ b/.github/workflows/scbe-gates.yml
@@ -16,7 +16,7 @@ on:
   schedule:
     - cron: '0 2 * * *'
   push:
-    branches: [ main, 'claude/**' ]
+    branches: [ main, master, 'claude/**' ]
 
 permissions:
   contents: read

--- a/.github/workflows/scbe-tests.yml
+++ b/.github/workflows/scbe-tests.yml
@@ -2,7 +2,7 @@ name: SCBE-AETHERMOORE Tests
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, master ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/scbe.yml
+++ b/.github/workflows/scbe.yml
@@ -2,7 +2,7 @@ name: "SCBE-AETHERMOORE Validation"
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, master ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -2,9 +2,9 @@ name: Security Checks
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
   pull_request:
-    branches: [main]
+    branches: [main, master]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/six-tongues-tests.yml
+++ b/.github/workflows/six-tongues-tests.yml
@@ -2,13 +2,13 @@ name: Six Tongues CLI Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, master ]
     paths:
       - '**.py'
       - 'requirements*.txt'
       - '.github/workflows/six-tongues-tests.yml'
   pull_request:
-    branches: [ main ]
+    branches: [ main, master ]
     paths:
       - '**.py'
       - 'requirements*.txt'

--- a/.github/workflows/vertex-training.yml
+++ b/.github/workflows/vertex-training.yml
@@ -18,7 +18,7 @@ on:
         default: ''
         type: string
   push:
-    branches: [main]
+    branches: [main, master]
     paths:
       - 'training/**'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,7 @@ include = [
     "storage*",
 ]
 exclude = ["tests*", "scripts*", "agents*", "training*"]
+
+[tool.black]
+line-length = 120
+target-version = ["py311", "py312", "py313"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def tmp_path():
     finally:
         shutil.rmtree(path, ignore_errors=True)
 
+
 # Compatibility alias for ai_brain package imports that may resolve through
 # legacy/broken repo symlink paths.
 try:
@@ -271,6 +272,7 @@ def performance_timer():
 # LIBOQS AVAILABILITY CHECK
 # =============================================================================
 
+
 def _liboqs_available() -> bool:
     """
     Check whether liboqs shared library appears available.
@@ -311,23 +313,17 @@ def _liboqs_available() -> bool:
 
     return any(p.exists() for p in candidates)
 
+
 LIBOQS_AVAILABLE = _liboqs_available()
 
 # Skip decorator for tests requiring liboqs
-requires_liboqs = pytest.mark.skipif(
-    not LIBOQS_AVAILABLE,
-    reason="liboqs-python not installed (optional dependency)"
-)
+requires_liboqs = pytest.mark.skipif(not LIBOQS_AVAILABLE, reason="liboqs-python not installed (optional dependency)")
 
 
 def pytest_configure(config):
     """Register custom markers."""
-    config.addinivalue_line(
-        "markers", "enterprise: Enterprise-grade tests (compliance, security)"
-    )
-    config.addinivalue_line(
-        "markers", "professional: Professional/industry standard tests"
-    )
+    config.addinivalue_line("markers", "enterprise: Enterprise-grade tests (compliance, security)")
+    config.addinivalue_line("markers", "professional: Professional/industry standard tests")
     config.addinivalue_line("markers", "homebrew: Quick developer feedback tests")
     config.addinivalue_line("markers", "api: API endpoint tests")
     config.addinivalue_line("markers", "crypto: Cryptographic tests")

--- a/tests/test_code_scanning_batch3.py
+++ b/tests/test_code_scanning_batch3.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from src.gacha_isekai import training as gacha_training
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 


### PR DESCRIPTION
## Summary

- **All 20 CI/CD workflows targeted `main` but the repo uses `master`** — meaning no CI (tests, lint, security, CodeQL, deploys) has been running on any push or PR. This PR adds `master` to the branch triggers in all 20 workflows, restoring CI coverage.
- **Add `[tool.black]` config to `pyproject.toml`** with `line-length = 120` and `target-version = ["py311", "py312", "py313"]`, matching the project convention documented in CLAUDE.md. CI's `black --check` will now automatically pick up the correct line length.
- **Reformat `tests/conftest.py` and `tests/test_code_scanning_batch3.py`** — these 2 files were failing the Black lint gate, which was blocking all 5 Dependabot PRs (#844, #847, #853, #855, #858).

### Workflows updated (20 total)

`ci.yml`, `scbe.yml`, `scbe-gates.yml`, `scbe-tests.yml`, `codeql-analysis.yml`, `security-checks.yml`, `coherence-gate.yml`, `code-prism-parity.yml`, `pqc-python.yml`, `six-tongues-tests.yml`, `deploy-cloudrun.yml`, `deploy-gke.yml`, `pages-deploy.yml`, `docs.yml`, `vertex-training.yml`, `nightly-ops.yml`, `auto-rebase-prs.yml`, `auto-resolve-conflicts.yml`, `premerge-triage.yml`, `copilot-setup-steps.yml`

## Test plan

- [x] `npm test` — 5,530 passed, 43 skipped, 0 failures
- [x] `black --check tests/conftest.py tests/test_code_scanning_batch3.py` — clean
- [x] Verified all 20 workflow files now include `master` in branch triggers
- [ ] After merge, confirm CI runs on subsequent PRs (especially Dependabot)

https://claude.ai/code/session_01BJFupcCLH2uy793JHqgDYQ