### PR TITLE
feat(materials): add Sacred Egg CRP PUF harness

### DIFF
--- a/docs/specs/AETHERFAB_PUF_NEGATIVE_RESULT.md
+++ b/docs/specs/AETHERFAB_PUF_NEGATIVE_RESULT.md
@@ -1,0 +1,170 @@
+# Raw Seeded-Topology PUF: Simulation-Stage Disconfirmation
+
+**Status:** parked diagnostic, not a production architecture.  
+**Architecture status:** `RAW_SEEDED_TOPOLOGY_PUF_DISCONFIRMED_STANDALONE_2026_05`  
+**Harness:** `scripts/experiments/puf_measurement_analysis.py`
+
+## Proposal
+
+The narrow proposal tested here was to derive deterministic topology
+perturbations from a cryptographic or post-quantum seed, fabricate the resulting
+geometry, measure the physical response, and use that raw geometry response as a
+standalone physically unclonable identity signal.
+
+The attractive part is clear: one seed can deterministically produce many
+manufacturable variants, and each physical object can be audited through
+measurement. The failure mode is also clear: if the seed reproduces too much of
+the identity-bearing structure, an attacker who knows the seed gets a strong
+head start.
+
+## Method
+
+The v2 surrogate simulation used a weak PUF model rather than an expensive FEM
+model:
+
+1. Expand seed into a topology feature vector.
+2. Add stochastic fabrication noise at swept amplitudes.
+3. Project the feature vector through a fixed measurement operator.
+4. Quantize responses into bit vectors.
+5. Compare three Hamming-distance distributions.
+
+The three distributions are:
+
+- `intra`: same physical device, repeated measurement
+- `clone`: same seed, different fabrication realization
+- `inter`: different seed, different fabrication realization
+
+The important attacker model is the `clone` distribution. If same-seed clones
+are close to the original, the seed behaves like a reproducible barcode. If
+same-seed clones are far above the intra-device noise floor and approach the
+inter-device random baseline, the architecture may be PUF-like.
+
+## Finding
+
+The raw standalone seeded-topology PUF idea is structurally weak in the
+realistic printer-tolerance regime. A surrogate v2 simulation compared three
+distance distributions:
+
+- `intra`: same physical device, repeated measurement
+- `clone`: same seed, different fabrication realization
+- `inter`: different seed, different fabrication realization
+
+At realistic SLA/SLS/FDM tolerance bands, same-seed clone pairs stayed much
+closer to the original than random inter-device pairs. That means an attacker
+who knows the seed can fabricate a near-clone under this narrow model. In that
+regime, raw seeded topology behaves closer to a reproducible barcode than a
+standalone physically unclonable function.
+
+The architecture only moved toward PUF-like behavior when fabrication noise
+became large relative to the seed feature scale. That is not a good security
+story: if fabrication noise dominates the seed, the seed is no longer the useful
+identity primitive.
+
+Approximate simulated regime:
+
+| Fabrication noise sigma | Practical reading | Clone behavior |
+|---|---|---|
+| `0.001` | sub-SLA / idealized | clone indistinguishable from noise floor |
+| `0.025` | SLA-like | marginal; clone much closer than random inter-device |
+| `0.050` | SLS-like | inadequate cloning resistance |
+| `0.100` | FDM-like | detectable clone distance, still far below random baseline |
+| `0.300+` | deliberately poor / exotic | first PUF-like regime in the surrogate |
+
+The crossover around sigma approximately `0.3` is the red flag. A system that
+only becomes unclonable when fabrication error is large relative to the intended
+feature scale is not a strong seeded-topology security primitive.
+
+## Interpretation
+
+Deterministic structure and unclonability are in tension. Deterministic
+seed-derived geometry makes the object reproducible. PUF security comes from
+uncontrolled physical variation that is stable for the enrolled device but hard
+to recreate in a second fabrication run.
+
+The raw standalone architecture inverted that relationship: the public or
+recoverable seed carried too much identity. The printer did not add enough
+useful variation at realistic tolerances to defeat a same-seed attacker.
+
+This does **not** disconfirm the broader Sacred Egg / GeoSeal / genesis stack.
+That stack adds layers the surrogate did not model: encrypted initialization
+payloads, hatch conditions, fail-to-noise behavior, context-bound attestation,
+batch offsets, cube hashes, and post-fabrication enrollment. Those layers can
+change the production security question from "does raw geometry alone resist
+cloning?" to "does the full protocol make cloning operationally, cryptographically,
+or economically infeasible?"
+
+## What remains useful
+
+The measurement harness is still useful as a diagnostic and negative-result
+tool:
+
+```powershell
+python scripts/experiments/puf_measurement_analysis.py measurements.csv `
+  --report artifacts/aetherfab/puf_measurement_report.json
+```
+
+Expected CSV shape:
+
+```csv
+device_id,seed_id,fabrication_id,read_id,z_1hz,z_10hz,z_100hz
+seed-a-print-0,seed-a,fab-0,0,0.11,0.20,0.33
+seed-a-print-0,seed-a,fab-0,1,0.10,0.21,0.32
+seed-a-print-1,seed-a,fab-1,0,0.28,0.41,0.51
+seed-b-print-0,seed-b,fab-0,0,0.72,0.60,0.12
+```
+
+The harness reports:
+
+- `reliability`: `1 - mean(intra)`
+- `uniqueness`: `mean(inter)`
+- `clone_gap`: `min(clone) - max(intra)`
+- `clone_vs_inter_ratio`: whether same-seed clones approach random-pair distance
+- `works_against_seed_clone`: whether a fuzzy extractor can reject same-seed clones
+
+Green synthetic tests only prove the harness math. They do not prove the
+seeded-topology architecture works on real printed parts.
+
+Every JSON report emitted by the harness includes:
+
+```json
+{
+  "architecture_status": "RAW_SEEDED_TOPOLOGY_PUF_DISCONFIRMED_STANDALONE_2026_05"
+}
+```
+
+The CLI also prints the negative-finding warning so the status travels with
+terminal output, not only with this note.
+
+## Disposition
+
+Future PUF work should treat the Sacred Egg stack as a protocol envelope and
+test the stronger challenge-selector model:
+
+1. Keep geometry uniform enough that the public seed does not reveal a
+   reproducible macro-identity.
+2. Enroll each fabricated device by measuring a large challenge-response
+   database.
+3. Use a public PQC-derived seed to select the measurement challenge for each
+   session.
+4. Authenticate by comparing the observed response against the enrolled
+   per-device response distribution.
+
+That model needs a different harness:
+
+```csv
+device_id,challenge_id,read_id,<response columns>
+```
+
+Do not extend the raw seeded-topology harness as if it validates the whole
+Sacred Egg production path. Extend it only for negative-result documentation,
+exotic fabrication processes, or as one component inside a larger Sacred
+Egg/GeoSeal/challenge-response validation.
+
+## Meta-Finding
+
+This is a useful SCBE-AETHERMOORE governance example. A plausible AI-generated
+engineering proposal moved through several agents. The simulation-before-
+fabrication step caught the weakness of the **raw geometry-only** version before
+hardware spend. The negative result is now attached to the diagnostic harness so
+future agents do not quietly convert a parked sub-architecture into a production
+claim about the entire Sacred Egg system.

--- a/docs/specs/SACRED_EGG_CRP_PUF_HARNESS.md
+++ b/docs/specs/SACRED_EGG_CRP_PUF_HARNESS.md
@@ -1,0 +1,82 @@
+# Sacred Egg Challenge-Response PUF Harness
+
+**Status:** candidate forward path.  
+**Harness:** `scripts/experiments/sacred_egg_crp_puf_analysis.py`  
+**Tests:** `tests/experiments/test_sacred_egg_crp_puf_analysis.py`
+
+## Why this exists
+
+The raw seeded-topology PUF test asks whether deterministic seed-derived
+geometry alone can resist cloning. That narrow model is parked because the
+simulation-stage result showed same-seed clones stay too close at realistic
+printer tolerances.
+
+The Sacred Egg architecture is a larger protocol. It can use geometry,
+enrollment, GeoSeal context, hatch conditions, batch offsets, and sealed
+receipts together. The right production-shaped question is therefore:
+
+> Given an enrolled physical device and a public challenge selected by Sacred
+> Egg / GeoSeal context, does the device produce a stable response that impostor
+> devices cannot reproduce?
+
+## CSV Schema
+
+```csv
+device_id,challenge_id,read_id,r_0,r_1,r_2
+unit-a,challenge-1,0,0.10,0.90,0.11
+unit-a,challenge-1,1,0.12,0.88,0.10
+unit-b,challenge-1,0,0.91,0.10,0.89
+```
+
+Fields:
+
+- `device_id`: enrolled physical part
+- `challenge_id`: measurement challenge selected by Sacred Egg / GeoSeal context
+- `read_id`: repeated read index
+- response columns: impedance, RF, vibration, thermal, or other numeric features
+
+## Distance Regimes
+
+- `genuine`: same device, same challenge, repeated reads
+- `impostor`: different device, same challenge
+- `cross_challenge`: same device, different challenge
+
+The authentication condition is:
+
+```text
+max(genuine) < min(impostor) / 2
+```
+
+The harness estimates:
+
+- `reliability = 1 - mean(genuine)`
+- `uniqueness = mean(impostor)`
+- `challenge_separation = min(impostor) - max(genuine)`
+- `works_for_authentication`
+- `estimated_t_bits`
+- `estimated_impostor_delta_bits`
+- per-bit min-entropy estimate
+
+## Command
+
+```powershell
+python scripts/experiments/sacred_egg_crp_puf_analysis.py measurements.csv `
+  --report artifacts/aetherfab/sacred_egg_crp_puf_report.json
+```
+
+The command exits `0` only when the current measurements satisfy the estimated
+authentication condition. It exits `2` when the measurement set overlaps or is
+unproven.
+
+## How It Fits Sacred Eggs
+
+Sacred Eggs should not be treated as raw geometry. In the protocol framing:
+
+1. `SacredEgg` / `GeoSeal` context selects or authorizes `challenge_id`.
+2. The physical device produces response features.
+3. The response is quantized and compared against enrollment.
+4. A sealed receipt records challenge, response hash, measurement fixture, and
+   decision metadata.
+
+This keeps the seed as a challenge selector and authorization context rather
+than the sole identity-bearing geometry.

--- a/scripts/experiments/puf_measurement_analysis.py
+++ b/scripts/experiments/puf_measurement_analysis.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""AetherFab PUF measurement analysis harness.
+
+This is the first empirical gate for crypto-seeded topology research. It does
+not assume the material works. It asks the only question that matters first:
+
+    does knowing the seed help an attacker clone the physical response?
+
+Input CSV format (wide):
+
+    device_id,seed_id,read_id,f_1hz,f_10hz,f_100hz,...
+    seed-a-print-0,seed-a,0,0.11,0.20,0.33,...
+    seed-a-print-0,seed-a,1,0.10,0.21,0.32,...
+    seed-a-print-1,seed-a,0,0.28,0.41,0.51,...
+
+Numeric feature columns are quantized to bits by global feature medians unless
+explicit thresholds are provided in a JSON file.
+
+Distance regimes:
+- intra: same physical device, repeated reads; this is the noise floor.
+- clone: same seed, different physical device/fabrication; attacker knows seed.
+- inter: different seed; random baseline pair.
+
+Status: parked diagnostic harness, not a claim that seeded topology is a good
+PUF design. The v2 surrogate simulation found the original seeded-topology
+architecture structurally weak at realistic printer tolerances: same-seed clone
+pairs were much closer than random inter-device pairs. Preserve this harness for
+negative-result documentation and for exotic fabrication regimes where clone
+measurements may actually clear the noise floor. Future PUF work should pivot to
+the challenge-selector model: uniform geometry, per-device challenge-response
+database, and public seed selecting which measurement challenge to apply.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import asdict, dataclass
+import json
+import math
+from pathlib import Path
+import random
+from statistics import mean
+from typing import Sequence
+
+SCHEMA_VERSION = "aetherfab_puf_measurement_analysis_v1"
+ARCHITECTURE_STATUS = "RAW_SEEDED_TOPOLOGY_PUF_DISCONFIRMED_STANDALONE_2026_05"
+NEGATIVE_FINDING_NOTE = (
+    "Parked raw seeded-topology diagnostic. Prior v2 surrogate simulation found realistic "
+    "SLA/SLS/FDM printer tolerances likely make same-seed clones too close to originals "
+    "when geometry alone is treated as the PUF. This does not evaluate Sacred Eggs, "
+    "GeoSeal context, batch offsets, enrollment, or challenge-routing layers."
+)
+CLI_NEGATIVE_FINDING_WARNING = (
+    "NOTE: This harness validates raw seeded topology as a standalone PUF. "
+    "Simulation (puf_sim_v2.py, 2026-05-09) showed that narrow model is "
+    "structurally weak at printer tolerances sigma=0.025-0.10. This warning "
+    "does not evaluate Sacred Eggs, GeoSeal, batch offsets, enrollment, or "
+    "challenge-selector layers."
+)
+RECOMMENDED_PIVOT = (
+    "challenge-selector CRP-PUF: uniform geometry, per-device response database, "
+    "public seed selects fresh measurement challenge"
+)
+
+
+@dataclass(frozen=True)
+class Measurement:
+    device_id: str
+    read_id: str
+    values: tuple[float, ...]
+    seed_id: str | None = None
+    fabrication_id: str | None = None
+
+
+@dataclass(frozen=True)
+class DistanceSummary:
+    count: int
+    mean: float
+    minimum: float
+    maximum: float
+
+
+@dataclass(frozen=True)
+class PufMetrics:
+    schema_version: str
+    measurement_count: int
+    device_count: int
+    feature_count: int
+    quantization: str
+    intra: DistanceSummary
+    clone: DistanceSummary
+    inter: DistanceSummary
+    reliability: float
+    clone_gap: float
+    uniqueness: float
+    separation_margin: float
+    works_for_fuzzy_extractor: bool
+    works_against_seed_clone: bool
+    estimated_t_bits: int
+    estimated_clone_delta_bits: int
+    estimated_delta_bits: int
+    clone_vs_intra_ratio: float
+    clone_vs_inter_ratio: float
+    mean_min_entropy_per_bit: float
+    estimated_total_min_entropy_bits: float
+
+
+def load_measurements(path: Path) -> tuple[list[Measurement], list[str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if not reader.fieldnames:
+            raise ValueError("CSV has no header")
+        required = {"device_id", "read_id"}
+        missing = sorted(required.difference(reader.fieldnames))
+        if missing:
+            raise ValueError(f"CSV missing required columns: {missing}")
+        metadata = required.union({"seed_id", "fabrication_id"})
+        feature_names = [name for name in reader.fieldnames if name not in metadata]
+        if not feature_names:
+            raise ValueError("CSV must include at least one numeric feature column")
+        rows: list[Measurement] = []
+        for line_number, row in enumerate(reader, start=2):
+            device_id = str(row.get("device_id") or "").strip()
+            read_id = str(row.get("read_id") or "").strip()
+            if not device_id or not read_id:
+                raise ValueError(f"line {line_number}: device_id/read_id required")
+            try:
+                values = tuple(float(row[name]) for name in feature_names)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"line {line_number}: non-numeric feature value"
+                ) from exc
+            seed_id = str(row.get("seed_id") or "").strip() or None
+            fabrication_id = str(row.get("fabrication_id") or "").strip() or None
+            rows.append(
+                Measurement(
+                    device_id=device_id,
+                    read_id=read_id,
+                    values=values,
+                    seed_id=seed_id,
+                    fabrication_id=fabrication_id,
+                )
+            )
+    return rows, feature_names
+
+
+def median(values: Sequence[float]) -> float:
+    if not values:
+        raise ValueError("median requires at least one value")
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def median_thresholds(measurements: Sequence[Measurement]) -> tuple[float, ...]:
+    width = len(measurements[0].values)
+    return tuple(median([row.values[i] for row in measurements]) for i in range(width))
+
+
+def load_thresholds(path: Path, feature_names: Sequence[str]) -> tuple[float, ...]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        if len(data) != len(feature_names):
+            raise ValueError("threshold list length must equal feature count")
+        return tuple(float(value) for value in data)
+    if isinstance(data, dict):
+        missing = [name for name in feature_names if name not in data]
+        if missing:
+            raise ValueError(f"threshold JSON missing features: {missing}")
+        return tuple(float(data[name]) for name in feature_names)
+    raise ValueError("threshold JSON must be a list or object")
+
+
+def quantize(values: Sequence[float], thresholds: Sequence[float]) -> tuple[int, ...]:
+    if len(values) != len(thresholds):
+        raise ValueError("values and thresholds length mismatch")
+    return tuple(
+        1 if value >= threshold else 0 for value, threshold in zip(values, thresholds)
+    )
+
+
+def hamming_fraction(left: Sequence[int], right: Sequence[int]) -> float:
+    if len(left) != len(right) or not left:
+        raise ValueError("bit vectors must be non-empty and equal length")
+    return sum(1 for a, b in zip(left, right) if a != b) / len(left)
+
+
+def summarize_distances(values: Sequence[float]) -> DistanceSummary:
+    if not values:
+        return DistanceSummary(count=0, mean=0.0, minimum=0.0, maximum=0.0)
+    return DistanceSummary(
+        count=len(values),
+        mean=float(mean(values)),
+        minimum=float(min(values)),
+        maximum=float(max(values)),
+    )
+
+
+def _seed_key(row: Measurement) -> str:
+    return row.seed_id or row.device_id
+
+
+def pairwise_distances(
+    bit_rows: Sequence[tuple[Measurement, tuple[int, ...]]],
+) -> tuple[list[float], list[float], list[float]]:
+    intra: list[float] = []
+    clone: list[float] = []
+    inter: list[float] = []
+    for i, (row_a, bits_a) in enumerate(bit_rows):
+        for row_b, bits_b in bit_rows[i + 1 :]:
+            distance = hamming_fraction(bits_a, bits_b)
+            if row_a.device_id == row_b.device_id:
+                intra.append(distance)
+            elif _seed_key(row_a) == _seed_key(row_b):
+                clone.append(distance)
+            else:
+                inter.append(distance)
+    return intra, clone, inter
+
+
+def bit_min_entropy(bit_rows: Sequence[tuple[int, ...]]) -> tuple[float, float]:
+    if not bit_rows:
+        return 0.0, 0.0
+    width = len(bit_rows[0])
+    per_bit: list[float] = []
+    for i in range(width):
+        ones = sum(row[i] for row in bit_rows)
+        p_one = ones / len(bit_rows)
+        p_max = max(p_one, 1.0 - p_one)
+        per_bit.append(-math.log2(max(p_max, 1e-12)))
+    return float(mean(per_bit)), float(sum(per_bit))
+
+
+def analyze_measurements(
+    measurements: Sequence[Measurement],
+    *,
+    thresholds: Sequence[float] | None = None,
+    quantization: str = "global_median",
+) -> PufMetrics:
+    if len(measurements) < 2:
+        raise ValueError("need at least two measurements")
+    feature_count = len(measurements[0].values)
+    if any(len(row.values) != feature_count for row in measurements):
+        raise ValueError("all measurements must have the same feature count")
+    thresholds = (
+        tuple(thresholds) if thresholds is not None else median_thresholds(measurements)
+    )
+    bit_rows = [(row, quantize(row.values, thresholds)) for row in measurements]
+    intra_values, clone_values, inter_values = pairwise_distances(bit_rows)
+    intra = summarize_distances(intra_values)
+    clone = summarize_distances(clone_values)
+    inter = summarize_distances(inter_values)
+    bit_vectors = [bits for _, bits in bit_rows]
+    mean_entropy, total_entropy = bit_min_entropy(bit_vectors)
+    estimated_t_bits = math.ceil(intra.maximum * feature_count)
+    estimated_clone_delta_bits = (
+        math.floor(clone.minimum * feature_count) if clone.count else 0
+    )
+    estimated_delta_bits = (
+        math.floor(inter.minimum * feature_count) if inter.count else 0
+    )
+    fuzzy_vs_inter = bool(
+        intra.count and inter.count and estimated_t_bits < estimated_delta_bits / 2
+    )
+    fuzzy_vs_clone = bool(
+        intra.count
+        and clone.count
+        and estimated_t_bits < estimated_clone_delta_bits / 2
+    )
+    clone_gap = clone.minimum - intra.maximum if intra.count and clone.count else 0.0
+    clone_vs_intra_ratio = clone.mean / max(intra.mean, 1e-12) if clone.count else 0.0
+    clone_vs_inter_ratio = (
+        clone.mean / max(inter.mean, 1e-12) if clone.count and inter.count else 0.0
+    )
+    return PufMetrics(
+        schema_version=SCHEMA_VERSION,
+        measurement_count=len(measurements),
+        device_count=len({row.device_id for row in measurements}),
+        feature_count=feature_count,
+        quantization=quantization,
+        intra=intra,
+        clone=clone,
+        inter=inter,
+        reliability=1.0 - intra.mean,
+        clone_gap=clone_gap,
+        uniqueness=inter.mean,
+        separation_margin=(
+            inter.minimum - intra.maximum if intra.count and inter.count else 0.0
+        ),
+        works_for_fuzzy_extractor=fuzzy_vs_inter,
+        works_against_seed_clone=fuzzy_vs_clone,
+        estimated_t_bits=estimated_t_bits,
+        estimated_clone_delta_bits=estimated_clone_delta_bits,
+        estimated_delta_bits=estimated_delta_bits,
+        clone_vs_intra_ratio=clone_vs_intra_ratio,
+        clone_vs_inter_ratio=clone_vs_inter_ratio,
+        mean_min_entropy_per_bit=mean_entropy,
+        estimated_total_min_entropy_bits=total_entropy,
+    )
+
+
+def bootstrap_gap_ci(
+    measurements: Sequence[Measurement],
+    *,
+    iterations: int = 300,
+    seed: int = 1337,
+) -> tuple[float, float]:
+    """Bootstrap separation margin CI by resampling measurements with replacement."""
+
+    if iterations <= 0:
+        raise ValueError("iterations must be positive")
+    rng = random.Random(seed)
+    margins: list[float] = []
+    rows = list(measurements)
+    for _ in range(iterations):
+        sample = [rng.choice(rows) for _ in rows]
+        try:
+            margins.append(analyze_measurements(sample).separation_margin)
+        except ValueError:
+            continue
+    if not margins:
+        return 0.0, 0.0
+    margins.sort()
+    low = margins[int(0.025 * (len(margins) - 1))]
+    high = margins[int(0.975 * (len(margins) - 1))]
+    return float(low), float(high)
+
+
+def metrics_to_report(
+    metrics: PufMetrics, *, feature_names: Sequence[str], gap_ci: tuple[float, float]
+) -> dict:
+    report = asdict(metrics)
+    report["architecture_status"] = ARCHITECTURE_STATUS
+    report["status_note"] = NEGATIVE_FINDING_NOTE
+    report["recommended_pivot"] = RECOMMENDED_PIVOT
+    report["feature_names"] = list(feature_names)
+    report["separation_margin_ci95"] = {"low": gap_ci[0], "high": gap_ci[1]}
+    if metrics.clone.count:
+        report["verdict"] = (
+            "clone_resistant_candidate"
+            if metrics.clone_gap > 0
+            else "clone_overlap_or_barcode"
+        )
+    else:
+        report["verdict"] = (
+            "separated" if metrics.separation_margin > 0 else "overlap_or_unproven"
+        )
+    report["recommended_next"] = (
+        "choose ECC parameters from estimated_t_bits and estimated_clone_delta_bits"
+        if metrics.works_against_seed_clone
+        else (
+            "print same-seed clones and estimate clone distribution"
+            if not metrics.clone.count
+            else "increase fabrication-sensitive feature size or try another measurement modality"
+        )
+    )
+    return report
+
+
+def write_report(report: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Analyze PUF measurement CSVs for uniqueness/reliability."
+    )
+    parser.add_argument(
+        "csv",
+        type=Path,
+        help="Wide CSV with device_id, read_id, numeric feature columns",
+    )
+    parser.add_argument(
+        "--thresholds",
+        type=Path,
+        help="Optional JSON thresholds list or feature-name mapping",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("artifacts/aetherfab/puf_measurement_report.json"),
+        help="Output JSON report path",
+    )
+    parser.add_argument(
+        "--bootstrap",
+        type=int,
+        default=300,
+        help="Bootstrap iterations for separation CI",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    measurements, feature_names = load_measurements(args.csv)
+    thresholds = (
+        load_thresholds(args.thresholds, feature_names) if args.thresholds else None
+    )
+    metrics = analyze_measurements(
+        measurements,
+        thresholds=thresholds,
+        quantization="provided_thresholds" if thresholds else "global_median",
+    )
+    gap_ci = bootstrap_gap_ci(measurements, iterations=args.bootstrap)
+    report = metrics_to_report(metrics, feature_names=feature_names, gap_ci=gap_ci)
+    write_report(report, args.report)
+    print(
+        "AetherFab PUF analysis: "
+        f"reliability={metrics.reliability:.4f} "
+        f"clone_gap={metrics.clone_gap:.4f} "
+        f"uniqueness={metrics.uniqueness:.4f} "
+        f"separation_margin={metrics.separation_margin:.4f} "
+        f"seed_clone_resistant={metrics.works_against_seed_clone}"
+    )
+    print(CLI_NEGATIVE_FINDING_WARNING)
+    print(f"report={args.report}")
+    return (
+        0
+        if (
+            metrics.works_against_seed_clone
+            or (not metrics.clone.count and metrics.separation_margin > 0)
+        )
+        else 2
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/sacred_egg_crp_puf_analysis.py
+++ b/scripts/experiments/sacred_egg_crp_puf_analysis.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Sacred Egg CRP-PUF analysis harness.
+
+This is the forward path after the raw seeded-topology PUF diagnostic:
+
+    uniform/mostly-uniform device -> enrolled challenge-response database
+    public seed / Sacred Egg context -> challenge selector
+    verifier asks challenge -> device response must match enrollment
+
+CSV input format:
+
+    device_id,challenge_id,read_id,r_0,r_1,r_2,...
+    unit-a,c-001,0,0.10,0.90,0.11,...
+    unit-a,c-001,1,0.12,0.88,0.10,...
+    unit-b,c-001,0,0.91,0.10,0.89,...
+
+Distance regimes:
+- genuine: same device, same challenge, repeated reads
+- impostor: different device, same challenge
+- cross_challenge: same device, different challenge
+
+For production, genuine distances must stay below impostor distances for the
+same challenge. That is the challenge-response PUF question Sacred Eggs can
+route into: the seed selects the challenge; the enrolled physical device answers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import asdict, dataclass
+import json
+import math
+from pathlib import Path
+from statistics import mean
+from typing import Sequence
+
+SCHEMA_VERSION = "sacred_egg_crp_puf_analysis_v1"
+ARCHITECTURE_STATUS = "CHALLENGE_SELECTOR_CRP_PUF_CANDIDATE_2026_05"
+
+
+@dataclass(frozen=True)
+class CrpMeasurement:
+    device_id: str
+    challenge_id: str
+    read_id: str
+    values: tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class DistanceSummary:
+    count: int
+    mean: float
+    minimum: float
+    maximum: float
+
+
+@dataclass(frozen=True)
+class CrpMetrics:
+    schema_version: str
+    architecture_status: str
+    measurement_count: int
+    device_count: int
+    challenge_count: int
+    feature_count: int
+    genuine: DistanceSummary
+    impostor: DistanceSummary
+    cross_challenge: DistanceSummary
+    reliability: float
+    uniqueness: float
+    challenge_separation: float
+    works_for_authentication: bool
+    estimated_t_bits: int
+    estimated_impostor_delta_bits: int
+    mean_min_entropy_per_bit: float
+    estimated_total_min_entropy_bits: float
+
+
+def load_measurements(path: Path) -> tuple[list[CrpMeasurement], list[str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if not reader.fieldnames:
+            raise ValueError("CSV has no header")
+        required = {"device_id", "challenge_id", "read_id"}
+        missing = sorted(required.difference(reader.fieldnames))
+        if missing:
+            raise ValueError(f"CSV missing required columns: {missing}")
+        feature_names = [name for name in reader.fieldnames if name not in required]
+        if not feature_names:
+            raise ValueError("CSV must include at least one numeric response column")
+        rows: list[CrpMeasurement] = []
+        for line_number, row in enumerate(reader, start=2):
+            device_id = str(row.get("device_id") or "").strip()
+            challenge_id = str(row.get("challenge_id") or "").strip()
+            read_id = str(row.get("read_id") or "").strip()
+            if not device_id or not challenge_id or not read_id:
+                raise ValueError(
+                    f"line {line_number}: device_id/challenge_id/read_id required"
+                )
+            try:
+                values = tuple(float(row[name]) for name in feature_names)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"line {line_number}: non-numeric response value"
+                ) from exc
+            rows.append(CrpMeasurement(device_id, challenge_id, read_id, values))
+    return rows, feature_names
+
+
+def _median(values: Sequence[float]) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        raise ValueError("median requires at least one value")
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def _thresholds(rows: Sequence[CrpMeasurement]) -> tuple[float, ...]:
+    width = len(rows[0].values)
+    return tuple(_median([row.values[i] for row in rows]) for i in range(width))
+
+
+def quantize(values: Sequence[float], thresholds: Sequence[float]) -> tuple[int, ...]:
+    if len(values) != len(thresholds):
+        raise ValueError("values and thresholds length mismatch")
+    return tuple(
+        1 if value >= threshold else 0 for value, threshold in zip(values, thresholds)
+    )
+
+
+def hamming_fraction(left: Sequence[int], right: Sequence[int]) -> float:
+    if len(left) != len(right) or not left:
+        raise ValueError("bit vectors must be non-empty and equal length")
+    return sum(1 for a, b in zip(left, right) if a != b) / len(left)
+
+
+def summarize(values: Sequence[float]) -> DistanceSummary:
+    if not values:
+        return DistanceSummary(0, 0.0, 0.0, 0.0)
+    return DistanceSummary(
+        len(values), float(mean(values)), float(min(values)), float(max(values))
+    )
+
+
+def bit_min_entropy(bit_rows: Sequence[tuple[int, ...]]) -> tuple[float, float]:
+    if not bit_rows:
+        return 0.0, 0.0
+    per_bit: list[float] = []
+    for i in range(len(bit_rows[0])):
+        ones = sum(row[i] for row in bit_rows)
+        p_one = ones / len(bit_rows)
+        p_max = max(p_one, 1.0 - p_one)
+        per_bit.append(-math.log2(max(p_max, 1e-12)))
+    return float(mean(per_bit)), float(sum(per_bit))
+
+
+def pairwise_distances(
+    bit_rows: Sequence[tuple[CrpMeasurement, tuple[int, ...]]],
+) -> tuple[list[float], list[float], list[float]]:
+    genuine: list[float] = []
+    impostor: list[float] = []
+    cross_challenge: list[float] = []
+    for i, (row_a, bits_a) in enumerate(bit_rows):
+        for row_b, bits_b in bit_rows[i + 1 :]:
+            distance = hamming_fraction(bits_a, bits_b)
+            same_device = row_a.device_id == row_b.device_id
+            same_challenge = row_a.challenge_id == row_b.challenge_id
+            if same_device and same_challenge:
+                genuine.append(distance)
+            elif (not same_device) and same_challenge:
+                impostor.append(distance)
+            elif same_device and not same_challenge:
+                cross_challenge.append(distance)
+    return genuine, impostor, cross_challenge
+
+
+def analyze_measurements(rows: Sequence[CrpMeasurement]) -> CrpMetrics:
+    if len(rows) < 2:
+        raise ValueError("need at least two measurements")
+    feature_count = len(rows[0].values)
+    if any(len(row.values) != feature_count for row in rows):
+        raise ValueError("all measurements must have the same feature count")
+    thresholds = _thresholds(rows)
+    bit_rows = [(row, quantize(row.values, thresholds)) for row in rows]
+    genuine_values, impostor_values, cross_values = pairwise_distances(bit_rows)
+    genuine = summarize(genuine_values)
+    impostor = summarize(impostor_values)
+    cross_challenge = summarize(cross_values)
+    mean_entropy, total_entropy = bit_min_entropy([bits for _, bits in bit_rows])
+    estimated_t_bits = math.ceil(genuine.maximum * feature_count)
+    estimated_impostor_delta_bits = (
+        math.floor(impostor.minimum * feature_count) if impostor.count else 0
+    )
+    challenge_separation = (
+        impostor.minimum - genuine.maximum if genuine.count and impostor.count else 0.0
+    )
+    return CrpMetrics(
+        schema_version=SCHEMA_VERSION,
+        architecture_status=ARCHITECTURE_STATUS,
+        measurement_count=len(rows),
+        device_count=len({row.device_id for row in rows}),
+        challenge_count=len({row.challenge_id for row in rows}),
+        feature_count=feature_count,
+        genuine=genuine,
+        impostor=impostor,
+        cross_challenge=cross_challenge,
+        reliability=1.0 - genuine.mean,
+        uniqueness=impostor.mean,
+        challenge_separation=challenge_separation,
+        works_for_authentication=bool(
+            genuine.count
+            and impostor.count
+            and estimated_t_bits < estimated_impostor_delta_bits / 2
+        ),
+        estimated_t_bits=estimated_t_bits,
+        estimated_impostor_delta_bits=estimated_impostor_delta_bits,
+        mean_min_entropy_per_bit=mean_entropy,
+        estimated_total_min_entropy_bits=total_entropy,
+    )
+
+
+def metrics_to_report(metrics: CrpMetrics, *, feature_names: Sequence[str]) -> dict:
+    report = asdict(metrics)
+    report["feature_names"] = list(feature_names)
+    report["verdict"] = (
+        "auth_candidate" if metrics.works_for_authentication else "overlap_or_unproven"
+    )
+    report["sacred_egg_role"] = (
+        "Sacred Egg / GeoSeal context should select challenge_id and bind the response receipt; "
+        "this harness only tests whether enrolled CRP responses separate genuine from impostor reads."
+    )
+    report["recommended_next"] = (
+        "bind challenge_id selection to Sacred Egg context and sealed measurement receipts"
+        if metrics.works_for_authentication
+        else "increase response dimensionality, improve fixture stability, or collect cleaner challenge data"
+    )
+    return report
+
+
+def write_report(report: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Analyze challenge-response PUF measurement CSVs."
+    )
+    parser.add_argument(
+        "csv",
+        type=Path,
+        help="CSV with device_id, challenge_id, read_id, response columns",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("artifacts/aetherfab/sacred_egg_crp_puf_report.json"),
+        help="Output JSON report path",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    rows, feature_names = load_measurements(args.csv)
+    metrics = analyze_measurements(rows)
+    report = metrics_to_report(metrics, feature_names=feature_names)
+    write_report(report, args.report)
+    print(
+        "Sacred Egg CRP-PUF analysis: "
+        f"reliability={metrics.reliability:.4f} "
+        f"uniqueness={metrics.uniqueness:.4f} "
+        f"challenge_separation={metrics.challenge_separation:.4f} "
+        f"auth_ready={metrics.works_for_authentication}"
+    )
+    print(f"report={args.report}")
+    return 0 if metrics.works_for_authentication else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/experiments/test_puf_measurement_analysis.py
+++ b/tests/experiments/test_puf_measurement_analysis.py
@@ -1,0 +1,144 @@
+import csv
+import json
+
+import pytest
+
+from scripts.experiments.puf_measurement_analysis import (
+    Measurement,
+    analyze_measurements,
+    bootstrap_gap_ci,
+    load_measurements,
+    metrics_to_report,
+    write_report,
+)
+
+
+def separated_measurements() -> list[Measurement]:
+    return [
+        Measurement(
+            "seed-a-print-0",
+            "0",
+            (0.10, 0.10, 0.10, 0.10, 0.90, 0.90, 0.90, 0.90),
+            "seed-a",
+        ),
+        Measurement(
+            "seed-a-print-0",
+            "1",
+            (0.11, 0.11, 0.11, 0.11, 0.89, 0.89, 0.89, 0.89),
+            "seed-a",
+        ),
+        Measurement(
+            "seed-a-print-1",
+            "0",
+            (0.90, 0.90, 0.10, 0.10, 0.10, 0.10, 0.90, 0.90),
+            "seed-a",
+        ),
+        Measurement(
+            "seed-b-print-0",
+            "0",
+            (0.90, 0.90, 0.90, 0.90, 0.10, 0.10, 0.10, 0.10),
+            "seed-b",
+        ),
+        Measurement(
+            "seed-b-print-0",
+            "1",
+            (0.89, 0.89, 0.89, 0.89, 0.11, 0.11, 0.11, 0.11),
+            "seed-b",
+        ),
+        Measurement(
+            "seed-b-print-1",
+            "0",
+            (0.10, 0.10, 0.90, 0.90, 0.90, 0.90, 0.10, 0.10),
+            "seed-b",
+        ),
+    ]
+
+
+def overlapping_measurements() -> list[Measurement]:
+    return [
+        Measurement("seed-a-print-0", "0", (0.10, 0.10, 0.90, 0.90), "seed-a"),
+        Measurement("seed-a-print-0", "1", (0.11, 0.11, 0.89, 0.89), "seed-a"),
+        Measurement("seed-a-print-1", "0", (0.10, 0.10, 0.90, 0.90), "seed-a"),
+        Measurement("seed-b-print-0", "0", (0.90, 0.90, 0.10, 0.10), "seed-b"),
+        Measurement("seed-b-print-0", "1", (0.89, 0.89, 0.11, 0.11), "seed-b"),
+    ]
+
+
+def test_analyze_measurements_reports_separated_puf_candidate() -> None:
+    metrics = analyze_measurements(separated_measurements())
+
+    assert metrics.schema_version == "aetherfab_puf_measurement_analysis_v1"
+    assert metrics.device_count == 4
+    assert metrics.measurement_count == 6
+    assert metrics.reliability == 1.0
+    assert metrics.clone.count == 4
+    assert metrics.clone_gap > 0.0
+    assert metrics.uniqueness > 0.45
+    assert metrics.separation_margin > 0.0
+    assert metrics.works_for_fuzzy_extractor is True
+    assert metrics.works_against_seed_clone is True
+    assert metrics.estimated_t_bits == 0
+    assert metrics.estimated_clone_delta_bits > 0
+    assert metrics.estimated_delta_bits > 0
+
+
+def test_analyze_measurements_rejects_overlapping_candidate() -> None:
+    metrics = analyze_measurements(overlapping_measurements())
+
+    assert metrics.clone_gap <= 0.0
+    assert metrics.works_against_seed_clone is False
+
+
+def test_load_measurements_from_wide_csv(tmp_path) -> None:
+    path = tmp_path / "impedance.csv"
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["device_id", "seed_id", "read_id", "z_1hz", "z_10hz"])
+        writer.writerow(["seed-a-print-0", "seed-a", "0", "0.1", "0.2"])
+        writer.writerow(["seed-a-print-0", "seed-a", "1", "0.1", "0.21"])
+
+    rows, features = load_measurements(path)
+
+    assert features == ["z_1hz", "z_10hz"]
+    assert rows == [
+        Measurement("seed-a-print-0", "0", (0.1, 0.2), "seed-a"),
+        Measurement("seed-a-print-0", "1", (0.1, 0.21), "seed-a"),
+    ]
+
+
+def test_report_contains_verdict_and_next_step(tmp_path) -> None:
+    metrics = analyze_measurements(separated_measurements())
+    report = metrics_to_report(
+        metrics, feature_names=["f0"] * metrics.feature_count, gap_ci=(0.25, 0.75)
+    )
+    path = tmp_path / "report.json"
+
+    write_report(report, path)
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+
+    assert loaded["verdict"] == "clone_resistant_candidate"
+    assert (
+        loaded["architecture_status"]
+        == "RAW_SEEDED_TOPOLOGY_PUF_DISCONFIRMED_STANDALONE_2026_05"
+    )
+    assert "Parked raw seeded-topology diagnostic" in loaded["status_note"]
+    assert "Sacred Eggs" in loaded["status_note"]
+    assert "challenge-selector" in loaded["recommended_pivot"]
+    assert loaded["separation_margin_ci95"] == {"low": 0.25, "high": 0.75}
+    assert "ECC" in loaded["recommended_next"]
+
+
+def test_bootstrap_gap_ci_is_deterministic() -> None:
+    ci_a = bootstrap_gap_ci(separated_measurements(), iterations=20, seed=7)
+    ci_b = bootstrap_gap_ci(separated_measurements(), iterations=20, seed=7)
+
+    assert ci_a == ci_b
+    assert ci_a[0] <= ci_a[1]
+
+
+def test_load_measurements_requires_feature_columns(tmp_path) -> None:
+    path = tmp_path / "bad.csv"
+    path.write_text("device_id,read_id\nseed-a,0\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="numeric feature"):
+        load_measurements(path)

--- a/tests/experiments/test_sacred_egg_crp_puf_analysis.py
+++ b/tests/experiments/test_sacred_egg_crp_puf_analysis.py
@@ -1,0 +1,93 @@
+import csv
+import json
+
+import pytest
+
+from scripts.experiments.sacred_egg_crp_puf_analysis import (
+    CrpMeasurement,
+    analyze_measurements,
+    load_measurements,
+    metrics_to_report,
+    write_report,
+)
+
+
+def auth_candidate_rows() -> list[CrpMeasurement]:
+    return [
+        CrpMeasurement("unit-a", "challenge-1", "0", (0.10, 0.10, 0.90, 0.90)),
+        CrpMeasurement("unit-a", "challenge-1", "1", (0.11, 0.11, 0.89, 0.89)),
+        CrpMeasurement("unit-b", "challenge-1", "0", (0.90, 0.90, 0.10, 0.10)),
+        CrpMeasurement("unit-b", "challenge-1", "1", (0.89, 0.89, 0.11, 0.11)),
+        CrpMeasurement("unit-a", "challenge-2", "0", (0.90, 0.10, 0.10, 0.90)),
+        CrpMeasurement("unit-b", "challenge-2", "0", (0.10, 0.90, 0.90, 0.10)),
+    ]
+
+
+def overlapping_rows() -> list[CrpMeasurement]:
+    return [
+        CrpMeasurement("unit-a", "challenge-1", "0", (0.10, 0.10, 0.90, 0.90)),
+        CrpMeasurement("unit-a", "challenge-1", "1", (0.90, 0.90, 0.10, 0.10)),
+        CrpMeasurement("unit-b", "challenge-1", "0", (0.11, 0.11, 0.89, 0.89)),
+        CrpMeasurement("unit-b", "challenge-1", "1", (0.12, 0.12, 0.88, 0.88)),
+    ]
+
+
+def test_auth_candidate_separates_genuine_from_impostor() -> None:
+    metrics = analyze_measurements(auth_candidate_rows())
+
+    assert metrics.schema_version == "sacred_egg_crp_puf_analysis_v1"
+    assert metrics.architecture_status == "CHALLENGE_SELECTOR_CRP_PUF_CANDIDATE_2026_05"
+    assert metrics.device_count == 2
+    assert metrics.challenge_count == 2
+    assert metrics.genuine.count == 2
+    assert metrics.impostor.count == 5
+    assert metrics.reliability == 1.0
+    assert metrics.challenge_separation > 0.0
+    assert metrics.works_for_authentication is True
+    assert metrics.estimated_t_bits == 0
+    assert metrics.estimated_impostor_delta_bits > 0
+
+
+def test_overlap_rejects_authentication_claim() -> None:
+    metrics = analyze_measurements(overlapping_rows())
+
+    assert metrics.works_for_authentication is False
+    assert metrics.challenge_separation <= 0.0
+
+
+def test_load_measurements_from_csv(tmp_path) -> None:
+    path = tmp_path / "crp.csv"
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["device_id", "challenge_id", "read_id", "r0", "r1"])
+        writer.writerow(["unit-a", "challenge-1", "0", "0.1", "0.9"])
+        writer.writerow(["unit-a", "challenge-1", "1", "0.11", "0.88"])
+
+    rows, features = load_measurements(path)
+
+    assert features == ["r0", "r1"]
+    assert rows == [
+        CrpMeasurement("unit-a", "challenge-1", "0", (0.1, 0.9)),
+        CrpMeasurement("unit-a", "challenge-1", "1", (0.11, 0.88)),
+    ]
+
+
+def test_report_carries_sacred_egg_role(tmp_path) -> None:
+    metrics = analyze_measurements(auth_candidate_rows())
+    report = metrics_to_report(metrics, feature_names=["r0"] * metrics.feature_count)
+    path = tmp_path / "report.json"
+
+    write_report(report, path)
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+
+    assert loaded["verdict"] == "auth_candidate"
+    assert "Sacred Egg / GeoSeal context" in loaded["sacred_egg_role"]
+    assert "challenge_id selection" in loaded["recommended_next"]
+
+
+def test_load_requires_response_columns(tmp_path) -> None:
+    path = tmp_path / "bad.csv"
+    path.write_text("device_id,challenge_id,read_id\nunit-a,c1,0\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="response column"):
+        load_measurements(path)


### PR DESCRIPTION
## Summary

Adds a focused materials-security validation lane for AetherFab / Sacred Egg PUF work.

This PR keeps two claims separate:

- raw seeded topology as a standalone PUF is parked as a diagnostic/negative-result harness
- the forward path is a Sacred Egg / GeoSeal challenge-response PUF harness where the seed/context selects `challenge_id` and enrolled physical measurements prove or reject authentication readiness

## Changed paths

- `scripts/experiments/puf_measurement_analysis.py`
- `scripts/experiments/sacred_egg_crp_puf_analysis.py`
- `tests/experiments/test_puf_measurement_analysis.py`
- `tests/experiments/test_sacred_egg_crp_puf_analysis.py`
- `docs/specs/AETHERFAB_PUF_NEGATIVE_RESULT.md`
- `docs/specs/SACRED_EGG_CRP_PUF_HARNESS.md`

## Test evidence

- `python -m pytest tests/experiments/test_sacred_egg_crp_puf_analysis.py tests/experiments/test_puf_measurement_analysis.py -q` -> 11 passed
- `python -m compileall scripts/experiments/sacred_egg_crp_puf_analysis.py scripts/experiments/puf_measurement_analysis.py tests/experiments/test_sacred_egg_crp_puf_analysis.py tests/experiments/test_puf_measurement_analysis.py` -> passed

## Rollback

Revert this PR. It only adds standalone scripts, tests, and docs; no runtime paths are wired into production.