### PR TITLE
feat(polly): route governance heartbeat offer

### DIFF
--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -41,6 +41,28 @@ const PRODUCT_CATALOG = [
     ],
   },
   {
+    sku: 'governance-heartbeat',
+    name: 'Governance Heartbeat',
+    priceLabel: '$99/month',
+    short:
+      'Monthly governance scan for one AI workflow. Includes a short delta report, risk/change summary, recommended action list, and optional training/dataset capture notes.',
+    checkoutUrl: 'mailto:issdandavis7795@gmail.com?subject=Governance%20Heartbeat%20signup',
+    deliveryUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html#heartbeat',
+    keywords: [
+      'governance heartbeat',
+      'heartbeat',
+      'monthly governance',
+      'monthly scan',
+      'monthly ai governance',
+      'monthly report',
+      'recurring governance',
+      'subscription governance',
+      '$99',
+      '99/month',
+      '99 per month',
+    ],
+  },
+  {
     sku: 'ai-governance-toolkit',
     name: 'SCBE AI Governance Toolkit',
     priceLabel: '$29 one-time',
@@ -204,7 +226,7 @@ function classifyIntent(message) {
 
 function renderBuyReply(product) {
   if (!product) {
-    const lines = ['Three current products. Click to check out:', ''];
+    const lines = ['Current products. Click to check out:', ''];
     const actions = [];
     for (const item of PRODUCT_CATALOG) {
       lines.push(`- **${item.name}** — ${item.priceLabel}. ${item.short}`);
@@ -216,6 +238,14 @@ function renderBuyReply(product) {
   let text = `**${product.name}** — ${product.priceLabel}.\n\n${product.short}\n\nCheckout: ${product.checkoutUrl}`;
   if (product.deliveryUrl) {
     text += `\nWhat you get + delivery: ${product.deliveryUrl}`;
+  }
+  if (product.sku === 'governance-heartbeat') {
+    text +=
+      '\n\nImmediate value after signup: reply with one workflow URL or repo path and the first scan starts as an intake checklist + baseline review.';
+  }
+  if (product.sku === 'ai-governance-snapshot') {
+    text +=
+      '\n\nImmediate value after purchase: buyer intake checklist, order recap, starter governance resources, and a 1-business-day human inspection window.';
   }
   const actions = [{ label: `Buy ${product.name}`, url: product.checkoutUrl }];
   if (product.deliveryUrl) {
@@ -425,6 +455,7 @@ function renderMembershipReply() {
   const text =
     'Three ways to stay close to the work:\n\n' +
     '- **Use service credits** for pay-as-you-go hosted routing without a big subscription\n' +
+    '- **Governance Heartbeat** for a $99/month scan/report loop on one AI workflow\n' +
     '- **Sponsor / tip** the open-source work via Ko-fi\n' +
     '- **Watch the GitHub repo** for releases (`Watch -> Custom -> Releases`)\n' +
     '- **Email** me at the address below for a private update list\n\n' +
@@ -434,6 +465,10 @@ function renderMembershipReply() {
     {
       label: 'Service credits',
       url: 'https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html',
+    },
+    {
+      label: 'Governance Heartbeat',
+      url: 'mailto:issdandavis7795@gmail.com?subject=Governance%20Heartbeat%20signup',
     },
     { label: 'Top up on Ko-fi', url: MEMBERSHIP_KOFI_URL },
     { label: 'Watch the repo', url: 'https://github.com/issdandavis/SCBE-AETHERMOORE' },

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -176,10 +176,10 @@ describe('polly lead handler — anti-abuse', () => {
 });
 
 describe('polly commerce intent classification', () => {
-  it('catalog has five live products with valid stripe/kofi urls', () => {
-    expect(commerce.PRODUCT_CATALOG).toHaveLength(5);
+  it('catalog has live products with valid checkout urls', () => {
+    expect(commerce.PRODUCT_CATALOG).toHaveLength(6);
     for (const product of commerce.PRODUCT_CATALOG) {
-      expect(product.checkoutUrl).toMatch(/^https:\/\/(buy\.stripe\.com|ko-fi\.com)/);
+      expect(product.checkoutUrl).toMatch(/^(https:\/\/(buy\.stripe\.com|ko-fi\.com)|mailto:)/);
       expect(product.keywords.length).toBeGreaterThan(0);
     }
   });
@@ -209,6 +209,19 @@ describe('polly commerce intent classification', () => {
     const intent = commerce.classifyIntent('Can I get the $500 governance snapshot?');
     expect(intent.name).toBe('buy');
     expect(intent.product.sku).toBe('ai-governance-snapshot');
+  });
+
+  it('classifies governance heartbeat as the monthly subscription offer', () => {
+    const intent = commerce.classifyIntent('I want the $99 monthly governance heartbeat');
+    expect(intent.name).toBe('buy');
+    expect(intent.product.sku).toBe('governance-heartbeat');
+  });
+
+  it('classifies monthly scan as governance heartbeat without an explicit buy verb', () => {
+    const intent = commerce.classifyIntent('Do you have a monthly AI governance scan?');
+    expect(intent.name).toBe('buy');
+    expect(intent.confidence).toBeCloseTo(0.6, 2);
+    expect(intent.product.sku).toBe('governance-heartbeat');
   });
 
   it('classifies custom intent at 0.85', () => {
@@ -274,8 +287,18 @@ describe('polly commerce reply rendering', () => {
     const out = commerce.renderBuyReply(null);
     expect(out.actions).toHaveLength(commerce.PRODUCT_CATALOG.length);
     for (const action of out.actions) {
-      expect(action.url).toMatch(/^https:\/\//);
+      expect(action.url).toMatch(/^(https:\/\/|mailto:)/);
     }
+  });
+
+  it('renderBuyReply for heartbeat includes immediate signup value', () => {
+    const product = commerce.PRODUCT_CATALOG.find(
+      (p: { sku: string }) => p.sku === 'governance-heartbeat'
+    );
+    const out = commerce.renderBuyReply(product);
+    expect(out.text).toContain('$99/month');
+    expect(out.text).toContain('first scan starts');
+    expect(out.actions[0].url).toMatch(/^mailto:/);
   });
 
   it('renderCustomReply returns mailto with pre-filled context', () => {
@@ -291,12 +314,14 @@ describe('polly commerce reply rendering', () => {
 
   it('renderMembershipReply has credits + Ko-fi + GitHub + email actions', () => {
     const out = commerce.renderMembershipReply();
-    expect(out.actions).toHaveLength(4);
+    expect(out.actions).toHaveLength(5);
     expect(out.actions[0].url).toContain('service-credits');
-    expect(out.actions[1].url).toContain('ko-fi.com');
-    expect(out.actions[2].url).toContain('github.com');
-    expect(out.actions[3].url).toContain('mailto:');
+    expect(out.actions[1].url).toContain('Governance%20Heartbeat');
+    expect(out.actions[2].url).toContain('ko-fi.com');
+    expect(out.actions[3].url).toContain('github.com');
+    expect(out.actions[4].url).toContain('mailto:');
     expect(out.text).toContain('2-5%');
+    expect(out.text).toContain('$99/month');
   });
 
   it('renderResearchReply with matching topic returns canonical body + repo links', () => {


### PR DESCRIPTION
## Summary
- Adds Governance Heartbeat as a first-class Polly commerce catalog product
- Routes $99/month, monthly scan, and heartbeat buyer language to the offer
- Adds immediate-value reply copy for Heartbeat and Snapshot purchases
- Updates membership replies to surface Heartbeat alongside service credits and support paths

## Test evidence
- `npm test -- tests/api/polly_commerce_js.test.ts` -> 62 passed
- `npx prettier --check api/polly/commerce.js tests/api/polly_commerce_js.test.ts` -> passed
- `git diff --check` -> passed

## Rollback
- Revert this PR to remove Heartbeat routing from Polly commerce responses.