### PR TITLE
fix(vercel): use working Hugging Face chat router

### DIFF
--- a/api/_chat_llm.js
+++ b/api/_chat_llm.js
@@ -6,7 +6,8 @@
 // dependency tree, but cross-function requires like `../agent/chat`
 // from `api/polly/chat.js` are not guaranteed to be hoisted).
 
-const DEFAULT_HF_MODEL = 'Qwen/Qwen2.5-72B-Instruct';
+const DEFAULT_HF_MODEL = 'Qwen/Qwen2.5-7B-Instruct';
+const DEFAULT_HF_CHAT_URL = 'https://router.huggingface.co/v1/chat/completions';
 const DEFAULT_OLLAMA_MODEL = 'llama3.2';
 const DEFAULT_MAX_TOKENS = 512;
 const DEFAULT_TIMEOUT_MS = 25000;
@@ -39,7 +40,7 @@ function chatConfig() {
       '',
     hfUrl:
       process.env.HF_CHAT_URL ||
-      `https://router.huggingface.co/hf-inference/models/${encodeURIComponent(hfModel)}/v1/chat/completions`,
+      DEFAULT_HF_CHAT_URL,
     ollamaUrl: cleanBaseUrl(process.env.OLLAMA_URL || process.env.AGENT_OLLAMA_URL || ''),
     ollamaModel,
     providerOrder: String(process.env.AGENT_CHAT_PROVIDER_ORDER || 'ollama,huggingface,offline')

--- a/api/agent/health.js
+++ b/api/agent/health.js
@@ -31,7 +31,7 @@ module.exports = async function handler(req, res) {
         process.env.HF_TOKEN || process.env.HUGGINGFACE_TOKEN || process.env.HUGGING_FACE_HUB_TOKEN
       ),
       ollama_model: process.env.OLLAMA_MODEL || process.env.AGENT_OLLAMA_MODEL || 'llama3.2',
-      hf_model: process.env.HF_MODEL || process.env.AGENT_HF_MODEL || 'Qwen/Qwen2.5-72B-Instruct',
+      hf_model: process.env.HF_MODEL || process.env.AGENT_HF_MODEL || 'Qwen/Qwen2.5-7B-Instruct',
       cost_policy:
         'prefer local Ollama, then configured Hugging Face, then deterministic offline fallback',
     },

--- a/docs/legal/code-of-conduct.html
+++ b/docs/legal/code-of-conduct.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AetherMoore Code of Conduct</title>
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/legal/code-of-conduct.html" />
+    <style>
+      body { margin: 0; font: 16px/1.6 system-ui, -apple-system, Segoe UI, sans-serif; color: #e7f2ef; background: #071412; }
+      main { width: min(860px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0 72px; }
+      a { color: #6ee7b7; }
+      h1, h2 { line-height: 1.2; }
+      .muted { color: #9fb8b2; }
+      .card { border: 1px solid rgba(110,231,183,.25); background: rgba(255,255,255,.04); border-radius: 12px; padding: 20px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p><a href="../index.html">AetherMoore</a> / Legal</p>
+      <h1>Code of Conduct</h1>
+      <p class="muted">Last updated: May 9, 2026</p>
+      <div class="card">
+        <p>
+          AetherMoore spaces are for practical building, research, testing, and support. Keep collaboration useful,
+          honest, and bounded by safety and consent.
+        </p>
+      </div>
+      <h2>Expected Behavior</h2>
+      <p>
+        Be direct without harassment. Respect privacy. Do not request or share credentials, private keys, or
+        personal data unless an explicit secure workflow requires it.
+      </p>
+      <h2>Unacceptable Behavior</h2>
+      <p>
+        Do not use AetherMoore systems for abuse, credential theft, evasion of platform rules, harassment,
+        doxxing, malware distribution, or unauthorized access.
+      </p>
+      <h2>Reporting</h2>
+      <p>
+        Report concerns to <a href="mailto:ai@aethermoore.com">ai@aethermoore.com</a>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/docs/legal/privacy.html
+++ b/docs/legal/privacy.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AetherMoore Privacy Policy</title>
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/legal/privacy.html" />
+    <style>
+      body { margin: 0; font: 16px/1.6 system-ui, -apple-system, Segoe UI, sans-serif; color: #e7f2ef; background: #071412; }
+      main { width: min(860px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0 72px; }
+      a { color: #6ee7b7; }
+      h1, h2 { line-height: 1.2; }
+      .muted { color: #9fb8b2; }
+      .card { border: 1px solid rgba(110,231,183,.25); background: rgba(255,255,255,.04); border-radius: 12px; padding: 20px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p><a href="../index.html">AetherMoore</a> / Legal</p>
+      <h1>Privacy Policy</h1>
+      <p class="muted">Last updated: May 9, 2026</p>
+      <div class="card">
+        <p>
+          AetherMoore is built around local-first and privacy-by-default operation. Hosted services should collect
+          only what is needed to answer requests, deliver products, protect the service, and improve support.
+        </p>
+      </div>
+      <h2>Data We May Receive</h2>
+      <p>
+        We may receive contact messages, payment metadata from payment processors, support requests, site logs,
+        and text you intentionally send to hosted AI or agent endpoints.
+      </p>
+      <h2>How Data Is Used</h2>
+      <p>
+        Data is used to operate the website, process purchases, provide support, route AI responses, detect abuse,
+        and improve product reliability. Sensitive secrets should not be pasted into public demos or support forms.
+      </p>
+      <h2>Third-Party Services</h2>
+      <p>
+        The site may use services such as Vercel, GitHub Pages, Stripe, Hugging Face, or email providers. Those
+        services process data under their own policies when used.
+      </p>
+      <h2>Contact</h2>
+      <p>
+        Privacy questions can be sent to <a href="mailto:ai@aethermoore.com">ai@aethermoore.com</a>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/docs/legal/terms.html
+++ b/docs/legal/terms.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AetherMoore Terms of Service</title>
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/legal/terms.html" />
+    <style>
+      body { margin: 0; font: 16px/1.6 system-ui, -apple-system, Segoe UI, sans-serif; color: #e7f2ef; background: #071412; }
+      main { width: min(860px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0 72px; }
+      a { color: #6ee7b7; }
+      h1, h2 { line-height: 1.2; }
+      .muted { color: #9fb8b2; }
+      .card { border: 1px solid rgba(110,231,183,.25); background: rgba(255,255,255,.04); border-radius: 12px; padding: 20px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p><a href="../index.html">AetherMoore</a> / Legal</p>
+      <h1>Terms of Service</h1>
+      <p class="muted">Last updated: May 9, 2026</p>
+      <div class="card">
+        <p>
+          These terms cover use of AetherMoore public websites, demos, support pages, and lightweight hosted
+          services. Paid products may include additional written terms, delivery notes, or license agreements.
+        </p>
+      </div>
+      <h2>Use</h2>
+      <p>
+        Use the site and demos lawfully. Do not abuse hosted endpoints, attempt unauthorized access, upload secrets
+        you do not intend to share, or interfere with service operation.
+      </p>
+      <h2>AI Outputs</h2>
+      <p>
+        AI-assisted responses are provided for operational help and experimentation. Verify important technical,
+        legal, financial, safety, or compliance decisions before relying on them.
+      </p>
+      <h2>Payments and Delivery</h2>
+      <p>
+        Stripe or another listed processor may handle payments. Delivery routes and support instructions are shown
+        on the relevant product or supporter page.
+      </p>
+      <h2>Contact</h2>
+      <p>
+        Questions, support requests, or delivery issues can be sent to
+        <a href="mailto:ai@aethermoore.com">ai@aethermoore.com</a>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/docs/ops/LOCAL_FIRST_MODEL_ROUTING.md
+++ b/docs/ops/LOCAL_FIRST_MODEL_ROUTING.md
@@ -19,7 +19,8 @@ AGENT_CHAT_PROVIDER_ORDER=ollama,huggingface,offline
 AGENT_OLLAMA_URL=http://127.0.0.1:11434
 AGENT_OLLAMA_MODEL=llama3.2
 HF_TOKEN=...
-AGENT_HF_MODEL=Qwen/Qwen2.5-72B-Instruct
+AGENT_HF_MODEL=Qwen/Qwen2.5-7B-Instruct
+HF_CHAT_URL=https://router.huggingface.co/v1/chat/completions
 AGENT_CHAT_TIMEOUT_MS=25000
 ```
 

--- a/docs/static/polly-sidebar.js
+++ b/docs/static/polly-sidebar.js
@@ -316,7 +316,7 @@
     }
   }
 
-  var HF_MODEL = "Qwen/Qwen2.5-72B-Instruct";
+  var HF_MODEL = "Qwen/Qwen2.5-7B-Instruct";
   var VERCEL_BASE = window.POLLY_VERCEL_BASE || "https://scbe-agent-bridge-vercel.vercel.app";
   var CHAT_PROXY = VERCEL_BASE + "/api/agent/chat";
   var SEARCH_PROXY = VERCEL_BASE + "/api/agent/search";


### PR DESCRIPTION
## Summary
- Make the Vercel chat bridge default to the working Hugging Face router endpoint.
- Use `Qwen/Qwen2.5-7B-Instruct` as the hosted fallback default instead of the unsupported 72B hf-inference route.
- Add public AetherMoore legal links for Vercel app consent screen fields.

## Live verification
- Production env set: `HF_TOKEN`, `AGENT_HF_MODEL=Qwen/Qwen2.5-7B-Instruct`, `HF_CHAT_URL=https://router.huggingface.co/v1/chat/completions`.
- Live chat smoke returned provider `huggingface` and text `AetherMoore Bus AI is online.`

## Tests
- `python -m pytest tests/test_agent_chat_local_first.py tests/test_vercel_launch_bridge.py tests/system/test_remote_app_config_smoke.py -q` -> 13 passed