### PR TITLE
feat(polly): wire training capture to private HF dataset (always-on)

### DIFF
--- a/.github/workflows/polly-training-capture.yml
+++ b/.github/workflows/polly-training-capture.yml
@@ -5,59 +5,69 @@ on:
     types: [polly_training_turn]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: polly-training-capture
   cancel-in-progress: false
 
 jobs:
-  append-jsonl:
+  push-to-private-hf-dataset:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Append consented turn to live corpus
+      - name: Push consented turn to private HF dataset
         env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           PAYLOAD: ${{ toJSON(github.event.client_payload.record) }}
+          HF_REPO: ${{ vars.POLLY_HF_DATASET || 'issdandavis/polly-chat-live' }}
         run: |
           set -euo pipefail
-          mkdir -p training-data/polly-chat-live
-          shard="training-data/polly-chat-live/$(date -u +%Y-%m).jsonl"
-          # PII guard: never echo PAYLOAD to logs. Pipe via env var into Python,
-          # which validates and writes the compact JSON to the shard file. Only
-          # the shard path and a row counter ever land in the workflow log.
-          python3 - <<'PY'
-          import json, os, pathlib
-          payload = os.environ["PAYLOAD"]
-          record = json.loads(payload)
-          shard = pathlib.Path(os.environ["GITHUB_WORKSPACE"]) / "training-data" / "polly-chat-live"
-          shard.mkdir(parents=True, exist_ok=True)
-          import datetime
-          name = datetime.datetime.utcnow().strftime("%Y-%m") + ".jsonl"
-          target = shard / name
-          with target.open("a", encoding="utf-8") as f:
-              f.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
-          rows = sum(1 for _ in target.open("r", encoding="utf-8"))
-          print(f"appended to {target.relative_to(os.environ['GITHUB_WORKSPACE'])} (rows={rows})")
-          PY
-
-      - name: Commit if anything changed
-        run: |
-          set -euo pipefail
-          # training-data/**/*.jsonl is gitignored at .gitignore:92 — git status
-          # will report no changes and we exit cleanly. Keeping this step so a
-          # future un-ignoring would still need an explicit decision.
-          if [[ -z "$(git status --porcelain training-data/polly-chat-live)" ]]; then
-            echo "no tracked changes to commit (path is gitignored — record kept ephemerally on the runner)"
+          if [[ -z "${HF_TOKEN:-}" ]]; then
+            echo "HF_TOKEN not configured; skipping push" >&2
             exit 0
           fi
-          git config user.name "polly-train-capture[bot]"
-          git config user.email "polly-train-capture@users.noreply.github.com"
-          git add training-data/polly-chat-live
-          git commit -m "chore(polly): append consented chat turn to live corpus"
-          git push
+          python3 -m pip install --quiet 'huggingface_hub>=0.27,<1.0'
+          # PII guard: never echo PAYLOAD to logs. Pipe via env var into Python,
+          # which validates, writes a per-turn JSON file, and uploads it to the
+          # PRIVATE Hugging Face dataset. Only the dataset path + remote URL
+          # ever land in the workflow log.
+          python3 - <<'PY'
+          import datetime as dt
+          import io
+          import json
+          import os
+          import secrets
+          from huggingface_hub import HfApi
+
+          payload = os.environ["PAYLOAD"]
+          record = json.loads(payload)
+          repo_id = os.environ["HF_REPO"]
+          token = os.environ["HF_TOKEN"]
+
+          api = HfApi(token=token)
+          # Ensure the dataset exists and is private. exist_ok=True is idempotent.
+          api.create_repo(
+              repo_id=repo_id,
+              repo_type="dataset",
+              private=True,
+              exist_ok=True,
+          )
+
+          ts = dt.datetime.utcfromtimestamp(int(record.get("ts") or 0)) if record.get("ts") else dt.datetime.utcnow()
+          day = ts.strftime("%Y-%m-%d")
+          stamp = ts.strftime("%Y%m%dT%H%M%S")
+          nonce = secrets.token_hex(3)
+          path_in_repo = f"polly-chat-live/{day}/{stamp}-{nonce}.json"
+          payload_bytes = json.dumps(record, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+          buffer = io.BytesIO(payload_bytes)
+
+          api.upload_file(
+              path_or_fileobj=buffer,
+              path_in_repo=path_in_repo,
+              repo_id=repo_id,
+              repo_type="dataset",
+              commit_message=f"chore(polly): consented turn {stamp}",
+          )
+          print(f"uploaded to private dataset: {repo_id}/{path_in_repo}")
+          PY

--- a/api/_polly_train_capture.js
+++ b/api/_polly_train_capture.js
@@ -19,7 +19,11 @@ function trainConfig() {
       process.env.GH_TOKEN ||
       '',
     repo: process.env.POLLY_TRAIN_REPO || process.env.GITHUB_REPO || DEFAULT_REPO,
-    enabled: String(process.env.POLLY_TRAIN_DISPATCH_ENABLED || 'false').toLowerCase() === 'true',
+    // Dispatch defaults to ON — the workflow pushes to a PRIVATE Hugging Face
+    // dataset (issdandavis/polly-chat-live), so always-on capture is the
+    // intended state. Set POLLY_TRAIN_DISPATCH_ENABLED='false' on Vercel to
+    // explicitly opt out per-deploy.
+    enabled: String(process.env.POLLY_TRAIN_DISPATCH_ENABLED || 'true').toLowerCase() !== 'false',
     timeoutMs: Math.max(500, Number(process.env.POLLY_TRAIN_DISPATCH_TIMEOUT_MS || 4000)),
   };
 }

--- a/docs/deployment/POLLY_TRAINING_CAPTURE.md
+++ b/docs/deployment/POLLY_TRAINING_CAPTURE.md
@@ -1,72 +1,107 @@
-# Polly training capture — privacy-by-default contract
+# Polly training capture — private HF dataset contract
 
-`api/polly/chat.js` can durably capture consented chat turns for training. As of
-2026-05-09 the capture path is **off by default**. Two independent gates must
-both be on for any record to leave the Vercel runtime:
+`api/polly/chat.js` durably captures consented chat turns and pushes them to
+the **private** Hugging Face dataset
+[`issdandavis/polly-chat-live`](https://huggingface.co/datasets/issdandavis/polly-chat-live)
+(visible only to the dataset owner). As of 2026-05-09 the path is wired
+end-to-end: widget → Vercel Function → GitHub `repository_dispatch` →
+`polly-training-capture` workflow → `huggingface_hub.upload_file` →
+private dataset.
 
-1. **Per-message consent** — the request body must include `consent_to_train: true`.
-   `docs/hire.html` ships an unchecked checkbox bound to the widget's
-   `setConsent(boolean)` method, so the default user state is no-consent.
-2. **Server-side enable** — the Vercel project must set
-   `POLLY_TRAIN_DISPATCH_ENABLED=true`. Anything else (unset, `false`, `0`)
-   short-circuits `dispatchTrainingTurn` to `{ ok: false, reason: 'disabled' }`.
+## What capture does (default)
 
-When both gates are on, `dispatchTrainingTurn` fires a GitHub
-`repository_dispatch` event of type `polly_training_turn` with the record as
-`client_payload`. Vercel still writes a `polly_train_v1` line to its function
-log (private to the project) regardless of dispatch state, so commerce-intent
-turns remain auditable per-deploy without leaving Vercel.
+By default everything is on:
 
-## Where the data goes
+- Widget checkbox at `docs/hire.html` ships **checked** — `consentToTrain: true`
+- `POLLY_TRAIN_DISPATCH_ENABLED` defaults to `'true'` in `api/_polly_train_capture.js`
+  unless explicitly set to `'false'` on Vercel
+- Workflow runs on every dispatched event and uploads one JSON file per turn
 
-The `polly-training-capture` workflow consumes the dispatched event and tries to
-append the record to `training-data/polly-chat-live/{YYYY-MM}.jsonl` on `main`.
+To turn capture off per-deploy, set `POLLY_TRAIN_DISPATCH_ENABLED=false` on
+Vercel. To turn capture off per-conversation, the user unticks the checkbox.
 
-That path is **gitignored** at `.gitignore:92` (`training-data/**/*.jsonl`), so
-the workflow's commit step deliberately no-ops with a "no tracked changes to
-commit" message. Records reach the runner filesystem, get appended to a shard,
-and are discarded when the runner shuts down.
+## Required secrets
 
-This is intentional — until a private destination is wired, the workflow's job
-is to (a) prove the dispatch path works end-to-end and (b) keep the option
-open. **Do not turn `POLLY_TRAIN_DISPATCH_ENABLED=true` in production unless one
-of the persistence options below is in place.**
+Set once on the GitHub repository (Settings → Secrets and variables → Actions):
 
-## To make capture durable, pick one
+| Secret | Where to get it | Purpose |
+|---|---|---|
+| `HF_TOKEN` | <https://huggingface.co/settings/tokens> | workflow uploads to the private dataset |
+| `GITHUB_TOKEN` (auto) | provided by GitHub | dispatch event from Vercel uses this |
 
-- **Private companion repo** (preferred for low volume): create
-  `issdandavis/polly-chat-live` as a private repository, set
-  `POLLY_TRAIN_REPO=issdandavis/polly-chat-live` on Vercel, and update the
-  workflow's `actions/checkout` `ref` to that repo. The training-data gitignore
-  no longer applies, so the commit step will land actual files.
-- **Private HF dataset**: replace the workflow's commit step with a
-  `huggingface_hub.HfApi().upload_file` call against `issdandavis/polly-chat-live`
-  with `private=True`. Requires `HF_TOKEN` as a workflow secret.
-- **S3 with bucket policy**: forward the runner-local file to a private S3
-  bucket via `aws s3 cp` with object lifecycle configured.
+Set on the Vercel project (Settings → Environment Variables):
 
-Whichever destination is chosen, document it here and revisit the
-[`docs/deployment/VERCEL_COST_GUARD.md`](VERCEL_COST_GUARD.md) entry — additional
-storage and CI cycles attach to this surface.
+| Var | Value | Purpose |
+|---|---|---|
+| `POLLY_TRAIN_GITHUB_TOKEN` | a fine-grained PAT with `Contents: read` and `Metadata: read` on `issdandavis/SCBE-AETHERMOORE` | Vercel-side dispatch auth (or set `GITHUB_TOKEN` if your env already has one) |
+| `POLLY_TRAIN_DISPATCH_ENABLED` | `true` (default) or `false` | per-deploy kill switch |
+| `POLLY_TRAIN_REPO` | optional, defaults to `issdandavis/SCBE-AETHERMOORE` | which repo receives the dispatch event |
+| `POLLY_HF_DATASET` (workflow var) | optional, defaults to `issdandavis/polly-chat-live` | which HF dataset receives the records — set as a repo *variable*, not secret |
 
-## What never leaves the runtime, even when capture is enabled
+## Path layout in the dataset
 
-The chat handler caps `user` at 4 KB and `assistant` at 8 KB before
-dispatching, and the workflow uses a Python heredoc to read `PAYLOAD` from the
-environment without echoing it to the action log. Workflow logs on the public
-repo therefore see only the shard path and a row counter, not the chat content.
+Each turn becomes one file:
+
+```
+polly-chat-live/
+  2026-05-09/
+    20260509T203412-a4f7c2.json
+    20260509T203518-9bc81d.json
+    ...
+  2026-05-10/
+    ...
+```
+
+Per-turn JSON shape (capped at 4 KB user / 8 KB assistant before upload):
+
+```json
+{
+  "ts": 1715201652,
+  "session_id": "hire-1715201640000",
+  "intent": "research",
+  "provider": "research",
+  "user": "...",
+  "assistant": "...",
+  "page_context": "/hire",
+  "transport": "vercel-polly-chat"
+}
+```
+
+A daily consolidation script (TODO) can collapse the per-turn files into a
+single `polly-chat-live/{YYYY-MM}.jsonl` shard for easier training-data import.
+
+## Cost / volume notes
+
+- HF dataset commits are free for accounts with a paid plan; the user has HF Pro.
+- Each consented turn = 1 GitHub Actions minute (workflow runtime ~30s).
+- At 100 turns/day that's ~3000 minutes/month — within free GitHub Actions
+  allotment for personal accounts (2000) plus public-repo concession.
+
+If volume grows past ~500 turns/day, batch the workflow (e.g. trigger every
+N minutes) instead of per-event.
+
+## What never leaves the runtime
+
+- Vercel function logs see a `polly_train_v1 {...}` line per consented turn
+  (private to the project).
+- Workflow logs see only `uploaded to private dataset: {repo}/{path}` —
+  PAYLOAD is read via env var into Python without echoing.
+- The dataset itself is private; only the owner (Issac) and any explicit
+  collaborators can list or download files.
 
 ## Smoke-checking the contract
 
 ```bash
-# Default state should be disabled.
-unset POLLY_TRAIN_DISPATCH_ENABLED
-node -e "process.env.POLLY_TRAIN_DISPATCH_ENABLED='';\
-require('./api/_polly_train_capture').dispatchTrainingTurn({ts:1}).then(r=>console.log(r))"
-# expected: { ok: false, reason: 'disabled' }
+# Disable for the next deploy
+echo "POLLY_TRAIN_DISPATCH_ENABLED=false" | vercel env add POLLY_TRAIN_DISPATCH_ENABLED production
+
+# Re-enable (or unset to use the on-by-default behaviour)
+vercel env rm POLLY_TRAIN_DISPATCH_ENABLED production
+
+# Local: confirm dispatch shape without firing it
+node -e "console.log(require('./api/_polly_train_capture').trainConfig())"
 ```
 
-The vitest contract lives at
-`tests/api/polly_commerce_js.test.ts` — `polly training capture
-(repository_dispatch)` describe block. The "defaults to disabled" case is the
-load-bearing assertion.
+Vitest contract: `tests/api/polly_commerce_js.test.ts` →
+`polly training capture (repository_dispatch)`. The "defaults to enabled" case
+is the load-bearing assertion.

--- a/docs/hire.html
+++ b/docs/hire.html
@@ -550,8 +550,9 @@
         <h2>Talk to Polly</h2>
         <p class="muted">
           Polly is the SCBE assistant. Ask about products, scope a custom build, or get pointed at
-          the right resource. By default conversations are NOT used for training — tick the box
-          below if you want to contribute the conversation to the next release.
+          the right resource. Conversations are routed to a private Hugging Face dataset and used
+          to train the next release — uncheck the box below if you'd rather opt out for this
+          conversation.
         </p>
         <label
           style="
@@ -564,10 +565,10 @@
             cursor: pointer;
           "
         >
-          <input id="pollyConsentToTrain" type="checkbox" />
+          <input id="pollyConsentToTrain" type="checkbox" checked />
           <span
-            >Use this conversation to improve the next Polly release. Avoid sharing personal
-            information either way.</span
+            >Contribute this conversation to the private training dataset. Don't paste secrets,
+            credentials, or anything you wouldn't want a reviewer to see.</span
           >
         </label>
         <div
@@ -602,7 +603,7 @@
           subtitle: 'Direct line to product, custom builds, and the work itself.',
           mode: 'scbe-polly',
           scbeApiBase: window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app',
-          consentToTrain: false,
+          consentToTrain: true,
           sessionId: 'hire-' + Date.now(),
           initialAssistantText:
             'Ask anything: products, custom builds, federal subcontract conversations, or how the 14-layer pipeline works.',

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -331,16 +331,29 @@ describe('polly catalog handler', () => {
 });
 
 describe('polly training capture (repository_dispatch)', () => {
-  it('defaults to disabled when POLLY_TRAIN_DISPATCH_ENABLED is unset (privacy-by-default)', async () => {
-    const originalDisable = process.env.POLLY_TRAIN_DISPATCH_ENABLED;
+  it('defaults to enabled when POLLY_TRAIN_DISPATCH_ENABLED is unset (private destination is wired)', async () => {
+    const original = {
+      enabled: process.env.POLLY_TRAIN_DISPATCH_ENABLED,
+      gh: process.env.GITHUB_TOKEN,
+      gh2: process.env.GH_TOKEN,
+      polly: process.env.POLLY_TRAIN_GITHUB_TOKEN,
+    };
     delete process.env.POLLY_TRAIN_DISPATCH_ENABLED;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    delete process.env.POLLY_TRAIN_GITHUB_TOKEN;
     try {
+      // With env unset and no token, we should hit no_token (proves the
+      // disabled gate did NOT short-circuit — i.e. enabled-by-default).
       const result = await trainCapture.dispatchTrainingTurn({ ts: 1 });
       expect(result.ok).toBe(false);
-      expect(result.reason).toBe('disabled');
+      expect(result.reason).toBe('no_token');
     } finally {
-      if (originalDisable === undefined) delete process.env.POLLY_TRAIN_DISPATCH_ENABLED;
-      else process.env.POLLY_TRAIN_DISPATCH_ENABLED = originalDisable;
+      if (original.enabled === undefined) delete process.env.POLLY_TRAIN_DISPATCH_ENABLED;
+      else process.env.POLLY_TRAIN_DISPATCH_ENABLED = original.enabled;
+      if (original.gh) process.env.GITHUB_TOKEN = original.gh;
+      if (original.gh2) process.env.GH_TOKEN = original.gh2;
+      if (original.polly) process.env.POLLY_TRAIN_GITHUB_TOKEN = original.polly;
     }
   });
 
@@ -354,30 +367,6 @@ describe('polly training capture (repository_dispatch)', () => {
     } finally {
       if (originalDisable === undefined) delete process.env.POLLY_TRAIN_DISPATCH_ENABLED;
       else process.env.POLLY_TRAIN_DISPATCH_ENABLED = originalDisable;
-    }
-  });
-
-  it('returns no_token when enabled but GITHUB_TOKEN absent', async () => {
-    const original = {
-      enabled: process.env.POLLY_TRAIN_DISPATCH_ENABLED,
-      gh: process.env.GITHUB_TOKEN,
-      gh2: process.env.GH_TOKEN,
-      polly: process.env.POLLY_TRAIN_GITHUB_TOKEN,
-    };
-    process.env.POLLY_TRAIN_DISPATCH_ENABLED = 'true';
-    delete process.env.GITHUB_TOKEN;
-    delete process.env.GH_TOKEN;
-    delete process.env.POLLY_TRAIN_GITHUB_TOKEN;
-    try {
-      const result = await trainCapture.dispatchTrainingTurn({ ts: 1, user: 'x', assistant: 'y' });
-      expect(result.ok).toBe(false);
-      expect(result.reason).toBe('no_token');
-    } finally {
-      if (original.enabled === undefined) delete process.env.POLLY_TRAIN_DISPATCH_ENABLED;
-      else process.env.POLLY_TRAIN_DISPATCH_ENABLED = original.enabled;
-      if (original.gh) process.env.GITHUB_TOKEN = original.gh;
-      if (original.gh2) process.env.GH_TOKEN = original.gh2;
-      if (original.polly) process.env.POLLY_TRAIN_GITHUB_TOKEN = original.polly;
     }
   });
 


### PR DESCRIPTION
## Summary
Closes the persistence gap from PR #1492. Capture path is now end-to-end: widget → Vercel Function → GitHub `repository_dispatch` → `polly-training-capture` workflow → `huggingface_hub.upload_file` → **private** dataset `issdandavis/polly-chat-live`.

Defaults flipped back to always-on now that the destination is private:
- Widget consent checkbox ships **checked** (with explicit "private dataset" labelling)
- `POLLY_TRAIN_DISPATCH_ENABLED` defaults to `'true'` (Vercel env-set `'false'` opts out per-deploy)

Each consented turn becomes one file at `polly-chat-live/{YYYY-MM-DD}/{stamp}-{nonce}.json`. PAYLOAD never echoes into workflow logs (read via env var into Python heredoc).

## Files
- `.github/workflows/polly-training-capture.yml` — replace gitignored-no-op git commit with `huggingface_hub.HfApi().upload_file`. Auto-creates dataset as private if missing. Uses `HF_TOKEN` repo secret (already configured 2026-04-06).
- `api/_polly_train_capture.js` — env semantics inverted: default-on instead of default-off
- `docs/hire.html` — checkbox `checked` + label rewritten for clarity
- `tests/api/polly_commerce_js.test.ts` — load-bearing assertion now "defaults to enabled" via no_token return
- `docs/deployment/POLLY_TRAINING_CAPTURE.md` — full rewrite for private-dataset contract

## What the user needs to do post-merge
1. Set on Vercel project `scbe-agent-bridge-vercel` (Settings → Environment Variables):
   - `POLLY_TRAIN_GITHUB_TOKEN` — fine-grained PAT with `Contents: read` and `Metadata: read` on this repo
   - `POLLY_TRAIN_DISPATCH_ENABLED=true` (or leave unset; default is now true)
2. Trigger a Vercel redeploy so HF_TOKEN + new env vars take effect for the LLM router and capture
3. Smoke: send a real chat through the widget on `aethermoore.com/SCBE-AETHERMOORE/hire.html`, then look for the file at https://huggingface.co/datasets/issdandavis/polly-chat-live

## Test plan
- [x] `npx vitest run tests/api/polly_commerce_js.test.ts` → 31/31 green
- [x] HF_TOKEN repo secret confirmed present (`gh secret list | grep HF_TOKEN` → 2026-04-06)
- [ ] Post-merge: trigger one consented turn, verify file lands in private HF dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)