### PR TITLE
Add iteration cap tracking and warnings to harmonic key stretch

### DIFF
--- a/src/symphonic_cipher/scbe_aethermoore/pqc/pqc_harmonic.py
+++ b/src/symphonic_cipher/scbe_aethermoore/pqc/pqc_harmonic.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import math
 import secrets
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple, Dict, Any
 from enum import Enum
@@ -98,6 +99,8 @@ class HarmonicKeyMaterial:
     iteration_count: int
     salt: bytes
     info: bytes = b""
+    requested_iterations: int = 0
+    cap_engaged: bool = False
 
     @property
     def harmonic_multiplier(self) -> float:
@@ -150,6 +153,14 @@ def harmonic_key_stretch(
     # while maintaining the security claim
     max_iterations = 10_000_000
     actual_iterations = min(iteration_count, max_iterations)
+    cap_engaged = iteration_count > max_iterations
+    if cap_engaged:
+        warnings.warn(
+            f"harmonic_key_stretch cap engaged: requested {iteration_count} iterations "
+            f"(d={dimension}, R={R}), capped to {max_iterations}. "
+            f"Exponential cost-scaling claim degrades beyond this point.",
+            stacklevel=2,
+        )
 
     # Progressive key strengthening through iterated hashing
     # Each iteration incorporates dimension and ratio info
@@ -179,6 +190,8 @@ def harmonic_key_stretch(
         iteration_count=actual_iterations,
         salt=salt,
         info=info,
+        requested_iterations=iteration_count,
+        cap_engaged=cap_engaged,
     )
 
 

--- a/symphonic_cipher/scbe_aethermoore/pqc/pqc_harmonic.py
+++ b/symphonic_cipher/scbe_aethermoore/pqc/pqc_harmonic.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import math
 import secrets
+import warnings
 from dataclasses import dataclass, field
 from typing import Optional, Tuple, List, Dict, Any
 from enum import Enum
@@ -90,6 +91,8 @@ class HarmonicKeyMaterial:
     iteration_count: int
     salt: bytes
     info: bytes = b""
+    requested_iterations: int = 0
+    cap_engaged: bool = False
 
     @property
     def harmonic_multiplier(self) -> float:
@@ -142,6 +145,14 @@ def harmonic_key_stretch(
     # while maintaining the security claim
     max_iterations = 10_000_000
     actual_iterations = min(iteration_count, max_iterations)
+    cap_engaged = iteration_count > max_iterations
+    if cap_engaged:
+        warnings.warn(
+            f"harmonic_key_stretch cap engaged: requested {iteration_count} iterations "
+            f"(d={dimension}, R={R}), capped to {max_iterations}. "
+            f"Exponential cost-scaling claim degrades beyond this point.",
+            stacklevel=2,
+        )
 
     # Progressive key strengthening through iterated hashing
     # Each iteration incorporates dimension and ratio info
@@ -178,7 +189,9 @@ def harmonic_key_stretch(
         effective_security_bits=eff_bits,
         iteration_count=actual_iterations,
         salt=salt,
-        info=info
+        info=info,
+        requested_iterations=iteration_count,
+        cap_engaged=cap_engaged,
     )
 
 


### PR DESCRIPTION
## Summary

Add instrumentation to the `harmonic_key_stretch` function to track when the iteration count exceeds the security-bounded maximum and emit a warning to alert users that the exponential cost-scaling security claim degrades beyond the cap. This improves observability of potential security implications when requesting excessive iterations.

## Changes

- Import `warnings` module in both Python implementations
- Add `requested_iterations` and `cap_engaged` fields to `HarmonicKeyMaterial` dataclass to track the original requested iteration count and whether the cap was applied
- Detect when `iteration_count` exceeds `max_iterations` (10,000,000) and set `cap_engaged` flag
- Emit a user-facing warning when the cap is engaged, indicating the requested iterations, parameters (dimension and R), the applied cap, and that the security claim degrades beyond this point
- Pass the new fields to the `HarmonicKeyMaterial` constructor in both implementations

## Affected Layers

- [x] L11-12: Temporal distance / harmonic wall

## Axiom Compliance

- [x] N/A

## Test Plan

- [x] Python tests pass (`python -m pytest tests/ -v`)

## Cross-Language Parity

- [x] Python updated to match (both implementations synchronized)

https://claude.ai/code/session_01T8zrRfQbAES9sTwE5kj32k