### PR TITLE
fix(wildlife): cap Ollama num_ctx so 1.5B fits in 6 GB VRAM

### DIFF
--- a/scripts/wildlife/dispatch.py
+++ b/scripts/wildlife/dispatch.py
@@ -62,8 +62,21 @@ def _take_topn(animals: list[dict], n: int) -> list[dict]:
 
 
 def call_ollama(model: str, prompt: str, base_url: str, timeout: int) -> dict:
-    """One-shot completion against local Ollama HTTP API."""
-    body = json.dumps({"model": model, "prompt": prompt, "stream": False}).encode("utf-8")
+    """One-shot completion against local Ollama HTTP API.
+
+    `num_ctx` is held small so KV cache fits on consumer GPUs (6 GB VRAM
+    can't hold the default 8 K context for a 1.5B model + prompt).
+    `num_predict` caps reply length so a stuck model can't burn the
+    whole timeout.
+    """
+    body = json.dumps(
+        {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"num_ctx": 1024, "num_predict": 220},
+        }
+    ).encode("utf-8")
     req = urllib.request.Request(
         url=base_url.rstrip("/") + "/api/generate",
         data=body,


### PR DESCRIPTION
## Summary

Default Ollama context (8 K) allocates a KV cache that doesn't fit on a 6 GB consumer GPU even for the 1.5B coder model — calls fail with `cudaMalloc failed: out of memory`. Capping `num_ctx=1024` (plenty for one TODO line + 220-token reply) and `num_predict=220` makes the model load cleanly.

Verified by taming 5 crows end-to-end (5/5 ok=true). Sample replies:

```
TODO: (@ganler): OPTIMIZATION: reuse the samples from the generations of other datasets
  → FIX: Optimize sampling process by reusing existing dataset samples.

TODO: having return does not mean this is complete
  → DELETE

HACK: list integer
  → FIX: Convert the list integer to a more descriptive data structure
```

## Test plan

- [x] PYTHONPATH=. python -m pytest tests/wildlife/ -q → 38/38
- [x] python scripts/wildlife/dispatch.py --pack crows --execute --max 5 → 5/5 ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)