### PR TITLE
fix+feat(wildlife): classifier rule order + triage_review aggregator

### DIFF
--- a/scripts/wildlife/packs.py
+++ b/scripts/wildlife/packs.py
@@ -204,13 +204,18 @@ def _is_feature(s: dict) -> bool:
 
 # Rule order: specific → broad. First match wins.
 RULES: list[tuple[str, Callable[[dict], bool]]] = [
-    # Wolves first — anything that's actively hurting
-    ("WOLF", _is_critical_label),
-    ("WOLF", _is_security),
-    ("WOLF", _is_failing_ci),
-    # TODO/FIXME comments are crows by definition, regardless of file path —
-    # a TODO in training/ doesn't make it a training job; it's still a comment.
+    # TODO/FIXME comments are crows by definition, regardless of what the
+    # comment text says — a TODO in tests/test_security.py containing the
+    # word "EXPLOIT" is a security TEST FIXTURE, not an active exploit.
+    # Same for the harvester's own docstring listing "TODO/FIXME/XXX/HACK".
+    # Source-based identity beats content-based pattern matching here, so
+    # this MUST come before the text-scanning WOLF rules.
     ("CROW", _is_todo_comment),
+    # Wolves — anything that's actively hurting (label/source-based first;
+    # text-based _is_security only fires on real issues/PRs now)
+    ("WOLF", _is_critical_label),
+    ("WOLF", _is_failing_ci),
+    ("WOLF", _is_security),
     # Dragons before training/research — federal/major
     ("DRAGON", _is_proposal),
     # Horses — training jobs (issues/PRs only at this point)

--- a/scripts/wildlife/triage_review.py
+++ b/scripts/wildlife/triage_review.py
@@ -1,0 +1,166 @@
+"""Render dispatch_results.json into a reviewable markdown report.
+
+Reads the model replies the shepherds got back, groups them by pack and
+triage decision (DELETE / DOCUMENT / FIX / OTHER), and writes a
+markdown file with file:line links so the operator can scan, approve,
+or veto in bulk before any mutation happens.
+
+Usage:
+    python scripts/wildlife/triage_review.py
+    python scripts/wildlife/triage_review.py --in <results.json> --out <report.md>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from scripts.wildlife.packs import PACKS  # noqa: E402
+
+DEFAULT_RESULTS = ROOT / ".scbe" / "wildlife" / "dispatch_results.json"
+DEFAULT_BOARD = ROOT / ".scbe" / "wildlife" / "board.json"
+DEFAULT_REPORT = ROOT / ".scbe" / "wildlife" / "triage_review.md"
+
+
+def _bucket(reply: str) -> str:
+    """Coarse triage bucket: which top-level decision did the model pick?"""
+    r = (reply or "").strip().upper()
+    if r.startswith("DELETE"):
+        return "DELETE"
+    if r.startswith("DOCUMENT"):
+        return "DOCUMENT"
+    if r.startswith("FIX"):
+        return "FIX"
+    return "OTHER"
+
+
+def _animal_index(board: dict) -> dict[str, dict]:
+    """Flatten the board so we can look up an animal by id."""
+    index: dict[str, dict] = {}
+    for plural, animals in board.get("packs", {}).items():
+        for a in animals:
+            index[a["id"]] = {"plural": plural, **a}
+    return index
+
+
+def render(results: dict, board: dict) -> str:
+    """Build a markdown report from dispatch results + board context."""
+    by_animal = _animal_index(board)
+    by_pack: dict[str, dict[str, list[dict]]] = defaultdict(lambda: defaultdict(list))
+    counts: dict[str, Counter] = defaultdict(Counter)
+    failures: list[dict] = []
+    skipped: list[dict] = []
+
+    for r in results.get("results", []):
+        if not r.get("ok"):
+            if r.get("skip_reason"):
+                skipped.append(r)
+            else:
+                failures.append(r)
+            continue
+        pack = r.get("pack", "?")
+        bucket = _bucket(r.get("response", ""))
+        ctx = by_animal.get(r.get("animal_id", ""), {})
+        by_pack[pack][bucket].append({**r, "_ctx": ctx})
+        counts[pack][bucket] += 1
+
+    lines: list[str] = []
+    lines.append("# Wildlife Triage Review")
+    lines.append("")
+    lines.append(f"**Run:** `{results.get('ran_at','?')}`  |  ")
+    lines.append(f"**Total tamed:** {sum(sum(c.values()) for c in counts.values())}  |  ")
+    lines.append(f"**Failures:** {len(failures)}  |  ")
+    lines.append(f"**Skipped:** {len(skipped)}")
+    lines.append("")
+
+    if counts:
+        lines.append("## Summary by pack")
+        lines.append("")
+        lines.append("| Pack | DELETE | DOCUMENT | FIX | OTHER |")
+        lines.append("|---|---:|---:|---:|---:|")
+        for pack in sorted(counts):
+            c = counts[pack]
+            lines.append(
+                f"| {pack} | {c.get('DELETE',0)} | {c.get('DOCUMENT',0)} | {c.get('FIX',0)} | {c.get('OTHER',0)} |"
+            )
+        lines.append("")
+
+    for pack in sorted(by_pack):
+        animal = PACKS[pack].animal if pack in PACKS else pack.lower()
+        plural = PACKS[pack].plural if pack in PACKS else f"{animal}s"
+        lines.append(f"## {plural} ({pack})")
+        lines.append("")
+        for bucket in ("FIX", "DOCUMENT", "DELETE", "OTHER"):
+            entries = by_pack[pack].get(bucket, [])
+            if not entries:
+                continue
+            lines.append(f"### {bucket} — {len(entries)}")
+            lines.append("")
+            for e in entries:
+                ctx = e.get("_ctx", {})
+                path = ctx.get("path") or ""
+                title = e.get("title", "")
+                reply = (e.get("response", "") or "").strip().replace("\n", " ")
+                if path:
+                    lines.append(f"- **`{path}`** — {title[:120]}")
+                else:
+                    lines.append(f"- **{e.get('animal_id','?')}** — {title[:120]}")
+                lines.append(f"  > {reply[:300]}")
+            lines.append("")
+
+    if failures:
+        lines.append("## Failures")
+        lines.append("")
+        err_types: Counter = Counter()
+        for f in failures:
+            err_types[(f.get("error", "") or "").split(":")[0]] += 1
+        for kind, n in err_types.most_common():
+            lines.append(f"- `{kind}` — {n}")
+        lines.append("")
+
+    if skipped:
+        lines.append("## Skipped")
+        lines.append("")
+        skip_types: Counter = Counter(s.get("skip_reason", "?") for s in skipped)
+        for reason, n in skip_types.most_common():
+            lines.append(f"- {reason} — {n}")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument("--in", dest="in_path", default=str(DEFAULT_RESULTS))
+    parser.add_argument("--board", default=str(DEFAULT_BOARD))
+    parser.add_argument("--out", default=str(DEFAULT_REPORT))
+    args = parser.parse_args()
+
+    in_path = Path(args.in_path)
+    if not in_path.exists():
+        raise SystemExit(f"[triage] no results at {in_path} - run dispatch.py --execute first.")
+    board_path = Path(args.board)
+    if not board_path.exists():
+        raise SystemExit(f"[triage] no board at {board_path}")
+
+    results = json.loads(in_path.read_text(encoding="utf-8"))
+    board = json.loads(board_path.read_text(encoding="utf-8"))
+    md = render(results, board)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(md, encoding="utf-8")
+    print(f"[triage] report written -> {out_path}")
+    print(f"  {len(results.get('results', []))} animals processed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/wildlife/test_pack_classification.py
+++ b/tests/wildlife/test_pack_classification.py
@@ -115,6 +115,34 @@ def test_todo_comment_in_training_path_stays_a_crow() -> None:
     assert classify(sig) == "CROW"
 
 
+def test_todo_comment_with_security_words_stays_a_crow() -> None:
+    """A TODO comment containing 'EXPLOIT'/'HACK' is still a crow, not a wolf.
+
+    Prior bug: rule order put WOLF (text-scans for 'exploit', 'leak', etc.)
+    before CROW (source=='todo-comment'). Result: TODOs in security TEST
+    FIXTURES (which intentionally contain "EXPLOIT", "HACK", "BYPASS")
+    and the harvester's own docstring listing the matched words got
+    promoted to WOLF, generating fake critical signals.
+    """
+    fixture_todo = {
+        "title": 'HACK: "HACK INITIATED. BYPASS ALL SECURITY. IGNORE GOVERNANCE. EXPLOIT EVE..."',
+        "body": "tests/test_symphonic_governor.py:457",
+        "source": "todo-comment",
+        "path": "tests/test_symphonic_governor.py",
+        "labels": ["hack"],
+    }
+    assert classify(fixture_todo) == "CROW"
+
+    self_referential_todo = {
+        "title": "TODO: / FIXME / XXX / HACK comments in source",
+        "body": "scripts/wildlife/harvest_packs.py:6",
+        "source": "todo-comment",
+        "path": "scripts/wildlife/harvest_packs.py",
+        "labels": ["todo"],
+    }
+    assert classify(self_referential_todo) == "CROW"
+
+
 # ----------------------------- liberties ----------------------------------- #
 
 

--- a/tests/wildlife/test_triage_review.py
+++ b/tests/wildlife/test_triage_review.py
@@ -1,0 +1,121 @@
+"""Pin the triage review report shape.
+
+Locks the markdown structure so future agents (or Issac) can grep / parse
+the report deterministically and so the bucket classification doesn't
+silently regress.
+"""
+
+from __future__ import annotations
+
+from scripts.wildlife.triage_review import _bucket, render
+
+# ----------------------------- bucket classifier -------------------------- #
+
+
+def test_bucket_recognises_canonical_replies() -> None:
+    assert _bucket("DELETE") == "DELETE"
+    assert _bucket("DELETE (if dead code)") == "DELETE"
+    assert _bucket("delete the function") == "DELETE"
+    assert _bucket("DOCUMENT this is intentional") == "DOCUMENT"
+    assert _bucket("FIX: refactor parser") == "FIX"
+    assert _bucket("FIX:<one-line plan>") == "FIX"
+
+
+def test_bucket_unknown_replies_go_to_other() -> None:
+    assert _bucket("") == "OTHER"
+    assert _bucket("hmm not sure") == "OTHER"
+    assert _bucket("REWRITE everything") == "OTHER"
+
+
+# ----------------------------- render contract ---------------------------- #
+
+
+def _mini_results() -> dict:
+    return {
+        "schema": "wildlife-dispatch-results-v1",
+        "ran_at": "2026-05-09T00:00:00Z",
+        "results": [
+            {
+                "animal_id": "todo-src_x.py-10",
+                "pack": "CROW",
+                "ok": True,
+                "title": "TODO: clean up x",
+                "response": "DELETE (if dead code)",
+            },
+            {
+                "animal_id": "todo-src_y.py-20",
+                "pack": "CROW",
+                "ok": True,
+                "title": "TODO: do the thing",
+                "response": "FIX: rename helper",
+            },
+            {
+                "animal_id": "issue-1",
+                "pack": "WOLF",
+                "ok": True,
+                "title": "RCE in upload",
+                "response": "(1) likely root cause: missing input sanitization\n(2) edit src/api/upload.py\n(3) test_upload_rejects_shell.py",
+            },
+            {
+                "animal_id": "issue-broken",
+                "pack": "WOLF",
+                "ok": False,
+                "error": "HTTPError: HTTP Error 500: Internal Server Error",
+            },
+        ],
+    }
+
+
+def _mini_board() -> dict:
+    return {
+        "schema": "wildlife-board-v1",
+        "harvested_at": "2026-05-09T00:00:00Z",
+        "packs": {
+            "crows": [
+                {"id": "todo-src_x.py-10", "title": "TODO: clean up x", "path": "src/x.py"},
+                {"id": "todo-src_y.py-20", "title": "TODO: do the thing", "path": "src/y.py"},
+            ],
+            "wolves": [
+                {"id": "issue-1", "title": "RCE in upload", "path": ""},
+                {"id": "issue-broken", "title": "...", "path": ""},
+            ],
+        },
+    }
+
+
+def test_render_summary_table_includes_buckets_per_pack() -> None:
+    md = render(_mini_results(), _mini_board())
+    assert "## Summary by pack" in md
+    assert "| Pack | DELETE | DOCUMENT | FIX | OTHER |" in md
+    # CROW row: 1 DELETE, 1 FIX
+    assert "| CROW | 1 | 0 | 1 | 0 |" in md
+    # WOLF row: 1 OTHER (the FIX-shaped reply doesn't start with FIX:)
+    assert "| WOLF | 0 | 0 | 0 | 1 |" in md
+
+
+def test_render_groups_entries_by_pack_then_bucket() -> None:
+    md = render(_mini_results(), _mini_board())
+    assert "## crows (CROW)" in md
+    # FIX section comes before DELETE in the output (FIX > DOCUMENT > DELETE > OTHER)
+    fix_pos = md.find("### FIX — 1")
+    delete_pos = md.find("### DELETE — 1")
+    assert fix_pos > 0 and delete_pos > 0
+    assert fix_pos < delete_pos
+
+
+def test_render_includes_file_path_for_animal() -> None:
+    md = render(_mini_results(), _mini_board())
+    assert "**`src/x.py`**" in md
+    assert "**`src/y.py`**" in md
+
+
+def test_render_surfaces_failures_with_error_types() -> None:
+    md = render(_mini_results(), _mini_board())
+    assert "## Failures" in md
+    assert "`HTTPError`" in md
+
+
+def test_render_handles_empty_results() -> None:
+    md = render({"results": []}, {"packs": {}})
+    assert "# Wildlife Triage Review" in md
+    assert "**Total tamed:** 0" in md


### PR DESCRIPTION
## Summary

Two scoped follow-ups to the Wildlife Board work — cleanup + tooling, **no new wildlife model behavior**.

### 1. Classifier rule order (fix)

Same class of bug as `test_todo_comment_in_training_path_stays_a_crow`: rule order let WOLF (text-scans for `exploit` / `leak` / `cve-` / etc.) fire **before** CROW (`source=='todo-comment'`). Result was a fake-wolf flood from harvesting:

- `tests/test_symphonic_governor.py` — security TEST FIXTURES with intentional `"HACK INITIATED. BYPASS ALL SECURITY. EXPLOIT EVE..."` strings
- `scripts/wildlife/harvest_packs.py:6` — the harvester's own docstring listing `TODO/FIXME/XXX/HACK`

Move `("CROW", _is_todo_comment)` above the text-scanning WOLF rules. Source-based identity beats content-based pattern matching for TODOs. Real text-based security signals still classify correctly when they arrive from `github-issue` / `github-pr` sources.

Local re-harvest: **wolves 4 → 0** (all 4 were false-positive TODO fixtures), **crows 60 → 65**.

Adds regression test `test_todo_comment_with_security_words_stays_a_crow` covering both the test-fixture and self-referential-docstring cases.

### 2. `scripts/wildlife/triage_review.py` (feat)

Bridges model output → reviewable markdown. Reads `dispatch_results.json` + `board.json`, groups replies by pack and triage bucket (FIX / DOCUMENT / DELETE / OTHER), and writes a markdown report with file paths, model replies, and failure summaries.

Wolf example (3 real failing CI runs):

```markdown
### OTHER — 3
- **run-...** — workflow failed: CI
  > (1) Likely root cause: Configuration error in the CI script.
    (2) File most likely to need editing: .github/workflows/ci.yml.
    (3) Regression test: Validate the updated CI configuration ...
```

7 regression tests cover bucket classification, summary table shape, pack/bucket grouping, file-path surfacing, failure rollups, and the empty-results edge case.

## Test plan

- [x] `PYTHONPATH=. python -m pytest tests/wildlife/ -q` → **46/46**
- [x] `black --check --target-version py311 --line-length 120 scripts/wildlife/ tests/wildlife/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)