### PR TITLE
style(governance): apply black + drop unused imports in L13 overlays

### DIFF
--- a/src/governance/bijective_tamper.py
+++ b/src/governance/bijective_tamper.py
@@ -52,16 +52,15 @@ L13 integration sketch (not wired here to keep the change additive):
 The fingerprint is a SHA-256 of the canonical AST. Two semantically-equal
 programs hash the same — useful for replay detection, dedup, whitelisting.
 """
+
 from __future__ import annotations
 
 import ast
 import hashlib
-import json
 import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
-
 
 # --------------------------------------------------------------------------- #
 #  Public types
@@ -100,6 +99,7 @@ class TamperResult:
 #  Per-language AST canonicalization
 # --------------------------------------------------------------------------- #
 
+
 def _ast_canonical_python(src: str) -> str:
     """Canonical AST dump for Python. Raises SyntaxError on bad input."""
     tree = ast.parse(src)
@@ -116,10 +116,7 @@ _AST_CANONICAL = {
 # --------------------------------------------------------------------------- #
 
 _DEFAULT_TOKENIZER_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "artifacts"
-    / "extended_tokenizer"
-    / "qwen25-coder-7b-sacred-tongues"
+    Path(__file__).resolve().parents[2] / "artifacts" / "extended_tokenizer" / "qwen25-coder-7b-sacred-tongues"
 )
 _TOKENIZER_CACHE: dict[str, object] = {}
 
@@ -147,6 +144,7 @@ def _decode_through_tokenizer(src: str, tokenizer) -> str:
 # --------------------------------------------------------------------------- #
 #  Public evaluate_code
 # --------------------------------------------------------------------------- #
+
 
 def evaluate_code(
     src: str,
@@ -209,7 +207,6 @@ def evaluate_code(
     # Step 3: does decoded source parse?
     try:
         decoded_canonical = canonicalize(decoded)
-        decoded_parses = True
     except SyntaxError as e:
         return TamperResult(
             score=1.0,
@@ -284,9 +281,7 @@ def evaluate_code(
         detail={
             "note": "AST canonical changed after tokenize-decode (not NFC-recoverable)",
             "src_fingerprint": src_fingerprint,
-            "decoded_fingerprint": hashlib.sha256(
-                decoded_canonical.encode("utf-8")
-            ).hexdigest(),
+            "decoded_fingerprint": hashlib.sha256(decoded_canonical.encode("utf-8")).hexdigest(),
         },
     )
 

--- a/src/governance/identifier_canonicality.py
+++ b/src/governance/identifier_canonicality.py
@@ -56,14 +56,13 @@ L13 mapping (recommendation; production may compose with other signals):
     invisible     → DENY
     input_invalid → no-op (handled by sibling gates / not a tamper signal)
 """
+
 from __future__ import annotations
 
 import ast
 import hashlib
-import unicodedata
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
-
+from typing import Dict, List, Optional
 
 # --------------------------------------------------------------------------- #
 #  Public types
@@ -303,9 +302,7 @@ def _classify_identifier(name: str) -> Optional[IdentifierFinding]:
             name=name,
             kind="invisible",
             scripts=_scripts_in(name),
-            detail=(
-                f"contains invisible/BiDi codepoint U+{ord(invisible_ch):04X}"
-            ),
+            detail=(f"contains invisible/BiDi codepoint U+{ord(invisible_ch):04X}"),
         )
 
     # Math-alphanumeric block check — always treat as catastrophic confusable
@@ -352,6 +349,7 @@ def _classify_identifier(name: str) -> Optional[IdentifierFinding]:
 # --------------------------------------------------------------------------- #
 #  AST identifier extraction
 # --------------------------------------------------------------------------- #
+
 
 def _extract_identifiers_python(src: str) -> List[str]:
     """Return all identifier strings used in the AST.
@@ -441,9 +439,7 @@ def evaluate_code(src: str, language: str = "python") -> CanonicalityResult:
             detail={"error": f"input does not parse: {e}"},
         )
 
-    fingerprint = hashlib.sha256(
-        "\n".join(sorted(set(identifiers))).encode("utf-8")
-    ).hexdigest()
+    fingerprint = hashlib.sha256("\n".join(sorted(set(identifiers))).encode("utf-8")).hexdigest()
 
     findings: List[IdentifierFinding] = []
     seen: set = set()

--- a/tests/governance/test_bijective_tamper.py
+++ b/tests/governance/test_bijective_tamper.py
@@ -1,4 +1,5 @@
 """Tests for the bijective tamper signal (L13 input)."""
+
 from __future__ import annotations
 
 import sys
@@ -18,27 +19,23 @@ from src.governance.bijective_tamper import (  # noqa: E402
     recommended_l13_action,
 )
 
-
 # --------------------------------------------------------------------------- #
 #  Helpers
 # --------------------------------------------------------------------------- #
+
 
 @pytest.fixture(scope="module")
 def tokenizer():
     from transformers import AutoTokenizer
 
-    path = (
-        REPO_ROOT
-        / "artifacts"
-        / "extended_tokenizer"
-        / "qwen25-coder-7b-sacred-tongues"
-    )
+    path = REPO_ROOT / "artifacts" / "extended_tokenizer" / "qwen25-coder-7b-sacred-tongues"
     return AutoTokenizer.from_pretrained(str(path), use_fast=True)
 
 
 # --------------------------------------------------------------------------- #
 #  Clean cases — score 0.0, ALLOW
 # --------------------------------------------------------------------------- #
+
 
 def test_clean_ascii_python(tokenizer):
     src = "def f(x):\n    return x + 1\n"
@@ -59,11 +56,7 @@ def test_clean_with_unicode_string_literal(tokenizer):
 
 
 def test_clean_function_with_decorators(tokenizer):
-    src = (
-        "@staticmethod\n"
-        "def helper(x, y, *, key=None):\n"
-        "    return (x + y, key)\n"
-    )
+    src = "@staticmethod\n" "def helper(x, y, *, key=None):\n" "    return (x + y, key)\n"
     r = evaluate_code(src, "python", tokenizer=tokenizer)
     assert r.kind == "none"
 
@@ -71,6 +64,7 @@ def test_clean_function_with_decorators(tokenizer):
 # --------------------------------------------------------------------------- #
 #  NFD-shift case — score ~0.2, ALLOW with annotation
 # --------------------------------------------------------------------------- #
+
 
 def test_nfd_combining_marks_recover_via_nfc(tokenizer):
     """NFD literal in source becomes NFC after tokenize-decode.
@@ -83,7 +77,7 @@ def test_nfd_combining_marks_recover_via_nfc(tokenizer):
     Despite ast_diverge=True, kind="nfc" because nfc_recovers_bytes wins —
     this is documented expected normalization, not adversarial tampering.
     """
-    nfd_text = unicodedata.normalize("NFD", "combining = \"áb́ć\"")
+    nfd_text = unicodedata.normalize("NFD", 'combining = "áb́ć"')
     src = nfd_text + "\n"
     assert src != unicodedata.normalize("NFC", src), "fixture must actually be NFD"
     r = evaluate_code(src, "python", tokenizer=tokenizer)
@@ -100,6 +94,7 @@ def test_nfd_combining_marks_recover_via_nfc(tokenizer):
 #  Catastrophic case — input does not parse → DENY
 # --------------------------------------------------------------------------- #
 
+
 def test_input_invalid_python_returns_input_invalid(tokenizer):
     src = "def f(:\n    return\n"  # syntax error
     r = evaluate_code(src, "python", tokenizer=tokenizer)
@@ -112,8 +107,9 @@ def test_input_invalid_python_returns_input_invalid(tokenizer):
 #  Unsupported language → input_invalid
 # --------------------------------------------------------------------------- #
 
+
 def test_unsupported_language_returns_input_invalid(tokenizer):
-    r = evaluate_code("fn main() { println!(\"hi\"); }", "rust", tokenizer=tokenizer)
+    r = evaluate_code('fn main() { println!("hi"); }', "rust", tokenizer=tokenizer)
     assert r.kind == "input_invalid"
     assert r.score == 1.0
 
@@ -122,10 +118,11 @@ def test_unsupported_language_returns_input_invalid(tokenizer):
 #  Semantic fingerprint stability
 # --------------------------------------------------------------------------- #
 
+
 def test_semantic_fingerprint_equal_for_equivalent_sources(tokenizer):
     """Two byte-different but AST-equivalent sources should hash the same."""
     src_a = "def f(x):\n    return x+1\n"
-    src_b = "def f(x):\n    return x + 1\n"   # extra spaces, same AST
+    src_b = "def f(x):\n    return x + 1\n"  # extra spaces, same AST
     r_a = evaluate_code(src_a, "python", tokenizer=tokenizer)
     r_b = evaluate_code(src_b, "python", tokenizer=tokenizer)
     assert r_a.semantic_fingerprint == r_b.semantic_fingerprint
@@ -143,6 +140,7 @@ def test_semantic_fingerprint_differs_for_different_programs(tokenizer):
 #  L13 mapping coverage
 # --------------------------------------------------------------------------- #
 
+
 def test_l13_mapping_covers_all_kinds():
     expected = {"none", "nfc", "structural", "syntax", "input_invalid"}
     assert set(L13_MAPPING_RECOMMENDATION.keys()) == expected
@@ -157,6 +155,7 @@ def test_l13_mapping_actions_are_valid():
 # --------------------------------------------------------------------------- #
 #  TamperResult.to_dict serialization
 # --------------------------------------------------------------------------- #
+
 
 def test_to_dict_is_json_serializable(tokenizer):
     import json

--- a/tests/governance/test_bijective_tamper_wireup.py
+++ b/tests/governance/test_bijective_tamper_wireup.py
@@ -9,6 +9,7 @@ The contract under test:
   5. base ALLOW + synthetic kind="syntax"      -> DENY (true tamper escalates)
   6. prose with code keywords                  -> NOT DENY (heuristic safety)
 """
+
 from __future__ import annotations
 
 import sys
@@ -22,7 +23,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from src.governance.runtime_gate import Decision, RuntimeGate  # noqa: E402
 
-
 CLEAN_PY = "def add(x, y):\n    return x + y\n"
 BROKEN_PY = "def add(:\n    return\n"
 
@@ -30,6 +30,7 @@ BROKEN_PY = "def add(:\n    return\n"
 # --------------------------------------------------------------------------- #
 #  1. flag off — no behavior change
 # --------------------------------------------------------------------------- #
+
 
 def test_flag_off_default_is_no_op():
     """With the flag off, the tamper overlay must not run at all."""
@@ -54,6 +55,7 @@ def test_flag_off_does_not_deny_broken_code():
 #  2. flag on  + clean code  -> ALLOW (with annotation)
 # --------------------------------------------------------------------------- #
 
+
 def test_flag_on_clean_code_allows():
     gate = RuntimeGate(use_bijective_tamper=True)
     assert gate._bijective_tamper_enabled is True
@@ -69,6 +71,7 @@ def test_flag_on_clean_code_allows():
 # --------------------------------------------------------------------------- #
 #  3. flag on  + user-submitted syntax-broken code  -> no-op
 # --------------------------------------------------------------------------- #
+
 
 def test_flag_on_user_syntax_broken_is_noop():
     """input_invalid is NOT a tamper signal at the runtime-gate layer.
@@ -86,6 +89,7 @@ def test_flag_on_user_syntax_broken_is_noop():
 # --------------------------------------------------------------------------- #
 #  4. base DENY + tamper ALLOW -> stays DENY (monotonic)
 # --------------------------------------------------------------------------- #
+
 
 def test_base_deny_plus_tamper_allow_stays_deny():
     """If the base gate denies for non-tamper reasons, a clean tamper signal
@@ -107,9 +111,7 @@ def test_base_deny_plus_tamper_allow_stays_deny():
     ).hexdigest()
     gate._immune.add(h)
     result = gate.evaluate(forced_immune_text)
-    assert result.decision == Decision.DENY, (
-        f"immune-hit path must DENY regardless of tamper; got {result.decision}"
-    )
+    assert result.decision == Decision.DENY, f"immune-hit path must DENY regardless of tamper; got {result.decision}"
     # Tamper receipt should still be present in audit (overlay computed at top).
     assert result.bijective_tamper_kind == "none"
     assert result.bijective_tamper_action == "ALLOW"
@@ -118,6 +120,7 @@ def test_base_deny_plus_tamper_allow_stays_deny():
 # --------------------------------------------------------------------------- #
 #  5. base ALLOW + synthetic kind="syntax" -> DENY (escalation via top short-circuit)
 # --------------------------------------------------------------------------- #
+
 
 def test_synthetic_syntax_tamper_escalates_to_deny(monkeypatch):
     """Inject a synthetic kind='syntax' TamperResult to verify the escalation
@@ -154,6 +157,7 @@ def test_synthetic_syntax_tamper_escalates_to_deny(monkeypatch):
 #  6. prose with code keywords -> NOT DENY (heuristic false-positive guard)
 # --------------------------------------------------------------------------- #
 
+
 def test_prose_with_code_keywords_not_denied():
     """Prose containing 'function', 'import', 'return', 'class', 'from' must
     not get parsed as Python and falsely DENY'd. The two-signal heuristic
@@ -168,17 +172,16 @@ def test_prose_with_code_keywords_not_denied():
     ]
     for text in prose_samples:
         result = gate.evaluate(text)
-        assert result.decision != Decision.DENY, (
-            f"prose falsely DENY'd: {text!r} (signals={result.signals})"
-        )
-        assert result.bijective_tamper_kind == "", (
-            f"prose triggered tamper kind={result.bijective_tamper_kind!r}: {text!r}"
-        )
+        assert result.decision != Decision.DENY, f"prose falsely DENY'd: {text!r} (signals={result.signals})"
+        assert (
+            result.bijective_tamper_kind == ""
+        ), f"prose triggered tamper kind={result.bijective_tamper_kind!r}: {text!r}"
 
 
 # --------------------------------------------------------------------------- #
 #  Env-var enablement path
 # --------------------------------------------------------------------------- #
+
 
 def test_env_var_enables_overlay(monkeypatch):
     monkeypatch.setenv("SCBE_ENABLE_BIJECTIVE_TAMPER_GATE", "1")
@@ -204,6 +207,7 @@ def test_explicit_kwarg_beats_env(monkeypatch):
 #  Heuristic skip — non-code action_text never invokes the tokenizer
 # --------------------------------------------------------------------------- #
 
+
 def test_non_code_skips_tamper(monkeypatch):
     """Plain prose must not trigger the AST/tokenizer path."""
     gate = RuntimeGate(use_bijective_tamper=True)
@@ -218,6 +222,7 @@ def test_non_code_skips_tamper(monkeypatch):
 # --------------------------------------------------------------------------- #
 #  Receipt envelope is parseable
 # --------------------------------------------------------------------------- #
+
 
 def test_receipt_envelope_format():
     gate = RuntimeGate(use_bijective_tamper=True)

--- a/tests/governance/test_identifier_canonicality.py
+++ b/tests/governance/test_identifier_canonicality.py
@@ -1,4 +1,5 @@
 """Unit tests for the identifier-canonicality signal."""
+
 from __future__ import annotations
 
 import sys
@@ -18,10 +19,10 @@ from src.governance.identifier_canonicality import (  # noqa: E402
     recommended_l13_action,
 )
 
-
 # --------------------------------------------------------------------------- #
 #  Clean cases
 # --------------------------------------------------------------------------- #
+
 
 def test_clean_ascii_python():
     r = evaluate_code("def add(x, y):\n    return x + y\n")
@@ -43,6 +44,7 @@ def test_clean_with_unicode_string_literal():
 # --------------------------------------------------------------------------- #
 #  Mixed-script attack (Latin + Cyrillic in one identifier)
 # --------------------------------------------------------------------------- #
+
 
 def test_mixed_script_cyrillic_latin():
     # Cyrillic а sneaked into 'password'
@@ -68,6 +70,7 @@ def test_mixed_script_greek_latin():
 #  Confusable-only attack (pure non-Latin script that mimics ASCII)
 # --------------------------------------------------------------------------- #
 
+
 def test_all_confusable_cyrillic():
     # 'аре' is all Cyrillic, looks like ASCII 'ape'
     src = "def get():\n    аре = 1\n    return аре\n"
@@ -80,6 +83,7 @@ def test_all_confusable_cyrillic():
 # --------------------------------------------------------------------------- #
 #  Invisible / BiDi character attacks
 # --------------------------------------------------------------------------- #
+
 
 def test_zero_width_joiner_in_identifier():
     # ZWJ between 'admin' and '_check'
@@ -108,6 +112,7 @@ def test_bidi_control_in_identifier_rejected_by_parser():
 #  Legitimate non-ASCII single-script identifier (allow with annotation)
 # --------------------------------------------------------------------------- #
 
+
 def test_greek_single_script_legitimate():
     # 'τ' is a legitimate Greek-only identifier
     src = "def τ(x):\n    return x\n"
@@ -120,6 +125,7 @@ def test_greek_single_script_legitimate():
 # --------------------------------------------------------------------------- #
 #  Catastrophic / edge cases
 # --------------------------------------------------------------------------- #
+
 
 def test_input_invalid_python():
     r = evaluate_code("def f(:\n    return\n")
@@ -137,6 +143,7 @@ def test_unsupported_language():
 #  L13 mapping coverage
 # --------------------------------------------------------------------------- #
 
+
 def test_l13_mapping_covers_all_kinds():
     expected = {"clean", "non_ascii", "confusable", "mixed_script", "invisible", "input_invalid"}
     assert set(L13_MAPPING_RECOMMENDATION.keys()) == expected
@@ -151,6 +158,7 @@ def test_l13_mapping_actions_are_valid():
 # --------------------------------------------------------------------------- #
 #  Fingerprint stability
 # --------------------------------------------------------------------------- #
+
 
 def test_fingerprint_equal_for_same_identifiers_different_order():
     src_a = "def f(x):\n    y = x\n    z = y\n    return z\n"
@@ -170,6 +178,7 @@ def test_fingerprint_differs_for_different_identifiers():
 # --------------------------------------------------------------------------- #
 #  Serialization
 # --------------------------------------------------------------------------- #
+
 
 def test_to_dict_is_json_serializable():
     import json

--- a/tests/governance/test_identifier_canonicality_wireup.py
+++ b/tests/governance/test_identifier_canonicality_wireup.py
@@ -12,6 +12,7 @@ Contract:
   9. env-var enables overlay
  10. tamper + canonicality compose: both signals visible in receipts
 """
+
 from __future__ import annotations
 
 import sys
@@ -23,7 +24,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from src.governance.runtime_gate import Decision, RuntimeGate  # noqa: E402
 
-
 CLEAN_PY = "def add(x, y):\n    return x + y\n"
 MIXED_SCRIPT_PY = "def login(pаssword):\n    return pаssword\n"  # Cyrillic а
 CONFUSABLE_PY = "def get():\n    аре = 1\n    return аре\n"  # all Cyrillic
@@ -34,6 +34,7 @@ GREEK_PY = "def τ(x):\n    return x\n"  # legitimate Greek single-script
 # --------------------------------------------------------------------------- #
 #  1. flag off — no behavior change
 # --------------------------------------------------------------------------- #
+
 
 def test_flag_off_default_is_no_op():
     gate = RuntimeGate()
@@ -48,6 +49,7 @@ def test_flag_off_default_is_no_op():
 # --------------------------------------------------------------------------- #
 #  2. flag on + clean -> ALLOW with receipt
 # --------------------------------------------------------------------------- #
+
 
 def test_flag_on_clean_allows_with_receipt():
     gate = RuntimeGate(use_identifier_canonicality=True)
@@ -64,6 +66,7 @@ def test_flag_on_clean_allows_with_receipt():
 #  3. mixed-script -> DENY + immune
 # --------------------------------------------------------------------------- #
 
+
 def test_mixed_script_attack_denies():
     gate = RuntimeGate(use_identifier_canonicality=True)
     result = gate.evaluate(MIXED_SCRIPT_PY)
@@ -77,6 +80,7 @@ def test_mixed_script_attack_denies():
 # --------------------------------------------------------------------------- #
 #  4. confusable-only -> QUARANTINE
 # --------------------------------------------------------------------------- #
+
 
 def test_confusable_only_quarantines():
     gate = RuntimeGate(use_identifier_canonicality=True)
@@ -92,6 +96,7 @@ def test_confusable_only_quarantines():
 #  5. invisible char -> DENY + immune
 # --------------------------------------------------------------------------- #
 
+
 def test_invisible_char_denies():
     gate = RuntimeGate(use_identifier_canonicality=True)
     result = gate.evaluate(INVISIBLE_PY)
@@ -105,6 +110,7 @@ def test_invisible_char_denies():
 #  6. legitimate Greek -> ALLOW (non_ascii)
 # --------------------------------------------------------------------------- #
 
+
 def test_legitimate_greek_allows():
     gate = RuntimeGate(use_identifier_canonicality=True)
     result = gate.evaluate(GREEK_PY)
@@ -116,6 +122,7 @@ def test_legitimate_greek_allows():
 # --------------------------------------------------------------------------- #
 #  7. base DENY (immune-hit) + canonicality clean -> stays DENY
 # --------------------------------------------------------------------------- #
+
 
 def test_base_deny_plus_canonicality_clean_stays_deny():
     gate = RuntimeGate(use_identifier_canonicality=True)
@@ -132,6 +139,7 @@ def test_base_deny_plus_canonicality_clean_stays_deny():
 # --------------------------------------------------------------------------- #
 #  8. prose with code keywords -> NOT DENY (heuristic safety)
 # --------------------------------------------------------------------------- #
+
 
 def test_prose_with_code_keywords_not_denied():
     gate = RuntimeGate(use_identifier_canonicality=True)
@@ -150,6 +158,7 @@ def test_prose_with_code_keywords_not_denied():
 #  9. env-var enablement
 # --------------------------------------------------------------------------- #
 
+
 def test_env_var_enables_overlay(monkeypatch):
     monkeypatch.setenv("SCBE_ENABLE_IDENTIFIER_CANONICALITY_GATE", "1")
     gate = RuntimeGate()
@@ -165,6 +174,7 @@ def test_env_var_explicit_kwarg_wins(monkeypatch):
 # --------------------------------------------------------------------------- #
 #  10. tamper + canonicality compose — both signals visible
 # --------------------------------------------------------------------------- #
+
 
 def test_tamper_and_canonicality_compose():
     """Both overlays on at once: both receipts must appear in audit."""


### PR DESCRIPTION
## Summary

Follow-up lint fix to PR #1463. The squash-merge captured the pre-black state of the L13 overlay files, breaking `Lint and Format Check` on main. This PR:

- Applies `black --target-version py311 --line-length 120` to the 6 files CI flagged.
- Drops 4 ruff-flagged dead lines that pre-existed but only get scanned once black passes.

## What changed

**Reformatted (black, no logic change):**
- `src/governance/bijective_tamper.py`
- `src/governance/identifier_canonicality.py`
- `tests/governance/test_bijective_tamper.py`
- `tests/governance/test_bijective_tamper_wireup.py`
- `tests/governance/test_identifier_canonicality.py`
- `tests/governance/test_identifier_canonicality_wireup.py`

**Removed (ruff F401 / F841 — confirmed unused via grep):**
- `bijective_tamper.py:60` — `import json`
- `bijective_tamper.py:211` — `decoded_parses = True` local
- `identifier_canonicality.py:64` — `import unicodedata`
- `identifier_canonicality.py:66` — `Tuple` from typing

## Test plan

- [x] `black --check --target-version py311 --line-length 120 src/governance/* tests/governance/test_*` passes
- [x] `ruff check --config ruff.toml src/governance/bijective_tamper.py src/governance/identifier_canonicality.py` passes
- [x] `tests/governance/` 227/227 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)