### PR TITLE
style(harmonic): format abacus exports

### DIFF
--- a/src/harmonic/governanceAbacus.ts
+++ b/src/harmonic/governanceAbacus.ts
@@ -63,7 +63,11 @@ export interface AbacusInput {
  * >= 0.45 is QUARANTINE, >= 0.25 is ESCALATE, otherwise DENY. Stored as
  * rationals so the comparison is exact.
  */
-export const TIER_THRESHOLDS: ReadonlyArray<{ tier: GovernanceTier; minScoreNum: bigint; minScoreDen: bigint }> = [
+export const TIER_THRESHOLDS: ReadonlyArray<{
+  tier: GovernanceTier;
+  minScoreNum: bigint;
+  minScoreDen: bigint;
+}> = [
   { tier: 'ALLOW', minScoreNum: 65n, minScoreDen: 100n },
   { tier: 'QUARANTINE', minScoreNum: 45n, minScoreDen: 100n },
   { tier: 'ESCALATE', minScoreNum: 25n, minScoreDen: 100n },
@@ -183,7 +187,9 @@ export function runGovernanceAbacus(input: AbacusInput, config: AbacusConfig = {
   //   scaled_two_pd     = 2 * pd_pos
   const denPos = scale + d_h_pos + 2n * pd_pos;
   if (denPos <= 0n) {
-    throw new RangeError('abacus denominator collapsed to zero (impossible for non-negative inputs)');
+    throw new RangeError(
+      'abacus denominator collapsed to zero (impossible for non-negative inputs)'
+    );
   }
 
   // score = 1 / (1 + d_h + 2*pd)

--- a/src/harmonic/index.ts
+++ b/src/harmonic/index.ts
@@ -586,7 +586,6 @@ export {
   type GovernanceRouterConfig,
 } from './phdmSheafLattice.js';
 
-
 // ── Governance Abacus (deterministic BigInt-only L12+L13 mechanical scoring) ──
 export {
   runGovernanceAbacus,


### PR DESCRIPTION
## Summary
- apply Prettier formatting to the abacus TypeScript files that failed CI after the release PR auto-merged

## Verification
- `npx --yes prettier@3.8.1 --check src/harmonic/governanceAbacus.ts src/harmonic/index.ts`
- `npm run build`
- `node scripts\harmonic\abacus_smoke.cjs`

## Rollback
- revert this style-only commit