### PR TITLE
fix(tests): isolate spiralword governance import

### DIFF
--- a/tests/test_code_scanning_batch3.py
+++ b/tests/test_code_scanning_batch3.py
@@ -14,15 +14,16 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def _load_module(relative_path: str, module_name: str, extra_paths: list[Path] | None = None):
-    added: list[str] = []
+    path_positions: dict[str, int | None] = {}
     # Save and clear any cached modules that extra_paths might shadow
     saved_mods: dict[str, object] = {}
     if extra_paths:
         for extra in extra_paths:
             extra_str = str(extra)
-            if extra_str not in sys.path:
-                sys.path.insert(0, extra_str)
-                added.append(extra_str)
+            path_positions[extra_str] = sys.path.index(extra_str) if extra_str in sys.path else None
+            if extra_str in sys.path:
+                sys.path.remove(extra_str)
+            sys.path.insert(0, extra_str)
         # Clear cached governance so spiral-word-app/governance.py can be found
         # during module execution (it would otherwise resolve to src/governance/)
         gov = sys.modules.get("governance")
@@ -39,9 +40,11 @@ def _load_module(relative_path: str, module_name: str, extra_paths: list[Path] |
         return module
     finally:
         # Remove temporary paths so they don't shadow packages in src/
-        for p in added:
+        for p, old_index in path_positions.items():
             if p in sys.path:
                 sys.path.remove(p)
+            if old_index is not None:
+                sys.path.insert(min(old_index, len(sys.path)), p)
         # Restore original governance module if we cleared it
         for k, v in saved_mods.items():
             sys.modules.pop(k, None)  # remove spiral-word-app's governance


### PR DESCRIPTION
## Summary
- make the code-scanning batch3 module loader move SpiralWord's app directory to the front of sys.path during local module execution
- restore the original sys.path position afterward so src/governance remains authoritative for the rest of the suite
- fixes the Daily Tests pytest collection error where spiral-word-app/app.py imported src/governance instead of spiral-word-app/governance.py

## Verification
- python -m pytest tests/test_code_scanning_batch3.py -q
- previous Daily Tests run 25497775814 showed liboqs setup passed and this import-order error was the remaining pytest collection failure

## Rollback
- revert this test-only change if SpiralWord is packaged with explicit package-relative imports later