### PR TITLE
fix(geoseal-cli): graceful errors for bridge subcommands

### DIFF
--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -5211,15 +5211,22 @@ def cmd_terminus_training(args: argparse.Namespace) -> int:
     )
 
     out_dir = Path(args.out_dir)
-    if args.mode == "scripted":
-        payload = run_scripted(
-            BENCHMARK_PATHS[args.scenario],
-            agent_id=args.agent_id,
-            scenario=args.scenario,
-            out_dir=out_dir,
-        )
-    else:
-        payload = run_benchmark(out_dir, agent_id=args.agent_id)
+    try:
+        if args.mode == "scripted":
+            if args.scenario not in BENCHMARK_PATHS:
+                raise SystemExit(
+                    f"error: unknown scenario {args.scenario!r}; choose from {', '.join(sorted(BENCHMARK_PATHS))}"
+                )
+            payload = run_scripted(
+                BENCHMARK_PATHS[args.scenario],
+                agent_id=args.agent_id,
+                scenario=args.scenario,
+                out_dir=out_dir,
+            )
+        else:
+            payload = run_benchmark(out_dir, agent_id=args.agent_id)
+    except (ValueError, KeyError, FileNotFoundError) as exc:
+        raise SystemExit(f"error: {exc}")
 
     if args.json:
         print(json.dumps(payload, indent=2))
@@ -5233,12 +5240,15 @@ def cmd_yin_yang_dual(args: argparse.Namespace) -> int:
     """Bridge the geoseal CLI to the KO/DR yin-yang dual token builder."""
     from src.tokenizer.yin_yang_lattice import build_yin_yang_dual_packet
 
-    packet = build_yin_yang_dual_packet(
-        ko_text=args.ko_text,
-        dr_text=args.dr_text,
-        size=args.size,
-        active_frame=args.frame,
-    )
+    try:
+        packet = build_yin_yang_dual_packet(
+            ko_text=args.ko_text,
+            dr_text=args.dr_text,
+            size=args.size,
+            active_frame=args.frame,
+        )
+    except (ValueError, KeyError) as exc:
+        raise SystemExit(f"error: {exc}")
     if args.json:
         print(json.dumps(packet, indent=2))
     else:
@@ -5253,8 +5263,11 @@ def cmd_pair_agent_training(args: argparse.Namespace) -> int:
         write_outputs,
     )
 
-    dataset = build_dataset()
-    paths = write_outputs(dataset, Path(args.output_dir), Path(args.event_path))
+    try:
+        dataset = build_dataset()
+        paths = write_outputs(dataset, Path(args.output_dir), Path(args.event_path))
+    except (ValueError, KeyError, OSError) as exc:
+        raise SystemExit(f"error: {exc}")
     payload = {
         "ok": True,
         "train_count": len(dataset["train"]),

--- a/tests/test_geoseal_cli_error_handling.py
+++ b/tests/test_geoseal_cli_error_handling.py
@@ -1,0 +1,45 @@
+"""Geoseal CLI subcommand error-handling contract.
+
+The bridge subcommands (terminus-training, yin-yang-dual, pair-agent-training)
+delegate to backing modules that raise ValueError/KeyError on invalid domain
+input. The CLI must surface those as a clean one-line error with a non-zero
+exit code -- matching geoseal_cli house style -- never a raw Python traceback.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "src.geoseal_cli", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+
+
+def test_yin_yang_dual_bad_size_fails_cleanly() -> None:
+    proc = _run("yin-yang-dual", "--ko-text", "a", "--dr-text", "b", "--size", "8")
+    assert proc.returncode != 0
+    assert "Traceback (most recent call last)" not in proc.stderr
+    assert "size must be an odd integer >= 5" in proc.stderr
+
+
+def test_terminus_training_bad_scenario_fails_cleanly() -> None:
+    proc = _run("terminus-training", "--mode", "scripted", "--scenario", "nope")
+    assert proc.returncode != 0
+    assert "Traceback (most recent call last)" not in proc.stderr
+
+
+def test_yin_yang_dual_valid_input_still_succeeds() -> None:
+    proc = _run("yin-yang-dual", "--ko-text", "route", "--dr-text", "shape", "--frame", "1", "--json")
+    assert proc.returncode == 0, proc.stderr
+    assert '"schema_version": "scbe-yin-yang-dual-token-v1"' in proc.stdout


### PR DESCRIPTION
## Problem
`terminus-training`, `yin-yang-dual`, `pair-agent-training` delegated to backing modules without guarding domain errors. Invalid input leaked a **raw Python traceback** (exit 1) instead of a clean message — inconsistent with geoseal_cli house style (9 existing `cmd_*` guards use `except (ValueError|KeyError): raise SystemExit(...)`).

```
# before
$ geoseal yin-yang-dual --size 8 ...   -> Traceback ... ValueError: size must be an odd integer >= 5
# after
$ geoseal yin-yang-dual --size 8 ...   -> error: size must be an odd integer >= 5   (exit 1, no traceback)
$ geoseal terminus-training --scenario nope -> error: unknown scenario 'nope'; choose from guild_math_intro, representation_guilds
```

## Fix
Wrap each delegate in `except (ValueError, KeyError[, OSError]) -> SystemExit("error: ...")`; unknown `--scenario` now enumerates valid choices.

## Tests / proof
- New `tests/test_geoseal_cli_error_handling.py` — RED before (traceback leaked), GREEN after.
- Live CLI verified: clean errors + exit 1; happy paths still emit real artifacts (SFT jsonl, benchmark report, token packet).
- Regression: full `geoseal` selection **393 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI commands now display user-friendly error messages instead of raw Python stack traces when encountering invalid inputs or data issues.

* **Tests**
  * Added integration tests to ensure CLI commands fail gracefully, emit proper error messages, and do not display raw Python tracebacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->