### PR TITLE
feat(system): read-only disk-hygiene scanners (find_home_dedup + find_regenerable_bloat)

### DIFF
--- a/scripts/system/find_home_dedup.py
+++ b/scripts/system/find_home_dedup.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Read-only home-directory duplicate-file finder.
+
+Walks a user-home subtree and reports byte-identical files grouped by
+sha256. Writes ONE artifact: a JSON report. Does NOT delete, move,
+copy, hash open, or otherwise mutate any input file.
+
+Hard-excluded paths (never descended into):
+  - Microsoft OneDrive subtree (would force file hydration on Win)
+  - .claude/ session memory (Claude Code auto-managed; corrupting it
+    breaks the session)
+  - AppData/ (Windows app state; touching is the road to ruin)
+  - any **/node_modules/, **/.git/, **/.venv/, **/dist/, **/build/,
+    **/__pycache__/, **/.pytest_cache/, **/.codex_tmp/, **/.tmp-build/
+  - any **/artifacts/aetherdesk_receipts/ (append-only governance log)
+
+Output schema: home_dedup_report_v1
+  {
+    "schema": "home_dedup_report_v1",
+    "generated_at": "...",
+    "scope_root": "...",
+    "files_scanned": int,
+    "files_hashed": int,
+    "files_skipped_too_large": int,
+    "files_skipped_too_small": int,
+    "files_skipped_unreadable": int,
+    "directories_excluded": [...],
+    "duplicate_clusters": [
+      {
+        "sha256": "...",
+        "bytes_each": int,
+        "n_copies": int,
+        "bytes_recoverable": int,   # (n-1) * bytes_each
+        "paths": [...],             # all copies, longest first
+        "suggested_keep": "...",    # canonical-ish keeper
+        "risk": "low" | "medium" | "high"
+      },
+      ...
+    ],
+    "totals": {
+      "n_clusters": int,
+      "n_redundant_files": int,
+      "bytes_recoverable_total": int
+    }
+  }
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+DEFAULT_SCOPE_ROOT = Path(r"C:\Users\issda")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "artifacts" / "dedup"
+
+# Names that should never be descended into anywhere they appear.
+EXCLUDE_DIR_NAMES: Set[str] = {
+    "OneDrive",
+    "OneDrive - Personal",
+    ".claude",
+    "AppData",
+    "node_modules",
+    ".git",
+    ".venv",
+    ".env",
+    "venv",
+    "dist",
+    "build",
+    "__pycache__",
+    ".pytest_cache",
+    ".codex_tmp",
+    ".tmp-build",
+    ".pytest_tmp_hallpass_review",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    ".gradle",
+    ".m2",
+    ".cargo",
+    ".rustup",
+    ".npm",
+    ".yarn",
+    ".nuget",
+    "site-packages",
+    # SCBE bulk dirs — millions of small training/intake artifacts that
+    # are not actionable for dedup (they're append-only by design).
+    "training-data",
+    "training-runs",
+    "training_data",
+    "intake",
+    "training",
+    "origin",
+    ".scbe",
+    "scbe-aethermoore",  # nested mirror of the repo inside itself
+    "artifacts",
+    "dropbox_brain",  # external mirror, owned elsewhere
+    ".cache",
+    ".local",
+    "Library",  # macOS-style cache dir if present
+    "Logs",
+}
+
+# Paths that should never be descended into at this exact location
+# (relative to scope root). For things that legitimately use one of the
+# names above and shouldn't be excluded, add an exception here later.
+EXCLUDE_RELATIVE_PATHS: Set[str] = {
+    "SCBE-AETHERMOORE/artifacts/aetherdesk_receipts",
+    "SCBE-AETHERMOORE/artifacts/build-tmp",
+    "SCBE-AETHERMOORE/artifacts/pytest_tmp",
+    "SCBE-AETHERMOORE/artifacts/playwright-both-side",
+    "SCBE-AETHERMOORE/artifacts/scbe_min",
+    "SCBE-AETHERMOORE/.scbe/lanes",
+    "SCBE-AETHERMOORE/.scbe/packets",
+    "SCBE-AETHERMOORE/.scbe/skill_registry",
+}
+
+# File-name extensions that are almost always either generated or where
+# duplicate detection is unhelpful. We still hash them but flag them
+# higher-risk so the user knows to think before deleting.
+GENERATED_EXTENSIONS = {".pyc", ".pyo", ".o", ".so", ".dll", ".dylib", ".class"}
+
+# We intentionally skip anything bigger than this on the first pass —
+# hashing 5GB models eats hours. The report still lists their existence.
+DEFAULT_MAX_HASH_BYTES = 500 * 1024 * 1024  # 500 MB
+
+# Files this small are almost always system config (empty markers,
+# .keep, .gitkeep, etc.) and would generate huge spurious clusters.
+DEFAULT_MIN_HASH_BYTES = 256
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+_EXCLUDE_DIR_NAMES_LOWER = {n.lower() for n in EXCLUDE_DIR_NAMES}
+
+
+def _is_excluded_dir(path: Path, scope_root: Path) -> bool:
+    # Windows file system is case-insensitive — match accordingly.
+    if path.name.lower() in _EXCLUDE_DIR_NAMES_LOWER:
+        return True
+    try:
+        rel = path.relative_to(scope_root).as_posix()
+    except ValueError:
+        return False
+    return rel in EXCLUDE_RELATIVE_PATHS
+
+
+def _walk_safely(scope_root: Path) -> Iterable[Tuple[Path, int]]:
+    """Yield (file_path, size_bytes) tuples, descending only into safe dirs.
+
+    Uses os.scandir for speed and to avoid forcing OneDrive hydration
+    of files we never open.
+    """
+    stack: List[Path] = [scope_root]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            child = Path(entry.path)
+                            if _is_excluded_dir(child, scope_root):
+                                continue
+                            stack.append(child)
+                        elif entry.is_file(follow_symlinks=False):
+                            try:
+                                size = entry.stat(follow_symlinks=False).st_size
+                            except OSError:
+                                continue
+                            yield Path(entry.path), size
+                    except (PermissionError, OSError):
+                        continue
+        except (PermissionError, OSError, NotADirectoryError):
+            continue
+
+
+def _sha256_file(path: Path, chunk_size: int = 1 << 20) -> Optional[str]:
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as fh:
+            while True:
+                chunk = fh.read(chunk_size)
+                if not chunk:
+                    break
+                h.update(chunk)
+        return h.hexdigest()
+    except (PermissionError, OSError):
+        return None
+
+
+def _suggest_keeper(paths: List[str]) -> Tuple[str, str]:
+    """Pick the canonical keeper from a list of duplicate paths.
+
+    Heuristic (low to high preference):
+      1. Inside SCBE-AETHERMOORE/origin/ replica  -> avoid (it's a mirror)
+      2. Inside .home/.agents/skills/             -> avoid
+      3. Inside artifacts/                        -> avoid
+      4. Inside src/, tests/, docs/, book/        -> prefer
+      5. Shorter path tiebreak
+    """
+
+    def rank(p: str) -> Tuple[int, int]:
+        norm = p.replace("\\", "/").lower()
+        # Higher first-element = LESS preferred
+        if "/origin/" in norm:
+            tier = 9
+        elif "/.home/.agents/skills/" in norm:
+            tier = 8
+        elif "/artifacts/" in norm:
+            tier = 7
+        elif "/training-data/" in norm or "/training-runs/" in norm:
+            tier = 6
+        elif "/src/" in norm or "/tests/" in norm or "/docs/" in norm or "/book/" in norm:
+            tier = 1
+        elif "/scbe-aethermoore/" in norm and "/scbe-aethermoore/scbe-aethermoore/" not in norm:
+            tier = 2
+        else:
+            tier = 5
+        return (tier, len(p))
+
+    best = sorted(paths, key=rank)[0]
+
+    # Reason: state which heuristic chose it
+    norm = best.replace("\\", "/").lower()
+    if "/src/" in norm or "/tests/" in norm or "/docs/" in norm or "/book/" in norm:
+        reason = "in canonical source tree (src/tests/docs/book)"
+    elif "/scbe-aethermoore/" in norm:
+        reason = "inside repo root (preferred over external mirrors)"
+    else:
+        reason = "shortest path among non-mirror candidates"
+    return best, reason
+
+
+def _classify_risk(paths: List[str]) -> str:
+    """Conservative risk class for a duplicate cluster."""
+    norms = [p.replace("\\", "/").lower() for p in paths]
+    # If any copy is under a contracts / proposal / sealed / private path,
+    # mark high-risk regardless. We never want to nudge the user toward
+    # collapsing those.
+    high_risk_substrings = (
+        "/scbe-private/",
+        "/proposals/",
+        "/contracts/",
+        "/contracting/",
+        "/dava_blind",
+        "/sealed",
+        "/.secrets/",
+        "/.ssh/",
+        "/credentials",
+        "/keys/",
+    )
+    for n in norms:
+        if any(s in n for s in high_risk_substrings):
+            return "high"
+    # Anything with an extension we know is generated -> low risk to dedupe
+    if all(Path(p).suffix.lower() in GENERATED_EXTENSIONS for p in paths):
+        return "low"
+    # If all copies are inside artifacts/ or origin/ mirrors, low risk
+    if all("/artifacts/" in n or "/origin/" in n for n in norms):
+        return "low"
+    return "medium"
+
+
+def scan(
+    scope_root: Path,
+    *,
+    min_size: int,
+    max_size: int,
+    progress_every: int = 5000,
+) -> Dict:
+    if not scope_root.exists():
+        raise FileNotFoundError(f"scope root does not exist: {scope_root}")
+
+    started_at = time.perf_counter()
+    files_scanned = 0
+    files_hashed = 0
+    files_skipped_too_large = 0
+    files_skipped_too_small = 0
+    files_skipped_unreadable = 0
+
+    # First pass: build size_groups so we only hash files that have at
+    # least one same-size sibling. This skips the vast majority of files
+    # (their size alone proves they're unique).
+    size_groups: Dict[int, List[Path]] = {}
+    print(f"[dedup] walking {scope_root} (excluding hazard dirs)", file=sys.stderr, flush=True)
+    for path, size in _walk_safely(scope_root):
+        files_scanned += 1
+        if files_scanned % progress_every == 0:
+            elapsed = time.perf_counter() - started_at
+            print(
+                f"[dedup] walked {files_scanned} files in {elapsed:.1f}s, " f"{len(size_groups)} distinct sizes",
+                file=sys.stderr,
+                flush=True,
+            )
+        if size < min_size:
+            files_skipped_too_small += 1
+            continue
+        if size > max_size:
+            files_skipped_too_large += 1
+            continue
+        size_groups.setdefault(size, []).append(path)
+
+    candidate_groups = {sz: paths for sz, paths in size_groups.items() if len(paths) > 1}
+    n_candidates = sum(len(p) for p in candidate_groups.values())
+    print(
+        f"[dedup] walk complete: {files_scanned} files, "
+        f"{n_candidates} candidates in {len(candidate_groups)} same-size groups; hashing...",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    hash_to_paths: Dict[str, List[Path]] = {}
+    for sz, paths in candidate_groups.items():
+        for p in paths:
+            digest = _sha256_file(p)
+            if digest is None:
+                files_skipped_unreadable += 1
+                continue
+            files_hashed += 1
+            hash_to_paths.setdefault(digest, []).append(p)
+            if files_hashed % 500 == 0:
+                elapsed = time.perf_counter() - started_at
+                print(
+                    f"[dedup] hashed {files_hashed} files in {elapsed:.1f}s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+    clusters: List[Dict] = []
+    n_redundant = 0
+    bytes_recoverable_total = 0
+    for digest, paths in hash_to_paths.items():
+        if len(paths) < 2:
+            continue
+        try:
+            bytes_each = paths[0].stat().st_size
+        except OSError:
+            continue
+        path_strs = sorted(str(p) for p in paths)
+        keeper, keeper_reason = _suggest_keeper(path_strs)
+        bytes_recoverable = (len(paths) - 1) * bytes_each
+        risk = _classify_risk(path_strs)
+        clusters.append(
+            {
+                "sha256": digest,
+                "bytes_each": bytes_each,
+                "n_copies": len(paths),
+                "bytes_recoverable": bytes_recoverable,
+                "paths": path_strs,
+                "suggested_keep": keeper,
+                "suggested_keep_reason": keeper_reason,
+                "risk": risk,
+            }
+        )
+        n_redundant += len(paths) - 1
+        bytes_recoverable_total += bytes_recoverable
+
+    # Sort: biggest savings first
+    clusters.sort(key=lambda c: c["bytes_recoverable"], reverse=True)
+
+    elapsed = time.perf_counter() - started_at
+    print(
+        f"[dedup] done in {elapsed:.1f}s: {len(clusters)} clusters, "
+        f"{n_redundant} redundant files, {bytes_recoverable_total / 1024 / 1024:.1f} MB recoverable",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    return {
+        "schema": "home_dedup_report_v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "scope_root": str(scope_root),
+        "files_scanned": files_scanned,
+        "files_hashed": files_hashed,
+        "files_skipped_too_large": files_skipped_too_large,
+        "files_skipped_too_small": files_skipped_too_small,
+        "files_skipped_unreadable": files_skipped_unreadable,
+        "directories_excluded": sorted(EXCLUDE_DIR_NAMES),
+        "relative_paths_excluded": sorted(EXCLUDE_RELATIVE_PATHS),
+        "min_size_bytes": min_size,
+        "max_size_bytes": max_size,
+        "duration_seconds": round(elapsed, 2),
+        "duplicate_clusters": clusters,
+        "totals": {
+            "n_clusters": len(clusters),
+            "n_redundant_files": n_redundant,
+            "bytes_recoverable_total": bytes_recoverable_total,
+        },
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--scope-root",
+        type=Path,
+        default=DEFAULT_SCOPE_ROOT,
+        help=f"directory to scan (default: {DEFAULT_SCOPE_ROOT})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"directory to write the JSON report (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    parser.add_argument(
+        "--min-size",
+        type=int,
+        default=DEFAULT_MIN_HASH_BYTES,
+        help=f"skip files smaller than N bytes (default: {DEFAULT_MIN_HASH_BYTES})",
+    )
+    parser.add_argument(
+        "--max-size",
+        type=int,
+        default=DEFAULT_MAX_HASH_BYTES,
+        help=f"skip files larger than N bytes (default: {DEFAULT_MAX_HASH_BYTES})",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=20,
+        help="how many largest-savings clusters to print to stdout (default: 20)",
+    )
+    args = parser.parse_args(argv)
+
+    report = scan(
+        args.scope_root,
+        min_size=args.min_size,
+        max_size=args.max_size,
+    )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = args.output_dir / f"dedup_report_{_utc_stamp()}.json"
+    out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    rel = (
+        out_path.relative_to(REPO_ROOT)
+        if out_path.is_absolute() and str(out_path).startswith(str(REPO_ROOT))
+        else out_path
+    )
+
+    print()
+    print(f"Report: {rel}")
+    print()
+    print(
+        f"Scanned {report['files_scanned']} files, hashed {report['files_hashed']}, "
+        f"found {report['totals']['n_clusters']} duplicate clusters covering "
+        f"{report['totals']['n_redundant_files']} redundant files."
+    )
+    print(
+        f"Bytes recoverable if all redundant copies were collapsed: "
+        f"{report['totals']['bytes_recoverable_total'] / 1024 / 1024:.1f} MB"
+    )
+    print()
+    print(f"Top {args.top} clusters by bytes recoverable:")
+    print(f"{'#':>3}  {'risk':<6}  {'copies':>6}  {'each_KB':>9}  {'recover_MB':>11}  example_paths")
+    for i, c in enumerate(report["duplicate_clusters"][: args.top], 1):
+        each_kb = c["bytes_each"] / 1024
+        recover_mb = c["bytes_recoverable"] / 1024 / 1024
+        sample = c["paths"][0]
+        if len(sample) > 70:
+            sample = "..." + sample[-67:]
+        print(f"{i:>3}  {c['risk']:<6}  {c['n_copies']:>6}  {each_kb:>9.1f}  {recover_mb:>11.2f}  {sample}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/system/find_regenerable_bloat.py
+++ b/scripts/system/find_regenerable_bloat.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Find regenerable-bloat directories and report sizes (read-only).
+
+Locates directories whose contents regenerate (node_modules, .venv, dist,
+build, __pycache__, .next, .turbo, target, etc.) and totals their bytes.
+Does NOT delete anything. Does NOT descend into OneDrive. Does NOT
+descend into the bloat dirs themselves once found (we just sum-then-skip).
+
+Output: artifacts/dedup/regenerable_bloat_<UTC>.json
+Schema: regenerable_bloat_v1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "artifacts" / "dedup"
+DEFAULT_SCOPE_ROOT = Path(r"C:\Users\issda")
+
+# Directories whose contents are regenerable. Case-insensitive match on dir name.
+REGENERABLE_DIR_NAMES = {
+    "node_modules",
+    ".venv",
+    "venv",
+    "env",
+    "dist",
+    "build",
+    "__pycache__",
+    ".next",
+    ".turbo",
+    ".nuxt",
+    ".cache",
+    ".parcel-cache",
+    "target",  # rust/cargo
+    ".gradle",  # java
+    "out",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    "site-packages",
+    ".eggs",
+    ".tmp-build",
+    ".codex_tmp",
+    ".pytest_tmp_hallpass_review",
+    "coverage",
+    ".nyc_output",
+    "playwright-report",
+    "test-results",
+}
+
+# Hard-skip these — never descend into them at all.
+HARD_SKIP_DIR_NAMES = {
+    "OneDrive",
+    "OneDrive - Personal",
+    ".claude",
+    "AppData",
+    ".git",
+    ".rustup",  # the rustup toolchain itself, not regenerable
+    ".cargo",  # cargo registry — regenerable but huge, separate handling
+    ".npm",  # npm cache — regenerable
+    ".nuget",
+    "Library",
+}
+
+_REGEN_LOWER = {n.lower() for n in REGENERABLE_DIR_NAMES}
+_HARD_SKIP_LOWER = {n.lower() for n in HARD_SKIP_DIR_NAMES}
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _dir_size_bytes(path: Path) -> Tuple[int, int]:
+    """Return (total_bytes, file_count) of everything under path. Errors swallowed."""
+    total = 0
+    count = 0
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(Path(entry.path))
+                        elif entry.is_file(follow_symlinks=False):
+                            try:
+                                total += entry.stat(follow_symlinks=False).st_size
+                                count += 1
+                            except OSError:
+                                continue
+                    except OSError:
+                        continue
+        except (PermissionError, OSError, NotADirectoryError):
+            continue
+    return total, count
+
+
+def find_bloat(scope_root: Path, *, progress_every: float = 5.0) -> List[Dict]:
+    """Walk scope_root, yielding hits at regenerable dirs (no recursion into them)."""
+    hits: List[Dict] = []
+    last_progress = time.perf_counter()
+    dirs_visited = 0
+    stack = [scope_root]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    try:
+                        if not entry.is_dir(follow_symlinks=False):
+                            continue
+                        name_lower = entry.name.lower()
+                        if name_lower in _HARD_SKIP_LOWER:
+                            continue
+                        child = Path(entry.path)
+                        if name_lower in _REGEN_LOWER:
+                            size_bytes, file_count = _dir_size_bytes(child)
+                            hits.append(
+                                {
+                                    "path": str(child),
+                                    "kind": entry.name,
+                                    "bytes": size_bytes,
+                                    "file_count": file_count,
+                                }
+                            )
+                            # Do NOT descend — we already counted everything under it.
+                            continue
+                        stack.append(child)
+                        dirs_visited += 1
+                        now = time.perf_counter()
+                        if now - last_progress >= progress_every:
+                            print(
+                                f"[bloat] visited {dirs_visited} dirs, " f"{len(hits)} regenerable hits so far",
+                                file=sys.stderr,
+                                flush=True,
+                            )
+                            last_progress = now
+                    except (PermissionError, OSError):
+                        continue
+        except (PermissionError, OSError, NotADirectoryError):
+            continue
+    return hits
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--scope-root", type=Path, default=DEFAULT_SCOPE_ROOT)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--top", type=int, default=30)
+    args = parser.parse_args(argv)
+
+    if not args.scope_root.exists():
+        print(f"scope root does not exist: {args.scope_root}", file=sys.stderr)
+        return 2
+
+    started = time.perf_counter()
+    print(f"[bloat] scanning {args.scope_root} for regenerable dirs", file=sys.stderr, flush=True)
+    hits = find_bloat(args.scope_root)
+    elapsed = time.perf_counter() - started
+    print(f"[bloat] done in {elapsed:.1f}s: {len(hits)} regenerable dirs found", file=sys.stderr, flush=True)
+
+    by_kind: Dict[str, Dict] = {}
+    for h in hits:
+        k = h["kind"]
+        slot = by_kind.setdefault(k, {"count": 0, "bytes": 0, "file_count": 0})
+        slot["count"] += 1
+        slot["bytes"] += h["bytes"]
+        slot["file_count"] += h["file_count"]
+
+    hits.sort(key=lambda h: h["bytes"], reverse=True)
+    total_bytes = sum(h["bytes"] for h in hits)
+    total_files = sum(h["file_count"] for h in hits)
+
+    report = {
+        "schema": "regenerable_bloat_v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "scope_root": str(args.scope_root),
+        "duration_seconds": round(elapsed, 2),
+        "regenerable_dir_names": sorted(REGENERABLE_DIR_NAMES),
+        "hard_skip_dir_names": sorted(HARD_SKIP_DIR_NAMES),
+        "totals": {
+            "regenerable_dirs_found": len(hits),
+            "total_bytes": total_bytes,
+            "total_mb": round(total_bytes / 1024 / 1024, 1),
+            "total_gb": round(total_bytes / 1024 / 1024 / 1024, 2),
+            "total_files": total_files,
+        },
+        "by_kind": dict(sorted(by_kind.items(), key=lambda kv: -kv[1]["bytes"])),
+        "hits": hits,
+    }
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = args.output_dir / f"regenerable_bloat_{_utc_stamp()}.json"
+    out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    print()
+    print(f"Report: {out_path}")
+    print(
+        f"Total regenerable disk: {report['totals']['total_gb']} GB "
+        f"({report['totals']['total_files']} files in {len(hits)} dirs)"
+    )
+    print()
+    print("By kind:")
+    for k, v in report["by_kind"].items():
+        gb = v["bytes"] / 1024 / 1024 / 1024
+        print(f"  {k:<24} {v['count']:>5} dirs   {gb:>8.2f} GB   {v['file_count']:>9} files")
+    print()
+    print(f"Top {args.top} biggest:")
+    for i, h in enumerate(hits[: args.top], 1):
+        gb = h["bytes"] / 1024 / 1024 / 1024
+        path = h["path"]
+        if len(path) > 80:
+            path = "..." + path[-77:]
+        print(f"  {i:>2}. {gb:>7.2f} GB  {h['kind']:<16}  {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/system/test_disk_hygiene.py
+++ b/tests/system/test_disk_hygiene.py
@@ -1,0 +1,176 @@
+"""Smoke tests for the disk-hygiene scanner scripts.
+
+Both scripts are READ-ONLY: they walk a tree and emit a JSON report.
+Tests use isolated tmp_path trees so we don't touch real user files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts" / "system"
+DEDUP = SCRIPTS_DIR / "find_home_dedup.py"
+BLOAT = SCRIPTS_DIR / "find_regenerable_bloat.py"
+
+
+def _run(script: Path, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, str(script), *args]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=str(cwd) if cwd else str(REPO_ROOT),
+        env=env,
+    )
+
+
+def _make_dupes(root: Path) -> tuple[Path, Path, Path]:
+    """Three identical 1KB files in different subdirs."""
+    payload = ("hello-world-" * 80).encode("utf-8")  # > 256-byte min threshold
+    a = root / "a" / "file.txt"
+    b = root / "b" / "file.txt"
+    c = root / "src" / "file.txt"
+    for p in (a, b, c):
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(payload)
+    return a, b, c
+
+
+@pytest.mark.skipif(not DEDUP.exists(), reason="find_home_dedup.py missing")
+def test_dedup_finds_known_duplicates(tmp_path: Path) -> None:
+    out_dir = tmp_path / "reports"
+    _make_dupes(tmp_path)
+
+    result = _run(
+        DEDUP,
+        "--scope-root",
+        str(tmp_path).replace("\\", "/"),
+        "--output-dir",
+        str(out_dir).replace("\\", "/"),
+        "--top",
+        "5",
+    )
+    assert result.returncode == 0, result.stderr
+
+    reports = list(out_dir.glob("dedup_report_*.json"))
+    assert len(reports) == 1, "expected exactly one report"
+    report = json.loads(reports[0].read_text(encoding="utf-8"))
+
+    assert report["schema"] == "home_dedup_report_v1"
+    assert report["totals"]["n_clusters"] >= 1
+    assert report["totals"]["n_redundant_files"] >= 2  # 3 copies = 2 redundant
+    cluster = report["duplicate_clusters"][0]
+    assert cluster["n_copies"] == 3
+    # Suggested keeper must be one of the 3 cluster paths.
+    # (Note: tmp_path lives under artifacts/ here, which the heuristic
+    # explicitly avoids — the src/-preference branch can't fire from a
+    # tmp tree, so we only assert the keeper is a valid cluster member.)
+    assert cluster["suggested_keep"] in cluster["paths"]
+    assert cluster["suggested_keep_reason"]
+
+
+@pytest.mark.skipif(not DEDUP.exists(), reason="find_home_dedup.py missing")
+def test_dedup_skips_excluded_dirs(tmp_path: Path) -> None:
+    """node_modules siblings must NOT appear in any cluster."""
+    out_dir = tmp_path / "reports"
+    payload = ("noise-" * 80).encode("utf-8")
+    for sub in ("node_modules/pkg-a", "node_modules/pkg-b"):
+        p = tmp_path / sub / "index.js"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(payload)
+
+    result = _run(
+        DEDUP,
+        "--scope-root",
+        str(tmp_path).replace("\\", "/"),
+        "--output-dir",
+        str(out_dir).replace("\\", "/"),
+    )
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads(next(out_dir.glob("dedup_report_*.json")).read_text(encoding="utf-8"))
+    for cluster in report["duplicate_clusters"]:
+        for path in cluster["paths"]:
+            assert "node_modules" not in path.replace("\\", "/"), f"node_modules leaked into report: {path}"
+
+
+@pytest.mark.skipif(not BLOAT.exists(), reason="find_regenerable_bloat.py missing")
+def test_bloat_finds_node_modules(tmp_path: Path) -> None:
+    out_dir = tmp_path / "reports"
+    nm = tmp_path / "myproject" / "node_modules" / "lodash"
+    nm.mkdir(parents=True)
+    (nm / "index.js").write_bytes(b"x" * 4096)
+
+    result = _run(
+        BLOAT,
+        "--scope-root",
+        str(tmp_path).replace("\\", "/"),
+        "--output-dir",
+        str(out_dir).replace("\\", "/"),
+    )
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads(next(out_dir.glob("regenerable_bloat_*.json")).read_text(encoding="utf-8"))
+    assert report["schema"] == "regenerable_bloat_v1"
+    assert report["totals"]["regenerable_dirs_found"] >= 1
+    assert "node_modules" in report["by_kind"]
+    assert report["by_kind"]["node_modules"]["bytes"] >= 4096
+
+
+@pytest.mark.skipif(not BLOAT.exists(), reason="find_regenerable_bloat.py missing")
+def test_bloat_does_not_descend_into_hits(tmp_path: Path) -> None:
+    """Once we find node_modules, we should not double-count nested .venvs inside it."""
+    out_dir = tmp_path / "reports"
+    nested = tmp_path / "outer" / "node_modules" / "fake-pkg" / ".venv"
+    nested.mkdir(parents=True)
+    (nested / "marker").write_bytes(b"y" * 1024)
+
+    result = _run(
+        BLOAT,
+        "--scope-root",
+        str(tmp_path).replace("\\", "/"),
+        "--output-dir",
+        str(out_dir).replace("\\", "/"),
+    )
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads(next(out_dir.glob("regenerable_bloat_*.json")).read_text(encoding="utf-8"))
+    # Only the outer node_modules should be reported; .venv inside it is rolled in.
+    nm_hits = [h for h in report["hits"] if h["kind"] == "node_modules"]
+    venv_hits = [h for h in report["hits"] if h["kind"] == ".venv"]
+    assert len(nm_hits) == 1
+    assert len(venv_hits) == 0, f"unexpectedly descended into hit: {venv_hits}"
+
+
+@pytest.mark.skipif(not BLOAT.exists(), reason="find_regenerable_bloat.py missing")
+def test_bloat_ignores_hard_skip_dirs(tmp_path: Path) -> None:
+    """OneDrive subtree must never be descended into."""
+    out_dir = tmp_path / "reports"
+    inside_onedrive = tmp_path / "OneDrive" / "myproject" / "node_modules"
+    inside_onedrive.mkdir(parents=True)
+    (inside_onedrive / "x").write_bytes(b"z" * 1024)
+
+    result = _run(
+        BLOAT,
+        "--scope-root",
+        str(tmp_path).replace("\\", "/"),
+        "--output-dir",
+        str(out_dir).replace("\\", "/"),
+    )
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads(next(out_dir.glob("regenerable_bloat_*.json")).read_text(encoding="utf-8"))
+    for hit in report["hits"]:
+        assert (
+            "onedrive" not in hit["path"].replace("\\", "/").lower()
+        ), f"OneDrive leaked into bloat scan: {hit['path']}"


### PR DESCRIPTION
## Summary

Two read-only scripts for understanding where disk space lives across a home tree, both safe-by-design (only writes a JSON report).

### scripts/system/find_home_dedup.py
Walks a subtree and reports byte-identical files grouped by sha256. Two-pass strategy: walk to build size_groups, then hash only files with same-size siblings (skips the 99% of files whose size alone proves they're unique). Suggests a canonical keeper per cluster (prefers `src/`, `tests/`, `docs/`, `book/`; avoids `origin/` mirrors and `artifacts/`).

Output: `artifacts/dedup/dedup_report_<UTC>.json` (schema `home_dedup_report_v1`).

### scripts/system/find_regenerable_bloat.py
Walks a subtree, totals bytes inside any directory whose contents regenerate (`node_modules`, `.venv`, `dist`, `build`, `__pycache__`, `.next`, `.turbo`, `target`, `.pytest_cache`, etc.). Stops descending once it hits a regenerable dir to avoid double-counting.

Output: `artifacts/dedup/regenerable_bloat_<UTC>.json` (schema `regenerable_bloat_v1`).

## Safety properties

Both scripts:
- Hard-skip OneDrive (would force file hydration on Windows)
- Hard-skip `.claude/` (Claude Code session memory; corrupting breaks the session)
- Hard-skip `AppData/`, `.git/`, etc.
- Use `os.scandir` for speed and to avoid hydrating on-demand cloud files
- NEVER delete, move, copy, or rename anything

## Used in this session

Confirmed the SCBE-AETHERMOORE curated source tree is essentially dedupe-clean (~40 KB across `src/`, `scripts/`, `tests/`, `docs/`, `book/`, `aetherdesk/`, `python/`). Scan output guided the realization that disk hogs live in regenerable categories (which `find_regenerable_bloat` then surfaces).

## Test plan

- [x] `pytest tests/system/test_disk_hygiene.py` — 5/5 green
  - `test_dedup_finds_known_duplicates` — 3 identical files in 3 dirs → 1 cluster, valid keeper
  - `test_dedup_skips_excluded_dirs` — `node_modules` siblings never appear in any cluster
  - `test_bloat_finds_node_modules` — flagged with correct byte count
  - `test_bloat_does_not_descend_into_hits` — nested `.venv` inside `node_modules` not double-counted
  - `test_bloat_ignores_hard_skip_dirs` — OneDrive subtree hard-skipped
- [x] `black --check` clean
- [x] `flake8` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)