### PR TITLE
fix(agent): format harness bridge files

### DIFF
--- a/src/api/geoseal_cli_bridge.py
+++ b/src/api/geoseal_cli_bridge.py
@@ -92,9 +92,7 @@ def dispatch_geoseal_command(command: str, body: dict[str, Any]) -> dict[str, An
         _reject_external_file_fields(body, "candidates_file")
         ns = argparse.Namespace(
             goal=body.get("goal") or "",
-            inline_candidates=json.dumps(
-                body.get("candidates") or body.get("inline_candidates") or []
-            ),
+            inline_candidates=json.dumps(body.get("candidates") or body.get("inline_candidates") or []),
             candidates_file=None,
             top_k=int(body.get("top_k") or 8),
             block_size=int(body.get("block_size") or 16),

--- a/src/coding_spine/agent_tool_bridge.py
+++ b/src/coding_spine/agent_tool_bridge.py
@@ -35,16 +35,14 @@ def _language_matrix() -> list[dict[str, Any]]:
                 "route_class": "native" if tongue in LANG_MAP else "extended",
                 "cli": {
                     "code_packet": (
-                        f"{_exe()} -m src.geoseal_cli code-packet "
-                        f"--language {language} --source-file <file> --json"
+                        f"{_exe()} -m src.geoseal_cli code-packet " f"--language {language} --source-file <file> --json"
                     ),
                     "explain_route": (
                         f"{_exe()} -m src.geoseal_cli explain-route "
                         f"--language {language} --source-file <file> --json"
                     ),
                     "testing_cli": (
-                        f"{_exe()} -m src.geoseal_cli testing-cli "
-                        f"--language {language} --source-file <file> --json"
+                        f"{_exe()} -m src.geoseal_cli testing-cli " f"--language {language} --source-file <file> --json"
                     ),
                 },
             }
@@ -108,8 +106,7 @@ def _tool_contracts() -> list[dict[str, Any]]:
             "risk": "critical",
             "approval": "deny_by_default",
             "purpose": (
-                "Secrets are never routed through free model prompts; "
-                "tools receive only named env requirements."
+                "Secrets are never routed through free model prompts; " "tools receive only named env requirements."
             ),
             "routes": ["connector_env_check", "redacted_evidence_only"],
         },
@@ -355,8 +352,7 @@ def build_agent_tool_bridge_v1(
         "testing_cli_json": f"{exe} -m src.geoseal_cli testing-cli {file_args} --json",
         "compile_intent_json": f"{exe} -m src.geoseal_cli compile --json {shlex.quote(compile_text)}",
         "ghost_terminal_audit_ps1": (
-            "powershell.exe -NoProfile -ExecutionPolicy Bypass "
-            "-File scripts/system/ghost_terminal_audit.ps1 -Json"
+            "powershell.exe -NoProfile -ExecutionPolicy Bypass " "-File scripts/system/ghost_terminal_audit.ps1 -Json"
         ),
         "ghost_terminal_cleanup_stale_ps1": (
             "powershell.exe -NoProfile -ExecutionPolicy Bypass "
@@ -364,8 +360,7 @@ def build_agent_tool_bridge_v1(
         ),
         "call_switchboard_json": f"{exe} -m src.geoseal_cli call-switchboard --request <json> --json",
         "lightning_indexer_json": (
-            f"{exe} -m src.geoseal_cli lightning-indexer "
-            "--goal <goal> --inline-candidates <json> --json"
+            f"{exe} -m src.geoseal_cli lightning-indexer " "--goal <goal> --inline-candidates <json> --json"
         ),
     }
 


### PR DESCRIPTION
## Summary
- applies Black formatting to the two Python files from #1735 so CI formatting matches the merged code

## Verification
- `python -m black --check --target-version py311 --line-length 120 src/api/geoseal_cli_bridge.py src/coding_spine/agent_tool_bridge.py` -> passed
- `python -m pytest tests/test_agent_task_run_and_external_eval.py tests/coding_spine/test_agent_call_switchboard.py tests/coding_spine/test_lightning_indexer.py tests/coding_spine/test_skill_harness_tools.py -q` -> 45 passed
- `python -m py_compile src/geoseal_cli.py src/api/geoseal_cli_bridge.py src/coding_spine/agent_tool_bridge.py` -> passed
- `python -m flake8 src/api/geoseal_cli_bridge.py src/coding_spine/agent_tool_bridge.py tests/test_agent_task_run_and_external_eval.py tests/coding_spine/test_agent_call_switchboard.py tests/coding_spine/test_lightning_indexer.py tests/coding_spine/test_skill_harness_tools.py` -> passed
