### PR TITLE
feat(polly): /help meta-intent (deterministic capability list)

### DIFF
--- a/api/polly/chat.js
+++ b/api/polly/chat.js
@@ -7,6 +7,7 @@ const {
   renderBuyReply,
   renderCustomReply,
   renderGuideReply,
+  renderHelpReply,
   renderMembershipReply,
   renderResearchReply,
   HIRE_EMAIL,
@@ -21,6 +22,7 @@ const COMMERCE_INTENTS = new Set([
   'buy',
   'custom',
   'guide',
+  'help',
   'membership',
   'research',
 ]);
@@ -119,6 +121,8 @@ module.exports = async function handler(req, res) {
       rendered = renderCustomReply(message);
     } else if (intent.name === 'guide') {
       rendered = renderGuideReply();
+    } else if (intent.name === 'help') {
+      rendered = renderHelpReply();
     } else if (intent.name === 'research') {
       rendered = renderResearchReply(message);
     } else if (intent.name === 'agent_task') {
@@ -131,8 +135,8 @@ module.exports = async function handler(req, res) {
       intent.name === 'research'
         ? 'research'
         : intent.name === 'agent_task'
-        ? 'agent_task'
-        : 'commerce';
+          ? 'agent_task'
+          : 'commerce';
 
     await captureIfConsented({
       req: body,

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -211,6 +211,12 @@ const RESEARCH_PATTERN =
 const MEMBERSHIP_PATTERN =
   /\b(member|membership|subscribe|signup|sign\s*up|join|newsletter|follow|stay\s+updated|notify|sponsor|tip|donate)\b/i;
 
+// HELP: bare "/help", "?", "what can you do" — meta-help asking what Polly
+// understands. Sidebar starters advertise /help so this can't be a dead-end.
+// Returns a structured capability list with one-click action chips.
+const HELP_PATTERN =
+  /^(\/help|\/\?|help)\s*$|^\?+\s*$|\b(what\s+can\s+you\s+(do|help\s+with)|what\s+do\s+you\s+know(\s+about)?\s*$|what\s+(commands?|options?|features?|topics?)\s+do\s+you\s+(have|support)|how\s+do\s+(you|i\s+use\s+you)\s+work|help\s+menu|show\s+me\s+(the\s+)?(commands?|options?|menu))\b/i;
+
 // AGENT TASK: user wants to dispatch a one-shot agent run (research, monitor,
 // scrape, web_search) through the SCBE agent-router workflow. Distinct from
 // the `research` intent above which renders topic explainers — this intent
@@ -273,6 +279,13 @@ function resolveProduct(message) {
 function classifyIntent(message) {
   if (typeof message !== 'string' || !message.trim()) {
     return { name: 'general', confidence: 0, matchedTerm: null, product: null };
+  }
+
+  // HELP runs first so "/help" and "what can you do" never fall through to
+  // a topic-explainer or LLM fallback. Sidebar starters advertise /help.
+  const helpMatch = HELP_PATTERN.exec(message);
+  if (helpMatch) {
+    return { name: 'help', confidence: 0.95, matchedTerm: helpMatch[0], product: null };
   }
 
   // Guide goes before buy: "what should I get" / "i don't know what to buy"
@@ -608,7 +621,7 @@ const PRODUCTS_PAGE_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/products.htm
 
 function renderGuideReply() {
   const lines = [
-    "Happy to help you pick. Three or four routes cover almost everyone — which one fits?",
+    'Happy to help you pick. Three or four routes cover almost everyone — which one fits?',
     '',
   ];
   for (const route of GUIDE_ROUTES) {
@@ -616,7 +629,7 @@ function renderGuideReply() {
   }
   lines.push('');
   lines.push(
-    'Tell me which one and I\'ll point you at the right product. ' +
+    "Tell me which one and I'll point you at the right product. " +
       "If you'd rather see all options at once, the full picker is on the products page."
   );
 
@@ -662,6 +675,40 @@ function renderMembershipReply() {
   return { text, actions };
 }
 
+function renderHelpReply() {
+  const text =
+    "Here's what I can do — pick a chip below or just ask in plain English.\n\n" +
+    '**Pick a tool**\n' +
+    '- "Help me choose a product" → 3-question picker\n' +
+    '- "Buy the toolkit" / "I want the snapshot" → direct checkout\n' +
+    '- "I need a custom audit" → scoping path\n\n' +
+    '**Ask a question**\n' +
+    '- "What is the harmonic wall?" → topic explainer\n' +
+    '- "Tell me about the 14-layer pipeline" / Sacred Tongues / axiom mesh\n\n' +
+    '**Run an agent**\n' +
+    '- "Search the web for X" → web_search agent\n' +
+    '- "Monitor these sites: a.com, b.com" → monitor agent\n' +
+    '- "Scrape this URL: https://..." → scrape agent\n' +
+    '- "/agent" or "/dispatch" → agent_bus event\n\n' +
+    '**Stay close**\n' +
+    '- "Subscribe / tip / sponsor" → membership routes\n' +
+    '- "Watch the repo" → GitHub releases\n\n' +
+    "If your question doesn't match any of the above, I'll fall back to a free " +
+    'LLM with the SCBE governance pipeline checking the response.';
+
+  const actions = [
+    { label: 'Help me choose a product', prompt: 'Help me choose a product' },
+    { label: 'What is the harmonic wall?', prompt: 'What is the harmonic wall?' },
+    {
+      label: 'Run a research agent',
+      prompt: 'search the web for SCBE hyperbolic geometry AI safety',
+    },
+    { label: 'Browse all products', url: PRODUCTS_PAGE_URL },
+    { label: 'Open the agents page', url: AGENT_TASK_PAGE_URL },
+  ];
+  return { text, actions };
+}
+
 function renderAgentTaskReply(message) {
   const taskType = classifyAgentTaskType(message);
   const query = extractAgentQuery(message, taskType);
@@ -684,7 +731,7 @@ function renderAgentTaskReply(message) {
     '',
     query
       ? `I pulled this query from your message: \`${query.slice(0, 200)}\``
-      : 'Click through and I\'ll leave the query field blank for you to fill in.',
+      : "Click through and I'll leave the query field blank for you to fill in.",
     '',
     'The agent runs on a free GitHub server (the Vercel bridge will queue it ' +
       'when configured, otherwise the page falls back to opening the GitHub ' +
@@ -722,6 +769,7 @@ module.exports = {
   renderBuyReply,
   renderCustomReply,
   renderGuideReply,
+  renderHelpReply,
   renderMembershipReply,
   renderResearchReply,
   renderAgentTaskReply,

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -371,6 +371,21 @@ describe('polly commerce intent classification', () => {
     expect(commerce.classifyIntent('Purchase the snapshot').name).toBe('buy');
   });
 
+  it('routes "/help" and "?" to the help intent', () => {
+    expect(commerce.classifyIntent('/help').name).toBe('help');
+    expect(commerce.classifyIntent('help').name).toBe('help');
+    expect(commerce.classifyIntent('?').name).toBe('help');
+    expect(commerce.classifyIntent('what can you do?').name).toBe('help');
+    expect(commerce.classifyIntent('what commands do you support').name).toBe('help');
+  });
+
+  it('does not steal "help me choose a product" from guide intent', () => {
+    // HELP must run before GUIDE but its phrasing must be specific enough that
+    // "help me choose" is still routed to guide.
+    expect(commerce.classifyIntent('Help me choose a product').name).toBe('guide');
+    expect(commerce.classifyIntent('help me pick a product').name).toBe('guide');
+  });
+
   it('routes "search the web for X" to agent_task (not research topic)', () => {
     const intent = commerce.classifyIntent('search the web for AI safety governance');
     expect(intent.name).toBe('agent_task');
@@ -422,12 +437,35 @@ describe('polly agent_task task-type and query extraction', () => {
   });
 
   it('extractAgentQuery splits on connector words for non-URL tasks', () => {
-    expect(commerce.extractAgentQuery('search the web for AI safety governance', 'web_search')).toBe(
-      'AI safety governance'
-    );
     expect(
-      commerce.extractAgentQuery('research about hyperbolic geometry', 'research')
-    ).toContain('hyperbolic geometry');
+      commerce.extractAgentQuery('search the web for AI safety governance', 'web_search')
+    ).toBe('AI safety governance');
+    expect(commerce.extractAgentQuery('research about hyperbolic geometry', 'research')).toContain(
+      'hyperbolic geometry'
+    );
+  });
+});
+
+describe('polly renderHelpReply', () => {
+  it('returns a structured capability list with prompt + url actions', () => {
+    const out = commerce.renderHelpReply();
+    expect(out.text).toContain('Pick a tool');
+    expect(out.text).toContain('Run an agent');
+    expect(out.actions.length).toBeGreaterThanOrEqual(3);
+    const promptActions = out.actions.filter(
+      (a: { prompt?: string }) => typeof a.prompt === 'string'
+    );
+    expect(promptActions.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('every prompt action round-trips to a non-help intent', () => {
+    const out = commerce.renderHelpReply();
+    for (const action of out.actions) {
+      if (typeof action.prompt !== 'string') continue;
+      const reIntent = commerce.classifyIntent(action.prompt);
+      expect(reIntent.name).not.toBe('help');
+      expect(reIntent.confidence).toBeGreaterThanOrEqual(0.6);
+    }
   });
 });
 
@@ -448,9 +486,7 @@ describe('polly renderAgentTaskReply', () => {
 
   it('exposes a "pick a different tool" prompt action', () => {
     const out = commerce.renderAgentTaskReply('monitor these sites: https://example.com');
-    const promptAction = out.actions.find(
-      (a: { prompt?: string }) => typeof a.prompt === 'string'
-    );
+    const promptAction = out.actions.find((a: { prompt?: string }) => typeof a.prompt === 'string');
     expect(promptAction).toBeDefined();
     // Round-trip safety: the prompt action should re-classify cleanly.
     const reIntent = commerce.classifyIntent(promptAction!.prompt as string);
@@ -649,6 +685,23 @@ describe('polly chat handler — commerce path', () => {
     expect(body.text).toContain('Three or four routes');
     expect(body.actions.some((a) => a.url.includes('products.html'))).toBe(true);
     expect(body.actions.some((a) => a.url.includes('start-here.html'))).toBe(true);
+  });
+
+  it('routes "/help" to deterministic capability list (no LLM fallback)', async () => {
+    const req = makeReq({ body: { message: '/help', consent_to_train: false } });
+    const res = makeRes();
+    await chatHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as {
+      provider: string;
+      intent: string;
+      text: string;
+      actions: { prompt?: string; url?: string }[];
+    };
+    expect(body.provider).toBe('commerce');
+    expect(body.intent).toBe('help');
+    expect(body.text).toContain('Pick a tool');
+    expect(body.actions.length).toBeGreaterThan(0);
   });
 
   it('routes "search the web for X" to agent_task with dispatch URL', async () => {


### PR DESCRIPTION
## Summary
- Adds a deterministic \`/help\` intent so the sidebar's advertised \`/help\` starter prompt no longer falls through to LLM fallback.
- Returns a structured capability list grouped by Pick a tool / Ask a question / Run an agent / Stay close, plus quick-prompt action chips that round-trip cleanly back into other intents.
- Runs FIRST in \`classifyIntent\` so it can never be stolen by a downstream pattern, but the regex is specific enough that "Help me choose a product" still routes to guide (regression test guards this).

## Why this PR
The polly-sidebar STARTERS list (shipped in #1601) advertises \`/help\` as one of the canned starters. But the chat handler had no deterministic case for it — meaning a brand-new visitor's first click could either return an offline-router four-bucket reply, an LLM-provider answer, or (if the LLM was down) the generic offline router. That's a broken expectation: a slash-command-style starter that doesn't have a stable answer.

This closes that gap with a 5-section capability map that mirrors what the existing intents already deliver — pick / ask / run / stay close — and gives the user 3 quick-prompt chips plus 2 page links so they can keep moving in chat without typing.

## Test plan
- [x] \`npx vitest run tests/api/polly_commerce_js.test.ts\` — 93/93 green
- [x] HELP intent is matched first; "Help me choose a product" still classifies as guide (regression guarded)
- [x] Round-trip safety: every \`prompt\` action in renderHelpReply re-classifies to a non-help intent with confidence ≥ 0.6
- [x] Chat-handler integration: POST \`{message: "/help"}\` returns provider="commerce", intent="help", text contains "Pick a tool"
- [x] Prettier-formatted