### PR TITLE
fix(benchmarks): install GeoSeal preflight dependency

### DIFF
--- a/.github/workflows/public-agentic-benchmarks.yml
+++ b/.github/workflows/public-agentic-benchmarks.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install uv
         run: python -m pip install --upgrade uv
 
+      - name: Install SCBE benchmark preflight deps
+        run: python -m pip install numpy
+
       - name: Probe remote Docker lane
         run: |
           mkdir -p artifacts/public_agentic_benchmark_setup


### PR DESCRIPTION
## Summary
- install numpy in the public agentic benchmark workflow before SCBE GeoSeal preflight imports
- keeps the Aider Polyglot smoke using the real command compiler on GitHub runners

## Test evidence
- python -m pytest tests\\benchmark\\test_public_agentic_benchmark_workflow.py tests\\benchmark\\test_aider_polyglot_smoke.py -q
- git diff --check

## Rollback
- remove the workflow dependency-install step if the runner image grows the dependency by default