### PR TITLE
fix(neurogolf): skip ONNX-only tests when optional deps are absent

### DIFF
--- a/tests/test_neurogolf_onnx_emit.py
+++ b/tests/test_neurogolf_onnx_emit.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from zipfile import ZipFile
 
-import onnx
+import pytest
+
+onnx = pytest.importorskip("onnx")
+pytest.importorskip("torch")
+pytest.importorskip("onnxscript")
 
 from neurogolf.ir import (
     make_copy_color_program,
@@ -40,6 +44,17 @@ def test_build_submission_zip_with_exported_program(tmp_path):
 
     with ZipFile(zip_path) as zf:
         assert zf.namelist() == ["task001.onnx"]
+
+
+def test_build_submission_zip_rejects_noncanonical_arc_hash(tmp_path):
+    onnx_path = tmp_path / "task001.onnx"
+    zip_path = tmp_path / "submission.zip"
+    program = make_shift_color_remap_program(shift_x=1, shift_y=0, mapping={1: 7})
+
+    export_program_onnx(program, onnx_path)
+
+    with pytest.raises(ValueError, match="canonical competition key"):
+        build_submission_zip({"136b0064": onnx_path}, zip_path)
 
 
 def test_export_program_onnx_for_flip_then_remap(tmp_path):

--- a/tests/test_neurogolf_validate.py
+++ b/tests/test_neurogolf_validate.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-import onnx
+import pytest
+
+onnx = pytest.importorskip("onnx")
+pytest.importorskip("torch")
+pytest.importorskip("onnxscript")
 from onnx import TensorProto, helper
 
 from neurogolf.ir import make_multi_shift_color_program


### PR DESCRIPTION
## Summary
- mark NeuroGolf ONNX export/validation tests as optional-dependency tests
- skip them cleanly when `onnx`, `torch`, or `onnxscript` are not installed

## Why
After the package import edge was fixed, the live `SCBE Overnight Pipeline` on `main` still failed Tier 1 core gates because `tests/test_neurogolf_onnx_emit.py` and `tests/test_neurogolf_validate.py` import ONNX tooling directly. Tier 1 does not install the full ONNX export stack, so these tests should skip instead of failing collection.

## Effect
- Tier 1 core gates stays lean
- ONNX-specific tests still run in environments that actually install the ONNX export stack
