### PR TITLE
feat(revenue): add governance snapshot intake rail

### DIFF
--- a/docs/governance-snapshot.html
+++ b/docs/governance-snapshot.html
@@ -135,6 +135,14 @@
         color: var(--muted);
         font-size: 14px;
       }
+      .checklist {
+        margin: 0;
+        padding-left: 20px;
+      }
+      .small-link {
+        color: var(--blue);
+        font-weight: 700;
+      }
     </style>
   </head>
   <body>
@@ -162,8 +170,8 @@
         >
         <a
           class="btn secondary"
-          href="mailto:ai@aethermoore.com?subject=AI%20Governance%20Snapshot%20question"
-          >Ask a question first</a
+          href="mailto:ai@aethermoore.com?subject=AI%20Governance%20Snapshot%20intake&body=Payment%20email%3A%0AWorkflow%20or%20tool%20to%20review%3A%0AWhat%20decision%20or%20output%20matters%3A%0ALinks%20or%20screenshots%20I%20can%20share%3A%0ADeadline%20or%20context%3A%0A"
+          >Send intake</a
         >
       </div>
 
@@ -192,6 +200,33 @@
             <li>One follow-up email thread for clarification.</li>
           </ul>
         </article>
+      </section>
+
+      <section class="panel" id="intake">
+        <h2>After checkout, send this intake</h2>
+        <p>
+          Payment opens the slot. The review starts when the intake arrives by email. Keep the
+          package small enough to inspect quickly.
+        </p>
+        <ol class="checklist">
+          <li>Payment email or receipt email.</li>
+          <li>The one AI workflow, tool, prompt chain, agent, or customer-facing feature to review.</li>
+          <li>What decision, output, or failure would create risk if the AI gets it wrong.</li>
+          <li>Links, screenshots, prompts, policy notes, or public docs that explain the workflow.</li>
+          <li>Any deadline, buyer conversation, grant packet, or internal review this needs to support.</li>
+        </ol>
+        <p class="note">
+          Do not send secrets, private keys, customer records, medical records, export-controlled
+          files, classified material, bank data, or regulated production data. Use redacted examples
+          or screenshots when possible.
+        </p>
+        <p>
+          <a
+            class="small-link"
+            href="mailto:ai@aethermoore.com?subject=AI%20Governance%20Snapshot%20intake&body=Payment%20email%3A%0AWorkflow%20or%20tool%20to%20review%3A%0AWhat%20decision%20or%20output%20matters%3A%0ALinks%20or%20screenshots%20I%20can%20share%3A%0ADeadline%20or%20context%3A%0A"
+            >Open the intake email template</a
+          >
+        </p>
       </section>
 
       <section class="panel">

--- a/scripts/revenue/daily_cash_sprint.py
+++ b/scripts/revenue/daily_cash_sprint.py
@@ -57,6 +57,7 @@ DEFAULT_OFFERS = [
             "docs/governance-snapshot.html",
             "docs/offers/index.html",
             "scripts/system/create_governance_snapshot_stripe_link.py",
+            "scripts/revenue/governance_snapshot_intake.py",
             "src/governance/runtime_gate.py",
             "src/governance/bijective_tamper.py",
             "src/governance/identifier_canonicality.py",
@@ -64,7 +65,8 @@ DEFAULT_OFFERS = [
             "docs/specs/IDENTIFIER_CANONICALITY_L13.md",
         ],
         call_to_action=(
-            "Send one AI workflow you want reviewed, or use the fixed checkout link: "
+            "Buy the fixed checkout, then send the intake at https://aethermoore.com/governance-snapshot.html#intake. "
+            "Checkout link: "
             "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
         ),
     ),
@@ -152,7 +154,9 @@ def _path_status(paths: Iterable[str]) -> list[dict[str, object]]:
             {
                 "path": raw,
                 "exists": path.exists(),
-                "kind": "dir" if path.is_dir() else "file" if path.is_file() else "missing",
+                "kind": (
+                    "dir" if path.is_dir() else "file" if path.is_file() else "missing"
+                ),
             }
         )
     return rows
@@ -174,7 +178,12 @@ def _run_quick(cmd: list[str], timeout: int = 12) -> dict[str, object]:
             check=False,
         )
     except Exception as exc:  # pragma: no cover - exact OS failures vary
-        return {"command": cmd, "resolved_command": resolved_cmd, "returncode": -1, "error": str(exc)}
+        return {
+            "command": cmd,
+            "resolved_command": resolved_cmd,
+            "returncode": -1,
+            "error": str(exc),
+        }
     return {
         "command": cmd,
         "resolved_command": resolved_cmd,
@@ -193,7 +202,9 @@ def _proof_snapshot() -> dict[str, object]:
     return {"checks": [_run_quick(cmd) for cmd in checks]}
 
 
-def _dispatch_bus_task(prompt: str, *, task_id: str, dry_run: bool = False) -> dict[str, object]:
+def _dispatch_bus_task(
+    prompt: str, *, task_id: str, dry_run: bool = False
+) -> dict[str, object]:
     """Route one real task through the local HYDRA free-LLM bus."""
 
     try:
@@ -244,14 +255,21 @@ def _select_offer(offer_id: str) -> Offer:
 
 
 def _price_label(offer: Offer | dict[str, object]) -> str:
-    floor = int(offer["price_floor_usd"] if isinstance(offer, dict) else offer.price_floor_usd)
-    anchor = int(offer["price_anchor_usd"] if isinstance(offer, dict) else offer.price_anchor_usd)
+    floor = int(
+        offer["price_floor_usd"] if isinstance(offer, dict) else offer.price_floor_usd
+    )
+    anchor = int(
+        offer["price_anchor_usd"] if isinstance(offer, dict) else offer.price_anchor_usd
+    )
     return f"${floor}" if floor == anchor else f"${floor}-${anchor}"
 
 
 def _build_outreach(offer: Offer) -> list[dict[str, str]]:
     price = _price_label(offer)
-    base = f"I am offering a small {offer.title} sprint ({price}). " f"{offer.promise} {offer.call_to_action}"
+    base = (
+        f"I am offering a small {offer.title} sprint ({price}). "
+        f"{offer.promise} {offer.call_to_action}"
+    )
     return [
         {
             "channel": "dm_short",
@@ -264,7 +282,9 @@ def _build_outreach(offer: Offer) -> list[dict[str, str]]:
                 f"Hi,\n\n"
                 f"I am running a fixed-scope {offer.title} sprint for {offer.buyer}.\n\n"
                 f"Result: {offer.promise}\n\n"
-                f"Includes:\n" + "\n".join(f"- {item}" for item in offer.deliverables) + f"\n\nPrice: {price}.\n"
+                f"Includes:\n"
+                + "\n".join(f"- {item}" for item in offer.deliverables)
+                + f"\n\nPrice: {price}.\n"
                 f"{offer.call_to_action}\n\n"
                 f"- Issac"
             ),
@@ -321,7 +341,9 @@ def _markdown(report: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def generate_packet(*, offer_id: str, minutes: int, out_root: Path = OUT_ROOT) -> dict[str, Path]:
+def generate_packet(
+    *, offer_id: str, minutes: int, out_root: Path = OUT_ROOT
+) -> dict[str, Path]:
     offer = _select_offer(offer_id)
     date = datetime.now().strftime("%Y-%m-%d")
     out_dir = out_root / date
@@ -345,13 +367,18 @@ def generate_packet(*, offer_id: str, minutes: int, out_root: Path = OUT_ROOT) -
     json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
     md_path.write_text(_markdown(report), encoding="utf-8")
     queue_path.write_text(
-        "".join(json.dumps(row, ensure_ascii=True) + "\n" for row in report["outreach_drafts"]),
+        "".join(
+            json.dumps(row, ensure_ascii=True) + "\n"
+            for row in report["outreach_drafts"]
+        ),
         encoding="utf-8",
     )
     return {"json": json_path, "markdown": md_path, "queue": queue_path}
 
 
-def _task(task_id: str, kind: str, label: str, payload: dict[str, object]) -> dict[str, object]:
+def _task(
+    task_id: str, kind: str, label: str, payload: dict[str, object]
+) -> dict[str, object]:
     return {
         "task_id": task_id,
         "kind": kind,
@@ -400,7 +427,11 @@ def _initial_state(*, offer_id: str, minutes: int, out_root: Path) -> dict[str, 
                 "publish_guard",
                 "command",
                 "Run npm package guard for GeoSeal CLI publish readiness.",
-                {"command": ["npm", "run", "publish:check:strict"], "timeout": 300, "nonblocking": True},
+                {
+                    "command": ["npm", "run", "publish:check:strict"],
+                    "timeout": 300,
+                    "nonblocking": True,
+                },
             ),
             _task(
                 "bus_dm_short",
@@ -441,7 +472,9 @@ def _write_state(state_path: Path, state: dict[str, object]) -> None:
     state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
 
 
-def _cycle_state(state: dict[str, object], *, offer_id: str, minutes: int, out_root: Path) -> dict[str, object]:
+def _cycle_state(
+    state: dict[str, object], *, offer_id: str, minutes: int, out_root: Path
+) -> dict[str, object]:
     tasks = state.get("tasks", [])
     assert isinstance(tasks, list)
     cycle_history = state.setdefault("cycle_history", [])
@@ -460,7 +493,9 @@ def _cycle_state(state: dict[str, object], *, offer_id: str, minutes: int, out_r
     return next_state
 
 
-def _record(task: dict[str, object], state: StateName, result: dict[str, object]) -> None:
+def _record(
+    task: dict[str, object], state: StateName, result: dict[str, object]
+) -> None:
     task["state"] = state
     task["attempts"] = int(task.get("attempts", 0)) + 1
     history = task.setdefault("history", [])
@@ -500,10 +535,14 @@ def _run_task(
         paths = generate_packet(offer_id=offer_id, minutes=minutes, out_root=out_root)
         return "DONE", {name: _safe_rel(path) for name, path in paths.items()}
     if kind == "bus_dispatch":
-        result = _dispatch_bus_task(str(payload["prompt"]), task_id=str(task["task_id"]))
+        result = _dispatch_bus_task(
+            str(payload["prompt"]), task_id=str(task["task_id"])
+        )
         return ("DONE" if result.get("status") == "ok" else "BLOCKED"), result
     if kind == "command":
-        result = _run_quick(list(payload["command"]), timeout=int(payload.get("timeout", 120)))
+        result = _run_quick(
+            list(payload["command"]), timeout=int(payload.get("timeout", 120))
+        )
         if result.get("returncode") == 0:
             return "DONE", result
         if bool(payload.get("nonblocking")):
@@ -543,21 +582,33 @@ def run_continuous(
     assert isinstance(tasks, list)
     steps: list[dict[str, object]] = []
     for _ in range(max_steps):
-        next_task = next((task for task in tasks if task.get("state") == "PENDING"), None)
+        next_task = next(
+            (task for task in tasks if task.get("state") == "PENDING"), None
+        )
         if not next_task:
-            if cycle_when_complete and not any(task.get("state") == "BLOCKED" for task in tasks):
-                state = _cycle_state(state, offer_id=offer_id, minutes=minutes, out_root=out_root)
+            if cycle_when_complete and not any(
+                task.get("state") == "BLOCKED" for task in tasks
+            ):
+                state = _cycle_state(
+                    state, offer_id=offer_id, minutes=minutes, out_root=out_root
+                )
                 tasks = state["tasks"]
                 assert isinstance(tasks, list)
                 _write_state(state_path, state)
-                next_task = next((task for task in tasks if task.get("state") == "PENDING"), None)
+                next_task = next(
+                    (task for task in tasks if task.get("state") == "PENDING"), None
+                )
             if not next_task:
                 break
         next_task["state"] = "RUNNING"
         _write_state(state_path, state)
-        final_state, result = _run_task(next_task, offer_id=offer_id, minutes=minutes, out_root=out_root)
+        final_state, result = _run_task(
+            next_task, offer_id=offer_id, minutes=minutes, out_root=out_root
+        )
         _record(next_task, final_state, result)
-        steps.append({"task_id": next_task["task_id"], "state": final_state, "result": result})
+        steps.append(
+            {"task_id": next_task["task_id"], "state": final_state, "result": result}
+        )
         if final_state == "BLOCKED":
             break
         _write_state(state_path, state)
@@ -577,15 +628,34 @@ def run_continuous(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Generate the daily 20-minute SCBE cash sprint packet.")
-    parser.add_argument("--offer", default="rotate", help="Offer ID to use, or 'rotate'.")
-    parser.add_argument("--minutes", type=int, default=20, help="Execution budget in minutes.")
-    parser.add_argument("--out-root", default=str(OUT_ROOT), help="Output directory root.")
-    parser.add_argument(
-        "--continuous", action="store_true", help="Run the next stateful task instead of stopping at packet generation."
+    parser = argparse.ArgumentParser(
+        description="Generate the daily 20-minute SCBE cash sprint packet."
     )
-    parser.add_argument("--max-steps", type=int, default=1, help="Maximum continuous tasks to advance this invocation.")
-    parser.add_argument("--reset-state", action="store_true", help="Start the continuous state machine over.")
+    parser.add_argument(
+        "--offer", default="rotate", help="Offer ID to use, or 'rotate'."
+    )
+    parser.add_argument(
+        "--minutes", type=int, default=20, help="Execution budget in minutes."
+    )
+    parser.add_argument(
+        "--out-root", default=str(OUT_ROOT), help="Output directory root."
+    )
+    parser.add_argument(
+        "--continuous",
+        action="store_true",
+        help="Run the next stateful task instead of stopping at packet generation.",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=1,
+        help="Maximum continuous tasks to advance this invocation.",
+    )
+    parser.add_argument(
+        "--reset-state",
+        action="store_true",
+        help="Start the continuous state machine over.",
+    )
     parser.add_argument(
         "--cycle-when-complete",
         action="store_true",
@@ -610,7 +680,9 @@ def main() -> int:
         )
         print(json.dumps(result, indent=2))
         return 1 if int(result["blocked_count"]) else 0
-    paths = generate_packet(offer_id=args.offer, minutes=args.minutes, out_root=out_root)
+    paths = generate_packet(
+        offer_id=args.offer, minutes=args.minutes, out_root=out_root
+    )
     for name, path in paths.items():
         print(f"{name}={_safe_rel(path)}")
     return 0

--- a/scripts/revenue/governance_snapshot_intake.py
+++ b/scripts/revenue/governance_snapshot_intake.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Create a fulfillment folder for a paid AI Governance Snapshot buyer.
+
+This is the post-checkout rail: payment is handled by Stripe, then this script
+turns the buyer intake into a small working packet with a memo template,
+evidence checklist, and delivery checklist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUT_ROOT = REPO_ROOT / "artifacts" / "revenue" / "governance_snapshot"
+
+
+@dataclass(frozen=True)
+class SnapshotIntake:
+    buyer_email: str
+    workflow_name: str
+    payment_reference: str
+    deadline: str
+    notes: str
+    created_at_utc: str
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _slug(value: str) -> str:
+    cleaned = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    return cleaned[:64] or "snapshot"
+
+
+def _memo_template(intake: SnapshotIntake) -> str:
+    return f"""# AI Governance Snapshot Findings Memo
+
+Buyer: {intake.buyer_email}
+Workflow: {intake.workflow_name}
+Payment reference: {intake.payment_reference or "pending"}
+Deadline: {intake.deadline or "not provided"}
+
+## 1. Workflow Summary
+
+Describe the AI workflow in plain English:
+
+- Inputs:
+- Model or tool:
+- Human review point:
+- Output or decision:
+- External systems touched:
+
+## 2. Risk Findings
+
+Write three prioritized fixes: one immediate fix, one medium fix, and one optional fix.
+
+### Finding 1
+- Risk:
+- Evidence:
+- Practical fix:
+
+### Finding 2
+- Risk:
+- Evidence:
+- Practical fix:
+
+### Finding 3
+- Risk:
+- Evidence:
+- Practical fix:
+
+## 3. Evidence Checklist
+
+- [ ] Intake materials reviewed.
+- [ ] No secrets or regulated production data retained.
+- [ ] Data path mapped.
+- [ ] Human decision point identified.
+- [ ] Audit/logging gap identified.
+- [ ] Vendor/model dependency identified.
+- [ ] Three fixes prioritized.
+
+## 4. Delivery Summary
+
+Write the buyer-facing summary here.
+"""
+
+
+def _evidence_checklist() -> str:
+    return """# Evidence Checklist
+
+Use this checklist while reviewing the buyer's workflow.
+
+- [ ] Confirm payment or receipt reference.
+- [ ] Save only redacted/public-safe intake files.
+- [ ] Identify the AI system, model provider, or local runtime.
+- [ ] Identify what data enters the workflow.
+- [ ] Identify what data leaves the workflow.
+- [ ] Identify who can override the AI output.
+- [ ] Identify logging, audit, or receipt gaps.
+- [ ] Identify one immediate fix, one medium fix, and one optional fix.
+- [ ] Prepare final memo as PDF or Markdown.
+- [ ] Send final memo and one follow-up clarification route.
+"""
+
+
+def _delivery_checklist(intake: SnapshotIntake) -> str:
+    return f"""# Delivery Checklist
+
+Offer: AI Governance Snapshot
+Buyer: {intake.buyer_email}
+Workflow: {intake.workflow_name}
+
+- [ ] Intake packet created.
+- [ ] Materials screened for secrets or regulated data.
+- [ ] Findings memo drafted.
+- [ ] Three prioritized fixes written.
+- [ ] Evidence checklist completed.
+- [ ] Final package delivered by email.
+- [ ] Follow-up email thread kept open for one clarification round.
+
+Boundary reminder: this is not legal advice, certification, penetration testing,
+FedRAMP authorization, or a guaranteed contract outcome.
+"""
+
+
+def create_snapshot_packet(
+    *,
+    buyer_email: str,
+    workflow_name: str,
+    payment_reference: str = "",
+    deadline: str = "",
+    notes: str = "",
+    out_root: Path = DEFAULT_OUT_ROOT,
+) -> dict[str, Path]:
+    intake = SnapshotIntake(
+        buyer_email=buyer_email.strip(),
+        workflow_name=workflow_name.strip(),
+        payment_reference=payment_reference.strip(),
+        deadline=deadline.strip(),
+        notes=notes.strip(),
+        created_at_utc=_utc_now(),
+    )
+    if not intake.buyer_email or "@" not in intake.buyer_email:
+        raise ValueError("buyer_email must look like an email address")
+    if not intake.workflow_name:
+        raise ValueError("workflow_name is required")
+
+    day = datetime.now().strftime("%Y-%m-%d")
+    folder = (
+        out_root / day / f"{_slug(intake.buyer_email)}-{_slug(intake.workflow_name)}"
+    )
+    folder.mkdir(parents=True, exist_ok=True)
+
+    intake_path = folder / "intake.json"
+    memo_path = folder / "findings-memo.md"
+    evidence_path = folder / "evidence-checklist.md"
+    delivery_path = folder / "delivery-checklist.md"
+
+    intake_path.write_text(json.dumps(asdict(intake), indent=2), encoding="utf-8")
+    memo_path.write_text(_memo_template(intake), encoding="utf-8")
+    evidence_path.write_text(_evidence_checklist(), encoding="utf-8")
+    delivery_path.write_text(_delivery_checklist(intake), encoding="utf-8")
+
+    return {
+        "folder": folder,
+        "intake": intake_path,
+        "memo": memo_path,
+        "evidence": evidence_path,
+        "delivery": delivery_path,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create an AI Governance Snapshot buyer fulfillment packet."
+    )
+    parser.add_argument("--buyer-email", required=True)
+    parser.add_argument("--workflow-name", required=True)
+    parser.add_argument("--payment-reference", default="")
+    parser.add_argument("--deadline", default="")
+    parser.add_argument("--notes", default="")
+    parser.add_argument("--out-root", default=str(DEFAULT_OUT_ROOT))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    paths = create_snapshot_packet(
+        buyer_email=args.buyer_email,
+        workflow_name=args.workflow_name,
+        payment_reference=args.payment_reference,
+        deadline=args.deadline,
+        notes=args.notes,
+        out_root=Path(args.out_root),
+    )
+    print(json.dumps({name: str(path) for name, path in paths.items()}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/system/monetization_connector_push.py
+++ b/scripts/system/monetization_connector_push.py
@@ -31,7 +31,9 @@ from src.security.secret_store import get_secret
 
 try:
     from scripts.gumroad_publish import GumroadPublisher, PRODUCTS, STRIPE_LINKS
-except ModuleNotFoundError:  # pragma: no cover - depends on optional local sales tooling
+except (
+    ModuleNotFoundError
+):  # pragma: no cover - depends on optional local sales tooling
     GumroadPublisher = None
     PRODUCTS = {}
     STRIPE_LINKS = {}
@@ -47,6 +49,8 @@ class StaticOffer:
     tags: List[str]
     cadence: str
     proof_url: str
+    intake_url: str = ""
+    fulfillment_command: str = ""
 
 
 STATIC_OFFERS: List[StaticOffer] = [
@@ -69,6 +73,11 @@ STATIC_OFFERS: List[StaticOffer] = [
         tags=["consulting", "governance", "fixed-scope", "cash-sprint"],
         cadence="one_time",
         proof_url="https://aethermoore.com/governance-snapshot.html",
+        intake_url="https://aethermoore.com/governance-snapshot.html#intake",
+        fulfillment_command=(
+            "python scripts/revenue/governance_snapshot_intake.py "
+            "--buyer-email <buyer-email> --workflow-name <workflow-name>"
+        ),
     ),
 ]
 
@@ -85,7 +94,11 @@ def _latest_lead_file() -> Optional[Path]:
     sales_dir = REPO_ROOT / "artifacts" / "sales"
     if not sales_dir.exists():
         return None
-    files = sorted(sales_dir.glob("github_leads_*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    files = sorted(
+        sales_dir.glob("github_leads_*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
     return files[0] if files else None
 
 
@@ -125,6 +138,8 @@ def _build_offers(include_gumroad: bool) -> List[Dict[str, Any]]:
             "tags": offer.tags,
             "cadence": offer.cadence,
             "proof_url": offer.proof_url,
+            "intake_url": offer.intake_url,
+            "fulfillment_command": offer.fulfillment_command,
         }
         for offer in STATIC_OFFERS
     ]
@@ -182,24 +197,41 @@ async def _dispatch(
             out["n8n"] = {"status": "skipped", "reason": "not_configured"}
         else:
             res = await bridge.execute("n8n", "trigger", payload)
-            out["n8n"] = {"status": "sent" if res.success else "failed", **_result_to_dict(res)}
+            out["n8n"] = {
+                "status": "sent" if res.success else "failed",
+                **_result_to_dict(res),
+            }
 
     if route_zapier:
         if not bridge.is_configured("zapier"):
             out["zapier"] = {"status": "skipped", "reason": "not_configured"}
         else:
             res = await bridge.execute("zapier", "trigger", payload)
-            out["zapier"] = {"status": "sent" if res.success else "failed", **_result_to_dict(res)}
+            out["zapier"] = {
+                "status": "sent" if res.success else "failed",
+                **_result_to_dict(res),
+            }
 
     return out
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Push latest leads + offers to n8n/Zapier monetization connectors.")
-    parser.add_argument("--leads-json", default="", help="Optional leads JSON file path.")
-    parser.add_argument("--top-leads", type=int, default=10, help="Number of leads to include in connector payload.")
+    parser = argparse.ArgumentParser(
+        description="Push latest leads + offers to n8n/Zapier monetization connectors."
+    )
     parser.add_argument(
-        "--include-gumroad", action="store_true", help="Attempt to enrich offers with Gumroad live URLs."
+        "--leads-json", default="", help="Optional leads JSON file path."
+    )
+    parser.add_argument(
+        "--top-leads",
+        type=int,
+        default=10,
+        help="Number of leads to include in connector payload.",
+    )
+    parser.add_argument(
+        "--include-gumroad",
+        action="store_true",
+        help="Attempt to enrich offers with Gumroad live URLs.",
     )
 
     parser.add_argument("--route-n8n", dest="route_n8n", action="store_true")
@@ -210,8 +242,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--no-route-zapier", dest="route_zapier", action="store_false")
     parser.set_defaults(route_zapier=True)
 
-    parser.add_argument("--dry-run", action="store_true", help="Do not send connector traffic.")
-    parser.add_argument("--output-dir", default="artifacts/monetization", help="Output root for run artifacts.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Do not send connector traffic."
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="artifacts/monetization",
+        help="Output root for run artifacts.",
+    )
     return parser.parse_args()
 
 
@@ -220,7 +258,11 @@ def main() -> int:
     day = _utc_now().strftime("%Y%m%d")
     run_id = f"monetization-connector-push-{_utc_stamp()}"
 
-    lead_path = Path(args.leads_json).resolve() if args.leads_json.strip() else _latest_lead_file()
+    lead_path = (
+        Path(args.leads_json).resolve()
+        if args.leads_json.strip()
+        else _latest_lead_file()
+    )
     leads: List[Dict[str, Any]] = []
     if lead_path and lead_path.exists():
         loaded = _load_json(lead_path, default=[])

--- a/tests/revenue/test_daily_cash_sprint.py
+++ b/tests/revenue/test_daily_cash_sprint.py
@@ -45,7 +45,10 @@ def test_daily_cash_sprint_generates_governance_snapshot_offer(tmp_path: Path) -
 
     drafts = report["outreach_drafts"]
     assert len(drafts) == 3
-    assert any("https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j" in draft["text"] for draft in drafts)
+    assert any(
+        "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j" in draft["text"]
+        for draft in drafts
+    )
     markdown = paths["markdown"].read_text(encoding="utf-8")
     assert "2-page findings memo" in markdown
     assert "Price: $500\n" in markdown

--- a/tests/revenue/test_governance_snapshot_intake.py
+++ b/tests/revenue/test_governance_snapshot_intake.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.revenue.governance_snapshot_intake import create_snapshot_packet
+
+
+def test_create_snapshot_packet_generates_fulfillment_files(tmp_path: Path) -> None:
+    paths = create_snapshot_packet(
+        buyer_email="buyer@example.com",
+        workflow_name="Customer support chatbot",
+        payment_reference="stripe:cs_test_123",
+        deadline="2026-05-15",
+        notes="Review public docs only.",
+        out_root=tmp_path,
+    )
+
+    assert paths["folder"].exists()
+    assert paths["intake"].exists()
+    assert paths["memo"].exists()
+    assert paths["evidence"].exists()
+    assert paths["delivery"].exists()
+
+    intake = json.loads(paths["intake"].read_text(encoding="utf-8"))
+    assert intake["buyer_email"] == "buyer@example.com"
+    assert intake["workflow_name"] == "Customer support chatbot"
+    assert intake["payment_reference"] == "stripe:cs_test_123"
+
+    memo = paths["memo"].read_text(encoding="utf-8")
+    assert "AI Governance Snapshot Findings Memo" in memo
+    assert "three prioritized fixes" in memo
+
+    delivery = paths["delivery"].read_text(encoding="utf-8")
+    assert "not legal advice" in delivery
+    assert "Final package delivered by email" in delivery
+
+
+def test_create_snapshot_packet_rejects_bad_intake(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="buyer_email"):
+        create_snapshot_packet(
+            buyer_email="not-an-email",
+            workflow_name="Workflow",
+            out_root=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match="workflow_name"):
+        create_snapshot_packet(
+            buyer_email="buyer@example.com",
+            workflow_name="",
+            out_root=tmp_path,
+        )

--- a/tests/system/test_monetization_connector_push.py
+++ b/tests/system/test_monetization_connector_push.py
@@ -8,9 +8,23 @@ def test_monetization_connector_push_includes_live_cash_offers() -> None:
     by_id = {offer["id"]: offer for offer in offers}
 
     assert by_id["supporter_monthly"]["price_usd"] == 20.0
-    assert by_id["supporter_monthly"]["stripe_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    assert (
+        by_id["supporter_monthly"]["stripe_url"]
+        == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    )
     assert by_id["supporter_monthly"]["cadence"] == "monthly"
 
     assert by_id["governance_snapshot"]["price_usd"] == 500.0
-    assert by_id["governance_snapshot"]["stripe_url"] == "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+    assert (
+        by_id["governance_snapshot"]["stripe_url"]
+        == "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+    )
     assert by_id["governance_snapshot"]["cadence"] == "one_time"
+    assert (
+        by_id["governance_snapshot"]["intake_url"]
+        == "https://aethermoore.com/governance-snapshot.html#intake"
+    )
+    assert (
+        "governance_snapshot_intake.py"
+        in by_id["governance_snapshot"]["fulfillment_command"]
+    )


### PR DESCRIPTION
## Summary
- adds a buyer-facing intake section to the $500 AI Governance Snapshot page
- adds a local fulfillment packet generator for paid Snapshot buyers
- includes the intake URL and fulfillment command in the monetization connector offer payload
- updates the daily cash sprint so outreach sends buyers through checkout plus intake

## Test evidence
- `python -m pytest tests/revenue/test_governance_snapshot_intake.py tests/revenue/test_daily_cash_sprint.py tests/system/test_monetization_connector_push.py -q` -> 7 passed
- HTML parser smoke: `docs/governance-snapshot.html` and `docs/offers/index.html` ok
- `python -m black --check ...` -> passed
- `python -m ruff check ...` -> passed
- `python -m py_compile scripts/revenue/governance_snapshot_intake.py scripts/revenue/daily_cash_sprint.py scripts/system/monetization_connector_push.py` -> passed
- Connector dry-run emitted both live offers with governance snapshot intake URL and fulfillment command

## Rollback
Revert this PR. It only touches website revenue copy, local revenue scripts, connector payload fields, and focused tests.