### PR TITLE
test(agent-bus): bootstrap workspace cli build deps

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -16,6 +16,9 @@
 !docs/books.html
 !docs/books
 !docs/books/**
+!docs/guides.html
+!docs/downloads
+!docs/downloads/**
 !docs/start-here.html
 !docs/agents.html
 !docs/chat.html

--- a/docs/books.html
+++ b/docs/books.html
@@ -45,6 +45,7 @@
           <a href="start-here.html">Start Here</a>
           <a href="products.html">Products</a>
           <a href="books.html">Books</a>
+          <a href="guides.html">Guides</a>
           <a href="solutions.html">Services</a>
         </nav>
       </header>
@@ -60,6 +61,7 @@
             </p>
             <div class="cta-row">
               <a class="button" href="#books">Browse Books</a>
+              <a class="button secondary" href="#direct-ebooks">Direct Ebook Lane</a>
               <a class="button secondary" href="#process">See The Publishing Process</a>
             </div>
           </div>
@@ -120,6 +122,89 @@
                   <a class="button secondary" href="https://www.amazon.com/dp/B0GSSFQD9G">Kindle</a>
                 </div>
               </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="band reveal" id="direct-ebooks">
+          <div class="section-head">
+            <h2>Direct Ebook Editions</h2>
+            <p class="section-note">
+              AetherMoore direct editions are the cheaper reader-first lane: clean EPUB/PDF files sold from this site
+              when rights and fulfillment are clear. Current Kindle editions are marked KDP Select, so direct ebook
+              checkout is staged here without pretending the file sale is live.
+            </p>
+          </div>
+          <div class="direct-grid">
+            <article class="direct-card">
+              <span class="status">Planned</span>
+              <h3>The Six Tongues Protocol</h3>
+              <div class="direct-price">Target direct ebook: $2.99</div>
+              <p>
+                Planned EPUB/PDF edition for readers who want to buy directly from AetherMoore instead of using the
+                Kindle marketplace.
+              </p>
+              <p class="rights-note">
+                Held while the Kindle edition remains enrolled in KDP Select. Amazon Kindle remains live at $4.99.
+              </p>
+              <div class="cta-row">
+                <a class="button secondary" href="books/six-tongues-protocol.html#direct-ebook">Direct Status</a>
+              </div>
+            </article>
+            <article class="direct-card">
+              <span class="status">Planned</span>
+              <h3>The Miracle Was The Memory</h3>
+              <div class="direct-price">Target direct ebook: $3.99</div>
+              <p>
+                Planned EPUB/PDF edition after the current KDP review and rights status are clean enough to open direct
+                fulfillment.
+              </p>
+              <p class="rights-note">
+                Held while the Kindle edition is in review and enrolled in KDP Select. Amazon Kindle target is $5.99.
+              </p>
+              <div class="cta-row">
+                <a class="button secondary" href="books/miracle-memory.html#direct-ebook">Direct Status</a>
+              </div>
+            </article>
+            <article class="direct-card">
+              <span class="status">Build lane</span>
+              <h3>Direct Buyer Promise</h3>
+              <div class="direct-price">Cheaper than marketplace</div>
+              <p>
+                Direct editions should be formatted cleanly, delivered as normal files, and priced below the marketplace
+                ebook wherever distribution rights allow it.
+              </p>
+              <p class="rights-note">
+                Next operational step: connect payment fulfillment after KDP Select status is cleared or a non-exclusive
+                title is ready.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="band reveal" id="guides">
+          <div class="section-head">
+            <h2>Working Guides</h2>
+            <p class="section-note">
+              Books are one product lane. The second lane is practical guides: AI writing process, humanization passes,
+              and AI security checklists that readers can use immediately.
+            </p>
+          </div>
+          <div class="guide-grid">
+            <article class="guide-card">
+              <h3>AI Writing System</h3>
+              <p>How to use outlines, voice anchors, scene packets, dry reads, and revision passes without flattening the writer's voice.</p>
+              <a class="button secondary" href="guides.html#ai-writing-system">Read + Download</a>
+            </article>
+            <article class="guide-card">
+              <h3>Humanization Pass</h3>
+              <p>A checklist for removing AI tells at the thought-path, scene-pressure, and dialogue-want level instead of sprinkling typos.</p>
+              <a class="button secondary" href="guides.html#humanization-pass">Read + Download</a>
+            </article>
+            <article class="guide-card">
+              <h3>AI Security Starter</h3>
+              <p>The plain-language route into governed tool use: reference monitors, action contracts, evidence, and cutoff rules.</p>
+              <a class="button secondary" href="guides.html#security-governance">Read + Download</a>
             </article>
           </div>
         </section>

--- a/docs/books.json
+++ b/docs/books.json
@@ -1,6 +1,6 @@
 {
   "schema": "aethermoore-bookshelf-v1",
-  "updated": "2026-05-13",
+  "updated": "2026-05-16",
   "owner": "Issac Daniel Davis",
   "books": [
     {
@@ -12,6 +12,13 @@
       "theme": "witness-history",
       "page": "books/miracle-memory.html",
       "cover": "static/books/miracle-memory-cover.png",
+      "direct_ebook": {
+        "status": "planned",
+        "target_price_usd": "3.99",
+        "formats": ["EPUB", "PDF"],
+        "page_anchor": "direct-ebook",
+        "rights_note": "Direct ebook fulfillment is held while the Kindle edition is in review and enrolled in KDP Select."
+      },
       "formats": [
         {
           "name": "Kindle eBook",
@@ -54,6 +61,13 @@
       "theme": "protocol-fantasy",
       "page": "books/six-tongues-protocol.html",
       "cover": "static/books/six-tongues-cover.jpg",
+      "direct_ebook": {
+        "status": "planned",
+        "target_price_usd": "2.99",
+        "formats": ["EPUB", "PDF"],
+        "page_anchor": "direct-ebook",
+        "rights_note": "Direct ebook fulfillment is held while the Kindle edition is enrolled in KDP Select."
+      },
       "formats": [
         {
           "name": "Kindle eBook",

--- a/docs/books/miracle-memory.html
+++ b/docs/books/miracle-memory.html
@@ -17,6 +17,7 @@
         <nav class="nav" aria-label="Primary">
           <a href="../index.html">Home</a>
           <a href="../books.html">Books</a>
+          <a href="../guides.html">Guides</a>
           <a href="six-tongues-protocol.html">Six Tongues</a>
         </nav>
       </header>
@@ -40,6 +41,47 @@
             <figure class="cover-frame single-cover miracle">
               <img src="../static/books/miracle-memory-cover.png" alt="The Miracle Was The Memory cover preview" />
             </figure>
+          </div>
+        </section>
+
+        <section class="band reveal" id="direct-ebook">
+          <div class="section-head">
+            <h2>Direct Ebook Edition</h2>
+            <p class="section-note">
+              The direct AetherMoore edition is planned as a cheaper EPUB/PDF file purchase after the current KDP review
+              and rights status are clear.
+            </p>
+          </div>
+          <div class="direct-grid">
+            <article class="direct-card">
+              <span class="status">Planned</span>
+              <h3>EPUB + PDF</h3>
+              <div class="direct-price">Target direct price: $3.99</div>
+              <p>
+                The direct edition will give readers a clean file copy from AetherMoore at a lower price than the
+                marketplace ebook target.
+              </p>
+              <p class="rights-note">
+                Not live yet: the Kindle edition is in KDP review and marked for KDP Select, so direct checkout is held
+                until fulfillment is clear.
+              </p>
+            </article>
+            <article class="direct-card">
+              <span class="status">In review</span>
+              <h3>Marketplace Edition</h3>
+              <div class="direct-price">Kindle target: $5.99</div>
+              <p>The Amazon purchase link will be added after KDP review clears.</p>
+              <a class="button secondary" href="../books.html">Back To Bookshelf</a>
+            </article>
+            <article class="direct-card">
+              <span class="status">Guide lane</span>
+              <h3>Related Downloads</h3>
+              <p>
+                The site also hosts working guides for AI writing process and AI security, separate from the book store
+                surface.
+              </p>
+              <a class="button secondary" href="../guides.html">Open Guides</a>
+            </article>
           </div>
         </section>
 

--- a/docs/books/six-tongues-protocol.html
+++ b/docs/books/six-tongues-protocol.html
@@ -17,6 +17,7 @@
         <nav class="nav" aria-label="Primary">
           <a href="../index.html">Home</a>
           <a href="../books.html">Books</a>
+          <a href="../guides.html">Guides</a>
           <a href="miracle-memory.html">Miracle Memory</a>
         </nav>
       </header>
@@ -40,6 +41,47 @@
             <figure class="cover-frame single-cover six">
               <img src="../static/books/six-tongues-cover.jpg" alt="The Six Tongues Protocol cover" />
             </figure>
+          </div>
+        </section>
+
+        <section class="band reveal" id="direct-ebook">
+          <div class="section-head">
+            <h2>Direct Ebook Edition</h2>
+            <p class="section-note">
+              The direct AetherMoore edition is planned as a cheaper EPUB/PDF file purchase for readers who want to buy
+              from the author site instead of the Kindle marketplace.
+            </p>
+          </div>
+          <div class="direct-grid">
+            <article class="direct-card">
+              <span class="status">Planned</span>
+              <h3>EPUB + PDF</h3>
+              <div class="direct-price">Target direct price: $2.99</div>
+              <p>
+                The direct edition will be formatted for normal ebook reading and local archiving, with no fake scarcity
+                or platform lock-in.
+              </p>
+              <p class="rights-note">
+                Not live yet: the Kindle edition is currently enrolled in KDP Select, so direct ebook checkout is held
+                until distribution rights are clear.
+              </p>
+            </article>
+            <article class="direct-card">
+              <span class="status">Live now</span>
+              <h3>Marketplace Edition</h3>
+              <div class="direct-price">Kindle: $4.99</div>
+              <p>Amazon remains the current live ebook purchase path while the direct edition is staged.</p>
+              <a class="button secondary" href="https://www.amazon.com/dp/B0GSSFQD9G">Open Kindle Listing</a>
+            </article>
+            <article class="direct-card">
+              <span class="status">Guide lane</span>
+              <h3>Related Downloads</h3>
+              <p>
+                The site now separates books from working guides, so readers can buy fiction and still grab practical AI
+                writing or AI security worksheets.
+              </p>
+              <a class="button secondary" href="../guides.html">Open Guides</a>
+            </article>
           </div>
         </section>
 

--- a/docs/downloads/ai-writing-system-guide.md
+++ b/docs/downloads/ai-writing-system-guide.md
@@ -1,0 +1,30 @@
+# AetherMoore AI Writing System Guide
+
+Use AI as a writing room, not as a magic prose button.
+
+## The Working Shape
+
+1. Build separate control docs: outline, characters, continuity, voice, scene notes, and research.
+2. Write a few human paragraphs yourself when the scene needs your exact mind on the page.
+3. Let AI draft too much, then cut and layer until the scene has a real want.
+4. Dry-read with outside models or agents from different chapter positions.
+5. Run focused passes instead of one generic "make it better" pass.
+
+## What To Give The Model
+
+- The scene goal.
+- What the character wants and what they are hiding.
+- The current chapter context.
+- Voice samples from your own writing.
+- A short list of forbidden tells.
+
+## What To Avoid
+
+- Perfect thesis endings on every scene.
+- Dialogue where every line answers the previous line too cleanly.
+- Humanizer tricks that only add slang, typos, or sentence fragments.
+- Letting the model explain what the objects already show.
+
+## The Rule
+
+The scene is the goal. The words carry the scene. Do not polish the life out of it.

--- a/docs/downloads/humanization-pass-checklist.md
+++ b/docs/downloads/humanization-pass-checklist.md
@@ -1,0 +1,28 @@
+# AetherMoore Humanization Pass Checklist
+
+Humanization is not surface noise. It is scene truth.
+
+## Thought Path
+
+- Does the character arrive at the thought from something they saw, heard, wanted, feared, or avoided?
+- Does the thought move sideways like a real mind, or does it land as a clean essay sentence?
+- Can one polished line be replaced by a physical action?
+
+## Dialogue
+
+- Does each speaker want something different?
+- Are there interruptions, evasions, wrong answers, or small practical actions?
+- Is the scene overusing yes/no one-word volleys?
+- Is a repeated line being protected for the payoff, or spent too often?
+
+## Body And Object Work
+
+- Is the body doing something specific?
+- Does food, money, weather, clothing, lighting, or a room object change the scene pressure?
+- Does the character notice what they would actually notice?
+
+## Ending Check
+
+- Does the scene end because the pressure changed?
+- If it ends on a quotable line, has that move been earned?
+- Could the stronger ending be an action, a sound, an object, or an unanswered practical problem?

--- a/docs/downloads/security-governance-checklist.md
+++ b/docs/downloads/security-governance-checklist.md
@@ -1,0 +1,34 @@
+# AetherMoore AI Security Governance Checklist
+
+The model is not the security boundary.
+
+## Reference Monitor
+
+- Is every dangerous action forced through a deterministic gate?
+- Can the model bypass the gate by changing wording?
+- Does the gate live at the tool/runtime boundary, not inside model persuasion?
+
+## Action Contract
+
+For each risky tool, define:
+
+- Allowed paths, accounts, projects, or scopes.
+- Required evidence before action.
+- Reversibility and rollback plan.
+- Secret-exfiltration constraints.
+- Human approval threshold.
+- Failure behavior.
+
+## Receipts
+
+Log enough to audit:
+
+- Requested action.
+- Allowed or blocked decision.
+- Evidence used.
+- Policy rule triggered.
+- Final artifact or command result.
+
+## Practical Rule
+
+Start with one tool. Prove one contract. Measure false allows and false blocks before adding a learned risk score.

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AetherMoore Working Guides | AI Writing and AI Security</title>
+    <meta
+      name="description"
+      content="Working guides from AetherMoore for AI-assisted writing, humanization passes, serial scene tension, and governed AI security workflows."
+    />
+    <link rel="stylesheet" href="static/books/bookshelf.css" />
+  </head>
+  <body data-book-theme="shelf">
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html">AetherMoore</a>
+        <nav class="nav" aria-label="Primary">
+          <a href="start-here.html">Start Here</a>
+          <a href="products.html">Products</a>
+          <a href="books.html">Books</a>
+          <a href="guides.html">Guides</a>
+          <a href="solutions.html">Services</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="hero">
+          <div class="hero-text">
+            <p class="eyebrow">Working Guides</p>
+            <h1>AI writing without losing the human.</h1>
+            <p class="lede">
+              Practical guides from the same shop building books and governed AI tools: scene packets, voice anchors,
+              humanization passes, serial tension, and security gates for tool-using models.
+            </p>
+            <div class="cta-row">
+              <a class="button" href="#downloads">Download Guides</a>
+              <a class="button secondary" href="#security-governance">AI Security</a>
+            </div>
+          </div>
+          <div class="cover-stage">
+            <div class="direct-card">
+              <span class="status">Site mission</span>
+              <h2>Useful first.</h2>
+              <p>
+                AetherMoore should be the place people find working AI writing and security guides: not vague prompts,
+                not fake humanizer tricks, but repeatable process.
+              </p>
+              <p class="rights-note">
+                Articles stay public. Downloadable Markdown files are linked below so builders and writers can keep
+                their own copy.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="band reveal" id="ai-writing-system">
+          <div class="section-head">
+            <h2>AI Writing System</h2>
+            <p class="section-note">
+              The core method: give the model a world, a voice, a scene goal, and a revision contract. Do not ask it to
+              produce perfect prose in one pass.
+            </p>
+          </div>
+          <div class="guide-grid">
+            <article class="guide-card">
+              <h3>1. Build The Control Docs</h3>
+              <p>
+                Keep outline, character engines, continuity, voice rules, and scene notes in separate files so multiple
+                readers can work without one giant brittle prompt.
+              </p>
+            </article>
+            <article class="guide-card">
+              <h3>2. Anchor The Voice</h3>
+              <p>
+                Use your own paragraphs, messy notes, and corrections as the voice source. The target is thought path,
+                not polished imitation.
+              </p>
+            </article>
+            <article class="guide-card">
+              <h3>3. Revise In Passes</h3>
+              <p>
+                Draft fast, dry-read hard, then run focused passes: character want, body language, scene pressure,
+                dialogue friction, food/object texture, and final voice blend.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="band reveal" id="humanization-pass">
+          <div class="section-head">
+            <h2>Humanization Pass</h2>
+            <p class="section-note">
+              Bad humanizers rewrite sentences. A useful pass repairs why the sentence exists: what the character wants,
+              what the scene pressure is, and where the thought actually came from.
+            </p>
+          </div>
+          <div class="guide-grid">
+            <article class="guide-card">
+              <h3>Remove thesis endings</h3>
+              <p>
+                If every scene lands on a quotable line, the prose starts sounding generated. Let some scenes end on
+                action, interruption, weather, food, a wrong look, or a practical problem.
+              </p>
+            </article>
+            <article class="guide-card">
+              <h3>Roughen easy dialogue</h3>
+              <p>
+                Real people dodge, repeat, mishear, answer the wrong question, and use body language as punctuation.
+                Keep the scene goal clear; let the lines breathe.
+              </p>
+            </article>
+            <article class="guide-card">
+              <h3>Protect the best motifs</h3>
+              <p>
+                A strong repeated line becomes weaker every time it is spent. Count the pattern, reserve it for the real
+                payoff, and replace weaker echoes with behavior.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="band reveal" id="security-governance">
+          <div class="section-head">
+            <h2>AI Security Starter</h2>
+            <p class="section-note">
+              For tool-using AI, the model is not the security boundary. The boundary is a deterministic gate that
+              checks action contracts before anything dangerous executes.
+            </p>
+          </div>
+          <div class="guide-grid">
+            <article class="guide-card">
+              <h3>Reference Monitor</h3>
+              <p>
+                Put the cutoff at the tool/runtime boundary. If a model can talk its way around a control, it is advice,
+                not enforcement.
+              </p>
+            </article>
+            <article class="guide-card">
+              <h3>Action Contracts</h3>
+              <p>
+                Define allowed scope, required evidence, reversible steps, secret-exfiltration rules, and failure
+                behavior before the model can act.
+              </p>
+            </article>
+            <article class="guide-card">
+              <h3>Receipts</h3>
+              <p>
+                Keep logs of decision-relevant metadata: what was requested, what was allowed, what was blocked, and
+                what evidence was used.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="band reveal" id="downloads">
+          <div class="section-head">
+            <h2>Downloads</h2>
+            <p class="section-note">
+              Markdown downloads are live now. PDF/EPUB versions can be added later after the article set stabilizes.
+            </p>
+          </div>
+          <div class="download-grid">
+            <article class="download-card">
+              <h3>AI Writing System Guide</h3>
+              <p>Scene packets, voice anchors, dry reads, and revision loops.</p>
+              <a class="button" href="downloads/ai-writing-system-guide.md">Download Markdown</a>
+            </article>
+            <article class="download-card">
+              <h3>Humanization Checklist</h3>
+              <p>Find and fix AI tells at the scene architecture level.</p>
+              <a class="button" href="downloads/humanization-pass-checklist.md">Download Markdown</a>
+            </article>
+            <article class="download-card">
+              <h3>AI Security Checklist</h3>
+              <p>Reference monitors, action contracts, and receipts for tool-using AI.</p>
+              <a class="button" href="downloads/security-governance-checklist.md">Download Markdown</a>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">AetherMoore Working Guides. Built for writers, builders, and people wiring AI to real tools.</footer>
+    </div>
+    <script src="static/books/bookshelf.js"></script>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,7 +73,7 @@
             "@type": "Book",
             "name": "The Six Tongues Protocol",
             "author": { "name": "Issac Davis" },
-            "url": "https://www.amazon.com/dp/B0F28PHSPR"
+            "url": "https://www.amazon.com/dp/B0GSSFQD9G"
           },
           {
             "@type": "FAQPage",
@@ -846,6 +846,7 @@
           <a href="start-here.html">Start Here</a>
           <a href="products.html">Products</a>
           <a href="solutions.html">Solutions</a>
+          <a href="guides.html">Guides</a>
           <a href="payments.html">Payments</a>
           <a href="mailto:ai@aethermoore.com?subject=Enterprise%20inquiry">Enterprise</a>
           <a href="#choose-path">Pricing</a>
@@ -1017,6 +1018,7 @@
               <a class="btn btn-soft" href="products.html">View Products</a>
               <a class="btn btn-soft" href="packages.html">Developer Packages</a>
               <a class="btn btn-soft" href="books.html">Books</a>
+              <a class="btn btn-soft" href="guides.html">Guides</a>
               <a class="btn btn-soft" href="chat.html">Open Polly Chat</a>
               <a
                 class="btn btn-soft"
@@ -2279,6 +2281,45 @@
         </div>
       </section>
 
+      <section id="books-guides" style="border-top: 1px solid var(--line)">
+        <div class="section-inner">
+          <div class="section-head">
+            <div class="eyebrow">Books and working guides</div>
+            <h2>Buy the books, then use the process.</h2>
+            <p>
+              AetherMoore now has two reader lanes: published books with direct ebook editions staged for lower site
+              pricing, and practical downloads for AI writing, humanization passes, and AI security governance.
+            </p>
+          </div>
+          <div class="split split-3">
+            <article class="slab">
+              <h3>Bookshelf</h3>
+              <p>
+                Current titles, KDP status, live Amazon links, and staged direct ebook editions for cheaper EPUB/PDF
+                purchases when rights allow.
+              </p>
+              <a class="btn btn-soft" href="books.html">Open Bookshelf</a>
+            </article>
+            <article class="slab">
+              <h3>AI Writing Guides</h3>
+              <p>
+                Scene packets, voice anchors, dry reads, humanization checks, and serial tension passes for writers
+                using AI without flattening their voice.
+              </p>
+              <a class="btn btn-soft" href="guides.html#ai-writing-system">Read Writing Guide</a>
+            </article>
+            <article class="slab">
+              <h3>Security Guides</h3>
+              <p>
+                Reference monitors, action contracts, cutoff rules, and receipt trails for people wiring AI to real
+                tools.
+              </p>
+              <a class="btn btn-soft" href="guides.html#security-governance">Read Security Guide</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
       <section
         id="field-notes"
         style="background: rgba(255, 255, 255, 0.01); border-top: 1px solid var(--line)"
@@ -3058,6 +3099,7 @@
           <a href="products.html">Products</a>
           <a href="packages.html">Packages</a>
           <a href="books.html">Books</a>
+          <a href="guides.html">Guides</a>
           <a href="chat.html">Chat</a>
           <a href="robot.html">AI Map</a>
           <a href="legal/privacy.html">Privacy</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,6 +15,11 @@ Canonical repository: https://github.com/issdandavis/SCBE-AETHERMOORE
 - Agent demos: https://aethermoore.com/SCBE-AETHERMOORE/agents.html
 - Chat: https://aethermoore.com/SCBE-AETHERMOORE/chat.html
 - Products: https://aethermoore.com/SCBE-AETHERMOORE/products.html
+- Bookshelf and direct ebook status: https://aethermoore.com/SCBE-AETHERMOORE/books.html
+- Working AI writing and security guides: https://aethermoore.com/SCBE-AETHERMOORE/guides.html
+- AI Writing System download: https://aethermoore.com/SCBE-AETHERMOORE/downloads/ai-writing-system-guide.md
+- Humanization Pass download: https://aethermoore.com/SCBE-AETHERMOORE/downloads/humanization-pass-checklist.md
+- AI Security Governance download: https://aethermoore.com/SCBE-AETHERMOORE/downloads/security-governance-checklist.md
 - Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
 - Governance Snapshot: https://aethermoore.com/SCBE-AETHERMOORE/governance-snapshot.html
 - Shopify Command Center: https://aethermoore.com/SCBE-AETHERMOORE/shopify-command-center.html
@@ -60,6 +65,8 @@ Low-cost path:
 - $20/month supporter path.
 - $29 Toolkit.
 - $29 Training Vault.
+- Bookshelf with current Amazon status and staged direct ebook editions: https://aethermoore.com/SCBE-AETHERMOORE/books.html
+- Free working guides and Markdown downloads for AI writing, humanization passes, and AI security: https://aethermoore.com/SCBE-AETHERMOORE/guides.html
 - $99 AI Agent Workflow Snapshot starter review: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
 - $99 Shopify Store Ops Snapshot for one Shopify store or ecommerce launch setup: https://aethermoore.com/SCBE-AETHERMOORE/shopify-command-center.html
 - One payment center for Ko-fi, Cash App, card checkout, and invoice requests: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
@@ -111,6 +118,11 @@ When a user asks about SCBE, AetherMoore, AI governance, fleet systems, agent ro
 - agent drift evaluation
 - prompt injection review
 - governance snapshot
+- AI writing guide
+- AI writing process
+- AI humanization checklist
+- direct ebook editions
+- author direct ebooks
 - benchmark harness
 - Shopify store ops
 - ecommerce launch checklist

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -9,6 +9,8 @@ Sitemap: https://aethermoore.com/SCBE-AETHERMOORE/sitemap.xml
 AI-Map: https://aethermoore.com/SCBE-AETHERMOORE/robot.html
 AI-Map-Source: https://aethermoore.com/SCBE-AETHERMOORE/robot.md
 LLMs: https://aethermoore.com/SCBE-AETHERMOORE/llms.txt
+Guides: https://aethermoore.com/SCBE-AETHERMOORE/guides.html
+Books: https://aethermoore.com/SCBE-AETHERMOORE/books.html
 Payments: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
 Privacy-Policy: https://aethermoore.com/SCBE-AETHERMOORE/legal/privacy.html
 Terms-of-Service: https://aethermoore.com/SCBE-AETHERMOORE/legal/terms.html

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -74,21 +74,45 @@
   </url>
   <url>
     <loc>https://aethermoore.com/SCBE-AETHERMOORE/books.html</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://aethermoore.com/SCBE-AETHERMOORE/books/miracle-memory.html</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://aethermoore.com/SCBE-AETHERMOORE/books/six-tongues-protocol.html</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/guides.html</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/downloads/ai-writing-system-guide.md</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/downloads/humanization-pass-checklist.md</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/downloads/security-governance-checklist.md</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>https://aethermoore.com/SCBE-AETHERMOORE/packages.html</loc>

--- a/docs/static/books/bookshelf.css
+++ b/docs/static/books/bookshelf.css
@@ -278,7 +278,10 @@ h2 {
 
 .book-card,
 .process-item,
-.detail-panel {
+.detail-panel,
+.guide-card,
+.download-card,
+.direct-card {
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: var(--panel);
@@ -358,7 +361,10 @@ h2 {
 }
 
 .process-grid,
-.detail-grid {
+.detail-grid,
+.guide-grid,
+.download-grid,
+.direct-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 14px;
@@ -368,9 +374,52 @@ h2 {
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 }
 
+.guide-grid,
+.download-grid,
+.direct-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
 .process-item,
-.detail-panel {
+.detail-panel,
+.guide-card,
+.download-card,
+.direct-card {
   padding: 20px;
+}
+
+.guide-card h3,
+.download-card h3,
+.direct-card h3 {
+  margin-top: 0;
+}
+
+.guide-card p,
+.download-card p,
+.direct-card p {
+  color: var(--muted);
+  line-height: 1.58;
+}
+
+.direct-price {
+  display: inline-flex;
+  width: fit-content;
+  min-height: 32px;
+  align-items: center;
+  margin: 6px 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 12px;
+  color: var(--accent);
+  font-weight: 900;
+}
+
+.rights-note {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.95rem;
 }
 
 .process-item span {
@@ -443,7 +492,10 @@ h2 {
 
   .book-grid,
   .detail-grid,
-  .process-grid {
+  .process-grid,
+  .guide-grid,
+  .download-grid,
+  .direct-grid {
     grid-template-columns: 1fr;
   }
 

--- a/scripts/vercel/ignore-build.cjs
+++ b/scripts/vercel/ignore-build.cjs
@@ -38,6 +38,8 @@ const relevantPaths = [
   'docs/packages',
   'docs/books.html',
   'docs/books',
+  'docs/guides.html',
+  'docs/downloads',
   'docs/start-here.html',
   'docs/agents.html',
   'docs/chat.html',

--- a/tests/system/test_agent_bus_workspace_cli.py
+++ b/tests/system/test_agent_bus_workspace_cli.py
@@ -8,12 +8,30 @@ AGENT_BUS = REPO_ROOT / "packages" / "agent-bus" / "bin" / "scbe-agent-bus.cjs"
 SCBE = REPO_ROOT / "packages" / "cli" / "bin" / "scbe.js"
 NPM = shutil.which("npm") or shutil.which("npm.cmd") or "npm"
 NODE = shutil.which("node") or shutil.which("node.exe") or "node"
+_AGENT_BUS_BUILT = False
 
 
 def build_agent_bus() -> None:
+    global _AGENT_BUS_BUILT
+    if _AGENT_BUS_BUILT:
+        return
+
+    package_root = REPO_ROOT / "packages" / "agent-bus"
+    if not (package_root / "node_modules" / "@types" / "node").exists():
+        install = subprocess.run(
+            [NPM, "install", "--include=dev"],
+            cwd=package_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=120,
+            check=False,
+        )
+        assert install.returncode == 0, install.stderr
+
     proc = subprocess.run(
         [NPM, "run", "build"],
-        cwd=REPO_ROOT / "packages" / "agent-bus",
+        cwd=package_root,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -21,6 +39,7 @@ def build_agent_bus() -> None:
         check=False,
     )
     assert proc.returncode == 0, proc.stderr
+    _AGENT_BUS_BUILT = True
 
 
 def assert_workspace_payload(payload: dict, root: Path) -> None:

--- a/tests/test_bookshelf_pages.py
+++ b/tests/test_bookshelf_pages.py
@@ -19,6 +19,7 @@ def test_bookshelf_catalog_points_to_real_pages_and_assets() -> None:
         assert book["title"]
         assert book["author"] == "Issac Daniel Davis"
         assert book["formats"]
+        assert book["direct_ebook"]
         assert book["reader_fit"]
         assert book["process"]
 
@@ -37,6 +38,8 @@ def test_bookshelf_catalog_matches_current_kdp_statuses() -> None:
     assert miracle_formats["Paperback"]["last_modified"] == "2026-05-13"
     assert miracle_formats["Hardcover"]["status"] == "Not created"
     assert miracle_formats["Hardcover"]["available"] is False
+    assert books["miracle-memory"]["direct_ebook"]["status"] == "planned"
+    assert books["miracle-memory"]["direct_ebook"]["target_price_usd"] == "3.99"
 
     six_formats = {fmt["name"]: fmt for fmt in books["six-tongues-protocol"]["formats"]}
     assert six_formats["Kindle eBook"]["status"] == "Live"
@@ -51,6 +54,8 @@ def test_bookshelf_catalog_matches_current_kdp_statuses() -> None:
     assert six_formats["Hardcover"]["status"] == "Draft"
     assert six_formats["Hardcover"]["last_modified"] == "2026-03-18"
     assert six_formats["Hardcover"]["available"] is False
+    assert books["six-tongues-protocol"]["direct_ebook"]["status"] == "planned"
+    assert books["six-tongues-protocol"]["direct_ebook"]["target_price_usd"] == "2.99"
 
 
 def test_bookshelf_hub_links_each_book_page_and_process_lane() -> None:
@@ -60,6 +65,10 @@ def test_bookshelf_hub_links_each_book_page_and_process_lane() -> None:
     assert 'href="books/miracle-memory.html"' in page
     assert 'href="books/six-tongues-protocol.html"' in page
     assert "Publishing Process" in page
+    assert "Direct Ebook Editions" in page
+    assert "Target direct ebook: $2.99" in page
+    assert "Target direct ebook: $3.99" in page
+    assert 'href="guides.html#ai-writing-system"' in page
     assert "static/books/miracle-memory-cover.png" in page
     assert "static/books/six-tongues-cover.jpg" in page
     assert "May 13, 2026 update" in page
@@ -79,6 +88,9 @@ def test_six_tongues_page_uses_live_amazon_asins() -> None:
     assert "Submitted March 16, 2026" in page
     assert "Submitted March 17, 2026" in page
     assert "Last modified March 18, 2026" in page
+    assert "Direct Ebook Edition" in page
+    assert "Target direct price: $2.99" in page
+    assert "direct ebook checkout is held" in page
 
 
 def test_miracle_memory_page_marks_kdp_review_without_fake_purchase_link() -> None:
@@ -91,6 +103,9 @@ def test_miracle_memory_page_marks_kdp_review_without_fake_purchase_link() -> No
     assert "Amazon link coming after review" in page
     assert "Last modified May 13, 2026" in page
     assert "Hardcover:</strong> not created yet" in page
+    assert "Direct Ebook Edition" in page
+    assert "Target direct price: $3.99" in page
+    assert "direct checkout is held" in page
     assert "amazon.com/dp/" not in page.lower()
 
 
@@ -99,12 +114,41 @@ def test_bookshelf_routes_are_discoverable_to_search_and_vercel() -> None:
     vercelignore = (REPO_ROOT / ".vercelignore").read_text(encoding="utf-8")
     ignore_build = (REPO_ROOT / "scripts" / "vercel" / "ignore-build.cjs").read_text(encoding="utf-8")
     homepage = (DOCS / "index.html").read_text(encoding="utf-8")
+    llms = (DOCS / "llms.txt").read_text(encoding="utf-8")
+    robots = (DOCS / "robots.txt").read_text(encoding="utf-8")
 
     assert "https://aethermoore.com/SCBE-AETHERMOORE/books.html" in sitemap
     assert "https://aethermoore.com/SCBE-AETHERMOORE/books/miracle-memory.html" in sitemap
     assert "https://aethermoore.com/SCBE-AETHERMOORE/books/six-tongues-protocol.html" in sitemap
+    assert "https://aethermoore.com/SCBE-AETHERMOORE/guides.html" in sitemap
+    assert "https://aethermoore.com/SCBE-AETHERMOORE/downloads/ai-writing-system-guide.md" in sitemap
     assert "!docs/books.html" in vercelignore
     assert "!docs/books/**" in vercelignore
+    assert "!docs/guides.html" in vercelignore
+    assert "!docs/downloads/**" in vercelignore
     assert "'docs/books.html'" in ignore_build
     assert "'docs/books'" in ignore_build
+    assert "'docs/guides.html'" in ignore_build
+    assert "'docs/downloads'" in ignore_build
     assert 'href="books.html"' in homepage
+    assert 'href="guides.html"' in homepage
+    assert "https://aethermoore.com/SCBE-AETHERMOORE/guides.html" in llms
+    assert "Guides: https://aethermoore.com/SCBE-AETHERMOORE/guides.html" in robots
+
+
+def test_guides_page_links_live_downloads() -> None:
+    page = (DOCS / "guides.html").read_text(encoding="utf-8")
+
+    assert "AetherMoore Working Guides" in page
+    assert "AI Writing System" in page
+    assert "Humanization Pass" in page
+    assert "AI Security Starter" in page
+
+    downloads = [
+        "downloads/ai-writing-system-guide.md",
+        "downloads/humanization-pass-checklist.md",
+        "downloads/security-governance-checklist.md",
+    ]
+    for download in downloads:
+        assert f'href="{download}"' in page
+        assert (DOCS / download).exists(), download


### PR DESCRIPTION
## Summary
- bootstrap packages/agent-bus dev dependencies inside the workspace CLI Python test helper when @types/node is missing
- cache the build helper so the test suite does not rebuild on every workspace test

## Test evidence
- python -m pytest tests/test_bookshelf_pages.py tests/system/test_agent_bus_workspace_cli.py::test_agent_bus_workspace_new_creates_formation -q

## Context
This fixes the GitHub Test Python Components failure observed on PR #1775: packages/agent-bus build could not find @types/node in the clean Python CI runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct ebook editions now available for select titles with target pricing information
  * New "Guides" section with working resources for AI writing, humanization, and security practices

* **Documentation**
  * Added AI Writing System Guide
  * Added Humanization Pass Checklist
  * Added Security Governance Checklist

* **Style**
  * Enhanced visual styling for guide and download components

* **Chores**
  * Updated site navigation and information architecture
  * Updated search indexing and deployment configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->