### PR TITLE
fix(version): align pyproject.toml to 4.0.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | **Property Testing** | fast-check (TS), Hypothesis (Python) |
 | **API** | FastAPI + Uvicorn (Python), Express 5 (TypeScript) |
 | **TypeScript** | ^6.0.2, target ES2022, CommonJS (`ignoreDeprecations: "6.0"`) |
-| **Package Version** | 3.3.0 (npm + PyPI synced) |
+| **Package Version** | 4.0.3 (npm + PyPI synced) |
 | **Package Entry** | `./dist/src/index.js` |
 
 ## Common Commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scbe-aethermoore"
-version = "3.3.0"
+version = "4.0.3"
 description = "Hyperbolic Geometry AI Safety Framework with 14-Layer Architecture"
 readme = "README.md"
 license = "MIT"

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scbe-aethermoore"
-version = "3.3.0"
+version = "4.0.3"
 description = "Post-quantum hybrid encryption with hyperbolic geometry for AI safety governance"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Both `pyproject.toml` and `src/pyproject.toml` were stuck at 3.3.0 while `package.json` moved to 4.0.3
- Updates CLAUDE.md to reflect correct version
- 3 files changed, 3 lines each

## Test plan
- [ ] CI passes
- [ ] `pip install -e .` shows version 4.0.3