### PR TITLE
fix(agent-bus): stabilize workspace lineage ordering

### DIFF
--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -901,6 +901,16 @@ const LINEAGE_KIND_BY_SCHEMA: Record<string, LineageEntry['kind']> = {
   'aethermoor.bus.workspace_trap_dispatch.v1': 'trap_dispatch',
 };
 
+const LINEAGE_KIND_ORDER: Record<LineageEntry['kind'], number> = {
+  formation: 0,
+  ingest: 1,
+  import: 2,
+  export: 3,
+  verify: 4,
+  trap_dispatch: 5,
+  unknown: 99,
+};
+
 /**
  * Walk a workspace's 20_receipts/ directory and build a chronological audit
  * chain of formation, export, and verify receipts. Read-only: never writes.
@@ -944,6 +954,8 @@ export function lineageAgentWorkspace(
       if (parsed) {
         if (typeof parsed.created_at === 'string') timestamp = parsed.created_at;
         else if (typeof parsed.verified_at === 'string') timestamp = parsed.verified_at as string;
+        else if (typeof parsed.ingested_at === 'string') timestamp = parsed.ingested_at as string;
+        else if (typeof parsed.imported_at === 'string') timestamp = parsed.imported_at as string;
       }
       if (!timestamp) {
         try {
@@ -987,7 +999,12 @@ export function lineageAgentWorkspace(
     }
   }
   entries.sort((a, b) => {
-    if (a.timestamp && b.timestamp) return a.timestamp.localeCompare(b.timestamp);
+    if (a.timestamp && b.timestamp) {
+      const byTimestamp = a.timestamp.localeCompare(b.timestamp);
+      if (byTimestamp !== 0) return byTimestamp;
+    }
+    const byKind = LINEAGE_KIND_ORDER[a.kind] - LINEAGE_KIND_ORDER[b.kind];
+    if (byKind !== 0) return byKind;
     return a.receipt_name.localeCompare(b.receipt_name);
   });
 


### PR DESCRIPTION
## Summary
- use receipt-native timestamps for ingest/import lineage entries
- add deterministic same-timestamp ordering so formation stays before import/export/verify receipts
- fixes the scheduled CI failure in SCBE Overnight Pipeline run 26222349282

## Test evidence
- npm run build (packages/agent-bus)
- python -m pytest tests/system/test_agent_bus_workspace_cli.py::test_workspace_lineage_classifies_import tests/system/test_agent_bus_workspace_cli.py::test_workspace_lineage_classifies_chain tests/system/test_agent_bus_workspace_cli.py::test_workspace_export_import_export_roundtrip_preserves_content -q
- python -m pytest tests/system/test_agent_bus_workspace_cli.py -q

## Rollback
- revert this single commit; lineage ordering falls back to previous timestamp/name sorting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced lineage data ordering to ensure accurate chronological sequencing across receipt types when timestamps are unavailable or identical.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->