### PR TITLE
fix(neurogolf): make validation imports optional for CI

### DIFF
--- a/src/neurogolf/__init__.py
+++ b/src/neurogolf/__init__.py
@@ -7,7 +7,6 @@ from .ir import StraightLineProgram
 from .onnx_emit import export_program_onnx
 from .solver import SynthesizedSolution, execute_program, synthesize_program
 from .structural_encode import StructuralEncoding, encode_grid_structurally
-from .validate import ValidationReport, validate_submission_model
 
 __all__ = [
     "ARCExample",
@@ -27,6 +26,15 @@ __all__ = [
     "score_from_total_cost",
     "synthesize_program",
     "SynthesizedSolution",
-    "ValidationReport",
-    "validate_submission_model",
 ]
+
+try:
+    from .validate import ValidationReport, validate_submission_model
+except ImportError:  # Optional ONNX dependency for validation-only workflows.
+    ValidationReport = None  # type: ignore[assignment]
+    validate_submission_model = None  # type: ignore[assignment]
+else:
+    __all__.extend([
+        "ValidationReport",
+        "validate_submission_model",
+    ])


### PR DESCRIPTION
## Summary
- stop `neurogolf.arc_io` imports from requiring `onnx`
- keep validation symbols available when the optional ONNX dependency is installed

## Why
The live `SCBE Overnight Pipeline` on `main` was failing Tier 1 core gates during test collection because `tests/test_neurogolf_arc_io.py` imports `neurogolf.arc_io`, which loads `neurogolf.__init__`, which eagerly imported `validate.py` and required `onnx` even though the ARC I/O tests do not use the validation path.

## Effect
- Tier 1 can collect and run ARC I/O tests without installing the full ONNX validation dependency
- validation exports remain present in environments that actually install `onnx`
