### PR TITLE
feat(polly): direct HF upload from Vercel — closes the broken-dispatch gap

### DIFF
--- a/api/_polly_hf_upload.js
+++ b/api/_polly_hf_upload.js
@@ -1,0 +1,149 @@
+'use strict';
+
+// Direct upload to a private Hugging Face dataset from the Vercel runtime.
+// Bypasses the GitHub repository_dispatch round-trip so capture works as
+// long as HF_TOKEN is set on the project — no GitHub PAT required for the
+// data path. The dispatch path remains the signal channel for the
+// issue + email side effects.
+
+const DEFAULT_DATASET = 'issdandavis/polly-chat-live';
+const HF_API_BASE = 'https://huggingface.co/api';
+
+function uploadConfig() {
+  return {
+    token:
+      process.env.HF_TOKEN ||
+      process.env.HUGGINGFACE_TOKEN ||
+      process.env.HUGGING_FACE_HUB_TOKEN ||
+      '',
+    repo: process.env.POLLY_HF_DATASET || DEFAULT_DATASET,
+    enabled:
+      String(process.env.POLLY_HF_UPLOAD_ENABLED || 'true').toLowerCase() !== 'false',
+    timeoutMs: Math.max(2000, Number(process.env.POLLY_HF_UPLOAD_TIMEOUT_MS || 8000)),
+  };
+}
+
+async function fetchWithTimeout(url, init, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function stamp(record) {
+  const tsSeconds =
+    typeof record.ts === 'number' && Number.isFinite(record.ts)
+      ? record.ts
+      : Math.floor(Date.now() / 1000);
+  const date = new Date(tsSeconds * 1000);
+  const day = date.toISOString().slice(0, 10);
+  const compact =
+    date.toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, '').replace('T', 'T');
+  return { day, compact };
+}
+
+function nonceHex(bytes) {
+  const out = new Uint8Array(bytes);
+  if (typeof globalThis.crypto !== 'undefined' && globalThis.crypto.getRandomValues) {
+    globalThis.crypto.getRandomValues(out);
+  } else {
+    for (let i = 0; i < out.length; i += 1) out[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(out, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function pathFor(record) {
+  const kind = String(record.kind || 'chat').toLowerCase();
+  const prefix = kind === 'lead' ? 'polly-leads' : 'polly-chat-live';
+  const { day, compact } = stamp(record);
+  return `${prefix}/${day}/${compact}-${nonceHex(3)}.json`;
+}
+
+async function ensureRepo(cfg) {
+  // Idempotent: returns 200 if exists, 409 if conflict (already exists), or
+  // 201 on create. Anything else is propagated up.
+  const response = await fetchWithTimeout(
+    `${HF_API_BASE}/repos/create`,
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${cfg.token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'scbe-polly-hf-upload',
+      },
+      body: JSON.stringify({
+        type: 'dataset',
+        name: cfg.repo.split('/').slice(-1)[0],
+        organization: cfg.repo.includes('/') ? cfg.repo.split('/')[0] : undefined,
+        private: true,
+      }),
+    },
+    cfg.timeoutMs
+  );
+  if (response.status === 409 || response.ok) return true;
+  const detail = (await response.text()).slice(0, 240);
+  throw new Error(`hf repo create ${response.status}: ${detail}`);
+}
+
+async function commitFile(cfg, pathInRepo, payloadString, summary) {
+  const base64 =
+    typeof Buffer !== 'undefined'
+      ? Buffer.from(payloadString, 'utf-8').toString('base64')
+      : btoa(unescape(encodeURIComponent(payloadString)));
+  // NDJSON commit body — first line is the header, second line is the file.
+  const ndjson =
+    JSON.stringify({ key: 'header', value: { summary } }) +
+    '\n' +
+    JSON.stringify({
+      key: 'file',
+      value: { path: pathInRepo, encoding: 'base64', content: base64 },
+    }) +
+    '\n';
+  const response = await fetchWithTimeout(
+    `${HF_API_BASE}/datasets/${cfg.repo}/commit/main`,
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${cfg.token}`,
+        'Content-Type': 'application/x-ndjson',
+        'User-Agent': 'scbe-polly-hf-upload',
+      },
+      body: ndjson,
+    },
+    cfg.timeoutMs
+  );
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 240);
+    throw new Error(`hf commit ${response.status}: ${detail}`);
+  }
+  return response.json().catch(() => ({ ok: true }));
+}
+
+async function uploadRecord(record) {
+  const cfg = uploadConfig();
+  if (!cfg.enabled) return { ok: false, reason: 'disabled' };
+  if (!cfg.token) return { ok: false, reason: 'no_token' };
+  if (!record || typeof record !== 'object') return { ok: false, reason: 'invalid_record' };
+
+  try {
+    await ensureRepo(cfg);
+    const pathInRepo = pathFor(record);
+    const payload = JSON.stringify(record);
+    const summary = `chore(polly): ${String(record.kind || 'chat')} ${pathInRepo.split('/').slice(-1)[0]}`;
+    const commit = await commitFile(cfg, pathInRepo, payload, summary);
+    return { ok: true, repo: cfg.repo, path: pathInRepo, commit };
+  } catch (error) {
+    return { ok: false, reason: 'fetch_error', detail: String(error.message || error).slice(0, 240) };
+  }
+}
+
+module.exports = {
+  uploadConfig,
+  uploadRecord,
+  pathFor,
+};

--- a/api/polly/chat.js
+++ b/api/polly/chat.js
@@ -12,6 +12,7 @@ const {
 } = require('./commerce');
 const llm = require('../_chat_llm');
 const trainCapture = require('../_polly_train_capture');
+const hfUpload = require('../_polly_hf_upload');
 
 const COMMERCE_INTENTS = new Set(['buy', 'custom', 'membership', 'research']);
 const COMMERCE_CONFIDENCE_FLOOR = 0.6;
@@ -25,7 +26,15 @@ function logTrainingTurn(record) {
   }
 }
 
-function captureIfConsented({ req, message, reply, intent, sessionId, pageContext, provider }) {
+async function captureIfConsented({
+  req,
+  message,
+  reply,
+  intent,
+  sessionId,
+  pageContext,
+  provider,
+}) {
   if (!req || req.consent_to_train !== true) return;
   if (typeof message !== 'string' || !message.trim()) return;
   if (typeof reply !== 'string' || !reply.trim()) return;
@@ -40,8 +49,19 @@ function captureIfConsented({ req, message, reply, intent, sessionId, pageContex
     transport: 'vercel-polly-chat',
   };
   logTrainingTurn(record);
-  // Best-effort durable capture via GitHub repository_dispatch — never throws.
-  trainCapture.dispatchTrainingTurn(record).catch(() => {});
+  // Two parallel best-effort signal channels. Awaited together so the
+  // serverless runtime doesn't kill the function before the HF commit
+  // completes — chat is non-realtime and the extra ~1-2s is acceptable.
+  // Errors from either channel are swallowed (allSettled) so a transient
+  // HF or GitHub blip never poisons the chat response.
+  //   1. Direct HF upload using HF_TOKEN (already on Vercel) — primary
+  //      durable capture, works without any GitHub PAT.
+  //   2. GitHub repository_dispatch — fires the issue + email side
+  //      effects when POLLY_TRAIN_GITHUB_TOKEN is also set.
+  await Promise.allSettled([
+    hfUpload.uploadRecord(record),
+    trainCapture.dispatchTrainingTurn(record),
+  ]);
 }
 
 async function llmFallback(message, history) {
@@ -89,7 +109,7 @@ module.exports = async function handler(req, res) {
       rendered = renderMembershipReply();
     }
 
-    captureIfConsented({
+    await captureIfConsented({
       req: body,
       message,
       reply: rendered.text,
@@ -128,7 +148,7 @@ module.exports = async function handler(req, res) {
   // step. Real LLM responses (provider in ollama|huggingface) pass through.
   if (!llm || llm.provider === 'offline' || llm.provider === 'error') {
     const fallback = renderOfflineRouter(message);
-    captureIfConsented({
+    await captureIfConsented({
       req: body,
       message,
       reply: fallback.text,
@@ -150,7 +170,7 @@ module.exports = async function handler(req, res) {
     });
   }
 
-  captureIfConsented({
+  await captureIfConsented({
     req: body,
     message,
     reply: llm && llm.text,

--- a/api/polly/lead.js
+++ b/api/polly/lead.js
@@ -2,6 +2,7 @@
 
 const { readJsonBody, sendJson, setCors } = require('../_agent_common');
 const trainCapture = require('../_polly_train_capture');
+const hfUpload = require('../_polly_hf_upload');
 
 const PROJECT_TYPES = new Set([
   'audit',
@@ -135,16 +136,19 @@ module.exports = async function handler(req, res) {
 
   logLead(record);
 
-  // Reuse the same dispatch path as chat capture; the workflow uploads to the
-  // PRIVATE dataset issdandavis/polly-chat-live, with leads landing under a
-  // distinct path prefix via the record's `kind` field. Lead submission is
-  // always-on (no consent gate) — the act of submitting the form IS consent
-  // to be contacted.
-  trainCapture
-    .dispatchTrainingTurn(record)
-    .catch(() => {
-      /* never raise into the request path */
-    });
+  // Two parallel best-effort signal channels, awaited together so the
+  // serverless runtime doesn't kill the function before the HF commit
+  // completes. allSettled means a transient HF or GitHub blip never
+  // poisons the lead response.
+  //   1. Direct HF upload using HF_TOKEN — primary durable capture.
+  //      Lead lands at polly-leads/{YYYY-MM-DD}/{stamp}-{nonce}.json in
+  //      the PRIVATE dataset issdandavis/polly-chat-live.
+  //   2. GitHub repository_dispatch — fires the issue + email side
+  //      effects when POLLY_TRAIN_GITHUB_TOKEN is also set on Vercel.
+  await Promise.allSettled([
+    hfUpload.uploadRecord(record),
+    trainCapture.dispatchTrainingTurn(record),
+  ]);
 
   return sendJson(res, 200, {
     ok: true,

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -17,6 +17,8 @@ const catalogHandler = require('../../api/polly/catalog.js');
 const trainCapture = require('../../api/_polly_train_capture.js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const leadHandler = require('../../api/polly/lead.js');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const hfUpload = require('../../api/_polly_hf_upload.js');
 
 interface MockRes {
   statusCode: number;
@@ -398,6 +400,57 @@ describe('polly lead handler', () => {
     const res = makeRes();
     await leadHandler(req, res);
     expect(res.statusCode).toBe(405);
+  });
+});
+
+describe('polly direct HF upload', () => {
+  it('returns no_token when HF_TOKEN is unset', async () => {
+    const original = {
+      hf: process.env.HF_TOKEN,
+      hugging: process.env.HUGGINGFACE_TOKEN,
+      hub: process.env.HUGGING_FACE_HUB_TOKEN,
+    };
+    delete process.env.HF_TOKEN;
+    delete process.env.HUGGINGFACE_TOKEN;
+    delete process.env.HUGGING_FACE_HUB_TOKEN;
+    try {
+      const result = await hfUpload.uploadRecord({ ts: 1, kind: 'chat', user: 'x', assistant: 'y' });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('no_token');
+    } finally {
+      if (original.hf) process.env.HF_TOKEN = original.hf;
+      if (original.hugging) process.env.HUGGINGFACE_TOKEN = original.hugging;
+      if (original.hub) process.env.HUGGING_FACE_HUB_TOKEN = original.hub;
+    }
+  });
+
+  it('returns disabled when POLLY_HF_UPLOAD_ENABLED=false', async () => {
+    const originalEnabled = process.env.POLLY_HF_UPLOAD_ENABLED;
+    const originalToken = process.env.HF_TOKEN;
+    process.env.POLLY_HF_UPLOAD_ENABLED = 'false';
+    process.env.HF_TOKEN = 'test-token';
+    try {
+      const result = await hfUpload.uploadRecord({ ts: 1 });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('disabled');
+    } finally {
+      if (originalEnabled === undefined) delete process.env.POLLY_HF_UPLOAD_ENABLED;
+      else process.env.POLLY_HF_UPLOAD_ENABLED = originalEnabled;
+      if (originalToken === undefined) delete process.env.HF_TOKEN;
+      else process.env.HF_TOKEN = originalToken;
+    }
+  });
+
+  it('routes leads under polly-leads/ and chats under polly-chat-live/', () => {
+    const leadPath = hfUpload.pathFor({ kind: 'lead', ts: 1715200000 });
+    const chatPath = hfUpload.pathFor({ kind: 'chat', ts: 1715200000 });
+    expect(leadPath.startsWith('polly-leads/')).toBe(true);
+    expect(chatPath.startsWith('polly-chat-live/')).toBe(true);
+  });
+
+  it('falls back to chat path when kind is missing', () => {
+    const path = hfUpload.pathFor({ ts: 1715200000 });
+    expect(path.startsWith('polly-chat-live/')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
The `polly-training-capture` workflow had zero runs in its history because `POLLY_TRAIN_GITHUB_TOKEN` isn't set on Vercel — every consented chat turn and every lead form submission was silently lost.

This adds direct HF dataset upload from the Vercel runtime using `HF_TOKEN` (which IS set on Vercel as of 2026-05-09 21:30). No GitHub PAT round-trip required for the data path.

Both chat.js and lead.js now fire two parallel signal channels, awaited together via `Promise.allSettled`:
1. **Direct HF upload** — primary durable capture, works today
2. **GitHub repository_dispatch** — fires the issue + email side effects when the GitHub PAT is also wired

Either channel can fail without poisoning the response.

## Implementation
- `api/_polly_hf_upload.js` — NEW. Hand-rolled fetch against the HF NDJSON commit endpoint. No new npm deps. Idempotent `repos/create` (private), base64-encoded single-file commit. Configurable timeout (`POLLY_HF_UPLOAD_TIMEOUT_MS`), per-deploy kill switch (`POLLY_HF_UPLOAD_ENABLED=false`), routes leads under `polly-leads/{YYYY-MM-DD}/` and chat turns under `polly-chat-live/{YYYY-MM-DD}/` via `record.kind`.
- `api/polly/chat.js`, `api/polly/lead.js` — both now `await Promise.allSettled([hfUpload, dispatch])`.
- `tests/api/polly_commerce_js.test.ts` — 4 new HF upload cases. 43/43 green.

## Live verification before merge
Local node smoke against the real HF API committed a record at:
- `polly-chat-live/2026-05-09/20260509T215756-748b72.json`
- commitOid `133f6662573785d2724976f726c48eceea25c268`
- visible at https://huggingface.co/datasets/issdandavis/polly-chat-live

Proves the API call shape is correct before the Vercel deploy.

## What this means
After this PR merges and Vercel redeploys:
- Every consented chat turn → JSON file in private HF dataset
- Every lead → JSON file in private HF dataset (under polly-leads/)
- No further user action required for the data path
- (The GitHub-issue + SMTP email side effects still need `POLLY_TRAIN_GITHUB_TOKEN` on Vercel + `POLLY_LEAD_SMTP_*` repo secrets, but those are now optional improvements not load-bearing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)