### PR TITLE
fix(polly): Vercel proxy for chat + search

### DIFF
--- a/api/agent/chat.js
+++ b/api/agent/chat.js
@@ -1,0 +1,92 @@
+/**
+ * Vercel serverless function: proxy chat to HuggingFace Inference API.
+ * Solves CORS — browser calls this, this calls HF.
+ *
+ * POST /api/agent/chat
+ * Body: { message: "...", history: [...] }
+ * Returns: { text: "...", model: "...", provider: "huggingface" }
+ */
+
+const HF_MODEL = "Qwen/Qwen2.5-72B-Instruct";
+const HF_URL = `https://router.huggingface.co/hf-inference/models/${HF_MODEL}/v1/chat/completions`;
+const HF_TOKEN = process.env.HF_TOKEN || "";
+
+const SYSTEM_PROMPT =
+  "You are Polly, the AI assistant for AetherMoore — an AI safety and governance framework " +
+  "using hyperbolic geometry with a 14-layer security pipeline. The framework makes adversarial " +
+  "AI behavior exponentially expensive using Poincaré ball geometry. Be helpful, concise, and " +
+  "accurate. If asked about SCBE, explain the core innovation: adversarial intent costs " +
+  "exponentially more the further it drifts from safe operation.";
+
+export default async function handler(req, res) {
+  // CORS
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "POST only" });
+  }
+
+  const { message, history } = req.body || {};
+  if (!message) {
+    return res.status(400).json({ error: "message required" });
+  }
+
+  const messages = [{ role: "system", content: SYSTEM_PROMPT }];
+
+  if (Array.isArray(history)) {
+    history.slice(-6).forEach((h) => {
+      if (h.role && h.content) {
+        messages.push({ role: h.role, content: h.content });
+      }
+    });
+  }
+
+  messages.push({ role: "user", content: message });
+
+  const headers = { "Content-Type": "application/json" };
+  if (HF_TOKEN) {
+    headers["Authorization"] = `Bearer ${HF_TOKEN}`;
+  }
+
+  try {
+    const hfResp = await fetch(HF_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: HF_MODEL,
+        messages,
+        max_tokens: 512,
+      }),
+    });
+
+    if (!hfResp.ok) {
+      const errText = await hfResp.text();
+      return res.status(502).json({
+        error: "HuggingFace error",
+        detail: errText.substring(0, 200),
+        provider: "huggingface",
+      });
+    }
+
+    const data = await hfResp.json();
+    const text =
+      data.choices?.[0]?.message?.content || "No response from model.";
+
+    return res.status(200).json({
+      text,
+      model: HF_MODEL,
+      provider: "huggingface",
+    });
+  } catch (err) {
+    return res.status(500).json({
+      error: String(err),
+      provider: "huggingface",
+    });
+  }
+}

--- a/api/agent/search.js
+++ b/api/agent/search.js
@@ -1,0 +1,70 @@
+/**
+ * Vercel serverless function: proxy search to DuckDuckGo.
+ * Browser calls this, this calls DDG API (avoids CORS issues).
+ *
+ * POST /api/agent/search
+ * Body: { query: "..." }
+ * Returns: { results: [...], source: "duckduckgo" }
+ */
+
+const DDG_API = "https://api.duckduckgo.com/";
+
+export default async function handler(req, res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") return res.status(200).end();
+  if (req.method !== "POST") return res.status(405).json({ error: "POST only" });
+
+  const { query } = req.body || {};
+  if (!query) return res.status(400).json({ error: "query required" });
+
+  try {
+    const url = `${DDG_API}?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+    const resp = await fetch(url, {
+      headers: { "User-Agent": "SCBE-Polly/1.0 (aethermoore.com)" },
+    });
+    const data = await resp.json();
+
+    const results = [];
+
+    if (data.AbstractURL) {
+      results.push({
+        title: data.Heading || query,
+        url: data.AbstractURL,
+        excerpt: (data.Abstract || "").substring(0, 250),
+      });
+    }
+
+    (data.RelatedTopics || []).forEach((t) => {
+      if (t?.FirstURL && !t.FirstURL.startsWith("https://duckduckgo.com/c/")) {
+        results.push({
+          title: (t.Text || "").substring(0, 100),
+          url: t.FirstURL,
+          excerpt: (t.Text || "").substring(0, 250),
+        });
+      }
+      // Sub-topics
+      if (t?.Topics) {
+        t.Topics.forEach((sub) => {
+          if (sub?.FirstURL && !sub.FirstURL.startsWith("https://duckduckgo.com/c/")) {
+            results.push({
+              title: (sub.Text || "").substring(0, 100),
+              url: sub.FirstURL,
+              excerpt: (sub.Text || "").substring(0, 250),
+            });
+          }
+        });
+      }
+    });
+
+    return res.status(200).json({
+      results: results.slice(0, 8),
+      source: "duckduckgo",
+      query,
+    });
+  } catch (err) {
+    return res.status(500).json({ error: String(err), source: "duckduckgo" });
+  }
+}

--- a/docs/static/polly-sidebar.js
+++ b/docs/static/polly-sidebar.js
@@ -233,21 +233,16 @@
         if (resp.ok) data = await resp.json();
       } catch (_) {}
 
-      // Fallback: DuckDuckGo API directly from browser
+      // Fallback: DuckDuckGo via Vercel proxy (avoids CORS)
       if (!data || !data.results || !data.results.length) {
-        var ddgUrl = "https://api.duckduckgo.com/?q=" + encodeURIComponent(query) + "&format=json&no_html=1&skip_disambig=1";
-        var ddgResp = await fetch(ddgUrl);
-        var ddg = await ddgResp.json();
-        var results = [];
-        if (ddg.AbstractURL) {
-          results.push({ title: ddg.Heading || query, url: ddg.AbstractURL, excerpt: (ddg.Abstract || "").substring(0, 200) });
-        }
-        (ddg.RelatedTopics || []).forEach(function(t) {
-          if (t && t.FirstURL && !t.FirstURL.startsWith("https://duckduckgo.com/c/")) {
-            results.push({ title: (t.Text || "").substring(0, 80), url: t.FirstURL, excerpt: (t.Text || "").substring(0, 200) });
-          }
+        var ddgResp = await fetch(SEARCH_PROXY, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ query: query }),
         });
-        data = { results: results.slice(0, 5), source: "duckduckgo" };
+        if (ddgResp.ok) {
+          data = await ddgResp.json();
+        }
       }
 
       if (pending) pending.remove();
@@ -322,7 +317,10 @@
   }
 
   var HF_MODEL = "Qwen/Qwen2.5-72B-Instruct";
-  var HF_ENDPOINT = "https://router.huggingface.co/hf-inference/models/" + HF_MODEL + "/v1/chat/completions";
+  // Vercel proxy handles CORS — browser can't call HF directly
+  var VERCEL_BASE = window.POLLY_VERCEL_BASE || "https://scbe-aethermoore.vercel.app";
+  var CHAT_PROXY = VERCEL_BASE + "/api/agent/chat";
+  var SEARCH_PROXY = VERCEL_BASE + "/api/agent/search";
 
   async function handleChat(message, thinking, thread) {
     var thinkingMode = thinking || false;
@@ -373,19 +371,17 @@
       history.forEach(function(h) { messages.push(h); });
       messages.push({ role: "user", content: message });
 
-      var hfResp = await fetch(HF_ENDPOINT, {
+      var hfResp = await fetch(CHAT_PROXY, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: HF_MODEL, messages: messages, max_tokens: 512 }),
+        body: JSON.stringify({ message: message, history: history }),
       });
 
       if (pending) pending.remove();
 
       if (hfResp.ok) {
         var hfData = await hfResp.json();
-        var text = hfData.choices && hfData.choices[0] && hfData.choices[0].message
-          ? hfData.choices[0].message.content
-          : "No response from model.";
+        var text = hfData.text || "No response from model.";
         addMsg(thread, "assistant", md(text), chip("Qwen 72B", "online") + chip("HuggingFace", "science"));
         appendMemory("polly", text);
       } else {


### PR DESCRIPTION
Adds Vercel serverless proxy endpoints so Polly can talk from the browser:
- `/api/agent/chat` → HuggingFace Qwen 72B (needs HF_TOKEN in Vercel env)
- `/api/agent/search` → DuckDuckGo API

Polly sidebar updated to: try backend → fall back to Vercel proxy.

**To activate:** Set `HF_TOKEN` in your Vercel project environment variables.