### PR TITLE
style(site): black format Shopify route test

### DIFF
--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -228,9 +228,7 @@ def test_public_app_config_explains_remote_update_boundary() -> None:
     assert config["endpoints"]["polly_hosted_run"].endswith("/v1/polly/hosted-run")
     assert config["endpoints"]["polly_chat"].endswith("/chat.html")
     assert config["endpoints"]["shopify_command_center_page"].endswith("/shopify-command-center.html")
-    assert config["endpoints"]["shopify_command_center_demo"].startswith(
-        "https://shopify-command-center-"
-    )
+    assert config["endpoints"]["shopify_command_center_demo"].startswith("https://shopify-command-center-")
     assert config["endpoints"]["shopify_command_center_repo"].endswith("/Shopify-Command-Center")
     assert config["polly_role"]["role"] == "scbe-web-agent"
     assert "superpowers:subagent-driven-development" in config["polly_role"]["skills"]


### PR DESCRIPTION
## Summary
- runs Black on the Shopify Command Center route regression test after #1741 merged before the formatter follow-up landed

## Verification
- `python -m pytest tests\test_vercel_launch_bridge.py -q` -> 14 passed
- `python -m black --check --target-version py311 --line-length 120 tests\test_vercel_launch_bridge.py` -> passed

## Rollback
- revert this PR; formatting-only change