### PR TITLE
feat(training): add Stage 6 boss retry planning

### DIFF
--- a/docs/research/drone_autonomy_training_patterns_2026-05-02.md
+++ b/docs/research/drone_autonomy_training_patterns_2026-05-02.md
@@ -1,0 +1,166 @@
+# Drone Autonomy Training Patterns for SCBE Agent Training
+
+Date: 2026-05-02
+
+Purpose: capture public, official patterns from DARPA, NASA, Army, and Air Force autonomy work that can inform SCBE's coding-agent and GeoSeal training loops without claiming physical drone capability.
+
+## Executive Takeaway
+
+Government drone and autonomy training does not look like one big model run. It looks like a staged progression:
+
+1. high-fidelity simulation,
+2. instrumented test ranges,
+3. human trust calibration,
+4. runtime assurance,
+5. live or field-like demonstrations,
+6. continuous repair from failures.
+
+That maps cleanly to the SCBE "boss fight" model: run the agent against a frozen gate, record failure mechanics, convert failures into analog repair experience, retry, and only promote when the same gate passes.
+
+## Source Patterns
+
+### DARPA OFFSET: swarm tactics as a development ecosystem
+
+Source: https://www.darpa.mil/research/programs/offensive-swarm-enabled-tactics
+
+DARPA OFFSET frames swarm autonomy around hundreds of small unmanned aircraft or ground systems, human-swarm teaming, fast tactic generation, evaluation, and integration into field operations. The useful pattern for SCBE is not "more drones"; it is the open tactics ecosystem:
+
+- generate candidate tactics,
+- evaluate effectiveness,
+- preserve the best tactics,
+- expose humans to swarm state through a command interface.
+
+SCBE mapping: agent plans should become reusable tactics with score histories, not one-off chat outputs.
+
+### DARPA REMA: adapter interface plus mission autonomy
+
+Source: https://www.darpa.mil/research/programs/rema-rapid-experimental-missionized-autonomy
+
+REMA focuses on adding autonomy subsystems to existing commercial and stock military drones, with two technical areas: a drone-autonomy adapter interface and mission-specific autonomy software. DARPA explicitly describes repeated "accelerating spirals" of development.
+
+SCBE mapping: GeoSeal should treat tools like adapter surfaces. The coding agent does not need to own every tool internally; it needs a stable adapter interface, mission-specific policies, and repeatable spiral upgrades.
+
+### DARPA ACE and AIR: hierarchy, trust, and sim-to-live progression
+
+Sources:
+
+- https://www.darpa.mil/research/programs/air-combat-evolution
+- https://www.darpa.mil/news/2024/ace-ai-aerospace
+- https://www.darpa.mil/research/programs/artificial-intelligence-reinforcements
+
+ACE separates higher-level human cognitive functions from lower-level autonomous maneuver/tactics. It also names trust calibration as a core challenge. AIR extends this into multi-ship beyond-visual-range missions, emphasizing uncertainty, open-world adaptation, human feedback, modeling, simulation, and live missions.
+
+SCBE mapping:
+
+- Human/user sets mission intent and constraints.
+- GeoSeal handles lower-level tool routing, budget checks, and fallback.
+- The training system logs where trust should increase or decrease.
+- Promotion requires both task success and trust evidence.
+
+### DARPA Assured Autonomy: continual assurance for learning-enabled systems
+
+Source: https://www.darpa.mil/research/programs/assured-autonomy
+
+DARPA Assured Autonomy targets continual assurance of learning-enabled cyber-physical systems. The key pattern is that assurance is not only design-time certification; it is monitored, updated, and evaluated during operation as the system and environment evolve.
+
+SCBE mapping: a coding agent should not be trusted because it once passed a test. It should carry live assurance state: last gate, failure class, allowed tools, denied tools, and current promotion tier.
+
+### NASA simulation and multi-UAV visualization
+
+Sources:
+
+- https://www.nasa.gov/reference/jsc-simulation-modeling/
+- https://software.nasa.gov/software/LAR-19641-1
+
+NASA simulation uses high-fidelity simulation hosts, virtual computers running flight software, partner interfaces, training devices, and human-in-the-loop simulation. NASA WebGS supports multi-UAV test design, automated simulation execution, repeatable/adjustable flight planning, live flights interacting with simulated vehicles, remote monitoring, and multi-user interaction.
+
+SCBE mapping:
+
+- Treat evals as repeatable simulation worlds.
+- Keep live systems and simulated systems able to interact through the same message format.
+- Make test runs replayable and inspectable by humans.
+
+### NASA Armstrong: AI-enabled UAS and collision/landing safety
+
+Source: https://www.nasa.gov/centers-and-facilities/armstrong/autonomous-systems/
+
+NASA Armstrong work includes AI-enabled small UAS for disaster/crash-site search, object detection and geo-tagging, improved ground collision avoidance, and autonomous emergency landing. Important training pattern: safety features are paired with maps, reachable sets, real-time updates, and vehicle-specific models.
+
+SCBE mapping:
+
+- Every agent run should track reachable states: what actions are allowed next, what rollback paths exist, and what terrain/map of the repo it is using.
+- GeoSeal should expose minimap-like state for code: changed files, tests run, blocked tools, current lane, and fallback route.
+
+### Army UAS simulation and swarm test ranges
+
+Sources:
+
+- https://www.army.mil/article/187989
+- https://www.army.mil/article/236381/army_researchers_find_new_ways_to_test_swarming_drones
+- https://www.tradoc.army.mil/2025/08/19/u-s-army-aviation-center-of-excellence-launches-unmanned-advanced-lethality-course-to-equip-soldiers-for-future-warfare/
+
+The Army uses accredited simulation systems for UAS crew readiness and keeps simulator software aligned with tactical system upgrades. Army swarm testing also emphasizes large outdoor instrumented ranges, camera navigation, RF communication, heterogeneous swarms, ground/aerial interactions, and human-agent teaming. The newer UAS training course pattern is classroom plus simulator hours before live flight.
+
+SCBE mapping:
+
+- Use simulator-first agent training before granting broader filesystem or network powers.
+- Record "simulator hours" as EXP: number of successful gated tasks, failure repairs, and no-regression repeats.
+- Do not let a model jump to live actions until it clears the simulation lane.
+
+### Air Force Skyborg: open systems, modeling/simulation, and runtime assurance
+
+Source: https://www.af.mil/News/Features/Article/1796930/skyborg-program-seeks-industry-input-for-artificial-intelligence-initiative/
+
+Skyborg emphasizes low-cost attritable unmanned aircraft, open systems architecture, modeling and simulation, modularity, autonomous teaming, runtime assurance, and building trust as the system evolves. The Air Force source explicitly connects gaming AI progress to the question of moving AI safely into real flight.
+
+SCBE mapping:
+
+- Use game-like worlds as useful training environments, but require runtime assurance before giving real powers.
+- Make tool interfaces modular so small models can learn one subsystem at a time.
+- Track trust as a progressive score, not a binary claim.
+
+## SCBE Implementation Pattern
+
+### EXP Unit
+
+An EXP unit is a verified micro-skill record:
+
+```json
+{
+  "task_id": "stage6_unseen_hex_trace",
+  "failure_kind": "byte_hex_compute_trace",
+  "missing_required_marker": "compute",
+  "repair_action": "analog_repair_rows",
+  "gate_retested": true,
+  "same_gate_improved": true,
+  "heldout_leak": false
+}
+```
+
+### Training Ladder
+
+1. Simulator Lane: frozen prompts, fake filesystem, no live side effects.
+2. Instrumented Range: real repo read access, dry-run tool calls, full telemetry.
+3. Supervised Live Lane: small patches only, human approval required.
+4. Trusted Routine Lane: repeated task family with bounded write scope.
+5. Mission Lane: paired agents, switchboard arbitration, full runbook and rollback.
+
+### Boss Loop
+
+```text
+train candidate
+run frozen gate
+extract failure mechanics
+generate analog repair data
+apply constrained decoding or preference repair if SFT saturates
+retry same gate
+promote only after pass
+```
+
+## What To Build Next
+
+- Add a GeoSeal "simulation world" runner for coding tasks that exposes a minimap: files, tests, tools, budget, failure class, and rollback route.
+- Extend `boss-retry-plan` into a repair-row generator that writes analog SFT/DPO rows from failure kinds without copying held-out prompt text.
+- Add a paired-agent flight rule: one agent proposes actions, one agent audits route/budget/tool permission before execution.
+- Score EXP as cumulative evidence across runs: pass rate, no-regression count, repair lift, tool discipline, and context continuity.
+

--- a/scripts/system/geoseal_coding_training_system.py
+++ b/scripts/system/geoseal_coding_training_system.py
@@ -142,6 +142,141 @@ def summarize_training_log(text: str) -> dict[str, Any]:
     }
 
 
+def extract_gate_report(text: str) -> dict[str, Any] | None:
+    """Extract the last inline gate report from HF job logs.
+
+    The training script emits the promotion gate as a single JSON event before
+    it decides whether to push. Keeping this parser line-oriented avoids fragile
+    regex matching across tqdm progress output.
+    """
+    latest: dict[str, Any] | None = None
+    decoder = json.JSONDecoder()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or '"gate_report"' not in line:
+            continue
+        start = line.find("{")
+        if start < 0:
+            continue
+        try:
+            event, _ = decoder.raw_decode(line[start:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict) and event.get("event") == "gate_report" and isinstance(event.get("report"), dict):
+            latest = event["report"]
+    return latest
+
+
+def _failure_kind_from_id(prompt_id: str) -> str:
+    if "resource_jump" in prompt_id:
+        return "resource_overrun_fallback"
+    if "lane_separation" in prompt_id:
+        return "byte_hex_semantic_lane_separation"
+    if "hex_trace" in prompt_id:
+        return "byte_hex_compute_trace"
+    if "cost_propagation" in prompt_id:
+        return "multi_budget_cost_propagation"
+    if "training_boundary" in prompt_id:
+        return "heldout_boundary_pollution_control"
+    return "unknown_contract_gap"
+
+
+def build_boss_retry_plan(
+    gate_report: dict[str, Any],
+    *,
+    profile_id: str = "",
+    source: str = "",
+) -> dict[str, Any]:
+    """Turn a failed promotion gate into the next bounded repair plan.
+
+    This is the video-game boss loop in repo terms: fight the gate, record
+    exactly which mechanics beat the model, generate analog repair curriculum,
+    retry, and only promote when the same frozen boss gate passes. It does not
+    copy frozen prompt text into training instructions.
+    """
+    results = [item for item in gate_report.get("results", []) if isinstance(item, dict)]
+    failed = [item for item in results if not item.get("ok")]
+    passed = [item for item in results if item.get("ok")]
+    n_total = int(gate_report.get("n_total") or len(results))
+    n_pass = int(gate_report.get("n_pass") or len(passed))
+    pass_rate = float(gate_report.get("pass_rate") or (n_pass / n_total if n_total else 0.0))
+    minimum = float(gate_report.get("minimum_pass_rate") or 0.8)
+    must_pass_results = gate_report.get("must_pass_results") or {}
+    must_pass_failed = [key for key, ok in must_pass_results.items() if ok is not True]
+
+    repair_targets = []
+    for item in failed:
+        prompt_id = str(item.get("id") or "")
+        missing = [str(token) for token in item.get("missing_required", item.get("missing", [])) if str(token)]
+        kind = _failure_kind_from_id(prompt_id)
+        repair_targets.append(
+            {
+                "id": prompt_id,
+                "kind": kind,
+                "missing_required": missing,
+                "must_pass": prompt_id in must_pass_failed,
+                "repair_rule": (
+                    "Generate new analog scenarios with different nouns and action chains, "
+                    "but preserve the missing required markers and the same forbidden-marker guard."
+                ),
+                "recommended_rows": 72 if prompt_id in must_pass_failed else 48,
+            }
+        )
+
+    strategy = "promote_or_merge"
+    if repair_targets:
+        strategy = "constrained_decoding_plus_targeted_dpo" if "v12" in profile_id.lower() else "targeted_repair_sft"
+    if pass_rate < 0.5 and repair_targets:
+        strategy = "constrained_decoding_plus_targeted_dpo"
+
+    next_actions = [
+        "Do not change the frozen eval contract.",
+        "Do not copy held-out prompt text into training data.",
+        "Generate analog repair rows only from missing marker classes and failure kinds.",
+        "Run the next candidate through the same inline gate and push only if the gate passes.",
+    ]
+    if strategy == "constrained_decoding_plus_targeted_dpo":
+        next_actions.insert(
+            2,
+            "Add a decoding shim or response scaffold that forces a required-token checklist before prose, then train preferences around pass/fail responses.",
+        )
+
+    return {
+        "schema_version": "geoseal_stage6_boss_retry_plan_v1",
+        "generated_utc": datetime.now(timezone.utc).isoformat(),
+        "source": source,
+        "profile_id": profile_id or gate_report.get("profile_id", ""),
+        "contract_id": gate_report.get("contract_id", ""),
+        "score": {
+            "n_pass": n_pass,
+            "n_total": n_total,
+            "pass_rate": pass_rate,
+            "minimum_pass_rate": minimum,
+            "must_pass_failed": must_pass_failed,
+            "promotion_ready": bool(pass_rate >= minimum and not must_pass_failed and n_total),
+        },
+        "strategy": strategy,
+        "passed_ids": [str(item.get("id") or "") for item in passed],
+        "repair_targets": repair_targets,
+        "experience_model": {
+            "definition": (
+                "EXP is aggregate micro-skill evidence: each failed gate records the small repeated behaviors "
+                "that must become routine before the agent earns promotion."
+            ),
+            "unit_fields": [
+                "failure_kind",
+                "missing_required_marker",
+                "must_pass_pressure",
+                "analog_repair_rows",
+                "same_gate_retry",
+            ],
+            "promotion_rule": "EXP counts only when the same frozen gate improves without training on the held-out prompt text.",
+        },
+        "next_actions": next_actions,
+        "loop_rule": "train -> frozen gate -> mine failures -> analog repair data -> retry; publish only after gate pass",
+    }
+
+
 def assess_job_health(inspect_summary: dict[str, Any], logs_payload: dict[str, Any] | None) -> dict[str, Any]:
     """Classify common HF Jobs failure modes before a full train is launched."""
     stage = str(inspect_summary.get("stage") or "").upper()
@@ -586,6 +721,42 @@ def reward_smoke_report(report_path: Path, manifest: dict[str, Any]) -> dict[str
     }
 
 
+def boss_retry_plan_from_report(
+    report_path: Path,
+    *,
+    profile_id: str = "",
+    output: Path | None = None,
+) -> dict[str, Any]:
+    payload = _load_json(report_path)
+    gate_report = payload.get("report") if payload.get("event") == "gate_report" else payload
+    if not isinstance(gate_report, dict) or "results" not in gate_report:
+        raise ValueError(f"Report does not look like a Stage 6 gate report: {report_path}")
+    plan = build_boss_retry_plan(gate_report, profile_id=profile_id, source=str(report_path))
+    if output is not None:
+        _write_json(output, plan)
+        plan["output_path"] = str(output)
+    return plan
+
+
+def boss_retry_plan_from_job(
+    job_id: str,
+    *,
+    profile_id: str = "",
+    output: Path | None = None,
+) -> dict[str, Any]:
+    logs_result = _run_hf(["hf", "jobs", "logs", job_id, "--tail", "400"], timeout_s=90)
+    combined = logs_result["stdout"] + "\n" + logs_result["stderr"]
+    gate_report = extract_gate_report(combined)
+    if gate_report is None:
+        raise ValueError(f"No gate_report event found in HF job logs: {job_id}")
+    plan = build_boss_retry_plan(gate_report, profile_id=profile_id, source=f"hf_job:{job_id}")
+    plan["logs_returncode"] = logs_result["returncode"]
+    if output is not None:
+        _write_json(output, plan)
+        plan["output_path"] = str(output)
+    return plan
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", default=str(MANIFEST_PATH))
@@ -622,6 +793,12 @@ def main() -> int:
     score_parser.add_argument("--report", required=True)
     reward_parser = sub.add_parser("reward-smoke-report")
     reward_parser.add_argument("--report", required=True)
+    boss_parser = sub.add_parser("boss-retry-plan")
+    boss_src = boss_parser.add_mutually_exclusive_group(required=True)
+    boss_src.add_argument("--report")
+    boss_src.add_argument("--job-id")
+    boss_parser.add_argument("--profile-id", default="")
+    boss_parser.add_argument("--output", default="")
     args = parser.parse_args()
 
     manifest = load_manifest(Path(args.manifest))
@@ -657,6 +834,12 @@ def main() -> int:
         payload = score_smoke_report(Path(args.report), manifest)
     elif args.command == "reward-smoke-report":
         payload = reward_smoke_report(Path(args.report), manifest)
+    elif args.command == "boss-retry-plan":
+        output = Path(args.output) if args.output else None
+        if args.report:
+            payload = boss_retry_plan_from_report(Path(args.report), profile_id=args.profile_id, output=output)
+        else:
+            payload = boss_retry_plan_from_job(str(args.job_id), profile_id=args.profile_id, output=output)
     else:
         raise AssertionError(args.command)
     print(json.dumps(payload, indent=2, ensure_ascii=True))

--- a/tests/test_geoseal_coding_training_system.py
+++ b/tests/test_geoseal_coding_training_system.py
@@ -224,6 +224,35 @@ def test_reward_smoke_report_exports_rule_based_rlvr_signal(tmp_path: Path) -> N
     assert reward["items"][0]["forbidden_penalty"] == 0.0
 
 
+def test_extract_gate_report_and_boss_retry_plan_target_failed_mechanics(tmp_path: Path) -> None:
+    module = _load_module()
+    log_text = """
+noise
+{"event": "gate_report", "report": {"contract_id": "stage6_atomic_workflow_unseen_eval_v1", "n_total": 5, "n_pass": 2, "pass_rate": 0.4, "minimum_pass_rate": 0.8, "must_pass_results": {"stage6_unseen_hex_trace": false}, "results": [{"id": "stage6_unseen_hex_trace", "ok": false, "missing_required": ["compute"]}, {"id": "stage6_unseen_cost_propagation", "ok": false, "missing_required": ["sample_soil", "send_digest"]}, {"id": "stage6_unseen_lane_separation", "ok": true}]}}
+"""
+
+    report = module.extract_gate_report(log_text)
+    assert report is not None
+    plan = module.build_boss_retry_plan(report, profile_id="coding-agent-qwen-stage6-repair-v12")
+
+    assert plan["schema_version"] == "geoseal_stage6_boss_retry_plan_v1"
+    assert plan["score"]["promotion_ready"] is False
+    assert plan["strategy"] == "constrained_decoding_plus_targeted_dpo"
+    targets = {item["id"]: item for item in plan["repair_targets"]}
+    assert targets["stage6_unseen_hex_trace"]["kind"] == "byte_hex_compute_trace"
+    assert targets["stage6_unseen_hex_trace"]["must_pass"] is True
+    assert targets["stage6_unseen_cost_propagation"]["recommended_rows"] == 48
+    assert "aggregate micro-skill evidence" in plan["experience_model"]["definition"]
+    assert "Do not copy held-out prompt text into training data." in plan["next_actions"]
+
+    out = tmp_path / "boss_retry.json"
+    wrapped = tmp_path / "gate_report.json"
+    wrapped.write_text(json.dumps({"event": "gate_report", "report": report}), encoding="utf-8")
+    written = module.boss_retry_plan_from_report(wrapped, profile_id="coding-agent-qwen-stage6-repair-v12", output=out)
+    assert out.exists()
+    assert written["output_path"] == str(out)
+
+
 def test_summarize_training_log_parses_pretty_completion_json() -> None:
     module = _load_module()
     summary = module.summarize_training_log("""


### PR DESCRIPTION
## Summary
- adds a Stage 6 boss-retry planner to turn failed HF gate logs into bounded repair targets and EXP-style micro-skill evidence
- generates a real retry plan from failed HF job 69f5795798a8d679adfb865c
- adds a source-backed research brief mapping DARPA/NASA/Army/Air Force drone autonomy training patterns into SCBE agent training

## Verification
- `python -m pytest tests\test_geoseal_coding_training_system.py -q` -> 10 passed
- `python scripts\system\geoseal_coding_training_system.py boss-retry-plan --job-id 69f5795798a8d679adfb865c --profile-id coding-agent-qwen-stage6-repair-v12 --output artifacts\model_training\stage6-v12-boss-retry-plan.json` -> generated plan

## Notes
- The boss loop does not copy held-out prompt text into training data.
- The research brief uses public official sources and does not claim physical drone capability.