### PR TITLE
fix(codeql): resolve loop variable and non-iterable alerts

### DIFF
--- a/src/cognitive_governance/dimensional_space.py
+++ b/src/cognitive_governance/dimensional_space.py
@@ -272,13 +272,13 @@ class DimensionalSpace:
 
         weighted_diff_sq = 0.0
         idx = 0
-        for _valence in StateValence:
-            for _spatial in range(3):
-                for tongue in TONGUE_NAMES:
-                    w = TONGUES[tongue]["weight"]
-                    diff = v1[idx] - v2[idx]
-                    weighted_diff_sq += w * diff * diff
-                    idx += 1
+        # Iterate over all (valence × spatial × tongue) triples in flat vector order
+        for _ in range(len(StateValence) * 3):
+            for tongue in TONGUE_NAMES:
+                w = TONGUES[tongue]["weight"]
+                diff = v1[idx] - v2[idx]
+                weighted_diff_sq += w * diff * diff
+                idx += 1
 
         return math.sqrt(weighted_diff_sq)
 

--- a/src/symphonic_cipher/scbe_aethermoore/concept_blocks/context_credit_ledger/exchange.py
+++ b/src/symphonic_cipher/scbe_aethermoore/concept_blocks/context_credit_ledger/exchange.py
@@ -19,6 +19,7 @@ because credits represent compute receipts, not investment contracts.
 from __future__ import annotations
 
 import hashlib
+import itertools
 import time
 import uuid
 from dataclasses import dataclass
@@ -412,8 +413,6 @@ class ComputeExchange:
             "total_volume_settled": round(total_volume, 6),
             "exchange_rates": {
                 f"{d1.value}/{d2.value}": round(w1 / w2, 4)
-                for i, (d1, w1) in enumerate(DENOMINATION_WEIGHTS.items())
-                for j, (d2, w2) in enumerate(DENOMINATION_WEIGHTS.items())
-                if i < j
+                for (d1, w1), (d2, w2) in itertools.combinations(DENOMINATION_WEIGHTS.items(), 2)
             },
         }


### PR DESCRIPTION
## Summary\n\n- **dimensional_space.py**: Replace unused `_valence`/`_spatial` loop variables with a single `range(len(StateValence) * 3)` loop, eliminating the \"suspicious unused loop iteration variable\" CodeQL error at line 275\n- **exchange.py**: Replace nested `enumerate()` + `i < j` filter with `itertools.combinations()`, eliminating the \"non-iterable used in for loop\" CodeQL error at line 413\n\nBoth changes are behavior-preserving refactors — same iteration count, same output.\n\nAddresses error-level CodeQL alerts from #895.\n\n## Test plan\n\n- [ ] CI passes (TypeScript build + tests, Python lint)\n- [ ] CodeQL re-scan shows resolved alerts\n- [ ] No regression in coherence pipeline\n\nhttps://claude.ai/code/session_01ADuTVYs6H8P567SB6EfHbD