### PR TITLE
chore(codeql): clear final note findings

### DIFF
--- a/scripts/kaggle_auto/kernel_template.py
+++ b/scripts/kaggle_auto/kernel_template.py
@@ -495,7 +495,6 @@ try:
         else:
             MAX_STEPS = min(MAX_STEPS, CPU_SMOKE_MAX_STEPS)
         quant_config = None
-        compute_dtype = torch.float32
         load_kwargs = {"torch_dtype": torch.float32, "device_map": "cpu"}
 except (Exception, SystemExit) as exc:
     fail_status("checking_device", exc)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -72,10 +72,7 @@ try:
     from src.contracts.operation_panel import resolve_source_to_operation_panel
     from src.contracts.system_cards import build_system_deck, play_system_card
     from src.contracts.runtime_contract import inspect_runtime_packet
-
-    _CONTRACTS_AVAILABLE = True
 except ImportError:
-    _CONTRACTS_AVAILABLE = False
     logger.warning("src.contracts not available — operation panel / system cards endpoints disabled")
 
     def resolve_source_to_operation_panel(*a, **kw):

--- a/src/api/polly_routes.py
+++ b/src/api/polly_routes.py
@@ -14,6 +14,7 @@ import re
 import smtplib
 import ssl
 import time
+import functools
 from email.message import EmailMessage
 from typing import Any, Dict, List, Optional
 from urllib import request as urlrequest
@@ -66,28 +67,28 @@ from pathlib import Path
 
 _DEFAULT_ENV_FILE = Path(__file__).parent.parent.parent / "config" / "connector_oauth" / ".env.connector.oauth"
 ENV_FILE = os.environ.get("POLLY_ENV_FILE") or str(_DEFAULT_ENV_FILE)
-_env_loaded = False
 import threading
 
 _env_lock = threading.Lock()
 
 
+@functools.lru_cache(maxsize=1)
+def _load_env_file(env_file: str) -> None:
+    if os.path.isfile(env_file):
+        with open(env_file) as fh:
+            for line in fh:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, _, v = line.partition("=")
+                    k = k.strip()
+                    v = v.strip().strip("\"'")
+                    if k and v:
+                        os.environ.setdefault(k, v)
+
+
 def _load_env() -> None:
-    global _env_loaded
     with _env_lock:
-        if _env_loaded:
-            return
-        if os.path.isfile(ENV_FILE):
-            with open(ENV_FILE) as fh:
-                for line in fh:
-                    line = line.strip()
-                    if line and not line.startswith("#") and "=" in line:
-                        k, _, v = line.partition("=")
-                        k = k.strip()
-                        v = v.strip().strip("\"'")
-                        if k and v:
-                            os.environ.setdefault(k, v)
-        _env_loaded = True
+        _load_env_file(ENV_FILE)
 
 
 def _gemini_key() -> Optional[str]:

--- a/tests/crypto/pqc-strategies.test.ts
+++ b/tests/crypto/pqc-strategies.test.ts
@@ -18,12 +18,10 @@ import {
   type PQCStrategy,
   // TriStitch
   triStitch,
-  type TriStitchResult,
   // Geometric binding
   geometricFingerprint,
   bindKeyToGeometry,
   verifyGeometricBinding,
-  type GeoBoundKey,
   // Strategy executor
   executeStrategy,
   signWithStrategy,


### PR DESCRIPTION
## Summary
- removes the remaining real CodeQL note-class unused globals/imports in the refreshed scanner set
- keeps public contract fallback behavior unchanged while removing dead availability state
- changes Polly env loading from a module sentinel to a cached helper

## Verification
- python -m black --line-length 120 src/api/polly_routes.py src/api/main.py scripts/kaggle_auto/kernel_template.py
- python -m py_compile src/api/polly_routes.py src/api/main.py scripts/kaggle_auto/kernel_template.py
- python -m ruff check --config ruff.toml src/api/polly_routes.py src/api/main.py scripts/kaggle_auto/kernel_template.py
- npx prettier --check tests/crypto/pqc-strategies.test.ts aetherdesk/server.js
- npm test -- --run tests/crypto/pqc-strategies.test.ts -> 56 passed
- python scripts/security/code_governance_gate.py check-push -> PASS
- git diff --check

## Rollback
- revert this PR to restore the previous helper/cache structure