### PR TITLE
feat(agents): add agent_bus task to router (npm/PyPI bridge to website)

### DIFF
--- a/.github/workflows/agent-router.yml
+++ b/.github/workflows/agent-router.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       task:
-        description: 'Task type: research | monitor | ask | scrape | web_search | coding | system_build | agentic_ladder | pair_benchmark | poly_coding_seed'
+        description: 'Task type: research | monitor | ask | scrape | web_search | coding | system_build | agentic_ladder | pair_benchmark | poly_coding_seed | agent_bus'
         required: true
         default: 'monitor'
         type: string
@@ -130,6 +130,23 @@ jobs:
             poly_coding_seed)
               python scripts/system/agent_router_smoke.py poly_coding_seed \
                 > artifacts/agent-router/result.json
+              ;;
+            agent_bus)
+              # Dispatch QUERY as one SCBE agent-bus event. Defaults
+              # taskType=general / privacy=remote_ok; advanced callers can
+              # override by passing a JSON-shaped QUERY whose task field
+              # carries the natural-language instruction.
+              if echo "$QUERY" | python -c 'import json,sys; json.loads(sys.stdin.read())' >/dev/null 2>&1; then
+                EVENT_JSON="$QUERY"
+              else
+                EVENT_JSON=$(python -c "import json,sys; print(json.dumps({'task': sys.argv[1], 'taskType': 'general', 'privacy': 'remote_ok'}))" "$QUERY")
+              fi
+              echo "$EVENT_JSON" | node scripts/system/agentbus_pipe.mjs \
+                > artifacts/agent-router/result.json || {
+                  echo "agent_bus event failed; emitting fallback envelope"
+                  echo '{"schema_version":"scbe-agentbus-pipe-result-v1","ok":false,"exit_code":null,"stderr_tail":"agentbus_pipe failed in CI","result":null}' \
+                    > artifacts/agent-router/result.json
+                }
               ;;
             *)
               echo "Unknown task: $TASK"

--- a/api/_agent_common.js
+++ b/api/_agent_common.js
@@ -15,6 +15,11 @@ const ALLOWED_TASKS = new Set([
   "agentic_ladder",
   "pair_benchmark",
   "poly_coding_seed",
+  // agent_bus dispatches the query as a single SCBE agent-bus event via
+  // scripts/system/agentbus_pipe.mjs in the GH Actions runner. Returns the
+  // typed envelope result. This is the bridge between the website's chat
+  // surface and the published scbe-agent-bus npm/PyPI package.
+  "agent_bus",
 ]);
 const PAGES_DATA_BASE = "https://aethermoore.com/SCBE-AETHERMOORE/static/agent-data";
 

--- a/docs/agents.html
+++ b/docs/agents.html
@@ -203,6 +203,13 @@
             <div style="margin-top:8px;"><span class="tag">Training</span> <span class="tag">GeoSeal</span></div>
           </div>
         </div>
+        <div class="card">
+          <h2>Agent Bus</h2>
+          <div class="body">
+            Dispatches one SCBE agent-bus event through scripts/system/agentbus_pipe.mjs. Bridge between the published scbe-agent-bus npm/PyPI package and the website chat surface; returns a typed envelope.
+            <div style="margin-top:8px;"><span class="tag green">Local</span> <span class="tag blue">scbe-agent-bus</span> <span class="tag">Typed envelope</span></div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -222,6 +229,7 @@
           <option value="agentic_ladder">Agentic ladder — Levels 0–1 + optional 6 (query = max level: 1 fast, 6 includes CLI/GeoSeal pytest)</option>
           <option value="pair_benchmark">Pair Benchmark — compare solo vs paired coding workflow</option>
           <option value="poly_coding_seed">Poly Coding Seed — rebuild external poly-coded training seed records</option>
+          <option value="agent_bus">Agent Bus — dispatch one SCBE bus event (query = task text or JSON event)</option>
         </select>
         <label for="d-query">Query or URLs</label>
         <input id="d-query" placeholder="e.g. URLs, research query, or ladder max level: 1 (default depth) or 6 (adds CLI/GeoSeal tests)">
@@ -239,6 +247,7 @@
           <button type="button" onclick="setRecipe('agentic_ladder','6')">Ladder through L6 (CLI/GeoSeal)</button>
           <button type="button" onclick="setRecipe('pair_benchmark','Run dual-agent pair benchmark')">Pair benchmark</button>
           <button type="button" onclick="setRecipe('poly_coding_seed','Regenerate external poly coding seed corpus')">Poly seed</button>
+          <button type="button" onclick="setRecipe('agent_bus','Summarize the latest SCBE governance posture in three sentences')">Agent bus demo</button>
         </div>
       </div>
     </div>

--- a/tests/test_agent_router_bridge_tasks.py
+++ b/tests/test_agent_router_bridge_tasks.py
@@ -18,6 +18,7 @@ EXPECTED_TASKS = {
     "agentic_ladder",
     "pair_benchmark",
     "poly_coding_seed",
+    "agent_bus",
 }
 
 


### PR DESCRIPTION
## Summary
- Adds an `agent_bus` task to the agent-router workflow that pipes the query through `scripts/system/agentbus_pipe.mjs` and returns the typed envelope from the published `scbe-agent-bus` npm/PyPI package.
- Surfaces the new task in `docs/agents.html` (dropdown option, recipe button, grid card) so non-tech visitors can dispatch a single bus event from the browser.
- Keeps lockstep parity across `api/_agent_common.js`, the workflow yml, and the page through the existing `EXPECTED_TASKS` test.

## Why this PR
This is the deterministic action surface task #45. The chat/website previously had no way to invoke the published agent-bus package end-to-end. With this PR a single GitHub Actions dispatch can run a real bus event and write the typed envelope to the public agent-data feed, which the chat surface can then read back without any new server intent or session state.

The query can be either natural language (becomes `{task, taskType: "general", privacy: "remote_ok"}`) or a JSON-shaped event for advanced callers. If the pipe fails the workflow emits a stable fallback envelope so consumers always get the same schema.

## Test plan
- [x] `python -m pytest tests/test_agent_router_bridge_tasks.py::test_vercel_bridge_allowed_tasks_match_router_and_page -v` (passes locally)
- [ ] CI pytest + lint
- [ ] Smoke: trigger `agent-router` workflow with `task=agent_bus`, `query="ping"` and confirm the typed envelope lands in `docs/static/agent-data/latest-agent_bus.json`