### PR TITLE
fix(codeql): wire path filters and resolve TypeScript no-unused-vars

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -21,3 +21,5 @@ paths-ignore:
   - kindle-app/android/capacitor-cordova-android-plugins/**
   - .n8n_local_iso/**
   - SCBE-AETHERMOORE-v3.0.0/**
+  - docs-build-smoke/**
+  - ai-ide/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,12 +74,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        config-file: ./.github/codeql/codeql-config.yml
 
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above

--- a/src/fleet/juggling-scheduler.ts
+++ b/src/fleet/juggling-scheduler.ts
@@ -28,7 +28,6 @@
 import {
   FleetAgent,
   GovernanceTier,
-  GOVERNANCE_TIERS,
   TaskPriority,
   PRIORITY_WEIGHTS,
 } from './types';
@@ -707,7 +706,6 @@ export class JugglingScheduler {
 
   /** Get current scheduler health metrics */
   getMetrics(): SchedulerMetrics {
-    const now = Date.now();
     const allCapsules = Array.from(this.capsules.values());
 
     const inFlight = allCapsules.filter((c) => c.state === FlightState.THROWN).length;
@@ -790,7 +788,7 @@ export class JugglingScheduler {
     if (!capsule) return '';
 
     const parts: string[] = [];
-    for (const [agentId, , state] of capsule.provenance) {
+    for (const [_agentId, , state] of capsule.provenance) {
       if (state === FlightState.CAUGHT) {
         parts.push(`${capsule.arcHeight}`);
       } else if (state === FlightState.VALIDATING) {

--- a/src/harmonic/sheafCohomology.ts
+++ b/src/harmonic/sheafCohomology.ts
@@ -1819,7 +1819,7 @@ export function createUnitIntervalLattice(n: number): ConvenienceLattice<number>
 /** Build a CellComplex from vertex ID strings and edge pairs */
 export function buildComplex(vertexIds: string[], edges: [string, string][]): CellComplex {
   const vertices: CellVertex[] = vertexIds.map((id) => ({ id }));
-  const cellEdges: CellEdge[] = edges.map(([src, tgt], i) => ({
+  const cellEdges: CellEdge[] = edges.map(([src, tgt], _i) => ({
     id: `e-${src}-${tgt}`,
     source: src,
     target: tgt,

--- a/src/selfHealing/deepHealing.ts
+++ b/src/selfHealing/deepHealing.ts
@@ -1,7 +1,7 @@
 import { Failure } from './types.js';
 
 export class DeepHealing {
-  async diagnose(failure: Failure) {
+  async diagnose(_failure: Failure) {
     // Multi-agent roundtable placeholder
     const approaches = ['refactor_logic', 'rewrite_integration', 'add_idempotency'];
     return { plan: approaches, branch: `fix/deep-${Math.random().toString(36).slice(2, 10)}` };

--- a/src/selfHealing/quickFixBot.ts
+++ b/src/selfHealing/quickFixBot.ts
@@ -1,7 +1,7 @@
 import { Failure } from './types.js';
 
 export class QuickFixBot {
-  async attemptFix(failure: Failure) {
+  async attemptFix(_failure: Failure) {
     // Heuristics: increase retry, adjust params, flip fallback
     const actions = ['increase_retry', 'adjust_timeout', 'enable_fallback'];
     return { success: false, actions, branch: `hotfix/quick-${Date.now()}` };

--- a/src/spiralverse/types.ts
+++ b/src/spiralverse/types.ts
@@ -25,6 +25,7 @@ export type PolicyLevel = 'standard' | 'strict' | 'secret' | 'critical';
  *
  * @template T - Payload type (must be JSON-serializable)
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface RWP2MultiEnvelope<T = Record<string, unknown>> {
   /** Protocol version (always "2.1") */
   ver: '2.1';

--- a/tests/L2-unit/sheafCohomology.unit.test.ts
+++ b/tests/L2-unit/sheafCohomology.unit.test.ts
@@ -33,18 +33,15 @@ import {
   convHarmonicFlow as harmonicFlow,
   tarskiCohomology0,
   pseudoCoboundary,
-  tarskiLaplacian1,
   tarskiCohomology1,
   // Consensus
   analyzeConsensus,
-  riskConsensusSheaf,
   governanceConsensusSheaf,
   riskConsensus,
   consensusSummary,
   // Types
   type RiskDecision,
   type GovernanceTier,
-  type DimensionalState,
   type ConvenienceLattice,
 } from '../../src/harmonic/sheafCohomology.js';
 

--- a/tests/crypto/kms.test.ts
+++ b/tests/crypto/kms.test.ts
@@ -6,7 +6,7 @@
  * Tests for KMS/HSM master key retrieval and environment enforcement.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { getMasterKey } from '../../src/crypto/kms.js';
 
 describe('KMS getMasterKey', () => {

--- a/tests/governance/offline_mode.test.ts
+++ b/tests/governance/offline_mode.test.ts
@@ -18,7 +18,6 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { sha512 } from '@noble/hashes/sha2.js';
 import { ml_dsa65 } from '@noble/post-quantum/ml-dsa.js';
 import {
   evaluateTrustState,


### PR DESCRIPTION
## Summary

- Wire CodeQL Advanced (`codeql.yml`) to use `codeql-config.yml` path filters so it respects the same `paths-ignore` as `codeql-analysis.yml`; add `docs-build-smoke/**` and `ai-ide/**` to exclusions
- Remove/prefix unused TypeScript variables and imports flagged by CodeQL across `src/` and `tests/`:
  - `juggling-scheduler.ts`: remove `GOVERNANCE_TIERS` import, drop unused `now` in `getMetrics`, prefix `agentId` → `_agentId`
  - `sheafCohomology.ts`: prefix unused map index `_i`
  - `deepHealing.ts` / `quickFixBot.ts`: prefix unused `failure` param → `_failure`
  - `spiralverse/types.ts`: suppress eslint for intentionally unused generic `T` on `RWP2MultiEnvelope`
  - `tests/crypto/kms.test.ts`: remove unused `vi` import
  - `tests/governance/offline_mode.test.ts`: remove unused `sha512` import
  - `tests/L2-unit/sheafCohomology.unit.test.ts`: remove three unused imports (`tarskiLaplacian1`, `riskConsensusSheaf`, `DimensionalState`)

Closes #973

## Test plan
- [ ] CI passes (TypeScript build + lint + tests)
- [ ] CodeQL Advanced no longer scans `docs-build-smoke/` or `ai-ide/`
- [ ] No new `no-unused-vars` alerts in affected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)