### PR TITLE
style(test): format delivery bridge regression

### DIFF
--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -40,6 +40,6 @@ def test_download_bridge_serves_private_blob_with_delivery_token() -> None:
     assert "BLOB_READ_WRITE_TOKEN" in source
     assert "SCBE_TOOLKIT_BLOB_URL" in source
     assert "SCBE_VAULT_BLOB_URL" in source
-    assert 'product must be toolkit or vault' in source
-    assert 'Content-Disposition' in source
+    assert "product must be toolkit or vault" in source
+    assert "Content-Disposition" in source
     assert 'Cache-Control", "private, no-store"' in source


### PR DESCRIPTION
## Summary
- format the merged delivery bridge regression test with CI's Black settings
- keeps the customer download bridge test lane green on main

## Verification
- python -m pytest tests/test_vercel_launch_bridge.py tests/smoke/test_app_deploy_config.py tests/api/test_stripe_billing_hardening.py tests/test_package_products.py -q

## Notes
- No product logic changes. This only fixes the formatter mismatch left after PR #1406 auto-merged before the style commit attached.