### PR TITLE
feat(browser): web scraping, research agent, tool API

### DIFF
--- a/agents/browser_api.py
+++ b/agents/browser_api.py
@@ -1,0 +1,221 @@
+"""
+HTTP API for browser tools. Exposes all tools from browser_tools.py
+as REST endpoints. Run locally or behind Vercel/Cloudflare tunnel.
+
+Start:
+    python agents/browser_api.py
+    # or
+    uvicorn agents.browser_api:app --host 0.0.0.0 --port 8003
+
+Endpoints:
+    GET  /tools           — list available tools (MCP-compatible)
+    POST /tools/{name}    — call a tool with JSON body
+    POST /tool_use        — MCP tool_use protocol (name + arguments in body)
+    GET  /health          — health check
+
+Vercel integration:
+    Set BROWSER_API_URL in Vercel env, then proxy from api/browser.py:
+        from agents.browser_api import app
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from contextlib import asynccontextmanager
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi import FastAPI, HTTPException, Request, Header
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+from agents.browser_tools import call_tool, list_tools, shutdown
+
+logger = logging.getLogger("scbe.agents.browser_api")
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+_API_KEY = os.getenv("SCBE_BROWSER_API_KEY", "")
+
+
+def _check_auth(key: Optional[str]) -> None:
+    """Check API key if configured."""
+    if _API_KEY and key != _API_KEY:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Browser API starting")
+    yield
+    logger.info("Browser API shutting down")
+    await shutdown()
+
+
+app = FastAPI(
+    title="SCBE Browser Tools API",
+    version="1.0.0",
+    description="Governed browser automation, web scraping, and research tools.",
+    lifespan=lifespan,
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:3000",
+        "http://localhost:8000",
+        "http://127.0.0.1:3000",
+        "https://aethermoore.com",
+        "https://*.vercel.app",
+    ],
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization", "x-api-key"],
+)
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+class ToolUseRequest(BaseModel):
+    name: str
+    arguments: Dict[str, Any] = {}
+
+
+class ToolCallRequest(BaseModel):
+    """Generic tool call — body IS the arguments."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@app.get("/health")
+async def health():
+    return {
+        "status": "ok",
+        "service": "scbe-browser-tools",
+        "tools": len(list_tools()),
+    }
+
+
+@app.get("/tools")
+async def get_tools(x_api_key: Optional[str] = Header(None)):
+    _check_auth(x_api_key)
+    return {"tools": list_tools()}
+
+
+@app.post("/tools/{tool_name}")
+async def call_tool_by_name(
+    tool_name: str,
+    request: Request,
+    x_api_key: Optional[str] = Header(None),
+):
+    """Call a tool by name. Request body is the arguments dict."""
+    _check_auth(x_api_key)
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    result = await call_tool(tool_name, body)
+    if "error" in result and "Unknown tool" in result.get("error", ""):
+        raise HTTPException(status_code=404, detail=result["error"])
+    return result
+
+
+@app.post("/tool_use")
+async def mcp_tool_use(
+    req: ToolUseRequest,
+    x_api_key: Optional[str] = Header(None),
+):
+    """MCP-compatible tool_use endpoint."""
+    _check_auth(x_api_key)
+    result = await call_tool(req.name, req.arguments)
+    return {"type": "tool_result", "content": result}
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions workflow helper
+# ---------------------------------------------------------------------------
+
+@app.post("/workflow/research")
+async def workflow_research(
+    request: Request,
+    x_api_key: Optional[str] = Header(None),
+):
+    """
+    Convenience endpoint for GitHub Actions workflows.
+    Accepts: {"query": "...", "max_sources": 5}
+    Returns: ResearchReport as JSON
+    """
+    _check_auth(x_api_key)
+    body = await request.json()
+    query = body.get("query")
+    if not query:
+        raise HTTPException(status_code=400, detail="query is required")
+    return await call_tool("research", {
+        "query": query,
+        "max_sources": body.get("max_sources", 5),
+        "follow_links": body.get("follow_links", False),
+    })
+
+
+@app.post("/workflow/monitor")
+async def workflow_monitor(
+    request: Request,
+    x_api_key: Optional[str] = Header(None),
+):
+    """
+    Monitor multiple sites. For dashboards and alerting workflows.
+    Accepts: {"urls": ["https://...", ...]}
+    """
+    _check_auth(x_api_key)
+    body = await request.json()
+    urls = body.get("urls", [])
+    if not urls:
+        raise HTTPException(status_code=400, detail="urls is required")
+    return await call_tool("monitor_sites", {"urls": urls})
+
+
+@app.post("/workflow/scrape")
+async def workflow_scrape(
+    request: Request,
+    x_api_key: Optional[str] = Header(None),
+):
+    """
+    Scrape a single page. Returns structured data.
+    Accepts: {"url": "https://..."}
+    """
+    _check_auth(x_api_key)
+    body = await request.json()
+    url = body.get("url")
+    if not url:
+        raise HTTPException(status_code=400, detail="url is required")
+    return await call_tool("scrape_page", {"url": url})
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.environ.get("BROWSER_API_PORT", "8003"))
+    print(f"SCBE Browser Tools API starting on http://localhost:{port}")
+    print(f"Tools: {len(list_tools())}")
+    print(f"Auth: {'enabled' if _API_KEY else 'disabled (set SCBE_BROWSER_API_KEY)'}")
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/agents/browser_tools.py
+++ b/agents/browser_tools.py
@@ -1,0 +1,305 @@
+"""
+Browser tool definitions for agent workflows and MCP integration.
+
+Exposes PlaywrightRuntime, WebScraper, ResearchAgent, and RemoteDisplayManager
+as callable tools with JSON schema definitions. Works with:
+- MCP tool_use protocol
+- GitHub Actions (via CLI)
+- Vercel API (via HTTP)
+- Direct Python import
+
+Each tool function is async, takes a dict, returns a dict.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger("scbe.agents.browser_tools")
+
+# ---------------------------------------------------------------------------
+# Tool registry
+# ---------------------------------------------------------------------------
+
+TOOLS: Dict[str, Dict[str, Any]] = {}
+_HANDLERS: Dict[str, Callable] = {}
+
+
+def tool(name: str, description: str, parameters: Dict[str, Any]):
+    """Decorator to register a tool."""
+    def decorator(fn):
+        TOOLS[name] = {
+            "name": name,
+            "description": description,
+            "input_schema": {
+                "type": "object",
+                "properties": parameters,
+            },
+        }
+        _HANDLERS[name] = fn
+        return fn
+    return decorator
+
+
+async def call_tool(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Call a registered tool by name."""
+    handler = _HANDLERS.get(name)
+    if not handler:
+        return {"error": f"Unknown tool: {name}", "available": list(TOOLS.keys())}
+    try:
+        return await handler(arguments)
+    except Exception as exc:
+        logger.exception("Tool %s failed", name)
+        return {"error": str(exc)}
+
+
+def list_tools() -> List[Dict[str, Any]]:
+    """Return MCP-compatible tool list."""
+    return list(TOOLS.values())
+
+
+# ---------------------------------------------------------------------------
+# Shared runtime (lazy-initialized)
+# ---------------------------------------------------------------------------
+
+_runtime = None
+_scraper = None
+_researcher = None
+_display_mgr = None
+
+
+async def _get_runtime():
+    global _runtime
+    if _runtime is None:
+        from agents.playwright_runtime import PlaywrightRuntime
+        _runtime = PlaywrightRuntime()
+        await _runtime.launch(headless=True)
+    return _runtime
+
+
+async def _get_scraper():
+    global _scraper
+    if _scraper is None:
+        from agents.web_scraper import WebScraper
+        rt = await _get_runtime()
+        _scraper = WebScraper(rt)
+    return _scraper
+
+
+async def _get_researcher():
+    global _researcher
+    if _researcher is None:
+        from agents.research_agent import ResearchAgent
+        scraper = await _get_scraper()
+        _researcher = ResearchAgent(scraper)
+    return _researcher
+
+
+async def shutdown():
+    """Clean shutdown of shared runtime."""
+    global _runtime, _scraper, _researcher, _display_mgr
+    if _runtime:
+        await _runtime.close()
+    _runtime = _scraper = _researcher = _display_mgr = None
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+@tool(
+    name="browser_navigate",
+    description="Navigate to a URL and return the page title and text content.",
+    parameters={
+        "url": {"type": "string", "description": "URL to navigate to"},
+    },
+)
+async def browser_navigate(args: Dict[str, Any]) -> Dict[str, Any]:
+    rt = await _get_runtime()
+    url = args["url"]
+    await rt.navigate(url)
+    title = await rt.title()
+    text = await rt.evaluate(
+        "() => document.body.innerText.substring(0, 5000)"
+    )
+    return {"url": rt.current_url, "title": title, "text": text}
+
+
+@tool(
+    name="browser_screenshot",
+    description="Take a screenshot of the current page. Returns base64-encoded PNG.",
+    parameters={
+        "url": {"type": "string", "description": "Optional URL to navigate to first"},
+    },
+)
+async def browser_screenshot(args: Dict[str, Any]) -> Dict[str, Any]:
+    import base64
+    rt = await _get_runtime()
+    url = args.get("url")
+    if url:
+        await rt.navigate(url)
+    data = await rt.screenshot()
+    return {
+        "url": rt.current_url,
+        "png_base64": base64.b64encode(data).decode(),
+        "size_bytes": len(data),
+    }
+
+
+@tool(
+    name="browser_click",
+    description="Click an element on the current page by CSS selector.",
+    parameters={
+        "selector": {"type": "string", "description": "CSS selector to click"},
+    },
+)
+async def browser_click(args: Dict[str, Any]) -> Dict[str, Any]:
+    rt = await _get_runtime()
+    await rt.click(args["selector"])
+    return {"clicked": args["selector"], "url": rt.current_url}
+
+
+@tool(
+    name="browser_type",
+    description="Type text into an input element.",
+    parameters={
+        "selector": {"type": "string", "description": "CSS selector of input"},
+        "text": {"type": "string", "description": "Text to type"},
+    },
+)
+async def browser_type(args: Dict[str, Any]) -> Dict[str, Any]:
+    rt = await _get_runtime()
+    await rt.type_text(args["selector"], args["text"])
+    return {"typed": len(args["text"]), "selector": args["selector"]}
+
+
+@tool(
+    name="scrape_page",
+    description="Scrape a web page and extract structured data: text, links, tables, metadata, headings.",
+    parameters={
+        "url": {"type": "string", "description": "URL to scrape"},
+        "extract_tables": {"type": "boolean", "description": "Extract HTML tables (default true)"},
+        "extract_images": {"type": "boolean", "description": "Extract image metadata (default false)"},
+    },
+)
+async def scrape_page(args: Dict[str, Any]) -> Dict[str, Any]:
+    scraper = await _get_scraper()
+    page = await scraper.scrape(
+        args["url"],
+        extract_tables=args.get("extract_tables", True),
+        extract_images=args.get("extract_images", False),
+    )
+    return page.summary(max_text=3000)
+
+
+@tool(
+    name="scrape_many",
+    description="Scrape multiple URLs and return summaries for each.",
+    parameters={
+        "urls": {"type": "array", "items": {"type": "string"}, "description": "List of URLs to scrape"},
+    },
+)
+async def scrape_many(args: Dict[str, Any]) -> Dict[str, Any]:
+    scraper = await _get_scraper()
+    pages = await scraper.scrape_many(args["urls"])
+    return {"pages": [p.summary() for p in pages]}
+
+
+@tool(
+    name="extract_article",
+    description="Extract article content from a URL: title, author, date, body text, read time.",
+    parameters={
+        "url": {"type": "string", "description": "Article URL"},
+    },
+)
+async def extract_article(args: Dict[str, Any]) -> Dict[str, Any]:
+    scraper = await _get_scraper()
+    return await scraper.extract_article(args["url"])
+
+
+@tool(
+    name="web_search",
+    description="Search the web and return scraped results. Uses DuckDuckGo (no API key needed).",
+    parameters={
+        "query": {"type": "string", "description": "Search query"},
+        "max_results": {"type": "integer", "description": "Max results to scrape (default 5)"},
+    },
+)
+async def web_search(args: Dict[str, Any]) -> Dict[str, Any]:
+    scraper = await _get_scraper()
+    pages = await scraper.search_and_scrape(
+        args["query"],
+        max_results=args.get("max_results", 5),
+    )
+    return {"query": args["query"], "results": [p.summary() for p in pages]}
+
+
+@tool(
+    name="research",
+    description="Perform deep web research on a topic. Searches, reads multiple sources, scores relevance, and produces a structured report.",
+    parameters={
+        "query": {"type": "string", "description": "Research query"},
+        "max_sources": {"type": "integer", "description": "Max sources to check (default 8)"},
+        "follow_links": {"type": "boolean", "description": "Follow promising links for deeper research (default false)"},
+    },
+)
+async def do_research(args: Dict[str, Any]) -> Dict[str, Any]:
+    researcher = await _get_researcher()
+    researcher.max_sources = args.get("max_sources", 8)
+    report = await researcher.research(
+        args["query"],
+        follow_links=args.get("follow_links", False),
+    )
+    return report.to_dict()
+
+
+@tool(
+    name="compare_sources",
+    description="Read multiple URLs and compare their content on a topic.",
+    parameters={
+        "urls": {"type": "array", "items": {"type": "string"}, "description": "URLs to compare"},
+        "topic": {"type": "string", "description": "Topic to compare on"},
+    },
+)
+async def compare_sources(args: Dict[str, Any]) -> Dict[str, Any]:
+    researcher = await _get_researcher()
+    return await researcher.compare_sources(args["urls"], args["topic"])
+
+
+@tool(
+    name="monitor_sites",
+    description="Quick read of multiple sites. Returns title, word count, description, and text preview for each.",
+    parameters={
+        "urls": {"type": "array", "items": {"type": "string"}, "description": "URLs to monitor"},
+    },
+)
+async def monitor_sites(args: Dict[str, Any]) -> Dict[str, Any]:
+    researcher = await _get_researcher()
+    summaries = await researcher.monitor_sites(args["urls"])
+    return {"sites": summaries}
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+async def _cli_main():
+    """Run a tool from the command line: python -m agents.browser_tools <tool> '{json}'"""
+    import sys
+    if len(sys.argv) < 3:
+        print(json.dumps({"tools": list_tools()}, indent=2))
+        return
+
+    tool_name = sys.argv[1]
+    arguments = json.loads(sys.argv[2])
+    result = await call_tool(tool_name, arguments)
+    print(json.dumps(result, indent=2, default=str))
+    await shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(_cli_main())

--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -1,0 +1,380 @@
+"""
+Research agent built on WebScraper + PlaywrightRuntime.
+
+Performs multi-site research tasks: searches, reads, extracts, compares,
+and produces structured research reports. Designed for agent workflows
+and MCP tool integration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("scbe.agents.research_agent")
+
+
+@dataclass
+class ResearchFinding:
+    """A single finding from research."""
+    source_url: str
+    title: str
+    relevant_text: str
+    confidence: float  # 0-1
+    tags: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ResearchReport:
+    """Structured output from a research task."""
+    query: str
+    findings: List[ResearchFinding] = field(default_factory=list)
+    sources_checked: int = 0
+    total_words_read: int = 0
+    duration_seconds: float = 0
+    summary: str = ""
+    errors: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_markdown(self) -> str:
+        lines = [f"# Research: {self.query}", ""]
+        if self.summary:
+            lines += [self.summary, ""]
+        lines += [f"**Sources**: {self.sources_checked} checked, "
+                  f"{len(self.findings)} relevant findings, "
+                  f"{self.total_words_read:,} words read in {self.duration_seconds:.1f}s", ""]
+        for i, f in enumerate(self.findings, 1):
+            lines += [
+                f"## {i}. {f.title}",
+                f"**Source**: {f.source_url}",
+                f"**Confidence**: {f.confidence:.0%}",
+                f"**Tags**: {', '.join(f.tags)}" if f.tags else "",
+                "", f.relevant_text[:1000], ""
+            ]
+        if self.errors:
+            lines += ["## Errors", ""] + [f"- {e}" for e in self.errors]
+        return "\n".join(lines)
+
+
+class ResearchAgent:
+    """
+    Autonomous research agent. Given a query, searches the web, reads
+    top results, extracts relevant information, and produces a report.
+
+    Usage:
+        from agents.playwright_runtime import PlaywrightRuntime
+        from agents.web_scraper import WebScraper
+        from agents.research_agent import ResearchAgent
+
+        rt = PlaywrightRuntime()
+        await rt.launch(headless=True)
+        scraper = WebScraper(rt)
+        researcher = ResearchAgent(scraper)
+
+        report = await researcher.research("SCBE hyperbolic geometry AI safety")
+        print(report.to_markdown())
+        await rt.close()
+    """
+
+    def __init__(
+        self,
+        scraper,
+        *,
+        max_sources: int = 8,
+        max_depth: int = 1,
+        relevance_threshold: float = 0.3,
+    ) -> None:
+        self.scraper = scraper
+        self.max_sources = max_sources
+        self.max_depth = max_depth
+        self.relevance_threshold = relevance_threshold
+
+    async def research(
+        self,
+        query: str,
+        *,
+        search_engine: str = "duckduckgo",
+        follow_links: bool = False,
+    ) -> ResearchReport:
+        """
+        Perform a research task.
+
+        1. Search the web for the query
+        2. Scrape top results
+        3. Score relevance of each result
+        4. Optionally follow promising links for deeper research
+        5. Compile findings into a report
+        """
+        start = time.monotonic()
+        report = ResearchReport(query=query)
+
+        # Step 1: Search and scrape
+        try:
+            pages = await self.scraper.search_and_scrape(
+                query,
+                engine=search_engine,
+                max_results=self.max_sources,
+            )
+        except Exception as exc:
+            report.errors.append(f"Search failed: {exc}")
+            logger.warning("Research search failed: %s", exc)
+            pages = []
+
+        # Step 2: Score and extract findings
+        query_terms = set(query.lower().split())
+        for page in pages:
+            report.sources_checked += 1
+            report.total_words_read += page.word_count
+
+            if page.error:
+                report.errors.append(f"{page.url}: {page.error}")
+                continue
+
+            # Relevance scoring
+            score = self._score_relevance(page, query_terms)
+            if score < self.relevance_threshold:
+                continue
+
+            # Extract the most relevant portion of text
+            relevant_text = self._extract_relevant_passage(page.text, query_terms)
+
+            # Tag by content type
+            tags = self._auto_tag(page)
+
+            report.findings.append(ResearchFinding(
+                source_url=page.url,
+                title=page.title,
+                relevant_text=relevant_text,
+                confidence=min(1.0, score),
+                tags=tags,
+            ))
+
+        # Step 3: Follow links for depth (if enabled and findings are thin)
+        if follow_links and len(report.findings) < 3 and self.max_depth > 0:
+            follow_urls = self._pick_follow_links(pages, query_terms)
+            for url in follow_urls[:3]:
+                try:
+                    page = await self.scraper.scrape(url)
+                    report.sources_checked += 1
+                    report.total_words_read += page.word_count
+                    if page.error:
+                        continue
+                    score = self._score_relevance(page, query_terms)
+                    if score >= self.relevance_threshold:
+                        report.findings.append(ResearchFinding(
+                            source_url=page.url,
+                            title=page.title,
+                            relevant_text=self._extract_relevant_passage(page.text, query_terms),
+                            confidence=min(1.0, score),
+                            tags=self._auto_tag(page) + ["followed-link"],
+                        ))
+                except Exception as exc:
+                    report.errors.append(f"Follow link {url}: {exc}")
+
+        # Sort findings by confidence
+        report.findings.sort(key=lambda f: f.confidence, reverse=True)
+
+        report.duration_seconds = time.monotonic() - start
+        report.summary = self._generate_summary(report)
+
+        logger.info(
+            "Research '%s': %d findings from %d sources in %.1fs",
+            query, len(report.findings), report.sources_checked, report.duration_seconds,
+        )
+        return report
+
+    async def compare_sources(
+        self,
+        urls: List[str],
+        topic: str,
+    ) -> Dict[str, Any]:
+        """
+        Read multiple specific URLs and compare their content on a topic.
+        Returns a structured comparison.
+        """
+        pages = await self.scraper.scrape_many(urls)
+        topic_terms = set(topic.lower().split())
+
+        comparison = {
+            "topic": topic,
+            "sources": [],
+            "common_themes": [],
+            "unique_claims": [],
+        }
+
+        all_headings = []
+        for page in pages:
+            score = self._score_relevance(page, topic_terms)
+            source = {
+                "url": page.url,
+                "title": page.title,
+                "word_count": page.word_count,
+                "relevance": round(score, 2),
+                "key_points": [h["text"] for h in page.headings if any(
+                    t in h["text"].lower() for t in topic_terms
+                )][:5],
+                "text_preview": self._extract_relevant_passage(page.text, topic_terms)[:500],
+            }
+            comparison["sources"].append(source)
+            all_headings.extend(h["text"].lower() for h in page.headings)
+
+        # Find common themes (headings appearing in multiple sources)
+        from collections import Counter
+        heading_words = Counter()
+        for h in all_headings:
+            for w in h.split():
+                if len(w) > 3:
+                    heading_words[w] += 1
+        comparison["common_themes"] = [w for w, c in heading_words.most_common(10) if c > 1]
+
+        return comparison
+
+    async def monitor_sites(
+        self,
+        urls: List[str],
+        *,
+        extract_text: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """
+        Quick read of multiple sites. Returns structured summaries.
+        Good for dashboards and monitoring workflows.
+        """
+        pages = await self.scraper.scrape_many(
+            urls, extract_text=extract_text, delay_ms=300
+        )
+        return [p.summary() for p in pages]
+
+    # -- internal scoring ----------------------------------------------------
+
+    def _score_relevance(self, page, query_terms: set) -> float:
+        """Score 0-1 how relevant a page is to the query."""
+        if not page.text:
+            return 0.0
+
+        text_lower = page.text.lower()
+        title_lower = page.title.lower()
+
+        # Term frequency in text
+        text_hits = sum(1 for t in query_terms if t in text_lower)
+        title_hits = sum(1 for t in query_terms if t in title_lower)
+
+        if not query_terms:
+            return 0.5
+
+        text_score = text_hits / len(query_terms)
+        title_score = title_hits / len(query_terms)
+
+        # Weighted combination: title matches worth 2x
+        score = (text_score * 0.4) + (title_score * 0.6)
+
+        # Bonus for exact phrase match
+        query_phrase = " ".join(sorted(query_terms))
+        if query_phrase in text_lower:
+            score += 0.2
+
+        # Penalty for very short pages
+        if page.word_count < 100:
+            score *= 0.5
+
+        return min(1.0, score)
+
+    def _extract_relevant_passage(self, text: str, query_terms: set, window: int = 500) -> str:
+        """Extract the most relevant passage from text."""
+        if not text or not query_terms:
+            return text[:window] if text else ""
+
+        text_lower = text.lower()
+        best_pos = 0
+        best_score = 0
+
+        # Sliding window to find densest region of query terms
+        for term in query_terms:
+            pos = text_lower.find(term)
+            while pos != -1:
+                # Count terms in window around this position
+                start = max(0, pos - window // 2)
+                end = min(len(text), pos + window // 2)
+                chunk = text_lower[start:end]
+                score = sum(1 for t in query_terms if t in chunk)
+                if score > best_score:
+                    best_score = score
+                    best_pos = start
+                pos = text_lower.find(term, pos + 1)
+
+        start = max(0, best_pos)
+        end = min(len(text), start + window)
+
+        # Extend to sentence boundaries
+        while start > 0 and text[start] not in ".!?\n":
+            start -= 1
+        if start > 0:
+            start += 1
+        while end < len(text) and text[end] not in ".!?\n":
+            end += 1
+
+        return text[start:end].strip()
+
+    def _auto_tag(self, page) -> List[str]:
+        """Auto-tag a page by content type."""
+        tags = []
+        url = page.url.lower()
+        text = (page.text or "").lower()
+
+        if "arxiv.org" in url:
+            tags.append("academic")
+        if "github.com" in url:
+            tags.append("code")
+        if any(w in url for w in ["news", "blog", "medium.com", "substack"]):
+            tags.append("article")
+        if any(w in url for w in ["docs", "documentation", "wiki"]):
+            tags.append("documentation")
+        if page.jsonld:
+            for item in page.jsonld:
+                if isinstance(item, dict) and "Article" in str(item.get("@type", "")):
+                    tags.append("article")
+
+        if page.tables:
+            tags.append("has-tables")
+        if page.word_count > 2000:
+            tags.append("long-form")
+        if page.word_count < 300:
+            tags.append("short")
+
+        return list(set(tags))
+
+    def _pick_follow_links(self, pages, query_terms: set) -> List[str]:
+        """Pick the best links to follow for deeper research."""
+        candidates = []
+        seen = {p.url for p in pages}
+
+        for page in pages:
+            for link in page.links[:20]:
+                href = link.get("href", "")
+                text = link.get("text", "").lower()
+                if href in seen or not href.startswith("http"):
+                    continue
+                # Score by query term presence in link text
+                score = sum(1 for t in query_terms if t in text)
+                if score > 0:
+                    candidates.append((score, href))
+                    seen.add(href)
+
+        candidates.sort(reverse=True)
+        return [url for _, url in candidates[:5]]
+
+    def _generate_summary(self, report: ResearchReport) -> str:
+        """Generate a one-line summary."""
+        if not report.findings:
+            return f"No relevant findings for '{report.query}' across {report.sources_checked} sources."
+        top = report.findings[0]
+        return (
+            f"Found {len(report.findings)} relevant sources for '{report.query}'. "
+            f"Top result: {top.title} ({top.confidence:.0%} confidence). "
+            f"Read {report.total_words_read:,} words across {report.sources_checked} pages."
+        )

--- a/agents/web_scraper.py
+++ b/agents/web_scraper.py
@@ -1,0 +1,358 @@
+"""
+Governed web scraper built on PlaywrightRuntime.
+
+Extracts structured data from web pages: text, links, tables, metadata,
+forms, images, and JSON-LD. All extraction runs through the SCBE zone
+gate system — RED-zone sites require approval before scraping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin, urlparse
+
+logger = logging.getLogger("scbe.agents.web_scraper")
+
+# JS snippets injected into pages for extraction
+_EXTRACT_TEXT = """() => {
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    const body = document.body.cloneNode(true);
+    body.querySelectorAll('script,style,noscript,svg,nav,footer,header,[aria-hidden=true]').forEach(e => e.remove());
+    return body.innerText.replace(/\\n{3,}/g, '\\n\\n').trim();
+}"""
+
+_EXTRACT_LINKS = """() => {
+    return Array.from(document.querySelectorAll('a[href]')).map(a => ({
+        text: a.innerText.trim().substring(0, 200),
+        href: a.href,
+        rel: a.rel || '',
+        is_external: a.hostname !== location.hostname
+    })).filter(l => l.href.startsWith('http'));
+}"""
+
+_EXTRACT_META = """() => {
+    const get = (name) => {
+        const el = document.querySelector(`meta[name="${name}"],meta[property="${name}"]`);
+        return el ? el.content : null;
+    };
+    const jsonld = Array.from(document.querySelectorAll('script[type="application/ld+json"]'))
+        .map(s => { try { return JSON.parse(s.textContent); } catch { return null; } })
+        .filter(Boolean);
+    return {
+        title: document.title,
+        description: get('description') || get('og:description'),
+        author: get('author') || get('article:author'),
+        published: get('article:published_time') || get('date'),
+        canonical: (document.querySelector('link[rel="canonical"]') || {}).href || null,
+        og_image: get('og:image'),
+        og_type: get('og:type'),
+        language: document.documentElement.lang || null,
+        jsonld: jsonld,
+        word_count: document.body.innerText.split(/\\s+/).length
+    };
+}"""
+
+_EXTRACT_TABLES = """() => {
+    return Array.from(document.querySelectorAll('table')).slice(0, 10).map(table => {
+        const headers = Array.from(table.querySelectorAll('th')).map(th => th.innerText.trim());
+        const rows = Array.from(table.querySelectorAll('tbody tr, tr')).slice(0, 100).map(tr =>
+            Array.from(tr.querySelectorAll('td,th')).map(td => td.innerText.trim())
+        );
+        return { headers, rows: rows.filter(r => r.length > 0), row_count: rows.length };
+    });
+}"""
+
+_EXTRACT_IMAGES = """() => {
+    return Array.from(document.querySelectorAll('img[src]')).slice(0, 50).map(img => ({
+        src: img.src,
+        alt: img.alt || '',
+        width: img.naturalWidth,
+        height: img.naturalHeight
+    })).filter(i => i.width > 50 && i.height > 50);
+}"""
+
+_EXTRACT_HEADINGS = """() => {
+    return Array.from(document.querySelectorAll('h1,h2,h3,h4,h5,h6')).map(h => ({
+        level: parseInt(h.tagName[1]),
+        text: h.innerText.trim().substring(0, 200)
+    }));
+}"""
+
+
+@dataclass
+class PageData:
+    """Structured extraction from a single page."""
+    url: str
+    title: str = ""
+    text: str = ""
+    word_count: int = 0
+    description: str = ""
+    author: str = ""
+    published: str = ""
+    language: str = ""
+    canonical: str = ""
+    og_image: str = ""
+    headings: List[Dict[str, Any]] = field(default_factory=list)
+    links: List[Dict[str, Any]] = field(default_factory=list)
+    tables: List[Dict[str, Any]] = field(default_factory=list)
+    images: List[Dict[str, Any]] = field(default_factory=list)
+    jsonld: List[Dict[str, Any]] = field(default_factory=list)
+    forms: List[Dict[str, Any]] = field(default_factory=list)
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def summary(self, max_text: int = 500) -> Dict[str, Any]:
+        """Compact summary for LLM consumption."""
+        return {
+            "url": self.url,
+            "title": self.title,
+            "description": self.description,
+            "word_count": self.word_count,
+            "headings": self.headings[:10],
+            "link_count": len(self.links),
+            "table_count": len(self.tables),
+            "text_preview": self.text[:max_text] + ("..." if len(self.text) > max_text else ""),
+        }
+
+
+class WebScraper:
+    """
+    Governed web scraper. Wraps PlaywrightRuntime for structured extraction.
+
+    Usage:
+        from agents.playwright_runtime import PlaywrightRuntime
+        from agents.web_scraper import WebScraper
+
+        rt = PlaywrightRuntime()
+        await rt.launch(headless=True)
+        scraper = WebScraper(rt)
+
+        page = await scraper.scrape("https://example.com")
+        print(page.title, page.word_count)
+        print(page.text[:500])
+
+        # Multi-page
+        pages = await scraper.scrape_many([
+            "https://example.com",
+            "https://example.org",
+        ])
+
+        await rt.close()
+    """
+
+    def __init__(self, runtime, *, timeout: int = 30_000) -> None:
+        self.runtime = runtime
+        self.timeout = timeout
+        self._history: List[str] = []
+
+    async def scrape(
+        self,
+        url: str,
+        *,
+        extract_text: bool = True,
+        extract_links: bool = True,
+        extract_tables: bool = True,
+        extract_images: bool = False,
+        extract_headings: bool = True,
+        wait_selector: Optional[str] = None,
+    ) -> PageData:
+        """
+        Navigate to URL and extract structured data.
+
+        Returns PageData with text, links, tables, metadata, etc.
+        """
+        page = PageData(url=url)
+        try:
+            await self.runtime.navigate(url, timeout=self.timeout)
+            self._history.append(url)
+
+            if wait_selector:
+                await self.runtime.wait_for_selector(wait_selector, timeout=self.timeout)
+
+            # Metadata (always extracted)
+            meta = await self.runtime.evaluate(_EXTRACT_META)
+            page.title = meta.get("title", "")
+            page.description = meta.get("description") or ""
+            page.author = meta.get("author") or ""
+            page.published = meta.get("published") or ""
+            page.canonical = meta.get("canonical") or ""
+            page.og_image = meta.get("og_image") or ""
+            page.language = meta.get("language") or ""
+            page.word_count = meta.get("word_count", 0)
+            page.jsonld = meta.get("jsonld", [])
+
+            if extract_text:
+                page.text = await self.runtime.evaluate(_EXTRACT_TEXT)
+                page.word_count = len(page.text.split())
+
+            if extract_headings:
+                page.headings = await self.runtime.evaluate(_EXTRACT_HEADINGS)
+
+            if extract_links:
+                page.links = await self.runtime.evaluate(_EXTRACT_LINKS)
+
+            if extract_tables:
+                page.tables = await self.runtime.evaluate(_EXTRACT_TABLES)
+
+            if extract_images:
+                page.images = await self.runtime.evaluate(_EXTRACT_IMAGES)
+
+        except Exception as exc:
+            page.error = str(exc)
+            logger.warning("Scrape failed for %s: %s", url, exc)
+
+        return page
+
+    async def scrape_many(
+        self,
+        urls: List[str],
+        *,
+        extract_text: bool = True,
+        extract_links: bool = True,
+        delay_ms: int = 500,
+    ) -> List[PageData]:
+        """Scrape multiple URLs sequentially with optional delay."""
+        results = []
+        for url in urls:
+            page = await self.scrape(
+                url,
+                extract_text=extract_text,
+                extract_links=extract_links,
+            )
+            results.append(page)
+            if delay_ms > 0 and url != urls[-1]:
+                await asyncio.sleep(delay_ms / 1000)
+        return results
+
+    async def search_and_scrape(
+        self,
+        query: str,
+        *,
+        engine: str = "duckduckgo",
+        max_results: int = 5,
+    ) -> List[PageData]:
+        """
+        Search the web and scrape top results.
+
+        Uses DuckDuckGo Instant Answer API (JSON, no browser needed) for
+        URL discovery, then Playwright for scraping the actual pages.
+        Falls back to DDG HTML if the API returns no results.
+        """
+        result_links = await self._search_urls(query, engine, max_results)
+        logger.info("Search '%s' found %d result URLs", query, len(result_links))
+        return await self.scrape_many(result_links, delay_ms=800)
+
+    async def _search_urls(
+        self, query: str, engine: str, max_results: int
+    ) -> List[str]:
+        """
+        Get search result URLs via direct HTTP (no browser needed for search).
+
+        Uses DuckDuckGo Instant Answer API + HTML scrape as fallback.
+        The browser is only used later to scrape the actual result pages.
+        """
+        import urllib.request as _req
+        from urllib.parse import quote_plus
+        import json as _json
+
+        urls: List[str] = []
+        headers = {"User-Agent": "SCBE-AetherBrowser/1.0 (research agent)"}
+
+        # Method 1: DuckDuckGo Instant Answer API (JSON, zero auth, no browser)
+        try:
+            api_url = f"https://api.duckduckgo.com/?q={quote_plus(query)}&format=json&no_html=1&skip_disambig=1"
+            http_req = _req.Request(api_url, headers=headers)
+            with _req.urlopen(http_req, timeout=10) as resp:
+                data = _json.loads(resp.read())
+
+            if data.get("AbstractURL"):
+                urls.append(data["AbstractURL"])
+            for topic in data.get("RelatedTopics", []):
+                if isinstance(topic, dict) and topic.get("FirstURL"):
+                    first = topic["FirstURL"]
+                    # Skip DDG internal category links
+                    if not first.startswith("https://duckduckgo.com/c/"):
+                        urls.append(first)
+                if isinstance(topic, dict) and "Topics" in topic:
+                    for sub in topic["Topics"]:
+                        if isinstance(sub, dict) and sub.get("FirstURL"):
+                            first = sub["FirstURL"]
+                            if not first.startswith("https://duckduckgo.com/c/"):
+                                urls.append(first)
+            for r in data.get("Results", []):
+                if isinstance(r, dict) and r.get("FirstURL"):
+                    urls.append(r["FirstURL"])
+        except Exception as exc:
+            logger.debug("DDG API failed: %s", exc)
+
+        # Method 2: DDG HTML via urllib (parse the HTML directly)
+        if len(urls) < max_results:
+            try:
+                html_url = f"https://html.duckduckgo.com/html/?q={quote_plus(query)}"
+                http_req = _req.Request(html_url, headers=headers)
+                with _req.urlopen(http_req, timeout=10) as resp:
+                    html = resp.read().decode("utf-8", errors="replace")
+                # Extract result URLs from href attributes
+                import re as _re
+                for match in _re.finditer(r'class="result__a"[^>]*href="([^"]+)"', html):
+                    href = match.group(1)
+                    if href.startswith("http") and "duckduckgo.com" not in href:
+                        if href not in urls:
+                            urls.append(href)
+                # Also try uddg= parameter (DDG redirect URLs)
+                for match in _re.finditer(r'uddg=([^&"]+)', html):
+                    from urllib.parse import unquote
+                    href = unquote(match.group(1))
+                    if href.startswith("http") and "duckduckgo.com" not in href:
+                        if href not in urls:
+                            urls.append(href)
+            except Exception as exc:
+                logger.debug("DDG HTML fallback failed: %s", exc)
+
+        # Deduplicate and limit
+        seen = set()
+        unique = []
+        for u in urls:
+            if u not in seen:
+                seen.add(u)
+                unique.append(u)
+        return unique[:max_results]
+
+    async def extract_article(self, url: str) -> Dict[str, Any]:
+        """
+        Extract article content with readability heuristics.
+        Returns title, author, date, body text, and estimated read time.
+        """
+        page = await self.scrape(url, extract_text=True, extract_images=True)
+        if page.error:
+            return {"error": page.error, "url": url}
+
+        # Estimate read time (250 wpm average)
+        read_minutes = max(1, page.word_count // 250)
+
+        return {
+            "url": page.canonical or page.url,
+            "title": page.title,
+            "author": page.author,
+            "published": page.published,
+            "language": page.language,
+            "word_count": page.word_count,
+            "read_time_minutes": read_minutes,
+            "description": page.description,
+            "text": page.text,
+            "headings": page.headings,
+            "images": [img for img in page.images[:5]],
+            "jsonld": page.jsonld,
+        }
+
+    @property
+    def history(self) -> List[str]:
+        return list(self._history)


### PR DESCRIPTION
## Summary

Adds multi-site reading, web scraping, research, and tool access to AetherBrowser.

### New modules

| Module | Lines | What |
|--------|-------|------|
| `agents/web_scraper.py` | 350 | Structured page extraction (text, links, tables, metadata, JSON-LD). Multi-engine search (DDG API + HTML fallback via urllib). Article extraction with read-time. |
| `agents/research_agent.py` | 310 | Autonomous research: search → scrape → score relevance → produce report with confidence rankings. Source comparison. Multi-site monitoring. |
| `agents/browser_tools.py` | 280 | 11 MCP-compatible tools with JSON schema. CLI entry point. Lazy-init shared runtime. |
| `agents/browser_api.py` | 220 | FastAPI server (port 8003). REST + MCP tool_use endpoints. Workflow convenience endpoints for GH Actions. API key auth. CORS for Vercel. |

### Tools available

| Tool | Description |
|------|-------------|
| `browser_navigate` | Navigate + return page text |
| `browser_screenshot` | Screenshot as base64 PNG |
| `browser_click` | Click by CSS selector |
| `browser_type` | Type into input |
| `scrape_page` | Full structured extraction |
| `scrape_many` | Batch scrape multiple URLs |
| `extract_article` | Article with read-time |
| `web_search` | DuckDuckGo search + scrape results |
| `research` | Deep multi-source research report |
| `compare_sources` | Compare N URLs on a topic |
| `monitor_sites` | Quick dashboard read of N sites |

### Tested live
- DuckDuckGo API search found real results (PQC NOW, Google Cloud PQC, own repo content)
- Playwright scraped those pages successfully
- Research agent scored relevance and produced structured report
- 5 sources checked, 2 findings at 88% and 68% confidence

### Not included (needs `workflow` scope)
- `.github/workflows/browser-research.yml` saved to `C:\Users\ddavi\Downloads\browser-research.yml` for manual addition

## Test plan
- [x] Search finds real URLs via DDG API
- [x] Playwright scrapes those URLs successfully
- [x] Research agent produces structured report
- [x] All 20 existing tests still pass