### PR TITLE
feat(mcp): SCBE Context MCP server for Claude.ai Custom Connectors + other agents

### DIFF
--- a/mcp_context_server/README.md
+++ b/mcp_context_server/README.md
@@ -1,0 +1,99 @@
+# SCBE MCP Context Server
+
+Tiny MCP (Model Context Protocol) server that exposes the curated
+`docs/` and `book/` trees so agents — Claude.ai Custom Connectors,
+Claude Desktop, Cursor, Continue, etc. — can pull SCBE-AETHERMOORE
+context in the structured form the docs already define.
+
+Transport: **Streamable HTTP** (one POST `/mcp` endpoint, stateless).
+
+## Run it
+
+```powershell
+npm run mcp:context-server
+```
+
+The server prints:
+
+```
+SCBE MCP Context Server — http://127.0.0.1:5719/mcp
+Auth: OPEN (no token; localhost only)
+Docs roots: docs, book
+```
+
+Override:
+
+- `MCP_CONTEXT_PORT=NNNN` — bind a different port (default 5719)
+- `MCP_CONTEXT_HOST=0.0.0.0` — bind all interfaces (only do this behind a reverse proxy)
+- `MCP_CONTEXT_TOKEN=somesecret` — require `Authorization: Bearer somesecret` on every request
+
+## Tools exposed
+
+| Tool | Purpose |
+|---|---|
+| `list_docs(prefix?)` | List `.md`/`.mdx` files under `docs/` and `book/`, optionally filtered by path prefix |
+| `read_doc(path)` | Read one file by repo-relative path; rejected if path doesn't resolve under the allowed roots |
+| `search_docs(query, limit?)` | Case-insensitive substring search; returns up to `limit` hits with snippets |
+| `get_one_pager()` | Return `docs/SCBE_AETHERMOORE_ONE_PAGER.md` directly — best place to start |
+
+## Connecting from Claude.ai (Custom Connector)
+
+Claude.ai requires a **public HTTPS** URL for Custom Connectors. The
+server binds to `127.0.0.1` for safety, so you need a tunnel:
+
+### Option A — Cloudflare Tunnel (free, no signup needed for quick tunnel)
+
+```powershell
+# Install once: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/
+cloudflared tunnel --url http://127.0.0.1:5719
+```
+
+Cloudflared prints a URL like `https://random-words.trycloudflare.com`. Use:
+
+```
+Server URL: https://random-words.trycloudflare.com/mcp
+```
+
+Add a token first if you tunnel:
+
+```powershell
+$env:MCP_CONTEXT_TOKEN = (New-Guid).Guid
+npm run mcp:context-server
+```
+
+…and paste the token into Claude.ai's Custom Connector auth field.
+
+### Option B — ngrok
+
+```powershell
+ngrok http 5719
+```
+
+Use the `https://...ngrok-free.app/mcp` URL ngrok prints.
+
+### Option C — Deploy
+
+Wrap `mcp_context_server/server.js` in any Node host (Cloud Run, Render,
+Fly.io, Vercel — though Vercel's serverless model isn't ideal for
+streaming). Set `MCP_CONTEXT_HOST=0.0.0.0` and `MCP_CONTEXT_PORT=$PORT`
+in the environment, plus `MCP_CONTEXT_TOKEN` for auth.
+
+## Connecting from Claude Desktop
+
+Add to `claude_desktop_config.json` (Desktop uses stdio, not HTTP — this
+server only does HTTP, so wrap it via a small shim or use the Python
+`src/mcp_server/semantic_mesh.py` server which already speaks stdio).
+
+## Security
+
+- Path traversal: `read_doc` rejects anything that resolves outside `docs/` or `book/`.
+- File-name regex: only `[A-Za-z0-9_./-]` allowed; no shell metacharacters.
+- Size cap: 256 KB per file. Larger files return an error suggesting `search_docs` first.
+- No write tools. Read-only by design. Never exposes `src/`, `tests/`, `.git/`, secrets, or env values.
+- Bearer auth is opt-in but **strongly recommended** if you tunnel the server beyond localhost.
+
+## Testing
+
+```powershell
+npx vitest run tests/mcp_context_server/server.test.ts
+```

--- a/mcp_context_server/server.js
+++ b/mcp_context_server/server.js
@@ -1,0 +1,357 @@
+'use strict';
+
+/**
+ * SCBE-AETHERMOORE MCP Context Server (Streamable HTTP)
+ *
+ * Exposes the curated docs/ and book/ trees as an MCP server so any
+ * MCP client (Claude Desktop, Claude.ai Custom Connectors, Cursor,
+ * Continue, etc.) can pull repo context in the structured form the
+ * docs already define.
+ *
+ * Transport: Streamable HTTP (one POST /mcp endpoint, stateless).
+ * Bind:      127.0.0.1:5719 by default. Override with MCP_CONTEXT_PORT.
+ * Auth:      Optional bearer token via MCP_CONTEXT_TOKEN env var. If
+ *            unset, the server is open (only safe on localhost).
+ *
+ * Surfaces (tools):
+ *   list_docs(prefix?)       — list .md files under the curated tree
+ *   read_doc(path)           — return one file's contents (path-jailed)
+ *   search_docs(query, limit?) — case-insensitive substring search
+ *   get_one_pager()          — return the canonical project briefing
+ *
+ * Hard scope: only docs/ and book/. No src/, no tests/, no secrets.
+ */
+
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { z } = require('zod');
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+const {
+  StreamableHTTPServerTransport,
+} = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PORT = Number(process.env.MCP_CONTEXT_PORT || 5719);
+const HOST = process.env.MCP_CONTEXT_HOST || '127.0.0.1';
+const BEARER = process.env.MCP_CONTEXT_TOKEN || null;
+const MAX_DOC_BYTES = 256 * 1024; // 256 KB per doc
+
+// The allowed-roots list is the security boundary. A request for
+// `read_doc` with anything outside these roots is rejected.
+const DOC_ROOTS = [path.join(REPO_ROOT, 'docs'), path.join(REPO_ROOT, 'book')];
+
+const SAFE_NAME_RE = /^[A-Za-z0-9_./-]+$/;
+
+function listMarkdownFiles(root) {
+  const out = [];
+  if (!fs.existsSync(root)) return out;
+  const stack = [root];
+  while (stack.length) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch (_err) {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(current, e.name);
+      if (e.isDirectory()) {
+        // Skip dot-dirs and node_modules to keep the listing clean.
+        if (e.name.startsWith('.') || e.name === 'node_modules') continue;
+        stack.push(full);
+      } else if (e.isFile() && /\.(md|mdx)$/i.test(e.name)) {
+        out.push(path.relative(REPO_ROOT, full).replace(/\\/g, '/'));
+      }
+    }
+  }
+  return out.sort();
+}
+
+function isAllowedDocPath(rel) {
+  if (!SAFE_NAME_RE.test(rel)) return false;
+  if (rel.includes('..')) return false;
+  // Must resolve under one of the DOC_ROOTS.
+  const resolved = path.resolve(REPO_ROOT, rel);
+  return DOC_ROOTS.some((root) => resolved === root || resolved.startsWith(root + path.sep));
+}
+
+function readDocStrict(rel) {
+  if (!isAllowedDocPath(rel)) {
+    throw new Error(`path not in allowed docs roots: ${rel}`);
+  }
+  const full = path.resolve(REPO_ROOT, rel);
+  if (!fs.existsSync(full) || !fs.statSync(full).isFile()) {
+    throw new Error(`doc not found: ${rel}`);
+  }
+  const stat = fs.statSync(full);
+  if (stat.size > MAX_DOC_BYTES) {
+    throw new Error(
+      `doc too large (${stat.size} bytes; cap is ${MAX_DOC_BYTES}); fetch a section instead`
+    );
+  }
+  return {
+    path: rel,
+    bytes: stat.size,
+    modified: stat.mtime.toISOString(),
+    content: fs.readFileSync(full, 'utf8'),
+  };
+}
+
+function searchDocs(query, limit = 25) {
+  if (!query || query.length < 2) {
+    throw new Error('query must be >= 2 characters');
+  }
+  const ql = query.toLowerCase();
+  const hits = [];
+  for (const root of DOC_ROOTS) {
+    for (const rel of listMarkdownFiles(root)) {
+      const full = path.join(REPO_ROOT, rel);
+      let body;
+      try {
+        body = fs.readFileSync(full, 'utf8');
+      } catch (_err) {
+        continue;
+      }
+      const idx = body.toLowerCase().indexOf(ql);
+      if (idx === -1) continue;
+      const start = Math.max(0, idx - 80);
+      const end = Math.min(body.length, idx + 80 + ql.length);
+      hits.push({
+        path: rel,
+        offset: idx,
+        snippet: body.slice(start, end).replace(/\s+/g, ' ').trim(),
+      });
+      if (hits.length >= limit) return hits;
+    }
+  }
+  return hits;
+}
+
+function buildMcpServer() {
+  const server = new McpServer(
+    {
+      name: 'scbe-context',
+      version: '0.1.0',
+    },
+    {
+      capabilities: { tools: {}, logging: {} },
+    }
+  );
+
+  server.registerTool(
+    'list_docs',
+    {
+      description:
+        'List Markdown files in the curated docs/ and book/ trees. Optional prefix filters by path.',
+      inputSchema: {
+        prefix: z.string().optional().describe('Optional path prefix filter (e.g. "docs/specs/").'),
+      },
+    },
+    async ({ prefix }) => {
+      const files = [
+        ...listMarkdownFiles(path.join(REPO_ROOT, 'docs')),
+        ...listMarkdownFiles(path.join(REPO_ROOT, 'book')),
+      ];
+      const filtered = prefix ? files.filter((f) => f.startsWith(prefix)) : files;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ count: filtered.length, files: filtered }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerTool(
+    'read_doc',
+    {
+      description:
+        'Read one Markdown file by repo-relative path. Path must resolve under docs/ or book/.',
+      inputSchema: {
+        path: z.string().describe('Repo-relative path, e.g. "docs/SCBE_AETHERMOORE_ONE_PAGER.md".'),
+      },
+    },
+    async ({ path: docPath }) => {
+      try {
+        const doc = readDocStrict(docPath);
+        return { content: [{ type: 'text', text: JSON.stringify(doc, null, 2) }] };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `error: ${err.message}` }],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'search_docs',
+    {
+      description:
+        'Case-insensitive substring search across the curated docs/ and book/ trees. Returns up to N hits with a snippet around each match.',
+      inputSchema: {
+        query: z.string().min(2).describe('Search string (>=2 chars).'),
+        limit: z.number().int().min(1).max(100).default(25).describe('Max hits.'),
+      },
+    },
+    async ({ query, limit }) => {
+      try {
+        const hits = searchDocs(query, limit);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ query, count: hits.length, hits }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `error: ${err.message}` }],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'get_one_pager',
+    {
+      description:
+        'Return the canonical SCBE-AETHERMOORE one-pager (docs/SCBE_AETHERMOORE_ONE_PAGER.md). Best place to start.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const doc = readDocStrict('docs/SCBE_AETHERMOORE_ONE_PAGER.md');
+        return { content: [{ type: 'text', text: doc.content }] };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `error: ${err.message}` }],
+        };
+      }
+    }
+  );
+
+  return server;
+}
+
+function bearerAuthMiddleware(req, res, next) {
+  if (!BEARER) return next();
+  const auth = req.headers.authorization || '';
+  if (auth === `Bearer ${BEARER}`) return next();
+  return res.status(401).json({
+    jsonrpc: '2.0',
+    error: { code: -32001, message: 'unauthorized' },
+    id: null,
+  });
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ limit: '256kb' }));
+
+  app.get('/health', (_req, res) => {
+    res.json({
+      ok: true,
+      schema: 'mcp_context_health_v0',
+      name: 'scbe-context',
+      version: '0.1.0',
+      auth_required: Boolean(BEARER),
+    });
+  });
+
+  app.post('/mcp', bearerAuthMiddleware, async (req, res) => {
+    let server;
+    try {
+      server = buildMcpServer();
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined, // stateless — one server per request
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+      res.on('close', () => {
+        try {
+          transport.close();
+        } catch (_err) {
+          /* swallow */
+        }
+        try {
+          server.close();
+        } catch (_err) {
+          /* swallow */
+        }
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[mcp-context] error handling /mcp:', err);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'internal server error' },
+          id: null,
+        });
+      }
+      try {
+        if (server) server.close();
+      } catch (_err) {
+        /* swallow */
+      }
+    }
+  });
+
+  // GET/DELETE on /mcp aren't supported by the stateless transport.
+  app.get('/mcp', (_req, res) => {
+    res.status(405).json({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'method not allowed' },
+      id: null,
+    });
+  });
+  app.delete('/mcp', (_req, res) => {
+    res.status(405).json({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'method not allowed' },
+      id: null,
+    });
+  });
+
+  return app;
+}
+
+function main() {
+  const app = buildApp();
+  const server = app.listen(PORT, HOST, () => {
+    // eslint-disable-next-line no-console
+    console.log(`SCBE MCP Context Server — http://${HOST}:${PORT}/mcp`);
+    // eslint-disable-next-line no-console
+    console.log(
+      `Auth: ${BEARER ? 'Bearer token required (MCP_CONTEXT_TOKEN set)' : 'OPEN (no token; localhost only)'}`
+    );
+    // eslint-disable-next-line no-console
+    console.log(`Docs roots: ${DOC_ROOTS.map((r) => path.relative(REPO_ROOT, r)).join(', ')}`);
+  });
+  return server;
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildApp,
+  buildMcpServer,
+  listMarkdownFiles,
+  isAllowedDocPath,
+  readDocStrict,
+  searchDocs,
+  DOC_ROOTS,
+  REPO_ROOT,
+  HOST,
+  PORT,
+};

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "benchmark:coding-agents:gate": "python scripts/eval/gate_functional_benchmark.py",
     "benchmark:cli": "python scripts/benchmark/cli_competitive_benchmark.py",
     "aetherdesk": "node aetherdesk/server.js",
+    "mcp:context-server": "node mcp_context_server/server.js",
     "benchmark:representation-kaleidoscope": "python scripts/benchmark/build_representation_kaleidoscope.py",
     "benchmark:agentic:external": "python scripts/benchmark/external_agentic_eval_driver.py",
     "training:adapter-registry": "python scripts/model_training/build_adapter_registry.py",

--- a/tests/mcp_context_server/server.test.ts
+++ b/tests/mcp_context_server/server.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'path';
+import * as http from 'http';
+import { AddressInfo } from 'net';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const ctx = require('../../mcp_context_server/server.js');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+let server: http.Server;
+let baseUrl: string;
+
+function fetchJson(url: string, init?: RequestInit) {
+  return fetch(url, init).then((r) => r.json().then((b) => ({ status: r.status, body: b })));
+}
+
+beforeEach(async () => {
+  delete process.env.MCP_CONTEXT_TOKEN;
+  const app = ctx.buildApp();
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('mcp-context — health', () => {
+  it('GET /health returns schema + name + version', async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/health`);
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.schema).toBe('mcp_context_health_v0');
+    expect(body.name).toBe('scbe-context');
+    expect(body.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe('mcp-context — path security (security boundary)', () => {
+  it('isAllowedDocPath accepts docs/ paths', () => {
+    expect(ctx.isAllowedDocPath('docs/SCBE_AETHERMOORE_ONE_PAGER.md')).toBe(true);
+    expect(ctx.isAllowedDocPath('book/ai-governance-fundamentals/chapter-01.md')).toBe(true);
+  });
+
+  it('isAllowedDocPath rejects path traversal attempts', () => {
+    expect(ctx.isAllowedDocPath('../etc/passwd')).toBe(false);
+    expect(ctx.isAllowedDocPath('docs/../../etc/passwd')).toBe(false);
+    expect(ctx.isAllowedDocPath('..\\windows\\system32')).toBe(false);
+  });
+
+  it('isAllowedDocPath rejects paths outside docs/ and book/', () => {
+    expect(ctx.isAllowedDocPath('src/harmonic/pipeline14.ts')).toBe(false);
+    expect(ctx.isAllowedDocPath('package.json')).toBe(false);
+    expect(ctx.isAllowedDocPath('.git/config')).toBe(false);
+  });
+
+  it('isAllowedDocPath rejects paths with shell metacharacters', () => {
+    expect(ctx.isAllowedDocPath('docs/file;rm.md')).toBe(false);
+    expect(ctx.isAllowedDocPath('docs/file$(whoami).md')).toBe(false);
+    expect(ctx.isAllowedDocPath('docs/file with space.md')).toBe(false);
+    expect(ctx.isAllowedDocPath('docs/file|pipe.md')).toBe(false);
+  });
+
+  it('readDocStrict throws on paths outside allowed roots', () => {
+    expect(() => ctx.readDocStrict('package.json')).toThrow(/not in allowed/);
+    expect(() => ctx.readDocStrict('../etc/passwd')).toThrow();
+  });
+
+  it('readDocStrict throws on traversal attempts', () => {
+    expect(() => ctx.readDocStrict('docs/../package.json')).toThrow();
+  });
+});
+
+describe('mcp-context — listing + reading + searching', () => {
+  it('listMarkdownFiles returns relative paths under docs/', () => {
+    const files = ctx.listMarkdownFiles(path.join(REPO_ROOT, 'docs'));
+    expect(Array.isArray(files)).toBe(true);
+    expect(files.length).toBeGreaterThan(0);
+    for (const f of files) {
+      expect(f.startsWith('docs/')).toBe(true);
+      expect(f.endsWith('.md') || f.endsWith('.mdx')).toBe(true);
+    }
+  });
+
+  it('readDocStrict reads a known doc and returns metadata', () => {
+    const doc = ctx.readDocStrict('docs/SCBE_AETHERMOORE_ONE_PAGER.md');
+    expect(doc.path).toBe('docs/SCBE_AETHERMOORE_ONE_PAGER.md');
+    expect(typeof doc.content).toBe('string');
+    expect(doc.bytes).toBeGreaterThan(0);
+    expect(doc.modified).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(doc.content).toMatch(/SCBE-AETHERMOORE/);
+  });
+
+  it('searchDocs finds a known string with snippet', () => {
+    const hits = ctx.searchDocs('Poincare', 5);
+    expect(Array.isArray(hits)).toBe(true);
+    expect(hits.length).toBeGreaterThan(0);
+    for (const h of hits) {
+      expect(h.path).toMatch(/\.(md|mdx)$/);
+      expect(typeof h.offset).toBe('number');
+      expect(typeof h.snippet).toBe('string');
+      expect(h.snippet.toLowerCase()).toContain('poincare');
+    }
+  });
+
+  it('searchDocs throws on too-short query', () => {
+    expect(() => ctx.searchDocs('a', 5)).toThrow(/>= 2/);
+    expect(() => ctx.searchDocs('', 5)).toThrow();
+  });
+
+  it('searchDocs respects limit', () => {
+    const hits = ctx.searchDocs('the', 3);
+    expect(hits.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('mcp-context — HTTP method enforcement', () => {
+  it('GET /mcp returns 405', async () => {
+    const r = await fetch(`${baseUrl}/mcp`);
+    expect(r.status).toBe(405);
+  });
+
+  it('DELETE /mcp returns 405', async () => {
+    const r = await fetch(`${baseUrl}/mcp`, { method: 'DELETE' });
+    expect(r.status).toBe(405);
+  });
+});
+
+describe('mcp-context — bearer auth (when MCP_CONTEXT_TOKEN set)', () => {
+  let altServer: http.Server;
+  let altUrl: string;
+
+  beforeEach(async () => {
+    process.env.MCP_CONTEXT_TOKEN = 'test-token-xyz';
+    // Re-require the module to pick up the new env. Express middleware
+    // binds at app build time, so we need a fresh app.
+    delete require.cache[require.resolve('../../mcp_context_server/server.js')];
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const ctxAuth = require('../../mcp_context_server/server.js');
+    const app = ctxAuth.buildApp();
+    await new Promise<void>((resolve) => {
+      altServer = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = altServer.address() as AddressInfo;
+    altUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => altServer.close(() => resolve()));
+    delete process.env.MCP_CONTEXT_TOKEN;
+    delete require.cache[require.resolve('../../mcp_context_server/server.js')];
+  });
+
+  it('POST /mcp without token returns 401', async () => {
+    const r = await fetch(`${altUrl}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    });
+    expect(r.status).toBe(401);
+  });
+
+  it('POST /mcp with wrong token returns 401', async () => {
+    const r = await fetch(`${altUrl}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer WRONG' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    });
+    expect(r.status).toBe(401);
+  });
+
+  it('GET /health works without token (health is open)', async () => {
+    const r = await fetch(`${altUrl}/health`);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.auth_required).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

A small Model Context Protocol (MCP) server that exposes the curated `docs/` and `book/` trees so any MCP client — Claude.ai Custom Connectors, Claude Desktop, Cursor, Continue, etc. — can pull SCBE-AETHERMOORE context in the structured form the docs already define.

## What it serves

| Tool | Purpose |
|---|---|
| `list_docs(prefix?)` | List `.md`/`.mdx` files under `docs/` and `book/`, optional path-prefix filter |
| `read_doc(path)` | Read one file by repo-relative path; **path-jailed** to allowed roots |
| `search_docs(query, limit?)` | Case-insensitive substring search; returns snippets |
| `get_one_pager()` | Return `docs/SCBE_AETHERMOORE_ONE_PAGER.md` directly |

## Transport

**Streamable HTTP** (POST `/mcp`, stateless — one MCP server instance per request). This is what Claude.ai Custom Connectors expect.

## Run

```powershell
npm run mcp:context-server
```

Prints:
```
SCBE MCP Context Server — http://127.0.0.1:5719/mcp
Auth: OPEN (no token; localhost only)
Docs roots: docs, book
```

## Connect Claude.ai

Tunnel the local port via cloudflared/ngrok and paste the public https URL + `/mcp` into the Custom Connector form. Set `MCP_CONTEXT_TOKEN` first if you tunnel — README walks through both cloudflared and ngrok options.

## Security boundaries

- `read_doc` rejects path traversal (`..`), shell metacharacters, and any path that doesn't resolve under `docs/` or `book/`
- 256 KB cap per file — larger files return an error pointing at `search_docs`
- **No write tools.** Read-only by design. Never exposes `src/`, `tests/`, `.git/`, env values
- Bearer auth opt-in via `MCP_CONTEXT_TOKEN` env, strongly recommended when tunneled
- Server binds `127.0.0.1` by default

## Test plan

- [x] 17 cases in `tests/mcp_context_server/server.test.ts` — all green
  - health endpoint schema
  - path security: traversal, shell metacharacters, outside-roots all rejected
  - listing/reading/searching happy paths
  - HTTP method enforcement (GET/DELETE return 405)
  - bearer auth: 401 without token, 401 with wrong token, `/health` stays open
- [x] End-to-end smoke: `initialize` handshake + `tools/list` both return clean MCP responses with all 4 tools and proper JSON schemas
- [x] `prettier --write` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)