### PR TITLE
ci: remove stale PR conflict labeler

### DIFF
--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -56,17 +56,6 @@ jobs:
   # NOTE: Stale management is handled by the dedicated stale.yml workflow.
   # Removed duplicate stale-management job to prevent conflicting policies.
 
-  conflict-detection:
-    name: Detect PR Conflicts
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: github.event_name == 'pull_request_target'
-    steps:
-      - uses: eps1lon/actions-label-merge-conflict@v3
-        with:
-          dirtyLabel: 'needs-rebase'
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-
   auto-approve-dependabot:
     name: Auto Approve Dependabot PRs
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove the eps1lon/actions-label-merge-conflict job from auto-triage
- the helper times out scanning the old draft fleet PR and creates red checks even when code/tests are green
- GitHub's native mergeability plus existing conflict-marker guard remain in place

## Evidence
- PR #1422 had all build/test/product checks green, but Detect PR Conflicts failed after retrying PR #1313 for 10 minutes.
- auto-triage.yml parses locally with PyYAML.

## Rollback
- Reintroduce a bounded conflict-labeler only if it can target the current PR instead of scanning all open PRs.