### PR TITLE
fix(benchmark): install Aider stats dependencies

### DIFF
--- a/.github/workflows/public-agentic-benchmarks.yml
+++ b/.github/workflows/public-agentic-benchmarks.yml
@@ -108,6 +108,7 @@ jobs:
 
           latest_dir="$(ls -td tmp.benchmarks/*--scbe-remote-scored | head -1)"
           mkdir -p ../../../artifacts/public_agentic_benchmark_setup/aider_polyglot_scored
+          python -m pip install -e '.[dev]'
           python benchmark/benchmark.py --stats "${latest_dir}" \
             | tee ../../../artifacts/public_agentic_benchmark_setup/aider_polyglot_scored/latest_stats.yml
           cp -R "${latest_dir}" ../../../artifacts/public_agentic_benchmark_setup/aider_polyglot_scored/run


### PR DESCRIPTION
## Summary
- install Aider dev dependencies on the runner before invoking benchmark.py --stats
- fixes the post-score ModuleNotFoundError for git after the benchmark itself completes

## Evidence
- Run 25270922097 reached scoring and produced pass_rate_1/pass_rate_2 output, then failed in the runner stats command because GitPython was missing
- YAML parse passed locally

## Rollback
- Revert this PR to return to the previous stats invocation.