### PR TITLE
fix(polly): keep lead notifications green on SMTP failure

### DIFF
--- a/.github/workflows/polly-training-capture.yml
+++ b/.github/workflows/polly-training-capture.yml
@@ -80,7 +80,7 @@ jobs:
           # the default for port 587 (Proton, Gmail, most providers); for
           # implicit TLS on 465 the script auto-switches.
           python3 - <<'PY'
-          import os, ssl, json, smtplib
+          import os, ssl, json, smtplib, sys
           from email.message import EmailMessage
 
           record = json.loads(os.environ["PAYLOAD"])
@@ -114,14 +114,22 @@ jobs:
           msg.set_content("\n".join(body_lines))
 
           context = ssl.create_default_context()
-          if port == 465:
-              with smtplib.SMTP_SSL(host, port, context=context, timeout=20) as s:
-                  s.login(user, password)
-                  s.send_message(msg)
-          else:
-              with smtplib.SMTP(host, port, timeout=20) as s:
-                  s.starttls(context=context)
-                  s.login(user, password)
-                  s.send_message(msg)
-          print(f"emailed lead to {recipient}")
+          try:
+              if port == 465:
+                  with smtplib.SMTP_SSL(host, port, context=context, timeout=20) as s:
+                      s.login(user, password)
+                      s.send_message(msg)
+              else:
+                  with smtplib.SMTP(host, port, timeout=20) as s:
+                      s.starttls(context=context)
+                      s.login(user, password)
+                      s.send_message(msg)
+              print(f"emailed lead to {recipient}")
+          except Exception as exc:
+              print(
+                  f"SMTP send failed but lead notification already filed as a GitHub issue: "
+                  f"{type(exc).__name__}: {exc}",
+                  file=sys.stderr,
+              )
+              sys.exit(0)
           PY


### PR DESCRIPTION
## Summary
- Make the optional SMTP lead-email step non-fatal when provider auth or delivery fails.
- The GitHub issue notification remains the durable inbox-actionable fallback.
- A stale local Gmail app-password secret was removed from repo Actions secrets so the workflow skips SMTP until a valid app password/provider credential is supplied.

## Test evidence
- Live smoke lead created issue #1525.
- The smoke exposed SMTP auth failure from stale Gmail credentials; this PR prevents that optional path from failing the whole workflow.

## Rollback
- Revert this PR to make SMTP failures fail the workflow again.