### PR TITLE
style(monetization): match service credits ci black target

### DIFF
--- a/src/api/polly_commerce.py
+++ b/src/api/polly_commerce.py
@@ -186,8 +186,7 @@ SERVICE_CREDITS_POLICY: Dict[str, Any] = {
         "reports, delivery, storage, and provider/model usage"
     ),
     "fee_formula": (
-        "customer_charge = actual_provider_cost + "
-        "max(actual_provider_cost * service_fee_percent, small_run_floor)"
+        "customer_charge = actual_provider_cost + " "max(actual_provider_cost * service_fee_percent, small_run_floor)"
     ),
     "preferred_routing": (
         "local/Ollama and deterministic harness first; paid providers only "
@@ -212,8 +211,7 @@ class Intent:
 
 
 _BUY_PATTERN = re.compile(
-    r"\b(buy|purchase|order|checkout|pay\s+for|get\s+the|want\s+the|"
-    r"how\s+much|sign\s+me\s+up|add\s+to\s+cart)\b",
+    r"\b(buy|purchase|order|checkout|pay\s+for|get\s+the|want\s+the|" r"how\s+much|sign\s+me\s+up|add\s+to\s+cart)\b",
     re.IGNORECASE,
 )
 
@@ -260,30 +258,22 @@ def classify_intent(message: str) -> Intent:
     # Bare product keyword without explicit buy verb still surfaces the product.
     product = _resolve_product(message)
     if product is not None:
-        return Intent(
-            name="buy", confidence=0.6, matched_term=product.sku, product=product
-        )
+        return Intent(name="buy", confidence=0.6, matched_term=product.sku, product=product)
 
     # Custom-build intent.
     custom_match = _CUSTOM_PATTERN.search(message)
     if custom_match:
-        return Intent(
-            name="custom", confidence=0.85, matched_term=custom_match.group(0)
-        )
+        return Intent(name="custom", confidence=0.85, matched_term=custom_match.group(0))
 
     # Research intent.
     research_match = _RESEARCH_PATTERN.search(message)
     if research_match:
-        return Intent(
-            name="research", confidence=0.8, matched_term=research_match.group(0)
-        )
+        return Intent(name="research", confidence=0.8, matched_term=research_match.group(0))
 
     # Membership / sponsorship intent.
     membership_match = _MEMBERSHIP_PATTERN.search(message)
     if membership_match:
-        return Intent(
-            name="membership", confidence=0.75, matched_term=membership_match.group(0)
-        )
+        return Intent(name="membership", confidence=0.75, matched_term=membership_match.group(0))
 
     return Intent(name="general", confidence=0.0)
 
@@ -316,11 +306,7 @@ def render_buy_reply(product: Optional[Product]) -> Tuple[str, List[Dict[str, st
             actions.append({"label": f"Buy {item.name}", "url": item.checkout_url})
         return "\n".join(lines), actions
 
-    text = (
-        f"**{product.name}** — {product.price_label}.\n\n"
-        f"{product.short}\n\n"
-        f"Checkout: {product.checkout_url}"
-    )
+    text = f"**{product.name}** — {product.price_label}.\n\n" f"{product.short}\n\n" f"Checkout: {product.checkout_url}"
     if product.delivery_url:
         text += f"\nWhat you get + delivery: {product.delivery_url}"
     actions = [{"label": f"Buy {product.name}", "url": product.checkout_url}]
@@ -345,9 +331,7 @@ def render_custom_reply(message: str) -> Tuple[str, List[Dict[str, str]]]:
     )
     mailto = f"mailto:{HIRE_EMAIL}" f"?subject={quote(subject)}" f"&body={quote(body)}"
 
-    tier_lines = [
-        f"- **{t['name']}** ({t['price']}) — {t['fit']}" for t in CONSULTING_TIERS
-    ]
+    tier_lines = [f"- **{t['name']}** ({t['price']}) — {t['fit']}" for t in CONSULTING_TIERS]
     text = (
         "What you're describing is custom — not in the stock catalog. "
         "Four ways we can scope it:\n\n"
@@ -395,9 +379,7 @@ def render_membership_reply() -> Tuple[str, List[Dict[str, str]]]:
 
 
 _TRAIN_CORPUS_DIR_ENV = "POLLY_TRAIN_CORPUS_DIR"
-_DEFAULT_TRAIN_CORPUS_DIR = (
-    Path(__file__).resolve().parents[2] / "training-data" / "polly-chat-live"
-)
+_DEFAULT_TRAIN_CORPUS_DIR = Path(__file__).resolve().parents[2] / "training-data" / "polly-chat-live"
 
 
 def train_corpus_dir() -> Path:

--- a/tests/api/test_polly_commerce.py
+++ b/tests/api/test_polly_commerce.py
@@ -29,9 +29,7 @@ def test_catalog_is_nonempty_and_has_real_stripe_links() -> None:
         assert product.name
         assert product.price_label
         assert product.short
-        assert product.checkout_url.startswith(
-            ("https://buy.stripe.com/", "https://ko-fi.com/")
-        )
+        assert product.checkout_url.startswith(("https://buy.stripe.com/", "https://ko-fi.com/"))
 
 
 # ---------------------------------------------------------------------------
@@ -124,9 +122,7 @@ def test_render_buy_reply_without_product_lists_full_catalog() -> None:
 
 
 def test_render_custom_reply_includes_mailto_with_user_context() -> None:
-    text, actions = render_custom_reply(
-        "I need a governance overlay for our finance LLM"
-    )
+    text, actions = render_custom_reply("I need a governance overlay for our finance LLM")
     mailto_action = next((a for a in actions if a["url"].startswith("mailto:")), None)
     assert mailto_action is not None
     # mailto: URLs treat @ as a safe character; urllib.parse.quote leaves it as-is.
@@ -149,9 +145,7 @@ def test_render_membership_reply_returns_kofi_link() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_append_training_record_writes_jsonl_with_consent(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_append_training_record_writes_jsonl_with_consent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     shard = append_training_record(
         consent=True,
@@ -169,9 +163,7 @@ def test_append_training_record_writes_jsonl_with_consent(
     assert "ts" in record
 
 
-def test_append_training_record_skips_without_consent(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_append_training_record_skips_without_consent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     shard = append_training_record(
         consent=False,
@@ -183,9 +175,7 @@ def test_append_training_record_skips_without_consent(
     assert list(tmp_path.glob("*.jsonl")) == []
 
 
-def test_append_training_record_appends_multiple_turns(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_append_training_record_appends_multiple_turns(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     for i in range(3):
         append_training_record(
@@ -205,9 +195,7 @@ def test_append_training_record_appends_multiple_turns(
         assert record["session_id"] == "session-1"
 
 
-def test_append_training_record_records_feedback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_append_training_record_records_feedback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     shard = append_training_record(
         consent=True,
@@ -221,9 +209,7 @@ def test_append_training_record_records_feedback(
     assert record["feedback"] == "up"
 
 
-def test_append_training_record_truncates_long_inputs(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_append_training_record_truncates_long_inputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     shard = append_training_record(
         consent=True,
@@ -237,8 +223,6 @@ def test_append_training_record_truncates_long_inputs(
     assert len(record["assistant"]) <= 8192
 
 
-def test_train_corpus_dir_respects_env_override(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_train_corpus_dir_respects_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLLY_TRAIN_CORPUS_DIR", str(tmp_path))
     assert train_corpus_dir() == tmp_path

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -60,32 +60,20 @@ def test_download_bridge_serves_private_blob_with_delivery_token() -> None:
 
 
 def test_public_offer_catalog_has_live_revenue_links() -> None:
-    offers = json.loads(
-        (REPO_ROOT / "docs" / "offers.json").read_text(encoding="utf-8")
-    )
+    offers = json.loads((REPO_ROOT / "docs" / "offers.json").read_text(encoding="utf-8"))
     by_id = {offer["id"]: offer for offer in offers["offers"]}
 
     assert offers["schema"] == "aethermoore-offers-v1"
-    assert (
-        by_id["tip_jar"]["checkout_url"]
-        == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
-    )
+    assert by_id["tip_jar"]["checkout_url"] == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
     assert by_id["service_credits"]["checkout_url"] == "https://ko-fi.com/izdandavis"
     assert by_id["service_credits"]["proof_url"].endswith("/service-credits.html")
-    assert (
-        by_id["supporter_monthly"]["checkout_url"]
-        == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
-    )
-    assert by_id["governance_snapshot"]["intake_url"].endswith(
-        "/governance-snapshot.html#intake"
-    )
+    assert by_id["supporter_monthly"]["checkout_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    assert by_id["governance_snapshot"]["intake_url"].endswith("/governance-snapshot.html#intake")
     assert offers["usage_policy"]["service_fee_percent_range"] == [2, 5]
 
 
 def test_public_app_config_explains_remote_update_boundary() -> None:
-    config = json.loads(
-        (REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8")
-    )
+    config = json.loads((REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8"))
 
     assert config["schema"] == "aethermoor-bus-app-config-v1"
     assert config["app"]["package_name"] == "io.aethermoor.bus"
@@ -104,15 +92,9 @@ def test_supporter_page_uses_direct_stripe_checkout_not_broken_api_bridge() -> N
 
 
 def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:
-    offers_source = (REPO_ROOT / "api" / "agent" / "offers.js").read_text(
-        encoding="utf-8"
-    )
-    app_config_source = (REPO_ROOT / "api" / "agent" / "app-config.js").read_text(
-        encoding="utf-8"
-    )
-    system_source = (REPO_ROOT / "api" / "agent" / "system.js").read_text(
-        encoding="utf-8"
-    )
+    offers_source = (REPO_ROOT / "api" / "agent" / "offers.js").read_text(encoding="utf-8")
+    app_config_source = (REPO_ROOT / "api" / "agent" / "app-config.js").read_text(encoding="utf-8")
+    system_source = (REPO_ROOT / "api" / "agent" / "system.js").read_text(encoding="utf-8")
 
     assert "docs/offers.json" in offers_source
     assert "s-maxage=300" in offers_source
@@ -125,8 +107,6 @@ def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:
 
 
 def test_public_app_config_exposes_unified_system_contract() -> None:
-    config = json.loads(
-        (REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8")
-    )
+    config = json.loads((REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8"))
 
     assert config["endpoints"]["agent_bridge_system"].endswith("/api/agent/system")


### PR DESCRIPTION
## Summary
- apply the exact CI Black target formatting for the service credits Python mirror/tests
- fixes the Lint and Format Check failure left after #1557 auto-merged before the format-only commit was picked up

## Tests
- python -m black --check --target-version py311 --line-length 120 src\api\polly_commerce.py tests\api\test_polly_commerce.py tests\test_vercel_launch_bridge.py
- python -m pytest tests/api/test_polly_commerce.py tests/test_vercel_launch_bridge.py -q
- git diff --check origin/main...HEAD