### PR TITLE
ci(docker): add remote API image build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+# Keep Docker build contexts small and secret-safe.
+.git
+.github
+.codex_tmp
+.pytest_cache
+.hypothesis
+.mypy_cache
+.ruff_cache
+.npm-cache
+node_modules
+dist
+build
+src/build
+src/*.egg-info
+*.egg-info
+__pycache__
+*.pyc
+*.pyo
+
+# Local/generated artifacts.
+artifacts
+training/runs
+training-data
+notebooks
+notes
+exports
+_staging
+sealed_blobs
+external
+external_repos
+experiments
+
+# Secrets and local config.
+.env
+.env.*
+!.env.example
+config/connector_oauth
+*.pem
+*.key
+*.p12
+*.pfx
+
+# Non-container product surfaces.
+docs
+coverage
+htmlcov
+*.log
+*.zip
+*.tar
+*.tar.gz
+*.tgz

--- a/.github/workflows/docker-remote-build.yml
+++ b/.github/workflows/docker-remote-build.yml
@@ -1,0 +1,128 @@
+name: Remote Docker Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_target:
+        description: Container target to build
+        required: true
+        default: api
+        type: choice
+        options:
+          - api
+      push_image:
+        description: Push image to GitHub Container Registry after smoke test
+        required: true
+        default: false
+        type: boolean
+      run_smoke:
+        description: Run container health smoke test after build
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      TARGET: ${{ inputs.image_target }}
+      PUSH_IMAGE: ${{ inputs.push_image }}
+      RUN_SMOKE: ${{ inputs.run_smoke }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve image metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo_lc="${GITHUB_REPOSITORY,,}"
+          short_sha="${GITHUB_SHA::12}"
+
+          case "${TARGET}" in
+            api)
+              dockerfile="Dockerfile.api"
+              image="ghcr.io/${repo_lc}/scbe-api"
+              smoke_url="http://127.0.0.1:8080/v1/health"
+              ;;
+            *)
+              echo "Unsupported image target: ${TARGET}" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "DOCKERFILE=${dockerfile}"
+            echo "IMAGE=${image}"
+            echo "IMAGE_SHA=${image}:sha-${short_sha}"
+            echo "IMAGE_LATEST=${image}:latest"
+            echo "SMOKE_URL=${smoke_url}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Build image locally on runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --file "${DOCKERFILE}" \
+            --tag "${IMAGE_SHA}" \
+            --tag "${IMAGE_LATEST}" \
+            --load \
+            .
+
+      - name: Smoke test API image
+        if: ${{ inputs.run_smoke }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm -d --name scbe-api-smoke -p 8080:8080 "${IMAGE_SHA}"
+          trap 'docker logs scbe-api-smoke || true; docker stop scbe-api-smoke || true' EXIT
+
+          for attempt in $(seq 1 30); do
+            if curl -fsS "${SMOKE_URL}"; then
+              echo
+              echo "Smoke test passed on attempt ${attempt}"
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Smoke test failed: ${SMOKE_URL}" >&2
+          exit 1
+
+      - name: Log in to GHCR
+        if: ${{ inputs.push_image }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push image
+        if: ${{ inputs.push_image }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker push "${IMAGE_SHA}"
+          docker push "${IMAGE_LATEST}"
+
+      - name: Write summary
+        shell: bash
+        run: |
+          {
+            echo "## Remote Docker Build"
+            echo
+            echo "- Target: ${TARGET}"
+            echo "- Dockerfile: ${DOCKERFILE}"
+            echo "- Image SHA tag: ${IMAGE_SHA}"
+            echo "- Pushed: ${PUSH_IMAGE}"
+            echo "- Smoke test: ${RUN_SMOKE}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/readiness/RELEASE_READINESS_2026-04-27.md
+++ b/docs/readiness/RELEASE_READINESS_2026-04-27.md
@@ -60,7 +60,7 @@ No PyPI upload was run.
 
 ## Docker
 
-Readiness: local build not verified in this pass.
+Readiness: local build not verified in this pass; remote build path added after local storage constraint was confirmed.
 
 Command:
 
@@ -71,10 +71,25 @@ npm run docker:doctor:api
 Result:
 
 - Blocked locally because Docker Desktop / Docker Engine is not reachable.
+- Local blocker is expected on this machine because Docker is not set up and there is not enough local disk headroom.
+
+Remote fallback:
+
+```powershell
+npm run docker:remote:api
+```
+
+This dispatches the `Remote Docker Build` GitHub Actions workflow. It builds `Dockerfile.api` on a GitHub-hosted runner and runs the API health smoke test without using local disk. It does not push an image by default.
+
+Optional GHCR push, only when explicitly wanted:
+
+```powershell
+npm run docker:remote:api:push
+```
 
 Packaging note:
 
-- `Dockerfile.api` remains the safer production-facing container path.
+- `Dockerfile.api` remains the safer production-facing container path and is now the remote-build target.
 - The root `Dockerfile` still contains `npm run build || true`, which can hide TypeScript build failures. This should be removed or split into an explicit best-effort development image before treating the root image as release-grade.
 
 ## GitHub Pages

--- a/package.json
+++ b/package.json
@@ -155,6 +155,8 @@
     "docker:down:api": "node ./scripts/scbe_docker_status.mjs --Action down --Stack api",
     "docker:down:unified": "node ./scripts/scbe_docker_status.mjs --Action down --Stack unified",
     "docker:status:all": "node ./scripts/scbe_docker_status.mjs --InspectStacks",
+    "docker:remote:api": "gh workflow run docker-remote-build.yml -f image_target=api -f push_image=false -f run_smoke=true",
+    "docker:remote:api:push": "gh workflow run docker-remote-build.yml -f image_target=api -f push_image=true -f run_smoke=true",
     "mcp:doctor": "node ./scripts/scbe_mcp_terminal.mjs --Action doctor",
     "mcp:servers": "node ./scripts/scbe_mcp_terminal.mjs --Action servers",
     "mcp:tools": "node ./scripts/scbe_mcp_terminal.mjs --Action tools",


### PR DESCRIPTION
## Summary
- Adds a manual GitHub Actions remote Docker build for `Dockerfile.api` so local Docker/disk limits do not block release readiness.
- Adds `.dockerignore` to keep build contexts small and prevent local artifacts/secrets from entering container builds.
- Adds npm dispatch scripts for no-push smoke builds and explicit GHCR pushes.
- Updates release readiness docs with the remote fallback.

## Validation
- `python` JSON parse for `package.json`
- `python` YAML parse for `.github/workflows/docker-remote-build.yml`
- `git diff --check`

## Notes
- Default command does not push images: `npm run docker:remote:api`.
- Push command is explicit: `npm run docker:remote:api:push`.
- Local untracked `experiments/bijective_2tongue_build/` was left untouched.