### PR TITLE
feat(website): sidebar fix + homepage CTA + dual-audience polish on chat/hire

### DIFF
--- a/docs/chat.html
+++ b/docs/chat.html
@@ -5,11 +5,182 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <title>Polly Chat | AetherMoore</title>
-  <meta name="description" content="Chat with Polly about AetherMoore lore and SCBE science. The assistant separates canon, story, governance math, and technical implementation details.">
+  <meta name="description" content="Chat with Polly. Walks you through picking the right tool, answers research questions about the SCBE pipeline, or routes you straight to a buy or hire path.">
   <link rel="canonical" href="https://aethermoore.com/chat.html">
   <link rel="stylesheet" href="static/polly-sidebar.css">
+  <style>
+    :root {
+      --bg: #0b0d12;
+      --panel: rgba(18, 23, 32, 0.92);
+      --line: rgba(214, 167, 86, 0.18);
+      --text: #f2f0ea;
+      --muted: #a3acb9;
+      --accent: #d6a756;
+      --accent-strong: #f0bf67;
+      --good: #2dd3a6;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body.polly-chat-page {
+      font-family: Georgia, "Times New Roman", serif;
+      background:
+        radial-gradient(circle at top, rgba(214, 167, 86, 0.12), transparent 34%),
+        linear-gradient(180deg, #0b0d12 0%, #0e131b 40%, #0b0d12 100%);
+      color: var(--text);
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+    a { color: inherit; text-decoration: none; }
+    .topbar {
+      position: sticky; top: 0; z-index: 20;
+      backdrop-filter: blur(14px);
+      background: rgba(11, 13, 18, 0.82);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+    .topbar-inner {
+      width: min(1080px, calc(100% - 32px));
+      margin: 0 auto;
+      min-height: 64px;
+      display: flex; align-items: center; justify-content: space-between; gap: 20px;
+    }
+    .brand {
+      font-size: 14px; letter-spacing: 0.18em; text-transform: uppercase;
+      color: var(--accent); font-weight: 700;
+    }
+    .nav { display: flex; gap: 16px; flex-wrap: wrap; justify-content: flex-end; font-size: 14px; color: var(--muted); }
+    .nav a:hover { color: var(--text); }
+    .nav a.current { color: var(--text); }
+
+    main { width: min(960px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0 80px; }
+    .eyebrow {
+      color: var(--accent); text-transform: uppercase;
+      letter-spacing: 0.18em; font-size: 12px; font-weight: 700; margin-bottom: 14px;
+    }
+    h1 { font-size: clamp(34px, 5vw, 52px); line-height: 1.04; letter-spacing: -0.03em; max-width: 18ch; margin-bottom: 14px; }
+    .lead { color: var(--muted); font-size: clamp(16px, 1.6vw, 18px); max-width: 60ch; margin-bottom: 28px; }
+
+    .welcome-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 14px;
+      margin: 16px 0 32px;
+    }
+    @media (min-width: 880px) {
+      .welcome-grid { grid-template-columns: 1fr 1fr 1fr; }
+    }
+    .what-card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 18px;
+    }
+    .what-card .tag {
+      display: inline-block;
+      background: rgba(214, 167, 86, 0.14);
+      color: var(--accent-strong);
+      font-size: 11px; font-weight: 700;
+      padding: 3px 8px; border-radius: 6px;
+      text-transform: uppercase; letter-spacing: 0.08em;
+      margin-bottom: 8px;
+    }
+    .what-card h3 { font-size: 16px; margin-bottom: 6px; letter-spacing: -0.01em; }
+    .what-card p { color: var(--muted); font-size: 14px; line-height: 1.55; }
+    .what-card code {
+      background: rgba(255,255,255,0.06);
+      padding: 1px 6px; border-radius: 4px;
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 13px; color: var(--text);
+    }
+
+    .escape-row {
+      margin-top: 14px;
+      padding: 14px 16px;
+      border: 1px dashed rgba(45, 211, 166, 0.3);
+      border-radius: 14px;
+      background: rgba(45, 211, 166, 0.04);
+      display: flex; flex-wrap: wrap; gap: 10px; align-items: center;
+      color: var(--text); font-size: 14px;
+    }
+    .escape-row strong { color: var(--good); }
+    .escape-row a {
+      padding: 6px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(45, 211, 166, 0.4);
+      font-weight: 700; font-size: 13px;
+    }
+    .escape-row a:hover { background: rgba(45, 211, 166, 0.12); }
+
+    .chat-anchor { color: var(--muted); font-size: 14px; margin-top: 24px; }
+
+    footer {
+      border-top: 1px solid rgba(255,255,255,0.06);
+      padding: 28px 0;
+      text-align: center;
+      color: var(--muted); font-size: 13px;
+    }
+    footer a { color: var(--text); text-decoration: underline; text-underline-offset: 3px; }
+  </style>
 </head>
 <body class="polly-chat-page" data-polly-context="chat" data-polly-root=".">
+
+  <header class="topbar">
+    <div class="topbar-inner">
+      <a class="brand" href="index.html">AetherMoore</a>
+      <nav class="nav">
+        <a href="index.html">Home</a>
+        <a href="start-here.html">Start Here</a>
+        <a href="products.html">Products</a>
+        <a href="hire.html">Hire</a>
+        <a href="chat.html" class="current">Chat with Polly</a>
+        <a href="agents.html">Agents</a>
+        <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="eyebrow">Polly chat</div>
+    <h1>Talk to Polly. Pick a tool, ask a question, or buy.</h1>
+    <p class="lead">
+      Polly is the AetherMoore chat assistant. She routes your question to one of three deterministic answers
+      (no LLM cost) and falls back to a free LLM only when nothing matches.
+      Click the launcher in the bottom-right to start, or pick a starter below.
+    </p>
+
+    <div class="welcome-grid">
+      <div class="what-card">
+        <div class="tag">Pick a tool</div>
+        <h3>Find your fit</h3>
+        <p>Type <code>help me choose a product</code> and Polly walks you through three or four routes in chat. Or open the <a href="products.html" style="color:var(--accent-strong); text-decoration:underline;">picker page</a> directly.</p>
+      </div>
+      <div class="what-card">
+        <div class="tag">Ask a question</div>
+        <h3>Research mode</h3>
+        <p>Polly knows the canonical answers for the harmonic wall, the 14-layer pipeline, axiom mesh, Sacred Tongues, post-quantum primitives, and active federal proposals. Try <code>What is the harmonic wall?</code></p>
+      </div>
+      <div class="what-card">
+        <div class="tag">Buy or hire</div>
+        <h3>Commerce mode</h3>
+        <p>Type <code>buy the toolkit</code> or <code>I need a custom audit</code> and Polly returns the right Stripe link or hire path with one click. No sales pitch.</p>
+      </div>
+    </div>
+
+    <div class="escape-row">
+      <strong>Don't want to chat?</strong>
+      <span>Pick whichever route fits.</span>
+      <a href="products.html">Open the products picker</a>
+      <a href="start-here.html">See the three starter routes</a>
+      <a href="mailto:issdandavis7795@gmail.com?subject=AetherMoore%20question">Email Issac</a>
+    </div>
+
+    <p class="chat-anchor">↘ Polly's chat launcher is in the bottom-right corner. Conversation history stays in your browser; nothing is uploaded unless you opt in.</p>
+  </main>
+
+  <footer>
+    <p>SCBE-AETHERMOORE — governed AI workflow tools.<br>
+    <a href="index.html">Home</a> · <a href="start-here.html">Start Here</a> · <a href="products.html">Products</a> · <a href="hire.html">Hire</a> · <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">GitHub</a></p>
+  </footer>
+
   <script src="static/polly-sidebar.js"></script>
 </body>
 </html>

--- a/docs/hire.html
+++ b/docs/hire.html
@@ -356,6 +356,13 @@
   </head>
   <body>
     <div class="container">
+      <nav style="display:flex; gap:14px; flex-wrap:wrap; padding:14px 0; font-size:13px; color:var(--muted, #a0a0a8); border-bottom:1px solid rgba(255,255,255,0.06); margin-bottom:24px;">
+        <a href="/SCBE-AETHERMOORE/" style="color:inherit;">← Home</a>
+        <a href="/SCBE-AETHERMOORE/start-here.html" style="color:inherit;">Start Here</a>
+        <a href="/SCBE-AETHERMOORE/products.html" style="color:inherit;">Products</a>
+        <a href="/SCBE-AETHERMOORE/chat.html" style="color:inherit;">Chat with Polly</a>
+        <a href="/SCBE-AETHERMOORE/agents.html" style="color:inherit;">Agents</a>
+      </nav>
       <header>
         <div class="eyebrow">Available now · Federal-registered · Open-source-first</div>
         <h1>AI safety and governance engineering, <span>built solo, shipped real.</span></h1>
@@ -365,6 +372,12 @@
           Independent. SAM.gov registered. Available for contract, advisory, and audit work this
           quarter.
         </p>
+
+        <div role="region" aria-label="Not sure this fits? Pick the right route" style="margin: 6px 0 22px; padding: 12px 16px; border: 1px dashed rgba(45, 211, 166, 0.32); border-radius: 14px; background: rgba(45, 211, 166, 0.05); display: flex; flex-wrap: wrap; gap: 10px; align-items: center; font-size: 14px;">
+          <strong style="color: #2dd3a6;">Not technical?</strong>
+          <span>The Snapshot below is the most common starter — fixed $500, written read on one workflow, no integration. If you're not sure, the picker walks you through three questions and recommends a tool.</span>
+          <a href="/SCBE-AETHERMOORE/products.html" style="background: linear-gradient(135deg, #d6a756, #f0bf67); color: #14110c; font-weight: 700; padding: 7px 14px; border-radius: 999px; text-decoration: none; white-space: nowrap; font-size: 13px;">Find your fit →</a>
+        </div>
 
         <div class="cta-row">
           <a class="cta primary" href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"

--- a/docs/index.html
+++ b/docs/index.html
@@ -712,6 +712,12 @@
           <p style="max-width:58ch;font-size:16px;color:var(--text);margin-top:-8px;">
             Built by Issac Davis. Patent pending (USPTO #63/961,403). SAM.gov registered (UEI: J4NXHM6N5F59). The site includes live demos, public proof, and Polly chat so you can inspect the system instead of taking my word for it.
           </p>
+          <div role="region" aria-label="First time here? Pick your route" style="max-width:62ch; margin: 6px 0 22px; padding: 14px 18px; border: 1px solid rgba(214, 167, 86, 0.45); border-radius: 18px; background: linear-gradient(135deg, rgba(214, 167, 86, 0.10), rgba(214, 167, 86, 0.02)); display: flex; flex-wrap: wrap; gap: 12px; align-items: center;">
+            <strong style="color: var(--accent-strong);">First time here?</strong>
+            <span style="color: var(--text); font-size: 15px;">Three questions, one recommendation — picks the right tool in about 60 seconds.</span>
+            <a href="products.html" style="background: linear-gradient(135deg, var(--accent), var(--accent-strong)); color: #14110c; font-weight: 700; padding: 8px 16px; border-radius: 999px; text-decoration: none; white-space: nowrap;">Find your fit →</a>
+            <a href="start-here.html" style="color: var(--text); text-decoration: underline; text-underline-offset: 3px; font-size: 14px; white-space: nowrap;">Or see the three starter routes</a>
+          </div>
           <div class="cta-row">
             <a class="btn btn-primary" href="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k" target="_blank" rel="noopener">Tip $5 one time</a>
             <a class="btn btn-secondary" href="supporter.html">Support $20/month</a>

--- a/docs/static/polly-sidebar.js
+++ b/docs/static/polly-sidebar.js
@@ -494,12 +494,16 @@
 
     var thinkingOn = false;
 
-    // Starter prompts
+    // Starter prompts. Ordered so a cold visitor sees the picker entry
+    // first, followed by a buy-shaped prompt that routes cleanly to the
+    // governance snapshot, then the technical research lookup, then /help
+    // as the safety hatch. Each prompt is verified to route through a
+    // deterministic commerce/research path — no LLM dependency.
     var STARTERS = [
+      "Help me choose a product",
+      "Tell me about the governance snapshot",
       "What is the harmonic wall?",
       "search hyperbolic geometry AI safety",
-      "How do I get started?",
-      "think about the 14-layer pipeline",
       "/help",
     ];
     startersContainer.innerHTML = STARTERS.map(function (s) {

--- a/docs/static/polly-sidebar.js
+++ b/docs/static/polly-sidebar.js
@@ -114,6 +114,43 @@
     return el;
   }
 
+  // Render server-returned action items as inline buttons under the assistant
+  // message. Two action shapes are supported, mirroring polly-hf-chat.js:
+  //   { label, url }    -> opens link in new tab
+  //   { label, prompt } -> submits the prompt as a follow-up chat message
+  // Returns a string of HTML; click delegation lives on the thread element so
+  // dynamically-inserted buttons keep working without per-message rewires.
+  function renderSidebarActions(actions) {
+    if (!actions || !actions.length) return "";
+    var styles = [
+      "display:inline-block",
+      "margin: 4px 6px 0 0",
+      "padding: 6px 12px",
+      "border-radius: 999px",
+      "background: linear-gradient(135deg, #d6a756, #f0bf67)",
+      "color: #14110c",
+      "text-decoration: none",
+      "font-weight: 700",
+      "font-size: 0.85rem",
+      "border: 0",
+      "cursor: pointer",
+    ].join(";");
+    var html = '<div class="polly-sidebar-actions" style="margin-top:10px;">';
+    for (var i = 0; i < actions.length; i++) {
+      var a = actions[i] || {};
+      var label = esc(a.label || "Open");
+      if (a.prompt) {
+        html += '<button type="button" data-polly-prompt="' + esc(String(a.prompt)) + '" style="' + styles + '">' + label + '</button>';
+      } else if (a.url) {
+        var url = esc(String(a.url));
+        var target = /^(mailto:|tel:)/.test(url) ? "" : ' target="_blank" rel="noopener"';
+        html += '<a href="' + url + '"' + target + ' style="' + styles + '">' + label + '</a>';
+      }
+    }
+    html += '</div>';
+    return html;
+  }
+
   // -------------------------------------------------------------------------
   // Status bar
   // -------------------------------------------------------------------------
@@ -348,11 +385,17 @@
         var data = await resp.json();
         if (pending) pending.remove();
         var routeMeta = [
-          chip(data.route || "general", data.thinking ? "science" : "hybrid"),
+          chip(data.route || data.intent || "general", data.thinking ? "science" : "hybrid"),
           chip(data.model || "polly", data.thinking ? "online" : "lore"),
         ].join("");
-        addMsg(thread, "assistant", md(data.response || "No response."), routeMeta);
-        appendMemory("polly", data.response || "");
+        // /v1/polly/chat returns the assistant text under `text` (Vercel JS handler)
+        // or `response` (older Python handler). Accept both so the widget keeps
+        // working through any backend swap. Without this, the Vercel route sets
+        // text but the sidebar would render "No response." for every reply.
+        var replyText = data.text || data.response || "No response.";
+        var actionsHtml = renderSidebarActions(Array.isArray(data.actions) ? data.actions : []);
+        addMsg(thread, "assistant", md(replyText) + actionsHtml, routeMeta);
+        appendMemory("polly", replyText);
         answered = true;
       }
     } catch (_) {}
@@ -572,6 +615,25 @@
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         submit();
+      }
+    });
+
+    // Click delegation for in-chat action buttons. Server replies can include
+    // { label, prompt } actions (via renderSidebarActions); clicking submits
+    // the prompt as a follow-up message. URL actions render as <a> and
+    // navigate normally — they don't carry data-polly-prompt so this handler
+    // ignores them.
+    thread.addEventListener("click", function (event) {
+      var target = event.target;
+      while (target && target !== thread) {
+        var prompt = target.getAttribute && target.getAttribute("data-polly-prompt");
+        if (prompt) {
+          if (sendBtn.disabled) return;
+          input.value = prompt;
+          submit();
+          return;
+        }
+        target = target.parentNode;
       }
     });
 


### PR DESCRIPTION
## Why

This bundles three follow-ups to PR #1579/#1582 that complete the dual-audience treatment across the website. Three commits:

1. **Sidebar bug fix** — sidebar was returning "No response." for every chat
2. **Homepage CTA** — picker wasn't promoted in the hero
3. **Dual-audience polish** — chat.html and hire.html were technical-only or empty for cold visitors

## Commit 1: Sidebar bugs (fix/polly-sidebar-actions-and-text)

The Polly sidebar (`docs/static/polly-sidebar.js`) had two latent bugs that became visible when PR #1579 added the new `guide` intent:

- **Wrong response field.** Sidebar reads `data.response` — the field name from the older Python `/v1/polly/chat` handler. The current Vercel JS handler returns `data.text`. Result: every sidebar reply rendered "No response." instead of the actual text.
- **Ignored `data.actions`.** The new `guide` intent and the in-chat quick-prompts reached `chat.html` visitors but never sidebar visitors who first land on `index.html`.

Fix: read `data.text || data.response`, render actions via new `renderSidebarActions()` helper that mirrors `polly-hf-chat.js`, click delegation re-enters `submit()` for quick-prompt buttons.

## Commit 2: Homepage hero "Find your fit" rail

The picker (`/products.html`) and 3-route onboarding (`/start-here.html`) only appeared in the nav. Hero had 7 CTA buttons but none pointed to either page. Cold visitors above the fold would miss them.

Adds a single high-contrast "**First time here?**" rail between the lede and the existing CTA row:
- Accent gold border + soft gradient, visually distinct from the 7 existing CTA buttons
- One sentence + primary "Find your fit →" button + secondary text link to start-here

## Commit 3: Dual-audience polish on chat.html, hire.html, sidebar starters

- **chat.html** was a 15-line shell that loaded the sidebar widget. Cold visitors got no context, no nav, no escape hatch. Now wraps the sidebar in a proper landing: top nav, hero explaining what Polly does, 3 mode cards (Pick a tool / Ask a question / Buy or hire), escape row, footer.
- **hire.html** added a thin top nav and a "Not technical?" rail between the lede and the first CTA row, pointing cold non-tech buyers at the picker so they don't feel forced to read 600 lines of technical pitch.
- **polly-sidebar.js STARTERS** reordered. First starter is now "Help me choose a product" (triggers new guide intent). Every starter routes through a deterministic commerce / research path — no LLM dependency.

## Scope

- 5 files, +263 lines, -7 lines
- Pure HTML/CSS/JS. No build step. No dependencies.
- Sidebar JS syntax-checked with `node -c`.
- All static — works on Cloudflare Pages, no Vercel dependency.

## Test plan

- [ ] CI passes
- [ ] Visit `/index.html` — confirm gold "First time here?" rail renders below lede; click "Find your fit →" → lands on products.html
- [ ] Visit `/chat.html` — confirm hero + 3 mode cards + escape row + footer render around the sidebar widget
- [ ] Visit `/hire.html` — confirm thin top nav and the green "Not technical?" rail between lede and CTA
- [ ] Open Polly sidebar from `/index.html` (or any page with the launcher) — confirm starter "Help me choose a product" appears first
- [ ] Once Vercel is back: type "help me choose a product" in the sidebar — confirm it now returns the guide reply (not "No response."), with the four route buttons rendered, and clicking one continues the conversation in-place

🤖 Generated with [Claude Code](https://claude.com/claude-code)