### PR TITLE
fix: tsconfig ignoreDeprecations 6.0 → 5.0 for typescript 5.9.x

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "target": "ES2022",
     "module": "CommonJS",
     "moduleResolution": "Node",


### PR DESCRIPTION
Companion to #974. typescript was reverted to ^5.9.3 but tsconfig still had ignoreDeprecations: 6.0 which is invalid in TS5. Fixes typecheck failures.