### PR TITLE
feat(site): surface supporter payment lane

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -946,6 +946,7 @@
               Templates, decision records, threshold worksheets, and a manual. One checkout, no subscription. You'll have a governed AI workflow running before dinner.
             </p>
             <p style="margin-top:16px;"><a class="btn btn-secondary" href="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06" target="_blank" rel="noopener">Buy the Toolkit ($29)</a></p>
+            <p style="margin-top:10px;"><a class="btn btn-secondary" href="supporter.html">Support for $20/month</a></p>
           </article>
           <article class="slab">
             <h3>Try the live demos</h3>

--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -44,6 +44,12 @@
         <a class="btn" href="https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g" target="_blank" rel="noopener">Buy Training Vault</a>
       </article>
       <article class="card">
+        <h2>AetherMoore Supporter</h2>
+        <p>Monthly operator notes, early package updates, and a visible support route for people who want to keep the work moving.</p>
+        <div class="price">$20/month</div>
+        <a class="btn" href="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i" target="_blank" rel="noopener">Join as Supporter</a>
+      </article>
+      <article class="card">
         <h2>Delivery or access help</h2>
         <p>If a buyer does not receive the package link or a manual path fails, use the delivery page first and then email support.</p>
         <a class="btn secondary" href="../product-manual/delivery-and-access.html">Delivery + Access</a>


### PR DESCRIPTION
## Summary
- Adds a homepage link to the AetherMoore $20/month Supporter page.
- Adds the Supporter card to the public offers index with the live Stripe Payment Link.

## Live payment link
- https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i

## Tests
- `python` stdlib `HTMLParser` smoke over `docs/index.html` and `docs/offers/index.html`

## Rollback
- Revert this PR to remove the extra homepage/offers links. The direct Supporter page and Stripe link remain from PR #1471.