### PR TITLE
chore(website): clearer H1 copy on hire/products/start-here

### DIFF
--- a/docs/hire.html
+++ b/docs/hire.html
@@ -365,7 +365,7 @@
       </nav>
       <header>
         <div class="eyebrow">Available now · Federal-registered · Open-source-first</div>
-        <h1>AI safety and governance engineering, <span>built solo, shipped real.</span></h1>
+        <h1>Hire SCBE for paid AI governance audits and agent safety.</h1>
         <p class="lede">
           I build the parts of AI systems that the model providers don't ship. Adversarial-cost
           manifolds, governance overlays, formal-methods tooling, audit-grade telemetry.

--- a/docs/products.html
+++ b/docs/products.html
@@ -381,7 +381,7 @@
 <main>
   <section class="hero">
     <div class="eyebrow">Find your fit</div>
-    <h1>Pick the right tool. In plain words.</h1>
+    <h1>Buy the right SCBE option for your AI workflow.</h1>
     <p class="lead">
       If you have an AI workflow and want a concrete written answer, start with the $500 Snapshot.
       If you are browsing, the picker will route you in under a minute.

--- a/docs/start-here.html
+++ b/docs/start-here.html
@@ -217,7 +217,7 @@
 <main>
   <section class="hero">
     <div class="eyebrow">Start here</div>
-    <h1>Three routes in. Pick yours.</h1>
+    <h1>Choose your route: support, snapshot, or open code.</h1>
     <p class="lead">
       AetherMoore is a governed AI workflow toolkit. If you need a useful result,
       the fastest path is the $500 Governance Snapshot. Everything else supports,

--- a/public/hire.html
+++ b/public/hire.html
@@ -350,7 +350,7 @@
     <div class="container">
       <header>
         <div class="eyebrow">Available now · Federal-registered · Open-source-first</div>
-        <h1>AI safety and governance engineering, <span>built solo, shipped real.</span></h1>
+        <h1>Hire SCBE for paid AI governance audits and agent safety.</h1>
         <p class="lede">
           I build the parts of AI systems that the model providers don't ship. Adversarial-cost
           manifolds, governance overlays, formal-methods tooling, audit-grade telemetry.


### PR DESCRIPTION
## Summary
Sharpens the page-1 promise on three landing pages from voice-first to CTA-direct + search-friendly:

- \`docs/hire.html\` + \`public/hire.html\`: "AI safety and governance engineering, built solo, shipped real." → "Hire SCBE for paid AI governance audits and agent safety."
- \`docs/products.html\`: "Pick the right tool. In plain words." → "Buy the right SCBE option for your AI workflow."
- \`docs/start-here.html\`: "Three routes in. Pick yours." → "Choose your route: support, snapshot, or open code."

## Why this PR
The voice-first H1s were charming but hid the offer. New H1s lead with the verb (Hire, Buy, Choose) and the SKU/category, which lets a first-time visitor decide whether they're on the right page in two seconds without reading the lede.

## Notes
- **Preserves** the docs/hire.html top nav and the "Not technical?" rail that #1601 added — both are still load-bearing for the non-tech audience requirement.
- Pure copy change; no script or layout edits.

## Test plan
- [x] Pure 1-line H1 swap on each page; nothing else touched
- [ ] Visual smoke after deploy on hire / products / start-here