### PR TITLE
docs: add Cursor Cloud development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,3 +172,32 @@ python scripts/apollo/video_review.py review-all
 Review scores: title (structure, length, searchability), description (depth, links, hashtags),
 transcript (speaking rate, vocabulary richness, technical density), tags (count, brand coverage).
 Reports saved to `artifacts/apollo/video_reviews/`.
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Start command | Port | Notes |
+|---------|--------------|------|-------|
+| **FastAPI (core API)** | `SCBE_FORCE_SKIP_LIBOQS=1 PYTHONPATH=. python3 -m uvicorn src.api.main:app --reload --host 0.0.0.0 --port 8000` | 8000 | Main governance/compute API |
+| **Gateway (Express)** | `npm run gateway:build && npm run gateway:serve` | 8080 | TypeScript API gateway (requires build first) |
+
+### Key gotchas
+
+- **`python3` not `python`**: The VM has `python3` on PATH but not `python`. Always use `python3` or `python3 -m ...`.
+- **`~/.local/bin` on PATH**: pip installs (pytest, uvicorn, black, flake8) go to `~/.local/bin`. The update script ensures this is on PATH via `~/.bashrc`.
+- **`SCBE_FORCE_SKIP_LIBOQS=1`**: Always set this when running Python tests or the FastAPI server, since liboqs C bindings are not installed.
+- **`PYTHONPATH`**: Set `PYTHONPATH=.` for pytest and `PYTHONPATH=src:.` for using `scbe_aethermoore` package imports directly.
+- **Pre-existing test failures**: ~28 TS test failures (in `tests/hydra/swarm_governance.test.ts`) and ~51 Python collection errors (missing `agents/`, `hydra/` modules not in this checkout) are pre-existing. Do not count these as regressions.
+- **Python test collection errors**: Many tests under `tests/` import from `hydra.*`, `agents.*`, `experiments.*`, `doc_verifier` which only have placeholder READMEs in this checkout. These tests cannot be collected and should be ignored with `--ignore`.
+- **Scan API "hello world"**: `PYTHONPATH=src:. python3 -c "from scbe_aethermoore import scan; print(scan('hello world'))"` — verifies the core pipeline works.
+
+### Build, lint, test commands (see also CLAUDE.md)
+
+Standard commands per `CLAUDE.md` "Pre-Push Verification" section. Quick reference:
+```bash
+npm run build && npm run lint && npm test          # TypeScript
+SCBE_FORCE_SKIP_LIBOQS=1 PYTHONPATH=. python3 -m pytest tests/ -v --ignore=tests/node_modules -x  # Python (will hit collection errors on agents/hydra modules)
+flake8 --max-line-length 120 src/ tests/           # Python lint
+black --check --target-version py311 --line-length 120 src/ tests/  # Python format check
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add Cursor Cloud specific instructions to `AGENTS.md` so future cloud agents can quickly set up and validate the development environment without rediscovering gotchas.

## Changes

- Added `## Cursor Cloud specific instructions` section to `AGENTS.md` with:
  - Service overview table (FastAPI on port 8000, Gateway on port 8080)
  - Key gotchas: `python3` vs `python`, `~/.local/bin` PATH, `SCBE_FORCE_SKIP_LIBOQS`, `PYTHONPATH` setup
  - Pre-existing test failure documentation (28 TS failures, 51 Python collection errors)
  - Quick-reference build/lint/test commands

## Affected Layers

- [x] Infrastructure / CI / Docker

## Axiom Compliance

- [x] N/A

## Test Plan

- [x] TypeScript tests pass (`npm test`) — 6047/6083 passed (28 pre-existing failures)
- [x] Python tests pass — 7210 passed (51 pre-existing collection errors from missing modules)
- [x] Type check passes (`npm run build` compiles cleanly)
- [x] Lint passes (`npm run lint` and `flake8`)

## Cross-Language Parity

- [x] N/A (single-language change)

## Evidence

Demo output showing the full dev environment working:

[demo_output.log](https://cursor.com/agents/bc-717690e4-39d6-44e3-b365-a806d9155866/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_output.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-717690e4-39d6-44e3-b365-a806d9155866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-717690e4-39d6-44e3-b365-a806d9155866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

