### PR TITLE
fix(ci): use HF /api/whoami-v2 in secret-rotation audit

### DIFF
--- a/.github/workflows/secret-rotation-audit.yml
+++ b/.github/workflows/secret-rotation-audit.yml
@@ -76,7 +76,7 @@ jobs:
           fi
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer $HF_TOKEN" \
-            https://huggingface.co/api/whoami)
+            https://huggingface.co/api/whoami-v2)
           if [ "$STATUS" = "200" ]; then
             echo "HF_TOKEN: VALID"
           else


### PR DESCRIPTION
HuggingFace deprecated `GET /api/whoami` — it 401s even for valid tokens, so the nightly **Secret Rotation & Audit** job false-fails every run. Verified: a known-good token returns 401 on `/api/whoami`, 200 on `/api/whoami-v2`.

One-line fix. Only this workflow used the legacy endpoint. `HF_TOKEN` secret was also independently rotated to a verified-valid token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated token validation processes to use the latest API version for improved reliability in secret rotation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->