### PR TITLE
fix(vercel): serve hire page from agent bridge

### DIFF
--- a/api/agent/hire.js
+++ b/api/agent/hire.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const HIRE_PAGE = path.join(process.cwd(), 'public', 'hire.html');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.setHeader('Allow', 'GET, HEAD');
+    return res.status(405).json({ ok: false, error: 'method_not_allowed' });
+  }
+
+  try {
+    const html = fs.readFileSync(HIRE_PAGE, 'utf8');
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300');
+    return res.status(200).send(req.method === 'HEAD' ? '' : html);
+  } catch (err) {
+    return res.status(500).json({
+      ok: false,
+      error: 'hire_page_unavailable',
+      detail: err && err.message ? err.message : String(err),
+    });
+  }
+};

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -15,8 +15,8 @@ def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
     assert "fix/vercel-*" in config["ignoreCommand"]
     assert ("^/$", "/api/agent/launch.js") in routes
     assert ("^/launch$", "/api/agent/launch.js") in routes
-    assert ("^/hire/?$", "/hire.html") in routes
-    assert ("^/SCBE-AETHERMOORE/hire\\.html$", "/hire.html") in routes
+    assert ("^/hire/?$", "/api/agent/hire.js") in routes
+    assert ("^/SCBE-AETHERMOORE/hire\\.html$", "/api/agent/hire.js") in routes
     assert ("^/api/agent/(.*)$", "/api/agent/$1.js") in routes
 
 
@@ -25,6 +25,7 @@ def test_vercelignore_ships_launch_handler_with_api_bridge() -> None:
     handler = REPO_ROOT / "api" / "agent" / "launch.js"
 
     assert handler.exists()
+    assert (REPO_ROOT / "api" / "agent" / "hire.js").exists()
     assert "!api" in ignore
     assert "!api/**" in ignore
     assert "!docs/offers.json" in ignore
@@ -34,8 +35,11 @@ def test_vercelignore_ships_launch_handler_with_api_bridge() -> None:
 def test_launch_page_links_to_public_docs_and_bridge_endpoints() -> None:
     source = (REPO_ROOT / "api" / "agent" / "launch.js").read_text(encoding="utf-8")
     hire_page = REPO_ROOT / "public" / "hire.html"
+    hire_handler = (REPO_ROOT / "api" / "agent" / "hire.js").read_text(encoding="utf-8")
 
     assert hire_page.exists()
+    assert "public', 'hire.html" in hire_handler
+    assert "Content-Type" in hire_handler
     assert "/api/agent/health" in source
     assert "/api/agent/status?limit=5" in source
     assert "https://aethermoore.com/SCBE-AETHERMOORE" in source

--- a/vercel.json
+++ b/vercel.json
@@ -22,11 +22,11 @@
     },
     {
       "src": "^/hire/?$",
-      "dest": "/hire.html"
+      "dest": "/api/agent/hire.js"
     },
     {
       "src": "^/SCBE-AETHERMOORE/hire\\.html$",
-      "dest": "/hire.html"
+      "dest": "/api/agent/hire.js"
     },
     {
       "src": "^/api/agent/(.*)$",


### PR DESCRIPTION
## Summary
- Add pi/agent/hire.js to serve the checked-in public/hire.html page through the Vercel agent bridge.
- Route both /hire and /SCBE-AETHERMOORE/hire.html to that handler.
- Update launch bridge regression tests so the route cannot silently drift back to a dead static path.

## Test evidence
- 
ode -c api/agent/hire.js
- python -m pytest tests/test_vercel_launch_bridge.py -q -> 9 passed

## Rollback
- Revert this PR to restore the previous static route behavior.