### PR TITLE
fix(ci): treat skipped/cancelled CI steps as neutral in coherence gate

### DIFF
--- a/.github/workflows/daily-review.yml
+++ b/.github/workflows/daily-review.yml
@@ -86,8 +86,15 @@ jobs:
               test_score=1
             fi
           fi
-          lint_score=0; [ "$lint_outcome" = "success" ] && lint_score=1
-          type_score=0; [ "$type_outcome" = "success" ] && type_score=1
+          # Treat skipped/cancelled checks as neutral-pass (1) rather than failure (0)
+          lint_score=0
+          if [ "$lint_outcome" = "success" ] || [ "$lint_outcome" = "skipped" ] || [ "$lint_outcome" = "cancelled" ]; then
+            lint_score=1
+          fi
+          type_score=0
+          if [ "$type_outcome" = "success" ] || [ "$type_outcome" = "skipped" ] || [ "$type_outcome" = "cancelled" ]; then
+            type_score=1
+          fi
           python scripts/coherence-check.py \
             --threshold 0.97 \
             --test-pass-rate "$test_score" \
@@ -125,7 +132,12 @@ jobs:
           echo "lint_result=$lint_result" >> "$GITHUB_OUTPUT"
           echo "typecheck_result=$typecheck_result" >> "$GITHUB_OUTPUT"
           echo "coherence_status=$coherence_status" >> "$GITHUB_OUTPUT"
-          if [ "$npm_result" != "success" ] || [ "$pytest_result" != "success" ] || \
+          # pytest cancelled/skipped is acceptable; only fail on actual test failures
+          pytest_ok="false"
+          if [ "$pytest_result" = "success" ] || [ "$pytest_result" = "skipped" ] || [ "$pytest_result" = "cancelled" ]; then
+            pytest_ok="true"
+          fi
+          if [ "$npm_result" != "success" ] || [ "$pytest_ok" != "true" ] || \
              ([ "$coherence_status" != "pass" ] && [ "$coherence_status" != "skip" ]); then
             echo "tests_failed=true" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/notion_pipeline_gap_review.py
+++ b/scripts/notion_pipeline_gap_review.py
@@ -72,6 +72,13 @@ def _safe_load_yaml(path: Path) -> Dict[str, Any]:
             if not in_fine_tune:
                 continue
 
+            # Detect indented 'streams:' key under fine_tune
+            if not in_streams and re.match(r"^\s{2,4}streams:\s*$", line):
+                data.setdefault("fine_tune", {})
+                data["fine_tune"]["streams"] = []
+                in_streams = True
+                continue
+
             if in_streams and re.match(r"^\s{2,4}streams:\s*$", line):
                 in_streams = True
                 continue


### PR DESCRIPTION
## Summary

- **Fix coherence score dropping to 0.5** when lint/typecheck steps are skipped or cancelled (#890). These outcomes are now treated as neutral-pass (1.0) instead of failure (0.0), matching how pytest was already handled.
- **Fix `tests_failed` gate** treating pytest "cancelled"/"skipped" as a failure, which incorrectly triggered issue creation.
- **Fix false-positive "missing fine_tune streams"** critical task (#891). The YAML fallback parser in `notion_pipeline_gap_review.py` couldn't detect the indented `streams:` key under `fine_tune:` because the top-level regex required column-0 start.

Closes #890, partially addresses #891 (Notion token scope issue requires manual intervention).

## Test plan

- [x] Verified coherence-check.py produces 1.0 with all-pass inputs
- [x] Verified YAML fallback parser now finds both streams (technical_system_stream + isekai_emotive_stream)
- [x] Verified gap review no longer produces false-positive "Missing fine_tune streams" task
- [x] Integration test: `run_gap_review()` returns 0 stream-related false positives

https://claude.ai/code/session_01KtXECUYUzq6VcvUupEAe4G