### PR TITLE
fix(polly): require public checkout override urls

### DIFF
--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -2,7 +2,19 @@
 
 function checkoutUrlFromEnv(envName, fallback) {
   const value = String(process.env[envName] || '').trim();
-  return value || fallback;
+  if (!value) return fallback;
+
+  // Stripe Payment Link IDs (`plink_...`) are not browser checkout URLs.
+  // Vercel historically stored those internal IDs in SCBE_PAYMENT_LINK_*.
+  // Only accept public URLs that a customer can actually click.
+  if (
+    value.startsWith('https://buy.stripe.com/') ||
+    value.startsWith('https://ko-fi.com/') ||
+    value.startsWith('mailto:')
+  ) {
+    return value;
+  }
+  return fallback;
 }
 
 const PRODUCT_CATALOG = [

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -221,6 +221,21 @@ describe('polly commerce intent classification', () => {
     expect(product.checkoutUrl).toBe('https://buy.stripe.com/heartbeat-live-placeholder');
   });
 
+  it('ignores Stripe internal payment link IDs as public checkout overrides', () => {
+    const loaded = loadCommerceWithEnv({
+      SCBE_PAYMENT_LINK_TOOLKIT: 'plink_1T5t5MJTF2SuUODITNiC7v43',
+      SCBE_PAYMENT_LINK_VAULT: 'plink_1TG7QuJTF2SuUODIpeN0DUVw',
+    });
+    const toolkit = loaded.PRODUCT_CATALOG.find(
+      (p: { sku: string }) => p.sku === 'ai-governance-toolkit'
+    );
+    const vault = loaded.PRODUCT_CATALOG.find(
+      (p: { sku: string }) => p.sku === 'ai-security-training-vault'
+    );
+    expect(toolkit.checkoutUrl).toMatch(/^https:\/\/buy\.stripe\.com\//);
+    expect(vault.checkoutUrl).toMatch(/^https:\/\/buy\.stripe\.com\//);
+  });
+
   it('classifies "buy" verb with bound product at 0.95 confidence', () => {
     const intent = commerce.classifyIntent('I want to buy the AI governance toolkit');
     expect(intent.name).toBe('buy');


### PR DESCRIPTION
## Summary
- Prevents `SCBE_PAYMENT_LINK_*` env values like `plink_...` from becoming public checkout URLs
- Only accepts browser-usable checkout overrides: Stripe checkout URLs, Ko-fi URLs, or mailto links
- Adds regression coverage for Vercel's current internal `plink_...` values so public catalog output stays clickable

## Test evidence
- `npm test -- tests/api/polly_commerce_js.test.ts` -> 64 passed
- `npx prettier --check api/polly/commerce.js tests/api/polly_commerce_js.test.ts` -> passed
- `git diff --check` -> passed

## Rollback
- Revert this PR to allow any non-empty env override again.