### PR TITLE
chore: format security cleanup files

### DIFF
--- a/src/api/geoseal_cli_bridge.py
+++ b/src/api/geoseal_cli_bridge.py
@@ -11,7 +11,6 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Any
 
-
 _SAFE_SUFFIX_RE = re.compile(r"^\.[A-Za-z0-9][A-Za-z0-9._-]{0,15}$")
 
 

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -1032,7 +1032,9 @@ describe('polly hosted-run handler', () => {
     expect(
       body.hosted_run_packet.immediate_value.some((item) => item.url.includes('service-credits'))
     ).toBe(true);
-    expect(body.hosted_run_packet.immediate_value.some((item) => hostnameOf(item.url) === 'ko-fi.com')).toBe(true);
+    expect(
+      body.hosted_run_packet.immediate_value.some((item) => hostnameOf(item.url) === 'ko-fi.com')
+    ).toBe(true);
   });
 
   it('rejects hosted run intake without contact', async () => {

--- a/tests/api/test_polly_commerce.py
+++ b/tests/api/test_polly_commerce.py
@@ -26,6 +26,7 @@ def _hostname(url: str) -> str | None:
 def _is_checkout_url(url: str) -> bool:
     return _hostname(url) in {"buy.stripe.com", "ko-fi.com"}
 
+
 # ---------------------------------------------------------------------------
 # Catalog sanity
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- follows up the merged code-scanning cleanup with the final formatter-safe deltas
- keeps the change boundary to geoseal bridge formatting plus commerce URL test helpers

## Verification
- `python -m black --check --line-length 120 src/api/geoseal_cli_bridge.py tests/api/test_polly_commerce.py`
- `npx prettier --check tests/api/polly_commerce_js.test.ts`
- `python -m pytest tests/test_agent_task_run_and_external_eval.py tests/api/test_polly_commerce.py -q` -> 56 passed
- `npx vitest run tests/api/polly_commerce_js.test.ts` -> 106 passed
- `python scripts/security/code_governance_gate.py check-push` -> PASS, 0 findings