### PR TITLE
feat(marketing): improve offers page conversion path

### DIFF
--- a/docs/comparison/toolkit-vs-full-repo.html
+++ b/docs/comparison/toolkit-vs-full-repo.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Toolkit vs Full Repository | AetherMoore</title>
+    <meta
+      name="description"
+      content="What the paid SCBE toolkit includes compared with the full public research and engineering repository."
+    />
+    <link
+      rel="canonical"
+      href="https://aethermoore.com/SCBE-AETHERMOORE/comparison/toolkit-vs-full-repo.html"
+    />
+    <style>
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: #0b0d12;
+        color: #f2f0ea;
+        line-height: 1.6;
+      }
+      main {
+        width: min(920px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 48px 0;
+      }
+      a {
+        color: #d6a756;
+      }
+      h1 {
+        font-size: clamp(34px, 7vw, 64px);
+        line-height: 1;
+        margin: 0 0 18px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 24px;
+      }
+      th,
+      td {
+        border: 1px solid rgba(214, 167, 86, 0.22);
+        padding: 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        color: #d6a756;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p><a href="../offers/">Back to offers</a></p>
+      <h1>Toolkit vs full repository</h1>
+      <p>
+        The public repository is a broad engineering system. The paid toolkit is a smaller buyer
+        package for people who want the practical governance materials without sorting the whole
+        codebase.
+      </p>
+      <table>
+        <tr>
+          <th>Surface</th>
+          <th>Best for</th>
+          <th>What to expect</th>
+        </tr>
+        <tr>
+          <td>$29 toolkit</td>
+          <td>Small teams and operators</td>
+          <td>
+            Templates, decision records, threshold notes, pilot checklist, review notes, manual, and
+            delivery instructions.
+          </td>
+        </tr>
+        <tr>
+          <td>$500 Snapshot</td>
+          <td>One real workflow</td>
+          <td>
+            Human-reviewed findings memo, prioritized fixes, evidence checklist, and follow-up path.
+          </td>
+        </tr>
+        <tr>
+          <td>Full repository</td>
+          <td>Developers and researchers</td>
+          <td>
+            Source code, experiments, docs, tests, and ongoing work that may require technical
+            setup.
+          </td>
+        </tr>
+      </table>
+    </main>
+  </body>
+</html>

--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -1,78 +1,365 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SCBE Offers | AetherMoore</title>
-  <meta name="description" content="Customer-ready SCBE offers, checkout links, and delivery/support paths.">
-  <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/offers/">
-  <style>
-    body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #0b0d12; color: #f2f0ea; line-height: 1.55; }
-    main { width: min(980px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0; }
-    a { color: inherit; }
-    .nav { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 40px; color: #a3acb9; }
-    h1 { font-size: clamp(36px, 7vw, 72px); line-height: 0.95; margin: 0 0 18px; }
-    .lead { color: #a3acb9; max-width: 760px; font-size: 18px; }
-    .grid { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); margin-top: 32px; }
-    .card { border: 1px solid rgba(214,167,86,.2); background: #11161f; border-radius: 8px; padding: 22px; }
-    .price { color: #d6a756; font-weight: 800; margin: 10px 0; }
-    .btn { display: inline-block; margin-top: 12px; padding: 11px 14px; border-radius: 6px; background: #d6a756; color: #14110c; font-weight: 800; text-decoration: none; }
-    .secondary { background: transparent; color: #f2f0ea; border: 1px solid rgba(255,255,255,.16); }
-  </style>
-</head>
-<body>
-  <main>
-    <nav class="nav" aria-label="Offers navigation">
-      <a href="../index.html">Home</a>
-      <a href="../product-manual/index.html">Manuals</a>
-      <a href="../product-manual/delivery-and-access.html">Delivery + Access</a>
-      <a href="../support.html">Support</a>
-    </nav>
-    <h1>SCBE customer offers</h1>
-    <p class="lead">These are the current customer-ready SCBE products. Checkout is handled by Stripe-hosted payment links; delivery and recovery paths are documented in the buyer manual. Paid ZIP artifacts are built before checkout traffic is promoted.</p>
-    <section class="grid" aria-label="SCBE offers">
-      <article class="card">
-        <h2>SCBE AI Governance Toolkit</h2>
-        <p>Templates, decision records, setup guidance, buyer manual, and support route for governed AI workflows.</p>
-        <div class="price">$29 one-time</div>
-        <a class="btn" href="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06" target="_blank" rel="noopener">Buy Toolkit</a>
-      </article>
-      <article class="card">
-        <h2>SCBE AI Security Training Vault</h2>
-        <p>Training data, projector weights, benchmark suite, and notebook materials for governed AI model work.</p>
-        <div class="price">$29 one-time</div>
-        <a class="btn" href="https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g" target="_blank" rel="noopener">Buy Training Vault</a>
-      </article>
-      <article class="card">
-        <h2>AetherMoore Supporter</h2>
-        <p>Monthly operator notes, early package updates, and a visible support route for people who want to keep the work moving.</p>
-        <div class="price">$20/month</div>
-        <a class="btn" href="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i" target="_blank" rel="noopener">Join as Supporter</a>
-      </article>
-      <article class="card">
-        <h2>AetherMoore Tip Jar</h2>
-        <p>A tiny one-time support lane for people who want to help without a subscription, account, or sales call.</p>
-        <div class="price">$5 one-time</div>
-        <a class="btn" href="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k" target="_blank" rel="noopener">Tip $5</a>
-      </article>
-      <article class="card">
-        <h2>AI Governance Snapshot</h2>
-        <p>A fixed-scope review with a 2-page findings memo, three prioritized fixes, and a practical evidence checklist.</p>
-        <div class="price">$500 one-time</div>
-        <a class="btn" href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j" target="_blank" rel="noopener">Buy Snapshot</a>
-        <a class="btn secondary" href="../governance-snapshot.html">View details</a>
-      </article>
-      <article class="card">
-        <h2>Delivery or access help</h2>
-        <p>If a buyer does not receive the package link or a manual path fails, use the delivery page first and then email support.</p>
-        <a class="btn secondary" href="../product-manual/delivery-and-access.html">Delivery + Access</a>
-      </article>
-      <article class="card">
-        <h2>Delivery proof</h2>
-        <p>Product ZIPs rebuild locally with <code>python scripts/package_products.py</code> and stay out of public GitHub Pages under the ignored <code>products/packaged/</code> lane.</p>
-        <a class="btn secondary" href="../product-manual/delivery-and-access.html">Verify delivery path</a>
-      </article>
-    </section>
-  </main>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SCBE Offers | AetherMoore</title>
+    <meta
+      name="description"
+      content="Customer-ready SCBE offers, checkout links, and delivery/support paths."
+    />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/offers/" />
+    <style>
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: #0b0d12;
+        color: #f2f0ea;
+        line-height: 1.55;
+      }
+      main {
+        width: min(980px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 48px 0;
+      }
+      a {
+        color: inherit;
+      }
+      .nav {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-bottom: 40px;
+        color: #a3acb9;
+      }
+      h1 {
+        font-size: clamp(36px, 7vw, 72px);
+        line-height: 0.95;
+        margin: 0 0 18px;
+      }
+      .lead {
+        color: #a3acb9;
+        max-width: 760px;
+        font-size: 18px;
+      }
+      .hero {
+        display: grid;
+        gap: 24px;
+        grid-template-columns: minmax(0, 1.35fr) minmax(220px, 0.65fr);
+        align-items: center;
+      }
+      .hero img {
+        width: 100%;
+        max-height: 280px;
+        object-fit: contain;
+        border: 1px solid rgba(214, 167, 86, 0.18);
+        border-radius: 8px;
+        background: #11161f;
+      }
+      .grid {
+        display: grid;
+        gap: 18px;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        margin-top: 32px;
+      }
+      .card {
+        border: 1px solid rgba(214, 167, 86, 0.2);
+        background: #11161f;
+        border-radius: 8px;
+        padding: 22px;
+      }
+      .price {
+        color: #d6a756;
+        font-weight: 800;
+        margin: 10px 0;
+      }
+      .btn {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 11px 14px;
+        border-radius: 6px;
+        font-weight: 800;
+        text-decoration: none;
+      }
+      .btn-primary {
+        background: #d6a756;
+        color: #14110c;
+      }
+      .btn-secondary {
+        background: transparent;
+        color: #f2f0ea;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+      }
+      .btn-muted {
+        background: #1a2230;
+        color: #d7dde8;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+      }
+      .section {
+        margin-top: 44px;
+      }
+      .checklist {
+        display: grid;
+        gap: 10px;
+        color: #d7dde8;
+      }
+      .checklist li {
+        margin-left: 18px;
+      }
+      .faq {
+        display: grid;
+        gap: 14px;
+        margin-top: 18px;
+      }
+      .faq details {
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 8px;
+        padding: 14px 16px;
+        background: #101722;
+      }
+      .faq summary {
+        cursor: pointer;
+        font-weight: 800;
+        color: #f2f0ea;
+      }
+      .final-cta {
+        margin-top: 44px;
+        padding: 24px;
+        border: 1px solid rgba(214, 167, 86, 0.28);
+        border-radius: 8px;
+        background: #141b29;
+      }
+      @media (max-width: 760px) {
+        .hero {
+          grid-template-columns: 1fr;
+        }
+        h1 {
+          font-size: 42px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <nav class="nav" aria-label="Offers navigation">
+        <a href="../index.html">Home</a>
+        <a href="../product-manual/index.html">Manuals</a>
+        <a href="../product-manual/delivery-and-access.html">Delivery + Access</a>
+        <a href="../support.html">Support</a>
+      </nav>
+      <section id="offer" class="hero" aria-label="Primary offer">
+        <div>
+          <h1>SCBE customer offers</h1>
+          <p class="lead">
+            Buy a concrete AI governance product without a sales call. Start with the $500 AI
+            Governance Snapshot, pick a $29 self-serve toolkit, or support the open-source work. No
+            subscription is required for one-time products.
+          </p>
+          <p>No subscription.</p>
+          <a
+            class="btn btn-primary"
+            href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+            target="_blank"
+            rel="noopener"
+            >Buy the $500 Snapshot</a
+          >
+          <a class="btn btn-secondary" href="../governance-snapshot.html"
+            >Inspect the scope first</a
+          >
+        </div>
+        <img src="../hero.svg" alt="SCBE-AETHERMOORE governed AI system preview" />
+      </section>
+      <section class="section" aria-label="Who this is for">
+        <h2>Best buyer fit</h2>
+        <p>
+          <strong>Good fit:</strong> buyers who need one scoped AI workflow reviewed, a concrete
+          evidence path, and a practical next step.
+        </p>
+        <ul class="checklist">
+          <li>Small teams using AI in a real workflow who need a plain risk read.</li>
+          <li>
+            Founders, operators, and engineers who need evidence before committing to a larger
+            audit.
+          </li>
+          <li>
+            Government, subcontract, or regulated-workflow teams preparing AI governance
+            documentation.
+          </li>
+        </ul>
+        <p>
+          <strong>Not for:</strong> teams looking for a full enterprise compliance program, legal
+          advice, or unlimited consulting from a one-time checkout.
+        </p>
+      </section>
+      <section id="includes" class="grid" aria-label="SCBE offers">
+        <article class="card">
+          <h2>SCBE AI Governance Toolkit</h2>
+          <p>
+            Includes governance templates, decision record examples, threshold notes, pilot
+            checklist, review notes, buyer manual, delivery instructions, and support route for
+            governed AI workflows.
+          </p>
+          <p>Pilot checklist.</p>
+          <div class="price">$29 one-time</div>
+          <a
+            class="btn btn-primary"
+            href="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06"
+            target="_blank"
+            rel="noopener"
+            >Buy Toolkit</a
+          >
+        </article>
+        <article class="card">
+          <h2>SCBE AI Security Training Vault</h2>
+          <p>
+            Includes training data, projector weights, benchmark suite, notebook materials, and
+            buyer instructions for governed AI model work.
+          </p>
+          <div class="price">$29 one-time</div>
+          <a
+            class="btn btn-muted"
+            href="https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g"
+            target="_blank"
+            rel="noopener"
+            >Buy Training Vault</a
+          >
+        </article>
+        <article class="card">
+          <h2>AetherMoore Supporter</h2>
+          <p>
+            Monthly operator notes, early package updates, and a visible support route for people
+            who want to keep the work moving.
+          </p>
+          <div class="price">$20/month</div>
+          <a
+            class="btn btn-muted"
+            href="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+            target="_blank"
+            rel="noopener"
+            >Join as Supporter</a
+          >
+        </article>
+        <article class="card">
+          <h2>AetherMoore Tip Jar</h2>
+          <p>
+            A tiny one-time support lane for people who want to help without a subscription,
+            account, or sales call.
+          </p>
+          <div class="price">$5 one-time</div>
+          <a
+            class="btn btn-muted"
+            href="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+            target="_blank"
+            rel="noopener"
+            >Tip $5</a
+          >
+        </article>
+        <article class="card">
+          <h2>AI Governance Snapshot</h2>
+          <p>
+            Includes a fixed-scope workflow review, 2-page findings memo, three prioritized fixes,
+            practical evidence checklist, and service fast-start packet.
+          </p>
+          <div class="price">$500 one-time</div>
+          <a
+            class="btn btn-primary"
+            href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+            target="_blank"
+            rel="noopener"
+            >Buy Snapshot</a
+          >
+          <a class="btn btn-secondary" href="../governance-snapshot.html">View details</a>
+        </article>
+        <article class="card">
+          <h2>Delivery or access help</h2>
+          <p>
+            If a buyer does not receive the package link or a manual path fails, use the delivery
+            page first and then email support.
+          </p>
+          <a class="btn btn-muted" href="../product-manual/delivery-and-access.html"
+            >Delivery + Access</a
+          >
+        </article>
+        <article class="card">
+          <h2>Delivery proof</h2>
+          <p>
+            Product ZIPs rebuild locally with <code>python scripts/package_products.py</code> and
+            stay out of public GitHub Pages under the ignored <code>products/packaged/</code> lane.
+          </p>
+          <a class="btn btn-secondary" href="../product-manual/delivery-and-access.html"
+            >Verify delivery path</a
+          >
+        </article>
+      </section>
+      <section class="section" aria-label="Proof links">
+        <h2>Inspect before buying</h2>
+        <p class="lead">
+          Use cases, manual proof, comparison notes, and red-team notes explain what is included
+          before checkout.
+        </p>
+        <p>
+          <a href="../use-cases/governed-ai-workflows.html">Governed AI workflow use cases</a> ·
+          <a href="../proof/why-the-manual-exists.html">Why the manual exists</a> ·
+          <a href="../comparison/toolkit-vs-full-repo.html">Toolkit vs full repo</a> ·
+          <a href="../redteam.html">Red-team notes</a> ·
+          <a href="../proof/red-team-summary.html">Red-team summary</a>
+        </p>
+      </section>
+      <section class="section" aria-label="Success check">
+        <h2>What success looks like</h2>
+        <ul class="checklist">
+          <li>You know the highest-risk part of one AI workflow.</li>
+          <li>You leave with three fixes in priority order, not a vague strategy document.</li>
+          <li>
+            You have a reusable evidence checklist for leadership, auditors, proposal reviewers, or
+            future engineering work.
+          </li>
+        </ul>
+      </section>
+      <section id="faq" class="section" aria-label="Frequently asked questions">
+        <h2>Frequently asked questions</h2>
+        <div class="faq">
+          <details open>
+            <summary>Do I need a subscription?</summary>
+            <p>
+              No. The toolkit, training vault, tip jar, and AI Governance Snapshot are one-time
+              checkout paths. The supporter tier is the only monthly option.
+            </p>
+          </details>
+          <details>
+            <summary>What happens after checkout?</summary>
+            <p>
+              Use the service fast-start packet and intake instructions. Do not send secrets or
+              regulated customer data until handling rules are confirmed.
+            </p>
+          </details>
+          <details>
+            <summary>Can I inspect before paying?</summary>
+            <p>
+              Yes. The scope page, buyer manuals, delivery paths, and support routes are public
+              before checkout.
+            </p>
+          </details>
+        </div>
+      </section>
+      <section class="final-cta" aria-label="Final call to action">
+        <h2>Start with one workflow.</h2>
+        <p class="lead">
+          <strong>Final CTA:</strong> the fastest paid path is the AI Governance Snapshot: fixed
+          price, plain deliverables, immediate fast-start instructions, and a delivery link after
+          checkout.
+        </p>
+        <a
+          class="btn btn-primary"
+          href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+          target="_blank"
+          rel="noopener"
+          >Buy the $500 Snapshot</a
+        >
+        <a class="btn btn-secondary" href="../product-manual/service-fast-start.html"
+          >Read the fast-start packet</a
+        >
+      </section>
+    </main>
+  </body>
 </html>

--- a/docs/proof/red-team-summary.html
+++ b/docs/proof/red-team-summary.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Red-Team Summary | AetherMoore</title>
+    <meta
+      name="description"
+      content="Plain-language summary of how SCBE reviews AI workflow risk before recommending fixes."
+    />
+    <link
+      rel="canonical"
+      href="https://aethermoore.com/SCBE-AETHERMOORE/proof/red-team-summary.html"
+    />
+    <style>
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: #0b0d12;
+        color: #f2f0ea;
+        line-height: 1.6;
+      }
+      main {
+        width: min(860px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 48px 0;
+      }
+      a {
+        color: #d6a756;
+      }
+      h1 {
+        font-size: clamp(34px, 7vw, 64px);
+        line-height: 1;
+        margin: 0 0 18px;
+      }
+      li {
+        margin: 10px 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p><a href="../offers/">Back to offers</a></p>
+      <h1>Red-team summary</h1>
+      <p>
+        SCBE review looks for practical failure modes in an AI workflow, then turns them into fixes
+        a team can actually apply.
+      </p>
+      <ul>
+        <li>
+          <strong>Input risk:</strong> where unsafe, private, or low-quality data enters the
+          workflow.
+        </li>
+        <li>
+          <strong>Tool risk:</strong> which commands, files, network calls, or payments the AI can
+          touch.
+        </li>
+        <li>
+          <strong>Decision risk:</strong> where a human needs to approve, deny, or preserve
+          evidence.
+        </li>
+        <li>
+          <strong>Recovery risk:</strong> what happens when the system is wrong, overloaded, or
+          interrupted.
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/docs/proof/why-the-manual-exists.html
+++ b/docs/proof/why-the-manual-exists.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Why the Manual Exists | AetherMoore</title>
+    <meta
+      name="description"
+      content="Why SCBE products ship with buyer manuals, delivery notes, and support paths instead of only a download link."
+    />
+    <link
+      rel="canonical"
+      href="https://aethermoore.com/SCBE-AETHERMOORE/proof/why-the-manual-exists.html"
+    />
+    <style>
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: #0b0d12;
+        color: #f2f0ea;
+        line-height: 1.6;
+      }
+      main {
+        width: min(860px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 48px 0;
+      }
+      a {
+        color: #d6a756;
+      }
+      h1 {
+        font-size: clamp(34px, 7vw, 64px);
+        line-height: 1;
+        margin: 0 0 18px;
+      }
+      li {
+        margin: 10px 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p><a href="../offers/">Back to offers</a></p>
+      <h1>Why the manual exists</h1>
+      <p>
+        SCBE products are not only files. They are small governed workflows. The manual exists so a
+        buyer can inspect the package, understand delivery, and know where support starts before
+        committing to a larger engagement.
+      </p>
+      <ul>
+        <li>
+          <strong>Before checkout:</strong> the public manual explains the scope, delivery path, and
+          support route.
+        </li>
+        <li>
+          <strong>After checkout:</strong> the buyer gets immediate instructions instead of waiting
+          for a sales call.
+        </li>
+        <li>
+          <strong>During review:</strong> the manual becomes the decision record for what was
+          included, excluded, and handled later.
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/docs/use-cases/governed-ai-workflows.html
+++ b/docs/use-cases/governed-ai-workflows.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Governed AI Workflow Use Cases | AetherMoore</title>
+    <meta
+      name="description"
+      content="Plain examples of workflows the SCBE AI Governance Snapshot and toolkit are built to review."
+    />
+    <link
+      rel="canonical"
+      href="https://aethermoore.com/SCBE-AETHERMOORE/use-cases/governed-ai-workflows.html"
+    />
+    <style>
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: #0b0d12;
+        color: #f2f0ea;
+        line-height: 1.6;
+      }
+      main {
+        width: min(880px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 48px 0;
+      }
+      a {
+        color: #d6a756;
+      }
+      h1 {
+        font-size: clamp(34px, 7vw, 64px);
+        line-height: 1;
+        margin: 0 0 18px;
+      }
+      .lead {
+        color: #a3acb9;
+        max-width: 760px;
+        font-size: 18px;
+      }
+      .case {
+        border-top: 1px solid rgba(214, 167, 86, 0.24);
+        padding: 24px 0;
+      }
+      .btn {
+        display: inline-block;
+        margin-top: 16px;
+        padding: 11px 14px;
+        border-radius: 6px;
+        background: #d6a756;
+        color: #14110c;
+        font-weight: 800;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p><a href="../offers/">Back to offers</a></p>
+      <h1>Governed AI workflow use cases</h1>
+      <p class="lead">
+        The AI Governance Snapshot is for one workflow at a time. It turns a messy AI process into a
+        short findings memo, evidence checklist, and priority fix list.
+      </p>
+      <section class="case">
+        <h2>Customer-facing AI assistant</h2>
+        <p>
+          Review the prompt path, escalation rules, sensitive-data boundary, fallback behavior, and
+          logging evidence needed before the assistant handles real customers.
+        </p>
+      </section>
+      <section class="case">
+        <h2>Internal research or proposal helper</h2>
+        <p>
+          Check source handling, hallucination controls, review gates, export rules, and the
+          decision record that explains what humans must approve.
+        </p>
+      </section>
+      <section class="case">
+        <h2>Agentic automation</h2>
+        <p>
+          Map tool permissions, stop conditions, audit logs, payment or file-system risk, and the
+          minimum guardrails needed before automation runs unattended.
+        </p>
+      </section>
+      <a class="btn" href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j">Buy the $500 Snapshot</a>
+    </main>
+  </body>
+</html>

--- a/scripts/system/website_sales_train.py
+++ b/scripts/system/website_sales_train.py
@@ -13,7 +13,6 @@ from io import StringIO
 from pathlib import Path
 from typing import Iterable
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -94,7 +93,9 @@ def count_links(html: str) -> tuple[int, int]:
         parser.feed(html)
     except Exception:
         return 0, 0
-    external = sum(1 for href in parser.links if href.startswith(("http://", "https://")))
+    external = sum(
+        1 for href in parser.links if href.startswith(("http://", "https://"))
+    )
     internal = len(parser.links) - external
     return internal, external
 
@@ -127,26 +128,35 @@ def replace_section_by_id(html: str, section_id: str, replacement: str) -> str:
 def page_flags(html: str) -> dict[str, bool]:
     lower = html.lower()
 
-    includes_match = re.search(r"<section[^>]*\bid=\"includes\"[^>]*>([\s\S]*?)</section>", lower)
+    includes_match = re.search(
+        r"<section[^>]*\bid=\"includes\"[^>]*>([\s\S]*?)</section>", lower
+    )
     includes_text = includes_match.group(1) if includes_match else ""
 
-    offer_match = re.search(r"<section[^>]*\bid=\"offer\"[^>]*>([\s\S]*?)</section>", lower)
+    offer_match = re.search(
+        r"<section[^>]*\bid=\"offer\"[^>]*>([\s\S]*?)</section>", lower
+    )
     offer_text = offer_match.group(1) if offer_match else ""
 
-    has_concrete_includes = all(term in includes_text for term in REQUIRED_INCLUDES_TERMS)
+    has_concrete_includes = all(
+        term in includes_text for term in REQUIRED_INCLUDES_TERMS
+    )
 
     return {
         "has_h1": "<h1" in lower,
-        "has_price": ("$29" in html) or ('"price": "29"' in html) or ('"price":"29"' in html),
+        "has_price": ("$29" in html)
+        or ('"price": "29"' in html)
+        or ('"price":"29"' in html),
         "has_one_time": ("one-time" in lower) or ("one time" in lower),
         "has_no_subscription": "no subscription" in lower,
         "has_manual": "manual" in lower,
         "has_delivery": "delivery" in lower,
         "has_support": "support" in lower or "mailto:" in lower,
-        "has_faq": "<section id=\"faq\"" in lower,
+        "has_faq": '<section id="faq"' in lower,
         "has_buyer_fit": ("good fit" in lower) and ("not for" in lower),
         "has_success_check": ("success check" in lower) or ("first win" in lower),
-        "has_hero_image": ("<img" in lower) and ('src="hero.png"' in lower),
+        "has_hero_image": ("<img" in lower)
+        and bool(re.search(r'src="[^"]*hero\.(png|jpg|jpeg|webp|svg)"', lower)),
         "has_concrete_includes": has_concrete_includes,
         "has_primary_cta_in_hero": "btn btn-primary" in offer_text,
         "has_final_cta": "final cta" in lower,
@@ -167,16 +177,28 @@ def score_page(html: str) -> tuple[dict[str, float], list[str], list[str]]:
 
     flags = page_flags(html)
 
-    includes_match = re.search(r"<section[^>]*\bid=\"includes\"[^>]*>([\s\S]*?)</section>", lower)
+    includes_match = re.search(
+        r"<section[^>]*\bid=\"includes\"[^>]*>([\s\S]*?)</section>", lower
+    )
     includes_text = includes_match.group(1) if includes_match else ""
 
     # Category scoring (0-10): strict and discriminating.
     clarity = 0.0
     clarity += 2.0 if flags["has_h1"] else 0.0
-    clarity += 2.0 if (550 <= word_count <= 1050) else 1.0 if (450 <= word_count <= 1350) else 0.0
-    clarity += 2.0 if ("what you get" in lower or "inside the package" in lower) else 0.0
+    clarity += (
+        2.0
+        if (550 <= word_count <= 1050)
+        else 1.0 if (450 <= word_count <= 1350) else 0.0
+    )
+    clarity += (
+        2.0 if ("what you get" in lower or "inside the package" in lower) else 0.0
+    )
     clarity += 1.0 if flags["has_faq"] else 0.0
-    clarity += 2.0 if flags["has_concrete_includes"] else 0.5 if "manual" in includes_text else 0.0
+    clarity += (
+        2.0
+        if flags["has_concrete_includes"]
+        else 0.5 if "manual" in includes_text else 0.0
+    )
     clarity += 1.0 if flags["has_success_check"] else 0.0
     clarity = clamp_0_10(clarity)
 
@@ -190,9 +212,11 @@ def score_page(html: str) -> tuple[dict[str, float], list[str], list[str]]:
     offer_strength = clamp_0_10(offer_strength)
 
     proof = 0.0
-    proof += 2.0 if (flags["has_manual"] and flags["has_delivery"] and flags["has_support"]) else 1.0 if (
-        flags["has_manual"] and flags["has_support"]
-    ) else 0.0
+    proof += (
+        2.0
+        if (flags["has_manual"] and flags["has_delivery"] and flags["has_support"])
+        else 1.0 if (flags["has_manual"] and flags["has_support"]) else 0.0
+    )
     proof += 1.5 if flags["has_hero_image"] else 0.0
     proof += 1.0 if flags["has_use_cases_link"] else 0.0
     proof += 1.0 if flags["has_comparison_link"] else 0.0
@@ -236,7 +260,9 @@ def score_page(html: str) -> tuple[dict[str, float], list[str], list[str]]:
     if not flags["has_hero_image"]:
         risks.append("Hero has no visible product image (only metadata).")
     if not flags["has_concrete_includes"]:
-        risks.append("Includes section is still abstract; missing concrete deliverables phrasing.")
+        risks.append(
+            "Includes section is still abstract; missing concrete deliverables phrasing."
+        )
     if not flags["has_success_check"]:
         risks.append("Missing explicit success check / first win criteria.")
     if not flags["has_faq"]:
@@ -245,13 +271,23 @@ def score_page(html: str) -> tuple[dict[str, float], list[str], list[str]]:
     if flags["has_buyer_fit"]:
         strengths.append("Buyer fit is explicitly scoped (good fit + not for).")
     if flags["has_manual"] and flags["has_delivery"] and flags["has_support"]:
-        strengths.append("Trust path is inspectable before checkout (manual + delivery + support).")
+        strengths.append(
+            "Trust path is inspectable before checkout (manual + delivery + support)."
+        )
     if flags["has_price"] and flags["has_one_time"] and flags["has_no_subscription"]:
         strengths.append("Offer is explicit (price + one-time + no subscription).")
-    if flags["has_use_cases_link"] and flags["has_comparison_link"] and flags["has_manual_proof_link"]:
-        strengths.append("Supporting pages exist (use cases + comparison + manual proof).")
+    if (
+        flags["has_use_cases_link"]
+        and flags["has_comparison_link"]
+        and flags["has_manual_proof_link"]
+    ):
+        strengths.append(
+            "Supporting pages exist (use cases + comparison + manual proof)."
+        )
     if flags["has_concrete_includes"]:
-        strengths.append("Deliverables are concrete (templates/worksheet/checklist/notes/manual/delivery).")
+        strengths.append(
+            "Deliverables are concrete (templates/worksheet/checklist/notes/manual/delivery)."
+        )
 
     metrics = {
         "clarity": round(clarity, 2),
@@ -260,7 +296,11 @@ def score_page(html: str) -> tuple[dict[str, float], list[str], list[str]]:
         "buyer_fit": round(buyer_fit, 2),
         "cta_discipline": round(cta_discipline, 2),
         "friction_control": round(friction, 2),
-        "overall": round((clarity + offer_strength + proof + buyer_fit + cta_discipline + friction) / 6, 2),
+        "overall": round(
+            (clarity + offer_strength + proof + buyer_fit + cta_discipline + friction)
+            / 6,
+            2,
+        ),
     }
     return metrics, risks, strengths
 
@@ -317,7 +357,10 @@ def build_backlog(audit: PageAudit) -> list[dict[str, str]]:
         if not (ROOT / "docs" / item["page_slug"]).exists():
             backlog.append(item)
 
-    if audit.metrics["proof"] < 8.5 and not (ROOT / "docs" / "proof/red-team-summary.html").exists():
+    if (
+        audit.metrics["proof"] < 8.5
+        and not (ROOT / "docs" / "proof/red-team-summary.html").exists()
+    ):
         backlog.insert(
             0,
             {
@@ -331,8 +374,12 @@ def build_backlog(audit: PageAudit) -> list[dict[str, str]]:
     return backlog
 
 
-def build_model_packets(audit: PageAudit, backlog: Iterable[dict[str, str]]) -> dict[str, str]:
-    backlog_lines = "\n".join(f"- {item['page_slug']}: {item['reason']}" for item in backlog)
+def build_model_packets(
+    audit: PageAudit, backlog: Iterable[dict[str, str]]
+) -> dict[str, str]:
+    backlog_lines = "\n".join(
+        f"- {item['page_slug']}: {item['reason']}" for item in backlog
+    )
     summary = json.dumps(audit.metrics, indent=2)
     return {
         "closer_pass": (
@@ -352,7 +399,9 @@ def build_model_packets(audit: PageAudit, backlog: Iterable[dict[str, str]]) -> 
     }
 
 
-def ollama_generate(*, base_url: str, model: str, prompt: str, timeout_s: int = 120) -> str:
+def ollama_generate(
+    *, base_url: str, model: str, prompt: str, timeout_s: int = 120
+) -> str:
     url = base_url.rstrip("/") + "/api/generate"
     payload = {
         "model": model,
@@ -364,7 +413,9 @@ def ollama_generate(*, base_url: str, model: str, prompt: str, timeout_s: int = 
         },
     }
     data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=timeout_s) as resp:
             out = json.loads(resp.read().decode("utf-8"))
@@ -391,22 +442,30 @@ def escape_text(value: str) -> str:
 
 def build_ul(items: list[str], *, klass: str | None = None) -> str:
     class_attr = f' class="{klass}"' if klass else ""
-    lis = "\n".join(f"              <li>{escape_text(item.strip())}</li>" for item in items if item.strip())
+    lis = "\n".join(
+        f"              <li>{escape_text(item.strip())}</li>"
+        for item in items
+        if item.strip()
+    )
     return f"            <ul{class_attr}>\n{lis}\n            </ul>"
 
 
 def build_includes_section(packet: dict[str, object]) -> str:
-    headline = escape_text(str(packet.get("headline", "This is the part you can open and use first.")).strip())
+    headline = escape_text(
+        str(
+            packet.get("headline", "This is the part you can open and use first.")
+        ).strip()
+    )
     paragraph = escape_text(str(packet.get("paragraph", "")).strip())
     inside = [str(x) for x in (packet.get("inside_package_bullets") or [])]
-    first_win_title = escape_text(str(packet.get("first_win_title", "First win")).strip())
+    first_win_title = escape_text(
+        str(packet.get("first_win_title", "First win")).strip()
+    )
     first_win = [str(x) for x in (packet.get("first_win_bullets") or [])]
     helps = [str(x) for x in (packet.get("helps_you_do_bullets") or [])]
 
     if not paragraph:
-        paragraph = (
-            "The toolkit is built for fast starts: concrete templates, a pilot-first worksheet path, and a short manual that tells you what to do first."
-        )
+        paragraph = "The toolkit is built for fast starts: concrete templates, a pilot-first worksheet path, and a short manual that tells you what to do first."
 
     return f"""<section id="includes">
       <div class="section-inner">
@@ -438,7 +497,9 @@ def build_includes_section(packet: dict[str, object]) -> str:
 
 def validate_includes_packet(packet: dict[str, object]) -> list[str]:
     issues: list[str] = []
-    inside_text = " ".join(str(x).lower() for x in (packet.get("inside_package_bullets") or []))
+    inside_text = " ".join(
+        str(x).lower() for x in (packet.get("inside_package_bullets") or [])
+    )
     if not inside_text:
         issues.append("inside_package_bullets is empty")
         return issues
@@ -449,7 +510,7 @@ def validate_includes_packet(packet: dict[str, object]) -> list[str]:
 
     # Cheap length checks so the UI doesn't become a novel.
     for k in ["inside_package_bullets", "first_win_bullets", "helps_you_do_bullets"]:
-        for item in (packet.get(k) or []):
+        for item in packet.get(k) or []:
             if len(str(item)) > 120:
                 issues.append(f"{k} bullet too long")
                 break
@@ -459,18 +520,18 @@ def validate_includes_packet(packet: dict[str, object]) -> list[str]:
 
 def build_includes_prompt(*, current_section_text: str) -> str:
     return (
-        "You are improving one section of a landing page: the \"What you get\" section for a $29 one-time purchase called the "
+        'You are improving one section of a landing page: the "What you get" section for a $29 one-time purchase called the '
         "SCBE AI Governance Toolkit.\n\n"
         "Write buyer-first, concrete copy. No enterprise promises, no hype, no guarantees. Avoid deep internal jargon.\n\n"
         "Return ONLY valid JSON. No markdown.\n\n"
         "JSON schema:\n"
         "{\n"
-        "  \"headline\": \"...\",\n"
-        "  \"paragraph\": \"...\",\n"
-        "  \"inside_package_bullets\": [\"...\"],\n"
-        "  \"first_win_title\": \"...\",\n"
-        "  \"first_win_bullets\": [\"...\"],\n"
-        "  \"helps_you_do_bullets\": [\"...\"]\n"
+        '  "headline": "...",\n'
+        '  "paragraph": "...",\n'
+        '  "inside_package_bullets": ["..."],\n'
+        '  "first_win_title": "...",\n'
+        '  "first_win_bullets": ["..."],\n'
+        '  "helps_you_do_bullets": ["..."]\n'
         "}\n\n"
         "Hard constraints:\n"
         "- inside_package_bullets MUST mention: decision record template, threshold worksheet, pilot checklist, review notes format, manual, delivery + recovery.\n"
@@ -502,7 +563,11 @@ def pick_best_includes_rewrite(
             packet["_raw"] = raw[:1500]
             packet["_issues"] = validate_includes_packet(packet)
         except Exception as e:
-            packet = {"_model": model, "_raw": raw[:1500], "_issues": [f"parse_error: {e}"]}
+            packet = {
+                "_model": model,
+                "_raw": raw[:1500],
+                "_issues": [f"parse_error: {e}"],
+            }
         candidates.append(packet)
 
     best: dict[str, object] | None = None
@@ -530,25 +595,42 @@ def pick_best_includes_rewrite(
             best_html = trial_html
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / "rewrite_candidates.json").write_text(json.dumps(candidates, indent=2), encoding="utf-8")
+    (output_dir / "rewrite_candidates.json").write_text(
+        json.dumps(candidates, indent=2), encoding="utf-8"
+    )
 
     if best is None or best_html is None:
         return None, {"error": "no_valid_rewrite"}
 
-    (output_dir / "chosen_rewrite.json").write_text(json.dumps(best, indent=2), encoding="utf-8")
+    (output_dir / "chosen_rewrite.json").write_text(
+        json.dumps(best, indent=2), encoding="utf-8"
+    )
     return best_html, best
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run a repeatable sales-improvement audit and packet builder for the website.")
-    parser.add_argument("--page", default="docs/index.html", help="Target page relative to repo root.")
+    parser = argparse.ArgumentParser(
+        description="Run a repeatable sales-improvement audit and packet builder for the website."
+    )
+    parser.add_argument(
+        "--page", default="docs/index.html", help="Target page relative to repo root."
+    )
     parser.add_argument(
         "--output-dir",
         default="artifacts/marketing/website_sales_train",
         help="Output directory relative to repo root.",
     )
-    parser.add_argument("--iterations", type=int, default=0, help="If set, run iterative include-section rewrite passes.")
-    parser.add_argument("--ollama-url", default="http://127.0.0.1:11434", help="Base URL for local Ollama.")
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=0,
+        help="If set, run iterative include-section rewrite passes.",
+    )
+    parser.add_argument(
+        "--ollama-url",
+        default="http://127.0.0.1:11434",
+        help="Base URL for local Ollama.",
+    )
     parser.add_argument(
         "--models",
         default="llama3.2,AetherBot",
@@ -559,7 +641,9 @@ def main() -> None:
         action="store_true",
         help="Write improved HTML back to the target page during iterations (backup is created once).",
     )
-    parser.add_argument("--sleep-ms", type=int, default=0, help="Optional delay between iterations.")
+    parser.add_argument(
+        "--sleep-ms", type=int, default=0, help="Optional delay between iterations."
+    )
     args = parser.parse_args()
 
     page = ROOT / args.page
@@ -573,9 +657,15 @@ def main() -> None:
         backlog = build_backlog(audit)
         packets = build_model_packets(audit, backlog)
 
-        (output_dir / "audit.json").write_text(json.dumps(asdict(audit), indent=2), encoding="utf-8")
-        (output_dir / "backlog.json").write_text(json.dumps(backlog, indent=2), encoding="utf-8")
-        (output_dir / "model_packets.json").write_text(json.dumps(packets, indent=2), encoding="utf-8")
+        (output_dir / "audit.json").write_text(
+            json.dumps(asdict(audit), indent=2), encoding="utf-8"
+        )
+        (output_dir / "backlog.json").write_text(
+            json.dumps(backlog, indent=2), encoding="utf-8"
+        )
+        (output_dir / "model_packets.json").write_text(
+            json.dumps(packets, indent=2), encoding="utf-8"
+        )
 
         summary = {
             "page": audit.path,
@@ -603,9 +693,15 @@ def main() -> None:
         audit = audit_html(page, best_html)
         backlog = build_backlog(audit)
         packets = build_model_packets(audit, backlog)
-        (iter_dir / "audit.json").write_text(json.dumps(asdict(audit), indent=2), encoding="utf-8")
-        (iter_dir / "backlog.json").write_text(json.dumps(backlog, indent=2), encoding="utf-8")
-        (iter_dir / "model_packets.json").write_text(json.dumps(packets, indent=2), encoding="utf-8")
+        (iter_dir / "audit.json").write_text(
+            json.dumps(asdict(audit), indent=2), encoding="utf-8"
+        )
+        (iter_dir / "backlog.json").write_text(
+            json.dumps(backlog, indent=2), encoding="utf-8"
+        )
+        (iter_dir / "model_packets.json").write_text(
+            json.dumps(packets, indent=2), encoding="utf-8"
+        )
 
         rewritten_html, chosen = pick_best_includes_rewrite(
             base_html=best_html,
@@ -625,7 +721,9 @@ def main() -> None:
                 page.write_text(best_html, encoding="utf-8")
         else:
             (iter_dir / "page_snapshot.html").write_text(best_html, encoding="utf-8")
-            (iter_dir / "rewrite_failed.json").write_text(json.dumps(chosen, indent=2), encoding="utf-8")
+            (iter_dir / "rewrite_failed.json").write_text(
+                json.dumps(chosen, indent=2), encoding="utf-8"
+            )
 
         if args.sleep_ms > 0:
             time.sleep(args.sleep_ms / 1000.0)


### PR DESCRIPTION
## Summary
- rebuild the offers page around the  AI Governance Snapshot as the primary paid path
- add buyer-fit, FAQ, success-check, proof-link, and final CTA sections
- add supporting buyer pages for use cases, manual proof, toolkit comparison, and red-team summary
- update the sales scorer to accept hero SVG/JPG/WebP/PNG assets, matching the current site

## Test evidence
- python scripts\\system\\website_sales_train.py --page docs/offers/index.html --output-dir artifacts/revenue/website_sales_offers_2026-05-09-pr --iterations 0 -> overall 8.75, no risks
- python scripts\\system\\remote_app_config_smoke.py --live --report artifacts\\revenue\\remote_app_config_smoke_2026-05-09-pr.json -> PASS
- npx prettier --check docs\\offers\\index.html docs\\use-cases\\governed-ai-workflows.html docs\\proof\\why-the-manual-exists.html docs\\comparison\\toolkit-vs-full-repo.html docs\\proof\\red-team-summary.html -> PASS
- python -m black --check scripts\\system\\website_sales_train.py -> PASS

## Rollback
- Revert this PR to restore the previous simple offers index and sales-scorer behavior.