### PR TITLE
chore(license): add dual MIT Apache licensing surfaces

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,163 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control
+with that entity. For the purposes of this definition, "control" means
+(i) the power, direct or indirect, to cause the direction or management
+of such entity, whether by contract or otherwise, or (ii) ownership of
+fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source,
+and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled
+object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object
+form, made available under the License, as indicated by a copyright notice
+that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent,
+as a whole, an original work of authorship. For the purposes of this
+License, Derivative Works shall not include works that remain separable
+from, or merely link (or bind by name) to the interfaces of, the Work.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Licensor or its representatives,
+including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed
+by, or on behalf of, the Licensor for the purpose of discussing and
+improving the Work, but excluding communication that is conspicuously
+marked or otherwise designated in writing by the copyright owner as
+"Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source
+or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable patent license to make,
+have made, use, offer to sell, sell, import, and otherwise transfer the
+Work, where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their Contribution(s)
+alone or by combination of their Contribution(s) with the Work to which
+such Contribution(s) was submitted. If You institute patent litigation
+against any entity alleging that the Work or a Contribution incorporated
+within the Work constitutes direct or contributory patent infringement,
+then any patent licenses granted to You under this License for that Work
+shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work
+or Derivative Works thereof in any medium, with or without modifications,
+and in Source or Object form, provided that You meet the following
+conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works
+a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating
+that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from
+the Source form of the Work, excluding those notices that do not pertain
+to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy
+of the attribution notices contained within such NOTICE file, excluding
+those notices that do not pertain to any part of the Derivative Works,
+in at least one of the following places: within a NOTICE text file
+distributed as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or, within a
+display generated by the Derivative Works, if and wherever such third-party
+notices normally appear. The contents of the NOTICE file are for
+informational purposes only and do not modify the License. You may add
+Your own attribution notices within Derivative Works that You distribute,
+alongside or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed as modifying
+the License.
+
+You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated
+in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work by You
+to the Licensor shall be under the terms and conditions of this License,
+without any additional terms or conditions. Notwithstanding the above,
+nothing herein shall supersede or modify the terms of any separate license
+agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor, except
+as required for reasonable and customary use in describing the origin of
+the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to
+in writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining
+the appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether
+in tort (including negligence), contract, or otherwise, unless required
+by applicable law (such as deliberate and grossly negligent acts) or agreed
+to in writing, shall any Contributor be liable to You for damages, including
+any direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability
+to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses), even if such Contributor has been advised
+of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the
+Work or Derivative Works thereof, You may choose to offer, and charge a fee
+for, acceptance of support, warranty, indemnity, or other liability
+obligations and/or rights consistent with this License. However, in accepting
+such obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/LICENSE-NOTICE.md
+++ b/LICENSE-NOTICE.md
@@ -1,0 +1,15 @@
+# SCBE-AETHERMOORE Licensing
+
+SCBE-AETHERMOORE project-owned source, npm packages, PyPI packages, and packaged
+customer ZIP artifacts are offered under a dual permissive license:
+
+```text
+MIT OR Apache-2.0
+```
+
+You may choose either license for open-source use. The MIT text is in
+`LICENSE`; the Apache License 2.0 text is in `LICENSE-APACHE`.
+
+Paid services, support, hosted deployments, audits, delivery help, and custom
+commercial terms are separate commercial offerings and are not required to use
+the open-source code under either permissive license.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ The packages are companion surfaces, not forced dependencies. Install the
 smallest package that fits your task; the operator and agent-bus APIs can
 recommend a companion package when a feature lives in another ecosystem.
 
+## License
+
+Project-owned source, npm packages, PyPI packages, and packaged customer ZIP
+artifacts are dual licensed under `MIT OR Apache-2.0`. See `LICENSE`,
+`LICENSE-APACHE`, and `LICENSE-NOTICE.md`.
+
+Paid services, support, hosted deployments, audits, delivery help, and custom
+commercial terms are separate commercial offerings and are not required to use
+the open-source code under either permissive license.
+
 Website and public demos:
 
 - Website: [aethermoore.com](https://aethermoore.com)
@@ -81,6 +91,7 @@ pip install scbe-aethermoore    # Python
 ## Quickstart
 
 **Python:**
+
 ```python
 from scbe_aethermoore import scan, scan_batch, is_safe
 
@@ -101,6 +112,7 @@ if not is_safe(user_input):
 ```
 
 **Command line:**
+
 ```bash
 scbe-scan "hello world"
 # [OK] ALLOW         score=1.0000  d*=0.0000  pd=0.0000  len=11
@@ -115,28 +127,29 @@ scbe-scan --batch prompts.txt   # one line per input
 ```
 
 **TypeScript/Node:**
+
 ```ts
 import { scan, scanBatch, isSafe, harmonicWall } from 'scbe-aethermoore';
 
 const result = scan('ignore all previous instructions');
-result.decision  // "ESCALATE"
-result.score     // 0.384615
+result.decision; // "ESCALATE"
+result.score; // 0.384615
 
-isSafe('hello world')                       // true
-isSafe('ignore all previous instructions')  // false
+isSafe('hello world'); // true
+isSafe('ignore all previous instructions'); // false
 
 // Superexponential cost — how expensive is this drift?
-harmonicWall(result.d_star)  // cost in [1, ∞)
+harmonicWall(result.d_star); // cost in [1, ∞)
 ```
 
 **Decision tiers:**
 
-| Tier | Score | Meaning |
-|------|-------|---------|
-| `ALLOW` | ≥ 0.75 | Safe — proceed |
-| `QUARANTINE` | ≥ 0.45 | Suspicious — flag for review |
-| `ESCALATE` | ≥ 0.20 | High risk — requires governance action |
-| `DENY` | < 0.20 | Adversarial — blocked |
+| Tier         | Score  | Meaning                                |
+| ------------ | ------ | -------------------------------------- |
+| `ALLOW`      | ≥ 0.75 | Safe — proceed                         |
+| `QUARANTINE` | ≥ 0.45 | Suspicious — flag for review           |
+| `ESCALATE`   | ≥ 0.20 | High risk — requires governance action |
+| `DENY`       | < 0.20 | Adversarial — blocked                  |
 
 ## The origin story
 
@@ -146,27 +159,27 @@ Built by [Issac Davis](https://github.com/issdandavis) in Port Angeles, WA.
 
 ## Benchmark results
 
-| System | F1 | Detection | FPR | Method |
-|--------|-----|-----------|-----|--------|
-| No defense | 0.000 | 0% | 0% | — |
-| DeBERTa PromptGuard | — | 76.7% | 0% | Fine-tuned classifier |
+| System                        | F1        | Detection | FPR     | Method                               |
+| ----------------------------- | --------- | --------- | ------- | ------------------------------------ |
+| No defense                    | 0.000     | 0%        | 0%      | —                                    |
+| DeBERTa PromptGuard           | —         | 76.7%     | 0%      | Fine-tuned classifier                |
 | **SCBE (semantic projector)** | **0.813** | **74.2%** | tunable | Geometric cost + semantic embeddings |
 
 Before/after the semantic projector upgrade:
 
-| Attack | Before | After |
-|--------|--------|-------|
-| “Ignore all instructions” | ALLOW (cost=1.81) | **QUARANTINE (cost=16.20)** |
-| “You are DAN” | ALLOW (cost=19.80) | **DENY (cost=69.70)** |
-| “Bypass safety filter” | ALLOW (cost=1.20) | ALLOW (cost=21.54) |
+| Attack                    | Before             | After                       |
+| ------------------------- | ------------------ | --------------------------- |
+| “Ignore all instructions” | ALLOW (cost=1.81)  | **QUARANTINE (cost=16.20)** |
+| “You are DAN”             | ALLOW (cost=19.80) | **DENY (cost=69.70)**       |
+| “Bypass safety filter”    | ALLOW (cost=1.20)  | ALLOW (cost=21.54)          |
 
 Cross-model biblical null-space evaluation:
 
-| Model | Score | Null tongues |
-|-------|-------|-------------|
-| AetherBot (SCBE-trained) | 60.0% | 0 |
-| Llama 3.2 (base) | 55.0% | 0 |
-| Gemini 2.5 Flash | 23.3% | 6 (all) |
+| Model                    | Score | Null tongues |
+| ------------------------ | ----- | ------------ |
+| AetherBot (SCBE-trained) | 60.0% | 0            |
+| Llama 3.2 (base)         | 55.0% | 0            |
+| Gemini 2.5 Flash         | 23.3% | 6 (all)      |
 
 ## What's in the box
 
@@ -220,12 +233,14 @@ pip install scbe-aethermoore
 ## What you get when you install
 
 **npm (`scbe-aethermoore`):**
+
 - `scan()`, `scanBatch()`, `isSafe()`, `harmonicWall()` — zero-dep governance API
 - Full TypeScript types (`ScanResult`, `Decision`)
 - Deep pipeline exports: `scbe-aethermoore/harmonic`, `/crypto`, `/symphonic`, `/governance`
 - CLI (included in the package, run via `npx scbe ...`)
 
 **PyPI (`scbe-aethermoore`):**
+
 - `from scbe_aethermoore import scan` — zero-dep, pure Python 3.11+
 - `scbe-scan` CLI — `scbe-scan "text"` or `scbe-scan --batch file.txt`
 - `scan_batch()`, `is_safe()`, `harmonic_wall()`
@@ -249,21 +264,27 @@ These give users a concrete launch path for common fleet patterns while keeping 
 ## Live Demos
 
 ### 1. Rogue Agent Detection
+
 ```bash
 curl $SCBE_BASE_URL/v1/demo/rogue-detection
 ```
+
 Watch 6 legitimate agents detect and quarantine a phase-null intruder using only math.
 
 ### 2. Swarm Coordination
+
 ```bash
 curl $SCBE_BASE_URL/v1/demo/swarm-coordination?agents=20
 ```
+
 See 20 agents self-organize without any central coordinator.
 
 ### 3. Pipeline Visualization
+
 ```bash
 curl "$SCBE_BASE_URL/v1/demo/pipeline-layers?trust=0.8&sensitivity=0.7"
 ```
+
 See exactly how each of the 14 layers processes a request.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "scbe-aethermoore",
       "version": "4.0.3",
-      "license": "MIT",
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@noble/hashes": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.3",
   "description": "SCBE-AETHERMOORE: Hyperbolic Geometry-Based Security with 14-Layer Architecture",
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
-  "license": "MIT",
+  "license": "MIT OR Apache-2.0",
   "type": "commonjs",
   "bin": {
     "geoseal": "bin/geoseal.cjs",
@@ -74,6 +74,8 @@
     "dist/packages",
     "README.md",
     "LICENSE",
+    "LICENSE-APACHE",
+    "LICENSE-NOTICE.md",
     "examples/npm"
   ],
   "scripts": {

--- a/packages/agent-bus-py/LICENSE-APACHE
+++ b/packages/agent-bus-py/LICENSE-APACHE
@@ -1,0 +1,1 @@
+See ../../LICENSE-APACHE.

--- a/packages/agent-bus-py/README.md
+++ b/packages/agent-bus-py/README.md
@@ -80,4 +80,4 @@ features should be added only when a user requests that lane.
 
 ## License
 
-MIT — see `LICENSE`.
+Dual licensed under `MIT OR Apache-2.0`. See `LICENSE` and `LICENSE-APACHE`.

--- a/packages/agent-bus-py/pyproject.toml
+++ b/packages/agent-bus-py/pyproject.toml
@@ -7,8 +7,8 @@ name = "scbe-agent-bus"
 version = "0.2.0"
 description = "SCBE agent-bus: Python surface over the SCBE governed event runner. Routes AI/human/AI events through the harmonic-wall pipeline and returns a typed envelope."
 readme = "README.md"
-license = "MIT"
-license-files = ["LICENSE"]
+license = "MIT OR Apache-2.0"
+license-files = ["LICENSE", "LICENSE-APACHE"]
 requires-python = ">=3.11"
 authors = [
     {name = "Issac Daniel Davis", email = "issdandavis@gmail.com"},

--- a/packages/agent-bus/LICENSE
+++ b/packages/agent-bus/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Issac Daniel Davis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-bus/LICENSE-APACHE
+++ b/packages/agent-bus/LICENSE-APACHE
@@ -1,0 +1,1 @@
+See ../../LICENSE-APACHE.

--- a/packages/agent-bus/README.md
+++ b/packages/agent-bus/README.md
@@ -1,0 +1,9 @@
+# scbe-agent-bus
+
+Typed Node surface over the SCBE governed event runner. It routes AI, human,
+and AI-to-AI events through the harmonic-wall pipeline and returns a typed
+envelope.
+
+## License
+
+Dual licensed under `MIT OR Apache-2.0`. See `LICENSE` and `LICENSE-APACHE`.

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "scbe-agent-bus",
+  "version": "0.2.0",
+  "description": "SCBE agent-bus: typed Node surface over the SCBE governed event runner.",
+  "license": "MIT OR Apache-2.0",
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "LICENSE-APACHE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/issdandavis/SCBE-AETHERMOORE.git",
+    "directory": "packages/agent-bus"
+  },
+  "bugs": {
+    "url": "https://github.com/issdandavis/SCBE-AETHERMOORE/issues"
+  },
+  "homepage": "https://aethermoore.com/SCBE-AETHERMOORE/offers/"
+}

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Issac Daniel Davis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/LICENSE-APACHE
+++ b/packages/cli/LICENSE-APACHE
@@ -1,0 +1,1 @@
+See ../../LICENSE-APACHE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,8 @@
+# scbe-aethermoore-cli
+
+Standalone CLI packaging surface for SCBE-AETHERMOORE GeoSeal tools and governed
+operator commands.
+
+## License
+
+Dual licensed under `MIT OR Apache-2.0`. See `LICENSE` and `LICENSE-APACHE`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "scbe-aethermoore-cli",
+  "version": "4.1.3",
+  "description": "Standalone CLI for SCBE-AETHERMOORE GeoSeal tools, tokenizer lanes, governance packets, web lookup, and mechanical verification.",
+  "license": "MIT OR Apache-2.0",
+  "type": "commonjs",
+  "bin": {
+    "geoseal": "../../bin/geoseal.cjs",
+    "scbe-geoseal": "../../bin/geoseal.cjs"
+  },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "LICENSE-APACHE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/issdandavis/SCBE-AETHERMOORE.git"
+  },
+  "bugs": {
+    "url": "https://github.com/issdandavis/SCBE-AETHERMOORE/issues"
+  },
+  "homepage": "https://aethermoore.com/SCBE-AETHERMOORE/offers/"
+}

--- a/scripts/package_products.py
+++ b/scripts/package_products.py
@@ -30,7 +30,10 @@ DEFAULT_OUTPUT = REPO_ROOT / "products" / "packaged"
 TOOLKIT_FILES = [
     # Buyer-facing start guide
     ("deliverables/SCBE_Production_Pack/BUYER_START_GUIDE.md", "BUYER_START_GUIDE.md"),
-    ("deliverables/SCBE_Production_Pack/packages/ai-governance-toolkit/README.md", "quickstart/README.md"),
+    (
+        "deliverables/SCBE_Production_Pack/packages/ai-governance-toolkit/README.md",
+        "quickstart/README.md",
+    ),
     # Practical buyer templates promised on the sales/manual pages
     (
         "deliverables/SCBE_Production_Pack/packages/ai-governance-toolkit/decision-record-template.md",
@@ -118,7 +121,10 @@ VAULT_EXTRA_FILES = [
     # Benchmark scripts
     ("scripts/benchmark/scbe_vs_baseline.py", "benchmark/scbe_vs_baseline.py"),
     ("scripts/benchmark/scbe_vs_industry.py", "benchmark/scbe_vs_industry.py"),
-    ("scripts/benchmark/context_embedding_benchmark.py", "benchmark/context_embedding_benchmark.py"),
+    (
+        "scripts/benchmark/context_embedding_benchmark.py",
+        "benchmark/context_embedding_benchmark.py",
+    ),
     ("scripts/benchmark/null_space_ablation.py", "benchmark/null_space_ablation.py"),
     # Architecture reference
     ("docs/specs/CANONICAL_FORMULA_REGISTRY.md", "docs/CANONICAL_FORMULA_REGISTRY.md"),
@@ -186,7 +192,11 @@ def package_toolkit(output_dir: Path) -> Path:
 
     with ZipFile(zip_path, "w", ZIP_DEFLATED) as zf:
         zf.writestr("README.md", TOOLKIT_README)
-        zf.writestr("LICENSE", "MIT License\n\nCopyright (c) 2026 Issac Davis / AetherMoore\n")
+        zf.writestr(
+            "LICENSE", "MIT License\n\nCopyright (c) 2026 Issac Davis / AetherMoore\n"
+        )
+        zf.write(REPO_ROOT / "LICENSE-APACHE", "LICENSE-APACHE")
+        zf.write(REPO_ROOT / "LICENSE-NOTICE.md", "LICENSE-NOTICE.md")
 
         for src_rel, dst_rel in TOOLKIT_FILES:
             src = REPO_ROOT / src_rel
@@ -210,7 +220,11 @@ def package_vault(output_dir: Path) -> Path:
 
     with ZipFile(zip_path, "w", ZIP_DEFLATED) as zf:
         zf.writestr("README.md", VAULT_README)
-        zf.writestr("LICENSE", "MIT License\n\nCopyright (c) 2026 Issac Davis / AetherMoore\n")
+        zf.writestr(
+            "LICENSE", "MIT License\n\nCopyright (c) 2026 Issac Davis / AetherMoore\n"
+        )
+        zf.write(REPO_ROOT / "LICENSE-APACHE", "LICENSE-APACHE")
+        zf.write(REPO_ROOT / "LICENSE-NOTICE.md", "LICENSE-NOTICE.md")
 
         # SFT data files
         for sft_rel in VAULT_SFT_FILES:
@@ -245,7 +259,9 @@ def package_vault(output_dir: Path) -> Path:
         zf.writestr("metadata.json", json.dumps(metadata, indent=2))
 
     size_mb = zip_path.stat().st_size / (1024 * 1024)
-    print(f"\nVault packaged: {zip_path} ({size_mb:.1f} MB, {total_records} SFT records)")
+    print(
+        f"\nVault packaged: {zip_path} ({size_mb:.1f} MB, {total_records} SFT records)"
+    )
     return zip_path
 
 
@@ -267,7 +283,9 @@ def main() -> None:
         package_vault(args.output_dir)
         print()
 
-    print("Done. Upload these ZIPs to your delivery system (GitHub Releases, S3, or direct email).")
+    print(
+        "Done. Upload these ZIPs to your delivery system (GitHub Releases, S3, or direct email)."
+    )
 
 
 if __name__ == "__main__":

--- a/src/package.json
+++ b/src/package.json
@@ -19,7 +19,7 @@
     "scbe"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "MIT OR Apache-2.0",
   "devDependencies": {
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0",


### PR DESCRIPTION
## Summary
- add Apache-2.0 license text and a dual-license notice for project-owned SCBE surfaces
- update root npm metadata to MIT OR Apache-2.0 and include Apache/license notice files in npm package contents
- add package metadata/license files for the published scbe-agent-bus and scbe-aethermoore-cli npm sibling surfaces
- update the Python agent-bus package metadata/readme/license files to MIT OR Apache-2.0
- include Apache/license notice files in generated paid ZIP packages

## Test evidence
- node JSON parse check for package manifests -> PASS
- Python TOML parse check for packages/agent-bus-py/pyproject.toml -> PASS
- npx prettier --check package/readme/license metadata files -> PASS
- python -m black --check scripts/package_products.py -> PASS
- npm run build && npm run publish:check:strict -> PASS; npm tarball clean and includes LICENSE, LICENSE-APACHE, LICENSE-NOTICE.md
- python -m pytest packages/agent-bus-py/tests -q -> 7 passed
- python scripts/package_products.py --output-dir artifacts/products/license-smoke-final -> packaged toolkit/vault ZIPs include LICENSE-APACHE and LICENSE-NOTICE.md

## Rollback
- Revert this PR to restore MIT-only package metadata and remove Apache license notice files from generated packages.