### PR TITLE
fix(security): tighten public service responses

### DIFF
--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -125,6 +125,38 @@ def _public_service_result(result: Any) -> Any:
     return result
 
 
+def _public_search_result(result: Any) -> dict[str, Any]:
+    """Build an explicit public schema for Polly search responses."""
+    if not isinstance(result, dict):
+        return {"ok": False, "error": "Search service temporarily unavailable."}
+    records = result.get("results") or result.get("sources") or result.get("data") or []
+    if not isinstance(records, list):
+        records = []
+    public_records = []
+    for record in records[:10]:
+        if not isinstance(record, dict):
+            continue
+        public_records.append(
+            {
+                "title": str(record.get("title") or "")[:240],
+                "url": str(record.get("url") or record.get("href") or "")[:500],
+                "snippet": str(record.get("snippet") or record.get("content") or record.get("excerpt") or "")[:800],
+            }
+        )
+    return {
+        "ok": bool(result.get("ok", True)),
+        "query": str(result.get("query") or "")[:500],
+        "results": public_records,
+    }
+
+
+def _public_email_result(result: Any) -> dict[str, Any]:
+    """Build an explicit public schema for email-send responses."""
+    if not isinstance(result, dict):
+        return {"ok": False, "error": "Email service temporarily unavailable."}
+    return {"ok": bool(result.get("ok", False)), "message_id": str(result.get("message_id") or "")[:128]}
+
+
 # ---------------------------------------------------------------------------
 #  Lazy-load the runtime gate (best effort — works even if deps are missing)
 # ---------------------------------------------------------------------------
@@ -3618,7 +3650,7 @@ async def polly_search(payload: PollySearchPayload):
         from scripts.system.polly_service import search
 
         result = await search(payload.query)
-        return _public_service_result(result)
+        return _public_search_result(result)
     except Exception as e:
         logger.warning("Polly search error: %s", type(e).__name__)
         return {"ok": False, "error": "Search service temporarily unavailable."}
@@ -3644,7 +3676,7 @@ async def polly_email(payload: PollyEmailPayload):
         from scripts.system.polly_service import send_email_from_chat
 
         result = await send_email_from_chat(payload.to, payload.subject, payload.body)
-        return {"ok": bool(result.get("ok", False)), "message_id": str(result.get("message_id") or "")[:128]}
+        return _public_email_result(result)
     except Exception as e:
         logger.warning("Polly email error: %s", type(e).__name__)
         return {"ok": False, "error": "Email service temporarily unavailable."}

--- a/src/.github/workflows/release-and-deploy.yml
+++ b/src/.github/workflows/release-and-deploy.yml
@@ -29,6 +29,8 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       

--- a/src/api/free_llm_routes.py
+++ b/src/api/free_llm_routes.py
@@ -165,6 +165,39 @@ def _append_bus_event(event: Dict[str, Any]) -> None:
         handle.write(json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n")
 
 
+def _public_dispatch_payload(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Return only externally safe dispatch fields for API callers."""
+
+    data = response.get("data") if isinstance(response, dict) else {}
+    data = data if isinstance(data, dict) else {}
+    result = data.get("result")
+    result = result if isinstance(result, dict) else {}
+    bus_event = data.get("bus_event")
+    bus_event = bus_event if isinstance(bus_event, dict) else {}
+    return {
+        "status": response.get("status", "ok") if isinstance(response, dict) else "ok",
+        "data": {
+            "version": data.get("version", "hydra-free-llm-dispatch-v1"),
+            "user": data.get("user"),
+            "route": data.get("route"),
+            "result": {
+                "provider": result.get("provider"),
+                "model": result.get("model"),
+                "finish_reason": result.get("finish_reason"),
+                "text": result.get("text", ""),
+            },
+            "bus_event": {
+                "event_id": bus_event.get("event_id"),
+                "origin": bus_event.get("origin"),
+                "timestamp": bus_event.get("timestamp"),
+                "route": bus_event.get("route"),
+                "prompt": bus_event.get("prompt"),
+                "result": bus_event.get("result"),
+            },
+        },
+    }
+
+
 OLLAMA_LAUNCH_INTEGRATIONS: Dict[str, Dict[str, Any]] = {
     "claude": {"name": "Claude Code", "aliases": []},
     "cline": {"name": "Cline", "aliases": []},
@@ -554,4 +587,4 @@ def dispatch_free_llm_request(
 @free_llm_router.post("/dispatch")
 async def dispatch_free_llm(request: FreeLLMDispatchRequest, x_api_key: str = Header(...)):
     user = await verify_api_key(x_api_key)
-    return dispatch_free_llm_request(request, user=user, origin="outside")
+    return _public_dispatch_payload(dispatch_free_llm_request(request, user=user, origin="outside"))


### PR DESCRIPTION
## Summary
- add explicit job-level read permissions to the release/deploy test job
- return explicit public schemas from Polly search/email endpoints instead of service objects
- wrap outside free-LLM dispatch responses in a public payload so internal bus fields stay bounded

## Validation
- python -m black --line-length 120 --check scripts/aetherbrowser/api_server.py src/api/free_llm_routes.py
- python -m py_compile scripts/aetherbrowser/api_server.py src/api/free_llm_routes.py
- python -m pytest tests/api/test_polly_widget_contract.py tests/api/test_polly_workers.py tests/test_script_artifact_redaction.py -q
- python scripts/security/code_governance_gate.py check-push

## Rollback
Revert this commit to restore the previous raw service response shapes.