### PR TITLE
ci: skip native liboqs build in PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
     name: Test Python Components
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # PR CI exercises the deterministic fallback/PQC governance path. Native
+      # liboqs builds are too slow/flaky for the merge gate and belong in a
+      # dedicated PQC-native workflow.
+      SCBE_FORCE_SKIP_LIBOQS: "1"
 
     steps:
       - name: Checkout code
@@ -68,16 +73,6 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-
-      - name: Install liboqs C library
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq astyle cmake gcc ninja-build libssl-dev
-          git clone --depth 1 --branch 0.12.0 https://github.com/open-quantum-safe/liboqs.git /tmp/liboqs
-          cmake -S /tmp/liboqs -B /tmp/liboqs/build -GNinja -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr
-          ninja -C /tmp/liboqs/build
-          sudo ninja -C /tmp/liboqs/build install
-          sudo ldconfig
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
## Summary
- removes the native liboqs C build from normal PR Python CI
- sets SCBE_FORCE_SKIP_LIBOQS=1 so CI uses the repo's deterministic fallback/PQC governance path
- keeps native liboqs validation out of the merge gate so it can move to a dedicated PQC-native workflow later

## Validation
- SCBE_FORCE_SKIP_LIBOQS=1 python scripts/system/run_core_python_checks.py
- result: 831 passed, 22 skipped

## Rollback
- restore the Install liboqs C library step in .github/workflows/ci.yml if native liboqs must become required for every PR