### PR TITLE
feat(system): add multi-agent deploy smoke

### DIFF
--- a/scripts/system/agent_workcell_demo.py
+++ b/scripts/system/agent_workcell_demo.py
@@ -18,7 +18,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUT_DIR = REPO_ROOT / "artifacts" / "agent_workcells" / "latest"
 DEFAULT_BUS_LOG = REPO_ROOT / "artifacts" / "agent-bus" / "events.jsonl"
@@ -84,6 +83,50 @@ AGENTS = (
 )
 
 
+DEPLOY_AGENTS = (
+    WorkcellAgent(
+        agent_id="architect",
+        model_slot="codex",
+        role="deploy-router",
+        job="Break the deploy request into bounded, non-overlapping release packets.",
+    ),
+    WorkcellAgent(
+        agent_id="builder",
+        model_slot="free-local-first",
+        role="release-builder",
+        job="Prepare the deployable artifact and local proof paths.",
+    ),
+    WorkcellAgent(
+        agent_id="security",
+        model_slot="geoseal",
+        role="command-gate",
+        job="Gate every deploy command before execution.",
+    ),
+    WorkcellAgent(
+        agent_id="tester",
+        model_slot="local-shell",
+        role="regression-runner",
+        job="Run deterministic deploy and product-readiness checks.",
+    ),
+    WorkcellAgent(
+        agent_id="deployer",
+        model_slot="github-ci",
+        role="promotion-coordinator",
+        job="Promote only when gates pass and rollback evidence exists.",
+    ),
+    WorkcellAgent(
+        agent_id="monitor",
+        model_slot="vercel-smoke",
+        role="post-deploy-monitor",
+        job="Confirm live-route and Agent Bus evidence after the deploy lane runs.",
+    ),
+)
+
+
+def scenario_agents(scenario: str) -> tuple[WorkcellAgent, ...]:
+    return DEPLOY_AGENTS if scenario == "deploy" else AGENTS
+
+
 def utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -95,7 +138,13 @@ def tail(text: str, limit: int = 1800) -> str:
     return cleaned[-limit:]
 
 
-def run_command(command: str, cwd: Path, *, max_attempts: int = 1, claimed_paths: list[str] | None = None) -> CommandResult:
+def run_command(
+    command: str,
+    cwd: Path,
+    *,
+    max_attempts: int = 1,
+    claimed_paths: list[str] | None = None,
+) -> CommandResult:
     gate = scan_command(command, claimed_paths=claimed_paths).to_dict()
     if not gate["allowed"]:
         return CommandResult(
@@ -153,7 +202,13 @@ def git_value(args: Iterable[str], cwd: Path) -> str:
     return proc.stdout.strip() or proc.stderr.strip() or "unknown"
 
 
-def packet(sender: WorkcellAgent, recipient: WorkcellAgent, task_id: str, summary: str, proof: list[str]) -> dict[str, Any]:
+def packet(
+    sender: WorkcellAgent,
+    recipient: WorkcellAgent,
+    task_id: str,
+    summary: str,
+    proof: list[str],
+) -> dict[str, Any]:
     return {
         "created_at": utc_now(),
         "task_id": task_id,
@@ -195,6 +250,47 @@ def build_lease_plan(agent_count: int = DEFAULT_AGENT_COUNT) -> list[dict[str, A
     ]
 
 
+def command_specs_for_scenario(scenario: str) -> list[dict[str, Any]]:
+    if scenario == "deploy":
+        return [
+            {
+                "command": "python -m py_compile scripts\\system\\agent_workcell_demo.py scripts\\system\\remote_app_config_smoke.py scripts\\system\\product_launch_readiness.py",
+                "claimed_paths": ["scripts/system"],
+            },
+            {
+                "command": "python -m pytest tests\\system\\test_agent_workcell_demo.py tests\\system\\test_product_launch_readiness.py -q",
+                "claimed_paths": ["tests/system", "scripts/system"],
+            },
+            {
+                "command": "npm run smoke:remote-app-config --silent",
+                "claimed_paths": [
+                    "package.json",
+                    "scripts/system",
+                    "docs",
+                    "vercel.json",
+                ],
+            },
+            {
+                "command": "npm run cash:launch-readiness:gate --silent",
+                "claimed_paths": ["package.json", "scripts/system", "docs"],
+            },
+        ]
+    return [
+        {
+            "command": "python -m py_compile scripts\\system\\product_launch_readiness.py scripts\\system\\build_manufacturing_braid_package.py",
+            "claimed_paths": ["scripts/system"],
+        },
+        {
+            "command": "python -m pytest tests\\system\\test_product_launch_readiness.py tests\\system\\test_build_manufacturing_braid_package.py -q",
+            "claimed_paths": ["tests/system", "scripts/system"],
+        },
+        {
+            "command": "npm run cash:launch-readiness:gate --silent",
+            "claimed_paths": ["package.json", "scripts/system", "docs"],
+        },
+    ]
+
+
 def collision_report(leases: list[dict[str, Any]]) -> dict[str, Any]:
     owners_by_scope: dict[str, list[str]] = {}
     for lease in leases:
@@ -212,14 +308,35 @@ def collision_report(leases: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def write_lease_manifest(
+    path: Path, leases: list[dict[str, Any]], collisions: dict[str, Any]
+) -> None:
+    write_json(
+        path,
+        {
+            "schema": "scbe.agent_workcell_leases.v1",
+            "created_at": utc_now(),
+            "agent_slots": len(leases),
+            "collision_count": collisions["collision_count"],
+            "policy": collisions["policy"],
+            "leases": leases,
+        },
+    )
+
+
 def write_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
 
 
 def append_jsonl(path: Path, row: dict[str, Any]) -> None:
@@ -231,7 +348,11 @@ def append_jsonl(path: Path, row: dict[str, Any]) -> None:
 def build_bus_event(report: dict[str, Any]) -> dict[str, Any]:
     return {
         "_schema_version": CURRENT_SCHEMA_VERSION,
-        "task_type": "agent_workcell_sop",
+        "task_type": (
+            "agent_workcell_deploy"
+            if report["scenario"] == "deploy"
+            else "agent_workcell_sop"
+        ),
         "query": report["task"],
         "timestamp": report["created_at"],
         "success": report["decision"] == "SHIP_READY",
@@ -240,18 +361,24 @@ def build_bus_event(report: dict[str, Any]) -> dict[str, Any]:
         "llm_model": "codex+claude+gemini+local-shell+github-ci slots",
         "sources_used": len(report["agents"]),
         "duration_seconds": round(
-            sum(item["duration_ms"] for item in report["verification"]["checks"]) / 1000,
+            sum(item["duration_ms"] for item in report["verification"]["checks"])
+            / 1000,
             3,
         ),
         "breaker_state": {"geoseal": "closed", "collision_gate": "closed"},
         "scbe": {
             "decision": report["decision"],
-            "geo_seal_gate_tiers": [item["geoseal_gate"]["tier"] for item in report["verification"]["checks"]],
+            "geo_seal_gate_tiers": [
+                item["geoseal_gate"]["tier"]
+                for item in report["verification"]["checks"]
+            ],
             "collision_count": report["collision_report"]["collision_count"],
             "agent_slots": report["collision_report"]["agent_slots"],
             "coding_systems": report["coding_operating_system"]["coding_systems"],
             "product_routes": report["coding_operating_system"]["product_routes"],
             "artifact_paths": report["artifacts"],
+            "scenario": report["scenario"],
+            "deploy_policy": report.get("deploy_policy"),
         },
     }
 
@@ -276,10 +403,20 @@ def build_markdown(report: dict[str, Any]) -> str:
         f"- Collision count: `{report['collision_report']['collision_count']}`",
         f"- Bus event: `{report['artifacts']['agent_bus_event_log']}`",
     ]
+    deploy_lines = []
+    if report["scenario"] == "deploy":
+        deploy_lines = [
+            "",
+            "## Deploy Policy",
+            f"- Promotion: {report['deploy_policy']['promotion']}",
+            f"- Rollback: {report['deploy_policy']['rollback']}",
+            f"- Monitor: {report['deploy_policy']['monitor']}",
+        ]
     return "\n".join(
         [
             "# SCBE Workcell Ship Report",
             "",
+            f"Scenario: `{report['scenario']}`",
             f"Task: {report['task']}",
             f"Decision: **{report['decision']}**",
             f"Branch: `{report['git']['branch']}`",
@@ -296,6 +433,7 @@ def build_markdown(report: dict[str, Any]) -> str:
             "",
             "## Coding Operating System",
             *os_lines,
+            *deploy_lines,
             "",
             "## Artifacts",
             *proof_lines,
@@ -307,36 +445,40 @@ def build_markdown(report: dict[str, Any]) -> str:
     )
 
 
-def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: int = 1) -> dict[str, Any]:
+def run_workcell(
+    task: str,
+    out_dir: Path,
+    verify: bool = True,
+    max_attempts: int = 1,
+    scenario: str = "launch",
+) -> dict[str, Any]:
     out_dir.mkdir(parents=True, exist_ok=True)
-    task_id = "visible-system-proof"
-    command_specs = [
-        {
-            "command": "python -m py_compile scripts\\system\\product_launch_readiness.py scripts\\system\\build_manufacturing_braid_package.py",
-            "claimed_paths": ["scripts/system"],
-        },
-        {
-            "command": "python -m pytest tests\\system\\test_product_launch_readiness.py tests\\system\\test_build_manufacturing_braid_package.py -q",
-            "claimed_paths": ["tests/system", "scripts/system"],
-        },
-        {
-            "command": "npm run cash:launch-readiness:gate --silent",
-            "claimed_paths": ["package.json", "scripts/system", "docs"],
-        },
-    ]
-    checks = [
-        asdict(
-            run_command(
-                spec["command"],
-                REPO_ROOT,
-                max_attempts=max_attempts,
-                claimed_paths=spec["claimed_paths"],
+    if scenario not in {"launch", "deploy"}:
+        raise ValueError(f"unsupported workcell scenario: {scenario}")
+    agents = scenario_agents(scenario)
+    task_id = (
+        "multi-agent-deploy-proof" if scenario == "deploy" else "visible-system-proof"
+    )
+    command_specs = command_specs_for_scenario(scenario)
+    checks = (
+        [
+            asdict(
+                run_command(
+                    spec["command"],
+                    REPO_ROOT,
+                    max_attempts=max_attempts,
+                    claimed_paths=spec["claimed_paths"],
+                )
             )
-        )
-        for spec in command_specs
-    ] if verify else []
+            for spec in command_specs
+        ]
+        if verify
+        else []
+    )
     passed = bool(checks) and all(item["returncode"] == 0 for item in checks)
-    geoseal_passed = bool(checks) and all(item["geoseal_gate"]["allowed"] for item in checks)
+    geoseal_passed = bool(checks) and all(
+        item["geoseal_gate"]["allowed"] for item in checks
+    )
     leases = build_lease_plan()
     collisions = collision_report(leases)
     decision = "SHIP_READY" if passed else "BLOCKED"
@@ -346,12 +488,30 @@ def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: in
         decision = "BLOCKED"
 
     packets = [
-        packet(AGENTS[0], AGENTS[1], task_id, "Planner bounded the work into build, review, verify, and ship packets.", []),
-        packet(AGENTS[1], AGENTS[2], task_id, "Builder identified the launch readiness and Braid package gates as the concrete work.", []),
-        packet(AGENTS[2], AGENTS[3], task_id, "Reviewer required executable proof instead of claims.", []),
         packet(
-            AGENTS[3],
-            AGENTS[4],
+            agents[0],
+            agents[1],
+            task_id,
+            "Planner bounded the work into build, review, verify, and ship packets.",
+            [],
+        ),
+        packet(
+            agents[1],
+            agents[2],
+            task_id,
+            "Builder identified the deployable gates and product readiness checks as the concrete work.",
+            [],
+        ),
+        packet(
+            agents[2],
+            agents[3],
+            task_id,
+            "Reviewer required executable proof instead of claims.",
+            [],
+        ),
+        packet(
+            agents[3],
+            agents[4],
             task_id,
             f"Verifier completed {len(checks)} GeoSeal-gated checks with decision {decision}.",
             [item["command"] for item in checks],
@@ -362,14 +522,16 @@ def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: in
         "report_json": str((out_dir / "workcell-report.json").relative_to(REPO_ROOT)),
         "crosstalk_jsonl": str((out_dir / "crosstalk.jsonl").relative_to(REPO_ROOT)),
         "ship_report": str((out_dir / "ship-report.md").relative_to(REPO_ROOT)),
+        "lease_manifest": str((out_dir / "leases.json").relative_to(REPO_ROOT)),
         "agent_bus_event_log": str(DEFAULT_BUS_LOG.relative_to(REPO_ROOT)),
     }
     report: dict[str, Any] = {
         "schema": "scbe.agent_workcell_demo.v1",
         "created_at": utc_now(),
+        "scenario": scenario,
         "task": task,
         "decision": decision,
-        "agents": [asdict(agent) for agent in AGENTS],
+        "agents": [asdict(agent) for agent in agents],
         "crosstalk": {"packet_count": len(packets), "packets": packets},
         "verification": {"checks": checks},
         "leases": leases,
@@ -394,6 +556,11 @@ def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: in
                 "training_vault",
             ],
         },
+        "deploy_policy": {
+            "promotion": "staging proof must pass GeoSeal, regression checks, remote-app route smoke, and launch readiness gate before production promotion",
+            "rollback": "failed gate or post-deploy monitor returns BLOCKED and preserves artifacts for rollback review",
+            "monitor": "Agent Bus event plus route/product readiness artifacts become the post-deploy evidence trail",
+        },
         "git": {
             "branch": git_value(["branch", "--show-current"], REPO_ROOT),
             "commit": git_value(["rev-parse", "--short", "HEAD"], REPO_ROOT),
@@ -407,6 +574,7 @@ def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: in
         ),
     }
     write_jsonl(out_dir / "crosstalk.jsonl", packets)
+    write_lease_manifest(out_dir / "leases.json", leases, collisions)
     append_jsonl(DEFAULT_BUS_LOG, build_bus_event(report))
     write_json(out_dir / "workcell-report.json", report)
     (out_dir / "ship-report.md").write_text(build_markdown(report), encoding="utf-8")
@@ -414,18 +582,38 @@ def run_workcell(task: str, out_dir: Path, verify: bool = True, max_attempts: in
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run a visible SCBE multi-agent workcell proof.")
-    parser.add_argument("--task", default="Show that SCBE can coordinate one unit of work from plan to ship.")
+    parser = argparse.ArgumentParser(
+        description="Run a visible SCBE multi-agent workcell proof."
+    )
+    parser.add_argument(
+        "--task",
+        default="Show that SCBE can coordinate one unit of work from plan to ship.",
+    )
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument("--max-attempts", type=int, default=1)
-    parser.add_argument("--no-verify", action="store_true", help="Write packets/report without running commands.")
+    parser.add_argument("--scenario", choices=("launch", "deploy"), default="launch")
+    parser.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="Write packets/report without running commands.",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
-    report = run_workcell(args.task, args.out_dir, verify=not args.no_verify, max_attempts=args.max_attempts)
-    print(json.dumps({"decision": report["decision"], "artifacts": report["artifacts"]}, indent=2))
+    report = run_workcell(
+        args.task,
+        args.out_dir,
+        verify=not args.no_verify,
+        max_attempts=args.max_attempts,
+        scenario=args.scenario,
+    )
+    print(
+        json.dumps(
+            {"decision": report["decision"], "artifacts": report["artifacts"]}, indent=2
+        )
+    )
     return 0 if report["decision"] == "SHIP_READY" else 1
 
 

--- a/tests/system/test_agent_workcell_demo.py
+++ b/tests/system/test_agent_workcell_demo.py
@@ -4,7 +4,9 @@ import scripts.system.agent_workcell_demo as demo
 from agents.agent_bus_schema import validate_log
 
 
-def test_workcell_writes_packets_report_and_markdown(tmp_path: Path, monkeypatch) -> None:
+def test_workcell_writes_packets_report_and_markdown(
+    tmp_path: Path, monkeypatch
+) -> None:
     def fake_run(
         command: str,
         cwd: Path,
@@ -29,11 +31,17 @@ def test_workcell_writes_packets_report_and_markdown(tmp_path: Path, monkeypatch
     report = demo.run_workcell("prove cross-talk", tmp_path)
 
     assert report["decision"] == "SHIP_READY"
+    assert report["scenario"] == "launch"
     assert report["crosstalk"]["packet_count"] == 4
     assert report["collision_report"]["agent_slots"] == 100
     assert report["collision_report"]["collision_count"] == 0
-    assert report["coding_operating_system"]["agent_bus_policy"].startswith("all products")
-    assert "workflow_snapshot_starter" in report["coding_operating_system"]["product_routes"]
+    assert report["coding_operating_system"]["agent_bus_policy"].startswith(
+        "all products"
+    )
+    assert (
+        "workflow_snapshot_starter"
+        in report["coding_operating_system"]["product_routes"]
+    )
     assert {agent["agent_id"] for agent in report["agents"]} == {
         "planner",
         "builder",
@@ -42,8 +50,11 @@ def test_workcell_writes_packets_report_and_markdown(tmp_path: Path, monkeypatch
         "shipper",
     }
     assert (tmp_path / "workcell-report.json").exists()
+    assert (tmp_path / "leases.json").exists()
     assert (tmp_path / "crosstalk.jsonl").read_text(encoding="utf-8").count("\n") == 4
-    assert "Decision: **SHIP_READY**" in (tmp_path / "ship-report.md").read_text(encoding="utf-8")
+    assert "Decision: **SHIP_READY**" in (tmp_path / "ship-report.md").read_text(
+        encoding="utf-8"
+    )
     ship_report = (tmp_path / "ship-report.md").read_text(encoding="utf-8")
     assert "Bus event:" in ship_report
     assert report["artifacts"]["agent_bus_event_log"] in ship_report
@@ -54,7 +65,67 @@ def test_workcell_writes_packets_report_and_markdown(tmp_path: Path, monkeypatch
     assert bus_report.rejected == 0
 
 
-def test_workcell_blocks_when_any_verification_fails(tmp_path: Path, monkeypatch) -> None:
+def test_deploy_scenario_runs_deploy_gates_and_bus_event(
+    tmp_path: Path, monkeypatch
+) -> None:
+    def fake_run(
+        command: str,
+        cwd: Path,
+        *,
+        max_attempts: int = 1,
+        claimed_paths: list[str] | None = None,
+    ) -> demo.CommandResult:
+        return demo.CommandResult(
+            command=command,
+            returncode=0,
+            duration_ms=9,
+            stdout_tail="ok",
+            stderr_tail="",
+            geoseal_gate={"allowed": True, "tier": "ALLOW"},
+            attempts=1,
+        )
+
+    monkeypatch.setattr(demo, "run_command", fake_run)
+    monkeypatch.setattr(demo, "git_value", lambda args, cwd: "test-value")
+    monkeypatch.setattr(demo, "DEFAULT_BUS_LOG", tmp_path / "events.jsonl")
+
+    report = demo.run_workcell("test multi agent deploy", tmp_path, scenario="deploy")
+
+    assert report["decision"] == "SHIP_READY"
+    assert report["scenario"] == "deploy"
+    assert report["collision_report"]["agent_slots"] == 100
+    assert report["collision_report"]["collision_count"] == 0
+    assert "deployer" in {agent["agent_id"] for agent in report["agents"]}
+    assert any(
+        "smoke:remote-app-config" in item["command"]
+        for item in report["verification"]["checks"]
+    )
+    assert report["deploy_policy"]["rollback"].startswith("failed gate")
+    assert (tmp_path / "leases.json").exists()
+    assert "Scenario: `deploy`" in (tmp_path / "ship-report.md").read_text(
+        encoding="utf-8"
+    )
+
+    bus_report = validate_log(tmp_path / "events.jsonl")
+    assert bus_report.total == 1
+    assert bus_report.accepted == 1
+    assert bus_report.rejected == 0
+
+
+def test_collision_report_detects_duplicate_write_scope() -> None:
+    leases = demo.build_lease_plan(2)
+    leases[1]["write_scope"] = leases[0]["write_scope"]
+
+    report = demo.collision_report(leases)
+
+    assert report["agent_slots"] == 2
+    assert report["collision_count"] == 1
+    assert leases[0]["write_scope"][0] in report["collisions"]
+
+
+def test_workcell_blocks_when_any_verification_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
     def fake_run(
         command: str,
         cwd: Path,


### PR DESCRIPTION
## Summary
- adds a deploy scenario to the SCBE workcell runner
- routes deploy proof through deployer/security/monitor agent slots
- writes a 100-slot lease manifest, GeoSeal-gated ship report, and Agent Bus deploy event

## Verification
- python -m py_compile scripts\system\agent_workcell_demo.py
- python -m pytest tests\system\test_agent_workcell_demo.py tests\system\test_product_launch_readiness.py tests\system\test_build_manufacturing_braid_package.py -q
- npm run system:workcell-demo --silent -- --scenario deploy --task "Test multi agent deploy" --max-attempts 2
- python -m agents.agent_bus_cli verify artifacts\agent-bus\events.jsonl

## Rollback
- revert this PR; launch scenario remains the prior default path