### PR TITLE
fix(vercel): use GitHub metadata for preview path checks

### DIFF
--- a/scripts/vercel/ignore-build.cjs
+++ b/scripts/vercel/ignore-build.cjs
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-const { spawnSync } = require('node:child_process');
-
 // Vercel ignoreCommand contract:
 //   exit 0 => skip deployment
 //   exit 1 => continue deployment
@@ -12,25 +10,11 @@ const { spawnSync } = require('node:child_process');
 // training data, local agent skills, or other non-deployed repo surfaces.
 
 const ref = process.env.VERCEL_GIT_COMMIT_REF || '';
-
-if (
-  ref === 'main' ||
-  ref.startsWith('launch/') ||
-  ref.startsWith('customer/') ||
-  ref.startsWith('vercel-test/')
-) {
-  console.log(`vercel-build: deploy branch '${ref}'`);
-  process.exit(1);
-}
-
-function git(args) {
-  return spawnSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
-}
-
-let base = process.env.VERCEL_GIT_PREVIOUS_SHA || '';
-if (!base || git(['cat-file', '-e', `${base}^{commit}`]).status !== 0) {
-  base = 'HEAD^';
-}
+const repoOwner = process.env.VERCEL_GIT_REPO_OWNER || 'issdandavis';
+const repoSlug = process.env.VERCEL_GIT_REPO_SLUG || 'SCBE-AETHERMOORE';
+const prId = process.env.VERCEL_GIT_PULL_REQUEST_ID || '';
+const currentSha = process.env.VERCEL_GIT_COMMIT_SHA || '';
+const previousSha = process.env.VERCEL_GIT_PREVIOUS_SHA || '';
 
 const relevantPaths = [
   'vercel.json',
@@ -51,17 +35,87 @@ const relevantPaths = [
   'docs/product-manual',
 ];
 
-const diff = git(['diff', '--quiet', base, 'HEAD', '--', ...relevantPaths]);
-
-if (diff.status === 0) {
-  console.log('vercel-build: skip; no deployed paths changed');
-  process.exit(0);
+function isRelevant(path) {
+  return relevantPaths.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
 }
 
-if (diff.status === 1) {
+function finish(files) {
+  const changed = files.filter(Boolean);
+  if (!changed.some(isRelevant)) {
+    console.log('vercel-build: skip; no deployed paths changed');
+    process.exit(0);
+  }
+
   console.log('vercel-build: deploy; deployed paths changed');
   process.exit(1);
 }
 
-console.error(diff.stderr || 'vercel-build: git diff failed; deploying to be safe');
-process.exit(1);
+async function githubJson(path) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'scbe-vercel-ignore-build',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status} for ${path}`);
+  }
+  return response.json();
+}
+
+async function prFiles() {
+  const files = [];
+  let page = 1;
+  while (page <= 10) {
+    const batch = await githubJson(
+      `/repos/${repoOwner}/${repoSlug}/pulls/${prId}/files?per_page=100&page=${page}`,
+    );
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    files.push(...batch.map((item) => item.filename));
+    if (batch.length < 100) break;
+    page += 1;
+  }
+  return files;
+}
+
+async function compareFiles() {
+  if (!previousSha || !currentSha) return null;
+  const compare = await githubJson(
+    `/repos/${repoOwner}/${repoSlug}/compare/${previousSha}...${currentSha}`,
+  );
+  if (!Array.isArray(compare.files)) return null;
+  return compare.files.map((item) => item.filename);
+}
+
+async function main() {
+  if (
+    ref === 'main' ||
+    ref.startsWith('launch/') ||
+    ref.startsWith('customer/') ||
+    ref.startsWith('vercel-test/')
+  ) {
+    console.log(`vercel-build: deploy branch '${ref}'`);
+    process.exit(1);
+  }
+
+  if (process.env.SCBE_VERCEL_CHANGED_FILES) {
+    finish(process.env.SCBE_VERCEL_CHANGED_FILES.split(/[\r\n,]+/).map((item) => item.trim()));
+  }
+
+  try {
+    if (prId) {
+      finish(await prFiles());
+    }
+
+    const files = await compareFiles();
+    if (files) finish(files);
+
+    console.log('vercel-build: deploy; no PR or compare metadata available');
+    process.exit(1);
+  } catch (error) {
+    console.error(`vercel-build: deploy; path check failed: ${error.message || error}`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Make Vercel ignoreCommand work after .vercelignore removes the Git checkout metadata
- Use VERCEL_GIT_PULL_REQUEST_ID with the GitHub PR files API for preview PR path checks
- Fall back to GitHub compare when Vercel exposes previous/current SHAs
- Keep production/customer/launch branches deploying unconditionally

## Tests
- node -c scripts/vercel/ignore-build.cjs
- SCBE_VERCEL_CHANGED_FILES=tests/test_vercel_launch_bridge.py,docs/specs/something.md node scripts/vercel/ignore-build.cjs  # exits 0 / skip
- python -m pytest tests/test_vercel_launch_bridge.py tests/smoke/test_app_deploy_config.py tests/api/test_stripe_billing_hardening.py tests/test_package_products.py -q

## Rollback
- Revert this commit to return to the previous git-diff based ignore command.