### PR TITLE
feat(polly): show per-event funnel breakdown

### DIFF
--- a/api/_polly_hf_upload.js
+++ b/api/_polly_hf_upload.js
@@ -64,10 +64,28 @@ const KIND_PREFIX = {
   chat: 'polly-chat-live',
 };
 
+// Funnel event names are constrained at /v1/polly/funnel to a fixed
+// allow-list of [a-z_0-9]+, so prefixing the filename with `${event}__`
+// is path-safe and lets /v1/polly/stats?breakdown=event count by event
+// in one HF directory listing instead of N file reads.
+function safeFunnelEvent(value) {
+  if (typeof value !== 'string') return '';
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, '')
+    .slice(0, 60);
+}
+
 function pathFor(record) {
   const kind = String(record.kind || 'chat').toLowerCase();
   const prefix = KIND_PREFIX[kind] || 'polly-chat-live';
   const { day, compact } = stamp(record);
+  if (kind === 'funnel') {
+    const event = safeFunnelEvent(record.event);
+    if (event) {
+      return `${prefix}/${day}/${event}__${compact}-${nonceHex(3)}.json`;
+    }
+  }
   return `${prefix}/${day}/${compact}-${nonceHex(3)}.json`;
 }
 
@@ -160,3 +178,5 @@ module.exports = {
   uploadRecord,
   pathFor,
 };
+
+module.exports._internal = { pathFor, safeFunnelEvent, KIND_PREFIX };

--- a/api/polly/stats.js
+++ b/api/polly/stats.js
@@ -46,34 +46,52 @@ async function listFolder(repo, token, prefix, dateDir, timeoutMs) {
   try {
     const headers = token ? { Authorization: `Bearer ${token}` } : {};
     const response = await fetch(url, { method: 'GET', headers, signal: controller.signal });
-    if (response.status === 404) return { count: 0, exists: false };
+    if (response.status === 404) return { count: 0, exists: false, files: [] };
     if (!response.ok) {
-      return { count: 0, exists: false, error: `hf list ${response.status}` };
+      return { count: 0, exists: false, error: `hf list ${response.status}`, files: [] };
     }
     const data = await response.json();
-    if (!Array.isArray(data)) return { count: 0, exists: false };
-    const fileCount = data.filter(
+    if (!Array.isArray(data)) return { count: 0, exists: false, files: [] };
+    const files = data.filter(
       (entry) => entry && entry.type === 'file' && /\.json$/i.test(entry.path || '')
-    ).length;
-    return { count: fileCount, exists: true };
+    );
+    return { count: files.length, exists: true, files };
   } catch (error) {
     return {
       count: 0,
       exists: false,
       error: String((error && error.message) || error).slice(0, 120),
+      files: [],
     };
   } finally {
     clearTimeout(timer);
   }
 }
 
-async function gather(repo, token, dateDir, timeoutMs) {
+// Per-event count from funnel filenames. Files written after the
+// `${event}__${compact}-${nonce}.json` naming change have an event
+// prefix; older files (no `__` separator) are bucketed under
+// `unknown` so the breakdown stays additive without losing rows.
+function breakdownByEvent(files) {
+  const counts = {};
+  for (const entry of files) {
+    const path = (entry && entry.path) || '';
+    const filename = path.split('/').pop() || '';
+    const sep = filename.indexOf('__');
+    const event = sep > 0 ? filename.slice(0, sep) : 'unknown';
+    counts[event] = (counts[event] || 0) + 1;
+  }
+  return counts;
+}
+
+async function gather(repo, token, dateDir, timeoutMs, options) {
+  const includeBreakdown = !!(options && options.breakdown);
   const [chats, leads, funnel] = await Promise.all([
     listFolder(repo, token, 'polly-chat-live', dateDir, timeoutMs),
     listFolder(repo, token, 'polly-leads', dateDir, timeoutMs),
     listFolder(repo, token, 'polly-funnel', dateDir, timeoutMs),
   ]);
-  return {
+  const result = {
     date: dateDir,
     chats: chats.count,
     leads: leads.count,
@@ -83,6 +101,10 @@ async function gather(repo, token, dateDir, timeoutMs) {
     funnel_dir_exists: funnel.exists,
     errors: [chats.error, leads.error, funnel.error].filter(Boolean),
   };
+  if (includeBreakdown) {
+    result.funnel_by_event = breakdownByEvent(funnel.files || []);
+  }
+  return result;
 }
 
 module.exports = async function handler(req, res) {
@@ -113,17 +135,17 @@ module.exports = async function handler(req, res) {
     });
   }
 
-  const queryDate =
-    (req.query && (req.query.date || (req.query.date === '' ? '' : null))) || '';
+  const queryDate = (req.query && (req.query.date || (req.query.date === '' ? '' : null))) || '';
   const dateDir = isValidDate(queryDate) ? queryDate : todayUtc();
-  const cacheKey = `${dateDir}|${cfg.repo}`;
+  const breakdown = String((req.query && req.query.breakdown) || '').toLowerCase() === 'event';
+  const cacheKey = `${dateDir}|${cfg.repo}|${breakdown ? 'b' : 'p'}`;
   const cached = cache.get(cacheKey);
   const now = Date.now();
   if (cached && now - cached.at < CACHE_TTL_MS) {
     return sendJson(res, 200, { ...cached.payload, cached: true });
   }
 
-  const stats = await gather(cfg.repo, cfg.token, dateDir, cfg.timeoutMs);
+  const stats = await gather(cfg.repo, cfg.token, dateDir, cfg.timeoutMs, { breakdown });
   const payload = {
     ok: true,
     capture_enabled: true,
@@ -134,4 +156,4 @@ module.exports = async function handler(req, res) {
   return sendJson(res, 200, payload);
 };
 
-module.exports._internal = { todayUtc, isValidDate, gather };
+module.exports._internal = { todayUtc, isValidDate, gather, breakdownByEvent };

--- a/docs/polly-stats.html
+++ b/docs/polly-stats.html
@@ -1,211 +1,473 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Polly Capture Stats — SCBE</title>
-<meta name="robots" content="noindex" />
-<style>
-  :root {
-    color-scheme: light dark;
-    --bg: #0d0f14;
-    --panel: #161922;
-    --text: #e8eaf0;
-    --muted: #8a93a3;
-    --green: #4ade80;
-    --red: #f87171;
-    --amber: #fbbf24;
-    --bar: #38bdf8;
-    --bar-leads: #a78bfa;
-    --bar-funnel: #4ade80;
-    --border: #232936;
-  }
-  @media (prefers-color-scheme: light) {
-    :root { --bg:#fafafa;--panel:#fff;--text:#111;--muted:#666;--border:#e5e7eb; }
-  }
-  * { box-sizing: border-box; }
-  body {
-    margin: 0; font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
-    background: var(--bg); color: var(--text);
-    padding: 24px 16px; max-width: 760px; margin-inline: auto;
-  }
-  h1 { font-size: 20px; margin: 0 0 4px; }
-  .sub { color: var(--muted); font-size: 13px; margin-bottom: 24px; }
-  .panel {
-    background: var(--panel); border: 1px solid var(--border);
-    border-radius: 10px; padding: 16px; margin-bottom: 16px;
-  }
-  .row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-  .badge {
-    display: inline-block; padding: 2px 8px; border-radius: 999px;
-    font-size: 12px; font-weight: 600;
-    background: var(--muted); color: var(--bg);
-  }
-  .badge.green { background: var(--green); color: #062e15; }
-  .badge.red   { background: var(--red);   color: #2a0606; }
-  .badge.amber { background: var(--amber); color: #2a1a06; }
-  .totals { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-top: 12px; }
-  .stat { background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: 12px; text-align: center; }
-  .stat .n { font-size: 28px; font-weight: 700; }
-  .stat .label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; }
-  table { width: 100%; border-collapse: collapse; font-size: 14px; }
-  th, td { padding: 8px 6px; text-align: right; border-bottom: 1px solid var(--border); }
-  th:first-child, td:first-child { text-align: left; color: var(--muted); }
-  th { font-weight: 600; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .5px; }
-  .bar { height: 6px; background: var(--bar); border-radius: 3px; display: inline-block; vertical-align: middle; min-width: 2px; }
-  .bar.leads { background: var(--bar-leads); }
-  .bar.funnel { background: var(--bar-funnel); }
-  .footer { color: var(--muted); font-size: 12px; margin-top: 16px; text-align: center; }
-  .footer a { color: var(--muted); }
-  details { font-size: 12px; color: var(--muted); margin-top: 8px; }
-  code { background: var(--bg); padding: 1px 4px; border-radius: 3px; font-size: 12px; }
-</style>
-</head>
-<body>
-  <h1>Polly Capture Stats</h1>
-  <div class="sub">Daily counts of consented chat turns + lead submissions captured to the private HF dataset. Auto-refresh every 60 s.</div>
-
-  <div class="panel" id="status-panel">
-    <div class="row">
-      <span class="badge" id="status-badge">checking…</span>
-      <span class="sub" id="status-text">probing endpoint…</span>
-    </div>
-    <div class="totals">
-      <div class="stat"><div class="n" id="total-chats">—</div><div class="label">chats (7 d)</div></div>
-      <div class="stat"><div class="n" id="total-leads">—</div><div class="label">leads (7 d)</div></div>
-      <div class="stat"><div class="n" id="total-funnel">—</div><div class="label">funnel events (7 d)</div></div>
-    </div>
-  </div>
-
-  <div class="panel">
-    <table>
-      <thead>
-        <tr><th>Date</th><th>Chats</th><th>Leads</th><th>Funnel</th><th>Activity</th></tr>
-      </thead>
-      <tbody id="rows">
-        <tr><td colspan="5" style="text-align:center;color:var(--muted)">loading…</td></tr>
-      </tbody>
-    </table>
-  </div>
-
-  <details>
-    <summary>About this page</summary>
-    <p>
-      Reads <code>/v1/polly/stats?date=YYYY-MM-DD</code> for today + the previous 6 days.
-      Counts come from listing per-day directories on the HF dataset; no contents are exposed.
-      The endpoint is rate-limited (60/min, <code>feedback</code> bucket) and cached 60 s
-      per Vercel instance. <code>noindex</code> so search engines don't index the page.
-    </p>
-  </details>
-  <div class="footer">
-    Endpoint: <a id="endpoint-link" href="#" target="_blank" rel="noopener">/v1/polly/stats</a>
-    · last sync: <span id="last-sync">—</span>
-  </div>
-
-<script>
-(function () {
-  var API_BASE = (window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app').replace(/\/$/, '');
-  var STATS_URL = API_BASE + '/v1/polly/stats';
-  var REFRESH_MS = 60_000;
-  var DAYS = 7;
-
-  document.getElementById('endpoint-link').href = STATS_URL;
-  document.getElementById('endpoint-link').textContent = STATS_URL;
-
-  function pad(n) { return n < 10 ? '0' + n : '' + n; }
-  function ymdUTC(d) {
-    return d.getUTCFullYear() + '-' + pad(d.getUTCMonth() + 1) + '-' + pad(d.getUTCDate());
-  }
-  function lastNDates(n) {
-    var out = [], today = new Date();
-    for (var i = 0; i < n; i++) {
-      var d = new Date(today);
-      d.setUTCDate(today.getUTCDate() - i);
-      out.push(ymdUTC(d));
-    }
-    return out;
-  }
-
-  function setBadge(state, msg) {
-    var b = document.getElementById('status-badge');
-    var t = document.getElementById('status-text');
-    b.className = 'badge ' + state;
-    b.textContent = state === 'green' ? 'live' : state === 'amber' ? 'partial' : 'down';
-    t.textContent = msg;
-  }
-
-  function fetchOne(date) {
-    return fetch(STATS_URL + '?date=' + encodeURIComponent(date))
-      .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, data: j }; }); })
-      .catch(function (e) { return { ok: false, data: { error: String(e) } }; });
-  }
-
-  function render(results) {
-    var rows = document.getElementById('rows');
-    rows.innerHTML = '';
-    var totalChats = 0, totalLeads = 0, totalFunnel = 0, maxAct = 1;
-    results.forEach(function (r) {
-      var c = (r.data && r.data.chats) || 0;
-      var l = (r.data && r.data.leads) || 0;
-      var f = (r.data && r.data.funnel_events) || 0;
-      totalChats += c; totalLeads += l; totalFunnel += f;
-      // Funnel events are noisier than chats/leads (one visitor → many
-      // events) so cap their bar contribution at 5x leads to keep the
-      // small intent signals visible.
-      var fScaled = Math.min(f, l * 5 + 5);
-      if (c + l + fScaled > maxAct) maxAct = c + l + fScaled;
-    });
-    results.forEach(function (r) {
-      var c = (r.data && r.data.chats) || 0;
-      var l = (r.data && r.data.leads) || 0;
-      var f = (r.data && r.data.funnel_events) || 0;
-      var fScaled = Math.min(f, l * 5 + 5);
-      var cw = Math.max(0, Math.round((c / maxAct) * 100));
-      var lw = Math.max(0, Math.round((l / maxAct) * 100));
-      var fw = Math.max(0, Math.round((fScaled / maxAct) * 100));
-      var tr = document.createElement('tr');
-      tr.innerHTML =
-        '<td>' + r.date + '</td>' +
-        '<td>' + c + '</td>' +
-        '<td>' + l + '</td>' +
-        '<td>' + f + '</td>' +
-        '<td><span class="bar" style="width:' + cw + '%"></span> ' +
-        '<span class="bar leads" style="width:' + lw + '%"></span> ' +
-        '<span class="bar funnel" style="width:' + fw + '%"></span></td>';
-      rows.appendChild(tr);
-    });
-    document.getElementById('total-chats').textContent = totalChats;
-    document.getElementById('total-leads').textContent = totalLeads;
-    document.getElementById('total-funnel').textContent = totalFunnel;
-  }
-
-  function tick() {
-    var dates = lastNDates(DAYS);
-    Promise.all(dates.map(fetchOne))
-      .then(function (results) {
-        var withDates = results.map(function (r, i) { return { date: dates[i], ok: r.ok, data: r.data }; });
-        var failed = withDates.filter(function (r) { return !r.ok; }).length;
-        var disabled = withDates.some(function (r) { return r.data && r.data.capture_enabled === false; });
-        if (disabled) {
-          setBadge('amber', (withDates[0].data && withDates[0].data.message) || 'capture disabled');
-        } else if (failed === 0) {
-          setBadge('green', 'all ' + DAYS + ' days fetched');
-        } else if (failed < DAYS) {
-          setBadge('amber', failed + ' of ' + DAYS + ' day(s) failed');
-        } else {
-          setBadge('red', 'endpoint unreachable');
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Polly Capture Stats — SCBE</title>
+    <meta name="robots" content="noindex" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #0d0f14;
+        --panel: #161922;
+        --text: #e8eaf0;
+        --muted: #8a93a3;
+        --green: #4ade80;
+        --red: #f87171;
+        --amber: #fbbf24;
+        --bar: #38bdf8;
+        --bar-leads: #a78bfa;
+        --bar-funnel: #4ade80;
+        --border: #232936;
+      }
+      @media (prefers-color-scheme: light) {
+        :root {
+          --bg: #fafafa;
+          --panel: #fff;
+          --text: #111;
+          --muted: #666;
+          --border: #e5e7eb;
         }
-        render(withDates);
-        document.getElementById('last-sync').textContent = new Date().toLocaleTimeString();
-      })
-      .catch(function (e) {
-        setBadge('red', 'fetch failed: ' + e);
-      });
-  }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font:
+          15px/1.5 system-ui,
+          -apple-system,
+          'Segoe UI',
+          sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        padding: 24px 16px;
+        max-width: 760px;
+        margin-inline: auto;
+      }
+      h1 {
+        font-size: 20px;
+        margin: 0 0 4px;
+      }
+      .sub {
+        color: var(--muted);
+        font-size: 13px;
+        margin-bottom: 24px;
+      }
+      .panel {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .badge {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 600;
+        background: var(--muted);
+        color: var(--bg);
+      }
+      .badge.green {
+        background: var(--green);
+        color: #062e15;
+      }
+      .badge.red {
+        background: var(--red);
+        color: #2a0606;
+      }
+      .badge.amber {
+        background: var(--amber);
+        color: #2a1a06;
+      }
+      .totals {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+        margin-top: 12px;
+      }
+      .stat {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 12px;
+        text-align: center;
+      }
+      .stat .n {
+        font-size: 28px;
+        font-weight: 700;
+      }
+      .stat .label {
+        font-size: 12px;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+      }
+      th,
+      td {
+        padding: 8px 6px;
+        text-align: right;
+        border-bottom: 1px solid var(--border);
+      }
+      th:first-child,
+      td:first-child {
+        text-align: left;
+        color: var(--muted);
+      }
+      th {
+        font-weight: 600;
+        color: var(--muted);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      .bar {
+        height: 6px;
+        background: var(--bar);
+        border-radius: 3px;
+        display: inline-block;
+        vertical-align: middle;
+        min-width: 2px;
+      }
+      .bar.leads {
+        background: var(--bar-leads);
+      }
+      .bar.funnel {
+        background: var(--bar-funnel);
+      }
+      .footer {
+        color: var(--muted);
+        font-size: 12px;
+        margin-top: 16px;
+        text-align: center;
+      }
+      .footer a {
+        color: var(--muted);
+      }
+      details {
+        font-size: 12px;
+        color: var(--muted);
+        margin-top: 8px;
+      }
+      code {
+        background: var(--bg);
+        padding: 1px 4px;
+        border-radius: 3px;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Polly Capture Stats</h1>
+    <div class="sub">
+      Daily counts of consented chat turns + lead submissions captured to the private HF dataset.
+      Auto-refresh every 60 s.
+    </div>
 
-  tick();
-  setInterval(tick, REFRESH_MS);
-})();
-</script>
-</body>
+    <div class="panel" id="status-panel">
+      <div class="row">
+        <span class="badge" id="status-badge">checking…</span>
+        <span class="sub" id="status-text">probing endpoint…</span>
+      </div>
+      <div class="totals">
+        <div class="stat">
+          <div class="n" id="total-chats">—</div>
+          <div class="label">chats (7 d)</div>
+        </div>
+        <div class="stat">
+          <div class="n" id="total-leads">—</div>
+          <div class="label">leads (7 d)</div>
+        </div>
+        <div class="stat">
+          <div class="n" id="total-funnel">—</div>
+          <div class="label">funnel events (7 d)</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <table>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Chats</th>
+            <th>Leads</th>
+            <th>Funnel</th>
+            <th>Activity</th>
+          </tr>
+        </thead>
+        <tbody id="rows">
+          <tr>
+            <td colspan="5" style="text-align: center; color: var(--muted)">loading…</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="panel">
+      <div style="margin-bottom: 8px; font-size: 13px; color: var(--muted)">
+        7-day funnel breakdown by event (where the leak is). Events captured before the
+        filename-prefix migration land under <code>unknown</code>.
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>7-day total</th>
+            <th>Share</th>
+          </tr>
+        </thead>
+        <tbody id="event-rows">
+          <tr>
+            <td colspan="3" style="text-align: center; color: var(--muted)">loading…</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <details>
+      <summary>About this page</summary>
+      <p>
+        Reads <code>/v1/polly/stats?date=YYYY-MM-DD</code> for today + the previous 6 days. Counts
+        come from listing per-day directories on the HF dataset; no contents are exposed. The
+        endpoint is rate-limited (60/min, <code>feedback</code> bucket) and cached 60 s per Vercel
+        instance. <code>noindex</code> so search engines don't index the page.
+      </p>
+    </details>
+    <div class="footer">
+      Endpoint: <a id="endpoint-link" href="#" target="_blank" rel="noopener">/v1/polly/stats</a> ·
+      last sync: <span id="last-sync">—</span>
+    </div>
+
+    <script>
+      (function () {
+        var API_BASE = (
+          window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app'
+        ).replace(/\/$/, '');
+        var STATS_URL = API_BASE + '/v1/polly/stats';
+        var REFRESH_MS = 60_000;
+        var DAYS = 7;
+
+        document.getElementById('endpoint-link').href = STATS_URL;
+        document.getElementById('endpoint-link').textContent = STATS_URL;
+
+        function pad(n) {
+          return n < 10 ? '0' + n : '' + n;
+        }
+        function ymdUTC(d) {
+          return d.getUTCFullYear() + '-' + pad(d.getUTCMonth() + 1) + '-' + pad(d.getUTCDate());
+        }
+        function lastNDates(n) {
+          var out = [],
+            today = new Date();
+          for (var i = 0; i < n; i++) {
+            var d = new Date(today);
+            d.setUTCDate(today.getUTCDate() - i);
+            out.push(ymdUTC(d));
+          }
+          return out;
+        }
+
+        function setBadge(state, msg) {
+          var b = document.getElementById('status-badge');
+          var t = document.getElementById('status-text');
+          b.className = 'badge ' + state;
+          b.textContent = state === 'green' ? 'live' : state === 'amber' ? 'partial' : 'down';
+          t.textContent = msg;
+        }
+
+        function fetchOne(date) {
+          // breakdown=event lets the same call return per-event counts without
+          // a second round-trip, so the per-event card stays in sync with the
+          // per-day table on every refresh.
+          return fetch(STATS_URL + '?date=' + encodeURIComponent(date) + '&breakdown=event')
+            .then(function (r) {
+              return r.json().then(function (j) {
+                return { ok: r.ok, data: j };
+              });
+            })
+            .catch(function (e) {
+              return { ok: false, data: { error: String(e) } };
+            });
+        }
+
+        // Stage order matches the buyer journey on /hire and
+        // /governance-snapshot. Anything not in this list (legacy, or
+        // unprefixed files captured before the migration) renders after.
+        var EVENT_ORDER = [
+          'arrival',
+          'scroll_50',
+          'scroll_90',
+          'chat_open',
+          'chat_msg',
+          'lead_form_focus',
+          'lead_submit_attempt',
+          'lead_submit_ok',
+          'lead_submit_fail',
+          'cta_click_buy',
+          'cta_click_chat',
+          'cta_click_email',
+          'snapshot_intake_attempt',
+          'snapshot_intake_ok',
+          'snapshot_intake_fail',
+          'unknown',
+        ];
+
+        function renderEventTable(results) {
+          var rows = document.getElementById('event-rows');
+          rows.innerHTML = '';
+          var totals = {};
+          results.forEach(function (r) {
+            var by = (r.data && r.data.funnel_by_event) || {};
+            Object.keys(by).forEach(function (k) {
+              totals[k] = (totals[k] || 0) + by[k];
+            });
+          });
+          var grand = Object.keys(totals).reduce(function (s, k) {
+            return s + totals[k];
+          }, 0);
+          var ordered = EVENT_ORDER.filter(function (k) {
+            return totals[k] != null;
+          }).concat(
+            Object.keys(totals).filter(function (k) {
+              return EVENT_ORDER.indexOf(k) < 0;
+            })
+          );
+          if (!ordered.length) {
+            rows.innerHTML =
+              '<tr><td colspan="3" style="text-align:center;color:var(--muted)">' +
+              'no funnel events captured yet</td></tr>';
+            return;
+          }
+          ordered.forEach(function (event) {
+            var n = totals[event];
+            var pct = grand ? Math.round((n / grand) * 1000) / 10 : 0;
+            var pctW = grand ? Math.max(0, Math.round((n / grand) * 100)) : 0;
+            var tr = document.createElement('tr');
+            tr.innerHTML =
+              '<td><code>' +
+              event +
+              '</code></td>' +
+              '<td>' +
+              n +
+              '</td>' +
+              '<td><span class="bar funnel" style="width:' +
+              pctW +
+              '%"></span> ' +
+              pct +
+              '%</td>';
+            rows.appendChild(tr);
+          });
+        }
+
+        function render(results) {
+          var rows = document.getElementById('rows');
+          rows.innerHTML = '';
+          var totalChats = 0,
+            totalLeads = 0,
+            totalFunnel = 0,
+            maxAct = 1;
+          results.forEach(function (r) {
+            var c = (r.data && r.data.chats) || 0;
+            var l = (r.data && r.data.leads) || 0;
+            var f = (r.data && r.data.funnel_events) || 0;
+            totalChats += c;
+            totalLeads += l;
+            totalFunnel += f;
+            // Funnel events are noisier than chats/leads (one visitor → many
+            // events) so cap their bar contribution at 5x leads to keep the
+            // small intent signals visible.
+            var fScaled = Math.min(f, l * 5 + 5);
+            if (c + l + fScaled > maxAct) maxAct = c + l + fScaled;
+          });
+          results.forEach(function (r) {
+            var c = (r.data && r.data.chats) || 0;
+            var l = (r.data && r.data.leads) || 0;
+            var f = (r.data && r.data.funnel_events) || 0;
+            var fScaled = Math.min(f, l * 5 + 5);
+            var cw = Math.max(0, Math.round((c / maxAct) * 100));
+            var lw = Math.max(0, Math.round((l / maxAct) * 100));
+            var fw = Math.max(0, Math.round((fScaled / maxAct) * 100));
+            var tr = document.createElement('tr');
+            tr.innerHTML =
+              '<td>' +
+              r.date +
+              '</td>' +
+              '<td>' +
+              c +
+              '</td>' +
+              '<td>' +
+              l +
+              '</td>' +
+              '<td>' +
+              f +
+              '</td>' +
+              '<td><span class="bar" style="width:' +
+              cw +
+              '%"></span> ' +
+              '<span class="bar leads" style="width:' +
+              lw +
+              '%"></span> ' +
+              '<span class="bar funnel" style="width:' +
+              fw +
+              '%"></span></td>';
+            rows.appendChild(tr);
+          });
+          document.getElementById('total-chats').textContent = totalChats;
+          document.getElementById('total-leads').textContent = totalLeads;
+          document.getElementById('total-funnel').textContent = totalFunnel;
+          renderEventTable(results);
+        }
+
+        function tick() {
+          var dates = lastNDates(DAYS);
+          Promise.all(dates.map(fetchOne))
+            .then(function (results) {
+              var withDates = results.map(function (r, i) {
+                return { date: dates[i], ok: r.ok, data: r.data };
+              });
+              var failed = withDates.filter(function (r) {
+                return !r.ok;
+              }).length;
+              var disabled = withDates.some(function (r) {
+                return r.data && r.data.capture_enabled === false;
+              });
+              if (disabled) {
+                setBadge(
+                  'amber',
+                  (withDates[0].data && withDates[0].data.message) || 'capture disabled'
+                );
+              } else if (failed === 0) {
+                setBadge('green', 'all ' + DAYS + ' days fetched');
+              } else if (failed < DAYS) {
+                setBadge('amber', failed + ' of ' + DAYS + ' day(s) failed');
+              } else {
+                setBadge('red', 'endpoint unreachable');
+              }
+              render(withDates);
+              document.getElementById('last-sync').textContent = new Date().toLocaleTimeString();
+            })
+            .catch(function (e) {
+              setBadge('red', 'fetch failed: ' + e);
+            });
+        }
+
+        tick();
+        setInterval(tick, REFRESH_MS);
+      })();
+    </script>
+  </body>
 </html>

--- a/tests/api/polly_funnel_breakdown.test.ts
+++ b/tests/api/polly_funnel_breakdown.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @file polly_funnel_breakdown.test.ts
+ * Pins the per-event funnel breakdown contract.
+ *
+ * Two new code paths land here together:
+ *   1. _polly_hf_upload.js prefixes funnel filenames with `${event}__`
+ *      so the dataset's directory listing carries event identity in
+ *      the filename and a single HF tree call yields per-event counts.
+ *   2. stats.js exposes ?breakdown=event which parses those filenames
+ *      and returns funnel_by_event, the per-event card on the
+ *      polly-stats dashboard.
+ *
+ * Files captured before the migration (no `__` separator) bucket as
+ * `unknown` so the breakdown stays additive without losing rows.
+ */
+
+delete process.env.HF_TOKEN;
+delete process.env.HUGGINGFACE_TOKEN;
+delete process.env.HUGGING_FACE_HUB_TOKEN;
+
+import { describe, it, expect } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const hfUpload = require('../../api/_polly_hf_upload.js');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stats = require('../../api/polly/stats.js');
+
+describe('hf_upload pathFor — funnel filename prefix', () => {
+  const { pathFor, safeFunnelEvent } = hfUpload._internal;
+
+  it('prefixes filename with event for funnel records', () => {
+    const path = pathFor({
+      kind: 'funnel',
+      event: 'arrival',
+      ts: 1715200000,
+    });
+    // polly-funnel/2024-05-08/arrival__YYYYMMDDTHHMMSS-NONCE.json
+    expect(path).toMatch(
+      /^polly-funnel\/\d{4}-\d{2}-\d{2}\/arrival__\d{8}T\d{6}-[0-9a-f]{6}\.json$/
+    );
+  });
+
+  it('keeps legacy filename shape when funnel record has no event', () => {
+    const path = pathFor({ kind: 'funnel', ts: 1715200000 });
+    expect(path).toMatch(/^polly-funnel\/\d{4}-\d{2}-\d{2}\/\d{8}T\d{6}-[0-9a-f]{6}\.json$/);
+    expect(path).not.toContain('__');
+  });
+
+  it('strips dangerous chars from the event slug', () => {
+    expect(safeFunnelEvent('arrival/../etc/passwd')).toBe('arrivaletcpasswd');
+    expect(safeFunnelEvent('Snapshot Intake OK')).toBe('snapshotintakeok');
+    expect(safeFunnelEvent(undefined as unknown as string)).toBe('');
+    expect(safeFunnelEvent('a'.repeat(200)).length).toBeLessThanOrEqual(60);
+  });
+
+  it('does not change non-funnel kinds', () => {
+    const lead = pathFor({ kind: 'lead', ts: 1715200000 });
+    expect(lead).toMatch(/^polly-leads\/\d{4}-\d{2}-\d{2}\/\d{8}T\d{6}-[0-9a-f]{6}\.json$/);
+    expect(lead).not.toContain('__');
+    const chat = pathFor({ kind: 'chat', ts: 1715200000 });
+    expect(chat).toMatch(/^polly-chat-live\/\d{4}-\d{2}-\d{2}\/\d{8}T\d{6}-[0-9a-f]{6}\.json$/);
+  });
+});
+
+describe('stats breakdownByEvent — parses funnel filenames', () => {
+  const { breakdownByEvent } = stats._internal;
+
+  it('counts new-format filenames by event prefix', () => {
+    const counts = breakdownByEvent([
+      { path: 'polly-funnel/2026-05-09/arrival__20260509T120000-aaaaaa.json' },
+      { path: 'polly-funnel/2026-05-09/arrival__20260509T121000-bbbbbb.json' },
+      { path: 'polly-funnel/2026-05-09/scroll_50__20260509T122000-cccccc.json' },
+      { path: 'polly-funnel/2026-05-09/cta_click_buy__20260509T123000-dddddd.json' },
+    ]);
+    expect(counts).toEqual({
+      arrival: 2,
+      scroll_50: 1,
+      cta_click_buy: 1,
+    });
+  });
+
+  it('buckets legacy unprefixed filenames as unknown', () => {
+    const counts = breakdownByEvent([
+      { path: 'polly-funnel/2026-05-08/20260508T120000-aaaaaa.json' },
+      { path: 'polly-funnel/2026-05-08/20260508T121000-bbbbbb.json' },
+      { path: 'polly-funnel/2026-05-08/arrival__20260508T122000-cccccc.json' },
+    ]);
+    expect(counts).toEqual({ unknown: 2, arrival: 1 });
+  });
+
+  it('returns empty object for empty input', () => {
+    expect(breakdownByEvent([])).toEqual({});
+  });
+
+  it('tolerates malformed entries without crashing', () => {
+    const counts = breakdownByEvent([
+      null,
+      undefined,
+      {},
+      { path: '' },
+      { path: 'polly-funnel/2026-05-09/arrival__x.json' },
+    ] as unknown as { path: string }[]);
+    // null/undefined/empty path → unknown bucket; only the valid one counts.
+    expect(counts.arrival).toBe(1);
+    expect(counts.unknown).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- prefix new funnel records in HF with the event name so stats can group them without reading every JSON body
- add `/v1/polly/stats?breakdown=event` support with legacy rows counted as `unknown`
- show a 7-day per-event funnel table on `docs/polly-stats.html`

## Why this matters
This turns the funnel from a raw counter into a useful conversion diagnostic: arrival, scroll, buy clicks, lead attempts, lead failures, snapshot intake attempts, and other events can be compared directly. That tells us where people fall out before they buy or submit a lead.

## Tests
- `npm test -- tests/api/polly_funnel_breakdown.test.ts` -> 8 passed
- `npx prettier --check api/_polly_hf_upload.js api/polly/stats.js docs/polly-stats.html tests/api/polly_funnel_breakdown.test.ts` -> passed