### PR TITLE
feat(bus): agent bus + free LLMs + DDG search + website

### DIFF
--- a/agents/agent_bus.py
+++ b/agents/agent_bus.py
@@ -1,0 +1,398 @@
+"""
+SCBE Agent Bus — unified pipeline connecting browser tools, free LLMs,
+web search, and the aethermoore.com website.
+
+The bus routes tasks through:
+  1. Web search (DuckDuckGo API, free)
+  2. Page scraping (Playwright)
+  3. Free LLM inference (HuggingFace Inference API / Ollama local)
+  4. Governed output (zone gates, Sacred Tongues scoring)
+
+All LLM calls are free-tier: HuggingFace serverless inference (HF_TOKEN)
+or Ollama running locally. No paid API keys required.
+
+Usage:
+    bus = AgentBus()
+    await bus.start()
+
+    # Ask a question with web research
+    result = await bus.ask("What is post-quantum cryptography?")
+
+    # Search + summarize
+    result = await bus.search_and_summarize("SCBE AI safety", max_sources=3)
+
+    # Scrape + analyze
+    result = await bus.analyze_page("https://example.com")
+
+    # Monitor sites
+    result = await bus.monitor(["https://news.ycombinator.com", "https://github.com"])
+
+    await bus.stop()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("scbe.agent_bus")
+
+# Bus event log
+BUS_LOG = Path("artifacts/agent-bus/events.jsonl")
+
+
+@dataclass
+class BusEvent:
+    """Audit record for every bus operation."""
+    task_type: str
+    query: str
+    sources_used: int = 0
+    llm_provider: str = ""
+    llm_model: str = ""
+    tokens_in: int = 0
+    tokens_out: int = 0
+    duration_seconds: float = 0
+    success: bool = True
+    error: Optional[str] = None
+    timestamp: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class AgentBus:
+    """
+    Unified agent bus. Connects:
+    - PlaywrightRuntime (browser)
+    - WebScraper (extraction)
+    - ResearchAgent (multi-site research)
+    - Free LLM inference (HuggingFace / Ollama)
+    """
+
+    def __init__(
+        self,
+        *,
+        hf_model: str = "Qwen/Qwen2.5-72B-Instruct",
+        ollama_model: str = "llama3.2",
+        ollama_url: str = "http://127.0.0.1:11434",
+        prefer_local: bool = True,
+    ) -> None:
+        self.hf_model = hf_model
+        self.ollama_model = ollama_model
+        self.ollama_url = ollama_url.rstrip("/")
+        self.prefer_local = prefer_local
+
+        self._runtime = None
+        self._scraper = None
+        self._researcher = None
+        self._started = False
+        self._event_log: List[BusEvent] = []
+
+    # -- lifecycle -----------------------------------------------------------
+
+    async def start(self, *, headless: bool = True) -> None:
+        """Start the bus (launches browser + initializes scraper)."""
+        from agents.playwright_runtime import PlaywrightRuntime
+        from agents.web_scraper import WebScraper
+        from agents.research_agent import ResearchAgent
+
+        self._runtime = PlaywrightRuntime()
+        await self._runtime.launch(headless=headless)
+        self._scraper = WebScraper(self._runtime)
+        self._researcher = ResearchAgent(self._scraper, max_sources=5)
+        self._started = True
+
+        BUS_LOG.parent.mkdir(parents=True, exist_ok=True)
+        logger.info("AgentBus started (hf=%s, ollama=%s)", self.hf_model, self.ollama_model)
+
+    async def stop(self) -> None:
+        """Stop the bus."""
+        if self._runtime:
+            await self._runtime.close()
+        self._runtime = self._scraper = self._researcher = None
+        self._started = False
+        logger.info("AgentBus stopped")
+
+    # -- main operations -----------------------------------------------------
+
+    async def ask(
+        self,
+        question: str,
+        *,
+        search_first: bool = True,
+        max_sources: int = 3,
+    ) -> Dict[str, Any]:
+        """
+        Answer a question using web research + free LLM.
+
+        1. Search the web for relevant context
+        2. Scrape top results
+        3. Build a context prompt
+        4. Send to free LLM for answer
+        """
+        self._require_started()
+        start = time.monotonic()
+        event = BusEvent(task_type="ask", query=question)
+
+        context_text = ""
+        sources = []
+
+        if search_first:
+            try:
+                pages = await self._scraper.search_and_scrape(question, max_results=max_sources)
+                for p in pages:
+                    if p.text and not p.error:
+                        snippet = p.text[:1500]
+                        context_text += f"\n\n---\nSource: {p.title} ({p.url})\n{snippet}"
+                        sources.append({"title": p.title, "url": p.url, "words": p.word_count})
+                event.sources_used = len(sources)
+            except Exception as exc:
+                logger.warning("Search failed for '%s': %s", question, exc)
+
+        prompt = self._build_prompt(question, context_text)
+        answer = await self._llm_generate(prompt)
+
+        event.llm_provider = answer["provider"]
+        event.llm_model = answer["model"]
+        event.duration_seconds = time.monotonic() - start
+        event.success = not answer.get("error")
+        event.error = answer.get("error")
+        self._log_event(event)
+
+        return {
+            "question": question,
+            "answer": answer["text"],
+            "sources": sources,
+            "provider": answer["provider"],
+            "model": answer["model"],
+            "duration_seconds": round(event.duration_seconds, 1),
+        }
+
+    async def search_and_summarize(
+        self,
+        query: str,
+        *,
+        max_sources: int = 5,
+    ) -> Dict[str, Any]:
+        """Search the web, scrape results, summarize with free LLM."""
+        self._require_started()
+        start = time.monotonic()
+        event = BusEvent(task_type="search_and_summarize", query=query)
+
+        report = await self._researcher.research(query)
+        event.sources_used = report.sources_checked
+
+        if not report.findings:
+            event.duration_seconds = time.monotonic() - start
+            self._log_event(event)
+            return {
+                "query": query,
+                "summary": f"No relevant findings for '{query}'.",
+                "findings": [],
+                "sources_checked": report.sources_checked,
+            }
+
+        # Build context from findings
+        context = "\n\n".join(
+            f"[{f.confidence:.0%}] {f.title}\n{f.relevant_text[:800]}"
+            for f in report.findings[:5]
+        )
+
+        prompt = (
+            f"Summarize these research findings about '{query}' in 2-3 paragraphs. "
+            f"Cite sources by title. Be concise and factual.\n\n{context}"
+        )
+
+        answer = await self._llm_generate(prompt)
+        event.llm_provider = answer["provider"]
+        event.llm_model = answer["model"]
+        event.duration_seconds = time.monotonic() - start
+        self._log_event(event)
+
+        return {
+            "query": query,
+            "summary": answer["text"],
+            "findings": [
+                {"title": f.title, "url": f.source_url, "confidence": f.confidence}
+                for f in report.findings
+            ],
+            "sources_checked": report.sources_checked,
+            "words_read": report.total_words_read,
+            "provider": answer["provider"],
+            "duration_seconds": round(event.duration_seconds, 1),
+        }
+
+    async def analyze_page(self, url: str) -> Dict[str, Any]:
+        """Scrape a page and analyze it with free LLM."""
+        self._require_started()
+        start = time.monotonic()
+        event = BusEvent(task_type="analyze_page", query=url)
+
+        page = await self._scraper.scrape(url, extract_tables=True, extract_images=True)
+        event.sources_used = 1
+
+        if page.error:
+            event.error = page.error
+            event.success = False
+            self._log_event(event)
+            return {"url": url, "error": page.error}
+
+        prompt = (
+            f"Analyze this web page and provide a structured summary:\n\n"
+            f"Title: {page.title}\n"
+            f"URL: {page.url}\n"
+            f"Word count: {page.word_count}\n"
+            f"Headings: {json.dumps([h['text'] for h in page.headings[:10]])}\n"
+            f"Tables: {len(page.tables)}\n"
+            f"Links: {len(page.links)}\n\n"
+            f"Content:\n{page.text[:3000]}\n\n"
+            f"Provide: 1) What this page is about, 2) Key points, 3) Notable data"
+        )
+
+        answer = await self._llm_generate(prompt)
+        event.llm_provider = answer["provider"]
+        event.llm_model = answer["model"]
+        event.duration_seconds = time.monotonic() - start
+        self._log_event(event)
+
+        return {
+            "url": page.url,
+            "title": page.title,
+            "word_count": page.word_count,
+            "analysis": answer["text"],
+            "headings": [h["text"] for h in page.headings[:10]],
+            "tables": len(page.tables),
+            "links": len(page.links),
+            "provider": answer["provider"],
+        }
+
+    async def monitor(self, urls: List[str]) -> Dict[str, Any]:
+        """Quick read of multiple sites with summaries."""
+        self._require_started()
+        summaries = await self._researcher.monitor_sites(urls)
+        return {"sites": summaries, "count": len(summaries)}
+
+    # -- free LLM inference --------------------------------------------------
+
+    async def _llm_generate(self, prompt: str) -> Dict[str, Any]:
+        """
+        Generate text using free LLMs.
+
+        Priority: Ollama (local) → HuggingFace (free API) → Offline fallback
+        """
+        # Try Ollama first if prefer_local
+        if self.prefer_local:
+            result = await self._try_ollama(prompt)
+            if result:
+                return result
+
+        # Try HuggingFace
+        result = await self._try_huggingface(prompt)
+        if result:
+            return result
+
+        # Try Ollama as fallback if not preferred
+        if not self.prefer_local:
+            result = await self._try_ollama(prompt)
+            if result:
+                return result
+
+        # Offline fallback
+        return {
+            "text": f"[LLM unavailable — raw context returned]\n\n{prompt[:2000]}",
+            "provider": "offline",
+            "model": "none",
+            "error": "No LLM provider available (set HF_TOKEN or run Ollama)",
+        }
+
+    async def _try_ollama(self, prompt: str) -> Optional[Dict[str, Any]]:
+        """Try Ollama local inference."""
+        try:
+            import urllib.request
+            url = f"{self.ollama_url}/api/generate"
+            payload = json.dumps({
+                "model": self.ollama_model,
+                "prompt": prompt,
+                "stream": False,
+            }).encode()
+            req = urllib.request.Request(
+                url,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                data = json.loads(resp.read())
+            return {
+                "text": data.get("response", ""),
+                "provider": "ollama",
+                "model": self.ollama_model,
+            }
+        except Exception as exc:
+            logger.debug("Ollama failed: %s", exc)
+            return None
+
+    async def _try_huggingface(self, prompt: str) -> Optional[Dict[str, Any]]:
+        """Try HuggingFace Inference API (free tier, chat completions)."""
+        hf_token = os.getenv("HF_TOKEN")
+        if not hf_token:
+            return None
+
+        try:
+            from huggingface_hub import InferenceClient
+            client = InferenceClient(model=self.hf_model, token=hf_token)
+            resp = client.chat_completion(
+                messages=[{"role": "user", "content": prompt[:4000]}],
+                max_tokens=512,
+            )
+            text = resp.choices[0].message.content
+            if text and text.strip():
+                return {
+                    "text": text.strip(),
+                    "provider": "huggingface",
+                    "model": self.hf_model,
+                }
+            return None
+        except Exception as exc:
+            logger.debug("HuggingFace failed: %s", exc)
+            return None
+
+    # -- internal ------------------------------------------------------------
+
+    def _build_prompt(self, question: str, context: str) -> str:
+        if context:
+            return (
+                f"Answer the following question using the provided context. "
+                f"Be concise, factual, and cite sources when possible.\n\n"
+                f"Question: {question}\n\n"
+                f"Context:{context}\n\n"
+                f"Answer:"
+            )
+        return f"Answer concisely: {question}"
+
+    def _log_event(self, event: BusEvent) -> None:
+        event.timestamp = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+        self._event_log.append(event)
+        try:
+            with open(BUS_LOG, "a") as f:
+                f.write(json.dumps(event.to_dict()) + "\n")
+        except Exception:
+            pass
+
+    def _require_started(self) -> None:
+        if not self._started:
+            raise RuntimeError("AgentBus not started — call await bus.start() first")
+
+    @property
+    def event_count(self) -> int:
+        return len(self._event_log)
+
+    @property
+    def events(self) -> List[Dict[str, Any]]:
+        return [e.to_dict() for e in self._event_log]

--- a/agents/browser_api.py
+++ b/agents/browser_api.py
@@ -209,6 +209,67 @@ async def workflow_scrape(
 
 
 # ---------------------------------------------------------------------------
+# Agent Bus endpoints (search + scrape + free LLM)
+# ---------------------------------------------------------------------------
+
+@app.post("/bus/ask")
+async def bus_ask(
+    request: Request,
+    x_api_key: Optional[str] = Header(None),
+):
+    """
+    Ask a question. Searches the web, scrapes context, answers with free LLM.
+    Accepts: {"question": "What is post-quantum cryptography?"}
+    """
+    _check_auth(x_api_key)
+    body = await request.json()
+    question = body.get("question")
+    if not question:
+        raise HTTPException(status_code=400, detail="question is required")
+    return await call_tool("ask", {
+        "question": question,
+        "search_first": body.get("search_first", True),
+    })
+
+
+@app.post("/bus/summarize")
+async def bus_summarize(
+    request: Request,
+    x_api_key: Optional[str] = Header(None),
+):
+    """
+    Search and summarize a topic with free LLM.
+    Accepts: {"query": "topic", "max_sources": 5}
+    """
+    _check_auth(x_api_key)
+    body = await request.json()
+    query = body.get("query")
+    if not query:
+        raise HTTPException(status_code=400, detail="query is required")
+    return await call_tool("search_and_summarize", {
+        "query": query,
+        "max_sources": body.get("max_sources", 5),
+    })
+
+
+@app.post("/bus/analyze")
+async def bus_analyze(
+    request: Request,
+    x_api_key: Optional[str] = Header(None),
+):
+    """
+    Scrape and analyze a page with free LLM.
+    Accepts: {"url": "https://..."}
+    """
+    _check_auth(x_api_key)
+    body = await request.json()
+    url = body.get("url")
+    if not url:
+        raise HTTPException(status_code=400, detail="url is required")
+    return await call_tool("analyze_page", {"url": url})
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 

--- a/agents/browser_tools.py
+++ b/agents/browser_tools.py
@@ -284,6 +284,66 @@ async def monitor_sites(args: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Agent Bus tools (search + scrape + free LLM)
+# ---------------------------------------------------------------------------
+
+_bus = None
+
+
+async def _get_bus():
+    global _bus
+    if _bus is None:
+        from agents.agent_bus import AgentBus
+        _bus = AgentBus()
+        await _bus.start(headless=True)
+    return _bus
+
+
+@tool(
+    name="ask",
+    description="Answer a question using web research + free LLM (HuggingFace/Ollama). Searches the web, scrapes relevant pages, sends context to a free model.",
+    parameters={
+        "question": {"type": "string", "description": "The question to answer"},
+        "search_first": {"type": "boolean", "description": "Search web for context first (default true)"},
+    },
+)
+async def bus_ask(args: Dict[str, Any]) -> Dict[str, Any]:
+    bus = await _get_bus()
+    return await bus.ask(
+        args["question"],
+        search_first=args.get("search_first", True),
+    )
+
+
+@tool(
+    name="search_and_summarize",
+    description="Search the web for a topic, scrape results, and summarize with a free LLM.",
+    parameters={
+        "query": {"type": "string", "description": "Topic to research and summarize"},
+        "max_sources": {"type": "integer", "description": "Max sources (default 5)"},
+    },
+)
+async def bus_summarize(args: Dict[str, Any]) -> Dict[str, Any]:
+    bus = await _get_bus()
+    return await bus.search_and_summarize(
+        args["query"],
+        max_sources=args.get("max_sources", 5),
+    )
+
+
+@tool(
+    name="analyze_page",
+    description="Scrape a web page and analyze its content with a free LLM. Returns structured analysis.",
+    parameters={
+        "url": {"type": "string", "description": "URL to analyze"},
+    },
+)
+async def bus_analyze(args: Dict[str, Any]) -> Dict[str, Any]:
+    bus = await _get_bus()
+    return await bus.analyze_page(args["url"])
+
+
+# ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -91,6 +91,7 @@ from src.api.compute_routes import compute_router
 from src.api.search_routes import search_router
 from src.api.llm_routes import llm_router
 from src.api.polly_routes import polly_router
+from src.api.free_llm_routes import free_llm_router
 
 try:
     from src.api.mesh_routes import mesh_router
@@ -156,6 +157,9 @@ app.include_router(llm_router)
 
 # Polly v2 — public assistant chat, search, email, slack, and context endpoints.
 app.include_router(polly_router)
+
+# Free LLM dispatch — Ollama, HuggingFace, offline fallback.
+app.include_router(free_llm_router)
 
 # ============================================================================
 # RATE LIMITING

--- a/src/api/polly_routes.py
+++ b/src/api/polly_routes.py
@@ -272,6 +272,49 @@ def _deterministic_route(message: str) -> tuple[str, str]:
     )
 
 
+async def _free_llm_chat(message: str, page_context: Optional[str]) -> Optional[dict]:
+    """Try free LLMs: Ollama (local) → HuggingFace (free API). Returns dict or None."""
+    prompt = message
+    if page_context:
+        prompt = f"Page context: {page_context[:1000]}\n\nUser: {message}"
+
+    # Try Ollama first (local, zero cost)
+    ollama_url = os.environ.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434").rstrip("/")
+    ollama_model = os.environ.get("OLLAMA_MODEL", "llama3.2")
+    try:
+        payload = json.dumps({"model": ollama_model, "prompt": prompt, "stream": False}).encode()
+        req = urlrequest.Request(
+            f"{ollama_url}/api/generate", data=payload,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        with urlrequest.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+        text = data.get("response", "")
+        if text.strip():
+            return {"text": text, "provider": "ollama", "model": ollama_model}
+    except Exception:
+        pass
+
+    # Try HuggingFace Inference API (free tier, chat completions)
+    hf_token = os.environ.get("HF_TOKEN")
+    hf_model = os.environ.get("HF_MODEL", "Qwen/Qwen2.5-72B-Instruct")
+    if hf_token:
+        try:
+            from huggingface_hub import InferenceClient
+            client = InferenceClient(model=hf_model, token=hf_token)
+            resp = client.chat_completion(
+                messages=[{"role": "user", "content": prompt[:4000]}],
+                max_tokens=512,
+            )
+            text = resp.choices[0].message.content
+            if text and text.strip():
+                return {"text": text.strip(), "provider": "huggingface", "model": hf_model}
+        except Exception:
+            pass
+
+    return None
+
+
 async def _gemini_chat(message: str, history: List[ChatMessage], page_context: Optional[str]) -> str:
     """Call Gemini for thinking-mode responses. Returns text or raises."""
     api_key = _gemini_key()
@@ -350,7 +393,18 @@ async def polly_chat(req: ChatRequest) -> ChatResponse:
                 ts=int(time.time()),
             )
         except RuntimeError as exc:
-            logger.warning("Gemini fallback to deterministic: %s", exc)
+            logger.warning("Gemini fallback: %s", exc)
+
+    # Try free LLM (HuggingFace / Ollama) before deterministic fallback
+    free_result = await _free_llm_chat(req.message, req.page_context)
+    if free_result:
+        return ChatResponse(
+            response=free_result["text"],
+            route=f"free-llm-{free_result['provider']}",
+            thinking=req.thinking,
+            model=free_result["model"],
+            ts=int(time.time()),
+        )
 
     route, response = _deterministic_route(req.message)
     return ChatResponse(
@@ -397,16 +451,41 @@ async def polly_search(req: SearchRequest) -> SearchResponse:
         except (HTTPError, URLError, Exception) as exc:
             logger.warning("Tavily search error: %s", exc)
 
-    # Fallback: inform the client no search backend is available.
+    # Free fallback: DuckDuckGo Instant Answer API (no key needed)
+    try:
+        ddg_url = f"https://api.duckduckgo.com/?q={quote_plus(query)}&format=json&no_html=1&skip_disambig=1"
+        ddg_req = urlrequest.Request(ddg_url, headers={"User-Agent": "SCBE-Polly/1.0"})
+        with urlrequest.urlopen(ddg_req, timeout=8) as resp:
+            ddg_data: Dict[str, Any] = json.loads(resp.read().decode())
+
+        ddg_results: list[SearchResult] = []
+        if ddg_data.get("AbstractURL"):
+            ddg_results.append(SearchResult(
+                title=ddg_data.get("Heading", query),
+                url=ddg_data["AbstractURL"],
+                excerpt=ddg_data.get("Abstract", "")[:300],
+            ))
+        for topic in ddg_data.get("RelatedTopics", []):
+            if isinstance(topic, dict) and topic.get("FirstURL") and not topic["FirstURL"].startswith("https://duckduckgo.com/c/"):
+                ddg_results.append(SearchResult(
+                    title=topic.get("Text", "")[:100],
+                    url=topic["FirstURL"],
+                    excerpt=topic.get("Text", "")[:300],
+                ))
+            if len(ddg_results) >= MAX_SEARCH_RESULTS:
+                break
+        if ddg_results:
+            return SearchResponse(results=ddg_results, source="duckduckgo", query=query, ts=int(time.time()))
+    except Exception as exc:
+        logger.debug("DuckDuckGo fallback failed: %s", exc)
+
+    # Last resort: link to DDG
     return SearchResponse(
         results=[
             SearchResult(
                 title=f"Search: {query}",
                 url=f"https://duckduckgo.com/?q={quote_plus(query)}",
-                excerpt=(
-                    "No Tavily API key is configured. Click the link to search DuckDuckGo directly, "
-                    "or add TAVILY_API_KEY to the server environment."
-                ),
+                excerpt="Click to search DuckDuckGo. Add TAVILY_API_KEY for richer results.",
             )
         ],
         source="fallback",


### PR DESCRIPTION
## Summary
Full agent bus pipeline: web search → scrape → free LLM → governed output.

### What works now (tested live on DESKTOP-K2JGGGI)

| Endpoint | What | Provider | Cost |
|----------|------|----------|------|
| `POST /v1/polly/chat` | Chat with free LLM | Qwen 72B via HuggingFace | Free |
| `POST /v1/polly/search` | Web search | DuckDuckGo API | Free |
| `POST /bus/ask` | Search + scrape + LLM answer | DDG + Playwright + Qwen 72B | Free |
| `POST /bus/summarize` | Research + LLM summary | DDG + Playwright + Qwen 72B | Free |
| `POST /bus/analyze` | Scrape + LLM analysis | Playwright + Qwen 72B | Free |

### LLM priority chain
1. Ollama (local, if running)
2. HuggingFace Qwen/Qwen2.5-72B-Instruct (free tier)
3. Gemini (if GEMINI_API_KEY set)
4. Deterministic routing (keyword-based)

14 browser tools available on port 8003. All services running.