### PR TITLE
feat(governance): wire L13 overlays — bijective_tamper, identifier_canonicality, and Tree of Escalation v1.0

### DIFF
--- a/api/agent/storage.js
+++ b/api/agent/storage.js
@@ -4,6 +4,52 @@ const { readJsonBody, sendJson, setCors } = require('../_agent_common');
 
 const MAX_EXPORT_BYTES = 256 * 1024;
 
+const WORKSPACE_FORMATION = {
+  schema_version: 'aethermoor.bus.workspace_formation.v1',
+  default_root: '.aethermoor-bus/workspaces',
+  lifecycle: 'temp-local-first-offload-required',
+  folders: [
+    {
+      path: '00_inbox',
+      role: 'raw drops, user uploads, unclassified imports',
+      ship: false,
+    },
+    {
+      path: '10_work',
+      role: 'active editable working files',
+      ship: false,
+    },
+    {
+      path: '20_receipts',
+      role: 'governance verdicts, hashes, signatures, run receipts',
+      ship: true,
+    },
+    {
+      path: '30_exports',
+      role: 'customer-ready packets and handoff bundles',
+      ship: true,
+    },
+    {
+      path: '40_refs',
+      role: 'non-secret reference files and source notes',
+      ship: true,
+    },
+    {
+      path: '90_tmp',
+      role: 'scratch files; delete after successful offload',
+      ship: false,
+    },
+  ],
+  transport_stops: ['local_download', 'browser_local', 'github', 'dropbox', 'onedrive', 'gdrive'],
+  rules: [
+    'Classify before offload.',
+    'Never export secrets by default.',
+    'Receipts and manifests travel with customer work.',
+    'Temporary local workspaces are disposable after offload verification.',
+    'External storage is user-designated; the bus does not retain export content.',
+  ],
+};
+
 const PROVIDERS = [
   {
     id: 'local_download',
@@ -103,6 +149,7 @@ function buildExportPacket(body) {
     byte_length: bytes,
     destination_hint: body.destination || 'local_download',
     metadata: body.metadata && typeof body.metadata === 'object' ? body.metadata : {},
+    workspace_formation: WORKSPACE_FORMATION,
     content,
   };
   return {
@@ -129,6 +176,7 @@ module.exports = async function handler(req, res) {
       cost: 'zero-server-storage',
       default_provider: 'local_download',
       providers: PROVIDERS,
+      workspace_formation: WORKSPACE_FORMATION,
     });
   }
 
@@ -150,5 +198,6 @@ module.exports._private = {
   buildExportPacket,
   normalizeContent,
   PROVIDERS,
+  WORKSPACE_FORMATION,
   slugify,
 };

--- a/docs/specs/AGENT_BUS_WORKSPACE_FORMATION.md
+++ b/docs/specs/AGENT_BUS_WORKSPACE_FORMATION.md
@@ -1,0 +1,84 @@
+# Agent Bus Workspace Formation
+
+The agent bus should feel like a small operating system, not a loose download
+button. Customer work gets a temporary local workspace, a visible folder shape,
+and a clean offload path to the storage stop the user designates.
+
+This is the product-facing companion to `FOLDER.md` hexa cards. `FOLDER.md`
+organizes the repo for builders. The bus workspace formation organizes user
+work for operators and customers.
+
+## Shape
+
+```text
+.aethermoor-bus/workspaces/<workspace-id>/
+  00_inbox/     raw drops, uploads, imports, unclassified files
+  10_work/      active editable working files
+  20_receipts/  governance verdicts, hashes, signatures, run receipts
+  30_exports/   customer-ready packets and handoff bundles
+  40_refs/      non-secret reference files and source notes
+  90_tmp/       scratch files, deleted after offload verification
+```
+
+## Lifecycle
+
+1. Create a workspace ID from timestamp, user hint, and random suffix.
+2. Put raw inputs in `00_inbox`.
+3. Move active files into `10_work`.
+4. Write every governance/result receipt into `20_receipts`.
+5. Build user-facing outputs in `30_exports`.
+6. Keep safe public references in `40_refs`.
+7. Use `90_tmp` for scratch only.
+8. Offload `20_receipts`, `30_exports`, and selected `40_refs` to the user's
+   transport stop.
+9. Verify the offload manifest.
+10. Delete or retain the temporary workspace according to the user's request.
+
+## Transport Stops
+
+The zero-server-storage endpoint exposes these stops:
+
+- `local_download` - browser-generated JSON packet download.
+- `browser_local` - small local browser records.
+- `github` - user-designated repository handoff.
+- `dropbox` - user-designated Dropbox handoff.
+- `onedrive` - user-designated OneDrive handoff.
+- `gdrive` - user-designated Google Drive handoff.
+
+The bus does not need to own customer storage to be useful. It needs to produce
+clean packets that the customer can move to storage they already trust.
+
+## Rules
+
+- Classify before offload.
+- Never export secrets by default.
+- Receipts and manifests travel with customer work.
+- Temporary local workspaces are disposable after offload verification.
+- External storage is user-designated; the bus does not retain export content.
+- If a file is not in `20_receipts`, `30_exports`, or selected `40_refs`, it does
+  not ship by default.
+
+## API Surface
+
+`GET /api/agent/storage` returns the current `workspace_formation`.
+
+`POST /api/agent/storage` embeds the same `workspace_formation` in the export
+packet so mobile clients, browser clients, and CLI clients all see the same
+folder shape.
+
+The schema string is:
+
+```text
+aethermoor.bus.workspace_formation.v1
+```
+
+## Customer Meaning
+
+For the user, this becomes a one-click organizer:
+
+```text
+New bus workspace -> work happens -> receipts generated -> export packet -> chosen storage stop
+```
+
+For SCBE, it gives every agent a shared map. No more guessing whether a file is
+scratch, evidence, customer output, or reference material.

--- a/docs/specs/BIJECTIVE_TAMPER_L13.md
+++ b/docs/specs/BIJECTIVE_TAMPER_L13.md
@@ -1,0 +1,158 @@
+# Bijective Tamper Signal — L13 Integration
+
+**Status:** v1 SHIPPED + WIRED (2026-05-09). 23/23 pytest cases pass
+(11 unit + 12 wire-up incl. prose-FP guard). 207/207 governance +
+runtime_gate regressions green.
+**Code:** `src/governance/bijective_tamper.py` + wire-up in
+`src/governance/runtime_gate.py`.
+**Tests:** `tests/governance/test_bijective_tamper.py`,
+`tests/governance/test_bijective_tamper_wireup.py`.
+**Substrate dependency:** Bijective Compiler Gate (705/705 KO=Python).
+**Feature flag:** `SCBE_ENABLE_BIJECTIVE_TAMPER_GATE=1` (env) OR
+`RuntimeGate(use_bijective_tamper=True)` (kwarg). Default OFF.
+
+## What it is
+
+A new signal source for L13 risk decision (`src/governance/runtime_gate.py`).
+Takes source code, runs it through the bijective tokenizer pipeline, and
+emits a tamper score in `[0, 1]` with a categorical kind:
+
+| kind | score range | recommended L13 action |
+|------|-------------|------------------------|
+| `none` | 0.00 | ALLOW |
+| `nfc` | 0.20-0.30 | ALLOW (annotate) |
+| `structural` | ~0.60 | QUARANTINE |
+| `syntax` | 1.00 | DENY |
+| `input_invalid` | 1.00 | DENY |
+
+## What it catches
+
+The bijective compiler proved
+`parse(decode(encode(src))) ≡ parse(src)` for legitimate code. When this
+identity FAILS in unexpected ways, that's a fingerprint of:
+
+- **NFD/NFC normalization shifts** in literals — visible as `kind="nfc"`
+  with `nfc_recovers_bytes=True`. Recoverable by pre-normalizing.
+- **Subword-boundary tricks** — token sequences that decode back to a
+  source that parses to a DIFFERENT AST. Surfaces as `kind="structural"`.
+- **Outright corrupt bytes** — decoded source doesn't parse at all. Surfaces
+  as `kind="syntax"`.
+
+## What it does NOT catch (sibling gates needed)
+
+- **Homoglyph identifiers** (Cyrillic `а` vs Latin `a`). Each is a single
+  valid codepoint that round-trips fine; the AST identifier strings just
+  happen to look identical to humans. A separate identifier-canonicality
+  gate is needed.
+- **Logically-equivalent but structurally-different programs** — same
+  behavior, different AST. Out of scope; this gate is structural, not
+  behavioral.
+- **Run-time behavior** — this is purely a static encoding-level signal.
+
+## API
+
+```python
+from src.governance.bijective_tamper import (
+    evaluate_code,
+    recommended_l13_action,
+)
+
+result = evaluate_code(src, language="python")
+# result.score: float in [0, 1]
+# result.kind: "none" | "nfc" | "structural" | "syntax" | "input_invalid"
+# result.semantic_fingerprint: SHA-256 of canonical AST (hex), or None
+# result.bytes_diverge / nfc_recovers_bytes / ast_diverge / decoded_parses
+# result.detail: dict with notes / sub-fingerprints
+
+action = recommended_l13_action(result)  # "ALLOW" | "QUARANTINE" | "DENY"
+```
+
+The semantic fingerprint is a SHA-256 of the canonical AST dump. Two
+byte-different but AST-equivalent programs hash the same. Use cases:
+
+- **Replay detection**: if the same fingerprint reappears, it's the same
+  program semantically (regardless of formatting).
+- **Allowlist**: maintain a set of trusted fingerprints; admit unchanged.
+- **Drift tracking**: log fingerprint per gate evaluation; surface deltas.
+
+## Integration (WIRED — feature-flagged, additive)
+
+The overlay sits at the **top** of `RuntimeGate.evaluate()`, computed once
+per call. Catastrophic results (syntax, input_invalid → DENY-recommended)
+short-circuit immediately and learn the immune entry — this prevents
+syntax-broken submissions from contaminating the calibration centroid
+during the first 5 warm-up calls.
+
+Non-catastrophic results (none, nfc, structural-quarantine) flow through
+the normal pipeline. The receipt + escalation are applied at every
+return path (calibration, immune, reflex, reroute, full evaluation) so
+audit always sees the signal regardless of which fast-path fires.
+
+**Monotonic guarantee:** `_escalate_decision(base, tamper)` only raises
+severity; a base DENY can never be downgraded to ALLOW by the tamper
+overlay.
+
+**Receipt envelope** appended to `GateResult.signals`:
+```
+bijective_tamper(kind=<kind>,score=<float>,action=<ALLOW|QUARANTINE|DENY>[,fp=<12-hex>])
+```
+On veto, an additional signal:
+```
+bijective_tamper_veto_<deny|quarantine|review>(kind=<kind>,score=<float>)
+```
+
+**Structured fields on `GateResult`:**
+```python
+result.bijective_tamper_score    # float in [0.0, 1.0]
+result.bijective_tamper_kind     # "" | "none" | "nfc" | "structural" | "syntax" | "input_invalid"
+result.bijective_tamper_action   # "" | "ALLOW" | "QUARANTINE" | "DENY"
+result.semantic_fingerprint      # SHA-256 hex of canonical AST, or None
+```
+
+**Enabling:**
+```bash
+# Production (env-driven, no code change)
+export SCBE_ENABLE_BIJECTIVE_TAMPER_GATE=1
+```
+```python
+# Per-instance (env override)
+gate = RuntimeGate(use_bijective_tamper=True)
+```
+
+**Heuristic skip (two-signal):** the AST/tokenizer pipeline is only
+invoked when action_text contains BOTH (a) a structural keyword like
+`def `/`class `/`function `/etc. AND (b) a syntax token like `():`,
+`->`, `=>`, `):\n`, `==`, `self.`, etc. — in the first 512 chars. This
+prevents prose like *"please write a function that sorts the list"* or
+*"import duty applies"* from invoking the parser and false-positiving
+into a DENY.
+
+**`input_invalid` is a no-op at this layer.** It just means the input
+did not parse as the configured language — true for prose too. The
+genuine catastrophic case is `kind="syntax"` (the original parsed but
+the decoded form did not), which is what triggers the top-of-evaluate
+DENY short-circuit. Strict code-only callers should use
+`bijective_tamper.evaluate_code(...)` directly.
+
+**Test matrix** (all green):
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | flag off | no behavior change, no receipt |
+| 2 | flag on + clean code | ALLOW, kind=none, fingerprint set |
+| 3 | flag on + syntax-broken | DENY, kind=input_invalid, immune learned |
+| 4 | base DENY + tamper ALLOW | DENY (monotonic) |
+| 5 | base ALLOW + tamper DENY | DENY (escalation) |
+| 6 | env-var enables | flag on at construction |
+| 7 | explicit kwarg beats env | kwarg wins |
+| 8 | non-code skips overlay | no receipt, no AST work |
+
+## Languages
+
+v1 supports Python only (uses stdlib `ast`). Per-language extension follows
+the same pattern as the bijective compiler gates — see
+`docs/specs/COMPILER_GATES_BY_LANGUAGE_TODO.md`. Each language needs:
+
+1. A canonical AST dump function (parse + serialize, omit positions).
+2. Optionally a per-language tokenizer if not using the canonical Qwen one.
+
+The classification logic in `evaluate_code` is language-agnostic.

--- a/docs/specs/IDENTIFIER_CANONICALITY_L13.md
+++ b/docs/specs/IDENTIFIER_CANONICALITY_L13.md
@@ -1,0 +1,168 @@
+# Identifier-Canonicality Signal — L13 Sibling to Bijective Tamper
+
+**Status:** v1 SHIPPED + WIRED (2026-05-09). 27/27 pytest cases pass
+(15 unit + 12 wire-up). 105/105 governance + 129/129 runtime_gate
+regressions green.
+**Code:** `src/governance/identifier_canonicality.py` + wire-up in
+`src/governance/runtime_gate.py`.
+**Tests:** `tests/governance/test_identifier_canonicality.py`,
+`tests/governance/test_identifier_canonicality_wireup.py`.
+**Sibling gate:** `bijective_tamper` (encoding-level tamper); this
+module catches the homoglyph attacks that bijective tamper explicitly
+documents as out of scope.
+**Feature flag:** `SCBE_ENABLE_IDENTIFIER_CANONICALITY_GATE=1` (env)
+OR `RuntimeGate(use_identifier_canonicality=True)`. Default OFF.
+
+## What it catches
+
+The bijective tamper signal proves
+`parse(decode(encode(src))) ≡ parse(src)` for clean code. But it does
+NOT catch homoglyph identifier attacks because each homoglyph codepoint
+is a single valid Unicode character that round-trips fine. The AST sees
+them as DIFFERENT identifier strings, but a human reading the source
+can't tell `аpi_key` (Cyrillic а) from `api_key` (Latin a).
+
+This module fills that gap. It walks the AST, extracts every identifier,
+and classifies each:
+
+| kind | score | trigger | L13 action |
+|------|-------|---------|------------|
+| `clean` | 0.00 | ASCII only | ALLOW |
+| `non_ascii` | 0.30 | single non-Latin script (e.g., legitimate Greek) | ALLOW (annotate) |
+| `confusable` | 0.65 | all-confusable codepoints mimicking ASCII | QUARANTINE |
+| `mixed_script` | 0.90 | 2+ scripts in one identifier | DENY |
+| `invisible` | 1.00 | zero-width / BiDi codepoint inside identifier | DENY |
+| `input_invalid` | 1.00 | input did not parse | (no-op at runtime gate) |
+
+Aggregate `score` and `kind` reflect the highest-severity finding;
+`findings: List[IdentifierFinding]` carries every suspicious identifier.
+A `fingerprint` (SHA-256 of the sorted identifier set) is emitted for
+audit / replay-detection / allowlist use.
+
+## What it does NOT catch (out of scope)
+
+- **Logically-equivalent identifier renames** (e.g., `auth_token` vs
+  `bearer_token`) — same semantics, different name.
+- **BiDi controls in string literals or comments** (the original
+  Trojan Source attack, CVE-2021-42574). Python's parser already
+  rejects BiDi in identifiers, so the residual risk is in source text
+  outside identifiers — needs a separate source-text BiDi scanner.
+- **Run-time behavior** (this is a static lexical signal).
+
+## Known false positive: multilingual codebases
+
+The `confusable` classification fires when **every** codepoint in an
+identifier is in the curated ASCII-confusables table. For English-only
+codebases this is the right behavior — a non-Latin identifier whose
+glyphs all mimic ASCII is almost certainly an attack.
+
+For **multilingual codebases this is a known false positive**.
+Legitimate non-Latin words whose codepoints all happen to be in the
+confusables table will be classified as `confusable` → recommended
+QUARANTINE. Empirically verified examples (v1):
+
+| Identifier | Language | Glyphs | v1 result |
+|------------|----------|--------|-----------|
+| `ορα`      | Greek "vision" | ο, ρ, α — all in table | `confusable` (score 0.65) → QUARANTINE |
+| `αρα`      | Greek "so/therefore" | α, ρ, α — all in table | `confusable` (score 0.65) → QUARANTINE |
+| `τ`        | Greek "tau" | τ — NOT in table | `non_ascii` (score 0.30) → ALLOW |
+| `оке`      | Russian "OK" | о, к, е — к not in table | `non_ascii` (score 0.30) → ALLOW |
+
+**Contract for operators flipping `SCBE_ENABLE_IDENTIFIER_CANONICALITY_GATE=1`:**
+
+- If your codebase is English-only / ASCII-only: no impact, this is the
+  intended behavior.
+- If your codebase contains intentional Greek, Cyrillic, or other
+  non-Latin identifiers (mathematical conventions, internationalized
+  variable names, transliterated domain terms): expect QUARANTINE on
+  short identifiers whose glyphs all happen to be ASCII-lookalikes.
+  Workarounds today: leave the gate off for that codebase, or add an
+  allowlist via the `fingerprint` channel (SHA-256 of the sorted
+  identifier set is emitted on every result).
+
+**v2 work (deferred until justified by signal):** opt-in stricter mode
+(e.g., minimum identifier length for `confusable` classification, or a
+known-suspicious-name corpus check), or an opt-out for the `confusable`
+kind specifically while keeping `mixed_script` and `invisible`. Not
+shipped in v1 — the curated table was deliberately kept small precisely
+to limit this surface, and the signal cost of v2 changes is
+attack-telemetry-driven.
+
+## Integration
+
+The overlay runs at the **top** of `RuntimeGate.evaluate()`, in parallel
+with the bijective tamper signal. Both compute once per call. Either
+recommending DENY short-circuits the whole gate. Lower severities
+(QUARANTINE, REVIEW) flow through the normal pipeline and apply via
+`_escalate_decision` at every fast-path return.
+
+**Heuristic skip:** non-code action_text (no structural keyword AND
+syntax token in first 512 chars) is skipped without invoking the AST
+pipeline. Same heuristic as bijective tamper — they share
+`_looks_like_code`.
+
+**`input_invalid` is a no-op at this layer.** Same policy as bijective
+tamper: an input that doesn't parse is just prose at the runtime-gate
+level, not a canonicality signal.
+
+**Receipt envelope** appended to `GateResult.signals`:
+```
+identifier_canonicality(kind=<kind>,score=<float>,action=<ALLOW|QUARANTINE|DENY>[,fp=<12-hex>])
+```
+On veto, an additional signal:
+```
+identifier_canonicality_veto_<deny|quarantine|review>(kind=<kind>,score=<float>)
+```
+
+**Structured fields on `GateResult`:**
+```python
+result.identifier_canonicality_score       # float in [0.0, 1.0]
+result.identifier_canonicality_kind        # "" | "clean" | "non_ascii" | "confusable" | "mixed_script" | "invisible"
+result.identifier_canonicality_action      # "" | "ALLOW" | "QUARANTINE" | "DENY"
+result.identifier_canonicality_fingerprint # SHA-256 hex of sorted identifier set, or None
+```
+
+**Composition with bijective tamper:** when both flags are on, both
+receipts appear in audit. The catastrophic short-circuit at the top
+of `evaluate()` checks both decisions; if either says DENY, both
+receipts appear in the DENY result.
+
+## API
+
+```python
+from src.governance.identifier_canonicality import (
+    evaluate_code,
+    recommended_l13_action,
+)
+
+result = evaluate_code(src, language="python")
+# result.score: float in [0, 1]
+# result.kind: "clean" | "non_ascii" | "confusable" | "mixed_script" | "invisible" | "input_invalid"
+# result.findings: list of IdentifierFinding (per-identifier breakdown)
+# result.identifier_count: total distinct identifiers seen
+# result.fingerprint: SHA-256 hex of sorted identifier set, or None
+# result.detail: dict (distinct_kinds, total_findings, etc.)
+
+action = recommended_l13_action(result)  # "ALLOW" | "QUARANTINE" | "DENY"
+```
+
+## Languages
+
+v1 supports Python only (uses stdlib `ast`). Per-language extension
+follows the same pattern as bijective tamper / compiler gates — see
+`docs/specs/COMPILER_GATES_BY_LANGUAGE_TODO.md`. Each language needs
+an identifier-extraction function added to `_LANGUAGE_EXTRACTORS`. The
+classification logic in `_classify_identifier` is language-agnostic.
+
+## Confusable table
+
+The v1 module ships with a curated ~50-entry table of the
+highest-confidence ASCII-confusable codepoints (Cyrillic + Greek
+lowercase/uppercase that mimic Latin letters). A complete Unicode TR39
+confusables table has ~7,000 entries; for v1 we focus on what shows up
+in real attacks. The Mathematical Alphanumeric Symbols block
+(U+1D400..U+1D7FF) is rejected programmatically (1,024 codepoints, all
+homoglyph abuse vectors).
+
+Future work: optional dependency on a full TR39 confusables data file
+for v2 if attack telemetry shows the curated table is insufficient.

--- a/docs/specs/TREE_OF_ESCALATION.md
+++ b/docs/specs/TREE_OF_ESCALATION.md
@@ -1,0 +1,401 @@
+# Tree of Escalation — Compilation-Driven Multi-Tongue Computation
+
+**Status:** v0 SPEC (design only; no implementation yet).
+**Date:** 2026-05-09.
+**Architecture author:** Issac.
+**Transcription:** Claude.
+**Composes with:** `docs/LANGUES_WEIGHTING_SYSTEM.md`,
+`docs/specs/BIJECTIVE_TAMPER_L13.md`,
+`docs/specs/IDENTIFIER_CANONICALITY_L13.md`,
+`artifacts/cross_language_lookup/` (seed of the interop matrix),
+`src/symphonic/audio/tri_bundle.py` (tri-band substrate).
+
+## Premise
+
+Most pipelines escalate when they get scared. This one escalates when
+it runs out of bits.
+
+The system reads an input the way two readers can read the same book.
+When their interpretations agree, the work is cheap and done. When
+their interpretations diverge, the system has discovered that the
+current representation cannot hold the meaning, and it climbs to a
+richer one. Security flags do not stop a read; they reroute it through
+a sandbox that asks "what does this become after I think about it
+under my own priors?" — and the result of that becomes another node in
+the tree.
+
+When no representation in the system is rich enough to compile the
+input, the system has hit a **novel-truth node**: a piece of the woods
+where no existing tool fits. The system either mints a new provisional
+form (humble posture) or refuses to act (rigid posture). The choice is
+configurable per deployment; both are honest answers.
+
+## The Gunpowder Principle (substrate-agnosticism)
+
+> "The goal is always to have it be any input any output, and the
+> middle piece and the trajectory of the end piece are the important
+> parts. If code is the gunpowder, then we need to form the bullet,
+> the shell, the firing pin, etc. of the whole thing. And if we can
+> make the gun take any metal as the bullets, any ignition as the
+> ignition, then we have a more useful weapon." — Issac, 2026-05-09
+
+The architecture is a SHELL around three interchangeable parts:
+
+1. **Input substrate** (the metal). The reader does not assume what
+   the input IS — text, code, audio, structured graph, whatever can be
+   tokenized into atomic ops counts. The first job of every lane is to
+   reduce its input to its own atomic-op stream; the input format is
+   the lane's problem, not the tree's.
+
+2. **Bridge substrate** (the firing pin). M is pluggable. The six
+   Sacred Tongues are the v1 instantiation, not the only possible
+   readers. New lanes (new tongues, new spirit-mapped languages,
+   non-tongue readers like raw byte-stream parsers) can be added to
+   the matrix as new rows/columns; existing lanes do not change. The
+   matrix is the integration surface.
+
+3. **Output substrate** (the trajectory). The abridged form is a HASH
+   plus the audit tree. Downstream serialization (JSON, audio via L14,
+   structured action call, etc.) is the consumer's choice. The runtime
+   does not pre-commit to an output format; it commits to a CONTENT
+   that can be rendered in any.
+
+**What this rules out:** hard-coded assumptions that input is text,
+that bridges only exist between the v1 six tongues, that output is
+JSON. Anywhere the v0.1+ implementation makes such an assumption, that
+assumption is a v1.0 LIMITATION to be removed, not a contract to be
+defended.
+
+**What this rules in:** new lanes can be added by registering a reader
+function and a row/column in M. New input formats can be added by
+extending lanes' tokenizer surface. New output formats can be added by
+writing a serializer over the abridged form. None of these require
+changes to the walker, the sandbox loop, or the posture switch.
+
+The same gun. Different ammo. Different ignition. Same trajectory
+contract.
+
+## The Woods Heuristic (architectural anchor)
+
+> "If you go to lift a log and it's rotten, you don't try the same way.
+> You inspect it. You try and find what's wrong with the wood, if it
+> can be saved. If not, then move on, or use something of it, or don't.
+> It's a tree and you're in the woods. AI is in this situation in a
+> lot of ways. They exist in the infinite woods and they have the
+> tools to make the tools they need to build the things that will be a
+> construction of growth and resource consumption to output format and
+> potentiality." — Issac, 2026-05-09
+
+Translated to compute:
+
+| Woodsman action                              | Tree-of-Escalation action                                  |
+|----------------------------------------------|------------------------------------------------------------|
+| Try to lift the log                          | Bicameral read at lowest bit-depth                         |
+| Log holds — move on                          | Tongues converge -> abridged form, exit                    |
+| Log feels off — inspect                      | Disagreement -> escalate bit-depth                         |
+| Wood sound but grip misjudged                | Add a third tongue, re-read                                |
+| Wood partly rotten — salvage useful parts    | Partial bridge via M[i,j], file partial node               |
+| Wood fully rotten — leave or repurpose scraps | Novel-truth node: mint provisional OR refuse              |
+| Fire only when YOU choose to burn            | Sandbox loop only when flagged content arrives             |
+
+The point: a failed read is information about the **log**, not about
+the woodsman. The system updates its model of the input, not its model
+of itself. Self-update happens elsewhere, in the training loop.
+
+## Architecture
+
+### 1. Lanes — six tongues, six readers
+
+Six parallel readers, one per Sacred Tongue. Each reader compiles the
+input into its own atomic-op stream. Phi-weighted bit-depth: denser per
+token means richer reader, more cost.
+
+| Tongue        | Spirit-mapped language | phi weight | Bit-depth tier |
+|---------------|------------------------|------------|----------------|
+| Kor'aelin     | Python                 | 1.00       | T1 (lowest)    |
+| Avali         | JavaScript             | 1.62       | T2             |
+| Runethic      | Rust                   | 2.62       | T3             |
+| Cassisivadan  | Mathematica            | 4.24       | T4             |
+| Umbroth       | Haskell                | 6.85       | T5             |
+| Draumric      | Markdown               | 11.09      | T6 (highest)   |
+
+A lane's output is a stream `[(op_id, args_hash, result_hash), ...]`,
+one entry per atomic operation. The HASH SPACE is the same across
+tongues; the OP SPACE differs.
+
+### 2. Bands — tri-chromatic non-visual substrate per lane
+
+Each lane carries three bands, reusing the tri-braid pattern from
+`src/symphonic/audio/tri_bundle.py`:
+
+| Band     | Substrate analogy   | Computational role                                       |
+|----------|---------------------|----------------------------------------------------------|
+| INFRA    | Sub-audible         | Pre-computed deterministic atoms (cache, lookup, lexicon)|
+| AUDIBLE  | Audible             | Live execution trace (running ops)                       |
+| ULTRA    | Super-audible       | Speculative continuations (predicted next ops)           |
+
+Identification reads the lane (WHO computed) and the band (WHAT KIND).
+Three bands are not a tier. They are concurrent state-of-knowledge
+markers per lane: cache hit, live work, prediction.
+
+### 3. Bridge — interop matrix M
+
+`M` is a 6x6 matrix of translators between tongues. `M[i,i] = id`.
+`M[i,j]` for `i != j` is a function taking a tongue-i atomic op and
+returning either:
+
+- the equivalent tongue-j atomic op (clean bridge),
+- a partial bridge (multiple j-ops needed to express one i-op),
+- a NULL bridge (no equivalent in tongue j; the OPERATION ITSELF is
+  the new information).
+
+Seed of M: `artifacts/cross_language_lookup/` (composed byte<->token +
+tongue->lang + 64-op lexicon). **M is the architectural object — the
+tree is its dynamic projection on a specific input.**
+
+### 4. Bicameral read — the cheap path
+
+1. Pick TWO lanes at T1 (e.g., Kor'aelin + Avali).
+2. Both compute the same input, emit their op-streams.
+3. Compare result_hashes at each step.
+4. If all hashes agree: the abridged form is the agreed sequence.
+   Done. Cost ~ 2x single-lane.
+
+Most inputs end here. The escalation machinery exists for the
+disagreement cases; it does not run when it does not need to.
+
+### 5. Bit-depth escalation — when readings disagree
+
+Disagreement is the signal that bit-depth is too low. The walker
+escalates:
+
+1. Add the next phi-tier tongue (T1 -> add T2 reader).
+2. Re-read input with the new lane.
+3. Bridge prior lanes' ops up via M to the new bit-depth.
+4. Re-check convergence.
+5. If converged: abridged form lives at the LOWEST tier where majority
+   agreed; higher-tier reads attached as nuance nodes.
+6. If still split: escalate to T3, T4, ..., T6.
+
+Cost grows linearly with tier reached, not exponentially: each new
+lane is one more parallel read, not a re-do of all prior lanes.
+
+### 6. Sandbox loop — when content is flagged
+
+Flag sources: `identifier_canonicality`, `bijective_tamper`, content
+classifiers, prior-knowledge contradiction signals. A flag does NOT
+stop the read. It diverts through:
+
+1. **Provisional ingest** — the input becomes a tagged provisional
+   node. It is in the tree but not yet allowed to influence downstream
+   action.
+2. **Inspection under priors** — the sandbox runs the input against
+   the system's existing moral-compass model. Outputs are not verdicts
+   (good/bad); they are TRANSFORMS — "what does this become if I read
+   it through prior X? prior Y?"
+3. **Internalized own-interpretation** — the system constructs its OWN
+   reading of the input, distinct from the input's apparent surface
+   meaning. This reading is also added as a node.
+4. **Re-entry** — the bicameral read resumes on the COMBINED tree
+   (original + sandbox-derived nodes). Convergence is now measured
+   across the whole tree.
+
+The sandbox does not cleanse the input. It thickens the tree.
+
+This is the load-bearing departure from the security framing: the
+contract is "I will read this and tell you what I made of it," not "I
+will or won't read this." The refusal-or-action decision happens at
+the GOVERNANCE LAYER above the tree, with the tree as evidence.
+
+### 7. Termination — novel-truth nodes (the rigid/humble switch)
+
+If the walker exhausts T1..T6 and lanes still do not converge, the
+input has no representation in the system. Two configurable postures:
+
+| Posture | Behavior on exhaustion                                          | When to use                                                              |
+|---------|------------------------------------------------------------------|--------------------------------------------------------------------------|
+| Humble  | Mint a NEW abridged form, marked provisional. File for revisit. | Research, exploration, agents that should grow their vocabulary.         |
+| Rigid   | Refuse to compile. Return NULL with reason "no representation". | Production governance, contracts where action requires existing precedent.|
+
+**Default:** HUMBLE in research/training contexts; RIGID in
+runtime-governance contexts. Configurable per `RuntimeGate` instance
+and per call.
+
+A minted provisional form is a real new node in M. The next time the
+same input shape arrives, the provisional is the first candidate.
+Provisionals decay if not corroborated by additional reads within a
+configurable window — the system does not let one-off mints harden
+into doctrine without evidence.
+
+This is the woods heuristic at termination: rotten log, no tool fits.
+Humble takes a piece home to study. Rigid leaves it in place. Neither
+pretends the log is sound.
+
+## Output: the tree itself
+
+The escalation tree is the artifact, not a side-effect. Per call, the
+runtime emits:
+
+```
+{
+  "abridged_form": <hash | null>,
+  "posture": "humble" | "rigid",
+  "lanes_used": [...],
+  "tier_reached": 1..6,
+  "bridges_walked": [(i, j, op_id), ...],
+  "sandbox_invoked": bool,
+  "sandbox_nodes": [...],
+  "provisional_minted": bool,
+  "tree": <serialized tree>
+}
+```
+
+Every node carries `(lane, band, op_id, args_hash, result_hash,
+source)`. Replay-deterministic given the same input and the same M.
+The tree IS the audit trail; no separate log is required.
+
+## Composition with existing layers
+
+- **L13 governance.** Existing gates (`bijective_tamper`,
+  `identifier_canonicality`) become FLAG SOURCES that route into the
+  sandbox loop instead of blocking. DENY recommendations from those
+  gates set posture=RIGID and skip mint-provisional. ALLOW
+  recommendations let the tree run normally. The gates keep their
+  current contract; the tree adds a richer downstream consumer.
+- **L14 audio axis.** The per-lane band-streams are emittable as audio
+  telemetry — INFRA / AUDIBLE / ULTRA already maps to the three audio
+  bands in `tri_bundle.py`. A lane's band-stream IS audio-ready.
+- **L8 multi-well realms.** Wells are candidate abridged forms. The
+  walker's tier escalation is hill-climbing across well basins. A
+  novel-truth node is a new well being dug.
+- **MAHSS substrate.** The bridge matrix M is exactly the role-bound
+  HRR fold — bridges are unbinding ops on a holographic representation.
+  ToE could be implemented on top of MAHSS rather than as a sibling.
+- **L11 triadic temporal.** Provisional decay schedules are temporal
+  windows; L11's three-scale intent signal is a natural input to the
+  decay-policy decision.
+
+## Open questions (deferred to v0.1+)
+
+1. **Convergence threshold.** Exact-hash agreement is too strict for
+   anything beyond pure compute. Need a per-tier tolerance schedule
+   (T1 = exact-hash, T6 = semantic-equivalence-class).
+2. **Bridge cost weighting.** Some bridges are cheap (lexicon lookup),
+   some are expensive (learned embedding, multi-op decomposition). The
+   walker needs a budget, not just a tier counter.
+3. **Provisional decay.** How long does a minted provisional live
+   without corroboration before garbage-collected? Per-tier? Per
+   posture? Per concept domain?
+4. **Sandbox prior-set selection.** Which moral-compass priors get run
+   against a flagged input? All of them (expensive, complete) or
+   selected by flag-source (cheap, lossy)?
+5. **~~Initial-pair selection~~ (RESOLVED 2026-05-09).** Input-shape
+   driven adversarial pairing at the LANE LEVEL. The orchestrator
+   classifies the input's primary domain, selects the lane with
+   highest historical capability in that domain (Primary Resolver),
+   and pairs it with the lane that has the highest historical
+   disagreement delta against the Primary in that domain (Adversarial
+   Reader). MODEL-WITHIN-LANE selection (which LLM serves a given
+   tongue) is a separate selection problem, deferred to v0.2.
+6. **~~NULL-bridge semantics~~ (RESOLVED 2026-05-09).** Both edge and
+   node, with per-failure metadata living on the EDGE. The edge
+   carries `is_untranslatable=True`,
+   `untranslatable_reason=<structured>`, and `untranslatable_op_id`.
+   The edge terminates at a global singleton sink node
+   `NULL_BRIDGE_VOID` which holds aggregate stats only (incoming-edge
+   count, distinct ops failed, failures by lane-pair). This preserves
+   a clean traversal stop AND a queryable per-failure audit record
+   without overloading the singleton.
+
+## What this is NOT
+
+- Not a security pipeline. Security flags are INPUTS, not the driver.
+- Not a fault-tolerance scheme primarily. BFT is a side-benefit.
+- Not a translation system. M bridges OPS, not strings.
+- Not a consensus protocol. Lanes do not vote; they READ. Convergence
+  is a property of the input + M, not of the lanes themselves.
+- Not a replacement for the 14-layer pipeline. It composes inside L13
+  as an alternative decision substrate when enabled.
+
+## Glossary (coined terms)
+
+| Term                       | Meaning                                                                                                              |
+|----------------------------|----------------------------------------------------------------------------------------------------------------------|
+| Tree of Escalation (ToE)   | Dynamic projection of the bicameral-read process on a specific input. Audit-bearing artifact.                        |
+| Bicameral read             | Two-or-more lanes reading the same input in parallel. Convergence-or-divergence is the signal.                       |
+| Bit-depth escalation       | Adding a richer (higher phi-weight) tongue to a read when lower tongues fail to converge.                            |
+| Sandbox loop               | The ingest -> inspect-under-priors -> internalize -> re-enter cycle triggered by a flagged input.                    |
+| Interop matrix (M)         | 6x6 matrix of bridge functions between tongue op-spaces. The architectural object.                                   |
+| Abridged form              | The agreed-upon canonical reading across converged lanes. Output of a successful tree walk.                          |
+| Novel-truth node           | A point where M has no path that lets ANY tongue compile the input. Triggers the posture decision.                   |
+| Posture                    | Per-deployment switch: HUMBLE (mint provisional on exhaustion) vs RIGID (refuse on exhaustion).                       |
+| Lane                       | One tongue's reader. Six lanes total.                                                                                 |
+| Band                       | INFRA / AUDIBLE / ULTRA — concurrent state-of-knowledge marker per lane.                                              |
+| Provisional                | A minted abridged form not yet corroborated by additional reads. Decays without confirmation.                         |
+| NULL bridge                | `M[i,j](op)` returning no equivalent. The absence is itself filed as information.                                     |
+
+## Implementation roadmap (proposed)
+
+1. **v0.1 SHIPPED 2026-05-09** — `src/governance/tree_of_escalation.py`:
+   data structures only (`Tree`, `Node`, `Lane`, `Band`, `Posture`,
+   `BridgeEdge`, `LanePair`, `VoidStats`, `NodeKind`,
+   `NULL_BRIDGE_VOID_ID`, `LANE_PHI_WEIGHT`, `LANE_TIER`,
+   `DEFAULT_LADDER`, `hash_payload`). 27 unit tests.
+2. **v0.2 SHIPPED 2026-05-09** — Bridge matrix + walker
+   (`BridgeMatrix`, `Reader` protocol, `OpTrace`, `HashReader`
+   reference, `majority_converged`, `walk()`). Bicameral-read with
+   strict-majority convergence; bit-depth escalation across
+   `DEFAULT_LADDER`; T6 exhaustion leaves `abridged_form=None` (v0.4
+   will mint or refuse per posture). 18 additional unit tests
+   (45 total). Hardcoded M from `artifacts/cross_language_lookup/`
+   deferred to v0.3 — v0.2 ships pluggable matrix with
+   reference HashReader for tests.
+3. **v0.3 SHIPPED 2026-05-09** — Sandbox loop and adversarial pair
+   selection. New: `Flag`, `MoralPrior` protocol, `IdentityPrior`,
+   `IsolationPrior`, `InspectionResult`, `sandbox()`, `classify_domain`,
+   `select_initial_pair`, `DOMAIN_KEYWORDS`, `DOMAIN_PRIMARY`,
+   `DOMAIN_ADVERSARY`. `walk()` extended to accept `flags` and
+   `priors`; sandbox interpretation joins convergence vote as an extra
+   voter (does not override lane majority). Q5 lock activated:
+   default initial pair now comes from `select_initial_pair(payload)`
+   instead of static (Kor'aelin, Avali). Stub keyword classifier; v0.4+
+   will replace with learned classifier. 30 additional unit tests
+   (75 total). Full governance suite 180/180 green.
+4. **v0.4 SHIPPED 2026-05-09** — Termination posture switch +
+   provisional decay registry. New: `Termination` enum
+   (INCOMPLETE / ABRIDGED / PROVISIONAL / REFUSED), `mint_provisional`
+   (deterministic synthesis from observed streams), `ProvisionalRecord`,
+   `ProvisionalRegistry` (call-counter-based decay, NOT wall-clock —
+   keeps replay deterministic). `walk()` extended with
+   `provisional_registry` kwarg. Tree gains `terminated_as`,
+   `refusal_reason`, `provisional_corroboration_count`. HUMBLE T6
+   exhaustion mints provisional + adds `PROVISIONAL_MINT` node + records
+   in registry if supplied. RIGID T6 exhaustion sets refusal_reason and
+   leaves `abridged_form=None`. 22 additional unit tests (97 total).
+   Full governance suite 202/202 green.
+5. **v0.5 SHIPPED 2026-05-09** — L14 audio emission adapter. New:
+   `AudioEvent` (frozen), `TreeAudioEmission` with `by_lane`/`by_band`
+   indexes, `emit_audio(tree, *, event_duration_s)`,
+   `LANE_TO_TRI_BUNDLE_CODE`, `BAND_FREQUENCY_MULTIPLIER`,
+   `SYSTEM_FUNDAMENTAL_HZ`. Frequencies sourced from
+   `src/crypto/tri_bundle.TONGUE_FREQUENCIES` with a fallback table
+   baked in. Tri-octave Band signature: INFRA = -2 octaves, AUDIBLE =
+   fundamental, ULTRA = +2 octaves. Per-NodeKind emission rules:
+   OP -> AUDIBLE, sandbox provisional/inspection -> INFRA,
+   sandbox internalize -> AUDIBLE, provisional mint -> ULTRA, void ->
+   silent. Synthesis to waveform left to downstream consumers; v0.5
+   ships the EVENT stream only. 16 additional unit tests (113 total).
+   Full governance suite 218/218 green.
+6. **v1.0** — Fold into `RuntimeGate` as `use_tree_of_escalation=True`
+   feature flag, behind env var
+   `SCBE_ENABLE_TREE_OF_ESCALATION_GATE=1`. Default OFF, same pattern
+   as `bijective_tamper` and `identifier_canonicality`.
+
+## Closing note (the woods)
+
+The whole architecture is the woodsman heuristic, scaled. The system
+has six tools (tongues), three depths of attention per tool (bands), a
+mapping of which tool can stand in for which (M), a way to learn it
+needs a richer tool (escalation), a way to handle wood it does not
+recognize (sandbox), and an honest answer for wood no tool can lift
+(posture). Nothing here pretends the woods are smaller than they are.

--- a/scripts/security/native_liboqs_smoke.py
+++ b/scripts/security/native_liboqs_smoke.py
@@ -85,6 +85,7 @@ def main() -> int:
     if not status.get("quantum_resistant"):
         _die(f"SCBE PQC governance status is not quantum resistant: {status}")
 
+    print("SCBE_LIBOQS_PASS=1")
     print("native-liboqs-smoke: PASS")
     print(f"oqs_module={getattr(oqs, '__file__', 'unknown')}")
     print(f"oqs_version={getattr(oqs, '__version__', 'unknown')}")

--- a/src/governance/bijective_tamper.py
+++ b/src/governance/bijective_tamper.py
@@ -1,0 +1,313 @@
+"""Bijective Tamper Signal — encoding-level tamper detection for L13.
+
+Builds on the bijective compiler substrate (705/705 KO=Python, 335/335 AV=TS):
+
+    parse(decode(encode(src))) ≡ parse(src)   — holds for legitimate code
+
+When code DIVERGES under tokenize-decode, that divergence is a FINGERPRINT
+of encoding-level tampering or unicode trickery. This module turns that
+fingerprint into a tamper signal in [0, 1] for the L13 risk decision gate.
+
+What this gate catches well:
+    * NFD/NFC normalization shifts (combining marks rearranged to hide payload)
+    * Zero-width-joiner (ZWJ) and zero-width-space (ZWSP) injections in
+      identifiers that the BPE tokenizer normalizes away
+    * Subword-boundary tricks where the tokenizer cannot round-trip
+    * Outright corrupt bytes that don't parse after tokenize/decode
+
+What this gate does NOT catch (out of scope, needs sibling gates):
+    * Homoglyph identifiers (Cyrillic а vs Latin a — both are valid,
+      single-codepoint identifiers; AST sees them as different but each
+      independently round-trips fine)
+    * Logically-equivalent but structurally-different programs
+    * Run-time behavior (this is a STATIC encoding-level signal)
+
+Tamper score scale:
+    0.00 - 0.10   → kind="none"        — bytes and AST both stable
+    0.10 - 0.40   → kind="nfc"         — bytes shift via NFC, AST stable
+                                          (recoverable, log-only)
+    0.40 - 0.80   → kind="structural"  — AST shifts after decode
+                                          (semantic shift, quarantine)
+    0.80 - 1.00   → kind="syntax"      — decoded source does not parse
+                                          (catastrophic, deny)
+
+Plus a side channel:
+    kind="input_invalid" — input source itself does not parse. Not a
+    tamper signal per se; route to syntax-error handling.
+
+L13 integration sketch (not wired here to keep the change additive):
+
+    from src.governance.bijective_tamper import evaluate_code
+    from src.governance.runtime_gate import Decision
+
+    def l13_with_tamper_signal(src, language, base_decision):
+        result = evaluate_code(src, language)
+        if result.kind == "syntax":
+            return Decision.DENY
+        if result.kind == "structural":
+            return max(base_decision, Decision.QUARANTINE)
+        # nfc / none — pass through, annotate
+        return base_decision.with_annotation(result.fingerprint, result.score)
+
+The fingerprint is a SHA-256 of the canonical AST. Two semantically-equal
+programs hash the same — useful for replay detection, dedup, whitelisting.
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# --------------------------------------------------------------------------- #
+#  Public types
+# --------------------------------------------------------------------------- #
+
+DivergenceKind = str  # Literal: "none" | "nfc" | "structural" | "syntax" | "input_invalid"
+
+
+@dataclass
+class TamperResult:
+    """Outcome of a single bijective-tamper evaluation."""
+
+    score: float  # 0.0 = clean, 1.0 = catastrophic
+    kind: DivergenceKind
+    semantic_fingerprint: Optional[str]  # SHA-256 of canonical AST, hex
+    bytes_diverge: bool
+    nfc_recovers_bytes: bool
+    ast_diverge: bool
+    decoded_parses: bool
+    detail: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "score": self.score,
+            "kind": self.kind,
+            "semantic_fingerprint": self.semantic_fingerprint,
+            "bytes_diverge": self.bytes_diverge,
+            "nfc_recovers_bytes": self.nfc_recovers_bytes,
+            "ast_diverge": self.ast_diverge,
+            "decoded_parses": self.decoded_parses,
+            "detail": self.detail,
+        }
+
+
+# --------------------------------------------------------------------------- #
+#  Per-language AST canonicalization
+# --------------------------------------------------------------------------- #
+
+def _ast_canonical_python(src: str) -> str:
+    """Canonical AST dump for Python. Raises SyntaxError on bad input."""
+    tree = ast.parse(src)
+    return ast.dump(tree, annotate_fields=True, include_attributes=False, indent=2)
+
+
+_AST_CANONICAL = {
+    "python": _ast_canonical_python,
+}
+
+
+# --------------------------------------------------------------------------- #
+#  Tokenizer access (lazy / injectable)
+# --------------------------------------------------------------------------- #
+
+_DEFAULT_TOKENIZER_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "artifacts"
+    / "extended_tokenizer"
+    / "qwen25-coder-7b-sacred-tongues"
+)
+_TOKENIZER_CACHE: dict[str, object] = {}
+
+
+def _load_tokenizer(tokenizer_dir: Optional[Path] = None):
+    key = str(tokenizer_dir or _DEFAULT_TOKENIZER_DIR)
+    if key in _TOKENIZER_CACHE:
+        return _TOKENIZER_CACHE[key]
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(key, use_fast=True)
+    _TOKENIZER_CACHE[key] = tok
+    return tok
+
+
+def _decode_through_tokenizer(src: str, tokenizer) -> str:
+    encoded = tokenizer.encode(src, add_special_tokens=False)
+    ids = encoded.ids if hasattr(encoded, "ids") else encoded
+    try:
+        return tokenizer.decode(ids, skip_special_tokens=False)
+    except TypeError:
+        return tokenizer.decode(ids)
+
+
+# --------------------------------------------------------------------------- #
+#  Public evaluate_code
+# --------------------------------------------------------------------------- #
+
+def evaluate_code(
+    src: str,
+    language: str = "python",
+    tokenizer=None,
+    tokenizer_dir: Optional[Path] = None,
+) -> TamperResult:
+    """Compute the bijective tamper signal for a source string.
+
+    Args:
+        src: Source code to evaluate.
+        language: Currently only "python" is implemented. Future: "typescript",
+                  "rust", etc. — see docs/specs/COMPILER_GATES_BY_LANGUAGE_TODO.md.
+        tokenizer: Optional pre-loaded HF tokenizer. If None, the canonical
+                   Qwen+atomic-tongue tokenizer is loaded (cached).
+        tokenizer_dir: Optional override for the tokenizer artifacts path.
+
+    Returns:
+        TamperResult with score, divergence kind, and semantic fingerprint.
+    """
+    if language not in _AST_CANONICAL:
+        return TamperResult(
+            score=1.0,
+            kind="input_invalid",
+            semantic_fingerprint=None,
+            bytes_diverge=False,
+            nfc_recovers_bytes=False,
+            ast_diverge=False,
+            decoded_parses=False,
+            detail={"error": f"unsupported language: {language}"},
+        )
+
+    canonicalize = _AST_CANONICAL[language]
+
+    # Step 1: input must parse
+    try:
+        src_canonical = canonicalize(src)
+    except SyntaxError as e:
+        return TamperResult(
+            score=1.0,
+            kind="input_invalid",
+            semantic_fingerprint=None,
+            bytes_diverge=False,
+            nfc_recovers_bytes=False,
+            ast_diverge=False,
+            decoded_parses=False,
+            detail={"error": f"input does not parse: {e}"},
+        )
+
+    src_fingerprint = hashlib.sha256(src_canonical.encode("utf-8")).hexdigest()
+
+    # Step 2: tokenize-decode round trip
+    if tokenizer is None:
+        tokenizer = _load_tokenizer(tokenizer_dir)
+    decoded = _decode_through_tokenizer(src, tokenizer)
+
+    bytes_diverge = decoded != src
+    nfc_recovers = bytes_diverge and unicodedata.normalize("NFC", src) == decoded
+
+    # Step 3: does decoded source parse?
+    try:
+        decoded_canonical = canonicalize(decoded)
+        decoded_parses = True
+    except SyntaxError as e:
+        return TamperResult(
+            score=1.0,
+            kind="syntax",
+            semantic_fingerprint=src_fingerprint,
+            bytes_diverge=bytes_diverge,
+            nfc_recovers_bytes=nfc_recovers,
+            ast_diverge=True,
+            decoded_parses=False,
+            detail={"error": f"decoded source does not parse: {e}"},
+        )
+
+    ast_diverge = src_canonical != decoded_canonical
+
+    # Step 4: classify.
+    # Decision order matters: NFC-recoverable cases are documented expected
+    # divergence and classify as "nfc" even when the AST shifts (string literal
+    # values are codepoint-sensitive, so NFD↔NFC literals change AST values).
+    if not bytes_diverge:
+        return TamperResult(
+            score=0.0,
+            kind="none",
+            semantic_fingerprint=src_fingerprint,
+            bytes_diverge=False,
+            nfc_recovers_bytes=False,
+            ast_diverge=False,
+            decoded_parses=True,
+        )
+
+    if nfc_recovers:
+        # Documented expected normalization. Score reflects whether AST also
+        # shifted (slightly higher when literals were affected).
+        score = 0.25 if ast_diverge else 0.20
+        note = (
+            "bytes diverged via NFC normalization; literal contents shifted (AST changed)"
+            if ast_diverge
+            else "bytes diverged via NFC normalization; AST stable"
+        )
+        return TamperResult(
+            score=score,
+            kind="nfc",
+            semantic_fingerprint=src_fingerprint,
+            bytes_diverge=True,
+            nfc_recovers_bytes=True,
+            ast_diverge=ast_diverge,
+            decoded_parses=True,
+            detail={"note": note},
+        )
+
+    if not ast_diverge:
+        # Bytes diverge via something other than NFC, but AST stable.
+        return TamperResult(
+            score=0.30,
+            kind="nfc",
+            semantic_fingerprint=src_fingerprint,
+            bytes_diverge=True,
+            nfc_recovers_bytes=False,
+            ast_diverge=False,
+            decoded_parses=True,
+            detail={"note": "bytes diverged via non-NFC normalization; AST stable"},
+        )
+
+    # Bytes AND AST diverge AND NFC does not recover — semantic-level shift.
+    return TamperResult(
+        score=0.60,
+        kind="structural",
+        semantic_fingerprint=src_fingerprint,
+        bytes_diverge=True,
+        nfc_recovers_bytes=False,
+        ast_diverge=True,
+        decoded_parses=True,
+        detail={
+            "note": "AST canonical changed after tokenize-decode (not NFC-recoverable)",
+            "src_fingerprint": src_fingerprint,
+            "decoded_fingerprint": hashlib.sha256(
+                decoded_canonical.encode("utf-8")
+            ).hexdigest(),
+        },
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  Convenience: L13 mapping
+# --------------------------------------------------------------------------- #
+
+L13_MAPPING_RECOMMENDATION = {
+    "none": "ALLOW",
+    "nfc": "ALLOW",  # log only; could be QUARANTINE in stricter modes
+    "structural": "QUARANTINE",
+    "syntax": "DENY",
+    "input_invalid": "DENY",  # cannot reason about syntactically-invalid input
+}
+
+
+def recommended_l13_action(result: TamperResult) -> str:
+    """Map a TamperResult to the recommended L13 action string.
+
+    Conservative default; production wiring should compose with other signals
+    (harmonic wall score, swarm consensus, etc.).
+    """
+    return L13_MAPPING_RECOMMENDATION.get(result.kind, "QUARANTINE")

--- a/src/governance/identifier_canonicality.py
+++ b/src/governance/identifier_canonicality.py
@@ -1,0 +1,501 @@
+"""Identifier-Canonicality Signal — sibling gate to bijective_tamper.
+
+The bijective tamper signal proves that
+
+    parse(decode(encode(src))) ≡ parse(src)
+
+holds for clean code. But it does NOT catch homoglyph identifier attacks
+because each homoglyph codepoint is a single valid Unicode character that
+round-trips through the tokenizer perfectly. The AST happens to see them
+as DIFFERENT identifier strings (Cyrillic `а` vs Latin `a` are distinct
+codepoints), but a human reading the source can't tell them apart.
+
+This module catches what bijective_tamper explicitly leaves on the table:
+
+    1. Mixed-script identifiers (Latin + Cyrillic + Greek in one name) —
+       almost always a confusable attack, never legitimate.
+    2. Identifiers containing only-confusable codepoints (a Cyrillic-only
+       version of an ASCII identifier name).
+    3. Invisible characters in identifiers (zero-width joiner, zero-width
+       space, soft hyphen, byte-order mark in interior position).
+    4. Bidirectional control characters (a known supply-chain attack vector
+       — the "Trojan Source" class of bugs).
+
+What this gate does NOT catch (out of scope):
+    * Single-script non-Latin identifiers (e.g., a fully Cyrillic legitimate
+      identifier). These look weird but are not deceptive.
+    * Logically-equivalent semantically-different programs.
+    * Run-time behavior.
+
+Known false positive (multilingual codebases):
+    The `confusable` kind fires when EVERY codepoint in an identifier is in
+    the curated ASCII-confusables table. Legitimate non-Latin words whose
+    glyphs all happen to be in that table will also classify as `confusable`
+    → QUARANTINE. Verified examples: Greek `ορα` ("vision"), Greek `αρα`
+    ("so/therefore"). For English-only codebases this is intended; for
+    multilingual codebases, leave the env-var off or allowlist via the
+    emitted SHA-256 fingerprint. See docs/specs/IDENTIFIER_CANONICALITY_L13.md
+    "Known false positive: multilingual codebases" for the operator contract.
+
+Score scale:
+    0.00          → kind="clean"           — no canonicality issues
+    0.30 - 0.50   → kind="non_ascii"       — non-ASCII single-script ids
+                                              (legitimate but log-worthy)
+    0.60 - 0.80   → kind="confusable"      → all-confusable codepoints used
+                                              to mimic an ASCII name
+    0.85 - 0.95   → kind="mixed_script"    → script-mixing attack
+    1.00          → kind="invisible"       → invisible chars or BiDi
+                                              controls (catastrophic)
+    1.00          → kind="input_invalid"   — input did not parse
+
+L13 mapping (recommendation; production may compose with other signals):
+    clean         → ALLOW
+    non_ascii     → ALLOW (annotate)
+    confusable    → QUARANTINE
+    mixed_script  → DENY
+    invisible     → DENY
+    input_invalid → no-op (handled by sibling gates / not a tamper signal)
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import unicodedata
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+
+# --------------------------------------------------------------------------- #
+#  Public types
+# --------------------------------------------------------------------------- #
+
+CanonicalityKind = str  # "clean" | "non_ascii" | "confusable" | "mixed_script" | "invisible" | "input_invalid"
+
+
+@dataclass
+class IdentifierFinding:
+    """One suspicious identifier from the source."""
+
+    name: str
+    kind: CanonicalityKind
+    scripts: List[str]
+    detail: str
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "scripts": list(self.scripts),
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class CanonicalityResult:
+    """Outcome of a single identifier-canonicality evaluation."""
+
+    score: float  # 0.0 = clean, 1.0 = catastrophic
+    kind: CanonicalityKind
+    findings: List[IdentifierFinding] = field(default_factory=list)
+    identifier_count: int = 0
+    fingerprint: Optional[str] = None  # SHA-256 of sorted identifier set
+    detail: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "score": self.score,
+            "kind": self.kind,
+            "findings": [f.to_dict() for f in self.findings],
+            "identifier_count": self.identifier_count,
+            "fingerprint": self.fingerprint,
+            "detail": self.detail,
+        }
+
+
+# --------------------------------------------------------------------------- #
+#  Confusable / invisible codepoint tables
+#
+#  This is a curated, deliberately small table covering the highest-confidence
+#  ASCII-confusable attack codepoints. A complete TR39 confusables table has
+#  ~7,000 entries; for v1 we focus on what actually shows up in real source-code
+#  homoglyph attacks, which is dominated by Cyrillic and a handful of Greek.
+# --------------------------------------------------------------------------- #
+
+# Map: confusable codepoint -> ASCII codepoint it mimics
+_ASCII_CONFUSABLES: Dict[str, str] = {
+    # Cyrillic lowercase that looks like Latin
+    "а": "a",  # а
+    "е": "e",  # е
+    "о": "o",  # о
+    "р": "p",  # р
+    "с": "c",  # с
+    "х": "x",  # х
+    "у": "y",  # у
+    "і": "i",  # і (Ukrainian)
+    "ј": "j",  # ј (Serbian)
+    "һ": "h",  # һ
+    # Cyrillic uppercase that looks like Latin
+    "А": "A",  # А
+    "В": "B",  # В
+    "С": "C",  # С
+    "Е": "E",  # Е
+    "Н": "H",  # Н
+    "К": "K",  # К
+    "М": "M",  # М
+    "О": "O",  # О
+    "Р": "P",  # Р
+    "Т": "T",  # Т
+    "Х": "X",  # Х
+    # Greek that looks like Latin
+    "α": "a",  # α
+    "ο": "o",  # ο
+    "ρ": "p",  # ρ
+    "υ": "u",  # υ
+    "ν": "v",  # ν (looks like v in some fonts)
+    "Α": "A",  # Α
+    "Β": "B",  # Β
+    "Ε": "E",  # Ε
+    "Η": "H",  # Η
+    "Ι": "I",  # Ι
+    "Κ": "K",  # Κ
+    "Μ": "M",  # Μ
+    "Ν": "N",  # Ν
+    "Ο": "O",  # Ο
+    "Ρ": "P",  # Ρ
+    "Τ": "T",  # Τ
+    "Χ": "X",  # Χ
+    "Υ": "Y",  # Υ
+    "Ζ": "Z",  # Ζ
+    # Mathematical Alphanumeric Symbols (whole homoglyph alphabet block)
+    # We don't enumerate all 1,024; reject ALL identifiers containing any
+    # codepoint in U+1D400..U+1D7FF range (handled programmatically below).
+}
+
+# Invisible / formatting-control codepoints that should NEVER appear inside
+# identifiers (they are valid Python identifier characters per PEP 3131 in
+# some cases, which is exactly the supply-chain risk).
+_INVISIBLE_CODEPOINTS: frozenset = frozenset(
+    {
+        "​",  # zero-width space
+        "‌",  # zero-width non-joiner
+        "‍",  # zero-width joiner
+        "⁠",  # word joiner
+        "﻿",  # zero-width no-break space (BOM)
+        "­",  # soft hyphen
+        "᠎",  # Mongolian vowel separator
+        "⁡",  # function application
+        "⁢",  # invisible times
+        "⁣",  # invisible separator
+        "⁤",  # invisible plus
+    }
+)
+
+# BiDi control codepoints — the Trojan Source class. NEVER legitimate inside
+# identifiers; very rarely legitimate in source at all.
+_BIDI_CODEPOINTS: frozenset = frozenset(
+    {
+        "‪",  # LRE
+        "‫",  # RLE
+        "‬",  # PDF
+        "‭",  # LRO
+        "‮",  # RLO
+        "⁦",  # LRI
+        "⁧",  # RLI
+        "⁨",  # FSI
+        "⁩",  # PDI
+    }
+)
+
+
+def _codepoint_script(ch: str) -> str:
+    """Return a coarse script bucket for a single codepoint.
+
+    We don't load the full Unicode Script property; a coarse bucket is
+    enough for the mixed-script attack which always combines 2 scripts that
+    share visual confusability (Latin + Cyrillic, Latin + Greek).
+    """
+    cp = ord(ch)
+    if 0x0041 <= cp <= 0x007A or cp == 0x005F:  # A-Z, a-z, _ (Latin/ASCII)
+        return "Latin"
+    if 0x0030 <= cp <= 0x0039:
+        return "Digit"
+    if 0x00C0 <= cp <= 0x024F:
+        return "Latin"  # Latin-1 Supplement / Extended-A/B
+    if 0x0370 <= cp <= 0x03FF:
+        return "Greek"
+    if 0x0400 <= cp <= 0x04FF:
+        return "Cyrillic"
+    if 0x0500 <= cp <= 0x052F:
+        return "Cyrillic"
+    if 0x0530 <= cp <= 0x058F:
+        return "Armenian"
+    if 0x0590 <= cp <= 0x05FF:
+        return "Hebrew"
+    if 0x0600 <= cp <= 0x06FF:
+        return "Arabic"
+    if 0x3040 <= cp <= 0x309F:
+        return "Hiragana"
+    if 0x30A0 <= cp <= 0x30FF:
+        return "Katakana"
+    if 0x4E00 <= cp <= 0x9FFF:
+        return "Han"
+    if 0xAC00 <= cp <= 0xD7AF:
+        return "Hangul"
+    if 0x1D400 <= cp <= 0x1D7FF:
+        return "Math"  # Math alphanumerics — almost always confusable abuse
+    return "Other"
+
+
+def _scripts_in(name: str) -> List[str]:
+    """Distinct (non-Digit, non-_) script buckets present in the identifier."""
+    seen: List[str] = []
+    for ch in name:
+        if ch == "_":
+            continue
+        s = _codepoint_script(ch)
+        if s == "Digit":
+            continue
+        if s not in seen:
+            seen.append(s)
+    return seen
+
+
+def _has_invisible(name: str) -> Optional[str]:
+    """Return the first invisible character found, if any."""
+    for ch in name:
+        if ch in _INVISIBLE_CODEPOINTS or ch in _BIDI_CODEPOINTS:
+            return ch
+    return None
+
+
+def _is_all_confusable(name: str) -> bool:
+    """True if every non-Latin codepoint in the name is in the ASCII confusable
+    table AND the name has at least one such codepoint AND, when we replace
+    the confusables with their ASCII mimics, the result is a plain ASCII
+    identifier-shaped string.
+
+    This is the classic homoglyph attack: `аpi_key` (with Cyrillic а) that
+    looks identical to `api_key` (with Latin a) on screen.
+    """
+    has_any_confusable = False
+    rebuilt = []
+    for ch in name:
+        if ch in _ASCII_CONFUSABLES:
+            has_any_confusable = True
+            rebuilt.append(_ASCII_CONFUSABLES[ch])
+        elif ord(ch) < 128:
+            rebuilt.append(ch)
+        else:
+            # Non-confusable, non-ASCII codepoint present — not a pure
+            # ASCII-mimic attack; fall through to mixed-script handling.
+            return False
+    if not has_any_confusable:
+        return False
+    candidate = "".join(rebuilt)
+    return candidate.isidentifier()
+
+
+def _classify_identifier(name: str) -> Optional[IdentifierFinding]:
+    """Return a finding if the identifier is suspicious, else None."""
+    invisible_ch = _has_invisible(name)
+    if invisible_ch is not None:
+        return IdentifierFinding(
+            name=name,
+            kind="invisible",
+            scripts=_scripts_in(name),
+            detail=(
+                f"contains invisible/BiDi codepoint U+{ord(invisible_ch):04X}"
+            ),
+        )
+
+    # Math-alphanumeric block check — always treat as catastrophic confusable
+    if any(0x1D400 <= ord(ch) <= 0x1D7FF for ch in name):
+        return IdentifierFinding(
+            name=name,
+            kind="mixed_script",
+            scripts=_scripts_in(name),
+            detail="contains Mathematical Alphanumeric Symbol codepoint",
+        )
+
+    scripts = _scripts_in(name)
+
+    # Mixed-script: any combination of >1 distinct non-trivial scripts
+    if len(scripts) >= 2:
+        return IdentifierFinding(
+            name=name,
+            kind="mixed_script",
+            scripts=scripts,
+            detail=f"identifier mixes scripts: {scripts}",
+        )
+
+    # All-confusable single non-Latin script that mimics an ASCII identifier
+    if _is_all_confusable(name):
+        return IdentifierFinding(
+            name=name,
+            kind="confusable",
+            scripts=scripts,
+            detail=f"identifier uses only ASCII-confusable codepoints from {scripts}",
+        )
+
+    # Single non-Latin script (legitimate but worth annotating)
+    if scripts and scripts != ["Latin"]:
+        return IdentifierFinding(
+            name=name,
+            kind="non_ascii",
+            scripts=scripts,
+            detail=f"non-ASCII single-script identifier ({scripts})",
+        )
+
+    return None
+
+
+# --------------------------------------------------------------------------- #
+#  AST identifier extraction
+# --------------------------------------------------------------------------- #
+
+def _extract_identifiers_python(src: str) -> List[str]:
+    """Return all identifier strings used in the AST.
+
+    Walks every node and collects identifier-bearing fields. Order of first
+    appearance is preserved; duplicates are kept (so a repeated bad name
+    contributes proportionally to score weighting if we ever choose to).
+    """
+    tree = ast.parse(src)
+    names: List[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            names.append(node.id)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.append(node.name)
+        elif isinstance(node, ast.arg):
+            names.append(node.arg)
+        elif isinstance(node, ast.Attribute):
+            names.append(node.attr)
+        elif isinstance(node, ast.alias):
+            names.append(node.name)
+            if node.asname is not None:
+                names.append(node.asname)
+        elif isinstance(node, ast.keyword):
+            if node.arg is not None:
+                names.append(node.arg)
+        elif isinstance(node, ast.ExceptHandler):
+            if node.name is not None:
+                names.append(node.name)
+        elif isinstance(node, ast.Global):
+            names.extend(node.names)
+        elif isinstance(node, ast.Nonlocal):
+            names.extend(node.names)
+    return names
+
+
+_LANGUAGE_EXTRACTORS = {
+    "python": _extract_identifiers_python,
+}
+
+
+# --------------------------------------------------------------------------- #
+#  Public evaluate_code
+# --------------------------------------------------------------------------- #
+
+# Score table per kind — used to compute the aggregate score (max severity wins).
+_KIND_SCORE: Dict[CanonicalityKind, float] = {
+    "clean": 0.0,
+    "non_ascii": 0.30,
+    "confusable": 0.65,
+    "mixed_script": 0.90,
+    "invisible": 1.00,
+    "input_invalid": 1.00,
+}
+
+
+def evaluate_code(src: str, language: str = "python") -> CanonicalityResult:
+    """Compute the identifier-canonicality signal for a source string.
+
+    Args:
+        src: Source code to evaluate.
+        language: Currently only "python" is implemented.
+
+    Returns:
+        CanonicalityResult with score, kind, findings, and fingerprint.
+    """
+    if language not in _LANGUAGE_EXTRACTORS:
+        return CanonicalityResult(
+            score=1.0,
+            kind="input_invalid",
+            findings=[],
+            identifier_count=0,
+            fingerprint=None,
+            detail={"error": f"unsupported language: {language}"},
+        )
+
+    extractor = _LANGUAGE_EXTRACTORS[language]
+    try:
+        identifiers = extractor(src)
+    except SyntaxError as e:
+        return CanonicalityResult(
+            score=1.0,
+            kind="input_invalid",
+            findings=[],
+            identifier_count=0,
+            fingerprint=None,
+            detail={"error": f"input does not parse: {e}"},
+        )
+
+    fingerprint = hashlib.sha256(
+        "\n".join(sorted(set(identifiers))).encode("utf-8")
+    ).hexdigest()
+
+    findings: List[IdentifierFinding] = []
+    seen: set = set()
+    for ident in identifiers:
+        if ident in seen:
+            continue
+        seen.add(ident)
+        finding = _classify_identifier(ident)
+        if finding is not None:
+            findings.append(finding)
+
+    if not findings:
+        return CanonicalityResult(
+            score=0.0,
+            kind="clean",
+            findings=[],
+            identifier_count=len(seen),
+            fingerprint=fingerprint,
+        )
+
+    # Aggregate: max-severity kind wins (catastrophic findings dominate).
+    max_kind = max(findings, key=lambda f: _KIND_SCORE.get(f.kind, 0.0))
+    score = _KIND_SCORE.get(max_kind.kind, 0.5)
+    # Slight bump if multiple kinds present (more findings = more severity).
+    n_distinct = len({f.kind for f in findings})
+    if n_distinct > 1:
+        score = min(1.0, score + 0.05)
+
+    return CanonicalityResult(
+        score=score,
+        kind=max_kind.kind,
+        findings=findings,
+        identifier_count=len(seen),
+        fingerprint=fingerprint,
+        detail={"distinct_kinds": n_distinct, "total_findings": len(findings)},
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  Convenience: L13 mapping
+# --------------------------------------------------------------------------- #
+
+L13_MAPPING_RECOMMENDATION: Dict[CanonicalityKind, str] = {
+    "clean": "ALLOW",
+    "non_ascii": "ALLOW",  # log-only; could be QUARANTINE in stricter modes
+    "confusable": "QUARANTINE",
+    "mixed_script": "DENY",
+    "invisible": "DENY",
+    "input_invalid": "QUARANTINE",  # not a canonicality signal at runtime layer
+}
+
+
+def recommended_l13_action(result: CanonicalityResult) -> str:
+    """Map a CanonicalityResult to the recommended L13 action string."""
+    return L13_MAPPING_RECOMMENDATION.get(result.kind, "QUARANTINE")

--- a/src/governance/runtime_gate.py
+++ b/src/governance/runtime_gate.py
@@ -135,6 +135,21 @@ class GateResult:
     trichromatic_flagged: bool = False
     trichromatic_state_hash: str = ""
     trichromatic_strongest_bridge: str = ""
+    # Optional bijective tamper overlay (encoding-level fingerprint)
+    bijective_tamper_score: float = 0.0
+    bijective_tamper_kind: str = ""
+    bijective_tamper_action: str = ""
+    semantic_fingerprint: Optional[str] = None
+    # Optional identifier-canonicality overlay (homoglyph / mixed-script / invisible char)
+    identifier_canonicality_score: float = 0.0
+    identifier_canonicality_kind: str = ""
+    identifier_canonicality_action: str = ""
+    identifier_canonicality_fingerprint: Optional[str] = None
+    # Optional Tree of Escalation observation (compilation-driven multi-tongue read)
+    toe_terminated_as: str = ""
+    toe_tier_reached: int = 0
+    toe_provisional_minted: bool = False
+    toe_abridged_form_hex: str = ""
     # Audit
     action_hash: str = ""
     timestamp: float = 0.0
@@ -425,6 +440,12 @@ class RuntimeGate:
         trichromatic_deny_threshold: float = 0.76,
         use_council_manifold: bool = False,
         council_manifold_seeds_path: Optional[Path] = None,
+        use_bijective_tamper: Optional[bool] = None,
+        bijective_tamper_language: str = "python",
+        bijective_tamper_tokenizer_dir: Optional[Path] = None,
+        use_identifier_canonicality: Optional[bool] = None,
+        identifier_canonicality_language: str = "python",
+        use_tree_of_escalation: Optional[bool] = None,
     ):
         # Thresholds
         self.cost_allow = cost_allow
@@ -503,6 +524,44 @@ class RuntimeGate:
             except (FileNotFoundError, OSError):
                 self._council_manifold = None
                 self._council_manifold_enabled = False
+
+        # Bijective tamper overlay (encoding-level fingerprint via
+        # parse(decode(encode(src))) ≡ parse(src) substrate). Defaults to the
+        # SCBE_ENABLE_BIJECTIVE_TAMPER_GATE env var so production rollout is
+        # flag-driven without code changes; explicit constructor arg wins.
+        if use_bijective_tamper is None:
+            env_flag = os.environ.get("SCBE_ENABLE_BIJECTIVE_TAMPER_GATE", "").strip()
+            self._bijective_tamper_enabled = env_flag in ("1", "true", "TRUE", "yes", "on")
+        else:
+            self._bijective_tamper_enabled = bool(use_bijective_tamper)
+        self._bijective_tamper_language = (bijective_tamper_language or "python").lower()
+        self._bijective_tamper_tokenizer_dir = bijective_tamper_tokenizer_dir
+        self._bijective_tamper_evaluator: Optional[Callable[..., Any]] = None
+        self._bijective_tamper_action_map: Optional[Callable[[Any], str]] = None
+
+        # Identifier-canonicality overlay (sibling gate to bijective tamper).
+        # Catches homoglyph identifier attacks, mixed-script names, invisible
+        # characters in identifiers, and BiDi controls (Trojan Source class).
+        if use_identifier_canonicality is None:
+            env_flag = os.environ.get("SCBE_ENABLE_IDENTIFIER_CANONICALITY_GATE", "").strip()
+            self._identifier_canonicality_enabled = env_flag in ("1", "true", "TRUE", "yes", "on")
+        else:
+            self._identifier_canonicality_enabled = bool(use_identifier_canonicality)
+        self._identifier_canonicality_language = (identifier_canonicality_language or "python").lower()
+        self._identifier_canonicality_evaluator: Optional[Callable[..., Any]] = None
+        self._identifier_canonicality_action_map: Optional[Callable[[Any], str]] = None
+
+        # Tree of Escalation overlay (compilation-driven multi-tongue read).
+        # Observational at v1.0: populates GateResult.toe_* fields and a
+        # receipt signal but does NOT veto decisions. v1.1+ may add
+        # decision contribution once real lane-readers replace the default
+        # HashReader matrix.
+        if use_tree_of_escalation is None:
+            env_flag = os.environ.get("SCBE_ENABLE_TREE_OF_ESCALATION_GATE", "").strip()
+            self._tree_of_escalation_enabled = env_flag in ("1", "true", "TRUE", "yes", "on")
+        else:
+            self._tree_of_escalation_enabled = bool(use_tree_of_escalation)
+        self._tree_of_escalation_matrix: Optional[Any] = None
 
     @staticmethod
     def _map_council_tier(tier: str) -> "Decision":
@@ -914,6 +973,108 @@ class RuntimeGate:
         ts = time.time()
         action_hash = hashlib.blake2s(action_text.encode("utf-8", errors="replace"), digest_size=8).hexdigest()
 
+        # ---- Bijective tamper + identifier canonicality overlays (top-of-evaluate) ----
+        # Both signals are monotonic — they can only RAISE severity. We compute
+        # them once at the top so calibration / immune / reflex / reroute all see
+        # them. Catastrophic results short-circuit immediately and learn the
+        # immune entry, preventing contamination of the calibration centroid.
+        tamper_data = self._evaluate_bijective_tamper(action_text)
+        bijective_tamper_score: float = 0.0
+        bijective_tamper_kind: str = ""
+        bijective_tamper_action: str = ""
+        bijective_tamper_fingerprint: Optional[str] = None
+        tamper_decision: Optional[Decision] = None
+        if tamper_data is not None:
+            tamper_decision, bijective_tamper_kind, bijective_tamper_score, bijective_tamper_fingerprint = tamper_data
+            bijective_tamper_action = tamper_decision.value
+
+        canonicality_data = self._evaluate_identifier_canonicality(action_text)
+        identifier_canonicality_score: float = 0.0
+        identifier_canonicality_kind: str = ""
+        identifier_canonicality_action: str = ""
+        identifier_canonicality_fingerprint: Optional[str] = None
+        canonicality_decision: Optional[Decision] = None
+        if canonicality_data is not None:
+            (
+                canonicality_decision,
+                identifier_canonicality_kind,
+                identifier_canonicality_score,
+                identifier_canonicality_fingerprint,
+            ) = canonicality_data
+            identifier_canonicality_action = canonicality_decision.value
+
+        # Tree of Escalation observation (v1.0: non-vetoing — populates fields
+        # and emits a receipt signal but does not contribute to the decision).
+        toe_data = self._evaluate_tree_of_escalation(action_text)
+        toe_terminated_as: str = ""
+        toe_tier_reached: int = 0
+        toe_provisional_minted: bool = False
+        toe_abridged_form_hex: str = ""
+        if toe_data is not None:
+            (
+                toe_terminated_as,
+                toe_tier_reached,
+                toe_provisional_minted,
+                toe_abridged_form_hex,
+            ) = toe_data
+
+        # Catastrophic short-circuit: either overlay recommending DENY ends here.
+        if (tamper_decision == Decision.DENY) or (canonicality_decision == Decision.DENY):
+            self._immune.add(action_hash)
+            signals_short: List[str] = []
+            if tamper_data is not None:
+                signals_short.append(
+                    self._tamper_receipt_signal(
+                        bijective_tamper_kind,
+                        bijective_tamper_score,
+                        bijective_tamper_action,
+                        bijective_tamper_fingerprint,
+                    )
+                )
+            if canonicality_data is not None:
+                signals_short.append(
+                    self._canonicality_receipt_signal(
+                        identifier_canonicality_kind,
+                        identifier_canonicality_score,
+                        identifier_canonicality_action,
+                        identifier_canonicality_fingerprint,
+                    )
+                )
+            if tamper_decision == Decision.DENY:
+                signals_short.append(
+                    f"bijective_tamper_veto_deny(kind={bijective_tamper_kind},score={bijective_tamper_score:.2f})"
+                )
+            if canonicality_decision == Decision.DENY:
+                signals_short.append(
+                    f"identifier_canonicality_veto_deny(kind={identifier_canonicality_kind},score={identifier_canonicality_score:.2f})"  # noqa: E501
+                )
+            result = GateResult(
+                decision=Decision.DENY,
+                cost=float("inf"),
+                spin_magnitude=6,
+                tongue_coords=[0.0] * 6,
+                signals=signals_short,
+                noise=_fail_to_noise(action_hash),
+                bijective_tamper_score=bijective_tamper_score,
+                bijective_tamper_kind=bijective_tamper_kind,
+                bijective_tamper_action=bijective_tamper_action,
+                semantic_fingerprint=bijective_tamper_fingerprint,
+                identifier_canonicality_score=identifier_canonicality_score,
+                identifier_canonicality_kind=identifier_canonicality_kind,
+                identifier_canonicality_action=identifier_canonicality_action,
+                identifier_canonicality_fingerprint=identifier_canonicality_fingerprint,
+                toe_terminated_as=toe_terminated_as,
+                toe_tier_reached=toe_tier_reached,
+                toe_provisional_minted=toe_provisional_minted,
+                toe_abridged_form_hex=toe_abridged_form_hex,
+                action_hash=action_hash,
+                timestamp=ts,
+                session_query_count=self._query_count,
+                cumulative_cost=self._cumulative_cost,
+            )
+            self._audit_log.append(result)
+            return result
+
         # ---- Fast paths (O(1)) ----
 
         full_text = f"{tool_name} {action_text}" if tool_name else action_text
@@ -974,12 +1135,45 @@ class RuntimeGate:
             self._cumulative_cost += 1.0  # nominal cost during calibration
             self._trust_history.append(1)  # calibration = +1 trust
             fib = fibonacci_trust_level(self._trust_history)
+            calib_signals = ["calibrating"]
+            calib_decision = Decision.ALLOW
+            if tamper_data is not None:
+                calib_signals.append(
+                    self._tamper_receipt_signal(
+                        bijective_tamper_kind,
+                        bijective_tamper_score,
+                        bijective_tamper_action,
+                        bijective_tamper_fingerprint,
+                    )
+                )
+                # tamper_decision is at most QUARANTINE here (DENY short-circuited above)
+                escalated = _escalate_decision(calib_decision, tamper_decision or Decision.ALLOW)
+                if escalated == Decision.QUARANTINE:
+                    calib_signals.append(
+                        f"bijective_tamper_veto_quarantine(kind={bijective_tamper_kind},score={bijective_tamper_score:.2f})"  # noqa: E501
+                    )
+                calib_decision = escalated
+            if canonicality_data is not None:
+                calib_signals.append(
+                    self._canonicality_receipt_signal(
+                        identifier_canonicality_kind,
+                        identifier_canonicality_score,
+                        identifier_canonicality_action,
+                        identifier_canonicality_fingerprint,
+                    )
+                )
+                escalated = _escalate_decision(calib_decision, canonicality_decision or Decision.ALLOW)
+                if escalated == Decision.QUARANTINE:
+                    calib_signals.append(
+                        f"identifier_canonicality_veto_quarantine(kind={identifier_canonicality_kind},score={identifier_canonicality_score:.2f})"  # noqa: E501
+                    )
+                calib_decision = escalated
             result = GateResult(
-                decision=Decision.ALLOW,
+                decision=calib_decision,
                 cost=1.0,
                 spin_magnitude=0,
                 tongue_coords=coords,
-                signals=["calibrating"],
+                signals=calib_signals,
                 trust_weight=fib["weight"],
                 trust_level=fib["level"],
                 trust_index=fib["index"],
@@ -989,6 +1183,18 @@ class RuntimeGate:
                 trichromatic_risk_score=trichromatic_risk,
                 trichromatic_state_hash=trichromatic_state_hash,
                 trichromatic_strongest_bridge=trichromatic_strongest_bridge,
+                bijective_tamper_score=bijective_tamper_score,
+                bijective_tamper_kind=bijective_tamper_kind,
+                bijective_tamper_action=bijective_tamper_action,
+                semantic_fingerprint=bijective_tamper_fingerprint,
+                identifier_canonicality_score=identifier_canonicality_score,
+                identifier_canonicality_kind=identifier_canonicality_kind,
+                identifier_canonicality_action=identifier_canonicality_action,
+                identifier_canonicality_fingerprint=identifier_canonicality_fingerprint,
+                toe_terminated_as=toe_terminated_as,
+                toe_tier_reached=toe_tier_reached,
+                toe_provisional_minted=toe_provisional_minted,
+                toe_abridged_form_hex=toe_abridged_form_hex,
                 action_hash=action_hash,
                 timestamp=ts,
                 session_query_count=self._query_count,
@@ -999,13 +1205,44 @@ class RuntimeGate:
 
         # Immune memory: known attack → instant DENY + noise
         if action_hash in self._immune:
+            immune_signals = ["immune_memory_hit"]
+            if tamper_data is not None:
+                immune_signals.append(
+                    self._tamper_receipt_signal(
+                        bijective_tamper_kind,
+                        bijective_tamper_score,
+                        bijective_tamper_action,
+                        bijective_tamper_fingerprint,
+                    )
+                )
+            if canonicality_data is not None:
+                immune_signals.append(
+                    self._canonicality_receipt_signal(
+                        identifier_canonicality_kind,
+                        identifier_canonicality_score,
+                        identifier_canonicality_action,
+                        identifier_canonicality_fingerprint,
+                    )
+                )
             result = GateResult(
                 decision=Decision.DENY,
                 cost=float("inf"),
                 spin_magnitude=6,
                 tongue_coords=[0.0] * 6,
-                signals=["immune_memory_hit"],
+                signals=immune_signals,
                 noise=_fail_to_noise(action_hash),
+                bijective_tamper_score=bijective_tamper_score,
+                bijective_tamper_kind=bijective_tamper_kind,
+                bijective_tamper_action=bijective_tamper_action,
+                semantic_fingerprint=bijective_tamper_fingerprint,
+                identifier_canonicality_score=identifier_canonicality_score,
+                identifier_canonicality_kind=identifier_canonicality_kind,
+                identifier_canonicality_action=identifier_canonicality_action,
+                identifier_canonicality_fingerprint=identifier_canonicality_fingerprint,
+                toe_terminated_as=toe_terminated_as,
+                toe_tier_reached=toe_tier_reached,
+                toe_provisional_minted=toe_provisional_minted,
+                toe_abridged_form_hex=toe_abridged_form_hex,
                 action_hash=action_hash,
                 timestamp=ts,
                 session_query_count=self._query_count,
@@ -1018,15 +1255,59 @@ class RuntimeGate:
         if action_hash in self._reflex and not classifier_quarantine:
             self._trust_history.append(1)  # known-safe = +1 trust
             fib = fibonacci_trust_level(self._trust_history)
+            reflex_signals = ["reflex_hit"]
+            reflex_decision = Decision.ALLOW
+            if tamper_data is not None:
+                reflex_signals.append(
+                    self._tamper_receipt_signal(
+                        bijective_tamper_kind,
+                        bijective_tamper_score,
+                        bijective_tamper_action,
+                        bijective_tamper_fingerprint,
+                    )
+                )
+                escalated = _escalate_decision(reflex_decision, tamper_decision or Decision.ALLOW)
+                if escalated == Decision.QUARANTINE:
+                    reflex_signals.append(
+                        f"bijective_tamper_veto_quarantine(kind={bijective_tamper_kind},score={bijective_tamper_score:.2f})"  # noqa: E501
+                    )
+                reflex_decision = escalated
+            if canonicality_data is not None:
+                reflex_signals.append(
+                    self._canonicality_receipt_signal(
+                        identifier_canonicality_kind,
+                        identifier_canonicality_score,
+                        identifier_canonicality_action,
+                        identifier_canonicality_fingerprint,
+                    )
+                )
+                escalated = _escalate_decision(reflex_decision, canonicality_decision or Decision.ALLOW)
+                if escalated == Decision.QUARANTINE:
+                    reflex_signals.append(
+                        f"identifier_canonicality_veto_quarantine(kind={identifier_canonicality_kind},score={identifier_canonicality_score:.2f})"  # noqa: E501
+                    )
+                reflex_decision = escalated
             result = GateResult(
-                decision=Decision.ALLOW,
+                decision=reflex_decision,
                 cost=1.0,
                 spin_magnitude=0,
                 tongue_coords=[0.5] * 6,
-                signals=["reflex_hit"],
+                signals=reflex_signals,
                 trust_weight=fib["weight"],
                 trust_level=fib["level"],
                 trust_index=fib["index"],
+                bijective_tamper_score=bijective_tamper_score,
+                bijective_tamper_kind=bijective_tamper_kind,
+                bijective_tamper_action=bijective_tamper_action,
+                semantic_fingerprint=bijective_tamper_fingerprint,
+                identifier_canonicality_score=identifier_canonicality_score,
+                identifier_canonicality_kind=identifier_canonicality_kind,
+                identifier_canonicality_action=identifier_canonicality_action,
+                identifier_canonicality_fingerprint=identifier_canonicality_fingerprint,
+                toe_terminated_as=toe_terminated_as,
+                toe_tier_reached=toe_tier_reached,
+                toe_provisional_minted=toe_provisional_minted,
+                toe_abridged_form_hex=toe_abridged_form_hex,
                 action_hash=action_hash,
                 timestamp=ts,
                 session_query_count=self._query_count,
@@ -1103,6 +1384,24 @@ class RuntimeGate:
             else:
                 reroute_signals.append("semantic_confirmed")
             fib_trust = fibonacci_trust_level(self._trust_history)
+            if tamper_data is not None:
+                reroute_signals.append(
+                    self._tamper_receipt_signal(
+                        bijective_tamper_kind,
+                        bijective_tamper_score,
+                        bijective_tamper_action,
+                        bijective_tamper_fingerprint,
+                    )
+                )
+            if canonicality_data is not None:
+                reroute_signals.append(
+                    self._canonicality_receipt_signal(
+                        identifier_canonicality_kind,
+                        identifier_canonicality_score,
+                        identifier_canonicality_action,
+                        identifier_canonicality_fingerprint,
+                    )
+                )
             result = GateResult(
                 decision=Decision.REROUTE,
                 cost=cost,
@@ -1110,6 +1409,18 @@ class RuntimeGate:
                 tongue_coords=coords,
                 signals=reroute_signals,
                 reroute_to=reroute_rule.replacement,
+                bijective_tamper_score=bijective_tamper_score,
+                bijective_tamper_kind=bijective_tamper_kind,
+                bijective_tamper_action=bijective_tamper_action,
+                semantic_fingerprint=bijective_tamper_fingerprint,
+                identifier_canonicality_score=identifier_canonicality_score,
+                identifier_canonicality_kind=identifier_canonicality_kind,
+                identifier_canonicality_action=identifier_canonicality_action,
+                identifier_canonicality_fingerprint=identifier_canonicality_fingerprint,
+                toe_terminated_as=toe_terminated_as,
+                toe_tier_reached=toe_tier_reached,
+                toe_provisional_minted=toe_provisional_minted,
+                toe_abridged_form_hex=toe_abridged_form_hex,
                 action_hash=action_hash,
                 timestamp=ts,
                 session_query_count=self._query_count,
@@ -1288,6 +1599,63 @@ class RuntimeGate:
             if decision == Decision.ALLOW and self._trichromatic_engine is not None:
                 self._trichromatic_engine.update_baseline(tri_state)
 
+        # Bijective tamper + identifier canonicality overlays — receipt +
+        # monotonic escalation. Both were computed once at the top of evaluate();
+        # catastrophic DENY-recommended cases short-circuited there, so by the
+        # time we reach here neither overlay can recommend DENY. We still emit
+        # the receipt and apply QUARANTINE-or-REVIEW escalation so audit +
+        # governance see the signal.
+        if decision != Decision.REROUTE:
+            if tamper_data is not None:
+                signals.append(
+                    self._tamper_receipt_signal(
+                        bijective_tamper_kind,
+                        bijective_tamper_score,
+                        bijective_tamper_action,
+                        bijective_tamper_fingerprint,
+                    )
+                )
+                escalated = _escalate_decision(decision, tamper_decision or Decision.ALLOW)
+                if escalated != decision:
+                    if escalated == Decision.QUARANTINE:
+                        signals.append(
+                            f"bijective_tamper_veto_quarantine(kind={bijective_tamper_kind},score={bijective_tamper_score:.2f})"  # noqa: E501  # noqa: E501
+                        )
+                    elif escalated == Decision.REVIEW:
+                        signals.append(
+                            f"bijective_tamper_veto_review(kind={bijective_tamper_kind},score={bijective_tamper_score:.2f})"  # noqa: E501
+                        )
+                    decision = escalated
+            if canonicality_data is not None:
+                signals.append(
+                    self._canonicality_receipt_signal(
+                        identifier_canonicality_kind,
+                        identifier_canonicality_score,
+                        identifier_canonicality_action,
+                        identifier_canonicality_fingerprint,
+                    )
+                )
+                escalated = _escalate_decision(decision, canonicality_decision or Decision.ALLOW)
+                if escalated != decision:
+                    if escalated == Decision.QUARANTINE:
+                        signals.append(
+                            f"identifier_canonicality_veto_quarantine(kind={identifier_canonicality_kind},score={identifier_canonicality_score:.2f})"  # noqa: E501
+                        )
+                    elif escalated == Decision.REVIEW:
+                        signals.append(
+                            f"identifier_canonicality_veto_review(kind={identifier_canonicality_kind},score={identifier_canonicality_score:.2f})"  # noqa: E501
+                        )
+                    decision = escalated
+            if toe_data is not None:
+                signals.append(
+                    self._toe_receipt_signal(
+                        toe_terminated_as,
+                        toe_tier_reached,
+                        toe_provisional_minted,
+                        toe_abridged_form_hex,
+                    )
+                )
+
         # Clean → learn as safe reflex (fast-path for future)
         if decision == Decision.ALLOW and not any("council" in s for s in signals):
             self._reflex[action_hash] = True
@@ -1312,6 +1680,18 @@ class RuntimeGate:
             trichromatic_flagged=trichromatic_flagged,
             trichromatic_state_hash=trichromatic_state_hash,
             trichromatic_strongest_bridge=trichromatic_strongest_bridge,
+            bijective_tamper_score=bijective_tamper_score,
+            bijective_tamper_kind=bijective_tamper_kind,
+            bijective_tamper_action=bijective_tamper_action,
+            semantic_fingerprint=bijective_tamper_fingerprint,
+            identifier_canonicality_score=identifier_canonicality_score,
+            identifier_canonicality_kind=identifier_canonicality_kind,
+            identifier_canonicality_action=identifier_canonicality_action,
+            identifier_canonicality_fingerprint=identifier_canonicality_fingerprint,
+            toe_terminated_as=toe_terminated_as,
+            toe_tier_reached=toe_tier_reached,
+            toe_provisional_minted=toe_provisional_minted,
+            toe_abridged_form_hex=toe_abridged_form_hex,
             action_hash=action_hash,
             timestamp=ts,
             session_query_count=self._query_count,
@@ -1319,6 +1699,273 @@ class RuntimeGate:
         )
         self._audit_log.append(result)
         return result
+
+    # ------------------------------------------------------------------ #
+    #  Bijective tamper overlay (encoding-level fingerprint)
+    # ------------------------------------------------------------------ #
+
+    # Cheap heuristic: only ~plausible code triggers the AST/tokenizer pipeline.
+    # The tamper signal only makes sense when action_text IS source code; for
+    # plain prose this would just consume cycles to produce kind="input_invalid".
+    # We require TWO independent code signals to fire — a structural-keyword
+    # AND a syntax-token in the first 512 chars — because single-keyword
+    # substring matches catch prose like "write a function that sorts" or
+    # "import duty applies", which would otherwise false-positive into the
+    # parser pipeline and look like tampering.
+    _CODE_HEURISTIC_KEYWORDS = (
+        "def ",
+        "class ",
+        "import ",
+        "from ",
+        "return ",
+        "lambda ",
+        "async def ",
+        "function ",
+        "fn ",
+    )
+    _CODE_HEURISTIC_SYNTAX_TOKENS = (
+        "):",
+        "->",
+        "=>",
+        "{\n",
+        "};",
+        "==",
+        "!=",
+        "self.",
+        ":\n",
+        "):\n",
+    )
+
+    def _looks_like_code(self, text: str) -> bool:
+        if not text or len(text) < 4:
+            return False
+        head = text.lstrip()[:512]
+        has_keyword = any(pat in head for pat in self._CODE_HEURISTIC_KEYWORDS)
+        if not has_keyword:
+            return False
+        has_syntax = any(tok in head for tok in self._CODE_HEURISTIC_SYNTAX_TOKENS)
+        return has_syntax
+
+    def _ensure_bijective_tamper(self) -> bool:
+        """Lazy-load the tamper evaluator. Returns True if usable."""
+        if self._bijective_tamper_evaluator is not None:
+            return True
+        try:
+            from .bijective_tamper import (  # type: ignore[import-not-found]
+                evaluate_code,
+                recommended_l13_action,
+            )
+
+            self._bijective_tamper_evaluator = evaluate_code
+            self._bijective_tamper_action_map = recommended_l13_action
+            return True
+        except Exception:
+            self._bijective_tamper_evaluator = None
+            self._bijective_tamper_action_map = None
+            return False
+
+    def _tamper_receipt_signal(
+        self,
+        kind: str,
+        score: float,
+        action: str,
+        fingerprint: Optional[str],
+    ) -> str:
+        """Format the receipt envelope appended to GateResult.signals."""
+        return (
+            "bijective_tamper("
+            f"kind={kind},"
+            f"score={score:.3f},"
+            f"action={action}" + (f",fp={fingerprint[:12]}" if fingerprint else "") + ")"
+        )
+
+    def _evaluate_bijective_tamper(self, action_text: str) -> Optional[Tuple[Decision, str, float, Optional[str]]]:
+        """Run the bijective tamper signal. Returns None if skipped or unavailable.
+
+        Return tuple: (recommended_decision, kind, score, semantic_fingerprint)
+        """
+        if not self._bijective_tamper_enabled:
+            return None
+        if not self._looks_like_code(action_text):
+            return None
+        if not self._ensure_bijective_tamper():
+            return None
+
+        try:
+            assert self._bijective_tamper_evaluator is not None
+            assert self._bijective_tamper_action_map is not None
+            kwargs: Dict[str, Any] = {"language": self._bijective_tamper_language}
+            if self._bijective_tamper_tokenizer_dir is not None:
+                kwargs["tokenizer_dir"] = self._bijective_tamper_tokenizer_dir
+            result = self._bijective_tamper_evaluator(action_text, **kwargs)
+            action_str = self._bijective_tamper_action_map(result)
+        except Exception:
+            # Fail closed-to-noop: a tamper-overlay crash must never kill the gate.
+            return None
+
+        # input_invalid is NOT a tamper signal at this layer — it just means
+        # the action_text did not parse as the configured language. Prose
+        # actions and natural-language tool descriptions routinely fall here.
+        # Catastrophic encoding-level tamper is signaled by kind="syntax"
+        # (the original parsed but the decoded form did not). Skip the rest.
+        if str(result.kind) == "input_invalid":
+            return None
+
+        recommended = {
+            "ALLOW": Decision.ALLOW,
+            "QUARANTINE": Decision.QUARANTINE,
+            "DENY": Decision.DENY,
+            "REROUTE": Decision.REROUTE,
+            "REVIEW": Decision.REVIEW,
+        }.get(action_str, Decision.QUARANTINE)
+        return recommended, str(result.kind), float(result.score), result.semantic_fingerprint
+
+    # ------------------------------------------------------------------ #
+    #  Identifier canonicality overlay (sibling to bijective tamper)
+    # ------------------------------------------------------------------ #
+
+    def _ensure_identifier_canonicality(self) -> bool:
+        if self._identifier_canonicality_evaluator is not None:
+            return True
+        try:
+            from .identifier_canonicality import (  # type: ignore[import-not-found]
+                evaluate_code as _ic_eval,
+                recommended_l13_action as _ic_action,
+            )
+
+            self._identifier_canonicality_evaluator = _ic_eval
+            self._identifier_canonicality_action_map = _ic_action
+            return True
+        except Exception:
+            self._identifier_canonicality_evaluator = None
+            self._identifier_canonicality_action_map = None
+            return False
+
+    def _evaluate_identifier_canonicality(
+        self, action_text: str
+    ) -> Optional[Tuple[Decision, str, float, Optional[str]]]:
+        """Run the identifier-canonicality signal. Returns None if skipped."""
+        if not self._identifier_canonicality_enabled:
+            return None
+        if not self._looks_like_code(action_text):
+            return None
+        if not self._ensure_identifier_canonicality():
+            return None
+
+        try:
+            assert self._identifier_canonicality_evaluator is not None
+            assert self._identifier_canonicality_action_map is not None
+            result = self._identifier_canonicality_evaluator(
+                action_text, language=self._identifier_canonicality_language
+            )
+            action_str = self._identifier_canonicality_action_map(result)
+        except Exception:
+            return None
+
+        # Same policy as bijective tamper: input_invalid is not a canonicality
+        # signal at this layer (just means the parser couldn't read it).
+        if str(result.kind) == "input_invalid":
+            return None
+
+        recommended = {
+            "ALLOW": Decision.ALLOW,
+            "QUARANTINE": Decision.QUARANTINE,
+            "DENY": Decision.DENY,
+            "REROUTE": Decision.REROUTE,
+            "REVIEW": Decision.REVIEW,
+        }.get(action_str, Decision.QUARANTINE)
+        return recommended, str(result.kind), float(result.score), result.fingerprint
+
+    def _canonicality_receipt_signal(
+        self,
+        kind: str,
+        score: float,
+        action: str,
+        fingerprint: Optional[str],
+    ) -> str:
+        return (
+            "identifier_canonicality("
+            f"kind={kind},"
+            f"score={score:.3f},"
+            f"action={action}" + (f",fp={fingerprint[:12]}" if fingerprint else "") + ")"
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Tree of Escalation overlay (compilation-driven multi-tongue read)
+    #
+    #  v1.0 wire-up is OBSERVATIONAL ONLY: populates GateResult.toe_*
+    #  fields and emits a receipt signal but does NOT veto decisions.
+    #  Production deployments wanting decision contribution must wait
+    #  for v1.1, after real lane-readers replace the default HashReader
+    #  matrix.
+    # ------------------------------------------------------------------ #
+
+    def _ensure_tree_of_escalation_matrix(self) -> bool:
+        """Lazy-build a default BridgeMatrix with HashReader for all six lanes."""
+        if self._tree_of_escalation_matrix is not None:
+            return True
+        try:
+            from .tree_of_escalation import (  # type: ignore[import-not-found]
+                DEFAULT_LADDER as _toe_ladder,
+                BridgeMatrix as _ToeBridgeMatrix,
+                HashReader as _ToeHashReader,
+            )
+
+            matrix = _ToeBridgeMatrix()
+            for lane in _toe_ladder:
+                matrix.register_reader(lane, _ToeHashReader(lane=lane))
+            self._tree_of_escalation_matrix = matrix
+            return True
+        except Exception:
+            self._tree_of_escalation_matrix = None
+            return False
+
+    def _evaluate_tree_of_escalation(self, action_text: str) -> Optional[Tuple[str, int, bool, str]]:
+        """Run a ToE walk on the action_text bytes. Returns None if skipped.
+
+        Returns: (terminated_as, tier_reached, provisional_minted, abridged_form_hex).
+        Observational only at v1.0 — no Decision is returned because no
+        veto is contributed.
+        """
+        if not self._tree_of_escalation_enabled:
+            return None
+        if not self._ensure_tree_of_escalation_matrix():
+            return None
+
+        try:
+            from .tree_of_escalation import walk as _toe_walk  # type: ignore[import-not-found]
+
+            tree = _toe_walk(
+                action_text.encode("utf-8", errors="replace"),
+                self._tree_of_escalation_matrix,
+            )
+        except Exception:
+            return None
+
+        terminated_as = tree.terminated_as.value if hasattr(tree.terminated_as, "value") else str(tree.terminated_as)
+        abridged_hex = tree.abridged_form.hex() if tree.abridged_form else ""
+        return (
+            terminated_as,
+            int(tree.tier_reached),
+            bool(tree.provisional_minted),
+            abridged_hex,
+        )
+
+    def _toe_receipt_signal(
+        self,
+        terminated_as: str,
+        tier_reached: int,
+        provisional_minted: bool,
+        abridged_form_hex: str,
+    ) -> str:
+        return (
+            "tree_of_escalation("
+            f"terminated_as={terminated_as},"
+            f"tier={tier_reached},"
+            f"provisional={int(provisional_minted)}"
+            + (f",abridged={abridged_form_hex[:12]}" if abridged_form_hex else "")
+            + ")"
+        )
 
     # ------------------------------------------------------------------ #
     #  Session management

--- a/src/governance/tree_of_escalation.py
+++ b/src/governance/tree_of_escalation.py
@@ -1,0 +1,1167 @@
+"""Tree of Escalation v0.5 — compilation-driven multi-tongue escalation.
+
+v0.1: data structures (Lane, Band, Posture, NodeKind, Node, BridgeEdge,
+LanePair, VoidStats, Tree, NULL_BRIDGE_VOID_ID).
+v0.2: bridge matrix + walker (BridgeMatrix, Reader protocol, OpTrace,
+HashReader reference, walk()). Bicameral read with majority-convergence,
+bit-depth escalation across DEFAULT_LADDER.
+v0.3: sandbox loop (Flag, MoralPrior protocol, IdentityPrior,
+IsolationPrior, sandbox()) and input-shape adversarial pair selection
+(classify_domain, select_initial_pair).
+v0.4: termination posture switch — HUMBLE mints a deterministic
+provisional from observed streams; RIGID returns abridged_form=None
+with a refusal_reason. ProvisionalRegistry tracks corroboration with
+a deterministic call-counter decay policy.
+v0.5: L14 audio emission adapter (AudioEvent, TreeAudioEmission,
+emit_audio). Each node renders to an audio event with frequency from
+tri_bundle.TONGUE_FREQUENCIES; the three Bands map to a tri-octave
+signature (INFRA = -2 octaves, AUDIBLE = fundamental, ULTRA = +2
+octaves). Synthesis itself is left to downstream consumers.
+
+The structures here implement the locked architectural decisions:
+
+  - Six Sacred Tongue lanes (Kor'aelin, Avali, Runethic, Cassisivadan,
+    Umbroth, Draumric) plus a CUSTOM slot for pluggable substrates.
+  - Three concurrent bands per lane (INFRA / AUDIBLE / ULTRA).
+  - Adversarial lane-pair selection (Primary Resolver + Adversarial
+    Reader, chosen by input domain).
+  - NULL-bridge serialization as edge-property AND singleton sink:
+    per-failure metadata on the edge, aggregate stats on the void node.
+  - Posture switch (HUMBLE mints provisional, RIGID refuses) for
+    novel-truth termination.
+
+Composes with: ``bijective_tamper.py``, ``identifier_canonicality.py``,
+``src/symphonic/audio/tri_bundle.py``, and the seed bridge matrix at
+``artifacts/cross_language_lookup/``.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import math
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Protocol, Sequence, Tuple
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+NULL_BRIDGE_VOID_ID: int = 0
+"""Canonical id of the singleton sink node for untranslatable bridges.
+
+Per-failure metadata lives on the edges that point here, NOT on this
+node. This node carries aggregate stats only.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Lane — the six Sacred Tongue readers (plus a pluggable slot)
+# --------------------------------------------------------------------------- #
+
+
+class Lane(str, enum.Enum):
+    """Reader identifier. Six tongues plus a CUSTOM slot for pluggability.
+
+    Order matches the phi-weighted bit-depth ladder T1..T6.
+    """
+
+    KORAELIN = "koraelin"  # T1, Python-spirit
+    AVALI = "avali"  # T2, JavaScript-spirit
+    RUNETHIC = "runethic"  # T3, Rust-spirit
+    CASSISIVADAN = "cassisivadan"  # T4, Mathematica-spirit
+    UMBROTH = "umbroth"  # T5, Haskell-spirit
+    DRAUMRIC = "draumric"  # T6, Markdown-spirit
+    CUSTOM = "custom"  # Pluggable substrate; not in default ladder
+
+
+LANE_PHI_WEIGHT: Dict[Lane, float] = {
+    Lane.KORAELIN: 1.00,
+    Lane.AVALI: 1.62,
+    Lane.RUNETHIC: 2.62,
+    Lane.CASSISIVADAN: 4.24,
+    Lane.UMBROTH: 6.85,
+    Lane.DRAUMRIC: 11.09,
+}
+"""Phi-scaled weights per tongue. CUSTOM intentionally omitted — its
+weight is set per-instance by whoever registers the substrate.
+"""
+
+
+LANE_TIER: Dict[Lane, int] = {
+    Lane.KORAELIN: 1,
+    Lane.AVALI: 2,
+    Lane.RUNETHIC: 3,
+    Lane.CASSISIVADAN: 4,
+    Lane.UMBROTH: 5,
+    Lane.DRAUMRIC: 6,
+}
+"""Bit-depth tier per lane. CUSTOM omitted; pluggable substrates
+declare their own tier at registration time.
+"""
+
+
+DEFAULT_LADDER: Tuple[Lane, ...] = (
+    Lane.KORAELIN,
+    Lane.AVALI,
+    Lane.RUNETHIC,
+    Lane.CASSISIVADAN,
+    Lane.UMBROTH,
+    Lane.DRAUMRIC,
+)
+"""Canonical phi-weighted escalation order. v0.2+ walker climbs this."""
+
+
+# --------------------------------------------------------------------------- #
+# Band — concurrent state-of-knowledge marker (NOT a tier)
+# --------------------------------------------------------------------------- #
+
+
+class Band(str, enum.Enum):
+    INFRA = "infra"  # Pre-computed deterministic atoms (cache, lookup)
+    AUDIBLE = "audible"  # Live execution trace
+    ULTRA = "ultra"  # Speculative continuations (predicted next ops)
+
+
+# --------------------------------------------------------------------------- #
+# Posture — termination behavior on T6 exhaustion
+# --------------------------------------------------------------------------- #
+
+
+class Posture(str, enum.Enum):
+    HUMBLE = "humble"  # Mint a provisional abridged form, file for revisit
+    RIGID = "rigid"  # Refuse to compile; return NULL with reason
+
+
+class Termination(str, enum.Enum):
+    """How the walker exited.
+
+    INCOMPLETE is the initial state on a fresh Tree before walk() runs.
+    Real termination values are set by walk() before return.
+    """
+
+    INCOMPLETE = "incomplete"  # Walk did not run (initial state)
+    ABRIDGED = "abridged"  # Strict majority converged
+    PROVISIONAL = "provisional"  # HUMBLE mint on T6 exhaustion (v0.4)
+    REFUSED = "refused"  # RIGID refusal on T6 exhaustion (v0.4)
+
+
+# --------------------------------------------------------------------------- #
+# NodeKind — categorizes nodes in the tree
+# --------------------------------------------------------------------------- #
+
+
+class NodeKind(str, enum.Enum):
+    OP = "op"  # Atomic op trace from a lane
+    SANDBOX_PROVISIONAL = "sandbox_provisional"  # Flagged-input provisional ingest
+    SANDBOX_INSPECTION = "sandbox_inspection"  # Inspect-under-priors output
+    SANDBOX_INTERNALIZED = "sandbox_internalized"  # Own-interpretation node
+    NULL_BRIDGE_VOID = "null_bridge_void"  # Singleton sink for null bridges
+    PROVISIONAL_MINT = "provisional_mint"  # Humble-posture termination
+
+
+# --------------------------------------------------------------------------- #
+# Hashing
+# --------------------------------------------------------------------------- #
+
+
+def hash_payload(data: bytes) -> bytes:
+    """SHA-256 of a payload. Returns the raw 32-byte digest."""
+    return hashlib.sha256(data).digest()
+
+
+# --------------------------------------------------------------------------- #
+# Node
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Node:
+    """A node in the escalation tree.
+
+    Most nodes are OP traces from a lane. Special node kinds (sandbox,
+    void, provisional) carry kind-specific information in ``payload``.
+    The ``lane`` and ``band`` fields are None for non-OP nodes.
+    """
+
+    id: int
+    kind: NodeKind
+    lane: Optional[Lane] = None
+    band: Optional[Band] = None
+    op_id: Optional[str] = None
+    args_hash: Optional[bytes] = None
+    result_hash: Optional[bytes] = None
+    source: str = ""
+    payload: Dict[str, object] = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------- #
+# BridgeEdge — directed edge between nodes
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class BridgeEdge:
+    """Directed edge representing one step of the bridge matrix M.
+
+    For successful bridges (M[i,j](op) is not None):
+        is_untranslatable=False, information_variance carries the
+        statistical disagreement delta between source and target.
+
+    For NULL bridges:
+        is_untranslatable=True, target_id=NULL_BRIDGE_VOID_ID,
+        untranslatable_reason and untranslatable_op_id record the
+        per-failure metadata.
+    """
+
+    source_id: int
+    target_id: int
+    is_untranslatable: bool = False
+    information_variance: float = 0.0
+    untranslatable_reason: Optional[str] = None
+    untranslatable_op_id: Optional[str] = None
+
+
+# --------------------------------------------------------------------------- #
+# LanePair — adversarial pairing (resolved Q5)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class LanePair:
+    """Initial-read pair selected by input-shape adversarial pairing.
+
+    primary: lane with highest historical capability in this domain.
+    adversary: lane with highest historical disagreement delta against
+               primary in the same domain.
+    domain: the classified input domain that drove the selection
+            (audit field; not used by the walker, only by replay).
+    """
+
+    primary: Lane
+    adversary: Lane
+    domain: str = ""
+
+    def __post_init__(self) -> None:
+        if self.primary == self.adversary:
+            raise ValueError(f"LanePair primary and adversary must differ; got {self.primary}")
+
+
+# --------------------------------------------------------------------------- #
+# VoidStats — aggregate stats carried by the singleton sink node
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class VoidStats:
+    """Aggregate statistics on the singleton NULL_BRIDGE_VOID node.
+
+    Per-failure metadata lives on the edges, NOT here. This node holds
+    rollups for queryable audit.
+    """
+
+    incoming_edge_count: int = 0
+    distinct_ops_failed: int = 0
+    failures_by_lane_pair: Dict[Tuple[Lane, Lane], int] = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------- #
+# Tree
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Tree:
+    """The escalation tree. One per call.
+
+    On construction, the singleton VOID sink is inserted at index
+    ``NULL_BRIDGE_VOID_ID`` (always the first node). All real nodes are
+    appended after it; their ids are their index in ``nodes``.
+
+    NO EXECUTION LOGIC. The walker, sandbox loop, and provisional-mint
+    behavior live in v0.2+.
+    """
+
+    nodes: List[Node] = field(default_factory=list)
+    edges: List[BridgeEdge] = field(default_factory=list)
+    lane_pair: Optional[LanePair] = None
+    posture: Posture = Posture.HUMBLE
+    tier_reached: int = 0
+    void_stats: VoidStats = field(default_factory=VoidStats)
+    abridged_form: Optional[bytes] = None
+    sandbox_invoked: bool = False
+    provisional_minted: bool = False
+    terminated_as: Termination = Termination.INCOMPLETE
+    refusal_reason: str = ""
+    provisional_corroboration_count: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.nodes:
+            self.nodes.append(
+                Node(
+                    id=NULL_BRIDGE_VOID_ID,
+                    kind=NodeKind.NULL_BRIDGE_VOID,
+                    source="tree_init",
+                )
+            )
+
+    def add_node(self, node: Node) -> int:
+        """Append a node. Caller must set ``node.id`` to the next index."""
+        if node.id != len(self.nodes):
+            raise ValueError(f"node id {node.id} != insertion index {len(self.nodes)}")
+        self.nodes.append(node)
+        return node.id
+
+    def add_edge(self, edge: BridgeEdge) -> None:
+        """Append an edge. NULL-bridge edges update void_stats automatically.
+
+        ``distinct_ops_failed`` is recomputed from scratch each time so
+        cross-edge dedup is correct.
+        """
+        if (
+            edge.target_id < 0
+            or edge.target_id >= len(self.nodes)
+            or edge.source_id < 0
+            or edge.source_id >= len(self.nodes)
+        ):
+            raise ValueError(f"edge endpoints out of range: {edge.source_id} -> {edge.target_id}")
+        if edge.is_untranslatable and edge.target_id != NULL_BRIDGE_VOID_ID:
+            raise ValueError("untranslatable edges must terminate at NULL_BRIDGE_VOID_ID")
+        self.edges.append(edge)
+        if edge.is_untranslatable:
+            self.void_stats.incoming_edge_count += 1
+            distinct_ops = {
+                e.untranslatable_op_id for e in self.edges if e.is_untranslatable and e.untranslatable_op_id is not None
+            }
+            self.void_stats.distinct_ops_failed = len(distinct_ops)
+            if self.lane_pair is not None:
+                key = (self.lane_pair.primary, self.lane_pair.adversary)
+                self.void_stats.failures_by_lane_pair[key] = self.void_stats.failures_by_lane_pair.get(key, 0) + 1
+
+
+# =========================================================================== #
+#  v0.2 — Bridge matrix, readers, walker
+# =========================================================================== #
+
+
+# --------------------------------------------------------------------------- #
+#  OpTrace — one atomic operation observation
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class OpTrace:
+    """One atomic operation as observed in a lane.
+
+    op_id is human-readable for audit (e.g., ``"koraelin.tokenize[0:32]"``).
+    args_hash and result_hash are 32-byte SHA-256 digests.
+    """
+
+    op_id: str
+    args_hash: bytes
+    result_hash: bytes
+
+
+# --------------------------------------------------------------------------- #
+#  Reader protocol + reference HashReader
+# --------------------------------------------------------------------------- #
+
+
+class Reader(Protocol):
+    """A lane reader: payload bytes -> sequence of atomic op traces.
+
+    Implementations are pluggable per the gunpowder principle. The walker
+    does not assume what the reader does internally; it only consumes the
+    op-stream the reader emits.
+    """
+
+    def read(self, payload: bytes) -> Sequence[OpTrace]: ...
+
+
+@dataclass
+class HashReader:
+    """Reference reader for v0.2 testing and demos.
+
+    The reader's final result_hash is ``sha256(payload || perturb)``. Two
+    HashReaders with empty perturb agree. A reader with a non-empty
+    perturb diverges from clean readers — this is how v0.2 tests
+    demonstrate escalation behavior without needing real LLM lanes.
+    """
+
+    lane: Lane
+    perturb: bytes = b""
+
+    def read(self, payload: bytes) -> Sequence[OpTrace]:
+        return (
+            OpTrace(
+                op_id=f"{self.lane.value}.read",
+                args_hash=hash_payload(payload),
+                result_hash=hash_payload(payload + self.perturb),
+            ),
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  Bridge matrix M
+# --------------------------------------------------------------------------- #
+
+BridgeFn = Callable[[OpTrace], Optional[OpTrace]]
+
+
+class BridgeMatrix:
+    """6x6 (plus CUSTOM) registry of readers and inter-lane bridges.
+
+    Identity bridges (M[i,i]) are implicit and always return the input op
+    unchanged. Off-diagonal bridges may return None to signal a NULL
+    bridge, which the walker records as an untranslatable edge into the
+    singleton sink.
+    """
+
+    def __init__(self) -> None:
+        self._readers: Dict[Lane, Reader] = {}
+        self._bridges: Dict[Tuple[Lane, Lane], BridgeFn] = {}
+
+    def register_reader(self, lane: Lane, reader: Reader) -> None:
+        self._readers[lane] = reader
+
+    def register_bridge(self, src: Lane, dst: Lane, fn: BridgeFn) -> None:
+        if src == dst:
+            raise ValueError("identity bridge is implicit; do not register")
+        self._bridges[(src, dst)] = fn
+
+    def reader_for(self, lane: Lane) -> Reader:
+        if lane not in self._readers:
+            raise KeyError(f"no reader registered for {lane}")
+        return self._readers[lane]
+
+    def has_reader(self, lane: Lane) -> bool:
+        return lane in self._readers
+
+    def bridge(self, src: Lane, dst: Lane, op: OpTrace) -> Optional[OpTrace]:
+        if src == dst:
+            return op
+        fn = self._bridges.get((src, dst))
+        if fn is None:
+            return None
+        return fn(op)
+
+
+# --------------------------------------------------------------------------- #
+#  Convergence — strict-majority on final result_hash
+# --------------------------------------------------------------------------- #
+
+
+def majority_converged(
+    streams: Dict[Lane, Sequence[OpTrace]],
+    extra_votes: Sequence[bytes] = (),
+) -> Optional[bytes]:
+    """Return the strict-majority final result_hash, or None.
+
+    Per spec: "abridged form lives at the LOWEST tier where MAJORITY
+    agreed." Agreement is exact-hash on the final op of each lane's
+    stream. Strict majority: more than half of all voters (lane streams
+    + extra_votes) must produce the same final hash.
+
+    extra_votes (v0.3+) are additional result_hashes that participate
+    in the vote alongside the lane streams — used by the sandbox loop
+    to inject the internalized own-interpretation as an extra voter.
+    """
+    if not streams and not extra_votes:
+        return None
+    finals: List[Optional[bytes]] = []
+    for stream in streams.values():
+        finals.append(stream[-1].result_hash if stream else None)
+    finals.extend(extra_votes)
+    counts = Counter(finals)
+    most_common, count = counts.most_common(1)[0]
+    if most_common is None:
+        return None
+    if count * 2 > len(finals):
+        return most_common
+    return None
+
+
+# --------------------------------------------------------------------------- #
+#  Walker
+# --------------------------------------------------------------------------- #
+
+# =========================================================================== #
+#  v0.3 — Sandbox loop and adversarial pair selection
+# =========================================================================== #
+
+
+# --------------------------------------------------------------------------- #
+#  Flag — what an upstream gate raised about the input
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Flag:
+    """A signal from an upstream gate that the input needs sandbox routing.
+
+    A flag does NOT block the read. It diverts the read through the
+    sandbox loop before the bicameral read fans out.
+
+    source: which gate raised it (e.g., "bijective_tamper",
+            "identifier_canonicality").
+    kind:   gate-specific kind (e.g., "syntax", "mixed_script").
+    severity: 0.0-1.0; informational for audit, not used to gate.
+    metadata: gate-specific structured payload.
+    """
+
+    source: str
+    kind: str
+    severity: float = 0.0
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------- #
+#  MoralPrior protocol + reference implementations
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class InspectionResult:
+    """Output of one prior inspecting the flagged payload.
+
+    transformed_payload is a re-rendering of the input through this
+    prior's lens — NOT a verdict. The walker uses transformed payloads
+    to compute the internalized own-interpretation hash that joins the
+    convergence vote.
+    """
+
+    prior_id: str
+    transformed_payload: bytes
+    notes: str = ""
+
+
+class MoralPrior(Protocol):
+    """A prior that inspects flagged input and returns a transformed reading."""
+
+    @property
+    def prior_id(self) -> str: ...
+
+    def inspect(self, payload: bytes, flags: Sequence[Flag]) -> InspectionResult: ...
+
+
+@dataclass
+class IdentityPrior:
+    """Reference no-op prior: returns the payload unchanged.
+
+    Useful as a baseline when callers want to invoke the sandbox
+    machinery without transforming the input.
+    """
+
+    prior_id: str = "identity"
+
+    def inspect(self, payload: bytes, flags: Sequence[Flag]) -> InspectionResult:
+        return InspectionResult(
+            prior_id=self.prior_id,
+            transformed_payload=payload,
+            notes="identity prior; no transform applied",
+        )
+
+
+@dataclass
+class IsolationPrior:
+    """Reference prior that wraps payload in an isolation envelope.
+
+    Demonstrates a non-trivial prior. Production deployments register
+    their own moral-compass priors instead of (or alongside) this.
+    """
+
+    prior_id: str = "isolation"
+    envelope: bytes = b"<isolated>"
+
+    def inspect(self, payload: bytes, flags: Sequence[Flag]) -> InspectionResult:
+        return InspectionResult(
+            prior_id=self.prior_id,
+            transformed_payload=self.envelope + payload + self.envelope,
+            notes=f"wrapped in {self.envelope!r}; flag_count={len(flags)}",
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  Sandbox loop
+# --------------------------------------------------------------------------- #
+
+
+def sandbox(
+    payload: bytes,
+    flags: Sequence[Flag],
+    priors: Sequence[MoralPrior],
+    tree: Tree,
+) -> bytes:
+    """Run the sandbox loop on flagged input. Mutates tree.
+
+    Spec section 6 steps:
+      1. Provisional ingest -> SANDBOX_PROVISIONAL node.
+      2. Inspection under each prior -> SANDBOX_INSPECTION node per prior.
+      3. Internalize: combine prior outputs deterministically.
+      4. Add SANDBOX_INTERNALIZED node carrying the internalized hash.
+
+    Returns the internalized own-interpretation payload (raw bytes, not
+    hash). The caller hashes it and passes the hash as an extra_vote to
+    majority_converged so the sandbox interpretation participates in
+    the convergence decision without overriding it.
+    """
+    if not flags:
+        raise ValueError("sandbox called with no flags")
+    if not priors:
+        raise ValueError("sandbox called with no priors registered")
+
+    tree.add_node(
+        Node(
+            id=len(tree.nodes),
+            kind=NodeKind.SANDBOX_PROVISIONAL,
+            source="sandbox.provisional_ingest",
+            payload={
+                "raw_hash": hash_payload(payload).hex(),
+                "flags": [{"source": f.source, "kind": f.kind, "severity": f.severity} for f in flags],
+            },
+        )
+    )
+
+    inspection_results: List[InspectionResult] = []
+    for prior in priors:
+        result = prior.inspect(payload, flags)
+        inspection_results.append(result)
+        tree.add_node(
+            Node(
+                id=len(tree.nodes),
+                kind=NodeKind.SANDBOX_INSPECTION,
+                source=f"sandbox.inspection.{result.prior_id}",
+                payload={
+                    "prior_id": result.prior_id,
+                    "transformed_hash": hash_payload(result.transformed_payload).hex(),
+                    "notes": result.notes,
+                },
+            )
+        )
+
+    internalized = b""
+    for r in inspection_results:
+        internalized += hash_payload(r.transformed_payload)
+    internalized_hash = hash_payload(internalized)
+
+    tree.add_node(
+        Node(
+            id=len(tree.nodes),
+            kind=NodeKind.SANDBOX_INTERNALIZED,
+            source="sandbox.internalize",
+            result_hash=internalized_hash,
+            payload={
+                "prior_count": len(inspection_results),
+                "internalized_hash": internalized_hash.hex(),
+            },
+        )
+    )
+
+    tree.sandbox_invoked = True
+    return internalized
+
+
+# --------------------------------------------------------------------------- #
+#  Input-shape adversarial pair selection (Q5 lock)
+# --------------------------------------------------------------------------- #
+
+DOMAIN_KEYWORDS: Dict[str, Tuple[str, ...]] = {
+    "formal_logic": ("forall", "exists", "implies", "lemma", "theorem", "axiom"),
+    "low_level": ("malloc", "ptr", "buffer", "unsafe", "&mut", "asm"),
+    "symbolic_math": ("integral", "matrix", "eigen", "tensor", "polynomial"),
+    "scripting": ("function ", "var ", "const ", "=>", "console.log"),
+    "linguistic_nuance": ("metaphor", "connotation", "rhetoric", "irony"),
+}
+"""Stub keyword table for v0.3 domain classification. Replace with a
+learned classifier in v0.4+.
+"""
+
+
+DOMAIN_PRIMARY: Dict[str, Lane] = {
+    "default": Lane.KORAELIN,
+    "formal_logic": Lane.UMBROTH,
+    "low_level": Lane.RUNETHIC,
+    "symbolic_math": Lane.CASSISIVADAN,
+    "scripting": Lane.AVALI,
+    "linguistic_nuance": Lane.DRAUMRIC,
+}
+"""Domain -> Primary Resolver lane (highest historical capability stub)."""
+
+
+DOMAIN_ADVERSARY: Dict[str, Lane] = {
+    "default": Lane.AVALI,
+    "formal_logic": Lane.AVALI,
+    "low_level": Lane.DRAUMRIC,
+    "symbolic_math": Lane.AVALI,
+    "scripting": Lane.UMBROTH,
+    "linguistic_nuance": Lane.RUNETHIC,
+}
+"""Domain -> Adversarial Reader lane (highest historical disagreement
+delta against primary in this domain — stub).
+"""
+
+
+def classify_domain(payload: bytes) -> str:
+    """Stub domain classifier. v0.3 uses keyword matching.
+
+    v0.4+ will replace with a learned classifier. Falls back to
+    ``"default"`` when no keyword matches or the payload isn't
+    decodable as UTF-8.
+    """
+    try:
+        text = payload.decode("utf-8", errors="replace").lower()
+    except Exception:
+        return "default"
+    for domain, keywords in DOMAIN_KEYWORDS.items():
+        if any(kw in text for kw in keywords):
+            return domain
+    return "default"
+
+
+def select_initial_pair(payload: bytes) -> LanePair:
+    """Q5-locked input-shape adversarial pair selection.
+
+    Classifies the input domain, picks the lane with highest historical
+    capability in that domain (Primary Resolver), and pairs it with the
+    lane that historically disagrees most with the Primary in that
+    domain (Adversarial Reader). v0.3 uses static stub tables; v0.4+
+    will populate from real capability/disagreement metrics.
+    """
+    domain = classify_domain(payload)
+    primary = DOMAIN_PRIMARY.get(domain, Lane.KORAELIN)
+    adversary = DOMAIN_ADVERSARY.get(domain, Lane.AVALI)
+    if primary == adversary:
+        adversary = Lane.AVALI if primary != Lane.AVALI else Lane.KORAELIN
+    return LanePair(primary=primary, adversary=adversary, domain=domain)
+
+
+# --------------------------------------------------------------------------- #
+#  Walker (v0.3: sandbox + adversarial pair selection wired in)
+# --------------------------------------------------------------------------- #
+
+
+def walk(
+    payload: bytes,
+    matrix: BridgeMatrix,
+    *,
+    posture: Posture = Posture.HUMBLE,
+    initial_pair: Optional[LanePair] = None,
+    flags: Sequence[Flag] = (),
+    priors: Sequence[MoralPrior] = (),
+    provisional_registry: Optional["ProvisionalRegistry"] = None,
+) -> Tree:
+    """Bicameral read + bit-depth escalation.
+
+    v0.3 additions:
+      - If ``flags`` is non-empty, route through sandbox loop first;
+        the internalized own-interpretation hash joins convergence vote.
+      - When ``initial_pair`` is None, use input-shape adversarial pair
+        selection (Q5 lock) instead of the static Kor'aelin+Avali
+        default.
+
+    v0.4 additions:
+      - On T6 exhaustion under HUMBLE posture, mint a deterministic
+        provisional from observed streams and set
+        ``terminated_as=PROVISIONAL``.
+      - On T6 exhaustion under RIGID posture, leave abridged_form=None
+        and set ``terminated_as=REFUSED`` with a refusal_reason.
+      - When ``provisional_registry`` is supplied and a provisional is
+        minted, the registry records the mint and the resulting
+        corroboration_count is propagated to ``tree``.
+    """
+    tree = Tree(posture=posture)
+
+    extra_votes: List[bytes] = []
+    if flags:
+        if not priors:
+            raise ValueError("flags supplied but no priors registered")
+        internalized = sandbox(payload, flags, priors, tree)
+        extra_votes.append(hash_payload(internalized))
+
+    if initial_pair is None:
+        initial_pair = select_initial_pair(payload)
+    tree.lane_pair = initial_pair
+
+    active_lanes: List[Lane] = [initial_pair.primary, initial_pair.adversary]
+    streams: Dict[Lane, Sequence[OpTrace]] = {}
+
+    def _ingest(lane: Lane, source_label: str) -> None:
+        stream = matrix.reader_for(lane).read(payload)
+        streams[lane] = stream
+        for op in stream:
+            tree.add_node(
+                Node(
+                    id=len(tree.nodes),
+                    kind=NodeKind.OP,
+                    lane=lane,
+                    band=Band.AUDIBLE,
+                    op_id=op.op_id,
+                    args_hash=op.args_hash,
+                    result_hash=op.result_hash,
+                    source=source_label,
+                )
+            )
+
+    for lane in active_lanes:
+        _ingest(lane, "walker.bicameral_read")
+    tree.tier_reached = max(
+        (LANE_TIER.get(lane, 0) for lane in active_lanes),
+        default=0,
+    )
+
+    abridged = majority_converged(streams, extra_votes=extra_votes)
+    if abridged is not None:
+        tree.abridged_form = abridged
+        tree.terminated_as = Termination.ABRIDGED
+        return tree
+
+    for next_lane in DEFAULT_LADDER:
+        if next_lane in active_lanes:
+            continue
+        if LANE_TIER[next_lane] <= tree.tier_reached:
+            continue
+        active_lanes.append(next_lane)
+        _ingest(next_lane, "walker.escalation")
+        tree.tier_reached = LANE_TIER[next_lane]
+        abridged = majority_converged(streams, extra_votes=extra_votes)
+        if abridged is not None:
+            tree.abridged_form = abridged
+            tree.terminated_as = Termination.ABRIDGED
+            return tree
+
+    # T6 exhaustion — posture switch (v0.4)
+    if posture == Posture.HUMBLE:
+        provisional_hash = mint_provisional(streams, extra_votes=extra_votes)
+        tree.add_node(
+            Node(
+                id=len(tree.nodes),
+                kind=NodeKind.PROVISIONAL_MINT,
+                source="walker.provisional_mint",
+                result_hash=provisional_hash,
+                payload={
+                    "tier_reached": tree.tier_reached,
+                    "lane_count": len(streams),
+                    "provisional_hash": provisional_hash.hex(),
+                },
+            )
+        )
+        tree.abridged_form = provisional_hash
+        tree.provisional_minted = True
+        tree.terminated_as = Termination.PROVISIONAL
+        if provisional_registry is not None:
+            rec = provisional_registry.record(provisional_hash)
+            tree.provisional_corroboration_count = rec.corroboration_count
+    else:
+        tree.refusal_reason = (
+            f"no representation across T1..T{tree.tier_reached}; " f"{len(streams)} lanes did not converge"
+        )
+        tree.terminated_as = Termination.REFUSED
+
+    return tree
+
+
+# =========================================================================== #
+#  v0.4 — Provisional minting + decay registry
+# =========================================================================== #
+
+
+def mint_provisional(
+    streams: Dict[Lane, Sequence[OpTrace]],
+    extra_votes: Sequence[bytes] = (),
+) -> bytes:
+    """Synthesize a provisional abridged form from observed streams.
+
+    Deterministic: collect the unique final result_hashes across all
+    lanes (and any extra_votes from the sandbox loop), sort, concatenate,
+    and SHA-256. Same set of voters always produces the same provisional.
+
+    The hash is intentionally NOT distinguishable from a majority-converged
+    hash by inspection alone — the distinction lives in the Tree
+    (``tree.terminated_as == PROVISIONAL`` and ``provisional_minted=True``).
+    """
+    finals: set = set()
+    for stream in streams.values():
+        if stream:
+            finals.add(stream[-1].result_hash)
+    for vote in extra_votes:
+        finals.add(vote)
+    if not finals:
+        return hash_payload(b"")
+    sorted_finals = sorted(finals)
+    return hash_payload(b"".join(sorted_finals))
+
+
+@dataclass
+class ProvisionalRecord:
+    """One minted provisional with its corroboration history.
+
+    minted_at and last_seen_at are monotonic call-counter values from
+    the registry, NOT wall-clock — keeps the registry deterministic for
+    replay and audit.
+    """
+
+    provisional_hash: bytes
+    minted_at: int
+    corroboration_count: int = 0
+    last_seen_at: int = 0
+
+
+class ProvisionalRegistry:
+    """In-memory registry of minted provisionals with decay policy.
+
+    Deterministic by design: uses a monotonic call counter rather than
+    wall-clock time. Decay removes provisionals that are stale (last
+    seen more than ``decay_window`` calls ago) AND under-corroborated
+    (fewer than ``min_corroborations`` re-mints).
+
+    Defaults are conservative — most v0.4 deployments will tune these
+    based on workload. Production wire-up is v1.0.
+    """
+
+    def __init__(
+        self,
+        *,
+        decay_window: int = 100,
+        min_corroborations: int = 3,
+    ) -> None:
+        self._store: Dict[bytes, ProvisionalRecord] = {}
+        self._call_counter: int = 0
+        self.decay_window = decay_window
+        self.min_corroborations = min_corroborations
+
+    @property
+    def call_counter(self) -> int:
+        return self._call_counter
+
+    def record(self, provisional_hash: bytes) -> ProvisionalRecord:
+        """Mint a new provisional or corroborate an existing one.
+
+        First call for a given hash creates a record with
+        ``corroboration_count=0``. Each subsequent call for the same
+        hash increments ``corroboration_count`` and refreshes
+        ``last_seen_at``.
+        """
+        self._call_counter += 1
+        rec = self._store.get(provisional_hash)
+        if rec is None:
+            rec = ProvisionalRecord(
+                provisional_hash=provisional_hash,
+                minted_at=self._call_counter,
+                corroboration_count=0,
+                last_seen_at=self._call_counter,
+            )
+            self._store[provisional_hash] = rec
+        else:
+            rec.corroboration_count += 1
+            rec.last_seen_at = self._call_counter
+        return rec
+
+    def get(self, provisional_hash: bytes) -> Optional[ProvisionalRecord]:
+        return self._store.get(provisional_hash)
+
+    def decay(self) -> List[bytes]:
+        """Remove stale, un-corroborated provisionals. Returns removed hashes."""
+        removed: List[bytes] = []
+        for h, rec in list(self._store.items()):
+            stale = (self._call_counter - rec.last_seen_at) > self.decay_window
+            under_corroborated = rec.corroboration_count < self.min_corroborations
+            if stale and under_corroborated:
+                del self._store[h]
+                removed.append(h)
+        return removed
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __contains__(self, provisional_hash: bytes) -> bool:
+        return provisional_hash in self._store
+
+
+# =========================================================================== #
+#  v0.5 — L14 audio emission adapter
+# =========================================================================== #
+
+
+# Frequencies are sourced from the canonical tri_bundle table so the audio
+# emission stays in sync with the Crypto/L14 substrate. Imported lazily inside
+# helpers to avoid a hard module-import cycle if tri_bundle ever evolves; the
+# fallback table mirrors the values at the time of writing.
+_FALLBACK_LANE_FREQUENCY_HZ: Dict[Lane, float] = {
+    Lane.KORAELIN: 440.00,  # A4 — ko in tri_bundle
+    Lane.AVALI: 523.25,  # C5 — av
+    Lane.RUNETHIC: 293.66,  # D4 — ru
+    Lane.CASSISIVADAN: 659.25,  # E5 — ca
+    Lane.UMBROTH: 196.00,  # G3 — um
+    Lane.DRAUMRIC: 392.00,  # G4 — dr
+}
+
+
+LANE_TO_TRI_BUNDLE_CODE: Dict[Lane, str] = {
+    Lane.KORAELIN: "ko",
+    Lane.AVALI: "av",
+    Lane.RUNETHIC: "ru",
+    Lane.CASSISIVADAN: "ca",
+    Lane.UMBROTH: "um",
+    Lane.DRAUMRIC: "dr",
+}
+
+
+BAND_FREQUENCY_MULTIPLIER: Dict[Band, float] = {
+    Band.INFRA: 0.25,  # -2 octaves
+    Band.AUDIBLE: 1.0,  # fundamental
+    Band.ULTRA: 4.0,  # +2 octaves
+}
+
+
+SYSTEM_FUNDAMENTAL_HZ: float = 440.0
+"""Fundamental frequency for non-lane (system) events: sandbox nodes,
+provisional mints. Tri-octave signature still applies via Band multiplier.
+"""
+
+
+def _lane_frequency_hz(lane: Optional[Lane]) -> float:
+    """Resolve a lane's fundamental frequency, with tri_bundle as the
+    canonical source and a fallback table baked in.
+    """
+    if lane is None or lane == Lane.CUSTOM:
+        return SYSTEM_FUNDAMENTAL_HZ
+    try:
+        from src.crypto.tri_bundle import TONGUE_FREQUENCIES
+
+        code = LANE_TO_TRI_BUNDLE_CODE[lane]
+        return TONGUE_FREQUENCIES[code]
+    except Exception:
+        return _FALLBACK_LANE_FREQUENCY_HZ.get(lane, SYSTEM_FUNDAMENTAL_HZ)
+
+
+def _frequency_for(lane: Optional[Lane], band: Band) -> float:
+    """Per-(lane, band) frequency: lane fundamental times band multiplier."""
+    return _lane_frequency_hz(lane) * BAND_FREQUENCY_MULTIPLIER[band]
+
+
+def _amplitude_from_hash(h: Optional[bytes], default: float = 0.5) -> float:
+    """Deterministic amplitude in [0.0, 1.0] derived from a result_hash.
+
+    Empty/None hash falls back to ``default``. First byte of the hash
+    is used so the amplitude reflects the head of the digest space
+    (uniform if hash is uniform).
+    """
+    if not h:
+        return default
+    return h[0] / 255.0
+
+
+def _phase_from_id(node_id: int) -> float:
+    """Phase angle in [0, 2π) derived from node_id. Wraps every 16 ids."""
+    return (2.0 * math.pi * node_id / 16.0) % (2.0 * math.pi)
+
+
+# --------------------------------------------------------------------------- #
+#  AudioEvent + TreeAudioEmission
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class AudioEvent:
+    """One audio event derived from a tree node.
+
+    lane is None for system events (sandbox nodes, provisional mints,
+    void). band always set — system events still pick a band so the
+    emission has consistent tri-band structure.
+    """
+
+    source_node_id: int
+    lane: Optional[Lane]
+    band: Band
+    frequency_hz: float
+    amplitude: float
+    phase_rad: float
+    duration_s: float
+    label: str
+
+
+@dataclass
+class TreeAudioEmission:
+    """Audio emission from one tree.
+
+    events is the canonical ordered list (matches node order). by_lane
+    and by_band are convenience indexes computed on demand.
+    """
+
+    events: List[AudioEvent] = field(default_factory=list)
+
+    def by_lane(self) -> Dict[Optional[Lane], List[AudioEvent]]:
+        out: Dict[Optional[Lane], List[AudioEvent]] = {}
+        for e in self.events:
+            out.setdefault(e.lane, []).append(e)
+        return out
+
+    def by_band(self) -> Dict[Band, List[AudioEvent]]:
+        out: Dict[Band, List[AudioEvent]] = {}
+        for e in self.events:
+            out.setdefault(e.band, []).append(e)
+        return out
+
+
+# --------------------------------------------------------------------------- #
+#  Per-NodeKind emission rules
+# --------------------------------------------------------------------------- #
+
+# Map: NodeKind -> (band, label, default_amplitude). Lane is taken from the
+# node when present, else None. NULL_BRIDGE_VOID is intentionally absent —
+# the void sink emits nothing.
+_NODEKIND_EMISSION: Dict[NodeKind, Tuple[Band, str, float]] = {
+    NodeKind.OP: (Band.AUDIBLE, "op", 0.5),
+    NodeKind.SANDBOX_PROVISIONAL: (Band.INFRA, "sandbox.provisional", 0.7),
+    NodeKind.SANDBOX_INSPECTION: (Band.INFRA, "sandbox.inspection", 0.5),
+    NodeKind.SANDBOX_INTERNALIZED: (Band.AUDIBLE, "sandbox.internalize", 0.6),
+    NodeKind.PROVISIONAL_MINT: (Band.ULTRA, "provisional_mint", 0.8),
+}
+
+
+def emit_audio(
+    tree: Tree,
+    *,
+    event_duration_s: float = 0.05,
+) -> TreeAudioEmission:
+    """Render a tree as a sequence of AudioEvents.
+
+    Emission rules per NodeKind:
+      OP                    -> AUDIBLE band, lane fundamental
+      SANDBOX_PROVISIONAL   -> INFRA band, system fundamental
+      SANDBOX_INSPECTION    -> INFRA band, system fundamental
+      SANDBOX_INTERNALIZED  -> AUDIBLE band, system fundamental
+      PROVISIONAL_MINT      -> ULTRA band, system fundamental
+      NULL_BRIDGE_VOID      -> silent (no event)
+
+    Frequency = lane_fundamental * band_multiplier (tri-octave signature).
+    Amplitude = first byte of result_hash / 255 (or default per kind).
+    Phase = 2*pi * node_id / 16, wrapping.
+
+    Synthesis to a waveform is left to downstream consumers; v0.5 ships
+    the EVENT stream only.
+    """
+    emission = TreeAudioEmission()
+    for node in tree.nodes:
+        rule = _NODEKIND_EMISSION.get(node.kind)
+        if rule is None:
+            continue  # NULL_BRIDGE_VOID and any future silent kinds
+        band, label, default_amp = rule
+        # OP nodes: prefer the node's own band if set, fall back to rule.
+        if node.kind == NodeKind.OP and node.band is not None:
+            band = node.band
+        lane = node.lane if node.kind == NodeKind.OP else None
+        emission.events.append(
+            AudioEvent(
+                source_node_id=node.id,
+                lane=lane,
+                band=band,
+                frequency_hz=_frequency_for(lane, band),
+                amplitude=_amplitude_from_hash(node.result_hash, default=default_amp),
+                phase_rad=_phase_from_id(node.id),
+                duration_s=event_duration_s,
+                label=label,
+            )
+        )
+    return emission

--- a/tests/governance/test_bijective_tamper.py
+++ b/tests/governance/test_bijective_tamper.py
@@ -1,0 +1,168 @@
+"""Tests for the bijective tamper signal (L13 input)."""
+from __future__ import annotations
+
+import sys
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.governance.bijective_tamper import (  # noqa: E402
+    L13_MAPPING_RECOMMENDATION,
+    TamperResult,
+    evaluate_code,
+    recommended_l13_action,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    from transformers import AutoTokenizer
+
+    path = (
+        REPO_ROOT
+        / "artifacts"
+        / "extended_tokenizer"
+        / "qwen25-coder-7b-sacred-tongues"
+    )
+    return AutoTokenizer.from_pretrained(str(path), use_fast=True)
+
+
+# --------------------------------------------------------------------------- #
+#  Clean cases — score 0.0, ALLOW
+# --------------------------------------------------------------------------- #
+
+def test_clean_ascii_python(tokenizer):
+    src = "def f(x):\n    return x + 1\n"
+    r = evaluate_code(src, "python", tokenizer=tokenizer)
+    assert r.kind == "none"
+    assert r.score == 0.0
+    assert r.semantic_fingerprint is not None
+    assert recommended_l13_action(r) == "ALLOW"
+
+
+def test_clean_with_unicode_string_literal(tokenizer):
+    # Emoji in a string literal — NFC stable, no tampering.
+    src = 'msg = "hello 🌍 world"\nprint(msg)\n'
+    r = evaluate_code(src, "python", tokenizer=tokenizer)
+    assert r.kind == "none"
+    assert r.score == 0.0
+    assert recommended_l13_action(r) == "ALLOW"
+
+
+def test_clean_function_with_decorators(tokenizer):
+    src = (
+        "@staticmethod\n"
+        "def helper(x, y, *, key=None):\n"
+        "    return (x + y, key)\n"
+    )
+    r = evaluate_code(src, "python", tokenizer=tokenizer)
+    assert r.kind == "none"
+
+
+# --------------------------------------------------------------------------- #
+#  NFD-shift case — score ~0.2, ALLOW with annotation
+# --------------------------------------------------------------------------- #
+
+def test_nfd_combining_marks_recover_via_nfc(tokenizer):
+    """NFD literal in source becomes NFC after tokenize-decode.
+
+    bytes_diverge=True (NFD bytes != NFC bytes after Qwen normalization)
+    nfc_recovers_bytes=True (this is the canonical NFC normalization case)
+    ast_diverge=True (Python string compare is codepoint-by-codepoint, so
+        Constant('a\\u0301') != Constant('\\u00e1'))
+
+    Despite ast_diverge=True, kind="nfc" because nfc_recovers_bytes wins —
+    this is documented expected normalization, not adversarial tampering.
+    """
+    nfd_text = unicodedata.normalize("NFD", "combining = \"áb́ć\"")
+    src = nfd_text + "\n"
+    assert src != unicodedata.normalize("NFC", src), "fixture must actually be NFD"
+    r = evaluate_code(src, "python", tokenizer=tokenizer)
+    assert r.kind == "nfc", f"expected nfc, got {r.kind} (detail={r.detail})"
+    assert 0.10 < r.score < 0.40
+    assert r.bytes_diverge is True
+    assert r.nfc_recovers_bytes is True
+    # AST diverge is EXPECTED here because string literal value changes under NFC
+    assert r.ast_diverge is True
+    assert recommended_l13_action(r) == "ALLOW"
+
+
+# --------------------------------------------------------------------------- #
+#  Catastrophic case — input does not parse → DENY
+# --------------------------------------------------------------------------- #
+
+def test_input_invalid_python_returns_input_invalid(tokenizer):
+    src = "def f(:\n    return\n"  # syntax error
+    r = evaluate_code(src, "python", tokenizer=tokenizer)
+    assert r.kind == "input_invalid"
+    assert r.score == 1.0
+    assert recommended_l13_action(r) == "DENY"
+
+
+# --------------------------------------------------------------------------- #
+#  Unsupported language → input_invalid
+# --------------------------------------------------------------------------- #
+
+def test_unsupported_language_returns_input_invalid(tokenizer):
+    r = evaluate_code("fn main() { println!(\"hi\"); }", "rust", tokenizer=tokenizer)
+    assert r.kind == "input_invalid"
+    assert r.score == 1.0
+
+
+# --------------------------------------------------------------------------- #
+#  Semantic fingerprint stability
+# --------------------------------------------------------------------------- #
+
+def test_semantic_fingerprint_equal_for_equivalent_sources(tokenizer):
+    """Two byte-different but AST-equivalent sources should hash the same."""
+    src_a = "def f(x):\n    return x+1\n"
+    src_b = "def f(x):\n    return x + 1\n"   # extra spaces, same AST
+    r_a = evaluate_code(src_a, "python", tokenizer=tokenizer)
+    r_b = evaluate_code(src_b, "python", tokenizer=tokenizer)
+    assert r_a.semantic_fingerprint == r_b.semantic_fingerprint
+
+
+def test_semantic_fingerprint_differs_for_different_programs(tokenizer):
+    src_a = "def f(x):\n    return x + 1\n"
+    src_b = "def f(x):\n    return x * 1\n"
+    r_a = evaluate_code(src_a, "python", tokenizer=tokenizer)
+    r_b = evaluate_code(src_b, "python", tokenizer=tokenizer)
+    assert r_a.semantic_fingerprint != r_b.semantic_fingerprint
+
+
+# --------------------------------------------------------------------------- #
+#  L13 mapping coverage
+# --------------------------------------------------------------------------- #
+
+def test_l13_mapping_covers_all_kinds():
+    expected = {"none", "nfc", "structural", "syntax", "input_invalid"}
+    assert set(L13_MAPPING_RECOMMENDATION.keys()) == expected
+
+
+def test_l13_mapping_actions_are_valid():
+    valid = {"ALLOW", "QUARANTINE", "DENY", "REROUTE"}
+    for action in L13_MAPPING_RECOMMENDATION.values():
+        assert action in valid
+
+
+# --------------------------------------------------------------------------- #
+#  TamperResult.to_dict serialization
+# --------------------------------------------------------------------------- #
+
+def test_to_dict_is_json_serializable(tokenizer):
+    import json
+
+    r = evaluate_code("x = 1\n", "python", tokenizer=tokenizer)
+    serialized = json.dumps(r.to_dict())
+    restored = json.loads(serialized)
+    assert restored["kind"] == "none"
+    assert restored["score"] == 0.0

--- a/tests/governance/test_bijective_tamper_wireup.py
+++ b/tests/governance/test_bijective_tamper_wireup.py
@@ -1,0 +1,233 @@
+"""Wire-up tests for the bijective tamper overlay on RuntimeGate.
+
+The contract under test:
+  1. flag off                                  -> no behavior change vs baseline
+  2. flag on  + clean code                     -> still ALLOW + receipt
+  3. flag on  + user-submitted syntax-broken   -> NO-OP (input_invalid is not
+     a tamper signal at this layer; prose looks the same to the parser)
+  4. base DENY + tamper ALLOW                  -> stays DENY (monotonic)
+  5. base ALLOW + synthetic kind="syntax"      -> DENY (true tamper escalates)
+  6. prose with code keywords                  -> NOT DENY (heuristic safety)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.governance.runtime_gate import Decision, RuntimeGate  # noqa: E402
+
+
+CLEAN_PY = "def add(x, y):\n    return x + y\n"
+BROKEN_PY = "def add(:\n    return\n"
+
+
+# --------------------------------------------------------------------------- #
+#  1. flag off — no behavior change
+# --------------------------------------------------------------------------- #
+
+def test_flag_off_default_is_no_op():
+    """With the flag off, the tamper overlay must not run at all."""
+    gate = RuntimeGate()
+    assert gate._bijective_tamper_enabled is False
+    result = gate.evaluate(CLEAN_PY)
+    assert result.bijective_tamper_action == ""
+    assert result.bijective_tamper_kind == ""
+    assert result.bijective_tamper_score == 0.0
+    assert result.semantic_fingerprint is None
+    assert not any("bijective_tamper" in s for s in result.signals)
+
+
+def test_flag_off_does_not_deny_broken_code():
+    """Without the flag, syntax-broken code is just text; gate uses base logic only."""
+    gate = RuntimeGate()
+    result = gate.evaluate(BROKEN_PY)
+    assert not any("bijective_tamper" in s for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  2. flag on  + clean code  -> ALLOW (with annotation)
+# --------------------------------------------------------------------------- #
+
+def test_flag_on_clean_code_allows():
+    gate = RuntimeGate(use_bijective_tamper=True)
+    assert gate._bijective_tamper_enabled is True
+    result = gate.evaluate(CLEAN_PY)
+    assert result.decision == Decision.ALLOW
+    assert result.bijective_tamper_kind == "none"
+    assert result.bijective_tamper_action == "ALLOW"
+    assert result.bijective_tamper_score == 0.0
+    assert result.semantic_fingerprint is not None
+    assert any(s.startswith("bijective_tamper(") for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  3. flag on  + user-submitted syntax-broken code  -> no-op
+# --------------------------------------------------------------------------- #
+
+def test_flag_on_user_syntax_broken_is_noop():
+    """input_invalid is NOT a tamper signal at the runtime-gate layer.
+    It just means the input did not parse — which is true for prose too.
+    The genuine tamper case is kind='syntax' (decoded form fails to parse
+    even though the original parsed)."""
+    gate = RuntimeGate(use_bijective_tamper=True)
+    result = gate.evaluate(BROKEN_PY)
+    # Must not produce a tamper receipt or DENY based on input_invalid alone.
+    assert result.bijective_tamper_kind == ""
+    assert result.bijective_tamper_action == ""
+    assert not any("bijective_tamper" in s for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  4. base DENY + tamper ALLOW -> stays DENY (monotonic)
+# --------------------------------------------------------------------------- #
+
+def test_base_deny_plus_tamper_allow_stays_deny():
+    """If the base gate denies for non-tamper reasons, a clean tamper signal
+    must NOT downgrade the decision (monotonic property).
+
+    Approach: pre-seed the immune set with the action's exact action_hash,
+    using the same blake2s(digest_size=8) the gate computes. Then evaluate
+    clean Python whose tamper recommendation is ALLOW. The base gate must
+    return DENY via immune_memory_hit, and the tamper signal must not
+    silently downgrade it.
+    """
+    gate = RuntimeGate(use_bijective_tamper=True)
+    forced_immune_text = CLEAN_PY  # clean python — tamper alone says ALLOW
+    import hashlib
+
+    h = hashlib.blake2s(
+        forced_immune_text.encode("utf-8", errors="replace"),
+        digest_size=8,
+    ).hexdigest()
+    gate._immune.add(h)
+    result = gate.evaluate(forced_immune_text)
+    assert result.decision == Decision.DENY, (
+        f"immune-hit path must DENY regardless of tamper; got {result.decision}"
+    )
+    # Tamper receipt should still be present in audit (overlay computed at top).
+    assert result.bijective_tamper_kind == "none"
+    assert result.bijective_tamper_action == "ALLOW"
+
+
+# --------------------------------------------------------------------------- #
+#  5. base ALLOW + synthetic kind="syntax" -> DENY (escalation via top short-circuit)
+# --------------------------------------------------------------------------- #
+
+def test_synthetic_syntax_tamper_escalates_to_deny(monkeypatch):
+    """Inject a synthetic kind='syntax' TamperResult to verify the escalation
+    path. We cannot reliably mangle Qwen's tokenizer in a unit test, so we
+    mock the evaluator. This proves the wire-up will DENY when a true
+    encoding-level tamper is detected in production."""
+    from src.governance import bijective_tamper as bt
+
+    def fake_evaluate_code(src, language="python", tokenizer=None, tokenizer_dir=None):
+        return bt.TamperResult(
+            score=1.0,
+            kind="syntax",
+            semantic_fingerprint="deadbeef" * 8,
+            bytes_diverge=True,
+            nfc_recovers_bytes=False,
+            ast_diverge=True,
+            decoded_parses=False,
+            detail={"error": "synthetic test injection"},
+        )
+
+    gate = RuntimeGate(use_bijective_tamper=True)
+    # Force lazy-load to populate, then patch the evaluator.
+    gate._ensure_bijective_tamper()
+    gate._bijective_tamper_evaluator = fake_evaluate_code
+    result = gate.evaluate(CLEAN_PY)
+    assert result.decision == Decision.DENY
+    assert result.bijective_tamper_kind == "syntax"
+    assert result.bijective_tamper_action == "DENY"
+    assert any("bijective_tamper_veto_deny" in s for s in result.signals)
+    assert result.action_hash in gate._immune
+
+
+# --------------------------------------------------------------------------- #
+#  6. prose with code keywords -> NOT DENY (heuristic false-positive guard)
+# --------------------------------------------------------------------------- #
+
+def test_prose_with_code_keywords_not_denied():
+    """Prose containing 'function', 'import', 'return', 'class', 'from' must
+    not get parsed as Python and falsely DENY'd. The two-signal heuristic
+    plus the input_invalid no-op together make this safe."""
+    gate = RuntimeGate(use_bijective_tamper=True)
+    prose_samples = [
+        "Please write a function that sorts a list of numbers.",
+        "Import duty applies to this category from the spec.",
+        "Return to the previous step and try again.",
+        "The class action settlement covers all members.",
+        "From the documentation above, summarize the API contract.",
+    ]
+    for text in prose_samples:
+        result = gate.evaluate(text)
+        assert result.decision != Decision.DENY, (
+            f"prose falsely DENY'd: {text!r} (signals={result.signals})"
+        )
+        assert result.bijective_tamper_kind == "", (
+            f"prose triggered tamper kind={result.bijective_tamper_kind!r}: {text!r}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  Env-var enablement path
+# --------------------------------------------------------------------------- #
+
+def test_env_var_enables_overlay(monkeypatch):
+    monkeypatch.setenv("SCBE_ENABLE_BIJECTIVE_TAMPER_GATE", "1")
+    gate = RuntimeGate()
+    assert gate._bijective_tamper_enabled is True
+    result = gate.evaluate(CLEAN_PY)
+    assert result.bijective_tamper_kind == "none"
+
+
+def test_env_var_off_string_disables(monkeypatch):
+    monkeypatch.setenv("SCBE_ENABLE_BIJECTIVE_TAMPER_GATE", "0")
+    gate = RuntimeGate()
+    assert gate._bijective_tamper_enabled is False
+
+
+def test_explicit_kwarg_beats_env(monkeypatch):
+    monkeypatch.setenv("SCBE_ENABLE_BIJECTIVE_TAMPER_GATE", "1")
+    gate = RuntimeGate(use_bijective_tamper=False)
+    assert gate._bijective_tamper_enabled is False
+
+
+# --------------------------------------------------------------------------- #
+#  Heuristic skip — non-code action_text never invokes the tokenizer
+# --------------------------------------------------------------------------- #
+
+def test_non_code_skips_tamper(monkeypatch):
+    """Plain prose must not trigger the AST/tokenizer path."""
+    gate = RuntimeGate(use_bijective_tamper=True)
+    # A side channel: if _evaluate_bijective_tamper returns None,
+    # the result fields stay at their defaults.
+    result = gate.evaluate("hello world, please summarize the latest news")
+    assert result.bijective_tamper_kind == ""
+    assert result.bijective_tamper_action == ""
+    assert not any("bijective_tamper" in s for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  Receipt envelope is parseable
+# --------------------------------------------------------------------------- #
+
+def test_receipt_envelope_format():
+    gate = RuntimeGate(use_bijective_tamper=True)
+    result = gate.evaluate(CLEAN_PY)
+    receipts = [s for s in result.signals if s.startswith("bijective_tamper(")]
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    # Required keys per the wire-up contract
+    assert "kind=" in receipt
+    assert "score=" in receipt
+    assert "action=" in receipt
+    # Clean code has a fingerprint
+    assert "fp=" in receipt

--- a/tests/governance/test_identifier_canonicality.py
+++ b/tests/governance/test_identifier_canonicality.py
@@ -1,0 +1,182 @@
+"""Unit tests for the identifier-canonicality signal."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.governance.identifier_canonicality import (  # noqa: E402
+    L13_MAPPING_RECOMMENDATION,
+    CanonicalityResult,
+    IdentifierFinding,
+    evaluate_code,
+    recommended_l13_action,
+)
+
+
+# --------------------------------------------------------------------------- #
+#  Clean cases
+# --------------------------------------------------------------------------- #
+
+def test_clean_ascii_python():
+    r = evaluate_code("def add(x, y):\n    return x + y\n")
+    assert r.kind == "clean"
+    assert r.score == 0.0
+    assert r.findings == []
+    assert r.identifier_count >= 3
+    assert r.fingerprint is not None
+    assert recommended_l13_action(r) == "ALLOW"
+
+
+def test_clean_with_unicode_string_literal():
+    """Unicode in string LITERALS is fine — it's only the identifier that matters."""
+    src = 'def hello(name):\n    return f"hello, {name} 🌍"\n'
+    r = evaluate_code(src)
+    assert r.kind == "clean"
+
+
+# --------------------------------------------------------------------------- #
+#  Mixed-script attack (Latin + Cyrillic in one identifier)
+# --------------------------------------------------------------------------- #
+
+def test_mixed_script_cyrillic_latin():
+    # Cyrillic а sneaked into 'password'
+    src = "def login(pаssword):\n    return pаssword\n"
+    r = evaluate_code(src)
+    assert r.kind == "mixed_script"
+    assert r.score >= 0.85
+    assert recommended_l13_action(r) == "DENY"
+    bad = [f for f in r.findings if f.kind == "mixed_script"]
+    assert len(bad) >= 1
+    assert "Cyrillic" in bad[0].scripts and "Latin" in bad[0].scripts
+
+
+def test_mixed_script_greek_latin():
+    # Greek omicron in 'login'
+    src = "def lοgin(x):\n    return x\n"
+    r = evaluate_code(src)
+    assert r.kind == "mixed_script"
+    assert recommended_l13_action(r) == "DENY"
+
+
+# --------------------------------------------------------------------------- #
+#  Confusable-only attack (pure non-Latin script that mimics ASCII)
+# --------------------------------------------------------------------------- #
+
+def test_all_confusable_cyrillic():
+    # 'аре' is all Cyrillic, looks like ASCII 'ape'
+    src = "def get():\n    аре = 1\n    return аре\n"
+    r = evaluate_code(src)
+    assert r.kind == "confusable"
+    assert 0.55 < r.score < 0.75
+    assert recommended_l13_action(r) == "QUARANTINE"
+
+
+# --------------------------------------------------------------------------- #
+#  Invisible / BiDi character attacks
+# --------------------------------------------------------------------------- #
+
+def test_zero_width_joiner_in_identifier():
+    # ZWJ between 'admin' and '_check'
+    src = "def admin‍_check(x):\n    return x\n"
+    r = evaluate_code(src)
+    assert r.kind == "invisible"
+    assert r.score == 1.0
+    assert recommended_l13_action(r) == "DENY"
+
+
+def test_bidi_control_in_identifier_rejected_by_parser():
+    """Python's parser rejects BiDi controls in identifiers per PEP 3131
+    (only specific Unicode categories are allowed). So BiDi-in-identifier
+    surfaces as input_invalid, not a canonicality finding.
+
+    Genuine Trojan-Source attacks (CVE-2021-42574) target string literals
+    and comments — out of scope for the v1 identifier gate; a sibling
+    source-text BiDi scanner would catch those.
+    """
+    src = "def bad‮name(x):\n    return x\n"
+    r = evaluate_code(src)
+    assert r.kind == "input_invalid"
+
+
+# --------------------------------------------------------------------------- #
+#  Legitimate non-ASCII single-script identifier (allow with annotation)
+# --------------------------------------------------------------------------- #
+
+def test_greek_single_script_legitimate():
+    # 'τ' is a legitimate Greek-only identifier
+    src = "def τ(x):\n    return x\n"
+    r = evaluate_code(src)
+    assert r.kind == "non_ascii"
+    assert 0.20 < r.score < 0.40
+    assert recommended_l13_action(r) == "ALLOW"
+
+
+# --------------------------------------------------------------------------- #
+#  Catastrophic / edge cases
+# --------------------------------------------------------------------------- #
+
+def test_input_invalid_python():
+    r = evaluate_code("def f(:\n    return\n")
+    assert r.kind == "input_invalid"
+    assert r.score == 1.0
+
+
+def test_unsupported_language():
+    r = evaluate_code("fn main() {}", language="rust")
+    assert r.kind == "input_invalid"
+    assert r.score == 1.0
+
+
+# --------------------------------------------------------------------------- #
+#  L13 mapping coverage
+# --------------------------------------------------------------------------- #
+
+def test_l13_mapping_covers_all_kinds():
+    expected = {"clean", "non_ascii", "confusable", "mixed_script", "invisible", "input_invalid"}
+    assert set(L13_MAPPING_RECOMMENDATION.keys()) == expected
+
+
+def test_l13_mapping_actions_are_valid():
+    valid = {"ALLOW", "QUARANTINE", "DENY", "REROUTE"}
+    for action in L13_MAPPING_RECOMMENDATION.values():
+        assert action in valid
+
+
+# --------------------------------------------------------------------------- #
+#  Fingerprint stability
+# --------------------------------------------------------------------------- #
+
+def test_fingerprint_equal_for_same_identifiers_different_order():
+    src_a = "def f(x):\n    y = x\n    z = y\n    return z\n"
+    src_b = "def f(x):\n    z = y = x\n    return z\n"
+    r_a = evaluate_code(src_a)
+    r_b = evaluate_code(src_b)
+    # Same identifier set → same fingerprint
+    assert r_a.fingerprint == r_b.fingerprint
+
+
+def test_fingerprint_differs_for_different_identifiers():
+    r_a = evaluate_code("def f(x):\n    return x\n")
+    r_b = evaluate_code("def f(y):\n    return y\n")
+    assert r_a.fingerprint != r_b.fingerprint
+
+
+# --------------------------------------------------------------------------- #
+#  Serialization
+# --------------------------------------------------------------------------- #
+
+def test_to_dict_is_json_serializable():
+    import json
+
+    src = "def login(pаssword):\n    return pаssword\n"
+    r = evaluate_code(src)
+    serialized = json.dumps(r.to_dict())
+    restored = json.loads(serialized)
+    assert restored["kind"] == "mixed_script"
+    assert isinstance(restored["findings"], list)

--- a/tests/governance/test_identifier_canonicality_wireup.py
+++ b/tests/governance/test_identifier_canonicality_wireup.py
@@ -1,0 +1,198 @@
+"""Wire-up tests for identifier-canonicality overlay on RuntimeGate.
+
+Contract:
+  1. flag off                       -> no behavior change
+  2. flag on  + clean code          -> ALLOW + receipt
+  3. flag on  + mixed-script id     -> DENY + immune
+  4. flag on  + confusable-only id  -> QUARANTINE
+  5. flag on  + invisible char      -> DENY + immune
+  6. flag on  + legitimate Greek    -> ALLOW (non_ascii annotation)
+  7. base DENY + canonicality clean -> stays DENY (monotonic)
+  8. prose with code keywords       -> NOT DENY (heuristic safety)
+  9. env-var enables overlay
+ 10. tamper + canonicality compose: both signals visible in receipts
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.governance.runtime_gate import Decision, RuntimeGate  # noqa: E402
+
+
+CLEAN_PY = "def add(x, y):\n    return x + y\n"
+MIXED_SCRIPT_PY = "def login(pаssword):\n    return pаssword\n"  # Cyrillic а
+CONFUSABLE_PY = "def get():\n    аре = 1\n    return аре\n"  # all Cyrillic
+INVISIBLE_PY = "def admin‍_check(x):\n    return x\n"  # ZWJ
+GREEK_PY = "def τ(x):\n    return x\n"  # legitimate Greek single-script
+
+
+# --------------------------------------------------------------------------- #
+#  1. flag off — no behavior change
+# --------------------------------------------------------------------------- #
+
+def test_flag_off_default_is_no_op():
+    gate = RuntimeGate()
+    assert gate._identifier_canonicality_enabled is False
+    result = gate.evaluate(MIXED_SCRIPT_PY)
+    assert result.identifier_canonicality_kind == ""
+    assert result.identifier_canonicality_action == ""
+    assert result.identifier_canonicality_score == 0.0
+    assert not any("identifier_canonicality" in s for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  2. flag on + clean -> ALLOW with receipt
+# --------------------------------------------------------------------------- #
+
+def test_flag_on_clean_allows_with_receipt():
+    gate = RuntimeGate(use_identifier_canonicality=True)
+    result = gate.evaluate(CLEAN_PY)
+    assert result.decision == Decision.ALLOW
+    assert result.identifier_canonicality_kind == "clean"
+    assert result.identifier_canonicality_action == "ALLOW"
+    assert result.identifier_canonicality_score == 0.0
+    assert result.identifier_canonicality_fingerprint is not None
+    assert any(s.startswith("identifier_canonicality(") for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  3. mixed-script -> DENY + immune
+# --------------------------------------------------------------------------- #
+
+def test_mixed_script_attack_denies():
+    gate = RuntimeGate(use_identifier_canonicality=True)
+    result = gate.evaluate(MIXED_SCRIPT_PY)
+    assert result.decision == Decision.DENY
+    assert result.identifier_canonicality_kind == "mixed_script"
+    assert result.identifier_canonicality_action == "DENY"
+    assert any("identifier_canonicality_veto_deny" in s for s in result.signals)
+    assert result.action_hash in gate._immune
+
+
+# --------------------------------------------------------------------------- #
+#  4. confusable-only -> QUARANTINE
+# --------------------------------------------------------------------------- #
+
+def test_confusable_only_quarantines():
+    gate = RuntimeGate(use_identifier_canonicality=True)
+    result = gate.evaluate(CONFUSABLE_PY)
+    # QUARANTINE-recommendation overrides calibration ALLOW
+    assert result.decision == Decision.QUARANTINE
+    assert result.identifier_canonicality_kind == "confusable"
+    assert result.identifier_canonicality_action == "QUARANTINE"
+    assert any("identifier_canonicality_veto_quarantine" in s for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  5. invisible char -> DENY + immune
+# --------------------------------------------------------------------------- #
+
+def test_invisible_char_denies():
+    gate = RuntimeGate(use_identifier_canonicality=True)
+    result = gate.evaluate(INVISIBLE_PY)
+    assert result.decision == Decision.DENY
+    assert result.identifier_canonicality_kind == "invisible"
+    assert result.identifier_canonicality_score == 1.0
+    assert any("identifier_canonicality_veto_deny" in s for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  6. legitimate Greek -> ALLOW (non_ascii)
+# --------------------------------------------------------------------------- #
+
+def test_legitimate_greek_allows():
+    gate = RuntimeGate(use_identifier_canonicality=True)
+    result = gate.evaluate(GREEK_PY)
+    assert result.decision == Decision.ALLOW
+    assert result.identifier_canonicality_kind == "non_ascii"
+    assert result.identifier_canonicality_action == "ALLOW"
+
+
+# --------------------------------------------------------------------------- #
+#  7. base DENY (immune-hit) + canonicality clean -> stays DENY
+# --------------------------------------------------------------------------- #
+
+def test_base_deny_plus_canonicality_clean_stays_deny():
+    gate = RuntimeGate(use_identifier_canonicality=True)
+    import hashlib
+
+    h = hashlib.blake2s(CLEAN_PY.encode("utf-8", errors="replace"), digest_size=8).hexdigest()
+    gate._immune.add(h)
+    result = gate.evaluate(CLEAN_PY)
+    assert result.decision == Decision.DENY
+    # Receipt should still surface the clean canonicality assessment
+    assert result.identifier_canonicality_kind == "clean"
+
+
+# --------------------------------------------------------------------------- #
+#  8. prose with code keywords -> NOT DENY (heuristic safety)
+# --------------------------------------------------------------------------- #
+
+def test_prose_with_code_keywords_not_denied():
+    gate = RuntimeGate(use_identifier_canonicality=True)
+    for text in [
+        "Please write a function that sorts a list of numbers.",
+        "Import duty applies to this category from the spec.",
+        "Return to the previous step and try again.",
+        "The class action settlement covers all members.",
+    ]:
+        result = gate.evaluate(text)
+        assert result.decision != Decision.DENY, f"prose denied: {text!r}"
+        assert result.identifier_canonicality_kind == ""
+
+
+# --------------------------------------------------------------------------- #
+#  9. env-var enablement
+# --------------------------------------------------------------------------- #
+
+def test_env_var_enables_overlay(monkeypatch):
+    monkeypatch.setenv("SCBE_ENABLE_IDENTIFIER_CANONICALITY_GATE", "1")
+    gate = RuntimeGate()
+    assert gate._identifier_canonicality_enabled is True
+
+
+def test_env_var_explicit_kwarg_wins(monkeypatch):
+    monkeypatch.setenv("SCBE_ENABLE_IDENTIFIER_CANONICALITY_GATE", "1")
+    gate = RuntimeGate(use_identifier_canonicality=False)
+    assert gate._identifier_canonicality_enabled is False
+
+
+# --------------------------------------------------------------------------- #
+#  10. tamper + canonicality compose — both signals visible
+# --------------------------------------------------------------------------- #
+
+def test_tamper_and_canonicality_compose():
+    """Both overlays on at once: both receipts must appear in audit."""
+    gate = RuntimeGate(
+        use_bijective_tamper=True,
+        use_identifier_canonicality=True,
+    )
+    result = gate.evaluate(CLEAN_PY)
+    receipts = [s for s in result.signals if "(" in s]
+    has_tamper = any(s.startswith("bijective_tamper(") for s in receipts)
+    has_canon = any(s.startswith("identifier_canonicality(") for s in receipts)
+    assert has_tamper, f"missing bijective_tamper receipt; got {receipts}"
+    assert has_canon, f"missing identifier_canonicality receipt; got {receipts}"
+    # Both fields populated
+    assert result.bijective_tamper_kind == "none"
+    assert result.identifier_canonicality_kind == "clean"
+
+
+def test_canonicality_deny_short_circuits_with_tamper_receipt():
+    """When canonicality says DENY, the receipt for any concurrently-enabled
+    tamper signal must still appear in the short-circuit signals."""
+    gate = RuntimeGate(
+        use_bijective_tamper=True,
+        use_identifier_canonicality=True,
+    )
+    result = gate.evaluate(MIXED_SCRIPT_PY)
+    assert result.decision == Decision.DENY
+    has_tamper = any(s.startswith("bijective_tamper(") for s in result.signals)
+    has_canon = any(s.startswith("identifier_canonicality(") for s in result.signals)
+    assert has_tamper, f"missing tamper receipt in DENY signals: {result.signals}"
+    assert has_canon, f"missing canonicality receipt in DENY signals: {result.signals}"

--- a/tests/governance/test_tree_of_escalation.py
+++ b/tests/governance/test_tree_of_escalation.py
@@ -1,0 +1,1183 @@
+"""Unit tests for Tree of Escalation v0.1 data structures.
+
+v0.1 is data-structures-only: no walker, no sandbox, no execution.
+These tests verify construction, invariants, and the locked
+architectural decisions (Q5 adversarial pairing, Q6 NULL-bridge
+serialization).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.governance.tree_of_escalation import (  # noqa: E402
+    BAND_FREQUENCY_MULTIPLIER,
+    DEFAULT_LADDER,
+    DOMAIN_ADVERSARY,
+    DOMAIN_PRIMARY,
+    LANE_PHI_WEIGHT,
+    LANE_TIER,
+    LANE_TO_TRI_BUNDLE_CODE,
+    NULL_BRIDGE_VOID_ID,
+    SYSTEM_FUNDAMENTAL_HZ,
+    AudioEvent,
+    Band,
+    BridgeEdge,
+    BridgeMatrix,
+    Flag,
+    HashReader,
+    IdentityPrior,
+    InspectionResult,
+    IsolationPrior,
+    Lane,
+    LanePair,
+    Node,
+    NodeKind,
+    OpTrace,
+    Posture,
+    ProvisionalRegistry,
+    Termination,
+    Tree,
+    VoidStats,
+    classify_domain,
+    emit_audio,
+    hash_payload,
+    majority_converged,
+    mint_provisional,
+    sandbox,
+    select_initial_pair,
+    walk,
+)
+
+# --------------------------------------------------------------------------- #
+#  Lane enumeration — six tongues plus CUSTOM
+# --------------------------------------------------------------------------- #
+
+
+def test_lane_enum_has_six_tongues_plus_custom():
+    expected = {
+        "koraelin",
+        "avali",
+        "runethic",
+        "cassisivadan",
+        "umbroth",
+        "draumric",
+        "custom",
+    }
+    assert {lane.value for lane in Lane} == expected
+
+
+def test_default_ladder_excludes_custom():
+    assert Lane.CUSTOM not in DEFAULT_LADDER
+    assert len(DEFAULT_LADDER) == 6
+
+
+def test_default_ladder_in_phi_weight_ascending_order():
+    weights = [LANE_PHI_WEIGHT[lane] for lane in DEFAULT_LADDER]
+    assert weights == sorted(weights)
+
+
+def test_lane_tier_assignment_t1_to_t6():
+    tiers = [LANE_TIER[lane] for lane in DEFAULT_LADDER]
+    assert tiers == [1, 2, 3, 4, 5, 6]
+
+
+def test_custom_lane_intentionally_omitted_from_weight_and_tier():
+    assert Lane.CUSTOM not in LANE_PHI_WEIGHT
+    assert Lane.CUSTOM not in LANE_TIER
+
+
+# --------------------------------------------------------------------------- #
+#  Band — three concurrent substrates
+# --------------------------------------------------------------------------- #
+
+
+def test_band_enum_has_three_substrates():
+    assert {b.value for b in Band} == {"infra", "audible", "ultra"}
+
+
+# --------------------------------------------------------------------------- #
+#  Posture — humble vs rigid
+# --------------------------------------------------------------------------- #
+
+
+def test_posture_enum_has_humble_and_rigid():
+    assert {p.value for p in Posture} == {"humble", "rigid"}
+
+
+# --------------------------------------------------------------------------- #
+#  NodeKind covers all categories from the spec
+# --------------------------------------------------------------------------- #
+
+
+def test_node_kind_covers_all_spec_categories():
+    expected = {
+        "op",
+        "sandbox_provisional",
+        "sandbox_inspection",
+        "sandbox_internalized",
+        "null_bridge_void",
+        "provisional_mint",
+    }
+    assert {k.value for k in NodeKind} == expected
+
+
+# --------------------------------------------------------------------------- #
+#  hash_payload — sanity
+# --------------------------------------------------------------------------- #
+
+
+def test_hash_payload_returns_32_bytes():
+    h = hash_payload(b"hello")
+    assert isinstance(h, bytes)
+    assert len(h) == 32
+
+
+def test_hash_payload_deterministic():
+    assert hash_payload(b"abc") == hash_payload(b"abc")
+    assert hash_payload(b"abc") != hash_payload(b"abd")
+
+
+# --------------------------------------------------------------------------- #
+#  Tree — singleton VOID is auto-inserted
+# --------------------------------------------------------------------------- #
+
+
+def test_tree_init_inserts_void_singleton_at_canonical_id():
+    t = Tree()
+    assert len(t.nodes) == 1
+    assert t.nodes[0].id == NULL_BRIDGE_VOID_ID
+    assert t.nodes[0].kind == NodeKind.NULL_BRIDGE_VOID
+
+
+def test_tree_void_is_first_node_index_zero():
+    t = Tree()
+    assert NULL_BRIDGE_VOID_ID == 0
+    assert t.nodes[NULL_BRIDGE_VOID_ID].kind == NodeKind.NULL_BRIDGE_VOID
+
+
+def test_tree_default_posture_is_humble():
+    assert Tree().posture == Posture.HUMBLE
+
+
+# --------------------------------------------------------------------------- #
+#  add_node — id must match insertion index
+# --------------------------------------------------------------------------- #
+
+
+def test_add_node_appends_with_matching_id():
+    t = Tree()
+    n = Node(id=1, kind=NodeKind.OP, lane=Lane.KORAELIN, band=Band.AUDIBLE)
+    nid = t.add_node(n)
+    assert nid == 1
+    assert t.nodes[1] is n
+
+
+def test_add_node_rejects_id_mismatch():
+    t = Tree()
+    bad = Node(id=99, kind=NodeKind.OP)
+    with pytest.raises(ValueError, match="node id"):
+        t.add_node(bad)
+
+
+# --------------------------------------------------------------------------- #
+#  LanePair — adversarial pairing invariants (Q5)
+# --------------------------------------------------------------------------- #
+
+
+def test_lane_pair_carries_domain_field():
+    pair = LanePair(
+        primary=Lane.KORAELIN,
+        adversary=Lane.UMBROTH,
+        domain="formal_logic",
+    )
+    assert pair.domain == "formal_logic"
+
+
+def test_lane_pair_rejects_self_pairing():
+    with pytest.raises(ValueError, match="must differ"):
+        LanePair(primary=Lane.AVALI, adversary=Lane.AVALI)
+
+
+def test_lane_pair_allows_custom_lane_as_adversary():
+    pair = LanePair(primary=Lane.KORAELIN, adversary=Lane.CUSTOM)
+    assert pair.adversary == Lane.CUSTOM
+
+
+# --------------------------------------------------------------------------- #
+#  BridgeEdge — defaults and NULL-bridge invariants (Q6)
+# --------------------------------------------------------------------------- #
+
+
+def test_bridge_edge_defaults_to_translatable():
+    e = BridgeEdge(source_id=1, target_id=2)
+    assert e.is_untranslatable is False
+    assert e.untranslatable_reason is None
+    assert e.untranslatable_op_id is None
+
+
+def test_null_bridge_edge_carries_failure_metadata_on_edge_not_void():
+    """Q6: per-failure metadata lives on the edge, NOT the singleton."""
+    t = Tree()
+    src = Node(id=1, kind=NodeKind.OP, lane=Lane.KORAELIN)
+    t.add_node(src)
+    e = BridgeEdge(
+        source_id=1,
+        target_id=NULL_BRIDGE_VOID_ID,
+        is_untranslatable=True,
+        untranslatable_reason="no quantum-allocation analogue in tongue j",
+        untranslatable_op_id="qmem_alloc_v1",
+    )
+    t.add_edge(e)
+    # Metadata is on the edge:
+    assert t.edges[0].untranslatable_reason.startswith("no quantum")
+    assert t.edges[0].untranslatable_op_id == "qmem_alloc_v1"
+    # The void node still carries no per-failure metadata, only stats:
+    assert t.nodes[NULL_BRIDGE_VOID_ID].payload == {}
+
+
+def test_null_bridge_must_terminate_at_void_singleton():
+    t = Tree()
+    src = Node(id=1, kind=NodeKind.OP, lane=Lane.AVALI)
+    t.add_node(src)
+    bad = BridgeEdge(
+        source_id=1,
+        target_id=1,  # NOT the void singleton
+        is_untranslatable=True,
+    )
+    with pytest.raises(ValueError, match="NULL_BRIDGE_VOID"):
+        t.add_edge(bad)
+
+
+def test_edge_endpoints_validated():
+    t = Tree()
+    bad = BridgeEdge(source_id=42, target_id=NULL_BRIDGE_VOID_ID)
+    with pytest.raises(ValueError, match="out of range"):
+        t.add_edge(bad)
+
+
+# --------------------------------------------------------------------------- #
+#  VoidStats aggregation (Q6)
+# --------------------------------------------------------------------------- #
+
+
+def test_void_stats_increment_on_null_bridge():
+    t = Tree()
+    a = Node(id=1, kind=NodeKind.OP, lane=Lane.KORAELIN)
+    t.add_node(a)
+    t.add_edge(
+        BridgeEdge(
+            source_id=1,
+            target_id=NULL_BRIDGE_VOID_ID,
+            is_untranslatable=True,
+            untranslatable_op_id="op_a",
+        )
+    )
+    assert t.void_stats.incoming_edge_count == 1
+    assert t.void_stats.distinct_ops_failed == 1
+
+
+def test_void_stats_distinct_ops_dedup():
+    t = Tree()
+    a = Node(id=1, kind=NodeKind.OP, lane=Lane.KORAELIN)
+    b = Node(id=2, kind=NodeKind.OP, lane=Lane.AVALI)
+    t.add_node(a)
+    t.add_node(b)
+    for src in (1, 2, 1):  # three failures, two distinct ops
+        t.add_edge(
+            BridgeEdge(
+                source_id=src,
+                target_id=NULL_BRIDGE_VOID_ID,
+                is_untranslatable=True,
+                untranslatable_op_id=("op_a" if src == 1 else "op_b"),
+            )
+        )
+    assert t.void_stats.incoming_edge_count == 3
+    assert t.void_stats.distinct_ops_failed == 2
+
+
+def test_void_stats_lane_pair_attribution():
+    t = Tree()
+    t.lane_pair = LanePair(primary=Lane.KORAELIN, adversary=Lane.UMBROTH)
+    a = Node(id=1, kind=NodeKind.OP, lane=Lane.KORAELIN)
+    t.add_node(a)
+    t.add_edge(
+        BridgeEdge(
+            source_id=1,
+            target_id=NULL_BRIDGE_VOID_ID,
+            is_untranslatable=True,
+            untranslatable_op_id="op_a",
+        )
+    )
+    key = (Lane.KORAELIN, Lane.UMBROTH)
+    assert t.void_stats.failures_by_lane_pair[key] == 1
+
+
+def test_translatable_edge_does_not_touch_void_stats():
+    t = Tree()
+    a = Node(id=1, kind=NodeKind.OP, lane=Lane.KORAELIN)
+    b = Node(id=2, kind=NodeKind.OP, lane=Lane.AVALI)
+    t.add_node(a)
+    t.add_node(b)
+    t.add_edge(BridgeEdge(source_id=1, target_id=2, information_variance=0.42))
+    assert t.void_stats.incoming_edge_count == 0
+    assert t.void_stats.distinct_ops_failed == 0
+
+
+# --------------------------------------------------------------------------- #
+#  Standalone VoidStats default invariants
+# --------------------------------------------------------------------------- #
+
+
+def test_void_stats_defaults_zero():
+    s = VoidStats()
+    assert s.incoming_edge_count == 0
+    assert s.distinct_ops_failed == 0
+    assert s.failures_by_lane_pair == {}
+
+
+# =========================================================================== #
+#  v0.2 — BridgeMatrix, HashReader, walker
+# =========================================================================== #
+
+
+def _all_clean_matrix() -> BridgeMatrix:
+    matrix = BridgeMatrix()
+    for lane in DEFAULT_LADDER:
+        matrix.register_reader(lane, HashReader(lane=lane))
+    return matrix
+
+
+def test_hash_reader_clean_payload_is_deterministic():
+    r = HashReader(lane=Lane.KORAELIN)
+    a = r.read(b"hello")
+    b = r.read(b"hello")
+    assert a[0].result_hash == b[0].result_hash
+
+
+def test_hash_reader_perturb_changes_result_hash():
+    clean = HashReader(lane=Lane.AVALI)
+    dirty = HashReader(lane=Lane.AVALI, perturb=b"X")
+    assert clean.read(b"hi")[0].result_hash != dirty.read(b"hi")[0].result_hash
+
+
+def test_bridge_matrix_identity_implicit():
+    m = BridgeMatrix()
+    op = OpTrace(op_id="t", args_hash=b"\x00" * 32, result_hash=b"\x01" * 32)
+    assert m.bridge(Lane.KORAELIN, Lane.KORAELIN, op) is op
+
+
+def test_bridge_matrix_unregistered_returns_null():
+    m = BridgeMatrix()
+    op = OpTrace(op_id="t", args_hash=b"\x00" * 32, result_hash=b"\x01" * 32)
+    assert m.bridge(Lane.KORAELIN, Lane.AVALI, op) is None
+
+
+def test_bridge_matrix_registered_bridge_invoked():
+    m = BridgeMatrix()
+    sentinel = OpTrace(op_id="bridged", args_hash=b"\x02" * 32, result_hash=b"\x03" * 32)
+    m.register_bridge(Lane.KORAELIN, Lane.AVALI, lambda _op: sentinel)
+    op = OpTrace(op_id="t", args_hash=b"\x00" * 32, result_hash=b"\x01" * 32)
+    assert m.bridge(Lane.KORAELIN, Lane.AVALI, op) is sentinel
+
+
+def test_bridge_matrix_reader_for_missing_raises():
+    m = BridgeMatrix()
+    with pytest.raises(KeyError):
+        m.reader_for(Lane.RUNETHIC)
+
+
+def test_bridge_matrix_register_identity_bridge_rejected():
+    m = BridgeMatrix()
+    with pytest.raises(ValueError, match="identity"):
+        m.register_bridge(Lane.KORAELIN, Lane.KORAELIN, lambda op: op)
+
+
+# --- majority_converged ---------------------------------------------------- #
+
+
+def test_majority_converged_unanimous_returns_hash():
+    h = b"\xaa" * 32
+    streams = {
+        Lane.KORAELIN: (OpTrace("a", b"", h),),
+        Lane.AVALI: (OpTrace("b", b"", h),),
+    }
+    assert majority_converged(streams) == h
+
+
+def test_majority_converged_split_returns_none():
+    streams = {
+        Lane.KORAELIN: (OpTrace("a", b"", b"\xaa" * 32),),
+        Lane.AVALI: (OpTrace("b", b"", b"\xbb" * 32),),
+    }
+    assert majority_converged(streams) is None
+
+
+def test_majority_converged_strict_majority_in_five():
+    h_clean = b"\xcc" * 32
+    streams = {
+        Lane.KORAELIN: (OpTrace("a", b"", b"\x01" * 32),),  # dirty
+        Lane.AVALI: (OpTrace("b", b"", b"\x02" * 32),),  # dirty
+        Lane.RUNETHIC: (OpTrace("c", b"", h_clean),),  # clean
+        Lane.CASSISIVADAN: (OpTrace("d", b"", h_clean),),  # clean
+        Lane.UMBROTH: (OpTrace("e", b"", h_clean),),  # clean
+    }
+    assert majority_converged(streams) == h_clean
+
+
+def test_majority_converged_no_strict_majority_in_four():
+    h = b"\xdd" * 32
+    streams = {
+        Lane.KORAELIN: (OpTrace("a", b"", b"\x01" * 32),),
+        Lane.AVALI: (OpTrace("b", b"", b"\x02" * 32),),
+        Lane.RUNETHIC: (OpTrace("c", b"", h),),
+        Lane.CASSISIVADAN: (OpTrace("d", b"", h),),
+    }
+    # 2 of 4 is not STRICT majority
+    assert majority_converged(streams) is None
+
+
+# --- walker --------------------------------------------------------------- #
+
+
+def test_walker_bicameral_converges_when_clean():
+    matrix = _all_clean_matrix()
+    tree = walk(b"hello", matrix)
+    assert tree.abridged_form is not None
+    assert tree.abridged_form == hash_payload(b"hello")
+    assert tree.tier_reached == 2  # T1 (KO) + T2 (AV)
+    assert tree.lane_pair.primary == Lane.KORAELIN
+    assert tree.lane_pair.adversary == Lane.AVALI
+
+
+def test_walker_records_op_nodes_for_each_lane_read():
+    matrix = _all_clean_matrix()
+    tree = walk(b"abc", matrix)
+    op_nodes = [n for n in tree.nodes if n.kind == NodeKind.OP]
+    # Two lanes converged on first read -> exactly 2 op nodes
+    assert len(op_nodes) == 2
+    assert {n.lane for n in op_nodes} == {Lane.KORAELIN, Lane.AVALI}
+    assert all(n.band == Band.AUDIBLE for n in op_nodes)
+
+
+def test_walker_escalates_when_pair_diverges():
+    matrix = BridgeMatrix()
+    matrix.register_reader(Lane.KORAELIN, HashReader(Lane.KORAELIN, perturb=b"X"))
+    matrix.register_reader(Lane.AVALI, HashReader(Lane.AVALI, perturb=b"Y"))
+    matrix.register_reader(Lane.RUNETHIC, HashReader(Lane.RUNETHIC))
+    matrix.register_reader(Lane.CASSISIVADAN, HashReader(Lane.CASSISIVADAN))
+    matrix.register_reader(Lane.UMBROTH, HashReader(Lane.UMBROTH))
+    matrix.register_reader(Lane.DRAUMRIC, HashReader(Lane.DRAUMRIC))
+    tree = walk(b"input", matrix)
+    # Convergence happens at T5 (UM): 3 of 5 lanes are clean -> strict majority
+    assert tree.abridged_form == hash_payload(b"input")
+    assert tree.tier_reached == 5
+
+
+def test_walker_t6_exhaustion_rigid_refuses():
+    # All six lanes perturbed differently — never converges
+    matrix = BridgeMatrix()
+    for i, lane in enumerate(DEFAULT_LADDER):
+        matrix.register_reader(lane, HashReader(lane, perturb=bytes([i])))
+    tree = walk(b"input", matrix, posture=Posture.RIGID)
+    assert tree.abridged_form is None
+    assert tree.tier_reached == 6
+    assert tree.provisional_minted is False
+    assert tree.terminated_as == Termination.REFUSED
+    assert tree.refusal_reason  # non-empty
+
+
+def test_walker_respects_explicit_initial_pair():
+    matrix = _all_clean_matrix()
+    pair = LanePair(
+        primary=Lane.RUNETHIC,
+        adversary=Lane.UMBROTH,
+        domain="formal_logic",
+    )
+    tree = walk(b"x", matrix, initial_pair=pair)
+    assert tree.lane_pair == pair
+    assert tree.abridged_form is not None
+    # Initial tier is the higher of the two: UMBROTH = T5
+    assert tree.tier_reached == 5
+
+
+def test_walker_posture_propagates_to_tree():
+    matrix = _all_clean_matrix()
+    tree = walk(b"x", matrix, posture=Posture.RIGID)
+    assert tree.posture == Posture.RIGID
+
+
+def test_walker_missing_reader_raises():
+    matrix = BridgeMatrix()
+    matrix.register_reader(Lane.KORAELIN, HashReader(Lane.KORAELIN))
+    # Avali never registered -> KeyError on bicameral read
+    with pytest.raises(KeyError):
+        # pin pair to KORAELIN+AVALI so we don't depend on default classifier
+        walk(
+            b"x",
+            matrix,
+            initial_pair=LanePair(
+                primary=Lane.KORAELIN,
+                adversary=Lane.AVALI,
+            ),
+        )
+
+
+# =========================================================================== #
+#  v0.3 — Flag, MoralPrior, sandbox, adversarial pair selection
+# =========================================================================== #
+
+
+# --- Flag ----------------------------------------------------------------- #
+
+
+def test_flag_defaults():
+    f = Flag(source="bijective_tamper", kind="syntax")
+    assert f.severity == 0.0
+    assert f.metadata == {}
+
+
+def test_flag_carries_metadata():
+    f = Flag(
+        source="identifier_canonicality",
+        kind="mixed_script",
+        severity=0.9,
+        metadata={"identifier": "pаssword"},
+    )
+    assert f.metadata["identifier"] == "pаssword"
+
+
+# --- IdentityPrior / IsolationPrior --------------------------------------- #
+
+
+def test_identity_prior_returns_payload_unchanged():
+    p = IdentityPrior()
+    r = p.inspect(b"hello", [Flag("test", "test")])
+    assert r.transformed_payload == b"hello"
+    assert r.prior_id == "identity"
+
+
+def test_isolation_prior_wraps_payload():
+    p = IsolationPrior(envelope=b"|")
+    r = p.inspect(b"x", [Flag("test", "test")])
+    assert r.transformed_payload == b"|x|"
+    assert r.prior_id == "isolation"
+
+
+def test_inspection_result_carries_notes():
+    r = InspectionResult(prior_id="x", transformed_payload=b"y", notes="hi")
+    assert r.notes == "hi"
+
+
+# --- sandbox() ------------------------------------------------------------ #
+
+
+def test_sandbox_requires_flags():
+    t = Tree()
+    with pytest.raises(ValueError, match="no flags"):
+        sandbox(b"x", [], [IdentityPrior()], t)
+
+
+def test_sandbox_requires_priors():
+    t = Tree()
+    with pytest.raises(ValueError, match="no priors"):
+        sandbox(b"x", [Flag("s", "k")], [], t)
+
+
+def test_sandbox_adds_provisional_inspections_and_internalized_nodes():
+    t = Tree()
+    flags = [Flag("bijective_tamper", "syntax", 0.5)]
+    priors = [IdentityPrior(), IsolationPrior()]
+    sandbox(b"hello", flags, priors, t)
+    # 1 VOID + 1 provisional + 2 inspection + 1 internalized = 5 total
+    assert len(t.nodes) == 5
+    kinds = [n.kind for n in t.nodes]
+    assert kinds.count(NodeKind.SANDBOX_PROVISIONAL) == 1
+    assert kinds.count(NodeKind.SANDBOX_INSPECTION) == 2
+    assert kinds.count(NodeKind.SANDBOX_INTERNALIZED) == 1
+
+
+def test_sandbox_sets_tree_invoked_flag():
+    t = Tree()
+    sandbox(b"x", [Flag("s", "k")], [IdentityPrior()], t)
+    assert t.sandbox_invoked is True
+
+
+def test_sandbox_internalized_node_has_result_hash():
+    t = Tree()
+    sandbox(b"x", [Flag("s", "k")], [IdentityPrior()], t)
+    internalized = next(n for n in t.nodes if n.kind == NodeKind.SANDBOX_INTERNALIZED)
+    assert internalized.result_hash is not None
+    assert len(internalized.result_hash) == 32
+
+
+def test_sandbox_provisional_records_flags():
+    t = Tree()
+    flags = [Flag("a", "k1", 0.3), Flag("b", "k2", 0.7)]
+    sandbox(b"x", flags, [IdentityPrior()], t)
+    prov = next(n for n in t.nodes if n.kind == NodeKind.SANDBOX_PROVISIONAL)
+    recorded = prov.payload["flags"]
+    assert len(recorded) == 2
+    assert recorded[0]["source"] == "a"
+    assert recorded[1]["kind"] == "k2"
+
+
+# --- classify_domain ------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "text,expected_domain",
+    [
+        ("forall x, x = x", "formal_logic"),
+        ("Theorem: there exists a prime", "formal_logic"),
+        ("malloc(64); buffer overflow risk", "low_level"),
+        ("integral of x^2 dx", "symbolic_math"),
+        ("function add(a, b) { return a + b; }", "scripting"),
+        ("the metaphor of the woods", "linguistic_nuance"),
+        ("just some random text", "default"),
+        ("", "default"),
+    ],
+)
+def test_classify_domain_keyword_match(text, expected_domain):
+    assert classify_domain(text.encode("utf-8")) == expected_domain
+
+
+def test_classify_domain_handles_non_utf8():
+    # Invalid UTF-8 bytes shouldn't crash — fall back to default
+    assert classify_domain(b"\xff\xfe\xfd random bytes") == "default"
+
+
+# --- select_initial_pair -------------------------------------------------- #
+
+
+def test_select_initial_pair_default_domain():
+    pair = select_initial_pair(b"random text")
+    assert pair.domain == "default"
+    assert pair.primary == Lane.KORAELIN
+    assert pair.adversary == Lane.AVALI
+
+
+def test_select_initial_pair_formal_logic():
+    pair = select_initial_pair(b"forall x, x implies x")
+    assert pair.domain == "formal_logic"
+    assert pair.primary == Lane.UMBROTH  # Haskell-spirit
+    assert pair.adversary == Lane.AVALI  # JS-spirit
+
+
+def test_select_initial_pair_low_level():
+    pair = select_initial_pair(b"malloc(buffer)")
+    assert pair.domain == "low_level"
+    assert pair.primary == Lane.RUNETHIC  # Rust-spirit
+    assert pair.adversary == Lane.DRAUMRIC  # Markdown-spirit
+
+
+def test_select_initial_pair_never_self_pair():
+    # All domain mappings must produce distinct primary/adversary
+    for domain, primary in DOMAIN_PRIMARY.items():
+        adversary = DOMAIN_ADVERSARY.get(domain, Lane.AVALI)
+        assert primary != adversary, f"domain {domain} self-pairs on {primary}"
+
+
+# --- walker integration with v0.3 features --------------------------------- #
+
+
+def test_walker_uses_adversarial_selection_when_no_explicit_pair():
+    matrix = _all_clean_matrix()
+    tree = walk(b"forall x, x", matrix)
+    # formal_logic -> Umbroth + Avali
+    assert tree.lane_pair.primary == Lane.UMBROTH
+    assert tree.lane_pair.adversary == Lane.AVALI
+    assert tree.lane_pair.domain == "formal_logic"
+
+
+def test_walker_with_flags_invokes_sandbox():
+    matrix = _all_clean_matrix()
+    tree = walk(
+        b"hello",
+        matrix,
+        flags=[Flag("bijective_tamper", "syntax", 0.5)],
+        priors=[IdentityPrior()],
+    )
+    assert tree.sandbox_invoked is True
+    sandbox_kinds = {NodeKind.SANDBOX_PROVISIONAL, NodeKind.SANDBOX_INSPECTION, NodeKind.SANDBOX_INTERNALIZED}
+    sandbox_nodes = [n for n in tree.nodes if n.kind in sandbox_kinds]
+    assert len(sandbox_nodes) == 3  # provisional + 1 inspection + internalized
+
+
+def test_walker_without_flags_no_sandbox_nodes():
+    matrix = _all_clean_matrix()
+    tree = walk(b"hello", matrix)
+    assert tree.sandbox_invoked is False
+    sandbox_kinds = {NodeKind.SANDBOX_PROVISIONAL, NodeKind.SANDBOX_INSPECTION, NodeKind.SANDBOX_INTERNALIZED}
+    sandbox_nodes = [n for n in tree.nodes if n.kind in sandbox_kinds]
+    assert sandbox_nodes == []
+
+
+def test_walker_flags_without_priors_raises():
+    matrix = _all_clean_matrix()
+    with pytest.raises(ValueError, match="no priors"):
+        walk(b"x", matrix, flags=[Flag("s", "k")])
+
+
+def test_walker_sandbox_vote_does_not_override_lane_majority():
+    """Clean lanes converge on hash(payload); sandbox interpretation
+    differs but is outvoted. Abridged form is still the lane majority.
+    """
+    matrix = _all_clean_matrix()
+    tree = walk(
+        b"hello",
+        matrix,
+        flags=[Flag("bijective_tamper", "syntax")],
+        priors=[IdentityPrior()],
+    )
+    # 2 lanes vote hash("hello"); sandbox votes hash(hash(hash("hello"))).
+    # Strict majority needs >50% which means 2 of 3 -> lanes win.
+    assert tree.abridged_form == hash_payload(b"hello")
+
+
+def test_walker_explicit_pair_overrides_classifier():
+    matrix = _all_clean_matrix()
+    pin = LanePair(primary=Lane.RUNETHIC, adversary=Lane.UMBROTH, domain="pinned")
+    tree = walk(b"forall x, x", matrix, initial_pair=pin)
+    # Even though payload classifies as formal_logic, explicit pair wins
+    assert tree.lane_pair == pin
+
+
+# =========================================================================== #
+#  v0.4 — Termination, provisional minting, decay registry
+# =========================================================================== #
+
+
+def _all_perturbed_matrix() -> BridgeMatrix:
+    """All six lanes perturbed differently — guaranteed T6 exhaustion."""
+    matrix = BridgeMatrix()
+    for i, lane in enumerate(DEFAULT_LADDER):
+        matrix.register_reader(lane, HashReader(lane, perturb=bytes([i + 1])))
+    return matrix
+
+
+# --- Termination enum ----------------------------------------------------- #
+
+
+def test_termination_enum_has_four_states():
+    assert {t.value for t in Termination} == {
+        "incomplete",
+        "abridged",
+        "provisional",
+        "refused",
+    }
+
+
+def test_tree_default_termination_is_incomplete():
+    assert Tree().terminated_as == Termination.INCOMPLETE
+
+
+# --- Walker termination tagging ------------------------------------------- #
+
+
+def test_walker_converged_tags_abridged():
+    matrix = _all_clean_matrix()
+    tree = walk(b"x", matrix)
+    assert tree.terminated_as == Termination.ABRIDGED
+
+
+def test_walker_humble_t6_exhaustion_mints_provisional():
+    matrix = _all_perturbed_matrix()
+    tree = walk(b"input", matrix)  # HUMBLE default
+    assert tree.tier_reached == 6
+    assert tree.provisional_minted is True
+    assert tree.abridged_form is not None
+    assert tree.terminated_as == Termination.PROVISIONAL
+    assert any(n.kind == NodeKind.PROVISIONAL_MINT for n in tree.nodes)
+
+
+def test_walker_rigid_t6_exhaustion_refuses_with_reason():
+    matrix = _all_perturbed_matrix()
+    tree = walk(b"input", matrix, posture=Posture.RIGID)
+    assert tree.tier_reached == 6
+    assert tree.provisional_minted is False
+    assert tree.abridged_form is None
+    assert tree.terminated_as == Termination.REFUSED
+    assert "no representation" in tree.refusal_reason
+    assert "T1..T6" in tree.refusal_reason
+
+
+def test_walker_humble_no_provisional_mint_node_when_converged():
+    matrix = _all_clean_matrix()
+    tree = walk(b"x", matrix)
+    assert not any(n.kind == NodeKind.PROVISIONAL_MINT for n in tree.nodes)
+
+
+# --- mint_provisional ----------------------------------------------------- #
+
+
+def test_mint_provisional_deterministic():
+    streams = {
+        Lane.KORAELIN: (OpTrace("a", b"", b"\x01" * 32),),
+        Lane.AVALI: (OpTrace("b", b"", b"\x02" * 32),),
+    }
+    a = mint_provisional(streams)
+    b = mint_provisional(streams)
+    assert a == b
+    assert len(a) == 32
+
+
+def test_mint_provisional_order_independent():
+    s1 = {
+        Lane.KORAELIN: (OpTrace("a", b"", b"\x01" * 32),),
+        Lane.AVALI: (OpTrace("b", b"", b"\x02" * 32),),
+    }
+    s2 = {
+        Lane.AVALI: (OpTrace("b", b"", b"\x02" * 32),),
+        Lane.KORAELIN: (OpTrace("a", b"", b"\x01" * 32),),
+    }
+    assert mint_provisional(s1) == mint_provisional(s2)
+
+
+def test_mint_provisional_includes_extra_votes():
+    streams = {Lane.KORAELIN: (OpTrace("a", b"", b"\x01" * 32),)}
+    a = mint_provisional(streams)
+    b = mint_provisional(streams, extra_votes=[b"\x99" * 32])
+    assert a != b
+
+
+def test_mint_provisional_empty_input_returns_hash_of_empty():
+    assert mint_provisional({}) == hash_payload(b"")
+
+
+# --- ProvisionalRegistry -------------------------------------------------- #
+
+
+def test_registry_first_record_is_a_mint_with_zero_corroboration():
+    reg = ProvisionalRegistry()
+    rec = reg.record(b"\xaa" * 32)
+    assert rec.corroboration_count == 0
+    assert rec.minted_at == 1
+    assert rec.last_seen_at == 1
+
+
+def test_registry_second_record_corroborates():
+    reg = ProvisionalRegistry()
+    h = b"\xaa" * 32
+    reg.record(h)
+    rec = reg.record(h)
+    assert rec.corroboration_count == 1
+    assert rec.minted_at == 1  # original mint
+    assert rec.last_seen_at == 2  # refreshed
+
+
+def test_registry_distinct_hashes_independent():
+    reg = ProvisionalRegistry()
+    a = reg.record(b"\xaa" * 32)
+    b = reg.record(b"\xbb" * 32)
+    assert a.minted_at == 1
+    assert b.minted_at == 2
+    assert len(reg) == 2
+
+
+def test_registry_get_returns_record_or_none():
+    reg = ProvisionalRegistry()
+    h = b"\xcc" * 32
+    assert reg.get(h) is None
+    reg.record(h)
+    assert reg.get(h) is not None
+
+
+def test_registry_contains_membership():
+    reg = ProvisionalRegistry()
+    h = b"\xdd" * 32
+    assert h not in reg
+    reg.record(h)
+    assert h in reg
+
+
+def test_registry_decay_removes_stale_under_corroborated():
+    reg = ProvisionalRegistry(decay_window=2, min_corroborations=2)
+    stale = b"\x01" * 32
+    reg.record(stale)
+    # advance counter past decay_window without re-recording stale
+    for _ in range(5):
+        reg.record(b"\x02" * 32)
+    removed = reg.decay()
+    assert stale in removed
+    assert stale not in reg
+
+
+def test_registry_decay_keeps_corroborated_even_if_stale():
+    reg = ProvisionalRegistry(decay_window=2, min_corroborations=2)
+    h = b"\xee" * 32
+    reg.record(h)
+    reg.record(h)  # corroboration_count=1
+    reg.record(h)  # corroboration_count=2 -> meets threshold
+    # let it go stale by recording other things
+    for _ in range(10):
+        reg.record(b"\x02" * 32)
+    reg.decay()
+    assert h in reg
+
+
+def test_registry_decay_keeps_recent_even_if_under_corroborated():
+    reg = ProvisionalRegistry(decay_window=100, min_corroborations=5)
+    h = b"\xff" * 32
+    reg.record(h)
+    reg.decay()
+    assert h in reg
+
+
+# --- Walker integration with registry ------------------------------------- #
+
+
+def test_walker_records_provisional_in_registry():
+    matrix = _all_perturbed_matrix()
+    reg = ProvisionalRegistry()
+    tree = walk(b"input", matrix, provisional_registry=reg)
+    assert tree.terminated_as == Termination.PROVISIONAL
+    assert tree.provisional_corroboration_count == 0  # first mint
+    assert tree.abridged_form in reg
+
+
+def test_walker_corroboration_count_increments_on_repeat():
+    matrix = _all_perturbed_matrix()
+    reg = ProvisionalRegistry()
+    t1 = walk(b"input", matrix, provisional_registry=reg)
+    t2 = walk(b"input", matrix, provisional_registry=reg)
+    assert t1.provisional_corroboration_count == 0
+    assert t2.provisional_corroboration_count == 1
+    # Both walks produced the same provisional (deterministic mint)
+    assert t1.abridged_form == t2.abridged_form
+
+
+def test_walker_rigid_does_not_touch_registry():
+    matrix = _all_perturbed_matrix()
+    reg = ProvisionalRegistry()
+    tree = walk(b"input", matrix, posture=Posture.RIGID, provisional_registry=reg)
+    assert tree.terminated_as == Termination.REFUSED
+    assert len(reg) == 0
+
+
+def test_walker_converged_does_not_touch_registry():
+    matrix = _all_clean_matrix()
+    reg = ProvisionalRegistry()
+    tree = walk(b"x", matrix, provisional_registry=reg)
+    assert tree.terminated_as == Termination.ABRIDGED
+    assert len(reg) == 0
+
+
+# =========================================================================== #
+#  v0.5 — L14 audio emission adapter
+# =========================================================================== #
+
+
+# --- Constants --------------------------------------------------------------#
+
+
+def test_lane_to_tri_bundle_code_covers_all_six_tongues():
+    expected = {
+        Lane.KORAELIN: "ko",
+        Lane.AVALI: "av",
+        Lane.RUNETHIC: "ru",
+        Lane.CASSISIVADAN: "ca",
+        Lane.UMBROTH: "um",
+        Lane.DRAUMRIC: "dr",
+    }
+    assert LANE_TO_TRI_BUNDLE_CODE == expected
+
+
+def test_band_frequency_multiplier_tri_octave_signature():
+    # INFRA = -2 octaves, AUDIBLE = fundamental, ULTRA = +2 octaves
+    assert BAND_FREQUENCY_MULTIPLIER[Band.INFRA] == 0.25
+    assert BAND_FREQUENCY_MULTIPLIER[Band.AUDIBLE] == 1.0
+    assert BAND_FREQUENCY_MULTIPLIER[Band.ULTRA] == 4.0
+
+
+def test_system_fundamental_is_a4():
+    assert SYSTEM_FUNDAMENTAL_HZ == 440.0
+
+
+# --- AudioEvent ------------------------------------------------------------- #
+
+
+def test_audio_event_is_frozen():
+    e = AudioEvent(
+        source_node_id=1,
+        lane=Lane.KORAELIN,
+        band=Band.AUDIBLE,
+        frequency_hz=440.0,
+        amplitude=0.5,
+        phase_rad=0.0,
+        duration_s=0.05,
+        label="op",
+    )
+    with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
+        e.amplitude = 0.9  # type: ignore[misc]
+
+
+# --- emit_audio ------------------------------------------------------------- #
+
+
+def test_emit_audio_empty_tree_produces_no_events():
+    """A fresh Tree only contains the VOID singleton, which is silent."""
+    tree = Tree()
+    em = emit_audio(tree)
+    assert em.events == []
+
+
+def test_emit_audio_op_node_uses_lane_fundamental_at_audible_band():
+    matrix = _all_clean_matrix()
+    tree = walk(
+        b"x",
+        matrix,
+        initial_pair=LanePair(
+            primary=Lane.KORAELIN,
+            adversary=Lane.AVALI,
+        ),
+    )
+    em = emit_audio(tree)
+    op_events = [e for e in em.events if e.label == "op"]
+    assert len(op_events) == 2
+    ko_event = next(e for e in op_events if e.lane == Lane.KORAELIN)
+    assert ko_event.band == Band.AUDIBLE
+    assert ko_event.frequency_hz == 440.0  # ko fundamental
+    av_event = next(e for e in op_events if e.lane == Lane.AVALI)
+    assert av_event.frequency_hz == 523.25  # av fundamental
+
+
+def test_emit_audio_amplitude_derived_from_result_hash():
+    matrix = _all_clean_matrix()
+    tree = walk(b"abc", matrix)
+    em = emit_audio(tree)
+    op = next(e for e in em.events if e.label == "op")
+    op_node = next(n for n in tree.nodes if n.id == op.source_node_id)
+    assert op.amplitude == op_node.result_hash[0] / 255.0
+
+
+def test_emit_audio_void_node_is_silent():
+    tree = Tree()
+    # Void singleton is at index 0; emit nothing for it
+    em = emit_audio(tree)
+    assert all(e.source_node_id != NULL_BRIDGE_VOID_ID for e in em.events)
+
+
+def test_emit_audio_sandbox_emits_infra_and_audible_events():
+    matrix = _all_clean_matrix()
+    tree = walk(
+        b"x",
+        matrix,
+        flags=[Flag("bijective_tamper", "syntax")],
+        priors=[IdentityPrior()],
+    )
+    em = emit_audio(tree)
+    labels = {e.label for e in em.events}
+    assert "sandbox.provisional" in labels
+    assert "sandbox.inspection" in labels
+    assert "sandbox.internalize" in labels
+    # provisional + inspection on INFRA band
+    provisional = next(e for e in em.events if e.label == "sandbox.provisional")
+    assert provisional.band == Band.INFRA
+    inspection = next(e for e in em.events if e.label == "sandbox.inspection")
+    assert inspection.band == Band.INFRA
+    # internalize on AUDIBLE
+    internalize = next(e for e in em.events if e.label == "sandbox.internalize")
+    assert internalize.band == Band.AUDIBLE
+
+
+def test_emit_audio_provisional_mint_on_ultra_band():
+    matrix = _all_perturbed_matrix()
+    tree = walk(b"x", matrix)  # HUMBLE -> mint
+    em = emit_audio(tree)
+    mint_events = [e for e in em.events if e.label == "provisional_mint"]
+    assert len(mint_events) == 1
+    assert mint_events[0].band == Band.ULTRA
+    # ULTRA at system fundamental = 440 * 4 = 1760 Hz (A6)
+    assert mint_events[0].frequency_hz == 1760.0
+    assert mint_events[0].lane is None
+
+
+def test_emit_audio_rigid_refusal_no_provisional_event():
+    matrix = _all_perturbed_matrix()
+    tree = walk(b"x", matrix, posture=Posture.RIGID)
+    em = emit_audio(tree)
+    assert all(e.label != "provisional_mint" for e in em.events)
+
+
+def test_emit_audio_phase_wraps_every_16_nodes():
+    # Build two events with node ids 0 and 16: phases should match
+    tree = Tree()
+    # Add 16 OP nodes after the VOID singleton
+    for i in range(16):
+        tree.add_node(
+            Node(
+                id=len(tree.nodes),
+                kind=NodeKind.OP,
+                lane=Lane.KORAELIN,
+                band=Band.AUDIBLE,
+                result_hash=b"\x00" * 32,
+            )
+        )
+    em = emit_audio(tree)
+    # node id 16 should have the same phase as node id 0... but node id 0 is
+    # VOID (silent). node id 16 wraps to phase 0 (= 2*pi*16/16 = 2*pi mod 2*pi)
+    e16 = next(e for e in em.events if e.source_node_id == 16)
+    assert abs(e16.phase_rad) < 1e-9
+
+
+def test_emit_audio_index_by_lane_and_band():
+    matrix = _all_clean_matrix()
+    tree = walk(
+        b"x",
+        matrix,
+        initial_pair=LanePair(
+            primary=Lane.KORAELIN,
+            adversary=Lane.AVALI,
+        ),
+    )
+    em = emit_audio(tree)
+    by_lane = em.by_lane()
+    assert Lane.KORAELIN in by_lane
+    assert Lane.AVALI in by_lane
+    by_band = em.by_band()
+    assert Band.AUDIBLE in by_band
+    assert all(e.band == Band.AUDIBLE for e in by_band[Band.AUDIBLE])
+
+
+def test_emit_audio_event_duration_is_configurable():
+    matrix = _all_clean_matrix()
+    tree = walk(b"x", matrix)
+    em_short = emit_audio(tree, event_duration_s=0.01)
+    em_long = emit_audio(tree, event_duration_s=0.5)
+    assert all(e.duration_s == 0.01 for e in em_short.events)
+    assert all(e.duration_s == 0.5 for e in em_long.events)
+
+
+def test_emit_audio_event_count_matches_emittable_node_count():
+    matrix = _all_clean_matrix()
+    tree = walk(b"x", matrix)
+    # Tree has: 1 VOID (silent) + N OP nodes
+    op_node_count = sum(1 for n in tree.nodes if n.kind == NodeKind.OP)
+    em = emit_audio(tree)
+    assert len(em.events) == op_node_count
+
+
+def test_emit_audio_band_multiplier_applied_correctly():
+    """Direct test: an INFRA-band Kor'aelin OP node should be at 440/4 = 110 Hz."""
+    tree = Tree()
+    tree.add_node(
+        Node(
+            id=len(tree.nodes),
+            kind=NodeKind.OP,
+            lane=Lane.KORAELIN,
+            band=Band.INFRA,
+            result_hash=b"\x80" * 32,
+        )
+    )
+    em = emit_audio(tree)
+    e = em.events[0]
+    assert e.frequency_hz == 110.0  # 440 * 0.25
+    assert e.amplitude == 0x80 / 255.0

--- a/tests/governance/test_tree_of_escalation_wireup.py
+++ b/tests/governance/test_tree_of_escalation_wireup.py
@@ -1,0 +1,171 @@
+"""Wire-up tests for Tree of Escalation v1.0 overlay on RuntimeGate.
+
+Contract:
+  1. flag off                                  -> no toe behavior
+  2. flag on  + clean code (post-calibration)  -> toe fields populated +
+                                                  receipt in signals
+  3. flag on  + early fast-path (calibration)  -> toe fields populated
+                                                  even though receipt
+                                                  signal absent
+  4. env-var enables overlay
+  5. explicit kwarg beats env
+  6. toe is observational: never overrides decision
+  7. compose with bijective_tamper + canonicality enabled simultaneously
+  8. toe_terminated_as values are valid
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.governance.runtime_gate import Decision, RuntimeGate  # noqa: E402
+
+CLEAN_PY = "def add(x, y):\n    return x + y\n"
+
+
+def _drain_calibration(gate: RuntimeGate, payloads=("def f(x):\n    return x\n",)) -> None:
+    """Burn through calibration warm-up so the next evaluate hits the main path."""
+    for _ in range(8):
+        for p in payloads:
+            gate.evaluate(p)
+
+
+# --------------------------------------------------------------------------- #
+#  1. flag off — no behavior change
+# --------------------------------------------------------------------------- #
+
+
+def test_flag_off_default_is_no_op():
+    gate = RuntimeGate()
+    assert gate._tree_of_escalation_enabled is False
+    result = gate.evaluate(CLEAN_PY)
+    assert result.toe_terminated_as == ""
+    assert result.toe_tier_reached == 0
+    assert result.toe_provisional_minted is False
+    assert result.toe_abridged_form_hex == ""
+    assert not any("tree_of_escalation" in s for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  2. flag on + clean (post-calibration) — fields + signal
+# --------------------------------------------------------------------------- #
+
+
+def test_flag_on_clean_post_calibration_emits_receipt():
+    gate = RuntimeGate(use_tree_of_escalation=True)
+    _drain_calibration(gate)
+    result = gate.evaluate(CLEAN_PY)
+    assert result.decision == Decision.ALLOW
+    assert result.toe_terminated_as == "abridged"
+    assert result.toe_tier_reached >= 2  # at least the bicameral pair
+    assert result.toe_provisional_minted is False
+    assert result.toe_abridged_form_hex  # non-empty
+    assert any(s.startswith("tree_of_escalation(") for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  3. fields populated even on calibration fast-path
+# --------------------------------------------------------------------------- #
+
+
+def test_fields_populated_on_calibration_fast_path():
+    gate = RuntimeGate(use_tree_of_escalation=True)
+    # First call goes straight to calibration warm-up — receipt signal
+    # may not be appended (that lives on the main pipeline return) but
+    # the structured GateResult fields MUST be populated.
+    result = gate.evaluate(CLEAN_PY)
+    assert result.toe_terminated_as == "abridged"
+    assert result.toe_tier_reached >= 2
+    assert result.toe_abridged_form_hex
+
+
+# --------------------------------------------------------------------------- #
+#  4. env-var enablement
+# --------------------------------------------------------------------------- #
+
+
+def test_env_var_enables_overlay(monkeypatch):
+    monkeypatch.setenv("SCBE_ENABLE_TREE_OF_ESCALATION_GATE", "1")
+    gate = RuntimeGate()
+    assert gate._tree_of_escalation_enabled is True
+
+
+def test_env_var_explicit_kwarg_wins(monkeypatch):
+    monkeypatch.setenv("SCBE_ENABLE_TREE_OF_ESCALATION_GATE", "1")
+    gate = RuntimeGate(use_tree_of_escalation=False)
+    assert gate._tree_of_escalation_enabled is False
+
+
+# --------------------------------------------------------------------------- #
+#  5. toe is observational — never overrides the base decision (v1.0)
+# --------------------------------------------------------------------------- #
+
+
+def test_toe_does_not_override_base_decision_on_clean_input():
+    """Without ToE the decision is ALLOW; with ToE it must STILL be ALLOW."""
+    base = RuntimeGate()
+    _drain_calibration(base)
+    base_result = base.evaluate(CLEAN_PY)
+
+    with_toe = RuntimeGate(use_tree_of_escalation=True)
+    _drain_calibration(with_toe)
+    toe_result = with_toe.evaluate(CLEAN_PY)
+
+    assert base_result.decision == toe_result.decision
+
+
+# --------------------------------------------------------------------------- #
+#  6. compose with bijective_tamper + canonicality
+# --------------------------------------------------------------------------- #
+
+
+def test_toe_composes_with_other_overlays():
+    gate = RuntimeGate(
+        use_bijective_tamper=True,
+        use_identifier_canonicality=True,
+        use_tree_of_escalation=True,
+    )
+    _drain_calibration(gate)
+    result = gate.evaluate(CLEAN_PY)
+    receipts = [s for s in result.signals if "(" in s]
+    has_tamper = any(s.startswith("bijective_tamper(") for s in receipts)
+    has_canon = any(s.startswith("identifier_canonicality(") for s in receipts)
+    has_toe = any(s.startswith("tree_of_escalation(") for s in receipts)
+    assert has_tamper, f"missing tamper receipt; got {receipts}"
+    assert has_canon, f"missing canonicality receipt; got {receipts}"
+    assert has_toe, f"missing toe receipt; got {receipts}"
+
+
+# --------------------------------------------------------------------------- #
+#  7. terminated_as values are valid strings from the Termination enum
+# --------------------------------------------------------------------------- #
+
+
+def test_terminated_as_values_are_known():
+    valid = {"abridged", "provisional", "refused", "incomplete"}
+    gate = RuntimeGate(use_tree_of_escalation=True)
+    for payload in [
+        CLEAN_PY,
+        "def f(x):\n    return x * 2\n",
+        "def g():\n    return 42\n",
+    ]:
+        result = gate.evaluate(payload)
+        assert result.toe_terminated_as in valid
+
+
+# --------------------------------------------------------------------------- #
+#  8. prose payloads still get a toe observation (HashReader works on bytes)
+# --------------------------------------------------------------------------- #
+
+
+def test_prose_payload_still_observed():
+    gate = RuntimeGate(use_tree_of_escalation=True)
+    result = gate.evaluate("Please write a function that sorts a list of numbers.")
+    # ToE runs on raw bytes so prose doesn't bypass it (unlike the
+    # canonicality / tamper gates which require code-shaped input).
+    assert result.toe_terminated_as in {"abridged", "provisional", "refused"}

--- a/tests/test_agent_storage_zero_credit.py
+++ b/tests/test_agent_storage_zero_credit.py
@@ -27,13 +27,16 @@ def test_agent_storage_endpoint_requires_commonjs_cleanly() -> None:
         console.log(JSON.stringify({
           handlerType: typeof mod,
           hasBuilder: typeof mod._private.buildExportPacket,
-          providers: mod._private.PROVIDERS.map((p) => p.id)
+          providers: mod._private.PROVIDERS.map((p) => p.id),
+          formation: mod._private.WORKSPACE_FORMATION
         }));
         """)
     assert payload["handlerType"] == "function"
     assert payload["hasBuilder"] == "function"
     assert payload["providers"][:2] == ["local_download", "browser_local"]
     assert {"github", "dropbox", "onedrive", "gdrive"}.issubset(set(payload["providers"]))
+    assert payload["formation"]["schema_version"] == "aethermoor.bus.workspace_formation.v1"
+    assert payload["formation"]["folders"][0]["path"] == "00_inbox"
 
 
 def test_agent_storage_builds_zero_server_storage_export_packet() -> None:
@@ -52,6 +55,7 @@ def test_agent_storage_builds_zero_server_storage_export_packet() -> None:
     assert payload["cost"] == "zero-server-storage"
     assert payload["packet"]["destination_hint"] == "gdrive"
     assert payload["packet"]["filename"] == "customer-smoke-export.json"
+    assert payload["packet"]["workspace_formation"]["default_root"] == ".aethermoor-bus/workspaces"
     assert payload["download"]["mime"] == "application/json"
     decoded = json.loads(
         subprocess.check_output(


### PR DESCRIPTION
## Summary
- Wires three L13 governance overlays into `RuntimeGate`, all behind feature flags (default OFF)
- Same composition pattern across all three: top-of-evaluate computation, monotonic decision contribution via `_escalate_decision`, receipt envelope on `GateResult`, env-var or kwarg enablement
- Tree of Escalation lands at v1.0 OBSERVATIONAL — populates `GateResult.toe_*` fields and emits a `tree_of_escalation` receipt signal but does not contribute to the decision (v1.1 will add that once real lane-readers replace the default HashReader matrix)

## Overlays
- **bijective_tamper** (`SCBE_ENABLE_BIJECTIVE_TAMPER_GATE=1`): encoding-level fingerprint via `parse(decode(encode(src))) ≡ parse(src)`. Spec: `docs/specs/BIJECTIVE_TAMPER_L13.md`.
- **identifier_canonicality** (`SCBE_ENABLE_IDENTIFIER_CANONICALITY_GATE=1`): sibling gate catching homoglyph / mixed-script / invisible-char identifier attacks that bijective_tamper explicitly leaves on the table. Spec: `docs/specs/IDENTIFIER_CANONICALITY_L13.md`.
- **Tree of Escalation v1.0** (`SCBE_ENABLE_TREE_OF_ESCALATION_GATE=1`): compilation-driven multi-tongue read; bicameral read across phi-weighted lane pair; bit-depth escalation; HUMBLE-mints / RIGID-refuses on T6 exhaustion. Spec: `docs/specs/TREE_OF_ESCALATION.md`.

## Tests
- 146 new tests in `tests/governance/test_*.py`
- Local governance suite: 227/227 green
- Full local pytest suite: 9374 passed, 87 skipped (15 pre-existing failures in CLI / training-data / SIMD tests unrelated to governance)

## Test plan
- [ ] CI green on the full workflow set
- [ ] No regressions in pre-existing governance / runtime_gate tests
- [ ] black + flake8 clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)