### PR TITLE
fix(security): add native liboqs release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
     name: Test Python Components
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # PR CI exercises the deterministic fallback/PQC governance path. Native
+      # liboqs builds are too slow/flaky for the merge gate and belong in a
+      # dedicated PQC-native workflow.
+      SCBE_FORCE_SKIP_LIBOQS: "1"
 
     steps:
       - name: Checkout code
@@ -68,16 +73,6 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-
-      - name: Install liboqs C library
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq astyle cmake gcc ninja-build libssl-dev
-          git clone --depth 1 --branch 0.12.0 https://github.com/open-quantum-safe/liboqs.git /tmp/liboqs
-          cmake -S /tmp/liboqs -B /tmp/liboqs/build -GNinja -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr
-          ninja -C /tmp/liboqs/build
-          sudo ninja -C /tmp/liboqs/build install
-          sudo ldconfig
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
     timeout-minutes: 30
     env:
       # PR CI exercises the deterministic fallback/PQC governance path. Native
-      # liboqs builds are too slow/flaky for the merge gate and belong in a
-      # dedicated PQC-native workflow.
+      # liboqs builds are handled by the dedicated "PQC Native liboqs" workflow,
+      # which must pass for release/security validation.
       SCBE_FORCE_SKIP_LIBOQS: "1"
 
     steps:

--- a/.github/workflows/pqc-native-liboqs.yml
+++ b/.github/workflows/pqc-native-liboqs.yml
@@ -1,0 +1,84 @@
+name: PQC Native liboqs
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/pqc-native-liboqs.yml"
+      - "requirements.txt"
+      - "scripts/security/native_liboqs_smoke.py"
+      - "src/crypto/**"
+      - "tests/crypto/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/pqc-native-liboqs.yml"
+      - "requirements.txt"
+      - "scripts/security/native_liboqs_smoke.py"
+      - "src/crypto/**"
+      - "tests/crypto/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  LIBOQS_VERSION: "0.15.0"
+  LIBOQS_INSTALL: "${{ github.workspace }}/.oqs"
+  OQS_INSTALL_PATH: "${{ github.workspace }}/.oqs"
+  LD_LIBRARY_PATH: "${{ github.workspace }}/.oqs/lib:${{ github.workspace }}/.oqs/lib64"
+
+jobs:
+  native-liboqs:
+    name: Native liboqs Tier 1 smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake build-essential
+
+      - name: Cache native liboqs
+        id: cache-liboqs
+        uses: actions/cache@v4
+        with:
+          path: .oqs
+          key: ${{ runner.os }}-liboqs-${{ env.LIBOQS_VERSION }}-shared-v1
+
+      - name: Build and install native liboqs
+        if: steps.cache-liboqs.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "${LIBOQS_VERSION}" https://github.com/open-quantum-safe/liboqs.git /tmp/liboqs
+          cmake -S /tmp/liboqs -B /tmp/liboqs/build -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${LIBOQS_INSTALL}" \
+            -DBUILD_SHARED_LIBS=ON \
+            -DOQS_BUILD_ONLY_LIB=ON \
+            -DOQS_USE_OPENSSL=OFF
+          cmake --build /tmp/liboqs/build --target install --parallel 2
+
+      - name: Install Python native bindings
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install liboqs-python==0.14.1
+
+      - name: Prove native liboqs security backend
+        run: python scripts/security/native_liboqs_smoke.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,13 @@ permissions:
   contents: write
 
 jobs:
+  pqc-native-liboqs:
+    name: PQC Native liboqs Gate
+    uses: ./.github/workflows/pqc-native-liboqs.yml
+
   github-release:
     name: Create GitHub Release
+    needs: pqc-native-liboqs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,11 +13,12 @@ httpx>=0.27.0
 requests>=2.32.0
 jsonschema>=4.23.0
 # Post-Quantum Cryptography
-# Local: install from main to match native liboqs 0.15.0:
-#   pip install git+https://github.com/open-quantum-safe/liboqs-python.git@main
-# CI: uses SCBE_FORCE_SKIP_LIBOQS=1 until Docker ships liboqs 0.15.0
-liboqs-python==0.14.1  # PyPI pin for CI; local uses main branch (0.14.0 bindings, 0.15.0 native)
-# python-oqs is currently unavailable in PyPI CI environments; install separately if needed for local PQC workflows.
+# Python bindings are pinned here; the native C library is installed by the
+# dedicated PQC Native liboqs workflow using liboqs 0.15.0. Normal PR CI may
+# force the deterministic fallback path, but release/security validation must
+# pass native liboqs Tier 1.
+liboqs-python==0.14.1
+# python-oqs is currently unavailable in PyPI CI environments; use liboqs-python.
 pycryptodome>=3.20.0
 argon2-cffi>=23.1.0
 

--- a/scripts/security/native_liboqs_smoke.py
+++ b/scripts/security/native_liboqs_smoke.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Fail-fast native liboqs smoke test for release/security gates.
+
+This script is intentionally stricter than the normal test suite. The normal
+suite may use Tier 2/Tier 3 fallbacks so developers can run tests without a C
+toolchain. This smoke test proves the final security lane is actually using the
+native liboqs backend.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _die(message: str) -> None:
+    print(f"native-liboqs-smoke: FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def _first_enabled(enabled: Iterable[str], candidates: Iterable[str]) -> str:
+    enabled_set = set(enabled)
+    for candidate in candidates:
+        if candidate in enabled_set:
+            return candidate
+    _die(f"none of {list(candidates)} are enabled")
+
+
+def _kem_roundtrip(oqs_module, algorithm: str) -> None:
+    kem = oqs_module.KeyEncapsulation(algorithm)
+    public_key = kem.generate_keypair()
+    ciphertext, shared_secret_a = kem.encap_secret(public_key)
+    shared_secret_b = kem.decap_secret(ciphertext)
+
+    if shared_secret_a != shared_secret_b:
+        _die(f"{algorithm} KEM shared secrets did not match")
+
+
+def _signature_roundtrip(oqs_module, algorithm: str) -> None:
+    message = b"SCBE native liboqs security gate"
+    signer = oqs_module.Signature(algorithm)
+    public_key = signer.generate_keypair()
+    signature = signer.sign(message)
+    verified = signer.verify(message, signature, public_key)
+
+    if not verified:
+        _die(f"{algorithm} signature did not verify")
+
+
+def main() -> int:
+    if os.getenv("SCBE_FORCE_SKIP_LIBOQS", "").strip().lower() in {"1", "true", "yes"}:
+        _die("SCBE_FORCE_SKIP_LIBOQS is set; native security lane must not skip liboqs")
+
+    try:
+        import oqs
+    except BaseException as exc:  # liboqs-python may raise SystemExit while bootstrapping.
+        _die(f"could not import oqs: {exc!r}")
+
+    kem_algorithm = _first_enabled(
+        oqs.get_enabled_kem_mechanisms(),
+        ("ML-KEM-768", "Kyber768"),
+    )
+    signature_algorithm = _first_enabled(
+        oqs.get_enabled_sig_mechanisms(),
+        ("ML-DSA-65", "Dilithium3"),
+    )
+
+    _kem_roundtrip(oqs, kem_algorithm)
+    _signature_roundtrip(oqs, signature_algorithm)
+
+    from src.crypto import pqc_liboqs
+
+    status = pqc_liboqs.get_pqc_governance_status()
+    if pqc_liboqs.get_pqc_proof_tier() != 1:
+        _die(f"SCBE PQC wrapper is not Tier 1 native: {status}")
+    if not pqc_liboqs.is_liboqs_available():
+        _die(f"SCBE PQC wrapper reports liboqs unavailable: {status}")
+    if not status.get("quantum_resistant"):
+        _die(f"SCBE PQC governance status is not quantum resistant: {status}")
+
+    print("native-liboqs-smoke: PASS")
+    print(f"oqs_module={getattr(oqs, '__file__', 'unknown')}")
+    print(f"oqs_version={getattr(oqs, '__version__', 'unknown')}")
+    print(f"kem_algorithm={kem_algorithm}")
+    print(f"signature_algorithm={signature_algorithm}")
+    print(f"scbe_backend={status['backend']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dedicated PQC Native liboqs workflow that builds native liboqs 0.15.0 and proves Tier 1 ML-KEM/ML-DSA operation
- add scripts/security/native_liboqs_smoke.py as a fail-fast native backend smoke test
- make GitHub releases depend on the native PQC gate
- clarify that normal CI may use fallback, but release/security validation must pass native liboqs

## Local verification
- python -m py_compile scripts/security/native_liboqs_smoke.py
- python scripts/security/native_liboqs_smoke.py -> PASS locally with ML-KEM-768 and ML-DSA-65
- python -m pytest tests/crypto/test_pqc_liboqs_status.py -q -> 5 passed
- SCBE_FORCE_SKIP_LIBOQS=1 native smoke exits nonzero as intended

## Rollback
- remove .github/workflows/pqc-native-liboqs.yml
- remove scripts/security/native_liboqs_smoke.py
- remove release.yml dependency on pqc-native-liboqs