### PR TITLE
fix(security): resolve CodeQL alerts from issue #895 — path traversal…

### DIFF
--- a/kindle-app/www/aetherbrowser.html
+++ b/kindle-app/www/aetherbrowser.html
@@ -1816,7 +1816,7 @@ window.AetherBrowser = (function() {
 
         // Summary
         var summary = document.createElement('div');
-        summary.innerHTML = '<span style="color:var(--aqua);">[' + ts + '] COMPLETE: ' + passed + '/' + total + (failed === 0 ? ' ALL PASS' : ' (' + failed + ' FAILED)') + '</span>';
+        summary.innerHTML = '<span style="color:var(--aqua);">[' + _escHtml(ts) + '] COMPLETE: ' + _escHtml(passed + '/' + total) + (failed === 0 ? ' ALL PASS' : ' (' + _escHtml(String(failed)) + ' FAILED)') + '</span>';
         log.appendChild(summary);
         log.scrollTop = log.scrollHeight;
 

--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -1484,7 +1484,12 @@ async def ops_momentum_run(req: MomentumRunRequest = MomentumRunRequest()):
 @app.get("/api/ops/momentum/latest")
 async def ops_momentum_latest(train_id: str = "daily_ops"):
     """Return the latest Momentum Train state.json summary (no execution)."""
+    # Validate train_id against allowlist to prevent path traversal (CodeQL alert)
+    if train_id not in MOMENTUM_TRAIN_CONFIGS:
+        return {"error": f"Unknown train_id: {train_id}", "ok": False}
     run_root = MOMENTUM_RUNS_DIR / train_id
+    if not _is_path_within(run_root, MOMENTUM_RUNS_DIR):
+        return {"error": "Invalid train_id", "ok": False}
     if not run_root.exists():
         return {"error": f"No runs found for train_id={train_id}", "ok": False}
     dirs = [p for p in run_root.iterdir() if p.is_dir()]
@@ -1872,13 +1877,14 @@ async def cli_run(req: CliRunRequest = CliRunRequest()):
 
     result = await _cli_dispatch(parts)
     # Normalise to always include command + timestamp
+    # Use safe_raw (newlines stripped) in response to prevent log injection via returned JSON
     if isinstance(result, dict):
         out: dict[str, Any] = dict(result)
         out.setdefault("ok", True)
-        out.setdefault("command", raw)
+        out.setdefault("command", safe_raw)
         out.setdefault("timestamp", _cli_now_iso())
     else:
-        out = {"ok": True, "command": raw, "result": result, "timestamp": _cli_now_iso()}
+        out = {"ok": True, "command": safe_raw, "result": result, "timestamp": _cli_now_iso()}
 
     _append_jsonl(
         IDE_CLI_LOG,

--- a/scripts/apollo/video_review.py
+++ b/scripts/apollo/video_review.py
@@ -145,8 +145,15 @@ def score_description(description: str) -> tuple[int, list, list]:
     elif len(description) > 200:
         score += 2  # substantial description
 
-    if any(urllib.parse.urlparse(w).scheme in ("http", "https") for w in description.split()):
-        score += 1  # has links
+    # Validate URLs: only count well-formed http/https URLs with a valid netloc
+    for w in description.split():
+        try:
+            parsed = urllib.parse.urlparse(w)
+            if parsed.scheme in ("http", "https") and parsed.netloc and "\x00" not in w:
+                score += 1  # has links
+                break
+        except Exception:
+            pass
 
     if "#" in description:
         score += 1  # has hashtags

--- a/scripts/system/aetherbrowser_notion_nav.py
+++ b/scripts/system/aetherbrowser_notion_nav.py
@@ -110,6 +110,7 @@ def nav_notion_playwright(
 ) -> List[Dict[str, Any]]:
     """Navigate Notion via Playwright (requires login)."""
     try:
+        from playwright.sync_api import sync_playwright  # noqa: F401
     except ImportError:
         print("Playwright not installed. Using API only.", file=sys.stderr)
         return search_notion_api(query, max_results)


### PR DESCRIPTION
…, log injection, XSS, URL sanitization

- api_server.py: Add MOMENTUM_TRAIN_CONFIGS allowlist + _is_path_within() guard to /api/ops/momentum/latest endpoint (path traversal)
- api_server.py: Use sanitized safe_raw in CLI response object to prevent log injection via returned JSON
- aetherbrowser.html: Wrap API-derived values in _escHtml() before innerHTML insertion (XSS)
- video_review.py: Add netloc validation and null-byte rejection to URL parsing (incomplete sanitization)
- aetherbrowser_notion_nav.py: Fix empty try block syntax error — add missing playwright import

https://claude.ai/code/session_01Ps8HqbS23t7e2bCL3KCHMx

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Affected Layers

<!-- Check all that apply -->
- [ ] L1-2: Context realification
- [ ] L3-4: Weighted transform / Poincare embedding
- [ ] L5-6: Hyperbolic distance / breathing transform
- [ ] L7-8: Mobius phase / Hamiltonian CFI
- [ ] L9-10: Spectral / spin coherence
- [ ] L11-12: Temporal distance / harmonic wall
- [ ] L13-14: Risk decision / audio axis
- [ ] Infrastructure / CI / Docker

## Axiom Compliance

<!-- Which axioms does this change satisfy or affect? -->
- [ ] A1: Unitarity (norm preservation)
- [ ] A2: Locality (spatial bounds)
- [ ] A3: Causality (time-ordering)
- [ ] A4: Symmetry (gauge invariance)
- [ ] A5: Composition (pipeline integrity)
- [ ] N/A

## Test Plan

- [ ] TypeScript tests pass (`npm test`)
- [ ] Python tests pass (`python -m pytest tests/ -v`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Lint passes (`npm run lint`)

## Cross-Language Parity

- [ ] TypeScript updated
- [ ] Python updated to match
- [ ] N/A (single-language change)
