### PR TITLE
fix(site): keep offer checkout URLs Stripe-backed

### DIFF
--- a/docs/offers.json
+++ b/docs/offers.json
@@ -43,8 +43,8 @@
       "name": "Tip Jar",
       "price_label": "$5 one time",
       "type": "one_time",
-      "checkout_url": "https://ko-fi.com/izdandavis",
-      "stripe_checkout_url": "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k",
+      "checkout_url": "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k",
+      "kofi_url": "https://ko-fi.com/izdandavis",
       "alternate_checkout": {
         "cash_app": "$IzzyDDavis7",
         "cash_app_qr_url": "https://aethermoore.com/SCBE-AETHERMOORE/static/cash-app-payment.png"
@@ -57,8 +57,8 @@
       "name": "AetherMoore Supporter",
       "price_label": "$20/month",
       "type": "subscription",
-      "checkout_url": "https://ko-fi.com/izdandavis",
-      "stripe_checkout_url": "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i",
+      "checkout_url": "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i",
+      "kofi_url": "https://ko-fi.com/izdandavis",
       "alternate_checkout": {
         "cash_app": "$IzzyDDavis7",
         "cash_app_qr_url": "https://aethermoore.com/SCBE-AETHERMOORE/static/cash-app-payment.png"


### PR DESCRIPTION
## Summary
- keeps the human-facing site Ko-fi-first from #1688
- restores `tip_jar.checkout_url` and `supporter_monthly.checkout_url` to the Stripe URLs expected by product delivery smoke tests
- preserves Ko-fi on each offer as `kofi_url` and keeps Cash App alternate checkout metadata

## Why
The site should make Ko-fi the low-pressure support path, but `offers.json.checkout_url` is also used as the structured delivery/revenue link in smoke tests and automation. This keeps both paths working.

## Tests
- `node -e "JSON.parse(require('fs').readFileSync('docs/offers.json','utf8')); console.log('offers ok')"`
- `python -m pytest tests\test_vercel_launch_bridge.py -q`
- `npm run cash:autopromo:dry-run`
- `git diff --check origin/main..HEAD`