### PR TITLE
fix(lint): resolve syntax error and unused loop variable (#895)

### DIFF
--- a/scripts/system/aetherbrowser_notion_nav.py
+++ b/scripts/system/aetherbrowser_notion_nav.py
@@ -110,6 +110,7 @@ def nav_notion_playwright(
 ) -> List[Dict[str, Any]]:
     """Navigate Notion via Playwright (requires login)."""
     try:
+        from playwright.sync_api import sync_playwright  # noqa: F401
     except ImportError:
         print("Playwright not installed. Using API only.", file=sys.stderr)
         return search_notion_api(query, max_results)

--- a/src/symphonic_cipher/scbe_aethermoore/flock_shepherd.py
+++ b/src/symphonic_cipher/scbe_aethermoore/flock_shepherd.py
@@ -291,7 +291,7 @@ class Flock:
                 for sid, s in self.sheep.items()
                 if sid not in stale and s.state in (SheepState.ACTIVE, SheepState.IDLE)
             ]
-            for tid, task in self.tasks.items():
+            for _tid, task in self.tasks.items():
                 if task.owner in stale and task.status == "active":
                     if available:
                         new_owner = available[reassigned % len(available)]


### PR DESCRIPTION
- Fix empty try block in aetherbrowser_notion_nav.py (ruff/CodeQL syntax error)
- Rename unused loop variable tid → _tid in flock_shepherd.py (ruff B007)

https://claude.ai/code/session_013PAYUUk4VQv33R4bVVQmFs

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Affected Layers

<!-- Check all that apply -->
- [ ] L1-2: Context realification
- [ ] L3-4: Weighted transform / Poincare embedding
- [ ] L5-6: Hyperbolic distance / breathing transform
- [ ] L7-8: Mobius phase / Hamiltonian CFI
- [ ] L9-10: Spectral / spin coherence
- [ ] L11-12: Temporal distance / harmonic wall
- [ ] L13-14: Risk decision / audio axis
- [ ] Infrastructure / CI / Docker

## Axiom Compliance

<!-- Which axioms does this change satisfy or affect? -->
- [ ] A1: Unitarity (norm preservation)
- [ ] A2: Locality (spatial bounds)
- [ ] A3: Causality (time-ordering)
- [ ] A4: Symmetry (gauge invariance)
- [ ] A5: Composition (pipeline integrity)
- [ ] N/A

## Test Plan

- [ ] TypeScript tests pass (`npm test`)
- [ ] Python tests pass (`python -m pytest tests/ -v`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Lint passes (`npm run lint`)

## Cross-Language Parity

- [ ] TypeScript updated
- [ ] Python updated to match
- [ ] N/A (single-language change)
