### PR TITLE
chore(release): recover tag-driven release workflows + RELEASING.md from stale branch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,89 @@
+name: npm-publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v4.0.3). Defaults to latest semver tag.'
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  npmjs:
+    name: Publish to npmjs.org
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify package version matches tag
+        run: |
+          PKG_VER=$(node -p "require('./package.json').version")
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          TAG_VER="${TAG#v}"
+          if [ "$PKG_VER" != "$TAG_VER" ]; then
+            echo "::error::package.json version ($PKG_VER) does not match tag ($TAG_VER)"
+            exit 1
+          fi
+
+      - name: Publish to npmjs
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  github-packages:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Setup Node (GH Packages registry)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@issdandavis'
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Rewrite package name to scoped form for GH Packages
+        # GitHub Packages requires a scope matching the owner. We don't change the
+        # name on disk in main — only in this transient build artifact.
+        run: |
+          node -e "
+            const fs = require('fs');
+            const p = JSON.parse(fs.readFileSync('package.json','utf8'));
+            p.name = '@issdandavis/scbe-aethermoore';
+            p.publishConfig = { registry: 'https://npm.pkg.github.com' };
+            fs.writeFileSync('package.json', JSON.stringify(p, null, 2));
+          "
+
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,52 @@
+name: python-publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v3.3.1)'
+        required: false
+
+permissions:
+  contents: read
+  id-token: write  # required for PyPI Trusted Publishing (OIDC)
+
+jobs:
+  build-and-publish:
+    name: Build sdist+wheel and publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Verify pyproject version matches tag
+        run: |
+          PKG_VER=$(python -c "import tomllib,sys; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          TAG_VER="${TAG#v}"
+          if [ "$PKG_VER" != "$TAG_VER" ]; then
+            echo "::warning::pyproject.toml version ($PKG_VER) does not match tag ($TAG_VER) — skipping PyPI publish."
+            echo "skip_pypi=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build distributions
+        if: env.skip_pypi != 'true'
+        run: python -m build
+
+      - name: Publish to PyPI (Trusted Publisher)
+        if: env.skip_pypi != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Requires PyPI Trusted Publishing to be configured for this repo + workflow.
+        # If not configured, this step will fail and you can fall back to API-token
+        # publishing by setting secrets.PYPI_API_TOKEN and using the `password` input.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish a release for (e.g. v4.0.3)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          # Strip leading 'v' for the package version compare
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine previous tag
+        id: prev
+        run: |
+          PREV=$(git tag --list 'v*.*.*' --sort=-v:refname \
+            | grep -v "^${{ steps.tag.outputs.tag }}$" \
+            | head -1 || true)
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+
+      - name: Build release notes
+        id: notes
+        run: |
+          {
+            echo "## ${{ steps.tag.outputs.tag }}"
+            echo
+            if [ -n "${{ steps.prev.outputs.prev }}" ]; then
+              echo "### Changes since ${{ steps.prev.outputs.prev }}"
+              echo
+              git log --pretty=format:'- %s (%h)' \
+                "${{ steps.prev.outputs.prev }}..${{ steps.tag.outputs.tag }}" \
+                || true
+              echo
+              echo
+              echo "Full diff: https://github.com/${{ github.repository }}/compare/${{ steps.prev.outputs.prev }}...${{ steps.tag.outputs.tag }}"
+            else
+              echo "Initial release."
+            fi
+          } > release_notes.md
+          echo "path=release_notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          body_path: ${{ steps.notes.outputs.path }}
+          draft: false
+          prerelease: ${{ contains(steps.tag.outputs.tag, '-rc') || contains(steps.tag.outputs.tag, '-alpha') || contains(steps.tag.outputs.tag, '-beta') }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,85 @@
+# Releasing SCBE-AETHERMOORE
+
+This repo ships three publishable artifacts:
+
+| Artifact | Registry | Version source |
+|----------|----------|----------------|
+| `scbe-aethermoore` (npm) | <https://registry.npmjs.org> | `package.json#version` |
+| `@issdandavis/scbe-aethermoore` (mirror) | <https://npm.pkg.github.com> | `package.json#version` (rewritten in CI) |
+| `scbe-aethermoore` (PyPI) | <https://pypi.org> | `pyproject.toml#project.version` |
+
+## Workflow
+
+Releases are tag-driven. Pushing a tag of the form `vMAJOR.MINOR.PATCH` triggers
+the chain in `.github/workflows/`:
+
+1. **`release.yml`** — on tag push, creates a GitHub Release with auto-generated
+   notes (commit log between the previous and current tag).
+2. **`npm-publish.yml`** — fires on `release: published`. Publishes to
+   `npmjs.org` (job `npmjs`) and to `npm.pkg.github.com` (job `github-packages`,
+   which rewrites the package name to the scoped form `@issdandavis/scbe-aethermoore`
+   in the build artifact only).
+3. **`python-publish.yml`** — fires on `release: published`. Builds sdist+wheel
+   and publishes to PyPI via OIDC Trusted Publishing. If `pyproject.toml`
+   version doesn't match the tag, the publish step is skipped with a warning
+   so a tag for an npm-only release doesn't try to push the wrong Python
+   version.
+
+## How to cut a release
+
+1. Decide the version. Conventional rules apply: bump MAJOR for breaking
+   changes, MINOR for backwards-compatible features, PATCH for fixes.
+2. Update `package.json#version` (always) and `pyproject.toml#project.version`
+   (only if the Python package is changing). Add a CHANGELOG.md entry under
+   the new version heading.
+3. Commit on a release branch and merge to `main` via PR.
+4. Tag and push:
+
+   ```bash
+   git tag -a v<MAJOR>.<MINOR>.<PATCH> -m "Release v<MAJOR>.<MINOR>.<PATCH>"
+   git push origin v<MAJOR>.<MINOR>.<PATCH>
+   ```
+
+5. The `release` workflow will create the GitHub Release. Once it's published,
+   the `npm-publish` and `python-publish` workflows fire automatically.
+
+## Required secrets / configuration
+
+| Name | Used by | Purpose |
+|------|---------|---------|
+| `NPM_TOKEN` | `npm-publish.yml` (npmjs job) | npm registry auth (an automation token with publish access). |
+| `GITHUB_TOKEN` | `npm-publish.yml` (github-packages job) | Provided by Actions; needs `packages: write` (set at workflow level). |
+| PyPI Trusted Publisher binding | `python-publish.yml` | Configured at <https://pypi.org/manage/project/scbe-aethermoore/settings/publishing/>. Map this repo + the `python-publish.yml` workflow + the `release` environment (or none) to the project. |
+
+If PyPI Trusted Publishing is not configured, swap the `pypa/gh-action-pypi-publish`
+step to use a `password: ${{ secrets.PYPI_API_TOKEN }}` input and add the
+secret.
+
+## Manual / one-shot publishes
+
+All three workflows expose `workflow_dispatch` with an optional `tag` input
+so you can re-run a publish for an existing tag from the Actions UI.
+
+## Catching GitHub Releases up to npm
+
+If npm has versions that GitHub Releases doesn't (this happened around the
+3.x → 4.x transition), the safe procedure is:
+
+1. Find the commit that bumped `package.json` to that version
+   (`git log -S '"version": "<X.Y.Z>"' -- package.json`).
+2. Create the tag at that commit and push it.
+3. The `release` workflow generates the Release. If the npm artifact is
+   already published, you can either:
+   - Skip `npm-publish` for that tag (delete the `release` event handler
+     run from Actions, or manually mark it "Skip"),
+   - Or re-publish the tarball from the tagged commit and let the version
+     compare in `npmjs` job catch any mismatch.
+
+## Version skew policy
+
+`scbe-aethermoore`'s npm and PyPI versions have drifted in the past
+(`CLAUDE.md` says "3.3.0 (npm + PyPI synced)" but as of the current `main`
+that's npm `4.0.3` vs PyPI `3.3.0`). The publish workflows do not enforce
+lockstep — each language publishes only when its version matches the tag.
+This lets you ship a TS-only patch as `vX.Y.Z+1` without dragging the Python
+package along.


### PR DESCRIPTION
## Summary

Recovers 4 unmerged files from a stale local branch (\`release/v4-publish-workflows\`) that never made it to main. All 4 are new to main (verified by content diff, not just commit metadata).

| File | Purpose |
|---|---|
| \`.github/workflows/release.yml\` | On tag push \`v*.*.*\`, create GitHub Release with auto-generated notes |
| \`.github/workflows/npm-publish.yml\` | On release: published, publish to npmjs.org and mirror to GitHub Packages as \`@issdandavis/scbe-aethermoore\` |
| \`.github/workflows/python-publish.yml\` | On release: published, build sdist+wheel and publish to PyPI via OIDC trusted publishing |
| \`RELEASING.md\` | Docs: how to cut a release end-to-end |

Content is current — uses \`actions/checkout@v4\`, \`softprops/action-gh-release@v2\`, references v4.0.3 (current package version).

## Why this is safe

- All 4 files are net-new (verified \`git diff main..source --diff-filter=A\`)
- No conflicts with existing main workflows
- Doesn't change \`pyproject.toml\` / \`package.json\` versions
- Won't fire until the next \`v*.*.*\` tag is pushed

## Test plan

- [ ] Workflows lint clean in GitHub Actions UI
- [ ] First release tag push triggers the chain end-to-end (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)