### PR TITLE
fix(billing): route workflow snapshot starter purchases

### DIFF
--- a/.github/workflows/polly-snapshot-paid.yml
+++ b/.github/workflows/polly-snapshot-paid.yml
@@ -33,6 +33,7 @@ jobs:
           CONTACT_EMAIL: ${{ github.event.client_payload.record.contact_email }}
           CONTACT_NAME: ${{ github.event.client_payload.record.contact_name }}
           LIVEMODE: ${{ github.event.client_payload.record.livemode }}
+          SOURCE: ${{ github.event.client_payload.record.source }}
         run: |
           set -euo pipefail
           # Idempotency: if an issue already exists for this Stripe session id
@@ -64,11 +65,12 @@ jobs:
 
           title="snapshot paid: ${SESSION_ID} (${price}, ${mode_tag})"
           body=$(cat <<EOF
-          A buyer just completed a \$500 AI Governance Snapshot checkout.
+          A buyer just completed an AetherMoore snapshot checkout.
 
           - session id: \`${SESSION_ID}\`
           - payment intent: \`${PAYMENT_INTENT}\`
           - amount: ${price}
+          - source: ${SOURCE:-snapshot}
           - mode: ${mode_tag}
           - buyer name: ${CONTACT_NAME:-(not provided)}
           - buyer email: ${CONTACT_EMAIL:-(not provided)}
@@ -129,7 +131,7 @@ jobs:
           body_lines = [
               f"Hi {name},",
               "",
-              "Thanks for purchasing the $500 AI Governance Snapshot.",
+              "Thanks for purchasing an AetherMoore AI workflow/snapshot review.",
               "I'll reply within one business day to schedule a 30-minute kickoff call.",
               "Until then, please prep these so the snapshot covers what you actually need:",
               "",

--- a/api/billing/stripe_webhook.js
+++ b/api/billing/stripe_webhook.js
@@ -26,6 +26,7 @@ const crypto = require('crypto');
 
 const SNAPSHOT_AMOUNT_CENTS = 50000;
 const HEARTBEAT_AMOUNT_CENTS = 9900;
+const LIVE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID = 'plink_1TW71yJTF2SuUODIqYFRU9JY';
 const LIVE_HEARTBEAT_PAYMENT_LINK_ID = 'plink_1TW71zJTF2SuUODICZLQCCS3';
 const DIGITAL_PRODUCT_AMOUNT_CENTS = 2900;
 const TOLERANCE_SECONDS = 300; // Stripe default replay window
@@ -124,6 +125,10 @@ function snapshotConfig() {
   return {
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
     paymentLinkId: process.env.STRIPE_SNAPSHOT_PAYMENT_LINK_ID || '',
+    workflowSnapshotPaymentLinkId:
+      process.env.STRIPE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID ||
+      process.env.SCBE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID ||
+      LIVE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID,
     heartbeatPaymentLinkId:
       process.env.STRIPE_HEARTBEAT_PAYMENT_LINK_ID || LIVE_HEARTBEAT_PAYMENT_LINK_ID,
     toolkitPaymentLinkId:
@@ -179,6 +184,14 @@ function isSnapshotSession(session, cfg) {
     Number(session.amount_total) === SNAPSHOT_AMOUNT_CENTS &&
     String(session.currency || '').toLowerCase() === 'usd'
   ) {
+    return true;
+  }
+  return false;
+}
+
+function isWorkflowSnapshotSession(session, cfg) {
+  if (!session || typeof session !== 'object') return false;
+  if (cfg.workflowSnapshotPaymentLinkId && session.payment_link === cfg.workflowSnapshotPaymentLinkId) {
     return true;
   }
   return false;
@@ -316,7 +329,8 @@ function buildProductDeliveryRecord(session, productKey) {
 }
 
 async function dispatchSnapshotPaid(session, cfg) {
-  const record = buildSessionRecord(session, 'snapshot_paid', 'governance-snapshot');
+  const source = isWorkflowSnapshotSession(session, cfg) ? 'workflow-snapshot' : 'governance-snapshot';
+  const record = buildSessionRecord(session, 'snapshot_paid', source);
   return dispatchEvent('polly_snapshot_paid', record, cfg);
 }
 
@@ -386,7 +400,7 @@ module.exports = async function handler(req, res) {
   // Only act on the one event we care about; everything else is a 200 ack.
   if (event && event.type === 'checkout.session.completed') {
     const session = event.data && event.data.object;
-    if (isSnapshotSession(session, cfg)) {
+    if (isWorkflowSnapshotSession(session, cfg) || isSnapshotSession(session, cfg)) {
       const dispatch = await dispatchSnapshotPaid(session, cfg);
       return sendJson(res, 200, {
         ok: true,
@@ -437,6 +451,7 @@ module.exports = async function handler(req, res) {
 module.exports._private = {
   parseSignatureHeader,
   verifySignature,
+  isWorkflowSnapshotSession,
   isSnapshotSession,
   isHeartbeatSession,
   isToolkitSession,
@@ -446,6 +461,7 @@ module.exports._private = {
   buildSessionRecord,
   buildProductDeliveryRecord,
   SNAPSHOT_AMOUNT_CENTS,
+  LIVE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID,
   HEARTBEAT_AMOUNT_CENTS,
   DIGITAL_PRODUCT_AMOUNT_CENTS,
   DIGITAL_PRODUCTS,

--- a/tests/api/stripe_webhook_js.test.ts
+++ b/tests/api/stripe_webhook_js.test.ts
@@ -18,6 +18,7 @@ const stripeWebhook = require('../../api/billing/stripe_webhook.js');
 
 const TEST_SECRET = 'whsec_test_secret_xyz';
 const SNAPSHOT_LINK_ID = 'plink_snapshot_test_42';
+const WORKFLOW_SNAPSHOT_LINK_ID = 'plink_workflow_snapshot_test_99';
 const HEARTBEAT_LINK_ID = 'plink_heartbeat_test_99';
 const TOOLKIT_LINK_ID = 'plink_toolkit_test_29';
 const VAULT_LINK_ID = 'plink_vault_test_29';
@@ -25,6 +26,7 @@ const VAULT_LINK_ID = 'plink_vault_test_29';
 function setEnv(): void {
   process.env.STRIPE_WEBHOOK_SECRET = TEST_SECRET;
   process.env.STRIPE_SNAPSHOT_PAYMENT_LINK_ID = SNAPSHOT_LINK_ID;
+  process.env.STRIPE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID = WORKFLOW_SNAPSHOT_LINK_ID;
   process.env.STRIPE_HEARTBEAT_PAYMENT_LINK_ID = HEARTBEAT_LINK_ID;
   process.env.STRIPE_TOOLKIT_PAYMENT_LINK_ID = TOOLKIT_LINK_ID;
   process.env.STRIPE_VAULT_PAYMENT_LINK_ID = VAULT_LINK_ID;
@@ -36,6 +38,8 @@ function setEnv(): void {
 function clearEnv(): void {
   delete process.env.STRIPE_WEBHOOK_SECRET;
   delete process.env.STRIPE_SNAPSHOT_PAYMENT_LINK_ID;
+  delete process.env.STRIPE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID;
+  delete process.env.SCBE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID;
   delete process.env.STRIPE_HEARTBEAT_PAYMENT_LINK_ID;
   delete process.env.STRIPE_TOOLKIT_PAYMENT_LINK_ID;
   delete process.env.STRIPE_VAULT_PAYMENT_LINK_ID;
@@ -427,6 +431,20 @@ describe('stripe webhook — digital product detection', () => {
     expect(isToolkitSession({ payment_link: TOOLKIT_LINK_ID }, cfg)).toBe(true);
   });
 
+  it('matches workflow snapshot starter by payment_link id', () => {
+    const { isWorkflowSnapshotSession, snapshotConfig } = stripeWebhook._private;
+    const cfg = snapshotConfig();
+    expect(isWorkflowSnapshotSession({ payment_link: WORKFLOW_SNAPSHOT_LINK_ID }, cfg)).toBe(true);
+  });
+
+  it('accepts existing SCBE workflow snapshot payment link env alias', () => {
+    clearEnv();
+    process.env.SCBE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID = 'plink_workflow_alias';
+    const { isWorkflowSnapshotSession, snapshotConfig } = stripeWebhook._private;
+    const cfg = snapshotConfig();
+    expect(isWorkflowSnapshotSession({ payment_link: 'plink_workflow_alias' }, cfg)).toBe(true);
+  });
+
   it('matches vault by payment_link id', () => {
     const { isVaultSession, snapshotConfig } = stripeWebhook._private;
     const cfg = snapshotConfig();
@@ -567,6 +585,33 @@ describe('stripe webhook — event routing', () => {
     expect(rec.contact_email).toBe('buyer@example.com');
     expect(rec.amount_total).toBe(50000);
     expect(rec.source).toBe('governance-snapshot');
+  });
+
+  it('workflow snapshot starter checkout completes → snapshot dispatch with workflow source', async () => {
+    let capturedBody: string | undefined;
+    vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
+      capturedBody = (init as { body: string }).body;
+      return new Response('{}', { status: 200 });
+    });
+    const raw = snapshotEvent({
+      id: 'cs_test_workflow_snapshot_99',
+      amount_total: 9900,
+      payment_link: WORKFLOW_SNAPSHOT_LINK_ID,
+    });
+    const sig = signPayload(raw, TEST_SECRET);
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': sig } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { handled: string }).handled).toBe('snapshot_paid');
+    expect(capturedBody).toBeDefined();
+    const dispatched = JSON.parse(capturedBody as string);
+    expect(dispatched.event_type).toBe('polly_snapshot_paid');
+    const rec = dispatched.client_payload.record;
+    expect(rec.kind).toBe('snapshot_paid');
+    expect(rec.session_id).toBe('cs_test_workflow_snapshot_99');
+    expect(rec.amount_total).toBe(9900);
+    expect(rec.source).toBe('workflow-snapshot');
   });
 
   it('heartbeat checkout completes → heartbeat dispatch payload', async () => {


### PR DESCRIPTION
## Summary
- route the $99 Workflow Snapshot starter Payment Link through the paid-snapshot webhook path
- tag starter dispatch records as `workflow-snapshot` so fulfillment can distinguish it from the $500 Governance Snapshot
- make the buyer issue/email copy price-neutral so the starter buyer is not told they bought the $500 product
- set the exact starter Payment Link as a production Vercel env var

## Tests
- `npx vitest run tests/api/stripe_webhook_js.test.ts` -> 33 passed
- `python scripts\security\code_governance_gate.py check-push` -> PASS, 0 findings
- `git diff --check` -> line-ending warnings only

## Rollback
Revert this PR and remove `STRIPE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID` from Vercel if starter purchases should stop auto-filing snapshot intake.