### PR TITLE
feat(cli): expose liboqs proof receipt

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 4.3.3 - 2026-05-14
+
+### Fixed
+
+- **`scbe liboqs` outside a source checkout**: fresh npm installs now return a structured `SCBE_LIBOQS_PASS=0` source-checkout-required receipt instead of a raw Python `ModuleNotFoundError`.
+
+## 4.3.2 - 2026-05-14
+
+### Added
+
+- **`scbe liboqs [--json]` native proof receipt**: runs the existing `src.crypto.pqc_liboqs` governance proof ladder plus an ML-KEM roundtrip and ML-DSA verify smoke. Emits `SCBE_LIBOQS_PASS=1` only when native liboqs is active and the smoke passes; lower proof tiers are reported honestly with `SCBE_LIBOQS_PASS=0`.
+
 ## 4.3.1 - 2026-05-14
 
 ### Changed

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -34,6 +34,8 @@ Core commands:
   scbe shell
   scbe run "npm test"
   scbe status
+  scbe liboqs
+  scbe liboqs --json
   scbe history --limit 20
 
 Flow loop (operator workflow — source checkout required for plan/packetize):
@@ -182,7 +184,7 @@ function gateCommand(command) {
     'import json, sys',
     'from src.crypto.geoseal_execution_gate import scan_command',
     'print(json.dumps(scan_command(sys.argv[1]).to_dict()))',
-  ].join('; ');
+  ].join('\n');
   const child = spawnSync(pythonCommand(), ['-c', code, command], {
     cwd: repoRoot(),
     encoding: 'utf8',
@@ -607,6 +609,102 @@ function runStatus() {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
 }
 
+function runLiboqs(args) {
+  const asJson = args.includes('--json');
+  if (!resolveRepoScript('src/crypto/pqc_liboqs.py')) {
+    const payload = {
+      schema_version: 'scbe_liboqs_receipt_v1',
+      receipt: 'SCBE_LIBOQS_PASS=0',
+      native_pass: false,
+      error: 'source checkout required',
+      detail:
+        'scbe liboqs needs the local SCBE-AETHERMOORE Python source tree at src/crypto/pqc_liboqs.py.',
+    };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    process.exit(2);
+  }
+  const code = [
+    'import json',
+    'from src.crypto.pqc_liboqs import MLDSA65, MLKEM768, get_pqc_governance_status',
+    'status = get_pqc_governance_status()',
+    'kem = MLKEM768()',
+    'ct, ss = kem.encapsulate()',
+    'ss2 = kem.decapsulate(ct)',
+    'dsa = MLDSA65()',
+    'msg = b"scbe-liboqs-smoke"',
+    'sig = dsa.sign(msg)',
+    'kem_roundtrip = bool(ss == ss2)',
+    'dsa_verify = bool(dsa.verify(msg, sig))',
+    'native_pass = bool(status.get("liboqs_available") and kem_roundtrip and dsa_verify)',
+    'print(json.dumps({',
+    '  "schema_version": "scbe_liboqs_receipt_v1",',
+    '  "receipt": "SCBE_LIBOQS_PASS=1" if native_pass else "SCBE_LIBOQS_PASS=0",',
+    '  "native_pass": native_pass,',
+    '  "status": status,',
+    '  "smoke": {',
+    '    "ml_kem_roundtrip": kem_roundtrip,',
+    '    "ml_dsa_verify": dsa_verify,',
+    '    "ciphertext_bytes": len(ct),',
+    '    "shared_secret_bytes": len(ss),',
+    '    "signature_bytes": len(sig),',
+    '  },',
+    '}))',
+  ].join('\n');
+  const result = runCapture(pythonCommand(), ['-c', code], { timeout: 20000 });
+  if (!result.ok) {
+    const payload = {
+      schema_version: 'scbe_liboqs_receipt_v1',
+      receipt: 'SCBE_LIBOQS_PASS=0',
+      native_pass: false,
+      error: 'pqc_liboqs smoke failed to execute',
+      stderr_preview: result.stderr.slice(0, 1000),
+      stdout_preview: result.stdout.slice(0, 1000),
+    };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    process.exit(1);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(result.stdout);
+  } catch (_err) {
+    payload = {
+      schema_version: 'scbe_liboqs_receipt_v1',
+      receipt: 'SCBE_LIBOQS_PASS=0',
+      native_pass: false,
+      error: 'pqc_liboqs smoke returned non-JSON',
+      stderr_preview: result.stderr.slice(0, 1000),
+      stdout_preview: result.stdout.slice(0, 1000),
+    };
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    process.exit(1);
+  }
+  if (result.stderr) {
+    payload.warnings = result.stderr
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  }
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    const status = payload.status || {};
+    const smoke = payload.smoke || {};
+    process.stdout.write(
+      [
+        `SCBE liboqs receipt: ${payload.receipt}`,
+        `Native liboqs: ${payload.native_pass ? 'PASS' : 'NOT ACTIVE'}`,
+        `Proof tier: ${status.tier || 'unknown'} (${status.proof || 'unknown'})`,
+        `Backend: ${status.backend || 'unknown'}`,
+        `Quantum resistant: ${status.quantum_resistant ? 'true' : 'false'}`,
+        `KEM: ${status.kem_algorithm || 'unknown'} roundtrip=${smoke.ml_kem_roundtrip ? 'pass' : 'fail'}`,
+        `DSA: ${status.sig_algorithm || 'unknown'} verify=${smoke.ml_dsa_verify ? 'pass' : 'fail'}`,
+        '',
+      ].join('\n')
+    );
+  }
+  process.exit(payload.native_pass ? 0 : 1);
+}
+
 function runInteractiveShell() {
   process.stdout.write('SCBE Terminal. Type commands normally. Use :help or :exit.\n');
   const rl = readline.createInterface({
@@ -701,6 +799,7 @@ const KNOWN_COMMANDS = [
   'shell',
   'run',
   'status',
+  'liboqs',
   'history',
   'flow',
   'agent-bus',
@@ -991,6 +1090,10 @@ if (argv[0] === 'selftest') {
 if (argv[0] === 'status') {
   runStatus();
   process.exit(0);
+}
+
+if (argv[0] === 'liboqs') {
+  runLiboqs(argv.slice(1));
 }
 
 if (argv[0] === 'history') {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scbe-aethermoore-cli",
-  "version": "4.3.1",
-  "description": "Standalone CLI for SCBE-AETHERMOORE: GeoSeal tools, flow operator loop (plan/packetize/status/run-next/continue/report), agent-bus passthrough, tokenizer lanes, governance packets, web lookup, mechanical verification, governance abacus (BigInt L12+L13).",
+  "version": "4.3.3",
+  "description": "Standalone CLI for SCBE-AETHERMOORE: GeoSeal tools, flow operator loop (plan/packetize/status/run-next/continue/report), liboqs proof receipts, agent-bus passthrough, tokenizer lanes, governance packets, web lookup, mechanical verification, governance abacus (BigInt L12+L13).",
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT OR Apache-2.0",
   "type": "commonjs",

--- a/tests/system/test_scbe_npm_cli_compiler.py
+++ b/tests/system/test_scbe_npm_cli_compiler.py
@@ -1,6 +1,9 @@
 import json
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI = REPO_ROOT / "packages" / "cli" / "bin" / "scbe.js"
@@ -95,3 +98,47 @@ def test_cli_status_reports_terminal_capabilities() -> None:
     assert payload["providers"]["local"]["available"] is True
     assert payload["budget"]["posture"] in {"local_free_default", "hosted_enabled"}
     assert payload["workspace"]["flow_status_ready"] is True
+
+
+def test_cli_liboqs_reports_native_proof_receipt() -> None:
+    from src.crypto.pqc_liboqs import get_pqc_governance_status
+
+    if get_pqc_governance_status()["tier"] != 1:
+        pytest.skip("native liboqs is optional in CI")
+
+    proc = run_cli("liboqs", "--json")
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "scbe_liboqs_receipt_v1"
+    assert payload["receipt"] == "SCBE_LIBOQS_PASS=1"
+    assert payload["native_pass"] is True
+    assert payload["status"]["tier"] == 1
+    assert payload["status"]["liboqs_available"] is True
+    assert payload["smoke"]["ml_kem_roundtrip"] is True
+    assert payload["smoke"]["ml_dsa_verify"] is True
+
+
+def test_cli_liboqs_reports_source_checkout_required_outside_repo(tmp_path: Path) -> None:
+    package_root = tmp_path / "node_modules" / "scbe-aethermoore-cli"
+    bin_dir = package_root / "bin"
+    bin_dir.mkdir(parents=True)
+    copied_cli = bin_dir / "scbe.js"
+    shutil.copy2(CLI, copied_cli)
+
+    proc = subprocess.run(
+        ["node", str(copied_cli), "liboqs", "--json"],
+        cwd=tmp_path,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert proc.returncode == 2, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "scbe_liboqs_receipt_v1"
+    assert payload["receipt"] == "SCBE_LIBOQS_PASS=0"
+    assert payload["native_pass"] is False
+    assert payload["error"] == "source checkout required"


### PR DESCRIPTION
## Summary
- add `scbe liboqs [--json]` as the priority-2 operator backlog receipt
- run the existing `src.crypto.pqc_liboqs` proof ladder plus ML-KEM roundtrip and ML-DSA verify smoke
- emit `SCBE_LIBOQS_PASS=1` only for native liboqs pass; report lower/source-missing states as structured `SCBE_LIBOQS_PASS=0`
- bump `scbe-aethermoore-cli` to 4.3.3 and publish npm latest

## Verification
- `npm run build`
- `python -m pytest tests\crypto\test_pqc_liboqs_status.py tests\system\test_scbe_npm_cli_compiler.py -q` -> 13 passed
- `node packages\cli\bin\scbe.js liboqs --json` -> `SCBE_LIBOQS_PASS=1`
- `SCBE_FORCE_SKIP_LIBOQS=1 node packages\cli\bin\scbe.js liboqs --json` -> structured `SCBE_LIBOQS_PASS=0`
- `npm pack --dry-run --json` -> `scbe-aethermoore-cli@4.3.3`
- `npm publish --access public` -> `+ scbe-aethermoore-cli@4.3.3`
- fresh temp install of `scbe-aethermoore-cli@4.3.3` -> structured source-checkout-required receipt
- `git diff --check`

## Rollback
- revert this commit and deprecate npm `scbe-aethermoore-cli@4.3.3` if needed; 4.3.1 remains the previous stable status-receipt release.