### PR TITLE
feat(hire): /hire-b A/B variant with Snapshot-led hero

### DIFF
--- a/api/agent/hire-b.js
+++ b/api/agent/hire-b.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// /hire-b — A/B variant of /hire with a Snapshot-led hero. Funnel
+// beacons fire with page='hire-b' so the operator dashboard can
+// compare conversion against the consulting-services-led /hire page.
+// Below-the-fold content matches /hire so the test isolates hero impact.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const HIRE_B_PAGE = path.join(process.cwd(), 'docs', 'hire-b.html');
+const FALLBACK_HIRE_B_PAGE = path.join(process.cwd(), 'public', 'hire-b.html');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.setHeader('Allow', 'GET, HEAD');
+    return res.status(405).json({ ok: false, error: 'method_not_allowed' });
+  }
+
+  try {
+    const pagePath = fs.existsSync(HIRE_B_PAGE) ? HIRE_B_PAGE : FALLBACK_HIRE_B_PAGE;
+    const html = fs.readFileSync(pagePath, 'utf8');
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300');
+    return res.status(200).send(req.method === 'HEAD' ? '' : html);
+  } catch (err) {
+    return res.status(500).json({
+      ok: false,
+      error: 'hire_b_page_unavailable',
+      detail: err && err.message ? err.message : String(err),
+    });
+  }
+};

--- a/docs/hire-b.html
+++ b/docs/hire-b.html
@@ -1,0 +1,1114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>$500 AI Governance Snapshot — Issac Davis</title>
+    <meta
+      name="description"
+      content="Independent AI safety and governance engineering. Federal-registered, open-source-first. Available for contract work, security audits, and short-term advisory."
+    />
+    <meta property="og:title" content="Hire Issac Davis — AI Safety & Governance Engineering" />
+    <meta
+      property="og:description"
+      content="Independent AI safety and governance engineering. Federal-registered, open-source-first."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://aethermoore.com/SCBE-AETHERMOORE/hire.html" />
+    <meta property="og:image" content="https://aethermoore.com/SCBE-AETHERMOORE/hero.svg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Hire Issac Davis — AI Safety & Governance Engineering" />
+    <meta
+      name="twitter:description"
+      content="Independent AI safety and governance engineering. Federal-registered, open-source-first."
+    />
+    <meta name="twitter:image" content="https://aethermoore.com/SCBE-AETHERMOORE/hero.svg" />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/hire.html" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "ProfessionalService",
+        "name": "Issac Davis — AI Safety & Governance Engineering",
+        "url": "https://aethermoore.com/SCBE-AETHERMOORE/hire.html",
+        "image": "https://aethermoore.com/SCBE-AETHERMOORE/hero.svg",
+        "description": "Independent AI safety and governance engineering. Federal-registered (SAM UEI J4NXHM6N5F59), open-source-first. Available for adversarial audits, custom governance overlays, federal subcontract work, and short-term advisory.",
+        "founder": {
+          "@type": "Person",
+          "name": "Issac Davis"
+        },
+        "areaServed": "US",
+        "serviceType": [
+          "AI Safety Audit",
+          "Adversarial LLM Evaluation",
+          "Governance Overlay Engineering",
+          "Federal AI Subcontracting",
+          "Technical Advisory"
+        ],
+        "offers": [
+          {
+            "@type": "Offer",
+            "name": "AI Governance Snapshot",
+            "price": "500",
+            "priceCurrency": "USD",
+            "url": "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j",
+            "description": "Fixed-scope governance assessment for one AI workflow with a findings memo, prioritized fixes, evidence checklist, and fast-start packet"
+          },
+          {
+            "@type": "Offer",
+            "name": "Short advisory call",
+            "price": "300",
+            "priceCurrency": "USD",
+            "description": "60-minute call on one concrete AI safety / governance problem"
+          },
+          {
+            "@type": "Offer",
+            "name": "Adversarial audit",
+            "priceSpecification": {
+              "@type": "PriceSpecification",
+              "minPrice": "5000",
+              "maxPrice": "15000",
+              "priceCurrency": "USD"
+            },
+            "description": "1-3 weeks. Audit production LLM endpoint or agent against the SCBE governance harness"
+          },
+          {
+            "@type": "Offer",
+            "name": "Custom governance overlay",
+            "priceSpecification": {
+              "@type": "PriceSpecification",
+              "minPrice": "25000",
+              "maxPrice": "80000",
+              "priceCurrency": "USD"
+            },
+            "description": "4-10 weeks. Build a deployable governance layer in front of your model API"
+          }
+        ],
+        "sameAs": ["https://github.com/issdandavis/SCBE-AETHERMOORE", "https://aethermoore.com/"]
+      }
+    </script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      :root {
+        --bg: #0a0e1a;
+        --surface: #0f1626;
+        --card: #152033;
+        --border: #243352;
+        --text: #e8f0fb;
+        --dim: #a2b6cc;
+        --accent: #17c6cf;
+        --accent2: #ff9152;
+        --green: #2dd3a6;
+        --gold: #ffd166;
+        --mono: 'SF Mono', 'Cascadia Code', 'JetBrains Mono', 'Consolas', monospace;
+        --font: 'Inter', 'Space Grotesk', 'Trebuchet MS', sans-serif;
+      }
+      body {
+        background: var(--bg);
+        background-image:
+          radial-gradient(1200px 600px at 12% -8%, rgba(23, 198, 207, 0.18), transparent 60%),
+          radial-gradient(900px 500px at 92% 0%, rgba(255, 145, 82, 0.14), transparent 58%);
+        color: var(--text);
+        font-family: var(--font);
+        min-height: 100vh;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+      .container {
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 48px 24px 96px;
+      }
+      header {
+        margin-bottom: 48px;
+      }
+      .eyebrow {
+        display: inline-block;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--accent);
+        font-weight: 700;
+        margin-bottom: 12px;
+      }
+      h1 {
+        font-size: 42px;
+        line-height: 1.15;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        margin-bottom: 18px;
+      }
+      h1 span {
+        color: var(--accent);
+      }
+      .lede {
+        font-size: 19px;
+        color: var(--dim);
+        max-width: 680px;
+        margin-bottom: 32px;
+      }
+      .cta-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 48px;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 13px 22px;
+        border-radius: 8px;
+        font-weight: 700;
+        font-size: 14px;
+        text-decoration: none;
+        transition: all 0.15s ease;
+        border: 1px solid transparent;
+      }
+      .cta.primary {
+        background: var(--accent);
+        color: #06121a;
+      }
+      .cta.primary:hover {
+        background: #1ddae4;
+        transform: translateY(-1px);
+      }
+      .cta.secondary {
+        background: transparent;
+        border-color: var(--border);
+        color: var(--text);
+      }
+      .cta.secondary:hover {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      .cta.tertiary {
+        background: transparent;
+        border: none;
+        color: var(--dim);
+        padding: 13px 0;
+      }
+      .cta.tertiary:hover {
+        color: var(--accent);
+      }
+
+      section {
+        margin-bottom: 56px;
+      }
+      h2 {
+        font-size: 24px;
+        font-weight: 700;
+        margin-bottom: 18px;
+        letter-spacing: -0.01em;
+      }
+      h2::before {
+        content: '§ ';
+        color: var(--accent);
+        font-weight: 400;
+        opacity: 0.55;
+      }
+      .muted {
+        color: var(--dim);
+        margin-bottom: 14px;
+      }
+
+      .services {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+      .service-card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+      }
+      .service-card h3 {
+        font-size: 16px;
+        font-weight: 700;
+        margin-bottom: 8px;
+      }
+      .service-card .price {
+        font-size: 13px;
+        color: var(--gold);
+        font-weight: 700;
+        margin-bottom: 10px;
+        font-family: var(--mono);
+      }
+      .service-card p {
+        font-size: 14px;
+        color: var(--dim);
+        flex: 1;
+      }
+
+      .proof {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 24px;
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.7;
+      }
+      .proof .row {
+        display: flex;
+        justify-content: space-between;
+        gap: 24px;
+        padding: 6px 0;
+        border-bottom: 1px dashed rgba(142, 170, 199, 0.18);
+      }
+      .proof .row:last-child {
+        border-bottom: none;
+      }
+      .proof .label {
+        color: var(--dim);
+      }
+      .proof .value {
+        color: var(--text);
+        text-align: right;
+      }
+      .proof .value a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      .proof .value a:hover {
+        text-decoration: underline;
+      }
+
+      .qual-list {
+        list-style: none;
+        display: grid;
+        gap: 14px;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+      .qual-list li {
+        padding: 18px 20px;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        font-size: 14px;
+      }
+      .qual-list strong {
+        display: block;
+        color: var(--accent);
+        margin-bottom: 6px;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+      }
+
+      .trust {
+        background: linear-gradient(135deg, rgba(23, 198, 207, 0.08), rgba(255, 145, 82, 0.04));
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 28px;
+      }
+      .trust h2 {
+        margin-bottom: 8px;
+      }
+      .trust p {
+        color: var(--dim);
+        font-size: 14px;
+        margin-bottom: 14px;
+      }
+      .trust .legal {
+        font-size: 12px;
+        color: #7a8da3;
+        font-style: italic;
+      }
+
+      footer {
+        margin-top: 80px;
+        padding-top: 32px;
+        border-top: 1px solid var(--border);
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 16px;
+        font-size: 12px;
+        color: #7a8da3;
+      }
+      footer a {
+        color: var(--dim);
+        text-decoration: none;
+      }
+      footer a:hover {
+        color: var(--accent);
+      }
+
+      @media (max-width: 600px) {
+        h1 {
+          font-size: 32px;
+        }
+        .lede {
+          font-size: 17px;
+        }
+        .container {
+          padding: 32px 18px 72px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <div class="eyebrow">Fixed scope · 5 business days · Pay once</div>
+        <h1>Get a written AI governance read on your workflow. <span>$500.</span></h1>
+        <p class="lede">
+          Most teams don't need a giant compliance program. They need one written read of the AI
+          workflow they already shipped — what data flows in, what the model decides, where the
+          audit trail breaks. Two-page memo, three prioritized fixes, evidence checklist you can
+          hand to a buyer or reviewer. Five business days from intake. Cancel any time before
+          delivery for a full refund.
+        </p>
+
+        <div class="cta-row">
+          <a class="cta primary" href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+            >Buy the $500 Snapshot</a
+          >
+          <a class="cta secondary" href="governance-snapshot.html">See exactly what's inside</a>
+          <a
+            class="cta secondary"
+            href="mailto:issdandavis7795@gmail.com?subject=Snapshot%20question&body=Hi%20Issac%2C%0A%0AOne%20question%20before%20I%20buy%20the%20Snapshot%3A%0A%0A"
+            >Ask before you buy</a
+          >
+          <a class="cta tertiary" href="#hire-larger">Need something larger? →</a>
+        </div>
+      </header>
+
+      <section
+        id="hire-larger"
+        style="margin-top: 24px; padding: 12px 16px; border-left: 3px solid var(--accent)"
+      >
+        <p class="muted" style="margin: 0">
+          The $500 Snapshot is the on-ramp. If you already know you need an audit, custom
+          governance overlay, or federal subcontract help, the full menu is below.
+        </p>
+      </section>
+
+      <section>
+        <h2>What I do</h2>
+        <p class="muted">
+          Concrete engagements with real deliverables. Pricing is anchored, not theoretical.
+        </p>
+        <div class="services">
+          <div class="service-card">
+            <h3>AI Governance Snapshot</h3>
+            <div class="price">$500 · fixed scope · immediate fast-start packet</div>
+            <p>
+              A first-pass governance assessment for one AI workflow. You get immediate checkout
+              confirmation, the service fast-start packet, a human-reviewed findings memo, three
+              prioritized fixes, and an evidence checklist you can reuse with leadership, auditors,
+              or proposal reviewers.
+            </p>
+            <p>
+              <a href="governance-snapshot.html" style="color: var(--accent)">View scope</a> ·
+              <a href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j" style="color: var(--accent)"
+                >buy now</a
+              >
+            </p>
+          </div>
+
+          <div class="service-card">
+            <h3>Short advisory call</h3>
+            <div class="price">$300 · 60 min · same week</div>
+            <p>
+              One-hour conversation about a concrete AI safety / governance problem you're facing.
+              You leave with a written summary and a follow-up action list. If we don't find a real
+              path, you don't pay.
+            </p>
+          </div>
+
+          <div class="service-card">
+            <h3>Adversarial audit</h3>
+            <div class="price">$5,000 – $15,000 · 1–3 weeks</div>
+            <p>
+              I run my own L13 governance harness against your production LLM endpoint or agent. You
+              get the full attack catalog, false-allow rate, latency profile, and a remediation
+              plan. Composes with Anthropic Petri.
+            </p>
+          </div>
+
+          <div class="service-card">
+            <h3>Custom governance overlay</h3>
+            <div class="price">$25,000 – $80,000 · 4–10 weeks</div>
+            <p>
+              I build a deployable governance layer (containerized service, ≤200ms median latency)
+              sitting in front of your model API. Handles prompt-injection, identifier-canonicality,
+              bijective-tamper, and your domain-specific constraints. Open-source by default;
+              private-fork for regulated workloads.
+            </p>
+          </div>
+
+          <div class="service-card">
+            <h3>Federal subcontract role</h3>
+            <div class="price">$150 – $250 / hour · contract</div>
+            <p>
+              I'm SAM.gov registered (UEI J4NXHM6N5F59) and ready to subcontract on AI-safety,
+              governance, or LLM-evaluation work. Two DARPA proposals in active eval. Comfortable
+              with FAR 9.5 source-selection-protected work.
+            </p>
+          </div>
+
+          <div class="service-card">
+            <h3>Open-source feature work</h3>
+            <div class="price">$100 – $300 / hour · contract</div>
+            <p>
+              If you're using
+              <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" style="color: var(--accent)"
+                >SCBE-AETHERMOORE</a
+              >
+              or any of my npm/PyPI packages and want a feature added, integrated, or hardened — I'm
+              the canonical author. Sponsorships and bounties accepted.
+            </p>
+          </div>
+
+          <div class="service-card">
+            <h3>Workshops & internal training</h3>
+            <div class="price">$2,500 – $7,500 · half day or full day</div>
+            <p>
+              Walk your engineering team through hyperbolic-geometry foundations, the 14-layer
+              pipeline, or the practical implementation of NIST AI RMF / EO 14110 governance
+              evidence. Remote or in-person (PNW preferred).
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Verifiable proof</h2>
+        <p class="muted">
+          Don't take my word for it. Every claim below is independently verifiable in 30 seconds.
+        </p>
+        <div class="proof">
+          <div class="row">
+            <span class="label">SAM.gov UEI</span
+            ><span class="value">J4NXHM6N5F59 · ACTIVE through 2027-04-03</span>
+          </div>
+          <div class="row">
+            <span class="label">CAGE code</span><span class="value">1EXD5</span>
+          </div>
+          <div class="row">
+            <span class="label">Open-source library</span
+            ><span class="value"
+              ><a
+                href="https://github.com/issdandavis/SCBE-AETHERMOORE"
+                target="_blank"
+                rel="noopener"
+                >github.com/issdandavis/SCBE-AETHERMOORE</a
+              ></span
+            >
+          </div>
+          <div class="row">
+            <span class="label">npm package</span
+            ><span class="value"
+              ><a
+                href="https://www.npmjs.com/package/scbe-aethermoore"
+                target="_blank"
+                rel="noopener"
+                >scbe-aethermoore</a
+              ></span
+            >
+          </div>
+          <div class="row">
+            <span class="label">PyPI package</span
+            ><span class="value"
+              ><a href="https://pypi.org/project/scbe-agent-bus/" target="_blank" rel="noopener"
+                >scbe-agent-bus</a
+              ></span
+            >
+          </div>
+          <div class="row">
+            <span class="label">Provisional patent</span
+            ><span class="value">US 63/961,403 (hyperbolic governance substrate)</span>
+          </div>
+          <div class="row">
+            <span class="label">Federal proposals</span
+            ><span class="value">DARPA CLARA FP-033 · DARPA MATHBAC abstract</span>
+          </div>
+          <div class="row">
+            <span class="label">APEX Accelerator</span
+            ><span class="value">Port Angeles SBA-affiliated partner</span>
+          </div>
+          <div class="row">
+            <span class="label">Small business status</span
+            ><span class="value">Sole proprietor · minority-owned</span>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>What I'm uniquely good at</h2>
+        <ul class="qual-list">
+          <li>
+            <strong>Adversarial-cost manifold design</strong>Closed-form bounds on attack cost, not
+            learned filters. Hyperbolic geometry as substrate.
+          </li>
+          <li>
+            <strong>Constrained-decoding governance</strong>180/180 cross-lane structural
+            enforcement. Wilson CI [0.979, 1.0]. Deterministic.
+          </li>
+          <li>
+            <strong>Multi-axiom formal models</strong>5-axiom mesh (unitarity, locality, causality,
+            symmetry, composition) across 14 pipeline layers.
+          </li>
+          <li>
+            <strong>Composing with audit tools</strong>173/173 Petri seeds blocked when SCBE wired
+            as enforcement layer. Cite: Anthropic Petri (2026 Q1).
+          </li>
+          <li>
+            <strong>Post-quantum primitives</strong>ML-KEM-768 + ML-DSA-65 + AES-256-GCM throughout.
+            Migration-tested across liboqs renames.
+          </li>
+          <li>
+            <strong>Federal-readiness packaging</strong>SAM-registered, capability statement on
+            file, NAICS coverage across 7 codes.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>How to engage</h2>
+        <p class="muted">I prefer concrete starts. Here are three frictionless ways in:</p>
+        <div class="services">
+          <div class="service-card">
+            <h3>1. Email — fastest</h3>
+            <p style="margin-bottom: 14px">
+              <a
+                href="mailto:issdandavis7795@gmail.com?subject=Engagement%20inquiry%20%E2%80%94%20from%20aethermoore.com%2Fhire"
+                style="color: var(--accent)"
+                >issdandavis7795@gmail.com</a
+              >
+            </p>
+            <p>
+              Best for advisory calls, audits, or scoped engagements. Average reply time under 24
+              hours, often same day.
+            </p>
+          </div>
+          <div class="service-card">
+            <h3>2. Phone — for federal</h3>
+            <p style="margin-bottom: 14px">
+              <a href="tel:+13608080876" style="color: var(--accent)">(360) 808-0876</a>
+            </p>
+            <p>
+              Best for federal subcontract conversations, prime contractor BD calls, or anything
+              involving SAM/CAGE verification.
+            </p>
+          </div>
+          <div class="service-card">
+            <h3>3. Sponsor or tip</h3>
+            <p style="margin-bottom: 14px">
+              <a
+                href="https://ko-fi.com/izdandavis"
+                target="_blank"
+                rel="noopener"
+                style="color: var(--accent)"
+                >ko-fi.com/izdandavis</a
+              >
+            </p>
+            <p>
+              If the open-source work has helped you and there's no engagement on the table, a
+              sponsorship keeps the work funded and the next release shipping.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="trust">
+          <h2>How I work</h2>
+          <p>
+            Solo. No subcontracting layers, no junior teams shadowed by a senior, no offshoring. You
+            talk directly to the principal. Engagements get a written scope before money changes
+            hands. Open-source delivery is the default; private-fork is available for regulated
+            workloads with a written justification.
+          </p>
+          <p>
+            Booked from Port Angeles, WA. APEX Accelerator partnership. SAM.gov UEI J4NXHM6N5F59.
+          </p>
+          <p class="legal">
+            This page is informational. Engagements require a written agreement (statement of work
+            or contract) before performance begins. Federal subcontract work follows the prime's
+            flowdown clauses; FAR 9.5 source-selection sensitive matters are handled per the prime's
+            policy.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Talk to Polly</h2>
+        <p class="muted">
+          Polly is the SCBE assistant. Ask about products, scope a custom build, or get pointed at
+          the right resource. Conversations are routed to a private Hugging Face dataset and used to
+          train the next release — uncheck the box below if you'd rather opt out for this
+          conversation.
+        </p>
+        <label
+          style="
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 12px;
+            font-size: 13px;
+            color: var(--dim);
+            cursor: pointer;
+          "
+        >
+          <input id="pollyConsentToTrain" type="checkbox" checked />
+          <span
+            >Contribute this conversation to the private training dataset. Don't paste secrets,
+            credentials, or anything you wouldn't want a reviewer to see.</span
+          >
+        </label>
+        <div
+          id="pollyChatRoot"
+          style="
+            min-height: 560px;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
+            background: var(--card);
+          "
+        ></div>
+      </section>
+      <section>
+        <h2>Or scope a custom build directly</h2>
+        <p class="muted">
+          Skip the email back-and-forth — fill in the four fields below and you'll have a same-day
+          reply. Submissions land in a private dataset only Issac can see.
+        </p>
+        <form id="leadForm" style="display: grid; gap: 14px; max-width: 640px">
+          <!--
+            Honeypot: hidden from real users via off-screen positioning + tab
+            removal + autocomplete-off. Spambots scraping the form will fill
+            it; the server short-circuits any submission with this field non-
+            empty. Don't relabel "website" to something humans understand —
+            the field's job is to look interesting to dumb scrapers.
+          -->
+          <div
+            style="
+              position: absolute;
+              left: -10000px;
+              top: auto;
+              width: 1px;
+              height: 1px;
+              overflow: hidden;
+            "
+            aria-hidden="true"
+          >
+            <label
+              >Website (leave blank)
+              <input id="leadWebsite" name="website" type="text" tabindex="-1" autocomplete="off"
+            /></label>
+          </div>
+          <label style="display: grid; gap: 6px; font-size: 13px; color: var(--dim)">
+            <span>Email or phone *</span>
+            <input
+              id="leadContact"
+              name="contact"
+              type="text"
+              required
+              placeholder="you@company.com or (555) 555-5555"
+              style="
+                background: var(--bg);
+                border: 1px solid var(--border);
+                border-radius: 8px;
+                padding: 10px 12px;
+                color: var(--text);
+                font-size: 14px;
+              "
+            />
+          </label>
+          <label style="display: grid; gap: 6px; font-size: 13px; color: var(--dim)">
+            <span>Project type</span>
+            <select
+              id="leadProjectType"
+              name="project_type"
+              style="
+                background: var(--bg);
+                border: 1px solid var(--border);
+                border-radius: 8px;
+                padding: 10px 12px;
+                color: var(--text);
+                font-size: 14px;
+              "
+            >
+              <option value="ai-governance-snapshot">AI Governance Snapshot ($500)</option>
+              <option value="advisory-call">Short advisory call ($300)</option>
+              <option value="audit">Adversarial audit ($5K-15K)</option>
+              <option value="custom-overlay">Custom governance overlay ($25K-80K)</option>
+              <option value="subcontract">Federal subcontract role</option>
+              <option value="training">Workshop / internal training</option>
+              <option value="other">Other</option>
+            </select>
+          </label>
+          <label style="display: grid; gap: 6px; font-size: 13px; color: var(--dim)">
+            <span>Budget range</span>
+            <select
+              id="leadBudget"
+              name="budget"
+              style="
+                background: var(--bg);
+                border: 1px solid var(--border);
+                border-radius: 8px;
+                padding: 10px 12px;
+                color: var(--text);
+                font-size: 14px;
+              "
+            >
+              <option value="open">Open / not sure yet</option>
+              <option value="under-5k">Under $5,000</option>
+              <option value="5k-15k">$5,000 - $15,000</option>
+              <option value="15k-50k">$15,000 - $50,000</option>
+              <option value="50k-plus">$50,000+</option>
+            </select>
+          </label>
+          <label style="display: grid; gap: 6px; font-size: 13px; color: var(--dim)">
+            <span>Timeline</span>
+            <select
+              id="leadTimeline"
+              name="timeline"
+              style="
+                background: var(--bg);
+                border: 1px solid var(--border);
+                border-radius: 8px;
+                padding: 10px 12px;
+                color: var(--text);
+                font-size: 14px;
+              "
+            >
+              <option value="open">Flexible / open</option>
+              <option value="asap">ASAP / this week</option>
+              <option value="2-4-weeks">2-4 weeks</option>
+              <option value="1-3-months">1-3 months</option>
+              <option value="q3">Q3</option>
+              <option value="q4">Q4</option>
+            </select>
+          </label>
+          <label style="display: grid; gap: 6px; font-size: 13px; color: var(--dim)">
+            <span>What you need (be specific)</span>
+            <textarea
+              id="leadDescription"
+              name="description"
+              required
+              minlength="10"
+              maxlength="4000"
+              rows="6"
+              placeholder="What are you trying to do, what's the constraint, what does success look like..."
+              style="
+                background: var(--bg);
+                border: 1px solid var(--border);
+                border-radius: 8px;
+                padding: 10px 12px;
+                color: var(--text);
+                font-size: 14px;
+                font-family: inherit;
+                resize: vertical;
+              "
+            ></textarea>
+          </label>
+          <button
+            type="submit"
+            class="cta primary"
+            style="justify-self: start; cursor: pointer; border: 0"
+          >
+            Send to Issac
+          </button>
+          <div
+            id="leadStatus"
+            role="status"
+            aria-live="polite"
+            style="font-size: 13px; color: var(--dim)"
+          ></div>
+        </form>
+      </section>
+      <footer>
+        <div>
+          <a href="https://aethermoore.com">aethermoore.com</a> ·
+          <a href="https://github.com/issdandavis/SCBE-AETHERMOORE">GitHub</a> ·
+          <a href="mailto:issdandavis7795@gmail.com">issdandavis7795@gmail.com</a>
+        </div>
+        <div>Built solo · Last updated 2026-05-09</div>
+      </footer>
+    </div>
+
+    <script src="/static/polly-hf-chat.js"></script>
+    <script src="/static/polly-funnel.js"></script>
+    <script>
+      // Funnel beacons — operator-only telemetry. PollyFunnel auto-fires
+      // 'arrival' on DOMContentLoaded and 'scroll_50' / 'scroll_90' as
+      // the user scrolls. Below we add stage-specific beacons:
+      // chat_open, chat_msg, lead_form_focus, lead_submit_*, cta_click_*.
+      (function () {
+        if (!window.PollyFunnel) return;
+        // Buy-CTA clicks
+        document.querySelectorAll('a[href*="buy.stripe.com"]').forEach(function (link) {
+          link.addEventListener('click', function () {
+            window.PollyFunnel.fire('cta_click_buy', {
+              href: link.getAttribute('href') || '',
+              label: (link.textContent || '').trim().slice(0, 60),
+            });
+          });
+        });
+        // Email CTAs (mailto links)
+        document.querySelectorAll('a[href^="mailto:"]').forEach(function (link) {
+          link.addEventListener('click', function () {
+            window.PollyFunnel.fire('cta_click_email', {
+              href: link.getAttribute('href') || '',
+            });
+          });
+        });
+      })();
+
+      (function () {
+        var root = document.getElementById('pollyChatRoot');
+        if (!root || !window.PollyHFChat) return;
+        var consentBox = document.getElementById('pollyConsentToTrain');
+        var instance = window.PollyHFChat.mount(root, {
+          title: 'Polly',
+          subtitle: 'Direct line to product, custom builds, and the work itself.',
+          mode: 'scbe-polly',
+          scbeApiBase: window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app',
+          consentToTrain: true,
+          sessionId: 'hire-' + Date.now(),
+          initialAssistantText:
+            'Ask anything: products, custom builds, federal subcontract conversations, or how the 14-layer pipeline works.',
+          suggestions: [
+            'How much is the AI Governance Toolkit?',
+            'I need a custom audit for my finance LLM',
+            'How do I sponsor the work?',
+            'What does the harmonic wall actually do?',
+          ],
+        });
+        if (consentBox && instance && typeof instance.setConsent === 'function') {
+          consentBox.addEventListener('change', function () {
+            instance.setConsent(consentBox.checked === true);
+          });
+        }
+      })();
+
+      (function () {
+        var form = document.getElementById('leadForm');
+        var status = document.getElementById('leadStatus');
+        if (!form || !status) return;
+        var apiBase = window.POLLY_VERCEL_BASE || 'https://scbe-agent-bridge-vercel.vercel.app';
+        // First-focus beacon — fires once when the user starts engaging
+        // with the form (any field). PollyFunnel dedupes additional fires.
+        if (window.PollyFunnel) {
+          form.addEventListener(
+            'focusin',
+            function () {
+              window.PollyFunnel.fire('lead_form_focus');
+            },
+            { once: true }
+          );
+        }
+
+        // Contextual self-serve options based on project_type. The API now
+        // returns the canonical fulfillment packet; this table is a fallback.
+        var SELF_SERVE = {
+          'advisory-call': {
+            label: 'Want a head start while I reach out?',
+            cta: 'Open the service fast-start packet',
+            href: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html',
+          },
+          audit: {
+            label: 'Want to start reviewing the methodology now?',
+            cta: 'Open the service fast-start packet',
+            href: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html',
+          },
+          training: {
+            label: 'Want the workshop materials in advance?',
+            cta: 'Open the service fast-start packet',
+            href: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/service-fast-start.html',
+          },
+        };
+
+        function escapeHtml(value) {
+          return String(value || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+        }
+
+        function renderList(items) {
+          if (!items || !items.length) return '';
+          return (
+            '<ul style="margin:10px 0 0 18px;color:var(--dim);font-size:13px">' +
+            items
+              .map(function (item) {
+                return '<li style="margin-bottom:6px">' + escapeHtml(item) + '</li>';
+              })
+              .join('') +
+            '</ul>'
+          );
+        }
+
+        function renderGiftCards(gifts) {
+          if (!gifts || !gifts.length) return '';
+          return (
+            '<div style="display:grid;gap:10px;margin:12px 0 14px">' +
+            gifts
+              .map(function (gift) {
+                return (
+                  '<div style="border:1px solid var(--border);border-radius:10px;padding:12px;background:var(--card)">' +
+                  '<a href="' +
+                  escapeHtml(gift.url) +
+                  '" target="_blank" rel="noopener" style="color:var(--accent);font-weight:700;text-decoration:none">' +
+                  escapeHtml(gift.label) +
+                  '</a>' +
+                  '<p style="color:var(--dim);font-size:13px;margin:6px 0 0">' +
+                  escapeHtml(gift.why) +
+                  '</p>' +
+                  '</div>'
+                );
+              })
+              .join('') +
+            '</div>'
+          );
+        }
+
+        function renderThankYou(parent, projectType, packet) {
+          var offer = SELF_SERVE[projectType];
+          var blocks = [];
+          blocks.push(
+            '<h3 style="margin-bottom:8px;color:var(--green)">Got it — your message landed.</h3>'
+          );
+          blocks.push(
+            '<p style="color:var(--dim);margin-bottom:14px">' +
+              'I read every lead myself, usually within a few hours, always within 24h. ' +
+              'Reply will come from <strong style="color:var(--text)">issdandavis7795@gmail.com</strong> — ' +
+              "add it to your contacts so it doesn't go to spam." +
+              '</p>'
+          );
+          if (packet) {
+            blocks.push(
+              '<div style="border:1px solid var(--border);border-radius:10px;padding:14px;background:var(--surface);margin-bottom:14px">' +
+                '<div style="font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.08em;margin-bottom:6px">Order recap</div>' +
+                '<strong style="color:var(--text)">' +
+                escapeHtml(packet.offer) +
+                '</strong>' +
+                '<div style="color:var(--gold);font-size:13px;margin-top:4px">' +
+                escapeHtml(packet.price_anchor) +
+                '</div>' +
+                renderList(packet.order_recap) +
+                '</div>'
+            );
+            blocks.push(
+              '<div style="border:1px solid var(--border);border-radius:10px;padding:14px;background:var(--card);margin-bottom:14px">' +
+                '<div style="font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.08em;margin-bottom:6px">Initial AI inspection</div>' +
+                '<p style="color:var(--dim);font-size:13px;margin:0 0 8px">' +
+                escapeHtml(packet.review_window) +
+                '</p>' +
+                renderList(packet.initial_ai_inspection) +
+                '</div>'
+            );
+            blocks.push(
+              '<h4 style="margin:18px 0 8px;color:var(--text)">Free fast-start resources</h4>' +
+                renderGiftCards(packet.immediate_value)
+            );
+            blocks.push(
+              '<h4 style="margin:18px 0 8px;color:var(--text)">Follow-up steps</h4>' +
+                renderList(packet.follow_up_steps)
+            );
+          }
+          if (offer) {
+            blocks.push(
+              '<div style="border:1px solid var(--border);border-radius:10px;padding:14px;background:var(--card);margin-bottom:14px">' +
+                '<div style="font-size:13px;color:var(--dim);margin-bottom:8px">' +
+                offer.label +
+                '</div>' +
+                '<a href="' +
+                offer.href +
+                '" target="_blank" rel="noopener" class="cta primary" style="display:inline-block;text-decoration:none">' +
+                offer.cta +
+                '</a>' +
+                '</div>'
+            );
+          }
+          blocks.push(
+            '<p style="font-size:13px;color:var(--dim)">' +
+              "If something's urgent, " +
+              '<a href="mailto:issdandavis7795@gmail.com" style="color:var(--accent)">email directly</a> — ' +
+              'or scroll up and ask Polly anything in the meantime.' +
+              '</p>'
+          );
+          parent.innerHTML = blocks.join('');
+        }
+
+        form.addEventListener('submit', async function (event) {
+          event.preventDefault();
+          status.textContent = 'Sending…';
+          status.style.color = 'var(--dim)';
+          var projectType = document.getElementById('leadProjectType').value;
+          if (window.PollyFunnel) {
+            window.PollyFunnel.fire('lead_submit_attempt', { project_type: projectType });
+          }
+          var payload = {
+            contact: document.getElementById('leadContact').value,
+            project_type: projectType,
+            budget: document.getElementById('leadBudget').value,
+            timeline: document.getElementById('leadTimeline').value,
+            description: document.getElementById('leadDescription').value,
+            source: 'aethermoore.com/hire',
+            website: document.getElementById('leadWebsite').value,
+          };
+          try {
+            var response = await fetch(apiBase.replace(/\/$/, '') + '/v1/polly/lead', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+            var data = await response.json();
+            if (!response.ok || !data.ok) {
+              status.style.color = '#ff7a7a';
+              status.textContent =
+                'Could not send: ' +
+                (data.error || 'unknown error') +
+                '. Try again or email directly.';
+              if (window.PollyFunnel) {
+                window.PollyFunnel.fire('lead_submit_fail', {
+                  http: response.status,
+                  error: (data && data.error) || '',
+                });
+              }
+              return;
+            }
+            if (window.PollyFunnel) {
+              window.PollyFunnel.fire('lead_submit_ok', { project_type: projectType });
+            }
+            // Replace the form with the contextual thank-you panel so the
+            // user gets a clear next step instead of a one-line confirmation.
+            var section = form.parentElement;
+            var heading = section ? section.querySelector('h2') : null;
+            if (heading) heading.textContent = 'Thanks for the message';
+            var preBlurb = section ? section.querySelector('p.muted') : null;
+            if (preBlurb) preBlurb.remove();
+            form.remove();
+            var thankYouHost = document.createElement('div');
+            thankYouHost.id = 'leadThankYou';
+            thankYouHost.style.maxWidth = '640px';
+            (section || document.body).appendChild(thankYouHost);
+            renderThankYou(thankYouHost, projectType, data.fulfillment_packet);
+          } catch (error) {
+            status.style.color = '#ff7a7a';
+            status.textContent =
+              'Network error sending the lead. Email issdandavis7795@gmail.com directly as a fallback.';
+            if (window.PollyFunnel) {
+              window.PollyFunnel.fire('lead_submit_fail', {
+                error: String((error && error.message) || error).slice(0, 80),
+              });
+            }
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/docs/static/polly-funnel.js
+++ b/docs/static/polly-funnel.js
@@ -31,6 +31,10 @@
   function pageId() {
     var p = (location.pathname || '').toLowerCase();
     if (p.indexOf('governance-snapshot') !== -1) return 'governance-snapshot';
+    // Variant pages MUST be detected before the generic /hire match,
+    // otherwise hire-b.html would funnel into the same bucket as /hire
+    // and the A/B comparison would be impossible.
+    if (p.indexOf('hire-b') !== -1) return 'hire-b';
     if (p.indexOf('/hire') !== -1) return 'hire';
     if (p.indexOf('hire.html') !== -1) return 'hire';
     if (p.indexOf('polly-stats') !== -1) return 'polly-stats';

--- a/vercel.json
+++ b/vercel.json
@@ -33,6 +33,14 @@
       "dest": "/api/agent/hire.js"
     },
     {
+      "src": "^/hire-b/?$",
+      "dest": "/api/agent/hire-b.js"
+    },
+    {
+      "src": "^/SCBE-AETHERMOORE/hire-b\\.html$",
+      "dest": "/api/agent/hire-b.js"
+    },
+    {
       "src": "^/(?:SCBE-AETHERMOORE/)?product-manual/service-fast-start\\.html$",
       "dest": "/api/agent/service-fast-start.js"
     },


### PR DESCRIPTION
## Summary

- **`docs/hire-b.html`** — same body as `/hire`, hero rewritten to lead with "$500 fixed-scope written read" instead of broad consulting tiers. Single concrete outcome anchored on price + 5-business-day timeline. Below-the-fold matches `/hire` so the test isolates hero impact.
- **`api/agent/hire-b.js` + `vercel.json`** routes for `/hire-b` and `/SCBE-AETHERMOORE/hire-b.html`. Mirrors `hire.js`.
- **`docs/static/polly-funnel.js`** `pageId()` now detects `hire-b` BEFORE the generic `/hire` match. Funnel beacons fire with `page='hire-b'` so the per-event dashboard breaks the variants apart.

## How to run the test

Drive 50/50 traffic at `/hire` and `/hire-b` for a week. Compare `cta_click_buy` and `lead_submit_ok` per page on the polly-stats dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)