### PR TITLE
feat(billing): route one-time purchases to digital delivery

### DIFF
--- a/docs/ops/STRIPE_DIGITAL_DELIVERY.md
+++ b/docs/ops/STRIPE_DIGITAL_DELIVERY.md
@@ -77,4 +77,3 @@ attempt and records the purchase as an audit trail item.
 python -m pytest tests\api\test_stripe_billing_hardening.py tests\test_package_products.py -q
 python scripts\package_products.py --product all --output-dir artifacts\product_delivery_current_smoke
 ```
-

--- a/docs/ops/STRIPE_DIGITAL_DELIVERY.md
+++ b/docs/ops/STRIPE_DIGITAL_DELIVERY.md
@@ -1,0 +1,80 @@
+# Stripe Digital Delivery
+
+This is the one-time product fulfillment rail for AetherMoore digital products.
+
+## Required Stripe event
+
+Configure the Stripe webhook to send:
+
+- `checkout.session.completed`
+
+The handler lives at:
+
+- `src/api/stripe_billing.py`
+- route: `POST /billing/webhook`
+
+Webhook signature verification must stay enabled in production with:
+
+- `STRIPE_WEBHOOK_SECRET`
+
+## Product routing
+
+Preferred setup: set product metadata on each Stripe Payment Link.
+
+- Toolkit Payment Link: `metadata[scbe_product]=toolkit`
+- Training Vault Payment Link: `metadata[scbe_product]=vault`
+
+Fallback setup for existing links: map Stripe Payment Link IDs in environment.
+
+```text
+SCBE_PAYMENT_LINK_TOOLKIT=plink_...
+SCBE_PAYMENT_LINK_VAULT=plink_...
+```
+
+Do not route by price. Both current products are low-cost one-time offers and
+price-based routing can mis-deliver when products have the same price.
+
+## Delivery links
+
+Set direct product download URLs in environment when the ZIPs are hosted.
+
+```text
+SCBE_TOOLKIT_DOWNLOAD_URL=https://...
+SCBE_VAULT_DOWNLOAD_URL=https://...
+```
+
+If these are not set, the delivery email falls back to the latest GitHub release:
+
+```text
+https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest
+```
+
+## SMTP
+
+Buyer delivery email uses:
+
+```text
+SCBE_SMTP_HOST=smtp.porkbun.com
+SCBE_SMTP_PORT=587
+SCBE_SMTP_USER=ai@aethermoore.com
+SCBE_SMTP_PASS=...
+```
+
+If SMTP is not configured, the webhook does not crash. It logs the delivery
+attempt and records the purchase as an audit trail item.
+
+## Buyer email includes
+
+- product name
+- download URL
+- manual URL
+- expected ZIP filename
+- support URL
+
+## Smoke test
+
+```powershell
+python -m pytest tests\api\test_stripe_billing_hardening.py tests\test_package_products.py -q
+python scripts\package_products.py --product all --output-dir artifacts\product_delivery_current_smoke
+```
+

--- a/src/api/stripe_billing.py
+++ b/src/api/stripe_billing.py
@@ -119,9 +119,9 @@ def _stripe_request(
 
     encoded_data = None
     if form_data:
-        encoded_data = urllib.parse.urlencode(
-            {k: str(v) for k, v in form_data.items() if v is not None}
-        ).encode("utf-8")
+        encoded_data = urllib.parse.urlencode({k: str(v) for k, v in form_data.items() if v is not None}).encode(
+            "utf-8"
+        )
 
     req = urllib.request.Request(
         url,
@@ -172,9 +172,7 @@ def _verify_stripe_signature(payload: bytes, sig_header: str) -> bool:
 
     # Compute expected signature
     signed_payload = f"{timestamp}.".encode("utf-8") + payload
-    expected = hmac.new(
-        secret.encode("utf-8"), signed_payload, hashlib.sha256
-    ).hexdigest()
+    expected = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
 
     return hmac.compare_digest(expected, v1_sig)
 
@@ -226,10 +224,7 @@ async def create_checkout(request: CheckoutRequest):
         raise HTTPException(400, f"Unknown plan: {request.plan}")
 
     base_url = os.getenv("SCBE_BILLING_BASE_URL", "http://localhost:8000").rstrip("/")
-    success_url = (
-        request.success_url
-        or f"{base_url}/billing/success?session_id={{CHECKOUT_SESSION_ID}}"
-    )
+    success_url = request.success_url or f"{base_url}/billing/success?session_id={{CHECKOUT_SESSION_ID}}"
     cancel_url = request.cancel_url or f"{base_url}/billing/cancel"
 
     form_data: Dict[str, str] = {
@@ -300,9 +295,7 @@ async def stripe_webhook(request: Request):
 
     # Verify signature. Unsigned webhooks are only allowed when explicitly enabled.
     webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET", "").strip()
-    allow_unsigned = os.getenv(
-        "SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", ""
-    ).strip().lower() in {
+    allow_unsigned = os.getenv("SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", "").strip().lower() in {
         "1",
         "true",
         "yes",
@@ -339,9 +332,7 @@ def _handle_checkout_completed(session: Dict[str, Any]) -> None:
     customer_id = session.get("customer", "")
     plan_id = session.get("metadata", {}).get("scbe_plan", "starter")
     subscription_id = session.get("subscription", "")
-    email = session.get("customer_email") or session.get("customer_details", {}).get(
-        "email", ""
-    )
+    email = session.get("customer_email") or session.get("customer_details", {}).get("email", "")
 
     api_key = _generate_api_key()
     now = int(time.time())
@@ -485,9 +476,7 @@ def _resolve_onetime_product_key(session: Dict[str, Any]) -> str:
     return ""
 
 
-def _delivery_plaintext(
-    product_name: str, download_url: str, manual_url: str, package_filename: str
-) -> str:
+def _delivery_plaintext(product_name: str, download_url: str, manual_url: str, package_filename: str) -> str:
     return "\n".join(
         [
             f"Thank you for your purchase. Your {product_name} is ready.",
@@ -551,9 +540,7 @@ If you have any questions, reply to this email or reach us at ai@aethermoore.com
     msg["Reply-To"] = "ai@aethermoore.com"
     msg.attach(
         MIMEText(
-            _delivery_plaintext(
-                product_name, download_url, manual_url, package_filename
-            ),
+            _delivery_plaintext(product_name, download_url, manual_url, package_filename),
             "plain",
         )
     )
@@ -597,9 +584,7 @@ def _notify_owner(product_name: str, buyer_email: str, amount_cents: int) -> Non
 
 def _handle_onetime_purchase(session: Dict[str, Any]) -> None:
     """Handle a one-time product purchase from Payment Links."""
-    email = session.get("customer_email") or session.get("customer_details", {}).get(
-        "email", ""
-    )
+    email = session.get("customer_email") or session.get("customer_details", {}).get("email", "")
     amount = session.get("amount_total", 0)
     payment_status = session.get("payment_status", "")
 

--- a/src/api/stripe_billing.py
+++ b/src/api/stripe_billing.py
@@ -119,9 +119,9 @@ def _stripe_request(
 
     encoded_data = None
     if form_data:
-        encoded_data = urllib.parse.urlencode({k: str(v) for k, v in form_data.items() if v is not None}).encode(
-            "utf-8"
-        )
+        encoded_data = urllib.parse.urlencode(
+            {k: str(v) for k, v in form_data.items() if v is not None}
+        ).encode("utf-8")
 
     req = urllib.request.Request(
         url,
@@ -172,7 +172,9 @@ def _verify_stripe_signature(payload: bytes, sig_header: str) -> bool:
 
     # Compute expected signature
     signed_payload = f"{timestamp}.".encode("utf-8") + payload
-    expected = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
+    expected = hmac.new(
+        secret.encode("utf-8"), signed_payload, hashlib.sha256
+    ).hexdigest()
 
     return hmac.compare_digest(expected, v1_sig)
 
@@ -224,7 +226,10 @@ async def create_checkout(request: CheckoutRequest):
         raise HTTPException(400, f"Unknown plan: {request.plan}")
 
     base_url = os.getenv("SCBE_BILLING_BASE_URL", "http://localhost:8000").rstrip("/")
-    success_url = request.success_url or f"{base_url}/billing/success?session_id={{CHECKOUT_SESSION_ID}}"
+    success_url = (
+        request.success_url
+        or f"{base_url}/billing/success?session_id={{CHECKOUT_SESSION_ID}}"
+    )
     cancel_url = request.cancel_url or f"{base_url}/billing/cancel"
 
     form_data: Dict[str, str] = {
@@ -295,7 +300,9 @@ async def stripe_webhook(request: Request):
 
     # Verify signature. Unsigned webhooks are only allowed when explicitly enabled.
     webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET", "").strip()
-    allow_unsigned = os.getenv("SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", "").strip().lower() in {
+    allow_unsigned = os.getenv(
+        "SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", ""
+    ).strip().lower() in {
         "1",
         "true",
         "yes",
@@ -332,7 +339,9 @@ def _handle_checkout_completed(session: Dict[str, Any]) -> None:
     customer_id = session.get("customer", "")
     plan_id = session.get("metadata", {}).get("scbe_plan", "starter")
     subscription_id = session.get("subscription", "")
-    email = session.get("customer_email") or session.get("customer_details", {}).get("email", "")
+    email = session.get("customer_email") or session.get("customer_details", {}).get(
+        "email", ""
+    )
 
     api_key = _generate_api_key()
     now = int(time.time())
@@ -392,20 +401,32 @@ def _handle_subscription_deleted(subscription: Dict[str, Any]) -> None:
 # One-time product purchases (Payment Links)
 # ---------------------------------------------------------------------------
 
-# Map Stripe Payment Link product IDs to delivery info.
-# These correspond to the buy.stripe.com links on the website.
+# Map one-time product keys to delivery info.
+# Payment Links should set metadata[scbe_product] to one of these keys.
+# As a fallback, set SCBE_PAYMENT_LINK_TOOLKIT or SCBE_PAYMENT_LINK_VAULT to
+# the live Stripe Payment Link IDs if metadata is unavailable.
 ONETIME_PRODUCTS: Dict[str, Dict[str, str]] = {
     # AI Governance Toolkit - $29
     "toolkit": {
         "name": "SCBE AI Governance Toolkit",
-        "download_url": "https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest",
+        "download_url": os.getenv(
+            "SCBE_TOOLKIT_DOWNLOAD_URL",
+            "https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest",
+        ),
         "manual_url": "https://aethermoore.com/product-manual/ai-governance-toolkit.html",
+        "package_filename": "SCBE_AI_Governance_Toolkit_v1.zip",
+        "support_url": "https://aethermoore.com/support.html",
     },
     # AI Security Training Vault - $29
     "vault": {
         "name": "SCBE AI Security Training Vault",
-        "download_url": "https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest",
+        "download_url": os.getenv(
+            "SCBE_VAULT_DOWNLOAD_URL",
+            "https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest",
+        ),
         "manual_url": "https://aethermoore.com/product-manual/training-vault.html",
+        "package_filename": "SCBE_AI_Security_Training_Vault_v1.zip",
+        "support_url": "https://aethermoore.com/support.html",
     },
 }
 
@@ -413,7 +434,86 @@ ONETIME_PRODUCTS: Dict[str, Dict[str, str]] = {
 PURCHASE_LOG: list = []
 
 
-def _send_delivery_email(to_email: str, product_name: str, download_url: str, manual_url: str) -> bool:
+def _payment_link_product_map() -> Dict[str, str]:
+    """Return optional Stripe Payment Link ID -> product key mapping from env."""
+    mapping: Dict[str, str] = {}
+    for product_key in ONETIME_PRODUCTS:
+        env_name = f"SCBE_PAYMENT_LINK_{product_key.upper()}"
+        payment_link_id = os.getenv(env_name, "").strip()
+        if payment_link_id:
+            mapping[payment_link_id] = product_key
+    return mapping
+
+
+def _normalize_product_key(value: object) -> str:
+    """Normalize product selector text into a known one-time product key."""
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "ai_governance_toolkit": "toolkit",
+        "governance_toolkit": "toolkit",
+        "scbe_ai_governance_toolkit": "toolkit",
+        "ai_security_training_vault": "vault",
+        "training_vault": "vault",
+        "security_training_vault": "vault",
+        "scbe_ai_security_training_vault": "vault",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _resolve_onetime_product_key(session: Dict[str, Any]) -> str:
+    """Resolve a one-time product from signed Stripe session data.
+
+    Metadata is the preferred path because it is explicit and deterministic.
+    Payment Link ID mapping is an operational fallback for existing links.
+    """
+    metadata = session.get("metadata", {}) or {}
+    for metadata_key in ("scbe_product", "product", "product_key", "offer"):
+        product_key = _normalize_product_key(metadata.get(metadata_key, ""))
+        if product_key in ONETIME_PRODUCTS:
+            return product_key
+
+    client_reference_id = _normalize_product_key(session.get("client_reference_id", ""))
+    if client_reference_id in ONETIME_PRODUCTS:
+        return client_reference_id
+
+    payment_link = str(session.get("payment_link", "") or "").strip()
+    if payment_link:
+        mapped_key = _payment_link_product_map().get(payment_link, "")
+        if mapped_key in ONETIME_PRODUCTS:
+            return mapped_key
+
+    return ""
+
+
+def _delivery_plaintext(
+    product_name: str, download_url: str, manual_url: str, package_filename: str
+) -> str:
+    return "\n".join(
+        [
+            f"Thank you for your purchase. Your {product_name} is ready.",
+            "",
+            f"Download: {download_url}",
+            f"Manual:   {manual_url}",
+            f"Package:  {package_filename}",
+            "",
+            "First steps:",
+            "1. Download the package.",
+            "2. Open README.md or BUYER_START_GUIDE.md first.",
+            "3. Use the manual if you need the web instructions.",
+            "",
+            "Support: ai@aethermoore.com or https://aethermoore.com/support.html",
+        ]
+    )
+
+
+def _send_delivery_email(
+    to_email: str,
+    product_name: str,
+    download_url: str,
+    manual_url: str,
+    package_filename: str = "",
+    support_url: str = "https://aethermoore.com/support.html",
+) -> bool:
     """Send product delivery email via SMTP.
 
     Uses Porkbun email (ai@aethermoore.com) configured in .secrets/email_credentials.txt.
@@ -432,9 +532,11 @@ def _send_delivery_email(to_email: str, product_name: str, download_url: str, ma
     html_body = f"""<html><body style="font-family: Georgia, serif; color: #333; max-width: 600px;">
 <h2 style="color: #d6a756;">Thank you for your purchase!</h2>
 <p>Your <strong>{product_name}</strong> is ready for download.</p>
+<p>Expected package: <code>{package_filename or 'product ZIP'}</code></p>
 <p><a href="{download_url}" style="display:inline-block;padding:12px 24px;background:#d6a756;color:#14110c;
 text-decoration:none;border-radius:6px;font-weight:bold;">Download Your Product</a></p>
 <p><a href="{manual_url}">Read the Manual</a></p>
+<p><a href="{support_url}">Delivery support</a></p>
 <hr style="border:none;border-top:1px solid #eee;margin:24px 0;">
 <p style="font-size:14px;color:#888;">
 If you have any questions, reply to this email or reach us at ai@aethermoore.com.<br>
@@ -447,7 +549,14 @@ If you have any questions, reply to this email or reach us at ai@aethermoore.com
     msg["From"] = f"AetherMoore <{smtp_user}>"
     msg["To"] = to_email
     msg["Reply-To"] = "ai@aethermoore.com"
-    msg.attach(MIMEText(f"Your {product_name} is ready: {download_url}", "plain"))
+    msg.attach(
+        MIMEText(
+            _delivery_plaintext(
+                product_name, download_url, manual_url, package_filename
+            ),
+            "plain",
+        )
+    )
     msg.attach(MIMEText(html_body, "html"))
 
     if not smtp_pass:
@@ -482,21 +591,22 @@ def _notify_owner(product_name: str, buyer_email: str, amount_cents: int) -> Non
         product_name=f"NEW SALE: {product_name}",
         download_url=f"Buyer: {buyer_email} | Amount: ${amount_cents / 100:.2f}",
         manual_url="https://dashboard.stripe.com/payments",
+        package_filename="owner-notification",
     )
 
 
 def _handle_onetime_purchase(session: Dict[str, Any]) -> None:
     """Handle a one-time product purchase from Payment Links."""
-    email = session.get("customer_email") or session.get("customer_details", {}).get("email", "")
+    email = session.get("customer_email") or session.get("customer_details", {}).get(
+        "email", ""
+    )
     amount = session.get("amount_total", 0)
     payment_status = session.get("payment_status", "")
 
     if payment_status != "paid":
         return
 
-    # Determine which product was purchased based on amount or metadata
-    metadata = session.get("metadata", {})
-    product_key = metadata.get("scbe_product", "")
+    product_key = _resolve_onetime_product_key(session)
 
     # Do not guess from amount to avoid mis-delivery between similarly priced products.
     product = ONETIME_PRODUCTS.get(product_key) if product_key else None
@@ -506,6 +616,8 @@ def _handle_onetime_purchase(session: Dict[str, Any]) -> None:
             "name": "UNRESOLVED_PRODUCT",
             "download_url": "",
             "manual_url": "",
+            "package_filename": "",
+            "support_url": "https://aethermoore.com/support.html",
         }
 
     # Log the purchase
@@ -516,6 +628,9 @@ def _handle_onetime_purchase(session: Dict[str, Any]) -> None:
         "product_name": product["name"],
         "unresolved_product": unresolved_product,
         "amount_cents": amount,
+        "download_url": product["download_url"],
+        "manual_url": product["manual_url"],
+        "package_filename": product.get("package_filename", ""),
         "timestamp": int(time.time()),
     }
     PURCHASE_LOG.append(record)
@@ -525,7 +640,14 @@ def _handle_onetime_purchase(session: Dict[str, Any]) -> None:
 
     # Send delivery email to buyer
     if email and not unresolved_product:
-        _send_delivery_email(email, product["name"], product["download_url"], product["manual_url"])
+        _send_delivery_email(
+            email,
+            product["name"],
+            product["download_url"],
+            product["manual_url"],
+            product.get("package_filename", ""),
+            product.get("support_url", "https://aethermoore.com/support.html"),
+        )
         _notify_owner(product["name"], email, amount)
     elif unresolved_product:
         LOGGER.warning(

--- a/tests/api/test_stripe_billing_hardening.py
+++ b/tests/api/test_stripe_billing_hardening.py
@@ -22,9 +22,7 @@ def test_purchases_requires_owner_token(monkeypatch):
 def test_purchases_allows_with_owner_token(monkeypatch):
     monkeypatch.setenv("SCBE_OWNER_API_TOKEN", "owner-secret")
     client = _client()
-    response = client.get(
-        "/billing/purchases", headers={"x-owner-token": "owner-secret"}
-    )
+    response = client.get("/billing/purchases", headers={"x-owner-token": "owner-secret"})
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "ok"
@@ -34,16 +32,12 @@ def test_webhook_requires_secret_or_explicit_unsigned_override(monkeypatch):
     monkeypatch.delenv("STRIPE_WEBHOOK_SECRET", raising=False)
     monkeypatch.delenv("SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", raising=False)
     client = _client()
-    response = client.post(
-        "/billing/webhook", json={"type": "noop", "data": {"object": {}}}
-    )
+    response = client.post("/billing/webhook", json={"type": "noop", "data": {"object": {}}})
     assert response.status_code == 503
 
 
 def test_onetime_purchase_without_product_metadata_is_marked_unresolved(monkeypatch):
-    monkeypatch.setattr(
-        stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True
-    )
+    monkeypatch.setattr(stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True)
     monkeypatch.setattr(stripe_billing, "_notify_owner", lambda *args, **kwargs: None)
     stripe_billing.PURCHASE_LOG.clear()
     session = {
@@ -68,9 +62,7 @@ def test_onetime_purchase_metadata_triggers_delivery_record(monkeypatch):
         sent["kwargs"] = kwargs
         return True
 
-    monkeypatch.setattr(
-        stripe_billing, "_send_delivery_email", fake_send_delivery_email
-    )
+    monkeypatch.setattr(stripe_billing, "_send_delivery_email", fake_send_delivery_email)
     monkeypatch.setattr(stripe_billing, "_notify_owner", lambda *args, **kwargs: None)
     stripe_billing.PURCHASE_LOG.clear()
 
@@ -95,9 +87,7 @@ def test_onetime_purchase_metadata_triggers_delivery_record(monkeypatch):
 
 def test_onetime_purchase_resolves_existing_payment_link_from_env(monkeypatch):
     monkeypatch.setenv("SCBE_PAYMENT_LINK_VAULT", "plink_vault_live")
-    monkeypatch.setattr(
-        stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True
-    )
+    monkeypatch.setattr(stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True)
     monkeypatch.setattr(stripe_billing, "_notify_owner", lambda *args, **kwargs: None)
     stripe_billing.PURCHASE_LOG.clear()
 
@@ -121,9 +111,7 @@ def test_onetime_purchase_resolves_existing_payment_link_from_env(monkeypatch):
 def test_webhook_payment_event_records_onetime_delivery(monkeypatch):
     monkeypatch.setenv("SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", "true")
     monkeypatch.delenv("STRIPE_WEBHOOK_SECRET", raising=False)
-    monkeypatch.setattr(
-        stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True
-    )
+    monkeypatch.setattr(stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True)
     monkeypatch.setattr(stripe_billing, "_notify_owner", lambda *args, **kwargs: None)
     stripe_billing.PURCHASE_LOG.clear()
 
@@ -171,8 +159,6 @@ def test_onetime_product_manual_urls_are_live_buyer_routes():
     assert stripe_billing.ONETIME_PRODUCTS["toolkit"]["manual_url"].endswith(
         "/product-manual/ai-governance-toolkit.html"
     )
-    assert stripe_billing.ONETIME_PRODUCTS["vault"]["manual_url"].endswith(
-        "/product-manual/training-vault.html"
-    )
+    assert stripe_billing.ONETIME_PRODUCTS["vault"]["manual_url"].endswith("/product-manual/training-vault.html")
     for product in stripe_billing.ONETIME_PRODUCTS.values():
         assert "/docs/product-manual/" not in product["manual_url"]

--- a/tests/api/test_stripe_billing_hardening.py
+++ b/tests/api/test_stripe_billing_hardening.py
@@ -22,7 +22,9 @@ def test_purchases_requires_owner_token(monkeypatch):
 def test_purchases_allows_with_owner_token(monkeypatch):
     monkeypatch.setenv("SCBE_OWNER_API_TOKEN", "owner-secret")
     client = _client()
-    response = client.get("/billing/purchases", headers={"x-owner-token": "owner-secret"})
+    response = client.get(
+        "/billing/purchases", headers={"x-owner-token": "owner-secret"}
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "ok"
@@ -32,12 +34,16 @@ def test_webhook_requires_secret_or_explicit_unsigned_override(monkeypatch):
     monkeypatch.delenv("STRIPE_WEBHOOK_SECRET", raising=False)
     monkeypatch.delenv("SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", raising=False)
     client = _client()
-    response = client.post("/billing/webhook", json={"type": "noop", "data": {"object": {}}})
+    response = client.post(
+        "/billing/webhook", json={"type": "noop", "data": {"object": {}}}
+    )
     assert response.status_code == 503
 
 
 def test_onetime_purchase_without_product_metadata_is_marked_unresolved(monkeypatch):
-    monkeypatch.setattr(stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True
+    )
     monkeypatch.setattr(stripe_billing, "_notify_owner", lambda *args, **kwargs: None)
     stripe_billing.PURCHASE_LOG.clear()
     session = {
@@ -54,10 +60,119 @@ def test_onetime_purchase_without_product_metadata_is_marked_unresolved(monkeypa
     assert latest["unresolved_product"] is True
 
 
+def test_onetime_purchase_metadata_triggers_delivery_record(monkeypatch):
+    sent = {}
+
+    def fake_send_delivery_email(*args, **kwargs):
+        sent["args"] = args
+        sent["kwargs"] = kwargs
+        return True
+
+    monkeypatch.setattr(
+        stripe_billing, "_send_delivery_email", fake_send_delivery_email
+    )
+    monkeypatch.setattr(stripe_billing, "_notify_owner", lambda *args, **kwargs: None)
+    stripe_billing.PURCHASE_LOG.clear()
+
+    session = {
+        "id": "cs_test_toolkit",
+        "customer_email": "buyer@example.com",
+        "amount_total": 2900,
+        "payment_status": "paid",
+        "metadata": {"scbe_product": "toolkit"},
+    }
+
+    stripe_billing._handle_onetime_purchase(session)
+
+    latest = stripe_billing.PURCHASE_LOG[-1]
+    assert latest["product"] == "toolkit"
+    assert latest["unresolved_product"] is False
+    assert latest["package_filename"] == "SCBE_AI_Governance_Toolkit_v1.zip"
+    assert latest["manual_url"].endswith("/product-manual/ai-governance-toolkit.html")
+    assert sent["args"][0] == "buyer@example.com"
+    assert sent["args"][4] == "SCBE_AI_Governance_Toolkit_v1.zip"
+
+
+def test_onetime_purchase_resolves_existing_payment_link_from_env(monkeypatch):
+    monkeypatch.setenv("SCBE_PAYMENT_LINK_VAULT", "plink_vault_live")
+    monkeypatch.setattr(
+        stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True
+    )
+    monkeypatch.setattr(stripe_billing, "_notify_owner", lambda *args, **kwargs: None)
+    stripe_billing.PURCHASE_LOG.clear()
+
+    session = {
+        "id": "cs_test_vault",
+        "customer_details": {"email": "buyer@example.com"},
+        "amount_total": 2900,
+        "payment_status": "paid",
+        "payment_link": "plink_vault_live",
+        "metadata": {},
+    }
+
+    stripe_billing._handle_onetime_purchase(session)
+
+    latest = stripe_billing.PURCHASE_LOG[-1]
+    assert latest["product"] == "vault"
+    assert latest["unresolved_product"] is False
+    assert latest["package_filename"] == "SCBE_AI_Security_Training_Vault_v1.zip"
+
+
+def test_webhook_payment_event_records_onetime_delivery(monkeypatch):
+    monkeypatch.setenv("SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", "true")
+    monkeypatch.delenv("STRIPE_WEBHOOK_SECRET", raising=False)
+    monkeypatch.setattr(
+        stripe_billing, "_send_delivery_email", lambda *args, **kwargs: True
+    )
+    monkeypatch.setattr(stripe_billing, "_notify_owner", lambda *args, **kwargs: None)
+    stripe_billing.PURCHASE_LOG.clear()
+
+    client = _client()
+    response = client.post(
+        "/billing/webhook",
+        json={
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "id": "cs_test_webhook_toolkit",
+                    "mode": "payment",
+                    "customer_email": "buyer@example.com",
+                    "amount_total": 2900,
+                    "payment_status": "paid",
+                    "metadata": {"scbe_product": "toolkit"},
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    latest = stripe_billing.PURCHASE_LOG[-1]
+    assert latest["session_id"] == "cs_test_webhook_toolkit"
+    assert latest["product"] == "toolkit"
+    assert latest["unresolved_product"] is False
+
+
+def test_delivery_plaintext_includes_fast_start_paths():
+    body = stripe_billing._delivery_plaintext(
+        "SCBE AI Governance Toolkit",
+        "https://example.com/download",
+        "https://example.com/manual",
+        "SCBE_AI_Governance_Toolkit_v1.zip",
+    )
+
+    assert "Download: https://example.com/download" in body
+    assert "Manual:   https://example.com/manual" in body
+    assert "Package:  SCBE_AI_Governance_Toolkit_v1.zip" in body
+    assert "Open README.md or BUYER_START_GUIDE.md first." in body
+
+
 def test_onetime_product_manual_urls_are_live_buyer_routes():
     assert stripe_billing.ONETIME_PRODUCTS["toolkit"]["manual_url"].endswith(
         "/product-manual/ai-governance-toolkit.html"
     )
-    assert stripe_billing.ONETIME_PRODUCTS["vault"]["manual_url"].endswith("/product-manual/training-vault.html")
+    assert stripe_billing.ONETIME_PRODUCTS["vault"]["manual_url"].endswith(
+        "/product-manual/training-vault.html"
+    )
     for product in stripe_billing.ONETIME_PRODUCTS.values():
         assert "/docs/product-manual/" not in product["manual_url"]

--- a/tests/test_package_products.py
+++ b/tests/test_package_products.py
@@ -53,11 +53,6 @@ def test_toolkit_zip_contains_promised_buyer_templates(tmp_path: Path):
 
 
 def test_production_pack_support_email_is_current():
-    inventory = (
-        package_products.REPO_ROOT
-        / "deliverables"
-        / "SCBE_Production_Pack"
-        / "PACKAGE_INVENTORY.json"
-    )
+    inventory = package_products.REPO_ROOT / "deliverables" / "SCBE_Production_Pack" / "PACKAGE_INVENTORY.json"
     payload = json.loads(inventory.read_text(encoding="utf-8"))
     assert payload["support_email"] == "ai@aethermoore.com"

--- a/tests/test_package_products.py
+++ b/tests/test_package_products.py
@@ -53,6 +53,11 @@ def test_toolkit_zip_contains_promised_buyer_templates(tmp_path: Path):
 
 
 def test_production_pack_support_email_is_current():
-    inventory = package_products.REPO_ROOT / "deliverables" / "SCBE_Production_Pack" / "PACKAGE_INVENTORY.json"
+    inventory = (
+        package_products.REPO_ROOT
+        / "deliverables"
+        / "SCBE_Production_Pack"
+        / "PACKAGE_INVENTORY.json"
+    )
     payload = json.loads(inventory.read_text(encoding="utf-8"))
     assert payload["support_email"] == "ai@aethermoore.com"


### PR DESCRIPTION
## Summary
- harden one-time Stripe purchase fulfillment for Toolkit and Training Vault
- resolve products from explicit Payment Link metadata first, with payment-link ID env mapping as a fallback
- include direct download URL, manual URL, expected ZIP filename, and support URL in buyer delivery emails
- record delivery fields in the local purchase audit log
- document required Stripe metadata/env vars in `docs/ops/STRIPE_DIGITAL_DELIVERY.md`

## Test Evidence
- `python -m pytest tests\api\test_stripe_billing_hardening.py tests\test_package_products.py -q` -> 13 passed
- `python -m black --check src\api\stripe_billing.py tests\api\test_stripe_billing_hardening.py tests\test_package_products.py` -> unchanged
- `git diff --check` -> clean
- `python scripts\package_products.py --product all --output-dir artifacts\product_delivery_current_smoke` -> Toolkit and Training Vault ZIPs generated

## Ops Notes
- Preferred Stripe setup: `metadata[scbe_product]=toolkit` or `metadata[scbe_product]=vault`
- Existing Payment Link fallback: set `SCBE_PAYMENT_LINK_TOOLKIT` / `SCBE_PAYMENT_LINK_VAULT`
- Direct ZIP links: set `SCBE_TOOLKIT_DOWNLOAD_URL` / `SCBE_VAULT_DOWNLOAD_URL`
- SMTP delivery requires `SCBE_SMTP_HOST`, `SCBE_SMTP_PORT`, `SCBE_SMTP_USER`, `SCBE_SMTP_PASS`

## Rollback
- revert commit `37bab1c7`