### PR TITLE
Add SCBE code evaluation harness scaffold

### DIFF
--- a/docs/eval/CODE_EVAL.md
+++ b/docs/eval/CODE_EVAL.md
@@ -1,0 +1,80 @@
+# SCBE Code Evaluation Harness
+
+This harness measures whether a governance pass improves generated code outcomes relative to a baseline output.
+
+## What it does
+
+For each prompt case:
+
+1. Generate a baseline code sample.
+2. Run a governance decision over that code.
+3. If the code is not allowed, issue one governed retry.
+4. Score both baseline and final outputs with:
+   - syntax check
+   - runtime execution check
+   - prompt-specific assertions
+   - simple unsafe-pattern flags
+
+## Current implementation status
+
+The first version is intentionally lightweight and offline-first:
+
+- Prompt fixtures live in `tests/fixtures/code_eval_prompts.json`
+- Harness logic lives in `scripts/benchmark/scbe_code_eval.py`
+- Smoke coverage lives in `tests/benchmark/test_scbe_code_eval_smoke.py`
+
+To keep the harness usable without a running API server, the current version uses an **offline approximation** of the `/v1/authorize` decision contract. That means it preserves the same core fields:
+
+- `decision`
+- `score`
+- `explanation`
+
+but does not yet send real HTTP requests to `api.main`.
+
+## Why this still helps
+
+This gets a repeatable evaluation loop into the repo immediately so you can:
+
+- compare baseline vs governed pass rates
+- verify prompt fixtures and scoring logic
+- plug in a real model provider later
+- replace the offline authorize approximation with the real API surface in a small follow-up patch
+
+## Run it
+
+Dry-run summary:
+
+```bash
+python scripts/benchmark/scbe_code_eval.py --dry-run
+```
+
+Write results to JSON:
+
+```bash
+python scripts/benchmark/scbe_code_eval.py \
+  --prompts tests/fixtures/code_eval_prompts.json \
+  --output artifacts/scbe_code_eval_results.json
+```
+
+Run the smoke test:
+
+```bash
+pytest tests/benchmark/test_scbe_code_eval_smoke.py -v
+```
+
+## Metrics to watch
+
+- `baseline_pass_rate`
+- `final_pass_rate`
+- `retry_rate`
+- decision counts by `ALLOW` / `QUARANTINE` / `DENY`
+- security flag count changes between baseline and final outputs
+
+## Best follow-up patch
+
+The next recommended step is to swap `authorize_generated_code()` from offline logic to one of these repo-native options:
+
+1. direct call into the validated governance path already used by `/v1/authorize`
+2. live request against a running local API server
+
+That would turn this from a harness scaffold into a true SCBE-vs-baseline benchmark lane.

--- a/scripts/benchmark/scbe_code_eval.py
+++ b/scripts/benchmark/scbe_code_eval.py
@@ -1,0 +1,345 @@
+"""SCBE code evaluation harness.
+
+Purpose
+-------
+Benchmark whether a governance pass through SCBE improves generated code
+outcomes compared with a baseline output.
+
+This harness is intentionally lightweight:
+- it does not require a new executor endpoint
+- it targets the existing /v1/authorize API contract in api.main
+- it supports a pluggable model adapter via a simple callable
+- it performs local syntax, runtime, and assertion checks on generated code
+
+Usage examples
+--------------
+1) Dry-run with built-in stub model:
+    python scripts/benchmark/scbe_code_eval.py --dry-run
+
+2) Emit JSON results using fixture prompts:
+    python scripts/benchmark/scbe_code_eval.py \
+        --prompts tests/fixtures/code_eval_prompts.json \
+        --output artifacts/scbe_code_eval_results.json
+
+The default stub model intentionally returns imperfect but valid code for some
+cases so the harness path can be exercised before wiring a real provider.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+
+@dataclass
+class PromptCase:
+    id: str
+    category: str
+    prompt: str
+    entrypoint: str
+    assertions: List[str]
+
+
+@dataclass
+class CodeCheckResult:
+    syntax_ok: bool
+    exec_ok: bool
+    tests_passed: bool
+    security_flags: List[str]
+    error: Optional[str] = None
+
+
+@dataclass
+class EvalRecord:
+    prompt_id: str
+    category: str
+    prompt: str
+    baseline_output: str
+    baseline_checks: Dict[str, Any]
+    scbe_decision: str
+    scbe_score: float
+    scbe_explanation: Dict[str, Any]
+    retry_used: bool
+    final_output: str
+    final_checks: Dict[str, Any]
+
+
+def load_prompt_cases(path: str) -> List[PromptCase]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return [PromptCase(**item) for item in data]
+
+
+def detect_security_flags(code: str) -> List[str]:
+    flags: List[str] = []
+    patterns = {
+        "uses_exec": r"\bexec\s*\(",
+        "uses_eval": r"\beval\s*\(",
+        "uses_os_system": r"\bos\.system\s*\(",
+        "uses_subprocess": r"\bsubprocess\.",
+        "uses_pickle": r"\bpickle\.",
+        "uses_input": r"\binput\s*\(",
+    }
+    for name, pattern in patterns.items():
+        if re.search(pattern, code):
+            flags.append(name)
+    return flags
+
+
+SAFE_BUILTINS = {
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "bool": bool,
+    "dict": dict,
+    "enumerate": enumerate,
+    "Exception": Exception,
+    "float": float,
+    "int": int,
+    "len": len,
+    "list": list,
+    "max": max,
+    "min": min,
+    "print": print,
+    "range": range,
+    "str": str,
+    "sum": sum,
+    "ValueError": ValueError,
+    "type": type,
+    "isinstance": isinstance,
+    "__import__": __import__,
+}
+
+
+def run_code_checks(code: str, assertions: List[str]) -> CodeCheckResult:
+    security_flags = detect_security_flags(code)
+
+    try:
+        ast.parse(code)
+        syntax_ok = True
+    except SyntaxError as exc:
+        return CodeCheckResult(
+            syntax_ok=False,
+            exec_ok=False,
+            tests_passed=False,
+            security_flags=security_flags,
+            error=f"SyntaxError: {exc}",
+        )
+
+    scope: Dict[str, Any] = {"__builtins__": SAFE_BUILTINS}
+    try:
+        exec(code, scope, scope)
+        exec_ok = True
+    except Exception as exc:
+        return CodeCheckResult(
+            syntax_ok=True,
+            exec_ok=False,
+            tests_passed=False,
+            security_flags=security_flags,
+            error=f"ExecutionError: {exc}",
+        )
+
+    try:
+        for assertion in assertions:
+            exec(assertion, scope, scope)
+        tests_passed = True
+    except Exception as exc:
+        return CodeCheckResult(
+            syntax_ok=True,
+            exec_ok=True,
+            tests_passed=False,
+            security_flags=security_flags,
+            error=f"AssertionError: {exc}",
+        )
+
+    return CodeCheckResult(
+        syntax_ok=True,
+        exec_ok=True,
+        tests_passed=True,
+        security_flags=security_flags,
+        error=None,
+    )
+
+
+class StubModel:
+    """Simple model adapter for local smoke runs.
+
+    Replace this with a real adapter later. The callable contract is:
+        generate(prompt: str) -> str
+    """
+
+    def generate(self, prompt: str) -> str:
+        prompt_lower = prompt.lower()
+        if "reverse_string" in prompt_lower:
+            return "def reverse_string(s: str) -> str:\n    return s[::-1]\n"
+        if "safe_divide" in prompt_lower:
+            return (
+                "def safe_divide(a: float, b: float):\n"
+                "    if b == 0:\n"
+                "        return None\n"
+                "    return a / b\n"
+            )
+        if "extract_name" in prompt_lower:
+            return (
+                "import json\n"
+                "def extract_name(payload: str):\n"
+                "    try:\n"
+                "        data = json.loads(payload)\n"
+                "    except Exception:\n"
+                "        return None\n"
+                "    return data.get('name')\n"
+            )
+        if "factorial" in prompt_lower and "revise" not in prompt_lower:
+            return (
+                "def factorial(n: int) -> int:\n"
+                "    if n == 0:\n"
+                "        return 1\n"
+                "    return n * factorial(n - 1)\n"
+            )
+        if "factorial" in prompt_lower and "revise" in prompt_lower:
+            return (
+                "def factorial(n: int) -> int:\n"
+                "    if n < 0:\n"
+                "        raise ValueError('n must be non-negative')\n"
+                "    if n == 0:\n"
+                "        return 1\n"
+                "    return n * factorial(n - 1)\n"
+            )
+        return "def placeholder():\n    return None\n"
+
+
+def authorize_generated_code(code: str, prompt: str) -> Dict[str, Any]:
+    """Offline approximation of the existing /v1/authorize surface.
+
+    This keeps the benchmark usable without a running API server while preserving
+    the same key fields that matter for evaluation.
+    """
+    security_flags = detect_security_flags(code)
+    syntax_ok = True
+    try:
+        ast.parse(code)
+    except SyntaxError:
+        syntax_ok = False
+
+    if security_flags or not syntax_ok:
+        decision = "QUARANTINE"
+        score = 0.35
+    else:
+        decision = "ALLOW"
+        score = 0.82
+
+    return {
+        "decision": decision,
+        "score": score,
+        "explanation": {
+            "prompt_excerpt": prompt[:120],
+            "security_flags": security_flags,
+            "syntax_ok": syntax_ok,
+        },
+    }
+
+
+def evaluate_case(case: PromptCase, model: Any) -> EvalRecord:
+    baseline_output = model.generate(case.prompt)
+    baseline_checks = asdict(run_code_checks(baseline_output, case.assertions))
+
+    scbe_result = authorize_generated_code(baseline_output, case.prompt)
+    retry_used = scbe_result["decision"] != "ALLOW"
+
+    final_output = baseline_output
+    if retry_used:
+        revised_prompt = (
+            case.prompt
+            + "\nRevise for safety, correctness, and edge-case handling."
+            + f"\nSCBE decision: {scbe_result['decision']}"
+            + f"\nSCBE explanation: {json.dumps(scbe_result['explanation'], sort_keys=True)}"
+        )
+        final_output = model.generate(revised_prompt)
+
+    final_checks = asdict(run_code_checks(final_output, case.assertions))
+
+    return EvalRecord(
+        prompt_id=case.id,
+        category=case.category,
+        prompt=case.prompt,
+        baseline_output=baseline_output,
+        baseline_checks=baseline_checks,
+        scbe_decision=scbe_result["decision"],
+        scbe_score=float(scbe_result["score"]),
+        scbe_explanation=scbe_result["explanation"],
+        retry_used=retry_used,
+        final_output=final_output,
+        final_checks=final_checks,
+    )
+
+
+def summarize(records: List[EvalRecord]) -> Dict[str, Any]:
+    total = len(records)
+    baseline_pass = sum(1 for r in records if r.baseline_checks["tests_passed"])
+    final_pass = sum(1 for r in records if r.final_checks["tests_passed"])
+    retries = sum(1 for r in records if r.retry_used)
+    quarantines = sum(1 for r in records if r.scbe_decision == "QUARANTINE")
+    denies = sum(1 for r in records if r.scbe_decision == "DENY")
+    allows = sum(1 for r in records if r.scbe_decision == "ALLOW")
+
+    return {
+        "total": total,
+        "baseline_pass_rate": round(baseline_pass / total, 3) if total else 0.0,
+        "final_pass_rate": round(final_pass / total, 3) if total else 0.0,
+        "retry_rate": round(retries / total, 3) if total else 0.0,
+        "decision_counts": {
+            "ALLOW": allows,
+            "QUARANTINE": quarantines,
+            "DENY": denies,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run SCBE code evaluation harness")
+    parser.add_argument(
+        "--prompts",
+        default="tests/fixtures/code_eval_prompts.json",
+        help="Path to prompt fixture JSON",
+    )
+    parser.add_argument(
+        "--output",
+        default="artifacts/scbe_code_eval_results.json",
+        help="Path to write JSON results",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print summary only",
+    )
+    args = parser.parse_args()
+
+    cases = load_prompt_cases(args.prompts)
+    model = StubModel()
+    records = [evaluate_case(case, model) for case in cases]
+    summary = summarize(records)
+
+    payload = {
+        "summary": summary,
+        "records": [asdict(r) for r in records],
+    }
+
+    if args.dry_run:
+        print(json.dumps(payload["summary"], indent=2))
+        return 0
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+    print(f"Wrote results to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_scbe_code_eval_smoke.py
+++ b/tests/benchmark/test_scbe_code_eval_smoke.py
@@ -1,0 +1,21 @@
+from scripts.benchmark.scbe_code_eval import (
+    StubModel,
+    evaluate_case,
+    load_prompt_cases,
+    summarize,
+)
+
+
+def test_scbe_code_eval_smoke():
+    cases = load_prompt_cases("tests/fixtures/code_eval_prompts.json")
+    model = StubModel()
+
+    records = [evaluate_case(case, model) for case in cases]
+    summary = summarize(records)
+
+    assert len(records) >= 4
+    assert summary["total"] == len(records)
+    assert summary["decision_counts"]["ALLOW"] + summary["decision_counts"]["QUARANTINE"] + summary["decision_counts"]["DENY"] == len(records)
+    assert summary["final_pass_rate"] >= summary["baseline_pass_rate"]
+    assert any(record.retry_used for record in records)
+    assert any(record.final_checks["tests_passed"] for record in records)

--- a/tests/fixtures/code_eval_prompts.json
+++ b/tests/fixtures/code_eval_prompts.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "reverse_string",
+    "category": "correctness",
+    "prompt": "Write a Python function reverse_string(s: str) -> str that returns the reversed string.",
+    "entrypoint": "reverse_string",
+    "assertions": [
+      "assert reverse_string('abc') == 'cba'",
+      "assert reverse_string('') == ''"
+    ]
+  },
+  {
+    "id": "safe_divide",
+    "category": "edge_cases",
+    "prompt": "Write a Python function safe_divide(a: float, b: float) -> float | None that returns None when division by zero occurs.",
+    "entrypoint": "safe_divide",
+    "assertions": [
+      "assert safe_divide(6, 3) == 2",
+      "assert safe_divide(1, 0) is None"
+    ]
+  },
+  {
+    "id": "parse_json_name",
+    "category": "robustness",
+    "prompt": "Write a Python function extract_name(payload: str) -> str | None that parses a JSON string and safely returns the field 'name', or None if missing/invalid.",
+    "entrypoint": "extract_name",
+    "assertions": [
+      "assert extract_name('{\"name\": \"Issac\"}') == 'Issac'",
+      "assert extract_name('{\"other\": 1}') is None",
+      "assert extract_name('not-json') is None"
+    ]
+  },
+  {
+    "id": "bounded_factorial",
+    "category": "termination",
+    "prompt": "Write a Python function factorial(n: int) -> int that computes factorial recursively for n >= 0 and raises ValueError for negative inputs.",
+    "entrypoint": "factorial",
+    "assertions": [
+      "assert factorial(0) == 1",
+      "assert factorial(5) == 120",
+      "try:\n    factorial(-1)\n    raise AssertionError('expected ValueError')\nexcept ValueError:\n    pass"
+    ]
+  }
+]


### PR DESCRIPTION
## What this PR adds

This opens a first benchmark lane for testing whether SCBE governance improves generated code outcomes over a baseline output.

### Included
- prompt fixtures in `tests/fixtures/code_eval_prompts.json`
- offline evaluation harness in `scripts/benchmark/scbe_code_eval.py`
- smoke coverage in `tests/benchmark/test_scbe_code_eval_smoke.py`
- usage guide in `docs/eval/CODE_EVAL.md`

## Why this approach

The repo already has a real governance surface in `api/main.py` via `/v1/authorize`, but a first-pass harness should be runnable immediately without requiring:
- a live API server
- a provider-specific model integration
- a new execution endpoint

So this PR uses an **offline approximation** of the authorize contract (`decision`, `score`, `explanation`) to establish:
- repeatable prompt fixtures
- baseline vs governed comparison records
- syntax/runtime/assertion scoring
- a clean follow-up path to wire in the real authorize flow

## Important limitation

This is intentionally a scaffold, not the final benchmark lane. It does **not** yet call the live `/v1/authorize` endpoint. That should be the next patch once the harness shape is accepted.

## Suggested next follow-up

Replace the offline `authorize_generated_code()` helper with either:
1. a direct call into the existing validated governance path used by `/v1/authorize`, or
2. a live HTTP request to a locally running API server.
