### PR TITLE
feat(polly): add supporter subscription offer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,7 @@ STRIPE_SNAPSHOT_PAYMENT_LINK_ID=plink_snapshot_live_or_test
 STRIPE_HEARTBEAT_PAYMENT_LINK_ID=plink_heartbeat_live_or_test
 SCBE_PAYMENT_LINK_SNAPSHOT=https://buy.stripe.com/live_snapshot_link
 SCBE_PAYMENT_LINK_HEARTBEAT=https://buy.stripe.com/live_heartbeat_subscription_link
+SCBE_PAYMENT_LINK_SUPPORTER=https://buy.stripe.com/live_supporter_subscription_link
 SCBE_PAYMENT_LINK_TOOLKIT=https://buy.stripe.com/live_toolkit_link
 SCBE_PAYMENT_LINK_VAULT=https://buy.stripe.com/live_training_vault_link
 STRIPE_PRICE_STARTER=price_starter_monthly

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -41,6 +41,28 @@ const PRODUCT_CATALOG = [
     ],
   },
   {
+    sku: 'aethermoore-supporter',
+    name: 'AetherMoore Supporter',
+    priceLabel: '$20/month',
+    short:
+      'Monthly supporter subscription for people who want the open-source work to keep moving without scoping a formal service engagement.',
+    checkoutUrl: checkoutUrlFromEnv(
+      'SCBE_PAYMENT_LINK_SUPPORTER',
+      'https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i'
+    ),
+    deliveryUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/supporter.html',
+    keywords: [
+      'supporter',
+      'aethermoore supporter',
+      'monthly supporter',
+      'support monthly',
+      '20/month',
+      '$20',
+      'sponsor monthly',
+      'small subscription',
+    ],
+  },
+  {
     sku: 'ai-governance-snapshot',
     name: 'AI Governance Snapshot',
     priceLabel: '$500 one-time',
@@ -484,6 +506,7 @@ function renderMembershipReply() {
   const text =
     'Three ways to stay close to the work:\n\n' +
     '- **Use service credits** for pay-as-you-go hosted routing without a big subscription\n' +
+    '- **AetherMoore Supporter** for a $20/month open-source support subscription\n' +
     '- **Governance Heartbeat** for a $99/month scan/report loop on one AI workflow\n' +
     '- **Sponsor / tip** the open-source work via Ko-fi\n' +
     '- **Watch the GitHub repo** for releases (`Watch -> Custom -> Releases`)\n' +
@@ -494,6 +517,13 @@ function renderMembershipReply() {
     {
       label: 'Service credits',
       url: 'https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html',
+    },
+    {
+      label: 'AetherMoore Supporter',
+      url: checkoutUrlFromEnv(
+        'SCBE_PAYMENT_LINK_SUPPORTER',
+        'https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i'
+      ),
     },
     {
       label: 'Governance Heartbeat',

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -198,7 +198,7 @@ describe('polly lead handler — anti-abuse', () => {
 
 describe('polly commerce intent classification', () => {
   it('catalog has live products with valid checkout urls', () => {
-    expect(commerce.PRODUCT_CATALOG).toHaveLength(6);
+    expect(commerce.PRODUCT_CATALOG).toHaveLength(7);
     for (const product of commerce.PRODUCT_CATALOG) {
       expect(product.checkoutUrl).toMatch(/^(https:\/\/(buy\.stripe\.com|ko-fi\.com)|mailto:)/);
       expect(product.keywords.length).toBeGreaterThan(0);
@@ -209,6 +209,13 @@ describe('polly commerce intent classification', () => {
     const intent = commerce.classifyIntent('I want to buy service credits for hosted routing');
     expect(intent.name).toBe('buy');
     expect(intent.product.sku).toBe('scbe-service-credits');
+  });
+
+  it('classifies the $20 supporter offer as a buyable subscription', () => {
+    const intent = commerce.classifyIntent('I want to buy the $20 monthly supporter subscription');
+    expect(intent.name).toBe('buy');
+    expect(intent.product.sku).toBe('aethermoore-supporter');
+    expect(intent.product.checkoutUrl).toMatch(/^https:\/\/buy\.stripe\.com\//);
   });
 
   it('honors env checkout override for governance heartbeat', () => {
@@ -358,15 +365,17 @@ describe('polly commerce reply rendering', () => {
     );
   });
 
-  it('renderMembershipReply has credits + Ko-fi + GitHub + email actions', () => {
+  it('renderMembershipReply has credits + supporter + heartbeat + Ko-fi + GitHub + email actions', () => {
     const out = commerce.renderMembershipReply();
-    expect(out.actions).toHaveLength(5);
+    expect(out.actions).toHaveLength(6);
     expect(out.actions[0].url).toContain('service-credits');
-    expect(out.actions[1].url).toContain('Governance%20Heartbeat');
-    expect(out.actions[2].url).toContain('ko-fi.com');
-    expect(out.actions[3].url).toContain('github.com');
-    expect(out.actions[4].url).toContain('mailto:');
+    expect(out.actions[1].url).toMatch(/^https:\/\/buy\.stripe\.com\//);
+    expect(out.actions[2].url).toContain('Governance%20Heartbeat');
+    expect(out.actions[3].url).toContain('ko-fi.com');
+    expect(out.actions[4].url).toContain('github.com');
+    expect(out.actions[5].url).toContain('mailto:');
     expect(out.text).toContain('2-5%');
+    expect(out.text).toContain('$20/month');
     expect(out.text).toContain('$99/month');
   });
 


### PR DESCRIPTION
## Summary
- Adds the existing $20/month AetherMoore Supporter subscription to Polly's commerce catalog
- Routes buyer phrases like `$20 monthly supporter subscription` to the live Stripe supporter link
- Adds Supporter to membership replies as the lowest-friction recurring support path
- Documents `SCBE_PAYMENT_LINK_SUPPORTER` for future public checkout URL override

## Test evidence
- `npm test -- tests/api/polly_commerce_js.test.ts` -> 65 passed
- `npx prettier --check api/polly/commerce.js tests/api/polly_commerce_js.test.ts .env.example` -> passed
- `git diff --check` -> passed

## Rollback
- Revert this PR to remove Supporter from Polly's server-side commerce catalog.