### PR TITLE
ci: exclude vendored lanes from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      # These are vendored or submodule lanes. Dependabot's recursive checkout can
+      # leave them dirty after root npm security updates, which turns a useful
+      # advisory check into a red background run.
+      - "external/**"
+      - "external_repos/**"
+      - "spiralverse-protocol/**"
+      - "aws-lambda-simple-web-app/**"
+      - "hioujhn/**"
+      - "scbe-aethermoore/**"
+      - "packages/six-tongues-geoseal/**"
+      - "archive/**"
+      - "test-install/**"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary
- exclude vendored/submodule lanes from root npm Dependabot updates
- prevents Dependabot security jobs from dirtying recursive submodule checkouts and failing before creating a PR

## Evidence
- Recent Dependabot failures errored after root npm security update attempts left external/*, external_repos/*, and spiralverse-protocol submodules dirty.
- dependabot.yml parses locally with PyYAML.

## Rollback
- Remove the exclude-paths block if those vendored lanes become first-class root package surfaces.