### PR TITLE
fix(vercel): route home aliases

### DIFF
--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -35,6 +35,9 @@ def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
     assert "'docs/legal/terms.html'" in ignore_source
     assert ("^/$", "/api/agent/launch.js") in routes
     assert ("^/launch$", "/api/agent/launch.js") in routes
+    assert ("^/index\\.html$", "/api/agent/launch.js") in routes
+    assert ("^/SCBE-AETHERMOORE/?$", "/api/agent/launch.js") in routes
+    assert ("^/SCBE-AETHERMOORE/index\\.html$", "/api/agent/launch.js") in routes
     assert ("^/hire/?$", "/api/agent/hire.js") in routes
     assert ("^/SCBE-AETHERMOORE/hire\\.html$", "/api/agent/hire.js") in routes
     assert ("^/products/?$", "/api/agent/products.js") in routes

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,18 @@
       "dest": "/api/agent/launch.js"
     },
     {
+      "src": "^/index\\.html$",
+      "dest": "/api/agent/launch.js"
+    },
+    {
+      "src": "^/SCBE-AETHERMOORE/?$",
+      "dest": "/api/agent/launch.js"
+    },
+    {
+      "src": "^/SCBE-AETHERMOORE/index\\.html$",
+      "dest": "/api/agent/launch.js"
+    },
+    {
       "src": "^/hire/?$",
       "dest": "/api/agent/hire.js"
     },


### PR DESCRIPTION
## Summary
- routes common Vercel home aliases to the customer launch page
- covers /index.html, /SCBE-AETHERMOORE/, and /SCBE-AETHERMOORE/index.html
- adds regression assertions so these paths do not fall back to 404 again

## Tests
- python -m pytest tests\test_vercel_launch_bridge.py -q
- python scripts\security\code_governance_gate.py check-push
- git diff --check

## Rollback
- Revert this PR to restore the previous Vercel route table.