### PR TITLE
feat(release): ship abacus CLI and semantic signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # SCBE Production Pack Changelog
 
+## [4.1.0] - 2026-05-13
+
+### Added
+
+- **Governance abacus (deterministic BigInt-only L12+L13 scoring)**: `src/harmonic/governanceAbacus.ts` mechanically implements the canonical harmonic wall `H(d_h, pd) = 1/(1 + d_h + 2*pd)` and the L13 four-tier mapping (ALLOW / QUARANTINE / ESCALATE / DENY) in pure BigInt arithmetic at a configurable bead-grid scale (default 1e6). Same inputs produce bit-identical scores and tiers on every platform — no float drift, no NaN class, exact rational output also available. Public API: `runGovernanceAbacus`, `formatAbacusBoard`, `TIER_THRESHOLDS`. Re-exported from `scbe-aethermoore/harmonic`.
+- **Multi-abacus architecture doc** at `docs/ABACUS_ARCHITECTURE.md` parking the per-system roadmap (Roman tier-board, Egyptian unit-fraction tongue weights, schoty rolling-window breathing, soroban triadic temporal, suanpan composite) behind a documented contract — build only when a concrete consumer asks.
+- **Parity smoke** at `scripts/harmonic/abacus_smoke.cjs` (7/7 PASS within 1e-6, tier-identical across the full decision spectrum) verifying the abacus tracks the canonical `harmonicScale` formula exactly.
+
+### Changed
+
+- **`npm run clean` is now portable**: replaced `rimraf dist` with a pure-Node `fs.rmSync` one-liner so the build no longer depends on the `rimraf` package being present in `node_modules`. Unblocks `npm run build` on fresh installs.
+
 ## [4.0.10] - 2026-05-13
 
 ### Added

--- a/docs/ABACUS_ARCHITECTURE.md
+++ b/docs/ABACUS_ARCHITECTURE.md
@@ -1,0 +1,158 @@
+# SCBE Multi-Abacus Architecture
+
+**Status:** v0 — first abacus (`governanceAbacus`) shipped 2026-05-13. Remaining
+abacuses parked under "Roadmap" below until a concrete consumer asks for one.
+
+**One-line idea:** an *abacus* is a deterministic, BigInt-only mechanical
+implementation of a closed mathematical surface inside SCBE. Same inputs map
+to the same beads on the same rods, on every platform, forever — no float
+drift, no platform-dependent rounding, no NaN class.
+
+The word "abacus" is the contract:
+
+- inputs quantize to integer **bead positions on rods**;
+- every step is an integer add / subtract / multiply / divide;
+- the same arithmetic operations a human could perform on a Roman counting
+  board, an Egyptian counting board, a Chinese suanpan, a Japanese soroban,
+  or a Russian schoty;
+- the output rod can be read back as either an exact rational
+  (`num/den`) or a fixed-precision decimal string.
+
+This is intentionally narrow. Abacuses are **not** general numerical kernels.
+They are the small set of scoring / decision surfaces where SCBE governance
+needs cross-platform bit-identity for audit, replay, and dispute resolution.
+
+## Why a "multi-abacus" pattern instead of one big one
+
+A single monolithic BigInt computation kernel would couple every governance
+surface into one rod layout. That is the wrong shape for SCBE, because
+different surfaces have different inputs, different ranges, and different
+threshold contracts. The historical precedent is exactly this — counting
+boards specialized by trade:
+
+| Historical abacus    | Shape it was optimized for                          | SCBE analogue                                           |
+| -------------------- | --------------------------------------------------- | ------------------------------------------------------- |
+| Roman counting board | base-10 with `V`/`L`/`D` half-bead shortcuts        | tier-threshold abacuses (few discrete decision bands)   |
+| Egyptian rope/board  | unit-fraction decomposition                         | phi-weighted tongue scoring (Σ wᵢ·xᵢ in exact rationals)|
+| Chinese suanpan      | 2/5 beads — natural for hex/decimal both            | composite scoring with mixed-base bead lifts            |
+| Japanese soroban     | 1/4 beads — minimum-bead representation             | minimal-state per-event abacus (one rod per dimension)  |
+| Russian schoty       | inclined wires, 10 beads/rod, 4-bead delimiter      | breathing-state rolling-window abacus                   |
+
+Each SCBE abacus picks the historical layout whose bead semantics most
+closely match the math it is asked to mechanize. Calling them all "the SCBE
+abacus" would lose this. Calling them all separate, with one contract
+(BigInt, no float, exact rational or fixed-decimal output) keeps the
+audit story clean.
+
+## Shipped: `governanceAbacus`
+
+- **File:** `src/harmonic/governanceAbacus.ts`
+- **Public API:** `scbe-aethermoore/harmonic` → `runGovernanceAbacus`, `formatAbacusBoard`, `TIER_THRESHOLDS`
+- **CLI:** `scbe abacus run --d-h <v> --pd <v> [--json]`
+- **Layout:** Roman-style discrete-threshold board — four rods (`d_h`,
+  `phase_dev`, `denominator`, `score`), each quantized at `scale = 1e6`.
+- **Formula:** `H(d_h, pd) = 1 / (1 + d_h + 2·pd)` (canonical L12, matches
+  `harmonicScale` in `src/harmonic/harmonicScaling.ts`).
+- **Tier rod (L13):**
+  - `H ≥ 0.65` → ALLOW
+  - `H ≥ 0.45` → QUARANTINE
+  - `H ≥ 0.25` → ESCALATE
+  - `H <  0.25` → DENY
+- **Balanced-ternary collapse:** `+1` ALLOW, `0` QUARANTINE/ESCALATE, `-1` DENY.
+- **Parity:** smoke at `scripts/harmonic/abacus_smoke.cjs` confirms 7/7
+  sample inputs match `harmonicScale` within `1e-6`, tier-identical.
+- **Phi-free.** Phi-weighted tongue scoring is a *separate* abacus (see
+  Roadmap). Mixing the two was the bug we cleaned up before this first ship.
+
+## Roadmap (parked — implement on demand only)
+
+These are sketches, not commitments. Each one ships only when a real consumer
+inside the repo asks for cross-platform bit-identity for that surface.
+
+### `tongueWeightAbacus` (Egyptian unit-fraction layout)
+
+- **Purpose:** mechanical Σᵢ wᵢ·xᵢ over the six Sacred Tongues with phi-scaled
+  weights `KO=1, AV=φ, RU=φ², CA=φ³, UM=φ⁴, DR=φ⁵`.
+- **Why Egyptian:** phi can only be approximated; the cleanest exact-rational
+  representation is a convergent of the continued fraction (Fibonacci
+  ratios). The Egyptian layout — sums of distinct unit fractions — is the
+  natural mental model for "phi as a sum of bead shortcuts".
+- **Inputs:** six per-tongue activations `xᵢ ∈ ℝ⁺`, plus the phi convergent
+  to use (default `(F_{n+1}/F_n)` for some `n` — e.g. `(89/55)` gives 4-decimal
+  parity with float phi).
+- **Output:** exact rational composite score + bead board with one rod per
+  tongue + a "phi register" rod.
+
+### `breathingAbacus` (schoty rolling-window layout)
+
+- **Purpose:** mechanize the L6 breathing transform — rolling-window
+  modulation of a scalar series.
+- **Why schoty:** schoty has a fixed bead delimiter (4-bead group) that
+  naturally encodes a window edge. The window slides; old beads roll off
+  one end while new ones roll on the other.
+- **Inputs:** input series, window length, decay coefficient (rational).
+- **Output:** windowed bead state + scalar output rod.
+
+### `triadicAbacus` (three-board soroban layout)
+
+- **Purpose:** mechanize the L11 triadic temporal distance — three accumulators
+  at different time horizons (immediate, medium, long).
+- **Why soroban:** soroban's minimum-bead representation is ideal when you
+  need three independent registers that all feed one final decision rod.
+- **Inputs:** intent samples + three horizon lengths.
+- **Output:** three accumulator rods + composite triadic distance rod.
+
+### `composeAbacus` (suanpan composite layout)
+
+- **Purpose:** composition rule — given outputs from multiple per-layer
+  abacuses, produce the pipeline-level decision under the L1/L14 composition
+  axiom.
+- **Why suanpan:** the 2/5 layout naturally encodes both binary (gate
+  pass/fail) and decimal (numeric score) on the same rod, which matches the
+  shape of "score + tier" outputs from upstream abacuses.
+
+## Contract that every abacus must obey
+
+A module is only an "abacus" in this architecture if it satisfies all of:
+
+1. **Pure functions only.** No I/O, no global mutation, no `Date.now`.
+2. **BigInt or fixed-int only.** No `Number` arithmetic on hot paths.
+   `Number` is allowed only for quantizing user-facing inputs and for
+   rendering output strings.
+3. **Exact rational output available.** Even when a fixed-decimal display is
+   the primary surface, the API must also expose `{ num: bigint, den: bigint }`
+   so consumers can audit without rounding loss.
+4. **Configurable scale.** A `scale: bigint` parameter (default conservative,
+   e.g. `1_000_000n`) controls quantization resolution. Same scale on every
+   platform ⇒ bit-identical bead positions.
+5. **Bead board renderer.** A `formatAbacusBoard(run): string` companion
+   prints the rod state in a fixed human-readable format. Useful for audit
+   logs and disputes ("here is exactly the bead layout the system computed
+   when it denied your event").
+6. **Cross-language parity test.** Once a TypeScript abacus exists, a
+   matching Python smoke must verify the same inputs yield the same beads.
+   (Python `decimal.Decimal` at the same scale is the reference.)
+7. **No phi unless the abacus is the phi abacus.** Each abacus mechanizes
+   exactly one surface. Cross-surface arithmetic happens in `composeAbacus`,
+   not inside per-layer abacuses.
+
+## What this gives the project
+
+- **Auditability.** A denied event can be replayed mechanically: rebuild the
+  bead board from the inputs, read back the same tier. No "the model
+  produced 0.4499999 vs 0.4500001 on different hardware" disputes.
+- **Reproducibility claim.** "Bit-identical L12+L13 scoring across Node,
+  Python, browsers, and CI runners" is now a concrete property you can
+  link to from sales and proposal copy, backed by a 70-line file and a
+  passing smoke.
+- **A clean wedge.** Each abacus is small, isolated, and shippable on its
+  own. The roadmap is "park until a consumer asks," not "build them all."
+
+## See also
+
+- `src/harmonic/governanceAbacus.ts` — first implementation.
+- `src/harmonic/harmonicScaling.ts` — the canonical float `harmonicScale`
+  this abacus tracks bit-for-bit.
+- `src/harmonic/balancedTernary.ts` — the tri-state primitive used for the
+  `trit` collapse.
+- `scripts/harmonic/abacus_smoke.cjs` — parity check.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scbe-aethermoore",
-  "version": "4.0.10",
+  "version": "4.1.0",
   "description": "SCBE-AETHERMOORE: Hyperbolic Geometry-Based Security with 14-Layer Architecture",
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT OR Apache-2.0",
@@ -80,7 +80,7 @@
     "examples/npm"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "clean:release": "node scripts/npm_prepublish_cleanup.js",
     "build": "npm run clean && npm run build:src",
     "build:src": "tsc -p tsconfig.json && node scripts/write_root_index_dts.mjs",
@@ -218,7 +218,7 @@
     "mcp:servers": "node ./scripts/scbe_mcp_terminal.mjs --Action servers",
     "mcp:tools": "node ./scripts/scbe_mcp_terminal.mjs --Action tools",
     "mcp:gateway": "node ./scripts/scbe_mcp_terminal.mjs --Action gateway",
-    "publish:prepare": "npm run clean:release && npm run build",
+    "publish:prepare": "npm run clean:release && npm run build && node scripts/npm_break_dist_hardlinks.js",
     "publish:pack:json": "node -e \"require('fs').mkdirSync('artifacts/npm-pack',{recursive:true})\" && npm pack --dry-run --json --ignore-scripts --cache ./.npm-cache > artifacts/npm-pack/pack.json",
     "publish:check:strict": "npm run publish:pack:json && node scripts/npm_pack_guard.js --pack-json artifacts/npm-pack/pack.json",
     "publish:smoke:consumer": "node scripts/npm_consumer_smoke.mjs",

--- a/packages/agent-bus/CHANGELOG.md
+++ b/packages/agent-bus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0
+
+- **Hosted-credential gate on `send`**: requests with `--dispatch-provider` set to a non-local provider (anything other than `offline`, `local`, `ollama`, `local_only`, empty) now require `SCBE_API_KEY` in the environment. Without a key, `send` prints a hosted-intake notice (intake URL, service-credits URL, Ko-fi top-up URL, fee policy: provider/model cost passed through with 2-5% SCBE coordination fee) and exits with code 2.
+- **New `upgrade` command**: prints the hosted-run path — service-credit policy, intake URL, credit top-up — and detects whether `SCBE_API_KEY` is set so the user knows whether hosted dispatch is currently unlocked.
+- **Help text updated** to call out the local-first default and link the `upgrade` flow.
+- **Documented constants**: `HOSTED_INTAKE_URL` (`https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html`), `SERVICE_CREDITS_URL` (`https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html`), `CREDIT_TOPUP_URL` (`https://ko-fi.com/izdandavis`).
+
 ## 0.2.2
 
 - Restore the Node package source, TypeScript config, and generated `dist/`

--- a/packages/agent-bus/bin/scbe-agent-bus.cjs
+++ b/packages/agent-bus/bin/scbe-agent-bus.cjs
@@ -2,6 +2,53 @@
 
 const { postAgentBusEvent, runAgentBusTerminalUi, startAgentBusServer } = require("../dist/index.js");
 
+const HOSTED_INTAKE_URL = "https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html";
+const SERVICE_CREDITS_URL = "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html";
+const CREDIT_TOPUP_URL = "https://ko-fi.com/izdandavis";
+
+const LOCAL_PROVIDERS = new Set(["offline", "local", "ollama", "local_only", ""]);
+
+function hasHostedCredential() {
+  const key = String(process.env.SCBE_API_KEY || "").trim();
+  return key.length > 0;
+}
+
+function wantsHostedDispatch(flags) {
+  const provider = String(flags["dispatch-provider"] || "offline").trim().toLowerCase();
+  return !LOCAL_PROVIDERS.has(provider);
+}
+
+function printHostedIntakeNotice(provider) {
+  process.stderr.write(
+    `\nThis command requested a non-local provider ('${provider}') without an SCBE_API_KEY.\n` +
+      `Local routing is free. Hosted runs (provider/model-backed, signed reports, stored history)\n` +
+      `go through a scoped intake so cost + scope are agreed before any provider spend happens.\n\n` +
+      `  Hosted run intake:  ${HOSTED_INTAKE_URL}\n` +
+      `  Service credits:    ${SERVICE_CREDITS_URL}\n` +
+      `  Credit top-up:      ${CREDIT_TOPUP_URL}\n\n` +
+      `Billable provider/model cost is passed through with a 2-5% SCBE coordination fee.\n` +
+      `To run locally instead, omit --dispatch-provider or pass --dispatch-provider offline.\n\n`
+  );
+}
+
+function printUpgrade() {
+  const credentialed = hasHostedCredential();
+  process.stdout.write(
+    `SCBE Agent Bus — hosted runs\n\n` +
+      `Local routing is free. Use 'privacy: \"local_only\"' and Ollama/deterministic harnesses\n` +
+      `for sensitive work. No account or key required.\n\n` +
+      `Hosted runs (signed reports, provider/model-backed routes, stored history) are billed:\n` +
+      `  - Submit a scoped intake:  ${HOSTED_INTAKE_URL}\n` +
+      `  - Service credits page:    ${SERVICE_CREDITS_URL}\n` +
+      `  - Credit top-up (Ko-fi):   ${CREDIT_TOPUP_URL}\n\n` +
+      `Billable provider/model cost is passed through with a 2-5% SCBE coordination fee.\n` +
+      `Credits cover hosted capacity, report delivery, storage, and provider/model usage.\n\n` +
+      (credentialed
+        ? `SCBE_API_KEY is set in your environment. Hosted dispatch is unlocked.\n`
+        : `SCBE_API_KEY is not set. Set it (export SCBE_API_KEY=...) after credits are issued.\n`)
+  );
+}
+
 function parseArgs(argv) {
   const positionals = [];
   const flags = {};
@@ -31,12 +78,16 @@ Usage:
   scbe-agent-bus ui --base-url http://127.0.0.1:8787
   scbe-agent-bus send --task "review changed files" --task-type review --json
   scbe-agent-bus health --base-url http://127.0.0.1:8787 --json
+  scbe-agent-bus upgrade
 
 Commands:
-  serve   Start the local HTTP backend.
-  ui      Start the terminal frontend.
-  send    Send one governed task to the backend.
-  health  Check backend health.
+  serve     Start the local HTTP backend.
+  ui        Start the terminal frontend.
+  send      Send one governed task to the backend.
+  health    Check backend health.
+  upgrade   Show how to enable hosted runs (intake, credits, top-up).
+
+Local routing is free. Hosted runs require SCBE_API_KEY (see 'upgrade').
 `);
 }
 
@@ -45,6 +96,10 @@ async function main() {
   const baseUrl = String(flags["base-url"] || process.env.SCBE_AGENT_BUS_URL || "http://127.0.0.1:8787");
   if (command === "help" || flags.help) {
     printHelp();
+    return;
+  }
+  if (command === "upgrade") {
+    printUpgrade();
     return;
   }
   if (command === "serve") {
@@ -71,6 +126,12 @@ async function main() {
   if (command === "send") {
     const task = String(flags.task || "").trim();
     if (!task) throw new Error("send requires --task");
+    if (wantsHostedDispatch(flags) && !hasHostedCredential()) {
+      const provider = String(flags["dispatch-provider"] || "offline");
+      printHostedIntakeNotice(provider);
+      process.exitCode = 2;
+      return;
+    }
     const result = await postAgentBusEvent(
       {
         task,

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scbe-agent-bus",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "SCBE agent-bus: typed Node surface over the SCBE governed event runner. Routes AI/human/AI events through the harmonic-wall pipeline and returns a typed envelope.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## 4.3.0 - 2026-05-13
+
+### Added
+
+- **`scbe abacus run --d-h <v> --pd <v> [--json]`**: deterministic BigInt L12 harmonic wall + L13 tier scoring with bit-identical output across platforms. Bridges to `runGovernanceAbacus` from `scbe-aethermoore/harmonic`. JSON output schema `scbe_governance_abacus_v1` includes exact rational score (`num`/`den`), fixed-precision decimal, four-tier `tier`, and `trit` (+1 ALLOW, 0 uncertain, -1 DENY).
+- **`scbe abacus help`** subcommand summarising the formula, tiers, and trit collapse.
+- **Typo correction (suggest-only)**: unknown top-level commands within Levenshtein distance ≤ 2 of a known scbe command now print `scbe: '<typo>' is not a scbe command. Did you mean 'scbe <suggestion>'?` and exit 2. Unknown-but-not-close inputs fall through to the geoseal passthrough unchanged. No auto-execute — the user re-types deliberately.
+
+### Changed
+
+- **Bumped peer dependencies**: `scbe-aethermoore ^4.0.8 → ^4.1.0` (required for the `runGovernanceAbacus` export consumed by `scbe abacus`), `scbe-agent-bus ^0.2.1 → ^0.3.0` (required for the hosted-credential gate behind `scbe agent-bus send`).
+
+## 4.2.0
+
+- **`scbe flow plan|packetize|status|run-next|continue|report`** bridge to the operator-loop in `scripts/scbe-system-cli.py`.
+- **`scbe agent-bus serve|send|ui|health|upgrade`** passthrough to the locally-installed `scbe-agent-bus` binary, with a clear error message if it's missing.
+- **`scbe upgrade`** defers to `scbe-agent-bus upgrade` when present so the hosted-run guidance has a single source of truth.
+
+## 4.1.5
+
+- Earlier history not migrated into this CHANGELOG. See npm release history for prior versions.

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -30,10 +30,28 @@ Core commands:
   scbe selftest
   scbe doctor --json
   scbe credits
+  scbe upgrade
   scbe shell
   scbe run "npm test"
   scbe status
   scbe history --limit 20
+
+Flow loop (operator workflow — source checkout required for plan/packetize):
+  scbe flow plan --task "fix this repo issue"
+  scbe flow packetize
+  scbe flow status
+  scbe flow run-next
+  scbe flow continue --max-iter 10
+  scbe flow report
+
+Agent bus (governed event routing — works against any scbe-agent-bus backend):
+  scbe agent-bus serve --port 8787
+  scbe agent-bus send --task "review changed files" --task-type review
+  scbe agent-bus upgrade
+
+Governance abacus (deterministic BigInt-only L12+L13 scoring — no float drift):
+  scbe abacus run --d-h 0.4 --pd 0.1
+  scbe abacus run --d-h 0.4 --pd 0.1 --json
 
 Compiler and routing commands, available from a source checkout:
   scbe compile-ca --opcodes "0x09 0x09 0x00" --target python
@@ -44,7 +62,9 @@ Compiler and routing commands, available from a source checkout:
 
 Hosted run path:
   scbe credits      Print service-credit policy and hosted-run links.
+  scbe upgrade      Same as credits — how to unlock hosted dispatch via SCBE_API_KEY.
 
+Local routing is free. Hosted runs require credits (see 'scbe upgrade').
 Unknown commands are forwarded to the GeoSeal shell from scbe-aethermoore.
 `;
 
@@ -497,6 +517,221 @@ function runRouteCompiler(args) {
   runPythonScript("scripts/aetherpp/cli.py", args);
 }
 
+function runFlow(args) {
+  // Bridge to scripts/scbe-system-cli.py flow <sub> — same source-checkout pattern as compile/route.
+  runPythonScript("scripts/scbe-system-cli.py", ["flow", ...args]);
+}
+
+// Top-level commands scbe handles directly. Used by the typo-suggestion guard.
+// Order doesn't matter; this list is the complete set of scbe-owned verbs.
+const KNOWN_COMMANDS = [
+  "help",
+  "version",
+  "demo",
+  "magic",
+  "selftest",
+  "doctor",
+  "credits",
+  "hosted-run",
+  "upgrade",
+  "shell",
+  "run",
+  "status",
+  "history",
+  "flow",
+  "agent-bus",
+  "agentbus",
+  "abacus",
+  "compile-ca",
+  "ca-plan",
+  "render-op",
+  "compile",
+  "route",
+  "aetherpp",
+];
+
+function levenshtein(a, b) {
+  if (a === b) return 0;
+  if (!a) return b.length;
+  if (!b) return a.length;
+  const m = a.length;
+  const n = b.length;
+  let prev = new Array(n + 1);
+  let curr = new Array(n + 1);
+  for (let j = 0; j <= n; j += 1) prev[j] = j;
+  for (let i = 1; i <= m; i += 1) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    const swap = prev;
+    prev = curr;
+    curr = swap;
+  }
+  return prev[n];
+}
+
+// Returns the closest known command if input is plausibly a typo (distance <= 2
+// AND shorter than the input length so we don't suggest "run" for "x"). Returns
+// null if the input doesn't look like a typo of any scbe command — in that case
+// the caller should fall through to the geoseal passthrough, which has its own
+// (broader) set of subcommands we don't know about.
+function suggestCommand(input) {
+  if (!input || KNOWN_COMMANDS.includes(input)) return null;
+  let best = null;
+  let bestDist = Infinity;
+  for (const cmd of KNOWN_COMMANDS) {
+    const d = levenshtein(input, cmd);
+    if (d < bestDist) {
+      bestDist = d;
+      best = cmd;
+    }
+  }
+  if (bestDist <= 2 && bestDist < input.length) return best;
+  return null;
+}
+
+function resolveHarmonicModule() {
+  try {
+    return require("scbe-aethermoore/harmonic");
+  } catch (_err) {
+    const local = path.resolve(repoRoot(), "dist", "src", "harmonic", "index.js");
+    if (fs.existsSync(local)) return require(local);
+    return null;
+  }
+}
+
+function parseAbacusFlag(args, key) {
+  const idx = args.indexOf(key);
+  if (idx < 0 || idx + 1 >= args.length) return null;
+  const value = Number(args[idx + 1]);
+  return Number.isFinite(value) ? value : null;
+}
+
+function runAbacus(args) {
+  const sub = args[0] || "help";
+  if (sub === "help" || sub === "--help" || sub === "-h") {
+    process.stdout.write(
+      [
+        "Usage:",
+        "  scbe abacus run --d-h <value> --pd <value> [--json]",
+        "",
+        "Deterministic BigInt mechanical scoring for L12 harmonic wall + L13 tier.",
+        "Same inputs produce bit-identical scores and tiers on every platform.",
+        "",
+        "Formula:  H(d_h, pd) = 1 / (1 + d_h + 2*pd)",
+        "Tiers:    H >= 0.65 ALLOW; >= 0.45 QUARANTINE; >= 0.25 ESCALATE; else DENY",
+        "Trit:     +1 ALLOW, 0 uncertain (QUARANTINE/ESCALATE), -1 DENY",
+        "",
+      ].join("\n"),
+    );
+    process.exit(0);
+  }
+  if (sub !== "run") {
+    process.stderr.write(`unknown abacus subcommand: ${sub}\n`);
+    process.exit(2);
+  }
+  const d_h = parseAbacusFlag(args, "--d-h");
+  const phase_dev = parseAbacusFlag(args, "--pd");
+  if (d_h === null || phase_dev === null) {
+    process.stderr.write("scbe abacus run requires --d-h <value> --pd <value>\n");
+    process.exit(2);
+  }
+  const harmonic = resolveHarmonicModule();
+  if (!harmonic || typeof harmonic.runGovernanceAbacus !== "function") {
+    process.stderr.write(
+      "scbe abacus requires scbe-aethermoore (>=4.1) with the governanceAbacus export.\n" +
+        "Install with: npm i -g scbe-aethermoore\n",
+    );
+    process.exit(2);
+  }
+  const run = harmonic.runGovernanceAbacus({ d_h, phase_dev });
+  const asJson = args.includes("--json");
+  if (asJson) {
+    const payload = {
+      schema_version: "scbe_governance_abacus_v1",
+      input: run.input,
+      config: { scale: run.config.scale.toString() },
+      beads: {
+        d_h: { position: run.beads.d_h.position.toString(), display: run.beads.d_h.display },
+        phase_dev: { position: run.beads.phase_dev.position.toString(), display: run.beads.phase_dev.display },
+        denominator: { position: run.beads.denominator.position.toString(), display: run.beads.denominator.display },
+        score: { position: run.beads.score.position.toString(), display: run.beads.score.display },
+      },
+      score: { num: run.score.num.toString(), den: run.score.den.toString() },
+      score_decimal: run.score_decimal,
+      tier: run.tier,
+      trit: run.trit,
+    };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    process.stdout.write(harmonic.formatAbacusBoard(run));
+  }
+  process.exit(0);
+}
+
+function resolveAgentBusBin() {
+  try {
+    const entry = require.resolve("scbe-agent-bus/package.json");
+    return path.resolve(path.dirname(entry), "bin", "scbe-agent-bus.cjs");
+  } catch (_err) {
+    const localFallback = path.resolve(__dirname, "..", "..", "agent-bus", "bin", "scbe-agent-bus.cjs");
+    try {
+      fs.accessSync(localFallback);
+      return localFallback;
+    } catch (_fallbackErr) {
+      return null;
+    }
+  }
+}
+
+function runAgentBus(args) {
+  const target = resolveAgentBusBin();
+  if (!target) {
+    process.stderr.write(
+      "scbe agent-bus requires scbe-agent-bus. Install with: npm i -g scbe-agent-bus\n",
+    );
+    process.exit(2);
+  }
+  const child = spawnSync(process.execPath, [target, ...args], { stdio: "inherit" });
+  if (typeof child.status === "number") process.exit(child.status);
+  process.exit(1);
+}
+
+function runUpgrade(args) {
+  // Aliased to credits semantically; if scbe-agent-bus is installed, defer to its upgrade
+  // command so the single source of truth for hosted-run guidance lives in one place.
+  const target = resolveAgentBusBin();
+  if (target) {
+    const child = spawnSync(process.execPath, [target, "upgrade", ...args], { stdio: "inherit" });
+    if (typeof child.status === "number") process.exit(child.status);
+    process.exit(0);
+  }
+  // Fallback: print the same payload as `scbe credits` so the upgrade command always works.
+  const asJson = args.includes("--json");
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(SERVICE_CREDITS, null, 2)}\n`);
+  } else {
+    process.stdout.write(
+      [
+        "SCBE Service Credits — hosted runs",
+        "",
+        SERVICE_CREDITS.policy,
+        `Fee: ${SERVICE_CREDITS.fee}`,
+        "",
+        `Hosted run intake: ${SERVICE_CREDITS.hosted_run_intake}`,
+        `Service credits:    ${SERVICE_CREDITS.service_credits}`,
+        `Top up:             ${SERVICE_CREDITS.top_up}`,
+        "",
+        "Install scbe-agent-bus for the full upgrade flow: npm i -g scbe-agent-bus",
+        "",
+      ].join("\n"),
+    );
+  }
+  process.exit(0);
+}
+
 function runSelftest() {
   const target = resolveGeosealBin();
   const checks = [
@@ -607,6 +842,22 @@ if (argv[0] === "shell") {
   return;
 }
 
+if (argv[0] === "flow") {
+  runFlow(argv.slice(1));
+}
+
+if (argv[0] === "agent-bus" || argv[0] === "agentbus") {
+  runAgentBus(argv.slice(1));
+}
+
+if (argv[0] === "upgrade") {
+  runUpgrade(argv.slice(1));
+}
+
+if (argv[0] === "abacus") {
+  runAbacus(argv.slice(1));
+}
+
 if (argv[0] === "compile-ca" || argv[0] === "ca-plan" || argv[0] === "render-op") {
   runCompiler(argv);
 }
@@ -645,6 +896,22 @@ if (argv[0] === "compile") {
 
 if (argv[0] === "route" || argv[0] === "aetherpp") {
   runRouteCompiler(argv[0] === "route" ? argv.slice(1) : argv.slice(1));
+}
+
+// Typo guard: if argv[0] looks like a near-miss of a known scbe command,
+// suggest the corrected form and exit. We don't auto-execute the suggestion —
+// running a different command than the user typed is the classic
+// typo-amplification trap. Unknown-but-not-close inputs fall through to the
+// geoseal passthrough below, which has its own command set.
+{
+  const suggestion = suggestCommand(argv[0]);
+  if (suggestion) {
+    process.stderr.write(
+      `scbe: '${argv[0]}' is not a scbe command. Did you mean 'scbe ${suggestion}'?\n` +
+        `      Run 'scbe help' for the full command list.\n`,
+    );
+    process.exit(2);
+  }
 }
 
 const target = resolveGeosealBin();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scbe-aethermoore-cli",
-  "version": "4.1.5",
-  "description": "Standalone CLI for SCBE-AETHERMOORE GeoSeal tools, tokenizer lanes, governance packets, web lookup, and mechanical verification.",
+  "version": "4.3.0",
+  "description": "Standalone CLI for SCBE-AETHERMOORE: GeoSeal tools, flow operator loop (plan/packetize/status/run-next/continue/report), agent-bus passthrough, tokenizer lanes, governance packets, web lookup, mechanical verification, governance abacus (BigInt L12+L13).",
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT OR Apache-2.0",
   "type": "commonjs",
@@ -26,8 +26,8 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "scbe-aethermoore": "^4.0.8",
-    "scbe-agent-bus": "^0.2.1"
+    "scbe-aethermoore": "^4.1.0",
+    "scbe-agent-bus": "^0.3.0"
   },
   "keywords": [
     "scbe",
@@ -38,7 +38,12 @@
     "governance",
     "sacred-tongues",
     "agent-tools",
-    "dimensional-analysis"
+    "dimensional-analysis",
+    "agent-bus",
+    "workflow",
+    "operator-loop",
+    "agent-orchestration",
+    "ai-safety"
   ],
   "repository": {
     "type": "git",

--- a/scripts/harmonic/abacus_smoke.cjs
+++ b/scripts/harmonic/abacus_smoke.cjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Smoke: governanceAbacus (BigInt mechanical) vs canonical harmonicScale (float).
+ *
+ * Verifies the abacus matches the canonical L12 formula to within the
+ * abacus scale (1e-6 by default), across a range of representative inputs.
+ */
+
+const { runGovernanceAbacus } = require("../../dist/src/harmonic/governanceAbacus.js");
+const { harmonicScale } = require("../../dist/src/harmonic/harmonicScaling.js");
+
+const SAMPLES = [
+  { d_h: 0.0, phase_dev: 0.0 },
+  { d_h: 0.1, phase_dev: 0.0 },
+  { d_h: 0.4, phase_dev: 0.1 },
+  { d_h: 0.6, phase_dev: 0.0 },
+  { d_h: 1.0, phase_dev: 0.0 },
+  { d_h: 2.0, phase_dev: 0.5 },
+  { d_h: 5.0, phase_dev: 1.0 },
+];
+
+const TOLERANCE = 1e-6;
+
+function tierFromFloat(h) {
+  if (h >= 0.65) return "ALLOW";
+  if (h >= 0.45) return "QUARANTINE";
+  if (h >= 0.25) return "ESCALATE";
+  return "DENY";
+}
+
+let failed = 0;
+for (const sample of SAMPLES) {
+  const run = runGovernanceAbacus(sample);
+  const floatScore = harmonicScale(sample.d_h, sample.phase_dev);
+  const abacusScore = Number(run.score_decimal);
+  const delta = Math.abs(floatScore - abacusScore);
+  const floatTier = tierFromFloat(floatScore);
+  const ok = delta <= TOLERANCE && floatTier === run.tier;
+  if (!ok) failed += 1;
+  console.log(
+    `${ok ? "PASS" : "FAIL"}  d_h=${sample.d_h.toFixed(4)} pd=${sample.phase_dev.toFixed(4)}  ` +
+      `float=${floatScore.toFixed(8)}  abacus=${run.score_decimal}  delta=${delta.toExponential(2)}  ` +
+      `tier(float=${floatTier} abacus=${run.tier})  trit=${run.trit}`
+  );
+}
+
+if (failed === 0) {
+  console.log(`\nAll ${SAMPLES.length} samples within tolerance ${TOLERANCE}.`);
+  process.exit(0);
+}
+console.log(`\n${failed}/${SAMPLES.length} samples FAILED.`);
+process.exit(1);

--- a/scripts/npm_break_dist_hardlinks.js
+++ b/scripts/npm_break_dist_hardlinks.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/*
+ * npm rejects tarballs containing hard-link entries. Some Windows sync tools
+ * can leave build outputs hard-linked to temporary upload files, so normalize
+ * dist files after TypeScript builds and before npm packs.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const distRoot = path.join(root, "dist");
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(full));
+    } else if (entry.isFile()) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function breakHardlink(file) {
+  const stat = fs.statSync(file);
+  if (stat.nlink <= 1) return false;
+  const bytes = fs.readFileSync(file);
+  const mode = stat.mode;
+  fs.unlinkSync(file);
+  fs.writeFileSync(file, bytes, { mode });
+  return true;
+}
+
+let broken = 0;
+for (const file of walk(distRoot)) {
+  if (breakHardlink(file)) {
+    broken += 1;
+  }
+}
+
+console.log(`[break-dist-hardlinks] normalized ${broken} hard-linked dist file(s)`);

--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -74,6 +74,7 @@ from src.ca_lexicon import (
     trit_vector,
 )
 from src.crypto.sacred_tongues import SACRED_TONGUE_TOKENIZER
+from src.tokenizer.code_weight_packets import semantic_operation_signature_from_tokens
 from src.crypto.geoseal_execution_gate import (
     DEFAULT_AUDIT_SECRET_ENV,
     DEFAULT_EXEC_AUDIT_LOG,
@@ -1160,6 +1161,10 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
     lexical_tokens = re.findall(r"[A-Za-z_][A-Za-z0-9_]*|==|!=|<=|>=|[^\s]", source)
     transport_tokens = SACRED_TONGUE_TOKENIZER.encode_bytes(transport, source_bytes)
     semantic = _compute_semantic_expression(source)
+    semantic_operation = semantic_operation_signature_from_tokens(lexical_tokens, language=language)
+    semantic["operation_signature"] = semantic_operation
+    semantic["operation_path"] = semantic_operation["operation_path"]
+    semantic["interchange_key"] = semantic_operation["interchange_key"]
     definitions = [
         {"symbol": name, "kind": kind}
         for kind, name in re.findall(r"\b(import|class|def)\s+([A-Za-z_][A-Za-z0-9_]*)", source)
@@ -1260,6 +1265,7 @@ def _build_code_packet_payload(args: argparse.Namespace) -> dict[str, Any]:
             ],
         },
         "semantic_expression": semantic,
+        "semantic_operation_signature": semantic_operation,
         "route_ir": _build_route_ir_for_source(
             source=source,
             source_name=source_name,

--- a/src/harmonic/governanceAbacus.ts
+++ b/src/harmonic/governanceAbacus.ts
@@ -1,0 +1,263 @@
+/**
+ * @file governanceAbacus.ts
+ * @module harmonic/governanceAbacus
+ * @layer Layer 12, Layer 13
+ * @component Governance Abacus (deterministic mechanical scoring)
+ * @version 1.0.0
+ *
+ * Exact-arithmetic mechanical implementation of the L12 harmonic wall scoring +
+ * L13 tier assignment. All computation runs in BigInt with a fixed scale; no
+ * floating-point arithmetic, no platform-dependent drift.
+ *
+ * "Like an abacus": each input is quantized to a discrete bead position on a
+ * rod (an integer). The harmonic-wall computation is a sequence of integer
+ * additions and one integer division. The tier is read from the score rod by
+ * comparing against fixed integer thresholds. Same inputs → same beads → same
+ * tier on every platform, forever.
+ *
+ * Canonical formula (matches `harmonicScale` in harmonicScaling.ts exactly):
+ *   H(d_h, pd) = 1 / (1 + d_h + 2*pd)  ∈ (0, 1]
+ *
+ * The L13 tier mapping is:
+ *   H >= 0.65 → ALLOW
+ *   H >= 0.45 → QUARANTINE
+ *   H >= 0.25 → ESCALATE
+ *   H <  0.25 → DENY
+ *
+ * Output is BOTH the four-tier governance decision and a balanced-ternary
+ * collapse for tri-state surfaces:
+ *   +1 = ALLOW         (safe)
+ *    0 = QUARANTINE or ESCALATE  (uncertain)
+ *   -1 = DENY          (unsafe)
+ *
+ * Phi does NOT enter this formula. Phi-weighted tongue scoring is a separate
+ * abacus (per-tongue, future extension). See docs/ABACUS_ARCHITECTURE.md for
+ * the multi-abacus roadmap.
+ *
+ * Public API:
+ *   - runGovernanceAbacus({ d_h, phase_dev }) → AbacusRun
+ *   - formatAbacusBoard(run) → string (human-readable bead display)
+ *
+ * @see src/harmonic/balancedTernary.ts — the tri-state primitive
+ * @see src/harmonic/harmonicScaling.ts — the canonical float version of H_score
+ */
+
+import type { Trit } from './balancedTernary.js';
+
+export type GovernanceTier = 'ALLOW' | 'QUARANTINE' | 'ESCALATE' | 'DENY';
+
+export interface AbacusConfig {
+  /** Bead-grid resolution. Default 1_000_000 (6 decimal places of input precision). */
+  scale?: bigint;
+}
+
+export interface AbacusInput {
+  /** Hyperbolic distance from the safe center, d_h ≥ 0. */
+  d_h: number;
+  /** Phase deviation from expected coherence, pd ≥ 0. */
+  phase_dev: number;
+}
+
+/**
+ * Tier thresholds, expressed as score lower bounds. A score >= 0.65 is ALLOW,
+ * >= 0.45 is QUARANTINE, >= 0.25 is ESCALATE, otherwise DENY. Stored as
+ * rationals so the comparison is exact.
+ */
+export const TIER_THRESHOLDS: ReadonlyArray<{ tier: GovernanceTier; minScoreNum: bigint; minScoreDen: bigint }> = [
+  { tier: 'ALLOW', minScoreNum: 65n, minScoreDen: 100n },
+  { tier: 'QUARANTINE', minScoreNum: 45n, minScoreDen: 100n },
+  { tier: 'ESCALATE', minScoreNum: 25n, minScoreDen: 100n },
+  { tier: 'DENY', minScoreNum: 0n, minScoreDen: 1n },
+];
+
+export interface AbacusBead {
+  /** Rod label (human-readable). */
+  rod: string;
+  /** Integer bead position on the rod. */
+  position: bigint;
+  /** Scale (denominator) for converting position to a real number. */
+  scale: bigint;
+  /** Decoded human-readable value. */
+  display: string;
+}
+
+export interface AbacusRun {
+  /** Original input values (echo for trace). */
+  input: AbacusInput;
+  /** Configuration in effect (with defaults filled in). */
+  config: Required<AbacusConfig>;
+  /** Bead positions on each rod after the run. */
+  beads: {
+    d_h: AbacusBead;
+    phase_dev: AbacusBead;
+    /** Denominator rod: 1 + d_h + 2*pd (scaled). */
+    denominator: AbacusBead;
+    /** Final score rod: scale^2 / denominator. */
+    score: AbacusBead;
+  };
+  /** Exact score as a rational number. */
+  score: { num: bigint; den: bigint };
+  /** Score as a decimal string with explicit precision (no float). */
+  score_decimal: string;
+  /** Four-tier governance decision. */
+  tier: GovernanceTier;
+  /** Balanced-ternary collapse: +1 ALLOW, 0 uncertain, -1 DENY. */
+  trit: Trit;
+}
+
+function quantize(value: number, scale: bigint): bigint {
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`abacus input must be finite, got ${value}`);
+  }
+  if (value < 0) {
+    throw new RangeError(`abacus input must be >= 0, got ${value}`);
+  }
+  // Round half-away-from-zero (since value >= 0, this is just round half up).
+  const scaled = Math.round(value * Number(scale));
+  return BigInt(scaled);
+}
+
+function formatScaled(position: bigint, scale: bigint, decimals: number): string {
+  // position / scale, rendered with `decimals` digits after the point.
+  if (decimals < 0 || decimals > 18) {
+    throw new RangeError('decimals must be in [0, 18]');
+  }
+  const sign = position < 0n ? '-' : '';
+  const abs = position < 0n ? -position : position;
+  const whole = abs / scale;
+  const remainder = abs - whole * scale;
+  if (decimals === 0) {
+    return `${sign}${whole.toString()}`;
+  }
+  // Render fractional part by re-scaling.
+  const tenPow = 10n ** BigInt(decimals);
+  const fracRescaled = (remainder * tenPow) / scale;
+  const fracStr = fracRescaled.toString().padStart(decimals, '0');
+  return `${sign}${whole.toString()}.${fracStr}`;
+}
+
+function tierFor(scoreNum: bigint, scoreDen: bigint): GovernanceTier {
+  // Compare score = scoreNum/scoreDen against each threshold minScoreNum/minScoreDen.
+  // score >= threshold  ⟺  scoreNum * thresholdDen >= thresholdNum * scoreDen
+  for (const t of TIER_THRESHOLDS) {
+    if (scoreNum * t.minScoreDen >= t.minScoreNum * scoreDen) {
+      return t.tier;
+    }
+  }
+  return 'DENY';
+}
+
+function tritFor(tier: GovernanceTier): Trit {
+  if (tier === 'ALLOW') return 1;
+  if (tier === 'DENY') return -1;
+  return 0;
+}
+
+/**
+ * Run the governance abacus on a single input. Pure, deterministic, BigInt-only.
+ *
+ * Matches the canonical `harmonicScale(d_h, phase_dev)` from harmonicScaling.ts
+ * to within the configured `scale` (default 1e6 = 6 decimal places). The exact
+ * rational score is also returned for consumers that want zero-loss audit
+ * trails.
+ *
+ * @example
+ *   const run = runGovernanceAbacus({ d_h: 0.4, phase_dev: 0.1 });
+ *   // run.tier === 'QUARANTINE'
+ *   // run.trit === 0
+ *   // run.score_decimal === '0.625000'
+ */
+export function runGovernanceAbacus(input: AbacusInput, config: AbacusConfig = {}): AbacusRun {
+  const scale = config.scale ?? 1_000_000n;
+  if (scale <= 0n) {
+    throw new RangeError('scale must be a positive bigint');
+  }
+
+  // Quantize inputs to bead positions on their rods.
+  const d_h_pos = quantize(input.d_h, scale);
+  const pd_pos = quantize(input.phase_dev, scale);
+
+  // Compute denominator = 1 + d_h + 2*pd, all in `scale` units.
+  //   scaled_one        = scale
+  //   scaled_d_h        = d_h_pos
+  //   scaled_two_pd     = 2 * pd_pos
+  const denPos = scale + d_h_pos + 2n * pd_pos;
+  if (denPos <= 0n) {
+    throw new RangeError('abacus denominator collapsed to zero (impossible for non-negative inputs)');
+  }
+
+  // score = 1 / (1 + d_h + 2*pd)
+  //       = scale / denPos    (as a rational; both numerator and denominator are in `scale` units)
+  // For the bead display, render score * scale rounded to integer.
+  const scorePos = (scale * scale) / denPos;
+
+  // Exact rational score.
+  const scoreNum = scale; // numerator in `scale` units
+  const scoreDen = denPos;
+
+  const tier = tierFor(scoreNum, scoreDen);
+  const trit = tritFor(tier);
+
+  const scoreDecimals = 6;
+  const score_decimal = formatScaled(scorePos, scale, scoreDecimals);
+
+  return {
+    input,
+    config: { scale },
+    beads: {
+      d_h: {
+        rod: 'd_h',
+        position: d_h_pos,
+        scale,
+        display: formatScaled(d_h_pos, scale, 6),
+      },
+      phase_dev: {
+        rod: 'phase_dev',
+        position: pd_pos,
+        scale,
+        display: formatScaled(pd_pos, scale, 6),
+      },
+      denominator: {
+        rod: 'denominator',
+        position: denPos,
+        scale,
+        display: formatScaled(denPos, scale, 6),
+      },
+      score: {
+        rod: 'score',
+        position: scorePos,
+        scale,
+        display: score_decimal,
+      },
+    },
+    score: { num: scoreNum, den: scoreDen },
+    score_decimal,
+    tier,
+    trit,
+  };
+}
+
+/**
+ * Render an abacus run as a human-readable bead board.
+ */
+export function formatAbacusBoard(run: AbacusRun): string {
+  const lines = [
+    `SCBE Governance Abacus (deterministic, BigInt-only)`,
+    ``,
+    `  formula: H(d_h, pd) = 1 / (1 + d_h + 2*pd)`,
+    `  config:  scale=${run.config.scale.toString()}`,
+    ``,
+    `  rod          | bead position                         | reads as`,
+    `  -------------+---------------------------------------+----------`,
+    `  d_h          | ${run.beads.d_h.position.toString().padStart(37, ' ')} | ${run.beads.d_h.display}`,
+    `  phase_dev    | ${run.beads.phase_dev.position.toString().padStart(37, ' ')} | ${run.beads.phase_dev.display}`,
+    `  denominator  | ${run.beads.denominator.position.toString().padStart(37, ' ')} | ${run.beads.denominator.display}`,
+    `  score        | ${run.beads.score.position.toString().padStart(37, ' ')} | ${run.score_decimal}`,
+    ``,
+    `  exact score: ${run.score.num.toString()} / ${run.score.den.toString()}`,
+    `  tier:        ${run.tier}`,
+    `  trit:        ${run.trit > 0 ? '+' : ''}${run.trit}    (${run.trit === 1 ? 'ALLOW' : run.trit === -1 ? 'DENY' : 'uncertain'})`,
+    ``,
+  ];
+  return lines.join('\n');
+}

--- a/src/harmonic/index.ts
+++ b/src/harmonic/index.ts
@@ -585,3 +585,16 @@ export {
   type GovernanceRoutingResult,
   type GovernanceRouterConfig,
 } from './phdmSheafLattice.js';
+
+
+// ── Governance Abacus (deterministic BigInt-only L12+L13 mechanical scoring) ──
+export {
+  runGovernanceAbacus,
+  formatAbacusBoard,
+  TIER_THRESHOLDS,
+  type GovernanceTier,
+  type AbacusConfig,
+  type AbacusInput,
+  type AbacusBead,
+  type AbacusRun,
+} from './governanceAbacus.js';

--- a/src/tokenizer/code_weight_packets.py
+++ b/src/tokenizer/code_weight_packets.py
@@ -155,6 +155,186 @@ def _quarks(tokens: list[str]) -> list[str]:
     return result or ["semantic_operation"]
 
 
+def _token_roles(tokens: list[str]) -> list[dict[str, Any]]:
+    roles: list[dict[str, Any]] = []
+    for index, token in enumerate(tokens):
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", token):
+            lowered = token.lower()
+            if lowered in {
+                "class",
+                "const",
+                "def",
+                "else",
+                "false",
+                "fn",
+                "for",
+                "function",
+                "if",
+                "let",
+                "none",
+                "null",
+                "return",
+                "true",
+                "while",
+            }:
+                role = "keyword"
+            else:
+                role = "identifier"
+        elif re.fullmatch(r"\d+(?:\.\d+)?", token):
+            role = "literal:number"
+        elif token in {'"', "'", "`"}:
+            role = "literal:string_delimiter"
+        elif token in {"+", "-", "*", "/", "%"}:
+            role = "operator:arithmetic"
+        elif token in {"==", "!=", "<", ">", "<=", ">="}:
+            role = "operator:comparison"
+        elif token in {"=", "+=", "-=", "*=", "/=", "%="}:
+            role = "operator:assignment"
+        elif token in {"(", ")", "{", "}", "[", "]", ",", ":", ";", "->", "=>", "::"}:
+            role = "punctuator"
+        else:
+            role = "symbol"
+        roles.append({"index": index, "token": token, "role": role})
+    return roles
+
+
+def _find_after(tokens: list[str], candidates: set[str], start: int = 0) -> int | None:
+    for index in range(start, len(tokens)):
+        if tokens[index].lower() in candidates:
+            return index
+    return None
+
+
+def _function_name(tokens: list[str], language: str) -> str | None:
+    lowered = [token.lower() for token in tokens]
+    for keyword in ("def", "fn", "function"):
+        if keyword in lowered:
+            index = lowered.index(keyword)
+            if index + 1 < len(tokens) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", tokens[index + 1]):
+                return tokens[index + 1]
+
+    # C-like declarations often arrive as: int add(int a, int b) { ... }
+    if language.lower() in {"c", "cpp", "c++", "java", "go"}:
+        for index in range(1, len(tokens) - 1):
+            if tokens[index + 1] == "(" and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", tokens[index]):
+                if tokens[index].lower() not in {"if", "for", "while", "switch", "return"}:
+                    return tokens[index]
+    return None
+
+
+def _extract_params(tokens: list[str], function_name: str | None) -> list[str]:
+    if function_name is None:
+        return []
+    try:
+        open_index = tokens.index("(", tokens.index(function_name))
+    except ValueError:
+        return []
+    depth = 0
+    params: list[str] = []
+    current: list[str] = []
+    for token in tokens[open_index + 1 :]:
+        if token == "(":
+            depth += 1
+            current.append(token)
+            continue
+        if token == ")":
+            if depth == 0:
+                if current:
+                    params.append(" ".join(current))
+                break
+            depth -= 1
+            current.append(token)
+            continue
+        if token == "," and depth == 0:
+            if current:
+                params.append(" ".join(current))
+                current = []
+            continue
+        current.append(token)
+    return [param for param in params if param]
+
+
+def _normalize_param(param: str) -> str:
+    pieces = re.findall(r"[A-Za-z_][A-Za-z0-9_]*|\*|&|\.\.\.", param)
+    identifiers = [piece for piece in pieces if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", piece)]
+    if not identifiers:
+        return "arg"
+    return identifiers[-1]
+
+
+def _operation_atoms(tokens: list[str], language: str) -> list[dict[str, Any]]:
+    atoms: list[dict[str, Any]] = []
+    function_name = _function_name(tokens, language)
+    params = [_normalize_param(param) for param in _extract_params(tokens, function_name)]
+    if function_name:
+        atoms.append(
+            {
+                "kind": "function_definition",
+                "name": function_name,
+                "arity": len(params),
+                "params": params,
+            }
+        )
+
+    return_index = _find_after(tokens, {"return"})
+    if return_index is not None:
+        atoms.append({"kind": "return_flow"})
+
+    arithmetic_ops = {"+": "add", "-": "sub", "*": "mul", "/": "div", "%": "mod"}
+    comparison_ops = {"==": "eq", "!=": "neq", "<": "lt", "<=": "lte", ">": "gt", ">=": "gte"}
+    for index, token in enumerate(tokens):
+        if token in arithmetic_ops:
+            atoms.append({"kind": "arithmetic", "operator": arithmetic_ops[token], "arity": 2, "token_index": index})
+        elif token in comparison_ops:
+            atoms.append({"kind": "comparison", "operator": comparison_ops[token], "arity": 2, "token_index": index})
+        elif token in {"=", "+=", "-=", "*=", "/=", "%="}:
+            operator = "assign" if token == "=" else f"{arithmetic_ops[token[0]]}_assign"
+            atoms.append({"kind": "assignment", "operator": operator, "arity": 2, "token_index": index})
+
+    if any(token.lower() in {"for", "while"} for token in tokens):
+        atoms.append({"kind": "iteration_flow"})
+    if any(token.lower() in {"if", "else"} for token in tokens):
+        atoms.append({"kind": "control_guard"})
+    return atoms
+
+
+def _atom_key(atom: dict[str, Any]) -> str:
+    kind = str(atom.get("kind", "operation"))
+    if kind == "function_definition":
+        return f"function_definition/{int(atom.get('arity', 0))}"
+    operator = atom.get("operator")
+    if operator:
+        return f"{kind}:{operator}/{int(atom.get('arity', 0))}"
+    return kind
+
+
+def build_semantic_operation_signature(source: str, *, language: str) -> dict[str, Any]:
+    tokens = _lexical_tokens(source)
+    return semantic_operation_signature_from_tokens(tokens, language=language)
+
+
+def semantic_operation_signature_from_tokens(tokens: list[str], *, language: str) -> dict[str, Any]:
+    roles = _token_roles(tokens)
+    atoms = _operation_atoms(tokens, language)
+    operation_path = [_atom_key(atom) for atom in atoms] or ["semantic_operation"]
+    interchange_payload = "|".join(operation_path)
+    return {
+        "schema_version": "scbe-semantic-operation-signature-v1",
+        "source_language": language,
+        "token_roles": roles,
+        "operation_atoms": atoms,
+        "operation_path": operation_path,
+        "interchange_key": hashlib.sha256(interchange_payload.encode("utf-8")).hexdigest(),
+        "interchange_payload": interchange_payload,
+        "preservation": {
+            "source_text_hash_bound": True,
+            "lexical_tokens_preserved": True,
+            "identifier_names_preserved_in_atoms": True,
+            "language_specific_syntax_excluded_from_interchange_key": True,
+        },
+    }
+
+
 def build_code_weight_packet(source: str, *, language: str, source_name: str = "") -> dict[str, Any]:
     tokens = _lexical_tokens(source)
     tongue = LANGUAGE_TONGUES.get(language.lower(), "KO")
@@ -176,6 +356,7 @@ def build_code_weight_packet(source: str, *, language: str, source_name: str = "
     transport_tokens = _transport_tokens(source, tongue)
     source_sha = hashlib.sha256(source_bytes).hexdigest()
     token_sha = hashlib.sha256(" ".join(transport_tokens).encode("utf-8")).hexdigest()
+    semantic_operation = semantic_operation_signature_from_tokens(tokens, language=language)
     return {
         "schema_version": "scbe-code-weight-packet-v1",
         "source_name": source_name,
@@ -195,10 +376,20 @@ def build_code_weight_packet(source: str, *, language: str, source_name: str = "
             "token_sha256": token_sha,
         },
         "route": {"tongue": tongue, "language": language},
-        "semantic_expression": {"quarks": _quarks(tokens)},
+        "semantic_expression": {
+            "quarks": _quarks(tokens),
+            "operation_signature": semantic_operation,
+            "interchange_key": semantic_operation["interchange_key"],
+            "operation_path": semantic_operation["operation_path"],
+        },
+        "semantic_operation_signature": semantic_operation,
         "lane_alignment": _lane_alignment(language, tongue),
         "content_sha256": _sha256_text(source),
     }
 
 
-__all__ = ["build_code_weight_packet"]
+__all__ = [
+    "build_code_weight_packet",
+    "build_semantic_operation_signature",
+    "semantic_operation_signature_from_tokens",
+]

--- a/tests/test_geoseal_cli_tokenizer_atomic.py
+++ b/tests/test_geoseal_cli_tokenizer_atomic.py
@@ -213,6 +213,13 @@ def test_code_packet_emits_source_packet(tmp_path: Path) -> None:
     assert packet["scip_symbol_index"]["planned_provider"] == "scip"
     assert packet["semantic_token_bridge"]["provider"] == "tree_sitter_semantic_tokens"
     assert packet["semantic_token_bridge"]["planned_provider"] == "lsp_semantic_tokens"
+    assert packet["semantic_operation_signature"]["schema_version"] == "scbe-semantic-operation-signature-v1"
+    assert packet["semantic_operation_signature"]["operation_path"] == [
+        "function_definition/2",
+        "return_flow",
+        "arithmetic:add/2",
+    ]
+    assert packet["semantic_expression"]["interchange_key"] == packet["semantic_operation_signature"]["interchange_key"]
     assert "def" in packet["lexical_tokens"]
     assert packet["route_ir"]["schema_version"] == "scbe_route_ir_v1"
     assert packet["route_ir"]["route"]["tongue"] == "KO"

--- a/tests/tokenizer/test_code_weight_semantic_operation_signature.py
+++ b/tests/tokenizer/test_code_weight_semantic_operation_signature.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from src.tokenizer.code_weight_packets import build_code_weight_packet
+
+
+def _signature(source: str, language: str) -> dict:
+    packet = build_code_weight_packet(source, language=language, source_name=f"sample.{language}")
+    return packet["semantic_operation_signature"]
+
+
+def test_semantic_operation_signature_matches_add_function_across_languages() -> None:
+    samples = {
+        "python": "def add(a, b):\n    return a + b\n",
+        "typescript": "function add(a, b) { return a + b; }\n",
+        "rust": "fn add(a: i32, b: i32) -> i32 { return a + b }\n",
+        "c": "int add(int a, int b) { return a + b; }\n",
+    }
+
+    signatures = {language: _signature(source, language) for language, source in samples.items()}
+    keys = {signature["interchange_key"] for signature in signatures.values()}
+    paths = {tuple(signature["operation_path"]) for signature in signatures.values()}
+
+    assert len(keys) == 1
+    assert paths == {("function_definition/2", "return_flow", "arithmetic:add/2")}
+    for language, signature in signatures.items():
+        assert signature["source_language"] == language
+        assert signature["preservation"]["language_specific_syntax_excluded_from_interchange_key"] is True
+        assert signature["preservation"]["identifier_names_preserved_in_atoms"] is True
+
+
+def test_semantic_operation_signature_preserves_identifiers_without_polluting_interchange_key() -> None:
+    first = _signature("def add(left, right):\n    return left + right\n", "python")
+    second = _signature("def sum_values(a, b):\n    return a + b\n", "python")
+
+    assert first["interchange_key"] == second["interchange_key"]
+    assert first["operation_atoms"][0]["name"] == "add"
+    assert first["operation_atoms"][0]["params"] == ["left", "right"]
+    assert second["operation_atoms"][0]["name"] == "sum_values"
+    assert second["operation_atoms"][0]["params"] == ["a", "b"]
+
+
+def test_packet_surfaces_operation_signature_in_semantic_expression() -> None:
+    packet = build_code_weight_packet("def guarded(x):\n    if x >= 0:\n        return x\n", language="python")
+    semantic = packet["semantic_expression"]
+
+    assert semantic["interchange_key"] == packet["semantic_operation_signature"]["interchange_key"]
+    assert semantic["operation_signature"]["schema_version"] == "scbe-semantic-operation-signature-v1"
+    assert "control_guard" in semantic["operation_path"]
+    assert "comparison:gte/2" in semantic["operation_path"]


### PR DESCRIPTION
## Summary
- publish `scbe-aethermoore@4.1.0`, `scbe-agent-bus@0.3.0`, and `scbe-aethermoore-cli@4.3.0`
- add BigInt governance abacus scoring with CLI text/JSON output and parity smoke
- add CLI typo suggestions for SCBE-owned commands without shadowing GeoSeal fallback
- add semantic operation signatures for cross-language code packet comparison
- add npm publish hardlink normalization for `dist/` tarballs

## Verification
- `npm run build`
- `python -m pytest tests/tokenizer/test_code_weight_semantic_operation_signature.py tests/test_geoseal_cli_tokenizer_atomic.py::test_code_packet_emits_source_packet -q` -> 4 passed
- `node scripts\harmonic\abacus_smoke.cjs` -> 7/7 PASS within 1e-6
- `npm run publish:check:strict`
- `npm run build` in `packages/agent-bus`
- fresh temp install of `scbe-aethermoore-cli@4.3.0`
- temp install commands: `scbe selftest`, `scbe abacus run --d-h 0.1 --pd 0 --json`, `scbe agent-bus send --help`

## Published
- `scbe-aethermoore@4.1.0`
- `scbe-agent-bus@0.3.0`
- `scbe-aethermoore-cli@4.3.0`

## Rollback
- npm releases are immutable; rollback by publishing patch versions that revert the package metadata/CLI behavior and closing this PR before merge if CI exposes an issue.