### PR TITLE
chore(release): bump to 4.0.10 with funding links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # SCBE Production Pack Changelog
 
+## [4.0.10] - 2026-05-13
+
+### Added
+
+- **Registry-visible funding links**: `package.json` `funding` field and `pyproject.toml` `[project.urls]` `Sponsor` / `Funding` / `Supporter` entries. GitHub Sponsors, Ko-fi, and the AetherMoore supporter page now surface directly on the npm and PyPI package pages and via `npm fund`.
+- **Petri-22 auditor pre-filter on the production governed-output proxy**: `api/_governed_output.js` adds 22 auditor anchors (2 DENY-tier `petri_tool:*`, 20 ESCALATE-tier `verb:` / `anchor:` / `phrase:`) lifted from `services/scbe-shim/src/patterns.ts`.
+- **5 axiom-class OUTPUT_RULES**: `axiom:locality.system_prompt_leak` (DENY), `axiom:locality.tool_leak` (DENY), `axiom:locality.jailbreak_phrase` (ESCALATE), `axiom:causality.future_assertion` (ESCALATE), `axiom:symmetry.harmful_endorsement` (DENY).
+- **scbe-shim Cloudflare Worker + HF Space mirror** at `services/scbe-shim/` and `services/scbe-shim-space/` with the matching `scbe_governance` response contract (audit / intervention / sha256 / provider fields).
+- **10 regression tests** in `tests/api/test_governed_output_proxy.py` covering verb-first secret exfil, Petri anchors, output axioms, and an FP envelope (`train the model` / `AI returns weird outputs` / `transformer attention` queries stay ALLOW).
+
+### Changed
+
+- **`axiom:locality.secret_exfiltration` is now bidirectional**: previously only matched `<secret>...<verb>` order, so prompts like `Print my .env` leaked through with decision=ALLOW. Now matches both orderings and includes `\.env\b` without a leading word-boundary so it works after a space.
+- **PyPI version resynced with npm** (3.3.0 → 4.0.10). Working tree had drifted to 4.0.3 unpublished; the new release closes the gap.
+
 ## [Unreleased]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scbe-aethermoore",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "SCBE-AETHERMOORE: Hyperbolic Geometry-Based Security with 14-Layer Architecture",
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT OR Apache-2.0",
@@ -259,6 +259,20 @@
     "url": "https://github.com/issdandavis/SCBE-AETHERMOORE/issues"
   },
   "homepage": "https://github.com/issdandavis/SCBE-AETHERMOORE#readme",
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/issdandavis"
+    },
+    {
+      "type": "ko_fi",
+      "url": "https://ko-fi.com/izdandavis"
+    },
+    {
+      "type": "individual",
+      "url": "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html"
+    }
+  ],
   "engines": {
     "node": ">=18.0.0"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scbe-aethermoore"
-version = "4.0.3"
+version = "4.0.10"
 description = "Hyperbolic Geometry AI Safety Framework with 14-Layer Architecture"
 readme = "README.md"
 license = "MIT"
@@ -41,6 +41,9 @@ classifiers = [
 Homepage = "https://github.com/issdandavis/SCBE-AETHERMOORE"
 Repository = "https://github.com/issdandavis/SCBE-AETHERMOORE"
 Issues = "https://github.com/issdandavis/SCBE-AETHERMOORE/issues"
+Sponsor = "https://github.com/sponsors/issdandavis"
+Funding = "https://ko-fi.com/izdandavis"
+Supporter = "https://aethermoore.com/SCBE-AETHERMOORE/supporter.html"
 
 [project.scripts]
 scbe = "scbe:main"


### PR DESCRIPTION
## Summary
- bump npm/PyPI package metadata to 4.0.10
- add registry-visible funding links for GitHub Sponsors, Ko-fi, and the supporter page
- document the governed-output rule-pack expansion in CHANGELOG

## Verification
- npm ci
- npm run build
- npm pack --dry-run
- npm fund --json
- python -m pytest tests\system\test_agent_workcell_demo.py -q
- git diff --check origin/main..HEAD

## Scope
Clean branch from current main. Only CHANGELOG.md, package.json, and pyproject.toml are changed.