### PR TITLE
feat(narrative-combat): add go board legality engine

### DIFF
--- a/docs/superpowers/specs/2026-05-21-go-board-narrative-engine-design.md
+++ b/docs/superpowers/specs/2026-05-21-go-board-narrative-engine-design.md
@@ -1,0 +1,198 @@
+# Go-Board Narrative Combat Engine — Design
+
+Date: 2026-05-21
+Status: approved (author-delegated; user authorized autonomous build)
+Package: `src/narrative_combat/go_board/` — a **domain-agnostic legality kernel** plus a
+**narrative-combat adapter** (the first of several planned domains). Sibling to the linear
+maze-director.
+
+## The board is a legality engine (SCBE Board Kernel)
+
+The board is not a writing engine; it is a **deterministic graph-lattice legality controller**.
+The core rule across every domain:
+
+> The LLM (or any agent) may *suggest* moves. The board decides whether a move is **legal**.
+
+This matters because hard domains already have real truth gates; the board just gives those
+gates a shared memory and a move system. Architecture: a generic `kernel` (players, points,
+typed nodes, legality, capture, superko, score, graph view — **no domain words, no SCBE
+imports**) with thin **domain adapters** on top.
+
+| Board concept | Narrative (v1) | Coding (next adapter) |
+|---|---|---|
+| stone | character / faction / event | AST-IR node, file, function, type, test, API |
+| liberty | possible next beat | valid compile/test/refactor path |
+| capture | contradiction, dead branch, weak scene | type error, failing test, broken import, unsafe cmd, secret leak |
+| ko (superko) | prevents repeated plot loops | prevents rewrite loops / repeated failed patches |
+| territory | zone influence | module ownership, dependency boundary |
+| qi (resource node) | pressure / emotional resource | compute, context, model/tool budget |
+| treaty edge | brokered truce zone | contract between modules / APIs / schemas / tests |
+
+The kernel is the publishable core and the future bridge into the SCBE 14-layer governance and
+agent bus (that wiring is a *separate* adapter that imports both — the kernel itself stays pure).
+v1 ships the narrative adapter end-to-end and proves the kernel by structuring it so a coding
+adapter is an addition, not a rewrite.
+
+## One-line
+
+A deterministic **Go-derived graph-lattice** is the authoritative truth layer; a fixed
+six-phase director drives narratively-meaningful moves across it; each verified board event
+becomes a story beat the translator renders. Same invariant as the maze-director: **the board
+is truth, the LLM only renders.**
+
+> Framing (working definition): a deterministic Go-derived graph lattice where stones represent
+> combatant parties, liberties represent available action space, captures represent
+> failed/removed options, ko prevents looped reasoning, and added typed nodes represent borders,
+> treaties, qi, terrain, and research/study moves. LLMs do not decide truth; they translate
+> verified board events into narrative.
+
+It is a **state-space / graph-lattice engine**, not a literal dimensional manifold — the
+manifold/lattice math (if formalized) lives on the SCBE side; here a board "string" is a graph
+node and liberties are its edges, which is the rigorous version of the lattice idea.
+
+## Rules base
+
+Tromp-Taylor-style backbone: **positional superko** (no whole-board repeat) and **area scoring**
+(stones + surrounded empty points). Deliberate divergence for v1 simplicity: **suicide is
+illegal** (mainstream convention) rather than T-T's legal-self-removal — documented, not silent.
+Ref: https://tromp.github.io/go.html
+
+Known T-T behavior (not a bug): the empty starting position is in the superko history at
+construction, so a move that legitimately empties the board again would be rejected. This is
+correct positional-superko under Tromp-Taylor; it only matters on tiny boards / full captures.
+
+## Why a board
+
+Go concepts map cleanly onto narrative structure:
+
+| Go concept | Narrative meaning |
+|---|---|
+| stone / group | a combatant party's local presence |
+| liberties | the options open to that group |
+| atari (1 liberty) | a crisis / cliffhanger |
+| capture | a faction's local position collapses |
+| positional superko | a feud that cannot immediately repeat |
+| sente / gote | who controls the scene's tempo |
+| territory | influence over a zone |
+
+Plus three pieces the linear engine never had:
+
+- **Qi node** — a board point that, once claimed by an adjacent stone, grants a party qi
+  (spendable power). Makes qi spatial and contestable, not a private counter.
+- **Treaty zone** — a rectangle locked by a party; inside it, capture is forbidden. A truce
+  made structural. Lets a duel end in a brokered peace, not only a kill.
+- **Study move** — a party spends a turn to consult outside sources (web search), turning a
+  turn into a knowledge advantage. **Web search is a move on the board**, governed and audited.
+
+## Honest framing (the design hand-wave, resolved)
+
+The arc does **not** emerge from free play (that is a research project). The director runs a
+fixed phase machine; the board supplies the spatial mechanics that make each phase non-trivial.
+Phases drop onto the existing `PhaseName` literal:
+
+1. **opening** — each party places 2 separated stones (presence)
+2. **first_tactic** — a forced-adjacency contact move
+3. **hidden_problem** — moves that reduce a target group's liberties (incl. a Study move)
+4. **cost_unavoidable** — target group brought to atari (1 liberty)
+5. **strategy_change** — defender plays Treaty or Study, OR attacker commits to the capture
+6. **understanding_wins** — capture executed / treaty locked; score + aftermath
+
+The seed shuffles move ordering within a phase; the phase structure is fixed.
+
+## Truth layer: `board.py` (Goban)
+
+- 9×9 grid (hard-coded v1). Cell = party index (`int`) or `None`.
+- `group_and_liberties(pt)` — BFS over same-color adjacency → (group points, liberty points).
+- `place(party, pt)` — empty-check → place → remove opponent groups at 0 liberties →
+  reject own-group suicide → reject positional-superko repeat (whole-board hash history) →
+  commit. Returns captured points. Raises `IllegalMove` otherwise.
+- `legal_placements(party)` — points where `place` would succeed (director picks from these).
+- `score()` — stones + simple territory (empty region bordered by one color only). For aftermath.
+- `ascii()` — text board for the packet + demo.
+
+Cut from v1: life/eye detection (Benson's), the suicide-that-captures edge case, custom sizes.
+
+## Governed search: `governor.py`
+
+`SearchGovernor` (≤50 lines, fully local — **no SCBE governance imports**):
+- allowlist + per-call audit-log entry (query, decision, backend, latency). The `timeout` is
+  carried as an advisory bound and recorded, not enforced on the stub backend; a real v2 backend
+  is responsible for honoring it.
+- pluggable backend; **deterministic stub default** (mirrors `LLMTranslator` fallback exactly)
+- result cache keyed by `(seed, turn_index, query)` → same encounter+seed ⇒ same fight even if
+  a real backend is wired in v2.
+
+## Rendering: `translator.py` (Go variant)
+
+- `GoTemplateTranslator` — deterministic, golden-stable; renders a `TurnEvent` via a literal
+  **board-event → beat-frame dispatch table** (not implicit director logic).
+- `GoLLMTranslator` — opt-in; same pattern as the maze `LLMTranslator` (facts dict, party
+  **temperament** wired in, fallback to template on any failure).
+
+## Output
+
+CLI `python -m src.narrative_combat.go_board.cli` emits a `scbe.narrative_combat.go_fight.v1`
+packet: schema, encounter_id, seed, board_size, parties, qi/treaty state, ordered `turns`, final
+ascii board, aftermath (captures, score, treaties, surviving qi).
+
+Each turn carries four fields (the user's "board event → mechanical summary → story beat →
+verifier note" shape):
+- `board_event` — the typed event (presence / contact / liberty_pressure / atari / qi_claimed /
+  study_revealed / treaty_locked / capture)
+- `mechanical` — the deterministic truth (points changed, liberties remaining, captured stones,
+  qi delta, score delta)
+- `prose` — the rendered beat (template or LLM)
+- `verifier` — a note asserting prose↔truth correspondence: the mechanical claim the prose must
+  honor, plus a flag if the LLM fell back or the render is empty. (v1 records the contract; v2
+  can run an NLI/keyword check against it.)
+
+## Future axis (v2+) — board as shared world-state for an agent harness
+
+User framing (2026-05-21): A→Z is visible (A = "write this fight / solve this scene / analyze
+this system"; Z = final narrative or report); the board is the hidden b–y middle — board state,
+legal moves, parallel attempts, rule checks, captures/failures, deliberation, rewrite, verifier,
+render. The win over "spawn five agents and summarize" (cf. HeavySkill: parallel reasoning +
+deliberation) is that the board gives agents a **real shared world** instead of a pile of vibes;
+reasoning paths are shaped by board/legal-move constraints. Deferred v1 move types that this
+needs: `move_party`, `break_treaty`, `TerrainCell`. Graph view (strings=nodes, liberties=edges,
+captures=graph rewrites) is the bridge to the lattice-analysis idea.
+
+## Invariants / constraints
+
+- Board state is the only source of truth; the translator never invents captures/outcomes.
+- Deterministic for a given seed (incl. the stub Study backend).
+- Package isolated: no `agentbus` / `governance` / `harmonic` imports.
+- Reuse `models.Fighter`/`Technique`/`Terrain` where they fit; add local dataclasses otherwise.
+
+## Probe moves (sensing the state space)
+
+Two move classes, not one:
+- **legal move** — commits; changes board state.
+- **probe move** — samples without committing: `probe(player, pt) → Observation` (would it be
+  legal? what would it capture? would it repeat a ko / be suicide?). `commit: false`.
+
+Then the caller's loop is: `if probe improves confidence: promote to legal move; else: reject
+(capture the invalid branch)`. Superko also forbids *repeating a failed probe's* committed
+result. This is how good coding already works — poke, measure, then play the real move. In v1
+the kernel exposes `probe()` (it is the same simulation `legal_placements` already needs); the
+narrative Study move and the "render one beat in N tones" comparison are probe moves in spirit.
+Atari is the warning state: one more committed move breaks the group.
+
+## Tests (v1 gate)
+
+liberties correct · capture removes group · superko forbids immediate recapture · illegal move
+rejected · packet shape + invariants · determinism by seed · search governor audits + falls back.
+
+## Future axis (v2+) — boards as a cross-dimensional reference lattice
+
+User seed (2026-05-21): treat a board as a **dimensional manifold** whose points are degrees of
+freedom, and *stack* boards so that a "chemistry style" (each point carries a composition of
+elements/stone-types, like bonds) mixes with an "algebraic style" (the existing weighted/
+harmonic lattice) to form a **cross-dimensional analysis reference lattice**. Each board becomes
+one coordinate axis; a lattice of boards becomes a higher-dimensional analysis surface.
+
+v1 enabler, not v1 scope: keep the `Goban` a clean coordinate object — points addressed by
+`(row, col)`, single-occupant cells, no global singletons — so a v2 can add a third "layer" axis
+(stacked boards) and a per-point composition vector without reworking the core. The lattice
+*analysis* itself belongs on the SCBE side (polyhedral / 47D-manifold machinery); the engine
+stays isolated and just exposes board state as a serializable coordinate grid.

--- a/src/narrative_combat/go_board/__init__.py
+++ b/src/narrative_combat/go_board/__init__.py
@@ -1,0 +1,9 @@
+"""Go-board narrative engine: a domain-agnostic legality kernel + a narrative-combat adapter.
+
+The kernel (`kernel.Board`) decides legality; callers only propose moves. This is the
+publishable core of the "SCBE Board Kernel" idea — no domain words, no SCBE imports.
+"""
+
+from .kernel import Board, IllegalMove, MoveResult, Observation
+
+__all__ = ["Board", "IllegalMove", "MoveResult", "Observation"]

--- a/src/narrative_combat/go_board/cli.py
+++ b/src/narrative_combat/go_board/cli.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .director import GoDirector
+from .fixtures import boss_board_demo
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a Go-board narrative fight packet.")
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--out", type=Path)
+    parser.add_argument(
+        "--translator",
+        choices=["template", "llm"],
+        default="template",
+        help="template = deterministic (default); llm = prose via Ollama, falls back to template",
+    )
+    parser.add_argument("--style", default=None, help="override prose style for the llm translator")
+    parser.add_argument("--model", default="glm-5.1:cloud", help="Ollama model for the llm translator")
+    parser.add_argument("--ollama-host", default="http://127.0.0.1:11434")
+    args = parser.parse_args()
+
+    encounter = boss_board_demo(seed=args.seed)
+    translator = None
+    if args.translator == "llm":
+        from .translator import GoLLMTranslator
+
+        translator = GoLLMTranslator(
+            model=args.model,
+            host=args.ollama_host,
+            style=args.style or encounter.style,
+        )
+
+    packet = GoDirector(encounter, translator=translator).run()
+    payload = json.dumps(packet, indent=2, sort_keys=True)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/narrative_combat/go_board/director.py
+++ b/src/narrative_combat/go_board/director.py
@@ -1,0 +1,217 @@
+"""Phase machine: drives narratively-meaningful moves across the legality kernel.
+
+Honest framing — the arc does not emerge from free play. The director runs a fixed six-phase
+sequence (opening -> first_tactic -> hidden_problem -> cost_unavoidable -> strategy_change ->
+understanding_wins); the board supplies the spatial mechanics (liberties, capture, ko, qi,
+treaty, study) that make each phase non-trivial. Every turn carries the board_event, the
+deterministic `mechanical` truth, the rendered `prose`, and a `verifier` note asserting the
+prose must honor that truth. The seed decides the climax: a capture or a brokered treaty.
+"""
+
+from __future__ import annotations
+
+from random import Random
+from typing import Any
+
+from .governor import SearchGovernor, StudyRecord
+from .kernel import Board
+from .models import GoEncounter
+from .translator import GoTemplateTranslator
+
+SCHEMA = "scbe.narrative_combat.go_fight.v1"
+DEFENDER_ANCHOR = (2, 2)  # the pressured group the fight forms around
+
+
+class GoDirector:
+    def __init__(self, encounter: GoEncounter, translator: Any | None = None, governor: SearchGovernor | None = None):
+        self.encounter = encounter
+        self.board = Board(size=encounter.board_size)
+        self.rng = Random(encounter.seed)
+        self.translator = translator if translator is not None else GoTemplateTranslator()
+        self.governor = governor if governor is not None else SearchGovernor()
+        self.qi: dict[int, int] = {p.color: 0 for p in encounter.parties}
+        self.captures: dict[int, int] = {p.color: 0 for p in encounter.parties}
+        self.claimed_qi: set = set()
+        self.treaty_zone: list | None = None
+        self._turns: list[dict] = []
+        self._turn_index = 0
+
+    def run(self) -> dict[str, Any]:
+        attacker = self.encounter.parties[0].color
+        defender = self.encounter.parties[1].color
+        target = DEFENDER_ANCHOR
+
+        self._place(attacker, (6, 6), "opening", "presence")
+        self._place(defender, target, "opening", "presence")
+        self._pressure(attacker, (2, 3), target, "first_tactic", "contact")
+        self._pressure(attacker, (1, 2), target, "hidden_problem", "liberty_pressure")
+        self._claim_qi(attacker, (4, 3), "hidden_problem")
+        self._study(attacker, "hidden_problem")
+        self._pressure(attacker, (3, 2), target, "cost_unavoidable", "atari")
+
+        kill = (2, 1)
+        observation = self.board.probe(attacker, kill)  # the probe move: sense without committing
+        self._emit(
+            "strategy_change",
+            attacker,
+            "probe",
+            {"point": kill, "would_capture": [list(p) for p in observation.would_capture], "committed": False},
+            f"probe only; would capture {[list(p) for p in observation.would_capture]}; board left unchanged",
+        )
+
+        if self.rng.random() < 0.5:
+            ending = self._capture(attacker, kill, "understanding_wins")
+        else:
+            ending = self._treaty(defender, target, "understanding_wins")
+        return self._packet(ending)
+
+    # --- turn emitters ---
+
+    def _emit(self, phase: str, color: int, board_event: str, mechanical: dict, verifier_claim: str) -> dict:
+        event = {"phase": phase, "party": color, "board_event": board_event, "mechanical": mechanical}
+        prose = self.translator.render(event, self.encounter)
+        self._turn_index += 1
+        turn = {
+            "turn_id": f"turn_{self._turn_index:03d}",
+            "phase": phase,
+            "party": self.encounter.parties[color].name,
+            "color": color,
+            "board_event": board_event,
+            "mechanical": mechanical,
+            "prose": prose,
+            "verifier": {"claim": verifier_claim, "source": "kernel", "rendered": bool(prose)},
+        }
+        self._turns.append(turn)
+        return turn
+
+    def _place(self, color: int, pt: tuple, phase: str, board_event: str) -> dict:
+        result = self.board.place(color, pt)
+        name = self.encounter.parties[color].name
+        return self._emit(
+            phase,
+            color,
+            board_event,
+            {"point": pt, "liberties": result.liberties},
+            f"{name} placed at {pt}; its group has {result.liberties} liberties",
+        )
+
+    def _pressure(self, color: int, pt: tuple, target: tuple, phase: str, board_event: str) -> dict:
+        self.board.place(color, pt)
+        _, libs = self.board.group_and_liberties(target)
+        name = self.encounter.parties[color].name
+        return self._emit(
+            phase,
+            color,
+            board_event,
+            {"point": pt, "target": target, "target_liberties": len(libs)},
+            f"after {name} plays {pt}, the group at {target} has {len(libs)} liberties left",
+        )
+
+    def _claim_qi(self, color: int, pt: tuple, phase: str) -> dict:
+        self.board.place(color, pt)
+        name = self.encounter.parties[color].name
+        for node in self.encounter.qi_nodes:
+            if node.point in self.claimed_qi:
+                continue
+            if node.point == pt or node.point in self.board.neighbors(pt):
+                self.claimed_qi.add(node.point)
+                self.qi[color] += node.value
+                return self._emit(
+                    phase,
+                    color,
+                    "qi_claimed",
+                    {"point": pt, "qi_node": node.point, "qi_gained": node.value, "qi_total": self.qi[color]},
+                    f"{name} claimed qi node {node.point} (+{node.value}); reserve now {self.qi[color]}",
+                )
+        return self._emit(
+            phase,
+            color,
+            "presence",
+            {"point": pt, "liberties": self.board.liberties(pt)},
+            f"{name} placed at {pt}; no qi node adjacent",
+        )
+
+    def _study(self, color: int, phase: str) -> dict:
+        name = self.encounter.parties[color].name
+        query = f"{self.encounter.style} techniques to break a {self.encounter.terrain_name} guard"
+        results = self.governor.study(query, seed=self.encounter.seed, turn_index=self._turn_index + 1)
+        decision = self.governor.audit[-1].decision if self.governor.audit else "unknown"
+        return self._emit(
+            phase,
+            color,
+            "study_revealed",
+            {"query": query, "study": list(results), "backend": self.governor.backend.name, "committed": False},
+            f"{name} ran a governed study: decision={decision}, backend={self.governor.backend.name}, "
+            f"{len(results)} result(s)",
+        )
+
+    def _capture(self, color: int, pt: tuple, phase: str) -> str:
+        result = self.board.place(color, pt)
+        self.captures[color] += len(result.captured)
+        name = self.encounter.parties[color].name
+        captured = [list(p) for p in result.captured]
+        self._emit(
+            phase,
+            color,
+            "capture",
+            {"point": pt, "captured": captured},
+            f"{name} captured {captured} by playing {pt}",
+        )
+        return "capture"
+
+    def _treaty(self, color: int, target: tuple, phase: str) -> str:
+        group, _ = self.board.group_and_liberties(target)
+        self.board.set_protected(group)
+        self.treaty_zone = sorted(list(p) for p in group)
+        name = self.encounter.parties[color].name
+        self._emit(
+            phase,
+            color,
+            "treaty_locked",
+            {"zone": f"the ground around {target}", "protected": sorted(list(p) for p in group)},
+            f"{name} locked a treaty over {sorted(group)}; those stones are now uncapturable",
+        )
+        return "treaty"
+
+    # --- packet ---
+
+    @staticmethod
+    def _record(record: StudyRecord) -> dict:
+        return {
+            "query": record.query,
+            "decision": record.decision,
+            "backend": record.backend,
+            "latency_ms": round(record.latency_ms, 3),
+            "results": list(record.results),
+        }
+
+    def _packet(self, ending: str) -> dict[str, Any]:
+        score = self.board.score()
+        colors = [p.color for p in self.encounter.parties]
+        return {
+            "schema": SCHEMA,
+            "encounter_id": self.encounter.encounter_id,
+            "seed": self.encounter.seed,
+            "style": self.encounter.style,
+            "board_size": self.encounter.board_size,
+            "terrain": {"name": self.encounter.terrain_name, "tags": self.encounter.terrain_tags},
+            "parties": [
+                {"name": p.name, "color": p.color, "temperament": p.temperament, "goal": p.goal}
+                for p in self.encounter.parties
+            ],
+            "qi_nodes": [
+                {"point": list(n.point), "value": n.value, "claimed": n.point in self.claimed_qi}
+                for n in self.encounter.qi_nodes
+            ],
+            "turns": self._turns,
+            "final_board": self.board.ascii(),
+            "graph": self.board.graph_view(),
+            "study_audit": [self._record(r) for r in self.governor.audit],
+            "aftermath": {
+                "ending": ending,
+                "captures": {self.encounter.parties[c].name: self.captures[c] for c in colors},
+                "qi": {self.encounter.parties[c].name: self.qi[c] for c in colors},
+                "score": {self.encounter.parties[c].name: score.get(c, 0) for c in colors},
+                "treaty_zone": self.treaty_zone,
+            },
+        }

--- a/src/narrative_combat/go_board/fixtures.py
+++ b/src/narrative_combat/go_board/fixtures.py
@@ -1,0 +1,31 @@
+"""A demo encounter for the Go-board engine: two cultivation factions over a drained shrine."""
+
+from __future__ import annotations
+
+from .models import GoEncounter, Party, QiNode
+
+
+def boss_board_demo(seed: int = 1337) -> GoEncounter:
+    return GoEncounter(
+        encounter_id="boss_board_demo",
+        seed=seed,
+        style="xianxia",
+        board_size=9,
+        parties=[
+            Party(
+                name="Iron Lotus Sect",
+                color=0,
+                temperament=["relentless", "disciplined"],
+                goal="break the magistrate's hold on the shrine",
+            ),
+            Party(
+                name="Ash-Crowned Bailiff",
+                color=1,
+                temperament=["punitive", "certain"],
+                goal="enforce the old law to the letter",
+            ),
+        ],
+        qi_nodes=[QiNode(point=(4, 4), value=3), QiNode(point=(7, 1), value=2)],
+        terrain_name="drained river shrine",
+        terrain_tags=["dry riverbed", "broken shrine", "ash haze"],
+    )

--- a/src/narrative_combat/go_board/governor.py
+++ b/src/narrative_combat/go_board/governor.py
@@ -1,0 +1,81 @@
+"""Governed study move: web search as a move on the board.
+
+A Study move samples outside sources without committing a stone — a probe move that buys
+knowledge. It is *governed*: an allowlist decides whether a query may run, every call is
+audited, and results are cached by ``(seed, turn_index, query)`` so the same encounter+seed
+produces the same fight even once a real backend is wired in.
+
+Fully local — no SCBE governance imports. The default backend is an offline stub, mirroring the
+LLMTranslator's deterministic fallback: the engine works with no network, and a real web-search
+backend is an opt-in v2 swap behind the same interface.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class StudyBackend(Protocol):
+    name: str
+
+    def search(self, query: str) -> tuple[str, ...]:  # pragma: no cover - interface only
+        ...
+
+
+class StubSearchBackend:
+    """Offline default: returns nothing, deterministically. Real web search is a v2 swap."""
+
+    name = "stub"
+
+    def search(self, query: str) -> tuple[str, ...]:
+        return ()
+
+
+@dataclass(frozen=True)
+class StudyRecord:
+    """One audited study call — the trail a reviewer reads."""
+
+    query: str
+    decision: str  # "allow" | "deny" | "cached"
+    backend: str
+    latency_ms: float
+    results: tuple[str, ...]
+
+
+class SearchGovernor:
+    """Decides whether a study query may run, audits every call, and caches results."""
+
+    def __init__(
+        self,
+        backend: StudyBackend | None = None,
+        allow_terms: list[str] | None = None,
+        timeout: float = 5.0,
+    ) -> None:
+        self.backend: StudyBackend = backend or StubSearchBackend()
+        self.allow_terms = allow_terms  # None = allow anything; else the query must contain one
+        self.timeout = timeout
+        self.audit: list[StudyRecord] = []
+        self._cache: dict[tuple[int, int, str], tuple[str, ...]] = {}
+
+    def study(self, query: str, *, seed: int, turn_index: int) -> tuple[str, ...]:
+        if self.allow_terms is not None and not any(term.lower() in query.lower() for term in self.allow_terms):
+            self.audit.append(StudyRecord(query, "deny", self.backend.name, 0.0, ()))
+            return ()
+
+        key = (seed, turn_index, query)
+        if key in self._cache:
+            results = self._cache[key]
+            self.audit.append(StudyRecord(query, "cached", self.backend.name, 0.0, results))
+            return results
+
+        start = time.perf_counter()
+        try:
+            results = tuple(self.backend.search(query))
+        except Exception:
+            results = ()
+        latency_ms = (time.perf_counter() - start) * 1000.0
+        self._cache[key] = results
+        self.audit.append(StudyRecord(query, "allow", self.backend.name, latency_ms, results))
+        return results

--- a/src/narrative_combat/go_board/kernel.py
+++ b/src/narrative_combat/go_board/kernel.py
@@ -1,0 +1,244 @@
+"""Domain-agnostic legality kernel for the SCBE Board Kernel.
+
+A deterministic Go-derived graph lattice. Players are integers; points are ``(row, col)``.
+The board decides legality; callers only *propose* moves. Tromp-Taylor-style backbone:
+**positional superko** (no whole-board repeat) + **area scoring**. Deliberate v1 divergence:
+**suicide is illegal** (mainstream convention) rather than T-T's legal self-removal.
+
+No domain words (no parties / prose / qi) and no SCBE imports live here — this is the reusable
+core that narrative, coding, writing, and workflow adapters all build on. The graph view (a
+*string* of stones is a node; its liberties are edges) is exposed for lattice analysis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+Point = tuple[int, int]
+Grid = list[list[Optional[int]]]
+
+
+class IllegalMove(ValueError):
+    """Raised when a proposed move violates board legality (occupied / suicide / superko)."""
+
+
+@dataclass(frozen=True)
+class Observation:
+    """What a probe move *would* do, sampled without committing."""
+
+    legal: bool
+    reason: str  # "" when legal, else why it is rejected
+    would_capture: tuple[Point, ...]  # opponent points that would be removed
+    resulting_liberties: int  # liberties of the played group after captures (0 if illegal)
+
+
+@dataclass(frozen=True)
+class MoveResult:
+    """The outcome of a committed legal move."""
+
+    player: int
+    point: Point
+    captured: tuple[Point, ...]
+    liberties: int  # liberties of the played group after captures
+
+
+def _neighbors(pt: Point, size: int) -> list[Point]:
+    r, c = pt
+    out: list[Point] = []
+    if r > 0:
+        out.append((r - 1, c))
+    if r < size - 1:
+        out.append((r + 1, c))
+    if c > 0:
+        out.append((r, c - 1))
+    if c < size - 1:
+        out.append((r, c + 1))
+    return out
+
+
+def _group_and_liberties(grid: Grid, pt: Point, size: int) -> tuple[set[Point], set[Point]]:
+    """Flood-fill the maximal same-player string containing ``pt`` and its liberty set."""
+    player = grid[pt[0]][pt[1]]
+    if player is None:
+        return set(), set()
+    group: set[Point] = set()
+    liberties: set[Point] = set()
+    stack = [pt]
+    while stack:
+        cur = stack.pop()
+        if cur in group:
+            continue
+        group.add(cur)
+        for nb in _neighbors(cur, size):
+            occupant = grid[nb[0]][nb[1]]
+            if occupant is None:
+                liberties.add(nb)
+            elif occupant == player and nb not in group:
+                stack.append(nb)
+    return group, liberties
+
+
+class Board:
+    """A square Go board. Default 9x9; smaller sizes are allowed for tests and small scenes."""
+
+    def __init__(self, size: int = 9) -> None:
+        self.size = size
+        self._grid: Grid = [[None] * size for _ in range(size)]
+        self._protected: set[Point] = set()  # stones here are immune from capture (e.g. treaty zones)
+        self._history: set[tuple] = {self._snapshot()}
+
+    # --- geometry / inspection ---
+
+    def in_bounds(self, pt: Point) -> bool:
+        r, c = pt
+        return 0 <= r < self.size and 0 <= c < self.size
+
+    def at(self, pt: Point) -> Optional[int]:
+        return self._grid[pt[0]][pt[1]]
+
+    def neighbors(self, pt: Point) -> list[Point]:
+        return _neighbors(pt, self.size)
+
+    def group_and_liberties(self, pt: Point) -> tuple[set[Point], set[Point]]:
+        return _group_and_liberties(self._grid, pt, self.size)
+
+    def liberties(self, pt: Point) -> int:
+        return len(self.group_and_liberties(pt)[1])
+
+    def set_protected(self, points: Iterable[Point]) -> None:
+        """Mark points whose stones cannot be captured (the generic hook a treaty zone uses)."""
+        self._protected = {pt for pt in points if self.in_bounds(pt)}
+
+    # --- the one simulation both probe() and place() share ---
+
+    def _simulate(self, player: int, pt: Point) -> tuple[bool, str, frozenset[Point], int, Optional[Grid]]:
+        if not self.in_bounds(pt):
+            return False, "out of bounds", frozenset(), 0, None
+        if self._grid[pt[0]][pt[1]] is not None:
+            return False, "point is occupied", frozenset(), 0, None
+
+        grid: Grid = [row[:] for row in self._grid]
+        grid[pt[0]][pt[1]] = player
+
+        captured: set[Point] = set()
+        for nb in _neighbors(pt, self.size):
+            occupant = grid[nb[0]][nb[1]]
+            if occupant is not None and occupant != player:
+                group, libs = _group_and_liberties(grid, nb, self.size)
+                if not libs and not (group & self._protected):
+                    for gp in group:
+                        grid[gp[0]][gp[1]] = None
+                    captured |= group
+
+        _, own_libs = _group_and_liberties(grid, pt, self.size)
+        if not own_libs:
+            return False, "suicide (own group would have no liberties)", frozenset(), 0, None
+
+        snapshot = tuple(tuple(row) for row in grid)
+        if snapshot in self._history:
+            return False, "superko (repeats a previous board position)", frozenset(), 0, None
+
+        return True, "", frozenset(captured), len(own_libs), grid
+
+    # --- the two move classes ---
+
+    def probe(self, player: int, pt: Point) -> Observation:
+        """Sense the state space: report what the move would do without committing it."""
+        legal, reason, captured, libs, _ = self._simulate(player, pt)
+        return Observation(
+            legal=legal,
+            reason=reason,
+            would_capture=tuple(sorted(captured)),
+            resulting_liberties=libs,
+        )
+
+    def place(self, player: int, pt: Point) -> MoveResult:
+        """Commit a legal move, or raise IllegalMove. The board, not the caller, decides."""
+        legal, reason, captured, libs, grid = self._simulate(player, pt)
+        if not legal or grid is None:
+            raise IllegalMove(f"{pt}: {reason}")
+        self._grid = grid
+        self._history.add(tuple(tuple(row) for row in grid))
+        return MoveResult(player=player, point=pt, captured=tuple(sorted(captured)), liberties=libs)
+
+    def legal_placements(self, player: int) -> list[Point]:
+        return [
+            (r, c)
+            for r in range(self.size)
+            for c in range(self.size)
+            if self._grid[r][c] is None and self.probe(player, (r, c)).legal
+        ]
+
+    # --- analysis ---
+
+    def score(self) -> dict[int, int]:
+        """Area score per player: stones + empty regions bordered by exactly one player."""
+        stones: dict[int, int] = {}
+        for r in range(self.size):
+            for c in range(self.size):
+                occupant = self._grid[r][c]
+                if occupant is not None:
+                    stones[occupant] = stones.get(occupant, 0) + 1
+
+        territory: dict[int, int] = {}
+        visited: set[Point] = set()
+        for r in range(self.size):
+            for c in range(self.size):
+                if self._grid[r][c] is not None or (r, c) in visited:
+                    continue
+                region: set[Point] = set()
+                borders: set[int] = set()
+                stack = [(r, c)]
+                while stack:
+                    cur = stack.pop()
+                    if cur in region:
+                        continue
+                    region.add(cur)
+                    visited.add(cur)
+                    for nb in _neighbors(cur, self.size):
+                        occupant = self._grid[nb[0]][nb[1]]
+                        if occupant is None and nb not in region:
+                            stack.append(nb)
+                        elif occupant is not None:
+                            borders.add(occupant)
+                if len(borders) == 1:
+                    owner = next(iter(borders))
+                    territory[owner] = territory.get(owner, 0) + len(region)
+
+        return {p: stones.get(p, 0) + territory.get(p, 0) for p in set(stones) | set(territory)}
+
+    def graph_view(self) -> list[dict]:
+        """Strings as nodes, liberties as edge-count — the lattice view of the position."""
+        seen: set[Point] = set()
+        nodes: list[dict] = []
+        for r in range(self.size):
+            for c in range(self.size):
+                if self._grid[r][c] is None or (r, c) in seen:
+                    continue
+                group, libs = _group_and_liberties(self._grid, (r, c), self.size)
+                seen |= group
+                nodes.append({"player": self._grid[r][c], "stones": tuple(sorted(group)), "liberties": len(libs)})
+        return nodes
+
+    # --- serialization ---
+
+    def _snapshot(self) -> tuple:
+        return tuple(tuple(row) for row in self._grid)
+
+    def ascii(self, symbols: Optional[dict] = None) -> str:
+        glyphs = symbols or {None: ".", 0: "X", 1: "O"}
+        return "\n".join("".join(glyphs.get(self._grid[r][c], "?") for c in range(self.size)) for r in range(self.size))
+
+    @classmethod
+    def from_ascii(cls, text: str, mapping: Optional[dict] = None) -> "Board":
+        """Build a board from rows of glyphs (spaces ignored), for tests and fixtures."""
+        glyphs = mapping or {"X": 0, "O": 1, ".": None}
+        rows = [line.replace(" ", "") for line in text.strip().splitlines() if line.strip()]
+        size = len(rows)
+        if any(len(row) != size for row in rows):
+            raise ValueError("from_ascii expects a square board (every row as long as the row count)")
+        board = cls(size=size)
+        board._grid = [[glyphs[ch] for ch in row] for row in rows]
+        board._history = {board._snapshot()}
+        return board

--- a/src/narrative_combat/go_board/models.py
+++ b/src/narrative_combat/go_board/models.py
@@ -1,0 +1,44 @@
+"""Narrative-combat domain types layered on the legality kernel.
+
+The kernel knows only players, points, and stones. These dataclasses give those board atoms
+narrative meaning: a player is a Party (with temperament, so prose can vary by personality),
+a resource node is a QiNode, and the whole scene is a GoEncounter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+Point = tuple[int, int]
+
+
+@dataclass(frozen=True)
+class Party:
+    """A combatant faction — the narrative meaning of a kernel player (color = player index)."""
+
+    name: str
+    color: int
+    temperament: list[str] = field(default_factory=list)
+    goal: str = "prevail"
+
+
+@dataclass(frozen=True)
+class QiNode:
+    """A board point that grants qi to the party that first plants a stone on or beside it."""
+
+    point: Point
+    value: int = 3
+
+
+@dataclass(frozen=True)
+class GoEncounter:
+    """Everything the GoDirector needs to drive one board-fight."""
+
+    encounter_id: str
+    seed: int
+    style: str
+    board_size: int
+    parties: list[Party]
+    qi_nodes: list[QiNode] = field(default_factory=list)
+    terrain_name: str = "open field"
+    terrain_tags: list[str] = field(default_factory=list)

--- a/src/narrative_combat/go_board/translator.py
+++ b/src/narrative_combat/go_board/translator.py
@@ -1,0 +1,146 @@
+"""Render verified board events as prose. The board decides truth; this only translates it.
+
+`GoTemplateTranslator` is the deterministic default: a literal board-event -> beat-frame dispatch
+table, golden-stable, no network. `GoLLMTranslator` is opt-in and mirrors the maze LLMTranslator
+exactly (facts dict, party temperament wired in, fallback to the template on any failure). Neither
+may invent an outcome the board did not produce.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .models import GoEncounter
+
+# board_event -> deterministic narrative frame (the literal dispatch table the spec calls for)
+_FRAMES: dict[str, str] = {
+    "presence": "{actor} sets a stone at {point}, taking presence in the {terrain}.",
+    "contact": "{actor} presses forward to {point}, and the lines of {actor} and {opponent} finally touch.",
+    "liberty_pressure": "{actor} plays {point}; {opponent}'s pressed group now breathes through only "
+    "{liberties} ways.",
+    "atari": "{actor} seizes {point} — {opponent}'s group is down to a single breath, one move from "
+    "being swept away.",
+    "qi_claimed": "{actor} plants beside the qi-font at {qi_node}, drawing +{qi_gained} into reserve "
+    "({qi_total} held).",
+    "study_revealed": "{actor} breaks to read the old records before striking: {study}.",
+    "probe": "{actor} feints toward {point}, testing the killing line without committing — "
+    "{opponent} would lose {would_capture} there.",
+    "treaty_locked": "{actor} and {opponent} cut a treaty across {zone}; inside that ground no stone " "may be taken.",
+    "capture": "{actor} takes {point} and severs the last breath; {opponent}'s group of {captured} "
+    "stone(s) is swept from the board.",
+    "_default": "{actor} acts at {point}.",
+}
+
+
+def _fmt_point(point: Any) -> str:
+    if point is None:
+        return "an unmarked point"
+    r, c = point
+    return f"({r}, {c})"
+
+
+def _context(event: dict[str, Any], encounter: GoEncounter) -> dict[str, Any]:
+    color = event["party"]
+    actor = encounter.parties[color].name
+    opponent = next((p.name for p in encounter.parties if p.color != color), "the opponent")
+    mech = event.get("mechanical", {})
+    study_results = mech.get("study", ())
+    captured = mech.get("captured", [])
+    return {
+        "actor": actor,
+        "opponent": opponent,
+        "terrain": encounter.terrain_name,
+        "point": _fmt_point(mech.get("point")),
+        "liberties": mech.get("target_liberties", ""),
+        "qi_node": _fmt_point(mech.get("qi_node")),
+        "qi_gained": mech.get("qi_gained", ""),
+        "qi_total": mech.get("qi_total", ""),
+        "zone": mech.get("zone", "the contested ground"),
+        "captured": len(captured) if isinstance(captured, (list, tuple)) else captured,
+        "would_capture": len(mech.get("would_capture", [])),
+        "study": "; ".join(study_results) if study_results else "the old masters left only silence",
+    }
+
+
+class GoTemplateTranslator:
+    """Deterministic prose from the dispatch table. The default renderer: no model, no network."""
+
+    def render(self, event: dict[str, Any], encounter: GoEncounter) -> str:
+        frame = _FRAMES.get(event["board_event"], _FRAMES["_default"])
+        return frame.format(**_context(event, encounter))
+
+
+class GoLLMTranslator:
+    """Opt-in renderer: turns one verified board event into cultivation-combat prose.
+
+    The board owns truth (board_event + mechanical). This renders that fixed event as a martial
+    exchange — stones are fighters and positions, a capture is a defeat — coloring voice by each
+    party's temperament, never inventing an outcome. Any failure falls back to the template.
+    """
+
+    def __init__(
+        self,
+        model: str = "glm-5.1:cloud",
+        host: str = "http://127.0.0.1:11434",
+        style: str = "xianxia",
+        timeout: float = 60.0,
+        fallback: Any | None = None,
+    ) -> None:
+        self.model = model
+        self.host = host.rstrip("/")
+        self.style = style
+        self.timeout = timeout
+        self.fallback = fallback if fallback is not None else GoTemplateTranslator()
+
+    def render(self, event: dict[str, Any], encounter: GoEncounter) -> str:
+        try:
+            return self._render_llm(event, encounter)
+        except Exception:
+            return self.fallback.render(event, encounter)
+
+    def _render_llm(self, event: dict[str, Any], encounter: GoEncounter) -> str:
+        import json
+        import urllib.request
+
+        color = event["party"]
+        actor = encounter.parties[color]
+        opponent = next((p for p in encounter.parties if p.color != color), actor)
+        style = self.style or encounter.style
+        facts = {
+            "actor": actor.name,
+            "actor_temperament": actor.temperament,
+            "opponent": opponent.name,
+            "opponent_temperament": opponent.temperament,
+            "phase": event["phase"],
+            "board_event": event["board_event"],
+            "mechanical_truth": event.get("mechanical", {}),
+            "terrain": encounter.terrain_name,
+            "terrain_feel": encounter.terrain_tags,
+        }
+        system = (
+            f"You are a {style} combat-prose stylist. The fight is tracked on a board; render this one "
+            "exchange as a martial duel, NOT as a board game: stones are fighters and positions, a "
+            "'capture' is a defeat or a position overrun, 'liberties' are escape routes, 'qi' is power "
+            "drawn. Render 2-4 vivid sentences. Use ONLY the given facts; the 'board_event' and "
+            "'mechanical_truth' are FIXED — convey them through action and image, never invent outcomes, "
+            "injuries, winners, or deaths beyond them, and never use board jargon ('stone', 'liberty', "
+            "'atari', 'point'). Let each party's temperament shape voice and posture. Output prose only."
+        )
+        user = "Facts (authoritative — render, never change):\n" + json.dumps(facts, ensure_ascii=False, indent=2)
+        body = json.dumps(
+            {
+                "model": self.model,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(self.host + "/api/chat", data=body, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        text = str((data.get("message") or {}).get("content", "")).strip()
+        if not text:
+            raise ValueError("empty LLM response")
+        return text

--- a/tests/narrative_combat/go_board/test_go_director.py
+++ b/tests/narrative_combat/go_board/test_go_director.py
@@ -1,0 +1,74 @@
+"""The director drives the board and emits verifiable, deterministic, board-true turns."""
+
+from __future__ import annotations
+
+from src.narrative_combat.go_board.director import GoDirector
+from src.narrative_combat.go_board.fixtures import boss_board_demo
+
+
+def _fight(seed: int) -> dict:
+    return GoDirector(boss_board_demo(seed=seed)).run()
+
+
+def test_packet_shape_and_per_turn_fields():
+    fight = _fight(1337)
+    assert fight["schema"] == "scbe.narrative_combat.go_fight.v1"
+    assert fight["board_size"] == 9
+    assert fight["turns"]
+    for turn in fight["turns"]:
+        assert {"turn_id", "phase", "party", "board_event", "mechanical", "prose", "verifier"} <= set(turn)
+        assert turn["prose"]
+        assert turn["verifier"]["claim"]
+
+
+def test_phase_sequence_follows_the_machine():
+    fight = _fight(1337)
+    phases = [t["phase"] for t in fight["turns"]]
+    assert phases[0] == "opening"
+    assert "cost_unavoidable" in phases
+    assert phases[-1] == "understanding_wins"
+
+
+def test_atari_turn_reports_a_single_remaining_liberty():
+    fight = _fight(1337)
+    atari = next(t for t in fight["turns"] if t["board_event"] == "atari")
+    assert atari["mechanical"]["target_liberties"] == 1
+
+
+def test_probe_turn_does_not_commit_but_shows_the_capture():
+    fight = _fight(1337)
+    probe = next(t for t in fight["turns"] if t["board_event"] == "probe")
+    assert probe["mechanical"]["committed"] is False
+    assert probe["mechanical"]["would_capture"] == [[2, 2]]
+
+
+def test_qi_claim_and_study_are_present_and_audited():
+    fight = _fight(1337)
+    qi = next(t for t in fight["turns"] if t["board_event"] == "qi_claimed")
+    assert qi["mechanical"]["qi_gained"] == 3
+    study = next(t for t in fight["turns"] if t["board_event"] == "study_revealed")
+    assert study["mechanical"]["committed"] is False
+    assert fight["study_audit"] and fight["study_audit"][0]["decision"] == "allow"
+
+
+def test_fight_is_deterministic_for_a_seed():
+    assert _fight(1337) == _fight(1337)
+
+
+def test_both_endings_are_reachable_and_truthful():
+    endings = {}
+    for seed in range(40):
+        fight = _fight(seed)
+        endings.setdefault(fight["aftermath"]["ending"], fight)
+        if {"capture", "treaty"} <= set(endings):
+            break
+    assert {"capture", "treaty"} <= set(endings), "expected both a capture and a treaty across seeds"
+
+    capture = endings["capture"]
+    # the captured stone is actually gone from the final board (row 2 of a 9-wide board)
+    assert capture["final_board"].splitlines()[2][2] == "."
+    assert sum(capture["aftermath"]["captures"].values()) >= 1
+
+    treaty = endings["treaty"]
+    assert treaty["aftermath"]["treaty_zone"] is not None
+    assert treaty["final_board"].splitlines()[2][2] != "."  # protected stone survives

--- a/tests/narrative_combat/go_board/test_governor.py
+++ b/tests/narrative_combat/go_board/test_governor.py
@@ -1,0 +1,55 @@
+"""The study move is governed: allowlist gates it, every call is audited, results are cached."""
+
+from __future__ import annotations
+
+from src.narrative_combat.go_board.governor import SearchGovernor, StubSearchBackend
+
+
+def test_stub_backend_returns_nothing_and_audits_allow():
+    gov = SearchGovernor()
+    results = gov.study("xianxia footwork", seed=1337, turn_index=3)
+    assert results == ()
+    assert len(gov.audit) == 1
+    assert gov.audit[0].decision == "allow"
+    assert gov.audit[0].backend == "stub"
+
+
+def test_allowlist_denies_off_topic_queries():
+    gov = SearchGovernor(allow_terms=["lawful", "shrine"])
+    assert gov.study("how to pick a lock", seed=1, turn_index=1) == ()
+    assert gov.audit[-1].decision == "deny"
+    # an on-topic query is allowed
+    gov.study("shrine wards", seed=1, turn_index=2)
+    assert gov.audit[-1].decision == "allow"
+
+
+def test_results_are_cached_by_seed_turn_query():
+    class CountingBackend(StubSearchBackend):
+        name = "counting"
+
+        def __init__(self):
+            self.calls = 0
+
+        def search(self, query):
+            self.calls += 1
+            return ("a fact",)
+
+    backend = CountingBackend()
+    gov = SearchGovernor(backend=backend)
+    first = gov.study("ash law", seed=42, turn_index=5)
+    second = gov.study("ash law", seed=42, turn_index=5)
+    assert first == second == ("a fact",)
+    assert backend.calls == 1  # second call served from cache
+    assert gov.audit[-1].decision == "cached"
+
+
+def test_backend_failure_degrades_to_empty():
+    class BrokenBackend(StubSearchBackend):
+        name = "broken"
+
+        def search(self, query):
+            raise RuntimeError("network down")
+
+    gov = SearchGovernor(backend=BrokenBackend())
+    assert gov.study("anything", seed=7, turn_index=1) == ()
+    assert gov.audit[-1].decision == "allow"  # it was permitted; the backend just yielded nothing

--- a/tests/narrative_combat/go_board/test_kernel.py
+++ b/tests/narrative_combat/go_board/test_kernel.py
@@ -1,0 +1,128 @@
+"""The legality kernel is the truth layer: liberties, capture, superko, suicide, probe."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.narrative_combat.go_board.kernel import Board, IllegalMove
+
+
+def test_single_stone_liberties_depend_on_position():
+    board = Board(size=9)
+    board.place(0, (4, 4))  # center
+    assert board.liberties((4, 4)) == 4
+    board.place(0, (0, 0))  # corner
+    assert board.liberties((0, 0)) == 2
+    board.place(0, (0, 4))  # edge
+    assert board.liberties((0, 4)) == 3
+
+
+def test_connected_group_shares_liberties():
+    board = Board(size=9)
+    board.place(0, (4, 4))
+    board.place(0, (4, 5))
+    group, libs = board.group_and_liberties((4, 4))
+    assert group == {(4, 4), (4, 5)}
+    assert len(libs) == 6  # two stones in open space: 3 liberties each, none shared
+
+
+def test_placing_the_last_liberty_captures_the_enemy_stone():
+    board = Board(size=9)
+    board.place(0, (4, 4))  # lone black target
+    board.place(1, (3, 4))
+    board.place(1, (5, 4))
+    board.place(1, (4, 3))
+    assert board.at((4, 4)) == 0  # still there, one liberty left at (4, 5)
+    result = board.place(1, (4, 5))  # remove the final liberty
+    assert (4, 4) in result.captured
+    assert board.at((4, 4)) is None
+
+
+def test_suicide_is_illegal():
+    board = Board(size=9)
+    for pt in [(3, 4), (5, 4), (4, 3), (4, 5)]:  # white rings the center, no capture available
+        board.place(1, pt)
+    with pytest.raises(IllegalMove, match="suicide"):
+        board.place(0, (4, 4))
+
+
+def test_suicide_that_captures_is_legal():
+    # A move with no liberties of its own is legal when it captures first (gains a liberty).
+    board = Board.from_ascii("""
+        .OX
+        OXX
+        XX.
+        """)
+    # Both white stones (0,1) and (1,0) sit in atari with their only liberty at (0,0).
+    # Black plays (0,0): it captures them, so black (0,0) ends with liberties -> legal.
+    result = board.place(0, (0, 0))
+    assert (0, 1) in result.captured
+    assert (1, 0) in result.captured
+    assert board.at((0, 1)) is None
+
+
+def test_positional_superko_forbids_immediate_recapture():
+    # Textbook ko: white (1,1) sits in atari with its only liberty at (1,2).
+    board = Board.from_ascii("""
+        .XO.
+        XO.O
+        .XO.
+        ....
+        """)
+    captured = board.place(0, (1, 2)).captured  # black captures white (1,1)
+    assert (1, 1) in captured
+    # White recapturing at (1,1) would recreate the prior whole-board position -> superko.
+    with pytest.raises(IllegalMove, match="superko"):
+        board.place(1, (1, 1))
+
+
+def test_occupied_point_is_illegal():
+    board = Board(size=9)
+    board.place(0, (2, 2))
+    with pytest.raises(IllegalMove, match="occupied"):
+        board.place(1, (2, 2))
+
+
+def test_probe_does_not_mutate_but_reports_capture():
+    board = Board(size=9)
+    board.place(0, (4, 4))
+    board.place(1, (3, 4))
+    board.place(1, (5, 4))
+    board.place(1, (4, 3))
+    snapshot = board.ascii()
+    obs = board.probe(1, (4, 5))  # the capturing move, sampled only
+    assert obs.legal
+    assert (4, 4) in obs.would_capture
+    assert board.ascii() == snapshot  # nothing committed
+    assert board.at((4, 4)) == 0
+
+
+def test_protected_stones_cannot_be_captured():
+    board = Board(size=9)
+    board.place(0, (4, 4))
+    board.set_protected([(4, 4)])  # a treaty zone shields this stone
+    board.place(1, (3, 4))
+    board.place(1, (5, 4))
+    board.place(1, (4, 3))
+    obs = board.probe(1, (4, 5))
+    assert obs.would_capture == ()  # protection prevents the capture
+    board.place(1, (4, 5))
+    assert board.at((4, 4)) == 0  # protected stone survives even at zero liberties
+
+
+def test_score_counts_stones_and_single_owner_territory():
+    board = Board(size=3)
+    board.place(0, (1, 1))  # one black stone; all 8 empties border only black
+    scores = board.score()
+    assert scores[0] == 9  # 1 stone + 8 territory on a 3x3
+
+
+def test_graph_view_lists_strings_with_liberties():
+    board = Board(size=9)
+    board.place(0, (4, 4))
+    board.place(0, (4, 5))
+    board.place(1, (0, 0))
+    nodes = board.graph_view()
+    assert {"player": 1, "stones": ((0, 0),), "liberties": 2} in nodes
+    black = next(n for n in nodes if n["player"] == 0)
+    assert black["stones"] == ((4, 4), (4, 5))


### PR DESCRIPTION
## Summary
- Adds a Go-derived narrative combat legality engine under `src/narrative_combat/go_board/`.
- Implements deterministic board truth for presence, liberty pressure, qi claim, governed study, atari, probe, treaty/capture outcomes, and packet rendering.
- Adds the approved design spec and focused tests for kernel, director, and search governor behavior.

## Test evidence
- `python -m pytest tests/narrative_combat/go_board -q` -> 22 passed
- `python -m src.narrative_combat.go_board.cli --help` -> CLI help renders
- `python -m src.narrative_combat.go_board.cli --seed 7` -> emits `scbe.narrative_combat.go_fight.v1` packet with atari, probe, qi, study, and capture events

## Rollback
- Revert this PR to remove the isolated `go_board` package, its tests, and the design spec.

## Notes
- This PR intentionally does not include the independent maze temperament/custom encounter loader work.
- The coding adapter is not built here; this PR only lands the reusable board-truth narrative slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Go-board narrative combat engine with CLI support for generating encounter fight packets.
  * Implemented configurable narrative rendering: template-based or LLM-powered prose generation with fallback.
  * Board mechanics include stone placement, capture resolution, liberty tracking, and protected group management.
  * Multiple game endings: deterministic capture or treaty outcomes.
  * Deterministic gameplay via seed-based initialization.

* **Documentation**
  * Added design specification for the Go-board narrative system.

* **Tests**
  * Comprehensive test coverage for board legality, director phase sequences, governor caching, and end-to-end combat progression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->