### PR TITLE
feat(monetization): add service credits pilot

### DIFF
--- a/api/agent/system.js
+++ b/api/agent/system.js
@@ -2,7 +2,13 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { ALLOWED_TASKS, MAX_QUERY_LENGTH, envConfig, sendJson, setCors } = require('../_agent_common');
+const {
+  ALLOWED_TASKS,
+  MAX_QUERY_LENGTH,
+  envConfig,
+  sendJson,
+  setCors,
+} = require('../_agent_common');
 const { chatConfig } = require('../_chat_llm');
 const storage = require('./storage');
 
@@ -56,7 +62,11 @@ function buildSystemContract() {
     frontend: {
       static_host: appConfig.endpoints?.site_home || '',
       mobile_routes: [
-        { id: 'home', path: './index.html', purpose: 'status, offers, storage, and bridge overview' },
+        {
+          id: 'home',
+          path: './index.html',
+          purpose: 'status, offers, storage, and bridge overview',
+        },
         { id: 'chat', path: './chat.html', purpose: 'assistant, search, and export thread' },
         { id: 'ops', path: './ops.html', purpose: 'operator diagnostics and backend checks' },
         { id: 'browse', path: './browse.html', purpose: 'web lane entrypoint' },
@@ -89,6 +99,7 @@ function buildSystemContract() {
     },
     monetization: {
       offers_schema: offers.schema,
+      usage_policy: offers.usage_policy || {},
       live_offers: (offers.offers || [])
         .filter((offer) => offer.status === 'live')
         .map((offer) => ({

--- a/api/polly/catalog.js
+++ b/api/polly/catalog.js
@@ -4,6 +4,7 @@ const { sendJson, setCors } = require('../_agent_common');
 const {
   PRODUCT_CATALOG,
   CONSULTING_TIERS,
+  SERVICE_CREDITS_POLICY,
   CONSULTING_LANDING_URL,
   HIRE_EMAIL,
 } = require('./commerce');
@@ -25,6 +26,7 @@ module.exports = async function handler(req, res) {
       checkout_url: p.checkoutUrl,
       delivery_url: p.deliveryUrl,
     })),
+    service_credits_policy: SERVICE_CREDITS_POLICY,
     consulting_tiers: CONSULTING_TIERS,
     consulting_landing_url: CONSULTING_LANDING_URL,
     hire_email: HIRE_EMAIL,

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -2,6 +2,28 @@
 
 const PRODUCT_CATALOG = [
   {
+    sku: 'scbe-service-credits',
+    name: 'SCBE Service Credits',
+    priceLabel: '$5+ pay-as-you-go',
+    short:
+      'Small credit top-ups for hosted SCBE routing, governed runs, reports, and provider/model usage. We pass through compute/model cost and add only a 2-5% coordination fee where usage is billable.',
+    checkoutUrl: 'https://ko-fi.com/izdandavis',
+    deliveryUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html',
+    keywords: [
+      'credits',
+      'service credits',
+      'pay as you go',
+      'pay-as-you-go',
+      'token routing',
+      'tokens',
+      'usage',
+      'hosted run',
+      'hosted routing',
+      'ollama cloud',
+      'cloud models',
+    ],
+  },
+  {
     sku: 'ai-governance-snapshot',
     name: 'AI Governance Snapshot',
     priceLabel: '$500 one-time',
@@ -79,6 +101,18 @@ const CONSULTING_TIERS = [
     fit: "AI safety / LLM evaluation work on a SAM-registered prime's contract",
   },
 ];
+
+const SERVICE_CREDITS_POLICY = {
+  name: 'SCBE Service Credits',
+  serviceFeePercentRange: [2, 5],
+  minimumTopUpUsd: 5,
+  usageModel:
+    'mostly-free local tools; service credits only pay for hosted routing, reports, delivery, storage, and provider/model usage',
+  feeFormula:
+    'customer_charge = actual_provider_cost + max(actual_provider_cost * service_fee_percent, small_run_floor)',
+  preferredRouting:
+    'local/Ollama and deterministic harness first; paid providers only when the run needs hosted capacity or a customer explicitly requests it',
+};
 
 // Apex aethermoore.com only resolves Pages content under the project-prefixed
 // path; bare /hire returns 404 via the current Cloudflare routing. Use the
@@ -390,13 +424,18 @@ function renderResearchReply(message) {
 function renderMembershipReply() {
   const text =
     'Three ways to stay close to the work:\n\n' +
+    '- **Use service credits** for pay-as-you-go hosted routing without a big subscription\n' +
     '- **Sponsor / tip** the open-source work via Ko-fi\n' +
     '- **Watch the GitHub repo** for releases (`Watch -> Custom -> Releases`)\n' +
     '- **Email** me at the address below for a private update list\n\n' +
-    'There is no paid membership tier yet — open-source first; ' +
-    'sponsorships keep the next release shipping.';
+    'The target model is mostly free local tools, with credits only used when a hosted run, report, ' +
+    'or provider/model call is needed. Billable usage is passed through with a small 2-5% SCBE coordination fee.';
   const actions = [
-    { label: 'Tip on Ko-fi', url: MEMBERSHIP_KOFI_URL },
+    {
+      label: 'Service credits',
+      url: 'https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html',
+    },
+    { label: 'Top up on Ko-fi', url: MEMBERSHIP_KOFI_URL },
     { label: 'Watch the repo', url: 'https://github.com/issdandavis/SCBE-AETHERMOORE' },
     { label: 'Email Issac', url: `mailto:${HIRE_EMAIL}` },
   ];
@@ -406,6 +445,7 @@ function renderMembershipReply() {
 module.exports = {
   PRODUCT_CATALOG,
   CONSULTING_TIERS,
+  SERVICE_CREDITS_POLICY,
   CONSULTING_LANDING_URL,
   HIRE_EMAIL,
   MEMBERSHIP_KOFI_URL,

--- a/docs/app-config.json
+++ b/docs/app-config.json
@@ -27,6 +27,7 @@
     "site_home": "https://aethermoore.com/SCBE-AETHERMOORE/",
     "offers_page": "https://aethermoore.com/SCBE-AETHERMOORE/offers/",
     "supporter_page": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html",
+    "service_credits_page": "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html",
     "governance_snapshot_page": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
     "offers_json": "https://aethermoore.com/SCBE-AETHERMOORE/offers.json",
     "agent_bridge_health": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/health",
@@ -36,6 +37,7 @@
   },
   "features": {
     "tip_jar": true,
+    "service_credits": true,
     "supporter_monthly": true,
     "governance_snapshot": true,
     "zero_key_agent_bus": true,

--- a/docs/offers.json
+++ b/docs/offers.json
@@ -2,7 +2,23 @@
   "schema": "aethermoore-offers-v1",
   "updated_at": "2026-05-09",
   "site_base": "https://aethermoore.com/SCBE-AETHERMOORE",
+  "usage_policy": {
+    "name": "SCBE Service Credits",
+    "model": "mostly-free local tools with pay-as-you-go credits only for hosted routing, reports, delivery, storage, and provider/model usage",
+    "service_fee_percent_range": [2, 5],
+    "fee_note": "Provider/model costs are passed through with a small 2-5% SCBE coordination fee where usage is billable.",
+    "preferred_routing": "local/Ollama and deterministic harness first; paid providers only when needed"
+  },
   "offers": [
+    {
+      "id": "service_credits",
+      "name": "SCBE Service Credits",
+      "price_label": "$5+ pay-as-you-go",
+      "type": "usage_credit",
+      "checkout_url": "https://ko-fi.com/izdandavis",
+      "proof_url": "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html",
+      "status": "live"
+    },
     {
       "id": "tip_jar",
       "name": "Tip Jar",

--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -152,8 +152,10 @@
           <h1>SCBE customer offers</h1>
           <p class="lead">
             Buy a concrete AI governance product without a sales call. Start with the $500 AI
-            Governance Snapshot, pick a $29 self-serve toolkit, or support the open-source work. No
-            subscription is required for one-time products.
+            Governance Snapshot, pick a $29 self-serve toolkit, or use small SCBE Service Credits
+            for hosted routing and reports. Local tools stay mostly free; credits are only for
+            hosted capacity, delivery, storage, and provider/model usage with a 2-5% coordination
+            fee.
           </p>
           <p>No subscription.</p>
           <a
@@ -192,6 +194,24 @@
         </p>
       </section>
       <section id="includes" class="grid" aria-label="SCBE offers">
+        <article class="card">
+          <h2>SCBE Service Credits</h2>
+          <p>
+            Pay-as-you-go top-ups for hosted governed runs, AI routing, report delivery, and
+            provider/model usage. The system prefers local/Ollama and deterministic harnesses first;
+            billable usage passes through actual provider cost plus a small 2-5% SCBE coordination
+            fee.
+          </p>
+          <div class="price">$5+ top-up</div>
+          <a
+            class="btn btn-primary"
+            href="https://ko-fi.com/izdandavis"
+            target="_blank"
+            rel="noopener"
+            >Top Up Credits</a
+          >
+          <a class="btn btn-secondary" href="../service-credits.html">How Credits Work</a>
+        </article>
         <article class="card">
           <h2>SCBE AI Governance Toolkit</h2>
           <p>

--- a/docs/service-credits.html
+++ b/docs/service-credits.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SCBE Service Credits | AetherMoore</title>
+    <meta
+      name="description"
+      content="Pay-as-you-go SCBE service credits for hosted routing, governed reports, and provider usage."
+    />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html" />
+    <style>
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: #0b0d12;
+        color: #f2f0ea;
+        line-height: 1.55;
+      }
+      main {
+        width: min(920px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 46px 0;
+      }
+      a {
+        color: inherit;
+      }
+      .nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        color: #a3acb9;
+        margin-bottom: 40px;
+      }
+      h1 {
+        font-size: clamp(36px, 7vw, 70px);
+        line-height: 0.96;
+        margin: 0 0 18px;
+      }
+      .lead {
+        color: #a3acb9;
+        max-width: 740px;
+        font-size: 18px;
+      }
+      .grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        margin-top: 30px;
+      }
+      .card,
+      .notice {
+        border: 1px solid rgba(214, 167, 86, 0.2);
+        background: #11161f;
+        border-radius: 8px;
+        padding: 22px;
+      }
+      .notice {
+        margin-top: 28px;
+        background: #141b29;
+      }
+      .price {
+        color: #d6a756;
+        font-weight: 800;
+      }
+      .btn {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 11px 14px;
+        border-radius: 6px;
+        background: #d6a756;
+        color: #14110c;
+        font-weight: 800;
+        text-decoration: none;
+      }
+      code {
+        color: #d6a756;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <nav class="nav" aria-label="Service credits navigation">
+        <a href="index.html">Home</a>
+        <a href="offers/">Offers</a>
+        <a href="hire.html">Hire</a>
+        <a href="support.html">Support</a>
+      </nav>
+
+      <h1>SCBE Service Credits</h1>
+      <p class="lead">
+        Credits are the small, flexible payment path for hosted SCBE work. Local npm tools,
+        deterministic checks, and Ollama-first routing should stay free whenever possible. Credits
+        are used only when a run needs hosted capacity, report delivery, storage, or paid
+        provider/model usage.
+      </p>
+
+      <section class="grid" aria-label="Credit model">
+        <article class="card">
+          <h2>Fee Rule</h2>
+          <p>
+            Billable usage is charged as actual provider/model cost plus a small SCBE coordination
+            fee.
+          </p>
+          <p class="price">2-5% over actual usage cost</p>
+        </article>
+        <article class="card">
+          <h2>Routing Rule</h2>
+          <p>
+            The system tries local/Ollama, deterministic harnesses, and free hosted routes first.
+            Paid providers are reserved for work that actually needs them.
+          </p>
+          <p class="price">mostly free by default</p>
+        </article>
+        <article class="card">
+          <h2>Top Up</h2>
+          <p>
+            Small top-ups fund hosted runs while the automated wallet matures. Include your email
+            and what you want routed or reviewed.
+          </p>
+          <p class="price">$5+ pilot top-up</p>
+          <a class="btn" href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
+            >Top Up Credits</a
+          >
+        </article>
+      </section>
+
+      <section class="notice">
+        <h2>What credits can pay for</h2>
+        <p>
+          Hosted agent-bus routing, governance snapshots, report generation, model calls, dataset
+          cleanup, private delivery links, and storage handoff. The receipt should show the routed
+          job, the provider/model used when applicable, the estimated or actual provider cost, and
+          the SCBE fee.
+        </p>
+        <p>
+          Target formula:
+          <code>customer charge = provider cost + 2-5% SCBE coordination fee</code>.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/api/polly_commerce.py
+++ b/src/api/polly_commerce.py
@@ -60,6 +60,31 @@ class Product:
 
 PRODUCT_CATALOG: Tuple[Product, ...] = (
     Product(
+        sku="scbe-service-credits",
+        name="SCBE Service Credits",
+        price_label="$5+ pay-as-you-go",
+        short=(
+            "Small credit top-ups for hosted SCBE routing, governed runs, "
+            "reports, and provider/model usage. We pass through compute/model "
+            "cost and add only a 2-5% coordination fee where usage is billable."
+        ),
+        checkout_url="https://ko-fi.com/izdandavis",
+        delivery_url="https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html",
+        keywords=(
+            "credits",
+            "service credits",
+            "pay as you go",
+            "pay-as-you-go",
+            "token routing",
+            "tokens",
+            "usage",
+            "hosted run",
+            "hosted routing",
+            "ollama cloud",
+            "cloud models",
+        ),
+    ),
+    Product(
         sku="ai-governance-toolkit",
         name="SCBE AI Governance Toolkit",
         price_label="$29 one-time",
@@ -70,7 +95,13 @@ PRODUCT_CATALOG: Tuple[Product, ...] = (
         ),
         checkout_url="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06",
         delivery_url="https://aethermoore.com/product-manual/ai-governance-toolkit.html",
-        keywords=("toolkit", "governance toolkit", "ai governance", "templates", "decision records"),
+        keywords=(
+            "toolkit",
+            "governance toolkit",
+            "ai governance",
+            "templates",
+            "decision records",
+        ),
     ),
     Product(
         sku="ai-security-training-vault",
@@ -83,7 +114,14 @@ PRODUCT_CATALOG: Tuple[Product, ...] = (
         ),
         checkout_url="https://buy.stripe.com/28E8wQ5Cacuj64EaCydby0g",
         delivery_url="https://aethermoore.com/product-manual/training-vault.html",
-        keywords=("training vault", "training data", "vault", "ai security", "benchmark suite", "notebooks"),
+        keywords=(
+            "training vault",
+            "training data",
+            "vault",
+            "ai security",
+            "benchmark suite",
+            "notebooks",
+        ),
     ),
     Product(
         sku="five-dollar-tip-jar",
@@ -93,8 +131,16 @@ PRODUCT_CATALOG: Tuple[Product, ...] = (
             "If the open-source work has helped you and there's no formal "
             "engagement, a tip keeps the next release shipping."
         ),
-        checkout_url="https://ko-fi.com/Y8Y51UQYWZ",
-        keywords=("tip", "tip jar", "donate", "donation", "support", "buy a coffee", "coffee"),
+        checkout_url="https://ko-fi.com/izdandavis",
+        keywords=(
+            "tip",
+            "tip jar",
+            "donate",
+            "donation",
+            "support",
+            "buy a coffee",
+            "coffee",
+        ),
     ),
 )
 
@@ -129,7 +175,25 @@ CONSULTING_TIERS: Tuple[Dict[str, str], ...] = (
 
 CONSULTING_LANDING_URL = "https://aethermoore.com/hire"
 HIRE_EMAIL = "issdandavis7795@gmail.com"
-MEMBERSHIP_KOFI_URL = "https://ko-fi.com/Y8Y51UQYWZ"
+MEMBERSHIP_KOFI_URL = "https://ko-fi.com/izdandavis"
+
+SERVICE_CREDITS_POLICY: Dict[str, Any] = {
+    "name": "SCBE Service Credits",
+    "service_fee_percent_range": [2, 5],
+    "minimum_top_up_usd": 5,
+    "usage_model": (
+        "mostly-free local tools; service credits only pay for hosted routing, "
+        "reports, delivery, storage, and provider/model usage"
+    ),
+    "fee_formula": (
+        "customer_charge = actual_provider_cost + "
+        "max(actual_provider_cost * service_fee_percent, small_run_floor)"
+    ),
+    "preferred_routing": (
+        "local/Ollama and deterministic harness first; paid providers only "
+        "when the run needs hosted capacity or a customer explicitly requests it"
+    ),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -148,7 +212,8 @@ class Intent:
 
 
 _BUY_PATTERN = re.compile(
-    r"\b(buy|purchase|order|checkout|pay\s+for|get\s+the|want\s+the|" r"how\s+much|sign\s+me\s+up|add\s+to\s+cart)\b",
+    r"\b(buy|purchase|order|checkout|pay\s+for|get\s+the|want\s+the|"
+    r"how\s+much|sign\s+me\s+up|add\s+to\s+cart)\b",
     re.IGNORECASE,
 )
 
@@ -195,22 +260,30 @@ def classify_intent(message: str) -> Intent:
     # Bare product keyword without explicit buy verb still surfaces the product.
     product = _resolve_product(message)
     if product is not None:
-        return Intent(name="buy", confidence=0.6, matched_term=product.sku, product=product)
+        return Intent(
+            name="buy", confidence=0.6, matched_term=product.sku, product=product
+        )
 
     # Custom-build intent.
     custom_match = _CUSTOM_PATTERN.search(message)
     if custom_match:
-        return Intent(name="custom", confidence=0.85, matched_term=custom_match.group(0))
+        return Intent(
+            name="custom", confidence=0.85, matched_term=custom_match.group(0)
+        )
 
     # Research intent.
     research_match = _RESEARCH_PATTERN.search(message)
     if research_match:
-        return Intent(name="research", confidence=0.8, matched_term=research_match.group(0))
+        return Intent(
+            name="research", confidence=0.8, matched_term=research_match.group(0)
+        )
 
     # Membership / sponsorship intent.
     membership_match = _MEMBERSHIP_PATTERN.search(message)
     if membership_match:
-        return Intent(name="membership", confidence=0.75, matched_term=membership_match.group(0))
+        return Intent(
+            name="membership", confidence=0.75, matched_term=membership_match.group(0)
+        )
 
     return Intent(name="general", confidence=0.0)
 
@@ -243,7 +316,11 @@ def render_buy_reply(product: Optional[Product]) -> Tuple[str, List[Dict[str, st
             actions.append({"label": f"Buy {item.name}", "url": item.checkout_url})
         return "\n".join(lines), actions
 
-    text = f"**{product.name}** — {product.price_label}.\n\n" f"{product.short}\n\n" f"Checkout: {product.checkout_url}"
+    text = (
+        f"**{product.name}** — {product.price_label}.\n\n"
+        f"{product.short}\n\n"
+        f"Checkout: {product.checkout_url}"
+    )
     if product.delivery_url:
         text += f"\nWhat you get + delivery: {product.delivery_url}"
     actions = [{"label": f"Buy {product.name}", "url": product.checkout_url}]
@@ -268,7 +345,9 @@ def render_custom_reply(message: str) -> Tuple[str, List[Dict[str, str]]]:
     )
     mailto = f"mailto:{HIRE_EMAIL}" f"?subject={quote(subject)}" f"&body={quote(body)}"
 
-    tier_lines = [f"- **{t['name']}** ({t['price']}) — {t['fit']}" for t in CONSULTING_TIERS]
+    tier_lines = [
+        f"- **{t['name']}** ({t['price']}) — {t['fit']}" for t in CONSULTING_TIERS
+    ]
     text = (
         "What you're describing is custom — not in the stock catalog. "
         "Four ways we can scope it:\n\n"
@@ -287,15 +366,24 @@ def render_membership_reply() -> Tuple[str, List[Dict[str, str]]]:
     """Render a membership / sponsorship CTA."""
     text = (
         "Three ways to stay close to the work:\n\n"
+        "- **Use service credits** for pay-as-you-go hosted routing without a big subscription\n"
         "- **Sponsor / tip** the open-source work via Ko-fi\n"
         "- **Watch the GitHub repo** for releases (`Watch -> Custom -> Releases`)\n"
         "- **Email** me at the address below for a private update list\n\n"
-        "There is no paid membership tier yet — open-source first; "
-        "sponsorships keep the next release shipping."
+        "The target model is mostly free local tools, with credits only used when "
+        "a hosted run, report, or provider/model call is needed. Billable usage is "
+        "passed through with a small 2-5% SCBE coordination fee."
     )
     actions = [
-        {"label": "Tip on Ko-fi", "url": MEMBERSHIP_KOFI_URL},
-        {"label": "Watch the repo", "url": "https://github.com/issdandavis/SCBE-AETHERMOORE"},
+        {
+            "label": "Service credits",
+            "url": "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html",
+        },
+        {"label": "Top up on Ko-fi", "url": MEMBERSHIP_KOFI_URL},
+        {
+            "label": "Watch the repo",
+            "url": "https://github.com/issdandavis/SCBE-AETHERMOORE",
+        },
         {"label": "Email Issac", "url": f"mailto:{HIRE_EMAIL}"},
     ]
     return text, actions
@@ -307,7 +395,9 @@ def render_membership_reply() -> Tuple[str, List[Dict[str, str]]]:
 
 
 _TRAIN_CORPUS_DIR_ENV = "POLLY_TRAIN_CORPUS_DIR"
-_DEFAULT_TRAIN_CORPUS_DIR = Path(__file__).resolve().parents[2] / "training-data" / "polly-chat-live"
+_DEFAULT_TRAIN_CORPUS_DIR = (
+    Path(__file__).resolve().parents[2] / "training-data" / "polly-chat-live"
+)
 
 
 def train_corpus_dir() -> Path:
@@ -376,6 +466,7 @@ __all__ = [
     "Product",
     "PRODUCT_CATALOG",
     "CONSULTING_TIERS",
+    "SERVICE_CREDITS_POLICY",
     "CONSULTING_LANDING_URL",
     "HIRE_EMAIL",
     "MEMBERSHIP_KOFI_URL",

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -174,12 +174,18 @@ describe('polly lead handler — anti-abuse', () => {
 });
 
 describe('polly commerce intent classification', () => {
-  it('catalog has four live products with valid stripe/kofi urls', () => {
-    expect(commerce.PRODUCT_CATALOG).toHaveLength(4);
+  it('catalog has five live products with valid stripe/kofi urls', () => {
+    expect(commerce.PRODUCT_CATALOG).toHaveLength(5);
     for (const product of commerce.PRODUCT_CATALOG) {
       expect(product.checkoutUrl).toMatch(/^https:\/\/(buy\.stripe\.com|ko-fi\.com)/);
       expect(product.keywords.length).toBeGreaterThan(0);
     }
+  });
+
+  it('classifies service credits as the pay-as-you-go product', () => {
+    const intent = commerce.classifyIntent('I want to buy service credits for hosted routing');
+    expect(intent.name).toBe('buy');
+    expect(intent.product.sku).toBe('scbe-service-credits');
   });
 
   it('classifies "buy" verb with bound product at 0.95 confidence', () => {
@@ -262,9 +268,9 @@ describe('polly commerce reply rendering', () => {
     expect(out.actions[0].url).toBe(product.checkoutUrl);
   });
 
-  it('renderBuyReply with null lists all 4 products', () => {
+  it('renderBuyReply with null lists all products', () => {
     const out = commerce.renderBuyReply(null);
-    expect(out.actions).toHaveLength(4);
+    expect(out.actions).toHaveLength(commerce.PRODUCT_CATALOG.length);
     for (const action of out.actions) {
       expect(action.url).toMatch(/^https:\/\//);
     }
@@ -281,12 +287,14 @@ describe('polly commerce reply rendering', () => {
     );
   });
 
-  it('renderMembershipReply has Ko-fi + GitHub + email actions', () => {
+  it('renderMembershipReply has credits + Ko-fi + GitHub + email actions', () => {
     const out = commerce.renderMembershipReply();
-    expect(out.actions).toHaveLength(3);
-    expect(out.actions[0].url).toContain('ko-fi.com');
-    expect(out.actions[1].url).toContain('github.com');
-    expect(out.actions[2].url).toContain('mailto:');
+    expect(out.actions).toHaveLength(4);
+    expect(out.actions[0].url).toContain('service-credits');
+    expect(out.actions[1].url).toContain('ko-fi.com');
+    expect(out.actions[2].url).toContain('github.com');
+    expect(out.actions[3].url).toContain('mailto:');
+    expect(out.text).toContain('2-5%');
   });
 
   it('renderResearchReply with matching topic returns canonical body + repo links', () => {
@@ -441,7 +449,7 @@ describe('polly catalog handler', () => {
     expect(res.statusCode).toBe(200);
     const body = res.body as { ok: boolean; products: unknown[]; consulting_tiers: unknown[] };
     expect(body.ok).toBe(true);
-    expect(body.products).toHaveLength(4);
+    expect(body.products).toHaveLength(commerce.PRODUCT_CATALOG.length);
     expect(body.consulting_tiers.length).toBeGreaterThan(0);
   });
 

--- a/tests/api/test_polly_commerce.py
+++ b/tests/api/test_polly_commerce.py
@@ -29,7 +29,9 @@ def test_catalog_is_nonempty_and_has_real_stripe_links() -> None:
         assert product.name
         assert product.price_label
         assert product.short
-        assert product.checkout_url.startswith(("https://buy.stripe.com/", "https://ko-fi.com/"))
+        assert product.checkout_url.startswith(
+            ("https://buy.stripe.com/", "https://ko-fi.com/")
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -45,6 +47,8 @@ def test_catalog_is_nonempty_and_has_real_stripe_links() -> None:
         ("Can I purchase the SCBE governance toolkit?", "buy"),
         ("Add to cart please", "buy"),
         ("Sign me up for the toolkit", "buy"),
+        ("I want to buy service credits", "buy"),
+        ("hosted routing credits", "buy"),
         ("toolkit", "buy"),
         ("training vault", "buy"),
         ("buy a coffee", "buy"),  # tip jar keyword
@@ -77,6 +81,13 @@ def test_classify_intent_buy_resolves_training_vault() -> None:
     assert intent.name == "buy"
     assert intent.product is not None
     assert intent.product.sku == "ai-security-training-vault"
+
+
+def test_classify_intent_buy_resolves_service_credits() -> None:
+    intent = classify_intent("Can I buy service credits for cloud models?")
+    assert intent.name == "buy"
+    assert intent.product is not None
+    assert intent.product.sku == "scbe-service-credits"
 
 
 def test_classify_intent_buy_without_product_keyword() -> None:
@@ -113,7 +124,9 @@ def test_render_buy_reply_without_product_lists_full_catalog() -> None:
 
 
 def test_render_custom_reply_includes_mailto_with_user_context() -> None:
-    text, actions = render_custom_reply("I need a governance overlay for our finance LLM")
+    text, actions = render_custom_reply(
+        "I need a governance overlay for our finance LLM"
+    )
     mailto_action = next((a for a in actions if a["url"].startswith("mailto:")), None)
     assert mailto_action is not None
     # mailto: URLs treat @ as a safe character; urllib.parse.quote leaves it as-is.
@@ -124,8 +137,11 @@ def test_render_custom_reply_includes_mailto_with_user_context() -> None:
 def test_render_membership_reply_returns_kofi_link() -> None:
     text, actions = render_membership_reply()
     kofi = next((a for a in actions if "ko-fi.com" in a["url"]), None)
+    credits = next((a for a in actions if "service-credits" in a["url"]), None)
+    assert credits is not None
     assert kofi is not None
     assert "Ko-fi" in text or "ko-fi" in text.lower()
+    assert "2-5%" in text
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +149,9 @@ def test_render_membership_reply_returns_kofi_link() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_append_training_record_writes_jsonl_with_consent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_append_training_record_writes_jsonl_with_consent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     shard = append_training_record(
         consent=True,
@@ -151,7 +169,9 @@ def test_append_training_record_writes_jsonl_with_consent(tmp_path: Path, monkey
     assert "ts" in record
 
 
-def test_append_training_record_skips_without_consent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_append_training_record_skips_without_consent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     shard = append_training_record(
         consent=False,
@@ -163,7 +183,9 @@ def test_append_training_record_skips_without_consent(tmp_path: Path, monkeypatc
     assert list(tmp_path.glob("*.jsonl")) == []
 
 
-def test_append_training_record_appends_multiple_turns(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_append_training_record_appends_multiple_turns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     for i in range(3):
         append_training_record(
@@ -183,7 +205,9 @@ def test_append_training_record_appends_multiple_turns(tmp_path: Path, monkeypat
         assert record["session_id"] == "session-1"
 
 
-def test_append_training_record_records_feedback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_append_training_record_records_feedback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     shard = append_training_record(
         consent=True,
@@ -197,7 +221,9 @@ def test_append_training_record_records_feedback(tmp_path: Path, monkeypatch: py
     assert record["feedback"] == "up"
 
 
-def test_append_training_record_truncates_long_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_append_training_record_truncates_long_inputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     shard = append_training_record(
         consent=True,
@@ -211,6 +237,8 @@ def test_append_training_record_truncates_long_inputs(tmp_path: Path, monkeypatc
     assert len(record["assistant"]) <= 8192
 
 
-def test_train_corpus_dir_respects_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_train_corpus_dir_respects_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     assert train_corpus_dir() == tmp_path

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -60,17 +60,32 @@ def test_download_bridge_serves_private_blob_with_delivery_token() -> None:
 
 
 def test_public_offer_catalog_has_live_revenue_links() -> None:
-    offers = json.loads((REPO_ROOT / "docs" / "offers.json").read_text(encoding="utf-8"))
+    offers = json.loads(
+        (REPO_ROOT / "docs" / "offers.json").read_text(encoding="utf-8")
+    )
     by_id = {offer["id"]: offer for offer in offers["offers"]}
 
     assert offers["schema"] == "aethermoore-offers-v1"
-    assert by_id["tip_jar"]["checkout_url"] == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
-    assert by_id["supporter_monthly"]["checkout_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
-    assert by_id["governance_snapshot"]["intake_url"].endswith("/governance-snapshot.html#intake")
+    assert (
+        by_id["tip_jar"]["checkout_url"]
+        == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+    )
+    assert by_id["service_credits"]["checkout_url"] == "https://ko-fi.com/izdandavis"
+    assert by_id["service_credits"]["proof_url"].endswith("/service-credits.html")
+    assert (
+        by_id["supporter_monthly"]["checkout_url"]
+        == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    )
+    assert by_id["governance_snapshot"]["intake_url"].endswith(
+        "/governance-snapshot.html#intake"
+    )
+    assert offers["usage_policy"]["service_fee_percent_range"] == [2, 5]
 
 
 def test_public_app_config_explains_remote_update_boundary() -> None:
-    config = json.loads((REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8"))
+    config = json.loads(
+        (REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8")
+    )
 
     assert config["schema"] == "aethermoor-bus-app-config-v1"
     assert config["app"]["package_name"] == "io.aethermoor.bus"
@@ -78,6 +93,7 @@ def test_public_app_config_explains_remote_update_boundary() -> None:
     assert "offer links" in config["remote_update"]["applies_to"]
     assert "package name" in config["remote_update"]["requires_store_release"]
     assert config["features"]["tip_jar"] is True
+    assert config["features"]["service_credits"] is True
 
 
 def test_supporter_page_uses_direct_stripe_checkout_not_broken_api_bridge() -> None:
@@ -88,9 +104,15 @@ def test_supporter_page_uses_direct_stripe_checkout_not_broken_api_bridge() -> N
 
 
 def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:
-    offers_source = (REPO_ROOT / "api" / "agent" / "offers.js").read_text(encoding="utf-8")
-    app_config_source = (REPO_ROOT / "api" / "agent" / "app-config.js").read_text(encoding="utf-8")
-    system_source = (REPO_ROOT / "api" / "agent" / "system.js").read_text(encoding="utf-8")
+    offers_source = (REPO_ROOT / "api" / "agent" / "offers.js").read_text(
+        encoding="utf-8"
+    )
+    app_config_source = (REPO_ROOT / "api" / "agent" / "app-config.js").read_text(
+        encoding="utf-8"
+    )
+    system_source = (REPO_ROOT / "api" / "agent" / "system.js").read_text(
+        encoding="utf-8"
+    )
 
     assert "docs/offers.json" in offers_source
     assert "s-maxage=300" in offers_source
@@ -99,9 +121,12 @@ def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:
     assert "aethermoor.agent.system_contract.v1" in system_source
     assert "/api/agent/chat" in system_source
     assert "workspace_formation" in system_source
+    assert "usage_policy" in system_source
 
 
 def test_public_app_config_exposes_unified_system_contract() -> None:
-    config = json.loads((REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8"))
+    config = json.loads(
+        (REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8")
+    )
 
     assert config["endpoints"]["agent_bridge_system"].endswith("/api/agent/system")


### PR DESCRIPTION
## Summary
- add SCBE Service Credits as a low-friction pay-as-you-go offer
- expose usage policy through the Polly commerce catalog, agent system payload, offers JSON, and app config
- add a public service-credits page and surface it in the offers page

## Monetization model
- local npm/deterministic/Ollama-first usage stays mostly free
- credits apply to hosted routing, reports, delivery, storage, and provider/model usage
- billable usage is provider cost plus a 2-5% SCBE coordination fee
- initial checkout routes to Ko-fi for fast top-ups

## Tests
- npx prettier --check api\polly\commerce.js api\polly\catalog.js api\agent\system.js docs\offers.json docs\app-config.json docs\offers\index.html docs\service-credits.html tests\api\polly_commerce_js.test.ts
- python -m black --check src\api\polly_commerce.py tests\api\test_polly_commerce.py tests\test_vercel_launch_bridge.py
- npm test -- tests/api/polly_commerce_js.test.ts
- python -m pytest tests/api/test_polly_commerce.py tests/test_vercel_launch_bridge.py -q
- python scripts\system\remote_app_config_smoke.py
- git diff --check