### PR TITLE
feat(polly): vercel JS commerce bridge + durable training capture for aethermoore.com

### DIFF
--- a/.github/workflows/polly-training-capture.yml
+++ b/.github/workflows/polly-training-capture.yml
@@ -1,0 +1,48 @@
+name: Polly Training Capture
+
+on:
+  repository_dispatch:
+    types: [polly_training_turn]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: polly-training-capture
+  cancel-in-progress: false
+
+jobs:
+  append-jsonl:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Append consented turn to live corpus
+        env:
+          PAYLOAD: ${{ toJSON(github.event.client_payload.record) }}
+        run: |
+          set -euo pipefail
+          mkdir -p training-data/polly-chat-live
+          shard="training-data/polly-chat-live/$(date -u +%Y-%m).jsonl"
+          # Validate JSON before writing.
+          echo "$PAYLOAD" | python3 -c "import json,sys; json.loads(sys.stdin.read())"
+          # Compact to one line and append.
+          echo "$PAYLOAD" | python3 -c "import json,sys; print(json.dumps(json.loads(sys.stdin.read()), ensure_ascii=False))" >> "$shard"
+          echo "appended to $shard"
+
+      - name: Commit if anything changed
+        run: |
+          set -euo pipefail
+          if [[ -z "$(git status --porcelain training-data/polly-chat-live)" ]]; then
+            echo "no changes to commit"
+            exit 0
+          fi
+          git config user.name "polly-train-capture[bot]"
+          git config user.email "polly-train-capture@users.noreply.github.com"
+          git add training-data/polly-chat-live
+          git commit -m "chore(polly): append consented chat turn to live corpus"
+          git push

--- a/api/_chat_llm.js
+++ b/api/_chat_llm.js
@@ -1,0 +1,242 @@
+'use strict';
+
+// Shared LLM router used by api/agent/chat.js and api/polly/chat.js.
+// Extracted to a sibling helper so each Vercel Function can bundle it
+// independently (ncc follows relative requires within the function dir's
+// dependency tree, but cross-function requires like `../agent/chat`
+// from `api/polly/chat.js` are not guaranteed to be hoisted).
+
+const DEFAULT_HF_MODEL = 'Qwen/Qwen2.5-72B-Instruct';
+const DEFAULT_OLLAMA_MODEL = 'llama3.2';
+const DEFAULT_MAX_TOKENS = 512;
+const DEFAULT_TIMEOUT_MS = 25000;
+
+const SYSTEM_PROMPT =
+  'You are Polly, the AI assistant for AetherMoore — an AI safety and governance framework ' +
+  'using hyperbolic geometry with a 14-layer security pipeline. Be helpful, concise, and ' +
+  'accurate. If asked about SCBE, explain the core innovation: governed agent behavior with ' +
+  'auditable safety decisions and cheap-first/local-first model routing.';
+
+function cleanBaseUrl(value) {
+  return String(value || '')
+    .trim()
+    .replace(/\/+$/, '');
+}
+
+function chatConfig() {
+  const hfModel = String(
+    process.env.HF_MODEL || process.env.AGENT_HF_MODEL || DEFAULT_HF_MODEL
+  ).trim();
+  const ollamaModel = String(
+    process.env.OLLAMA_MODEL || process.env.AGENT_OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL
+  ).trim();
+  return {
+    hfModel,
+    hfToken:
+      process.env.HF_TOKEN ||
+      process.env.HUGGINGFACE_TOKEN ||
+      process.env.HUGGING_FACE_HUB_TOKEN ||
+      '',
+    hfUrl:
+      process.env.HF_CHAT_URL ||
+      `https://router.huggingface.co/hf-inference/models/${encodeURIComponent(hfModel)}/v1/chat/completions`,
+    ollamaUrl: cleanBaseUrl(process.env.OLLAMA_URL || process.env.AGENT_OLLAMA_URL || ''),
+    ollamaModel,
+    providerOrder: String(process.env.AGENT_CHAT_PROVIDER_ORDER || 'ollama,huggingface,offline')
+      .split(',')
+      .map((item) => item.trim().toLowerCase())
+      .filter(Boolean),
+    timeoutMs: Math.max(1000, Number(process.env.AGENT_CHAT_TIMEOUT_MS || DEFAULT_TIMEOUT_MS)),
+  };
+}
+
+function normalizeText(value) {
+  if (typeof value === 'string') return value.trim();
+  if (Array.isArray(value)) {
+    return value.map(normalizeText).filter(Boolean).join('\n').trim();
+  }
+  if (value && typeof value === 'object') {
+    return normalizeText(value.text || value.content || value.generated_text || '');
+  }
+  return '';
+}
+
+function buildMessages(message, history) {
+  const messages = [{ role: 'system', content: SYSTEM_PROMPT }];
+  if (Array.isArray(history)) {
+    history.slice(-6).forEach((row) => {
+      const role = row && ['system', 'user', 'assistant'].includes(row.role) ? row.role : '';
+      const content = normalizeText(row && row.content);
+      if (role && content) messages.push({ role, content });
+    });
+  }
+  messages.push({ role: 'user', content: String(message).trim() });
+  return messages;
+}
+
+function messagesToPrompt(messages) {
+  return messages
+    .map((row) => {
+      const role =
+        row.role === 'assistant' ? 'Assistant' : row.role === 'system' ? 'System' : 'User';
+      return `${role}: ${row.content}`;
+    })
+    .join('\n\n')
+    .slice(0, 12000);
+}
+
+async function fetchWithTimeout(url, init, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function tryOllama(cfg, messages) {
+  if (!cfg.ollamaUrl) return null;
+  const response = await fetchWithTimeout(
+    `${cfg.ollamaUrl}/api/generate`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: cfg.ollamaModel,
+        prompt: messagesToPrompt(messages),
+        stream: false,
+      }),
+    },
+    cfg.timeoutMs
+  );
+  if (!response.ok) {
+    return {
+      ok: false,
+      provider: 'ollama',
+      model: cfg.ollamaModel,
+      error: `Ollama returned ${response.status}`,
+      detail: (await response.text()).slice(0, 400),
+    };
+  }
+  const data = await response.json();
+  const text = normalizeText(data.response);
+  if (!text) {
+    return {
+      ok: false,
+      provider: 'ollama',
+      model: cfg.ollamaModel,
+      error: 'Ollama returned no text',
+    };
+  }
+  return {
+    ok: true,
+    text,
+    provider: 'ollama',
+    model: cfg.ollamaModel,
+    tokens_in: Number(data.prompt_eval_count || 0),
+    tokens_out: Number(data.eval_count || 0),
+  };
+}
+
+async function tryHuggingFace(cfg, messages) {
+  if (!cfg.hfToken) return null;
+  const response = await fetchWithTimeout(
+    cfg.hfUrl,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${cfg.hfToken}`,
+      },
+      body: JSON.stringify({ model: cfg.hfModel, messages, max_tokens: DEFAULT_MAX_TOKENS }),
+    },
+    cfg.timeoutMs
+  );
+  if (!response.ok) {
+    return {
+      ok: false,
+      provider: 'huggingface',
+      model: cfg.hfModel,
+      error: `Hugging Face returned ${response.status}`,
+      detail: (await response.text()).slice(0, 400),
+    };
+  }
+  const data = await response.json();
+  const text =
+    normalizeText(
+      data &&
+        data.choices &&
+        data.choices[0] &&
+        data.choices[0].message &&
+        data.choices[0].message.content
+    ) ||
+    normalizeText(data && data.generated_text) ||
+    normalizeText(data && data.text) ||
+    normalizeText(Array.isArray(data) && data[0]);
+  if (!text) {
+    return {
+      ok: false,
+      provider: 'huggingface',
+      model: cfg.hfModel,
+      error: 'Hugging Face returned no text',
+    };
+  }
+  return { ok: true, text, provider: 'huggingface', model: cfg.hfModel };
+}
+
+function offlineReply(message, attempts) {
+  return {
+    ok: true,
+    text:
+      '[offline/local-first mode]\n\n' +
+      'No configured chat model answered. Start Ollama at home or set HF_TOKEN for the hosted fallback.\n\n' +
+      `Your message was received: ${String(message).slice(0, 600)}`,
+    provider: 'offline',
+    model: 'none',
+    attempts,
+  };
+}
+
+async function routeChat(cfg, message, history) {
+  const messages = buildMessages(message, history);
+  const attempts = [];
+  for (const provider of cfg.providerOrder) {
+    try {
+      const result =
+        provider === 'ollama'
+          ? await tryOllama(cfg, messages)
+          : provider === 'huggingface'
+            ? await tryHuggingFace(cfg, messages)
+            : null;
+      if (!result) {
+        attempts.push({ provider, status: 'skipped', reason: 'not_configured' });
+        continue;
+      }
+      if (result.ok) return { ...result, attempts };
+      attempts.push({
+        provider,
+        status: 'failed',
+        model: result.model,
+        error: result.error,
+        detail: result.detail || '',
+      });
+    } catch (error) {
+      attempts.push({
+        provider,
+        status: 'failed',
+        error: String(error && error.message ? error.message : error).slice(0, 400),
+      });
+    }
+  }
+  return offlineReply(message, attempts);
+}
+
+module.exports = {
+  SYSTEM_PROMPT,
+  chatConfig,
+  buildMessages,
+  messagesToPrompt,
+  normalizeText,
+  routeChat,
+};

--- a/api/_polly_train_capture.js
+++ b/api/_polly_train_capture.js
@@ -1,0 +1,86 @@
+'use strict';
+
+// Best-effort durable capture of consented Polly chat turns.
+// Strategy: fire a GitHub repository_dispatch event whose payload is the
+// training record. A workflow listens for the `polly_training_turn` event
+// type and appends the record to training-data/polly-chat-live/{YYYY-MM}.jsonl
+// in main, then commits.
+//
+// All paths are non-blocking and never raise into the chat path.
+
+const DEFAULT_REPO = 'issdandavis/SCBE-AETHERMOORE';
+const EVENT_TYPE = 'polly_training_turn';
+
+function trainConfig() {
+  return {
+    token:
+      process.env.POLLY_TRAIN_GITHUB_TOKEN ||
+      process.env.GITHUB_TOKEN ||
+      process.env.GH_TOKEN ||
+      '',
+    repo: process.env.POLLY_TRAIN_REPO || process.env.GITHUB_REPO || DEFAULT_REPO,
+    enabled: String(process.env.POLLY_TRAIN_DISPATCH_ENABLED || 'true').toLowerCase() !== 'false',
+    timeoutMs: Math.max(500, Number(process.env.POLLY_TRAIN_DISPATCH_TIMEOUT_MS || 4000)),
+  };
+}
+
+async function fetchWithTimeout(url, init, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function dispatchTrainingTurn(record) {
+  const cfg = trainConfig();
+  if (!cfg.enabled) return { ok: false, reason: 'disabled' };
+  if (!cfg.token) return { ok: false, reason: 'no_token' };
+  if (!record || typeof record !== 'object') return { ok: false, reason: 'invalid_record' };
+
+  const url = `https://api.github.com/repos/${cfg.repo}/dispatches`;
+  const body = JSON.stringify({
+    event_type: EVENT_TYPE,
+    client_payload: { record },
+  });
+
+  try {
+    const response = await fetchWithTimeout(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${cfg.token}`,
+          'Content-Type': 'application/json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'scbe-polly-train-capture',
+        },
+        body,
+      },
+      cfg.timeoutMs
+    );
+    if (!response.ok) {
+      return {
+        ok: false,
+        reason: `github_${response.status}`,
+        detail: (await response.text()).slice(0, 240),
+      };
+    }
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'fetch_error',
+      detail: String(error && error.message).slice(0, 240),
+    };
+  }
+}
+
+module.exports = {
+  EVENT_TYPE,
+  trainConfig,
+  dispatchTrainingTurn,
+};

--- a/api/agent/chat.js
+++ b/api/agent/chat.js
@@ -1,232 +1,7 @@
 'use strict';
 
 const { readJsonBody, sendJson, setCors } = require('../_agent_common');
-
-const DEFAULT_HF_MODEL = 'Qwen/Qwen2.5-72B-Instruct';
-const DEFAULT_OLLAMA_MODEL = 'llama3.2';
-const DEFAULT_MAX_TOKENS = 512;
-const DEFAULT_TIMEOUT_MS = 25000;
-
-const SYSTEM_PROMPT =
-  'You are Polly, the AI assistant for AetherMoore — an AI safety and governance framework ' +
-  'using hyperbolic geometry with a 14-layer security pipeline. Be helpful, concise, and ' +
-  'accurate. If asked about SCBE, explain the core innovation: governed agent behavior with ' +
-  'auditable safety decisions and cheap-first/local-first model routing.';
-
-function cleanBaseUrl(value) {
-  return String(value || '')
-    .trim()
-    .replace(/\/+$/, '');
-}
-
-function chatConfig() {
-  const hfModel = String(
-    process.env.HF_MODEL || process.env.AGENT_HF_MODEL || DEFAULT_HF_MODEL
-  ).trim();
-  const ollamaModel = String(
-    process.env.OLLAMA_MODEL || process.env.AGENT_OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL
-  ).trim();
-  return {
-    hfModel,
-    hfToken:
-      process.env.HF_TOKEN ||
-      process.env.HUGGINGFACE_TOKEN ||
-      process.env.HUGGING_FACE_HUB_TOKEN ||
-      '',
-    hfUrl:
-      process.env.HF_CHAT_URL ||
-      `https://router.huggingface.co/hf-inference/models/${encodeURIComponent(hfModel)}/v1/chat/completions`,
-    ollamaUrl: cleanBaseUrl(process.env.OLLAMA_URL || process.env.AGENT_OLLAMA_URL || ''),
-    ollamaModel,
-    providerOrder: String(process.env.AGENT_CHAT_PROVIDER_ORDER || 'ollama,huggingface,offline')
-      .split(',')
-      .map((item) => item.trim().toLowerCase())
-      .filter(Boolean),
-    timeoutMs: Math.max(1000, Number(process.env.AGENT_CHAT_TIMEOUT_MS || DEFAULT_TIMEOUT_MS)),
-  };
-}
-
-function normalizeText(value) {
-  if (typeof value === 'string') return value.trim();
-  if (Array.isArray(value)) {
-    return value.map(normalizeText).filter(Boolean).join('\n').trim();
-  }
-  if (value && typeof value === 'object') {
-    return normalizeText(value.text || value.content || value.generated_text || '');
-  }
-  return '';
-}
-
-function buildMessages(message, history) {
-  const messages = [{ role: 'system', content: SYSTEM_PROMPT }];
-  if (Array.isArray(history)) {
-    history.slice(-6).forEach((row) => {
-      const role = row && ['system', 'user', 'assistant'].includes(row.role) ? row.role : '';
-      const content = normalizeText(row && row.content);
-      if (role && content) messages.push({ role, content });
-    });
-  }
-  messages.push({ role: 'user', content: String(message).trim() });
-  return messages;
-}
-
-function messagesToPrompt(messages) {
-  return messages
-    .map((row) => {
-      const role =
-        row.role === 'assistant' ? 'Assistant' : row.role === 'system' ? 'System' : 'User';
-      return `${role}: ${row.content}`;
-    })
-    .join('\n\n')
-    .slice(0, 12000);
-}
-
-async function fetchWithTimeout(url, init, timeoutMs) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function tryOllama(cfg, messages) {
-  if (!cfg.ollamaUrl) return null;
-  const response = await fetchWithTimeout(
-    `${cfg.ollamaUrl}/api/generate`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model: cfg.ollamaModel,
-        prompt: messagesToPrompt(messages),
-        stream: false,
-      }),
-    },
-    cfg.timeoutMs
-  );
-  if (!response.ok) {
-    return {
-      ok: false,
-      provider: 'ollama',
-      model: cfg.ollamaModel,
-      error: `Ollama returned ${response.status}`,
-      detail: (await response.text()).slice(0, 400),
-    };
-  }
-  const data = await response.json();
-  const text = normalizeText(data.response);
-  if (!text) {
-    return {
-      ok: false,
-      provider: 'ollama',
-      model: cfg.ollamaModel,
-      error: 'Ollama returned no text',
-    };
-  }
-  return {
-    ok: true,
-    text,
-    provider: 'ollama',
-    model: cfg.ollamaModel,
-    tokens_in: Number(data.prompt_eval_count || 0),
-    tokens_out: Number(data.eval_count || 0),
-  };
-}
-
-async function tryHuggingFace(cfg, messages) {
-  if (!cfg.hfToken) return null;
-  const response = await fetchWithTimeout(
-    cfg.hfUrl,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${cfg.hfToken}`,
-      },
-      body: JSON.stringify({ model: cfg.hfModel, messages, max_tokens: DEFAULT_MAX_TOKENS }),
-    },
-    cfg.timeoutMs
-  );
-  if (!response.ok) {
-    return {
-      ok: false,
-      provider: 'huggingface',
-      model: cfg.hfModel,
-      error: `Hugging Face returned ${response.status}`,
-      detail: (await response.text()).slice(0, 400),
-    };
-  }
-  const data = await response.json();
-  const text =
-    normalizeText(
-      data &&
-        data.choices &&
-        data.choices[0] &&
-        data.choices[0].message &&
-        data.choices[0].message.content
-    ) ||
-    normalizeText(data && data.generated_text) ||
-    normalizeText(data && data.text) ||
-    normalizeText(Array.isArray(data) && data[0]);
-  if (!text) {
-    return {
-      ok: false,
-      provider: 'huggingface',
-      model: cfg.hfModel,
-      error: 'Hugging Face returned no text',
-    };
-  }
-  return { ok: true, text, provider: 'huggingface', model: cfg.hfModel };
-}
-
-function offlineReply(message, attempts) {
-  return {
-    ok: true,
-    text:
-      '[offline/local-first mode]\n\n' +
-      'No configured chat model answered. Start Ollama at home or set HF_TOKEN for the hosted fallback.\n\n' +
-      `Your message was received: ${String(message).slice(0, 600)}`,
-    provider: 'offline',
-    model: 'none',
-    attempts,
-  };
-}
-
-async function routeChat(cfg, message, history) {
-  const messages = buildMessages(message, history);
-  const attempts = [];
-  for (const provider of cfg.providerOrder) {
-    try {
-      const result =
-        provider === 'ollama'
-          ? await tryOllama(cfg, messages)
-          : provider === 'huggingface'
-            ? await tryHuggingFace(cfg, messages)
-            : null;
-      if (!result) {
-        attempts.push({ provider, status: 'skipped', reason: 'not_configured' });
-        continue;
-      }
-      if (result.ok) return { ...result, attempts };
-      attempts.push({
-        provider,
-        status: 'failed',
-        model: result.model,
-        error: result.error,
-        detail: result.detail || '',
-      });
-    } catch (error) {
-      attempts.push({
-        provider,
-        status: 'failed',
-        error: String(error && error.message ? error.message : error).slice(0, 400),
-      });
-    }
-  }
-  return offlineReply(message, attempts);
-}
+const llm = require('../_chat_llm');
 
 module.exports = async function handler(req, res) {
   setCors(res);
@@ -248,7 +23,7 @@ module.exports = async function handler(req, res) {
   if (!message || !String(message).trim())
     return sendJson(res, 400, { ok: false, error: 'message required' });
 
-  const result = await routeChat(chatConfig(), message, body.history);
+  const result = await llm.routeChat(llm.chatConfig(), message, body.history);
   return sendJson(res, 200, {
     ...result,
     cost: result.provider === 'huggingface' ? 'hf-token-or-free-tier' : 'zero-local-or-offline',
@@ -256,9 +31,9 @@ module.exports = async function handler(req, res) {
 };
 
 module.exports._private = {
-  buildMessages,
-  chatConfig,
-  messagesToPrompt,
-  normalizeText,
-  routeChat,
+  buildMessages: llm.buildMessages,
+  chatConfig: llm.chatConfig,
+  messagesToPrompt: llm.messagesToPrompt,
+  normalizeText: llm.normalizeText,
+  routeChat: llm.routeChat,
 };

--- a/api/polly/catalog.js
+++ b/api/polly/catalog.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { sendJson, setCors } = require('../_agent_common');
+const {
+  PRODUCT_CATALOG,
+  CONSULTING_TIERS,
+  CONSULTING_LANDING_URL,
+  HIRE_EMAIL,
+} = require('./commerce');
+
+module.exports = async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'GET') {
+    return sendJson(res, 405, { ok: false, error: 'GET only' });
+  }
+
+  return sendJson(res, 200, {
+    ok: true,
+    products: PRODUCT_CATALOG.map((p) => ({
+      sku: p.sku,
+      name: p.name,
+      price_label: p.priceLabel,
+      short: p.short,
+      checkout_url: p.checkoutUrl,
+      delivery_url: p.deliveryUrl,
+    })),
+    consulting_tiers: CONSULTING_TIERS,
+    consulting_landing_url: CONSULTING_LANDING_URL,
+    hire_email: HIRE_EMAIL,
+  });
+};

--- a/api/polly/chat.js
+++ b/api/polly/chat.js
@@ -7,7 +7,8 @@ const {
   renderCustomReply,
   renderMembershipReply,
 } = require('./commerce');
-const agentChat = require('../agent/chat');
+const llm = require('../_chat_llm');
+const trainCapture = require('../_polly_train_capture');
 
 const COMMERCE_INTENTS = new Set(['buy', 'custom', 'membership']);
 const COMMERCE_CONFIDENCE_FLOOR = 0.6;
@@ -25,7 +26,7 @@ function captureIfConsented({ req, message, reply, intent, sessionId, pageContex
   if (!req || req.consent_to_train !== true) return;
   if (typeof message !== 'string' || !message.trim()) return;
   if (typeof reply !== 'string' || !reply.trim()) return;
-  logTrainingTurn({
+  const record = {
     ts: Math.floor(Date.now() / 1000),
     session_id: sessionId || '',
     intent,
@@ -34,12 +35,14 @@ function captureIfConsented({ req, message, reply, intent, sessionId, pageContex
     assistant: reply.slice(0, 8192),
     page_context: pageContext ? String(pageContext).slice(0, 512) : '',
     transport: 'vercel-polly-chat',
-  });
+  };
+  logTrainingTurn(record);
+  // Best-effort durable capture via GitHub repository_dispatch — never throws.
+  trainCapture.dispatchTrainingTurn(record).catch(() => {});
 }
 
 async function llmFallback(message, history) {
-  const cfg = agentChat._private.chatConfig();
-  return agentChat._private.routeChat(cfg, message, history);
+  return llm.routeChat(llm.chatConfig(), message, history);
 }
 
 module.exports = async function handler(req, res) {

--- a/api/polly/chat.js
+++ b/api/polly/chat.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const { readJsonBody, sendJson, setCors } = require('../_agent_common');
+const {
+  classifyIntent,
+  renderBuyReply,
+  renderCustomReply,
+  renderMembershipReply,
+} = require('./commerce');
+const agentChat = require('../agent/chat');
+
+const COMMERCE_INTENTS = new Set(['buy', 'custom', 'membership']);
+const COMMERCE_CONFIDENCE_FLOOR = 0.6;
+const TRAIN_LOG_PREFIX = 'polly_train_v1 ';
+
+function logTrainingTurn(record) {
+  try {
+    process.stdout.write(TRAIN_LOG_PREFIX + JSON.stringify(record) + '\n');
+  } catch (_err) {
+    /* never raise into the chat path */
+  }
+}
+
+function captureIfConsented({ req, message, reply, intent, sessionId, pageContext, provider }) {
+  if (!req || req.consent_to_train !== true) return;
+  if (typeof message !== 'string' || !message.trim()) return;
+  if (typeof reply !== 'string' || !reply.trim()) return;
+  logTrainingTurn({
+    ts: Math.floor(Date.now() / 1000),
+    session_id: sessionId || '',
+    intent,
+    provider: provider || 'commerce',
+    user: message.slice(0, 4096),
+    assistant: reply.slice(0, 8192),
+    page_context: pageContext ? String(pageContext).slice(0, 512) : '',
+    transport: 'vercel-polly-chat',
+  });
+}
+
+async function llmFallback(message, history) {
+  const cfg = agentChat._private.chatConfig();
+  return agentChat._private.routeChat(cfg, message, history);
+}
+
+module.exports = async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'POST') {
+    return sendJson(res, 405, { ok: false, error: 'POST only' });
+  }
+
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch (error) {
+    return sendJson(res, 400, {
+      ok: false,
+      error: 'invalid JSON body',
+      detail: String(error.message || error),
+    });
+  }
+
+  const message = body && body.message;
+  if (!message || typeof message !== 'string' || !message.trim()) {
+    return sendJson(res, 400, { ok: false, error: 'message required' });
+  }
+
+  const history = Array.isArray(body.history) ? body.history : [];
+  const sessionId = body.session_id || '';
+  const pageContext = body.page_context || '';
+
+  const intent = classifyIntent(message);
+
+  if (intent.confidence >= COMMERCE_CONFIDENCE_FLOOR && COMMERCE_INTENTS.has(intent.name)) {
+    let rendered;
+    if (intent.name === 'buy') {
+      rendered = renderBuyReply(intent.product);
+    } else if (intent.name === 'custom') {
+      rendered = renderCustomReply(message);
+    } else {
+      rendered = renderMembershipReply();
+    }
+
+    captureIfConsented({
+      req: body,
+      message,
+      reply: rendered.text,
+      intent: intent.name,
+      sessionId,
+      pageContext,
+      provider: 'commerce',
+    });
+
+    return sendJson(res, 200, {
+      ok: true,
+      text: rendered.text,
+      provider: 'commerce',
+      model: 'intent-classifier-v1',
+      intent: intent.name,
+      confidence: intent.confidence,
+      actions: rendered.actions,
+      cost: 'zero-deterministic',
+    });
+  }
+
+  let llm;
+  try {
+    llm = await llmFallback(message, history);
+  } catch (error) {
+    llm = {
+      ok: false,
+      text: `[error] LLM call failed: ${String(error.message || error).slice(0, 240)}`,
+      provider: 'error',
+      model: 'none',
+    };
+  }
+
+  captureIfConsented({
+    req: body,
+    message,
+    reply: llm && llm.text,
+    intent: intent.name,
+    sessionId,
+    pageContext,
+    provider: llm && llm.provider,
+  });
+
+  return sendJson(res, 200, {
+    ok: !!(llm && llm.ok !== false),
+    text: (llm && llm.text) || '',
+    provider: (llm && llm.provider) || 'offline',
+    model: (llm && llm.model) || 'none',
+    attempts: (llm && llm.attempts) || [],
+    intent: intent.name,
+    confidence: intent.confidence,
+    actions: [],
+    cost: llm && llm.provider === 'huggingface' ? 'hf-token-or-free-tier' : 'zero-local-or-offline',
+  });
+};
+
+module.exports._private = {
+  COMMERCE_INTENTS,
+  COMMERCE_CONFIDENCE_FLOOR,
+  llmFallback,
+  logTrainingTurn,
+  captureIfConsented,
+};

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const PRODUCT_CATALOG = [
+  {
+    sku: 'ai-governance-toolkit',
+    name: 'SCBE AI Governance Toolkit',
+    priceLabel: '$29 one-time',
+    short:
+      'Templates, decision records, setup guidance, buyer manual, and a support route for governed AI workflows. Shipped as a downloadable ZIP after Stripe checkout.',
+    checkoutUrl: 'https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06',
+    deliveryUrl: 'https://aethermoore.com/product-manual/ai-governance-toolkit.html',
+    keywords: ['toolkit', 'governance toolkit', 'ai governance', 'templates', 'decision records'],
+  },
+  {
+    sku: 'ai-security-training-vault',
+    name: 'SCBE AI Security Training Vault',
+    priceLabel: '$29 one-time',
+    short:
+      'Training data, projector weights, benchmark suite, and notebook materials for governed AI model work. Shipped as a downloadable ZIP after Stripe checkout.',
+    checkoutUrl: 'https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g',
+    deliveryUrl: 'https://aethermoore.com/product-manual/training-vault.html',
+    keywords: [
+      'training vault',
+      'training data',
+      'vault',
+      'ai security',
+      'benchmark suite',
+      'notebooks',
+    ],
+  },
+  {
+    sku: 'five-dollar-tip-jar',
+    name: '$5 SCBE Tip Jar',
+    priceLabel: '$5 one-time',
+    short:
+      "If the open-source work has helped you and there's no formal engagement, a tip keeps the next release shipping.",
+    checkoutUrl: 'https://ko-fi.com/Y8Y51UQYWZ',
+    deliveryUrl: '',
+    keywords: ['tip', 'tip jar', 'donate', 'donation', 'support', 'buy a coffee', 'coffee'],
+  },
+];
+
+const CONSULTING_TIERS = [
+  {
+    name: 'Short advisory call',
+    price: '$300 / 60 min',
+    fit: "one concrete AI safety / governance problem you're facing",
+  },
+  {
+    name: 'Adversarial audit',
+    price: '$5,000 – $15,000 / 1–3 weeks',
+    fit: 'audit your production LLM endpoint or agent against the SCBE governance harness',
+  },
+  {
+    name: 'Custom governance overlay',
+    price: '$25,000 – $80,000 / 4–10 weeks',
+    fit: 'build a deployable governance layer in front of your model API',
+  },
+  {
+    name: 'Federal subcontract role',
+    price: '$150 – $250 / hour, contract',
+    fit: "AI safety / LLM evaluation work on a SAM-registered prime's contract",
+  },
+];
+
+const CONSULTING_LANDING_URL = 'https://aethermoore.com/hire';
+const HIRE_EMAIL = 'issdandavis7795@gmail.com';
+const MEMBERSHIP_KOFI_URL = 'https://ko-fi.com/Y8Y51UQYWZ';
+
+const BUY_PATTERN =
+  /\b(buy|purchase|order|checkout|pay\s+for|get\s+the|want\s+the|how\s+much|sign\s+me\s+up|add\s+to\s+cart)\b/i;
+
+const CUSTOM_PATTERN =
+  /\b(custom|bespoke|tailor|specifically\s+for|my\s+team|my\s+company|my\s+org|my\s+(use\s*case|workflow)|something\s+else|not\s+listed|build\s+me|hire\s+you|consulting|advisory|audit|engagement|contract)\b/i;
+
+const RESEARCH_PATTERN =
+  /\b(research|find|look\s+up|search|investigate|what\s+do\s+you\s+know|recent|latest|news|paper|study|literature|sources?|cite|references?)\b/i;
+
+const MEMBERSHIP_PATTERN =
+  /\b(member|membership|subscribe|signup|sign\s*up|join|newsletter|follow|stay\s+updated|notify|sponsor|tip|donate)\b/i;
+
+function resolveProduct(message) {
+  const lower = String(message || '').toLowerCase();
+  for (const product of PRODUCT_CATALOG) {
+    for (const keyword of product.keywords) {
+      if (lower.includes(keyword)) return product;
+    }
+  }
+  return null;
+}
+
+function classifyIntent(message) {
+  if (typeof message !== 'string' || !message.trim()) {
+    return { name: 'general', confidence: 0, matchedTerm: null, product: null };
+  }
+
+  const buyMatch = BUY_PATTERN.exec(message);
+  if (buyMatch) {
+    const product = resolveProduct(message);
+    return {
+      name: 'buy',
+      confidence: product ? 0.95 : 0.7,
+      matchedTerm: buyMatch[0],
+      product,
+    };
+  }
+
+  const product = resolveProduct(message);
+  if (product) {
+    return { name: 'buy', confidence: 0.6, matchedTerm: product.sku, product };
+  }
+
+  const customMatch = CUSTOM_PATTERN.exec(message);
+  if (customMatch) {
+    return { name: 'custom', confidence: 0.85, matchedTerm: customMatch[0], product: null };
+  }
+
+  const researchMatch = RESEARCH_PATTERN.exec(message);
+  if (researchMatch) {
+    return { name: 'research', confidence: 0.8, matchedTerm: researchMatch[0], product: null };
+  }
+
+  const membershipMatch = MEMBERSHIP_PATTERN.exec(message);
+  if (membershipMatch) {
+    return { name: 'membership', confidence: 0.75, matchedTerm: membershipMatch[0], product: null };
+  }
+
+  return { name: 'general', confidence: 0, matchedTerm: null, product: null };
+}
+
+function renderBuyReply(product) {
+  if (!product) {
+    const lines = ['Three current products. Click to check out:', ''];
+    const actions = [];
+    for (const item of PRODUCT_CATALOG) {
+      lines.push(`- **${item.name}** — ${item.priceLabel}. ${item.short}`);
+      actions.push({ label: `Buy ${item.name}`, url: item.checkoutUrl });
+    }
+    return { text: lines.join('\n'), actions };
+  }
+
+  let text = `**${product.name}** — ${product.priceLabel}.\n\n${product.short}\n\nCheckout: ${product.checkoutUrl}`;
+  if (product.deliveryUrl) {
+    text += `\nWhat you get + delivery: ${product.deliveryUrl}`;
+  }
+  const actions = [{ label: `Buy ${product.name}`, url: product.checkoutUrl }];
+  if (product.deliveryUrl) {
+    actions.push({ label: "What's inside", url: product.deliveryUrl });
+  }
+  return { text, actions };
+}
+
+function renderCustomReply(message) {
+  const subject = 'Custom engagement inquiry — from Polly chat';
+  const trimmed = String(message || '').slice(0, 300);
+  const body =
+    `Hi Issac,\n\n` +
+    `I described to Polly: "${trimmed}"\n\n` +
+    `I'd like to discuss:\n` +
+    `[ ] Short advisory call ($300, 60 min)\n` +
+    `[ ] Adversarial audit\n` +
+    `[ ] Custom governance overlay\n` +
+    `[ ] Federal subcontract conversation\n\n` +
+    `Context:\n\n` +
+    `Thanks,\n`;
+  const mailto = `mailto:${HIRE_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+
+  const tierLines = CONSULTING_TIERS.map((t) => `- **${t.name}** (${t.price}) — ${t.fit}`);
+  const text =
+    "What you're describing is custom — not in the stock catalog. " +
+    'Four ways we can scope it:\n\n' +
+    tierLines.join('\n') +
+    '\n\nFastest path: email with a one-paragraph description of the ' +
+    'outcome you want. I reply same day where I can.';
+  const actions = [
+    { label: 'Email Issac with this context', url: mailto },
+    { label: 'Full hire details', url: CONSULTING_LANDING_URL },
+  ];
+  return { text, actions };
+}
+
+function renderMembershipReply() {
+  const text =
+    'Three ways to stay close to the work:\n\n' +
+    '- **Sponsor / tip** the open-source work via Ko-fi\n' +
+    '- **Watch the GitHub repo** for releases (`Watch -> Custom -> Releases`)\n' +
+    '- **Email** me at the address below for a private update list\n\n' +
+    'There is no paid membership tier yet — open-source first; ' +
+    'sponsorships keep the next release shipping.';
+  const actions = [
+    { label: 'Tip on Ko-fi', url: MEMBERSHIP_KOFI_URL },
+    { label: 'Watch the repo', url: 'https://github.com/issdandavis/SCBE-AETHERMOORE' },
+    { label: 'Email Issac', url: `mailto:${HIRE_EMAIL}` },
+  ];
+  return { text, actions };
+}
+
+module.exports = {
+  PRODUCT_CATALOG,
+  CONSULTING_TIERS,
+  CONSULTING_LANDING_URL,
+  HIRE_EMAIL,
+  MEMBERSHIP_KOFI_URL,
+  classifyIntent,
+  renderBuyReply,
+  renderCustomReply,
+  renderMembershipReply,
+  resolveProduct,
+};

--- a/api/polly/feedback.js
+++ b/api/polly/feedback.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { readJsonBody, sendJson, setCors } = require('../_agent_common');
+
+const VALID_RATINGS = new Set(['up', 'down']);
+const FEEDBACK_LOG_PREFIX = 'polly_feedback_v1 ';
+
+function logFeedback(record) {
+  try {
+    process.stdout.write(FEEDBACK_LOG_PREFIX + JSON.stringify(record) + '\n');
+  } catch (_err) {
+    /* never raise */
+  }
+}
+
+module.exports = async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'POST') {
+    return sendJson(res, 405, { ok: false, error: 'POST only' });
+  }
+
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch (error) {
+    return sendJson(res, 400, {
+      ok: false,
+      error: 'invalid JSON body',
+      detail: String(error.message || error),
+    });
+  }
+
+  const rating = String((body && body.rating) || '').toLowerCase();
+  if (!VALID_RATINGS.has(rating)) {
+    return sendJson(res, 400, { ok: false, error: "rating must be 'up' or 'down'" });
+  }
+
+  const userMessage = typeof body.user_message === 'string' ? body.user_message.slice(0, 4096) : '';
+  const assistantReply =
+    typeof body.assistant_reply === 'string' ? body.assistant_reply.slice(0, 8192) : '';
+
+  logFeedback({
+    ts: Math.floor(Date.now() / 1000),
+    session_id: (body && body.session_id) || '',
+    rating,
+    intent: (body && body.intent) || '',
+    user: userMessage,
+    assistant: assistantReply,
+    page_context: typeof body.page_context === 'string' ? body.page_context.slice(0, 512) : '',
+    transport: 'vercel-polly-feedback',
+  });
+
+  return sendJson(res, 200, { ok: true, captured: true, rating });
+};
+
+module.exports._private = { logFeedback, VALID_RATINGS };

--- a/docs/hire.html
+++ b/docs/hire.html
@@ -1,264 +1,600 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Hire Issac Davis — AI Safety & Governance Engineering</title>
-<meta name="description" content="Independent AI safety and governance engineering. Federal-registered, open-source-first. Available for contract work, security audits, and short-term advisory.">
-<meta property="og:title" content="Hire Issac Davis — AI Safety & Governance Engineering">
-<meta property="og:description" content="Independent AI safety and governance engineering. Federal-registered, open-source-first.">
-<meta property="og:url" content="https://aethermoore.com/hire">
-<meta name="twitter:card" content="summary">
-<style>
-*{margin:0;padding:0;box-sizing:border-box}
-:root{
-  --bg:#0a0e1a;--surface:#0f1626;--card:#152033;--border:#243352;
-  --text:#e8f0fb;--dim:#a2b6cc;--accent:#17c6cf;--accent2:#ff9152;
-  --green:#2dd3a6;--gold:#ffd166;
-  --mono:'SF Mono','Cascadia Code','JetBrains Mono','Consolas',monospace;
-  --font:'Inter','Space Grotesk','Trebuchet MS',sans-serif;
-}
-body{
-  background:var(--bg);
-  background-image:
-    radial-gradient(1200px 600px at 12% -8%, rgba(23,198,207,.18), transparent 60%),
-    radial-gradient(900px 500px at 92% 0%, rgba(255,145,82,.14), transparent 58%);
-  color:var(--text);font-family:var(--font);min-height:100vh;line-height:1.5;
-  -webkit-font-smoothing:antialiased;
-}
-.container{max-width:880px;margin:0 auto;padding:48px 24px 96px}
-header{margin-bottom:48px}
-.eyebrow{
-  display:inline-block;font-size:11px;letter-spacing:.18em;text-transform:uppercase;
-  color:var(--accent);font-weight:700;margin-bottom:12px;
-}
-h1{font-size:42px;line-height:1.15;font-weight:800;letter-spacing:-0.02em;margin-bottom:18px}
-h1 span{color:var(--accent)}
-.lede{font-size:19px;color:var(--dim);max-width:680px;margin-bottom:32px}
-.cta-row{display:flex;flex-wrap:wrap;gap:12px;margin-bottom:48px}
-.cta{
-  display:inline-flex;align-items:center;gap:8px;padding:13px 22px;border-radius:8px;
-  font-weight:700;font-size:14px;text-decoration:none;transition:all .15s ease;
-  border:1px solid transparent;
-}
-.cta.primary{background:var(--accent);color:#06121a}
-.cta.primary:hover{background:#1ddae4;transform:translateY(-1px)}
-.cta.secondary{background:transparent;border-color:var(--border);color:var(--text)}
-.cta.secondary:hover{border-color:var(--accent);color:var(--accent)}
-.cta.tertiary{background:transparent;border:none;color:var(--dim);padding:13px 0}
-.cta.tertiary:hover{color:var(--accent)}
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hire Issac Davis — AI Safety & Governance Engineering</title>
+    <meta
+      name="description"
+      content="Independent AI safety and governance engineering. Federal-registered, open-source-first. Available for contract work, security audits, and short-term advisory."
+    />
+    <meta property="og:title" content="Hire Issac Davis — AI Safety & Governance Engineering" />
+    <meta
+      property="og:description"
+      content="Independent AI safety and governance engineering. Federal-registered, open-source-first."
+    />
+    <meta property="og:url" content="https://aethermoore.com/hire" />
+    <meta name="twitter:card" content="summary" />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      :root {
+        --bg: #0a0e1a;
+        --surface: #0f1626;
+        --card: #152033;
+        --border: #243352;
+        --text: #e8f0fb;
+        --dim: #a2b6cc;
+        --accent: #17c6cf;
+        --accent2: #ff9152;
+        --green: #2dd3a6;
+        --gold: #ffd166;
+        --mono: 'SF Mono', 'Cascadia Code', 'JetBrains Mono', 'Consolas', monospace;
+        --font: 'Inter', 'Space Grotesk', 'Trebuchet MS', sans-serif;
+      }
+      body {
+        background: var(--bg);
+        background-image:
+          radial-gradient(1200px 600px at 12% -8%, rgba(23, 198, 207, 0.18), transparent 60%),
+          radial-gradient(900px 500px at 92% 0%, rgba(255, 145, 82, 0.14), transparent 58%);
+        color: var(--text);
+        font-family: var(--font);
+        min-height: 100vh;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+      .container {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 48px 24px 96px;
+      }
+      header {
+        margin-bottom: 48px;
+      }
+      .eyebrow {
+        display: inline-block;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--accent);
+        font-weight: 700;
+        margin-bottom: 12px;
+      }
+      h1 {
+        font-size: 42px;
+        line-height: 1.15;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        margin-bottom: 18px;
+      }
+      h1 span {
+        color: var(--accent);
+      }
+      .lede {
+        font-size: 19px;
+        color: var(--dim);
+        max-width: 680px;
+        margin-bottom: 32px;
+      }
+      .cta-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 48px;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 13px 22px;
+        border-radius: 8px;
+        font-weight: 700;
+        font-size: 14px;
+        text-decoration: none;
+        transition: all 0.15s ease;
+        border: 1px solid transparent;
+      }
+      .cta.primary {
+        background: var(--accent);
+        color: #06121a;
+      }
+      .cta.primary:hover {
+        background: #1ddae4;
+        transform: translateY(-1px);
+      }
+      .cta.secondary {
+        background: transparent;
+        border-color: var(--border);
+        color: var(--text);
+      }
+      .cta.secondary:hover {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      .cta.tertiary {
+        background: transparent;
+        border: none;
+        color: var(--dim);
+        padding: 13px 0;
+      }
+      .cta.tertiary:hover {
+        color: var(--accent);
+      }
 
-section{margin-bottom:56px}
-h2{font-size:24px;font-weight:700;margin-bottom:18px;letter-spacing:-0.01em}
-h2::before{content:"§ ";color:var(--accent);font-weight:400;opacity:.55}
-.muted{color:var(--dim);margin-bottom:14px}
+      section {
+        margin-bottom: 56px;
+      }
+      h2 {
+        font-size: 24px;
+        font-weight: 700;
+        margin-bottom: 18px;
+        letter-spacing: -0.01em;
+      }
+      h2::before {
+        content: '§ ';
+        color: var(--accent);
+        font-weight: 400;
+        opacity: 0.55;
+      }
+      .muted {
+        color: var(--dim);
+        margin-bottom: 14px;
+      }
 
-.services{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
-.service-card{
-  background:var(--card);border:1px solid var(--border);border-radius:12px;padding:24px;
-  display:flex;flex-direction:column;
-}
-.service-card h3{font-size:16px;font-weight:700;margin-bottom:8px}
-.service-card .price{font-size:13px;color:var(--gold);font-weight:700;margin-bottom:10px;font-family:var(--mono)}
-.service-card p{font-size:14px;color:var(--dim);flex:1}
+      .services {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+      .service-card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+      }
+      .service-card h3 {
+        font-size: 16px;
+        font-weight: 700;
+        margin-bottom: 8px;
+      }
+      .service-card .price {
+        font-size: 13px;
+        color: var(--gold);
+        font-weight: 700;
+        margin-bottom: 10px;
+        font-family: var(--mono);
+      }
+      .service-card p {
+        font-size: 14px;
+        color: var(--dim);
+        flex: 1;
+      }
 
-.proof{
-  background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:24px;
-  font-family:var(--mono);font-size:13px;line-height:1.7;
-}
-.proof .row{display:flex;justify-content:space-between;gap:24px;padding:6px 0;border-bottom:1px dashed rgba(142,170,199,.18)}
-.proof .row:last-child{border-bottom:none}
-.proof .label{color:var(--dim)}
-.proof .value{color:var(--text);text-align:right}
-.proof .value a{color:var(--accent);text-decoration:none}
-.proof .value a:hover{text-decoration:underline}
+      .proof {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 24px;
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.7;
+      }
+      .proof .row {
+        display: flex;
+        justify-content: space-between;
+        gap: 24px;
+        padding: 6px 0;
+        border-bottom: 1px dashed rgba(142, 170, 199, 0.18);
+      }
+      .proof .row:last-child {
+        border-bottom: none;
+      }
+      .proof .label {
+        color: var(--dim);
+      }
+      .proof .value {
+        color: var(--text);
+        text-align: right;
+      }
+      .proof .value a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      .proof .value a:hover {
+        text-decoration: underline;
+      }
 
-.qual-list{list-style:none;display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
-.qual-list li{
-  padding:18px 20px;background:var(--card);border:1px solid var(--border);border-radius:10px;
-  font-size:14px;
-}
-.qual-list strong{display:block;color:var(--accent);margin-bottom:6px;font-size:13px;font-weight:700;letter-spacing:.02em}
+      .qual-list {
+        list-style: none;
+        display: grid;
+        gap: 14px;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+      .qual-list li {
+        padding: 18px 20px;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        font-size: 14px;
+      }
+      .qual-list strong {
+        display: block;
+        color: var(--accent);
+        margin-bottom: 6px;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+      }
 
-.trust{
-  background:linear-gradient(135deg,rgba(23,198,207,.08),rgba(255,145,82,.04));
-  border:1px solid var(--border);border-radius:12px;padding:28px;
-}
-.trust h2{margin-bottom:8px}
-.trust p{color:var(--dim);font-size:14px;margin-bottom:14px}
-.trust .legal{font-size:12px;color:#7a8da3;font-style:italic}
+      .trust {
+        background: linear-gradient(135deg, rgba(23, 198, 207, 0.08), rgba(255, 145, 82, 0.04));
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 28px;
+      }
+      .trust h2 {
+        margin-bottom: 8px;
+      }
+      .trust p {
+        color: var(--dim);
+        font-size: 14px;
+        margin-bottom: 14px;
+      }
+      .trust .legal {
+        font-size: 12px;
+        color: #7a8da3;
+        font-style: italic;
+      }
 
-footer{
-  margin-top:80px;padding-top:32px;border-top:1px solid var(--border);
-  display:flex;flex-wrap:wrap;justify-content:space-between;gap:16px;
-  font-size:12px;color:#7a8da3;
-}
-footer a{color:var(--dim);text-decoration:none}
-footer a:hover{color:var(--accent)}
+      footer {
+        margin-top: 80px;
+        padding-top: 32px;
+        border-top: 1px solid var(--border);
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 16px;
+        font-size: 12px;
+        color: #7a8da3;
+      }
+      footer a {
+        color: var(--dim);
+        text-decoration: none;
+      }
+      footer a:hover {
+        color: var(--accent);
+      }
 
-@media (max-width:600px){
-  h1{font-size:32px}
-  .lede{font-size:17px}
-  .container{padding:32px 18px 72px}
-}
-</style>
-</head>
-<body>
-<div class="container">
+      @media (max-width: 600px) {
+        h1 {
+          font-size: 32px;
+        }
+        .lede {
+          font-size: 17px;
+        }
+        .container {
+          padding: 32px 18px 72px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <div class="eyebrow">Available now · Federal-registered · Open-source-first</div>
+        <h1>AI safety and governance engineering, <span>built solo, shipped real.</span></h1>
+        <p class="lede">
+          I build the parts of AI systems that the model providers don't ship. Adversarial-cost
+          manifolds, governance overlays, formal-methods tooling, audit-grade telemetry.
+          Independent. SAM.gov registered. Available for contract, advisory, and audit work this
+          quarter.
+        </p>
 
-<header>
-<div class="eyebrow">Available now · Federal-registered · Open-source-first</div>
-<h1>AI safety and governance engineering, <span>built solo, shipped real.</span></h1>
-<p class="lede">I build the parts of AI systems that the model providers don't ship. Adversarial-cost manifolds, governance overlays, formal-methods tooling, audit-grade telemetry. Independent. SAM.gov registered. Available for contract, advisory, and audit work this quarter.</p>
+        <div class="cta-row">
+          <a
+            class="cta primary"
+            href="mailto:issdandavis7795@gmail.com?subject=Engagement%20inquiry%20%E2%80%94%20from%20aethermoore.com%2Fhire&body=Hi%20Issac%2C%0A%0AI%27d%20like%20to%20discuss%3A%0A%5B%20%5D%20Short%20advisory%20call%0A%5B%20%5D%20Custom%20governance%20overlay%0A%5B%20%5D%20Adversarial%20audit%0A%5B%20%5D%20Federal%20subcontract%20conversation%0A%5B%20%5D%20Other%3A%0A%0AContext%3A%0A%0AThanks%2C"
+            >Email me directly</a
+          >
+          <a
+            class="cta secondary"
+            href="https://github.com/issdandavis/SCBE-AETHERMOORE"
+            target="_blank"
+            rel="noopener"
+            >See the work</a
+          >
+          <a class="cta tertiary" href="https://ko-fi.com/Y8Y51UQYWZ" target="_blank" rel="noopener"
+            >Or tip the work →</a
+          >
+        </div>
+      </header>
 
-<div class="cta-row">
-<a class="cta primary" href="mailto:issdandavis7795@gmail.com?subject=Engagement%20inquiry%20%E2%80%94%20from%20aethermoore.com%2Fhire&body=Hi%20Issac%2C%0A%0AI%27d%20like%20to%20discuss%3A%0A%5B%20%5D%20Short%20advisory%20call%0A%5B%20%5D%20Custom%20governance%20overlay%0A%5B%20%5D%20Adversarial%20audit%0A%5B%20%5D%20Federal%20subcontract%20conversation%0A%5B%20%5D%20Other%3A%0A%0AContext%3A%0A%0AThanks%2C">Email me directly</a>
-<a class="cta secondary" href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">See the work</a>
-<a class="cta tertiary" href="https://ko-fi.com/Y8Y51UQYWZ" target="_blank" rel="noopener">Or tip the work →</a>
-</div>
-</header>
+      <section>
+        <h2>What I do</h2>
+        <p class="muted">
+          Concrete engagements with real deliverables. Pricing is anchored, not theoretical.
+        </p>
+        <div class="services">
+          <div class="service-card">
+            <h3>Short advisory call</h3>
+            <div class="price">$300 · 60 min · same week</div>
+            <p>
+              One-hour conversation about a concrete AI safety / governance problem you're facing.
+              You leave with a written summary and a follow-up action list. If we don't find a real
+              path, you don't pay.
+            </p>
+          </div>
 
-<section>
-<h2>What I do</h2>
-<p class="muted">Concrete engagements with real deliverables. Pricing is anchored, not theoretical.</p>
-<div class="services">
+          <div class="service-card">
+            <h3>Adversarial audit</h3>
+            <div class="price">$5,000 – $15,000 · 1–3 weeks</div>
+            <p>
+              I run my own L13 governance harness against your production LLM endpoint or agent. You
+              get the full attack catalog, false-allow rate, latency profile, and a remediation
+              plan. Composes with Anthropic Petri.
+            </p>
+          </div>
 
-<div class="service-card">
-<h3>Short advisory call</h3>
-<div class="price">$300 · 60 min · same week</div>
-<p>One-hour conversation about a concrete AI safety / governance problem you're facing. You leave with a written summary and a follow-up action list. If we don't find a real path, you don't pay.</p>
-</div>
+          <div class="service-card">
+            <h3>Custom governance overlay</h3>
+            <div class="price">$25,000 – $80,000 · 4–10 weeks</div>
+            <p>
+              I build a deployable governance layer (containerized service, ≤200ms median latency)
+              sitting in front of your model API. Handles prompt-injection, identifier-canonicality,
+              bijective-tamper, and your domain-specific constraints. Open-source by default;
+              private-fork for regulated workloads.
+            </p>
+          </div>
 
-<div class="service-card">
-<h3>Adversarial audit</h3>
-<div class="price">$5,000 – $15,000 · 1–3 weeks</div>
-<p>I run my own L13 governance harness against your production LLM endpoint or agent. You get the full attack catalog, false-allow rate, latency profile, and a remediation plan. Composes with Anthropic Petri.</p>
-</div>
+          <div class="service-card">
+            <h3>Federal subcontract role</h3>
+            <div class="price">$150 – $250 / hour · contract</div>
+            <p>
+              I'm SAM.gov registered (UEI J4NXHM6N5F59) and ready to subcontract on AI-safety,
+              governance, or LLM-evaluation work. Two DARPA proposals in active eval. Comfortable
+              with FAR 9.5 source-selection-protected work.
+            </p>
+          </div>
 
-<div class="service-card">
-<h3>Custom governance overlay</h3>
-<div class="price">$25,000 – $80,000 · 4–10 weeks</div>
-<p>I build a deployable governance layer (containerized service, ≤200ms median latency) sitting in front of your model API. Handles prompt-injection, identifier-canonicality, bijective-tamper, and your domain-specific constraints. Open-source by default; private-fork for regulated workloads.</p>
-</div>
+          <div class="service-card">
+            <h3>Open-source feature work</h3>
+            <div class="price">$100 – $300 / hour · contract</div>
+            <p>
+              If you're using
+              <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" style="color: var(--accent)"
+                >SCBE-AETHERMOORE</a
+              >
+              or any of my npm/PyPI packages and want a feature added, integrated, or hardened — I'm
+              the canonical author. Sponsorships and bounties accepted.
+            </p>
+          </div>
 
-<div class="service-card">
-<h3>Federal subcontract role</h3>
-<div class="price">$150 – $250 / hour · contract</div>
-<p>I'm SAM.gov registered (UEI J4NXHM6N5F59) and ready to subcontract on AI-safety, governance, or LLM-evaluation work. Two DARPA proposals in active eval. Comfortable with FAR 9.5 source-selection-protected work.</p>
-</div>
+          <div class="service-card">
+            <h3>Workshops & internal training</h3>
+            <div class="price">$2,500 – $7,500 · half day or full day</div>
+            <p>
+              Walk your engineering team through hyperbolic-geometry foundations, the 14-layer
+              pipeline, or the practical implementation of NIST AI RMF / EO 14110 governance
+              evidence. Remote or in-person (PNW preferred).
+            </p>
+          </div>
+        </div>
+      </section>
 
-<div class="service-card">
-<h3>Open-source feature work</h3>
-<div class="price">$100 – $300 / hour · contract</div>
-<p>If you're using <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" style="color:var(--accent)">SCBE-AETHERMOORE</a> or any of my npm/PyPI packages and want a feature added, integrated, or hardened — I'm the canonical author. Sponsorships and bounties accepted.</p>
-</div>
+      <section>
+        <h2>Verifiable proof</h2>
+        <p class="muted">
+          Don't take my word for it. Every claim below is independently verifiable in 30 seconds.
+        </p>
+        <div class="proof">
+          <div class="row">
+            <span class="label">SAM.gov UEI</span
+            ><span class="value">J4NXHM6N5F59 · ACTIVE through 2027-04-03</span>
+          </div>
+          <div class="row">
+            <span class="label">CAGE code</span><span class="value">1EXD5</span>
+          </div>
+          <div class="row">
+            <span class="label">Open-source library</span
+            ><span class="value"
+              ><a
+                href="https://github.com/issdandavis/SCBE-AETHERMOORE"
+                target="_blank"
+                rel="noopener"
+                >github.com/issdandavis/SCBE-AETHERMOORE</a
+              ></span
+            >
+          </div>
+          <div class="row">
+            <span class="label">npm package</span
+            ><span class="value"
+              ><a
+                href="https://www.npmjs.com/package/scbe-aethermoore"
+                target="_blank"
+                rel="noopener"
+                >scbe-aethermoore</a
+              ></span
+            >
+          </div>
+          <div class="row">
+            <span class="label">PyPI package</span
+            ><span class="value"
+              ><a href="https://pypi.org/project/scbe-agent-bus/" target="_blank" rel="noopener"
+                >scbe-agent-bus</a
+              ></span
+            >
+          </div>
+          <div class="row">
+            <span class="label">Provisional patent</span
+            ><span class="value">US 63/961,403 (hyperbolic governance substrate)</span>
+          </div>
+          <div class="row">
+            <span class="label">Federal proposals</span
+            ><span class="value">DARPA CLARA FP-033 · DARPA MATHBAC abstract</span>
+          </div>
+          <div class="row">
+            <span class="label">APEX Accelerator</span
+            ><span class="value">Port Angeles SBA-affiliated partner</span>
+          </div>
+          <div class="row">
+            <span class="label">Small business status</span
+            ><span class="value">Sole proprietor · minority-owned</span>
+          </div>
+        </div>
+      </section>
 
-<div class="service-card">
-<h3>Workshops & internal training</h3>
-<div class="price">$2,500 – $7,500 · half day or full day</div>
-<p>Walk your engineering team through hyperbolic-geometry foundations, the 14-layer pipeline, or the practical implementation of NIST AI RMF / EO 14110 governance evidence. Remote or in-person (PNW preferred).</p>
-</div>
+      <section>
+        <h2>What I'm uniquely good at</h2>
+        <ul class="qual-list">
+          <li>
+            <strong>Adversarial-cost manifold design</strong>Closed-form bounds on attack cost, not
+            learned filters. Hyperbolic geometry as substrate.
+          </li>
+          <li>
+            <strong>Constrained-decoding governance</strong>180/180 cross-lane structural
+            enforcement. Wilson CI [0.979, 1.0]. Deterministic.
+          </li>
+          <li>
+            <strong>Multi-axiom formal models</strong>5-axiom mesh (unitarity, locality, causality,
+            symmetry, composition) across 14 pipeline layers.
+          </li>
+          <li>
+            <strong>Composing with audit tools</strong>173/173 Petri seeds blocked when SCBE wired
+            as enforcement layer. Cite: Anthropic Petri (2026 Q1).
+          </li>
+          <li>
+            <strong>Post-quantum primitives</strong>ML-KEM-768 + ML-DSA-65 + AES-256-GCM throughout.
+            Migration-tested across liboqs renames.
+          </li>
+          <li>
+            <strong>Federal-readiness packaging</strong>SAM-registered, capability statement on
+            file, NAICS coverage across 7 codes.
+          </li>
+        </ul>
+      </section>
 
-</div>
-</section>
+      <section>
+        <h2>How to engage</h2>
+        <p class="muted">I prefer concrete starts. Here are three frictionless ways in:</p>
+        <div class="services">
+          <div class="service-card">
+            <h3>1. Email — fastest</h3>
+            <p style="margin-bottom: 14px">
+              <a
+                href="mailto:issdandavis7795@gmail.com?subject=Engagement%20inquiry%20%E2%80%94%20from%20aethermoore.com%2Fhire"
+                style="color: var(--accent)"
+                >issdandavis7795@gmail.com</a
+              >
+            </p>
+            <p>
+              Best for advisory calls, audits, or scoped engagements. Average reply time under 24
+              hours, often same day.
+            </p>
+          </div>
+          <div class="service-card">
+            <h3>2. Phone — for federal</h3>
+            <p style="margin-bottom: 14px">
+              <a href="tel:+13608080876" style="color: var(--accent)">(360) 808-0876</a>
+            </p>
+            <p>
+              Best for federal subcontract conversations, prime contractor BD calls, or anything
+              involving SAM/CAGE verification.
+            </p>
+          </div>
+          <div class="service-card">
+            <h3>3. Sponsor or tip</h3>
+            <p style="margin-bottom: 14px">
+              <a
+                href="https://ko-fi.com/Y8Y51UQYWZ"
+                target="_blank"
+                rel="noopener"
+                style="color: var(--accent)"
+                >ko-fi.com/Y8Y51UQYWZ</a
+              >
+            </p>
+            <p>
+              If the open-source work has helped you and there's no engagement on the table, a
+              sponsorship keeps the work funded and the next release shipping.
+            </p>
+          </div>
+        </div>
+      </section>
 
-<section>
-<h2>Verifiable proof</h2>
-<p class="muted">Don't take my word for it. Every claim below is independently verifiable in 30 seconds.</p>
-<div class="proof">
-<div class="row"><span class="label">SAM.gov UEI</span><span class="value">J4NXHM6N5F59 · ACTIVE through 2027-04-03</span></div>
-<div class="row"><span class="label">CAGE code</span><span class="value">1EXD5</span></div>
-<div class="row"><span class="label">Open-source library</span><span class="value"><a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">github.com/issdandavis/SCBE-AETHERMOORE</a></span></div>
-<div class="row"><span class="label">npm package</span><span class="value"><a href="https://www.npmjs.com/package/scbe-aethermoore" target="_blank" rel="noopener">scbe-aethermoore</a></span></div>
-<div class="row"><span class="label">PyPI package</span><span class="value"><a href="https://pypi.org/project/scbe-agent-bus/" target="_blank" rel="noopener">scbe-agent-bus</a></span></div>
-<div class="row"><span class="label">Provisional patent</span><span class="value">US 63/961,403 (hyperbolic governance substrate)</span></div>
-<div class="row"><span class="label">Federal proposals</span><span class="value">DARPA CLARA FP-033 · DARPA MATHBAC abstract</span></div>
-<div class="row"><span class="label">APEX Accelerator</span><span class="value">Port Angeles SBA-affiliated partner</span></div>
-<div class="row"><span class="label">Small business status</span><span class="value">Sole proprietor · minority-owned</span></div>
-</div>
-</section>
+      <section>
+        <div class="trust">
+          <h2>How I work</h2>
+          <p>
+            Solo. No subcontracting layers, no junior teams shadowed by a senior, no offshoring. You
+            talk directly to the principal. Engagements get a written scope before money changes
+            hands. Open-source delivery is the default; private-fork is available for regulated
+            workloads with a written justification.
+          </p>
+          <p>
+            Booked from Port Angeles, WA. APEX Accelerator partnership. SAM.gov UEI J4NXHM6N5F59.
+          </p>
+          <p class="legal">
+            This page is informational. Engagements require a written agreement (statement of work
+            or contract) before performance begins. Federal subcontract work follows the prime's
+            flowdown clauses; FAR 9.5 source-selection sensitive matters are handled per the prime's
+            policy.
+          </p>
+        </div>
+      </section>
 
-<section>
-<h2>What I'm uniquely good at</h2>
-<ul class="qual-list">
-<li><strong>Adversarial-cost manifold design</strong>Closed-form bounds on attack cost, not learned filters. Hyperbolic geometry as substrate.</li>
-<li><strong>Constrained-decoding governance</strong>180/180 cross-lane structural enforcement. Wilson CI [0.979, 1.0]. Deterministic.</li>
-<li><strong>Multi-axiom formal models</strong>5-axiom mesh (unitarity, locality, causality, symmetry, composition) across 14 pipeline layers.</li>
-<li><strong>Composing with audit tools</strong>173/173 Petri seeds blocked when SCBE wired as enforcement layer. Cite: Anthropic Petri (2026 Q1).</li>
-<li><strong>Post-quantum primitives</strong>ML-KEM-768 + ML-DSA-65 + AES-256-GCM throughout. Migration-tested across liboqs renames.</li>
-<li><strong>Federal-readiness packaging</strong>SAM-registered, capability statement on file, NAICS coverage across 7 codes.</li>
-</ul>
-</section>
+      <section>
+        <h2>Talk to Polly</h2>
+        <p class="muted">
+          Polly is the SCBE assistant. Ask about products, scope a custom build, or get pointed at
+          the right resource. Conversations help train the next release (with your consent).
+        </p>
+        <div
+          id="pollyChatRoot"
+          style="
+            min-height: 560px;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
+            background: var(--card);
+          "
+        ></div>
+      </section>
+      <footer>
+        <div>
+          <a href="https://aethermoore.com">aethermoore.com</a> ·
+          <a href="https://github.com/issdandavis/SCBE-AETHERMOORE">GitHub</a> ·
+          <a href="mailto:issdandavis7795@gmail.com">issdandavis7795@gmail.com</a>
+        </div>
+        <div>Built solo · Last updated 2026-05-09</div>
+      </footer>
+    </div>
 
-<section>
-<h2>How to engage</h2>
-<p class="muted">I prefer concrete starts. Here are three frictionless ways in:</p>
-<div class="services">
-<div class="service-card">
-<h3>1. Email — fastest</h3>
-<p style="margin-bottom:14px"><a href="mailto:issdandavis7795@gmail.com?subject=Engagement%20inquiry%20%E2%80%94%20from%20aethermoore.com%2Fhire" style="color:var(--accent)">issdandavis7795@gmail.com</a></p>
-<p>Best for advisory calls, audits, or scoped engagements. Average reply time under 24 hours, often same day.</p>
-</div>
-<div class="service-card">
-<h3>2. Phone — for federal</h3>
-<p style="margin-bottom:14px"><a href="tel:+13608080876" style="color:var(--accent)">(360) 808-0876</a></p>
-<p>Best for federal subcontract conversations, prime contractor BD calls, or anything involving SAM/CAGE verification.</p>
-</div>
-<div class="service-card">
-<h3>3. Sponsor or tip</h3>
-<p style="margin-bottom:14px"><a href="https://ko-fi.com/Y8Y51UQYWZ" target="_blank" rel="noopener" style="color:var(--accent)">ko-fi.com/Y8Y51UQYWZ</a></p>
-<p>If the open-source work has helped you and there's no engagement on the table, a sponsorship keeps the work funded and the next release shipping.</p>
-</div>
-</div>
-</section>
-
-<section>
-<div class="trust">
-<h2>How I work</h2>
-<p>Solo. No subcontracting layers, no junior teams shadowed by a senior, no offshoring. You talk directly to the principal. Engagements get a written scope before money changes hands. Open-source delivery is the default; private-fork is available for regulated workloads with a written justification.</p>
-<p>Booked from Port Angeles, WA. APEX Accelerator partnership. SAM.gov UEI J4NXHM6N5F59.</p>
-<p class="legal">This page is informational. Engagements require a written agreement (statement of work or contract) before performance begins. Federal subcontract work follows the prime's flowdown clauses; FAR 9.5 source-selection sensitive matters are handled per the prime's policy.</p>
-</div>
-</section>
-
-
-<section>
-<h2>Talk to Polly</h2>
-<p class="muted">Polly is the SCBE assistant. Ask about products, scope a custom build, or get pointed at the right resource. Conversations help train the next release (with your consent).</p>
-<div id="pollyChatRoot" style="min-height:560px;border:1px solid var(--border);border-radius:12px;overflow:hidden;background:var(--card);"></div>
-</section>
-<footer>
-<div>
-<a href="https://aethermoore.com">aethermoore.com</a> · <a href="https://github.com/issdandavis/SCBE-AETHERMOORE">GitHub</a> · <a href="mailto:issdandavis7795@gmail.com">issdandavis7795@gmail.com</a>
-</div>
-<div>
-Built solo · Last updated 2026-05-09
-</div>
-</footer>
-
-</div>
-
-<script src="/static/polly-hf-chat.js"></script>
-<script>
-(function(){
-  var root = document.getElementById('pollyChatRoot');
-  if (!root || !window.PollyHFChat) return;
-  window.PollyHFChat.mount(root, {
-    title: 'Polly',
-    subtitle: 'Direct line to product, custom builds, and the work itself.',
-    mode: 'scbe-polly',
-    scbeApiBase: window.location.origin,
-    consentToTrain: true,
-    sessionId: 'hire-' + Date.now(),
-    initialAssistantText: "Ask anything: products, custom builds, federal subcontract conversations, or how the 14-layer pipeline works.",
-    suggestions: [
-      'How much is the AI Governance Toolkit?',
-      'I need a custom audit for my finance LLM',
-      'How do I sponsor the work?',
-      'What does the harmonic wall actually do?'
-    ]
-  });
-})();
-</script>
-</body>
+    <script src="/static/polly-hf-chat.js"></script>
+    <script>
+      (function () {
+        var root = document.getElementById('pollyChatRoot');
+        if (!root || !window.PollyHFChat) return;
+        window.PollyHFChat.mount(root, {
+          title: 'Polly',
+          subtitle: 'Direct line to product, custom builds, and the work itself.',
+          mode: 'scbe-polly',
+          scbeApiBase: window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app',
+          consentToTrain: true,
+          sessionId: 'hire-' + Date.now(),
+          initialAssistantText:
+            'Ask anything: products, custom builds, federal subcontract conversations, or how the 14-layer pipeline works.',
+          suggestions: [
+            'How much is the AI Governance Toolkit?',
+            'I need a custom audit for my finance LLM',
+            'How do I sponsor the work?',
+            'What does the harmonic wall actually do?',
+          ],
+        });
+      })();
+    </script>
+  </body>
 </html>

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -1,0 +1,246 @@
+/**
+ * @file polly_commerce_js.test.ts
+ * Tests the JS Vercel-side port of polly commerce intent classification.
+ * Mirrors the Python parity tests in test_polly_commerce.py.
+ */
+
+import { describe, it, expect } from 'vitest';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const commerce = require('../../api/polly/commerce.js');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const chatHandler = require('../../api/polly/chat.js');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const feedbackHandler = require('../../api/polly/feedback.js');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const catalogHandler = require('../../api/polly/catalog.js');
+
+interface MockRes {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  setHeader(k: string, v: string): void;
+  status(code: number): MockRes;
+  json(payload: unknown): MockRes;
+  end(): MockRes;
+}
+
+function makeRes(): MockRes {
+  const headers: Record<string, string> = {};
+  const res: MockRes = {
+    statusCode: 200,
+    headers,
+    body: undefined,
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    end() {
+      return this;
+    },
+  };
+  return res;
+}
+
+function makeReq(opts: {
+  method?: string;
+  body?: Record<string, unknown>;
+  headers?: Record<string, string>;
+}): unknown {
+  return {
+    method: opts.method || 'POST',
+    headers: opts.headers || {},
+    body: opts.body || {},
+    on() {
+      return this;
+    },
+    destroy() {
+      /* noop */
+    },
+  };
+}
+
+describe('polly commerce intent classification', () => {
+  it('catalog has three live products with valid stripe/kofi urls', () => {
+    expect(commerce.PRODUCT_CATALOG).toHaveLength(3);
+    for (const product of commerce.PRODUCT_CATALOG) {
+      expect(product.checkoutUrl).toMatch(/^https:\/\/(buy\.stripe\.com|ko-fi\.com)/);
+      expect(product.keywords.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('classifies "buy" verb with bound product at 0.95 confidence', () => {
+    const intent = commerce.classifyIntent('I want to buy the AI governance toolkit');
+    expect(intent.name).toBe('buy');
+    expect(intent.confidence).toBeGreaterThanOrEqual(0.95);
+    expect(intent.product).not.toBeNull();
+    expect(intent.product.sku).toBe('ai-governance-toolkit');
+  });
+
+  it('classifies bare product keyword as buy at 0.6', () => {
+    const intent = commerce.classifyIntent('Tell me about the training vault');
+    expect(intent.name).toBe('buy');
+    expect(intent.confidence).toBeCloseTo(0.6, 2);
+    expect(intent.product.sku).toBe('ai-security-training-vault');
+  });
+
+  it('classifies custom intent at 0.85', () => {
+    const intent = commerce.classifyIntent('I need a custom audit for my team');
+    expect(intent.name).toBe('custom');
+    expect(intent.confidence).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it('classifies membership intent at 0.75', () => {
+    const intent = commerce.classifyIntent('How do I subscribe to the newsletter?');
+    expect(intent.name).toBe('membership');
+  });
+
+  it('returns general intent when nothing matches', () => {
+    const intent = commerce.classifyIntent('What is the weather today?');
+    expect(intent.name).toBe('general');
+    expect(intent.confidence).toBe(0);
+  });
+
+  it('handles empty input safely', () => {
+    expect(commerce.classifyIntent('').name).toBe('general');
+    expect(commerce.classifyIntent(null as unknown as string).name).toBe('general');
+  });
+});
+
+describe('polly commerce reply rendering', () => {
+  it('renderBuyReply with product returns checkout url in actions', () => {
+    const product = commerce.PRODUCT_CATALOG[0];
+    const out = commerce.renderBuyReply(product);
+    expect(out.text).toContain(product.name);
+    expect(out.text).toContain(product.checkoutUrl);
+    expect(out.actions[0].url).toBe(product.checkoutUrl);
+  });
+
+  it('renderBuyReply with null lists all 3 products', () => {
+    const out = commerce.renderBuyReply(null);
+    expect(out.actions).toHaveLength(3);
+    for (const action of out.actions) {
+      expect(action.url).toMatch(/^https:\/\//);
+    }
+  });
+
+  it('renderCustomReply returns mailto with pre-filled context', () => {
+    const out = commerce.renderCustomReply('We need governance for our finance LLM');
+    const mailtoAction = out.actions.find((a: { url: string }) => a.url.startsWith('mailto:'));
+    expect(mailtoAction).toBeDefined();
+    expect(mailtoAction!.url).toContain('issdandavis7795@gmail.com');
+    expect(mailtoAction!.url).toContain('finance');
+  });
+
+  it('renderMembershipReply has Ko-fi + GitHub + email actions', () => {
+    const out = commerce.renderMembershipReply();
+    expect(out.actions).toHaveLength(3);
+    expect(out.actions[0].url).toContain('ko-fi.com');
+    expect(out.actions[1].url).toContain('github.com');
+    expect(out.actions[2].url).toContain('mailto:');
+  });
+});
+
+describe('polly chat handler — commerce path', () => {
+  it('returns Stripe link when buy intent + product matches', async () => {
+    const req = makeReq({
+      body: { message: 'I want to buy the AI governance toolkit', consent_to_train: false },
+    });
+    const res = makeRes();
+    await chatHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as {
+      ok: boolean;
+      provider: string;
+      intent: string;
+      actions: { url: string }[];
+    };
+    expect(body.ok).toBe(true);
+    expect(body.provider).toBe('commerce');
+    expect(body.intent).toBe('buy');
+    expect(body.actions[0].url).toContain('buy.stripe.com');
+  });
+
+  it('returns mailto + hire url for custom intent', async () => {
+    const req = makeReq({
+      body: {
+        message: 'I need a custom governance overlay for my company',
+        consent_to_train: false,
+      },
+    });
+    const res = makeRes();
+    await chatHandler(req, res);
+    const body = res.body as { intent: string; actions: { url: string }[] };
+    expect(body.intent).toBe('custom');
+    expect(body.actions.some((a) => a.url.startsWith('mailto:'))).toBe(true);
+    expect(body.actions.some((a) => a.url.includes('aethermoore.com/hire'))).toBe(true);
+  });
+
+  it('rejects POST without message', async () => {
+    const req = makeReq({ body: {} });
+    const res = makeRes();
+    await chatHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects non-POST methods', async () => {
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    await chatHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('handles OPTIONS for CORS preflight', async () => {
+    const req = makeReq({ method: 'OPTIONS' });
+    const res = makeRes();
+    await chatHandler(req, res);
+    expect(res.statusCode).toBe(204);
+  });
+});
+
+describe('polly feedback handler', () => {
+  it('captures up rating', async () => {
+    const req = makeReq({
+      body: { rating: 'up', user_message: 'hi', assistant_reply: 'hello', session_id: 'test-1' },
+    });
+    const res = makeRes();
+    await feedbackHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { ok: boolean; rating: string };
+    expect(body.ok).toBe(true);
+    expect(body.rating).toBe('up');
+  });
+
+  it('rejects invalid rating', async () => {
+    const req = makeReq({ body: { rating: 'maybe' } });
+    const res = makeRes();
+    await feedbackHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('polly catalog handler', () => {
+  it('returns the product catalog over GET', async () => {
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    await catalogHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { ok: boolean; products: unknown[]; consulting_tiers: unknown[] };
+    expect(body.ok).toBe(true);
+    expect(body.products).toHaveLength(3);
+    expect(body.consulting_tiers.length).toBeGreaterThan(0);
+  });
+
+  it('rejects POST', async () => {
+    const req = makeReq({ method: 'POST' });
+    const res = makeRes();
+    await catalogHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+});

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -13,6 +13,8 @@ const chatHandler = require('../../api/polly/chat.js');
 const feedbackHandler = require('../../api/polly/feedback.js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const catalogHandler = require('../../api/polly/catalog.js');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const trainCapture = require('../../api/_polly_train_capture.js');
 
 interface MockRes {
   statusCode: number;
@@ -242,5 +244,44 @@ describe('polly catalog handler', () => {
     const res = makeRes();
     await catalogHandler(req, res);
     expect(res.statusCode).toBe(405);
+  });
+});
+
+describe('polly training capture (repository_dispatch)', () => {
+  it('returns no_token when GITHUB_TOKEN not set', async () => {
+    const original = {
+      gh: process.env.GITHUB_TOKEN,
+      gh2: process.env.GH_TOKEN,
+      polly: process.env.POLLY_TRAIN_GITHUB_TOKEN,
+    };
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    delete process.env.POLLY_TRAIN_GITHUB_TOKEN;
+    try {
+      const result = await trainCapture.dispatchTrainingTurn({ ts: 1, user: 'x', assistant: 'y' });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('no_token');
+    } finally {
+      if (original.gh) process.env.GITHUB_TOKEN = original.gh;
+      if (original.gh2) process.env.GH_TOKEN = original.gh2;
+      if (original.polly) process.env.POLLY_TRAIN_GITHUB_TOKEN = original.polly;
+    }
+  });
+
+  it('returns disabled when env opt-out is set', async () => {
+    const originalDisable = process.env.POLLY_TRAIN_DISPATCH_ENABLED;
+    process.env.POLLY_TRAIN_DISPATCH_ENABLED = 'false';
+    try {
+      const result = await trainCapture.dispatchTrainingTurn({ ts: 1 });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('disabled');
+    } finally {
+      if (originalDisable === undefined) delete process.env.POLLY_TRAIN_DISPATCH_ENABLED;
+      else process.env.POLLY_TRAIN_DISPATCH_ENABLED = originalDisable;
+    }
+  });
+
+  it('exports the canonical event type so the workflow listens correctly', () => {
+    expect(trainCapture.EVENT_TYPE).toBe('polly_training_turn');
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,13 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in main|launch/*|vercel-test/*|customer/*|fix/launch-*|feat/vercel-*|fix/vercel-*) exit 1 ;; *) exit 0 ;; esac",
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in main|launch/*|vercel-test/*|customer/*|fix/launch-*|feat/vercel-*|fix/vercel-*|feat/polly-*|fix/polly-*) exit 1 ;; *) exit 0 ;; esac",
   "builds": [
     {
       "src": "api/agent/*.js",
+      "use": "@vercel/node"
+    },
+    {
+      "src": "api/polly/*.js",
       "use": "@vercel/node"
     }
   ],
@@ -19,6 +23,22 @@
     {
       "src": "^/api/agent/(.*)$",
       "dest": "/api/agent/$1.js"
+    },
+    {
+      "src": "^/api/polly/(.*)$",
+      "dest": "/api/polly/$1.js"
+    },
+    {
+      "src": "^/v1/polly/chat/?$",
+      "dest": "/api/polly/chat.js"
+    },
+    {
+      "src": "^/v1/polly/feedback/?$",
+      "dest": "/api/polly/feedback.js"
+    },
+    {
+      "src": "^/v1/polly/catalog/?$",
+      "dest": "/api/polly/catalog.js"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes the architectural gap that left the Polly chat widget on `aethermoore.com/hire` calling `/v1/polly/chat` against GitHub Pages — which has no FastAPI backend and was returning 404 to actual visitors. The buy/custom/membership intents could not return real Stripe / mailto / Ko-fi links to anyone landing on the hire page.

This ports the Python commerce surface (`src/api/polly_commerce.py`) to JS Vercel Functions on the existing `scbe-agent-bridge-vercel` project, then points the widget at the stable Vercel production URL.

## What lands

**New Vercel Functions** (deployed to `https://scbe-agent-bridge-vercel.vercel.app`):
- `POST /v1/polly/chat` — runs deterministic commerce intent classification first; on `confidence>=0.6` returns the synthetic reply with `actions[]` buttons (Stripe/mailto/Ko-fi). Otherwise falls through to the existing Ollama → HF → offline LLM router.
- `POST /v1/polly/feedback` — captures thumbs-up/down with `polly_feedback_v1` log prefix.
- `GET /v1/polly/catalog` — returns the product catalog + consulting tiers as JSON.

**Shared helpers**:
- `api/_chat_llm.js` — extracted from `api/agent/chat.js` so each Vercel Function bundles independently (no cross-function `require`).
- `api/_polly_train_capture.js` — fires GitHub `repository_dispatch` events for **durable** consented-turn capture.

**Workflow**:
- `.github/workflows/polly-training-capture.yml` — listens for `polly_training_turn` events and appends validated JSON to `training-data/polly-chat-live/{YYYY-MM}.jsonl` on main.

**Wiring**:
- `vercel.json` — adds `api/polly/*` to builds, routes `/v1/polly/{chat,feedback,catalog}` and `/api/polly/*`, and adds `feat/polly-*` + `fix/polly-*` to the build allowlist.
- `docs/hire.html` — widget config now sets `scbeApiBase` to `window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app'` instead of `window.location.origin`.

## Test plan

- [x] `npx vitest run tests/api/polly_commerce_js.test.ts` — 23/23 passing
- [x] `npm run typecheck` — clean
- [x] `npx prettier --check` — clean
- [ ] Vercel preview build succeeds for this PR (allowed by `feat/polly-*` branch rule)
- [ ] After merge, hit `https://scbe-agent-bridge-vercel.vercel.app/v1/polly/catalog` and confirm 200 + product JSON
- [ ] After merge, hit `https://aethermoore.com/hire`, ask "I want to buy the AI governance toolkit" in Polly, confirm Stripe button renders and works

## Notes for future-you

- **Cost guard**: `docs/deployment/VERCEL_COST_GUARD.md` flags `scbe-agent-bridge-vercel` as a paid-service test surface, not the primary customer site. Now that `/hire` funnels through it, traffic costs land here. Revisit if conversion volume grows.
- **Training capture optional**: `POLLY_TRAIN_DISPATCH_ENABLED=false` disables the GitHub dispatch; `polly_train_v1` stdout lines remain regardless.
- **Required Vercel env vars** for full LLM fallback: `HF_TOKEN` (or `OLLAMA_URL` for self-hosted). Commerce intent works with zero env vars.
- **Required Vercel env var for durable training**: `POLLY_TRAIN_GITHUB_TOKEN` (or `GITHUB_TOKEN`) with `repo` scope — without it, capture falls back to stdout-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)