### PR TITLE
fix(ci): repair nightly ops workflow yaml

### DIFF
--- a/.github/workflows/nightly-ops.yml
+++ b/.github/workflows/nightly-ops.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   orchestrate:
     runs-on: ubuntu-latest
+    env:
+      SCBE_MODE: 'ci'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -17,8 +19,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-    env:
-      SCBE_MODE: 'ci'
       - name: 'Smoke'
         id: step_01_smoke
         shell: bash


### PR DESCRIPTION
## Summary
- move SCBE_MODE env to the job level in nightly-ops
- restore Smoke and Packetize as real workflow steps instead of invalid env children
- format the workflow YAML

## Verification
- npx prettier --write .github/workflows/nightly-ops.yml
- git diff --check