### PR TITLE
style(cli): match CI Black formatting

### DIFF
--- a/src/cli/cross_build_ir.py
+++ b/src/cli/cross_build_ir.py
@@ -198,14 +198,10 @@ def lift_to_lattice(src_code: str, src_tongue: str) -> LatticeOp:
         matches.append((entry, _named_groups_to_args(m)))
 
     if not matches:
-        raise LiftFailure(
-            f"no lexicon op template matched in tongue={tongue}: {src_code!r}"
-        )
+        raise LiftFailure(f"no lexicon op template matched in tongue={tongue}: {src_code!r}")
     if len(matches) > 1:
         names = sorted(e.name for e, _ in matches)
-        raise AmbiguityError(
-            f"source matched multiple lexicon ops in tongue={tongue}: {names}"
-        )
+        raise AmbiguityError(f"source matched multiple lexicon ops in tongue={tongue}: {names}")
     entry, args = matches[0]
     return LatticeOp.from_entry(entry, args)
 
@@ -228,9 +224,7 @@ def emit_from_ir(ir: LatticeOp, dst_tongue: str) -> str:
     needed = set(_template_field_names(template))
     missing = needed - set(ir.args.keys())
     if missing:
-        raise EmitFailure(
-            f"IR missing args for tongue={tongue} template: {sorted(missing)}"
-        )
+        raise EmitFailure(f"IR missing args for tongue={tongue} template: {sorted(missing)}")
     return template.format(**ir.args)
 
 

--- a/src/cli/param_binding.py
+++ b/src/cli/param_binding.py
@@ -52,9 +52,7 @@ class ParameterSetError(ValueError):
 
 
 def _is_literal(annotation: Any) -> bool:
-    return get_origin(annotation) is not None and "Literal" in str(
-        get_origin(annotation)
-    )
+    return get_origin(annotation) is not None and "Literal" in str(get_origin(annotation))
 
 
 def _literal_choices(annotation: Any) -> list[Any]:
@@ -203,13 +201,9 @@ class BoundCommand(BaseModel):
                 if any(getattr(inst, m, None) not in absent for m in members):
                     present_sets.append(set_name)
             if len(present_sets) == 0:
-                raise ParameterSetError(
-                    f"no parameter set satisfied; supply args for one of: {list(sets.keys())}"
-                )
+                raise ParameterSetError(f"no parameter set satisfied; supply args for one of: {list(sets.keys())}")
             if len(present_sets) > 1:
-                raise ParameterSetError(
-                    f"parameter sets are mutually exclusive; saw multiple: {present_sets}"
-                )
+                raise ParameterSetError(f"parameter sets are mutually exclusive; saw multiple: {present_sets}")
         return inst
 
     @classmethod

--- a/src/cli/slm_router.py
+++ b/src/cli/slm_router.py
@@ -91,9 +91,7 @@ class StubSLMAdapter:
     can't accidentally pass on undefined inputs.
     """
 
-    scripted_by_choice_set: Dict[frozenset, Tuple[str, float]] = field(
-        default_factory=dict
-    )
+    scripted_by_choice_set: Dict[frozenset, Tuple[str, float]] = field(default_factory=dict)
     scripted_by_prompt: Dict[str, Tuple[str, float]] = field(default_factory=dict)
     calls: List[Tuple[str, Tuple[str, ...]]] = field(default_factory=list)
 
@@ -104,9 +102,7 @@ class StubSLMAdapter:
             return self.scripted_by_choice_set[key_set]
         if prompt in self.scripted_by_prompt:
             return self.scripted_by_prompt[prompt]
-        raise KeyError(
-            f"StubSLMAdapter has no script for choices={choices} or prompt={prompt!r}"
-        )
+        raise KeyError(f"StubSLMAdapter has no script for choices={choices} or prompt={prompt!r}")
 
 
 @dataclass
@@ -128,9 +124,7 @@ class OllamaAdapter:
         try:
             import httpx  # noqa: PLC0415  - lazy so tests don't require it
         except ImportError as exc:  # pragma: no cover - import-time guard
-            raise RuntimeError(
-                "OllamaAdapter requires `httpx`; install with `pip install httpx`"
-            ) from exc
+            raise RuntimeError("OllamaAdapter requires `httpx`; install with `pip install httpx`") from exc
 
         full_prompt = (
             f"{prompt}\n\n"
@@ -147,14 +141,10 @@ class OllamaAdapter:
         # All HTTP and parse failures must surface as ClassificationFailure
         # so the funnel filter can branch on a single QuarantineError catch.
         try:
-            resp = httpx.post(
-                f"{self.host}/api/generate", json=body, timeout=self.request_timeout
-            )
+            resp = httpx.post(f"{self.host}/api/generate", json=body, timeout=self.request_timeout)
             resp.raise_for_status()
         except Exception as exc:
-            raise ClassificationFailure(
-                f"OllamaAdapter HTTP failed: {type(exc).__name__}: {exc}"
-            ) from exc
+            raise ClassificationFailure(f"OllamaAdapter HTTP failed: {type(exc).__name__}: {exc}") from exc
         raw = resp.json().get("response", "")
         try:
             parsed = json.loads(raw)
@@ -252,9 +242,7 @@ def _tongue_prompt(intent: str, op_name: str, tongues: Sequence[str]) -> str:
 
 
 def _ops_in_band(band: str) -> List[str]:
-    return sorted(
-        name for name in TIER1_PARTICIPATING_OPS if LEXICON_BY_NAME[name].band == band
-    )
+    return sorted(name for name in TIER1_PARTICIPATING_OPS if LEXICON_BY_NAME[name].band == band)
 
 
 def _required_args_for(op_name: str) -> List[str]:
@@ -263,11 +251,7 @@ def _required_args_for(op_name: str) -> List[str]:
 
     fields: set[str] = set()
     for template in LEXICON_BY_NAME[op_name].code.values():
-        fields.update(
-            field
-            for _, field, _, _ in _s.Formatter().parse(template)
-            if field is not None
-        )
+        fields.update(field for _, field, _, _ in _s.Formatter().parse(template) if field is not None)
     return sorted(fields)
 
 
@@ -321,9 +305,7 @@ class Mode(str, enum.Enum):
         try:
             return cls(value.lower())
         except ValueError as exc:
-            raise ManualModeError(
-                f"unknown routing mode {value!r}; valid: {[m.value for m in cls]}"
-            ) from exc
+            raise ManualModeError(f"unknown routing mode {value!r}; valid: {[m.value for m in cls]}") from exc
 
 
 # Type alias for the optional arg validator. The validator is called with
@@ -339,13 +321,10 @@ def _default_safe_arg_validator(op_name: str, args: Mapping[str, str]) -> None:
     forbidden = (";", "|", "&", "`", "$", "\x00")
     for k, v in args.items():
         if not isinstance(v, str):
-            raise ArgValidationFailure(
-                f"arg {k!r} for op={op_name} must be a string, got {type(v).__name__}"
-            )
+            raise ArgValidationFailure(f"arg {k!r} for op={op_name} must be a string, got {type(v).__name__}")
         if any(ch in v for ch in forbidden):
             raise ArgValidationFailure(
-                f"arg {k!r}={v!r} for op={op_name} contains forbidden char "
-                f"(any of {forbidden!r})"
+                f"arg {k!r}={v!r} for op={op_name} contains forbidden char " f"(any of {forbidden!r})"
             )
 
 
@@ -448,18 +427,13 @@ class LatticeRouter:
             # if it disagrees, but log the conflict so silent drift is loud.
             entry = LEXICON_BY_NAME.get(op_name)
             if entry is None:
-                raise ManualModeError(
-                    f"pinned op_name={op_name!r} is not in the lexicon"
-                )
+                raise ManualModeError(f"pinned op_name={op_name!r} is not in the lexicon")
             if op_name not in TIER1_PARTICIPATING_OPS:
-                raise ManualModeError(
-                    f"pinned op_name={op_name!r} is excluded from Tier 1 sphere"
-                )
+                raise ManualModeError(f"pinned op_name={op_name!r} is excluded from Tier 1 sphere")
             derived_band = entry.band
             if band is not None and band != derived_band:
                 raise ManualModeError(
-                    f"pinned band={band!r} disagrees with op_name={op_name!r} "
-                    f"which lives in {derived_band!r}"
+                    f"pinned band={band!r} disagrees with op_name={op_name!r} " f"which lives in {derived_band!r}"
                 )
             band_resolved = derived_band
             reasoning.append(f"band=pinned-via-op:{band_resolved}")
@@ -470,9 +444,7 @@ class LatticeRouter:
             reasoning.append(f"band=pinned:{band_resolved}")
         else:
             if resolved_mode is Mode.MANUAL:
-                raise ManualModeError(
-                    "manual mode requires op_name (or band+op_name to be pinned)"
-                )
+                raise ManualModeError("manual mode requires op_name (or band+op_name to be pinned)")
             band_resolved = self._classify_with_floor(
                 prompt=_band_prompt(intent),
                 choices=_band_choices(),
@@ -502,9 +474,7 @@ class LatticeRouter:
         if dst_tongue is not None:
             chosen_tongue = dst_tongue.upper()
             if chosen_tongue not in TONGUE_NAMES:
-                raise ClassificationFailure(
-                    f"caller-supplied dst_tongue not in {TONGUE_NAMES}: {dst_tongue!r}"
-                )
+                raise ClassificationFailure(f"caller-supplied dst_tongue not in {TONGUE_NAMES}: {dst_tongue!r}")
             reasoning.append(f"tongue=caller-supplied:{chosen_tongue}")
         elif resolved_mode is Mode.MANUAL:
             raise ManualModeError("manual mode requires dst_tongue to be pinned")
@@ -528,9 +498,7 @@ class LatticeRouter:
         needed = set(_required_args_for(op_name))
         missing = needed - set(args.keys())
         if missing:
-            raise ClassificationFailure(
-                f"op={op_name} requires args {sorted(needed)}; missing {sorted(missing)}"
-            )
+            raise ClassificationFailure(f"op={op_name} requires args {sorted(needed)}; missing {sorted(missing)}")
 
         # Optional caller-supplied arg-value validator runs *before* the op
         # is built. This is the tripwire for shell-injection-able arg values.
@@ -540,9 +508,7 @@ class LatticeRouter:
             except QuarantineError:
                 raise
             except Exception as exc:
-                raise ArgValidationFailure(
-                    f"arg validator raised {type(exc).__name__}: {exc}"
-                ) from exc
+                raise ArgValidationFailure(f"arg validator raised {type(exc).__name__}: {exc}") from exc
 
         op = LatticeOp.from_entry(entry, dict(args))
         digest = _digest_action(op, chosen_tongue)
@@ -573,14 +539,10 @@ class LatticeRouter:
 
     def _ensure_executor(self) -> ThreadPoolExecutor:
         if self._executor is None:
-            self._executor = ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="slm-router"
-            )
+            self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="slm-router")
         return self._executor
 
-    def _call_adapter(
-        self, prompt: str, choices: Sequence[str], stage: str
-    ) -> Tuple[object, object]:
+    def _call_adapter(self, prompt: str, choices: Sequence[str], stage: str) -> Tuple[object, object]:
         """Invoke the adapter, optionally wrapped in a deadline future.
 
         Any non-QuarantineError exception is wrapped as ClassificationFailure
@@ -594,9 +556,7 @@ class LatticeRouter:
             return future.result(timeout=self._adapter_timeout)
         except FuturesTimeout as exc:
             future.cancel()
-            raise ClassificationFailure(
-                f"{stage}: adapter timed out after {self._adapter_timeout}s"
-            ) from exc
+            raise ClassificationFailure(f"{stage}: adapter timed out after {self._adapter_timeout}s") from exc
 
     def _classify_with_floor(
         self,
@@ -615,40 +575,31 @@ class LatticeRouter:
         except QuarantineError:
             raise
         except Exception as exc:
-            raise ClassificationFailure(
-                f"{stage}: adapter raised {type(exc).__name__}: {exc}"
-            ) from exc
+            raise ClassificationFailure(f"{stage}: adapter raised {type(exc).__name__}: {exc}") from exc
 
         # Type validation — reject non-string choices and non-numeric
         # confidence before they reach comparison operators.
         if not isinstance(chosen, str):
             raise ClassificationFailure(
-                f"{stage}: SLM returned non-string choice "
-                f"({type(chosen).__name__}): {chosen!r}"
+                f"{stage}: SLM returned non-string choice " f"({type(chosen).__name__}): {chosen!r}"
             )
         # Note: bool is a subclass of int in Python; explicitly exclude it.
         if isinstance(conf, bool) or not isinstance(conf, (int, float)):
             raise ClassificationFailure(
-                f"{stage}: SLM returned non-numeric confidence "
-                f"({type(conf).__name__}): {conf!r}"
+                f"{stage}: SLM returned non-numeric confidence " f"({type(conf).__name__}): {conf!r}"
             )
         conf = float(conf)
 
         # Range validation — NaN, ±inf, negative, and >1.0 all fail this
         # check because IEEE 754 makes `nan` comparisons return False.
         if not (0.0 <= conf <= 1.0):
-            raise ClassificationFailure(
-                f"{stage}: confidence={conf!r} is outside the [0, 1] contract"
-            )
+            raise ClassificationFailure(f"{stage}: confidence={conf!r} is outside the [0, 1] contract")
 
         if chosen not in choices:
-            raise ClassificationFailure(
-                f"{stage}: SLM returned {chosen!r} which is not in choices={list(choices)}"
-            )
+            raise ClassificationFailure(f"{stage}: SLM returned {chosen!r} which is not in choices={list(choices)}")
         if conf < self._min_confidence:
             raise ClassificationFailure(
-                f"{stage}: confidence={conf:.3f} below floor={self._min_confidence:.3f} "
-                f"for chosen={chosen!r}"
+                f"{stage}: confidence={conf:.3f} below floor={self._min_confidence:.3f} " f"for chosen={chosen!r}"
             )
         reasoning.append(f"{stage}={chosen} conf={conf:.3f}")
         confidences.append(conf)

--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -245,9 +245,7 @@ def inspect_runtime_packet(payload: dict[str, Any]) -> dict[str, Any]:
     content = str(payload.get("content", ""))
     language = str(payload.get("language", "python"))
     source_name = str(payload.get("source_name", "inline"))
-    portal = _build_portal_box_payload(
-        content=content, language=language, source_name=source_name
-    )
+    portal = _build_portal_box_payload(content=content, language=language, source_name=source_name)
     route_packet = (portal.get("shell_contract") or {}).get("route_packet", {})
     return {
         "version": "geoseal-runtime-inspect-v1",
@@ -272,9 +270,7 @@ def _build_execution_shell_payload(
         source_name=source_name,
         include_extended=include_extended,
     )
-    deck = build_system_deck(
-        resolution, source_text=content, source_name=source_name, max_cards=deck_size
-    )
+    deck = build_system_deck(resolution, source_text=content, source_name=source_name, max_cards=deck_size)
     return {
         "version": "geoseal-execution-shell-v1",
         "resolution": resolution,
@@ -289,14 +285,10 @@ def _execute_execution_shell_payload(
     timeout: float = 10.0,
     tongue: Optional[str] = None,
 ) -> dict[str, Any]:
-    route_packet = (
-        (shell_payload.get("resolution") or {}).get("shell_contract") or {}
-    ).get("route_packet", {})
+    route_packet = ((shell_payload.get("resolution") or {}).get("shell_contract") or {}).get("route_packet", {})
     exec_tongue = (tongue or route_packet.get("route_tongue") or "KO").upper()
     command_key = route_packet.get("command_key", "add")
-    replay = run_tongue_call(
-        command_key, exec_tongue, {"a": "7", "b": "3"}, execute=True, timeout=timeout
-    )
+    replay = run_tongue_call(command_key, exec_tongue, {"a": "7", "b": "3"}, execute=True, timeout=timeout)
     return {
         "version": "geoseal-execution-run-v1",
         "route_packet": route_packet,
@@ -526,9 +518,7 @@ def syntax_check(tongue: str, code: str, timeout: float = 5.0) -> Tuple[bool, st
 
     Uses real compilers when available, falls back to structural brace-balance check.
     """
-    compiler_map: Dict[
-        str, Tuple[Optional[str], Optional[List[str]], Optional[str]]
-    ] = {
+    compiler_map: Dict[str, Tuple[Optional[str], Optional[List[str]], Optional[str]]] = {
         "RU": (
             shutil.which("rustc"),
             ["rustc", "--edition=2021", "--crate-type=lib", "-"],
@@ -551,16 +541,10 @@ def syntax_check(tongue: str, code: str, timeout: float = 5.0) -> Tuple[bool, st
         balanced = opens == closes
         return (
             balanced,
-            (
-                "structural-ok"
-                if balanced
-                else f"unbalanced: {opens} opens vs {closes} closes"
-            ),
+            ("structural-ok" if balanced else f"unbalanced: {opens} opens vs {closes} closes"),
         )
     try:
-        proc = subprocess.run(
-            argv, input=wrapper, capture_output=True, text=True, timeout=timeout
-        )
+        proc = subprocess.run(argv, input=wrapper, capture_output=True, text=True, timeout=timeout)
         return (proc.returncode == 0, proc.stderr.strip() or "ok")
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         return (False, str(exc))
@@ -641,9 +625,7 @@ def run_tongue_call(
         import tempfile
 
         suffix = ".go" if tongue == "GO" else ".zig"
-        fd, tmp_name = tempfile.mkstemp(
-            suffix=suffix, prefix=f"geoseal_{tongue.lower()}_"
-        )
+        fd, tmp_name = tempfile.mkstemp(suffix=suffix, prefix=f"geoseal_{tongue.lower()}_")
         tmp_path = Path(tmp_name)
         with open(fd, "w", encoding="utf-8") as fh:
             fh.write(wrapped)
@@ -653,9 +635,7 @@ def run_tongue_call(
     gate_command = shlex.join(str(part) for part in argv)
     gate_decision = scan_command(gate_command)
     if TIER_RANK[gate_decision.tier] > TIER_RANK[gate_max_tier]:
-        result.error = (
-            f"execution gate {gate_decision.tier}: exceeds max tier {gate_max_tier}"
-        )
+        result.error = f"execution gate {gate_decision.tier}: exceeds max tier {gate_max_tier}"
         if gate_audit_log is not None:
             append_sealed_exec_audit(
                 {
@@ -709,12 +689,8 @@ def run_tongue_call(
                 "decision": gate_decision.to_dict(),
                 "ran": result.ran,
                 "returncode": result.returncode,
-                "stdout_sha256": hashlib.sha256(
-                    result.stdout.encode("utf-8")
-                ).hexdigest(),
-                "stderr_sha256": hashlib.sha256(
-                    result.stderr.encode("utf-8")
-                ).hexdigest(),
+                "stdout_sha256": hashlib.sha256(result.stdout.encode("utf-8")).hexdigest(),
+                "stderr_sha256": hashlib.sha256(result.stderr.encode("utf-8")).hexdigest(),
                 "error": result.error,
             },
             audit_log=gate_audit_log,
@@ -744,9 +720,7 @@ def swarm_dispatch(
         outputs = sorted({c.stdout for c in successful if c.stdout})
         if len(outputs) == 1:
             result.quorum_ok = True
-            result.consensus_hash = hashlib.sha256(
-                outputs[0].encode("utf-8")
-            ).hexdigest()
+            result.consensus_hash = hashlib.sha256(outputs[0].encode("utf-8")).hexdigest()
         elif len(outputs) > 1:
             tally: Dict[str, int] = {}
             for c in successful:
@@ -868,8 +842,7 @@ def cmd_portal_box(args: argparse.Namespace) -> int:
     payload = _build_portal_box_payload(
         content=content or "",
         language=args.language,
-        source_name=args.source_name
-        or (Path(args.source_file).name if args.source_file else "inline"),
+        source_name=args.source_name or (Path(args.source_file).name if args.source_file else "inline"),
         include_extended=args.include_extended,
     )
     print(json.dumps(payload, indent=2 if args.json else None))
@@ -883,8 +856,7 @@ def cmd_stream_wheel(args: argparse.Namespace) -> int:
     payload = _build_stream_wheel_payload(
         content=content or "",
         language=args.language,
-        source_name=args.source_name
-        or (Path(args.source_file).name if args.source_file else "inline"),
+        source_name=args.source_name or (Path(args.source_file).name if args.source_file else "inline"),
         include_extended=args.include_extended,
     )
     print(json.dumps(payload, indent=2 if args.json else None))
@@ -922,21 +894,16 @@ def cmd_binary_to_tokenizer(args: argparse.Namespace) -> int:
         b = int(bits, 2)
         raw.append(b)
         token = SACRED_TONGUE_TOKENIZER.encode_bytes(transport, bytes([b]))[0]
-        rows.append(
-            {"bits": bits, "byte_int": b, "byte_hex": f"0x{b:02X}", "token": token}
-        )
+        rows.append({"bits": bits, "byte_int": b, "byte_hex": f"0x{b:02X}", "token": token})
 
-    decoded = SACRED_TONGUE_TOKENIZER.decode_tokens(
-        transport, [row["token"] for row in rows]
-    )
+    decoded = SACRED_TONGUE_TOKENIZER.decode_tokens(transport, [row["token"] for row in rows])
     payload = {
         "version": "geoseal-binary-tokenizer-map-v1",
         "tongue": tongue,
         "conlang": CONLANG_NAME_MAP.get(tongue, tongue),
         "prime_language": LANG_MAP.get(tongue, ""),
         "requested_language": (args.language or "").lower() if args.language else None,
-        "language_matches_prime": (args.language or "").lower()
-        in {"", LANG_MAP.get(tongue, "")},
+        "language_matches_prime": (args.language or "").lower() in {"", LANG_MAP.get(tongue, "")},
         "byte_count": len(rows),
         "rows": rows,
         "harmonic_spiral": {
@@ -1052,24 +1019,16 @@ def _token_digest_for_tongue(tongue: str, payload: bytes) -> dict[str, Any]:
     }
 
 
-def _build_native_tokenization_surface(
-    *, input_bytes: bytes, language_views: list[dict[str, str]]
-) -> dict[str, Any]:
+def _build_native_tokenization_surface(*, input_bytes: bytes, language_views: list[dict[str, str]]) -> dict[str, Any]:
     outputs: list[dict[str, Any]] = []
     for lane in language_views:
         tongue, lang = next(iter(lane.items()))
         snippet = lane.get("snippet", "")
-        digest = _token_digest_for_tongue(
-            tongue, snippet.encode("utf-8", errors="replace")
-        )
-        outputs.append(
-            {**digest, "output_kind": "language_view_snippet", "language_view": lang}
-        )
+        digest = _token_digest_for_tongue(tongue, snippet.encode("utf-8", errors="replace"))
+        outputs.append({**digest, "output_kind": "language_view_snippet", "language_view": lang})
     return {
         "schema_version": "scbe_native_tokenization_surface_v1",
-        "inputs": [
-            _token_digest_for_tongue(tongue, input_bytes) for tongue in TONGUE_NAMES
-        ],
+        "inputs": [_token_digest_for_tongue(tongue, input_bytes) for tongue in TONGUE_NAMES],
         "outputs": outputs,
     }
 
@@ -1122,9 +1081,7 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
     semantic = _compute_semantic_expression(source)
     definitions = [
         {"symbol": name, "kind": kind}
-        for kind, name in re.findall(
-            r"\b(import|class|def)\s+([A-Za-z_][A-Za-z0-9_]*)", source
-        )
+        for kind, name in re.findall(r"\b(import|class|def)\s+([A-Za-z_][A-Za-z0-9_]*)", source)
     ]
     class_names = set(re.findall(r"\bclass\s+([A-Za-z_][A-Za-z0-9_]*)", source))
     function_names = set(re.findall(r"\bdef\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", source))
@@ -1145,10 +1102,7 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
                 ],
             }
         )
-    language_views = [
-        {code: LANG_MAP[code], "snippet": emit_code("add", code, a="x", b="y")}
-        for code in TONGUE_NAMES
-    ]
+    language_views = [{code: LANG_MAP[code], "snippet": emit_code("add", code, a="x", b="y")} for code in TONGUE_NAMES]
     return {
         "version": "scbe-code-weight-packet-v1",
         "source_name": source_name,
@@ -1158,9 +1112,7 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
         "transport": {
             "tongue": tongue,
             "source_sha256": hashlib.sha256(source_bytes).hexdigest(),
-            "token_sha256": hashlib.sha256(
-                " ".join(transport_tokens).encode("utf-8")
-            ).hexdigest(),
+            "token_sha256": hashlib.sha256(" ".join(transport_tokens).encode("utf-8")).hexdigest(),
         },
         "binary": {
             "byte_count": len(source_bytes),
@@ -1193,11 +1145,7 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
                 ]
             ],
             "token_rows": stisa_rows,
-            "binary_groups": (
-                [{"group_id": "g0", "tokens": lexical_tokens[:8]}]
-                if lexical_tokens
-                else []
-            ),
+            "binary_groups": ([{"group_id": "g0", "tokens": lexical_tokens[:8]}] if lexical_tokens else []),
         },
         "structural_parse": {
             "provider": "tree_sitter",
@@ -1205,9 +1153,7 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
             "captures": {
                 "imports": re.findall(r"\bimport\s+([A-Za-z_][A-Za-z0-9_]*)", source),
                 "classes": re.findall(r"\bclass\s+([A-Za-z_][A-Za-z0-9_]*)", source),
-                "functions": re.findall(
-                    r"\bdef\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", source
-                ),
+                "functions": re.findall(r"\bdef\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", source),
             },
         },
         "scip_symbol_index": {
@@ -1225,9 +1171,7 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
                         "keyword"
                         if tok in {"def", "class", "import", "return"}
                         else (
-                            "class"
-                            if tok in class_names
-                            else ("function" if tok in function_names else "identifier")
+                            "class" if tok in class_names else ("function" if tok in function_names else "identifier")
                         )
                     ),
                 }
@@ -1248,10 +1192,7 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
             "route_tongue": tongue,
             "route_language": language,
         },
-        "atomic_states": [
-            {"token": tok, "tau": ((i % 3) - 1)}
-            for i, tok in enumerate(lexical_tokens[:64])
-        ],
+        "atomic_states": [{"token": tok, "tau": ((i % 3) - 1)} for i, tok in enumerate(lexical_tokens[:64])],
         "ternary_semantics": {
             "version": "scbe-ternary-semantics-v1",
             "checksum": (
@@ -1279,9 +1220,7 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
-def _build_interaction_graph(
-    packet: dict[str, Any], max_binary_nodes: int = 8
-) -> dict[str, Any]:
+def _build_interaction_graph(packet: dict[str, Any], max_binary_nodes: int = 8) -> dict[str, Any]:
     tongue = packet["route"]["tongue"]
     semantic = packet.get("semantic_expression", {})
     nodes: list[dict[str, Any]] = [
@@ -1321,33 +1260,21 @@ def _build_interaction_graph(
     for i, tok in enumerate(packet.get("lexical_tokens", [])[:max_binary_nodes]):
         tid = f"token:{i}:{tok}"
         nodes.append({"id": tid, "label": tok, "kind": "token"})
-        edges.append(
-            {"source": "source:program", "target": tid, "relation": "contains_token"}
-        )
+        edges.append({"source": "source:program", "target": tid, "relation": "contains_token"})
         if i < len(packet.get("stisa", {}).get("token_rows", [])):
             sid = f"stisa:{i}"
             nodes.append({"id": sid, "label": f"stisa:{tok}", "kind": "stisa"})
-            edges.append(
-                {"source": tid, "target": sid, "relation": "maps_to_stisa_row"}
-            )
+            edges.append({"source": tid, "target": sid, "relation": "maps_to_stisa_row"})
         if i < len(packet.get("atomic_states", [])):
             aid = f"atom:{i}"
             nodes.append({"id": aid, "label": f"atom:{tok}", "kind": "atom"})
-            edges.append(
-                {"source": tid, "target": aid, "relation": "maps_to_atomic_state"}
-            )
+            edges.append({"source": tid, "target": aid, "relation": "maps_to_atomic_state"})
     for i, token in enumerate(packet.get("transport_tokens", [])[:max_binary_nodes]):
-        nodes.append(
-            {"id": f"transport_token:{i}", "label": token, "kind": "transport_token"}
-        )
+        nodes.append({"id": f"transport_token:{i}", "label": token, "kind": "transport_token"})
     for group in packet.get("stisa", {}).get("binary_groups", []):
         gid = f"binary_group:{group.get('group_id', 'g0')}"
         nodes.append({"id": gid, "label": gid, "kind": "binary_group"})
-    for cell in (
-        packet.get("braille_lane", {})
-        .get("binary_surface", {})
-        .get("cells", [])[:max_binary_nodes]
-    ):
+    for cell in packet.get("braille_lane", {}).get("binary_surface", {}).get("cells", [])[:max_binary_nodes]:
         bid = f"braille:{cell['index']}"
         nodes.append({"id": bid, "label": f"braille:{cell['bits']}", "kind": "braille"})
         edges.append(
@@ -1357,11 +1284,7 @@ def _build_interaction_graph(
                 "relation": "projects_to_braille_cell",
             }
         )
-    for state in (
-        packet.get("braille_lane", {})
-        .get("harmonic_spiral", {})
-        .get("states", [])[:max_binary_nodes]
-    ):
+    for state in packet.get("braille_lane", {}).get("harmonic_spiral", {}).get("states", [])[:max_binary_nodes]:
         hid = f"spiral:{state['index']}"
         nodes.append({"id": hid, "label": hid, "kind": "spiral"})
         edges.append(
@@ -1392,9 +1315,7 @@ def _build_interaction_graph(
             "language_view_count": len(packet.get("language_views", [])),
             "binary_group_count": len(packet.get("stisa", {}).get("binary_groups", [])),
             "harmonic_spiral_state_count": len(
-                packet.get("braille_lane", {})
-                .get("harmonic_spiral", {})
-                .get("states", [])
+                packet.get("braille_lane", {}).get("harmonic_spiral", {}).get("states", [])
             ),
         },
         "nodes": nodes,
@@ -1442,23 +1363,16 @@ def _command_binding() -> dict[str, Any]:
             for code in TONGUE_NAMES
         },
         "primary_transport_tokens": {
-            code: " ".join(
-                SACRED_TONGUE_TOKENIZER.encode_bytes(TONGUE_CODE_MAP[code], b"add")
-            )
-            for code in TONGUE_NAMES
+            code: " ".join(SACRED_TONGUE_TOKENIZER.encode_bytes(TONGUE_CODE_MAP[code], b"add")) for code in TONGUE_NAMES
         },
         "topology_local_relevance_score": 0.92,
     }
 
 
-def _build_topology_view(
-    packet: dict[str, Any], max_binary_nodes: int = 8
-) -> dict[str, Any]:
+def _build_topology_view(packet: dict[str, Any], max_binary_nodes: int = 8) -> dict[str, Any]:
     graph = _build_interaction_graph(packet, max_binary_nodes=max_binary_nodes)
     polygons = []
-    for i, row in enumerate(
-        packet.get("stisa", {}).get("token_rows", [])[:max_binary_nodes]
-    ):
+    for i, row in enumerate(packet.get("stisa", {}).get("token_rows", [])[:max_binary_nodes]):
         vec = row.get("feature_vector", [0.0] * 8)[:8]
         total = max(sum(abs(float(v)) for v in vec), 1.0)
         normalized = [round(float(v) / total, 6) for v in vec]
@@ -1466,9 +1380,7 @@ def _build_topology_view(
             {
                 "token": row["token"],
                 "normalized_vector": normalized,
-                "vertices": [
-                    {"axis": j, "value": value} for j, value in enumerate(normalized)
-                ],
+                "vertices": [{"axis": j, "value": value} for j, value in enumerate(normalized)],
                 "centroid": {
                     "x": normalized[0],
                     "y": normalized[1],
@@ -1500,12 +1412,10 @@ def _build_topology_view(
         }
     ]
     leylines = [
-        {"kind": k, "weight": i + 1}
-        for i, k in enumerate(["semantic_backbone", "binary_spine", "harmonic_spine"])
+        {"kind": k, "weight": i + 1} for i, k in enumerate(["semantic_backbone", "binary_spine", "harmonic_spine"])
     ]
     nodes = graph["nodes"] + [
-        {"id": f"polygon:{i}", "kind": "data_polygon", "label": f"polygon:{p['token']}"}
-        for i, p in enumerate(polygons)
+        {"id": f"polygon:{i}", "kind": "data_polygon", "label": f"polygon:{p['token']}"} for i, p in enumerate(polygons)
     ]
     edges = graph["edges"] + [
         {
@@ -1540,9 +1450,7 @@ def _build_topology_view(
         "surfaces": {
             "stisa_row_count": len(packet.get("stisa", {}).get("token_rows", [])),
             "harmonic_spiral_state_count": len(
-                packet.get("braille_lane", {})
-                .get("harmonic_spiral", {})
-                .get("states", [])
+                packet.get("braille_lane", {}).get("harmonic_spiral", {}).get("states", [])
             ),
         },
         "dictionaries": {
@@ -1587,9 +1495,7 @@ def cmd_braille_lane(args: argparse.Namespace) -> int:
 
 
 def cmd_interaction_graph(args: argparse.Namespace) -> int:
-    graph = _build_interaction_graph(
-        _packet_from_surface_args(args), max_binary_nodes=args.max_binary_nodes
-    )
+    graph = _build_interaction_graph(_packet_from_surface_args(args), max_binary_nodes=args.max_binary_nodes)
     if args.format == "mermaid":
         print(_graph_to_mermaid(graph, direction="TD"), end="")
     elif args.format == "dot":
@@ -1600,14 +1506,10 @@ def cmd_interaction_graph(args: argparse.Namespace) -> int:
 
 
 def cmd_topology_view(args: argparse.Namespace) -> int:
-    topology = _build_topology_view(
-        _packet_from_surface_args(args), max_binary_nodes=args.max_binary_nodes
-    )
+    topology = _build_topology_view(_packet_from_surface_args(args), max_binary_nodes=args.max_binary_nodes)
     if args.format == "mermaid":
         print(
-            _graph_to_mermaid(
-                {"nodes": topology["nodes"], "edges": topology["edges"]}, direction="LR"
-            ),
+            _graph_to_mermaid({"nodes": topology["nodes"], "edges": topology["edges"]}, direction="LR"),
             end="",
         )
     elif args.format == "dot":
@@ -1656,9 +1558,7 @@ def cmd_cross_domain_sequence(args: argparse.Namespace) -> int:
     if args.topology_file:
         topology = json.loads(Path(args.topology_file).read_text(encoding="utf-8"))
     else:
-        topology = _build_topology_view(
-            _packet_from_surface_args(args), max_binary_nodes=8
-        )
+        topology = _build_topology_view(_packet_from_surface_args(args), max_binary_nodes=8)
     print(
         json.dumps(
             {"sequence": _build_cross_domain_sequence(topology)},
@@ -1699,9 +1599,7 @@ def cmd_cognition_map(args: argparse.Namespace) -> int:
     quarks = set(packet.get("semantic_expression", {}).get("quarks", []))
     payload = {
         "version": "scbe-cognition-map-v1",
-        "semantic_label": packet.get("semantic_expression", {}).get(
-            "label", "generic_program_bin"
-        ),
+        "semantic_label": packet.get("semantic_expression", {}).get("label", "generic_program_bin"),
         "well_scores": {
             "measurement": 1.0 if "measurement_signal" in quarks else 0.4,
             "governance": 1.0 if "risk_gate" in quarks else 0.4,
@@ -1712,9 +1610,7 @@ def cmd_cognition_map(args: argparse.Namespace) -> int:
             "counts": {"positive": 3, "zero": 2, "negative": 1},
             "tongue_projection": packet["ternary_semantics"]["route_projection"],
         },
-        "dual_ternary": {
-            "history_length": max(1, len(packet.get("atomic_states", [])))
-        },
+        "dual_ternary": {"history_length": max(1, len(packet.get("atomic_states", [])))},
         "tri_manifold": {"tick": max(1, len(packet.get("lexical_tokens", [])))},
     }
     print(json.dumps(payload, indent=2))
@@ -1761,9 +1657,7 @@ def _build_cluster_graph(
 def cmd_cluster_graph(args: argparse.Namespace) -> int:
     print(
         json.dumps(
-            _build_cluster_graph(
-                _packet_from_surface_args(args), max_binary_nodes=args.max_binary_nodes
-            ),
+            _build_cluster_graph(_packet_from_surface_args(args), max_binary_nodes=args.max_binary_nodes),
             indent=2,
         )
     )
@@ -1812,9 +1706,7 @@ def cmd_agent_harness(args: argparse.Namespace) -> int:
         print(json.dumps(payload, indent=2))
         return 0
     selected = payload["selected_language"]
-    print(
-        f"schema={payload['schema_version']} language={selected['language']} tongue={selected['tongue']}"
-    )
+    print(f"schema={payload['schema_version']} language={selected['language']} tongue={selected['tongue']}")
     print(f"permission_mode={payload['permission_mode']}")
     print("flow=" + " -> ".join(payload["standard_flow"]))
     return 0
@@ -1879,11 +1771,7 @@ def cmd_explain_route(args: argparse.Namespace) -> int:
         source_name=source_name,
         language=language,
         force_tongue=force_tongue,
-        selected_backend=(
-            provider_explain["resolved_chain"][0]
-            if provider_explain["resolved_chain"]
-            else None
-        ),
+        selected_backend=(provider_explain["resolved_chain"][0] if provider_explain["resolved_chain"] else None),
     )
     payload = {
         "version": "geoseal-route-explain-v1",
@@ -1896,9 +1784,7 @@ def cmd_explain_route(args: argparse.Namespace) -> int:
         print(json.dumps(payload, indent=2))
         return 0
     print(f"source={source_name} language={language}")
-    print(
-        f"signature={route_ir['route']['signature']} tongue={route_ir['route']['tongue']}"
-    )
+    print(f"signature={route_ir['route']['signature']} tongue={route_ir['route']['tongue']}")
     print(f"backend={route_ir['backend']['selected']}")
     return 0
 
@@ -1924,9 +1810,7 @@ def cmd_history(args: argparse.Namespace) -> int:
     ledger = Path(args.ledger)
     rows = _read_ledger_records(ledger)
     if args.type:
-        rows = [
-            row for row in rows if str(row.get("type", "swarm_result")) == args.type
-        ]
+        rows = [row for row in rows if str(row.get("type", "swarm_result")) == args.type]
     if args.op:
         rows = [row for row in rows if str(row.get("op", "")) == args.op]
     if args.limit > 0:
@@ -1960,18 +1844,12 @@ def cmd_replay(args: argparse.Namespace) -> int:
 
     if row.get("type") == "swarm_tokens":
         op = str(row.get("op", "add"))
-        tongues = [
-            str(item.get("tongue", "KO")).upper()
-            for item in row.get("calls", [])
-            if isinstance(item, dict)
-        ]
+        tongues = [str(item.get("tongue", "KO")).upper() for item in row.get("calls", []) if isinstance(item, dict)]
         prior_swarm = next(
             (
                 candidate
                 for candidate in reversed(rows)
-                if candidate is not row
-                and candidate.get("type") == "swarm_result"
-                and candidate.get("op") == op
+                if candidate is not row and candidate.get("type") == "swarm_result" and candidate.get("op") == op
             ),
             None,
         )
@@ -1996,11 +1874,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
 
     if "op" in row and "calls" in row and isinstance(row["calls"], list):
         op = str(row.get("op", "add"))
-        tongues = [
-            str(item.get("tongue", "KO")).upper()
-            for item in row.get("calls", [])
-            if isinstance(item, dict)
-        ]
+        tongues = [str(item.get("tongue", "KO")).upper() for item in row.get("calls", []) if isinstance(item, dict)]
         args_map = row.get("args", {})
         result = swarm_dispatch(
             op,
@@ -2026,11 +1900,7 @@ def _command_key_and_route_packet(source: str, language: str) -> dict[str, Any]:
     command_key = _extract_command_key(source, fallback="add")
     if command_key == "code":
         command_key = "add"
-    operative = (
-        f"arithmetic:{command_key}"
-        if command_key in {"add", "sub", "mul", "div", "mod"}
-        else command_key
-    )
+    operative = f"arithmetic:{command_key}" if command_key in {"add", "sub", "mul", "div", "mod"} else command_key
     return {
         "operative_command": operative,
         "command_key": command_key,
@@ -2045,9 +1915,7 @@ def _command_key_and_route_packet(source: str, language: str) -> dict[str, Any]:
 def _run_python_add(a: int = 7, b: int = 3) -> SwarmCallResult:
     code = f"print({a} + {b})"
     t0 = time.time()
-    proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, timeout=10.0
-    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=10.0)
     return SwarmCallResult(
         op="add",
         tongue="KO",
@@ -2072,9 +1940,7 @@ def cmd_testing_cli(args: argparse.Namespace) -> int:
     playback_exec = (
         _run_python_add()
         if args.execute
-        else SwarmCallResult(
-            op="add", tongue="KO", language="python", code="", ran=False
-        )
+        else SwarmCallResult(op="add", tongue="KO", language="python", code="", ran=False)
     )
     payload = {
         "version": "geoseal-testing-cli-v1",
@@ -2087,23 +1953,17 @@ def cmd_testing_cli(args: argparse.Namespace) -> int:
             },
             "execution": playback_exec.to_dict(),
         },
-        "honeycomb_analysis": {
-            "matched_output": playback_exec.stdout if playback_exec.ran else ""
-        },
+        "honeycomb_analysis": {"matched_output": playback_exec.stdout if playback_exec.ran else ""},
         "topology": {
             "route_packet": route_packet,
             "operative_command": {
                 "phase_operation": "arithmetic:add",
-                "stability_adjusted_route_score": route_packet[
-                    "stability_adjusted_route_score"
-                ],
+                "stability_adjusted_route_score": route_packet["stability_adjusted_route_score"],
             },
         },
         "native_tokenization": {
             "schema_version": "scbe_testing_cli_native_tokenization_v1",
-            "input": _token_digest_for_tongue(
-                route_packet["route_tongue"], source.encode("utf-8", errors="replace")
-            ),
+            "input": _token_digest_for_tongue(route_packet["route_tongue"], source.encode("utf-8", errors="replace")),
             "output": _token_digest_for_tongue(
                 route_packet["route_tongue"],
                 playback_exec.stdout.encode("utf-8", errors="replace"),
@@ -2117,9 +1977,7 @@ def cmd_testing_cli(args: argparse.Namespace) -> int:
 def cmd_project_scaffold(args: argparse.Namespace) -> int:
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    route_packet = _command_key_and_route_packet(
-        args.content or "", (args.language or "python").lower()
-    )
+    route_packet = _command_key_and_route_packet(args.content or "", (args.language or "python").lower())
     (out_dir / "index.html").write_text(
         "<!doctype html><html><head><title>Pacman Scaffold</title><link rel='stylesheet' href='style.css'></head>"
         "<body><h1>Pacman Scaffold</h1><canvas id='game'></canvas><script src='game.js'></script></body></html>",
@@ -2139,9 +1997,7 @@ def cmd_project_scaffold(args: argparse.Namespace) -> int:
         "route_packet": {"command_key": route_packet["command_key"]},
         "honeycomb_feedback": {"route_confidence": route_packet["route_confidence"]},
     }
-    (out_dir / "project_manifest.json").write_text(
-        json.dumps(manifest, indent=2), encoding="utf-8"
-    )
+    (out_dir / "project_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     payload = {
         "version": "geoseal-project-scaffold-v1",
         "project_kind": "pacman_web",
@@ -2182,9 +2038,7 @@ def _execute_rust_source(source_path: Path) -> tuple[bool, dict[str, Any]]:
             "stdout": "",
             "stderr": compile_proc.stderr,
         }
-    run_proc = subprocess.run(
-        [str(exe_path)], capture_output=True, text=True, timeout=30.0
-    )
+    run_proc = subprocess.run([str(exe_path)], capture_output=True, text=True, timeout=30.0)
     return True, {
         "ran": True,
         "returncode": run_proc.returncode,
@@ -2216,9 +2070,7 @@ def cmd_code_roundtrip(args: argparse.Namespace) -> int:
     }
     if args.execute and language == "rust":
         ran, original_exec = _execute_rust_source(source_path)
-        decoded_path = source_path.with_name(
-            source_path.stem + ".decoded" + source_path.suffix
-        )
+        decoded_path = source_path.with_name(source_path.stem + ".decoded" + source_path.suffix)
         decoded_path.write_bytes(back)
         _, decoded_exec = _execute_rust_source(decoded_path)
         if decoded_path.exists():
@@ -2232,19 +2084,12 @@ def cmd_code_roundtrip(args: argparse.Namespace) -> int:
         "execution": {
             "original": original_exec,
             "decoded": decoded_exec,
-            "stdout_identical": original_exec.get("stdout")
-            == decoded_exec.get("stdout"),
-            "returncode_identical": original_exec.get("returncode")
-            == decoded_exec.get("returncode"),
+            "stdout_identical": original_exec.get("stdout") == decoded_exec.get("stdout"),
+            "returncode_identical": original_exec.get("returncode") == decoded_exec.get("returncode"),
         },
     }
     print(json.dumps(payload, indent=2 if args.json else None))
-    return (
-        0
-        if payload["byte_identical"]
-        and (not args.execute or payload["execution"]["returncode_identical"])
-        else 1
-    )
+    return 0 if payload["byte_identical"] and (not args.execute or payload["execution"]["returncode_identical"]) else 1
 
 
 def cmd_shell(args: argparse.Namespace) -> int:
@@ -2316,9 +2161,7 @@ def cmd_exec(args: argparse.Namespace) -> int:
         print(json.dumps(payload, indent=2))
     else:
         decision = result.decision
-        print(
-            f"[gate] tier={decision.tier} allowed={decision.allowed} ran={result.ran}"
-        )
+        print(f"[gate] tier={decision.tier} allowed={decision.allowed} ran={result.ran}")
         for finding in decision.findings:
             print(f"  - {finding.rule}: {finding.message}")
         if result.stdout:
@@ -2374,12 +2217,8 @@ class SealHereCommand(BoundCommand):
         None,
         description="Use a known named location (port-angeles | sequim | seattle)",
     )
-    lat: Optional[float] = Field(
-        None, ge=-90.0, le=90.0, description="Latitude in degrees"
-    )
-    lon: Optional[float] = Field(
-        None, ge=-180.0, le=180.0, description="Longitude in degrees"
-    )
+    lat: Optional[float] = Field(None, ge=-90.0, le=90.0, description="Latitude in degrees")
+    lon: Optional[float] = Field(None, ge=-180.0, le=180.0, description="Longitude in degrees")
     label: str = Field("seal-here", description="Audit label for the sealed packet")
     tongue: _Literal["ko", "av", "ru", "ca", "um", "dr"] = Field(
         "ko",
@@ -2508,9 +2347,7 @@ def _handle_cross_build(bound: BoundCommand, ns: argparse.Namespace) -> int:
                 "translations": translations,
             }
         else:
-            result = cross_build(
-                cmd.src_code or "", cmd.src_tongue or "", cmd.dst_tongue or ""
-            )
+            result = cross_build(cmd.src_code or "", cmd.src_tongue or "", cmd.dst_tongue or "")
             payload = {
                 "version": "geoseal-cross-build-v1",
                 "mode": "single",
@@ -2571,8 +2408,8 @@ class RouteCommand(BoundCommand):
         None,
         description="Pin the lexicon op (e.g. add, mul, xor) — skips band+op SLM stages",
     )
-    band: Optional[_Literal["ARITHMETIC", "LOGIC", "COMPARISON", "AGGREGATION"]] = (
-        Field(None, description="Pin the operation band — skips band SLM stage")
+    band: Optional[_Literal["ARITHMETIC", "LOGIC", "COMPARISON", "AGGREGATION"]] = Field(
+        None, description="Pin the operation band — skips band SLM stage"
     )
     dst_tongue: Optional[_Literal["KO", "AV", "RU", "CA", "UM", "DR"]] = Field(
         None, description="Pin the destination tongue — skips tongue SLM stage"
@@ -2601,12 +2438,8 @@ class RouteCommand(BoundCommand):
         description="Override Ollama model name (default qwen2.5:1.5b-instruct-q4_K_M)",
     )
     ollama_host: str = Field("http://localhost:11434", description="Ollama server URL")
-    min_confidence: float = Field(
-        0.5, ge=0.0, le=1.0, description="Reject SLM stages below this confidence"
-    )
-    timeout_seconds: float = Field(
-        30.0, ge=0.1, le=300.0, description="Per-classify timeout"
-    )
+    min_confidence: float = Field(0.5, ge=0.0, le=1.0, description="Reject SLM stages below this confidence")
+    timeout_seconds: float = Field(30.0, ge=0.1, le=300.0, description="Per-classify timeout")
 
 
 def _parse_args_pairs(pairs: List[str]) -> Dict[str, str]:
@@ -2726,9 +2559,7 @@ def _handle_route(bound: BoundCommand, ns: argparse.Namespace) -> int:
         try:
             if cmd.emit_all:
                 tongues = ("KO", "AV", "RU", "CA", "UM", "DR")
-                payload["translations"] = {
-                    t: emit_from_ir(result.op, t) for t in tongues
-                }
+                payload["translations"] = {t: emit_from_ir(result.op, t) for t in tongues}
                 # The "primary" dst_code is still the routed tongue.
                 payload["dst_code"] = payload["translations"][result.dst_tongue]
             else:
@@ -2776,15 +2607,11 @@ def cmd_swarm_exec(args: argparse.Namespace) -> int:
         print(f"reverse half not found: {reverse_path}", file=sys.stderr)
         return 2
 
-    seam_names = tuple(
-        n.strip() for n in (args.seam_names or "").split(",") if n.strip()
-    )
+    seam_names = tuple(n.strip() for n in (args.seam_names or "").split(",") if n.strip())
     if not seam_names:
         print("--seam-names is required (comma-separated identifiers)", file=sys.stderr)
         return 2
-    seam_types = tuple(
-        t.strip() for t in (args.seam_types or "").split(",") if t.strip()
-    )
+    seam_types = tuple(t.strip() for t in (args.seam_types or "").split(",") if t.strip())
     if seam_types and len(seam_types) != len(seam_names):
         print("--seam-types must be empty or parallel to --seam-names", file=sys.stderr)
         return 2
@@ -2829,9 +2656,7 @@ def cmd_swarm_exec(args: argparse.Namespace) -> int:
         if args.json:
             print(json.dumps(base_payload, indent=2))
         else:
-            print(
-                f"[swarm-exec] converged=False  seam_tongue_hash={base_payload['seam_contract']['tongue_hash'][:16]}"
-            )
+            print(f"[swarm-exec] converged=False  seam_tongue_hash={base_payload['seam_contract']['tongue_hash'][:16]}")
             for diag in report.diagnostics:
                 print(f"  - {diag}")
         return 2
@@ -2841,14 +2666,10 @@ def cmd_swarm_exec(args: argparse.Namespace) -> int:
         if args.json:
             print(json.dumps(base_payload, indent=2))
         else:
-            print(
-                f"[swarm-exec] converged=True  seam_tongue_hash={base_payload['seam_contract']['tongue_hash'][:16]}"
-            )
+            print(f"[swarm-exec] converged=True  seam_tongue_hash={base_payload['seam_contract']['tongue_hash'][:16]}")
             print(f"  forward_hash: {report.forward_seam_hash[:16]}")
             print(f"  reverse_hash: {report.reverse_seam_hash[:16]}")
-            print(
-                f"  merged source: {len(report.merged_source or '')} bytes (use --execute to run)"
-            )
+            print(f"  merged source: {len(report.merged_source or '')} bytes (use --execute to run)")
         return 0
 
     # Execute the merged module through the SCBE execution gate.
@@ -2878,12 +2699,8 @@ def cmd_swarm_exec(args: argparse.Namespace) -> int:
         print(json.dumps(payload, indent=2))
     else:
         decision = gate_result.decision
-        print(
-            f"[swarm-exec] converged=True  seam_tongue_hash={base_payload['seam_contract']['tongue_hash'][:16]}"
-        )
-        print(
-            f"[gate] tier={decision.tier} allowed={decision.allowed} ran={gate_result.ran}"
-        )
+        print(f"[swarm-exec] converged=True  seam_tongue_hash={base_payload['seam_contract']['tongue_hash'][:16]}")
+        print(f"[gate] tier={decision.tier} allowed={decision.allowed} ran={gate_result.ran}")
         for finding in decision.findings:
             print(f"  - {finding.rule}: {finding.message}")
         if gate_result.stdout:
@@ -2973,9 +2790,7 @@ def cmd_emit(args: argparse.Namespace) -> int:
             payload = {
                 "version": "geoseal-emit-v1",
                 "op": args.op,
-                "semantic_expression": {
-                    "gloss": "add x and y" if args.op == "add" else args.op
-                },
+                "semantic_expression": {"gloss": "add x and y" if args.op == "add" else args.op},
                 "variants": [
                     {
                         "tongue": tongue,
@@ -2984,11 +2799,7 @@ def cmd_emit(args: argparse.Namespace) -> int:
                         "code": code,
                         "seal": seal,
                         "binary": {"byte_count": len(code.encode("utf-8"))},
-                        "tokenizer": {
-                            "token_count": tongue_token_digest(tongue, code).get(
-                                "n_tokens", 0
-                            )
-                        },
+                        "tokenizer": {"token_count": tongue_token_digest(tongue, code).get("n_tokens", 0)},
                     }
                 ],
             }
@@ -3009,9 +2820,7 @@ def cmd_emit(args: argparse.Namespace) -> int:
                     "code": code,
                     "seal": compute_seal(args.op, t, code),
                     "binary": {"byte_count": len(code.encode("utf-8"))},
-                    "tokenizer": {
-                        "token_count": tongue_token_digest(t, code).get("n_tokens", 0)
-                    },
+                    "tokenizer": {"token_count": tongue_token_digest(t, code).get("n_tokens", 0)},
                 }
             )
         print(
@@ -3019,9 +2828,7 @@ def cmd_emit(args: argparse.Namespace) -> int:
                 {
                     "version": "geoseal-emit-v1",
                     "op": args.op,
-                    "semantic_expression": {
-                        "gloss": "add x and y" if args.op == "add" else args.op
-                    },
+                    "semantic_expression": {"gloss": "add x and y" if args.op == "add" else args.op},
                     "variants": rows,
                 },
                 indent=2,
@@ -3067,9 +2874,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 + "\n"
             )
     if args.json:
-        print(
-            json.dumps({"version": "geoseal-run-v1", "call": call.to_dict()}, indent=2)
-        )
+        print(json.dumps({"version": "geoseal-run-v1", "call": call.to_dict()}, indent=2))
         return 0 if (call.ran and call.returncode == 0) else 1
     print(f"op={call.op} tongue={call.tongue} lang={call.language}")
     print(f"code: {call.code}")
@@ -3086,11 +2891,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 
 def cmd_swarm(args: argparse.Namespace) -> int:
     kv = _parse_kv_args(args.args)
-    tongues = (
-        [t.strip().upper() for t in args.tongues.split(",") if t.strip()]
-        if args.tongues
-        else list(TONGUE_NAMES)
-    )
+    tongues = [t.strip().upper() for t in args.tongues.split(",") if t.strip()] if args.tongues else list(TONGUE_NAMES)
     unknown = [t for t in tongues if t not in ALL_TONGUE_NAMES]
     if unknown:
         print(f"unknown tongues: {unknown}", file=sys.stderr)
@@ -3109,9 +2910,7 @@ def cmd_swarm(args: argparse.Namespace) -> int:
         status = "ok" if (call.ran and call.returncode == 0) else (call.error or "skip")
         out = call.stdout or ""
         print(f"  {call.tongue} ({call.language:>10}): {status:<20} {out}")
-    print(
-        f"quorum_ok={result.quorum_ok}  consensus={result.consensus_hash[:12] or '-'}"
-    )
+    print(f"quorum_ok={result.quorum_ok}  consensus={result.consensus_hash[:12] or '-'}")
 
     # Per-call sacred-tongue boundary digests for downstream parity training.
     # Written as a single 'swarm_tokens' summary record so we don't disturb the
@@ -3153,12 +2952,8 @@ def cmd_seal(args: argparse.Namespace) -> int:
     tongue = (args.tongue or "KO").upper()
     phi_cost = getattr(args, "phi_cost", 0.0)
     tier = getattr(args, "tier", "ALLOW")
-    seal = compute_seal(
-        args.op or "seal", tongue, args.payload, phi_cost=phi_cost, tier=tier
-    )
-    print(
-        f"tongue={tongue} phase={ALL_TONGUE_PHASES.get(tongue, 0.0):.6f} phi_cost={phi_cost:.4f} tier={tier}"
-    )
+    seal = compute_seal(args.op or "seal", tongue, args.payload, phi_cost=phi_cost, tier=tier)
+    print(f"tongue={tongue} phase={ALL_TONGUE_PHASES.get(tongue, 0.0):.6f} phi_cost={phi_cost:.4f} tier={tier}")
     print(f"seal={seal}")
     return 0
 
@@ -3167,9 +2962,7 @@ def cmd_verify(args: argparse.Namespace) -> int:
     tongue = (args.tongue or "KO").upper()
     phi_cost = getattr(args, "phi_cost", 0.0)
     tier = getattr(args, "tier", "ALLOW")
-    ok = verify_seal(
-        args.seal, args.op or "seal", tongue, args.payload, phi_cost=phi_cost, tier=tier
-    )
+    ok = verify_seal(args.seal, args.op or "seal", tongue, args.payload, phi_cost=phi_cost, tier=tier)
     print("OK" if ok else "MISMATCH")
     return 0 if ok else 1
 
@@ -3207,9 +3000,7 @@ def cmd_agent(args: argparse.Namespace) -> int:
     semantic_ir = infer_semantic_ir(task, force_tongue=force_tongue)
     if verbose:
         kw = f" (keyword: {route.override_keyword!r})" if route.override_keyword else ""
-        print(
-            f"[route] {route.full_name} ({route.tongue}) -> {route.language} | conf={route.confidence:.2f}{kw}"
-        )
+        print(f"[route] {route.full_name} ({route.tongue}) -> {route.language} | conf={route.confidence:.2f}{kw}")
         print(f"[route] trits: {route.trit_scores}")
         print(f"[ir] {semantic_ir.signature}")
 
@@ -3265,9 +3056,7 @@ def cmd_agent(args: argparse.Namespace) -> int:
         while not ok and result.provider != "none":
             forbidden.append(result.provider)
             if verbose:
-                print(
-                    f"[escalate] syntax_check failed on {result.provider}; retrying with forbid={forbidden}"
-                )
+                print(f"[escalate] syntax_check failed on {result.provider}; retrying with forbid={forbidden}")
             result = generate(
                 task,
                 language=route.language,
@@ -3293,9 +3082,7 @@ def cmd_agent(args: argparse.Namespace) -> int:
 
     if verbose:
         print(f"[generate] provider={result.provider} model={result.model}")
-        print(
-            f"[generate] prompt_tokens={result.prompt_tokens} completion_tokens={result.completion_tokens}"
-        )
+        print(f"[generate] prompt_tokens={result.prompt_tokens} completion_tokens={result.completion_tokens}")
         if result.attempted_providers:
             chain = " -> ".join(
                 f"{a['provider']}({'ok' if a['success'] else (a.get('skipped_reason') or 'err')})"
@@ -3307,9 +3094,7 @@ def cmd_agent(args: argparse.Namespace) -> int:
     seal = compute_seal("agent", route.tongue, result.code, task, phi_cost, tier)
 
     # 5. Print output
-    print(
-        f"# tongue={route.full_name} ({route.tongue}) lang={route.language} tier={tier} seal={seal[:16]}..."
-    )
+    print(f"# tongue={route.full_name} ({route.tongue}) lang={route.language} tier={tier} seal={seal[:16]}...")
     _write_stdout_safe(result.code)
 
     # 6. SFT log — write as governance record to .scbe/geoseal_calls.jsonl
@@ -3389,9 +3174,7 @@ def cmd_arc(args: argparse.Namespace) -> int:
     verbose = args.verbose
 
     if verbose:
-        print(
-            f"[arc] task_id={task.task_id}  train={len(task.train)}  test_inputs={len(task.test_inputs)}"
-        )
+        print(f"[arc] task_id={task.task_id}  train={len(task.train)}  test_inputs={len(task.test_inputs)}")
 
     # Synthesize program
     solution = synthesize_program(task)
@@ -3465,9 +3248,7 @@ def cmd_arc(args: argparse.Namespace) -> int:
         ledger.parent.mkdir(parents=True, exist_ok=True)
         # Boundary digests: input is the task identity + family seed; output is the
         # serialized synthesized program (deterministic, semantic-preserving).
-        arc_in_payload = json.dumps(
-            {"task_id": task.task_id, "n_train": total}, sort_keys=True
-        )
+        arc_in_payload = json.dumps({"task_id": task.task_id, "n_train": total}, sort_keys=True)
         arc_out_payload = json.dumps(
             {
                 "family": solution.family,
@@ -3665,9 +3446,7 @@ def validate_workflow_spec(spec: Dict[str, Any]) -> List[str]:
             seen_ids.add(sid)
         op = step.get("op")
         if op not in WORKFLOW_OP_KINDS:
-            errors.append(
-                f"{prefix}({sid}): op must be one of {sorted(WORKFLOW_OP_KINDS)}, got {op!r}"
-            )
+            errors.append(f"{prefix}({sid}): op must be one of {sorted(WORKFLOW_OP_KINDS)}, got {op!r}")
         if "task" not in step:
             errors.append(f"{prefix}({sid}): missing required field 'task'")
         tongue = step.get("tongue")
@@ -3686,9 +3465,7 @@ def validate_workflow_spec(spec: Dict[str, Any]) -> List[str]:
             else:
                 for fp in forbid:
                     if fp not in WORKFLOW_VALID_PROVIDERS:
-                        errors.append(
-                            f"{prefix}({sid}): forbid_provider entry invalid {fp!r}"
-                        )
+                        errors.append(f"{prefix}({sid}): forbid_provider entry invalid {fp!r}")
     return errors
 
 
@@ -3725,9 +3502,7 @@ def substitute_workflow_refs(
     return _WORKFLOW_REF_PATTERN.sub(_resolve, template)
 
 
-def _resolve_step_setting(
-    step: Dict[str, Any], spec: Dict[str, Any], key: str, default: Any = None
-) -> Any:
+def _resolve_step_setting(step: Dict[str, Any], spec: Dict[str, Any], key: str, default: Any = None) -> Any:
     if key in step and step[key] is not None:
         return step[key]
     default_key = f"default_{key}"
@@ -3769,18 +3544,14 @@ def _run_workflow_step_agent(
         budget_tokens = int(budget_tokens)
     max_tier = _resolve_step_setting(step, spec, "max_tier")
     small_first = bool(_resolve_step_setting(step, spec, "small_first", default=False))
-    forbid_provider = list(
-        _resolve_step_setting(step, spec, "forbid_provider", default=[]) or []
-    )
+    forbid_provider = list(_resolve_step_setting(step, spec, "forbid_provider", default=[]) or [])
     chi = float(_resolve_step_setting(step, spec, "chi", default=0.2))
 
     route = route_task(task, force_tongue=force_tongue)
     phi_cost = phi_wall_cost(chi, route.tongue)
     tier = phi_wall_tier(phi_cost)
     if verbose:
-        print(
-            f"[workflow:{sid}] route={route.full_name}({route.tongue}) tier={tier} cost={phi_cost:.4f}"
-        )
+        print(f"[workflow:{sid}] route={route.full_name}({route.tongue}) tier={tier} cost={phi_cost:.4f}")
     if tier == "DENY":
         return WorkflowStepResult(
             step_id=sid,
@@ -3912,13 +3683,9 @@ def run_workflow(
     for idx, step in enumerate(spec["steps"]):
         op = step["op"]
         if op == "agent":
-            result = _run_workflow_step_agent(
-                step, spec, input_text, step_outputs, verbose=verbose
-            )
+            result = _run_workflow_step_agent(step, spec, input_text, step_outputs, verbose=verbose)
         elif op == "seal":
-            result = _run_workflow_step_seal(
-                step, spec, input_text, step_outputs, verbose=verbose
-            )
+            result = _run_workflow_step_seal(step, spec, input_text, step_outputs, verbose=verbose)
         else:  # pragma: no cover - already validated
             raise SystemExit(f"workflow op kind not implemented: {op}")
         step_outputs[result.step_id] = result
@@ -3955,9 +3722,7 @@ def run_workflow(
                 )
             break
         prev_step_id = result.step_id
-        prev_tongue_out_sha = (
-            (result.tongue_out or {}).get("sha256") if result.tongue_out else None
-        )
+        prev_tongue_out_sha = (result.tongue_out or {}).get("sha256") if result.tongue_out else None
 
     summary = {
         "type": "workflow_run",
@@ -4032,9 +3797,7 @@ def cmd_workflow(args: argparse.Namespace) -> int:
         if args.input_file:
             input_text = Path(args.input_file).read_text(encoding="utf-8")
         ledger = None if args.no_ledger else Path(args.ledger)
-        summary = run_workflow(
-            spec, input_text=input_text, ledger=ledger, verbose=args.verbose
-        )
+        summary = run_workflow(spec, input_text=input_text, ledger=ledger, verbose=args.verbose)
         if args.json:
             payload = {k: v for k, v in summary.items() if not k.startswith("_")}
             print(json.dumps(payload))
@@ -4060,23 +3823,15 @@ def build_parser() -> argparse.ArgumentParser:
     sub = p.add_subparsers(dest="cmd", required=True)
 
     p_ops = sub.add_parser("ops", help="List tokenizer ops")
-    p_ops.add_argument(
-        "--band", default=None, help="ARITHMETIC|LOGIC|COMPARISON|AGGREGATION"
-    )
+    p_ops.add_argument("--band", default=None, help="ARITHMETIC|LOGIC|COMPARISON|AGGREGATION")
     p_ops.set_defaults(func=cmd_ops)
 
-    p_encode = sub.add_parser(
-        "encode-cmd", help="Encode payload through Sacred Tongues transport"
-    )
+    p_encode = sub.add_parser("encode-cmd", help="Encode payload through Sacred Tongues transport")
     p_encode.add_argument("--tongue", required=True, help="KO|AV|RU|CA|UM|DR")
-    p_encode.add_argument(
-        "payload", nargs="?", default=None, help="Plaintext payload (defaults to stdin)"
-    )
+    p_encode.add_argument("payload", nargs="?", default=None, help="Plaintext payload (defaults to stdin)")
     p_encode.set_defaults(func=cmd_encode_cmd)
 
-    p_binary = sub.add_parser(
-        "binary-to-tokenizer", help="Map binary bytes into Sacred Tongue tokenizer rows"
-    )
+    p_binary = sub.add_parser("binary-to-tokenizer", help="Map binary bytes into Sacred Tongue tokenizer rows")
     p_binary.add_argument("--tongue", required=True, help="KO|AV|RU|CA|UM|DR")
     p_binary.add_argument(
         "--language",
@@ -4084,28 +3839,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional requested language for prime-lane check",
     )
     p_binary.add_argument("--json", action="store_true")
-    p_binary.add_argument(
-        "bits", nargs="?", default="", help="Space/comma separated 8-bit chunks"
-    )
+    p_binary.add_argument("bits", nargs="?", default="", help="Space/comma separated 8-bit chunks")
     p_binary.set_defaults(func=cmd_binary_to_tokenizer)
 
-    p_code_packet = sub.add_parser(
-        "code-packet", help="Build SCBE weighted code packet from source"
-    )
+    p_code_packet = sub.add_parser("code-packet", help="Build SCBE weighted code packet from source")
     p_code_packet.add_argument("--content", default="", help="Inline source content")
-    p_code_packet.add_argument(
-        "--source-file", default=None, help="Read source content from file"
-    )
+    p_code_packet.add_argument("--source-file", default=None, help="Read source content from file")
     p_code_packet.add_argument("--source-name", default=None)
     p_code_packet.add_argument("--language", default="python")
-    p_code_packet.add_argument(
-        "--backend", default=None, choices=["local", "ollama", "hf", "claude"]
-    )
+    p_code_packet.add_argument("--backend", default=None, choices=["local", "ollama", "hf", "claude"])
     p_code_packet.set_defaults(func=cmd_code_packet)
 
-    p_braille = sub.add_parser(
-        "braille-lane", help="Build braille/polyhedral lane from source or code packet"
-    )
+    p_braille = sub.add_parser("braille-lane", help="Build braille/polyhedral lane from source or code packet")
     p_braille.add_argument("--content", default="")
     p_braille.add_argument("--source-file", default=None)
     p_braille.add_argument("--packet-file", default=None)
@@ -4114,41 +3859,27 @@ def build_parser() -> argparse.ArgumentParser:
     p_braille.add_argument("--json", action="store_true")
     p_braille.set_defaults(func=cmd_braille_lane)
 
-    p_igraph = sub.add_parser(
-        "interaction-graph", help="Build source/token/STISA/atomic interaction graph"
-    )
+    p_igraph = sub.add_parser("interaction-graph", help="Build source/token/STISA/atomic interaction graph")
     p_igraph.add_argument("--content", default="")
     p_igraph.add_argument("--source-file", default=None)
     p_igraph.add_argument("--packet-file", default=None)
     p_igraph.add_argument("--source-name", default=None)
     p_igraph.add_argument("--language", default="python")
-    p_igraph.add_argument(
-        "--max-binary-nodes", type=int, default=8, dest="max_binary_nodes"
-    )
-    p_igraph.add_argument(
-        "--format", default="json", choices=["json", "mermaid", "dot"]
-    )
+    p_igraph.add_argument("--max-binary-nodes", type=int, default=8, dest="max_binary_nodes")
+    p_igraph.add_argument("--format", default="json", choices=["json", "mermaid", "dot"])
     p_igraph.set_defaults(func=cmd_interaction_graph)
 
-    p_topology = sub.add_parser(
-        "topology-view", help="Build topology view from source or packet"
-    )
+    p_topology = sub.add_parser("topology-view", help="Build topology view from source or packet")
     p_topology.add_argument("--content", default="")
     p_topology.add_argument("--source-file", default=None)
     p_topology.add_argument("--packet-file", default=None)
     p_topology.add_argument("--source-name", default=None)
     p_topology.add_argument("--language", default="python")
-    p_topology.add_argument(
-        "--max-binary-nodes", type=int, default=8, dest="max_binary_nodes"
-    )
-    p_topology.add_argument(
-        "--format", default="json", choices=["json", "mermaid", "dot"]
-    )
+    p_topology.add_argument("--max-binary-nodes", type=int, default=8, dest="max_binary_nodes")
+    p_topology.add_argument("--format", default="json", choices=["json", "mermaid", "dot"])
     p_topology.set_defaults(func=cmd_topology_view)
 
-    p_sequence = sub.add_parser(
-        "cross-domain-sequence", help="Build near-related cross-domain route sequence"
-    )
+    p_sequence = sub.add_parser("cross-domain-sequence", help="Build near-related cross-domain route sequence")
     p_sequence.add_argument("--content", default="")
     p_sequence.add_argument("--source-file", default=None)
     p_sequence.add_argument("--packet-file", default=None)
@@ -4158,9 +3889,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_sequence.add_argument("--json", action="store_true")
     p_sequence.set_defaults(func=cmd_cross_domain_sequence)
 
-    p_honeycomb = sub.add_parser(
-        "honeycomb-analysis", help="Analyze route cells and execution stability"
-    )
+    p_honeycomb = sub.add_parser("honeycomb-analysis", help="Analyze route cells and execution stability")
     p_honeycomb.add_argument("--content", default="")
     p_honeycomb.add_argument("--source-file", default=None)
     p_honeycomb.add_argument("--packet-file", default=None)
@@ -4170,9 +3899,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_honeycomb.add_argument("--json", action="store_true")
     p_honeycomb.set_defaults(func=cmd_honeycomb_analysis)
 
-    p_cognition = sub.add_parser(
-        "cognition-map", help="Build cognitive well/ternary map"
-    )
+    p_cognition = sub.add_parser("cognition-map", help="Build cognitive well/ternary map")
     p_cognition.add_argument("--content", default="")
     p_cognition.add_argument("--source-file", default=None)
     p_cognition.add_argument("--packet-file", default=None)
@@ -4180,45 +3907,31 @@ def build_parser() -> argparse.ArgumentParser:
     p_cognition.add_argument("--language", default="python")
     p_cognition.set_defaults(func=cmd_cognition_map)
 
-    p_cluster = sub.add_parser(
-        "cluster-graph", help="Build cross-lattice cluster graph"
-    )
+    p_cluster = sub.add_parser("cluster-graph", help="Build cross-lattice cluster graph")
     p_cluster.add_argument("--content", default="")
     p_cluster.add_argument("--source-file", default=None)
     p_cluster.add_argument("--packet-file", default=None)
     p_cluster.add_argument("--source-name", default=None)
     p_cluster.add_argument("--language", default="python")
-    p_cluster.add_argument(
-        "--max-binary-nodes", type=int, default=8, dest="max_binary_nodes"
-    )
+    p_cluster.add_argument("--max-binary-nodes", type=int, default=8, dest="max_binary_nodes")
     p_cluster.set_defaults(func=cmd_cluster_graph)
 
-    p_formation = sub.add_parser(
-        "formation-graph", help="Build cross-lattice formation graph"
-    )
+    p_formation = sub.add_parser("formation-graph", help="Build cross-lattice formation graph")
     p_formation.add_argument("--content", default="")
     p_formation.add_argument("--source-file", default=None)
     p_formation.add_argument("--packet-file", default=None)
     p_formation.add_argument("--source-name", default=None)
     p_formation.add_argument("--language", default="python")
-    p_formation.add_argument(
-        "--max-binary-nodes", type=int, default=8, dest="max_binary_nodes"
-    )
+    p_formation.add_argument("--max-binary-nodes", type=int, default=8, dest="max_binary_nodes")
     p_formation.set_defaults(func=cmd_formation_graph)
 
-    p_explain = sub.add_parser(
-        "explain-route", help="Explain route IR + backend chain for a source/task"
-    )
+    p_explain = sub.add_parser("explain-route", help="Explain route IR + backend chain for a source/task")
     p_explain.add_argument("--content", default="", help="Inline source content")
-    p_explain.add_argument(
-        "--source-file", default=None, help="Read source content from file"
-    )
+    p_explain.add_argument("--source-file", default=None, help="Read source content from file")
     p_explain.add_argument("--source-name", default=None)
     p_explain.add_argument("--language", default="python")
     p_explain.add_argument("--tongue", default=None, help="Force tongue")
-    p_explain.add_argument(
-        "--provider", default=None, choices=["local", "ollama", "hf", "claude"]
-    )
+    p_explain.add_argument("--provider", default=None, choices=["local", "ollama", "hf", "claude"])
     p_explain.add_argument(
         "--forbid-provider",
         action="append",
@@ -4235,15 +3948,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_explain.add_argument("--json", action="store_true")
     p_explain.set_defaults(func=cmd_explain_route)
 
-    p_backends = sub.add_parser(
-        "backend-registry", help="List backend providers and lane support"
-    )
+    p_backends = sub.add_parser("backend-registry", help="List backend providers and lane support")
     p_backends.add_argument("--json", action="store_true")
     p_backends.set_defaults(func=cmd_backend_registry)
 
-    p_harness = sub.add_parser(
-        "agent-harness", help="Emit model-neutral agent harness manifest"
-    )
+    p_harness = sub.add_parser("agent-harness", help="Emit model-neutral agent harness manifest")
     p_harness.add_argument("--goal", default="", help="Agent goal or task intent")
     p_harness.add_argument(
         "--language",
@@ -4260,17 +3969,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_harness.add_argument("--json", action="store_true")
     p_harness.set_defaults(func=cmd_agent_harness)
 
-    p_assist = sub.add_parser(
-        "assist", help="Run local micro-assist for terminal agents"
-    )
+    p_assist = sub.add_parser("assist", help="Run local micro-assist for terminal agents")
     p_assist.add_argument("task", help="Task text to classify and route")
     p_assist.add_argument("--agent", default="agent.codex")
     p_assist.add_argument("--recipient", default="agent.claude")
     p_assist.add_argument("--repo-root", default=str(Path.cwd()))
     p_assist.add_argument("--bus", default=None)
-    p_assist.add_argument(
-        "--post", action="store_true", help="Post advice to centerline bus"
-    )
+    p_assist.add_argument("--post", action="store_true", help="Post advice to centerline bus")
     p_assist.add_argument("--json", action="store_true")
     p_assist.set_defaults(func=cmd_assist)
 
@@ -4284,29 +3989,21 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_replay = sub.add_parser("replay", help="Replay a previous ledger record")
     p_replay.add_argument("--ledger", default=str(DEFAULT_LEDGER))
-    p_replay.add_argument(
-        "--index", type=int, default=None, help="Record index (default: last)"
-    )
+    p_replay.add_argument("--index", type=int, default=None, help="Record index (default: last)")
     p_replay.add_argument("--timeout", type=float, default=10.0)
     p_replay.add_argument("--no-ledger", action="store_true")
     p_replay.add_argument("--json", action="store_true")
     p_replay.set_defaults(func=cmd_replay)
 
-    p_testing = sub.add_parser(
-        "testing-cli", help="Build testing playback packet and optionally execute"
-    )
+    p_testing = sub.add_parser("testing-cli", help="Build testing playback packet and optionally execute")
     p_testing.add_argument("--content", default="", help="Inline source content")
-    p_testing.add_argument(
-        "--source-file", default=None, help="Read source content from file"
-    )
+    p_testing.add_argument("--source-file", default=None, help="Read source content from file")
     p_testing.add_argument("--language", default="python")
     p_testing.add_argument("--execute", action="store_true")
     p_testing.add_argument("--json", action="store_true")
     p_testing.set_defaults(func=cmd_testing_cli)
 
-    p_scaffold = sub.add_parser(
-        "project-scaffold", help="Create lightweight project scaffold from task intent"
-    )
+    p_scaffold = sub.add_parser("project-scaffold", help="Create lightweight project scaffold from task intent")
     p_scaffold.add_argument("--content", required=True)
     p_scaffold.add_argument("--language", default="python")
     p_scaffold.add_argument("--output-dir", required=True, dest="output_dir")
@@ -4324,35 +4021,25 @@ def build_parser() -> argparse.ArgumentParser:
     p_roundtrip.add_argument("--json", action="store_true")
     p_roundtrip.set_defaults(func=cmd_code_roundtrip)
 
-    p_portal = sub.add_parser(
-        "portal-box", help="Build a local Polly portal-box route packet"
-    )
+    p_portal = sub.add_parser("portal-box", help="Build a local Polly portal-box route packet")
     p_portal.add_argument("--content", default="", help="Inline source content")
-    p_portal.add_argument(
-        "--source-file", default=None, help="Read source content from file"
-    )
+    p_portal.add_argument("--source-file", default=None, help="Read source content from file")
     p_portal.add_argument("--language", default="python")
     p_portal.add_argument("--source-name", default=None)
     p_portal.add_argument("--include-extended", action="store_true")
     p_portal.add_argument("--json", action="store_true")
     p_portal.set_defaults(func=cmd_portal_box)
 
-    p_stream = sub.add_parser(
-        "stream-wheel", help="Build a local Polly stream-wheel route packet"
-    )
+    p_stream = sub.add_parser("stream-wheel", help="Build a local Polly stream-wheel route packet")
     p_stream.add_argument("--content", default="", help="Inline source content")
-    p_stream.add_argument(
-        "--source-file", default=None, help="Read source content from file"
-    )
+    p_stream.add_argument("--source-file", default=None, help="Read source content from file")
     p_stream.add_argument("--language", default="python")
     p_stream.add_argument("--source-name", default=None)
     p_stream.add_argument("--include-extended", action="store_true")
     p_stream.add_argument("--json", action="store_true")
     p_stream.set_defaults(func=cmd_stream_wheel)
 
-    p_mars = sub.add_parser(
-        "mars-mission", help="Build a GeoSeal Mars mission compass/minimap packet"
-    )
+    p_mars = sub.add_parser("mars-mission", help="Build a GeoSeal Mars mission compass/minimap packet")
     p_mars.add_argument("--input", default=None, help="Mission telemetry JSON file")
     p_mars.add_argument("--payload", default=None, help="Inline mission telemetry JSON")
     p_mars.add_argument("--json", action="store_true")
@@ -4373,15 +4060,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_shell.add_argument("--json", action="store_true")
     p_shell.set_defaults(func=cmd_shell)
 
-    p_exec = sub.add_parser(
-        "exec", help="Run an external command through the GeoSeal execution gate"
-    )
-    p_exec.add_argument(
-        "command", nargs=argparse.REMAINDER, help="Command to parse, scan, and execute"
-    )
-    p_exec.add_argument(
-        "--cwd", default=None, help="Working directory for the subprocess"
-    )
+    p_exec = sub.add_parser("exec", help="Run an external command through the GeoSeal execution gate")
+    p_exec.add_argument("command", nargs=argparse.REMAINDER, help="Command to parse, scan, and execute")
+    p_exec.add_argument("--cwd", default=None, help="Working directory for the subprocess")
     p_exec.add_argument("--timeout", type=float, default=30.0)
     p_exec.add_argument(
         "--max-tier",
@@ -4435,12 +4116,8 @@ def build_parser() -> argparse.ArgumentParser:
         "swarm-exec",
         help="Meet-in-the-middle codegen: merge two halves through the bijective seam, then run through the gate",
     )
-    p_swarm_exec.add_argument(
-        "--forward", required=True, help="Path to the forward (input → seam) half"
-    )
-    p_swarm_exec.add_argument(
-        "--reverse", required=True, help="Path to the reverse (seam → output) half"
-    )
+    p_swarm_exec.add_argument("--forward", required=True, help="Path to the forward (input → seam) half")
+    p_swarm_exec.add_argument("--reverse", required=True, help="Path to the reverse (seam → output) half")
     p_swarm_exec.add_argument(
         "--seam-names",
         required=True,
@@ -4463,9 +4140,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Actually run the merged module through the gate",
     )
-    p_swarm_exec.add_argument(
-        "--cwd", default=None, help="Working directory for the merged-module subprocess"
-    )
+    p_swarm_exec.add_argument("--cwd", default=None, help="Working directory for the merged-module subprocess")
     p_swarm_exec.add_argument("--timeout", type=float, default=30.0)
     p_swarm_exec.add_argument(
         "--max-tier",
@@ -4503,30 +4178,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_validate_line.add_argument("--json", action="store_true")
     p_validate_line.set_defaults(func=cmd_validate_line)
 
-    p_decode = sub.add_parser(
-        "decode-cmd", help="Decode Sacred Tongue tokens back to plaintext"
-    )
+    p_decode = sub.add_parser("decode-cmd", help="Decode Sacred Tongue tokens back to plaintext")
     p_decode.add_argument("--tongue", required=True, help="KO|AV|RU|CA|UM|DR")
-    p_decode.add_argument(
-        "tokens", nargs="?", default=None, help="Token stream (defaults to stdin)"
-    )
+    p_decode.add_argument("tokens", nargs="?", default=None, help="Token stream (defaults to stdin)")
     p_decode.set_defaults(func=cmd_decode_cmd)
 
-    p_xlate = sub.add_parser(
-        "xlate-cmd", help="Translate Sacred Tongue token stream across tongues"
-    )
+    p_xlate = sub.add_parser("xlate-cmd", help="Translate Sacred Tongue token stream across tongues")
     p_xlate.add_argument("--src", required=True, help="Source tongue")
     p_xlate.add_argument("--dst", required=True, help="Destination tongue")
-    p_xlate.add_argument(
-        "tokens", nargs="?", default=None, help="Token stream (defaults to stdin)"
-    )
+    p_xlate.add_argument("tokens", nargs="?", default=None, help="Token stream (defaults to stdin)")
     p_xlate.set_defaults(func=cmd_xlate_cmd)
 
     p_atomic = sub.add_parser("atomic", help="Inspect atomic substrate row for an op")
     p_atomic.add_argument("op")
-    p_atomic.add_argument(
-        "--show-code", action="store_true", help="Include all code templates"
-    )
+    p_atomic.add_argument("--show-code", action="store_true", help="Include all code templates")
     p_atomic.set_defaults(func=cmd_atomic)
 
     p_emit = sub.add_parser("emit", help="Emit code for an op")
@@ -4560,13 +4225,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_swarm = sub.add_parser("swarm", help="Dispatch an op to a swarm of tongue bots")
     p_swarm.add_argument("op")
-    p_swarm.add_argument(
-        "--tongues", default=None, help="comma-separated (default: all 6)"
-    )
+    p_swarm.add_argument("--tongues", default=None, help="comma-separated (default: all 6)")
     p_swarm.add_argument("--timeout", type=float, default=10.0)
-    p_swarm.add_argument(
-        "--no-run", action="store_true", help="Emit only, don't execute"
-    )
+    p_swarm.add_argument("--no-run", action="store_true", help="Emit only, don't execute")
     p_swarm.add_argument("--no-ledger", action="store_true", help="Skip writing ledger")
     p_swarm.add_argument("--ledger", default=str(DEFAULT_LEDGER))
     p_swarm.add_argument("--json", action="store_true")
@@ -4612,9 +4273,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_agent = sub.add_parser("agent", help="Route a coding task via Polly + GeoSeal")
     p_agent.add_argument("task", help="Natural language coding task")
-    p_agent.add_argument(
-        "--tongue", default=None, help="Force tongue (KO/AV/RU/CA/UM/DR)"
-    )
+    p_agent.add_argument("--tongue", default=None, help="Force tongue (KO/AV/RU/CA/UM/DR)")
     p_agent.add_argument(
         "--provider",
         default=None,
@@ -4665,28 +4324,18 @@ def build_parser() -> argparse.ArgumentParser:
     p_arc.add_argument("task_file", help="Path to ARC task JSON")
     p_arc.add_argument("--json", action="store_true", help="Machine-readable output")
     p_arc.add_argument("--onnx", action="store_true", help="Export program as ONNX")
-    p_arc.add_argument(
-        "--onnx-out", default=None, dest="onnx_out", help="ONNX output path"
-    )
+    p_arc.add_argument("--onnx-out", default=None, dest="onnx_out", help="ONNX output path")
     p_arc.add_argument("--no-ledger", action="store_true", help="Skip ledger write")
     p_arc.add_argument("--ledger", default=str(DEFAULT_LEDGER))
     p_arc.add_argument("--verbose", "-v", action="store_true")
     p_arc.set_defaults(func=cmd_arc)
 
-    p_cursor = sub.add_parser(
-        "cursor", help="Delegate a bounded repo task to Cursor Agent"
-    )
+    p_cursor = sub.add_parser("cursor", help="Delegate a bounded repo task to Cursor Agent")
     p_cursor.add_argument("task", help="Repo task to hand to Cursor Agent")
-    p_cursor.add_argument(
-        "--workspace", default=str(Path.cwd()), help="Workspace directory"
-    )
+    p_cursor.add_argument("--workspace", default=str(Path.cwd()), help="Workspace directory")
     p_cursor.add_argument("--model", default=None, help="Cursor model override")
-    p_cursor.add_argument(
-        "--mode", default=None, choices=["plan", "ask"], help="Cursor execution mode"
-    )
-    p_cursor.add_argument(
-        "--force", action="store_true", help="Pass --force to Cursor Agent"
-    )
+    p_cursor.add_argument("--mode", default=None, choices=["plan", "ask"], help="Cursor execution mode")
+    p_cursor.add_argument("--force", action="store_true", help="Pass --force to Cursor Agent")
     p_cursor.add_argument(
         "--output-format",
         default="text",
@@ -4700,22 +4349,16 @@ def build_parser() -> argparse.ArgumentParser:
         dest="stream_partial_output",
         help="Enable stream-json partial output deltas",
     )
-    p_cursor.add_argument(
-        "--continue-session", action="store_true", dest="continue_session"
-    )
+    p_cursor.add_argument("--continue-session", action="store_true", dest="continue_session")
     p_cursor.add_argument("--no-ledger", action="store_true", help="Skip ledger write")
     p_cursor.add_argument("--ledger", default=str(DEFAULT_LEDGER))
     p_cursor.add_argument("--verbose", "-v", action="store_true")
     p_cursor.set_defaults(func=cmd_cursor)
 
-    p_workflow = sub.add_parser(
-        "workflow", help="Declarative .geoseal.yaml workflow runner"
-    )
+    p_workflow = sub.add_parser("workflow", help="Declarative .geoseal.yaml workflow runner")
     wf_sub = p_workflow.add_subparsers(dest="workflow_cmd", required=True)
 
-    p_wf_list = wf_sub.add_parser(
-        "list", help="List .geoseal.yaml workflows in a directory"
-    )
+    p_wf_list = wf_sub.add_parser("list", help="List .geoseal.yaml workflows in a directory")
     p_wf_list.add_argument("--dir", default=".", help="Directory to scan")
     p_wf_list.add_argument("--json", action="store_true")
     p_wf_list.set_defaults(func=cmd_workflow, workflow_cmd="list")

--- a/src/input/bijective_input.py
+++ b/src/input/bijective_input.py
@@ -182,9 +182,7 @@ def _pack_mouse(ev: MouseEvent) -> bytes:
 
 def _unpack_mouse(payload: bytes) -> MouseEvent:
     if len(payload) != MOUSE_FRAME_SIZE - 1:
-        raise ValueError(
-            f"mouse frame must be {MOUSE_FRAME_SIZE - 1} bytes after kind, got {len(payload)}"
-        )
+        raise ValueError(f"mouse frame must be {MOUSE_FRAME_SIZE - 1} bytes after kind, got {len(payload)}")
     ts, x, y, btn, act, reserved, scroll_unsigned = struct.unpack("<Qiibb2sI", payload)
     if reserved != b"\x00\x00":
         raise ValueError("mouse frame reserved bytes must be zero")
@@ -213,9 +211,7 @@ def _pack_key(ev: KeyEvent) -> bytes:
 
 def _unpack_key(payload: bytes) -> KeyEvent:
     if len(payload) != KEY_FRAME_SIZE - 1:
-        raise ValueError(
-            f"key frame must be {KEY_FRAME_SIZE - 1} bytes after kind, got {len(payload)}"
-        )
+        raise ValueError(f"key frame must be {KEY_FRAME_SIZE - 1} bytes after kind, got {len(payload)}")
     ts, keycode, mods, action, reserved = struct.unpack("<QHBB4s", payload)
     if reserved != b"\x00\x00\x00\x00":
         raise ValueError("key frame reserved bytes must be zero")

--- a/tests/cli/test_command_trace.py
+++ b/tests/cli/test_command_trace.py
@@ -84,12 +84,8 @@ def test_digest_changes_when_stdin_changes() -> None:
 
 
 def test_digest_changes_when_env_changes() -> None:
-    a = record_session(
-        ["geoseal", "ops"], env={"GEOSEAL_TIER": "public"}, timestamp_us=0
-    )
-    b = record_session(
-        ["geoseal", "ops"], env={"GEOSEAL_TIER": "keyed"}, timestamp_us=0
-    )
+    a = record_session(["geoseal", "ops"], env={"GEOSEAL_TIER": "public"}, timestamp_us=0)
+    b = record_session(["geoseal", "ops"], env={"GEOSEAL_TIER": "keyed"}, timestamp_us=0)
     assert a.digest() != b.digest()
 
 
@@ -220,9 +216,7 @@ def test_ledger_jsonl_round_trip(tmp_path: Path) -> None:
 
 
 def test_ledger_load_missing_file_returns_empty() -> None:
-    ledger = PromotionLedger.load(
-        Path("/tmp/nonexistent_ledger_xyz.jsonl"), threshold=2
-    )
+    ledger = PromotionLedger.load(Path("/tmp/nonexistent_ledger_xyz.jsonl"), threshold=2)
     assert ledger.entries == {}
 
 
@@ -238,9 +232,7 @@ def test_recurrent_invocations_from_replayed_packets_are_counted() -> None:
     ledger = PromotionLedger(threshold=2)
 
     # Agent A's session
-    trace_a = record_session(
-        ["geoseal", "swarm-exec", "--task", "add"], timestamp_us=100
-    )
+    trace_a = record_session(["geoseal", "swarm-exec", "--task", "add"], timestamp_us=100)
     packets = trace_to_packets(trace_a)
 
     # Agent B receives and replays

--- a/tests/cli/test_cross_build_cli.py
+++ b/tests/cli/test_cross_build_cli.py
@@ -76,9 +76,7 @@ def test_cross_build_single_av_to_dr_for_xor() -> None:
 
 def test_alias_xb_works_identically() -> None:
     main = _run("--src-code", "(x - y)", "--src-tongue", "KO", "--dst-tongue", "DR")
-    aliased = _run_alias(
-        "--src-code", "(x - y)", "--src-tongue", "KO", "--dst-tongue", "DR"
-    )
+    aliased = _run_alias("--src-code", "(x - y)", "--src-tongue", "KO", "--dst-tongue", "DR")
     assert main.returncode == 0 and aliased.returncode == 0
     assert json.loads(main.stdout)["dst_code"] == json.loads(aliased.stdout)["dst_code"]
 

--- a/tests/cli/test_cross_build_ir.py
+++ b/tests/cli/test_cross_build_ir.py
@@ -50,11 +50,7 @@ def _canonical_args_for(op_name: str) -> Dict[str, str]:
         # Collect every {field} occurrence across all 6 tongue templates.
         import string as _s
 
-        fields.update(
-            field
-            for _, field, _, _ in _s.Formatter().parse(template)
-            if field is not None
-        )
+        fields.update(field for _, field, _, _ in _s.Formatter().parse(template) if field is not None)
     # Stable, simple, regex-safe arg values.
     canon = {
         "a": "x",
@@ -131,17 +127,11 @@ def test_symmetry_lexicon_all_directed_pairs() -> None:
                 forward = cross_build(src_code, src_tongue, dst_tongue)
                 back = cross_build(forward.dst_code, dst_tongue, src_tongue)
             except QuarantineError as exc:
-                failures.append(
-                    (op_name, src_tongue, dst_tongue, "<quarantine>", str(exc))
-                )
+                failures.append((op_name, src_tongue, dst_tongue, "<quarantine>", str(exc)))
                 continue
             if back.dst_code != src_code:
-                failures.append(
-                    (op_name, src_tongue, dst_tongue, src_code, back.dst_code)
-                )
-    assert (
-        not failures
-    ), f"symmetry broken in {len(failures)} cases: first={failures[:3]}"
+                failures.append((op_name, src_tongue, dst_tongue, src_code, back.dst_code))
+    assert not failures, f"symmetry broken in {len(failures)} cases: first={failures[:3]}"
 
 
 # ---------------------------------------------------------------------------
@@ -176,9 +166,7 @@ def test_ir_closure_value_equality_across_source_tongues() -> None:
         if canonical is None:
             canonical = ir
         else:
-            assert (
-                ir == canonical
-            ), f"IR drift for {op_name} from tongue={tongue}: {ir} != {canonical}"
+            assert ir == canonical, f"IR drift for {op_name} from tongue={tongue}: {ir} != {canonical}"
 
 
 def test_ir_closure_holds_for_every_lexicon_op() -> None:

--- a/tests/cli/test_param_binding.py
+++ b/tests/cli/test_param_binding.py
@@ -85,11 +85,7 @@ def test_validate_range_rejects_out_of_band_value() -> None:
     ns = parser.parse_args(["--name", "x", "--count", "99"])
     with pytest.raises(ParameterSetError) as exc:
         _SimpleCmd.from_namespace(ns)
-    assert (
-        "less_than_equal" in str(exc.value)
-        or "100" in str(exc.value)
-        or "10" in str(exc.value)
-    )
+    assert "less_than_equal" in str(exc.value) or "100" in str(exc.value) or "10" in str(exc.value)
 
 
 def test_literal_choices_propagate_to_argparse() -> None:

--- a/tests/cli/test_route_cli.py
+++ b/tests/cli/test_route_cli.py
@@ -25,9 +25,7 @@ def _run(*extra: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _ollama_reachable(
-    host: str = "http://localhost:11434", timeout: float = 1.0
-) -> bool:
+def _ollama_reachable(host: str = "http://localhost:11434", timeout: float = 1.0) -> bool:
     try:
         import httpx  # noqa: PLC0415
     except ImportError:

--- a/tests/cli/test_slm_router_harsh.py
+++ b/tests/cli/test_slm_router_harsh.py
@@ -285,9 +285,7 @@ def test_ollama_adapter_http_500_surfaces_as_quarantine() -> None:
 
     adapter = OllamaAdapter()
     fake_response = MagicMock()
-    fake_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-        "500", request=MagicMock(), response=MagicMock()
-    )
+    fake_response.raise_for_status.side_effect = httpx.HTTPStatusError("500", request=MagicMock(), response=MagicMock())
     with patch("httpx.post", return_value=fake_response):
         with pytest.raises(QuarantineError):
             adapter.classify("test", ["A", "B"])
@@ -325,9 +323,7 @@ def test_ollama_adapter_choice_outside_choices_surfaces_as_quarantine() -> None:
     adapter = OllamaAdapter()
     fake_response = MagicMock()
     fake_response.raise_for_status.return_value = None
-    fake_response.json.return_value = {
-        "response": '{"choice": "TRANSCENDENT", "confidence": 0.99}'
-    }
+    fake_response.json.return_value = {"response": '{"choice": "TRANSCENDENT", "confidence": 0.99}'}
     with patch("httpx.post", return_value=fake_response):
         chosen, conf = adapter.classify("test", ["A", "B"])
         # Adapter contract is "return whatever model said" — verification

--- a/tests/cli/test_slm_router_live_ollama.py
+++ b/tests/cli/test_slm_router_live_ollama.py
@@ -19,9 +19,7 @@ from typing import Optional
 import pytest
 
 
-def _ollama_reachable(
-    host: str = "http://localhost:11434", timeout: float = 1.0
-) -> bool:
+def _ollama_reachable(host: str = "http://localhost:11434", timeout: float = 1.0) -> bool:
     try:
         import httpx  # noqa: PLC0415
     except ImportError:
@@ -33,9 +31,7 @@ def _ollama_reachable(
         return False
 
 
-def _model_available(
-    model: str, host: str = "http://localhost:11434", timeout: float = 2.0
-) -> bool:
+def _model_available(model: str, host: str = "http://localhost:11434", timeout: float = 2.0) -> bool:
     try:
         import httpx  # noqa: PLC0415
 
@@ -98,10 +94,7 @@ _QUALIFIED_MODEL = _resolve_qualified_model() if _REACHABLE else None
 
 
 if not _REACHABLE:
-    _SKIP_REASON = (
-        f"Ollama not reachable at {_HOST}. "
-        "Start with `ollama serve` to enable these tests."
-    )
+    _SKIP_REASON = f"Ollama not reachable at {_HOST}. " "Start with `ollama serve` to enable these tests."
 elif _QUALIFIED_MODEL is None:
     _SKIP_REASON = (
         f"No qualified instruct model installed at {_HOST}. "
@@ -149,9 +142,7 @@ def test_live_ollama_classifies_op_within_arithmetic_band() -> None:
 
     adapter = OllamaAdapter(model=_QUALIFIED_MODEL, host=_HOST)
     arith_ops = _ops_in_band("ARITHMETIC")
-    chosen, conf = adapter.classify(
-        _op_prompt("add x and y", "ARITHMETIC", arith_ops), arith_ops
-    )
+    chosen, conf = adapter.classify(_op_prompt("add x and y", "ARITHMETIC", arith_ops), arith_ops)
     assert chosen in arith_ops, f"out-of-set: {chosen!r}"
     assert chosen == "add", f"expected 'add', got {chosen!r}"
 

--- a/tests/cli/test_slm_router_modes.py
+++ b/tests/cli/test_slm_router_modes.py
@@ -313,9 +313,7 @@ def test_pinned_stages_appear_in_reasoning() -> None:
         op_name="add",
         dst_tongue="RU",
     )
-    pinned_lines = [
-        r for r in result.reasoning if "pinned" in r or "caller-supplied" in r
-    ]
+    pinned_lines = [r for r in result.reasoning if "pinned" in r or "caller-supplied" in r]
     assert len(pinned_lines) == 3  # band-via-op, op, tongue
     assert any("band=pinned-via-op:ARITHMETIC" in r for r in pinned_lines)
     assert any("op=pinned:add" in r for r in pinned_lines)
@@ -333,9 +331,7 @@ def test_manual_mode_still_detects_loops() -> None:
 
     adapter = _RecordingAdapter()
     router = LatticeRouter(adapter, loop_window=4)
-    router.route(
-        "a", args={"a": "x", "b": "y"}, op_name="add", dst_tongue="KO", mode=Mode.MANUAL
-    )
+    router.route("a", args={"a": "x", "b": "y"}, op_name="add", dst_tongue="KO", mode=Mode.MANUAL)
     with pytest.raises(LoopDetected):
         router.route(
             "b",

--- a/tests/input/test_bijective_input.py
+++ b/tests/input/test_bijective_input.py
@@ -50,9 +50,7 @@ from src.input.bijective_input import (
 def test_mouse_move_round_trip() -> None:
     ev = MouseEvent(timestamp_us=1_700_000_000_000_000, x=512, y=384)
     tokens = encode_mouse_event(ev)
-    assert (
-        isinstance(tokens, list) and tokens
-    ), "encoder must return non-empty token list"
+    assert isinstance(tokens, list) and tokens, "encoder must return non-empty token list"
     decoded = decode_mouse_event(tokens)
     assert decoded == ev
 
@@ -247,9 +245,7 @@ def test_polar_zero_origin_returns_zero_radius() -> None:
 def _sample_trace() -> List[object]:
     return [
         MouseEvent(timestamp_us=10, x=100, y=100, action=MouseAction.MOVE),
-        KeyEvent(
-            timestamp_us=20, keycode=0x41, modifiers=MOD_SHIFT, action=KeyAction.DOWN
-        ),
+        KeyEvent(timestamp_us=20, keycode=0x41, modifiers=MOD_SHIFT, action=KeyAction.DOWN),
         MouseEvent(
             timestamp_us=30,
             x=200,
@@ -332,9 +328,7 @@ def test_verify_trace_with_expected_count() -> None:
 
 def test_verify_trace_with_expected_kinds() -> None:
     packets = encode_trace(_sample_trace())
-    good = verify_trace(
-        packets, expected_kinds=[KIND_MOUSE, KIND_KEY, KIND_MOUSE, KIND_KEY, KIND_MOUSE]
-    )
+    good = verify_trace(packets, expected_kinds=[KIND_MOUSE, KIND_KEY, KIND_MOUSE, KIND_KEY, KIND_MOUSE])
     assert good["ok"] is True
 
     wrong = verify_trace(packets, expected_kinds=[KIND_KEY] * 5)
@@ -386,9 +380,7 @@ def test_replay_trace_sink_is_optional() -> None:
 
 def test_same_event_yields_same_tokens() -> None:
     """Determinism is the whole point — same event, byte-equal tokens."""
-    ev = MouseEvent(
-        timestamp_us=12345, x=10, y=20, action=MouseAction.DOWN, button=MouseButton.LEFT
-    )
+    ev = MouseEvent(timestamp_us=12345, x=10, y=20, action=MouseAction.DOWN, button=MouseButton.LEFT)
     a = encode_mouse_event(ev)
     b = encode_mouse_event(ev)
     assert a == b


### PR DESCRIPTION
## Summary
- apply the exact CI Black profile to the route/cross-build slice merged in #1414
- no behavior changes

## Validation
- python -m black --check --target-version py311 --line-length 120 src/ tests/
- python -m ruff check src/geoseal_cli.py src/cli src/input tests/cli tests/input
- python -m pytest tests/cli/test_command_trace.py tests/cli/test_cross_build_ir.py tests/cli/test_cross_build_cli.py tests/cli/test_param_binding.py tests/cli/test_route_cli.py tests/cli/test_slm_router.py tests/cli/test_slm_router_modes.py tests/cli/test_slm_router_concurrency.py tests/cli/test_slm_router_harsh.py tests/cli/test_slm_router_live_ollama.py tests/input -q

## Rollback
- revert this style-only commit if needed