### PR TITLE
feat(polly): replace LLM offline placeholder with four-bucket router

### DIFF
--- a/api/polly/chat.js
+++ b/api/polly/chat.js
@@ -7,6 +7,8 @@ const {
   renderCustomReply,
   renderMembershipReply,
   renderResearchReply,
+  HIRE_EMAIL,
+  CONSULTING_LANDING_URL,
 } = require('./commerce');
 const llm = require('../_chat_llm');
 const trainCapture = require('../_polly_train_capture');
@@ -121,6 +123,33 @@ module.exports = async function handler(req, res) {
     };
   }
 
+  // If the LLM router returns the offline placeholder, replace the dead-end
+  // message with a useful four-bucket router so the user always has a next
+  // step. Real LLM responses (provider in ollama|huggingface) pass through.
+  if (!llm || llm.provider === 'offline' || llm.provider === 'error') {
+    const fallback = renderOfflineRouter(message);
+    captureIfConsented({
+      req: body,
+      message,
+      reply: fallback.text,
+      intent: intent.name,
+      sessionId,
+      pageContext,
+      provider: 'offline-router',
+    });
+    return sendJson(res, 200, {
+      ok: true,
+      text: fallback.text,
+      provider: 'offline-router',
+      model: 'fallback-router-v1',
+      attempts: (llm && llm.attempts) || [],
+      intent: intent.name,
+      confidence: intent.confidence,
+      actions: fallback.actions,
+      cost: 'zero-deterministic',
+    });
+  }
+
   captureIfConsented({
     req: body,
     message,
@@ -144,10 +173,39 @@ module.exports = async function handler(req, res) {
   });
 };
 
+function renderOfflineRouter(message) {
+  const trimmed = String(message || '').slice(0, 300);
+  const subject = 'Polly conversation — direct follow-up';
+  const body =
+    `Hi Issac,\n\n` +
+    `I asked Polly: "${trimmed}"\n\n` +
+    `It didn't match a stock answer — could you reply directly? My context:\n\n`;
+  const mailto = `mailto:${HIRE_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  const text =
+    "I don't have a stock answer for that one — but here are the four ways " +
+    'I can actually help right now:\n\n' +
+    '- **Buy** a $29 toolkit (governance or training vault)\n' +
+    '- **Custom** scope: audit, advisory, or governance overlay\n' +
+    '- **Research**: ask about the harmonic wall, the 14-layer pipeline, ' +
+    'Sacred Tongues, axiom mesh, Petri composition, or DARPA work\n' +
+    '- **Stay close**: tip the work or watch the GitHub repo\n\n' +
+    'Or email me directly with your question — same-day reply where I can.';
+  const actions = [
+    { label: 'See products', url: CONSULTING_LANDING_URL },
+    { label: 'Email Issac with this question', url: mailto },
+    {
+      label: 'Browse the repo',
+      url: 'https://github.com/issdandavis/SCBE-AETHERMOORE',
+    },
+  ];
+  return { text, actions };
+}
+
 module.exports._private = {
   COMMERCE_INTENTS,
   COMMERCE_CONFIDENCE_FLOOR,
   llmFallback,
   logTrainingTurn,
   captureIfConsented,
+  renderOfflineRouter,
 };

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -188,6 +188,34 @@ describe('polly chat handler — research path', () => {
   });
 });
 
+describe('polly chat handler — offline-router fallback', () => {
+  it('replaces dead-end LLM offline message with the four-bucket router', async () => {
+    const original = {
+      hf: process.env.HF_TOKEN,
+      ollama: process.env.OLLAMA_URL,
+    };
+    delete process.env.HF_TOKEN;
+    delete process.env.HUGGINGFACE_TOKEN;
+    delete process.env.HUGGING_FACE_HUB_TOKEN;
+    delete process.env.OLLAMA_URL;
+    try {
+      const req = makeReq({
+        body: { message: 'tell me a joke about ducks please', consent_to_train: false },
+      });
+      const res = makeRes();
+      await chatHandler(req, res);
+      const body = res.body as { provider: string; text: string; actions: { url: string }[] };
+      expect(body.provider).toBe('offline-router');
+      expect(body.text).toContain('four ways');
+      expect(body.actions.length).toBeGreaterThanOrEqual(2);
+      expect(body.actions.some((a) => a.url.startsWith('mailto:'))).toBe(true);
+    } finally {
+      if (original.hf) process.env.HF_TOKEN = original.hf;
+      if (original.ollama) process.env.OLLAMA_URL = original.ollama;
+    }
+  });
+});
+
 describe('polly chat handler — commerce path', () => {
   it('returns Stripe link when buy intent + product matches', async () => {
     const req = makeReq({


### PR DESCRIPTION
## Summary
When HF_TOKEN and OLLAMA_URL are both unset on Vercel (current production state), the chat handler used to return the literal `[offline/local-first mode]\n\nNo configured chat model answered...` placeholder. Useful as a debug signal but a dead-end for end users.

This PR short-circuits when `llm.provider` is `offline` or `error` and returns a deterministic four-bucket router (buy / custom / research / membership) + a pre-filled mailto. Real LLM responses (provider in `ollama|huggingface`) still pass through unchanged.

Setting HF_TOKEN on Vercel is now a quality upgrade, not a release-blocker.

## Files
- `api/polly/chat.js` — `renderOfflineRouter(message)` + branch on `provider === 'offline' || 'error'`
- `tests/api/polly_commerce_js.test.ts` — 1 new env-isolated case

## Test plan
- [x] `npx vitest run tests/api/polly_commerce_js.test.ts` → 29/29 green
- [ ] Post-merge: `curl https://scbe-agent-bridge-vercel.vercel.app/v1/polly/chat -d '{"message":"tell me about ducks"}'` should return `provider: "offline-router"` with mailto + repo links

🤖 Generated with [Claude Code](https://claude.com/claude-code)