### PR TITLE
fix(lint): mark unused memory-binding filler

### DIFF
--- a/scripts/eval/sanity_phase3a_2_memory_binding.py
+++ b/scripts/eval/sanity_phase3a_2_memory_binding.py
@@ -65,7 +65,7 @@ def main() -> int:
     print(f"{'helper':<22} {'self_cos':<10} {'best_other':<12} {'top_match':<22} {'OK'}")
     print("-" * 80)
     n_correct = 0
-    for i, (name, filler) in enumerate(helpers):
+    for i, (name, _filler) in enumerate(helpers):
         role_vec = mod.deterministic_role_vector(f"role::{name}", DIM)
         u = mod.circular_correlation_torch(role_vec, memory)
         # Cosine vs each filler in vocab (vocab is stacked in helper order)


### PR DESCRIPTION
## Summary
- fix the one Ruff B007 issue left by the merged unused-symbol cleanup
- rename the unused loop value to `_filler` in the memory-binding sanity script

## Validation
- python -m ruff check --config ruff.toml
- python -m black --line-length 120 --check scripts/eval/sanity_phase3a_2_memory_binding.py
- python -m pytest tests/benchmark/test_operator_agent_bus_eval.py -q

## Rollback
Revert this commit to restore the prior loop variable name.