### PR TITLE
chore(npm): align published dual-license packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scbe-aethermoore",
-  "version": "4.0.3",
+  "version": "4.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scbe-aethermoore",
-      "version": "4.0.3",
+      "version": "4.0.8",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scbe-aethermoore",
-  "version": "4.0.3",
+  "version": "4.0.8",
   "description": "SCBE-AETHERMOORE: Hyperbolic Geometry-Based Security with 14-Layer Architecture",
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT OR Apache-2.0",

--- a/packages/agent-bus/CHANGELOG.md
+++ b/packages/agent-bus/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.1
+
+- Restore package source files on the release branch.
+- Update TypeScript build settings for the current TypeScript 6 toolchain.
+
+## 0.1.0
+
+- Initial typed Node wrapper for the SCBE agent-bus pipe runner.

--- a/packages/agent-bus/LICENSE-APACHE
+++ b/packages/agent-bus/LICENSE-APACHE
@@ -1,1 +1,163 @@
-See ../../LICENSE-APACHE.
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control
+with that entity. For the purposes of this definition, "control" means
+(i) the power, direct or indirect, to cause the direction or management
+of such entity, whether by contract or otherwise, or (ii) ownership of
+fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source,
+and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled
+object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object
+form, made available under the License, as indicated by a copyright notice
+that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent,
+as a whole, an original work of authorship. For the purposes of this
+License, Derivative Works shall not include works that remain separable
+from, or merely link (or bind by name) to the interfaces of, the Work.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Licensor or its representatives,
+including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed
+by, or on behalf of, the Licensor for the purpose of discussing and
+improving the Work, but excluding communication that is conspicuously
+marked or otherwise designated in writing by the copyright owner as
+"Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source
+or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable patent license to make,
+have made, use, offer to sell, sell, import, and otherwise transfer the
+Work, where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their Contribution(s)
+alone or by combination of their Contribution(s) with the Work to which
+such Contribution(s) was submitted. If You institute patent litigation
+against any entity alleging that the Work or a Contribution incorporated
+within the Work constitutes direct or contributory patent infringement,
+then any patent licenses granted to You under this License for that Work
+shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work
+or Derivative Works thereof in any medium, with or without modifications,
+and in Source or Object form, provided that You meet the following
+conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works
+a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating
+that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from
+the Source form of the Work, excluding those notices that do not pertain
+to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy
+of the attribution notices contained within such NOTICE file, excluding
+those notices that do not pertain to any part of the Derivative Works,
+in at least one of the following places: within a NOTICE text file
+distributed as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or, within a
+display generated by the Derivative Works, if and wherever such third-party
+notices normally appear. The contents of the NOTICE file are for
+informational purposes only and do not modify the License. You may add
+Your own attribution notices within Derivative Works that You distribute,
+alongside or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed as modifying
+the License.
+
+You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated
+in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work by You
+to the Licensor shall be under the terms and conditions of this License,
+without any additional terms or conditions. Notwithstanding the above,
+nothing herein shall supersede or modify the terms of any separate license
+agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor, except
+as required for reasonable and customary use in describing the origin of
+the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to
+in writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining
+the appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether
+in tort (including negligence), contract, or otherwise, unless required
+by applicable law (such as deliberate and grossly negligent acts) or agreed
+to in writing, shall any Contributor be liable to You for damages, including
+any direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability
+to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses), even if such Contributor has been advised
+of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the
+Work or Derivative Works thereof, You may choose to offer, and charge a fee
+for, acceptance of support, warranty, indemnity, or other liability
+obligations and/or rights consistent with this License. However, in accepting
+such obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/packages/agent-bus/LICENSE-NOTICE.md
+++ b/packages/agent-bus/LICENSE-NOTICE.md
@@ -1,0 +1,15 @@
+# SCBE-AETHERMOORE Licensing
+
+SCBE-AETHERMOORE project-owned source, npm packages, PyPI packages, and packaged
+customer ZIP artifacts are offered under a dual permissive license:
+
+```text
+MIT OR Apache-2.0
+```
+
+You may choose either license for open-source use. The MIT text is in
+`LICENSE`; the Apache License 2.0 text is in `LICENSE-APACHE`.
+
+Paid services, support, hosted deployments, audits, delivery help, and custom
+commercial terms are separate commercial offerings and are not required to use
+the open-source code under either permissive license.

--- a/packages/agent-bus/README.md
+++ b/packages/agent-bus/README.md
@@ -1,9 +1,54 @@
 # scbe-agent-bus
 
-Typed Node surface over the SCBE governed event runner. It routes AI, human,
-and AI-to-AI events through the harmonic-wall pipeline and returns a typed
-envelope.
+Typed Node surface over the SCBE governed event runner.
 
-## License
+This package routes AI, human, and automation events through the existing
+`scripts/system/agentbus_pipe.mjs` runner and returns typed result envelopes for
+Node callers.
 
-Dual licensed under `MIT OR Apache-2.0`. See `LICENSE` and `LICENSE-APACHE`.
+## Install
+
+```bash
+npm i scbe-agent-bus
+```
+
+## Usage
+
+```ts
+import { runEvent } from 'scbe-agent-bus';
+
+const result = await runEvent({
+  task: 'Summarize the changed training files.',
+  taskType: 'review',
+  privacy: 'local_only',
+});
+
+console.log(result.ok, result.result);
+```
+
+## Backend
+
+```bash
+scbe-agent-bus serve --port 8787
+```
+
+Routes:
+
+- `GET /health`
+- `POST /v1/events`
+- `POST /v1/batch`
+
+## Frontend
+
+```bash
+scbe-agent-bus ui --base-url http://127.0.0.1:8787
+```
+
+The terminal frontend can health-check the backend and send governed local-only
+tasks through the bus. It does not expose shell execution.
+
+## Notes
+
+- The repo-local runner remains the source of truth.
+- `privacy: "local_only"` should be used for sensitive data.
+- Remote dispatch should be explicit with budget and provider fields.

--- a/packages/agent-bus/bin/scbe-agent-bus.cjs
+++ b/packages/agent-bus/bin/scbe-agent-bus.cjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+const { postAgentBusEvent, runAgentBusTerminalUi, startAgentBusServer } = require("../dist/index.js");
+
+function parseArgs(argv) {
+  const positionals = [];
+  const flags = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) {
+      positionals.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      flags[key] = true;
+      continue;
+    }
+    flags[key] = next;
+    i += 1;
+  }
+  return { command: positionals[0] || "help", flags };
+}
+
+function printHelp() {
+  process.stdout.write(`SCBE Agent Bus
+
+Usage:
+  scbe-agent-bus serve --port 8787
+  scbe-agent-bus ui --base-url http://127.0.0.1:8787
+  scbe-agent-bus send --task "review changed files" --task-type review --json
+  scbe-agent-bus health --base-url http://127.0.0.1:8787 --json
+
+Commands:
+  serve   Start the local HTTP backend.
+  ui      Start the terminal frontend.
+  send    Send one governed task to the backend.
+  health  Check backend health.
+`);
+}
+
+async function main() {
+  const { command, flags } = parseArgs(process.argv);
+  const baseUrl = String(flags["base-url"] || process.env.SCBE_AGENT_BUS_URL || "http://127.0.0.1:8787");
+  if (command === "help" || flags.help) {
+    printHelp();
+    return;
+  }
+  if (command === "serve") {
+    const handle = await startAgentBusServer({
+      host: String(flags.host || "127.0.0.1"),
+      port: Number(flags.port || 8787),
+      repoRoot: flags["repo-root"] ? String(flags["repo-root"]) : undefined,
+      python: flags.python ? String(flags.python) : undefined,
+      continueOnError: Boolean(flags["continue-on-error"]),
+    });
+    const payload = {
+      schema_version: "scbe-agent-bus-backend-start-v1",
+      ok: true,
+      url: handle.url,
+      routes: ["/health", "/v1/events", "/v1/batch"],
+    };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  if (command === "ui") {
+    await runAgentBusTerminalUi({ baseUrl });
+    return;
+  }
+  if (command === "send") {
+    const task = String(flags.task || "").trim();
+    if (!task) throw new Error("send requires --task");
+    const result = await postAgentBusEvent(
+      {
+        task,
+        taskType: String(flags["task-type"] || "general"),
+        privacy: String(flags.privacy || "local_only"),
+        budgetCents: Number(flags["budget-cents"] || 0),
+        dispatchProvider: String(flags["dispatch-provider"] || "offline"),
+        dispatch: flags.dispatch !== "false",
+      },
+      { baseUrl }
+    );
+    process.stdout.write(flags.json ? `${JSON.stringify(result, null, 2)}\n` : `${JSON.stringify(result)}\n`);
+    return;
+  }
+  if (command === "health") {
+    const result = await fetch(`${baseUrl.replace(/\/+$/, "")}/health`).then((res) => res.json());
+    process.stdout.write(flags.json ? `${JSON.stringify(result, null, 2)}\n` : `${JSON.stringify(result)}\n`);
+    return;
+  }
+  throw new Error(`unknown command: ${command}`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -1,17 +1,40 @@
 {
   "name": "scbe-agent-bus",
-  "version": "0.2.0",
-  "description": "SCBE agent-bus: typed Node surface over the SCBE governed event runner.",
-  "license": "MIT OR Apache-2.0",
-  "type": "commonjs",
+  "version": "0.2.1",
+  "description": "SCBE agent-bus: typed Node surface over the SCBE governed event runner. Routes AI/human/AI events through the harmonic-wall pipeline and returns a typed envelope.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "scbe-agent-bus": "bin/scbe-agent-bus.cjs"
+  },
   "files": [
+    "bin",
     "dist",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE",
-    "LICENSE-APACHE"
+    "LICENSE-APACHE",
+    "LICENSE-NOTICE.md"
   ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "agentbus:pipe": "node ../../scripts/system/agentbus_pipe.mjs",
+    "pack:dry": "npm pack --dry-run --json",
+    "prepublishOnly": "npm run build"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "scbe",
+    "agent-bus",
+    "governance",
+    "harmonic-wall",
+    "agent-orchestration",
+    "ai-safety"
+  ],
+  "author": "Issac Daniel Davis <issdandavis@gmail.com>",
+  "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/issdandavis/SCBE-AETHERMOORE.git",
@@ -20,5 +43,12 @@
   "bugs": {
     "url": "https://github.com/issdandavis/SCBE-AETHERMOORE/issues"
   },
-  "homepage": "https://aethermoore.com/SCBE-AETHERMOORE/offers/"
+  "homepage": "https://github.com/issdandavis/SCBE-AETHERMOORE/tree/main/packages/agent-bus#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^6.0.2"
+  }
 }

--- a/packages/cli/LICENSE-APACHE
+++ b/packages/cli/LICENSE-APACHE
@@ -1,1 +1,163 @@
-See ../../LICENSE-APACHE.
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control
+with that entity. For the purposes of this definition, "control" means
+(i) the power, direct or indirect, to cause the direction or management
+of such entity, whether by contract or otherwise, or (ii) ownership of
+fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source,
+and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled
+object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object
+form, made available under the License, as indicated by a copyright notice
+that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent,
+as a whole, an original work of authorship. For the purposes of this
+License, Derivative Works shall not include works that remain separable
+from, or merely link (or bind by name) to the interfaces of, the Work.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Licensor or its representatives,
+including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed
+by, or on behalf of, the Licensor for the purpose of discussing and
+improving the Work, but excluding communication that is conspicuously
+marked or otherwise designated in writing by the copyright owner as
+"Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source
+or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable patent license to make,
+have made, use, offer to sell, sell, import, and otherwise transfer the
+Work, where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their Contribution(s)
+alone or by combination of their Contribution(s) with the Work to which
+such Contribution(s) was submitted. If You institute patent litigation
+against any entity alleging that the Work or a Contribution incorporated
+within the Work constitutes direct or contributory patent infringement,
+then any patent licenses granted to You under this License for that Work
+shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work
+or Derivative Works thereof in any medium, with or without modifications,
+and in Source or Object form, provided that You meet the following
+conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works
+a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating
+that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from
+the Source form of the Work, excluding those notices that do not pertain
+to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy
+of the attribution notices contained within such NOTICE file, excluding
+those notices that do not pertain to any part of the Derivative Works,
+in at least one of the following places: within a NOTICE text file
+distributed as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or, within a
+display generated by the Derivative Works, if and wherever such third-party
+notices normally appear. The contents of the NOTICE file are for
+informational purposes only and do not modify the License. You may add
+Your own attribution notices within Derivative Works that You distribute,
+alongside or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed as modifying
+the License.
+
+You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated
+in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work by You
+to the Licensor shall be under the terms and conditions of this License,
+without any additional terms or conditions. Notwithstanding the above,
+nothing herein shall supersede or modify the terms of any separate license
+agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor, except
+as required for reasonable and customary use in describing the origin of
+the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to
+in writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining
+the appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether
+in tort (including negligence), contract, or otherwise, unless required
+by applicable law (such as deliberate and grossly negligent acts) or agreed
+to in writing, shall any Contributor be liable to You for damages, including
+any direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability
+to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses), even if such Contributor has been advised
+of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the
+Work or Derivative Works thereof, You may choose to offer, and charge a fee
+for, acceptance of support, warranty, indemnity, or other liability
+obligations and/or rights consistent with this License. However, in accepting
+such obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/packages/cli/LICENSE-NOTICE.md
+++ b/packages/cli/LICENSE-NOTICE.md
@@ -1,0 +1,15 @@
+# SCBE-AETHERMOORE Licensing
+
+SCBE-AETHERMOORE project-owned source, npm packages, PyPI packages, and packaged
+customer ZIP artifacts are offered under a dual permissive license:
+
+```text
+MIT OR Apache-2.0
+```
+
+You may choose either license for open-source use. The MIT text is in
+`LICENSE`; the Apache License 2.0 text is in `LICENSE-APACHE`.
+
+Paid services, support, hosted deployments, audits, delivery help, and custom
+commercial terms are separate commercial offerings and are not required to use
+the open-source code under either permissive license.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,39 @@
 # scbe-aethermoore-cli
 
-Standalone CLI packaging surface for SCBE-AETHERMOORE GeoSeal tools and governed
-operator commands.
+`scbe-aethermoore-cli` is the terminal interface for SCBE-AETHERMOORE. It exposes
+the GeoSeal shell from the main `scbe-aethermoore` package under small-agent
+friendly commands.
 
-## License
+## Install
 
-Dual licensed under `MIT OR Apache-2.0`. See `LICENSE` and `LICENSE-APACHE`.
+```bash
+npm i -g scbe-aethermoore-cli
+```
+
+## Commands
+
+```bash
+scbe --help
+scbe version
+scbe selftest
+scbe doctor --json
+```
+
+The same binary is also exposed as `geoseal` and `scbe-geoseal`.
+
+## Tool Surface
+
+- `version`: prints the installed `scbe-aethermoore` package version.
+- `doctor --json`: verifies the installed GeoSeal shell and reports available
+  API-routed commands.
+- `selftest`: runs the npm-installable smoke test (`version` + `doctor`).
+
+The full repo-local GeoSeal command set still lives in `scbe-aethermoore`.
+Commands that require Python repo modules need a source checkout or a backend
+API configured with `SCBE_API_BASE`.
+
+## Self Test
+
+```bash
+scbe selftest
+```

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+
+function resolveGeosealBin() {
+  try {
+    const entry = require.resolve("scbe-aethermoore");
+    return path.resolve(path.dirname(entry), "..", "..", "bin", "geoseal.cjs");
+  } catch (_err) {
+    const localFallback = path.resolve(__dirname, "..", "..", "..", "bin", "geoseal.cjs");
+    try {
+      require("node:fs").accessSync(localFallback);
+      return localFallback;
+    } catch (_fallbackErr) {
+      process.stderr.write(
+        "scbe-aethermoore-cli could not find scbe-aethermoore. Reinstall with: npm i -g scbe-aethermoore-cli\n",
+      );
+      process.exit(1);
+    }
+  }
+}
+
+function runSelftest() {
+  const target = resolveGeosealBin();
+  const checks = [
+    ["version"],
+    ["doctor", "--json"],
+  ];
+  const results = checks.map((args) => {
+    const child = spawnSync(process.execPath, [target, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return {
+      command: `scbe ${args.join(" ")}`,
+      ok: child.status === 0,
+      status: child.status,
+      stdout_preview: String(child.stdout || "").slice(0, 500),
+      stderr_preview: String(child.stderr || "").slice(0, 500),
+    };
+  });
+  const payload = {
+    schema_version: "scbe_aethermoore_cli_selftest_v1",
+    ok: results.every((row) => row.ok),
+    results,
+  };
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  process.exit(payload.ok ? 0 : 1);
+}
+
+const argv = process.argv.slice(2);
+if (argv[0] === "selftest") {
+  runSelftest();
+}
+
+const target = resolveGeosealBin();
+const child = spawnSync(process.execPath, [target, ...argv], {
+  stdio: "inherit",
+});
+
+if (typeof child.status === "number") {
+  process.exit(child.status);
+}
+
+process.exit(1);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,24 +1,55 @@
 {
   "name": "scbe-aethermoore-cli",
-  "version": "4.1.3",
+  "version": "4.1.5",
   "description": "Standalone CLI for SCBE-AETHERMOORE GeoSeal tools, tokenizer lanes, governance packets, web lookup, and mechanical verification.",
+  "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT OR Apache-2.0",
   "type": "commonjs",
   "bin": {
-    "geoseal": "../../bin/geoseal.cjs",
-    "scbe-geoseal": "../../bin/geoseal.cjs"
+    "scbe": "bin/scbe.js",
+    "geoseal": "bin/scbe.js",
+    "scbe-geoseal": "bin/scbe.js"
   },
   "files": [
+    "bin",
     "README.md",
     "LICENSE",
-    "LICENSE-APACHE"
+    "LICENSE-APACHE",
+    "LICENSE-NOTICE.md"
+  ],
+  "scripts": {
+    "help": "node ./bin/scbe.js --help",
+    "selftest": "node ./bin/scbe.js selftest",
+    "pack:dry": "npm pack --dry-run --json"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "dependencies": {
+    "scbe-aethermoore": "^4.0.8",
+    "scbe-agent-bus": "^0.2.1"
+  },
+  "keywords": [
+    "scbe",
+    "aethermoore",
+    "cli",
+    "geoseal",
+    "tokenizer",
+    "governance",
+    "sacred-tongues",
+    "agent-tools",
+    "dimensional-analysis"
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/issdandavis/SCBE-AETHERMOORE.git"
+    "url": "git+https://github.com/issdandavis/SCBE-AETHERMOORE.git",
+    "directory": "packages/scbe-aethermoore-cli"
   },
   "bugs": {
     "url": "https://github.com/issdandavis/SCBE-AETHERMOORE/issues"
   },
-  "homepage": "https://aethermoore.com/SCBE-AETHERMOORE/offers/"
+  "homepage": "https://github.com/issdandavis/SCBE-AETHERMOORE#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Summary
- align repo package versions with npm releases published for the dual-license refresh
- preserve the real scbe-agent-bus and scbe-aethermoore-cli package contents in repo
- fix CLI package resolution against scbe-aethermoore's exports map and narrow npm selftest to installable commands

## Published
- scbe-aethermoore@4.0.8
- scbe-agent-bus@0.2.1
- scbe-aethermoore-cli@4.1.5

## Verification
- npm view confirms all three packages now report license MIT OR Apache-2.0
- clean temp install: npm install scbe-aethermoore@4.0.8 scbe-agent-bus@0.2.1 scbe-aethermoore-cli@4.1.5
- node node_modules/scbe-aethermoore-cli/bin/scbe.js selftest -> ok true
- node node_modules/scbe-agent-bus/bin/scbe-agent-bus.cjs help -> ok
- npx prettier --check package.json package-lock.json packages/agent-bus/package.json packages/cli/package.json packages/agent-bus/README.md packages/cli/README.md