### PR TITLE
feat(aetherdesk): operator shell v0 — buttons + receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ scripts/*.bak
 artifacts/npm-pack/
 artifacts/shopify-both-side/
 artifacts/social/
+artifacts/aetherdesk_receipts/
 
 artifacts/
 *.gif

--- a/aetherdesk/README.md
+++ b/aetherdesk/README.md
@@ -1,0 +1,71 @@
+# AetherDesk Operator Shell v0
+
+Local-only operator console for the SCBE-AETHERMOORE backend. Implements the
+v0 slice of [`docs/specs/AETHERDESK_OPERATOR_SHELL_v0.md`](../docs/specs/AETHERDESK_OPERATOR_SHELL_v0.md):
+the **Terminal Task Pane** + the **GeoSeal Receipt Pane**.
+
+## Run it
+
+```
+npm run aetherdesk
+```
+
+Open `http://127.0.0.1:5717` in any browser. The server binds to 127.0.0.1
+only — there is no remote attack surface.
+
+Override port with `AETHERDESK_PORT=NNNN` if 5717 collides with something.
+
+## What it does (v0)
+
+- Lists the five known-good commands from the spec as runnable buttons.
+- Spawns each via `npm run <script>` against the existing repo.
+- Captures exit code, stdout/stderr tails (8 KB each), and timing.
+- Writes a `aetherdesk_receipt_v0` JSON to
+  `artifacts/aetherdesk_receipts/` per run.
+- Lists recent receipts in the right pane; click to expand.
+
+## What it intentionally does NOT do (v0)
+
+- No arbitrary command execution. The allowlist in `server.js` is the
+  security boundary — anything not on it returns HTTP 400.
+- No file-write access from the UI. The Diff/Patch Pane is v0.1.
+- No agent-bus invocation from the UI. The Agent Bus Pane is v0.1.
+- No provider status checks. The Provider Status Pane is v0.1.
+
+## Receipt schema
+
+```json
+{
+  "schema": "aetherdesk_receipt_v0",
+  "task_id": "20260510T180000Z_typecheck",
+  "command_id": "typecheck",
+  "command_label": "Typecheck (TypeScript)",
+  "command": "npm run typecheck",
+  "command_digest": "<sha256 of command string>",
+  "risk_tier": "read-only",
+  "allowed_paths": ["<repo-readonly>"],
+  "started_at": "...",
+  "finished_at": "...",
+  "duration_ms": 12345,
+  "exit_code": 0,
+  "result": "pass",
+  "stdout_tail": "...",
+  "stderr_tail": "...",
+  "artifact_path": "artifacts/aetherdesk_receipts/20260510T180000Z_typecheck.json"
+}
+```
+
+## Test surface
+
+```
+npx vitest run tests/aetherdesk/server.test.ts
+```
+
+17 tests cover allowlist enforcement, receipt schema, on-disk round-trip,
+and path-traversal rejection.
+
+## Known v0 limitation
+
+The `Coding-agent benchmark` button will run but cannot fully score the
+TypeScript scenarios — the harness expects `scripts/run_typescript_debug_scenario.cjs`
+which does not exist yet. See the spec's "Immediate Technical Debt" section.

--- a/aetherdesk/public/index.html
+++ b/aetherdesk/public/index.html
@@ -1,0 +1,338 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AetherDesk Operator Shell v0</title>
+    <style>
+      :root {
+        --bg: #0b0d12;
+        --panel: #11161f;
+        --border: rgba(214, 167, 86, 0.25);
+        --text: #f2f0ea;
+        --muted: #8a8b8c;
+        --accent: #d6a756;
+        --pass: #7ed99c;
+        --fail: #e88080;
+        --running: #8cc7e8;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: 'JetBrains Mono', Consolas, Menlo, monospace;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.5;
+      }
+      header {
+        padding: 14px 22px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 18px;
+        color: var(--accent);
+        letter-spacing: 0.5px;
+      }
+      header .sub {
+        color: var(--muted);
+        font-size: 12px;
+      }
+      main {
+        display: grid;
+        grid-template-columns: minmax(320px, 1fr) minmax(360px, 1fr);
+        gap: 0;
+        height: calc(100vh - 53px);
+      }
+      .panel {
+        padding: 18px 22px;
+        overflow-y: auto;
+      }
+      .panel + .panel {
+        border-left: 1px solid var(--border);
+      }
+      .panel h2 {
+        margin: 0 0 12px 0;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--accent);
+      }
+      .commands {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .cmd {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 12px 14px;
+      }
+      .cmd-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+      }
+      .cmd-label {
+        font-weight: 600;
+        font-size: 14px;
+      }
+      .cmd-tier {
+        font-size: 10px;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+      }
+      .cmd-desc {
+        margin: 6px 0 10px 0;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .cmd-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+      }
+      .cmd-script {
+        font-size: 11px;
+        color: var(--muted);
+      }
+      button.run {
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+        border-radius: 4px;
+        padding: 4px 12px;
+        font-family: inherit;
+        font-size: 12px;
+        cursor: pointer;
+      }
+      button.run:hover {
+        background: var(--accent);
+        color: var(--bg);
+      }
+      button.run:disabled {
+        opacity: 0.4;
+        cursor: wait;
+      }
+      .status {
+        font-size: 11px;
+        margin-top: 8px;
+        color: var(--muted);
+      }
+      .status.pass {
+        color: var(--pass);
+      }
+      .status.fail {
+        color: var(--fail);
+      }
+      .status.running {
+        color: var(--running);
+      }
+      .receipts {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .receipt {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 8px 12px;
+        cursor: pointer;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 4px 12px;
+      }
+      .receipt:hover {
+        border-color: var(--accent);
+      }
+      .receipt.selected {
+        border-color: var(--accent);
+      }
+      .receipt-label {
+        font-size: 13px;
+      }
+      .receipt-meta {
+        font-size: 10px;
+        color: var(--muted);
+        text-align: right;
+      }
+      .receipt-result {
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+      }
+      .receipt-result.pass {
+        color: var(--pass);
+      }
+      .receipt-result.fail {
+        color: var(--fail);
+      }
+      .detail {
+        margin-top: 14px;
+        padding: 12px;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        font-size: 11px;
+      }
+      .detail h3 {
+        margin: 0 0 8px 0;
+        font-size: 12px;
+        color: var(--accent);
+      }
+      .detail pre {
+        margin: 6px 0 0 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+        max-height: 280px;
+        overflow-y: auto;
+        background: var(--bg);
+        padding: 8px;
+        border-radius: 3px;
+        font-size: 11px;
+      }
+      .empty {
+        color: var(--muted);
+        font-size: 12px;
+        font-style: italic;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>AetherDesk</h1>
+      <span class="sub">Operator Shell v0 — local only · 127.0.0.1</span>
+    </header>
+    <main>
+      <section class="panel">
+        <h2>Terminal Task Pane</h2>
+        <div id="commands" class="commands"><p class="empty">loading...</p></div>
+      </section>
+      <section class="panel">
+        <h2>GeoSeal Receipts</h2>
+        <div id="receipts" class="receipts"><p class="empty">no runs yet</p></div>
+        <div id="detail"></div>
+      </section>
+    </main>
+
+    <script>
+      const $ = (sel) => document.querySelector(sel);
+      const cmdsEl = $('#commands');
+      const receiptsEl = $('#receipts');
+      const detailEl = $('#detail');
+
+      async function loadCommands() {
+        const r = await fetch('/api/commands').then((r) => r.json());
+        cmdsEl.innerHTML = '';
+        for (const c of r.commands) {
+          const div = document.createElement('div');
+          div.className = 'cmd';
+          div.innerHTML = `
+            <div class="cmd-head">
+              <div class="cmd-label">${c.label}</div>
+              <div class="cmd-tier">${c.risk_tier}</div>
+            </div>
+            <div class="cmd-desc">${c.description}</div>
+            <div class="cmd-row">
+              <code class="cmd-script">npm run ${c.npm_script}</code>
+              <button class="run" data-id="${c.id}">Run</button>
+            </div>
+            <div class="status" id="status-${c.id}"></div>
+          `;
+          cmdsEl.appendChild(div);
+        }
+        cmdsEl.querySelectorAll('button.run').forEach((b) => {
+          b.addEventListener('click', () => runCommand(b.dataset.id, b));
+        });
+      }
+
+      async function loadReceipts() {
+        const r = await fetch('/api/receipts').then((r) => r.json());
+        if (!r.receipts.length) {
+          receiptsEl.innerHTML = '<p class="empty">no runs yet</p>';
+          return;
+        }
+        receiptsEl.innerHTML = '';
+        for (const rec of r.receipts) {
+          const div = document.createElement('div');
+          div.className = 'receipt';
+          const dur = rec.duration_ms ? Math.round(rec.duration_ms / 1000) + 's' : '';
+          div.innerHTML = `
+            <div>
+              <div class="receipt-label">${rec.command_label || rec.command_id}</div>
+              <div class="receipt-meta">${rec.started_at || ''} · ${dur}</div>
+            </div>
+            <div class="receipt-result ${rec.result}">${rec.result}</div>
+          `;
+          div.addEventListener('click', () => showReceipt(rec.file, div));
+          receiptsEl.appendChild(div);
+        }
+      }
+
+      async function showReceipt(file, el) {
+        receiptsEl.querySelectorAll('.receipt').forEach((d) => d.classList.remove('selected'));
+        el.classList.add('selected');
+        const r = await fetch('/api/receipts/' + encodeURIComponent(file)).then((r) => r.json());
+        if (!r.ok) {
+          detailEl.innerHTML = '<p class="empty">receipt not found</p>';
+          return;
+        }
+        const rec = r.receipt;
+        detailEl.innerHTML = `
+          <div class="detail">
+            <h3>${rec.command_label}</h3>
+            <div>task_id: ${rec.task_id}</div>
+            <div>command: <code>${rec.command}</code></div>
+            <div>digest: ${rec.command_digest.slice(0, 16)}...</div>
+            <div>result: <span class="receipt-result ${rec.result}">${rec.result}</span> (exit ${rec.exit_code})</div>
+            <div>duration: ${Math.round(rec.duration_ms / 1000)}s</div>
+            <div>artifact: ${rec.artifact_path}</div>
+            <h3 style="margin-top:10px">stdout (tail)</h3>
+            <pre>${(rec.stdout_tail || '(empty)').replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' })[c])}</pre>
+            <h3 style="margin-top:10px">stderr (tail)</h3>
+            <pre>${(rec.stderr_tail || '(empty)').replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' })[c])}</pre>
+          </div>
+        `;
+      }
+
+      async function runCommand(id, btn) {
+        const status = $('#status-' + id);
+        btn.disabled = true;
+        status.textContent = 'running...';
+        status.className = 'status running';
+        try {
+          const r = await fetch('/api/run/' + encodeURIComponent(id), { method: 'POST' }).then(
+            (r) => r.json()
+          );
+          if (!r.ok) {
+            status.textContent = 'error: ' + (r.error || 'unknown');
+            status.className = 'status fail';
+          } else {
+            status.textContent = `${r.receipt.result} (exit ${r.receipt.exit_code}, ${Math.round(r.receipt.duration_ms / 1000)}s)`;
+            status.className = 'status ' + r.receipt.result;
+          }
+        } catch (err) {
+          status.textContent = 'fetch error: ' + String(err);
+          status.className = 'status fail';
+        } finally {
+          btn.disabled = false;
+          loadReceipts();
+        }
+      }
+
+      loadCommands();
+      loadReceipts();
+      setInterval(loadReceipts, 5000);
+    </script>
+  </body>
+</html>

--- a/aetherdesk/server.js
+++ b/aetherdesk/server.js
@@ -1,0 +1,294 @@
+'use strict';
+
+/**
+ * AetherDesk Operator Shell v0 — local server
+ *
+ * Binds to 127.0.0.1:5717 only. Exposes a small set of allowlisted
+ * "known-good command" routes from docs/specs/AETHERDESK_OPERATOR_SHELL_v0.md.
+ * Every command run writes a GeoSeal-shaped receipt to
+ * artifacts/aetherdesk_receipts/ that the UI can list and re-open.
+ *
+ * Non-goals (v0):
+ *   - No arbitrary command execution. The allowlist is the security boundary.
+ *   - No remote access. The bind address is hardcoded to 127.0.0.1.
+ *   - No secrets in receipts. stderr/stdout tails are truncated.
+ */
+
+const express = require('express');
+const { spawn } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const RECEIPTS_DIR = path.join(REPO_ROOT, 'artifacts', 'aetherdesk_receipts');
+const PORT = Number(process.env.AETHERDESK_PORT || 5717);
+const HOST = '127.0.0.1';
+const MAX_OUTPUT_TAIL_BYTES = 8192;
+const COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
+
+// The allowlist is the security boundary. Every entry is a {npm, script}
+// reference resolved against package.json scripts. Frontend cannot pass a
+// raw shell string; it can only ask to run one of these IDs.
+const COMMAND_ALLOWLIST = Object.freeze({
+  typecheck: {
+    label: 'Typecheck (TypeScript)',
+    npmScript: 'typecheck',
+    risk_tier: 'read-only',
+    description: 'tsc --noEmit — no files are written.',
+  },
+  ts_tests: {
+    label: 'TS tests (vitest)',
+    npmScript: 'test',
+    risk_tier: 'read-only',
+    description: 'Run the full Vitest suite.',
+  },
+  benchmark_cli: {
+    label: 'CLI benchmark',
+    npmScript: 'benchmark:cli',
+    risk_tier: 'read-only',
+    description: 'Run scripts/benchmark/cli_competitive_benchmark.py.',
+  },
+  research_aether_lattice: {
+    label: 'Aether-Lattice sim',
+    npmScript: 'research:aether-lattice',
+    risk_tier: 'read-only',
+    description: 'Run the Aether-Lattice containment simulator (deterministic seed=42).',
+  },
+  benchmark_coding_agents: {
+    label: 'Coding-agent benchmark',
+    npmScript: 'benchmark:coding-agents',
+    risk_tier: 'read-only',
+    description:
+      'Run scripts/eval/functional_coding_agent_benchmark.py. Note: TS scenario runner is missing per spec; see AETHERDESK_OPERATOR_SHELL_v0.md.',
+  },
+});
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function utcStamp() {
+  return new Date().toISOString().replace(/[-:]/g, '').replace(/\..*/, 'Z');
+}
+
+function sha256(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function tailBytes(str, max) {
+  if (str.length <= max) return str;
+  return '...[truncated]...\n' + str.slice(str.length - max);
+}
+
+function buildReceipt({
+  commandId,
+  command,
+  exitCode,
+  stdoutTail,
+  stderrTail,
+  startedAt,
+  finishedAt,
+  artifactPath,
+}) {
+  const entry = COMMAND_ALLOWLIST[commandId];
+  const result = exitCode === 0 ? 'pass' : 'fail';
+  const commandStr = `npm run ${entry.npmScript}`;
+  return {
+    schema: 'aetherdesk_receipt_v0',
+    task_id: `${utcStamp()}_${commandId}`,
+    command_id: commandId,
+    command_label: entry.label,
+    command: commandStr,
+    command_digest: sha256(Buffer.from(commandStr, 'utf8')),
+    risk_tier: entry.risk_tier,
+    allowed_paths: ['<repo-readonly>'],
+    started_at: startedAt,
+    finished_at: finishedAt,
+    duration_ms: new Date(finishedAt).getTime() - new Date(startedAt).getTime(),
+    exit_code: exitCode,
+    result,
+    stdout_tail: stdoutTail,
+    stderr_tail: stderrTail,
+    artifact_path: artifactPath,
+  };
+}
+
+function receiptFilename(receipt) {
+  return `${receipt.task_id}.json`;
+}
+
+function writeReceipt(receipt) {
+  ensureDir(RECEIPTS_DIR);
+  const filePath = path.join(RECEIPTS_DIR, receiptFilename(receipt));
+  fs.writeFileSync(filePath, JSON.stringify(receipt, null, 2) + '\n');
+  return filePath;
+}
+
+function listReceipts(limit = 50) {
+  if (!fs.existsSync(RECEIPTS_DIR)) return [];
+  const files = fs
+    .readdirSync(RECEIPTS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .reverse()
+    .slice(0, limit);
+  return files.map((f) => {
+    const full = path.join(RECEIPTS_DIR, f);
+    try {
+      const r = JSON.parse(fs.readFileSync(full, 'utf8'));
+      return {
+        task_id: r.task_id,
+        command_id: r.command_id,
+        command_label: r.command_label,
+        result: r.result,
+        exit_code: r.exit_code,
+        started_at: r.started_at,
+        duration_ms: r.duration_ms,
+        file: f,
+      };
+    } catch (_err) {
+      return { task_id: f, command_id: 'unknown', result: 'unreadable', file: f };
+    }
+  });
+}
+
+function readReceipt(file) {
+  // Strict: only allow simple filenames — no path separators, no traversal.
+  if (!/^[A-Za-z0-9_.-]+\.json$/.test(file)) return null;
+  const full = path.join(RECEIPTS_DIR, file);
+  if (!fs.existsSync(full)) return null;
+  return JSON.parse(fs.readFileSync(full, 'utf8'));
+}
+
+function runCommand(commandId) {
+  return new Promise((resolve) => {
+    const entry = COMMAND_ALLOWLIST[commandId];
+    if (!entry) {
+      return resolve({ ok: false, error: 'command not allowlisted' });
+    }
+    const startedAt = new Date().toISOString();
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    const child = spawn('npm', ['run', entry.npmScript], {
+      cwd: REPO_ROOT,
+      env: process.env,
+      shell: process.platform === 'win32',
+    });
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGTERM');
+      } catch (_err) {
+        /* swallow */
+      }
+    }, COMMAND_TIMEOUT_MS);
+    child.stdout.on('data', (d) => stdoutChunks.push(d.toString('utf8')));
+    child.stderr.on('data', (d) => stderrChunks.push(d.toString('utf8')));
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const finishedAt = new Date().toISOString();
+      const stdout = stdoutChunks.join('');
+      const stderr = stderrChunks.join('');
+      const receipt = buildReceipt({
+        commandId,
+        exitCode: code,
+        stdoutTail: tailBytes(stdout, MAX_OUTPUT_TAIL_BYTES),
+        stderrTail: tailBytes(stderr, MAX_OUTPUT_TAIL_BYTES),
+        startedAt,
+        finishedAt,
+        artifactPath: null,
+      });
+      const filePath = writeReceipt(receipt);
+      receipt.artifact_path = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+      resolve({ ok: true, receipt });
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      const finishedAt = new Date().toISOString();
+      const receipt = buildReceipt({
+        commandId,
+        exitCode: -1,
+        stdoutTail: '',
+        stderrTail: `[spawn error] ${String(err && err.message ? err.message : err)}`,
+        startedAt,
+        finishedAt,
+        artifactPath: null,
+      });
+      const filePath = writeReceipt(receipt);
+      receipt.artifact_path = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+      resolve({ ok: true, receipt });
+    });
+  });
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ limit: '64kb' }));
+  app.use(express.static(path.join(__dirname, 'public')));
+
+  app.get('/api/health', (_req, res) => {
+    res.json({ ok: true, schema: 'aetherdesk_health_v0', port: PORT, host: HOST });
+  });
+
+  app.get('/api/commands', (_req, res) => {
+    const items = Object.entries(COMMAND_ALLOWLIST).map(([id, entry]) => ({
+      id,
+      label: entry.label,
+      npm_script: entry.npmScript,
+      risk_tier: entry.risk_tier,
+      description: entry.description,
+    }));
+    res.json({ ok: true, schema: 'aetherdesk_commands_v0', commands: items });
+  });
+
+  app.get('/api/receipts', (req, res) => {
+    const limit = Math.max(1, Math.min(200, Number(req.query.limit || 50)));
+    res.json({ ok: true, schema: 'aetherdesk_receipt_list_v0', receipts: listReceipts(limit) });
+  });
+
+  app.get('/api/receipts/:file', (req, res) => {
+    const r = readReceipt(req.params.file);
+    if (!r) return res.status(404).json({ ok: false, error: 'receipt not found' });
+    res.json({ ok: true, receipt: r });
+  });
+
+  app.post('/api/run/:command_id', async (req, res) => {
+    const id = String(req.params.command_id || '');
+    if (!Object.prototype.hasOwnProperty.call(COMMAND_ALLOWLIST, id)) {
+      return res.status(400).json({ ok: false, error: 'command not allowlisted', command_id: id });
+    }
+    const result = await runCommand(id);
+    if (!result.ok) return res.status(500).json(result);
+    res.json(result);
+  });
+
+  return app;
+}
+
+function main() {
+  const app = buildApp();
+  const server = app.listen(PORT, HOST, () => {
+    // eslint-disable-next-line no-console
+    console.log(`AetherDesk Operator Shell v0 — http://${HOST}:${PORT}`);
+    // eslint-disable-next-line no-console
+    console.log(`Receipts: ${path.relative(REPO_ROOT, RECEIPTS_DIR)}`);
+  });
+  return server;
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildApp,
+  COMMAND_ALLOWLIST,
+  buildReceipt,
+  listReceipts,
+  readReceipt,
+  writeReceipt,
+  RECEIPTS_DIR,
+  HOST,
+  PORT,
+  _private: { tailBytes, sha256, runCommand },
+};

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "benchmark:coding-agents:compare": "python scripts/eval/compare_functional_benchmark_reports.py",
     "benchmark:coding-agents:gate": "python scripts/eval/gate_functional_benchmark.py",
     "benchmark:cli": "python scripts/benchmark/cli_competitive_benchmark.py",
+    "aetherdesk": "node aetherdesk/server.js",
     "benchmark:representation-kaleidoscope": "python scripts/benchmark/build_representation_kaleidoscope.py",
     "benchmark:agentic:external": "python scripts/benchmark/external_agentic_eval_driver.py",
     "training:adapter-registry": "python scripts/model_training/build_adapter_registry.py",

--- a/tests/aetherdesk/server.test.ts
+++ b/tests/aetherdesk/server.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as http from 'http';
+import { AddressInfo } from 'net';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const aetherdesk = require('../../aetherdesk/server.js');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const RECEIPTS_DIR = path.join(REPO_ROOT, 'artifacts', 'aetherdesk_receipts');
+
+let server: http.Server;
+let baseUrl: string;
+
+function fetchJson(url: string, init?: RequestInit) {
+  return fetch(url, init).then((r) => r.json().then((b) => ({ status: r.status, body: b })));
+}
+
+beforeEach(async () => {
+  const app = aetherdesk.buildApp();
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('AetherDesk server — health + introspection', () => {
+  it('GET /api/health returns ok', async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/health`);
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.schema).toBe('aetherdesk_health_v0');
+  });
+
+  it('GET /api/commands lists all five spec commands', async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/commands`);
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.schema).toBe('aetherdesk_commands_v0');
+    const ids = body.commands.map((c: { id: string }) => c.id).sort();
+    expect(ids).toEqual([
+      'benchmark_cli',
+      'benchmark_coding_agents',
+      'research_aether_lattice',
+      'ts_tests',
+      'typecheck',
+    ]);
+  });
+
+  it('every command surface includes label, npm_script, risk_tier, description', async () => {
+    const { body } = await fetchJson(`${baseUrl}/api/commands`);
+    for (const c of body.commands) {
+      expect(typeof c.label).toBe('string');
+      expect(typeof c.npm_script).toBe('string');
+      expect(typeof c.risk_tier).toBe('string');
+      expect(typeof c.description).toBe('string');
+      expect(c.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('AetherDesk server — allowlist enforcement (security boundary)', () => {
+  it('POST /api/run/<known> resolves to a known command id without spawning', async () => {
+    // We don't actually invoke runCommand here (it spawns npm). We verify
+    // that the allowlist export contains exactly the spec's five entries.
+    const ids = Object.keys(aetherdesk.COMMAND_ALLOWLIST).sort();
+    expect(ids).toEqual([
+      'benchmark_cli',
+      'benchmark_coding_agents',
+      'research_aether_lattice',
+      'ts_tests',
+      'typecheck',
+    ]);
+  });
+
+  it('POST /api/run/<unknown> rejects with 400 and does not run anything', async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/run/rm_dash_rf`, { method: 'POST' });
+    expect(status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/not allowlisted/i);
+    expect(body.command_id).toBe('rm_dash_rf');
+  });
+
+  it('POST /api/run/<shell-injection-attempt> rejects with 400', async () => {
+    const malicious = encodeURIComponent('typecheck; rm -rf /');
+    const { status, body } = await fetchJson(`${baseUrl}/api/run/${malicious}`, { method: 'POST' });
+    expect(status).toBe(400);
+    expect(body.ok).toBe(false);
+  });
+
+  it('POST /api/run/<prototype-pollution-attempt> rejects with 400', async () => {
+    // Object.prototype.hasOwnProperty test: __proto__ MUST NOT be treated
+    // as an allowlisted command even though it lives on Object.prototype.
+    const { status, body } = await fetchJson(`${baseUrl}/api/run/__proto__`, { method: 'POST' });
+    expect(status).toBe(400);
+    expect(body.ok).toBe(false);
+  });
+});
+
+describe('AetherDesk server — receipt schema + listing', () => {
+  it('buildReceipt produces an aetherdesk_receipt_v0 with the required fields', () => {
+    const r = aetherdesk.buildReceipt({
+      commandId: 'typecheck',
+      exitCode: 0,
+      stdoutTail: 'ok',
+      stderrTail: '',
+      startedAt: '2026-05-10T12:00:00.000Z',
+      finishedAt: '2026-05-10T12:00:01.500Z',
+      artifactPath: null,
+    });
+    expect(r.schema).toBe('aetherdesk_receipt_v0');
+    expect(r.command_id).toBe('typecheck');
+    expect(r.command).toBe('npm run typecheck');
+    expect(r.command_digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(r.exit_code).toBe(0);
+    expect(r.result).toBe('pass');
+    expect(r.duration_ms).toBe(1500);
+    expect(r.risk_tier).toBe('read-only');
+    expect(r.allowed_paths).toEqual(['<repo-readonly>']);
+    expect(r.task_id).toMatch(/_typecheck$/);
+  });
+
+  it('non-zero exit code maps to result=fail', () => {
+    const r = aetherdesk.buildReceipt({
+      commandId: 'typecheck',
+      exitCode: 1,
+      stdoutTail: '',
+      stderrTail: 'TS2322 error',
+      startedAt: '2026-05-10T12:00:00.000Z',
+      finishedAt: '2026-05-10T12:00:00.500Z',
+      artifactPath: null,
+    });
+    expect(r.exit_code).toBe(1);
+    expect(r.result).toBe('fail');
+  });
+
+  it('GET /api/receipts returns a list bounded by limit', async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/receipts?limit=5`);
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.schema).toBe('aetherdesk_receipt_list_v0');
+    expect(Array.isArray(body.receipts)).toBe(true);
+    expect(body.receipts.length).toBeLessThanOrEqual(5);
+  });
+
+  it('GET /api/receipts/<traversal-attempt> rejects', async () => {
+    const malicious = encodeURIComponent('../../../etc/passwd');
+    const { status, body } = await fetchJson(`${baseUrl}/api/receipts/${malicious}`);
+    expect(status).toBe(404);
+    expect(body.ok).toBe(false);
+  });
+
+  it('GET /api/receipts/<bad-name> rejects (no path traversal, only safe chars)', async () => {
+    const { status } = await fetchJson(`${baseUrl}/api/receipts/some%2Fnested%2Ffile.json`);
+    expect(status).toBe(404);
+  });
+});
+
+describe('AetherDesk server — receipt round-trip on disk', () => {
+  it('writeReceipt + listReceipts + readReceipt round-trips a receipt', () => {
+    const r = aetherdesk.buildReceipt({
+      commandId: 'typecheck',
+      exitCode: 0,
+      stdoutTail: 'all good',
+      stderrTail: '',
+      startedAt: '2026-05-10T12:00:00.000Z',
+      finishedAt: '2026-05-10T12:00:00.250Z',
+      artifactPath: null,
+    });
+    const filePath = aetherdesk.writeReceipt(r);
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const list = aetherdesk.listReceipts(50);
+    const found = list.find((x: { task_id: string }) => x.task_id === r.task_id);
+    expect(found).toBeTruthy();
+
+    const file = path.basename(filePath);
+    const readBack = aetherdesk.readReceipt(file);
+    expect(readBack).toBeTruthy();
+    expect(readBack.task_id).toBe(r.task_id);
+    expect(readBack.command_digest).toBe(r.command_digest);
+
+    // Cleanup
+    fs.unlinkSync(filePath);
+  });
+
+  it('readReceipt rejects names with separators or traversal', () => {
+    expect(aetherdesk.readReceipt('../etc/passwd')).toBeNull();
+    expect(aetherdesk.readReceipt('foo/bar.json')).toBeNull();
+    expect(aetherdesk.readReceipt('foo\\bar.json')).toBeNull();
+  });
+});
+
+describe('AetherDesk server — output truncation', () => {
+  it('tailBytes truncates oversized output and adds a marker', () => {
+    const big = 'A'.repeat(20000);
+    const tail = aetherdesk._private.tailBytes(big, 8192);
+    expect(tail.length).toBeLessThan(big.length);
+    expect(tail).toMatch(/truncated/);
+    expect(tail.endsWith('A'.repeat(100))).toBe(true);
+  });
+
+  it('tailBytes leaves small output untouched', () => {
+    const small = 'B'.repeat(100);
+    expect(aetherdesk._private.tailBytes(small, 8192)).toBe(small);
+  });
+});
+
+// Smoke marker: confirm the receipts dir is created on demand under artifacts/
+describe('AetherDesk server — receipts directory', () => {
+  it('RECEIPTS_DIR resolves under artifacts/', () => {
+    expect(aetherdesk.RECEIPTS_DIR.replace(/\\/g, '/')).toMatch(/artifacts\/aetherdesk_receipts$/);
+    expect(aetherdesk.RECEIPTS_DIR.startsWith(REPO_ROOT)).toBe(true);
+    expect(RECEIPTS_DIR).toBe(aetherdesk.RECEIPTS_DIR);
+  });
+});


### PR DESCRIPTION
## Summary

First implementation slice of [\`docs/specs/AETHERDESK_OPERATOR_SHELL_v0.md\`](docs/specs/AETHERDESK_OPERATOR_SHELL_v0.md). Ships the two panels the spec called out as v0 — **Terminal Task Pane** and **GeoSeal Receipt Pane** — and defers Agent Bus, Diff/Patch, and Provider Status to v0.1.

## What ships

| Surface | Details |
|---|---|
| \`aetherdesk/server.js\` | Tiny Express server, binds to \`127.0.0.1:5717\` only. No remote attack surface. |
| \`aetherdesk/public/index.html\` | Static, framework-free UI. Left pane: five command buttons. Right pane: receipt list + click-to-expand detail. |
| \`tests/aetherdesk/server.test.ts\` | 17 tests covering allowlist enforcement, receipt schema, on-disk round-trip, path-traversal rejection. |
| \`npm run aetherdesk\` | Starts the server. \`AETHERDESK_PORT\` env overrides default. |

## The five known-good commands

Match the spec's \"Initial buttons\" list 1:1. Each maps to an existing npm script — no new backend code.

| Button | Maps to |
|---|---|
| Typecheck (TypeScript) | \`npm run typecheck\` |
| TS tests (vitest) | \`npm test\` |
| CLI benchmark | \`npm run benchmark:cli\` |
| Aether-Lattice sim | \`npm run research:aether-lattice\` |
| Coding-agent benchmark | \`npm run benchmark:coding-agents\` |

## Receipt schema (\`aetherdesk_receipt_v0\`)

Every run writes a JSON receipt to \`artifacts/aetherdesk_receipts/\` with: \`task_id\`, \`command_digest\` (sha256), \`risk_tier\`, \`allowed_paths\`, \`started_at\`/\`finished_at\`, \`duration_ms\`, \`exit_code\`, \`result\` (pass/fail), 8 KB \`stdout_tail\` + \`stderr_tail\`. Receipts are git-ignored (per-run artifacts, not source).

## Security boundary

The allowlist in \`server.js\` is the security boundary. The frontend cannot pass a raw shell string — it can only request one of five command IDs. Tested:
- Unknown command IDs → HTTP 400, no spawn.
- Shell-injection attempts (e.g. \`typecheck; rm -rf /\`) → HTTP 400.
- Prototype-pollution attempts (\`__proto__\`) → HTTP 400 (uses \`Object.prototype.hasOwnProperty.call\`).
- Receipt read with traversal (\`../../etc/passwd\`) → HTTP 404, no read.

## Test plan

- [x] \`npx vitest run tests/aetherdesk/server.test.ts\` — **17 passed**
- [x] \`npx vitest run\` — **6222 passed, 18 skipped** (zero regressions; skips are provider-credit-bound)
- [x] \`npm run typecheck\` — clean
- [x] \`npx prettier --check aetherdesk/ tests/aetherdesk/\` — clean
- [x] Live smoke: server starts on \`127.0.0.1:5717\`, \`/api/health\` + \`/api/commands\` + static HTML all respond
- [ ] After merge: run \`npm run aetherdesk\`, click each button, confirm receipts land in \`artifacts/aetherdesk_receipts/\`

## What this PR explicitly does NOT do (per spec v0)

- ❌ No agent-bus invocation from UI (v0.1)
- ❌ No file-write or diff/patch flow (v0.1)
- ❌ No provider status checks (v0.1)
- ❌ No arbitrary command execution — the allowlist is the boundary

## Known limitation

The Coding-agent benchmark button will run, but the harness cannot fully score TS scenarios until \`scripts/run_typescript_debug_scenario.cjs\` lands. The spec already flagged this as \"Immediate Technical Debt\" — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)