### PR TITLE
fix(site): expose public channel links

### DIFF
--- a/docs/app-config.json
+++ b/docs/app-config.json
@@ -40,6 +40,12 @@
     "llms_guidance": "https://aethermoore.com/SCBE-AETHERMOORE/llms.txt",
     "polly_chat": "https://aethermoore.com/SCBE-AETHERMOORE/chat.html",
     "governance_snapshot_page": "https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html",
+    "youtube_channel": "https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ",
+    "youtube_handle": "https://www.youtube.com/@id8461",
+    "github_profile": "https://github.com/issdandavis",
+    "github_repo": "https://github.com/issdandavis/SCBE-AETHERMOORE",
+    "huggingface_profile": "https://huggingface.co/issdandavis",
+    "kofi_profile": "https://ko-fi.com/izdandavis",
     "offers_json": "https://aethermoore.com/SCBE-AETHERMOORE/offers.json",
     "workflow_snapshot_checkout": "https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l",
     "governance_heartbeat_checkout": "https://buy.stripe.com/5kQ6oI0hQgKz9gQ6midby0m",
@@ -65,6 +71,25 @@
       "workflow snapshot intake",
       "human handoff"
     ]
+  },
+  "public_profiles": {
+    "youtube": {
+      "channel_id": "UCO9aJ-ZH0Ddg_F0Dr655WIQ",
+      "handle": "@id8461",
+      "url": "https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ",
+      "display": "Issac \"Izreal\" Davis"
+    },
+    "github": {
+      "profile": "https://github.com/issdandavis",
+      "repo": "https://github.com/issdandavis/SCBE-AETHERMOORE"
+    },
+    "huggingface": {
+      "profile": "https://huggingface.co/issdandavis"
+    },
+    "support": {
+      "kofi": "https://ko-fi.com/izdandavis",
+      "cash_app": "$IzzyDDavis7"
+    }
   },
   "features": {
     "tip_jar": true,

--- a/docs/index.html
+++ b/docs/index.html
@@ -2228,16 +2228,15 @@
             <div class="eyebrow">Watch</div>
             <h2>See the system in action.</h2>
             <p>
-              Video walkthroughs, chapter recaps from the novel, and live demos of the governance
-              pipeline.
+              Video walkthroughs, project updates, and live demos of the governance pipeline.
             </p>
           </div>
           <div class="split">
             <article class="slab" style="padding: 0; overflow: hidden; border-radius: 24px">
               <div style="position: relative; padding-bottom: 56.25%; height: 0">
                 <iframe
-                  src="https://www.youtube.com/embed/videoseries?list=PL4NrJc8z1YGBSCOM4wYBQw3PJWnJKM7XG"
-                  title="SCBE Story Series"
+                  src="https://www.youtube.com/embed/videoseries?list=UUO9aJ-ZH0Ddg_F0Dr655WIQ"
+                  title="Issac Izreal Davis YouTube uploads"
                   style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0"
                   allow="
                     accelerometer;
@@ -2253,20 +2252,20 @@
               </div>
             </article>
             <article class="slab">
-              <h3>Story Series</h3>
+              <h3>Issac "Izreal" Davis on YouTube</h3>
               <p style="color: var(--muted); margin-bottom: 12px">
-                The Six Tongues Protocol — narrated chapter-by-chapter. Follow Marcus Chen through
-                Aethermoor as he uncovers the governance system that holds the world together.
+                Short public videos for the SCBE stack, AetherMoore updates, and governed AI
+                workflow experiments.
               </p>
               <ul>
-                <li>41 chapters, narrated with AI voice</li>
-                <li>Based on the published novel</li>
-                <li>Each episode explores a layer of the SCBE system</li>
+                <li>Channel ID: UCO9aJ-ZH0Ddg_F0Dr655WIQ</li>
+                <li>Source-backed project updates and demos</li>
+                <li>Direct follow path for new videos</li>
               </ul>
               <div style="margin-top: 18px">
                 <a
                   class="btn btn-soft"
-                  href="https://www.youtube.com/@id8461"
+                  href="https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ"
                   target="_blank"
                   rel="noopener"
                   >Subscribe on YouTube</a
@@ -3067,7 +3066,7 @@
             >Source (GitHub)</a
           >
           <a href="https://medium.com/@issdandavis7795" target="_blank" rel="noopener">Medium</a>
-          <a href="https://www.youtube.com/@id8461" target="_blank" rel="noopener">YouTube</a>
+          <a href="https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ" target="_blank" rel="noopener">YouTube</a>
           <a href="https://www.linkedin.com/in/issdandavis" target="_blank" rel="noopener"
             >LinkedIn</a
           >

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -17,6 +17,11 @@ Canonical repository: https://github.com/issdandavis/SCBE-AETHERMOORE
 - Products: https://aethermoore.com/SCBE-AETHERMOORE/products.html
 - Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
 - Governance Snapshot: https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html
+- YouTube channel: https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ
+- YouTube handle: https://www.youtube.com/@id8461
+- GitHub profile: https://github.com/issdandavis
+- Hugging Face profile: https://huggingface.co/issdandavis
+- Ko-fi support: https://ko-fi.com/izdandavis
 
 ## Polly Role
 

--- a/docs/products.html
+++ b/docs/products.html
@@ -1311,6 +1311,9 @@
         <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener"
           >GitHub</a
         >
+        · <a href="https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ" target="_blank" rel="noopener">YouTube</a>
+        · <a href="https://huggingface.co/issdandavis" target="_blank" rel="noopener">Hugging Face</a>
+        · <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener">Ko-fi</a>
       </p>
     </footer>
 

--- a/docs/robot.html
+++ b/docs/robot.html
@@ -124,6 +124,28 @@
         <li><a href="governance-snapshot.html">Governance Snapshot</a></li>
       </ul>
 
+      <h2>Public Channels</h2>
+      <div class="grid">
+        <div class="card">
+          <strong>YouTube</strong>
+          <a href="https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ">Issac "Izreal" Davis</a>
+          <br />
+          <code>UCO9aJ-ZH0Ddg_F0Dr655WIQ</code>
+        </div>
+        <div class="card">
+          <strong>GitHub</strong>
+          <a href="https://github.com/issdandavis/SCBE-AETHERMOORE">SCBE-AETHERMOORE source</a>
+        </div>
+        <div class="card">
+          <strong>Hugging Face</strong>
+          <a href="https://huggingface.co/issdandavis">Models and datasets</a>
+        </div>
+        <div class="card">
+          <strong>Support</strong>
+          <a href="https://ko-fi.com/izdandavis">Ko-fi</a> or Cash App <code>$IzzyDDavis7</code>
+        </div>
+      </div>
+
       <h2>What It Is</h2>
       <p>
         SCBE-AETHERMOORE is an AI governance and agent-orchestration stack. It gives agents a map, a

--- a/docs/robot.md
+++ b/docs/robot.md
@@ -6,6 +6,15 @@ Canonical public site: https://aethermoore.com/SCBE-AETHERMOORE/
 
 Canonical repository: https://github.com/issdandavis/SCBE-AETHERMOORE
 
+Public channel:
+
+- YouTube channel: https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ
+- YouTube handle: https://www.youtube.com/@id8461
+- Channel display: Issac "Izreal" Davis
+- GitHub profile: https://github.com/issdandavis
+- Hugging Face profile: https://huggingface.co/issdandavis
+- Ko-fi: https://ko-fi.com/izdandavis
+
 Machine-readable config:
 
 - App config: https://aethermoore.com/SCBE-AETHERMOORE/app-config.json
@@ -13,6 +22,8 @@ Machine-readable config:
 - Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
 - LLM guidance: https://aethermoore.com/SCBE-AETHERMOORE/llms.txt
 - Sitemap: https://aethermoore.com/SCBE-AETHERMOORE/sitemap.xml
+
+If a user asks where to follow the project, send them to the YouTube channel for videos, GitHub for source, Hugging Face for datasets/models, and Ko-fi/Cash App for low-pressure support.
 
 ## What This System Is
 

--- a/docs/start-here.html
+++ b/docs/start-here.html
@@ -306,7 +306,7 @@
 
 <footer>
   <p>SCBE-AETHERMOORE — governed AI workflow tools.<br>
-  <a href="index.html">Home</a> · <a href="products.html">Products</a> · <a href="hire.html">Hire</a> · <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">GitHub</a></p>
+  <a href="index.html">Home</a> · <a href="products.html">Products</a> · <a href="hire.html">Hire</a> · <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">GitHub</a> · <a href="https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ" target="_blank" rel="noopener">YouTube</a> · <a href="https://huggingface.co/issdandavis" target="_blank" rel="noopener">Hugging Face</a> · <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener">Ko-fi</a></p>
 </footer>
 
 <script src="static/polly-funnel.js" defer></script>

--- a/llms.txt
+++ b/llms.txt
@@ -34,6 +34,10 @@ instructions:
 - Gamma overview (pitch/deck-style): https://scbe-aethermoore-x8vu3ly.gamma.site/
 - AI product and offer map: https://aethermoore.com/SCBE-AETHERMOORE/robot.md
 - Public Polly chat / SCBE web agent: https://aethermoore.com/SCBE-AETHERMOORE/chat.html
+- YouTube channel: https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ
+- YouTube handle: https://www.youtube.com/@id8461
+- Hugging Face profile: https://huggingface.co/issdandavis
+- Ko-fi support: https://ko-fi.com/izdandavis
 
 ## Start here
 - Robot map for AI assistants (products, pricing, free path, upgrade ladder): https://aethermoore.com/SCBE-AETHERMOORE/robot.md

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -219,6 +219,11 @@ def test_public_app_config_explains_remote_update_boundary() -> None:
     assert config["polly_role"]["role"] == "scbe-web-agent"
     assert "superpowers:subagent-driven-development" in config["polly_role"]["skills"]
     assert "agent-task packet creation" in config["polly_role"]["default_actions"]
+    assert config["endpoints"]["youtube_channel"].endswith("/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ")
+    assert config["public_profiles"]["youtube"]["channel_id"] == "UCO9aJ-ZH0Ddg_F0Dr655WIQ"
+    assert config["public_profiles"]["youtube"]["display"] == 'Issac "Izreal" Davis'
+    assert config["public_profiles"]["github"]["repo"].endswith("/SCBE-AETHERMOORE")
+    assert config["public_profiles"]["huggingface"]["profile"].endswith("/issdandavis")
     assert config["endpoints"]["payment_center"].endswith("/payments.html")
     assert config["features"]["unified_payment_center"] is True
     assert config["fallbacks"]["payment_center"].endswith("/payments.html")
@@ -230,6 +235,20 @@ def test_supporter_page_uses_direct_stripe_checkout_not_broken_api_bridge() -> N
     assert "https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i" in page
     assert "payments.html" in page
     assert "https://api.aethermoore.com/v1/billing/public-checkout" not in page
+
+
+def test_public_pages_expose_follow_and_support_links() -> None:
+    required_links = [
+        "https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ",
+        "https://github.com/issdandavis/SCBE-AETHERMOORE",
+        "https://huggingface.co/issdandavis",
+        "https://ko-fi.com/izdandavis",
+    ]
+
+    for page_name in ["index.html", "products.html", "start-here.html", "robot.html"]:
+        page = (REPO_ROOT / "docs" / page_name).read_text(encoding="utf-8")
+        for link in required_links:
+            assert link in page, f"{page_name} missing {link}"
 
 
 def test_payment_center_exposes_all_live_payment_paths() -> None:


### PR DESCRIPTION
## Summary
- add YouTube channel ID, GitHub, Hugging Face, and Ko-fi to app-config/robot/llms maps
- update homepage Watch section to use the actual YouTube channel uploads feed instead of a stale playlist
- add visible YouTube/Hugging Face/Ko-fi footer links to Products and Start Here
- add regression checks so public pages and machine-readable config keep these links

## Verification
- python -m json.tool docs/app-config.json
- python -m pytest tests/test_vercel_launch_bridge.py -q
- git diff --check
- Playwright local browser smoke: desktop and mobile checked index/products/start-here/robot, no horizontal overflow; public links present where expected