### PR TITLE
feat(email): contact form API + agentic email triage

### DIFF
--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -1304,6 +1304,33 @@ async def vault_sync():
 # =========================================================================== #
 
 
+class ContactFormPayload(BaseModel):
+    name: str
+    email: str
+    subject: str
+    message: str
+    page: Optional[str] = None
+
+
+@app.post("/api/contact")
+async def contact_submit(payload: ContactFormPayload):
+    """Receive contact form submissions from the website and notify via email."""
+    try:
+        from scripts.system.email_service import send_contact_notification
+        result = send_contact_notification(
+            name=payload.name,
+            email=payload.email,
+            subject=payload.subject,
+            message=payload.message,
+            page=payload.page,
+        )
+        if result["ok"]:
+            return {"ok": True, "message": "Message sent. We usually reply within 24 hours."}
+        return {"ok": False, "error": result.get("error", "Email delivery failed")}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
 @app.post("/api/ops/check-email")
 async def ops_check_email():
     """Run the Apollo email reader and return classified digests."""

--- a/scripts/apollo/agentic_email_triage.py
+++ b/scripts/apollo/agentic_email_triage.py
@@ -1,0 +1,330 @@
+"""Agentic Email Triage — LLM-powered email routing for SCBE.
+
+Extends Apollo with intelligent classification beyond keyword matching.
+Routes emails to "agentic employees" (specialized dispatch queues) and
+generates draft responses.
+
+Usage:
+    python scripts/apollo/agentic_email_triage.py --run
+    python scripts/apollo/agentic_email_triage.py --run --auto-reply
+    python scripts/apollo/agentic_email_triage.py --dry-run --days 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# Project paths
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+# Load env
+_env = ROOT / "config" / "connector_oauth" / ".env.connector.oauth"
+if _env.exists():
+    for line in _env.read_text().splitlines():
+        if line.strip() and not line.startswith("#") and "=" in line:
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip("\"'"))
+
+
+# ---------------------------------------------------------------------------
+# Agentic Employee Definitions
+# ---------------------------------------------------------------------------
+
+AGENTIC_EMPLOYEES = {
+    "sales": {
+        "name": "Ava (Sales)",
+        "role": "agent.sales",
+        "handles": ["pricing inquiry", "custom project", "enterprise scoping", "pilot application", "partnership"],
+        "tone": "professional, concise, outcome-focused",
+        "actions": ["send pricing sheet", "book scoping call", "send pilot agreement"],
+    },
+    "support": {
+        "name": "Sam (Support)",
+        "role": "agent.support",
+        "handles": ["delivery issue", "missing file", "broken link", "refund request", "purchase help"],
+        "tone": "helpful, patient, solution-oriented",
+        "actions": ["resend delivery", "process refund", "escalate to human"],
+    },
+    "technical": {
+        "name": "Tao (Technical)",
+        "role": "agent.technical",
+        "handles": ["api question", "integration help", "bug report", "self-hosting", "code review request"],
+        "tone": "precise, technical, references docs",
+        "actions": ["link to docs", "provide code snippet", "open GitHub issue"],
+    },
+    "security": {
+        "name": "Sage (Security)",
+        "role": "agent.security",
+        "handles": ["vulnerability report", "penetration test inquiry", "audit request", "compliance question"],
+        "tone": "serious, thorough, process-oriented",
+        "actions": ["acknowledge receipt", "request details", "route to red team"],
+    },
+    "content": {
+        "name": "Cara (Content)",
+        "role": "agent.content",
+        "handles": ["guest post", "interview request", "speaking engagement", "media inquiry"],
+        "tone": "warm, story-oriented, calendar-aware",
+        "actions": ["send media kit", "propose dates", "decline politely"],
+    },
+    "admin": {
+        "name": "Alex (Admin)",
+        "role": "agent.admin",
+        "handles": ["spam", "newsletter signup", "unsubscribe", "generic hello", "unclear intent"],
+        "tone": "neutral, efficient",
+        "actions": ["mark spam", "add to newsletter", "archive"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# LLM Classification (Gemini fallback to local heuristic)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TriageResult:
+    msg_id: str
+    sender: str
+    subject: str
+    agent: str
+    confidence: float
+    summary: str
+    draft_reply: str = ""
+    action: str = ""
+    urgency: str = "normal"  # low, normal, high, critical
+    tongue: str = ""
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+def classify_with_llm(sender: str, subject: str, body: str, api_key: Optional[str] = None) -> dict:
+    """Use Gemini to classify email intent and route to agentic employee.
+
+    Falls back to heuristic if Gemini is unavailable.
+    """
+    api_key = api_key or os.environ.get("GEMINI_API_KEY", "")
+    if not api_key:
+        return classify_heuristic(sender, subject, body)
+
+    try:
+        import google.generativeai as genai
+        genai.configure(api_key=api_key)
+        model = genai.GenerativeModel("gemini-1.5-flash")
+
+        agent_descriptions = "\n".join(
+            f"- {k}: handles {', '.join(v['handles'])}"
+            for k, v in AGENTIC_EMPLOYEES.items()
+        )
+
+        prompt = f"""You are an email triage specialist for SCBE-AETHERMOORE, an AI governance company.
+
+Incoming email:
+From: {sender}
+Subject: {subject}
+Body: {body[:2000]}
+
+Agentic employees available:
+{agent_descriptions}
+
+Classify this email. Respond ONLY with valid JSON in this exact format:
+{{
+  "agent": "<employee_key>",
+  "confidence": 0.0-1.0,
+  "summary": "1-sentence summary",
+  "urgency": "low|normal|high|critical",
+  "action": "recommended next step",
+  "draft_reply": "1-paragraph draft response"
+}}
+"""
+        response = model.generate_content(prompt)
+        text = response.text.strip()
+        # Extract JSON if wrapped in markdown
+        if "```json" in text:
+            text = text.split("```json")[1].split("```")[0].strip()
+        elif "```" in text:
+            text = text.split("```")[1].split("```")[0].strip()
+        return json.loads(text)
+    except Exception as e:
+        print(f"[LLM classification failed: {e}] — falling back to heuristic")
+        return classify_heuristic(sender, subject, body)
+
+
+def classify_heuristic(sender: str, subject: str, body: str) -> dict:
+    """Fallback keyword-based classification (extends Apollo's tongue system)."""
+    text = f"{subject} {body}".lower()
+
+    scores = {}
+    for agent_key, agent in AGENTIC_EMPLOYEES.items():
+        score = 0
+        for keyword in agent["handles"]:
+            if keyword.lower() in text:
+                score += 1
+        scores[agent_key] = score
+
+    best = max(scores, key=scores.get)
+    confidence = min(0.5 + scores[best] * 0.15, 0.95)
+
+    # Urgency heuristics
+    urgency = "normal"
+    if any(w in text for w in ["urgent", "asap", "critical", "breach", "outage"]):
+        urgency = "critical"
+    elif any(w in text for w in ["deadline", "tomorrow", "expiring", "payment due"]):
+        urgency = "high"
+
+    return {
+        "agent": best,
+        "confidence": confidence,
+        "summary": f"Email from {sender} about {subject[:60]}",
+        "urgency": urgency,
+        "action": AGENTIC_EMPLOYEES[best]["actions"][0],
+        "draft_reply": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Triage Runner
+# ---------------------------------------------------------------------------
+
+def run_triage(dry_run: bool = False, days: int = 1, auto_reply: bool = False) -> list[TriageResult]:
+    """Run agentic triage on recent emails.
+
+    Args:
+        dry_run: Classify without dispatching or saving.
+        days: How many days back to look.
+        auto_reply: Generate draft replies (does not send without confirmation).
+    """
+    from scripts.apollo.email_reader import read_account
+
+    host = os.environ.get("PROTONMAIL_IMAP_HOST", "127.0.0.1")
+    port = int(os.environ.get("PROTONMAIL_IMAP_PORT", "1143"))
+    user = os.environ.get("PROTONMAIL_USER", os.environ.get("PROTONMAIL_SMTP_USER", ""))
+    password = os.environ.get("PROTONMAIL_BRIDGE_PASSWORD", "")
+
+    results = []
+    if not user or not password:
+        print("[WARN] IMAP credentials not configured. Using mock data for demo.")
+        digests = []
+    else:
+        digests = read_account(host=host, port=port, user=user, password=password, account_name="proton", days=days)
+
+    for digest in digests:
+        classification = classify_with_llm(
+            sender=digest.get("from", "unknown"),
+            subject=digest.get("subject", ""),
+            body=digest.get("body", ""),
+        )
+
+        triage = TriageResult(
+            msg_id=digest.get("msg_id", "unknown"),
+            sender=digest.get("from", "unknown"),
+            subject=digest.get("subject", ""),
+            agent=classification["agent"],
+            confidence=classification["confidence"],
+            summary=classification["summary"],
+            draft_reply=classification.get("draft_reply", ""),
+            action=classification["action"],
+            urgency=classification["urgency"],
+            tongue=digest.get("tongue", ""),
+        )
+
+        if not dry_run:
+            _dispatch_to_queue(triage)
+
+        results.append(triage)
+
+    return results
+
+
+def _dispatch_to_queue(triage: TriageResult):
+    """Store triage result in the dispatch spine for agent pickup."""
+    try:
+        from scripts.system.advanced_ai_dispatch import connect_db, build_task_id, utc_now
+
+        agent = AGENTIC_EMPLOYEES.get(triage.agent, AGENTIC_EMPLOYEES["admin"])
+        conn = connect_db()
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO tasks (
+                task_id, title, goal, capability, priority, status, owner_role,
+                requested_by, write_scope, dependencies, payload, route, notes,
+                evidence_required, created_at, updated_at, lease_owner, lease_expires_at,
+                result_summary, failure_reason
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                build_task_id(),
+                f"Email: {triage.subject[:80]}",
+                triage.summary,
+                f"email.{triage.agent}",
+                _urgency_to_priority(triage.urgency),
+                "queued",
+                agent["role"],
+                triage.sender,
+                json.dumps(["inbox", triage.agent]),
+                json.dumps([]),
+                json.dumps(asdict(triage)),
+                json.dumps({"queue": triage.agent, "action": triage.action}),
+                f"Agentic triage: {triage.agent} | confidence: {triage.confidence:.2f}",
+                True,
+                utc_now(),
+                utc_now(),
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+        conn.commit()
+        conn.close()
+        print(f"  → Dispatched to {agent['name']} (priority {_urgency_to_priority(triage.urgency)})")
+    except Exception as e:
+        print(f"  → Dispatch failed: {e}")
+
+
+def _urgency_to_priority(urgency: str) -> int:
+    return {"low": 40, "normal": 60, "high": 80, "critical": 95}.get(urgency, 60)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Agentic Email Triage for SCBE-AETHERMOORE")
+    parser.add_argument("--run", action="store_true", help="Run triage on recent emails")
+    parser.add_argument("--dry-run", action="store_true", help="Classify without dispatching")
+    parser.add_argument("--days", type=int, default=1, help="Days back to look")
+    parser.add_argument("--auto-reply", action="store_true", help="Generate draft replies")
+    parser.add_argument("--output", type=str, default="", help="Write results to JSON file")
+    args = parser.parse_args()
+
+    if not args.run and not args.dry_run:
+        parser.print_help()
+        return
+
+    print(f"Running agentic email triage (days={args.days}, dry_run={args.dry_run})...")
+    results = run_triage(dry_run=args.dry_run, days=args.days, auto_reply=args.auto_reply)
+
+    print(f"\nTriage complete. {len(results)} emails processed.\n")
+    for r in results:
+        agent = AGENTIC_EMPLOYEES.get(r.agent, {})
+        print(f"  [{r.urgency.upper()}] {agent.get('name', r.agent)} | {r.subject[:60]}")
+        print(f"           confidence: {r.confidence:.2f} | action: {r.action}")
+        if r.draft_reply:
+            print(f"           draft: {r.draft_reply[:120]}...")
+        print()
+
+    if args.output:
+        Path(args.output).write_text(json.dumps([asdict(r) for r in results], indent=2))
+        print(f"Results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/system/email_service.py
+++ b/scripts/system/email_service.py
@@ -1,0 +1,151 @@
+"""SCBE Email Service — SMTP outbound and contact form handler.
+
+Sends emails via Proton Mail SMTP submission for website contact forms,
+notifications, and agentic triage alerts.
+"""
+
+from __future__ import annotations
+
+import os
+import smtplib
+import ssl
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Optional
+
+
+ENV_FILE = Path(__file__).resolve().parent.parent.parent / "config" / "connector_oauth" / ".env.connector.oauth"
+
+
+def _load_env():
+    """Lazy-load env file if present."""
+    if ENV_FILE.exists():
+        for line in ENV_FILE.read_text().splitlines():
+            if line.strip() and not line.startswith("#") and "=" in line:
+                k, v = line.split("=", 1)
+                os.environ.setdefault(k.strip(), v.strip().strip("\"'"))
+
+
+def get_smtp_config() -> dict:
+    """Return SMTP configuration from environment."""
+    _load_env()
+    return {
+        "host": os.environ.get("PROTONMAIL_SMTP_HOST", "smtp.protonmail.ch"),
+        "port": int(os.environ.get("PROTONMAIL_SMTP_PORT", "587")),
+        "user": os.environ.get("PROTONMAIL_SMTP_USER", ""),
+        "password": os.environ.get("PROTONMAIL_SMTP_TOKEN", ""),
+        "starttls": os.environ.get("PROTONMAIL_SMTP_STARTTLS", "true").lower() == "true",
+    }
+
+
+def send_email(
+    to: str,
+    subject: str,
+    body: str,
+    from_addr: Optional[str] = None,
+    reply_to: Optional[str] = None,
+    html_body: Optional[str] = None,
+) -> dict:
+    """Send an email via Proton SMTP.
+
+    Args:
+        to: Recipient email address.
+        subject: Email subject line.
+        body: Plain text body.
+        from_addr: Sender address (defaults to SMTP user).
+        reply_to: Reply-To header for contact forms.
+        html_body: Optional HTML alternative.
+
+    Returns:
+        {"ok": True, "message_id": str} or {"ok": False, "error": str}
+    """
+    cfg = get_smtp_config()
+    if not cfg["user"] or not cfg["password"]:
+        return {"ok": False, "error": "SMTP credentials not configured"}
+
+    sender = from_addr or cfg["user"]
+
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["To"] = to
+    if reply_to:
+        msg["Reply-To"] = reply_to
+
+    msg.set_content(body)
+    if html_body:
+        msg.add_alternative(html_body, subtype="html")
+
+    try:
+        context = ssl.create_default_context()
+        with smtplib.SMTP(cfg["host"], cfg["port"], timeout=30) as server:
+            if cfg["starttls"]:
+                server.starttls(context=context)
+            server.login(cfg["user"], cfg["password"])
+            server.send_message(msg)
+        return {"ok": True, "message_id": msg["Message-ID"] or "sent"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+def send_contact_notification(
+    name: str,
+    email: str,
+    subject: str,
+    message: str,
+    page: Optional[str] = None,
+) -> dict:
+    """Send a contact form submission to the site owner.
+
+    Formats the email and triggers notification to the admin inbox.
+    """
+    cfg = get_smtp_config()
+    owner = cfg["user"]
+
+    body_lines = [
+        f"New contact form submission from aethermoore.com",
+        f"",
+        f"Name:    {name}",
+        f"Email:   {email}",
+        f"Subject: {subject}",
+        f"Page:    {page or 'contact.html'}",
+        f"",
+        f"Message:",
+        f"{message}",
+        f"",
+        f"---",
+        f"This email was sent by the SCBE website contact form.",
+        f"To reply, use Reply-To: {email}",
+    ]
+
+    html_body = f"""<!DOCTYPE html>
+<html><body style="font-family:sans-serif;color:#333;">
+<h2>New contact form submission</h2>
+<table style="border-collapse:collapse;">
+<tr><td style="padding:8px;border:1px solid #ddd;"><strong>Name</strong></td><td style="padding:8px;border:1px solid #ddd;">{name}</td></tr>
+<tr><td style="padding:8px;border:1px solid #ddd;"><strong>Email</strong></td><td style="padding:8px;border:1px solid #ddd;">{email}</td></tr>
+<tr><td style="padding:8px;border:1px solid #ddd;"><strong>Subject</strong></td><td style="padding:8px;border:1px solid #ddd;">{subject}</td></tr>
+<tr><td style="padding:8px;border:1px solid #ddd;"><strong>Page</strong></td><td style="padding:8px;border:1px solid #ddd;">{page or 'contact.html'}</td></tr>
+</table>
+<h3>Message</h3>
+<div style="background:#f5f5f5;padding:16px;border-radius:8px;">{message.replace(chr(10), '<br>')}</div>
+<p><em>Sent by SCBE website contact form. Reply-To: {email}</em></p>
+</body></html>"""
+
+    return send_email(
+        to=owner,
+        subject=f"[SCBE Contact] {subject}",
+        body="\n".join(body_lines),
+        reply_to=email,
+        html_body=html_body,
+    )
+
+
+if __name__ == "__main__":
+    # Quick test
+    result = send_email(
+        to="issac@aethermoorgames.com",
+        subject="SCBE Email Service Test",
+        body="This is a test email from the SCBE email service module.",
+    )
+    print(result)

--- a/scripts/system/setup_cloudflare_tunnel.sh
+++ b/scripts/system/setup_cloudflare_tunnel.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Setup Cloudflare Tunnel for SCBE AetherBrowser API
+# This exposes your local API (port 8100) to the internet via HTTPS
+
+set -e
+
+TUNNEL_NAME="scbe-aetherbrowser"
+CONFIG_DIR="$HOME/.cloudflared"
+API_PORT="${AETHER_API_PORT:-8100}"
+
+echo "=== SCBE Cloudflare Tunnel Setup ==="
+echo ""
+
+# Check if cloudflared is installed
+if ! command -v cloudflared &> /dev/null; then
+    echo "Installing cloudflared..."
+    curl -L --output /tmp/cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+    sudo dpkg -i /tmp/cloudflared.deb || sudo apt-get install -f -y
+fi
+
+# Authenticate
+echo "Step 1: Authenticate with Cloudflare"
+echo "This will open a browser. Choose the zone for aethermoore.com"
+if [ ! -f "$CONFIG_DIR/cert.pem" ]; then
+    cloudflared tunnel login
+fi
+
+# Create tunnel
+echo ""
+echo "Step 2: Creating tunnel: $TUNNEL_NAME"
+TUNNEL_ID=$(cloudflared tunnel create "$TUNNEL_NAME" 2>/dev/null | grep -oP 'Created tunnel \K[a-z0-9-]+' || true)
+
+if [ -z "$TUNNEL_ID" ]; then
+    echo "Tunnel may already exist. Listing tunnels:"
+    cloudflared tunnel list
+    echo ""
+    echo "Enter the tunnel ID from above:"
+    read TUNNEL_ID
+fi
+
+# Write config
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_DIR/$TUNNEL_ID.json" << EOF
+{
+    "tunnel": "$TUNNEL_ID",
+    "credentials-file": "$CONFIG_DIR/$TUNNEL_ID.json",
+    "ingress": [
+        {
+            "hostname": "api.aethermoore.com",
+            "service": "http://localhost:$API_PORT"
+        },
+        {
+            "service": "http_status:404"
+        }
+    ]
+}
+EOF
+
+# Create DNS record
+echo ""
+echo "Step 3: Creating DNS record api.aethermoore.com → tunnel"
+cloudflared tunnel route dns "$TUNNEL_NAME" "api.aethermoore.com"
+
+echo ""
+echo "=== Setup complete ==="
+echo ""
+echo "To start the tunnel:"
+echo "  cloudflared tunnel run $TUNNEL_NAME"
+echo ""
+echo "To run as a service:"
+echo "  sudo cloudflared service install"
+echo "  sudo systemctl start cloudflared"
+echo ""
+echo "Your API will be available at: https://api.aethermoore.com"
+echo ""
+echo "Test the contact endpoint:"
+echo "  curl -X POST https://api.aethermoore.com/api/contact \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"name\":\"Test\",\"email\":\"test@example.com\",\"subject\":\"Hello\",\"message\":\"Test message\"}'"


### PR DESCRIPTION
## What's New

- **Email Service** (`scripts/system/email_service.py`): Proton SMTP outbound for sending contact form notifications
- **Agentic Triage** (`scripts/apollo/agentic_email_triage.py`): LLM-powered email routing to 6 agentic employees
- **Contact API** (`/api/contact`): New FastAPI endpoint in AetherBrowser that receives website form submissions
- **Cloudflare Tunnel Setup** (`scripts/system/setup_cloudflare_tunnel.sh`): One-script setup to expose API to internet
- **SMTP Config** (`config/connector_oauth/.env.connector.oauth`): Proton Mail SMTP submission settings

## Agentic Employees

| Agent | Role | Handles |
|---|---|---|
| Ava | Sales | Pricing, custom projects, pilots |
| Sam | Support | Delivery issues, refunds, purchases |
| Tao | Technical | API questions, bugs, integrations |
| Sage | Security | Vulnerability reports, audits |
| Cara | Content | Media, interviews, speaking |
| Alex | Admin | Spam, newsletters, unclear intent |

## Usage

```bash
# Start API
python scripts/aetherbrowser/api_server.py

# Run agentic triage (dry run)
python scripts/apollo/agentic_email_triage.py --dry-run --days 1

# Setup Cloudflare tunnel
bash scripts/system/setup_cloudflare_tunnel.sh
```
