### PR TITLE
fix(site): add customer offer and manual routes

### DIFF
--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCBE Offers | AetherMoore</title>
+  <meta name="description" content="Customer-ready SCBE offers, checkout links, and delivery/support paths.">
+  <link rel="canonical" href="https://aethermoore.com/offers/">
+  <style>
+    body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #0b0d12; color: #f2f0ea; line-height: 1.55; }
+    main { width: min(980px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0; }
+    a { color: inherit; }
+    .nav { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 40px; color: #a3acb9; }
+    h1 { font-size: clamp(36px, 7vw, 72px); line-height: 0.95; margin: 0 0 18px; }
+    .lead { color: #a3acb9; max-width: 760px; font-size: 18px; }
+    .grid { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); margin-top: 32px; }
+    .card { border: 1px solid rgba(214,167,86,.2); background: #11161f; border-radius: 8px; padding: 22px; }
+    .price { color: #d6a756; font-weight: 800; margin: 10px 0; }
+    .btn { display: inline-block; margin-top: 12px; padding: 11px 14px; border-radius: 6px; background: #d6a756; color: #14110c; font-weight: 800; text-decoration: none; }
+    .secondary { background: transparent; color: #f2f0ea; border: 1px solid rgba(255,255,255,.16); }
+  </style>
+</head>
+<body>
+  <main>
+    <nav class="nav" aria-label="Offers navigation">
+      <a href="../index.html">Home</a>
+      <a href="../product-manual/index.html">Manuals</a>
+      <a href="../product-manual/delivery-and-access.html">Delivery + Access</a>
+      <a href="../support.html">Support</a>
+    </nav>
+    <h1>SCBE customer offers</h1>
+    <p class="lead">These are the current customer-ready SCBE products. Checkout is handled by Stripe-hosted payment links; delivery and recovery paths are documented in the buyer manual.</p>
+    <section class="grid" aria-label="SCBE offers">
+      <article class="card">
+        <h2>SCBE AI Governance Toolkit</h2>
+        <p>Templates, decision records, setup guidance, buyer manual, and support route for governed AI workflows.</p>
+        <div class="price">$29 one-time</div>
+        <a class="btn" href="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06" target="_blank" rel="noopener">Buy Toolkit</a>
+      </article>
+      <article class="card">
+        <h2>SCBE AI Security Training Vault</h2>
+        <p>Training data, projector weights, benchmark suite, and notebook materials for governed AI model work.</p>
+        <div class="price">$29 one-time</div>
+        <a class="btn" href="https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g" target="_blank" rel="noopener">Buy Training Vault</a>
+      </article>
+      <article class="card">
+        <h2>Delivery or access help</h2>
+        <p>If a buyer does not receive the package link or a manual path fails, use the delivery page first and then email support.</p>
+        <a class="btn secondary" href="../product-manual/delivery-and-access.html">Delivery + Access</a>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/product-manual/ai-governance-toolkit.html
+++ b/docs/product-manual/ai-governance-toolkit.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCBE AI Governance Toolkit Guide</title>
+  <meta name="description" content="Buyer guide for the SCBE AI Governance Toolkit.">
+  <style>body{margin:0;font-family:Inter,system-ui,sans-serif;background:#0b0d12;color:#f2f0ea;line-height:1.6}main{width:min(900px,calc(100% - 32px));margin:0 auto;padding:48px 0}a{color:#d6a756}.nav{display:flex;gap:16px;flex-wrap:wrap;margin-bottom:40px}.panel{border:1px solid rgba(214,167,86,.2);background:#11161f;border-radius:8px;padding:20px;margin:18px 0}</style>
+</head>
+<body><main><nav class="nav"><a href="../index.html">Home</a><a href="index.html">Manuals</a><a href="delivery-and-access.html">Delivery + Access</a><a href="../support.html">Support</a></nav><h1>SCBE AI Governance Toolkit guide</h1><section class="panel"><p>The toolkit is the buyer route for governed AI workflow templates, decision records, and setup guidance. If the package link is missing, use <a href="delivery-and-access.html">Delivery + Access</a>.</p></section></main></body>
+</html>

--- a/docs/product-manual/content-spin-engine.html
+++ b/docs/product-manual/content-spin-engine.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Content Spin Engine</title><style>body{margin:0;font-family:Inter,system-ui,sans-serif;background:#0b0d12;color:#f2f0ea;line-height:1.6}main{width:min(900px,calc(100% - 32px));margin:0 auto;padding:48px 0}a{color:#d6a756}</style></head>
+<body><main><p><a href="index.html">Manuals</a> / <a href="delivery-and-access.html">Delivery + Access</a></p><h1>Content Spin Engine</h1><p>Buyer route for content workflow materials. If access is missing, email <a href="mailto:ai@aethermoore.com?subject=SCBE%20Delivery%20Issue">ai@aethermoore.com</a>.</p></main></body>
+</html>

--- a/docs/product-manual/delivery-and-access.html
+++ b/docs/product-manual/delivery-and-access.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCBE Delivery and Access</title>
+  <meta name="description" content="Delivery and access recovery instructions for SCBE buyers.">
+  <link rel="canonical" href="https://aethermoore.com/product-manual/delivery-and-access.html">
+  <style>
+    body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #0b0d12; color: #f2f0ea; line-height: 1.6; }
+    main { width: min(900px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0; }
+    a { color: #d6a756; }
+    .nav { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 40px; }
+    h1 { font-size: clamp(34px, 6vw, 64px); margin: 0 0 16px; }
+    .panel { border: 1px solid rgba(214,167,86,.2); background: #11161f; border-radius: 8px; padding: 20px; margin: 18px 0; }
+    code { color: #d6a756; }
+  </style>
+</head>
+<body>
+  <main>
+    <nav class="nav" aria-label="Delivery navigation">
+      <a href="../index.html">Home</a>
+      <a href="index.html">Manuals</a>
+      <a href="../offers/index.html">Offers</a>
+      <a href="../support.html">Support</a>
+    </nav>
+    <h1>Delivery and access</h1>
+    <p>Use this page when a buyer paid but cannot find the package, access note, manual, or support route.</p>
+    <section class="panel">
+      <h2>Fast recovery path</h2>
+      <ol>
+        <li>Check the purchase email used at Stripe checkout.</li>
+        <li>Search for <code>SCBE</code>, <code>AetherMoore</code>, and <code>Stripe</code>.</li>
+        <li>If the delivery link is missing or broken, email <a href="mailto:ai@aethermoore.com?subject=SCBE%20Delivery%20Issue">ai@aethermoore.com</a>.</li>
+        <li>Include product name, purchase email, receipt ID if available, and the broken URL if one exists.</li>
+      </ol>
+    </section>
+    <section class="panel">
+      <h2>Current product routes</h2>
+      <ul>
+        <li><a href="ai-governance-toolkit.html">SCBE AI Governance Toolkit guide</a></li>
+        <li><a href="user-guide.html">SCBE Training Vault user guide</a></li>
+        <li><a href="../offers/index.html">Customer offers and checkout links</a></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/product-manual/hydra-agent-templates.html
+++ b/docs/product-manual/hydra-agent-templates.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>HYDRA Agent Templates</title><style>body{margin:0;font-family:Inter,system-ui,sans-serif;background:#0b0d12;color:#f2f0ea;line-height:1.6}main{width:min(900px,calc(100% - 32px));margin:0 auto;padding:48px 0}a{color:#d6a756}</style></head>
+<body><main><p><a href="index.html">Manuals</a> / <a href="delivery-and-access.html">Delivery + Access</a></p><h1>HYDRA Agent Templates</h1><p>Buyer route for HYDRA-style agent template materials. If access is missing, email <a href="mailto:ai@aethermoore.com?subject=SCBE%20Delivery%20Issue">ai@aethermoore.com</a>.</p></main></body>
+</html>

--- a/docs/product-manual/index.html
+++ b/docs/product-manual/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCBE Product Manual</title>
+  <meta name="description" content="Buyer manual and access paths for SCBE customer products.">
+  <link rel="canonical" href="https://aethermoore.com/product-manual/">
+  <style>
+    body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #0b0d12; color: #f2f0ea; line-height: 1.55; }
+    main { width: min(980px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0; }
+    a { color: #d6a756; }
+    .nav { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 40px; }
+    h1 { font-size: clamp(34px, 6vw, 64px); margin: 0 0 16px; }
+    .grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); margin-top: 28px; }
+    .card { border: 1px solid rgba(214,167,86,.2); background: #11161f; border-radius: 8px; padding: 20px; }
+  </style>
+</head>
+<body>
+  <main>
+    <nav class="nav" aria-label="Manual navigation">
+      <a href="../index.html">Home</a>
+      <a href="../offers/index.html">Offers</a>
+      <a href="delivery-and-access.html">Delivery + Access</a>
+      <a href="../support.html">Support</a>
+    </nav>
+    <h1>SCBE product manual</h1>
+    <p>Start here after purchase. The manual routes buyers to delivery recovery, setup instructions, and the specific product page they bought.</p>
+    <section class="grid">
+      <article class="card"><h2>Delivery + Access</h2><p>Use this when a receipt arrived but a package link, access note, or manual path is missing.</p><a href="delivery-and-access.html">Open delivery guide</a></article>
+      <article class="card"><h2>AI Governance Toolkit</h2><p>Buyer orientation for the governed AI toolkit package.</p><a href="ai-governance-toolkit.html">Open toolkit guide</a></article>
+      <article class="card"><h2>Training Vault</h2><p>Buyer orientation for training data, benchmark, and notebook materials.</p><a href="user-guide.html">Open user guide</a></article>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/product-manual/n8n-workflow-pack.html
+++ b/docs/product-manual/n8n-workflow-pack.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>n8n Workflow Pack</title><style>body{margin:0;font-family:Inter,system-ui,sans-serif;background:#0b0d12;color:#f2f0ea;line-height:1.6}main{width:min(900px,calc(100% - 32px));margin:0 auto;padding:48px 0}a{color:#d6a756}</style></head>
+<body><main><p><a href="index.html">Manuals</a> / <a href="delivery-and-access.html">Delivery + Access</a></p><h1>n8n Workflow Pack</h1><p>Buyer route for n8n workflow materials. If access is missing, email <a href="mailto:ai@aethermoore.com?subject=SCBE%20Delivery%20Issue">ai@aethermoore.com</a>.</p></main></body>
+</html>

--- a/docs/product-manual/user-guide.html
+++ b/docs/product-manual/user-guide.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCBE Training Vault User Guide</title>
+  <meta name="description" content="User guide for the SCBE AI Security Training Vault.">
+  <style>body{margin:0;font-family:Inter,system-ui,sans-serif;background:#0b0d12;color:#f2f0ea;line-height:1.6}main{width:min(900px,calc(100% - 32px));margin:0 auto;padding:48px 0}a{color:#d6a756}.nav{display:flex;gap:16px;flex-wrap:wrap;margin-bottom:40px}.panel{border:1px solid rgba(214,167,86,.2);background:#11161f;border-radius:8px;padding:20px;margin:18px 0}</style>
+</head>
+<body><main><nav class="nav"><a href="../index.html">Home</a><a href="index.html">Manuals</a><a href="delivery-and-access.html">Delivery + Access</a><a href="../support.html">Support</a></nav><h1>SCBE Training Vault user guide</h1><section class="panel"><p>The Training Vault is the buyer route for SCBE training data, benchmark materials, and notebook-oriented model work. If the package link is missing, use <a href="delivery-and-access.html">Delivery + Access</a>.</p></section></main></body>
+</html>


### PR DESCRIPTION
## Summary
- add repo-backed customer offer index at `docs/offers/index.html`
- add repo-backed buyer manual and delivery/access routes under `docs/product-manual/`
- keep checkout handoff on live Stripe-hosted payment links and support recovery on `ai@aethermoore.com`

## Test evidence
- `python C:\Users\issda\.codex\skills\scbe-checkout-launch-ops\scripts\audit_checkout_surfaces.py C:\Users\issda\SCBE-AETHERMOORE-main-customer-launch\docs` -> 0 blocking findings
- local relative-link check for new customer routes -> ok
- live Stripe links return `Stripe Checkout` for Toolkit and Training Vault

## Launch impact
This makes the actual customer path repo-backed: offers -> Stripe checkout -> buyer manual / delivery recovery / support.

## Rollback
Revert this PR to remove the static customer offer/manual fallback pages.