### PR TITLE
feat(system): partial bloat report on Ctrl+C (don't lose hours of walk)

### DIFF
--- a/scripts/system/find_regenerable_bloat.py
+++ b/scripts/system/find_regenerable_bloat.py
@@ -105,51 +105,73 @@ def _dir_size_bytes(path: Path) -> Tuple[int, int]:
     return total, count
 
 
-def find_bloat(scope_root: Path, *, progress_every: float = 5.0) -> List[Dict]:
-    """Walk scope_root, yielding hits at regenerable dirs (no recursion into them)."""
-    hits: List[Dict] = []
+class _BloatScanResult:
+    """Result of a (possibly interrupted) walk."""
+
+    def __init__(self) -> None:
+        self.hits: List[Dict] = []
+        self.dirs_visited: int = 0
+        self.interrupted: bool = False
+
+
+def find_bloat(scope_root: Path, *, progress_every: float = 5.0) -> _BloatScanResult:
+    """Walk scope_root, returning hits at regenerable dirs (no recursion into them).
+
+    On KeyboardInterrupt (Ctrl+C), returns whatever has been collected so far
+    with `interrupted=True` so the caller can still write a partial report.
+    """
+    result = _BloatScanResult()
     last_progress = time.perf_counter()
-    dirs_visited = 0
     stack = [scope_root]
-    while stack:
-        current = stack.pop()
-        try:
-            with os.scandir(current) as it:
-                for entry in it:
-                    try:
-                        if not entry.is_dir(follow_symlinks=False):
+    try:
+        while stack:
+            current = stack.pop()
+            try:
+                with os.scandir(current) as it:
+                    for entry in it:
+                        try:
+                            if not entry.is_dir(follow_symlinks=False):
+                                continue
+                            name_lower = entry.name.lower()
+                            if name_lower in _HARD_SKIP_LOWER:
+                                continue
+                            child = Path(entry.path)
+                            if name_lower in _REGEN_LOWER:
+                                size_bytes, file_count = _dir_size_bytes(child)
+                                result.hits.append(
+                                    {
+                                        "path": str(child),
+                                        "kind": entry.name,
+                                        "bytes": size_bytes,
+                                        "file_count": file_count,
+                                    }
+                                )
+                                # Do NOT descend — we already counted everything under it.
+                                continue
+                            stack.append(child)
+                            result.dirs_visited += 1
+                            now = time.perf_counter()
+                            if now - last_progress >= progress_every:
+                                print(
+                                    f"[bloat] visited {result.dirs_visited} dirs, "
+                                    f"{len(result.hits)} regenerable hits so far",
+                                    file=sys.stderr,
+                                    flush=True,
+                                )
+                                last_progress = now
+                        except (PermissionError, OSError):
                             continue
-                        name_lower = entry.name.lower()
-                        if name_lower in _HARD_SKIP_LOWER:
-                            continue
-                        child = Path(entry.path)
-                        if name_lower in _REGEN_LOWER:
-                            size_bytes, file_count = _dir_size_bytes(child)
-                            hits.append(
-                                {
-                                    "path": str(child),
-                                    "kind": entry.name,
-                                    "bytes": size_bytes,
-                                    "file_count": file_count,
-                                }
-                            )
-                            # Do NOT descend — we already counted everything under it.
-                            continue
-                        stack.append(child)
-                        dirs_visited += 1
-                        now = time.perf_counter()
-                        if now - last_progress >= progress_every:
-                            print(
-                                f"[bloat] visited {dirs_visited} dirs, " f"{len(hits)} regenerable hits so far",
-                                file=sys.stderr,
-                                flush=True,
-                            )
-                            last_progress = now
-                    except (PermissionError, OSError):
-                        continue
-        except (PermissionError, OSError, NotADirectoryError):
-            continue
-    return hits
+            except (PermissionError, OSError, NotADirectoryError):
+                continue
+    except KeyboardInterrupt:
+        result.interrupted = True
+        print(
+            f"[bloat] INTERRUPTED after {result.dirs_visited} dirs, "
+            f"{len(result.hits)} hits — writing partial report",
+            file=sys.stderr,
+            flush=True,
+        )
+    return result
 
 
 def main(argv=None) -> int:
@@ -165,9 +187,11 @@ def main(argv=None) -> int:
 
     started = time.perf_counter()
     print(f"[bloat] scanning {args.scope_root} for regenerable dirs", file=sys.stderr, flush=True)
-    hits = find_bloat(args.scope_root)
+    scan_result = find_bloat(args.scope_root)
+    hits = scan_result.hits
     elapsed = time.perf_counter() - started
-    print(f"[bloat] done in {elapsed:.1f}s: {len(hits)} regenerable dirs found", file=sys.stderr, flush=True)
+    status = "interrupted" if scan_result.interrupted else "done"
+    print(f"[bloat] {status} in {elapsed:.1f}s: {len(hits)} regenerable dirs found", file=sys.stderr, flush=True)
 
     by_kind: Dict[str, Dict] = {}
     for h in hits:
@@ -186,6 +210,8 @@ def main(argv=None) -> int:
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "scope_root": str(args.scope_root),
         "duration_seconds": round(elapsed, 2),
+        "interrupted": scan_result.interrupted,
+        "dirs_visited": scan_result.dirs_visited,
         "regenerable_dir_names": sorted(REGENERABLE_DIR_NAMES),
         "hard_skip_dir_names": sorted(HARD_SKIP_DIR_NAMES),
         "totals": {
@@ -200,7 +226,8 @@ def main(argv=None) -> int:
     }
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    out_path = args.output_dir / f"regenerable_bloat_{_utc_stamp()}.json"
+    suffix = "_partial" if scan_result.interrupted else ""
+    out_path = args.output_dir / f"regenerable_bloat_{_utc_stamp()}{suffix}.json"
     out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
 
     print()

--- a/tests/system/test_disk_hygiene.py
+++ b/tests/system/test_disk_hygiene.py
@@ -174,3 +174,37 @@ def test_bloat_ignores_hard_skip_dirs(tmp_path: Path) -> None:
         assert (
             "onedrive" not in hit["path"].replace("\\", "/").lower()
         ), f"OneDrive leaked into bloat scan: {hit['path']}"
+
+
+@pytest.mark.skipif(not BLOAT.exists(), reason="find_regenerable_bloat.py missing")
+def test_bloat_partial_report_on_keyboard_interrupt(tmp_path: Path, monkeypatch) -> None:
+    """KeyboardInterrupt mid-scan returns whatever hits we already have."""
+    # Import the script's module by path so we can monkeypatch it.
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_bloat_under_test", BLOAT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    # Build a tree with TWO node_modules; force interrupt after the first.
+    for sub in ("a/node_modules", "b/node_modules"):
+        d = tmp_path / sub
+        d.mkdir(parents=True)
+        (d / "x").write_bytes(b"q" * 512)
+
+    real_dir_size = mod._dir_size_bytes
+    call_count = {"n": 0}
+
+    def fake_dir_size(path):
+        call_count["n"] += 1
+        if call_count["n"] >= 2:
+            raise KeyboardInterrupt
+        return real_dir_size(path)
+
+    monkeypatch.setattr(mod, "_dir_size_bytes", fake_dir_size)
+
+    result = mod.find_bloat(tmp_path)
+    assert result.interrupted is True
+    assert len(result.hits) == 1, "should have exactly the one hit collected before interrupt"
+    assert result.hits[0]["kind"] == "node_modules"


### PR DESCRIPTION
## Summary

The bloat scanner can take hours on large home trees. Before this change, hitting Ctrl+C threw away every hit collected so far. Now you get a partial report.

## Behavior change

- `find_bloat()` catches `KeyboardInterrupt` internally and returns whatever hits it has, with `interrupted=True`
- `main()` writes the report regardless of completion status
- partial reports get a `_partial` suffix on the filename so they can't be confused with a complete scan
- the report JSON includes `interrupted: true` and `dirs_visited` so consumers know coverage was incomplete

## Why it matters

Live evidence today: an in-flight scan ran for 90+ minutes across 1.2M dirs before its hit rate plateaued in low-density territory. Without partial reporting, killing the doomed long-tail walk meant losing 13k+ collected hits. Future scans can now Ctrl+C confidently.

## Test plan

- [x] `pytest tests/system/test_disk_hygiene.py` — 6/6 green
  - new `test_bloat_partial_report_on_keyboard_interrupt` — monkeypatches `_dir_size_bytes` to raise `KeyboardInterrupt` after one hit, confirms scan returns `interrupted=True` with the hit intact
- [x] `black --check` clean
- [x] `flake8` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)