### PR TITLE
[codex] Tighten remote worker artifact defaults

### DIFF
--- a/.github/workflows/free-remote-worker.yml
+++ b/.github/workflows/free-remote-worker.yml
@@ -32,7 +32,7 @@ on:
       artifact_glob:
         description: Additional files or globs to upload
         required: false
-        default: artifacts/**
+        default: ""
   repository_dispatch:
     types:
       - free-remote-worker
@@ -51,7 +51,7 @@ jobs:
       PYTHON_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.python_version || github.event.client_payload.python_version || '3.11' }}
       INSTALL_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.install_mode || github.event.client_payload.install_mode || 'auto' }}
       WORKING_DIRECTORY: ${{ github.event_name == 'workflow_dispatch' && inputs.working_directory || github.event.client_payload.working_directory || '.' }}
-      ARTIFACT_GLOB: ${{ github.event_name == 'workflow_dispatch' && inputs.artifact_glob || github.event.client_payload.artifact_glob || 'artifacts/**' }}
+      ARTIFACT_GLOB: ${{ github.event_name == 'workflow_dispatch' && inputs.artifact_glob || github.event.client_payload.artifact_glob || '' }}
       ARTIFACT_ROOT: ${{ github.workspace }}/artifacts/remote-worker
     steps:
       - name: Validate payload

--- a/docs/GITHUB_REMOTE_WORKER.md
+++ b/docs/GITHUB_REMOTE_WORKER.md
@@ -60,6 +60,9 @@ or pass `--repo owner/name`.
 By default this runs on the remote repo default branch. Use `--ref some-branch`
 if you need a specific pushed branch.
 
+The default artifact behavior only uploads `artifacts/remote-worker/**`.
+Pass `--artifact-glob some/path/**` only when you intentionally want more files.
+
 ## Check Latest Status
 
 ```bash
@@ -83,5 +86,7 @@ gh api repos/issdandavis/SCBE-AETHERMOORE/dispatches \
 - `working_directory` is resolved relative to the repo root on the runner.
 - `install_mode=auto` tries `requirements.txt`, editable Python install, and
   `npm install` when relevant files exist.
+- `artifact_glob` is optional. Leave it empty unless you want extra artifacts
+  beyond the remote-worker logs and metadata.
 - If the command fails, the workflow still uploads logs and artifacts, then
   exits nonzero at the end.

--- a/scripts/system/github_remote_worker.py
+++ b/scripts/system/github_remote_worker.py
@@ -141,7 +141,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Dependency bootstrap strategy",
     )
     dispatch.add_argument("--working-directory", default=".", help="Working directory relative to repo root")
-    dispatch.add_argument("--artifact-glob", default="artifacts/**", help="Additional files or globs to upload")
+    dispatch.add_argument("--artifact-glob", default="", help="Additional files or globs to upload")
     dispatch.add_argument("--ref", help="Git ref or branch to run the workflow on; defaults to the remote repo default branch")
     dispatch.add_argument("--watch", action="store_true", help="Watch the dispatched run until completion")
     dispatch.add_argument("--poll-seconds", type=int, default=10, help="Polling interval for watch mode")

--- a/workflows/n8n/github_remote_worker_payload.sample.json
+++ b/workflows/n8n/github_remote_worker_payload.sample.json
@@ -6,6 +6,6 @@
     "python_version": "3.11",
     "install_mode": "auto",
     "working_directory": ".",
-    "artifact_glob": "artifacts/**"
+    "artifact_glob": ""
   }
 }


### PR DESCRIPTION
## What changed
Tightens the remote worker artifact defaults so a normal run uploads only `artifacts/remote-worker/**` unless the operator explicitly passes an additional artifact glob.

## Why
The first live verification run succeeded, but it also uploaded unrelated repository artifacts because the default extra artifact glob was `artifacts/**`.

## Impact
Default runs stay small and predictable. Operators can still upload more files when needed by setting `artifact_glob` or `--artifact-glob` explicitly.

## Validation
- `/home/issdandavis7795/SCBE-AETHERMOORE/.venv/bin/python -m py_compile /tmp/scbe-push/scripts/system/github_remote_worker.py`
- `/home/issdandavis7795/SCBE-AETHERMOORE/.venv/bin/python /tmp/scbe-push/scripts/system/github_remote_worker.py dispatch "echo artifact scope fixed" --repo issdandavis/SCBE-AETHERMOORE --dry-run`
- `git -C /tmp/scbe-push diff --check`