### PR TITLE
feat(polly): anti-abuse — per-IP rate limit + lead-form honeypot

### DIFF
--- a/api/_polly_rate_limit.js
+++ b/api/_polly_rate_limit.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// Per-IP sliding-window rate limiter. In-memory per Vercel function instance,
+// so it does not share state across cold starts or instances — a determined
+// attacker hitting different invocations can bypass it. The point is not
+// fortress-grade abuse prevention, just a defense against single-IP burst
+// floods that would otherwise drain Vercel function invocations, HF commits,
+// GitHub workflow runs, and (when wired) outbound email.
+//
+// For real-grade protection, swap the in-memory Map for Vercel KV or Upstash
+// Redis and key on user_id where available.
+
+const buckets = new Map();
+
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULTS = {
+  chat: { limit: 30, windowMs: DEFAULT_WINDOW_MS },
+  lead: { limit: 5, windowMs: DEFAULT_WINDOW_MS },
+  feedback: { limit: 60, windowMs: DEFAULT_WINDOW_MS },
+};
+
+function clientIp(req) {
+  const forwarded = req && req.headers && req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0].trim();
+  }
+  const real = req && req.headers && req.headers['x-real-ip'];
+  if (typeof real === 'string' && real.length > 0) return real.trim();
+  return 'unknown';
+}
+
+function envLimit(name, fallback) {
+  const upper = name.toUpperCase();
+  const limit = Number(process.env[`POLLY_RATE_LIMIT_${upper}`] || fallback.limit);
+  const windowMs = Number(
+    process.env[`POLLY_RATE_LIMIT_${upper}_WINDOW_MS`] || fallback.windowMs
+  );
+  return {
+    limit: Number.isFinite(limit) && limit > 0 ? limit : fallback.limit,
+    windowMs: Number.isFinite(windowMs) && windowMs > 0 ? windowMs : fallback.windowMs,
+  };
+}
+
+function check({ name, ip, now }) {
+  const fallback = DEFAULTS[name] || DEFAULTS.chat;
+  const cfg = envLimit(name, fallback);
+  const key = `${name}:${ip}`;
+  const horizon = now - cfg.windowMs;
+  const existing = buckets.get(key) || [];
+  // Drop timestamps that fell out of the window.
+  const recent = existing.filter((t) => t >= horizon);
+  if (recent.length >= cfg.limit) {
+    const oldest = recent[0];
+    const retryAfterMs = Math.max(0, oldest + cfg.windowMs - now);
+    return {
+      allowed: false,
+      remaining: 0,
+      limit: cfg.limit,
+      windowMs: cfg.windowMs,
+      retryAfterMs,
+    };
+  }
+  recent.push(now);
+  buckets.set(key, recent);
+  // Best-effort GC: evict buckets with no recent activity to bound memory.
+  if (buckets.size > 5000) {
+    for (const [k, ts] of buckets) {
+      if (!ts.length || ts[ts.length - 1] < horizon) buckets.delete(k);
+    }
+  }
+  return {
+    allowed: true,
+    remaining: cfg.limit - recent.length,
+    limit: cfg.limit,
+    windowMs: cfg.windowMs,
+    retryAfterMs: 0,
+  };
+}
+
+function enforce(req, res, name) {
+  const ip = clientIp(req);
+  const result = check({ name, ip, now: Date.now() });
+  res.setHeader('X-RateLimit-Limit', String(result.limit));
+  res.setHeader('X-RateLimit-Remaining', String(Math.max(0, result.remaining)));
+  if (!result.allowed) {
+    res.setHeader('Retry-After', String(Math.ceil(result.retryAfterMs / 1000)));
+  }
+  return result;
+}
+
+function reset() {
+  buckets.clear();
+}
+
+module.exports = {
+  enforce,
+  check,
+  clientIp,
+  reset,
+  _buckets: buckets,
+  DEFAULTS,
+};

--- a/api/polly/chat.js
+++ b/api/polly/chat.js
@@ -12,6 +12,7 @@ const {
 } = require('./commerce');
 const llm = require('../_chat_llm');
 const hfUpload = require('../_polly_hf_upload');
+const rateLimit = require('../_polly_rate_limit');
 
 const COMMERCE_INTENTS = new Set(['buy', 'custom', 'membership', 'research']);
 const COMMERCE_CONFIDENCE_FLOOR = 0.6;
@@ -68,6 +69,15 @@ module.exports = async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(204).end();
   if (req.method !== 'POST') {
     return sendJson(res, 405, { ok: false, error: 'POST only' });
+  }
+
+  const rl = rateLimit.enforce(req, res, 'chat');
+  if (!rl.allowed) {
+    return sendJson(res, 429, {
+      ok: false,
+      error: 'rate limit exceeded',
+      retry_after_ms: rl.retryAfterMs,
+    });
   }
 
   let body;

--- a/api/polly/feedback.js
+++ b/api/polly/feedback.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { readJsonBody, sendJson, setCors } = require('../_agent_common');
+const rateLimit = require('../_polly_rate_limit');
 
 const VALID_RATINGS = new Set(['up', 'down']);
 const FEEDBACK_LOG_PREFIX = 'polly_feedback_v1 ';
@@ -18,6 +19,15 @@ module.exports = async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(204).end();
   if (req.method !== 'POST') {
     return sendJson(res, 405, { ok: false, error: 'POST only' });
+  }
+
+  const rl = rateLimit.enforce(req, res, 'feedback');
+  if (!rl.allowed) {
+    return sendJson(res, 429, {
+      ok: false,
+      error: 'rate limit exceeded',
+      retry_after_ms: rl.retryAfterMs,
+    });
   }
 
   let body;

--- a/api/polly/lead.js
+++ b/api/polly/lead.js
@@ -3,6 +3,7 @@
 const { readJsonBody, sendJson, setCors } = require('../_agent_common');
 const trainCapture = require('../_polly_train_capture');
 const hfUpload = require('../_polly_hf_upload');
+const rateLimit = require('../_polly_rate_limit');
 
 const PROJECT_TYPES = new Set([
   'audit',
@@ -108,6 +109,15 @@ module.exports = async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(204).end();
   if (req.method !== 'POST') return sendJson(res, 405, { ok: false, error: 'POST only' });
 
+  const rl = rateLimit.enforce(req, res, 'lead');
+  if (!rl.allowed) {
+    return sendJson(res, 429, {
+      ok: false,
+      error: 'rate limit exceeded',
+      retry_after_ms: rl.retryAfterMs,
+    });
+  }
+
   let body;
   try {
     body = await readJsonBody(req);
@@ -116,6 +126,18 @@ module.exports = async function handler(req, res) {
       ok: false,
       error: 'invalid JSON body',
       detail: String(error.message || error),
+    });
+  }
+
+  // Honeypot: real users never see or fill the `website` hidden field.
+  // Bots scraping the form will. We accept the request with 200 so the
+  // bot doesn't retry, but skip every downstream side effect (no HF
+  // upload, no GitHub issue, no email).
+  if (body && typeof body.website === 'string' && body.website.trim().length > 0) {
+    return sendJson(res, 200, {
+      ok: true,
+      message: "Got it — Issac will reply within 24 hours.",
+      next_steps: [],
     });
   }
 

--- a/docs/hire.html
+++ b/docs/hire.html
@@ -589,6 +589,27 @@
           reply. Submissions land in a private dataset only Issac can see.
         </p>
         <form id="leadForm" style="display: grid; gap: 14px; max-width: 640px">
+          <!--
+            Honeypot: hidden from real users via off-screen positioning + tab
+            removal + autocomplete-off. Spambots scraping the form will fill
+            it; the server short-circuits any submission with this field non-
+            empty. Don't relabel "website" to something humans understand —
+            the field's job is to look interesting to dumb scrapers.
+          -->
+          <div
+            style="position: absolute; left: -10000px; top: auto; width: 1px; height: 1px; overflow: hidden"
+            aria-hidden="true"
+          >
+            <label
+              >Website (leave blank)
+              <input
+                id="leadWebsite"
+                name="website"
+                type="text"
+                tabindex="-1"
+                autocomplete="off"
+              /></label>
+          </div>
           <label style="display: grid; gap: 6px; font-size: 13px; color: var(--dim)">
             <span>Email or phone *</span>
             <input
@@ -765,6 +786,7 @@
             timeline: document.getElementById('leadTimeline').value,
             description: document.getElementById('leadDescription').value,
             source: 'aethermoore.com/hire',
+            website: document.getElementById('leadWebsite').value,
           };
           try {
             var response = await fetch(apiBase.replace(/\/$/, '') + '/v1/polly/lead', {

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -4,7 +4,7 @@
  * Mirrors the Python parity tests in test_polly_commerce.py.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const commerce = require('../../api/polly/commerce.js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -19,6 +19,8 @@ const trainCapture = require('../../api/_polly_train_capture.js');
 const leadHandler = require('../../api/polly/lead.js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const hfUpload = require('../../api/_polly_hf_upload.js');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rateLimit = require('../../api/_polly_rate_limit.js');
 
 interface MockRes {
   statusCode: number;
@@ -71,6 +73,91 @@ function makeReq(opts: {
     },
   };
 }
+
+describe('polly rate limiter', () => {
+  it('allows requests under the limit and blocks beyond it', () => {
+    rateLimit.reset();
+    const ip = '203.0.113.42';
+    const req = { headers: { 'x-forwarded-for': ip } };
+    const res = makeRes();
+    // chat default: 30/min — fire 30 requests, 31st should be blocked
+    for (let i = 0; i < 30; i += 1) {
+      const result = rateLimit.enforce(req, res, 'chat');
+      expect(result.allowed).toBe(true);
+    }
+    const blocked = rateLimit.enforce(req, res, 'chat');
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterMs).toBeGreaterThan(0);
+    expect(res.statusCode).toBe(200); // headers set, status not changed by enforce
+  });
+
+  it('isolates per-IP buckets so one abuser does not block another', () => {
+    rateLimit.reset();
+    const abuserReq = { headers: { 'x-forwarded-for': '198.51.100.1' } };
+    const cleanReq = { headers: { 'x-forwarded-for': '198.51.100.2' } };
+    const res = makeRes();
+    for (let i = 0; i < 5; i += 1) rateLimit.enforce(abuserReq, res, 'lead'); // exhaust
+    const abuserBlocked = rateLimit.enforce(abuserReq, res, 'lead');
+    const cleanAllowed = rateLimit.enforce(cleanReq, res, 'lead');
+    expect(abuserBlocked.allowed).toBe(false);
+    expect(cleanAllowed.allowed).toBe(true);
+  });
+
+  it('extracts the leftmost X-Forwarded-For value', () => {
+    expect(
+      rateLimit.clientIp({ headers: { 'x-forwarded-for': '203.0.113.5, 10.0.0.1, 10.0.0.2' } })
+    ).toBe('203.0.113.5');
+  });
+
+  it('falls back to X-Real-IP then unknown', () => {
+    expect(rateLimit.clientIp({ headers: { 'x-real-ip': '203.0.113.7' } })).toBe('203.0.113.7');
+    expect(rateLimit.clientIp({ headers: {} })).toBe('unknown');
+  });
+});
+
+describe('polly lead handler — anti-abuse', () => {
+  beforeEach(() => rateLimit.reset());
+
+  it('honeypot filled → returns 200 but skips downstream side effects', async () => {
+    const req = makeReq({
+      body: {
+        contact: 'spambot@example.com',
+        project_type: 'audit',
+        budget: 'open',
+        timeline: 'open',
+        description: 'this is a spambot scraping the form blindly',
+        website: 'https://spambot.example/',
+      },
+      headers: { 'x-forwarded-for': '203.0.113.99' },
+    });
+    const res = makeRes();
+    await leadHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { ok: boolean; next_steps: string[] };
+    expect(body.ok).toBe(true);
+    // Honeypot path returns empty next_steps so we can distinguish from real path
+    expect(body.next_steps.length).toBe(0);
+  });
+
+  it('rate limit kicks in after 5 lead submissions per IP', async () => {
+    const headers = { 'x-forwarded-for': '203.0.113.50' };
+    const validBody = {
+      contact: 'real@example.com',
+      project_type: 'audit',
+      budget: 'open',
+      timeline: 'open',
+      description: 'this is a real lead description from a real human',
+    };
+    for (let i = 0; i < 5; i += 1) {
+      const res = makeRes();
+      await leadHandler(makeReq({ body: validBody, headers }), res);
+      expect(res.statusCode).toBe(200);
+    }
+    const overRes = makeRes();
+    await leadHandler(makeReq({ body: validBody, headers }), overRes);
+    expect(overRes.statusCode).toBe(429);
+  });
+});
 
 describe('polly commerce intent classification', () => {
   it('catalog has three live products with valid stripe/kofi urls', () => {
@@ -192,6 +279,7 @@ describe('polly commerce reply rendering', () => {
 });
 
 describe('polly chat handler — research path', () => {
+  beforeEach(() => rateLimit.reset());
   it('returns deterministic answer for harmonic wall research question', async () => {
     const req = makeReq({
       body: {
@@ -209,6 +297,7 @@ describe('polly chat handler — research path', () => {
 });
 
 describe('polly chat handler — offline-router fallback', () => {
+  beforeEach(() => rateLimit.reset());
   it('replaces dead-end LLM offline message with the four-bucket router', async () => {
     const original = {
       hf: process.env.HF_TOKEN,
@@ -237,6 +326,7 @@ describe('polly chat handler — offline-router fallback', () => {
 });
 
 describe('polly chat handler — commerce path', () => {
+  beforeEach(() => rateLimit.reset());
   it('returns Stripe link when buy intent + product matches', async () => {
     const req = makeReq({
       body: { message: 'I want to buy the AI governance toolkit', consent_to_train: false },
@@ -294,6 +384,7 @@ describe('polly chat handler — commerce path', () => {
 });
 
 describe('polly feedback handler', () => {
+  beforeEach(() => rateLimit.reset());
   it('captures up rating', async () => {
     const req = makeReq({
       body: { rating: 'up', user_message: 'hi', assistant_reply: 'hello', session_id: 'test-1' },
@@ -335,6 +426,8 @@ describe('polly catalog handler', () => {
 });
 
 describe('polly lead handler', () => {
+  beforeEach(() => rateLimit.reset());
+
   const validLead = {
     contact: 'someone@example.com',
     project_type: 'audit',


### PR DESCRIPTION
## Summary
Closes the load-bearing gap from the 65/100 wrap-up review (anti-abuse: 20/100). The `/v1/polly/lead`, `/chat`, and `/feedback` endpoints had zero abuse controls — a single bot could drain Vercel function invocations, HF commits, and (when SMTP wires) outbound email.

## What lands
- **`api/_polly_rate_limit.js`** — sliding-window per-IP limiter, in-memory per Vercel function instance. Defaults: chat 30/min, lead 5/min, feedback 60/min. Tunable via env (`POLLY_RATE_LIMIT_CHAT=N`, etc). Returns `X-RateLimit-Limit / -Remaining / Retry-After` headers and 429 on block. Best-effort GC bounds memory at 5K buckets.
- **chat / lead / feedback handlers** — rate-limit enforcement before any body parsing. Lead handler also short-circuits on filled honeypot (returns 200 to discourage retry, skips all side effects).
- **`docs/hire.html`** — hidden honeypot input `website`. Off-screen via `position:absolute`, `tabindex=-1`, `autocomplete=off`, `aria-hidden`. Real users never see it; dumb scrapers fill it.
- **tests** — 49/49 green. Added rate-limiter sliding-window + per-IP isolation + IP extraction cases, plus lead-handler honeypot + rate-limit-after-5 cases.

## Limitation
In-memory state doesn't share across Vercel function instances or cold starts — a determined attacker hitting different invocations bypasses the limit. For real-grade protection swap the Map for Vercel KV or Upstash Redis. This PR stops **single-IP burst floods**, which is the main spam vector for tiny public APIs.

## Test plan
- [x] `npx vitest run tests/api/polly_commerce_js.test.ts` → 49/49 green
- [ ] Post-merge: hit `/v1/polly/lead` 6 times from one IP, expect 6th to return 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)