### PR TITLE
fix(ci): Black formatting on test_scbe_code_eval_smoke.py

### DIFF
--- a/tests/benchmark/test_scbe_code_eval_smoke.py
+++ b/tests/benchmark/test_scbe_code_eval_smoke.py
@@ -15,7 +15,9 @@ def test_scbe_code_eval_smoke():
 
     assert len(records) >= 4
     assert summary["total"] == len(records)
-    assert summary["decision_counts"]["ALLOW"] + summary["decision_counts"]["QUARANTINE"] + summary["decision_counts"]["DENY"] == len(records)
+    assert summary["decision_counts"]["ALLOW"] + summary["decision_counts"]["QUARANTINE"] + summary["decision_counts"][
+        "DENY"
+    ] == len(records)
     assert summary["final_pass_rate"] >= summary["baseline_pass_rate"]
     assert any(record.retry_used for record in records)
     assert any(record.final_checks["tests_passed"] for record in records)


### PR DESCRIPTION
## Summary
- Wraps a 120+ char line in `tests/benchmark/test_scbe_code_eval_smoke.py` to satisfy Black
- Unblocks the **Lint and Format Check** job that failed on main (run 24313334537)

## Root cause
PR #989 introduced this file without running `black --line-length 120` first.

## Test plan
- [ ] CI `Lint and Format Check` job passes on this PR
- [ ] No functional change — pure formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)