### PR TITLE
fix(delivery): add customer download bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,4 @@ external/cli-quests/
 # Symlink roots — points to full drives, never commit
 .roots/
 .home/.codex/
+.vercel

--- a/api/agent/download.js
+++ b/api/agent/download.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const { sendJson, setCors } = require("../_agent_common");
+
+const PRODUCTS = {
+  toolkit: {
+    envUrl: "SCBE_TOOLKIT_BLOB_URL",
+    filename: "SCBE_AI_Governance_Toolkit_v1.zip",
+  },
+  vault: {
+    envUrl: "SCBE_VAULT_BLOB_URL",
+    filename: "SCBE_AI_Security_Training_Vault_v1.zip",
+  },
+};
+
+function resolveProduct(req) {
+  const rawUrl = new URL(req.url || "/api/agent/download", "https://scbe-agent-bridge-vercel.vercel.app");
+  return String(rawUrl.searchParams.get("product") || "").trim().toLowerCase();
+}
+
+function resolveToken(req) {
+  const rawUrl = new URL(req.url || "/api/agent/download", "https://scbe-agent-bridge-vercel.vercel.app");
+  const queryToken = String(rawUrl.searchParams.get("token") || "").trim();
+  const bearer = String(req.headers.authorization || "").replace(/^Bearer\s+/i, "").trim();
+  return queryToken || bearer;
+}
+
+module.exports = async function handler(req, res) {
+  setCors(res);
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    return sendJson(res, 405, { status: "error", error: "GET required" });
+  }
+
+  const expectedToken = String(process.env.SCBE_DELIVERY_TOKEN || "").trim();
+  if (!expectedToken) {
+    return sendJson(res, 503, { status: "error", error: "delivery token is not configured" });
+  }
+
+  const providedToken = resolveToken(req);
+  if (!providedToken || providedToken !== expectedToken) {
+    return sendJson(res, 401, { status: "error", error: "unauthorized" });
+  }
+
+  const productKey = resolveProduct(req);
+  const product = PRODUCTS[productKey];
+  if (!product) {
+    return sendJson(res, 400, { status: "error", error: "product must be toolkit or vault" });
+  }
+
+  const blobUrl = String(process.env[product.envUrl] || "").trim();
+  const blobToken = String(process.env.BLOB_READ_WRITE_TOKEN || "").trim();
+  if (!blobUrl || !blobToken) {
+    return sendJson(res, 503, { status: "error", error: "blob delivery is not configured" });
+  }
+
+  const upstream = await fetch(blobUrl, {
+    method: req.method,
+    headers: { Authorization: `Bearer ${blobToken}` },
+  });
+  if (!upstream.ok) {
+    return sendJson(res, upstream.status, { status: "error", error: "blob fetch failed" });
+  }
+
+  res.setHeader("Content-Type", upstream.headers.get("content-type") || "application/zip");
+  res.setHeader("Content-Disposition", `attachment; filename="${product.filename}"`);
+  res.setHeader("Cache-Control", "private, no-store");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  if (req.method === "HEAD") return res.status(200).end();
+
+  const body = Buffer.from(await upstream.arrayBuffer());
+  return res.status(200).send(body);
+};

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="scbe-api-base" content="">
+  <title>SCBE App</title>
+</head>
+<body>
+  <main id="app">SCBE application shell</main>
+  <script>
+    function resolveApiBase() {
+      const meta = document.querySelector('meta[name="scbe-api-base"]');
+      const configured = meta && meta.getAttribute('content');
+      if (configured) return configured.replace(/\/$/, '');
+      if (window.SCBE_API_BASE) return String(window.SCBE_API_BASE).replace(/\/$/, '');
+      return window.location.origin;
+    }
+
+    const API_URL = resolveApiBase();
+    window.SCBE_APP_CONFIG = { apiBase: API_URL };
+  </script>
+</body>
+</html>

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -31,3 +31,15 @@ def test_launch_page_links_to_public_docs_and_bridge_endpoints() -> None:
     assert "/api/agent/health" in source
     assert "/api/agent/status?limit=5" in source
     assert "https://aethermoore.com/SCBE-AETHERMOORE" in source
+
+
+def test_download_bridge_serves_private_blob_with_delivery_token() -> None:
+    source = (REPO_ROOT / "api" / "agent" / "download.js").read_text(encoding="utf-8")
+
+    assert "SCBE_DELIVERY_TOKEN" in source
+    assert "BLOB_READ_WRITE_TOKEN" in source
+    assert "SCBE_TOOLKIT_BLOB_URL" in source
+    assert "SCBE_VAULT_BLOB_URL" in source
+    assert 'product must be toolkit or vault' in source
+    assert 'Content-Disposition' in source
+    assert 'Cache-Control", "private, no-store"' in source


### PR DESCRIPTION
## Summary
- add Vercel `/api/agent/download` bridge for buyer package downloads from private Blob storage
- restore deploy smoke `app/index.html` shell without hardcoded localhost API
- add bridge regression coverage

## Operational setup completed
- packaged current buyer ZIPs under `artifacts/product_delivery_current_smoke/`
- uploaded Toolkit and Training Vault ZIPs to the existing private Vercel Blob store
- configured Vercel production env names for blob URLs, delivery token, download URLs, and payment-link IDs
- updated Stripe Payment Links so the existing site URLs are active, tagged with `metadata[scbe_product]`, and redirect after payment to the delivery bridge

## Verification
- `python -m pytest tests/test_vercel_launch_bridge.py tests/smoke/test_app_deploy_config.py tests/api/test_stripe_billing_hardening.py tests/test_package_products.py -q` -> 20 passed
- `python scripts/package_products.py --product all --output-dir artifacts/product_delivery_current_smoke` -> Toolkit and Training Vault ZIPs built
- `python .codex skill audit_checkout_surfaces` equivalent checkout audit against `docs/` -> 0 blocking findings