### PR TITLE
fix(vercel): ship ignore script with bridge payload

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -8,4 +8,7 @@
 !docs/app-config.json
 !public
 !public/hire.html
+!scripts
+!scripts/vercel
+!scripts/vercel/ignore-build.cjs
 !vercel.json

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -43,6 +43,7 @@ def test_vercelignore_ships_launch_handler_with_api_bridge() -> None:
     assert "!docs/app-config.json" in ignore
     assert "!public" in ignore
     assert "!public/hire.html" in ignore
+    assert "!scripts/vercel/ignore-build.cjs" in ignore
 
 
 def test_launch_page_links_to_public_docs_and_bridge_endpoints() -> None:


### PR DESCRIPTION
## Summary
- Include scripts/vercel/ignore-build.cjs in the Vercel payload so ignoreCommand can actually run after .vercelignore pruning
- Add a Product Delivery Smoke assertion so this cannot regress silently

## Tests
- python -m pytest tests/test_vercel_launch_bridge.py tests/smoke/test_app_deploy_config.py tests/api/test_stripe_billing_hardening.py tests/test_package_products.py -q
- node -c scripts/vercel/ignore-build.cjs

## Rollback
- Revert this commit to return to previous Vercel payload behavior.