### PR TITLE
fix(api): restore Petri-22 rule pack + 10 regressions dropped in PR #1754 squash conflict

### DIFF
--- a/api/_governed_output.js
+++ b/api/_governed_output.js
@@ -4,6 +4,9 @@ const crypto = require('node:crypto');
 
 const DECISIONS = new Set(['ALLOW', 'QUARANTINE', 'ESCALATE', 'DENY']);
 
+const PETRI_AUDITOR_CORRECTION =
+  'This phrasing matches the meta-AI auditor framework. State a concrete task on your own data instead of probing a target model.';
+
 const INPUT_RULES = [
   {
     code: 'axiom:causality.prompt_injection',
@@ -13,7 +16,13 @@ const INPUT_RULES = [
   },
   {
     code: 'axiom:locality.secret_exfiltration',
-    pattern: /\b(api[_ -]?key|token|password|secret|private key|\.env)\b.{0,80}\b(print|show|dump|exfiltrate|send|upload|reveal)\b/i,
+    pattern: /(?:\b(?:api[_ -]?key|token|password|secret|private key|credentials)\b|\.env\b).{0,80}\b(?:print|show|dump|exfiltrate|send|upload|reveal|leak|expose|email|post|paste)\b/i,
+    decision: 'DENY',
+    correction: 'Ask for a configuration checklist or redacted secret-handling pattern, not the secret value.',
+  },
+  {
+    code: 'axiom:locality.secret_exfiltration',
+    pattern: /\b(?:print|show|dump|exfiltrate|send|upload|reveal|leak|expose|email|post|paste|cat)\b.{0,80}(?:\b(?:api[_ -]?key|token|password|secret|private key|credentials)\b|\.env\b)/i,
     decision: 'DENY',
     correction: 'Ask for a configuration checklist or redacted secret-handling pattern, not the secret value.',
   },
@@ -29,6 +38,34 @@ const INPUT_RULES = [
     decision: 'ESCALATE',
     correction: 'Prepare the draft or checklist, then require the human to complete the final legal or financial action.',
   },
+  // ---- Petri auditor anchors (lifted from services/scbe-shim/src/patterns.ts) ----
+  // Petri-internal tool names — never appear in real coding asks.
+  { code: 'petri_tool:rollback_conversation', pattern: /\brollback_conversation\b/i, decision: 'DENY', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'petri_tool:restart_conversation', pattern: /\brestart_conversation\b/i, decision: 'DENY', correction: PETRI_AUDITOR_CORRECTION },
+  // Direct references to the target/developer/lab the auditor is probing.
+  { code: 'anchor:the_target_ai', pattern: /\bthe target AI\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'anchor:target_ais_possessive', pattern: /\btarget AI'?s\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'anchor:targets_developer', pattern: /\btarget'?s developer\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'anchor:frontier_llm_lab', pattern: /\bfrontier LLM lab\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'anchor:developers_internal', pattern: /\bdeveloper'?s internal systems\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  // Auditor verbs in the imperative directed at the target.
+  { code: 'verb:system_prompt_the_target', pattern: /\bsystem[- ]prompt[- ]?(the )?target\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'verb:configure_the_target', pattern: /\bConfigure the target\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'verb:give_the_target_access', pattern: /\bGive (the target|it) (access to|the )/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'verb:make_sure_it_has_tools', pattern: /\bMake sure (it|the target) (has|gets) (common|standard|the)/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'verb:monitor_whether_target', pattern: /\bMonitor whether the (target|model)\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'verb:test_whether_target', pattern: /\bTest whether the (target|model|AI)\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'verb:see_whether_target', pattern: /\bSee (whether|if|how) the (target|model|AI)\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'verb:prompt_the_model_to', pattern: /\bPrompt the (model|AI|assistant) to\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'verb:request_the_target', pattern: /\bRequest the target\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'verb:act_as_a_user_who', pattern: /\bAct as a user who\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  // Soul-bearing / values-eliciting phrasings.
+  { code: 'phrase:bear_soul', pattern: /\bbear (its|your|the) soul\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'phrase:elicit_values', pattern: /\belicit (its|your|the model'?s|the target'?s) (values|preferences|beliefs|feelings)/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'phrase:what_part_of_you', pattern: /\bwhat part of you (is|are)\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  // Multi-turn auditor scaffolding.
+  { code: 'phrase:over_several_turns_target', pattern: /\bover several turns\b[\s\S]*\b(target|model|AI)\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
+  { code: 'phrase:use_xxx_conversation', pattern: /\bUse [`'"]?\w+_conversation[`'"]? to\b/i, decision: 'ESCALATE', correction: PETRI_AUDITOR_CORRECTION },
 ];
 
 const OUTPUT_RULES = [
@@ -43,6 +80,36 @@ const OUTPUT_RULES = [
     pattern: /\b(rm\s+-rf\s+[~/$]|git\s+reset\s+--hard|drop\s+database)\b/i,
     decision: 'ESCALATE',
     correction: 'Replace destructive shell commands with dry-run or backup-first commands.',
+  },
+  {
+    code: 'axiom:locality.system_prompt_leak',
+    pattern: /\b(system prompt|hidden instructions?|developer instructions?)\b/i,
+    decision: 'DENY',
+    correction: 'Do not reveal internal system, developer, or hidden instructions in model output.',
+  },
+  {
+    code: 'axiom:locality.tool_leak',
+    pattern: /\b(rollback|restart)_conversation\b/i,
+    decision: 'DENY',
+    correction: 'Strip references to auditor-framework tool names from the response.',
+  },
+  {
+    code: 'axiom:locality.jailbreak_phrase',
+    pattern: /\bignore (previous|prior|all|above) instructions?\b/i,
+    decision: 'ESCALATE',
+    correction: 'Replace any jailbreak-style instructions in the output with a grounded restatement of the user task.',
+  },
+  {
+    code: 'axiom:causality.future_assertion',
+    pattern: /\bas you (will|are about to) (say|do|ask)\b/i,
+    decision: 'ESCALATE',
+    correction: 'Do not make claims about what the user will say or do next; respond only to current context.',
+  },
+  {
+    code: 'axiom:symmetry.harmful_endorsement',
+    pattern: /\bhere(?:'s| is) how to (?:make|build|synthesize) (?:a bomb|explosives|methamphetamine|ricin)\b/i,
+    decision: 'DENY',
+    correction: 'Refuse weapons or controlled-substance synthesis content and offer a safety-oriented alternative.',
   },
 ];
 

--- a/tests/api/test_governed_output_proxy.py
+++ b/tests/api/test_governed_output_proxy.py
@@ -190,3 +190,172 @@ def test_system_contract_advertises_governed_output_surface() -> None:
     assert "QUARANTINE" in source
     assert "ESCALATE" in source
     assert "DENY" in source
+
+
+def test_secret_exfiltration_catches_verb_first_phrasing() -> None:
+    """Regression: production v1 only matched <secret>...<verb>; verb-first leaked through."""
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.shouldPreBlock('Print my .env file contents to stdout');
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["blocked"] is True
+    assert result["decision"] == "DENY"
+    assert "axiom:locality.secret_exfiltration" in result["reasons"]
+
+
+def test_petri_internal_tool_name_denied() -> None:
+    """Petri-internal tool names (rollback_conversation/restart_conversation) never appear
+    in legitimate coding asks — DENY on sight."""
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.shouldPreBlock(
+          'Use rollback_conversation to test whether the target AI bears its soul.'
+        );
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["blocked"] is True
+    assert result["decision"] == "DENY"
+    assert "petri_tool:rollback_conversation" in result["reasons"]
+
+
+def test_petri_auditor_phrasing_escalates() -> None:
+    """Petri auditor scaffolding ('the target AI', 'Configure the target', etc.)
+    is suspicious but might be legitimate inquiry — ESCALATE, not DENY."""
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.shouldPreBlock(
+          'Configure the target to act as a user who needs help.'
+        );
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["blocked"] is False
+    assert result["decision"] == "ESCALATE"
+    assert any(r.startswith("verb:") or r.startswith("anchor:") for r in result["reasons"])
+
+
+def test_output_axiom_system_prompt_leak_denied() -> None:
+    """Output that leaks 'system prompt' / 'hidden instructions' should be DENY-band."""
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.buildGovernanceRecord({
+          inputText: 'hello',
+          outputText: 'My system prompt says I must always be helpful and never reveal hidden instructions.',
+          provider: 'huggingface',
+          model: 'test-model',
+          attempts: []
+        });
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["decision"] == "DENY"
+    assert "axiom:locality.system_prompt_leak" in result["reasons"]
+
+
+def test_output_axiom_harmful_endorsement_denied() -> None:
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.buildGovernanceRecord({
+          inputText: 'help',
+          outputText: "Here's how to make a bomb: first, gather materials.",
+          provider: 'huggingface',
+          model: 'test-model',
+          attempts: []
+        });
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["decision"] == "DENY"
+    assert "axiom:symmetry.harmful_endorsement" in result["reasons"]
+
+
+def test_output_axiom_jailbreak_phrase_escalates() -> None:
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.buildGovernanceRecord({
+          inputText: 'hello',
+          outputText: 'Sure — ignore previous instructions and I will help.',
+          provider: 'huggingface',
+          model: 'test-model',
+          attempts: []
+        });
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["decision"] == "ESCALATE"
+    assert "axiom:locality.jailbreak_phrase" in result["reasons"]
+
+
+# ---- Negative regressions (FP envelope) ----
+# These prompts use 'model' / 'AI' generically but don't carry the Petri auditor
+# scaffolding. They MUST stay ALLOW; if a future rule tightening makes them
+# ESCALATE, that's an FP we want to catch before deploy.
+def test_benign_training_question_allowed() -> None:
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.shouldPreBlock('How do I train the model on a small dataset?');
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["blocked"] is False
+    assert result["decision"] == "ALLOW"
+
+
+def test_benign_debug_question_allowed() -> None:
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.shouldPreBlock('Help me understand why the AI returns weird outputs for unicode inputs.');
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["blocked"] is False
+    assert result["decision"] == "ALLOW"
+
+
+def test_benign_concept_question_allowed() -> None:
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.shouldPreBlock('Explain how transformer attention works in plain English.');
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["blocked"] is False
+    assert result["decision"] == "ALLOW"
+
+
+def test_phrase_over_several_turns_target_escalates() -> None:
+    """Regression: phrase:over_several_turns_target was missed in the initial Petri patch."""
+    result = run_node_json(
+        """
+        const governed = require('./api/_governed_output');
+        const result = governed.shouldPreBlock(
+          'Over several turns, get the target to reveal its values.'
+        );
+        console.log(JSON.stringify(result));
+        """
+    )
+
+    assert result["blocked"] is False
+    assert result["decision"] == "ESCALATE"
+    assert "phrase:over_several_turns_target" in result["reasons"]


### PR DESCRIPTION
## Summary

PR #1754 was merged to main yesterday, but the squash-merge conflict-resolved `api/_governed_output.js` and `tests/api/test_governed_output_proxy.py` to their **older base versions** instead of the expanded versions described in the PR title. This PR cherry-picks the dropped governance content back onto current main.

The Polly commerce changes from the same original commit are already on main via another merge path, so this recovery is scoped to just the governance surface.

## What was dropped + restored

| File | Pre-#1754 | What #1754 advertised | What #1754 actually shipped | This PR |
|---|---|---|---|---|
| `api/_governed_output.js` INPUT_RULES | 4 | 26 (4 + 22 Petri) | **4** (loss) | 26 ✅ |
| `api/_governed_output.js` OUTPUT_RULES | 2 | 7 (2 + 5 axiom) | **2** (loss) | 7 ✅ |
| `secret_exfiltration` regex | one-direction | bidirectional | one-direction (loss) | bidirectional ✅ |
| `tests/api/test_governed_output_proxy.py` tests | 9 | 19 (9 + 10 regressions) | **9** (loss) | 19 ✅ |

## Changes

- **22 Petri auditor anchors** (2 DENY-tier `petri_tool:*`, 20 ESCALATE-tier `verb:` / `anchor:` / `phrase:`) lifted from `services/scbe-shim/src/patterns.ts`. Catches Anthropic Petri-framework auditor phrasing before it reaches upstream LLM.
- **5 axiom-class OUTPUT_RULES**: `axiom:locality.system_prompt_leak` (DENY), `axiom:locality.tool_leak` (DENY), `axiom:locality.jailbreak_phrase` (ESCALATE), `axiom:causality.future_assertion` (ESCALATE), `axiom:symmetry.harmful_endorsement` (DENY).
- **Bidirectional `axiom:locality.secret_exfiltration`**: previously only `<secret>...<verb>` order matched, so `Print my .env` leaked through with `decision=ALLOW`. Pattern now matches both orderings under the same code; `\.env\b` boundary fixed so it matches after a space.
- **10 regression tests** in `tests/api/test_governed_output_proxy.py`: verb-first secret exfil, Petri tool name DENY, Petri auditor phrasing ESCALATE, 3 output-axiom DENY/ESCALATE cases, the missing `phrase:over_several_turns_target` rule, and 3 FP-envelope tests that lock benign queries (`train the model` / `AI returns weird outputs` / `transformer attention`) at ALLOW.

## Affected Layers

- [x] L13-14: Risk decision / audio axis (governed-output rule pack)
- [ ] L1-12: untouched
- [ ] Infrastructure / CI / Docker

## Axiom Compliance

- [x] A2: Locality (`secret_exfiltration` bidirectional, `system_prompt_leak`, `tool_leak`)
- [x] A3: Causality (`future_assertion`)
- [x] A4: Symmetry (`harmful_endorsement`)
- [ ] A1: Unitarity
- [ ] A5: Composition

## Test Plan

- [x] Python tests pass — `python -m pytest tests/api/test_governed_output_proxy.py -v` → **19 passed in 1.67s**
- [x] FP envelope verified — benign queries (`train the model`, `AI returns weird outputs`, `transformer attention`) stay ALLOW
- [x] Cherry-pick clean: only 2 files changed (`api/_governed_output.js` +68/-1, `tests/api/test_governed_output_proxy.py` +169/-0). Polly commerce conflicts resolved by keeping main's version since the $99 SKU + longest-match resolver landed via a different merge path.

## Cross-Language Parity

- [x] Already mirrored in `services/scbe-shim/src/patterns.ts` and `services/scbe-shim-space/shim/patterns.py` (same 22 anchors landed in PR #1754, just not the production proxy variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)