### PR TITLE
feat(wildlife): shepherd dispatcher (model-per-pack, cheap-first)

### DIFF
--- a/scripts/wildlife/dispatch.py
+++ b/scripts/wildlife/dispatch.py
@@ -1,0 +1,316 @@
+"""Dispatch shepherds against the Wildlife Board.
+
+Reads `.scbe/wildlife/board.json`, picks a shepherd per pack, and either:
+
+  --plan     (default) — produces `.scbe/wildlife/dispatch_plan.json`
+             showing what would happen per pack
+  --execute  — actually calls the model for the chosen pack(s)
+
+Cheap-first: sheep/crows hit local Ollama (free), goats/wolves hit HF
+Router (cents). Dragons + horses are never auto-dispatched.
+
+Usage:
+    python scripts/wildlife/dispatch.py --plan
+    python scripts/wildlife/dispatch.py --pack crows --execute --max 5
+    python scripts/wildlife/dispatch.py --pack wolves --execute --max 3 \
+        --hf-token-env HF_TOKEN
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from scripts.wildlife.packs import PACKS, severity_order  # noqa: E402
+from scripts.wildlife.shepherds import (  # noqa: E402
+    Shepherd,
+    is_auto_dispatchable,
+    render_prompt,
+    shepherd_for,
+)
+
+DEFAULT_BOARD = ROOT / ".scbe" / "wildlife" / "board.json"
+DEFAULT_PLAN_OUT = ROOT / ".scbe" / "wildlife" / "dispatch_plan.json"
+
+
+def _load_board(path: Path) -> dict:
+    if not path.exists():
+        raise SystemExit(f"[dispatch] no board at {path} - run " f"`python scripts/wildlife/harvest_packs.py` first.")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _animals_for(board: dict, pack: str) -> list[dict]:
+    p = PACKS.get(pack.upper())
+    if p is None:
+        return []
+    return board.get("packs", {}).get(p.plural, [])
+
+
+def _take_topn(animals: list[dict], n: int) -> list[dict]:
+    """Sort by lowest liberties first (most urgent), take top N."""
+    return sorted(animals, key=lambda a: a.get("liberties", 99))[:n]
+
+
+def call_ollama(model: str, prompt: str, base_url: str, timeout: int) -> dict:
+    """One-shot completion against local Ollama HTTP API."""
+    body = json.dumps({"model": model, "prompt": prompt, "stream": False}).encode("utf-8")
+    req = urllib.request.Request(
+        url=base_url.rstrip("/") + "/api/generate",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8", errors="ignore"))
+            return {
+                "ok": True,
+                "model": model,
+                "backend": "ollama",
+                "response": (data.get("response") or "").strip()[:1000],
+            }
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError) as exc:
+        return {
+            "ok": False,
+            "model": model,
+            "backend": "ollama",
+            "error": f"{type(exc).__name__}: {exc}"[:200],
+        }
+
+
+def call_hf_router(model: str, prompt: str, token: str, timeout: int) -> dict:
+    """One-shot chat completion against HuggingFace Router (OpenAI-compat)."""
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 220,
+            "temperature": 0.2,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        url="https://router.huggingface.co/v1/chat/completions",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8", errors="ignore"))
+            choice = (data.get("choices") or [{}])[0]
+            content = (choice.get("message") or {}).get("content") or ""
+            return {
+                "ok": True,
+                "model": model,
+                "backend": "huggingface",
+                "response": content.strip()[:1000],
+            }
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError) as exc:
+        return {
+            "ok": False,
+            "model": model,
+            "backend": "huggingface",
+            "error": f"{type(exc).__name__}: {exc}"[:200],
+        }
+
+
+def dispatch_one(
+    animal: dict,
+    shepherd: Shepherd,
+    *,
+    ollama_url: str,
+    hf_token: Optional[str],
+    timeout: int,
+) -> dict:
+    """Run the shepherd against one animal and return the result envelope."""
+    title = str(animal.get("title", ""))
+    prompt = render_prompt(shepherd.pack, title)
+    base = {
+        "animal_id": animal.get("id"),
+        "pack": shepherd.pack,
+        "model": shepherd.model,
+        "backend": shepherd.backend,
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    if prompt is None:
+        return {**base, "ok": False, "skip_reason": "no auto-dispatchable shepherd"}
+    if shepherd.backend == "ollama":
+        result = call_ollama(shepherd.model, prompt, ollama_url, timeout)
+    elif shepherd.backend == "huggingface":
+        if not hf_token:
+            return {
+                **base,
+                "ok": False,
+                "skip_reason": "HF_TOKEN not set; cannot call HF Router",
+            }
+        result = call_hf_router(shepherd.model, prompt, hf_token, timeout)
+    else:
+        return {**base, "ok": False, "skip_reason": f"backend {shepherd.backend} not callable"}
+    return {
+        **base,
+        **result,
+        "title": title[:120],
+        "prompt": prompt,
+        "finished_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def build_plan(board: dict, max_per_pack: int) -> dict:
+    plan: dict[str, Any] = {
+        "schema": "wildlife-dispatch-plan-v1",
+        "board_harvested_at": board.get("harvested_at"),
+        "by_pack": {},
+        "totals": {"auto_dispatchable": 0, "human_only": 0, "skipped": 0},
+    }
+    for pname in severity_order():
+        pack_obj = PACKS[pname]
+        animals = _animals_for(board, pname)
+        if not animals:
+            continue
+        shepherd = shepherd_for(pname)
+        top = _take_topn(animals, max_per_pack)
+        entry = {
+            "count_total": len(animals),
+            "count_planned": len(top),
+            "shepherd": {
+                "backend": shepherd.backend if shepherd else "n/a",
+                "model": shepherd.model if shepherd else "n/a",
+                "cost_tier": shepherd.cost_tier if shepherd else "n/a",
+                "bus_dispatch": shepherd.bus_dispatch if shepherd else False,
+            },
+            "auto_dispatchable": is_auto_dispatchable(pname),
+            "skip_reason": (
+                None
+                if is_auto_dispatchable(pname)
+                else (
+                    "human-only (dragons require a rider)"
+                    if pname == "DRAGON"
+                    else "training-pipeline-owned (horses run elsewhere)"
+                )
+            ),
+            "preview": [{"id": a.get("id"), "title": a.get("title", "")[:80]} for a in top],
+        }
+        if entry["auto_dispatchable"]:
+            plan["totals"]["auto_dispatchable"] += len(top)
+        else:
+            plan["totals"]["human_only"] += len(animals)
+        plan["by_pack"][pack_obj.plural] = entry
+    return plan
+
+
+def execute(
+    board: dict,
+    *,
+    pack_filter: Optional[str],
+    max_per_pack: int,
+    ollama_url: str,
+    hf_token: Optional[str],
+    timeout: int,
+) -> list[dict]:
+    """Actually call models for each (filtered) pack and return per-animal results."""
+    results: list[dict] = []
+    for pname in severity_order():
+        if pack_filter and pack_filter.upper() != pname:
+            plural = PACKS[pname].plural
+            if pack_filter.lower() not in (plural.lower(), PACKS[pname].animal.lower()):
+                continue
+        if not is_auto_dispatchable(pname):
+            continue
+        animals = _animals_for(board, pname)
+        if not animals:
+            continue
+        shepherd = shepherd_for(pname)
+        for animal in _take_topn(animals, max_per_pack):
+            results.append(
+                dispatch_one(
+                    animal,
+                    shepherd,
+                    ollama_url=ollama_url,
+                    hf_token=hf_token,
+                    timeout=timeout,
+                )
+            )
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument("--board", default=str(DEFAULT_BOARD))
+    parser.add_argument("--pack", default=None, help="restrict to one pack (wolves, sheep, ...)")
+    parser.add_argument("--max", type=int, default=3, dest="max_per_pack")
+    parser.add_argument("--plan", action="store_true", help="emit plan only (default if --execute absent)")
+    parser.add_argument("--execute", action="store_true", help="actually call models")
+    parser.add_argument("--plan-out", default=str(DEFAULT_PLAN_OUT), help="path for the plan json")
+    parser.add_argument("--ollama-url", default=os.environ.get("OLLAMA_URL", "http://127.0.0.1:11434"))
+    parser.add_argument(
+        "--hf-token-env",
+        default="HF_TOKEN",
+        help="env var holding HF token for HF-routed packs",
+    )
+    parser.add_argument("--timeout", type=int, default=45, help="per-call timeout seconds")
+    args = parser.parse_args()
+
+    board = _load_board(Path(args.board))
+    plan = build_plan(board, args.max_per_pack)
+
+    if not args.execute:
+        out_path = Path(args.plan_out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(plan, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"[dispatch] plan written -> {out_path}")
+        print(f"  auto-dispatchable animals: {plan['totals']['auto_dispatchable']}")
+        print(f"  human-only animals:        {plan['totals']['human_only']}")
+        for plural, entry in plan["by_pack"].items():
+            shepherd = entry["shepherd"]
+            mark = " [AUTO]" if entry["auto_dispatchable"] else " [SKIP]"
+            print(
+                f"  {plural:<10s} planned={entry['count_planned']}/{entry['count_total']} "
+                f"{shepherd['backend']:<18s} {shepherd['model']}{mark}"
+            )
+        return 0
+
+    hf_token = os.environ.get(args.hf_token_env) or ""
+    results = execute(
+        board,
+        pack_filter=args.pack,
+        max_per_pack=args.max_per_pack,
+        ollama_url=args.ollama_url,
+        hf_token=hf_token,
+        timeout=args.timeout,
+    )
+    out_path = Path(args.plan_out).with_name("dispatch_results.json")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(
+            {
+                "schema": "wildlife-dispatch-results-v1",
+                "ran_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "results": results,
+            },
+            indent=2,
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    ok = sum(1 for r in results if r.get("ok"))
+    skipped = sum(1 for r in results if r.get("skip_reason"))
+    print(f"[dispatch] executed {len(results)} call(s) -> {out_path}")
+    print(f"  ok={ok} skipped={skipped} failed={len(results)-ok-skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wildlife/shepherds.py
+++ b/scripts/wildlife/shepherds.py
@@ -1,0 +1,173 @@
+"""Shepherds — model-per-pack dispatch strategy for the Wildlife Board.
+
+Each pack has different work-character: sheep are bulk-trivial, dragons are
+rare-and-grave. Routing all packs to the same model wastes money on sheep and
+under-powers wolves. The shepherds module maps each pack to a strategy:
+
+  - which model to call
+  - which backend (Ollama local, HF cloud, or "human-only")
+  - what prompt template to use
+  - whether to dispatch via the agent bus or call the model directly
+
+Cheap-first: local Ollama for sheep/crows/otters/bees (small qwen-coder
+variants), HF cloud for goats/wolves/cats (Qwen2.5-7B-Instruct), training
+pipeline for horses (own runner), and human-only for dragons (never auto).
+
+This module is **plan only by default** — it produces a `dispatch_plan.json`
+describing what would happen. Pass `--execute` to actually call models. The
+spec at docs/specs/WILDLIFE_BOARD_v1.md and the bus runner at
+`scripts/scbe-system-cli.py agentbus run` are the contracts; this module
+sits between the board and the bus.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Shepherd:
+    pack: str  # WOLF, CROW, ...
+    backend: str  # "ollama" | "huggingface" | "training-pipeline" | "human-only"
+    model: str  # model id within that backend
+    bus_dispatch: bool  # True = route through agentbus run; False = direct or skip
+    prompt_template: str  # one-line prompt scaffold; "{title}" is filled
+    cost_tier: str  # "free" | "cheap" | "standard" | "expensive" | "n/a"
+
+
+# Default shepherds. Change here to re-tune cost/quality per pack.
+# Cost tier rough scale (per call):
+#   free      = local Ollama on user's machine, $0
+#   cheap     = HF Router with small model, ~$0.001
+#   standard  = HF Router with 7B-class, ~$0.01
+#   expensive = HF Router with 70B-class, ~$0.10
+#   n/a       = no model invoked (human-only or pipeline-owned)
+
+SHEPHERDS: dict[str, Shepherd] = {
+    "SHEEP": Shepherd(
+        pack="SHEEP",
+        backend="ollama",
+        model="qwen2.5-coder:1.5b",
+        bus_dispatch=False,  # bulk trivial: bypass bus, batch directly
+        prompt_template=(
+            "One-line action for this trivial chore (dependabot/format/lint): "
+            "{title}. Reply with the shell command or PR title only."
+        ),
+        cost_tier="free",
+    ),
+    "CROW": Shepherd(
+        pack="CROW",
+        backend="ollama",
+        model="qwen2.5-coder:1.5b",
+        bus_dispatch=False,
+        prompt_template=(
+            "TODO/FIXME comment to triage: {title}. Reply with one of: "
+            "DELETE (if dead code), DOCUMENT (if intentional), or "
+            "FIX:<one-line plan> (if real work). 25 words max."
+        ),
+        cost_tier="free",
+    ),
+    "OTTER": Shepherd(
+        pack="OTTER",
+        backend="ollama",
+        model="qwen2.5-coder:7b",
+        bus_dispatch=True,
+        prompt_template=(
+            "UI/UX polish task: {title}. Suggest one concrete CSS/HTML change "
+            "that improves it without scope creep. 50 words max."
+        ),
+        cost_tier="free",
+    ),
+    "BEE": Shepherd(
+        pack="BEE",
+        backend="ollama",
+        model="qwen2.5-coder:7b",
+        bus_dispatch=True,
+        prompt_template=(
+            "CI/workflow infra issue: {title}. Suggest the YAML or env-var "
+            "change. Reference the file if you can guess it. 60 words max."
+        ),
+        cost_tier="free",
+    ),
+    "GOAT": Shepherd(
+        pack="GOAT",
+        backend="huggingface",
+        model="Qwen/Qwen2.5-7B-Instruct",
+        bus_dispatch=True,
+        prompt_template=(
+            "Scoped feature work: {title}. Draft an acceptance-criteria "
+            "checklist (3-5 bullets) so it can be penned into a milestone."
+        ),
+        cost_tier="standard",
+    ),
+    "WOLF": Shepherd(
+        pack="WOLF",
+        backend="huggingface",
+        model="Qwen/Qwen2.5-7B-Instruct",
+        bus_dispatch=True,
+        prompt_template=(
+            "Critical bug or failed CI: {title}. Reply with: (1) likely root "
+            "cause in 1 sentence; (2) the file most likely to need editing; "
+            "(3) the regression test that should lock the fix. 80 words max."
+        ),
+        cost_tier="standard",
+    ),
+    "CAT": Shepherd(
+        pack="CAT",
+        backend="huggingface",
+        model="Qwen/Qwen2.5-7B-Instruct",
+        bus_dispatch=True,
+        prompt_template=(
+            "Research spike: {title}. Reply with: (1) the question this spike "
+            "is supposed to answer; (2) the smallest experiment that resolves "
+            "it; (3) what 'inconclusive' would still teach us. 100 words max."
+        ),
+        cost_tier="standard",
+    ),
+    "HORSE": Shepherd(
+        pack="HORSE",
+        backend="training-pipeline",
+        model="<owned by training pipeline>",
+        bus_dispatch=False,
+        prompt_template="<routed to training pipeline, not LLM>",
+        cost_tier="n/a",
+    ),
+    "DRAGON": Shepherd(
+        pack="DRAGON",
+        backend="human-only",
+        model="<requires human rider>",
+        bus_dispatch=False,
+        prompt_template="<never auto-dispatched: dragons require human review>",
+        cost_tier="n/a",
+    ),
+}
+
+
+def shepherd_for(pack: str) -> Optional[Shepherd]:
+    return SHEPHERDS.get(pack.upper())
+
+
+def render_prompt(pack: str, title: str) -> Optional[str]:
+    """Return the rendered prompt for a pack, or None if the shepherd is non-callable.
+
+    Sentinel templates (training-pipeline / human-only) start with `<` and contain
+    no `{title}` slot — they exist for documentation only.
+    """
+    s = shepherd_for(pack)
+    if s is None:
+        return None
+    if "{title}" not in s.prompt_template:
+        return None  # sentinel template, not a real prompt
+    return s.prompt_template.format(title=title)
+
+
+def is_auto_dispatchable(pack: str) -> bool:
+    """True if a shepherd will autonomously call a model for this pack.
+
+    Dragons (human-only) and Horses (training-pipeline-owned) are not.
+    """
+    s = shepherd_for(pack)
+    if s is None:
+        return False
+    return s.backend in {"ollama", "huggingface"}

--- a/tests/wildlife/test_shepherd_dispatch.py
+++ b/tests/wildlife/test_shepherd_dispatch.py
@@ -1,0 +1,134 @@
+"""Pin shepherd model selection + dispatch plan structure.
+
+These tests lock the cost/safety contract:
+- DRAGONS must never be auto-dispatched (require human rider)
+- HORSES must never be auto-dispatched (training pipeline owns them)
+- SHEEP and CROWS must use cheapest backend (Ollama local)
+- Every dispatchable pack must have a non-empty prompt template
+- Plan must surface skip_reason for non-dispatchable packs so the operator
+  is never confused about why something didn't run
+"""
+
+from __future__ import annotations
+
+from scripts.wildlife.dispatch import build_plan
+from scripts.wildlife.shepherds import (
+    SHEPHERDS,
+    is_auto_dispatchable,
+    render_prompt,
+    shepherd_for,
+)
+
+# ----------------------------- shepherd registry -------------------------- #
+
+
+def test_every_pack_has_a_shepherd() -> None:
+    expected = {"WOLF", "CROW", "GOAT", "BEE", "CAT", "HORSE", "SHEEP", "OTTER", "DRAGON"}
+    assert set(SHEPHERDS.keys()) == expected
+
+
+def test_dragons_are_human_only_never_auto() -> None:
+    s = shepherd_for("DRAGON")
+    assert s.backend == "human-only"
+    assert is_auto_dispatchable("DRAGON") is False
+    # Prompt must be a sentinel, not a real prompt
+    assert render_prompt("DRAGON", "DARPA proposal") is None
+
+
+def test_horses_are_pipeline_owned_never_auto() -> None:
+    s = shepherd_for("HORSE")
+    assert s.backend == "training-pipeline"
+    assert is_auto_dispatchable("HORSE") is False
+    assert render_prompt("HORSE", "v6h training run") is None
+
+
+def test_sheep_and_crows_use_cheapest_backend() -> None:
+    """Bulk trivial work must not hit paid HF."""
+    for pack in ("SHEEP", "CROW"):
+        s = shepherd_for(pack)
+        assert s.backend == "ollama", f"{pack} must use ollama (cheapest)"
+        assert s.cost_tier == "free", f"{pack} must be free tier"
+
+
+def test_wolves_use_a_real_model_not_local() -> None:
+    """Critical bugs deserve more capable model than 1.5B."""
+    s = shepherd_for("WOLF")
+    # Either local 7B+ or HF — never the 1.5B coder used for sheep
+    assert "1.5b" not in s.model.lower(), "WOLF shepherd must not be 1.5B model"
+
+
+def test_every_dispatchable_pack_has_nonempty_prompt() -> None:
+    for pack_name, shepherd in SHEPHERDS.items():
+        if shepherd.backend in {"ollama", "huggingface"}:
+            prompt = render_prompt(pack_name, "sample title")
+            assert prompt is not None, f"{pack_name} dispatchable but prompt is None"
+            assert "sample title" in prompt, f"{pack_name} prompt template missing {{title}}"
+            assert len(prompt) > 30, f"{pack_name} prompt too short ({len(prompt)})"
+
+
+def test_unknown_pack_has_no_shepherd() -> None:
+    assert shepherd_for("HIPPO") is None
+    assert is_auto_dispatchable("HIPPO") is False
+    assert render_prompt("HIPPO", "anything") is None
+
+
+# ----------------------------- dispatch plan ------------------------------ #
+
+
+def _mini_board(packs_with_counts: dict[str, int]) -> dict:
+    from scripts.wildlife.packs import PACKS
+
+    packs_section = {}
+    for pack_name, count in packs_with_counts.items():
+        plural = PACKS[pack_name].plural
+        packs_section[plural] = [
+            {"id": f"{pack_name.lower()}-{i}", "title": f"thing {i}", "liberties": 3} for i in range(count)
+        ]
+    return {
+        "schema": "wildlife-board-v1",
+        "harvested_at": "2026-05-09T00:00:00Z",
+        "packs": packs_section,
+    }
+
+
+def test_plan_marks_dragons_as_human_only_with_reason() -> None:
+    board = _mini_board({"DRAGON": 2, "WOLF": 3})
+    plan = build_plan(board, max_per_pack=5)
+    dragons_entry = plan["by_pack"]["dragons"]
+    assert dragons_entry["auto_dispatchable"] is False
+    assert "human" in dragons_entry["skip_reason"].lower()
+    # Dragons should NOT count toward auto-dispatchable totals
+    assert plan["totals"]["auto_dispatchable"] == 3  # only the wolves
+
+
+def test_plan_marks_horses_as_pipeline_owned_with_reason() -> None:
+    board = _mini_board({"HORSE": 4})
+    plan = build_plan(board, max_per_pack=5)
+    horses_entry = plan["by_pack"]["horses"]
+    assert horses_entry["auto_dispatchable"] is False
+    assert "training" in horses_entry["skip_reason"].lower()
+
+
+def test_plan_caps_per_pack_at_max_per_pack() -> None:
+    """A pack with 50 animals shouldn't try to dispatch all 50."""
+    board = _mini_board({"CROW": 50})
+    plan = build_plan(board, max_per_pack=3)
+    assert plan["by_pack"]["crows"]["count_total"] == 50
+    assert plan["by_pack"]["crows"]["count_planned"] == 3
+    assert len(plan["by_pack"]["crows"]["preview"]) == 3
+
+
+def test_plan_skips_empty_packs() -> None:
+    board = _mini_board({"CROW": 2})
+    plan = build_plan(board, max_per_pack=5)
+    # Wolves not in board → not in plan
+    assert "wolves" not in plan["by_pack"]
+    assert "crows" in plan["by_pack"]
+
+
+def test_plan_includes_cost_tier_for_each_dispatchable_pack() -> None:
+    """Operator can see at-a-glance whether a pack uses free or paid backend."""
+    board = _mini_board({"SHEEP": 3, "WOLF": 2})
+    plan = build_plan(board, max_per_pack=5)
+    assert plan["by_pack"]["sheep"]["shepherd"]["cost_tier"] == "free"
+    assert plan["by_pack"]["wolves"]["shepherd"]["cost_tier"] in {"cheap", "standard", "expensive"}


### PR DESCRIPTION
## Summary

Layers a dispatch strategy on top of the Wildlife Board so the 9 packs can actually be worked by models — cheap-first via local Ollama for bulk-trivial work (sheep/crows), HF Router for harder packs (wolves/goats/cats), and explicitly **never** for human-only (dragons) or training-pipeline (horses) packs.

- `scripts/wildlife/shepherds.py` — pack → (backend, model, prompt) registry. Sheep/crows: `qwen2.5-coder:1.5b` local. Otters/bees: `qwen2.5-coder:7b` local. Wolves/goats/cats: `Qwen/Qwen2.5-7B-Instruct` on HF Router. Horses: training pipeline. Dragons: human-only sentinel.
- `scripts/wildlife/dispatch.py` — `--plan` (default, safe) writes `.scbe/wildlife/dispatch_plan.json` showing what would happen per pack. `--execute` actually calls models via the Ollama HTTP API or HF Router OpenAI-compat endpoint. Picks lowest-liberties animals first.
- `tests/wildlife/test_shepherd_dispatch.py` — pins the cost/safety contract: dragons never auto, horses never auto, sheep/crows always free tier, plan caps at `--max` and surfaces `skip_reason` for non-dispatchable packs.

Plan run against the live board (232 real animals):

```
auto-dispatchable animals: 10
human-only animals:        0
wolves     planned=3/23  huggingface  Qwen/Qwen2.5-7B-Instruct [AUTO]
goats      planned=3/13  huggingface  Qwen/Qwen2.5-7B-Instruct [AUTO]
cats       planned=1/1   huggingface  Qwen/Qwen2.5-7B-Instruct [AUTO]
crows      planned=3/195 ollama       qwen2.5-coder:1.5b       [AUTO]
```

This realizes the "use Ollama+HF to work on tasks in groups via the bus" follow-up.

## Test plan

- [x] `PYTHONPATH=. python -m pytest tests/wildlife/ -q` → 38/38
- [x] `black --check --target-version py311 --line-length 120 scripts/wildlife/ tests/wildlife/`
- [x] `python scripts/wildlife/dispatch.py --plan --max 3` against live board
- [ ] Manual smoke: `python scripts/wildlife/dispatch.py --pack crows --execute --max 1` (deferred — would call local Ollama)

🤖 Generated with [Claude Code](https://claude.com/claude-code)