### PR TITLE
fix(security): tighten codeql critical paths

### DIFF
--- a/src/api/geoseal_cli_bridge.py
+++ b/src/api/geoseal_cli_bridge.py
@@ -175,16 +175,13 @@ def dispatch_geoseal_command(command: str, body: dict[str, Any]) -> dict[str, An
     if command == "code-roundtrip":
         content = body.get("content")
         source = body.get("source")
-        temp_path: Path | None = None
+        temp_dir: tempfile.TemporaryDirectory[str] | None = None
         try:
             if content is not None and str(content).strip() != "":
                 suffix = _safe_temp_suffix(body.get("source_name"), ".rs")
-                fd, path_str = tempfile.mkstemp(suffix=suffix, prefix="geoseal_rt_")
-                import os
-
-                with os.fdopen(fd, "wb") as f:
-                    f.write(str(content).encode("utf-8", errors="replace"))
-                temp_path = Path(path_str)
+                temp_dir = tempfile.TemporaryDirectory(prefix="geoseal_rt_")
+                temp_path = Path(temp_dir.name) / f"source{suffix}"
+                temp_path.write_bytes(str(content).encode("utf-8", errors="replace"))
                 source = str(temp_path)
             if not source:
                 raise ValueError("source or content is required for code-roundtrip")
@@ -199,14 +196,8 @@ def dispatch_geoseal_command(command: str, body: dict[str, Any]) -> dict[str, An
             data = _parse_json_stdout(stdout, stderr, rc)
             return {"exit_code": rc, "data": data, "stderr": stderr or None}
         finally:
-            if temp_path is not None and temp_path.exists():
-                try:
-                    decoded = temp_path.with_name(temp_path.stem + ".decoded" + temp_path.suffix)
-                    if decoded.exists():
-                        decoded.unlink(missing_ok=True)
-                    temp_path.unlink(missing_ok=True)
-                except OSError:
-                    pass
+            if temp_dir is not None:
+                temp_dir.cleanup()
 
     raise ValueError(f"unsupported GeoSeal bridge command: {command}")
 

--- a/src/api/polly_routes.py
+++ b/src/api/polly_routes.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import http.client
 import smtplib
 import ssl
 import time
@@ -19,7 +20,7 @@ from typing import Any, Dict, List, Optional
 from urllib import request as urlrequest
 import asyncio
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote_plus
+from urllib.parse import urlencode
 
 from fastapi import APIRouter
 from pydantic import BaseModel, Field, field_validator
@@ -648,10 +649,14 @@ async def polly_search(req: SearchRequest) -> SearchResponse:
 
     # Free fallback: DuckDuckGo Instant Answer API (no key needed)
     try:
-        ddg_url = f"https://api.duckduckgo.com/?q={quote_plus(query)}&format=json&no_html=1&skip_disambig=1"
-        ddg_req = urlrequest.Request(ddg_url, headers={"User-Agent": "SCBE-Polly/1.0"})
-        with urlrequest.urlopen(ddg_req, timeout=8) as resp:
+        ddg_path = "/?" + urlencode({"q": query, "format": "json", "no_html": "1", "skip_disambig": "1"})
+        conn = http.client.HTTPSConnection("api.duckduckgo.com", timeout=8)
+        try:
+            conn.request("GET", ddg_path, headers={"User-Agent": "SCBE-Polly/1.0"})
+            resp = conn.getresponse()
             ddg_data: Dict[str, Any] = json.loads(resp.read().decode())
+        finally:
+            conn.close()
 
         ddg_results: list[SearchResult] = []
         if ddg_data.get("AbstractURL"):

--- a/src/coding_spine/agent_tool_bridge.py
+++ b/src/coding_spine/agent_tool_bridge.py
@@ -282,9 +282,11 @@ def build_agent_tool_bridge_v1(
     if intent_relative_posix:
         src = shlex.quote(intent_relative_posix)
         file_args = f"--source-file {src} --language python --source-name task_intent.txt"
+        compile_text = "compile source intent"
     else:
         text = (inline_goal or "")[:12000]
         file_args = f"--content {shlex.quote(text)} --language python --source-name agent_goal"
+        compile_text = text
 
     geoseal_cli = {
         "backend_registry_json": f"{exe} -m src.geoseal_cli backend-registry --json",
@@ -292,7 +294,7 @@ def build_agent_tool_bridge_v1(
         "code_packet_json": f"{exe} -m src.geoseal_cli code-packet {file_args} --json",
         "history_json": f"{exe} -m src.geoseal_cli history --json",
         "testing_cli_json": f"{exe} -m src.geoseal_cli testing-cli {file_args} --json",
-        "compile_intent_json": f"{exe} -m src.geoseal_cli compile --json {shlex.quote(text if not intent_relative_posix else 'compile source intent')}",
+        "compile_intent_json": f"{exe} -m src.geoseal_cli compile --json {shlex.quote(compile_text)}",
         "ghost_terminal_audit_ps1": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/system/ghost_terminal_audit.ps1 -Json",
         "ghost_terminal_cleanup_stale_ps1": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/system/ghost_terminal_audit.ps1 -CleanStale",
         "call_switchboard_json": f"{exe} -m src.geoseal_cli call-switchboard --request <json> --json",


### PR DESCRIPTION
## Summary
- removes the user-influenced URL construction from Polly's free DuckDuckGo fallback by using a fixed HTTPS host and encoded request path
- fixes a potentially uninitialized `compile_text` path in the agent tool bridge
- constrains GeoSeal code-roundtrip temp artifacts to a fixed temporary directory cleanup boundary

## Verification
- `python -m black --check --line-length 120 src/api/polly_routes.py src/coding_spine/agent_tool_bridge.py src/api/geoseal_cli_bridge.py`
- `python -m py_compile src/api/polly_routes.py src/coding_spine/agent_tool_bridge.py src/api/geoseal_cli_bridge.py`
- `python -m pytest tests/test_agent_task_run_and_external_eval.py tests/test_geoseal_cli_tokenizer_atomic.py tests/coding_spine/test_agent_tool_policy.py tests/coding_spine/test_agent_tool_policy_mcdc.py tests/api/test_polly_widget_contract.py -q` -> 90 passed
- `python -m pytest tests/api/test_polly_commerce.py tests/api/test_polly_workers.py -q` -> 51 passed
- `python scripts/security/code_governance_gate.py check-push` -> PASS, 0 findings