### PR TITLE
fix(tests,security): resolve 2 test failures and URL encoding vulnerability

### DIFF
--- a/src/api/stripe_billing.py
+++ b/src/api/stripe_billing.py
@@ -21,6 +21,7 @@ import os
 import secrets
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, Dict, Optional
 
@@ -95,9 +96,9 @@ def _stripe_request(
 
     encoded_data = None
     if form_data:
-        encoded_data = "&".join(
-            f"{urllib.request.quote(k)}={urllib.request.quote(str(v))}" for k, v in form_data.items() if v is not None
-        ).encode("utf-8")
+        encoded_data = urllib.parse.urlencode({k: str(v) for k, v in form_data.items() if v is not None}).encode(
+            "utf-8"
+        )
 
     req = urllib.request.Request(
         url,

--- a/tests/spiralverse/rwp_v3.test.ts
+++ b/tests/spiralverse/rwp_v3.test.ts
@@ -216,8 +216,9 @@ describe('RWPv3Protocol', () => {
       const password = Buffer.from('password');
       const envelope = protocol.encrypt(password, Buffer.from('message'));
 
-      // Tamper with ciphertext
-      envelope.ct[0] = "bip'u";
+      // Tamper with ciphertext — ensure replacement differs from original
+      const original = envelope.ct[0];
+      envelope.ct[0] = original === "bip'u" ? "bop'a" : "bip'u";
 
       expect(() => {
         protocol.decrypt(password, envelope);

--- a/tests/test_render_webtoon_lock_packet.py
+++ b/tests/test_render_webtoon_lock_packet.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import scripts.render_webtoon_lock_packet as renderer
+import scripts.render_grok_storyboard_packet as storyboard_renderer
 
 
 def write_lock_packet(path: Path) -> None:
@@ -34,7 +35,7 @@ def test_run_lock_packet_dry_run_writes_manifest(tmp_path: Path, monkeypatch) ->
         "check_backends",
         lambda: {"imagen": True, "imagen-ultra": True, "hf": True, "zimage": False},
     )
-    monkeypatch.setattr(renderer, "pick_best_backend", lambda preference=None: "imagen")
+    monkeypatch.setattr(storyboard_renderer, "pick_best_backend", lambda preference=None: "imagen")
 
     manifest_path = renderer.run_lock_packet(lock_packet_path, dry_run=True)
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -56,7 +57,7 @@ def test_run_lock_packet_retries_with_fallback(tmp_path: Path, monkeypatch) -> N
         "check_backends",
         lambda: {"imagen": True, "imagen-ultra": True, "hf": True, "zimage": False},
     )
-    monkeypatch.setattr(renderer, "pick_best_backend", lambda preference=None: "imagen")
+    monkeypatch.setattr(storyboard_renderer, "pick_best_backend", lambda preference=None: "imagen")
 
     def fake_generate(*, backend, prompt, output, aspect, reference, negative_prompt, width, height):
         calls.append(backend)


### PR DESCRIPTION
## Summary

- **rwp_v3.test.ts**: Fixed flaky tampered-ciphertext test — the replacement token `bip'u` could decode to the same byte as the original, making the tamper a no-op. Now ensures the replacement always differs.
- **test_render_webtoon_lock_packet.py**: Fixed monkeypatch targeting wrong module for `pick_best_backend` (patched `renderer` but function lives in `storyboard_renderer`).
- **stripe_billing.py**: Replaced manual `urllib.request.quote()` form encoding with `urllib.parse.urlencode()` to prevent parameter injection edge cases.

## Test plan

- [x] TypeScript: 174 test files, 5957 tests passed, 0 failed
- [x] Python: 5581 tests passed, 0 failed
- [x] `npm run build` — clean compile
- [x] `npm run lint` (Prettier) — pass
- [x] `black --check` — pass

Addresses #918 (daily review failures) and #895 (security triage).

https://claude.ai/code/session_019NT8hahHSqsZT5adz4RymC