### PR TITLE
fix(codeql): add rust/ to CodeQL paths + fix TypeScript/Prettier CI failures

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,6 +5,7 @@ paths:
   - scripts
   - services
   - tests
+  - rust
   - kindle-app/android
   - kindle-app/www
 


### PR DESCRIPTION
## Summary

- **CodeQL Rust failure**: `codeql-config.yml` only listed `src/`, `scripts/`, etc. — Rust source in `rust/scbe_core/` was excluded, causing "no source code seen for Rust" errors. Added `rust/` to the paths list.

## Already merged separately

- TypeScript `^6.0.2` bump (PR #1039) — fixes `TS5103: Invalid value for '--ignoreDeprecations'`
- `check_secrets.py` (PR #1038) — fixes false-alarm secret scan issues

## Test plan

- [x] `rust/scbe_core/src/lib.rs` and `main.rs` exist in repo
- [ ] CodeQL Advanced → Analyze (rust) should now find source and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)