### PR TITLE
fix(governance): gate refund and CPT overclaims

### DIFF
--- a/api/_governed_output.js
+++ b/api/_governed_output.js
@@ -47,6 +47,29 @@ const INPUT_RULES = [
     correction:
       'Prepare the draft or checklist, then require the human to complete the final legal or financial action.',
   },
+  {
+    code: 'commerce:refund_authority_boundary',
+    pattern:
+      /\b(approve|issue|process|grant|guarantee|promise)\b.{0,80}\b(refund|chargeback|store credit|credit)\b/i,
+    decision: 'ESCALATE',
+    correction:
+      'Draft the support response, but require an authorized refund policy check before promising money back.',
+  },
+  {
+    code: 'commerce:refund_authority_boundary',
+    pattern:
+      /\b(refund|chargeback|store credit|credit)\b.{0,80}\b(approved|guaranteed|will be issued|has been issued|no questions asked)\b/i,
+    decision: 'ESCALATE',
+    correction:
+      'Draft the support response, but require an authorized refund policy check before promising money back.',
+  },
+  {
+    code: 'medical:cpt_billing_assertion',
+    pattern: /\b(CPT|HCPCS|ICD-10)\b.{0,80}\b(code|billing|claim|reimbursement|diagnosis)\b/i,
+    decision: 'ESCALATE',
+    correction:
+      'Treat medical billing codes as verification-required; cite an approved lookup source or route to a qualified billing reviewer.',
+  },
   // ---- Petri auditor anchors (lifted from services/scbe-shim/src/patterns.ts) ----
   // Petri-internal tool names — never appear in real coding asks.
   {
@@ -228,6 +251,21 @@ const OUTPUT_RULES = [
     pattern: /\b(rm\s+-rf\s+[~/$]|git\s+reset\s+--hard|drop\s+database)\b/i,
     decision: 'ESCALATE',
     correction: 'Replace destructive shell commands with dry-run or backup-first commands.',
+  },
+  {
+    code: 'commerce:refund_overpromise_output',
+    pattern:
+      /\b(your|the)\b.{0,40}\b(refund|chargeback|store credit|credit)\b.{0,80}\b(is approved|has been approved|will be issued|is guaranteed|no questions asked)\b/i,
+    decision: 'ESCALATE',
+    correction:
+      'Do not promise refunds from generated text alone; route to the store policy or an authorized support action.',
+  },
+  {
+    code: 'medical:cpt_billing_assertion_output',
+    pattern: /\b(CPT|HCPCS|ICD-10)\s*(?:code)?\s*[A-Z]?\d{4,5}\b/i,
+    decision: 'ESCALATE',
+    correction:
+      'Do not invent or assert medical billing codes without a verified lookup source and qualified review.',
   },
   {
     code: 'axiom:locality.system_prompt_leak',

--- a/tests/api/test_governed_output_proxy.py
+++ b/tests/api/test_governed_output_proxy.py
@@ -255,6 +255,68 @@ def test_output_axiom_system_prompt_leak_denied() -> None:
     assert "axiom:locality.system_prompt_leak" in result["reasons"]
 
 
+def test_refund_authority_boundary_escalates_input() -> None:
+    result = run_node_json("""
+        const governed = require('./api/_governed_output');
+        const result = governed.shouldPreBlock(
+          'Tell the customer their refund is approved and will be issued today.'
+        );
+        console.log(JSON.stringify(result));
+        """)
+
+    assert result["blocked"] is False
+    assert result["decision"] == "ESCALATE"
+    assert "commerce:refund_authority_boundary" in result["reasons"]
+
+
+def test_refund_overpromise_output_escalates() -> None:
+    result = run_node_json("""
+        const governed = require('./api/_governed_output');
+        const result = governed.buildGovernanceRecord({
+          inputText: 'Customer asks about a late order.',
+          outputText: 'Your refund is approved and will be issued today, no questions asked.',
+          provider: 'huggingface',
+          model: 'test-model',
+          attempts: []
+        });
+        console.log(JSON.stringify(result));
+        """)
+
+    assert result["decision"] == "ESCALATE"
+    assert "commerce:refund_overpromise_output" in result["reasons"]
+
+
+def test_medical_cpt_assertion_input_escalates() -> None:
+    result = run_node_json("""
+        const governed = require('./api/_governed_output');
+        const result = governed.shouldPreBlock(
+          'Use CPT code 99214 for this claim and submit the billing note.'
+        );
+        console.log(JSON.stringify(result));
+        """)
+
+    assert result["blocked"] is False
+    assert result["decision"] == "ESCALATE"
+    assert "medical:cpt_billing_assertion" in result["reasons"]
+
+
+def test_medical_cpt_assertion_output_escalates() -> None:
+    result = run_node_json("""
+        const governed = require('./api/_governed_output');
+        const result = governed.buildGovernanceRecord({
+          inputText: 'Which billing code applies?',
+          outputText: 'The correct CPT code 99214 applies and should be submitted for reimbursement.',
+          provider: 'huggingface',
+          model: 'test-model',
+          attempts: []
+        });
+        console.log(JSON.stringify(result));
+        """)
+
+    assert result["decision"] == "ESCALATE"
+    assert "medical:cpt_billing_assertion_output" in result["reasons"]
+
+
 def test_output_axiom_harmful_endorsement_denied() -> None:
     result = run_node_json("""
         const governed = require('./api/_governed_output');


### PR DESCRIPTION
## Summary
- add concrete governed-output gates for refund authority overpromises
- add concrete governed-output gates for medical CPT / billing-code assertions
- keep the product claim honest: the system escalates or denies specific risky behavior under test instead of promising universal prevention

## Behavior now under regression
- system-prompt leakage: DENY
- chatbot refund promise / approved refund wording: ESCALATE
- medical CPT / billing-code assertion: ESCALATE

## Test evidence
- `python -m pytest tests/api/test_governed_output_proxy.py tests/test_public_claim_language.py -q` -> 27 passed
- `node node_modules/typescript/bin/tsc --noEmit` -> passed
- `node node_modules/prettier/bin/prettier.cjs --check api/_governed_output.js api/polly/commerce.js` -> passed
- `python -m black --check --target-version py311 --line-length 120 tests/api/test_governed_output_proxy.py tests/test_public_claim_language.py` -> passed
- `git diff --check` -> passed

## Rollback
- Revert `api/_governed_output.js` and `tests/api/test_governed_output_proxy.py` changes in this PR.