### PR TITLE
fix(version): VERSION export stuck at 3.0.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -356,7 +356,7 @@ export * from './selfHealing/quickFixBot.js';
 export * from './governance/offline_mode.js';
 
 // Version and Metadata
-export const VERSION = '3.0.0';
+export const VERSION = '4.0.3';
 export const PATENT_NUMBER = 'USPTO #63/961,403';
 export const ARCHITECTURE_LAYERS = 14;
 


### PR DESCRIPTION
The `VERSION` constant exported from `src/index.ts` was `'3.0.0'` — every npm consumer who reads it gets the wrong version. Updates to `'4.0.3'`.