### PR TITLE
fix(vercel): restrict paid preview builds

### DIFF
--- a/docs/deployment/VERCEL_COST_GUARD.md
+++ b/docs/deployment/VERCEL_COST_GUARD.md
@@ -1,0 +1,37 @@
+# Vercel Cost Guard
+
+The Vercel project `scbe-agent-bridge-vercel` is kept as a paid-service test surface, not the primary customer website.
+
+Default customer delivery stays on GitHub Pages at `https://aethermoore.com/`. Vercel should only spend build CPU when a deployment is tied to production, launch validation, or an explicit customer/test branch.
+
+## Branches Allowed To Build
+
+The repository `vercel.json` allows Vercel builds only for:
+
+- `main`
+- `launch/*`
+- `vercel-test/*`
+- `customer/*`
+- `fix/launch-*`
+
+All other branches are ignored by Vercel's Ignored Build Step. This intentionally blocks routine automation branches, dependency branches, training branches, and research branches from burning preview build CPU.
+
+## Current Production Project
+
+- Team: `issac-davis-projects`
+- Project: `scbe-agent-bridge-vercel`
+- Project ID: `prj_9nwqtAmDwlZIOGUKSoIbkdiEttdC`
+- Production URL: `https://scbe-agent-bridge-vercel.vercel.app`
+
+## Operator Checks
+
+Use the Vercel CLI with the existing logged-in account:
+
+```powershell
+npx --yes vercel@latest whoami
+npx --yes vercel@latest project inspect scbe-agent-bridge-vercel --scope issac-davis-projects
+npx --yes vercel@latest usage --scope issac-davis-projects --group-by project
+npx --yes vercel@latest usage --scope issac-davis-projects --breakdown daily
+```
+
+Do not buy credits or enable paid extras unless there is a real customer need.

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in automation/*|dependabot/*) exit 0 ;; *) exit 1 ;; esac",
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in main|launch/*|vercel-test/*|customer/*|fix/launch-*) exit 1 ;; *) exit 0 ;; esac",
   "builds": [
     {
       "src": "api/agent/*.js",


### PR DESCRIPTION
## Summary
- Tighten Vercel Ignored Build Step so only main and explicit launch/customer/test branches build
- Document the Vercel cost guard and operator usage checks

## Cost behavior
- Builds allowed: main, launch/*, vercel-test/*, customer/*, fix/launch-*
- Everything else is ignored by Vercel, including automation, dependabot, training, research, and ordinary feature/chore branches

## Verification
- Vercel project setting updated live through CLI API
- vercel.json parses as valid JSON
- Vercel production endpoint returns 200 on GET
- aethermoore.com customer routes return 200
