### PR TITLE
style(vercel): format launch bridge test

### DIFF
--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 


### PR DESCRIPTION
## Summary
- apply Black formatting to the Vercel launch bridge test added in PR #1385

## Test evidence
- `python -m black --check tests/test_vercel_launch_bridge.py`
- `python -m pytest tests/test_vercel_launch_bridge.py -q` -> 3 passed

## Rollback
- Revert this PR if needed; it only removes an extra blank line.