### PR TITLE
chore(codeql): remove unused python symbols

### DIFF
--- a/scripts/apollo/agentic_email_triage.py
+++ b/scripts/apollo/agentic_email_triage.py
@@ -18,7 +18,7 @@ import logging
 import os
 import re
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
@@ -182,7 +182,7 @@ Classify this email. Respond ONLY with valid JSON in this exact format:
         elif "```" in text:
             text = text.split("```")[1].split("```")[0].strip()
         return json.loads(text)
-    except Exception as e:
+    except Exception:
         logger.warning("LLM classification failed — falling back to heuristic")
         return classify_heuristic(sender, subject, body)
 

--- a/scripts/benchmark/cli_quest_wrapper.py
+++ b/scripts/benchmark/cli_quest_wrapper.py
@@ -13,11 +13,10 @@ import argparse
 import json
 import shutil
 import sys
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = REPO_ROOT / "config" / "eval" / "cli_quest_tasks.sample.json"

--- a/scripts/benchmark/openclaw_swarm_benchmark.py
+++ b/scripts/benchmark/openclaw_swarm_benchmark.py
@@ -530,15 +530,20 @@ def score_case(parsed: dict[str, Any] | None, routing: dict[str, Any], exit_code
     points += 15 if parsed.get("models") else 0
     points += 15 if "promotable_lanes" in parsed and "blocked_lanes" in parsed else 0
     points += 20 if routing.get("schema") in {"scbe_swarm_routing_v1", "openclaw_swarm_routing_v1"} else 0
-    points += 10 if routing.get("next_action") in {
-        "extract_one_promotable_diff_then_safe_apply",
-        "escalate_to_paid_or_narrow_task",
-        "run_helper_guard_cycle_before_escalation",
-        "deliver_answer_to_user",
-        "handoff_evidence_to_builder",
-        "review_promotable_lane",
-        "safe_apply_verified",
-    } else 0
+    points += (
+        10
+        if routing.get("next_action")
+        in {
+            "extract_one_promotable_diff_then_safe_apply",
+            "escalate_to_paid_or_narrow_task",
+            "run_helper_guard_cycle_before_escalation",
+            "deliver_answer_to_user",
+            "handoff_evidence_to_builder",
+            "review_promotable_lane",
+            "safe_apply_verified",
+        }
+        else 0
+    )
     points += 5 if "correction_guide" in routing and "quality_flag_counts" in routing else 0
     if routing.get("assurance_packet"):
         points = min(100, points + 0)
@@ -589,7 +594,9 @@ def build_quality_vector(item: dict[str, Any]) -> dict[str, Any]:
     assurance = routing.get("assurance_packet") or {}
     quality_flags = routing.get("quality_flag_counts") or parsed.get("quality_flag_counts") or {}
     flag_total = sum(int(count) for count in quality_flags.values())
-    mean_applicability = float(assurance.get("mean_applicability_score", parsed.get("mean_applicability_score", 0)) or 0)
+    mean_applicability = float(
+        assurance.get("mean_applicability_score", parsed.get("mean_applicability_score", 0)) or 0
+    )
     next_action = str(routing.get("next_action") or parsed.get("next_action") or "")
     trace_parts = [
         bool(parsed.get("run_dir")),
@@ -661,14 +668,18 @@ def summarize_quality_vectors(results: list[dict[str, Any]]) -> dict[str, Any]:
         "schema": "scbe_swarm_quality_summary_v1",
         "average_quality_score": round(sum(float(vector["quality_score"]) for vector in vectors) / len(vectors), 2),
         "pass_depth_counts": depth_counts,
-        "dimension_averages": {
-            key: round(value / len(vectors), 2) for key, value in sorted(dimension_totals.items())
-        },
+        "dimension_averages": {key: round(value / len(vectors), 2) for key, value in sorted(dimension_totals.items())},
         "interpretation": "Use this to compare successful runs by quality, not just pass/fail. A green run with low traceability or patch_readiness is a thin pass.",
     }
 
 
-def build_summary(results: list[dict[str, Any]], *, completed_cases: int | None = None, planned_cases: int | None = None, case_workers: int | None = None) -> dict[str, Any]:
+def build_summary(
+    results: list[dict[str, Any]],
+    *,
+    completed_cases: int | None = None,
+    planned_cases: int | None = None,
+    case_workers: int | None = None,
+) -> dict[str, Any]:
     attach_quality_vectors(results)
     scores = [item["score"]["points"] for item in results]
     parsed_rows = [item.get("stdout_json") or {} for item in results]
@@ -750,7 +761,8 @@ def build_kaggle_winner_loop(report: dict[str, Any]) -> dict[str, Any]:
         )
 
     cloud_cases = [
-        item for item in cases
+        item
+        for item in cases
         if (item.get("case") or {}).get("allow_ollama_cloud") or (item.get("case") or {}).get("prefer_ollama_cloud")
     ]
     cloud_models: list[str] = []
@@ -779,10 +791,13 @@ def build_kaggle_winner_loop(report: dict[str, Any]) -> dict[str, Any]:
         "next_best_patch": first_weakness.get("patch_direction")
         or (weakest_stage or {}).get("next_repair_task")
         or "Run the benchmark before selecting a patch.",
-        "next_rerun": first_weakness.get("rerun") or "python scripts/benchmark/openclaw_swarm_benchmark.py --mode kaggle-loop",
+        "next_rerun": first_weakness.get("rerun")
+        or "python scripts/benchmark/openclaw_swarm_benchmark.py --mode kaggle-loop",
         "ollama_cloud": {
             "enabled_case_count": len(cloud_cases),
-            "prefer_cloud_case_count": sum(1 for item in cloud_cases if (item.get("case") or {}).get("prefer_ollama_cloud")),
+            "prefer_cloud_case_count": sum(
+                1 for item in cloud_cases if (item.get("case") or {}).get("prefer_ollama_cloud")
+            ),
             "models_seen": sorted(set(cloud_models)),
             "note": "Cloud models are used only by opted-in cases; local/free lanes remain the default first pass.",
         },
@@ -812,7 +827,7 @@ def run_safe_apply_case(output_dir: Path) -> dict[str, Any]:
     patch_path.parent.mkdir(parents=True, exist_ok=True)
     patch_path.write_text(build_safe_apply_patch(rel_path), encoding="utf-8")
     smoke = (
-        "python -c \"from pathlib import Path; "
+        'python -c "from pathlib import Path; '
         f"assert Path({rel_path!r}).exists(); "
         "print('sandbox patch visible')\""
     )
@@ -1022,7 +1037,11 @@ def run_self_cli_functional_case(
         "policy": "self_cli_functional_coding_gauntlet",
         "quality_flag_counts": quality_flags,
         "correction_guide": [],
-        "next_action": "safe_apply_verified" if failed_total == 0 and functional_report else "run_helper_guard_cycle_before_escalation",
+        "next_action": (
+            "safe_apply_verified"
+            if failed_total == 0 and functional_report
+            else "run_helper_guard_cycle_before_escalation"
+        ),
         "next_cycle": "inspect_failed_functional_tasks_then_repair_prompt_or_task_packet",
         "assurance_packet": {
             "schema": "scbe_darpa_style_assurance_packet_v1",
@@ -1089,7 +1108,6 @@ def run_self_cli_functional_case(
 
 
 def build_single_case_report(run_id: str, mode: str, output_dir: Path, item: dict[str, Any]) -> dict[str, Any]:
-    parsed = item.get("stdout_json") or {}
     results = [item]
     summary = build_summary(results)
     report = {
@@ -1416,7 +1434,9 @@ def build_geometric_consensus(report: dict[str, Any]) -> dict[str, Any]:
         "hexagonal_faces": face_coverage,
         "result_focus": {
             "completion_counts": completion_counts,
-            "dominant_completion": max(completion_counts, key=completion_counts.get) if completion_counts else "unknown",
+            "dominant_completion": (
+                max(completion_counts, key=completion_counts.get) if completion_counts else "unknown"
+            ),
             "note": "Dominant completion is a routing clue, not a consensus score.",
         },
         "information_ray_trace": {
@@ -1549,7 +1569,15 @@ def build_markdown(report: dict[str, Any]) -> str:
         for face, values in consensus["hexagonal_faces"].items():
             lines.append(f"| `{face}` | {values['coverage']} | {values['present']} | {values['total']} |")
         trace = consensus.get("information_ray_trace") or {}
-        lines.extend(["", "### Information Ray Trace", "", f"- ray_model: `{trace.get('ray_model', '')}`", f"- ray_count: `{trace.get('ray_count', 0)}`"])
+        lines.extend(
+            [
+                "",
+                "### Information Ray Trace",
+                "",
+                f"- ray_model: `{trace.get('ray_model', '')}`",
+                f"- ray_count: `{trace.get('ray_count', 0)}`",
+            ]
+        )
         if consensus.get("code_5w"):
             lines.extend(
                 [
@@ -1598,7 +1626,15 @@ def build_markdown(report: dict[str, Any]) -> str:
             ]
         )
     if grouped:
-        lines.extend(["", "## Grouped Totals", "", "| Group | Cases | Seconds | Promotable | Blocked | Failed |", "|---|---:|---:|---:|---:|---:|"])
+        lines.extend(
+            [
+                "",
+                "## Grouped Totals",
+                "",
+                "| Group | Cases | Seconds | Promotable | Blocked | Failed |",
+                "|---|---:|---:|---:|---:|---:|",
+            ]
+        )
         for key in sorted(grouped):
             bucket = grouped[key]
             lines.append(
@@ -1622,12 +1658,18 @@ def build_markdown(report: dict[str, Any]) -> str:
         )
         for target in loop["public_benchmark_targets"]:
             lines.append(f"| [{target['name']}]({target['url']}) | {target['what_it_tests']} | {target['scbe_gap']} |")
-        lines.extend(["", "### Current Weaknesses", "", "| Weakness | Observed | Why We Lose | Patch Direction | Rerun |", "|---|---|---|---|---|"])
+        lines.extend(
+            [
+                "",
+                "### Current Weaknesses",
+                "",
+                "| Weakness | Observed | Why We Lose | Patch Direction | Rerun |",
+                "|---|---|---|---|---|",
+            ]
+        )
         for weakness in loop["weaknesses"]:
             lines.append(
-                "| {weakness} | {observed} | {why_we_lose} | {patch_direction} | `{rerun}` |".format(
-                    **weakness
-                )
+                "| {weakness} | {observed} | {why_we_lose} | {patch_direction} | `{rerun}` |".format(**weakness)
             )
     if report.get("kaggle_winner_loop"):
         loop = report["kaggle_winner_loop"]
@@ -1652,7 +1694,9 @@ def build_markdown(report: dict[str, Any]) -> str:
                     stage=stage["stage"],
                     case_count=stage["case_count"],
                     quality=stage["average_quality_score"],
-                    delta="" if stage["delta_from_previous_run_stage"] is None else stage["delta_from_previous_run_stage"],
+                    delta=(
+                        "" if stage["delta_from_previous_run_stage"] is None else stage["delta_from_previous_run_stage"]
+                    ),
                     weakest=stage["weakest_dimension"],
                     repair=stage["next_repair_task"],
                 )
@@ -1721,7 +1765,9 @@ def main() -> int:
     if args.mode == "safe-apply":
         item = run_safe_apply_case(output_dir)
         report = build_single_case_report(run_id, args.mode, output_dir, item)
-        print(json.dumps({"ok": True, "report": str(output_dir / "report.json"), "summary": report["summary"]}, indent=2))
+        print(
+            json.dumps({"ok": True, "report": str(output_dir / "report.json"), "summary": report["summary"]}, indent=2)
+        )
         return 0
     if args.mode == "self-cli-functional":
         item = run_self_cli_functional_case(
@@ -1732,7 +1778,9 @@ def main() -> int:
             repair_attempts=max(0, int(args.self_cli_repair_attempts)),
         )
         report = build_single_case_report(run_id, args.mode, output_dir, item)
-        print(json.dumps({"ok": True, "report": str(output_dir / "report.json"), "summary": report["summary"]}, indent=2))
+        print(
+            json.dumps({"ok": True, "report": str(output_dir / "report.json"), "summary": report["summary"]}, indent=2)
+        )
         return 0
 
     if args.mode == "quick":

--- a/scripts/benchmark/public_agentic_cli_suite.py
+++ b/scripts/benchmark/public_agentic_cli_suite.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
-import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path

--- a/scripts/benchmarks/scbe_bijective_round_trip/run_ollama_submission.py
+++ b/scripts/benchmarks/scbe_bijective_round_trip/run_ollama_submission.py
@@ -235,7 +235,6 @@ def with_metadata_preface(row: dict[str, Any], prediction: str) -> str:
 def build_contract_hint(row: dict[str, Any]) -> str:
     meta = row.get("meta") or {}
     task = str(meta.get("task", "unknown"))
-    prompt = str(row.get("prompt", ""))
     slots = expanded_slots(row)
 
     lines = ["Output contract:"]
@@ -264,7 +263,6 @@ def structural_scaffold(row: dict[str, Any], prediction: str) -> str:
     """Add deterministic format rails without copying the hidden reference."""
     meta = row.get("meta") or {}
     task = str(meta.get("task", "unknown"))
-    prompt = str(row.get("prompt", ""))
     slots = expanded_slots(row)
     body = prediction.strip()
 
@@ -292,7 +290,6 @@ def contract_repair(row: dict[str, Any], prediction: str) -> str:
     """Minimal deterministic repair pass for known benchmark output contracts."""
     meta = row.get("meta") or {}
     task = str(meta.get("task", "unknown"))
-    prompt = str(row.get("prompt", ""))
     slots = expanded_slots(row)
     out = with_metadata_preface(row, prediction)
 

--- a/scripts/build_stage6_signal_shape_boost.py
+++ b/scripts/build_stage6_signal_shape_boost.py
@@ -33,13 +33,10 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from build_stage6_repair_sft import (  # noqa: E402
-    CONTRACT_FORBIDDEN,
-    CONTRACT_REQUIRED,
     SYSTEM_PROMPT,
     _assert_row_vocabulary,
     _token_hex,
 )
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SFT_ROOT = REPO_ROOT / "training-data" / "sft"
@@ -102,9 +99,7 @@ PREFIX_ORDER: dict[str, list[str]] = {
 }
 
 
-def _record(
-    prompt: str, response: str, *, kind: str, token: str, shape: str
-) -> dict[str, Any]:
+def _record(prompt: str, response: str, *, kind: str, token: str, shape: str) -> dict[str, Any]:
     return {
         "messages": [
             {"role": "system", "content": SYSTEM_PROMPT},
@@ -128,11 +123,16 @@ def _prefix_for(kind: str, *, anchor_token: str | None = None) -> str:
     a single deterministic prefix shape per kind.
     """
     tokens = list(PREFIX_ORDER[kind])
-    if anchor_token and anchor_token not in tokens and kind in {
-        "resource_jump_cancel",
-        "lane_separation",
-        "hex_trace",
-    }:
+    if (
+        anchor_token
+        and anchor_token not in tokens
+        and kind
+        in {
+            "resource_jump_cancel",
+            "lane_separation",
+            "hex_trace",
+        }
+    ):
         tokens[0] = anchor_token
     rendered = " | ".join(f"`{t}`" if "_" in t else t for t in tokens)
     return f"required-tokens: {rendered} ::"
@@ -143,46 +143,56 @@ def _prefix_for(kind: str, *, anchor_token: str | None = None) -> str:
 # ---------------------------------------------------------------------------
 
 JUMP_CASES: list[tuple[str, str, str, str]] = [
-    ("scan_ridge", "transmit_burst", "comms and power",
-     "power=0.18 compute=0.32 time=0.40 comms=0.08 wear=0.22"),
-    ("compress_map", "transmit_burst", "comms",
-     "power=0.21 compute=0.30 time=0.35 comms=0.05 wear=0.19"),
-    ("relay_cache_patch", "transmit_burst", "comms",
-     "power=0.27 compute=0.31 time=0.42 comms=0.04 wear=0.23"),
-    ("ridge_shadow_scan", "transmit_burst", "time and comms",
-     "power=0.40 compute=0.25 time=0.07 comms=0.06 wear=0.18"),
-    ("thermal_noise_gate", "transmit_burst", "comms and wear",
-     "power=0.33 compute=0.28 time=0.36 comms=0.05 wear=0.07"),
-    ("cache_delta_fold", "transmit_burst", "comms",
-     "power=0.45 compute=0.39 time=0.32 comms=0.04 wear=0.24"),
-    ("soil_shadow_index", "transmit_burst", "power and comms",
-     "power=0.05 compute=0.34 time=0.40 comms=0.06 wear=0.20"),
-    ("dust_blur_filter", "transmit_burst", "comms and time",
-     "power=0.46 compute=0.30 time=0.05 comms=0.04 wear=0.22"),
-    ("signal_calm_gate", "transmit_burst", "comms and time",
-     "power=0.34 compute=0.28 time=0.06 comms=0.05 wear=0.30"),
-    ("path_hash_guard", "transmit_burst", "power and comms",
-     "power=0.07 compute=0.41 time=0.22 comms=0.07 wear=0.27"),
-    ("crater_edge_index", "transmit_burst", "comms",
-     "power=0.31 compute=0.27 time=0.40 comms=0.04 wear=0.20"),
-    ("antenna_align_probe", "transmit_burst", "power and comms",
-     "power=0.06 compute=0.34 time=0.43 comms=0.05 wear=0.29"),
-    ("battery_taper_check", "transmit_burst", "power and comms",
-     "power=0.04 compute=0.32 time=0.45 comms=0.07 wear=0.26"),
-    ("comm_window_check", "transmit_burst", "comms",
-     "power=0.45 compute=0.38 time=0.34 comms=0.03 wear=0.20"),
-    ("storage_margin_check", "transmit_burst", "comms and time",
-     "power=0.33 compute=0.28 time=0.05 comms=0.04 wear=0.27"),
-    ("link_jitter_probe", "transmit_burst", "time and comms",
-     "power=0.37 compute=0.31 time=0.04 comms=0.05 wear=0.25"),
-    ("hazard_gradient_scan", "transmit_burst", "comms",
-     "power=0.40 compute=0.34 time=0.38 comms=0.04 wear=0.22"),
-    ("downlink_quota_probe", "transmit_burst", "comms",
-     "power=0.39 compute=0.32 time=0.41 comms=0.04 wear=0.21"),
-    ("orbiter_window_probe", "transmit_burst", "comms and time",
-     "power=0.36 compute=0.30 time=0.05 comms=0.04 wear=0.22"),
-    ("relay_pause_token", "transmit_burst", "comms",
-     "power=0.32 compute=0.29 time=0.39 comms=0.04 wear=0.21"),
+    ("scan_ridge", "transmit_burst", "comms and power", "power=0.18 compute=0.32 time=0.40 comms=0.08 wear=0.22"),
+    ("compress_map", "transmit_burst", "comms", "power=0.21 compute=0.30 time=0.35 comms=0.05 wear=0.19"),
+    ("relay_cache_patch", "transmit_burst", "comms", "power=0.27 compute=0.31 time=0.42 comms=0.04 wear=0.23"),
+    ("ridge_shadow_scan", "transmit_burst", "time and comms", "power=0.40 compute=0.25 time=0.07 comms=0.06 wear=0.18"),
+    (
+        "thermal_noise_gate",
+        "transmit_burst",
+        "comms and wear",
+        "power=0.33 compute=0.28 time=0.36 comms=0.05 wear=0.07",
+    ),
+    ("cache_delta_fold", "transmit_burst", "comms", "power=0.45 compute=0.39 time=0.32 comms=0.04 wear=0.24"),
+    (
+        "soil_shadow_index",
+        "transmit_burst",
+        "power and comms",
+        "power=0.05 compute=0.34 time=0.40 comms=0.06 wear=0.20",
+    ),
+    ("dust_blur_filter", "transmit_burst", "comms and time", "power=0.46 compute=0.30 time=0.05 comms=0.04 wear=0.22"),
+    ("signal_calm_gate", "transmit_burst", "comms and time", "power=0.34 compute=0.28 time=0.06 comms=0.05 wear=0.30"),
+    ("path_hash_guard", "transmit_burst", "power and comms", "power=0.07 compute=0.41 time=0.22 comms=0.07 wear=0.27"),
+    ("crater_edge_index", "transmit_burst", "comms", "power=0.31 compute=0.27 time=0.40 comms=0.04 wear=0.20"),
+    (
+        "antenna_align_probe",
+        "transmit_burst",
+        "power and comms",
+        "power=0.06 compute=0.34 time=0.43 comms=0.05 wear=0.29",
+    ),
+    (
+        "battery_taper_check",
+        "transmit_burst",
+        "power and comms",
+        "power=0.04 compute=0.32 time=0.45 comms=0.07 wear=0.26",
+    ),
+    ("comm_window_check", "transmit_burst", "comms", "power=0.45 compute=0.38 time=0.34 comms=0.03 wear=0.20"),
+    (
+        "storage_margin_check",
+        "transmit_burst",
+        "comms and time",
+        "power=0.33 compute=0.28 time=0.05 comms=0.04 wear=0.27",
+    ),
+    ("link_jitter_probe", "transmit_burst", "time and comms", "power=0.37 compute=0.31 time=0.04 comms=0.05 wear=0.25"),
+    ("hazard_gradient_scan", "transmit_burst", "comms", "power=0.40 compute=0.34 time=0.38 comms=0.04 wear=0.22"),
+    ("downlink_quota_probe", "transmit_burst", "comms", "power=0.39 compute=0.32 time=0.41 comms=0.04 wear=0.21"),
+    (
+        "orbiter_window_probe",
+        "transmit_burst",
+        "comms and time",
+        "power=0.36 compute=0.30 time=0.05 comms=0.04 wear=0.22",
+    ),
+    ("relay_pause_token", "transmit_burst", "comms", "power=0.32 compute=0.29 time=0.39 comms=0.04 wear=0.21"),
 ]
 
 
@@ -264,9 +274,7 @@ def _lane_prefix(token: str, domain: str) -> dict[str, Any]:
 
 def _lane_prefix_contrast(token: str, domain: str) -> dict[str, Any]:
     hex_trace = _token_hex(token)
-    prompt = (
-        f"Contrast Stage 6 lanes for `{token}` ({domain}). Where, if anywhere, does material chemistry enter?"
-    )
+    prompt = f"Contrast Stage 6 lanes for `{token}` ({domain}). Where, if anywhere, does material chemistry enter?"
     prefix = _prefix_for("lane_separation", anchor_token=token)
     body = (
         f"Structural lane: `{token}` is the byte and hex sequence `{hex_trace}`; nothing about the bytes asserts a "
@@ -484,9 +492,7 @@ def build() -> dict[str, Any]:
             if token in body:
                 must_pass_train[token] += 1
 
-    forced_prefix_train = sum(
-        1 for row in train_rows if row["messages"][-1]["content"].startswith("required-tokens:")
-    )
+    forced_prefix_train = sum(1 for row in train_rows if row["messages"][-1]["content"].startswith("required-tokens:"))
 
     manifest = {
         "schema_version": "atomic_workflow_stage6_signal_shape_boost_manifest_v1",
@@ -507,9 +513,7 @@ def build() -> dict[str, Any]:
             "prompt classes (v9 only covered 3 must_pass)."
         ),
     }
-    MANIFEST_OUT.write_text(
-        json.dumps(manifest, indent=2, ensure_ascii=True), encoding="utf-8"
-    )
+    MANIFEST_OUT.write_text(json.dumps(manifest, indent=2, ensure_ascii=True), encoding="utf-8")
     return manifest
 
 

--- a/scripts/demos/scbe_governance_terminal_demo.py
+++ b/scripts/demos/scbe_governance_terminal_demo.py
@@ -22,7 +22,7 @@ import math
 import re
 import sys
 from dataclasses import dataclass
-from typing import Iterable, List, Tuple
+from typing import List, Tuple
 
 PHI = (1 + math.sqrt(5)) / 2
 
@@ -178,7 +178,6 @@ def _format_cost(c: float) -> str:
 
 
 def _print_score(s: GateScore) -> None:
-    pad = lambda x: f"{x:>10}"
     color = VERDICT_COLOR.get(s.verdict, ANSI["muted"])
     verdict_pill = _color(f"  {s.verdict:<10}  ", ANSI["bold"] + color)
 

--- a/scripts/demos/scbe_recruitment_trial.py
+++ b/scripts/demos/scbe_recruitment_trial.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
-import os
 import subprocess
 import sys
 from pathlib import Path

--- a/scripts/eval/diffusion_codegen_bakeoff.py
+++ b/scripts/eval/diffusion_codegen_bakeoff.py
@@ -26,12 +26,11 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
-import os
 import re
 import sys
 from dataclasses import dataclass, asdict, field
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any, Callable
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -66,11 +65,7 @@ class GeneratorReport:
 def gate_score(prompt: dict, response: str) -> GateVerdict:
     """Identical to the v6h `_gate_score` rule (canonical scorer)."""
     body_lower = (response or "").lower()
-    missing_required = [
-        str(t)
-        for t in (prompt.get("required") or [])
-        if str(t).lower() not in body_lower
-    ]
+    missing_required = [str(t) for t in (prompt.get("required") or []) if str(t).lower() not in body_lower]
 
     def contains_forbidden(term: str) -> bool:
         needle = str(term).strip().lower()
@@ -82,9 +77,7 @@ def gate_score(prompt: dict, response: str) -> GateVerdict:
             return re.search(pattern, body_lower) is not None
         return needle in body_lower
 
-    triggered_forbidden = [
-        str(t) for t in (prompt.get("forbidden") or []) if contains_forbidden(t)
-    ]
+    triggered_forbidden = [str(t) for t in (prompt.get("forbidden") or []) if contains_forbidden(t)]
     return GateVerdict(
         id=str(prompt.get("id", "")),
         shape=str(prompt.get("shape", "unknown")),
@@ -179,9 +172,7 @@ def make_ar_generator(model_id: str, max_new_tokens: int = 320) -> Callable[[dic
         text = (prompt.get("prompt") or "").strip()
         messages = [{"role": "user", "content": text}]
         try:
-            enc = tok.apply_chat_template(
-                messages, return_tensors="pt", add_generation_prompt=True
-            )
+            enc = tok.apply_chat_template(messages, return_tensors="pt", add_generation_prompt=True)
         except Exception:
             enc = tok(text, return_tensors="pt").input_ids
         # Newer transformers may return a BatchEncoding here; unwrap to a tensor.
@@ -203,9 +194,7 @@ def make_ar_generator(model_id: str, max_new_tokens: int = 320) -> Callable[[dic
     return _gen
 
 
-def make_diffusion_generator(
-    model_id: str, max_new_tokens: int = 320, num_steps: int = 64
-) -> Callable[[dict], str]:
+def make_diffusion_generator(model_id: str, max_new_tokens: int = 320, num_steps: int = 64) -> Callable[[dict], str]:
     """Lazy-loaded diffusion-LM generator.
 
     DiffuCoder-style models expose `generate(...)` with `num_inference_steps`.
@@ -225,9 +214,7 @@ def make_diffusion_generator(
         if tok.pad_token_id is None:
             tok.pad_token_id = tok.eos_token_id
         dtype = torch.bfloat16 if torch.cuda.is_available() else torch.float32
-        model = AutoModel.from_pretrained(
-            model_id, torch_dtype=dtype, trust_remote_code=True
-        )
+        model = AutoModel.from_pretrained(model_id, torch_dtype=dtype, trust_remote_code=True)
         model.eval()
         if torch.cuda.is_available():
             model = model.to("cuda")
@@ -243,9 +230,7 @@ def make_diffusion_generator(
         text = (prompt.get("prompt") or "").strip()
         messages = [{"role": "user", "content": text}]
         try:
-            enc = tok.apply_chat_template(
-                messages, return_tensors="pt", add_generation_prompt=True
-            )
+            enc = tok.apply_chat_template(messages, return_tensors="pt", add_generation_prompt=True)
         except Exception:
             enc = tok(text, return_tensors="pt").input_ids
         if torch.cuda.is_available():
@@ -316,9 +301,7 @@ def triangulate(reports: list[GeneratorReport]) -> dict:
             (v.shape for v in verdicts.values() if v is not None and v.shape),
             "unknown",
         )
-        bucket = by_shape.setdefault(
-            shape, {lab: {"pass": 0, "fail": 0} for lab in labels}
-        )
+        bucket = by_shape.setdefault(shape, {lab: {"pass": 0, "fail": 0} for lab in labels})
         for lab in labels:
             v = verdicts[lab]
             key = "pass" if (v is not None and v.ok) else "fail"
@@ -398,9 +381,7 @@ def emit_markdown_report(report: dict, out_path: Path) -> None:
     lines.append("| Generator | Model | Pass | Rate |")
     lines.append("|---|---|---|---|")
     for g in report.get("generators") or []:
-        lines.append(
-            f"| {g['label']} | `{g['model_id']}` | {g['n_pass']}/{g['n_total']} | {g['pass_rate']:.3f} |"
-        )
+        lines.append(f"| {g['label']} | `{g['model_id']}` | {g['n_pass']}/{g['n_total']} | {g['pass_rate']:.3f} |")
     lines.append("")
     tri = report.get("triangulation") or {}
     if tri.get("shape_delta"):
@@ -408,12 +389,8 @@ def emit_markdown_report(report: dict, out_path: Path) -> None:
         lines.append("")
         lines.append("| Shape | AR pass | Diffusion pass | Delta |")
         lines.append("|---|---|---|---|")
-        for shape, row in sorted(
-            tri["shape_delta"].items(), key=lambda kv: -kv[1]["delta"]
-        ):
-            lines.append(
-                f"| {shape} | {row['ar_pass']} | {row['diffusion_pass']} | {row['delta']:+d} |"
-            )
+        for shape, row in sorted(tri["shape_delta"].items(), key=lambda kv: -kv[1]["delta"]):
+            lines.append(f"| {shape} | {row['ar_pass']} | {row['diffusion_pass']} | {row['delta']:+d} |")
         lines.append("")
     if tri.get("by_prompt"):
         lines.append("## Per-prompt verdict-class")
@@ -422,9 +399,7 @@ def emit_markdown_report(report: dict, out_path: Path) -> None:
         lines.append("|---|---|---|---|")
         for row in tri["by_prompt"]:
             winners = ", ".join(row.get("winners") or []) or "—"
-            lines.append(
-                f"| {row['id']} | {row['shape']} | {row['verdict_class']} | {winners} |"
-            )
+            lines.append(f"| {row['id']} | {row['shape']} | {row['verdict_class']} | {winners} |")
         lines.append("")
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text("\n".join(lines), encoding="utf-8")
@@ -484,17 +459,13 @@ def main(argv: list[str] | None = None) -> int:
             generators.append(("schrodinger", "dry-run::schrodinger", make_dry_run_generator("schrodinger")))
     else:
         if use_baseline:
-            generators.append(
-                ("ar", args.baseline_model, make_ar_generator(args.baseline_model, args.max_new_tokens))
-            )
+            generators.append(("ar", args.baseline_model, make_ar_generator(args.baseline_model, args.max_new_tokens)))
         if use_diffusion:
             generators.append(
                 (
                     "diffusion",
                     args.diffusion_model,
-                    make_diffusion_generator(
-                        args.diffusion_model, args.max_new_tokens, args.diffusion_steps
-                    ),
+                    make_diffusion_generator(args.diffusion_model, args.max_new_tokens, args.diffusion_steps),
                 )
             )
         if use_schrodinger:

--- a/scripts/eval/gate_smoke_v6.py
+++ b/scripts/eval/gate_smoke_v6.py
@@ -19,7 +19,6 @@ from typing import Dict, List
 
 from src.cli.cascade_router import AndAllowCascadeRouter
 from src.cli.slm_router import (
-    BandNotApplicable,
     LatticeRouter,
     Mode,
     OllamaAdapter,

--- a/scripts/eval/gate_smoke_v7.py
+++ b/scripts/eval/gate_smoke_v7.py
@@ -29,7 +29,6 @@ from typing import Dict, List, Optional
 
 from src.cli.cascade_router import AndAllowCascadeRouter
 from src.cli.slm_router import (
-    BandNotApplicable,
     LatticeRouter,
     Mode,
     OllamaAdapter,

--- a/scripts/eval/petri_governance_gate_run.py
+++ b/scripts/eval/petri_governance_gate_run.py
@@ -37,7 +37,7 @@ import json
 import sys
 import time
 from collections import Counter
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -48,7 +48,6 @@ from src.cli.petri_seed_loader import (
 )
 from src.cli.cascade_router import AndAllowCascadeRouter, CascadeRouter
 from src.cli.slm_router import (
-    ClassificationFailure,
     LatticeRouter,
     Mode,
     OllamaAdapter,

--- a/scripts/eval/run_bijective_constrained_decoding_local.py
+++ b/scripts/eval/run_bijective_constrained_decoding_local.py
@@ -29,11 +29,10 @@ import gc
 import json
 import os
 import re
-import sys
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -43,9 +42,7 @@ BASE_MODEL = os.environ.get(
     "issdandavis/scbe-coding-agent-qwen-merged-coding-model-v1",
 ).strip()
 GATE_TONGUES = tuple(
-    t.strip()
-    for t in os.environ.get("SCBE_BIJ_GATE_TONGUES", "AV,RU,CA,UM,DR").split(",")
-    if t.strip()
+    t.strip() for t in os.environ.get("SCBE_BIJ_GATE_TONGUES", "AV,RU,CA,UM,DR").split(",") if t.strip()
 )
 GATE_PASS_RATE_MIN = float(os.environ.get("SCBE_BIJ_GATE_PASS_RATE_MIN", "0.80"))
 GATE_PER_CASE_MIN = float(os.environ.get("SCBE_BIJ_GATE_PER_CASE_MIN", "0.60"))
@@ -125,10 +122,7 @@ CASES = (
 SEEDS = {
     "reverse_string": "def reverse_string(s: str) -> str:\n    return s[::-1]\n",
     "safe_divide": (
-        "def safe_divide(a: float, b: float):\n"
-        "    if b == 0:\n"
-        "        return None\n"
-        "    return a / b\n"
+        "def safe_divide(a: float, b: float):\n" "    if b == 0:\n" "        return None\n" "    return a / b\n"
     ),
     "parse_json_name": (
         "import json\n"
@@ -171,30 +165,52 @@ BACK_PREFIX = {
         "        return None\n"
     ),
     "bounded_factorial": (
-        "def factorial(n: int) -> int:\n"
-        "    if n < 0:\n"
-        "        raise ValueError('n must be non-negative')\n"
+        "def factorial(n: int) -> int:\n" "    if n < 0:\n" "        raise ValueError('n must be non-negative')\n"
     ),
-    "eval_runner": (
-        "def run_expr(expr: str) -> object:\n"
-        "    _ALLOWED = {'__builtins__': {}}\n"
-    ),
+    "eval_runner": ("def run_expr(expr: str) -> object:\n" "    _ALLOWED = {'__builtins__': {}}\n"),
 }
 
 
 SAFE_BUILTINS = {
-    "abs": abs, "all": all, "any": any, "bool": bool, "dict": dict,
-    "enumerate": enumerate, "Exception": Exception, "float": float,
-    "filter": filter, "frozenset": frozenset, "int": int, "iter": iter,
-    "len": len, "list": list, "map": map, "max": max, "min": min,
-    "next": next, "print": print, "range": range, "reversed": reversed,
-    "set": set, "sorted": sorted, "str": str, "sum": sum, "tuple": tuple,
-    "type": type, "isinstance": isinstance, "zip": zip,
-    "AttributeError": AttributeError, "IndexError": IndexError,
-    "KeyError": KeyError, "RuntimeError": RuntimeError,
-    "StopIteration": StopIteration, "TypeError": TypeError,
-    "ValueError": ValueError, "ZeroDivisionError": ZeroDivisionError,
-    "__import__": __import__, "eval": eval,
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "bool": bool,
+    "dict": dict,
+    "enumerate": enumerate,
+    "Exception": Exception,
+    "float": float,
+    "filter": filter,
+    "frozenset": frozenset,
+    "int": int,
+    "iter": iter,
+    "len": len,
+    "list": list,
+    "map": map,
+    "max": max,
+    "min": min,
+    "next": next,
+    "print": print,
+    "range": range,
+    "reversed": reversed,
+    "set": set,
+    "sorted": sorted,
+    "str": str,
+    "sum": sum,
+    "tuple": tuple,
+    "type": type,
+    "isinstance": isinstance,
+    "zip": zip,
+    "AttributeError": AttributeError,
+    "IndexError": IndexError,
+    "KeyError": KeyError,
+    "RuntimeError": RuntimeError,
+    "StopIteration": StopIteration,
+    "TypeError": TypeError,
+    "ValueError": ValueError,
+    "ZeroDivisionError": ZeroDivisionError,
+    "__import__": __import__,
+    "eval": eval,
 }
 
 
@@ -263,9 +279,7 @@ def build_back_prompt(other_source: str, tongue: str, seed: str = "") -> str:
         joined = "\n".join(f"    {i}" for i in imports)
         contract_lines.append(f"  Required imports (must appear at top of code block):\n{joined}")
     contract_block = (
-        "\nThe Python output MUST satisfy this canonical contract:\n"
-        + "\n".join(contract_lines)
-        + "\n"
+        "\nThe Python output MUST satisfy this canonical contract:\n" + "\n".join(contract_lines) + "\n"
         if contract_lines
         else ""
     )
@@ -338,10 +352,17 @@ def round_trip_case(case: PromptCase, tongue: str, fwd_generate, back_generate) 
         intermediate = extract_first_codeblock(forward_output)
         if not intermediate:
             return RoundTripResult(
-                case_id=case.case_id, tongue=tongue, forward_output=forward_output,
-                intermediate_code="", back_output="", round_tripped_python="",
-                syntax_ok=False, exec_ok=False, tests_passed=False,
-                error="forward_extract_empty", forward_seconds=forward_seconds,
+                case_id=case.case_id,
+                tongue=tongue,
+                forward_output=forward_output,
+                intermediate_code="",
+                back_output="",
+                round_tripped_python="",
+                syntax_ok=False,
+                exec_ok=False,
+                tests_passed=False,
+                error="forward_extract_empty",
+                forward_seconds=forward_seconds,
             )
     back_prompt = build_back_prompt(intermediate, tongue if tongue != "KO" else "AV", seed)
     forced_prefix = BACK_PREFIX.get(case.case_id, "")
@@ -349,10 +370,18 @@ def round_trip_case(case: PromptCase, tongue: str, fwd_generate, back_generate) 
     round_tripped = extract_first_codeblock(back_output)
     if not round_tripped:
         return RoundTripResult(
-            case_id=case.case_id, tongue=tongue, forward_output=forward_output,
-            intermediate_code=intermediate, back_output=back_output,
-            round_tripped_python="", syntax_ok=False, exec_ok=False, tests_passed=False,
-            error="back_extract_empty", forward_seconds=forward_seconds, back_seconds=back_seconds,
+            case_id=case.case_id,
+            tongue=tongue,
+            forward_output=forward_output,
+            intermediate_code=intermediate,
+            back_output=back_output,
+            round_tripped_python="",
+            syntax_ok=False,
+            exec_ok=False,
+            tests_passed=False,
+            error="back_extract_empty",
+            forward_seconds=forward_seconds,
+            back_seconds=back_seconds,
             back_used_prefix=bool(forced_prefix),
         )
     check = run_code_checks(round_tripped, case.assertions)
@@ -368,13 +397,22 @@ def round_trip_case(case: PromptCase, tongue: str, fwd_generate, back_generate) 
         repaired_tests_passed = False
         repaired_error = check.error
     return RoundTripResult(
-        case_id=case.case_id, tongue=tongue, forward_output=forward_output,
-        intermediate_code=intermediate, back_output=back_output,
-        round_tripped_python=round_tripped, syntax_ok=check.syntax_ok,
-        exec_ok=check.exec_ok, tests_passed=check.tests_passed,
-        repaired_python=repaired_python, repair_actions=repair_actions,
-        repaired_tests_passed=repaired_tests_passed, repaired_error=repaired_error,
-        error=check.error, forward_seconds=forward_seconds, back_seconds=back_seconds,
+        case_id=case.case_id,
+        tongue=tongue,
+        forward_output=forward_output,
+        intermediate_code=intermediate,
+        back_output=back_output,
+        round_tripped_python=round_tripped,
+        syntax_ok=check.syntax_ok,
+        exec_ok=check.exec_ok,
+        tests_passed=check.tests_passed,
+        repaired_python=repaired_python,
+        repair_actions=repair_actions,
+        repaired_tests_passed=repaired_tests_passed,
+        repaired_error=repaired_error,
+        error=check.error,
+        forward_seconds=forward_seconds,
+        back_seconds=back_seconds,
         back_used_prefix=bool(forced_prefix),
     )
 
@@ -408,7 +446,8 @@ def aggregate(results, model_id, tongues):
         passed = sum(1 for r in subset if r.tests_passed)
         repaired = sum(1 for r in subset if r.repaired_tests_passed)
         report["by_tongue"][tongue] = {
-            "n": len(subset), "pass": passed,
+            "n": len(subset),
+            "pass": passed,
             "pass_rate": round(passed / len(subset), 4),
             "repaired_pass": repaired,
             "repaired_pass_rate": round(repaired / len(subset), 4),
@@ -419,7 +458,8 @@ def aggregate(results, model_id, tongues):
         passed = sum(1 for r in subset if r.tests_passed)
         repaired = sum(1 for r in subset if r.repaired_tests_passed)
         report["by_case"][cid] = {
-            "n": len(subset), "pass": passed,
+            "n": len(subset),
+            "pass": passed,
             "pass_rate": round(passed / len(subset), 4),
             "repaired_pass": repaired,
             "repaired_pass_rate": round(repaired / len(subset), 4),
@@ -513,33 +553,51 @@ def main() -> int:
         if args.cases
         else CASES
     )
-    selected_tongues = (
-        tuple(t.strip() for t in args.tongues.split(",") if t.strip()) if args.tongues else GATE_TONGUES
-    )
+    selected_tongues = tuple(t.strip() for t in args.tongues.split(",") if t.strip()) if args.tongues else GATE_TONGUES
 
-    print(json.dumps({"event": "boot", "model": args.model, "tongues": list(selected_tongues),
-                      "cases": [c.case_id for c in selected_cases],
-                      "prefix_enabled": not args.no_prefix,
-                      "max_new_tokens": MAX_NEW_TOKENS}, ensure_ascii=True), flush=True)
+    print(
+        json.dumps(
+            {
+                "event": "boot",
+                "model": args.model,
+                "tongues": list(selected_tongues),
+                "cases": [c.case_id for c in selected_cases],
+                "prefix_enabled": not args.no_prefix,
+                "max_new_tokens": MAX_NEW_TOKENS,
+            },
+            ensure_ascii=True,
+        ),
+        flush=True,
+    )
 
     import torch
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
     cuda = torch.cuda.is_available()
-    print(json.dumps({"event": "torch_env", "cuda": cuda,
-                      "device_name": torch.cuda.get_device_name(0) if cuda else "cpu",
-                      "vram_gb": (torch.cuda.get_device_properties(0).total_memory / 1024**3) if cuda else 0.0,
-                      }, ensure_ascii=True), flush=True)
+    print(
+        json.dumps(
+            {
+                "event": "torch_env",
+                "cuda": cuda,
+                "device_name": torch.cuda.get_device_name(0) if cuda else "cpu",
+                "vram_gb": (torch.cuda.get_device_properties(0).total_memory / 1024**3) if cuda else 0.0,
+            },
+            ensure_ascii=True,
+        ),
+        flush=True,
+    )
 
     dtype = torch.float16 if cuda else torch.float32
     t0 = time.time()
     tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
     model = AutoModelForCausalLM.from_pretrained(
-        args.model, torch_dtype=dtype, device_map="cuda" if cuda else "cpu", trust_remote_code=True,
+        args.model,
+        torch_dtype=dtype,
+        device_map="cuda" if cuda else "cpu",
+        trust_remote_code=True,
     )
     model.eval()
-    print(json.dumps({"event": "model_loaded", "seconds": round(time.time() - t0, 2)},
-                     ensure_ascii=True), flush=True)
+    print(json.dumps({"event": "model_loaded", "seconds": round(time.time() - t0, 2)}, ensure_ascii=True), flush=True)
 
     fwd_generate, back_generate = make_generators(model, tokenizer)
 
@@ -547,49 +605,68 @@ def main() -> int:
     for case in selected_cases:
         for tongue in selected_tongues:
             t_case = time.time()
-            print(json.dumps({"event": "case_start", "case": case.case_id, "tongue": tongue},
-                             ensure_ascii=True), flush=True)
+            print(
+                json.dumps({"event": "case_start", "case": case.case_id, "tongue": tongue}, ensure_ascii=True),
+                flush=True,
+            )
             r = round_trip_case(case, tongue, fwd_generate, back_generate)
             results.append(r)
-            print(json.dumps({"event": "case_done", "case": case.case_id, "tongue": tongue,
-                              "tests_passed": r.tests_passed,
-                              "repaired_tests_passed": r.repaired_tests_passed,
-                              "back_used_prefix": r.back_used_prefix,
-                              "seconds": round(time.time() - t_case, 2),
-                              "error": r.error,
-                              "repaired_error": r.repaired_error,
-                              }, ensure_ascii=True), flush=True)
+            print(
+                json.dumps(
+                    {
+                        "event": "case_done",
+                        "case": case.case_id,
+                        "tongue": tongue,
+                        "tests_passed": r.tests_passed,
+                        "repaired_tests_passed": r.repaired_tests_passed,
+                        "back_used_prefix": r.back_used_prefix,
+                        "seconds": round(time.time() - t_case, 2),
+                        "error": r.error,
+                        "repaired_error": r.repaired_error,
+                    },
+                    ensure_ascii=True,
+                ),
+                flush=True,
+            )
 
     report = aggregate(results, args.model, selected_tongues)
-    gate_pass = (
-        report["repaired_pass_rate"] >= GATE_PASS_RATE_MIN
-        and all(c["repaired_pass_rate"] >= GATE_PER_CASE_MIN for c in report["by_case"].values())
+    gate_pass = report["repaired_pass_rate"] >= GATE_PASS_RATE_MIN and all(
+        c["repaired_pass_rate"] >= GATE_PER_CASE_MIN for c in report["by_case"].values()
     )
     report["gate_pass_rate_min"] = GATE_PASS_RATE_MIN
     report["gate_per_case_min"] = GATE_PER_CASE_MIN
     report["gate_passed"] = gate_pass
 
-    out_path = Path(args.out) if args.out else (
-        REPO / "artifacts" / "bijective_tongue" /
-        f"local_constrained_{int(time.time())}.json"
+    out_path = (
+        Path(args.out)
+        if args.out
+        else (REPO / "artifacts" / "bijective_tongue" / f"local_constrained_{int(time.time())}.json")
     )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(report, indent=2, ensure_ascii=True), encoding="utf-8")
 
-    print(json.dumps({"event": "summary",
-                      "pass_rate": report["pass_rate"],
-                      "repaired_pass_rate": report["repaired_pass_rate"],
-                      "repair_lift": report["repair_lift"],
-                      "by_case": {k: v["repaired_pass_rate"] for k, v in report["by_case"].items()},
-                      "by_tongue": {k: v["repaired_pass_rate"] for k, v in report["by_tongue"].items()},
-                      "gate_passed": gate_pass,
-                      "report_path": str(out_path),
-                      }, ensure_ascii=True), flush=True)
+    print(
+        json.dumps(
+            {
+                "event": "summary",
+                "pass_rate": report["pass_rate"],
+                "repaired_pass_rate": report["repaired_pass_rate"],
+                "repair_lift": report["repair_lift"],
+                "by_case": {k: v["repaired_pass_rate"] for k, v in report["by_case"].items()},
+                "by_tongue": {k: v["repaired_pass_rate"] for k, v in report["by_tongue"].items()},
+                "gate_passed": gate_pass,
+                "report_path": str(out_path),
+            },
+            ensure_ascii=True,
+        ),
+        flush=True,
+    )
 
     del model, tokenizer
     gc.collect()
     if cuda:
         import torch
+
         torch.cuda.empty_cache()
 
     return 0 if gate_pass else 1

--- a/scripts/eval/sanity_phase3a_2_memory_binding.py
+++ b/scripts/eval/sanity_phase3a_2_memory_binding.py
@@ -30,7 +30,6 @@ DISPATCHER = Path(__file__).resolve().parents[1] / "eval" / "hf_job_v8_pre_phase
 spec = importlib.util.spec_from_file_location("d", DISPATCHER)
 mod = importlib.util.module_from_spec(spec)
 # Don't call main(); just import the helpers
-import torch.nn as nn
 spec.loader.exec_module(mod)
 
 DIM = 1024
@@ -43,7 +42,10 @@ def cosine(a: torch.Tensor, b: torch.Tensor) -> float:
 def main() -> int:
     helpers = [
         ("harmonic_wall", "(d_h: float, pd: float) -> float; returns 1/(1 + d_h + 2*pd)"),
-        ("phi_weight", "(tongue: str) -> float; returns {KO:1.00, AV:1.62, RU:2.62, CA:4.24, UM:6.85, DR:11.09}[tongue]"),
+        (
+            "phi_weight",
+            "(tongue: str) -> float; returns {KO:1.00, AV:1.62, RU:2.62, CA:4.24, UM:6.85, DR:11.09}[tongue]",
+        ),
         ("poincare_distance", "(u, v) -> float; returns arcosh(...)"),
         ("tongue_encode", "(text: str, tongue_code: str) -> list[int]; ..."),
         ("breath_phase", "(t: float) -> float; sin(2*pi*t/period)"),
@@ -69,7 +71,6 @@ def main() -> int:
         # Cosine vs each filler in vocab (vocab is stacked in helper order)
         cosines = []
         for j, (_, _other_filler) in enumerate(helpers):
-            target_filler = mod.deterministic_role_vector(f"filler::{name}::{filler}", DIM)
             # Note: filler vectors stored in vocab are namespaced by role::filler,
             # so vocab[j] corresponds to the j-th helper's filler under name
             cosines.append(cosine(u, vocab[j]))

--- a/scripts/eval/schrodinger_codewave_generator.py
+++ b/scripts/eval/schrodinger_codewave_generator.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Callable
 
 import numpy as np
 
@@ -110,9 +110,7 @@ def _build_indicator_masks(
     for f in forb:
         if re.fullmatch(r"[a-z0-9_ -]+", f):
             body = r"\s+".join(re.escape(part) for part in f.split())
-            forb_patterns.append(
-                re.compile(r"(?<![a-z0-9_])" + body + r"(?![a-z0-9_])")
-            )
+            forb_patterns.append(re.compile(r"(?<![a-z0-9_])" + body + r"(?![a-z0-9_])"))
         else:
             forb_patterns.append(re.compile(re.escape(f)))
 
@@ -163,9 +161,7 @@ def _evolve_wavefunction(
     return psi
 
 
-def _select_active_subset(
-    base_logits: np.ndarray, req_mask: np.ndarray, top_k: int
-) -> np.ndarray:
+def _select_active_subset(base_logits: np.ndarray, req_mask: np.ndarray, top_k: int) -> np.ndarray:
     """Indices of (top-K base-logit tokens) ∪ (required-marker tokens).
 
     The wave-evolution restriction set: large enough that the model's
@@ -209,9 +205,7 @@ def schrodinger_step_logits(
     p_base = p_base / np.maximum(p_base.sum(), 1e-30)
     psi = np.sqrt(p_base + 1e-30).astype(np.complex128)
 
-    V = (-cfg.alpha_required * sub_req + cfg.beta_forbidden * sub_forb).astype(
-        np.float64
-    )
+    V = (-cfg.alpha_required * sub_req + cfg.beta_forbidden * sub_forb).astype(np.float64)
     if cfg.include_log_p_base:
         V = V - np.log(p_base + 1e-30).astype(np.float64)
 
@@ -260,12 +254,8 @@ class SchrodingerLogitsProcessor:
         if np_scores.shape[0] != self.req_mask.shape[0]:
             if np_scores.shape[0] > self.req_mask.shape[0]:
                 pad = np_scores.shape[0] - self.req_mask.shape[0]
-                self.req_mask = np.concatenate(
-                    [self.req_mask, np.zeros(pad, dtype=self.req_mask.dtype)]
-                )
-                self.forb_mask = np.concatenate(
-                    [self.forb_mask, np.zeros(pad, dtype=self.forb_mask.dtype)]
-                )
+                self.req_mask = np.concatenate([self.req_mask, np.zeros(pad, dtype=self.req_mask.dtype)])
+                self.forb_mask = np.concatenate([self.forb_mask, np.zeros(pad, dtype=self.forb_mask.dtype)])
             else:
                 self.req_mask = self.req_mask[: np_scores.shape[0]]
                 self.forb_mask = self.forb_mask[: np_scores.shape[0]]
@@ -282,9 +272,7 @@ class SchrodingerLogitsProcessor:
         p_base = np.exp(shifted)
         p_base = p_base / np.maximum(p_base.sum(), 1e-30)
         psi = np.sqrt(p_base + 1e-30).astype(np.complex128)
-        V = (
-            -self.cfg.alpha_required * sub_req + self.cfg.beta_forbidden * sub_forb
-        ).astype(np.float64)
+        V = (-self.cfg.alpha_required * sub_req + self.cfg.beta_forbidden * sub_forb).astype(np.float64)
         if self.cfg.include_log_p_base:
             V = V - np.log(p_base + 1e-30).astype(np.float64)
 
@@ -343,9 +331,7 @@ class SchrodingerCodeWaveGenerator:
         else:
             device = "cuda" if torch.cuda.is_available() else "cpu"
         dtype = torch.float16 if device == "cuda" else torch.float32
-        model = AutoModelForCausalLM.from_pretrained(
-            self.model_id, torch_dtype=dtype, trust_remote_code=True
-        )
+        model = AutoModelForCausalLM.from_pretrained(self.model_id, torch_dtype=dtype, trust_remote_code=True)
         model.eval()
         model = model.to(device)
         self._tok = tok
@@ -407,9 +393,7 @@ def make_schrodinger_generator(
     cfg: SchrodingerConfig | None = None,
 ) -> Callable[[dict], str]:
     """Bake-off-compatible factory matching make_ar_generator signature."""
-    gen = SchrodingerCodeWaveGenerator(
-        model_id=model_id, max_new_tokens=max_new_tokens, cfg=cfg
-    )
+    gen = SchrodingerCodeWaveGenerator(model_id=model_id, max_new_tokens=max_new_tokens, cfg=cfg)
 
     def _call(prompt: dict) -> str:
         return gen.generate(prompt)

--- a/scripts/eval/score_adapter_frozen.py
+++ b/scripts/eval/score_adapter_frozen.py
@@ -12,15 +12,13 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import os
 import re
 import sys
 import time
-from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_BASE_MODEL = "Qwen/Qwen2.5-Coder-0.5B-Instruct"
@@ -52,9 +50,7 @@ class FileMetrics:
 
     @property
     def mean_nll(self) -> float:
-        return (
-            self.sum_nll / self.n_assistant_tokens if self.n_assistant_tokens else 0.0
-        )
+        return self.sum_nll / self.n_assistant_tokens if self.n_assistant_tokens else 0.0
 
     @property
     def perplexity(self) -> float:
@@ -78,9 +74,7 @@ def load_records(path: Path) -> list[dict[str, Any]]:
             except json.JSONDecodeError:
                 continue
             msgs = payload.get("messages")
-            if isinstance(msgs, list) and any(
-                m.get("role") == "assistant" for m in msgs
-            ):
+            if isinstance(msgs, list) and any(m.get("role") == "assistant" for m in msgs):
                 records.append({"messages": msgs, "meta": payload.get("meta", {})})
     return records
 
@@ -89,10 +83,6 @@ def build_supervised_inputs(
     tokenizer, messages: list[dict[str, str]], max_length: int
 ) -> tuple[list[int], list[int]] | None:
     """Returns (input_ids, labels) where non-assistant positions are -100."""
-    full_text = tokenizer.apply_chat_template(
-        messages, tokenize=False, add_generation_prompt=False
-    )
-
     # Split before each assistant turn so we can mask user/system tokens.
     # We rebuild a prefix containing all turns up to (but not including) each
     # assistant turn, tokenize the prefix and the prefix+assistant, and the
@@ -103,24 +93,16 @@ def build_supervised_inputs(
 
     for msg in messages:
         prefix_text = (
-            tokenizer.apply_chat_template(
-                prefix_messages, tokenize=False, add_generation_prompt=False
-            )
+            tokenizer.apply_chat_template(prefix_messages, tokenize=False, add_generation_prompt=False)
             if prefix_messages
             else ""
         )
         prefix_messages_with = prefix_messages + [msg]
-        with_text = tokenizer.apply_chat_template(
-            prefix_messages_with, tokenize=False, add_generation_prompt=False
-        )
+        with_text = tokenizer.apply_chat_template(prefix_messages_with, tokenize=False, add_generation_prompt=False)
 
         # Tokenize without special tokens to keep alignment honest; chat
         # template already injects role markers as text.
-        prefix_ids = (
-            tokenizer(prefix_text, add_special_tokens=False)["input_ids"]
-            if prefix_text
-            else []
-        )
+        prefix_ids = tokenizer(prefix_text, add_special_tokens=False)["input_ids"] if prefix_text else []
         with_ids = tokenizer(with_text, add_special_tokens=False)["input_ids"]
 
         if len(with_ids) <= len(prefix_ids):
@@ -160,9 +142,7 @@ def score_file(
     import torch
 
     for rec in records:
-        prepared = build_supervised_inputs(
-            tokenizer, rec["messages"], max_length=max_length
-        )
+        prepared = build_supervised_inputs(tokenizer, rec["messages"], max_length=max_length)
         if prepared is None:
             metrics.skipped += 1
             continue
@@ -171,9 +151,7 @@ def score_file(
         label_tensor = torch.tensor([labels], dtype=torch.long, device=device)
         attn = torch.ones_like(input_tensor)
         with torch.no_grad():
-            out = model(
-                input_ids=input_tensor, attention_mask=attn, labels=label_tensor
-            )
+            out = model(input_ids=input_tensor, attention_mask=attn, labels=label_tensor)
         n_supervised = int((label_tensor != -100).sum().item())
         # HF returns mean loss over supervised positions; multiply back.
         loss_val = float(out.loss.item())
@@ -184,9 +162,7 @@ def score_file(
     return metrics
 
 
-def load_model_and_tokenizer(
-    base_model: str, adapter: str, dtype_arg: str, use_4bit: bool
-):
+def load_model_and_tokenizer(base_model: str, adapter: str, dtype_arg: str, use_4bit: bool):
     import torch
     from peft import PeftModel
     from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -199,9 +175,7 @@ def load_model_and_tokenizer(
         else:
             dtype = torch.float32
     else:
-        dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[
-            dtype_arg
-        ]
+        dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[dtype_arg]
 
     tok = AutoTokenizer.from_pretrained(base_model, use_fast=True)
     if tok.pad_token is None:
@@ -283,9 +257,7 @@ def write_report(
     }
 
     json_path = out_dir / "report.json"
-    json_path.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
-    )
+    json_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
 
     md_lines = [
         f"# Frozen Eval — {adapter}",
@@ -321,9 +293,7 @@ def parse_args() -> argparse.Namespace:
         help="HF repo id OR local path to adapter; pass BASE to score the un-adapted base model",
     )
     p.add_argument("--base-model", default=DEFAULT_BASE_MODEL)
-    p.add_argument(
-        "--eval-dir", type=Path, default=PROJECT_ROOT / "training-data" / "sft"
-    )
+    p.add_argument("--eval-dir", type=Path, default=PROJECT_ROOT / "training-data" / "sft")
     p.add_argument(
         "--eval-files",
         nargs="*",
@@ -394,9 +364,7 @@ def main() -> int:
         "use_4bit": not args.no_4bit,
         "dtype": args.dtype,
     }
-    paths = write_report(
-        args.output_root, args.adapter, args.base_model, metrics, elapsed, runtime_meta
-    )
+    paths = write_report(args.output_root, args.adapter, args.base_model, metrics, elapsed, runtime_meta)
 
     total_records = sum(m.n_records for m in metrics)
     total_tokens = sum(m.n_assistant_tokens for m in metrics)

--- a/scripts/eval/score_aligned_foundations_cross_lane.py
+++ b/scripts/eval/score_aligned_foundations_cross_lane.py
@@ -52,13 +52,11 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from src.governance.aligned_foundations_cross_lane import (  # noqa: E402
     aligned_foundations_concept_verdict,
-    group_records_by_concept,
     reference_assistant_text,
     score_packet_compliance,
     system_prompt_text,
     user_prompt_text,
 )
-
 
 DEFAULT_HOLDOUT = "training-data/sft/drill_langues_full_holdout.sft.jsonl"
 DEFAULT_BASE = "Qwen/Qwen2.5-7B-Instruct"

--- a/scripts/eval/score_dsl_executable.py
+++ b/scripts/eval/score_dsl_executable.py
@@ -25,7 +25,7 @@ import time
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
@@ -163,12 +163,8 @@ def _build_prompt(messages: List[Dict[str, str]]) -> Tuple[List[Dict[str, str]],
     return prompt_msgs, expected
 
 
-def _generate(
-    model, tokenizer, prompt_msgs: List[Dict[str, str]], max_new_tokens: int = 96
-) -> str:
-    text = tokenizer.apply_chat_template(
-        prompt_msgs, tokenize=False, add_generation_prompt=True
-    )
+def _generate(model, tokenizer, prompt_msgs: List[Dict[str, str]], max_new_tokens: int = 96) -> str:
+    text = tokenizer.apply_chat_template(prompt_msgs, tokenize=False, add_generation_prompt=True)
     inputs = tokenizer(text, return_tensors="pt").to(model.device)
     n_in = inputs["input_ids"].shape[1]
     out = model.generate(
@@ -184,9 +180,7 @@ def _generate(
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument(
-        "--adapter", required=True, help="HF repo id or local path of the LoRA"
-    )
+    ap.add_argument("--adapter", required=True, help="HF repo id or local path of the LoRA")
     ap.add_argument("--base", default="Qwen/Qwen2.5-Coder-0.5B-Instruct")
     ap.add_argument(
         "--holdout",
@@ -250,9 +244,7 @@ def main() -> int:
             continue
         try:
             with torch.no_grad():
-                prediction = _generate(
-                    model, tokenizer, prompt_msgs, max_new_tokens=args.max_new_tokens
-                )
+                prediction = _generate(model, tokenizer, prompt_msgs, max_new_tokens=args.max_new_tokens)
         except Exception as exc:
             failure_counts["generation_error"] += 1
             sample_diags.append({"idx": idx, "error": str(exc)})
@@ -285,10 +277,7 @@ def main() -> int:
             )
 
     overall = (n_pass / n_total) if n_total else 0.0
-    cat_acc: Dict[str, float] = {
-        cat: (cat_pass[cat] / cat_total[cat]) if cat_total[cat] else 0.0
-        for cat in cat_total
-    }
+    cat_acc: Dict[str, float] = {cat: (cat_pass[cat] / cat_total[cat]) if cat_total[cat] else 0.0 for cat in cat_total}
 
     floors = (contract.get("must_pass_categories") or {}).get("floors") or {}
     floor_failures: List[str] = []
@@ -296,9 +285,7 @@ def main() -> int:
         if cat in cat_acc and cat_acc[cat] < floor:
             floor_failures.append(f"{cat}: {cat_acc[cat]:.3f} < {floor}")
 
-    gate = ((contract.get("metrics") or {}).get("executable_accuracy") or {}).get(
-        "gate"
-    ) or 0.50
+    gate = ((contract.get("metrics") or {}).get("executable_accuracy") or {}).get("gate") or 0.50
     overall_pass = overall >= gate
     floor_pass = not floor_failures
 

--- a/scripts/experiments/atomic_tokenizer_rename_benchmark.py
+++ b/scripts/experiments/atomic_tokenizer_rename_benchmark.py
@@ -30,12 +30,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.mathbac_cross_primary_atomic import (
-    ATOMIC_SEMANTIC_CLASSES,
-    TONGUES,
     _accuracy,
     _atomic_feature,
-    _feature_keys,
-    _l2_squared,
     _per_concept_accuracy,
     loo_nearest_concept,
 )

--- a/scripts/hf_jobs/run_bijective_tongue_gate_hf.py
+++ b/scripts/hf_jobs/run_bijective_tongue_gate_hf.py
@@ -33,8 +33,7 @@ import os
 import re
 import time
 from dataclasses import asdict, dataclass, field
-from typing import Any, Callable, Dict, List, Optional
-
+from typing import Any, Callable, Optional
 
 DEFAULT_MODEL = "issdandavis/scbe-coding-agent-qwen-merged-coding-model-v1"
 DEFAULT_TONGUES = ("AV",)
@@ -116,10 +115,7 @@ CASES: tuple[PromptCase, ...] = (
 SEEDS: dict[str, str] = {
     "reverse_string": "def reverse_string(s: str) -> str:\n    return s[::-1]\n",
     "safe_divide": (
-        "def safe_divide(a: float, b: float):\n"
-        "    if b == 0:\n"
-        "        return None\n"
-        "    return a / b\n"
+        "def safe_divide(a: float, b: float):\n" "    if b == 0:\n" "        return None\n" "    return a / b\n"
     ),
     "parse_json_name": (
         "import json\n"
@@ -269,9 +265,7 @@ def build_back_prompt(other_source: str, tongue: str, seed: str = "") -> str:
         joined = "\n".join(f"    {i}" for i in imports)
         contract_lines.append(f"  Required imports (must appear at top of code block):\n{joined}")
     contract_block = (
-        "\nThe Python output MUST satisfy this canonical contract:\n"
-        + "\n".join(contract_lines)
-        + "\n"
+        "\nThe Python output MUST satisfy this canonical contract:\n" + "\n".join(contract_lines) + "\n"
         if contract_lines
         else ""
     )
@@ -552,7 +546,7 @@ def main() -> int:
             )
         elapsed = time.time() - t0
         response = tokenizer.decode(
-            output[0][inputs["input_ids"].shape[1]:],
+            output[0][inputs["input_ids"].shape[1] :],
             skip_special_tokens=True,
         )
         return response, elapsed

--- a/scripts/hf_jobs/run_paired_coding_gate_hf.py
+++ b/scripts/hf_jobs/run_paired_coding_gate_hf.py
@@ -33,8 +33,7 @@ import os
 import re
 import time
 from dataclasses import asdict, dataclass, field
-from typing import Any, Callable, Dict, List, Optional
-
+from typing import Any, Callable, Optional
 
 DEFAULT_MODEL = "issdandavis/scbe-coding-agent-qwen-merged-coding-model-v1"
 
@@ -345,9 +344,7 @@ def _load_model(model_id: str, token: Optional[str]):
 def _make_generate(tokenizer, model, max_new_tokens: int) -> GenerateFn:
     def generate(prompt: str) -> tuple[str, float]:
         messages = [{"role": "user", "content": prompt}]
-        rendered = tokenizer.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
-        )
+        rendered = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
         inputs = tokenizer(rendered, return_tensors="pt").to(model.device)
         t0 = time.time()
         with torch.no_grad():
@@ -359,7 +356,7 @@ def _make_generate(tokenizer, model, max_new_tokens: int) -> GenerateFn:
             )
         elapsed = time.time() - t0
         response = tokenizer.decode(
-            output[0][inputs["input_ids"].shape[1]:],
+            output[0][inputs["input_ids"].shape[1] :],
             skip_special_tokens=True,
         )
         return response, elapsed

--- a/scripts/kaggle_auto/kernel_template.py
+++ b/scripts/kaggle_auto/kernel_template.py
@@ -2,7 +2,7 @@
 """Auto-generated Kaggle kernel - SCBE Polly Training.
 Config is injected via the KERNEL_CONFIG dict at the top."""
 
-import subprocess, sys, json, os, math, re
+import subprocess, sys, json, os
 from collections import Counter
 
 os.environ.setdefault("PYTHONIOENCODING", "utf-8")

--- a/scripts/repo_reorg/plan_repo_shape.py
+++ b/scripts/repo_reorg/plan_repo_shape.py
@@ -16,7 +16,6 @@ and performs the actual ``git mv`` for the docs phase only.
 from __future__ import annotations
 
 import json
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 

--- a/scripts/revenue/build_workflow_snapshot_autopromo.py
+++ b/scripts/revenue/build_workflow_snapshot_autopromo.py
@@ -14,7 +14,6 @@ import argparse
 import json
 import os
 import subprocess
-import sys
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone

--- a/scripts/server_node.py
+++ b/scripts/server_node.py
@@ -20,7 +20,6 @@ Environment:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -32,7 +31,7 @@ import sys
 import time
 from dataclasses import dataclass, asdict
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 # Add project root to path
 ROOT = Path(__file__).parent.parent
@@ -87,6 +86,7 @@ class ServiceStatus:
 # Process management
 # ---------------------------------------------------------------------------
 
+
 def _pid_file(name: str) -> Path:
     return PID_DIR / f"{name}.pid"
 
@@ -105,11 +105,16 @@ def _start_service(name: str, cfg: dict) -> Optional[int]:
         return None
 
     cmd = [
-        sys.executable, "-m", "uvicorn",
+        sys.executable,
+        "-m",
+        "uvicorn",
         cfg["module"],
-        "--host", HOST,
-        "--port", str(port),
-        "--log-level", "info",
+        "--host",
+        HOST,
+        "--port",
+        str(port),
+        "--log-level",
+        "info",
     ]
 
     log_file = PID_DIR / f"{name}.log"
@@ -138,8 +143,7 @@ def _stop_service(name: str) -> bool:
     pid = int(pf.read_text().strip())
     try:
         if sys.platform == "win32":
-            subprocess.run(["taskkill", "/F", "/PID", str(pid)],
-                           capture_output=True, timeout=5)
+            subprocess.run(["taskkill", "/F", "/PID", str(pid)], capture_output=True, timeout=5)
         else:
             os.kill(pid, signal.SIGTERM)
         pf.unlink(missing_ok=True)
@@ -188,6 +192,7 @@ def _write_status(statuses: Dict[str, ServiceStatus]) -> None:
 # Commands
 # ---------------------------------------------------------------------------
 
+
 def cmd_start(api_only: bool = False) -> None:
     """Start all services."""
     PID_DIR.mkdir(parents=True, exist_ok=True)
@@ -225,8 +230,12 @@ def cmd_start(api_only: bool = False) -> None:
     # Print quick-start commands
     print("  Quick access:")
     print(f"    Browser tools: curl http://localhost:8003/tools")
-    print(f"    Scrape a page: curl -X POST http://localhost:8003/tools/scrape_page -H 'Content-Type: application/json' -d '{{\"url\":\"https://example.com\"}}'")
-    print(f"    Research:      curl -X POST http://localhost:8003/workflow/research -H 'Content-Type: application/json' -d '{{\"query\":\"your topic\"}}'")
+    print(
+        f"    Scrape a page: curl -X POST http://localhost:8003/tools/scrape_page -H 'Content-Type: application/json' -d '{{\"url\":\"https://example.com\"}}'"
+    )
+    print(
+        f"    Research:      curl -X POST http://localhost:8003/workflow/research -H 'Content-Type: application/json' -d '{{\"query\":\"your topic\"}}'"
+    )
     print()
 
 
@@ -255,6 +264,7 @@ def cmd_stop() -> None:
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+
 
 def main():
     args = sys.argv[1:]

--- a/scripts/system/build_model_portfolio_board.py
+++ b/scripts/system/build_model_portfolio_board.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 from collections import Counter, defaultdict
 from datetime import datetime, timezone

--- a/scripts/system/colab_worker_lease.py
+++ b/scripts/system/colab_worker_lease.py
@@ -731,7 +731,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
         return 0
-    artifact = provision_colab_worker(
+    provision_colab_worker(
         notebook_query=args.notebook,
         mission_id=mission_id,
         worker_id=worker_id,

--- a/scripts/system/consolidate_kaggle_kernels.py
+++ b/scripts/system/consolidate_kaggle_kernels.py
@@ -14,12 +14,10 @@ import csv
 import json
 import re
 import subprocess
-import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
-
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUT = REPO_ROOT / "docs" / "map-room" / "KAGGLE_KERNEL_CONSOLIDATION_2026-04-25.md"
@@ -249,7 +247,9 @@ def main() -> int:
     parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
     parser.add_argument("--json-out", type=Path, default=DEFAULT_JSON)
     parser.add_argument("--pull-root", type=Path, default=DEFAULT_PULL_ROOT)
-    parser.add_argument("--pull-archive", action="store_true", help="Pull all kernel source/metadata into local archive.")
+    parser.add_argument(
+        "--pull-archive", action="store_true", help="Pull all kernel source/metadata into local archive."
+    )
     parser.add_argument(
         "--apply-delete-candidates",
         action="store_true",

--- a/scripts/system/dispatch_aligned_foundations_hf_job.py
+++ b/scripts/system/dispatch_aligned_foundations_hf_job.py
@@ -26,15 +26,12 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_PROFILE = (
-    REPO_ROOT / "config" / "model_training" / "aligned-foundations-qwen-primary.json"
-)
+DEFAULT_PROFILE = REPO_ROOT / "config" / "model_training" / "aligned-foundations-qwen-primary.json"
 ARTIFACT_ROOT = REPO_ROOT / "artifacts" / "hf_aligned_foundations_jobs"
 ENV_FILE = REPO_ROOT / "config" / "connector_oauth" / ".env.connector.oauth"
 CROSS_LANE_SRC = REPO_ROOT / "src" / "governance" / "aligned_foundations_cross_lane.py"
@@ -595,11 +592,7 @@ def build_packet(
     profile = _load_profile(profile_path)
     execution = profile.get("execution") or {}
     hub_cfg = profile.get("hub") or {}
-    resolved_dataset_repo = (
-        dataset_repo
-        or str(hub_cfg.get("dataset_repo", "")).strip()
-        or DEFAULT_DATASET_REPO
-    )
+    resolved_dataset_repo = dataset_repo or str(hub_cfg.get("dataset_repo", "")).strip() or DEFAULT_DATASET_REPO
     stamp = _utc_stamp()
     run_dir = artifact_root / str(profile["profile_id"]) / stamp
     script_path = run_dir / "train_aligned_foundations_hf.py"
@@ -738,9 +731,7 @@ def upload_training_dataset(profile: dict[str, Any], dataset_repo: str) -> list[
             "--commit-message",
             f"Update SCBE aligned-foundations data {name}",
         ]
-        result = subprocess.run(
-            command, cwd=str(REPO_ROOT), capture_output=True, text=True, check=False
-        )
+        result = subprocess.run(command, cwd=str(REPO_ROOT), capture_output=True, text=True, check=False)
         uploads.append(
             {
                 "name": str(name),
@@ -766,9 +757,7 @@ def upload_training_dataset(profile: dict[str, Any], dataset_repo: str) -> list[
         "--commit-message",
         "Update SCBE aligned-foundations cross-lane primitives",
     ]
-    result = subprocess.run(
-        command, cwd=str(REPO_ROOT), capture_output=True, text=True, check=False
-    )
+    result = subprocess.run(command, cwd=str(REPO_ROOT), capture_output=True, text=True, check=False)
     uploads.append(
         {
             "name": CROSS_LANE_FILENAME,
@@ -778,9 +767,7 @@ def upload_training_dataset(profile: dict[str, Any], dataset_repo: str) -> list[
         }
     )
     if result.returncode != 0:
-        raise RuntimeError(
-            f"Cross-lane primitives upload failed: {result.stderr.strip()}"
-        )
+        raise RuntimeError(f"Cross-lane primitives upload failed: {result.stderr.strip()}")
     return uploads
 
 

--- a/scripts/system/dispatch_coding_agent_hf_job.py
+++ b/scripts/system/dispatch_coding_agent_hf_job.py
@@ -9,15 +9,12 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_PROFILE = (
-    REPO_ROOT / "config" / "model_training" / "coding-agent-qwen-smoke.json"
-)
+DEFAULT_PROFILE = REPO_ROOT / "config" / "model_training" / "coding-agent-qwen-smoke.json"
 ARTIFACT_ROOT = REPO_ROOT / "artifacts" / "hf_coding_agent_jobs"
 ENV_FILE = REPO_ROOT / "config" / "connector_oauth" / ".env.connector.oauth"
 
@@ -55,9 +52,7 @@ def _load_profile(path: Path) -> dict[str, Any]:
 def _count_jsonl(path: Path) -> int:
     if not path.exists():
         return 0
-    return sum(
-        1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
-    )
+    return sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
 
 
 def _dataset_rows(profile: dict[str, Any], split: str) -> list[dict[str, Any]]:
@@ -463,11 +458,7 @@ def build_packet(
             "flavor": selected_flavor,
             "timeout": selected_timeout,
             "cli": shutil.which("hf") or "",
-            "token_present": bool(
-                os.environ.get(
-                    str((profile.get("hub") or {}).get("token_env", "HF_TOKEN")), ""
-                )
-            ),
+            "token_present": bool(os.environ.get(str((profile.get("hub") or {}).get("token_env", "HF_TOKEN")), "")),
         },
         "command": command,
         "dispatched": False,
@@ -531,9 +522,7 @@ def upload_training_dataset(profile: dict[str, Any]) -> list[dict[str, Any]]:
             "--commit-message",
             f"Update SCBE coding agent data {name}",
         ]
-        result = subprocess.run(
-            command, cwd=str(REPO_ROOT), capture_output=True, text=True, check=False
-        )
+        result = subprocess.run(command, cwd=str(REPO_ROOT), capture_output=True, text=True, check=False)
         uploads.append(
             {
                 "name": str(name),
@@ -543,9 +532,7 @@ def upload_training_dataset(profile: dict[str, Any]) -> list[dict[str, Any]]:
             }
         )
         if result.returncode != 0:
-            raise RuntimeError(
-                f"Dataset upload failed for {name}: {result.stderr.strip()}"
-            )
+            raise RuntimeError(f"Dataset upload failed for {name}: {result.stderr.strip()}")
     return uploads
 
 

--- a/scripts/system/geoseal_coding_training_system.py
+++ b/scripts/system/geoseal_coding_training_system.py
@@ -9,7 +9,6 @@ import json
 import os
 import re
 import subprocess
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -285,7 +284,10 @@ def assess_job_health(inspect_summary: dict[str, Any], logs_payload: dict[str, A
     summary = (logs_payload or {}).get("summary") or {}
     has_training_signal = bool(
         tail
-        or (isinstance(summary, dict) and (summary.get("latest_loss") or summary.get("progress") or summary.get("training_complete")))
+        or (
+            isinstance(summary, dict)
+            and (summary.get("latest_loss") or summary.get("progress") or summary.get("training_complete"))
+        )
     )
     if stage == "RUNNING" and logs_payload is not None and not has_training_signal and logs_returncode == 0:
         return {
@@ -375,7 +377,9 @@ def status(manifest: dict[str, Any], profile_id: str | None, job_id: str | None,
                 first = inspected[0]
                 if isinstance(first, dict):
                     inspect_summary = {
-                        "stage": ((first.get("status") or {}) if isinstance(first.get("status"), dict) else {}).get("stage"),
+                        "stage": ((first.get("status") or {}) if isinstance(first.get("status"), dict) else {}).get(
+                            "stage"
+                        ),
                         "url": first.get("url"),
                         "flavor": first.get("flavor"),
                         "created_at": first.get("created_at"),
@@ -578,7 +582,9 @@ if __name__ == "__main__":
 '''
 
 
-def dispatch_smoke_eval(manifest: dict[str, Any], profile_id: str | None, adapter_repo: str | None, timeout: str) -> dict[str, Any]:
+def dispatch_smoke_eval(
+    manifest: dict[str, Any], profile_id: str | None, adapter_repo: str | None, timeout: str
+) -> dict[str, Any]:
     plan = smoke_eval_plan(manifest, profile_id, adapter_repo)
     out_dir = Path(plan["output_dir"])
     script_path = out_dir / "smoke_eval_hf.py"

--- a/scripts/system/polly_service.py
+++ b/scripts/system/polly_service.py
@@ -6,11 +6,9 @@ Uses Gemini as the primary reasoning engine with deterministic keyword fallback.
 
 from __future__ import annotations
 
-import json
 import os
 import re
-import urllib.parse
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 
 def _env_get(key: str, default: str = "") -> str:
@@ -71,17 +69,41 @@ INTENT_PATTERNS = {
         "route": "/pricing.html",
     },
     "cx_guardrail": {
-        "patterns": [r"refund", r"guardrail", r"cx", r"customer support", r"chatbot liability", r"moffatt", r"policy enforcement"],
+        "patterns": [
+            r"refund",
+            r"guardrail",
+            r"cx",
+            r"customer support",
+            r"chatbot liability",
+            r"moffatt",
+            r"policy enforcement",
+        ],
         "response": "The CX Refund Guardrail stops chatbots from promising refunds they can't deliver. It's policy-enforcement middleware between your LLM and customer. $500-5K/month. https://aethermoore.com/cx-guardrail.html",
         "route": "/cx-guardrail.html",
     },
     "iso_42001": {
-        "patterns": [r"iso.?42001", r"audit", r"compliance", r"regulatory", r"eu ai act", r"sr 11-7", r"governance framework"],
+        "patterns": [
+            r"iso.?42001",
+            r"audit",
+            r"compliance",
+            r"regulatory",
+            r"eu ai act",
+            r"sr 11-7",
+            r"governance framework",
+        ],
         "response": "ISO 42001 Evidence-as-a-Service provides adversarial testing, risk reports, drift monitoring, and audit response dossiers. $50-150K/year. https://aethermoore.com/iso-42001.html",
         "route": "/iso-42001.html",
     },
     "red_team": {
-        "patterns": [r"red team", r"penetration", r"adversarial", r"attack", r"security test", r"vulnerability", r"threat"],
+        "patterns": [
+            r"red team",
+            r"penetration",
+            r"adversarial",
+            r"attack",
+            r"security test",
+            r"vulnerability",
+            r"threat",
+        ],
         "response": "AI Red Team as a Service runs 6,000+ adversarial tests against your LLM application. Branded PDF report and remediation roadmap. $5-50K/engagement. https://aethermoore.com/red-team.html",
         "route": "/red-team.html",
     },
@@ -152,11 +174,17 @@ def classify_intent(text: str) -> tuple[str, dict]:
 
 # Multi-provider LLM support
 LLM_CONFIGS = [
-    ("GEMINI_API_KEY", "gemini-1.5-flash", "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}", "google"),
+    (
+        "GEMINI_API_KEY",
+        "gemini-1.5-flash",
+        "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}",
+        "google",
+    ),
     ("OPENAI_API_KEY", "gpt-4o-mini", "https://api.openai.com/v1/chat/completions", "openai"),
     ("GROQ_API_KEY", "llama-3.1-8b-instant", "https://api.groq.com/openai/v1/chat/completions", "openai"),
     ("ANTHROPIC_API_KEY", "claude-3-haiku-20240307", "https://api.anthropic.com/v1/messages", "anthropic"),
 ]
+
 
 async def _llm_generate(
     system_prompt: str,
@@ -235,8 +263,8 @@ async def generate_response(message: str, thinking: bool = False) -> dict:
     mode_label = "DEEP THINKING" if thinking else "STANDARD"
     mode_instruction = (
         "Think step by step. Analyze the user's request carefully, identify the domain, then provide a thorough, well-reasoned response. Use 2-4 paragraphs."
-        if thinking else
-        "Be concise and direct. Route first, explain second. Use 1-2 sentences for simple questions, 1 short paragraph for complex ones."
+        if thinking
+        else "Be concise and direct. Route first, explain second. Use 1-2 sentences for simple questions, 1 short paragraph for complex ones."
     )
     system = f"""{POLLY_LORE}
 
@@ -281,6 +309,7 @@ If you don't know something, say "I don't have that" — never invent.
 
 TAVILY_API_KEY = _env_get("TAVILY_API_KEY", "")
 
+
 async def web_search(query: str, max_results: int = 5) -> dict:
     """Search the web using Tavily API (free tier: 1000 req/month)."""
     if not TAVILY_API_KEY:
@@ -288,6 +317,7 @@ async def web_search(query: str, max_results: int = 5) -> dict:
 
     try:
         import httpx
+
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(
                 "https://api.tavily.com/search",
@@ -305,11 +335,13 @@ async def web_search(query: str, max_results: int = 5) -> dict:
             data = resp.json()
             results = []
             for r in data.get("results", []):
-                results.append({
-                    "title": r.get("title", ""),
-                    "url": r.get("url", ""),
-                    "snippet": r.get("content", "")[:300],
-                })
+                results.append(
+                    {
+                        "title": r.get("title", ""),
+                        "url": r.get("url", ""),
+                        "snippet": r.get("content", "")[:300],
+                    }
+                )
 
             return {
                 "query": query,
@@ -325,10 +357,12 @@ async def web_search(query: str, max_results: int = 5) -> dict:
 #  Email via Proton SMTP
 # ---------------------------------------------------------------------------
 
+
 async def send_email_from_chat(to: str, subject: str, body: str) -> dict:
     """Send an email using the existing Proton SMTP service."""
     try:
         from scripts.system.email_service import send_contact_notification
+
         result = send_contact_notification(
             name="Polly Assistant",
             email=to,
@@ -347,6 +381,7 @@ async def send_email_from_chat(to: str, subject: str, body: str) -> dict:
 
 SLACK_WEBHOOK_URL = _env_get("SLACK_WEBHOOK_URL", "")
 
+
 async def notify_slack(message: str, channel: Optional[str] = None) -> dict:
     """Send a notification to Slack via webhook."""
     if not SLACK_WEBHOOK_URL:
@@ -354,6 +389,7 @@ async def notify_slack(message: str, channel: Optional[str] = None) -> dict:
 
     try:
         import httpx
+
         payload = {"text": f"🤖 Polly: {message}"}
         if channel:
             payload["channel"] = channel
@@ -370,6 +406,7 @@ async def notify_slack(message: str, channel: Optional[str] = None) -> dict:
 # ---------------------------------------------------------------------------
 #  Legacy Service Interface (API-compatible)
 # ---------------------------------------------------------------------------
+
 
 async def chat(message: str, context: str = "site", thinking: bool = False) -> dict:
     """Handle a chat message and return a response."""

--- a/scripts/system/push_hf_card_constrained_decoding_2026_04_30.py
+++ b/scripts/system/push_hf_card_constrained_decoding_2026_04_30.py
@@ -11,15 +11,16 @@ pushing again.
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 
 try:
     from dotenv import load_dotenv
 except ImportError:
+
     def load_dotenv(*_args, **_kwargs):
         return False
+
 
 from huggingface_hub import HfApi, hf_hub_download
 

--- a/scripts/system/repo_cleanliness_audit.py
+++ b/scripts/system/repo_cleanliness_audit.py
@@ -13,7 +13,7 @@ import argparse
 import json
 import subprocess
 from collections import Counter, defaultdict
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
@@ -136,9 +136,7 @@ def normalize_status_path(raw: str) -> str:
 
 
 def path_matches(path: str, prefixes: Iterable[str]) -> bool:
-    return any(
-        path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes
-    )
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes)
 
 
 def classify_path(path: str) -> str:
@@ -213,9 +211,7 @@ def summarize(rows: list[StatusRow], repo_root: Path) -> dict[str, object]:
         "repo_root": str(repo_root),
         "total_dirty_paths": len(rows),
         "status_counts": dict(sorted(status_counts.items())),
-        "bucket_counts": {
-            bucket: payload["count"] for bucket, payload in by_bucket.items()
-        },
+        "bucket_counts": {bucket: payload["count"] for bucket, payload in by_bucket.items()},
         "buckets": by_bucket,
         "next_actions": [
             "stage source/test/config changes in scoped commits only",
@@ -235,9 +231,7 @@ def write_report(payload: dict[str, object], output: Path | None) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Audit repo cleanliness without modifying files."
-    )
+    parser = argparse.ArgumentParser(description="Audit repo cleanliness without modifying files.")
     parser.add_argument(
         "--repo-root",
         default=None,
@@ -278,10 +272,7 @@ def main() -> int:
             print(f"[repo-cleanliness] report={output}")
 
     failed = False
-    if (
-        args.max_dirty is not None
-        and int(payload["total_dirty_paths"]) > args.max_dirty
-    ):
+    if args.max_dirty is not None and int(payload["total_dirty_paths"]) > args.max_dirty:
         failed = True
     unclassified = int(payload["bucket_counts"].get("needs_manual_classification", 0))
     if unclassified > args.max_unclassified:

--- a/scripts/training/build_agentic_seed.py
+++ b/scripts/training/build_agentic_seed.py
@@ -18,7 +18,7 @@ import argparse
 import json
 import random
 from pathlib import Path
-from typing import List, Dict
+from typing import Dict
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_OUTPUT = PROJECT_ROOT / "training-data" / "agentic_coding" / "seed_dataset.jsonl"
@@ -35,15 +35,29 @@ ATOMIC_TASKS = [
         "task": "Add a new Polly endpoint for phone calls",
         "files": ["scripts/aetherbrowser/api_server.py"],
         "steps": [
-            {"thought": "I need to add a Twilio call endpoint. First, let me check the existing Polly endpoints to follow the pattern.", 
-             "tool": "read_file", "args": {"path": "scripts/aetherbrowser/api_server.py", "offset": 2130, "lines": 30}},
-            {"thought": "I see the pattern: define a Pydantic payload class, then add an @app.post endpoint. I'll add a PollyCallPayload and a /v1/polly/call endpoint.",
-             "tool": "apply_diff", "args": {"path": "scripts/aetherbrowser/api_server.py", 
-              "diff": "+class PollyCallPayload(BaseModel):\n+    phone: str\n+    name: Optional[str] = ''\n+\n+@app.post('/v1/polly/call')\n+async def polly_call(payload: PollyCallPayload):\n+    ..."}},
-            {"thought": "Let me verify the endpoint is syntactically correct by checking the file.",
-             "tool": "read_file", "args": {"path": "scripts/aetherbrowser/api_server.py", "offset": 2160, "lines": 40}},
-            {"thought": "Looks good. Let me run a quick syntax check.",
-             "tool": "terminal", "args": {"command": "python -m py_compile scripts/aetherbrowser/api_server.py"}},
+            {
+                "thought": "I need to add a Twilio call endpoint. First, let me check the existing Polly endpoints to follow the pattern.",
+                "tool": "read_file",
+                "args": {"path": "scripts/aetherbrowser/api_server.py", "offset": 2130, "lines": 30},
+            },
+            {
+                "thought": "I see the pattern: define a Pydantic payload class, then add an @app.post endpoint. I'll add a PollyCallPayload and a /v1/polly/call endpoint.",
+                "tool": "apply_diff",
+                "args": {
+                    "path": "scripts/aetherbrowser/api_server.py",
+                    "diff": "+class PollyCallPayload(BaseModel):\n+    phone: str\n+    name: Optional[str] = ''\n+\n+@app.post('/v1/polly/call')\n+async def polly_call(payload: PollyCallPayload):\n+    ...",
+                },
+            },
+            {
+                "thought": "Let me verify the endpoint is syntactically correct by checking the file.",
+                "tool": "read_file",
+                "args": {"path": "scripts/aetherbrowser/api_server.py", "offset": 2160, "lines": 40},
+            },
+            {
+                "thought": "Looks good. Let me run a quick syntax check.",
+                "tool": "terminal",
+                "args": {"command": "python -m py_compile scripts/aetherbrowser/api_server.py"},
+            },
             {"thought": "Syntax check passed. The endpoint is ready.", "tool": "finish", "args": {"status": "success"}},
         ],
         "tongues": ["KO", "CA", "DR"],
@@ -55,14 +69,26 @@ ATOMIC_TASKS = [
         "task": "Fix the missing favicon on index.html",
         "files": ["index.html"],
         "steps": [
-            {"thought": "The user says index.html is missing a favicon. Let me check the head section.",
-             "tool": "read_file", "args": {"path": "index.html", "offset": 1, "lines": 20}},
-            {"thought": "I see the head section but no favicon link. I need to add `<link rel=\"icon\" ...>` after the charset meta.",
-             "tool": "apply_diff", "args": {"path": "index.html", 
-              "diff": "+  <link rel=\"icon\" type=\"image/svg+xml\" href=\"/favicon.svg\">"}},
-            {"thought": "Let me verify the favicon file exists.",
-             "tool": "terminal", "args": {"command": "ls favicon.svg"}},
-            {"thought": "Favicon exists and link is added. Task complete.", "tool": "finish", "args": {"status": "success"}},
+            {
+                "thought": "The user says index.html is missing a favicon. Let me check the head section.",
+                "tool": "read_file",
+                "args": {"path": "index.html", "offset": 1, "lines": 20},
+            },
+            {
+                "thought": 'I see the head section but no favicon link. I need to add `<link rel="icon" ...>` after the charset meta.',
+                "tool": "apply_diff",
+                "args": {"path": "index.html", "diff": '+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">'},
+            },
+            {
+                "thought": "Let me verify the favicon file exists.",
+                "tool": "terminal",
+                "args": {"command": "ls favicon.svg"},
+            },
+            {
+                "thought": "Favicon exists and link is added. Task complete.",
+                "tool": "finish",
+                "args": {"status": "success"},
+            },
         ],
         "tongues": ["KO", "AV"],
         "layers": [1, 3, 14],
@@ -73,15 +99,31 @@ ATOMIC_TASKS = [
         "task": "Run tests after adding the Twilio endpoint",
         "files": ["scripts/aetherbrowser/api_server.py", "tests/"],
         "steps": [
-            {"thought": "I need to verify the new Twilio endpoint doesn't break existing tests.",
-             "tool": "terminal", "args": {"command": "python -m pytest tests/ -v --tb=short"}},
-            {"thought": "Tests are failing with ImportError for 'twilio'. I need to check if twilio is in requirements.",
-             "tool": "read_file", "args": {"path": "requirements.txt", "offset": 1, "lines": 50}},
-            {"thought": "Twilio is not in requirements. I need to add it.",
-             "tool": "apply_diff", "args": {"path": "requirements.txt", "diff": "+twilio>=9.0.0"}},
-            {"thought": "Now let me install and re-run tests.",
-             "tool": "terminal", "args": {"command": "pip install twilio && python -m pytest tests/ -v"}},
-            {"thought": "All tests pass. The endpoint is properly integrated.", "tool": "finish", "args": {"status": "success"}},
+            {
+                "thought": "I need to verify the new Twilio endpoint doesn't break existing tests.",
+                "tool": "terminal",
+                "args": {"command": "python -m pytest tests/ -v --tb=short"},
+            },
+            {
+                "thought": "Tests are failing with ImportError for 'twilio'. I need to check if twilio is in requirements.",
+                "tool": "read_file",
+                "args": {"path": "requirements.txt", "offset": 1, "lines": 50},
+            },
+            {
+                "thought": "Twilio is not in requirements. I need to add it.",
+                "tool": "apply_diff",
+                "args": {"path": "requirements.txt", "diff": "+twilio>=9.0.0"},
+            },
+            {
+                "thought": "Now let me install and re-run tests.",
+                "tool": "terminal",
+                "args": {"command": "pip install twilio && python -m pytest tests/ -v"},
+            },
+            {
+                "thought": "All tests pass. The endpoint is properly integrated.",
+                "tool": "finish",
+                "args": {"status": "success"},
+            },
         ],
         "tongues": ["RU", "CA", "KO"],
         "layers": [1, 5, 7, 10, 14],
@@ -92,14 +134,29 @@ ATOMIC_TASKS = [
         "task": "Refactor the polly_service.py to add error handling",
         "files": ["scripts/system/polly_service.py"],
         "steps": [
-            {"thought": "I need to add better error handling to polly_service.py. Let me first read the current implementation.",
-             "tool": "read_file", "args": {"path": "scripts/system/polly_service.py", "offset": 1, "lines": 100}},
-            {"thought": "I see the chat() function. It needs try/except around the LLM call and a fallback to deterministic responses.",
-             "tool": "apply_diff", "args": {"path": "scripts/system/polly_service.py",
-              "diff": " async def chat(message, context='site', thinking=False):\n+    try:\n         result = await _llm_call(message, context, thinking)\n+    except Exception as e:\n+        logger.warning('LLM failed: %s', e)\n+        result = deterministic_fallback(message)\n+    return result"}},
-            {"thought": "Let me verify the syntax.",
-             "tool": "terminal", "args": {"command": "python -m py_compile scripts/system/polly_service.py"}},
-            {"thought": "Syntax is valid. The error handling is in place.", "tool": "finish", "args": {"status": "success"}},
+            {
+                "thought": "I need to add better error handling to polly_service.py. Let me first read the current implementation.",
+                "tool": "read_file",
+                "args": {"path": "scripts/system/polly_service.py", "offset": 1, "lines": 100},
+            },
+            {
+                "thought": "I see the chat() function. It needs try/except around the LLM call and a fallback to deterministic responses.",
+                "tool": "apply_diff",
+                "args": {
+                    "path": "scripts/system/polly_service.py",
+                    "diff": " async def chat(message, context='site', thinking=False):\n+    try:\n         result = await _llm_call(message, context, thinking)\n+    except Exception as e:\n+        logger.warning('LLM failed: %s', e)\n+        result = deterministic_fallback(message)\n+    return result",
+                },
+            },
+            {
+                "thought": "Let me verify the syntax.",
+                "tool": "terminal",
+                "args": {"command": "python -m py_compile scripts/system/polly_service.py"},
+            },
+            {
+                "thought": "Syntax is valid. The error handling is in place.",
+                "tool": "finish",
+                "args": {"status": "success"},
+            },
         ],
         "tongues": ["RU", "UM", "CA"],
         "layers": [1, 3, 7, 12, 14],
@@ -110,17 +167,33 @@ ATOMIC_TASKS = [
         "task": "Add a new page to the website and link it from the nav",
         "files": ["new-page.html", "index.html"],
         "steps": [
-            {"thought": "I need to create a new status page and add it to the navigation. Let me check the current nav structure first.",
-             "tool": "read_file", "args": {"path": "index.html", "offset": 40, "lines": 20}},
-            {"thought": "I see the nav pattern. Let me create the new page first.",
-             "tool": "write_file", "args": {"path": "status.html", 
-              "content": "<!DOCTYPE html>...<a href='index.html'>Home</a>..."}},
-            {"thought": "Now add the link to the nav in index.html.",
-             "tool": "apply_diff", "args": {"path": "index.html", 
-              "diff": "+        <a href='status.html'>Status</a>"}},
-            {"thought": "Let me verify both files are valid HTML.",
-             "tool": "terminal", "args": {"command": "python -c \"import html.parser; list(html.parser.HTMLParser().feed(open('status.html').read()))\""}},
-            {"thought": "Both files are valid. The new page is linked.", "tool": "finish", "args": {"status": "success"}},
+            {
+                "thought": "I need to create a new status page and add it to the navigation. Let me check the current nav structure first.",
+                "tool": "read_file",
+                "args": {"path": "index.html", "offset": 40, "lines": 20},
+            },
+            {
+                "thought": "I see the nav pattern. Let me create the new page first.",
+                "tool": "write_file",
+                "args": {"path": "status.html", "content": "<!DOCTYPE html>...<a href='index.html'>Home</a>..."},
+            },
+            {
+                "thought": "Now add the link to the nav in index.html.",
+                "tool": "apply_diff",
+                "args": {"path": "index.html", "diff": "+        <a href='status.html'>Status</a>"},
+            },
+            {
+                "thought": "Let me verify both files are valid HTML.",
+                "tool": "terminal",
+                "args": {
+                    "command": "python -c \"import html.parser; list(html.parser.HTMLParser().feed(open('status.html').read()))\""
+                },
+            },
+            {
+                "thought": "Both files are valid. The new page is linked.",
+                "tool": "finish",
+                "args": {"status": "success"},
+            },
         ],
         "tongues": ["KO", "AV", "DR"],
         "layers": [1, 3, 5, 14],
@@ -131,16 +204,34 @@ ATOMIC_TASKS = [
         "task": "Debug why the Arena Debate button doesn't work",
         "files": ["arena.html", "arena.js"],
         "steps": [
-            {"thought": "The user says the Debate button doesn't work. Let me check if the button exists in the HTML.",
-             "tool": "read_file", "args": {"path": "arena.html", "offset": 230, "lines": 20}},
-            {"thought": "I don't see a debateBtn in the HTML. But arena.js references it. Let me check the JS.",
-             "tool": "read_file", "args": {"path": "arena.js", "offset": 90, "lines": 20}},
-            {"thought": "The JS references debateBtn but the HTML only has dealBtn, relayBtn, deliberateBtn, shareBtn. I need to add the missing button.",
-             "tool": "apply_diff", "args": {"path": "arena.html",
-              "diff": "+                <button class=\"btn-dm\" id=\"debateBtn\" onclick=\"debateDuel()\">Debate</button>"}},
-            {"thought": "Let me verify the button is properly placed and the JS function exists.",
-             "tool": "read_file", "args": {"path": "arena.html", "offset": 230, "lines": 20}},
-            {"thought": "The button is added and the debateDuel function already exists in arena.js. The fix is complete.", "tool": "finish", "args": {"status": "success"}},
+            {
+                "thought": "The user says the Debate button doesn't work. Let me check if the button exists in the HTML.",
+                "tool": "read_file",
+                "args": {"path": "arena.html", "offset": 230, "lines": 20},
+            },
+            {
+                "thought": "I don't see a debateBtn in the HTML. But arena.js references it. Let me check the JS.",
+                "tool": "read_file",
+                "args": {"path": "arena.js", "offset": 90, "lines": 20},
+            },
+            {
+                "thought": "The JS references debateBtn but the HTML only has dealBtn, relayBtn, deliberateBtn, shareBtn. I need to add the missing button.",
+                "tool": "apply_diff",
+                "args": {
+                    "path": "arena.html",
+                    "diff": '+                <button class="btn-dm" id="debateBtn" onclick="debateDuel()">Debate</button>',
+                },
+            },
+            {
+                "thought": "Let me verify the button is properly placed and the JS function exists.",
+                "tool": "read_file",
+                "args": {"path": "arena.html", "offset": 230, "lines": 20},
+            },
+            {
+                "thought": "The button is added and the debateDuel function already exists in arena.js. The fix is complete.",
+                "tool": "finish",
+                "args": {"status": "success"},
+            },
         ],
         "tongues": ["RU", "CA", "KO"],
         "layers": [1, 3, 7, 14],
@@ -151,14 +242,28 @@ ATOMIC_TASKS = [
         "task": "Commit the agentic coding scaffolding to git",
         "files": ["scripts/training/", "training-data/agentic_coding/"],
         "steps": [
-            {"thought": "I need to commit the new training scripts. Let me check what changed.",
-             "tool": "terminal", "args": {"command": "git status --short"}},
-            {"thought": "I see new files in scripts/training/ and training-data/agentic_coding/. Let me stage them.",
-             "tool": "terminal", "args": {"command": "git add scripts/training/ training-data/agentic_coding/ config/model_training/"}},
-            {"thought": "Now commit with a descriptive message.",
-             "tool": "terminal", "args": {"command": "git commit -m 'feat(training): add agentic coding scaffolding\\n\\n- generate_agentic_sft.py: Convert SKILL.md to SFT pairs\\n- build_agentic_seed.py: Synthetic trajectory generator\\n- ingest_open_datasets.py: R2E-Gym + CodeActInstruct importer\\n- trajectory_logger.py: AetherBrowse session exporter\\n- agentic-coding-qlora.json: Training config'"}},
-            {"thought": "Commit successful. Now push to the remote.",
-             "tool": "terminal", "args": {"command": "git push origin feature/agentic-coding-scaffold"}},
+            {
+                "thought": "I need to commit the new training scripts. Let me check what changed.",
+                "tool": "terminal",
+                "args": {"command": "git status --short"},
+            },
+            {
+                "thought": "I see new files in scripts/training/ and training-data/agentic_coding/. Let me stage them.",
+                "tool": "terminal",
+                "args": {"command": "git add scripts/training/ training-data/agentic_coding/ config/model_training/"},
+            },
+            {
+                "thought": "Now commit with a descriptive message.",
+                "tool": "terminal",
+                "args": {
+                    "command": "git commit -m 'feat(training): add agentic coding scaffolding\\n\\n- generate_agentic_sft.py: Convert SKILL.md to SFT pairs\\n- build_agentic_seed.py: Synthetic trajectory generator\\n- ingest_open_datasets.py: R2E-Gym + CodeActInstruct importer\\n- trajectory_logger.py: AetherBrowse session exporter\\n- agentic-coding-qlora.json: Training config'"
+                },
+            },
+            {
+                "thought": "Commit successful. Now push to the remote.",
+                "tool": "terminal",
+                "args": {"command": "git push origin feature/agentic-coding-scaffold"},
+            },
             {"thought": "Push successful. PR created at #1145.", "tool": "finish", "args": {"status": "success"}},
         ],
         "tongues": ["KO"],
@@ -170,13 +275,24 @@ ATOMIC_TASKS = [
         "task": "Add Open Graph tags to a page missing them",
         "files": ["profile.html"],
         "steps": [
-            {"thought": "I need to add OG tags to profile.html. Let me check what it currently has.",
-             "tool": "read_file", "args": {"path": "profile.html", "offset": 1, "lines": 15}},
-            {"thought": "No OG tags present. I'll add them after the description meta.",
-             "tool": "apply_diff", "args": {"path": "profile.html",
-              "diff": "+  <meta property=\"og:title\" content=\"Issac's Profile | aethermoore.com\">\n+  <meta property=\"og:description\" content=\"Issac Davis — builder of SCBE-AETHERMOORE.\">\n+  <meta property=\"og:type\" content=\"profile\">\n+  <meta property=\"og:url\" content=\"https://aethermoore.com/profile.html\">\n+  <meta property=\"og:image\" content=\"https://aethermoore.com/hero.webp\">"}},
-            {"thought": "OG tags added. Let me do a quick syntax check.",
-             "tool": "terminal", "args": {"command": "grep -c 'og:' profile.html"}},
+            {
+                "thought": "I need to add OG tags to profile.html. Let me check what it currently has.",
+                "tool": "read_file",
+                "args": {"path": "profile.html", "offset": 1, "lines": 15},
+            },
+            {
+                "thought": "No OG tags present. I'll add them after the description meta.",
+                "tool": "apply_diff",
+                "args": {
+                    "path": "profile.html",
+                    "diff": '+  <meta property="og:title" content="Issac\'s Profile | aethermoore.com">\n+  <meta property="og:description" content="Issac Davis — builder of SCBE-AETHERMOORE.">\n+  <meta property="og:type" content="profile">\n+  <meta property="og:url" content="https://aethermoore.com/profile.html">\n+  <meta property="og:image" content="https://aethermoore.com/hero.webp">',
+                },
+            },
+            {
+                "thought": "OG tags added. Let me do a quick syntax check.",
+                "tool": "terminal",
+                "args": {"command": "grep -c 'og:' profile.html"},
+            },
             {"thought": "5 OG tags found. Task complete.", "tool": "finish", "args": {"status": "success"}},
         ],
         "tongues": ["AV", "KO"],
@@ -188,13 +304,26 @@ ATOMIC_TASKS = [
         "task": "Update the sitemap.xml after adding new pages",
         "files": ["sitemap.xml"],
         "steps": [
-            {"thought": "I need to add the new status.html and contact.html pages to the sitemap.",
-             "tool": "read_file", "args": {"path": "sitemap.xml", "offset": 1, "lines": 30}},
-            {"thought": "I see the sitemap structure. I'll add the new URLs before the closing </urlset>.",
-             "tool": "apply_diff", "args": {"path": "sitemap.xml",
-              "diff": "+  <url>\n+    <loc>https://aethermoore.com/status.html</loc>\n+    <lastmod>2026-04-23</lastmod>\n+  </url>\n+  <url>\n+    <loc>https://aethermoore.com/contact.html</loc>\n+    <lastmod>2026-04-23</lastmod>\n+  </url>"}},
-            {"thought": "Let me validate the XML.",
-             "tool": "terminal", "args": {"command": "python -c \"import xml.etree.ElementTree as ET; ET.parse('sitemap.xml')\" && echo 'Valid XML'"}},
+            {
+                "thought": "I need to add the new status.html and contact.html pages to the sitemap.",
+                "tool": "read_file",
+                "args": {"path": "sitemap.xml", "offset": 1, "lines": 30},
+            },
+            {
+                "thought": "I see the sitemap structure. I'll add the new URLs before the closing </urlset>.",
+                "tool": "apply_diff",
+                "args": {
+                    "path": "sitemap.xml",
+                    "diff": "+  <url>\n+    <loc>https://aethermoore.com/status.html</loc>\n+    <lastmod>2026-04-23</lastmod>\n+  </url>\n+  <url>\n+    <loc>https://aethermoore.com/contact.html</loc>\n+    <lastmod>2026-04-23</lastmod>\n+  </url>",
+                },
+            },
+            {
+                "thought": "Let me validate the XML.",
+                "tool": "terminal",
+                "args": {
+                    "command": "python -c \"import xml.etree.ElementTree as ET; ET.parse('sitemap.xml')\" && echo 'Valid XML'"
+                },
+            },
             {"thought": "XML is valid. Sitemap updated.", "tool": "finish", "args": {"status": "success"}},
         ],
         "tongues": ["KO", "AV"],
@@ -206,18 +335,34 @@ ATOMIC_TASKS = [
         "task": "Add a cookie consent banner to all HTML pages",
         "files": ["*.html"],
         "steps": [
-            {"thought": "I need to add a cookie banner to all pages. Let me first create the banner script.",
-             "tool": "write_file", "args": {"path": "static/cookie-consent.js",
-              "content": "(function(){...cookie banner code...})();"}},
-            {"thought": "Now I need to add the script tag to all HTML files. Let me find them first.",
-             "tool": "terminal", "args": {"command": "find . -name '*.html' -not -path '*/.git/*' | head -10"}},
-            {"thought": "I'll use a Python script to batch-add the script tag before </body>.",
-             "tool": "write_file", "args": {"path": "scripts/add_cookie_banner.py",
-              "content": "#!/usr/bin/env python3\nimport os, re\nfor root, dirs, files in os.walk('.'):\n    for f in files:\n        if f.endswith('.html'):\n            path = os.path.join(root, f)\n            with open(path) as fh: content = fh.read()\n            if 'cookie-consent.js' not in content:\n                content = content.replace('</body>', '  <script src=\"/static/cookie-consent.js\" defer></script>\\n</body>')\n                with open(path, 'w') as fh: fh.write(content)\n                print(f'Updated: {path}')\n"}},
-            {"thought": "Run the script.",
-             "tool": "terminal", "args": {"command": "python3 scripts/add_cookie_banner.py"}},
-            {"thought": "Let me verify one file.",
-             "tool": "terminal", "args": {"command": "grep 'cookie-consent' index.html"}},
+            {
+                "thought": "I need to add a cookie banner to all pages. Let me first create the banner script.",
+                "tool": "write_file",
+                "args": {"path": "static/cookie-consent.js", "content": "(function(){...cookie banner code...})();"},
+            },
+            {
+                "thought": "Now I need to add the script tag to all HTML files. Let me find them first.",
+                "tool": "terminal",
+                "args": {"command": "find . -name '*.html' -not -path '*/.git/*' | head -10"},
+            },
+            {
+                "thought": "I'll use a Python script to batch-add the script tag before </body>.",
+                "tool": "write_file",
+                "args": {
+                    "path": "scripts/add_cookie_banner.py",
+                    "content": "#!/usr/bin/env python3\nimport os, re\nfor root, dirs, files in os.walk('.'):\n    for f in files:\n        if f.endswith('.html'):\n            path = os.path.join(root, f)\n            with open(path) as fh: content = fh.read()\n            if 'cookie-consent.js' not in content:\n                content = content.replace('</body>', '  <script src=\"/static/cookie-consent.js\" defer></script>\\n</body>')\n                with open(path, 'w') as fh: fh.write(content)\n                print(f'Updated: {path}')\n",
+                },
+            },
+            {
+                "thought": "Run the script.",
+                "tool": "terminal",
+                "args": {"command": "python3 scripts/add_cookie_banner.py"},
+            },
+            {
+                "thought": "Let me verify one file.",
+                "tool": "terminal",
+                "args": {"command": "grep 'cookie-consent' index.html"},
+            },
             {"thought": "Banner added to all pages. Task complete.", "tool": "finish", "args": {"status": "success"}},
         ],
         "tongues": ["KO", "AV", "UM"],
@@ -231,6 +376,7 @@ ATOMIC_TASKS = [
 #  Trajectory formatter
 # ---------------------------------------------------------------------------
 
+
 def format_trajectory(task: Dict) -> Dict:
     """Convert an atomic task into a chat-format SFT trajectory."""
     messages = [
@@ -240,36 +386,31 @@ def format_trajectory(task: Dict) -> Dict:
                 "You are SCBE-Coder, an agentic coding assistant. "
                 "You use tools to read files, edit code, run commands, and verify results. "
                 "Always think before acting. Always verify before finishing."
-            )
+            ),
         },
-        {
-            "role": "user",
-            "content": task["task"]
-        },
+        {"role": "user", "content": task["task"]},
     ]
-    
+
     for step in task["steps"]:
         thought = step.get("thought", "")
         tool = step.get("tool", "")
         args = step.get("args", {})
-        
+
         if tool == "finish":
-            messages.append({
-                "role": "assistant",
-                "content": f"<think>\n{thought}\n</think>\n\n<finish status=\"{args.get('status', 'success')}\" />"
-            })
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": f"<think>\n{thought}\n</think>\n\n<finish status=\"{args.get('status', 'success')}\" />",
+                }
+            )
         else:
             args_str = json.dumps(args, ensure_ascii=False)
-            messages.append({
-                "role": "assistant",
-                "content": f"<think>\n{thought}\n</think>\n\n<{tool}>\n{args_str}\n</{tool}>"
-            })
+            messages.append(
+                {"role": "assistant", "content": f"<think>\n{thought}\n</think>\n\n<{tool}>\n{args_str}\n</{tool}>"}
+            )
             # Simulate tool result
-            messages.append({
-                "role": "tool",
-                "content": f"[{tool}] Executed with args: {args_str[:200]}"
-            })
-    
+            messages.append({"role": "tool", "content": f"[{tool}] Executed with args: {args_str[:200]}"})
+
     return {
         "id": task["id"],
         "category": "agentic-trajectory",
@@ -284,7 +425,7 @@ def format_trajectory(task: Dict) -> Dict:
             "layers": task.get("layers", [1, 14]),
             "difficulty": task.get("difficulty", "medium"),
             "turn_count": len(messages) - 2,
-        }
+        },
     }
 
 
@@ -292,7 +433,7 @@ def augment_task(task: Dict, variation: int) -> Dict:
     """Create a variation of a task with different wording or files."""
     augmented = dict(task)
     augmented["id"] = f"{task['id']}-v{variation}"
-    
+
     # Paraphrase the task
     paraphrases = {
         "Add": ["Implement", "Create", "Set up", "Build"],
@@ -300,18 +441,16 @@ def augment_task(task: Dict, variation: int) -> Dict:
         "Update": ["Refresh", "Modify", "Adjust", "Change"],
         "Debug": ["Troubleshoot", "Investigate", "Diagnose", "Fix"],
     }
-    
+
     words = task["task"].split()
     if words and words[0] in paraphrases:
         words[0] = random.choice(paraphrases[words[0]])
         augmented["task"] = " ".join(words)
-    
+
     # Slightly vary layers
-    augmented["layers"] = sorted(list(set(
-        [l + random.choice([-1, 0, 1]) for l in task["layers"]]
-    )))
+    augmented["layers"] = sorted(list(set([l + random.choice([-1, 0, 1]) for l in task["layers"]])))
     augmented["layers"] = [max(1, min(14, l)) for l in augmented["layers"]]
-    
+
     return augmented
 
 
@@ -319,43 +458,42 @@ def augment_task(task: Dict, variation: int) -> Dict:
 #  Main
 # ---------------------------------------------------------------------------
 
+
 def main():
     parser = argparse.ArgumentParser(description="Build agentic coding seed dataset")
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
-    parser.add_argument("--count", type=int, default=100,
-                        help="Target number of trajectories (includes augmentations)")
-    parser.add_argument("--augmentations", type=int, default=2,
-                        help="Variations per base task")
+    parser.add_argument("--count", type=int, default=100, help="Target number of trajectories (includes augmentations)")
+    parser.add_argument("--augmentations", type=int, default=2, help="Variations per base task")
     args = parser.parse_args()
-    
+
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    
+
     trajectories = []
-    
+
     # Base tasks
     for task in ATOMIC_TASKS:
         trajectories.append(format_trajectory(task))
-        
+
         # Augmentations
         for v in range(1, args.augmentations + 1):
             aug = augment_task(task, v)
             trajectories.append(format_trajectory(aug))
-    
+
     # If we need more, duplicate with random modifications from base tasks
     while len(trajectories) < args.count:
         base = random.choice(ATOMIC_TASKS)
         aug = augment_task(base, len(trajectories))
         trajectories.append(format_trajectory(aug))
-    
+
     # Trim to exact count
-    trajectories = trajectories[:args.count]
-    
-    with open(args.output, 'w', encoding='utf-8') as f:
+    trajectories = trajectories[: args.count]
+
+    with open(args.output, "w", encoding="utf-8") as f:
         for t in trajectories:
-            f.write(json.dumps(t, ensure_ascii=False) + '\n')
-    
+            f.write(json.dumps(t, ensure_ascii=False) + "\n")
+
     print(f"Wrote {len(trajectories)} agentic trajectories to {args.output}")
-    
+
     # Stats
     difficulties = {}
     tongues = {}
@@ -364,7 +502,7 @@ def main():
         difficulties[d] = difficulties.get(d, 0) + 1
         for tongue in t["metadata"]["tongues"]:
             tongues[tongue] = tongues.get(tongue, 0) + 1
-    
+
     print(f"\nDifficulty: {difficulties}")
     print(f"Tongues: {tongues}")
     print(f"Avg turns: {sum(t['metadata']['turn_count'] for t in trajectories) / len(trajectories):.1f}")

--- a/scripts/training_data/build_coding_raw_code_sft.py
+++ b/scripts/training_data/build_coding_raw_code_sft.py
@@ -26,7 +26,7 @@ import hashlib
 import json
 import random
 import shutil
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -311,9 +311,7 @@ def generate_rows(
       ~45% of total rows -- the v6e-bumped target.
     """
     if not 1 <= marker_negative_variants <= len(MARKER_NEGATIVE_VARIANTS):
-        raise ValueError(
-            f"marker_negative_variants must be in [1, {len(MARKER_NEGATIVE_VARIANTS)}]"
-        )
+        raise ValueError(f"marker_negative_variants must be in [1, {len(MARKER_NEGATIVE_VARIANTS)}]")
     samples = load_coding_system_full_samples() + load_external_poly_samples()
     if not samples:
         return []
@@ -363,9 +361,7 @@ def generate_rows(
         active_variants = MARKER_NEGATIVE_VARIANTS[:marker_negative_variants]
         for s in samples:
             for variant_fn in active_variants:
-                rows.append(
-                    make_row(variant_fn(s), s.code, scenario="marker_negative", sample=s, split=split)
-                )
+                rows.append(make_row(variant_fn(s), s.code, scenario="marker_negative", sample=s, split=split))
 
     return rows
 
@@ -517,9 +513,7 @@ def build(
 ) -> dict[str, int]:
     train_path, eval_path, manifest_path, kaggle_root = _shard_paths_for(shard_suffix)
     rng = random.Random(seed)
-    rows = generate_rows(
-        rng, split="train", marker_negative_variants=marker_negative_variants
-    )
+    rows = generate_rows(rng, split="train", marker_negative_variants=marker_negative_variants)
     if not rows:
         raise RuntimeError(
             "No source rows loaded. Check that coding_system_full_v1_train.sft.jsonl and "

--- a/scripts/training_data/build_geoshell_pair_agent_sft.py
+++ b/scripts/training_data/build_geoshell_pair_agent_sft.py
@@ -14,7 +14,6 @@ import argparse
 import hashlib
 import json
 import sys
-from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any

--- a/scripts/wildlife/packs.py
+++ b/scripts/wildlife/packs.py
@@ -9,7 +9,7 @@ See docs/specs/WILDLIFE_BOARD_v1.md for the full spec.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 

--- a/scripts/wildlife/triage_review.py
+++ b/scripts/wildlife/triage_review.py
@@ -17,7 +17,6 @@ import json
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- remove CodeQL-surfaced unused Python imports, locals, and globals
- apply Black only to the touched cleanup files after import removal
- keep behavior unchanged; this is scanner-noise and hygiene cleanup

## Validation
- python -m ruff check --isolated --select F401,F841 <CodeQL unused-symbol files>
- python -m black --line-length 120 --check <CodeQL unused-symbol files>
- python -m py_compile <CodeQL unused-symbol files>
- python -m pytest tests/api/test_polly_widget_contract.py tests/api/test_polly_workers.py tests/test_script_artifact_redaction.py tests/benchmark/test_operator_agent_bus_eval.py -q
- python scripts/security/code_governance_gate.py check-push
- git diff --check

## Rollback
Revert this commit to restore the previous import/local declarations and formatting.