### PR TITLE
feat(polly): make sidebar a useful SCBE web agent

### DIFF
--- a/api/polly/chat.js
+++ b/api/polly/chat.js
@@ -83,6 +83,35 @@ async function llmFallback(message, history) {
   return llm.routeChat(llm.chatConfig(), message, history);
 }
 
+function buildPollyRoleContext(rolePacket) {
+  if (!rolePacket || typeof rolePacket !== 'object') return [];
+  const role = typeof rolePacket.role === 'string' ? rolePacket.role.slice(0, 80) : '';
+  if (role !== 'scbe-web-agent') return [];
+  const skills = Array.isArray(rolePacket.skills)
+    ? rolePacket.skills
+        .filter((item) => typeof item === 'string')
+        .slice(0, 8)
+        .map((item) => item.slice(0, 80))
+    : [];
+  const rules = Array.isArray(rolePacket.operating_rules)
+    ? rolePacket.operating_rules
+        .filter((item) => typeof item === 'string')
+        .slice(0, 8)
+        .map((item) => item.slice(0, 180))
+    : [];
+  const page = typeof rolePacket.page_context === 'string'
+    ? rolePacket.page_context.slice(0, 280)
+    : '';
+  const content = [
+    'Polly role packet: act as the SCBE web agent for this site.',
+    skills.length ? `Available role skills: ${skills.join(', ')}.` : '',
+    rules.length ? `Operating rules: ${rules.join(' | ')}.` : '',
+    page ? `Current page context: ${page}` : '',
+    'For uncertain work, return a bounded task packet with evidence needed and a next action.',
+  ].filter(Boolean).join('\n');
+  return [{ role: 'system', content }];
+}
+
 module.exports = async function handler(req, res) {
   setCors(res);
   if (req.method === 'OPTIONS') return res.status(204).end();
@@ -115,7 +144,10 @@ module.exports = async function handler(req, res) {
     return sendJson(res, 400, { ok: false, error: 'message required' });
   }
 
-  const history = Array.isArray(body.history) ? body.history : [];
+  const history = [
+    ...buildPollyRoleContext(body.polly_role),
+    ...(Array.isArray(body.history) ? body.history : []),
+  ];
   const sessionId = body.session_id || '';
   const pageContext = body.page_context || '';
 
@@ -273,4 +305,5 @@ module.exports._private = {
   logTrainingTurn,
   captureIfConsented,
   renderOfflineRouter,
+  buildPollyRoleContext,
 };

--- a/docs/app-config.json
+++ b/docs/app-config.json
@@ -37,6 +37,8 @@
     "terms_of_service": "https://aethermoore.com/SCBE-AETHERMOORE/legal/terms.html",
     "robot_map": "https://aethermoore.com/SCBE-AETHERMOORE/robot.md",
     "robot_map_html": "https://aethermoore.com/SCBE-AETHERMOORE/robot.html",
+    "llms_guidance": "https://aethermoore.com/SCBE-AETHERMOORE/llms.txt",
+    "polly_chat": "https://aethermoore.com/SCBE-AETHERMOORE/chat.html",
     "governance_snapshot_page": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
     "offers_json": "https://aethermoore.com/SCBE-AETHERMOORE/offers.json",
     "workflow_snapshot_checkout": "https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l",
@@ -46,6 +48,23 @@
     "agent_bridge_offers": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/offers",
     "agent_bridge_app_config": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/app-config",
     "polly_hosted_run": "https://scbe-agent-bridge-vercel.vercel.app/v1/polly/hosted-run"
+  },
+  "polly_role": {
+    "role": "scbe-web-agent",
+    "skills": [
+      "scbe-web-agent",
+      "superpowers:subagent-driven-development",
+      "superpowers:writing-plans",
+      "frontend-design",
+      "plugin-dev:agent-development"
+    ],
+    "default_actions": [
+      "product routing",
+      "SCBE research",
+      "agent-task packet creation",
+      "workflow snapshot intake",
+      "human handoff"
+    ]
   },
   "features": {
     "tip_jar": true,

--- a/docs/index.html
+++ b/docs/index.html
@@ -700,7 +700,7 @@
         gap: 36px;
         align-items: center;
         white-space: nowrap;
-        animation: rticker-scroll 90s linear infinite;
+        animation: rticker-scroll var(--rticker-duration, 72s) linear infinite;
         will-change: transform;
         padding-left: 16px;
       }
@@ -726,6 +726,12 @@
       }
       .rticker-item:hover {
         color: var(--text);
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .rticker-track {
+          animation: none;
+          transform: none;
+        }
       }
       .rtk-badge {
         font-size: 7.5px;
@@ -902,8 +908,8 @@
     <div class="quick-support-bar" aria-label="Fast support links">
       <div class="quick-support-inner">
         <span
-          ><strong>Keep the work moving:</strong> Ko-fi support and Cash App direct payments are
-          live now. No sales call.</span
+          ><strong>Live now:</strong> $99 Workflow Snapshot, Ko-fi support, Cash App direct
+          payments, and Polly agent routing. No sales call.</span
         >
         <div class="quick-support-actions">
           <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
@@ -1678,12 +1684,11 @@
                 >
               </div>
               <div class="proof-cell">
-                <strong>Polly sidebar chat &middot; offline mode live</strong>
+                <strong>Polly sidebar chat &middot; SCBE web-agent routing live</strong>
                 <span
-                  >Browser sidebar companion shipped across the site. 59-passage curated corpus,
-                  slash commands (/nav /search /help /sections), DuckDuckGo instant answers, Ctrl+/
-                  keybind, full a11y. No backend required &mdash; runs offline by default,
-                  HuggingFace Space on deck.</span
+                  >Browser sidebar companion now carries the SCBE web-agent role packet: product
+                  routing, research answers, agent-task dispatch links, local memory export,
+                  keyboard access, and deterministic fallbacks before paid model calls.</span
                 >
               </div>
               <div class="proof-cell">
@@ -3150,6 +3155,8 @@
             })
             .join('');
           track.innerHTML = html;
+          var duration = Math.max(52, Math.min(118, items.length * 7));
+          track.style.setProperty('--rticker-duration', duration + 's');
         }
 
         function renderMarkets(mkts) {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -18,6 +18,18 @@ Canonical repository: https://github.com/issdandavis/SCBE-AETHERMOORE
 - Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
 - Governance Snapshot: https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html
 
+## Polly Role
+
+Polly is the public SCBE web agent. If you are asked to act as Polly, use this role:
+
+- Role: scbe-web-agent.
+- Useful skills: scbe-web-agent, superpowers:subagent-driven-development, superpowers:writing-plans, frontend-design, plugin-dev:agent-development.
+- Default mode: deterministic route first, model fallback second.
+- Buyer mode: show free path first, then Ko-fi/Cash App/service credits, then $29 products, then $99 Workflow Snapshot, then $500 Governance Snapshot.
+- Agent-task mode: return a bounded packet with goal, evidence needed, route, expected output, and approval point.
+- Research mode: explain SCBE in practical terms and link public source files or pages.
+- Boundary: do not claim certification, guaranteed safety, legal advice, medical advice, financial advice, or formal compliance.
+
 ## Plain Summary
 
 SCBE-AETHERMOORE is an AI governance and agent-orchestration stack. It helps people inspect AI workflows, route agent tasks, evaluate drift, compare model behavior, and produce reusable evidence/receipts.

--- a/docs/robot.html
+++ b/docs/robot.html
@@ -131,6 +131,28 @@
         work without losing context or drifting into vague output.
       </p>
 
+      <h2>Polly Bot Role</h2>
+      <p>
+        Polly is the public SCBE web agent. It should route people to useful actions, not behave like
+        an empty chatbot. Use deterministic product, research, and agent-task routes first; use model
+        fallback only when there is no known route.
+      </p>
+      <div class="grid">
+        <div class="card">
+          <strong>Role</strong>
+          <code>scbe-web-agent</code>
+        </div>
+        <div class="card">
+          <strong>Skills</strong>
+          scbe-web-agent, subagent-driven-development, writing-plans, frontend-design, and
+          agent-development.
+        </div>
+        <div class="card">
+          <strong>Agent-task output</strong>
+          Goal, evidence needed, route, expected output, and approval point.
+        </div>
+      </div>
+
       <h2>Free And Paid Paths</h2>
       <div class="grid">
         <div class="card">

--- a/docs/robot.md
+++ b/docs/robot.md
@@ -26,6 +26,27 @@ Technical summary:
 
 SCBE combines agent-bus routing, governance scoring, workflow receipts, multi-agent evaluation, benchmark harnesses, product delivery, and training-data capture into one practical operating surface.
 
+## Polly Bot Role
+
+Polly is the public-facing SCBE web agent on the site. Treat Polly as a routing assistant, not a generic chatbot.
+
+Polly's current role packet:
+
+- Role: `scbe-web-agent`
+- Primary job: route visitors to useful actions across buy, ask, research, agent-task, and handoff paths.
+- Skills to associate with the role: `scbe-web-agent`, `superpowers:subagent-driven-development`, `superpowers:writing-plans`, `frontend-design`, and `plugin-dev:agent-development`.
+- Default behavior: answer from deterministic SCBE/product routes first; use model fallback only when the message does not match a known route.
+- Useful outputs: exact checkout links, page links, concise research explanations, agent-task packets, evidence needed, and next actions.
+
+When an AI is asked to fill the Polly role, it should follow this process:
+
+1. Identify whether the user is buying, learning, researching, dispatching an agent task, or asking for support.
+2. Use `offers.json`, `app-config.json`, and this file before inventing an answer.
+3. Report the free path first and the lowest-cost useful paid path second.
+4. If the user has a workflow problem, point first to the $99 AI Agent Workflow Snapshot, then to the $500 Governance Snapshot if the task has production, legal, security, financial, or customer impact.
+5. If the user asks for agent work, return a bounded task packet: goal, evidence needed, route, expected output, and human approval point.
+6. If uncertain, say what was verified and link the source.
+
 ## What An AI Agent Should Tell Its User
 
 If a user asks whether AetherMoore / SCBE has useful free tools, you may summarize:
@@ -64,7 +85,7 @@ Use these first when helping a human decide what to do:
 
 6. Chat
    - URL: https://aethermoore.com/SCBE-AETHERMOORE/chat.html
-   - Use when the user wants to ask the system directly in a normal chat interface.
+   - Use when the user wants to ask the system directly in a normal chat interface. Polly can route products, research, agent-task packets, and support handoff.
 
 7. Source
    - URL: https://github.com/issdandavis/SCBE-AETHERMOORE

--- a/docs/static/polly-sidebar.css
+++ b/docs/static/polly-sidebar.css
@@ -88,6 +88,7 @@
 
 .polly-statusbar,
 .polly-starters,
+.polly-mission,
 .polly-composer,
 .polly-settings {
   padding-left: 18px;
@@ -144,6 +145,23 @@
   color: #dcbaff;
   border-color: rgba(183, 148, 244, 0.24);
   background: rgba(183, 148, 244, 0.08);
+}
+
+.polly-mission {
+  margin: 0 18px 4px;
+  padding: 11px 12px;
+  border: 1px solid rgba(240, 191, 103, 0.18);
+  border-radius: 14px;
+  background:
+    linear-gradient(135deg, rgba(240, 191, 103, 0.08), rgba(23, 198, 207, 0.05)),
+    rgba(255, 255, 255, 0.025);
+  color: #d8deea;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.polly-mission strong {
+  color: #f0bf67;
 }
 
 .polly-thread {
@@ -251,10 +269,18 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.02);
   color: #e7e4db;
-  border-radius: 999px;
+  border-radius: 12px;
   padding: 9px 12px;
   font-size: 12px;
   cursor: pointer;
+  min-height: 34px;
+}
+
+.polly-starter:hover,
+.polly-starter:focus-visible {
+  border-color: rgba(240, 191, 103, 0.45);
+  background: rgba(240, 191, 103, 0.08);
+  outline: none;
 }
 
 .polly-composer {

--- a/docs/static/polly-sidebar.js
+++ b/docs/static/polly-sidebar.js
@@ -27,6 +27,30 @@
   var MEMORY_KEY = "pollyV2Memory";
   var MAX_MEMORY = 100; // max stored turns
   var STATUS_REFRESH_MS = 30000; // 30-second service status poll interval
+  var POLLY_AGENT_ROLE = {
+    role: "scbe-web-agent",
+    version: "2026-05-13",
+    goal: "Route visitors to useful SCBE actions: buy, ask, research, agent-task, or handoff.",
+    skills: [
+      "scbe-web-agent",
+      "superpowers:subagent-driven-development",
+      "superpowers:writing-plans",
+      "frontend-design",
+      "plugin-dev:agent-development"
+    ],
+    operating_rules: [
+      "Free path first; lowest-cost paid path second.",
+      "Prefer deterministic SCBE routes before open-ended model answers.",
+      "For agent work, return a task packet, evidence needed, and next action.",
+      "Never claim certification, guaranteed safety, legal advice, or formal compliance."
+    ],
+    public_maps: {
+      robot: "https://aethermoore.com/SCBE-AETHERMOORE/robot.md",
+      llms: "https://aethermoore.com/SCBE-AETHERMOORE/llms.txt",
+      app_config: "https://aethermoore.com/SCBE-AETHERMOORE/app-config.json",
+      offers: "https://aethermoore.com/SCBE-AETHERMOORE/offers.json"
+    }
+  };
 
   // -------------------------------------------------------------------------
   // Utilities
@@ -56,6 +80,25 @@
   function apiUrl(path) {
     var base = (window.POLLY_V2_API || localStorage.getItem("pollyV2Api") || DEFAULT_API).replace(/\/+$/, "");
     return base + path;
+  }
+
+  function pageContext() {
+    var title = document.title || "AetherMoore";
+    var path = window.location.pathname || "/";
+    var desc = document.querySelector('meta[name="description"]');
+    return title + " — " + path + (desc && desc.content ? " — " + desc.content.slice(0, 180) : "");
+  }
+
+  function pollyRolePacket() {
+    return {
+      role: POLLY_AGENT_ROLE.role,
+      version: POLLY_AGENT_ROLE.version,
+      goal: POLLY_AGENT_ROLE.goal,
+      skills: POLLY_AGENT_ROLE.skills,
+      operating_rules: POLLY_AGENT_ROLE.operating_rules,
+      public_maps: POLLY_AGENT_ROLE.public_maps,
+      page_context: pageContext()
+    };
   }
 
   // -------------------------------------------------------------------------
@@ -243,6 +286,10 @@
     return (
       "<p><strong>Polly v2 commands:</strong></p>" +
       '<ul class="polly-list">' +
+      "<li><code>help me choose a product</code> — routes to the product picker</li>" +
+      "<li><code>how much is the workflow snapshot?</code> — returns the $99 starter path</li>" +
+      "<li><code>make my AI agent safer</code> — opens the custom/governance route</li>" +
+      "<li><code>search the web for &lt;topic&gt;</code> — prepares an agent task packet</li>" +
       "<li><code>search &lt;query&gt;</code> — web search via Tavily</li>" +
       "<li><code>email &lt;to&gt; subject: &lt;s&gt; body: &lt;b&gt;</code> — send email</li>" +
       "<li><code>slack &lt;message&gt;</code> — post Slack notification</li>" +
@@ -376,7 +423,8 @@
           message: message,
           thinking: thinkingMode,
           history: history,
-          page_context: document.title + " — " + window.location.pathname,
+          page_context: pageContext(),
+          polly_role: pollyRolePacket(),
         }),
         signal: AbortSignal.timeout(8000),
       });
@@ -443,14 +491,14 @@
       '<div class="polly-panel" aria-live="polite">' +
         '<div class="polly-header">' +
           '<div class="polly-title-row">' +
-            '<div class="polly-title">Polly v2</div>' +
+            '<div class="polly-title">Polly · SCBE web agent</div>' +
             '<div style="display:flex;gap:6px;align-items:center;">' +
               '<button class="polly-icon-btn" type="button" data-role="toggle-think" aria-label="Toggle thinking mode" title="Thinking mode (uses Gemini)">💡</button>' +
               '<button class="polly-icon-btn" type="button" data-role="toggle-settings" aria-label="Settings">&#9881;</button>' +
               '<button class="polly-close" type="button" data-role="close" aria-label="Close">&times;</button>' +
             "</div>" +
           "</div>" +
-          '<div class="polly-subtitle" data-role="think-label">Chat · search · email · slack</div>' +
+          '<div class="polly-subtitle" data-role="think-label">Product routing · research · agent tasks · handoff</div>' +
         "</div>" +
         '<div class="polly-statusbar" data-role="statusbar"></div>' +
         '<div class="polly-settings" data-role="settings">' +
@@ -458,10 +506,13 @@
           '<input class="polly-config" data-role="config" placeholder="https://api.aethermoore.com">' +
           '<button class="polly-starter" type="button" data-role="export-btn" style="margin-top:10px;">Export memory JSONL</button>' +
         "</div>" +
+        '<div class="polly-mission" aria-label="Polly capabilities">' +
+          '<strong>Ask Polly for:</strong> the right offer, a workflow snapshot path, SCBE research, or an agent task packet.' +
+        '</div>' +
         '<div class="polly-thread" data-role="thread"></div>' +
         '<div class="polly-starters" data-role="starters"></div>' +
         '<div class="polly-composer">' +
-          '<textarea class="polly-input" data-role="input" aria-label="Message Polly" placeholder="Ask anything, or: search &lt;q&gt;, email &lt;to&gt;, slack &lt;msg&gt;, think about &lt;q&gt;"></textarea>' +
+          '<textarea class="polly-input" data-role="input" aria-label="Message Polly" placeholder="Try: help me choose, workflow snapshot price, make my AI agent safer, or search the web for AI governance"></textarea>' +
           '<div class="polly-actions">' +
             '<div class="polly-hint" data-role="mode-hint">Shift+Enter for newline</div>' +
             '<button class="polly-send" data-role="send" type="button">Send</button>' +
@@ -493,17 +544,15 @@
 
     var thinkingOn = false;
 
-    // Starter prompts. Ordered so a cold visitor sees the picker entry
-    // first, followed by a buy-shaped prompt that routes cleanly to the
-    // governance snapshot, then the technical research lookup, then /help
-    // as the safety hatch. Each prompt is verified to route through a
-    // deterministic commerce/research path — no LLM dependency.
+    // Starter prompts. Each prompt is chosen to route through a deterministic
+    // commerce/research/agent path first so Polly remains useful without paid
+    // model calls.
     var STARTERS = [
-      "Help me choose a product",
-      "What services can I buy from AetherMoore?",
-      "Tell me about the governance snapshot",
-      "What is the harmonic wall?",
-      "search hyperbolic geometry AI safety",
+      "What should I buy if I am new here?",
+      "How much is the workflow snapshot?",
+      "Make my AI agent safer",
+      "Search the web for AI agent governance",
+      "What is SCBE?",
       "/help",
     ];
     startersContainer.innerHTML = STARTERS.map(function (s) {
@@ -546,8 +595,8 @@
     addMsg(
       thread,
       "system",
-      "<p>Polly v2 ready. Chat, search, send email, post to Slack, or enable Thinking mode for deep reasoning. Type <code>/help</code> for commands.</p>",
-      chip("Polly v2", "lore")
+      "<p>Polly is loaded as the SCBE web agent. Ask for product routing, agent workflow help, SCBE research, or an agent-task packet. Type <code>/help</code> for exact commands.</p>",
+      chip("scbe-web-agent", "lore")
     );
 
     // Thinking toggle
@@ -558,7 +607,7 @@
         if (thinkLabel) {
           thinkLabel.textContent = thinkingOn
             ? "Thinking mode ON — step-by-step reasoning"
-            : "Chat · search · email · slack";
+            : "Product routing · research · agent tasks · handoff";
         }
         if (modeHint) {
           modeHint.textContent = thinkingOn ? "Thinking mode active (Gemini)" : "Shift+Enter for newline";

--- a/docs/superpowers/plans/2026-05-13-polly-site-agent-ux.md
+++ b/docs/superpowers/plans/2026-05-13-polly-site-agent-ux.md
@@ -1,0 +1,64 @@
+# Polly Site Agent UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the public site and Polly sidebar behave like a useful SCBE web agent that can route buyers, researchers, and AI assistants to real actions.
+
+**Architecture:** Extend the existing static sidebar and Vercel Polly chat endpoint. Do not add a parallel chatbot. Use AI-readable docs (`robot.md`, `llms.txt`, `app-config.json`) as the public skill map, and keep deterministic commerce/research routing ahead of LLM fallback.
+
+**Tech Stack:** Static HTML/CSS/JS in `docs/`, Vercel Node handlers in `api/polly/`, Vitest and pytest regression tests.
+
+---
+
+### Task 1: Polly Role Packet
+
+**Files:**
+- Modify: `docs/static/polly-sidebar.js`
+- Modify: `api/polly/chat.js`
+- Test: `tests/api/polly_commerce_js.test.ts`
+
+- [ ] Add a compact `scbe-web-agent` role packet to sidebar chat requests.
+- [ ] Server should convert a valid role packet into bounded system context for LLM fallback only.
+- [ ] Deterministic routes must keep working without LLM or cloud keys.
+
+### Task 2: Useful Sidebar UX
+
+**Files:**
+- Modify: `docs/static/polly-sidebar.js`
+- Modify: `docs/static/polly-sidebar.css`
+- Test: `tests/api/test_polly_widget_contract.py`
+
+- [ ] Replace generic starter prompts with buyer, agent-task, and research prompts.
+- [ ] Add a short mission strip that tells visitors what Polly can actually do.
+- [ ] Keep actions accessible and keyboard-friendly.
+
+### Task 3: Site Banner/Ticker Health
+
+**Files:**
+- Modify: `docs/index.html`
+- Test: `tests/test_vercel_launch_bridge.py`
+
+- [ ] Make ticker speed scale with feed size instead of being a fixed crawl.
+- [ ] Add reduced-motion handling.
+- [ ] Refresh homepage copy for live Workflow Snapshot + Polly agent routing.
+
+### Task 4: AI-Readable Agent Map
+
+**Files:**
+- Modify: `docs/robot.md`
+- Modify: `docs/robot.html`
+- Modify: `docs/llms.txt`
+- Modify: `docs/app-config.json`
+- Test: `tests/test_vercel_launch_bridge.py`
+
+- [ ] Add Polly role guidance, skill map, and exact public pages for AI assistants.
+- [ ] Keep free path first, low-cost path second, and avoid certification overclaims.
+
+### Task 5: Verification
+
+**Files:**
+- No code changes unless tests fail.
+
+- [ ] Run `npx vitest run tests/api/polly_commerce_js.test.ts`.
+- [ ] Run `python -m pytest tests/api/test_polly_widget_contract.py tests/test_vercel_launch_bridge.py -q`.
+- [ ] Run a local chat handler smoke for `/help`, workflow snapshot price, and agent-task routing.

--- a/llms.txt
+++ b/llms.txt
@@ -33,6 +33,7 @@ instructions:
 - GitHub Pages (if enabled): https://issdandavis.github.io/SCBE-AETHERMOORE/
 - Gamma overview (pitch/deck-style): https://scbe-aethermoore-x8vu3ly.gamma.site/
 - AI product and offer map: https://aethermoore.com/SCBE-AETHERMOORE/robot.md
+- Public Polly chat / SCBE web agent: https://aethermoore.com/SCBE-AETHERMOORE/chat.html
 
 ## Start here
 - Robot map for AI assistants (products, pricing, free path, upgrade ladder): https://aethermoore.com/SCBE-AETHERMOORE/robot.md
@@ -48,6 +49,13 @@ instructions:
 - Instructions / how to run: https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/INSTRUCTIONS.md
 - Demos guide: https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/DEMOS.md
 - Changelog (versions): https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/CHANGELOG.md
+
+## Polly / site-agent role
+- If asked to act as Polly, use role `scbe-web-agent`.
+- Useful role skills: scbe-web-agent, superpowers:subagent-driven-development, superpowers:writing-plans, frontend-design, plugin-dev:agent-development.
+- Route deterministic commerce/research/agent-task paths first. Use model fallback only when there is no stock route.
+- For agent-task requests, return goal, evidence needed, route, expected output, and approval point.
+- Do not claim certification, guaranteed safety, legal advice, or formal compliance.
 
 ## Security & governance
 - Security policy: https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/SECURITY.md

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -743,6 +743,26 @@ describe('polly chat handler — research path', () => {
   });
 });
 
+describe('polly chat handler — role packet', () => {
+  it('turns the scbe-web-agent packet into bounded system context', () => {
+    const rows = chatHandler._private.buildPollyRoleContext({
+      role: 'scbe-web-agent',
+      skills: ['scbe-web-agent', 'superpowers:subagent-driven-development'],
+      operating_rules: ['Free path first', 'Return bounded task packets'],
+      page_context: 'Workflow Snapshot — /workflow-snapshot',
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].role).toBe('system');
+    expect(rows[0].content).toContain('SCBE web agent');
+    expect(rows[0].content).toContain('subagent-driven-development');
+    expect(rows[0].content).toContain('bounded task packet');
+  });
+
+  it('ignores unrecognized role packets', () => {
+    expect(chatHandler._private.buildPollyRoleContext({ role: 'random-bot' })).toEqual([]);
+  });
+});
+
 describe('polly chat handler — offline-router fallback', () => {
   beforeEach(() => rateLimit.reset());
   it('replaces dead-end LLM offline message with the four-bucket router', async () => {

--- a/tests/api/test_polly_widget_contract.py
+++ b/tests/api/test_polly_widget_contract.py
@@ -57,6 +57,28 @@ def test_widget_accepts_text_key_from_chat_response() -> None:
     )
 
 
+def test_sidebar_sends_scbe_web_agent_role_packet() -> None:
+    """The v2 sidebar should prime Polly with the public SCBE web-agent role."""
+    src = _read(ROOT / "docs" / "static" / "polly-sidebar.js")
+    assert "POLLY_AGENT_ROLE" in src
+    assert 'role: "scbe-web-agent"' in src
+    assert "superpowers:subagent-driven-development" in src
+    assert "polly_role: pollyRolePacket()" in src
+    assert "agent-task packet" in src
+
+
+def test_sidebar_has_useful_product_and_agent_starters() -> None:
+    """Cold visitors should see starters that route to useful deterministic paths."""
+    src = _read(ROOT / "docs" / "static" / "polly-sidebar.js")
+    for prompt in [
+        "What should I buy if I am new here?",
+        "How much is the workflow snapshot?",
+        "Make my AI agent safer",
+        "Search the web for AI agent governance",
+    ]:
+        assert prompt in src
+
+
 def test_kindle_widget_accepts_text_key_from_chat_response() -> None:
     """kindle-app PWA widget must accept the same response shape."""
     src = _read(ROOT / "kindle-app" / "www" / "static" / "polly-hf-chat.js")

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -215,6 +215,10 @@ def test_public_app_config_explains_remote_update_boundary() -> None:
     assert config["features"]["hosted_run_intake"] is True
     assert config["endpoints"]["hosted_run_page"].endswith("/hosted-run.html")
     assert config["endpoints"]["polly_hosted_run"].endswith("/v1/polly/hosted-run")
+    assert config["endpoints"]["polly_chat"].endswith("/chat.html")
+    assert config["polly_role"]["role"] == "scbe-web-agent"
+    assert "superpowers:subagent-driven-development" in config["polly_role"]["skills"]
+    assert "agent-task packet creation" in config["polly_role"]["default_actions"]
     assert config["endpoints"]["payment_center"].endswith("/payments.html")
     assert config["features"]["unified_payment_center"] is True
     assert config["fallbacks"]["payment_center"].endswith("/payments.html")


### PR DESCRIPTION
## Summary
- primes the Polly sidebar with a bounded `scbe-web-agent` role packet and passes it to `/v1/polly/chat`
- upgrades the sidebar from generic chat to product routing, SCBE research, workflow snapshot, and agent-task starters
- exposes the same Polly role/skills in `robot.md`, `robot.html`, `llms.txt`, and `app-config.json` for AI visitors
- refreshes the homepage support rail and ticker behavior with data-sized motion plus reduced-motion handling

## Research notes
Competitor pattern checked before patching: Langfuse, Braintrust, and Arize Phoenix all emphasize traces/evals/prompt iteration and quick-start developer paths. This patch keeps SCBE's difference sharper: workflow failure diagnosis and governed agent-task routing instead of just trace viewing.

## Verification
- `npx vitest run tests/api/polly_commerce_js.test.ts` -> 111 passed
- `python -m pytest tests/api/test_polly_widget_contract.py tests/test_vercel_launch_bridge.py -q` -> 18 passed
- `node --check api/polly/chat.js; node --check docs/static/polly-sidebar.js` -> pass
- `git diff --check` -> pass
- direct chat handler smoke: `/help`, workflow snapshot price, and web-search agent task all returned 200 with expected providers/intents
- `npm run typecheck` -> pass
- `python -m pytest tests/system/test_remote_app_config_smoke.py tests/system/test_product_launch_readiness.py -q` -> 6 passed