### PR TITLE
feat(polly): SMTP email send on lead (Proton / Gmail / Mailgun / any)

### DIFF
--- a/.github/workflows/polly-training-capture.yml
+++ b/.github/workflows/polly-training-capture.yml
@@ -111,3 +111,72 @@ jobs:
             --body "$body" \
             --label "lead" \
             --repo "${{ github.repository }}"
+
+      - name: Email the lead via SMTP (Proton / Gmail / Mailgun / any)
+        if: ${{ github.event.client_payload.record.kind == 'lead' }}
+        env:
+          SMTP_HOST: ${{ secrets.POLLY_LEAD_SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.POLLY_LEAD_SMTP_PORT }}
+          SMTP_USER: ${{ secrets.POLLY_LEAD_SMTP_USER }}
+          SMTP_PASS: ${{ secrets.POLLY_LEAD_SMTP_PASS }}
+          SMTP_FROM: ${{ secrets.POLLY_LEAD_SMTP_FROM }}
+          SMTP_TO: ${{ secrets.POLLY_LEAD_SMTP_TO }}
+          PAYLOAD: ${{ toJSON(github.event.client_payload.record) }}
+        run: |
+          set -euo pipefail
+          # Bail quietly when SMTP isn't configured — the workflow stays green
+          # so the only signal channel is the GitHub issue + HF dataset row.
+          if [[ -z "${SMTP_HOST:-}" || -z "${SMTP_USER:-}" || -z "${SMTP_PASS:-}" ]]; then
+            echo "SMTP credentials missing (POLLY_LEAD_SMTP_HOST/USER/PASS); skipping email send" >&2
+            exit 0
+          fi
+          # Pipe PAYLOAD via env into Python so it never echoes; build the
+          # full lead email server-side then submit via SMTP. starttls is
+          # the default for port 587 (Proton, Gmail, most providers); for
+          # implicit TLS on 465 the script auto-switches.
+          python3 - <<'PY'
+          import os, ssl, json, smtplib
+          from email.message import EmailMessage
+
+          record = json.loads(os.environ["PAYLOAD"])
+          host = os.environ["SMTP_HOST"]
+          port = int(os.environ.get("SMTP_PORT") or "587")
+          user = os.environ["SMTP_USER"]
+          password = os.environ["SMTP_PASS"]
+          sender = os.environ.get("SMTP_FROM") or user
+          recipient = os.environ.get("SMTP_TO") or user
+
+          subject = f"[polly lead] {record.get('project_type','?')} - {record.get('budget','?')} - {record.get('timeline','?')}"
+          body_lines = [
+              "A new lead landed via the /hire form.",
+              "",
+              f"contact:      {record.get('contact','')}",
+              f"project type: {record.get('project_type','')}",
+              f"budget:       {record.get('budget','')}",
+              f"timeline:     {record.get('timeline','')}",
+              f"source:       {record.get('source','')}",
+              "",
+              "description:",
+              record.get("description",""),
+              "",
+              "(also stored in the private HF dataset issdandavis/polly-chat-live under polly-leads/)",
+          ]
+          msg = EmailMessage()
+          msg["Subject"] = subject
+          msg["From"] = sender
+          msg["To"] = recipient
+          msg["Reply-To"] = record.get("contact","") or sender
+          msg.set_content("\n".join(body_lines))
+
+          context = ssl.create_default_context()
+          if port == 465:
+              with smtplib.SMTP_SSL(host, port, context=context, timeout=20) as s:
+                  s.login(user, password)
+                  s.send_message(msg)
+          else:
+              with smtplib.SMTP(host, port, timeout=20) as s:
+                  s.starttls(context=context)
+                  s.login(user, password)
+                  s.send_message(msg)
+          print(f"emailed lead to {recipient}")
+          PY

--- a/docs/deployment/POLLY_LEAD_EMAIL_SMTP.md
+++ b/docs/deployment/POLLY_LEAD_EMAIL_SMTP.md
@@ -1,0 +1,101 @@
+# Polly lead email — SMTP wire-up
+
+The `polly-training-capture` workflow emails leads via plain SMTP when the
+following GitHub repo secrets are set. If any of `POLLY_LEAD_SMTP_HOST` /
+`POLLY_LEAD_SMTP_USER` / `POLLY_LEAD_SMTP_PASS` is missing the email step bails
+quietly and the only signal channels remain the auto-filed GitHub issue + the
+private HF dataset row.
+
+## Required secrets
+
+| Secret | Purpose |
+|---|---|
+| `POLLY_LEAD_SMTP_HOST` | SMTP server hostname |
+| `POLLY_LEAD_SMTP_PORT` | optional, defaults to `587` (STARTTLS); use `465` for implicit TLS |
+| `POLLY_LEAD_SMTP_USER` | SMTP username |
+| `POLLY_LEAD_SMTP_PASS` | SMTP password (or app password) |
+| `POLLY_LEAD_SMTP_FROM` | optional, defaults to `POLLY_LEAD_SMTP_USER` |
+| `POLLY_LEAD_SMTP_TO` | optional, defaults to `POLLY_LEAD_SMTP_USER` |
+
+Set them with `gh secret set POLLY_LEAD_SMTP_HOST` etc., or via the repo
+Settings → Secrets and variables → Actions UI.
+
+## Provider configurations
+
+### Proton Mail (Plus / Pro / Business)
+
+Bridge runs locally and only listens on `127.0.0.1`, so a hosted GitHub
+runner can't reach it. You have two viable paths:
+
+1. **Proton SMTP submission** (cleanest, no local infra):
+   - `POLLY_LEAD_SMTP_HOST = smtp.protonmail.ch`
+   - `POLLY_LEAD_SMTP_PORT = 587`
+   - `POLLY_LEAD_SMTP_USER = your-bridge-issued-username` (find it in
+     Bridge → Mailbox details → SMTP)
+   - `POLLY_LEAD_SMTP_PASS = your-bridge-issued-password`
+   - `POLLY_LEAD_SMTP_FROM = you@protonmail.com`
+   - `POLLY_LEAD_SMTP_TO = wherever-you-want-leads-delivered`
+
+2. **Local Bridge via Cloudflare Tunnel** (uses real Bridge):
+   - Run `cloudflared tunnel --url smtp://127.0.0.1:1025` on the machine that
+     has Bridge installed. Cloudflare Tunnel issues a public hostname.
+   - `POLLY_LEAD_SMTP_HOST = the-tunnel-hostname`
+   - `POLLY_LEAD_SMTP_PORT = 1025` (or whichever Bridge exposes)
+   - The Bridge-issued SMTP user/pass you'd otherwise paste into
+     Thunderbird.
+
+### Gmail (App Passwords)
+
+- Enable 2FA on the Google account.
+- Visit <https://myaccount.google.com/apppasswords> → generate "Mail" → 16-char
+  app password.
+- Settings:
+  - `POLLY_LEAD_SMTP_HOST = smtp.gmail.com`
+  - `POLLY_LEAD_SMTP_PORT = 587`
+  - `POLLY_LEAD_SMTP_USER = you@gmail.com`
+  - `POLLY_LEAD_SMTP_PASS = the-16-char-app-password`
+
+### Mailgun (free tier)
+
+- Sign up, verify a domain.
+- Settings → Domain → SMTP credentials.
+- Settings:
+  - `POLLY_LEAD_SMTP_HOST = smtp.mailgun.org`
+  - `POLLY_LEAD_SMTP_PORT = 587`
+  - `POLLY_LEAD_SMTP_USER = postmaster@yourdomain`
+  - `POLLY_LEAD_SMTP_PASS = the-domain-smtp-password`
+
+### SendGrid (free tier)
+
+- API → SMTP Relay.
+- Settings:
+  - `POLLY_LEAD_SMTP_HOST = smtp.sendgrid.net`
+  - `POLLY_LEAD_SMTP_PORT = 587`
+  - `POLLY_LEAD_SMTP_USER = apikey`
+  - `POLLY_LEAD_SMTP_PASS = your-sendgrid-api-key`
+
+## Email shape
+
+Each lead-triggered email has:
+
+- Subject: `[polly lead] <project_type> - <budget> - <timeline>`
+- Reply-To: the contact field from the lead (so a single reply goes back to
+  the prospect)
+- Body: contact / project / budget / timeline / source / description, plus a
+  pointer to the private HF dataset row
+
+PII is in the email body and the HF dataset only. The companion GitHub issue
+(see `polly-training-capture.yml`) deliberately omits contact + description.
+
+## Smoke test
+
+After setting secrets:
+
+1. Submit a test lead via <https://aethermoore.com/SCBE-AETHERMOORE/hire.html>
+2. Watch the workflow run at
+   <https://github.com/issdandavis/SCBE-AETHERMOORE/actions/workflows/polly-training-capture.yml>
+3. Check the inbox you set as `POLLY_LEAD_SMTP_TO`
+4. If the workflow shows "SMTP credentials missing" — your secrets aren't set
+   yet
+5. If the workflow shows an SMTP error — auth almost always; double-check the
+   provider's app-password vs account-password requirement


### PR DESCRIPTION
## Summary
Adds an opt-in email step to the `polly-training-capture` workflow. Triggers only on records with `kind=lead`. Without `POLLY_LEAD_SMTP_HOST/USER/PASS` set as repo secrets the step bails quietly — the existing GitHub-issue + HF-dataset signal channels keep working.

Implementation uses Python stdlib `smtplib` (no third-party action) so the runner doesn't need to fetch anything extra. STARTTLS on 587 by default, implicit TLS on 465 auto-detected.

## Email shape
- Subject: `[polly lead] <type> - <budget> - <timeline>`
- Reply-To: prospect's contact (so reply routes back directly)
- Body: contact / project type / budget / timeline / source / description + HF dataset pointer

PII goes in the email body and HF dataset only — the companion GitHub issue from the previous workflow step deliberately omits both.

## Provider configurations (covered in `docs/deployment/POLLY_LEAD_EMAIL_SMTP.md`)
- **Proton** (`smtp.protonmail.ch:587` + Bridge-issued credentials, OR Cloudflare Tunnel over local Bridge)
- **Gmail** (`smtp.gmail.com:587` + 16-char App Password)
- **Mailgun**, **SendGrid** — both free-tier compatible

## Test plan
- [x] Workflow YAML validates
- [ ] Set the SMTP secrets, submit a test lead via the form, verify email lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)