### PR TITLE
fix(security): clean medium scanner findings

### DIFF
--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -111,6 +111,20 @@ sys.path.insert(0, str(ROOT / "src"))
 
 logger = logging.getLogger(__name__)
 
+
+def _public_service_result(result: Any) -> Any:
+    """Drop debug/error payloads before returning service results to clients."""
+    if isinstance(result, dict):
+        return {
+            str(key): _public_service_result(value)
+            for key, value in result.items()
+            if str(key).lower() not in {"traceback", "stack", "exception", "exc", "error_detail", "stderr"}
+        }
+    if isinstance(result, list):
+        return [_public_service_result(item) for item in result]
+    return result
+
+
 # ---------------------------------------------------------------------------
 #  Lazy-load the runtime gate (best effort — works even if deps are missing)
 # ---------------------------------------------------------------------------
@@ -922,7 +936,9 @@ def _build_snippet(text: str, terms: list[str], max_chars: int = 320) -> str:
     return snippet
 
 
-def _chunk_text(text: str, target_chars: int = RAG_CHUNK_TARGET_CHARS, overlap_chars: int = RAG_CHUNK_OVERLAP_CHARS) -> list[str]:
+def _chunk_text(
+    text: str, target_chars: int = RAG_CHUNK_TARGET_CHARS, overlap_chars: int = RAG_CHUNK_OVERLAP_CHARS
+) -> list[str]:
     normalized = _normalize_text_blob(text)
     if not normalized:
         return []
@@ -1981,12 +1997,7 @@ async def arena_training_push():
 
 @app.get("/v1/lore/art")
 async def arena_lore_art_index():
-    return {
-        "items": [
-            {"title": item["title"], "url": f"/v1/lore/art/{item['slug']}"}
-            for item in LORE_ART_ITEMS
-        ]
-    }
+    return {"items": [{"title": item["title"], "url": f"/v1/lore/art/{item['slug']}"} for item in LORE_ART_ITEMS]}
 
 
 @app.get("/v1/lore/art/{slug}")
@@ -2123,11 +2134,7 @@ def _allowed_relative_paths(root: str) -> frozenset[str]:
     root_path = Path(root)
     if not root_path.exists():
         return frozenset()
-    return frozenset(
-        path.relative_to(root_path).as_posix()
-        for path in root_path.rglob("*")
-        if path.is_file()
-    )
+    return frozenset(path.relative_to(root_path).as_posix() for path in root_path.rglob("*") if path.is_file())
 
 
 def _resolve_safe_relative_file(root: Path, requested_path: str) -> Path:
@@ -2775,6 +2782,7 @@ async def contact_submit(payload: ContactFormPayload):
     """Receive contact form submissions from the website and notify via email."""
     try:
         from scripts.system.email_service import send_contact_notification
+
         result = send_contact_notification(
             name=payload.name,
             email=payload.email,
@@ -3501,10 +3509,12 @@ _cli_jobs: dict[str, dict[str, Any]] = {}
 
 from pydantic import BaseModel
 
+
 class PollyChatPayload(BaseModel):
     message: str
     context: Optional[str] = "site"
     thinking: Optional[bool] = False
+
 
 class PollyRespondPayload(BaseModel):
     text: str
@@ -3512,16 +3522,20 @@ class PollyRespondPayload(BaseModel):
     intent: Optional[str] = ""
     thinking: Optional[bool] = False
 
+
 class PollySearchPayload(BaseModel):
     query: str
 
+
 class PollyDelegatePayload(BaseModel):
     text: str
+
 
 class PollyEmailPayload(BaseModel):
     to: str
     subject: str
     body: str
+
 
 class PollySlackPayload(BaseModel):
     message: str
@@ -3547,14 +3561,11 @@ async def polly_call(payload: PollyCallPayload):
 
     try:
         from twilio.rest import Client
+
         client = Client(account_sid, auth_token)
-        twiml = f'<Response><Dial>{business_number}</Dial></Response>'
-        call = client.calls.create(
-            to=payload.phone,
-            from_=twilio_number,
-            twiml=twiml
-        )
-        logger.info("Twilio call initiated: %s to %s", call.sid, payload.phone)
+        twiml = f"<Response><Dial>{business_number}</Dial></Response>"
+        call = client.calls.create(to=payload.phone, from_=twilio_number, twiml=twiml)
+        logger.info("Twilio call initiated")
         return {"ok": True, "data": {"call_sid": call.sid, "status": call.status}}
     except Exception as e:
         logger.warning("Twilio call error: %s", e)
@@ -3566,6 +3577,7 @@ async def polly_chat(payload: PollyChatPayload):
     """Main chat endpoint for Polly sidebar. Supports thinking mode."""
     try:
         from scripts.system.polly_service import chat
+
         result = await chat(payload.message, payload.context, thinking=payload.thinking)
         return {"ok": True, "data": result}
     except Exception as e:
@@ -3578,6 +3590,7 @@ async def polly_respond(payload: PollyRespondPayload):
     """Alternative response endpoint for Polly."""
     try:
         from scripts.system.polly_service import respond
+
         result = await respond(payload.text, payload.context, payload.intent, thinking=payload.thinking)
         return {"ok": True, "data": result}
     except Exception as e:
@@ -3590,6 +3603,7 @@ async def polly_context():
     """Return backend capabilities and service status."""
     try:
         from scripts.system.polly_service import get_context
+
         result = await get_context()
         return {"ok": True, "data": result}
     except Exception as e:
@@ -3602,8 +3616,9 @@ async def polly_search(payload: PollySearchPayload):
     """Real web search via Tavily + intent fallback."""
     try:
         from scripts.system.polly_service import search
+
         result = await search(payload.query)
-        return result
+        return _public_service_result(result)
     except Exception as e:
         logger.warning("Polly search error: %s", type(e).__name__)
         return {"ok": False, "error": "Search service temporarily unavailable."}
@@ -3614,6 +3629,7 @@ async def polly_delegate(payload: PollyDelegatePayload):
     """Delegation endpoint — routes to appropriate handler."""
     try:
         from scripts.system.polly_service import delegate
+
         result = await delegate(payload.text)
         return {"ok": True, "data": result}
     except Exception as e:
@@ -3626,8 +3642,9 @@ async def polly_email(payload: PollyEmailPayload):
     """Send email from Polly chat via Proton SMTP."""
     try:
         from scripts.system.polly_service import send_email_from_chat
+
         result = await send_email_from_chat(payload.to, payload.subject, payload.body)
-        return {"ok": result.get("ok", False), "message_id": result.get("message_id")}
+        return {"ok": bool(result.get("ok", False)), "message_id": str(result.get("message_id") or "")[:128]}
     except Exception as e:
         logger.warning("Polly email error: %s", type(e).__name__)
         return {"ok": False, "error": "Email service temporarily unavailable."}
@@ -3638,8 +3655,9 @@ async def polly_slack(payload: PollySlackPayload):
     """Send Slack notification from Polly chat."""
     try:
         from scripts.system.polly_service import notify_slack
+
         result = await notify_slack(payload.message, payload.channel)
-        return {"ok": result.get("ok", False)}
+        return {"ok": bool(result.get("ok", False))}
     except Exception as e:
         logger.warning("Polly slack error: %s", type(e).__name__)
         return {"ok": False, "error": "Slack service temporarily unavailable."}

--- a/src/.github/workflows/release-and-deploy.yml
+++ b/src/.github/workflows/release-and-deploy.yml
@@ -106,6 +106,8 @@ print('Dual Lattice Consensus: OK')
     needs: test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/.github/workflows/scbe-tests.yml
+++ b/src/.github/workflows/scbe-tests.yml
@@ -118,6 +118,8 @@ jobs:
 
   harmonic-scaling:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -140,6 +142,8 @@ jobs:
 
   core-cipher:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/src/.github/workflows/scbe.yml
+++ b/src/.github/workflows/scbe.yml
@@ -13,6 +13,8 @@ jobs:
   axiom-verification:
     name: 'Axiom Compliance (A1-A12)'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -57,6 +59,8 @@ jobs:
   unit-tests:
     name: 'Unit Tests'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -102,6 +106,8 @@ jobs:
   requirements-verification:
     name: 'EARS Requirements (R1-R8)'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -200,6 +206,8 @@ jobs:
   patent-validation:
     name: 'Patent Claims Validation'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/src/api/postgres_lite.py
+++ b/src/api/postgres_lite.py
@@ -76,7 +76,7 @@ def probe_postgres(*, dsn: str | None = None, timeout_s: float = 3.0) -> dict[st
             "configured": True,
             "reachable": False,
             "driver": "psycopg3",
-            "error": str(exc)[:500],
+            "error": type(exc).__name__,
         }
 
 


### PR DESCRIPTION
## Summary
- Add explicit read-only permissions to nested example workflow jobs flagged by CodeQL.
- Stop Postgres health from returning raw database exception text.
- Sanitize AetherBrowser/Polly service result payloads and avoid logging phone numbers in Twilio call initiation.

## Verification
- `python -m black --line-length 120 --check scripts/aetherbrowser/api_server.py src/api/postgres_lite.py`
- `python -m py_compile scripts/aetherbrowser/api_server.py src/api/postgres_lite.py src/api/free_llm_routes.py src/api/main.py src/api/geoseal_service.py`
- `python -m pytest tests/api/test_polly_widget_contract.py tests/api/test_polly_workers.py tests/test_script_artifact_redaction.py -q` -> 22 passed
- `python scripts/security/code_governance_gate.py check-push` -> PASS

## Rollback
Revert this PR to restore the prior verbose service-result behavior and nested workflow permission shape.