### PR TITLE
feat(revenue): add remote offer config bridge

### DIFF
--- a/api/agent/app-config.js
+++ b/api/agent/app-config.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { sendJson, setCors } = require('../_agent_common');
+
+function readPublicJson(name) {
+  const target = path.join(process.cwd(), 'docs', name);
+  return JSON.parse(fs.readFileSync(target, 'utf8'));
+}
+
+module.exports = async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'GET') return sendJson(res, 405, { ok: false, error: 'GET required' });
+
+  res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=86400');
+  return sendJson(res, 200, {
+    ok: true,
+    source: 'docs/app-config.json',
+    ...readPublicJson('app-config.json'),
+  });
+};

--- a/api/agent/offers.js
+++ b/api/agent/offers.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { sendJson, setCors } = require('../_agent_common');
+
+function readPublicJson(name) {
+  const target = path.join(process.cwd(), 'docs', name);
+  return JSON.parse(fs.readFileSync(target, 'utf8'));
+}
+
+module.exports = async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'GET') return sendJson(res, 405, { ok: false, error: 'GET required' });
+
+  res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=86400');
+  return sendJson(res, 200, {
+    ok: true,
+    source: 'docs/offers.json',
+    ...readPublicJson('offers.json'),
+  });
+};

--- a/docs/app-config.json
+++ b/docs/app-config.json
@@ -1,0 +1,48 @@
+{
+  "schema": "aethermoor-bus-app-config-v1",
+  "updated_at": "2026-05-09",
+  "app": {
+    "name": "Aethermoor Bus",
+    "package_name": "io.aethermoor.bus",
+    "current_release": "0.1.0"
+  },
+  "remote_update": {
+    "supported": true,
+    "applies_to": [
+      "offer links",
+      "public copy",
+      "backend endpoints",
+      "feature flags",
+      "support and intake destinations"
+    ],
+    "requires_store_release": [
+      "package name",
+      "signing certificate",
+      "native permissions",
+      "native Android shell code",
+      "offline bundled assets"
+    ]
+  },
+  "endpoints": {
+    "site_home": "https://aethermoore.com/SCBE-AETHERMOORE/",
+    "offers_page": "https://aethermoore.com/SCBE-AETHERMOORE/offers/",
+    "supporter_page": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html",
+    "governance_snapshot_page": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
+    "offers_json": "https://aethermoore.com/SCBE-AETHERMOORE/offers.json",
+    "agent_bridge_health": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/health",
+    "agent_bridge_offers": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/offers",
+    "agent_bridge_app_config": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/app-config"
+  },
+  "features": {
+    "tip_jar": true,
+    "supporter_monthly": true,
+    "governance_snapshot": true,
+    "zero_key_agent_bus": true,
+    "local_download_storage": true,
+    "user_owned_cloud_storage": true
+  },
+  "fallbacks": {
+    "primary_offer": "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k",
+    "support_email": "aethermoregames@pm.me"
+  }
+}

--- a/docs/governance-snapshot.html
+++ b/docs/governance-snapshot.html
@@ -8,7 +8,7 @@
       name="description"
       content="A fixed-scope AI governance assessment for small teams that need an audit-ready findings memo and three practical fixes."
     />
-    <link rel="canonical" href="https://aethermoore.com/governance-snapshot.html" />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html" />
     <style>
       :root {
         --bg: #0f1217;

--- a/docs/offers.json
+++ b/docs/offers.json
@@ -1,0 +1,51 @@
+{
+  "schema": "aethermoore-offers-v1",
+  "updated_at": "2026-05-09",
+  "site_base": "https://aethermoore.com/SCBE-AETHERMOORE",
+  "offers": [
+    {
+      "id": "tip_jar",
+      "name": "Tip Jar",
+      "price_label": "$5 one time",
+      "type": "one_time",
+      "checkout_url": "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k",
+      "proof_url": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html",
+      "status": "live"
+    },
+    {
+      "id": "supporter_monthly",
+      "name": "AetherMoore Supporter",
+      "price_label": "$20/month",
+      "type": "subscription",
+      "checkout_url": "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i",
+      "proof_url": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html",
+      "status": "live"
+    },
+    {
+      "id": "governance_snapshot",
+      "name": "Governance Snapshot",
+      "price_label": "$500 fixed scope",
+      "type": "service",
+      "checkout_url": "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j",
+      "proof_url": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
+      "intake_url": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html#intake",
+      "status": "live"
+    },
+    {
+      "id": "toolkit",
+      "name": "SCBE Toolkit",
+      "price_label": "$29",
+      "type": "digital_download",
+      "checkout_url": "https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06",
+      "status": "live"
+    },
+    {
+      "id": "training_vault",
+      "name": "Training Vault",
+      "price_label": "$29",
+      "type": "digital_download",
+      "checkout_url": "https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g",
+      "status": "live"
+    }
+  ]
+}

--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SCBE Offers | AetherMoore</title>
   <meta name="description" content="Customer-ready SCBE offers, checkout links, and delivery/support paths.">
-  <link rel="canonical" href="https://aethermoore.com/offers/">
+  <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/offers/">
   <style>
     body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #0b0d12; color: #f2f0ea; line-height: 1.55; }
     main { width: min(980px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0; }
@@ -59,7 +59,8 @@
         <h2>AI Governance Snapshot</h2>
         <p>A fixed-scope review with a 2-page findings memo, three prioritized fixes, and a practical evidence checklist.</p>
         <div class="price">$500 one-time</div>
-        <a class="btn" href="../governance-snapshot.html">View Snapshot</a>
+        <a class="btn" href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j" target="_blank" rel="noopener">Buy Snapshot</a>
+        <a class="btn secondary" href="../governance-snapshot.html">View details</a>
       </article>
       <article class="card">
         <h2>Delivery or access help</h2>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -13,7 +13,7 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://aethermoore.com/offers/index.html</loc>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/offers/index.html</loc>
     <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/docs/supporter.html
+++ b/docs/supporter.html
@@ -8,7 +8,7 @@
       name="description"
       content="Support AetherMoore and receive monthly operator notes, early package updates, and a visible support route."
     />
-    <link rel="canonical" href="https://aethermoore.com/supporter.html" />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/supporter.html" />
     <style>
       :root {
         --bg: #101216;
@@ -207,7 +207,7 @@
       <section class="panel" aria-label="Join">
         <h2>Join with Stripe</h2>
         <p>
-          Use the direct Stripe checkout link, or enter your email to try the API checkout path.
+          Use the direct Stripe checkout link. Stripe collects the email at checkout.
         </p>
         <form id="supporter-form">
           <label for="email">Email</label>
@@ -236,8 +236,8 @@
           </div>
           <div class="status" id="status" role="status"></div>
           <p class="note">
-            If checkout is not configured yet, use the manual payment link. That keeps this lane
-            usable even before the full processor path is polished.
+            The button uses the same Stripe-hosted checkout as the direct link, so it does not
+            depend on the API bridge being online.
           </p>
         </form>
       </section>
@@ -247,28 +247,8 @@
       const statusEl = document.getElementById('status');
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
-        statusEl.textContent = 'Opening checkout...';
-        const email = document.getElementById('email').value.trim();
-        try {
-          const response = await fetch('https://api.aethermoore.com/v1/billing/public-checkout', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              email,
-              tier: 'SUPPORTER',
-              source: 'supporter-page',
-              success_url: 'https://aethermoore.com/supporter.html?status=success',
-              cancel_url: 'https://aethermoore.com/supporter.html?status=cancel',
-            }),
-          });
-          const data = await response.json();
-          if (!response.ok || !data.checkout_url) {
-            throw new Error(data.detail || data.error || 'Checkout is not configured yet.');
-          }
-          window.location.href = data.checkout_url;
-        } catch (err) {
-          statusEl.textContent = 'Checkout is not ready. Use the manual payment link button.';
-        }
+        statusEl.textContent = 'Opening Stripe checkout...';
+        window.location.href = 'https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i';
       });
     </script>
   </body>

--- a/scripts/revenue/daily_cash_sprint.py
+++ b/scripts/revenue/daily_cash_sprint.py
@@ -85,7 +85,7 @@ DEFAULT_OFFERS = [
             "docs/specs/IDENTIFIER_CANONICALITY_L13.md",
         ],
         call_to_action=(
-            "Buy the fixed checkout, then send the intake at https://aethermoore.com/governance-snapshot.html#intake. "
+            "Buy the fixed checkout, then send the intake at https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html#intake. "
             "Checkout link: "
             "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
         ),
@@ -174,7 +174,9 @@ def _path_status(paths: Iterable[str]) -> list[dict[str, object]]:
             {
                 "path": raw,
                 "exists": path.exists(),
-                "kind": ("dir" if path.is_dir() else "file" if path.is_file() else "missing"),
+                "kind": (
+                    "dir" if path.is_dir() else "file" if path.is_file() else "missing"
+                ),
             }
         )
     return rows
@@ -220,7 +222,9 @@ def _proof_snapshot() -> dict[str, object]:
     return {"checks": [_run_quick(cmd) for cmd in checks]}
 
 
-def _dispatch_bus_task(prompt: str, *, task_id: str, dry_run: bool = False) -> dict[str, object]:
+def _dispatch_bus_task(
+    prompt: str, *, task_id: str, dry_run: bool = False
+) -> dict[str, object]:
     """Route one real task through the local HYDRA free-LLM bus."""
 
     try:
@@ -271,8 +275,12 @@ def _select_offer(offer_id: str) -> Offer:
 
 
 def _price_label(offer: Offer | dict[str, object]) -> str:
-    floor = int(offer["price_floor_usd"] if isinstance(offer, dict) else offer.price_floor_usd)
-    anchor = int(offer["price_anchor_usd"] if isinstance(offer, dict) else offer.price_anchor_usd)
+    floor = int(
+        offer["price_floor_usd"] if isinstance(offer, dict) else offer.price_floor_usd
+    )
+    anchor = int(
+        offer["price_anchor_usd"] if isinstance(offer, dict) else offer.price_anchor_usd
+    )
     return f"${floor}" if floor == anchor else f"${floor}-${anchor}"
 
 
@@ -308,7 +316,10 @@ def _build_outreach(offer: Offer) -> list[dict[str, str]]:
                 ),
             },
         ]
-    base = f"I am offering a small {offer.title} sprint ({price}). " f"{offer.promise} {offer.call_to_action}"
+    base = (
+        f"I am offering a small {offer.title} sprint ({price}). "
+        f"{offer.promise} {offer.call_to_action}"
+    )
     return [
         {
             "channel": "dm_short",
@@ -321,7 +332,9 @@ def _build_outreach(offer: Offer) -> list[dict[str, str]]:
                 f"Hi,\n\n"
                 f"I am running a fixed-scope {offer.title} sprint for {offer.buyer}.\n\n"
                 f"Result: {offer.promise}\n\n"
-                f"Includes:\n" + "\n".join(f"- {item}" for item in offer.deliverables) + f"\n\nPrice: {price}.\n"
+                f"Includes:\n"
+                + "\n".join(f"- {item}" for item in offer.deliverables)
+                + f"\n\nPrice: {price}.\n"
                 f"{offer.call_to_action}\n\n"
                 f"- Issac"
             ),
@@ -378,7 +391,9 @@ def _markdown(report: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def generate_packet(*, offer_id: str, minutes: int, out_root: Path = OUT_ROOT) -> dict[str, Path]:
+def generate_packet(
+    *, offer_id: str, minutes: int, out_root: Path = OUT_ROOT
+) -> dict[str, Path]:
     offer = _select_offer(offer_id)
     date = datetime.now().strftime("%Y-%m-%d")
     out_dir = out_root / date
@@ -402,13 +417,18 @@ def generate_packet(*, offer_id: str, minutes: int, out_root: Path = OUT_ROOT) -
     json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
     md_path.write_text(_markdown(report), encoding="utf-8")
     queue_path.write_text(
-        "".join(json.dumps(row, ensure_ascii=True) + "\n" for row in report["outreach_drafts"]),
+        "".join(
+            json.dumps(row, ensure_ascii=True) + "\n"
+            for row in report["outreach_drafts"]
+        ),
         encoding="utf-8",
     )
     return {"json": json_path, "markdown": md_path, "queue": queue_path}
 
 
-def _task(task_id: str, kind: str, label: str, payload: dict[str, object]) -> dict[str, object]:
+def _task(
+    task_id: str, kind: str, label: str, payload: dict[str, object]
+) -> dict[str, object]:
     return {
         "task_id": task_id,
         "kind": kind,
@@ -502,7 +522,9 @@ def _write_state(state_path: Path, state: dict[str, object]) -> None:
     state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
 
 
-def _cycle_state(state: dict[str, object], *, offer_id: str, minutes: int, out_root: Path) -> dict[str, object]:
+def _cycle_state(
+    state: dict[str, object], *, offer_id: str, minutes: int, out_root: Path
+) -> dict[str, object]:
     tasks = state.get("tasks", [])
     assert isinstance(tasks, list)
     cycle_history = state.setdefault("cycle_history", [])
@@ -521,7 +543,9 @@ def _cycle_state(state: dict[str, object], *, offer_id: str, minutes: int, out_r
     return next_state
 
 
-def _record(task: dict[str, object], state: StateName, result: dict[str, object]) -> None:
+def _record(
+    task: dict[str, object], state: StateName, result: dict[str, object]
+) -> None:
     task["state"] = state
     task["attempts"] = int(task.get("attempts", 0)) + 1
     history = task.setdefault("history", [])
@@ -561,10 +585,14 @@ def _run_task(
         paths = generate_packet(offer_id=offer_id, minutes=minutes, out_root=out_root)
         return "DONE", {name: _safe_rel(path) for name, path in paths.items()}
     if kind == "bus_dispatch":
-        result = _dispatch_bus_task(str(payload["prompt"]), task_id=str(task["task_id"]))
+        result = _dispatch_bus_task(
+            str(payload["prompt"]), task_id=str(task["task_id"])
+        )
         return ("DONE" if result.get("status") == "ok" else "BLOCKED"), result
     if kind == "command":
-        result = _run_quick(list(payload["command"]), timeout=int(payload.get("timeout", 120)))
+        result = _run_quick(
+            list(payload["command"]), timeout=int(payload.get("timeout", 120))
+        )
         if result.get("returncode") == 0:
             return "DONE", result
         if bool(payload.get("nonblocking")):
@@ -604,21 +632,33 @@ def run_continuous(
     assert isinstance(tasks, list)
     steps: list[dict[str, object]] = []
     for _ in range(max_steps):
-        next_task = next((task for task in tasks if task.get("state") == "PENDING"), None)
+        next_task = next(
+            (task for task in tasks if task.get("state") == "PENDING"), None
+        )
         if not next_task:
-            if cycle_when_complete and not any(task.get("state") == "BLOCKED" for task in tasks):
-                state = _cycle_state(state, offer_id=offer_id, minutes=minutes, out_root=out_root)
+            if cycle_when_complete and not any(
+                task.get("state") == "BLOCKED" for task in tasks
+            ):
+                state = _cycle_state(
+                    state, offer_id=offer_id, minutes=minutes, out_root=out_root
+                )
                 tasks = state["tasks"]
                 assert isinstance(tasks, list)
                 _write_state(state_path, state)
-                next_task = next((task for task in tasks if task.get("state") == "PENDING"), None)
+                next_task = next(
+                    (task for task in tasks if task.get("state") == "PENDING"), None
+                )
             if not next_task:
                 break
         next_task["state"] = "RUNNING"
         _write_state(state_path, state)
-        final_state, result = _run_task(next_task, offer_id=offer_id, minutes=minutes, out_root=out_root)
+        final_state, result = _run_task(
+            next_task, offer_id=offer_id, minutes=minutes, out_root=out_root
+        )
         _record(next_task, final_state, result)
-        steps.append({"task_id": next_task["task_id"], "state": final_state, "result": result})
+        steps.append(
+            {"task_id": next_task["task_id"], "state": final_state, "result": result}
+        )
         if final_state == "BLOCKED":
             break
         _write_state(state_path, state)
@@ -638,10 +678,18 @@ def run_continuous(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Generate the daily 20-minute SCBE cash sprint packet.")
-    parser.add_argument("--offer", default="rotate", help="Offer ID to use, or 'rotate'.")
-    parser.add_argument("--minutes", type=int, default=20, help="Execution budget in minutes.")
-    parser.add_argument("--out-root", default=str(OUT_ROOT), help="Output directory root.")
+    parser = argparse.ArgumentParser(
+        description="Generate the daily 20-minute SCBE cash sprint packet."
+    )
+    parser.add_argument(
+        "--offer", default="rotate", help="Offer ID to use, or 'rotate'."
+    )
+    parser.add_argument(
+        "--minutes", type=int, default=20, help="Execution budget in minutes."
+    )
+    parser.add_argument(
+        "--out-root", default=str(OUT_ROOT), help="Output directory root."
+    )
     parser.add_argument(
         "--continuous",
         action="store_true",
@@ -682,7 +730,9 @@ def main() -> int:
         )
         print(json.dumps(result, indent=2))
         return 1 if int(result["blocked_count"]) else 0
-    paths = generate_packet(offer_id=args.offer, minutes=args.minutes, out_root=out_root)
+    paths = generate_packet(
+        offer_id=args.offer, minutes=args.minutes, out_root=out_root
+    )
     for name, path in paths.items():
         print(f"{name}={_safe_rel(path)}")
     return 0

--- a/scripts/system/create_governance_snapshot_stripe_link.py
+++ b/scripts/system/create_governance_snapshot_stripe_link.py
@@ -37,7 +37,9 @@ def resolve_output(raw_path: str) -> Path:
     return target
 
 
-def stripe_request(secret_key: str, method: str, path: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+def stripe_request(
+    secret_key: str, method: str, path: str, data: dict[str, Any] | None = None
+) -> dict[str, Any]:
     encoded = urllib.parse.urlencode(data or {}, doseq=True).encode("utf-8")
     token = base64.b64encode(f"{secret_key}:".encode("utf-8")).decode("ascii")
     req = urllib.request.Request(
@@ -101,16 +103,21 @@ def create_payment_link(secret_key: str, price_id: str) -> dict[str, Any]:
             "line_items[0][price]": price_id,
             "line_items[0][quantity]": "1",
             "after_completion[type]": "redirect",
-            "after_completion[redirect][url]": "https://aethermoore.com/governance-snapshot.html?status=success",
+            "after_completion[redirect][url]": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html?status=success",
             "metadata[scbe_offer]": "governance_snapshot",
         },
     )
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Create/reuse the AetherMoore $500 AI Governance Snapshot link")
+    parser = argparse.ArgumentParser(
+        description="Create/reuse the AetherMoore $500 AI Governance Snapshot link"
+    )
     parser.add_argument("--lookup-key", default=DEFAULT_LOOKUP_KEY)
-    parser.add_argument("--output", default="artifacts/monetization/governance_snapshot_stripe_link.json")
+    parser.add_argument(
+        "--output",
+        default="artifacts/monetization/governance_snapshot_stripe_link.json",
+    )
     args = parser.parse_args()
 
     secret_key = os.getenv("STRIPE_SECRET_KEY", "").strip()

--- a/scripts/system/create_supporter_stripe_link.py
+++ b/scripts/system/create_supporter_stripe_link.py
@@ -37,7 +37,9 @@ def resolve_output(raw_path: str) -> Path:
     return target
 
 
-def stripe_request(secret_key: str, method: str, path: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+def stripe_request(
+    secret_key: str, method: str, path: str, data: dict[str, Any] | None = None
+) -> dict[str, Any]:
     encoded = urllib.parse.urlencode(data or {}, doseq=True).encode("utf-8")
     token = base64.b64encode(f"{secret_key}:".encode("utf-8")).decode("ascii")
     req = urllib.request.Request(
@@ -104,7 +106,7 @@ def create_payment_link(secret_key: str, price_id: str) -> dict[str, Any]:
             "line_items[0][price]": price_id,
             "line_items[0][quantity]": "1",
             "after_completion[type]": "redirect",
-            "after_completion[redirect][url]": "https://aethermoore.com/supporter.html?status=success",
+            "after_completion[redirect][url]": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html?status=success",
             "metadata[scbe_tier]": "SUPPORTER",
             "metadata[scbe_offer]": "supporter_monthly",
         },
@@ -112,9 +114,13 @@ def create_payment_link(secret_key: str, price_id: str) -> dict[str, Any]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Create/reuse the AetherMoore $20/month SUPPORTER Stripe link")
+    parser = argparse.ArgumentParser(
+        description="Create/reuse the AetherMoore $20/month SUPPORTER Stripe link"
+    )
     parser.add_argument("--lookup-key", default=DEFAULT_LOOKUP_KEY)
-    parser.add_argument("--output", default="artifacts/monetization/supporter_stripe_link.json")
+    parser.add_argument(
+        "--output", default="artifacts/monetization/supporter_stripe_link.json"
+    )
     args = parser.parse_args()
 
     secret_key = os.getenv("STRIPE_SECRET_KEY", "").strip()

--- a/scripts/system/create_tip_jar_stripe_link.py
+++ b/scripts/system/create_tip_jar_stripe_link.py
@@ -36,7 +36,9 @@ def resolve_output(raw_path: str) -> Path:
     return target
 
 
-def stripe_request(secret_key: str, method: str, path: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+def stripe_request(
+    secret_key: str, method: str, path: str, data: dict[str, Any] | None = None
+) -> dict[str, Any]:
     encoded = urllib.parse.urlencode(data or {}, doseq=True).encode("utf-8")
     token = base64.b64encode(f"{secret_key}:".encode("utf-8")).decode("ascii")
     req = urllib.request.Request(
@@ -76,7 +78,9 @@ def create_product(secret_key: str) -> dict[str, Any]:
     )
 
 
-def create_price(secret_key: str, product_id: str, lookup_key: str, amount_cents: int) -> dict[str, Any]:
+def create_price(
+    secret_key: str, product_id: str, lookup_key: str, amount_cents: int
+) -> dict[str, Any]:
     return stripe_request(
         secret_key,
         "POST",
@@ -100,17 +104,21 @@ def create_payment_link(secret_key: str, price_id: str) -> dict[str, Any]:
             "line_items[0][price]": price_id,
             "line_items[0][quantity]": "1",
             "after_completion[type]": "redirect",
-            "after_completion[redirect][url]": "https://aethermoore.com/supporter.html?status=tip-success",
+            "after_completion[redirect][url]": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html?status=tip-success",
             "metadata[scbe_offer]": "tip_jar",
         },
     )
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Create/reuse the AetherMoore $5 one-time tip Stripe link")
+    parser = argparse.ArgumentParser(
+        description="Create/reuse the AetherMoore $5 one-time tip Stripe link"
+    )
     parser.add_argument("--lookup-key", default=DEFAULT_LOOKUP_KEY)
     parser.add_argument("--amount-cents", type=int, default=500)
-    parser.add_argument("--output", default="artifacts/monetization/tip_jar_stripe_link.json")
+    parser.add_argument(
+        "--output", default="artifacts/monetization/tip_jar_stripe_link.json"
+    )
     args = parser.parse_args()
 
     if args.amount_cents < 100:
@@ -128,7 +136,9 @@ def main() -> int:
         created_price = False
     else:
         product = create_product(secret_key)
-        price = create_price(secret_key, product["id"], args.lookup_key, args.amount_cents)
+        price = create_price(
+            secret_key, product["id"], args.lookup_key, args.amount_cents
+        )
         created_product = product["id"]
         created_price = True
 

--- a/scripts/system/monetization_connector_push.py
+++ b/scripts/system/monetization_connector_push.py
@@ -31,7 +31,9 @@ from src.security.secret_store import get_secret
 
 try:
     from scripts.gumroad_publish import GumroadPublisher, PRODUCTS, STRIPE_LINKS
-except ModuleNotFoundError:  # pragma: no cover - depends on optional local sales tooling
+except (
+    ModuleNotFoundError
+):  # pragma: no cover - depends on optional local sales tooling
     GumroadPublisher = None
     PRODUCTS = {}
     STRIPE_LINKS = {}
@@ -60,7 +62,7 @@ STATIC_OFFERS: List[StaticOffer] = [
         stripe_url="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k",
         tags=["tip", "one-time", "low-friction", "support"],
         cadence="one_time",
-        proof_url="https://aethermoore.com/supporter.html",
+        proof_url="https://aethermoore.com/SCBE-AETHERMOORE/supporter.html",
     ),
     StaticOffer(
         id="supporter_monthly",
@@ -70,7 +72,7 @@ STATIC_OFFERS: List[StaticOffer] = [
         stripe_url="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i",
         tags=["supporter", "subscription", "operator-notes"],
         cadence="monthly",
-        proof_url="https://aethermoore.com/supporter.html",
+        proof_url="https://aethermoore.com/SCBE-AETHERMOORE/supporter.html",
     ),
     StaticOffer(
         id="governance_snapshot",
@@ -80,8 +82,8 @@ STATIC_OFFERS: List[StaticOffer] = [
         stripe_url="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j",
         tags=["consulting", "governance", "fixed-scope", "cash-sprint"],
         cadence="one_time",
-        proof_url="https://aethermoore.com/governance-snapshot.html",
-        intake_url="https://aethermoore.com/governance-snapshot.html#intake",
+        proof_url="https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
+        intake_url="https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html#intake",
         fulfillment_command=(
             "python scripts/revenue/governance_snapshot_intake.py "
             "--buyer-email <buyer-email> --workflow-name <workflow-name>"
@@ -224,8 +226,12 @@ async def _dispatch(
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Push latest leads + offers to n8n/Zapier monetization connectors.")
-    parser.add_argument("--leads-json", default="", help="Optional leads JSON file path.")
+    parser = argparse.ArgumentParser(
+        description="Push latest leads + offers to n8n/Zapier monetization connectors."
+    )
+    parser.add_argument(
+        "--leads-json", default="", help="Optional leads JSON file path."
+    )
     parser.add_argument(
         "--top-leads",
         type=int,
@@ -246,7 +252,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--no-route-zapier", dest="route_zapier", action="store_false")
     parser.set_defaults(route_zapier=True)
 
-    parser.add_argument("--dry-run", action="store_true", help="Do not send connector traffic.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Do not send connector traffic."
+    )
     parser.add_argument(
         "--output-dir",
         default="artifacts/monetization",
@@ -260,7 +268,11 @@ def main() -> int:
     day = _utc_now().strftime("%Y%m%d")
     run_id = f"monetization-connector-push-{_utc_stamp()}"
 
-    lead_path = Path(args.leads_json).resolve() if args.leads_json.strip() else _latest_lead_file()
+    lead_path = (
+        Path(args.leads_json).resolve()
+        if args.leads_json.strip()
+        else _latest_lead_file()
+    )
     leads: List[Dict[str, Any]] = []
     if lead_path and lead_path.exists():
         loaded = _load_json(lead_path, default=[])

--- a/tests/system/test_monetization_connector_push.py
+++ b/tests/system/test_monetization_connector_push.py
@@ -8,15 +8,30 @@ def test_monetization_connector_push_includes_live_cash_offers() -> None:
     by_id = {offer["id"]: offer for offer in offers}
 
     assert by_id["tip_jar"]["price_usd"] == 5.0
-    assert by_id["tip_jar"]["stripe_url"] == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+    assert (
+        by_id["tip_jar"]["stripe_url"]
+        == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+    )
     assert by_id["tip_jar"]["cadence"] == "one_time"
 
     assert by_id["supporter_monthly"]["price_usd"] == 20.0
-    assert by_id["supporter_monthly"]["stripe_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    assert (
+        by_id["supporter_monthly"]["stripe_url"]
+        == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    )
     assert by_id["supporter_monthly"]["cadence"] == "monthly"
 
     assert by_id["governance_snapshot"]["price_usd"] == 500.0
-    assert by_id["governance_snapshot"]["stripe_url"] == "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+    assert (
+        by_id["governance_snapshot"]["stripe_url"]
+        == "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+    )
     assert by_id["governance_snapshot"]["cadence"] == "one_time"
-    assert by_id["governance_snapshot"]["intake_url"] == "https://aethermoore.com/governance-snapshot.html#intake"
-    assert "governance_snapshot_intake.py" in by_id["governance_snapshot"]["fulfillment_command"]
+    assert (
+        by_id["governance_snapshot"]["intake_url"]
+        == "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html#intake"
+    )
+    assert (
+        "governance_snapshot_intake.py"
+        in by_id["governance_snapshot"]["fulfillment_command"]
+    )

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -43,3 +43,57 @@ def test_download_bridge_serves_private_blob_with_delivery_token() -> None:
     assert "product must be toolkit or vault" in source
     assert "Content-Disposition" in source
     assert 'Cache-Control", "private, no-store"' in source
+
+
+def test_public_offer_catalog_has_live_revenue_links() -> None:
+    offers = json.loads(
+        (REPO_ROOT / "docs" / "offers.json").read_text(encoding="utf-8")
+    )
+    by_id = {offer["id"]: offer for offer in offers["offers"]}
+
+    assert offers["schema"] == "aethermoore-offers-v1"
+    assert (
+        by_id["tip_jar"]["checkout_url"]
+        == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+    )
+    assert (
+        by_id["supporter_monthly"]["checkout_url"]
+        == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    )
+    assert by_id["governance_snapshot"]["intake_url"].endswith(
+        "/governance-snapshot.html#intake"
+    )
+
+
+def test_public_app_config_explains_remote_update_boundary() -> None:
+    config = json.loads(
+        (REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8")
+    )
+
+    assert config["schema"] == "aethermoor-bus-app-config-v1"
+    assert config["app"]["package_name"] == "io.aethermoor.bus"
+    assert config["remote_update"]["supported"] is True
+    assert "offer links" in config["remote_update"]["applies_to"]
+    assert "package name" in config["remote_update"]["requires_store_release"]
+    assert config["features"]["tip_jar"] is True
+
+
+def test_supporter_page_uses_direct_stripe_checkout_not_broken_api_bridge() -> None:
+    page = (REPO_ROOT / "docs" / "supporter.html").read_text(encoding="utf-8")
+
+    assert "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i" in page
+    assert "https://api.aethermoore.com/v1/billing/public-checkout" not in page
+
+
+def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:
+    offers_source = (REPO_ROOT / "api" / "agent" / "offers.js").read_text(
+        encoding="utf-8"
+    )
+    app_config_source = (REPO_ROOT / "api" / "agent" / "app-config.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert "docs/offers.json" in offers_source
+    assert "s-maxage=300" in offers_source
+    assert "docs/app-config.json" in app_config_source
+    assert "s-maxage=300" in app_config_source


### PR DESCRIPTION
## Summary
- add public offer and app config JSON for remote web/mobile clients
- expose the same payloads through the Vercel agent bridge at /api/agent/offers and /api/agent/app-config
- fix revenue URLs to the live GitHub Pages subpath and bypass the broken api.aethermoore.com checkout call on the supporter page

## Test evidence
- python -m pytest tests/test_vercel_launch_bridge.py tests/system/test_monetization_connector_push.py tests/revenue/test_daily_cash_sprint.py -q
- python -m black --check scripts/revenue/daily_cash_sprint.py scripts/system/create_governance_snapshot_stripe_link.py scripts/system/create_supporter_stripe_link.py scripts/system/create_tip_jar_stripe_link.py scripts/system/monetization_connector_push.py tests/system/test_monetization_connector_push.py tests/test_vercel_launch_bridge.py
- node smoke for api/agent/offers.js and api/agent/app-config.js

## Notes
- App-store remote update boundary is now encoded in docs/app-config.json: links/flags/endpoints can update remotely; native package/signing/permissions still require a store release.
