### PR TITLE
feat(agent-bus): add workspace formation command

### DIFF
--- a/packages/agent-bus/CHANGELOG.md
+++ b/packages/agent-bus/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1
+
+- **Workspace formation command**: adds `scbe-agent-bus workspace new [--root <path>] [--hint <name>] [--json]`, creating the canonical `.aethermoor-bus/workspaces/<workspace-id>/` folder shape and writing a `SCBE_WORKSPACE_READY=1` receipt into `20_receipts/workspace.json`.
+
 ## 0.3.0
 
 - **Hosted-credential gate on `send`**: requests with `--dispatch-provider` set to a non-local provider (anything other than `offline`, `local`, `ollama`, `local_only`, empty) now require `SCBE_API_KEY` in the environment. Without a key, `send` prints a hosted-intake notice (intake URL, service-credits URL, Ko-fi top-up URL, fee policy: provider/model cost passed through with 2-5% SCBE coordination fee) and exits with code 2.

--- a/packages/agent-bus/bin/scbe-agent-bus.cjs
+++ b/packages/agent-bus/bin/scbe-agent-bus.cjs
@@ -1,20 +1,27 @@
 #!/usr/bin/env node
 
-const { postAgentBusEvent, runAgentBusTerminalUi, startAgentBusServer } = require("../dist/index.js");
+const {
+  createAgentWorkspace,
+  postAgentBusEvent,
+  runAgentBusTerminalUi,
+  startAgentBusServer,
+} = require('../dist/index.js');
 
-const HOSTED_INTAKE_URL = "https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html";
-const SERVICE_CREDITS_URL = "https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html";
-const CREDIT_TOPUP_URL = "https://ko-fi.com/izdandavis";
+const HOSTED_INTAKE_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html';
+const SERVICE_CREDITS_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html';
+const CREDIT_TOPUP_URL = 'https://ko-fi.com/izdandavis';
 
-const LOCAL_PROVIDERS = new Set(["offline", "local", "ollama", "local_only", ""]);
+const LOCAL_PROVIDERS = new Set(['offline', 'local', 'ollama', 'local_only', '']);
 
 function hasHostedCredential() {
-  const key = String(process.env.SCBE_API_KEY || "").trim();
+  const key = String(process.env.SCBE_API_KEY || '').trim();
   return key.length > 0;
 }
 
 function wantsHostedDispatch(flags) {
-  const provider = String(flags["dispatch-provider"] || "offline").trim().toLowerCase();
+  const provider = String(flags['dispatch-provider'] || 'offline')
+    .trim()
+    .toLowerCase();
   return !LOCAL_PROVIDERS.has(provider);
 }
 
@@ -54,20 +61,20 @@ function parseArgs(argv) {
   const flags = {};
   for (let i = 2; i < argv.length; i += 1) {
     const token = argv[i];
-    if (!token.startsWith("--")) {
+    if (!token.startsWith('--')) {
       positionals.push(token);
       continue;
     }
     const key = token.slice(2);
     const next = argv[i + 1];
-    if (!next || next.startsWith("--")) {
+    if (!next || next.startsWith('--')) {
       flags[key] = true;
       continue;
     }
     flags[key] = next;
     i += 1;
   }
-  return { command: positionals[0] || "help", flags };
+  return { command: positionals[0] || 'help', flags };
 }
 
 function printHelp() {
@@ -78,6 +85,7 @@ Usage:
   scbe-agent-bus ui --base-url http://127.0.0.1:8787
   scbe-agent-bus send --task "review changed files" --task-type review --json
   scbe-agent-bus health --base-url http://127.0.0.1:8787 --json
+  scbe-agent-bus workspace new --hint customer-smoke --json
   scbe-agent-bus upgrade
 
 Commands:
@@ -85,6 +93,7 @@ Commands:
   ui        Start the terminal frontend.
   send      Send one governed task to the backend.
   health    Check backend health.
+  workspace Create a temporary local bus workspace.
   upgrade   Show how to enable hosted runs (intake, credits, top-up).
 
 Local routing is free. Hosted runs require SCBE_API_KEY (see 'upgrade').
@@ -93,41 +102,70 @@ Local routing is free. Hosted runs require SCBE_API_KEY (see 'upgrade').
 
 async function main() {
   const { command, flags } = parseArgs(process.argv);
-  const baseUrl = String(flags["base-url"] || process.env.SCBE_AGENT_BUS_URL || "http://127.0.0.1:8787");
-  if (command === "help" || flags.help) {
+  const baseUrl = String(
+    flags['base-url'] || process.env.SCBE_AGENT_BUS_URL || 'http://127.0.0.1:8787'
+  );
+  if (command === 'help' || flags.help) {
     printHelp();
     return;
   }
-  if (command === "upgrade") {
+  if (command === 'upgrade') {
     printUpgrade();
     return;
   }
-  if (command === "serve") {
+  if (command === 'workspace') {
+    const action = String(flags._action || process.argv[3] || 'help').trim();
+    if (action !== 'new') {
+      process.stderr.write(
+        'Usage: scbe-agent-bus workspace new [--root <path>] [--hint <name>] [--json]\n'
+      );
+      process.exitCode = action === 'help' ? 0 : 2;
+      return;
+    }
+    const payload = createAgentWorkspace({
+      root: flags.root ? String(flags.root) : undefined,
+      hint: flags.hint ? String(flags.hint) : undefined,
+    });
+    if (flags.json) {
+      process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    } else {
+      process.stdout.write(
+        [
+          `SCBE workspace receipt: ${payload.receipt}`,
+          `Workspace: ${payload.workspace_root}`,
+          `Receipt: ${payload.receipt_path}`,
+          '',
+        ].join('\n')
+      );
+    }
+    return;
+  }
+  if (command === 'serve') {
     const handle = await startAgentBusServer({
-      host: String(flags.host || "127.0.0.1"),
+      host: String(flags.host || '127.0.0.1'),
       port: Number(flags.port || 8787),
-      repoRoot: flags["repo-root"] ? String(flags["repo-root"]) : undefined,
+      repoRoot: flags['repo-root'] ? String(flags['repo-root']) : undefined,
       python: flags.python ? String(flags.python) : undefined,
-      continueOnError: Boolean(flags["continue-on-error"]),
+      continueOnError: Boolean(flags['continue-on-error']),
     });
     const payload = {
-      schema_version: "scbe-agent-bus-backend-start-v1",
+      schema_version: 'scbe-agent-bus-backend-start-v1',
       ok: true,
       url: handle.url,
-      routes: ["/health", "/v1/events", "/v1/batch"],
+      routes: ['/health', '/v1/events', '/v1/batch'],
     };
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
     return;
   }
-  if (command === "ui") {
+  if (command === 'ui') {
     await runAgentBusTerminalUi({ baseUrl });
     return;
   }
-  if (command === "send") {
-    const task = String(flags.task || "").trim();
-    if (!task) throw new Error("send requires --task");
+  if (command === 'send') {
+    const task = String(flags.task || '').trim();
+    if (!task) throw new Error('send requires --task');
     if (wantsHostedDispatch(flags) && !hasHostedCredential()) {
-      const provider = String(flags["dispatch-provider"] || "offline");
+      const provider = String(flags['dispatch-provider'] || 'offline');
       printHostedIntakeNotice(provider);
       process.exitCode = 2;
       return;
@@ -135,20 +173,24 @@ async function main() {
     const result = await postAgentBusEvent(
       {
         task,
-        taskType: String(flags["task-type"] || "general"),
-        privacy: String(flags.privacy || "local_only"),
-        budgetCents: Number(flags["budget-cents"] || 0),
-        dispatchProvider: String(flags["dispatch-provider"] || "offline"),
-        dispatch: flags.dispatch !== "false",
+        taskType: String(flags['task-type'] || 'general'),
+        privacy: String(flags.privacy || 'local_only'),
+        budgetCents: Number(flags['budget-cents'] || 0),
+        dispatchProvider: String(flags['dispatch-provider'] || 'offline'),
+        dispatch: flags.dispatch !== 'false',
       },
       { baseUrl }
     );
-    process.stdout.write(flags.json ? `${JSON.stringify(result, null, 2)}\n` : `${JSON.stringify(result)}\n`);
+    process.stdout.write(
+      flags.json ? `${JSON.stringify(result, null, 2)}\n` : `${JSON.stringify(result)}\n`
+    );
     return;
   }
-  if (command === "health") {
-    const result = await fetch(`${baseUrl.replace(/\/+$/, "")}/health`).then((res) => res.json());
-    process.stdout.write(flags.json ? `${JSON.stringify(result, null, 2)}\n` : `${JSON.stringify(result)}\n`);
+  if (command === 'health') {
+    const result = await fetch(`${baseUrl.replace(/\/+$/, '')}/health`).then((res) => res.json());
+    process.stdout.write(
+      flags.json ? `${JSON.stringify(result, null, 2)}\n` : `${JSON.stringify(result)}\n`
+    );
     return;
   }
   throw new Error(`unknown command: ${command}`);

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scbe-agent-bus",
-  "version": "0.3.0",
-  "description": "SCBE agent-bus: typed Node surface over the SCBE governed event runner. Routes AI/human/AI events through the harmonic-wall pipeline and returns a typed envelope.",
+  "version": "0.3.1",
+  "description": "SCBE agent-bus: typed Node surface over the SCBE governed event runner. Routes AI/human/AI events through the harmonic-wall pipeline, creates local bus workspaces, and returns a typed envelope.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
 import { createInterface } from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
@@ -56,7 +58,75 @@ export interface AgentBusClientOptions {
   fetchImpl?: typeof fetch;
 }
 
+export interface WorkspaceOptions {
+  root?: string;
+  hint?: string;
+}
+
+export interface AgentWorkspaceReceipt {
+  schema_version: 'aethermoor.bus.workspace_receipt.v1';
+  receipt: 'SCBE_WORKSPACE_READY=1';
+  workspace_id: string;
+  workspace_root: string;
+  created_at: string;
+  formation: {
+    schema_version: 'aethermoor.bus.workspace_formation.v1';
+    default_root: '.aethermoor-bus/workspaces';
+    folders: Array<{ path: string; purpose: string }>;
+  };
+  receipt_path: string;
+}
+
+export const WORKSPACE_FORMATION: AgentWorkspaceReceipt['formation'] = {
+  schema_version: 'aethermoor.bus.workspace_formation.v1',
+  default_root: '.aethermoor-bus/workspaces',
+  folders: [
+    { path: '00_inbox', purpose: 'raw drops, uploads, imports, unclassified files' },
+    { path: '10_work', purpose: 'active editable working files' },
+    { path: '20_receipts', purpose: 'governance verdicts, hashes, signatures, run receipts' },
+    { path: '30_exports', purpose: 'customer-ready packets and handoff bundles' },
+    { path: '40_refs', purpose: 'non-secret reference files and source notes' },
+    { path: '90_tmp', purpose: 'scratch files, deleted after offload verification' },
+  ],
+};
+
 const TASK_TYPES = new Set(['coding', 'review', 'research', 'governance', 'training', 'general']);
+
+function slugify(value: string): string {
+  return String(value || 'workspace')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48) || 'workspace';
+}
+
+function timestampId(date = new Date()): string {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+export function createAgentWorkspace(options: WorkspaceOptions = {}): AgentWorkspaceReceipt {
+  const baseRoot = path.resolve(options.root || WORKSPACE_FORMATION.default_root);
+  const workspaceId = `${timestampId()}-${slugify(options.hint || 'workspace')}-${crypto
+    .randomBytes(3)
+    .toString('hex')}`;
+  const workspaceRoot = path.join(baseRoot, workspaceId);
+  fs.mkdirSync(workspaceRoot, { recursive: true });
+  for (const folder of WORKSPACE_FORMATION.folders) {
+    fs.mkdirSync(path.join(workspaceRoot, folder.path), { recursive: true });
+  }
+  const payload: AgentWorkspaceReceipt = {
+    schema_version: 'aethermoor.bus.workspace_receipt.v1',
+    receipt: 'SCBE_WORKSPACE_READY=1',
+    workspace_id: workspaceId,
+    workspace_root: workspaceRoot,
+    created_at: new Date().toISOString(),
+    formation: WORKSPACE_FORMATION,
+    receipt_path: path.join(workspaceRoot, '20_receipts', 'workspace.json'),
+  };
+  fs.writeFileSync(payload.receipt_path, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return payload;
+}
 
 function normalizeTaskType(value: unknown): string {
   const taskType = String(value || 'general')

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.3.4 - 2026-05-14
+
+### Added
+
+- **`scbe workspace new [--hint <name>] [--json]`**: forwards to the agent-bus workspace formation command and emits `SCBE_WORKSPACE_READY=1` for a freshly-created local bus workspace.
+
+### Changed
+
+- **Bumped `scbe-agent-bus` dependency**: `^0.3.0 → ^0.3.1` for the workspace formation command.
+
 ## 4.3.3 - 2026-05-14
 
 ### Fixed

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -50,6 +50,7 @@ Agent bus (governed event routing — works against any scbe-agent-bus backend):
   scbe agent-bus serve --port 8787
   scbe agent-bus send --task "review changed files" --task-type review
   scbe agent-bus upgrade
+  scbe workspace new --hint customer-smoke --json
 
 Governance abacus (deterministic BigInt-only L12+L13 scoring — no float drift):
   scbe abacus run --d-h 0.4 --pd 0.1
@@ -802,6 +803,7 @@ const KNOWN_COMMANDS = [
   'liboqs',
   'history',
   'flow',
+  'workspace',
   'agent-bus',
   'agentbus',
   'abacus',
@@ -941,24 +943,25 @@ function runAbacus(args) {
 }
 
 function resolveAgentBusBin() {
+  const localFallback = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'agent-bus',
+    'bin',
+    'scbe-agent-bus.cjs'
+  );
+  try {
+    fs.accessSync(localFallback);
+    return localFallback;
+  } catch (_fallbackErr) {
+    // Continue to the installed package lookup below.
+  }
   try {
     const entry = require.resolve('scbe-agent-bus/package.json');
     return path.resolve(path.dirname(entry), 'bin', 'scbe-agent-bus.cjs');
   } catch (_err) {
-    const localFallback = path.resolve(
-      __dirname,
-      '..',
-      '..',
-      'agent-bus',
-      'bin',
-      'scbe-agent-bus.cjs'
-    );
-    try {
-      fs.accessSync(localFallback);
-      return localFallback;
-    } catch (_fallbackErr) {
-      return null;
-    }
+    return null;
   }
 }
 
@@ -1121,6 +1124,10 @@ if (argv[0] === 'shell') {
 
 if (argv[0] === 'flow') {
   runFlow(argv.slice(1));
+}
+
+if (argv[0] === 'workspace') {
+  runAgentBus(['workspace', ...argv.slice(1)]);
 }
 
 if (argv[0] === 'agent-bus' || argv[0] === 'agentbus') {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scbe-aethermoore-cli",
-  "version": "4.3.3",
-  "description": "Standalone CLI for SCBE-AETHERMOORE: GeoSeal tools, flow operator loop (plan/packetize/status/run-next/continue/report), liboqs proof receipts, agent-bus passthrough, tokenizer lanes, governance packets, web lookup, mechanical verification, governance abacus (BigInt L12+L13).",
+  "version": "4.3.4",
+  "description": "Standalone CLI for SCBE-AETHERMOORE: GeoSeal tools, flow operator loop (plan/packetize/status/run-next/continue/report), liboqs proof receipts, bus workspace formation, agent-bus passthrough, tokenizer lanes, governance packets, web lookup, mechanical verification, governance abacus (BigInt L12+L13).",
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT OR Apache-2.0",
   "type": "commonjs",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "scbe-aethermoore": "^4.1.0",
-    "scbe-agent-bus": "^0.3.0"
+    "scbe-agent-bus": "^0.3.1"
   },
   "keywords": [
     "scbe",

--- a/tests/system/test_agent_bus_workspace_cli.py
+++ b/tests/system/test_agent_bus_workspace_cli.py
@@ -1,0 +1,90 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_BUS = REPO_ROOT / "packages" / "agent-bus" / "bin" / "scbe-agent-bus.cjs"
+SCBE = REPO_ROOT / "packages" / "cli" / "bin" / "scbe.js"
+NPM = shutil.which("npm") or shutil.which("npm.cmd") or "npm"
+NODE = shutil.which("node") or shutil.which("node.exe") or "node"
+
+
+def build_agent_bus() -> None:
+    proc = subprocess.run(
+        [NPM, "run", "build"],
+        cwd=REPO_ROOT / "packages" / "agent-bus",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=120,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def assert_workspace_payload(payload: dict, root: Path) -> None:
+    assert payload["schema_version"] == "aethermoor.bus.workspace_receipt.v1"
+    assert payload["receipt"] == "SCBE_WORKSPACE_READY=1"
+    workspace_root = Path(payload["workspace_root"])
+    assert workspace_root.exists()
+    assert workspace_root.parent == root.resolve()
+    for folder in ["00_inbox", "10_work", "20_receipts", "30_exports", "40_refs", "90_tmp"]:
+        assert (workspace_root / folder).is_dir()
+    receipt_path = Path(payload["receipt_path"])
+    assert receipt_path == workspace_root / "20_receipts" / "workspace.json"
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["receipt"] == "SCBE_WORKSPACE_READY=1"
+
+
+def test_agent_bus_workspace_new_creates_formation(tmp_path: Path) -> None:
+    build_agent_bus()
+    workspace_root = tmp_path / "workspaces"
+    proc = subprocess.run(
+        [
+            NODE,
+            str(AGENT_BUS),
+            "workspace",
+            "new",
+            "--root",
+            str(workspace_root),
+            "--hint",
+            "customer-smoke",
+            "--json",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert_workspace_payload(json.loads(proc.stdout), workspace_root)
+
+
+def test_scbe_workspace_new_forwards_to_agent_bus(tmp_path: Path) -> None:
+    build_agent_bus()
+    workspace_root = tmp_path / "workspaces"
+    proc = subprocess.run(
+        [
+            NODE,
+            str(SCBE),
+            "workspace",
+            "new",
+            "--root",
+            str(workspace_root),
+            "--hint",
+            "cli-smoke",
+            "--json",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert_workspace_payload(json.loads(proc.stdout), workspace_root)


### PR DESCRIPTION
## Summary
- add `scbe-agent-bus workspace new [--root <path>] [--hint <name>] [--json]`
- create the canonical bus workspace formation: `00_inbox`, `10_work`, `20_receipts`, `30_exports`, `40_refs`, `90_tmp`
- write `SCBE_WORKSPACE_READY=1` receipt into `20_receipts/workspace.json`
- expose the same command through `scbe workspace new`
- publish `scbe-agent-bus@0.3.1` and `scbe-aethermoore-cli@4.3.4`

## Verification
- `npm run build` from root
- `npm run build` in `packages/agent-bus`
- `python -m pytest tests\system\test_agent_bus_workspace_cli.py -q` -> 2 passed
- `python -m pytest tests\system\test_agent_bus_workspace_cli.py tests\system\test_scbe_npm_cli_compiler.py -q` -> 10 passed
- `node packages\agent-bus\bin\scbe-agent-bus.cjs workspace new --root artifacts\tmp-workspaces --hint manual-smoke --json` -> `SCBE_WORKSPACE_READY=1`
- `node packages\cli\bin\scbe.js workspace new --root artifacts\tmp-workspaces --hint scbe-smoke --json` -> `SCBE_WORKSPACE_READY=1`
- `npm pack --dry-run --json` for agent-bus and CLI
- `npm publish --access public` for agent-bus and CLI
- fresh temp install of `scbe-aethermoore-cli@4.3.4` -> `scbe workspace new` creates receipt
- `git diff --check`

## Rollback
- revert this commit; deprecate `scbe-agent-bus@0.3.1` and `scbe-aethermoore-cli@4.3.4` if needed. The prior releases remain usable.