### PR TITLE
feat(polly): commerce intents + auto-train + Kaggle/Twilio workers

### DIFF
--- a/src/api/polly_commerce.py
+++ b/src/api/polly_commerce.py
@@ -1,0 +1,389 @@
+"""Polly commerce + auto-training surface.
+
+Adds three behaviors on top of the deterministic chat router in
+``polly_routes.py``:
+
+1. **Order fulfillment** — when the user expresses buying intent, return the
+   exact product + Stripe payment link, not generic pricing copy.
+
+2. **Custom-product builder** — when the user describes a need that doesn't
+   match a stock product, surface a "scope a custom build" CTA that points
+   at the consulting page (``aethermoore.com/hire``) and an email pre-fill.
+
+3. **Auto-training capture** — every consented conversation turn is appended
+   to ``training-data/polly-chat-live/{YYYY-MM}.jsonl`` so the next training
+   run can pull live customer interactions as supervised data.
+
+4. **Membership / sign-up CTA** — when the user shows research / repeat-visit
+   intent, surface the Ko-fi sponsorship + newsletter signup link.
+
+Design constraints:
+- No external secrets required for capture (writes to local disk).
+- Every link in the catalog is verified live as of 2026-05-09.
+- Intent classification is deterministic regex — no LLM needed for the
+  routing layer; the LLM (Gemini / HF) handles the conversational reply
+  separately.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
+
+logger = logging.getLogger("scbe.api.polly.commerce")
+
+# ---------------------------------------------------------------------------
+# Product catalog — single source of truth for what Polly can sell.
+# Keep this in sync with docs/offers/index.html and src/api/stripe_billing.py.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Product:
+    """A Polly-sellable product surface."""
+
+    sku: str
+    name: str
+    price_label: str
+    short: str
+    checkout_url: str
+    delivery_url: str = ""
+    keywords: Tuple[str, ...] = field(default_factory=tuple)
+
+
+PRODUCT_CATALOG: Tuple[Product, ...] = (
+    Product(
+        sku="ai-governance-toolkit",
+        name="SCBE AI Governance Toolkit",
+        price_label="$29 one-time",
+        short=(
+            "Templates, decision records, setup guidance, buyer manual, and a "
+            "support route for governed AI workflows. Shipped as a downloadable "
+            "ZIP after Stripe checkout."
+        ),
+        checkout_url="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06",
+        delivery_url="https://aethermoore.com/product-manual/ai-governance-toolkit.html",
+        keywords=("toolkit", "governance toolkit", "ai governance", "templates", "decision records"),
+    ),
+    Product(
+        sku="ai-security-training-vault",
+        name="SCBE AI Security Training Vault",
+        price_label="$29 one-time",
+        short=(
+            "Training data, projector weights, benchmark suite, and notebook "
+            "materials for governed AI model work. Shipped as a downloadable "
+            "ZIP after Stripe checkout."
+        ),
+        checkout_url="https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g",
+        delivery_url="https://aethermoore.com/product-manual/training-vault.html",
+        keywords=("training vault", "training data", "vault", "ai security", "benchmark suite", "notebooks"),
+    ),
+    Product(
+        sku="five-dollar-tip-jar",
+        name="$5 SCBE Tip Jar",
+        price_label="$5 one-time",
+        short=(
+            "If the open-source work has helped you and there's no formal "
+            "engagement, a tip keeps the next release shipping."
+        ),
+        checkout_url="https://ko-fi.com/Y8Y51UQYWZ",
+        keywords=("tip", "tip jar", "donate", "donation", "support", "buy a coffee", "coffee"),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Consulting / custom-build CTA — when no stock product matches.
+# ---------------------------------------------------------------------------
+
+
+CONSULTING_TIERS: Tuple[Dict[str, str], ...] = (
+    {
+        "name": "Short advisory call",
+        "price": "$300 / 60 min",
+        "fit": "one concrete AI safety / governance problem you're facing",
+    },
+    {
+        "name": "Adversarial audit",
+        "price": "$5,000 – $15,000 / 1–3 weeks",
+        "fit": "audit your production LLM endpoint or agent against the SCBE governance harness",
+    },
+    {
+        "name": "Custom governance overlay",
+        "price": "$25,000 – $80,000 / 4–10 weeks",
+        "fit": "build a deployable governance layer in front of your model API",
+    },
+    {
+        "name": "Federal subcontract role",
+        "price": "$150 – $250 / hour, contract",
+        "fit": "AI safety / LLM evaluation work on a SAM-registered prime's contract",
+    },
+)
+
+CONSULTING_LANDING_URL = "https://aethermoore.com/hire"
+HIRE_EMAIL = "issdandavis7795@gmail.com"
+MEMBERSHIP_KOFI_URL = "https://ko-fi.com/Y8Y51UQYWZ"
+
+
+# ---------------------------------------------------------------------------
+# Intent classification — deterministic regex on the user message.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Intent:
+    """Result of classifying a user message."""
+
+    name: str
+    confidence: float
+    matched_term: Optional[str] = None
+    product: Optional[Product] = None
+
+
+_BUY_PATTERN = re.compile(
+    r"\b(buy|purchase|order|checkout|pay\s+for|get\s+the|want\s+the|" r"how\s+much|sign\s+me\s+up|add\s+to\s+cart)\b",
+    re.IGNORECASE,
+)
+
+_CUSTOM_PATTERN = re.compile(
+    r"\b(custom|bespoke|tailor|specifically\s+for|my\s+team|my\s+company|"
+    r"my\s+org|my\s+(use\s*case|workflow)|something\s+else|not\s+listed|"
+    r"build\s+me|hire\s+you|consulting|advisory|audit|engagement|contract)\b",
+    re.IGNORECASE,
+)
+
+_RESEARCH_PATTERN = re.compile(
+    r"\b(research|find|look\s+up|search|investigate|what\s+do\s+you\s+know|"
+    r"recent|latest|news|paper|study|literature|sources?|cite|references?)\b",
+    re.IGNORECASE,
+)
+
+_MEMBERSHIP_PATTERN = re.compile(
+    r"\b(member|membership|subscribe|signup|sign\s*up|join|newsletter|"
+    r"follow|stay\s+updated|notify|sponsor|tip|donate)\b",
+    re.IGNORECASE,
+)
+
+
+def classify_intent(message: str) -> Intent:
+    """Classify the dominant intent of a user message.
+
+    Order of precedence (highest first): buy > custom > research > membership.
+    Returns ``Intent(name="general", confidence=0.0)`` when nothing matches.
+    """
+    if not isinstance(message, str) or not message.strip():
+        return Intent(name="general", confidence=0.0)
+
+    # Buy intent — try to bind a specific product if a keyword matches.
+    buy_match = _BUY_PATTERN.search(message)
+    if buy_match:
+        product = _resolve_product(message)
+        return Intent(
+            name="buy",
+            confidence=0.95 if product else 0.7,
+            matched_term=buy_match.group(0),
+            product=product,
+        )
+
+    # Bare product keyword without explicit buy verb still surfaces the product.
+    product = _resolve_product(message)
+    if product is not None:
+        return Intent(name="buy", confidence=0.6, matched_term=product.sku, product=product)
+
+    # Custom-build intent.
+    custom_match = _CUSTOM_PATTERN.search(message)
+    if custom_match:
+        return Intent(name="custom", confidence=0.85, matched_term=custom_match.group(0))
+
+    # Research intent.
+    research_match = _RESEARCH_PATTERN.search(message)
+    if research_match:
+        return Intent(name="research", confidence=0.8, matched_term=research_match.group(0))
+
+    # Membership / sponsorship intent.
+    membership_match = _MEMBERSHIP_PATTERN.search(message)
+    if membership_match:
+        return Intent(name="membership", confidence=0.75, matched_term=membership_match.group(0))
+
+    return Intent(name="general", confidence=0.0)
+
+
+def _resolve_product(message: str) -> Optional[Product]:
+    """Return the first product whose keywords appear in the message."""
+    lower = message.lower()
+    for product in PRODUCT_CATALOG:
+        for keyword in product.keywords:
+            if keyword in lower:
+                return product
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Reply rendering — builds the assistant text + structured action links.
+# ---------------------------------------------------------------------------
+
+
+def render_buy_reply(product: Optional[Product]) -> Tuple[str, List[Dict[str, str]]]:
+    """Render a buy-intent reply. If product is None, list the catalog."""
+    if product is None:
+        lines = [
+            "Three current products. Click to check out:",
+            "",
+        ]
+        actions: List[Dict[str, str]] = []
+        for item in PRODUCT_CATALOG:
+            lines.append(f"- **{item.name}** — {item.price_label}. {item.short}")
+            actions.append({"label": f"Buy {item.name}", "url": item.checkout_url})
+        return "\n".join(lines), actions
+
+    text = f"**{product.name}** — {product.price_label}.\n\n" f"{product.short}\n\n" f"Checkout: {product.checkout_url}"
+    if product.delivery_url:
+        text += f"\nWhat you get + delivery: {product.delivery_url}"
+    actions = [{"label": f"Buy {product.name}", "url": product.checkout_url}]
+    if product.delivery_url:
+        actions.append({"label": "What's inside", "url": product.delivery_url})
+    return text, actions
+
+
+def render_custom_reply(message: str) -> Tuple[str, List[Dict[str, str]]]:
+    """Render a custom-build reply with consulting tiers + email pre-fill."""
+    subject = "Custom engagement inquiry — from Polly chat"
+    body = (
+        f"Hi Issac,\n\n"
+        f'I described to Polly: "{message[:300]}"\n\n'
+        f"I'd like to discuss:\n"
+        f"[ ] Short advisory call ($300, 60 min)\n"
+        f"[ ] Adversarial audit\n"
+        f"[ ] Custom governance overlay\n"
+        f"[ ] Federal subcontract conversation\n\n"
+        f"Context:\n\n"
+        f"Thanks,\n"
+    )
+    mailto = f"mailto:{HIRE_EMAIL}" f"?subject={quote(subject)}" f"&body={quote(body)}"
+
+    tier_lines = [f"- **{t['name']}** ({t['price']}) — {t['fit']}" for t in CONSULTING_TIERS]
+    text = (
+        "What you're describing is custom — not in the stock catalog. "
+        "Four ways we can scope it:\n\n"
+        + "\n".join(tier_lines)
+        + "\n\nFastest path: email with a one-paragraph description of the "
+        "outcome you want. I reply same day where I can."
+    )
+    actions = [
+        {"label": "Email Issac with this context", "url": mailto},
+        {"label": "Full hire details", "url": CONSULTING_LANDING_URL},
+    ]
+    return text, actions
+
+
+def render_membership_reply() -> Tuple[str, List[Dict[str, str]]]:
+    """Render a membership / sponsorship CTA."""
+    text = (
+        "Three ways to stay close to the work:\n\n"
+        "- **Sponsor / tip** the open-source work via Ko-fi\n"
+        "- **Watch the GitHub repo** for releases (`Watch -> Custom -> Releases`)\n"
+        "- **Email** me at the address below for a private update list\n\n"
+        "There is no paid membership tier yet — open-source first; "
+        "sponsorships keep the next release shipping."
+    )
+    actions = [
+        {"label": "Tip on Ko-fi", "url": MEMBERSHIP_KOFI_URL},
+        {"label": "Watch the repo", "url": "https://github.com/issdandavis/SCBE-AETHERMOORE"},
+        {"label": "Email Issac", "url": f"mailto:{HIRE_EMAIL}"},
+    ]
+    return text, actions
+
+
+# ---------------------------------------------------------------------------
+# Auto-training capture — append consented conversations to a JSONL corpus.
+# ---------------------------------------------------------------------------
+
+
+_TRAIN_CORPUS_DIR_ENV = "POLLY_TRAIN_CORPUS_DIR"
+_DEFAULT_TRAIN_CORPUS_DIR = Path(__file__).resolve().parents[2] / "training-data" / "polly-chat-live"
+
+
+def train_corpus_dir() -> Path:
+    """Return the directory where live training corpus shards are written."""
+    override = os.environ.get(_TRAIN_CORPUS_DIR_ENV, "").strip()
+    if override:
+        return Path(override)
+    return _DEFAULT_TRAIN_CORPUS_DIR
+
+
+def append_training_record(
+    *,
+    consent: bool,
+    user_message: str,
+    assistant_reply: str,
+    intent: str,
+    page_context: Optional[str] = None,
+    feedback: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> Optional[Path]:
+    """Append one conversation turn to the live training corpus.
+
+    Returns the path written to, or ``None`` if consent was not granted or the
+    write failed. Never raises — training capture must not break the chat path.
+    """
+    if not consent:
+        return None
+    if not isinstance(user_message, str) or not user_message.strip():
+        return None
+    if not isinstance(assistant_reply, str) or not assistant_reply.strip():
+        return None
+
+    corpus_dir = train_corpus_dir()
+    try:
+        corpus_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("polly training corpus dir create failed: %s", exc)
+        return None
+
+    shard_name = f"{time.strftime('%Y-%m')}.jsonl"
+    shard = corpus_dir / shard_name
+
+    record: Dict[str, Any] = {
+        "ts": int(time.time()),
+        "session_id": session_id or "",
+        "intent": intent,
+        "user": user_message[:4096],
+        "assistant": assistant_reply[:8192],
+    }
+    if page_context:
+        record["page_context"] = page_context[:512]
+    if feedback in ("up", "down"):
+        record["feedback"] = feedback
+
+    try:
+        with shard.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        logger.warning("polly training corpus write failed: %s", exc)
+        return None
+
+    return shard
+
+
+__all__ = [
+    "Product",
+    "PRODUCT_CATALOG",
+    "CONSULTING_TIERS",
+    "CONSULTING_LANDING_URL",
+    "HIRE_EMAIL",
+    "MEMBERSHIP_KOFI_URL",
+    "Intent",
+    "classify_intent",
+    "render_buy_reply",
+    "render_custom_reply",
+    "render_membership_reply",
+    "train_corpus_dir",
+    "append_training_record",
+]

--- a/src/api/polly_routes.py
+++ b/src/api/polly_routes.py
@@ -24,6 +24,19 @@ from urllib.parse import quote_plus
 from fastapi import APIRouter
 from pydantic import BaseModel, Field, field_validator
 
+from src.api.polly_commerce import (
+    PRODUCT_CATALOG,
+    append_training_record,
+    classify_intent,
+    render_buy_reply,
+    render_custom_reply,
+    render_membership_reply,
+)
+from src.api.polly_workers import (
+    all_statuses as workers_all_statuses,
+    voice_response_twiml,
+)
+
 logger = logging.getLogger("scbe.api.polly")
 
 polly_router = APIRouter(prefix="/v1/polly", tags=["polly"])
@@ -127,6 +140,16 @@ class ChatRequest(BaseModel):
     thinking: bool = Field(default=False, description="Enable step-by-step reasoning mode (Gemini)")
     history: List[ChatMessage] = Field(default_factory=list, max_length=20)
     page_context: Optional[str] = Field(default=None, max_length=512)
+    consent_to_train: bool = Field(
+        default=False,
+        description="If True, the turn is appended to the live training corpus.",
+    )
+    session_id: Optional[str] = Field(default=None, max_length=128)
+
+
+class ActionLink(BaseModel):
+    label: str
+    url: str
 
 
 class ChatResponse(BaseModel):
@@ -135,6 +158,8 @@ class ChatResponse(BaseModel):
     thinking: bool
     model: str
     ts: int
+    actions: List[ActionLink] = Field(default_factory=list)
+    intent: Optional[str] = None
 
 
 class SearchRequest(BaseModel):
@@ -375,6 +400,121 @@ async def polly_context() -> ContextResponse:
     )
 
 
+class CatalogProduct(BaseModel):
+    sku: str
+    name: str
+    price_label: str
+    short: str
+    checkout_url: str
+    delivery_url: str = ""
+
+
+class CatalogResponse(BaseModel):
+    products: List[CatalogProduct]
+
+
+@polly_router.get("/catalog", response_model=CatalogResponse, summary="Product catalog")
+async def polly_catalog() -> CatalogResponse:
+    """Return the list of products Polly can sell."""
+    return CatalogResponse(
+        products=[
+            CatalogProduct(
+                sku=p.sku,
+                name=p.name,
+                price_label=p.price_label,
+                short=p.short,
+                checkout_url=p.checkout_url,
+                delivery_url=p.delivery_url,
+            )
+            for p in PRODUCT_CATALOG
+        ]
+    )
+
+
+class FeedbackRequest(BaseModel):
+    rating: str = Field(..., pattern="^(up|down)$")
+    user_message: str = Field(..., min_length=1, max_length=4096)
+    assistant_reply: str = Field(..., min_length=1, max_length=8192)
+    intent: Optional[str] = Field(default=None, max_length=64)
+    session_id: Optional[str] = Field(default=None, max_length=128)
+    consent_to_train: bool = Field(default=True)
+
+
+class FeedbackResponse(BaseModel):
+    ok: bool
+    captured: bool
+
+
+class WorkerStatusItem(BaseModel):
+    name: str
+    configured: bool
+    detail: str = ""
+
+
+class WorkersResponse(BaseModel):
+    workers: List[WorkerStatusItem]
+
+
+@polly_router.get(
+    "/workers",
+    response_model=WorkersResponse,
+    summary="External integration status (Ollama, HF, Kaggle, Twilio)",
+)
+async def polly_workers_status() -> WorkersResponse:
+    """Report which external integrations are configured.
+
+    Used by the chat widget to decide which features to surface (e.g. show
+    the AI-call CTA only if Twilio is configured) and by ops dashboards.
+    """
+    return WorkersResponse(
+        workers=[
+            WorkerStatusItem(name=s.name, configured=s.configured, detail=s.detail) for s in workers_all_statuses()
+        ]
+    )
+
+
+from fastapi import Response
+
+
+@polly_router.api_route(
+    "/voice/inbound",
+    methods=["GET", "POST"],
+    summary="Twilio inbound voice webhook",
+)
+async def polly_voice_inbound() -> Response:
+    """TwiML response for an inbound Twilio call.
+
+    Twilio webhooks default to POST; we accept GET as well to make
+    smoke-testing from a browser easy.
+    """
+    xml = voice_response_twiml()
+    return Response(content=xml, media_type="text/xml")
+
+
+@polly_router.post(
+    "/feedback",
+    response_model=FeedbackResponse,
+    summary="Record thumbs-up / thumbs-down on an assistant reply",
+)
+async def polly_feedback(req: FeedbackRequest) -> FeedbackResponse:
+    """Append a feedback-bearing turn to the live training corpus.
+
+    Treated as the supervised-finetune signal: thumbs-up stays as a positive
+    example, thumbs-down feeds the rejection sampler. Storage is the same
+    JSONL shard used by ``polly_chat``; downstream tooling reads the
+    ``feedback`` field to split positive vs. negative.
+    """
+    written = append_training_record(
+        consent=req.consent_to_train,
+        user_message=req.user_message,
+        assistant_reply=req.assistant_reply,
+        intent=req.intent or "feedback",
+        feedback=req.rating,
+        session_id=req.session_id,
+    )
+    return FeedbackResponse(ok=True, captured=written is not None)
+
+
 @polly_router.post("/chat", response_model=ChatResponse, summary="Chat with Polly")
 async def polly_chat(req: ChatRequest) -> ChatResponse:
     """
@@ -385,38 +525,90 @@ async def polly_chat(req: ChatRequest) -> ChatResponse:
     - Otherwise a deterministic router handles common query types (pricing,
       support, science, lore, training, setup, contact).
     """
+    # 1. Commerce + custom-build + membership intents take precedence over LLMs.
+    #    Direct buying signals deserve a direct answer with a real Stripe link,
+    #    not a freeform LLM riff that may hallucinate the price or skip the URL.
+    intent = classify_intent(req.message)
+    if intent.confidence >= 0.6 and intent.name in {"buy", "custom", "membership"}:
+        if intent.name == "buy":
+            text, action_dicts = render_buy_reply(intent.product)
+        elif intent.name == "custom":
+            text, action_dicts = render_custom_reply(req.message)
+        else:
+            text, action_dicts = render_membership_reply()
+
+        actions = [ActionLink(**a) for a in action_dicts]
+        response_obj = ChatResponse(
+            response=text,
+            route=f"commerce-{intent.name}",
+            thinking=False,
+            model="polly-commerce",
+            ts=int(time.time()),
+            actions=actions,
+            intent=intent.name,
+        )
+        _capture_training_turn(req, response_obj)
+        return response_obj
+
     if req.thinking and _gemini_key():
         try:
             text = await _gemini_chat(req.message, req.history, req.page_context)
-            return ChatResponse(
+            response_obj = ChatResponse(
                 response=text,
                 route="gemini-thinking",
                 thinking=True,
                 model=os.environ.get("GEMINI_MODEL", DEFAULT_GEMINI_MODEL),
                 ts=int(time.time()),
+                intent=intent.name,
             )
+            _capture_training_turn(req, response_obj)
+            return response_obj
         except RuntimeError as exc:
             logger.warning("Gemini fallback: %s", exc)
 
     # Try free LLM (HuggingFace / Ollama) before deterministic fallback
     free_result = await _free_llm_chat(req.message, req.page_context)
     if free_result:
-        return ChatResponse(
+        response_obj = ChatResponse(
             response=free_result["text"],
             route=f"free-llm-{free_result['provider']}",
             thinking=req.thinking,
             model=free_result["model"],
             ts=int(time.time()),
+            intent=intent.name,
         )
+        _capture_training_turn(req, response_obj)
+        return response_obj
 
     route, response = _deterministic_route(req.message)
-    return ChatResponse(
+    response_obj = ChatResponse(
         response=response,
         route=route,
         thinking=False,
         model="polly-deterministic",
         ts=int(time.time()),
+        intent=intent.name,
     )
+    _capture_training_turn(req, response_obj)
+    return response_obj
+
+
+def _capture_training_turn(req: "ChatRequest", resp: "ChatResponse") -> None:
+    """Append the turn to the live training corpus when consent is granted.
+
+    Never raises — training capture must not break the chat path.
+    """
+    try:
+        append_training_record(
+            consent=req.consent_to_train,
+            user_message=req.message,
+            assistant_reply=resp.response,
+            intent=resp.intent or resp.route,
+            page_context=req.page_context,
+            session_id=req.session_id,
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.debug("training capture skipped: %s", exc)
 
 
 @polly_router.post("/search", response_model=SearchResponse, summary="Web search")

--- a/src/api/polly_workers.py
+++ b/src/api/polly_workers.py
@@ -1,0 +1,318 @@
+"""External worker / integration surfaces for Polly.
+
+Single place to wire third-party datasets, models, and call services into
+Polly's runtime. All integrations are **opt-in via environment variables** —
+the module never throws when credentials are missing; it returns a structured
+``WorkerStatus`` so callers can degrade gracefully.
+
+Currently wired:
+
+- **Ollama** (local LLM) — already used by ``polly_routes._free_llm_chat``.
+  Status only here.
+
+- **Hugging Face** (Inference API + datasets) — chat already used by
+  ``polly_routes._free_llm_chat``. This module adds dataset push/pull for
+  the live training corpus.
+
+- **Kaggle** (datasets) — pull public CSV/JSON datasets for model
+  enrichment. Push training corpus snapshots if Kaggle credentials are
+  configured.
+
+- **Twilio** (voice calls) — stub for an inbound AI customer-call service.
+  When ``TWILIO_ACCOUNT_SID`` + ``TWILIO_AUTH_TOKEN`` + ``TWILIO_PHONE_NUMBER``
+  are set, the ``call_service_status()`` reports as ``configured``; the
+  TwiML endpoint is intentionally a thin stub so the prod deploy can wire
+  to a real LLM voice service (Vapi, Bland, Retell, etc.) without changing
+  this module's contract.
+
+Design constraints:
+- Never raise — degraded status, never crash.
+- Never log secrets — only log "configured" / "missing" booleans.
+- Pure stdlib for stub paths; optional packages (``kaggle``, ``twilio``,
+  ``huggingface_hub``) are imported lazily only when the integration is
+  actually invoked.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("scbe.api.polly.workers")
+
+
+# ---------------------------------------------------------------------------
+# Status reporting
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorkerStatus:
+    """Per-integration health and configuration report."""
+
+    name: str
+    configured: bool
+    detail: str = ""
+
+
+def ollama_status() -> WorkerStatus:
+    """Ollama is local; we treat it as 'configured' if the env hint is set
+    OR the default URL is reachable. We don't probe the network here — that
+    belongs in a healthcheck endpoint.
+    """
+    base = os.environ.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434").strip()
+    model = os.environ.get("OLLAMA_MODEL", "llama3.2").strip()
+    return WorkerStatus(
+        name="ollama",
+        configured=bool(base),
+        detail=f"base_url={base or '(unset)'} model={model}",
+    )
+
+
+def hf_status() -> WorkerStatus:
+    """Hugging Face is configured when ``HF_TOKEN`` is set."""
+    token = os.environ.get("HF_TOKEN", "").strip()
+    model = os.environ.get("HF_MODEL", "Qwen/Qwen2.5-72B-Instruct").strip()
+    dataset_repo = os.environ.get("POLLY_TRAIN_HF_REPO", "issdandavis/polly-chat-live").strip()
+    return WorkerStatus(
+        name="huggingface",
+        configured=bool(token),
+        detail=f"model={model} dataset_repo={dataset_repo}",
+    )
+
+
+def kaggle_status() -> WorkerStatus:
+    """Kaggle is configured when ``KAGGLE_USERNAME`` + ``KAGGLE_KEY`` are set,
+    or when ``~/.kaggle/kaggle.json`` exists.
+    """
+    username = os.environ.get("KAGGLE_USERNAME", "").strip()
+    key = os.environ.get("KAGGLE_KEY", "").strip()
+    json_path = Path.home() / ".kaggle" / "kaggle.json"
+    configured = bool(username and key) or json_path.is_file()
+    detail = []
+    if username:
+        detail.append(f"user={username}")
+    if json_path.is_file():
+        detail.append(f"kaggle.json present")
+    return WorkerStatus(
+        name="kaggle",
+        configured=configured,
+        detail=" ".join(detail) or "no credentials",
+    )
+
+
+def call_service_status() -> WorkerStatus:
+    """Twilio voice / AI-call service status."""
+    sid = os.environ.get("TWILIO_ACCOUNT_SID", "").strip()
+    token = os.environ.get("TWILIO_AUTH_TOKEN", "").strip()
+    number = os.environ.get("TWILIO_PHONE_NUMBER", "").strip()
+    bridge = os.environ.get("POLLY_VOICE_AGENT_URL", "").strip()
+    configured = bool(sid and token and number)
+    detail_parts: List[str] = []
+    if number:
+        detail_parts.append(f"number={number}")
+    if bridge:
+        detail_parts.append(f"voice_agent={bridge}")
+    if not detail_parts:
+        detail_parts.append("not configured")
+    return WorkerStatus(
+        name="twilio_voice",
+        configured=configured,
+        detail=" ".join(detail_parts),
+    )
+
+
+def all_statuses() -> List[WorkerStatus]:
+    """Return health for every wired integration."""
+    return [
+        ollama_status(),
+        hf_status(),
+        kaggle_status(),
+        call_service_status(),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Hugging Face — push live training corpus snapshot.
+# ---------------------------------------------------------------------------
+
+
+def push_training_corpus_to_hf(
+    *,
+    corpus_dir: Path,
+    repo_id: Optional[str] = None,
+    private: bool = True,
+) -> Dict[str, Any]:
+    """Upload the live JSONL training corpus to Hugging Face Datasets.
+
+    Returns ``{"ok": bool, "uploaded": [...], "error": Optional[str]}``.
+    Never raises; on failure returns ``ok=False`` with a string ``error``.
+
+    Requires ``HF_TOKEN`` and the optional ``huggingface_hub`` package.
+    """
+    token = os.environ.get("HF_TOKEN", "").strip()
+    if not token:
+        return {"ok": False, "uploaded": [], "error": "HF_TOKEN not set"}
+    if not corpus_dir.exists():
+        return {"ok": False, "uploaded": [], "error": f"corpus dir missing: {corpus_dir}"}
+
+    target_repo = repo_id or os.environ.get("POLLY_TRAIN_HF_REPO", "issdandavis/polly-chat-live").strip()
+    if not target_repo:
+        return {"ok": False, "uploaded": [], "error": "no HF dataset repo configured"}
+
+    try:
+        from huggingface_hub import HfApi  # type: ignore[import-not-found]
+    except ImportError:
+        return {
+            "ok": False,
+            "uploaded": [],
+            "error": "huggingface_hub package not installed",
+        }
+
+    api = HfApi(token=token)
+    try:
+        api.create_repo(
+            repo_id=target_repo,
+            repo_type="dataset",
+            private=private,
+            exist_ok=True,
+        )
+    except Exception as exc:
+        logger.warning("HF create_repo failed: %s", exc)
+        return {"ok": False, "uploaded": [], "error": f"create_repo: {exc}"}
+
+    uploaded: List[str] = []
+    errors: List[str] = []
+    for shard in sorted(corpus_dir.glob("*.jsonl")):
+        try:
+            api.upload_file(
+                path_or_fileobj=str(shard),
+                path_in_repo=f"shards/{shard.name}",
+                repo_id=target_repo,
+                repo_type="dataset",
+            )
+            uploaded.append(shard.name)
+        except Exception as exc:
+            logger.warning("HF upload_file failed for %s: %s", shard.name, exc)
+            errors.append(f"{shard.name}: {exc}")
+
+    return {
+        "ok": not errors,
+        "uploaded": uploaded,
+        "error": "; ".join(errors) if errors else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Kaggle — pull a public dataset for model enrichment.
+# ---------------------------------------------------------------------------
+
+
+def pull_kaggle_dataset(
+    *,
+    dataset_slug: str,
+    target_dir: Path,
+) -> Dict[str, Any]:
+    """Download a Kaggle dataset to ``target_dir``.
+
+    ``dataset_slug`` is the standard ``user/dataset-name`` form.
+    Returns ``{"ok": bool, "files": [...], "error": Optional[str]}``.
+    Never raises.
+
+    Requires Kaggle credentials and the optional ``kaggle`` package.
+    """
+    if not kaggle_status().configured:
+        return {"ok": False, "files": [], "error": "Kaggle credentials not configured"}
+    if not isinstance(dataset_slug, str) or "/" not in dataset_slug:
+        return {"ok": False, "files": [], "error": f"invalid slug: {dataset_slug!r}"}
+
+    try:
+        from kaggle import KaggleApi  # type: ignore[import-not-found]
+    except ImportError:
+        return {"ok": False, "files": [], "error": "kaggle package not installed"}
+
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        api = KaggleApi()
+        api.authenticate()
+        api.dataset_download_files(
+            dataset_slug,
+            path=str(target_dir),
+            unzip=True,
+            quiet=True,
+        )
+    except Exception as exc:
+        logger.warning("Kaggle pull failed for %s: %s", dataset_slug, exc)
+        return {"ok": False, "files": [], "error": str(exc)}
+
+    files = [str(p.relative_to(target_dir)) for p in target_dir.rglob("*") if p.is_file()]
+    return {"ok": True, "files": files, "error": None}
+
+
+# ---------------------------------------------------------------------------
+# Twilio AI-call service — stub TwiML response for inbound calls.
+# ---------------------------------------------------------------------------
+
+
+VOICE_GREETING_DEFAULT = (
+    "Hi, you've reached Aethermoor. I'm Polly. "
+    "Tell me briefly what brought you to call, "
+    "and I'll either help directly or route you to Issac."
+)
+
+
+def voice_response_twiml(
+    *,
+    greeting: Optional[str] = None,
+    voice_agent_url: Optional[str] = None,
+) -> str:
+    """Return a TwiML XML string for an inbound voice call.
+
+    If ``voice_agent_url`` (or ``POLLY_VOICE_AGENT_URL`` env var) is set,
+    the TwiML connects the call to that streaming voice-agent endpoint
+    (Vapi, Bland, Retell, or any TwiML-Stream-compatible service).
+    Otherwise it plays the greeting and records a short voicemail that
+    can later be transcribed by Whisper for Polly to follow up.
+    """
+    spoken = (greeting or VOICE_GREETING_DEFAULT).replace("&", "&amp;").replace("<", "&lt;")
+    bridge = (voice_agent_url or os.environ.get("POLLY_VOICE_AGENT_URL", "")).strip()
+
+    if bridge:
+        # Stream the call audio to the bridge agent. The bridge is responsible
+        # for ASR + LLM + TTS round-trip; this module just hands it the pipe.
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<Response>\n"
+            f'  <Say voice="alice">{spoken}</Say>\n'
+            f'  <Connect><Stream url="{bridge}"/></Connect>\n'
+            "</Response>"
+        )
+
+    # Fallback: greeting + voicemail recording.
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<Response>\n"
+        f'  <Say voice="alice">{spoken}</Say>\n'
+        '  <Record maxLength="120" playBeep="true" '
+        'transcribe="true" '
+        'transcribeCallback="/v1/polly/voicemail"/>\n'
+        '  <Say voice="alice">Thanks. Issac will follow up by email. Goodbye.</Say>\n'
+        "</Response>"
+    )
+
+
+__all__ = [
+    "WorkerStatus",
+    "ollama_status",
+    "hf_status",
+    "kaggle_status",
+    "call_service_status",
+    "all_statuses",
+    "push_training_corpus_to_hf",
+    "pull_kaggle_dataset",
+    "voice_response_twiml",
+    "VOICE_GREETING_DEFAULT",
+]

--- a/tests/api/test_polly_commerce.py
+++ b/tests/api/test_polly_commerce.py
@@ -1,0 +1,216 @@
+"""Tests for Polly commerce + auto-training capture."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.api.polly_commerce import (
+    PRODUCT_CATALOG,
+    append_training_record,
+    classify_intent,
+    render_buy_reply,
+    render_custom_reply,
+    render_membership_reply,
+    train_corpus_dir,
+)
+
+# ---------------------------------------------------------------------------
+# Catalog sanity
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_is_nonempty_and_has_real_stripe_links() -> None:
+    assert len(PRODUCT_CATALOG) >= 2
+    for product in PRODUCT_CATALOG:
+        assert product.sku
+        assert product.name
+        assert product.price_label
+        assert product.short
+        assert product.checkout_url.startswith(("https://buy.stripe.com/", "https://ko-fi.com/"))
+
+
+# ---------------------------------------------------------------------------
+# Intent classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message,expected_intent",
+    [
+        ("How much is the toolkit?", "buy"),
+        ("I want to buy the training vault", "buy"),
+        ("Can I purchase the SCBE governance toolkit?", "buy"),
+        ("Add to cart please", "buy"),
+        ("Sign me up for the toolkit", "buy"),
+        ("toolkit", "buy"),
+        ("training vault", "buy"),
+        ("buy a coffee", "buy"),  # tip jar keyword
+        ("I need something custom for my team", "custom"),
+        ("Can you do a custom build for my company?", "custom"),
+        ("hire you for an audit", "custom"),
+        ("I want to research recent prompt-injection papers", "research"),
+        ("look up the latest sources on AI safety", "research"),
+        ("how do I become a member?", "membership"),
+        ("can I sponsor the project?", "membership"),
+        ("subscribe to your newsletter", "membership"),
+        ("what is the harmonic wall formula?", "general"),
+        ("", "general"),
+    ],
+)
+def test_classify_intent_basic(message: str, expected_intent: str) -> None:
+    intent = classify_intent(message)
+    assert intent.name == expected_intent
+
+
+def test_classify_intent_buy_resolves_specific_product() -> None:
+    intent = classify_intent("How much is the AI Governance Toolkit?")
+    assert intent.name == "buy"
+    assert intent.product is not None
+    assert intent.product.sku == "ai-governance-toolkit"
+
+
+def test_classify_intent_buy_resolves_training_vault() -> None:
+    intent = classify_intent("I want to purchase the training vault")
+    assert intent.name == "buy"
+    assert intent.product is not None
+    assert intent.product.sku == "ai-security-training-vault"
+
+
+def test_classify_intent_buy_without_product_keyword() -> None:
+    intent = classify_intent("How much does it cost?")
+    assert intent.name == "buy"
+    assert intent.product is None
+    assert intent.confidence < 0.8  # lower confidence without specific product
+
+
+def test_classify_intent_custom_takes_precedence_over_research() -> None:
+    """Custom-build language wins when both 'custom' and 'research' tokens appear."""
+    intent = classify_intent("I want a custom audit and some research on top")
+    assert intent.name == "custom"
+
+
+# ---------------------------------------------------------------------------
+# Reply rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_buy_reply_with_product_returns_link() -> None:
+    product = PRODUCT_CATALOG[0]
+    text, actions = render_buy_reply(product)
+    assert product.name in text
+    assert product.checkout_url in text
+    assert any(a["url"] == product.checkout_url for a in actions)
+
+
+def test_render_buy_reply_without_product_lists_full_catalog() -> None:
+    text, actions = render_buy_reply(None)
+    assert len(actions) >= len(PRODUCT_CATALOG)
+    for product in PRODUCT_CATALOG:
+        assert product.name in text
+
+
+def test_render_custom_reply_includes_mailto_with_user_context() -> None:
+    text, actions = render_custom_reply("I need a governance overlay for our finance LLM")
+    mailto_action = next((a for a in actions if a["url"].startswith("mailto:")), None)
+    assert mailto_action is not None
+    # mailto: URLs treat @ as a safe character; urllib.parse.quote leaves it as-is.
+    assert "issdandavis7795@gmail.com" in mailto_action["url"]
+    assert "finance" in mailto_action["url"].lower() or "finance" in text.lower()
+
+
+def test_render_membership_reply_returns_kofi_link() -> None:
+    text, actions = render_membership_reply()
+    kofi = next((a for a in actions if "ko-fi.com" in a["url"]), None)
+    assert kofi is not None
+    assert "Ko-fi" in text or "ko-fi" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Auto-training capture
+# ---------------------------------------------------------------------------
+
+
+def test_append_training_record_writes_jsonl_with_consent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
+    shard = append_training_record(
+        consent=True,
+        user_message="hi",
+        assistant_reply="hello",
+        intent="general",
+    )
+    assert shard is not None
+    assert shard.exists()
+    line = shard.read_text(encoding="utf-8").strip()
+    record = json.loads(line)
+    assert record["user"] == "hi"
+    assert record["assistant"] == "hello"
+    assert record["intent"] == "general"
+    assert "ts" in record
+
+
+def test_append_training_record_skips_without_consent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
+    shard = append_training_record(
+        consent=False,
+        user_message="hi",
+        assistant_reply="hello",
+        intent="general",
+    )
+    assert shard is None
+    assert list(tmp_path.glob("*.jsonl")) == []
+
+
+def test_append_training_record_appends_multiple_turns(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
+    for i in range(3):
+        append_training_record(
+            consent=True,
+            user_message=f"user-{i}",
+            assistant_reply=f"reply-{i}",
+            intent="general",
+            session_id="session-1",
+        )
+    shards = list(tmp_path.glob("*.jsonl"))
+    assert len(shards) == 1
+    lines = shards[0].read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 3
+    for i, line in enumerate(lines):
+        record = json.loads(line)
+        assert record["user"] == f"user-{i}"
+        assert record["session_id"] == "session-1"
+
+
+def test_append_training_record_records_feedback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
+    shard = append_training_record(
+        consent=True,
+        user_message="useful?",
+        assistant_reply="yes",
+        intent="general",
+        feedback="up",
+    )
+    assert shard is not None
+    record = json.loads(shard.read_text(encoding="utf-8").strip())
+    assert record["feedback"] == "up"
+
+
+def test_append_training_record_truncates_long_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
+    shard = append_training_record(
+        consent=True,
+        user_message="x" * 10_000,
+        assistant_reply="y" * 20_000,
+        intent="general",
+    )
+    assert shard is not None
+    record = json.loads(shard.read_text(encoding="utf-8").strip())
+    assert len(record["user"]) <= 4096
+    assert len(record["assistant"]) <= 8192
+
+
+def test_train_corpus_dir_respects_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
+    assert train_corpus_dir() == tmp_path

--- a/tests/api/test_polly_workers.py
+++ b/tests/api/test_polly_workers.py
@@ -1,0 +1,153 @@
+"""Tests for Polly worker / integration surfaces."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api.polly_workers import (
+    VOICE_GREETING_DEFAULT,
+    all_statuses,
+    call_service_status,
+    hf_status,
+    kaggle_status,
+    ollama_status,
+    voice_response_twiml,
+)
+
+# ---------------------------------------------------------------------------
+# Status reporting
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_status_always_returns_a_status() -> None:
+    s = ollama_status()
+    assert s.name == "ollama"
+    assert isinstance(s.configured, bool)
+
+
+def test_hf_status_unconfigured_when_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    s = hf_status()
+    assert s.name == "huggingface"
+    assert s.configured is False
+
+
+def test_hf_status_configured_when_token_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HF_TOKEN", "hf_test_token")
+    s = hf_status()
+    assert s.configured is True
+    assert "model=" in s.detail
+
+
+def test_kaggle_status_returns_structured_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without globally mocking Path, just verify the function returns a sane
+    structure regardless of local Kaggle setup."""
+    monkeypatch.delenv("KAGGLE_USERNAME", raising=False)
+    monkeypatch.delenv("KAGGLE_KEY", raising=False)
+    s = kaggle_status()
+    assert s.name == "kaggle"
+    assert isinstance(s.configured, bool)
+    assert isinstance(s.detail, str)
+
+
+def test_kaggle_status_configured_when_env_creds_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KAGGLE_USERNAME", "testuser")
+    monkeypatch.setenv("KAGGLE_KEY", "testkey")
+    s = kaggle_status()
+    assert s.configured is True
+    assert "user=testuser" in s.detail
+
+
+def test_call_service_unconfigured_without_twilio_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN", "TWILIO_PHONE_NUMBER"):
+        monkeypatch.delenv(var, raising=False)
+    s = call_service_status()
+    assert s.name == "twilio_voice"
+    assert s.configured is False
+
+
+def test_call_service_configured_with_all_three(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "ACtest")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TWILIO_PHONE_NUMBER", "+13608080876")
+    s = call_service_status()
+    assert s.configured is True
+    assert "+13608080876" in s.detail
+
+
+def test_all_statuses_returns_four_integrations() -> None:
+    statuses = all_statuses()
+    names = {s.name for s in statuses}
+    assert names == {"ollama", "huggingface", "kaggle", "twilio_voice"}
+
+
+# ---------------------------------------------------------------------------
+# Voice TwiML
+# ---------------------------------------------------------------------------
+
+
+def test_voice_response_uses_default_greeting() -> None:
+    xml = voice_response_twiml()
+    assert "<?xml" in xml
+    assert VOICE_GREETING_DEFAULT.split(",")[0] in xml  # first word of greeting
+    assert "<Record" in xml  # falls back to voicemail
+
+
+def test_voice_response_with_bridge_streams_to_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POLLY_VOICE_AGENT_URL", raising=False)
+    xml = voice_response_twiml(voice_agent_url="wss://example.com/agent")
+    assert '<Stream url="wss://example.com/agent"/>' in xml
+    assert "<Record" not in xml  # bridge mode, no voicemail
+
+
+def test_voice_response_uses_env_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLLY_VOICE_AGENT_URL", "wss://env.example/stream")
+    xml = voice_response_twiml()
+    assert "wss://env.example/stream" in xml
+
+
+def test_voice_response_escapes_xml_specials() -> None:
+    """Custom greeting with & and < should not break the XML."""
+    xml = voice_response_twiml(greeting="Hi & welcome <here>")
+    assert "&amp;" in xml
+    assert "&lt;here>" in xml
+    # And the result should still be parseable XML structure (no raw <here>).
+    assert "<here>" not in xml
+
+
+# ---------------------------------------------------------------------------
+# HF push / Kaggle pull — we don't have credentials in test env, just verify
+# the failure path returns structured errors instead of raising.
+# ---------------------------------------------------------------------------
+
+
+def test_push_to_hf_returns_structured_error_without_token(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    from src.api.polly_workers import push_training_corpus_to_hf
+
+    result = push_training_corpus_to_hf(corpus_dir=tmp_path)
+    assert result["ok"] is False
+    assert "HF_TOKEN" in (result["error"] or "")
+
+
+def test_pull_kaggle_returns_structured_error_when_unconfigured(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.delenv("KAGGLE_USERNAME", raising=False)
+    monkeypatch.delenv("KAGGLE_KEY", raising=False)
+    # Note: this still passes if user has ~/.kaggle/kaggle.json. We only assert
+    # the function returns a dict and never raises.
+    from src.api.polly_workers import pull_kaggle_dataset
+
+    result = pull_kaggle_dataset(dataset_slug="invalid/does-not-exist", target_dir=tmp_path)
+    assert isinstance(result, dict)
+    assert "ok" in result
+    assert "error" in result
+
+
+def test_pull_kaggle_rejects_invalid_slug(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv("KAGGLE_USERNAME", "x")
+    monkeypatch.setenv("KAGGLE_KEY", "y")
+    from src.api.polly_workers import pull_kaggle_dataset
+
+    result = pull_kaggle_dataset(dataset_slug="no-slash-here", target_dir=tmp_path)
+    assert result["ok"] is False
+    assert "invalid slug" in (result["error"] or "")


### PR DESCRIPTION
## Summary
Three-layer upgrade to Polly chat (`/v1/polly/chat`) so the assistant actually helps make money:

1. **Order fulfillment** — buy intent detected → real Stripe link + product details, structured as `ChatResponse.actions[]` so the widget can render real buttons.
2. **Custom-build CTA** — non-stock requests → 4 consulting tiers + pre-filled mailto: with the user's described context. Funnels into \`aethermoore.com/hire\`.
3. **Membership / sponsorship CTA** — tip jar + repo watch + email signup.

Plus auto-training capture and four worker integrations:
- Live conversation turns append to \`training-data/polly-chat-live/{YYYY-MM}.jsonl\` when \`consent_to_train=True\`
- Feedback (thumbs-up/down) capture for rejection sampling
- Ollama + HuggingFace already wired; new \`push_training_corpus_to_hf()\` for periodic dataset upload
- Kaggle dataset puller for training enrichment
- Twilio inbound-voice TwiML stub (bridges to Vapi/Bland/Retell)

## New endpoints
- \`GET  /v1/polly/catalog\` — products Polly can sell
- \`GET  /v1/polly/workers\` — integration health
- \`POST /v1/polly/feedback\` — thumbs-up/down capture
- \`ANY  /v1/polly/voice/inbound\` — Twilio webhook

## Test plan
- [x] 48 new tests (33 commerce + 15 workers) all passing
- [x] Black-formatted
- [x] No new runtime deps required
- [x] All integrations are opt-in (env-var-gated; degrade gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)