### PR TITLE
fix+feat(wildlife): HF Router UA, harvester filter, classifier rule order, triage aggregator

### DIFF
--- a/scripts/wildlife/dispatch.py
+++ b/scripts/wildlife/dispatch.py
@@ -61,44 +61,60 @@ def _take_topn(animals: list[dict], n: int) -> list[dict]:
     return sorted(animals, key=lambda a: a.get("liberties", 99))[:n]
 
 
-def call_ollama(model: str, prompt: str, base_url: str, timeout: int) -> dict:
+def call_ollama(model: str, prompt: str, base_url: str, timeout: int, retries: int = 3) -> dict:
     """One-shot completion against local Ollama HTTP API.
 
     `num_ctx` is held small so KV cache fits on consumer GPUs (6 GB VRAM
     can't hold the default 8 K context for a 1.5B model + prompt).
     `num_predict` caps reply length so a stuck model can't burn the
-    whole timeout.
+    whole timeout. `keep_alive` keeps the model resident between calls
+    so a sustained sweep doesn't pay the load cost on every request.
+    Transient 5xx (Ollama runner restart / brief OOM) is retried with
+    backoff before giving up.
     """
     body = json.dumps(
         {
             "model": model,
             "prompt": prompt,
             "stream": False,
+            "keep_alive": "5m",
             "options": {"num_ctx": 1024, "num_predict": 220},
         }
     ).encode("utf-8")
-    req = urllib.request.Request(
-        url=base_url.rstrip("/") + "/api/generate",
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            data = json.loads(resp.read().decode("utf-8", errors="ignore"))
-            return {
-                "ok": True,
-                "model": model,
-                "backend": "ollama",
-                "response": (data.get("response") or "").strip()[:1000],
-            }
-    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError) as exc:
-        return {
-            "ok": False,
-            "model": model,
-            "backend": "ollama",
-            "error": f"{type(exc).__name__}: {exc}"[:200],
-        }
+    last_exc: Exception | None = None
+    for attempt in range(retries):
+        req = urllib.request.Request(
+            url=base_url.rstrip("/") + "/api/generate",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode("utf-8", errors="ignore"))
+                return {
+                    "ok": True,
+                    "model": model,
+                    "backend": "ollama",
+                    "response": (data.get("response") or "").strip()[:1000],
+                    "attempts": attempt + 1,
+                }
+        except urllib.error.HTTPError as exc:
+            last_exc = exc
+            if exc.code in {500, 502, 503, 504} and attempt < retries - 1:
+                time.sleep(1.5 * (attempt + 1))
+                continue
+            break
+        except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+            last_exc = exc
+            break
+    return {
+        "ok": False,
+        "model": model,
+        "backend": "ollama",
+        "error": f"{type(last_exc).__name__}: {last_exc}"[:200],
+        "attempts": retries,
+    }
 
 
 def call_hf_router(model: str, prompt: str, token: str, timeout: int) -> dict:

--- a/scripts/wildlife/dispatch.py
+++ b/scripts/wildlife/dispatch.py
@@ -133,6 +133,9 @@ def call_hf_router(model: str, prompt: str, token: str, timeout: int) -> dict:
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bearer {token}",
+            # Cloudflare in front of router.huggingface.co 403s the default
+            # `Python-urllib/3.x` UA; send a normal one.
+            "User-Agent": "scbe-wildlife-dispatch/1.0",
         },
         method="POST",
     )

--- a/scripts/wildlife/harvest_packs.py
+++ b/scripts/wildlife/harvest_packs.py
@@ -48,9 +48,24 @@ SKIP_DIRS = (
     "external",
     ".home",
     ".scbe",
+    # vendored / cached / generated content — TODOs in here aren't ours
+    # to triage and flooded the crow pack with 195 third-party comments
+    "artifacts",
+    "training-data",
+    "training_data",
+    "training",
+    ".cache",
+    ".next",
+    "site-packages",
     "rust/scbe_core/target",
     "scbe-visual-system/node_modules",
     "kindle-app/node_modules",
+    # vendored repos
+    "unsloth",
+    "_external",
+    "vendored",
+    "third_party",
+    "third-party",
 )
 
 
@@ -180,13 +195,20 @@ def _walk_source_files(root: Path) -> list[Path]:
 
     A naive `root.glob('**/*.py')` walks every directory including
     node_modules and external/ before filtering, which is many seconds on
-    this repo.
+    this repo. Match SKIP_DIRS by exact name OR prefix so e.g.
+    `unsloth_compiled_cache/` is pruned by the `unsloth` entry.
     """
     out: list[Path] = []
-    skip = set(SKIP_DIRS)
+    skip = tuple(SKIP_DIRS)
+
+    def _pruned(d: str) -> bool:
+        if d.startswith(".") or d.startswith("_"):
+            return True
+        return any(d == s or d.startswith(s + "_") or d.startswith(s + "-") for s in skip)
+
     for dirpath, dirnames, filenames in os.walk(root, topdown=True):
         # Prune in place — must mutate dirnames so os.walk skips them
-        dirnames[:] = [d for d in dirnames if d not in skip and not d.startswith(".")]
+        dirnames[:] = [d for d in dirnames if not _pruned(d)]
         for name in filenames:
             ext = os.path.splitext(name)[1]
             if ext not in _SOURCE_EXTS:

--- a/scripts/wildlife/shepherds.py
+++ b/scripts/wildlife/shepherds.py
@@ -48,7 +48,7 @@ SHEPHERDS: dict[str, Shepherd] = {
     "SHEEP": Shepherd(
         pack="SHEEP",
         backend="ollama",
-        model="qwen2.5-coder:1.5b",
+        model="qwen2.5-coder:0.5b",
         bus_dispatch=False,  # bulk trivial: bypass bus, batch directly
         prompt_template=(
             "One-line action for this trivial chore (dependabot/format/lint): "
@@ -59,7 +59,7 @@ SHEPHERDS: dict[str, Shepherd] = {
     "CROW": Shepherd(
         pack="CROW",
         backend="ollama",
-        model="qwen2.5-coder:1.5b",
+        model="qwen2.5-coder:0.5b",
         bus_dispatch=False,
         prompt_template=(
             "TODO/FIXME comment to triage: {title}. Reply with one of: "


### PR DESCRIPTION
## Summary

Two follow-ups from the first live taming session.

**1. HF Router was 403-ing every request.** Cloudflare in front of `router.huggingface.co` rejects the default `Python-urllib/3.x` User-Agent. Setting `User-Agent: scbe-wildlife-dispatch/1.0` unblocks wolves/goats/cats — 3/3 wolves came back with usable replies (root cause + file + regression test) on retry:

```
> workflow failed: CI
  (1) Likely root cause: Configuration error in the CI script.
  (2) File most likely to need editing: .github/workflows/ci.yml.
  (3) Regression test: Validate the updated CI configuration passes all tests.
```

**2. Harvester pulled 195 crows from vendored / cached / training dirs** (`unsloth_compiled_cache/`, `artifacts/`, `training-data/`, etc.) — those TODOs aren't ours to triage. Added them to SKIP_DIRS, made the prune predicate also drop dirs starting with `_`, and switched to exact-name OR `<name>_` / `<name>-` prefix matching so `unsloth_compiled_cache/` is pruned by the `unsloth` entry. Crow count drops from **195 → 60**, all from real source (`scripts/`, `src/`, `tests/`, ...).

## Note on triage quality

The 0.5B coder model used for crows reliably loads on 6 GB VRAM (the goal of #1546) but biases hard — 60/60 replies came back as some variant of DELETE. Pipeline is end-to-end functional (no failures, ~1s per call); triage quality needs a 3B-class model or option-order rotation in the prompt. Tracked as follow-up.

## Test plan

- [x] `PYTHONPATH=. python -m pytest tests/wildlife/ -q` → 38/38
- [x] `python scripts/wildlife/dispatch.py --pack wolves --execute --max 3` → 3/3 ok via HF Router
- [x] `python scripts/wildlife/dispatch.py --pack crows --execute --max 60` → 60/60 ok via local Ollama
- [x] Re-harvest produces 60 crows from real source dirs (down from 195)

🤖 Generated with [Claude Code](https://claude.com/claude-code)