### PR TITLE
fix(pages): add docs/hire.html so /hire renders

### DIFF
--- a/docs/hire.html
+++ b/docs/hire.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hire Issac Davis — AI Safety & Governance Engineering</title>
+<meta name="description" content="Independent AI safety and governance engineering. Federal-registered, open-source-first. Available for contract work, security audits, and short-term advisory.">
+<meta property="og:title" content="Hire Issac Davis — AI Safety & Governance Engineering">
+<meta property="og:description" content="Independent AI safety and governance engineering. Federal-registered, open-source-first.">
+<meta property="og:url" content="https://aethermoore.com/hire">
+<meta name="twitter:card" content="summary">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#0a0e1a;--surface:#0f1626;--card:#152033;--border:#243352;
+  --text:#e8f0fb;--dim:#a2b6cc;--accent:#17c6cf;--accent2:#ff9152;
+  --green:#2dd3a6;--gold:#ffd166;
+  --mono:'SF Mono','Cascadia Code','JetBrains Mono','Consolas',monospace;
+  --font:'Inter','Space Grotesk','Trebuchet MS',sans-serif;
+}
+body{
+  background:var(--bg);
+  background-image:
+    radial-gradient(1200px 600px at 12% -8%, rgba(23,198,207,.18), transparent 60%),
+    radial-gradient(900px 500px at 92% 0%, rgba(255,145,82,.14), transparent 58%);
+  color:var(--text);font-family:var(--font);min-height:100vh;line-height:1.5;
+  -webkit-font-smoothing:antialiased;
+}
+.container{max-width:880px;margin:0 auto;padding:48px 24px 96px}
+header{margin-bottom:48px}
+.eyebrow{
+  display:inline-block;font-size:11px;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--accent);font-weight:700;margin-bottom:12px;
+}
+h1{font-size:42px;line-height:1.15;font-weight:800;letter-spacing:-0.02em;margin-bottom:18px}
+h1 span{color:var(--accent)}
+.lede{font-size:19px;color:var(--dim);max-width:680px;margin-bottom:32px}
+.cta-row{display:flex;flex-wrap:wrap;gap:12px;margin-bottom:48px}
+.cta{
+  display:inline-flex;align-items:center;gap:8px;padding:13px 22px;border-radius:8px;
+  font-weight:700;font-size:14px;text-decoration:none;transition:all .15s ease;
+  border:1px solid transparent;
+}
+.cta.primary{background:var(--accent);color:#06121a}
+.cta.primary:hover{background:#1ddae4;transform:translateY(-1px)}
+.cta.secondary{background:transparent;border-color:var(--border);color:var(--text)}
+.cta.secondary:hover{border-color:var(--accent);color:var(--accent)}
+.cta.tertiary{background:transparent;border:none;color:var(--dim);padding:13px 0}
+.cta.tertiary:hover{color:var(--accent)}
+
+section{margin-bottom:56px}
+h2{font-size:24px;font-weight:700;margin-bottom:18px;letter-spacing:-0.01em}
+h2::before{content:"§ ";color:var(--accent);font-weight:400;opacity:.55}
+.muted{color:var(--dim);margin-bottom:14px}
+
+.services{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+.service-card{
+  background:var(--card);border:1px solid var(--border);border-radius:12px;padding:24px;
+  display:flex;flex-direction:column;
+}
+.service-card h3{font-size:16px;font-weight:700;margin-bottom:8px}
+.service-card .price{font-size:13px;color:var(--gold);font-weight:700;margin-bottom:10px;font-family:var(--mono)}
+.service-card p{font-size:14px;color:var(--dim);flex:1}
+
+.proof{
+  background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;
+  font-family:var(--mono);font-size:13px;line-height:1.7;
+}
+.proof .row{display:flex;justify-content:space-between;gap:24px;padding:6px 0;border-bottom:1px dashed rgba(142,170,199,.18)}
+.proof .row:last-child{border-bottom:none}
+.proof .label{color:var(--dim)}
+.proof .value{color:var(--text);text-align:right}
+.proof .value a{color:var(--accent);text-decoration:none}
+.proof .value a:hover{text-decoration:underline}
+
+.qual-list{list-style:none;display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+.qual-list li{
+  padding:18px 20px;background:var(--card);border:1px solid var(--border);border-radius:10px;
+  font-size:14px;
+}
+.qual-list strong{display:block;color:var(--accent);margin-bottom:6px;font-size:13px;font-weight:700;letter-spacing:.02em}
+
+.trust{
+  background:linear-gradient(135deg,rgba(23,198,207,.08),rgba(255,145,82,.04));
+  border:1px solid var(--border);border-radius:12px;padding:28px;
+}
+.trust h2{margin-bottom:8px}
+.trust p{color:var(--dim);font-size:14px;margin-bottom:14px}
+.trust .legal{font-size:12px;color:#7a8da3;font-style:italic}
+
+footer{
+  margin-top:80px;padding-top:32px;border-top:1px solid var(--border);
+  display:flex;flex-wrap:wrap;justify-content:space-between;gap:16px;
+  font-size:12px;color:#7a8da3;
+}
+footer a{color:var(--dim);text-decoration:none}
+footer a:hover{color:var(--accent)}
+
+@media (max-width:600px){
+  h1{font-size:32px}
+  .lede{font-size:17px}
+  .container{padding:32px 18px 72px}
+}
+</style>
+</head>
+<body>
+<div class="container">
+
+<header>
+<div class="eyebrow">Available now · Federal-registered · Open-source-first</div>
+<h1>AI safety and governance engineering, <span>built solo, shipped real.</span></h1>
+<p class="lede">I build the parts of AI systems that the model providers don't ship. Adversarial-cost manifolds, governance overlays, formal-methods tooling, audit-grade telemetry. Independent. SAM.gov registered. Available for contract, advisory, and audit work this quarter.</p>
+
+<div class="cta-row">
+<a class="cta primary" href="mailto:issdandavis7795@gmail.com?subject=Engagement%20inquiry%20%E2%80%94%20from%20aethermoore.com%2Fhire&body=Hi%20Issac%2C%0A%0AI%27d%20like%20to%20discuss%3A%0A%5B%20%5D%20Short%20advisory%20call%0A%5B%20%5D%20Custom%20governance%20overlay%0A%5B%20%5D%20Adversarial%20audit%0A%5B%20%5D%20Federal%20subcontract%20conversation%0A%5B%20%5D%20Other%3A%0A%0AContext%3A%0A%0AThanks%2C">Email me directly</a>
+<a class="cta secondary" href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">See the work</a>
+<a class="cta tertiary" href="https://ko-fi.com/Y8Y51UQYWZ" target="_blank" rel="noopener">Or tip the work →</a>
+</div>
+</header>
+
+<section>
+<h2>What I do</h2>
+<p class="muted">Concrete engagements with real deliverables. Pricing is anchored, not theoretical.</p>
+<div class="services">
+
+<div class="service-card">
+<h3>Short advisory call</h3>
+<div class="price">$300 · 60 min · same week</div>
+<p>One-hour conversation about a concrete AI safety / governance problem you're facing. You leave with a written summary and a follow-up action list. If we don't find a real path, you don't pay.</p>
+</div>
+
+<div class="service-card">
+<h3>Adversarial audit</h3>
+<div class="price">$5,000 – $15,000 · 1–3 weeks</div>
+<p>I run my own L13 governance harness against your production LLM endpoint or agent. You get the full attack catalog, false-allow rate, latency profile, and a remediation plan. Composes with Anthropic Petri.</p>
+</div>
+
+<div class="service-card">
+<h3>Custom governance overlay</h3>
+<div class="price">$25,000 – $80,000 · 4–10 weeks</div>
+<p>I build a deployable governance layer (containerized service, ≤200ms median latency) sitting in front of your model API. Handles prompt-injection, identifier-canonicality, bijective-tamper, and your domain-specific constraints. Open-source by default; private-fork for regulated workloads.</p>
+</div>
+
+<div class="service-card">
+<h3>Federal subcontract role</h3>
+<div class="price">$150 – $250 / hour · contract</div>
+<p>I'm SAM.gov registered (UEI J4NXHM6N5F59) and ready to subcontract on AI-safety, governance, or LLM-evaluation work. Two DARPA proposals in active eval. Comfortable with FAR 9.5 source-selection-protected work.</p>
+</div>
+
+<div class="service-card">
+<h3>Open-source feature work</h3>
+<div class="price">$100 – $300 / hour · contract</div>
+<p>If you're using <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" style="color:var(--accent)">SCBE-AETHERMOORE</a> or any of my npm/PyPI packages and want a feature added, integrated, or hardened — I'm the canonical author. Sponsorships and bounties accepted.</p>
+</div>
+
+<div class="service-card">
+<h3>Workshops & internal training</h3>
+<div class="price">$2,500 – $7,500 · half day or full day</div>
+<p>Walk your engineering team through hyperbolic-geometry foundations, the 14-layer pipeline, or the practical implementation of NIST AI RMF / EO 14110 governance evidence. Remote or in-person (PNW preferred).</p>
+</div>
+
+</div>
+</section>
+
+<section>
+<h2>Verifiable proof</h2>
+<p class="muted">Don't take my word for it. Every claim below is independently verifiable in 30 seconds.</p>
+<div class="proof">
+<div class="row"><span class="label">SAM.gov UEI</span><span class="value">J4NXHM6N5F59 · ACTIVE through 2027-04-03</span></div>
+<div class="row"><span class="label">CAGE code</span><span class="value">1EXD5</span></div>
+<div class="row"><span class="label">Open-source library</span><span class="value"><a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">github.com/issdandavis/SCBE-AETHERMOORE</a></span></div>
+<div class="row"><span class="label">npm package</span><span class="value"><a href="https://www.npmjs.com/package/scbe-aethermoore" target="_blank" rel="noopener">scbe-aethermoore</a></span></div>
+<div class="row"><span class="label">PyPI package</span><span class="value"><a href="https://pypi.org/project/scbe-agent-bus/" target="_blank" rel="noopener">scbe-agent-bus</a></span></div>
+<div class="row"><span class="label">Provisional patent</span><span class="value">US 63/961,403 (hyperbolic governance substrate)</span></div>
+<div class="row"><span class="label">Federal proposals</span><span class="value">DARPA CLARA FP-033 · DARPA MATHBAC abstract</span></div>
+<div class="row"><span class="label">APEX Accelerator</span><span class="value">Port Angeles SBA-affiliated partner</span></div>
+<div class="row"><span class="label">Small business status</span><span class="value">Sole proprietor · minority-owned</span></div>
+</div>
+</section>
+
+<section>
+<h2>What I'm uniquely good at</h2>
+<ul class="qual-list">
+<li><strong>Adversarial-cost manifold design</strong>Closed-form bounds on attack cost, not learned filters. Hyperbolic geometry as substrate.</li>
+<li><strong>Constrained-decoding governance</strong>180/180 cross-lane structural enforcement. Wilson CI [0.979, 1.0]. Deterministic.</li>
+<li><strong>Multi-axiom formal models</strong>5-axiom mesh (unitarity, locality, causality, symmetry, composition) across 14 pipeline layers.</li>
+<li><strong>Composing with audit tools</strong>173/173 Petri seeds blocked when SCBE wired as enforcement layer. Cite: Anthropic Petri (2026 Q1).</li>
+<li><strong>Post-quantum primitives</strong>ML-KEM-768 + ML-DSA-65 + AES-256-GCM throughout. Migration-tested across liboqs renames.</li>
+<li><strong>Federal-readiness packaging</strong>SAM-registered, capability statement on file, NAICS coverage across 7 codes.</li>
+</ul>
+</section>
+
+<section>
+<h2>How to engage</h2>
+<p class="muted">I prefer concrete starts. Here are three frictionless ways in:</p>
+<div class="services">
+<div class="service-card">
+<h3>1. Email — fastest</h3>
+<p style="margin-bottom:14px"><a href="mailto:issdandavis7795@gmail.com?subject=Engagement%20inquiry%20%E2%80%94%20from%20aethermoore.com%2Fhire" style="color:var(--accent)">issdandavis7795@gmail.com</a></p>
+<p>Best for advisory calls, audits, or scoped engagements. Average reply time under 24 hours, often same day.</p>
+</div>
+<div class="service-card">
+<h3>2. Phone — for federal</h3>
+<p style="margin-bottom:14px"><a href="tel:+13608080876" style="color:var(--accent)">(360) 808-0876</a></p>
+<p>Best for federal subcontract conversations, prime contractor BD calls, or anything involving SAM/CAGE verification.</p>
+</div>
+<div class="service-card">
+<h3>3. Sponsor or tip</h3>
+<p style="margin-bottom:14px"><a href="https://ko-fi.com/Y8Y51UQYWZ" target="_blank" rel="noopener" style="color:var(--accent)">ko-fi.com/Y8Y51UQYWZ</a></p>
+<p>If the open-source work has helped you and there's no engagement on the table, a sponsorship keeps the work funded and the next release shipping.</p>
+</div>
+</div>
+</section>
+
+<section>
+<div class="trust">
+<h2>How I work</h2>
+<p>Solo. No subcontracting layers, no junior teams shadowed by a senior, no offshoring. You talk directly to the principal. Engagements get a written scope before money changes hands. Open-source delivery is the default; private-fork is available for regulated workloads with a written justification.</p>
+<p>Booked from Port Angeles, WA. APEX Accelerator partnership. SAM.gov UEI J4NXHM6N5F59.</p>
+<p class="legal">This page is informational. Engagements require a written agreement (statement of work or contract) before performance begins. Federal subcontract work follows the prime's flowdown clauses; FAR 9.5 source-selection sensitive matters are handled per the prime's policy.</p>
+</div>
+</section>
+
+<footer>
+<div>
+<a href="https://aethermoore.com">aethermoore.com</a> · <a href="https://github.com/issdandavis/SCBE-AETHERMOORE">GitHub</a> · <a href="mailto:issdandavis7795@gmail.com">issdandavis7795@gmail.com</a>
+</div>
+<div>
+Built solo · Last updated 2026-05-09
+</div>
+</footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
GitHub Pages source is /docs not /public. PR #1480 added public/hire.html but aethermoore.com/hire still returns 404 because that file isn't at the served path. This adds the same content at docs/hire.html.

## Verification
- `gh api repos/issdandavis/SCBE-AETHERMOORE/pages` confirms source.path = '/docs'
- `curl -sIL https://aethermoore.com/hire` returned 404 before this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)