### PR TITLE
feat(agent): add tongue VM harness gate

### DIFF
--- a/src/api/geoseal_cli_bridge.py
+++ b/src/api/geoseal_cli_bridge.py
@@ -77,6 +77,34 @@ def dispatch_geoseal_command(command: str, body: dict[str, Any]) -> dict[str, An
         data = _parse_json_stdout(stdout, stderr, rc)
         return {"exit_code": rc, "data": data, "stderr": stderr or None}
 
+    if command == "call-switchboard":
+        ns = argparse.Namespace(
+            calls=None,
+            inline_calls=json.dumps(body.get("calls") or []),
+            request=json.dumps(body.get("request") or {}),
+            json=True,
+        )
+        rc, stdout, stderr = _capture_cli(geoseal_cli.cmd_call_switchboard, ns)
+        data = _parse_json_stdout(stdout, stderr, rc)
+        return {"exit_code": rc, "data": data, "stderr": stderr or None}
+
+    if command == "lightning-indexer":
+        _reject_external_file_fields(body, "candidates_file")
+        ns = argparse.Namespace(
+            goal=body.get("goal") or "",
+            inline_candidates=json.dumps(
+                body.get("candidates") or body.get("inline_candidates") or []
+            ),
+            candidates_file=None,
+            top_k=int(body.get("top_k") or 8),
+            block_size=int(body.get("block_size") or 16),
+            channel_budget=int(body.get("channel_budget") or 3),
+            json=True,
+        )
+        rc, stdout, stderr = _capture_cli(geoseal_cli.cmd_lightning_indexer, ns)
+        data = _parse_json_stdout(stdout, stderr, rc)
+        return {"exit_code": rc, "data": data, "stderr": stderr or None}
+
     if command == "compile":
         intent = body.get("intent") or body.get("goal") or ""
         if isinstance(intent, str):

--- a/src/coding_spine/agent_tool_bridge.py
+++ b/src/coding_spine/agent_tool_bridge.py
@@ -34,9 +34,18 @@ def _language_matrix() -> list[dict[str, Any]]:
                 "parent_tongue": parent,
                 "route_class": "native" if tongue in LANG_MAP else "extended",
                 "cli": {
-                    "code_packet": f"{_exe()} -m src.geoseal_cli code-packet --language {language} --source-file <file> --json",
-                    "explain_route": f"{_exe()} -m src.geoseal_cli explain-route --language {language} --source-file <file> --json",
-                    "testing_cli": f"{_exe()} -m src.geoseal_cli testing-cli --language {language} --source-file <file> --json",
+                    "code_packet": (
+                        f"{_exe()} -m src.geoseal_cli code-packet "
+                        f"--language {language} --source-file <file> --json"
+                    ),
+                    "explain_route": (
+                        f"{_exe()} -m src.geoseal_cli explain-route "
+                        f"--language {language} --source-file <file> --json"
+                    ),
+                    "testing_cli": (
+                        f"{_exe()} -m src.geoseal_cli testing-cli "
+                        f"--language {language} --source-file <file> --json"
+                    ),
                 },
             }
         )
@@ -98,7 +107,10 @@ def _tool_contracts() -> list[dict[str, Any]]:
             "tool": "secrets_or_credentials",
             "risk": "critical",
             "approval": "deny_by_default",
-            "purpose": "Secrets are never routed through free model prompts; tools receive only named env requirements.",
+            "purpose": (
+                "Secrets are never routed through free model prompts; "
+                "tools receive only named env requirements."
+            ),
             "routes": ["connector_env_check", "redacted_evidence_only"],
         },
         {
@@ -205,6 +217,7 @@ def build_agent_harness_manifest_v1(
         for row in skill_tools.get("skills", [])
         if row.get("route_name") and row.get("invocation_kind") == "skill_lookup"
     ]
+    tongue_vm_gate = _build_tongue_vm_gate(permission_mode=permission_mode)
     return {
         "schema_version": "scbe_agent_harness_manifest_v1",
         "goal_excerpt": goal[:500],
@@ -239,9 +252,18 @@ def build_agent_harness_manifest_v1(
             "agent_harness_json": f"{_exe()} -m src.geoseal_cli agent-harness --goal <goal> --json",
             "compile_intent_json": f"{_exe()} -m src.geoseal_cli compile --json <intent>",
             "language_matrix_json": f"{_exe()} -m src.geoseal_cli agent-harness --language {preferred} --json",
-            "ghost_terminal_audit_ps1": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/system/ghost_terminal_audit.ps1 -Json",
-            "ghost_terminal_cleanup_stale_ps1": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/system/ghost_terminal_audit.ps1 -CleanStale",
+            "tongue_compile_json": f"{_exe()} -m src.geoseal_cli tongue-compile --source-file gate.sts",
+            "tongue_run_json": f"{_exe()} -m src.geoseal_cli tongue-run --source-file gate.sts --json",
+            "ghost_terminal_audit_ps1": (
+                "powershell.exe -NoProfile -ExecutionPolicy Bypass "
+                "-File scripts/system/ghost_terminal_audit.ps1 -Json"
+            ),
+            "ghost_terminal_cleanup_stale_ps1": (
+                "powershell.exe -NoProfile -ExecutionPolicy Bypass "
+                "-File scripts/system/ghost_terminal_audit.ps1 -CleanStale"
+            ),
         },
+        "tongue_vm_gate": tongue_vm_gate,
         "service_routes": {
             **bridge["geoseal_service"],
             "agent_harness": f"{bridge['geoseal_service']['env']['GEOSEAL_SERVICE_URL']}/v1/harness/agent-harness",
@@ -261,6 +283,43 @@ def build_agent_harness_manifest_v1(
             "prompts": ["explain-route", "testing-cli", "project-scaffold"],
             "skill_lookup_names": skill_lookup_names,
             "skill_route_names": skill_route_names,
+        },
+    }
+
+
+def _build_tongue_vm_gate(*, permission_mode: str) -> dict[str, Any]:
+    """Return a compiled Sacred Tongues gate packet for agent self-tests."""
+
+    from src.sacred_tongues_toolchain import compile_packet, run_packet
+
+    gate_source = "\n".join(
+        [
+            "; r0 is the permission gate flag; 1 means continue, 0 means stop",
+            "ko:set r0, 1",
+            "ko:jz r0, blocked",
+            "ko:set r1, 1",
+            "ko:print r1",
+            "ko:halt",
+            "blocked:",
+            "ko:set r1, 0",
+            "ko:print r1",
+            "ko:halt",
+        ]
+    )
+    compile_result = compile_packet(gate_source, source_name=f"agent-harness-{permission_mode}-gate.sts")
+    run_result = run_packet(compile_result["bytecode"], max_steps=32)
+    return {
+        "schema_version": "scbe_agent_harness_tongue_vm_gate_v1",
+        "purpose": "bounded preflight gate agents can compile/run before requesting tools",
+        "permission_mode": permission_mode,
+        "source": gate_source,
+        "compile": compile_result,
+        "self_test": run_result,
+        "expected_output": [1],
+        "failure_output": [0],
+        "local_commands": {
+            "compile": f"{_exe()} -m src.geoseal_cli tongue-compile --source-file gate.sts",
+            "run": f"{_exe()} -m src.geoseal_cli tongue-run --source-file gate.sts --json",
         },
     }
 
@@ -295,10 +354,19 @@ def build_agent_tool_bridge_v1(
         "history_json": f"{exe} -m src.geoseal_cli history --json",
         "testing_cli_json": f"{exe} -m src.geoseal_cli testing-cli {file_args} --json",
         "compile_intent_json": f"{exe} -m src.geoseal_cli compile --json {shlex.quote(compile_text)}",
-        "ghost_terminal_audit_ps1": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/system/ghost_terminal_audit.ps1 -Json",
-        "ghost_terminal_cleanup_stale_ps1": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/system/ghost_terminal_audit.ps1 -CleanStale",
+        "ghost_terminal_audit_ps1": (
+            "powershell.exe -NoProfile -ExecutionPolicy Bypass "
+            "-File scripts/system/ghost_terminal_audit.ps1 -Json"
+        ),
+        "ghost_terminal_cleanup_stale_ps1": (
+            "powershell.exe -NoProfile -ExecutionPolicy Bypass "
+            "-File scripts/system/ghost_terminal_audit.ps1 -CleanStale"
+        ),
         "call_switchboard_json": f"{exe} -m src.geoseal_cli call-switchboard --request <json> --json",
-        "lightning_indexer_json": f"{exe} -m src.geoseal_cli lightning-indexer --goal <goal> --inline-candidates <json> --json",
+        "lightning_indexer_json": (
+            f"{exe} -m src.geoseal_cli lightning-indexer "
+            "--goal <goal> --inline-candidates <json> --json"
+        ),
     }
 
     base_url = os.environ.get("GEOSEAL_SERVICE_URL", "http://127.0.0.1:8765").rstrip("/")

--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -1793,6 +1793,51 @@ def cmd_agent_harness(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_call_switchboard(args: argparse.Namespace) -> int:
+    from src.coding_spine.agent_call_switchboard import evaluate_call_request
+
+    calls: list[dict[str, Any]] = []
+    if args.calls:
+        loaded = json.loads(Path(args.calls).read_text(encoding="utf-8"))
+        if not isinstance(loaded, list):
+            raise SystemExit("--calls must point to a JSON array")
+        calls = loaded
+    if getattr(args, "inline_calls", None):
+        loaded = json.loads(args.inline_calls)
+        if not isinstance(loaded, list):
+            raise SystemExit("--inline-calls must be a JSON array")
+        calls.extend(loaded)
+    request = json.loads(args.request)
+    payload = evaluate_call_request(calls, request)
+    print(json.dumps(payload, indent=2 if args.json else None))
+    return 0
+
+
+def cmd_lightning_indexer(args: argparse.Namespace) -> int:
+    from src.coding_spine.lightning_indexer import select_sparse_candidates
+
+    candidates: list[dict[str, Any]] = []
+    if args.candidates_file:
+        loaded = json.loads(Path(args.candidates_file).read_text(encoding="utf-8"))
+        if not isinstance(loaded, list):
+            raise SystemExit("--candidates-file must point to a JSON array")
+        candidates = loaded
+    if args.inline_candidates:
+        loaded = json.loads(args.inline_candidates)
+        if not isinstance(loaded, list):
+            raise SystemExit("--inline-candidates must be a JSON array")
+        candidates.extend(loaded)
+    payload = select_sparse_candidates(
+        args.goal,
+        candidates,
+        top_k=args.top_k,
+        block_size=args.block_size,
+        channel_budget=args.channel_budget,
+    )
+    print(json.dumps(payload, indent=2 if args.json else None))
+    return 0
+
+
 def cmd_compile(args: argparse.Namespace) -> int:
     from src.coding_spine.command_compiler import compile_intent_to_plan
 
@@ -4623,6 +4668,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_harness.add_argument("--json", action="store_true")
     p_harness.set_defaults(func=cmd_agent_harness)
+
+    p_switchboard = sub.add_parser("call-switchboard", help="Evaluate a multi-agent call reservation")
+    p_switchboard.add_argument("--calls", default=None, help="Existing call reservations JSON array")
+    p_switchboard.add_argument("--inline-calls", default=None, help="Existing call reservations JSON array")
+    p_switchboard.add_argument("--request", required=True, help="Requested call JSON object")
+    p_switchboard.add_argument("--json", action="store_true")
+    p_switchboard.set_defaults(func=cmd_call_switchboard)
+
+    p_indexer = sub.add_parser("lightning-indexer", help="Select sparse agent context candidates")
+    p_indexer.add_argument("--goal", required=True)
+    p_indexer.add_argument("--inline-candidates", default=None, help="Candidate JSON array")
+    p_indexer.add_argument("--candidates-file", default=None, help="Candidate JSON array file")
+    p_indexer.add_argument("--top-k", type=int, default=8)
+    p_indexer.add_argument("--block-size", type=int, default=16)
+    p_indexer.add_argument("--channel-budget", type=int, default=3)
+    p_indexer.add_argument("--json", action="store_true")
+    p_indexer.set_defaults(func=cmd_lightning_indexer)
 
     p_compile = sub.add_parser("compile", help="Compile intent into an SCBE agent-bus command plan")
     p_compile.add_argument("intent", nargs=argparse.REMAINDER)

--- a/tests/coding_spine/test_agent_call_switchboard.py
+++ b/tests/coding_spine/test_agent_call_switchboard.py
@@ -138,7 +138,10 @@ def test_geoseal_call_switchboard_cli(tmp_path: Path) -> None:
             "--calls",
             str(calls),
             "--request",
-            '{"call_id":"call-codex-ui","agent_id":"agent.codex","lane":"ui","resource":"scbe-visual-system","mode":"write"}',
+            (
+                '{"call_id":"call-codex-ui","agent_id":"agent.codex",'
+                '"lane":"ui","resource":"scbe-visual-system","mode":"write"}'
+            ),
             "--json",
         ],
         cwd=ROOT,

--- a/tests/test_agent_task_run_and_external_eval.py
+++ b/tests/test_agent_task_run_and_external_eval.py
@@ -102,6 +102,9 @@ def test_agent_harness_manifest_routes_all_code_languages():
     assert manifest["permission_mode"] == "workspace-write"
     assert any(tool["tool"] == "execute_tests" for tool in manifest["tool_contracts"])
     assert "agent_harness_json" in manifest["geoseal_cli"]
+    assert manifest["tongue_vm_gate"]["schema_version"] == "scbe_agent_harness_tongue_vm_gate_v1"
+    assert manifest["tongue_vm_gate"]["self_test"]["output"] == [1]
+    assert "tongue-run" in manifest["geoseal_cli"]["tongue_run_json"]
 
 
 def test_agent_harness_exposes_ghost_terminal_audit_tool():
@@ -357,6 +360,70 @@ def test_geoseal_service_cli_bridge_code_packet():
     assert body["status"] == "ok"
     assert body["exit_code"] == 0
     assert "native_tokenization" in body["data"] or "transport_tokens" in body["data"]
+
+
+def test_geoseal_service_cli_bridge_call_switchboard():
+    from fastapi.testclient import TestClient
+
+    from src.api.geoseal_service import app
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/geoseal/call-switchboard",
+        json={
+            "calls": [
+                {
+                    "call_id": "active-writer",
+                    "agent_id": "agent.alpha",
+                    "lane": "ui",
+                    "resource": "route/home",
+                    "mode": "write",
+                    "state": "active",
+                }
+            ],
+            "request": {
+                "call_id": "next-writer",
+                "agent_id": "agent.beta",
+                "lane": "ui",
+                "resource": "route/home",
+                "mode": "write",
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["exit_code"] == 0
+    assert body["data"]["decision"] == "QUEUE"
+    assert body["data"]["reason"] == "exclusive_surface_collision"
+
+
+def test_geoseal_service_cli_bridge_lightning_indexer():
+    from fastapi.testclient import TestClient
+
+    from src.api.geoseal_service import app
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/geoseal/lightning-indexer",
+        json={
+            "goal": "multi agent switchboard route",
+            "candidates": [
+                {"candidate_id": "visual", "text": "demo colors"},
+                {
+                    "candidate_id": "switchboard",
+                    "text": "multi agent switchboard route",
+                    "kind": "tool",
+                },
+            ],
+            "top_k": 1,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["exit_code"] == 0
+    assert body["data"]["selected"][0]["candidate_id"] == "switchboard"
 
 
 def test_geoseal_service_cli_bridge_blocks_code_roundtrip_over_http():


### PR DESCRIPTION
## Summary
- adds a compiled Sacred Tongues VM preflight gate into the agent harness manifest
- wires advertised switchboard and lightning-indexer surfaces into the GeoSeal CLI and HTTP bridge
- adds service bridge coverage so multi-agent call collision and sparse context selection are executable through `/v1/geoseal/*`

## Verification
- `python -m pytest tests/test_agent_task_run_and_external_eval.py tests/coding_spine/test_agent_call_switchboard.py tests/coding_spine/test_lightning_indexer.py tests/coding_spine/test_skill_harness_tools.py -q` -> 45 passed
- `python -m flake8 src/api/geoseal_cli_bridge.py src/coding_spine/agent_tool_bridge.py tests/test_agent_task_run_and_external_eval.py tests/coding_spine/test_agent_call_switchboard.py tests/coding_spine/test_lightning_indexer.py tests/coding_spine/test_skill_harness_tools.py` -> passed
- `python -m py_compile src/geoseal_cli.py src/api/geoseal_cli_bridge.py src/coding_spine/agent_tool_bridge.py` -> passed
- manual smoke: `call-switchboard` returns `QUEUE` on colliding write reservation
- manual smoke: `lightning-indexer` selects the matching switchboard candidate
