### PR TITLE
feat(operator): add triadic manifold package surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Package links:
 
 - npm: [`scbe-aethermoore`](https://www.npmjs.com/package/scbe-aethermoore)
 - PyPI: [`scbe-aethermoore`](https://pypi.org/project/scbe-aethermoore/)
+- Optional Python agent bus: [`scbe-agent-bus`](https://pypi.org/project/scbe-agent-bus/)
+- Optional lightweight kernel: [`@scbe/kernel`](https://www.npmjs.com/package/@scbe/kernel)
+
+The packages are companion surfaces, not forced dependencies. Install the
+smallest package that fits your task; the operator and agent-bus APIs can
+recommend a companion package when a feature lives in another ecosystem.
 
 Website and public demos:
 

--- a/config/system/triadic_operator_packages.json
+++ b/config/system/triadic_operator_packages.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "scbe-triadic-operator-packages-v1",
+  "principle": "Companion packages are prompts, not forced dependencies. Keep local installs small and add only the feature pack the user requested.",
+  "default_mode": "local_first",
+  "cloud_policy": {
+    "use_cloud_when": [
+      "privacy is remote_ok",
+      "workload is large or long-running",
+      "local CPU, memory, disk, or battery pressure is high",
+      "the user explicitly approves Codespaces, VM, or hosted runner use"
+    ],
+    "do_not_upload": [
+      "secrets",
+      "private keys",
+      "local-only notes",
+      "unreviewed proprietary customer files"
+    ]
+  },
+  "packages": [
+    {
+      "name": "scbe-aethermoore",
+      "ecosystem": "npm",
+      "install": "npm install scbe-aethermoore",
+      "features": ["governance", "operator-manifold", "tokenizer", "browser", "node"],
+      "heavy": false
+    },
+    {
+      "name": "scbe-agent-bus",
+      "ecosystem": "pypi",
+      "install": "pip install scbe-agent-bus",
+      "features": ["agent-bus", "python", "batch-dispatch", "workspace"],
+      "heavy": false
+    },
+    {
+      "name": "@scbe/kernel",
+      "ecosystem": "npm",
+      "install": "npm install @scbe/kernel",
+      "features": ["kernel", "sacred-tongues", "lightweight-math"],
+      "heavy": false
+    },
+    {
+      "name": "scbe-sixtongues",
+      "ecosystem": "pypi",
+      "install": "pip install scbe-sixtongues",
+      "features": ["sacred-tongues", "python", "tokenizer"],
+      "heavy": false
+    }
+  ],
+  "receipts": [
+    "SCBE_OPERATOR_PLAN_READY=1",
+    "SCBE_WORKSPACE_READY=1",
+    "SCBE_GATE_ALLOW=1",
+    "SCBE_STORAGE_EXPORT_READY=1"
+  ]
+}

--- a/docs/specs/TRIADIC_OPERATOR_MANIFOLD.md
+++ b/docs/specs/TRIADIC_OPERATOR_MANIFOLD.md
@@ -1,0 +1,100 @@
+# Triadic Operator Manifold
+
+**Status:** v1 product slice.  
+**Code:** `src/operator/triadic_manifold.ts` and `packages/agent-bus-py/src/scbe_agent_bus/companions.py`.
+
+## Purpose
+
+The operating surface is not just 2D, 2.5D, or 3D. Those are rendered views.
+The real work happens in an N-dimensional shared operating space between:
+
+- the human, who supplies intent, trust, approval, and time pressure;
+- the machine, which supplies files, processes, storage, permissions, and real execution;
+- the AI, which supplies fast navigation, synthesis, uncertainty, and tool use.
+
+The Triadic Operator Manifold names that shared space so product features can
+route through it instead of becoming one-off scripts.
+
+## Rule
+
+Do not replace working tools. Upgrade them.
+
+Scripts become commands. Commands become workflows. Workflows emit receipts.
+Receipts become product trust.
+
+## Lightweight install policy
+
+SCBE packages should reference companion packages without forcing heavy
+installs. A user who only needs the tokenizer should not be forced to install a
+large agent workspace. A user who only needs the Python agent bus should not be
+forced to pull a browser, model cache, or full repo.
+
+Companion prompts are advisory:
+
+- npm users can be pointed toward PyPI agent-bus features;
+- Python users can be pointed toward npm governance/operator features;
+- no package silently installs another ecosystem;
+- cloud lanes are opt-in and must honor privacy.
+
+The package map lives at `config/system/triadic_operator_packages.json`.
+
+## Runtime model
+
+```text
+Human intent
+  x Machine state
+  x AI inference
+  x constraints
+  -> operator plan
+  -> governed action
+  -> receipts
+  -> export, merge, release, or storage handoff
+```
+
+The TypeScript API:
+
+```ts
+import { createTriadicOperatorPlan } from 'scbe-aethermoore/operator';
+
+const plan = createTriadicOperatorPlan({
+  intent: 'run repo verification without straining my laptop',
+  privacy: 'remote_ok',
+  workload: 'large',
+  preferCloud: true,
+  features: ['agent-bus', 'workspace'],
+});
+```
+
+The Python API:
+
+```py
+from scbe_agent_bus import recommend_companion_packages
+
+print(recommend_companion_packages(["operator_manifold", "tokenizer"]))
+```
+
+## Cloud and compute posture
+
+Default to `local_first`.
+
+Use `cloud_assist` only when:
+
+- privacy is `remote_ok`;
+- workload is large or long-running;
+- local CPU, memory, disk, or battery pressure is high;
+- the user explicitly approves Codespaces, VM, or hosted runner use.
+
+Do not upload secrets, private keys, local-only notes, or unreviewed proprietary
+customer files to cloud lanes.
+
+## Receipts
+
+The first receipt markers are:
+
+- `SCBE_OPERATOR_PLAN_READY=1`
+- `SCBE_WORKSPACE_READY=1`
+- `SCBE_GATE_ALLOW=1`
+- `SCBE_STORAGE_EXPORT_READY=1`
+
+These are intentionally small. They let CLI, mobile, npm, PyPI, and GitHub
+Actions show positive progress without inventing a new UI for every subsystem.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
       "types": "./dist/src/governance/index.d.ts",
       "import": "./dist/src/governance/index.js",
       "require": "./dist/src/governance/index.js"
+    },
+    "./operator": {
+      "types": "./dist/src/operator/index.d.ts",
+      "import": "./dist/src/operator/index.js",
+      "require": "./dist/src/operator/index.js"
     }
   },
   "files": [

--- a/packages/agent-bus-py/README.md
+++ b/packages/agent-bus-py/README.md
@@ -63,6 +63,21 @@ on npm. Both wrap the same underlying Python runner (`scripts/scbe-system-cli.py
 agentbus run`) and produce identical envelope shapes. Pick whichever fits your
 host environment.
 
+## Companion package prompts
+
+The Python package can point users toward optional SCBE companion packages
+without installing them automatically:
+
+```python
+from scbe_agent_bus import recommend_companion_packages
+
+recommend_companion_packages(["operator_manifold", "tokenizer"])
+# -> prompts for scbe-aethermoore on npm
+```
+
+This keeps local installs small. Cloud, Codespaces, VM, browser, and tokenizer
+features should be added only when a user requests that lane.
+
 ## License
 
 MIT — see `LICENSE`.

--- a/packages/agent-bus-py/src/scbe_agent_bus/__init__.py
+++ b/packages/agent-bus-py/src/scbe_agent_bus/__init__.py
@@ -27,6 +27,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Literal, Optional, TypedDict
 
+from .companions import COMPANION_PACKAGES, recommend_companion_packages
+
 __all__ = [
     "AgentBusEvent",
     "AgentBusResult",
@@ -34,6 +36,8 @@ __all__ = [
     "run_event",
     "run_batch",
     "AgentBusError",
+    "COMPANION_PACKAGES",
+    "recommend_companion_packages",
     "__version__",
 ]
 
@@ -98,12 +102,16 @@ def _normalize_event(event: AgentBusEvent | dict, index: int) -> dict:
         "operation_command": str(
             event.get("operation_command") or event.get("operationCommand") or ""
         ).strip(),
-        "task_type": str(event.get("task_type") or event.get("taskType") or "general").strip(),
+        "task_type": str(
+            event.get("task_type") or event.get("taskType") or "general"
+        ).strip(),
         "series_id": str(
             event.get("series_id") or event.get("seriesId") or f"pipe-event-{index}"
         ).strip(),
         "privacy": str(event.get("privacy") or "local_only").strip(),
-        "budget_cents": float(event.get("budget_cents", event.get("budgetCents", 0)) or 0),
+        "budget_cents": float(
+            event.get("budget_cents", event.get("budgetCents", 0)) or 0
+        ),
         "dispatch": event.get("dispatch") is not False,
         "dispatch_provider": str(
             event.get("dispatch_provider") or event.get("dispatchProvider") or "offline"

--- a/packages/agent-bus-py/src/scbe_agent_bus/companions.py
+++ b/packages/agent-bus-py/src/scbe_agent_bus/companions.py
@@ -1,0 +1,114 @@
+"""Companion-package discovery for the lightweight SCBE agent bus.
+
+This module intentionally does not install anything. It only explains which
+SCBE package unlocks a requested feature so users can keep their local install
+small and add companion packs when they actually need them.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+CompanionName = Literal[
+    "scbe-aethermoore",
+    "scbe-agent-bus",
+    "@scbe/kernel",
+    "scbe-sixtongues",
+]
+
+
+class CompanionPackage(TypedDict):
+    name: CompanionName
+    ecosystem: Literal["npm", "pypi"]
+    install: str
+    purpose: str
+    features: list[str]
+    heavy: bool
+
+
+class CompanionRecommendation(TypedDict):
+    feature: str
+    package: CompanionName
+    install: str
+    reason: str
+
+
+COMPANION_PACKAGES: list[CompanionPackage] = [
+    {
+        "name": "scbe-aethermoore",
+        "ecosystem": "npm",
+        "install": "npm install scbe-aethermoore",
+        "purpose": "Core TypeScript governance, tokenizer, harmonic wall, and operator APIs.",
+        "features": ["governance", "operator-manifold", "tokenizer", "browser", "node"],
+        "heavy": False,
+    },
+    {
+        "name": "scbe-agent-bus",
+        "ecosystem": "pypi",
+        "install": "pip install scbe-agent-bus",
+        "purpose": "Python event runner surface for agent-bus workflows and governed batch dispatch.",
+        "features": ["agent-bus", "python", "batch-dispatch", "workspace"],
+        "heavy": False,
+    },
+    {
+        "name": "@scbe/kernel",
+        "ecosystem": "npm",
+        "install": "npm install @scbe/kernel",
+        "purpose": "Smaller kernel-level package for Sacred Tongues and core math without the full repo.",
+        "features": ["kernel", "sacred-tongues", "lightweight-math"],
+        "heavy": False,
+    },
+    {
+        "name": "scbe-sixtongues",
+        "ecosystem": "pypi",
+        "install": "pip install scbe-sixtongues",
+        "purpose": "Standalone Python Six Tongues tokenizer package for local scripts.",
+        "features": ["sacred-tongues", "python", "tokenizer"],
+        "heavy": False,
+    },
+]
+
+
+def _normalize_feature(feature: str) -> str:
+    return "-".join(feature.strip().lower().replace("_", " ").split())
+
+
+def recommend_companion_packages(
+    requested_features: list[str],
+    available_packages: list[CompanionName] | None = None,
+) -> list[CompanionRecommendation]:
+    """Return optional package prompts for missing features.
+
+    The first matching package is returned for each feature. Already available
+    packages are skipped so this function can be used in CLIs without nagging
+    users to install what they already have.
+    """
+
+    available = set(available_packages or ["scbe-agent-bus"])
+    recommendations: list[CompanionRecommendation] = []
+    for raw_feature in requested_features:
+        feature = _normalize_feature(raw_feature)
+        provider = next(
+            (
+                package
+                for package in COMPANION_PACKAGES
+                if package["name"] not in available
+                and feature
+                in {_normalize_feature(item) for item in package["features"]}
+            ),
+            None,
+        )
+        if provider is None:
+            continue
+        recommendations.append(
+            {
+                "feature": feature,
+                "package": provider["name"],
+                "install": provider["install"],
+                "reason": (
+                    f"{provider['name']} provides {feature} without being installed "
+                    "as a forced dependency."
+                ),
+            }
+        )
+    return recommendations

--- a/packages/agent-bus-py/tests/test_smoke.py
+++ b/packages/agent-bus-py/tests/test_smoke.py
@@ -13,12 +13,39 @@ if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
 import scbe_agent_bus  # noqa: E402
-from scbe_agent_bus import AgentBusError, run_batch, run_event  # noqa: E402
+from scbe_agent_bus import (
+    AgentBusError,
+    recommend_companion_packages,
+    run_batch,
+    run_event,
+)  # noqa: E402
 from scbe_agent_bus.__main__ import _parse_events, main  # noqa: E402
 
 
 def test_module_exports_version():
     assert scbe_agent_bus.__version__ == "0.2.0"
+
+
+def test_recommend_companion_packages_skips_installed_package():
+    rows = recommend_companion_packages(
+        ["operator_manifold", "tokenizer", "batch dispatch"],
+        available_packages=["scbe-agent-bus"],
+    )
+
+    assert rows == [
+        {
+            "feature": "operator-manifold",
+            "package": "scbe-aethermoore",
+            "install": "npm install scbe-aethermoore",
+            "reason": "scbe-aethermoore provides operator-manifold without being installed as a forced dependency.",
+        },
+        {
+            "feature": "tokenizer",
+            "package": "scbe-aethermoore",
+            "install": "npm install scbe-aethermoore",
+            "reason": "scbe-aethermoore provides tokenizer without being installed as a forced dependency.",
+        },
+    ]
 
 
 def test_run_batch_rejects_empty():

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,8 +325,9 @@ import * as spiralverse from './spiralverse/index.js';
 import * as spiralauth from './spiralauth/index.js';
 import * as ai_brain from './ai_brain/index.js';
 import * as governance from './governance/index.js';
+import * as operator from './operator/index.js';
 import * as securityEngine from './security-engine/index.js';
-export { symphonic, crypto, spiralverse, spiralauth, ai_brain, governance, securityEngine };
+export { symphonic, crypto, spiralverse, spiralauth, ai_brain, governance, operator, securityEngine };
 
 // Core Crypto Exports (also available at top level)
 export * from './crypto/envelope.js';
@@ -354,6 +355,9 @@ export * from './selfHealing/quickFixBot.js';
 
 // Governance Exports
 export * from './governance/offline_mode.js';
+
+// Operator Surface Exports
+export * from './operator/index.js';
 
 // Version and Metadata
 export const VERSION = '4.0.3';

--- a/src/operator/index.ts
+++ b/src/operator/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @file index.ts
+ * @module operator
+ * @layer Layer 14
+ * @component Operator-surface exports
+ */
+
+export * from './triadic_manifold.js';

--- a/src/operator/triadic_manifold.ts
+++ b/src/operator/triadic_manifold.ts
@@ -1,0 +1,203 @@
+/**
+ * @file triadic_manifold.ts
+ * @module operator/triadic_manifold
+ * @layer Layer 14
+ * @component Triadic Operator Manifold
+ *
+ * A lightweight coordination model for the shared operating space between:
+ * - human intent,
+ * - machine state,
+ * - AI inference.
+ *
+ * This is intentionally dependency-free. It is the operator surface contract
+ * that heavier cloud, Codespaces, VM, local-Ollama, storage, and governance
+ * adapters can hang from without forcing a large install onto every user.
+ */
+
+export type ActorKind = 'human' | 'machine' | 'ai';
+export type OperatorMode = 'local_first' | 'cloud_assist' | 'hybrid';
+export type PrivacyLevel = 'local_only' | 'remote_ok';
+export type WorkloadSize = 'small' | 'medium' | 'large';
+export type CompanionPackageName =
+  | 'scbe-aethermoore'
+  | 'scbe-agent-bus'
+  | '@scbe/kernel'
+  | 'scbe-sixtongues';
+
+export interface OperatorActor {
+  kind: ActorKind;
+  role: string;
+  constraints: string[];
+}
+
+export interface OperatorRequest {
+  intent: string;
+  features?: string[];
+  privacy?: PrivacyLevel;
+  workload?: WorkloadSize;
+  preferCloud?: boolean;
+  availablePackages?: CompanionPackageName[];
+}
+
+export interface OperatorPlan {
+  schema_version: 'scbe-triadic-operator-plan-v1';
+  mode: OperatorMode;
+  actors: OperatorActor[];
+  dimensions: string[];
+  actions: string[];
+  receipts: string[];
+  companionRecommendations: CompanionRecommendation[];
+}
+
+export interface CompanionPackage {
+  name: CompanionPackageName;
+  ecosystem: 'npm' | 'pypi';
+  install: string;
+  purpose: string;
+  features: string[];
+  heavy: boolean;
+}
+
+export interface CompanionRecommendation {
+  feature: string;
+  package: CompanionPackageName;
+  install: string;
+  reason: string;
+}
+
+export const TRIADIC_DIMENSIONS = [
+  'intent',
+  'visual_layout',
+  'filesystem_state',
+  'process_state',
+  'permissions',
+  'context_window',
+  'tool_affordances',
+  'risk',
+  'latency',
+  'cost',
+  'storage',
+  'audit_receipts',
+] as const;
+
+export const COMPANION_PACKAGES: CompanionPackage[] = [
+  {
+    name: 'scbe-aethermoore',
+    ecosystem: 'npm',
+    install: 'npm install scbe-aethermoore',
+    purpose: 'Core TypeScript governance, tokenizer, harmonic wall, and operator APIs.',
+    features: ['governance', 'operator-manifold', 'tokenizer', 'browser', 'node'],
+    heavy: false,
+  },
+  {
+    name: 'scbe-agent-bus',
+    ecosystem: 'pypi',
+    install: 'pip install scbe-agent-bus',
+    purpose: 'Python event runner surface for agent-bus workflows and governed batch dispatch.',
+    features: ['agent-bus', 'python', 'batch-dispatch', 'workspace'],
+    heavy: false,
+  },
+  {
+    name: '@scbe/kernel',
+    ecosystem: 'npm',
+    install: 'npm install @scbe/kernel',
+    purpose: 'Smaller kernel-level package for Sacred Tongues and core math without the full repo.',
+    features: ['kernel', 'sacred-tongues', 'lightweight-math'],
+    heavy: false,
+  },
+  {
+    name: 'scbe-sixtongues',
+    ecosystem: 'pypi',
+    install: 'pip install scbe-sixtongues',
+    purpose: 'Standalone Python Six Tongues tokenizer package for local scripts.',
+    features: ['sacred-tongues', 'python', 'tokenizer'],
+    heavy: false,
+  },
+];
+
+function normalizeFeature(feature: string): string {
+  return feature
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-');
+}
+
+function selectMode(request: OperatorRequest): OperatorMode {
+  if (request.privacy === 'local_only') return 'local_first';
+  if (request.preferCloud || request.workload === 'large') return 'cloud_assist';
+  if (request.workload === 'medium') return 'hybrid';
+  return 'local_first';
+}
+
+function defaultActors(request: OperatorRequest): OperatorActor[] {
+  return [
+    {
+      kind: 'human',
+      role: 'sets intent, trust boundary, and final approval',
+      constraints: ['time pressure', 'visual clarity', request.privacy ?? 'local_only'],
+    },
+    {
+      kind: 'machine',
+      role: 'executes real files, processes, storage, and network calls',
+      constraints: ['permissions', 'disk', 'cpu', 'memory', 'available tools'],
+    },
+    {
+      kind: 'ai',
+      role: 'accelerates navigation, planning, synthesis, and verification',
+      constraints: ['context window', 'tool access', 'policy', 'uncertainty'],
+    },
+  ];
+}
+
+export function recommendCompanionPackages(
+  requestedFeatures: string[],
+  availablePackages: CompanionPackageName[] = ['scbe-aethermoore']
+): CompanionRecommendation[] {
+  const available = new Set(availablePackages);
+  const requested = requestedFeatures.map(normalizeFeature);
+  const recommendations: CompanionRecommendation[] = [];
+
+  for (const feature of requested) {
+    const provider = COMPANION_PACKAGES.find(
+      (pkg) => !available.has(pkg.name) && pkg.features.map(normalizeFeature).includes(feature)
+    );
+    if (!provider) continue;
+    recommendations.push({
+      feature,
+      package: provider.name,
+      install: provider.install,
+      reason: `${provider.name} provides ${feature} without being installed as a forced dependency.`,
+    });
+  }
+
+  return recommendations;
+}
+
+export function createTriadicOperatorPlan(request: OperatorRequest): OperatorPlan {
+  const features = request.features ?? [];
+  const mode = selectMode(request);
+  const actions = [
+    'project intent into the shared operator manifold',
+    'bind actions to real machine objects instead of simulated UI state',
+    'route cheap/low-risk work locally first',
+  ];
+  if (mode !== 'local_first') {
+    actions.push('offload heavy or long-running work to a user-approved cloud lane');
+  }
+  actions.push('emit receipts before export, merge, release, or external storage handoff');
+
+  return {
+    schema_version: 'scbe-triadic-operator-plan-v1',
+    mode,
+    actors: defaultActors(request),
+    dimensions: [...TRIADIC_DIMENSIONS],
+    actions,
+    receipts: [
+      'SCBE_OPERATOR_PLAN_READY=1',
+      'SCBE_WORKSPACE_READY=1',
+      'SCBE_GATE_ALLOW=1',
+      'SCBE_STORAGE_EXPORT_READY=1',
+    ],
+    companionRecommendations: recommendCompanionPackages(features, request.availablePackages),
+  };
+}

--- a/tests/operator/triadic-operator-manifold.test.ts
+++ b/tests/operator/triadic-operator-manifold.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTriadicOperatorPlan,
+  recommendCompanionPackages,
+  TRIADIC_DIMENSIONS,
+} from '../../src/operator/index.js';
+
+describe('Triadic Operator Manifold', () => {
+  it('builds a local-first plan by default', () => {
+    const plan = createTriadicOperatorPlan({
+      intent: 'organize local workspace',
+      features: ['workspace'],
+    });
+
+    expect(plan.schema_version).toBe('scbe-triadic-operator-plan-v1');
+    expect(plan.mode).toBe('local_first');
+    expect(plan.actors.map((actor) => actor.kind)).toEqual(['human', 'machine', 'ai']);
+    expect(plan.dimensions).toContain('context_window');
+    expect(plan.receipts).toContain('SCBE_OPERATOR_PLAN_READY=1');
+  });
+
+  it('moves large remote-ok tasks into cloud assist without forcing dependencies', () => {
+    const plan = createTriadicOperatorPlan({
+      intent: 'run a large repository verification job',
+      privacy: 'remote_ok',
+      workload: 'large',
+      preferCloud: true,
+      features: ['agent-bus', 'batch-dispatch'],
+      availablePackages: ['scbe-aethermoore'],
+    });
+
+    expect(plan.mode).toBe('cloud_assist');
+    expect(plan.actions.join(' ')).toContain('user-approved cloud lane');
+    expect(plan.companionRecommendations).toEqual([
+      expect.objectContaining({
+        feature: 'agent-bus',
+        package: 'scbe-agent-bus',
+        install: 'pip install scbe-agent-bus',
+      }),
+      expect.objectContaining({
+        feature: 'batch-dispatch',
+        package: 'scbe-agent-bus',
+      }),
+    ]);
+  });
+
+  it('does not recommend already installed companion packages', () => {
+    const recommendations = recommendCompanionPackages(
+      ['agent-bus', 'python'],
+      ['scbe-aethermoore', 'scbe-agent-bus']
+    );
+
+    expect(recommendations).toEqual([
+      expect.objectContaining({
+        feature: 'python',
+        package: 'scbe-sixtongues',
+      }),
+    ]);
+  });
+
+  it('keeps the dimension list explicit and bounded', () => {
+    expect(TRIADIC_DIMENSIONS.length).toBeGreaterThanOrEqual(10);
+    expect(TRIADIC_DIMENSIONS).toContain('cost');
+    expect(TRIADIC_DIMENSIONS).toContain('audit_receipts');
+  });
+});


### PR DESCRIPTION
## Summary
- add a lightweight Triadic Operator Manifold API under `scbe-aethermoore/operator`
- add companion-package recommendation helpers for the Python `scbe-agent-bus` package
- document the no-forced-heavy-install policy and cloud-assist guardrails

## Why
This turns the human x machine x AI operating-space idea into a package surface users can call without installing the whole world. Packages can now reference companion packs when a requested feature lives elsewhere, while keeping installs local-first and small by default.

## Validation
- `npm test -- --run tests/operator/triadic-operator-manifold.test.ts` -> 4 passed
- `python -m pytest packages/agent-bus-py/tests/test_smoke.py -q` -> 7 passed
- `npm run build` -> passed
- `npx prettier --check src/operator/**/*.ts tests/operator/**/*.ts docs/specs/TRIADIC_OPERATOR_MANIFOLD.md config/system/triadic_operator_packages.json` -> passed
- `python -m black --check packages/agent-bus-py/src/scbe_agent_bus/companions.py packages/agent-bus-py/src/scbe_agent_bus/__init__.py packages/agent-bus-py/tests/test_smoke.py` -> passed
- `npm run publish:check:strict` -> pack guard passed

## Note
Local broad `npm run lint` still reports pre-existing formatting warnings across hundreds of unrelated TS files in this checkout, so I kept the validation focused on changed files plus build/typecheck/pack guard.