### PR TITLE
fix(ci): add missing jsonschema dependency for overnight pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ hypothesis>=6.100.0
 pytest-hypothesis>=0.1.0
 httpx>=0.27.0
 requests>=2.32.0
+jsonschema>=4.23.0
 # Post-Quantum Cryptography
 # Local: install from main to match native liboqs 0.15.0:
 #   pip install git+https://github.com/open-quantum-safe/liboqs-python.git@main
@@ -41,4 +42,3 @@ lxml>=5.0.0
 
 # Optional: Visualization (for extended demos)
 # matplotlib>=3.5.0
-


### PR DESCRIPTION
## Summary
- add `jsonschema` to `requirements.txt`
- restore current-main `SCBE Overnight Pipeline` jobs that import schema validators during Tier 1 and Tier 3

## Root cause
Current tests and ingestion/training modules import `jsonschema`, but `requirements.txt` did not install it. That breaks the overnight pipeline with `ModuleNotFoundError: No module named 'jsonschema'` in both the core-gates and security lanes.

## Expected effect
- Tier 1 `core-gates` can import routing/ingestion modules again
- Tier 3 `security` can run the schema-driven training tests again

## Validation
- rooted the failure from the current-main GitHub Actions logs for run `24673477667`
- confirmed `requirements.txt` on `main` was missing `jsonschema`
- landed the minimal dependency fix only
