### PR TITLE
style(tests): format polly commerce test

### DIFF
--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -521,7 +521,12 @@ describe('polly direct HF upload', () => {
     delete process.env.HUGGINGFACE_TOKEN;
     delete process.env.HUGGING_FACE_HUB_TOKEN;
     try {
-      const result = await hfUpload.uploadRecord({ ts: 1, kind: 'chat', user: 'x', assistant: 'y' });
+      const result = await hfUpload.uploadRecord({
+        ts: 1,
+        kind: 'chat',
+        user: 'x',
+        assistant: 'y',
+      });
       expect(result.ok).toBe(false);
       expect(result.reason).toBe('no_token');
     } finally {


### PR DESCRIPTION
## Summary
- format the existing Polly commerce Vitest file with Prettier
- clears the recurring `Lint and Format Check` failure that was blocking docs-only PRs

## Tests
- `npx prettier --check tests/api/polly_commerce_js.test.ts`
- `python -m pytest tests/test_vercel_launch_bridge.py -q`

## Rollback
- revert this formatting-only PR