### PR TITLE
feat(polly): topic-key fallback for research classifier

### DIFF
--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -120,6 +120,25 @@ function classifyIntent(message) {
     return { name: 'research', confidence: 0.8, matchedTerm: researchMatch[0], product: null };
   }
 
+  // Topic-key fallback: "What is the harmonic wall?" doesn't match the
+  // RESEARCH_PATTERN regex but contains a known topic key. If the message
+  // hits a registered topic AND looks like a question/explanation prompt,
+  // route it to research.
+  const looksLikeQuestion = /\b(what|how|why|when|where|who|which|explain|describe|tell\s+me)\b/i.test(
+    message
+  );
+  if (looksLikeQuestion) {
+    const topic = resolveResearchTopic(message);
+    if (topic) {
+      return {
+        name: 'research',
+        confidence: 0.78,
+        matchedTerm: topic.title,
+        product: null,
+      };
+    }
+  }
+
   const membershipMatch = MEMBERSHIP_PATTERN.exec(message);
   if (membershipMatch) {
     return { name: 'membership', confidence: 0.75, matchedTerm: membershipMatch[0], product: null };

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -109,6 +109,22 @@ describe('polly commerce intent classification', () => {
     expect(intent.confidence).toBeCloseTo(0.8, 2);
   });
 
+  it('classifies "what is the harmonic wall" via topic-key fallback at 0.78', () => {
+    const intent = commerce.classifyIntent('What is the harmonic wall in SCBE?');
+    expect(intent.name).toBe('research');
+    expect(intent.confidence).toBeCloseTo(0.78, 2);
+  });
+
+  it('classifies "explain the 14-layer pipeline" via topic-key fallback', () => {
+    const intent = commerce.classifyIntent('Explain the 14-layer pipeline please');
+    expect(intent.name).toBe('research');
+  });
+
+  it('does NOT route question-shaped non-topic prompts to research', () => {
+    const intent = commerce.classifyIntent('What time is it?');
+    expect(intent.name).toBe('general');
+  });
+
   it('returns general intent when nothing matches', () => {
     const intent = commerce.classifyIntent('What is the weather today?');
     expect(intent.name).toBe('general');


### PR DESCRIPTION
## Summary
PR #1494 added a 7-topic research handler but the classifier regex only matched explicit research verbs (`research / find / look up / latest / paper / cite`). Bare question forms like "What is the harmonic wall?" or "Explain the 14-layer pipeline" fell through to the offline-router fallback even though we ship a deterministic answer for them.

This PR adds a topic-key fallback: if the message is question-shaped (`what/how/why/when/where/who/which/explain/describe/tell me`) AND contains a registered `RESEARCH_TOPIC` key, route to research at 0.78 confidence.

Verified that non-topic question forms ("What time is it?") still classify as `general`.

## Files
- `api/polly/commerce.js` — topic-key fallback after RESEARCH_PATTERN check
- `tests/api/polly_commerce_js.test.ts` — 3 new cases (positive, second-topic positive, non-topic negative)

## Test plan
- [x] `npx vitest run tests/api/polly_commerce_js.test.ts` → 32/32 green
- [ ] Post-merge: `curl https://scbe-agent-bridge-vercel.vercel.app/v1/polly/chat -d '{"message":"What is the harmonic wall in SCBE?"}'` should return `intent: "research"` `provider: "research"` with the formula in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)