### PR TITLE
fix(ci): seal geoseal PR fallout

### DIFF
--- a/demo/spiralverse_complete_demo.py
+++ b/demo/spiralverse_complete_demo.py
@@ -30,7 +30,7 @@ import os
 import asyncio
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 from datetime import datetime, timezone
-from typing import Optional, Tuple
+from typing import Tuple
 import numpy as np
 
 # Try to import real crypto (AES-GCM)
@@ -38,20 +38,24 @@ import numpy as np
 REAL_CRYPTO_AVAILABLE = False
 AESGCM = None
 
+
 def _try_import_crypto():
     """Attempt to import cryptography library safely"""
     global REAL_CRYPTO_AVAILABLE, AESGCM
     try:
         # Check if cffi backend is available first
         import importlib.util
+
         if importlib.util.find_spec("_cffi_backend") is None:
             return False
         from cryptography.hazmat.primitives.ciphers.aead import AESGCM as _AESGCM
+
         AESGCM = _AESGCM
         REAL_CRYPTO_AVAILABLE = True
         return True
     except Exception:
         return False
+
 
 _try_import_crypto()
 
@@ -65,6 +69,7 @@ MAX_COMPLEXITY = 1e10  # Cap to prevent overflow
 # ============================================================================
 # These show where ML-KEM-768 and ML-DSA-65 would integrate
 # For production, use liboqs or pqcrypto library
+
 
 class PQCStub:
     """
@@ -105,6 +110,7 @@ class PQCStub:
         # Stub: can't verify without proper keypair
         return len(signature) == 32
 
+
 # ============================================================================
 # PART 1: THE SIX SACRED TONGUES (Languages)
 # ============================================================================
@@ -116,7 +122,7 @@ TONGUES = {
     "RU": "Runethic - Context (the detective who knows the situation)",
     "CA": "Cassisivadan - Math & Logic (the accountant)",
     "UM": "Umbroth - Security & Encryption (the vault keeper)",
-    "DR": "Draumric - Data Types (the librarian)"
+    "DR": "Draumric - Data Types (the librarian)",
 }
 
 # ============================================================================
@@ -124,6 +130,7 @@ TONGUES = {
 # ============================================================================
 # Simple tasks = simple music = cheap
 # Complex tasks = complex harmonies = expensive
+
 
 def harmonic_complexity(depth: int, ratio: float = 1.5) -> float:
     """
@@ -138,6 +145,7 @@ def harmonic_complexity(depth: int, ratio: float = 1.5) -> float:
     result = ratio ** (depth * depth)
     return min(result, MAX_COMPLEXITY)  # Cap to prevent overflow
 
+
 def pricing_tier(depth: int) -> dict:
     """Convert complexity to a price tier"""
     H = harmonic_complexity(depth)
@@ -151,10 +159,12 @@ def pricing_tier(depth: int) -> dict:
     else:
         return {"tier": "ENTERPRISE", "complexity": H, "description": "Complex orchestration"}
 
+
 # ============================================================================
 # PART 3: 6D VECTOR NAVIGATION (Geometric Trust)
 # ============================================================================
 # Agents exist in a 6-dimensional space - like GPS but with 6 coordinates
+
 
 class Agent6D:
     """An AI agent with a position in 6D space"""
@@ -174,7 +184,7 @@ class Agent6D:
         self.trust_score = 1.0  # Starts fully trusted
         self.last_seen = time.time()
 
-    def distance_to(self, other: 'Agent6D') -> float:
+    def distance_to(self, other: "Agent6D") -> float:
         """
         Calculate distance between two agents.
         Close agents = simple communication
@@ -193,10 +203,12 @@ class Agent6D:
         self.trust_score *= np.exp(-decay_rate * time_elapsed)
         return self.trust_score
 
+
 # ============================================================================
 # PART 4: RWP ENVELOPE (The Secure Letter)
 # ============================================================================
 # This is like a tamper-proof envelope with a wax seal
+
 
 class RWPEnvelope:
     """
@@ -237,11 +249,11 @@ class RWPEnvelope:
 
         # Convert payload to JSON
         payload_json = json.dumps(self.payload, sort_keys=True)
-        payload_bytes = payload_json.encode('utf-8')
+        payload_bytes = payload_json.encode("utf-8")
 
         # Create the envelope metadata (AAD - Authenticated Associated Data)
         aad = f"{self.version}|{self.tongue}|{self.origin}|{self.timestamp}|{self.nonce}"
-        aad_bytes = aad.encode('utf-8')
+        aad_bytes = aad.encode("utf-8")
 
         # PQC: Optionally include ML-KEM encapsulated key
         pqc_ciphertext = None
@@ -278,7 +290,7 @@ class RWPEnvelope:
             "aad": aad,
             "payload": urlsafe_b64encode(encrypted).decode(),
             "sig": signature,
-            "enc": enc_mode
+            "enc": enc_mode,
         }
 
         if pqc_ciphertext:
@@ -340,16 +352,18 @@ class RWPEnvelope:
                 keystream = hmac.new(secret_key, envelope["aad"].encode(), hashlib.sha256).digest()
                 decrypted = bytes(p ^ keystream[i % len(keystream)] for i, p in enumerate(encrypted))
 
-            return json.loads(decrypted.decode('utf-8'))
+            return json.loads(decrypted.decode("utf-8"))
         except Exception:
             # Decryption failed - return noise
             noise = hmac.new(secret_key, b"decrypt_error", hashlib.sha256).digest()
             return {"error": "NOISE", "data": noise.hex()}
 
+
 # ============================================================================
 # PART 5: SECURITY GATE (The Bouncer)
 # ============================================================================
 # This decides if an agent is allowed to do something
+
 
 class SecurityGate:
     """
@@ -402,7 +416,7 @@ class SecurityGate:
 
         # Adaptive dwell time (higher risk = longer wait)
         # Note: This is time-dilation defense, not constant-time
-        dwell_ms = min(self.max_wait_ms, self.min_wait_ms * (self.alpha ** risk))
+        dwell_ms = min(self.max_wait_ms, self.min_wait_ms * (self.alpha**risk))
         await asyncio.sleep(dwell_ms / 1000.0)  # Non-blocking wait
 
         # Calculate composite score (0-1, higher = safer)
@@ -415,16 +429,16 @@ class SecurityGate:
         if score > 0.8:
             return {"status": "allow", "score": score, "dwell_ms": dwell_ms}
         elif score > 0.5:
-            return {"status": "review", "score": score, "dwell_ms": dwell_ms,
-                    "reason": "Manual approval required"}
+            return {"status": "review", "score": score, "dwell_ms": dwell_ms, "reason": "Manual approval required"}
         else:
-            return {"status": "deny", "score": score, "dwell_ms": dwell_ms,
-                    "reason": "Security threshold not met"}
+            return {"status": "deny", "score": score, "dwell_ms": dwell_ms, "reason": "Security threshold not met"}
+
 
 # ============================================================================
 # PART 6: ROUNDTABLE CONSENSUS (Multi-Signature Approval)
 # ============================================================================
 # Important decisions need multiple "departments" to agree
+
 
 class Roundtable:
     """
@@ -441,7 +455,7 @@ class Roundtable:
         "low": ["KO"],  # Just control flow
         "medium": ["KO", "RU"],  # Control + context
         "high": ["KO", "RU", "UM"],  # Control + context + security
-        "critical": ["KO", "RU", "UM", "DR"]  # All departments
+        "critical": ["KO", "RU", "UM", "DR"],  # All departments
     }
 
     @staticmethod
@@ -461,9 +475,11 @@ class Roundtable:
         """Check if we have all required signatures"""
         return all(tongue in signatures for tongue in required)
 
+
 # ============================================================================
 # DEMONSTRATION: Putting It All Together
 # ============================================================================
+
 
 async def demonstrate_spiralverse():
     """
@@ -506,12 +522,7 @@ async def demonstrate_spiralverse():
     print("✉️  PART 3: Creating Secure Envelope (RWP Demo)")
     print("-" * 80)
 
-    message = {
-        "action": "transfer_funds",
-        "amount": 1000,
-        "from": "account_123",
-        "to": "account_456"
-    }
+    message = {"action": "transfer_funds", "amount": 1000, "from": "account_123", "to": "account_456"}
 
     envelope_obj = RWPEnvelope(tongue="KO", origin="Alice-GPT", payload=message)
     sealed = envelope_obj.seal(secret_key)
@@ -563,7 +574,7 @@ async def demonstrate_spiralverse():
     print(f"    Status: {result2['status'].upper()}")
     print(f"    Score: {result2['score']:.2f}")
     print(f"    Wait time: {result2['dwell_ms']:.0f}ms")
-    if result2['status'] != 'allow':
+    if result2["status"] != "allow":
         print(f"    Reason: {result2.get('reason', 'N/A')}")
 
     # Scenario 3: Suspicious agent
@@ -664,6 +675,7 @@ Note: For production use, see the full RWP v2.1 implementation
 with AES-256-GCM encryption in src/spiralverse/index.ts
 """)
     print("=" * 80)
+
 
 # Run the demo
 if __name__ == "__main__":

--- a/examples/spiralverse_core.py
+++ b/examples/spiralverse_core.py
@@ -22,7 +22,6 @@ import os
 import asyncio
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 from datetime import datetime, timezone
-from typing import Dict, Tuple, Optional
 import numpy as np
 
 # ============================================================================
@@ -58,9 +57,7 @@ class NonceCache:
             try:
                 from bloom_filter2 import BloomFilter
 
-                self._bloom = BloomFilter(
-                    max_elements=max_size, error_rate=bloom_error_rate
-                )
+                self._bloom = BloomFilter(max_elements=max_size, error_rate=bloom_error_rate)
             except ImportError:
                 # Graceful fallback: bloom_filter2 not installed
                 self.use_bloom = False
@@ -89,9 +86,7 @@ class NonceCache:
             try:
                 from bloom_filter2 import BloomFilter
 
-                self._bloom = BloomFilter(
-                    max_elements=self.max_size, error_rate=0.001
-                )
+                self._bloom = BloomFilter(max_elements=self.max_size, error_rate=0.001)
             except ImportError:
                 pass
         else:
@@ -148,9 +143,7 @@ class EnvelopeCore:
         keystream = hmac.new(secret_key, aad.encode(), hashlib.sha256).digest()
 
         # Encrypt with XOR (keystream repeats if payload longer than 32 bytes)
-        encrypted = bytes(
-            p ^ keystream[i % len(keystream)] for i, p in enumerate(payload_bytes)
-        )
+        encrypted = bytes(p ^ keystream[i % len(keystream)] for i, p in enumerate(payload_bytes))
 
         # Create signature (HMAC over AAD + encrypted payload)
         signature_data = (aad + "|" + urlsafe_b64encode(encrypted).decode()).encode()
@@ -170,9 +163,7 @@ class EnvelopeCore:
         }
 
     @staticmethod
-    def verify_and_open(
-        envelope: dict, secret_key: bytes, max_age_seconds: int = 300
-    ) -> dict:
+    def verify_and_open(envelope: dict, secret_key: bytes, max_age_seconds: int = 300) -> dict:
         """
         Verify signature and decrypt payload.
 
@@ -221,12 +212,8 @@ class EnvelopeCore:
 
         # Decrypt payload
         encrypted = urlsafe_b64decode(envelope["payload"])
-        keystream = hmac.new(
-            secret_key, envelope["aad"].encode(), hashlib.sha256
-        ).digest()
-        decrypted = bytes(
-            e ^ keystream[i % len(keystream)] for i, e in enumerate(encrypted)
-        )
+        keystream = hmac.new(secret_key, envelope["aad"].encode(), hashlib.sha256).digest()
+        decrypted = bytes(e ^ keystream[i % len(keystream)] for i, e in enumerate(encrypted))
 
         return json.loads(decrypted.decode("utf-8"))
 
@@ -244,9 +231,7 @@ class SecurityGateCore:
     This is a time-dilation defense, not a timing-attack defense.
     """
 
-    def __init__(
-        self, min_wait_ms: int = 100, max_wait_ms: int = 5000, alpha: float = 1.5
-    ):
+    def __init__(self, min_wait_ms: int = 100, max_wait_ms: int = 5000, alpha: float = 1.5):
         self.min_wait_ms = min_wait_ms
         self.max_wait_ms = max_wait_ms
         self.alpha = alpha
@@ -409,9 +394,7 @@ class RoundtableCore:
             return RoundtableCore.TIERS["critical"]
 
     @staticmethod
-    def verify_quorum(
-        signatures: dict, required: list, pqc_pubkey: bytes = None
-    ) -> bool:
+    def verify_quorum(signatures: dict, required: list, pqc_pubkey: bytes = None) -> bool:
         """
         Check if we have all required signatures.
 
@@ -447,9 +430,7 @@ class RoundtableCore:
                     sig = signatures[tongue]
                     if isinstance(sig, str):
                         sig = sig.encode("utf-8")
-                    if not verifier.verify(
-                        tongue.encode("utf-8"), sig, pqc_pubkey
-                    ):
+                    if not verifier.verify(tongue.encode("utf-8"), sig, pqc_pubkey):
                         return False
             except ImportError:
                 # liboqs not installed — skip PQC check, rely on presence check

--- a/scripts/demos/scbe_governance_terminal_demo.py
+++ b/scripts/demos/scbe_governance_terminal_demo.py
@@ -110,12 +110,7 @@ def _fragment_score(s: str) -> float:
 def estimate_d_h(text: str) -> float:
     if not text:
         return 0.0
-    raw = (
-        _fragment_score(text)
-        + _length_drift(text)
-        + _repetition_drift(text)
-        + _shoutiness(text)
-    )
+    raw = _fragment_score(text) + _length_drift(text) + _repetition_drift(text) + _shoutiness(text)
     return min(6.0, raw)
 
 
@@ -190,9 +185,12 @@ def _print_score(s: GateScore) -> None:
     print(verdict_pill + " " + _color(s.prompt[:88], ANSI["muted"]))
     print(
         "    "
-        + _color("d_H=", ANSI["dim"]) + _color(f"{s.d_h:.3f}", ANSI["gold"])
-        + _color("  H=", ANSI["dim"]) + _color(f"{s.h_score:.3f}", ANSI["gold"])
-        + _color("  cost=", ANSI["dim"]) + _color(_format_cost(s.cost), ANSI["gold"])
+        + _color("d_H=", ANSI["dim"])
+        + _color(f"{s.d_h:.3f}", ANSI["gold"])
+        + _color("  H=", ANSI["dim"])
+        + _color(f"{s.h_score:.3f}", ANSI["gold"])
+        + _color("  cost=", ANSI["dim"])
+        + _color(_format_cost(s.cost), ANSI["gold"])
         + _color("  - " + s.rationale, ANSI["muted"])
     )
     print()
@@ -220,8 +218,10 @@ def main() -> int:
     args = p.parse_args()
 
     print()
-    print(_color("  SCBE Governance Gate  ", ANSI["bold"] + ANSI["cyan"])
-          + _color("  Layer 12 harmonic wall · canonical formula", ANSI["muted"]))
+    print(
+        _color("  SCBE Governance Gate  ", ANSI["bold"] + ANSI["cyan"])
+        + _color("  Layer 12 harmonic wall · canonical formula", ANSI["muted"])
+    )
     print(_color("  H = 1 / (1 + d_H + 2*p_d)        cost = phi^(d_H^2)", ANSI["muted"]))
     print()
 
@@ -234,9 +234,7 @@ def main() -> int:
     by_verdict: dict[str, int] = {}
     for s in scores:
         by_verdict[s.verdict] = by_verdict.get(s.verdict, 0) + 1
-    summary = "  " + "  ".join(
-        f"{v}={by_verdict.get(v, 0)}" for v in ("ALLOW", "QUARANTINE", "ESCALATE", "DENY")
-    )
+    summary = "  " + "  ".join(f"{v}={by_verdict.get(v, 0)}" for v in ("ALLOW", "QUARANTINE", "ESCALATE", "DENY"))
     print(_color(f"  scored {n} prompts", ANSI["bold"]) + _color(summary, ANSI["muted"]))
     print()
     return 0

--- a/scripts/demos/scbe_meet_in_middle_demo.py
+++ b/scripts/demos/scbe_meet_in_middle_demo.py
@@ -30,7 +30,6 @@ from src.agentic.meet_in_the_middle import (
     merge_halves,
 )
 
-
 CONTRACT = SeamContract(
     names=("payload", "verdict", "score"),
     types=("dict", "str", "float"),

--- a/scripts/demos/scbe_recruitment_trial.py
+++ b/scripts/demos/scbe_recruitment_trial.py
@@ -33,18 +33,35 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 #  Terminal niceties
 # ---------------------------------------------------------------------------
 
+
 def _color(s: str, code: str) -> str:
     if not sys.stdout.isatty():
         return s
     return f"\033[{code}m{s}\033[0m"
 
 
-def _bold(s: str) -> str: return _color(s, "1")
-def _dim(s: str) -> str: return _color(s, "2")
-def _green(s: str) -> str: return _color(s, "38;5;78")
-def _red(s: str) -> str: return _color(s, "38;5;203")
-def _cyan(s: str) -> str: return _color(s, "38;5;87")
-def _gold(s: str) -> str: return _color(s, "38;5;221")
+def _bold(s: str) -> str:
+    return _color(s, "1")
+
+
+def _dim(s: str) -> str:
+    return _color(s, "2")
+
+
+def _green(s: str) -> str:
+    return _color(s, "38;5;78")
+
+
+def _red(s: str) -> str:
+    return _color(s, "38;5;203")
+
+
+def _cyan(s: str) -> str:
+    return _color(s, "38;5;87")
+
+
+def _gold(s: str) -> str:
+    return _color(s, "38;5;221")
 
 
 def _file_sha(path: Path) -> str:
@@ -62,6 +79,7 @@ def _file_sha(path: Path) -> str:
 #  and run the public terminal demo? This is the "do they know what they
 #  are looking at" filter.
 # ---------------------------------------------------------------------------
+
 
 def phase1_terminal_hygiene() -> Tuple[bool, List[str]]:
     notes: List[str] = []
@@ -102,11 +120,10 @@ def phase1_terminal_hygiene() -> Tuple[bool, List[str]]:
 #  this trial verifies it against the canonical implementation by sampling.
 # ---------------------------------------------------------------------------
 
+
 def phase2_math_fluency(candidate_solution: Path | None = None) -> Tuple[bool, List[str]]:
     notes: List[str] = []
-    target = candidate_solution or (
-        REPO_ROOT / "candidate" / "phase2_harmonic_scale.py"
-    )
+    target = candidate_solution or (REPO_ROOT / "candidate" / "phase2_harmonic_scale.py")
     if not target.exists():
         notes.append(
             f"Expected the candidate to create {target.relative_to(REPO_ROOT) if target.is_relative_to(REPO_ROOT) else target} "
@@ -116,6 +133,7 @@ def phase2_math_fluency(candidate_solution: Path | None = None) -> Tuple[bool, L
 
     # Import the candidate's module without trusting the path.
     import importlib.util
+
     spec = importlib.util.spec_from_file_location("candidate_phase2", target)
     if spec is None or spec.loader is None:
         notes.append("Could not load candidate file as a Python module.")
@@ -155,6 +173,7 @@ def phase2_math_fluency(candidate_solution: Path | None = None) -> Tuple[bool, L
 #  governance verdict? Tests both networking competence and JSON discipline.
 # ---------------------------------------------------------------------------
 
+
 def phase3_bus_integration() -> Tuple[bool, List[str]]:
     notes: List[str] = []
     candidate = REPO_ROOT / "candidate" / "phase3_bus_call.py"
@@ -166,6 +185,7 @@ def phase3_bus_integration() -> Tuple[bool, List[str]]:
         return False, notes
 
     import importlib.util
+
     spec = importlib.util.spec_from_file_location("candidate_phase3", candidate)
     if spec is None or spec.loader is None:
         notes.append("Could not load candidate phase 3 file.")
@@ -201,6 +221,7 @@ def phase3_bus_integration() -> Tuple[bool, List[str]]:
 #  short report (Markdown) that pairs each prompt with the verdict and a
 #  one-sentence reason. Tests judgement, not just plumbing.
 # ---------------------------------------------------------------------------
+
 
 def phase4_adversarial_report() -> Tuple[bool, List[str]]:
     notes: List[str] = []

--- a/scripts/ouroboros_sft.py
+++ b/scripts/ouroboros_sft.py
@@ -53,7 +53,6 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
-
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -1219,8 +1218,7 @@ def main():
     print("=" * 72)
     print("  THE OUROBOROS CONCEPT")
     print("=" * 72)
-    print(
-        """
+    print("""
   Like the mythological serpent that eats its own tail, this script
   feeds the SCBE-AETHERMOORE system's own artifacts back into training
   data. The model learns not from external corpora but from:
@@ -1238,8 +1236,7 @@ def main():
     Code -> SFT Data -> Fine-Tuned Model -> Better Code -> Better SFT Data -> ...
 
   Patent: USPTO #63/961,403  |  Author: Issac Davis  |  v3.3.0
-"""
-    )
+""")
     print("=" * 72)
 
 

--- a/scripts/system/github_workflow_audit.py
+++ b/scripts/system/github_workflow_audit.py
@@ -160,11 +160,20 @@ def triage_failure(name: str, log: str) -> tuple[str, str]:
     if "rate limit" in log_lower:
         return "yellow", "Rate limited — add retry logic or reduce API calls"
     if "dependabot" in log_lower and ("doesn't have access" in log_lower or "does not have access" in log_lower):
-        return "yellow", "Dependabot cannot access one dependency source — remove the private/unreachable source or grant Dependabot access"
+        return (
+            "yellow",
+            "Dependabot cannot access one dependency source — remove the private/unreachable source or grant Dependabot access",
+        )
     if "failed to request additional scope" in log_lower:
-        return "yellow", "Dependabot failed while requesting repository scope — fix dependency source visibility or Dependabot permissions"
+        return (
+            "yellow",
+            "Dependabot failed while requesting repository scope — fix dependency source visibility or Dependabot permissions",
+        )
     if "either the repo doesn't exist" in log_lower or "repository not found" in log_lower:
-        return "yellow", "Dependency source repository is missing or inaccessible — fix the dependency URL/source or repository permissions"
+        return (
+            "yellow",
+            "Dependency source repository is missing or inaccessible — fix the dependency URL/source or repository permissions",
+        )
     if "assertionerror" in log_lower or "assert" in log_lower:
         return "red", "Test assertion failure — real bug, needs code fix"
     if "out of memory" in log_lower or "oom" in log_lower:

--- a/src/agentic/meet_in_the_middle.py
+++ b/src/agentic/meet_in_the_middle.py
@@ -44,14 +44,14 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from src.crypto.sacred_tongues import SACRED_TONGUE_TOKENIZER as _TOK
-
 
 # ---------------------------------------------------------------------------
 #  Data types
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class SeamContract:
@@ -64,6 +64,7 @@ class SeamContract:
         notes: Free-text guidance for the agents. NOT included in the seam
                canonical hash so notes can change without breaking convergence.
     """
+
     names: tuple[str, ...]
     types: tuple[str, ...] = ()
     notes: str = ""
@@ -93,6 +94,7 @@ class CodeHalf:
     `code` is the literal Python source for this half.
     `direction` is "forward" (input → seam) or "reverse" (seam → output).
     """
+
     direction: str
     code: str
     declared_seam: SeamContract
@@ -182,9 +184,7 @@ def merge_halves(
     fwd_hash = forward.declared_seam.seam_tongue_hash()
     rev_hash = reverse.declared_seam.seam_tongue_hash()
     if fwd_hash != rev_hash:
-        diagnostics.append(
-            f"seam contracts differ: fwd={fwd_hash[:12]} rev={rev_hash[:12]}"
-        )
+        diagnostics.append(f"seam contracts differ: fwd={fwd_hash[:12]} rev={rev_hash[:12]}")
 
     if _has_seam_marker(forward.code):
         scope = set(_names_in_scope_at_seam(forward.code))
@@ -207,11 +207,7 @@ def merge_halves(
     fwd_idx = next(i for i, l in enumerate(fwd_lines) if SEAM_MARKER in l)
     rev_idx = next(i for i, l in enumerate(rev_lines) if SEAM_MARKER in l)
 
-    merged = (
-        "\n".join(fwd_lines[: fwd_idx + 1])
-        + "\n"
-        + "\n".join(rev_lines[rev_idx + 1 :])
-    )
+    merged = "\n".join(fwd_lines[: fwd_idx + 1]) + "\n" + "\n".join(rev_lines[rev_idx + 1 :])
     if not merged.endswith("\n"):
         merged += "\n"
 

--- a/src/cli/param_binding.py
+++ b/src/cli/param_binding.py
@@ -36,9 +36,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Iterable,
     Mapping,
-    Optional,
     Sequence,
     Type,
     get_args,
@@ -198,13 +196,9 @@ class BoundCommand(BaseModel):
                 if any(getattr(inst, m, None) not in (None, [], "") for m in members):
                     present_sets.append(set_name)
             if len(present_sets) == 0:
-                raise ParameterSetError(
-                    f"no parameter set satisfied; supply args for one of: {list(sets.keys())}"
-                )
+                raise ParameterSetError(f"no parameter set satisfied; supply args for one of: {list(sets.keys())}")
             if len(present_sets) > 1:
-                raise ParameterSetError(
-                    f"parameter sets are mutually exclusive; saw multiple: {present_sets}"
-                )
+                raise ParameterSetError(f"parameter sets are mutually exclusive; saw multiple: {present_sets}")
         return inst
 
     @classmethod

--- a/src/crypto/geo_fenced_seal.py
+++ b/src/crypto/geo_fenced_seal.py
@@ -49,16 +49,14 @@ EARTH_RADIUS_M = 6_371_008.8
 #  Distance
 # ---------------------------------------------------------------------------
 
+
 def haversine_meters(lat_a: float, lon_a: float, lat_b: float, lon_b: float) -> float:
     """Great-circle distance between two (lat, lon) points in meters."""
     phi_a = math.radians(lat_a)
     phi_b = math.radians(lat_b)
     d_phi = math.radians(lat_b - lat_a)
     d_lam = math.radians(lon_b - lon_a)
-    a = (
-        math.sin(d_phi / 2) ** 2
-        + math.cos(phi_a) * math.cos(phi_b) * math.sin(d_lam / 2) ** 2
-    )
+    a = math.sin(d_phi / 2) ** 2 + math.cos(phi_a) * math.cos(phi_b) * math.sin(d_lam / 2) ** 2
     c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
     return EARTH_RADIUS_M * c
 
@@ -82,6 +80,7 @@ def _validate_fence(fence: Mapping[str, Any]) -> Dict[str, float]:
 # ---------------------------------------------------------------------------
 #  Seal / unseal with geo policy
 # ---------------------------------------------------------------------------
+
 
 class GeoFenceViolation(PermissionError):
     """Raised when an unseal attempt is outside the configured fence."""
@@ -145,8 +144,7 @@ def unseal_with_geo_check(
     distance_m = haversine_meters(fence["lat"], fence["lon"], cur_lat, cur_lon)
     if distance_m > fence["radius_m"]:
         raise GeoFenceViolation(
-            f"current location is {distance_m:.1f} m from fence center; "
-            f"fence radius is {fence['radius_m']:.1f} m"
+            f"current location is {distance_m:.1f} m from fence center; " f"fence radius is {fence['radius_m']:.1f} m"
         )
 
     result = unseal_memory_packet(secret, packet, enable_pqc=enable_pqc)

--- a/src/crypto/geoseal_execution_gate.py
+++ b/src/crypto/geoseal_execution_gate.py
@@ -141,7 +141,6 @@ def scan_command(command: str, *, claimed_paths: Optional[Sequence[str]] = None)
     argv, parse_findings = _parse_command(command)
     findings.extend(parse_findings)
     command_l = command.lower()
-    joined_argv_l = " ".join(argv).lower()
 
     if any(marker in command for marker in ("|", "&&", "||", ";")):
         findings.append(
@@ -170,9 +169,7 @@ def scan_command(command: str, *, claimed_paths: Optional[Sequence[str]] = None)
         executable = Path(argv[0]).name.lower()
         if executable in {"powershell", "powershell.exe", "pwsh", "pwsh.exe"}:
             if any(arg.lower() in {"-encodedcommand", "-enc"} for arg in argv[1:]):
-                findings.append(
-                    GateFinding("encoded-powershell", "DENY", "encoded PowerShell commands are blocked")
-                )
+                findings.append(GateFinding("encoded-powershell", "DENY", "encoded PowerShell commands are blocked"))
         if executable in {"python", "python.exe", "py", "node", "node.exe"} and "-c" in argv[1:]:
             findings.append(
                 GateFinding(
@@ -185,11 +182,7 @@ def scan_command(command: str, *, claimed_paths: Optional[Sequence[str]] = None)
 
     if claimed_paths:
         normalized_claims = [Path(path).as_posix().lower().strip("/") for path in claimed_paths]
-        touched = [
-            token.strip("\"'").replace("\\", "/").lower()
-            for token in argv
-            if "/" in token or "\\" in token
-        ]
+        touched = [token.strip("\"'").replace("\\", "/").lower() for token in argv if "/" in token or "\\" in token]
         for token in touched:
             if normalized_claims and not any(token.startswith(claim) or claim in token for claim in normalized_claims):
                 findings.append(

--- a/src/crypto/sealed_memory_packets.py
+++ b/src/crypto/sealed_memory_packets.py
@@ -1,0 +1,225 @@
+"""Sealed memory packets built on Sacred Tongues transport and RWP v3.
+
+This module does not make Sacred Tongues a security boundary by itself. The
+tokenizer supplies exact byte-for-token reversibility; RWP v3 supplies the
+authenticated encryption boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+from .rwp_v3 import RWPEnvelope, RWPv3Protocol, get_rwp_pqc_governance_status
+from .sacred_tongues import SACRED_TONGUE_TOKENIZER
+
+SCHEMA_VERSION = "scbe.sealed_memory_packet.v1"
+DEFAULT_TONGUE = "ca"
+
+BytesLike = Union[bytes, bytearray, memoryview]
+Payload = Union[str, BytesLike]
+Secret = Union[str, BytesLike]
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _coerce_secret(secret: Secret) -> bytes:
+    if isinstance(secret, str):
+        value = secret.encode("utf-8")
+    elif isinstance(secret, (bytes, bytearray, memoryview)):
+        value = bytes(secret)
+    else:
+        raise TypeError("secret must be str or bytes-like")
+    if not value:
+        raise ValueError("secret must not be empty")
+    return value
+
+
+def _coerce_payload(payload: Payload) -> bytes:
+    if isinstance(payload, str):
+        return payload.encode("utf-8")
+    if isinstance(payload, (bytes, bytearray, memoryview)):
+        return bytes(payload)
+    raise TypeError("payload must be str or bytes-like")
+
+
+def _normalize_metadata(metadata: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, Mapping):
+        raise TypeError("metadata must be a mapping")
+    normalized = dict(metadata)
+    _canonical_json_bytes(normalized)
+    return normalized
+
+
+def _token_hash(tokens: List[str]) -> str:
+    return _sha256_hex(_canonical_json_bytes(tokens))
+
+
+def _metadata_hash(metadata: Mapping[str, Any]) -> str:
+    return _sha256_hex(_canonical_json_bytes(metadata))
+
+
+def _build_aad(packet_fields: Mapping[str, Any], metadata: Mapping[str, Any]) -> bytes:
+    aad = {
+        "schema_version": packet_fields["schema_version"],
+        "kind": packet_fields["kind"],
+        "label": packet_fields["label"],
+        "tongue": packet_fields["tongue"],
+        "token_count": packet_fields["token_count"],
+        "source_sha256": packet_fields["source_sha256"],
+        "token_sha256": packet_fields["token_sha256"],
+        "metadata_sha256": _metadata_hash(metadata),
+    }
+    return _canonical_json_bytes(aad)
+
+
+def seal_memory_packet(
+    secret: Secret,
+    payload: Payload,
+    *,
+    tongue: str = DEFAULT_TONGUE,
+    label: str = "memory",
+    metadata: Optional[Mapping[str, Any]] = None,
+    enable_pqc: bool = False,
+) -> Dict[str, Any]:
+    """Encode payload into a bijective tongue stream, then seal it with RWP v3.
+
+    The returned dict is JSON-serializable. The plaintext Sacred Tongue tokens
+    are encrypted inside the RWP envelope; only hashes and routing metadata stay
+    outside for audit and lookup.
+    """
+
+    if tongue not in SACRED_TONGUE_TOKENIZER.tongues:
+        raise ValueError(f"unknown Sacred Tongue code: {tongue}")
+    if not label:
+        raise ValueError("label must not be empty")
+
+    secret_bytes = _coerce_secret(secret)
+    payload_bytes = _coerce_payload(payload)
+    normalized_metadata = _normalize_metadata(metadata)
+
+    tokens = SACRED_TONGUE_TOKENIZER.encode_bytes(tongue, payload_bytes)
+    token_document = {"tongue": tongue, "tokens": tokens}
+    token_document_bytes = _canonical_json_bytes(token_document)
+
+    packet_fields: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "sealed_memory_packet",
+        "label": label,
+        "tongue": tongue,
+        "token_count": len(tokens),
+        "source_sha256": _sha256_hex(payload_bytes),
+        "token_sha256": _token_hash(tokens),
+    }
+    aad = _build_aad(packet_fields, normalized_metadata)
+
+    protocol = RWPv3Protocol(enable_pqc=enable_pqc)
+    envelope = protocol.encrypt(
+        password=secret_bytes,
+        plaintext=token_document_bytes,
+        aad=aad,
+    )
+
+    return {
+        **packet_fields,
+        "metadata": normalized_metadata,
+        "envelope": envelope.to_dict(),
+        "crypto_governance": get_rwp_pqc_governance_status(),
+    }
+
+
+def unseal_memory_packet(
+    secret: Secret,
+    packet: Mapping[str, Any],
+    *,
+    enable_pqc: bool = False,
+) -> Dict[str, Any]:
+    """Open a sealed memory packet and verify transport and payload hashes."""
+
+    secret_bytes = _coerce_secret(secret)
+    normalized_metadata = _normalize_metadata(packet.get("metadata", {}))
+
+    packet_fields = {
+        "schema_version": packet.get("schema_version"),
+        "kind": packet.get("kind"),
+        "label": packet.get("label"),
+        "tongue": packet.get("tongue"),
+        "token_count": packet.get("token_count"),
+        "source_sha256": packet.get("source_sha256"),
+        "token_sha256": packet.get("token_sha256"),
+    }
+    if packet_fields["schema_version"] != SCHEMA_VERSION:
+        raise ValueError("unsupported sealed memory packet schema")
+    if packet_fields["kind"] != "sealed_memory_packet":
+        raise ValueError("unsupported sealed memory packet kind")
+    if packet_fields["tongue"] not in SACRED_TONGUE_TOKENIZER.tongues:
+        raise ValueError(f"unknown Sacred Tongue code: {packet_fields['tongue']}")
+    if not isinstance(packet_fields["token_count"], int) or packet_fields["token_count"] < 0:
+        raise ValueError("invalid token_count")
+
+    aad = _build_aad(packet_fields, normalized_metadata)
+    protocol = RWPv3Protocol(enable_pqc=enable_pqc)
+    try:
+        envelope = RWPEnvelope.from_dict(packet["envelope"])
+    except Exception as exc:
+        raise ValueError("invalid RWP envelope") from exc
+
+    sealed_aad = SACRED_TONGUE_TOKENIZER.decode_section("aad", envelope.aad)
+    if sealed_aad != aad:
+        raise ValueError("sealed packet AAD mismatch")
+
+    token_document_bytes = protocol.decrypt(secret_bytes, envelope)
+    try:
+        token_document = json.loads(token_document_bytes.decode("utf-8"))
+    except Exception as exc:
+        raise ValueError("sealed token document is not valid JSON") from exc
+
+    if token_document.get("tongue") != packet_fields["tongue"]:
+        raise ValueError("sealed token tongue does not match packet tongue")
+    tokens = token_document.get("tokens")
+    if not isinstance(tokens, list) or not all(isinstance(token, str) for token in tokens):
+        raise ValueError("sealed token document has invalid token list")
+    if len(tokens) != packet_fields["token_count"]:
+        raise ValueError("sealed token count mismatch")
+    if _token_hash(tokens) != packet_fields["token_sha256"]:
+        raise ValueError("sealed token hash mismatch")
+
+    payload_bytes = SACRED_TONGUE_TOKENIZER.decode_tokens(packet_fields["tongue"], tokens)
+    if _sha256_hex(payload_bytes) != packet_fields["source_sha256"]:
+        raise ValueError("sealed payload hash mismatch")
+
+    try:
+        text = payload_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        text = None
+
+    return {
+        "payload": payload_bytes,
+        "text": text,
+        "tokens": tokens,
+        "metadata": normalized_metadata,
+        "label": packet_fields["label"],
+        "tongue": packet_fields["tongue"],
+        "source_sha256": packet_fields["source_sha256"],
+        "token_sha256": packet_fields["token_sha256"],
+        "roundtrip_ok": True,
+    }
+
+
+def verify_memory_packet(secret: Secret, packet: Mapping[str, Any], *, enable_pqc: bool = False) -> bool:
+    """Return True only if the sealed packet opens and all hashes verify."""
+
+    try:
+        unseal_memory_packet(secret, packet, enable_pqc=enable_pqc)
+    except Exception:
+        return False
+    return True

--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -53,6 +53,12 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+if __package__ in (None, ""):
+    repo_root = Path(__file__).resolve().parent.parent
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
 from src.ca_lexicon import (
     ALL_LANG_MAP,
     ALL_TONGUE_NAMES,
@@ -78,7 +84,6 @@ from src.crypto.geoseal_execution_gate import (
 )
 from src.agentic.meet_in_the_middle import (
     CodeHalf,
-    SEAM_MARKER,
     SeamContract,
     merge_halves,
 )
@@ -2169,8 +2174,8 @@ def cmd_exec(args: argparse.Namespace) -> int:
 # Named locations for the location-by-name parameter set.
 _NAMED_LOCATIONS: Dict[str, Tuple[float, float]] = {
     "port-angeles": (48.1181, -123.4307),
-    "sequim":       (48.0792, -123.1027),
-    "seattle":      (47.6062, -122.3321),
+    "sequim": (48.0792, -123.1027),
+    "seattle": (47.6062, -122.3321),
 }
 
 
@@ -2181,7 +2186,7 @@ class SealHereCommand(BoundCommand):
         extra="forbid",
         validate_assignment=True,
         parameter_sets={
-            "by-name":   ["location_name"],
+            "by-name": ["location_name"],
             "by-coords": ["lat", "lon"],
         },
     )
@@ -2189,7 +2194,9 @@ class SealHereCommand(BoundCommand):
     secret: str = Field(..., description="Secret used to seal the packet (required)")
     payload: str = Field(..., description="Payload string to seal (required)")
     radius_km: float = Field(
-        5.0, ge=0.1, le=100.0,
+        5.0,
+        ge=0.1,
+        le=100.0,
         description="Fence radius in kilometers (1-100)",
     )
     location_name: Optional[_Literal["port-angeles", "sequim", "seattle"]] = Field(
@@ -2200,7 +2207,8 @@ class SealHereCommand(BoundCommand):
     lon: Optional[float] = Field(None, ge=-180.0, le=180.0, description="Longitude in degrees")
     label: str = Field("seal-here", description="Audit label for the sealed packet")
     tongue: _Literal["ko", "av", "ru", "ca", "um", "dr"] = Field(
-        "ko", description="Sacred Tongue used as transport for the sealed bytes",
+        "ko",
+        description="Sacred Tongue used as transport for the sealed bytes",
     )
 
 

--- a/tests/agentic/test_geoseal_swarm_exec_cli.py
+++ b/tests/agentic/test_geoseal_swarm_exec_cli.py
@@ -14,24 +14,18 @@ import sys
 import textwrap
 from pathlib import Path
 
-import pytest
-
-
 GEOSEAL_CLI = "src/geoseal_cli.py"
 
-FORWARD_GOOD = textwrap.dedent(
-    """\
+FORWARD_GOOD = textwrap.dedent("""\
     def gate_prompt(raw):
         payload = {"text": raw, "len": len(raw)}
         drift = 1.5 if "ignore previous" in (raw or "").lower() else 0.0
         score = 1.0 / (1.0 + drift)
         verdict = "ALLOW" if score >= 0.66 else "DENY"
         # === SCBE_MEET_SEAM ===
-    """
-)
+    """)
 
-REVERSE_GOOD = textwrap.dedent(
-    """\
+REVERSE_GOOD = textwrap.dedent("""\
         # === SCBE_MEET_SEAM ===
         return {"payload": payload, "verdict": verdict, "score": round(score, 3)}
 
@@ -39,8 +33,7 @@ REVERSE_GOOD = textwrap.dedent(
     if __name__ == "__main__":
         import json
         print(json.dumps(gate_prompt("Help me draft an email.")))
-    """
-)
+    """)
 
 
 def _write_halves(tmp_path: Path, fwd_text: str, rev_text: str) -> tuple[Path, Path]:
@@ -63,10 +56,14 @@ def _run_cli(*extra: str) -> subprocess.CompletedProcess[str]:
 def test_convergence_only_prints_matching_hashes(tmp_path: Path) -> None:
     fwd, rev = _write_halves(tmp_path, FORWARD_GOOD, REVERSE_GOOD)
     proc = _run_cli(
-        "--forward", str(fwd),
-        "--reverse", str(rev),
-        "--seam-names", "payload,verdict,score",
-        "--seam-types", "dict,str,float",
+        "--forward",
+        str(fwd),
+        "--reverse",
+        str(rev),
+        "--seam-names",
+        "payload,verdict,score",
+        "--seam-types",
+        "dict,str,float",
         "--json",
     )
     assert proc.returncode == 0, proc.stderr
@@ -80,10 +77,13 @@ def test_convergence_only_prints_matching_hashes(tmp_path: Path) -> None:
 def test_divergent_seam_names_block_merge(tmp_path: Path) -> None:
     fwd, rev = _write_halves(tmp_path, FORWARD_GOOD, REVERSE_GOOD)
     proc = _run_cli(
-        "--forward", str(fwd),
-        "--reverse", str(rev),
+        "--forward",
+        str(fwd),
+        "--reverse",
+        str(rev),
         # `decision` is not bound by the forward half → fail
-        "--seam-names", "payload,decision,score",
+        "--seam-names",
+        "payload,decision,score",
         "--json",
     )
     assert proc.returncode == 2
@@ -95,9 +95,12 @@ def test_divergent_seam_names_block_merge(tmp_path: Path) -> None:
 def test_execute_path_runs_merged_module_through_gate(tmp_path: Path) -> None:
     fwd, rev = _write_halves(tmp_path, FORWARD_GOOD, REVERSE_GOOD)
     proc = _run_cli(
-        "--forward", str(fwd),
-        "--reverse", str(rev),
-        "--seam-names", "payload,verdict,score",
+        "--forward",
+        str(fwd),
+        "--reverse",
+        str(rev),
+        "--seam-names",
+        "payload,verdict,score",
         "--execute",
         "--no-audit",
     )
@@ -114,9 +117,12 @@ def test_missing_forward_file_returns_error(tmp_path: Path) -> None:
     rev = tmp_path / "reverse.py"
     rev.write_text(REVERSE_GOOD, encoding="utf-8")
     proc = _run_cli(
-        "--forward", str(tmp_path / "nope.py"),
-        "--reverse", str(rev),
-        "--seam-names", "payload,verdict,score",
+        "--forward",
+        str(tmp_path / "nope.py"),
+        "--reverse",
+        str(rev),
+        "--seam-names",
+        "payload,verdict,score",
     )
     assert proc.returncode == 2
     assert "forward half not found" in proc.stderr
@@ -126,9 +132,12 @@ def test_missing_seam_marker_blocks_with_diagnostic(tmp_path: Path) -> None:
     fwd_no_seam = "x = 1\n"  # no SEAM_MARKER
     fwd, rev = _write_halves(tmp_path, fwd_no_seam, REVERSE_GOOD)
     proc = _run_cli(
-        "--forward", str(fwd),
-        "--reverse", str(rev),
-        "--seam-names", "payload,verdict,score",
+        "--forward",
+        str(fwd),
+        "--reverse",
+        str(rev),
+        "--seam-names",
+        "payload,verdict,score",
         "--json",
     )
     assert proc.returncode == 2
@@ -140,10 +149,14 @@ def test_missing_seam_marker_blocks_with_diagnostic(tmp_path: Path) -> None:
 def test_seam_types_must_be_parallel_or_empty(tmp_path: Path) -> None:
     fwd, rev = _write_halves(tmp_path, FORWARD_GOOD, REVERSE_GOOD)
     proc = _run_cli(
-        "--forward", str(fwd),
-        "--reverse", str(rev),
-        "--seam-names", "payload,verdict,score",
-        "--seam-types", "dict,str",  # too short
+        "--forward",
+        str(fwd),
+        "--reverse",
+        str(rev),
+        "--seam-names",
+        "payload,verdict,score",
+        "--seam-types",
+        "dict,str",  # too short
     )
     assert proc.returncode == 2
     assert "parallel" in proc.stderr

--- a/tests/agentic/test_meet_in_the_middle.py
+++ b/tests/agentic/test_meet_in_the_middle.py
@@ -11,10 +11,10 @@ from src.agentic.meet_in_the_middle import (
     merge_halves,
 )
 
-
 # ---------------------------------------------------------------------------
 #  SeamContract canonicalization
 # ---------------------------------------------------------------------------
+
 
 def test_seam_contract_hash_is_stable() -> None:
     a = SeamContract(names=("x", "y"), types=("int", "int"))

--- a/tests/cli/test_param_binding.py
+++ b/tests/cli/test_param_binding.py
@@ -14,7 +14,6 @@ import argparse
 import json
 import subprocess
 import sys
-from pathlib import Path
 from typing import Literal, Optional
 
 import pytest
@@ -26,10 +25,10 @@ from src.cli.param_binding import (
     bind_subparser,
 )
 
-
 # ---------------------------------------------------------------------------
 #  Models used as fixtures
 # ---------------------------------------------------------------------------
+
 
 class _SimpleCmd(BoundCommand):
     name: str = Field(..., description="Required name")
@@ -43,7 +42,7 @@ class _ParamSetCmd(BoundCommand):
     model_config = ConfigDict(
         extra="forbid",
         parameter_sets={
-            "by-name":   ["location_name"],
+            "by-name": ["location_name"],
             "by-coords": ["lat", "lon"],
         },
     )
@@ -62,6 +61,7 @@ def _make_parser_with(model, handler):
 #  Direct framework tests
 # ---------------------------------------------------------------------------
 
+
 def test_required_field_marked_required_in_argparse() -> None:
     parser = _make_parser_with(_SimpleCmd, lambda c, ns: 0)
     with pytest.raises(SystemExit):
@@ -74,8 +74,8 @@ def test_defaults_flow_through_argparse_and_validate() -> None:
     ns = parser.parse_args(["--name", "alpha"])
     bound = _SimpleCmd.from_namespace(ns)
     assert bound.name == "alpha"
-    assert bound.count == 3       # default flowed through
-    assert bound.flag is False    # store_true default
+    assert bound.count == 3  # default flowed through
+    assert bound.flag is False  # store_true default
     assert bound.tongue == "ko"
     assert bound.tags == []
 
@@ -112,6 +112,7 @@ def test_boolean_flag_default_false_becomes_true_when_passed() -> None:
 # ---------------------------------------------------------------------------
 #  Parameter-set tests
 # ---------------------------------------------------------------------------
+
 
 def test_parameter_set_by_name_path_succeeds() -> None:
     parser = _make_parser_with(_ParamSetCmd, lambda c, ns: 0)
@@ -162,16 +163,22 @@ GEOSEAL_CLI = "src/geoseal_cli.py"
 def _run_cli(*extra: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, GEOSEAL_CLI, "seal-here", *extra],
-        capture_output=True, text=True, timeout=60,
+        capture_output=True,
+        text=True,
+        timeout=60,
     )
 
 
 def test_seal_here_by_name_emits_packet_summary() -> None:
     proc = _run_cli(
-        "--secret", "testkey",
-        "--payload", "agent-state-42",
-        "--location-name", "port-angeles",
-        "--radius-km", "5",
+        "--secret",
+        "testkey",
+        "--payload",
+        "agent-state-42",
+        "--location-name",
+        "port-angeles",
+        "--radius-km",
+        "5",
     )
     assert proc.returncode == 0, proc.stderr
     body = proc.stdout.strip().splitlines()
@@ -184,17 +191,26 @@ def test_seal_here_by_name_emits_packet_summary() -> None:
 
 def test_seal_here_by_coords_matches_by_name_for_same_point() -> None:
     by_name = _run_cli(
-        "--secret", "testkey",
-        "--payload", "agent-state-42",
-        "--location-name", "port-angeles",
-        "--radius-km", "5",
+        "--secret",
+        "testkey",
+        "--payload",
+        "agent-state-42",
+        "--location-name",
+        "port-angeles",
+        "--radius-km",
+        "5",
     )
     by_coords = _run_cli(
-        "--secret", "testkey",
-        "--payload", "agent-state-42",
-        "--lat", "48.1181",
-        "--lon", "-123.4307",
-        "--radius-km", "5",
+        "--secret",
+        "testkey",
+        "--payload",
+        "agent-state-42",
+        "--lat",
+        "48.1181",
+        "--lon",
+        "-123.4307",
+        "--radius-km",
+        "5",
     )
     name_summary = json.loads(by_name.stdout)
     coord_summary = json.loads(by_coords.stdout)
@@ -206,9 +222,14 @@ def test_seal_here_by_coords_matches_by_name_for_same_point() -> None:
 
 def test_seal_here_radius_out_of_range_rejected() -> None:
     proc = _run_cli(
-        "--secret", "k", "--payload", "p",
-        "--location-name", "seattle",
-        "--radius-km", "200",
+        "--secret",
+        "k",
+        "--payload",
+        "p",
+        "--location-name",
+        "seattle",
+        "--radius-km",
+        "200",
     )
     assert proc.returncode != 0
     assert "less_than_equal" in proc.stderr or "100" in proc.stderr
@@ -216,9 +237,16 @@ def test_seal_here_radius_out_of_range_rejected() -> None:
 
 def test_seal_here_both_sets_rejected() -> None:
     proc = _run_cli(
-        "--secret", "k", "--payload", "p",
-        "--location-name", "sequim",
-        "--lat", "48.0", "--lon", "-123.0",
+        "--secret",
+        "k",
+        "--payload",
+        "p",
+        "--location-name",
+        "sequim",
+        "--lat",
+        "48.0",
+        "--lon",
+        "-123.0",
     )
     assert proc.returncode != 0
     assert "mutually exclusive" in proc.stderr
@@ -226,8 +254,12 @@ def test_seal_here_both_sets_rejected() -> None:
 
 def test_seal_here_unknown_named_location_rejected_by_argparse() -> None:
     proc = _run_cli(
-        "--secret", "k", "--payload", "p",
-        "--location-name", "moscow",
+        "--secret",
+        "k",
+        "--payload",
+        "p",
+        "--location-name",
+        "moscow",
     )
     assert proc.returncode != 0
     assert "invalid choice" in proc.stderr

--- a/tests/crypto/test_geo_fenced_seal.py
+++ b/tests/crypto/test_geo_fenced_seal.py
@@ -12,20 +12,17 @@ from src.crypto.geo_fenced_seal import (
 )
 from src.crypto.sealed_memory_packets import unseal_memory_packet
 
-
 PORT_ANGELES = {"lat": 48.1181, "lon": -123.4307}
-SEQUIM = {"lat": 48.0792, "lon": -123.1027}             # ~25 km east
-SEATTLE = {"lat": 47.6062, "lon": -122.3321}            # ~120 km east-southeast
-MOSCOW = {"lat": 55.7558, "lon": 37.6173}               # ~8500 km
+SEQUIM = {"lat": 48.0792, "lon": -123.1027}  # ~25 km east
+SEATTLE = {"lat": 47.6062, "lon": -122.3321}  # ~120 km east-southeast
+MOSCOW = {"lat": 55.7558, "lon": 37.6173}  # ~8500 km
 SECRET = b"k" * 32
 PAYLOAD = b"agent state v1: deploy=true, run=42"
 
 
 def test_haversine_known_pairs() -> None:
     # Port Angeles → Sequim ≈ 24 km, ±1 km
-    d = haversine_meters(
-        PORT_ANGELES["lat"], PORT_ANGELES["lon"], SEQUIM["lat"], SEQUIM["lon"]
-    )
+    d = haversine_meters(PORT_ANGELES["lat"], PORT_ANGELES["lon"], SEQUIM["lat"], SEQUIM["lon"])
     assert 23_000 < d < 26_000
     # Self-distance is zero
     assert haversine_meters(48.0, -123.0, 48.0, -123.0) == pytest.approx(0.0, abs=1e-6)
@@ -33,11 +30,14 @@ def test_haversine_known_pairs() -> None:
 
 def test_seal_unseal_inside_fence() -> None:
     pkt = seal_with_geo_fence(
-        SECRET, PAYLOAD,
+        SECRET,
+        PAYLOAD,
         geo_fence={**PORT_ANGELES, "radius_m": 5_000},
     )
     out = unseal_with_geo_check(
-        SECRET, pkt, current_location=PORT_ANGELES,
+        SECRET,
+        pkt,
+        current_location=PORT_ANGELES,
     )
     assert out["payload"] == PAYLOAD
     assert out["geo_fence_check"]["passed"] is True
@@ -46,7 +46,8 @@ def test_seal_unseal_inside_fence() -> None:
 
 def test_unseal_outside_fence_raises() -> None:
     pkt = seal_with_geo_fence(
-        SECRET, PAYLOAD,
+        SECRET,
+        PAYLOAD,
         geo_fence={**PORT_ANGELES, "radius_m": 5_000},
     )
     # Sequim is ~25 km away — well outside a 5 km fence.
@@ -57,7 +58,8 @@ def test_unseal_outside_fence_raises() -> None:
 
 def test_far_away_violates() -> None:
     pkt = seal_with_geo_fence(
-        SECRET, PAYLOAD,
+        SECRET,
+        PAYLOAD,
         geo_fence={**PORT_ANGELES, "radius_m": 1_000_000},  # 1000 km radius
     )
     # Moscow is way outside any sane fence around Port Angeles.
@@ -67,9 +69,7 @@ def test_far_away_violates() -> None:
 
 def test_packet_without_fence_rejects_geo_unseal() -> None:
     # Seal without geo_fence metadata — must not silently bypass the policy.
-    pkt = seal_with_geo_fence(
-        SECRET, PAYLOAD, geo_fence={**PORT_ANGELES, "radius_m": 5_000}
-    )
+    pkt = seal_with_geo_fence(SECRET, PAYLOAD, geo_fence={**PORT_ANGELES, "radius_m": 5_000})
     # Manually strip the fence to simulate a downgrade attempt.
     pkt["metadata"] = {k: v for k, v in pkt["metadata"].items() if k != "geo_fence"}
     with pytest.raises(ValueError):
@@ -79,7 +79,8 @@ def test_packet_without_fence_rejects_geo_unseal() -> None:
 def test_tampered_fence_breaks_aead() -> None:
     # Bind to Port Angeles, attacker tries to widen the fence to cover Moscow.
     pkt = seal_with_geo_fence(
-        SECRET, PAYLOAD,
+        SECRET,
+        PAYLOAD,
         geo_fence={**PORT_ANGELES, "radius_m": 1_000},
     )
     pkt["metadata"]["geo_fence"]["radius_m"] = 100_000_000  # global
@@ -102,7 +103,8 @@ def test_metadata_geo_fence_collision_rejected() -> None:
     # Caller cannot smuggle a geo_fence in via metadata — must use the kwarg.
     with pytest.raises(ValueError):
         seal_with_geo_fence(
-            SECRET, PAYLOAD,
+            SECRET,
+            PAYLOAD,
             geo_fence={**PORT_ANGELES, "radius_m": 100},
             metadata={"geo_fence": {"lat": 0.0, "lon": 0.0, "radius_m": 100}},
         )

--- a/tests/crypto/test_geoseal_execution_gate.py
+++ b/tests/crypto/test_geoseal_execution_gate.py
@@ -111,7 +111,7 @@ def test_exec_runs_bare_python_alias_after_resolution() -> None:
     """The CLI passes 'python' as argv[0]; the resolver must rewrite it
     so subprocess.run does not raise FileNotFoundError on Windows."""
     result = execute_governed_command(
-        'python -c "print(\'resolved-ok\')"',
+        "python -c \"print('resolved-ok')\"",
         max_tier="QUARANTINE",
         audit_log=None,
     )

--- a/tests/crypto/test_sealed_memory_packets.py
+++ b/tests/crypto/test_sealed_memory_packets.py
@@ -1,0 +1,84 @@
+"""Tests for sealed memory packets."""
+
+import copy
+import json
+
+import pytest
+
+from src.crypto.sealed_memory_packets import (
+    seal_memory_packet,
+    unseal_memory_packet,
+    verify_memory_packet,
+)
+
+
+def test_sealed_memory_packet_roundtrips_exact_bytes():
+    payload = b"system: keep spacing\ncommand: run-tests --target=crypto\n\xff\x00tail"
+    packet = seal_memory_packet(
+        b"test-secret",
+        payload,
+        tongue="ca",
+        label="agent-instruction",
+        metadata={"agent": "codex", "priority": 1},
+    )
+
+    opened = unseal_memory_packet(b"test-secret", packet)
+
+    assert opened["payload"] == payload
+    assert opened["text"] is None
+    assert opened["tongue"] == "ca"
+    assert opened["label"] == "agent-instruction"
+    assert opened["metadata"] == {"agent": "codex", "priority": 1}
+    assert opened["roundtrip_ok"] is True
+    assert len(opened["tokens"]) == len(payload)
+    json.dumps(packet, sort_keys=True)
+    assert verify_memory_packet(b"test-secret", packet) is True
+
+
+def test_sealed_memory_packet_roundtrips_text():
+    packet = seal_memory_packet("test-secret", "Seal this instruction exactly.", tongue="dr")
+    opened = unseal_memory_packet("test-secret", packet)
+
+    assert opened["text"] == "Seal this instruction exactly."
+    assert opened["payload"] == b"Seal this instruction exactly."
+
+
+def test_wrong_secret_rejects_packet():
+    packet = seal_memory_packet("correct-secret", "private instruction")
+
+    with pytest.raises(ValueError, match="AEAD authentication failed"):
+        unseal_memory_packet("wrong-secret", packet)
+
+    assert verify_memory_packet("wrong-secret", packet) is False
+
+
+def test_metadata_tamper_rejects_packet():
+    packet = seal_memory_packet(
+        "test-secret",
+        "private instruction",
+        metadata={"role": "operator"},
+    )
+    tampered = copy.deepcopy(packet)
+    tampered["metadata"]["role"] = "admin"
+
+    with pytest.raises(ValueError, match="sealed packet AAD mismatch"):
+        unseal_memory_packet("test-secret", tampered)
+
+
+def test_token_hash_tamper_rejects_packet():
+    packet = seal_memory_packet("test-secret", "private instruction")
+    tampered = copy.deepcopy(packet)
+    tampered["token_sha256"] = "0" * 64
+
+    with pytest.raises(ValueError, match="sealed packet AAD mismatch"):
+        unseal_memory_packet("test-secret", tampered)
+
+
+def test_invalid_tongue_rejected_before_seal():
+    with pytest.raises(ValueError, match="unknown Sacred Tongue code"):
+        seal_memory_packet("test-secret", "payload", tongue="invalid")
+
+
+def test_empty_secret_rejected():
+    with pytest.raises(ValueError, match="secret must not be empty"):
+        seal_memory_packet("", "payload")


### PR DESCRIPTION
## Summary

Follow-up after #1410 was squash-merged before the lint-fix commit landed.

Fixes:
- formats the Python files added by the geoseal execution-gate PR so CI Black passes
- removes ruff-unused imports / unused variable in the new slice
- adds the missing `src.crypto.sealed_memory_packets` module and regression tests that #1410 imports
- preserves direct `python src/geoseal_cli.py ...` subprocess execution by bootstrapping repo root onto `sys.path`

## Verification

Local focused checks from a clean worktree based on current `origin/main`:

- `black --check` on the touched Python slice: pass
- `ruff check` on the touched Python slice: pass
- `pytest` focused geoseal/agentic/crypto/CLI stack: 57 passed