### PR TITLE
feat(business): cold outreach + AI safety job apps

### DIFF
--- a/docs/business/AI_SAFETY_JOB_APPLICATIONS_2026_05_09.md
+++ b/docs/business/AI_SAFETY_JOB_APPLICATIONS_2026_05_09.md
@@ -1,0 +1,382 @@
+# AI safety job applications — 2026-05-09
+
+Three pre-filled application packages: Anthropic, Apollo Research, METR.
+Designed to be copy-paste-able into web application forms with minimal editing.
+
+**Realistic timing:** application → first-round interview is 1–3 weeks; full loop to offer is 4–8 weeks; first paycheck typically 2–4 weeks after start. So total time to first money is **6–12 weeks**.
+
+**Why this is worth it even with that timeline:**
+- $200K–$400K base salary range for these roles
+- Contractor / part-time options often available — much faster start
+- Even one interview loop generates real feedback you can apply to other applications
+- Anthropic/Apollo/METR have all publicly stated they're under-staffed for AI safety; demand exceeds supply
+
+---
+
+## Master resume content (paste into any application)
+
+### Identity
+
+```
+Issac D. Davis
+Port Angeles, WA · (360) 808-0876 · issdandavis7795@gmail.com
+GitHub: https://github.com/issdandavis · LinkedIn: [TO FILL]
+Site: https://aethermoore.com · Hire: https://aethermoore.com/hire
+```
+
+### Headline
+
+```
+Independent AI safety engineer · Federal-registered (SAM UEI J4NXHM6N5F59)
+Built and shipped a 14-layer governance pipeline grounded in hyperbolic
+geometry; open-source on npm/PyPI; US Provisional Patent 63/961,403
+```
+
+### Highlights (bullet form — pick 4–6 per application)
+
+```
+- Built SCBE-AETHERMOORE solo: 14-layer AI governance pipeline using the
+  Poincaré ball model of hyperbolic space, MIT-licensed, open-sourced on
+  npm (`scbe-aethermoore`) and PyPI (`scbe-agent-bus`)
+
+- 180/180 cross-lane structural decoding gate (Wilson CI [0.979, 1.0]);
+  173/173 Petri training_blocked when SCBE wired as the enforcement layer
+  behind Anthropic's audit tool
+
+- Two L13 governance overlays in production behind feature flags: bijective
+  tamper detection (catches code-injection via lossy round-trip transforms)
+  and identifier canonicality (catches Unicode homoglyph + invisible-char +
+  mixed-script attacks); 218/218 governance regression suite green
+
+- Five-axiom mesh implementation (unitarity, locality, causality, symmetry,
+  composition) across 14 layers; Python reference + TypeScript canonical;
+  comprehensive cross-language parity tests
+
+- Independently derived Lyapunov, control-barrier-function, port-Hamiltonian,
+  and persistence-of-excitation formulations of governance dynamics; verified
+  against the existing applied-mathematics literature post-derivation
+
+- US Provisional Patent No. 63/961,403 covering hyperbolic governance substrate;
+  non-exclusive licensing available to research collaborators
+
+- SAM.gov-registered minority-owned small business; two DARPA proposals in
+  active evaluation (CLARA FP-033 decision 2026-06-16; MATHBAC abstract
+  submitted 2026-04-27); APEX Accelerator partnership
+
+- Post-quantum cryptography throughout: ML-KEM-768, ML-DSA-65, AES-256-GCM;
+  migration-tested across liboqs 0.14→0.15 algorithm renames
+
+- Self-taught; no academic affiliation; full technical depth from working
+  artifacts, not pedigree
+```
+
+### Skills (paste verbatim or trim)
+
+```
+Languages: TypeScript (canonical), Python, Rust (experimental)
+ML/AI: HuggingFace ecosystem, LoRA/QLoRA fine-tuning, vLLM, constrained decoding
+Safety: governance overlay design, adversarial-cost manifolds, formal axioms
+Crypto: post-quantum (ML-KEM, ML-DSA), AES-GCM envelopes, hyperbolic substrates
+Infra: Docker, Kubernetes, multi-cloud (AWS/GCP/Azure deployment configs)
+Federal: SAM.gov, NAICS coverage (541511, 541512, 541519, 541611, 541690,
+         541715, 611430), FAR 9.5 awareness, DARPA proposal experience
+```
+
+---
+
+## 1. Anthropic Application Package
+
+### Position to apply for
+
+Primary: **Member of Technical Staff, Alignment Research** (or Research Engineer if MTS unavailable)
+Secondary fallback: **Contractor — Petri / Audit Tooling**
+
+URL to verify openings: https://www.anthropic.com/careers
+
+### Cover letter (long form)
+
+```
+Dear Anthropic team,
+
+I'm Issac Davis, an independent AI safety engineer applying for the Member
+of Technical Staff role on the Alignment Research team.
+
+I've spent three years building SCBE-AETHERMOORE, a 14-layer AI governance
+pipeline grounded in hyperbolic geometry. The substrate composes directly
+with Petri: when I wire SCBE as the enforcement layer behind Petri's audit
+tool, I get 173/173 training_blocked across the full seed set, with regex
+pre-filter reducing residual false-allows from 2.31% to 0.58%. The result
+is published in my open-source repository and is bit-reproducible.
+
+Why this is interesting for Anthropic specifically:
+
+(1) Petri measures unsafe behavior across 36 dimensions but does not block
+it. SCBE is the natural enforcement complement — and the composition is
+already validated. This is an immediate force multiplier on Petri's value
+to the alignment community without requiring Petri's own roadmap to change.
+
+(2) The substrate is closed-form algebra, not learned filtering. The harmonic
+wall H(d, pd) = 1/(1 + φ·d_H + 2·pd) cannot be "trained around" because it
+is not a parameter. This is the kind of property formal-methods work can
+verify, and the kind of guarantee Anthropic's policy/safety teams need
+when arguing for production deployment of frontier models.
+
+(3) I'm SAM.gov-registered with two DARPA proposals in active evaluation
+(CLARA FP-033 decision 2026-06-16; MATHBAC abstract submitted). The
+federal pipeline matters because Anthropic's federal customer interest
+will accelerate, and an alignment researcher who can simultaneously
+operate in that compliance environment is rare.
+
+What I bring beyond the SCBE work:
+
+- Independently derived Lyapunov, control-barrier-function, port-Hamiltonian,
+  and persistence-of-excitation formulations of governance dynamics, then
+  verified against published math; this is unconventional but indicates
+  depth, not naïveté.
+
+- Two production L13 overlays (bijective tamper, identifier canonicality)
+  catching code-injection and Unicode-homoglyph attacks; 218/218 regression
+  suite green.
+
+- Self-taught, no academic affiliation. The work itself is the credential.
+
+I'd welcome consideration for full-time MTS, Research Engineer, or a
+contractor engagement focused on Petri-adjacent infrastructure. I can
+relocate to SF or work remote from Port Angeles, WA, depending on team
+preference.
+
+Code: https://github.com/issdandavis/SCBE-AETHERMOORE
+Site: https://aethermoore.com
+
+Thank you for your time.
+
+Issac D. Davis
+```
+
+### Sample essay answers (Anthropic asks 1–2)
+
+**Q: Why are you interested in working at Anthropic?**
+
+```
+Petri is the cleanest piece of public AI safety infrastructure shipped in
+the last two years. It's open-source, it's reproducible, it composes with
+external work (mine being one example: 173/173 training_blocked when SCBE
+governance is wired behind it). That posture — ship the science, accept
+external composition, publish the seeds — is exactly the engineering
+culture I want to work inside.
+
+I'm also interested in the policy-team interface. Anthropic publishes
+position papers that meaningfully move how the federal government thinks
+about AI risk. As an SAM-registered researcher with two DARPA proposals
+in active evaluation, I have direct working knowledge of the agencies
+that consume those papers. That's a useful lateral-thinking input for
+internal policy work.
+
+Last: alignment research is currently bottlenecked on people who can
+both write rigorous evaluation harnesses AND ship the production code
+that uses them. I've been doing both solo for three years. I want to
+do it on a team.
+```
+
+**Q: Describe a recent technical project.**
+
+```
+Most recent: a three-state verdict gate for the Sacred Egg cryptographic
+ring-pair PUF (physical unclonable function) authentication harness. The
+substrate uses hyperbolic geometry to derive a hash that's continuously
+deformable under valid challenge-response pairs but discontinuous under
+adversarial substitution.
+
+The technical problem: a binary "is this an authentic challenge response?"
+verdict was being read by downstream consumers as if geometric separation
+implied authentication-grade security. It does not — geometric separation
+is necessary but not sufficient; you also need an entropy floor (NIST
+SP 800-63B specifies 64 effective bits for authentication). I introduced
+a three-state verdict (auth_candidate / separation_only_low_entropy /
+overlap_or_unproven) with corresponding exit codes (0/3/2) so downstream
+consumers cannot conflate the two properties.
+
+Shipped 2026-05-09 as PR #1469: 7 unit tests, three-branch CLI flag
+(--min-entropy-bits, default 64), documented in
+docs/specs/SACRED_EGG_CRP_PUF_HARNESS.md.
+
+The lesson generalizes: any safety property that has both a necessary
+condition (separation) and a sufficient condition (entropy) needs a
+three-state verdict, not a boolean. A lot of governance code conflates
+them and loses the ability to surface the distinction to downstream
+consumers.
+```
+
+---
+
+## 2. Apollo Research Application Package
+
+### Position
+
+**Research Engineer** or **Software Engineer**
+
+URL: https://www.apolloresearch.ai/careers
+
+### Cover letter
+
+```
+Dear Apollo Research team,
+
+I'm applying for the Research Engineer role.
+
+Apollo's focus on dangerous-capability evaluation, scheming behavior, and
+production-relevant AI risk maps directly to two governance overlays I've
+shipped in production:
+
+(1) Bijective tamper detection — catches code-injection attacks that rely
+on lossy round-trip transforms. When an LLM-generated code packet round-trips
+through a serializer/deserializer chain and the result diverges from the
+original, the divergence is the attack signature. Wired into SCBE's L13
+governance layer behind a feature flag; 218/218 regression suite green.
+
+(2) Identifier canonicality — catches Unicode homoglyph attacks (Cyrillic
+"а" instead of Latin "a"), invisible-character attacks (zero-width joiners),
+and mixed-script attacks (Latin/Cyrillic interleaved). All three are common
+in adversarial code generation; SCBE catches them at the identifier level
+before runtime gets a chance to be confused.
+
+Both overlays are sitting on top of a 14-layer pipeline that uses hyperbolic
+geometry as the substrate. The harmonic wall H(d, pd) = 1/(1 + φ·d_H + 2·pd)
+makes adversarial cost scale exponentially with semantic distance from the
+safe operating manifold — closed-form algebra, not learned filtering, so
+attacks cannot be "trained around" because they are not parameters.
+
+Public artifacts:
+- npm: scbe-aethermoore
+- PyPI: scbe-agent-bus
+- US Provisional Patent 63/961,403
+- 180/180 cross-lane structural decoding gate (Wilson CI [0.979, 1.0])
+- 173/173 Petri training_blocked when wired as enforcement behind Petri
+
+Available for full-time, contractor, or scoped collaboration. Remote
+from Port Angeles, WA preferred but flexible.
+
+Code: https://github.com/issdandavis/SCBE-AETHERMOORE
+Site: https://aethermoore.com
+
+Issac D. Davis
+```
+
+### Sample technical sample (if Apollo asks for one)
+
+Point them at:
+- The bijective tamper module: `src/governance/bijective_tamper.py`
+- The identifier canonicality module: `src/governance/identifier_canonicality.py`
+- The L13 wireup: `src/governance/runtime_gate.py`
+- The 218-test governance suite: `tests/governance/`
+
+These are MIT-licensed and runnable today.
+
+---
+
+## 3. METR Application Package
+
+### Position
+
+**Research Engineer** or **Technical Staff**
+
+URL: https://metr.org/job-application
+
+### Cover letter
+
+```
+Dear METR team,
+
+I'm applying for the Research Engineer role.
+
+METR's empirical evaluation of frontier-model risks is the most consequential
+public-good infrastructure in AI safety today. I've been building adjacent
+work and would like to bring it into a focused team setting.
+
+Specifically: a public benchmark suite ("TAIBS" — Trustworthy-AI Benchmark
+Suite) that measures cost-of-attack as a first-class trust metric, distinct
+from existing detection-only audits. The proposal is currently being
+finalized for Schmidt Sciences funding (2026-05-17 deadline) but the
+substrate already exists:
+
+- 180/180 cross-lane structural decoding adherence (Wilson CI [0.979, 1.0])
+- 173/173 Petri composition (Anthropic's tool used as detection layer with
+  SCBE as enforcement layer)
+- Two L13 governance overlays with 218/218 regression suite green
+- Five-axiom formal mesh ready for Coq/Lean formalization
+
+The substrate is open-source (npm scbe-aethermoore, PyPI scbe-agent-bus,
+MIT-licensed). The benchmark concept is what I want to develop with METR's
+evaluation expertise applied.
+
+Beyond TAIBS: I'm comfortable with capability-elicitation protocols,
+red-team automation, and the production engineering needed to make
+evaluation infrastructure reliable enough that other labs trust the
+results.
+
+I'm SAM.gov-registered (UEI J4NXHM6N5F59) with two DARPA proposals in
+active evaluation. Self-taught, no academic affiliation. Available for
+full-time, contractor, or a scoped collaboration.
+
+Code: https://github.com/issdandavis/SCBE-AETHERMOORE
+Site: https://aethermoore.com
+
+Issac D. Davis
+Port Angeles, WA
+```
+
+---
+
+## How to actually ship these applications
+
+1. **Anthropic first.** Largest funnel, most roles open, fastest first-response.
+2. **Apollo and METR same day** — they review weekly, so missing a Friday means waiting 7 days.
+3. **For all three: do not wait for Schmidt's outcome before applying.** Even if Schmidt funds, having an Anthropic / Apollo / METR offer in hand strengthens negotiating position.
+4. **Save responses to a single file** so you can compare interview feedback across the three.
+
+### When you get an interview
+
+- They will ask: "Why didn't you go to grad school?" Answer: "I built the work the field needs without it. The work itself is the credential."
+- They will ask: "How do you stay current on AI safety research?" Answer: name the actual papers/reports you've read recently. Pulling from memory: Anthropic's Petri paper (cite the technical report directly), DARPA MRC program reports, Sala et al. 2018 hyperbolic representation tradeoffs, Nickel & Kiela 2017 Poincaré embeddings.
+- They will ask: "What's a project you wish you'd done differently?" Answer (honest): the Bijective Tongue Coder v1 — you trained an adapter to 98% accuracy on a benchmark that turned out to be overfittable to format rather than semantics. The lesson (data-curation bias > model capacity) drove the v6 → v8-pre redesign. That's a real answer with a real lesson.
+
+### What NOT to do in interviews
+
+- Don't claim the formal proof (Coq) is done. It's the Aim 1 of a proposal, not yet a result.
+- Don't oversell the R^(d²) cost-bound. It's conjectured, not yet proved.
+- Don't pretend academic familiarity you don't have. "I'm self-taught and the work is the proof" is stronger than "I read [X paper]" if you can't discuss the paper in technical depth.
+
+---
+
+## Realistic conversion math
+
+5 applications submitted (Anthropic + Apollo + METR + ARC + Goodfire AI):
+- 2 will get no response (normal for unconventional candidates)
+- 2 will get a polite "thanks, not a fit" (normal)
+- 1 will get a screening call → that's your conversion
+
+Screening call → first interview: 50%
+First interview → full loop: 30%
+Full loop → offer: 60%
+
+Net: 5 applications → 0.045 offers = expected ~0.05 offer per round of 5.
+
+So: send 20 applications across the AI safety lab landscape (the 5 above
+plus FAR.ai, Constellation, Lakera, Patronus, Robust Intelligence, etc.)
+and expect ~0.2 offers in the first 8-week cycle. Continue for two
+cycles and the offer rate compounds because (a) you get interview
+practice, (b) your portfolio grows as you keep shipping SCBE work,
+(c) referrals start arriving from friendly rejections.
+
+**This is not a fast money path. But it's a real money path with a
+realistic ceiling of $300K+ base salary.**
+
+---
+
+## OPSEC
+
+- All cover letters above are MIT-license-compatible (no proprietary disclosure)
+- Do not name DAVA / Collin Hoag in any application (private teaming until awarded)
+- Do not reference CLARA proposal contents (FAR 9.5)
+- Do mention "two DARPA proposals in active evaluation" — that's public-facing signal
+- Use issdandavis7795@gmail.com as the contact email; do not use a phone number that's tied to the Wendy's job (employer interference risk if they call to verify)

--- a/docs/business/COLD_OUTREACH_PACKET_2026_05_09.md
+++ b/docs/business/COLD_OUTREACH_PACKET_2026_05_09.md
@@ -1,0 +1,258 @@
+# Cold outreach packet — 2026-05-09
+
+**Goal:** real money in 2–8 weeks via consulting / contractor / subcontract conversations.
+**Mode:** direct cold email + LinkedIn message. No "let's grab coffee", just specific asks.
+
+---
+
+## How to use this packet
+
+1. Copy the relevant template into your email client.
+2. **Verify the recipient's current title and email before sending** — people change jobs every 12–18 months in this market. Use LinkedIn to confirm or get a recent contact via their company's `team` page.
+3. Send between 7am–10am Pacific in their local time zone (highest open rate).
+4. **One per company per week.** Don't shotgun. Quality > volume. If they reply, follow up same day.
+5. Track responses in a spreadsheet. If no response in 7 days, ONE polite follow-up. Then drop.
+
+---
+
+## Tier 1 — AI safety labs (highest fit, contractor + research roles)
+
+These labs hire continuously and have publicly stated they're under-staffed for AI safety research and engineering. Contractor rates $200–$400/hr are common.
+
+### 1. Anthropic — Research Engineer / Member of Technical Staff
+
+- **URL to verify openings:** https://www.anthropic.com/careers
+- **Likely contact for Alignment team:** Jared Kaplan (co-founder, leads alignment research direction). Email format unknown — apply through portal.
+- **Why this fit:** SCBE composes with Petri (their open-source auditing tool); your work is detection-tool-friendly enforcement, exactly what they need.
+
+**Cover letter (paste into application):**
+
+```
+Hi Anthropic team,
+
+I'm Issac Davis. I've spent the last three years building SCBE-AETHERMOORE,
+a 14-layer AI governance pipeline grounded in hyperbolic geometry. The
+substrate composes with Petri — when I wire it as the enforcement layer
+behind your audit tool, I get 173/173 training_blocked across the full
+seed set, with regex pre-filter reducing residual false-allows from
+2.31% to 0.58%.
+
+I work solo, MIT-license everything, and have shipped:
+- npm: scbe-aethermoore (the 14-layer pipeline)
+- PyPI: scbe-agent-bus (governance overlay primitives)
+- US Provisional Patent 63/961,403 (hyperbolic cost-bound)
+- 180/180 constrained-decoding gate, Wilson CI [0.979, 1.0]
+
+I'm SAM.gov registered (UEI J4NXHM6N5F59) with two DARPA proposals in
+active evaluation. I'd love to be considered for the Alignment Research
+Engineer role, or a contractor engagement on Petri-adjacent work if
+that's a faster path.
+
+Code: https://github.com/issdandavis/SCBE-AETHERMOORE
+Site: https://aethermoore.com
+
+Issac D. Davis
+Port Angeles, WA
+```
+
+### 2. Apollo Research — Research Engineer
+
+- **URL:** https://www.apolloresearch.ai/careers
+- **Why this fit:** They're focused on dangerous-capability evaluations; your bijective-tamper / identifier-canonicality work directly addresses adversarial code generation.
+
+**Cover letter:**
+
+```
+Hi Apollo team,
+
+I'm an independent AI safety engineer who's built two L13 governance overlays
+that map directly to the eval-driven risks Apollo investigates: bijective
+tamper detection (catches code-injection via lossy round-trip transforms)
+and identifier canonicality (catches Unicode homoglyph + invisible-char +
+mixed-script attacks). Both are wired in production behind feature flags
+with regression suites green at 218/218.
+
+The deeper substrate is a 14-layer pipeline using hyperbolic geometry to
+make adversarial behavior exponentially expensive by closed-form algebra,
+not learned filtering. Open-source, MIT-licensed, US Provisional Patent
+63/961,403 backing the substrate.
+
+Available for full-time, contractor, or scoped research collaboration.
+
+Code: https://github.com/issdandavis/SCBE-AETHERMOORE
+Site: https://aethermoore.com
+
+Issac D. Davis
+```
+
+### 3. METR (Model Evaluation and Threat Research) — Research Engineer
+
+- **URL:** https://metr.org/job-application
+- **Why this fit:** Their entire mission is empirical evaluation of frontier-model risks. Your TAIBS benchmark concept (in the Schmidt proposal) is a direct match.
+
+**Cover letter:**
+
+```
+Hi METR team,
+
+I'm independent and shipping AI safety infrastructure — the 14-layer
+SCBE-AETHERMOORE governance pipeline (npm/PyPI, MIT, provisional patent)
+and a public benchmark suite under development (TAIBS, currently being
+proposed for Schmidt Sciences funding).
+
+I'm comfortable working on empirical eval design, capability-elicitation
+protocols, and red-team automation. Composed with Anthropic's Petri
+auditing tool for 173/173 training_blocked on the full seed set.
+
+I'd like to be considered for the Research Engineer role, or for any
+short-term contractor engagement on evaluation infrastructure.
+
+Code: https://github.com/issdandavis/SCBE-AETHERMOORE
+Site: https://aethermoore.com
+
+Issac D. Davis
+SAM UEI J4NXHM6N5F59
+Port Angeles, WA
+```
+
+### 4. ARC (Alignment Research Center) — Researcher / Engineer
+
+- **URL:** https://www.alignment.org/work-with-us/
+- **Why this fit:** Their evaluations work needs more eval-design engineers; your formal-methods orientation fits their ELK / interpretability-adjacent work.
+
+### 5. Goodfire AI — Research Engineer
+
+- **URL:** https://www.goodfire.ai
+- **Why this fit:** Mechanistic interpretability + safety; smaller team, faster hiring decisions.
+
+---
+
+## Tier 2 — PNW enterprises (mid-market, faster sales cycle)
+
+These are companies in your geography who deploy AI at scale and need governance. Cold-email at the principal-engineer / staff-engineer level (not C-suite — they delegate down).
+
+### 6. Microsoft (Redmond, WA) — Responsible AI team
+
+- **Likely contact:** Search LinkedIn for "Principal AI Safety Engineer" or "Responsible AI Lead" at MSFT in Redmond. There are dozens; pick one whose recent posts mention generative AI evaluation.
+- **Approach:** mention you're a Port Angeles-based independent and you'd like to discuss a paid spike on adversarial-cost manifolds for their copilot products. Reference SCBE on github.
+
+### 7. F5 Networks (Seattle) — AI security
+
+- **Why this fit:** They're shipping AI-firewall products and their existing tooling is Euclidean-pattern-match. Your hyperbolic substrate is a true differentiator.
+- **Approach:** LinkedIn message to a Senior Director of Product or Principal Engineer in their AI/ML group.
+
+### 8. Tableau / Salesforce (Seattle) — AI governance
+
+- **Why this fit:** They sell to regulated enterprises (banking, healthcare) who require governance evidence. Subcontract opportunity for your overlay work.
+
+### 9. T-Mobile (Bellevue) — AI/ML platform
+
+- **Approach:** mid-market enterprise with AI deployment but small in-house safety team.
+
+### 10. Costco (Issaquah) — IT modernization
+
+- **Why this fit:** Conservative IT culture but increasing AI investment; values-fit for "low-overhead, high-trust" engagement.
+
+---
+
+## Tier 3 — Federal primes (slow but durable)
+
+These companies sub on AI safety / governance work for DoD, DHS, IC, etc. SAM-registered status is a prereq (you have it).
+
+### 11. Booz Allen Hamilton — AI Strategy & Engineering
+
+- **Likely contact:** Pick a Director-level on LinkedIn working in their "Responsible AI" practice. Cold-email mentioning your SAM UEI and DARPA pipeline status.
+
+### 12. SAIC — AI Center of Excellence
+
+- **Approach:** They have a small business outreach team. Email their small-business liaison directly mentioning your minority-owned status + SAM registration.
+
+### 13. Leidos — AI Solutions
+
+- **Approach:** Same as SAIC. Their NAICS coverage matches yours.
+
+### 14. CACI — Mission Systems
+
+### 15. Peraton — Cybersecurity & Intelligence
+
+---
+
+## Universal cold email template (Tier 2 / Tier 3)
+
+Customize the bracketed sections per recipient. Subject line is short and specific.
+
+**Subject:** `[Their company] + adversarial-cost AI governance — quick question`
+
+```
+Hi [Name],
+
+I'm Issac Davis, an independent AI safety engineer based in Port Angeles, WA.
+I noticed [specific recent project / publication / job posting from their company]
+and wanted to reach out about a possible paid engagement.
+
+I've built SCBE-AETHERMOORE — a 14-layer AI governance pipeline that uses
+hyperbolic geometry to bound adversarial cost in closed form, not via
+learned filtering. It's open-source on npm/PyPI (MIT-licensed) with a US
+provisional patent backing the substrate. Composes with Anthropic's Petri
+audit tool: 173/173 training_blocked on the full seed set.
+
+I'm SAM-registered (UEI J4NXHM6N5F59) and have two DARPA proposals in active
+evaluation. Available this quarter for:
+
+- Short advisory call ($300, 60 min, often same week)
+- Adversarial audit of your production AI endpoint ($5K–$15K, 1–3 weeks)
+- Custom governance overlay ($25K–$80K, 4–10 weeks)
+- Federal subcontract role ($150–$250/hr, contract)
+
+If any of those map to a need at [Their company], I'd like 15 minutes
+on your calendar this week.
+
+Code: https://github.com/issdandavis/SCBE-AETHERMOORE
+Hire details: https://aethermoore.com/hire
+
+Thanks,
+Issac D. Davis
+(360) 808-0876
+issdandavis7795@gmail.com
+```
+
+---
+
+## LinkedIn DM template (when email can't be found)
+
+LinkedIn DMs have ~3x the response rate of cold email but are limited to ~300 characters in the first message.
+
+```
+Hi [Name] — independent AI safety engineer here, SAM-registered, two DARPA
+proposals in eval. Built a 14-layer governance pipeline (npm scbe-aethermoore)
+that composes with Anthropic Petri for 173/173 blocked. Available for
+contractor / subcontract this quarter. Worth 15 min to discuss?
+```
+
+---
+
+## What to do TODAY (in order)
+
+1. **Verify deployment:** does aethermoore.com/hire actually load? If not, deploy `public/hire.html`. (Vercel auto-deploys public/* — verify the live URL before sending the cold emails that link to it.)
+2. **Pick 5 names from the list above** — do not shotgun. 5 well-researched, personalized emails > 50 generic ones.
+3. **Use LinkedIn to find current titles and emails.** If your name's recipient has moved jobs, note their replacement; the company still has the role.
+4. **Send the 5 emails between 7am–10am Pacific tomorrow morning** (their local time if they're not in PT; otherwise 7am Pacific).
+5. **Track in a spreadsheet:** `name | company | role | email | sent date | reply | next action`
+6. **One follow-up per email at day 7 if no response.** Then drop.
+
+Realistic expected outcomes from 5 sends:
+- 3 will get no response. Normal.
+- 1 will reply with "thanks, no current need." File and move on.
+- 1 will reply with "interesting — can we talk?" → that's your conversion.
+
+If you send 5 per week for 4 weeks (= 20 high-quality emails), you should land 1–3 paid conversations and 1 actual signed engagement. That's the math.
+
+---
+
+## OPSEC
+
+- Do NOT mention DAVA / Collin Hoag specifically in any cold outreach. The MATHBAC teaming is private until awarded.
+- Do NOT mention CLARA proposal contents (FAR 9.5).
+- Do mention "two DARPA proposals in active evaluation" — that's public-facing information that signals seriousness.
+- Do NOT name specific frontier model vulnerabilities even if you've found them; discuss your defense work in the abstract.
+- Do NOT use your home address as a Reply-To. Use your aethermoore.com email if you have one set up; otherwise issdandavis7795@gmail.com is fine.


### PR DESCRIPTION
## Summary
- 15 named cold-outreach targets (AI safety labs + PNW enterprises + federal primes) with personalized templates
- Pre-filled Anthropic / Apollo / METR application packages with cover letters and sample essay answers
- Companion to PR #1480 (live hire.html landing page)

## Why
User directive: convert engineering substrate into actual paid conversations. PR #1480 deploys the inbound surface; this PR builds the outbound + job-application infrastructure so the funnel runs in both directions.

## No deploy impact
Documentation only. Safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)