### PR TITLE
feat(browser): AetherBrowser pack with multi-lane controls

### DIFF
--- a/agents/browser_agent.py
+++ b/agents/browser_agent.py
@@ -384,12 +384,14 @@ class SCBEBrowserAgent:
         agent_id: str = "browser-agent-001",
         agent_name: str = "SCBE Browser Agent",
         initial_trust: float = 0.7,
-        auto_escalate: bool = True
+        auto_escalate: bool = True,
+        runtime=None,
     ):
         self.agent_id = agent_id
         self.agent_name = agent_name
         self.initial_trust = initial_trust
         self.auto_escalate = auto_escalate
+        self.runtime = runtime  # PlaywrightRuntime instance or None for dry-run
 
         # Initialize components
         self.scbe = SCBEClient()
@@ -514,8 +516,11 @@ class SCBEBrowserAgent:
                 "result": result,
                 "timestamp": datetime.now(timezone.utc).isoformat()
             })
-            # In quarantine mode, we might still execute with extra logging
-            can_execute = True  # Execute but monitored
+            # Only auto-execute quarantined actions on low-risk domains
+            domain_risk = self._get_domain_risk(action.target)
+            can_execute = domain_risk < 0.5
+            if not can_execute:
+                print(f"         [QUARANTINE-BLOCKED] Domain risk {domain_risk:.2f} too high for auto-execute")
 
         elif result.needs_escalation:
             if self.auto_escalate:
@@ -563,8 +568,9 @@ class SCBEBrowserAgent:
 
         if can_execute:
             print(f"         Navigating to: {url}")
-            # In real implementation, this would use browser automation
-            # e.g., selenium, playwright, or Chrome DevTools Protocol
+            if self.runtime:
+                import asyncio
+                asyncio.get_event_loop().run_until_complete(self.runtime.navigate(url))
             return True
         return False
 
@@ -580,6 +586,9 @@ class SCBEBrowserAgent:
 
         if can_execute:
             print(f"         Clicking: {selector}")
+            if self.runtime:
+                import asyncio
+                asyncio.get_event_loop().run_until_complete(self.runtime.click(selector))
             return True
         return False
 
@@ -598,6 +607,9 @@ class SCBEBrowserAgent:
 
         if can_execute:
             print(f"         Typing into: {selector}")
+            if self.runtime:
+                import asyncio
+                asyncio.get_event_loop().run_until_complete(self.runtime.type_text(selector, text))
             return True
         return False
 
@@ -613,6 +625,9 @@ class SCBEBrowserAgent:
 
         if can_execute:
             print(f"         Submitting form: {form_selector}")
+            if self.runtime:
+                import asyncio
+                asyncio.get_event_loop().run_until_complete(self.runtime.submit_form(form_selector))
             return True
         return False
 
@@ -648,6 +663,9 @@ class SCBEBrowserAgent:
 
         if can_execute:
             print(f"         Executing script (hash: {script_hash})")
+            if self.runtime:
+                import asyncio
+                asyncio.get_event_loop().run_until_complete(self.runtime.evaluate(script))
             return True
         return False
 

--- a/agents/playwright_runtime.py
+++ b/agents/playwright_runtime.py
@@ -1,0 +1,144 @@
+"""
+Async Playwright browser runtime for SCBE browser agents.
+
+Provides real browser automation behind the governance layer.
+When Playwright is not installed, methods raise RuntimeError with
+a helpful message — governance stubs (dry-run mode) remain available
+in browser_agent.py and swarm_browser.py without this dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger("scbe.agents.playwright_runtime")
+
+try:
+    from playwright.async_api import async_playwright, Browser, BrowserContext, Page
+    _PW_AVAILABLE = True
+except ImportError:
+    _PW_AVAILABLE = False
+
+
+class PlaywrightRuntime:
+    """Async Playwright wrapper for governed browser agents."""
+
+    def __init__(self) -> None:
+        self._pw: Any = None
+        self._browser: Optional[Browser] = None
+        self._context: Optional[BrowserContext] = None
+        self._page: Optional[Page] = None
+
+    # -- lifecycle -----------------------------------------------------------
+
+    async def launch(self, *, headless: bool = True, **kwargs: Any) -> None:
+        if not _PW_AVAILABLE:
+            raise RuntimeError(
+                "playwright is not installed. "
+                "Run: pip install playwright && python -m playwright install chromium"
+            )
+        self._pw = await async_playwright().start()
+        self._browser = await self._pw.chromium.launch(headless=headless, **kwargs)
+        self._context = await self._browser.new_context()
+        self._page = await self._context.new_page()
+        logger.info("PlaywrightRuntime launched (headless=%s)", headless)
+
+    async def close(self) -> None:
+        if self._context:
+            await self._context.close()
+            self._context = None
+        if self._browser:
+            await self._browser.close()
+            self._browser = None
+        if self._pw:
+            await self._pw.stop()
+            self._pw = None
+        self._page = None
+        logger.info("PlaywrightRuntime closed")
+
+    @property
+    def is_connected(self) -> bool:
+        return self._browser is not None and self._browser.is_connected()
+
+    @property
+    def current_url(self) -> str:
+        if self._page:
+            return self._page.url
+        return ""
+
+    # -- navigation ----------------------------------------------------------
+
+    async def navigate(self, url: str, *, timeout: int = 30_000) -> str:
+        self._require_page()
+        response = await self._page.goto(url, timeout=timeout, wait_until="domcontentloaded")
+        logger.info("Navigated to %s (status=%s)", url, response.status if response else "?")
+        return self._page.url
+
+    async def go_back(self) -> None:
+        self._require_page()
+        await self._page.go_back()
+
+    async def go_forward(self) -> None:
+        self._require_page()
+        await self._page.go_forward()
+
+    # -- interaction ---------------------------------------------------------
+
+    async def click(self, selector: str, *, timeout: int = 10_000) -> None:
+        self._require_page()
+        await self._page.click(selector, timeout=timeout)
+        logger.debug("Clicked %s", selector)
+
+    async def type_text(self, selector: str, text: str, *, delay: int = 0) -> None:
+        self._require_page()
+        await self._page.fill(selector, "")
+        if delay:
+            await self._page.type(selector, text, delay=delay)
+        else:
+            await self._page.fill(selector, text)
+        logger.debug("Typed %d chars into %s", len(text), selector)
+
+    async def submit_form(self, selector: str) -> None:
+        self._require_page()
+        await self._page.click(selector)
+        logger.debug("Submitted form via %s", selector)
+
+    async def select_option(self, selector: str, value: str) -> None:
+        self._require_page()
+        await self._page.select_option(selector, value)
+
+    async def hover(self, selector: str) -> None:
+        self._require_page()
+        await self._page.hover(selector)
+
+    # -- observation ---------------------------------------------------------
+
+    async def screenshot(self, *, path: Optional[str] = None, full_page: bool = False) -> bytes:
+        self._require_page()
+        data = await self._page.screenshot(path=path, full_page=full_page)
+        logger.debug("Screenshot taken (full_page=%s)", full_page)
+        return data
+
+    async def evaluate(self, script: str, *args: Any) -> Any:
+        self._require_page()
+        return await self._page.evaluate(script, *args)
+
+    async def content(self) -> str:
+        self._require_page()
+        return await self._page.content()
+
+    async def title(self) -> str:
+        self._require_page()
+        return await self._page.title()
+
+    async def wait_for_selector(self, selector: str, *, timeout: int = 10_000) -> None:
+        self._require_page()
+        await self._page.wait_for_selector(selector, timeout=timeout)
+
+    # -- internal ------------------------------------------------------------
+
+    def _require_page(self) -> None:
+        if self._page is None:
+            raise RuntimeError("PlaywrightRuntime not launched — call await runtime.launch() first")

--- a/agents/swarm_browser.py
+++ b/agents/swarm_browser.py
@@ -252,12 +252,22 @@ class ScoutAgent(SwarmAgent):
             # Analyze URL for safety
             risk = self._assess_url_risk(url)
 
+            # Execute real navigation if browser backend available and safe
+            nav_success = False
+            if risk < 0.7 and self.swarm.browser and hasattr(self.swarm.browser, "navigate"):
+                try:
+                    await self.swarm.browser.navigate(url)
+                    nav_success = True
+                except Exception as exc:
+                    logger.warning("ScoutAgent: browser navigate failed: %s", exc)
+
             return self.create_message(
                 "navigation_plan",
                 {
                     "url": url,
                     "risk_score": risk,
                     "safe": risk < 0.7,
+                    "navigated": nav_success,
                     "recommendation": "proceed" if risk < 0.7 else "escalate"
                 },
                 to_agent=SacredTongue.DR  # Send to Judge
@@ -432,12 +442,19 @@ class ClickerAgent(SwarmAgent):
 
         if action == "click":
             coordinates = payload.get("coordinates", [0, 0])
-            # Would execute click via browser backend
+            selector = payload.get("selector")
+            success = True
+            if selector and self.swarm.browser and hasattr(self.swarm.browser, "click"):
+                try:
+                    await self.swarm.browser.click(selector)
+                except Exception as exc:
+                    logger.warning("ClickerAgent: browser click failed: %s", exc)
+                    success = False
             return self.create_message(
                 "click_result",
                 {
                     "coordinates": coordinates,
-                    "success": True,
+                    "success": success,
                     "element_clicked": payload.get("target", "unknown")
                 }
             )
@@ -457,12 +474,19 @@ class TyperAgent(SwarmAgent):
 
         if action == "type":
             text = payload.get("text", "")
-            # Would execute typing via browser backend
+            selector = payload.get("selector")
+            success = True
+            if selector and self.swarm.browser and hasattr(self.swarm.browser, "type_text"):
+                try:
+                    await self.swarm.browser.type_text(selector, text)
+                except Exception as exc:
+                    logger.warning("TyperAgent: browser type failed: %s", exc)
+                    success = False
             return self.create_message(
                 "type_result",
                 {
                     "length": len(text),
-                    "success": True,
+                    "success": success,
                     "masked": True  # Never log actual text
                 }
             )

--- a/docs/AETHERBROWSER_PACK.md
+++ b/docs/AETHERBROWSER_PACK.md
@@ -1,0 +1,168 @@
+# AetherBrowser Pack
+
+Multi-lane governed browser automation for agentic browsing.
+
+## What ships
+
+### TypeScript (`scbe-aethermoore/browser`)
+
+```ts
+import {
+  BrowserAgent,
+  CDPBackend,
+  PlaywrightBackend,
+  MockBrowserBackend,
+  BrowserActionEvaluator,
+  BrowserSession,
+  WSClient,
+} from 'scbe-aethermoore/browser';
+```
+
+| Module | What it does |
+|--------|-------------|
+| **BrowserAgent** | Orchestrator — routes every action through 14-layer governance pipeline |
+| **CDPBackend** | Zero-dependency Chrome DevTools Protocol automation (raw WebSocket) |
+| **PlaywrightBackend** | Playwright wrapper with graceful fallback if not installed |
+| **MockBrowserBackend** | Testing backend — no real browser needed |
+| **BrowserActionEvaluator** | 14-layer governance: semantic encoding → Poincare embedding → hyperbolic distance → harmonic scaling → risk decision |
+| **BrowserSession** | Session state: risk accumulation, action history, escalation queue |
+| **WSClient** | RFC 6455 WebSocket client for extension ↔ server communication |
+
+### Chrome Extension (`src/extension/`)
+
+Manifest V3 sidePanel extension connecting to the Python WebSocket server:
+
+- **Side panel UI**: agent grid, conversation feed, zone approval prompts, topology canvas
+- **Content script**: DOM observation on all pages
+- **Background worker**: WebSocket connection management
+- Load via `chrome://extensions` → Developer mode → Load unpacked → select `src/extension/`
+
+### Python Server (`src/aetherbrowser/`)
+
+```bash
+python -m uvicorn src.aetherbrowser.serve:app --host 127.0.0.1 --port 8002
+```
+
+| Module | What it does |
+|--------|-------------|
+| **serve.py** | FastAPI WebSocket server handling COMMAND, PAGE_CONTEXT, ZONE_RESPONSE |
+| **router.py** | OctoArmorRouter — 7-provider model selection with cost tiers and rate limiting |
+| **command_planner.py** | Risk inference, zone assignment (RED/YELLOW/GREEN), intent classification |
+| **provider_executor.py** | Async LLM execution: Anthropic, OpenAI, xAI, HuggingFace, local fallback |
+| **page_analyzer.py** | Heuristic page analysis (topic detection, auth/payment/destructive field classification) |
+| **ws_feed.py** | WebSocket message protocol factory |
+
+### Python Agents (`agents/`)
+
+| Agent | Architecture | What it does |
+|-------|-------------|-------------|
+| **browser_agent.py** | Single-agent + SCBE API | Every action → governance gate → execute if approved. 4-tier escalation (ALLOW/QUARANTINE/ESCALATE/DENY). |
+| **swarm_browser.py** | 6-agent Byzantine consensus | Six Sacred Tongue agents (Scout/Vision/Reader/Clicker/Typer/Judge). 4/6 majority vote. HMAC-signed messages. JSONL audit hub. |
+| **playwright_runtime.py** | Browser backend | Async Playwright wrapper. Pass to browser_agent or swarm_browser for real browser control. |
+
+## Multi-lane controls
+
+### Zone gates (hard-enforced)
+
+| Zone | Trigger | Behavior |
+|------|---------|----------|
+| **RED** | High-risk action (banking, auth, side-effects) | Blocks execution until explicit user approval via extension UI |
+| **YELLOW** | Medium-risk action (mixed analysis + action) | Requires approval; auto-allowed for low-risk domains |
+| **GREEN** | Low-risk action (read-only, analysis) | Passes through without gate |
+
+Safety net: any `risk_tier == "high"` action is forced to RED even if keyword heuristics missed it.
+
+Quarantine enforcement: quarantined actions only auto-execute when domain risk < 0.5. Banking (0.95), healthcare (0.8), government (0.75) domains are blocked in quarantine.
+
+### Sacred Tongues routing
+
+Each action is assigned to a Sacred Tongue agent based on type:
+
+| Action | Tongue | Default Provider |
+|--------|--------|-----------------|
+| navigate | KO (Knowledge) | OPUS |
+| click | AV (Analysis) | FLASH |
+| type | RU (Runtime) | LOCAL |
+| scroll | CA (Cascade) | SONNET |
+| execute_script | DR (Diagnosis) | HAIKU |
+| screenshot | UM (Uncertainty) | GROK |
+
+### Provider cascade
+
+OctoArmorRouter scores task complexity (LOW/MEDIUM/HIGH) and selects provider by cost tier:
+
+- Tier 0: LOCAL (free, immediate)
+- Tier 1: HAIKU (fast, cheap)
+- Tier 2: FLASH, GROK (balanced)
+- Tier 3: SONNET (capable)
+- Tier 4: OPUS (best, expensive)
+
+Auto-cascade: if the selected provider fails, falls back through the chain.
+
+## What does NOT ship
+
+- Training data, SFT pairs, model weights
+- Research pipeline or news feed
+- API keys or credentials
+- Basin river paths (Dropbox, OneDrive, etc.) — config only
+- HYDRA orchestrator (separate repo: `issdandavis/scbe-agents`)
+
+## Quick start
+
+```bash
+# TypeScript
+npm install scbe-aethermoore
+```
+
+```ts
+import { BrowserAgent, PlaywrightBackend } from 'scbe-aethermoore/browser';
+
+const backend = new PlaywrightBackend();
+await backend.initialize({ headless: false });
+
+const agent = new BrowserAgent({ backend });
+await agent.startSession();
+
+// Every action goes through 14-layer governance
+const result = await agent.navigate('https://example.com');
+console.log(result.decision); // ALLOW | QUARANTINE | ESCALATE | DENY
+```
+
+```bash
+# Python (governed single-agent)
+pip install playwright && python -m playwright install chromium
+
+python -c "
+import asyncio
+from agents.playwright_runtime import PlaywrightRuntime
+from agents.browser_agent import SCBEBrowserAgent
+
+async def main():
+    rt = PlaywrightRuntime()
+    await rt.launch(headless=False)
+    agent = SCBEBrowserAgent(runtime=rt)
+    agent.navigate('https://example.com')  # governed
+    await rt.close()
+
+asyncio.run(main())
+"
+```
+
+```bash
+# Python (6-agent Byzantine swarm)
+python -c "
+import asyncio
+from agents.playwright_runtime import PlaywrightRuntime
+from agents.swarm_browser import SwarmBrowser
+
+async def main():
+    rt = PlaywrightRuntime()
+    await rt.launch(headless=False)
+    swarm = SwarmBrowser(browser_backend=rt)
+    await swarm.initialize()
+    await swarm.navigate('https://example.com')  # consensus-governed
+    await rt.close()
+
+asyncio.run(main())
+"
+```

--- a/package.json
+++ b/package.json
@@ -61,12 +61,19 @@
       "types": "./dist/src/governance/index.d.ts",
       "import": "./dist/src/governance/index.js",
       "require": "./dist/src/governance/index.js"
-    }
+    },
+    "./browser": {
+      "types": "./dist/src/browser/index.d.ts",
+      "import": "./dist/src/browser/index.js",
+      "require": "./dist/src/browser/index.js"
+    },
+    "./browser/extension": "./src/extension/manifest.json"
   },
   "files": [
     "bin",
     "dist/src",
     "dist/packages",
+    "src/extension",
     "README.md",
     "LICENSE",
     "examples/npm"

--- a/src/aetherbrowser/serve.py
+++ b/src/aetherbrowser/serve.py
@@ -156,6 +156,11 @@ async def _handle_command(ws: WebSocket, msg: dict) -> None:
         routing_preferences=routing_preferences,
         auto_cascade=auto_cascade,
     )
+    # A4: force RED gate on high-risk actions even if keyword heuristics missed
+    if plan.risk_tier == "high" and not plan.approval_required:
+        import dataclasses
+        plan = dataclasses.replace(plan, approval_required=True, review_zone="RED")
+
     assignments = plan.assignments
     squad.set_state(TongueRole.KO, AgentState.WORKING, model=plan.provider)
     await ws.send_json(feed.agent_status(Agent.KO, "working", model=plan.provider))

--- a/tests/aetherbrowser/test_zone_hard_gate.py
+++ b/tests/aetherbrowser/test_zone_hard_gate.py
@@ -1,0 +1,100 @@
+"""Tests for zone enforcement hard gates."""
+
+import pytest
+import os
+import sys
+from unittest.mock import MagicMock, patch
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+
+def _make_agent(agent_id="test"):
+    """Create an SCBEBrowserAgent with mocked API connectivity."""
+    with patch.dict(os.environ, {"SCBE_API_KEY": "test-key-000"}):
+        with patch("agents.browser_agent.SCBEClient") as MockClient:
+            instance = MockClient.return_value
+            instance.api_key = "test-key-000"
+            instance.health_check.return_value = True
+            instance.register_agent.return_value = True
+            from agents.browser_agent import SCBEBrowserAgent
+            return SCBEBrowserAgent(agent_id=agent_id)
+
+
+def test_quarantine_blocks_high_risk_domain():
+    """QUARANTINE on a banking domain (risk >= 0.5) should NOT auto-execute."""
+    agent = _make_agent("test-001")
+    risk = agent._get_domain_risk("https://bank.example.com/transfer")
+    assert risk >= 0.5, f"Banking domain risk {risk} should be >= 0.5"
+
+
+def test_quarantine_allows_low_risk_domain():
+    """QUARANTINE on a search domain (risk < 0.5) should auto-execute."""
+    agent = _make_agent("test-002")
+    risk = agent._get_domain_risk("https://google.com/search?q=test")
+    assert risk < 0.5, f"Search domain risk {risk} should be < 0.5"
+
+
+def test_domain_risk_categories():
+    """Verify domain risk classification covers expected categories."""
+    agent = _make_agent("test-003")
+
+    # High risk (>= 0.5)
+    assert agent._get_domain_risk("https://bankofamerica.com") >= 0.5
+    assert agent._get_domain_risk("https://pay.google.com") >= 0.5
+    assert agent._get_domain_risk("https://health.gov") >= 0.5
+
+    # Lower risk (< 0.5)
+    assert agent._get_domain_risk("https://google.com") < 0.5
+    assert agent._get_domain_risk("https://wikipedia.org") < 0.5
+
+
+def test_serve_forces_red_on_high_risk():
+    """High risk_tier without approval_required gets forced to RED gate."""
+    # Simulate the logic from serve.py _handle_command
+    import dataclasses
+
+    @dataclass
+    class FakePlan:
+        risk_tier: str
+        approval_required: bool
+        review_zone: str = ""
+        assignments: list = None
+        provider: str = "local"
+        targets: list = None
+        intent: str = "general"
+        required_approvals: list = None
+
+        def __post_init__(self):
+            self.assignments = self.assignments or []
+            self.targets = self.targets or []
+            self.required_approvals = self.required_approvals or []
+
+    # A plan with high risk but no approval flag (heuristic miss)
+    plan = FakePlan(risk_tier="high", approval_required=False, review_zone="")
+
+    # Apply the fix from serve.py
+    if plan.risk_tier == "high" and not plan.approval_required:
+        plan = dataclasses.replace(plan, approval_required=True, review_zone="RED")
+
+    assert plan.approval_required is True
+    assert plan.review_zone == "RED"
+
+
+def test_low_risk_not_forced():
+    """Low risk plans should not be forced to RED."""
+    import dataclasses
+
+    @dataclass
+    class FakePlan:
+        risk_tier: str
+        approval_required: bool
+        review_zone: str = ""
+
+    plan = FakePlan(risk_tier="low", approval_required=False)
+
+    if plan.risk_tier == "high" and not plan.approval_required:
+        plan = dataclasses.replace(plan, approval_required=True, review_zone="RED")
+
+    assert plan.approval_required is False
+    assert plan.review_zone == ""


### PR DESCRIPTION
## Summary

Ships AetherBrowser as a governed agentic browsing pack with multi-lane controls.

### What's new
- **`scbe-aethermoore/browser` export** — BrowserAgent, CDPBackend, PlaywrightBackend, evaluator, session, WSClient now available as a package subpath
- **`agents/playwright_runtime.py`** — real async Playwright backend for Python agents (was all stubs before)
- **Hard zone gates** — RED/YELLOW/GREEN zones now actually enforce. Banking domains blocked in quarantine. High-risk actions forced to RED even if heuristics missed them.
- **Chrome extension** included in package files

### What ships
| Layer | Components |
|-------|-----------|
| TypeScript | BrowserAgent + CDPBackend + PlaywrightBackend + 14-layer evaluator + session + WSClient |
| Chrome Extension | Manifest V3 sidePanel with agent grid, zone approval, topology canvas |
| Python Server | serve.py (WebSocket) + OctoArmorRouter (7 providers) + CommandPlan (risk/zone) |
| Python Agents | Single-agent (browser_agent.py) + 6-agent Byzantine swarm (swarm_browser.py) |
| Browser Runtime | playwright_runtime.py — real Playwright calls behind governance layer |

### What does NOT ship
Training data, SFT pairs, model weights, research pipeline, API keys

## Test plan
- [x] `npm run build` succeeds (browser module compiles)
- [x] `dist/src/browser/index.js` + `.d.ts` generated
- [x] 5 zone gate tests pass (`test_zone_hard_gate.py`)
- [ ] CI passes
- [ ] Chrome extension loads in developer mode