### PR TITLE
fix(security): clear high codeql followups

### DIFF
--- a/scripts/system/playwright_crosstalk_runner.mjs
+++ b/scripts/system/playwright_crosstalk_runner.mjs
@@ -320,7 +320,9 @@ async function collectPageEvidence(browser, target, viewportName, args) {
   await page.close();
 
   const expectedCopyMissing = target.expects.filter((text) => !bodyText.includes(text));
-  const stripeLinks = links.filter((link) => /stripe\.com|buy\.stripe\.com/i.test(link.href));
+  const stripeLinks = links.filter((link) =>
+    /^(https?:\/\/)?([^/?#]+\.)?(stripe\.com|buy\.stripe\.com)([/?#]|$)/i.test(link.href)
+  );
 
   return {
     targetId: target.id,

--- a/src/api/geoseal_cli_bridge.py
+++ b/src/api/geoseal_cli_bridge.py
@@ -178,9 +178,8 @@ def dispatch_geoseal_command(command: str, body: dict[str, Any]) -> dict[str, An
         temp_dir: tempfile.TemporaryDirectory[str] | None = None
         try:
             if content is not None and str(content).strip() != "":
-                suffix = _safe_temp_suffix(body.get("source_name"), ".rs")
                 temp_dir = tempfile.TemporaryDirectory(prefix="geoseal_rt_")
-                temp_path = Path(temp_dir.name) / f"source{suffix}"
+                temp_path = Path(temp_dir.name) / "source.rs"
                 temp_path.write_bytes(str(content).encode("utf-8", errors="replace"))
                 source = str(temp_path)
             if not source:

--- a/src/api/polly_routes.py
+++ b/src/api/polly_routes.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 import re
-import http.client
 import smtplib
 import ssl
 import time
@@ -20,7 +19,7 @@ from typing import Any, Dict, List, Optional
 from urllib import request as urlrequest
 import asyncio
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import quote_plus
 
 from fastapi import APIRouter
 from pydantic import BaseModel, Field, field_validator
@@ -647,47 +646,8 @@ async def polly_search(req: SearchRequest) -> SearchResponse:
         except (HTTPError, URLError, Exception) as exc:
             logger.warning("Tavily search error: %s", exc)
 
-    # Free fallback: DuckDuckGo Instant Answer API (no key needed)
-    try:
-        ddg_path = "/?" + urlencode({"q": query, "format": "json", "no_html": "1", "skip_disambig": "1"})
-        conn = http.client.HTTPSConnection("api.duckduckgo.com", timeout=8)
-        try:
-            conn.request("GET", ddg_path, headers={"User-Agent": "SCBE-Polly/1.0"})
-            resp = conn.getresponse()
-            ddg_data: Dict[str, Any] = json.loads(resp.read().decode())
-        finally:
-            conn.close()
-
-        ddg_results: list[SearchResult] = []
-        if ddg_data.get("AbstractURL"):
-            ddg_results.append(
-                SearchResult(
-                    title=ddg_data.get("Heading", query),
-                    url=ddg_data["AbstractURL"],
-                    excerpt=ddg_data.get("Abstract", "")[:300],
-                )
-            )
-        for topic in ddg_data.get("RelatedTopics", []):
-            if (
-                isinstance(topic, dict)
-                and topic.get("FirstURL")
-                and not topic["FirstURL"].startswith("https://duckduckgo.com/c/")
-            ):
-                ddg_results.append(
-                    SearchResult(
-                        title=topic.get("Text", "")[:100],
-                        url=topic["FirstURL"],
-                        excerpt=topic.get("Text", "")[:300],
-                    )
-                )
-            if len(ddg_results) >= MAX_SEARCH_RESULTS:
-                break
-        if ddg_results:
-            return SearchResponse(results=ddg_results, source="duckduckgo", query=query, ts=int(time.time()))
-    except Exception as exc:
-        logger.debug("DuckDuckGo fallback failed: %s", exc)
-
-    # Last resort: link to DDG
+    # Last resort: provide a user-clickable link instead of making unauthenticated
+    # server-side search calls from a public endpoint.
     return SearchResponse(
         results=[
             SearchResult(

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -785,7 +785,7 @@ describe('polly chat handler — commerce path', () => {
     const body = res.body as { intent: string; actions: { url: string }[] };
     expect(body.intent).toBe('custom');
     expect(body.actions.some((a) => a.url.startsWith('mailto:'))).toBe(true);
-    expect(body.actions.some((a) => /aethermoore\.com\/.*hire/.test(a.url))).toBe(true);
+    expect(body.actions.some((a) => /^https:\/\/aethermoore\.com\/.*hire/.test(a.url))).toBe(true);
   });
 
   it('routes "help me choose" to guide intent with picker + start-here actions', async () => {


### PR DESCRIPTION
## Summary
- removes the unauthenticated server-side DuckDuckGo fallback from the public Polly search endpoint; it now returns a user-clickable search link unless Tavily is configured
- removes the remaining dynamic temp suffix from GeoSeal code-roundtrip bridge handling
- anchors Stripe/hire URL regex checks flagged by CodeQL/ESLint SARIF

## Verification
- `python -m black --check --line-length 120 src/api/polly_routes.py src/api/geoseal_cli_bridge.py`
- `python -m py_compile src/api/polly_routes.py src/api/geoseal_cli_bridge.py`
- `npx prettier --check scripts/system/playwright_crosstalk_runner.mjs tests/api/polly_commerce_js.test.ts`
- `npx vitest run tests/api/polly_commerce_js.test.ts` -> 106 passed
- `python -m pytest tests/test_agent_task_run_and_external_eval.py tests/test_geoseal_cli_tokenizer_atomic.py tests/api/test_polly_widget_contract.py tests/api/test_polly_commerce.py -q` -> 94 passed
- `python scripts/security/code_governance_gate.py check-push` -> PASS, 0 findings