### PR TITLE
fix(marketing): update Ko-fi support URL

### DIFF
--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -51,7 +51,7 @@ const PRODUCT_CATALOG = [
     priceLabel: '$5 one-time',
     short:
       "If the open-source work has helped you and there's no formal engagement, a tip keeps the next release shipping.",
-    checkoutUrl: 'https://ko-fi.com/Y8Y51UQYWZ',
+    checkoutUrl: 'https://ko-fi.com/izdandavis',
     deliveryUrl: '',
     keywords: ['tip', 'tip jar', 'donate', 'donation', 'support', 'buy a coffee', 'coffee'],
   },
@@ -85,7 +85,7 @@ const CONSULTING_TIERS = [
 // canonical Pages URL until a custom rewrite is configured.
 const CONSULTING_LANDING_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/hire.html';
 const HIRE_EMAIL = 'issdandavis7795@gmail.com';
-const MEMBERSHIP_KOFI_URL = 'https://ko-fi.com/Y8Y51UQYWZ';
+const MEMBERSHIP_KOFI_URL = 'https://ko-fi.com/izdandavis';
 const SERVICE_FAST_START_URL =
   'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html';
 

--- a/docs/hire.html
+++ b/docs/hire.html
@@ -382,7 +382,7 @@
             rel="noopener"
             >See the work</a
           >
-          <a class="cta tertiary" href="https://ko-fi.com/Y8Y51UQYWZ" target="_blank" rel="noopener"
+          <a class="cta tertiary" href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
             >Or tip the work →</a
           >
         </div>
@@ -601,11 +601,11 @@
             <h3>3. Sponsor or tip</h3>
             <p style="margin-bottom: 14px">
               <a
-                href="https://ko-fi.com/Y8Y51UQYWZ"
+                href="https://ko-fi.com/izdandavis"
                 target="_blank"
                 rel="noopener"
                 style="color: var(--accent)"
-                >ko-fi.com/Y8Y51UQYWZ</a
+                >ko-fi.com/izdandavis</a
               >
             </p>
             <p>

--- a/docs/hire.html
+++ b/docs/hire.html
@@ -18,7 +18,10 @@
     <meta property="og:image" content="https://aethermoore.com/SCBE-AETHERMOORE/hero.svg" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Hire Issac Davis — AI Safety & Governance Engineering" />
-    <meta name="twitter:description" content="Independent AI safety and governance engineering. Federal-registered, open-source-first." />
+    <meta
+      name="twitter:description"
+      content="Independent AI safety and governance engineering. Federal-registered, open-source-first."
+    />
     <meta name="twitter:image" content="https://aethermoore.com/SCBE-AETHERMOORE/hero.svg" />
     <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/hire.html" />
     <script type="application/ld+json">
@@ -42,6 +45,14 @@
           "Technical Advisory"
         ],
         "offers": [
+          {
+            "@type": "Offer",
+            "name": "AI Governance Snapshot",
+            "price": "500",
+            "priceCurrency": "USD",
+            "url": "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j",
+            "description": "Fixed-scope governance assessment for one AI workflow with a findings memo, prioritized fixes, evidence checklist, and fast-start packet"
+          },
           {
             "@type": "Offer",
             "name": "Short advisory call",
@@ -72,10 +83,7 @@
             "description": "4-10 weeks. Build a deployable governance layer in front of your model API"
           }
         ],
-        "sameAs": [
-          "https://github.com/issdandavis/SCBE-AETHERMOORE",
-          "https://aethermoore.com/"
-        ]
+        "sameAs": ["https://github.com/issdandavis/SCBE-AETHERMOORE", "https://aethermoore.com/"]
       }
     </script>
     <style>
@@ -359,8 +367,11 @@
         </p>
 
         <div class="cta-row">
+          <a class="cta primary" href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+            >Buy $500 Snapshot</a
+          >
           <a
-            class="cta primary"
+            class="cta secondary"
             href="mailto:issdandavis7795@gmail.com?subject=Engagement%20inquiry%20%E2%80%94%20from%20aethermoore.com%2Fhire&body=Hi%20Issac%2C%0A%0AI%27d%20like%20to%20discuss%3A%0A%5B%20%5D%20Short%20advisory%20call%0A%5B%20%5D%20Custom%20governance%20overlay%0A%5B%20%5D%20Adversarial%20audit%0A%5B%20%5D%20Federal%20subcontract%20conversation%0A%5B%20%5D%20Other%3A%0A%0AContext%3A%0A%0AThanks%2C"
             >Email me directly</a
           >
@@ -383,6 +394,23 @@
           Concrete engagements with real deliverables. Pricing is anchored, not theoretical.
         </p>
         <div class="services">
+          <div class="service-card">
+            <h3>AI Governance Snapshot</h3>
+            <div class="price">$500 · fixed scope · immediate fast-start packet</div>
+            <p>
+              A first-pass governance assessment for one AI workflow. You get immediate checkout
+              confirmation, the service fast-start packet, a human-reviewed findings memo, three
+              prioritized fixes, and an evidence checklist you can reuse with leadership, auditors,
+              or proposal reviewers.
+            </p>
+            <p>
+              <a href="governance-snapshot.html" style="color: var(--accent)">View scope</a> ·
+              <a href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j" style="color: var(--accent)"
+                >buy now</a
+              >
+            </p>
+          </div>
+
           <div class="service-card">
             <h3>Short advisory call</h3>
             <div class="price">$300 · 60 min · same week</div>
@@ -613,8 +641,8 @@
         <h2>Talk to Polly</h2>
         <p class="muted">
           Polly is the SCBE assistant. Ask about products, scope a custom build, or get pointed at
-          the right resource. Conversations are routed to a private Hugging Face dataset and used
-          to train the next release — uncheck the box below if you'd rather opt out for this
+          the right resource. Conversations are routed to a private Hugging Face dataset and used to
+          train the next release — uncheck the box below if you'd rather opt out for this
           conversation.
         </p>
         <label
@@ -660,18 +688,20 @@
             the field's job is to look interesting to dumb scrapers.
           -->
           <div
-            style="position: absolute; left: -10000px; top: auto; width: 1px; height: 1px; overflow: hidden"
+            style="
+              position: absolute;
+              left: -10000px;
+              top: auto;
+              width: 1px;
+              height: 1px;
+              overflow: hidden;
+            "
             aria-hidden="true"
           >
             <label
               >Website (leave blank)
-              <input
-                id="leadWebsite"
-                name="website"
-                type="text"
-                tabindex="-1"
-                autocomplete="off"
-              /></label>
+              <input id="leadWebsite" name="website" type="text" tabindex="-1" autocomplete="off"
+            /></label>
           </div>
           <label style="display: grid; gap: 6px; font-size: 13px; color: var(--dim)">
             <span>Email or phone *</span>
@@ -705,6 +735,7 @@
                 font-size: 14px;
               "
             >
+              <option value="ai-governance-snapshot">AI Governance Snapshot ($500)</option>
               <option value="advisory-call">Short advisory call ($300)</option>
               <option value="audit">Adversarial audit ($5K-15K)</option>
               <option value="custom-overlay">Custom governance overlay ($25K-80K)</option>
@@ -836,8 +867,7 @@
         var form = document.getElementById('leadForm');
         var status = document.getElementById('leadStatus');
         if (!form || !status) return;
-        var apiBase =
-          window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app';
+        var apiBase = window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app';
 
         // Contextual self-serve options based on project_type. The API now
         // returns the canonical fulfillment packet; this table is a fallback.
@@ -847,12 +877,12 @@
             cta: 'Open the service fast-start packet',
             href: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html',
           },
-          'audit': {
+          audit: {
             label: 'Want to start reviewing the methodology now?',
             cta: 'Open the service fast-start packet',
             href: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html',
           },
-          'training': {
+          training: {
             label: 'Want the workshop materials in advance?',
             cta: 'Open the service fast-start packet',
             href: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html',
@@ -997,7 +1027,9 @@
             if (!response.ok || !data.ok) {
               status.style.color = '#ff7a7a';
               status.textContent =
-                'Could not send: ' + (data.error || 'unknown error') + '. Try again or email directly.';
+                'Could not send: ' +
+                (data.error || 'unknown error') +
+                '. Try again or email directly.';
               return;
             }
             // Replace the form with the contextual thank-you panel so the

--- a/docs/index.html
+++ b/docs/index.html
@@ -1579,7 +1579,7 @@
           <p style="color:var(--muted);font-size:16px;max-width:60ch;margin:0 auto 18px;">Built by someone who works at Wendy's and knows what it's like when tools cost more than they help. These will be free and open source — forever.</p>
           <div class="cta-row" style="justify-content:center;">
             <a class="btn btn-secondary" href="https://github.com/issdandavis" target="_blank" rel="noopener">Follow on GitHub for launch</a>
-            <a class="btn btn-secondary" href="https://ko-fi.com/Y8Y51UQYWZ" target="_blank" rel="noopener" style="border-color:rgba(114,164,242,0.4);color:#72a4f2;">Support on Ko-fi</a>
+            <a class="btn btn-secondary" href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener" style="border-color:rgba(114,164,242,0.4);color:#72a4f2;">Support on Ko-fi</a>
           </div>
         </div>
       </div>
@@ -1628,7 +1628,7 @@
         </div>
         <div style="margin-top:24px;">
           <script type='text/javascript' src='https://storage.ko-fi.com/cdn/widget/Widget_2.js'></script>
-          <script type='text/javascript'>kofiwidget2.init('Support me on Ko-fi', '#72a4f2', 'Y8Y51UQYWZ');kofiwidget2.draw();</script>
+          <script type='text/javascript'>kofiwidget2.init('Support me on Ko-fi', '#72a4f2', 'izdandavis');kofiwidget2.draw();</script>
         </div>
       </div>
     </section>
@@ -1651,7 +1651,7 @@
         <a href="https://www.youtube.com/@id8461" target="_blank" rel="noopener">YouTube</a>
         <a href="https://www.linkedin.com/in/issdandavis" target="_blank" rel="noopener">LinkedIn</a>
         <a href="https://huggingface.co/issdandavis" target="_blank" rel="noopener">HuggingFace</a>
-        <a href="https://ko-fi.com/Y8Y51UQYWZ" target="_blank" rel="noopener">Ko-fi</a>
+        <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener">Ko-fi</a>
       </div>
       <div>AetherMoore. Geometric AI governance by Issac Davis. Patent pending.</div>
     </div>


### PR DESCRIPTION
## Summary
- updates Ko-fi support links from the old generated code URL to `https://ko-fi.com/izdandavis`
- keeps Polly commerce, homepage, and hire page support routes aligned
- updates the embedded Ko-fi widget handle to `izdandavis`

## Test Evidence
- `npx prettier --check api\polly\commerce.js docs\hire.html`
- `node -e "import('./api/polly/commerce.js').then(m=>{console.log('ok')}).catch(e=>{console.error(e);process.exit(1)})"`
- `rg -n "Y8Y51UQYWZ|ko-fi\.com/izdandavis|kofiwidget2\.init" api\polly\commerce.js docs\index.html docs\hire.html content\articles -g "*.js" -g "*.html" -g "*.md"`

## Rollback
- Revert this PR to restore the prior Ko-fi support code URL.