### PR TITLE
feat(cli): add Sacred Tongues compiler VM

### DIFF
--- a/bin/geoseal.cjs
+++ b/bin/geoseal.cjs
@@ -57,6 +57,8 @@ Useful commands:
   geoseal decode-code-lanes "$(cat artifacts/tokenizer_code_lanes/shl_lanes.json)" --output-dir artifacts/tokenizer_code_lanes/decoded --from-binary --write-binary --json
   geoseal ai2ai-bridge --content "def add(a, b): return a + b" --language python --json
   geoseal code-packet --content "def add(a, b): return a + b" --language python
+  geoseal tongue-compile --content "ko:set r0, 2" --json
+  geoseal tongue-run --content "ko:set r0, 2\nko:print r0\nko:halt" --json
   geoseal explain-route --content "def add(a, b): return a + b" --language python --json
   geoseal backend-registry --json
   geoseal history --limit 20 --json

--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -1053,6 +1053,73 @@ def cmd_code_packet(args: argparse.Namespace) -> int:
     return 0
 
 
+def _read_tongue_program_source(args: argparse.Namespace) -> tuple[str, str]:
+    source = getattr(args, "content", None)
+    source_name = getattr(args, "source_name", None) or "inline"
+    source_file = getattr(args, "source_file", None)
+    if source_file:
+        path = Path(source_file)
+        source = path.read_text(encoding="utf-8")
+        source_name = getattr(args, "source_name", None) or path.name
+    if source is None:
+        source = sys.stdin.read()
+        source_name = getattr(args, "source_name", None) or "stdin"
+    return source, source_name
+
+
+def cmd_tongue_compile(args: argparse.Namespace) -> int:
+    from src.sacred_tongues_toolchain import SacredTonguesToolchainError, compile_packet
+
+    try:
+        source, source_name = _read_tongue_program_source(args)
+        packet = compile_packet(source, source_name=source_name)
+        output = getattr(args, "output", None)
+        if output:
+            out_path = Path(output)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            if getattr(args, "output_format", "json") == "bin":
+                out_path.write_bytes(bytes(packet["bytecode"]))
+            else:
+                out_path.write_text(json.dumps(packet["bytecode"], indent=2) + "\n", encoding="utf-8")
+            packet["output_path"] = str(out_path)
+        print(json.dumps(packet))
+        return 0
+    except SacredTonguesToolchainError as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}), file=sys.stderr)
+        return 2
+
+
+def cmd_tongue_run(args: argparse.Namespace) -> int:
+    from src.sacred_tongues_toolchain import SacredTonguesToolchainError, compile_packet, load_program, run_packet
+
+    try:
+        program_file = getattr(args, "program_file", None)
+        compile_payload = None
+        if program_file:
+            program = load_program(Path(program_file))
+            source_name = Path(program_file).name
+        else:
+            source, source_name = _read_tongue_program_source(args)
+            compile_payload = compile_packet(source, source_name=source_name)
+            program = compile_payload["bytecode"]
+        run_payload = run_packet(program, max_steps=int(getattr(args, "max_steps", 10000)))
+        payload = {
+            "schema_version": "geoseal_tongue_run_v1",
+            "source_name": source_name,
+            "compile": compile_payload,
+            "run": run_payload,
+        }
+        if getattr(args, "json", False):
+            print(json.dumps(payload))
+        else:
+            for value in run_payload["output"]:
+                print(value)
+        return 0
+    except SacredTonguesToolchainError as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}), file=sys.stderr)
+        return 2
+
+
 def _read_source_for_surface(args: argparse.Namespace) -> tuple[str, str, str]:
     source = getattr(args, "content", "") or ""
     source_name = getattr(args, "source_name", None) or "inline"
@@ -4414,6 +4481,29 @@ def build_parser() -> argparse.ArgumentParser:
     p_code_packet.add_argument("--language", default="python")
     p_code_packet.add_argument("--backend", default=None, choices=["local", "ollama", "hf", "claude"])
     p_code_packet.set_defaults(func=cmd_code_packet)
+
+    p_tongue_compile = sub.add_parser(
+        "tongue-compile",
+        help="Compile Sacred Tongues .sts assembly into bounded VM bytecode",
+    )
+    p_tongue_compile.add_argument("--content", default=None, help="Inline .sts source; defaults to stdin")
+    p_tongue_compile.add_argument("--source-file", default=None, help="Read .sts source from file")
+    p_tongue_compile.add_argument("--source-name", default=None)
+    p_tongue_compile.add_argument("--output", default=None, help="Optional bytecode output path")
+    p_tongue_compile.add_argument("--output-format", default="json", choices=["json", "bin"])
+    p_tongue_compile.set_defaults(func=cmd_tongue_compile)
+
+    p_tongue_run = sub.add_parser(
+        "tongue-run",
+        help="Compile/run Sacred Tongues .sts assembly in the bounded VM",
+    )
+    p_tongue_run.add_argument("--content", default=None, help="Inline .sts source; defaults to stdin")
+    p_tongue_run.add_argument("--source-file", default=None, help="Read .sts source from file")
+    p_tongue_run.add_argument("--program-file", default=None, help="Run existing bytecode .json or .bin")
+    p_tongue_run.add_argument("--source-name", default=None)
+    p_tongue_run.add_argument("--max-steps", type=int, default=10000)
+    p_tongue_run.add_argument("--json", action="store_true")
+    p_tongue_run.set_defaults(func=cmd_tongue_run)
 
     p_braille = sub.add_parser("braille-lane", help="Build braille/polyhedral lane from source or code packet")
     p_braille.add_argument("--content", default="")

--- a/src/sacred_tongues_toolchain.py
+++ b/src/sacred_tongues_toolchain.py
@@ -1,0 +1,373 @@
+"""Bounded Sacred Tongues assembler and VM.
+
+This is the local compiler lane for `.sts` command programs. It deliberately
+stays below the canon/semantic layer: source text is assembled into bytecode and
+run inside an in-process VM, not routed to a shell.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class SacredTonguesToolchainError(ValueError):
+    """Raised when assembly or VM execution fails."""
+
+
+KO_PREFIXES = [
+    "sil",
+    "kor",
+    "vel",
+    "zar",
+    "keth",
+    "thul",
+    "nav",
+    "ael",
+    "ra",
+    "med",
+    "gal",
+    "lan",
+    "joy",
+    "good",
+    "nex",
+    "vara",
+]
+KO_SUFFIXES = [
+    "a",
+    "ae",
+    "ei",
+    "ia",
+    "oa",
+    "uu",
+    "eth",
+    "ar",
+    "or",
+    "il",
+    "an",
+    "en",
+    "un",
+    "ir",
+    "oth",
+    "esh",
+]
+
+CA_PREFIXES = [
+    "bip",
+    "bop",
+    "klik",
+    "loopa",
+    "ifta",
+    "thena",
+    "elsa",
+    "spira",
+    "rythm",
+    "quirk",
+    "fizz",
+    "gear",
+    "pop",
+    "zip",
+    "mix",
+    "chass",
+]
+CA_SUFFIXES = [
+    "a",
+    "e",
+    "i",
+    "o",
+    "u",
+    "y",
+    "ta",
+    "na",
+    "sa",
+    "ra",
+    "lo",
+    "mi",
+    "ki",
+    "zi",
+    "qwa",
+    "sh",
+]
+
+MNEMONIC_TO_OPCODE = {
+    "ko:nop": 0x00,
+    "ko:halt": 0x01,
+    "ko:jmp": 0x02,
+    "ko:jz": 0x03,
+    "ko:jnz": 0x04,
+    "ko:set": 0x05,
+    "ko:mov": 0x06,
+    "ko:print": 0x07,
+    "ca:add": 0x10,
+    "ca:sub": 0x11,
+    "ca:mul": 0x12,
+    "ca:div": 0x13,
+    "ca:xor": 0x14,
+    "ca:and": 0x15,
+    "ca:or": 0x16,
+    "ca:cmp_eq": 0x17,
+}
+
+EXPECTED_ARITY = {
+    0x00: 0,
+    0x01: 0,
+    0x02: 1,
+    0x03: 2,
+    0x04: 2,
+    0x05: 2,
+    0x06: 2,
+    0x07: 1,
+    0x10: 3,
+    0x11: 3,
+    0x12: 3,
+    0x13: 3,
+    0x14: 3,
+    0x15: 3,
+    0x16: 3,
+    0x17: 3,
+}
+
+
+@dataclass(frozen=True)
+class ParsedLine:
+    lineno: int
+    opcode: int
+    args: list[str]
+
+
+def _build_token_map(prefixes: list[str], suffixes: list[str]) -> dict[str, int]:
+    return {f"{prefixes[byte >> 4]}'{suffixes[byte & 0x0F]}": byte for byte in range(256)}
+
+
+KO_TOKENS = _build_token_map(KO_PREFIXES, KO_SUFFIXES)
+CA_TOKENS = _build_token_map(CA_PREFIXES, CA_SUFFIXES)
+
+
+def _clean_line(raw: str) -> str:
+    return raw.split(";", 1)[0].strip()
+
+
+def _normalize_opcode(token: str) -> int:
+    token = token.strip().lower()
+    if token in MNEMONIC_TO_OPCODE:
+        return MNEMONIC_TO_OPCODE[token]
+    if token.startswith("ko:") and token[3:] in KO_TOKENS:
+        return KO_TOKENS[token[3:]]
+    if token.startswith("ca:") and token[3:] in CA_TOKENS:
+        return CA_TOKENS[token[3:]]
+    raise SacredTonguesToolchainError(f"unknown opcode token: {token}")
+
+
+def _parse_register(text: str) -> int:
+    text = text.strip().lower()
+    if not text.startswith("r"):
+        raise SacredTonguesToolchainError(f"expected register r0..r15, got: {text}")
+    try:
+        idx = int(text[1:])
+    except ValueError as exc:
+        raise SacredTonguesToolchainError(f"invalid register: {text}") from exc
+    if not 0 <= idx <= 15:
+        raise SacredTonguesToolchainError(f"register out of range: {text}")
+    return idx
+
+
+def _parse_byte(text: str) -> int:
+    text = text.strip().lower()
+    try:
+        value = int(text, 16) if text.startswith("0x") else int(text, 10)
+    except ValueError as exc:
+        raise SacredTonguesToolchainError(f"invalid byte value: {text}") from exc
+    if not 0 <= value <= 255:
+        raise SacredTonguesToolchainError(f"byte value out of range 0..255: {text}")
+    return value
+
+
+def _first_pass(lines: list[str]) -> tuple[list[tuple[int, str]], dict[str, int]]:
+    instructions: list[tuple[int, str]] = []
+    labels: dict[str, int] = {}
+    for lineno, raw in enumerate(lines, start=1):
+        line = _clean_line(raw)
+        if not line:
+            continue
+        if line.endswith(":"):
+            label = line[:-1].strip()
+            if not label:
+                raise SacredTonguesToolchainError(f"line {lineno}: empty label")
+            if label in labels:
+                raise SacredTonguesToolchainError(f"line {lineno}: duplicate label '{label}'")
+            labels[label] = len(instructions)
+            continue
+        instructions.append((lineno, line))
+    return instructions, labels
+
+
+def _parse_instruction(lineno: int, line: str) -> ParsedLine:
+    if " " in line:
+        head, tail = line.split(" ", 1)
+        args = [arg.strip() for arg in tail.split(",") if arg.strip()]
+    else:
+        head = line
+        args = []
+
+    opcode = _normalize_opcode(head)
+    expected = EXPECTED_ARITY.get(opcode)
+    if expected is None:
+        raise SacredTonguesToolchainError(f"line {lineno}: unsupported opcode byte 0x{opcode:02x}")
+    if len(args) != expected:
+        raise SacredTonguesToolchainError(f"line {lineno}: opcode '{head}' expects {expected} args, got {len(args)}")
+    return ParsedLine(lineno=lineno, opcode=opcode, args=args)
+
+
+def _resolve_arg(opcode: int, arg_pos: int, text: str, labels: dict[str, int]) -> int:
+    if opcode == 0x02:
+        return labels[text] if text in labels else _parse_byte(text)
+    if opcode in {0x03, 0x04}:
+        if arg_pos == 0:
+            return _parse_register(text)
+        return labels[text] if text in labels else _parse_byte(text)
+    if opcode == 0x05:
+        return _parse_register(text) if arg_pos == 0 else _parse_byte(text)
+    if opcode in {0x06, 0x07}:
+        return _parse_register(text)
+    if opcode in {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17}:
+        return _parse_register(text)
+    return 0
+
+
+def assemble_text(text: str) -> list[int]:
+    """Assemble `.sts` text into four-byte instruction bytecode."""
+    instruction_lines, labels = _first_pass(text.splitlines())
+    bytecode: list[int] = []
+    for lineno, line in instruction_lines:
+        parsed = _parse_instruction(lineno, line)
+        args = [_resolve_arg(parsed.opcode, i, arg, labels) for i, arg in enumerate(parsed.args)]
+        while len(args) < 3:
+            args.append(0)
+        bytecode.extend([parsed.opcode, args[0], args[1], args[2]])
+    return bytecode
+
+
+def load_program(path: Path) -> list[int]:
+    if path.suffix.lower() == ".json":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            raise SacredTonguesToolchainError("JSON program must be a byte array")
+        return [int(value) & 0xFF for value in data]
+    return list(path.read_bytes())
+
+
+class SacredTongueVM:
+    def __init__(self, program: list[int]):
+        if len(program) % 4 != 0:
+            raise SacredTonguesToolchainError("program length must be a multiple of 4 bytes")
+        self.program = [int(value) & 0xFF for value in program]
+        self.reg = [0] * 16
+        self.pc = 0
+        self.halted = False
+        self.output: list[int] = []
+        self.steps = 0
+
+    @property
+    def instruction_count(self) -> int:
+        return len(self.program) // 4
+
+    def _fetch(self) -> tuple[int, int, int, int]:
+        if not 0 <= self.pc < self.instruction_count:
+            self.halted = True
+            return (0x01, 0, 0, 0)
+        i = self.pc * 4
+        return self.program[i], self.program[i + 1], self.program[i + 2], self.program[i + 3]
+
+    def step(self) -> None:
+        if self.halted:
+            return
+
+        op, a, b, c = self._fetch()
+        next_pc = self.pc + 1
+        if op == 0x00:
+            pass
+        elif op == 0x01:
+            self.halted = True
+        elif op == 0x02:
+            next_pc = a
+        elif op == 0x03:
+            if self.reg[a] == 0:
+                next_pc = b
+        elif op == 0x04:
+            if self.reg[a] != 0:
+                next_pc = b
+        elif op == 0x05:
+            self.reg[a] = b & 0xFF
+        elif op == 0x06:
+            self.reg[a] = self.reg[b] & 0xFF
+        elif op == 0x07:
+            self.output.append(self.reg[a] & 0xFF)
+        elif op == 0x10:
+            self.reg[a] = (self.reg[b] + self.reg[c]) & 0xFF
+        elif op == 0x11:
+            self.reg[a] = (self.reg[b] - self.reg[c]) & 0xFF
+        elif op == 0x12:
+            self.reg[a] = (self.reg[b] * self.reg[c]) & 0xFF
+        elif op == 0x13:
+            if self.reg[c] == 0:
+                raise SacredTonguesToolchainError(f"division by zero at pc={self.pc}")
+            self.reg[a] = (self.reg[b] // self.reg[c]) & 0xFF
+        elif op == 0x14:
+            self.reg[a] = (self.reg[b] ^ self.reg[c]) & 0xFF
+        elif op == 0x15:
+            self.reg[a] = (self.reg[b] & self.reg[c]) & 0xFF
+        elif op == 0x16:
+            self.reg[a] = (self.reg[b] | self.reg[c]) & 0xFF
+        elif op == 0x17:
+            self.reg[a] = 1 if self.reg[b] == self.reg[c] else 0
+        else:
+            raise SacredTonguesToolchainError(f"unknown opcode 0x{op:02x} at pc={self.pc}")
+
+        self.pc = next_pc
+        self.steps += 1
+
+    def run(self, max_steps: int = 10000) -> dict[str, Any]:
+        while not self.halted and self.steps < max_steps:
+            self.step()
+        if self.steps >= max_steps and not self.halted:
+            raise SacredTonguesToolchainError(f"execution exceeded max_steps={max_steps}")
+        return {
+            "output": self.output,
+            "registers": self.reg,
+            "pc": self.pc,
+            "halted": self.halted,
+            "steps": self.steps,
+        }
+
+
+def compile_packet(source: str, *, source_name: str = "inline") -> dict[str, Any]:
+    bytecode = assemble_text(source)
+    bytecode_bytes = bytes(bytecode)
+    return {
+        "schema_version": "scbe_tongues_toolchain_compile_v1",
+        "source_name": source_name,
+        "source_sha256": hashlib.sha256(source.encode("utf-8", errors="replace")).hexdigest(),
+        "bytecode": bytecode,
+        "bytecode_sha256": hashlib.sha256(bytecode_bytes).hexdigest(),
+        "instruction_count": len(bytecode) // 4,
+        "byte_length": len(bytecode),
+        "opcodes": {
+            "semantic_layer": "sts-assembly",
+            "transport_layer": "bounded-bytecode",
+            "vm": "scbe-sacred-tongue-vm-v1",
+        },
+    }
+
+
+def run_packet(program: list[int], *, max_steps: int = 10000) -> dict[str, Any]:
+    vm = SacredTongueVM(program)
+    result = vm.run(max_steps=max_steps)
+    return {
+        "schema_version": "scbe_tongues_toolchain_run_v1",
+        "program_sha256": hashlib.sha256(bytes(program)).hexdigest(),
+        "instruction_count": len(program) // 4,
+        **result,
+    }

--- a/tests/smoke/test_npm_geoseal_bin.py
+++ b/tests/smoke/test_npm_geoseal_bin.py
@@ -31,6 +31,7 @@ def test_npm_geoseal_bin_help() -> None:
     assert "nexus-dispatch" in proc.stdout
     assert "agent-io-contract" in proc.stdout
     assert "tokenizer-code-lanes" in proc.stdout
+    assert "tongue-run" in proc.stdout
 
 
 def test_npm_geoseal_bin_version_matches_package() -> None:
@@ -147,6 +148,31 @@ def test_npm_geoseal_bin_python_passthrough_shell_command() -> None:
     payload = json.loads(proc.stdout)
     assert payload["version"] == "geoseal-polly-portal-box-v1"
     assert payload["shell_contract"]["route_packet"]["command_key"] == "add"
+
+
+def test_npm_geoseal_bin_python_passthrough_tongue_run() -> None:
+    env = dict(os.environ)
+    env["SCBE_GEOSEAL_PYTHON"] = sys.executable
+    program = "ko:set r0, 4\nko:set r1, 6\nca:add r2, r0, r1\nko:print r2\nko:halt"
+    proc = subprocess.run(
+        [
+            "node",
+            str(ROOT / "bin" / "geoseal.cjs"),
+            "tongue-run",
+            "--content",
+            program,
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "geoseal_tongue_run_v1"
+    assert payload["run"]["output"] == [10]
 
 
 def test_npm_geoseal_bin_code_lanes_roundtrip(tmp_path: Path) -> None:

--- a/tests/test_geoseal_cli_tokenizer_atomic.py
+++ b/tests/test_geoseal_cli_tokenizer_atomic.py
@@ -35,6 +35,38 @@ def test_encode_decode_cmd_roundtrip() -> None:
     assert decoded.stdout == "hello"
 
 
+def test_tongue_compile_and_run_bounded_vm() -> None:
+    program = "\n".join(
+        [
+            "ko:set r0, 2",
+            "ko:set r1, 3",
+            "ca:add r2, r0, r1",
+            "ko:print r2",
+            "ko:halt",
+        ]
+    )
+    compiled = _run_cli("tongue-compile", "--content", program)
+    assert compiled.returncode == 0, compiled.stderr
+    compile_payload = json.loads(compiled.stdout)
+    assert compile_payload["schema_version"] == "scbe_tongues_toolchain_compile_v1"
+    assert compile_payload["instruction_count"] == 5
+    assert compile_payload["bytecode"] == [5, 0, 2, 0, 5, 1, 3, 0, 16, 2, 0, 1, 7, 2, 0, 0, 1, 0, 0, 0]
+
+    executed = _run_cli("tongue-run", "--content", program, "--json")
+    assert executed.returncode == 0, executed.stderr
+    run_payload = json.loads(executed.stdout)
+    assert run_payload["schema_version"] == "geoseal_tongue_run_v1"
+    assert run_payload["run"]["output"] == [5]
+    assert run_payload["run"]["registers"][2] == 5
+    assert run_payload["run"]["halted"] is True
+
+
+def test_tongue_run_rejects_unbounded_loop() -> None:
+    executed = _run_cli("tongue-run", "--content", "loop:\nko:jmp loop", "--max-steps", "3", "--json")
+    assert executed.returncode == 2
+    assert "execution exceeded max_steps=3" in executed.stderr
+
+
 def test_xlate_cmd_preserves_payload() -> None:
     encoded = _run_cli("encode-cmd", "--tongue", "KO", "abc")
     assert encoded.returncode == 0, encoded.stderr


### PR DESCRIPTION
## Summary
- add a bounded Sacred Tongues assembler/VM for .sts command programs
- expose it through local GeoSeal CLI verbs: tongue-compile and tongue-run
- surface the commands in the npm geoseal help path and verify Node passthrough

## Test evidence
- python -m pytest tests/test_geoseal_cli_tokenizer_atomic.py tests/smoke/test_npm_geoseal_bin.py -q
- python -m pytest tests/test_agent_task_run_and_external_eval.py -q
- python -m flake8 src/sacred_tongues_toolchain.py tests/test_geoseal_cli_tokenizer_atomic.py tests/smoke/test_npm_geoseal_bin.py
- python -m py_compile src/sacred_tongues_toolchain.py src/geoseal_cli.py
- manual: python -m src.geoseal_cli tongue-run --content <KO/CA program> --json returned output [15]

## Notes
- This is an in-process bounded VM, not shell execution.
- The public HTTP bridge is not expanded in this PR.