### PR TITLE
test(app): add remote config smoke gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,8 @@
     "cash:sprint": "python scripts/revenue/daily_cash_sprint.py",
     "cash:sprint:run": "python scripts/revenue/daily_cash_sprint.py --continuous",
     "cash:sprint:watch": "python scripts/revenue/daily_cash_sprint.py --continuous --cycle-when-complete --max-steps 1",
+    "smoke:remote-app-config": "python scripts/system/remote_app_config_smoke.py",
+    "smoke:remote-app-config:live": "python scripts/system/remote_app_config_smoke.py --live",
     "feature:explore": "python scripts/explore_scbe_feature_space.py",
     "eval:legacy:hf": "python scripts/run_legacy_hf_eval.py",
     "probe:attention:fft": "python scripts/probe_attention_fft.py",

--- a/scripts/system/remote_app_config_smoke.py
+++ b/scripts/system/remote_app_config_smoke.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Smoke-test the remote app configuration and public offer surfaces.
+
+This is the quick gate to run before an app bundle release or after changing
+remote revenue/config files. It validates the local JSON first, then optionally
+checks the live GitHub Pages and Vercel endpoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PAGES_BASE = "https://aethermoore.com/SCBE-AETHERMOORE"
+VERCEL_BASE = "https://scbe-agent-bridge-vercel.vercel.app"
+
+OFFERS_SCHEMA = "aethermoore-offers-v1"
+APP_CONFIG_SCHEMA = "aethermoor-bus-app-config-v1"
+PACKAGE_NAME = "io.aethermoor.bus"
+
+REQUIRED_OFFER_IDS = {
+    "tip_jar",
+    "supporter_monthly",
+    "governance_snapshot",
+}
+
+DEAD_CHECKOUT_ENDPOINT = "api.aethermoore.com/v1/billing/public-checkout"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+
+
+def pass_check(name: str, detail: str = "ok") -> CheckResult:
+    return CheckResult(name=name, ok=True, detail=detail)
+
+
+def fail_check(name: str, detail: str) -> CheckResult:
+    return CheckResult(name=name, ok=False, detail=detail)
+
+
+def load_json_file(path: Path) -> tuple[dict[str, Any] | None, CheckResult]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, fail_check(f"local:{path.name}:exists", f"missing {path}")
+    except json.JSONDecodeError as exc:
+        return None, fail_check(f"local:{path.name}:json", f"invalid json: {exc}")
+    if not isinstance(data, dict):
+        return None, fail_check(f"local:{path.name}:object", "top-level JSON must be an object")
+    return data, pass_check(f"local:{path.name}:json")
+
+
+def fetch_url(url: str, timeout: float = 20.0) -> tuple[str | None, CheckResult]:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "SCBE-remote-app-config-smoke/1.0",
+            "Accept": "application/json,text/html;q=0.9,*/*;q=0.8",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            status = getattr(response, "status", 200)
+    except urllib.error.HTTPError as exc:
+        return None, fail_check(f"live:{url}", f"http {exc.code}")
+    except urllib.error.URLError as exc:
+        return None, fail_check(f"live:{url}", f"request failed: {exc.reason}")
+    except TimeoutError:
+        return None, fail_check(f"live:{url}", "request timed out")
+    if status < 200 or status >= 300:
+        return None, fail_check(f"live:{url}", f"http {status}")
+    return body, pass_check(f"live:{url}", f"http {status}")
+
+
+def parse_json_text(text: str, source: str) -> tuple[dict[str, Any] | None, CheckResult]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, fail_check(f"{source}:json", f"invalid json: {exc}")
+    if not isinstance(data, dict):
+        return None, fail_check(f"{source}:object", "top-level JSON must be an object")
+    return data, pass_check(f"{source}:json")
+
+
+def normalize_vercel_payload(data: dict[str, Any]) -> dict[str, Any]:
+    """Vercel endpoints wrap payloads in {ok, data}; local Pages JSON does not."""
+    payload = data.get("data")
+    if data.get("ok") is True and isinstance(payload, dict):
+        return payload
+    return data
+
+
+def validate_offer_catalog(data: dict[str, Any], source: str) -> list[CheckResult]:
+    payload = normalize_vercel_payload(data)
+    checks: list[CheckResult] = []
+
+    schema = payload.get("schema")
+    checks.append(
+        pass_check(f"{source}:schema", schema)
+        if schema == OFFERS_SCHEMA
+        else fail_check(f"{source}:schema", f"expected {OFFERS_SCHEMA}, got {schema!r}")
+    )
+
+    offers = payload.get("offers")
+    if not isinstance(offers, list):
+        return checks + [fail_check(f"{source}:offers", "offers must be a list")]
+
+    by_id = {offer.get("id"): offer for offer in offers if isinstance(offer, dict)}
+    missing = sorted(REQUIRED_OFFER_IDS - set(by_id))
+    checks.append(
+        pass_check(f"{source}:required_offers", ",".join(sorted(REQUIRED_OFFER_IDS)))
+        if not missing
+        else fail_check(f"{source}:required_offers", f"missing {missing}")
+    )
+
+    for offer_id in sorted(REQUIRED_OFFER_IDS):
+        offer = by_id.get(offer_id)
+        if not isinstance(offer, dict):
+            continue
+        checkout = str(offer.get("checkout_url", ""))
+        checks.append(
+            pass_check(f"{source}:{offer_id}:checkout", checkout)
+            if checkout.startswith("https://buy.stripe.com/")
+            else fail_check(f"{source}:{offer_id}:checkout", f"not a Stripe hosted checkout: {checkout!r}")
+        )
+        proof_url = str(offer.get("proof_url", ""))
+        checks.append(
+            pass_check(f"{source}:{offer_id}:proof_url", proof_url)
+            if not proof_url or proof_url.startswith(PAGES_BASE)
+            else fail_check(f"{source}:{offer_id}:proof_url", f"unexpected proof URL: {proof_url!r}")
+        )
+
+    return checks
+
+
+def validate_app_config(data: dict[str, Any], source: str) -> list[CheckResult]:
+    payload = normalize_vercel_payload(data)
+    checks: list[CheckResult] = []
+
+    schema = payload.get("schema")
+    checks.append(
+        pass_check(f"{source}:schema", schema)
+        if schema == APP_CONFIG_SCHEMA
+        else fail_check(f"{source}:schema", f"expected {APP_CONFIG_SCHEMA}, got {schema!r}")
+    )
+
+    app = payload.get("app")
+    package_name = app.get("package_name") if isinstance(app, dict) else None
+    checks.append(
+        pass_check(f"{source}:package_name", package_name)
+        if package_name == PACKAGE_NAME
+        else fail_check(f"{source}:package_name", f"expected {PACKAGE_NAME}, got {package_name!r}")
+    )
+
+    remote_update = payload.get("remote_update")
+    supported = remote_update.get("supported") if isinstance(remote_update, dict) else None
+    checks.append(
+        pass_check(f"{source}:remote_update", "supported")
+        if supported is True
+        else fail_check(f"{source}:remote_update", f"expected true, got {supported!r}")
+    )
+
+    endpoints = payload.get("endpoints")
+    if not isinstance(endpoints, dict):
+        return checks + [fail_check(f"{source}:endpoints", "endpoints must be an object")]
+
+    expected_endpoints = {
+        "offers_json": f"{PAGES_BASE}/offers.json",
+        "supporter_page": f"{PAGES_BASE}/supporter.html",
+        "agent_bridge_offers": f"{VERCEL_BASE}/api/agent/offers",
+        "agent_bridge_app_config": f"{VERCEL_BASE}/api/agent/app-config",
+    }
+    for key, expected in expected_endpoints.items():
+        actual = endpoints.get(key)
+        checks.append(
+            pass_check(f"{source}:endpoint:{key}", expected)
+            if actual == expected
+            else fail_check(f"{source}:endpoint:{key}", f"expected {expected!r}, got {actual!r}")
+        )
+
+    features = payload.get("features")
+    if isinstance(features, dict):
+        for key in REQUIRED_OFFER_IDS:
+            checks.append(
+                pass_check(f"{source}:feature:{key}", "enabled")
+                if features.get(key) is True
+                else fail_check(f"{source}:feature:{key}", f"expected true, got {features.get(key)!r}")
+            )
+    else:
+        checks.append(fail_check(f"{source}:features", "features must be an object"))
+
+    fallback = payload.get("fallbacks", {}).get("primary_offer") if isinstance(payload.get("fallbacks"), dict) else ""
+    checks.append(
+        pass_check(f"{source}:fallback_primary_offer", fallback)
+        if str(fallback).startswith("https://buy.stripe.com/")
+        else fail_check(f"{source}:fallback_primary_offer", f"not a Stripe hosted checkout: {fallback!r}")
+    )
+
+    return checks
+
+
+def validate_supporter_page(text: str, source: str) -> list[CheckResult]:
+    return [
+        (
+            pass_check(f"{source}:no_dead_checkout_endpoint")
+            if DEAD_CHECKOUT_ENDPOINT not in text
+            else fail_check(f"{source}:no_dead_checkout_endpoint", DEAD_CHECKOUT_ENDPOINT)
+        ),
+        (
+            pass_check(f"{source}:stripe_checkout_present")
+            if "https://buy.stripe.com/" in text
+            else fail_check(f"{source}:stripe_checkout_present", "no Stripe hosted checkout link found")
+        ),
+    ]
+
+
+def run_checks(live: bool = False) -> list[CheckResult]:
+    checks: list[CheckResult] = []
+
+    offers_data, check = load_json_file(REPO_ROOT / "docs" / "offers.json")
+    checks.append(check)
+    if offers_data is not None:
+        checks.extend(validate_offer_catalog(offers_data, "local:offers"))
+
+    app_config_data, check = load_json_file(REPO_ROOT / "docs" / "app-config.json")
+    checks.append(check)
+    if app_config_data is not None:
+        checks.extend(validate_app_config(app_config_data, "local:app_config"))
+
+    supporter_path = REPO_ROOT / "docs" / "supporter.html"
+    if supporter_path.exists():
+        checks.extend(validate_supporter_page(supporter_path.read_text(encoding="utf-8"), "local:supporter_page"))
+    else:
+        checks.append(fail_check("local:supporter_page:exists", f"missing {supporter_path}"))
+
+    if not live:
+        return checks
+
+    live_json_targets = [
+        (f"{PAGES_BASE}/offers.json", validate_offer_catalog, "live:pages:offers"),
+        (f"{PAGES_BASE}/app-config.json", validate_app_config, "live:pages:app_config"),
+        (f"{VERCEL_BASE}/api/agent/offers", validate_offer_catalog, "live:vercel:offers"),
+        (f"{VERCEL_BASE}/api/agent/app-config", validate_app_config, "live:vercel:app_config"),
+    ]
+    for url, validator, source in live_json_targets:
+        text, check = fetch_url(url)
+        checks.append(check)
+        if text is None:
+            continue
+        data, parse_check = parse_json_text(text, source)
+        checks.append(parse_check)
+        if data is not None:
+            checks.extend(validator(data, source))
+
+    for url, source in [
+        (f"{PAGES_BASE}/supporter.html", "live:pages:supporter_page"),
+        (f"{PAGES_BASE}/offers/", "live:pages:offers_page"),
+    ]:
+        text, check = fetch_url(url)
+        checks.append(check)
+        if text is not None:
+            checks.extend(validate_supporter_page(text, source))
+
+    return checks
+
+
+def write_report(path: Path, checks: list[CheckResult], live: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": "scbe-remote-app-config-smoke-v1",
+        "live": live,
+        "ok": all(check.ok for check in checks),
+        "checks": [asdict(check) for check in checks],
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--live", action="store_true", help="also check live GitHub Pages and Vercel endpoints")
+    parser.add_argument("--json", action="store_true", dest="as_json", help="print JSON instead of line output")
+    parser.add_argument("--report", type=Path, help="write a JSON report to this path")
+    args = parser.parse_args(argv)
+
+    checks = run_checks(live=args.live)
+    ok = all(check.ok for check in checks)
+
+    if args.report:
+        write_report(args.report, checks, live=args.live)
+
+    if args.as_json:
+        print(json.dumps({"ok": ok, "live": args.live, "checks": [asdict(check) for check in checks]}, indent=2))
+    else:
+        mode = "LIVE" if args.live else "LOCAL"
+        print(f"SCBE remote app config smoke ({mode})")
+        for check in checks:
+            tag = "PASS" if check.ok else "FAIL"
+            print(f"[{tag}] {check.name} - {check.detail}")
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/system/test_remote_app_config_smoke.py
+++ b/tests/system/test_remote_app_config_smoke.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from scripts.system.remote_app_config_smoke import (
+    APP_CONFIG_SCHEMA,
+    OFFERS_SCHEMA,
+    PACKAGE_NAME,
+    PAGES_BASE,
+    VERCEL_BASE,
+    run_checks,
+    validate_app_config,
+    validate_offer_catalog,
+)
+
+
+def _details(checks):
+    return "\n".join(f"{check.name}: {check.detail}" for check in checks if not check.ok)
+
+
+def test_remote_app_config_local_smoke_passes():
+    checks = run_checks(live=False)
+    assert all(check.ok for check in checks), _details(checks)
+
+
+def test_offer_catalog_rejects_non_stripe_required_checkout():
+    checks = validate_offer_catalog(
+        {
+            "schema": OFFERS_SCHEMA,
+            "offers": [
+                {
+                    "id": "tip_jar",
+                    "checkout_url": "https://example.com/not-stripe",
+                    "proof_url": f"{PAGES_BASE}/supporter.html",
+                },
+                {
+                    "id": "supporter_monthly",
+                    "checkout_url": "https://buy.stripe.com/test",
+                    "proof_url": f"{PAGES_BASE}/supporter.html",
+                },
+                {
+                    "id": "governance_snapshot",
+                    "checkout_url": "https://buy.stripe.com/test2",
+                    "proof_url": f"{PAGES_BASE}/governance-snapshot.html",
+                },
+            ],
+        },
+        "unit:offers",
+    )
+    assert any(not check.ok and check.name == "unit:offers:tip_jar:checkout" for check in checks)
+
+
+def test_app_config_rejects_package_name_drift():
+    checks = validate_app_config(
+        {
+            "schema": APP_CONFIG_SCHEMA,
+            "app": {"package_name": "io.aethermoor.wrong"},
+            "remote_update": {"supported": True},
+            "endpoints": {
+                "offers_json": f"{PAGES_BASE}/offers.json",
+                "supporter_page": f"{PAGES_BASE}/supporter.html",
+                "agent_bridge_offers": f"{VERCEL_BASE}/api/agent/offers",
+                "agent_bridge_app_config": f"{VERCEL_BASE}/api/agent/app-config",
+            },
+            "features": {
+                "tip_jar": True,
+                "supporter_monthly": True,
+                "governance_snapshot": True,
+            },
+            "fallbacks": {"primary_offer": "https://buy.stripe.com/test"},
+        },
+        "unit:app_config",
+    )
+    assert any(
+        not check.ok and check.name == "unit:app_config:package_name" and PACKAGE_NAME in check.detail
+        for check in checks
+    )


### PR DESCRIPTION
## Summary
- add a standard-library smoke script for Aethermoor Bus remote app config and offer surfaces
- validate package name, remote update support, required Stripe offer IDs, public proof URLs, and dead checkout endpoint removal
- expose npm shortcuts for local and live smoke checks

## Test evidence
- python scripts/system/remote_app_config_smoke.py
- python scripts/system/remote_app_config_smoke.py --live
- npm run smoke:remote-app-config -- --json
- python -m black --check --line-length 120 scripts/system/remote_app_config_smoke.py tests/system/test_remote_app_config_smoke.py
- python -m pytest tests/system/test_remote_app_config_smoke.py tests/test_vercel_launch_bridge.py -q

## Rollback
- revert dda95f00 to remove the smoke script, tests, and npm shortcuts