### PR TITLE
[codex] Add GitHub Actions remote worker

### DIFF
--- a/.github/workflows/free-remote-worker.yml
+++ b/.github/workflows/free-remote-worker.yml
@@ -1,0 +1,166 @@
+name: Free Remote Worker
+
+on:
+  workflow_dispatch:
+    inputs:
+      task_label:
+        description: Short label for the remote job
+        required: false
+        default: manual-remote-job
+      command:
+        description: Bash command to run on the GitHub-hosted worker
+        required: true
+        type: string
+      python_version:
+        description: Python version to install on the worker
+        required: false
+        default: "3.11"
+      install_mode:
+        description: Dependency bootstrap strategy
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - editable
+          - requirements
+          - none
+      working_directory:
+        description: Working directory relative to repo root
+        required: false
+        default: "."
+      artifact_glob:
+        description: Additional files or globs to upload
+        required: false
+        default: artifacts/**
+  repository_dispatch:
+    types:
+      - free-remote-worker
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  remote-job:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      TASK_LABEL: ${{ github.event_name == 'workflow_dispatch' && inputs.task_label || github.event.client_payload.task_label || 'remote-job' }}
+      COMMAND: ${{ github.event_name == 'workflow_dispatch' && inputs.command || github.event.client_payload.command || '' }}
+      PYTHON_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.python_version || github.event.client_payload.python_version || '3.11' }}
+      INSTALL_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.install_mode || github.event.client_payload.install_mode || 'auto' }}
+      WORKING_DIRECTORY: ${{ github.event_name == 'workflow_dispatch' && inputs.working_directory || github.event.client_payload.working_directory || '.' }}
+      ARTIFACT_GLOB: ${{ github.event_name == 'workflow_dispatch' && inputs.artifact_glob || github.event.client_payload.artifact_glob || 'artifacts/**' }}
+      ARTIFACT_ROOT: ${{ github.workspace }}/artifacts/remote-worker
+    steps:
+      - name: Validate payload
+        run: |
+          if [ -z "${COMMAND}" ]; then
+            echo "COMMAND is required"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up Node.js when package.json exists
+        if: ${{ hashFiles('package.json') != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Bootstrap dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+
+          case "${INSTALL_MODE}" in
+            none)
+              echo "Skipping dependency install"
+              ;;
+            editable)
+              python -m pip install -e ".[test]" || python -m pip install -e .
+              ;;
+            requirements)
+              if [ -f requirements.txt ]; then
+                python -m pip install -r requirements.txt
+              else
+                echo "requirements.txt not found"
+                exit 1
+              fi
+              ;;
+            auto)
+              if [ -f requirements.txt ]; then
+                python -m pip install -r requirements.txt || true
+              fi
+              if [ -f pyproject.toml ]; then
+                python -m pip install -e ".[test]" || python -m pip install -e . || true
+              fi
+              if [ -f package-lock.json ]; then
+                npm ci || npm install
+              elif [ -f package.json ]; then
+                npm install
+              fi
+              ;;
+            *)
+              echo "Unknown install mode: ${INSTALL_MODE}"
+              exit 1
+              ;;
+          esac
+
+      - name: Run remote command
+        shell: bash
+        run: |
+          set -u
+          set +e
+          set -o pipefail
+          mkdir -p "${ARTIFACT_ROOT}"
+          {
+            echo "task_label=${TASK_LABEL}"
+            echo "working_directory=${WORKING_DIRECTORY}"
+            echo "python_version=${PYTHON_VERSION}"
+            echo "install_mode=${INSTALL_MODE}"
+            echo "command=${COMMAND}"
+            echo "run_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > "${ARTIFACT_ROOT}/metadata.txt"
+
+          if ! cd "${WORKING_DIRECTORY}"; then
+            status=$?
+            echo "Failed to enter working directory: ${WORKING_DIRECTORY}" | tee "${ARTIFACT_ROOT}/command.log"
+            echo "${status}" > "${ARTIFACT_ROOT}/exit_code.txt"
+            exit 0
+          fi
+
+          bash -lc "${COMMAND}" 2>&1 | tee "${ARTIFACT_ROOT}/command.log"
+          status=${PIPESTATUS[0]}
+          echo "${status}" > "${ARTIFACT_ROOT}/exit_code.txt"
+          exit 0
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: remote-worker-${{ github.run_id }}
+          retention-days: 7
+          if-no-files-found: warn
+          path: |
+            artifacts/remote-worker/**
+            ${{ env.ARTIFACT_GLOB }}
+
+      - name: Fail when command failed
+        if: always()
+        shell: bash
+        run: |
+          status="$(cat artifacts/remote-worker/exit_code.txt)"
+          if [ "${status}" != "0" ]; then
+            echo "Remote command failed with exit code ${status}"
+            exit "${status}"
+          fi

--- a/docs/GITHUB_REMOTE_WORKER.md
+++ b/docs/GITHUB_REMOTE_WORKER.md
@@ -1,0 +1,87 @@
+# GitHub Remote Worker
+
+This repo can use GitHub Actions as a free remote worker for heavier or longer
+commands than this machine should carry locally.
+
+## What This Gives You
+
+- ad hoc remote command execution on `ubuntu-latest`
+- Python and Node bootstrap when the repo has the expected files
+- log capture in `artifacts/remote-worker/command.log`
+- metadata and exit code capture
+- artifact upload from `artifacts/remote-worker/**` plus an optional extra glob
+
+This is a remote worker, not a persistent VM.
+
+## Files
+
+- workflow: `.github/workflows/free-remote-worker.yml`
+- local dispatcher: `scripts/system/github_remote_worker.py`
+- n8n dispatch sample: `workflows/n8n/github_remote_worker_payload.sample.json`
+
+## Local Requirements
+
+- `gh` CLI installed and authenticated
+- admin or workflow-dispatch access to the target repo
+- the workflow committed to the target GitHub repository
+
+The dispatcher defaults to:
+
+```text
+issdandavis/SCBE-AETHERMOORE
+```
+
+Override that with:
+
+```bash
+export SCBE_GITHUB_REMOTE_REPO=owner/name
+```
+
+or pass `--repo owner/name`.
+
+## Dry Run
+
+```bash
+.venv/bin/python scripts/system/github_remote_worker.py dispatch \
+  "python -m pytest tests/aetherbrowser tests/aethermoore_constants" \
+  --task-label remote-pytest-slice \
+  --dry-run
+```
+
+## Dispatch A Real Job
+
+```bash
+.venv/bin/python scripts/system/github_remote_worker.py dispatch \
+  "python -m pytest tests/aetherbrowser tests/aethermoore_constants" \
+  --task-label remote-pytest-slice \
+  --watch
+```
+
+By default this runs on the remote repo default branch. Use `--ref some-branch`
+if you need a specific pushed branch.
+
+## Check Latest Status
+
+```bash
+.venv/bin/python scripts/system/github_remote_worker.py status
+```
+
+## Trigger From n8n Or Any Webhook Client
+
+The sample payload in
+`workflows/n8n/github_remote_worker_payload.sample.json` is intended for
+GitHub `repository_dispatch`. Typical call:
+
+```bash
+gh api repos/issdandavis/SCBE-AETHERMOORE/dispatches \
+  --method POST \
+  --input workflows/n8n/github_remote_worker_payload.sample.json
+```
+
+## Notes
+
+- `working_directory` is resolved relative to the repo root on the runner.
+- `install_mode=auto` tries `requirements.txt`, editable Python install, and
+  `npm install` when relevant files exist.
+- If the command fails, the workflow still uploads logs and artifacts, then
+  exits nonzero at the end.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 - [`DOCS_CATALOG.md`](DOCS_CATALOG.md) - Alphabetical catalog grouped by system part and priority
 - [`security/AETHER_ANTIVIRUS.md`](security/AETHER_ANTIVIRUS.md) - Public overview of the existing antivirus stack
 - [`system/CANONICAL_NAMING_HYDRA_ARMOR_OCTOARMOR_AETHER_ANTIVIRUS.md`](system/CANONICAL_NAMING_HYDRA_ARMOR_OCTOARMOR_AETHER_ANTIVIRUS.md) - Naming lock for HYDRA, Hydra Armor, OctoArmor, and Aether Antivirus
+- [`GITHUB_REMOTE_WORKER.md`](GITHUB_REMOTE_WORKER.md) - Free GitHub Actions remote worker setup and operator usage
 
 ### Operator Quick Lanes (Current)
 

--- a/scripts/system/github_remote_worker.py
+++ b/scripts/system/github_remote_worker.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Dispatch and monitor free remote jobs on GitHub Actions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[2]
+WORKFLOW_NAME = "free-remote-worker.yml"
+DEFAULT_REPO = os.environ.get("SCBE_GITHUB_REMOTE_REPO", "issdandavis/SCBE-AETHERMOORE")
+
+
+def _run(cmd: list[str], *, capture: bool = False, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        encoding="utf-8",
+        capture_output=capture,
+    )
+
+
+def _must(cmd: list[str], *, cwd: Path = REPO_ROOT) -> str:
+    proc = _run(cmd, capture=True, cwd=cwd)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "command failed")
+    return proc.stdout.strip()
+
+
+def _repo_name(repo: str) -> str:
+    return _must(["gh", "repo", "view", repo, "--json", "nameWithOwner", "--jq", ".nameWithOwner"])
+
+
+def _default_branch(repo: str) -> str:
+    return _must(["gh", "repo", "view", repo, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"])
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    branch = args.ref or _default_branch(args.repo)
+    gh_cmd = [
+        "gh",
+        "workflow",
+        "run",
+        "-R",
+        args.repo,
+        WORKFLOW_NAME,
+        "--ref",
+        branch,
+        "-f",
+        f"task_label={args.task_label}",
+        "-f",
+        f"command={args.command}",
+        "-f",
+        f"python_version={args.python_version}",
+        "-f",
+        f"install_mode={args.install_mode}",
+        "-f",
+        f"working_directory={args.working_directory}",
+        "-f",
+        f"artifact_glob={args.artifact_glob}",
+    ]
+
+    if args.dry_run:
+        print("Dispatch command:")
+        print(" ".join(shlex.quote(part) for part in gh_cmd))
+        return 0
+
+    proc = _run(gh_cmd)
+    if proc.returncode != 0:
+        return proc.returncode
+
+    print(f"Dispatched {WORKFLOW_NAME} on branch {branch}")
+    if args.watch:
+        return _watch(args.repo, branch=branch, poll_seconds=args.poll_seconds)
+    return 0
+
+
+def _latest_run(repo: str, branch: str | None = None) -> dict[str, Any]:
+    cmd = [
+        "gh",
+        "run",
+        "list",
+        "-R",
+        repo,
+        "--workflow",
+        WORKFLOW_NAME,
+        "--limit",
+        "1",
+        "--json",
+        "databaseId,status,conclusion,url,displayTitle,headBranch,createdAt",
+    ]
+    if branch:
+        cmd.extend(["--branch", branch])
+    payload = _must(cmd)
+    runs = json.loads(payload)
+    if not runs:
+        raise RuntimeError("No runs found for workflow")
+    return runs[0]
+
+
+def _watch(repo: str, branch: str | None = None, *, poll_seconds: int = 10) -> int:
+    run = _latest_run(repo, branch)
+    run_id = str(run["databaseId"])
+    print(f"Watching run {run_id}: {run['url']}")
+    watch_proc = _run(["gh", "run", "watch", "-R", repo, run_id, "--interval", str(poll_seconds)])
+    refreshed = _latest_run(repo, branch)
+    conclusion = refreshed.get("conclusion") or "unknown"
+    print(f"Final conclusion: {conclusion}")
+    return 0 if conclusion == "success" and watch_proc.returncode == 0 else 1
+
+
+def _status(args: argparse.Namespace) -> int:
+    run = _latest_run(args.repo, args.branch)
+    print(json.dumps(run, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Dispatch work to the free GitHub Actions remote worker")
+    subparsers = parser.add_subparsers(dest="command_name", required=True)
+
+    dispatch = subparsers.add_parser("dispatch", help="Trigger a remote job")
+    dispatch.add_argument("command", help="Bash command to run on the remote worker")
+    dispatch.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repository in owner/name form")
+    dispatch.add_argument("--task-label", default="manual-remote-job", help="Short label for the remote task")
+    dispatch.add_argument("--python-version", default="3.11", help="Python version for the worker")
+    dispatch.add_argument(
+        "--install-mode",
+        default="auto",
+        choices=("auto", "editable", "requirements", "none"),
+        help="Dependency bootstrap strategy",
+    )
+    dispatch.add_argument("--working-directory", default=".", help="Working directory relative to repo root")
+    dispatch.add_argument("--artifact-glob", default="artifacts/**", help="Additional files or globs to upload")
+    dispatch.add_argument("--ref", help="Git ref or branch to run the workflow on; defaults to the remote repo default branch")
+    dispatch.add_argument("--watch", action="store_true", help="Watch the dispatched run until completion")
+    dispatch.add_argument("--poll-seconds", type=int, default=10, help="Polling interval for watch mode")
+    dispatch.add_argument("--dry-run", action="store_true", help="Print the gh command instead of dispatching")
+    dispatch.set_defaults(handler=_dispatch)
+
+    status = subparsers.add_parser("status", help="Show the latest remote worker run")
+    status.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repository in owner/name form")
+    status.add_argument("--branch", help="Filter by branch")
+    status.set_defaults(handler=_status)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        resolved = _repo_name(args.repo)
+    except RuntimeError as exc:
+        print(f"GitHub repo lookup failed: {exc}", file=sys.stderr)
+        return 2
+    if resolved != args.repo:
+        print(f"Resolved GitHub repo: {resolved}")
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/n8n/github_remote_worker_payload.sample.json
+++ b/workflows/n8n/github_remote_worker_payload.sample.json
@@ -1,0 +1,11 @@
+{
+  "event_type": "free-remote-worker",
+  "client_payload": {
+    "task_label": "remote-pytest-slice",
+    "command": "python -m pytest tests/aetherbrowser tests/aethermoore_constants",
+    "python_version": "3.11",
+    "install_mode": "auto",
+    "working_directory": ".",
+    "artifact_glob": "artifacts/**"
+  }
+}


### PR DESCRIPTION
## What changed
Adds a free GitHub Actions remote worker so this repo can offload heavier or longer commands from the local Chromebook/container.

## Why
The local machine is intentionally lightweight. This adds a documented remote execution path using GitHub-hosted runners, with a local dispatcher script and an n8n-compatible dispatch payload.

## Impact
Operators can trigger ad hoc remote commands, capture logs and artifacts, and watch runs from the local machine without provisioning a separate VM.

## Validation
- `/home/issdandavis7795/SCBE-AETHERMOORE/.venv/bin/python -m py_compile /tmp/scbe-push/scripts/system/github_remote_worker.py`
- `/home/issdandavis7795/SCBE-AETHERMOORE/.venv/bin/python /tmp/scbe-push/scripts/system/github_remote_worker.py dispatch "echo hello from branch worker" --repo issdandavis/SCBE-AETHERMOORE --dry-run`
- `git -C /tmp/scbe-push diff --check`

## Note
GitHub does not allow `workflow_dispatch` execution of a workflow file that is not yet present on the default branch, so the live remote-worker verification is expected after merge on `main`.