### PR TITLE
chore(vercel): limit bridge deployment payload

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,6 @@
+# Vercel is only the lightweight agent bridge for this repo.
+# GitHub Pages remains the public static website host.
+*
+!api/
+!api/**
+!vercel.json


### PR DESCRIPTION
## Summary
- add .vercelignore so Vercel uploads only the lightweight API bridge and vercel.json
- keeps generated data, training artifacts, models, node_modules, and experiments out of Vercel deployments

## Test evidence
- git diff --cached --check before commit
- branch protection correctly blocked direct main push; this PR is the compliant path