### PR TITLE
feat(billing): Stripe webhook → auto-email Snapshot intake checklist

### DIFF
--- a/.github/workflows/polly-snapshot-paid.yml
+++ b/.github/workflows/polly-snapshot-paid.yml
@@ -1,0 +1,186 @@
+name: Polly Snapshot Paid Notify
+
+# Receives polly_snapshot_paid repository_dispatch events from the
+# Vercel-hosted Stripe webhook (api/billing/stripe_webhook.js). Two
+# side-effects: (1) file a GitHub issue tagged snapshot-paid so the
+# operator sees it on the wildlife board, (2) email the buyer the
+# intake checklist + scheduling reply within one business day.
+
+on:
+  repository_dispatch:
+    types: [polly_snapshot_paid]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: polly-snapshot-paid-${{ github.event.client_payload.record.session_id }}
+  cancel-in-progress: false
+
+jobs:
+  notify-buyer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: File a snapshot-paid GitHub issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SESSION_ID: ${{ github.event.client_payload.record.session_id }}
+          PAYMENT_INTENT: ${{ github.event.client_payload.record.payment_intent }}
+          AMOUNT_CENTS: ${{ github.event.client_payload.record.amount_total }}
+          CURRENCY: ${{ github.event.client_payload.record.currency }}
+          CONTACT_EMAIL: ${{ github.event.client_payload.record.contact_email }}
+          CONTACT_NAME: ${{ github.event.client_payload.record.contact_name }}
+          LIVEMODE: ${{ github.event.client_payload.record.livemode }}
+        run: |
+          set -euo pipefail
+          # Idempotency: if an issue already exists for this Stripe session id
+          # we skip both the issue create and the email send. Stripe retries
+          # webhooks on 5xx; we always 200, but a long network failure could
+          # leave a duplicate dispatch in flight.
+          existing=$(gh issue list --state all --search "snapshot paid: ${SESSION_ID} in:title" --json number --jq '.[0].number' --repo "${{ github.repository }}" || true)
+          if [[ -n "$existing" && "$existing" != "null" ]]; then
+            echo "issue already exists for session ${SESSION_ID} (#${existing}); skipping"
+            echo "ALREADY_FILED=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          # Compose pricing string defensively in case Stripe ever changes
+          # the unit. AMOUNT_CENTS is integer cents; convert to USD only
+          # when currency is usd, otherwise show the raw value.
+          if [[ "${CURRENCY,,}" == "usd" && -n "${AMOUNT_CENTS:-}" ]]; then
+            price="\$$(awk "BEGIN { printf \"%.2f\", ${AMOUNT_CENTS}/100 }")"
+          else
+            price="${AMOUNT_CENTS:-?} ${CURRENCY:-?}"
+          fi
+
+          mode_tag="LIVE"
+          if [[ "${LIVEMODE,,}" != "true" ]]; then
+            mode_tag="TEST-MODE"
+          fi
+
+          gh label create snapshot-paid --description "Snapshot Stripe checkout completed" --color "D6A756" --repo "${{ github.repository }}" 2>/dev/null || true
+
+          title="snapshot paid: ${SESSION_ID} (${price}, ${mode_tag})"
+          body=$(cat <<EOF
+          A buyer just completed a \$500 AI Governance Snapshot checkout.
+
+          - session id: \`${SESSION_ID}\`
+          - payment intent: \`${PAYMENT_INTENT}\`
+          - amount: ${price}
+          - mode: ${mode_tag}
+          - buyer name: ${CONTACT_NAME:-(not provided)}
+          - buyer email: ${CONTACT_EMAIL:-(not provided)}
+
+          **Operator action — within 1 business day:**
+
+          1. Confirm the intake email landed (see the SMTP step in this workflow run; if SMTP isn't configured, send manually).
+          2. Reply to ${CONTACT_EMAIL:-the buyer} with a 30-minute kickoff call slot.
+          3. Open the Snapshot delivery template and copy fixed-scope Q1-Q3 into the kickoff agenda.
+          EOF
+          )
+          gh issue create \
+            --title "$title" \
+            --body "$body" \
+            --label "snapshot-paid" \
+            --repo "${{ github.repository }}"
+
+      - name: Email the buyer the intake checklist
+        # Only send real emails on livemode events. `stripe trigger` and
+        # other test-mode events still file the GH issue (operator visibility)
+        # but never email a real (or test) buyer.
+        if: ${{ env.ALREADY_FILED != '1' && github.event.client_payload.record.livemode == true }}
+        env:
+          SMTP_HOST: ${{ secrets.POLLY_LEAD_SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.POLLY_LEAD_SMTP_PORT }}
+          SMTP_USER: ${{ secrets.POLLY_LEAD_SMTP_USER }}
+          SMTP_PASS: ${{ secrets.POLLY_LEAD_SMTP_PASS }}
+          SMTP_FROM: ${{ secrets.POLLY_LEAD_SMTP_FROM }}
+          SMTP_OPERATOR: ${{ secrets.POLLY_LEAD_SMTP_TO }}
+          PAYLOAD: ${{ toJSON(github.event.client_payload.record) }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SMTP_HOST:-}" || -z "${SMTP_USER:-}" || -z "${SMTP_PASS:-}" ]]; then
+            echo "SMTP credentials missing; intake email will need manual send (issue is filed)" >&2
+            exit 0
+          fi
+          python3 - <<'PY'
+          import os, ssl, json, smtplib, sys
+          from email.message import EmailMessage
+
+          record = json.loads(os.environ["PAYLOAD"])
+          host = os.environ["SMTP_HOST"]
+          port = int(os.environ.get("SMTP_PORT") or "587")
+          user = os.environ["SMTP_USER"]
+          password = os.environ["SMTP_PASS"]
+          sender = os.environ.get("SMTP_FROM") or user
+          operator_bcc = os.environ.get("SMTP_OPERATOR") or user
+          buyer = record.get("contact_email") or ""
+          name = record.get("contact_name") or "there"
+          if not buyer:
+              # No buyer email on the session — fall back to operator-only
+              # so the operator at least sees the unmailed intake. The
+              # filed GitHub issue is the durable trail.
+              print("buyer email missing; sending operator-only intake summary", file=sys.stderr)
+              buyer = operator_bcc
+
+          subject = f"Your AI Governance Snapshot intake checklist (session {record.get('session_id','?')})"
+          body_lines = [
+              f"Hi {name},",
+              "",
+              "Thanks for purchasing the $500 AI Governance Snapshot.",
+              "I'll reply within one business day to schedule a 30-minute kickoff call.",
+              "Until then, please prep these so the snapshot covers what you actually need:",
+              "",
+              "INTAKE CHECKLIST",
+              "  1. The one workflow you want assessed (one paragraph).",
+              "  2. Inputs and outputs the workflow handles (data types, sample volumes).",
+              "  3. Models / providers in the loop (e.g. GPT-4o, Claude, in-house, mixed).",
+              "  4. Existing guardrails: prompt filters, content moderation, human-in-the-loop?",
+              "  5. The single risk that bothers you most (regulatory, reputational, safety, $).",
+              "",
+              "WHAT YOU GET (within 5 business days of kickoff)",
+              "  - 2-page findings memo",
+              "  - 3 prioritized fixes (highest-leverage first)",
+              "  - Evidence checklist mapped to your inputs/outputs",
+              "  - 30 minutes of Q&A on the deliverable",
+              "",
+              "REPLY TO SCHEDULE",
+              "  Just reply to this email with 2-3 time windows that work for you.",
+              "  Anywhere from US Pacific morning through Eastern evening is fine.",
+              "",
+              f"Order ref: session {record.get('session_id','?')}, payment {record.get('payment_intent','?')}",
+              "",
+              "- Issac Davis",
+              "  https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
+          ]
+          msg = EmailMessage()
+          msg["Subject"] = subject
+          msg["From"] = sender
+          msg["To"] = buyer
+          msg["Reply-To"] = sender
+          if operator_bcc and operator_bcc != buyer:
+              msg["Bcc"] = operator_bcc
+          msg.set_content("\n".join(body_lines))
+
+          context = ssl.create_default_context()
+          try:
+              if port == 465:
+                  with smtplib.SMTP_SSL(host, port, context=context, timeout=20) as s:
+                      s.login(user, password)
+                      s.send_message(msg)
+              else:
+                  with smtplib.SMTP(host, port, timeout=20) as s:
+                      s.starttls(context=context)
+                      s.login(user, password)
+                      s.send_message(msg)
+              print(f"intake checklist emailed to {buyer}")
+          except Exception as exc:
+              print(
+                  f"SMTP send failed but snapshot-paid issue is already filed: "
+                  f"{type(exc).__name__}: {exc}",
+                  file=sys.stderr,
+              )
+              sys.exit(0)
+          PY

--- a/api/billing/stripe_webhook.js
+++ b/api/billing/stripe_webhook.js
@@ -1,0 +1,266 @@
+'use strict';
+
+// POST /v1/billing/stripe-webhook — receives Stripe events and, when a
+// Snapshot ($500 fixed-scope governance review) checkout completes, fires
+// a `polly_snapshot_paid` repository_dispatch so the GitHub Actions
+// notify workflow can email the buyer the intake checklist + scheduling
+// link inside one business day.
+//
+// Verification: HMAC-SHA256 of `${timestamp}.${raw_body}` against
+// STRIPE_WEBHOOK_SECRET, matched in constant time. No `stripe` npm
+// package needed; we only consume the JSON shape and the t=/v1= header.
+//
+// Snapshot detection (any of):
+//   - session.payment_link === STRIPE_SNAPSHOT_PAYMENT_LINK_ID
+//   - mode='payment' AND amount_total === 50000 AND currency === 'usd'
+// Both keep working if the Payment Link is re-created.
+//
+// Always responds 200 after a valid signature so Stripe stops retrying;
+// the side-effect dispatch is best-effort and logged on failure.
+
+const crypto = require('crypto');
+
+const SNAPSHOT_AMOUNT_CENTS = 50000;
+const TOLERANCE_SECONDS = 300; // Stripe default replay window
+
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Stripe-Signature');
+}
+
+function sendJson(res, status, payload) {
+  setCors(res);
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.status(status).json(payload);
+}
+
+function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    if (req.rawBody) return resolve(req.rawBody.toString('utf8'));
+    let raw = '';
+    let total = 0;
+    req.on('data', (chunk) => {
+      total += chunk.length;
+      if (total > 65536) {
+        reject(new Error('request body too large'));
+        req.destroy();
+        return;
+      }
+      raw += chunk;
+    });
+    req.on('end', () => resolve(raw));
+    req.on('error', reject);
+  });
+}
+
+function parseSignatureHeader(header) {
+  const parts = String(header || '').split(',');
+  let timestamp = null;
+  const signatures = [];
+  for (const part of parts) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    if (key === 't') timestamp = value;
+    else if (key === 'v1') signatures.push(value);
+  }
+  return { timestamp, signatures };
+}
+
+function verifySignature(rawBody, header, secret, nowSeconds) {
+  if (!header || !secret) return { ok: false, reason: 'missing_signature_or_secret' };
+  const { timestamp, signatures } = parseSignatureHeader(header);
+  if (!timestamp || signatures.length === 0) {
+    return { ok: false, reason: 'malformed_signature_header' };
+  }
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts)) return { ok: false, reason: 'bad_timestamp' };
+  if (Math.abs(nowSeconds - ts) > TOLERANCE_SECONDS) {
+    return { ok: false, reason: 'timestamp_outside_tolerance' };
+  }
+  const signedPayload = `${timestamp}.${rawBody}`;
+  const expected = crypto.createHmac('sha256', secret).update(signedPayload, 'utf8').digest('hex');
+  const expectedBuf = Buffer.from(expected, 'utf8');
+  for (const sig of signatures) {
+    let provided;
+    try {
+      provided = Buffer.from(sig, 'utf8');
+    } catch {
+      continue;
+    }
+    if (provided.length !== expectedBuf.length) continue;
+    if (crypto.timingSafeEqual(provided, expectedBuf)) return { ok: true };
+  }
+  return { ok: false, reason: 'signature_mismatch' };
+}
+
+function snapshotConfig() {
+  return {
+    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
+    paymentLinkId: process.env.STRIPE_SNAPSHOT_PAYMENT_LINK_ID || '',
+    repo: process.env.POLLY_TRAIN_REPO || process.env.GITHUB_REPO || 'issdandavis/SCBE-AETHERMOORE',
+    githubToken:
+      process.env.POLLY_TRAIN_GITHUB_TOKEN ||
+      process.env.GITHUB_TOKEN ||
+      process.env.GH_TOKEN ||
+      '',
+    dispatchEnabled:
+      String(process.env.POLLY_SNAPSHOT_DISPATCH_ENABLED || 'true').toLowerCase() !== 'false',
+    dispatchTimeoutMs: Math.max(500, Number(process.env.POLLY_SNAPSHOT_DISPATCH_TIMEOUT_MS || 4000)),
+  };
+}
+
+function isSnapshotSession(session, cfg) {
+  if (!session || typeof session !== 'object') return false;
+  if (cfg.paymentLinkId && session.payment_link === cfg.paymentLinkId) return true;
+  // Fall-through identification when the env var isn't pinned to a link id:
+  // a one-off USD payment for exactly $500 is the Snapshot product.
+  if (
+    session.mode === 'payment' &&
+    Number(session.amount_total) === SNAPSHOT_AMOUNT_CENTS &&
+    String(session.currency || '').toLowerCase() === 'usd'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+async function fetchWithTimeout(url, init, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function dispatchSnapshotPaid(session, cfg) {
+  if (!cfg.dispatchEnabled) return { ok: false, reason: 'disabled' };
+  if (!cfg.githubToken) return { ok: false, reason: 'no_token' };
+
+  const details = (session && session.customer_details) || {};
+  const record = {
+    kind: 'snapshot_paid',
+    session_id: session && session.id,
+    payment_intent: session && session.payment_intent,
+    customer_id: session && session.customer,
+    amount_total: session && session.amount_total,
+    currency: session && session.currency,
+    contact_email: details.email || (session && session.customer_email) || '',
+    contact_name: details.name || '',
+    contact_phone: details.phone || '',
+    created: session && session.created,
+    livemode: !!(session && session.livemode),
+    payment_link: session && session.payment_link,
+    source: 'governance-snapshot',
+  };
+
+  const url = `https://api.github.com/repos/${cfg.repo}/dispatches`;
+  const body = JSON.stringify({
+    event_type: 'polly_snapshot_paid',
+    client_payload: { record },
+  });
+
+  try {
+    const response = await fetchWithTimeout(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${cfg.githubToken}`,
+          'Content-Type': 'application/json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'scbe-stripe-snapshot-webhook',
+        },
+        body,
+      },
+      cfg.dispatchTimeoutMs
+    );
+    if (!response.ok) {
+      const detail = (await response.text()).slice(0, 240);
+      return { ok: false, reason: `github_${response.status}`, detail };
+    }
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: 'fetch_error', detail: String(error && error.message).slice(0, 240) };
+  }
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    setCors(res);
+    return res.status(204).end();
+  }
+  if (req.method !== 'POST') {
+    return sendJson(res, 405, { ok: false, error: 'POST only' });
+  }
+
+  let raw;
+  try {
+    raw = await readRawBody(req);
+  } catch (error) {
+    return sendJson(res, 400, { ok: false, error: 'invalid body', detail: String(error.message || error) });
+  }
+
+  const cfg = snapshotConfig();
+  if (!cfg.webhookSecret) {
+    // Refuse to accept anything if the secret isn't configured. This prevents
+    // a misconfigured deploy from silently green-checking unsigned events.
+    return sendJson(res, 503, { ok: false, error: 'STRIPE_WEBHOOK_SECRET not configured' });
+  }
+
+  const sigHeader = req.headers['stripe-signature'];
+  const verification = verifySignature(raw, sigHeader, cfg.webhookSecret, Math.floor(Date.now() / 1000));
+  if (!verification.ok) {
+    return sendJson(res, 400, { ok: false, error: 'signature verification failed', reason: verification.reason });
+  }
+
+  let event;
+  try {
+    event = JSON.parse(raw);
+  } catch (error) {
+    return sendJson(res, 400, { ok: false, error: 'invalid JSON', detail: String(error.message || error) });
+  }
+
+  // Only act on the one event we care about; everything else is a 200 ack.
+  if (event && event.type === 'checkout.session.completed') {
+    const session = event.data && event.data.object;
+    if (isSnapshotSession(session, cfg)) {
+      const dispatch = await dispatchSnapshotPaid(session, cfg);
+      return sendJson(res, 200, {
+        ok: true,
+        handled: 'snapshot_paid',
+        session_id: session && session.id,
+        dispatch,
+      });
+    }
+    return sendJson(res, 200, {
+      ok: true,
+      handled: 'checkout_other',
+      session_id: session && session.id,
+    });
+  }
+
+  return sendJson(res, 200, { ok: true, handled: 'ignored', event_type: event && event.type });
+};
+
+module.exports._private = {
+  parseSignatureHeader,
+  verifySignature,
+  isSnapshotSession,
+  snapshotConfig,
+  SNAPSHOT_AMOUNT_CENTS,
+  TOLERANCE_SECONDS,
+};
+
+// Critical: Stripe signature verification MUST see the exact raw request
+// bytes. The default @vercel/node body parser would drain the stream and
+// leave readRawBody() with `""`, causing every real event to fail HMAC
+// match. This config disables that parsing for this single endpoint.
+module.exports.config = {
+  api: { bodyParser: false },
+};

--- a/tests/api/stripe_webhook_js.test.ts
+++ b/tests/api/stripe_webhook_js.test.ts
@@ -1,0 +1,378 @@
+/**
+ * @file stripe_webhook_js.test.ts
+ * Pins the contract for /v1/billing/stripe-webhook — Stripe receives
+ * checkout.session.completed events here and a successful Snapshot
+ * purchase fans out a polly_snapshot_paid repository_dispatch.
+ *
+ * The handler verifies HMAC-SHA256 of `${timestamp}.${raw_body}` against
+ * STRIPE_WEBHOOK_SECRET. Tests construct that signature directly so we
+ * never need the real `stripe` npm package as a dev dependency.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHmac } from 'crypto';
+import { EventEmitter } from 'events';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stripeWebhook = require('../../api/billing/stripe_webhook.js');
+
+const TEST_SECRET = 'whsec_test_secret_xyz';
+const SNAPSHOT_LINK_ID = 'plink_snapshot_test_42';
+
+function setEnv(): void {
+  process.env.STRIPE_WEBHOOK_SECRET = TEST_SECRET;
+  process.env.STRIPE_SNAPSHOT_PAYMENT_LINK_ID = SNAPSHOT_LINK_ID;
+  process.env.GITHUB_TOKEN = 'ghp_test_token';
+  process.env.GITHUB_REPO = 'test-org/test-repo';
+  process.env.POLLY_SNAPSHOT_DISPATCH_ENABLED = 'true';
+}
+
+function clearEnv(): void {
+  delete process.env.STRIPE_WEBHOOK_SECRET;
+  delete process.env.STRIPE_SNAPSHOT_PAYMENT_LINK_ID;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_TOKEN;
+  delete process.env.POLLY_TRAIN_GITHUB_TOKEN;
+  delete process.env.GITHUB_REPO;
+  delete process.env.POLLY_SNAPSHOT_DISPATCH_ENABLED;
+}
+
+interface MockRes {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  setHeader(k: string, v: string): void;
+  status(code: number): MockRes;
+  json(payload: unknown): MockRes;
+  end(): MockRes;
+}
+
+function makeRes(): MockRes {
+  const headers: Record<string, string> = {};
+  return {
+    statusCode: 200,
+    headers,
+    body: undefined,
+    setHeader(k, v) {
+      headers[k] = v;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end() {
+      return this;
+    },
+  };
+}
+
+interface MockReqOpts {
+  method?: string;
+  rawBody?: string;
+  headers?: Record<string, string>;
+}
+
+function makeReq(opts: MockReqOpts): EventEmitter & {
+  method: string;
+  headers: Record<string, string>;
+  destroy: () => void;
+} {
+  const req = new EventEmitter() as EventEmitter & {
+    method: string;
+    headers: Record<string, string>;
+    destroy: () => void;
+  };
+  req.method = opts.method || 'POST';
+  req.headers = opts.headers || {};
+  req.destroy = () => undefined;
+  // Schedule the body emit on next tick so the handler can attach listeners.
+  if (opts.rawBody !== undefined) {
+    setImmediate(() => {
+      req.emit('data', Buffer.from(opts.rawBody as string, 'utf8'));
+      req.emit('end');
+    });
+  } else if (opts.method !== 'OPTIONS' && opts.method !== 'GET') {
+    setImmediate(() => req.emit('end'));
+  }
+  return req;
+}
+
+function signPayload(payload: string, secret: string, timestamp?: number): string {
+  const ts = timestamp ?? Math.floor(Date.now() / 1000);
+  const signedPayload = `${ts}.${payload}`;
+  const sig = createHmac('sha256', secret).update(signedPayload, 'utf8').digest('hex');
+  return `t=${ts},v1=${sig}`;
+}
+
+function snapshotEvent(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    id: 'evt_test_1',
+    type: 'checkout.session.completed',
+    data: {
+      object: {
+        id: 'cs_test_session_42',
+        object: 'checkout.session',
+        mode: 'payment',
+        amount_total: 50000,
+        currency: 'usd',
+        payment_link: SNAPSHOT_LINK_ID,
+        payment_intent: 'pi_test_42',
+        customer: 'cus_test_42',
+        customer_email: 'buyer@example.com',
+        customer_details: {
+          email: 'buyer@example.com',
+          name: 'Buyer Name',
+          phone: null,
+        },
+        livemode: false,
+        created: 1715200000,
+        ...overrides,
+      },
+    },
+  });
+}
+
+describe('stripe webhook — signature verification', () => {
+  beforeEach(() => {
+    setEnv();
+  });
+  afterEach(() => {
+    clearEnv();
+    vi.restoreAllMocks();
+  });
+
+  it('valid signature → 200 and dispatch attempted', async () => {
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    const raw = snapshotEvent();
+    const sig = signPayload(raw, TEST_SECRET);
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': sig } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { ok: boolean; handled: string; dispatch: { ok: boolean } };
+    expect(body.ok).toBe(true);
+    expect(body.handled).toBe('snapshot_paid');
+    expect(body.dispatch.ok).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('mismatched signature → 400', async () => {
+    const raw = snapshotEvent();
+    const badSig = signPayload(raw, 'wrong_secret');
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': badSig } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { reason: string }).reason).toBe('signature_mismatch');
+  });
+
+  it('missing signature header → 400', async () => {
+    const raw = snapshotEvent();
+    const req = makeReq({ rawBody: raw, headers: {} });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { reason: string }).reason).toMatch(/missing|malformed/);
+  });
+
+  it('replay-old timestamp → 400', async () => {
+    const raw = snapshotEvent();
+    const oldTs = Math.floor(Date.now() / 1000) - 600; // 10min ago, > 5min tolerance
+    const sig = signPayload(raw, TEST_SECRET, oldTs);
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': sig } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { reason: string }).reason).toBe('timestamp_outside_tolerance');
+  });
+
+  it('malformed signature header → 400', async () => {
+    const raw = snapshotEvent();
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': 'garbage' } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { reason: string }).reason).toMatch(/malformed/);
+  });
+});
+
+describe('stripe webhook — drained stream regression', () => {
+  // Vercel's @vercel/node body parser may drain the request stream before
+  // the handler attaches data listeners. If that ever happens, raw becomes
+  // "" and every signature would fail. We pin the contract: the handler
+  // exports `config.api.bodyParser = false` so Vercel leaves the stream
+  // alone. Without that flag, this scenario would produce silent prod
+  // failures while the happy-path tests still pass.
+  it('handler exports bodyParser:false to prevent silent stream drainage', () => {
+    expect(stripeWebhook.config).toBeDefined();
+    expect(stripeWebhook.config.api).toBeDefined();
+    expect(stripeWebhook.config.api.bodyParser).toBe(false);
+  });
+
+  it('drained stream (no data, only end) → signature_mismatch (not silent 200)', async () => {
+    setEnv();
+    try {
+      // Simulate the failure mode: Vercel parsed the body, drained the
+      // stream, our raw read returns "". HMAC would then be over `${ts}.`
+      // and never match a real Stripe signature.
+      const realRaw = snapshotEvent();
+      const realSig = signPayload(realRaw, TEST_SECRET);
+      const req = makeReq({ headers: { 'stripe-signature': realSig } });
+      // No rawBody — just method:POST. The makeReq helper for that case
+      // emits 'end' with zero data chunks, mimicking the drained state.
+      const res = makeRes();
+      await stripeWebhook(req as never, res as never);
+      // Must FAIL signature verification (not silently succeed). This is
+      // the safety net — even if bodyParser:false is bypassed somehow,
+      // we never accept a payload we can't verify.
+      expect(res.statusCode).toBe(400);
+      expect((res.body as { reason: string }).reason).toBe('signature_mismatch');
+    } finally {
+      clearEnv();
+    }
+  });
+});
+
+describe('stripe webhook — env guard', () => {
+  beforeEach(() => clearEnv());
+  afterEach(() => {
+    clearEnv();
+    vi.restoreAllMocks();
+  });
+
+  it('missing STRIPE_WEBHOOK_SECRET → 503 (refuse to silently accept)', async () => {
+    const raw = snapshotEvent();
+    // Without secret, the verify path can't even be exercised; the handler
+    // must refuse rather than green-check unsigned events.
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': 't=1,v1=x' } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(503);
+  });
+});
+
+describe('stripe webhook — snapshot detection', () => {
+  beforeEach(() => setEnv());
+  afterEach(() => {
+    clearEnv();
+    vi.restoreAllMocks();
+  });
+
+  it('matches by payment_link id', () => {
+    const { isSnapshotSession, snapshotConfig } = stripeWebhook._private;
+    const cfg = snapshotConfig();
+    expect(isSnapshotSession({ payment_link: SNAPSHOT_LINK_ID }, cfg)).toBe(true);
+  });
+
+  it('matches by amount + mode + currency when no payment_link match', () => {
+    const { isSnapshotSession, snapshotConfig } = stripeWebhook._private;
+    const cfg = snapshotConfig();
+    expect(
+      isSnapshotSession(
+        { mode: 'payment', amount_total: 50000, currency: 'usd', payment_link: 'plink_other' },
+        cfg
+      )
+    ).toBe(true);
+  });
+
+  it('rejects subscription mode even with $500 total', () => {
+    const { isSnapshotSession, snapshotConfig } = stripeWebhook._private;
+    const cfg = snapshotConfig();
+    expect(
+      isSnapshotSession({ mode: 'subscription', amount_total: 50000, currency: 'usd' }, cfg)
+    ).toBe(false);
+  });
+
+  it('rejects mismatched amount', () => {
+    const { isSnapshotSession, snapshotConfig } = stripeWebhook._private;
+    const cfg = snapshotConfig();
+    expect(isSnapshotSession({ mode: 'payment', amount_total: 12900, currency: 'usd' }, cfg)).toBe(
+      false
+    );
+  });
+});
+
+describe('stripe webhook — event routing', () => {
+  beforeEach(() => setEnv());
+  afterEach(() => {
+    clearEnv();
+    vi.restoreAllMocks();
+  });
+
+  it('non-snapshot checkout completes → 200, no dispatch', async () => {
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    const raw = snapshotEvent({
+      payment_link: 'plink_unrelated',
+      amount_total: 12900,
+      mode: 'payment',
+    });
+    const sig = signPayload(raw, TEST_SECRET);
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': sig } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { handled: string }).handled).toBe('checkout_other');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('unrelated event type → 200 ignored, no dispatch', async () => {
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    const raw = JSON.stringify({
+      id: 'evt_test_2',
+      type: 'invoice.paid',
+      data: { object: {} },
+    });
+    const sig = signPayload(raw, TEST_SECRET);
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': sig } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { handled: string }).handled).toBe('ignored');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET → 405', async () => {
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('OPTIONS → 204', async () => {
+    const req = makeReq({ method: 'OPTIONS' });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('dispatch payload contains buyer email + session id + snapshot source tag', async () => {
+    let capturedBody: string | undefined;
+    vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
+      capturedBody = (init as { body: string }).body;
+      return new Response('{}', { status: 200 });
+    });
+    const raw = snapshotEvent();
+    const sig = signPayload(raw, TEST_SECRET);
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': sig } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(capturedBody).toBeDefined();
+    const dispatched = JSON.parse(capturedBody as string);
+    expect(dispatched.event_type).toBe('polly_snapshot_paid');
+    const rec = dispatched.client_payload.record;
+    expect(rec.session_id).toBe('cs_test_session_42');
+    expect(rec.contact_email).toBe('buyer@example.com');
+    expect(rec.amount_total).toBe(50000);
+    expect(rec.source).toBe('governance-snapshot');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
     {
       "src": "api/polly/*.js",
       "use": "@vercel/node"
+    },
+    {
+      "src": "api/billing/*.js",
+      "use": "@vercel/node"
     }
   ],
   "routes": [
@@ -67,6 +71,10 @@
     {
       "src": "^/v1/polly/funnel/?$",
       "dest": "/api/polly/funnel.js"
+    },
+    {
+      "src": "^/v1/billing/stripe-webhook/?$",
+      "dest": "/api/billing/stripe_webhook.js"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes the gap between Stripe Snapshot checkout and the operator's intake response.

- **`api/billing/stripe_webhook.js`** — verifies Stripe HMAC-SHA256 signature (no `stripe` npm dep, constant-time compare), detects Snapshot via `STRIPE_SNAPSHOT_PAYMENT_LINK_ID` OR `mode=payment + amount_total=50000 + currency=usd`, fires `polly_snapshot_paid` repository_dispatch on match. Exports `config.api.bodyParser=false` so Vercel doesn't drain the request stream before HMAC sees the raw bytes.
- **`.github/workflows/polly-snapshot-paid.yml`** — listens for the dispatch, files a `snapshot-paid` GitHub issue (idempotent on session id), emails the buyer the intake checklist + 1-business-day SLA via the same SMTP secrets the lead notify workflow already uses. SMTP step gated on `livemode==true`.
- **`tests/api/stripe_webhook_js.test.ts`** — 17 tests covering signature verification, snapshot detection, event routing, env guard, and a drained-stream regression that catches the Vercel body-parser silent failure mode.

## Activation (post-merge, manual)

1. Vercel env: `STRIPE_WEBHOOK_SECRET=<from Stripe webhook config>` and `STRIPE_SNAPSHOT_PAYMENT_LINK_ID=<plink_...>`
2. Stripe Dashboard → Developers → Webhooks → Add endpoint:
   - URL: `https://scbe-agent-bridge-vercel.vercel.app/v1/billing/stripe-webhook`
   - Events: `checkout.session.completed`
3. Smoke: `stripe trigger checkout.session.completed` — issue files (test mode), no email sent.

## Test plan

- [x] `npx vitest run tests/api/stripe_webhook_js.test.ts` → 17/17
- [x] `npm run typecheck` clean
- [x] `npm run lint` (own file passes; existing `polly_commerce_js.test.ts` warning unchanged from `main`)
- [x] Workflow YAML parses, SMTP step gated on `livemode==true`
- [ ] Post-merge: deploy preview, run `stripe trigger checkout.session.completed --add checkout_session:payment_link=$STRIPE_SNAPSHOT_PAYMENT_LINK_ID` against the preview URL, confirm `signature_mismatch` does NOT appear in Vercel logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)