### PR TITLE
feat(encoding): DenseBundle multi-encoding primitive + bus routing

### DIFF
--- a/src/encoding/__init__.py
+++ b/src/encoding/__init__.py
@@ -1,0 +1,9 @@
+"""SCBE encoding primitives.
+
+Dense data bundles: one input, many parallel encodings, all lossless.
+The swarm bus can route on the encoding-form hint.
+"""
+
+from src.encoding.dense_bundle import DenseBundle, route_lane_for_bundle
+
+__all__ = ["DenseBundle", "route_lane_for_bundle"]

--- a/src/encoding/dense_bundle.py
+++ b/src/encoding/dense_bundle.py
@@ -1,0 +1,241 @@
+"""Dense data bundle: one input, many parallel encodings.
+
+Per the bit/float/trit theory note (notes/theory/2026-04-05-training-pair-taxonomy.md):
+    "same byte, different intent polarity (+1/0/-1) -> 24x encoding density.
+     Trit = intent layer (same code, different purpose)."
+
+A `DenseBundle` packages five lossless views of the same payload:
+    - binary       bit string ('010101...')
+    - hex          base-16 string
+    - base64       transport-safe ASCII
+    - ternary      balanced ternary (Issac's symphonic_cipher.trinary)
+    - intent       per-byte polarity overlay (+1 / 0 / -1)
+
+The first four are lossless byte-level encodings of the same payload.
+The fifth is an intent-layer overlay (one trit per byte) — the same code,
+different purpose. Bundles round-trip: decode any of the four byte
+views and you get the same bytes back.
+
+For routing: `route_lane_for_bundle` picks a swarm lane hint from
+the encoding form. Hex bundles -> byte/binary analysis lane.
+Ternary bundles -> governance / intent lane. And so on.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+from typing import Sequence
+
+from src.symphonic_cipher.scbe_aethermoore.trinary import (
+    BalancedTernary,
+    Trit,
+)
+
+# Canonical lane keys the swarm router already understands. The bus
+# can dispatch on these without needing a new lane vocabulary.
+LANE_BINARY_ANALYSIS = "binary_analysis"
+LANE_GOVERNANCE_INTENT = "governance_intent"
+LANE_TRANSPORT_OPAQUE = "transport_opaque"
+LANE_TEXT_DEFAULT = "text_default"
+
+
+def _bytes_to_balanced_ternary(payload: bytes) -> BalancedTernary:
+    """Encode raw bytes as one big-int balanced ternary number.
+
+    Reversible via :func:`_balanced_ternary_to_bytes`. The byte length
+    is recovered from the bundle's `byte_length` field, not from the
+    BT representation itself (BT has no inherent length).
+    """
+    if not payload:
+        return BalancedTernary([])
+    n = int.from_bytes(payload, "big", signed=False)
+    return BalancedTernary.from_int(n)
+
+
+def _balanced_ternary_to_bytes(bt: BalancedTernary, byte_length: int) -> bytes:
+    if byte_length == 0:
+        return b""
+    n = bt.to_int()
+    if n < 0:
+        raise ValueError("dense bundle balanced ternary decoded to a negative int")
+    return n.to_bytes(byte_length, "big", signed=False)
+
+
+def _bytes_to_intent(payload: bytes) -> list[Trit]:
+    """Map each byte to an intent polarity: +1 / 0 / -1.
+
+    Mapping is deterministic but coarse on purpose:
+        byte == 0           -> Trit.ZERO   (null)
+        byte & 0x80 == 0    -> Trit.PLUS    (low ASCII / structural)
+        byte & 0x80 != 0    -> Trit.MINUS    (high-bit / payload)
+
+    The intent overlay is NOT used to recover the bytes. It's a
+    parallel signal — same code, different purpose.
+    """
+    out: list[Trit] = []
+    for b in payload:
+        if b == 0:
+            out.append(Trit.ZERO)
+        elif b & 0x80:
+            out.append(Trit.MINUS)
+        else:
+            out.append(Trit.PLUS)
+    return out
+
+
+@dataclass(frozen=True)
+class DenseBundle:
+    """One payload, four lossless encodings, one intent overlay."""
+
+    byte_length: int
+    binary: str
+    hex: str
+    base64: str
+    ternary: str
+    intent: tuple[int, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_bytes(cls, payload: bytes) -> "DenseBundle":
+        bt = _bytes_to_balanced_ternary(payload)
+        return cls(
+            byte_length=len(payload),
+            binary="".join(f"{b:08b}" for b in payload),
+            hex=payload.hex(),
+            base64=base64.b64encode(payload).decode("ascii"),
+            ternary=str(bt),
+            intent=tuple(int(t) for t in _bytes_to_intent(payload)),
+        )
+
+    @classmethod
+    def from_text(cls, text: str, encoding: str = "utf-8") -> "DenseBundle":
+        return cls.from_bytes(text.encode(encoding))
+
+    def to_bytes(self, view: str = "hex") -> bytes:
+        """Decode any of the four byte views back to bytes.
+
+        `view` must be one of: "hex", "binary", "base64", "ternary".
+        Each view is independently lossless and produces the same
+        bytes.
+        """
+        if view == "hex":
+            return bytes.fromhex(self.hex)
+        if view == "binary":
+            if len(self.binary) % 8 != 0:
+                raise ValueError("binary view length is not a multiple of 8")
+            return bytes(int(self.binary[i : i + 8], 2) for i in range(0, len(self.binary), 8))
+        if view == "base64":
+            return base64.b64decode(self.base64.encode("ascii"))
+        if view == "ternary":
+            from src.symphonic_cipher.scbe_aethermoore.trinary import parse_bt
+
+            bt = parse_bt(self.ternary)
+            return _balanced_ternary_to_bytes(bt, self.byte_length)
+        raise ValueError(f"unknown view: {view!r}")
+
+    def to_text(self, view: str = "hex", encoding: str = "utf-8") -> str:
+        return self.to_bytes(view).decode(encoding)
+
+    def density_ratio(self) -> float:
+        """Total characters across the four byte views, divided by raw byte length.
+
+        Pure observability metric. The intent overlay is excluded
+        because it's not a byte view.
+        """
+        if self.byte_length == 0:
+            return 0.0
+        total_chars = len(self.binary) + len(self.hex) + len(self.base64) + len(self.ternary)
+        return total_chars / self.byte_length
+
+    def to_dict(self) -> dict:
+        return {
+            "byte_length": self.byte_length,
+            "binary": self.binary,
+            "hex": self.hex,
+            "base64": self.base64,
+            "ternary": self.ternary,
+            "intent": list(self.intent),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "DenseBundle":
+        return cls(
+            byte_length=int(d["byte_length"]),
+            binary=str(d["binary"]),
+            hex=str(d["hex"]),
+            base64=str(d["base64"]),
+            ternary=str(d["ternary"]),
+            intent=tuple(int(x) for x in d.get("intent", ())),
+        )
+
+
+def route_lane_for_bundle(view_hint: str, bundle: DenseBundle | None = None) -> str:
+    """Pick a swarm-bus lane key from the encoding form.
+
+    The bus dispatches on the lane key returned here. `bundle` is
+    accepted but currently unused — kept in the signature so future
+    routing rules can inspect bundle properties (intent profile,
+    density ratio) without breaking callers.
+
+    Mapping rationale:
+        - "hex" / "binary" -> byte-level analysis (low-level decoders,
+          binary parsers, format inspectors)
+        - "ternary" -> governance / intent (the BT view IS Issac's
+          intent-layer encoding; route to the agent that reads intent)
+        - "base64" -> transport / opaque payload (deserializer, blob
+          handler, content-type sniffer)
+        - anything else -> default text lane
+    """
+    if view_hint in ("hex", "binary"):
+        return LANE_BINARY_ANALYSIS
+    if view_hint == "ternary":
+        return LANE_GOVERNANCE_INTENT
+    if view_hint == "base64":
+        return LANE_TRANSPORT_OPAQUE
+    return LANE_TEXT_DEFAULT
+
+
+def bundle_intent_profile(bundle: DenseBundle) -> dict[str, float]:
+    """Summarize the intent overlay as a 3-bucket histogram.
+
+    Useful for the swarm bus to decide which intent lane gets a
+    bundle: heavy NEG (high-bit) -> binary/payload lane, heavy POS
+    (low-ASCII) -> text lane, ZERO-rich -> null/governance lane.
+    """
+    if not bundle.intent:
+        return {"neg": 0.0, "zero": 0.0, "pos": 0.0}
+    n = len(bundle.intent)
+    neg = sum(1 for x in bundle.intent if x < 0)
+    zero = sum(1 for x in bundle.intent if x == 0)
+    pos = sum(1 for x in bundle.intent if x > 0)
+    return {"neg": neg / n, "zero": zero / n, "pos": pos / n}
+
+
+def encode_for_route(payload: bytes | str, view: str = "hex") -> tuple[DenseBundle, str]:
+    """One-shot helper for the swarm bus.
+
+    Returns `(bundle, lane_key)` so the bus can both ship the bundle
+    AND know which lane it's heading to.
+    """
+    if isinstance(payload, str):
+        bundle = DenseBundle.from_text(payload)
+    else:
+        bundle = DenseBundle.from_bytes(payload)
+    return bundle, route_lane_for_bundle(view, bundle)
+
+
+def equivalent_views(payload: bytes | Sequence[int]) -> tuple[bytes, bytes, bytes, bytes]:
+    """Return all four lossless byte views of the same payload.
+
+    Convenience for tests and for SFT augmentation pipelines that
+    want every parallel form of the same input.
+    """
+    if not isinstance(payload, (bytes, bytearray)):
+        payload = bytes(payload)
+    bundle = DenseBundle.from_bytes(bytes(payload))
+    return (
+        bundle.to_bytes("hex"),
+        bundle.to_bytes("binary"),
+        bundle.to_bytes("base64"),
+        bundle.to_bytes("ternary"),
+    )

--- a/tests/encoding/test_dense_bundle.py
+++ b/tests/encoding/test_dense_bundle.py
@@ -1,0 +1,192 @@
+"""Tests for src/encoding/dense_bundle.py."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.encoding.dense_bundle import (
+    LANE_BINARY_ANALYSIS,
+    LANE_GOVERNANCE_INTENT,
+    LANE_TEXT_DEFAULT,
+    LANE_TRANSPORT_OPAQUE,
+    DenseBundle,
+    bundle_intent_profile,
+    encode_for_route,
+    equivalent_views,
+    route_lane_for_bundle,
+)
+
+# ---------------------------------------------------------------------------
+# Round-trip: every byte view decodes back to the original payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"",
+        b"a",
+        b"hello",
+        b"\x00\x01\x02\x03\xff\xfe\xfd",
+        bytes(range(256)),
+        b"SCBE-AETHERMOORE",
+        "Sacred Tongues: KO/AV/RU/CA/UM/DR".encode("utf-8"),
+    ],
+)
+@pytest.mark.parametrize("view", ["hex", "binary", "base64", "ternary"])
+def test_byte_view_round_trip(payload: bytes, view: str) -> None:
+    bundle = DenseBundle.from_bytes(payload)
+    assert bundle.to_bytes(view) == payload, f"{view!r} view did not round-trip"
+
+
+def test_text_round_trip_unicode() -> None:
+    text = "phi: φ — Sacred Tongues 🌀 mix"
+    bundle = DenseBundle.from_text(text)
+    assert bundle.to_text("hex") == text
+    assert bundle.to_text("binary") == text
+    assert bundle.to_text("base64") == text
+    assert bundle.to_text("ternary") == text
+
+
+def test_empty_payload_is_well_defined() -> None:
+    bundle = DenseBundle.from_bytes(b"")
+    assert bundle.byte_length == 0
+    assert bundle.binary == ""
+    assert bundle.hex == ""
+    assert bundle.base64 == ""
+    assert bundle.intent == ()
+    for view in ("hex", "binary", "base64", "ternary"):
+        assert bundle.to_bytes(view) == b""
+
+
+# ---------------------------------------------------------------------------
+# Encoding shape
+# ---------------------------------------------------------------------------
+
+
+def test_binary_view_is_eight_bits_per_byte() -> None:
+    bundle = DenseBundle.from_bytes(b"\x00\xff\xa5")
+    assert bundle.binary == "00000000" "11111111" "10100101"
+
+
+def test_hex_view_matches_bytes_hex() -> None:
+    payload = b"\xde\xad\xbe\xef"
+    assert DenseBundle.from_bytes(payload).hex == payload.hex()
+
+
+# ---------------------------------------------------------------------------
+# Intent overlay
+# ---------------------------------------------------------------------------
+
+
+def test_intent_overlay_polarity() -> None:
+    bundle = DenseBundle.from_bytes(b"\x00\x41\xff")
+    # 0x00 -> ZERO (0), 0x41 (low ASCII 'A') -> POS (+1), 0xff -> NEG (-1)
+    assert bundle.intent == (0, 1, -1)
+
+
+def test_intent_profile_sums_to_one() -> None:
+    bundle = DenseBundle.from_bytes(bytes(range(256)))
+    profile = bundle_intent_profile(bundle)
+    assert profile["neg"] + profile["zero"] + profile["pos"] == pytest.approx(1.0)
+    # 1 zero byte, 127 low-ASCII (POS), 128 high-bit (NEG)
+    assert profile["zero"] == pytest.approx(1 / 256)
+    assert profile["pos"] == pytest.approx(127 / 256)
+    assert profile["neg"] == pytest.approx(128 / 256)
+
+
+def test_intent_profile_empty() -> None:
+    bundle = DenseBundle.from_bytes(b"")
+    assert bundle_intent_profile(bundle) == {"neg": 0.0, "zero": 0.0, "pos": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# JSON serialization
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_round_trip() -> None:
+    bundle = DenseBundle.from_bytes(b"hello world")
+    serialized = json.dumps(bundle.to_dict())
+    restored = DenseBundle.from_dict(json.loads(serialized))
+    assert restored == bundle
+    assert restored.to_bytes("hex") == b"hello world"
+
+
+# ---------------------------------------------------------------------------
+# Bus routing
+# ---------------------------------------------------------------------------
+
+
+def test_route_lane_for_bundle_dispatch() -> None:
+    assert route_lane_for_bundle("hex") == LANE_BINARY_ANALYSIS
+    assert route_lane_for_bundle("binary") == LANE_BINARY_ANALYSIS
+    assert route_lane_for_bundle("ternary") == LANE_GOVERNANCE_INTENT
+    assert route_lane_for_bundle("base64") == LANE_TRANSPORT_OPAQUE
+    assert route_lane_for_bundle("text") == LANE_TEXT_DEFAULT
+    assert route_lane_for_bundle("unknown_view") == LANE_TEXT_DEFAULT
+
+
+def test_encode_for_route_returns_bundle_and_lane() -> None:
+    bundle, lane = encode_for_route("hello", view="ternary")
+    assert isinstance(bundle, DenseBundle)
+    assert lane == LANE_GOVERNANCE_INTENT
+    assert bundle.to_text("ternary") == "hello"
+
+    bundle_b, lane_b = encode_for_route(b"\x00\xff", view="hex")
+    assert lane_b == LANE_BINARY_ANALYSIS
+    assert bundle_b.to_bytes("hex") == b"\x00\xff"
+
+
+# ---------------------------------------------------------------------------
+# equivalent_views helper
+# ---------------------------------------------------------------------------
+
+
+def test_equivalent_views_all_match() -> None:
+    payload = b"the quick brown fox"
+    a, b, c, d = equivalent_views(payload)
+    assert a == b == c == d == payload
+
+
+def test_equivalent_views_accepts_int_sequence() -> None:
+    payload_ints = [0, 1, 2, 255]
+    a, b, c, d = equivalent_views(payload_ints)
+    assert a == b == c == d == bytes(payload_ints)
+
+
+# ---------------------------------------------------------------------------
+# Density observability
+# ---------------------------------------------------------------------------
+
+
+def test_density_ratio_sane() -> None:
+    bundle = DenseBundle.from_bytes(b"a" * 100)
+    # binary = 800 chars, hex = 200, base64 = ~136, ternary varies
+    ratio = bundle.density_ratio()
+    assert ratio > 10  # at minimum the binary view alone is 8x
+    assert ratio < 100  # sanity ceiling
+
+
+def test_density_ratio_empty_is_zero() -> None:
+    assert DenseBundle.from_bytes(b"").density_ratio() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Bad input
+# ---------------------------------------------------------------------------
+
+
+def test_to_bytes_unknown_view_raises() -> None:
+    bundle = DenseBundle.from_bytes(b"x")
+    with pytest.raises(ValueError, match="unknown view"):
+        bundle.to_bytes("invalid_view")
+
+
+def test_corrupted_binary_view_raises() -> None:
+    # Manually construct a bundle with a binary length that's not a multiple of 8.
+    bundle = DenseBundle(byte_length=1, binary="0101", hex="55", base64="VQ==", ternary="0", intent=(1,))
+    with pytest.raises(ValueError, match="multiple of 8"):
+        bundle.to_bytes("binary")


### PR DESCRIPTION
## Summary

First piece of the dense-data-bundles work. Adds \`src/encoding/dense_bundle.py\` — one payload, four lossless byte views (binary / hex / base64 / balanced-ternary) plus a per-byte intent overlay (+1/0/-1).

Implements the bit/float/trit theory note (\`notes/theory/2026-04-05-training-pair-taxonomy.md\`, row 10): "same byte, different intent polarity → 24x encoding density. Trit = intent layer (same code, different purpose)."

## What it does

- \`DenseBundle.from_bytes(payload)\` builds all five views in one shot
- All four byte views round-trip back to the same bytes (44 tests prove this)
- \`route_lane_for_bundle(view)\` returns a canonical swarm-bus lane key — the bus can dispatch on encoding form without new lane vocabulary:
  - \`hex\` / \`binary\` → \`binary_analysis\`
  - \`ternary\` → \`governance_intent\`
  - \`base64\` → \`transport_opaque\`
  - anything else → \`text_default\`

## Layering

Builds on existing \`BalancedTernary\` from \`src/symphonic_cipher/scbe_aethermoore/trinary.py\`. No new ternary math.

## Follow-ups (separate PRs)

- Wire \`route_lane_for_bundle\` into \`scripts/system/openclaw_swarm.py\` so the bus actually uses it
- SFT augmentation: add a \`dense_bundle\` field to coding-agent training records so the model trains on parallel views of the same input

## Test plan

- [x] \`PYTHONPATH=. python -m pytest tests/encoding/ -v\` — 44/44 green
- [x] black --target-version py311 --line-length 120 — clean
- [x] flake8 --max-line-length 120 — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)