### PR TITLE
fix(docs): skip code spans in finish audit

### DIFF
--- a/scripts/system/docs_finish_audit.py
+++ b/scripts/system/docs_finish_audit.py
@@ -17,6 +17,17 @@ from typing import Iterable
 UNFINISHED_RE = re.compile(r"\b(TODO|TBD|WIP|FIXME|placeholder|to be configured)\b", re.IGNORECASE)
 MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 EXCLUDE_PREFIXES = ("http://", "https://", "mailto:", "#")
+# Strip fenced code blocks (```...```) and inline code (`...`) before scanning
+# so rust `todo!()` macros, `M[i,j](op)` inline-code expressions, and similar
+# legitimate code references don't false-trigger as unfinished work or broken
+# markdown links.
+FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+
+
+def _strip_code(content: str) -> str:
+    without_fenced = FENCED_CODE_RE.sub("", content)
+    return INLINE_CODE_RE.sub("", without_fenced)
 
 
 @dataclass
@@ -46,7 +57,7 @@ def _normalize_link_target(raw: str) -> str:
 
 
 def _find_broken_links(md_path: Path) -> list[str]:
-    content = md_path.read_text(encoding="utf-8", errors="replace")
+    content = _strip_code(md_path.read_text(encoding="utf-8", errors="replace"))
     broken: list[str] = []
     for match in MARKDOWN_LINK_RE.finditer(content):
         raw_target = match.group(1)
@@ -66,7 +77,7 @@ def audit_docs(repo_root: Path, docs_dir: str = "docs") -> dict[str, object]:
     total_markers = 0
     total_broken_links = 0
     for md in _iter_docs(repo_root, docs_dir):
-        content = md.read_text(encoding="utf-8", errors="replace")
+        content = _strip_code(md.read_text(encoding="utf-8", errors="replace"))
         markers = len(UNFINISHED_RE.findall(content))
         broken = _find_broken_links(md)
         if markers or broken:

--- a/tests/system/test_docs_finish_audit.py
+++ b/tests/system/test_docs_finish_audit.py
@@ -24,3 +24,42 @@ def test_audit_docs_detects_markers_and_broken_links(tmp_path: Path) -> None:
     findings = report["findings"]
     assert isinstance(findings, list) and findings
     assert findings[0]["path"] == "docs/bad.md"
+
+
+def test_audit_skips_inline_code_and_fenced_blocks(tmp_path: Path) -> None:
+    """Markers inside code (`todo!()`, ```...TODO...```) and pseudo-links
+    inside inline code (`M[i,j](op)`) must not count as findings."""
+    docs = tmp_path / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+
+    f = docs / "code_only.md"
+    f.write_text(
+        "# Code references only\n\n"
+        "Inline rust macro: `todo!()` — this is just a reference.\n\n"
+        "Inline-code-not-link: `M[i,j](op)` returns the equivalent.\n\n"
+        "```rust\nfn placeholder() { todo!() }\n```\n",
+        encoding="utf-8",
+    )
+
+    report = audit_docs(repo_root=tmp_path, docs_dir="docs")
+    assert report["files_with_findings"] == 0
+    assert report["unfinished_marker_total"] == 0
+    assert report["broken_local_link_total"] == 0
+
+
+def test_audit_still_detects_real_markers_outside_code(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+
+    f = docs / "mixed.md"
+    f.write_text(
+        "# Mixed\n\n"
+        "TODO: needs a real value here.\n\n"
+        "But `todo!()` inside backticks is fine.\n\n"
+        "```\nplaceholder text in fenced code stays silent\n```\n",
+        encoding="utf-8",
+    )
+
+    report = audit_docs(repo_root=tmp_path, docs_dir="docs")
+    assert report["unfinished_marker_total"] == 1
+    assert report["files_with_findings"] == 1


### PR DESCRIPTION
## Summary
- strips fenced code blocks and inline code before docs-finish scanning
- prevents code examples like `todo!()` or `M[i,j](op)` from counting as unfinished work or broken local links
- reduces current `npm run docs:check` output to 3 finding files and 0 broken local links

## Test evidence
- `python -m pytest tests/system/test_docs_finish_audit.py -q`
- `npm run docs:check`
- `python -m black --check --target-version py311 --line-length 120 scripts/system/docs_finish_audit.py tests/system/test_docs_finish_audit.py`
- `python scripts/security/code_governance_gate.py check-push`

## Rollback
- revert `scripts/system/docs_finish_audit.py` and `tests/system/test_docs_finish_audit.py`