### PR TITLE
feat(polly): add autonomous service fulfillment packets

### DIFF
--- a/api/agent/hire.js
+++ b/api/agent/hire.js
@@ -3,7 +3,8 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const HIRE_PAGE = path.join(process.cwd(), 'public', 'hire.html');
+const HIRE_PAGE = path.join(process.cwd(), 'docs', 'hire.html');
+const FALLBACK_HIRE_PAGE = path.join(process.cwd(), 'public', 'hire.html');
 
 module.exports = async function handler(req, res) {
   if (req.method !== 'GET' && req.method !== 'HEAD') {
@@ -12,7 +13,8 @@ module.exports = async function handler(req, res) {
   }
 
   try {
-    const html = fs.readFileSync(HIRE_PAGE, 'utf8');
+    const pagePath = fs.existsSync(HIRE_PAGE) ? HIRE_PAGE : FALLBACK_HIRE_PAGE;
+    const html = fs.readFileSync(pagePath, 'utf8');
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300');
     return res.status(200).send(req.method === 'HEAD' ? '' : html);

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -2,6 +2,23 @@
 
 const PRODUCT_CATALOG = [
   {
+    sku: 'ai-governance-snapshot',
+    name: 'AI Governance Snapshot',
+    priceLabel: '$500 one-time',
+    short:
+      'Fixed-scope governance assessment for one AI workflow. Includes a 2-page findings memo, three prioritized fixes, and an evidence checklist.',
+    checkoutUrl: 'https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j',
+    deliveryUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html',
+    keywords: [
+      'governance snapshot',
+      'snapshot',
+      'risk read',
+      'fixed scope',
+      'evidence checklist',
+      'governance assessment',
+    ],
+  },
+  {
     sku: 'ai-governance-toolkit',
     name: 'SCBE AI Governance Toolkit',
     priceLabel: '$29 one-time',
@@ -69,12 +86,14 @@ const CONSULTING_TIERS = [
 const CONSULTING_LANDING_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/hire.html';
 const HIRE_EMAIL = 'issdandavis7795@gmail.com';
 const MEMBERSHIP_KOFI_URL = 'https://ko-fi.com/Y8Y51UQYWZ';
+const SERVICE_FAST_START_URL =
+  'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html';
 
 const BUY_PATTERN =
   /\b(buy|purchase|order|checkout|pay\s+for|get\s+the|want\s+the|how\s+much|sign\s+me\s+up|add\s+to\s+cart)\b/i;
 
 const CUSTOM_PATTERN =
-  /\b(custom|bespoke|tailor|specifically\s+for|my\s+team|my\s+company|my\s+org|my\s+(use\s*case|workflow)|something\s+else|not\s+listed|build\s+me|hire\s+you|consulting|advisory|audit|engagement|contract)\b/i;
+  /\b(custom|bespoke|tailor|specifically\s+for|my\s+team|my\s+company|my\s+org|my\s+(use\s*case|workflow)|something\s+else|not\s+listed|build\s+me|hire\s+(you|issac|isaac|davis|me)|consulting|advisory|audit|engagement|contract|chatbot\s+safer|llm\s+safer|ai\s+safety|governance\s+help)\b/i;
 
 const RESEARCH_PATTERN =
   /\b(research|find|look\s+up|search|investigate|what\s+do\s+you\s+know|recent|latest|news|paper|study|literature|sources?|cite|references?)\b/i;
@@ -127,9 +146,8 @@ function classifyIntent(message) {
   // RESEARCH_PATTERN regex but contains a known topic key. If the message
   // hits a registered topic AND looks like a question/explanation prompt,
   // route it to research.
-  const looksLikeQuestion = /\b(what|how|why|when|where|who|which|explain|describe|tell\s+me)\b/i.test(
-    message
-  );
+  const looksLikeQuestion =
+    /\b(what|how|why|when|where|who|which|explain|describe|tell\s+me)\b/i.test(message);
   if (looksLikeQuestion) {
     const topic = resolveResearchTopic(message);
     if (topic) {
@@ -192,11 +210,13 @@ function renderCustomReply(message) {
     "What you're describing is custom — not in the stock catalog. " +
     'Four ways we can scope it:\n\n' +
     tierLines.join('\n') +
-    '\n\nFastest path: email with a one-paragraph description of the ' +
-    'outcome you want. I reply same day where I can.';
+    '\n\nEvery serious inquiry now gets an instant fast-start packet: order recap, intake checklist, ' +
+    'starter governance resources, human inspection window, and follow-up steps. Fastest path: email ' +
+    'with a one-paragraph description of the outcome you want. I reply same day where I can.';
   const actions = [
     { label: 'Email Issac with this context', url: mailto },
     { label: 'Full hire details', url: CONSULTING_LANDING_URL },
+    { label: 'Service fast-start packet', url: SERVICE_FAST_START_URL },
   ];
   return { text, actions };
 }
@@ -319,9 +339,7 @@ const RESEARCH_TOPICS = [
       'MATHBAC abstract (submitted 2026-04-27, full proposal due 2026-06-16). SCBE positions ' +
       'as post-quantum hyperbolic successor to DARPA I2O Mission-oriented Resilient Clouds ' +
       '(MRC, ~2011-2017). SAM.gov UEI J4NXHM6N5F59, CAGE 1EXD5.',
-    links: [
-      { label: 'Hire / federal subcontract', url: CONSULTING_LANDING_URL },
-    ],
+    links: [{ label: 'Hire / federal subcontract', url: CONSULTING_LANDING_URL }],
   },
 ];
 
@@ -352,7 +370,7 @@ function renderResearchReply(message) {
 
   const titles = RESEARCH_TOPICS.map((t) => `- ${t.title}`);
   const text =
-    "I can answer research questions about any of these directly without an LLM call:\n\n" +
+    'I can answer research questions about any of these directly without an LLM call:\n\n' +
     titles.join('\n') +
     '\n\nAsk again with one of those terms in your question, or ' +
     'browse the full repo for the longer-form documentation.';
@@ -391,6 +409,7 @@ module.exports = {
   CONSULTING_LANDING_URL,
   HIRE_EMAIL,
   MEMBERSHIP_KOFI_URL,
+  SERVICE_FAST_START_URL,
   RESEARCH_TOPICS,
   classifyIntent,
   renderBuyReply,

--- a/api/polly/lead.js
+++ b/api/polly/lead.js
@@ -4,6 +4,7 @@ const { readJsonBody, sendJson, setCors } = require('../_agent_common');
 const trainCapture = require('../_polly_train_capture');
 const hfUpload = require('../_polly_hf_upload');
 const rateLimit = require('../_polly_rate_limit');
+const { CONSULTING_LANDING_URL, SERVICE_FAST_START_URL } = require('./commerce');
 
 const PROJECT_TYPES = new Set([
   'audit',
@@ -14,22 +15,9 @@ const PROJECT_TYPES = new Set([
   'other',
 ]);
 
-const BUDGET_RANGES = new Set([
-  'under-5k',
-  '5k-15k',
-  '15k-50k',
-  '50k-plus',
-  'open',
-]);
+const BUDGET_RANGES = new Set(['under-5k', '5k-15k', '15k-50k', '50k-plus', 'open']);
 
-const TIMELINES = new Set([
-  'asap',
-  '2-4-weeks',
-  '1-3-months',
-  'q3',
-  'q4',
-  'open',
-]);
+const TIMELINES = new Set(['asap', '2-4-weeks', '1-3-months', 'q3', 'q4', 'open']);
 
 const FIELD_CAPS = {
   contact: 240,
@@ -58,7 +46,9 @@ function validateLead(body) {
     return { ok: false, error: 'description must be at least 10 characters' };
   }
 
-  const projectType = String((body && body.project_type) || 'other').trim().toLowerCase();
+  const projectType = String((body && body.project_type) || 'other')
+    .trim()
+    .toLowerCase();
   if (!PROJECT_TYPES.has(projectType)) {
     return {
       ok: false,
@@ -66,7 +56,9 @@ function validateLead(body) {
     };
   }
 
-  const budget = String((body && body.budget) || 'open').trim().toLowerCase();
+  const budget = String((body && body.budget) || 'open')
+    .trim()
+    .toLowerCase();
   if (!BUDGET_RANGES.has(budget)) {
     return {
       ok: false,
@@ -74,7 +66,9 @@ function validateLead(body) {
     };
   }
 
-  const timeline = String((body && body.timeline) || 'open').trim().toLowerCase();
+  const timeline = String((body && body.timeline) || 'open')
+    .trim()
+    .toLowerCase();
   if (!TIMELINES.has(timeline)) {
     return {
       ok: false,
@@ -102,6 +96,211 @@ function logLead(record) {
   } catch (_err) {
     /* never raise into the request path */
   }
+}
+
+const OFFER_PACKETS = {
+  'advisory-call': {
+    offer: 'Short advisory call',
+    price_anchor: '$300 / 60 minutes',
+    review_window: 'Same-day human review when possible; always within 24 hours.',
+    gifts: [
+      {
+        label: 'Service fast-start packet',
+        url: SERVICE_FAST_START_URL,
+        why: 'Prepare the problem, evidence, and success criteria before the call.',
+      },
+      {
+        label: 'AI Governance Toolkit guide',
+        url: 'https://aethermoore.com/product-manual/ai-governance-toolkit.html',
+        why: 'Preview the template style used in paid governance work.',
+      },
+      {
+        label: 'Public SCBE repository',
+        url: 'https://github.com/issdandavis/SCBE-AETHERMOORE',
+        why: 'Proof surface for shipped governance code and tests.',
+      },
+    ],
+    next_steps: [
+      'Issac reviews the description and replies with a yes/no fit check.',
+      'If it fits, the reply includes payment/scheduling instructions and a short agenda.',
+      'After the call, buyer receives a written recap and action list.',
+    ],
+  },
+  audit: {
+    offer: 'Adversarial audit',
+    price_anchor: '$5,000-$15,000 / 1-3 weeks',
+    review_window:
+      'Initial human scope review within 24 hours; urgent production-risk leads are prioritized.',
+    gifts: [
+      {
+        label: 'Service fast-start packet',
+        url: SERVICE_FAST_START_URL,
+        why: 'Contains the intake checklist and no-secrets submission guidance.',
+      },
+      {
+        label: 'AI Governance Snapshot',
+        url: 'https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html',
+        why: 'Cheaper fixed-scope starting point if the audit is not ready yet.',
+      },
+      {
+        label: 'Training Vault guide',
+        url: 'https://aethermoore.com/product-manual/training-vault.html',
+        why: 'Shows the evaluation/training materials behind the security lane.',
+      },
+      {
+        label: 'SCBE governance tests',
+        url: 'https://github.com/issdandavis/SCBE-AETHERMOORE/tree/main/tests/governance',
+        why: 'Public proof of the governance overlay test surface.',
+      },
+    ],
+    next_steps: [
+      'AI triage classifies the lead as an audit request and stores it in the private lead dataset.',
+      'Issac inspects scope, endpoint risk, test boundaries, and whether secrets/customer data can be avoided.',
+      'The reply proposes either a $500 Snapshot, a $5K-$15K audit scope, or a no-fit explanation.',
+    ],
+  },
+  'custom-overlay': {
+    offer: 'Custom governance overlay',
+    price_anchor: '$25,000-$80,000 / 4-10 weeks',
+    review_window:
+      'Initial architecture review within 24 hours; scope may require a paid discovery step.',
+    gifts: [
+      {
+        label: 'Service fast-start packet',
+        url: SERVICE_FAST_START_URL,
+        why: 'Prepares model, API, latency, logging, and deployment constraints.',
+      },
+      {
+        label: 'Hire page proof packet',
+        url: CONSULTING_LANDING_URL,
+        why: 'Canonical scope and proof surface.',
+      },
+      {
+        label: 'AI Governance Toolkit guide',
+        url: 'https://aethermoore.com/product-manual/ai-governance-toolkit.html',
+        why: 'Shows the decision-record and evidence style used in delivery.',
+      },
+      {
+        label: 'SCBE source',
+        url: 'https://github.com/issdandavis/SCBE-AETHERMOORE',
+        why: 'Open-source-first implementation reference.',
+      },
+    ],
+    next_steps: [
+      'AI triage stores the request with project type, budget range, and timeline.',
+      'Issac checks whether the requested overlay can be delivered without unsafe data access.',
+      'The reply proposes discovery, implementation milestones, rollback boundaries, and payment structure.',
+    ],
+  },
+  subcontract: {
+    offer: 'Federal subcontract role',
+    price_anchor: '$150-$250 / hour, contract',
+    review_window:
+      'Human review within 24 hours; same-day where a prime or agency deadline is active.',
+    gifts: [
+      {
+        label: 'Hire page proof packet',
+        url: CONSULTING_LANDING_URL,
+        why: 'Capability, pricing, and direct contact surface.',
+      },
+      {
+        label: 'Public SCBE repository',
+        url: 'https://github.com/issdandavis/SCBE-AETHERMOORE',
+        why: 'Open-source proof of work for technical review.',
+      },
+      {
+        label: 'Service fast-start packet',
+        url: SERVICE_FAST_START_URL,
+        why: 'Use the subcontract intake section to prepare period of performance and deliverables.',
+      },
+    ],
+    next_steps: [
+      'Issac checks deadline, workshare, role fit, and conflict constraints.',
+      'The reply asks for the solicitation/prime context, period of performance, and expected deliverables.',
+      'If it fits, the next step is a short scope call or written teaming note.',
+    ],
+  },
+  training: {
+    offer: 'Workshop / internal training',
+    price_anchor: '$2,500-$7,500 / half day or full day',
+    review_window: 'Human review within 24 hours; curriculum fit checked before payment.',
+    gifts: [
+      {
+        label: 'Training Vault guide',
+        url: 'https://aethermoore.com/product-manual/training-vault.html',
+        why: 'Preview the training materials and evaluation language.',
+      },
+      {
+        label: 'Service fast-start packet',
+        url: SERVICE_FAST_START_URL,
+        why: 'Use the workshop intake section to define audience, outcome, and constraints.',
+      },
+      {
+        label: 'AI Governance Toolkit guide',
+        url: 'https://aethermoore.com/product-manual/ai-governance-toolkit.html',
+        why: 'Preview the practical templates used in training.',
+      },
+    ],
+    next_steps: [
+      'Issac reviews audience, technical level, and desired outcome.',
+      'The reply proposes a half-day or full-day outline with prep materials.',
+      'After payment, the buyer receives agenda, slide/source packet, and follow-up notes.',
+    ],
+  },
+  other: {
+    offer: 'Custom inquiry',
+    price_anchor: 'Scoped after review',
+    review_window: 'Human review within 24 hours.',
+    gifts: [
+      {
+        label: 'Service fast-start packet',
+        url: SERVICE_FAST_START_URL,
+        why: 'Use this to turn the idea into a reviewable scope.',
+      },
+      {
+        label: 'Hire page proof packet',
+        url: CONSULTING_LANDING_URL,
+        why: 'See the existing paid paths and direct contact routes.',
+      },
+      {
+        label: 'AI Governance Snapshot',
+        url: 'https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html',
+        why: 'Best fixed-scope fallback if the custom idea is too broad.',
+      },
+    ],
+    next_steps: [
+      'AI triage stores the lead and labels it as custom/other.',
+      'Issac replies with a fit check, a narrower offer, or a no-fit answer.',
+      'If the idea is broad, the $500 Snapshot is the recommended first paid step.',
+    ],
+  },
+};
+
+function buildFulfillmentPacket(lead) {
+  const base = OFFER_PACKETS[lead.projectType] || OFFER_PACKETS.other;
+  return {
+    status: 'instant-service-intake-v1',
+    offer: base.offer,
+    project_type: lead.projectType,
+    budget: lead.budget,
+    timeline: lead.timeline,
+    price_anchor: base.price_anchor,
+    review_window: base.review_window,
+    order_recap: [
+      `Requested path: ${base.offer}`,
+      `Budget signal: ${lead.budget}`,
+      `Timeline signal: ${lead.timeline}`,
+      'Payment status: not charged by this form; payment/scope is confirmed after human review.',
+    ],
+    initial_ai_inspection: [
+      'Contact format validated.',
+      'Project type, budget range, and timeline normalized.',
+      'Description stored for private review and training capture when enabled.',
+      'No secrets are required at this stage.',
+    ],
+    immediate_value: base.gifts,
+    follow_up_steps: base.next_steps,
+  };
 }
 
 module.exports = async function handler(req, res) {
@@ -136,7 +335,7 @@ module.exports = async function handler(req, res) {
   if (body && typeof body.website === 'string' && body.website.trim().length > 0) {
     return sendJson(res, 200, {
       ok: true,
-      message: "Got it — Issac will reply within 24 hours.",
+      message: 'Got it — Issac will reply within 24 hours.',
       next_steps: [],
     });
   }
@@ -172,15 +371,15 @@ module.exports = async function handler(req, res) {
     trainCapture.dispatchTrainingTurn(record),
   ]);
 
+  const fulfillmentPacket = buildFulfillmentPacket(lead);
+
   return sendJson(res, 200, {
     ok: true,
     message:
       "Got it — Issac will reply within 24 hours. If it's urgent, " +
       'phone (360) 808-0876 is the fastest path.',
-    next_steps: [
-      'Watch your inbox / phone for a direct reply',
-      'In the meantime, browse the open-source work at https://github.com/issdandavis/SCBE-AETHERMOORE',
-    ],
+    next_steps: [...fulfillmentPacket.order_recap, ...fulfillmentPacket.follow_up_steps],
+    fulfillment_packet: fulfillmentPacket,
   });
 };
 
@@ -190,4 +389,6 @@ module.exports._private = {
   TIMELINES,
   validateLead,
   logLead,
+  buildFulfillmentPacket,
+  OFFER_PACKETS,
 };

--- a/docs/hire.html
+++ b/docs/hire.html
@@ -839,27 +839,73 @@
         var apiBase =
           window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app';
 
-        // Contextual self-serve options based on project_type. Lets buyers
-        // who don't want to wait 24h grab the matching paid artifact now.
+        // Contextual self-serve options based on project_type. The API now
+        // returns the canonical fulfillment packet; this table is a fallback.
         var SELF_SERVE = {
           'advisory-call': {
             label: 'Want a head start while I reach out?',
-            cta: 'Buy the AI Governance Toolkit ($29)',
-            href: 'https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06',
+            cta: 'Open the service fast-start packet',
+            href: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html',
           },
           'audit': {
             label: 'Want to start reviewing the methodology now?',
-            cta: 'Buy the Security Training Vault ($29)',
-            href: 'https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g',
+            cta: 'Open the service fast-start packet',
+            href: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html',
           },
           'training': {
             label: 'Want the workshop materials in advance?',
-            cta: 'Buy the Security Training Vault ($29)',
-            href: 'https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g',
+            cta: 'Open the service fast-start packet',
+            href: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html',
           },
         };
 
-        function renderThankYou(parent, projectType) {
+        function escapeHtml(value) {
+          return String(value || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+        }
+
+        function renderList(items) {
+          if (!items || !items.length) return '';
+          return (
+            '<ul style="margin:10px 0 0 18px;color:var(--dim);font-size:13px">' +
+            items
+              .map(function (item) {
+                return '<li style="margin-bottom:6px">' + escapeHtml(item) + '</li>';
+              })
+              .join('') +
+            '</ul>'
+          );
+        }
+
+        function renderGiftCards(gifts) {
+          if (!gifts || !gifts.length) return '';
+          return (
+            '<div style="display:grid;gap:10px;margin:12px 0 14px">' +
+            gifts
+              .map(function (gift) {
+                return (
+                  '<div style="border:1px solid var(--border);border-radius:10px;padding:12px;background:var(--card)">' +
+                  '<a href="' +
+                  escapeHtml(gift.url) +
+                  '" target="_blank" rel="noopener" style="color:var(--accent);font-weight:700;text-decoration:none">' +
+                  escapeHtml(gift.label) +
+                  '</a>' +
+                  '<p style="color:var(--dim);font-size:13px;margin:6px 0 0">' +
+                  escapeHtml(gift.why) +
+                  '</p>' +
+                  '</div>'
+                );
+              })
+              .join('') +
+            '</div>'
+          );
+        }
+
+        function renderThankYou(parent, projectType, packet) {
           var offer = SELF_SERVE[projectType];
           var blocks = [];
           blocks.push(
@@ -872,6 +918,37 @@
               "add it to your contacts so it doesn't go to spam." +
               '</p>'
           );
+          if (packet) {
+            blocks.push(
+              '<div style="border:1px solid var(--border);border-radius:10px;padding:14px;background:var(--surface);margin-bottom:14px">' +
+                '<div style="font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.08em;margin-bottom:6px">Order recap</div>' +
+                '<strong style="color:var(--text)">' +
+                escapeHtml(packet.offer) +
+                '</strong>' +
+                '<div style="color:var(--gold);font-size:13px;margin-top:4px">' +
+                escapeHtml(packet.price_anchor) +
+                '</div>' +
+                renderList(packet.order_recap) +
+                '</div>'
+            );
+            blocks.push(
+              '<div style="border:1px solid var(--border);border-radius:10px;padding:14px;background:var(--card);margin-bottom:14px">' +
+                '<div style="font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.08em;margin-bottom:6px">Initial AI inspection</div>' +
+                '<p style="color:var(--dim);font-size:13px;margin:0 0 8px">' +
+                escapeHtml(packet.review_window) +
+                '</p>' +
+                renderList(packet.initial_ai_inspection) +
+                '</div>'
+            );
+            blocks.push(
+              '<h4 style="margin:18px 0 8px;color:var(--text)">Free fast-start resources</h4>' +
+                renderGiftCards(packet.immediate_value)
+            );
+            blocks.push(
+              '<h4 style="margin:18px 0 8px;color:var(--text)">Follow-up steps</h4>' +
+                renderList(packet.follow_up_steps)
+            );
+          }
           if (offer) {
             blocks.push(
               '<div style="border:1px solid var(--border);border-radius:10px;padding:14px;background:var(--card);margin-bottom:14px">' +
@@ -935,7 +1012,7 @@
             thankYouHost.id = 'leadThankYou';
             thankYouHost.style.maxWidth = '640px';
             (section || document.body).appendChild(thankYouHost);
-            renderThankYou(thankYouHost, projectType);
+            renderThankYou(thankYouHost, projectType, data.fulfillment_packet);
           } catch (error) {
             status.style.color = '#ff7a7a';
             status.textContent =

--- a/docs/product-manual/delivery-and-access.html
+++ b/docs/product-manual/delivery-and-access.html
@@ -40,6 +40,7 @@
       <ul>
         <li><a href="ai-governance-toolkit.html">SCBE AI Governance Toolkit guide</a></li>
         <li><a href="user-guide.html">SCBE Training Vault user guide</a></li>
+        <li><a href="service-fast-start.html">Service fast-start packet</a></li>
         <li><a href="../offers/index.html">Customer offers and checkout links</a></li>
       </ul>
     </section>

--- a/docs/product-manual/index.html
+++ b/docs/product-manual/index.html
@@ -30,6 +30,7 @@
       <article class="card"><h2>Delivery + Access</h2><p>Use this when a receipt arrived but a package link, access note, or manual path is missing.</p><a href="delivery-and-access.html">Open delivery guide</a></article>
       <article class="card"><h2>AI Governance Toolkit</h2><p>Buyer orientation for the governed AI toolkit package.</p><a href="ai-governance-toolkit.html">Open toolkit guide</a></article>
       <article class="card"><h2>Training Vault</h2><p>Buyer orientation for training data, benchmark, and notebook materials.</p><a href="user-guide.html">Open user guide</a></article>
+      <article class="card"><h2>Service Fast-Start</h2><p>Immediate value packet for consulting, audits, workshops, and custom governance work.</p><a href="service-fast-start.html">Open fast-start packet</a></article>
     </section>
   </main>
 </body>

--- a/docs/product-manual/service-fast-start.html
+++ b/docs/product-manual/service-fast-start.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SCBE Service Fast-Start Packet</title>
+    <meta
+      name="description"
+      content="Immediate value packet for AetherMoore AI governance service inquiries: intake checklist, free resources, review timeline, and follow-up steps."
+    />
+    <link
+      rel="canonical"
+      href="https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html"
+    />
+    <style>
+      :root {
+        --bg: #0b0f18;
+        --panel: #111827;
+        --card: #172033;
+        --line: #29364e;
+        --ink: #eef5ff;
+        --muted: #a9b8cc;
+        --accent: #17c6cf;
+        --gold: #ffd166;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          Inter,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+        line-height: 1.6;
+      }
+      main {
+        width: min(960px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 48px 0 80px;
+      }
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        margin-bottom: 36px;
+      }
+      a {
+        color: var(--accent);
+      }
+      h1 {
+        max-width: 820px;
+        margin: 0 0 16px;
+        font-size: clamp(36px, 7vw, 68px);
+        line-height: 1.03;
+        letter-spacing: 0;
+      }
+      h2,
+      h3 {
+        margin-top: 0;
+      }
+      p,
+      li {
+        color: var(--muted);
+      }
+      .eyebrow {
+        color: var(--gold);
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lede {
+        max-width: 760px;
+        font-size: 18px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 14px;
+        margin-top: 24px;
+      }
+      .panel,
+      .card {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 20px;
+      }
+      .card {
+        background: var(--card);
+      }
+      .btn {
+        display: inline-flex;
+        min-height: 44px;
+        align-items: center;
+        justify-content: center;
+        border-radius: 6px;
+        padding: 10px 16px;
+        background: var(--accent);
+        color: #06121a;
+        font-weight: 800;
+        text-decoration: none;
+      }
+      code {
+        color: var(--gold);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <nav aria-label="Fast-start navigation">
+        <a href="../hire.html">Hire Issac</a>
+        <a href="../governance-snapshot.html">AI Governance Snapshot</a>
+        <a href="ai-governance-toolkit.html">Toolkit guide</a>
+        <a href="training-vault.html">Training Vault guide</a>
+      </nav>
+
+      <div class="eyebrow">Immediate value after inquiry</div>
+      <h1>SCBE service fast-start packet</h1>
+      <p class="lede">
+        Use this before sending money or confidential files. It turns a rough AI governance problem
+        into a reviewable scope and gives both sides enough context to decide whether the next step
+        is a Snapshot, advisory call, audit, custom overlay, workshop, or no-fit answer.
+      </p>
+
+      <section class="panel">
+        <h2>What happens after you submit a service inquiry</h2>
+        <ol>
+          <li>The form validates contact, project type, budget range, timeline, and description.</li>
+          <li>Polly creates an instant recap and routes the lead into the private review dataset.</li>
+          <li>Issac inspects the request within 24 hours, same-day where possible.</li>
+          <li>
+            You receive one of three replies: a fixed next step, a request for narrower scope, or a
+            no-fit answer.
+          </li>
+        </ol>
+      </section>
+
+      <section class="grid" aria-label="Free resources">
+        <article class="card">
+          <h2>Free resource 1</h2>
+          <h3>Scope checklist</h3>
+          <ul>
+            <li>What system, agent, chatbot, workflow, or model is in scope?</li>
+            <li>What output would create harm if it were wrong?</li>
+            <li>Who sees the output: internal team, customers, buyers, reviewers, or the public?</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>Free resource 2</h2>
+          <h3>No-secrets intake rule</h3>
+          <ul>
+            <li>Send screenshots, public docs, mock data, or redacted examples first.</li>
+            <li>Do not send API keys, customer records, regulated data, or classified material.</li>
+            <li>Private-fork work requires written scope and data boundaries.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>Free resource 3</h2>
+          <h3>Evidence starter</h3>
+          <ul>
+            <li>List the prompt chain or agent steps.</li>
+            <li>List the known failure modes.</li>
+            <li>List the logs, tests, screenshots, or receipts that already exist.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>Free resource 4</h2>
+          <h3>Offer ladder</h3>
+          <ul>
+            <li><strong>$500 Snapshot:</strong> best first paid step for one workflow.</li>
+            <li><strong>$300 call:</strong> fastest focused discussion.</li>
+            <li><strong>$5K-$15K audit:</strong> production endpoint or agent assessment.</li>
+            <li><strong>$25K-$80K overlay:</strong> implemented governance layer.</li>
+          </ul>
+        </article>
+      </section>
+
+      <section class="panel">
+        <h2>Copy/paste intake</h2>
+        <p>Paste this into your reply email or the hire form.</p>
+        <pre><code>System or workflow:
+Who uses it:
+What the AI decides or outputs:
+Worst realistic failure:
+Current safeguards:
+Links/screenshots/docs I can share:
+Deadline:
+Budget range:
+Desired outcome:</code></pre>
+        <p>
+          <a class="btn" href="../hire.html">Send a service inquiry</a>
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/revenue/COMPETITIVE_PRICING_REVIEW_2026-05-09.md
+++ b/docs/revenue/COMPETITIVE_PRICING_REVIEW_2026-05-09.md
@@ -1,0 +1,61 @@
+# Competitive Pricing Review — AI Governance Offers
+
+Date: 2026-05-09
+
+## Market Read
+
+The current AetherMoore service ladder is broadly in range for the market, but
+the entry path should be simpler. Public pricing research shows:
+
+- ISO/IEC 42001 consulting commonly lands in the `10,000-50,000` USD/EUR band
+  for small and mid-sized scopes, with full-service implementations often
+  starting around `18,000 EUR` and running several months.
+- LLM / AI security audits are usually custom-priced. Public service pages
+  often avoid exact numbers, while pricing guides place serious security work
+  around senior consultant rates of `150-300 USD/hour` and multi-day to
+  multi-week engagements.
+- Compliance automation vendors usually hide pricing behind demos, which makes
+  a fixed, transparent entry product a useful wedge.
+
+Sources checked:
+
+- https://iso-easy.de/iso-42001/
+- https://ai-governance-schulung.de/wissen/iso-42001-kosten
+- https://storage.ghost.io/c/44/95/449506ca-034e-480f-9725-fcde08ef1cc1/content/files/2025/04/ISO-42001-Guide---Checklist-.pdf
+- https://www.zealynx.io/services/ai-audits/ai-red-team-audit
+- https://vibearmor.ai/blog/ai-security-audit-cost
+
+## Recommended Offer Ladder
+
+| Offer | Current price | Recommendation | Reason |
+| --- | ---: | --- | --- |
+| Tip/support | `$5` | Keep | Low-friction support path. |
+| Supporter | `$20/month` | Keep | Good emotional recurring support. |
+| Toolkit | `$29` | Keep | Cheap artifact, good impulse buy. |
+| Training Vault | `$29` | Keep | Cheap artifact, good technical buyer path. |
+| Governance Snapshot | `$500` | Make primary first paid service | Best fixed-scope buyer wedge. |
+| Advisory call | `$300` | Keep, but make secondary to Snapshot | A call sells better after a concrete artifact exists. |
+| Adversarial audit | `$5,000-$15,000` | Keep | Fits the market for a narrow LLM/agent audit. |
+| Custom overlay | `$25,000-$80,000` | Keep | Fits implementation/project work; needs discovery. |
+| Federal subcontract | `$150-$250/hour` | Keep | Normal senior technical consulting range. |
+| Workshop | `$2,500-$7,500` | Keep | Reasonable training/workshop band. |
+
+## Conversion Positioning
+
+The site should steer cold visitors toward one of three first actions:
+
+1. Buy the `$500 AI Governance Snapshot`.
+2. Buy a `$29` artifact if they are not ready for consulting.
+3. Submit a custom inquiry and receive the instant service fast-start packet.
+
+The high-ticket services should not feel like a black box. Every inquiry should
+immediately return:
+
+- order recap,
+- human review window,
+- initial AI inspection summary,
+- free fast-start resources,
+- follow-up steps,
+- no-secrets intake guidance.
+
+That fulfillment behavior is now implemented through `/v1/polly/lead`.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -26,9 +26,15 @@
   </url>
   <url>
     <loc>https://aethermoore.com/product-manual/delivery-and-access.html</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html</loc>
+    <lastmod>2026-05-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://aethermoore.com/training-hub.html</loc>

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -174,8 +174,8 @@ describe('polly lead handler — anti-abuse', () => {
 });
 
 describe('polly commerce intent classification', () => {
-  it('catalog has three live products with valid stripe/kofi urls', () => {
-    expect(commerce.PRODUCT_CATALOG).toHaveLength(3);
+  it('catalog has four live products with valid stripe/kofi urls', () => {
+    expect(commerce.PRODUCT_CATALOG).toHaveLength(4);
     for (const product of commerce.PRODUCT_CATALOG) {
       expect(product.checkoutUrl).toMatch(/^https:\/\/(buy\.stripe\.com|ko-fi\.com)/);
       expect(product.keywords.length).toBeGreaterThan(0);
@@ -197,10 +197,21 @@ describe('polly commerce intent classification', () => {
     expect(intent.product.sku).toBe('ai-security-training-vault');
   });
 
+  it('classifies governance snapshot as a buyable fixed-scope product', () => {
+    const intent = commerce.classifyIntent('Can I get the $500 governance snapshot?');
+    expect(intent.name).toBe('buy');
+    expect(intent.product.sku).toBe('ai-governance-snapshot');
+  });
+
   it('classifies custom intent at 0.85', () => {
     const intent = commerce.classifyIntent('I need a custom audit for my team');
     expect(intent.name).toBe('custom');
     expect(intent.confidence).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it('routes hire-Issac and chatbot-safety buyer questions to custom', () => {
+    expect(commerce.classifyIntent('How do I hire Issac?').name).toBe('custom');
+    expect(commerce.classifyIntent('I need help making my chatbot safer').name).toBe('custom');
   });
 
   it('classifies membership intent at 0.75', () => {
@@ -251,9 +262,9 @@ describe('polly commerce reply rendering', () => {
     expect(out.actions[0].url).toBe(product.checkoutUrl);
   });
 
-  it('renderBuyReply with null lists all 3 products', () => {
+  it('renderBuyReply with null lists all 4 products', () => {
     const out = commerce.renderBuyReply(null);
-    expect(out.actions).toHaveLength(3);
+    expect(out.actions).toHaveLength(4);
     for (const action of out.actions) {
       expect(action.url).toMatch(/^https:\/\//);
     }
@@ -265,6 +276,9 @@ describe('polly commerce reply rendering', () => {
     expect(mailtoAction).toBeDefined();
     expect(mailtoAction!.url).toContain('issdandavis7795@gmail.com');
     expect(mailtoAction!.url).toContain('finance');
+    expect(out.actions.some((a: { url: string }) => a.url.includes('service-fast-start'))).toBe(
+      true
+    );
   });
 
   it('renderMembershipReply has Ko-fi + GitHub + email actions', () => {
@@ -427,7 +441,7 @@ describe('polly catalog handler', () => {
     expect(res.statusCode).toBe(200);
     const body = res.body as { ok: boolean; products: unknown[]; consulting_tiers: unknown[] };
     expect(body.ok).toBe(true);
-    expect(body.products).toHaveLength(3);
+    expect(body.products).toHaveLength(4);
     expect(body.consulting_tiers.length).toBeGreaterThan(0);
   });
 
@@ -455,9 +469,27 @@ describe('polly lead handler', () => {
     const res = makeRes();
     await leadHandler(req, res);
     expect(res.statusCode).toBe(200);
-    const body = res.body as { ok: boolean; message: string; next_steps: string[] };
+    const body = res.body as {
+      ok: boolean;
+      message: string;
+      next_steps: string[];
+      fulfillment_packet: {
+        status: string;
+        offer: string;
+        initial_ai_inspection: string[];
+        immediate_value: { url: string }[];
+      };
+    };
     expect(body.ok).toBe(true);
     expect(body.next_steps.length).toBeGreaterThan(0);
+    expect(body.fulfillment_packet.status).toBe('instant-service-intake-v1');
+    expect(body.fulfillment_packet.offer).toBe('Adversarial audit');
+    expect(body.fulfillment_packet.initial_ai_inspection.length).toBeGreaterThan(0);
+    expect(
+      body.fulfillment_packet.immediate_value.some((item) =>
+        item.url.includes('service-fast-start')
+      )
+    ).toBe(true);
   });
 
   it('rejects a lead missing the contact field', async () => {


### PR DESCRIPTION
## Summary
- add the  AI Governance Snapshot to the live Polly catalog
- return structured instant fulfillment packets from /v1/polly/lead with order recap, AI inspection, free resources, and follow-up steps
- update /hire rendering so Vercel serves the full lead form and shows the packet after submission
- add service fast-start and competitive pricing review docs

## Test evidence
- npx prettier --check api/agent/hire.js api/polly/commerce.js api/polly/lead.js tests/api/polly_commerce_js.test.ts
- npx vitest run tests/api/polly_commerce_js.test.ts
- node smoke: api/agent/hire.js serves docs/hire.html with lead form + fulfillment packet support

## Rollback
- revert commit 0b94ac42 to restore the previous catalog, lead response, and hire page behavior