### PR TITLE
fix(benchmark): retry Aider Docker build

### DIFF
--- a/.github/workflows/public-agentic-benchmarks.yml
+++ b/.github/workflows/public-agentic-benchmarks.yml
@@ -84,7 +84,17 @@ jobs:
           cd external/benchmarks/aider
           mkdir -p tmp.benchmarks
           git clone --depth 1 https://github.com/Aider-AI/polyglot-benchmark.git tmp.benchmarks/polyglot-benchmark
-          ./benchmark/docker_build.sh
+          for attempt in 1 2 3; do
+            if ./benchmark/docker_build.sh; then
+              break
+            fi
+            if [ "${attempt}" = "3" ]; then
+              echo "Aider benchmark Docker build failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "Aider benchmark Docker build failed on attempt ${attempt}; retrying after transient registry/apt backoff"
+            sleep $((attempt * 20))
+          done
           docker run --rm \
             --memory=12g \
             --memory-swap=12g \


### PR DESCRIPTION
## Summary
- retry the public Aider benchmark Docker build up to three times
- absorbs transient apt/registry 504 failures seen in run 25270856986

## Test evidence
- YAML parse: python -c import yaml/pathlib over public-agentic-benchmarks.yml
- Remote failure diagnosed as deadsnakes/apt 504 during Docker build, before scoring began

## Rollback
- Revert this PR to return to single-attempt Docker build.