### PR TITLE
fix(agentbus-review): recognize source_outcomes as drop documentation

### DIFF
--- a/scripts/system/agentbus_self_review.py
+++ b/scripts/system/agentbus_self_review.py
@@ -12,8 +12,10 @@ script never edits the bus or the workflow.
 
 Categories:
     1. confidence_variance      (HIGH)  — research findings share a single confidence value
-    2. sources_vs_findings_ratio (MEDIUM)— findings_count / sources_checked < 0.7
-    3. silent_error             (HIGH)  — ratio < 0.7 AND errors: []
+    2. sources_vs_findings_ratio (MEDIUM)— findings_count / sources_checked < 0.7 AND
+                                          `source_outcomes` does not document every source
+    3. silent_error             (HIGH)  — ratio < 0.7 AND errors:[] AND
+                                          `source_outcomes` is missing or incomplete
     4. title_sanity             (LOW/MEDIUM)
         a. title_equals_description (LOW)    — both fields collapsed to the same value
         b. extraction_partial       (MEDIUM) — word_count > 200 but headings=[] and description empty
@@ -87,6 +89,23 @@ def check_confidence_variance(research: Optional[Dict[str, Any]]) -> List[Findin
     ]
 
 
+def _source_outcomes_cover_drops(research: Dict[str, Any]) -> bool:
+    """True if `source_outcomes` accounts for every checked source with a status."""
+    sources_checked = research.get("sources_checked")
+    outcomes = research.get("source_outcomes")
+    if not isinstance(sources_checked, int) or sources_checked <= 0:
+        return False
+    if not isinstance(outcomes, list) or len(outcomes) < sources_checked:
+        return False
+    for entry in outcomes:
+        if not isinstance(entry, dict):
+            return False
+        status = entry.get("status")
+        if not isinstance(status, str) or not status:
+            return False
+    return True
+
+
 def check_sources_vs_findings(research: Optional[Dict[str, Any]]) -> List[Finding]:
     if not research:
         return []
@@ -97,6 +116,8 @@ def check_sources_vs_findings(research: Optional[Dict[str, Any]]) -> List[Findin
         return []
     ratio = findings_count / sources_checked
     if ratio >= RATIO_FLOOR:
+        return []
+    if _source_outcomes_cover_drops(research):
         return []
     return [
         Finding(
@@ -131,6 +152,8 @@ def check_silent_error(research: Optional[Dict[str, Any]]) -> List[Finding]:
     if ratio >= RATIO_FLOOR:
         return []
     if errors:
+        return []
+    if _source_outcomes_cover_drops(research):
         return []
     return [
         Finding(

--- a/tests/test_agentbus_self_review.py
+++ b/tests/test_agentbus_self_review.py
@@ -1,0 +1,78 @@
+"""
+Regression tests for scripts/system/agentbus_self_review.py.
+
+Pins the source_outcomes recognition: when the research bus ships a complete
+`source_outcomes` array (one entry per checked source, each with a status),
+the analyzer must NOT flag silent_error or sources_vs_findings_ratio even
+though `errors:[]` is empty and findings_count < sources_checked.
+
+Without this, the analyzer false-positives against a bus that already fixed
+the silent-drop problem by structuring outcomes per source (PR #1228).
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "system" / "agentbus_self_review.py"
+spec = importlib.util.spec_from_file_location("agentbus_self_review", SCRIPT)
+asr = importlib.util.module_from_spec(spec)
+sys.modules["agentbus_self_review"] = asr
+spec.loader.exec_module(asr)
+
+
+def _research_with_outcomes():
+    return {
+        "sources_checked": 5,
+        "findings": [{"confidence": 0.7}, {"confidence": 0.6}, {"confidence": 0.9}],
+        "errors": [],
+        "source_outcomes": [
+            {"url": "https://a", "status": "matched", "score": 0.9, "reason": ""},
+            {"url": "https://b", "status": "matched", "score": 0.8, "reason": ""},
+            {"url": "https://c", "status": "matched", "score": 0.85, "reason": ""},
+            {"url": "https://d", "status": "below_threshold", "score": 0.0, "reason": ""},
+            {"url": "https://e", "status": "below_threshold", "score": 0.0, "reason": ""},
+        ],
+    }
+
+
+def test_silent_error_clears_when_source_outcomes_complete():
+    findings = asr.check_silent_error(_research_with_outcomes())
+    assert findings == [], f"silent_error should clear with full source_outcomes, got {findings}"
+
+
+def test_ratio_clears_when_source_outcomes_complete():
+    findings = asr.check_sources_vs_findings(_research_with_outcomes())
+    assert findings == [], f"ratio should clear with full source_outcomes, got {findings}"
+
+
+def test_silent_error_still_fires_when_outcomes_missing():
+    research = _research_with_outcomes()
+    del research["source_outcomes"]
+    findings = asr.check_silent_error(research)
+    assert len(findings) == 1
+    assert findings[0].category == "silent_error"
+
+
+def test_silent_error_still_fires_when_outcomes_partial():
+    research = _research_with_outcomes()
+    research["source_outcomes"] = research["source_outcomes"][:3]
+    findings = asr.check_silent_error(research)
+    assert len(findings) == 1
+    assert findings[0].category == "silent_error"
+
+
+def test_silent_error_still_fires_when_status_missing_on_entry():
+    research = _research_with_outcomes()
+    research["source_outcomes"][0] = {"url": "https://a", "score": 0.9}
+    findings = asr.check_silent_error(research)
+    assert len(findings) == 1
+
+
+def test_ratio_still_fires_when_outcomes_partial():
+    research = _research_with_outcomes()
+    research["source_outcomes"] = research["source_outcomes"][:2]
+    findings = asr.check_sources_vs_findings(research)
+    assert len(findings) == 1
+    assert findings[0].category == "sources_vs_findings_ratio"


### PR DESCRIPTION
## Summary

PR #1228 added a structured `source_outcomes` array to `latest-research.json` so per-source drops are tracked with `status` (matched | below_threshold | empty | error | rate_limited). The self-review analyzer (`scripts/system/agentbus_self_review.py`) was still flagging:

- **HIGH** `silent_error` — checks `errors:[]` only
- **MEDIUM** `sources_vs_findings_ratio` — checks ratio only

Both false-positive against a bus that already fixed the silent-drop problem.

## What changed

- `_source_outcomes_cover_drops()` helper: returns `True` if `source_outcomes` is a list covering every checked source with a non-empty `status` string.
- Both checks now skip when that helper passes. Partial or missing arrays still fire correctly.
- 6 regression tests in `tests/test_agentbus_self_review.py` pin the behavior:
  - clears for full outcomes (silent_error + ratio)
  - still fires when outcomes missing
  - still fires when outcomes partial
  - still fires when an entry is missing `status`

## Test plan

- [x] `python scripts/system/agentbus_self_review.py` reports `high=0 medium=0 low=0` against current `docs/static/agent-data/`
- [x] `pytest tests/test_agentbus_self_review.py -v` — 6/6 pass
- [x] `black --check` clean
- [x] `flake8` clean
- [ ] CI gates green

## Notes

Analyzer-only change. Does not touch production agent code, the cron, or published JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)