### PR TITLE
fix(vercel): skip previews for non-deployed paths

### DIFF
--- a/docs/M5_MESH_PRODUCT_SERVICE_BLUEPRINT.md
+++ b/docs/M5_MESH_PRODUCT_SERVICE_BLUEPRINT.md
@@ -1,88 +1,242 @@
-# M5 Mesh Foundry Product and Service Blueprint
+# M5 Mesh Foundry — Product & Service Blueprint
 
-Status: active sellable surface
+Last updated: 2026-05-10
+Status: **operational** — paying offers live, end-to-end pipeline shipped
 
-## Purpose
+## 1) What M5 is
 
-M5 Mesh Foundry is the practical product layer for SCBE-AETHERMOORE: governance-aware data ingestion, routing, audit, and intelligence operations for teams using AI tools.
+M5 Mesh Foundry is the productized, governance-aware data-and-intelligence
+layer that sits in front of the SCBE 14-layer pipeline and turns one workflow
+at a time into a delivered, audited artifact.
 
-It packages the existing SCBE agent bus, governance logs, training capture, and report generation into a buyer-facing service that can start small and expand.
+It is the **revenue surface** for SCBE-AETHERMOORE. Where M6 (see
+`M6_SEED_MULTI_NODAL_NETWORK_SPEC.md`) is the research substrate, M5 is what
+customers actually buy.
 
-## Buyer Problem
+Three properties define M5:
 
-Teams are adopting AI tools faster than they can document, audit, and govern them. Their common gaps are:
+1. **Single-workflow scope.** Every offer maps to exactly one workflow, one
+   delivery, one report. No open-ended consulting.
+2. **Governed by default.** Every record that flows through M5 passes through
+   the same harmonic-wall + axiom-mesh pipeline used internally; nothing
+   leaves without a governance stamp.
+3. **Capture-on-delivery.** Every governed delivery emits a structured record
+   into the training capture lane so M6 research benefits from M5 production.
+
+## 2) Buyer problem
+
+Teams are adopting AI tools faster than they can document, audit, and govern
+them. Their common gaps are:
 
 - no durable record of prompts, outputs, decisions, and follow-up actions
 - no clean separation between local/private work and cloud/provider work
 - no repeatable evidence packet for internal review, clients, or regulators
 - no clear way to turn operational traces into training/evaluation data
 
-## Offers
+M5 sells the read, not the platform.
+
+## 3) Live offers (canonical: `docs/offers.json`)
+
+The offer catalog is data-driven. The file `docs/offers.json` is the single
+source of truth. As of 2026-05-10:
+
+| ID | Name | Price | Type | Role in M5 |
+|---|---|---|---|---|
+| `service_credits` | SCBE Service Credits | $5+ pay-as-you-go | usage_credit | Usage-billed tier (2-5% coordination fee on provider passthrough) |
+| `tip_jar` | Tip Jar | $5 one time | one_time | Lowest-friction support |
+| `supporter_monthly` | AetherMoore Supporter | $20/mo | subscription | Recurring patron tier |
+| `governance_snapshot` | **Governance Snapshot** | **$500 fixed scope** | service | **Flagship M5 deliverable** |
+| `governance_heartbeat` | **Governance Heartbeat** | **$99/mo** | subscription | **Continuity tier; upsells from Snapshot** |
+| `toolkit` | SCBE Toolkit | $29 | digital_download | Self-serve tooling |
+| `training_vault` | Training Vault | $29 | digital_download | Self-serve dataset access |
+
+### 3.1) Governance Snapshot (the flagship)
+
+**What the buyer gets, fixed scope:**
+
+- One AI workflow scanned through the SCBE 14-layer pipeline
+- One short written report (delta vs. baseline, risks, recommendations)
+- One axiom-compliance summary (which of the 5 axioms held, where they bent)
+- One recommended action list
+- 5-business-day delivery, refund any time before delivery
+
+**Why it sells:** every other governance vendor sells a platform. M5 sells one
+finished read for a fixed price — the buyer is not committing to integration,
+they are buying clarity.
+
+### 3.2) Governance Heartbeat (the continuity)
+
+**What the buyer gets, monthly:**
+
+- Monthly scan of one workflow
+- Short report (delta vs. last month)
+- One risk / change summary
+- One recommended action list
+- Optional dataset / training capture
+- Cancel any time
+
+**Why it sells:** Snapshot proves the read; Heartbeat keeps it. First report
+within 14 days of subscription start.
+
+## 4) The pipeline (what actually runs)
+
+```
+Visitor on /hire or /governance-snapshot
+        │
+        │ funnel beacons (docs/static/polly-funnel.js)
+        ▼
+HF dataset: polly-funnel/  (event-prefixed)
+        │
+        │ /v1/polly/lead   (form intake)
+        │ /v1/polly/funnel (event endpoint)
+        ▼
+HF dataset: polly-leads/   +   polly-chat-live/
+        │
+        │ Stripe Payment Link → checkout.session.completed
+        ▼
+api/billing/stripe_webhook.js
+   ├─ HMAC-SHA256 verify (constant-time)
+   ├─ Snapshot detection: payment_link match OR (mode=payment, $500 USD)
+   └─ Heartbeat detection: payment_link match OR (mode=subscription, $99 USD)
+        │
+        ├─ repository_dispatch: polly_snapshot_paid
+        │       └─ .github/workflows/polly-snapshot-paid.yml
+        │             ├─ files tracking issue (idempotent on session_id)
+        │             └─ SMTP intake email (1-business-day SLA)
+        │
+        └─ repository_dispatch: polly_heartbeat_started
+                └─ .github/workflows/polly-heartbeat-started.yml
+                      ├─ files heartbeat-started issue
+                      └─ SMTP onboarding email (14-day first report SLA)
+        │
+        ▼
+Operator dashboard: docs/polly-stats.html
+   ├─ 7-day per-event funnel breakdown
+   └─ funnel_events column (per-event counts)
+        │
+        ▼
+scripts/polly/consolidate_to_sft.py --include-leads
+        └─ HF dataset: SFT training pairs (chat + leads) — feeds M6
+```
+
+Every box in that diagram exists in the repo today. Nothing in this section
+is aspirational.
+
+## 5) Sellable packaging tiers
+
+Beyond the catalog above, M5 packages into three sellable bundles for direct
+outreach:
 
 ### Launch Pack
 
-Fixed implementation sprint for one workflow.
-
-Deliverables:
-
-- intake interview and workflow map
-- governed folder / bus formation
-- first dataset or trace capture
-- one short governance report
-- recommended next actions
+- One Governance Snapshot delivery
+- First governed dataset published to the buyer's HuggingFace org (or to ours
+  with a license grant back)
+- One Heartbeat month included
+- Price: $500 + $99 = $599 first month
 
 ### Monthly Ops
 
-Managed ingestion and governance heartbeat.
+- Heartbeat baseline ($99/mo)
+- Plus N additional Snapshot deliveries per month at $500 each
+- Plus optional service credits for hosted runs (2-5% on passthrough)
+- Price: $99 + per-snapshot
 
-Deliverables:
+### Enterprise License (negotiated)
 
-- monthly scan of one workflow
-- delta report
-- risk/change summary
-- action list
-- optional training capture
+- Dedicated deployment of the SCBE pipeline behind the customer's auth
+- Optional blockchain notarization of governance stamps (the MMCCL credit
+  ledger primitives in
+  `src/symphonic_cipher/.../context_credit_ledger/`)
+- Custom axiom-mesh tuning
+- SLA + indemnification language
+- Price: by contract
 
-### Enterprise License
+## 6) Minimal delivery loop
 
-Dedicated deployment and support path for a team or regulated buyer.
+1. Buyer purchases (Stripe Payment Link) or requests via `/v1/polly/lead`.
+2. Stripe webhook fires `polly_snapshot_paid` (or `polly_heartbeat_started`).
+3. GitHub Actions opens an idempotent tracking issue and emails the intake
+   checklist within one business day.
+4. Buyer returns workflow / artifacts via the intake link.
+5. SCBE creates a workspace formation under
+   `.aethermoor-bus/workspaces/<workspace-id>/` and records inputs.
+6. Governance checks run over the supplied workflow (axiom-mesh + harmonic
+   wall + lexicon drift gate).
+7. Buyer receives the short report with findings, fixes, next steps —
+   5-business-day SLA for Snapshot, 14-day first report for Heartbeat.
+8. Approved traces get added to training/evaluation data via
+   `scripts/polly/consolidate_to_sft.py`.
 
-Deliverables:
+## 7) Operational state
 
-- private deployment plan
-- policy and role mapping
-- audit/export workflow
-- optional blockchain/notarization adapter
-- support and integration backlog
+| Surface | State | Notes |
+|---|---|---|
+| `docs/offers.json` | LIVE | 7 offers, all `status: live` |
+| Stripe webhook | LIVE | `/v1/billing/stripe-webhook` deployed on Vercel |
+| Snapshot Payment Link | LIVE | `buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j` |
+| Heartbeat Payment Link | **PENDING** | currently mailto; **needs Stripe link + `STRIPE_HEARTBEAT_PAYMENT_LINK_ID` env** |
+| Snapshot intake email automation | LIVE | `polly-snapshot-paid.yml`, gated on `livemode=true` |
+| Heartbeat onboarding email automation | LIVE | `polly-heartbeat-started.yml` |
+| Funnel beacons on /hire and /governance-snapshot | LIVE | `docs/static/polly-funnel.js` |
+| /hire-b A/B variant (Snapshot-led hero) | LIVE | separate funnel bucket, isolated for hero comparison |
+| Operator stats dashboard | LIVE | `docs/polly-stats.html`, per-event 7-day breakdown |
+| Lead → SFT consolidation | LIVE | `scripts/polly/consolidate_to_sft.py --include-leads` |
 
-## System Components
+## 8) Key files
 
-- Agent bus workspace formation: `.aethermoor-bus/workspaces/<workspace-id>/`
-- Intake and lead capture: `/hire`, `/v1/polly/lead`
-- Commerce routing: `/v1/polly/chat`, `docs/offers.json`
-- Training capture: Hugging Face dataset path and SFT consolidation
-- Governance overlays: bijective tamper, identifier canonicality, Tree of Escalation
-- Reports: snapshot and heartbeat deliverables
+| Concern | File |
+|---|---|
+| Offer catalog | `docs/offers.json` |
+| Snapshot landing | `docs/governance-snapshot.html` |
+| Hire page (control) | `docs/hire.html` |
+| Hire page (variant) | `docs/hire-b.html` |
+| Stripe webhook | `api/billing/stripe_webhook.js` |
+| Snapshot paid action | `.github/workflows/polly-snapshot-paid.yml` |
+| Heartbeat started action | `.github/workflows/polly-heartbeat-started.yml` |
+| Funnel client | `docs/static/polly-funnel.js` |
+| Funnel HF upload | `api/_polly_hf_upload.js` |
+| Stats endpoint | `api/polly/stats.js` |
+| Stats dashboard | `docs/polly-stats.html` |
+| Lead routing | `api/polly/commerce.js` |
+| Lead → SFT | `scripts/polly/consolidate_to_sft.py` |
+| n8n bridge | `workflows/n8n/scbe_n8n_bridge.py` |
 
-## Minimal Delivery Loop
+## 9) What's missing to scale
 
-1. Buyer purchases or requests a workflow review.
-2. Intake collects workflow, artifacts, risk concerns, and desired output.
-3. SCBE creates a workspace formation and records inputs.
-4. Governance checks run over the supplied workflow or artifact set.
-5. Buyer receives a short report with findings, fixes, and next steps.
-6. Approved traces can be added to training/evaluation data.
+Not "what to build next" — what is **already designed and missing only
+operator clicks** to ship more revenue:
 
-## Pricing Surface
+1. **Heartbeat Payment Link.** Create $99/mo Payment Link in Stripe Dashboard,
+   paste into `docs/offers.json`, set `STRIPE_HEARTBEAT_PAYMENT_LINK_ID` in
+   Vercel env. ~10 minutes.
+2. **Traffic.** All engineering is upstream of a problem that is no longer
+   engineering.
+3. **One delivered Snapshot reference.** First paid delivery becomes the proof
+   asset for everything else.
 
-- Governance Snapshot: $500 fixed scope
-- Governance Heartbeat: $99/month
-- Toolkit / Training Vault: $29 each
-- Service credits: $5+ pay-as-you-go for hosted routing/provider usage
+## 10) Gates and guardrails
 
-Provider/model costs should be passed through with a small 2-5% coordination fee only where hosted usage is billable.
+Every M5 delivery must clear:
 
-## Boundaries
+- Axiom-mesh check (5 axioms, see `docs/CORE_AXIOMS_CANONICAL_INDEX.md`)
+- Harmonic wall in (0,1] (see `src/harmonic/harmonicScaling.ts`)
+- Sacred Tongues lexicon drift gate
+- Idempotent Stripe processing (`session.id` is the dedup key)
 
-M5 is not a promise to replace a buyer's compliance team, legal counsel, or security program. It is a workflow evidence and governance package that makes AI usage easier to inspect, improve, and operationalize.
+If any gate fails, the delivery does not ship and the operator is paged via
+GitHub issue, not email.
 
+## 11) Boundaries
+
+M5 is not a promise to replace a buyer's compliance team, legal counsel, or
+security program. It is a workflow evidence and governance package that makes
+AI usage easier to inspect, improve, and operationalize.
+
+## 12) See also
+
+- `docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md` — research substrate
+- `docs/governance-snapshot.html` — buyer-facing landing
+- `docs/SCBE_SYSTEM_OVERVIEW.md` — pipeline architecture
+- `docs/CORE_AXIOMS_CANONICAL_INDEX.md` — axiom reference
+- `docs/LAYER_INDEX.md` — 14-layer reference

--- a/docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md
+++ b/docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md
@@ -1,52 +1,144 @@
-# M6 Seed Multi-Nodal Network Specification
+# M6 SphereMesh / GeoSeed Network — Specification
 
-Status: research and development track
+Last updated: 2026-05-10
+Status: **research substrate operational, sphere model pre-build**
 
-## Purpose
+## 1) What M6 is
 
-M6 SphereMesh / GeoSeed is the research layer for multi-seed, multi-tongue network formation on top of the 14-layer SCBE stack.
+M6 is the geometric substrate and training direction underneath M5.
 
-Where M5 is the sellable workflow foundry, M6 is the controlled genesis and topology layer: how multiple seeds, tongues, nodes, and governance states form a coherent network without losing auditability.
+M5 sells one governed read at a time. M6 is the model that those reads compose
+into: a 6-seed, 6-tongue, multi-nodal geometry over the existing 14-layer
+SCBE stack, with Sacred Eggs as the controlled mutation/genesis gate and a
+21D canonical state lift for decision consistency.
 
-## Core Idea
+M6 is not a product. M6 is what the M5 capture lane is feeding.
 
-Six seed channels map to the six Sacred Tongues:
+Where M5 is the sellable workflow foundry, M6 is the controlled genesis and
+topology layer: how multiple seeds, tongues, nodes, and governance states
+form a coherent network without losing auditability.
 
-- KO: command / control intent
-- AV: transport / routing
-- RU: policy / permissions
-- CA: computation / transformation
-- UM: privacy / protection
-- DR: schema / authentication
+## 2) Design anchor
 
-Each seed can initialize a node, role, or governance perspective. A multi-nodal system is valid only when the combined state remains consistent across the 14-layer pipeline.
+M6 has four invariants. Anything called "M6" must respect all four.
 
-## Canonical Lift
+### 2.1) Six seed channels (the Sacred Tongues)
 
-The system may lift raw node state into higher-dimensional canonical state for consistency checks:
+Six dimensions, each a 16x16 token grid (256 tokens), each weighted by powers
+of phi (golden ratio). Each tongue has multiple **faces** — a routing face,
+a coding face, a spirit face — that map bijectively to different downstream
+artifacts.
+
+| Tongue | Code | phi-weight | Routing face | Coding face (typical) |
+|---|---|---|---|---|
+| Kor'aelin | KO | 1.00 | command / control intent | Python |
+| Avali | AV | 1.62 | transport / routing | JavaScript / TypeScript |
+| Runethic | RU | 2.62 | policy / permissions | Rust |
+| Cassisivadan | CA | 4.24 | computation / transformation | Mathematica |
+| Umbroth | UM | 6.85 | privacy / protection | Haskell |
+| Draumric | DR | 11.09 | schema / authentication | Markdown |
+
+Each seed can initialize a node, role, or governance perspective. A
+multi-nodal system is valid only when the combined state remains consistent
+across the 14-layer pipeline. The phi-weighting is what makes the metric a
+Langues Weighting System (LWS) and not just six parallel channels.
+
+Real implementations:
+- TypeScript: `src/tokenizer/`, `packages/sixtongues/`
+- Python: `src/symphonic_cipher/scbe_aethermoore/` and root `symphonic_cipher/`
+
+### 2.2) Fourteen-layer dressing and governance stamps
+
+Every M6 record is dressed with the full 14-layer SCBE pipeline. No record
+exists in M6 without a governance stamp.
+
+The 14 layers (see `docs/LAYER_INDEX.md` for canonical detail):
+
+| Layers | Function | Role in M6 |
+|---|---|---|
+| L1-L2 | Complex context → realification | Lifts raw input into the substrate |
+| L3 | Weighted transform (LWS phi-weights) | Applies the 6-tongue weighting |
+| L4 | Poincare embedding | Projects into the hyperbolic ball |
+| L5 | Hyperbolic distance | Defines the metric M6 trains under |
+| L6-L7 | Breathing transform + Mobius phase | Adds temporal dynamics, preserves metric |
+| L8 | Multi-well realms (Hamiltonian CFI) | The realm-state machine M6 navigates |
+| L9-L10 | Spectral + spin coherence (FFT) | Anomaly substrate |
+| L11 | Triadic temporal distance | The d_tri(t) signal that intent-shapes M6 |
+| L12 | Harmonic wall H(d, pd) = 1/(1 + phi*d_H + 2*pd) | The bounded score every M6 record carries |
+| L13 | Risk decision | The decision M6 must learn to predict |
+| L14 | Audio axis (FFT telemetry) | The cross-system signaling channel |
+
+The 5-axiom mesh (Unitarity, Locality, Causality, Symmetry, Composition) gates
+the whole stack — see `docs/CORE_AXIOMS_CANONICAL_INDEX.md`.
+
+### 2.3) Sacred Eggs as controlled genesis gate
+
+Sacred Eggs are the only controlled mutation surface in M6. New seeds, new
+realms, new tongue grids only enter the substrate through an Egg. An Egg
+carries:
+
+- **hatch:** a new node or agent becomes active
+- **tongue:** native routing channel
+- **ritual:** training or school type
+- **credits:** progress and trust history
+- **shell integrity:** state protection and rollback boundary
+
+An Egg only opens through:
+
+- a quorum-signed governance event (the flock governor pattern in
+  `project_mother_avion_auth`),
+- a passing axiom-mesh check on the proposed mutation,
+- a harmonic-wall score in the ALLOW band.
+
+An egg should not become an unbounded autonomous actor. It enters through
+governance gates and acquires privileges through observed behavior.
+
+### 2.4) 21D canonical state lift
+
+Every M6 decision lifts to a 21-dimensional canonical brain-state before the
+decision is committed. This is the AI Brain Mapping in `src/ai_brain/`
+(TypeScript canonical) and `src/symphonic_cipher/scbe_aethermoore/ai_brain/`
+(Python reference).
+
+The 21D lift exists so two M6 records produced by different tongues, different
+times, different operators can be compared in a single common space. Without
+the lift, the harmonic wall score is local; with the lift, it is comparable.
+
+The lift is built from:
 
 - 6 direct tongue axes
 - pairwise tongue interactions
 - higher-order interaction surfaces
 - self-imaginary / internal-state axes
 
-This is a research surface, not a production promise. Production use should expose only bounded, testable outputs.
+This is a research surface. Production use exposes only bounded, testable
+outputs.
 
-## Sacred Eggs
+## 3) The substrate that exists today
 
-Sacred Eggs act as controlled genesis gates:
+This is what is real in the repo right now and what the M6 sphere model will
+compose on top of:
 
-- hatch: a new node or agent becomes active
-- tongue: native routing channel
-- ritual: training or school type
-- credits: progress and trust history
-- shell integrity: state protection and rollback boundary
+| Layer of M6 | Real artifact |
+|---|---|
+| Six tongues (tokenizer + lexicon) | `src/tokenizer/`, `packages/sixtongues/`, `src/symphonic/`, lexicon drift gate `lexicon_dimension_report.py` |
+| 14-layer pipeline (canonical) | `src/harmonic/pipeline14.ts` and the modules under `src/harmonic/` |
+| 14-layer pipeline (Python reference) | `src/symphonic_cipher/` (CAUTION: dual-package collision, see `CLAUDE.md` §"Dual symphonic_cipher Packages") |
+| Hyperbolic distance (L5) | `src/harmonic/hyperbolic.ts` |
+| Hamiltonian CFI / multi-well (L8) | `src/harmonic/hamiltonianCFI.ts` |
+| Spectral/spin coherence (L9-L10) | `src/spectral/index.ts` |
+| Triadic temporal (L11) | `src/symphonic_cipher/.../causality_axiom.py` |
+| Harmonic wall (L12) | `src/harmonic/harmonicScaling.ts` |
+| Audio axis (L14) | `src/harmonic/audioAxis.ts`, `src/harmonic/vacuumAcoustics.ts` |
+| 21D state lift | `src/ai_brain/` (TS) and `src/symphonic_cipher/scbe_aethermoore/ai_brain/` (Py) |
+| Sacred Eggs (concept + auth path) | flock governor pattern; codified in memory; not yet a single module |
+| 5-axiom mesh | `src/symphonic_cipher/scbe_aethermoore/axiom_grouped/` |
+| GeoSeal v1 primitives | imported by v2/compass/hyperbolic_rag (see `project_geoseal_v2_shape`) |
+| Capture lane (M5 → M6 fuel) | HF datasets `polly-chat-live/`, `polly-leads/`, `polly-funnel/`; `scripts/polly/consolidate_to_sft.py` |
 
-An egg should not become an unbounded autonomous actor. It should enter through governance gates and acquire privileges through observed behavior.
+## 4) Governance requirements
 
-## Governance Requirements
-
-Each M6 node should be able to emit:
+Each M6 node must be able to emit:
 
 - identity metadata
 - seed lineage
@@ -54,14 +146,134 @@ Each M6 node should be able to emit:
 - layer coverage
 - risk tier
 - recent state transitions
-- parent/child or peer relationship
+- parent / child or peer relationship
 - rollback / quarantine route
 
-## Relationship To M5
+If a node cannot emit all nine, it is not an M6 node — it is a proto-node and
+must remain inside an Egg until it can.
 
-M5 sells and operates governed workflows.
+## 5) The sphere model — what isn't built yet
 
-M6 researches how those workflows can become multi-node systems with controlled growth, mutation, and specialization.
+The sphere model is the thing **named** "GeoSeed Network" — six seed spheres
+arranged so that movement in any one tongue is a constrained motion on a
+phi-spaced toroidal interlattice (see
+`discovery_phi_toroidal_resonant_cavity`,
+`discovery_toroidal_polyhedral_confinement`,
+`discovery_gyroscopic_interlattice`).
+
+The sphere model is research-stage. The substrate above can support it; the
+glue does not yet exist as a single module. When it lands, it will live at:
+
+- `src/geoseed/` — the sphere geometry, the phi-toroidal cavity, the 5
+  Platonic constraint surfaces, the GeoSeal v1+ primitives composed into a
+  single addressing scheme
+- `scripts/train_m6_spheremesh.py` — the training entry point that consumes
+  M5-captured SFT pairs (`polly-chat-live/`, `polly-leads/`) and trains the
+  GeoSeed sphere assignments
+- `tests/geoseed/` — invariance and equivariance gates (the same
+  bit-identical equivariance pattern proved in
+  `project_atomic_tongue_observer_result`)
+
+These three paths are reserved. They do not exist yet. The substrate they
+will compose is real.
+
+## 6) Training signal
+
+M6 training does not synthesize data. It consumes the M5 capture lane:
+
+```
+M5 paying customer → governed delivery → capture lane
+        │
+        ├─ polly-chat-live/   (chat traffic from Polly)
+        ├─ polly-leads/       (form intake records)
+        └─ polly-funnel/      (per-event funnel beacons, event-prefixed)
+                │
+                ▼
+        scripts/polly/consolidate_to_sft.py --include-leads
+                │
+                ▼
+        SFT training pairs (chat + lead-derived)
+                │
+                ▼
+        M6 training entry (future scripts/train_m6_spheremesh.py)
+```
+
+This is the data-quality-beats-training-speed principle: M6 trains on real
+governed deliveries, not on scraped corpora. M5 revenue is the M6 dataset.
+
+## 7) Gates
+
+M6 inherits all M5 gates and adds three of its own:
+
+1. **Axiom-mesh gate** — every training step must clear the 5 axioms
+   (Unitarity, Locality, Causality, Symmetry, Composition). See
+   `src/symphonic_cipher/scbe_aethermoore/axiom_grouped/`.
+2. **Lexicon drift gate** — every released checkpoint must match the
+   canonical 6-tongue lexicon. See `lexicon_dimension_report.py`.
+3. **Executable promotion gate** — adapters need executable benchmark pass
+   (not just training metrics) before release. See
+   `tests/eval/multi_seed_gate_eval.py`.
+
+If any gate fails, the checkpoint is not promoted and is not pushed to HF.
+
+## 8) Minimal prototype (what to build first)
+
+1. Define six seed records (one per tongue) with identity metadata, tongue,
+   role, allowed action set.
+2. Route a task through at least three nodes.
+3. Record all handoffs in the agent bus
+   (`.aethermoor-bus/workspaces/<workspace-id>/`).
+4. Apply L13 governance to each transition.
+5. Lift each transition state into 21D and store the lifted vector alongside
+   the raw record.
+6. Emit a final report showing lineage, risk changes, output provenance, and
+   the 21D distance between input and output states.
+
+This prototype does not require `src/geoseed/`. It exercises the substrate
+that already exists and proves the M5 capture lane can serve as the M6
+training feed.
+
+## 9) Open research seams
+
+These are real seams the sphere model will need to close. Each has a memory
+entry with the current best understanding:
+
+- **Toroidal polyhedral confinement** — phi-winding + 5 Platonic constraint
+  surfaces as a continuous geometric hash; MitM-immune by construction.
+- **Phi toroidal resonant cavity** — six phi-scaled walls; cost scales as
+  R^(122.99·d²); cryptographic strength from geometry.
+- **Gyroscopic interlattice** — phi-spacing as a controlled lattice
+  distortion.
+- **Polyhedral friction training** — constraint surfaces produce a training
+  signal; an L_geometry loss term.
+- **Gravity battery / Sisyphus** — training carves permanent paths through
+  the polyhedral lattice.
+- **47D complex manifold** — 6 real + C(6,2) + C(6,3) + 6 imaginary = 47D,
+  matches the 47 lore realities.
+- **Multi-attention holographic fold (MAHSS)** — combine K attention via HRR
+  bound to roles, fold via L7 Mobius, query via unbinding.
+- **DNA-strand composition substrate** — DNA-strand objects unify
+  MAHSS / ΔS / circuit-breaker / slide / harness / telemetry.
+
+The sphere model is the place where these compose.
+
+## 10) Position vs external work
+
+M6's defensible position is **multi-axiom composition over Geometric Deep
+Learning** — patent-defensible cross-domain transfer through the 5-axiom mesh
+plus the phi-weighted Sacred Tongues plus the harmonic wall.
+
+External adjacent work:
+- DARPA MRC (~2011-2017) — historical lineage, SCBE positions as
+  post-quantum hyperbolic successor.
+- Anthropic Petri — detection-only auditing tool; composes with SCBE
+  enforcement, does not replace it.
+- Anthropic Natural Language Autoencoders — SCBE primitives close several
+  NLA limitations (harmonic wall = bounded faithfulness; Möbius equivariance
+  kills steganography; 6 Sacred Tongues = multi-seed convergence answer; L14
+  audio = anti-anthropomorphization channel).
+
+## 11) Boundary
 
 Do not sell M6 as a finished product until:
 
@@ -71,12 +283,16 @@ Do not sell M6 as a finished product until:
 - rollback and quarantine are tested
 - buyer-facing language is separated from internal lore
 
-## Minimal Prototype
+Until then, M6 stays under the M5 cover: customers buy the read, M6 trains in
+the back room.
 
-1. Define six seed records.
-2. Assign each seed a tongue, role, and allowed action set.
-3. Route a task through at least three nodes.
-4. Record all handoffs in the agent bus.
-5. Apply L13 governance to each transition.
-6. Emit a final report showing lineage, risk changes, and output provenance.
+## 12) See also
 
+- `docs/M5_MESH_PRODUCT_SERVICE_BLUEPRINT.md` — the revenue surface that
+  feeds M6
+- `docs/LAYER_INDEX.md` — 14-layer canonical reference
+- `docs/CORE_AXIOMS_CANONICAL_INDEX.md` — 5-axiom canonical reference
+- `docs/LANGUES_WEIGHTING_SYSTEM.md` — phi-weighted Langues metric deep dive
+- `docs/SCBE_SYSTEM_OVERVIEW.md` — pipeline architecture
+- `docs/SPEC.md` — SCBE Kernel Specification (canonical)
+- `docs/SYSTEM_ARCHITECTURE.md` — detailed architecture

--- a/scripts/vercel/ignore-build.cjs
+++ b/scripts/vercel/ignore-build.cjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+
+// Vercel ignoreCommand contract:
+//   exit 0 => skip deployment
+//   exit 1 => continue deployment
+//
+// Keep production deploys alive for main/customer/launch branches, but skip
+// preview builds when a PR only changes tests, deep docs, generated artifacts,
+// training data, local agent skills, or other non-deployed repo surfaces.
+
+const ref = process.env.VERCEL_GIT_COMMIT_REF || '';
+
+if (
+  ref === 'main' ||
+  ref.startsWith('launch/') ||
+  ref.startsWith('customer/') ||
+  ref.startsWith('vercel-test/')
+) {
+  console.log(`vercel-build: deploy branch '${ref}'`);
+  process.exit(1);
+}
+
+function git(args) {
+  return spawnSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+let base = process.env.VERCEL_GIT_PREVIOUS_SHA || '';
+if (!base || git(['cat-file', '-e', `${base}^{commit}`]).status !== 0) {
+  base = 'HEAD^';
+}
+
+const relevantPaths = [
+  'vercel.json',
+  'package.json',
+  'package-lock.json',
+  'api/agent',
+  'api/polly',
+  'api/billing',
+  'docs/offers.json',
+  'docs/governance-snapshot.html',
+  'docs/hire.html',
+  'docs/hire-b.html',
+  'docs/service-credits.html',
+  'docs/supporter.html',
+  'docs/hosted-run.html',
+  'docs/polly-stats.html',
+  'docs/static',
+  'docs/product-manual',
+];
+
+const diff = git(['diff', '--quiet', base, 'HEAD', '--', ...relevantPaths]);
+
+if (diff.status === 0) {
+  console.log('vercel-build: skip; no deployed paths changed');
+  process.exit(0);
+}
+
+if (diff.status === 1) {
+  console.log('vercel-build: deploy; deployed paths changed');
+  process.exit(1);
+}
+
+console.error(diff.stderr || 'vercel-build: git diff failed; deploying to be safe');
+process.exit(1);

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in main|launch/*|vercel-test/*|customer/*|fix/launch-*|feat/vercel-*|fix/vercel-*|feat/polly-*|fix/polly-*) exit 1 ;; *) exit 0 ;; esac",
+  "ignoreCommand": "node scripts/vercel/ignore-build.cjs",
   "builds": [
     {
       "src": "api/agent/*.js",


### PR DESCRIPTION
## Summary
- replace broad branch-name Vercel ignoreCommand with a path-aware Node script
- always deploy main/customer/launch/vercel-test branches
- skip preview deployments when PRs only change non-deployed surfaces like tests, deep docs, artifacts, training data, or local skills

## Why
Vercel was still creating preview activity for most SCBE-AETHERMOORE PRs. This keeps customer-facing deployments working while reducing build-minute burn and notification spam.

## Verification
- node -c scripts/vercel/ignore-build.cjs
- node scripts/vercel/ignore-build.cjs with no relevant commit diff -> exit 0 / skip
- VERCEL_GIT_COMMIT_REF=main node scripts/vercel/ignore-build.cjs -> exit 1 / deploy
- after commit, VERCEL_GIT_PREVIOUS_SHA=origin/main node scripts/vercel/ignore-build.cjs -> exit 1 / deploy