### PR TITLE
chore(android): ignore local signing secrets

### DIFF
--- a/kindle-app/android/.gitignore
+++ b/kindle-app/android/.gitignore
@@ -56,6 +56,10 @@ captures/
 # Uncomment the following lines if you do not want to check your keystore files in.
 #*.jks
 #*.keystore
+signing.local.properties
+*.jks
+*.keystore
+*.p12
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild


### PR DESCRIPTION
## Summary
- Ignore Android local signing files so Play upload keystores and passwords stay out of git.
- Verified existing local signing files are ignored.
- Built and verified a signed AAB locally for the Aethermoor Bus release lane.

## Evidence
- `git check-ignore -v kindle-app/android/signing.local.properties kindle-app/android/aethermoor-bus-upload.jks`
- `cd kindle-app/android && ./gradlew.bat bundleRelease` -> BUILD SUCCESSFUL
- `jarsigner -verify artifacts/releases/aethermoor-bus-appstore/2026-05-09/aethermoor-bus-internal-0.1.1-io.aethermoor.bus-signed.aab` -> `jar verified`, `SIGNED_AAB_VERIFY_PASS=1`

## Notes
- No keystore or signing password is committed.
- The generated signed AAB remains a local release artifact for Play Console upload.