### PR TITLE
fix(docs): make link checker actionable

### DIFF
--- a/.github/workflows/weekly-link-check.yml
+++ b/.github/workflows/weekly-link-check.yml
@@ -2,7 +2,7 @@ name: Weekly Dead Link Check
 
 on:
   schedule:
-    - cron: '0 7 * * 1'  # Every Monday at 7 AM UTC
+    - cron: '0 7 * * 1' # Every Monday at 7 AM UTC
   workflow_dispatch:
 
 permissions:
@@ -22,13 +22,27 @@ jobs:
           python3 - <<'PYEOF'
           import re, os, glob
           from pathlib import Path
+          from urllib.parse import unquote
 
           broken = []
           checked = 0
 
           # Check internal file references in markdown
           md_files = glob.glob("**/*.md", recursive=True)
-          skip_dirs = {"node_modules", "dist", ".git", "__pycache__", ".venv", "external"}
+          skip_dirs = {
+              ".git",
+              ".venv",
+              "__pycache__",
+              "archive",
+              "artifacts",
+              "dist",
+              "docs-build-smoke",
+              "external",
+              "notes",
+              "node_modules",
+              "training-data",
+              "training",
+          }
 
           for md_file in md_files:
               parts = Path(md_file).parts
@@ -37,6 +51,8 @@ jobs:
 
               try:
                   content = Path(md_file).read_text(encoding="utf-8", errors="ignore")
+                  content = re.sub(r"```.*?```", "", content, flags=re.S)
+                  content = re.sub(r"`[^`]*`", "", content)
               except Exception:
                   continue
 
@@ -44,11 +60,13 @@ jobs:
               links = re.findall(r'\[([^\]]*)\]\(([^)]+)\)', content)
               for text, href in links:
                   checked += 1
-                  # Skip external URLs, anchors, and mailto
-                  if href.startswith(('http://', 'https://', '#', 'mailto:')):
+                  # Skip external URLs, anchors, mail links, and local machine paths.
+                  if href.startswith(('http://', 'https://', '#', 'mailto:', 'file:')):
+                      continue
+                  if re.match(r'^[A-Za-z]:[/\\]', href):
                       continue
                   # Strip anchor from path
-                  path = href.split('#')[0]
+                  path = unquote(href.split('#')[0])
                   if not path:
                       continue
                   # Resolve relative to the markdown file's directory

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ pip install scbe-aethermoore
 ## Canonical public docs
 
 - Canonical system state: [`CANONICAL_SYSTEM_STATE.md`](CANONICAL_SYSTEM_STATE.md)
-- Repo surface map: [`REPO_SURFACE_MAP.md`](REPO_SURFACE_MAP.md)
+- Repo surface map: [`docs/REPO_SURFACE_MAP.md`](docs/REPO_SURFACE_MAP.md)
 - Architecture overview: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 - Research hub: [`docs/README.md`](docs/README.md)
 - Review + cleanup report: [`docs/REPO_AUDIT.md`](docs/REPO_AUDIT.md)

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -60,8 +60,8 @@ Open these first:
 
 1. [CANONICAL_SYSTEM_STATE.md](CANONICAL_SYSTEM_STATE.md)
 2. [docs/specs/SCBE_CANONICAL_CONSTANTS.md](docs/specs/SCBE_CANONICAL_CONSTANTS.md)
-3. [SPEC.md](SPEC.md)
-4. [CONCEPTS.md](CONCEPTS.md)
+3. [docs/SPEC.md](docs/SPEC.md)
+4. [docs/CONCEPTS.md](docs/CONCEPTS.md)
 
 ## If You Want Research Or Training
 

--- a/src/README.md
+++ b/src/README.md
@@ -40,9 +40,9 @@ ss = SpiralSealSS1(master_secret=secret, mode='hybrid')  # Kyber768 + AES-GCM
 
 ## Documentation
 
-- [Getting Started](../docs/GETTING_STARTED.md)
-- [SpiralSeal SS1 Spec](../docs/SPIRALSEAL_SS1_COMPLETE.md)
-- [Mathematical Foundations](../docs/COMPREHENSIVE_MATH_SCBE.md)
+- [Product Quickstart](../docs/PRODUCT_QUICKSTART.md)
+- [SpiralSeal implementation](symphonic_cipher/scbe_aethermoore/spiral_seal/)
+- [Compressed layer math](../docs/specs/LAYER_MATH_COMPRESSED.md)
 
 ## License
 

--- a/src/lambda/README.md
+++ b/src/lambda/README.md
@@ -21,4 +21,4 @@ sam deploy --guided
 
 ## Documentation
 
-See [AWS Lambda Deployment Guide](../../docs/AWS_LAMBDA_DEPLOYMENT.md) for complete deployment instructions.
+See the current [Product Quickstart](../../docs/PRODUCT_QUICKSTART.md) for supported deployment and runtime entrypoints.

--- a/src/symphonic_cipher/scbe_aethermoore/README.md
+++ b/src/symphonic_cipher/scbe_aethermoore/README.md
@@ -96,7 +96,7 @@ pytest tests/test_scbe_14layers.py -v
 
 - [SPECIFICATION.md](axiom_grouped/SPECIFICATION.md) - Full v3.0 spec
 - [PATENT_SPECIFICATION.md](PATENT_SPECIFICATION.md) - Patent documentation
-- [docs/COMPREHENSIVE_MATH_SCBE.md](../../docs/COMPREHENSIVE_MATH_SCBE.md) - Mathematical proofs
+- [docs/specs/LAYER_MATH_COMPRESSED.md](../../../docs/specs/LAYER_MATH_COMPRESSED.md) - compressed layer math
 
 ---
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,6 +20,7 @@ tests/
 ## Tier Descriptions
 
 ### L1-BASIC (High School Project Level)
+
 **Purpose**: Smoke tests and basic functionality verification
 **Complexity**: Simple assertions, happy path only
 **Who writes these**: Anyone, including newcomers
@@ -33,6 +34,7 @@ it('should create an envelope', () => {
 ```
 
 **What belongs here**:
+
 - "Does it run?" tests
 - Basic input/output verification
 - Simple happy path scenarios
@@ -41,6 +43,7 @@ it('should create an envelope', () => {
 ---
 
 ### L2-UNIT (Junior Developer Level)
+
 **Purpose**: Test individual functions and modules in isolation
 **Complexity**: Mock dependencies, test edge cases
 **Who writes these**: All developers
@@ -58,6 +61,7 @@ describe('computeSpectralCoherence', () => {
 ```
 
 **What belongs here**:
+
 - Single function tests
 - Boundary value testing
 - Error handling verification
@@ -66,6 +70,7 @@ describe('computeSpectralCoherence', () => {
 ---
 
 ### L3-INTEGRATION (Senior Developer Level)
+
 **Purpose**: Test component interactions and system flows
 **Complexity**: Multiple components working together
 **Who writes these**: Senior developers, architects
@@ -83,6 +88,7 @@ describe('14-Layer Pipeline Integration', () => {
 ```
 
 **What belongs here**:
+
 - End-to-end workflow tests
 - Multi-module interaction tests
 - Database + API integration
@@ -91,6 +97,7 @@ describe('14-Layer Pipeline Integration', () => {
 ---
 
 ### L4-PROPERTY (Staff Engineer Level)
+
 **Purpose**: Property-based testing with random inputs
 **Complexity**: Mathematical invariants, fuzzing
 **Who writes these**: Staff engineers, mathematicians
@@ -115,6 +122,7 @@ it('S_spec is phase-invariant (property-based)', () => {
 ```
 
 **What belongs here**:
+
 - fast-check property tests
 - Mathematical invariant verification
 - Fuzzing with random inputs
@@ -124,6 +132,7 @@ it('S_spec is phase-invariant (property-based)', () => {
 ---
 
 ### L5-SECURITY (Security Engineer Level)
+
 **Purpose**: Security boundaries, compliance, cryptographic correctness
 **Complexity**: Attack simulation, compliance verification
 **Who writes these**: Security engineers, compliance officers
@@ -138,13 +147,14 @@ describe('Cryptographic Boundary Enforcement', () => {
 
   it('F03: Tampered ciphertext must fail', () => {
     const ciphertext = encrypt(plaintext, key);
-    ciphertext[10] ^= 0xFF; // Flip bits
+    ciphertext[10] ^= 0xff; // Flip bits
     expect(() => decrypt(ciphertext, key)).toThrow('TAMPER_DETECTED');
   });
 });
 ```
 
 **What belongs here**:
+
 - OWASP Top 10 verification
 - Cryptographic boundary tests
 - Access control tests
@@ -155,6 +165,7 @@ describe('Cryptographic Boundary Enforcement', () => {
 ---
 
 ### L6-ADVERSARIAL (NSA Level)
+
 **Purpose**: Failable-by-design tests, adversarial scenarios, formal verification
 **Complexity**: Sophisticated attack vectors, cryptanalysis
 **Who writes these**: Cryptographers, security researchers
@@ -189,6 +200,7 @@ describe('Failable-by-Design: Adversarial Crypto', () => {
 ```
 
 **What belongs here**:
+
 - Timing attack resistance
 - Side-channel analysis
 - Cryptanalysis tests
@@ -207,6 +219,7 @@ tests/L{1-6}-{category}/{module}.{type}.test.ts
 ```
 
 Examples:
+
 - `tests/L1-basic/envelope.smoke.test.ts`
 - `tests/L2-unit/spectral-coherence.unit.test.ts`
 - `tests/L3-integration/14-layer-pipeline.integration.test.ts`
@@ -241,25 +254,25 @@ npm test -- --testPathPattern="L[4-6]"
 
 ## CI/CD Pipeline Integration
 
-| Stage | Tiers | Trigger | Timeout |
-|-------|-------|---------|---------|
-| Pre-commit | L1 | Every commit | 30s |
-| PR Check | L1-L3 | Pull request | 5m |
-| Nightly | L1-L5 | Scheduled | 30m |
-| Release | L1-L6 | Tag/Release | 2h |
+| Stage      | Tiers | Trigger      | Timeout |
+| ---------- | ----- | ------------ | ------- |
+| Pre-commit | L1    | Every commit | 30s     |
+| PR Check   | L1-L3 | Pull request | 5m      |
+| Nightly    | L1-L5 | Scheduled    | 30m     |
+| Release    | L1-L6 | Tag/Release  | 2h      |
 
 ---
 
 ## Test Coverage by Tier
 
-| Tier | Tests | Pass Rate | Coverage |
-|------|-------|-----------|----------|
-| L1-basic | ~50 | 100% | Smoke |
-| L2-unit | ~200 | 99%+ | Functions |
-| L3-integration | ~100 | 98%+ | Workflows |
-| L4-property | ~50 | 99%+ | Invariants |
-| L5-security | ~100 | 100% | Boundaries |
-| L6-adversarial | ~30 | 100% | Attacks |
+| Tier           | Tests | Pass Rate | Coverage   |
+| -------------- | ----- | --------- | ---------- |
+| L1-basic       | ~50   | 100%      | Smoke      |
+| L2-unit        | ~200  | 99%+      | Functions  |
+| L3-integration | ~100  | 98%+      | Workflows  |
+| L4-property    | ~50   | 99%+      | Invariants |
+| L5-security    | ~100  | 100%      | Boundaries |
+| L6-adversarial | ~30   | 100%      | Attacks    |
 
 ---
 
@@ -286,36 +299,39 @@ describe('Spectral Coherence Property Tests', () => {
 
 ## Axiom Coverage Matrix
 
-| Axiom | L1 | L2 | L3 | L4 | L5 | L6 |
-|-------|:--:|:--:|:--:|:--:|:--:|:--:|
-| 1. Positivity of Cost | - | ✓ | ✓ | ✓ | - | - |
-| 2. Monotonicity | - | ✓ | ✓ | ✓ | - | - |
-| 3. Convexity | - | - | ✓ | ✓ | - | - |
-| 4. Temporal Breathing | - | ✓ | ✓ | ✓ | - | - |
-| 5. C-infinity Smoothness | - | - | - | ✓ | - | - |
-| 6. Lyapunov Stability | - | - | ✓ | ✓ | - | - |
-| 7. Harmonic Resonance | - | ✓ | ✓ | - | - | - |
-| 8. Quantum Resistance | - | - | - | - | ✓ | ✓ |
-| 9. Hyperbolic Geometry | - | ✓ | ✓ | ✓ | - | - |
-| 10. Golden Ratio | - | ✓ | - | ✓ | - | - |
-| 11. Fractional Flux | - | - | - | ✓ | - | - |
-| 12. Topological Attack | - | - | - | - | ✓ | ✓ |
-| 13. Atomic Rekeying | - | - | ✓ | - | ✓ | ✓ |
+| Axiom                    | L1  | L2  | L3  | L4  | L5  | L6  |
+| ------------------------ | :-: | :-: | :-: | :-: | :-: | :-: |
+| 1. Positivity of Cost    |  -  |  ✓  |  ✓  |  ✓  |  -  |  -  |
+| 2. Monotonicity          |  -  |  ✓  |  ✓  |  ✓  |  -  |  -  |
+| 3. Convexity             |  -  |  -  |  ✓  |  ✓  |  -  |  -  |
+| 4. Temporal Breathing    |  -  |  ✓  |  ✓  |  ✓  |  -  |  -  |
+| 5. C-infinity Smoothness |  -  |  -  |  -  |  ✓  |  -  |  -  |
+| 6. Lyapunov Stability    |  -  |  -  |  ✓  |  ✓  |  -  |  -  |
+| 7. Harmonic Resonance    |  -  |  ✓  |  ✓  |  -  |  -  |  -  |
+| 8. Quantum Resistance    |  -  |  -  |  -  |  -  |  ✓  |  ✓  |
+| 9. Hyperbolic Geometry   |  -  |  ✓  |  ✓  |  ✓  |  -  |  -  |
+| 10. Golden Ratio         |  -  |  ✓  |  -  |  ✓  |  -  |  -  |
+| 11. Fractional Flux      |  -  |  -  |  -  |  ✓  |  -  |  -  |
+| 12. Topological Attack   |  -  |  -  |  -  |  -  |  ✓  |  ✓  |
+| 13. Atomic Rekeying      |  -  |  -  |  ✓  |  -  |  ✓  |  ✓  |
 
 ---
 
 ## Quality Gates
 
 ### L1-L3 (Must pass for merge)
+
 - All tests green
 - No regressions
 - Coverage maintained
 
 ### L4 (Must pass for release)
+
 - All property tests pass with 1000 iterations
 - No invariant violations
 
 ### L5-L6 (Must pass for production)
+
 - All security boundaries enforced
 - Zero cryptographic failures
 - Adversarial tests validated
@@ -325,6 +341,6 @@ describe('Spectral Coherence Property Tests', () => {
 ## References
 
 - [SCBE 14-Layer Architecture](../docs/ARCHITECTURE.md)
-- [13 Axioms Documentation](../docs/AXIOMS.md)
-- [Patent Claims](../docs/ENABLEMENT.md)
+- [Canonical spec](../docs/SPEC.md)
+- [Patent claims coverage](../docs/PATENT_CLAIMS_COVERAGE.md)
 - [NIST PQC Standards](https://csrc.nist.gov/projects/post-quantum-cryptography)


### PR DESCRIPTION
## Summary
- fix real broken links in root/source/test README docs
- make weekly link check ignore generated/archive/training/note mirror directories
- strip code blocks and inline code before Markdown link detection
- decode URL-encoded local link paths and skip local machine path references

## Verification
- local actionable link check using the workflow logic: checked=344, broken=0
- `npx prettier --check .github/workflows/weekly-link-check.yml README.md START_HERE.md src/README.md src/lambda/README.md src/symphonic_cipher/scbe_aethermoore/README.md tests/README.md` -> passed
- `python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/weekly-link-check.yml').read_text(encoding='utf-8')); print('weekly-link-check yaml parsed')"` -> parsed

Closes #1668