### PR TITLE
feat(site): add governance snapshot offer

### DIFF
--- a/docs/governance-snapshot.html
+++ b/docs/governance-snapshot.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Governance Snapshot | AetherMoore</title>
+    <meta
+      name="description"
+      content="A fixed-scope AI governance assessment for small teams that need an audit-ready findings memo and three practical fixes."
+    />
+    <link rel="canonical" href="https://aethermoore.com/governance-snapshot.html" />
+    <style>
+      :root {
+        --bg: #0f1217;
+        --panel: #171c24;
+        --ink: #f6f1e8;
+        --muted: #c8bda9;
+        --line: #34313a;
+        --gold: #d6a756;
+        --blue: #8cb4ff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+        background: var(--bg);
+        color: var(--ink);
+        line-height: 1.55;
+      }
+      main {
+        width: min(980px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 56px 0;
+      }
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        margin-bottom: 36px;
+        color: var(--muted);
+      }
+      a {
+        color: inherit;
+      }
+      .eyebrow {
+        color: var(--gold);
+        font-size: 13px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      h1 {
+        max-width: 820px;
+        margin: 10px 0 14px;
+        font-size: clamp(38px, 7vw, 72px);
+        line-height: 0.98;
+        letter-spacing: 0;
+      }
+      h2,
+      h3 {
+        margin-top: 0;
+      }
+      p {
+        max-width: 780px;
+        color: var(--muted);
+        font-size: 18px;
+      }
+      .price {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 8px;
+        margin: 18px 0 22px;
+      }
+      .price strong {
+        font-size: 44px;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin: 18px 0 28px;
+      }
+      .btn {
+        display: inline-flex;
+        min-height: 46px;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid var(--gold);
+        border-radius: 6px;
+        padding: 12px 18px;
+        color: #12110f;
+        background: var(--gold);
+        font-weight: 800;
+        text-decoration: none;
+      }
+      .btn.secondary {
+        color: var(--ink);
+        background: transparent;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 14px;
+        margin-top: 26px;
+      }
+      .card,
+      .panel {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 20px;
+      }
+      .panel {
+        margin-top: 26px;
+        border-color: rgba(214, 167, 86, 0.45);
+      }
+      li {
+        color: var(--muted);
+        font-size: 16px;
+        margin-bottom: 8px;
+      }
+      code {
+        color: var(--blue);
+      }
+      .note {
+        color: var(--muted);
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <nav aria-label="Offer navigation">
+        <a href="index.html">Home</a>
+        <a href="offers/index.html">Offers</a>
+        <a href="support.html">Support</a>
+      </nav>
+
+      <div class="eyebrow">Fixed-scope consulting</div>
+      <h1>AI Governance Snapshot for teams that need a plain risk read.</h1>
+      <p>
+        A compact assessment for a small business, project team, or subcontract lead using AI tools
+        and needing a practical governance memo instead of a giant compliance program.
+      </p>
+      <div class="price"><strong>$500</strong><span>one-time</span></div>
+      <div class="actions">
+        <a
+          class="btn"
+          href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+          target="_blank"
+          rel="noopener"
+          >Buy the Snapshot</a
+        >
+        <a
+          class="btn secondary"
+          href="mailto:ai@aethermoore.com?subject=AI%20Governance%20Snapshot%20question"
+          >Ask a question first</a
+        >
+      </div>
+
+      <section class="grid" aria-label="Snapshot details">
+        <article class="card">
+          <h2>What you receive</h2>
+          <ul>
+            <li>A 2-page findings memo covering your AI workflow, data path, and decision risks.</li>
+            <li>Three prioritized fixes you can implement without buying a new platform.</li>
+            <li>A short evidence checklist you can keep for buyers, grant reviewers, or internal notes.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>What you send</h2>
+          <ul>
+            <li>One AI workflow or toolchain you want reviewed.</li>
+            <li>Any public docs, screenshots, prompts, or policy notes you already have.</li>
+            <li>No secrets, private keys, customer records, or regulated data.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>Delivery</h2>
+          <ul>
+            <li>Five business day target after intake materials arrive.</li>
+            <li>Email delivery with a plain-English summary and action list.</li>
+            <li>One follow-up email thread for clarification.</li>
+          </ul>
+        </article>
+      </section>
+
+      <section class="panel">
+        <h2>Boundaries</h2>
+        <p>
+          This is not legal advice, certification, penetration testing, FedRAMP authorization, or a
+          guaranteed contract outcome. It is a fixed-scope governance review built to turn a messy AI
+          workflow into a clearer risk memo and next-action list.
+        </p>
+        <p class="note">
+          Best first buyers: small firms using AI in operations, founders applying to grants, teams
+          preparing subcontract conversations, or builders who need an outside governance read before
+          shipping.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -947,6 +947,7 @@
             </p>
             <p style="margin-top:16px;"><a class="btn btn-secondary" href="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06" target="_blank" rel="noopener">Buy the Toolkit ($29)</a></p>
             <p style="margin-top:10px;"><a class="btn btn-secondary" href="supporter.html">Support for $20/month</a></p>
+            <p style="margin-top:10px;"><a class="btn btn-secondary" href="governance-snapshot.html">Book a $500 Governance Snapshot</a></p>
           </article>
           <article class="slab">
             <h3>Try the live demos</h3>

--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -50,6 +50,12 @@
         <a class="btn" href="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i" target="_blank" rel="noopener">Join as Supporter</a>
       </article>
       <article class="card">
+        <h2>AI Governance Snapshot</h2>
+        <p>A fixed-scope review with a 2-page findings memo, three prioritized fixes, and a practical evidence checklist.</p>
+        <div class="price">$500 one-time</div>
+        <a class="btn" href="../governance-snapshot.html">View Snapshot</a>
+      </article>
+      <article class="card">
         <h2>Delivery or access help</h2>
         <p>If a buyer does not receive the package link or a manual path fails, use the delivery page first and then email support.</p>
         <a class="btn secondary" href="../product-manual/delivery-and-access.html">Delivery + Access</a>

--- a/scripts/system/create_governance_snapshot_stripe_link.py
+++ b/scripts/system/create_governance_snapshot_stripe_link.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Create a Stripe Payment Link for the AetherMoore AI Governance Snapshot.
+
+This script intentionally uses only the Python standard library so it can run
+even when the `stripe` package is not installed locally. It reads
+STRIPE_SECRET_KEY from the environment and writes a redacted JSON artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STRIPE_API = "https://api.stripe.com/v1"
+DEFAULT_LOOKUP_KEY = "aethermoore_governance_snapshot_500"
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_output(raw_path: str) -> Path:
+    target = (REPO_ROOT / raw_path).resolve()
+    artifacts_root = (REPO_ROOT / "artifacts").resolve()
+    if target != artifacts_root and artifacts_root not in target.parents:
+        raise ValueError("output path must stay under artifacts/")
+    return target
+
+
+def stripe_request(secret_key: str, method: str, path: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+    encoded = urllib.parse.urlencode(data or {}, doseq=True).encode("utf-8")
+    token = base64.b64encode(f"{secret_key}:".encode("utf-8")).decode("ascii")
+    req = urllib.request.Request(
+        STRIPE_API + path,
+        data=encoded if method.upper() == "POST" else None,
+        method=method.upper(),
+        headers={
+            "Authorization": f"Basic {token}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Stripe API error {exc.code}: {body[:500]}") from exc
+
+
+def search_price(secret_key: str, lookup_key: str) -> dict[str, Any] | None:
+    query = urllib.parse.quote(f"lookup_key:'{lookup_key}'")
+    result = stripe_request(secret_key, "GET", f"/prices/search?query={query}&limit=1")
+    rows = result.get("data", [])
+    return rows[0] if rows else None
+
+
+def create_product(secret_key: str) -> dict[str, Any]:
+    return stripe_request(
+        secret_key,
+        "POST",
+        "/products",
+        {
+            "name": "AetherMoore AI Governance Snapshot",
+            "description": "Fixed-scope AI governance assessment with a findings memo and three prioritized fixes.",
+            "metadata[scbe_offer]": "governance_snapshot",
+        },
+    )
+
+
+def create_price(secret_key: str, product_id: str, lookup_key: str) -> dict[str, Any]:
+    return stripe_request(
+        secret_key,
+        "POST",
+        "/prices",
+        {
+            "currency": "usd",
+            "unit_amount": "50000",
+            "product": product_id,
+            "lookup_key": lookup_key,
+            "metadata[scbe_offer]": "governance_snapshot",
+        },
+    )
+
+
+def create_payment_link(secret_key: str, price_id: str) -> dict[str, Any]:
+    return stripe_request(
+        secret_key,
+        "POST",
+        "/payment_links",
+        {
+            "line_items[0][price]": price_id,
+            "line_items[0][quantity]": "1",
+            "after_completion[type]": "redirect",
+            "after_completion[redirect][url]": "https://aethermoore.com/governance-snapshot.html?status=success",
+            "metadata[scbe_offer]": "governance_snapshot",
+        },
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create/reuse the AetherMoore $500 AI Governance Snapshot link")
+    parser.add_argument("--lookup-key", default=DEFAULT_LOOKUP_KEY)
+    parser.add_argument("--output", default="artifacts/monetization/governance_snapshot_stripe_link.json")
+    args = parser.parse_args()
+
+    secret_key = os.getenv("STRIPE_SECRET_KEY", "").strip()
+    if not secret_key:
+        print("ERROR: STRIPE_SECRET_KEY is not set.", file=sys.stderr)
+        return 2
+
+    existing = search_price(secret_key, args.lookup_key)
+    if existing:
+        price = existing
+        created_product = None
+        created_price = False
+    else:
+        product = create_product(secret_key)
+        price = create_price(secret_key, product["id"], args.lookup_key)
+        created_product = product["id"]
+        created_price = True
+
+    link = create_payment_link(secret_key, price["id"])
+
+    out = {
+        "generated_at_utc": now_utc(),
+        "mode": "live" if secret_key.startswith("sk_live_") else "test_or_restricted",
+        "lookup_key": args.lookup_key,
+        "created_product_id": created_product,
+        "created_price": created_price,
+        "price_id": price["id"],
+        "payment_link_id": link["id"],
+        "payment_link_url": link["url"],
+    }
+    target = resolve_output(args.output)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(f"payment_link_url={link['url']}")
+    print(f"price_id={price['id']}")
+    print(f"artifact={target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a fixed-price `AI Governance Snapshot` offer page for a $500 one-time assessment.
- Links the offer from the homepage and public offers index.
- Adds a standard-library Stripe helper to recreate/reuse the one-time payment link without the Stripe Python package.

## Live payment link
- https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j

## Offer promise
- 2-page findings memo
- Three prioritized fixes
- Practical evidence checklist
- Five business day target after intake materials arrive

## Tests
- `python -m black --check --target-version py311 --line-length 120 scripts/system/create_governance_snapshot_stripe_link.py`
- `python -m ruff check scripts/system/create_governance_snapshot_stripe_link.py`
- `python -m compileall scripts/system/create_governance_snapshot_stripe_link.py`
- Python stdlib `HTMLParser` smoke over `docs/index.html`, `docs/offers/index.html`, and `docs/governance-snapshot.html`

## Rollback
- Revert this PR to remove the fixed-price consulting offer. Existing toolkit, vault, and supporter payment lanes remain intact.