### PR TITLE
chore(cursor): add machine automation tasks

### DIFF
--- a/.cursor/rules/scbe-machine-automation.mdc
+++ b/.cursor/rules/scbe-machine-automation.mdc
@@ -1,0 +1,47 @@
+---
+description: Machine automation and Cursor agent safety rules for SCBE-AETHERMOORE.
+globs:
+  - "**/*"
+alwaysApply: true
+---
+
+# SCBE Machine Automation Rules
+
+Use Cursor agents as parallel workers, not as final authority.
+
+## Allowed default lanes
+
+- Documentation cleanup and link repair.
+- Focused tests for changed files.
+- Non-destructive repo inventory.
+- Public/free API connector metadata.
+- Small isolated scripts with tests.
+- Read-only GitHub issue or pull-request review.
+
+## Ask before doing
+
+- Sending email or posting externally.
+- Deleting files or moving large directories.
+- Changing secrets, tokens, OAuth config, or credential files.
+- Publishing models, datasets, npm packages, or releases.
+- Promoting training adapters or merged models.
+- Editing private proposal, tax, patent, or payment material.
+
+## Verification floor
+
+Before reporting completion, run the narrowest relevant check:
+
+- `python -m json.tool <changed-json>`
+- `python -m pytest <changed-tests> -q`
+- `black --check --target-version py311 --line-length 120 <changed-python-files>`
+- `git diff --check`
+
+If a check fails, fix the failure or report the exact failing command and file.
+
+## Git hygiene
+
+- Work on a branch.
+- Do not force-push shared branches unless explicitly instructed.
+- Do not revert work made by another agent unless the user explicitly asks.
+- Keep generated artifacts, caches, credentials, and local machine state out of commits.
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -312,6 +312,57 @@
         "reveal": "always",
         "panel": "shared"
       }
+    },
+    {
+      "label": "SCBE: Open Cursor Agents",
+      "type": "shell",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "Start-Process 'https://cursor.com/agents#workerId=45675c38-f466-408d-aa0d-d2ab0cf35bde'"
+      ],
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared"
+      }
+    },
+    {
+      "label": "SCBE: Open Cursor Automations",
+      "type": "shell",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "Start-Process 'https://cursor.com/automations/new#workerId=45675c38-f466-408d-aa0d-d2ab0cf35bde'"
+      ],
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "never",
+        "panel": "shared"
+      }
+    },
+    {
+      "label": "SCBE: Verify Government API Directory",
+      "type": "shell",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "python -m json.tool src\\knowledge\\storage\\government_api_directory.json > $null; python -m pytest tests\\test_government_api_directory.py -q"
+      ],
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- adds Cursor machine-automation rules for safe agent lanes
- adds VS Code/Cursor tasks to open Cursor Agents, open Cursor Automations, and verify the government API directory

## Verification
- python -m json.tool .vscode\\tasks.json
- python -m pytest tests\\test_government_api_directory.py -q
- git diff --check

## Notes
- Opened the provided Cursor Agents and Cursor Automations URLs locally with Start-Process.
- Cursor remains a parallel worker lane; Codex/GitHub checks remain the final verification path.