### PR TITLE
style(governance): drop ruff-flagged unused imports + B007 in tests

### DIFF
--- a/tests/governance/test_bijective_tamper.py
+++ b/tests/governance/test_bijective_tamper.py
@@ -14,7 +14,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from src.governance.bijective_tamper import (  # noqa: E402
     L13_MAPPING_RECOMMENDATION,
-    TamperResult,
     evaluate_code,
     recommended_l13_action,
 )

--- a/tests/governance/test_bijective_tamper_wireup.py
+++ b/tests/governance/test_bijective_tamper_wireup.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))

--- a/tests/governance/test_identifier_canonicality.py
+++ b/tests/governance/test_identifier_canonicality.py
@@ -5,16 +5,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from src.governance.identifier_canonicality import (  # noqa: E402
     L13_MAPPING_RECOMMENDATION,
-    CanonicalityResult,
-    IdentifierFinding,
     evaluate_code,
     recommended_l13_action,
 )

--- a/tests/governance/test_tree_of_escalation.py
+++ b/tests/governance/test_tree_of_escalation.py
@@ -1111,7 +1111,7 @@ def test_emit_audio_phase_wraps_every_16_nodes():
     # Build two events with node ids 0 and 16: phases should match
     tree = Tree()
     # Add 16 OP nodes after the VOID singleton
-    for i in range(16):
+    for _ in range(16):
         tree.add_node(
             Node(
                 id=len(tree.nodes),


### PR DESCRIPTION
## Summary

Follow-up to PR #1464. The previous lint-fix PR was squash-merged at the black-only commit `c2e6945f` before the ruff fix `b146a710` got CI, so main's ruff step is failing on 6 pre-existing dead imports / loop variables in the L13 overlay test files.

## What changed

| File | Line | Fix |
|------|------|-----|
| `tests/governance/test_bijective_tamper.py` | 17 | drop `TamperResult` import |
| `tests/governance/test_bijective_tamper_wireup.py` | 18 | drop unused `pytest` |
| `tests/governance/test_identifier_canonicality.py` | 8 | drop unused `pytest` |
| `tests/governance/test_identifier_canonicality.py` | 16 | drop `CanonicalityResult` |
| `tests/governance/test_identifier_canonicality.py` | 17 | drop `IdentifierFinding` |
| `tests/governance/test_tree_of_escalation.py` | 1114 | rename `for i in range(16)` → `for _ in range(16)` |

All 6 confirmed truly unused via grep before removing.

## Test plan

- [x] `ruff check --config ruff.toml tests/governance/ src/governance/` passes
- [x] `black --check tests/governance/` passes
- [x] `pytest tests/governance/` 227/227 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)