### PR TITLE
style(storage): format spin voxel kernel

### DIFF
--- a/src/storage/spin_voxel.py
+++ b/src/storage/spin_voxel.py
@@ -83,7 +83,9 @@ def spin_hamiltonian(
     return exchange_term + field_term
 
 
-def spin_disorder(spins: list[SpinVector], *, edges: list[tuple[int, int]] | None = None, epsilon: float = 1e-9) -> float:
+def spin_disorder(
+    spins: list[SpinVector], *, edges: list[tuple[int, int]] | None = None, epsilon: float = 1e-9
+) -> float:
     if not spins:
         return 0.0
     if edges is None:
@@ -96,7 +98,9 @@ def spin_disorder(spins: list[SpinVector], *, edges: list[tuple[int, int]] | Non
     return disagreement / (len(edges) + epsilon)
 
 
-def phason_rotation_matrix(*, n: int = 1, phi: float = (1.0 + math.sqrt(5.0)) / 2.0) -> tuple[tuple[float, float, float], tuple[float, float, float], tuple[float, float, float]]:
+def phason_rotation_matrix(
+    *, n: int = 1, phi: float = (1.0 + math.sqrt(5.0)) / 2.0
+) -> tuple[tuple[float, float, float], tuple[float, float, float], tuple[float, float, float]]:
     phase_n = max(1, int(n))
     theta = (2.0 * math.pi) / (phi**phase_n)
     c = math.cos(theta)
@@ -104,7 +108,9 @@ def phason_rotation_matrix(*, n: int = 1, phi: float = (1.0 + math.sqrt(5.0)) / 
     return ((c, -s, 0.0), (s, c, 0.0), (0.0, 0.0, 1.0))
 
 
-def rotate_spin(spin: SpinVector, matrix: tuple[tuple[float, float, float], tuple[float, float, float], tuple[float, float, float]]) -> SpinVector:
+def rotate_spin(
+    spin: SpinVector, matrix: tuple[tuple[float, float, float], tuple[float, float, float], tuple[float, float, float]]
+) -> SpinVector:
     x = (matrix[0][0] * spin[0]) + (matrix[0][1] * spin[1]) + (matrix[0][2] * spin[2])
     y = (matrix[1][0] * spin[0]) + (matrix[1][1] * spin[1]) + (matrix[1][2] * spin[2])
     z = (matrix[2][0] * spin[0]) + (matrix[2][1] * spin[1]) + (matrix[2][2] * spin[2])


### PR DESCRIPTION
## Summary
- applies Black formatting to the spin voxel storage kernel from the distribution readiness merge

## Verification
- black --check --target-version py311 --line-length 120 src\\storage\\spin_voxel.py tests\\test_scbe_system_cli_web_parallel.py
- python -m pytest tests\\test_scbe_system_cli_web_parallel.py tests\\test_spin_voxel.py -q
- git diff --check

## Rollback
- Revert this PR to restore the exact pre-format source layout.