### PR TITLE
feat(products): add writing technique pack

### DIFF
--- a/docs/downloads/aethermoore-writing-techniques-fieldbook.md
+++ b/docs/downloads/aethermoore-writing-techniques-fieldbook.md
@@ -1,0 +1,175 @@
+# AetherMoore Writing Techniques Fieldbook
+
+This is the working packet behind the AetherMoore AI writing process. It is for
+writers who want an AI writing room, not a generic prose machine.
+
+## Core Method
+
+1. Separate the book into control docs: outline, continuity, character engine,
+   voice guide, research notes, scene inventory, and revision ledger.
+2. Write human seed paragraphs for scenes that need your own mind on the page.
+3. Let AI draft more than needed, then cut and layer until the scene has a real
+   want.
+4. Dry-read from multiple entry points so the book is tested as a reader
+   experience, not only as a file tree.
+5. Run focused passes: voice, dialogue, food/object pressure, pacing, reveal
+   discipline, and final continuity.
+
+## Scene-First Rule
+
+The scene is the goal. The words carry the scene.
+
+Do not make every sentence prove the theme. Let the character walk, notice,
+forget, want, dodge, eat, check a phone, lose a thought, and come back to the
+pressure. A scene can be intelligent without every line sounding intelligent.
+
+## Control Documents
+
+Use multiple small docs instead of one giant bible:
+
+- `OUTLINE`: what happens and why now.
+- `CHARACTER_INTERIOR_ENGINE`: what each person wants, hides, repeats, and
+  refuses to know.
+- `CONTINUITY`: what has been planted, who knows it, and where it pays off.
+- `VOICE`: sentence habits, banned AI tells, human anchors, and protected
+  rhythms.
+- `SCENE_INVENTORY`: what each chapter must do before it is allowed to end.
+- `REVISION_LEDGER`: what changed and what downstream chapter might break.
+
+The point is not bureaucracy. The point is parallel work without losing canon.
+
+## Human Voice Anchors
+
+Save real writing samples from yourself. Mine voice from:
+
+- paragraphs you wrote without trying to sound polished;
+- dialogue you typed naturally;
+- ranty notes that explain what the scene is really doing;
+- lines you care about enough to protect.
+
+Then turn those into a voice guide. Do not paste the voice raw everywhere. Use
+it as a pressure source.
+
+## Thought Path Pass
+
+AI often jumps from image to thesis too fast. Human thought tends to move
+through friction.
+
+Ask:
+
+- What did the character just see, hear, smell, touch, want, or avoid?
+- What practical problem interrupts the thought?
+- Is this thought actually his, or is the narrator explaining him?
+- Could a body action or object carry the line better?
+
+Useful sentence pressure:
+
+- notice an object;
+- think the wrong thought;
+- correct it badly;
+- do the practical thing anyway.
+
+## Dialogue Wants
+
+Dialogue fails when every line answers the previous line too neatly.
+
+For each speaker, define:
+
+- what they want from the exchange;
+- what they refuse to say directly;
+- what they think the other person already knows;
+- what practical action they are doing while talking.
+
+Good dialogue can include wrong answers, interruptions, repeated questions,
+missed jokes, and small chores. The point is not mess. The point is pressure.
+
+## Serial Drama And Telenovela Pressure
+
+Long-form drama keeps emotion alive by letting scenes carry more than one job.
+
+Use:
+
+- public conversation with private stakes;
+- kindness that also functions as control;
+- a repeated line whose meaning changes later;
+- one relationship pulling the character toward normal life;
+- one relationship pulling the character toward the old pattern;
+- a reveal that changes the meaning of earlier warmth.
+
+The reader should not feel a twist being installed. They should feel a human
+relationship getting more complicated.
+
+## Food, Money, And Object Work
+
+Food is not decoration. It is class, hunger, care, shame, habit, recovery, and
+routine.
+
+Use food when it changes the scene:
+
+- cheap food under pressure;
+- someone else cooking or paying;
+- hunger making the body meaner;
+- a meal that feels normal for one person and strange for another;
+- an object passed across the table that changes the power in the room.
+
+Do not write "eggs and rice" only as poverty. Write eggs and rice plus hunger,
+creative cooking, habit, and what the character does after the bowl is empty.
+
+## Gaming Scene Method
+
+Gaming scenes need action, not summary.
+
+Show:
+
+- the objective;
+- the map or lane pressure;
+- who is calling;
+- what information is missing;
+- what the hands do;
+- what chat is doing to his attention;
+- the exact moment he locks in;
+- what the win gives him and what it fails to fix.
+
+The game is not a metaphor first. It is a third room where character leaks out
+under pressure.
+
+## Humanization Pass
+
+Humanization is not adding typos or slang.
+
+Check for:
+
+- too many clean aphoristic closers;
+- too many one-word yes/no volleys;
+- dialogue that sounds like a thesis debate;
+- paragraph endings that all land the same way;
+- repeated "he understood" or "he realized" explanations;
+- characters who speak only to reveal plot.
+
+Then fix with:
+
+- body;
+- object;
+- interruption;
+- practical problem;
+- withheld answer;
+- sharper want;
+- a scene ending caused by changed pressure, not a quote.
+
+## Dry-Read Harness
+
+Run multiple readers with different jobs:
+
+- reader one starts at Chapter 1 and reports where attention drops;
+- reader two starts near the middle and reports confusion;
+- reader three reads only dialogue and reports false lines;
+- reader four reads only continuity and reports unearned reveals.
+
+Do not ask "is it good?" Ask what broke, where, and why.
+
+## Final Rule
+
+The AI can produce pages. The author decides what the pages cost.
+
+If the scene has no want, no pressure, and no change, the prose is only a
+surface. Fix the scene before polishing the sentence.

--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
     "cash:autopromo:bluesky": "python scripts/revenue/build_workflow_snapshot_autopromo.py --publish-bluesky",
     "cash:launch-readiness": "python scripts/system/product_launch_readiness.py",
     "cash:launch-readiness:gate": "python scripts/system/product_launch_readiness.py --fail-on-not-ready",
+    "writing:package": "python scripts/package_products.py --product writing",
+    "writing:package:all": "python scripts/package_products.py --product all",
     "system:workcell-demo": "python scripts/system/agent_workcell_demo.py",
     "smoke:remote-app-config": "python scripts/system/remote_app_config_smoke.py",
     "smoke:remote-app-config:live": "python scripts/system/remote_app_config_smoke.py --live",

--- a/scripts/package_products.py
+++ b/scripts/package_products.py
@@ -177,6 +177,10 @@ MAKING_OF_FILES = [
     ("docs/downloads/ai-writing-system-guide.md", "guides/ai-writing-system-guide.md"),
     ("docs/downloads/humanization-pass-checklist.md", "guides/humanization-pass-checklist.md"),
     ("docs/downloads/security-governance-checklist.md", "guides/security-governance-checklist.md"),
+    (
+        "docs/downloads/aethermoore-writing-techniques-fieldbook.md",
+        "guides/aethermoore-writing-techniques-fieldbook.md",
+    ),
     ("docs/books.html", "site-source/books.html"),
     ("docs/guides.html", "site-source/guides.html"),
     ("docs/books/six-tongues-protocol.html", "site-source/books/six-tongues-protocol.html"),
@@ -208,7 +212,8 @@ material for readers and writers who want to study the workflow.
 1. Read `PROCESS_NOTES.txt`.
 2. Open `guides/ai-writing-system-guide.md`.
 3. Open `guides/humanization-pass-checklist.md`.
-4. Use `site-source/` to see how the book pages and guide hub are positioned.
+4. Open `guides/aethermoore-writing-techniques-fieldbook.md`.
+5. Use `site-source/` to see how the book pages and guide hub are positioned.
 
 ## Support
 
@@ -369,7 +374,11 @@ def package_making_of(output_dir: Path) -> Path:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Package SCBE products for delivery")
-    parser.add_argument("--product", choices=["toolkit", "vault", "making-of", "all"], default="all")
+    parser.add_argument(
+        "--product",
+        choices=["toolkit", "vault", "making-of", "writing", "all"],
+        default="all",
+    )
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
     args = parser.parse_args()
 
@@ -385,7 +394,7 @@ def main() -> None:
         package_vault(args.output_dir)
         print()
 
-    if args.product in ("making-of", "all"):
+    if args.product in ("making-of", "writing", "all"):
         print("=== Packaging Behind-the-Scenes Writing Process Pack ===")
         package_making_of(args.output_dir)
         print()

--- a/tests/test_package_products.py
+++ b/tests/test_package_products.py
@@ -69,6 +69,7 @@ def test_making_of_zip_excludes_manuscripts_and_includes_process_guides(tmp_path
 
     assert "guides/ai-writing-system-guide.md" in names
     assert "guides/humanization-pass-checklist.md" in names
+    assert "guides/aethermoore-writing-techniques-fieldbook.md" in names
     assert "site-source/books.html" in names
     assert "does NOT include the manuscript text" in readme
     assert "Amazon/KDP sells the finished book" in process_notes


### PR DESCRIPTION
## Summary
- add an AetherMoore writing techniques fieldbook to the public downloads
- add 
pm run writing:package as a friendly alias for packaging the behind-the-scenes writing/process pack
- include the fieldbook in the existing behind-the-scenes ZIP and cover it with package tests

## Tests
- python -m pytest tests/test_package_products.py -q
- npm run writing:package -- --output-dir artifacts\\writing_pack_smoke_main
- git diff --check HEAD~1 HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive writing techniques fieldbook covering the AetherMoore writing process, including outline controls, character development, revision practices, and prose refinement techniques.

* **Chores**
  * Added npm package scripts to streamline distribution of writing resources and process documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->