### PR TITLE
feat(monetization): add hosted run intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ The packages are companion surfaces, not forced dependencies. Install the
 smallest package that fits your task; the operator and agent-bus APIs can
 recommend a companion package when a feature lives in another ecosystem.
 
+### Free Local Use + Paid Hosted Runs
+
+The npm packages are free to run locally under `MIT OR Apache-2.0`. Use local
+Node, Python, deterministic harnesses, and Ollama first whenever possible.
+
+If you want SCBE to run hosted routing, a governed report, a benchmark pass, or
+provider/model-backed work for you, use:
+
+- Hosted run intake: [hosted-run.html](https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html)
+- Service credits: [service-credits.html](https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html)
+- Credit top-up: [Ko-fi / izdandavis](https://ko-fi.com/izdandavis)
+
+Service credits are the small pay-as-you-go path: billable provider/model usage
+is passed through with a 2-5% SCBE coordination fee. No subscription is required
+for the open-source packages.
+
 ## License
 
 Project-owned source, npm packages, PyPI packages, and packaged customer ZIP

--- a/api/_polly_hf_upload.js
+++ b/api/_polly_hf_upload.js
@@ -17,8 +17,7 @@ function uploadConfig() {
       process.env.HUGGING_FACE_HUB_TOKEN ||
       '',
     repo: process.env.POLLY_HF_DATASET || DEFAULT_DATASET,
-    enabled:
-      String(process.env.POLLY_HF_UPLOAD_ENABLED || 'true').toLowerCase() !== 'false',
+    enabled: String(process.env.POLLY_HF_UPLOAD_ENABLED || 'true').toLowerCase() !== 'false',
     timeoutMs: Math.max(2000, Number(process.env.POLLY_HF_UPLOAD_TIMEOUT_MS || 8000)),
   };
 }
@@ -40,8 +39,11 @@ function stamp(record) {
       : Math.floor(Date.now() / 1000);
   const date = new Date(tsSeconds * 1000);
   const day = date.toISOString().slice(0, 10);
-  const compact =
-    date.toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, '').replace('T', 'T');
+  const compact = date
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d+Z$/, '')
+    .replace('T', 'T');
   return { day, compact };
 }
 
@@ -57,6 +59,7 @@ function nonceHex(bytes) {
 
 const KIND_PREFIX = {
   lead: 'polly-leads',
+  hosted_run: 'polly-hosted-runs',
   funnel: 'polly-funnel',
   chat: 'polly-chat-live',
 };
@@ -144,7 +147,11 @@ async function uploadRecord(record) {
     const commit = await commitFile(cfg, pathInRepo, payload, summary);
     return { ok: true, repo: cfg.repo, path: pathInRepo, commit };
   } catch (error) {
-    return { ok: false, reason: 'fetch_error', detail: String(error.message || error).slice(0, 240) };
+    return {
+      ok: false,
+      reason: 'fetch_error',
+      detail: String(error.message || error).slice(0, 240),
+    };
   }
 }
 

--- a/api/_polly_rate_limit.js
+++ b/api/_polly_rate_limit.js
@@ -16,6 +16,7 @@ const DEFAULT_WINDOW_MS = 60_000;
 const DEFAULTS = {
   chat: { limit: 30, windowMs: DEFAULT_WINDOW_MS },
   lead: { limit: 5, windowMs: DEFAULT_WINDOW_MS },
+  hosted_run: { limit: 8, windowMs: DEFAULT_WINDOW_MS },
   feedback: { limit: 60, windowMs: DEFAULT_WINDOW_MS },
 };
 
@@ -32,9 +33,7 @@ function clientIp(req) {
 function envLimit(name, fallback) {
   const upper = name.toUpperCase();
   const limit = Number(process.env[`POLLY_RATE_LIMIT_${upper}`] || fallback.limit);
-  const windowMs = Number(
-    process.env[`POLLY_RATE_LIMIT_${upper}_WINDOW_MS`] || fallback.windowMs
-  );
+  const windowMs = Number(process.env[`POLLY_RATE_LIMIT_${upper}_WINDOW_MS`] || fallback.windowMs);
   return {
     limit: Number.isFinite(limit) && limit > 0 ? limit : fallback.limit,
     windowMs: Number.isFinite(windowMs) && windowMs > 0 ? windowMs : fallback.windowMs,

--- a/api/agent/system.js
+++ b/api/agent/system.js
@@ -80,6 +80,7 @@ function buildSystemContract() {
         health: '/api/agent/health',
         system: '/api/agent/system',
         chat: '/api/agent/chat',
+        hosted_run: '/v1/polly/hosted-run',
         search: '/api/agent/search',
         storage: '/api/agent/storage',
         status: '/api/agent/status',

--- a/api/polly/hosted-run.js
+++ b/api/polly/hosted-run.js
@@ -1,0 +1,233 @@
+'use strict';
+
+const { readJsonBody, sendJson, setCors } = require('../_agent_common');
+const trainCapture = require('../_polly_train_capture');
+const hfUpload = require('../_polly_hf_upload');
+const rateLimit = require('../_polly_rate_limit');
+
+const HOSTED_RUN_PAGE = 'https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html';
+const SERVICE_CREDITS_PAGE = 'https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html';
+const SERVICE_CREDITS_CHECKOUT = 'https://ko-fi.com/izdandavis';
+
+const RUN_TYPES = new Set([
+  'governance-scan',
+  'agent-routing',
+  'report',
+  'benchmark',
+  'training-capture',
+  'other',
+]);
+
+const ROUTES = new Set(['local-first', 'ollama-first', 'hosted-ok', 'hosted-required']);
+const BUDGETS = new Set(['credits-on-file', '5-20', '20-100', '100-plus', 'open']);
+
+const FIELD_CAPS = {
+  contact: 240,
+  task: 4000,
+  source: 240,
+  repo_url: 400,
+  artifact_url: 400,
+};
+
+function clean(value, max) {
+  if (typeof value !== 'string') return '';
+  return value.trim().slice(0, max);
+}
+
+function enumValue(value, allowed, fallback) {
+  const normalized = String(value || fallback)
+    .trim()
+    .toLowerCase();
+  return allowed.has(normalized) ? normalized : null;
+}
+
+function validateHostedRun(body) {
+  const contact = clean(body && body.contact, FIELD_CAPS.contact);
+  if (!contact) return { ok: false, error: 'contact is required (email or phone)' };
+  const looksLikeEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contact);
+  const looksLikePhone = /^[+()0-9\s.\-]{7,}$/.test(contact);
+  if (!looksLikeEmail && !looksLikePhone) {
+    return { ok: false, error: 'contact must look like an email or a phone number' };
+  }
+
+  const task = clean(body && body.task, FIELD_CAPS.task);
+  if (!task || task.length < 10) {
+    return { ok: false, error: 'task must be at least 10 characters' };
+  }
+
+  const runType = enumValue(body && body.run_type, RUN_TYPES, 'other');
+  if (!runType) {
+    return { ok: false, error: `run_type must be one of: ${Array.from(RUN_TYPES).join(', ')}` };
+  }
+
+  const route = enumValue(body && body.route, ROUTES, 'local-first');
+  if (!route) {
+    return { ok: false, error: `route must be one of: ${Array.from(ROUTES).join(', ')}` };
+  }
+
+  const budget = enumValue(body && body.budget, BUDGETS, 'open');
+  if (!budget) {
+    return { ok: false, error: `budget must be one of: ${Array.from(BUDGETS).join(', ')}` };
+  }
+
+  return {
+    ok: true,
+    contact,
+    task,
+    runType,
+    route,
+    budget,
+    source: clean(body && body.source, FIELD_CAPS.source),
+    repoUrl: clean(body && body.repo_url, FIELD_CAPS.repo_url),
+    artifactUrl: clean(body && body.artifact_url, FIELD_CAPS.artifact_url),
+    allowTrainingCapture: body && body.allow_training_capture === true,
+  };
+}
+
+const HOSTED_RUN_LOG_PREFIX = 'polly_hosted_run_v1 ';
+
+function logHostedRun(record) {
+  try {
+    process.stdout.write(HOSTED_RUN_LOG_PREFIX + JSON.stringify(record) + '\n');
+  } catch (_err) {
+    /* never raise into the request path */
+  }
+}
+
+function buildHostedRunPacket(run) {
+  return {
+    status: 'hosted-run-intake-v1',
+    offer: 'SCBE hosted run',
+    run_type: run.runType,
+    requested_route: run.route,
+    budget: run.budget,
+    usage_policy: {
+      default: 'local/Ollama/deterministic harness first',
+      billable_when:
+        'hosted capacity, report delivery, storage, or paid provider/model usage is needed',
+      fee: 'actual provider/model cost plus a 2-5% SCBE coordination fee',
+      checkout_url: SERVICE_CREDITS_CHECKOUT,
+    },
+    order_recap: [
+      `Requested run type: ${run.runType}`,
+      `Route preference: ${run.route}`,
+      `Budget/credit signal: ${run.budget}`,
+      'Payment status: not charged by this form; credits/top-up are confirmed before billable hosted work.',
+    ],
+    initial_ai_inspection: [
+      'Contact format validated.',
+      'Run type, route preference, and budget signal normalized.',
+      'No secrets are required at intake.',
+      run.allowTrainingCapture
+        ? 'Training capture consent was provided for this intake.'
+        : 'Training capture consent was not provided; use private review only.',
+    ],
+    immediate_value: [
+      {
+        label: 'How SCBE Service Credits work',
+        url: SERVICE_CREDITS_PAGE,
+        why: 'Explains the free-first routing policy and 2-5% coordination fee.',
+      },
+      {
+        label: 'Top up service credits',
+        url: SERVICE_CREDITS_CHECKOUT,
+        why: 'Use $5+ credits for small hosted runs without a large subscription.',
+      },
+      {
+        label: 'Hosted run intake page',
+        url: HOSTED_RUN_PAGE,
+        why: 'Return here to submit another scoped run request.',
+      },
+      {
+        label: 'Public SCBE repository',
+        url: 'https://github.com/issdandavis/SCBE-AETHERMOORE',
+        why: 'Inspect the open-source engine before paying for hosted work.',
+      },
+    ],
+    follow_up_steps: [
+      'The request is stored for private review.',
+      'If it can run locally/free-first, the reply points to the local command or npm package path.',
+      'If hosted capacity is needed, the reply confirms expected credit use before running.',
+      'After a hosted run, buyer receives the result, a short receipt, and the next recommended command or report step.',
+    ],
+  };
+}
+
+module.exports = async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'POST') return sendJson(res, 405, { ok: false, error: 'POST only' });
+
+  const rl = rateLimit.enforce(req, res, 'hosted_run');
+  if (!rl.allowed) {
+    return sendJson(res, 429, {
+      ok: false,
+      error: 'rate limit exceeded',
+      retry_after_ms: rl.retryAfterMs,
+    });
+  }
+
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch (error) {
+    return sendJson(res, 400, {
+      ok: false,
+      error: 'invalid JSON body',
+      detail: String(error.message || error),
+    });
+  }
+
+  // Honeypot: real users never see or fill `website`.
+  if (body && typeof body.website === 'string' && body.website.trim().length > 0) {
+    return sendJson(res, 200, {
+      ok: true,
+      message: 'Hosted run request received.',
+      next_steps: [],
+    });
+  }
+
+  const run = validateHostedRun(body);
+  if (!run.ok) return sendJson(res, 400, { ok: false, error: run.error });
+
+  const record = {
+    ts: Math.floor(Date.now() / 1000),
+    kind: 'hosted_run',
+    contact: run.contact,
+    task: run.task,
+    run_type: run.runType,
+    route: run.route,
+    budget: run.budget,
+    repo_url: run.repoUrl,
+    artifact_url: run.artifactUrl,
+    allow_training_capture: run.allowTrainingCapture,
+    source: run.source || 'aethermoore.com/hosted-run',
+    transport: 'vercel-polly-hosted-run',
+  };
+
+  logHostedRun(record);
+
+  await Promise.allSettled([
+    hfUpload.uploadRecord(record),
+    trainCapture.dispatchTrainingTurn(record),
+  ]);
+
+  const hostedRunPacket = buildHostedRunPacket(run);
+
+  return sendJson(res, 200, {
+    ok: true,
+    message:
+      'Hosted run request received. If credits are needed, usage will be confirmed before billable work runs.',
+    next_steps: [...hostedRunPacket.order_recap, ...hostedRunPacket.follow_up_steps],
+    hosted_run_packet: hostedRunPacket,
+  });
+};
+
+module.exports._private = {
+  RUN_TYPES,
+  ROUTES,
+  BUDGETS,
+  validateHostedRun,
+  buildHostedRunPacket,
+  logHostedRun,
+};

--- a/bin/geoseal.cjs
+++ b/bin/geoseal.cjs
@@ -23,6 +23,14 @@ Modes:
        python -m geoseal_cli
      Use SCBE_GEOSEAL_PYTHON to pin the Python executable.
 
+Hosted run path:
+  Local/npm/Ollama-first use stays free under the open-source license.
+  For AetherMoore-hosted routing, governed reports, benchmarks, storage,
+  delivery, or provider/model-backed work:
+    https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html
+    https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html
+  Service credits pass through provider/model cost with a 2-5% SCBE fee.
+
 Useful commands:
   geoseal doctor --json
   geoseal permissions --json

--- a/docs/app-config.json
+++ b/docs/app-config.json
@@ -28,16 +28,19 @@
     "offers_page": "https://aethermoore.com/SCBE-AETHERMOORE/offers/",
     "supporter_page": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html",
     "service_credits_page": "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html",
+    "hosted_run_page": "https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html",
     "governance_snapshot_page": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
     "offers_json": "https://aethermoore.com/SCBE-AETHERMOORE/offers.json",
     "agent_bridge_health": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/health",
     "agent_bridge_system": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/system",
     "agent_bridge_offers": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/offers",
-    "agent_bridge_app_config": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/app-config"
+    "agent_bridge_app_config": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/app-config",
+    "polly_hosted_run": "https://scbe-agent-bridge-vercel.vercel.app/v1/polly/hosted-run"
   },
   "features": {
     "tip_jar": true,
     "service_credits": true,
+    "hosted_run_intake": true,
     "supporter_monthly": true,
     "governance_snapshot": true,
     "zero_key_agent_bus": true,

--- a/docs/hosted-run.html
+++ b/docs/hosted-run.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SCBE Hosted Run Intake | AetherMoore</title>
+    <meta
+      name="description"
+      content="Submit a small SCBE hosted run request. Local and Ollama-first when possible; credits only apply to hosted/provider usage."
+    />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html" />
+    <style>
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: #0b0d12;
+        color: #f2f0ea;
+        line-height: 1.55;
+      }
+      main {
+        width: min(920px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 44px 0;
+      }
+      a {
+        color: inherit;
+      }
+      .nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        color: #a3acb9;
+        margin-bottom: 36px;
+      }
+      h1 {
+        font-size: clamp(34px, 6vw, 64px);
+        line-height: 0.98;
+        margin: 0 0 16px;
+      }
+      .lead {
+        color: #a3acb9;
+        max-width: 780px;
+        font-size: 18px;
+      }
+      .panel {
+        border: 1px solid rgba(214, 167, 86, 0.2);
+        background: #11161f;
+        border-radius: 8px;
+        padding: 22px;
+        margin-top: 24px;
+      }
+      .grid {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+      label {
+        display: grid;
+        gap: 6px;
+        font-weight: 800;
+      }
+      input,
+      select,
+      textarea {
+        width: 100%;
+        box-sizing: border-box;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        border-radius: 6px;
+        background: #0b0d12;
+        color: #f2f0ea;
+        padding: 11px 12px;
+        font: inherit;
+      }
+      textarea {
+        min-height: 150px;
+        resize: vertical;
+      }
+      .hidden {
+        position: absolute;
+        left: -10000px;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+      }
+      .actions {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: center;
+        margin-top: 16px;
+      }
+      button,
+      .btn {
+        border: 0;
+        border-radius: 6px;
+        padding: 11px 14px;
+        font-weight: 800;
+        text-decoration: none;
+        cursor: pointer;
+      }
+      button,
+      .btn-primary {
+        background: #d6a756;
+        color: #14110c;
+      }
+      .btn-secondary {
+        background: #1a2230;
+        color: #d7dde8;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+      }
+      .status {
+        color: #d7dde8;
+        white-space: pre-wrap;
+      }
+      .fine {
+        color: #a3acb9;
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <nav class="nav" aria-label="Hosted run navigation">
+        <a href="./index.html">Home</a>
+        <a href="./offers/">Offers</a>
+        <a href="./service-credits.html">Service Credits</a>
+        <a href="./hire.html">Hire</a>
+      </nav>
+
+      <section>
+        <h1>SCBE hosted run intake</h1>
+        <p class="lead">
+          Use this when the npm packages or local/Ollama route are not enough and you want a small
+          governed run, report, benchmark, or routing pass handled through SCBE. Intake is free.
+          Credits are used only when hosted capacity, delivery, storage, or paid provider/model
+          usage is needed.
+        </p>
+      </section>
+
+      <section class="panel" aria-label="Hosted run form">
+        <form id="hosted-run-form">
+          <div class="grid">
+            <label>
+              Contact
+              <input name="contact" type="text" autocomplete="email tel" required />
+            </label>
+            <label>
+              Run type
+              <select name="run_type">
+                <option value="governance-scan">Governance scan</option>
+                <option value="agent-routing">Agent routing</option>
+                <option value="report">Report</option>
+                <option value="benchmark">Benchmark</option>
+                <option value="training-capture">Training capture</option>
+                <option value="other">Other</option>
+              </select>
+            </label>
+            <label>
+              Routing preference
+              <select name="route">
+                <option value="local-first">Local/free first</option>
+                <option value="ollama-first">Ollama first</option>
+                <option value="hosted-ok">Hosted is OK if useful</option>
+                <option value="hosted-required">Hosted required</option>
+              </select>
+            </label>
+            <label>
+              Budget / credits
+              <select name="budget">
+                <option value="open">Open / not sure</option>
+                <option value="credits-on-file">Credits already topped up</option>
+                <option value="5-20">$5-$20</option>
+                <option value="20-100">$20-$100</option>
+                <option value="100-plus">$100+</option>
+              </select>
+            </label>
+          </div>
+
+          <label style="margin-top: 16px">
+            What should SCBE run or inspect?
+            <textarea
+              name="task"
+              required
+              placeholder="Example: run a governed prompt audit on this workflow, summarize risk, and tell me whether local/Ollama is enough."
+            ></textarea>
+          </label>
+
+          <div class="grid" style="margin-top: 16px">
+            <label>
+              Repo URL (optional)
+              <input name="repo_url" type="url" />
+            </label>
+            <label>
+              Artifact URL (optional)
+              <input name="artifact_url" type="url" />
+            </label>
+          </div>
+
+          <label class="hidden">
+            Website
+            <input name="website" tabindex="-1" autocomplete="off" />
+          </label>
+
+          <label style="margin-top: 16px">
+            <span>
+              <input name="allow_training_capture" type="checkbox" value="true" />
+              Allow anonymized training capture for this intake
+            </span>
+          </label>
+
+          <div class="actions">
+            <button type="submit">Submit Hosted Run</button>
+            <a
+              class="btn btn-secondary"
+              href="https://ko-fi.com/izdandavis"
+              target="_blank"
+              rel="noopener"
+              >Top Up Credits</a
+            >
+            <a class="btn btn-secondary" href="./service-credits.html">How Credits Work</a>
+          </div>
+          <p class="fine">
+            Do not paste secrets, private keys, passwords, customer data, or regulated data into
+            this form. Submit a description first; secure handoff is arranged only if needed.
+          </p>
+        </form>
+        <p id="hosted-run-status" class="status" role="status"></p>
+      </section>
+    </main>
+
+    <script>
+      const form = document.getElementById('hosted-run-form');
+      const statusEl = document.getElementById('hosted-run-status');
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        statusEl.textContent = 'Submitting hosted run intake...';
+        const data = Object.fromEntries(new FormData(form).entries());
+        data.allow_training_capture = form.elements.allow_training_capture.checked;
+        data.source = 'aethermoore.com/SCBE-AETHERMOORE/hosted-run.html';
+        try {
+          const response = await fetch(
+            'https://scbe-agent-bridge-vercel.vercel.app/v1/polly/hosted-run',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(data),
+            }
+          );
+          const payload = await response.json();
+          if (!response.ok || !payload.ok) {
+            throw new Error(payload.error || `Request failed with ${response.status}`);
+          }
+          statusEl.textContent = [
+            payload.message,
+            '',
+            ...(payload.next_steps || []).slice(0, 6).map((step) => `- ${step}`),
+          ].join('\n');
+          form.reset();
+        } catch (error) {
+          statusEl.textContent = `Could not submit: ${error.message || error}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/docs/offers.json
+++ b/docs/offers.json
@@ -17,6 +17,7 @@
       "type": "usage_credit",
       "checkout_url": "https://ko-fi.com/izdandavis",
       "proof_url": "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html",
+      "intake_url": "https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html",
       "status": "live"
     },
     {

--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -210,6 +210,7 @@
             rel="noopener"
             >Top Up Credits</a
           >
+          <a class="btn btn-muted" href="../hosted-run.html">Submit Hosted Run</a>
           <a class="btn btn-secondary" href="../service-credits.html">How Credits Work</a>
         </article>
         <article class="card">

--- a/docs/service-credits.html
+++ b/docs/service-credits.html
@@ -65,7 +65,7 @@
       }
       .btn {
         display: inline-block;
-        margin-top: 12px;
+        margin: 12px 8px 0 0;
         padding: 11px 14px;
         border-radius: 6px;
         background: #d6a756;
@@ -75,6 +75,11 @@
       }
       code {
         color: #d6a756;
+      }
+      .btn-secondary {
+        background: #1a2230;
+        color: #d7dde8;
+        border: 1px solid rgba(255, 255, 255, 0.1);
       }
     </style>
   </head>
@@ -122,6 +127,7 @@
           <a class="btn" href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
             >Top Up Credits</a
           >
+          <a class="btn btn-secondary" href="hosted-run.html">Submit Hosted Run</a>
         </article>
       </section>
 

--- a/packages/agent-bus/README.md
+++ b/packages/agent-bus/README.md
@@ -47,6 +47,23 @@ scbe-agent-bus ui --base-url http://127.0.0.1:8787
 The terminal frontend can health-check the backend and send governed local-only
 tasks through the bus. It does not expose shell execution.
 
+## Hosted Runs and Service Credits
+
+`scbe-agent-bus` is free for local/private routing. Keep sensitive work on your
+machine with `privacy: "local_only"` and use Ollama or deterministic harnesses
+first.
+
+If you want AetherMoore to run a hosted governed pass, report, benchmark, or
+provider/model-backed route, submit a scoped hosted-run request:
+
+- Hosted run intake: https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html
+- Service credits: https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html
+- Credit top-up: https://ko-fi.com/izdandavis
+
+Credits are only for hosted capacity, report delivery, storage, and
+provider/model usage. Billable provider/model cost is passed through with a
+2-5% SCBE coordination fee.
+
 ## Notes
 
 - The repo-local runner remains the source of truth.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,6 +17,7 @@ scbe --help
 scbe version
 scbe selftest
 scbe doctor --json
+scbe credits
 ```
 
 The same binary is also exposed as `geoseal` and `scbe-geoseal`.
@@ -27,10 +28,33 @@ The same binary is also exposed as `geoseal` and `scbe-geoseal`.
 - `doctor --json`: verifies the installed GeoSeal shell and reports available
   API-routed commands.
 - `selftest`: runs the npm-installable smoke test (`version` + `doctor`).
+- `credits`: prints the hosted-run intake, service-credit policy, and top-up
+  links for paid hosted work.
 
 The full repo-local GeoSeal command set still lives in `scbe-aethermoore`.
 Commands that require Python repo modules need a source checkout or a backend
 API configured with `SCBE_API_BASE`.
+
+## Free Local Use + Paid Hosted Runs
+
+The CLI is free for local use. Use `scbe-agent-bus`, GeoSeal, local Node/Python,
+and Ollama-first routing before spending credits.
+
+When you want AetherMoore to run hosted routing, a governed report, a benchmark,
+or provider/model-backed work, use:
+
+```bash
+scbe credits
+```
+
+That command prints:
+
+- hosted run intake: https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html
+- service credits: https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html
+- top-up: https://ko-fi.com/izdandavis
+
+Credits are pay-as-you-go. Billable provider/model usage is passed through with
+a 2-5% SCBE coordination fee.
 
 ## Self Test
 

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -4,6 +4,34 @@
 const { spawnSync } = require("node:child_process");
 const path = require("node:path");
 
+const SERVICE_CREDITS = {
+  schema_version: "scbe_service_credits_v1",
+  name: "SCBE Service Credits",
+  policy:
+    "Free/local/Ollama-first by default; credits only apply to hosted capacity, report delivery, storage, and provider/model usage.",
+  fee: "actual provider/model cost + 2-5% SCBE coordination fee",
+  hosted_run_intake: "https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html",
+  service_credits: "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html",
+  top_up: "https://ko-fi.com/izdandavis",
+};
+
+const CLI_HELP = `scbe-aethermoore-cli
+
+Usage:
+  scbe <command> [options]
+
+Core commands:
+  scbe version
+  scbe selftest
+  scbe doctor --json
+  scbe credits
+
+Hosted run path:
+  scbe credits      Print service-credit policy and hosted-run links.
+
+All other commands are forwarded to the GeoSeal shell from scbe-aethermoore.
+`;
+
 function resolveGeosealBin() {
   try {
     const entry = require.resolve("scbe-aethermoore");
@@ -51,6 +79,33 @@ function runSelftest() {
 }
 
 const argv = process.argv.slice(2);
+if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h" || argv[0] === "help") {
+  process.stdout.write(CLI_HELP);
+  process.exit(0);
+}
+
+if (argv[0] === "credits" || argv[0] === "hosted-run") {
+  const asJson = argv.includes("--json");
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(SERVICE_CREDITS, null, 2)}\n`);
+  } else {
+    process.stdout.write(
+      [
+        "SCBE Service Credits",
+        "",
+        SERVICE_CREDITS.policy,
+        `Fee: ${SERVICE_CREDITS.fee}`,
+        "",
+        `Hosted run intake: ${SERVICE_CREDITS.hosted_run_intake}`,
+        `Service credits:    ${SERVICE_CREDITS.service_credits}`,
+        `Top up:             ${SERVICE_CREDITS.top_up}`,
+        "",
+      ].join("\n"),
+    );
+  }
+  process.exit(0);
+}
+
 if (argv[0] === "selftest") {
   runSelftest();
 }

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -32,6 +32,8 @@ const trainCapture = require('../../api/_polly_train_capture.js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const leadHandler = require('../../api/polly/lead.js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+const hostedRunHandler = require('../../api/polly/hosted-run.js');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const hfUpload = require('../../api/_polly_hf_upload.js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const rateLimit = require('../../api/_polly_rate_limit.js');
@@ -547,6 +549,65 @@ describe('polly lead handler', () => {
     const res = makeRes();
     await leadHandler(req, res);
     expect(res.statusCode).toBe(405);
+  });
+});
+
+describe('polly hosted-run handler', () => {
+  beforeEach(() => rateLimit.reset());
+
+  const validHostedRun = {
+    contact: 'buyer@example.com',
+    run_type: 'governance-scan',
+    route: 'ollama-first',
+    budget: '5-20',
+    task: 'Run a small governed scan and tell me if local Ollama is enough.',
+    source: 'test',
+  };
+
+  it('accepts a hosted run intake and returns immediate value links', async () => {
+    const req = makeReq({ body: validHostedRun });
+    const res = makeRes();
+    await hostedRunHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as {
+      ok: boolean;
+      next_steps: string[];
+      hosted_run_packet: {
+        status: string;
+        usage_policy: { fee: string };
+        immediate_value: { url: string }[];
+      };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.next_steps.length).toBeGreaterThan(0);
+    expect(body.hosted_run_packet.status).toBe('hosted-run-intake-v1');
+    expect(body.hosted_run_packet.usage_policy.fee).toContain('2-5%');
+    expect(
+      body.hosted_run_packet.immediate_value.some((item) => item.url.includes('service-credits'))
+    ).toBe(true);
+    expect(
+      body.hosted_run_packet.immediate_value.some((item) => item.url.includes('ko-fi.com'))
+    ).toBe(true);
+  });
+
+  it('rejects hosted run intake without contact', async () => {
+    const req = makeReq({ body: { ...validHostedRun, contact: '' } });
+    const res = makeRes();
+    await hostedRunHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    const body = res.body as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('contact');
+  });
+
+  it('honeypot returns success with no downstream next steps', async () => {
+    const req = makeReq({ body: { ...validHostedRun, website: 'https://bot.example' } });
+    const res = makeRes();
+    await hostedRunHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { ok: boolean; next_steps: string[] };
+    expect(body.ok).toBe(true);
+    expect(body.next_steps).toHaveLength(0);
   });
 });
 

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -18,6 +18,7 @@ def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
     assert ("^/hire/?$", "/api/agent/hire.js") in routes
     assert ("^/SCBE-AETHERMOORE/hire\\.html$", "/api/agent/hire.js") in routes
     assert ("^/api/agent/(.*)$", "/api/agent/$1.js") in routes
+    assert ("^/v1/polly/hosted-run/?$", "/api/polly/hosted-run.js") in routes
 
 
 def test_vercelignore_ships_launch_handler_with_api_bridge() -> None:
@@ -67,6 +68,7 @@ def test_public_offer_catalog_has_live_revenue_links() -> None:
     assert by_id["tip_jar"]["checkout_url"] == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
     assert by_id["service_credits"]["checkout_url"] == "https://ko-fi.com/izdandavis"
     assert by_id["service_credits"]["proof_url"].endswith("/service-credits.html")
+    assert by_id["service_credits"]["intake_url"].endswith("/hosted-run.html")
     assert by_id["supporter_monthly"]["checkout_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
     assert by_id["governance_snapshot"]["intake_url"].endswith("/governance-snapshot.html#intake")
     assert offers["usage_policy"]["service_fee_percent_range"] == [2, 5]
@@ -82,6 +84,9 @@ def test_public_app_config_explains_remote_update_boundary() -> None:
     assert "package name" in config["remote_update"]["requires_store_release"]
     assert config["features"]["tip_jar"] is True
     assert config["features"]["service_credits"] is True
+    assert config["features"]["hosted_run_intake"] is True
+    assert config["endpoints"]["hosted_run_page"].endswith("/hosted-run.html")
+    assert config["endpoints"]["polly_hosted_run"].endswith("/v1/polly/hosted-run")
 
 
 def test_supporter_page_uses_direct_stripe_checkout_not_broken_api_bridge() -> None:
@@ -102,6 +107,7 @@ def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:
     assert "s-maxage=300" in app_config_source
     assert "aethermoor.agent.system_contract.v1" in system_source
     assert "/api/agent/chat" in system_source
+    assert "/v1/polly/hosted-run" in system_source
     assert "workspace_formation" in system_source
     assert "usage_policy" in system_source
 
@@ -110,3 +116,14 @@ def test_public_app_config_exposes_unified_system_contract() -> None:
     config = json.loads((REPO_ROOT / "docs" / "app-config.json").read_text(encoding="utf-8"))
 
     assert config["endpoints"]["agent_bridge_system"].endswith("/api/agent/system")
+
+
+def test_hosted_run_page_and_endpoint_are_present() -> None:
+    page = (REPO_ROOT / "docs" / "hosted-run.html").read_text(encoding="utf-8")
+    handler = (REPO_ROOT / "api" / "polly" / "hosted-run.js").read_text(encoding="utf-8")
+
+    assert "SCBE hosted run intake" in page
+    assert "/v1/polly/hosted-run" in page
+    assert "ko-fi.com/izdandavis" in page
+    assert "hosted-run-intake-v1" in handler
+    assert "2-5% SCBE coordination fee" in handler

--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,10 @@
       "dest": "/api/polly/lead.js"
     },
     {
+      "src": "^/v1/polly/hosted-run/?$",
+      "dest": "/api/polly/hosted-run.js"
+    },
+    {
       "src": "^/v1/polly/stats/?$",
       "dest": "/api/polly/stats.js"
     },


### PR DESCRIPTION
## Summary
- add a public hosted-run intake page for small SCBE paid/service-credit jobs
- add `/v1/polly/hosted-run` with validation, honeypot, rate limit, HF/GitHub capture, and instant fulfillment packet
- expose hosted-run links in app config, offers JSON, agent system contract, service credits page, offers page, npm READMEs, and CLI help
- add `scbe credits` / `scbe hosted-run` command to print hosted-run and service-credit links

## Monetization behavior
- free/local/Ollama-first remains the default
- service credits apply only to hosted capacity, report delivery, storage, or provider/model usage
- paid usage policy remains provider/model cost plus a 2-5% SCBE coordination fee

## Tests
- npm test -- tests/api/polly_commerce_js.test.ts
- python -m pytest tests/test_vercel_launch_bridge.py -q
- python scripts\system\remote_app_config_smoke.py
- node packages\cli\bin\scbe.js credits --json
- python -m black --check --target-version py311 --line-length 120 tests\test_vercel_launch_bridge.py
- git diff --check

Note: broad local `npx prettier --check "src/**/*.ts" "tests/**/*.ts"` reports pre-existing unrelated TS formatting noise in this Windows worktree; this PR does not modify those files.