### PR TITLE
fix(security): constrain path and URL alert sinks

### DIFF
--- a/scripts/security/traditional_security_layers.py
+++ b/scripts/security/traditional_security_layers.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import math
 import sys
+import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,6 +24,14 @@ DEFAULT_POLICY_PATH = REPO_ROOT / "config" / "security" / "traditional_security_
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "artifacts" / "security" / "traditional_layers"
 SCHEMA_VERSION = "scbe_traditional_security_layers_v1"
 EICAR_ASCII = b"X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
+ALLOWED_PATH_ROOTS = tuple(
+    root.resolve()
+    for root in (
+        REPO_ROOT,
+        Path.home(),
+        Path(tempfile.gettempdir()),
+    )
+)
 
 
 @dataclass(frozen=True)
@@ -53,8 +62,41 @@ def now_utc() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_local_path(path: Path, *, must_exist: bool = False) -> Path:
+    """Resolve a caller-supplied path and enforce local allowed roots.
+
+    The security layer is a local artifact triage tool. It can inspect files in
+    the repo, the user's profile, or the OS temp tree used by tests, but it must
+    not let API/CLI input become an arbitrary filesystem path expression.
+    """
+    resolved = path.expanduser().resolve(strict=must_exist)
+    if not any(_is_relative_to(resolved, root) for root in ALLOWED_PATH_ROOTS):
+        allowed = ", ".join(str(root) for root in ALLOWED_PATH_ROOTS)
+        raise ValueError(f"path is outside allowed local roots: {resolved} (allowed: {allowed})")
+    return resolved
+
+
+def resolve_local_file(path: Path) -> Path:
+    resolved = resolve_local_path(path, must_exist=True)
+    if not resolved.is_file():
+        raise FileNotFoundError(resolved)
+    return resolved
+
+
+def resolve_local_output_dir(path: Path) -> Path:
+    return resolve_local_path(path, must_exist=False)
+
+
 def public_path(path: Path) -> str:
-    raw = str(path.resolve())
+    raw = str(resolve_local_path(path, must_exist=False))
     replacements = {
         str(REPO_ROOT): "%REPO%",
         str(Path.home()): "%USERPROFILE%",
@@ -66,6 +108,7 @@ def public_path(path: Path) -> str:
 
 
 def sha256_file(path: Path) -> str:
+    path = resolve_local_file(path)
     digest = hashlib.sha256()
     with path.open("rb") as fh:
         for chunk in iter(lambda: fh.read(1024 * 1024), b""):
@@ -107,6 +150,7 @@ def magic_kind(data: bytes) -> str:
 
 
 def load_policy(path: Path = DEFAULT_POLICY_PATH) -> dict[str, Any]:
+    path = resolve_local_path(path, must_exist=False)
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8"))
@@ -124,8 +168,8 @@ def _is_trusted_repo_path(path: Path, policy: dict[str, Any]) -> bool:
 def evaluate_artifact(
     path: Path, policy_path: Path = DEFAULT_POLICY_PATH, max_bytes: int = 5_000_000
 ) -> TraditionalSecurityReport:
-    if not path.exists() or not path.is_file():
-        raise FileNotFoundError(path)
+    path = resolve_local_file(path)
+    policy_path = resolve_local_path(policy_path, must_exist=False)
     policy = load_policy(policy_path)
     data = path.read_bytes()
     scanned = data[:max_bytes]
@@ -250,6 +294,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     report = evaluate_artifact(args.artifact, policy_path=args.policy)
     payload = report_to_dict(report)
+    args.output_dir = resolve_local_output_dir(args.output_dir)
     args.output_dir.mkdir(parents=True, exist_ok=True)
     out_path = args.output_dir / f"{report.artifact_sha256[:16]}.json"
     out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/services/scbe-shim-space/app.py
+++ b/services/scbe-shim-space/app.py
@@ -114,6 +114,23 @@ class TriageRequest(BaseModel):
     max_bytes: Optional[int] = 5_000_000
 
 
+def _resolve_triage_artifact_path(raw_path: str):
+    import pathlib as _pl
+    import tempfile as _tempfile
+
+    candidate = _pl.Path(raw_path).expanduser().resolve(strict=True)
+    allowed_roots = [
+        _pl.Path.cwd().resolve(),
+        _pl.Path(__file__).resolve().parent,
+        _pl.Path(_tempfile.gettempdir()).resolve(),
+    ]
+    if not any(candidate == root or root in candidate.parents for root in allowed_roots):
+        raise HTTPException(status_code=400, detail="artifact path is outside allowed local roots")
+    if not candidate.is_file():
+        raise HTTPException(status_code=404, detail="artifact is not a file")
+    return candidate
+
+
 @app.post("/v1/scbe/triage")
 def scbe_triage(req: TriageRequest) -> dict:
     """Run Codex's traditional security layers + signal fusion on a local
@@ -129,11 +146,10 @@ def scbe_triage(req: TriageRequest) -> dict:
             status_code=501,
             detail="traditional_security_layers not importable in this deploy; mount the repo or rebuild with --build-arg INCLUDE_REPO=1",
         )
-    import pathlib as _pl
-
-    p = _pl.Path(req.artifact_path)
-    if not p.exists():
-        raise HTTPException(status_code=404, detail=f"artifact not found: {p}")
+    try:
+        p = _resolve_triage_artifact_path(req.artifact_path)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="artifact not found") from None
     try:
         report = _evaluate_artifact(p, max_bytes=req.max_bytes or 5_000_000)  # type: ignore
     except Exception as e:

--- a/tests/system/test_build_static_analysis_training_dataset.py
+++ b/tests/system/test_build_static_analysis_training_dataset.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "system" / "build_static_analysis_training_dataset.py"
@@ -17,6 +19,10 @@ def _load_module(path: Path, name: str):
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _url_hosts(text: str) -> set[str]:
+    return {urlparse(match.group(0)).netloc for match in re.finditer(r"https?://[^\s)\"']+", text)}
 
 
 def test_redaction_removes_tokens_and_home_path() -> None:
@@ -36,7 +42,7 @@ def test_scenarios_include_shopify_tailwind_and_safety_gate() -> None:
     assert "shopify_tailwind_cdn_to_bundled_vite" in scenarios
     assert "safe_reverse_engineering_policy_gate" in scenarios
     assert "reverse_engineering_levels_video_to_training" in scenarios
-    assert "cdn.tailwindcss.com" in scenarios["shopify_tailwind_cdn_to_bundled_vite"].user_prompt
+    assert "cdn.tailwindcss.com" in _url_hosts(scenarios["shopify_tailwind_cdn_to_bundled_vite"].user_prompt)
     assert "offensive payload" in " ".join(scenarios["safe_reverse_engineering_policy_gate"].remediation_steps)
     video = scenarios["reverse_engineering_levels_video_to_training"]
     assert "strings" in " ".join(video.analysis_steps)

--- a/tests/test_vercel_launch_bridge.py
+++ b/tests/test_vercel_launch_bridge.py
@@ -1,9 +1,33 @@
 from __future__ import annotations
 
+from html.parser import HTMLParser
 import json
 from pathlib import Path
+from urllib.parse import urlparse
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _HrefParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        for name, value in attrs:
+            if name == "href" and value:
+                self.hrefs.append(value)
+
+
+def _hrefs(html: str) -> list[str]:
+    parser = _HrefParser()
+    parser.feed(html)
+    return parser.hrefs
+
+
+def _assert_url_present(html: str, expected: str) -> None:
+    expected_url = urlparse(expected)
+    assert any(urlparse(href) == expected_url for href in _hrefs(html))
 
 
 def test_vercel_launch_rewrites_root_and_launch_to_agent_page() -> None:
@@ -285,9 +309,9 @@ def test_shopify_command_center_page_exposes_demo_repo_and_payment_paths() -> No
     sitemap = (REPO_ROOT / "docs" / "sitemap.xml").read_text(encoding="utf-8")
 
     assert "Shopify Store Ops Snapshot" in page
-    assert "https://shopify-command-center-165664533862.us-west2.run.app" in page
-    assert "https://github.com/issdandavis/Shopify-Command-Center" in page
-    assert "https://ko-fi.com/izdandavis" in page
+    _assert_url_present(page, "https://shopify-command-center-165664533862.us-west2.run.app")
+    _assert_url_present(page, "https://github.com/issdandavis/Shopify-Command-Center")
+    _assert_url_present(page, "https://ko-fi.com/izdandavis")
     assert "$IzzyDDavis7" in page
     assert "static/polly-sidebar-agent.js" in page
     assert "Shopify Store Ops Snapshot" in products


### PR DESCRIPTION
## Summary
- constrain traditional security artifact/policy/output paths to resolved local roots before reading or writing
- constrain the scbe-shim triage endpoint to resolved local artifact files under allowed roots
- replace CodeQL-flagged URL substring assertions with parsed URL/host checks in tests

## Test evidence
- python -m py_compile scripts/security/traditional_security_layers.py services/scbe-shim-space/app.py
- python -m pytest tests/security/test_traditional_security_layers.py tests/system/test_build_static_analysis_training_dataset.py tests/test_vercel_launch_bridge.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced path validation for CLI and API file inputs with restricted access to allowed system directories.
  * File path resolution now enforces sandboxing to prevent access outside permitted roots.

* **Tests**
  * Improved test utilities for URL and path extraction validation.
  * Updated test assertions to use structured parsing instead of substring matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->