### PR TITLE
feat(materials): add Sacred Egg CRP PUF harness

### DIFF
--- a/scripts/experiments/puf_measurement_analysis.py
+++ b/scripts/experiments/puf_measurement_analysis.py
@@ -128,9 +128,7 @@ def load_measurements(path: Path) -> tuple[list[Measurement], list[str]]:
             try:
                 values = tuple(float(row[name]) for name in feature_names)
             except (TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"line {line_number}: non-numeric feature value"
-                ) from exc
+                raise ValueError(f"line {line_number}: non-numeric feature value") from exc
             seed_id = str(row.get("seed_id") or "").strip() or None
             fabrication_id = str(row.get("fabrication_id") or "").strip() or None
             rows.append(
@@ -177,9 +175,7 @@ def load_thresholds(path: Path, feature_names: Sequence[str]) -> tuple[float, ..
 def quantize(values: Sequence[float], thresholds: Sequence[float]) -> tuple[int, ...]:
     if len(values) != len(thresholds):
         raise ValueError("values and thresholds length mismatch")
-    return tuple(
-        1 if value >= threshold else 0 for value, threshold in zip(values, thresholds)
-    )
+    return tuple(1 if value >= threshold else 0 for value, threshold in zip(values, thresholds))
 
 
 def hamming_fraction(left: Sequence[int], right: Sequence[int]) -> float:
@@ -245,9 +241,7 @@ def analyze_measurements(
     feature_count = len(measurements[0].values)
     if any(len(row.values) != feature_count for row in measurements):
         raise ValueError("all measurements must have the same feature count")
-    thresholds = (
-        tuple(thresholds) if thresholds is not None else median_thresholds(measurements)
-    )
+    thresholds = tuple(thresholds) if thresholds is not None else median_thresholds(measurements)
     bit_rows = [(row, quantize(row.values, thresholds)) for row in measurements]
     intra_values, clone_values, inter_values = pairwise_distances(bit_rows)
     intra = summarize_distances(intra_values)
@@ -256,25 +250,13 @@ def analyze_measurements(
     bit_vectors = [bits for _, bits in bit_rows]
     mean_entropy, total_entropy = bit_min_entropy(bit_vectors)
     estimated_t_bits = math.ceil(intra.maximum * feature_count)
-    estimated_clone_delta_bits = (
-        math.floor(clone.minimum * feature_count) if clone.count else 0
-    )
-    estimated_delta_bits = (
-        math.floor(inter.minimum * feature_count) if inter.count else 0
-    )
-    fuzzy_vs_inter = bool(
-        intra.count and inter.count and estimated_t_bits < estimated_delta_bits / 2
-    )
-    fuzzy_vs_clone = bool(
-        intra.count
-        and clone.count
-        and estimated_t_bits < estimated_clone_delta_bits / 2
-    )
+    estimated_clone_delta_bits = math.floor(clone.minimum * feature_count) if clone.count else 0
+    estimated_delta_bits = math.floor(inter.minimum * feature_count) if inter.count else 0
+    fuzzy_vs_inter = bool(intra.count and inter.count and estimated_t_bits < estimated_delta_bits / 2)
+    fuzzy_vs_clone = bool(intra.count and clone.count and estimated_t_bits < estimated_clone_delta_bits / 2)
     clone_gap = clone.minimum - intra.maximum if intra.count and clone.count else 0.0
     clone_vs_intra_ratio = clone.mean / max(intra.mean, 1e-12) if clone.count else 0.0
-    clone_vs_inter_ratio = (
-        clone.mean / max(inter.mean, 1e-12) if clone.count and inter.count else 0.0
-    )
+    clone_vs_inter_ratio = clone.mean / max(inter.mean, 1e-12) if clone.count and inter.count else 0.0
     return PufMetrics(
         schema_version=SCHEMA_VERSION,
         measurement_count=len(measurements),
@@ -287,9 +269,7 @@ def analyze_measurements(
         reliability=1.0 - intra.mean,
         clone_gap=clone_gap,
         uniqueness=inter.mean,
-        separation_margin=(
-            inter.minimum - intra.maximum if intra.count and inter.count else 0.0
-        ),
+        separation_margin=(inter.minimum - intra.maximum if intra.count and inter.count else 0.0),
         works_for_fuzzy_extractor=fuzzy_vs_inter,
         works_against_seed_clone=fuzzy_vs_clone,
         estimated_t_bits=estimated_t_bits,
@@ -329,9 +309,7 @@ def bootstrap_gap_ci(
     return float(low), float(high)
 
 
-def metrics_to_report(
-    metrics: PufMetrics, *, feature_names: Sequence[str], gap_ci: tuple[float, float]
-) -> dict:
+def metrics_to_report(metrics: PufMetrics, *, feature_names: Sequence[str], gap_ci: tuple[float, float]) -> dict:
     report = asdict(metrics)
     report["architecture_status"] = ARCHITECTURE_STATUS
     report["status_note"] = NEGATIVE_FINDING_NOTE
@@ -339,15 +317,9 @@ def metrics_to_report(
     report["feature_names"] = list(feature_names)
     report["separation_margin_ci95"] = {"low": gap_ci[0], "high": gap_ci[1]}
     if metrics.clone.count:
-        report["verdict"] = (
-            "clone_resistant_candidate"
-            if metrics.clone_gap > 0
-            else "clone_overlap_or_barcode"
-        )
+        report["verdict"] = "clone_resistant_candidate" if metrics.clone_gap > 0 else "clone_overlap_or_barcode"
     else:
-        report["verdict"] = (
-            "separated" if metrics.separation_margin > 0 else "overlap_or_unproven"
-        )
+        report["verdict"] = "separated" if metrics.separation_margin > 0 else "overlap_or_unproven"
     report["recommended_next"] = (
         "choose ECC parameters from estimated_t_bits and estimated_clone_delta_bits"
         if metrics.works_against_seed_clone
@@ -362,15 +334,11 @@ def metrics_to_report(
 
 def write_report(report: dict, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Analyze PUF measurement CSVs for uniqueness/reliability."
-    )
+    parser = argparse.ArgumentParser(description="Analyze PUF measurement CSVs for uniqueness/reliability.")
     parser.add_argument(
         "csv",
         type=Path,
@@ -399,9 +367,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     measurements, feature_names = load_measurements(args.csv)
-    thresholds = (
-        load_thresholds(args.thresholds, feature_names) if args.thresholds else None
-    )
+    thresholds = load_thresholds(args.thresholds, feature_names) if args.thresholds else None
     metrics = analyze_measurements(
         measurements,
         thresholds=thresholds,
@@ -420,14 +386,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     print(CLI_NEGATIVE_FINDING_WARNING)
     print(f"report={args.report}")
-    return (
-        0
-        if (
-            metrics.works_against_seed_clone
-            or (not metrics.clone.count and metrics.separation_margin > 0)
-        )
-        else 2
-    )
+    return 0 if (metrics.works_against_seed_clone or (not metrics.clone.count and metrics.separation_margin > 0)) else 2
 
 
 if __name__ == "__main__":

--- a/scripts/experiments/sacred_egg_crp_puf_analysis.py
+++ b/scripts/experiments/sacred_egg_crp_puf_analysis.py
@@ -94,15 +94,11 @@ def load_measurements(path: Path) -> tuple[list[CrpMeasurement], list[str]]:
             challenge_id = str(row.get("challenge_id") or "").strip()
             read_id = str(row.get("read_id") or "").strip()
             if not device_id or not challenge_id or not read_id:
-                raise ValueError(
-                    f"line {line_number}: device_id/challenge_id/read_id required"
-                )
+                raise ValueError(f"line {line_number}: device_id/challenge_id/read_id required")
             try:
                 values = tuple(float(row[name]) for name in feature_names)
             except (TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"line {line_number}: non-numeric response value"
-                ) from exc
+                raise ValueError(f"line {line_number}: non-numeric response value") from exc
             rows.append(CrpMeasurement(device_id, challenge_id, read_id, values))
     return rows, feature_names
 
@@ -125,9 +121,7 @@ def _thresholds(rows: Sequence[CrpMeasurement]) -> tuple[float, ...]:
 def quantize(values: Sequence[float], thresholds: Sequence[float]) -> tuple[int, ...]:
     if len(values) != len(thresholds):
         raise ValueError("values and thresholds length mismatch")
-    return tuple(
-        1 if value >= threshold else 0 for value, threshold in zip(values, thresholds)
-    )
+    return tuple(1 if value >= threshold else 0 for value, threshold in zip(values, thresholds))
 
 
 def hamming_fraction(left: Sequence[int], right: Sequence[int]) -> float:
@@ -139,9 +133,7 @@ def hamming_fraction(left: Sequence[int], right: Sequence[int]) -> float:
 def summarize(values: Sequence[float]) -> DistanceSummary:
     if not values:
         return DistanceSummary(0, 0.0, 0.0, 0.0)
-    return DistanceSummary(
-        len(values), float(mean(values)), float(min(values)), float(max(values))
-    )
+    return DistanceSummary(len(values), float(mean(values)), float(min(values)), float(max(values)))
 
 
 def bit_min_entropy(bit_rows: Sequence[tuple[int, ...]]) -> tuple[float, float]:
@@ -190,12 +182,8 @@ def analyze_measurements(rows: Sequence[CrpMeasurement]) -> CrpMetrics:
     cross_challenge = summarize(cross_values)
     mean_entropy, total_entropy = bit_min_entropy([bits for _, bits in bit_rows])
     estimated_t_bits = math.ceil(genuine.maximum * feature_count)
-    estimated_impostor_delta_bits = (
-        math.floor(impostor.minimum * feature_count) if impostor.count else 0
-    )
-    challenge_separation = (
-        impostor.minimum - genuine.maximum if genuine.count and impostor.count else 0.0
-    )
+    estimated_impostor_delta_bits = math.floor(impostor.minimum * feature_count) if impostor.count else 0
+    challenge_separation = impostor.minimum - genuine.maximum if genuine.count and impostor.count else 0.0
     return CrpMetrics(
         schema_version=SCHEMA_VERSION,
         architecture_status=ARCHITECTURE_STATUS,
@@ -210,9 +198,7 @@ def analyze_measurements(rows: Sequence[CrpMeasurement]) -> CrpMetrics:
         uniqueness=impostor.mean,
         challenge_separation=challenge_separation,
         works_for_authentication=bool(
-            genuine.count
-            and impostor.count
-            and estimated_t_bits < estimated_impostor_delta_bits / 2
+            genuine.count and impostor.count and estimated_t_bits < estimated_impostor_delta_bits / 2
         ),
         estimated_t_bits=estimated_t_bits,
         estimated_impostor_delta_bits=estimated_impostor_delta_bits,
@@ -224,9 +210,7 @@ def analyze_measurements(rows: Sequence[CrpMeasurement]) -> CrpMetrics:
 def metrics_to_report(metrics: CrpMetrics, *, feature_names: Sequence[str]) -> dict:
     report = asdict(metrics)
     report["feature_names"] = list(feature_names)
-    report["verdict"] = (
-        "auth_candidate" if metrics.works_for_authentication else "overlap_or_unproven"
-    )
+    report["verdict"] = "auth_candidate" if metrics.works_for_authentication else "overlap_or_unproven"
     report["sacred_egg_role"] = (
         "Sacred Egg / GeoSeal context should select challenge_id and bind the response receipt; "
         "this harness only tests whether enrolled CRP responses separate genuine from impostor reads."
@@ -241,15 +225,11 @@ def metrics_to_report(metrics: CrpMetrics, *, feature_names: Sequence[str]) -> d
 
 def write_report(report: dict, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Analyze challenge-response PUF measurement CSVs."
-    )
+    parser = argparse.ArgumentParser(description="Analyze challenge-response PUF measurement CSVs.")
     parser.add_argument(
         "csv",
         type=Path,

--- a/tests/experiments/test_puf_measurement_analysis.py
+++ b/tests/experiments/test_puf_measurement_analysis.py
@@ -108,19 +108,14 @@ def test_load_measurements_from_wide_csv(tmp_path) -> None:
 
 def test_report_contains_verdict_and_next_step(tmp_path) -> None:
     metrics = analyze_measurements(separated_measurements())
-    report = metrics_to_report(
-        metrics, feature_names=["f0"] * metrics.feature_count, gap_ci=(0.25, 0.75)
-    )
+    report = metrics_to_report(metrics, feature_names=["f0"] * metrics.feature_count, gap_ci=(0.25, 0.75))
     path = tmp_path / "report.json"
 
     write_report(report, path)
     loaded = json.loads(path.read_text(encoding="utf-8"))
 
     assert loaded["verdict"] == "clone_resistant_candidate"
-    assert (
-        loaded["architecture_status"]
-        == "RAW_SEEDED_TOPOLOGY_PUF_DISCONFIRMED_STANDALONE_2026_05"
-    )
+    assert loaded["architecture_status"] == "RAW_SEEDED_TOPOLOGY_PUF_DISCONFIRMED_STANDALONE_2026_05"
     assert "Parked raw seeded-topology diagnostic" in loaded["status_note"]
     assert "Sacred Eggs" in loaded["status_note"]
     assert "challenge-selector" in loaded["recommended_pivot"]


### PR DESCRIPTION
## Summary

Adds a focused materials-security validation lane for AetherFab / Sacred Egg PUF work.

This PR keeps two claims separate:

- raw seeded topology as a standalone PUF is parked as a diagnostic/negative-result harness
- the forward path is a Sacred Egg / GeoSeal challenge-response PUF harness where the seed/context selects `challenge_id` and enrolled physical measurements prove or reject authentication readiness

## Changed paths

- `scripts/experiments/puf_measurement_analysis.py`
- `scripts/experiments/sacred_egg_crp_puf_analysis.py`
- `tests/experiments/test_puf_measurement_analysis.py`
- `tests/experiments/test_sacred_egg_crp_puf_analysis.py`
- `docs/specs/AETHERFAB_PUF_NEGATIVE_RESULT.md`
- `docs/specs/SACRED_EGG_CRP_PUF_HARNESS.md`

## Test evidence

- `python -m pytest tests/experiments/test_sacred_egg_crp_puf_analysis.py tests/experiments/test_puf_measurement_analysis.py -q` -> 11 passed
- `python -m compileall scripts/experiments/sacred_egg_crp_puf_analysis.py scripts/experiments/puf_measurement_analysis.py tests/experiments/test_sacred_egg_crp_puf_analysis.py tests/experiments/test_puf_measurement_analysis.py` -> passed
- `python -m black --check --target-version py311 --line-length 120 ...` -> passed
- `python -m ruff check ...` -> passed

## Rollback

Revert this PR. It only adds standalone scripts, tests, and docs; no runtime paths are wired into production.