### PR TITLE
feat(revenue): publish live offers to connector payload

### DIFF
--- a/scripts/system/monetization_connector_push.py
+++ b/scripts/system/monetization_connector_push.py
@@ -17,8 +17,8 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
-
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -28,7 +28,49 @@ if str(REPO_ROOT / "src") not in sys.path:
 
 from src.fleet.connector_bridge import ConnectorBridge, ConnectorResult
 from src.security.secret_store import get_secret
-from scripts.gumroad_publish import GumroadPublisher, PRODUCTS, STRIPE_LINKS
+
+try:
+    from scripts.gumroad_publish import GumroadPublisher, PRODUCTS, STRIPE_LINKS
+except ModuleNotFoundError:  # pragma: no cover - depends on optional local sales tooling
+    GumroadPublisher = None
+    PRODUCTS = {}
+    STRIPE_LINKS = {}
+
+
+@dataclass(frozen=True)
+class StaticOffer:
+    id: str
+    name: str
+    sku: str
+    price_usd: float
+    stripe_url: str
+    tags: List[str]
+    cadence: str
+    proof_url: str
+
+
+STATIC_OFFERS: List[StaticOffer] = [
+    StaticOffer(
+        id="supporter_monthly",
+        name="AetherMoore Supporter",
+        sku="aethermoore-supporter-monthly",
+        price_usd=20.0,
+        stripe_url="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i",
+        tags=["supporter", "subscription", "operator-notes"],
+        cadence="monthly",
+        proof_url="https://aethermoore.com/supporter.html",
+    ),
+    StaticOffer(
+        id="governance_snapshot",
+        name="AI Governance Snapshot",
+        sku="aethermoore-governance-snapshot",
+        price_usd=500.0,
+        stripe_url="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j",
+        tags=["consulting", "governance", "fixed-scope", "cash-sprint"],
+        cadence="one_time",
+        proof_url="https://aethermoore.com/governance-snapshot.html",
+    ),
+]
 
 
 def _utc_now() -> datetime:
@@ -61,7 +103,7 @@ def _build_offers(include_gumroad: bool) -> List[Dict[str, Any]]:
             os.environ["GUMROAD_API_TOKEN"] = token
 
     gumroad_map: Dict[str, str] = {}
-    if include_gumroad:
+    if include_gumroad and GumroadPublisher is not None:
         try:
             listing = GumroadPublisher().list_products()
             if listing.success and isinstance(listing.data, list):
@@ -72,7 +114,20 @@ def _build_offers(include_gumroad: bool) -> List[Dict[str, Any]]:
         except Exception:
             pass
 
-    offers: List[Dict[str, Any]] = []
+    offers: List[Dict[str, Any]] = [
+        {
+            "id": offer.id,
+            "name": offer.name,
+            "sku": offer.sku,
+            "price_usd": offer.price_usd,
+            "stripe_url": offer.stripe_url,
+            "gumroad_url": "",
+            "tags": offer.tags,
+            "cadence": offer.cadence,
+            "proof_url": offer.proof_url,
+        }
+        for offer in STATIC_OFFERS
+    ]
     for key, spec in PRODUCTS.items():
         stripe = STRIPE_LINKS.get(key, {})
         offers.append(

--- a/tests/system/test_monetization_connector_push.py
+++ b/tests/system/test_monetization_connector_push.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from scripts.system.monetization_connector_push import _build_offers
+
+
+def test_monetization_connector_push_includes_live_cash_offers() -> None:
+    offers = _build_offers(include_gumroad=False)
+    by_id = {offer["id"]: offer for offer in offers}
+
+    assert by_id["supporter_monthly"]["price_usd"] == 20.0
+    assert by_id["supporter_monthly"]["stripe_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    assert by_id["supporter_monthly"]["cadence"] == "monthly"
+
+    assert by_id["governance_snapshot"]["price_usd"] == 500.0
+    assert by_id["governance_snapshot"]["stripe_url"] == "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+    assert by_id["governance_snapshot"]["cadence"] == "one_time"


### PR DESCRIPTION
## Summary
- Adds the live $20/month Supporter and $500 AI Governance Snapshot offers to `monetization_connector_push` payloads.
- Makes Gumroad publishing support optional so the connector push still works when `scripts.gumroad_publish` is absent.
- Adds a focused test that locks the live Stripe URLs, prices, and cadence into the connector offer catalog.

## Why
The site now has live cash lanes. Connector automations need those offers in the payload without manual copy/paste.

## Local verification
- `python scripts/system/monetization_connector_push.py --dry-run --no-route-n8n --no-route-zapier --output-dir artifacts/monetization/test_connector_push`
- `python -m pytest tests/system/test_monetization_connector_push.py -q`
- `python -m black --check --target-version py311 --line-length 120 scripts/system/monetization_connector_push.py tests/system/test_monetization_connector_push.py`
- `python -m ruff check scripts/system/monetization_connector_push.py tests/system/test_monetization_connector_push.py`
- `python -m py_compile scripts/system/monetization_connector_push.py tests/system/test_monetization_connector_push.py`

## Rollback
- Revert this PR to remove the static cash offers from connector payloads. Public checkout pages remain live.