### PR TITLE
fix(revenue): clean CI formatting and Vercel previews

### DIFF
--- a/tests/system/test_monetization_connector_push.py
+++ b/tests/system/test_monetization_connector_push.py
@@ -8,30 +8,18 @@ def test_monetization_connector_push_includes_live_cash_offers() -> None:
     by_id = {offer["id"]: offer for offer in offers}
 
     assert by_id["tip_jar"]["price_usd"] == 5.0
-    assert (
-        by_id["tip_jar"]["stripe_url"]
-        == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
-    )
+    assert by_id["tip_jar"]["stripe_url"] == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
     assert by_id["tip_jar"]["cadence"] == "one_time"
 
     assert by_id["supporter_monthly"]["price_usd"] == 20.0
-    assert (
-        by_id["supporter_monthly"]["stripe_url"]
-        == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
-    )
+    assert by_id["supporter_monthly"]["stripe_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
     assert by_id["supporter_monthly"]["cadence"] == "monthly"
 
     assert by_id["governance_snapshot"]["price_usd"] == 500.0
-    assert (
-        by_id["governance_snapshot"]["stripe_url"]
-        == "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
-    )
+    assert by_id["governance_snapshot"]["stripe_url"] == "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
     assert by_id["governance_snapshot"]["cadence"] == "one_time"
     assert (
         by_id["governance_snapshot"]["intake_url"]
         == "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html#intake"
     )
-    assert (
-        "governance_snapshot_intake.py"
-        in by_id["governance_snapshot"]["fulfillment_command"]
-    )
+    assert "governance_snapshot_intake.py" in by_id["governance_snapshot"]["fulfillment_command"]

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -46,29 +46,17 @@ def test_download_bridge_serves_private_blob_with_delivery_token() -> None:
 
 
 def test_public_offer_catalog_has_live_revenue_links() -> None:
-    offers = json.loads(
-        (REPO_ROOT / "docs" / "offers.json").read_text(encoding="utf-8")
-    )
+    offers = json.loads((REPO_ROOT / "docs" / "offers.json").read_text(encoding="utf-8"))
     by_id = {offer["id"]: offer for offer in offers["offers"]}
 
     assert offers["schema"] == "aethermoore-offers-v1"
-    assert (
-        by_id["tip_jar"]["checkout_url"]
-        == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
-    )
-    assert (
-        by_id["supporter_monthly"]["checkout_url"]
-        == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
-    )
-    assert by_id["governance_snapshot"]["intake_url"].endswith(
-        "/governance-snapshot.html#intake"
-    )
+    assert by_id["tip_jar"]["checkout_url"] == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+    assert by_id["supporter_monthly"]["checkout_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    assert by_id["governance_snapshot"]["intake_url"].endswith("/governance-snapshot.html#intake")
 
 
 def test_public_app_config_explains_remote_update_boundary() -> None:
-    config = json.loads(
-        (REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8")
-    )
+    config = json.loads((REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8"))
 
     assert config["schema"] == "aethermoor-bus-app-config-v1"
     assert config["app"]["package_name"] == "io.aethermoor.bus"
@@ -86,12 +74,8 @@ def test_supporter_page_uses_direct_stripe_checkout_not_broken_api_bridge() -> N
 
 
 def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:
-    offers_source = (REPO_ROOT / "api" / "agent" / "offers.js").read_text(
-        encoding="utf-8"
-    )
-    app_config_source = (REPO_ROOT / "api" / "agent" / "app-config.js").read_text(
-        encoding="utf-8"
-    )
+    offers_source = (REPO_ROOT / "api" / "agent" / "offers.js").read_text(encoding="utf-8")
+    app_config_source = (REPO_ROOT / "api" / "agent" / "app-config.js").read_text(encoding="utf-8")
 
     assert "docs/offers.json" in offers_source
     assert "s-maxage=300" in offers_source

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -11,6 +11,7 @@ def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
     routes = {(item["src"], item["dest"]) for item in config["routes"]}
 
     assert {"src": "api/agent/*.js", "use": "@vercel/node"} in config["builds"]
+    assert "feat/vercel-*" in config["ignoreCommand"]
     assert ("^/$", "/api/agent/launch.js") in routes
     assert ("^/launch$", "/api/agent/launch.js") in routes
     assert ("^/api/agent/(.*)$", "/api/agent/$1.js") in routes

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in main|launch/*|vercel-test/*|customer/*|fix/launch-*) exit 1 ;; *) exit 0 ;; esac",
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in main|launch/*|vercel-test/*|customer/*|fix/launch-*|feat/vercel-*) exit 1 ;; *) exit 0 ;; esac",
   "builds": [
     {
       "src": "api/agent/*.js",


### PR DESCRIPTION
## Summary
- match CI Black formatting for the remote offer config tests
- allow Vercel previews for feat/vercel-* branches so Vercel work can actually deploy during review

## Test evidence
- python -m pytest tests/test_vercel_launch_bridge.py tests/system/test_monetization_connector_push.py tests/revenue/test_daily_cash_sprint.py -q
- python -m black --check --target-version py311 --line-length 120 tests/system/test_monetization_connector_push.py tests/test_vercel_launch_bridge.py

## Context
PR #1481 auto-merged after the first commit. This follow-up carries the formatting and Vercel-preview corrections that were pushed immediately after.
