### PR TITLE
feat(site): add buyer solutions surface

### DIFF
--- a/docs/app-config.json
+++ b/docs/app-config.json
@@ -29,6 +29,7 @@
     "supporter_page": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html",
     "service_credits_page": "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html",
     "hosted_run_page": "https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html",
+    "solutions_page": "https://aethermoore.com/SCBE-AETHERMOORE/solutions.html",
     "governance_snapshot_page": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
     "offers_json": "https://aethermoore.com/SCBE-AETHERMOORE/offers.json",
     "agent_bridge_health": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/health",

--- a/docs/business/SCBE_BUYER_CAPABILITY_BUCKETS_2026-05.md
+++ b/docs/business/SCBE_BUYER_CAPABILITY_BUCKETS_2026-05.md
@@ -1,0 +1,219 @@
+# SCBE Buyer Capability Buckets
+
+Status: working buyer-facing packaging sheet  
+Entity: Issac Davis dba SCBE AetherMoore  
+CAGE: 1EXD5  
+UEI: J4NXHM6N5F59
+
+## Purpose
+
+SCBE-AETHERMOORE already has public technical surface area: GitHub code,
+Hugging Face datasets/models, npm/PyPI packages, a live website, governance
+offers, benchmark artifacts, and federal vendor credentials.
+
+The next business problem is not more architecture. It is making the work easy
+for a buyer, prime contractor, or technical evaluator to understand quickly.
+
+This sheet turns the system into purchasable capability buckets.
+
+## Plain Buyer Translation
+
+| SCBE Term | Buyer Translation |
+| --- | --- |
+| Harmonic governance | Adaptive risk scoring for AI workflows |
+| Sacred Tongues / domain routing | Domain-specialized orchestration and evidence lanes |
+| GeoSeal | Trust-boundary receipt and verification layer |
+| Aether-Lattice / pocket workcells | Bounded agent execution and failure containment |
+| Spinal ledger | Append-only operational trace |
+| Tree of Escalation | Policy-driven escalation and response map |
+| Wildlife / swarm routing | Multi-agent triage and task distribution |
+| Star Fortress fallback | Defense-in-depth receipt model for high-assurance workflows |
+| Agent bus | Secure orchestration bus for agents, tools, and review gates |
+
+## Productized Buckets
+
+### 1. SCBE Governance Snapshot
+
+Buyer problem:
+
+- "We have an AI workflow and do not know where it can drift, leak, or fail."
+
+What SCBE delivers:
+
+- A fixed-scope review of one AI workflow.
+- Risk map across prompt injection, drift, routing, state, logging, and review.
+- Short written report with concrete findings and next actions.
+- Optional Aether-Lattice simulation if the workflow has multi-agent routing.
+
+Current offer:
+
+- `governance_snapshot`
+- Price: `$500 fixed scope`
+- Checkout: live in `docs/offers.json`
+
+Best buyer:
+
+- Small AI teams, consultants, SaaS builders, research teams, agencies using
+  early AI tools.
+
+### 2. Agent Drift Evaluation
+
+Buyer problem:
+
+- "Our agent gives different answers over time, loses task state, or cannot
+  recover cleanly from tool failures."
+
+What SCBE delivers:
+
+- Stateful agent-path evaluation.
+- Before/after benchmark pack.
+- Failure mode decomposition: terminal recovery, routing boundary, decision
+  envelope, audit synchronization, context flooding, parser brittleness.
+- Recommendation sheet for memory, retry, and verification joints.
+
+Current evidence:
+
+- Functional agent benchmark artifacts.
+- Public-adapter readiness harness.
+- Atomic run-directory, focus-path grip, evidence parser, and decision parser
+  joints.
+
+Best buyer:
+
+- Agent framework builders, AI coding tools, internal automation teams.
+
+### 3. Multi-Agent Safety / Containment Harness
+
+Buyer problem:
+
+- "We want several agents working in parallel, but they collide, poison shared
+  state, or become impossible to audit."
+
+What SCBE delivers:
+
+- Flat-queue vs bounded-workcell simulation.
+- Failure propagation metrics.
+- Trace-cost metrics.
+- Recommended receipt schema for private-to-public agent boundaries.
+
+Current evidence:
+
+- `docs/business/STAR_FORTRESS_AETHER_LATTICE_CAPABILITY_NOTE.md`
+- Latest local simulation showed reduced public corruption and trace cost under
+  bounded workcells.
+
+Best buyer:
+
+- Robotics/autonomy teams, defense primes, multi-agent AI startups, internal
+  platform teams.
+
+### 4. Prompt Injection / Governance Gate Review
+
+Buyer problem:
+
+- "We are exposing tools or documents to AI and need to know what can be
+  manipulated."
+
+What SCBE delivers:
+
+- Boundary review for tools, MCP connectors, docs, API routes, and dataset
+  ingest.
+- Code governance gate run.
+- Finding list with severity, proof, and fix recommendation.
+- Optional regression tests for the fixed issues.
+
+Current evidence:
+
+- `scripts/security/code_governance_gate.py`
+- Governance gates and prompt-injection-aware code review surfaces.
+
+Best buyer:
+
+- Companies exposing tools to LLMs, agentic systems, or customer-facing chat.
+
+### 5. Hosted Governance Heartbeat
+
+Buyer problem:
+
+- "We want recurring lightweight monitoring, not a giant consulting project."
+
+What SCBE delivers:
+
+- Monthly scan of one workflow.
+- Delta report against last month.
+- Risk/change summary.
+- Recommended action list.
+- Optional training capture.
+
+Current offer:
+
+- `governance_heartbeat`
+- Price: `$99/month`
+- Gap: still needs non-mailto payment link activation.
+
+Best buyer:
+
+- Small AI teams and builders who can afford a monthly check but not enterprise
+  governance.
+
+## Public Technical Receipts
+
+Use these as proof points, not as the sales pitch itself:
+
+- GitHub repository: `SCBE-AETHERMOORE`
+- npm package: `scbe-aethermoore`
+- PyPI package / Python tooling
+- Hugging Face models and datasets
+- Live site: `aethermoore.com`
+- Benchmark artifacts under `artifacts/`
+- Offer registry: `docs/offers.json`
+- Governance snapshot page: `docs/governance-snapshot.html`
+
+## Prime Contractor Framing
+
+SCBE is easiest to place as a modular software / evaluation subcontract lane:
+
+| Work Package | Scope |
+| --- | --- |
+| WP-A: AI Workflow Governance | Risk scoring, routing controls, policy gates |
+| WP-B: Agentic Evaluation Harness | Benchmarks, recovery tests, regression packs |
+| WP-C: Provenance and Receipts | GeoSeal-style trace records, manifests, audit artifacts |
+| WP-D: Multi-Agent Containment | Failure propagation simulation, workcell routing, retry design |
+| WP-E: Training Data Support | Dataset cleanup, SFT conversion, schema checks, source capture |
+
+Use plain claims:
+
+- "We reduce agentic workflow failure modes through verified execution
+  continuity."
+- "We provide governance and traceability around AI agents, not a replacement
+  foundation model."
+- "We can run a fixed-scope evaluation and return a short evidence-backed
+  report."
+
+Avoid overclaims:
+
+- Do not say SCBE proves general AI safety.
+- Do not say hyperbolic geometry alone makes systems secure.
+- Do not call simulations hardware guarantees.
+- Do not lead with cosmology, mythos, or internal terminology when speaking to
+  procurement buyers.
+
+## Immediate Packaging Gaps
+
+1. Create the Heartbeat Stripe subscription payment link and replace the
+   `mailto:` checkout URL in `docs/offers.json`.
+2. Build a one-page PDF capability statement from this sheet.
+3. Update the Solutions page to present the five buckets above.
+4. Make one diagram: `AI workflow -> SCBE gate -> receipt -> report`.
+5. Create one demo video: run a failing agent workflow, apply SCBE joints, show
+   before/after result.
+
+## Default Sales Path
+
+1. Send buyer to `/governance-snapshot`.
+2. Offer the `$500` fixed-scope Snapshot.
+3. Deliver one useful report quickly.
+4. Convert successful Snapshot into `$99/month` Heartbeat or a custom
+   integration quote.
+5. Use public code and benchmark artifacts only when the buyer asks for proof.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -660,6 +660,7 @@
       <nav class="nav" aria-label="Primary">
         <a href="start-here.html">Start Here</a>
         <a href="products.html">Products</a>
+        <a href="solutions.html">Solutions</a>
         <a href="mailto:ai@aethermoore.com?subject=Enterprise%20inquiry">Enterprise</a>
         <a href="#choose-path">Pricing</a>
         <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">Demos</a>
@@ -716,12 +717,14 @@
             <strong style="color: var(--accent-strong);">First time here?</strong>
             <span style="color: var(--text); font-size: 15px;">Three questions, one recommendation — picks the right tool in about 60 seconds.</span>
             <a href="products.html" style="background: linear-gradient(135deg, var(--accent), var(--accent-strong)); color: #14110c; font-weight: 700; padding: 8px 16px; border-radius: 999px; text-decoration: none; white-space: nowrap;">Find your fit →</a>
+            <a href="solutions.html" style="color: var(--text); text-decoration: underline; text-underline-offset: 3px; font-size: 14px; white-space: nowrap;">See buyer-ready services</a>
             <a href="start-here.html" style="color: var(--text); text-decoration: underline; text-underline-offset: 3px; font-size: 14px; white-space: nowrap;">Or see the three starter routes</a>
           </div>
           <div class="cta-row">
             <a class="btn btn-primary" href="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k" target="_blank" rel="noopener">Tip $5 one time</a>
             <a class="btn btn-secondary" href="supporter.html">Support $20/month</a>
             <a class="btn btn-primary" href="#recent-milestones" style="background:linear-gradient(135deg,#2dd3a6,#17c6cf);">See the Results</a>
+            <a class="btn btn-secondary" href="solutions.html">See Buyer Services</a>
             <a class="btn btn-secondary" href="chat.html">Open Polly Chat</a>
             <a class="btn btn-secondary" href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">Try the Demos</a>
             <a class="btn btn-secondary" href="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06" target="_blank" rel="noopener">Explore the Toolkit ($29)</a>

--- a/docs/products.html
+++ b/docs/products.html
@@ -370,6 +370,7 @@
       <a href="index.html">Home</a>
       <a href="start-here.html">Start Here</a>
       <a href="products.html" style="color:var(--text);">Products</a>
+      <a href="solutions.html">Solutions</a>
       <a href="hire.html">Hire</a>
       <a href="chat.html">Chat with Polly</a>
       <a href="agents.html">Agents</a>
@@ -714,7 +715,7 @@
 
 <footer>
   <p>SCBE-AETHERMOORE — governed AI workflow tools.<br>
-  <a href="index.html">Home</a> · <a href="start-here.html">Start Here</a> · <a href="hire.html">Hire</a> · <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">GitHub</a></p>
+  <a href="index.html">Home</a> · <a href="start-here.html">Start Here</a> · <a href="solutions.html">Solutions</a> · <a href="hire.html">Hire</a> · <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">GitHub</a></p>
 </footer>
 
 <script>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -49,6 +49,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/solutions.html</loc>
+    <lastmod>2026-05-11</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://aethermoore.com/hire</loc>
     <lastmod>2026-05-09</lastmod>
     <changefreq>weekly</changefreq>

--- a/docs/solutions.html
+++ b/docs/solutions.html
@@ -1,0 +1,358 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Agent Governance Solutions | AetherMoore</title>
+    <meta
+      name="description"
+      content="AetherMoore turns SCBE-AETHERMOORE into practical buyer-ready services: governance snapshots, agent drift evaluation, multi-agent containment, prompt injection review, and monthly heartbeat monitoring."
+    />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/solutions.html" />
+    <meta property="og:title" content="AetherMoore AI Agent Governance Solutions" />
+    <meta
+      property="og:description"
+      content="Five buyer-ready services for AI workflow governance, drift evaluation, prompt injection review, and multi-agent containment."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://aethermoore.com/SCBE-AETHERMOORE/solutions.html" />
+    <meta name="twitter:card" content="summary" />
+    <link rel="stylesheet" href="static/polly-sidebar.css" />
+    <style>
+      :root {
+        --bg: #0f1217;
+        --panel: #171c24;
+        --panel-soft: #131821;
+        --ink: #f6f1e8;
+        --muted: #c8bda9;
+        --line: #34313a;
+        --gold: #d6a756;
+        --green: #2dd3a6;
+        --blue: #8cb4ff;
+      }
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      body {
+        margin: 0;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background:
+          radial-gradient(circle at 15% 0%, rgba(214, 167, 86, 0.12), transparent 30%),
+          linear-gradient(180deg, #0f1217 0%, #0b0d12 100%);
+        color: var(--ink);
+        line-height: 1.55;
+      }
+      a { color: inherit; }
+      .wrap {
+        width: min(1120px, calc(100% - 32px));
+        margin: 0 auto;
+      }
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        padding: 24px 0;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      nav a { text-decoration: none; }
+      nav a:hover { color: var(--ink); }
+      .hero {
+        padding: 48px 0 36px;
+        border-bottom: 1px solid rgba(214, 167, 86, 0.18);
+      }
+      .eyebrow {
+        color: var(--gold);
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        margin-bottom: 12px;
+      }
+      h1 {
+        max-width: 900px;
+        margin: 0 0 18px;
+        font-size: clamp(38px, 7vw, 76px);
+        line-height: 0.98;
+        letter-spacing: 0;
+      }
+      h2 { margin: 0 0 10px; font-size: clamp(26px, 4vw, 42px); line-height: 1.05; }
+      h3 { margin: 0 0 8px; font-size: 20px; }
+      p { color: var(--muted); font-size: 17px; max-width: 780px; }
+      .hero p { font-size: clamp(17px, 2vw, 21px); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 24px;
+      }
+      .btn {
+        display: inline-flex;
+        min-height: 46px;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid var(--gold);
+        border-radius: 6px;
+        padding: 12px 18px;
+        color: #12110f;
+        background: var(--gold);
+        font-weight: 800;
+        text-decoration: none;
+      }
+      .btn.secondary {
+        background: transparent;
+        color: var(--ink);
+      }
+      .proof-row {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 12px;
+        margin: 30px 0 0;
+      }
+      .proof {
+        border: 1px solid var(--line);
+        background: rgba(23, 28, 36, 0.8);
+        border-radius: 8px;
+        padding: 16px;
+      }
+      .proof strong { display: block; color: var(--ink); font-size: 18px; margin-bottom: 4px; }
+      .proof span { color: var(--muted); font-size: 14px; }
+      section { padding: 48px 0; }
+      .section-head { margin-bottom: 24px; }
+      .solutions {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(190px, 1fr));
+        gap: 14px;
+      }
+      .solution {
+        border: 1px solid var(--line);
+        background: var(--panel);
+        border-radius: 8px;
+        padding: 18px;
+      }
+      .solution .price {
+        display: inline-block;
+        margin: 8px 0 12px;
+        color: var(--green);
+        font-weight: 800;
+      }
+      .solution ul, .plain-list {
+        margin: 12px 0 0;
+        padding-left: 18px;
+        color: var(--muted);
+      }
+      li { margin-bottom: 7px; }
+      .flow {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 10px;
+      }
+      .step {
+        border: 1px solid rgba(214, 167, 86, 0.28);
+        background: rgba(214, 167, 86, 0.06);
+        border-radius: 8px;
+        padding: 18px;
+      }
+      .step b { color: var(--gold); }
+      .translation {
+        width: 100%;
+        border-collapse: collapse;
+        overflow: hidden;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel-soft);
+      }
+      .translation th, .translation td {
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--line);
+        text-align: left;
+        vertical-align: top;
+      }
+      .translation th { color: var(--gold); font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; }
+      .translation td { color: var(--muted); }
+      .translation tr:last-child td { border-bottom: 0; }
+      .band {
+        border-top: 1px solid var(--line);
+        border-bottom: 1px solid var(--line);
+        background: rgba(255,255,255,0.025);
+      }
+      .note {
+        font-size: 14px;
+        color: var(--muted);
+      }
+      footer {
+        padding: 32px 0;
+        color: var(--muted);
+        border-top: 1px solid var(--line);
+      }
+      @media (max-width: 920px) {
+        .proof-row, .solutions, .flow { grid-template-columns: 1fr 1fr; }
+      }
+      @media (max-width: 620px) {
+        .proof-row, .solutions, .flow { grid-template-columns: 1fr; }
+        h1 { font-size: 40px; }
+      }
+    </style>
+  </head>
+  <body data-polly-context="solutions" data-polly-root=".">
+    <div class="wrap">
+      <nav aria-label="Solutions navigation">
+        <a href="index.html">Home</a>
+        <a href="products.html">Products</a>
+        <a href="governance-snapshot.html">Governance Snapshot</a>
+        <a href="hire.html">Hire</a>
+        <a href="chat.html">Chat</a>
+      </nav>
+    </div>
+
+    <header class="hero">
+      <div class="wrap">
+        <div class="eyebrow">Buyer-ready AI governance</div>
+        <h1>Turn agent failures into a short report, a fixed scope, and a next action.</h1>
+        <p>
+          AetherMoore packages SCBE-AETHERMOORE into practical services for teams using AI
+          agents, tool-calling workflows, retrieval systems, or multi-agent automation. The goal
+          is not a giant compliance program. The goal is to find the weak joints, fix the ones
+          that matter, and leave you with evidence you can reuse.
+        </p>
+        <div class="actions">
+          <a class="btn" href="governance-snapshot.html">Buy the $500 Snapshot</a>
+          <a class="btn secondary" href="hire.html">Send a project brief</a>
+          <a class="btn secondary" href="#solutions">Compare the offers</a>
+        </div>
+        <div class="proof-row" aria-label="Proof points">
+          <div class="proof"><strong>Live offers</strong><span>Snapshot, service credits, toolkit, training vault, and supporter lanes are wired in the public offer registry.</span></div>
+          <div class="proof"><strong>Public code</strong><span>GitHub, npm/PyPI, and documented harnesses make the work inspectable.</span></div>
+          <div class="proof"><strong>Reusable evidence</strong><span>Reports focus on risk, routing, state, logging, recovery, and receipt gaps.</span></div>
+          <div class="proof"><strong>Federal posture</strong><span>CAGE 1EXD5 and UEI J4NXHM6N5F59 support subcontract and research conversations.</span></div>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section id="solutions">
+        <div class="wrap">
+          <div class="section-head">
+            <div class="eyebrow">What you can buy</div>
+            <h2>Five concrete entry points.</h2>
+            <p>Start small. The first paid deliverable should be useful even if nothing else is bought afterward.</p>
+          </div>
+          <div class="solutions">
+            <article class="solution">
+              <h3>Governance Snapshot</h3>
+              <span class="price">$500 fixed scope</span>
+              <p>One AI workflow reviewed for drift, leakage, routing risk, logging gaps, and unsafe tool paths.</p>
+              <ul>
+                <li>2-page findings memo</li>
+                <li>Three prioritized fixes</li>
+                <li>Evidence checklist</li>
+              </ul>
+            </article>
+            <article class="solution">
+              <h3>Agent Drift Evaluation</h3>
+              <span class="price">quoted after brief</span>
+              <p>Stateful evaluation for agents that lose task history, mutate instructions, or recover poorly from failures.</p>
+              <ul>
+                <li>Before/after task pack</li>
+                <li>Failure-mode breakdown</li>
+                <li>Repair recommendations</li>
+              </ul>
+            </article>
+            <article class="solution">
+              <h3>Multi-Agent Containment</h3>
+              <span class="price">snapshot or custom</span>
+              <p>Flat-queue versus bounded-workcell simulation for teams routing multiple agents through shared state.</p>
+              <ul>
+                <li>Failure spread metrics</li>
+                <li>Trace cost metrics</li>
+                <li>Receipt schema suggestion</li>
+              </ul>
+            </article>
+            <article class="solution">
+              <h3>Prompt Injection Review</h3>
+              <span class="price">snapshot or custom</span>
+              <p>Boundary review for exposed tools, retrieval, MCP connectors, API routes, and dataset ingest.</p>
+              <ul>
+                <li>Finding list</li>
+                <li>Proof and severity</li>
+                <li>Regression test ideas</li>
+              </ul>
+            </article>
+            <article class="solution">
+              <h3>Governance Heartbeat</h3>
+              <span class="price">$99/month planned</span>
+              <p>A lightweight monthly scan for one workflow after the first Snapshot has a baseline.</p>
+              <ul>
+                <li>Delta report</li>
+                <li>Risk/change summary</li>
+                <li>Recommended action list</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="band" id="workflow">
+        <div class="wrap">
+          <div class="section-head">
+            <div class="eyebrow">Delivery path</div>
+            <h2>How the work turns into evidence.</h2>
+          </div>
+          <div class="flow" aria-label="Delivery flow">
+            <div class="step"><b>1. Intake</b><p>One workflow, tool path, or agent problem. No secrets required.</p></div>
+            <div class="step"><b>2. Run</b><p>SCBE checks routing, state, prompt/tool boundaries, and recovery behavior.</p></div>
+            <div class="step"><b>3. Report</b><p>You receive a short memo with evidence, findings, and next actions.</p></div>
+            <div class="step"><b>4. Continue</b><p>Use the fixes, buy Heartbeat, or scope a custom integration.</p></div>
+          </div>
+        </div>
+      </section>
+
+      <section id="translation">
+        <div class="wrap">
+          <div class="section-head">
+            <div class="eyebrow">Procurement translation</div>
+            <h2>Same system, buyer-readable language.</h2>
+            <p>Internal SCBE terms stay useful, but buyers need the operational translation first.</p>
+          </div>
+          <table class="translation">
+            <thead><tr><th>SCBE term</th><th>Buyer translation</th></tr></thead>
+            <tbody>
+              <tr><td>Harmonic governance</td><td>Adaptive risk scoring for AI workflows</td></tr>
+              <tr><td>Sacred Tongues / routing lanes</td><td>Domain-specialized orchestration and evidence lanes</td></tr>
+              <tr><td>GeoSeal</td><td>Trust-boundary receipt and verification layer</td></tr>
+              <tr><td>Aether-Lattice workcells</td><td>Bounded agent execution and failure containment</td></tr>
+              <tr><td>Spinal ledger</td><td>Append-only operational trace</td></tr>
+              <tr><td>Agent bus</td><td>Secure orchestration bus for agents, tools, and review gates</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="band" id="proof">
+        <div class="wrap">
+          <div class="section-head">
+            <div class="eyebrow">Boundaries</div>
+            <h2>What this claims, and what it does not.</h2>
+          </div>
+          <ul class="plain-list">
+            <li>SCBE provides governance and traceability around AI agents. It is not a replacement foundation model.</li>
+            <li>Reports are technical risk reads and implementation guidance. They are not legal compliance guarantees.</li>
+            <li>Simulations are workflow evidence. They are not hardware guarantees or claims of infinite scalability.</li>
+            <li>Paid work starts with fixed scope because useful action beats vague enterprise theater.</li>
+          </ul>
+          <div class="actions">
+            <a class="btn" href="governance-snapshot.html">Start with the Snapshot</a>
+            <a class="btn secondary" href="business/SCBE_BUYER_CAPABILITY_BUCKETS_2026-05.md">Read the packaging sheet</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="wrap">
+        AetherMoore. Geometric AI governance by Issac Davis. CAGE 1EXD5. UEI J4NXHM6N5F59.
+      </div>
+    </footer>
+    <script src="static/polly-sidebar.js" data-polly-api="https://scbe-agent-bridge-vercel.vercel.app"></script>
+    <script src="static/polly-funnel.js" data-page="solutions"></script>
+  </body>
+</html>

--- a/docs/static/polly-sidebar.js
+++ b/docs/static/polly-sidebar.js
@@ -501,6 +501,7 @@
     // deterministic commerce/research path — no LLM dependency.
     var STARTERS = [
       "Help me choose a product",
+      "What services can I buy from AetherMoore?",
       "Tell me about the governance snapshot",
       "What is the harmonic wall?",
       "search hyperbolic geometry AI safety",


### PR DESCRIPTION
## Summary
- add a public `solutions.html` page that turns SCBE into five buyer-ready service buckets
- link Solutions from the homepage and products page
- expose the solutions route in app config, sitemap, and Polly starter prompts
- add a buyer capability packaging sheet for internal reuse

## Verification
- `python - <<static website checks>>` equivalent local link/content check passed
- `git diff --check` passed
- `docs/app-config.json` and `docs/offers.json` parse as JSON

## Rollback
- Revert this PR to remove the Solutions page and route links.