### PR TITLE
style(crypto): format RWP nonce helper

### DIFF
--- a/src/crypto/rwp_v3.py
+++ b/src/crypto/rwp_v3.py
@@ -120,9 +120,7 @@ def _derive_chacha20poly1305_nonce(envelope_nonce: bytes) -> bytes:
         return envelope_nonce
     if len(envelope_nonce) != RWP_ENVELOPE_NONCE_LEN:
         raise ValueError(f"RWP nonce must be {RWP_ENVELOPE_NONCE_LEN} bytes")
-    return hashlib.sha256(b"RWPv3-ChaCha20Poly1305 nonce\x00" + envelope_nonce).digest()[
-        :CHACHA20_POLY1305_NONCE_LEN
-    ]
+    return hashlib.sha256(b"RWPv3-ChaCha20Poly1305 nonce\x00" + envelope_nonce).digest()[:CHACHA20_POLY1305_NONCE_LEN]
 
 
 def get_rwp_pqc_governance_status() -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- apply Black formatting to the RWP nonce helper added in the nonce-contract fix

## Test evidence
- python -m py_compile src\\crypto\\rwp_v3.py
- python -m bandit -r src scripts api python agents -q --severity-level high -x tests,node_modules,dist,artifacts,training,external