### PR TITLE
feat(agent): add bus workspace formation

### DIFF
--- a/api/agent/storage.js
+++ b/api/agent/storage.js
@@ -4,6 +4,52 @@ const { readJsonBody, sendJson, setCors } = require('../_agent_common');
 
 const MAX_EXPORT_BYTES = 256 * 1024;
 
+const WORKSPACE_FORMATION = {
+  schema_version: 'aethermoor.bus.workspace_formation.v1',
+  default_root: '.aethermoor-bus/workspaces',
+  lifecycle: 'temp-local-first-offload-required',
+  folders: [
+    {
+      path: '00_inbox',
+      role: 'raw drops, user uploads, unclassified imports',
+      ship: false,
+    },
+    {
+      path: '10_work',
+      role: 'active editable working files',
+      ship: false,
+    },
+    {
+      path: '20_receipts',
+      role: 'governance verdicts, hashes, signatures, run receipts',
+      ship: true,
+    },
+    {
+      path: '30_exports',
+      role: 'customer-ready packets and handoff bundles',
+      ship: true,
+    },
+    {
+      path: '40_refs',
+      role: 'non-secret reference files and source notes',
+      ship: true,
+    },
+    {
+      path: '90_tmp',
+      role: 'scratch files; delete after successful offload',
+      ship: false,
+    },
+  ],
+  transport_stops: ['local_download', 'browser_local', 'github', 'dropbox', 'onedrive', 'gdrive'],
+  rules: [
+    'Classify before offload.',
+    'Never export secrets by default.',
+    'Receipts and manifests travel with customer work.',
+    'Temporary local workspaces are disposable after offload verification.',
+    'External storage is user-designated; the bus does not retain export content.',
+  ],
+};
+
 const PROVIDERS = [
   {
     id: 'local_download',
@@ -103,6 +149,7 @@ function buildExportPacket(body) {
     byte_length: bytes,
     destination_hint: body.destination || 'local_download',
     metadata: body.metadata && typeof body.metadata === 'object' ? body.metadata : {},
+    workspace_formation: WORKSPACE_FORMATION,
     content,
   };
   return {
@@ -129,6 +176,7 @@ module.exports = async function handler(req, res) {
       cost: 'zero-server-storage',
       default_provider: 'local_download',
       providers: PROVIDERS,
+      workspace_formation: WORKSPACE_FORMATION,
     });
   }
 
@@ -150,5 +198,6 @@ module.exports._private = {
   buildExportPacket,
   normalizeContent,
   PROVIDERS,
+  WORKSPACE_FORMATION,
   slugify,
 };

--- a/docs/specs/AGENT_BUS_WORKSPACE_FORMATION.md
+++ b/docs/specs/AGENT_BUS_WORKSPACE_FORMATION.md
@@ -1,0 +1,84 @@
+# Agent Bus Workspace Formation
+
+The agent bus should feel like a small operating system, not a loose download
+button. Customer work gets a temporary local workspace, a visible folder shape,
+and a clean offload path to the storage stop the user designates.
+
+This is the product-facing companion to `FOLDER.md` hexa cards. `FOLDER.md`
+organizes the repo for builders. The bus workspace formation organizes user
+work for operators and customers.
+
+## Shape
+
+```text
+.aethermoor-bus/workspaces/<workspace-id>/
+  00_inbox/     raw drops, uploads, imports, unclassified files
+  10_work/      active editable working files
+  20_receipts/  governance verdicts, hashes, signatures, run receipts
+  30_exports/   customer-ready packets and handoff bundles
+  40_refs/      non-secret reference files and source notes
+  90_tmp/       scratch files, deleted after offload verification
+```
+
+## Lifecycle
+
+1. Create a workspace ID from timestamp, user hint, and random suffix.
+2. Put raw inputs in `00_inbox`.
+3. Move active files into `10_work`.
+4. Write every governance/result receipt into `20_receipts`.
+5. Build user-facing outputs in `30_exports`.
+6. Keep safe public references in `40_refs`.
+7. Use `90_tmp` for scratch only.
+8. Offload `20_receipts`, `30_exports`, and selected `40_refs` to the user's
+   transport stop.
+9. Verify the offload manifest.
+10. Delete or retain the temporary workspace according to the user's request.
+
+## Transport Stops
+
+The zero-server-storage endpoint exposes these stops:
+
+- `local_download` - browser-generated JSON packet download.
+- `browser_local` - small local browser records.
+- `github` - user-designated repository handoff.
+- `dropbox` - user-designated Dropbox handoff.
+- `onedrive` - user-designated OneDrive handoff.
+- `gdrive` - user-designated Google Drive handoff.
+
+The bus does not need to own customer storage to be useful. It needs to produce
+clean packets that the customer can move to storage they already trust.
+
+## Rules
+
+- Classify before offload.
+- Never export secrets by default.
+- Receipts and manifests travel with customer work.
+- Temporary local workspaces are disposable after offload verification.
+- External storage is user-designated; the bus does not retain export content.
+- If a file is not in `20_receipts`, `30_exports`, or selected `40_refs`, it does
+  not ship by default.
+
+## API Surface
+
+`GET /api/agent/storage` returns the current `workspace_formation`.
+
+`POST /api/agent/storage` embeds the same `workspace_formation` in the export
+packet so mobile clients, browser clients, and CLI clients all see the same
+folder shape.
+
+The schema string is:
+
+```text
+aethermoor.bus.workspace_formation.v1
+```
+
+## Customer Meaning
+
+For the user, this becomes a one-click organizer:
+
+```text
+New bus workspace -> work happens -> receipts generated -> export packet -> chosen storage stop
+```
+
+For SCBE, it gives every agent a shared map. No more guessing whether a file is
+scratch, evidence, customer output, or reference material.

--- a/scripts/security/native_liboqs_smoke.py
+++ b/scripts/security/native_liboqs_smoke.py
@@ -85,6 +85,7 @@ def main() -> int:
     if not status.get("quantum_resistant"):
         _die(f"SCBE PQC governance status is not quantum resistant: {status}")
 
+    print("SCBE_LIBOQS_PASS=1")
     print("native-liboqs-smoke: PASS")
     print(f"oqs_module={getattr(oqs, '__file__', 'unknown')}")
     print(f"oqs_version={getattr(oqs, '__version__', 'unknown')}")

--- a/tests/test_agent_storage_zero_credit.py
+++ b/tests/test_agent_storage_zero_credit.py
@@ -27,13 +27,16 @@ def test_agent_storage_endpoint_requires_commonjs_cleanly() -> None:
         console.log(JSON.stringify({
           handlerType: typeof mod,
           hasBuilder: typeof mod._private.buildExportPacket,
-          providers: mod._private.PROVIDERS.map((p) => p.id)
+          providers: mod._private.PROVIDERS.map((p) => p.id),
+          formation: mod._private.WORKSPACE_FORMATION
         }));
         """)
     assert payload["handlerType"] == "function"
     assert payload["hasBuilder"] == "function"
     assert payload["providers"][:2] == ["local_download", "browser_local"]
     assert {"github", "dropbox", "onedrive", "gdrive"}.issubset(set(payload["providers"]))
+    assert payload["formation"]["schema_version"] == "aethermoor.bus.workspace_formation.v1"
+    assert payload["formation"]["folders"][0]["path"] == "00_inbox"
 
 
 def test_agent_storage_builds_zero_server_storage_export_packet() -> None:
@@ -52,6 +55,7 @@ def test_agent_storage_builds_zero_server_storage_export_packet() -> None:
     assert payload["cost"] == "zero-server-storage"
     assert payload["packet"]["destination_hint"] == "gdrive"
     assert payload["packet"]["filename"] == "customer-smoke-export.json"
+    assert payload["packet"]["workspace_formation"]["default_root"] == ".aethermoor-bus/workspaces"
     assert payload["download"]["mime"] == "application/json"
     decoded = json.loads(
         subprocess.check_output(


### PR DESCRIPTION
## Summary
- add a product-facing bus workspace formation for temporary local workspaces
- expose workspace_formation from /api/agent/storage GET responses
- embed workspace_formation in export packets so mobile/browser/CLI clients share the same folder shape
- document the temp-local-first-offload lifecycle and transport stops

## Formation
- 00_inbox raw drops
- 10_work active files
- 20_receipts governance receipts
- 30_exports customer-ready packets
- 40_refs safe references
- 90_tmp scratch files

## Verification
- python -m pytest tests/test_agent_storage_zero_credit.py -q -> 3 passed
- node require smoke returned aethermoor.bus.workspace_formation.v1