### PR TITLE
feat: trigger website stats sync when CI passes

### DIFF
--- a/.github/workflows/sync-stats-dispatch.yml
+++ b/.github/workflows/sync-stats-dispatch.yml
@@ -1,0 +1,19 @@
+name: Sync Stats to Website
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  dispatch:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger website stats sync
+        run: |
+          gh api repos/issdandavis/issdandavis.github.io/dispatches \
+            -f event_type=scbe-tests-passed
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}


### PR DESCRIPTION
## Summary
- When SCBE CI passes on main, dispatches `scbe-tests-passed` event to issdandavis.github.io
- Website repo has matching `cross-repo-stats-sync.yml` workflow to receive it
- Uses `CROSS_REPO_PAT` secret (already set)

## Test plan
- [ ] Merge this PR
- [ ] Push a commit to SCBE main that passes CI
- [ ] Verify website repo shows a workflow run triggered by repository_dispatch