### PR TITLE
ci: harden transient PR automation failures

### DIFF
--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -31,6 +31,10 @@ jobs:
             echo "Auto-merge already in progress; treating as success."
             exit 0
           fi
+          if echo "$out" | grep -q "Base branch was modified"; then
+            echo "Base branch changed while enabling auto-merge; treating as neutral."
+            exit 0
+          fi
           exit "$rc"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Local deterministic review gate
         shell: bash
@@ -25,6 +25,9 @@ jobs:
 
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
+
+          git cat-file -e "${base}^{commit}" || git fetch --no-tags --prune origin "${{ github.event.pull_request.base.ref }}"
+          git cat-file -e "${head}^{commit}" || git fetch --no-tags --prune origin "pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-${{ github.event.pull_request.number }}"
 
           echo "## Local deterministic review gate" >> "$GITHUB_STEP_SUMMARY"
           echo >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- fetch full PR history for the local deterministic Claude review gate
- add fallback fetches for missing base/head commits before diffing
- treat transient auto-merge base-branch races as neutral instead of red CI

## Test evidence
- git diff --check

## Rollback
- revert commit 8aa76642 if the stricter PR automation behavior is desired again.