### PR TITLE
fix(npm): restore harness package smoke path

### DIFF
--- a/bin/scbe-scan.cjs
+++ b/bin/scbe-scan.cjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function loadApi() {
+  const apiPath = path.resolve(__dirname, '..', 'dist', 'src', 'index.js');
+  try {
+    return require(apiPath);
+  } catch {
+    throw new Error(
+      `Unable to load built SCBE API at ${apiPath}. Run npm run build before using scbe-scan from source.`
+    );
+  }
+}
+
+function help() {
+  process.stdout.write(`scbe-scan
+
+Usage:
+  scbe-scan "text to evaluate"
+  scbe-scan --json "text to evaluate"
+  scbe-scan --batch prompts.txt
+
+Options:
+  --json   Emit full JSON records.
+  --batch  Read one prompt per line from a UTF-8 file.
+`);
+}
+
+function parse(argv) {
+  const args = { json: false, batch: '', text: [], help: false };
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+    } else if (token === '--json') {
+      args.json = true;
+    } else if (token === '--batch') {
+      args.batch = argv[++i] || '';
+    } else {
+      args.text.push(token);
+    }
+  }
+  return args;
+}
+
+function printRecord(record, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(record, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`${record.decision}\t${record.score.toFixed(6)}\t${record.text}\n`);
+}
+
+function main() {
+  const args = parse(process.argv);
+  if (args.help) {
+    help();
+    return;
+  }
+  const api = loadApi();
+  const inputs = args.batch
+    ? fs
+        .readFileSync(args.batch, 'utf-8')
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+    : [args.text.join(' ').trim()].filter(Boolean);
+  if (!inputs.length) {
+    help();
+    process.exitCode = 1;
+    return;
+  }
+  const records = api.scanBatch(inputs);
+  for (const record of records) {
+    printRecord(record, args.json);
+  }
+}
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scbe-aethermoore",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scbe-aethermoore",
-      "version": "4.0.8",
+      "version": "4.0.9",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -18,7 +18,8 @@
       },
       "bin": {
         "geoseal": "bin/geoseal.cjs",
-        "scbe-geoseal": "bin/geoseal.cjs"
+        "scbe-geoseal": "bin/geoseal.cjs",
+        "scbe-scan": "bin/scbe-scan.cjs"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "scbe-aethermoore",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "SCBE-AETHERMOORE: Hyperbolic Geometry-Based Security with 14-Layer Architecture",
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT OR Apache-2.0",
   "type": "commonjs",
   "bin": {
     "geoseal": "bin/geoseal.cjs",
-    "scbe-geoseal": "bin/geoseal.cjs"
+    "scbe-geoseal": "bin/geoseal.cjs",
+    "scbe-scan": "bin/scbe-scan.cjs"
   },
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -213,6 +214,7 @@
     "publish:prepare": "npm run clean:release && npm run build",
     "publish:pack:json": "node -e \"require('fs').mkdirSync('artifacts/npm-pack',{recursive:true})\" && npm pack --dry-run --json --ignore-scripts --cache ./.npm-cache > artifacts/npm-pack/pack.json",
     "publish:check:strict": "npm run publish:pack:json && node scripts/npm_pack_guard.js --pack-json artifacts/npm-pack/pack.json",
+    "publish:smoke:consumer": "node scripts/npm_consumer_smoke.mjs",
     "publish:pypi:build": "python scripts/pypi_build.py --dist-dir artifacts/pypi-dist",
     "publish:pypi:check": "python scripts/pypi_dist_guard.py --dist-dir artifacts/pypi-dist",
     "prepublishOnly": "npm run publish:prepare",

--- a/packages/agent-bus/CHANGELOG.md
+++ b/packages/agent-bus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.2
+
+- Restore the Node package source, TypeScript config, and generated `dist/`
+  build path so fresh npm installs expose working API and CLI entrypoints.
+- Keep the local-first server, terminal UI, send, and health commands
+  self-contained for downloader smoke tests.
+
 ## 0.1.1
 
 - Restore package source files on the release branch.

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scbe-agent-bus",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "SCBE agent-bus: typed Node surface over the SCBE governed event runner. Routes AI/human/AI events through the harmonic-wall pipeline and returns a typed envelope.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,6 +10,8 @@
   "files": [
     "bin",
     "dist",
+    "src",
+    "tsconfig.json",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",
@@ -20,7 +22,8 @@
     "build": "tsc -p tsconfig.json",
     "agentbus:pipe": "node ../../scripts/system/agentbus_pipe.mjs",
     "pack:dry": "npm pack --dry-run --json",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepack": "npm run build"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1,0 +1,284 @@
+import { spawnSync } from 'node:child_process';
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import path from 'node:path';
+
+export type AgentBusPrivacy = 'local_only' | 'remote_allowed' | string;
+
+export interface AgentBusEvent {
+  task: string;
+  taskType?: string;
+  operationCommand?: string;
+  seriesId?: string;
+  privacy?: AgentBusPrivacy;
+  budgetCents?: number;
+  dispatch?: boolean;
+  dispatchProvider?: string;
+}
+
+export interface RunOptions {
+  repoRoot?: string;
+  python?: string;
+  continueOnError?: boolean;
+}
+
+export interface AgentBusResult {
+  schema_version: 'scbe-agentbus-node-result-v1';
+  event_index: number;
+  started_at: string;
+  finished_at: string;
+  ok: boolean;
+  exit_code: number | null;
+  stderr_tail: string;
+  event: {
+    task_sha256: string | null;
+    task_chars: number;
+    series_id: string;
+    operation_command_chars: number;
+  };
+  result: unknown;
+}
+
+export interface AgentBusServerHandle {
+  url: string;
+  server: Server;
+  close: () => Promise<void>;
+}
+
+export interface AgentBusServerOptions extends RunOptions {
+  host?: string;
+  port?: number;
+}
+
+export interface AgentBusClientOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+const TASK_TYPES = new Set(['coding', 'review', 'research', 'governance', 'training', 'general']);
+
+function normalizeTaskType(value: unknown): string {
+  const taskType = String(value || 'general')
+    .trim()
+    .toLowerCase();
+  return TASK_TYPES.has(taskType) ? taskType : 'general';
+}
+
+function normalizePrivacy(value: unknown): string {
+  const privacy = String(value || 'local_only')
+    .trim()
+    .toLowerCase();
+  if (privacy === 'remote_allowed') return 'remote_ok';
+  if (privacy === 'remote_ok') return 'remote_ok';
+  return 'local_only';
+}
+
+function normalizeEvent(event: AgentBusEvent, index: number): Required<AgentBusEvent> {
+  if (!event || typeof event !== 'object') {
+    throw new Error(`event ${index} must be an object`);
+  }
+  const task = String(event.task || '').trim();
+  if (!task) {
+    throw new Error(`event ${index} missing task`);
+  }
+  return {
+    task,
+    operationCommand: String(event.operationCommand || '').trim(),
+    taskType: normalizeTaskType(event.taskType),
+    seriesId: String(event.seriesId || `node-event-${index}`).trim(),
+    privacy: normalizePrivacy(event.privacy),
+    budgetCents: Number(event.budgetCents || 0),
+    dispatch: event.dispatch !== false,
+    dispatchProvider: String(event.dispatchProvider || 'offline').trim(),
+  };
+}
+
+function tail(text: string, chars = 1000): string {
+  return String(text || '').slice(-chars);
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text || '{}');
+  } catch {
+    return null;
+  }
+}
+
+export async function runEvent(
+  event: AgentBusEvent,
+  options: RunOptions = {}
+): Promise<AgentBusResult> {
+  const normalized = normalizeEvent(event, 1);
+  const repoRoot = path.resolve(options.repoRoot || process.cwd());
+  const python = options.python || process.env.PYTHON || 'python';
+  const cli = path.join(repoRoot, 'scripts', 'scbe-system-cli.py');
+  const argv = [
+    cli,
+    '--repo-root',
+    repoRoot,
+    'agentbus',
+    'run',
+    '--task',
+    normalized.task,
+    '--task-type',
+    normalized.taskType,
+    '--series-id',
+    normalized.seriesId,
+    '--privacy',
+    normalized.privacy,
+    '--budget-cents',
+    String(normalized.budgetCents),
+    '--dispatch-provider',
+    normalized.dispatchProvider,
+    '--json',
+  ];
+  if (normalized.operationCommand) {
+    argv.push('--operation-command', normalized.operationCommand);
+  }
+  if (normalized.dispatch) {
+    argv.push('--dispatch');
+  }
+
+  const startedAt = new Date().toISOString();
+  const result = spawnSync(python, argv, {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    maxBuffer: 1024 * 1024 * 8,
+  });
+  const payload = parseJson(result.stdout || '{}') as Record<string, unknown> | null;
+  const taskPayload =
+    payload && typeof payload.task === 'object' ? (payload.task as Record<string, unknown>) : null;
+  return {
+    schema_version: 'scbe-agentbus-node-result-v1',
+    event_index: 1,
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    ok: result.status === 0 && Boolean(payload),
+    exit_code: result.status,
+    stderr_tail: tail(result.stderr || ''),
+    event: {
+      task_sha256: typeof taskPayload?.sha256 === 'string' ? taskPayload.sha256 : null,
+      task_chars: normalized.task.length,
+      series_id: normalized.seriesId,
+      operation_command_chars: normalized.operationCommand.length,
+    },
+    result: payload,
+  };
+}
+
+export async function runBatch(
+  events: AgentBusEvent[],
+  options: RunOptions = {}
+): Promise<AgentBusResult[]> {
+  if (!Array.isArray(events) || events.length === 0) {
+    throw new Error('events sequence is empty');
+  }
+  const rows: AgentBusResult[] = [];
+  for (const [index, event] of events.entries()) {
+    const row = await runEvent(
+      { ...event, seriesId: event.seriesId || `node-event-${index + 1}` },
+      options
+    );
+    rows.push({ ...row, event_index: index + 1 });
+    if (!row.ok && !options.continueOnError) break;
+  }
+  return rows;
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+  const body = `${JSON.stringify(payload, null, 2)}\n`;
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+export async function startAgentBusServer(
+  options: AgentBusServerOptions = {}
+): Promise<AgentBusServerHandle> {
+  const host = options.host || '127.0.0.1';
+  const port = Number(options.port || 8787);
+  const server = createServer(async (req, res) => {
+    try {
+      if (req.method === 'GET' && req.url === '/health') {
+        sendJson(res, 200, { ok: true, service: 'scbe-agent-bus', version: 1 });
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/v1/events') {
+        const body = JSON.parse(await readBody(req)) as AgentBusEvent;
+        const row = await runEvent(body, options);
+        sendJson(res, row.ok ? 200 : 500, row);
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/v1/batch') {
+        const body = JSON.parse(await readBody(req)) as
+          | { items?: AgentBusEvent[] }
+          | AgentBusEvent[];
+        const items = Array.isArray(body) ? body : body.items || [];
+        const rows = await runBatch(items, options);
+        sendJson(res, rows.every((row) => row.ok) ? 200 : 500, { rows });
+        return;
+      }
+      sendJson(res, 404, { ok: false, error: 'not_found' });
+    } catch (err) {
+      sendJson(res, 400, { ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(port, host, resolve));
+  return {
+    url: `http://${host}:${port}`,
+    server,
+    close: () =>
+      new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+export async function postAgentBusEvent(
+  event: AgentBusEvent,
+  options: AgentBusClientOptions = {}
+): Promise<unknown> {
+  const fetcher = options.fetchImpl || fetch;
+  const baseUrl = (options.baseUrl || 'http://127.0.0.1:8787').replace(/\/+$/, '');
+  const res = await fetcher(`${baseUrl}/v1/events`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(event),
+  });
+  const payload = await res.json();
+  if (!res.ok) {
+    throw new Error(
+      `agent-bus request failed: ${res.status} ${JSON.stringify(payload).slice(0, 500)}`
+    );
+  }
+  return payload;
+}
+
+export async function runAgentBusTerminalUi(options: AgentBusClientOptions = {}): Promise<void> {
+  const rl = createInterface({ input, output });
+  try {
+    output.write(`SCBE Agent Bus UI (${options.baseUrl || 'http://127.0.0.1:8787'})\n`);
+    while (true) {
+      const task = (await rl.question('task> ')).trim();
+      if (!task || task === 'exit' || task === 'quit') break;
+      const result = await postAgentBusEvent(
+        { task, taskType: 'general', privacy: 'local_only' },
+        options
+      );
+      output.write(`${JSON.stringify(result, null, 2)}\n`);
+    }
+  } finally {
+    rl.close();
+  }
+}

--- a/packages/agent-bus/tsconfig.json
+++ b/packages/agent-bus/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "types": ["node"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/npm_consumer_smoke.mjs
+++ b/scripts/npm_consumer_smoke.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/*
+Fresh-install smoke for the public npm surfaces.
+
+This packs the root `scbe-aethermoore` package and the `packages/agent-bus`
+package, installs both tarballs into a new temp project, and verifies the API
+and CLI entrypoints a downloader expects to use.
+*/
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const node = process.execPath;
+const npmCli =
+  process.env.npm_execpath ||
+  path.join(path.dirname(node), 'node_modules', 'npm', 'bin', 'npm-cli.js');
+const npxCli = path.join(path.dirname(npmCli), 'npx-cli.js');
+
+function run(cmd, args, options = {}) {
+  return execFileSync(cmd, args, {
+    cwd: options.cwd || repoRoot,
+    encoding: 'utf-8',
+    stdio: options.stdio || ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, ...(options.env || {}) },
+  });
+}
+
+function pack(cwd) {
+  const stdout = run(
+    node,
+    [npmCli, 'pack', '--json', '--cache', path.join(repoRoot, '.npm-cache')],
+    { cwd }
+  );
+  const lines = stdout.split(/\r?\n/);
+  const jsonStart = lines.findIndex((line) => line.trim() === '[');
+  if (jsonStart < 0) {
+    throw new Error(`npm pack did not emit JSON: ${stdout.slice(0, 1000)}`);
+  }
+  const payload = JSON.parse(lines.slice(jsonStart).join('\n'));
+  return path.join(cwd, payload[0].filename);
+}
+
+function assertIncludes(text, expected, label) {
+  if (!text.includes(expected)) {
+    throw new Error(`${label} did not include ${JSON.stringify(expected)}: ${text.slice(0, 500)}`);
+  }
+}
+
+const rootTarball = pack(repoRoot);
+const busTarball = pack(path.join(repoRoot, 'packages', 'agent-bus'));
+const consumerDir = mkdtempSync(path.join(os.tmpdir(), 'scbe-npm-consumer-'));
+const rootPackage = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'));
+
+run(node, [npmCli, 'init', '-y'], { cwd: consumerDir });
+run(
+  node,
+  [npmCli, 'install', rootTarball, busTarball, '--cache', path.join(consumerDir, '.npm-cache')],
+  {
+    cwd: consumerDir,
+  }
+);
+
+assertIncludes(
+  run(
+    node,
+    [
+      '-e',
+      "const scbe=require('scbe-aethermoore'); const r=scbe.scan('hello world'); if(r.decision!=='ALLOW') throw new Error('scan failed'); console.log('root-api', r.decision, typeof scbe.scanBatch, typeof scbe.isSafe, typeof scbe.harmonicWall);",
+    ],
+    { cwd: consumerDir }
+  ),
+  'root-api ALLOW function function function',
+  'root CommonJS API'
+);
+
+assertIncludes(
+  run(
+    node,
+    [
+      '--input-type=module',
+      '-e',
+      "import scbe, { scan } from 'scbe-aethermoore'; const r=scan('hello from esm'); if(!r || r.decision!=='ALLOW') throw new Error('esm scan failed'); console.log('root-esm', r.decision, typeof scbe.scanBatch);",
+    ],
+    { cwd: consumerDir }
+  ),
+  'root-esm ALLOW function',
+  'root ESM API'
+);
+
+const scanRecord = JSON.parse(
+  run(node, [npxCli, 'scbe-scan', '--json', 'hello world'], { cwd: consumerDir })
+);
+if (scanRecord.decision !== 'ALLOW') {
+  throw new Error(`scbe-scan returned ${scanRecord.decision}`);
+}
+
+assertIncludes(
+  run(node, [npxCli, 'geoseal', 'version'], { cwd: consumerDir }),
+  rootPackage.version,
+  'geoseal version'
+);
+assertIncludes(
+  run(
+    node,
+    [
+      '-e',
+      "const bus=require('scbe-agent-bus'); const keys=['runEvent','runBatch','startAgentBusServer','postAgentBusEvent','runAgentBusTerminalUi']; for (const k of keys) if(typeof bus[k]!=='function') throw new Error('missing '+k); console.log('bus-api', keys.join(','));",
+    ],
+    { cwd: consumerDir }
+  ),
+  'bus-api runEvent,runBatch,startAgentBusServer,postAgentBusEvent,runAgentBusTerminalUi',
+  'agent-bus API'
+);
+
+assertIncludes(
+  run(node, [npxCli, 'scbe-agent-bus', '--help'], { cwd: consumerDir }),
+  'SCBE Agent Bus',
+  'agent-bus help'
+);
+assertIncludes(
+  run(
+    node,
+    [
+      '-e',
+      "const bus=require('scbe-agent-bus'); (async()=>{const h=await bus.startAgentBusServer({port:8791}); const res=await fetch(h.url+'/health').then(r=>r.json()); await h.close(); if(!res.ok) throw new Error('health failed'); console.log('bus-health', res.ok, h.url);})().catch(e=>{console.error(e); process.exit(1);});",
+    ],
+    { cwd: consumerDir }
+  ),
+  'bus-health true http://127.0.0.1:8791',
+  'agent-bus local health'
+);
+
+assertIncludes(
+  run(
+    node,
+    [
+      '-e',
+      `const bus=require('scbe-agent-bus'); (async()=>{const r=await bus.runEvent({task:'npm harness smoke from installed package', taskType:'smoke', privacy:'remote_allowed', dispatch:false},{repoRoot:${JSON.stringify(repoRoot)}}); console.log('bus-run', r.ok, r.exit_code, r.event.task_chars); if(!r.ok) { console.error(r.stderr_tail); process.exit(1); }})().catch(e=>{console.error(e); process.exit(1);});`,
+    ],
+    { cwd: consumerDir }
+  ),
+  'bus-run true 0 40',
+  'agent-bus repo-backed run'
+);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      consumer_dir: consumerDir,
+      root_tarball: rootTarball,
+      agent_bus_tarball: busTarball,
+    },
+    null,
+    2
+  )
+);


### PR DESCRIPTION
## Summary
- bump `scbe-aethermoore` to 4.0.9 and ship the README-promised `scbe-scan` binary
- restore the `scbe-agent-bus` npm package source/tsconfig/build path and bump it to 0.2.2
- add `npm run publish:smoke:consumer`, which packs both npm surfaces, installs them into a fresh temp project, and verifies root API, ESM import, CLIs, local server health, and a repo-backed agent-bus run

## Verification
- `npm run typecheck`
- `npm run build` in `packages/agent-bus`
- `npm run publish:check:strict`
- `npm run publish:smoke:consumer`
- `npm test -- --run` (6246 passed, 21 skipped)
- touched-file Prettier check passed

## Notes
- Repo-wide `npm run lint` still reports pre-existing formatting warnings across `src/**/*.ts` and `tests/**/*.ts`; touched files were formatted and checked separately.
- Publishing should happen after merge from main: `npm publish` at repo root for `scbe-aethermoore@4.0.9`, then `npm publish` inside `packages/agent-bus` for `scbe-agent-bus@0.2.2`.