### PR TITLE
fix(polly): broken CONSULTING_LANDING_URL — was pointing to 404

### DIFF
--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -63,7 +63,10 @@ const CONSULTING_TIERS = [
   },
 ];
 
-const CONSULTING_LANDING_URL = 'https://aethermoore.com/hire';
+// Apex aethermoore.com only resolves Pages content under the project-prefixed
+// path; bare /hire returns 404 via the current Cloudflare routing. Use the
+// canonical Pages URL until a custom rewrite is configured.
+const CONSULTING_LANDING_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/hire.html';
 const HIRE_EMAIL = 'issdandavis7795@gmail.com';
 const MEMBERSHIP_KOFI_URL = 'https://ko-fi.com/Y8Y51UQYWZ';
 
@@ -317,7 +320,7 @@ const RESEARCH_TOPICS = [
       'as post-quantum hyperbolic successor to DARPA I2O Mission-oriented Resilient Clouds ' +
       '(MRC, ~2011-2017). SAM.gov UEI J4NXHM6N5F59, CAGE 1EXD5.',
     links: [
-      { label: 'Hire / federal subcontract', url: 'https://aethermoore.com/hire' },
+      { label: 'Hire / federal subcontract', url: CONSULTING_LANDING_URL },
     ],
   },
 ];

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -264,7 +264,7 @@ describe('polly chat handler — commerce path', () => {
     const body = res.body as { intent: string; actions: { url: string }[] };
     expect(body.intent).toBe('custom');
     expect(body.actions.some((a) => a.url.startsWith('mailto:'))).toBe(true);
-    expect(body.actions.some((a) => a.url.includes('aethermoore.com/hire'))).toBe(true);
+    expect(body.actions.some((a) => /aethermoore\.com\/.*hire/.test(a.url))).toBe(true);
   });
 
   it('rejects POST without message', async () => {


### PR DESCRIPTION
## Summary
Caught by the wrap-up advisor pass: production smoke confirmed `aethermoore.com/hire` returns 404 via current Cloudflare routing — only `aethermoore.com/SCBE-AETHERMOORE/hire.html` resolves.

Every "Full hire details" and "Hire / federal subcontract" action button shipped in PRs #1491 / #1494 / #1495 was silently sending users to a 404. This fixes the constant + test assertion so the rest of the chat surface no longer breaks the conversion path.

## Files
- `api/polly/commerce.js` — `CONSULTING_LANDING_URL` repointed; federal-proposals topic uses the constant instead of a duplicated literal
- `tests/api/polly_commerce_js.test.ts` — assertion loosened to match either URL form so a future Cloudflare rewrite can revert without churn

## Test plan
- [x] `npx vitest run tests/api/polly_commerce_js.test.ts` → 32/32 green
- [x] `curl -sSI https://aethermoore.com/SCBE-AETHERMOORE/hire.html` → HTTP/1.1 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)