### PR TITLE
fix(agent-router): sanitize public agent data

### DIFF
--- a/.github/workflows/agent-router.yml
+++ b/.github/workflows/agent-router.yml
@@ -162,8 +162,11 @@ jobs:
           TASK="${{ steps.task.outputs.task }}"
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          # Copy result to pages-accessible location
-          cp artifacts/agent-router/result.json docs/static/agent-data/latest-${TASK}.json
+          # Copy a public-safe result to the pages-accessible location. The
+          # private workflow artifact keeps raw stderr/stdout for debugging.
+          python scripts/system/sanitize_agent_router_public_result.py \
+            --input artifacts/agent-router/result.json \
+            --output docs/static/agent-data/latest-${TASK}.json
 
           # Build index of all agent data
           python -c "
@@ -180,7 +183,7 @@ jobs:
               index['tasks'][name] = {
                 'file': os.path.basename(f),
                 'updated': '$TIMESTAMP',
-                'preview': str(data)[:200]
+                'preview': json.dumps(data, sort_keys=True)[:200]
               }
             except:
               pass

--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,13 @@ external/cli-quests/
 .roots/
 .home/.codex/
 .vercel
+
+# Per-developer agent skills (personal Claude/Codex skill installs, not repo work)
+.home/.agents/skills/
+
+# Wildlife-flock runtime state: dispatch plans + result snapshots
+# (the dispatcher source itself lives under scripts/wildlife/)
+.scbe/wildlife/
+
+# Local replica directory created by some sync tools — never commit
+/origin/

--- a/scripts/system/sanitize_agent_router_public_result.py
+++ b/scripts/system/sanitize_agent_router_public_result.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Sanitize agent-router result envelopes before publishing them to Pages.
+
+The full CI artifact can keep stderr/stdout tails for debugging. The public
+`docs/static/agent-data/latest-*.json` feed should not carry environment
+warnings, auth configuration details, or credential-shaped strings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SENSITIVE_TEXT_RE = re.compile(
+    r"\b("
+    r"api[_-]?key|api[_-]?keys|token|secret|password|credential|bearer|authorization|"
+    r"SCBE_API_KEYS|HF_TOKEN|GITHUB_TOKEN|GMAIL_APP_PASS|PROTONMAIL_BRIDGE_PASSWORD"
+    r")\b",
+    re.IGNORECASE,
+)
+
+TAIL_KEYS = {"stderr_tail", "stdout_tail", "stderr", "stdout", "logs", "log_tail"}
+REDACTED_TAIL = "[redacted from public agent-data feed; see private workflow artifact]"
+
+
+def _sanitize_value(key: str | None, value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k): _sanitize_value(str(k), v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_value(key, item) for item in value]
+    if isinstance(value, str):
+        if key in TAIL_KEYS and SENSITIVE_TEXT_RE.search(value):
+            return REDACTED_TAIL
+        if key and SENSITIVE_TEXT_RE.search(key):
+            return REDACTED_TAIL
+    return value
+
+
+def sanitize_result(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a public-safe copy of an agent-router result object."""
+
+    sanitized = _sanitize_value(None, data)
+    if not isinstance(sanitized, dict):
+        raise TypeError("agent-router result must be a JSON object")
+    sanitized["public_sanitized"] = True
+    return sanitized
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sanitize agent-router JSON before public Pages publishing")
+    parser.add_argument("--input", required=True, help="Input JSON file")
+    parser.add_argument("--output", required=True, help="Output JSON file")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    data = json.loads(input_path.read_text(encoding="utf-8"))
+    sanitized = sanitize_result(data)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(sanitized, separators=(",", ":"), ensure_ascii=False) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/system/test_sanitize_agent_router_public_result.py
+++ b/tests/system/test_sanitize_agent_router_public_result.py
@@ -1,0 +1,32 @@
+from scripts.system.sanitize_agent_router_public_result import REDACTED_TAIL, sanitize_result
+
+
+def test_sanitizes_sensitive_stderr_tail() -> None:
+    result = {
+        "ok": True,
+        "stderr_tail": "No SCBE_API_KEYS configured and HF_TOKEN missing",
+        "result": {"text": "offline run accepted"},
+    }
+
+    sanitized = sanitize_result(result)
+
+    assert sanitized["stderr_tail"] == REDACTED_TAIL
+    assert sanitized["result"]["text"] == "offline run accepted"
+    assert sanitized["public_sanitized"] is True
+
+
+def test_leaves_normal_tail_for_public_diagnostics() -> None:
+    result = {"ok": False, "stderr_tail": "agentbus_pipe failed in CI"}
+
+    sanitized = sanitize_result(result)
+
+    assert sanitized["stderr_tail"] == "agentbus_pipe failed in CI"
+
+
+def test_sanitizes_credential_shaped_nested_keys() -> None:
+    result = {"result": {"token": "abc123", "safe": "visible"}}
+
+    sanitized = sanitize_result(result)
+
+    assert sanitized["result"]["token"] == REDACTED_TAIL
+    assert sanitized["result"]["safe"] == "visible"


### PR DESCRIPTION
## Summary
- ignores local-only agent skill installs, wildlife runtime state, and accidental local `origin/` replicas
- sanitizes agent-router results before publishing to `docs/static/agent-data/latest-*.json`
- keeps raw stderr/stdout in the private workflow artifact, but removes credential-shaped tails from public Pages data
- switches the public index preview from Python `str(data)` to deterministic JSON preview text

## Test evidence
- `python -m pytest tests/system/test_sanitize_agent_router_public_result.py -q`
- `python -m black --check --target-version py311 --line-length 120 scripts/system/sanitize_agent_router_public_result.py tests/system/test_sanitize_agent_router_public_result.py`
- `npm run typecheck`
- `python scripts/security/code_governance_gate.py check-push`

## Rollback
- revert the sanitizer workflow call and remove the script/test files
- remove the added `.gitignore` local-only patterns if they conflict with a future repo-managed skill lane