### PR TITLE
fix(ci): clean mobile bus release formatting

### DIFF
--- a/docs/ops/FREE_FIRST_AGENT_AND_STORAGE_POLICY.md
+++ b/docs/ops/FREE_FIRST_AGENT_AND_STORAGE_POLICY.md
@@ -78,4 +78,3 @@ Add storage buttons to the mobile/web agent UI:
 - Send to Google Drive
 
 The first two should work immediately. The cloud buttons can begin as export/download handoffs, then upgrade to OAuth flows later.
-

--- a/tests/test_agent_storage_zero_credit.py
+++ b/tests/test_agent_storage_zero_credit.py
@@ -33,9 +33,7 @@ def test_agent_storage_endpoint_requires_commonjs_cleanly() -> None:
     assert payload["handlerType"] == "function"
     assert payload["hasBuilder"] == "function"
     assert payload["providers"][:2] == ["local_download", "browser_local"]
-    assert {"github", "dropbox", "onedrive", "gdrive"}.issubset(
-        set(payload["providers"])
-    )
+    assert {"github", "dropbox", "onedrive", "gdrive"}.issubset(set(payload["providers"]))
 
 
 def test_agent_storage_builds_zero_server_storage_export_packet() -> None:


### PR DESCRIPTION
## Summary
- apply CI Black formatting for the storage endpoint test
- remove the extra EOF blank line rejected by the deterministic review gate

## Test evidence
- python -m pytest tests/test_aethermoor_bus_mobile_shell.py tests/test_agent_chat_local_first.py tests/test_agent_search_zero_credit.py tests/test_agent_storage_zero_credit.py -q
- python -m black --check --line-length 120 tests/test_aethermoor_bus_mobile_shell.py tests/test_agent_chat_local_first.py tests/test_agent_search_zero_credit.py tests/test_agent_storage_zero_credit.py
- npx prettier --check api/agent/chat.js api/agent/health.js api/agent/search.js api/agent/storage.js kindle-app/scripts/copy-pwa-assets.js kindle-app/bus-www/index.html kindle-app/bus-www/manifest.json kindle-app/bus-www/sw.js kindle-app/www/index.html kindle-app/www/manifest.json kindle-app/www/chat.html kindle-app/www/static/phone-shell.js