### PR TITLE
fix(kaggle): drop page_size kwarg from dataset_list

### DIFF
--- a/scripts/kaggle/scbe_kaggle.py
+++ b/scripts/kaggle/scbe_kaggle.py
@@ -155,7 +155,7 @@ class KaggleBridge:
     def list_my_datasets(self, limit: int = 50) -> list[dict]:
         api = self._get_api()
         # The CLI surface returns Dataset objects; convert to dicts.
-        raw = api.dataset_list(mine=True, page_size=limit)
+        raw = api.dataset_list(mine=True)
         out: list[dict] = []
         for ds in raw[:limit]:
             out.append(

--- a/tests/kaggle/test_scbe_kaggle.py
+++ b/tests/kaggle/test_scbe_kaggle.py
@@ -174,7 +174,7 @@ def test_list_my_datasets_shapes_results(sk) -> None:
     fake_ds = MagicMock(ref="me/x", title="X", totalBytes=100, lastUpdated="2026-05-11", isPrivate=True)
     api.dataset_list.return_value = [fake_ds]
     rows = bridge.list_my_datasets(limit=10)
-    api.dataset_list.assert_called_once_with(mine=True, page_size=10)
+    api.dataset_list.assert_called_once_with(mine=True)
     assert rows == [{"ref": "me/x", "title": "X", "size": 100, "last_updated": "2026-05-11", "is_private": True}]
 
 


### PR DESCRIPTION
## Summary
- `npm run kaggle:list` was crashing: newer kaggle CLI removed `page_size` from `dataset_list`. Trying the suggested replacement `max_size` silently returned `[]` because that kwarg filters by bytes, not count.
- Drop the kwarg entirely; the bridge already slices `[:limit]` after the fact.

## Test plan
- [x] `pytest tests/kaggle/test_scbe_kaggle.py` — 26/26 pass
- [x] `npm run kaggle:list` — returns 6 datasets (previously errored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)