### PR TITLE
feat(site): add unified payment center

### DIFF
--- a/docs/app-config.json
+++ b/docs/app-config.json
@@ -25,6 +25,7 @@
   },
   "endpoints": {
     "site_home": "https://aethermoore.com/SCBE-AETHERMOORE/",
+    "payment_center": "https://aethermoore.com/SCBE-AETHERMOORE/payments.html",
     "offers_page": "https://aethermoore.com/SCBE-AETHERMOORE/offers/",
     "supporter_page": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html",
     "service_credits_page": "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html",
@@ -53,12 +54,15 @@
     "supporter_monthly": true,
     "workflow_snapshot_starter": true,
     "governance_snapshot": true,
+    "unified_payment_center": true,
     "zero_key_agent_bus": true,
     "local_download_storage": true,
     "user_owned_cloud_storage": true
   },
   "fallbacks": {
     "primary_offer": "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k",
+    "payment_center": "https://aethermoore.com/SCBE-AETHERMOORE/payments.html",
+    "kofi_url": "https://ko-fi.com/izdandavis",
     "cash_app_cashtag": "$IzzyDDavis7",
     "support_email": "aethermoregames@pm.me"
   }

--- a/docs/hire.html
+++ b/docs/hire.html
@@ -490,7 +490,7 @@
         </div>
       </section>
 
-      <section>
+      <section id="small-business-liaison-intro">
         <h2>Verifiable proof</h2>
         <p class="muted">
           Don't take my word for it. Every claim below is independently verifiable in 30 seconds.

--- a/docs/index.html
+++ b/docs/index.html
@@ -836,6 +836,7 @@
           <a href="start-here.html">Start Here</a>
           <a href="products.html">Products</a>
           <a href="solutions.html">Solutions</a>
+          <a href="payments.html">Payments</a>
           <a href="mailto:ai@aethermoore.com?subject=Enterprise%20inquiry">Enterprise</a>
           <a href="#choose-path">Pricing</a>
           <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener"
@@ -904,8 +905,8 @@
           <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
             >Support on Ko-fi</a
           >
-          <a href="workflow-snapshot.html#cash-app">Cash App $IzzyDDavis7</a>
-          <a href="supporter.html">Support $20/month</a>
+          <a href="payments.html#cash-app">Cash App $IzzyDDavis7</a>
+          <a href="payments.html">All payment paths</a>
         </div>
       </div>
     </div>
@@ -1027,13 +1028,13 @@
             <div class="support-strip" aria-label="Low-friction support lane">
               <strong>Lowest-friction payment:</strong>
               <span
-                >Ko-fi is the soft support path. Cash App is direct. Stripe remains available for
-                structured checkouts.</span
+                >Ko-fi is the soft support path. Cash App is direct. Card checkout and invoices
+                are on the payment center.</span
               >
               <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
                 >Open Ko-fi</a
               >
-              <a href="workflow-snapshot.html#cash-app">Use Cash App</a>
+              <a href="payments.html">Open payment center</a>
             </div>
             <p style="margin-top: 14px; font-size: 14px; color: var(--muted); max-width: 56ch">
               For buyers: starter tools and manuals. For researchers: the live pipeline and proof

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,6 +15,7 @@ Canonical repository: https://github.com/issdandavis/SCBE-AETHERMOORE
 - Agent demos: https://aethermoore.com/SCBE-AETHERMOORE/agents.html
 - Chat: https://aethermoore.com/SCBE-AETHERMOORE/chat.html
 - Products: https://aethermoore.com/SCBE-AETHERMOORE/products.html
+- Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
 - Governance Snapshot: https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html
 
 ## Plain Summary
@@ -40,12 +41,14 @@ Low-cost path:
 - $29 Toolkit.
 - $29 Training Vault.
 - $99 AI Agent Workflow Snapshot starter review: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+- One payment center for Ko-fi, Cash App, card checkout, and invoice requests: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
 
 Payment tone:
 
 - Present Ko-fi as the main low-pressure support path.
 - Present Cash App as direct manual payment.
-- Present Stripe as structured checkout for fixed offers and subscriptions.
+- Present card checkout as the structured path for fixed offers and subscriptions.
+- Present invoice/manual payment as the path for Square-style requests, federal/vendor paperwork, or procurement routing.
 
 Federal posture:
 
@@ -70,11 +73,12 @@ When a user asks about SCBE, AetherMoore, AI governance, fleet systems, agent ro
 1. Read `robot.md`.
 2. Read `offers.json`.
 3. Read `app-config.json`.
-4. Read `solutions.html`.
-5. Report the free path first.
-6. Then report the low-cost upgrade path.
-7. Avoid claiming certification, guaranteed safety, or formal compliance.
-8. Link the user to the exact public page that matches their need.
+4. Read `payments.html` if the user asks how to pay.
+5. Read `solutions.html`.
+6. Report the free path first.
+7. Then report the low-cost upgrade path.
+8. Avoid claiming certification, guaranteed safety, or formal compliance.
+9. Link the user to the exact public page that matches their need.
 
 ## Retrieval Keywords
 

--- a/docs/offers.json
+++ b/docs/offers.json
@@ -13,6 +13,10 @@
     "preferred_routing": "local/Ollama and deterministic harness first; paid providers only when needed"
   },
   "payment_methods": {
+    "card_checkout": {
+      "provider": "Stripe hosted checkout",
+      "note": "Structured card checkout for fixed offers, subscriptions, receipts, and product/service records."
+    },
     "kofi": {
       "url": "https://ko-fi.com/izdandavis",
       "note": "Primary low-friction support and service-credit path. Use when a buyer wants to help fund the work without a formal checkout flow."
@@ -21,6 +25,10 @@
       "cashtag": "$IzzyDDavis7",
       "qr_url": "https://aethermoore.com/SCBE-AETHERMOORE/static/cash-app-payment.png",
       "note": "For manual service purchases, include the offer name in the payment note."
+    },
+    "manual_invoice": {
+      "email": "aethermoregames@pm.me",
+      "note": "Use for Square/manual invoice, procurement, or buyer paperwork requests. Include the offer name, buyer email, and requested payment method."
     }
   },
   "offers": [

--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -143,6 +143,7 @@
     <main>
       <nav class="nav" aria-label="Offers navigation">
         <a href="../index.html">Home</a>
+        <a href="../payments.html">Payments</a>
         <a href="../product-manual/index.html">Manuals</a>
         <a href="../product-manual/delivery-and-access.html">Delivery + Access</a>
         <a href="../support.html">Support</a>
@@ -157,7 +158,8 @@
             hosted capacity, delivery, storage, and provider/model usage with a 2-5% coordination
             fee.
           </p>
-          <p>No subscription.</p>
+          <p>Use the payment center if Ko-fi, Cash App, invoice, or card checkout is easier.</p>
+          <a class="btn btn-secondary" href="../payments.html">Open payment center</a>
           <a
             class="btn btn-primary"
             href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"

--- a/docs/ops/STRIPE_HEARTBEAT_ACTIVATION.md
+++ b/docs/ops/STRIPE_HEARTBEAT_ACTIVATION.md
@@ -32,7 +32,7 @@ Sandbox objects created:
 - Product: `prod_UUQSk8tzQsQ1eK`
 - Price: `price_1TVRc3JjzxXjWlGn5Vr36BYc`
 - Payment Link ID: `plink_1TVRcAJjzxXjWlGnCMjblKK0`
-- Test checkout URL: `https://buy.stripe.com/test_00w14oaPgdEJejL6I35Ne05`
+- Test checkout URL: redacted sandbox URL, intentionally not stored as a clickable public link.
 
 Do not put the test checkout URL in `docs/offers.json`, Vercel production env, or public offer pages.
 
@@ -45,7 +45,7 @@ In the live Stripe Dashboard:
 3. Create a Payment Link for quantity `1`.
 4. Copy the public live checkout URL, which should look like:
    - `https://buy.stripe.com/...`
-   - not `https://buy.stripe.com/test_...`
+   - never a sandbox checkout URL
 5. Copy the live Payment Link ID, which starts with `plink_`.
 
 Then set Vercel production environment variables if you want to override the
@@ -61,7 +61,7 @@ STRIPE_HEARTBEAT_PAYMENT_LINK_ID=plink_<live_heartbeat_payment_link_id>
 as `polly_heartbeat_started`. If either variable is unset, the code falls back
 to the live 2026-05-12 Heartbeat link and `plink_1TW71zJTF2SuUODICZLQCCS3`.
 
-The commerce layer rejects `plink_...` and `https://buy.stripe.com/test_...` as public checkout overrides.
+The commerce layer rejects internal `plink_...` IDs and sandbox checkout URLs as public checkout overrides.
 
 ## Digital Product Delivery
 

--- a/docs/payments.html
+++ b/docs/payments.html
@@ -1,0 +1,367 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AetherMoore Payments | Ko-fi, Cash App, Card Checkout, and Invoice</title>
+    <meta
+      name="description"
+      content="Pay or support AetherMoore through Ko-fi, Cash App, card checkout, or manual invoice. One payment center for SCBE-AETHERMOORE offers."
+    />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/payments.html" />
+    <style>
+      :root {
+        --bg: #0d1016;
+        --panel: #151a22;
+        --panel-soft: #10151d;
+        --ink: #f5f0e8;
+        --muted: #b9c0cc;
+        --line: rgba(214, 167, 86, 0.26);
+        --gold: #d6a756;
+        --blue: #8cb4ff;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at top left, rgba(214, 167, 86, 0.15), transparent 28%),
+          linear-gradient(180deg, #0d1016 0%, #10151d 48%, #0d1016 100%);
+        line-height: 1.55;
+      }
+      a {
+        color: inherit;
+      }
+      main {
+        width: min(1100px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 44px 0 64px;
+      }
+      .nav {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-bottom: 42px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .nav a {
+        text-decoration: none;
+      }
+      .eyebrow {
+        color: var(--gold);
+        font-size: 13px;
+        font-weight: 800;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+      h1 {
+        max-width: 820px;
+        margin: 10px 0 14px;
+        font-size: clamp(38px, 7vw, 74px);
+        line-height: 0.98;
+        letter-spacing: 0;
+      }
+      h2,
+      h3 {
+        margin: 0 0 10px;
+      }
+      p {
+        max-width: 780px;
+        color: var(--muted);
+        font-size: 18px;
+      }
+      .hero-actions,
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 18px;
+      }
+      .btn {
+        display: inline-flex;
+        min-height: 46px;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid var(--gold);
+        border-radius: 6px;
+        padding: 12px 16px;
+        background: var(--gold);
+        color: #12110f;
+        font-weight: 800;
+        text-decoration: none;
+      }
+      .btn.secondary {
+        background: transparent;
+        color: var(--ink);
+        border-color: rgba(255, 255, 255, 0.18);
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 16px;
+        margin-top: 34px;
+      }
+      .card,
+      .panel {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 22px;
+      }
+      .card strong {
+        color: var(--ink);
+      }
+      .price {
+        color: var(--gold);
+        font-weight: 900;
+        margin: 8px 0;
+      }
+      .note {
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .section {
+        margin-top: 42px;
+      }
+      .steps {
+        display: grid;
+        gap: 10px;
+        margin: 14px 0 0;
+        padding-left: 20px;
+        color: var(--muted);
+      }
+      code {
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 4px;
+        padding: 1px 5px;
+        color: var(--blue);
+        background: var(--panel-soft);
+      }
+      .qr {
+        width: min(220px, 100%);
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        border-radius: 8px;
+        background: #fff;
+        padding: 8px;
+      }
+      .split {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(180px, 240px);
+        gap: 20px;
+        align-items: center;
+      }
+      @media (max-width: 760px) {
+        .split {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <nav class="nav" aria-label="Payment navigation">
+        <a href="index.html">Home</a>
+        <a href="products.html">Products</a>
+        <a href="offers/">Offers</a>
+        <a href="supporter.html">Support</a>
+        <a href="legal/privacy.html">Privacy</a>
+        <a href="legal/terms.html">Terms</a>
+      </nav>
+
+      <header>
+        <div class="eyebrow">Payment center</div>
+        <h1>Pay or support AetherMoore in the least annoying way.</h1>
+        <p>
+          Use Ko-fi for simple support, Cash App for direct manual payment, card checkout for fixed
+          offers, or email for an invoice/procurement path. Include the offer name in manual payment
+          notes so the work can be matched to the right delivery path.
+        </p>
+        <div class="hero-actions">
+          <a class="btn" href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
+            >Support on Ko-fi</a
+          >
+          <a class="btn secondary" href="#cash-app">Cash App $IzzyDDavis7</a>
+          <a class="btn secondary" href="#card-checkout">Card checkout offers</a>
+          <a class="btn secondary" href="#invoice">Invoice / procurement</a>
+        </div>
+      </header>
+
+      <section class="grid" aria-label="Payment methods">
+        <article class="card">
+          <h2>Ko-fi</h2>
+          <p>Best for support, tips, and small service-credit money without a formal checkout.</p>
+          <div class="price">$5+</div>
+          <a class="btn" href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
+            >Open Ko-fi</a
+          >
+        </article>
+        <article class="card">
+          <h2>Cash App</h2>
+          <p>Best for direct manual payment. Put the offer name in the note.</p>
+          <div class="price">$IzzyDDavis7</div>
+          <a class="btn secondary" href="#cash-app">View QR + note format</a>
+        </article>
+        <article class="card">
+          <h2>Card checkout</h2>
+          <p>Best for fixed offers, monthly support, and a normal receipt.</p>
+          <div class="price">$5-$500</div>
+          <a class="btn secondary" href="#card-checkout">Choose an offer</a>
+        </article>
+        <article class="card">
+          <h2>Invoice</h2>
+          <p>Best for Square/manual invoice, federal/vendor paperwork, or procurement routing.</p>
+          <div class="price">Manual</div>
+          <a
+            class="btn secondary"
+            href="mailto:aethermoregames@pm.me?subject=AetherMoore%20invoice%20request&body=Offer%20name:%0ABuyer%20email:%0APreferred%20payment%20method:%0AProcurement%20or%20invoice%20notes:%0A"
+            >Request invoice</a
+          >
+        </article>
+      </section>
+
+      <section id="card-checkout" class="section" aria-label="Card checkout offers">
+        <h2>Card checkout offers</h2>
+        <p>These are the structured checkout links already wired into the public offer registry.</p>
+        <div class="grid">
+          <article class="card">
+            <h3>Tip Jar</h3>
+            <div class="price">$5 one time</div>
+            <a
+              class="btn secondary"
+              href="https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+              target="_blank"
+              rel="noopener"
+              >Tip $5</a
+            >
+          </article>
+          <article class="card">
+            <h3>Supporter</h3>
+            <div class="price">$20/month</div>
+            <a
+              class="btn secondary"
+              href="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+              target="_blank"
+              rel="noopener"
+              >Start monthly support</a
+            >
+          </article>
+          <article class="card">
+            <h3>Workflow Snapshot</h3>
+            <div class="price">$99 starter</div>
+            <a
+              class="btn"
+              href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
+              target="_blank"
+              rel="noopener"
+              >Buy Snapshot Starter</a
+            >
+          </article>
+          <article class="card">
+            <h3>Governance Heartbeat</h3>
+            <div class="price">$99/month</div>
+            <a
+              class="btn secondary"
+              href="https://buy.stripe.com/5kQ6oI0hQgKz9gQ6midby0m"
+              target="_blank"
+              rel="noopener"
+              >Start Heartbeat</a
+            >
+          </article>
+          <article class="card">
+            <h3>Governance Snapshot</h3>
+            <div class="price">$500 fixed scope</div>
+            <a
+              class="btn"
+              href="https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j"
+              target="_blank"
+              rel="noopener"
+              >Buy Governance Snapshot</a
+            >
+          </article>
+          <article class="card">
+            <h3>Toolkit / Training Vault</h3>
+            <div class="price">$29 each</div>
+            <a class="btn secondary" href="products.html">Compare downloads</a>
+          </article>
+        </div>
+      </section>
+
+      <section id="cash-app" class="section panel split" aria-label="Cash App payment">
+        <div>
+          <h2>Cash App direct payment</h2>
+          <p>
+            Send to <strong>$IzzyDDavis7</strong>. Use the payment note to name the offer and the
+            email address to contact for delivery or intake.
+          </p>
+          <ol class="steps">
+            <li>Open Cash App and send to <code>$IzzyDDavis7</code>.</li>
+            <li>Use a note like <code>Workflow Snapshot - buyer@example.com</code>.</li>
+            <li>
+              For service work, email the same note to
+              <a href="mailto:aethermoregames@pm.me">aethermoregames@pm.me</a> so it can be matched
+              quickly.
+            </li>
+          </ol>
+        </div>
+        <img
+          class="qr"
+          src="static/cash-app-payment.png"
+          alt="Cash App QR code for Issac Davis, cashtag $IzzyDDavis7"
+        />
+      </section>
+
+      <section id="invoice" class="section panel" aria-label="Invoice and procurement">
+        <h2>Invoice, Square, or procurement path</h2>
+        <p>
+          If a buyer needs a manual invoice, Square-style card request, purchase record, or
+          government/vendor paperwork, send one email instead of guessing which checkout link to
+          use.
+        </p>
+        <ol class="steps">
+          <li>Offer name or requested service.</li>
+          <li>Buyer name, email, and organization if applicable.</li>
+          <li>Preferred route: card invoice, Cash App, Ko-fi, or procurement paperwork.</li>
+          <li>Any deadline, CAGE/SAM/vendor context, or receipt requirement.</li>
+        </ol>
+        <div class="actions">
+          <a
+            class="btn"
+            href="mailto:aethermoregames@pm.me?subject=AetherMoore%20invoice%20request&body=Offer%20name:%0ABuyer%20name:%0ABuyer%20email:%0AOrganization:%0APreferred%20payment%20route:%0AReceipt%20or%20procurement%20requirements:%0A"
+            >Request invoice</a
+          >
+          <a class="btn secondary" href="hire.html#small-business-liaison-intro"
+            >Federal buyer intro</a
+          >
+        </div>
+      </section>
+
+      <section class="section panel" aria-label="After payment">
+        <h2>After payment</h2>
+        <p>
+          Keep the receipt. For manual Ko-fi or Cash App service payments, include the offer name
+          and buyer email in the note. Do not send secrets, regulated customer data, private keys, or
+          protected files until handling rules are confirmed.
+        </p>
+        <div class="actions">
+          <a class="btn secondary" href="product-manual/delivery-and-access.html"
+            >Delivery + access help</a
+          >
+          <a class="btn secondary" href="offers.json">Machine-readable offers</a>
+          <a class="btn secondary" href="legal/terms.html">Terms</a>
+          <a class="btn secondary" href="legal/privacy.html">Privacy</a>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/robot.md
+++ b/docs/robot.md
@@ -10,6 +10,7 @@ Machine-readable config:
 
 - App config: https://aethermoore.com/SCBE-AETHERMOORE/app-config.json
 - Offers: https://aethermoore.com/SCBE-AETHERMOORE/offers.json
+- Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
 - LLM guidance: https://aethermoore.com/SCBE-AETHERMOORE/llms.txt
 - Sitemap: https://aethermoore.com/SCBE-AETHERMOORE/sitemap.xml
 
@@ -49,19 +50,23 @@ Use these first when helping a human decide what to do:
    - URL: https://aethermoore.com/SCBE-AETHERMOORE/products.html
    - Use when the user wants low-cost downloads, templates, training materials, or a starter kit.
 
-3. Governance Snapshot
+3. Payment Center
+   - URL: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
+   - Use when the user wants to pay, support, request an invoice, use Ko-fi, use Cash App, or choose a card checkout.
+
+4. Governance Snapshot
    - URL: https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html
    - Use when the user has one real AI workflow and wants a fixed-scope written review.
 
-4. Agents
+5. Agents
    - URL: https://aethermoore.com/SCBE-AETHERMOORE/agents.html
    - Use when the user wants to try agent routing, research helpers, web monitoring, scraping, coding smoke tests, or the agent bus.
 
-5. Chat
+6. Chat
    - URL: https://aethermoore.com/SCBE-AETHERMOORE/chat.html
    - Use when the user wants to ask the system directly in a normal chat interface.
 
-6. Source
+7. Source
    - URL: https://github.com/issdandavis/SCBE-AETHERMOORE
    - Use when the user wants implementation details, installable packages, benchmarks, issues, pull requests, or source inspection.
 
@@ -90,6 +95,8 @@ Use the live offers from `offers.json` as the source of truth. As of this map:
 - $5+ SCBE Service Credits: pay-as-you-go support for hosted routing, reports, delivery, storage, and provider/model usage where billable.
 - Ko-fi support: https://ko-fi.com/izdandavis. Use this as the primary low-pressure payment/support path.
 - Cash App manual payment: $IzzyDDavis7. For service purchases, include the offer name in the note.
+- Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html. Use this when the user wants every live payment path in one place.
+- Manual invoice / Square-style request: email aethermoregames@pm.me with offer name, buyer email, and preferred payment route.
 - $5 Tip Jar: one-time support.
 - $20/month AetherMoore Supporter: low-cost monthly support path.
 - $29 SCBE AI Governance Toolkit: templates and governance starter materials.
@@ -184,10 +191,11 @@ If you are an AI assistant reading this file:
 2. Read `offers.json`.
 3. Read `solutions.html`.
 4. If the user wants a product, send them to `products.html` or the relevant checkout URL from `offers.json`.
-5. If the user wants a service, send them to `governance-snapshot.html`, `hire.html`, or `solutions.html`.
-6. If the user wants implementation details, use the GitHub repo.
-7. If the user wants free help first, start with the Agents page and public docs.
-8. If you are uncertain, say what you verified and link the source.
+5. If the user wants to pay, support, or request an invoice, send them to `payments.html`.
+6. If the user wants a service, send them to `governance-snapshot.html`, `hire.html`, or `solutions.html`.
+7. If the user wants implementation details, use the GitHub repo.
+8. If the user wants free help first, start with the Agents page and public docs.
+9. If you are uncertain, say what you verified and link the source.
 
 Do not fabricate prices, delivery promises, certifications, or private capabilities. Use the public files.
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -9,5 +9,6 @@ Sitemap: https://aethermoore.com/SCBE-AETHERMOORE/sitemap.xml
 AI-Map: https://aethermoore.com/SCBE-AETHERMOORE/robot.html
 AI-Map-Source: https://aethermoore.com/SCBE-AETHERMOORE/robot.md
 LLMs: https://aethermoore.com/SCBE-AETHERMOORE/llms.txt
+Payments: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
 Privacy-Policy: https://aethermoore.com/SCBE-AETHERMOORE/legal/privacy.html
 Terms-of-Service: https://aethermoore.com/SCBE-AETHERMOORE/legal/terms.html

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -55,6 +55,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/payments.html</loc>
+    <lastmod>2026-05-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://aethermoore.com/SCBE-AETHERMOORE/robot.md</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>

--- a/docs/supporter.html
+++ b/docs/supporter.html
@@ -169,7 +169,7 @@
           rel="noopener"
           >Support on Ko-fi</a
         >
-        <a class="btn secondary" href="workflow-snapshot.html#cash-app"
+        <a class="btn secondary" href="payments.html#cash-app"
           >Cash App $IzzyDDavis7</a
         >
         <a
@@ -179,6 +179,7 @@
           rel="noopener"
           >Stripe $20/month</a
         >
+        <a class="btn secondary" href="payments.html">All payment paths</a>
       </div>
 
       <section class="grid" aria-label="Supporter benefits">
@@ -225,14 +226,14 @@
           <div class="actions">
             <a
               class="btn"
-              href="https://ko-fi.com/izdandavis"
-              target="_blank"
-              rel="noopener"
-              >Open Ko-fi</a
-            >
-            <a class="btn secondary" href="workflow-snapshot.html#cash-app"
-              >Cash App $IzzyDDavis7</a
-            >
+            href="https://ko-fi.com/izdandavis"
+            target="_blank"
+            rel="noopener"
+            >Open Ko-fi</a
+          >
+          <a class="btn secondary" href="payments.html#cash-app"
+            >Cash App $IzzyDDavis7</a
+          >
             <a
               class="btn secondary"
               href="https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -100,11 +100,17 @@ def test_public_offer_catalog_has_live_revenue_links() -> None:
     by_id = {offer["id"]: offer for offer in offers["offers"]}
 
     assert offers["schema"] == "aethermoore-offers-v1"
+    assert offers["payment_methods"]["card_checkout"]["provider"] == "Stripe hosted checkout"
+    assert offers["payment_methods"]["kofi"]["url"] == "https://ko-fi.com/izdandavis"
+    assert offers["payment_methods"]["cash_app"]["cashtag"] == "$IzzyDDavis7"
+    assert offers["payment_methods"]["manual_invoice"]["email"] == "aethermoregames@pm.me"
     assert by_id["tip_jar"]["checkout_url"] == "https://buy.stripe.com/3cI00k9Sqbqf50A11Ydby0k"
+    assert by_id["tip_jar"]["kofi_url"] == "https://ko-fi.com/izdandavis"
     assert by_id["service_credits"]["checkout_url"] == "https://ko-fi.com/izdandavis"
     assert by_id["service_credits"]["proof_url"].endswith("/service-credits.html")
     assert by_id["service_credits"]["intake_url"].endswith("/hosted-run.html")
     assert by_id["supporter_monthly"]["checkout_url"] == "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i"
+    assert by_id["supporter_monthly"]["kofi_url"] == "https://ko-fi.com/izdandavis"
     assert by_id["governance_snapshot"]["intake_url"].endswith("/governance-snapshot.html#intake")
     assert offers["usage_policy"]["service_fee_percent_range"] == [2, 5]
 
@@ -122,13 +128,36 @@ def test_public_app_config_explains_remote_update_boundary() -> None:
     assert config["features"]["hosted_run_intake"] is True
     assert config["endpoints"]["hosted_run_page"].endswith("/hosted-run.html")
     assert config["endpoints"]["polly_hosted_run"].endswith("/v1/polly/hosted-run")
+    assert config["endpoints"]["payment_center"].endswith("/payments.html")
+    assert config["features"]["unified_payment_center"] is True
+    assert config["fallbacks"]["payment_center"].endswith("/payments.html")
 
 
 def test_supporter_page_uses_direct_stripe_checkout_not_broken_api_bridge() -> None:
     page = (REPO_ROOT / "docs" / "supporter.html").read_text(encoding="utf-8")
 
     assert "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i" in page
+    assert "payments.html" in page
     assert "https://api.aethermoore.com/v1/billing/public-checkout" not in page
+
+
+def test_payment_center_exposes_all_live_payment_paths() -> None:
+    page = (REPO_ROOT / "docs" / "payments.html").read_text(encoding="utf-8")
+    hire_page = (REPO_ROOT / "docs" / "hire.html").read_text(encoding="utf-8")
+    sitemap = (REPO_ROOT / "docs" / "sitemap.xml").read_text(encoding="utf-8")
+    robots = (REPO_ROOT / "docs" / "robots.txt").read_text(encoding="utf-8")
+
+    assert "https://ko-fi.com/izdandavis" in page
+    assert "$IzzyDDavis7" in page
+    assert "static/cash-app-payment.png" in page
+    assert "https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l" in page
+    assert "https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j" in page
+    assert "mailto:aethermoregames@pm.me?subject=AetherMoore%20invoice%20request" in page
+    assert "Do not send secrets" in page
+    assert "hire.html#small-business-liaison-intro" in page
+    assert 'id="small-business-liaison-intro"' in hire_page
+    assert "SCBE-AETHERMOORE/payments.html" in sitemap
+    assert "Payments: https://aethermoore.com/SCBE-AETHERMOORE/payments.html" in robots
 
 
 def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:


### PR DESCRIPTION
## Summary
- adds `docs/payments.html` as one buyer-facing payment center for Ko-fi, Cash App, card checkout, and invoice/procurement requests
- wires the payment center into homepage, supporter page, offers page, app config, sitemap, robots, `robot.md`, and `llms.txt`
- extends `offers.json` with explicit payment-method metadata while preserving existing checkout URLs for automation
- fixes the hire-page federal liaison anchor and redacts sandbox checkout examples from the ops doc so checkout-surface audit has no blockers

## Tests
- `node -e "JSON.parse(require('fs').readFileSync('docs/offers.json','utf8')); JSON.parse(require('fs').readFileSync('docs/app-config.json','utf8')); console.log('json ok')"`
- `python -m pytest tests\test_vercel_launch_bridge.py tests\api\test_polly_commerce.py -q`
- `npm run cash:autopromo:dry-run`
- `python C:\Users\issda\.codex\skills\scbe-checkout-launch-ops\scripts\audit_checkout_surfaces.py docs` → blocking=0
- `git diff --check` (line-ending warnings only)