### PR TITLE
fix(security): emit liboqs pass marker

### DIFF
--- a/scripts/security/native_liboqs_smoke.py
+++ b/scripts/security/native_liboqs_smoke.py
@@ -85,6 +85,7 @@ def main() -> int:
     if not status.get("quantum_resistant"):
         _die(f"SCBE PQC governance status is not quantum resistant: {status}")
 
+    print("SCBE_LIBOQS_PASS=1")
     print("native-liboqs-smoke: PASS")
     print(f"oqs_module={getattr(oqs, '__file__', 'unknown')}")
     print(f"oqs_version={getattr(oqs, '__version__', 'unknown')}")


### PR DESCRIPTION
## Summary
- print SCBE_LIBOQS_PASS=1 after native liboqs Tier 1 checks pass
- keeps the visible pass marker out of failure paths

## Verification
- python scripts/security/native_liboqs_smoke.py
- output begins with SCBE_LIBOQS_PASS=1