### PR TITLE
fix(operator): format triadic package export

### DIFF
--- a/docs/specs/TRIADIC_OPERATOR_MANIFOLD.md
+++ b/docs/specs/TRIADIC_OPERATOR_MANIFOLD.md
@@ -1,6 +1,6 @@
 # Triadic Operator Manifold
 
-**Status:** v1 product slice.  
+**Status:** v1 product slice.
 **Code:** `src/operator/triadic_manifold.ts` and `packages/agent-bus-py/src/scbe_agent_bus/companions.py`.
 
 ## Purpose

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,7 +327,16 @@ import * as ai_brain from './ai_brain/index.js';
 import * as governance from './governance/index.js';
 import * as operator from './operator/index.js';
 import * as securityEngine from './security-engine/index.js';
-export { symphonic, crypto, spiralverse, spiralauth, ai_brain, governance, operator, securityEngine };
+export {
+  symphonic,
+  crypto,
+  spiralverse,
+  spiralauth,
+  ai_brain,
+  governance,
+  operator,
+  securityEngine,
+};
 
 // Core Crypto Exports (also available at top level)
 export * from './crypto/envelope.js';


### PR DESCRIPTION
## Summary
- format the new operator export in src/index.ts for CI Prettier
- remove trailing Markdown whitespace from the triadic operator spec

## Validation
- git diff --check -> passed
- npx prettier --check src/index.ts docs/specs/TRIADIC_OPERATOR_MANIFOLD.md -> passed
- npm test -- --run tests/operator/triadic-operator-manifold.test.ts -> 4 passed
- python -m pytest packages/agent-bus-py/tests/test_smoke.py -q -> 7 passed
- npm run build -> passed