### PR TITLE
fix(polly): correct thank-you panel CTA prices ($29 not $79/$129)

### DIFF
--- a/docs/hire.html
+++ b/docs/hire.html
@@ -787,17 +787,17 @@
         var SELF_SERVE = {
           'advisory-call': {
             label: 'Want a head start while I reach out?',
-            cta: 'Buy the AI Governance Toolkit ($79)',
+            cta: 'Buy the AI Governance Toolkit ($29)',
             href: 'https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06',
           },
           'audit': {
             label: 'Want to start reviewing the methodology now?',
-            cta: 'Buy the Security Training Vault ($129)',
+            cta: 'Buy the Security Training Vault ($29)',
             href: 'https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g',
           },
           'training': {
             label: 'Want the workshop materials in advance?',
-            cta: 'Buy the Security Training Vault ($129)',
+            cta: 'Buy the Security Training Vault ($29)',
             href: 'https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g',
           },
         };


### PR DESCRIPTION
PR #1521's self-serve CTAs displayed inflated prices. Live catalog has both products at \$29 one-time (verified via \`GET /v1/polly/catalog\` → \`priceLabel: "\$29 one-time"\`). Stripe checkout was always correct; only the in-form text was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)