### PR TITLE
feat(revenue): add five dollar tip jar lane

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -946,6 +946,7 @@
               Templates, decision records, threshold worksheets, and a manual. One checkout, no subscription. You'll have a governed AI workflow running before dinner.
             </p>
             <p style="margin-top:16px;"><a class="btn btn-secondary" href="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06" target="_blank" rel="noopener">Buy the Toolkit ($29)</a></p>
+            <p style="margin-top:10px;"><a class="btn btn-secondary" href="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k" target="_blank" rel="noopener">Tip $5 one time</a></p>
             <p style="margin-top:10px;"><a class="btn btn-secondary" href="supporter.html">Support for $20/month</a></p>
             <p style="margin-top:10px;"><a class="btn btn-secondary" href="governance-snapshot.html">Book a $500 Governance Snapshot</a></p>
           </article>

--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -50,6 +50,12 @@
         <a class="btn" href="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i" target="_blank" rel="noopener">Join as Supporter</a>
       </article>
       <article class="card">
+        <h2>AetherMoore Tip Jar</h2>
+        <p>A tiny one-time support lane for people who want to help without a subscription, account, or sales call.</p>
+        <div class="price">$5 one-time</div>
+        <a class="btn" href="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k" target="_blank" rel="noopener">Tip $5</a>
+      </article>
+      <article class="card">
         <h2>AI Governance Snapshot</h2>
         <p>A fixed-scope review with a 2-page findings memo, three prioritized fixes, and a practical evidence checklist.</p>
         <div class="price">$500 one-time</div>

--- a/docs/supporter.html
+++ b/docs/supporter.html
@@ -162,6 +162,22 @@
         mystery box.
       </p>
       <div class="price"><strong>$20</strong><span>/ month</span></div>
+      <div class="actions" aria-label="Quick support actions">
+        <a
+          class="btn"
+          href="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+          target="_blank"
+          rel="noopener"
+          >Tip $5 one time</a
+        >
+        <a
+          class="btn secondary"
+          href="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+          target="_blank"
+          rel="noopener"
+          >Support for $20/month</a
+        >
+      </div>
 
       <section class="grid" aria-label="Supporter benefits">
         <article class="card">
@@ -214,7 +230,7 @@
             <button class="btn" type="submit">Start $20/month checkout</button>
             <a
               class="btn secondary"
-              href="mailto:ai@aethermoore.com?subject=AetherMoore%20Supporter%20-%20manual%20payment&body=I%20want%20to%20support%20AetherMoore%20for%20%2420%2Fmonth.%20Please%20send%20me%20a%20Stripe%20or%20Cash%20App%20payment%20link."
+              href="mailto:ai@aethermoore.com?subject=AetherMoore%20Supporter%20-%20manual%20payment&body=I%20want%20to%20support%20AetherMoore.%20Please%20send%20me%20a%20Stripe%20or%20Cash%20App%20payment%20link."
               >Ask for manual payment link</a
             >
           </div>

--- a/scripts/revenue/daily_cash_sprint.py
+++ b/scripts/revenue/daily_cash_sprint.py
@@ -42,6 +42,26 @@ class Offer:
 
 DEFAULT_OFFERS = [
     Offer(
+        offer_id="tip_jar",
+        title="AetherMoore Tip Jar",
+        buyer="people who want to help the work without a subscription, account setup, or sales call",
+        price_floor_usd=5,
+        price_anchor_usd=5,
+        promise="A tiny one-time support payment that keeps the work moving and proves the payment rail is alive.",
+        deliverables=[
+            "One direct Stripe-hosted $5 support link.",
+            "No account setup, subscription decision, or paperwork required.",
+            "Supporter can still upgrade later to the $20/month tier or $500 governance snapshot.",
+        ],
+        proof_paths=[
+            "docs/supporter.html",
+            "docs/offers/index.html",
+            "scripts/system/create_tip_jar_stripe_link.py",
+            "scripts/system/monetization_connector_push.py",
+        ],
+        call_to_action="Tip $5 here: https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k",
+    ),
+    Offer(
         offer_id="ai_governance_snapshot",
         title="AI Governance Snapshot",
         buyer="small teams, founders, and subcontract leads using AI who need a plain governance risk read",
@@ -154,9 +174,7 @@ def _path_status(paths: Iterable[str]) -> list[dict[str, object]]:
             {
                 "path": raw,
                 "exists": path.exists(),
-                "kind": (
-                    "dir" if path.is_dir() else "file" if path.is_file() else "missing"
-                ),
+                "kind": ("dir" if path.is_dir() else "file" if path.is_file() else "missing"),
             }
         )
     return rows
@@ -202,9 +220,7 @@ def _proof_snapshot() -> dict[str, object]:
     return {"checks": [_run_quick(cmd) for cmd in checks]}
 
 
-def _dispatch_bus_task(
-    prompt: str, *, task_id: str, dry_run: bool = False
-) -> dict[str, object]:
+def _dispatch_bus_task(prompt: str, *, task_id: str, dry_run: bool = False) -> dict[str, object]:
     """Route one real task through the local HYDRA free-LLM bus."""
 
     try:
@@ -255,21 +271,44 @@ def _select_offer(offer_id: str) -> Offer:
 
 
 def _price_label(offer: Offer | dict[str, object]) -> str:
-    floor = int(
-        offer["price_floor_usd"] if isinstance(offer, dict) else offer.price_floor_usd
-    )
-    anchor = int(
-        offer["price_anchor_usd"] if isinstance(offer, dict) else offer.price_anchor_usd
-    )
+    floor = int(offer["price_floor_usd"] if isinstance(offer, dict) else offer.price_floor_usd)
+    anchor = int(offer["price_anchor_usd"] if isinstance(offer, dict) else offer.price_anchor_usd)
     return f"${floor}" if floor == anchor else f"${floor}-${anchor}"
 
 
 def _build_outreach(offer: Offer) -> list[dict[str, str]]:
     price = _price_label(offer)
-    base = (
-        f"I am offering a small {offer.title} sprint ({price}). "
-        f"{offer.promise} {offer.call_to_action}"
-    )
+    if offer.offer_id == "tip_jar":
+        return [
+            {
+                "channel": "dm_short",
+                "text": (
+                    "I added a tiny AetherMoore support lane so people can help without a subscription "
+                    "or sales call. It is $5 one-time: https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+                ),
+            },
+            {
+                "channel": "email",
+                "subject": "Tiny AetherMoore support lane",
+                "text": (
+                    "Hi,\n\n"
+                    "I added a small one-time AetherMoore support lane for people who want to help the "
+                    "work without a subscription, account setup, or sales call.\n\n"
+                    "It is $5 through Stripe: https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k\n\n"
+                    "That is it. No paperwork, no pitch deck, no platform signup.\n\n"
+                    "- Issac"
+                ),
+            },
+            {
+                "channel": "post",
+                "text": (
+                    "I added a tiny $5 one-time AetherMoore support lane for anyone who wants to help "
+                    "the work move without a subscription or sales call: "
+                    "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+                ),
+            },
+        ]
+    base = f"I am offering a small {offer.title} sprint ({price}). " f"{offer.promise} {offer.call_to_action}"
     return [
         {
             "channel": "dm_short",
@@ -282,9 +321,7 @@ def _build_outreach(offer: Offer) -> list[dict[str, str]]:
                 f"Hi,\n\n"
                 f"I am running a fixed-scope {offer.title} sprint for {offer.buyer}.\n\n"
                 f"Result: {offer.promise}\n\n"
-                f"Includes:\n"
-                + "\n".join(f"- {item}" for item in offer.deliverables)
-                + f"\n\nPrice: {price}.\n"
+                f"Includes:\n" + "\n".join(f"- {item}" for item in offer.deliverables) + f"\n\nPrice: {price}.\n"
                 f"{offer.call_to_action}\n\n"
                 f"- Issac"
             ),
@@ -341,9 +378,7 @@ def _markdown(report: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def generate_packet(
-    *, offer_id: str, minutes: int, out_root: Path = OUT_ROOT
-) -> dict[str, Path]:
+def generate_packet(*, offer_id: str, minutes: int, out_root: Path = OUT_ROOT) -> dict[str, Path]:
     offer = _select_offer(offer_id)
     date = datetime.now().strftime("%Y-%m-%d")
     out_dir = out_root / date
@@ -367,18 +402,13 @@ def generate_packet(
     json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
     md_path.write_text(_markdown(report), encoding="utf-8")
     queue_path.write_text(
-        "".join(
-            json.dumps(row, ensure_ascii=True) + "\n"
-            for row in report["outreach_drafts"]
-        ),
+        "".join(json.dumps(row, ensure_ascii=True) + "\n" for row in report["outreach_drafts"]),
         encoding="utf-8",
     )
     return {"json": json_path, "markdown": md_path, "queue": queue_path}
 
 
-def _task(
-    task_id: str, kind: str, label: str, payload: dict[str, object]
-) -> dict[str, object]:
+def _task(task_id: str, kind: str, label: str, payload: dict[str, object]) -> dict[str, object]:
     return {
         "task_id": task_id,
         "kind": kind,
@@ -472,9 +502,7 @@ def _write_state(state_path: Path, state: dict[str, object]) -> None:
     state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
 
 
-def _cycle_state(
-    state: dict[str, object], *, offer_id: str, minutes: int, out_root: Path
-) -> dict[str, object]:
+def _cycle_state(state: dict[str, object], *, offer_id: str, minutes: int, out_root: Path) -> dict[str, object]:
     tasks = state.get("tasks", [])
     assert isinstance(tasks, list)
     cycle_history = state.setdefault("cycle_history", [])
@@ -493,9 +521,7 @@ def _cycle_state(
     return next_state
 
 
-def _record(
-    task: dict[str, object], state: StateName, result: dict[str, object]
-) -> None:
+def _record(task: dict[str, object], state: StateName, result: dict[str, object]) -> None:
     task["state"] = state
     task["attempts"] = int(task.get("attempts", 0)) + 1
     history = task.setdefault("history", [])
@@ -535,14 +561,10 @@ def _run_task(
         paths = generate_packet(offer_id=offer_id, minutes=minutes, out_root=out_root)
         return "DONE", {name: _safe_rel(path) for name, path in paths.items()}
     if kind == "bus_dispatch":
-        result = _dispatch_bus_task(
-            str(payload["prompt"]), task_id=str(task["task_id"])
-        )
+        result = _dispatch_bus_task(str(payload["prompt"]), task_id=str(task["task_id"]))
         return ("DONE" if result.get("status") == "ok" else "BLOCKED"), result
     if kind == "command":
-        result = _run_quick(
-            list(payload["command"]), timeout=int(payload.get("timeout", 120))
-        )
+        result = _run_quick(list(payload["command"]), timeout=int(payload.get("timeout", 120)))
         if result.get("returncode") == 0:
             return "DONE", result
         if bool(payload.get("nonblocking")):
@@ -582,33 +604,21 @@ def run_continuous(
     assert isinstance(tasks, list)
     steps: list[dict[str, object]] = []
     for _ in range(max_steps):
-        next_task = next(
-            (task for task in tasks if task.get("state") == "PENDING"), None
-        )
+        next_task = next((task for task in tasks if task.get("state") == "PENDING"), None)
         if not next_task:
-            if cycle_when_complete and not any(
-                task.get("state") == "BLOCKED" for task in tasks
-            ):
-                state = _cycle_state(
-                    state, offer_id=offer_id, minutes=minutes, out_root=out_root
-                )
+            if cycle_when_complete and not any(task.get("state") == "BLOCKED" for task in tasks):
+                state = _cycle_state(state, offer_id=offer_id, minutes=minutes, out_root=out_root)
                 tasks = state["tasks"]
                 assert isinstance(tasks, list)
                 _write_state(state_path, state)
-                next_task = next(
-                    (task for task in tasks if task.get("state") == "PENDING"), None
-                )
+                next_task = next((task for task in tasks if task.get("state") == "PENDING"), None)
             if not next_task:
                 break
         next_task["state"] = "RUNNING"
         _write_state(state_path, state)
-        final_state, result = _run_task(
-            next_task, offer_id=offer_id, minutes=minutes, out_root=out_root
-        )
+        final_state, result = _run_task(next_task, offer_id=offer_id, minutes=minutes, out_root=out_root)
         _record(next_task, final_state, result)
-        steps.append(
-            {"task_id": next_task["task_id"], "state": final_state, "result": result}
-        )
+        steps.append({"task_id": next_task["task_id"], "state": final_state, "result": result})
         if final_state == "BLOCKED":
             break
         _write_state(state_path, state)
@@ -628,18 +638,10 @@ def run_continuous(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Generate the daily 20-minute SCBE cash sprint packet."
-    )
-    parser.add_argument(
-        "--offer", default="rotate", help="Offer ID to use, or 'rotate'."
-    )
-    parser.add_argument(
-        "--minutes", type=int, default=20, help="Execution budget in minutes."
-    )
-    parser.add_argument(
-        "--out-root", default=str(OUT_ROOT), help="Output directory root."
-    )
+    parser = argparse.ArgumentParser(description="Generate the daily 20-minute SCBE cash sprint packet.")
+    parser.add_argument("--offer", default="rotate", help="Offer ID to use, or 'rotate'.")
+    parser.add_argument("--minutes", type=int, default=20, help="Execution budget in minutes.")
+    parser.add_argument("--out-root", default=str(OUT_ROOT), help="Output directory root.")
     parser.add_argument(
         "--continuous",
         action="store_true",
@@ -680,9 +682,7 @@ def main() -> int:
         )
         print(json.dumps(result, indent=2))
         return 1 if int(result["blocked_count"]) else 0
-    paths = generate_packet(
-        offer_id=args.offer, minutes=args.minutes, out_root=out_root
-    )
+    paths = generate_packet(offer_id=args.offer, minutes=args.minutes, out_root=out_root)
     for name, path in paths.items():
         print(f"{name}={_safe_rel(path)}")
     return 0

--- a/scripts/system/create_tip_jar_stripe_link.py
+++ b/scripts/system/create_tip_jar_stripe_link.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Create a Stripe Payment Link for a small one-time AetherMoore support payment.
+
+This is the lowest-friction cash lane: someone can send a small one-time payment
+without choosing a subscription or buying consulting.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STRIPE_API = "https://api.stripe.com/v1"
+DEFAULT_LOOKUP_KEY = "aethermoore_tip_jar_5"
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def resolve_output(raw_path: str) -> Path:
+    target = (REPO_ROOT / raw_path).resolve()
+    artifacts_root = (REPO_ROOT / "artifacts").resolve()
+    if target != artifacts_root and artifacts_root not in target.parents:
+        raise ValueError("output path must stay under artifacts/")
+    return target
+
+
+def stripe_request(secret_key: str, method: str, path: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+    encoded = urllib.parse.urlencode(data or {}, doseq=True).encode("utf-8")
+    token = base64.b64encode(f"{secret_key}:".encode("utf-8")).decode("ascii")
+    req = urllib.request.Request(
+        STRIPE_API + path,
+        data=encoded if method.upper() == "POST" else None,
+        method=method.upper(),
+        headers={
+            "Authorization": f"Basic {token}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Stripe API error {exc.code}: {body[:500]}") from exc
+
+
+def search_price(secret_key: str, lookup_key: str) -> dict[str, Any] | None:
+    query = urllib.parse.quote(f"lookup_key:'{lookup_key}'")
+    result = stripe_request(secret_key, "GET", f"/prices/search?query={query}&limit=1")
+    rows = result.get("data", [])
+    return rows[0] if rows else None
+
+
+def create_product(secret_key: str) -> dict[str, Any]:
+    return stripe_request(
+        secret_key,
+        "POST",
+        "/products",
+        {
+            "name": "AetherMoore Tip Jar",
+            "description": "Small one-time support payment for AetherMoore and SCBE-AETHERMOORE work.",
+            "metadata[scbe_offer]": "tip_jar",
+        },
+    )
+
+
+def create_price(secret_key: str, product_id: str, lookup_key: str, amount_cents: int) -> dict[str, Any]:
+    return stripe_request(
+        secret_key,
+        "POST",
+        "/prices",
+        {
+            "currency": "usd",
+            "unit_amount": str(amount_cents),
+            "product": product_id,
+            "lookup_key": lookup_key,
+            "metadata[scbe_offer]": "tip_jar",
+        },
+    )
+
+
+def create_payment_link(secret_key: str, price_id: str) -> dict[str, Any]:
+    return stripe_request(
+        secret_key,
+        "POST",
+        "/payment_links",
+        {
+            "line_items[0][price]": price_id,
+            "line_items[0][quantity]": "1",
+            "after_completion[type]": "redirect",
+            "after_completion[redirect][url]": "https://aethermoore.com/supporter.html?status=tip-success",
+            "metadata[scbe_offer]": "tip_jar",
+        },
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create/reuse the AetherMoore $5 one-time tip Stripe link")
+    parser.add_argument("--lookup-key", default=DEFAULT_LOOKUP_KEY)
+    parser.add_argument("--amount-cents", type=int, default=500)
+    parser.add_argument("--output", default="artifacts/monetization/tip_jar_stripe_link.json")
+    args = parser.parse_args()
+
+    if args.amount_cents < 100:
+        raise SystemExit("amount-cents must be at least 100")
+
+    secret_key = os.getenv("STRIPE_SECRET_KEY", "").strip()
+    if not secret_key:
+        print("ERROR: STRIPE_SECRET_KEY is not set.", file=sys.stderr)
+        return 2
+
+    existing = search_price(secret_key, args.lookup_key)
+    if existing:
+        price = existing
+        created_product = None
+        created_price = False
+    else:
+        product = create_product(secret_key)
+        price = create_price(secret_key, product["id"], args.lookup_key, args.amount_cents)
+        created_product = product["id"]
+        created_price = True
+
+    link = create_payment_link(secret_key, price["id"])
+
+    out = {
+        "generated_at_utc": now_utc(),
+        "mode": "live" if secret_key.startswith("sk_live_") else "test_or_restricted",
+        "lookup_key": args.lookup_key,
+        "amount_cents": args.amount_cents,
+        "created_product_id": created_product,
+        "created_price": created_price,
+        "price_id": price["id"],
+        "payment_link_id": link["id"],
+        "payment_link_url": link["url"],
+    }
+    target = resolve_output(args.output)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(f"payment_link_url={link['url']}")
+    print(f"price_id={price['id']}")
+    print(f"artifact={target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/system/monetization_connector_push.py
+++ b/scripts/system/monetization_connector_push.py
@@ -31,9 +31,7 @@ from src.security.secret_store import get_secret
 
 try:
     from scripts.gumroad_publish import GumroadPublisher, PRODUCTS, STRIPE_LINKS
-except (
-    ModuleNotFoundError
-):  # pragma: no cover - depends on optional local sales tooling
+except ModuleNotFoundError:  # pragma: no cover - depends on optional local sales tooling
     GumroadPublisher = None
     PRODUCTS = {}
     STRIPE_LINKS = {}
@@ -54,6 +52,16 @@ class StaticOffer:
 
 
 STATIC_OFFERS: List[StaticOffer] = [
+    StaticOffer(
+        id="tip_jar",
+        name="AetherMoore Tip Jar",
+        sku="aethermoore-tip-jar-5",
+        price_usd=5.0,
+        stripe_url="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k",
+        tags=["tip", "one-time", "low-friction", "support"],
+        cadence="one_time",
+        proof_url="https://aethermoore.com/supporter.html",
+    ),
     StaticOffer(
         id="supporter_monthly",
         name="AetherMoore Supporter",
@@ -216,12 +224,8 @@ async def _dispatch(
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Push latest leads + offers to n8n/Zapier monetization connectors."
-    )
-    parser.add_argument(
-        "--leads-json", default="", help="Optional leads JSON file path."
-    )
+    parser = argparse.ArgumentParser(description="Push latest leads + offers to n8n/Zapier monetization connectors.")
+    parser.add_argument("--leads-json", default="", help="Optional leads JSON file path.")
     parser.add_argument(
         "--top-leads",
         type=int,
@@ -242,9 +246,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--no-route-zapier", dest="route_zapier", action="store_false")
     parser.set_defaults(route_zapier=True)
 
-    parser.add_argument(
-        "--dry-run", action="store_true", help="Do not send connector traffic."
-    )
+    parser.add_argument("--dry-run", action="store_true", help="Do not send connector traffic.")
     parser.add_argument(
         "--output-dir",
         default="artifacts/monetization",
@@ -258,11 +260,7 @@ def main() -> int:
     day = _utc_now().strftime("%Y%m%d")
     run_id = f"monetization-connector-push-{_utc_stamp()}"
 
-    lead_path = (
-        Path(args.leads_json).resolve()
-        if args.leads_json.strip()
-        else _latest_lead_file()
-    )
+    lead_path = Path(args.leads_json).resolve() if args.leads_json.strip() else _latest_lead_file()
     leads: List[Dict[str, Any]] = []
     if lead_path and lead_path.exists():
         loaded = _load_json(lead_path, default=[])

--- a/tests/revenue/test_daily_cash_sprint.py
+++ b/tests/revenue/test_daily_cash_sprint.py
@@ -52,6 +52,24 @@ def test_daily_cash_sprint_generates_governance_snapshot_offer(tmp_path: Path) -
     assert "$500-$500" not in markdown
 
 
+def test_daily_cash_sprint_generates_tip_jar_offer(tmp_path: Path) -> None:
+    paths = generate_packet(
+        offer_id="tip_jar",
+        minutes=10,
+        out_root=tmp_path,
+    )
+
+    report = json.loads(paths["json"].read_text(encoding="utf-8"))
+    assert report["offer"]["offer_id"] == "tip_jar"
+    assert report["offer"]["price_floor_usd"] == 5
+    assert report["offer"]["price_anchor_usd"] == 5
+    assert any("https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k" in draft["text"] for draft in report["outreach_drafts"])
+
+    markdown = paths["markdown"].read_text(encoding="utf-8")
+    assert "Price: $5\n" in markdown
+    assert "$5-$5" not in markdown
+
+
 def test_daily_cash_sprint_continuous_advances_to_next_task(tmp_path: Path) -> None:
     state_path = tmp_path / "state.json"
 

--- a/tests/system/test_monetization_connector_push.py
+++ b/tests/system/test_monetization_connector_push.py
@@ -7,6 +7,10 @@ def test_monetization_connector_push_includes_live_cash_offers() -> None:
     offers = _build_offers(include_gumroad=False)
     by_id = {offer["id"]: offer for offer in offers}
 
+    assert by_id["tip_jar"]["price_usd"] == 5.0
+    assert by_id["tip_jar"]["stripe_url"] == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+    assert by_id["tip_jar"]["cadence"] == "one_time"
+
     assert by_id["supporter_monthly"]["price_usd"] == 20.0
     assert by_id["supporter_monthly"]["stripe_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
     assert by_id["supporter_monthly"]["cadence"] == "monthly"


### PR DESCRIPTION
## Summary
- creates a live $5 one-time Stripe tip jar payment link for the lowest-friction cash lane
- publishes the tip link on the homepage, offers page, and supporter page
- adds the tip offer to the monetization connector payload
- adds `tip_jar` to the daily cash sprint generator with plain outreach drafts
- adds repeatable Stripe helper `scripts/system/create_tip_jar_stripe_link.py`

## Live checkout
- $5 one-time: https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k

## Test evidence
- `black --check --target-version py311 --line-length 120 src/ tests/` -> passed
- `ruff check src/ tests/` -> passed
- `python -m pytest tests/revenue/test_daily_cash_sprint.py tests/system/test_monetization_connector_push.py -q` -> 6 passed
- `python -m py_compile scripts/system/create_tip_jar_stripe_link.py scripts/system/monetization_connector_push.py scripts/revenue/daily_cash_sprint.py` -> passed
- HTML parser smoke: docs/index.html, docs/supporter.html, docs/offers/index.html ok
- connector dry-run emitted artifact with tip/supporter/snapshot offers

## Rollback
Revert this PR. It only changes website revenue links, local revenue scripts, connector offer payload, and focused tests.