### PR TITLE
ci(smoke): add trap-dispatch + free-llm surfaces to PR-gated python smoke lane

### DIFF
--- a/scripts/system/run_core_python_checks.py
+++ b/scripts/system/run_core_python_checks.py
@@ -13,6 +13,12 @@ ARTIFACT_DIR = REPO_ROOT / "artifacts" / "system-audit"
 
 # Fast, deterministic smoke lane for PR gating. This should finish quickly on
 # GitHub-hosted runners and avoid pulling in long-running "everything tests".
+#
+# When you add a new product surface, add the test path here so regressions
+# get caught on PR rather than discovered post-merge. The PR #1700
+# `_public_dispatch_payload` regression that stripped `bus_event.version`
+# from the public free-llm response sat undetected on main for two days
+# because `tests/api/test_free_llm_routes.py` wasn't in this list.
 CORE_SMOKE_PATHS: tuple[str, ...] = (
     "tests/test_api_header_compat.py",
     "tests/test_geoseal_v2.py",
@@ -24,6 +30,12 @@ CORE_SMOKE_PATHS: tuple[str, ...] = (
     "tests/test_semantic_projector_deep.py",
     "tests/test_triangulated_lattice.py",
     "tests/crypto",
+    # Active product surfaces — keep these in PR-gated CI.
+    "tests/api/test_free_llm_routes.py",
+    "tests/system/test_agent_bus_workspace_cli.py",
+    "tests/system/test_trap_redirect_cli.py",
+    "tests/system/test_trap_dispatch_cli.py",
+    "tests/system/test_trap_dispatch_workspace_cli.py",
 )
 
 # Optional or experimental lanes that currently pull in extra services,


### PR DESCRIPTION
## Why

PR #1700 (`fix(security): tighten public service responses`) stripped `bus_event.version` + `result.fallback_from` from the public free-llm response and sat undetected on main for 2 days because the offending test (`tests/api/test_free_llm_routes.py`) wasn't in `CORE_SMOKE_PATHS`. I caught it on a manual full-tests pass during the v4.1.3 outside-reviewer audit.

## What

Adds 5 active product surfaces to the PR-gated smoke lane:

- `tests/api/test_free_llm_routes.py` — the surface that broke
- `tests/system/test_agent_bus_workspace_cli.py` — workspace audit chain
- `tests/system/test_trap_redirect_cli.py` — input-side trap inspector
- `tests/system/test_trap_dispatch_cli.py` — free-only LLM dispatch
- `tests/system/test_trap_dispatch_workspace_cli.py` — workspace + batch

## Cost

Local run: **887 passed / 19 skipped in 241s (~4 min)**. Acceptable for PR-gated CI on github-hosted runners. The original smoke was leaner but missed this surface entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)