### PR TITLE
fix(polly): make core chat answers useful

### DIFF
--- a/api/_chat_llm.js
+++ b/api/_chat_llm.js
@@ -14,9 +14,13 @@ const DEFAULT_TIMEOUT_MS = 25000;
 
 const SYSTEM_PROMPT =
   'You are Polly, the AI assistant for AetherMoore — an AI safety and governance framework ' +
-  'using hyperbolic geometry with a 14-layer security pipeline. Be helpful, concise, and ' +
-  'accurate. If asked about SCBE, explain the core innovation: governed agent behavior with ' +
-  'auditable safety decisions and cheap-first/local-first model routing.';
+  'using hyperbolic geometry with a 14-layer security pipeline. SCBE means Sacred ' +
+  'Circuitry / Symphonic Cipher Boundary Engine in this project context; never invent a ' +
+  'different expansion. Be helpful, concise, and accurate. If asked about SCBE, explain ' +
+  'the practical product: governed agent behavior with auditable safety decisions, ' +
+  'workflow failure analysis, and cheap-first/local-first model routing. For buyer-like ' +
+  'questions, point to the $99 AI Agent Workflow Snapshot, $29 toolkit/training vault, ' +
+  '$500 Governance Snapshot, or $5+ service credits.';
 
 function cleanBaseUrl(value) {
   return String(value || '')

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -88,6 +88,34 @@ const PRODUCT_CATALOG = [
     ],
   },
   {
+    sku: 'ai-agent-workflow-snapshot',
+    name: 'AI Agent Workflow Snapshot',
+    priceLabel: '$99 starter',
+    short:
+      'Starter written review for one AI workflow, repo link, prompt chain, MCP stack, automation flow, or diagram. Includes failure risks, missing recovery states, unsafe tool paths, observability gaps, and three prioritized fixes.',
+    checkoutUrl: checkoutUrlFromEnv(
+      'SCBE_PAYMENT_LINK_WORKFLOW_SNAPSHOT',
+      'https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l'
+    ),
+    deliveryUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html',
+    keywords: [
+      'workflow snapshot',
+      'agent workflow snapshot',
+      'ai agent workflow snapshot',
+      'agent snapshot',
+      'workflow review',
+      'starter snapshot',
+      '$99 snapshot',
+      '99 snapshot',
+      '$99',
+      'agent workflow',
+      'prompt chain',
+      'mcp stack',
+      'automation flow',
+      'failure analysis',
+    ],
+  },
+  {
     sku: 'governance-heartbeat',
     name: 'Governance Heartbeat',
     priceLabel: '$99/month',
@@ -205,7 +233,7 @@ const BUY_PATTERN =
   /\b(buy|purchase|order|checkout|pay\s+for|get\s+the|want\s+the|how\s+much|sign\s+me\s+up|add\s+to\s+cart)\b/i;
 
 const CUSTOM_PATTERN =
-  /\b(custom|bespoke|tailor|specifically\s+for|my\s+team|my\s+company|my\s+org|my\s+(use\s*case|workflow)|something\s+else|not\s+listed|build\s+me|hire\s+(you|issac|isaac|davis|me)|consulting|advisory|audit|engagement|contract|chatbot\s+safer|llm\s+safer|ai\s+safety|governance\s+help)\b/i;
+  /\b(custom|bespoke|tailor|specifically\s+for|my\s+team|my\s+company|my\s+org|my\s+(use\s*case|workflow)|something\s+else|not\s+listed|build\s+me|hire\s+(you|issac|isaac|davis|me)|consulting|advisory|audit|engagement|contract|chatbot\s+safer|llm\s+safer|ai\s+agent\s+safer|agent\s+safer|make\s+my\s+ai\s+safer|ai\s+safety|governance\s+help)\b/i;
 
 const RESEARCH_PATTERN =
   /\b(research|find|look\s+up|search|investigate|what\s+do\s+you\s+know|recent|latest|news|paper|study|literature|sources?|cite|references?)\b/i;
@@ -292,12 +320,17 @@ const GUIDE_PATTERN =
 
 function resolveProduct(message) {
   const lower = String(message || '').toLowerCase();
+  let best = null;
+  let bestLength = -1;
   for (const product of PRODUCT_CATALOG) {
     for (const keyword of product.keywords) {
-      if (lower.includes(keyword)) return product;
+      if (lower.includes(keyword) && keyword.length > bestLength) {
+        best = product;
+        bestLength = keyword.length;
+      }
     }
   }
-  return null;
+  return best;
 }
 
 function classifyIntent(message) {
@@ -432,6 +465,10 @@ function renderBuyReply(product) {
     text +=
       '\n\nImmediate value after purchase: buyer intake checklist, order recap, starter governance resources, and a 1-business-day human inspection window.';
   }
+  if (product.sku === 'ai-agent-workflow-snapshot') {
+    text +=
+      '\n\nBest first purchase if you are unsure: send one repo, prompt chain, MCP stack, workflow diagram, or automation flow. You get an immediate intake path and a concise written read with three fixes.';
+  }
   const actions = [{ label: `Buy ${product.name}`, url: product.checkoutUrl }];
   if (product.deliveryUrl) {
     actions.push({ label: "What's inside", url: product.deliveryUrl });
@@ -471,6 +508,28 @@ function renderCustomReply(message) {
 }
 
 const RESEARCH_TOPICS = [
+  {
+    keys: [
+      'scbe',
+      'sacred circuitry',
+      'symphonic cipher boundary',
+      'aethermoore',
+      'what is scbe',
+    ],
+    title: 'SCBE / AetherMoore',
+    body:
+      'SCBE is the AetherMoore governance stack for AI agents and workflows: deterministic gates, audit records, routing rules, and safety scores that sit around model output. Practically, it helps find hidden failure points in AI workflows: unsafe tool execution, drift, missing recovery logic, weak observability, prompt-injection exposure, and unclear handoff boundaries. It is not a replacement foundation model; it is a control/governance layer that makes smaller or mixed models more useful and easier to inspect.',
+    links: [
+      {
+        label: 'Start here',
+        url: 'https://aethermoore.com/SCBE-AETHERMOORE/start-here.html',
+      },
+      {
+        label: 'Products',
+        url: 'https://aethermoore.com/SCBE-AETHERMOORE/products.html',
+      },
+    ],
+  },
   {
     keys: ['harmonic wall', 'h(d', 'safety score', 'governance score'],
     title: 'Harmonic wall (L12)',

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -202,7 +202,7 @@ describe('polly lead handler — anti-abuse', () => {
 
 describe('polly commerce intent classification', () => {
   it('catalog has live products with valid checkout urls', () => {
-    expect(commerce.PRODUCT_CATALOG).toHaveLength(7);
+    expect(commerce.PRODUCT_CATALOG).toHaveLength(8);
     for (const product of commerce.PRODUCT_CATALOG) {
       expect(product.checkoutUrl).toMatch(/^(https:\/\/(buy\.stripe\.com|ko-fi\.com)|mailto:)/);
       expect(product.keywords.length).toBeGreaterThan(0);
@@ -278,6 +278,18 @@ describe('polly commerce intent classification', () => {
     expect(intent.product.sku).toBe('ai-governance-snapshot');
   });
 
+  it('classifies workflow snapshot as the $99 starter instead of the $500 snapshot', () => {
+    const intent = commerce.classifyIntent('how much is the workflow snapshot?');
+    expect(intent.name).toBe('buy');
+    expect(intent.product.sku).toBe('ai-agent-workflow-snapshot');
+    expect(intent.product.priceLabel).toContain('$99');
+  });
+
+  it('routes AI agent safer language to custom help instead of generic LLM chat', () => {
+    const intent = commerce.classifyIntent('I need help making my AI agent safer');
+    expect(intent.name).toBe('custom');
+  });
+
   it('classifies governance heartbeat as the monthly subscription offer', () => {
     const intent = commerce.classifyIntent('I want the $99 monthly governance heartbeat');
     expect(intent.name).toBe('buy');
@@ -327,6 +339,14 @@ describe('polly commerce intent classification', () => {
   it('does NOT route question-shaped non-topic prompts to research', () => {
     const intent = commerce.classifyIntent('What time is it?');
     expect(intent.name).toBe('general');
+  });
+
+  it('answers core SCBE identity questions with deterministic research copy', () => {
+    const intent = commerce.classifyIntent('what is SCBE?');
+    expect(intent.name).toBe('research');
+    expect(intent.confidence).toBeCloseTo(0.78, 2);
+    const rendered = commerce.renderResearchReply('what is SCBE?');
+    expect(rendered.text).toContain('AetherMoore governance stack');
   });
 
   it('returns general intent when nothing matches', () => {


### PR DESCRIPTION
## Summary
- add deterministic SCBE/AetherMoore identity answer so Polly stops relying on the model for core product framing
- add the $99 AI Agent Workflow Snapshot to the chat-side product catalog and prefer longest keyword matches so `workflow snapshot` does not route to the $500 snapshot
- route `make my AI agent safer` style buyer language to custom/help instead of generic LLM chat
- tighten the shared LLM system prompt so fallback models do not invent a wrong SCBE expansion

## Tests
- `npx vitest run tests/api/polly_commerce_js.test.ts` -> 109 passed
- direct Node smoke for: `what is SCBE?`, `I need help making my AI agent safer`, `how much is the workflow snapshot?`, `what should I buy if I am new here?`
- `python scripts\security\code_governance_gate.py check-push` -> PASS, 0 findings
- `git diff --check` -> line-ending warnings only

## Rollback
Revert this PR to return Polly to the previous catalog and LLM fallback behavior.