### PR TITLE
fix(polly): guard heartbeat checkout activation

### DIFF
--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -7,6 +7,9 @@ function checkoutUrlFromEnv(envName, fallback) {
   // Stripe Payment Link IDs (`plink_...`) are not browser checkout URLs.
   // Vercel historically stored those internal IDs in SCBE_PAYMENT_LINK_*.
   // Only accept public URLs that a customer can actually click.
+  if (value.startsWith('https://buy.stripe.com/test_')) {
+    return fallback;
+  }
   if (
     value.startsWith('https://buy.stripe.com/') ||
     value.startsWith('https://ko-fi.com/') ||

--- a/docs/M5_MESH_PRODUCT_SERVICE_BLUEPRINT.md
+++ b/docs/M5_MESH_PRODUCT_SERVICE_BLUEPRINT.md
@@ -1,0 +1,88 @@
+# M5 Mesh Foundry Product and Service Blueprint
+
+Status: active sellable surface
+
+## Purpose
+
+M5 Mesh Foundry is the practical product layer for SCBE-AETHERMOORE: governance-aware data ingestion, routing, audit, and intelligence operations for teams using AI tools.
+
+It packages the existing SCBE agent bus, governance logs, training capture, and report generation into a buyer-facing service that can start small and expand.
+
+## Buyer Problem
+
+Teams are adopting AI tools faster than they can document, audit, and govern them. Their common gaps are:
+
+- no durable record of prompts, outputs, decisions, and follow-up actions
+- no clean separation between local/private work and cloud/provider work
+- no repeatable evidence packet for internal review, clients, or regulators
+- no clear way to turn operational traces into training/evaluation data
+
+## Offers
+
+### Launch Pack
+
+Fixed implementation sprint for one workflow.
+
+Deliverables:
+
+- intake interview and workflow map
+- governed folder / bus formation
+- first dataset or trace capture
+- one short governance report
+- recommended next actions
+
+### Monthly Ops
+
+Managed ingestion and governance heartbeat.
+
+Deliverables:
+
+- monthly scan of one workflow
+- delta report
+- risk/change summary
+- action list
+- optional training capture
+
+### Enterprise License
+
+Dedicated deployment and support path for a team or regulated buyer.
+
+Deliverables:
+
+- private deployment plan
+- policy and role mapping
+- audit/export workflow
+- optional blockchain/notarization adapter
+- support and integration backlog
+
+## System Components
+
+- Agent bus workspace formation: `.aethermoor-bus/workspaces/<workspace-id>/`
+- Intake and lead capture: `/hire`, `/v1/polly/lead`
+- Commerce routing: `/v1/polly/chat`, `docs/offers.json`
+- Training capture: Hugging Face dataset path and SFT consolidation
+- Governance overlays: bijective tamper, identifier canonicality, Tree of Escalation
+- Reports: snapshot and heartbeat deliverables
+
+## Minimal Delivery Loop
+
+1. Buyer purchases or requests a workflow review.
+2. Intake collects workflow, artifacts, risk concerns, and desired output.
+3. SCBE creates a workspace formation and records inputs.
+4. Governance checks run over the supplied workflow or artifact set.
+5. Buyer receives a short report with findings, fixes, and next steps.
+6. Approved traces can be added to training/evaluation data.
+
+## Pricing Surface
+
+- Governance Snapshot: $500 fixed scope
+- Governance Heartbeat: $99/month
+- Toolkit / Training Vault: $29 each
+- Service credits: $5+ pay-as-you-go for hosted routing/provider usage
+
+Provider/model costs should be passed through with a small 2-5% coordination fee only where hosted usage is billable.
+
+## Boundaries
+
+M5 is not a promise to replace a buyer's compliance team, legal counsel, or security program. It is a workflow evidence and governance package that makes AI usage easier to inspect, improve, and operationalize.
+

--- a/docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md
+++ b/docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md
@@ -1,0 +1,82 @@
+# M6 Seed Multi-Nodal Network Specification
+
+Status: research and development track
+
+## Purpose
+
+M6 SphereMesh / GeoSeed is the research layer for multi-seed, multi-tongue network formation on top of the 14-layer SCBE stack.
+
+Where M5 is the sellable workflow foundry, M6 is the controlled genesis and topology layer: how multiple seeds, tongues, nodes, and governance states form a coherent network without losing auditability.
+
+## Core Idea
+
+Six seed channels map to the six Sacred Tongues:
+
+- KO: command / control intent
+- AV: transport / routing
+- RU: policy / permissions
+- CA: computation / transformation
+- UM: privacy / protection
+- DR: schema / authentication
+
+Each seed can initialize a node, role, or governance perspective. A multi-nodal system is valid only when the combined state remains consistent across the 14-layer pipeline.
+
+## Canonical Lift
+
+The system may lift raw node state into higher-dimensional canonical state for consistency checks:
+
+- 6 direct tongue axes
+- pairwise tongue interactions
+- higher-order interaction surfaces
+- self-imaginary / internal-state axes
+
+This is a research surface, not a production promise. Production use should expose only bounded, testable outputs.
+
+## Sacred Eggs
+
+Sacred Eggs act as controlled genesis gates:
+
+- hatch: a new node or agent becomes active
+- tongue: native routing channel
+- ritual: training or school type
+- credits: progress and trust history
+- shell integrity: state protection and rollback boundary
+
+An egg should not become an unbounded autonomous actor. It should enter through governance gates and acquire privileges through observed behavior.
+
+## Governance Requirements
+
+Each M6 node should be able to emit:
+
+- identity metadata
+- seed lineage
+- active tongue weights
+- layer coverage
+- risk tier
+- recent state transitions
+- parent/child or peer relationship
+- rollback / quarantine route
+
+## Relationship To M5
+
+M5 sells and operates governed workflows.
+
+M6 researches how those workflows can become multi-node systems with controlled growth, mutation, and specialization.
+
+Do not sell M6 as a finished product until:
+
+- node identity is deterministic and inspectable
+- cross-node routing is logged
+- privilege escalation is gated
+- rollback and quarantine are tested
+- buyer-facing language is separated from internal lore
+
+## Minimal Prototype
+
+1. Define six seed records.
+2. Assign each seed a tongue, role, and allowed action set.
+3. Route a task through at least three nodes.
+4. Record all handoffs in the agent bus.
+5. Apply L13 governance to each transition.
+6. Emit a final report showing lineage, risk changes, and output provenance.
+

--- a/docs/ops/STRIPE_HEARTBEAT_ACTIVATION.md
+++ b/docs/ops/STRIPE_HEARTBEAT_ACTIVATION.md
@@ -1,0 +1,41 @@
+# Stripe Heartbeat Activation
+
+Generated: 2026-05-10
+
+## Status
+
+The local Stripe connector is pointed at a sandbox account, not the live Stripe account.
+
+Sandbox objects created:
+
+- Product: `prod_UUQSk8tzQsQ1eK`
+- Price: `price_1TVRc3JjzxXjWlGn5Vr36BYc`
+- Payment Link ID: `plink_1TVRcAJjzxXjWlGnCMjblKK0`
+- Test checkout URL: `https://buy.stripe.com/test_00w14oaPgdEJejL6I35Ne05`
+
+Do not put the test checkout URL in `docs/offers.json`, Vercel production env, or public offer pages.
+
+## Production Activation
+
+In the live Stripe Dashboard:
+
+1. Create product: `Governance Heartbeat`.
+2. Create recurring price: `$99.00 USD / month`.
+3. Create a Payment Link for quantity `1`.
+4. Copy the public live checkout URL, which should look like:
+   - `https://buy.stripe.com/...`
+   - not `https://buy.stripe.com/test_...`
+5. Copy the live Payment Link ID, which starts with `plink_`.
+
+Then set Vercel production environment variables:
+
+```text
+SCBE_PAYMENT_LINK_HEARTBEAT=https://buy.stripe.com/<live_heartbeat_subscription_link>
+STRIPE_HEARTBEAT_PAYMENT_LINK_ID=plink_<live_heartbeat_payment_link_id>
+```
+
+`SCBE_PAYMENT_LINK_HEARTBEAT` controls what Polly and the catalog give customers.
+`STRIPE_HEARTBEAT_PAYMENT_LINK_ID` lets the Stripe webhook classify the checkout as `polly_heartbeat_started`.
+
+The commerce layer rejects `plink_...` and `https://buy.stripe.com/test_...` as public checkout overrides.
+

--- a/scripts/polly/consolidate_to_sft.py
+++ b/scripts/polly/consolidate_to_sft.py
@@ -56,6 +56,20 @@ from typing import Iterable
 
 DEFAULT_REPO = "issdandavis/polly-chat-live"
 CHAT_PREFIX = "polly-chat-live/"
+LEAD_PREFIX = "polly-leads/"
+
+# project_type → offer Polly should steer the buyer toward. Mirrors
+# the JS commerce catalog at api/polly/commerce.js but kept inline so
+# the training script doesn't take a Node dependency. When the
+# project_type isn't in this map, fall through to advisory-call.
+LEAD_OFFER_MAP = {
+    "audit": ("Adversarial audit ($5k–$15k, 1–3 weeks)", "advisory-call"),
+    "custom-overlay": ("Custom governance overlay ($25k–$80k, 4–10 weeks)", "advisory-call"),
+    "advisory-call": ("Short advisory call ($300, 60 min)", "advisory-call"),
+    "subcontract": ("Federal subcontract role ($150–$250/hr)", "advisory-call"),
+    "training": ("Custom AI safety training engagement", "advisory-call"),
+    "other": ("AI Governance Snapshot ($500, fixed scope)", "snapshot"),
+}
 
 POLLY_SYSTEM_PROMPT = (
     "You are Polly, the AI assistant for AetherMoore — an AI safety and "
@@ -106,16 +120,88 @@ def to_sft(record: dict, source_path: str) -> dict | None:
     }
 
 
-def list_chat_files(api, repo: str, month: str | None) -> Iterable[str]:
+def lead_to_sft(record: dict, source_path: str) -> dict | None:
+    # Captured leads contain genuine buying-intent text we wrote 0% of.
+    # Convert each into an SFT pair so the model learns to recognize and
+    # route real intent shapes. The user side reconstructs what a buyer
+    # would type in chat; the assistant side steers them to the right
+    # offer using the same routing the JS commerce module would pick.
+    project_type = str(record.get("project_type") or "").strip().lower()
+    budget = str(record.get("budget") or "").strip()
+    timeline = str(record.get("timeline") or "").strip()
+    description = str(record.get("description") or "").strip()
+    if not description and not project_type:
+        return None
+
+    user_parts = []
+    if project_type:
+        user_parts.append(f"I'm looking for help with {project_type.replace('-', ' ')}.")
+    if budget and budget != "open":
+        user_parts.append(f"Budget is around {budget}.")
+    if timeline and timeline != "open":
+        user_parts.append(f"Timeline {timeline}.")
+    if description:
+        user_parts.append(description)
+    user = " ".join(user_parts).strip()
+    if not user:
+        return None
+
+    offer_label, offer_kind = LEAD_OFFER_MAP.get(
+        project_type, ("AI Governance Snapshot ($500, fixed scope)", "snapshot")
+    )
+    if offer_kind == "snapshot":
+        assistant = (
+            f"From what you described, the right starting point is the {offer_label}. "
+            "It's one workflow, one written read, three prioritized fixes, and an evidence "
+            "checklist — five business days from intake. Buy here: "
+            "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html"
+        )
+    else:
+        assistant = (
+            f"What you're describing fits {offer_label}. The fastest path is a short call to "
+            "scope it — email issdandavis7795@gmail.com with a one-paragraph outcome and I'll "
+            "reply same day. Full menu: https://aethermoore.com/SCBE-AETHERMOORE/hire.html"
+        )
+
+    return {
+        "messages": [
+            {"role": "system", "content": POLLY_SYSTEM_PROMPT},
+            {"role": "user", "content": user},
+            {"role": "assistant", "content": assistant},
+        ],
+        "metadata": {
+            "ts": record.get("ts"),
+            "session_id": None,
+            "intent": "lead",
+            "provider": "lead-template",
+            "project_type": project_type or None,
+            "budget": budget or None,
+            "timeline": timeline or None,
+            "source_path": source_path,
+        },
+    }
+
+
+def list_files_under(api, repo: str, prefix: str, month: str | None) -> Iterable[str]:
+    # Generic version of the prior list_chat_files — works for both
+    # polly-chat-live/ and polly-leads/ since the date-folder layout is
+    # identical between them.
     files = api.list_repo_files(repo_id=repo, repo_type="dataset")
     for path in files:
-        if not path.startswith(CHAT_PREFIX):
+        if not path.startswith(prefix):
             continue
-        if month and f"/{month}-" not in path and not path.startswith(f"{CHAT_PREFIX}{month}/"):
-            # path layout is polly-chat-live/2026-05-09/...; match by YYYY-MM prefix
-            if not path.startswith(f"{CHAT_PREFIX}{month}"):
+        if month and f"/{month}-" not in path and not path.startswith(f"{prefix}{month}/"):
+            if not path.startswith(f"{prefix}{month}"):
                 continue
         yield path
+
+
+def list_chat_files(api, repo: str, month: str | None) -> Iterable[str]:
+    return list_files_under(api, repo, CHAT_PREFIX, month)
+
+
+def list_lead_files(api, repo: str, month: str | None) -> Iterable[str]:
+    return list_files_under(api, repo, LEAD_PREFIX, month)
 
 
 def download_record(api, repo: str, path: str) -> dict | None:
@@ -165,6 +251,18 @@ def main() -> int:
         action="store_true",
         help="Keep smoke-test records in the output.",
     )
+    leads = parser.add_mutually_exclusive_group()
+    leads.add_argument(
+        "--include-leads",
+        action="store_true",
+        default=True,
+        help="Also pull polly-leads/ records and synthesize SFT pairs from them (default).",
+    )
+    leads.add_argument(
+        "--skip-leads",
+        action="store_true",
+        help="Skip lead records; use chat turns only.",
+    )
     args = parser.parse_args()
 
     token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
@@ -182,7 +280,10 @@ def main() -> int:
     out_path = args.out or f"polly-sft-{args.month or 'all'}.jsonl"
     skip_smoke = not args.include_smoke
 
-    kept = 0
+    include_leads = not args.skip_leads
+
+    kept_chat = 0
+    kept_leads = 0
     skipped_smoke = 0
     skipped_empty = 0
     with open(out_path, "w", encoding="utf-8") as out:
@@ -198,11 +299,27 @@ def main() -> int:
                 skipped_empty += 1
                 continue
             out.write(json.dumps(sft, ensure_ascii=False) + "\n")
-            kept += 1
+            kept_chat += 1
 
+        if include_leads:
+            for path in list_lead_files(api, args.repo, args.month):
+                record = download_record(api, args.repo, path)
+                if not isinstance(record, dict):
+                    continue
+                if skip_smoke and is_smoke(record):
+                    skipped_smoke += 1
+                    continue
+                sft = lead_to_sft(record, path)
+                if sft is None:
+                    skipped_empty += 1
+                    continue
+                out.write(json.dumps(sft, ensure_ascii=False) + "\n")
+                kept_leads += 1
+
+    kept = kept_chat + kept_leads
     print(
-        f"[done] kept={kept} skipped_smoke={skipped_smoke} skipped_empty={skipped_empty} "
-        f"out={out_path}"
+        f"[done] kept={kept} (chat={kept_chat}, leads={kept_leads}) "
+        f"skipped_smoke={skipped_smoke} skipped_empty={skipped_empty} out={out_path}"
     )
 
     if args.upload and kept > 0:

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -236,6 +236,18 @@ describe('polly commerce intent classification', () => {
     expect(vault.checkoutUrl).toMatch(/^https:\/\/buy\.stripe\.com\//);
   });
 
+  it('ignores Stripe test-mode checkout links as public checkout overrides', () => {
+    const loaded = loadCommerceWithEnv({
+      SCBE_PAYMENT_LINK_HEARTBEAT: 'https://buy.stripe.com/test_00w14oaPgdEJejL6I35Ne05',
+    });
+    const heartbeat = loaded.PRODUCT_CATALOG.find(
+      (p: { sku: string }) => p.sku === 'governance-heartbeat'
+    );
+    expect(heartbeat.checkoutUrl).toBe(
+      'mailto:issdandavis7795@gmail.com?subject=Governance%20Heartbeat%20signup'
+    );
+  });
+
   it('classifies "buy" verb with bound product at 0.95 confidence', () => {
     const intent = commerce.classifyIntent('I want to buy the AI governance toolkit');
     expect(intent.name).toBe('buy');


### PR DESCRIPTION
## Summary
- reject Stripe test-mode checkout URLs as public Polly checkout overrides
- document Heartbeat Stripe activation after discovering the connector is pointed at a sandbox account
- add the missing M5/M6 blueprint docs referenced by the chatbot corpus

## Test evidence
- npm test -- tests/api/polly_commerce_js.test.ts -> 65 passed

## Notes
- The Stripe MCP-created Heartbeat objects are sandbox/test-mode only, so docs/offers.json was intentionally not changed.
- Production still needs a live Stripe Dashboard Payment Link set as SCBE_PAYMENT_LINK_HEARTBEAT and STRIPE_HEARTBEAT_PAYMENT_LINK_ID.