### PR TITLE
feat(site): floating Hire CTA + Vercel /hire routing

### DIFF
--- a/docs/agents.html
+++ b/docs/agents.html
@@ -455,5 +455,6 @@
   </script>
 
   <script src="static/polly-sidebar.js"></script>
-</body>
+<a href="https://aethermoore.com/SCBE-AETHERMOORE/hire.html" target="_self" aria-label="Hire Issac" style="position: fixed; bottom: 20px; right: 20px; z-index: 9999; background: #17c6cf; color: #06121a; padding: 12px 20px; border-radius: 999px; font-family: Inter, system-ui, -apple-system, sans-serif; font-weight: 700; font-size: 14px; letter-spacing: 0.01em; text-decoration: none; box-shadow: 0 4px 14px rgba(0,0,0,0.35); border: 1px solid #1ddae4; transition: transform 0.15s ease, box-shadow 0.15s ease;" onmouseover="this.style.transform='translateY(-1px)'; this.style.boxShadow='0 6px 18px rgba(0,0,0,0.45)';" onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 4px 14px rgba(0,0,0,0.35)';">Hire Issac</a>
+  </body>
 </html>

--- a/docs/governance-snapshot.html
+++ b/docs/governance-snapshot.html
@@ -243,5 +243,6 @@
         </p>
       </section>
     </main>
+  <a href="https://aethermoore.com/SCBE-AETHERMOORE/hire.html" target="_self" aria-label="Hire Issac" style="position: fixed; bottom: 20px; right: 20px; z-index: 9999; background: #17c6cf; color: #06121a; padding: 12px 20px; border-radius: 999px; font-family: Inter, system-ui, -apple-system, sans-serif; font-weight: 700; font-size: 14px; letter-spacing: 0.01em; text-decoration: none; box-shadow: 0 4px 14px rgba(0,0,0,0.35); border: 1px solid #1ddae4; transition: transform 0.15s ease, box-shadow 0.15s ease;" onmouseover="this.style.transform='translateY(-1px)'; this.style.boxShadow='0 6px 18px rgba(0,0,0,0.45)';" onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 4px 14px rgba(0,0,0,0.35)';">Hire Issac</a>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1758,5 +1758,6 @@
     setInterval(loadFeed, POLL);
   })();
   </script>
-</body>
+<a href="https://aethermoore.com/SCBE-AETHERMOORE/hire.html" target="_self" aria-label="Hire Issac" style="position: fixed; bottom: 20px; right: 20px; z-index: 9999; background: #17c6cf; color: #06121a; padding: 12px 20px; border-radius: 999px; font-family: Inter, system-ui, -apple-system, sans-serif; font-weight: 700; font-size: 14px; letter-spacing: 0.01em; text-decoration: none; box-shadow: 0 4px 14px rgba(0,0,0,0.35); border: 1px solid #1ddae4; transition: transform 0.15s ease, box-shadow 0.15s ease;" onmouseover="this.style.transform='translateY(-1px)'; this.style.boxShadow='0 6px 18px rgba(0,0,0,0.45)';" onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 4px 14px rgba(0,0,0,0.35)';">Hire Issac</a>
+  </body>
 </html>

--- a/docs/redteam.html
+++ b/docs/redteam.html
@@ -170,5 +170,6 @@ footer{border-top:1px solid #1a1a3e;padding:32px;text-align:center;color:#555;fo
   <br>USPTO #63/961,403 | ORCID 0009-0002-3936-9369
   <br><a href="https://www.youtube.com/@id8461" target="_blank" rel="noopener">YouTube</a>
 </footer>
-</body>
+<a href="https://aethermoore.com/SCBE-AETHERMOORE/hire.html" target="_self" aria-label="Hire Issac" style="position: fixed; bottom: 20px; right: 20px; z-index: 9999; background: #17c6cf; color: #06121a; padding: 12px 20px; border-radius: 999px; font-family: Inter, system-ui, -apple-system, sans-serif; font-weight: 700; font-size: 14px; letter-spacing: 0.01em; text-decoration: none; box-shadow: 0 4px 14px rgba(0,0,0,0.35); border: 1px solid #1ddae4; transition: transform 0.15s ease, box-shadow 0.15s ease;" onmouseover="this.style.transform='translateY(-1px)'; this.style.boxShadow='0 6px 18px rgba(0,0,0,0.45)';" onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 4px 14px rgba(0,0,0,0.35)';">Hire Issac</a>
+  </body>
 </html>

--- a/docs/support.html
+++ b/docs/support.html
@@ -195,5 +195,6 @@
     <div>This page exists to get people unstuck fast. It is a support route, not a research archive.</div>
   </footer>
 <script src="static/polly-sidebar.js"></script>
-</body>
+<a href="https://aethermoore.com/SCBE-AETHERMOORE/hire.html" target="_self" aria-label="Hire Issac" style="position: fixed; bottom: 20px; right: 20px; z-index: 9999; background: #17c6cf; color: #06121a; padding: 12px 20px; border-radius: 999px; font-family: Inter, system-ui, -apple-system, sans-serif; font-weight: 700; font-size: 14px; letter-spacing: 0.01em; text-decoration: none; box-shadow: 0 4px 14px rgba(0,0,0,0.35); border: 1px solid #1ddae4; transition: transform 0.15s ease, box-shadow 0.15s ease;" onmouseover="this.style.transform='translateY(-1px)'; this.style.boxShadow='0 6px 18px rgba(0,0,0,0.45)';" onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 4px 14px rgba(0,0,0,0.35)';">Hire Issac</a>
+  </body>
 </html>

--- a/docs/supporter.html
+++ b/docs/supporter.html
@@ -251,5 +251,6 @@
         window.location.href = 'https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i';
       });
     </script>
+  <a href="https://aethermoore.com/SCBE-AETHERMOORE/hire.html" target="_self" aria-label="Hire Issac" style="position: fixed; bottom: 20px; right: 20px; z-index: 9999; background: #17c6cf; color: #06121a; padding: 12px 20px; border-radius: 999px; font-family: Inter, system-ui, -apple-system, sans-serif; font-weight: 700; font-size: 14px; letter-spacing: 0.01em; text-decoration: none; box-shadow: 0 4px 14px rgba(0,0,0,0.35); border: 1px solid #1ddae4; transition: transform 0.15s ease, box-shadow 0.15s ease;" onmouseover="this.style.transform='translateY(-1px)'; this.style.boxShadow='0 6px 18px rgba(0,0,0,0.45)';" onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 4px 14px rgba(0,0,0,0.35)';">Hire Issac</a>
   </body>
 </html>

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -15,6 +15,8 @@ def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
     assert "fix/vercel-*" in config["ignoreCommand"]
     assert ("^/$", "/api/agent/launch.js") in routes
     assert ("^/launch$", "/api/agent/launch.js") in routes
+    assert ("^/hire/?$", "/hire.html") in routes
+    assert ("^/SCBE-AETHERMOORE/hire\\.html$", "/hire.html") in routes
     assert ("^/api/agent/(.*)$", "/api/agent/$1.js") in routes
 
 
@@ -31,7 +33,9 @@ def test_vercelignore_ships_launch_handler_with_api_bridge() -> None:
 
 def test_launch_page_links_to_public_docs_and_bridge_endpoints() -> None:
     source = (REPO_ROOT / "api" / "agent" / "launch.js").read_text(encoding="utf-8")
+    hire_page = REPO_ROOT / "public" / "hire.html"
 
+    assert hire_page.exists()
     assert "/api/agent/health" in source
     assert "/api/agent/status?limit=5" in source
     assert "https://aethermoore.com/SCBE-AETHERMOORE" in source

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,14 @@
       "dest": "/api/agent/launch.js"
     },
     {
+      "src": "^/hire/?$",
+      "dest": "/hire.html"
+    },
+    {
+      "src": "^/SCBE-AETHERMOORE/hire\\.html$",
+      "dest": "/hire.html"
+    },
+    {
       "src": "^/api/agent/(.*)$",
       "dest": "/api/agent/$1.js"
     },


### PR DESCRIPTION
## Summary
- **Floating "Hire Issac" CTA** on 6 public pages (`docs/index.html`, `support.html`, `agents.html`, `governance-snapshot.html`, `redteam.html`, `supporter.html`). Closes the conversion-funnel gap — none of the public pages on aethermoore.com previously linked to /hire, so visitors landed on the homepage with zero pathway to actually engage.
- **Vercel rewrites** for `/hire` and `/SCBE-AETHERMOORE/hire.html` to serve `public/hire.html` directly from the Vercel deployment, so the hire page works on the bridge host without needing the GitHub Pages prefix.

## Test plan
- [x] `python -m pytest tests/test_vercel_launch_bridge.py` (vercel routing assertions added)
- [ ] After Pages deploys: confirm cyan "Hire Issac" pill renders bottom-right on each of the 6 pages
- [ ] After Vercel deploys: `curl -I https://scbe-agent-bridge-vercel.vercel.app/hire` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)