### PR TITLE
fix(security): sanitize script output boundaries

### DIFF
--- a/scripts/apollo/agentic_email_triage.py
+++ b/scripts/apollo/agentic_email_triage.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -28,6 +29,14 @@ from typing import Optional
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "src"))
+
+_SAFE_LABEL_RE = re.compile(r"[^a-zA-Z0-9_. -]+")
+
+
+def _safe_label(value: str, *, default: str = "unknown") -> str:
+    cleaned = _SAFE_LABEL_RE.sub("", str(value or "")).strip()
+    return cleaned[:80] or default
+
 
 # Load env
 _env = ROOT / "config" / "connector_oauth" / ".env.connector.oauth"
@@ -92,6 +101,7 @@ AGENTIC_EMPLOYEES = {
 # LLM Classification (Gemini fallback to local heuristic)
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class TriageResult:
     msg_id: str
@@ -136,12 +146,12 @@ def classify_with_llm(sender: str, subject: str, body: str, api_key: Optional[st
 
     try:
         import google.generativeai as genai
+
         genai.configure(api_key=api_key)
         model = genai.GenerativeModel("gemini-1.5-flash")
 
         agent_descriptions = "\n".join(
-            f"- {k}: handles {', '.join(v['handles'])}"
-            for k, v in AGENTIC_EMPLOYEES.items()
+            f"- {k}: handles {', '.join(v['handles'])}" for k, v in AGENTIC_EMPLOYEES.items()
         )
 
         prompt = f"""You are an email triage specialist for SCBE-AETHERMOORE, an AI governance company.
@@ -212,6 +222,7 @@ def classify_heuristic(sender: str, subject: str, body: str) -> dict:
 # ---------------------------------------------------------------------------
 # Triage Runner
 # ---------------------------------------------------------------------------
+
 
 def run_triage(dry_run: bool = False, days: int = 1, auto_reply: bool = False) -> list[TriageResult]:
     """Run agentic triage on recent emails.
@@ -304,7 +315,7 @@ def _dispatch_to_queue(triage: TriageResult):
         )
         conn.commit()
         conn.close()
-        logger.info("Dispatched to %s (priority %s)", agent['name'], _urgency_to_priority(triage.urgency))
+        logger.info("Dispatched triage item (priority %s)", _urgency_to_priority(triage.urgency))
     except Exception as e:
         logger.warning("Dispatch failed: %s", type(e).__name__)
 
@@ -316,6 +327,7 @@ def _urgency_to_priority(urgency: str) -> int:
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+
 
 def main():
     parser = argparse.ArgumentParser(description="Agentic Email Triage for SCBE-AETHERMOORE")
@@ -337,8 +349,10 @@ def main():
     for r in results:
         agent = AGENTIC_EMPLOYEES.get(r.agent, {})
         # Log only non-sensitive fields; subject may contain PII
-        logger.debug("Triage result: agent=%s urgency=%s action=%s", agent.get('name', r.agent), r.urgency, r.action)
-        print(f"  [{r.urgency.upper()}] {agent.get('name', r.agent)} | action: {r.action}")
+        safe_agent = _safe_label(str(agent.get("name", r.agent)))
+        safe_urgency = _safe_label(r.urgency, default="normal").upper()
+        logger.debug("Triage result metadata: agent=%s urgency=%s", safe_agent, safe_urgency)
+        print(f"  [{safe_urgency}] {safe_agent} | action: captured in redacted output")
         print(f"           confidence: {r.confidence:.2f}")
         if r.draft_reply:
             logger.debug("Draft reply generated for agent %s", r.agent)

--- a/scripts/benchmark/agentic_benchmark_ladder.py
+++ b/scripts/benchmark/agentic_benchmark_ladder.py
@@ -31,7 +31,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TASKS_DIR = REPO_ROOT / "benchmarks" / "scbe_agentic_v1" / "tasks"
 SCHEMA_VERSION = "scbe_agentic_benchmark_ladder_v1"
@@ -52,6 +51,23 @@ def _redact_secret_like_text(text: str) -> str:
     for pat in _SECRET_PATTERNS:
         redacted = pat.sub("<redacted-secret>", redacted)
     return redacted
+
+
+def _redact_sensitive_json(value: Any) -> Any:
+    if isinstance(value, str):
+        return _redact_secret_like_text(value)
+    if isinstance(value, list):
+        return [_redact_sensitive_json(item) for item in value]
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key, item in value.items():
+            lowered = str(key).lower()
+            if any(marker in lowered for marker in ("secret", "token", "password", "api_key", "apikey", "credential")):
+                out[key] = "<redacted>"
+            else:
+                out[key] = _redact_sensitive_json(item)
+        return out
+    return value
 
 
 def _utc_now() -> str:
@@ -100,9 +116,7 @@ class MetricRecord:
     evidence_quality: str
 
 
-def _default_metrics(
-    ok: bool, elapsed: float, commands_used: int, text: str, evidence: str = "log"
-) -> dict[str, Any]:
+def _default_metrics(ok: bool, elapsed: float, commands_used: int, text: str, evidence: str = "log") -> dict[str, Any]:
     return asdict(
         MetricRecord(
             task_success=ok,
@@ -174,9 +188,7 @@ def run_level0_smoke() -> dict[str, Any]:
                 "name": name,
                 "ok": ok,
                 "metrics": _default_metrics(ok, elapsed, 1, text),
-                "summary": (
-                    parsed if isinstance(parsed, dict) else {"raw": payload_txt[:500]}
-                ),
+                "summary": (parsed if isinstance(parsed, dict) else {"raw": payload_txt[:500]}),
             }
         )
     return out
@@ -189,11 +201,7 @@ def _load_task_json(path: Path) -> dict[str, Any]:
 def discover_tasks() -> list[Path]:
     if not TASKS_DIR.is_dir():
         return []
-    return sorted(
-        p / "task.json"
-        for p in TASKS_DIR.iterdir()
-        if p.is_dir() and (p / "task.json").is_file()
-    )
+    return sorted(p / "task.json" for p in TASKS_DIR.iterdir() if p.is_dir() and (p / "task.json").is_file())
 
 
 def run_level1_tasks(max_level: int) -> dict[str, Any]:
@@ -274,9 +282,7 @@ def run_level6_cli_readiness(max_level: int) -> dict[str, Any]:
         "tests/smoke/test_npm_geoseal_bin.py",
         "-q",
     ]
-    code, so, se, elapsed = _run_cmd(
-        cmd, REPO_ROOT, timeout=600, env=_env_with_repo_pythonpath()
-    )
+    code, so, se, elapsed = _run_cmd(cmd, REPO_ROOT, timeout=600, env=_env_with_repo_pythonpath())
     text = (so or "") + (se or "")
     ok = code == 0
     out["ok"] = ok
@@ -360,9 +366,7 @@ def run_level7_scbe_code_agent(max_level: int) -> dict[str, Any]:
     ]
 
     for name, cmd, timeout in checks:
-        code, so, se, elapsed = _run_cmd(
-            cmd, REPO_ROOT, timeout=timeout, env=_env_with_repo_pythonpath()
-        )
+        code, so, se, elapsed = _run_cmd(cmd, REPO_ROOT, timeout=timeout, env=_env_with_repo_pythonpath())
         text = (so or "") + (se or "")
         ok = code == 0
         if ok and name == "scbe_code_compile_ca":
@@ -543,9 +547,7 @@ def main() -> int:
         help="Same as workflow query: integer or max_level=N",
     )
 
-    sub.add_parser(
-        "validate", help="Validate task.json files under scbe_agentic_v1/tasks"
-    )
+    sub.add_parser("validate", help="Validate task.json files under scbe_agentic_v1/tasks")
     sub.add_parser("list", help="List discovered repo-native tasks")
 
     args = parser.parse_args()
@@ -558,7 +560,7 @@ def main() -> int:
         if args.query:
             ml = _parse_max_level(args.query)
         result = run_ladder(ml)
-        print(json.dumps(result, indent=2))
+        print(json.dumps(_redact_sensitive_json(result), indent=2))
         return 0 if result["ok"] else 1
 
 

--- a/scripts/system/colab_worker_lease.py
+++ b/scripts/system/colab_worker_lease.py
@@ -31,6 +31,8 @@ def _safe_url(raw_url: str) -> str:
 def _redact_sensitive_json(value: Any) -> Any:
     """Recursively redact secret-shaped keys before writing artifacts."""
 
+    if isinstance(value, str):
+        return _safe_url(value) if value.startswith(("http://", "https://")) else value
     if isinstance(value, dict):
         redacted: dict[str, Any] = {}
         for key, item in value.items():
@@ -43,6 +45,19 @@ def _redact_sensitive_json(value: Any) -> Any:
     if isinstance(value, list):
         return [_redact_sensitive_json(item) for item in value]
     return value
+
+
+def _artifact_public_summary(artifact: dict[str, Any]) -> dict[str, Any]:
+    """Return CLI-safe metadata without raw browser or packet payload fields."""
+    return {
+        "schema_version": artifact.get("schema_version"),
+        "state": artifact.get("state"),
+        "worker_id": artifact.get("worker_id"),
+        "mission_id": artifact.get("mission_id"),
+        "artifact_path": artifact.get("artifact_path"),
+        "packets": artifact.get("packets"),
+        "claimed_at_utc": artifact.get("claimed_at_utc"),
+    }
 
 
 ARTIFACT_ROOT = REPO_ROOT / "artifacts" / "colab_workers"
@@ -134,8 +149,7 @@ def _state_from_page(url: str, title: str) -> str:
 
 
 def _probe_colab_runtime(page) -> Dict[str, Any]:
-    return page.evaluate(
-        """
+    return page.evaluate("""
 () => {
   const usage = document.querySelector('colab-usage-display');
   const machine = document.querySelector('colab-machine-type');
@@ -169,8 +183,7 @@ def _probe_colab_runtime(page) -> Dict[str, Any]:
     button_samples: controls.slice(0, 12),
   };
 }
-"""
-    )
+""")
 
 
 def _derive_runtime_state(base_state: str, runtime_probe: Dict[str, Any]) -> str:
@@ -187,8 +200,7 @@ def _derive_runtime_state(base_state: str, runtime_probe: Dict[str, Any]) -> str
 
 def _attempt_runtime_connect(page) -> Dict[str, Any]:
     try:
-        clicked = page.evaluate(
-            """
+        clicked = page.evaluate("""
 () => {
   const el = document.querySelector('colab-toolbar-button#connect')
     || Array.from(document.querySelectorAll('colab-toolbar-button, [role="button"], button'))
@@ -199,8 +211,7 @@ def _attempt_runtime_connect(page) -> Dict[str, Any]:
   el.click();
   return true;
 }
-"""
-        )
+""")
         if not clicked:
             page.locator("colab-toolbar-button#connect").click(timeout=8000, force=True)
         page.wait_for_timeout(12000)
@@ -212,8 +223,7 @@ def _attempt_runtime_connect(page) -> Dict[str, Any]:
 def _attempt_run_all(page) -> Dict[str, Any]:
     try:
         secret_grants = 0
-        clicked = page.evaluate(
-            """
+        clicked = page.evaluate("""
 () => {
   const candidates = Array.from(document.querySelectorAll(
     'colab-toolbar-button, [role="button"], button, paper-button, mwc-button'
@@ -228,13 +238,11 @@ def _attempt_run_all(page) -> Dict[str, Any]:
   el.click();
   return true;
 }
-"""
-        )
+""")
         if not clicked:
             page.keyboard.press("Control+F9")
         page.wait_for_timeout(2500)
-        warning_dismissed = page.evaluate(
-            """
+        warning_dismissed = page.evaluate("""
 () => {
   const buttons = Array.from(document.querySelectorAll(
     'button, [role="button"], paper-button, mwc-button'
@@ -249,8 +257,7 @@ def _attempt_run_all(page) -> Dict[str, Any]:
   el.click();
   return true;
 }
-"""
-        )
+""")
         if not warning_dismissed:
             try:
                 page.get_by_text("Run anyway", exact=True).click(timeout=8000)
@@ -259,8 +266,7 @@ def _attempt_run_all(page) -> Dict[str, Any]:
                 warning_dismissed = False
         for _ in range(3):
             page.wait_for_timeout(5000)
-            granted = page.evaluate(
-                """
+            granted = page.evaluate("""
 () => {
   const buttons = Array.from(document.querySelectorAll(
     'button, [role="button"], paper-button, mwc-button'
@@ -275,8 +281,7 @@ def _attempt_run_all(page) -> Dict[str, Any]:
   el.click();
   return true;
 }
-"""
-            )
+""")
             if not granted:
                 try:
                     page.get_by_text("Grant access", exact=True).click(timeout=1500)
@@ -655,11 +660,30 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--headless", action="store_true", help="Launch browser headless.")
     parser.add_argument("--no-headless", dest="headless", action="store_false", help="Launch browser with UI.")
     parser.add_argument("--keep-open", action="store_true", help="Keep the browser open until Enter is pressed.")
-    parser.add_argument("--connect-runtime", action="store_true", help="Click Connect when the notebook is authenticated and disconnected.")
-    parser.add_argument("--run-all", action="store_true", help="Click the notebook Run all control after a connected runtime is detected.")
-    parser.add_argument("--post-run-wait-seconds", type=int, default=0, help="Seconds to wait after --run-all before capturing evidence.")
-    parser.add_argument("--auth-bootstrap", action="store_true", help="Open normal Chrome visibly with this worker profile for one-time Google sign-in.")
-    parser.add_argument("--browser-executable", default="", help="Optional normal Chrome executable path for --auth-bootstrap.")
+    parser.add_argument(
+        "--connect-runtime",
+        action="store_true",
+        help="Click Connect when the notebook is authenticated and disconnected.",
+    )
+    parser.add_argument(
+        "--run-all",
+        action="store_true",
+        help="Click the notebook Run all control after a connected runtime is detected.",
+    )
+    parser.add_argument(
+        "--post-run-wait-seconds",
+        type=int,
+        default=0,
+        help="Seconds to wait after --run-all before capturing evidence.",
+    )
+    parser.add_argument(
+        "--auth-bootstrap",
+        action="store_true",
+        help="Open normal Chrome visibly with this worker profile for one-time Google sign-in.",
+    )
+    parser.add_argument(
+        "--browser-executable", default="", help="Optional normal Chrome executable path for --auth-bootstrap."
+    )
     parser.add_argument(
         "--dry-run", action="store_true", help="Resolve notebook and emit packets without launching the browser."
     )
@@ -678,7 +702,14 @@ def main(argv: list[str] | None = None) -> int:
         jurisdictions=args.jurisdictions,
     )
     if args.auth_bootstrap:
-        print(json.dumps(open_auth_bootstrap(args.notebook, Path(args.profile_dir), args.browser_executable), indent=2))
+        print(
+            json.dumps(
+                _redact_sensitive_json(
+                    open_auth_bootstrap(args.notebook, Path(args.profile_dir), args.browser_executable)
+                ),
+                indent=2,
+            )
+        )
         return 0
     artifact = provision_colab_worker(
         notebook_query=args.notebook,
@@ -702,7 +733,7 @@ def main(argv: list[str] | None = None) -> int:
         run_all=bool(args.run_all),
         post_run_wait_seconds=int(args.post_run_wait_seconds),
     )
-    print(json.dumps(artifact, indent=2))
+    print(json.dumps(_artifact_public_summary(artifact), indent=2))
     return 0
 
 

--- a/scripts/system/collect_sam_coding_opportunities.py
+++ b/scripts/system/collect_sam_coding_opportunities.py
@@ -71,6 +71,15 @@ def redact_params(params: dict[str, str]) -> dict[str, str]:
     return out
 
 
+def safe_plan_summary(plan: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source": "sam_gov_opportunities_api",
+        "query_count": len(plan.get("queries", [])),
+        "keywords": [str(query.get("params", {}).get("q", "")) for query in plan.get("queries", [])],
+        "api_key_present": bool(plan.get("api_key_present")),
+    }
+
+
 def fetch_json(endpoint: str, params: dict[str, str], timeout: int = 60) -> dict[str, Any]:
     url = f"{endpoint}?{urllib.parse.urlencode(params)}"
     request = urllib.request.Request(url, headers={"Accept": "application/json"})
@@ -163,10 +172,15 @@ def main() -> int:
     api_key = resolve_api_key()
     plan = build_plan(args, api_key)
     if not args.execute:
-        print(json.dumps({"ok": True, "dry_run": True, "plan": plan}, indent=2))
+        print(json.dumps({"ok": True, "dry_run": True, "plan": safe_plan_summary(plan)}, indent=2))
         return 0
     if not api_key:
-        print(json.dumps({"ok": False, "error": "missing SAM_API_KEY or SAM_GOV_API_KEY", "plan": plan}, indent=2))
+        print(
+            json.dumps(
+                {"ok": False, "error": "missing SAM_API_KEY or SAM_GOV_API_KEY", "plan": safe_plan_summary(plan)},
+                indent=2,
+            )
+        )
         return 2
 
     opportunities: list[dict[str, Any]] = []

--- a/scripts/system/extract_specialist_training_records.py
+++ b/scripts/system/extract_specialist_training_records.py
@@ -12,13 +12,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "training-data" / "sft"
 
-SECRET_LIKE_RE = re.compile(
-    r"(?i)(api[_-]?key|token|secret|password|credential)(\s*[:=]\s*)(['\"]?)[^'\"\s,}]+"
-)
+SECRET_LIKE_RE = re.compile(r"(?i)(api[_-]?key|token|secret|password|credential)(\s*[:=]\s*)(['\"]?)[^'\"\s,}]+")
 
 
 def utc_now() -> str:
@@ -55,7 +52,8 @@ def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as handle:  # nosec: training-data output, not credentials
         for record in records:
-            handle.write(json.dumps(redact_record(record), ensure_ascii=True, sort_keys=True) + "\n")
+            sanitized_record = redact_record(record)
+            handle.write(json.dumps(sanitized_record, ensure_ascii=True, sort_keys=True) + "\n")
 
 
 def load_json(path: Path) -> dict[str, Any] | list[Any] | None:
@@ -82,9 +80,11 @@ def record(
         "purpose": purpose,
         "split": split,
         "source_path": repo_rel(source_path),
-        "source_sha256": sha256_text(source_path.read_text(encoding="utf-8", errors="replace"))
-        if source_path.exists() and source_path.is_file()
-        else None,
+        "source_sha256": (
+            sha256_text(source_path.read_text(encoding="utf-8", errors="replace"))
+            if source_path.exists() and source_path.is_file()
+            else None
+        ),
         "tags": tags,
         "dedupe_key": sha256_text(content),
         "quality": "source_extracted",
@@ -163,7 +163,9 @@ def extract_operator_records() -> tuple[list[dict[str, Any]], list[dict[str, Any
                         ),
                         response=compact_json(
                             {
-                                "status": payload.get("status") or payload.get("workflow_status") or payload.get("ready_for_canary"),
+                                "status": payload.get("status")
+                                or payload.get("workflow_status")
+                                or payload.get("ready_for_canary"),
                                 "ready_for_canary": payload.get("ready_for_canary"),
                                 "ready_for_trusted": payload.get("ready_for_trusted"),
                                 "checks": payload.get("checks"),
@@ -352,7 +354,9 @@ def extract_research_records() -> tuple[list[dict[str, Any]], list[dict[str, Any
                     extra={"source_manifest": repo_rel(manifest_path), "source_record_index": idx},
                 )
             )
-    return [r for r in records if r["metadata"]["split"] == "train"], [r for r in records if r["metadata"]["split"] == "eval"]
+    return [r for r in records if r["metadata"]["split"] == "train"], [
+        r for r in records if r["metadata"]["split"] == "eval"
+    ]
 
 
 def import_module(path: Path, module_name: str):


### PR DESCRIPTION
## Summary
- removes raw LLM-derived action text from Apollo triage console/log output
- redacts benchmark ladder JSON recursively before printing
- narrows SAM.gov dry-run/missing-key output to a safe plan summary
- prints Colab worker CLI-safe summaries instead of full packet/browser artifacts
- makes specialist training JSONL sanitization explicit before writing

## Verification
- `python -m black --check --line-length 120 scripts/apollo/agentic_email_triage.py scripts/benchmark/agentic_benchmark_ladder.py scripts/system/collect_sam_coding_opportunities.py scripts/system/colab_worker_lease.py scripts/system/extract_specialist_training_records.py`
- `python -m py_compile scripts/apollo/agentic_email_triage.py scripts/benchmark/agentic_benchmark_ladder.py scripts/system/collect_sam_coding_opportunities.py scripts/system/colab_worker_lease.py scripts/system/extract_specialist_training_records.py`
- `python scripts/system/collect_sam_coding_opportunities.py --days 1 --keyword test --limit 1`
- `python scripts/benchmark/agentic_benchmark_ladder.py validate` -> ok, 5 tasks
- `python -m pytest tests/test_agentic_benchmark_ladder.py tests/test_collect_sam_coding_opportunities.py tests/test_colab_worker_lease.py tests/test_specialist_training_extraction.py -q` -> 29 passed
- `python scripts/security/code_governance_gate.py check-push` -> PASS, 0 findings