### PR TITLE
fix(geoseal-cli): wire missing terminus-training, yin-yang-dual, pair-agent-training subcommands

### DIFF
--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -5171,7 +5171,102 @@ def build_parser() -> argparse.ArgumentParser:
     p_wf_run.add_argument("--verbose", "-v", action="store_true")
     p_wf_run.set_defaults(func=cmd_workflow, workflow_cmd="run")
 
+    p_terminus = sub.add_parser(
+        "terminus-training",
+        help="Run Terminus guild agent training (benchmark or scripted scenario)",
+    )
+    p_terminus.add_argument("--mode", choices=["benchmark", "scripted"], default="benchmark")
+    p_terminus.add_argument("--scenario", default="guild_math_intro", help="Scenario name for scripted mode")
+    p_terminus.add_argument("--agent-id", default="benchmark-agent")
+    p_terminus.add_argument("--out-dir", default="artifacts/terminus_training")
+    p_terminus.add_argument("--json", action="store_true")
+    p_terminus.set_defaults(func=cmd_terminus_training)
+
+    p_yy = sub.add_parser("yin-yang-dual", help="Build a KO/DR yin-yang dual token packet")
+    p_yy.add_argument("--ko-text", required=True)
+    p_yy.add_argument("--dr-text", required=True)
+    p_yy.add_argument("--frame", type=int, choices=[0, 1], default=0, help="Active frame: 0=KO, 1=DR")
+    p_yy.add_argument("--size", type=int, default=9, help="Odd surface size >= 5")
+    p_yy.add_argument("--json", action="store_true")
+    p_yy.set_defaults(func=cmd_yin_yang_dual)
+
+    p_pair = sub.add_parser(
+        "pair-agent-training",
+        help="Build the GeoShell Builder/Navigator pair-agent SFT dataset",
+    )
+    p_pair.add_argument("--output-dir", default="training-data/sft")
+    p_pair.add_argument("--event-path", default="artifacts/geoshell/pair_agent/latest_events.json")
+    p_pair.add_argument("--json", action="store_true")
+    p_pair.set_defaults(func=cmd_pair_agent_training)
+
     return p
+
+
+def cmd_terminus_training(args: argparse.Namespace) -> int:
+    """Bridge the geoseal CLI to the Terminus guild training runner."""
+    from scripts.benchmark.terminus_training_runner import (
+        BENCHMARK_PATHS,
+        run_benchmark,
+        run_scripted,
+    )
+
+    out_dir = Path(args.out_dir)
+    if args.mode == "scripted":
+        payload = run_scripted(
+            BENCHMARK_PATHS[args.scenario],
+            agent_id=args.agent_id,
+            scenario=args.scenario,
+            out_dir=out_dir,
+        )
+    else:
+        payload = run_benchmark(out_dir, agent_id=args.agent_id)
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        score = payload.get("total_score", payload.get("score"))
+        print(f"pass={payload.get('pass', 'n/a')} score={score}")
+    return 0
+
+
+def cmd_yin_yang_dual(args: argparse.Namespace) -> int:
+    """Bridge the geoseal CLI to the KO/DR yin-yang dual token builder."""
+    from src.tokenizer.yin_yang_lattice import build_yin_yang_dual_packet
+
+    packet = build_yin_yang_dual_packet(
+        ko_text=args.ko_text,
+        dr_text=args.dr_text,
+        size=args.size,
+        active_frame=args.frame,
+    )
+    if args.json:
+        print(json.dumps(packet, indent=2))
+    else:
+        print(f"active={packet['active_tongue']} schema={packet['schema_version']}")
+    return 0
+
+
+def cmd_pair_agent_training(args: argparse.Namespace) -> int:
+    """Bridge the geoseal CLI to the GeoShell pair-agent SFT builder."""
+    from scripts.training_data.build_geoshell_pair_agent_sft import (
+        build_dataset,
+        write_outputs,
+    )
+
+    dataset = build_dataset()
+    paths = write_outputs(dataset, Path(args.output_dir), Path(args.event_path))
+    payload = {
+        "ok": True,
+        "train_count": len(dataset["train"]),
+        "holdout_count": len(dataset["holdout"]),
+        "paths": paths,
+        "geoshell_event_feed": paths["events"],
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"ok train={payload['train_count']} holdout={payload['holdout_count']} " f"manifest={paths['manifest']}")
+    return 0
 
 
 def main(argv: Optional[List[str]] = None) -> int:


### PR DESCRIPTION
## Problem
Three tracked tests shell out to `python -m src.geoseal_cli <subcmd>` for subcommands that were **never registered** in `build_parser()`, so they failed with argparse `invalid choice`:

- `tests/benchmark/test_terminus_training_runner.py::test_geoseal_terminus_training_cli`
- `tests/tokenizer/test_yin_yang_lattice.py::test_geoseal_yin_yang_dual_cli_json`
- `tests/training/test_geoshell_pair_agent_sft.py::test_geoseal_cli_builds_pair_agent_training_outputs`

These stayed green in CI because `scbe-tests.yml` only runs `symphonic_cipher/tests/` — it does not exercise `tests/benchmark`, `tests/tokenizer`, or `tests/training`. Silent CLI rot.

## Fix
Each subcommand is a thin delegate to its **already-tested** backing module — no new logic:

| Subcommand | Delegates to |
|---|---|
| `terminus-training` | `scripts/benchmark/terminus_training_runner` |
| `yin-yang-dual` | `src/tokenizer/yin_yang_lattice` |
| `pair-agent-training` | `scripts/training_data/build_geoshell_pair_agent_sft` |

Additive only (subparsers at end of `build_parser()` + `cmd_*` delegates before `main`); lazy imports. `black` formatted.

## Verification
- 3 previously-failing CLI tests now pass.
- Full `geoseal` selection: **378 passed, 0 failed** (was 2 failed before this branch).
- No regressions; parser builds clean with all subcommands registered.

## Follow-up (not in this PR)
CI gap is real: consider adding `tests/benchmark` + `tests/tokenizer` + `tests/training` to a gating workflow so this class of CLI rot can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `terminus-training` subcommand to run Terminus guild training in benchmark or scripted mode with configurable output formats (JSON or summary)
  * Added `yin-yang-dual` subcommand to build and output KO/DR yin-yang dual token packets in multiple formats
  * Added `pair-agent-training` subcommand to generate GeoShell pair-agent training datasets with flexible output formatting options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->