### PR TITLE
fix(governance-snapshot): use valid lead enums (HOTFIX for #1554)

### DIFF
--- a/docs/governance-snapshot.html
+++ b/docs/governance-snapshot.html
@@ -305,11 +305,16 @@
               'What matters if AI gets it wrong:\n' + values.risk + '\n\n' +
               'Links / screenshots:\n' + (values.links || '(none provided)') + '\n\n' +
               'Deadline / context:\n' + (values.deadline || '(none provided)');
+            // The shared /v1/polly/lead endpoint enforces strict enums on
+            // project_type / budget / timeline. Snapshot intake distinction
+            // lives in `source` ('aethermoore.com/governance-snapshot') and
+            // the labeled "GOVERNANCE SNAPSHOT INTAKE" header at the top of
+            // description — that's enough to filter in the operator view.
             var payload = {
               contact: values.email,
-              project_type: 'governance_snapshot_intake',
-              budget: '$500 (paid via Stripe)',
-              timeline: values.deadline || 'standard 5-business-day target',
+              project_type: 'other',
+              budget: 'under-5k',
+              timeline: 'asap',
               description: description,
               source: 'aethermoore.com/governance-snapshot',
               website: values.website,


### PR DESCRIPTION
## Summary

**HOTFIX for #1554.** The form shipped yesterday sent `project_type='governance_snapshot_intake'`, `budget='\$500 (paid via Stripe)'`, `timeline=<freeform deadline>`. The shared `/v1/polly/lead` endpoint enforces strict enums on all three — every submission would have 400ed.

Verified live against prod before fix:
\`\`\`
$ curl -X POST .../v1/polly/lead -d '{"project_type":"governance_snapshot_intake",...}'
HTTP 400  "project_type must be one of: audit, custom-overlay, advisory-call, subcontract, training, other"
\`\`\`

Verified live against prod with the patched payload:
\`\`\`
$ curl -X POST .../v1/polly/lead -d '{"project_type":"other","budget":"under-5k","timeline":"asap",...}'
HTTP 200  ok=true
\`\`\`

### Mapping

| Field | Before | After | Why |
|---|---|---|---|
| `project_type` | `governance_snapshot_intake` | `other` | Allowed enum; "Custom inquiry" is the closest semantic fit and already routes to a sane fulfillment packet |
| `budget` | `$500 (paid via Stripe)` | `under-5k` | Allowed enum bucket containing $500 |
| `timeline` | freeform deadline | `asap` | Allowed enum; SLA is 5 business days regardless |

### What's preserved

Snapshot intakes remain distinguishable in the operator view via:
- `source: 'aethermoore.com/governance-snapshot'` field (unchanged)
- `"GOVERNANCE SNAPSHOT INTAKE"` header at the top of `description` (unchanged)
- Freeform deadline still appears in description as `Deadline / context: …` (unchanged)

No info is lost; the dashboard just reads from `source` instead of `project_type` to filter snapshot leads.

## Test plan

- [x] Inline JS still parses
- [x] Live curl with patched payload returns HTTP 200
- [ ] After Pages deploy: submit a real intake form and confirm `polly-stats.html` lead count +1

🤖 Generated with [Claude Code](https://claude.com/claude-code)