### PR TITLE
chore(gitignore): MCP context bearer token + cloudflared binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 .secrets/
 # Kiro MCP Manager - Sensitive configuration files
 .kiro/settings/
+# MCP context server bearer token (created at tunnel-start time)
+.mcp_context_token
+# Bundled cloudflared binary (downloaded at runtime, not source)
+tools/cloudflared.exe
 
 # Performance test evidence files (hardware-specific)
 docs/evidence/*.json


### PR DESCRIPTION
## Summary

Belt-and-suspenders for PRs #1649 + #1650. Two new ignore entries created while wiring up the cloudflared tunnel for the MCP context server:

- \`.mcp_context_token\` — created at tunnel-start time, holds the bearer secret. A stray \`git add -A\` would publish it.
- \`tools/cloudflared.exe\` — 65 MB binary downloaded at runtime, not source.

Trivial diff (4 lines added). No code changes.

## Test plan

- [x] Doc/config-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)