### PR TITLE
fix(geoseal): block code-roundtrip on public bridge

### DIFF
--- a/src/api/geoseal_service.py
+++ b/src/api/geoseal_service.py
@@ -24,7 +24,6 @@ GEOSEAL_CLI_COMMANDS = frozenset(
         "replay",
         "testing-cli",
         "project-scaffold",
-        "code-roundtrip",
         "call-switchboard",
         "lightning-indexer",
         "yin-yang-dual",
@@ -175,7 +174,6 @@ async def spaceport_status() -> dict[str, Any]:
                     "/v1/geoseal/replay",
                     "/v1/geoseal/testing-cli",
                     "/v1/geoseal/project-scaffold",
-                    "/v1/geoseal/code-roundtrip",
                 ],
                 "authenticated_runtime": [
                     "/runtime/inspect",

--- a/tests/test_agent_task_run_and_external_eval.py
+++ b/tests/test_agent_task_run_and_external_eval.py
@@ -359,6 +359,20 @@ def test_geoseal_service_cli_bridge_code_packet():
     assert "native_tokenization" in body["data"] or "transport_tokens" in body["data"]
 
 
+def test_geoseal_service_cli_bridge_blocks_code_roundtrip_over_http():
+    from fastapi.testclient import TestClient
+
+    from src.api.geoseal_service import app
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/geoseal/code-roundtrip",
+        json={"content": "def add(a, b):\n    return a + b\n", "language": "python"},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Unknown GeoSeal command: code-roundtrip"
+
+
 def test_external_eval_manifest_validates():
     module = load_module(
         REPO_ROOT / "scripts" / "benchmark" / "external_agentic_eval_driver.py",


### PR DESCRIPTION
## Summary
- remove code-roundtrip from the public GeoSeal HTTP command allowlist
- remove the public metadata route advertisement for /v1/geoseal/code-roundtrip
- add a regression test proving public HTTP code-roundtrip returns 404

## Test evidence
- python -m pytest tests/test_agent_task_run_and_external_eval.py -q
- manual TestClient check: public metadata does not include /v1/geoseal/code-roundtrip and POST returns 404

## Rollback
- Revert this PR if authenticated code-roundtrip routing is implemented behind a separate protected endpoint.