### PR TITLE
fix(vercel): ship remote config json

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -3,4 +3,7 @@
 *
 !api
 !api/**
+!docs
+!docs/offers.json
+!docs/app-config.json
 !vercel.json

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -25,6 +25,8 @@ def test_vercelignore_ships_launch_handler_with_api_bridge() -> None:
     assert handler.exists()
     assert "!api" in ignore
     assert "!api/**" in ignore
+    assert "!docs/offers.json" in ignore
+    assert "!docs/app-config.json" in ignore
 
 
 def test_launch_page_links_to_public_docs_and_bridge_endpoints() -> None:


### PR DESCRIPTION
## Summary
- include docs/offers.json and docs/app-config.json in the Vercel deployment bundle
- assert those files stay unignored so /api/agent/offers and /api/agent/app-config do not 500

## Test evidence
- python -m pytest tests/test_vercel_launch_bridge.py -q
- python -m black --check --target-version py311 --line-length 120 tests/test_vercel_launch_bridge.py

## Context
The GitHub Pages remote config is live, but Vercel functions were returning 500 because .vercelignore shipped api/ without the JSON payloads they read.
