### PR TITLE
ci(pypi): allow PYPI_API_TOKEN fallback for scbe-aethermoore publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -42,9 +42,12 @@ jobs:
         if: env.skip_pypi != 'true'
         run: python -m build
 
-      - name: Publish to PyPI (Trusted Publisher)
+      - name: Publish to PyPI (Trusted Publisher or API token fallback)
         if: env.skip_pypi != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
-        # Requires PyPI Trusted Publishing to be configured for this repo + workflow.
-        # If not configured, this step will fail and you can fall back to API-token
-        # publishing by setting secrets.PYPI_API_TOKEN and using the `password` input.
+        with:
+          # When PYPI_API_TOKEN is set on the repo, the action authenticates with the
+          # token; otherwise it falls back to OIDC Trusted Publishing. The token path
+          # is in place because the project does not yet have a PyPI Trusted Publisher
+          # entry configured for scbe-aethermoore.
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Why

Trusted Publisher entry for `scbe-aethermoore` on pypi.org isn't configured yet, so the v4.1.3 publish workflow run (#25890086493) failed with `invalid-publisher`. Adding `password: secrets.PYPI_API_TOKEN` lets the same workflow authenticate via API token when the secret is present and continue to fall back to OIDC if it isn't.

## Scope

- `.github/workflows/pypi-publish.yml` only — 1 file, 7 insertions, 4 deletions
- `pypi-publish-agent-bus.yml` is **not** touched: agent-bus already has a working Trusted Publisher entry (`environment: release-agent-bus`)

## Next step after merge

```bash
gh workflow run pypi-publish.yml -f tag=v4.1.3
```

The v4.1.3 tag + GH release are already live on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)