### PR TITLE
feat(agent): add local Ollama bridge for mobile bus

### DIFF
--- a/docs/ops/LOCAL_FIRST_MODEL_ROUTING.md
+++ b/docs/ops/LOCAL_FIRST_MODEL_ROUTING.md
@@ -1,0 +1,109 @@
+# Local-First Model Routing
+
+SCBE chat and agent support should prefer the cheapest usable model path:
+
+1. Local Ollama when `OLLAMA_URL` or `AGENT_OLLAMA_URL` is configured.
+2. Hugging Face when `HF_TOKEN`, `HUGGINGFACE_TOKEN`, or `HUGGING_FACE_HUB_TOKEN` is configured.
+3. Deterministic offline response when no model provider is available.
+
+This keeps the mobile/web endpoint usable with minimal external dependency, while still allowing better hosted models when a token or paid provider is intentionally configured.
+
+## Vercel / Hosted Endpoint
+
+`api/agent/chat.js` is the public chat bridge used by mobile/web clients.
+
+Useful environment variables:
+
+```text
+AGENT_CHAT_PROVIDER_ORDER=ollama,huggingface,offline
+AGENT_OLLAMA_URL=http://127.0.0.1:11434
+AGENT_OLLAMA_MODEL=llama3.2
+HF_TOKEN=...
+AGENT_HF_MODEL=Qwen/Qwen2.5-72B-Instruct
+AGENT_CHAT_TIMEOUT_MS=25000
+```
+
+For Vercel production, `AGENT_OLLAMA_URL` should usually be unset unless the deployment can reach a private Ollama service. Vercel cannot reach an Ollama process running on the user's home PC at `127.0.0.1`. On a local/self-hosted backend, set `AGENT_OLLAMA_URL=http://127.0.0.1:11434` and keep Hugging Face as fallback.
+
+## Health Check
+
+`GET /api/agent/health` reports:
+
+- provider order
+- whether Ollama is configured
+- whether Hugging Face is configured
+- chosen Ollama and Hugging Face model IDs
+- the cost policy
+
+## At-Home Smoke Test
+
+Do not put Ollama model blobs in GitHub. Keep GitHub for code, scripts, and small manifests. Keep Ollama models on the
+machine that serves inference, or publish model artifacts through Hugging Face when a real model release is needed.
+
+This machine currently has small local models suitable for a free-first backend:
+
+- `qwen2.5-coder:1.5b`
+- `gemma3:1b`
+- `scbe-geoseal-coder:q8`
+- `qwen2.5-coder:0.5b`
+
+When the home machine is available, start Ollama:
+
+```powershell
+ollama list
+ollama serve
+```
+
+Then, from another shell, run the local bridge:
+
+```powershell
+npm run agent:local-ollama
+```
+
+The bridge serves the same public endpoints the mobile app already uses:
+
+- `GET /api/agent/health`
+- `POST /api/agent/chat`
+- `POST /api/agent/search`
+- `GET|POST /api/agent/storage`
+
+It prints a LAN URL like:
+
+```text
+phone: http://192.168.1.25:8787
+```
+
+Put that URL into the mobile app's **Bridge** field while the phone is on the same Wi-Fi. The app will then use the PC's
+Ollama models without customer API keys.
+
+One-shot setup helper:
+
+```powershell
+.\scripts\system\setup_local_ollama_backend.ps1
+```
+
+Use `-SkipPull` if the models are already present:
+
+```powershell
+.\scripts\system\setup_local_ollama_backend.ps1 -SkipPull
+```
+
+For a direct module smoke test:
+
+```powershell
+$env:AGENT_OLLAMA_URL="http://127.0.0.1:11434"
+$env:AGENT_OLLAMA_MODEL="qwen2.5-coder:1.5b"
+node -e "const {routeChat,chatConfig}=require('./api/agent/chat.js')._private; routeChat(chatConfig(),'Say READY in one word',[]).then(r=>console.log(JSON.stringify(r,null,2)))"
+```
+
+Expected result: `provider` is `ollama` and `model` is the configured local model.
+
+## Google Play Upload Reminder
+
+Upload the corrected internal-test bundle:
+
+```text
+C:\Users\issda\Downloads\aethermoor-bus-internal-0.1.1-io.aethermoor.bus-SIGNED.aab
+```
+
+Verified package name: `io.aethermoor.bus`.

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "agent:mars-mission-compass": "python -m src.geoseal_cli mars-mission",
     "benchmark:cross-language-lookup": "python scripts/system/build_cross_language_lookup.py",
     "agent:aetherpp": "python scripts/aetherpp/cli.py",
+    "agent:local-ollama": "node scripts/system/local_ollama_agent_bridge.cjs",
     "training:kaggle:approval-v2:ready": "python scripts/kaggle_auto/launch.py --round coding-approval-metrics-v2 --gpu t4 --ready",
     "training:kaggle:approval-v2:launch": "python scripts/kaggle_auto/launch.py --round coding-approval-metrics-v2 --gpu t4",
     "training:kaggle:dsl-v3-paid:ready": "python scripts/kaggle_auto/launch.py --round dsl-synthesis-v3-fast --gpu t4 --gpu-session-limit 3 --ready",

--- a/scripts/system/local_ollama_agent_bridge.cjs
+++ b/scripts/system/local_ollama_agent_bridge.cjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+'use strict';
+
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const ROUTES = {
+  '/api/agent/chat': require(path.join(REPO_ROOT, 'api/agent/chat.js')),
+  '/api/agent/health': require(path.join(REPO_ROOT, 'api/agent/health.js')),
+  '/api/agent/search': require(path.join(REPO_ROOT, 'api/agent/search.js')),
+  '/api/agent/storage': require(path.join(REPO_ROOT, 'api/agent/storage.js')),
+};
+
+function configureDefaults(env = process.env) {
+  env.AGENT_CHAT_PROVIDER_ORDER = env.AGENT_CHAT_PROVIDER_ORDER || 'ollama,huggingface,offline';
+  env.AGENT_OLLAMA_URL = env.AGENT_OLLAMA_URL || env.OLLAMA_URL || 'http://127.0.0.1:11434';
+  env.AGENT_OLLAMA_MODEL = env.AGENT_OLLAMA_MODEL || env.OLLAMA_MODEL || 'qwen2.5-coder:1.5b';
+  env.AGENT_CHAT_TIMEOUT_MS = env.AGENT_CHAT_TIMEOUT_MS || '45000';
+}
+
+function lanAddresses() {
+  const rows = [];
+  for (const entries of Object.values(os.networkInterfaces())) {
+    for (const entry of entries || []) {
+      if (entry.family === 'IPv4' && !entry.internal) {
+        rows.push(entry.address);
+      }
+    }
+  }
+  return rows;
+}
+
+function wrapResponse(res) {
+  let statusCode = 200;
+  return {
+    setHeader(name, value) {
+      res.setHeader(name, value);
+      return this;
+    },
+    status(code) {
+      statusCode = Number(code) || 500;
+      return this;
+    },
+    json(payload) {
+      if (!res.headersSent) {
+        res.statusCode = statusCode;
+      }
+      res.end(JSON.stringify(payload));
+      return this;
+    },
+    end(payload) {
+      if (!res.headersSent) {
+        res.statusCode = statusCode;
+      }
+      res.end(payload);
+      return this;
+    },
+  };
+}
+
+function createBridgeServer() {
+  configureDefaults();
+  return http.createServer(async (req, res) => {
+    const url = new URL(req.url || '/', `http://${req.headers.host || '127.0.0.1'}`);
+    const handler = ROUTES[url.pathname];
+    if (!handler) {
+      res.writeHead(404, { 'content-type': 'application/json; charset=utf-8' });
+      res.end(JSON.stringify({ ok: false, error: 'unknown route', route: url.pathname }));
+      return;
+    }
+    try {
+      await handler(req, wrapResponse(res));
+    } catch (error) {
+      if (!res.headersSent) {
+        res.writeHead(500, { 'content-type': 'application/json; charset=utf-8' });
+      }
+      res.end(
+        JSON.stringify({
+          ok: false,
+          error: 'local bridge handler failed',
+          detail: String(error && error.message ? error.message : error),
+        })
+      );
+    }
+  });
+}
+
+function main() {
+  configureDefaults();
+  const host = process.env.LOCAL_AGENT_BRIDGE_HOST || '0.0.0.0';
+  const port = Number(process.env.LOCAL_AGENT_BRIDGE_PORT || 8787);
+  const server = createBridgeServer();
+  server.listen(port, host, () => {
+    const address = server.address();
+    const boundPort = typeof address === 'object' && address ? address.port : port;
+    console.log('Aethermoor local Ollama agent bridge');
+    console.log(`  model: ${process.env.AGENT_OLLAMA_MODEL}`);
+    console.log(`  ollama: ${process.env.AGENT_OLLAMA_URL}`);
+    console.log(`  local: http://127.0.0.1:${boundPort}`);
+    for (const ip of lanAddresses()) {
+      console.log(`  phone: http://${ip}:${boundPort}`);
+    }
+    console.log('Set the app Bridge field to the phone URL while on the same Wi-Fi.');
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  configureDefaults,
+  createBridgeServer,
+  lanAddresses,
+};

--- a/scripts/system/setup_local_ollama_backend.ps1
+++ b/scripts/system/setup_local_ollama_backend.ps1
@@ -1,0 +1,37 @@
+param(
+  [string[]] $Models = @("qwen2.5-coder:1.5b", "gemma3:1b"),
+  [string] $ServeModel = "qwen2.5-coder:1.5b",
+  [int] $Port = 8787,
+  [switch] $SkipPull
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command ollama -ErrorAction SilentlyContinue)) {
+  throw "Ollama is not on PATH. Install Ollama first, then rerun this script."
+}
+
+Write-Host "Ollama detected:"
+ollama --version
+
+if (-not $SkipPull) {
+  foreach ($model in $Models) {
+    Write-Host "Ensuring Ollama model is present: $model"
+    ollama pull $model
+  }
+}
+
+$env:AGENT_CHAT_PROVIDER_ORDER = "ollama,huggingface,offline"
+$env:AGENT_OLLAMA_URL = "http://127.0.0.1:11434"
+$env:AGENT_OLLAMA_MODEL = $ServeModel
+$env:AGENT_CHAT_TIMEOUT_MS = "45000"
+$env:LOCAL_AGENT_BRIDGE_PORT = [string] $Port
+
+Write-Host ""
+Write-Host "Installed models:"
+ollama list
+
+Write-Host ""
+Write-Host "Starting Aethermoor local bridge. Leave this window open."
+Write-Host "If Ollama is not already running, start it in another window with: ollama serve"
+node scripts/system/local_ollama_agent_bridge.cjs

--- a/tests/test_local_ollama_agent_bridge.py
+++ b/tests/test_local_ollama_agent_bridge.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_node(script: str) -> dict:
+    env = os.environ.copy()
+    env["AGENT_CHAT_PROVIDER_ORDER"] = "offline"
+    env.pop("HF_TOKEN", None)
+    env.pop("HUGGINGFACE_TOKEN", None)
+    env.pop("HUGGING_FACE_HUB_TOKEN", None)
+    proc = subprocess.run(
+        ["node", "-e", script],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_local_bridge_exports_create_server() -> None:
+    payload = run_node("""
+        const bridge = require('./scripts/system/local_ollama_agent_bridge.cjs');
+        console.log(JSON.stringify({
+          createBridgeServer: typeof bridge.createBridgeServer,
+          configureDefaults: typeof bridge.configureDefaults
+        }));
+        """)
+    assert payload == {"createBridgeServer": "function", "configureDefaults": "function"}
+
+
+def test_local_bridge_serves_health_and_chat_without_customer_key() -> None:
+    payload = run_node("""
+        const { createBridgeServer } = require('./scripts/system/local_ollama_agent_bridge.cjs');
+        const server = createBridgeServer();
+        server.listen(0, '127.0.0.1', async () => {
+          const port = server.address().port;
+          const base = `http://127.0.0.1:${port}`;
+          const health = await fetch(`${base}/api/agent/health`).then((r) => r.json());
+          const chat = await fetch(`${base}/api/agent/chat`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ message: 'local bridge smoke' })
+          }).then((r) => r.json());
+          server.close(() => {
+            console.log(JSON.stringify({
+              healthOk: health.ok,
+              storageEndpoint: health.storage.endpoint,
+              chatOk: chat.ok,
+              provider: chat.provider,
+              text: chat.text
+            }));
+          });
+        });
+        """)
+    assert payload["healthOk"] is True
+    assert payload["storageEndpoint"] == "/api/agent/storage"
+    assert payload["chatOk"] is True
+    assert payload["provider"] == "offline"
+    assert "local bridge smoke" in payload["text"]


### PR DESCRIPTION
## Summary
- add a local Node bridge that serves the same /api/agent endpoints as the mobile app expects
- default the local bridge to Ollama at 127.0.0.1:11434 with qwen2.5-coder:1.5b
- add a PowerShell setup helper to pull small Ollama models and start the bridge
- document why model blobs should stay out of GitHub and how to point the phone app at the LAN bridge

## Test evidence
- python -m pytest tests/test_local_ollama_agent_bridge.py tests/test_agent_chat_local_first.py tests/test_aethermoor_bus_mobile_shell.py -q
- npx prettier --check package.json scripts/system/local_ollama_agent_bridge.cjs docs/ops/LOCAL_FIRST_MODEL_ROUTING.md
- python -m black --check --line-length 120 tests/test_local_ollama_agent_bridge.py tests/test_agent_chat_local_first.py tests/test_aethermoor_bus_mobile_shell.py
- local Ollama smoke: /api/agent/chat returned provider=ollama model=qwen2.5-coder:1.5b text=Ready