### PR TITLE
fix(security): make GitHub AI workflows local-only

### DIFF
--- a/.github/workflows/ai-issue-summary.yml
+++ b/.github/workflows/ai-issue-summary.yml
@@ -5,34 +5,45 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   summarize:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      issues: write
-      models: read
     steps:
-      - name: Summarize issue with AI
-        uses: actions/ai-inference@v1
-        id: summary
-        with:
-          model: openai/gpt-4o-mini
-          system-prompt: |
-            You are a helpful assistant that analyzes GitHub issues for the SCBE-AETHERMOORE project — a post-quantum cryptographic AI system with a Sacred Tongue protocol, Spiralverse game engine, and multi-modal training pipeline.
-            Summarize the issue in 2-3 sentences. Identify: 1) the component affected (crypto, game, CI, API, docs, etc.), 2) severity (bug/enhancement/question), 3) suggested next steps.
-            Be concise and technical.
-          prompt: "Please summarize this GitHub issue:\n\nTitle: ${{ github.event.issue.title }}\n\nBody: ${{ github.event.issue.body }}"
-      - name: Comment with AI summary
-        uses: actions/github-script@v7
+      - name: Record deterministic issue triage summary
         env:
-          AI_RESPONSE: ${{ steps.summary.outputs.response }}
-        with:
-          script: |
-            const body = `🤖 **AI Issue Summary**\n\n${process.env.AI_RESPONSE}\n\n---\n*Generated automatically by the AI Issue Summary workflow*`;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
-            })
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR_ASSOCIATION: ${{ github.event.issue.author_association }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          read -r title_chars body_chars < <(python - <<'PY'
+          import json
+          import os
+
+          with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as handle:
+              event = json.load(handle)
+          issue = event.get("issue") or {}
+          title = str(issue.get("title") or "")
+          body = str(issue.get("body") or "")
+          print(len(title.encode("utf-8")), len(body.encode("utf-8")))
+          PY
+          )
+
+          {
+            echo "## Deterministic Issue Intake"
+            echo
+            echo "- Issue: #${ISSUE_NUMBER}"
+            echo "- Author association: ${ISSUE_AUTHOR_ASSOCIATION}"
+            echo "- Title characters: ${title_chars}"
+            echo "- Body characters: ${body_chars}"
+            echo "- Public comment written: no"
+            echo "- AI model invoked: no"
+            echo
+            echo "Untrusted issue text is intentionally not sent to an AI model and not mirrored"
+            echo "back into an authenticated repository comment."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,41 +3,48 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+permissions:
+  contents: read
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    name: claude-review
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: read
-      id-token: write
-
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 2
 
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+      - name: Local deterministic review gate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          echo "## Local deterministic review gate" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+          echo "- External AI invoked: no" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Repository comment written: no" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Base: \`${base}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Head: \`${head}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+
+          git diff --check "$base" "$head"
+          git diff --name-only "$base" "$head" > changed-files.txt
+
+          if git grep -nE '^(<<<<<<<|>>>>>>>)' -- \
+            ':!node_modules/**' \
+            ':!artifacts/**' \
+            ':!training-data/**' \
+            ':!**/target/**'; then
+            echo "Conflict markers found." >&2
+            exit 1
+          fi
+
+          file_count="$(wc -l < changed-files.txt | tr -d ' ')"
+          echo "- Changed files: ${file_count}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 jobs:
   claude:
     if: |
@@ -18,33 +21,18 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+    timeout-minutes: 5
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+      - name: Record local-only Claude handoff
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Claude handoff disabled in GitHub Actions"
+            echo
+            echo "- External AI invoked: no"
+            echo "- Repository comment written: no"
+            echo "- Reason: keep untrusted GitHub text out of third-party AI action write paths."
+            echo
+            echo "Use the local SCBE agent transit workflow for AI review instead."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/daily-dep-audit.yml
+++ b/.github/workflows/daily-dep-audit.yml
@@ -98,7 +98,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Create alert
+      - name: Update rolling dependency alert
         uses: actions/github-script@v7
         env:
           NPM_CRIT: ${{ needs.npm-audit.outputs.critical }}
@@ -108,10 +108,43 @@ jobs:
         with:
           script: |
             const today = new Date().toISOString().slice(0, 10);
+            const title = 'Dependency Vulnerabilities - rolling';
+            const body = [
+              '## Daily Dependency Audit',
+              '',
+              `Last run: ${today}`,
+              '',
+              '| Package Manager | Critical | High | Total |',
+              '|---|---:|---:|---:|',
+              `| npm | ${process.env.NPM_CRIT} | ${process.env.NPM_HIGH} | ${process.env.NPM_TOTAL} |`,
+              `| pip | — | — | ${process.env.PIP_VULNS} vulnerable |`,
+              '',
+              'Run `npm audit --json` and `pip-audit -r requirements.txt` locally before promoting dependency changes.',
+              '',
+              '---',
+              '*Automated by daily-dep-audit. This workflow updates one rolling issue instead of opening duplicate daily issues.*',
+            ].join('\n');
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'dependencies,automated',
+              per_page: 100,
+            });
+            const rolling = existing.data.find((issue) => issue.title === title);
+            if (rolling) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: rolling.number,
+                body,
+              });
+              return;
+            }
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Dependency Vulnerabilities - ${today}`,
-              body: `## Daily Dependency Audit\n\n| Package Manager | Critical | High | Total |\n|---|---|---|---|\n| npm | ${process.env.NPM_CRIT} | ${process.env.NPM_HIGH} | ${process.env.NPM_TOTAL} |\n| pip | — | — | ${process.env.PIP_VULNS} vulnerable |\n\nRun \`npm audit fix\` and \`pip-audit --fix\` to resolve.\n\n---\n*Automated by daily-dep-audit*`,
+              title,
+              body,
               labels: ['dependencies', 'automated'],
             });

--- a/tests/security/test_ai_issue_summary_workflow.py
+++ b/tests/security/test_ai_issue_summary_workflow.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "ai-issue-summary.yml"
+
+
+def test_ai_issue_summary_has_no_ai_write_path() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "actions/ai-inference" not in text
+    assert "models: read" not in text
+    assert "issues: write" not in text
+    assert "createComment" not in text
+    assert "github.rest.issues.createComment" not in text
+
+
+def test_ai_issue_summary_records_only_deterministic_metadata() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "AI model invoked: no" in text
+    assert "Public comment written: no" in text
+    assert "Title characters" in text
+    assert "Body characters" in text
+    assert "Please summarize this GitHub issue" not in text

--- a/tests/security/test_independent_github_workflows.py
+++ b/tests/security/test_independent_github_workflows.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _workflow_text(name: str) -> str:
+    path = WORKFLOWS / name
+    return path.read_text(encoding="utf-8")
+
+
+def test_claude_workflows_are_local_only_and_do_not_call_external_ai_actions() -> None:
+    for name in ("claude.yml", "claude-code-review.yml"):
+        text = _workflow_text(name)
+        yaml.safe_load(text)
+
+        assert "anthropics/claude-code-action" not in text
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in text
+        assert "id-token: write" not in text
+        assert "pull-requests: write" not in text
+        assert "External AI invoked: no" in text
+
+
+def test_daily_dependency_audit_uses_one_rolling_issue_not_daily_issue_spam() -> None:
+    text = _workflow_text("daily-dep-audit.yml")
+    yaml.safe_load(text)
+
+    assert "Dependency Vulnerabilities - rolling" in text
+    assert "Dependency Vulnerabilities - ${today}" not in text
+    assert "issues.update" in text
+    assert "updates one rolling issue" in text


### PR DESCRIPTION
## Summary
- Replace AI issue summary model/comment path with deterministic metadata-only issue intake
- Replace external Claude PR/comment workflows with local-only summary/check gates
- Change dependency audit to update one rolling issue instead of opening duplicate daily vulnerability issues
- Add regression tests so these workflows do not drift back to third-party AI write paths

## Verification
- python -m pytest tests/security/test_ai_issue_summary_workflow.py tests/security/test_independent_github_workflows.py -q
- YAML parse check for ai-issue-summary.yml, claude.yml, claude-code-review.yml, daily-dep-audit.yml
- rg check: no anthropics/claude-code-action, CLAUDE_CODE_OAUTH_TOKEN, actions/ai-inference, or models: read in .github/workflows
