### PR TITLE
fix(benchmark): export Aider scored diagnostics

### DIFF
--- a/.github/workflows/public-agentic-benchmarks.yml
+++ b/.github/workflows/public-agentic-benchmarks.yml
@@ -113,6 +113,17 @@ jobs:
           python benchmark/benchmark.py --stats "${latest_dir}" \
             | tee ../../../artifacts/public_agentic_benchmark_setup/aider_polyglot_scored/latest_stats.yml
           cp -R "${latest_dir}" ../../../artifacts/public_agentic_benchmark_setup/aider_polyglot_scored/run
+          diagnostics_dir="../../../artifacts/public_agentic_benchmark_setup/aider_polyglot_scored/diagnostics"
+          mkdir -p "${diagnostics_dir}"
+          find "${latest_dir}" -name ".aider.results.json" -print0 | while IFS= read -r -d '' result_file; do
+            rel_dir="$(dirname "${result_file#${latest_dir}/}")"
+            safe_name="$(echo "${rel_dir}" | tr '/\\' '__')"
+            cp "${result_file}" "${diagnostics_dir}/${safe_name}.results.json"
+            chat_file="$(dirname "${result_file}")/.aider.chat.history.md"
+            if [ -f "${chat_file}" ]; then
+              cp "${chat_file}" "${diagnostics_dir}/${safe_name}.chat.history.md"
+            fi
+          done
 
       - name: Terminal-Bench remote setup note
         if: ${{ inputs.track == 'terminal-bench-setup' }}

--- a/.github/workflows/public-agentic-benchmarks.yml
+++ b/.github/workflows/public-agentic-benchmarks.yml
@@ -106,6 +106,7 @@ jobs:
             aider-benchmark \
             bash -lc "cd /aider && pip install -e '.[dev]' && python3 benchmark/benchmark.py scbe-remote-scored --model '${AIDER_MODEL}' --edit-format '${AIDER_EDIT_FORMAT}' --threads 1 --num-tests '${AIDER_NUM_TESTS}' --exercises-dir /benchmarks/polyglot-benchmark"
 
+          sudo chown -R "$(id -u):$(id -g)" "$PWD" tmp.benchmarks
           latest_dir="$(ls -td tmp.benchmarks/*--scbe-remote-scored | head -1)"
           mkdir -p ../../../artifacts/public_agentic_benchmark_setup/aider_polyglot_scored
           python -m pip install -e '.[dev]'

--- a/docs/ops/PUBLIC_AGENTIC_BENCHMARK_STATUS_2026-05-03.md
+++ b/docs/ops/PUBLIC_AGENTIC_BENCHMARK_STATUS_2026-05-03.md
@@ -1,0 +1,66 @@
+# Public Agentic Benchmark Status - 2026-05-03
+
+## Current Result
+
+The public GitHub Actions benchmark lane is live and has completed one remote scored Aider Polyglot smoke run.
+
+- Workflow: `Public Agentic Benchmarks`
+- Run: `25271257631`
+- URL: `https://github.com/issdandavis/SCBE-AETHERMOORE/actions/runs/25271257631`
+- Artifact: `public-agentic-benchmarks-aider-polyglot-scored-small`
+- Artifact URL: `https://github.com/issdandavis/SCBE-AETHERMOORE/actions/runs/25271257631/artifacts/6768448249`
+- Track: `aider-polyglot-scored-small`
+- Model: `gpt-4o-mini`
+- Edit format: `whole`
+- Test cases sampled: `1`
+- Aider commit: `3ec8ec5`
+
+## Score
+
+The first scored smoke completed successfully as infrastructure, but did not solve the sampled task.
+
+```text
+pass_rate_1: 0.0
+pass_rate_2: 0.0
+pass_num_1: 0
+pass_num_2: 0
+percent_cases_well_formed: 100.0
+error_outputs: 2
+num_malformed_responses: 0
+syntax_errors: 0
+indentation_errors: 0
+test_timeouts: 0
+total_tests: 225
+```
+
+The sampled task was Rust `simple-cipher`. The uploaded source still contained `todo!()` bodies after the run, and the tests failed `0 passed; 23 failed`.
+
+## Interpretation
+
+This is a real public benchmark plumbing milestone, not a capability win yet.
+
+What is proven:
+
+- GitHub Actions can provision Docker and execute the Aider Polyglot scorer remotely.
+- The workflow can upload a score artifact.
+- The lane can run without using local disk-heavy Docker.
+
+What is not proven:
+
+- GeoSeal or Sacred Tongues improves the public benchmark score.
+- The selected model/edit-format can solve the sampled task.
+- The one-case result generalizes to the 225-case suite.
+
+## Fix Landed After Run
+
+The first artifact omitted hidden Aider diagnostics such as `.aider.results.json` and `.aider.chat.history.md`. The workflow now copies those into a visible `diagnostics/` folder before upload so future runs expose model/API/edit failure details.
+
+## Next Benchmark Step
+
+Run another one-case scored variant after the diagnostics patch lands. The highest-value cheap comparison is:
+
+```bash
+gh workflow run public-agentic-benchmarks.yml --ref main -f track=aider-polyglot-scored-small -f num_tests=1 -f model=gpt-4o-mini -f edit_format=diff
+```
+
+If that still leaves the source unchanged, the next fix is provider/model invocation diagnostics. If it edits but fails tests, the next fix is a GeoSeal coding adapter or prompt wrapper, then a 3-case comparison against raw Aider.

--- a/tests/benchmark/test_public_agentic_benchmark_workflow.py
+++ b/tests/benchmark/test_public_agentic_benchmark_workflow.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "public-agentic-benchmarks.yml"
+
+
+def test_scored_aider_workflow_exports_visible_diagnostics() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "aider_polyglot_scored/diagnostics" in workflow
+    assert 'find "${latest_dir}" -name ".aider.results.json"' in workflow
+    assert ".chat.history.md" in workflow
+    assert "${safe_name}.results.json" in workflow


### PR DESCRIPTION
## Summary
- export hidden Aider .aider.results.json and .aider.chat.history.md files into visible scored benchmark diagnostics artifacts
- document the first successful public scored benchmark run and its caveats
- add a workflow regression test for diagnostics export

## Test evidence
- python -m pytest tests\\benchmark\\test_public_agentic_benchmark_workflow.py tests\\benchmark\\test_aider_polyglot_smoke.py -q

## Notes
- The first scored run proved remote benchmark plumbing, but scored 0/1 on Rust simple-cipher. This patch makes the next run diagnosable.