### PR TITLE
fix(benchmarks): default public scoring to low-cost guard

### DIFF
--- a/.github/workflows/public-agentic-benchmarks.yml
+++ b/.github/workflows/public-agentic-benchmarks.yml
@@ -21,7 +21,7 @@ on:
       model:
         description: "Aider model name for scored runs"
         required: false
-        default: "gpt-4o-mini"
+        default: "openai/Qwen/Qwen2.5-Coder-32B-Instruct"
       edit_format:
         description: "Aider edit format for scored runs"
         required: false
@@ -29,12 +29,21 @@ on:
       api_provider:
         description: "API provider for scored Aider runs"
         required: false
-        default: "openai"
+        default: "huggingface"
         type: choice
         options:
           - openai
           - huggingface
           - nvidia
+      cost_mode:
+        description: "Cost guard for scored runs"
+        required: false
+        default: "free_remote"
+        type: choice
+        options:
+          - local_artifact_only
+          - free_remote
+          - paid_allowed
 
 permissions:
   contents: read
@@ -49,6 +58,7 @@ jobs:
       AIDER_EDIT_FORMAT: ${{ inputs.edit_format }}
       AIDER_NUM_TESTS: ${{ inputs.num_tests }}
       AIDER_API_PROVIDER: ${{ inputs.api_provider }}
+      BENCHMARK_COST_MODE: ${{ inputs.cost_mode }}
       OPENAI_API_KEY_SECRET: ${{ secrets.OPENAI_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
@@ -76,6 +86,47 @@ jobs:
 
       - name: Validate public benchmark plan
         run: python scripts/benchmark/public_agentic_cli_suite.py --validate-only
+
+      - name: Enforce benchmark cost guard
+        if: ${{ inputs.track == 'aider-polyglot-scored-small' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${BENCHMARK_COST_MODE}" in
+            local_artifact_only)
+              echo "local_artifact_only forbids live scored model calls. Use setup-only, aider-polyglot-smoke, or paid_allowed intentionally." >&2
+              exit 1
+              ;;
+            free_remote)
+              if [ "${AIDER_API_PROVIDER}" != "huggingface" ]; then
+                echo "free_remote scored runs only allow api_provider=huggingface. Got ${AIDER_API_PROVIDER}." >&2
+                exit 1
+              fi
+              case "${AIDER_MODEL}" in
+                openai/Qwen/Qwen2.5-Coder-7B-Instruct|openai/Qwen/Qwen2.5-Coder-32B-Instruct)
+                  ;;
+                *)
+                  echo "free_remote scored runs only allow known low/no-cost HF router models. Got ${AIDER_MODEL}." >&2
+                  exit 1
+                  ;;
+              esac
+              if ! [[ "${AIDER_NUM_TESTS}" =~ ^[0-9]+$ ]]; then
+                echo "num_tests must be a positive integer under free_remote. Got ${AIDER_NUM_TESTS}." >&2
+                exit 1
+              fi
+              if [ "${AIDER_NUM_TESTS}" -gt 1 ]; then
+                echo "free_remote scored runs are capped at num_tests=1. Use paid_allowed for larger sweeps." >&2
+                exit 1
+              fi
+              ;;
+            paid_allowed)
+              echo "paid_allowed set explicitly; cost guard permits provider ${AIDER_API_PROVIDER} and ${AIDER_NUM_TESTS} tests."
+              ;;
+            *)
+              echo "Unsupported BENCHMARK_COST_MODE=${BENCHMARK_COST_MODE}" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Setup public benchmark harnesses
         run: python scripts/benchmark/setup_public_agentic_benchmarks.py --download --dry-run

--- a/tests/benchmark/test_public_agentic_benchmark_workflow.py
+++ b/tests/benchmark/test_public_agentic_benchmark_workflow.py
@@ -48,3 +48,18 @@ def test_scored_aider_workflow_can_select_openai_compatible_provider() -> None:
     assert "https://integrate.api.nvidia.com/v1" in workflow
     assert "AIDER_OPENAI_API_BASE" in workflow
     assert '"${api_env_args[@]}"' in workflow
+
+
+def test_scored_aider_workflow_defaults_to_low_cost_guard() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'default: "huggingface"' in workflow
+    assert 'default: "openai/Qwen/Qwen2.5-Coder-32B-Instruct"' in workflow
+    assert "cost_mode:" in workflow
+    assert 'default: "free_remote"' in workflow
+    assert "BENCHMARK_COST_MODE" in workflow
+    assert "local_artifact_only forbids live scored model calls" in workflow
+    assert "free_remote scored runs only allow api_provider=huggingface" in workflow
+    assert "num_tests must be a positive integer under free_remote" in workflow
+    assert "free_remote scored runs are capped at num_tests=1" in workflow
+    assert "paid_allowed set explicitly" in workflow


### PR DESCRIPTION
## Summary
- default public scored benchmarks to Hugging Face Qwen instead of OpenAI
- add `cost_mode` with `free_remote` default, `local_artifact_only`, and explicit `paid_allowed`
- block paid providers and multi-test scored sweeps unless `paid_allowed` is selected intentionally

## Local Ollama inventory
Detected local models for offline/cheap follow-up work:
- `qwen2.5:7b-instruct`
- `openclaw:latest`
- `qwen2.5:3b-instruct`
- `llama-guard3:1b`
- `qwen2.5-coder:1.5b`
- `gemma3:1b`
- `scbe-geoseal-coder:q8`
- `qwen2.5-coder:0.5b`

## Test evidence
- `python -m pytest tests\benchmark\test_public_agentic_benchmark_workflow.py tests\benchmark\test_workflow_completion_checklist.py tests\benchmark\test_known_fail_retry_prompts.py -q` -> 10 passed
- `python scripts\security\code_governance_gate.py check-push` -> PASS, 0 findings
- `ollama list` confirmed local models are available

## Rollback
- Revert this PR to restore OpenAI/gpt-4o-mini as the scored benchmark default and remove `cost_mode` enforcement.