### PR TITLE
chore(docs): wire docs:check to scripts/system/docs_finish_audit.py

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "codeprism:mesh": "python scripts/code_prism_build.py --mesh",
     "connector:health": "python scripts/connector_health_check.py",
     "repo:shape": "python scripts/system/report_repo_surface_shape.py",
+    "docs:check": "python scripts/system/docs_finish_audit.py",
     "scbe:bootstrap": "node scripts/scbe_bootstrap.mjs",
     "system:cli": "python scripts/scbe-system-cli.py",
     "training:terminal": "python scripts/system/training_terminal.py",


### PR DESCRIPTION
## Summary
- Adds back \`npm run docs:check\` pointing at the actual auditor (\`scripts/system/docs_finish_audit.py\`) — replaces the dead reference removed in #1621.

## Why this PR
#1621 dropped \`docs:check\`/\`docs:format\` because they pointed at a script that was never committed. The actual auditor lives at \`scripts/system/docs_finish_audit.py\` (already in main; scans for unfinished markers + broken local links). This restores the npm shortcut so contributors can run \`npm run docs:check\`.

## Test plan
- [x] \`npm run docs:check\` runs successfully (\`schema=scbe_docs_finish_audit_v1 scanned=234 findings=5 markers=10 broken_links=1\`)
- [ ] CI build + test