### PR TITLE
feat(system): add GeoSeal agent workcell SOP proof

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "cash:autopromo:bluesky": "python scripts/revenue/build_workflow_snapshot_autopromo.py --publish-bluesky",
     "cash:launch-readiness": "python scripts/system/product_launch_readiness.py",
     "cash:launch-readiness:gate": "python scripts/system/product_launch_readiness.py --fail-on-not-ready",
+    "system:workcell-demo": "python scripts/system/agent_workcell_demo.py",
     "smoke:remote-app-config": "python scripts/system/remote_app_config_smoke.py",
     "smoke:remote-app-config:live": "python scripts/system/remote_app_config_smoke.py --live",
     "smoke:playwright:crosstalk": "node scripts/system/playwright_crosstalk_runner.mjs",

--- a/scripts/system/agent_workcell_demo.py
+++ b/scripts/system/agent_workcell_demo.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Run a visible SCBE multi-agent workcell proof.
+
+This is an operator-facing proof path: one task is routed through named agent
+slots, cross-talk packets are written, verification commands run, and a ship
+report is emitted. Provider names are slots, not claims that an external model
+API was called.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUT_DIR = REPO_ROOT / "artifacts" / "agent_workcells" / "latest"
+DEFAULT_AGENT_COUNT = 100
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.crypto.geoseal_execution_gate import scan_command
+
+
+@dataclass(frozen=True)
+class WorkcellAgent:
+    agent_id: str
+    model_slot: str
+    role: str
+    job: str
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    command: str
+    returncode: int
+    duration_ms: int
+    stdout_tail: str
+    stderr_tail: str
+    geoseal_gate: dict[str, Any]
+    attempts: int = 1
+
+
+AGENTS = (
+    WorkcellAgent(
+        agent_id="planner",
+        model_slot="codex",
+        role="task-router",
+        job="Turn the human request into bounded work packets.",
+    ),
+    WorkcellAgent(
+        agent_id="builder",
+        model_slot="claude",
+        role="implementation-worker",
+        job="Apply or identify the concrete system change.",
+    ),
+    WorkcellAgent(
+        agent_id="reviewer",
+        model_slot="gemini",
+        role="risk-reviewer",
+        job="Challenge the work for missing proof and unsafe claims.",
+    ),
+    WorkcellAgent(
+        agent_id="verifier",
+        model_slot="local-shell",
+        role="test-runner",
+        job="Run deterministic checks and capture evidence.",
+    ),
+    WorkcellAgent(
+        agent_id="shipper",
+        model_slot="github-ci",
+        role="release-coordinator",
+        job="Summarize whether the work can ship and what artifact proves it.",
+    ),
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def tail(text: str, limit: int = 1800) -> str:
+    cleaned = text.strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[-limit:]
+
+
+def run_command(command: str, cwd: Path, *, max_attempts: int = 1, claimed_paths: list[str] | None = None) -> CommandResult:
+    gate = scan_command(command, claimed_paths=claimed_paths).to_dict()
+    if not gate["allowed"]:
+        return CommandResult(
+            command=command,
+            returncode=126,
+            duration_ms=0,
+            stdout_tail="",
+            stderr_tail=f"GeoSeal gate blocked command at tier {gate['tier']}",
+            geoseal_gate=gate,
+            attempts=0,
+        )
+
+    started = datetime.now(timezone.utc)
+    attempts = 0
+    proc: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(1, max(1, max_attempts) + 1):
+        attempts = attempt
+        proc = subprocess.run(
+            command,
+            cwd=str(cwd),
+            shell=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=180,
+        )
+        if proc.returncode == 0:
+            break
+    ended = datetime.now(timezone.utc)
+    assert proc is not None
+    return CommandResult(
+        command=command,
+        returncode=proc.returncode,
+        duration_ms=int((ended - started).total_seconds() * 1000),
+        stdout_tail=tail(proc.stdout),
+        stderr_tail=tail(proc.stderr),
+        geoseal_gate=gate,
+        attempts=attempts,
+    )
+
+
+def git_value(args: Iterable[str], cwd: Path) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+            check=False,
+        )
+    except Exception:
+        return "unknown"
+    return proc.stdout.strip() or proc.stderr.strip() or "unknown"
+
+
+def packet(sender: WorkcellAgent, recipient: WorkcellAgent, task_id: str, summary: str, proof: list[str]) -> dict[str, Any]:
+    return {
+        "created_at": utc_now(),
+        "task_id": task_id,
+        "sender": asdict(sender),
+        "recipient": asdict(recipient),
+        "intent": "workcell_crosstalk",
+        "status": "done",
+        "summary": summary,
+        "proof": proof,
+    }
+
+
+def build_lease_plan(agent_count: int = DEFAULT_AGENT_COUNT) -> list[dict[str, Any]]:
+    """Build disjoint agent work leases for a 100-agent coding swarm plan."""
+
+    roles = ("planner", "builder", "reviewer", "verifier", "shipper")
+    systems = (
+        "geoseal_agent_task",
+        "agent_bus",
+        "swarm_router",
+        "code_slice_geometry",
+        "functional_coding_agent_benchmark",
+        "cross_language_lookup",
+        "ss1_sacred_tongue_transport",
+        "stisa_atomic_tokenizer",
+    )
+    return [
+        {
+            "lease_id": f"agent-slot-{idx:03d}",
+            "agent_id": f"agent-{idx:03d}",
+            "role": roles[idx % len(roles)],
+            "model_policy": "free-first; paid escalation only when verification fails or human marks high value",
+            "coding_system": systems[idx % len(systems)],
+            "claim_path": f"artifacts/agent_workcells/slot-{idx:03d}",
+            "write_scope": [f"artifacts/agent_workcells/slot-{idx:03d}/"],
+            "shared_files": [],
+        }
+        for idx in range(1, agent_count + 1)
+    ]
+
+
+def collision_report(leases: list[dict[str, Any]]) -> dict[str, Any]:
+    owners_by_scope: dict[str, list[str]] = {}
+    for lease in leases:
+        for scope in lease["write_scope"]:
+            owners_by_scope.setdefault(scope, []).append(lease["agent_id"])
+    collisions = {
+        scope: owners for scope, owners in owners_by_scope.items() if len(owners) > 1
+    }
+    return {
+        "agent_slots": len(leases),
+        "exclusive_write_scopes": len(owners_by_scope),
+        "collision_count": len(collisions),
+        "collisions": collisions,
+        "policy": "one writer per scope; shared files require explicit integration packet",
+    }
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+
+
+def build_markdown(report: dict[str, Any]) -> str:
+    checks = report["verification"]["checks"]
+    check_lines = [
+        f"- `{item['command']}` -> `{item['returncode']}` in {item['duration_ms']} ms; GeoSeal `{item['geoseal_gate']['tier']}`"
+        for item in checks
+    ]
+    agent_lines = [
+        f"- `{agent['agent_id']}` / `{agent['model_slot']}`: {agent['job']}"
+        for agent in report["agents"]
+    ]
+    proof_lines = [f"- `{path}`" for path in report["artifacts"].values()]
+    os_lines = [
+        f"- Standard: `{report['coding_operating_system']['standard']}`",
+        f"- Gate: {report['coding_operating_system']['gate']}",
+        f"- Retry: {report['coding_operating_system']['retry_policy']}",
+        f"- Bus: {report['coding_operating_system']['agent_bus_policy']}",
+        f"- Concurrency target: `{report['coding_operating_system']['concurrency_goal']}` agent slots",
+        f"- Collision count: `{report['collision_report']['collision_count']}`",
+    ]
+    return "\n".join(
+        [
+            "# SCBE Workcell Ship Report",
+            "",
+            f"Task: {report['task']}",
+            f"Decision: **{report['decision']}**",
+            f"Branch: `{report['git']['branch']}`",
+            f"Commit: `{report['git']['commit']}`",
+            "",
+            "## Agent Slots",
+            *agent_lines,
+            "",
+            "## Verification",
+            *check_lines,
+            "",
+            "## Cross-Talk",
+            f"Packets written: `{report['crosstalk']['packet_count']}`",
+            "",
+            "## Coding Operating System",
+            *os_lines,
+            "",
+            "## Artifacts",
+            *proof_lines,
+            "",
+            "## Meaning",
+            report["meaning"],
+            "",
+        ]
+    )
+
+
+def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: int = 1) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    task_id = "visible-system-proof"
+    command_specs = [
+        {
+            "command": "python -m py_compile scripts\\system\\product_launch_readiness.py scripts\\system\\build_manufacturing_braid_package.py",
+            "claimed_paths": ["scripts/system"],
+        },
+        {
+            "command": "python -m pytest tests\\system\\test_product_launch_readiness.py tests\\system\\test_build_manufacturing_braid_package.py -q",
+            "claimed_paths": ["tests/system", "scripts/system"],
+        },
+        {
+            "command": "npm run cash:launch-readiness:gate --silent",
+            "claimed_paths": ["package.json", "scripts/system", "docs"],
+        },
+    ]
+    checks = [
+        asdict(
+            run_command(
+                spec["command"],
+                REPO_ROOT,
+                max_attempts=max_attempts,
+                claimed_paths=spec["claimed_paths"],
+            )
+        )
+        for spec in command_specs
+    ] if verify else []
+    passed = bool(checks) and all(item["returncode"] == 0 for item in checks)
+    geoseal_passed = bool(checks) and all(item["geoseal_gate"]["allowed"] for item in checks)
+    leases = build_lease_plan()
+    collisions = collision_report(leases)
+    decision = "SHIP_READY" if passed else "BLOCKED"
+    if collisions["collision_count"]:
+        decision = "BLOCKED"
+    if not geoseal_passed:
+        decision = "BLOCKED"
+
+    packets = [
+        packet(AGENTS[0], AGENTS[1], task_id, "Planner bounded the work into build, review, verify, and ship packets.", []),
+        packet(AGENTS[1], AGENTS[2], task_id, "Builder identified the launch readiness and Braid package gates as the concrete work.", []),
+        packet(AGENTS[2], AGENTS[3], task_id, "Reviewer required executable proof instead of claims.", []),
+        packet(
+            AGENTS[3],
+            AGENTS[4],
+            task_id,
+            f"Verifier completed {len(checks)} GeoSeal-gated checks with decision {decision}.",
+            [item["command"] for item in checks],
+        ),
+    ]
+
+    artifacts = {
+        "report_json": str((out_dir / "workcell-report.json").relative_to(REPO_ROOT)),
+        "crosstalk_jsonl": str((out_dir / "crosstalk.jsonl").relative_to(REPO_ROOT)),
+        "ship_report": str((out_dir / "ship-report.md").relative_to(REPO_ROOT)),
+    }
+    report: dict[str, Any] = {
+        "schema": "scbe.agent_workcell_demo.v1",
+        "created_at": utc_now(),
+        "task": task,
+        "decision": decision,
+        "agents": [asdict(agent) for agent in AGENTS],
+        "crosstalk": {"packet_count": len(packets), "packets": packets},
+        "verification": {"checks": checks},
+        "leases": leases,
+        "collision_report": collisions,
+        "coding_operating_system": {
+            "standard": "SCBE agent coding workcell SOP v1",
+            "gate": "GeoSeal scan before command execution; deterministic checks before ship",
+            "retry_policy": f"commands retry up to {max_attempts} attempt(s), then block",
+            "concurrency_goal": DEFAULT_AGENT_COUNT,
+            "agent_bus_policy": (
+                "all products and model workers support each other by emitting bus packets with task, "
+                "lease, proof, risk, product route, and training-capture metadata"
+            ),
+            "routing_policy": "free models do first-pass work; paid models review/escalate high-value or failing packets",
+            "coding_systems": sorted({lease["coding_system"] for lease in leases}),
+        },
+        "git": {
+            "branch": git_value(["branch", "--show-current"], REPO_ROOT),
+            "commit": git_value(["rev-parse", "--short", "HEAD"], REPO_ROOT),
+            "status": git_value(["status", "--short"], REPO_ROOT),
+        },
+        "artifacts": artifacts,
+        "meaning": (
+            "This proves the system can turn one operator task into coordinated agent slots, "
+            "pass bounded cross-talk, reserve non-colliding work scopes, run GeoSeal-gated "
+            "verification, and emit a ship/no-ship report."
+        ),
+    }
+    write_jsonl(out_dir / "crosstalk.jsonl", packets)
+    write_json(out_dir / "workcell-report.json", report)
+    (out_dir / "ship-report.md").write_text(build_markdown(report), encoding="utf-8")
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a visible SCBE multi-agent workcell proof.")
+    parser.add_argument("--task", default="Show that SCBE can coordinate one unit of work from plan to ship.")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--max-attempts", type=int, default=1)
+    parser.add_argument("--no-verify", action="store_true", help="Write packets/report without running commands.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = run_workcell(args.task, args.out_dir, verify=not args.no_verify, max_attempts=args.max_attempts)
+    print(json.dumps({"decision": report["decision"], "artifacts": report["artifacts"]}, indent=2))
+    return 0 if report["decision"] == "SHIP_READY" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/system/test_agent_workcell_demo.py
+++ b/tests/system/test_agent_workcell_demo.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import scripts.system.agent_workcell_demo as demo
+
+
+def test_workcell_writes_packets_report_and_markdown(tmp_path: Path, monkeypatch) -> None:
+    def fake_run(
+        command: str,
+        cwd: Path,
+        *,
+        max_attempts: int = 1,
+        claimed_paths: list[str] | None = None,
+    ) -> demo.CommandResult:
+        return demo.CommandResult(
+            command=command,
+            returncode=0,
+            duration_ms=7,
+            stdout_tail="ok",
+            stderr_tail="",
+            geoseal_gate={"allowed": True, "tier": "ALLOW"},
+            attempts=1,
+        )
+
+    monkeypatch.setattr(demo, "run_command", fake_run)
+    monkeypatch.setattr(demo, "git_value", lambda args, cwd: "test-value")
+
+    report = demo.run_workcell("prove cross-talk", tmp_path)
+
+    assert report["decision"] == "SHIP_READY"
+    assert report["crosstalk"]["packet_count"] == 4
+    assert report["collision_report"]["agent_slots"] == 100
+    assert report["collision_report"]["collision_count"] == 0
+    assert report["coding_operating_system"]["agent_bus_policy"].startswith("all products")
+    assert {agent["agent_id"] for agent in report["agents"]} == {
+        "planner",
+        "builder",
+        "reviewer",
+        "verifier",
+        "shipper",
+    }
+    assert (tmp_path / "workcell-report.json").exists()
+    assert (tmp_path / "crosstalk.jsonl").read_text(encoding="utf-8").count("\n") == 4
+    assert "Decision: **SHIP_READY**" in (tmp_path / "ship-report.md").read_text(encoding="utf-8")
+
+
+def test_workcell_blocks_when_any_verification_fails(tmp_path: Path, monkeypatch) -> None:
+    def fake_run(
+        command: str,
+        cwd: Path,
+        *,
+        max_attempts: int = 1,
+        claimed_paths: list[str] | None = None,
+    ) -> demo.CommandResult:
+        return demo.CommandResult(
+            command=command,
+            returncode=1 if "pytest" in command else 0,
+            duration_ms=7,
+            stdout_tail="",
+            stderr_tail="failed",
+            geoseal_gate={"allowed": True, "tier": "ALLOW"},
+            attempts=1,
+        )
+
+    monkeypatch.setattr(demo, "run_command", fake_run)
+    monkeypatch.setattr(demo, "git_value", lambda args, cwd: "test-value")
+
+    report = demo.run_workcell("prove blocking behavior", tmp_path)
+
+    assert report["decision"] == "BLOCKED"
+    assert any(item["returncode"] == 1 for item in report["verification"]["checks"])


### PR DESCRIPTION
## Summary
- add `npm run system:workcell-demo` as a visible agent operating-system proof
- routes one task through planner/builder/reviewer/verifier/shipper model slots
- emits bounded cross-talk packets, reserves 100 non-colliding agent leases, GeoSeal-gates commands, retries bounded checks, and writes a ship/no-ship report
- keeps generated proof artifacts under ignored `artifacts/agent_workcells/latest/`

## Why
This shows the user-facing system behavior we want: products and model workers support each other through the agent bus, GeoSeal/coding gates block unsafe work, and verification decides whether the unit can ship.

## Verification
- `python -m py_compile scripts\system\agent_workcell_demo.py tests\system\test_agent_workcell_demo.py`
- `python -m pytest tests\system\test_agent_workcell_demo.py tests\system\test_product_launch_readiness.py tests\system\test_build_manufacturing_braid_package.py -q`
- `npm run system:workcell-demo --silent -- --task "Show SCBE agent bus, GeoSeal, coding systems, and product lanes working as one no-collision workcell" --max-attempts 2`
- `git diff --check`
