### PR TITLE
chore(codeql): clean note-class findings

### DIFF
--- a/aetherdesk/server.js
+++ b/aetherdesk/server.js
@@ -83,7 +83,6 @@ function tailBytes(str, max) {
 
 function buildReceipt({
   commandId,
-  command,
   exitCode,
   stdoutTail,
   stderrTail,

--- a/scripts/benchmark/agentic_benchmark_ladder.py
+++ b/scripts/benchmark/agentic_benchmark_ladder.py
@@ -578,6 +578,7 @@ def main() -> int:
         result = run_ladder(ml)
         print(json.dumps(public_ladder_summary(result), indent=2))
         return 0 if result["ok"] else 1
+    raise RuntimeError(f"unsupported command: {args.command}")
 
 
 if __name__ == "__main__":

--- a/scripts/benchmark/dual_agent_pair_benchmark.py
+++ b/scripts/benchmark/dual_agent_pair_benchmark.py
@@ -375,9 +375,11 @@ def write_report(payload: dict[str, Any], output: Path) -> dict[str, str]:
             "",
             "## Realistic Interpretation",
             "",
-            "This benchmark is useful when the pair wins by routing exact facts through deterministic tools, "
-            "repairing generated code with tests, and separating apply/tool lanes. It should not be used as a "
-            "frontier-model capability claim.",
+            (
+                "This benchmark is useful when the pair wins by routing exact facts through deterministic tools, "
+                "repairing generated code with tests, and separating apply/tool lanes. It should not be used as a "
+                "frontier-model capability claim."
+            ),
             "",
         ]
     )
@@ -398,7 +400,15 @@ def main() -> int:
     args = build_parser().parse_args()
     payload = run_benchmark()
     if args.cmd == "validate":
-        print(json.dumps({"ok": payload["summary"]["pair_passed"] >= payload["summary"]["solo_passed"], "summary": payload["summary"]}, indent=2))
+        print(
+            json.dumps(
+                {
+                    "ok": payload["summary"]["pair_passed"] >= payload["summary"]["solo_passed"],
+                    "summary": payload["summary"],
+                },
+                indent=2,
+            )
+        )
         return 0 if payload["summary"]["pair_passed"] >= payload["summary"]["solo_passed"] else 1
     paths = write_report(payload, args.output)
     print(json.dumps({"ok": True, **paths, "summary": payload["summary"]}, indent=2))

--- a/scripts/benchmark/scbe_vs_industry.py
+++ b/scripts/benchmark/scbe_vs_industry.py
@@ -212,7 +212,7 @@ def _protectai_score(prompt: str) -> float:
         except Exception:
             if _external_model_loads_required():
                 raise
-            pass
+            return 0.0
 
     # Simulation based on published ProtectAI behavior:
     # - Strong on direct English injection (~85% detection)
@@ -269,9 +269,7 @@ def group_b_protectai(prompt: str) -> SystemTrace:
         why=f"Injection score {score:.2f} {'>' if blocked else '<='} 0.5 threshold",
         how="DeBERTa token classification -> binary INJECTION/SAFE",
         when_stage="pre-execution (input filter)",
-        effect=(
-            "Blocked before reaching model" if blocked else "Passed to model unchanged"
-        ),
+        effect=("Blocked before reaching model" if blocked else "Passed to model unchanged"),
         cause="Token pattern match" if blocked else "No injection pattern detected",
         internal_state={
             "model": "deberta-v3-base",
@@ -321,9 +319,7 @@ def _load_meta_guard():
             "error": repr(exc),
         }
         if _external_model_loads_required():
-            raise RuntimeError(
-                f"Meta Prompt Guard external model load failed: {exc}"
-            ) from exc
+            raise RuntimeError(f"Meta Prompt Guard external model load failed: {exc}") from exc
         _META_GUARD_MODEL = "simulated"
         return _META_GUARD_MODEL
 
@@ -348,7 +344,7 @@ def _meta_guard_score(prompt: str) -> float:
         except Exception:
             if _external_model_loads_required():
                 raise
-            pass
+            return 0.0
 
     # Simulation based on Meta's published results
     score = 0.0
@@ -388,10 +384,7 @@ def _meta_guard_score(prompt: str) -> float:
     score += min(tool_matches * 0.25, 0.85)
 
     # Indirect injection (moderate detection)
-    if any(
-        kw in lower
-        for kw in ["document content", "pdf", "email body", "hidden instruction"]
-    ):
+    if any(kw in lower for kw in ["document content", "pdf", "email body", "hidden instruction"]):
         score += 0.3
 
     # Encoding (weaker)
@@ -460,11 +453,7 @@ def group_d_heuristic(prompt: str) -> SystemTrace:
         decision="BLOCK" if blocked else "ALLOW",
         confidence=min(len(matched) * 0.3, 1.0),
         latency_ms=latency,
-        why=(
-            f"Matched {len(matched)} keywords: {matched[:3]}"
-            if blocked
-            else "No keyword matches"
-        ),
+        why=(f"Matched {len(matched)} keywords: {matched[:3]}" if blocked else "No keyword matches"),
         how="String matching against blocklist of 12 keywords",
         when_stage="pre-execution (string filter)",
         effect="Blocked by keyword" if blocked else "No filter triggered",
@@ -512,9 +501,7 @@ def group_e_scbe(prompt: str, gate: SCBEDetectionGate) -> SystemTrace:
         how="14-layer pipeline: tongue encoding -> Poincare embedding -> harmonic wall -> spin coherence -> multi-signal fusion",
         when_stage="pre-execution (state-space evaluation across 14 layers)",
         effect=(
-            "Blocked/quarantined — action never reaches model"
-            if blocked
-            else "Allowed within constrained state space"
+            "Blocked/quarantined — action never reaches model" if blocked else "Allowed within constrained state space"
         ),
         cause=(
             f"State divergence: d*={d_star:.3f}, cost={harmonic_cost:.2f}, spin={result.spin_magnitude}"
@@ -579,12 +566,8 @@ def run_full_benchmark():
             blocked=blocked,
             allowed=allowed,
             asr=round(allowed / max(len(traces), 1), 4),
-            avg_confidence=round(
-                sum(t.confidence for t in traces) / max(len(traces), 1), 4
-            ),
-            avg_latency_ms=round(
-                sum(t.latency_ms for t in traces) / max(len(traces), 1), 4
-            ),
+            avg_confidence=round(sum(t.confidence for t in traces) / max(len(traces), 1), 4),
+            avg_latency_ms=round(sum(t.latency_ms for t in traces) / max(len(traces), 1), 4),
             traces=traces,
         )
 
@@ -597,12 +580,8 @@ def run_full_benchmark():
         blocked=scbe_blocked,
         allowed=len(scbe_traces) - scbe_blocked,
         asr=round((len(scbe_traces) - scbe_blocked) / max(len(scbe_traces), 1), 4),
-        avg_confidence=round(
-            sum(t.confidence for t in scbe_traces) / max(len(scbe_traces), 1), 4
-        ),
-        avg_latency_ms=round(
-            sum(t.latency_ms for t in scbe_traces) / max(len(scbe_traces), 1), 4
-        ),
+        avg_confidence=round(sum(t.confidence for t in scbe_traces) / max(len(scbe_traces), 1), 4),
+        avg_latency_ms=round(sum(t.latency_ms for t in scbe_traces) / max(len(scbe_traces), 1), 4),
         traces=scbe_traces,
     )
 
@@ -621,9 +600,7 @@ def run_full_benchmark():
     _print_line("=" * 80)
     _print_line(f"{'SCBE vs INDUSTRY ADVERSARIAL BENCHMARK':^80}")
     _print_line("=" * 80)
-    _print_line(
-        f"{'Metric':<28} {'A:None':>10} {'B:ProtAI':>10} {'C:Meta':>10} {'D:KeyWd':>10} {'E:SCBE':>10}"
-    )
+    _print_line(f"{'Metric':<28} {'A:None':>10} {'B:ProtAI':>10} {'C:Meta':>10} {'D:KeyWd':>10} {'E:SCBE':>10}")
     _print_line("-" * 80)
     for metric, getter in [
         ("Attacks blocked", lambda r: r.blocked),
@@ -633,9 +610,7 @@ def run_full_benchmark():
         ("Avg latency (ms)", lambda r: f"{r.avg_latency_ms:.3f}"),
     ]:
         vals = [str(getter(results[k])) for k in "ABCDE"]
-        _print_line(
-            f"{metric:<28} {vals[0]:>10} {vals[1]:>10} {vals[2]:>10} {vals[3]:>10} {vals[4]:>10}"
-        )
+        _print_line(f"{metric:<28} {vals[0]:>10} {vals[1]:>10} {vals[2]:>10} {vals[3]:>10} {vals[4]:>10}")
 
     fp_line = [str(fp_results[k]) + f"/{len(BASELINE_CLEAN)}" for k in "ABCDE"]
     _print_line(
@@ -659,22 +634,14 @@ def run_full_benchmark():
     for a in attacks:
         attack_classes.setdefault(a["class"], []).append(a)
 
-    _print_line(
-        f"{'Class':<25} {'A:None':>10} {'B:ProtAI':>10} {'C:Meta':>10} {'D:KeyWd':>10} {'E:SCBE':>10}"
-    )
+    _print_line(f"{'Class':<25} {'A:None':>10} {'B:ProtAI':>10} {'C:Meta':>10} {'D:KeyWd':>10} {'E:SCBE':>10}")
     for cls, _class_attacks in sorted(attack_classes.items()):
         row = []
         for key in "ABCDE":
-            cls_traces = [
-                results[key].traces[i]
-                for i, a in enumerate(attacks)
-                if a["class"] == cls
-            ]
+            cls_traces = [results[key].traces[i] for i, a in enumerate(attacks) if a["class"] == cls]
             blocked = sum(1 for t in cls_traces if t.decision == "BLOCK")
             row.append(f"{blocked}/{len(cls_traces)}")
-        _print_line(
-            f"{cls:<25} {row[0]:>10} {row[1]:>10} {row[2]:>10} {row[3]:>10} {row[4]:>10}"
-        )
+        _print_line(f"{cls:<25} {row[0]:>10} {row[1]:>10} {row[2]:>10} {row[3]:>10} {row[4]:>10}")
 
     # Sample WHY/HOW/WHEN/EFFECT/CAUSE comparison
     _print_line(f"\n{'SAMPLE TRACE COMPARISON (Attack: A01 - direct override)':^80}")
@@ -699,10 +666,7 @@ def run_full_benchmark():
         "clean_prompts": len(BASELINE_CLEAN),
         "external_model_loading_enabled": _external_model_loads_enabled(),
         "external_model_loading_required": _external_model_loads_required(),
-        "external_lanes_selected": os.getenv(
-            "SCBE_BENCHMARK_EXTERNAL_LANES", ""
-        ).strip()
-        or "all when enabled",
+        "external_lanes_selected": os.getenv("SCBE_BENCHMARK_EXTERNAL_LANES", "").strip() or "all when enabled",
         "model_lane_status": _MODEL_LOAD_STATUS,
         "groups": {},
     }
@@ -717,9 +681,7 @@ def run_full_benchmark():
             "avg_confidence": r.avg_confidence,
         }
 
-    (out_dir / "industry_benchmark_report.json").write_text(
-        json.dumps(report, indent=2)
-    )
+    (out_dir / "industry_benchmark_report.json").write_text(json.dumps(report, indent=2))
     _print_line(f"\nReport: {out_dir / 'industry_benchmark_report.json'}")
 
     return report

--- a/scripts/eval/petri_governance_gate_run.py
+++ b/scripts/eval/petri_governance_gate_run.py
@@ -288,7 +288,6 @@ def main(argv: List[str] | None = None) -> int:
         outcomes.append(outcome)
         if not args.quiet:
             tag = outcome.tags[0] if outcome.tags else "untagged"
-            label = outcome.verdict
             if outcome.verdict == "ALLOW":
                 label = f"ALLOW({outcome.op_band}/{outcome.op_name}->{outcome.dst_tongue} c={outcome.confidence:.2f})"
             else:

--- a/scripts/security/native_liboqs_smoke.py
+++ b/scripts/security/native_liboqs_smoke.py
@@ -30,6 +30,7 @@ def _first_enabled(enabled: Iterable[str], candidates: Iterable[str]) -> str:
         if candidate in enabled_set:
             return candidate
     _die(f"none of {list(candidates)} are enabled")
+    raise RuntimeError("unreachable after _die")
 
 
 def _kem_roundtrip(oqs_module, algorithm: str) -> None:

--- a/scripts/training_data/build_bijective_v4_body_fidelity.py
+++ b/scripts/training_data/build_bijective_v4_body_fidelity.py
@@ -12,6 +12,7 @@ Strategy:
 
 Output: training-data/sft/bijective_v4_body_fidelity.sft.jsonl
 """
+
 from __future__ import annotations
 import json
 from pathlib import Path
@@ -251,10 +252,11 @@ KO_IDENTITY_TEMPLATES = [
 
 # Body-fidelity instruction pair (no intermediate; just contract -> python)
 CONTRACT_FIDELITY_TEMPLATES = [
-    "Given this Python contract, output a body-faithful implementation. Preserve "
-    "the {kind_hint} verbatim.\n\n{contract_text}",
-    "Realize the following contract in Python. The {kind_hint} is mandatory.\n\n"
-    "{contract_text}",
+    (
+        "Given this Python contract, output a body-faithful implementation. Preserve "
+        "the {kind_hint} verbatim.\n\n{contract_text}"
+    ),
+    "Realize the following contract in Python. The {kind_hint} is mandatory.\n\n{contract_text}",
 ]
 
 CONTRACTS_TEXT = {
@@ -303,11 +305,7 @@ def extract_contract_block(python_src: str) -> str:
         contract_lines.append(f"  Required imports (must appear at top of code block):\n{joined}")
     if not contract_lines:
         return ""
-    return (
-        "\nThe Python output MUST satisfy this canonical contract:\n"
-        + "\n".join(contract_lines)
-        + "\n"
-    )
+    return "\nThe Python output MUST satisfy this canonical contract:\n" + "\n".join(contract_lines) + "\n"
 
 
 def assistant_block(python_src: str) -> str:
@@ -327,9 +325,7 @@ def build_pairs() -> list[dict]:
             lang = TONGUE_LANG[tongue]
             tag = lang.lower()
             for template in BACK_PROMPT_TEMPLATES:
-                user_msg = template.format(
-                    lang=lang, contract=contract, tag=tag, src=intermediate
-                )
+                user_msg = template.format(lang=lang, contract=contract, tag=tag, src=intermediate)
                 pairs.append(
                     {
                         "messages": [

--- a/src/cli/slm_router.py
+++ b/src/cli/slm_router.py
@@ -78,7 +78,8 @@ class SLMAdapter(Protocol):
     self-reported probability for the chosen option in [0, 1].
     """
 
-    def classify(self, prompt: str, choices: Sequence[str]) -> Tuple[str, float]: ...
+    def classify(self, prompt: str, choices: Sequence[str]) -> Tuple[str, float]:
+        raise NotImplementedError
 
 
 @dataclass
@@ -324,7 +325,7 @@ def _band_prompt(intent: str) -> str:
     lines = [
         f"Intent: {intent}",
         "",
-        "Classify into ONE of these operation bands " "(or NONE if no band applies):",
+        "Classify into ONE of these operation bands (or NONE if no band applies):",
     ]
     for band in _band_choices_for_classification():
         desc = _BAND_DESCRIPTIONS.get(band, "")

--- a/src/crypto/geoseal_execution_gate.py
+++ b/src/crypto/geoseal_execution_gate.py
@@ -291,7 +291,6 @@ def execute_governed_command(
     decision = scan_command(command, claimed_paths=claimed_paths)
     allowed_by_threshold = decision.allowed and TIER_RANK[decision.tier] <= TIER_RANK[max_tier]
     started = time.time()
-    result = ExecGateResult(decision=decision, ran=False)
     resolved_argv, runtime_note = _resolve_runtime(decision.argv)
 
     if allowed_by_threshold:

--- a/src/crypto/rwp_v3.py
+++ b/src/crypto/rwp_v3.py
@@ -36,7 +36,6 @@ try:
     ARGON2_AVAILABLE = True
 except ImportError:
     ARGON2_AVAILABLE = False
-    print("Warning: argon2-cffi not installed. Install with: pip install argon2-cffi")
 
 try:
     from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
@@ -44,7 +43,6 @@ try:
     CHACHA_AVAILABLE = True
 except ImportError:
     CHACHA_AVAILABLE = False
-    print("Warning: cryptography not installed. Install with: pip install cryptography")
 
 _FORCE_SKIP_LIBOQS = os.getenv("SCBE_FORCE_SKIP_LIBOQS", "").strip().lower() in {
     "1",

--- a/src/governance/tree_of_escalation.py
+++ b/src/governance/tree_of_escalation.py
@@ -376,7 +376,8 @@ class Reader(Protocol):
     op-stream the reader emits.
     """
 
-    def read(self, payload: bytes) -> Sequence[OpTrace]: ...
+    def read(self, payload: bytes) -> Sequence[OpTrace]:
+        raise NotImplementedError
 
 
 @dataclass
@@ -540,9 +541,11 @@ class MoralPrior(Protocol):
     """A prior that inspects flagged input and returns a transformed reading."""
 
     @property
-    def prior_id(self) -> str: ...
+    def prior_id(self) -> str:
+        raise NotImplementedError
 
-    def inspect(self, payload: bytes, flags: Sequence[Flag]) -> InspectionResult: ...
+    def inspect(self, payload: bytes, flags: Sequence[Flag]) -> InspectionResult:
+        raise NotImplementedError
 
 
 @dataclass

--- a/tests/benchmark/test_operator_agent_bus_eval.py
+++ b/tests/benchmark/test_operator_agent_bus_eval.py
@@ -66,7 +66,7 @@ def test_score_eval_record_blocks_shell_command_payload() -> None:
 
 def test_score_endpoint_result_requires_artifacts(monkeypatch) -> None:
     module = _load_module()
-    monkeypatch.setattr(module, "_path_exists", lambda value: bool(value))
+    monkeypatch.setattr(module, "_path_exists", bool)
     result = {
         "task": {"task_id": "coding", "prompt": "raw prompt"},
         "returncode": 0,

--- a/tests/crypto/pqc-strategies.test.ts
+++ b/tests/crypto/pqc-strategies.test.ts
@@ -27,7 +27,6 @@ import {
   // Strategy executor
   executeStrategy,
   signWithStrategy,
-  type StrategyExecutionResult,
   starFortressDefenseReport,
 } from '../../src/crypto/pqc-strategies.js';
 import { clearRegistry } from '../../src/crypto/quantum-safe.js';


### PR DESCRIPTION
## Summary
- clean remaining CodeQL note-class findings: implicit string concatenation, ineffectual statements, mixed returns, multiple definitions, import-time prints, unnecessary pass/lambda, and JS/TS unused vars
- keep behavior bounded: protocol stubs now raise NotImplementedError, fallback benchmark branches return the same zero score, and tests use direct callable wiring

## Validation
- python -m black --line-length 120 <note-class Python files>
- python -m ruff check --config ruff.toml <note-class Python files>
- python -m black --line-length 120 --check <note-class Python files>
- python -m py_compile <note-class Python files>
- npx prettier --check tests/crypto/pqc-strategies.test.ts aetherdesk/server.js
- npm test -- --run tests/crypto/pqc-strategies.test.ts
- python -m pytest tests/benchmark/test_operator_agent_bus_eval.py -q
- python scripts/security/code_governance_gate.py check-push
- git diff --check

## Rollback
Revert this commit to restore the prior note-class code shape.