### PR TITLE
fix(benchmark): avoid flaky Aider deadsnakes Docker build

### DIFF
--- a/.github/workflows/public-agentic-benchmarks.yml
+++ b/.github/workflows/public-agentic-benchmarks.yml
@@ -82,6 +82,49 @@ jobs:
           rm -rf external/benchmarks/aider
           git clone --depth 1 https://github.com/Aider-AI/aider.git external/benchmarks/aider
           cd external/benchmarks/aider
+          python3 - <<'PY'
+          from pathlib import Path
+
+          dockerfile = Path("benchmark/Dockerfile")
+          text = dockerfile.read_text(encoding="utf-8")
+          text = text.replace("FROM buildpack-deps:jammy", "FROM buildpack-deps:noble")
+          old = """# Install Python 3.11
+          RUN apt-get update && apt-get install -y \\
+              software-properties-common \\
+              cmake \\
+              libboost-all-dev \\
+              && add-apt-repository ppa:deadsnakes/ppa \\
+              && apt-get update \\
+              && apt-get install -y \\
+              python3.11 \\
+              python3.11-venv \\
+              python3.11-dev \\
+              python3-pip \\
+              ca-certificates-java \\
+              openjdk-21-jdk \\
+              libtbb-dev \\
+              && rm -rf /var/lib/apt/lists/*
+
+          # Make python3.11 the default python3
+          RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+          """
+          new = """# Use Ubuntu noble's native Python to avoid flaky Launchpad/deadsnakes PPA resolution.
+          RUN apt-get update && apt-get install -y \\
+              cmake \\
+              libboost-all-dev \\
+              python3 \\
+              python3-venv \\
+              python3-dev \\
+              python3-pip \\
+              ca-certificates-java \\
+              openjdk-21-jdk \\
+              libtbb-dev \\
+              && rm -rf /var/lib/apt/lists/*
+          """
+          if old not in text:
+              raise SystemExit("Aider benchmark Dockerfile changed; refusing silent patch")
+          dockerfile.write_text(text.replace(old, new), encoding="utf-8")
+          PY
           mkdir -p tmp.benchmarks
           git clone --depth 1 https://github.com/Aider-AI/polyglot-benchmark.git tmp.benchmarks/polyglot-benchmark
           for attempt in 1 2 3; do

--- a/tests/benchmark/test_public_agentic_benchmark_workflow.py
+++ b/tests/benchmark/test_public_agentic_benchmark_workflow.py
@@ -13,3 +13,12 @@ def test_scored_aider_workflow_exports_visible_diagnostics() -> None:
     assert 'find "${latest_dir}" -name ".aider.results.json"' in workflow
     assert ".chat.history.md" in workflow
     assert "${safe_name}.results.json" in workflow
+
+
+def test_scored_aider_workflow_patches_flaky_deadsnakes_dockerfile() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "FROM buildpack-deps:noble" in workflow
+    assert "deadsnakes/ppa" in workflow
+    assert "Aider benchmark Dockerfile changed; refusing silent patch" in workflow
+    assert "Ubuntu noble's native Python" in workflow


### PR DESCRIPTION
## Summary
- patch the cloned Aider benchmark Dockerfile to use Ubuntu noble native Python instead of Launchpad/deadsnakes
- keep the patch fail-fast if upstream Aider changes the Dockerfile shape
- add a workflow regression test for this remote benchmark hardening

## Test evidence
- black --target-version py311 --line-length 120 tests\\benchmark\\test_public_agentic_benchmark_workflow.py
- python -m pytest tests\\benchmark\\test_public_agentic_benchmark_workflow.py tests\\benchmark\\test_aider_polyglot_smoke.py -q
- git diff --check

## Context
- Run 25278787159 failed before scoring because add-apt-repository ppa:deadsnakes/ppa timed out against Launchpad.