### PR TITLE
fix(vercel): serve discovery files

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -6,6 +6,8 @@
 !docs
 !docs/offers.json
 !docs/app-config.json
+!docs/robots.txt
+!docs/sitemap.xml
 !docs/solutions.html
 !docs/products.html
 !docs/start-here.html

--- a/api/agent/_static_file.js
+++ b/api/agent/_static_file.js
@@ -13,6 +13,7 @@ const MIME_TYPES = {
   '.md': 'text/markdown; charset=utf-8',
   '.svg': 'image/svg+xml',
   '.txt': 'text/plain; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
 };
 
 function docsPath(relativePath) {

--- a/api/agent/app-config-file.js
+++ b/api/agent/app-config-file.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { serveDocsHtml } = require('./_static_file');
+
+module.exports = async function handler(req, res) {
+  return serveDocsHtml(req, res, 'app-config.json', 'app_config_file_unavailable');
+};

--- a/api/agent/offers-file.js
+++ b/api/agent/offers-file.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { serveDocsHtml } = require('./_static_file');
+
+module.exports = async function handler(req, res) {
+  return serveDocsHtml(req, res, 'offers.json', 'offers_file_unavailable');
+};

--- a/api/agent/robots.js
+++ b/api/agent/robots.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { serveDocsHtml } = require('./_static_file');
+
+module.exports = async function handler(req, res) {
+  return serveDocsHtml(req, res, 'robots.txt', 'robots_file_unavailable');
+};

--- a/api/agent/sitemap.js
+++ b/api/agent/sitemap.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { serveDocsHtml } = require('./_static_file');
+
+module.exports = async function handler(req, res) {
+  return serveDocsHtml(req, res, 'sitemap.xml', 'sitemap_file_unavailable');
+};

--- a/scripts/vercel/ignore-build.cjs
+++ b/scripts/vercel/ignore-build.cjs
@@ -27,6 +27,8 @@ const relevantPaths = [
   'api/billing',
   'docs/offers.json',
   'docs/app-config.json',
+  'docs/robots.txt',
+  'docs/sitemap.xml',
   'docs/solutions.html',
   'docs/governance-snapshot.html',
   'docs/hire.html',

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -24,6 +24,8 @@ def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
     assert "'api/polly'" in ignore_source
     assert "'api/billing'" in ignore_source
     assert "'docs/app-config.json'" in ignore_source
+    assert "'docs/robots.txt'" in ignore_source
+    assert "'docs/sitemap.xml'" in ignore_source
     assert "'docs/solutions.html'" in ignore_source
     assert "'docs/governance-snapshot.html'" in ignore_source
     assert "'docs/hire.html'" in ignore_source
@@ -44,6 +46,14 @@ def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
     assert ("^/index\\.html$", "/api/agent/launch.js") in routes
     assert ("^/SCBE-AETHERMOORE/?$", "/api/agent/launch.js") in routes
     assert ("^/SCBE-AETHERMOORE/index\\.html$", "/api/agent/launch.js") in routes
+    assert ("^/offers\\.json$", "/api/agent/offers-file.js") in routes
+    assert ("^/SCBE-AETHERMOORE/offers\\.json$", "/api/agent/offers-file.js") in routes
+    assert ("^/app-config\\.json$", "/api/agent/app-config-file.js") in routes
+    assert ("^/SCBE-AETHERMOORE/app-config\\.json$", "/api/agent/app-config-file.js") in routes
+    assert ("^/robots\\.txt$", "/api/agent/robots.js") in routes
+    assert ("^/SCBE-AETHERMOORE/robots\\.txt$", "/api/agent/robots.js") in routes
+    assert ("^/sitemap\\.xml$", "/api/agent/sitemap.js") in routes
+    assert ("^/SCBE-AETHERMOORE/sitemap\\.xml$", "/api/agent/sitemap.js") in routes
     assert ("^/hire/?$", "/api/agent/hire.js") in routes
     assert ("^/SCBE-AETHERMOORE/hire\\.html$", "/api/agent/hire.js") in routes
     assert ("^/products/?$", "/api/agent/products.js") in routes
@@ -111,6 +121,8 @@ def test_vercelignore_ships_launch_handler_with_api_bridge() -> None:
     assert "!api/**" in ignore
     assert "!docs/offers.json" in ignore
     assert "!docs/app-config.json" in ignore
+    assert "!docs/robots.txt" in ignore
+    assert "!docs/sitemap.xml" in ignore
     assert "!docs/solutions.html" in ignore
     assert "!docs/products.html" in ignore
     assert "!docs/start-here.html" in ignore
@@ -236,6 +248,8 @@ def test_payment_center_exposes_all_live_payment_paths() -> None:
 
 
 def test_vercel_bridge_serves_payment_and_legal_static_pages() -> None:
+    offers_file_handler = (REPO_ROOT / "api" / "agent" / "offers-file.js").read_text(encoding="utf-8")
+    app_config_file_handler = (REPO_ROOT / "api" / "agent" / "app-config-file.js").read_text(encoding="utf-8")
     payment_handler = (REPO_ROOT / "api" / "agent" / "payments.js").read_text(encoding="utf-8")
     solutions_handler = (REPO_ROOT / "api" / "agent" / "solutions.js").read_text(encoding="utf-8")
     workflow_handler = (REPO_ROOT / "api" / "agent" / "workflow-snapshot.js").read_text(encoding="utf-8")
@@ -250,7 +264,11 @@ def test_vercel_bridge_serves_payment_and_legal_static_pages() -> None:
     robot_page_handler = (REPO_ROOT / "api" / "agent" / "robot-page.js").read_text(encoding="utf-8")
     robot_md_handler = (REPO_ROOT / "api" / "agent" / "robot-md.js").read_text(encoding="utf-8")
     llms_handler = (REPO_ROOT / "api" / "agent" / "llms.js").read_text(encoding="utf-8")
+    robots_handler = (REPO_ROOT / "api" / "agent" / "robots.js").read_text(encoding="utf-8")
+    sitemap_handler = (REPO_ROOT / "api" / "agent" / "sitemap.js").read_text(encoding="utf-8")
 
+    assert "offers.json" in offers_file_handler
+    assert "app-config.json" in app_config_file_handler
     assert "payments.html" in payment_handler
     assert "solutions.html" in solutions_handler
     assert "workflow-snapshot.html" in workflow_handler
@@ -263,6 +281,8 @@ def test_vercel_bridge_serves_payment_and_legal_static_pages() -> None:
     assert "robot.html" in robot_page_handler
     assert "robot.md" in robot_md_handler
     assert "llms.txt" in llms_handler
+    assert "robots.txt" in robots_handler
+    assert "sitemap.xml" in sitemap_handler
 
 
 def test_vercel_bridge_exposes_remote_offer_and_app_config_endpoints() -> None:

--- a/vercel.json
+++ b/vercel.json
@@ -37,6 +37,38 @@
       "dest": "/api/agent/launch.js"
     },
     {
+      "src": "^/offers\\.json$",
+      "dest": "/api/agent/offers-file.js"
+    },
+    {
+      "src": "^/SCBE-AETHERMOORE/offers\\.json$",
+      "dest": "/api/agent/offers-file.js"
+    },
+    {
+      "src": "^/app-config\\.json$",
+      "dest": "/api/agent/app-config-file.js"
+    },
+    {
+      "src": "^/SCBE-AETHERMOORE/app-config\\.json$",
+      "dest": "/api/agent/app-config-file.js"
+    },
+    {
+      "src": "^/robots\\.txt$",
+      "dest": "/api/agent/robots.js"
+    },
+    {
+      "src": "^/SCBE-AETHERMOORE/robots\\.txt$",
+      "dest": "/api/agent/robots.js"
+    },
+    {
+      "src": "^/sitemap\\.xml$",
+      "dest": "/api/agent/sitemap.js"
+    },
+    {
+      "src": "^/SCBE-AETHERMOORE/sitemap\\.xml$",
+      "dest": "/api/agent/sitemap.js"
+    },
+    {
       "src": "^/hire/?$",
       "dest": "/api/agent/hire.js"
     },


### PR DESCRIPTION
## Summary
- serves root and SCBE-AETHERMOORE-prefixed discovery files through Vercel
- adds raw routes for offers.json, app-config.json, robots.txt, and sitemap.xml
- ships those docs through .vercelignore and the Vercel relevance filter
- adds XML MIME support for sitemap delivery

## Tests
- python -m pytest tests\test_vercel_launch_bridge.py -q
- python scripts\security\code_governance_gate.py check-push
- git diff --check

## Rollback
- Revert this PR to restore the previous Vercel discovery-file behavior.