### PR TITLE
fix(stripe): use live heartbeat defaults without env

### DIFF
--- a/api/billing/stripe_webhook.js
+++ b/api/billing/stripe_webhook.js
@@ -26,6 +26,7 @@ const crypto = require('crypto');
 
 const SNAPSHOT_AMOUNT_CENTS = 50000;
 const HEARTBEAT_AMOUNT_CENTS = 9900;
+const LIVE_HEARTBEAT_PAYMENT_LINK_ID = 'plink_1TW71zJTF2SuUODICZLQCCS3';
 const DIGITAL_PRODUCT_AMOUNT_CENTS = 2900;
 const TOLERANCE_SECONDS = 300; // Stripe default replay window
 
@@ -123,7 +124,8 @@ function snapshotConfig() {
   return {
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
     paymentLinkId: process.env.STRIPE_SNAPSHOT_PAYMENT_LINK_ID || '',
-    heartbeatPaymentLinkId: process.env.STRIPE_HEARTBEAT_PAYMENT_LINK_ID || '',
+    heartbeatPaymentLinkId:
+      process.env.STRIPE_HEARTBEAT_PAYMENT_LINK_ID || LIVE_HEARTBEAT_PAYMENT_LINK_ID,
     toolkitPaymentLinkId: process.env.STRIPE_TOOLKIT_PAYMENT_LINK_ID || '',
     vaultPaymentLinkId: process.env.STRIPE_VAULT_PAYMENT_LINK_ID || '',
     repo: process.env.POLLY_TRAIN_REPO || process.env.GITHUB_REPO || 'issdandavis/SCBE-AETHERMOORE',

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const LIVE_HEARTBEAT_CHECKOUT_URL = 'https://buy.stripe.com/5kQ6oI0hQgKz9gQ6midby0m';
+
 function checkoutUrlFromEnv(envName, fallback) {
   const value = String(process.env[envName] || '').trim();
   if (!value) return fallback;
@@ -93,7 +95,7 @@ const PRODUCT_CATALOG = [
       'Monthly governance scan for one AI workflow. Includes a short delta report, risk/change summary, recommended action list, and optional training/dataset capture notes.',
     checkoutUrl: checkoutUrlFromEnv(
       'SCBE_PAYMENT_LINK_HEARTBEAT',
-      'mailto:issdandavis7795@gmail.com?subject=Governance%20Heartbeat%20signup'
+      LIVE_HEARTBEAT_CHECKOUT_URL
     ),
     deliveryUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html#heartbeat',
     keywords: [

--- a/docs/ops/STRIPE_HEARTBEAT_ACTIVATION.md
+++ b/docs/ops/STRIPE_HEARTBEAT_ACTIVATION.md
@@ -14,7 +14,9 @@ Live production objects created 2026-05-12:
 - Governance Heartbeat Payment Link ID: `plink_1TW71zJTF2SuUODICZLQCCS3`
 - Governance Heartbeat Price ID: `price_1TW71zJTF2SuUODIkHVk4Ws0`
 
-Set Vercel production environment variables:
+The public checkout URL and Payment Link ID are now baked in as safe public
+fallbacks. These Vercel production environment variables are still allowed as
+overrides, but the Heartbeat path no longer depends on setting them before use:
 
 ```text
 SCBE_PAYMENT_LINK_HEARTBEAT=https://buy.stripe.com/5kQ6oI0hQgKz9gQ6midby0m
@@ -46,7 +48,8 @@ In the live Stripe Dashboard:
    - not `https://buy.stripe.com/test_...`
 5. Copy the live Payment Link ID, which starts with `plink_`.
 
-Then set Vercel production environment variables:
+Then set Vercel production environment variables if you want to override the
+checked-in production defaults:
 
 ```text
 SCBE_PAYMENT_LINK_HEARTBEAT=https://buy.stripe.com/<live_heartbeat_subscription_link>
@@ -54,7 +57,9 @@ STRIPE_HEARTBEAT_PAYMENT_LINK_ID=plink_<live_heartbeat_payment_link_id>
 ```
 
 `SCBE_PAYMENT_LINK_HEARTBEAT` controls what Polly and the catalog give customers.
-`STRIPE_HEARTBEAT_PAYMENT_LINK_ID` lets the Stripe webhook classify the checkout as `polly_heartbeat_started`.
+`STRIPE_HEARTBEAT_PAYMENT_LINK_ID` lets the Stripe webhook classify the checkout
+as `polly_heartbeat_started`. If either variable is unset, the code falls back
+to the live 2026-05-12 Heartbeat link and `plink_1TW71zJTF2SuUODICZLQCCS3`.
 
 The commerce layer rejects `plink_...` and `https://buy.stripe.com/test_...` as public checkout overrides.
 

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -250,9 +250,7 @@ describe('polly commerce intent classification', () => {
     const heartbeat = loaded.PRODUCT_CATALOG.find(
       (p: { sku: string }) => p.sku === 'governance-heartbeat'
     );
-    expect(heartbeat.checkoutUrl).toBe(
-      'mailto:issdandavis7795@gmail.com?subject=Governance%20Heartbeat%20signup'
-    );
+    expect(heartbeat.checkoutUrl).toBe('https://buy.stripe.com/5kQ6oI0hQgKz9gQ6midby0m');
   });
 
   it('classifies "buy" verb with bound product at 0.95 confidence', () => {
@@ -637,7 +635,7 @@ describe('polly commerce reply rendering', () => {
     const out = commerce.renderBuyReply(product);
     expect(out.text).toContain('$99/month');
     expect(out.text).toContain('first scan starts');
-    expect(out.actions[0].url).toMatch(/^mailto:/);
+    expect(out.actions[0].url).toBe('https://buy.stripe.com/5kQ6oI0hQgKz9gQ6midby0m');
   });
 
   it('renderCustomReply returns mailto with pre-filled context', () => {


### PR DESCRIPTION
## Summary
- make the Governance Heartbeat public Stripe checkout URL the Polly fallback instead of mailto
- make the Stripe webhook fall back to the live Heartbeat Payment Link ID when Vercel env is missing
- update tests/docs so live public Stripe defaults are the expected no-config behavior

## Test evidence
- `npm test -- tests/api/polly_commerce_js.test.ts tests/api/stripe_webhook_js.test.ts` -> 135 passed
- `git diff --check`

## Why
This removes the remaining Vercel-env gate for the $99/mo Heartbeat path. Env vars can still override the checked-in public defaults later, but customers and webhook classification no longer depend on manual dashboard setup.