### PR TITLE
feat(system): emit workcell runs onto agent bus

### DIFF
--- a/scripts/system/agent_workcell_demo.py
+++ b/scripts/system/agent_workcell_demo.py
@@ -21,11 +21,13 @@ from typing import Any, Iterable
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUT_DIR = REPO_ROOT / "artifacts" / "agent_workcells" / "latest"
+DEFAULT_BUS_LOG = REPO_ROOT / "artifacts" / "agent-bus" / "events.jsonl"
 DEFAULT_AGENT_COUNT = 100
 
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from agents.agent_bus_schema import CURRENT_SCHEMA_VERSION
 from src.crypto.geoseal_execution_gate import scan_command
 
 
@@ -220,6 +222,40 @@ def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
     path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
 
 
+def append_jsonl(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def build_bus_event(report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "_schema_version": CURRENT_SCHEMA_VERSION,
+        "task_type": "agent_workcell_sop",
+        "query": report["task"],
+        "timestamp": report["created_at"],
+        "success": report["decision"] == "SHIP_READY",
+        "agent_id": "scbe-workcell-os",
+        "llm_provider": "multi-slot-free-first",
+        "llm_model": "codex+claude+gemini+local-shell+github-ci slots",
+        "sources_used": len(report["agents"]),
+        "duration_seconds": round(
+            sum(item["duration_ms"] for item in report["verification"]["checks"]) / 1000,
+            3,
+        ),
+        "breaker_state": {"geoseal": "closed", "collision_gate": "closed"},
+        "scbe": {
+            "decision": report["decision"],
+            "geo_seal_gate_tiers": [item["geoseal_gate"]["tier"] for item in report["verification"]["checks"]],
+            "collision_count": report["collision_report"]["collision_count"],
+            "agent_slots": report["collision_report"]["agent_slots"],
+            "coding_systems": report["coding_operating_system"]["coding_systems"],
+            "product_routes": report["coding_operating_system"]["product_routes"],
+            "artifact_paths": report["artifacts"],
+        },
+    }
+
+
 def build_markdown(report: dict[str, Any]) -> str:
     checks = report["verification"]["checks"]
     check_lines = [
@@ -238,6 +274,7 @@ def build_markdown(report: dict[str, Any]) -> str:
         f"- Bus: {report['coding_operating_system']['agent_bus_policy']}",
         f"- Concurrency target: `{report['coding_operating_system']['concurrency_goal']}` agent slots",
         f"- Collision count: `{report['collision_report']['collision_count']}`",
+        f"- Bus event: `{report['artifacts']['agent_bus_event_log']}`",
     ]
     return "\n".join(
         [
@@ -325,6 +362,7 @@ def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: in
         "report_json": str((out_dir / "workcell-report.json").relative_to(REPO_ROOT)),
         "crosstalk_jsonl": str((out_dir / "crosstalk.jsonl").relative_to(REPO_ROOT)),
         "ship_report": str((out_dir / "ship-report.md").relative_to(REPO_ROOT)),
+        "agent_bus_event_log": str(DEFAULT_BUS_LOG.relative_to(REPO_ROOT)),
     }
     report: dict[str, Any] = {
         "schema": "scbe.agent_workcell_demo.v1",
@@ -347,6 +385,14 @@ def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: in
             ),
             "routing_policy": "free models do first-pass work; paid models review/escalate high-value or failing packets",
             "coding_systems": sorted({lease["coding_system"] for lease in leases}),
+            "product_routes": [
+                "workflow_snapshot_starter",
+                "governance_snapshot",
+                "governance_heartbeat",
+                "service_credits",
+                "toolkit",
+                "training_vault",
+            ],
         },
         "git": {
             "branch": git_value(["branch", "--show-current"], REPO_ROOT),
@@ -361,6 +407,7 @@ def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: in
         ),
     }
     write_jsonl(out_dir / "crosstalk.jsonl", packets)
+    append_jsonl(DEFAULT_BUS_LOG, build_bus_event(report))
     write_json(out_dir / "workcell-report.json", report)
     (out_dir / "ship-report.md").write_text(build_markdown(report), encoding="utf-8")
     return report

--- a/tests/system/test_agent_workcell_demo.py
+++ b/tests/system/test_agent_workcell_demo.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import scripts.system.agent_workcell_demo as demo
+from agents.agent_bus_schema import validate_log
 
 
 def test_workcell_writes_packets_report_and_markdown(tmp_path: Path, monkeypatch) -> None:
@@ -23,6 +24,7 @@ def test_workcell_writes_packets_report_and_markdown(tmp_path: Path, monkeypatch
 
     monkeypatch.setattr(demo, "run_command", fake_run)
     monkeypatch.setattr(demo, "git_value", lambda args, cwd: "test-value")
+    monkeypatch.setattr(demo, "DEFAULT_BUS_LOG", tmp_path / "events.jsonl")
 
     report = demo.run_workcell("prove cross-talk", tmp_path)
 
@@ -31,6 +33,7 @@ def test_workcell_writes_packets_report_and_markdown(tmp_path: Path, monkeypatch
     assert report["collision_report"]["agent_slots"] == 100
     assert report["collision_report"]["collision_count"] == 0
     assert report["coding_operating_system"]["agent_bus_policy"].startswith("all products")
+    assert "workflow_snapshot_starter" in report["coding_operating_system"]["product_routes"]
     assert {agent["agent_id"] for agent in report["agents"]} == {
         "planner",
         "builder",
@@ -41,6 +44,14 @@ def test_workcell_writes_packets_report_and_markdown(tmp_path: Path, monkeypatch
     assert (tmp_path / "workcell-report.json").exists()
     assert (tmp_path / "crosstalk.jsonl").read_text(encoding="utf-8").count("\n") == 4
     assert "Decision: **SHIP_READY**" in (tmp_path / "ship-report.md").read_text(encoding="utf-8")
+    ship_report = (tmp_path / "ship-report.md").read_text(encoding="utf-8")
+    assert "Bus event:" in ship_report
+    assert report["artifacts"]["agent_bus_event_log"] in ship_report
+
+    bus_report = validate_log(tmp_path / "events.jsonl")
+    assert bus_report.total == 1
+    assert bus_report.accepted == 1
+    assert bus_report.rejected == 0
 
 
 def test_workcell_blocks_when_any_verification_fails(tmp_path: Path, monkeypatch) -> None:
@@ -63,8 +74,11 @@ def test_workcell_blocks_when_any_verification_fails(tmp_path: Path, monkeypatch
 
     monkeypatch.setattr(demo, "run_command", fake_run)
     monkeypatch.setattr(demo, "git_value", lambda args, cwd: "test-value")
+    monkeypatch.setattr(demo, "DEFAULT_BUS_LOG", tmp_path / "events.jsonl")
 
     report = demo.run_workcell("prove blocking behavior", tmp_path)
 
     assert report["decision"] == "BLOCKED"
     assert any(item["returncode"] == 1 for item in report["verification"]["checks"])
+    bus_report = validate_log(tmp_path / "events.jsonl")
+    assert bus_report.accepted == 1


### PR DESCRIPTION
## Summary
- make `system:workcell-demo` append schema-compatible Agent Bus events to `artifacts/agent-bus/events.jsonl`
- include SCBE decision metadata: GeoSeal gate tiers, 100 agent slots, collision count, coding systems, product routes, and artifact paths
- extend workcell tests to validate the emitted bus log with `agents.agent_bus_schema.validate_log`

## Verification
- `python -m pytest tests\system\test_agent_workcell_demo.py tests\system\test_product_launch_readiness.py tests\system\test_build_manufacturing_braid_package.py -q`
- `npm run system:workcell-demo --silent -- --task "Show SCBE agent bus, GeoSeal, coding systems, and product lanes working as one no-collision workcell" --max-attempts 2`
- `python -m agents.agent_bus_cli verify artifacts\agent-bus\events.jsonl`
- `git diff --check`
