### PR TITLE
fix(marketing): align SCBE claims with enforceable gates

### DIFF
--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -636,8 +636,10 @@ const RESEARCH_TOPICS = [
     title: 'Composing with Anthropic Petri',
     body:
       'Petri is detection-only auditing (36 dims, 181 seeds). SCBE composes with it as the ' +
-      'enforcement layer: 173/173 Petri seeds blocked when SCBE wired in front. Petri tells ' +
-      'you what the model would do; SCBE prevents the high-cost trajectories from running.',
+      'enforcement layer: in the recorded harness, 173/173 Petri seeds were denied when SCBE was ' +
+      'wired in front. Petri tells you what the model would do; SCBE adds configured DENY, ' +
+      'QUARANTINE, and ESCALATE decisions before high-cost trajectories are allowed to run. That ' +
+      'is harness evidence, not a blanket guarantee for every deployment.',
     links: [
       {
         label: 'Anthropic Petri (2026 Q1)',

--- a/docs/business/BATTLE_CARDS.md
+++ b/docs/business/BATTLE_CARDS.md
@@ -22,7 +22,7 @@ Pull up the relevant card when a prospect mentions a competitor by name, or when
 - $100K-500K+/year enterprise pricing
 
 **Where they fall short**:
-- **Detective, not preventive** — finds threats AFTER they happen
+- **Detective first** — finds threats and anomalies, but does not own the agent action gate
 - **Black-box ML** — cannot explain why it flagged something
 - **4-12 week tuning period** with high false positives during learning
 - **Not built for AI agents** — treats agents as generic endpoints
@@ -30,7 +30,7 @@ Pull up the relevant card when a prospect mentions a competitor by name, or when
 - **Expensive** — $10-100/entity/month vs SCBE's ~$0.003
 
 **Your line**:
-> "Darktrace tells you something went wrong. We prevent it from happening. Our math works on day one — no 12-week tuning period, no false positives during learning, and every decision is explainable to auditors."
+> "Darktrace tells you something went wrong. SCBE is designed to sit in front of configured agent actions and return ALLOW, DENY, QUARANTINE, or ESCALATE with evidence. The claim is enforceable gates and receipts, not a promise that every future model output is impossible."
 
 **Objection handling**:
 - "But Darktrace has 10K customers" → "They're the king of network detection. We're not competing there. We govern AI agents at inference time — a category they don't play in."
@@ -50,7 +50,7 @@ Pull up the relevant card when a prospect mentions a competitor by name, or when
 - $60-185/device/year (AIDR pricing not yet publicly fixed)
 
 **Where they fall short**:
-- **Still detection/response** — alerts and contains, doesn't prevent
+- **Endpoint-first detection/response** — strong security platform, but not a vendor-neutral agent policy gate
 - **AIDR is brand new** — launched Dec 2025, limited track record
 - **Agent-based deployment** — requires installing on every endpoint
 - **No PQC** — classical crypto only
@@ -58,7 +58,7 @@ Pull up the relevant card when a prospect mentions a competitor by name, or when
 - **No multi-agent consensus** — no governance for agent-to-agent coordination
 
 **Your line**:
-> "CrowdStrike is adding AI security on top of their endpoint platform. We built AI governance from the ground up — mathematically provable decisions, post-quantum crypto, and multi-agent consensus. They detect and respond. We prevent."
+> "CrowdStrike is adding AI security on top of their endpoint platform. SCBE is agent-native governance: mathematical decision records, post-quantum crypto, and multi-agent consensus around configured actions."
 
 **Objection handling**:
 - "CrowdStrike is a $80B company" → "They're defending endpoints. We're governing agents. Different problem, different architecture."
@@ -110,7 +110,7 @@ Pull up the relevant card when a prospect mentions a competitor by name, or when
 - **Massive burn rate** — $190M at seed stage means high expectations and expensive operations
 
 **Your line**:
-> "Kevin Mandia built the best incident response company in history. That's detection after the fact. We prevent unauthorized actions before they happen — using mathematics, not ML. Different philosophy, different architecture."
+> "Kevin Mandia built the best incident response company in history. SCBE is a different layer: it turns agent actions into governed decisions with mathematical scoring, policy thresholds, and evidence before the action runs."
 
 **Objection handling**:
 - "They have IQT and $190M" → "IQT also invested in SandboxAQ for PQC. When they see a governance layer that combines PQC with agent security, that's a complement to Armadin, not a conflict."
@@ -136,7 +136,7 @@ Pull up the relevant card when a prospect mentions a competitor by name, or when
 - **No agent-native architecture** — governance as oversight layer, not embedded in the action pipeline
 
 **Your line**:
-> "Aurascape governs AI with policies and documentation. We govern AI with mathematics — every action goes through a 14-layer pipeline that makes unauthorized behavior exponentially expensive. Their governance is a checklist. Ours is a wall."
+> "Aurascape governs AI with policies and documentation. SCBE is the runtime side: configured actions go through a 14-layer pipeline that can allow, deny, quarantine, or escalate with evidence."
 
 **Objection handling**:
 - "They just raised $63M" → "For policy governance. When their customers ask 'but how do I actually enforce this at runtime?' — that's us."

--- a/docs/business/COMPETITIVE_POSITIONING.md
+++ b/docs/business/COMPETITIVE_POSITIONING.md
@@ -8,7 +8,7 @@
 
 AI agents are going into production. Gartner says 40% of enterprise apps will embed AI agents by end of 2026 (up from 5% in 2025). Only 6% of organizations have an advanced AI security strategy. $392M+ poured into agentic AI security in Q1 2026 alone. Four AI security startups were acquired for $1.38B combined in 2024-2025.
 
-**The gap:** Nobody offers vendor-neutral, inference-time governance middleware that works with ANY model and provides mathematical proof of safety.
+**The gap:** Few teams have vendor-neutral, inference-time governance middleware that can sit in front of mixed models, enforce configured policy decisions, and produce evidence about why an action was allowed, denied, quarantined, or escalated.
 
 - OpenAI buys tools for their own platform (acquired Promptfoo).
 - Anthropic builds internally (Constitutional Classifiers).
@@ -17,11 +17,11 @@ AI agents are going into production. Gartner says 40% of enterprise apps will em
 
 ## Where SCBE Sits
 
-**Category:** AI Agent Governance (prevention, not detection)
+**Category:** AI Agent Governance (action-time policy enforcement, not just detection)
 
 **One-line pitch:** We make attacks 117,000x more expensive than authorized actions — not through rules, but through mathematical topology.
 
-**Positioning statement:** SCBE-AETHERMOORE is the only solution combining AI agent governance + post-quantum cryptography + explainable, mathematically-proven decisions at inference time.
+**Positioning statement:** SCBE-AETHERMOORE combines AI agent governance, post-quantum cryptography, and explainable mathematical decision records at inference/action time.
 
 ## The Four Pillars
 
@@ -47,13 +47,13 @@ No competitor has more than one. SCBE has all four.
 | **Manifold** | Runtime agent sec | $8M | Runtime enforcement | No | No | Partial |
 | **Cisco** (ex-Robust Intel) | Platform AI sec | ~$400M acq | Model security | No | No | Partial |
 | **Palo Alto** (ex-Protect AI) | Platform AI sec | ~$500M acq | Pipeline security | No | No | Partial |
-| **SCBE-AETHERMOORE** | **Agent governance** | **Pre-seed** | **Geometric prevention** | **Yes** | **Yes** | **Yes** |
+| **SCBE-AETHERMOORE** | **Agent governance** | **Pre-seed** | **Geometric policy enforcement** | **Yes** | **Yes** | **Configured gates** |
 
 ## Why We Win
 
-**Against detection players** (Darktrace, CrowdStrike, Armadin): They find threats after they happen. We prevent them before they execute. Different architecture, different value prop.
+**Against detection players** (Darktrace, CrowdStrike, Armadin): They find or respond to threats. We add a configured governance gate before agent actions execute. Different architecture, different value prop.
 
-**Against governance players** (Aurascape, Credo AI): They govern with policies and documentation. We govern with mathematics. Their governance is a checklist. Ours is a wall.
+**Against governance players** (Aurascape, Credo AI): They govern with policies and documentation. We turn policies into runtime decisions, thresholds, receipts, and tests.
 
 **Against runtime players** (Manifold): Same problem space, fundamentally different tools. They have conventional runtime security. We have patented geometric cost escalation.
 

--- a/docs/business/PRODUCT_ONE_PAGER_GATEWAY.md
+++ b/docs/business/PRODUCT_ONE_PAGER_GATEWAY.md
@@ -6,7 +6,7 @@
 
 ## The Problem
 
-Your AI agents make thousands of decisions per hour. You have no way to govern what they do, prove why they did it, or stop them before they cross a line. Traditional security watches the network — nobody watches the agent.
+Your AI agents make thousands of decisions per hour. You need a way to govern what they do, prove why they did it, and enforce a policy gate before high-risk actions run. Traditional security watches the network — it usually does not understand the agent decision path.
 
 ## The Solution
 
@@ -22,7 +22,7 @@ Agent → SCBE Gateway → [14-layer pipeline] → ALLOW / QUARANTINE / ESCALATE
 2. Gateway scores the action through hyperbolic distance + harmonic scaling
 3. Decision: ALLOW (safe), QUARANTINE (needs review), ESCALATE (requires governance), DENY (blocked)
 4. Cryptographic audit proof generated for every decision
-5. Agent proceeds or is blocked — attacker learns nothing from a DENY
+5. Agent proceeds, is denied, is quarantined for review, or is escalated — attacker learns nothing useful from a DENY
 
 ## Key Capabilities
 
@@ -62,13 +62,13 @@ Agent → SCBE Gateway → [14-layer pipeline] → ALLOW / QUARANTINE / ESCALATE
 | Alternative | Gap SCBE Fills |
 |-------------|---------------|
 | Build internally | 18+ months, $720K+ in engineering. SCBE deploys this week. |
-| Darktrace | Detects anomalies after the fact. SCBE prevents before the action. |
+| Darktrace | Detects anomalies after the fact. SCBE adds an action-time governance gate before configured actions run. |
 | CrowdStrike AIDR | Endpoint-focused detection. SCBE is agent-native governance. |
 | Policy-only tools | Documentation without enforcement. SCBE enforces mathematically. |
 
 ## The Math
 
-Adversarial actions cost **117,000x more** than authorized ones. Not through rules — through hyperbolic geometry where distance from safe operation grows exponentially. Patent-protected (USPTO #63/961,403).
+In the benchmarked geometry, adversarial trajectories cost **117,000x more** than authorized ones. Not through rules alone — through hyperbolic geometry where distance from safe operation grows exponentially. That is evidence for the gate design, not a blanket guarantee that every deployment stops every bad output. Patent-protected (USPTO #63/961,403).
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1014,6 +1014,9 @@
                 >See the Results</a
               >
               <a class="btn btn-soft" href="solutions.html">See Buyer Services</a>
+              <a class="btn btn-soft" href="products.html">View Products</a>
+              <a class="btn btn-soft" href="packages.html">Developer Packages</a>
+              <a class="btn btn-soft" href="books.html">Books</a>
               <a class="btn btn-soft" href="chat.html">Open Polly Chat</a>
               <a
                 class="btn btn-soft"
@@ -1070,11 +1073,11 @@
                   >
                 </div>
                 <div class="proof-cell">
-                  <strong>91 / 91 attacks blocked</strong>
+                  <strong>91 / 91 attacks denied by policy gate</strong>
                   <span
-                    >Hyperbolic cost scaling + multi-factor omega gate blocked the full attack
-                    corpus. 85.7% detection, 0% false positives — attacks become computationally
-                    infeasible.</span
+                    >In the published harness, hyperbolic cost scaling + multi-factor omega gate
+                    denied the full attack corpus. 85.7% detection, 0% false positives in that
+                    test set — not a universal safety guarantee.</span
                   >
                 </div>
                 <div class="proof-cell">
@@ -1142,8 +1145,8 @@
               </div>
               <p style="font-size: 14px; color: var(--muted); margin-bottom: 14px">
                 Type any AI prompt or task below. The 14-layer pipeline evaluates intent, calculates
-                hyperbolic risk, and returns a governance decision — the same math that blocked
-                91/91 attacks.
+                hyperbolic risk, and returns a governance decision — the same gate used in the
+                91/91 denied-policy harness.
               </p>
               <div style="display: grid; gap: 10px">
                 <textarea
@@ -1898,10 +1901,10 @@
             <article class="slab">
               <h3>Concrete first pilot</h3>
               <p>
-                Example: stop an AI agent from executing unsafe tool calls when drift, intent
-                accumulation, or context mismatch pushes the session outside a safe boundary. The
-                toolkit gives you the decision record, threshold worksheet, and manual path; the
-                demo hub shows the geometry and gate behavior in public.
+                Example: put a policy gate in front of unsafe tool calls so drift, intent
+                accumulation, or context mismatch can trigger DENY, QUARANTINE, or ESCALATE before
+                the action runs. The toolkit gives you the decision record, threshold worksheet,
+                and manual path; the demo hub shows the geometry and gate behavior in public.
               </p>
             </article>
             <article class="slab">
@@ -3052,6 +3055,9 @@
           <a href="#delivery">Delivery</a>
           <a href="mailto:ai@aethermoore.com?subject=SCBE%20Toolkit%20Support">Support</a>
           <a href="#recent-milestones">Research</a>
+          <a href="products.html">Products</a>
+          <a href="packages.html">Packages</a>
+          <a href="books.html">Books</a>
           <a href="chat.html">Chat</a>
           <a href="robot.html">AI Map</a>
           <a href="legal/privacy.html">Privacy</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -36,6 +36,7 @@ Polly is the public SCBE web agent. If you are asked to act as Polly, use this r
 - Agent-task mode: return a bounded packet with goal, evidence needed, route, expected output, and approval point.
 - Research mode: explain SCBE in practical terms and link public source files or pages.
 - Boundary: do not claim certification, guaranteed safety, legal advice, medical advice, financial advice, or formal compliance.
+- Boundary: do not say SCBE guarantees it stops every bad output. Say it provides configured policy gates, DENY / QUARANTINE / ESCALATE decisions, evidence, and regression-backed claims for named harnesses or integrations.
 
 ## Plain Summary
 

--- a/docs/products.html
+++ b/docs/products.html
@@ -1333,6 +1333,16 @@
               record automatically and grade the workflow against five mathematical safety axioms.
             </p>
           </details>
+          <details>
+            <summary>Does SCBE promise perfect AI safety?</summary>
+            <p>
+              No. SCBE is a governance and enforcement layer, not a magic shield around every model
+              in every context. A claim like "blocked 91/91" means the named gate denied all cases in
+              that test harness. For a customer workflow, the deliverable is configured policy gates,
+              evidence, failure analysis, regression tests, and clear DENY / QUARANTINE / ESCALATE
+              behavior where the system is wired to enforce those decisions.
+            </p>
+          </details>
         </section>
 
         <div class="stuck">

--- a/docs/robot.md
+++ b/docs/robot.md
@@ -278,6 +278,7 @@ Open the Solutions page, then compare offers.json for live prices and links.
 - Public prices and delivery paths can change; verify `offers.json`.
 - Some routes may be manual while the system is still being hardened.
 - Prefer "governance review", "workflow evaluation", and "agent routing support" over claims of guaranteed safety.
+- Prefer "configured policy gate", "denied in this harness", "quarantined for review", and "evidence record" over absolute phrases like "we stop every chatbot failure" or "we guarantee safe AI".
 
 ## Contact And Support
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -61,6 +61,66 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/products.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/books.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/books/miracle-memory.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/books/six-tongues-protocol.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/packages.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/packages/scbe-aethermoore.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/packages/scbe-aethermoore-cli.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/packages/scbe-agent-bus.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/packages/scbe-bookforge.html</loc>
+    <lastmod>2026-05-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://aethermoore.com/SCBE-AETHERMOORE/shopify-command-center.html</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>

--- a/docs/solutions.html
+++ b/docs/solutions.html
@@ -508,6 +508,11 @@
               foundation model.
             </li>
             <li>
+              When we say a gate blocks or denies something, that means a configured policy,
+              threshold, or regression harness rejected that action in a named integration. It does
+              not mean every future model output in every deployment is impossible.
+            </li>
+            <li>
               Reports are technical risk reads and implementation guidance. They are not legal
               compliance guarantees.
             </li>

--- a/tests/test_public_claim_language.py
+++ b/tests/test_public_claim_language.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PUBLIC_CLAIM_FILES = [
+    REPO_ROOT / "docs" / "index.html",
+    REPO_ROOT / "docs" / "solutions.html",
+    REPO_ROOT / "docs" / "products.html",
+    REPO_ROOT / "docs" / "workflow-snapshot.html",
+    REPO_ROOT / "docs" / "llms.txt",
+    REPO_ROOT / "api" / "polly" / "commerce.js",
+]
+
+OVERCLAIM_PHRASES = [
+    "we stop",
+    "we prevent",
+    "scbe prevents",
+    "prevent before",
+    "prevents before",
+    "stop chatbots",
+    "stop an ai agent",
+    "guarantees scbe stops",
+    "guarantee scbe stops",
+]
+
+
+def test_public_claim_language_uses_policy_gate_framing() -> None:
+    for path in PUBLIC_CLAIM_FILES:
+        text = path.read_text(encoding="utf-8").lower()
+        for phrase in OVERCLAIM_PHRASES:
+            assert phrase not in text, f"{path.relative_to(REPO_ROOT)} contains overclaim phrase: {phrase}"
+
+
+def test_public_claim_language_keeps_boundary_disclaimer() -> None:
+    combined = "\n".join(path.read_text(encoding="utf-8").lower() for path in PUBLIC_CLAIM_FILES)
+
+    assert "not a universal safety guarantee" in combined
+    assert "not a blanket guarantee" in combined
+    assert "configured policy gates" in combined
+    assert "deny / quarantine / escalate" in combined


### PR DESCRIPTION
## Summary
- Reframes public SCBE claims around configured policy gates, named harness evidence, and DENY / QUARANTINE / ESCALATE behavior instead of absolute "we stop everything" language.
- Updates Polly, llms.txt, robot.md, product/solution pages, and internal sales docs so future AI/marketing surfaces inherit the safer claim boundary.
- Adds sitemap entries for products, packages, books, and snapshot pages so the public funnel is discoverable.
- Adds a regression test that blocks overclaim phrasing from key public surfaces while requiring explicit boundary disclaimers.

## Test evidence
- `python -m pytest tests/test_public_claim_language.py tests/api/test_polly_commerce.py tests/test_package_product_pages.py tests/test_bookshelf_pages.py -q` -> 49 passed
- `npm run typecheck` -> passed
- `git diff --check` -> passed
- Overclaim scan: only remaining hit is robot.md guidance telling agents not to use the phrase

## Rollback
- Revert this PR to restore the prior copy. No schema or runtime migration involved.