### PR TITLE
fix(defensive-mesh): stabilize fallback dataclass path

### DIFF
--- a/python/scbe/defensive_mesh.py
+++ b/python/scbe/defensive_mesh.py
@@ -23,9 +23,8 @@ from urllib.parse import urlparse
 try:
     from agents.antivirus_membrane import scan_text_for_threats, turnstile_action
 except ImportError:
-    from dataclasses import dataclass as _dc
 
-    @_dc
+    @dataclass
     class _ScanResult:
         risk_score: float = 0.0
         reasons: list = None
@@ -49,7 +48,7 @@ try:
     from agents.kernel_antivirus_gate import evaluate_kernel_event
 except ImportError:
 
-    @_dc
+    @dataclass
     class _KernelGateResult:
         kernel_action: str = "ALLOW"
         allowed: bool = True


### PR DESCRIPTION
## Summary
- replace private `_dc` fallback decorator usage with direct `@dataclass`
- keep defensive mesh fallback stubs import-safe when `agents.*` packages are unavailable
- prevent Tier 1 pytest collection from dying on current `main`

## Why
Current `python/scbe/defensive_mesh.py` can raise `NameError: name '_dc' is not defined` in the second fallback block during test collection. That can fail the overnight Tier 1 lane before model/runtime work even starts.

## Validation
- local repro on current `main` failed in `tests/governance/test_atomic_tokenization_and_fusion.py`
- after this patch, that targeted suite passed locally (`15 passed`)
- TS typecheck and `cpse.py` compile preflight also passed on current `main`
