### PR TITLE
fix(benchmark): isolate Aider noble Python installs

### DIFF
--- a/.github/workflows/public-agentic-benchmarks.yml
+++ b/.github/workflows/public-agentic-benchmarks.yml
@@ -123,7 +123,21 @@ jobs:
           """
           if old not in text:
               raise SystemExit("Aider benchmark Dockerfile changed; refusing silent patch")
-          dockerfile.write_text(text.replace(old, new), encoding="utf-8")
+          text = text.replace(old, new)
+          old_pip = """COPY . /aider
+          RUN pip3 install --no-cache-dir --upgrade pip uv
+          RUN uv pip install --system --no-cache-dir -e /aider[dev]
+          """
+          new_pip = """RUN python3 -m venv /opt/aider-venv
+          ENV PATH="/opt/aider-venv/bin:$PATH"
+
+          COPY . /aider
+          RUN pip install --no-cache-dir --upgrade pip uv
+          RUN uv pip install --no-cache-dir -e /aider[dev]
+          """
+          if old_pip not in text:
+              raise SystemExit("Aider benchmark Dockerfile pip install block changed; refusing silent patch")
+          dockerfile.write_text(text.replace(old_pip, new_pip), encoding="utf-8")
           PY
           mkdir -p tmp.benchmarks
           git clone --depth 1 https://github.com/Aider-AI/polyglot-benchmark.git tmp.benchmarks/polyglot-benchmark

--- a/tests/benchmark/test_public_agentic_benchmark_workflow.py
+++ b/tests/benchmark/test_public_agentic_benchmark_workflow.py
@@ -22,3 +22,14 @@ def test_scored_aider_workflow_patches_flaky_deadsnakes_dockerfile() -> None:
     assert "deadsnakes/ppa" in workflow
     assert "Aider benchmark Dockerfile changed; refusing silent patch" in workflow
     assert "Ubuntu noble's native Python" in workflow
+
+
+def test_scored_aider_workflow_uses_venv_for_noble_pep668() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python3 -m venv /opt/aider-venv" in workflow
+    assert 'ENV PATH="/opt/aider-venv/bin:$PATH"' in workflow
+    assert "RUN pip install --no-cache-dir --upgrade pip uv" in workflow
+    assert "RUN uv pip install --no-cache-dir -e /aider[dev]" in workflow
+    assert "--system --no-cache-dir -e /aider[dev]" in workflow
+    assert "Aider benchmark Dockerfile pip install block changed; refusing silent patch" in workflow


### PR DESCRIPTION
## Summary
- patch the cloned Aider benchmark Dockerfile to install Python packages inside `/opt/aider-venv` on Ubuntu noble
- keep the previous deadsnakes/Launchpad avoidance patch
- add workflow regression coverage for the noble PEP 668 pip failure

## Test evidence
- `python -m pytest tests\benchmark\test_public_agentic_benchmark_workflow.py tests\benchmark\test_aider_polyglot_smoke.py -q` -> 6 passed
- `black --target-version py311 --line-length 120 tests\benchmark\test_public_agentic_benchmark_workflow.py` -> unchanged
- `git diff --check` -> no whitespace errors

## Rollback
- Revert this PR to restore the prior noble Dockerfile patch behavior.