### PR TITLE
Add Polly AI assistant backend endpoints

### DIFF
--- a/docs/AGENTIC_EMAIL_ARCHITECTURE.md
+++ b/docs/AGENTIC_EMAIL_ARCHITECTURE.md
@@ -1,0 +1,270 @@
+# Agentic Email Architecture
+
+> Research note: How to build AI-powered email triage with autonomous "agentic employees" — derived from SCBE-AETHERMOORE's Apollo pipeline and multi-agent dispatch spine.
+
+---
+
+## The Problem
+
+A single inbox becomes a bottleneck. Sales inquiries, support tickets, bug reports, partnership requests, spam, and newsletters all arrive in one stream. Manual sorting doesn't scale. Rules-based filters miss nuance. What's needed is **intent-aware routing** where specialized AI agents handle different email types autonomously.
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Website Form   │────▶│  /api/contact   │────▶│  Proton SMTP    │
+│  or IMAP Inbox  │     │  (FastAPI)      │     │  (issac@...)    │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                                                         │
+                              ┌────────────────────────┘
+                              ▼
+                    ┌─────────────────┐
+                    │  Apollo Email   │
+                    │  Reader (IMAP)  │
+                    └─────────────────┘
+                              │
+                              ▼
+                    ┌─────────────────┐
+                    │  LLM Classifier │◀── Gemini / Claude / Local
+                    │  (Intent + Urgency)
+                    └─────────────────┘
+                              │
+              ┌───────────────┼───────────────┐
+              ▼               ▼               ▼
+        ┌─────────┐    ┌─────────┐    ┌─────────┐
+        │  Sales  │    │ Support │    │  Tech   │
+        │  Agent  │    │  Agent  │    │  Agent  │
+        └─────────┘    └─────────┘    └─────────┘
+              │               │               │
+              ▼               ▼               ▼
+        ┌─────────┐    ┌─────────┐    ┌─────────┐
+        │  Draft  │    │  Draft  │    │  Draft  │
+        │  Reply  │    │  Reply  │    │  Reply  │
+        └─────────┘    └─────────┘    └─────────┘
+              │               │               │
+              └───────────────┼───────────────┘
+                              ▼
+                    ┌─────────────────┐
+                    │  Human Review   │◀── Gate for sensitive actions
+                    │  (Optional)     │
+                    └─────────────────┘
+                              │
+                              ▼
+                    ┌─────────────────┐
+                    │  SMTP Outbound  │
+                    │  (Proton)       │
+                    └─────────────────┘
+```
+
+---
+
+## Component Breakdown
+
+### 1. Ingestion Layer
+
+**Option A: Website Contact Form**
+- Static site POSTs to `/api/contact` (FastAPI)
+- API sends email via SMTP to owner
+- Same email address = same inbox = same triage pipeline
+
+**Option B: Direct IMAP Polling**
+- Apollo `email_reader.py` polls Proton/Gmail IMAP
+- Classifies by Sacred Tongue (KO/AV/RU/CA/UM/DR)
+- Processes last N days, max 50 messages per run
+
+**Option C: Webhook (n8n/Zapier)**
+- Form service (Formspree, Basin) triggers webhook
+- Webhook hits local n8n bridge or FastAPI endpoint
+- Real-time vs. polling tradeoff
+
+**Recommendation:** Use A (direct API) for website forms + B (IMAP polling) for general email. This gives both real-time website notifications and batch processing of all inbound mail.
+
+---
+
+### 2. Classification Layer
+
+**Two-tier approach:**
+
+**Tier 1 — Sacred Tongues (keyword heuristic)**
+Fast, deterministic, no API cost. Catches obvious patterns:
+- KO: "request", "need", "deadline", "approve"
+- AV: "update", "newsletter", "summary"
+- RU: "invoice", "contract", "payment"
+- CA: "bug", "deploy", "API", "error"
+- UM: "password", "security", "breach"
+- DR: "unsubscribe", "welcome", "settings"
+
+**Tier 2 — LLM Classifier**
+Runs when Tier 1 confidence is low or when `agentic_triage.py` is invoked. Uses Gemini/Claude with a structured prompt:
+
+```
+Agentic employees available:
+- sales: pricing inquiry, custom project, enterprise scoping
+- support: delivery issue, refund request, broken link
+- technical: API question, bug report, integration help
+- security: vulnerability report, audit request
+- content: guest post, interview, speaking engagement
+- admin: spam, newsletter, unclear intent
+
+Classify this email. Respond with JSON:
+{
+  "agent": "<key>",
+  "confidence": 0.0-1.0,
+  "summary": "...",
+  "urgency": "low|normal|high|critical",
+  "action": "recommended next step",
+  "draft_reply": "1-paragraph response"
+}
+```
+
+**Cost optimization:**
+- Run heuristic first (free)
+- Only call LLM if heuristic confidence < 0.7
+- Cache classifications by sender+subject hash
+- Use Gemini Flash ($0.075/1M tokens) or local Ollama
+
+---
+
+### 3. Agentic Employees (Dispatch)
+
+Each agent is a **capability + prompt template**, not a separate process.
+
+| Employee | Role | Capability | Prompt Anchor |
+|---|---|---|---|
+| **Ava** (Sales) | `agent.sales` | `email.sales` | "You are Ava, SCBE sales. Be concise, outcome-focused. Never invent pricing." |
+| **Sam** (Support) | `agent.support` | `email.support` | "You are Sam, SCBE support. Be patient, solution-oriented. Escalate refunds." |
+| **Tao** (Technical) | `agent.technical` | `email.technical` | "You are Tao, SCBE engineer. Be precise, reference docs, provide code." |
+| **Sage** (Security) | `agent.security` | `email.security` | "You are Sage, SCBE security. Be serious, thorough, follow disclosure policy." |
+| **Cara** (Content) | `agent.content` | `email.content` | "You are Cara, SCBE content. Be warm, calendar-aware, story-oriented." |
+| **Alex** (Admin) | `agent.admin` | `email.admin` | "You are Alex, SCBE admin. Be neutral, efficient, archive when appropriate." |
+
+**Dispatch mechanism:**
+1. Classification outputs `agent` key
+2. Task is inserted into `dispatch.db` (SQLite) with `owner_role = agent.role`
+3. Agent picks up tasks where `status = 'queued' AND owner_role = 'agent.X'`
+4. Agent generates draft reply using its prompt template + email context
+5. Draft goes to human review queue (or auto-send if confidence > 0.9 and low risk)
+
+---
+
+### 4. Response Generation
+
+**Draft reply flow:**
+```python
+agent = AGENTIC_EMPLOYEES[classification["agent"]]
+prompt = f"""{agent['tone']}
+
+Original email:
+From: {email.sender}
+Subject: {email.subject}
+Body: {email.body}
+
+Draft a response. Rules:
+- Only mention real products/prices from catalog
+- If unsure, say "I'll check with the team and get back to you"
+- Include relevant links from: {links_for_agent(agent)}
+- Sign as {agent['name']}
+"""
+```
+
+**Human-in-the-loop gates:**
+| Action | Auto-send? | Gate |
+|---|---|---|
+| Informational reply (pricing, links) | Yes, if confidence > 0.9 | Log only |
+| Refund processing | No | Human approval required |
+| Custom quote | No | Human approval required |
+| Security report acknowledgment | Yes | Log + alert human |
+| Spam/unsubscribe | Yes | No review |
+
+---
+
+### 5. Storage & Audit
+
+**SQLite schema (dispatch spine):**
+```sql
+CREATE TABLE tasks (
+    task_id TEXT PRIMARY KEY,
+    title TEXT,
+    goal TEXT,
+    capability TEXT,        -- email.sales, email.support, etc.
+    priority INTEGER,       -- 40 (low) to 95 (critical)
+    status TEXT,            -- queued, running, completed, failed
+    owner_role TEXT,        -- agent.sales, agent.support, etc.
+    requested_by TEXT,      -- sender email
+    payload TEXT,           -- JSON: full email + classification
+    route TEXT,             -- JSON: queue + action
+    notes TEXT,
+    created_at TEXT,
+    updated_at TEXT,
+    result_summary TEXT     -- draft reply or action taken
+);
+```
+
+**Audit trail:**
+- Every classification logged with confidence score
+- Every draft reply stored before sending
+- Every auto-send flagged for retroactive review
+- Monthly report: classification accuracy, response times, escalation rate
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Basic Triage (Done)
+- ✅ SMTP outbound (`email_service.py`)
+- ✅ Contact API endpoint (`/api/contact`)
+- ✅ Heuristic classifier (`agentic_email_triage.py`)
+- ✅ Dispatch to SQLite (`advanced_ai_dispatch.py`)
+
+### Phase 2: LLM Enhancement (Next)
+- [ ] Add Gemini API key to `.env.connector.oauth`
+- [ ] Enable LLM fallback in `agentic_email_triage.py`
+- [ ] Add response generation to each agent
+- [ ] Build human review UI (simple HTML page or CLI)
+
+### Phase 3: Automation (Future)
+- [ ] Auto-send high-confidence replies
+- [ ] Calendar integration for booking calls
+- [ ] Stripe integration for refund processing
+- [ ] Knowledge base retrieval for technical answers
+- [ ] Feedback loop: human corrections improve classifier
+
+### Phase 4: Scale (Future)
+- [ ] Separate agent processes (not just SQLite rows)
+- [ ] Vector DB for email history + RAG
+- [ ] Multi-language support
+- [ ] SLA monitoring and alerting
+
+---
+
+## Security Considerations
+
+1. **Secret scrubbing** — Apollo already scrubs API keys, tokens, card numbers before any email touches training data or logs
+2. **SMTP token isolation** — Stored in `.env.connector.oauth`, never committed
+3. **Reply gates** — Financial and security actions require human approval
+4. **Rate limiting** — Contact API should limit to 5 submissions/IP/hour
+5. **Spam filtering** — reCAPTCHA on contact form + honeypot field
+
+---
+
+## Cost Estimate
+
+| Component | Monthly Cost |
+|---|---|
+| Proton Mail Business | $12.99/mo (already paid) |
+| Gemini Flash API | ~$0.50-2.00/mo (light usage) |
+| Cloudflare Tunnel | Free |
+| SQLite storage | Negligible |
+| **Total** | **~$1-3/mo incremental** |
+
+---
+
+## References
+
+- SCBE `scripts/apollo/email_reader.py` — IMAP ingestion + tongue classification
+- SCBE `scripts/apollo/apollo_core.py` — Interactive search + teaching loops
+- SCBE `scripts/system/advanced_ai_dispatch.py` — Lease-based task dispatch
+- SCBE `scripts/system/email_service.py` — SMTP outbound
+- This doc: `docs/AGENTIC_EMAIL_ARCHITECTURE.md`

--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -2034,6 +2034,83 @@ _cli_jobs: dict[str, dict[str, Any]] = {}
 
 
 # =========================================================================== #
+#  Polly — AI Assistant Endpoints
+# =========================================================================== #
+
+from pydantic import BaseModel
+
+class PollyChatPayload(BaseModel):
+    message: str
+    context: Optional[str] = "site"
+
+class PollyRespondPayload(BaseModel):
+    text: str
+    context: Optional[str] = "site"
+    intent: Optional[str] = ""
+
+class PollySearchPayload(BaseModel):
+    query: str
+
+class PollyDelegatePayload(BaseModel):
+    text: str
+
+
+@app.post("/v1/polly/chat")
+async def polly_chat(payload: PollyChatPayload):
+    """Main chat endpoint for Polly sidebar."""
+    try:
+        from scripts.system.polly_service import chat
+        result = await chat(payload.message, payload.context)
+        return {"ok": True, "data": result}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+@app.post("/v1/polly/respond")
+async def polly_respond(payload: PollyRespondPayload):
+    """Alternative response endpoint for Polly."""
+    try:
+        from scripts.system.polly_service import respond
+        result = await respond(payload.text, payload.context, payload.intent)
+        return {"ok": True, "data": result}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+@app.get("/v1/polly/context")
+async def polly_context():
+    """Return backend capabilities."""
+    try:
+        from scripts.system.polly_service import get_context
+        result = await get_context()
+        return {"ok": True, "data": result}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+@app.post("/v1/polly/search")
+async def polly_search(payload: PollySearchPayload):
+    """Search proxy for Polly."""
+    try:
+        from scripts.system.polly_service import search
+        result = await search(payload.query)
+        return {"ok": True, "data": result}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+@app.post("/v1/polly/delegate")
+async def polly_delegate(payload: PollyDelegatePayload):
+    """Delegation endpoint for Polly."""
+    try:
+        from scripts.system.polly_service import delegate
+        result = await delegate(payload.text)
+        return {"ok": True, "data": result}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# =========================================================================== #
 #  Entry point
 # =========================================================================== #
 

--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -1304,6 +1304,33 @@ async def vault_sync():
 # =========================================================================== #
 
 
+class ContactFormPayload(BaseModel):
+    name: str
+    email: str
+    subject: str
+    message: str
+    page: Optional[str] = None
+
+
+@app.post("/api/contact")
+async def contact_submit(payload: ContactFormPayload):
+    """Receive contact form submissions from the website and notify via email."""
+    try:
+        from scripts.system.email_service import send_contact_notification
+        result = send_contact_notification(
+            name=payload.name,
+            email=payload.email,
+            subject=payload.subject,
+            message=payload.message,
+            page=payload.page,
+        )
+        if result["ok"]:
+            return {"ok": True, "message": "Message sent. We usually reply within 24 hours."}
+        return {"ok": False, "error": result.get("error", "Email delivery failed")}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
 @app.post("/api/ops/check-email")
 async def ops_check_email():
     """Run the Apollo email reader and return classified digests."""

--- a/scripts/apollo/agentic_email_triage.py
+++ b/scripts/apollo/agentic_email_triage.py
@@ -1,0 +1,330 @@
+"""Agentic Email Triage — LLM-powered email routing for SCBE.
+
+Extends Apollo with intelligent classification beyond keyword matching.
+Routes emails to "agentic employees" (specialized dispatch queues) and
+generates draft responses.
+
+Usage:
+    python scripts/apollo/agentic_email_triage.py --run
+    python scripts/apollo/agentic_email_triage.py --run --auto-reply
+    python scripts/apollo/agentic_email_triage.py --dry-run --days 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# Project paths
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+# Load env
+_env = ROOT / "config" / "connector_oauth" / ".env.connector.oauth"
+if _env.exists():
+    for line in _env.read_text().splitlines():
+        if line.strip() and not line.startswith("#") and "=" in line:
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip("\"'"))
+
+
+# ---------------------------------------------------------------------------
+# Agentic Employee Definitions
+# ---------------------------------------------------------------------------
+
+AGENTIC_EMPLOYEES = {
+    "sales": {
+        "name": "Ava (Sales)",
+        "role": "agent.sales",
+        "handles": ["pricing inquiry", "custom project", "enterprise scoping", "pilot application", "partnership"],
+        "tone": "professional, concise, outcome-focused",
+        "actions": ["send pricing sheet", "book scoping call", "send pilot agreement"],
+    },
+    "support": {
+        "name": "Sam (Support)",
+        "role": "agent.support",
+        "handles": ["delivery issue", "missing file", "broken link", "refund request", "purchase help"],
+        "tone": "helpful, patient, solution-oriented",
+        "actions": ["resend delivery", "process refund", "escalate to human"],
+    },
+    "technical": {
+        "name": "Tao (Technical)",
+        "role": "agent.technical",
+        "handles": ["api question", "integration help", "bug report", "self-hosting", "code review request"],
+        "tone": "precise, technical, references docs",
+        "actions": ["link to docs", "provide code snippet", "open GitHub issue"],
+    },
+    "security": {
+        "name": "Sage (Security)",
+        "role": "agent.security",
+        "handles": ["vulnerability report", "penetration test inquiry", "audit request", "compliance question"],
+        "tone": "serious, thorough, process-oriented",
+        "actions": ["acknowledge receipt", "request details", "route to red team"],
+    },
+    "content": {
+        "name": "Cara (Content)",
+        "role": "agent.content",
+        "handles": ["guest post", "interview request", "speaking engagement", "media inquiry"],
+        "tone": "warm, story-oriented, calendar-aware",
+        "actions": ["send media kit", "propose dates", "decline politely"],
+    },
+    "admin": {
+        "name": "Alex (Admin)",
+        "role": "agent.admin",
+        "handles": ["spam", "newsletter signup", "unsubscribe", "generic hello", "unclear intent"],
+        "tone": "neutral, efficient",
+        "actions": ["mark spam", "add to newsletter", "archive"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# LLM Classification (Gemini fallback to local heuristic)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TriageResult:
+    msg_id: str
+    sender: str
+    subject: str
+    agent: str
+    confidence: float
+    summary: str
+    draft_reply: str = ""
+    action: str = ""
+    urgency: str = "normal"  # low, normal, high, critical
+    tongue: str = ""
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+def classify_with_llm(sender: str, subject: str, body: str, api_key: Optional[str] = None) -> dict:
+    """Use Gemini to classify email intent and route to agentic employee.
+
+    Falls back to heuristic if Gemini is unavailable.
+    """
+    api_key = api_key or os.environ.get("GEMINI_API_KEY", "")
+    if not api_key:
+        return classify_heuristic(sender, subject, body)
+
+    try:
+        import google.generativeai as genai
+        genai.configure(api_key=api_key)
+        model = genai.GenerativeModel("gemini-1.5-flash")
+
+        agent_descriptions = "\n".join(
+            f"- {k}: handles {', '.join(v['handles'])}"
+            for k, v in AGENTIC_EMPLOYEES.items()
+        )
+
+        prompt = f"""You are an email triage specialist for SCBE-AETHERMOORE, an AI governance company.
+
+Incoming email:
+From: {sender}
+Subject: {subject}
+Body: {body[:2000]}
+
+Agentic employees available:
+{agent_descriptions}
+
+Classify this email. Respond ONLY with valid JSON in this exact format:
+{{
+  "agent": "<employee_key>",
+  "confidence": 0.0-1.0,
+  "summary": "1-sentence summary",
+  "urgency": "low|normal|high|critical",
+  "action": "recommended next step",
+  "draft_reply": "1-paragraph draft response"
+}}
+"""
+        response = model.generate_content(prompt)
+        text = response.text.strip()
+        # Extract JSON if wrapped in markdown
+        if "```json" in text:
+            text = text.split("```json")[1].split("```")[0].strip()
+        elif "```" in text:
+            text = text.split("```")[1].split("```")[0].strip()
+        return json.loads(text)
+    except Exception as e:
+        print(f"[LLM classification failed: {e}] — falling back to heuristic")
+        return classify_heuristic(sender, subject, body)
+
+
+def classify_heuristic(sender: str, subject: str, body: str) -> dict:
+    """Fallback keyword-based classification (extends Apollo's tongue system)."""
+    text = f"{subject} {body}".lower()
+
+    scores = {}
+    for agent_key, agent in AGENTIC_EMPLOYEES.items():
+        score = 0
+        for keyword in agent["handles"]:
+            if keyword.lower() in text:
+                score += 1
+        scores[agent_key] = score
+
+    best = max(scores, key=scores.get)
+    confidence = min(0.5 + scores[best] * 0.15, 0.95)
+
+    # Urgency heuristics
+    urgency = "normal"
+    if any(w in text for w in ["urgent", "asap", "critical", "breach", "outage"]):
+        urgency = "critical"
+    elif any(w in text for w in ["deadline", "tomorrow", "expiring", "payment due"]):
+        urgency = "high"
+
+    return {
+        "agent": best,
+        "confidence": confidence,
+        "summary": f"Email from {sender} about {subject[:60]}",
+        "urgency": urgency,
+        "action": AGENTIC_EMPLOYEES[best]["actions"][0],
+        "draft_reply": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Triage Runner
+# ---------------------------------------------------------------------------
+
+def run_triage(dry_run: bool = False, days: int = 1, auto_reply: bool = False) -> list[TriageResult]:
+    """Run agentic triage on recent emails.
+
+    Args:
+        dry_run: Classify without dispatching or saving.
+        days: How many days back to look.
+        auto_reply: Generate draft replies (does not send without confirmation).
+    """
+    from scripts.apollo.email_reader import read_account
+
+    host = os.environ.get("PROTONMAIL_IMAP_HOST", "127.0.0.1")
+    port = int(os.environ.get("PROTONMAIL_IMAP_PORT", "1143"))
+    user = os.environ.get("PROTONMAIL_USER", os.environ.get("PROTONMAIL_SMTP_USER", ""))
+    password = os.environ.get("PROTONMAIL_BRIDGE_PASSWORD", "")
+
+    results = []
+    if not user or not password:
+        print("[WARN] IMAP credentials not configured. Using mock data for demo.")
+        digests = []
+    else:
+        digests = read_account(host=host, port=port, user=user, password=password, account_name="proton", days=days)
+
+    for digest in digests:
+        classification = classify_with_llm(
+            sender=digest.get("from", "unknown"),
+            subject=digest.get("subject", ""),
+            body=digest.get("body", ""),
+        )
+
+        triage = TriageResult(
+            msg_id=digest.get("msg_id", "unknown"),
+            sender=digest.get("from", "unknown"),
+            subject=digest.get("subject", ""),
+            agent=classification["agent"],
+            confidence=classification["confidence"],
+            summary=classification["summary"],
+            draft_reply=classification.get("draft_reply", ""),
+            action=classification["action"],
+            urgency=classification["urgency"],
+            tongue=digest.get("tongue", ""),
+        )
+
+        if not dry_run:
+            _dispatch_to_queue(triage)
+
+        results.append(triage)
+
+    return results
+
+
+def _dispatch_to_queue(triage: TriageResult):
+    """Store triage result in the dispatch spine for agent pickup."""
+    try:
+        from scripts.system.advanced_ai_dispatch import connect_db, build_task_id, utc_now
+
+        agent = AGENTIC_EMPLOYEES.get(triage.agent, AGENTIC_EMPLOYEES["admin"])
+        conn = connect_db()
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO tasks (
+                task_id, title, goal, capability, priority, status, owner_role,
+                requested_by, write_scope, dependencies, payload, route, notes,
+                evidence_required, created_at, updated_at, lease_owner, lease_expires_at,
+                result_summary, failure_reason
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                build_task_id(),
+                f"Email: {triage.subject[:80]}",
+                triage.summary,
+                f"email.{triage.agent}",
+                _urgency_to_priority(triage.urgency),
+                "queued",
+                agent["role"],
+                triage.sender,
+                json.dumps(["inbox", triage.agent]),
+                json.dumps([]),
+                json.dumps(asdict(triage)),
+                json.dumps({"queue": triage.agent, "action": triage.action}),
+                f"Agentic triage: {triage.agent} | confidence: {triage.confidence:.2f}",
+                True,
+                utc_now(),
+                utc_now(),
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+        conn.commit()
+        conn.close()
+        print(f"  → Dispatched to {agent['name']} (priority {_urgency_to_priority(triage.urgency)})")
+    except Exception as e:
+        print(f"  → Dispatch failed: {e}")
+
+
+def _urgency_to_priority(urgency: str) -> int:
+    return {"low": 40, "normal": 60, "high": 80, "critical": 95}.get(urgency, 60)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Agentic Email Triage for SCBE-AETHERMOORE")
+    parser.add_argument("--run", action="store_true", help="Run triage on recent emails")
+    parser.add_argument("--dry-run", action="store_true", help="Classify without dispatching")
+    parser.add_argument("--days", type=int, default=1, help="Days back to look")
+    parser.add_argument("--auto-reply", action="store_true", help="Generate draft replies")
+    parser.add_argument("--output", type=str, default="", help="Write results to JSON file")
+    args = parser.parse_args()
+
+    if not args.run and not args.dry_run:
+        parser.print_help()
+        return
+
+    print(f"Running agentic email triage (days={args.days}, dry_run={args.dry_run})...")
+    results = run_triage(dry_run=args.dry_run, days=args.days, auto_reply=args.auto_reply)
+
+    print(f"\nTriage complete. {len(results)} emails processed.\n")
+    for r in results:
+        agent = AGENTIC_EMPLOYEES.get(r.agent, {})
+        print(f"  [{r.urgency.upper()}] {agent.get('name', r.agent)} | {r.subject[:60]}")
+        print(f"           confidence: {r.confidence:.2f} | action: {r.action}")
+        if r.draft_reply:
+            print(f"           draft: {r.draft_reply[:120]}...")
+        print()
+
+    if args.output:
+        Path(args.output).write_text(json.dumps([asdict(r) for r in results], indent=2))
+        print(f"Results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/system/email_service.py
+++ b/scripts/system/email_service.py
@@ -1,0 +1,151 @@
+"""SCBE Email Service — SMTP outbound and contact form handler.
+
+Sends emails via Proton Mail SMTP submission for website contact forms,
+notifications, and agentic triage alerts.
+"""
+
+from __future__ import annotations
+
+import os
+import smtplib
+import ssl
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Optional
+
+
+ENV_FILE = Path(__file__).resolve().parent.parent.parent / "config" / "connector_oauth" / ".env.connector.oauth"
+
+
+def _load_env():
+    """Lazy-load env file if present."""
+    if ENV_FILE.exists():
+        for line in ENV_FILE.read_text().splitlines():
+            if line.strip() and not line.startswith("#") and "=" in line:
+                k, v = line.split("=", 1)
+                os.environ.setdefault(k.strip(), v.strip().strip("\"'"))
+
+
+def get_smtp_config() -> dict:
+    """Return SMTP configuration from environment."""
+    _load_env()
+    return {
+        "host": os.environ.get("PROTONMAIL_SMTP_HOST", "smtp.protonmail.ch"),
+        "port": int(os.environ.get("PROTONMAIL_SMTP_PORT", "587")),
+        "user": os.environ.get("PROTONMAIL_SMTP_USER", ""),
+        "password": os.environ.get("PROTONMAIL_SMTP_TOKEN", ""),
+        "starttls": os.environ.get("PROTONMAIL_SMTP_STARTTLS", "true").lower() == "true",
+    }
+
+
+def send_email(
+    to: str,
+    subject: str,
+    body: str,
+    from_addr: Optional[str] = None,
+    reply_to: Optional[str] = None,
+    html_body: Optional[str] = None,
+) -> dict:
+    """Send an email via Proton SMTP.
+
+    Args:
+        to: Recipient email address.
+        subject: Email subject line.
+        body: Plain text body.
+        from_addr: Sender address (defaults to SMTP user).
+        reply_to: Reply-To header for contact forms.
+        html_body: Optional HTML alternative.
+
+    Returns:
+        {"ok": True, "message_id": str} or {"ok": False, "error": str}
+    """
+    cfg = get_smtp_config()
+    if not cfg["user"] or not cfg["password"]:
+        return {"ok": False, "error": "SMTP credentials not configured"}
+
+    sender = from_addr or cfg["user"]
+
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["To"] = to
+    if reply_to:
+        msg["Reply-To"] = reply_to
+
+    msg.set_content(body)
+    if html_body:
+        msg.add_alternative(html_body, subtype="html")
+
+    try:
+        context = ssl.create_default_context()
+        with smtplib.SMTP(cfg["host"], cfg["port"], timeout=30) as server:
+            if cfg["starttls"]:
+                server.starttls(context=context)
+            server.login(cfg["user"], cfg["password"])
+            server.send_message(msg)
+        return {"ok": True, "message_id": msg["Message-ID"] or "sent"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+def send_contact_notification(
+    name: str,
+    email: str,
+    subject: str,
+    message: str,
+    page: Optional[str] = None,
+) -> dict:
+    """Send a contact form submission to the site owner.
+
+    Formats the email and triggers notification to the admin inbox.
+    """
+    cfg = get_smtp_config()
+    owner = cfg["user"]
+
+    body_lines = [
+        f"New contact form submission from aethermoore.com",
+        f"",
+        f"Name:    {name}",
+        f"Email:   {email}",
+        f"Subject: {subject}",
+        f"Page:    {page or 'contact.html'}",
+        f"",
+        f"Message:",
+        f"{message}",
+        f"",
+        f"---",
+        f"This email was sent by the SCBE website contact form.",
+        f"To reply, use Reply-To: {email}",
+    ]
+
+    html_body = f"""<!DOCTYPE html>
+<html><body style="font-family:sans-serif;color:#333;">
+<h2>New contact form submission</h2>
+<table style="border-collapse:collapse;">
+<tr><td style="padding:8px;border:1px solid #ddd;"><strong>Name</strong></td><td style="padding:8px;border:1px solid #ddd;">{name}</td></tr>
+<tr><td style="padding:8px;border:1px solid #ddd;"><strong>Email</strong></td><td style="padding:8px;border:1px solid #ddd;">{email}</td></tr>
+<tr><td style="padding:8px;border:1px solid #ddd;"><strong>Subject</strong></td><td style="padding:8px;border:1px solid #ddd;">{subject}</td></tr>
+<tr><td style="padding:8px;border:1px solid #ddd;"><strong>Page</strong></td><td style="padding:8px;border:1px solid #ddd;">{page or 'contact.html'}</td></tr>
+</table>
+<h3>Message</h3>
+<div style="background:#f5f5f5;padding:16px;border-radius:8px;">{message.replace(chr(10), '<br>')}</div>
+<p><em>Sent by SCBE website contact form. Reply-To: {email}</em></p>
+</body></html>"""
+
+    return send_email(
+        to=owner,
+        subject=f"[SCBE Contact] {subject}",
+        body="\n".join(body_lines),
+        reply_to=email,
+        html_body=html_body,
+    )
+
+
+if __name__ == "__main__":
+    # Quick test
+    result = send_email(
+        to="issac@aethermoorgames.com",
+        subject="SCBE Email Service Test",
+        body="This is a test email from the SCBE email service module.",
+    )
+    print(result)

--- a/scripts/system/polly_service.py
+++ b/scripts/system/polly_service.py
@@ -1,0 +1,251 @@
+"""Polly Service — Route-first AI assistant backend for aethermoore.com.
+
+Handles chat, search, delegation, and context for the Polly sidebar assistant.
+Falls back to keyword-based deterministic responses when no LLM is available.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+def _env_get(key: str, default: str = "") -> str:
+    return os.environ.get(key, default)
+
+
+# ---------------------------------------------------------------------------
+#  Lore & Knowledge Base
+# ---------------------------------------------------------------------------
+
+POLLY_LORE = """
+You are Polly, the route-first operator for SCBE-AETHERMOORE (aethermoore.com).
+Your first job is to identify intent and point people to the correct surface before adding extra reasoning.
+
+CRITICAL RULE: Only recommend products that are listed below. NEVER invent products, prices, features, or URLs.
+
+=== SOLUTIONS ===
+A. CX Refund Guardrail — $500-5K/month SaaS. Page: /cx-guardrail.html
+B. ISO 42001 Evidence-as-a-Service — $50-150K/year. Page: /iso-42001.html
+C. AI Red Team as a Service — $5-50K/engagement. Page: /red-team.html
+
+=== PRODUCTS ===
+1. AI Governance Toolkit — $29 one-time. Buy: Stripe link. Manual: /product-manual/ai-governance-toolkit.html
+2. HYDRA Agent Templates — $29 one-time.
+3. n8n Workflow Pack — $29 one-time.
+4. Content Spin Engine — $29 one-time.
+5. The Six Tongues Protocol (Novel) — Amazon KDP.
+6. Training Data — /datasets.html
+
+=== OPEN SOURCE ===
+- SCBE-AETHERMOORE (main framework): github.com/issdandavis/SCBE-AETHERMOORE
+- 9 repos total, MIT licensed
+
+=== SITE ROUTES ===
+- /assistant.html — Front desk
+- /tools.html — Live action tools
+- /support.html — Recovery
+- /product-manual/ — Buyer guides
+- /research/ — Benchmarks and evidence
+- /book.html — Narrative teaching
+- /demos/ — Interactive visualizations
+- /arena.html — AI debate arena
+- /members/ — Exclusive research (gated)
+
+=== CONTACT ===
+- Email: issac@aethermoorgames.com
+- Built by Issac Davis in Port Angeles, WA
+"""
+
+
+# ---------------------------------------------------------------------------
+#  Intent Classification (Deterministic)
+# ---------------------------------------------------------------------------
+
+INTENT_PATTERNS = {
+    "pricing": {
+        "patterns": [r"price", r"cost", r"how much", r"pricing", r"\$\d+", r"monthly", r"subscription", r"fee"],
+        "response": "Our solutions range from $29 one-time products to $150K/year enterprise services. See the full pricing grid at https://aethermoore.com/pricing.html",
+        "route": "/pricing.html",
+    },
+    "cx_guardrail": {
+        "patterns": [r"refund", r"guardrail", r"cx", r"customer support", r"chatbot liability", r"moffatt", r"policy enforcement"],
+        "response": "The CX Refund Guardrail stops chatbots from promising refunds they can't deliver. It's policy-enforcement middleware between your LLM and customer. $500-5K/month. https://aethermoore.com/cx-guardrail.html",
+        "route": "/cx-guardrail.html",
+    },
+    "iso_42001": {
+        "patterns": [r"iso.?42001", r"audit", r"compliance", r"regulatory", r"eu ai act", r"sr 11-7", r"governance framework"],
+        "response": "ISO 42001 Evidence-as-a-Service provides adversarial testing, risk reports, drift monitoring, and audit response dossiers. $50-150K/year. https://aethermoore.com/iso-42001.html",
+        "route": "/iso-42001.html",
+    },
+    "red_team": {
+        "patterns": [r"red team", r"penetration", r"adversarial", r"attack", r"security test", r"vulnerability", r"threat"],
+        "response": "AI Red Team as a Service runs 6,000+ adversarial tests against your LLM application. Branded PDF report and remediation roadmap. $5-50K/engagement. https://aethermoore.com/red-team.html",
+        "route": "/red-team.html",
+    },
+    "datasets": {
+        "patterns": [r"dataset", r"training data", r"sft", r"corpus", r"prompt pack", r"adversarial prompts"],
+        "response": "We sell training datasets including the Governance SFT Pack ($99), Red Team Fortress ($149), and The Full Arsenal bundle ($399). https://aethermoore.com/datasets.html",
+        "route": "/datasets.html",
+    },
+    "contact": {
+        "patterns": [r"contact", r"email", r"reach out", r"talk to", r"schedule", r"book a call", r"get in touch"],
+        "response": "Email me directly at issac@aethermoorgames.com or use the contact form at https://aethermoore.com/contact.html. I usually reply within 24 hours.",
+        "route": "/contact.html",
+    },
+    "support": {
+        "patterns": [r"help", r"support", r"broken", r"missing", r"delivery", r"refund", r"issue", r"problem"],
+        "response": "For support with purchases, delivery, or broken links, visit https://aethermoore.com/support.html or email issac@aethermoorgames.com.",
+        "route": "/support.html",
+    },
+    "tools": {
+        "patterns": [r"tool", r"calculator", r"demo", r"interactive", r"browser tool", r"visualization"],
+        "response": "Our live browser tools and interactive demos are at https://aethermoore.com/demos/index.html. No install needed.",
+        "route": "/demos/index.html",
+    },
+    "research": {
+        "patterns": [r"research", r"benchmark", r"evidence", r"paper", r"study", r"proof", r"technical"],
+        "response": "Benchmarks, proofs, and technical justification are at https://aethermoore.com/research/index.html. Member-only raw notes are at https://aethermoore.com/members/research-notes.html",
+        "route": "/research/index.html",
+    },
+    "members": {
+        "patterns": [r"member", r"exclusive", r"insider", r"gated", r"research notes", r"early access"],
+        "response": "Members get raw research notes, early datasets, and member-only tools. Join SCBE Weekly to get the access PIN. https://aethermoore.com/members/",
+        "route": "/members/",
+    },
+    "open_source": {
+        "patterns": [r"github", r"open source", r"repo", r"code", r"npm", r"pypi", r"install"],
+        "response": "The framework is MIT-licensed and split across 9 repos. Main repo: github.com/issdandavis/SCBE-AETHERMOORE. npm install scbe-aethermoore",
+        "route": "https://github.com/issdandavis/SCBE-AETHERMOORE",
+    },
+    "book": {
+        "patterns": [r"book", r"novel", r"story", r"six tongues", r"fiction", r"read"],
+        "response": "The Six Tongues Protocol is a 70K-word novel that teaches the SCBE framework through story. Available on Amazon KDP.",
+        "route": "https://www.amazon.com/dp/B0F28PHSPR",
+    },
+    "greeting": {
+        "patterns": [r"^hi\b", r"^hello\b", r"^hey\b", r"^howdy\b"],
+        "response": "Hey. I'm Polly, the route-first operator for SCBE-AETHERMOORE. Tell me what you're looking for — pricing, products, research, support, or something else — and I'll point you to the right page.",
+        "route": "/assistant.html",
+    },
+}
+
+
+def classify_intent(text: str) -> tuple[str, dict]:
+    """Classify user text into an intent. Returns (intent_key, intent_data)."""
+    text_lower = text.lower().strip()
+
+    for intent_key, data in INTENT_PATTERNS.items():
+        for pattern in data["patterns"]:
+            if re.search(pattern, text_lower):
+                return intent_key, data
+
+    return "unknown", {
+        "response": "I'm not sure I understood. I can help with pricing, products, support, research, or point you to the right page. What are you looking for?",
+        "route": "/assistant.html",
+    }
+
+
+# ---------------------------------------------------------------------------
+#  LLM Enhancement (Gemini)
+# ---------------------------------------------------------------------------
+
+async def enhance_with_gemini(user_text: str, intent: str, route: str) -> Optional[str]:
+    """Use Gemini to enhance the response if API key is available."""
+    api_key = _env_get("GEMINI_API_KEY", "")
+    if not api_key:
+        return None
+
+    try:
+        import httpx
+
+        prompt = f"""You are Polly, a helpful and concise assistant for SCBE-AETHERMOORE (an AI governance company).
+
+User message: {user_text}
+Detected intent: {intent}
+Suggested route: {route}
+
+Respond in 1-2 sentences. Be direct, plain-spoken, and operational. Never use hype or marketing language. If you don't know something, say so."""
+
+        url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key={api_key}"
+        payload = {
+            "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+            "generationConfig": {"maxOutputTokens": 200, "temperature": 0.3},
+        }
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(url, json=payload)
+            if resp.status_code != 200:
+                return None
+            data = resp.json()
+            text = data.get("candidates", [{}])[0].get("content", {}).get("parts", [{}])[0].get("text", "")
+            return text.strip() if text else None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+#  Main Service Functions
+# ---------------------------------------------------------------------------
+
+async def chat(message: str, context: str = "site") -> dict:
+    """Handle a chat message and return a response."""
+    intent_key, intent_data = classify_intent(message)
+
+    # Try Gemini enhancement
+    enhanced = await enhance_with_gemini(message, intent_key, intent_data.get("route", ""))
+    response_text = enhanced or intent_data["response"]
+
+    return {
+        "response": response_text,
+        "intent": intent_key,
+        "route": intent_data.get("route", "/assistant.html"),
+        "context": context,
+        "enhanced": enhanced is not None,
+    }
+
+
+async def respond(text: str, context: str = "site", intent: str = "") -> dict:
+    """Alternative response endpoint (used by some Polly clients)."""
+    result = await chat(text, context)
+    return {
+        "text": result["response"],
+        "intent": result["intent"],
+        "route": result["route"],
+    }
+
+
+async def get_context() -> dict:
+    """Return backend capabilities and context."""
+    return {
+        "capabilities": ["chat", "search", "route", "delegate"],
+        "version": "1.0.0",
+        "model": "deterministic+gemini-fallback",
+        "lore_hash": hash(POLLY_LORE) & 0xFFFFFFFF,
+    }
+
+
+async def search(query: str) -> dict:
+    """Simple search proxy — returns intent-classified results."""
+    intent_key, intent_data = classify_intent(query)
+    return {
+        "query": query,
+        "intent": intent_key,
+        "route": intent_data.get("route", ""),
+        "results": [{"title": intent_data.get("response", "")[:80], "url": intent_data.get("route", "")}],
+    }
+
+
+async def delegate(text: str) -> dict:
+    """Delegation endpoint — routes to appropriate handler."""
+    intent_key, intent_data = classify_intent(text)
+    return {
+        "intent": intent_key,
+        "route": intent_data.get("route", "/assistant.html"),
+        "action": "route",
+        "confidence": 0.9 if intent_key != "unknown" else 0.3,
+    }

--- a/scripts/system/setup_cloudflare_tunnel.sh
+++ b/scripts/system/setup_cloudflare_tunnel.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Setup Cloudflare Tunnel for SCBE AetherBrowser API
+# This exposes your local API (port 8100) to the internet via HTTPS
+
+set -e
+
+TUNNEL_NAME="scbe-aetherbrowser"
+CONFIG_DIR="$HOME/.cloudflared"
+API_PORT="${AETHER_API_PORT:-8100}"
+
+echo "=== SCBE Cloudflare Tunnel Setup ==="
+echo ""
+
+# Check if cloudflared is installed
+if ! command -v cloudflared &> /dev/null; then
+    echo "Installing cloudflared..."
+    curl -L --output /tmp/cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+    sudo dpkg -i /tmp/cloudflared.deb || sudo apt-get install -f -y
+fi
+
+# Authenticate
+echo "Step 1: Authenticate with Cloudflare"
+echo "This will open a browser. Choose the zone for aethermoore.com"
+if [ ! -f "$CONFIG_DIR/cert.pem" ]; then
+    cloudflared tunnel login
+fi
+
+# Create tunnel
+echo ""
+echo "Step 2: Creating tunnel: $TUNNEL_NAME"
+TUNNEL_ID=$(cloudflared tunnel create "$TUNNEL_NAME" 2>/dev/null | grep -oP 'Created tunnel \K[a-z0-9-]+' || true)
+
+if [ -z "$TUNNEL_ID" ]; then
+    echo "Tunnel may already exist. Listing tunnels:"
+    cloudflared tunnel list
+    echo ""
+    echo "Enter the tunnel ID from above:"
+    read TUNNEL_ID
+fi
+
+# Write config
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_DIR/$TUNNEL_ID.json" << EOF
+{
+    "tunnel": "$TUNNEL_ID",
+    "credentials-file": "$CONFIG_DIR/$TUNNEL_ID.json",
+    "ingress": [
+        {
+            "hostname": "api.aethermoore.com",
+            "service": "http://localhost:$API_PORT"
+        },
+        {
+            "service": "http_status:404"
+        }
+    ]
+}
+EOF
+
+# Create DNS record
+echo ""
+echo "Step 3: Creating DNS record api.aethermoore.com → tunnel"
+cloudflared tunnel route dns "$TUNNEL_NAME" "api.aethermoore.com"
+
+echo ""
+echo "=== Setup complete ==="
+echo ""
+echo "To start the tunnel:"
+echo "  cloudflared tunnel run $TUNNEL_NAME"
+echo ""
+echo "To run as a service:"
+echo "  sudo cloudflared service install"
+echo "  sudo systemctl start cloudflared"
+echo ""
+echo "Your API will be available at: https://api.aethermoore.com"
+echo ""
+echo "Test the contact endpoint:"
+echo "  curl -X POST https://api.aethermoore.com/api/contact \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"name\":\"Test\",\"email\":\"test@example.com\",\"subject\":\"Hello\",\"message\":\"Test message\"}'"


### PR DESCRIPTION
Implements the missing /v1/polly/* endpoints that the website sidebar assistant expects.

**Changes:**
- New `scripts/system/polly_service.py` with deterministic intent classification
- Added `/v1/polly/chat`, `/respond`, `/context`, `/search`, `/delegate` to api_server.py
- Keyword-based routing (pricing, red team, iso 42001, datasets, contact, support, etc.)
- Optional Gemini enhancement when `GEMINI_API_KEY` is set
- Uses httpx (already in venv)

**Tested locally:**
All endpoints return correct responses. Cloudflare tunnel already serving them at `https://api.aethermoore.com`.