### PR TITLE
fix(ci): harden workflow failure gates

### DIFF
--- a/.github/workflows/agent-router.yml
+++ b/.github/workflows/agent-router.yml
@@ -54,7 +54,9 @@ jobs:
         run: |
           pip install playwright fastapi uvicorn pydantic huggingface_hub
           python -m playwright install chromium
-          pip install -r requirements.txt 2>/dev/null || true
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
 
       - name: Determine task
         id: task
@@ -195,7 +197,7 @@ jobs:
         run: |
           git config user.name "SCBE Agent Router"
           git config user.email "agent@aethermoore.com"
-          git add docs/static/agent-data/ || true
+          git add docs/static/agent-data/
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
@@ -206,7 +208,14 @@ jobs:
             gh pr create --base main --head "$BRANCH" \
               --title "chore(agent): publish ${{ steps.task.outputs.task }} results" \
               --body "Automated agent router output. Auto-merge enabled."
-            gh pr merge "$BRANCH" --squash --auto || gh pr merge "$BRANCH" --squash --admin || true
+            if gh pr merge "$BRANCH" --squash --auto; then
+              echo "Auto-merge enabled for $BRANCH"
+            elif gh pr merge "$BRANCH" --squash --admin; then
+              echo "Admin-merged $BRANCH"
+            else
+              echo "::error::Failed to merge agent data PR for $BRANCH"
+              exit 1
+            fi
           fi
 
       - name: Upload artifact

--- a/.github/workflows/browser-research.yml
+++ b/.github/workflows/browser-research.yml
@@ -40,7 +40,9 @@ jobs:
         run: |
           pip install playwright fastapi uvicorn pydantic
           python -m playwright install chromium
-          pip install -r requirements.txt || true
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
 
       - name: Run research
         env:

--- a/.github/workflows/docker-remote-build.yml
+++ b/.github/workflows/docker-remote-build.yml
@@ -84,7 +84,12 @@ jobs:
         run: |
           set -euo pipefail
           docker run --rm -d --name scbe-api-smoke -p 8080:8080 "${IMAGE_SHA}"
-          trap 'docker logs scbe-api-smoke || true; docker stop scbe-api-smoke || true' EXIT
+          cleanup() {
+            docker logs scbe-api-smoke 2>/dev/null
+            docker stop scbe-api-smoke 2>/dev/null
+            return 0
+          }
+          trap cleanup EXIT
 
           for attempt in $(seq 1 30); do
             if curl -fsS "${SMOKE_URL}"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,7 @@ jobs:
         id: prev
         run: |
           PREV=$(git tag --list 'v*.*.*' --sort=-v:refname \
-            | grep -v "^${{ steps.tag.outputs.tag }}$" \
-            | head -1 || true)
+            | awk -v current="${{ steps.tag.outputs.tag }}" '$0 != current { print; exit }')
           echo "prev=$PREV" >> "$GITHUB_OUTPUT"
 
       - name: Build release notes
@@ -53,8 +52,7 @@ jobs:
               echo "### Changes since ${{ steps.prev.outputs.prev }}"
               echo
               git log --pretty=format:'- %s (%h)' \
-                "${{ steps.prev.outputs.prev }}..${{ steps.tag.outputs.tag }}" \
-                || true
+                "${{ steps.prev.outputs.prev }}..${{ steps.tag.outputs.tag }}"
               echo
               echo
               echo "Full diff: https://github.com/${{ github.repository }}/compare/${{ steps.prev.outputs.prev }}...${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -90,5 +90,6 @@ jobs:
             failed=1
           fi
           if [ "$failed" -eq 1 ]; then
-            echo "::warning::One or more security checks reported issues — see summary above"
+            echo "::error::One or more security checks reported issues — see summary above"
+            exit 1
           fi


### PR DESCRIPTION
## Summary
- make `security-checks.yml` fail the job when Bandit, npm audit, or pip-audit fail
- remove high-risk `|| true` masking from Agent Router dependency install/result publishing
- remove high-risk failure masking from browser research, Docker smoke cleanup, and release-note tag diff generation

## Review Notes
- This preserves advisory/research lanes that intentionally use `continue-on-error`, but clears the workflow audit's high-risk masked-error findings.
- Work was done in a clean worktree so the dirty local checkout was not disturbed.

## Verification
- `python scripts/workflow_audit.py --workspace . --report artifacts/workflow-audit-after.json --summary artifacts/workflow-audit-after.md` -> High: 0
- workflow YAML parse with PyYAML -> ok
- `npm ci` -> ok, 0 vulnerabilities
- `npm run typecheck` -> ok
- `npm run build` -> ok
- `npm test` -> 180 passed, 2 skipped; 6051 passed, 21 skipped
