### PR TITLE
fix(ci): route daily repo stats through PR branch

### DIFF
--- a/.github/workflows/daily-repo-stats.yml
+++ b/.github/workflows/daily-repo-stats.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   stats:
@@ -98,7 +99,14 @@ jobs:
               print(f"  {k}: {v:,}" if isinstance(v, int) else f"  {k}: {v}")
           PYEOF
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: peter-evans/create-pull-request@v7
         with:
-          commit_message: "chore(stats): update daily repo stats badges"
-          file_pattern: "docs/static/badges/"
+          add-paths: "docs/static/badges/"
+          branch: "automation/daily-repo-stats"
+          commit-message: "chore(stats): update daily repo stats badges"
+          title: "chore(stats): update daily repo stats badges"
+          body: |
+            Automated daily repo stats badge refresh.
+
+            This workflow updates the generated badge JSON files under `docs/static/badges/`
+            through a pull request so it complies with branch protection on `main`.


### PR DESCRIPTION
## Summary
- replace direct auto-commit to protected main with PR-based badge updates
- add pull-request permission for the workflow
- keep the daily stats badge generation path unchanged

## Why
The Daily Repo Stats workflow was failing after successful badge generation because branch protection rejects direct pushes to main (GH013).

## Testing
- inspected failing run log showing GH013 branch protection rejection
- verified workflow patch is limited to .github/workflows/daily-repo-stats.yml
