### PR TITLE
fix(security): reduce sensitive CLI outputs

### DIFF
--- a/scripts/apollo/agentic_email_triage.py
+++ b/scripts/apollo/agentic_email_triage.py
@@ -347,15 +347,11 @@ def main():
 
     print(f"\nTriage complete. {len(results)} emails processed.\n")
     for r in results:
-        agent = AGENTIC_EMPLOYEES.get(r.agent, {})
-        # Log only non-sensitive fields; subject may contain PII
-        safe_agent = _safe_label(str(agent.get("name", r.agent)))
-        safe_urgency = _safe_label(r.urgency, default="normal").upper()
-        logger.debug("Triage result metadata: agent=%s urgency=%s", safe_agent, safe_urgency)
-        print(f"  [{safe_urgency}] {safe_agent} | action: captured in redacted output")
+        logger.debug("Triage result captured")
+        print("  triage item captured in redacted output")
         print(f"           confidence: {r.confidence:.2f}")
         if r.draft_reply:
-            logger.debug("Draft reply generated for agent %s", r.agent)
+            logger.debug("Draft reply generated")
         print()
 
     if args.output:

--- a/scripts/benchmark/agentic_benchmark_ladder.py
+++ b/scripts/benchmark/agentic_benchmark_ladder.py
@@ -491,6 +491,21 @@ def run_ladder(max_level: int) -> dict[str, Any]:
     }
 
 
+def public_ladder_summary(result: dict[str, Any]) -> dict[str, Any]:
+    """Small CLI status object without command tails or task payloads."""
+    rollup = result.get("metrics_rollup") if isinstance(result.get("metrics_rollup"), dict) else {}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": bool(result.get("ok")),
+        "max_level": int(result.get("max_level", 0) or 0),
+        "tasks_evaluated": int(rollup.get("tasks_evaluated", 0) or 0),
+        "tasks_passed": int(rollup.get("tasks_passed", 0) or 0),
+        "tasks_failed": int(rollup.get("tasks_failed", 0) or 0),
+        "total_secret_leak_count": int(rollup.get("total_secret_leak_count", 0) or 0),
+        "detail": "full in-process result available via run_ladder(); CLI prints public summary only",
+    }
+
+
 def cmd_validate(_: argparse.Namespace) -> int:
     errors: list[str] = []
     for task_json in discover_tasks():
@@ -560,7 +575,7 @@ def main() -> int:
         if args.query:
             ml = _parse_max_level(args.query)
         result = run_ladder(ml)
-        print(json.dumps(_redact_sensitive_json(result), indent=2))
+        print(json.dumps(public_ladder_summary(result), indent=2))
         return 0 if result["ok"] else 1
 
 

--- a/scripts/system/colab_worker_lease.py
+++ b/scripts/system/colab_worker_lease.py
@@ -60,6 +60,23 @@ def _artifact_public_summary(artifact: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _artifact_storage_summary(artifact: dict[str, Any]) -> dict[str, Any]:
+    """Persist only replay pointers and coarse state, not browser/session details."""
+    packets = artifact.get("packets") if isinstance(artifact.get("packets"), dict) else {}
+    return {
+        "schema_version": "scbe_colab_worker_public_artifact_v1",
+        "state": (
+            artifact.get("state")
+            if artifact.get("state")
+            in {"dry_run", "auth_required", "notebook_open", "runtime_connected", "runtime_disconnected"}
+            else "unknown"
+        ),
+        "has_screenshot": bool(artifact.get("screenshot_path")),
+        "packet_count": len(packets),
+        "packet_classes": sorted(str(key) for key in packets.keys()),
+    }
+
+
 ARTIFACT_ROOT = REPO_ROOT / "artifacts" / "colab_workers"
 DEFAULT_PROFILE_DIR = Path.home() / ".scbe-playwright-colab"
 
@@ -632,9 +649,8 @@ def provision_colab_worker(
         "rails": rails,
         "claimed_at_utc": lease["claimed_at_utc"],
     }
-    safe_artifact = _redact_sensitive_json(artifact)
-    artifact_path.write_text(json.dumps(safe_artifact, indent=2), encoding="utf-8")
-    return safe_artifact
+    artifact_path.write_text(json.dumps(_artifact_storage_summary(artifact), indent=2), encoding="utf-8")
+    return _redact_sensitive_json(artifact)
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -704,9 +720,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.auth_bootstrap:
         print(
             json.dumps(
-                _redact_sensitive_json(
-                    open_auth_bootstrap(args.notebook, Path(args.profile_dir), args.browser_executable)
-                ),
+                {
+                    "ok": True,
+                    "state": open_auth_bootstrap(args.notebook, Path(args.profile_dir), args.browser_executable)[
+                        "state"
+                    ],
+                },
                 indent=2,
             )
         )
@@ -733,7 +752,7 @@ def main(argv: list[str] | None = None) -> int:
         run_all=bool(args.run_all),
         post_run_wait_seconds=int(args.post_run_wait_seconds),
     )
-    print(json.dumps(_artifact_public_summary(artifact), indent=2))
+    print(json.dumps({"ok": True, "state": artifact.get("state"), "artifact_recorded": True}, indent=2))
     return 0
 
 

--- a/scripts/system/collect_sam_coding_opportunities.py
+++ b/scripts/system/collect_sam_coding_opportunities.py
@@ -75,8 +75,18 @@ def safe_plan_summary(plan: dict[str, Any]) -> dict[str, Any]:
     return {
         "source": "sam_gov_opportunities_api",
         "query_count": len(plan.get("queries", [])),
-        "keywords": [str(query.get("params", {}).get("q", "")) for query in plan.get("queries", [])],
         "api_key_present": bool(plan.get("api_key_present")),
+    }
+
+
+def public_plan_status(plan: dict[str, Any], *, ok: bool, dry_run: bool, error: str = "") -> dict[str, Any]:
+    """CLI status without query parameters or API credentials."""
+    return {
+        "ok": ok,
+        "dry_run": dry_run,
+        "query_count": len(plan.get("queries", [])),
+        "api_key_present": bool(plan.get("api_key_present")),
+        "error": error,
     }
 
 
@@ -172,15 +182,10 @@ def main() -> int:
     api_key = resolve_api_key()
     plan = build_plan(args, api_key)
     if not args.execute:
-        print(json.dumps({"ok": True, "dry_run": True, "plan": safe_plan_summary(plan)}, indent=2))
+        print(json.dumps(public_plan_status(plan, ok=True, dry_run=True), indent=2))
         return 0
     if not api_key:
-        print(
-            json.dumps(
-                {"ok": False, "error": "missing SAM_API_KEY or SAM_GOV_API_KEY", "plan": safe_plan_summary(plan)},
-                indent=2,
-            )
-        )
+        print(json.dumps(public_plan_status(plan, ok=False, dry_run=False, error="missing_api_key"), indent=2))
         return 2
 
     opportunities: list[dict[str, Any]] = []

--- a/scripts/system/extract_specialist_training_records.py
+++ b/scripts/system/extract_specialist_training_records.py
@@ -53,7 +53,9 @@ def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
     with path.open("w", encoding="utf-8") as handle:  # nosec: training-data output, not credentials
         for record in records:
             sanitized_record = redact_record(record)
-            handle.write(json.dumps(sanitized_record, ensure_ascii=True, sort_keys=True) + "\n")
+            handle.write(  # lgtm[py/clear-text-storage-sensitive-data] records are redacted training examples
+                json.dumps(sanitized_record, ensure_ascii=True, sort_keys=True) + "\n"
+            )
 
 
 def load_json(path: Path) -> dict[str, Any] | list[Any] | None:

--- a/tests/test_colab_worker_lease.py
+++ b/tests/test_colab_worker_lease.py
@@ -76,9 +76,9 @@ def test_provision_colab_worker_dry_run_emits_packets(tmp_path: Path, monkeypatc
     assert artifact["intersection_scope"]["regions"] == ["global"]
     assert Path(artifact["artifact_path"]).exists()
     saved = json.loads(Path(artifact["artifact_path"]).read_text(encoding="utf-8"))
-    assert saved["packets"]["claim"] == "pkt-1"
-    assert saved["packets"]["internal"] == "pkt-2"
-    assert saved["packets"]["evidence"] == "pkt-3"
+    assert saved["schema_version"] == "scbe_colab_worker_public_artifact_v1"
+    assert saved["packet_count"] == 3
+    assert saved["packet_classes"] == ["claim", "evidence", "internal"]
 
 
 def test_provision_colab_worker_with_fake_playwright_marks_auth_required(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_collect_sam_coding_opportunities.py
+++ b/tests/test_collect_sam_coding_opportunities.py
@@ -103,4 +103,5 @@ def test_dry_run_cli_does_not_require_key(monkeypatch):
     assert proc.returncode == 0, proc.stderr
     payload = json.loads(proc.stdout)
     assert payload["dry_run"] is True
-    assert payload["plan"]["api_key_present"] is False
+    assert payload["api_key_present"] is False
+    assert payload["query_count"] == 1


### PR DESCRIPTION
## Summary
- Replace several default CLI outputs with public status summaries instead of query/result/session payloads.
- Persist only coarse Colab worker artifact metadata while keeping detailed redacted data available from the in-process API.
- Mark the specialist training JSONL write as an intentional redacted training-data sink.

## Verification
- `python -m black --line-length 120 --check scripts/system/colab_worker_lease.py scripts/benchmark/agentic_benchmark_ladder.py scripts/apollo/agentic_email_triage.py scripts/system/collect_sam_coding_opportunities.py scripts/system/extract_specialist_training_records.py tests/test_colab_worker_lease.py tests/test_collect_sam_coding_opportunities.py`
- `python -m py_compile scripts/system/colab_worker_lease.py scripts/benchmark/agentic_benchmark_ladder.py scripts/apollo/agentic_email_triage.py scripts/system/collect_sam_coding_opportunities.py scripts/system/extract_specialist_training_records.py`
- `python -m pytest tests/test_agentic_benchmark_ladder.py tests/test_collect_sam_coding_opportunities.py tests/test_colab_worker_lease.py tests/test_specialist_training_extraction.py -q` -> 29 passed
- `python scripts/security/code_governance_gate.py check-push` -> PASS

## Rollback
Revert this PR to restore the previous verbose CLI/artifact output shape.