### PR TITLE
fix(codeql): clean warning-class findings

### DIFF
--- a/scripts/agents/safe_apply.py
+++ b/scripts/agents/safe_apply.py
@@ -140,15 +140,18 @@ def _remove_worktree(worktree: Path) -> None:
     try:
         _git(["worktree", "remove", "--force", str(worktree)], cwd=REPO_ROOT, check=False, timeout=30)
     except Exception:
+        # Best-effort cleanup; the caller must not fail because teardown did.
         pass
     if worktree.exists():
         try:
             shutil.rmtree(worktree, ignore_errors=True)
         except Exception:
+            # Best-effort cleanup; ignore stale or already-removed worktrees.
             pass
     try:
         _git(["worktree", "prune"], cwd=REPO_ROOT, check=False, timeout=30)
     except Exception:
+        # Best-effort cleanup; pruning failure should not mask apply results.
         pass
 
 
@@ -214,6 +217,7 @@ def apply_patch_safely(
         try:
             patch_file.unlink()
         except Exception:
+            # Best-effort cleanup of the temporary patch file.
             pass
 
         try:
@@ -261,6 +265,7 @@ def apply_patch_safely(
             try:
                 main_patch.unlink()
             except Exception:
+                # Best-effort cleanup of the temporary patch file.
                 pass
         return result
     finally:

--- a/scripts/benchmark/agentic_benchmark_ladder.py
+++ b/scripts/benchmark/agentic_benchmark_ladder.py
@@ -90,6 +90,7 @@ def _parse_max_level(query: str) -> int:
             if isinstance(obj, dict) and "max_level" in obj:
                 return max(0, min(7, int(obj["max_level"])))
         except json.JSONDecodeError:
+            # Plain-text config files are allowed; fall back to default level.
             pass
     return 1
 

--- a/scripts/benchmark/workflow_completion_checklist.py
+++ b/scripts/benchmark/workflow_completion_checklist.py
@@ -95,6 +95,7 @@ def _extract_stats(stats_text: str) -> dict[str, Any]:
             fields[key] = int(raw)
             continue
         except ValueError:
+            # Not an integer; try float parsing before preserving raw text.
             pass
         try:
             fields[key] = float(raw)

--- a/scripts/kaggle_auto/kernel_template.py
+++ b/scripts/kaggle_auto/kernel_template.py
@@ -375,7 +375,7 @@ try:
     tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL, use_fast=False)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
-except BaseException as exc:
+except (Exception, SystemExit) as exc:
     fail_status("loading_tokenizer", exc)
 
 
@@ -497,7 +497,7 @@ try:
         quant_config = None
         compute_dtype = torch.float32
         load_kwargs = {"torch_dtype": torch.float32, "device_map": "cpu"}
-except BaseException as exc:
+except (Exception, SystemExit) as exc:
     fail_status("checking_device", exc)
 
 try:

--- a/scripts/security/native_liboqs_smoke.py
+++ b/scripts/security/native_liboqs_smoke.py
@@ -14,7 +14,6 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -60,7 +59,7 @@ def main() -> int:
 
     try:
         import oqs
-    except BaseException as exc:  # liboqs-python may raise SystemExit while bootstrapping.
+    except (Exception, SystemExit) as exc:  # liboqs-python may raise SystemExit while bootstrapping.
         _die(f"could not import oqs: {exc!r}")
 
     kem_algorithm = _first_enabled(

--- a/scripts/server_node.py
+++ b/scripts/server_node.py
@@ -120,14 +120,17 @@ def _start_service(name: str, cfg: dict) -> Optional[int]:
     log_file = PID_DIR / f"{name}.log"
     log_handle = open(log_file, "w")
 
-    proc = subprocess.Popen(
-        cmd,
-        cwd=str(ROOT),
-        stdout=log_handle,
-        stderr=subprocess.STDOUT,
-        env={**os.environ, "PYTHONPATH": str(ROOT)},
-        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
-    )
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(ROOT),
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            env={**os.environ, "PYTHONPATH": str(ROOT)},
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
+        )
+    finally:
+        log_handle.close()
 
     _pid_file(name).write_text(str(proc.pid))
     logger.info("%s: started (pid=%d, port=%d)", name, proc.pid, port)

--- a/scripts/system/colab_workflow_catalog.py
+++ b/scripts/system/colab_workflow_catalog.py
@@ -11,7 +11,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CANONICAL_REPO = "issdandavis/SCBE-AETHERMOORE"
 CANONICAL_BRANCH = "main"
@@ -122,11 +121,7 @@ def _normalize(value: str) -> str:
 
 
 def _github_repo() -> str:
-    return (
-        CANONICAL_REPO.replace("\\", "/")
-        if CANONICAL_REPO
-        else "issdandavis/SCBE-AETHERMOORE"
-    )
+    return CANONICAL_REPO.replace("\\", "/") if CANONICAL_REPO else "issdandavis/SCBE-AETHERMOORE"
 
 
 def _github_branch() -> str:
@@ -147,6 +142,7 @@ def _github_branch() -> str:
         if result.returncode == 0 and branch:
             return branch
     except OSError:
+        # Git metadata is optional in packaged/catalog-only environments.
         pass
     return CANONICAL_BRANCH
 
@@ -214,12 +210,8 @@ def _print_text_list() -> int:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Catalog SCBE Colab notebooks and derived Colab URLs"
-    )
-    parser.add_argument(
-        "action", nargs="?", default="list", choices=["list", "show", "url"]
-    )
+    parser = argparse.ArgumentParser(description="Catalog SCBE Colab notebooks and derived Colab URLs")
+    parser.add_argument("action", nargs="?", default="list", choices=["list", "show", "url"])
     parser.add_argument("name", nargs="?", default="")
     parser.add_argument("--json", action="store_true", help="Emit JSON")
     args = parser.parse_args()

--- a/scripts/system/monetization_connector_push.py
+++ b/scripts/system/monetization_connector_push.py
@@ -31,9 +31,7 @@ from src.security.secret_store import get_secret
 
 try:
     from scripts.gumroad_publish import GumroadPublisher, PRODUCTS, STRIPE_LINKS
-except (
-    ModuleNotFoundError
-):  # pragma: no cover - depends on optional local sales tooling
+except ModuleNotFoundError:  # pragma: no cover - depends on optional local sales tooling
     GumroadPublisher = None
     PRODUCTS = {}
     STRIPE_LINKS = {}
@@ -135,6 +133,7 @@ def _build_offers(include_gumroad: bool) -> List[Dict[str, Any]]:
                     if name:
                         gumroad_map[name] = str(row.get("short_url", "")).strip()
         except Exception:
+            # Optional Gumroad enrichment should not block core offer packaging.
             pass
 
     offers: List[Dict[str, Any]] = [
@@ -226,12 +225,8 @@ async def _dispatch(
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Push latest leads + offers to n8n/Zapier monetization connectors."
-    )
-    parser.add_argument(
-        "--leads-json", default="", help="Optional leads JSON file path."
-    )
+    parser = argparse.ArgumentParser(description="Push latest leads + offers to n8n/Zapier monetization connectors.")
+    parser.add_argument("--leads-json", default="", help="Optional leads JSON file path.")
     parser.add_argument(
         "--top-leads",
         type=int,
@@ -252,9 +247,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--no-route-zapier", dest="route_zapier", action="store_false")
     parser.set_defaults(route_zapier=True)
 
-    parser.add_argument(
-        "--dry-run", action="store_true", help="Do not send connector traffic."
-    )
+    parser.add_argument("--dry-run", action="store_true", help="Do not send connector traffic.")
     parser.add_argument(
         "--output-dir",
         default="artifacts/monetization",
@@ -268,11 +261,7 @@ def main() -> int:
     day = _utc_now().strftime("%Y%m%d")
     run_id = f"monetization-connector-push-{_utc_stamp()}"
 
-    lead_path = (
-        Path(args.leads_json).resolve()
-        if args.leads_json.strip()
-        else _latest_lead_file()
-    )
+    lead_path = Path(args.leads_json).resolve() if args.leads_json.strip() else _latest_lead_file()
     leads: List[Dict[str, Any]] = []
     if lead_path and lead_path.exists():
         loaded = _load_json(lead_path, default=[])

--- a/scripts/system/news_pipeline.py
+++ b/scripts/system/news_pipeline.py
@@ -89,61 +89,61 @@ TONGUE_NAMES: dict[str, str] = {
 
 # Canonical tongue for each news source (which tongue "speaks" this data)
 SOURCE_TONGUE: dict[str, str] = {
-    "hn": "KO",       # Kor'aelin — precise/flow (Python/tech)
-    "arxiv": "CA",    # Cassisivadan — symbolic/math
-    "reddit": "AV",   # Avali — reactive/social
-    "darpa": "RU",    # Runethic — ethical/structured
-    "sam": "RU",      # Runethic — governance
-    "bbc": "AV",      # Avali — broadcast/context
-    "aje": "UM",      # Umbroth — veiled/multilingual
-    "dw": "RU",       # Runethic — structured
-    "f24": "AV",      # Avali — broadcast
-    "nhk": "UM",      # Umbroth — Japanese-adjacent
-    "toi": "AV",      # Avali — broadcast
-    "cgtn": "CA",     # Cassisivadan — state/systematic
-    "gdelt": "DR",    # Draumric — archival structure
-    "guardian": "KO", # Kor'aelin — precise reporting
-    "newsdata": "AV", # Avali
-    "worldnews": "DR", # Draumric
+    "hn": "KO",  # Kor'aelin — precise/flow (Python/tech)
+    "arxiv": "CA",  # Cassisivadan — symbolic/math
+    "reddit": "AV",  # Avali — reactive/social
+    "darpa": "RU",  # Runethic — ethical/structured
+    "sam": "RU",  # Runethic — governance
+    "bbc": "AV",  # Avali — broadcast/context
+    "aje": "UM",  # Umbroth — veiled/multilingual
+    "dw": "RU",  # Runethic — structured
+    "f24": "AV",  # Avali — broadcast
+    "nhk": "UM",  # Umbroth — Japanese-adjacent
+    "toi": "AV",  # Avali — broadcast
+    "cgtn": "CA",  # Cassisivadan — state/systematic
+    "gdelt": "DR",  # Draumric — archival structure
+    "guardian": "KO",  # Kor'aelin — precise reporting
+    "newsdata": "AV",  # Avali
+    "worldnews": "DR",  # Draumric
 }
 
 # Geographic coordinates (lat, lon, ISO-3166 alpha-2)
 SOURCE_COORDS: dict[str, tuple[float, float, str]] = {
-    "bbc":      (51.509, -0.118,  "GB"),
-    "aje":      (25.285,  51.531, "QA"),
-    "dw":       (52.520,  13.405, "DE"),
-    "f24":      (48.864,   2.349, "FR"),
-    "nhk":      (35.689, 139.692, "JP"),
-    "toi":      (19.076,  72.878, "IN"),
-    "cgtn":     (39.909, 116.397, "CN"),
-    "gdelt":    (0.000,    0.000, "XX"),  # global
-    "hn":       (37.387, -122.060, "US"),
-    "arxiv":    (40.730,  -73.935, "US"),
-    "reddit":   (37.535, -121.960, "US"),
-    "darpa":    (38.895,  -77.037, "US"),
-    "sam":      (38.895,  -77.037, "US"),
-    "guardian": (51.533,  -0.122,  "GB"),
+    "bbc": (51.509, -0.118, "GB"),
+    "aje": (25.285, 51.531, "QA"),
+    "dw": (52.520, 13.405, "DE"),
+    "f24": (48.864, 2.349, "FR"),
+    "nhk": (35.689, 139.692, "JP"),
+    "toi": (19.076, 72.878, "IN"),
+    "cgtn": (39.909, 116.397, "CN"),
+    "gdelt": (0.000, 0.000, "XX"),  # global
+    "hn": (37.387, -122.060, "US"),
+    "arxiv": (40.730, -73.935, "US"),
+    "reddit": (37.535, -121.960, "US"),
+    "darpa": (38.895, -77.037, "US"),
+    "sam": (38.895, -77.037, "US"),
+    "guardian": (51.533, -0.122, "GB"),
     "newsdata": (37.387, -122.060, "US"),
-    "worldnews": (0.000,   0.000,  "XX"),
+    "worldnews": (0.000, 0.000, "XX"),
 }
 
 REGION_COORDS: dict[str, tuple[float, float, str]] = {
-    "us":     (38.895,  -77.037, "US"),
-    "eu":     (50.110,    8.682, "DE"),
-    "asia":   (35.689,  139.692, "JP"),
-    "me":     (25.204,   55.270, "AE"),
-    "africa": (-1.286,   36.817, "KE"),
-    "global": (0.000,     0.000, "XX"),
+    "us": (38.895, -77.037, "US"),
+    "eu": (50.110, 8.682, "DE"),
+    "asia": (35.689, 139.692, "JP"),
+    "me": (25.204, 55.270, "AE"),
+    "africa": (-1.286, 36.817, "KE"),
+    "global": (0.000, 0.000, "XX"),
 }
 
 # Gnews-variant → region coords
 GNEWS_COORDS: dict[str, tuple[float, float, str]] = {
-    "gnews-eu":    (50.110,   8.682, "DE"),
-    "gnews-asia":  (35.689, 139.692, "JP"),
-    "gnews-me":    (25.204,  55.270, "AE"),
-    "gnews-af":    (-1.286,  36.817, "KE"),
+    "gnews-eu": (50.110, 8.682, "DE"),
+    "gnews-asia": (35.689, 139.692, "JP"),
+    "gnews-me": (25.204, 55.270, "AE"),
+    "gnews-af": (-1.286, 36.817, "KE"),
     "gnews-latam": (-23.550, -46.633, "BR"),
-    "gnews-jp":    (35.689, 139.692, "JP"),
+    "gnews-jp": (35.689, 139.692, "JP"),
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -249,6 +249,7 @@ def tongue_decode(tokens: list[str], tongue: str = "KO") -> bytes:
 
 _FORCE_SKIP = os.getenv("SCBE_FORCE_SKIP_LIBOQS", "").strip().lower() in {"1", "true", "yes"}
 
+
 def _load_oqs():
     """Attempt to import oqs without letting liboqs bootstrap abort importers."""
     if _FORCE_SKIP:
@@ -308,10 +309,15 @@ def _geo_phase_seal(
     phi_w = TONGUE_PHI_WEIGHTS.get(tongue, 1.0)
     h = hashlib.sha256()
     for part in (
-        source, tongue, country,
-        f"{lat:.4f}", f"{lon:.4f}",
-        f"{phase:.8f}", f"{phi_w:.6f}",
-        f"{ts:.6f}", payload_hash,
+        source,
+        tongue,
+        country,
+        f"{lat:.4f}",
+        f"{lon:.4f}",
+        f"{phase:.8f}",
+        f"{phi_w:.6f}",
+        f"{ts:.6f}",
+        payload_hash,
     ):
         h.update(part.encode())
         h.update(b"|")
@@ -486,15 +492,15 @@ def stage_egg(hashed: dict) -> dict:
     result = dict(hashed)
     result["egg"] = {
         "egg_id": egg_id,
-        "shell": chain_root,                       # cryptographic shell
-        "yolk": yolk_b64,                          # base64 payload
+        "shell": chain_root,  # cryptographic shell
+        "yolk": yolk_b64,  # base64 payload
         "yolk_byte_len": len(yolk_bytes),
         "tongue": tongue,
         "tongue_name": tongue_name,
         "ritual": "news_ingest",
         "source": source,
         "egg_cost_phi": egg_cost,
-        "hatched_at": None,                        # null until consumed
+        "hatched_at": None,  # null until consumed
         "credits": 0,
         "created_at": datetime.now(tz=timezone.utc).isoformat(),
     }
@@ -544,9 +550,7 @@ def stage_encrypt(egged: dict) -> dict:
     egg_id = egg.get("egg_id", "")
 
     # Derive transport key from egg identity (deterministic, session-specific)
-    key_material = hashlib.sha256(
-        f"SCBE-TRANSPORT-KEY:{egg_id}:{chain_root}".encode()
-    ).digest()
+    key_material = hashlib.sha256(f"SCBE-TRANSPORT-KEY:{egg_id}:{chain_root}".encode()).digest()
 
     plaintext = base64.b64decode(egg.get("yolk", ""))
 
@@ -634,7 +638,7 @@ def stage_sign(encrypted: dict) -> dict:
                         "sig_len": len(signature),
                         "pk_len": len(pub),
                     }
-            except BaseException:
+            except (Exception, SystemExit):
                 alg = "Dilithium3"
                 with oqs.Signature(alg) as signer:
                     pub = signer.generate_keypair()
@@ -645,7 +649,7 @@ def stage_sign(encrypted: dict) -> dict:
                         "sig_len": len(signature),
                         "pk_len": len(pub),
                     }
-        except BaseException as exc:
+        except (Exception, SystemExit) as exc:
             sig_meta = {
                 "algorithm": "HMAC-SHA256-fallback",
                 "signature": _hmac256(_CHAIN_KEY, blob),
@@ -664,11 +668,7 @@ def stage_sign(encrypted: dict) -> dict:
         "chain_root": chain_root,
         "source": encrypted.get("source", ""),
         "region": encrypted.get("region", ""),
-        "geo": {
-            k: v
-            for k, v in encrypted.get("geo", {}).items()
-            if k in ("lat", "lon", "country", "tongue", "seal")
-        },
+        "geo": {k: v for k, v in encrypted.get("geo", {}).items() if k in ("lat", "lon", "country", "tongue", "seal")},
         # Ciphertext omitted from records; auth_tag + ciphertext_len are sufficient
         # for training data — the actual bytes add ~2KB bloat per record.
         "encrypted_payload": {k: v for k, v in enc.items() if k != "ciphertext"},
@@ -758,14 +758,16 @@ def sft_tok_decode_roundtrip(tok: dict, idx: int) -> dict:
         {
             "tokens_preview": preview,
             "tongue": tongue,
-            "full_token_count": tok.get("tokenization", {}).get("tongue_matrix", {}).get(tongue, {}).get("token_count", 0),
+            "full_token_count": tok.get("tokenization", {})
+            .get("tongue_matrix", {})
+            .get(tongue, {})
+            .get("token_count", 0),
         },
         {
             "decoded_title": title,
             "all_roundtrip_ok": tok.get("tokenization", {}).get("all_roundtrip_ok", False),
             "tongue_matrix_summary": {
-                t: d.get("roundtrip_ok", False)
-                for t, d in tok.get("tokenization", {}).get("tongue_matrix", {}).items()
+                t: d.get("roundtrip_ok", False) for t, d in tok.get("tokenization", {}).get("tongue_matrix", {}).items()
             },
         },
     )
@@ -894,9 +896,7 @@ def sft_braid_alignment(tok: dict, idx: int) -> dict | None:
     tname = TONGUE_NAMES.get(tongue, tongue)
     title = tok.get("title", "")
     source = tok.get("source", "?")
-    preview_tokens = (
-        tok.get("tokenization", {}).get("tongue_matrix", {}).get(tongue, {}).get("tokens_preview", [])
-    )
+    preview_tokens = tok.get("tokenization", {}).get("tongue_matrix", {}).get(tongue, {}).get("tokens_preview", [])
     return _sft(
         f"news:braid-align:{tongue}:{idx}",
         f"Score the semantic-atomic braid alignment for this news article. "
@@ -956,9 +956,7 @@ def run_item(item: dict, idx: int) -> tuple[dict, list[dict]]:
             },
             "hashes": hashed.get("hashes", {}),
             "egg": signed.get("egg", {}),
-            "encrypted": {
-                k: v for k, v in signed.get("encrypted", {}).items() if k != "ciphertext"
-            },
+            "encrypted": {k: v for k, v in signed.get("encrypted", {}).items() if k != "ciphertext"},
             "transport": signed.get("transport", {}),
         },
         "crypto_tier": CRYPTO_TIER,
@@ -1030,9 +1028,7 @@ def main() -> None:
         "tongue_coverage": list(TONGUE_PHI_WEIGHTS.keys()),
         "records_file": records_path.relative_to(REPO_ROOT).as_posix(),
         "sft_file": sft_path.relative_to(REPO_ROOT).as_posix(),
-        "pipeline_stages": [
-            "raw", "geotagged", "tokenized", "hashed", "egged", "encrypted", "signed"
-        ],
+        "pipeline_stages": ["raw", "geotagged", "tokenized", "hashed", "egged", "encrypted", "signed"],
         "braid_available": _BRAID_AVAILABLE,
     }
     SUMMARY_PATH.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/scripts/train/hf_train_polly.py
+++ b/scripts/train/hf_train_polly.py
@@ -71,6 +71,7 @@ def resolve_token():
             os.environ["HF_TOKEN"] = tok
             return tok
     except Exception:
+        # Colab userdata is optional; continue with normal environment lookup.
         pass
     return None
 
@@ -174,8 +175,7 @@ def main():
         lora_dropout=args.lora_dropout,
         bias="none",
         task_type=TaskType.CAUSAL_LM,
-        target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
-                        "gate_proj", "up_proj", "down_proj"],
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
     )
     model = get_peft_model(model, lora)
     model.print_trainable_parameters()

--- a/scripts/training_dataset_inventory.py
+++ b/scripts/training_dataset_inventory.py
@@ -22,7 +22,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "artifacts" / "training_inventory" / "latest"
 DATA_EXTENSIONS = {".jsonl", ".json", ".csv", ".parquet", ".arrow", ".txt"}
@@ -269,6 +268,7 @@ def _jsonl_stats(path: Path) -> dict[str, Any]:
                     "lfs_pointer": True,
                 }
     except OSError:
+        # File disappeared or became unreadable during inventory; treat as empty.
         pass
     records = 0
     malformed = 0
@@ -503,7 +503,10 @@ def collect_cloud_surfaces(limit: int) -> dict[str, Any]:
                 if suffix not in DATA_EXTENSIONS and suffix != NOTEBOOK_EXTENSION:
                     continue
                 text = str(path)
-                if not any(token in text.lower() for token in ("scbe", "aether", "colab", "kaggle", "qwen", "polly", "training")):
+                if not any(
+                    token in text.lower()
+                    for token in ("scbe", "aether", "colab", "kaggle", "qwen", "polly", "training")
+                ):
                     continue
                 items.append(
                     {
@@ -530,8 +533,7 @@ def build_merge_plan(local_rows: list[dict[str, Any]], remotes: dict[str, Any]) 
         ready_rows = [
             row
             for row in rows
-            if str(row.get("regularization_status", "")).startswith("ready")
-            and row.get("split_hint") != "eval"
+            if str(row.get("regularization_status", "")).startswith("ready") and row.get("split_hint") != "eval"
         ]
         eval_rows = [row for row in rows if row.get("split_hint") == "eval"]
         model_sets[purpose] = {
@@ -569,7 +571,9 @@ def build_merge_plan(local_rows: list[dict[str, Any]], remotes: dict[str, Any]) 
     }
 
 
-def write_outputs(local_rows: list[dict[str, Any]], remotes: dict[str, Any], plan: dict[str, Any], output_dir: Path) -> dict[str, Path]:
+def write_outputs(
+    local_rows: list[dict[str, Any]], remotes: dict[str, Any], plan: dict[str, Any], output_dir: Path
+) -> dict[str, Path]:
     output_dir.mkdir(parents=True, exist_ok=True)
     summary = summarize(local_rows, remotes)
     inventory = {
@@ -608,9 +612,7 @@ def summarize(local_rows: list[dict[str, Any]], remotes: dict[str, Any]) -> dict
         "by_source": dict(sorted(by_source.items())),
         "by_purpose": dict(sorted(by_purpose.items())),
         "by_regularization_status": dict(sorted(by_status.items())),
-        "remote_counts": {
-            key: value.get("count", len(value.get("items", []))) for key, value in remotes.items()
-        },
+        "remote_counts": {key: value.get("count", len(value.get("items", []))) for key, value in remotes.items()},
     }
 
 

--- a/src/api/polly_routes.py
+++ b/src/api/polly_routes.py
@@ -320,7 +320,7 @@ async def _free_llm_chat(message: str, page_context: Optional[str]) -> Optional[
         if text.strip():
             return {"text": text, "provider": "ollama", "model": ollama_model}
     except Exception:
-        pass
+        logger.debug("Ollama fallback unavailable", exc_info=True)
 
     # Try HuggingFace Inference API (free tier, chat completions)
     hf_token = os.environ.get("HF_TOKEN")
@@ -338,7 +338,7 @@ async def _free_llm_chat(message: str, page_context: Optional[str]) -> Optional[
             if text and text.strip():
                 return {"text": text.strip(), "provider": "huggingface", "model": hf_model}
         except Exception:
-            pass
+            logger.debug("HuggingFace fallback unavailable", exc_info=True)
 
     return None
 

--- a/src/crypto/pqc_liboqs.py
+++ b/src/crypto/pqc_liboqs.py
@@ -28,7 +28,7 @@ def _load_oqs_module():
         import oqs as oqs_module
 
         return oqs_module
-    except BaseException:
+    except (Exception, SystemExit):
         # liboqs-python can raise SystemExit while trying to bootstrap missing
         # shared libraries. PQC is optional here, so fall back instead.
         return None

--- a/src/symphonic_cipher/scbe_aethermoore/sacred_eggs.py
+++ b/src/symphonic_cipher/scbe_aethermoore/sacred_eggs.py
@@ -21,6 +21,7 @@ import json
 import math
 import os
 import struct
+import sys
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -353,4 +354,4 @@ def self_test():
 
 if __name__ == "__main__":
     ok = self_test()
-    exit(0 if ok else 1)
+    sys.exit(0 if ok else 1)

--- a/src/symphonic_cipher/scbe_aethermoore_v2.1_production.py
+++ b/src/symphonic_cipher/scbe_aethermoore_v2.1_production.py
@@ -28,6 +28,7 @@ import hashlib
 import hmac
 import time
 import os
+import sys
 from typing import List, Dict
 
 # =============================================================================
@@ -710,7 +711,7 @@ if __name__ == "__main__":
     # Exit with appropriate code
     if result.decision == "ALLOW" and tests_passed:
         print("\nSCBE-AETHERMOORE v2.1: ALL SYSTEMS NOMINAL")
-        exit(0)
+        sys.exit(0)
     else:
         print("\nSCBE-AETHERMOORE v2.1: ANOMALY DETECTED")
-        exit(1)
+        sys.exit(1)

--- a/tests/demo_telemetry.py
+++ b/tests/demo_telemetry.py
@@ -309,4 +309,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- replace silent empty exception handlers with explicit logging or documented best-effort comments
- narrow liboqs/bootstrap BaseException catches to Exception/SystemExit
- close server log handles after spawning child processes
- replace bare exit() calls with sys.exit()

## Validation
- python -m black --line-length 120 <warning-class files>
- python -m ruff check --config ruff.toml <warning-class files>
- python -m black --line-length 120 --check <warning-class files>
- python -m py_compile <warning-class files>
- python -m pytest tests/benchmark/test_operator_agent_bus_eval.py tests/api/test_polly_widget_contract.py tests/api/test_polly_workers.py -q
- python scripts/security/code_governance_gate.py check-push
- git diff --check

## Rollback
Revert this commit to restore the prior warning-class handling.