### PR TITLE
docs(ux): add SCBE operator experience plan

### DIFF
--- a/config/system/operator_experience_backlog.json
+++ b/config/system/operator_experience_backlog.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "aethermoor.operator_experience_backlog.v1",
+  "created_at": "2026-05-09T00:00:00-07:00",
+  "purpose": "Route UX research into implementation tasks for the SCBE shell, bus storage, provider router, and receipts.",
+  "principles": [
+    "one command center",
+    "slash commands over script hunting",
+    "visible receipts",
+    "local-first and zero-credit by default",
+    "provider routing instead of key-first onboarding",
+    "workspace formation before export",
+    "monotonic governance gates"
+  ],
+  "commands": [
+    {
+      "command": "/status",
+      "priority": 1,
+      "surface": "scbe-shell",
+      "intent": "Show repo, branch, CI, provider, budget, workspace, and last gate state.",
+      "receipt": "SCBE_STATUS_READY=1"
+    },
+    {
+      "command": "/liboqs",
+      "priority": 2,
+      "surface": "scbe-shell",
+      "intent": "Run native liboqs smoke and expose the security proof.",
+      "receipt": "SCBE_LIBOQS_PASS=1"
+    },
+    {
+      "command": "/workspace new",
+      "priority": 3,
+      "surface": "agent-bus",
+      "intent": "Create a temporary bus workspace using the workspace formation.",
+      "receipt": "SCBE_WORKSPACE_READY=1"
+    },
+    {
+      "command": "/workspace export",
+      "priority": 4,
+      "surface": "agent-bus",
+      "intent": "Export receipts, customer packets, and selected references to a user-designated storage stop.",
+      "receipt": "SCBE_WORKSPACE_OFFLOAD_PASS=1"
+    },
+    {
+      "command": "/providers",
+      "priority": 5,
+      "surface": "provider-router",
+      "intent": "Display local, free, configured, and paid-disabled provider posture.",
+      "receipt": "SCBE_PROVIDERS_READY=1"
+    },
+    {
+      "command": "/ship",
+      "priority": 6,
+      "surface": "delivery",
+      "intent": "Build a customer handoff packet from exports plus receipts.",
+      "receipt": "SCBE_SHIP_PACKET_READY=1"
+    },
+    {
+      "command": "/agent-task",
+      "priority": 7,
+      "surface": "github-spoke",
+      "intent": "Create or track a GitHub agent task as a governed background spoke.",
+      "receipt": "SCBE_GITHUB_AGENT_TASK_READY=1"
+    }
+  ],
+  "storage_formation": {
+    "schema_version": "aethermoor.bus.workspace_formation.v1",
+    "folders": [
+      "00_inbox",
+      "10_work",
+      "20_receipts",
+      "30_exports",
+      "40_refs",
+      "90_tmp"
+    ]
+  },
+  "source_notes": [
+    "Claude Code slash commands and hooks informed command/hook surfaces.",
+    "GitHub Copilot CLI informed agent-task and local/cloud session handoff.",
+    "Codex CLI informed command-center and approval/receipt UX.",
+    "Hermes Agent informed shell-first daily-driver ergonomics."
+  ]
+}

--- a/docs/specs/SCBE_OPERATOR_EXPERIENCE_PLAN.md
+++ b/docs/specs/SCBE_OPERATOR_EXPERIENCE_PLAN.md
@@ -1,0 +1,186 @@
+# SCBE Operator Experience Plan
+
+Status: research-applied planning surface, 2026-05-09.
+
+SCBE already has unusually deep governance, cryptography, and multi-agent
+architecture. The next user-experience step is to make that depth feel like a
+single command center instead of many scripts.
+
+This document translates current agent CLI patterns into SCBE-specific product
+work. It is intentionally separate from the active `scbe-shell` implementation
+lane so it can be routed, reviewed, and merged without colliding with CLI code.
+
+## Research Inputs
+
+The strongest current patterns across Codex CLI, Claude Code, GitHub Copilot
+CLI, and Hermes-style agent shells are:
+
+- One command starts the daily-driver shell.
+- Slash commands expose repeatable workflows.
+- Status surfaces show model, account, connectivity, token/cost, and runtime
+  state.
+- Session resume makes the agent feel continuous.
+- Tool output streams visibly, with a way to interrupt or redirect.
+- Cloud/background agent tasks resolve into pull requests or reviewable
+  artifacts.
+- Hooks/guards run before and after tool use.
+- Skills or custom commands are stored as files, not hardcoded UI branches.
+
+References:
+
+- Claude Code slash commands: https://docs.claude.com/en/docs/claude-code/slash-commands
+- Claude Code hooks: https://code.claude.com/docs/en/hooks
+- GitHub Copilot CLI overview: https://docs.github.com/copilot/concepts/agents/copilot-cli/about-copilot-cli
+- GitHub Copilot CLI usage: https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli-agents/overview
+- OpenAI Codex CLI getting started: https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started
+- Hermes Agent docs: https://hermes-agent.nousresearch.com/docs/
+
+## SCBE Product Shape
+
+The target experience is:
+
+```text
+scbe
+  /status
+  /workspace new
+  /search
+  /providers
+  /liboqs
+  /gate
+  /ship
+```
+
+The user should not need to know which repo script, Python module, Vercel
+endpoint, or workflow file backs a command. The shell should show the route and
+receipt after the action completes.
+
+## Visible Receipts
+
+SCBE should preserve the feeling of progress by printing simple pass/fail
+markers for important gates. Examples:
+
+```text
+SCBE_LIBOQS_PASS=1
+SCBE_STORAGE_EXPORT_READY=1
+SCBE_WORKSPACE_OFFLOAD_PASS=1
+SCBE_GATE_ALLOW=1
+SCBE_BIJECTIVE_TAMPER_SIGNAL=1
+```
+
+Rules:
+
+- A `*_PASS=1` marker only prints after the underlying proof succeeds.
+- A failed gate prints a named failure marker and a short reason.
+- Receipts should also be written into `20_receipts` in bus workspaces.
+- Receipts should be friendly enough for a user and exact enough for CI logs.
+
+## Workspace Formation
+
+The bus workspace formation is the user-facing storage shape:
+
+```text
+.aethermoor-bus/workspaces/<workspace-id>/
+  00_inbox/
+  10_work/
+  20_receipts/
+  30_exports/
+  40_refs/
+  90_tmp/
+```
+
+The shell and mobile app should present this as:
+
+- Inbox: stuff you gave the bus.
+- Work: what the agents are editing.
+- Receipts: proof and governance.
+- Exports: what you can send, download, or sell.
+- References: safe source material.
+- Temporary: scratch that can be deleted.
+
+## Free-First Provider UX
+
+SCBE should expose provider state as a router, not as a list of API keys.
+
+Default order:
+
+1. Local Ollama or local model if available.
+2. Zero-credit public search and browser extraction.
+3. Browser/local download storage.
+4. User-designated GitHub, Dropbox, OneDrive, or Google Drive handoff.
+5. GitHub agent task / Codespaces when useful and within budget.
+6. Hugging Face, Kaggle, or Colab free lanes when configured.
+7. Paid APIs only when explicitly enabled.
+
+The shell should show:
+
+```text
+Mode: local-first
+Cost: zero-credit
+Fallback: GitHub Agent Task available
+Budget: protected
+```
+
+No account-stacking or limit evasion. The system should use free tiers hard,
+cache aggressively, batch work, and fall back cleanly.
+
+## Mission-Control Flow
+
+The long-term interaction model:
+
+```text
+Task
+  -> Route
+  -> Workspace
+  -> Agent lane
+  -> Receipts
+  -> Export or pull request
+  -> Review
+  -> Ship
+```
+
+This maps the Hydra metaphor into concrete UX:
+
+- Heads are agent lanes.
+- Tentacles are tool/provider routes.
+- Receipts are the nervous system.
+- Workspaces are the body cavities where work happens before shipping.
+- GitHub PRs, app bundles, and export packets are the shipping surfaces.
+
+## Priority Backlog
+
+1. `scbe /status`
+   - Show current repo, branch, dirty state, provider mode, last CI state, and
+     active workspace.
+
+2. `scbe /liboqs`
+   - Run the native smoke gate and print `SCBE_LIBOQS_PASS=1` on success.
+
+3. `scbe /workspace new`
+   - Create the bus formation locally and write a manifest.
+
+4. `scbe /workspace export <stop>`
+   - Package `20_receipts`, `30_exports`, and selected `40_refs` for
+     `local_download`, `github`, `dropbox`, `onedrive`, or `gdrive`.
+
+5. `scbe /providers`
+   - Show available local/free/cloud providers and budget posture.
+
+6. `scbe /ship`
+   - Build a customer handoff packet from `30_exports` plus receipts.
+
+7. `scbe /agent-task`
+   - Create a GitHub agent task and track the resulting PR/session as a spoke.
+
+## Done Definition
+
+This plan is successful when a non-coding user can:
+
+1. Open `scbe`.
+2. See system status.
+3. Start a workspace.
+4. Ask for research or a build task.
+5. Watch receipts appear.
+6. Export the result to a known storage stop.
+7. Verify what shipped.
+
+The goal is not to hide SCBE's depth. The goal is to make the depth navigable.


### PR DESCRIPTION
## Summary
- apply agent CLI UX research into a routeable SCBE operator-experience plan
- add a machine-readable backlog for scbe-shell, bus workspace, provider router, visible receipts, and GitHub agent-task spoke work
- keep this on a separate branch from active CLI implementation work to avoid collisions

## UX Targets
- one command center
- slash commands over script hunting
- visible receipts such as SCBE_LIBOQS_PASS=1
- local-first and zero-credit defaults
- workspace formation before export
- provider routing instead of key-first onboarding

## Verification
- python -m json.tool config/system/operator_experience_backlog.json
- docs-only / config-only change; no runtime code touched