### PR TITLE
fix(ci): clean release and liboqs guards

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   npmjs:
     name: Publish to npmjs.org
+    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +53,7 @@ jobs:
 
   github-packages:
     name: Publish to GitHub Packages
+    if: ${{ github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/crypto/pqc_liboqs.py
+++ b/src/crypto/pqc_liboqs.py
@@ -21,6 +21,19 @@ import os
 from typing import Tuple, Optional
 from dataclasses import dataclass
 
+
+def _load_oqs_module():
+    """Load liboqs-python without letting optional backend bootstrap kill import."""
+    try:
+        import oqs as oqs_module
+
+        return oqs_module
+    except BaseException:
+        # liboqs-python can raise SystemExit while trying to bootstrap missing
+        # shared libraries. PQC is optional here, so fall back instead.
+        return None
+
+
 # Constants matching NIST specifications
 MLKEM768_PK_LEN = 1184  # ML-KEM-768 public key size
 MLKEM768_SK_LEN = 2400  # ML-KEM-768 secret key size
@@ -39,16 +52,16 @@ _FORCE_SKIP_LIBOQS = os.getenv("SCBE_FORCE_SKIP_LIBOQS", "").strip().lower() in 
 }
 
 if not _FORCE_SKIP_LIBOQS:
-    try:
-        import oqs
-
+    oqs = _load_oqs_module()
+    if oqs is not None:
         LIBOQS_AVAILABLE = True
         _LIBOQS_VERSION = getattr(oqs, "__version__", "unknown")
-    except Exception:
+    else:
         # oqs may be installed without shared libs; treat as unavailable and fall back.
         LIBOQS_AVAILABLE = False
         _LIBOQS_VERSION = None
 else:
+    oqs = None
     LIBOQS_AVAILABLE = False
     _LIBOQS_VERSION = None
 

--- a/tests/crypto/test_pqc_liboqs_status.py
+++ b/tests/crypto/test_pqc_liboqs_status.py
@@ -1,6 +1,21 @@
 """Focused tests for PQC governance status reporting."""
 
+import builtins
+
 from src.crypto import pqc_liboqs
+
+
+def test_load_oqs_module_handles_system_exit(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "oqs":
+            raise SystemExit("liboqs bootstrap failed")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert pqc_liboqs._load_oqs_module() is None
 
 
 def test_get_pqc_proof_tier_native(monkeypatch):


### PR DESCRIPTION
## Summary
- Skip npm publish jobs for non-npm release tags such as `agent-bus-py-v0.2.0`
- Keep the liboqs bootstrap/status hardening in a clean branch from current `main`

## Verification
- `python -m pytest tests/crypto/test_pqc_liboqs_status.py -q` -> 5 passed
- Workflow guard assertion confirmed `.github/workflows/npm-publish.yml` contains the release-tag guard

## Notes
This replaces the dirty draft PR path for the immediate CI/release failure. The older PR remains broad/conflicted and should not be merged as the hotfix path.