### PR TITLE
fix(geoseal): block code-roundtrip from public HTTP bridge

### DIFF
--- a/src/api/geoseal_service.py
+++ b/src/api/geoseal_service.py
@@ -23,7 +23,6 @@ GEOSEAL_CLI_COMMANDS = frozenset(
         "replay",
         "testing-cli",
         "project-scaffold",
-        "code-roundtrip",
     }
 )
 
@@ -160,7 +159,6 @@ async def spaceport_status() -> dict[str, Any]:
                     "/v1/geoseal/replay",
                     "/v1/geoseal/testing-cli",
                     "/v1/geoseal/project-scaffold",
-                    "/v1/geoseal/code-roundtrip",
                 ],
                 "authenticated_runtime": [
                     "/runtime/inspect",

--- a/tests/test_agent_task_run_and_external_eval.py
+++ b/tests/test_agent_task_run_and_external_eval.py
@@ -213,6 +213,21 @@ def test_geoseal_service_cli_bridge_code_packet():
     assert "native_tokenization" in body["data"] or "transport_tokens" in body["data"]
 
 
+
+
+def test_geoseal_service_cli_bridge_blocks_code_roundtrip_over_http():
+    from fastapi.testclient import TestClient
+
+    from src.api.geoseal_service import app
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/geoseal/code-roundtrip",
+        json={"content": 'fn main() { println!("blocked"); }', "lang": "rust", "execute": True},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Unknown GeoSeal command: code-roundtrip"
+
 def test_external_eval_manifest_validates():
     module = load_module(
         REPO_ROOT / "scripts" / "benchmark" / "external_agentic_eval_driver.py",


### PR DESCRIPTION
### Motivation
- The HTTP-exposed GeoSeal bridge advertised and allowed the `code-roundtrip` command over `/v1/geoseal/{command}`, which can compile and execute attacker-supplied Rust when `execute=true`, creating an unauthenticated RCE surface. 

### Description
- Removed `"code-roundtrip"` from `GEOSEAL_CLI_COMMANDS` in `src/api/geoseal_service.py` so it cannot be dispatched via the public `/v1/geoseal/{command}` bridge.  
- Removed `/v1/geoseal/code-roundtrip` from the `auth_split.public_read` status payload in `src/api/geoseal_service.py` so the service no longer advertises it as a public-read endpoint.  
- Added a regression test `test_geoseal_service_cli_bridge_blocks_code_roundtrip_over_http` to `tests/test_agent_task_run_and_external_eval.py` which asserts that POSTing to `/v1/geoseal/code-roundtrip` returns `404` with `Unknown GeoSeal command`. 

### Testing
- Ran `pytest tests/test_agent_task_run_and_external_eval.py -k blocks_code_roundtrip_over_http -q` and the new regression test passed.  
- Ran `pytest tests/test_agent_task_run_and_external_eval.py -k geoseal_service_cli_bridge -q` and observed one unrelated pre-existing environment compatibility failure: `ImportError: cannot import name 'UTC' from 'datetime'` in `python/scbe/ingestion_rights.py`.  
- The change is minimal and isolates the dangerous command from the unauthenticated HTTP surface while preserving the other public GeoSeal CLI endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30b8d1f708322ac89dc5628cbadad)