### PR TITLE
fix(agentbus): remove unused score variance import

### DIFF
--- a/tests/test_research_agent_score_variance.py
+++ b/tests/test_research_agent_score_variance.py
@@ -17,8 +17,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from agents.research_agent import ResearchAgent  # noqa: E402


### PR DESCRIPTION
## Summary\n- Remove the unused pytest import that Ruff flagged after the Black-format fix merged.\n\n## Test Evidence\n- python -m ruff check --config ruff.toml tests/test_research_agent_score_variance.py agents/research_agent.py agents/web_scraper.py tests/test_agent_router_result_quality.py\n- python -m black --check --target-version py311 --line-length 120 agents/research_agent.py agents/web_scraper.py tests/test_agent_router_result_quality.py tests/test_research_agent_score_variance.py\n- PYTHONPATH=. python -m pytest tests/test_agent_router_result_quality.py tests/test_research_agent_score_variance.py tests/test_agentbus_user_e2e.py tests/benchmark/test_agentbus_competitive_wedge.py -q\n\n## Rollback\n- Revert this import-only commit.