### PR TITLE
fix(benchmark): use python3 in scored Aider container

### DIFF
--- a/.github/workflows/public-agentic-benchmarks.yml
+++ b/.github/workflows/public-agentic-benchmarks.yml
@@ -94,7 +94,7 @@ jobs:
             -e AIDER_DOCKER=1 \
             -e AIDER_BENCHMARK_DIR=/benchmarks \
             aider-benchmark \
-            bash -lc "cd /aider && pip install -e '.[dev]' && python benchmark/benchmark.py scbe-remote-scored --model '${AIDER_MODEL}' --edit-format '${AIDER_EDIT_FORMAT}' --threads 1 --num-tests '${AIDER_NUM_TESTS}' --exercises-dir /benchmarks/polyglot-benchmark"
+            bash -lc "cd /aider && pip install -e '.[dev]' && python3 benchmark/benchmark.py scbe-remote-scored --model '${AIDER_MODEL}' --edit-format '${AIDER_EDIT_FORMAT}' --threads 1 --num-tests '${AIDER_NUM_TESTS}' --exercises-dir /benchmarks/polyglot-benchmark"
 
           latest_dir="$(ls -td tmp.benchmarks/*--scbe-remote-scored | head -1)"
           mkdir -p ../../../artifacts/public_agentic_benchmark_setup/aider_polyglot_scored

--- a/scripts/benchmark/aider_polyglot_smoke.py
+++ b/scripts/benchmark/aider_polyglot_smoke.py
@@ -17,7 +17,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_AIDER_ROOT = REPO_ROOT / "external" / "benchmarks" / "aider"
 DEFAULT_POLYGLOT_ROOT = DEFAULT_AIDER_ROOT / "tmp.benchmarks" / "polyglot-benchmark"
@@ -244,7 +243,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--polyglot-root", type=Path, default=DEFAULT_POLYGLOT_ROOT)
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
     parser.add_argument("--execute", action="store_true", help="Run help and no-model/no-unit-tests smoke commands.")
-    parser.add_argument("--download-polyglot", action="store_true", help="Clone Aider-AI/polyglot-benchmark when missing.")
+    parser.add_argument(
+        "--download-polyglot", action="store_true", help="Clone Aider-AI/polyglot-benchmark when missing."
+    )
     parser.add_argument("--python", default="3.12", help="Python version passed to uv run.")
     parser.add_argument("--num-tests", type=int, default=1)
     return parser

--- a/scripts/benchmark/public_agentic_cli_suite.py
+++ b/scripts/benchmark/public_agentic_cli_suite.py
@@ -17,7 +17,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG = REPO_ROOT / "config" / "eval" / "public_agentic_cli_suite.v1.json"
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "artifacts" / "public_agentic_cli_suite"
@@ -78,9 +77,7 @@ def load_tracks(config: dict[str, Any]) -> list[Track]:
                 run_command=command,
                 expected_artifacts=[str(item) for item in row.get("expected_artifacts", [])],
                 primary_metric=str(row["primary_metric"]),
-                pass_threshold=(
-                    None if row.get("pass_threshold") is None else float(row["pass_threshold"])
-                ),
+                pass_threshold=(None if row.get("pass_threshold") is None else float(row["pass_threshold"])),
                 cost_tier=str(row["cost_tier"]),
             )
         )
@@ -258,11 +255,7 @@ def build_report(config_path: Path, output_root: Path, execute: bool, timeout: i
     tracks = load_tracks(config)
     results = [run_track(track, execute=execute, timeout=timeout) for track in tracks]
     required = [row for row in results if row["required_for_public_all_around_claim"]]
-    external_required = [
-        row
-        for row in required
-        if row["track_id"] != "geoseal_cli_competitive"
-    ]
+    external_required = [row for row in required if row["track_id"] != "geoseal_cli_competitive"]
     all_required_public_ready = all(row["public_claim_ready"] for row in required)
     local_ready = all(row["passed_gate"] for row in results if row["adapter_status"] == "wired")
     adapter_readiness_ok = all(row["command"]["returncode"] in {0, None} for row in results)
@@ -281,7 +274,9 @@ def build_report(config_path: Path, output_root: Path, execute: bool, timeout: i
             "planned_tracks": sum(1 for row in results if row["adapter_status"] != "wired"),
             "local_ready": local_ready,
             "all_required_public_ready": all_required_public_ready,
-            "external_required_not_ready": [row["track_id"] for row in external_required if not row["public_claim_ready"]],
+            "external_required_not_ready": [
+                row["track_id"] for row in external_required if not row["public_claim_ready"]
+            ],
             "external_setup_evidence": [
                 row["track_id"]
                 for row in external_required
@@ -394,7 +389,9 @@ def validate_config(config_path: Path) -> dict[str, Any]:
             problems.append(f"track is not marked required for all-around claim: {required}")
     forbidden = set(config.get("claim_policy", {}).get("forbidden_now", []))
     if not any("all-around best coding agent" in item for item in forbidden):
-        problems.append("claim_policy must explicitly forbid all-around best coding agent claims until official runs exist")
+        problems.append(
+            "claim_policy must explicitly forbid all-around best coding agent claims until official runs exist"
+        )
     return {"ok": not problems, "track_count": len(tracks), "problems": problems}
 
 
@@ -403,7 +400,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
     parser.add_argument("--validate-only", action="store_true")
-    parser.add_argument("--execute", action="store_true", help="Run wired local commands and adapter-readiness commands.")
+    parser.add_argument(
+        "--execute", action="store_true", help="Run wired local commands and adapter-readiness commands."
+    )
     parser.add_argument("--timeout", type=int, default=180)
     return parser
 

--- a/scripts/benchmark/setup_public_agentic_benchmarks.py
+++ b/scripts/benchmark/setup_public_agentic_benchmarks.py
@@ -12,7 +12,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG = REPO_ROOT / "config" / "eval" / "public_agentic_benchmark_sources.v1.json"
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "artifacts" / "public_agentic_benchmark_setup"
@@ -109,13 +108,26 @@ def _clone_or_status(source: BenchmarkSource, source_root: Path) -> dict[str, An
     target = source_root / source.local_dir
     if (target / ".git").exists():
         result = _run(["git", "rev-parse", "HEAD"], cwd=target)
-        return {"action": "already_present", "path": str(target), "ok": result["ok"], "head": result["stdout_tail"].strip()}
-    return {"action": "clone", "path": str(target), **_run(["git", "clone", "--depth", "1", source.repo_url, str(target)], cwd=REPO_ROOT, timeout=240)}
+        return {
+            "action": "already_present",
+            "path": str(target),
+            "ok": result["ok"],
+            "head": result["stdout_tail"].strip(),
+        }
+    return {
+        "action": "clone",
+        "path": str(target),
+        **_run(["git", "clone", "--depth", "1", source.repo_url, str(target)], cwd=REPO_ROOT, timeout=240),
+    }
 
 
 def _check_cwd(source: BenchmarkSource, source_root: Path, command: list[str]) -> Path:
     local_path = source_root / source.local_dir
-    if source.benchmark_id == "aider_polyglot" and local_path.exists() and command[:2] == ["python", "benchmark/benchmark.py"]:
+    if (
+        source.benchmark_id == "aider_polyglot"
+        and local_path.exists()
+        and command[:2] == ["python", "benchmark/benchmark.py"]
+    ):
         return local_path
     return REPO_ROOT
 
@@ -158,7 +170,10 @@ def inspect_source(source: BenchmarkSource, source_root: Path, download: bool, r
         blockers.append("Docker is not installed or not on PATH.")
     if source.benchmark_id == "terminal_bench" and shutil.which("tb") is None:
         blockers.append("Terminal-Bench CLI `tb` is not installed.")
-    if source.benchmark_id == "swe_bench" and not any(item["ok"] and item["command"][:3] == ["python", "-m", "swebench.harness.run_evaluation"] for item in tool_results):
+    if source.benchmark_id == "swe_bench" and not any(
+        item["ok"] and item["command"][:3] == ["python", "-m", "swebench.harness.run_evaluation"]
+        for item in tool_results
+    ):
         blockers.append("SWE-bench Python package is not installed in the active Python environment.")
     if source.benchmark_id == "aider_polyglot" and not repo_present:
         blockers.append("Aider repository is not downloaded; benchmark/benchmark.py is unavailable.")
@@ -184,16 +199,31 @@ def next_steps(results: list[dict[str, Any]]) -> list[str]:
     steps = []
     if any("Docker is not installed or not on PATH." in row["blockers"] for row in results):
         steps.append("Install or enable Docker before full Terminal-Bench or SWE-bench runs.")
-    if any(row["benchmark_id"] == "terminal_bench" and "Terminal-Bench CLI `tb` is not installed." in row["blockers"] for row in results):
+    if any(
+        row["benchmark_id"] == "terminal_bench" and "Terminal-Bench CLI `tb` is not installed." in row["blockers"]
+        for row in results
+    ):
         steps.append("Install Terminal-Bench CLI in an isolated environment, then rerun this setup dry-run.")
-    if any(row["benchmark_id"] == "swe_bench" and "SWE-bench Python package is not installed in the active Python environment." in row["blockers"] for row in results):
+    if any(
+        row["benchmark_id"] == "swe_bench"
+        and "SWE-bench Python package is not installed in the active Python environment." in row["blockers"]
+        for row in results
+    ):
         steps.append("Install SWE-bench from its checkout with pip install -e . after Docker is available.")
     if any(row["benchmark_id"] == "aider_polyglot" and not row["repo_present"] for row in results):
         steps.append("Run with --download to shallow-clone Aider before checking benchmark/benchmark.py.")
-    if any(row["benchmark_id"] == "aider_polyglot" and "Aider benchmark Python dependencies are not installed in the active environment." in row["blockers"] for row in results):
-        steps.append("Run python scripts/benchmark/aider_polyglot_smoke.py --execute to use the isolated uv-based Aider Polyglot smoke.")
+    if any(
+        row["benchmark_id"] == "aider_polyglot"
+        and "Aider benchmark Python dependencies are not installed in the active environment." in row["blockers"]
+        for row in results
+    ):
+        steps.append(
+            "Run python scripts/benchmark/aider_polyglot_smoke.py --execute to use the isolated uv-based Aider Polyglot smoke."
+        )
     if any(row["benchmark_id"] in {"terminal_bench", "swe_bench"} for row in results):
-        steps.append("Use the manual public-agentic-benchmarks GitHub workflow for Docker-heavy public harness setup instead of filling the local disk.")
+        steps.append(
+            "Use the manual public-agentic-benchmarks GitHub workflow for Docker-heavy public harness setup instead of filling the local disk."
+        )
     if not steps:
         steps.append("All public harness repos/tools are dry-run ready; wire GeoSeal as the agent runtime next.")
     return steps
@@ -213,7 +243,9 @@ def render_markdown(payload: dict[str, Any]) -> str:
     for row in payload["results"]:
         tool_ok = f"{sum(1 for item in row['tool_checks'] if item['ok'])}/{len(row['tool_checks'])}"
         blockers = "; ".join(row["blockers"]) if row["blockers"] else "none"
-        lines.append(f"| {row['display_name']} | `{row['repo_present']}` | `{tool_ok}` | `{row['ready_for_full_run']}` | {blockers} |")
+        lines.append(
+            f"| {row['display_name']} | `{row['repo_present']}` | `{tool_ok}` | `{row['ready_for_full_run']}` | {blockers} |"
+        )
     lines.extend(["", "## Next Steps", ""])
     lines.extend(f"- {step}" for step in payload["next_steps"])
     lines.extend(["", "## Sources", ""])
@@ -248,7 +280,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
-    parser.add_argument("--download", action="store_true", help="Shallow-clone public harness repos into external/benchmarks.")
+    parser.add_argument(
+        "--download", action="store_true", help="Shallow-clone public harness repos into external/benchmarks."
+    )
     parser.add_argument("--dry-run", action="store_true", help="Run available non-mutating help/list commands.")
     return parser
 
@@ -256,7 +290,19 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = build_parser().parse_args()
     report = build_report(args.config, args.output_root, download=args.download, run_dry=args.dry_run)
-    print(json.dumps({"ok": report["payload"]["ok"], "full_run_ready": report["payload"]["full_run_ready"], "json": report["json"], "markdown": report["markdown"], "next_steps": report["payload"]["next_steps"]}, indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "ok": report["payload"]["ok"],
+                "full_run_ready": report["payload"]["full_run_ready"],
+                "json": report["json"],
+                "markdown": report["markdown"],
+                "next_steps": report["payload"]["next_steps"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
     return 0 if report["payload"]["ok"] else 1
 
 

--- a/tests/benchmark/test_aider_polyglot_smoke.py
+++ b/tests/benchmark/test_aider_polyglot_smoke.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "benchmark" / "aider_polyglot_smoke.py"
 

--- a/tests/benchmark/test_public_agentic_cli_suite.py
+++ b/tests/benchmark/test_public_agentic_cli_suite.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "benchmark" / "public_agentic_cli_suite.py"
 CONFIG_PATH = ROOT / "config" / "eval" / "public_agentic_cli_suite.v1.json"
@@ -40,10 +39,7 @@ def test_public_agentic_cli_suite_required_tracks_and_claim_guardrails() -> None
         "swe_bench_verified_or_lite",
         "aider_polyglot",
     }.issubset(track_ids)
-    assert any(
-        "all-around best coding agent" in item
-        for item in config["claim_policy"]["forbidden_now"]
-    )
+    assert any("all-around best coding agent" in item for item in config["claim_policy"]["forbidden_now"])
     assert all(track.required_for_public_all_around_claim for track in tracks)
 
 

--- a/tests/benchmark/test_setup_public_agentic_benchmarks.py
+++ b/tests/benchmark/test_setup_public_agentic_benchmarks.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "benchmark" / "setup_public_agentic_benchmarks.py"
 CONFIG_PATH = ROOT / "config" / "eval" / "public_agentic_benchmark_sources.v1.json"


### PR DESCRIPTION
## Summary
- format public benchmark Python files missed by the merged benchmark PR
- use python3 inside the Aider Docker benchmark container

## Test evidence
- YAML parse: python -c import yaml/pathlib over public-agentic-benchmarks.yml
- Prior remote scored run reached Docker benchmark lane and failed only because python was unavailable in the container

## Rollback
- Revert this PR to restore the previous container command.