### PR TITLE
fix(ci): missing build script + Prettier formatting

### DIFF
--- a/scripts/write_root_index_dts.mjs
+++ b/scripts/write_root_index_dts.mjs
@@ -1,0 +1,23 @@
+/**
+ * Post-build step: copies dist/src/index.d.ts → dist/index.d.ts so that
+ * consumers using `import … from 'scbe-aethermoore'` resolve types from the
+ * package root even if their tooling doesn't follow the "types" field.
+ *
+ * If the source .d.ts doesn't exist (e.g. tsc errored), this script exits
+ * cleanly so the real error surfaces from tsc, not from here.
+ */
+
+import { copyFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const src = join(root, 'dist', 'src', 'index.d.ts');
+const dest = join(root, 'dist', 'index.d.ts');
+
+if (existsSync(src)) {
+  copyFileSync(src, dest);
+  console.log('write_root_index_dts: dist/index.d.ts written');
+} else {
+  console.log('write_root_index_dts: dist/src/index.d.ts not found, skipping');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * SCBE-AETHERMOORE v3.3.0
+ * SCBE-AETHERMOORE v4.0.3
  * Hyperbolic Geometry AI Safety & Governance Framework — 14-Layer Pipeline
  *
  * Patent Pending: USPTO #63/961,403

--- a/src/spiralauth/index.ts
+++ b/src/spiralauth/index.ts
@@ -111,14 +111,15 @@ export function tokenizeCommand(
   return { tokenIds, tokenMeanings, unknownTokens };
 }
 
-export function canonicalSpiralAuthEnvelope(
-  envelope: Omit<SpiralAuthEnvelope, 'mac'>
-): string {
+export function canonicalSpiralAuthEnvelope(envelope: Omit<SpiralAuthEnvelope, 'mac'>): string {
   return canonicalize(envelope);
 }
 
 export function signSpiralAuthCommand(params: SpiralAuthSignParams): SpiralAuthEnvelope {
-  const { tokenIds, tokenMeanings, unknownTokens } = tokenizeCommand(params.command, params.lexicon);
+  const { tokenIds, tokenMeanings, unknownTokens } = tokenizeCommand(
+    params.command,
+    params.lexicon
+  );
   if (unknownTokens.length > 0) {
     throw new Error(`unknown command tokens: ${unknownTokens.join(',')}`);
   }

--- a/tests/L2-unit/cli.unit.test.ts
+++ b/tests/L2-unit/cli.unit.test.ts
@@ -11,7 +11,8 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'child_process';
 
-const PYTHON_CANDIDATES = process.platform === 'win32' ? ['python', 'python3'] : ['python3', 'python'];
+const PYTHON_CANDIDATES =
+  process.platform === 'win32' ? ['python', 'python3'] : ['python3', 'python'];
 
 function resolvePython(): string | null {
   for (const candidate of PYTHON_CANDIDATES) {
@@ -127,10 +128,25 @@ maybeDescribe('Unified scbe CLI', () => {
   describe('tongues roundtrip', () => {
     for (const tongue of ['KO', 'AV', 'RU', 'CA', 'UM', 'DR']) {
       it(`${tongue}: encode then decode recovers original`, () => {
-        const encoded = run(
-          ['scbe.py', 'tongues', 'encode', '--tongue', tongue, '--text', 'roundtrip test 123']
-        );
-        const decoded = run(['scbe.py', 'tongues', 'decode', '--tongue', tongue, '--as-text', '--text', encoded]);
+        const encoded = run([
+          'scbe.py',
+          'tongues',
+          'encode',
+          '--tongue',
+          tongue,
+          '--text',
+          'roundtrip test 123',
+        ]);
+        const decoded = run([
+          'scbe.py',
+          'tongues',
+          'decode',
+          '--tongue',
+          tongue,
+          '--as-text',
+          '--text',
+          encoded,
+        ]);
         expect(decoded).toBe('roundtrip test 123');
       });
     }
@@ -243,9 +259,26 @@ maybeParityDescribe('Cross-CLI parity', () => {
 
   it('all 3 CLIs decode identically', () => {
     const tokens = run(['scbe.py', 'tongues', 'encode', '--tongue', 'ko', '--text', 'three way']);
-    const d1 = run(['scbe.py', 'tongues', 'decode', '--tongue', 'ko', '--as-text', '--text', tokens]);
+    const d1 = run([
+      'scbe.py',
+      'tongues',
+      'decode',
+      '--tongue',
+      'ko',
+      '--as-text',
+      '--text',
+      tokens,
+    ]);
     const d2 = run(['scbe-cli.py', 'decode', '--tongue', 'ko', '--as-text', '--text', tokens]);
-    const d3 = run(['six-tongues-cli.py', 'decode', '--tongue', 'KO', '--as-text', '--text', tokens]);
+    const d3 = run([
+      'six-tongues-cli.py',
+      'decode',
+      '--tongue',
+      'KO',
+      '--as-text',
+      '--text',
+      tokens,
+    ]);
     expect(d1).toBe('three way');
     expect(d2).toBe('three way');
     expect(d3).toBe('three way');

--- a/tests/cross-language/gyroscopic_interlattice_parity.test.ts
+++ b/tests/cross-language/gyroscopic_interlattice_parity.test.ts
@@ -21,7 +21,8 @@ import {
 
 const CWD = process.cwd();
 const TMP_SCRIPT = join(CWD, '_tmp_parity_test.py');
-const PYTHON_CANDIDATES = process.platform === 'win32' ? ['python', 'python3'] : ['python3', 'python'];
+const PYTHON_CANDIDATES =
+  process.platform === 'win32' ? ['python', 'python3'] : ['python3', 'python'];
 
 /**
  * Run a Python expression and return its output via temp file (avoids shell quoting issues).


### PR DESCRIPTION
## Summary
Fixes 2 of 3 CI failures that have been red on every PR:

- **Build failure**: `scripts/write_root_index_dts.mjs` was referenced in `package.json` build:src but never committed. Created the script — copies `dist/src/index.d.ts` to `dist/index.d.ts` for root-level type resolution.
- **Lint failure**: 3 files had Prettier formatting issues (`src/spiralauth/index.ts`, `tests/cross-language/gyroscopic_interlattice_parity.test.ts`, `tests/L2-unit/cli.unit.test.ts`).
- **Bonus**: version string in `src/index.ts` was still 3.3.0, updated to 4.0.3.

The third CI failure (Python test discovery, exit code 3) is a pre-existing test configuration issue — not addressed here.

## Test plan
- [ ] CI "Build project" step passes
- [ ] CI "Check TypeScript formatting" step passes
- [ ] `npm run build` succeeds locally