### PR TITLE
feat(site): default agents page to Vercel bridge

### DIFF
--- a/docs/agents.html
+++ b/docs/agents.html
@@ -192,7 +192,8 @@
 
   <script>
     var DATA_BASE = (location.pathname.replace(/\/[^/]*$/, '') || '.') + '/static/agent-data';
-    var AGENT_API_BASE = window.AGENT_API_BASE || localStorage.getItem('scbeAgentApiBase') || detectAgentApiBase();
+    var DEFAULT_AGENT_API_BASE = 'https://scbe-agent-bridge-vercel-9wun7fo3z-issac-davis-projects.vercel.app';
+    var AGENT_API_BASE = window.AGENT_API_BASE || localStorage.getItem('scbeAgentApiBase') || detectAgentApiBase() || DEFAULT_AGENT_API_BASE;
     var AGENT_DISPATCH_SECRET = window.AGENT_DISPATCH_SECRET || localStorage.getItem('scbeAgentDispatchSecret') || '';
 
     async function dispatchTask() {


### PR DESCRIPTION
## Summary
- set the deployed Vercel bridge as the default API base for the Agents page
- keep dispatch protected by the localStorage/header dispatch secret
- public visitors can read bridge status; protected dispatch falls back if no secret is present

## Test evidence
- extracted inline script from docs/agents.html and ran node --check
- git diff --check -- docs/agents.html
- verified bridge status endpoint returns active GitHub Actions run