### PR TITLE
style(agentbus): black-format research routing files

### DIFF
--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -193,7 +193,9 @@ class ResearchAgent:
                         )
                         report.source_outcomes.append(self._source_outcome(page, "matched_followed_link", score))
                     else:
-                        report.source_outcomes.append(self._source_outcome(page, "below_threshold_followed_link", score))
+                        report.source_outcomes.append(
+                            self._source_outcome(page, "below_threshold_followed_link", score)
+                        )
                 except Exception as exc:
                     report.errors.append(f"Follow link {url}: {exc}")
                     report.source_outcomes.append(
@@ -324,13 +326,7 @@ class ResearchAgent:
         else:
             position_signal = 0.0
 
-        score = (
-            (text_score * 0.4)
-            + (title_score * 0.6)
-            + density_signal
-            + length_signal
-            + position_signal
-        )
+        score = (text_score * 0.4) + (title_score * 0.6) + density_signal + length_signal + position_signal
 
         # Bonus for exact phrase match
         query_phrase = " ".join(sorted(query_terms))

--- a/agents/web_scraper.py
+++ b/agents/web_scraper.py
@@ -94,6 +94,7 @@ _EXTRACT_HEADINGS = """() => {
 @dataclass
 class PageData:
     """Structured extraction from a single page."""
+
     url: str
     title: str = ""
     text: str = ""
@@ -258,9 +259,7 @@ class WebScraper:
         logger.info("Search '%s' found %d result URLs", query, len(result_links))
         return await self.scrape_many(result_links, delay_ms=800)
 
-    async def _search_urls(
-        self, query: str, engine: str, max_results: int
-    ) -> List[str]:
+    async def _search_urls(self, query: str, engine: str, max_results: int) -> List[str]:
         """
         Get search result URLs via direct HTTP (no browser needed for search).
 
@@ -310,6 +309,7 @@ class WebScraper:
                     html = resp.read().decode("utf-8", errors="replace")
                 # Extract result URLs from href attributes
                 import re as _re
+
                 for match in _re.finditer(r'class="result__a"[^>]*href="([^"]+)"', html):
                     href = match.group(1)
                     if href.startswith("http") and "duckduckgo.com" not in href:
@@ -318,6 +318,7 @@ class WebScraper:
                 # Also try uddg= parameter (DDG redirect URLs)
                 for match in _re.finditer(r'uddg=([^&"]+)', html):
                     from urllib.parse import unquote
+
                     href = unquote(match.group(1))
                     if href.startswith("http") and "duckduckgo.com" not in href:
                         if href not in urls:

--- a/tests/test_research_agent_score_variance.py
+++ b/tests/test_research_agent_score_variance.py
@@ -74,10 +74,7 @@ def test_three_pages_same_hit_pattern_get_distinct_scores():
         assert phrase not in p.text.lower()
 
     agent = _make_agent()
-    scores = [
-        agent._score_relevance(p, query_terms)
-        for p in (short, medium, long_dense)
-    ]
+    scores = [agent._score_relevance(p, query_terms) for p in (short, medium, long_dense)]
 
     assert all(0.0 <= s <= 1.0 for s in scores), scores
     assert len(set(scores)) == 3, f"expected 3 distinct scores, got {scores}"


### PR DESCRIPTION
## Summary\n- Black-format the merged agent-bus research routing files that failed CI.\n- No behavior change.\n\n## Test Evidence\n- python -m black --check --target-version py311 --line-length 120 agents/research_agent.py agents/web_scraper.py tests/test_agent_router_result_quality.py tests/test_research_agent_score_variance.py\n- PYTHONPATH=. python -m pytest tests/test_agent_router_result_quality.py tests/test_research_agent_score_variance.py tests/test_agentbus_user_e2e.py tests/benchmark/test_agentbus_competitive_wedge.py -q\n\n## Rollback\n- Revert this formatting-only commit.