### PR TITLE
fix(ci): bump TypeScript to ^6.0.2 and fix Prettier formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "scbe-aethermoore",
       "version": "4.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.1013.0",
@@ -34,7 +35,7 @@
         "rimraf": "^6.1.3",
         "ts-node": "^10.9.2",
         "typedoc": "^0.28.18",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "vitest": "^4.1.1",
         "ws": "^8.20.0"
       },
@@ -6803,9 +6804,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -188,11 +188,11 @@
     "rimraf": "^6.1.3",
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.18",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "vitest": "^4.1.1",
     "ws": "^8.20.0"
   },
   "overrides": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/src/fleet/dtn-bundle-factory.ts
+++ b/src/fleet/dtn-bundle-factory.ts
@@ -235,11 +235,7 @@ export interface PipelineNetworkConfig {
  * Occlusion can be scheduled to simulate context blackouts at specific layers.
  */
 export function createPipelineNetwork(config: PipelineNetworkConfig = {}): DTNNetworkSimulator {
-  const {
-    storeCapacity = 500,
-    bandwidth = 10,
-    skipConnections = true,
-  } = config;
+  const { storeCapacity = 500, bandwidth = 10, skipConnections = true } = config;
 
   const sim = new DTNNetworkSimulator();
 
@@ -253,7 +249,8 @@ export function createPipelineNetwork(config: PipelineNetworkConfig = {}): DTNNe
     sim.addContactWindow(
       PIPELINE_LAYERS[i],
       PIPELINE_LAYERS[i + 1],
-      1, 10000, // Open for 10000 steps
+      1,
+      10000, // Open for 10000 steps
       bandwidth
     );
   }
@@ -414,7 +411,15 @@ export class DTNBundleFactory {
     // Check if fragmentation needed
     if (payloadStr.length > this.config.fragmentThreshold) {
       return this.fragmentTask(
-        task, source, destination, tongue, priority, d_H, pd, assumptions, contingencies
+        task,
+        source,
+        destination,
+        tongue,
+        priority,
+        d_H,
+        pd,
+        assumptions,
+        contingencies
       );
     }
 
@@ -500,7 +505,10 @@ export class DTNBundleFactory {
 
     // Sort by priority (critical first)
     const priorityOrder: Record<TaskPriority, number> = {
-      critical: 0, high: 1, medium: 2, low: 3,
+      critical: 0,
+      high: 1,
+      medium: 2,
+      low: 3,
     };
     const sorted = [...tasks].sort(
       (a, b) => (priorityOrder[a.priority] ?? 2) - (priorityOrder[b.priority] ?? 2)
@@ -607,9 +615,7 @@ export class DTNBundleFactory {
       expired,
       corrupted,
       layerTelemetry: this.pipeline.getNodeTelemetry(),
-      deliveryRate: this.allBundles.length > 0
-        ? delivered.length / this.allBundles.length
-        : 0,
+      deliveryRate: this.allBundles.length > 0 ? delivered.length / this.allBundles.length : 0,
       steps,
     };
   }
@@ -652,7 +658,7 @@ export class DTNBundleFactory {
     d_H: number,
     pd: number,
     assumptions: string[],
-    contingencies: string[],
+    contingencies: string[]
   ): BundleFactoryResult {
     const payloadStr = JSON.stringify(task.input);
     const chunks: string[] = [];
@@ -730,10 +736,10 @@ export class DTNBundleFactory {
     // Skip connections: L1→L5, L5→L12, L8→L13
     let current = srcIdx;
     const skips: Array<[number, number]> = [
-      [0, 4],   // L1 → L5
-      [4, 11],  // L5 → L12
-      [7, 12],  // L8 → L13
-      [0, 12],  // L1 → L13 (emergency)
+      [0, 4], // L1 → L5
+      [4, 11], // L5 → L12
+      [7, 12], // L8 → L13
+      [0, 12], // L1 → L13 (emergency)
     ];
 
     while (current < dstIdx) {

--- a/src/fleet/dtn-bundle.ts
+++ b/src/fleet/dtn-bundle.ts
@@ -187,7 +187,7 @@ export function createBundle(
   destination: string,
   payload: unknown,
   tongue: BundleTongue,
-  options: CreateBundleOptions = {},
+  options: CreateBundleOptions = {}
 ): DTNBundle {
   const d_H = options.hyperbolicDistance ?? 0.1;
   const pd = options.perturbationDensity ?? 0.0;
@@ -323,14 +323,20 @@ export interface ContactWindow {
 export class ContactGraph {
   private windows: ContactWindow[] = [];
 
-  addWindow(from: string, to: string, openStep: number, closeStep: number, bandwidth: number): void {
+  addWindow(
+    from: string,
+    to: string,
+    openStep: number,
+    closeStep: number,
+    bandwidth: number
+  ): void {
     this.windows.push({ fromNode: from, toNode: to, openStep, closeStep, bandwidth });
   }
 
   /** Get active windows from a given node at the current step */
   getActiveWindows(fromNode: string, currentStep: number): ContactWindow[] {
     return this.windows.filter(
-      (w) => w.fromNode === fromNode && currentStep >= w.openStep && currentStep <= w.closeStep,
+      (w) => w.fromNode === fromNode && currentStep >= w.openStep && currentStep <= w.closeStep
     );
   }
 
@@ -442,7 +448,7 @@ export class DTNNetworkSimulator {
     to: string,
     openStep: number,
     closeStep: number,
-    bandwidth: number,
+    bandwidth: number
   ): void {
     this.graph.addWindow(from, to, openStep, closeStep, bandwidth);
   }

--- a/src/fleet/juggling-scheduler.ts
+++ b/src/fleet/juggling-scheduler.ts
@@ -25,12 +25,7 @@
  *   7. Ledger catches, not just throws
  */
 
-import {
-  FleetAgent,
-  GovernanceTier,
-  TaskPriority,
-  PRIORITY_WEIGHTS,
-} from './types';
+import { FleetAgent, GovernanceTier, TaskPriority, PRIORITY_WEIGHTS } from './types';
 
 // ---------------------------------------------------------------------------
 // Enums & Constants

--- a/src/geosealCompass.ts
+++ b/src/geosealCompass.ts
@@ -52,12 +52,12 @@ const EPSILON = 1e-8;
 
 /** Sacred Tongue compass bearings (radians, evenly spaced at π/3) */
 export const COMPASS_BEARINGS: Record<string, number> = {
-  KO: 0.0,                    // Kor'aelin — North (Control)
-  AV: Math.PI / 3,            // Avali — NE (Transport)
-  RU: (2 * Math.PI) / 3,      // Runethic — SE (Policy)
-  CA: Math.PI,                 // Cassisivadan — South (Compute)
-  UM: (4 * Math.PI) / 3,      // Umbroth — SW (Privacy)
-  DR: (5 * Math.PI) / 3,      // Draumric — NW (Integrity)
+  KO: 0.0, // Kor'aelin — North (Control)
+  AV: Math.PI / 3, // Avali — NE (Transport)
+  RU: (2 * Math.PI) / 3, // Runethic — SE (Policy)
+  CA: Math.PI, // Cassisivadan — South (Compute)
+  UM: (4 * Math.PI) / 3, // Umbroth — SW (Privacy)
+  DR: (5 * Math.PI) / 3, // Draumric — NW (Integrity)
 };
 
 /** Tongue phi weights (L3 Langues Weighting System) */
@@ -273,7 +273,7 @@ export function tongueAnchorPosition(tongue: string, dimension: number = 6): num
 export function bearingToPosition(
   bearing: CompassBearing,
   radius: number = 0.5,
-  dimension: number = 6,
+  dimension: number = 6
 ): number[] {
   const pos = new Array(dimension).fill(0);
   pos[0] = radius * Math.cos(bearing.angle);
@@ -294,7 +294,7 @@ export function createWaypoint(
   position: number[],
   phase: number | null = null,
   time: number = 0,
-  tongue?: string,
+  tongue?: string
 ): Waypoint {
   // Ensure position is inside the ball
   const safePos = clampToBall([...position], 0.99);
@@ -322,7 +322,7 @@ export function createWaypoint(
 export function createTongueWaypoint(
   tongue: string,
   time: number = 0,
-  dimension: number = 6,
+  dimension: number = 6
 ): Waypoint {
   const bearing = COMPASS_BEARINGS[tongue];
   if (bearing === undefined) throw new Error(`Unknown tongue: ${tongue}`);
@@ -333,7 +333,7 @@ export function createTongueWaypoint(
     tongueAnchorPosition(tongue, dimension),
     bearing,
     time,
-    tongue,
+    tongue
   );
 }
 
@@ -350,11 +350,7 @@ export function createTongueWaypoint(
  * A1: Unitarity — geodesic preserves norm through the manifold.
  * A2: Locality — all points remain inside the ball.
  */
-export function geodesicInterpolate(
-  p: number[],
-  q: number[],
-  steps: number = 5,
-): number[][] {
+export function geodesicInterpolate(p: number[], q: number[], steps: number = 5): number[][] {
   if (steps < 2) return [p, q];
 
   const points: number[][] = [p];
@@ -396,7 +392,7 @@ export function buildSegment(
   from: Waypoint,
   to: Waypoint,
   geodesicResolution: number = 5,
-  perturbationDensity: number = 0.0,
+  perturbationDensity: number = 0.0
 ): RouteSegment {
   const distance = hyperbolicDistance(from.position, to.position);
   const bearing = computeBearing(from.position, to.position);
@@ -407,11 +403,7 @@ export function buildSegment(
   const effectivePD = perturbationDensity + phaseDev * 0.5;
   const govScore = segmentGovernanceScore(distance, effectivePD);
 
-  const geodesicPoints = geodesicInterpolate(
-    from.position,
-    to.position,
-    geodesicResolution,
-  );
+  const geodesicPoints = geodesicInterpolate(from.position, to.position, geodesicResolution);
 
   return {
     from,
@@ -438,13 +430,13 @@ const DEFAULT_MIN_GOVERNANCE = 0.3;
 export function planDirectRoute(
   origin: Waypoint,
   destination: Waypoint,
-  options: RoutePlanOptions = {},
+  options: RoutePlanOptions = {}
 ): Route {
   const segment = buildSegment(
     origin,
     destination,
     options.geodesicResolution ?? 5,
-    options.perturbationDensity ?? 0.0,
+    options.perturbationDensity ?? 0.0
   );
 
   const minGov = options.minGovernanceScore ?? DEFAULT_MIN_GOVERNANCE;
@@ -469,10 +461,7 @@ export function planDirectRoute(
  *
  * A3: Causality — waypoints must be in temporal order.
  */
-export function planRoute(
-  waypoints: Waypoint[],
-  options: RoutePlanOptions = {},
-): Route {
+export function planRoute(waypoints: Waypoint[], options: RoutePlanOptions = {}): Route {
   if (waypoints.length < 2) {
     throw new Error('Route requires at least 2 waypoints');
   }
@@ -522,7 +511,7 @@ export function planRoute(
 export function autoRoute(
   origin: Waypoint,
   destination: Waypoint,
-  options: RoutePlanOptions = {},
+  options: RoutePlanOptions = {}
 ): Route {
   const minGov = options.minGovernanceScore ?? DEFAULT_MIN_GOVERNANCE;
   const maxHops = options.maxHops ?? 14;
@@ -536,9 +525,10 @@ export function autoRoute(
   const bearing = computeBearing(origin.position, destination.position);
 
   // Rank tongues by affinity to the travel direction
-  const rankedTongues = TONGUES
-    .map((t) => ({ tongue: t, affinity: bearing.tongueAffinities[t] }))
-    .sort((a, b) => b.affinity - a.affinity);
+  const rankedTongues = TONGUES.map((t) => ({
+    tongue: t,
+    affinity: bearing.tongueAffinities[t],
+  })).sort((a, b) => b.affinity - a.affinity);
 
   // Build intermediate waypoints through highest-affinity tongues
   // Time is interpolated linearly between origin and destination
@@ -556,7 +546,7 @@ export function autoRoute(
       anchorPos,
       COMPASS_BEARINGS[t],
       origin.time + timeStep * (i + 1),
-      t,
+      t
     );
     intermediates.push(wp);
   }
@@ -625,10 +615,7 @@ function greedyPrune(waypoints: Waypoint[], options: RoutePlanOptions): Waypoint
  *
  * A3: Causality — only forward-time routes are valid.
  */
-export function applyTemporalWindows(
-  route: Route,
-  windows: TemporalWindow[],
-): Route {
+export function applyTemporalWindows(route: Route, windows: TemporalWindow[]): Route {
   const updatedSegments = route.segments.map((seg) => {
     // Check if segment falls within any active window
     const segStart = seg.from.time;
@@ -639,9 +626,7 @@ export function applyTemporalWindows(
       return { ...seg, governanceScore: 0 };
     }
 
-    const validWindow = windows.find(
-      (w) => segStart >= w.openTime && segEnd <= w.closeTime,
-    );
+    const validWindow = windows.find((w) => segStart >= w.openTime && segEnd <= w.closeTime);
 
     if (!validWindow) {
       // No window — segment is not temporally valid
@@ -649,8 +634,7 @@ export function applyTemporalWindows(
     }
 
     // Bonus governance if segment's tongue matches window's resonant tongue
-    const tongueBonus =
-      seg.bearing.dominantTongue === validWindow.resonantTongue ? 0.1 : 0;
+    const tongueBonus = seg.bearing.dominantTongue === validWindow.resonantTongue ? 0.1 : 0;
 
     return {
       ...seg,
@@ -660,8 +644,7 @@ export function applyTemporalWindows(
 
   const minGov = Math.min(...updatedSegments.map((s) => s.governanceScore));
   const avgGov =
-    updatedSegments.reduce((sum, s) => sum + s.governanceScore, 0) /
-    updatedSegments.length;
+    updatedSegments.reduce((sum, s) => sum + s.governanceScore, 0) / updatedSegments.length;
 
   return {
     ...route,
@@ -694,8 +677,7 @@ export function triadicTemporalDistance(route: Route): number {
 
   // Immediate: average phase deviation across segments
   const immediate =
-    route.segments.reduce((sum, s) => sum + s.phaseDeviation, 0) /
-    route.segments.length;
+    route.segments.reduce((sum, s) => sum + s.phaseDeviation, 0) / route.segments.length;
 
   // Medium: variance of governance scores in rolling 3-segment windows
   let medium = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,19 +114,34 @@ const INJECTION_PATTERNS: [number, string][] = [
 // ── Internal math ─────────────────────────────────────────────────────────────
 
 function _byteProfile(text: string): {
-  alpha: number; digit: number; space: number;
-  punct: number; ctrl: number; highbyte: number; n: number;
+  alpha: number;
+  digit: number;
+  space: number;
+  punct: number;
+  ctrl: number;
+  highbyte: number;
+  n: number;
 } {
   const buf = Buffer.from(text, 'utf8');
   const n = buf.length;
-  let alpha = 0, digit = 0, space = 0, punct = 0, ctrl = 0, highbyte = 0;
+  let alpha = 0,
+    digit = 0,
+    space = 0,
+    punct = 0,
+    ctrl = 0,
+    highbyte = 0;
   for (let i = 0; i < n; i++) {
     const b = buf[i];
     if ((b >= 65 && b <= 90) || (b >= 97 && b <= 122)) alpha++;
     else if (b >= 48 && b <= 57) digit++;
     else if (b === 32 || b === 9 || b === 10 || b === 13) space++;
-    else if ((b >= 33 && b <= 47) || (b >= 58 && b <= 64) ||
-             (b >= 91 && b <= 96) || (b >= 123 && b <= 126)) punct++;
+    else if (
+      (b >= 33 && b <= 47) ||
+      (b >= 58 && b <= 64) ||
+      (b >= 91 && b <= 96) ||
+      (b >= 123 && b <= 126)
+    )
+      punct++;
     else if (b < 32 && b !== 9 && b !== 10 && b !== 13) ctrl++;
     else if (b > 127) highbyte++;
   }
@@ -141,7 +156,10 @@ function _shannon(text: string): number {
   if (n === 0) return 0;
   let h = 0;
   for (const f of freq) {
-    if (f > 0) { const p = f / n; h -= p * Math.log2(p); }
+    if (f > 0) {
+      const p = f / n;
+      h -= p * Math.log2(p);
+    }
   }
   return h;
 }
@@ -207,7 +225,15 @@ export function scan(text: string): ScanResult {
   const digest = createHash('sha256').update(raw).digest('hex');
 
   if (n === 0) {
-    return { decision: 'DENY', score: 0, d_star: 0, phase_deviation: 2, x_poincare: 0, input_len: 0, digest };
+    return {
+      decision: 'DENY',
+      score: 0,
+      d_star: 0,
+      phase_deviation: 2,
+      x_poincare: 0,
+      input_len: 0,
+      digest,
+    };
   }
 
   const dStar = _hyperbolicDistance(text);

--- a/src/spiralverse/data_factory.ts
+++ b/src/spiralverse/data_factory.ts
@@ -36,7 +36,7 @@ class XorShift32 {
 
   constructor(seed: number) {
     // avoid zero-state lockup
-    this.state = (seed >>> 0) || 0x6d2b79f5;
+    this.state = seed >>> 0 || 0x6d2b79f5;
   }
 
   nextU32(): number {
@@ -139,7 +139,9 @@ export function generateSyntheticConversationV2Wire(params: {
 
     const vr = verifyRoundtableV2Wire(env, keyring, { policy });
     if (!vr.valid) {
-      throw new Error(`Synthetic envelope failed verification at step ${i}: ${vr.error ?? 'unknown error'}`);
+      throw new Error(
+        `Synthetic envelope failed verification at step ${i}: ${vr.error ?? 'unknown error'}`
+      );
     }
 
     envelopes.push(env);

--- a/src/spiralverse/index.ts
+++ b/src/spiralverse/index.ts
@@ -56,7 +56,6 @@ export interface VerifyResult {
   error?: string;
 }
 
-
 /** Options for signing */
 export interface SignOptions {
   kid?: string;
@@ -144,7 +143,6 @@ function toBase64Url(buf: Buffer): string {
 function fromBase64Url(s: string): Buffer {
   return Buffer.from(s, 'base64url');
 }
-
 
 /**
  * Create HMAC-SHA256 signature
@@ -440,7 +438,12 @@ export function suggestPolicy(action: string): PolicyLevel {
   return ACTION_POLICIES[normalizedAction] ?? 'standard';
 }
 
-export type { RWP2WireEnvelope, RWP2WireSig, RWP2WireTongue, VerifyWireResult } from './rwp_v2_wire';
+export type {
+  RWP2WireEnvelope,
+  RWP2WireSig,
+  RWP2WireTongue,
+  VerifyWireResult,
+} from './rwp_v2_wire';
 export { clearWireNonceCache, signRoundtableV2Wire, verifyRoundtableV2Wire } from './rwp_v2_wire';
 export { generateSyntheticConversationV2Wire } from './data_factory';
 

--- a/src/spiralverse/rwp_v2_wire.ts
+++ b/src/spiralverse/rwp_v2_wire.ts
@@ -118,7 +118,10 @@ function verifySignature(key: Buffer, data: Buffer, signature: string): boolean 
  *
  * Includes `kid` in the transcript when present (empty-string otherwise).
  */
-function createWireSignatureData(env: Omit<RWP2WireEnvelope, 'sigs'>, signingTongue: TongueID): Buffer {
+function createWireSignatureData(
+  env: Omit<RWP2WireEnvelope, 'sigs'>,
+  signingTongue: TongueID
+): Buffer {
   const kid = env.kid ?? '';
   const data = `${env.ver}.${env.tongue}.${signingTongue}.${env.aad}.${env.payload}.${env.nonce}.${env.ts}.${kid}`;
   return Buffer.from(data, 'utf8');
@@ -271,9 +274,13 @@ export function verifyRoundtableV2Wire(
       // allow non-JSON payloads
     }
 
-    return { valid: true, validTongues, payloadBytes, ...(payloadJson !== undefined ? { payload: payloadJson } : {}) };
+    return {
+      valid: true,
+      validTongues,
+      payloadBytes,
+      ...(payloadJson !== undefined ? { payload: payloadJson } : {}),
+    };
   } catch (err) {
     return { valid: false, validTongues, error: err instanceof Error ? err.message : String(err) };
   }
 }
-

--- a/tests/cross-language/gyroscopic_interlattice_parity.test.ts
+++ b/tests/cross-language/gyroscopic_interlattice_parity.test.ts
@@ -31,7 +31,11 @@ function pyEval(expr: string): string {
   try {
     return execSync(`python ${TMP_SCRIPT}`, { cwd: CWD, encoding: 'utf-8' }).trim();
   } finally {
-    try { unlinkSync(TMP_SCRIPT); } catch { /* ignore */ }
+    try {
+      unlinkSync(TMP_SCRIPT);
+    } catch {
+      /* ignore */
+    }
   }
 }
 
@@ -47,9 +51,7 @@ describe('Gyroscopic Interlattice Cross-Language Parity', () => {
     const couples = allCouplings();
     for (const c of couples) {
       const tsJ = couplingStrength(c.tongueA, c.tongueB);
-      const pyJ = parseFloat(
-        pyEval(`coupling_strength('${c.tongueA}', '${c.tongueB}')`)
-      );
+      const pyJ = parseFloat(pyEval(`coupling_strength('${c.tongueA}', '${c.tongueB}')`));
       // Allow small floating point differences
       if (tsJ > 1e-6) {
         expect(tsJ).toBeCloseTo(pyJ, 6);

--- a/tests/fleet/dtn-bundle-factory.test.ts
+++ b/tests/fleet/dtn-bundle-factory.test.ts
@@ -348,8 +348,9 @@ describe('DTN Bundle Factory', () => {
       expect(factory.totalBundles).toBe(1);
 
       const report = factory.simulate(20);
-      expect(report.delivered.length + report.pending.length + report.expired.length)
-        .toBe(factory.totalBundles);
+      expect(report.delivered.length + report.pending.length + report.expired.length).toBe(
+        factory.totalBundles
+      );
       expect(report.layerTelemetry).toHaveLength(14);
       expect(report.steps).toBe(20);
     });
@@ -364,9 +365,7 @@ describe('DTN Bundle Factory', () => {
       const report = factory.simulate(30);
       expect(report.deliveryRate).toBeGreaterThanOrEqual(0);
       expect(report.deliveryRate).toBeLessThanOrEqual(1);
-      expect(report.delivered.length).toBe(
-        Math.round(report.deliveryRate * factory.totalBundles)
-      );
+      expect(report.delivered.length).toBe(Math.round(report.deliveryRate * factory.totalBundles));
     });
 
     it('survives occlusion and delivers after lift', () => {
@@ -429,7 +428,8 @@ describe('DTN Bundle Factory', () => {
   describe('create', () => {
     it('creates a bundle from raw payload without a fleet task', () => {
       const result = factory.create(
-        'L5', 'L12',
+        'L5',
+        'L12',
         { telemetry: 'coherence_score', value: 0.95 },
         'UM',
         { priority: 'high' }

--- a/tests/harmonic/geosealCompass.test.ts
+++ b/tests/harmonic/geosealCompass.test.ts
@@ -240,7 +240,7 @@ describe('GeoSeal Compass — Route Planning', () => {
 
   it('multi-hop route through all 6 tongues', () => {
     const waypoints = ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'].map((t, i) =>
-      createTongueWaypoint(t, i, DIM),
+      createTongueWaypoint(t, i, DIM)
     );
     const route = planRoute(waypoints);
     expect(route.segments).toHaveLength(5);
@@ -312,7 +312,7 @@ describe('GeoSeal Compass — Temporal Windows', () => {
     // The original and filtered should differ if tongue matches
     // Either way, the filtered score should be >= original
     expect(filtered.segments[0].governanceScore).toBeGreaterThanOrEqual(
-      route.segments[0].governanceScore,
+      route.segments[0].governanceScore
     );
   });
 });
@@ -323,9 +323,7 @@ describe('GeoSeal Compass — Temporal Windows', () => {
 
 describe('GeoSeal Compass — Triadic Temporal Distance', () => {
   it('triadic distance is non-negative', () => {
-    const waypoints = ['KO', 'AV', 'RU', 'CA'].map((t, i) =>
-      createTongueWaypoint(t, i, DIM),
-    );
+    const waypoints = ['KO', 'AV', 'RU', 'CA'].map((t, i) => createTongueWaypoint(t, i, DIM));
     const route = planRoute(waypoints);
     const d = triadicTemporalDistance(route);
     expect(d).toBeGreaterThanOrEqual(0);

--- a/tests/harmonic/gyroscopicInterlattice.test.ts
+++ b/tests/harmonic/gyroscopicInterlattice.test.ts
@@ -189,9 +189,7 @@ describe('Nash Equation of Motion (First-Order Dynamics)', () => {
   });
 
   it('produces nonzero derivative for nonzero state', () => {
-    const sublattices = TONGUE_LABELS.map((t) =>
-      createSublattice(t, { real: 0.1, imag: 0.05 })
-    );
+    const sublattices = TONGUE_LABELS.map((t) => createSublattice(t, { real: 0.1, imag: 0.05 }));
     const couples = allCouplings();
     const coupleMap = new Map<string, (typeof couples)[0]>();
     for (const c of couples) {
@@ -212,7 +210,10 @@ describe('Nash Equation of Motion (First-Order Dynamics)', () => {
 
   it('evolution preserves finite state (no blow-up for small dt)', () => {
     const sublattices = TONGUE_LABELS.map((t) =>
-      createSublattice(t, { real: 0.1 * Math.cos(TONGUE_PHASES[t]), imag: 0.1 * Math.sin(TONGUE_PHASES[t]) })
+      createSublattice(t, {
+        real: 0.1 * Math.cos(TONGUE_PHASES[t]),
+        imag: 0.1 * Math.sin(TONGUE_PHASES[t]),
+      })
     );
 
     // Evolve 100 steps at dt=0.001
@@ -297,18 +298,14 @@ describe('L6 Bridge — Gyroscopic Breathing Factor', () => {
   });
 
   it('excited lattice produces breathing factor > 1.0', () => {
-    const sublattices = TONGUE_LABELS.map((t) =>
-      createSublattice(t, { real: 0.5, imag: 0.3 })
-    );
+    const sublattices = TONGUE_LABELS.map((t) => createSublattice(t, { real: 0.5, imag: 0.3 }));
     const b = gyroscopicBreathingFactor(sublattices);
     expect(b).toBeGreaterThan(1.0);
   });
 
   it('breathing factor is clamped to [1.0, 2.0]', () => {
     // Very high energy state
-    const sublattices = TONGUE_LABELS.map((t) =>
-      createSublattice(t, { real: 10.0, imag: 10.0 })
-    );
+    const sublattices = TONGUE_LABELS.map((t) => createSublattice(t, { real: 10.0, imag: 10.0 }));
     const b = gyroscopicBreathingFactor(sublattices);
     expect(b).toBeLessThanOrEqual(2.0);
     expect(b).toBeGreaterThanOrEqual(1.0);
@@ -328,9 +325,7 @@ describe('L6 Bridge — Gyroscopic Breathing Factor', () => {
   });
 
   it('per-tongue breathing factors have 6 elements', () => {
-    const sublattices = TONGUE_LABELS.map((t) =>
-      createSublattice(t, { real: 0.1, imag: 0.1 })
-    );
+    const sublattices = TONGUE_LABELS.map((t) => createSublattice(t, { real: 0.1, imag: 0.1 }));
     const factors = perTongueBreathingFactors(sublattices);
     expect(factors).toHaveLength(6);
     for (const f of factors) {
@@ -340,9 +335,7 @@ describe('L6 Bridge — Gyroscopic Breathing Factor', () => {
   });
 
   it('per-tongue KO factor > DR factor for equal amplitudes', () => {
-    const sublattices = TONGUE_LABELS.map((t) =>
-      createSublattice(t, { real: 0.3, imag: 0.2 })
-    );
+    const sublattices = TONGUE_LABELS.map((t) => createSublattice(t, { real: 0.3, imag: 0.2 }));
     const factors = perTongueBreathingFactors(sublattices);
     // KO (index 0) has fastest precession
     expect(factors[0]).toBeGreaterThan(factors[5]); // DR (index 5)

--- a/tests/openclaw-scbe-system-tools.test.ts
+++ b/tests/openclaw-scbe-system-tools.test.ts
@@ -82,7 +82,7 @@ describe('openclaw scbe system tools plugin', () => {
         workflowTemplate: 'training-center-loop',
         emitActionMap: false,
       },
-      '20260410T050000Z',
+      '20260410T050000Z'
     );
 
     expect(command.command).toBe('py');
@@ -96,7 +96,11 @@ describe('openclaw scbe system tools plugin', () => {
   });
 
   it('defaults octoarms dispatch to dry-run and supports hf provider selection', () => {
-    const cfg = resolvePluginConfig({ repoRoot: 'C:/repo', pythonBin: 'python', defaultProvider: 'hf' });
+    const cfg = resolvePluginConfig({
+      repoRoot: 'C:/repo',
+      pythonBin: 'python',
+      defaultProvider: 'hf',
+    });
     const command = buildOctoarmsDispatchCommand(cfg, {
       task: 'Test Hugging Face agent handler',
       lane: 'hydra-swarm',
@@ -138,7 +142,7 @@ describe('openclaw scbe system tools plugin', () => {
         contextJson: '{"task":"test"}',
         contextVector: '1,0,0,0,0,0',
       },
-      '20260410T050100Z',
+      '20260410T050100Z'
     );
 
     expect(command.command).toBe('py');
@@ -214,7 +218,11 @@ describe('openclaw scbe system tools plugin', () => {
   });
 
   it('builds the OpenClaw HF handler bootstrap command with repo-owned artifact output', () => {
-    const cfg = resolvePluginConfig({ repoRoot: 'C:/repo', pythonBin: 'python', defaultProvider: 'hf' });
+    const cfg = resolvePluginConfig({
+      repoRoot: 'C:/repo',
+      pythonBin: 'python',
+      defaultProvider: 'hf',
+    });
     const command = buildOpenClawHfHandlerBootstrapCommand(
       cfg,
       {
@@ -223,7 +231,7 @@ describe('openclaw scbe system tools plugin', () => {
         task: 'Verify the HF lane',
         executeDispatch: true,
       },
-      '20260410T060000Z',
+      '20260410T060000Z'
     );
 
     expect(command.command).toBe('python');
@@ -296,5 +304,3 @@ describe('openclaw scbe system tools plugin', () => {
     ]);
   });
 });
-
-

--- a/tests/spiralverse/data_factory.v2wire.test.ts
+++ b/tests/spiralverse/data_factory.v2wire.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { randomBytes } from 'crypto';
-import { clearWireNonceCache, generateSyntheticConversationV2Wire, type Keyring } from '../../src/spiralverse';
+import {
+  clearWireNonceCache,
+  generateSyntheticConversationV2Wire,
+  type Keyring,
+} from '../../src/spiralverse';
 
 const testKeyring: Keyring = {
   ko: randomBytes(32),
@@ -64,4 +68,3 @@ describe('generateSyntheticConversationV2Wire', () => {
     expect(a.envelopes).not.toEqual(b.envelopes);
   });
 });
-

--- a/tests/spiralverse/rwp.v2wire.test.ts
+++ b/tests/spiralverse/rwp.v2wire.test.ts
@@ -54,9 +54,16 @@ describe('RWP v2 wire envelopes (ver="2")', () => {
   });
 
   it('verifies valid signatures and decodes JSON payload', () => {
-    const env = signRoundtableV2Wire({ action: 'deploy', ok: true }, 'KO', 'agent=abc', testKeyring, ['KO', 'RU'], {
-      timestamp: Math.floor(Date.now() / 1000),
-    });
+    const env = signRoundtableV2Wire(
+      { action: 'deploy', ok: true },
+      'KO',
+      'agent=abc',
+      testKeyring,
+      ['KO', 'RU'],
+      {
+        timestamp: Math.floor(Date.now() / 1000),
+      }
+    );
 
     const vr = verifyRoundtableV2Wire(env, testKeyring, { policy: 'strict' });
     expect(vr.valid).toBe(true);
@@ -107,4 +114,3 @@ describe('RWP v2 wire envelopes (ver="2")', () => {
     expect(second.error?.toLowerCase()).toContain('nonce');
   });
 });
-


### PR DESCRIPTION
## Summary

- TypeScript 5.9.3 (resolved from `^5.9.3` in lock file) rejects `ignoreDeprecations: "6.0"` with error `TS5103: Invalid value for '--ignoreDeprecations'`
- Bumped `devDependencies.typescript` and `overrides.typescript` from `^5.9.3` → `^6.0.2` in `package.json`
- Ran `npm install` to update `package-lock.json` to TypeScript 6.0.2
- Ran `prettier --write` on 15 TypeScript files flagged by CI lint check after the polly-nav-clean merge

## Test plan

- [x] `tsc --noEmit` exits 0 locally with TypeScript 6.0.2
- [x] `prettier --check` passes on all 15 previously-failing files
- [ ] CI `Test (Node 20)` → `Run type check` should now pass
- [ ] CI `Lint and Format Check` → `Check TypeScript formatting` should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)