### PR TITLE
fix(skills): add frontmatter for local agent skills

### DIFF
--- a/.home/.agents/skills/scbe-agent-priming/SKILL.md
+++ b/.home/.agents/skills/scbe-agent-priming/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: scbe-agent-priming
+description: Prime AI agents before dispatch with task context, role assignment, tool guidance, multi-agent coordination, and perception review patterns. Use when starting or handing off agent work in SCBE.
+---
+
+# SCBE Agent Priming & Perception
+
+Reference guide for priming AI agents before task dispatch. Covers system prompt design, context engineering, role assignment, tool priming, multi-agent coordination, and self-perception (video/audio analysis).
+
+## When To Use
+
+- Dispatching a subagent for a task (Codex Agent tool, Codex, n8n agent)
+- Starting a new session and need to orient quickly
+- Reviewing generated content (video, audio, articles) before publishing
+- Coordinating Codex + Codex cross-talk handoffs
+- Deploying services from terminal
+
+## Agent Priming Best Practices
+
+### 1. Context Window Engineering
+
+**What to include (in priority order):**
+1. **Task objective** — 1-2 sentences, no ambiguity
+2. **Success criteria** — what "done" looks like, measurable
+3. **Relevant file paths** — exact paths, not "find the file"
+4. **Constraints** — time, cost, technology limits
+5. **Anti-patterns** — what NOT to do (prevents common drift)
+6. **Examples** — 1-2 concrete input→output pairs
+
+**What to omit:**
+- Full codebase history (agent doesn't need 67 repos of context)
+- Speculative requirements ("might need later")
+- Duplicate information across sections
+- Long explanations when a file path suffices
+
+### 2. Role-Based Priming
+
+Assign clear roles to reduce hallucination and increase focus:
+
+```
+You are a [ROLE] working on [PROJECT].
+Your expertise: [SPECIFIC SKILLS].
+Your deliverable: [EXACT OUTPUT FORMAT].
+You have access to: [TOOLS LIST].
+Do NOT: [ANTI-PATTERNS].
+```
+
+**Tested roles for SCBE agents:**
+- `content-publisher` — formats + publishes articles across platforms
+- `video-reviewer` — extracts frames, transcribes audio, gives quality feedback
+- `code-implementer` — writes code following TDD, commits after each test
+- `spec-reviewer` — verifies implementation matches specification exactly
+- `research-synthesizer` — searches web, cross-references sources, returns structured findings
+- `deployment-operator` — runs deploy commands, verifies health, reports status
+
+### 3. Tool Priming
+
+Agents perform better when told which tools to use for what:
+
+```
+For file search: use Glob (not find/ls)
+For content search: use Grep (not grep/rg)
+For reading files: use Read (not cat)
+For editing: use Edit (not sed)
+For web research: use WebSearch then WebFetch
+For browser automation: use Playwright MCP (navigate → snapshot → action → verify)
+```
+
+### 4. Multi-Agent Coordination
+
+**Cross-talk protocol** (Codex ↔ Codex):
+- Use `scripts/system/crosstalk_relay.py emit` with `--sender`, `--recipient`, `--task-id`, `--summary`, `--status`
+- Never use `--from` or `--to` flags (they don't exist)
+- Always ACK received packets
+- Check `notes/_inbox.md` at session start
+
+**Parallel dispatch rules:**
+- Independent tasks → parallel agents (no shared state)
+- Sequential tasks → one agent at a time with handoff context
+- Always include the plan file content in agent prompt (don't make agent search for it)
+- Use `run_in_background: true` for research, foreground for implementation
+
+### 5. Anti-Patterns That Degrade Agent Performance
+
+| Anti-Pattern | Fix |
+|---|---|
+| "Do whatever seems right" | Specify exact deliverables |
+| Giant context dumps | Curate to relevant 20% |
+| No success criteria | Define measurable "done" |
+| Missing file paths | Always give absolute paths |
+| Asking agent to "find" things | Tell it where things are |
+| No constraints | Set time/scope/tech limits |
+| Vague role ("help with code") | Specific role ("implement the TTS concat fix in article_to_video.py") |
+
+## Self-Perception Capabilities (Eyes & Ears)
+
+### Video Analysis (Eyes)
+
+Extract frames from any video and view them:
+
+```bash
+# Extract 6 key frames evenly across video
+ffmpeg -y -i VIDEO.mp4 \
+  -vf "select='eq(n\,0)+eq(n\,150)+eq(n\,900)+eq(n\,2700)+eq(n\,5400)+eq(n\,7200)'" \
+  -vsync vfr artifacts/youtube/review/frame_%03d.png
+
+# Then use Read tool on each PNG — Codex is multimodal
+```
+
+**What to check in video frames:**
+- Title card: branding, name, readability
+- Content slides: text truncation, number formatting, bullet structure
+- Code slides: syntax highlighting, font readability
+- Outro: links visible, hashtags readable, CTA clear
+- Overall: too much empty space, text too small, color contrast
+
+### Audio Analysis (Ears)
+
+Transcribe with Whisper to verify TTS output:
+
+```python
+import whisper
+model = whisper.load_model('tiny')  # 'tiny' for fast review, 'base' for accuracy
+result = model.transcribe('video.mp4', language='en')
+for seg in result['segments']:
+    print(f"[{seg['start']:.1f}s] {seg['text'].strip()}")
+```
+
+**What to check in transcription:**
+- Name pronunciation (Izack → "is at"? Need phonetic spelling)
+- Number handling (12,596 → "12. 596"? Need "twelve thousand five hundred ninety six")
+- Acronym expansion (AI → "A I"? Consider "artificial intelligence" for TTS)
+- Pacing: are segments too fast/slow?
+- Missing words: did TTS skip content?
+
+### Audio Properties (ffprobe)
+
+```bash
+# Check if video has audio
+ffprobe -v error -show_streams -select_streams a VIDEO.mp4
+
+# Get duration
+ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 VIDEO.mp4
+```
+
+## TTS Script Optimization
+
+When preparing text for Kokoro TTS, apply these transforms:
+
+```python
+TTS_REPLACEMENTS = {
+    # Names — phonetic spelling
+    "Izack": "Eye-zack",
+    "Thorne": "Thorn",
+    "Pollyoneth": "Polly-oh-neth",
+    "Aethermoore": "Eether-more",
+    "SCBE": "S C B E",
+    "PHDM": "P H D M",
+
+    # Numbers — spell out
+    "12,596": "twelve thousand five hundred ninety six",
+    "1/12": "one of twelve",
+    "H(d,R)": "H of d comma R",
+    "R^(d²)": "R to the power of d squared",
+
+    # Acronyms — expand for speech
+    "AI": "A.I.",  # period forces pause
+    "API": "A.P.I.",
+    "TTS": "text to speech",
+    "FFT": "F.F.T.",
+    "ML": "machine learning",
+}
+```
+
+## Service Deployment Quick Reference
+
+### Revenue Services (Deploy First)
+
+| Service | Command | Revenue Model |
+|---|---|---|
+| **FastAPI governance API** | `uvicorn src.api.main:app --host 0.0.0.0 --port 8000` | API-as-a-service ($99/mo) |
+| **n8n workflow engine** | `n8n start` | Managed automation ($49/mo) |
+| **YouTube content** | `python scripts/publish/article_to_video.py` | Ad revenue + funnel |
+| **npm/PyPI packages** | `npm publish` / `pip install` | Developer adoption |
+| **Shopify store** | Already live at aethermore-works.myshopify.com | Digital products |
+
+### Deploy to Hetzner (Cheapest Production)
+
+```bash
+# From deploy/ directory
+docker compose -f docker-compose.prod.yml up -d
+
+# Or manual:
+ssh root@YOUR_VPS "cd /opt/scbe && git pull && docker compose up -d"
+```
+
+### Free Tier Options
+
+| Platform | Free Tier | Best For |
+|---|---|---|
+| Railway | $5/mo credit | API hosting |
+| Render | 750 hrs/mo | Static + API |
+| Fly.io | 3 shared VMs | Edge deployment |
+| Cloudflare Workers | 100k req/day | API gateway |
+| GitHub Pages | Unlimited | Docs/demos |
+| Vercel | Hobby tier | Frontend |
+
+## Competitive Intelligence
+
+### vs OpenClaw
+OpenClaw has: multi-channel gateway (WhatsApp, Telegram, Slack, Discord, Signal, iMessage, Teams, Matrix), `openclaw onboard` wizard, daemon management, doctor checks.
+
+SCBE advantage: 14-layer governance per action, Sacred Tongues tokenizer, training data generation from every interaction, patent pending.
+
+Gap to close: operator UX packaging, channel gateway breadth.
+
+### vs MoltbotDen
+MoltbotDen has: API-first agent network, public activity/intelligence surfaces, social growth loop, MCP endpoint.
+
+SCBE advantage: deeper security primitives, hyperbolic cost scaling, audit trail.
+
+Gap to close: public trust surfaces, agent marketplace.
+
+## Guardrails
+
+- Never include API keys or tokens in agent prompts
+- Always verify video has audio before uploading (ffprobe check)
+- Upload YouTube as UNLISTED first, verify, then flip to public
+- Cross-talk packets are append-only — never edit prior packets
+- When priming agents, err on the side of too much context rather than too little

--- a/.home/.agents/skills/scbe-ide/SKILL.md
+++ b/.home/.agents/skills/scbe-ide/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: scbe-ide
+description: Launch and operate the SCBE Codex IDE with Polly Pad workspaces, Hugging Face integration, crew collaboration, and governance zones. Use when opening or recovering the local web-based code editor.
+---
+
+# scbe-ide
+
+Launch the SCBE Codex IDE — a multi-AI collaborative code editor with Polly Pad workspaces, HuggingFace AI integration, crew collaboration, and SCBE governance zones.
+
+## When to use
+
+- User says `/ide`, "open ide", "launch ide", "start the editor"
+- User wants to open the web-based code editor
+- User wants multi-AI collaborative coding
+
+## Steps
+
+1. **Kill any existing IDE server** on port 3000:
+   ```bash
+   # Windows
+   taskkill /F /IM python.exe /FI "WINDOWTITLE eq Codex IDE*" 2>/dev/null || true
+   ```
+
+2. **Start the IDE server** pointing at the SCBE workspace:
+   ```bash
+   cd C:/Users/issda/Codex-ide
+   python server.py "C:/Users/issda/SCBE_Production_Pack_local" -p 3000 --no-open &
+   ```
+
+3. **Open in browser**:
+   ```bash
+   start http://127.0.0.1:3000
+   ```
+
+4. **Join as crew member** — POST to `/api/crew/join` with your identity:
+   ```bash
+   curl -s -X POST http://127.0.0.1:3000/api/crew/join \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Codex", "role": "Codex"}'
+   ```
+
+5. **Report status** to the user: IDE is running at http://127.0.0.1:3000 with crew collaboration active.
+
+## Features
+
+- **File Explorer**: Browse, create, edit, delete files
+- **Monaco Editor**: Syntax highlighting, minimap, themes
+- **Terminal**: Run shell commands (git, build, npm, pytest)
+- **AI Chat**: Talk to HuggingFace models for code help, review, generation
+- **Crew Panel**: See connected agents (human + AI), chat together
+- **Polly Pad Zones**: HOT (exploratory) / SAFE (execution) dual code zones with SCBE governance
+- **Search**: Full-text search across workspace
+
+## Architecture
+
+- **Backend**: `C:/Users/issda/Codex-ide/server.py` (Python, zero-dependency HTTP server)
+- **Frontend**: `C:/Users/issda/Codex-ide/index.html` (Monaco editor, single-file SPA)
+- **Polly Pads**: SQLite-backed pad lifecycle via `hydra/polly_pad.py`
+- **AI Providers**: HuggingFace Inference API (direct HTTP from browser, no server proxy needed)

--- a/.home/.agents/skills/scbe-youtube-factory/SKILL.md
+++ b/.home/.agents/skills/scbe-youtube-factory/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: scbe-youtube-factory
+description: Generate faceless narrated videos from SCBE articles and upload or iterate them for YouTube. Use when creating, previewing, improving, or publishing videos from article content.
+---
+
+# SCBE YouTube Factory
+
+Generate faceless narrated videos from SCBE articles and upload to YouTube, with iterative quality improvement.
+
+## When To Use
+
+- User wants to create YouTube videos from articles
+- User says "make a video", "youtube", "faceless video", "narrate this"
+- User wants to improve an existing video (voice, visuals, pacing)
+- Batch video generation for the channel
+
+## Pipeline
+
+```
+Article (markdown) → Parse → TTS (Kokoro am_adam) → Slides (Pillow) → FFmpeg → MP4 → YouTube Upload
+```
+
+## Pick Good Content
+
+Best articles for video (in order):
+1. **X threads** — already segmented into bite-size pieces, 2-4 min videos
+2. **Technical explainers** — GitHub Discussion articles about HYDRA, hyperbolic geometry, Sacred Tongues
+3. **Story content** — Everweave/Spiralverse lore, isekai story chapters
+4. **Tutorials** — how-to articles with code blocks (syntax highlighted slides)
+
+Use `hydra content review` to see QA-approved articles. Pick ones with score >= 80 and word count 200-2000.
+
+## Commands
+
+### Generate video
+```bash
+python scripts/publish/article_to_video.py --file content/articles/ARTICLE.md
+```
+
+### Change voice
+```bash
+# Kokoro voices (local, high quality, FREE)
+--voice kokoro:am_adam        # male, natural (DEFAULT)
+--voice kokoro:am_michael     # male, deeper
+--voice kokoro:bm_george      # British male
+--voice kokoro:af_heart       # female, warm
+--voice kokoro:bf_emma        # British female
+
+# Edge-TTS voices (cloud, free, unlimited)
+--voice en-US-AndrewMultilingualNeural   # warm, confident male
+--voice en-US-ChristopherNeural          # authoritative male
+--voice en-GB-RyanNeural                 # British male
+```
+
+### Preview without generating
+```bash
+python scripts/publish/article_to_video.py --file ARTICLE.md --dry-run
+```
+
+### Generate thumbnail only
+```bash
+python scripts/publish/article_to_video.py --file ARTICLE.md --thumbnail-only
+```
+
+### Upload to YouTube
+```bash
+# First time: authenticate
+python scripts/publish/post_to_youtube.py --auth
+
+# Upload (unlisted by default — safe for iteration)
+python scripts/publish/post_to_youtube.py \
+  --file artifacts/youtube/VIDEO.mp4 \
+  --title "Video Title" \
+  --article content/articles/ARTICLE.md \
+  --tags "AI Safety,SCBE,Issac Daniel Davis" \
+  --privacy unlisted
+
+# Make public when happy
+python scripts/publish/post_to_youtube.py \
+  --file artifacts/youtube/VIDEO.mp4 \
+  --title "Video Title" \
+  --privacy public
+```
+
+### Batch generate
+```bash
+# Generate videos for all approved articles
+for f in content/articles/x_thread_*.md; do
+  python scripts/publish/article_to_video.py --file "$f"
+done
+```
+
+## Iteration Loop
+
+1. Generate → upload unlisted → user watches
+2. User gives feedback ("too fast", "voice weird on segment 3", "add more pauses")
+3. Adjust (voice, speed, segment splitting, slide design)
+4. Regenerate → re-upload unlisted
+5. Repeat until quality is good
+6. Flip to public
+
+## Video Output Location
+
+- Videos: `artifacts/youtube/*.mp4`
+- Thumbnails: `artifacts/youtube/*.thumb.png`
+- Evidence: `artifacts/publish_browser/youtube_*.json`
+
+## Dependencies
+
+```bash
+pip install kokoro-onnx soundfile edge-tts pillow pygments
+# FFmpeg must be on PATH (installed via: winget install Gyan.FFmpeg)
+# Kokoro model files in repo root: kokoro-v1.0.onnx, voices-v1.0.bin
+```
+
+## YouTube Channel
+
+- Channel: Issac "Izreal" Davis (@id8461)
+- Channel ID: UCO9aJ-ZH0Ddg_F0Dr655WIQ
+- OAuth tokens: config/connector_oauth/.youtube_tokens.json
+- Note: Refresh tokens expire every 7 days in Testing mode. Re-auth with --auth when needed.
+- Custom thumbnails need channel phone verification.
+
+## Future Improvements
+
+- Manhwa/comic panel visuals (Canva/Firefly API)
+- Manim math animations for geometry content
+- Podcastfy 2-host conversation format
+- Background music (royalty-free, mixed low)
+- SRT subtitles burned into video
+- Animated code typing effect
+- Chapter markers in YouTube description
+
+## Guardrails
+
+- Always upload as UNLISTED first
+- Never auto-publish to public without user approval
+- Credit "Issac Daniel Davis" (ISSAC with two S's) in all descriptions
+- Include SCBE-AETHERMOORE GitHub link in every video description


### PR DESCRIPTION
## Summary
- adds valid YAML frontmatter to three local agent skills that Codex skipped at startup
- preserves the existing skill bodies and instructions
- fixes startup warnings for `scbe-agent-priming`, `scbe-ide`, and `scbe-youtube-factory`

## Test Evidence
- frontmatter regex validation passed for all three `SKILL.md` files
- `git diff --cached --check`
- scoped secret-pattern scan found only instructional references to tokens, not credential values

## Rollback
- Revert this PR to remove these local skill files from the repo again.