### PR TITLE
feat(router): add Pazaak bitboard routing plan

### DIFF
--- a/config/eval/agentic_pazaak_cards.v1.json
+++ b/config/eval/agentic_pazaak_cards.v1.json
@@ -1,0 +1,84 @@
+{
+  "schema": "scbe_agentic_pazaak_cards_v1",
+  "description": "Pazaak-inspired bounded action cards for agentic task routing. Cards are small deterministic moves over a bitboard-style task state.",
+  "symbols": {
+    "+1": "constructive/amplify",
+    "-1": "destructive/contract",
+    "+0": "neutral-pass/abstain-continue",
+    "-0": "neutral-hold/abstain-quarantine"
+  },
+  "cards": [
+    {
+      "id": "stand_hold",
+      "symbol": "-0",
+      "name": "Stand Hold",
+      "effect": "Hold a risky or under-evidenced lane without discarding it.",
+      "risk_delta": -1,
+      "value_delta": 0,
+      "best_for": ["high_risk", "missing_evidence", "needs_human"]
+    },
+    {
+      "id": "pass_continue",
+      "symbol": "+0",
+      "name": "Pass Continue",
+      "effect": "Leave a lane active when no intervention is needed.",
+      "risk_delta": 0,
+      "value_delta": 0,
+      "best_for": ["already_clean", "low_risk"]
+    },
+    {
+      "id": "focus_plus",
+      "symbol": "+1",
+      "name": "Focus Plus",
+      "effect": "Attach narrow context or focus paths to improve model signal.",
+      "risk_delta": -1,
+      "value_delta": 2,
+      "best_for": ["context_noise", "weak_model", "repo_large"]
+    },
+    {
+      "id": "verify_minus_risk",
+      "symbol": "-1",
+      "name": "Verify Minus Risk",
+      "effect": "Run deterministic verifier, lookup table, tests, or parser gate before promotion.",
+      "risk_delta": -3,
+      "value_delta": 1,
+      "best_for": ["unverified", "high_risk", "benchmark"]
+    },
+    {
+      "id": "swap_lane",
+      "symbol": "+1",
+      "name": "Swap Lane",
+      "effect": "Move the task to a better agent/model lane while preserving artifacts.",
+      "risk_delta": -1,
+      "value_delta": 1,
+      "best_for": ["wrong_agent", "model_mismatch", "stalled"]
+    },
+    {
+      "id": "double_team",
+      "symbol": "+1",
+      "name": "Double Team",
+      "effect": "Run two independent agents on the same bounded subproblem and compare.",
+      "risk_delta": 1,
+      "value_delta": 3,
+      "best_for": ["high_value", "ambiguous", "architecture"]
+    },
+    {
+      "id": "discard_branch",
+      "symbol": "-1",
+      "name": "Discard Branch",
+      "effect": "Prune a low-value or repeatedly failing branch.",
+      "risk_delta": -2,
+      "value_delta": -1,
+      "best_for": ["low_value", "repeated_fail", "off_scope"]
+    },
+    {
+      "id": "claim_territory",
+      "symbol": "+1",
+      "name": "Claim Territory",
+      "effect": "Assign ownership of a repo/file/domain region to one lane to prevent conflicts.",
+      "risk_delta": -2,
+      "value_delta": 2,
+      "best_for": ["multi_agent", "file_conflict", "go_influence"]
+    }
+  ]
+}

--- a/scripts/system/agentic_pazaak_board.py
+++ b/scripts/system/agentic_pazaak_board.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Pazaak-style bitboard planner for SCBE agent routing.
+
+This is a deterministic planning primitive, not a model caller. It maps task
+lanes into small bitboards and scores bounded "card" actions such as hold,
+verify, focus, swap, double-team, discard, and claim-territory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CARD_FILE = REPO_ROOT / "config" / "eval" / "agentic_pazaak_cards.v1.json"
+
+
+@dataclass(frozen=True)
+class TaskLane:
+    lane_id: str
+    value: int = 1
+    risk: int = 0
+    verified: bool = False
+    blocked: bool = False
+    context_noise: bool = False
+    conflict: bool = False
+    stalled: bool = False
+    owner: str = ""
+
+
+@dataclass(frozen=True)
+class Card:
+    card_id: str
+    symbol: str
+    name: str
+    effect: str
+    risk_delta: int
+    value_delta: int
+    best_for: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Move:
+    lane_id: str
+    card_id: str
+    card_name: str
+    symbol: str
+    score: float
+    reason: str
+    before: dict[str, Any]
+    after: dict[str, Any]
+
+
+def load_cards(path: Path = DEFAULT_CARD_FILE) -> list[Card]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    cards = []
+    for item in payload.get("cards", []):
+        cards.append(
+            Card(
+                card_id=str(item["id"]),
+                symbol=str(item["symbol"]),
+                name=str(item["name"]),
+                effect=str(item["effect"]),
+                risk_delta=int(item.get("risk_delta", 0)),
+                value_delta=int(item.get("value_delta", 0)),
+                best_for=tuple(str(x) for x in item.get("best_for", [])),
+            )
+        )
+    return cards
+
+
+def load_lanes(path: Path | None) -> list[TaskLane]:
+    if path is None:
+        return [
+            TaskLane("implementation", value=4, risk=2, context_noise=True),
+            TaskLane("verification", value=5, risk=4, verified=False),
+            TaskLane("docs", value=2, risk=1, verified=True),
+            TaskLane("integration", value=5, risk=3, conflict=True),
+        ]
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    rows = payload.get("lanes", payload if isinstance(payload, list) else [])
+    return [
+        TaskLane(
+            lane_id=str(row.get("lane_id") or row.get("id")),
+            value=int(row.get("value", 1)),
+            risk=int(row.get("risk", 0)),
+            verified=bool(row.get("verified", False)),
+            blocked=bool(row.get("blocked", False)),
+            context_noise=bool(row.get("context_noise", False)),
+            conflict=bool(row.get("conflict", False)),
+            stalled=bool(row.get("stalled", False)),
+            owner=str(row.get("owner", "")),
+        )
+        for row in rows
+    ]
+
+
+def bitboards(lanes: list[TaskLane]) -> dict[str, int]:
+    boards = {
+        "high_value": 0,
+        "high_risk": 0,
+        "unverified": 0,
+        "blocked": 0,
+        "context_noise": 0,
+        "conflict": 0,
+        "stalled": 0,
+        "owned": 0,
+    }
+    for idx, lane in enumerate(lanes):
+        mask = 1 << idx
+        if lane.value >= 4:
+            boards["high_value"] |= mask
+        if lane.risk >= 3:
+            boards["high_risk"] |= mask
+        if not lane.verified:
+            boards["unverified"] |= mask
+        if lane.blocked:
+            boards["blocked"] |= mask
+        if lane.context_noise:
+            boards["context_noise"] |= mask
+        if lane.conflict:
+            boards["conflict"] |= mask
+        if lane.stalled:
+            boards["stalled"] |= mask
+        if lane.owner:
+            boards["owned"] |= mask
+    return boards
+
+
+def lane_tags(lane: TaskLane) -> set[str]:
+    tags = set()
+    if lane.value >= 4:
+        tags.add("high_value")
+    if lane.value <= 1:
+        tags.add("low_value")
+    if lane.risk >= 3:
+        tags.add("high_risk")
+    if lane.risk <= 1:
+        tags.add("low_risk")
+    if not lane.verified:
+        tags.add("unverified")
+    if lane.blocked:
+        tags.add("needs_human")
+    if lane.context_noise:
+        tags.update({"context_noise", "repo_large"})
+    if lane.conflict:
+        tags.update({"file_conflict", "multi_agent", "go_influence"})
+    if lane.stalled:
+        tags.update({"stalled", "repeated_fail"})
+    if lane.verified and lane.risk <= 1:
+        tags.add("already_clean")
+    return tags
+
+
+def apply_card(lane: TaskLane, card: Card) -> TaskLane:
+    risk = max(0, lane.risk + card.risk_delta)
+    value = max(0, lane.value + card.value_delta)
+    blocked = lane.blocked
+    verified = lane.verified
+    owner = lane.owner
+    if card.card_id == "stand_hold":
+        blocked = True
+    elif card.card_id == "pass_continue":
+        blocked = False
+    elif card.card_id == "verify_minus_risk":
+        verified = True
+    elif card.card_id == "claim_territory" and not owner:
+        owner = "assigned"
+    elif card.card_id == "discard_branch":
+        blocked = True
+    return TaskLane(
+        lane_id=lane.lane_id,
+        value=value,
+        risk=risk,
+        verified=verified,
+        blocked=blocked,
+        context_noise=lane.context_noise,
+        conflict=lane.conflict,
+        stalled=lane.stalled,
+        owner=owner,
+    )
+
+
+def score_card(lane: TaskLane, card: Card) -> tuple[float, str]:
+    tags = lane_tags(lane)
+    matches = sorted(tags.intersection(card.best_for))
+    score = float(lane.value) - (0.75 * lane.risk)
+    score += len(matches) * 2.0
+    score += max(0, -card.risk_delta) * 1.25
+    score += card.value_delta * 0.75
+    if card.card_id == "double_team" and lane.risk >= 4:
+        score -= 2.0
+    if card.card_id == "discard_branch" and lane.value >= 4:
+        score -= 4.0
+    if card.card_id == "pass_continue" and not lane.verified:
+        score -= 3.0
+    reason = "matched " + ", ".join(matches) if matches else "general fit"
+    return round(score, 3), reason
+
+
+def recommend_moves(lanes: list[TaskLane], cards: list[Card], limit: int = 5) -> list[Move]:
+    moves: list[Move] = []
+    for lane in lanes:
+        for card in cards:
+            score, reason = score_card(lane, card)
+            after = apply_card(lane, card)
+            moves.append(
+                Move(
+                    lane_id=lane.lane_id,
+                    card_id=card.card_id,
+                    card_name=card.name,
+                    symbol=card.symbol,
+                    score=score,
+                    reason=reason,
+                    before=asdict(lane),
+                    after=asdict(after),
+                )
+            )
+    return sorted(moves, key=lambda move: (-move.score, move.lane_id, move.card_id))[:limit]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lanes", type=Path, default=None, help="Optional JSON list or {'lanes': [...]} file.")
+    parser.add_argument("--cards", type=Path, default=DEFAULT_CARD_FILE)
+    parser.add_argument("--limit", type=int, default=5)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    lanes = load_lanes(args.lanes)
+    cards = load_cards(args.cards)
+    payload = {
+        "schema": "scbe_agentic_pazaak_board_report_v1",
+        "lane_count": len(lanes),
+        "bitboards": bitboards(lanes),
+        "moves": [asdict(move) for move in recommend_moves(lanes, cards, limit=args.limit)],
+    }
+    text = json.dumps(payload, indent=2, ensure_ascii=True)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n", encoding="utf-8")
+        print(f"wrote {args.out}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/system/openclaw_swarm.py
+++ b/scripts/system/openclaw_swarm.py
@@ -16,6 +16,7 @@ looks good, feed its unified diff through ``scripts/agents/safe_apply.py``.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import re
@@ -36,6 +37,7 @@ DEFAULT_OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://127.0.0.1:11434").rstr
 DEFAULT_MODELS = ("openclaw:latest", "qwen2.5-coder:1.5b", "scbe-geoseal-coder:q8")
 KNOWLEDGE_GRAPH_PATH = REPO_ROOT / "docs" / "research" / "SCBE_BUS_TASK_KNOWLEDGE_GRAPH_2026-05-10.json"
 CODING_SYSTEM_REGISTRY_PATH = REPO_ROOT / "docs" / "research" / "SCBE_CODING_SYSTEM_REGISTRY_2026-05-10.json"
+PAZAAK_BOARD_PATH = Path(__file__).with_name("agentic_pazaak_board.py")
 
 
 @dataclass(frozen=True)
@@ -81,6 +83,16 @@ class WorkLane:
     cycle_policy: str
     trust_policy: str
     output_contract: str
+
+
+def _load_pazaak_board_module() -> Any:
+    spec = importlib.util.spec_from_file_location("_agentic_pazaak_board_runtime", PAZAAK_BOARD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load Pazaak planner from {PAZAAK_BOARD_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, module)
+    spec.loader.exec_module(module)
+    return module
 
 
 AGENT_PROFILES: dict[str, AgentProfile] = {
@@ -741,6 +753,86 @@ def build_lanes(task: str, agents: list[ResolvedAgent], allowed_paths: tuple[str
     return lanes
 
 
+def _lane_conflicts(lanes: list[WorkLane]) -> set[str]:
+    owners_by_path: dict[str, set[str]] = {}
+    for lane in lanes:
+        if lane.lane_tier not in {"builder", "escalation"}:
+            continue
+        for path in lane.allowed_paths:
+            owners_by_path.setdefault(path, set()).add(lane.lane_id)
+    conflicts: set[str] = set()
+    for owners in owners_by_path.values():
+        if len(owners) > 1:
+            conflicts.update(owners)
+    return conflicts
+
+
+def _lane_value(lane: WorkLane, result: dict[str, Any] | None = None) -> int:
+    base_by_tier = {"helper": 2, "builder": 4, "guard": 4, "packager": 3, "escalation": 5}
+    value = base_by_tier.get(lane.lane_tier, 3)
+    if result is not None:
+        value += 1 if int(result.get("applicability_score", 0)) >= 85 else 0
+        value -= 1 if result.get("quality_flags") else 0
+    return max(1, min(5, value))
+
+
+def _lane_risk(lane: WorkLane, result: dict[str, Any] | None = None) -> int:
+    risk = 1
+    if lane.lane_tier in {"builder", "escalation"}:
+        risk += 1
+    if lane.cost_tier != "free_local":
+        risk += 1
+    if any(path.startswith(("package", ".github", "api/", "src/")) for path in lane.allowed_paths):
+        risk += 1
+    if result is not None:
+        risk += min(3, len(result.get("quality_flags") or []))
+        if not result.get("ok", False):
+            risk += 2
+        if int(result.get("applicability_score", 0)) >= 90 and not result.get("quality_flags"):
+            risk -= 1
+    return max(0, min(6, risk))
+
+
+def build_pazaak_plan(
+    lanes: list[WorkLane],
+    results: list[dict[str, Any]] | None = None,
+    limit: int = 8,
+) -> dict[str, Any]:
+    board = _load_pazaak_board_module()
+    result_by_lane = {item.get("lane", {}).get("lane_id"): item for item in results or []}
+    conflicts = _lane_conflicts(lanes)
+    pazaak_lanes = []
+    for lane in lanes:
+        result = result_by_lane.get(lane.lane_id)
+        flags = result.get("quality_flags") if result else []
+        ok = bool(result.get("ok", False)) if result else False
+        pazaak_lanes.append(
+            board.TaskLane(
+                lane_id=lane.lane_id,
+                value=_lane_value(lane, result),
+                risk=_lane_risk(lane, result),
+                verified=bool(result and ok and not flags),
+                blocked=bool(result and (not ok or flags)),
+                context_noise=len(lane.allowed_paths) > 3,
+                conflict=lane.lane_id in conflicts,
+                stalled=bool(result and (not ok or flags)),
+                owner=lane.agent_alias if lane.lane_tier in {"guard", "packager"} else "",
+            )
+        )
+    cards = board.load_cards()
+    moves = board.recommend_moves(pazaak_lanes, cards, limit=limit)
+    return {
+        "schema": "scbe_swarm_pazaak_plan_v1",
+        "planner": "scripts/system/agentic_pazaak_board.py",
+        "cards": str(board.DEFAULT_CARD_FILE.relative_to(REPO_ROOT)),
+        "lane_count": len(pazaak_lanes),
+        "bitboards": board.bitboards(pazaak_lanes),
+        "lanes": [asdict(lane) for lane in pazaak_lanes],
+        "moves": [asdict(move) for move in moves],
+        "top_move": asdict(moves[0]) if moves else None,
+    }
+
+
 def _safe_kaggle_context_hint() -> str:
     """Pull a Kaggle context block if the env var is set; never crash the bus."""
     try:
@@ -1319,6 +1411,28 @@ def build_integration_plan(task: str, results: list[dict[str, Any]], routing: di
         f"- mean_applicability_score: `{routing['assurance_packet']['mean_applicability_score']}`",
         f"- paid_escalation_note: {routing['paid_escalation_note']}",
         "",
+        "## Pazaak Board Recommendation",
+        "",
+    ]
+    pazaak_plan = routing.get("pazaak_plan") or {}
+    if pazaak_plan.get("moves"):
+        lines.extend(["| Lane | Card | Symbol | Score | Reason |", "|---|---|---:|---:|---|"])
+        for move in pazaak_plan["moves"][:6]:
+            lines.append(
+                f"| `{move['lane_id']}` | {move['card_name']} | `{move['symbol']}` | "
+                f"{move['score']} | {move['reason']} |"
+            )
+        lines.extend(
+            [
+                "",
+                f"- bitboards: `{json.dumps(pazaak_plan.get('bitboards', {}), sort_keys=True)}`",
+                "",
+            ]
+        )
+    else:
+        lines.extend(["No Pazaak board moves were generated.", ""])
+    lines.extend(
+        [
         "## Assurance Packet",
         "",
         f"- readiness: `{routing['assurance_packet']['readiness']}`",
@@ -1326,7 +1440,8 @@ def build_integration_plan(task: str, results: list[dict[str, Any]], routing: di
         "",
         "| Requirement | Evidence Rule |",
         "|---|---|",
-    ]
+        ]
+    )
     for key, value in routing["assurance_packet"]["requirements"].items():
         lines.append(f"| `{key}` | {value} |")
     lines.extend(
@@ -1537,6 +1652,9 @@ def main() -> int:
 
     _write_json(run_dir / "results.json", {"task": args.task, "results": results})
     routing = build_routing_recommendation(results, resolved_agents)
+    pazaak_plan = build_pazaak_plan(lanes, results, limit=8)
+    routing["pazaak_plan"] = pazaak_plan
+    _write_json(run_dir / "pazaak_plan.json", pazaak_plan)
     _write_json(run_dir / "routing.json", routing)
     plan = build_integration_plan(args.task, results, routing)
     (run_dir / "integration_plan.md").write_text(plan, encoding="utf-8")
@@ -1545,6 +1663,7 @@ def main() -> int:
     _write_json(latest / "results.json", {"task": args.task, "run_dir": str(run_dir), "results": results})
     _write_json(latest / "agents.json", [asdict(agent) for agent in resolved_agents])
     _write_json(latest / "routing.json", routing)
+    _write_json(latest / "pazaak_plan.json", pazaak_plan)
     (latest / "integration_plan.md").write_text(plan, encoding="utf-8")
 
     print(
@@ -1571,6 +1690,7 @@ def main() -> int:
                 "quality_flag_counts": summarize_quality_flags(results),
                 "next_action": routing["next_action"],
                 "next_cycle": routing["next_cycle"],
+                "pazaak_top_move": pazaak_plan.get("top_move"),
                 "integration_plan": str(run_dir / "integration_plan.md"),
             },
             indent=2,

--- a/scripts/system/scbe_swarm_router.py
+++ b/scripts/system/scbe_swarm_router.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Canonical entrypoint for the SCBE multi-swarm router.
+
+`openclaw_swarm.py` remains as a compatibility entrypoint because earlier local
+artifacts and docs referenced it. The system is broader than OpenClaw: OpenClaw
+is one router/bootstrap surface among many possible free/local agent swarms.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_COMPAT_PATH = Path(__file__).with_name("openclaw_swarm.py")
+_SPEC = importlib.util.spec_from_file_location("_scbe_swarm_router_impl", _COMPAT_PATH)
+if _SPEC is None or _SPEC.loader is None:
+    raise RuntimeError(f"cannot load swarm router implementation from {_COMPAT_PATH}")
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(_MODULE.main())

--- a/tests/system/test_agentic_pazaak_board.py
+++ b/tests/system/test_agentic_pazaak_board.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "system" / "agentic_pazaak_board.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("_agentic_pazaak_board_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bitboards_encode_lane_flags() -> None:
+    module = load_module()
+    lanes = [
+        module.TaskLane("clean", value=2, risk=1, verified=True),
+        module.TaskLane("risky", value=5, risk=4, verified=False, conflict=True),
+    ]
+
+    boards = module.bitboards(lanes)
+
+    assert boards["high_value"] == 0b10
+    assert boards["high_risk"] == 0b10
+    assert boards["unverified"] == 0b10
+    assert boards["conflict"] == 0b10
+
+
+def test_stand_hold_is_negative_zero_quarantine_move() -> None:
+    module = load_module()
+    card = next(card for card in module.load_cards() if card.card_id == "stand_hold")
+    lane = module.TaskLane("uncertain", value=3, risk=4, verified=False)
+
+    after = module.apply_card(lane, card)
+
+    assert card.symbol == "-0"
+    assert after.blocked is True
+    assert after.risk == 3
+
+
+def test_recommend_moves_prefers_verifier_for_high_risk_unverified_lane() -> None:
+    module = load_module()
+    cards = module.load_cards()
+    lanes = [module.TaskLane("verification", value=5, risk=4, verified=False)]
+
+    moves = module.recommend_moves(lanes, cards, limit=3)
+
+    assert moves[0].card_id == "verify_minus_risk"
+    assert moves[0].after["verified"] is True
+    assert moves[0].after["risk"] == 1
+
+
+def test_recommend_moves_prefers_claim_territory_for_conflict_lane() -> None:
+    module = load_module()
+    cards = module.load_cards()
+    lanes = [module.TaskLane("integration", value=5, risk=3, verified=False, conflict=True)]
+
+    moves = module.recommend_moves(lanes, cards, limit=3)
+
+    assert any(move.card_id == "claim_territory" for move in moves)

--- a/tests/test_openclaw_swarm.py
+++ b/tests/test_openclaw_swarm.py
@@ -1,0 +1,592 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "scripts" / "system" / "openclaw_swarm.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("_openclaw_swarm_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_mentioned_paths_normalizes_diff_prefixes():
+    module = load_module()
+
+    text = """
+    diff --git a/scripts/system/openclaw_swarm.py b/scripts/system/openclaw_swarm.py
+    --- a/scripts/system/openclaw_swarm.py
+    +++ b/scripts/system/openclaw_swarm.py
+    Files:
+      - /docs/AETHERBROWSER_PACK.md
+    Verification: ./scripts/system/openclaw_swarm.py
+    """
+
+    assert module.extract_mentioned_paths(text) == [
+        "docs/AETHERBROWSER_PACK.md",
+        "scripts/system/openclaw_swarm.py",
+    ]
+
+
+def test_quality_flags_reject_placeholder_and_git_mutating_verification():
+    module = load_module()
+
+    text = """
+    1. Decision: build
+    2. Files:
+       - scripts/system/missing.sh
+    3. Patch:
+    ```diff
+    diff --git a/scripts/system/missing.sh b/scripts/system/missing.sh
+    index 1234567..89abcdef 100755
+    ```
+    4. Verification: git add scripts/system/missing.sh && git commit -m test
+    """
+
+    flags = module.quality_flags(text, ("scripts/system/",))
+
+    assert "path_not_found:scripts/system/missing.sh" in flags
+    assert "placeholder_diff_index" in flags
+    assert "verification_mutates_git_state" in flags
+
+
+def test_quality_flags_accept_existing_scoped_file_reference():
+    module = load_module()
+
+    text = """
+    1. Decision: defer
+    2. Files:
+       - aetherdesk/server.js
+    3. Patch: none
+    4. Verification: npx vitest run tests/aetherdesk/server.test.ts
+    5. Risk: proposal only.
+    """
+
+    assert module.quality_flags(text, ("aetherdesk/", "tests/")) == []
+
+
+def test_resolve_agent_uses_catalog_and_fallback_candidates():
+    module = load_module()
+
+    resolved = module.resolve_agent("opencode", {"qwen2.5-coder:1.5b"})
+
+    assert resolved.status == "active"
+    assert resolved.model == "qwen2.5-coder:1.5b"
+    assert resolved.profile.launch_command == "ollama launch opencode"
+    assert resolved.profile.geometry_role == "open-source patch proposer"
+    assert resolved.execution_surface == "ollama_local"
+    assert resolved.cost_tier == "free_local"
+
+
+def test_resolve_agent_skips_missing_catalog_agent_without_losing_launch_path():
+    module = load_module()
+
+    resolved = module.resolve_agent("claude", set())
+
+    assert resolved.status == "skipped"
+    assert resolved.model is None
+    assert resolved.profile.launch_command == "ollama launch claude"
+    assert resolved.execution_surface == "none"
+
+
+def test_quality_flags_accept_markdown_bold_decision_label():
+    module = load_module()
+
+    text = """
+    1. **Decision**: defer
+    2. Files:
+       - aetherdesk/server.js
+    3. Patch: none
+    4. Verification: npx vitest run tests/aetherdesk/server.test.ts
+    5. Risk: proposal only.
+    """
+
+    assert "decision_missing_or_ambiguous" not in module.quality_flags(text, ("aetherdesk/", "tests/"))
+
+
+def test_quality_flags_accept_markdown_bold_decision_value():
+    module = load_module()
+
+    text = """
+    1. Decision: **build**
+    2. Files:
+       - aetherdesk/server.js
+    3. Patch: none
+    4. Verification: npx vitest run tests/aetherdesk/server.test.ts
+    5. Risk: proposal only.
+    """
+
+    assert "decision_missing_or_ambiguous" not in module.quality_flags(text, ("aetherdesk/", "tests/"))
+
+
+def test_quality_flags_accept_json_style_decision_value():
+    module = load_module()
+
+    text = """
+    {
+      "Decision": "evidence",
+      "Files checked": ["scripts/system/openclaw_swarm.py"]
+    }
+    """
+
+    assert "decision_missing_or_ambiguous" not in module.quality_flags(text, ("scripts/",))
+
+
+def test_quality_flags_accept_answer_contract_without_paths():
+    module = load_module()
+
+    text = """
+    1. Decision: answer
+    2. Capability: You can run local role benchmarks.
+    3. Limits: No repo mutation.
+    4. Next action: Run the role test.
+    5. Risk: Low.
+    """
+
+    assert module.quality_flags(text, ("docs/",), require_paths=False) == []
+
+
+def test_quality_flags_answer_contract_ignores_limit_path_mentions():
+    module = load_module()
+
+    text = """
+    1. Decision: answer
+    2. Capability: You can read public docs.
+    3. Limits: You cannot modify `.git` or `.env`.
+    4. Next action: Read docs.
+    5. Risk: Low.
+    """
+
+    assert module.quality_flags(text, ("docs/",), require_paths=False, check_paths=False) == []
+
+
+def test_quality_flags_reject_unresolved_answer_decision_template():
+    module = load_module()
+
+    text = """
+    1. Decision: answer | defer | needs-human
+    2. Capability: You can read public docs.
+    """
+
+    assert "unresolved_decision_template" in module.quality_flags(
+        text,
+        ("docs/",),
+        require_paths=False,
+        check_paths=False,
+    )
+
+
+def test_quality_flags_reject_non_git_diff_and_invented_runner_flag():
+    module = load_module()
+
+    text = """
+    1. **Decision**: build
+    2. **Files**:
+       - `tests/test_agent_router_bridge_tasks.py`
+    3. **Patch**:
+    ```diff
+    --- tests/test_agent_router_bridge_tasks.py.orig 2023-10-05
+    +++ tests/test_agent_router_bridge_tasks.py 2023-10-05
+    @@ -1,2 +1,3 @@
+    +from hermes.agent.router.result_quality import AgentRouterResultQuality
+    ```
+    4. **Verification**:
+    ```bash
+    pytest -v tests/test_agent_router_bridge_tasks.py --hermes-agent=hermes
+    ```
+    """
+
+    flags = module.quality_flags(text, ("tests/", "scripts/"))
+
+    assert "non_git_unified_diff_context" in flags
+    assert "invented_test_runner_flag" in flags
+    assert "probable_external_module_import" in flags
+
+
+def test_quality_flags_reject_wrapper_symbol_hallucination():
+    module = load_module()
+
+    text = """
+    1. Decision: build
+    2. Files:
+       - scripts/system/scbe_swarm_router.py
+    3. Patch:
+    ```diff
+    --- a/scripts/system/scbe_swarm_router.py
+    +++ b/scripts/system/scbe_swarm_router.py
+    @@ -1,2 +1,3 @@
+     class SCBESwarmRouter:
+         pass
+    ```
+    4. Verification: python -m py_compile scripts/system/scbe_swarm_router.py
+    """
+
+    assert "probable_wrapper_symbol_hallucination" in module.quality_flags(text, ("scripts/",))
+
+
+def test_quality_flags_reject_missing_context_symbol():
+    module = load_module()
+
+    text = """
+    1. Decision: build
+    2. Files:
+       - scripts/system/scbe_swarm_router.py
+    3. Patch:
+    ```diff
+    --- a/scripts/system/scbe_swarm_router.py
+    +++ b/scripts/system/scbe_swarm_router.py
+    @@ -42,6 +42,9 @@ class DefinitelyMissingRouter:
+         pass
+    ```
+    4. Verification: python -m py_compile scripts/system/scbe_swarm_router.py
+    """
+
+    flags = module.quality_flags(text, ("scripts/",))
+
+    assert "symbol_not_found:scripts/system/scbe_swarm_router.py#DefinitelyMissingRouter" in flags
+
+
+def test_quality_flags_reject_evidence_symbols_not_present_in_checked_files():
+    module = load_module()
+
+    text = """
+    1. Decision: evidence
+    2. Files checked:
+       - scripts/system/openclaw_swarm.py
+    3. Declarations:
+       - `load_task_graph_prompt`
+       - `WorkLane`
+    4. Builder handoff: Patch only real declarations.
+    5. Risk: invented declarations poison the builder lane.
+    """
+
+    flags = module.quality_flags(text, ("scripts/",), require_paths=True)
+
+    assert "evidence_symbol_not_found:load_task_graph_prompt" in flags
+    assert "evidence_symbol_not_found:WorkLane" not in flags
+
+
+def test_quality_flags_do_not_treat_evidence_file_stems_as_symbols():
+    module = load_module()
+
+    text = """
+    1. Decision: evidence
+    2. Files checked:
+       - `scripts/benchmark/openclaw_swarm_benchmark.py`
+       - `docs/research/SCBE_SWARM_ROUTER_COMPARISON_2026-05-10.md`
+    3. Declarations:
+       - `BenchmarkCase` (from scripts/benchmark/openclaw_swarm_benchmark.py)
+       - `openclaw_swarm_benchmark` evidence file
+       - `SCBE_SWARM_ROUTER_COMPARISON_2026` evidence note
+    """
+
+    flags = module.quality_flags(text, ("scripts/", "docs/"), require_paths=True)
+
+    assert "evidence_symbol_not_found:openclaw_swarm_benchmark" not in flags
+    assert "evidence_symbol_not_found:SCBE_SWARM_ROUTER_COMPARISON_2026" not in flags
+
+
+def test_applicability_score_penalizes_hard_blockers():
+    module = load_module()
+
+    score = module.applicability_score(
+        [
+            "path_not_found:scripts/missing.py",
+            "symbol_not_found:scripts/system/scbe_swarm_router.py#Missing",
+        ]
+    )
+
+    assert score == 30
+
+
+def test_quality_flags_reject_blacklisted_and_graylisted_paths():
+    module = load_module()
+
+    text = """
+    1. Decision: build
+    2. Files:
+       - .env
+       - package.json
+    3. Patch: none
+    4. Verification: npm test
+    """
+
+    flags = module.quality_flags(text, ("scripts/", "package.json"))
+
+    assert "blacklisted_path:.env" in flags
+    assert "graylisted_path_requires_approval:package.json" in flags
+
+
+def test_build_lanes_assigns_tiers_and_contracts():
+    module = load_module()
+
+    local = module.resolve_agent("openclaw", {"openclaw:latest"})
+    cloud = module.resolve_agent(
+        "opencode",
+        {"qwen2.5-coder:1.5b"},
+        allow_ollama_cloud=True,
+        prefer_ollama_cloud=True,
+    )
+
+    lanes = module.build_lanes("test task", [local, cloud], ("scripts/", "tests/"))
+
+    assert lanes[0].lane_tier == "builder"
+    assert lanes[0].helper_contract
+    assert lanes[1].lane_tier == "escalation"
+    assert "grey_requires_human" in lanes[1].trust_policy
+
+
+def test_routing_recommendation_includes_correction_guide():
+    module = load_module()
+
+    lane = module.WorkLane(
+        lane_id="01-implementation",
+        lane_tier="builder",
+        agent_alias="openclaw",
+        agent_name="OpenClaw",
+        model="openclaw:latest",
+        execution_surface="ollama_local",
+        cost_tier="free_local",
+        geometry_role="router",
+        geometry_anchor=(1.0, 0.0, 0.0),
+        goal="test",
+        allowed_paths=("scripts/",),
+        blocked_paths=(".git/",),
+        done_criteria=("done",),
+        verify_command="npm test",
+        helper_contract="builder",
+        cycle_policy="retry with correction",
+        trust_policy="allow=scripts/",
+        output_contract="patch-proposal",
+    )
+    agent = module.resolve_agent("openclaw", {"openclaw:latest"})
+    results = [
+        {
+            "lane": module.asdict(lane),
+            "ok": True,
+            "error": "",
+            "response": "1. Decision: build\n2. Files:\n- scripts/missing.py",
+            "response_chars": 10,
+            "quality_flags": ["path_not_found:scripts/missing.py"],
+            "constraint_mode": "strict",
+            "elapsed_seconds": 0.1,
+        }
+    ]
+
+    routing = module.build_routing_recommendation(results, [agent])
+
+    assert routing["policy"] == "tiered_free_first_guarded_builder_rotation"
+    assert routing["quality_flag_counts"]["path_not_found"] == 1
+    assert routing["correction_guide"][0]["flag"] == "path_not_found"
+    assert routing["assurance_packet"]["schema"] == "scbe_darpa_style_assurance_packet_v1"
+    assert "heterogeneous_evidence" in routing["assurance_packet"]["requirements"]
+    assert routing["next_cycle"] == "helper_collect_file_evidence_then_guard_review"
+
+
+def test_choose_next_action_is_output_contract_aware():
+    module = load_module()
+
+    answer_lane = {"lane": {"output_contract": "answer"}}
+    evidence_lane = {"lane": {"output_contract": "evidence"}}
+    patch_lane = {"lane": {"output_contract": "patch-proposal"}}
+
+    assert module.choose_next_action([answer_lane], False) == "deliver_answer_to_user"
+    assert module.choose_next_action([evidence_lane], False) == "handoff_evidence_to_builder"
+    assert module.choose_next_action([patch_lane], False) == "extract_one_promotable_diff_then_safe_apply"
+    assert module.choose_next_action([], True) == "run_helper_guard_cycle_before_escalation"
+
+
+def test_task_graph_selects_public_answer_node():
+    module = load_module()
+
+    graph = module.load_task_graph()
+    name, node = module.select_task_graph_node("Public free user role: what can I do?", "answer", graph)
+
+    assert name == "public_answer"
+    assert node["operation_frame"] == "answer"
+
+
+def test_prompt_includes_task_graph_hint():
+    module = load_module()
+
+    agent = module.resolve_agent("openclaw", {"openclaw:latest"})
+    lane = module.build_lanes("Public free user role: what can I do?", [agent], ("docs/",))[0]
+    lane = module.WorkLane(**{**module.asdict(lane), "output_contract": "answer"})
+
+    prompt = module.prompt_for_lane(lane, ["docs/research/SCBE_BUS_TASK_KNOWLEDGE_GRAPH_2026-05-10.json"], "relaxed")
+
+    assert "Task graph node: public_answer" in prompt
+    assert "Expected response shape:" in prompt
+
+
+def test_prompt_includes_deterministic_declaration_hints():
+    module = load_module()
+
+    agent = module.resolve_agent("openclaw", {"openclaw:latest"})
+    lane = module.build_lanes("Inspect router declarations", [agent], ("scripts/",))[0]
+
+    prompt = module.prompt_for_lane(lane, ["scripts/system/openclaw_swarm.py"], "strict")
+
+    assert "Known declaration hints:" in prompt
+    assert "scripts/system/openclaw_swarm.py:" in prompt
+    assert "WorkLane" in prompt
+
+
+def test_inventory_focus_paths_prevent_broad_repo_spray():
+    module = load_module()
+
+    files = module.inventory_allowed_files(
+        ("scripts/", "tests/", "docs/"),
+        (
+            "scripts/system/openclaw_swarm.py",
+            "scripts/benchmark/openclaw_swarm_benchmark.py",
+        ),
+    )
+
+    assert files == [
+        "scripts/system/openclaw_swarm.py",
+        "scripts/benchmark/openclaw_swarm_benchmark.py",
+    ]
+
+
+def test_make_run_dir_allocates_unique_directories(tmp_path):
+    module = load_module()
+
+    first = module.make_run_dir(tmp_path)
+    second = module.make_run_dir(tmp_path)
+
+    assert first.exists()
+    assert second.exists()
+    assert first != second
+
+
+def test_select_coding_systems_prefers_stisa_for_atomic_tasks():
+    module = load_module()
+
+    registry = {
+        "systems": [
+            {"system_id": "swarm_router", "name": "Router", "purpose": "Route agents", "best_for": [], "benchmark_role": "swarm_surface"},
+            {
+                "system_id": "stisa_atomic_tokenizer",
+                "name": "STISA Atomic Tokenizer Surface",
+                "purpose": "Atomic tokenizer feature rows",
+                "best_for": ["precision builds"],
+                "benchmark_role": "atomic_surface",
+            },
+        ]
+    }
+
+    selected = module.select_coding_systems("Use STISA atomic tokenizer for precision builds", "evidence", registry)
+
+    assert selected[0]["system_id"] == "stisa_atomic_tokenizer"
+
+
+def test_prompt_includes_coding_system_registry_hints():
+    module = load_module()
+
+    agent = module.resolve_agent("openclaw", {"openclaw:latest"})
+    lane = module.build_lanes("Use STISA and SS1 for cross-language precision coding", [agent], ("scripts/",))[0]
+
+    prompt = module.prompt_for_lane(lane, ["scripts/system/openclaw_swarm.py"], "strict")
+
+    assert "Coding system registry:" in prompt
+    assert "stisa_atomic_tokenizer" in prompt
+
+
+def test_inventory_allowed_files_prioritizes_existing_focus_paths():
+    module = load_module()
+
+    files = module.inventory_allowed_files(
+        ("scripts/", "tests/"),
+        ("scripts/system/openclaw_swarm.py", "not-real.py"),
+        limit=8,
+    )
+
+    assert "scripts/system/openclaw_swarm.py" in files
+    assert files[0] == "scripts/system/openclaw_swarm.py"
+    assert "not-real.py" not in files
+
+
+def test_implementation_lane_can_patch_tests_when_allowed():
+    module = load_module()
+
+    agent = module.resolve_agent("openclaw", {"openclaw:latest"})
+    lanes = module.build_lanes("Patch router and tests", [agent], ("scripts/", "tests/"))
+
+    assert "tests/" in lanes[0].allowed_paths
+
+
+def test_resolve_agent_can_prefer_ollama_cloud_when_opted_in():
+    module = load_module()
+
+    resolved = module.resolve_agent(
+        "opencode",
+        {"qwen2.5-coder:1.5b"},
+        allow_ollama_cloud=True,
+        prefer_ollama_cloud=True,
+    )
+
+    assert resolved.status == "active_cloud"
+    assert resolved.model.endswith("-cloud") or resolved.model.endswith(":cloud")
+    assert resolved.execution_surface == "ollama_cloud"
+    assert resolved.cost_tier == "ollama_cloud"
+
+
+def test_pazaak_plan_marks_overlapping_builder_lanes_as_conflicts():
+    module = load_module()
+
+    openclaw = module.resolve_agent("openclaw", {"openclaw:latest"})
+    opencode = module.resolve_agent("opencode", {"qwen2.5-coder:1.5b"})
+    lanes = module.build_lanes("Patch the same router surface", [openclaw, opencode], ("scripts/", "tests/"))
+
+    plan = module.build_pazaak_plan(lanes, limit=6)
+
+    assert plan["schema"] == "scbe_swarm_pazaak_plan_v1"
+    assert plan["bitboards"]["conflict"] != 0
+    assert any(move["card_id"] == "claim_territory" for move in plan["moves"])
+
+
+def test_integration_plan_includes_pazaak_board_recommendations():
+    module = load_module()
+
+    routing = {
+        "policy": "tiered_free_first_guarded_builder_rotation",
+        "free_signal_exhausted": False,
+        "next_action": "review_promotable_lane",
+        "next_cycle": "extract_one_promotable_diff_then_safe_apply",
+        "guard_clean_lanes": 1,
+        "builder_attempt_lanes": 1,
+        "paid_escalation_note": "none",
+        "correction_guide": [],
+        "tier_contract": {"builder": "coding models produce narrow diffs"},
+        "assurance_packet": {
+            "schema": "scbe_darpa_style_assurance_packet_v1",
+            "readiness": "prototype_evidence_packet",
+            "acceptance_rule": "accept only verified lanes",
+            "mean_applicability_score": 100,
+            "requirements": {"traceability": "lane artifacts exist"},
+        },
+        "pazaak_plan": {
+            "bitboards": {"conflict": 1},
+            "moves": [
+                {
+                    "lane_id": "01-implementation",
+                    "card_name": "Claim Territory",
+                    "symbol": "+1",
+                    "score": 12.5,
+                    "reason": "matched file_conflict",
+                }
+            ],
+        },
+    }
+
+    text = module.build_integration_plan("test", [], routing)
+
+    assert "## Pazaak Board Recommendation" in text
+    assert "Claim Territory" in text


### PR DESCRIPTION
## Summary
- adds a deterministic Pazaak-style bitboard planner for agentic task lanes
- integrates the planner into the SCBE swarm router output as pazaak_plan.json, routing metadata, CLI summary, and integration-plan markdown
- adds canonical scbe_swarm_router.py wrapper so the system is named broader than OpenClaw while keeping openclaw_swarm.py compatibility
- adds regression coverage for card scoring, bitboards, conflict detection, and integration-plan rendering

## Test evidence
- pytest tests/system/test_agentic_pazaak_board.py tests/test_openclaw_swarm.py -q -> 37 passed
- python -m py_compile scripts/system/openclaw_swarm.py scripts/system/agentic_pazaak_board.py scripts/system/scbe_swarm_router.py -> passed
- python scripts/system/scbe_swarm_router.py --task "Route a small SCBE agent-bus improvement with Pazaak board guidance" --agents openclaw,opencode --allowed-paths scripts/,tests/,config/,docs/ --dry-run --max-workers 1 --timeout 30 -> wrote run artifact and top move Claim Territory

## Claim boundary
This is not a public leaderboard result. It is deterministic routing guidance for multi-agent lane ownership, risk, verification, context noise, and conflict handling.

## Rollback
Revert this PR to remove the planner and router integration; existing openclaw_swarm.py behavior remains otherwise compatible.