### PR TITLE
fix(docs): remove Terax EOF whitespace

### DIFF
--- a/docs/research/TERAX_AI_TERMINAL_REFERENCE.md
+++ b/docs/research/TERAX_AI_TERMINAL_REFERENCE.md
@@ -160,4 +160,3 @@ model:
 
 This is the shortest path from SCBE's current backend strength to a product
 surface a buyer can understand.
-

--- a/docs/specs/AETHERDESK_OPERATOR_SHELL_v0.md
+++ b/docs/specs/AETHERDESK_OPERATOR_SHELL_v0.md
@@ -148,4 +148,3 @@ SCBE's wedge is different:
 
 That lets SCBE sell governance and repeatability instead of competing only on
 chat UX.
-


### PR DESCRIPTION
## Summary
- removes trailing blank EOF lines from the Terax research note and AetherDesk operator shell spec
- follow-up cleanup after #1637 auto-merged before the whitespace fix landed

## Test evidence
- git diff --check