### PR TITLE
fix(release): add PyPI dist guard and clear lint gates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -36,6 +36,7 @@ prune demos
 prune examples
 prune content
 prune artifacts
+prune build
 prune notes
 prune notebooks
 prune sealed_blobs
@@ -55,6 +56,8 @@ prune workflows
 
 # Exclude non-Python files from src
 recursive-exclude src *.ts *.js *.map *.d.ts *.json *.yaml *.yml *.md
+recursive-exclude src/build *
+recursive-exclude src *.egg-info *
 recursive-exclude * __pycache__ *.py[cod] *.so *.egg-info
 
 # Exclude dev/build files

--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -21,6 +21,7 @@ logger = logging.getLogger("scbe.agents.research_agent")
 @dataclass
 class ResearchFinding:
     """A single finding from research."""
+
     source_url: str
     title: str
     relevant_text: str
@@ -31,6 +32,7 @@ class ResearchFinding:
 @dataclass
 class ResearchReport:
     """Structured output from a research task."""
+
     query: str
     findings: List[ResearchFinding] = field(default_factory=list)
     sources_checked: int = 0
@@ -46,16 +48,21 @@ class ResearchReport:
         lines = [f"# Research: {self.query}", ""]
         if self.summary:
             lines += [self.summary, ""]
-        lines += [f"**Sources**: {self.sources_checked} checked, "
-                  f"{len(self.findings)} relevant findings, "
-                  f"{self.total_words_read:,} words read in {self.duration_seconds:.1f}s", ""]
+        lines += [
+            f"**Sources**: {self.sources_checked} checked, "
+            f"{len(self.findings)} relevant findings, "
+            f"{self.total_words_read:,} words read in {self.duration_seconds:.1f}s",
+            "",
+        ]
         for i, f in enumerate(self.findings, 1):
             lines += [
                 f"## {i}. {f.title}",
                 f"**Source**: {f.source_url}",
                 f"**Confidence**: {f.confidence:.0%}",
                 f"**Tags**: {', '.join(f.tags)}" if f.tags else "",
-                "", f.relevant_text[:1000], ""
+                "",
+                f.relevant_text[:1000],
+                "",
             ]
         if self.errors:
             lines += ["## Errors", ""] + [f"- {e}" for e in self.errors]
@@ -147,13 +154,15 @@ class ResearchAgent:
             # Tag by content type
             tags = self._auto_tag(page)
 
-            report.findings.append(ResearchFinding(
-                source_url=page.url,
-                title=page.title,
-                relevant_text=relevant_text,
-                confidence=min(1.0, score),
-                tags=tags,
-            ))
+            report.findings.append(
+                ResearchFinding(
+                    source_url=page.url,
+                    title=page.title,
+                    relevant_text=relevant_text,
+                    confidence=min(1.0, score),
+                    tags=tags,
+                )
+            )
 
         # Step 3: Follow links for depth (if enabled and findings are thin)
         if follow_links and len(report.findings) < 3 and self.max_depth > 0:
@@ -167,13 +176,15 @@ class ResearchAgent:
                         continue
                     score = self._score_relevance(page, query_terms)
                     if score >= self.relevance_threshold:
-                        report.findings.append(ResearchFinding(
-                            source_url=page.url,
-                            title=page.title,
-                            relevant_text=self._extract_relevant_passage(page.text, query_terms),
-                            confidence=min(1.0, score),
-                            tags=self._auto_tag(page) + ["followed-link"],
-                        ))
+                        report.findings.append(
+                            ResearchFinding(
+                                source_url=page.url,
+                                title=page.title,
+                                relevant_text=self._extract_relevant_passage(page.text, query_terms),
+                                confidence=min(1.0, score),
+                                tags=self._auto_tag(page) + ["followed-link"],
+                            )
+                        )
                 except Exception as exc:
                     report.errors.append(f"Follow link {url}: {exc}")
 
@@ -185,7 +196,10 @@ class ResearchAgent:
 
         logger.info(
             "Research '%s': %d findings from %d sources in %.1fs",
-            query, len(report.findings), report.sources_checked, report.duration_seconds,
+            query,
+            len(report.findings),
+            report.sources_checked,
+            report.duration_seconds,
         )
         return report
 
@@ -216,9 +230,9 @@ class ResearchAgent:
                 "title": page.title,
                 "word_count": page.word_count,
                 "relevance": round(score, 2),
-                "key_points": [h["text"] for h in page.headings if any(
-                    t in h["text"].lower() for t in topic_terms
-                )][:5],
+                "key_points": [h["text"] for h in page.headings if any(t in h["text"].lower() for t in topic_terms)][
+                    :5
+                ],
                 "text_preview": self._extract_relevant_passage(page.text, topic_terms)[:500],
             }
             comparison["sources"].append(source)
@@ -226,6 +240,7 @@ class ResearchAgent:
 
         # Find common themes (headings appearing in multiple sources)
         from collections import Counter
+
         heading_words = Counter()
         for h in all_headings:
             for w in h.split():
@@ -245,9 +260,7 @@ class ResearchAgent:
         Quick read of multiple sites. Returns structured summaries.
         Good for dashboards and monitoring workflows.
         """
-        pages = await self.scraper.scrape_many(
-            urls, extract_text=extract_text, delay_ms=300
-        )
+        pages = await self.scraper.scrape_many(urls, extract_text=extract_text, delay_ms=300)
         return [p.summary() for p in pages]
 
     # -- internal scoring ----------------------------------------------------
@@ -324,7 +337,6 @@ class ResearchAgent:
         """Auto-tag a page by content type."""
         tags = []
         url = page.url.lower()
-        text = (page.text or "").lower()
 
         if "arxiv.org" in url:
             tags.append("academic")

--- a/docs/readiness/RELEASE_READINESS_2026-04-27.md
+++ b/docs/readiness/RELEASE_READINESS_2026-04-27.md
@@ -1,0 +1,97 @@
+# Release Readiness - 2026-04-27
+
+Status: in-progress, package guards restored.
+
+## GitHub / CI
+
+- PR #1221 merged: route-first evaluation controls and agent-router Pages deployment wiring.
+- PR #1222 merged: Python release-gate fixes for formatting and choral render compatibility.
+- Latest `main` dependency-submission runs are passing. The earlier dependency-submission failure was a GitHub API snapshot submission error after local dependency discovery had succeeded.
+- The remaining PR-check failure observed on #1222 was Ruff lint. Local fixes were staged for the same lint class:
+  - unused variables/imports in research, tokenizer, API, security, and browser tests;
+  - unused loop variables renamed;
+  - Black formatting re-applied after Ruff fixes.
+
+## npm
+
+Readiness: pass.
+
+Command:
+
+```powershell
+npm run publish:check:strict
+```
+
+Result:
+
+- `npm pack --dry-run --json` succeeds.
+- `scripts/npm_pack_guard.js` reports clean package contents.
+- Tarball observed: `scbe-aethermoore-4.0.3.tgz`, 1275 entries, about 1.65 MB.
+
+No npm publish was run.
+
+## PyPI
+
+Readiness: guarded build path restored.
+
+Commands:
+
+```powershell
+npm run publish:pypi:build
+npm run publish:pypi:check
+```
+
+Result:
+
+- Clean build now removes stale `build/`, `src/build/`, and `src/scbe_aethermoore.egg-info` before creating artifacts.
+- `scripts/pypi_dist_guard.py` validates the wheel and source distribution for generated build trees, cache files, secret/config paths, repo artifacts, and missing wheel metadata.
+- Built artifacts:
+  - `artifacts/pypi-dist/scbe_aethermoore-4.0.3-py3-none-any.whl`
+  - `artifacts/pypi-dist/scbe_aethermoore-4.0.3.tar.gz`
+- Guard result: upload-safe.
+
+Known warnings to resolve before a polished public release:
+
+- Setuptools still warns that `scbe` is configured as a root `py-module` while the active package discovery expects `src/scbe.py`.
+- Setuptools warns that `api.darpa_prep` is importable but not explicitly declared in package configuration.
+- The wheel contains three validation-named modules under `symphonic_cipher/scbe_aethermoore/`: `layer_tests.py`, `patent_validation_tests.py`, and `test_scbe_system.py`. The guard reports these as warnings, not blockers.
+
+No PyPI upload was run.
+
+## Docker
+
+Readiness: local build not verified in this pass.
+
+Command:
+
+```powershell
+npm run docker:doctor:api
+```
+
+Result:
+
+- Blocked locally because Docker Desktop / Docker Engine is not reachable.
+
+Packaging note:
+
+- `Dockerfile.api` remains the safer production-facing container path.
+- The root `Dockerfile` still contains `npm run build || true`, which can hide TypeScript build failures. This should be removed or split into an explicit best-effort development image before treating the root image as release-grade.
+
+## GitHub Pages
+
+Readiness: live site reachable; agent-data deployment path improved.
+
+- Main Pages site and `agents.html` were reachable during this pass.
+- Agent Router now includes direct Pages deployment wiring so router-published data does not depend on a separate push-triggered Pages workflow from `GITHUB_TOKEN`.
+- Needs next Agent Router run or manual workflow run to verify the direct Pages artifact deploy end-to-end.
+
+## Training / Model Release
+
+Readiness: not a release artifact yet.
+
+- Training outputs remain gate-based and should not be flattened, quantized, pushed, or merged without frozen-eval proof.
+- Route-first evaluation remains the safer current operating model until the adapters pass executable and frozen-eval gates.
+
+## Current Recommendation
+
+Treat npm and PyPI as package-ready after the current release-guard branch lands. Treat Docker and model-release channels as blocked until Docker Engine is available and model gates pass. Do not publish externally from this report alone.

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "publish:prepare": "npm run clean:release && npm run build",
     "publish:pack:json": "node -e \"require('fs').mkdirSync('artifacts/npm-pack',{recursive:true})\" && npm pack --dry-run --json --ignore-scripts --cache ./.npm-cache > artifacts/npm-pack/pack.json",
     "publish:check:strict": "npm run publish:pack:json && node scripts/npm_pack_guard.js --pack-json artifacts/npm-pack/pack.json",
-    "publish:pypi:build": "python -m build --sdist --wheel --outdir artifacts/pypi-dist",
+    "publish:pypi:build": "python scripts/pypi_build.py --dist-dir artifacts/pypi-dist",
     "publish:pypi:check": "python scripts/pypi_dist_guard.py --dist-dir artifacts/pypi-dist",
     "prepublishOnly": "npm run publish:prepare",
     "prepack": "npm run publish:check:strict",

--- a/scripts/experiments/atomic_tokenizer_rename_benchmark.py
+++ b/scripts/experiments/atomic_tokenizer_rename_benchmark.py
@@ -47,7 +47,6 @@ from scripts.experiments.layered_geometry_semantic_packing import (
 )
 from python.scbe.atomic_tokenization import map_token_to_atomic_state
 
-
 DEFAULT_INPUT = Path("artifacts/mathbac/cross_primary_atomic")
 DEFAULT_OUTPUT = Path("artifacts/mathbac/atomic_tokenizer_rename_benchmark")
 PERIODIC_TABLE = Path("artifacts/mathbac/periodic_table_full.json")
@@ -477,7 +476,7 @@ def make_operational_flow_feature() -> Callable[[str], dict[str, float]]:
 
 
 def combine_feature_heads(
-    heads: list[tuple[str, Callable[[str], dict[str, float]], float]]
+    heads: list[tuple[str, Callable[[str], dict[str, float]], float]],
 ) -> Callable[[str], dict[str, float]]:
     def feature(text: str) -> dict[str, float]:
         combined: dict[str, float] = {}
@@ -536,20 +535,17 @@ def make_layered_geometry_semantic_feature() -> Callable[[str], dict[str, float]
         )
         for family in GEOMETRY_TOKEN_FAMILIES
     }
-    keys = (
-        [f"geom_family_{family}" for family in GEOMETRY_TOKEN_FAMILIES]
-        + [
-            "geom_token_count_log",
-            "geom_mean_fit_score",
-            "geom_mean_semantic_loss",
-            "geom_mean_utilization",
-            "geom_mean_octave_links",
-            "geom_mean_collision_count",
-            "geom_mean_boundary_violations",
-            "geom_control_to_callable_ratio",
-            "geom_governance_to_data_ratio",
-        ]
-    )
+    keys = [f"geom_family_{family}" for family in GEOMETRY_TOKEN_FAMILIES] + [
+        "geom_token_count_log",
+        "geom_mean_fit_score",
+        "geom_mean_semantic_loss",
+        "geom_mean_utilization",
+        "geom_mean_octave_links",
+        "geom_mean_collision_count",
+        "geom_mean_boundary_violations",
+        "geom_control_to_callable_ratio",
+        "geom_governance_to_data_ratio",
+    ]
 
     def feature(text: str) -> dict[str, float]:
         result = {key: 0.0 for key in keys}
@@ -571,9 +567,9 @@ def make_layered_geometry_semantic_feature() -> Callable[[str], dict[str, float]
         result["geom_mean_utilization"] = sum(shape_reports[family].utilization for family in families) / n
         result["geom_mean_octave_links"] = sum(shape_reports[family].octave_link_count for family in families) / n
         result["geom_mean_collision_count"] = sum(shape_reports[family].collision_count for family in families) / n
-        result["geom_mean_boundary_violations"] = sum(
-            shape_reports[family].boundary_violation_count for family in families
-        ) / n
+        result["geom_mean_boundary_violations"] = (
+            sum(shape_reports[family].boundary_violation_count for family in families) / n
+        )
         result["geom_control_to_callable_ratio"] = counts["CONTROL_FLOW"] / max(1.0, float(counts["CALLABLE"]))
         result["geom_governance_to_data_ratio"] = counts["GOVERNANCE_GATE"] / max(1.0, float(counts["DATA_SYMBOL"]))
         return result
@@ -583,9 +579,7 @@ def make_layered_geometry_semantic_feature() -> Callable[[str], dict[str, float]
     return feature
 
 
-def byte_periodic_signature(
-    text: str, table: list[dict[str, Any]], *, mode: str
-) -> dict[str, Any]:
+def byte_periodic_signature(text: str, table: list[dict[str, Any]], *, mode: str) -> dict[str, Any]:
     """Build a source-level molecule signature from byte->element traces."""
 
     data = text.encode("utf-8")
@@ -616,9 +610,7 @@ def byte_periodic_signature(
         "element_fracs": {key: value / n for key, value in sorted(element_counts.items())},
         "atomic_number_mean": atomic_mean,
         "atomic_number_std": math.sqrt(atomic_var),
-        "electronegativity_mean": sum(
-            float(element.get("electronegativity_pauling") or 0.0) for element in elements
-        )
+        "electronegativity_mean": sum(float(element.get("electronegativity_pauling") or 0.0) for element in elements)
         / n,
         "period_mean": sum(float(element.get("period") or 0.0) for element in elements) / n,
         "group_mean": sum(float(element.get("group") or 0.0) for element in elements) / n,
@@ -702,9 +694,7 @@ def chemical_distance_report(
         "same_concept_cross_primary_mean": mean(same_concept_cross_primary),
         "same_primary_cross_concept_mean": mean(same_primary_cross_concept),
         "intra_inter_ratio": mean(intra) / mean(inter) if inter else 0.0,
-        "per_concept_intra_mean": {
-            concept: mean(values) for concept, values in sorted(per_concept.items())
-        },
+        "per_concept_intra_mean": {concept: mean(values) for concept, values in sorted(per_concept.items())},
         "nearest_neighbor_confusions": {
             concept: dict(counter.most_common(5)) for concept, counter in sorted(nearest.items())
         },
@@ -719,12 +709,8 @@ def chemical_distance_report(
                 "electronegativity_mean": signature["electronegativity_mean"],
                 "period_mean": signature["period_mean"],
                 "group_mean": signature["group_mean"],
-                "top_elements": sorted(
-                    signature["element_fracs"].items(), key=lambda item: (-item[1], item[0])
-                )[:8],
-                "top_categories": sorted(
-                    signature["category_fracs"].items(), key=lambda item: (-item[1], item[0])
-                )[:5],
+                "top_elements": sorted(signature["element_fracs"].items(), key=lambda item: (-item[1], item[0]))[:8],
+                "top_categories": sorted(signature["category_fracs"].items(), key=lambda item: (-item[1], item[0]))[:5],
             }
             for sample, signature in zip(samples, signatures)
         ],
@@ -838,9 +824,7 @@ def workflow_training_records(
                         "feature": geometry_feature(source),
                     },
                 },
-                "workflow_chain": workflow_chain_string(
-                    source, table, hex_lookup, mode=mode
-                ),
+                "workflow_chain": workflow_chain_string(source, table, hex_lookup, mode=mode),
             }
         )
     return records
@@ -853,9 +837,7 @@ def _feature_keys_for(features: list[dict[str, float]]) -> list[str]:
     return sorted(keys)
 
 
-def _loo_nearest_with_keys(
-    features: list[dict[str, float]], concepts: list[str], keys: list[str]
-) -> list[str]:
+def _loo_nearest_with_keys(features: list[dict[str, float]], concepts: list[str], keys: list[str]) -> list[str]:
     sums: dict[str, dict[str, float]] = {}
     counts: dict[str, int] = {}
     for feature, concept in zip(features, concepts):
@@ -875,10 +857,7 @@ def _loo_nearest_with_keys(
                 rest_count = counts[candidate] - 1
                 if rest_count <= 0:
                     continue
-                prototype = {
-                    key: (total[key] - feature.get(key, 0.0)) / rest_count
-                    for key in keys
-                }
+                prototype = {key: (total[key] - feature.get(key, 0.0)) / rest_count for key in keys}
             else:
                 rest_count = counts[candidate]
                 prototype = {key: total[key] / rest_count for key in keys}
@@ -937,10 +916,7 @@ def _normalize_features(features: list[dict[str, float]], keys: list[str]) -> li
         variance = sum((feature.get(key, 0.0) - mean) ** 2 for feature in features) / n
         means[key] = mean
         stdevs[key] = math.sqrt(variance) or 1.0
-    return [
-        {key: (feature.get(key, 0.0) - means[key]) / stdevs[key] for key in keys}
-        for feature in features
-    ]
+    return [{key: (feature.get(key, 0.0) - means[key]) / stdevs[key] for key in keys} for feature in features]
 
 
 SITUATION_PROFILES: dict[str, dict[str, float]] = {
@@ -1088,24 +1064,18 @@ def _label_shuffle_control(
         null_accuracies: list[float] = []
         iteration_seeds: list[int] = []
         marginal_count_checks: list[bool] = []
-        for iteration in range(shuffle_runs):
+        for _iteration in range(shuffle_runs):
             iteration_seed = rng.randrange(0, 2**32)
             iteration_rng = random.Random(iteration_seed)
             iteration_seeds.append(iteration_seed)
             predictions: list[str] = ["UNKNOWN"] * len(samples)
             for held_out_group in unique_groups:
-                train_indices = [
-                    index for index, group in enumerate(groups) if group != held_out_group
-                ]
-                test_indices = [
-                    index for index, group in enumerate(groups) if group == held_out_group
-                ]
+                train_indices = [index for index, group in enumerate(groups) if group != held_out_group]
+                test_indices = [index for index, group in enumerate(groups) if group == held_out_group]
                 shuffled_train_labels = [true_concepts[index] for index in train_indices]
                 original_train_counts = Counter(shuffled_train_labels)
                 iteration_rng.shuffle(shuffled_train_labels)
-                marginal_count_checks.append(
-                    Counter(shuffled_train_labels) == original_train_counts
-                )
+                marginal_count_checks.append(Counter(shuffled_train_labels) == original_train_counts)
                 sums: dict[str, dict[str, float]] = {}
                 counts: dict[str, int] = {}
                 for train_index, shuffled_label in zip(train_indices, shuffled_train_labels):
@@ -1119,13 +1089,8 @@ def _label_shuffle_control(
                     best = "UNKNOWN"
                     best_distance = math.inf
                     for candidate in sorted(sums):
-                        prototype = {
-                            key: sums[candidate][key] / counts[candidate] for key in keys
-                        }
-                        distance = math.fsum(
-                            (features[test_index].get(key, 0.0) - prototype[key]) ** 2
-                            for key in keys
-                        )
+                        prototype = {key: sums[candidate][key] / counts[candidate] for key in keys}
+                        distance = math.fsum((features[test_index].get(key, 0.0) - prototype[key]) ** 2 for key in keys)
                         if distance < best_distance:
                             best_distance = distance
                             best = candidate
@@ -1197,9 +1162,7 @@ def _evaluate_within_primary_loo(
     }
 
 
-def _per_primary_accuracy(
-    samples: list[Sample], predictions: list[str]
-) -> dict[str, dict[str, Any]]:
+def _per_primary_accuracy(samples: list[Sample], predictions: list[str]) -> dict[str, dict[str, Any]]:
     buckets: dict[str, list[tuple[str, str]]] = defaultdict(list)
     for sample, pred in zip(samples, predictions):
         buckets[sample.primary].append((sample.concept, pred))
@@ -1316,11 +1279,7 @@ def _comparison_markdown(report: dict[str, Any]) -> str:
         "|---|---:|---:|---:|---|",
     ]
     for row in report["summary"]:
-        lines.append(
-            "| {feature} | {baseline:.1%} | {renamed:.1%} | {drop:.1%} | {interpretation} |".format(
-                **row
-            )
-        )
+        lines.append("| {feature} | {baseline:.1%} | {renamed:.1%} | {drop:.1%} | {interpretation} |".format(**row))
     lines.extend(
         [
             "",
@@ -1331,9 +1290,7 @@ def _comparison_markdown(report: dict[str, Any]) -> str:
         ]
     )
     for row in report["leave_primary_out_summary"]:
-        lines.append(
-            "| {feature} | {accuracy:.1%} | {risk} |".format(**row)
-        )
+        lines.append("| {feature} | {accuracy:.1%} | {risk} |".format(**row))
     lines.extend(
         [
             "",
@@ -1464,9 +1421,7 @@ def run(
     table = _load_periodic_table(PERIODIC_TABLE)
     hex_lookup = load_binary_hex_lookup()
     byte_feature = make_byte_periodic_feature(table, mode=byte_map_mode)
-    chemistry_feature = make_binary_hex_chemistry_feature(
-        table, hex_lookup, mode=byte_map_mode
-    )
+    chemistry_feature = make_binary_hex_chemistry_feature(table, hex_lookup, mode=byte_map_mode)
     flow_feature = make_operational_flow_feature()
     semantic_overlay_feature = make_atomic_semantic_overlay_feature()
     geometry_feature = make_layered_geometry_semantic_feature()
@@ -1509,36 +1464,78 @@ def run(
             "renamed": _evaluate(samples, renamed_sources, _default_atomic_feature, feature_name="atomic_current"),
         },
         f"byte_periodic_{byte_map_mode}": {
-            "baseline": _evaluate(samples, original_sources, byte_feature, feature_name=f"byte_periodic_{byte_map_mode}"),
+            "baseline": _evaluate(
+                samples, original_sources, byte_feature, feature_name=f"byte_periodic_{byte_map_mode}"
+            ),
             "renamed": _evaluate(samples, renamed_sources, byte_feature, feature_name=f"byte_periodic_{byte_map_mode}"),
         },
         f"chemistry_actual_{byte_map_mode}": {
-            "baseline": _evaluate(samples, original_sources, chemistry_feature, feature_name=f"chemistry_actual_{byte_map_mode}"),
-            "renamed": _evaluate(samples, renamed_sources, chemistry_feature, feature_name=f"chemistry_actual_{byte_map_mode}"),
+            "baseline": _evaluate(
+                samples, original_sources, chemistry_feature, feature_name=f"chemistry_actual_{byte_map_mode}"
+            ),
+            "renamed": _evaluate(
+                samples, renamed_sources, chemistry_feature, feature_name=f"chemistry_actual_{byte_map_mode}"
+            ),
         },
         "semantic_overlay_current": {
-            "baseline": _evaluate(samples, original_sources, semantic_overlay_feature, feature_name="semantic_overlay_current"),
-            "renamed": _evaluate(samples, renamed_sources, semantic_overlay_feature, feature_name="semantic_overlay_current"),
+            "baseline": _evaluate(
+                samples, original_sources, semantic_overlay_feature, feature_name="semantic_overlay_current"
+            ),
+            "renamed": _evaluate(
+                samples, renamed_sources, semantic_overlay_feature, feature_name="semantic_overlay_current"
+            ),
         },
         "flow_reinforcement": {
             "baseline": _evaluate(samples, original_sources, flow_feature, feature_name="flow_reinforcement"),
             "renamed": _evaluate(samples, renamed_sources, flow_feature, feature_name="flow_reinforcement"),
         },
         "layered_geometry_semantic": {
-            "baseline": _evaluate(samples, original_sources, geometry_feature, feature_name="layered_geometry_semantic"),
+            "baseline": _evaluate(
+                samples, original_sources, geometry_feature, feature_name="layered_geometry_semantic"
+            ),
             "renamed": _evaluate(samples, renamed_sources, geometry_feature, feature_name="layered_geometry_semantic"),
         },
         f"dual_lane_chemistry_semantic_{byte_map_mode}": {
-            "baseline": _evaluate(samples, original_sources, dual_lane_feature, feature_name=f"dual_lane_chemistry_semantic_{byte_map_mode}"),
-            "renamed": _evaluate(samples, renamed_sources, dual_lane_feature, feature_name=f"dual_lane_chemistry_semantic_{byte_map_mode}"),
+            "baseline": _evaluate(
+                samples,
+                original_sources,
+                dual_lane_feature,
+                feature_name=f"dual_lane_chemistry_semantic_{byte_map_mode}",
+            ),
+            "renamed": _evaluate(
+                samples,
+                renamed_sources,
+                dual_lane_feature,
+                feature_name=f"dual_lane_chemistry_semantic_{byte_map_mode}",
+            ),
         },
         f"reinforced_chemistry_semantic_flow_{byte_map_mode}": {
-            "baseline": _evaluate(samples, original_sources, reinforced_feature, feature_name=f"reinforced_chemistry_semantic_flow_{byte_map_mode}"),
-            "renamed": _evaluate(samples, renamed_sources, reinforced_feature, feature_name=f"reinforced_chemistry_semantic_flow_{byte_map_mode}"),
+            "baseline": _evaluate(
+                samples,
+                original_sources,
+                reinforced_feature,
+                feature_name=f"reinforced_chemistry_semantic_flow_{byte_map_mode}",
+            ),
+            "renamed": _evaluate(
+                samples,
+                renamed_sources,
+                reinforced_feature,
+                feature_name=f"reinforced_chemistry_semantic_flow_{byte_map_mode}",
+            ),
         },
         f"reinforced_chemistry_semantic_flow_geometry_{byte_map_mode}": {
-            "baseline": _evaluate(samples, original_sources, geometry_reinforced_feature, feature_name=f"reinforced_chemistry_semantic_flow_geometry_{byte_map_mode}"),
-            "renamed": _evaluate(samples, renamed_sources, geometry_reinforced_feature, feature_name=f"reinforced_chemistry_semantic_flow_geometry_{byte_map_mode}"),
+            "baseline": _evaluate(
+                samples,
+                original_sources,
+                geometry_reinforced_feature,
+                feature_name=f"reinforced_chemistry_semantic_flow_geometry_{byte_map_mode}",
+            ),
+            "renamed": _evaluate(
+                samples,
+                renamed_sources,
+                geometry_reinforced_feature,
+                feature_name=f"reinforced_chemistry_semantic_flow_geometry_{byte_map_mode}",
+            ),
         },
     }
     leave_primary_out = {
@@ -1569,11 +1566,7 @@ def run(
         seed=shuffle_seed,
     )
     label_shuffle_control_summary = [
-        {
-            key: value
-            for key, value in control.items()
-            if key != "distribution"
-        }
+        {key: value for key, value in control.items() if key != "distribution"}
         for control in label_shuffle_control.values()
     ]
 
@@ -1630,19 +1623,13 @@ def run(
     selected_control = label_shuffle_control.get(selected_lane["feature"])
     if selected_control and selected_control["risk"] == "passes shuffle control":
         training_status = "candidate"
-        training_status_reason = (
-            "Selected lane passed the pre-committed label-shuffle control; export remains a candidate training input, not a promoted dataset."
-        )
+        training_status_reason = "Selected lane passed the pre-committed label-shuffle control; export remains a candidate training input, not a promoted dataset."
     else:
         training_status = "hold"
         if selected_control:
-            training_status_reason = (
-                "Selected lane did not cleanly pass the label-shuffle null control; export is generated for inspection only and must not be promoted to training."
-            )
+            training_status_reason = "Selected lane did not cleanly pass the label-shuffle null control; export is generated for inspection only and must not be promoted to training."
         else:
-            training_status_reason = (
-                "Selected lane was not included in the shuffle control; export is generated for inspection only and must not be promoted to training."
-            )
+            training_status_reason = "Selected lane was not included in the shuffle control; export is generated for inspection only and must not be promoted to training."
     within_primary = {
         name: _evaluate_within_primary_loo(
             samples,
@@ -1702,12 +1689,8 @@ def run(
         "within_primary_diagnostic": within_primary_diagnostic,
         "renamed_aliases": {key: sorted(value) for key, value in renamed_aliases.items()},
         "atomic_collapse": _unknown_token_collapse(samples),
-        "chemical_distance": chemical_distance_report(
-            samples, original_sources, table, mode=byte_map_mode
-        ),
-        "token_atom_traces": token_atom_trace(
-            samples, table, mode=byte_map_mode, hex_lookup=hex_lookup
-        ),
+        "chemical_distance": chemical_distance_report(samples, original_sources, table, mode=byte_map_mode),
+        "token_atom_traces": token_atom_trace(samples, table, mode=byte_map_mode, hex_lookup=hex_lookup),
         "workflow_training_records": {
             "path": str(output_dir / "semantic_chemistry_workflows.jsonl"),
             "schema_version": "semantic_chemistry_workflow_v1",
@@ -1719,12 +1702,8 @@ def run(
     }
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / "rename_benchmark_report.json").write_text(
-        json.dumps(report, indent=2), encoding="utf-8"
-    )
-    (output_dir / "comparison.md").write_text(
-        _comparison_markdown(report), encoding="utf-8"
-    )
+    (output_dir / "rename_benchmark_report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    (output_dir / "comparison.md").write_text(_comparison_markdown(report), encoding="utf-8")
     (output_dir / "renamed_manifest.json").write_text(
         json.dumps(
             {
@@ -1744,12 +1723,8 @@ def run(
         ),
         encoding="utf-8",
     )
-    workflow_records = workflow_training_records(
-        samples, original_sources, table, hex_lookup, mode=byte_map_mode
-    )
-    with (output_dir / "semantic_chemistry_workflows.jsonl").open(
-        "w", encoding="utf-8", newline="\n"
-    ) as handle:
+    workflow_records = workflow_training_records(samples, original_sources, table, hex_lookup, mode=byte_map_mode)
+    with (output_dir / "semantic_chemistry_workflows.jsonl").open("w", encoding="utf-8", newline="\n") as handle:
         for record in workflow_records:
             handle.write(json.dumps(record, ensure_ascii=False) + "\n")
     return report

--- a/scripts/pypi_build.py
+++ b/scripts/pypi_build.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Clean generated packaging state and build PyPI artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+GENERATED_PATHS = (
+    Path("build"),
+    Path("src") / "build",
+    Path("src") / "scbe_aethermoore.egg-info",
+)
+
+
+def remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists():
+        path.unlink()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build clean PyPI sdist and wheel artifacts.")
+    parser.add_argument("--dist-dir", default="artifacts/pypi-dist", help="Output directory for PyPI artifacts.")
+    args = parser.parse_args(argv)
+
+    for path in GENERATED_PATHS:
+        remove_path(path)
+
+    dist_dir = Path(args.dist_dir)
+    if dist_dir.exists():
+        for child in dist_dir.iterdir():
+            if child.is_file() and (child.name.endswith(".whl") or child.name.endswith(".tar.gz")):
+                child.unlink()
+    else:
+        dist_dir.mkdir(parents=True, exist_ok=True)
+
+    return subprocess.run(
+        [sys.executable, "-m", "build", "--sdist", "--wheel", "--outdir", str(dist_dir)],
+        check=False,
+    ).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pypi_dist_guard.py
+++ b/scripts/pypi_dist_guard.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Validate PyPI release artifacts before upload.
+
+This guard is intentionally local and offline. It checks the built wheel and
+sdist for common release leaks that would make a public package look unsafe or
+unprofessional: generated build trees, caches, secrets, repo artifacts, and
+test-only payloads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DistFile:
+    path: Path
+    members: list[str]
+
+
+FAIL_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(^|/)\.git(/|$)"), ".git metadata"),
+    (re.compile(r"(^|/)\.env(\.|$|/)"), "environment secret file"),
+    (re.compile(r"(^|/)(?:config/connector_oauth|secrets?|\.aws|\.ssh)(/|$)", re.I), "secret/config directory"),
+    (
+        re.compile(r"(^|/)(?:artifacts|training-data|node_modules|external|external_repos)(/|$)", re.I),
+        "repo artifact or dependency tree",
+    ),
+    (re.compile(r"(^|/)build/lib/(?:src|api|crypto|harmonic|symphonic_cipher)(/|$)", re.I), "generated build/lib tree"),
+    (re.compile(r"(^|/)src/build(/|$)", re.I), "generated src/build tree"),
+    (re.compile(r"(^|/)__pycache__(/|$)", re.I), "__pycache__ directory"),
+    (re.compile(r"\.py[co]$", re.I), "Python bytecode"),
+    (re.compile(r"(^|/)\.(?:pytest_cache|mypy_cache|ruff_cache|hypothesis)(/|$)", re.I), "tool cache"),
+)
+
+WARN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(^|/)tests?(/|$)", re.I), "test package or test directory"),
+    (re.compile(r"(^|/)(?:test_.+|.+_tests?)\.py$", re.I), "test-like module"),
+    (re.compile(r"(^|/)src/(?![^/]+\.egg-info(?:/|$))", re.I), "raw src/ path inside artifact"),
+)
+
+REQUIRED_SUFFIXES = (".tar.gz", ".whl")
+
+
+def normalize_member(name: str) -> str:
+    return name.replace("\\", "/").lstrip("./")
+
+
+def read_members(path: Path) -> list[str]:
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as zf:
+            return [normalize_member(name) for name in zf.namelist()]
+    if path.name.endswith(".tar.gz"):
+        with tarfile.open(path, "r:gz") as tf:
+            return [normalize_member(name) for name in tf.getnames()]
+    raise ValueError(f"Unsupported distribution file: {path}")
+
+
+def load_dists(dist_dir: Path) -> list[DistFile]:
+    if not dist_dir.exists():
+        raise FileNotFoundError(f"dist dir does not exist: {dist_dir}")
+    files = sorted(path for path in dist_dir.iterdir() if path.is_file() and path.name.endswith(REQUIRED_SUFFIXES))
+    if not files:
+        raise FileNotFoundError(f"no .tar.gz or .whl files found in {dist_dir}")
+    return [DistFile(path=path, members=read_members(path)) for path in files]
+
+
+def check_required_artifacts(dists: list[DistFile]) -> list[str]:
+    names = [dist.path.name for dist in dists]
+    errors: list[str] = []
+    if not any(name.endswith(".whl") for name in names):
+        errors.append("missing wheel artifact (.whl)")
+    if not any(name.endswith(".tar.gz") for name in names):
+        errors.append("missing source distribution artifact (.tar.gz)")
+    return errors
+
+
+def scan_patterns(dist: DistFile, patterns: tuple[tuple[re.Pattern[str], str], ...]) -> list[tuple[str, str]]:
+    hits: list[tuple[str, str]] = []
+    for member in dist.members:
+        for pattern, reason in patterns:
+            if pattern.search(member):
+                hits.append((member, reason))
+                break
+    return hits
+
+
+def wheel_has_metadata(dist: DistFile) -> bool:
+    if dist.path.suffix != ".whl":
+        return True
+    return any(name.endswith(".dist-info/METADATA") for name in dist.members) and any(
+        name.endswith(".dist-info/WHEEL") for name in dist.members
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate PyPI dist artifacts before upload.")
+    parser.add_argument(
+        "--dist-dir", default="artifacts/pypi-dist", help="Directory containing .whl and .tar.gz files."
+    )
+    parser.add_argument(
+        "--strict-warnings",
+        action="store_true",
+        help="Treat warnings, such as test-like modules in artifacts, as failures.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        dists = load_dists(Path(args.dist_dir))
+    except (FileNotFoundError, ValueError, tarfile.TarError, zipfile.BadZipFile) as exc:
+        print(f"[pypi-dist-guard] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    errors = check_required_artifacts(dists)
+    warnings: list[str] = []
+
+    for dist in dists:
+        print(f"[pypi-dist-guard] inspecting {dist.path.name}: {len(dist.members)} entries")
+        if not wheel_has_metadata(dist):
+            errors.append(f"{dist.path.name}: missing wheel METADATA or WHEEL file")
+
+        for member, reason in scan_patterns(dist, FAIL_PATTERNS):
+            errors.append(f"{dist.path.name}: {member} ({reason})")
+
+        for member, reason in scan_patterns(dist, WARN_PATTERNS):
+            warnings.append(f"{dist.path.name}: {member} ({reason})")
+
+    if warnings:
+        print("[pypi-dist-guard] warnings:")
+        for warning in warnings[:40]:
+            print(f" - {warning}")
+        if len(warnings) > 40:
+            print(f" - ... {len(warnings) - 40} more warning(s)")
+
+    if errors:
+        print("[pypi-dist-guard] release blockers:", file=sys.stderr)
+        for error in errors[:80]:
+            print(f" - {error}", file=sys.stderr)
+        if len(errors) > 80:
+            print(f" - ... {len(errors) - 80} more error(s)", file=sys.stderr)
+        return 1
+
+    if args.strict_warnings and warnings:
+        print("[pypi-dist-guard] strict warning mode failed", file=sys.stderr)
+        return 1
+
+    print("[pypi-dist-guard] dist artifacts are upload-safe")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/polly_routes.py
+++ b/src/api/polly_routes.py
@@ -22,7 +22,6 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote_plus
 
 from fastapi import APIRouter
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger("scbe.api.polly")

--- a/src/security/phase_lattice_lookup.py
+++ b/src/security/phase_lattice_lookup.py
@@ -12,7 +12,7 @@ import hashlib
 import math
 import re
 from dataclasses import dataclass
-from typing import Iterable, Sequence
+from typing import Sequence
 
 import numpy as np
 

--- a/src/symphonic_cipher/scbe_aethermoore/concept_blocks/cstm/models.py
+++ b/src/symphonic_cipher/scbe_aethermoore/concept_blocks/cstm/models.py
@@ -113,10 +113,7 @@ class StoryGraph:
         # Lazy import to avoid circular dep
         import importlib
 
-        evaluator_class = getattr(
-            importlib.import_module(f"{__package__}.story_engine"),
-            "ConditionEvaluator",
-        )
+        evaluator_class = importlib.import_module(f"{__package__}.story_engine").ConditionEvaluator
         evaluator = evaluator_class()
         return [c for c in scene.choices if c.condition is None or evaluator.evaluate(c.condition, stats)]
 

--- a/src/tokenizer/accelerator_routing.py
+++ b/src/tokenizer/accelerator_routing.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import math
 from dataclasses import dataclass
 from typing import Any
 

--- a/src/tokenizer/atomic_workflow_units.py
+++ b/src/tokenizer/atomic_workflow_units.py
@@ -217,7 +217,6 @@ def _compatible(left: dict[str, Any], right: dict[str, Any]) -> tuple[bool, list
     left_sem = left["semantic_lane"]
     right_sem = right["semantic_lane"]
     left_chem = left["chemistry_lane"]
-    right_chem = right["chemistry_lane"]
     phase_gap = abs(float(right_sem["phase"]) - float(left_sem["phase"]))
     if phase_gap > 0.72:
         reasons.append(f"phase_gap_too_large:{phase_gap:.3f}")

--- a/src/tokenizer/topology_view.py
+++ b/src/tokenizer/topology_view.py
@@ -290,7 +290,7 @@ def _thought_field_cost_retro(
     total_energy_cost = 0.0
     total_risk_cost = 0.0
 
-    for index, chain in enumerate(chains):
+    for _index, chain in enumerate(chains):
         distance_cost = float(chain.get("distance") or 0.0)
         drift_cost = abs(float(chain.get("delta", {}).get("z") or 0.0))
         recovery_cost = float(chain.get("torsion_proxy") or 0.0) * 0.2

--- a/tests/aetherbrowser/test_zone_hard_gate.py
+++ b/tests/aetherbrowser/test_zone_hard_gate.py
@@ -1,9 +1,8 @@
 """Tests for zone enforcement hard gates."""
 
-import pytest
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from dataclasses import dataclass
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))

--- a/tests/contracts/test_auth_config.py
+++ b/tests/contracts/test_auth_config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import os
 
 
 def _reload_auth_config():


### PR DESCRIPTION
## Summary
- Adds a clean PyPI build wrapper so stale build/egg-info trees do not leak into release artifacts.
- Adds a PyPI dist guard wired to the existing `npm run publish:pypi:check` command.
- Clears current Ruff lint failures observed on PR #1222 and documents release readiness across npm, PyPI, Docker, Pages, and model channels.

## Validation
- `python -m py_compile scripts/pypi_build.py scripts/pypi_dist_guard.py`
- `black --check --target-version py311 --line-length 120 src/ tests/ scripts/pypi_build.py scripts/pypi_dist_guard.py agents/research_agent.py scripts/experiments/atomic_tokenizer_rename_benchmark.py`
- `ruff check --config ruff.toml`
- `npm run publish:check:strict`
- `npm run publish:pypi:build`
- `npm run publish:pypi:check`
- `pytest tests\aetherbrowser\test_zone_hard_gate.py tests\contracts\test_auth_config.py -q`

## Notes
- No npm or PyPI publish was run.
- Docker release verification remains blocked locally because Docker Engine is not reachable.
- Untracked local `experiments/bijective_2tongue_build/` was left untouched.