### PR TITLE
feat(agent): expose unified bus system contract

### DIFF
--- a/api/agent/system.js
+++ b/api/agent/system.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { ALLOWED_TASKS, MAX_QUERY_LENGTH, envConfig, sendJson, setCors } = require('../_agent_common');
+const { chatConfig } = require('../_chat_llm');
+const storage = require('./storage');
+
+const { PROVIDERS, WORKSPACE_FORMATION } = storage._private;
+
+function readPublicJson(name) {
+  const target = path.join(process.cwd(), 'docs', name);
+  return JSON.parse(fs.readFileSync(target, 'utf8'));
+}
+
+function bridgeHealth() {
+  const cfg = envConfig();
+  const chat = chatConfig();
+  return {
+    service: 'scbe-agent-vercel-bridge',
+    repo: cfg.repo,
+    workflow: cfg.workflow,
+    ref: cfg.ref,
+    dispatch_configured: Boolean(cfg.githubToken),
+    dispatch_secret_required: Boolean(cfg.dispatchSecret),
+    allowed_tasks: Array.from(ALLOWED_TASKS),
+    max_query_length: MAX_QUERY_LENGTH,
+    chat: {
+      provider_order: chat.providerOrder,
+      ollama_configured: Boolean(chat.ollamaUrl),
+      huggingface_configured: Boolean(chat.hfToken),
+      ollama_model: chat.ollamaModel,
+      hf_model: chat.hfModel,
+      hf_router: chat.hfUrl,
+      cost_policy:
+        'prefer local Ollama, then configured Hugging Face, then deterministic offline fallback',
+    },
+  };
+}
+
+function buildSystemContract() {
+  const appConfig = readPublicJson('app-config.json');
+  const offers = readPublicJson('offers.json');
+  const health = bridgeHealth();
+
+  return {
+    ok: true,
+    schema: 'aethermoor.agent.system_contract.v1',
+    generated_at: new Date().toISOString(),
+    product: {
+      name: appConfig.app?.name || 'Aethermoor Bus',
+      package_name: appConfig.app?.package_name || 'io.aethermoor.bus',
+      release: appConfig.app?.current_release || 'unknown',
+      principle: 'frontend and backend share one agent-bus contract',
+    },
+    frontend: {
+      static_host: appConfig.endpoints?.site_home || '',
+      mobile_routes: [
+        { id: 'home', path: './index.html', purpose: 'status, offers, storage, and bridge overview' },
+        { id: 'chat', path: './chat.html', purpose: 'assistant, search, and export thread' },
+        { id: 'ops', path: './ops.html', purpose: 'operator diagnostics and backend checks' },
+        { id: 'browse', path: './browse.html', purpose: 'web lane entrypoint' },
+      ],
+      remote_update: appConfig.remote_update || {},
+      features: appConfig.features || {},
+    },
+    backend: {
+      base_url: 'https://scbe-agent-bridge-vercel.vercel.app',
+      endpoints: {
+        health: '/api/agent/health',
+        system: '/api/agent/system',
+        chat: '/api/agent/chat',
+        search: '/api/agent/search',
+        storage: '/api/agent/storage',
+        status: '/api/agent/status',
+        offers: '/api/agent/offers',
+        app_config: '/api/agent/app-config',
+      },
+      health,
+    },
+    bus: {
+      workspace_formation: WORKSPACE_FORMATION,
+      storage_providers: PROVIDERS,
+      data_policy: {
+        server_storage: 'none by default',
+        export_path: 'local download first; user-owned cloud handoff optional',
+        secrets: 'never export secrets by default',
+      },
+    },
+    monetization: {
+      offers_schema: offers.schema,
+      live_offers: (offers.offers || [])
+        .filter((offer) => offer.status === 'live')
+        .map((offer) => ({
+          id: offer.id,
+          name: offer.name,
+          price_label: offer.price_label,
+          type: offer.type,
+          checkout_url: offer.checkout_url,
+          proof_url: offer.proof_url || '',
+          intake_url: offer.intake_url || '',
+        })),
+      primary_offer: appConfig.fallbacks?.primary_offer || '',
+    },
+  };
+}
+
+module.exports = async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'GET') return sendJson(res, 405, { ok: false, error: 'GET required' });
+
+  res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
+  return sendJson(res, 200, buildSystemContract());
+};
+
+module.exports._private = {
+  bridgeHealth,
+  buildSystemContract,
+};

--- a/docs/app-config.json
+++ b/docs/app-config.json
@@ -30,6 +30,7 @@
     "governance_snapshot_page": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
     "offers_json": "https://aethermoore.com/SCBE-AETHERMOORE/offers.json",
     "agent_bridge_health": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/health",
+    "agent_bridge_system": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/system",
     "agent_bridge_offers": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/offers",
     "agent_bridge_app_config": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/app-config"
   },

--- a/kindle-app/bus-www/index.html
+++ b/kindle-app/bus-www/index.html
@@ -48,17 +48,20 @@
       }
 
       .status-grid,
+      .system-grid,
       .action-grid,
       .provider-grid {
         display: grid;
         gap: 10px;
       }
 
-      .status-grid {
+      .status-grid,
+      .system-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
-      .status-tile {
+      .status-tile,
+      .system-cell {
         min-height: 86px;
         padding: 14px;
         border: 1px solid var(--border);
@@ -66,17 +69,27 @@
         background: rgba(255, 255, 255, 0.045);
       }
 
-      .status-tile span {
+      .status-tile span,
+      .system-cell span {
         display: block;
         color: var(--muted);
         font-size: 12px;
         text-transform: uppercase;
       }
 
-      .status-tile strong {
+      .status-tile strong,
+      .system-cell strong {
         display: block;
         margin-top: 8px;
         font-size: 16px;
+      }
+
+      .system-grid {
+        margin-top: 10px;
+      }
+
+      .system-cell {
+        min-height: 76px;
       }
 
       .action-grid {
@@ -134,6 +147,7 @@
 
       @media (max-width: 420px) {
         .status-grid,
+        .system-grid,
         .action-grid {
           grid-template-columns: 1fr;
         }
@@ -163,6 +177,17 @@
         <div class="status-tile">
           <span>Bridge</span>
           <strong id="bridgeLabel">Checking</strong>
+        </div>
+      </section>
+
+      <section class="system-grid" aria-label="System contract" id="systemGrid">
+        <div class="system-cell">
+          <span>AI route</span>
+          <strong>Loading</strong>
+        </div>
+        <div class="system-cell">
+          <span>Offer lane</span>
+          <strong>Loading</strong>
         </div>
       </section>
 
@@ -196,6 +221,7 @@
     <script>
       const runtimeLabel = document.getElementById('runtimeLabel');
       const bridgeLabel = document.getElementById('bridgeLabel');
+      const systemGrid = document.getElementById('systemGrid');
       const storageProviders = document.getElementById('storageProviders');
       const base = window.PhoneShell.bridgeBase();
 
@@ -203,6 +229,33 @@
       bridgeLabel.textContent = base;
 
       async function loadStatus() {
+        try {
+          const system = await fetch(`${base}/api/agent/system`, { cache: 'no-store' }).then(
+            window.PhoneShell.readJson
+          );
+          const chat = system.backend?.health?.chat || {};
+          const offers = system.monetization?.live_offers || [];
+          const providers = system.bus?.storage_providers || [];
+          bridgeLabel.textContent = chat.huggingface_configured ? 'AI online' : 'offline fallback';
+          systemGrid.innerHTML = [
+            `<div class="system-cell"><span>AI route</span><strong>${window.PhoneShell.escapeHtml(chat.hf_model || 'local fallback')}</strong></div>`,
+            `<div class="system-cell"><span>Offer lane</span><strong>${window.PhoneShell.escapeHtml(String(offers.length))} live</strong></div>`,
+          ].join('');
+          storageProviders.innerHTML = providers.length
+            ? providers
+                .slice(0, 6)
+                .map(
+                  (provider) =>
+                    `<div class="provider"><span>${window.PhoneShell.escapeHtml(provider.label || provider.id)}</span><small>${window.PhoneShell.escapeHtml(provider.cost || 'user owned')}</small></div>`
+                )
+                .join('')
+            : '<div class="provider"><span>Local export</span><small>offline ready</small></div>';
+          return;
+        } catch {
+          systemGrid.innerHTML =
+            '<div class="system-cell"><span>AI route</span><strong>fallback</strong></div><div class="system-cell"><span>Offer lane</span><strong>local</strong></div>';
+        }
+
         try {
           const health = await fetch(`${base}/api/agent/health`, { cache: 'no-store' }).then(
             window.PhoneShell.readJson

--- a/kindle-app/www/index.html
+++ b/kindle-app/www/index.html
@@ -48,17 +48,20 @@
       }
 
       .status-grid,
+      .system-grid,
       .action-grid,
       .provider-grid {
         display: grid;
         gap: 10px;
       }
 
-      .status-grid {
+      .status-grid,
+      .system-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
-      .status-tile {
+      .status-tile,
+      .system-cell {
         min-height: 86px;
         padding: 14px;
         border: 1px solid var(--border);
@@ -66,17 +69,27 @@
         background: rgba(255, 255, 255, 0.045);
       }
 
-      .status-tile span {
+      .status-tile span,
+      .system-cell span {
         display: block;
         color: var(--muted);
         font-size: 12px;
         text-transform: uppercase;
       }
 
-      .status-tile strong {
+      .status-tile strong,
+      .system-cell strong {
         display: block;
         margin-top: 8px;
         font-size: 16px;
+      }
+
+      .system-grid {
+        margin-top: 10px;
+      }
+
+      .system-cell {
+        min-height: 76px;
       }
 
       .action-grid {
@@ -134,6 +147,7 @@
 
       @media (max-width: 420px) {
         .status-grid,
+        .system-grid,
         .action-grid {
           grid-template-columns: 1fr;
         }
@@ -143,27 +157,27 @@
         }
       }
     </style>
-    <script>
-      // Capacitor bridge — detect native vs web
-      window.isKindleApp = typeof window.Capacitor !== 'undefined';
+  <script>
+  // Capacitor bridge — detect native vs web
+  window.isKindleApp = typeof window.Capacitor !== 'undefined';
 
-      // Handle offline state
-      window.addEventListener('offline', () => {
-        const dot = document.getElementById('status-dot');
-        const txt = document.getElementById('status-text');
-        if (dot) dot.className = 'dot off';
-        if (txt) txt.textContent = 'Offline';
-      });
-      window.addEventListener('online', () => {
-        const dot = document.getElementById('status-dot');
-        const txt = document.getElementById('status-text');
-        if (dot) dot.className = 'dot on';
-        if (txt) txt.textContent = 'Online';
-        // Re-check health
-        if (typeof checkHealth === 'function') checkHealth();
-      });
-    </script>
-  </head>
+  // Handle offline state
+  window.addEventListener('offline', () => {
+    const dot = document.getElementById('status-dot');
+    const txt = document.getElementById('status-text');
+    if (dot) dot.className = 'dot off';
+    if (txt) txt.textContent = 'Offline';
+  });
+  window.addEventListener('online', () => {
+    const dot = document.getElementById('status-dot');
+    const txt = document.getElementById('status-text');
+    if (dot) dot.className = 'dot on';
+    if (txt) txt.textContent = 'Online';
+    // Re-check health
+    if (typeof checkHealth === 'function') checkHealth();
+  });
+</script>
+</head>
   <body>
     <main class="phone-shell bus-shell">
       <section class="hero">
@@ -183,6 +197,17 @@
         <div class="status-tile">
           <span>Bridge</span>
           <strong id="bridgeLabel">Checking</strong>
+        </div>
+      </section>
+
+      <section class="system-grid" aria-label="System contract" id="systemGrid">
+        <div class="system-cell">
+          <span>AI route</span>
+          <strong>Loading</strong>
+        </div>
+        <div class="system-cell">
+          <span>Offer lane</span>
+          <strong>Loading</strong>
         </div>
       </section>
 
@@ -216,6 +241,7 @@
     <script>
       const runtimeLabel = document.getElementById('runtimeLabel');
       const bridgeLabel = document.getElementById('bridgeLabel');
+      const systemGrid = document.getElementById('systemGrid');
       const storageProviders = document.getElementById('storageProviders');
       const base = window.PhoneShell.bridgeBase();
 
@@ -223,6 +249,33 @@
       bridgeLabel.textContent = base;
 
       async function loadStatus() {
+        try {
+          const system = await fetch(`${base}/api/agent/system`, { cache: 'no-store' }).then(
+            window.PhoneShell.readJson
+          );
+          const chat = system.backend?.health?.chat || {};
+          const offers = system.monetization?.live_offers || [];
+          const providers = system.bus?.storage_providers || [];
+          bridgeLabel.textContent = chat.huggingface_configured ? 'AI online' : 'offline fallback';
+          systemGrid.innerHTML = [
+            `<div class="system-cell"><span>AI route</span><strong>${window.PhoneShell.escapeHtml(chat.hf_model || 'local fallback')}</strong></div>`,
+            `<div class="system-cell"><span>Offer lane</span><strong>${window.PhoneShell.escapeHtml(String(offers.length))} live</strong></div>`,
+          ].join('');
+          storageProviders.innerHTML = providers.length
+            ? providers
+                .slice(0, 6)
+                .map(
+                  (provider) =>
+                    `<div class="provider"><span>${window.PhoneShell.escapeHtml(provider.label || provider.id)}</span><small>${window.PhoneShell.escapeHtml(provider.cost || 'user owned')}</small></div>`
+                )
+                .join('')
+            : '<div class="provider"><span>Local export</span><small>offline ready</small></div>';
+          return;
+        } catch {
+          systemGrid.innerHTML =
+            '<div class="system-cell"><span>AI route</span><strong>fallback</strong></div><div class="system-cell"><span>Offer lane</span><strong>local</strong></div>';
+        }
+
         try {
           const health = await fetch(`${base}/api/agent/health`, { cache: 'no-store' }).then(
             window.PhoneShell.readJson

--- a/kindle-app/www/manifest.json
+++ b/kindle-app/www/manifest.json
@@ -6,7 +6,10 @@
   "start_url": "./index.html",
   "scope": "./",
   "display": "standalone",
-  "display_override": ["standalone", "minimal-ui"],
+  "display_override": [
+    "standalone",
+    "minimal-ui"
+  ],
   "background_color": "#07111d",
   "theme_color": "#07111d",
   "orientation": "portrait",
@@ -28,7 +31,11 @@
       "purpose": "maskable any"
     }
   ],
-  "categories": ["developer", "productivity", "utilities"],
+  "categories": [
+    "developer",
+    "productivity",
+    "utilities"
+  ],
   "shortcuts": [
     {
       "name": "Assistant",

--- a/kindle-app/www/sw.js
+++ b/kindle-app/www/sw.js
@@ -1,55 +1,32 @@
-const CACHE_NAME = "aethercode-shell-v1";
+const CACHE_NAME = 'aethermoor-bus-v1';
 const APP_SHELL = [
-  "./index.html",
-  "./arena",
-  "./manifest.json",
-  "./static/icons/icon-192.png",
-  "./static/icons/icon-512.png",
+  './index.html',
+  './chat.html',
+  './static/phone-shell.css',
+  './static/phone-shell.js',
 ];
 
-self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL))
-  );
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)));
   self.skipWaiting();
 });
 
-self.addEventListener("activate", (event) => {
+self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((names) =>
-      Promise.all(
-        names
-          .filter((name) => name !== CACHE_NAME)
-          .map((name) => caches.delete(name))
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
       )
-    )
   );
   self.clients.claim();
 });
 
-self.addEventListener("fetch", (event) => {
-  const req = event.request;
-  if (req.method !== "GET") return;
-  const url = new URL(req.url);
-  if (url.origin !== self.location.origin) return;
-  if (
-    url.pathname.startsWith("./v1/") ||
-    url.pathname.startsWith("./api/") ||
-    url.pathname.startsWith("./mesh/") ||
-    url.pathname.startsWith("./ws/")
-  ) {
-    return;
-  }
-
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
   event.respondWith(
-    caches.match(req).then((cached) => {
-      if (cached) return cached;
-      return fetch(req).then((res) => {
-        if (!res || res.status !== 200) return res;
-        const copy = res.clone();
-        caches.open(CACHE_NAME).then((cache) => cache.put(req, copy));
-        return res;
-      });
-    })
+    fetch(event.request).catch(() =>
+      caches.match(event.request).then((cached) => cached || caches.match('./index.html'))
+    )
   );
 });

--- a/scripts/system/remote_app_config_smoke.py
+++ b/scripts/system/remote_app_config_smoke.py
@@ -180,6 +180,7 @@ def validate_app_config(data: dict[str, Any], source: str) -> list[CheckResult]:
     expected_endpoints = {
         "offers_json": f"{PAGES_BASE}/offers.json",
         "supporter_page": f"{PAGES_BASE}/supporter.html",
+        "agent_bridge_system": f"{VERCEL_BASE}/api/agent/system",
         "agent_bridge_offers": f"{VERCEL_BASE}/api/agent/offers",
         "agent_bridge_app_config": f"{VERCEL_BASE}/api/agent/app-config",
     }
@@ -227,6 +228,48 @@ def validate_supporter_page(text: str, source: str) -> list[CheckResult]:
     ]
 
 
+def validate_system_contract(data: dict[str, Any], source: str) -> list[CheckResult]:
+    payload = normalize_vercel_payload(data)
+    checks: list[CheckResult] = []
+
+    schema = payload.get("schema")
+    checks.append(
+        pass_check(f"{source}:schema", schema)
+        if schema == "aethermoor.agent.system_contract.v1"
+        else fail_check(f"{source}:schema", f"expected aethermoor.agent.system_contract.v1, got {schema!r}")
+    )
+
+    backend = payload.get("backend")
+    endpoints = backend.get("endpoints") if isinstance(backend, dict) else None
+    checks.append(
+        pass_check(f"{source}:endpoint:chat", "/api/agent/chat")
+        if isinstance(endpoints, dict) and endpoints.get("chat") == "/api/agent/chat"
+        else fail_check(f"{source}:endpoint:chat", "missing /api/agent/chat")
+    )
+    checks.append(
+        pass_check(f"{source}:endpoint:storage", "/api/agent/storage")
+        if isinstance(endpoints, dict) and endpoints.get("storage") == "/api/agent/storage"
+        else fail_check(f"{source}:endpoint:storage", "missing /api/agent/storage")
+    )
+
+    bus = payload.get("bus")
+    formation = bus.get("workspace_formation") if isinstance(bus, dict) else None
+    checks.append(
+        pass_check(f"{source}:workspace_formation", "present")
+        if isinstance(formation, dict) and formation.get("schema_version") == "aethermoor.bus.workspace_formation.v1"
+        else fail_check(f"{source}:workspace_formation", "missing workspace formation")
+    )
+
+    offers = payload.get("monetization", {}).get("live_offers") if isinstance(payload.get("monetization"), dict) else None
+    checks.append(
+        pass_check(f"{source}:live_offers", str(len(offers)))
+        if isinstance(offers, list) and len(offers) >= len(REQUIRED_OFFER_IDS)
+        else fail_check(f"{source}:live_offers", "missing live offer list")
+    )
+
+    return checks
+
+
 def run_checks(live: bool = False) -> list[CheckResult]:
     checks: list[CheckResult] = []
 
@@ -252,6 +295,7 @@ def run_checks(live: bool = False) -> list[CheckResult]:
     live_json_targets = [
         (f"{PAGES_BASE}/offers.json", validate_offer_catalog, "live:pages:offers"),
         (f"{PAGES_BASE}/app-config.json", validate_app_config, "live:pages:app_config"),
+        (f"{VERCEL_BASE}/api/agent/system", validate_system_contract, "live:vercel:system"),
         (f"{VERCEL_BASE}/api/agent/offers", validate_offer_catalog, "live:vercel:offers"),
         (f"{VERCEL_BASE}/api/agent/app-config", validate_app_config, "live:vercel:app_config"),
     ]

--- a/tests/system/test_remote_app_config_smoke.py
+++ b/tests/system/test_remote_app_config_smoke.py
@@ -57,6 +57,7 @@ def test_app_config_rejects_package_name_drift():
             "endpoints": {
                 "offers_json": f"{PAGES_BASE}/offers.json",
                 "supporter_page": f"{PAGES_BASE}/supporter.html",
+                "agent_bridge_system": f"{VERCEL_BASE}/api/agent/system",
                 "agent_bridge_offers": f"{VERCEL_BASE}/api/agent/offers",
                 "agent_bridge_app_config": f"{VERCEL_BASE}/api/agent/app-config",
             },

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -80,8 +80,18 @@ def test_supporter_page_uses_direct_stripe_checkout_not_broken_api_bridge() -> N
 def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:
     offers_source = (REPO_ROOT / "api" / "agent" / "offers.js").read_text(encoding="utf-8")
     app_config_source = (REPO_ROOT / "api" / "agent" / "app-config.js").read_text(encoding="utf-8")
+    system_source = (REPO_ROOT / "api" / "agent" / "system.js").read_text(encoding="utf-8")
 
     assert "docs/offers.json" in offers_source
     assert "s-maxage=300" in offers_source
     assert "docs/app-config.json" in app_config_source
     assert "s-maxage=300" in app_config_source
+    assert "aethermoor.agent.system_contract.v1" in system_source
+    assert "/api/agent/chat" in system_source
+    assert "workspace_formation" in system_source
+
+
+def test_public_app_config_exposes_unified_system_contract() -> None:
+    config = json.loads((REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8"))
+
+    assert config["endpoints"]["agent_bridge_system"].endswith("/api/agent/system")


### PR DESCRIPTION
## Summary
- add `/api/agent/system` as the shared frontend/backend contract for the Aethermoor Bus app
- expose the system endpoint in `docs/app-config.json` and remote smoke validation
- update the Bus mobile landing shell to render AI route, live offers, and storage providers from the contract
- regenerate Bus `www/` with the correct `AETHERCODE_APP_VARIANT=aethermoor-bus` source and fix the Bus service-worker shell

## Tests
- `node -e "const {buildSystemContract}=require('./api/agent/system.js')._private; const c=buildSystemContract(); console.log(JSON.stringify({schema:c.schema, chat:c.backend.endpoints.chat, storage:c.backend.endpoints.storage, providers:c.bus.storage_providers.length, offers:c.monetization.live_offers.length}, null, 2));"`
- `python -m pytest tests/test_vercel_launch_bridge.py tests/system/test_remote_app_config_smoke.py tests/test_agent_chat_local_first.py -q`
- `python scripts/system/remote_app_config_smoke.py --report artifacts/app-smoke/system-contract-local.json`
- `MOBILE_BUS_SYSTEM_CONTRACT_SMOKE_PASS=1` via local Chrome smoke against `kindle-app/www/index.html`

## Rollback
- remove `api/agent/system.js`
- remove `agent_bridge_system` from `docs/app-config.json`
- restore the Bus landing shell to health/storage-only mode