### PR TITLE
feat(billing): add  supporter subscription lane

### DIFF
--- a/api/billing/database.py
+++ b/api/billing/database.py
@@ -7,7 +7,6 @@ Uses SQLAlchemy with SQLite for MVP (easily upgradeable to PostgreSQL).
 import os
 import uuid
 from datetime import datetime
-from typing import Optional
 from contextlib import contextmanager
 
 from sqlalchemy import (
@@ -78,7 +77,7 @@ class Subscription(Base):
     stripe_price_id = Column(String(255), nullable=True)
     tier = Column(
         String(20),
-        CheckConstraint("tier IN ('FREE', 'STARTER', 'PRO', 'ENTERPRISE')"),
+        CheckConstraint("tier IN ('FREE', 'SUPPORTER', 'STARTER', 'PRO', 'ENTERPRISE')"),
         nullable=False,
         default="FREE",
     )

--- a/api/billing/routes.py
+++ b/api/billing/routes.py
@@ -10,7 +10,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, Header
 from pydantic import BaseModel
 
-from .database import get_db, Customer, Subscription, UsageRecord, BillingEvent
+from .database import get_db, Customer, Subscription, UsageRecord
 from .stripe_client import StripeClient
 from .tiers import PRICING_TIERS, get_price_id_for_tier
 from .webhooks import process_webhook_event
@@ -77,8 +77,8 @@ async def create_public_checkout_session(request: PublicCheckoutRequest):
     This route intentionally avoids API-key auth to support first-time buyers.
     """
     tier = request.tier.upper().strip()
-    if tier not in {"STARTER", "PRO"}:
-        raise HTTPException(status_code=400, detail="Public checkout supports STARTER or PRO tiers.")
+    if tier not in {"SUPPORTER", "STARTER", "PRO"}:
+        raise HTTPException(status_code=400, detail="Public checkout supports SUPPORTER, STARTER, or PRO tiers.")
     if "@" not in request.email:
         raise HTTPException(status_code=400, detail="Valid email is required.")
 
@@ -201,7 +201,7 @@ async def cancel_subscription(
         if not subscription or not subscription.stripe_subscription_id:
             raise HTTPException(status_code=400, detail="No active subscription found")
 
-        result = StripeClient.cancel_subscription(subscription.stripe_subscription_id)
+        StripeClient.cancel_subscription(subscription.stripe_subscription_id)
         subscription.cancel_at_period_end = True
 
     return {"status": "cancellation_scheduled", "cancel_at_period_end": True}
@@ -219,7 +219,7 @@ async def reactivate_subscription(
             db.query(Subscription)
             .filter(
                 Subscription.customer_id == customer.customer_id,
-                Subscription.cancel_at_period_end == True,
+                Subscription.cancel_at_period_end,
             )
             .first()
         )
@@ -227,7 +227,7 @@ async def reactivate_subscription(
         if not subscription or not subscription.stripe_subscription_id:
             raise HTTPException(status_code=400, detail="No subscription to reactivate")
 
-        result = StripeClient.reactivate_subscription(subscription.stripe_subscription_id)
+        StripeClient.reactivate_subscription(subscription.stripe_subscription_id)
         subscription.cancel_at_period_end = False
 
     return {"status": "reactivated", "cancel_at_period_end": False}

--- a/api/billing/tiers.py
+++ b/api/billing/tiers.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 # Stripe Price IDs (set in environment or Stripe Dashboard)
 STRIPE_PRICE_STARTER = os.getenv("STRIPE_PRICE_STARTER", "price_starter_monthly")
+STRIPE_PRICE_SUPPORTER = os.getenv("STRIPE_PRICE_SUPPORTER", "price_supporter_monthly")
 STRIPE_PRICE_PRO = os.getenv("STRIPE_PRICE_PRO", "price_pro_monthly")
 STRIPE_PRICE_ENTERPRISE = os.getenv("STRIPE_PRICE_ENTERPRISE", "price_enterprise_monthly")
 
@@ -46,6 +47,23 @@ PRICING_TIERS = {
         ],
         "max_api_keys": 5,
         "audit_retention_days": 30,
+    },
+    "SUPPORTER": {
+        "stripe_price_id": STRIPE_PRICE_SUPPORTER,
+        "monthly_price_cents": 2000,  # $20/month
+        "rate_limits": {
+            "per_minute": 25,
+            "daily": 2500,
+            "monthly": 25_000,
+        },
+        "features": [
+            "basic_governance",
+            "audit_logs_14_days",
+            "monthly_operator_notes",
+            "community_support",
+        ],
+        "max_api_keys": 1,
+        "audit_retention_days": 14,
     },
     "PRO": {
         "stripe_price_id": STRIPE_PRICE_PRO,

--- a/docs/supporter.html
+++ b/docs/supporter.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AetherMoore Supporter | $20/month</title>
+    <meta
+      name="description"
+      content="Support AetherMoore and receive monthly operator notes, early package updates, and a visible support route."
+    />
+    <link rel="canonical" href="https://aethermoore.com/supporter.html" />
+    <style>
+      :root {
+        --bg: #101216;
+        --panel: #181c22;
+        --ink: #f6f1e8;
+        --muted: #c8bda9;
+        --line: #34313a;
+        --gold: #d6a756;
+        --green: #2dd3a6;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+        background: var(--bg);
+        color: var(--ink);
+        line-height: 1.55;
+      }
+      main {
+        width: min(920px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 56px 0;
+      }
+      .eyebrow {
+        color: var(--gold);
+        font-size: 13px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      h1 {
+        max-width: 760px;
+        margin: 10px 0 14px;
+        font-size: clamp(38px, 7vw, 72px);
+        line-height: 0.98;
+        letter-spacing: 0;
+      }
+      p {
+        color: var(--muted);
+        font-size: 18px;
+        max-width: 760px;
+      }
+      .price {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 8px;
+        margin: 18px 0 22px;
+        color: var(--ink);
+      }
+      .price strong {
+        font-size: 42px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 14px;
+        margin-top: 26px;
+      }
+      .card {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 20px;
+      }
+      .card h2,
+      .card h3 {
+        margin: 0 0 8px;
+      }
+      .card p,
+      li {
+        font-size: 16px;
+      }
+      ul {
+        padding-left: 20px;
+        color: var(--muted);
+      }
+      .panel {
+        margin-top: 30px;
+        border: 1px solid rgba(214, 167, 86, 0.45);
+        border-radius: 8px;
+        background: #151719;
+        padding: 22px;
+      }
+      label {
+        display: block;
+        margin-bottom: 8px;
+        font-weight: 700;
+      }
+      input {
+        width: min(440px, 100%);
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: #0d0f12;
+        color: var(--ink);
+        padding: 13px 14px;
+        font-size: 16px;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 16px;
+      }
+      .btn {
+        display: inline-flex;
+        min-height: 46px;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid var(--gold);
+        border-radius: 6px;
+        padding: 12px 18px;
+        color: #12110f;
+        background: var(--gold);
+        font-weight: 800;
+        text-decoration: none;
+        cursor: pointer;
+      }
+      .btn.secondary {
+        color: var(--ink);
+        background: transparent;
+      }
+      .note {
+        margin-top: 12px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .status {
+        min-height: 24px;
+        margin-top: 12px;
+        color: var(--green);
+        font-size: 15px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="eyebrow">Simple support lane</div>
+      <h1>Support AetherMoore for $20/month.</h1>
+      <p>
+        This is the smallest useful paid tier: keep the work moving, receive monthly operator notes,
+        and get early access to cleaned packages as they are released. No giant enterprise pitch. No
+        mystery box.
+      </p>
+      <div class="price"><strong>$20</strong><span>/ month</span></div>
+
+      <section class="grid" aria-label="Supporter benefits">
+        <article class="card">
+          <h2>What you get</h2>
+          <ul>
+            <li>Monthly operator notes: what shipped, what broke, what is usable.</li>
+            <li>Early supporter access to cleaned toolkit updates.</li>
+            <li>Direct support route for missing links or broken delivery.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>Who it is for</h2>
+          <p>
+            People who want the system to keep getting built and want practical notes without
+            waiting for a polished course, enterprise onboarding, or a sales call.
+          </p>
+        </article>
+        <article class="card">
+          <h2>Plain terms</h2>
+          <p>
+            Cancel when you want. This tier supports ongoing work and lightweight access; it is not
+            consulting, custom development, or guaranteed emergency support.
+          </p>
+        </article>
+      </section>
+
+      <section class="panel" aria-label="Join">
+        <h2>Join with Stripe</h2>
+        <p>
+          Enter your email and the checkout endpoint will open a $20/month SUPPORTER checkout when
+          configured.
+        </p>
+        <form id="supporter-form">
+          <label for="email">Email</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            autocomplete="email"
+            required
+            placeholder="you@example.com"
+          />
+          <div class="actions">
+            <button class="btn" type="submit">Start $20/month checkout</button>
+            <a
+              class="btn secondary"
+              href="mailto:ai@aethermoore.com?subject=AetherMoore%20Supporter%20-%20manual%20payment&body=I%20want%20to%20support%20AetherMoore%20for%20%2420%2Fmonth.%20Please%20send%20me%20a%20Stripe%20or%20Cash%20App%20payment%20link."
+              >Ask for manual payment link</a
+            >
+          </div>
+          <div class="status" id="status" role="status"></div>
+          <p class="note">
+            If checkout is not configured yet, use the manual payment link. That keeps this lane
+            usable even before the full processor path is polished.
+          </p>
+        </form>
+      </section>
+    </main>
+    <script>
+      const form = document.getElementById('supporter-form');
+      const statusEl = document.getElementById('status');
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        statusEl.textContent = 'Opening checkout...';
+        const email = document.getElementById('email').value.trim();
+        try {
+          const response = await fetch('https://api.aethermoore.com/v1/billing/public-checkout', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              email,
+              tier: 'SUPPORTER',
+              source: 'supporter-page',
+              success_url: 'https://aethermoore.com/supporter.html?status=success',
+              cancel_url: 'https://aethermoore.com/supporter.html?status=cancel',
+            }),
+          });
+          const data = await response.json();
+          if (!response.ok || !data.checkout_url) {
+            throw new Error(data.detail || data.error || 'Checkout is not configured yet.');
+          }
+          window.location.href = data.checkout_url;
+        } catch (err) {
+          statusEl.textContent = 'Checkout is not ready. Use the manual payment link button.';
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -95,7 +95,7 @@ export interface GateResult {
 
 /** Harmonic complexity pricing tier */
 export interface PricingTier {
-  tier: 'FREE' | 'STARTER' | 'PRO' | 'ENTERPRISE';
+  tier: 'FREE' | 'SUPPORTER' | 'STARTER' | 'PRO' | 'ENTERPRISE';
   complexity: number;
   description: string;
 }

--- a/tests/api/test_billing_public_checkout.py
+++ b/tests/api/test_billing_public_checkout.py
@@ -70,6 +70,53 @@ def test_public_checkout_creates_session(monkeypatch):
     assert captured["metadata"]["source"] == "landing-page"
 
 
+def test_public_checkout_supporter_tier(monkeypatch):
+    captured = {}
+
+    def fake_create_checkout_session(
+        tier,
+        price_id,
+        customer_email=None,
+        customer_id=None,
+        success_url=None,
+        cancel_url=None,
+        metadata=None,
+    ):
+        captured["tier"] = tier
+        captured["price_id"] = price_id
+        captured["customer_email"] = customer_email
+        captured["metadata"] = metadata
+        return {
+            "session_id": "cs_test_supporter",
+            "checkout_url": "https://checkout.stripe.test/session/cs_test_supporter",
+            "tier": tier,
+        }
+
+    monkeypatch.setattr(
+        routes.StripeClient,
+        "create_checkout_session",
+        staticmethod(fake_create_checkout_session),
+    )
+    client = _client()
+
+    response = client.post(
+        "/v1/billing/public-checkout",
+        json={
+            "email": "supporter@example.com",
+            "tier": "supporter",
+            "source": "supporter-page",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tier"] == "SUPPORTER"
+    assert captured["tier"] == "SUPPORTER"
+    assert captured["price_id"] == "price_supporter_monthly"
+    assert captured["customer_email"] == "supporter@example.com"
+    assert captured["metadata"]["source"] == "supporter-page"
+
+
 def test_public_checkout_rejects_invalid_tier():
     client = _client()
     response = client.post(


### PR DESCRIPTION
## Summary
- add a $20/month SUPPORTER billing tier backed by `STRIPE_PRICE_SUPPORTER`
- allow SUPPORTER through the unauthenticated public checkout endpoint
- add a public `/supporter.html` page with Stripe checkout attempt plus manual payment fallback for Stripe/Cash App link requests
- update billing type surface and public checkout test coverage

## Test evidence
- `python -m black --check --target-version py311 --line-length 120 api/billing/tiers.py api/billing/routes.py api/billing/database.py tests/api/test_billing_public_checkout.py` -> passed
- `python -m ruff check api/billing/tiers.py api/billing/routes.py api/billing/database.py tests/api/test_billing_public_checkout.py` -> passed
- `npx prettier --check docs/supporter.html src/api/index.ts` -> passed
- `python -m compileall api/billing/tiers.py api/billing/routes.py api/billing/database.py tests/api/test_billing_public_checkout.py` -> passed
- `python -m pytest tests/api/test_billing_public_checkout.py -q` -> skipped locally because this Python env lacks `stripe`; CI should exercise it where Stripe is installed

## Operational note
Set `STRIPE_PRICE_SUPPORTER` to the live Stripe recurring price ID before enabling the hosted checkout path. The supporter page still includes a manual payment fallback so the page can convert via email/Cash App/Stripe link before automation is perfect.

## Rollback
Revert this PR to remove the SUPPORTER tier and page.