### PR TITLE
fix(security): resolve CodeQL loop bugs, log injection, and cleartext logging

### DIFF
--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -195,6 +195,10 @@ _SECRET_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"(?i)\b(api[_-]?key|token|secret|password)\b\s*[:=]\s*([^\s\"']{8,})"),
     # Common prefix-style keys
     re.compile(r"\bsk-[A-Za-z0-9]{16,}\b"),
+    # Hugging Face tokens
+    re.compile(r"\bhf_[A-Za-z0-9]{10,}\b"),
+    # Bearer tokens
+    re.compile(r"Bearer\s+[A-Za-z0-9._-]{20,}"),
     # Long opaque tokens (avoid grabbing normal code identifiers by requiring mixed charset + length)
     re.compile(r"\b[A-Za-z0-9_-]{40,}\b"),
 ]
@@ -1158,8 +1162,8 @@ async def vault_search(q: str = Query(..., description="Search query")):
             query_lower = q.lower()
             for md_file in vault_path.rglob("*.md"):
                 try:
-                    resolved_file = md_file.resolve(strict=False)
-                    if not _is_path_within(resolved_file, vault_path):
+                    resolved_file = md_file.resolve()
+                    if md_file.is_symlink() or not _is_path_within(resolved_file, vault_path):
                         logger.warning("Skipping vault search file outside allowed root: %s", md_file)
                         continue
                     content = md_file.read_text(encoding="utf-8", errors="ignore")
@@ -1900,7 +1904,8 @@ async def cli_job(req: CliRunRequest = CliRunRequest()):
                 "result": out,
             }
         except Exception:
-            logger.exception("CLI job failed for command: %s", raw[:40] + "..." if len(raw) > 40 else raw)
+            safe_cmd = (raw[:40] + "..." if len(raw) > 40 else raw).replace("\n", " ").replace("\r", " ")
+            logger.exception("CLI job failed for command: %s", safe_cmd)
             _append_jsonl(
                 IDE_CLI_LOG,
                 {

--- a/scripts/apollo/tor_sweeper.py
+++ b/scripts/apollo/tor_sweeper.py
@@ -246,7 +246,7 @@ def sweep(tier: Optional[str] = None) -> List[dict]:
             if clearnet and clearnet != "none" and clearnet != "none (onion-only)":
                 # Fetch clearnet version through Tor for anonymity
                 url = f"https://{clearnet}"
-                logger.debug("Fetching %s via %s", site["name"], url)
+                logger.debug("Fetching %s via Tor", site["name"])
                 print(f"    Fetching {site['name']}...", end=" ")
                 result = sandboxed_fetch(url)
                 result["site_name"] = site["name"]

--- a/src/cognitive_governance/dimensional_space.py
+++ b/src/cognitive_governance/dimensional_space.py
@@ -272,14 +272,14 @@ class DimensionalSpace:
 
         weighted_diff_sq = 0.0
         num_tongues = len(TONGUE_NAMES)
+        total_blocks = len(StateValence) * 3  # valence x spatial components
         idx = 0
-        for _val in range(len(StateValence)):
-            for _sp in range(3):
-                for t_idx in range(num_tongues):
-                    w = TONGUES[TONGUE_NAMES[t_idx]]["weight"]
-                    diff = v1[idx] - v2[idx]
-                    weighted_diff_sq += w * diff * diff
-                    idx += 1
+        for _ in range(total_blocks):
+            for t_idx in range(num_tongues):
+                w = TONGUES[TONGUE_NAMES[t_idx]]["weight"]
+                diff = v1[idx] - v2[idx]
+                weighted_diff_sq += w * diff * diff
+                idx += 1
 
         return math.sqrt(weighted_diff_sq)
 

--- a/src/symphonic_cipher/scbe_aethermoore/concept_blocks/context_credit_ledger/exchange.py
+++ b/src/symphonic_cipher/scbe_aethermoore/concept_blocks/context_credit_ledger/exchange.py
@@ -412,8 +412,8 @@ class ComputeExchange:
             "total_volume_settled": round(total_volume, 6),
             "exchange_rates": {
                 f"{d1.value}/{d2.value}": round(DENOMINATION_WEIGHTS[d1] / DENOMINATION_WEIGHTS[d2], 4)
-                for d1 in list(Denomination)
-                for d2 in list(Denomination)
+                for d1 in Denomination
+                for d2 in Denomination
                 if d1 != d2 and d1.value < d2.value
             },
         }


### PR DESCRIPTION
## Summary

Addresses P0 code bugs and P1 security logging issues from #895 security triage.

- **Fix unused loop iteration variable** in `dimensional_space.py:275` — collapsed two nested loops with unused vars (`_val`, `_sp`) into a single loop over `total_blocks`, resolving the CodeQL "suspicious unused loop iteration variable" error
- **Fix redundant `list()` on Enum** in `exchange.py:415` — removed unnecessary `list(Denomination)` calls since `Denomination` is already iterable as a `str, Enum`, resolving the CodeQL "non-iterable used in for loop" alert
- **Add HF token + Bearer token patterns** to `_SECRET_PATTERNS` in `api_server.py` — strengthens the `_scrub_text()` secret redaction to catch `hf_*` and `Bearer` tokens before they hit JSONL logs
- **Sanitize newlines in CLI command logging** in `api_server.py:1903` — prevents log injection via `\n`/`\r` in user-supplied command strings
- **Skip symlinks in vault search** in `api_server.py:1165` — mitigates symlink-based path traversal in `/api/vault/search`
- **Remove URL from Tor sweeper debug logs** in `tor_sweeper.py:249` — prevents leaking sensitive query parameters

## Test plan

- [x] All changed Python files pass `ast.parse()` syntax verification
- [ ] CI pipeline (vitest + pytest) passes
- [ ] CodeQL re-scan confirms the 2 error-level alerts are resolved
- [ ] Verify coherence gate no longer blocked by these code errors

Closes the P0 code bugs and several P1 items from #895.

https://claude.ai/code/session_01QBqarT7pPAwM4d2nc8k9N3