### PR TITLE
feat(encoding): parallel batch augmenter (29 files in 10s vs 30s sequential)

### DIFF
--- a/scripts/encoding/parallel_augment_sft.py
+++ b/scripts/encoding/parallel_augment_sft.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Parallel batch augmenter for SFT JSONL files.
+
+Wraps `augment_sft_with_dense_bundle` in a multiprocessing pool so a
+whole directory of SFT files gets the dense_bundle treatment in
+parallel. The bash-loop version processed files serially; this one
+uses every available core.
+
+Usage:
+    python scripts/encoding/parallel_augment_sft.py \\
+        --input-dir artifacts/kaggle_datasets/scbe-coding-agent-stage6-repair-v7/ \\
+        --output-dir training-data/kaggle/dense_bundle_augmented/ \\
+        --workers 8
+
+Defaults: workers = number of CPUs - 1, glob = *.sft.jsonl.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing as mp
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+# Local import — keep relative to repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.encoding.dense_bundle import (  # noqa: E402
+    DenseBundle,
+    bundle_intent_profile,
+    route_lane_for_bundle,
+)
+
+
+@dataclass
+class JobResult:
+    input_path: str
+    output_path: str
+    records_in: int
+    records_out: int
+    bundles_added: int
+    elapsed_s: float
+    error: str | None = None
+
+
+def _augment_one_record(record: dict, target: str, default_view: str) -> dict:
+    """Pure record augmentation. Identical semantics to augment_record in
+    the sequential script — duplicated here so the worker process
+    doesn't need to import the script module (which would be brittle
+    across multiprocessing process boundaries).
+    """
+    messages = record.get("messages") or []
+    content: str | None = None
+    for msg in messages:
+        if msg.get("role") == target:
+            value = msg.get("content")
+            if isinstance(value, str):
+                content = value
+            elif isinstance(value, list):
+                content = "".join(p.get("text", "") for p in value if isinstance(p, dict))
+            break
+    if content is None or content == "":
+        return record
+    bundle = DenseBundle.from_text(content)
+    return {
+        **record,
+        "dense_bundle": {
+            "target": target,
+            "default_view": default_view,
+            "route_lane": route_lane_for_bundle(default_view, bundle),
+            "intent_profile": bundle_intent_profile(bundle),
+            "byte_length": bundle.byte_length,
+            "density_ratio": bundle.density_ratio(),
+            "views": {
+                "hex": bundle.hex,
+                "binary": bundle.binary,
+                "base64": bundle.base64,
+                "ternary": bundle.ternary,
+            },
+            "intent": list(bundle.intent),
+        },
+    }
+
+
+def _augment_file(args: tuple[str, str, str, str]) -> JobResult:
+    """Worker entry: augment one input file -> one output file."""
+    input_path, output_path, target, default_view = args
+    start = time.perf_counter()
+    in_p = Path(input_path)
+    out_p = Path(output_path)
+    out_p.parent.mkdir(parents=True, exist_ok=True)
+
+    records_in = 0
+    records_out = 0
+    bundles_added = 0
+    try:
+        with in_p.open("r", encoding="utf-8") as fin, out_p.open("w", encoding="utf-8") as fout:
+            for raw in fin:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                records_in += 1
+                try:
+                    record = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                augmented = _augment_one_record(record, target=target, default_view=default_view)
+                if "dense_bundle" in augmented:
+                    bundles_added += 1
+                fout.write(json.dumps(augmented, ensure_ascii=False))
+                fout.write("\n")
+                records_out += 1
+    except Exception as err:  # surface, don't crash the pool
+        return JobResult(
+            input_path=input_path,
+            output_path=output_path,
+            records_in=records_in,
+            records_out=records_out,
+            bundles_added=bundles_added,
+            elapsed_s=time.perf_counter() - start,
+            error=f"{type(err).__name__}: {err}",
+        )
+    return JobResult(
+        input_path=input_path,
+        output_path=output_path,
+        records_in=records_in,
+        records_out=records_out,
+        bundles_added=bundles_added,
+        elapsed_s=time.perf_counter() - start,
+    )
+
+
+def _discover_inputs(input_dir: Path, pattern: str) -> list[Path]:
+    return sorted(input_dir.glob(pattern))
+
+
+def _output_path_for(input_path: Path, input_dir: Path, output_dir: Path, suffix: str) -> Path:
+    rel = input_path.relative_to(input_dir)
+    base = rel.name
+    if base.endswith(".sft.jsonl"):
+        new_name = base[: -len(".sft.jsonl")] + suffix
+    elif base.endswith(".jsonl"):
+        new_name = base[: -len(".jsonl")] + suffix
+    else:
+        new_name = base + suffix
+    return output_dir / rel.parent / new_name
+
+
+def run(
+    input_dir: Path,
+    output_dir: Path,
+    pattern: str = "*.sft.jsonl",
+    workers: int | None = None,
+    target: str = "user",
+    default_view: str = "hex",
+    suffix: str = ".dense.jsonl",
+) -> tuple[list[JobResult], dict]:
+    """Run the parallel pool. Returns per-file results + aggregate stats."""
+    inputs = _discover_inputs(input_dir, pattern)
+    if not inputs:
+        return [], {"files": 0, "records_in": 0, "records_out": 0, "bundles_added": 0, "elapsed_s": 0.0}
+
+    workers = workers or max(1, (os.cpu_count() or 2) - 1)
+    workers = min(workers, len(inputs))
+
+    jobs = [(str(p), str(_output_path_for(p, input_dir, output_dir, suffix)), target, default_view) for p in inputs]
+
+    started = time.perf_counter()
+    if workers == 1:
+        results = [_augment_file(job) for job in jobs]
+    else:
+        with mp.Pool(processes=workers) as pool:
+            results = pool.map(_augment_file, jobs)
+    elapsed = time.perf_counter() - started
+
+    summary = {
+        "files": len(results),
+        "records_in": sum(r.records_in for r in results),
+        "records_out": sum(r.records_out for r in results),
+        "bundles_added": sum(r.bundles_added for r in results),
+        "elapsed_s": elapsed,
+        "workers": workers,
+        "errors": sum(1 for r in results if r.error),
+    }
+    return results, summary
+
+
+def _print_summary(results: Iterable[JobResult], summary: dict) -> None:
+    for r in results:
+        flag = f"  ERROR: {r.error}" if r.error else ""
+        print(
+            f"[{r.elapsed_s:6.2f}s] {Path(r.input_path).name}: "
+            f"{r.records_in} in -> {r.records_out} out, +{r.bundles_added} bundles{flag}"
+        )
+    print("---")
+    print(
+        f"DONE: {summary['files']} files, {summary['records_in']} records, "
+        f"+{summary['bundles_added']} bundles, {summary['elapsed_s']:.2f}s "
+        f"using {summary['workers']} workers, {summary['errors']} errors"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Parallel SFT dense-bundle augmenter.")
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--pattern", default="*.sft.jsonl")
+    parser.add_argument("--workers", type=int, default=None)
+    parser.add_argument("--target", default="user", choices=["user", "system", "assistant"])
+    parser.add_argument("--default-view", default="hex", choices=["hex", "binary", "base64", "ternary"])
+    parser.add_argument("--suffix", default=".dense.jsonl")
+    parser.add_argument("--quiet", action="store_true", help="Skip per-file lines, only print summary.")
+    args = parser.parse_args(argv)
+
+    if not args.input_dir.is_dir():
+        print(f"[error] input dir not found: {args.input_dir}", file=sys.stderr)
+        return 2
+
+    results, summary = run(
+        input_dir=args.input_dir,
+        output_dir=args.output_dir,
+        pattern=args.pattern,
+        workers=args.workers,
+        target=args.target,
+        default_view=args.default_view,
+        suffix=args.suffix,
+    )
+    if args.quiet:
+        print(
+            f"DONE: {summary['files']} files, {summary['records_in']} records, "
+            f"+{summary['bundles_added']} bundles, {summary['elapsed_s']:.2f}s, "
+            f"{summary['errors']} errors"
+        )
+    else:
+        _print_summary(results, summary)
+    return 1 if summary["errors"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/encoding/test_parallel_augment.py
+++ b/tests/encoding/test_parallel_augment.py
@@ -1,0 +1,152 @@
+"""Tests for scripts/encoding/parallel_augment_sft.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "encoding" / "parallel_augment_sft.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("_parallel_augment_sft", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def aug():
+    return _load_module()
+
+
+def _make_corpus(tmp_path: Path, files: dict[str, list[dict]]) -> Path:
+    src = tmp_path / "src"
+    src.mkdir()
+    for name, rows in files.items():
+        (src / name).write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return src
+
+
+# ---------------------------------------------------------------------------
+# Single-worker mode (no multiprocessing) — fast, deterministic
+# ---------------------------------------------------------------------------
+
+
+def test_single_worker_run(aug, tmp_path: Path) -> None:
+    src = _make_corpus(
+        tmp_path,
+        {
+            "a.sft.jsonl": [{"messages": [{"role": "user", "content": "hello"}]}],
+            "b.sft.jsonl": [{"messages": [{"role": "user", "content": "world"}]}],
+        },
+    )
+    out = tmp_path / "out"
+    results, summary = aug.run(input_dir=src, output_dir=out, workers=1)
+
+    assert summary["files"] == 2
+    assert summary["records_in"] == 2
+    assert summary["records_out"] == 2
+    assert summary["bundles_added"] == 2
+    assert summary["errors"] == 0
+    assert summary["workers"] == 1
+
+    a_out = out / "a.dense.jsonl"
+    b_out = out / "b.dense.jsonl"
+    assert a_out.exists()
+    assert b_out.exists()
+
+    rec = json.loads(a_out.read_text(encoding="utf-8").splitlines()[0])
+    assert rec["dense_bundle"]["byte_length"] == 5
+    assert rec["dense_bundle"]["views"]["hex"] == "68656c6c6f"
+
+
+def test_records_without_target_pass_through_unchanged(aug, tmp_path: Path) -> None:
+    src = _make_corpus(
+        tmp_path,
+        {
+            "a.sft.jsonl": [
+                {"messages": [{"role": "user", "content": "x"}]},
+                {"messages": [{"role": "system", "content": "no user turn"}]},
+            ]
+        },
+    )
+    out = tmp_path / "out"
+    _, summary = aug.run(input_dir=src, output_dir=out, workers=1)
+    assert summary["records_in"] == 2
+    assert summary["records_out"] == 2
+    assert summary["bundles_added"] == 1  # only the user-turn record
+
+    rows = [
+        json.loads(line) for line in (out / "a.dense.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    assert "dense_bundle" in rows[0]
+    assert "dense_bundle" not in rows[1]
+
+
+def test_empty_input_dir_returns_empty_summary(aug, tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    out = tmp_path / "out"
+    results, summary = aug.run(input_dir=src, output_dir=out, workers=1)
+    assert results == []
+    assert summary["files"] == 0
+    assert summary["records_in"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Output naming
+# ---------------------------------------------------------------------------
+
+
+def test_output_path_for_handles_three_extensions(aug, tmp_path: Path) -> None:
+    in_dir = tmp_path / "src"
+    out_dir = tmp_path / "out"
+    cases = [
+        ("foo.sft.jsonl", "foo.dense.jsonl"),
+        ("bar.jsonl", "bar.dense.jsonl"),
+        ("weird.txt", "weird.txt.dense.jsonl"),
+    ]
+    for input_name, expected in cases:
+        path = in_dir / input_name
+        result = aug._output_path_for(path, in_dir, out_dir, ".dense.jsonl")
+        assert result == out_dir / expected
+
+
+# ---------------------------------------------------------------------------
+# Workers parameter clamping
+# ---------------------------------------------------------------------------
+
+
+def test_worker_count_clamped_to_file_count(aug, tmp_path: Path) -> None:
+    """If we ask for 32 workers but only have 1 file, only 1 worker runs."""
+    src = _make_corpus(tmp_path, {"only.sft.jsonl": [{"messages": [{"role": "user", "content": "x"}]}]})
+    out = tmp_path / "out"
+    _, summary = aug.run(input_dir=src, output_dir=out, workers=32)
+    assert summary["workers"] == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_cli_missing_input_dir_returns_2(aug, tmp_path: Path) -> None:
+    rc = aug.main(["--input-dir", str(tmp_path / "nope"), "--output-dir", str(tmp_path / "out"), "--quiet"])
+    assert rc == 2
+
+
+def test_cli_quiet_path_runs(aug, tmp_path: Path, capsys) -> None:
+    src = _make_corpus(tmp_path, {"a.sft.jsonl": [{"messages": [{"role": "user", "content": "x"}]}]})
+    out = tmp_path / "out"
+    rc = aug.main(["--input-dir", str(src), "--output-dir", str(out), "--workers", "1", "--quiet"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "DONE:" in captured.out


### PR DESCRIPTION
## Summary

Multiprocessing pool wrapper around the dense-bundle augmentation logic from #1653. Same input format, same output format, same per-record semantics — just runs files in parallel instead of one at a time.

## Speedup

Smoke run on the full coding+chemistry corpus (29 files / 3,370 records / 3.9 MB):

| Mode | Wall time |
|---|---:|
| Sequential bash for-loop | ~30 s |
| Parallel pool (CPU_COUNT - 1 workers) | **10.05 s** |

3x speedup. More wins available with bigger corpora — pool overhead dominates at 29 files.

## Failure isolation

Errors per file are captured in the \`JobResult\` and surfaced in the summary, not raised. One bad file doesn't poison the pool.

## CLI

\`\`\`bash
PYTHONPATH=. python scripts/encoding/parallel_augment_sft.py \
  --input-dir artifacts/kaggle_datasets/scbe-coding-agent-stage6-repair-v7/ \
  --output-dir training-data/kaggle/dense_bundle_augmented/ \
  [--workers N] [--quiet]
\`\`\`

## Test plan

- [x] \`PYTHONPATH=. python -m pytest tests/encoding/ -q\` — **61/61 green**
- [x] Smoke-ran on real 29-file corpus, 0 errors
- [x] black + flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)