### PR TITLE
feat(materials): three-state verdict + entropy floor for Sacred Egg CRP PUF

### DIFF
--- a/docs/specs/SACRED_EGG_CRP_PUF_HARNESS.md
+++ b/docs/specs/SACRED_EGG_CRP_PUF_HARNESS.md
@@ -52,21 +52,37 @@ The harness estimates:
 - `reliability = 1 - mean(genuine)`
 - `uniqueness = mean(impostor)`
 - `challenge_separation = min(impostor) - max(genuine)`
-- `works_for_authentication`
+- `passes_separation_condition` — boolean for the geometric separation check
+  above. **Necessary but not sufficient for real authentication.** A small
+  device + challenge set can satisfy this with only a handful of entropy
+  bits; gate any production claim on `estimated_total_min_entropy_bits`
+  meeting your auth threshold (typical floor: 64+ bits).
 - `estimated_t_bits`
 - `estimated_impostor_delta_bits`
 - per-bit min-entropy estimate
+- `estimated_total_min_entropy_bits`
 
 ## Command
 
 ```powershell
 python scripts/experiments/sacred_egg_crp_puf_analysis.py measurements.csv `
-  --report artifacts/aetherfab/sacred_egg_crp_puf_report.json
+  --report artifacts/aetherfab/sacred_egg_crp_puf_report.json `
+  --min-entropy-bits 64
 ```
 
-The command exits `0` only when the current measurements satisfy the estimated
-authentication condition. It exits `2` when the measurement set overlaps or is
-unproven.
+`--min-entropy-bits` (default `64`) is the floor below which a passing
+separation downgrades to `separation_only_low_entropy`. 64 bits is the
+typical modern auth floor (cf. NIST SP 800-63B effective entropy guidance);
+override to `0` for raw geometric checks during bring-up, or raise it for
+hardened deployments.
+
+## Verdicts and Exit Codes
+
+| Verdict                          | Exit | Meaning |
+|----------------------------------|------|---------|
+| `auth_candidate`                 | `0`  | Geometry separates AND entropy ≥ threshold. Real silicon evidence still required before any production claim. |
+| `separation_only_low_entropy`    | `3`  | Geometry separates but entropy < threshold. Promising shape, insufficient bits. Expand challenge set / response dim / device count. |
+| `overlap_or_unproven`            | `2`  | Geometry does not separate. Fix fixture / collect cleaner data before re-running. |
 
 ## How It Fits Sacred Eggs
 

--- a/scripts/experiments/sacred_egg_crp_puf_analysis.py
+++ b/scripts/experiments/sacred_egg_crp_puf_analysis.py
@@ -38,6 +38,19 @@ from typing import Sequence
 SCHEMA_VERSION = "sacred_egg_crp_puf_analysis_v1"
 ARCHITECTURE_STATUS = "CHALLENGE_SELECTOR_CRP_PUF_CANDIDATE_2026_05"
 
+# Default min-entropy floor for treating a separation pass as an auth candidate.
+# 64 bits is the conventional modern auth floor (cf. NIST SP 800-63B effective
+# entropy guidance). Override per-call with --min-entropy-bits.
+MIN_ENTROPY_BITS_DEFAULT = 64
+
+VERDICT_AUTH_CANDIDATE = "auth_candidate"
+VERDICT_SEPARATION_ONLY = "separation_only_low_entropy"
+VERDICT_OVERLAP = "overlap_or_unproven"
+
+EXIT_AUTH_CANDIDATE = 0
+EXIT_SEPARATION_ONLY = 3
+EXIT_OVERLAP = 2
+
 
 @dataclass(frozen=True)
 class CrpMeasurement:
@@ -69,7 +82,7 @@ class CrpMetrics:
     reliability: float
     uniqueness: float
     challenge_separation: float
-    works_for_authentication: bool
+    passes_separation_condition: bool
     estimated_t_bits: int
     estimated_impostor_delta_bits: int
     mean_min_entropy_per_bit: float
@@ -197,7 +210,7 @@ def analyze_measurements(rows: Sequence[CrpMeasurement]) -> CrpMetrics:
         reliability=1.0 - genuine.mean,
         uniqueness=impostor.mean,
         challenge_separation=challenge_separation,
-        works_for_authentication=bool(
+        passes_separation_condition=bool(
             genuine.count and impostor.count and estimated_t_bits < estimated_impostor_delta_bits / 2
         ),
         estimated_t_bits=estimated_t_bits,
@@ -207,19 +220,42 @@ def analyze_measurements(rows: Sequence[CrpMeasurement]) -> CrpMetrics:
     )
 
 
-def metrics_to_report(metrics: CrpMetrics, *, feature_names: Sequence[str]) -> dict:
+def classify_verdict(metrics: CrpMetrics, min_entropy_bits: float) -> str:
+    """Three-state verdict gating geometric separation against entropy floor."""
+    if not metrics.passes_separation_condition:
+        return VERDICT_OVERLAP
+    if metrics.estimated_total_min_entropy_bits < min_entropy_bits:
+        return VERDICT_SEPARATION_ONLY
+    return VERDICT_AUTH_CANDIDATE
+
+
+def metrics_to_report(
+    metrics: CrpMetrics,
+    *,
+    feature_names: Sequence[str],
+    min_entropy_bits: float = MIN_ENTROPY_BITS_DEFAULT,
+) -> dict:
     report = asdict(metrics)
     report["feature_names"] = list(feature_names)
-    report["verdict"] = "auth_candidate" if metrics.works_for_authentication else "overlap_or_unproven"
+    report["min_entropy_bits_threshold"] = float(min_entropy_bits)
+    verdict = classify_verdict(metrics, min_entropy_bits)
+    report["verdict"] = verdict
     report["sacred_egg_role"] = (
         "Sacred Egg / GeoSeal context should select challenge_id and bind the response receipt; "
         "this harness only tests whether enrolled CRP responses separate genuine from impostor reads."
     )
-    report["recommended_next"] = (
-        "bind challenge_id selection to Sacred Egg context and sealed measurement receipts"
-        if metrics.works_for_authentication
-        else "increase response dimensionality, improve fixture stability, or collect cleaner challenge data"
-    )
+    if verdict == VERDICT_AUTH_CANDIDATE:
+        report["recommended_next"] = "bind challenge_id selection to Sacred Egg context and sealed measurement receipts"
+    elif verdict == VERDICT_SEPARATION_ONLY:
+        report["recommended_next"] = (
+            "geometry separates but entropy is below the auth floor "
+            f"({metrics.estimated_total_min_entropy_bits:.1f} < {min_entropy_bits:.1f} bits); "
+            "expand challenge set, increase response dimensionality, or enroll more devices"
+        )
+    else:
+        report["recommended_next"] = (
+            "increase response dimensionality, improve fixture stability, or collect cleaner challenge data"
+        )
     return report
 
 
@@ -241,6 +277,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=Path("artifacts/aetherfab/sacred_egg_crp_puf_report.json"),
         help="Output JSON report path",
     )
+    parser.add_argument(
+        "--min-entropy-bits",
+        type=float,
+        default=MIN_ENTROPY_BITS_DEFAULT,
+        help=(
+            "Minimum estimated_total_min_entropy_bits required to label the run "
+            f"as auth_candidate (default: {MIN_ENTROPY_BITS_DEFAULT}). "
+            "Below this floor, a passing separation downgrades to "
+            "separation_only_low_entropy."
+        ),
+    )
     return parser
 
 
@@ -248,17 +295,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     rows, feature_names = load_measurements(args.csv)
     metrics = analyze_measurements(rows)
-    report = metrics_to_report(metrics, feature_names=feature_names)
+    report = metrics_to_report(
+        metrics,
+        feature_names=feature_names,
+        min_entropy_bits=args.min_entropy_bits,
+    )
     write_report(report, args.report)
+    verdict = report["verdict"]
     print(
         "Sacred Egg CRP-PUF analysis: "
         f"reliability={metrics.reliability:.4f} "
         f"uniqueness={metrics.uniqueness:.4f} "
         f"challenge_separation={metrics.challenge_separation:.4f} "
-        f"auth_ready={metrics.works_for_authentication}"
+        f"passes_separation_condition={metrics.passes_separation_condition} "
+        f"min_entropy_bits={metrics.estimated_total_min_entropy_bits:.1f}/"
+        f"{args.min_entropy_bits:.1f} "
+        f"verdict={verdict}"
     )
     print(f"report={args.report}")
-    return 0 if metrics.works_for_authentication else 2
+    if verdict == VERDICT_AUTH_CANDIDATE:
+        return EXIT_AUTH_CANDIDATE
+    if verdict == VERDICT_SEPARATION_ONLY:
+        return EXIT_SEPARATION_ONLY
+    return EXIT_OVERLAP
 
 
 if __name__ == "__main__":

--- a/tests/experiments/test_sacred_egg_crp_puf_analysis.py
+++ b/tests/experiments/test_sacred_egg_crp_puf_analysis.py
@@ -43,7 +43,7 @@ def test_auth_candidate_separates_genuine_from_impostor() -> None:
     assert metrics.impostor.count == 5
     assert metrics.reliability == 1.0
     assert metrics.challenge_separation > 0.0
-    assert metrics.works_for_authentication is True
+    assert metrics.passes_separation_condition is True
     assert metrics.estimated_t_bits == 0
     assert metrics.estimated_impostor_delta_bits > 0
 
@@ -51,7 +51,7 @@ def test_auth_candidate_separates_genuine_from_impostor() -> None:
 def test_overlap_rejects_authentication_claim() -> None:
     metrics = analyze_measurements(overlapping_rows())
 
-    assert metrics.works_for_authentication is False
+    assert metrics.passes_separation_condition is False
     assert metrics.challenge_separation <= 0.0
 
 
@@ -74,15 +74,49 @@ def test_load_measurements_from_csv(tmp_path) -> None:
 
 def test_report_carries_sacred_egg_role(tmp_path) -> None:
     metrics = analyze_measurements(auth_candidate_rows())
-    report = metrics_to_report(metrics, feature_names=["r0"] * metrics.feature_count)
+    report = metrics_to_report(
+        metrics,
+        feature_names=["r0"] * metrics.feature_count,
+        min_entropy_bits=0.0,
+    )
     path = tmp_path / "report.json"
 
     write_report(report, path)
     loaded = json.loads(path.read_text(encoding="utf-8"))
 
     assert loaded["verdict"] == "auth_candidate"
+    assert loaded["min_entropy_bits_threshold"] == 0.0
     assert "Sacred Egg / GeoSeal context" in loaded["sacred_egg_role"]
     assert "challenge_id selection" in loaded["recommended_next"]
+
+
+def test_separation_pass_with_low_entropy_downgrades_to_separation_only() -> None:
+    """The auth_candidate fixture only delivers ~4 entropy bits. Under the
+    production-default 64-bit threshold, geometry separation alone is not
+    enough — the verdict must downgrade to separation_only_low_entropy.
+    """
+    metrics = analyze_measurements(auth_candidate_rows())
+    report = metrics_to_report(
+        metrics,
+        feature_names=["r0"] * metrics.feature_count,
+        min_entropy_bits=64.0,
+    )
+    assert metrics.passes_separation_condition is True
+    assert metrics.estimated_total_min_entropy_bits < 64.0
+    assert report["verdict"] == "separation_only_low_entropy"
+    assert report["min_entropy_bits_threshold"] == 64.0
+    assert "entropy is below the auth floor" in report["recommended_next"]
+
+
+def test_overlap_verdict_when_separation_fails() -> None:
+    metrics = analyze_measurements(overlapping_rows())
+    report = metrics_to_report(
+        metrics,
+        feature_names=["r0"] * metrics.feature_count,
+        min_entropy_bits=0.0,
+    )
+    assert metrics.passes_separation_condition is False
+    assert report["verdict"] == "overlap_or_unproven"
 
 
 def test_load_requires_response_columns(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #1466. Adds an entropy-floor gate on top of the geometric separation check so the harness verdict cannot be cited as an authentication claim purely on small-fixture separability.

## What changed

### Boolean field rename
`works_for_authentication` → `passes_separation_condition`. The original name read as an auth claim that the geometric check alone does not support; the new name says exactly what it measures.

### Three-state verdict (new `classify_verdict` helper)

| Verdict | Exit | Condition |
|---------|------|-----------|
| `auth_candidate`              | 0 | geometry passes AND `estimated_total_min_entropy_bits >= --min-entropy-bits` |
| `separation_only_low_entropy` | 3 | geometry passes, entropy below threshold |
| `overlap_or_unproven`         | 2 | geometry fails |

### CLI flag
New `--min-entropy-bits FLOAT` (default `64`, per NIST SP 800-63B effective entropy floor). Override to `0` for raw geometry checks during bring-up; raise for hardened deployments.

### Why this matters

The 2026-05-09 smoke run on a 2-device / 2-challenge / 6-measurement synthetic dataset previously emitted `auth_candidate` despite only 4 bits of estimated entropy. With the new gate, the same input correctly emits `separation_only_low_entropy` and exit 3 — geometry checks out, entropy doesn't. This keeps the JSON honest if a downstream reader scans it without context.

## Test plan

- [x] `black --check` on touched files — pass
- [x] `ruff check --config ruff.toml` on touched files — pass
- [x] `pytest tests/experiments/` — 13/13 (was 11; +1 entropy-gate test, +1 explicit overlap test)
- [x] Smoke run with default 64-bit threshold correctly downgrades to `separation_only_low_entropy` exit 3
- [x] Smoke run with `--min-entropy-bits 0` reproduces previous `auth_candidate` exit 0 (regression-protected via test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)