### PR TITLE
fix(vercel): stabilize metadata ignore exit path

### DIFF
--- a/scripts/vercel/ignore-build.cjs
+++ b/scripts/vercel/ignore-build.cjs
@@ -17,9 +17,11 @@ const currentSha = process.env.VERCEL_GIT_COMMIT_SHA || '';
 const previousSha = process.env.VERCEL_GIT_PREVIOUS_SHA || '';
 
 const relevantPaths = [
+  '.vercelignore',
   'vercel.json',
   'package.json',
   'package-lock.json',
+  'scripts/vercel/ignore-build.cjs',
   'api/agent',
   'api/polly',
   'api/billing',
@@ -43,11 +45,11 @@ function finish(files) {
   const changed = files.filter(Boolean);
   if (!changed.some(isRelevant)) {
     console.log('vercel-build: skip; no deployed paths changed');
-    process.exit(0);
+    return 0;
   }
 
   console.log('vercel-build: deploy; deployed paths changed');
-  process.exit(1);
+  return 1;
 }
 
 async function githubJson(path) {
@@ -95,27 +97,29 @@ async function main() {
     ref.startsWith('vercel-test/')
   ) {
     console.log(`vercel-build: deploy branch '${ref}'`);
-    process.exit(1);
+    return 1;
   }
 
   if (process.env.SCBE_VERCEL_CHANGED_FILES) {
-    finish(process.env.SCBE_VERCEL_CHANGED_FILES.split(/[\r\n,]+/).map((item) => item.trim()));
+    return finish(process.env.SCBE_VERCEL_CHANGED_FILES.split(/[\r\n,]+/).map((item) => item.trim()));
   }
 
   try {
     if (prId) {
-      finish(await prFiles());
+      return finish(await prFiles());
     }
 
     const files = await compareFiles();
-    if (files) finish(files);
+    if (files) return finish(files);
 
     console.log('vercel-build: deploy; no PR or compare metadata available');
-    process.exit(1);
+    return 1;
   } catch (error) {
     console.error(`vercel-build: deploy; path check failed: ${error.message || error}`);
-    process.exit(1);
+    return 1;
   }
 }
 
-main();
+main().then((code) => {
+  process.exitCode = code;
+});

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -18,6 +18,8 @@ def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
     assert "ref === 'main'" in ignore_source
     assert "ref.startsWith('launch/')" in ignore_source
     assert "ref.startsWith('customer/')" in ignore_source
+    assert "'.vercelignore'" in ignore_source
+    assert "'scripts/vercel/ignore-build.cjs'" in ignore_source
     assert "'api/agent'" in ignore_source
     assert "'api/polly'" in ignore_source
     assert "'api/billing'" in ignore_source


### PR DESCRIPTION
## Summary
- Restore .vercelignore and scripts/vercel/ignore-build.cjs as deployed policy paths
- Avoid immediate process.exit after GitHub fetch so the ignore script is stable on Windows and Vercel
- Keep GitHub PR-file based path checks for preview deploy skipping

## Tests
- node -c scripts/vercel/ignore-build.cjs
- VERCEL_GIT_PULL_REQUEST_ID=1577 node scripts/vercel/ignore-build.cjs => skip / exit 0 for test-only PR
- VERCEL_GIT_PULL_REQUEST_ID=1580 node scripts/vercel/ignore-build.cjs => deploy / exit 1 for policy-script PR
- python -m pytest tests/test_vercel_launch_bridge.py tests/smoke/test_app_deploy_config.py tests/api/test_stripe_billing_hardening.py tests/test_package_products.py -q

## Rollback
- Revert this commit to return to the previous metadata ignore behavior.