### PR TITLE
style(revenue): match CI black formatting

### DIFF
--- a/tests/revenue/test_daily_cash_sprint.py
+++ b/tests/revenue/test_daily_cash_sprint.py
@@ -45,10 +45,7 @@ def test_daily_cash_sprint_generates_governance_snapshot_offer(tmp_path: Path) -
 
     drafts = report["outreach_drafts"]
     assert len(drafts) == 3
-    assert any(
-        "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j" in draft["text"]
-        for draft in drafts
-    )
+    assert any("https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j" in draft["text"] for draft in drafts)
     markdown = paths["markdown"].read_text(encoding="utf-8")
     assert "2-page findings memo" in markdown
     assert "Price: $500\n" in markdown

--- a/tests/system/test_monetization_connector_push.py
+++ b/tests/system/test_monetization_connector_push.py
@@ -8,23 +8,11 @@ def test_monetization_connector_push_includes_live_cash_offers() -> None:
     by_id = {offer["id"]: offer for offer in offers}
 
     assert by_id["supporter_monthly"]["price_usd"] == 20.0
-    assert (
-        by_id["supporter_monthly"]["stripe_url"]
-        == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
-    )
+    assert by_id["supporter_monthly"]["stripe_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
     assert by_id["supporter_monthly"]["cadence"] == "monthly"
 
     assert by_id["governance_snapshot"]["price_usd"] == 500.0
-    assert (
-        by_id["governance_snapshot"]["stripe_url"]
-        == "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
-    )
+    assert by_id["governance_snapshot"]["stripe_url"] == "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
     assert by_id["governance_snapshot"]["cadence"] == "one_time"
-    assert (
-        by_id["governance_snapshot"]["intake_url"]
-        == "https://aethermoore.com/governance-snapshot.html#intake"
-    )
-    assert (
-        "governance_snapshot_intake.py"
-        in by_id["governance_snapshot"]["fulfillment_command"]
-    )
+    assert by_id["governance_snapshot"]["intake_url"] == "https://aethermoore.com/governance-snapshot.html#intake"
+    assert "governance_snapshot_intake.py" in by_id["governance_snapshot"]["fulfillment_command"]


### PR DESCRIPTION
## Summary
- applies the exact CI Black line-length format to the two revenue tests from #1477
- no behavior changes

## Test evidence
- `black --check --target-version py311 --line-length 120 src/ tests/` -> passed
- `ruff check src/ tests/` -> passed
- `python -m pytest tests/revenue/test_governance_snapshot_intake.py tests/revenue/test_daily_cash_sprint.py tests/system/test_monetization_connector_push.py -q` -> 7 passed

## Rollback
Revert this PR. It is format-only.