### PR TITLE
fix(ci): install liboqs for daily pytest

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -57,6 +57,15 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+      - name: Install liboqs C library
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq astyle cmake gcc ninja-build libssl-dev
+          git clone --depth 1 --branch 0.12.0 https://github.com/open-quantum-safe/liboqs.git /tmp/liboqs
+          cmake -S /tmp/liboqs -B /tmp/liboqs/build -GNinja -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr
+          ninja -C /tmp/liboqs/build
+          sudo ninja -C /tmp/liboqs/build install
+          sudo ldconfig
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- add the same liboqs C shared-library setup used by main CI to the Daily Tests pytest job
- fixes the full-suite import path for src.crypto.pqc_liboqs / oqs on GitHub runners

## Verification
- parsed .github/workflows/daily-tests.yml locally with PyYAML
- confirmed the previous manual Daily Tests run had already cleared typecheck, lint, build, and Vitest after PR #1398; this patch targets the remaining pytest liboqs setup failure

## Rollback
- revert this workflow-only commit if the runner image gains native liboqs support or the PQC import path is mocked in daily tests