### PR TITLE
fix(billing): accept deployed product link aliases

### DIFF
--- a/api/billing/stripe_webhook.js
+++ b/api/billing/stripe_webhook.js
@@ -126,8 +126,14 @@ function snapshotConfig() {
     paymentLinkId: process.env.STRIPE_SNAPSHOT_PAYMENT_LINK_ID || '',
     heartbeatPaymentLinkId:
       process.env.STRIPE_HEARTBEAT_PAYMENT_LINK_ID || LIVE_HEARTBEAT_PAYMENT_LINK_ID,
-    toolkitPaymentLinkId: process.env.STRIPE_TOOLKIT_PAYMENT_LINK_ID || '',
-    vaultPaymentLinkId: process.env.STRIPE_VAULT_PAYMENT_LINK_ID || '',
+    toolkitPaymentLinkId:
+      process.env.STRIPE_TOOLKIT_PAYMENT_LINK_ID ||
+      process.env.SCBE_PAYMENT_LINK_TOOLKIT ||
+      '',
+    vaultPaymentLinkId:
+      process.env.STRIPE_VAULT_PAYMENT_LINK_ID ||
+      process.env.SCBE_PAYMENT_LINK_VAULT ||
+      '',
     repo: process.env.POLLY_TRAIN_REPO || process.env.GITHUB_REPO || 'issdandavis/SCBE-AETHERMOORE',
     githubToken:
       process.env.POLLY_TRAIN_GITHUB_TOKEN ||

--- a/docs/ops/STRIPE_HEARTBEAT_ACTIVATION.md
+++ b/docs/ops/STRIPE_HEARTBEAT_ACTIVATION.md
@@ -76,6 +76,13 @@ STRIPE_TOOLKIT_PAYMENT_LINK_ID=plink_<live_toolkit_payment_link_id>
 STRIPE_VAULT_PAYMENT_LINK_ID=plink_<live_vault_payment_link_id>
 ```
 
+The webhook also accepts the older already-deployed aliases:
+
+```text
+SCBE_PAYMENT_LINK_TOOLKIT=plink_<live_toolkit_payment_link_id>
+SCBE_PAYMENT_LINK_VAULT=plink_<live_vault_payment_link_id>
+```
+
 Set these GitHub Actions secrets if the product-delivery workflow should email
 buyers a direct access link:
 

--- a/tests/api/stripe_webhook_js.test.ts
+++ b/tests/api/stripe_webhook_js.test.ts
@@ -39,6 +39,8 @@ function clearEnv(): void {
   delete process.env.STRIPE_HEARTBEAT_PAYMENT_LINK_ID;
   delete process.env.STRIPE_TOOLKIT_PAYMENT_LINK_ID;
   delete process.env.STRIPE_VAULT_PAYMENT_LINK_ID;
+  delete process.env.SCBE_PAYMENT_LINK_TOOLKIT;
+  delete process.env.SCBE_PAYMENT_LINK_VAULT;
   delete process.env.GITHUB_TOKEN;
   delete process.env.GH_TOKEN;
   delete process.env.POLLY_TRAIN_GITHUB_TOKEN;
@@ -429,6 +431,17 @@ describe('stripe webhook — digital product detection', () => {
     const { isVaultSession, snapshotConfig } = stripeWebhook._private;
     const cfg = snapshotConfig();
     expect(isVaultSession({ payment_link: VAULT_LINK_ID }, cfg)).toBe(true);
+  });
+
+  it('accepts existing SCBE product payment link env aliases', () => {
+    clearEnv();
+    process.env.SCBE_PAYMENT_LINK_TOOLKIT = 'plink_toolkit_alias';
+    process.env.SCBE_PAYMENT_LINK_VAULT = 'plink_vault_alias';
+    const { isToolkitSession, isVaultSession, snapshotConfig } = stripeWebhook._private;
+    const cfg = snapshotConfig();
+
+    expect(isToolkitSession({ payment_link: 'plink_toolkit_alias' }, cfg)).toBe(true);
+    expect(isVaultSession({ payment_link: 'plink_vault_alias' }, cfg)).toBe(true);
   });
 
   it('matches toolkit by explicit metadata + $29 payment when link id is absent', () => {


### PR DESCRIPTION
## Summary
- lets the Stripe webhook classify $29 Toolkit/Vault purchases using the env names already present in Vercel
- keeps STRIPE_TOOLKIT_PAYMENT_LINK_ID / STRIPE_VAULT_PAYMENT_LINK_ID as preferred names
- adds fallback support for SCBE_PAYMENT_LINK_TOOLKIT / SCBE_PAYMENT_LINK_VAULT
- documents the alias behavior in the activation runbook

## Why
Vercel production already has SCBE_PAYMENT_LINK_TOOLKIT and SCBE_PAYMENT_LINK_VAULT configured. The webhook only read STRIPE_* names, so a real $29 product purchase could fall through to checkout_other unless Stripe metadata was present. This removes that delivery-classification gap without requiring another operator config step.

## Tests
- npx vitest run tests/api/stripe_webhook_js.test.ts
- python scripts\security\code_governance_gate.py check-push
- git diff --check

## Rollback
- Revert this PR only after the STRIPE_* product link env vars are present in production.