### PR TITLE
[codex] Update remote worker actions to v6

### DIFF
--- a/.github/workflows/free-remote-worker.yml
+++ b/.github/workflows/free-remote-worker.yml
@@ -62,16 +62,16 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Node.js when package.json exists
         if: ${{ hashFiles('package.json') != '' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: remote-worker-${{ github.run_id }}
           retention-days: 7


### PR DESCRIPTION
## What changed
Updates the remote worker workflow to the current `v6` line of the official GitHub actions used there.

## Why
The live verification runs succeeded, but GitHub warned that the older action pins were still on the deprecated Node 20 runtime path.

## Impact
The workflow stays functionally the same, but aligns with GitHub's current Node 24-based action majors.

## Validation
- `git -C /tmp/scbe-push diff --check`
- reviewed exact workflow diff for `.github/workflows/free-remote-worker.yml`
- live verification will be rerun on `main` immediately after merge