### PR TITLE
feat(site): sell behind-the-scenes process pack

### DIFF
--- a/api/agent/download.js
+++ b/api/agent/download.js
@@ -11,6 +11,10 @@ const PRODUCTS = {
     envUrl: "SCBE_VAULT_BLOB_URL",
     filename: "SCBE_AI_Security_Training_Vault_v1.zip",
   },
+  making_of: {
+    envUrl: "SCBE_MAKING_OF_BLOB_URL",
+    filename: "AetherMoore_Behind_The_Scenes_Writing_Process_Pack_v1.zip",
+  },
 };
 
 function resolveProduct(req) {
@@ -45,7 +49,7 @@ module.exports = async function handler(req, res) {
   const productKey = resolveProduct(req);
   const product = PRODUCTS[productKey];
   if (!product) {
-    return sendJson(res, 400, { status: "error", error: "product must be toolkit or vault" });
+    return sendJson(res, 400, { status: "error", error: "product must be toolkit, vault, or making_of" });
   }
 
   const blobUrl = String(process.env[product.envUrl] || "").trim();

--- a/api/billing/stripe_webhook.js
+++ b/api/billing/stripe_webhook.js
@@ -28,7 +28,9 @@ const SNAPSHOT_AMOUNT_CENTS = 50000;
 const HEARTBEAT_AMOUNT_CENTS = 9900;
 const LIVE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID = 'plink_1TW71yJTF2SuUODIqYFRU9JY';
 const LIVE_HEARTBEAT_PAYMENT_LINK_ID = 'plink_1TW71zJTF2SuUODICZLQCCS3';
+const LIVE_MAKING_OF_PAYMENT_LINK_ID = 'plink_1TXo24JTF2SuUODIoRc6T3DD';
 const DIGITAL_PRODUCT_AMOUNT_CENTS = 2900;
+const MAKING_OF_AMOUNT_CENTS = 700;
 const TOLERANCE_SECONDS = 300; // Stripe default replay window
 
 const DIGITAL_PRODUCTS = {
@@ -45,6 +47,13 @@ const DIGITAL_PRODUCTS = {
     displayName: 'SCBE AI Security Training Vault',
     packageName: 'SCBE_AI_Security_Training_Vault_v1.zip',
     manualUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/product-manual/training-vault.html',
+  },
+  making_of: {
+    key: 'making_of',
+    source: 'behind-the-scenes-writing-process-pack',
+    displayName: 'AetherMoore Behind-the-Scenes Writing Process Pack',
+    packageName: 'AetherMoore_Behind_The_Scenes_Writing_Process_Pack_v1.zip',
+    manualUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/guides.html#behind-the-scenes-pack',
   },
 };
 
@@ -139,6 +148,10 @@ function snapshotConfig() {
       process.env.STRIPE_VAULT_PAYMENT_LINK_ID ||
       process.env.SCBE_PAYMENT_LINK_VAULT ||
       '',
+    makingOfPaymentLinkId:
+      process.env.STRIPE_MAKING_OF_PAYMENT_LINK_ID ||
+      process.env.SCBE_PAYMENT_LINK_MAKING_OF ||
+      LIVE_MAKING_OF_PAYMENT_LINK_ID,
     repo: process.env.POLLY_TRAIN_REPO || process.env.GITHUB_REPO || 'issdandavis/SCBE-AETHERMOORE',
     githubToken:
       process.env.POLLY_TRAIN_GITHUB_TOKEN ||
@@ -222,7 +235,11 @@ function isDigitalProductSession(session, cfg, productKey) {
   if (!product) return false;
 
   const paymentLinkId =
-    productKey === 'toolkit' ? cfg.toolkitPaymentLinkId : cfg.vaultPaymentLinkId;
+    productKey === 'toolkit'
+      ? cfg.toolkitPaymentLinkId
+      : productKey === 'vault'
+        ? cfg.vaultPaymentLinkId
+        : cfg.makingOfPaymentLinkId;
   if (paymentLinkId && session.payment_link === paymentLinkId) return true;
 
   const metadataKey = sessionProductMetadata(session);
@@ -231,9 +248,11 @@ function isDigitalProductSession(session, cfg, productKey) {
     metadataKey === product.source ||
     metadataKey === normalizeProductKey(product.displayName)
   ) {
+    const expectedAmount =
+      productKey === 'making_of' ? MAKING_OF_AMOUNT_CENTS : DIGITAL_PRODUCT_AMOUNT_CENTS;
     return (
       session.mode === 'payment' &&
-      Number(session.amount_total) === DIGITAL_PRODUCT_AMOUNT_CENTS &&
+      Number(session.amount_total) === expectedAmount &&
       String(session.currency || '').toLowerCase() === 'usd'
     );
   }
@@ -247,6 +266,10 @@ function isToolkitSession(session, cfg) {
 
 function isVaultSession(session, cfg) {
   return isDigitalProductSession(session, cfg, 'vault');
+}
+
+function isMakingOfSession(session, cfg) {
+  return isDigitalProductSession(session, cfg, 'making_of');
 }
 
 async function fetchWithTimeout(url, init, timeoutMs) {
@@ -438,6 +461,16 @@ module.exports = async function handler(req, res) {
         dispatch,
       });
     }
+    if (isMakingOfSession(session, cfg)) {
+      const dispatch = await dispatchProductDelivery(session, cfg, 'making_of');
+      return sendJson(res, 200, {
+        ok: true,
+        handled: 'product_delivery',
+        product_key: 'making_of',
+        session_id: session && session.id,
+        dispatch,
+      });
+    }
     return sendJson(res, 200, {
       ok: true,
       handled: 'checkout_other',
@@ -456,6 +489,7 @@ module.exports._private = {
   isHeartbeatSession,
   isToolkitSession,
   isVaultSession,
+  isMakingOfSession,
   isDigitalProductSession,
   snapshotConfig,
   buildSessionRecord,
@@ -464,6 +498,7 @@ module.exports._private = {
   LIVE_WORKFLOW_SNAPSHOT_PAYMENT_LINK_ID,
   HEARTBEAT_AMOUNT_CENTS,
   DIGITAL_PRODUCT_AMOUNT_CENTS,
+  MAKING_OF_AMOUNT_CENTS,
   DIGITAL_PRODUCTS,
   TOLERANCE_SECONDS,
 };

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -202,6 +202,27 @@ const PRODUCT_CATALOG = [
     ],
   },
   {
+    sku: 'behind-the-scenes-writing-process-pack',
+    name: 'AetherMoore Behind-the-Scenes Writing Process Pack',
+    priceLabel: '$7 one-time',
+    short:
+      'PDF/TXT process packet covering the making-of notes, AI writing workflow, revision passes, and publishing lane. The books themselves stay on Amazon/KDP.',
+    checkoutUrl: checkoutUrlFromEnv(
+      'SCBE_PAYMENT_LINK_MAKING_OF',
+      'https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n'
+    ),
+    deliveryUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/guides.html#behind-the-scenes-pack',
+    keywords: [
+      'behind the scenes',
+      'making of',
+      'writing process pack',
+      'ai writing process',
+      'process pack',
+      'book process',
+      'humanization',
+    ],
+  },
+  {
     sku: 'five-dollar-tip-jar',
     name: '$5 SCBE Tip Jar',
     priceLabel: '$5 one-time',

--- a/docs/app-config.json
+++ b/docs/app-config.json
@@ -1,6 +1,6 @@
 {
   "schema": "aethermoor-bus-app-config-v1",
-  "updated_at": "2026-05-12",
+  "updated_at": "2026-05-16",
   "app": {
     "name": "Aethermoor Bus",
     "package_name": "io.aethermoor.bus",
@@ -33,6 +33,8 @@
     "solutions_page": "https://aethermoore.com/SCBE-AETHERMOORE/solutions.html",
     "workflow_snapshot_page": "https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html",
     "shopify_command_center_page": "https://aethermoore.com/SCBE-AETHERMOORE/shopify-command-center.html",
+    "bookshelf_page": "https://aethermoore.com/SCBE-AETHERMOORE/books.html",
+    "guides_page": "https://aethermoore.com/SCBE-AETHERMOORE/guides.html",
     "shopify_command_center_demo": "https://shopify-command-center-165664533862.us-west2.run.app",
     "shopify_command_center_repo": "https://github.com/issdandavis/Shopify-Command-Center",
     "cash_app_qr": "https://aethermoore.com/SCBE-AETHERMOORE/static/cash-app-payment.png",
@@ -52,6 +54,7 @@
     "offers_json": "https://aethermoore.com/SCBE-AETHERMOORE/offers.json",
     "workflow_snapshot_checkout": "https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l",
     "governance_heartbeat_checkout": "https://buy.stripe.com/5kQ6oI0hQgKz9gQ6midby0m",
+    "behind_the_scenes_pack_checkout": "https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n",
     "agent_bridge_health": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/health",
     "agent_bridge_system": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/system",
     "agent_bridge_offers": "https://scbe-agent-bridge-vercel.vercel.app/api/agent/offers",
@@ -102,6 +105,7 @@
     "workflow_snapshot_starter": true,
     "shopify_command_center": true,
     "governance_snapshot": true,
+    "behind_the_scenes_pack": true,
     "unified_payment_center": true,
     "zero_key_agent_bus": true,
     "local_download_storage": true,

--- a/docs/books.html
+++ b/docs/books.html
@@ -61,7 +61,7 @@
             </p>
             <div class="cta-row">
               <a class="button" href="#books">Browse Books</a>
-              <a class="button secondary" href="#direct-ebooks">Direct Ebook Lane</a>
+              <a class="button secondary" href="#behind-the-scenes">Behind The Scenes Pack</a>
               <a class="button secondary" href="#process">See The Publishing Process</a>
             </div>
           </div>
@@ -126,58 +126,61 @@
           </div>
         </section>
 
-        <section class="band reveal" id="direct-ebooks">
+        <section class="band reveal" id="behind-the-scenes">
           <div class="section-head">
-            <h2>Direct Ebook Editions</h2>
+            <h2>Behind-The-Scenes Direct Pack</h2>
             <p class="section-note">
-              AetherMoore direct editions are the cheaper reader-first lane: clean EPUB/PDF files sold from this site
-              when rights and fulfillment are clear. Current Kindle editions are marked KDP Select, so direct ebook
-              checkout is staged here without pretending the file sale is live.
+              The books themselves stay on Amazon/KDP. The direct website product is a separate making-of/process pack:
+              PDF/TXT notes about the AI writing system, revision passes, book packaging, and what was learned while
+              building the books.
             </p>
           </div>
           <div class="direct-grid">
             <article class="direct-card">
-              <span class="status">Planned</span>
-              <h3>The Six Tongues Protocol</h3>
-              <div class="direct-price">Target direct ebook: $2.99</div>
+              <span class="status">Live direct checkout</span>
+              <h3>AetherMoore Behind-The-Scenes Writing Process Pack</h3>
+              <div class="direct-price">$7 PDF/TXT pack</div>
               <p>
-                Planned EPUB/PDF edition for readers who want to buy directly from AetherMoore instead of using the
-                Kindle marketplace.
+                A direct download product for readers and writers who want the process: how the book pages, AI writing
+                guides, scene passes, humanization checklist, and KDP packaging lane fit together.
               </p>
               <p class="rights-note">
-                Held while the Kindle edition remains enrolled in KDP Select. Amazon Kindle remains live at $4.99.
+                This does not include the KDP book manuscript. It is separate process material, so the books can remain
+                in KDP Select.
               </p>
               <div class="cta-row">
-                <a class="button secondary" href="books/six-tongues-protocol.html#direct-ebook">Direct Status</a>
+                <a class="button" href="https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n">Buy The Process Pack - $7</a>
+                <a class="button secondary" href="guides.html#behind-the-scenes-pack">What Is Inside</a>
               </div>
             </article>
             <article class="direct-card">
-              <span class="status">Planned</span>
-              <h3>The Miracle Was The Memory</h3>
-              <div class="direct-price">Target direct ebook: $3.99</div>
+              <span class="status">KDP lane</span>
+              <h3>Books Stay On Amazon</h3>
+              <div class="direct-price">Kindle + physical books</div>
               <p>
-                Planned EPUB/PDF edition after the current KDP review and rights status are clean enough to open direct
-                fulfillment.
+                Kindle editions stay inside KDP/KDP Select. Paperback links stay on Amazon too, so physical-book buyers
+                use the normal KDP print path.
               </p>
               <p class="rights-note">
-                Held while the Kindle edition is in review and enrolled in KDP Select. Amazon Kindle target is $5.99.
+                Six Tongues is live now. Miracle Memory links are added when KDP review clears.
               </p>
               <div class="cta-row">
-                <a class="button secondary" href="books/miracle-memory.html#direct-ebook">Direct Status</a>
+                <a class="button secondary" href="books/six-tongues-protocol.html">Open Six Tongues</a>
+                <a class="button secondary" href="books/miracle-memory.html">Open Miracle Memory</a>
               </div>
             </article>
             <article class="direct-card">
-              <span class="status">Build lane</span>
-              <h3>Direct Buyer Promise</h3>
-              <div class="direct-price">Cheaper than marketplace</div>
+              <span class="status">Free guide lane</span>
+              <h3>Working Guides Stay Public</h3>
+              <div class="direct-price">Free articles + downloads</div>
               <p>
-                Direct editions should be formatted cleanly, delivered as normal files, and priced below the marketplace
-                ebook wherever distribution rights allow it.
+                The public guide hub stays free. The paid process pack is the deeper, packaged behind-the-scenes version
+                for people who want the working files and notes together.
               </p>
               <p class="rights-note">
-                Next operational step: connect payment fulfillment after KDP Select status is cleared or a non-exclusive
-                title is ready.
+                Top-of-funnel stays useful without a purchase; paid buyers get the bundled packet and support path.
               </p>
+              <a class="button secondary" href="guides.html">Open Free Guides</a>
             </article>
           </div>
         </section>

--- a/docs/books.json
+++ b/docs/books.json
@@ -2,6 +2,15 @@
   "schema": "aethermoore-bookshelf-v1",
   "updated": "2026-05-16",
   "owner": "Issac Daniel Davis",
+  "direct_process_pack": {
+    "id": "behind-the-scenes-pack",
+    "name": "AetherMoore Behind-the-Scenes Writing Process Pack",
+    "status": "live",
+    "price_usd": "7.00",
+    "checkout_url": "https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n",
+    "formats": ["PDF", "TXT"],
+    "note": "Separate making-of/process material. It does not include the KDP book manuscript, so the books can remain in KDP Select."
+  },
   "books": [
     {
       "id": "miracle-memory",
@@ -13,11 +22,11 @@
       "page": "books/miracle-memory.html",
       "cover": "static/books/miracle-memory-cover.png",
       "direct_ebook": {
-        "status": "planned",
+        "status": "not offered while KDP Select",
         "target_price_usd": "3.99",
         "formats": ["EPUB", "PDF"],
         "page_anchor": "direct-ebook",
-        "rights_note": "Direct ebook fulfillment is held while the Kindle edition is in review and enrolled in KDP Select."
+        "rights_note": "The book manuscript stays on KDP/KDP Select. A separate behind-the-scenes process pack is sold directly on AetherMoore."
       },
       "formats": [
         {
@@ -62,11 +71,11 @@
       "page": "books/six-tongues-protocol.html",
       "cover": "static/books/six-tongues-cover.jpg",
       "direct_ebook": {
-        "status": "planned",
+        "status": "not offered while KDP Select",
         "target_price_usd": "2.99",
         "formats": ["EPUB", "PDF"],
         "page_anchor": "direct-ebook",
-        "rights_note": "Direct ebook fulfillment is held while the Kindle edition is enrolled in KDP Select."
+        "rights_note": "The book manuscript stays on KDP/KDP Select. A separate behind-the-scenes process pack is sold directly on AetherMoore."
       },
       "formats": [
         {

--- a/docs/books/miracle-memory.html
+++ b/docs/books/miracle-memory.html
@@ -44,33 +44,33 @@
           </div>
         </section>
 
-        <section class="band reveal" id="direct-ebook">
+        <section class="band reveal" id="behind-the-scenes-pack">
           <div class="section-head">
-            <h2>Direct Ebook Edition</h2>
+            <h2>Behind-The-Scenes Process Pack</h2>
             <p class="section-note">
-              The direct AetherMoore edition is planned as a cheaper EPUB/PDF file purchase after the current KDP review
-              and rights status are clear.
+              The Miracle Was The Memory manuscript stays on KDP/KDP Select. The direct site product is the separate
+              making-of packet: process notes, AI-writing workflow, revision checklists, and publication lessons.
             </p>
           </div>
           <div class="direct-grid">
             <article class="direct-card">
-              <span class="status">Planned</span>
-              <h3>EPUB + PDF</h3>
-              <div class="direct-price">Target direct price: $3.99</div>
+              <span class="status">Live direct checkout</span>
+              <h3>Making-Of PDF/TXT Pack</h3>
+              <div class="direct-price">$7</div>
               <p>
-                The direct edition will give readers a clean file copy from AetherMoore at a lower price than the
-                marketplace ebook target.
+                A bundled process packet for readers and writers who want to see how the nonfiction framing, AI writing
+                guides, revision passes, and KDP publication lane were built.
               </p>
               <p class="rights-note">
-                Not live yet: the Kindle edition is in KDP review and marked for KDP Select, so direct checkout is held
-                until fulfillment is clear.
+                This is not the book manuscript and does not replace the Kindle or paperback editions.
               </p>
+              <a class="button" href="https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n">Buy Process Pack - $7</a>
             </article>
             <article class="direct-card">
               <span class="status">In review</span>
-              <h3>Marketplace Edition</h3>
+              <h3>Book Purchase</h3>
               <div class="direct-price">Kindle target: $5.99</div>
-              <p>The Amazon purchase link will be added after KDP review clears.</p>
+              <p>The Amazon Kindle and paperback purchase links will be added after KDP review clears.</p>
               <a class="button secondary" href="../books.html">Back To Bookshelf</a>
             </article>
             <article class="direct-card">

--- a/docs/books/six-tongues-protocol.html
+++ b/docs/books/six-tongues-protocol.html
@@ -44,33 +44,33 @@
           </div>
         </section>
 
-        <section class="band reveal" id="direct-ebook">
+        <section class="band reveal" id="behind-the-scenes-pack">
           <div class="section-head">
-            <h2>Direct Ebook Edition</h2>
+            <h2>Behind-The-Scenes Process Pack</h2>
             <p class="section-note">
-              The direct AetherMoore edition is planned as a cheaper EPUB/PDF file purchase for readers who want to buy
-              from the author site instead of the Kindle marketplace.
+              The Six Tongues manuscript stays on KDP/KDP Select. The direct site product is the separate making-of
+              packet: process notes, AI-writing workflow, revision checklists, and publication lessons.
             </p>
           </div>
           <div class="direct-grid">
             <article class="direct-card">
-              <span class="status">Planned</span>
-              <h3>EPUB + PDF</h3>
-              <div class="direct-price">Target direct price: $2.99</div>
+              <span class="status">Live direct checkout</span>
+              <h3>Making-Of PDF/TXT Pack</h3>
+              <div class="direct-price">$7</div>
               <p>
-                The direct edition will be formatted for normal ebook reading and local archiving, with no fake scarcity
-                or platform lock-in.
+                A bundled process packet for readers and writers who want to see how the fiction, language-system notes,
+                AI writing guides, and publication lane were built.
               </p>
               <p class="rights-note">
-                Not live yet: the Kindle edition is currently enrolled in KDP Select, so direct ebook checkout is held
-                until distribution rights are clear.
+                This is not the book manuscript and does not replace the Kindle or paperback editions.
               </p>
+              <a class="button" href="https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n">Buy Process Pack - $7</a>
             </article>
             <article class="direct-card">
               <span class="status">Live now</span>
-              <h3>Marketplace Edition</h3>
+              <h3>Book Purchase</h3>
               <div class="direct-price">Kindle: $4.99</div>
-              <p>Amazon remains the current live ebook purchase path while the direct edition is staged.</p>
+              <p>Amazon remains the live book purchase path for Kindle and paperback.</p>
               <a class="button secondary" href="https://www.amazon.com/dp/B0GSSFQD9G">Open Kindle Listing</a>
             </article>
             <article class="direct-card">

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -34,6 +34,7 @@
             </p>
             <div class="cta-row">
               <a class="button" href="#downloads">Download Guides</a>
+              <a class="button secondary" href="#behind-the-scenes-pack">Buy Process Pack</a>
               <a class="button secondary" href="#security-governance">AI Security</a>
             </div>
           </div>
@@ -50,6 +51,37 @@
                 their own copy.
               </p>
             </div>
+          </div>
+        </section>
+
+        <section class="band reveal" id="behind-the-scenes-pack">
+          <div class="section-head">
+            <h2>Behind-The-Scenes Writing Process Pack</h2>
+            <p class="section-note">
+              A direct AetherMoore product that sells the making-of material, not the KDP book manuscripts. The public
+              articles stay free; this bundles the deeper PDF/TXT process notes and delivery support.
+            </p>
+          </div>
+          <div class="direct-grid">
+            <article class="direct-card">
+              <span class="status">Live direct checkout</span>
+              <h3>Process Pack</h3>
+              <div class="direct-price">$7 one-time</div>
+              <p>
+                Includes behind-the-scenes notes on AI-assisted drafting, scene packets, voice guides, humanization
+                passes, publishing setup, and the book-page workflow.
+              </p>
+              <a class="button" href="https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n">Buy Process Pack - $7</a>
+            </article>
+            <article class="direct-card">
+              <span class="status">KDP-safe split</span>
+              <h3>What It Is Not</h3>
+              <p>
+                It is not The Six Tongues Protocol, not The Miracle Was The Memory, and not a substitute for the Kindle
+                or paperback editions. Those book purchases stay on Amazon/KDP.
+              </p>
+              <a class="button secondary" href="books.html">Open Bookshelf</a>
+            </article>
           </div>
         </section>
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,8 +15,9 @@ Canonical repository: https://github.com/issdandavis/SCBE-AETHERMOORE
 - Agent demos: https://aethermoore.com/SCBE-AETHERMOORE/agents.html
 - Chat: https://aethermoore.com/SCBE-AETHERMOORE/chat.html
 - Products: https://aethermoore.com/SCBE-AETHERMOORE/products.html
-- Bookshelf and direct ebook status: https://aethermoore.com/SCBE-AETHERMOORE/books.html
+- Bookshelf and KDP/direct-process status: https://aethermoore.com/SCBE-AETHERMOORE/books.html
 - Working AI writing and security guides: https://aethermoore.com/SCBE-AETHERMOORE/guides.html
+- Behind-the-scenes writing process pack checkout: https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n
 - AI Writing System download: https://aethermoore.com/SCBE-AETHERMOORE/downloads/ai-writing-system-guide.md
 - Humanization Pass download: https://aethermoore.com/SCBE-AETHERMOORE/downloads/humanization-pass-checklist.md
 - AI Security Governance download: https://aethermoore.com/SCBE-AETHERMOORE/downloads/security-governance-checklist.md
@@ -65,8 +66,9 @@ Low-cost path:
 - $20/month supporter path.
 - $29 Toolkit.
 - $29 Training Vault.
-- Bookshelf with current Amazon status and staged direct ebook editions: https://aethermoore.com/SCBE-AETHERMOORE/books.html
+- Bookshelf with current Amazon/KDP status: https://aethermoore.com/SCBE-AETHERMOORE/books.html
 - Free working guides and Markdown downloads for AI writing, humanization passes, and AI security: https://aethermoore.com/SCBE-AETHERMOORE/guides.html
+- $7 Behind-the-Scenes Writing Process Pack (process material, not the KDP book manuscripts): https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n
 - $99 AI Agent Workflow Snapshot starter review: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
 - $99 Shopify Store Ops Snapshot for one Shopify store or ecommerce launch setup: https://aethermoore.com/SCBE-AETHERMOORE/shopify-command-center.html
 - One payment center for Ko-fi, Cash App, card checkout, and invoice requests: https://aethermoore.com/SCBE-AETHERMOORE/payments.html

--- a/docs/offers.json
+++ b/docs/offers.json
@@ -186,6 +186,26 @@
       },
       "value_position": "priced as a low-friction dataset and benchmark starter rather than a paid compute commitment",
       "status": "live"
+    },
+    {
+      "id": "behind_the_scenes_pack",
+      "name": "AetherMoore Behind-the-Scenes Writing Process Pack",
+      "price_label": "$7",
+      "type": "digital_download",
+      "checkout_url": "https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n",
+      "proof_url": "https://aethermoore.com/SCBE-AETHERMOORE/guides.html#behind-the-scenes-pack",
+      "delivery": {
+        "mode": "stripe_webhook_product_delivery",
+        "package_name": "AetherMoore_Behind_The_Scenes_Writing_Process_Pack_v1.zip",
+        "requires_env": [
+          "STRIPE_MAKING_OF_PAYMENT_LINK_ID or SCBE_PAYMENT_LINK_MAKING_OF",
+          "SCBE_DELIVERY_TOKEN",
+          "SCBE_MAKING_OF_BLOB_URL"
+        ]
+      },
+      "value_position": "priced as a small reader/writer process packet while the books themselves stay on KDP/KDP Select",
+      "status": "live",
+      "stripe_payment_link_id": "plink_1TXo24JTF2SuUODIoRc6T3DD"
     }
   ]
 }

--- a/docs/ops/STRIPE_DIGITAL_DELIVERY.md
+++ b/docs/ops/STRIPE_DIGITAL_DELIVERY.md
@@ -23,12 +23,14 @@ Preferred setup: set product metadata on each Stripe Payment Link.
 
 - Toolkit Payment Link: `metadata[scbe_product]=toolkit`
 - Training Vault Payment Link: `metadata[scbe_product]=vault`
+- Behind-the-Scenes Writing Process Pack: `metadata[scbe_product]=making_of`
 
 Fallback setup for existing links: map Stripe Payment Link IDs in environment.
 
 ```text
 SCBE_PAYMENT_LINK_TOOLKIT=plink_...
 SCBE_PAYMENT_LINK_VAULT=plink_...
+SCBE_PAYMENT_LINK_MAKING_OF=plink_...
 ```
 
 Do not route by price. Both current products are low-cost one-time offers and
@@ -41,6 +43,7 @@ Set direct product download URLs in environment when the ZIPs are hosted.
 ```text
 SCBE_TOOLKIT_DOWNLOAD_URL=https://...
 SCBE_VAULT_DOWNLOAD_URL=https://...
+SCBE_MAKING_OF_BLOB_URL=https://...
 ```
 
 If these are not set, the delivery email falls back to the latest GitHub release:
@@ -84,4 +87,5 @@ attempt and records the purchase as an audit trail item.
 ```powershell
 python -m pytest tests\api\test_stripe_billing_hardening.py tests\test_package_products.py -q
 python scripts\package_products.py --product all --output-dir artifacts\product_delivery_current_smoke
+python scripts\package_products.py --product making-of --output-dir artifacts\product_delivery_current_smoke
 ```

--- a/docs/payments.html
+++ b/docs/payments.html
@@ -303,6 +303,17 @@
             >
           </article>
           <article class="card">
+            <h3>Behind-The-Scenes Process Pack</h3>
+            <div class="price">$7 one time</div>
+            <a
+              class="btn"
+              href="https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n"
+              target="_blank"
+              rel="noopener"
+              >Buy Process Pack</a
+            >
+          </article>
+          <article class="card">
             <h3>Governance Snapshot</h3>
             <div class="price">$500 fixed scope</div>
             <a

--- a/docs/product-manual/delivery-and-access.html
+++ b/docs/product-manual/delivery-and-access.html
@@ -79,6 +79,7 @@
         <ul>
           <li><a href="ai-governance-toolkit.html">SCBE AI Governance Toolkit guide</a></li>
           <li><a href="training-vault.html">SCBE Training Vault user guide</a></li>
+          <li><a href="../guides.html#behind-the-scenes-pack">Behind-the-scenes writing process pack</a></li>
           <li><a href="service-fast-start.html">Service fast-start packet</a></li>
           <li><a href="../offers/index.html">Customer offers and checkout links</a></li>
         </ul>
@@ -95,9 +96,11 @@
         <p>
           Required delivery secrets: <code>SCBE_DELIVERY_TOKEN</code>,
           <code>SCBE_TOOLKIT_BLOB_URL</code>, and either
-          <code>SCBE_TRAINING_VAULT_DOWNLOAD_URL</code> or <code>SCBE_VAULT_BLOB_URL</code>.
+          <code>SCBE_TRAINING_VAULT_DOWNLOAD_URL</code> or <code>SCBE_VAULT_BLOB_URL</code>, plus
+          <code>SCBE_MAKING_OF_BLOB_URL</code> when the writing process pack is live.
           Required Stripe product routing secrets: <code>STRIPE_TOOLKIT_PAYMENT_LINK_ID</code> and
-          <code>STRIPE_VAULT_PAYMENT_LINK_ID</code>.
+          <code>STRIPE_VAULT_PAYMENT_LINK_ID</code>; the writing process pack also accepts
+          <code>STRIPE_MAKING_OF_PAYMENT_LINK_ID</code>.
         </p>
       </section>
     </main>

--- a/scripts/package_products.py
+++ b/scripts/package_products.py
@@ -171,6 +171,73 @@ MIT License — use commercially, modify freely, attribution appreciated.
 (c) 2026 Issac Davis / AetherMoore
 """
 
+# ---- Product: Behind-the-Scenes Writing Process Pack ----
+
+MAKING_OF_FILES = [
+    ("docs/downloads/ai-writing-system-guide.md", "guides/ai-writing-system-guide.md"),
+    ("docs/downloads/humanization-pass-checklist.md", "guides/humanization-pass-checklist.md"),
+    ("docs/downloads/security-governance-checklist.md", "guides/security-governance-checklist.md"),
+    ("docs/books.html", "site-source/books.html"),
+    ("docs/guides.html", "site-source/guides.html"),
+    ("docs/books/six-tongues-protocol.html", "site-source/books/six-tongues-protocol.html"),
+    ("docs/books/miracle-memory.html", "site-source/books/miracle-memory.html"),
+]
+
+MAKING_OF_README = """# AetherMoore Behind-the-Scenes Writing Process Pack
+
+Thank you for purchasing the AetherMoore Behind-the-Scenes Writing Process Pack.
+
+## What This Is
+
+This is a process product: AI-assisted writing guides, humanization checklists,
+book-page source material, and practical notes on how the AetherMoore book and
+guide surfaces are built.
+
+## What This Is Not
+
+This package does NOT include the manuscript text of:
+
+- The Six Tongues Protocol
+- The Miracle Was The Memory
+
+Those books stay on Amazon/KDP. This packet is separate making-of/process
+material for readers and writers who want to study the workflow.
+
+## Start Here
+
+1. Read `PROCESS_NOTES.txt`.
+2. Open `guides/ai-writing-system-guide.md`.
+3. Open `guides/humanization-pass-checklist.md`.
+4. Use `site-source/` to see how the book pages and guide hub are positioned.
+
+## Support
+
+- Email: ai@aethermoore.com
+- Site: https://aethermoore.com/SCBE-AETHERMOORE/guides.html
+
+(c) 2026 Issac Davis / AetherMoore
+"""
+
+MAKING_OF_PROCESS_NOTES = """AETHERMOORE WRITING PROCESS NOTES
+
+The working method:
+
+1. Put the book into control documents instead of one giant prompt.
+2. Keep outline, continuity, character wants, voice notes, and scene fragments separate.
+3. Let AI draft too much, then cut and layer with human voice.
+4. Do not humanize by sprinkling typos. Humanize by repairing thought path, scene pressure, dialogue wants, body language, and object logic.
+5. Keep the book itself on KDP/KDP Select when enrolled there. Sell separate process material directly.
+
+The useful split:
+
+- Amazon/KDP sells the finished book.
+- AetherMoore sells the making-of lane, guide lane, checklists, and workflow.
+
+Why this packet exists:
+
+Readers and writers often want the process behind a book more than a vague prompt list. This packet preserves the practical layer: how scenes are scaffolded, how AI tells are detected, how voice is blended, and how the site routes books, guides, and paid process material without mixing up rights.
+"""
+
 
 def _count_jsonl_records(path: Path) -> int:
     """Count non-empty lines in a JSONL file."""
@@ -265,9 +332,44 @@ def package_vault(output_dir: Path) -> Path:
     return zip_path
 
 
+def package_making_of(output_dir: Path) -> Path:
+    """Package the behind-the-scenes writing process pack."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = output_dir / "AetherMoore_Behind_The_Scenes_Writing_Process_Pack_v1.zip"
+
+    with ZipFile(zip_path, "w", ZIP_DEFLATED) as zf:
+        zf.writestr("README.md", MAKING_OF_README)
+        zf.writestr("PROCESS_NOTES.txt", MAKING_OF_PROCESS_NOTES)
+        zf.writestr(
+            "LICENSE", "Copyright (c) 2026 Issac Davis / AetherMoore. Personal reader/writer use allowed.\n"
+        )
+
+        for src_rel, dst_rel in MAKING_OF_FILES:
+            src = REPO_ROOT / src_rel
+            if src.exists():
+                zf.write(src, dst_rel)
+                print(f"  + {dst_rel}")
+            else:
+                print(f"  ! MISSING: {src_rel}")
+
+        metadata = {
+            "product": "AetherMoore Behind-the-Scenes Writing Process Pack",
+            "version": "1.0",
+            "packaged_at": datetime.now(timezone.utc).isoformat(),
+            "author": "Issac Davis",
+            "does_not_include": ["The Six Tongues Protocol manuscript", "The Miracle Was The Memory manuscript"],
+            "checkout_url": "https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n",
+        }
+        zf.writestr("metadata.json", json.dumps(metadata, indent=2))
+
+    size_mb = zip_path.stat().st_size / (1024 * 1024)
+    print(f"\nBehind-the-scenes pack packaged: {zip_path} ({size_mb:.1f} MB)")
+    return zip_path
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Package SCBE products for delivery")
-    parser.add_argument("--product", choices=["toolkit", "vault", "all"], default="all")
+    parser.add_argument("--product", choices=["toolkit", "vault", "making-of", "all"], default="all")
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
     args = parser.parse_args()
 
@@ -281,6 +383,11 @@ def main() -> None:
     if args.product in ("vault", "all"):
         print("=== Packaging AI Security Training Vault ===")
         package_vault(args.output_dir)
+        print()
+
+    if args.product in ("making-of", "all"):
+        print("=== Packaging Behind-the-Scenes Writing Process Pack ===")
+        package_making_of(args.output_dir)
         print()
 
     print(

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -202,7 +202,7 @@ describe('polly lead handler — anti-abuse', () => {
 
 describe('polly commerce intent classification', () => {
   it('catalog has live products with valid checkout urls', () => {
-    expect(commerce.PRODUCT_CATALOG).toHaveLength(9);
+    expect(commerce.PRODUCT_CATALOG).toHaveLength(10);
     for (const product of commerce.PRODUCT_CATALOG) {
       expect(product.checkoutUrl).toMatch(/^(https:\/\/(buy\.stripe\.com|ko-fi\.com)|mailto:)/);
       expect(product.keywords.length).toBeGreaterThan(0);
@@ -270,6 +270,13 @@ describe('polly commerce intent classification', () => {
     expect(intent.name).toBe('buy');
     expect(intent.confidence).toBeCloseTo(0.6, 2);
     expect(intent.product.sku).toBe('ai-security-training-vault');
+  });
+
+  it('classifies behind-the-scenes process pack as a buyable digital product', () => {
+    const intent = commerce.classifyIntent('I want the behind the scenes writing process pack');
+    expect(intent.name).toBe('buy');
+    expect(intent.product.sku).toBe('behind-the-scenes-writing-process-pack');
+    expect(intent.product.checkoutUrl).toBe('https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n');
   });
 
   it('classifies governance snapshot as a buyable fixed-scope product', () => {

--- a/tests/api/stripe_webhook_js.test.ts
+++ b/tests/api/stripe_webhook_js.test.ts
@@ -22,6 +22,7 @@ const WORKFLOW_SNAPSHOT_LINK_ID = 'plink_workflow_snapshot_test_99';
 const HEARTBEAT_LINK_ID = 'plink_heartbeat_test_99';
 const TOOLKIT_LINK_ID = 'plink_toolkit_test_29';
 const VAULT_LINK_ID = 'plink_vault_test_29';
+const MAKING_OF_LINK_ID = 'plink_making_of_test_7';
 
 function setEnv(): void {
   process.env.STRIPE_WEBHOOK_SECRET = TEST_SECRET;
@@ -30,6 +31,7 @@ function setEnv(): void {
   process.env.STRIPE_HEARTBEAT_PAYMENT_LINK_ID = HEARTBEAT_LINK_ID;
   process.env.STRIPE_TOOLKIT_PAYMENT_LINK_ID = TOOLKIT_LINK_ID;
   process.env.STRIPE_VAULT_PAYMENT_LINK_ID = VAULT_LINK_ID;
+  process.env.STRIPE_MAKING_OF_PAYMENT_LINK_ID = MAKING_OF_LINK_ID;
   process.env.GITHUB_TOKEN = 'ghp_test_token';
   process.env.GITHUB_REPO = 'test-org/test-repo';
   process.env.POLLY_SNAPSHOT_DISPATCH_ENABLED = 'true';
@@ -43,8 +45,10 @@ function clearEnv(): void {
   delete process.env.STRIPE_HEARTBEAT_PAYMENT_LINK_ID;
   delete process.env.STRIPE_TOOLKIT_PAYMENT_LINK_ID;
   delete process.env.STRIPE_VAULT_PAYMENT_LINK_ID;
+  delete process.env.STRIPE_MAKING_OF_PAYMENT_LINK_ID;
   delete process.env.SCBE_PAYMENT_LINK_TOOLKIT;
   delete process.env.SCBE_PAYMENT_LINK_VAULT;
+  delete process.env.SCBE_PAYMENT_LINK_MAKING_OF;
   delete process.env.GITHUB_TOKEN;
   delete process.env.GH_TOKEN;
   delete process.env.POLLY_TRAIN_GITHUB_TOKEN;
@@ -181,10 +185,16 @@ function heartbeatEvent(overrides: Record<string, unknown> = {}): string {
 }
 
 function productEvent(
-  productKey: 'toolkit' | 'vault',
+  productKey: 'toolkit' | 'vault' | 'making_of',
   overrides: Record<string, unknown> = {}
 ): string {
-  const linkId = productKey === 'toolkit' ? TOOLKIT_LINK_ID : VAULT_LINK_ID;
+  const linkId =
+    productKey === 'toolkit'
+      ? TOOLKIT_LINK_ID
+      : productKey === 'vault'
+        ? VAULT_LINK_ID
+        : MAKING_OF_LINK_ID;
+  const amount = productKey === 'making_of' ? 700 : 2900;
   return JSON.stringify({
     id: `evt_test_${productKey}`,
     type: 'checkout.session.completed',
@@ -193,7 +203,7 @@ function productEvent(
         id: `cs_test_${productKey}_29`,
         object: 'checkout.session',
         mode: 'payment',
-        amount_total: 2900,
+        amount_total: amount,
         currency: 'usd',
         payment_link: linkId,
         payment_intent: `pi_test_${productKey}`,
@@ -451,15 +461,24 @@ describe('stripe webhook — digital product detection', () => {
     expect(isVaultSession({ payment_link: VAULT_LINK_ID }, cfg)).toBe(true);
   });
 
+  it('matches making-of pack by payment_link id', () => {
+    const { isMakingOfSession, snapshotConfig } = stripeWebhook._private;
+    const cfg = snapshotConfig();
+    expect(isMakingOfSession({ payment_link: MAKING_OF_LINK_ID }, cfg)).toBe(true);
+  });
+
   it('accepts existing SCBE product payment link env aliases', () => {
     clearEnv();
     process.env.SCBE_PAYMENT_LINK_TOOLKIT = 'plink_toolkit_alias';
     process.env.SCBE_PAYMENT_LINK_VAULT = 'plink_vault_alias';
-    const { isToolkitSession, isVaultSession, snapshotConfig } = stripeWebhook._private;
+    process.env.SCBE_PAYMENT_LINK_MAKING_OF = 'plink_making_of_alias';
+    const { isToolkitSession, isVaultSession, isMakingOfSession, snapshotConfig } =
+      stripeWebhook._private;
     const cfg = snapshotConfig();
 
     expect(isToolkitSession({ payment_link: 'plink_toolkit_alias' }, cfg)).toBe(true);
     expect(isVaultSession({ payment_link: 'plink_vault_alias' }, cfg)).toBe(true);
+    expect(isMakingOfSession({ payment_link: 'plink_making_of_alias' }, cfg)).toBe(true);
   });
 
   it('matches toolkit by explicit metadata + $29 payment when link id is absent', () => {
@@ -490,6 +509,23 @@ describe('stripe webhook — digital product detection', () => {
     };
     expect(isToolkitSession(session, cfg)).toBe(false);
     expect(isVaultSession(session, cfg)).toBe(false);
+  });
+
+  it('matches making-of pack by explicit metadata + $7 payment when link id is absent', () => {
+    const { isMakingOfSession, snapshotConfig } = stripeWebhook._private;
+    const cfg = { ...snapshotConfig(), makingOfPaymentLinkId: '' };
+    expect(
+      isMakingOfSession(
+        {
+          mode: 'payment',
+          amount_total: 700,
+          currency: 'usd',
+          payment_link: 'plink_recreated',
+          metadata: { scbe_product: 'making_of' },
+        },
+        cfg
+      )
+    ).toBe(true);
   });
 
   it('rejects subscription mode even with matching toolkit metadata', () => {
@@ -665,6 +701,34 @@ describe('stripe webhook — event routing', () => {
     expect(rec.product_name).toBe('SCBE AI Governance Toolkit');
     expect(rec.package_name).toBe('SCBE_AI_Governance_Toolkit_v1.zip');
     expect(rec.source).toBe('ai-governance-toolkit');
+  });
+
+  it('making-of checkout completes → product delivery dispatch payload', async () => {
+    let capturedBody: string | undefined;
+    vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
+      capturedBody = (init as { body: string }).body;
+      return new Response('{}', { status: 200 });
+    });
+    const raw = productEvent('making_of');
+    const sig = signPayload(raw, TEST_SECRET);
+    const req = makeReq({ rawBody: raw, headers: { 'stripe-signature': sig } });
+    const res = makeRes();
+    await stripeWebhook(req as never, res as never);
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { handled: string; product_key: string }).handled).toBe('product_delivery');
+    expect((res.body as { handled: string; product_key: string }).product_key).toBe('making_of');
+    expect(capturedBody).toBeDefined();
+    const dispatched = JSON.parse(capturedBody as string);
+    expect(dispatched.event_type).toBe('polly_product_delivery');
+    const rec = dispatched.client_payload.record;
+    expect(rec.kind).toBe('product_delivery');
+    expect(rec.session_id).toBe('cs_test_making_of_29');
+    expect(rec.contact_email).toBe('making_of@example.com');
+    expect(rec.amount_total).toBe(700);
+    expect(rec.product_key).toBe('making_of');
+    expect(rec.product_name).toBe('AetherMoore Behind-the-Scenes Writing Process Pack');
+    expect(rec.package_name).toBe('AetherMoore_Behind_The_Scenes_Writing_Process_Pack_v1.zip');
+    expect(rec.source).toBe('behind-the-scenes-writing-process-pack');
   });
 
   it('ambiguous $29 checkout completes → checkout_other, no dispatch', async () => {

--- a/tests/test_bookshelf_pages.py
+++ b/tests/test_bookshelf_pages.py
@@ -12,6 +12,9 @@ def test_bookshelf_catalog_points_to_real_pages_and_assets() -> None:
 
     assert catalog["schema"] == "aethermoore-bookshelf-v1"
     assert catalog["books"], "bookshelf catalog should not be empty"
+    assert catalog["direct_process_pack"]["status"] == "live"
+    assert catalog["direct_process_pack"]["price_usd"] == "7.00"
+    assert catalog["direct_process_pack"]["checkout_url"].startswith("https://buy.stripe.com/")
 
     for book in catalog["books"]:
         assert (DOCS / book["page"]).exists(), book["page"]
@@ -38,7 +41,7 @@ def test_bookshelf_catalog_matches_current_kdp_statuses() -> None:
     assert miracle_formats["Paperback"]["last_modified"] == "2026-05-13"
     assert miracle_formats["Hardcover"]["status"] == "Not created"
     assert miracle_formats["Hardcover"]["available"] is False
-    assert books["miracle-memory"]["direct_ebook"]["status"] == "planned"
+    assert books["miracle-memory"]["direct_ebook"]["status"] == "not offered while KDP Select"
     assert books["miracle-memory"]["direct_ebook"]["target_price_usd"] == "3.99"
 
     six_formats = {fmt["name"]: fmt for fmt in books["six-tongues-protocol"]["formats"]}
@@ -54,7 +57,7 @@ def test_bookshelf_catalog_matches_current_kdp_statuses() -> None:
     assert six_formats["Hardcover"]["status"] == "Draft"
     assert six_formats["Hardcover"]["last_modified"] == "2026-03-18"
     assert six_formats["Hardcover"]["available"] is False
-    assert books["six-tongues-protocol"]["direct_ebook"]["status"] == "planned"
+    assert books["six-tongues-protocol"]["direct_ebook"]["status"] == "not offered while KDP Select"
     assert books["six-tongues-protocol"]["direct_ebook"]["target_price_usd"] == "2.99"
 
 
@@ -65,9 +68,10 @@ def test_bookshelf_hub_links_each_book_page_and_process_lane() -> None:
     assert 'href="books/miracle-memory.html"' in page
     assert 'href="books/six-tongues-protocol.html"' in page
     assert "Publishing Process" in page
-    assert "Direct Ebook Editions" in page
-    assert "Target direct ebook: $2.99" in page
-    assert "Target direct ebook: $3.99" in page
+    assert "Behind-The-Scenes Direct Pack" in page
+    assert "Buy The Process Pack - $7" in page
+    assert "https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n" in page
+    assert "does not include the KDP book manuscript" in page
     assert 'href="guides.html#ai-writing-system"' in page
     assert "static/books/miracle-memory-cover.png" in page
     assert "static/books/six-tongues-cover.jpg" in page
@@ -88,9 +92,9 @@ def test_six_tongues_page_uses_live_amazon_asins() -> None:
     assert "Submitted March 16, 2026" in page
     assert "Submitted March 17, 2026" in page
     assert "Last modified March 18, 2026" in page
-    assert "Direct Ebook Edition" in page
-    assert "Target direct price: $2.99" in page
-    assert "direct ebook checkout is held" in page
+    assert "Behind-The-Scenes Process Pack" in page
+    assert "Buy Process Pack - $7" in page
+    assert "This is not the book manuscript" in page
 
 
 def test_miracle_memory_page_marks_kdp_review_without_fake_purchase_link() -> None:
@@ -103,9 +107,9 @@ def test_miracle_memory_page_marks_kdp_review_without_fake_purchase_link() -> No
     assert "Amazon link coming after review" in page
     assert "Last modified May 13, 2026" in page
     assert "Hardcover:</strong> not created yet" in page
-    assert "Direct Ebook Edition" in page
-    assert "Target direct price: $3.99" in page
-    assert "direct checkout is held" in page
+    assert "Behind-The-Scenes Process Pack" in page
+    assert "Buy Process Pack - $7" in page
+    assert "This is not the book manuscript" in page
     assert "amazon.com/dp/" not in page.lower()
 
 
@@ -143,6 +147,8 @@ def test_guides_page_links_live_downloads() -> None:
     assert "AI Writing System" in page
     assert "Humanization Pass" in page
     assert "AI Security Starter" in page
+    assert "Behind-The-Scenes Writing Process Pack" in page
+    assert "https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n" in page
 
     downloads = [
         "downloads/ai-writing-system-guide.md",

--- a/tests/test_package_products.py
+++ b/tests/test_package_products.py
@@ -23,17 +23,24 @@ def test_packaged_product_sources_exist():
         if not (repo_root / src_rel).exists():
             missing.append(src_rel)
 
+    for src_rel, _dst_rel in package_products.MAKING_OF_FILES:
+        if not (repo_root / src_rel).exists():
+            missing.append(src_rel)
+
     assert missing == []
 
 
 def test_packaged_product_smoke(tmp_path: Path):
     toolkit = package_products.package_toolkit(tmp_path)
     vault = package_products.package_vault(tmp_path)
+    making_of = package_products.package_making_of(tmp_path)
 
     assert toolkit.exists()
     assert vault.exists()
+    assert making_of.exists()
     assert toolkit.stat().st_size > 0
     assert vault.stat().st_size > 0
+    assert making_of.stat().st_size > 0
 
 
 def test_toolkit_zip_contains_promised_buyer_templates(tmp_path: Path):
@@ -50,6 +57,21 @@ def test_toolkit_zip_contains_promised_buyer_templates(tmp_path: Path):
         "templates/review-notes-template.md",
         "quickstart/README.md",
     }.issubset(names)
+
+
+def test_making_of_zip_excludes_manuscripts_and_includes_process_guides(tmp_path: Path):
+    making_of = package_products.package_making_of(tmp_path)
+
+    with ZipFile(making_of) as zf:
+        names = set(zf.namelist())
+        readme = zf.read("README.md").decode("utf-8")
+        process_notes = zf.read("PROCESS_NOTES.txt").decode("utf-8")
+
+    assert "guides/ai-writing-system-guide.md" in names
+    assert "guides/humanization-pass-checklist.md" in names
+    assert "site-source/books.html" in names
+    assert "does NOT include the manuscript text" in readme
+    assert "Amazon/KDP sells the finished book" in process_notes
 
 
 def test_production_pack_support_email_is_current():

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -193,7 +193,8 @@ def test_download_bridge_serves_private_blob_with_delivery_token() -> None:
     assert "BLOB_READ_WRITE_TOKEN" in source
     assert "SCBE_TOOLKIT_BLOB_URL" in source
     assert "SCBE_VAULT_BLOB_URL" in source
-    assert "product must be toolkit or vault" in source
+    assert "SCBE_MAKING_OF_BLOB_URL" in source
+    assert "product must be toolkit, vault, or making_of" in source
     assert "Content-Disposition" in source
     assert 'Cache-Control", "private, no-store"' in source
 
@@ -218,6 +219,9 @@ def test_public_offer_catalog_has_live_revenue_links() -> None:
     assert by_id["shopify_command_center_snapshot"]["price_label"] == "$99 starter"
     assert by_id["shopify_command_center_snapshot"]["proof_url"].endswith("/shopify-command-center.html")
     assert by_id["governance_snapshot"]["intake_url"].endswith("/governance-snapshot.html#intake")
+    assert by_id["behind_the_scenes_pack"]["checkout_url"] == "https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n"
+    assert by_id["behind_the_scenes_pack"]["price_label"] == "$7"
+    assert by_id["behind_the_scenes_pack"]["stripe_payment_link_id"] == "plink_1TXo24JTF2SuUODIoRc6T3DD"
     assert offers["usage_policy"]["service_fee_percent_range"] == [2, 5]
 
 


### PR DESCRIPTION
## Summary
- keeps KDP book manuscripts on Amazon/KDP while adding a separate $7 direct process-pack checkout
- wires the process pack into books, guides, payments, offers, app config, llms guidance, and Polly commerce routing
- extends Stripe webhook/download/product packaging to route `making_of` product delivery

## Verification
- `python -m pytest tests/test_bookshelf_pages.py tests/test_vercel_launch_bridge.py tests/test_package_products.py -q`
- `npx vitest run tests/api/stripe_webhook_js.test.ts tests/api/polly_commerce_js.test.ts`
- `python scripts/package_products.py --product making-of --output-dir artifacts/product_delivery_current_smoke`
- checkout surface audit: 0 blocking findings

## Notes
- Live Stripe Payment Link: https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n
- Payment Link ID: `plink_1TXo24JTF2SuUODIoRc6T3DD`
- Product pack excludes the KDP manuscripts; it is only behind-the-scenes/process material.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Behind-the-Scenes Writing Process Pack" ($7) — a new downloadable digital product with Stripe checkout integration.
  * Added product checkout links across book pages, guides, and the payments page.

* **Updates**
  * Updated book landing pages to feature the new process pack option.
  * Refreshed direct purchase offerings on the bookshelf.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->