### PR TITLE
fix(product): include promised toolkit buyer templates

### DIFF
--- a/scripts/package_products.py
+++ b/scripts/package_products.py
@@ -28,6 +28,26 @@ DEFAULT_OUTPUT = REPO_ROOT / "products" / "packaged"
 # ---- Product: AI Governance Toolkit ----
 
 TOOLKIT_FILES = [
+    # Buyer-facing start guide
+    ("deliverables/SCBE_Production_Pack/BUYER_START_GUIDE.md", "BUYER_START_GUIDE.md"),
+    ("deliverables/SCBE_Production_Pack/packages/ai-governance-toolkit/README.md", "quickstart/README.md"),
+    # Practical buyer templates promised on the sales/manual pages
+    (
+        "deliverables/SCBE_Production_Pack/packages/ai-governance-toolkit/decision-record-template.md",
+        "templates/decision-record-template.md",
+    ),
+    (
+        "deliverables/SCBE_Production_Pack/packages/ai-governance-toolkit/threshold-worksheet.md",
+        "templates/threshold-worksheet.md",
+    ),
+    (
+        "deliverables/SCBE_Production_Pack/packages/ai-governance-toolkit/pilot-checklist.md",
+        "templates/pilot-checklist.md",
+    ),
+    (
+        "deliverables/SCBE_Production_Pack/packages/ai-governance-toolkit/review-notes-template.md",
+        "templates/review-notes-template.md",
+    ),
     # Architecture docs
     ("docs/specs/LAYER_INDEX.md", "docs/LAYER_INDEX.md"),
     ("docs/specs/SYSTEM_ARCHITECTURE.md", "docs/SYSTEM_ARCHITECTURE.md"),
@@ -50,14 +70,21 @@ Thank you for purchasing the AI Governance Toolkit from AetherMoore.
 ## What's Inside
 
 - `docs/` — Complete 14-layer architecture documentation
+- `BUYER_START_GUIDE.md` — First ten minutes and support path
+- `templates/decision-record-template.md` — Capture a governed decision
+- `templates/threshold-worksheet.md` — Set first allow/quarantine/deny thresholds
+- `templates/pilot-checklist.md` — Run one small pilot workflow
+- `templates/review-notes-template.md` — Record review findings
 - `templates/` — Governance configuration templates (YAML/JSON)
-- `quickstart/` — Demo flow to get started immediately
+- `quickstart/` — Package README and demo flow
 
 ## Quick Start
 
-1. Read `docs/LAYER_INDEX.md` for the full 14-layer pipeline overview
-2. Copy `templates/scbe_core_axioms.yaml` into your project
-3. Follow `quickstart/PRODUCT_QUICKSTART.md` for a hands-on walkthrough
+1. Open `BUYER_START_GUIDE.md`
+2. Fill `templates/threshold-worksheet.md` for one real workflow
+3. Complete `templates/decision-record-template.md` for one allow/quarantine/deny decision
+4. Use `templates/pilot-checklist.md` to verify the workflow is ready for a small pilot
+5. Use `docs/LAYER_INDEX.md` after the first decision record is complete
 
 ## Support
 

--- a/tests/test_package_products.py
+++ b/tests/test_package_products.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+from zipfile import ZipFile
 
 import scripts.package_products as package_products
 
@@ -33,6 +34,22 @@ def test_packaged_product_smoke(tmp_path: Path):
     assert vault.exists()
     assert toolkit.stat().st_size > 0
     assert vault.stat().st_size > 0
+
+
+def test_toolkit_zip_contains_promised_buyer_templates(tmp_path: Path):
+    toolkit = package_products.package_toolkit(tmp_path)
+
+    with ZipFile(toolkit) as zf:
+        names = set(zf.namelist())
+
+    assert {
+        "BUYER_START_GUIDE.md",
+        "templates/decision-record-template.md",
+        "templates/threshold-worksheet.md",
+        "templates/pilot-checklist.md",
+        "templates/review-notes-template.md",
+        "quickstart/README.md",
+    }.issubset(names)
 
 
 def test_production_pack_support_email_is_current():


### PR DESCRIPTION
## Summary
- include the buyer start guide and practical governance templates in the AI Governance Toolkit ZIP
- update the generated Toolkit README so first-use instructions match the delivered files
- add a regression test that opens the ZIP and verifies the promised buyer templates are present

## Test Evidence
- `python -m pytest tests\test_package_products.py -q` -> 4 passed
- `python scripts\package_products.py --product all --output-dir artifacts\product_delivery_current_smoke` -> generated Toolkit and Training Vault ZIPs
- checkout surface audit: 0 blocking findings; live Stripe links only reported as warnings

## Rollback
- revert commit `62a0349c` to restore previous package contents