### PR TITLE
chore(npm): drop dead docs:format and docs:check scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,8 +96,6 @@
     "format:python": "black src/ tests/",
     "lint": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "lint:python": "flake8 src/ tests/",
-    "docs:format": "python scripts/format_doc_markdown.py docs/specs docs/proposals --write",
-    "docs:check": "python scripts/format_doc_markdown.py docs/specs docs/proposals --check",
     "cli": "python scbe-cli.py",
     "codeprism:build": "python scripts/code_prism_build.py",
     "codeprism:mesh": "python scripts/code_prism_build.py --mesh",


### PR DESCRIPTION
## Summary
- Removes \`docs:format\` and \`docs:check\` from package.json. Both pointed at \`scripts/format_doc_markdown.py\`, which was never committed to the repo (verified with \`git log --all --diff-filter=A\`).
- No CI workflow references either npm script.

## Why this PR
Dead script references trip contributors who run \`npm run docs:check\` and get a missing-script error. Cleaner to remove than to ship a phantom script.