### PR TITLE
fix(cli): format SCBE terminal test

### DIFF
--- a/tests/system/test_scbe_npm_cli_compiler.py
+++ b/tests/system/test_scbe_npm_cli_compiler.py
@@ -2,7 +2,6 @@ import json
 import subprocess
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI = REPO_ROOT / "packages" / "cli" / "bin" / "scbe.js"
 


### PR DESCRIPTION
## Summary
- applies CI Black formatting to the SCBE terminal CLI test added by #1730
- no behavior change

## Verification
- python -m black --check --target-version py311 --line-length 120 src/ tests/
- python -m ruff check --config ruff.toml
- python -m pytest tests\system\test_scbe_npm_cli_compiler.py -q

## Rollback
- revert this PR; formatting-only