### PR TITLE
feat(polly): chat→agents bridge (agent_task intent + URL prefill)

### DIFF
--- a/api/polly/chat.js
+++ b/api/polly/chat.js
@@ -3,6 +3,7 @@
 const { readJsonBody, sendJson, setCors } = require('../_agent_common');
 const {
   classifyIntent,
+  renderAgentTaskReply,
   renderBuyReply,
   renderCustomReply,
   renderGuideReply,
@@ -15,7 +16,14 @@ const llm = require('../_chat_llm');
 const hfUpload = require('../_polly_hf_upload');
 const rateLimit = require('../_polly_rate_limit');
 
-const COMMERCE_INTENTS = new Set(['buy', 'custom', 'guide', 'membership', 'research']);
+const COMMERCE_INTENTS = new Set([
+  'agent_task',
+  'buy',
+  'custom',
+  'guide',
+  'membership',
+  'research',
+]);
 const COMMERCE_CONFIDENCE_FLOOR = 0.6;
 const TRAIN_LOG_PREFIX = 'polly_train_v1 ';
 
@@ -113,9 +121,18 @@ module.exports = async function handler(req, res) {
       rendered = renderGuideReply();
     } else if (intent.name === 'research') {
       rendered = renderResearchReply(message);
+    } else if (intent.name === 'agent_task') {
+      rendered = renderAgentTaskReply(message);
     } else {
       rendered = renderMembershipReply();
     }
+
+    const provider =
+      intent.name === 'research'
+        ? 'research'
+        : intent.name === 'agent_task'
+        ? 'agent_task'
+        : 'commerce';
 
     await captureIfConsented({
       req: body,
@@ -124,13 +141,13 @@ module.exports = async function handler(req, res) {
       intent: intent.name,
       sessionId,
       pageContext,
-      provider: intent.name === 'research' ? 'research' : 'commerce',
+      provider,
     });
 
     return sendJson(res, 200, {
       ok: true,
       text: rendered.text,
-      provider: intent.name === 'research' ? 'research' : 'commerce',
+      provider,
       model: 'intent-classifier-v1',
       intent: intent.name,
       confidence: intent.confidence,

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -211,6 +211,49 @@ const RESEARCH_PATTERN =
 const MEMBERSHIP_PATTERN =
   /\b(member|membership|subscribe|signup|sign\s*up|join|newsletter|follow|stay\s+updated|notify|sponsor|tip|donate)\b/i;
 
+// AGENT TASK: user wants to dispatch a one-shot agent run (research, monitor,
+// scrape, web_search) through the SCBE agent-router workflow. Distinct from
+// the `research` intent above which renders topic explainers — this intent
+// hands off to /agents.html with the dispatch form pre-filled. Worded to
+// catch action verbs that imply tool use ("the web", "these sites", "this
+// URL", "/dispatch") without colliding with topic explainer phrases.
+const AGENT_TASK_PATTERN =
+  /\b(use\s+the\s+agent|run\s+(an?\s+)?agent|dispatch\s+(an?\s+)?agent|agent\s+router|search\s+the\s+web|monitor\s+(these|this|the)\s+(sites?|urls?|pages?)|scrape\s+(this|the)\s+(url|page|site)|crawl\s+(this|the)|fetch\s+(this|the)\s+url)\b|^\/(?:agent|dispatch|bus)\b/i;
+
+const AGENT_TASK_PAGE_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/agents.html';
+const URL_EXTRACT_PATTERN = /\bhttps?:\/\/[^\s,]+/gi;
+
+// Heuristic: pick the most-specific agent-router task the user implied.
+// Defaults to research because that's the safest "tell me about X" run.
+function classifyAgentTaskType(message) {
+  const lower = String(message || '').toLowerCase();
+  if (/\bmonitor\b/.test(lower)) return 'monitor';
+  if (/\bscrape\b|\bcrawl\b|\bfetch\s+this\s+url\b/.test(lower)) return 'scrape';
+  if (/\b(search\s+the\s+web|web\s+search)\b/.test(lower)) return 'web_search';
+  if (/\bdispatch\b|\bbus\b|^\/(?:agent|dispatch|bus)\b/i.test(message || '')) return 'agent_bus';
+  return 'research';
+}
+
+// Strip the trigger phrasing so the dispatch form's query field gets just
+// the substantive part. Falls back to the whole message when nothing comes
+// after the trigger (e.g. bare "run an agent").
+function extractAgentQuery(message, taskType) {
+  const text = String(message || '').trim();
+  if (!text) return '';
+  const urls = text.match(URL_EXTRACT_PATTERN);
+  if (urls && (taskType === 'monitor' || taskType === 'scrape')) {
+    return urls.join(',');
+  }
+  // Try splitting on common connector words so "search the web for AI safety"
+  // → "AI safety".
+  const split = text.split(/\b(?:for|on|about|regarding|of)\b/i);
+  if (split.length >= 2) {
+    const tail = split.slice(1).join(' ').trim();
+    if (tail) return tail.replace(/^[,:\s-]+/, '').slice(0, 400);
+  }
+  return text.slice(0, 400);
+}
+
 // "I don't know what I need" signals. These are the chat-side mirror of the
 // /products.html "find your fit" picker. When the user is uncertain, we walk
 // them through 2-3 plain-language questions instead of dumping the catalog.
@@ -253,6 +296,19 @@ function classifyIntent(message) {
   const product = resolveProduct(message);
   if (product) {
     return { name: 'buy', confidence: 0.6, matchedTerm: product.sku, product };
+  }
+
+  // AGENT_TASK comes BEFORE custom AND research because its trigger phrases
+  // ("search the web", "monitor these sites", "/dispatch") are more specific
+  // than custom's broad keywords like "ai safety" and research's "search".
+  const agentTaskMatch = AGENT_TASK_PATTERN.exec(message);
+  if (agentTaskMatch) {
+    return {
+      name: 'agent_task',
+      confidence: 0.82,
+      matchedTerm: agentTaskMatch[0],
+      product: null,
+    };
   }
 
   const customMatch = CUSTOM_PATTERN.exec(message);
@@ -606,6 +662,47 @@ function renderMembershipReply() {
   return { text, actions };
 }
 
+function renderAgentTaskReply(message) {
+  const taskType = classifyAgentTaskType(message);
+  const query = extractAgentQuery(message, taskType);
+  const params = new URLSearchParams();
+  params.set('task', taskType);
+  if (query) params.set('query', query);
+  const dispatchUrl = `${AGENT_TASK_PAGE_URL}?${params.toString()}`;
+
+  const taskDescriptions = {
+    research: 'deep web research with AI summary and source citations',
+    monitor: 'quick-read of multiple URLs (titles, word counts, key text)',
+    scrape: 'structured extraction from one URL (text, links, metadata, JSON-LD)',
+    web_search: 'web search + AI summary',
+    agent_bus: 'one SCBE agent-bus event through the typed envelope pipeline',
+  };
+  const description = taskDescriptions[taskType] || taskDescriptions.research;
+
+  const lines = [
+    `I can route that to the **${taskType}** agent — ${description}.`,
+    '',
+    query
+      ? `I pulled this query from your message: \`${query.slice(0, 200)}\``
+      : 'Click through and I\'ll leave the query field blank for you to fill in.',
+    '',
+    'The agent runs on a free GitHub server (the Vercel bridge will queue it ' +
+      'when configured, otherwise the page falls back to opening the GitHub ' +
+      'workflow form). Results land on the Latest Results panel and are ' +
+      'published to the public agent-data feed when the run finishes.',
+  ];
+
+  const actions = [
+    { label: `Open ${taskType} dispatch`, url: dispatchUrl },
+    { label: 'See all agent tasks', url: AGENT_TASK_PAGE_URL },
+    {
+      label: 'Pick a different tool',
+      prompt: 'Help me choose a product',
+    },
+  ];
+  return { text: lines.join('\n'), actions, taskType, query };
+}
+
 module.exports = {
   PRODUCT_CATALOG,
   CONSULTING_TIERS,
@@ -618,12 +715,16 @@ module.exports = {
   GUIDE_ROUTES,
   START_HERE_URL,
   PRODUCTS_PAGE_URL,
+  AGENT_TASK_PAGE_URL,
   classifyIntent,
+  classifyAgentTaskType,
+  extractAgentQuery,
   renderBuyReply,
   renderCustomReply,
   renderGuideReply,
   renderMembershipReply,
   renderResearchReply,
+  renderAgentTaskReply,
   resolveProduct,
   resolveResearchTopic,
 };

--- a/docs/agents.html
+++ b/docs/agents.html
@@ -528,6 +528,26 @@
     loadAgentStatus();
     setInterval(loadResults, 300000);
     setInterval(loadAgentStatus, 120000);
+
+    // Polly chat (and other deep-links) can route visitors here with the
+    // dispatch form pre-filled via ?task=...&query=... — same effect as
+    // clicking a starter card. Keeps non-tech visitors one click away from
+    // running an agent without typing anything.
+    (function prefillFromUrl() {
+      try {
+        var params = new URLSearchParams(location.search);
+        var task = (params.get('task') || '').trim();
+        var query = (params.get('query') || '').trim();
+        if (!task) return;
+        var taskSelect = document.getElementById('d-task');
+        var validTasks = Array.prototype.map.call(
+          taskSelect.options,
+          function (opt) { return opt.value; }
+        );
+        if (validTasks.indexOf(task) === -1) return;
+        trySample(task, query);
+      } catch (_e) { /* never break the page on prefill */ }
+    })();
   </script>
 
   <script src="static/polly-sidebar.js"></script>

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -370,6 +370,92 @@ describe('polly commerce intent classification', () => {
     expect(commerce.classifyIntent('I want to buy the toolkit').name).toBe('buy');
     expect(commerce.classifyIntent('Purchase the snapshot').name).toBe('buy');
   });
+
+  it('routes "search the web for X" to agent_task (not research topic)', () => {
+    const intent = commerce.classifyIntent('search the web for AI safety governance');
+    expect(intent.name).toBe('agent_task');
+    expect(intent.confidence).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it('routes "monitor these sites" to agent_task', () => {
+    expect(commerce.classifyIntent('monitor these sites: a.com, b.com').name).toBe('agent_task');
+    expect(commerce.classifyIntent('monitor this site for me').name).toBe('agent_task');
+  });
+
+  it('routes "scrape this URL" to agent_task', () => {
+    expect(commerce.classifyIntent('scrape this URL https://example.com').name).toBe('agent_task');
+    expect(commerce.classifyIntent('scrape the page please').name).toBe('agent_task');
+  });
+
+  it('routes "/agent" or "/dispatch" slash commands to agent_task', () => {
+    expect(commerce.classifyIntent('/agent monitor').name).toBe('agent_task');
+    expect(commerce.classifyIntent('/dispatch research foo').name).toBe('agent_task');
+    expect(commerce.classifyIntent('/bus ping').name).toBe('agent_task');
+  });
+
+  it('does not steal "what is X" topic explainers from research intent', () => {
+    expect(commerce.classifyIntent('What is the harmonic wall?').name).toBe('research');
+    expect(commerce.classifyIntent('Tell me about the 14-layer pipeline').name).toBe('research');
+  });
+});
+
+describe('polly agent_task task-type and query extraction', () => {
+  it('classifyAgentTaskType picks monitor/scrape/web_search/agent_bus', () => {
+    expect(commerce.classifyAgentTaskType('monitor these sites')).toBe('monitor');
+    expect(commerce.classifyAgentTaskType('scrape this page')).toBe('scrape');
+    expect(commerce.classifyAgentTaskType('search the web for X')).toBe('web_search');
+    expect(commerce.classifyAgentTaskType('/dispatch ping')).toBe('agent_bus');
+  });
+
+  it('classifyAgentTaskType defaults to research', () => {
+    expect(commerce.classifyAgentTaskType('use the agent router for AI safety')).toBe('research');
+    expect(commerce.classifyAgentTaskType('run an agent')).toBe('research');
+  });
+
+  it('extractAgentQuery joins URLs for monitor/scrape', () => {
+    const q = commerce.extractAgentQuery(
+      'monitor these: https://a.com and https://b.com please',
+      'monitor'
+    );
+    expect(q).toContain('https://a.com');
+    expect(q).toContain('https://b.com');
+  });
+
+  it('extractAgentQuery splits on connector words for non-URL tasks', () => {
+    expect(commerce.extractAgentQuery('search the web for AI safety governance', 'web_search')).toBe(
+      'AI safety governance'
+    );
+    expect(
+      commerce.extractAgentQuery('research about hyperbolic geometry', 'research')
+    ).toContain('hyperbolic geometry');
+  });
+});
+
+describe('polly renderAgentTaskReply', () => {
+  it('returns a dispatch URL with task and query params', () => {
+    const out = commerce.renderAgentTaskReply('search the web for AI safety');
+    expect(out.taskType).toBe('web_search');
+    expect(out.actions[0].url).toContain('agents.html');
+    expect(out.actions[0].url).toContain('task=web_search');
+    expect(out.actions[0].url).toMatch(/AI(\+|%20)safety/);
+  });
+
+  it('still emits a dispatch URL when no query can be extracted', () => {
+    const out = commerce.renderAgentTaskReply('run an agent');
+    expect(out.taskType).toBe('research');
+    expect(out.actions[0].url).toContain('task=research');
+  });
+
+  it('exposes a "pick a different tool" prompt action', () => {
+    const out = commerce.renderAgentTaskReply('monitor these sites: https://example.com');
+    const promptAction = out.actions.find(
+      (a: { prompt?: string }) => typeof a.prompt === 'string'
+    );
+    expect(promptAction).toBeDefined();
+    // Round-trip safety: the prompt action should re-classify cleanly.
+    const reIntent = commerce.classifyIntent(promptAction!.prompt as string);
+    expect(reIntent.name).not.toBe('agent_task');
+  });
 });
 
 describe('polly commerce reply rendering', () => {
@@ -563,6 +649,27 @@ describe('polly chat handler — commerce path', () => {
     expect(body.text).toContain('Three or four routes');
     expect(body.actions.some((a) => a.url.includes('products.html'))).toBe(true);
     expect(body.actions.some((a) => a.url.includes('start-here.html'))).toBe(true);
+  });
+
+  it('routes "search the web for X" to agent_task with dispatch URL', async () => {
+    const req = makeReq({
+      body: { message: 'search the web for AI safety governance', consent_to_train: false },
+    });
+    const res = makeRes();
+    await chatHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as {
+      provider: string;
+      intent: string;
+      actions: { url?: string; prompt?: string }[];
+    };
+    expect(body.provider).toBe('agent_task');
+    expect(body.intent).toBe('agent_task');
+    const dispatchAction = body.actions.find(
+      (a) => typeof a.url === 'string' && a.url.includes('agents.html')
+    );
+    expect(dispatchAction).toBeDefined();
+    expect(dispatchAction!.url).toContain('task=web_search');
   });
 
   it('rejects POST without message', async () => {


### PR DESCRIPTION
## Summary
- Closes the chat→agent-router loop. Polly chat now recognizes "search the web for X", "monitor these sites", "scrape this URL", "/dispatch", and "use the agent router" as a new `agent_task` intent and renders a deterministic reply with a one-click link into `agents.html` with the dispatch form pre-filled.
- `agents.html` parses `?task=&query=` on load and calls the existing `trySample()` helper — same UX as clicking a starter card. Task value is validated against the dropdown options so junk URLs can never break the page.
- Pairs with #1613 (which added the `agent_bus` task to the router) so the natural-language path "/bus ping" / "dispatch an agent" classifies cleanly into the agent_bus task.

## Why this PR
The agent-router workflow shipped, but Polly chat had no awareness of it. Visitors who said "monitor these sites" or "search the web for X" got either a custom-audit pitch (misclassified) or a generic LLM fallback. This PR makes those phrases route to a deterministic action surface — same zero-cost pattern as the buy/guide/research intents.

The intent ordering is the load-bearing decision: AGENT_TASK runs before CUSTOM (whose `ai safety` keyword steals "search the web for AI safety") and before RESEARCH (whose plain `search` keyword steals "search the web"). The pattern only fires on phrases that strongly imply tool use ("the web", "these sites", "this URL", "/dispatch"), so topic explainers like "What is the harmonic wall?" still route to research.

## Test plan
- [x] `npx vitest run tests/api/polly_commerce_js.test.ts` — 96/96 green locally
- [x] Intent ordering regression: "What is the harmonic wall?" still classifies as research
- [x] Round-trip safety: the "Pick a different tool" prompt action re-classifies to a non-agent_task intent
- [ ] Manual smoke after merge: visit `/agents.html?task=monitor&query=https%3A%2F%2Fexample.com` and confirm form auto-fills + scrolls to dispatch button