### PR TITLE
fix(vercel): include hire page asset

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -6,4 +6,6 @@
 !docs
 !docs/offers.json
 !docs/app-config.json
+!public
+!public/hire.html
 !vercel.json

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -30,6 +30,8 @@ def test_vercelignore_ships_launch_handler_with_api_bridge() -> None:
     assert "!api/**" in ignore
     assert "!docs/offers.json" in ignore
     assert "!docs/app-config.json" in ignore
+    assert "!public" in ignore
+    assert "!public/hire.html" in ignore
 
 
 def test_launch_page_links_to_public_docs_and_bridge_endpoints() -> None:


### PR DESCRIPTION
## Summary
- Include public/hire.html in the Vercel deploy bundle.
- Keep the launch bridge test aware that the hire handler's backing asset must be shipped.

## Test evidence
- python -m pytest tests/test_vercel_launch_bridge.py -q -> 9 passed

## Rollback
- Revert this PR to remove the Vercel asset allowlist lines.