### PR TITLE
Add Claude Code GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,40 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*),Bash(python3 *),Bash(python -m pytest *)"
+            --system-prompt "You are working on SCBE-AETHERMOORE, an AI governance framework. Security formula: H(d,R) = R^(d²). Follow the 6 Sacred Tongues weighting system. Test tiers L1-L6."


### PR DESCRIPTION
## Summary
- Adds `@claude` trigger on issues/PRs via anthropics/claude-code-action@v1
- Configured with SCBE system prompt and allowed tools
- Requires `ANTHROPIC_API_KEY` secret

## Test plan
- [ ] Add API key to repo secrets
- [ ] Open test issue mentioning @claude
- [ ] Verify response

🤖 Generated with [Claude Code](https://claude.com/claude-code)