### PR TITLE
fix(vercel): allow fix branch previews

### DIFF
--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -12,6 +12,7 @@ def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
 
     assert {"src": "api/agent/*.js", "use": "@vercel/node"} in config["builds"]
     assert "feat/vercel-*" in config["ignoreCommand"]
+    assert "fix/vercel-*" in config["ignoreCommand"]
     assert ("^/$", "/api/agent/launch.js") in routes
     assert ("^/launch$", "/api/agent/launch.js") in routes
     assert ("^/api/agent/(.*)$", "/api/agent/$1.js") in routes

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in main|launch/*|vercel-test/*|customer/*|fix/launch-*|feat/vercel-*) exit 1 ;; *) exit 0 ;; esac",
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in main|launch/*|vercel-test/*|customer/*|fix/launch-*|feat/vercel-*|fix/vercel-*) exit 1 ;; *) exit 0 ;; esac",
   "builds": [
     {
       "src": "api/agent/*.js",


### PR DESCRIPTION
## Summary
- allow Vercel previews for fix/vercel-* branches
- assert the allowlist in the Vercel launch bridge test

## Test evidence
- python -m pytest tests/test_vercel_launch_bridge.py -q

## Context
PR #1483 landed the CI formatting and feat/vercel-* preview allowlist. This keeps fix/vercel-* branches from showing a misleading green Vercel status that is actually canceled by the ignored-build step.
