### PR TITLE
fix(agentbus): report source outcomes and monitor fallbacks

### DIFF
--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -40,6 +40,7 @@ class ResearchReport:
     duration_seconds: float = 0
     summary: str = ""
     errors: List[str] = field(default_factory=list)
+    source_outcomes: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -141,11 +142,13 @@ class ResearchAgent:
 
             if page.error:
                 report.errors.append(f"{page.url}: {page.error}")
+                report.source_outcomes.append(self._source_outcome(page, "error", 0.0, page.error))
                 continue
 
             # Relevance scoring
             score = self._score_relevance(page, query_terms)
             if score < self.relevance_threshold:
+                report.source_outcomes.append(self._source_outcome(page, "below_threshold", score))
                 continue
 
             # Extract the most relevant portion of text
@@ -163,6 +166,7 @@ class ResearchAgent:
                     tags=tags,
                 )
             )
+            report.source_outcomes.append(self._source_outcome(page, "matched", score))
 
         # Step 3: Follow links for depth (if enabled and findings are thin)
         if follow_links and len(report.findings) < 3 and self.max_depth > 0:
@@ -173,6 +177,8 @@ class ResearchAgent:
                     report.sources_checked += 1
                     report.total_words_read += page.word_count
                     if page.error:
+                        report.errors.append(f"{page.url}: {page.error}")
+                        report.source_outcomes.append(self._source_outcome(page, "error", 0.0, page.error))
                         continue
                     score = self._score_relevance(page, query_terms)
                     if score >= self.relevance_threshold:
@@ -185,8 +191,21 @@ class ResearchAgent:
                                 tags=self._auto_tag(page) + ["followed-link"],
                             )
                         )
+                        report.source_outcomes.append(self._source_outcome(page, "matched_followed_link", score))
+                    else:
+                        report.source_outcomes.append(self._source_outcome(page, "below_threshold_followed_link", score))
                 except Exception as exc:
                     report.errors.append(f"Follow link {url}: {exc}")
+                    report.source_outcomes.append(
+                        {
+                            "url": url,
+                            "title": "",
+                            "status": "error_followed_link",
+                            "score": 0.0,
+                            "word_count": 0,
+                            "reason": str(exc),
+                        }
+                    )
 
         # Sort findings by confidence
         report.findings.sort(key=lambda f: f.confidence, reverse=True)
@@ -266,25 +285,52 @@ class ResearchAgent:
     # -- internal scoring ----------------------------------------------------
 
     def _score_relevance(self, page, query_terms: set) -> float:
-        """Score 0-1 how relevant a page is to the query."""
+        """Score 0-1 how relevant a page is to the query.
+
+        Composite of presence (text+title), continuous tie-breakers
+        (term-frequency density, length, first-match position), phrase
+        bonus, and short-page penalty. The continuous tie-breakers
+        prevent same-pattern pages from collapsing to identical scores.
+        """
+        import math
+
         if not page.text:
             return 0.0
-
-        text_lower = page.text.lower()
-        title_lower = page.title.lower()
-
-        # Term frequency in text
-        text_hits = sum(1 for t in query_terms if t in text_lower)
-        title_hits = sum(1 for t in query_terms if t in title_lower)
-
         if not query_terms:
             return 0.5
 
+        text_lower = page.text.lower()
+        title_lower = (page.title or "").lower()
+
+        # Presence: fraction of query terms found.
+        text_hits = sum(1 for t in query_terms if t in text_lower)
+        title_hits = sum(1 for t in query_terms if t in title_lower)
         text_score = text_hits / len(query_terms)
         title_score = title_hits / len(query_terms)
 
-        # Weighted combination: title matches worth 2x
-        score = (text_score * 0.4) + (title_score * 0.6)
+        # Continuous tie-breakers (max combined ~0.16 so they refine
+        # rather than dominate the presence headline).
+        total_occurrences = sum(text_lower.count(t) for t in query_terms)
+        density = total_occurrences / max(page.word_count / 1000.0, 0.1)
+        density_signal = min(0.08, math.log1p(density) * 0.04)
+
+        length_signal = min(0.04, math.log10(max(page.word_count, 1) / 100.0) * 0.02)
+        length_signal = max(0.0, length_signal)
+
+        first_positions = [text_lower.find(t) for t in query_terms if t in text_lower]
+        if first_positions:
+            first_pos = min(first_positions)
+            position_signal = max(0.0, 0.04 - (first_pos / max(len(text_lower), 1)) * 0.04)
+        else:
+            position_signal = 0.0
+
+        score = (
+            (text_score * 0.4)
+            + (title_score * 0.6)
+            + density_signal
+            + length_signal
+            + position_signal
+        )
 
         # Bonus for exact phrase match
         query_phrase = " ".join(sorted(query_terms))
@@ -295,7 +341,7 @@ class ResearchAgent:
         if page.word_count < 100:
             score *= 0.5
 
-        return min(1.0, score)
+        return max(0.0, min(1.0, score))
 
     def _extract_relevant_passage(self, text: str, query_terms: set, window: int = 500) -> str:
         """Extract the most relevant passage from text."""
@@ -379,6 +425,17 @@ class ResearchAgent:
 
         candidates.sort(reverse=True)
         return [url for _, url in candidates[:5]]
+
+    def _source_outcome(self, page, status: str, score: float, reason: str = "") -> Dict[str, Any]:
+        """Compact per-source receipt for dashboard/debugging without storing full page text."""
+        return {
+            "url": page.url,
+            "title": page.title,
+            "status": status,
+            "score": round(float(score), 4),
+            "word_count": int(page.word_count or 0),
+            "reason": reason,
+        }
 
     def _generate_summary(self, report: ResearchReport) -> str:
         """Generate a one-line summary."""

--- a/agents/web_scraper.py
+++ b/agents/web_scraper.py
@@ -78,10 +78,16 @@ _EXTRACT_IMAGES = """() => {
 }"""
 
 _EXTRACT_HEADINGS = """() => {
-    return Array.from(document.querySelectorAll('h1,h2,h3,h4,h5,h6')).map(h => ({
+    const headings = Array.from(document.querySelectorAll('h1,h2,h3,h4,h5,h6')).map(h => ({
         level: parseInt(h.tagName[1]),
         text: h.innerText.trim().substring(0, 200)
-    }));
+    })).filter(h => h.text);
+    if (headings.length) return headings;
+    const fallbacks = Array.from(document.querySelectorAll('.titleline a, .athing .title a, article a, main a'))
+        .map(a => (a.innerText || '').trim())
+        .filter(Boolean)
+        .slice(0, 10);
+    return fallbacks.map(text => ({ level: 2, text: text.substring(0, 200), source: 'fallback-selector' }));
 }"""
 
 
@@ -195,6 +201,8 @@ class WebScraper:
 
             if extract_headings:
                 page.headings = await self.runtime.evaluate(_EXTRACT_HEADINGS)
+                if not page.description and page.headings:
+                    page.description = page.headings[0].get("text", "")
 
             if extract_links:
                 page.links = await self.runtime.evaluate(_EXTRACT_LINKS)

--- a/tests/test_agent_router_result_quality.py
+++ b/tests/test_agent_router_result_quality.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from agents.research_agent import ResearchAgent
+
+
+@dataclass
+class FakePage:
+    url: str
+    title: str
+    text: str
+    word_count: int
+    error: str | None = None
+    headings: list[dict[str, Any]] = field(default_factory=list)
+    links: list[dict[str, Any]] = field(default_factory=list)
+    tables: list[dict[str, Any]] = field(default_factory=list)
+    jsonld: list[dict[str, Any]] = field(default_factory=list)
+
+
+class FakeScraper:
+    def __init__(self, pages: list[FakePage]) -> None:
+        self.pages = pages
+
+    async def search_and_scrape(self, *_args, **_kwargs) -> list[FakePage]:
+        return self.pages
+
+
+def test_research_report_tracks_source_outcomes_and_nonconstant_scores() -> None:
+    pages = [
+        FakePage(
+            url="https://example.test/a",
+            title="SCBE hyperbolic geometry governance",
+            text="SCBE hyperbolic geometry AI governance " * 20,
+            word_count=80,
+        ),
+        FakePage(
+            url="https://example.test/b",
+            title="AI governance notes",
+            text="This source discusses AI governance and safety, with one mention of hyperbolic methods.",
+            word_count=320,
+        ),
+        FakePage(
+            url="https://example.test/c",
+            title="Cooking",
+            text="A short cooking note unrelated to the requested topic.",
+            word_count=40,
+        ),
+    ]
+    agent = ResearchAgent(FakeScraper(pages), max_sources=3, relevance_threshold=0.3)
+
+    import asyncio
+
+    report = asyncio.run(agent.research("SCBE hyperbolic geometry AI governance"))
+    payload = report.to_dict()
+
+    assert payload["sources_checked"] == 3
+    assert len(payload["source_outcomes"]) == 3
+    assert {row["status"] for row in payload["source_outcomes"]} == {"matched", "below_threshold"}
+    assert payload["errors"] == []
+
+    confidences = [finding["confidence"] for finding in payload["findings"]]
+    assert len(confidences) == 2
+    assert len(set(confidences)) == 2
+
+
+def test_research_report_records_error_outcomes_without_silent_drop() -> None:
+    pages = [
+        FakePage(
+            url="https://example.test/error",
+            title="Broken",
+            text="",
+            word_count=0,
+            error="provider_timeout",
+        )
+    ]
+    agent = ResearchAgent(FakeScraper(pages), max_sources=1, relevance_threshold=0.3)
+
+    import asyncio
+
+    report = asyncio.run(agent.research("SCBE governance"))
+    payload = report.to_dict()
+
+    assert payload["findings"] == []
+    assert payload["errors"] == ["https://example.test/error: provider_timeout"]
+    assert payload["source_outcomes"] == [
+        {
+            "url": "https://example.test/error",
+            "title": "Broken",
+            "status": "error",
+            "score": 0.0,
+            "word_count": 0,
+            "reason": "provider_timeout",
+        }
+    ]

--- a/tests/test_research_agent_score_variance.py
+++ b/tests/test_research_agent_score_variance.py
@@ -1,0 +1,116 @@
+"""
+Regression test for ResearchAgent._score_relevance.
+
+The agent bus self-review surfaced that all 3 published research findings
+shared confidence 0.76 because the previous scoring formula was a discrete
+function of (text_hits / N) and (title_hits / N) only — pages with the
+same hit pattern collapsed to identical scores.
+
+This test pins the fix: continuous tie-breakers (term-frequency density,
+length signal, first-match position) must produce distinct scores for
+three pages that share a hit pattern but differ on length / density /
+first-match position.
+"""
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agents.research_agent import ResearchAgent  # noqa: E402
+
+
+@dataclass
+class _StubPage:
+    url: str
+    title: str
+    text: str
+    word_count: int
+    headings: List[dict] = field(default_factory=list)
+    links: List[dict] = field(default_factory=list)
+    tables: List[dict] = field(default_factory=list)
+    jsonld: List[dict] = field(default_factory=list)
+    error: str = ""
+
+
+def _make_agent() -> ResearchAgent:
+    return ResearchAgent(scraper=None)
+
+
+def test_three_pages_same_hit_pattern_get_distinct_scores():
+    """Same query-term hit pattern, different bodies → distinct scores."""
+    query_terms = {"scbe", "hyperbolic", "geometry", "ai", "governance"}
+    # Use sorted phrase so we explicitly trigger or avoid the phrase bonus.
+    phrase = " ".join(sorted(query_terms))
+    title = "Some Unrelated Page Title"  # zero title hits
+
+    body_terms = "scbe hyperbolic geometry ai governance "  # all 5, but not sorted
+
+    short = _StubPage(
+        url="https://a.example/short",
+        title=title,
+        text=body_terms + ("filler word " * 50),
+        word_count=120,
+    )
+    medium = _StubPage(
+        url="https://b.example/medium",
+        title=title,
+        text=body_terms * 3 + ("filler word " * 400),
+        word_count=900,
+    )
+    long_dense = _StubPage(
+        url="https://c.example/long",
+        title=title,
+        text=body_terms * 8 + ("filler word " * 1200),
+        word_count=2600,
+    )
+
+    # Sanity: no phrase bonus on any of these (sorted phrase not present).
+    for p in (short, medium, long_dense):
+        assert phrase not in p.text.lower()
+
+    agent = _make_agent()
+    scores = [
+        agent._score_relevance(p, query_terms)
+        for p in (short, medium, long_dense)
+    ]
+
+    assert all(0.0 <= s <= 1.0 for s in scores), scores
+    assert len(set(scores)) == 3, f"expected 3 distinct scores, got {scores}"
+
+
+def test_empty_text_returns_zero():
+    agent = _make_agent()
+    page = _StubPage(url="https://x", title="t", text="", word_count=0)
+    assert agent._score_relevance(page, {"foo"}) == 0.0
+
+
+def test_empty_query_returns_neutral():
+    agent = _make_agent()
+    page = _StubPage(url="https://x", title="t", text="anything", word_count=10)
+    assert agent._score_relevance(page, set()) == 0.5
+
+
+def test_phrase_bonus_present_when_phrase_in_text():
+    agent = _make_agent()
+    terms = {"alpha", "beta"}
+    phrase = " ".join(sorted(terms))
+    page_with = _StubPage(
+        url="https://w/with",
+        title="t",
+        text=f"intro {phrase} body more body words " * 30,
+        word_count=300,
+    )
+    page_without = _StubPage(
+        url="https://w/without",
+        title="t",
+        text=("alpha gap " * 50) + ("beta gap " * 50),
+        word_count=300,
+    )
+    s_with = agent._score_relevance(page_with, terms)
+    s_without = agent._score_relevance(page_without, terms)
+    assert s_with > s_without


### PR DESCRIPTION
## Summary
- add source_outcomes to research reports so dropped sources are explicit
- preserve non-constant confidence scoring regression tests
- add heading/description fallback extraction for heading-light pages like Hacker News

## Tests
- PYTHONPATH=. python -m pytest tests/test_agent_router_result_quality.py tests/test_research_agent_score_variance.py tests/test_agentbus_user_e2e.py tests/benchmark/test_agentbus_competitive_wedge.py -v

## Notes
- Does not call paid or remote providers.
- Leaves unrelated untracked experiments/bijective_2tongue_build/ untouched.