### PR TITLE
fix(lint): resolve 107 flake8 violations across hydra/, src/, tests/

### DIFF
--- a/hydra/__init__.py
+++ b/hydra/__init__.py
@@ -20,8 +20,8 @@ import importlib as _importlib
 # Eager imports — core modules only (sqlite, dataclasses, stdlib)
 # ═══════════════════════════════════════════════════════════
 
-from .ledger import Ledger, LedgerEntry, EntryType
-from .switchboard import Switchboard
+from .ledger import Ledger, LedgerEntry, EntryType  # noqa: F401
+from .switchboard import Switchboard  # noqa: F401
 
 # ═══════════════════════════════════════════════════════════
 # Lazy imports — heavy modules (browsers, LLM providers, websockets)

--- a/hydra/branch_orchestrator.py
+++ b/hydra/branch_orchestrator.py
@@ -10,7 +10,7 @@ import importlib.util
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 
 GRAPH_NAMES = ("research_pipeline", "content_publisher", "training_funnel")
 

--- a/hydra/browsers.py
+++ b/hydra/browsers.py
@@ -229,7 +229,7 @@ class CDPBackend(BrowserBackend):
             raise RuntimeError("No page target found on CDP endpoint")
 
         ws_url = page_targets[0]["webSocketDebuggerUrl"]
-        import websockets
+        import websockets  # noqa: F811
 
         self._ws = await websockets.connect(ws_url, max_size=10 * 1024 * 1024)
 

--- a/hydra/canvas.py
+++ b/hydra/canvas.py
@@ -46,26 +46,15 @@ Usage:
 
 from __future__ import annotations
 
-import copy
 import hashlib
-import json
-import os
 import time
-import uuid
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from enum import Enum
-from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set
 
 try:
     from hydra.color_dimension import (
-        ColorChannel,
         SpectrumAllocator,
-        channel_for_provider,
-        channel_for_task,
-        sort_by_disorganized_order,
-        MultiColorTag,
-        BAND_CENTERS,
         ColorBand,
     )
 
@@ -286,7 +275,10 @@ def recipe_article(topic: str = "AI safety", target_length: int = 2000) -> List[
             assigned_color=ModelColor.VIOLET,
             depends_on=["research", "arxiv_scan"],
             params={
-                "instruction": f"Create a detailed outline for a {target_length}-word article on '{topic}'. Use the research findings."
+                "instruction": (
+                    f"Create a detailed outline for a {target_length}-word article on"
+                    f" '{topic}'. Use the research findings."
+                )
             },
         ),
         CanvasStep(
@@ -354,7 +346,7 @@ def recipe_article(topic: str = "AI safety", target_length: int = 2000) -> List[
         CanvasStep(
             "remember",
             StepType.REMEMBER,
-            f"Store article in memory",
+            "Store article in memory",
             depends_on=["synthesize"],
             params={"key": f"article_{topic.replace(' ', '_')[:30]}"},
         ),
@@ -885,7 +877,7 @@ class CanvasOrchestrator:
             target = step.params.get("target", "arxiv")
             url = step.params.get("url", "")
             output = f"[browser] Navigate: {target} {url}\n"
-            output += f"  Script: scripts/system/browser_chain_dispatcher.py\n"
+            output += "  Script: scripts/system/browser_chain_dispatcher.py\n"
             artifacts["target"] = target
             artifacts["status"] = "navigated"
 
@@ -894,7 +886,7 @@ class CanvasOrchestrator:
             title = step.params.get("title", step.description)
             output = f"[obsidian] Note created: {title}\n"
             output += f"  Vault: {vault}\n"
-            output += f"  Script: scripts/system/obsidian_byproduct_note.py\n"
+            output += "  Script: scripts/system/obsidian_byproduct_note.py\n"
             artifacts["vault"] = vault
             artifacts["title"] = title
 
@@ -952,7 +944,6 @@ class CanvasOrchestrator:
         )
 
         # Build dependency graph
-        step_map: Dict[str, CanvasStep] = {s.step_id: s for s in steps}
         executed: Set[str] = set()
         max_iterations = len(steps) * (self.max_retries + 1) * self.max_roundabout_visits
         iteration = 0
@@ -1016,7 +1007,10 @@ class CanvasOrchestrator:
                     result = StepResult(
                         step_id=step.step_id,
                         status="done",
-                        output=f"Canvas merged: {len(self.canvas.sections)} strokes from {len(self.canvas.colors_used)} colors\n",
+                        output=(
+                            f"Canvas merged: {len(self.canvas.sections)} strokes"
+                            f" from {len(self.canvas.colors_used)} colors\n"
+                        ),
                         provider_used="system",
                         color="white",
                     )
@@ -1101,10 +1095,17 @@ def list_recipes() -> List[Dict[str, Any]]:
                     )
                 ),
                 "description": {
-                    "article": "Full article pipeline (14 steps): research -> draft -> edit -> expand -> fact-check -> publish",
+                    "article": (
+                        "Full article pipeline (14 steps): research -> draft -> edit"
+                        " -> expand -> fact-check -> publish"
+                    ),
                     "research": "Deep multi-source research (8 steps): arxiv + web + debate + synthesis",
-                    "content": "Multi-platform content (variable): write -> adapt per platform -> govern -> publish",
-                    "training": "Training data generation (7 steps): research -> generate pairs -> quality check -> export",
+                    "content": (
+                        "Multi-platform content (variable): write -> adapt per platform" " -> govern -> publish"
+                    ),
+                    "training": (
+                        "Training data generation (7 steps): research -> generate pairs" " -> quality check -> export"
+                    ),
                     "full_loop": "End-to-end loop: browser nav + research + writing + obsidian + cross-talk + publish",
                 }.get(name, ""),
             }

--- a/hydra/cli.py
+++ b/hydra/cli.py
@@ -23,8 +23,6 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple, Optional
 
 from .spine import HydraSpine
-from .head import HydraHead, create_claude_head
-from .limbs import BrowserLimb, TerminalLimb, APILimb, MultiTabBrowserLimb
 from .ledger import Ledger
 from .librarian import Librarian
 from .arxiv_retrieval import AI2AIRetrievalService, ArxivClient
@@ -646,7 +644,8 @@ def handle_arxiv(args: List[str], librarian: Librarian, as_json: bool) -> None:
             return
 
         print(
-            f"\n[arxiv] packet={packet['packet_id']} returned={packet['returned_results']} total={packet['total_results']}"
+            f"\n[arxiv] packet={packet['packet_id']}"
+            f" returned={packet['returned_results']} total={packet['total_results']}"
         )
         for idx, paper in enumerate(packet.get("papers", []), start=1):
             print(f"{idx}. {paper['arxiv_id']} :: {paper['title']}")
@@ -1156,7 +1155,7 @@ def handle_branch(args: List[str], parsed_args) -> None:
         print('                 [--providers claude,gpt,gemini] [--context \'{"k":"v"}\']')
         print("                 [--no-council] [--export-n8n path] [--export-choicescript path]")
         print()
-        print(f"Available graphs: research_pipeline, content_publisher, training_funnel")
+        print("Available graphs: research_pipeline, content_publisher, training_funnel")
         print(f"Available strategies: {', '.join(list_strategies())}")
         return
 
@@ -1227,7 +1226,8 @@ def handle_branch(args: List[str], parsed_args) -> None:
         print(f"  Topic:      {options['topic'] or '(default)'}")
         print(f"  Paths:      {payload['paths_explored']}")
         print(
-            f"  Coverage:   {payload['coverage']:.0%} ({int(payload['coverage'] * payload['total_scenes'])}/{payload['total_scenes']})"
+            f"  Coverage:   {payload['coverage']:.0%}"
+            f" ({int(payload['coverage'] * payload['total_scenes'])}/{payload['total_scenes']})"
         )
         best = payload.get("best_path")
         if best:

--- a/hydra/color_dimension.py
+++ b/hydra/color_dimension.py
@@ -37,11 +37,10 @@ Flow Isolation Rules:
 
 from __future__ import annotations
 
-import hashlib
 import math
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple
 
 # Physical constants
 SPEED_OF_LIGHT_NM_THZ = 299792.458  # nm * THz (c in nm/ps = nm*THz)

--- a/hydra/consensus.py
+++ b/hydra/consensus.py
@@ -16,7 +16,6 @@ Guarantees:
 
 import asyncio
 import hashlib
-import json
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Callable
 from dataclasses import dataclass, field

--- a/hydra/head.py
+++ b/hydra/head.py
@@ -16,10 +16,9 @@ Features:
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import Dict, Any, List, Optional, Callable
+from typing import Dict, Any, List, Optional
 from dataclasses import dataclass, field
 from enum import Enum
-import hashlib
 import uuid
 
 from .llm_providers import LLMProvider, LLMResponse, create_provider, HYDRA_SYSTEM_PROMPT

--- a/hydra/ledger.py
+++ b/hydra/ledger.py
@@ -9,7 +9,7 @@ Portable, works anywhere Python runs.
 import sqlite3
 import json
 import os
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 from enum import Enum

--- a/hydra/librarian.py
+++ b/hydra/librarian.py
@@ -15,12 +15,11 @@ The Librarian manages the central ledger and provides:
 
 import json
 from datetime import datetime, timezone, timedelta
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Optional
 from dataclasses import dataclass, field
-import hashlib
 import re
 
-from .ledger import Ledger, LedgerEntry, EntryType
+from .ledger import Ledger, EntryType
 
 
 @dataclass
@@ -383,7 +382,7 @@ Recent Actions:
         for a in summary["actions"][:max_items]:
             context += f"  - {a['action']}: {a['target']} ({a['decision']})\n"
 
-        context += f"\n=== END CONTEXT ===\n"
+        context += "\n=== END CONTEXT ===\n"
 
         return context
 

--- a/hydra/limbs.py
+++ b/hydra/limbs.py
@@ -11,12 +11,10 @@ All limbs are governed by SCBE before execution.
 """
 
 import asyncio
-import subprocess
 import os
 import sys
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional, List
-from datetime import datetime, timezone
+from typing import Dict, Any, List
 import hashlib
 import json
 import uuid
@@ -39,7 +37,6 @@ class HydraLimb(ABC):
     @abstractmethod
     async def execute(self, action: str, target: str, params: Dict[str, Any]) -> Dict[str, Any]:
         """Execute an action."""
-        pass
 
     async def activate(self) -> bool:
         """Activate this limb."""

--- a/hydra/llm_providers.py
+++ b/hydra/llm_providers.py
@@ -21,10 +21,9 @@ Usage:
 """
 
 import asyncio
-import json
 import os
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 # ---------------------------------------------------------------------------
@@ -186,7 +185,7 @@ class ClaudeProvider(LLMProvider):
                 "parameter or set the ANTHROPIC_API_KEY environment variable."
             )
 
-        import anthropic
+        import anthropic  # noqa: F811
 
         self._client = anthropic.AsyncAnthropic(api_key=self._api_key)
 
@@ -276,7 +275,7 @@ class OpenAIProvider(LLMProvider):
                 "parameter or set the OPENAI_API_KEY environment variable."
             )
 
-        import openai
+        import openai  # noqa: F811
 
         kwargs: Dict[str, Any] = {"api_key": self._api_key}
         if base_url:
@@ -379,7 +378,7 @@ class GeminiProvider(LLMProvider):
                 "parameter or set the GOOGLE_API_KEY environment variable."
             )
 
-        from google import genai
+        from google import genai  # noqa: F811
 
         self._client = genai.Client(api_key=self._api_key)
 
@@ -513,7 +512,7 @@ class HuggingFaceProvider(LLMProvider):
         self.model = model
         self._api_key = api_key or os.environ.get("HF_TOKEN", "")
 
-        from huggingface_hub import InferenceClient
+        from huggingface_hub import InferenceClient  # noqa: F811
 
         kwargs: Dict[str, Any] = {"model": model}
         if self._api_key:
@@ -629,7 +628,7 @@ class LocalProvider(LLMProvider):
         self.model = model
         self._base_url = base_url
 
-        import openai
+        import openai  # noqa: F811
 
         self._client = openai.AsyncOpenAI(
             api_key=api_key,
@@ -732,7 +731,7 @@ class GrokProvider(LLMProvider):
                 "parameter or set the XAI_API_KEY environment variable."
             )
 
-        import openai
+        import openai  # noqa: F811
 
         self._client = openai.AsyncOpenAI(
             api_key=self._api_key,

--- a/hydra/octree_sphere_grid.py
+++ b/hydra/octree_sphere_grid.py
@@ -33,15 +33,13 @@ import hashlib
 import math
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np
 
-from hydra.color_dimension import ColorChannel, PHI, TONGUE_WEIGHTS
+from hydra.color_dimension import PHI, TONGUE_WEIGHTS
 from hydra.voxel_storage import (
-    Voxel,
     chladni_amplitude,
-    chladni_address,
     compute_authority_hash,
     normalize_intent,
     intent_similarity,
@@ -1464,7 +1462,7 @@ def _demo():
     print(f"  Path from slot {grid.active_slot} to slot 9: {path}")
 
     # Stats
-    print(f"\nOctree stats:")
+    print("\nOctree stats:")
     stats = tree.stats()
     for k, v in stats.items():
         print(f"  {k}: {v}")

--- a/hydra/quadtree25d.py
+++ b/hydra/quadtree25d.py
@@ -34,18 +34,14 @@ from __future__ import annotations
 
 import hashlib
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 
 from hydra.color_dimension import PHI, TONGUE_WEIGHTS
-from hydra.voxel_storage import (
-    chladni_amplitude,
-    normalize_intent,
-    intent_similarity,
-)
+from hydra.voxel_storage import chladni_amplitude
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -850,7 +846,10 @@ QUADTREE25D_INTEROP = {
         "rust": "struct QuadPoint { x: f64, y: f64, z: f64, tongue: String, authority: String }",
         "sql": "CREATE TABLE quad_points (id TEXT, x REAL, y REAL, z REAL, tongue TEXT, authority TEXT)",
         "wasm": "QuadPoint { x: f64, y: f64, z: f64 } via wasm-bindgen",
-        "html_css": "<div class='quad-point' data-x data-y data-z style='left: calc(x%); top: calc(y%); height: calc(z*scale)'></div>",
+        "html_css": (
+            "<div class='quad-point' data-x data-y data-z"
+            " style='left: calc(x%); top: calc(y%); height: calc(z*scale)'></div>"
+        ),
         "solidity": "struct QuadPoint { int256 x; int256 y; int256 z; string tongue; }",
         "go": "type QuadPoint struct { X, Y, Z float64; Tongue, Authority string }",
         "glsl": "struct QuadPoint { vec3 pos; float tongue_weight; };",
@@ -859,7 +858,10 @@ QUADTREE25D_INTEROP = {
         "python": "QuadNode(bounds, depth, children, points, z_stats)",
         "typescript": "class QuadNode { bounds: QuadBounds; children: Map<number, QuadNode>; points: QuadPoint[]; }",
         "rust": "struct QuadNode { bounds: QuadBounds, children: [Option<Box<QuadNode>>; 4], points: Vec<QuadPoint> }",
-        "sql": "CREATE TABLE quad_nodes (id TEXT, x_min REAL, y_min REAL, x_max REAL, y_max REAL, depth INT, z_min REAL, z_max REAL)",
+        "sql": (
+            "CREATE TABLE quad_nodes"
+            " (id TEXT, x_min REAL, y_min REAL, x_max REAL, y_max REAL, depth INT, z_min REAL, z_max REAL)"
+        ),
         "go": "type QuadNode struct { Bounds QuadBounds; Children [4]*QuadNode; Points []QuadPoint }",
         "glsl": "uniform sampler2D quadtree_texture; // encoded node hierarchy",
     },
@@ -944,7 +946,7 @@ def demo() -> Dict[str, Any]:
 
     # 5. Stats
     stats = qt.stats()
-    print(f"\n[4] Quadtree stats:")
+    print("\n[4] Quadtree stats:")
     print(f"    Points: {stats['point_count']}")
     print(f"    Leaves: {stats['leaf_count']}")
     print(f"    Max depth used: {stats['max_depth_used']}")
@@ -1251,9 +1253,6 @@ class AdaptiveQuadTree25D:
         Maps 2D quadrants to 3D octants with sign-based partitioning.
         z-height determines sign_z, enabling mirror operations across XY-plane.
         """
-        center_x = self.boundary.x + self.boundary.width / 2
-        center_y = self.boundary.y + self.boundary.height / 2
-
         b = self.boundary
         for p in self.points:
             # Normalize to [-1, 1]

--- a/hydra/remote_worker.py
+++ b/hydra/remote_worker.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 import socket
 import time
-from typing import Any, Dict, List
+from typing import List
 
 from .limbs import BrowserLimb
 from .switchboard import Switchboard

--- a/hydra/self_healing.py
+++ b/hydra/self_healing.py
@@ -10,10 +10,9 @@ Patterns sourced from AI Workflow Architect + SCBE governance.
 from __future__ import annotations
 
 import time
-import math
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 # ═══════════════════════════════════════════════════════════
 # Circuit Breaker

--- a/hydra/spectral.py
+++ b/hydra/spectral.py
@@ -21,7 +21,6 @@ from typing import Dict, Any, List, Optional, Tuple
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from collections import defaultdict
-import json
 
 
 @dataclass

--- a/hydra/spectral_langgraph.py
+++ b/hydra/spectral_langgraph.py
@@ -28,11 +28,8 @@ Usage:
 from __future__ import annotations
 
 import math
-import operator
 import time
-import hashlib
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import Annotated, Any, Callable, Dict, List, Optional, Set, Tuple, TypedDict
 
 import numpy as np
@@ -54,20 +51,10 @@ def _concat_lists(a: list, b: list) -> list:
 
 
 from hydra.color_dimension import (
-    BAND_CENTERS,
     ColorBand,
-    ColorChannel,
-    ColorNode,
-    MultiColorTag,
-    PHI,
-    RouteCheck,
-    RoutedFlow,
     SpectrumAllocator,
     SpectralFlowRouter,
     TONGUE_WEIGHTS,
-    channel_for_provider,
-    channel_for_task,
-    channel_for_tongue,
 )
 
 # ---------------------------------------------------------------------------
@@ -526,7 +513,9 @@ def build_article_graph(topic: str = "AI safety") -> SpectralStateGraph:
         outputs = state.get("outputs", {})
         fft = state.get("_fft_spectrum", {})
         return {
-            "output": f"Final article merged from {len(outputs)} color lanes. FFT energy: {fft.get('merged_energy', {})}"
+            "output": (
+                f"Final article merged from {len(outputs)} color lanes. FFT energy: {fft.get('merged_energy', {})}"
+            )
         }
 
     g = SpectralStateGraph(SpectralState)
@@ -573,7 +562,10 @@ def build_research_graph(topic: str = "quantum computing") -> SpectralStateGraph
         outputs = state.get("outputs", {})
         fft = state.get("_fft_spectrum", {})
         return {
-            "output": f"Synthesis from {len(outputs)} lanes. Consensus: safety gaps in deployment. FFT: {fft.get('merged_energy', {})}"
+            "output": (
+                f"Synthesis from {len(outputs)} lanes. Consensus: safety gaps in deployment."
+                f" FFT: {fft.get('merged_energy', {})}"
+            )
         }
 
     g = SpectralStateGraph(SpectralState)

--- a/hydra/spine.py
+++ b/hydra/spine.py
@@ -21,7 +21,6 @@ from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Callable, Set
 from dataclasses import dataclass, field
 from enum import Enum
-import hashlib
 import uuid
 
 # Add parent path for imports
@@ -34,7 +33,7 @@ from .switchboard import Switchboard
 # Import directly from the file to avoid triggering src.crypto.__init__.py's
 # heavy import chain (scipy, matplotlib) which hangs on Windows.
 try:
-    from src.crypto.dual_lattice import TongueLatticeGovernor, SacredTongue
+    from src.crypto.dual_lattice import TongueLatticeGovernor
 
     DUAL_LATTICE_AVAILABLE = True
 except (ImportError, Exception):
@@ -641,7 +640,7 @@ class HydraSpine:
 
             if not result.get("success", True) and result.get("decision") == "DENY":
                 workflow.status = WorkflowPhase.ERROR
-                print(f"  [BLOCKED] Phase denied by SCBE governance")
+                print("  [BLOCKED] Phase denied by SCBE governance")
                 break
 
             workflow.current_phase += 1

--- a/hydra/swarm_browser.py
+++ b/hydra/swarm_browser.py
@@ -23,8 +23,6 @@ Usage:
     await swarm.shutdown()
 """
 
-import asyncio
-import json
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -33,7 +31,7 @@ from .spine import HydraSpine
 from .limbs import MultiTabBrowserLimb
 from .ledger import Ledger
 from .librarian import Librarian
-from .consensus import RoundtableConsensus, VoteDecision
+from .consensus import RoundtableConsensus
 from .swarm_governance import (
     SwarmGovernance,
     GovernanceConfig,

--- a/hydra/swarm_governance.py
+++ b/hydra/swarm_governance.py
@@ -37,11 +37,10 @@ from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Callable, Tuple
 from dataclasses import dataclass, field
 from enum import Enum
-import uuid
 
 # Try numpy, fallback to pure Python
 try:
-    import numpy as np
+    pass
 
     HAS_NUMPY = True
 except ImportError:
@@ -1298,7 +1297,7 @@ async def simulate_swarm_attack(
     # Add malicious agents
     for i in range(num_malicious):
         pos = [random.uniform(-0.1, 0.1) for _ in range(6)]
-        agent = gov.add_agent(f"mal-{i}", AgentRole.MALICIOUS, pos, initial_coherence=0.3)
+        gov.add_agent(f"mal-{i}", AgentRole.MALICIOUS, pos, initial_coherence=0.3)
 
     # Run simulation
     history = []
@@ -1355,7 +1354,6 @@ def create_autonomous_coder(governance: SwarmGovernance, agent_id: str) -> Auton
 
 # Entry point for standalone simulation
 if __name__ == "__main__":
-    import asyncio
 
     async def main():
         print("Starting swarm attack simulation...")

--- a/hydra/switchboard.py
+++ b/hydra/switchboard.py
@@ -295,7 +295,8 @@ class Switchboard:
             by_status_rows = conn.execute("SELECT status, COUNT(*) AS c FROM tasks GROUP BY status").fetchall()
             by_role_rows = conn.execute("SELECT role, COUNT(*) AS c FROM tasks GROUP BY role").fetchall()
             leased_rows = conn.execute(
-                "SELECT task_id, role, lease_owner, lease_expires_at FROM tasks WHERE status='leased' ORDER BY updated_at DESC LIMIT 50"
+                "SELECT task_id, role, lease_owner, lease_expires_at"
+                " FROM tasks WHERE status='leased' ORDER BY updated_at DESC LIMIT 50"
             ).fetchall()
             msg_count = conn.execute("SELECT COUNT(*) AS c FROM role_messages").fetchone()
 

--- a/hydra/tenreary.py
+++ b/hydra/tenreary.py
@@ -13,7 +13,6 @@ Custom multi-step itinerary type for HYDRA that can orchestrate:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import re
@@ -613,7 +612,7 @@ class MCPTenrearyRunner:
         try:
             from PyQt5.QtWidgets import QApplication, QMessageBox  # type: ignore
 
-            app = QApplication.instance() or QApplication([])
+            QApplication.instance() or QApplication([])
             box = QMessageBox()
             box.setWindowTitle(title)
             box.setText(message)
@@ -625,7 +624,7 @@ class MCPTenrearyRunner:
         try:
             from PySide2.QtWidgets import QApplication, QMessageBox  # type: ignore
 
-            app = QApplication.instance() or QApplication([])
+            QApplication.instance() or QApplication([])
             box = QMessageBox()
             box.setWindowTitle(title)
             box.setText(message)

--- a/hydra/voxel_cli.py
+++ b/hydra/voxel_cli.py
@@ -13,13 +13,11 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import sys
 import time
 
-import numpy as np
 
-from hydra.voxel_storage import VoxelGrid, Voxel, chladni_amplitude, generate_chladni_grid
-from hydra.color_dimension import TONGUE_WAVELENGTHS, TONGUE_WEIGHTS, ColorBand
+from hydra.voxel_storage import VoxelGrid, generate_chladni_grid
+from hydra.color_dimension import TONGUE_WAVELENGTHS, TONGUE_WEIGHTS
 from hydra.octree_sphere_grid import HyperbolicLattice25D
 
 
@@ -83,7 +81,7 @@ def _build_layout(
         )
 
     now_ms = at_unix_ms or (time.time() * 1000)
-    half = window_ms / 2
+    window_ms / 2
 
     voxels_out = []
     for v in grid.voxels.values():

--- a/hydra/voxel_storage.py
+++ b/hydra/voxel_storage.py
@@ -38,12 +38,8 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import numpy as np
 
 from hydra.color_dimension import (
-    BAND_CENTERS,
-    ColorBand,
     ColorChannel,
     PHI,
-    TONGUE_WAVELENGTHS,
-    TONGUE_WEIGHTS,
 )
 
 # ---------------------------------------------------------------------------

--- a/hydra/websocket_manager.py
+++ b/hydra/websocket_manager.py
@@ -27,12 +27,10 @@ Research Validation:
 
 import asyncio
 import json
-import weakref
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Set, Callable
 from dataclasses import dataclass, field
 from enum import Enum
-import hashlib
 import uuid
 
 # Type hints for WebSocket - supports both websockets and aiohttp
@@ -51,7 +49,7 @@ try:
 except ImportError:
     AIOHTTP_AVAILABLE = False
 
-from .ledger import Ledger, LedgerEntry, EntryType
+from .ledger import LedgerEntry, EntryType
 
 
 class SubscriptionChannel(str, Enum):

--- a/src/api/compute_routes.py
+++ b/src/api/compute_routes.py
@@ -275,7 +275,7 @@ async def authorize_compute(req: WorkloadRequest):
             f"{energy_remaining:.1f}Wh remaining"
         )
     else:
-        justification = f"Denied: insufficient energy or cooling for workload"
+        justification = "Denied: insufficient energy or cooling for workload"
 
     reason = "authorized" if authorized else "denied_energy_budget"
 

--- a/tests/test_energy_budget.py
+++ b/tests/test_energy_budget.py
@@ -246,7 +246,7 @@ class TestFleetEnergyManager:
 
     def test_active_vs_quarantined(self):
         mgr = FleetEnergyManager(default_budget=10.0)
-        a1 = mgr.provision("agent-1")
+        mgr.provision("agent-1")
         a2 = mgr.provision("agent-2")
         # Quarantine agent-2
         far = [5.0] * 6


### PR DESCRIPTION
## Summary

- Removed ~70 unused imports (F401) across 22 files in `hydra/`, `src/`, and `tests/`
- Fixed 8 f-strings missing interpolation placeholders (F541) — converted to regular strings
- Removed unused variable assignments (F841) that had no side effects
- Broke 12 lines exceeding 120-character limit (E501) at logical breakpoints
- Added `noqa` annotations for intentional try/except import patterns (F811) in `llm_providers.py`, `browsers.py`, and `__init__.py` re-exports

`flake8 --max-line-length 120 src/ tests/ hydra/` now reports **0 violations** (was 107).

## Test plan

- [x] `npm run build` — TypeScript compilation clean
- [x] `npm test` — 174 test files, 5957 passed, 8 skipped
- [x] `npm run lint` — Prettier check passes
- [x] `python -m pytest tests/ -m 'not slow'` — 5548 passed, 105 skipped
- [x] `black --check src/ tests/ hydra/` — All files formatted
- [x] `flake8 --max-line-length 120 src/ tests/ hydra/` — 0 violations

https://claude.ai/code/session_016J6hXeC58jFEFeapbN4RMT