### PR TITLE
feat(narrative-combat): maze vertical slice — custom encounters + temperament

### DIFF
--- a/docs/superpowers/plans/2026-05-21-narrative-combat-generator-vertical-slice.md
+++ b/docs/superpowers/plans/2026-05-21-narrative-combat-generator-vertical-slice.md
@@ -1,0 +1,996 @@
+# Narrative Combat Generator Vertical Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first deterministic vertical slice of the narrative combat generator: fixture encounter -> director path -> resolver state shifts -> template prose -> JSON fight packet.
+
+**Architecture:** Implement a small standalone Python package at `src/narrative_combat/` with no SCBE governance dependency and no LLM dependency. The engine uses dataclasses for combat domain objects, a seeded resolver for deterministic pivots, a path-director for feature ordering/reversal/price placement, and a template translator for stable prose.
+
+**Tech Stack:** Python 3.11+, dataclasses, `random.Random`, pytest, JSON CLI output.
+
+---
+
+## File Structure
+
+- Create: `src/narrative_combat/__init__.py`
+  - Public exports for the vertical slice.
+- Create: `src/narrative_combat/models.py`
+  - Dataclasses and literal types: fighters, techniques, terrain, features, encounter, beats, fight packet.
+- Create: `src/narrative_combat/fixtures.py`
+  - One hardcoded boss-duel demo fixture used by CLI and tests.
+- Create: `src/narrative_combat/resolver.py`
+  - Seeded dice, margin calculation, outcome band mapping, state-shift emission.
+- Create: `src/narrative_combat/director.py`
+  - Plans shortest/longest/chosen path, enforces phase waypoints, places reversal and price.
+- Create: `src/narrative_combat/translator.py`
+  - Deterministic `TemplateTranslator`.
+- Create: `src/narrative_combat/cli.py`
+  - CLI that writes the fight packet to stdout or a file.
+- Create: `tests/narrative_combat/test_vertical_slice.py`
+  - End-to-end packet, determinism, structural reroll, wall, and translator tests.
+
+---
+
+### Task 1: Domain Models and Fixture Contract
+
+**Files:**
+- Create: `src/narrative_combat/__init__.py`
+- Create: `src/narrative_combat/models.py`
+- Create: `src/narrative_combat/fixtures.py`
+- Test: `tests/narrative_combat/test_vertical_slice.py`
+
+- [ ] **Step 1: Write the failing model/fixture test**
+
+Add this to `tests/narrative_combat/test_vertical_slice.py`:
+
+```python
+from src.narrative_combat.fixtures import boss_duel_demo
+
+
+def test_boss_duel_fixture_has_required_vertical_slice_parts():
+    encounter = boss_duel_demo(seed=1337)
+
+    assert encounter.encounter_id == "boss_duel_demo"
+    assert encounter.seed == 1337
+    assert encounter.objective == "choose"
+    assert len(encounter.fighters) == 2
+    assert len(encounter.techniques) == 4
+    assert len(encounter.features) == 3
+    assert {feature.kind for feature in encounter.features} == {"safe_zone", "treasure", "monster"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_boss_duel_fixture_has_required_vertical_slice_parts -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'src.narrative_combat'`.
+
+- [ ] **Step 3: Create the package exports**
+
+Create `src/narrative_combat/__init__.py`:
+
+```python
+"""Standalone narrative combat generator vertical slice."""
+
+from .fixtures import boss_duel_demo
+from .models import Encounter, Feature, Fighter, Technique, Terrain
+
+__all__ = [
+    "Encounter",
+    "Feature",
+    "Fighter",
+    "Technique",
+    "Terrain",
+    "boss_duel_demo",
+]
+```
+
+- [ ] **Step 4: Create domain dataclasses**
+
+Create `src/narrative_combat/models.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+FeatureKind = Literal["safe_zone", "treasure", "monster", "friend", "hazard"]
+OutcomeBand = Literal[
+    "dominating_strike",
+    "strong_advantage",
+    "minor_success",
+    "clash",
+    "defensive_loss",
+    "severe_opening_exposed",
+    "catastrophic_reversal",
+]
+PhaseName = Literal[
+    "objective",
+    "first_tactic",
+    "true_rule",
+    "hidden_problem",
+    "cost_unavoidable",
+    "strategy_change",
+    "understanding_wins",
+    "aftermath",
+]
+
+
+@dataclass(frozen=True)
+class Fighter:
+    name: str
+    tier: str
+    stats: dict[str, int]
+    temperament: list[str]
+    techniques: list[str]
+    concealed: list[str] = field(default_factory=list)
+    resources: dict[str, int] = field(default_factory=dict)
+    injuries: list[str] = field(default_factory=list)
+    momentum: int = 0
+    morale: float = 1.0
+    goal: str = "win"
+
+
+@dataclass(frozen=True)
+class Technique:
+    technique_id: str
+    name: str
+    type: str
+    cost: int
+    range: str
+    grade: str
+    hidden: bool
+    effect: dict[str, int | bool | str]
+    narrative_tags: list[str]
+
+
+@dataclass(frozen=True)
+class Terrain:
+    name: str
+    constraints: list[str]
+    modifiers: dict[str, int]
+    narrative_tags: list[str]
+
+
+@dataclass(frozen=True)
+class Feature:
+    feature_id: str
+    kind: FeatureKind
+    label: str
+    innate_test: str
+    consequence: str
+
+
+@dataclass(frozen=True)
+class PlannedGoal:
+    winner: str
+    price: str
+    aftermath: list[str]
+
+
+@dataclass(frozen=True)
+class Encounter:
+    encounter_id: str
+    seed: int
+    style: str
+    objective: str
+    fighters: list[Fighter]
+    techniques: list[Technique]
+    terrain: Terrain
+    features: list[Feature]
+    planned_goal: PlannedGoal
+```
+
+- [ ] **Step 5: Create the fixture**
+
+Create `src/narrative_combat/fixtures.py`:
+
+```python
+from __future__ import annotations
+
+from .models import Encounter, Feature, Fighter, PlannedGoal, Technique, Terrain
+
+
+def boss_duel_demo(seed: int = 1337) -> Encounter:
+    return Encounter(
+        encounter_id="boss_duel_demo",
+        seed=seed,
+        style="xianxia",
+        objective="choose",
+        fighters=[
+            Fighter(
+                name="Wu Jin",
+                tier="Iron Body",
+                stats={"body": 8, "qi": 7, "speed": 9, "focus": 6},
+                temperament=["prideful", "patient"],
+                techniques=["falling_river_cleave", "stone_breath_guard"],
+                concealed=["hidden_meridian_art"],
+                resources={"qi": 30, "stamina": 20},
+                goal="protect",
+            ),
+            Fighter(
+                name="Ash-Crowned Bailiff",
+                tier="Bronze Vein",
+                stats={"body": 9, "qi": 8, "speed": 5, "focus": 7},
+                temperament=["punitive", "certain"],
+                techniques=["ash_seal_brand"],
+                concealed=[],
+                resources={"qi": 24, "stamina": 24},
+                goal="humiliate",
+            ),
+        ],
+        techniques=[
+            Technique(
+                technique_id="falling_river_cleave",
+                name="Falling River Cleave",
+                type="saber",
+                cost=3,
+                range="mid",
+                grade="low",
+                hidden=False,
+                effect={"momentum_shift": 2, "guard_break": True},
+                narrative_tags=["flood", "weight", "pressure"],
+            ),
+            Technique(
+                technique_id="stone_breath_guard",
+                name="Stone Breath Guard",
+                type="body",
+                cost=2,
+                range="close",
+                grade="low",
+                hidden=False,
+                effect={"momentum_shift": 1, "guard": True},
+                narrative_tags=["stillness", "breath", "root"],
+            ),
+            Technique(
+                technique_id="hidden_meridian_art",
+                name="Hidden Meridian Art",
+                type="qi",
+                cost=9,
+                range="self",
+                grade="forbidden",
+                hidden=True,
+                effect={"momentum_shift": 4, "backlash": True},
+                narrative_tags=["secret", "vein", "backlash"],
+            ),
+            Technique(
+                technique_id="ash_seal_brand",
+                name="Ash Seal Brand",
+                type="curse",
+                cost=4,
+                range="mid",
+                grade="middle",
+                hidden=False,
+                effect={"momentum_shift": -2, "bind": True},
+                narrative_tags=["ash", "law", "brand"],
+            ),
+        ],
+        terrain=Terrain(
+            name="drained river shrine",
+            constraints=["the cracked shrine floor cannot flood", "ash clouds reduce sight"],
+            modifiers={"safe_zone": 1, "monster": -2, "treasure": 2},
+            narrative_tags=["dry riverbed", "broken shrine", "ash haze"],
+        ),
+        features=[
+            Feature(
+                feature_id="breathing_pillar",
+                kind="safe_zone",
+                label="fallen shrine pillar",
+                innate_test="patience",
+                consequence="regroup without ceding the whole tempo",
+            ),
+            Feature(
+                feature_id="buried_bell",
+                kind="treasure",
+                label="buried bronze bell",
+                innate_test="restraint",
+                consequence="unlock the old rhythm at the cost of an opening",
+            ),
+            Feature(
+                feature_id="ash_officer",
+                kind="monster",
+                label="ash-bound officer",
+                innate_test="resolve",
+                consequence="face the hidden phase instead of retreating",
+            ),
+        ],
+        planned_goal=PlannedGoal(
+            winner="Wu Jin",
+            price="spends the concealed meridian art and carries qi backlash",
+            aftermath=["right arm tremor", "enemy ideology disproven but not erased"],
+        ),
+    )
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_boss_duel_fixture_has_required_vertical_slice_parts -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add src/narrative_combat tests/narrative_combat/test_vertical_slice.py
+git commit -m "feat(narrative-combat): add vertical slice fixture"
+```
+
+---
+
+### Task 2: Seeded Resolver and State Shifts
+
+**Files:**
+- Modify: `src/narrative_combat/models.py`
+- Create: `src/narrative_combat/resolver.py`
+- Test: `tests/narrative_combat/test_vertical_slice.py`
+
+- [ ] **Step 1: Add failing resolver tests**
+
+Append:
+
+```python
+from src.narrative_combat.resolver import Resolver, outcome_band
+
+
+def test_outcome_band_mapping_uses_narrative_bands_not_damage():
+    assert outcome_band(15) == "dominating_strike"
+    assert outcome_band(8) == "strong_advantage"
+    assert outcome_band(2) == "minor_success"
+    assert outcome_band(0) == "clash"
+    assert outcome_band(-3) == "defensive_loss"
+    assert outcome_band(-8) == "severe_opening_exposed"
+    assert outcome_band(-15) == "catastrophic_reversal"
+
+
+def test_resolver_is_seeded_and_never_emits_damage():
+    encounter = boss_duel_demo(seed=1337)
+    resolver_a = Resolver(seed=encounter.seed)
+    resolver_b = Resolver(seed=encounter.seed)
+    attacker = encounter.fighters[0]
+    defender = encounter.fighters[1]
+    technique = encounter.techniques[0]
+    feature = encounter.features[0]
+
+    result_a = resolver_a.resolve(attacker, defender, technique, encounter.terrain, feature, momentum=0)
+    result_b = resolver_b.resolve(attacker, defender, technique, encounter.terrain, feature, momentum=0)
+
+    assert result_a == result_b
+    assert "damage" not in result_a.state_shift
+    assert result_a.roll >= 1
+    assert result_a.roll <= 20
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_outcome_band_mapping_uses_narrative_bands_not_damage tests/narrative_combat/test_vertical_slice.py::test_resolver_is_seeded_and_never_emits_damage -q
+```
+
+Expected: FAIL with missing `src.narrative_combat.resolver`.
+
+- [ ] **Step 3: Add resolver result model**
+
+Append to `src/narrative_combat/models.py`:
+
+```python
+
+@dataclass(frozen=True)
+class ResolveResult:
+    roll: int
+    margin: int
+    band: OutcomeBand
+    state_shift: dict[str, object]
+```
+
+- [ ] **Step 4: Implement resolver**
+
+Create `src/narrative_combat/resolver.py`:
+
+```python
+from __future__ import annotations
+
+from random import Random
+
+from .models import Feature, Fighter, OutcomeBand, ResolveResult, Technique, Terrain
+
+
+def outcome_band(margin: int) -> OutcomeBand:
+    if margin >= 15:
+        return "dominating_strike"
+    if margin >= 5:
+        return "strong_advantage"
+    if margin >= 1:
+        return "minor_success"
+    if margin == 0:
+        return "clash"
+    if margin >= -5:
+        return "defensive_loss"
+    if margin >= -10:
+        return "severe_opening_exposed"
+    return "catastrophic_reversal"
+
+
+class Resolver:
+    def __init__(self, seed: int) -> None:
+        self._rng = Random(seed)
+
+    def resolve(
+        self,
+        attacker: Fighter,
+        defender: Fighter,
+        technique: Technique,
+        terrain: Terrain,
+        feature: Feature,
+        momentum: int,
+    ) -> ResolveResult:
+        roll = self._rng.randint(1, 20)
+        combat_stat = attacker.stats.get("qi", 0)
+        technique_mod = int(technique.effect.get("momentum_shift", 0))
+        terrain_mod = terrain.modifiers.get(feature.kind, 0)
+        defender_state = defender.stats.get("focus", 0)
+        margin = roll + combat_stat + technique_mod + momentum + terrain_mod - defender_state
+        band = outcome_band(margin)
+
+        momentum_delta = max(-3, min(3, margin // 5))
+        qi_key = f"{attacker.name}.qi"
+        state_shift: dict[str, object] = {
+            "momentum": momentum_delta,
+            "resources": {qi_key: -technique.cost},
+            "revealed": [technique.technique_id] if technique.hidden else [],
+            "injuries": [],
+            "continuity_facts": [],
+        }
+        if technique.hidden:
+            state_shift["injuries"] = [f"{attacker.name} suffers meridian backlash"]
+            state_shift["continuity_facts"] = [
+                f"{attacker.name}'s right arm trembles after meridian backlash."
+            ]
+
+        return ResolveResult(roll=roll, margin=margin, band=band, state_shift=state_shift)
+```
+
+- [ ] **Step 5: Run resolver tests**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_outcome_band_mapping_uses_narrative_bands_not_damage tests/narrative_combat/test_vertical_slice.py::test_resolver_is_seeded_and_never_emits_damage -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/narrative_combat/models.py src/narrative_combat/resolver.py tests/narrative_combat/test_vertical_slice.py
+git commit -m "feat(narrative-combat): add seeded resolver"
+```
+
+---
+
+### Task 3: Director Path Planning and Fight Packet
+
+**Files:**
+- Modify: `src/narrative_combat/models.py`
+- Create: `src/narrative_combat/director.py`
+- Test: `tests/narrative_combat/test_vertical_slice.py`
+
+- [ ] **Step 1: Add failing director tests**
+
+Append:
+
+```python
+from src.narrative_combat.director import Director, structurally_different
+
+
+def test_director_emits_required_packet_shape_and_invariants():
+    fight = Director(boss_duel_demo(seed=1337)).run()
+
+    assert fight["schema"] == "scbe.narrative_combat.fight.v1"
+    assert fight["encounter_id"] == "boss_duel_demo"
+    assert fight["seed"] == 1337
+    assert fight["path"]["chosen"] != fight["path"]["shortest"]
+    assert fight["path"]["chosen"] != fight["path"]["longest"]
+    assert fight["path"]["reversal_index"] >= 0
+    assert fight["path"]["price_index"] >= 0
+    assert fight["aftermath"]["winner"] == "Wu Jin"
+    assert fight["aftermath"]["price_paid"]
+
+    for beat in fight["beats"]:
+        assert {"beat_id", "phase", "feature", "roll", "margin", "band", "state_shift", "prose"} <= set(beat)
+
+
+def test_structural_reroll_uses_more_than_different_wording():
+    fight_a = Director(boss_duel_demo(seed=1337)).run()
+    fight_b = Director(boss_duel_demo(seed=2026)).run()
+
+    assert structurally_different(fight_a, fight_b)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_director_emits_required_packet_shape_and_invariants tests/narrative_combat/test_vertical_slice.py::test_structural_reroll_uses_more_than_different_wording -q
+```
+
+Expected: FAIL with missing `src.narrative_combat.director`.
+
+- [ ] **Step 3: Implement director**
+
+Create `src/narrative_combat/director.py`:
+
+```python
+from __future__ import annotations
+
+from random import Random
+from typing import Any
+
+from .models import Encounter, Feature, PhaseName
+from .resolver import Resolver
+from .translator import TemplateTranslator
+
+
+PHASES: list[PhaseName] = [
+    "objective",
+    "first_tactic",
+    "true_rule",
+    "hidden_problem",
+    "cost_unavoidable",
+    "strategy_change",
+    "understanding_wins",
+    "aftermath",
+]
+
+
+def structurally_different(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return any(
+        [
+            left["path"]["chosen"] != right["path"]["chosen"],
+            left["path"]["reversal_index"] != right["path"]["reversal_index"],
+            left["path"]["price_index"] != right["path"]["price_index"],
+            left["aftermath"]["price_paid"] != right["aftermath"]["price_paid"],
+        ]
+    )
+
+
+class Director:
+    def __init__(self, encounter: Encounter) -> None:
+        self.encounter = encounter
+        self._rng = Random(encounter.seed)
+        self._resolver = Resolver(encounter.seed)
+        self._translator = TemplateTranslator()
+
+    def run(self) -> dict[str, Any]:
+        features = list(self.encounter.features)
+        feature_by_kind = {feature.kind: feature for feature in features}
+        shortest = ["monster", "treasure", "ending"]
+        longest = ["safe_zone", "monster", "safe_zone", "treasure", "ending"]
+        chosen_features = self._chosen_features(features)
+        chosen = [feature.kind for feature in chosen_features] + ["ending"]
+        reversal_index = self._pick_reversal_index(chosen_features)
+        price_index = self._pick_price_index(chosen_features, reversal_index)
+
+        attacker = self.encounter.fighters[0]
+        defender = self.encounter.fighters[1]
+        visible_techniques = [tech for tech in self.encounter.techniques if tech.technique_id in attacker.techniques]
+        concealed = next(tech for tech in self.encounter.techniques if tech.technique_id in attacker.concealed)
+
+        momentum = 0
+        beats: list[dict[str, Any]] = []
+        for idx, feature in enumerate(chosen_features):
+            phase = PHASES[min(idx + 1, len(PHASES) - 2)]
+            technique = concealed if idx == price_index else visible_techniques[idx % len(visible_techniques)]
+            result = self._resolver.resolve(attacker, defender, technique, self.encounter.terrain, feature, momentum)
+            momentum = max(-5, min(5, momentum + int(result.state_shift["momentum"])))
+            beat = {
+                "beat_id": f"beat_{idx + 1:03d}",
+                "phase": phase,
+                "feature": feature.kind,
+                "roll": result.roll,
+                "margin": result.margin,
+                "band": result.band,
+                "state_shift": result.state_shift,
+            }
+            beat["prose"] = self._translator.render(beat, feature, technique, self.encounter)
+            beats.append(beat)
+
+        price_paid = ["concealed technique revealed", "qi backlash"]
+        continuity_facts: list[str] = []
+        for beat in beats:
+            continuity_facts.extend(beat["state_shift"].get("continuity_facts", []))
+
+        return {
+            "schema": "scbe.narrative_combat.fight.v1",
+            "encounter_id": self.encounter.encounter_id,
+            "seed": self.encounter.seed,
+            "style": self.encounter.style,
+            "objective": self.encounter.objective,
+            "planned_goal": {
+                "winner": self.encounter.planned_goal.winner,
+                "price": self.encounter.planned_goal.price,
+                "aftermath": self.encounter.planned_goal.aftermath,
+            },
+            "path": {
+                "shortest": shortest,
+                "longest": longest,
+                "chosen": chosen,
+                "reversal_index": reversal_index,
+                "price_index": price_index,
+            },
+            "beats": beats,
+            "aftermath": {
+                "winner": self.encounter.planned_goal.winner,
+                "price_paid": price_paid,
+                "continuity_facts": continuity_facts,
+            },
+        }
+
+    def _chosen_features(self, features: list[Feature]) -> list[Feature]:
+        ordered = list(features)
+        self._rng.shuffle(ordered)
+        if [feature.kind for feature in ordered] == ["monster", "treasure"]:
+            ordered.insert(0, next(feature for feature in features if feature.kind == "safe_zone"))
+        return ordered
+
+    def _pick_reversal_index(self, features: list[Feature]) -> int:
+        monster_index = next((idx for idx, feature in enumerate(features) if feature.kind == "monster"), 0)
+        return monster_index
+
+    def _pick_price_index(self, features: list[Feature], reversal_index: int) -> int:
+        treasure_index = next((idx for idx, feature in enumerate(features) if feature.kind == "treasure"), len(features) - 1)
+        if treasure_index == reversal_index and len(features) > 1:
+            return min(len(features) - 1, treasure_index + 1)
+        return treasure_index
+```
+
+- [ ] **Step 4: Run director tests**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_director_emits_required_packet_shape_and_invariants tests/narrative_combat/test_vertical_slice.py::test_structural_reroll_uses_more_than_different_wording -q
+```
+
+Expected: initially FAIL because `TemplateTranslator` does not exist.
+
+- [ ] **Step 5: Commit only after Task 4 creates translator**
+
+Do not commit this task until Task 4 completes because `director.py` imports the translator.
+
+---
+
+### Task 4: Deterministic Template Translator
+
+**Files:**
+- Create: `src/narrative_combat/translator.py`
+- Test: `tests/narrative_combat/test_vertical_slice.py`
+
+- [ ] **Step 1: Add failing translator test**
+
+Append:
+
+```python
+from src.narrative_combat.translator import TemplateTranslator
+
+
+def test_template_translator_is_deterministic_and_mentions_feature_cost_or_rule():
+    encounter = boss_duel_demo(seed=1337)
+    feature = encounter.features[0]
+    technique = encounter.techniques[0]
+    beat = {
+        "beat_id": "beat_001",
+        "phase": "first_tactic",
+        "feature": feature.kind,
+        "roll": 17,
+        "margin": 8,
+        "band": "strong_advantage",
+        "state_shift": {"momentum": 2, "resources": {"Wu Jin.qi": -3}, "revealed": [], "injuries": []},
+    }
+    translator = TemplateTranslator()
+
+    rendered_a = translator.render(beat, feature, technique, encounter)
+    rendered_b = translator.render(beat, feature, technique, encounter)
+
+    assert rendered_a == rendered_b
+    assert feature.label in rendered_a
+    assert technique.name in rendered_a
+    assert "strong advantage" in rendered_a
+```
+
+- [ ] **Step 2: Run translator test to verify it fails**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_template_translator_is_deterministic_and_mentions_feature_cost_or_rule -q
+```
+
+Expected: FAIL with missing `TemplateTranslator`.
+
+- [ ] **Step 3: Implement translator**
+
+Create `src/narrative_combat/translator.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from .models import Encounter, Feature, Technique
+
+
+class TemplateTranslator:
+    def render(self, beat: dict[str, Any], feature: Feature, technique: Technique, encounter: Encounter) -> str:
+        band = str(beat["band"]).replace("_", " ")
+        actor = encounter.fighters[0].name
+        opponent = encounter.fighters[1].name
+        cost = technique.cost
+        test = feature.innate_test
+        consequence = feature.consequence
+        return (
+            f"{actor} meets the {test} test at the {feature.label}. "
+            f"He answers with {technique.name}, spending {cost} qi. "
+            f"The exchange lands as {band} against {opponent}: {consequence}."
+        )
+```
+
+- [ ] **Step 4: Run translator and director tests**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_template_translator_is_deterministic_and_mentions_feature_cost_or_rule tests/narrative_combat/test_vertical_slice.py::test_director_emits_required_packet_shape_and_invariants tests/narrative_combat/test_vertical_slice.py::test_structural_reroll_uses_more_than_different_wording -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Tasks 3 and 4 together**
+
+```powershell
+git add src/narrative_combat/director.py src/narrative_combat/translator.py tests/narrative_combat/test_vertical_slice.py
+git commit -m "feat(narrative-combat): generate deterministic fight packets"
+```
+
+---
+
+### Task 5: Wall and Continuity Invariant Tests
+
+**Files:**
+- Modify: `tests/narrative_combat/test_vertical_slice.py`
+- Modify: `src/narrative_combat/director.py` if needed
+
+- [ ] **Step 1: Add invariant tests**
+
+Append:
+
+```python
+def test_fight_never_spends_negative_qi_and_reveals_hidden_card_once():
+    fight = Director(boss_duel_demo(seed=1337)).run()
+    qi_spent = 0
+    hidden_reveals = []
+
+    for beat in fight["beats"]:
+        resources = beat["state_shift"]["resources"]
+        qi_spent += abs(sum(resources.values()))
+        hidden_reveals.extend(beat["state_shift"].get("revealed", []))
+
+    assert qi_spent <= 30
+    assert hidden_reveals == ["hidden_meridian_art"]
+
+
+def test_aftermath_carries_continuity_fact_from_price():
+    fight = Director(boss_duel_demo(seed=1337)).run()
+
+    assert any("right arm trembles" in fact for fact in fight["aftermath"]["continuity_facts"])
+```
+
+- [ ] **Step 2: Run invariant tests**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_fight_never_spends_negative_qi_and_reveals_hidden_card_once tests/narrative_combat/test_vertical_slice.py::test_aftermath_carries_continuity_fact_from_price -q
+```
+
+Expected: PASS. If hidden technique reveals more than once, update `Director.run()` to track `concealed_spent = False` and only use the concealed technique when `idx == price_index and not concealed_spent`.
+
+- [ ] **Step 3: Run full vertical slice tests**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add src/narrative_combat/director.py tests/narrative_combat/test_vertical_slice.py
+git commit -m "test(narrative-combat): lock wall and aftermath invariants"
+```
+
+---
+
+### Task 6: CLI Output
+
+**Files:**
+- Create: `src/narrative_combat/cli.py`
+- Test: `tests/narrative_combat/test_vertical_slice.py`
+
+- [ ] **Step 1: Add CLI test**
+
+Append:
+
+```python
+import json
+import subprocess
+import sys
+
+
+def test_cli_writes_json_packet_to_stdout():
+    result = subprocess.run(
+        [sys.executable, "-m", "src.narrative_combat.cli", "--seed", "1337"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    packet = json.loads(result.stdout)
+
+    assert packet["schema"] == "scbe.narrative_combat.fight.v1"
+    assert packet["seed"] == 1337
+    assert packet["beats"]
+```
+
+- [ ] **Step 2: Run CLI test to verify it fails**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_cli_writes_json_packet_to_stdout -q
+```
+
+Expected: FAIL with missing `src.narrative_combat.cli`.
+
+- [ ] **Step 3: Implement CLI**
+
+Create `src/narrative_combat/cli.py`:
+
+```python
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .director import Director
+from .fixtures import boss_duel_demo
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a narrative combat fight packet.")
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+
+    packet = Director(boss_duel_demo(seed=args.seed)).run()
+    payload = json.dumps(packet, indent=2, sort_keys=True)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run CLI test**
+
+Run:
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py::test_cli_writes_json_packet_to_stdout -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run a manual CLI output sample**
+
+Run:
+
+```powershell
+python -m src.narrative_combat.cli --seed 1337 --out artifacts\narrative_combat\boss_duel_demo.seed1337.json
+```
+
+Expected: file exists and contains `scbe.narrative_combat.fight.v1`.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src/narrative_combat/cli.py tests/narrative_combat/test_vertical_slice.py artifacts/narrative_combat/boss_duel_demo.seed1337.json
+git commit -m "feat(narrative-combat): add fight packet CLI"
+```
+
+---
+
+### Task 7: Final Verification
+
+**Files:**
+- Modify only if verification finds a real failure.
+
+- [ ] **Step 1: Run focused test suite**
+
+```powershell
+python -m pytest tests/narrative_combat/test_vertical_slice.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Compile package**
+
+```powershell
+python -m py_compile src\narrative_combat\__init__.py src\narrative_combat\models.py src\narrative_combat\fixtures.py src\narrative_combat\resolver.py src\narrative_combat\director.py src\narrative_combat\translator.py src\narrative_combat\cli.py
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 3: Confirm package is isolated from SCBE governance**
+
+```powershell
+rg -n "geoseal|governance|harmonic|SCBE_FORCE|liboqs|agentbus|agent-bus" src\narrative_combat tests\narrative_combat
+```
+
+Expected: no matches except intentional schema string if added later.
+
+- [ ] **Step 4: Commit any verification fixes**
+
+Only if files changed:
+
+```powershell
+git add src/narrative_combat tests/narrative_combat
+git commit -m "fix(narrative-combat): stabilize vertical slice verification"
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Story-first/no-HP model: Tasks 1-5 define state shifts, not damage.
+- Maze/pathfinder director: Task 3 implements shortest/longest/chosen path and structural reroll checks.
+- Feature graph and innate tests: Task 1 fixture defines safe zone, treasure, monster with tests; Task 3 consumes them.
+- Dice as pivots: Task 2 maps margins to narrative bands and state shifts.
+- Determinism: Tasks 2, 3, and 6 test seeded repeatability and CLI packet output.
+- Translator backend: Task 4 implements deterministic `TemplateTranslator`; LLM translator remains intentionally out of scope.
+- Packet compatibility: Task 3 emits `scbe.narrative_combat.fight.v1`.
+- Wall/continuity tests: Task 5 locks qi spend, concealed reveal, and aftermath facts.
+
+Placeholder scan:
+
+- No TBD/TODO/fill-in placeholders remain.
+- Every code step includes concrete code.
+- Every test step includes an exact command and expected result.
+
+Type consistency:
+
+- `Feature.kind`, `Technique.technique_id`, `Encounter.seed`, `ResolveResult.state_shift`, `Director.run()` packet fields are used consistently across tasks.
+

--- a/src/narrative_combat/__init__.py
+++ b/src/narrative_combat/__init__.py
@@ -1,0 +1,23 @@
+"""Standalone narrative combat generator vertical slice."""
+
+from .fixtures import boss_duel_demo
+from .loader import (
+    EncounterSpecError,
+    encounter_from_dict,
+    encounter_to_dict,
+    load_encounter,
+)
+from .models import Encounter, Feature, Fighter, Technique, Terrain
+
+__all__ = [
+    "Encounter",
+    "EncounterSpecError",
+    "Feature",
+    "Fighter",
+    "Technique",
+    "Terrain",
+    "boss_duel_demo",
+    "encounter_from_dict",
+    "encounter_to_dict",
+    "load_encounter",
+]

--- a/src/narrative_combat/cli.py
+++ b/src/narrative_combat/cli.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .director import Director
+from .fixtures import boss_duel_demo
+
+
+def _emit(payload: str, out: Path | None) -> None:
+    if out:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a narrative combat fight packet.")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="seed override (default 1337 for the demo, or the file's own seed when --encounter is given)",
+    )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "--encounter",
+        type=Path,
+        default=None,
+        help="path to a custom encounter JSON (default: built-in boss_duel_demo)",
+    )
+    source.add_argument(
+        "--dump-template",
+        action="store_true",
+        help="emit the built-in demo as a fillable encounter JSON template and exit",
+    )
+    parser.add_argument("--out", type=Path)
+    parser.add_argument(
+        "--translator",
+        choices=["template", "llm"],
+        default="template",
+        help="template = deterministic (default); llm = glm-5.1 prose via Ollama, falls back to template",
+    )
+    parser.add_argument("--style", default=None, help="override prose style for the llm translator")
+    parser.add_argument("--model", default="glm-5.1:cloud", help="Ollama model for the llm translator")
+    parser.add_argument("--ollama-host", default="http://127.0.0.1:11434")
+    args = parser.parse_args()
+
+    if args.dump_template:
+        from .loader import encounter_to_dict
+
+        _emit(json.dumps(encounter_to_dict(boss_duel_demo()), indent=2, sort_keys=True), args.out)
+        return 0
+
+    if args.encounter is not None:
+        from .loader import EncounterSpecError, load_encounter
+
+        try:
+            encounter = load_encounter(args.encounter, seed_override=args.seed)
+        except EncounterSpecError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+    else:
+        encounter = boss_duel_demo(seed=args.seed if args.seed is not None else 1337)
+
+    translator = None
+    if args.translator == "llm":
+        from .translator import LLMTranslator
+
+        translator = LLMTranslator(
+            model=args.model,
+            host=args.ollama_host,
+            style=args.style or encounter.style,
+        )
+
+    packet = Director(encounter, translator=translator).run()
+    _emit(json.dumps(packet, indent=2, sort_keys=True), args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/narrative_combat/director.py
+++ b/src/narrative_combat/director.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from random import Random
+from typing import Any
+
+from .models import Encounter, Feature, PhaseName
+from .resolver import Resolver
+from .translator import TemplateTranslator
+
+PHASES: list[PhaseName] = [
+    "objective",
+    "first_tactic",
+    "true_rule",
+    "hidden_problem",
+    "cost_unavoidable",
+    "strategy_change",
+    "understanding_wins",
+    "aftermath",
+]
+
+
+def structurally_different(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return any(
+        [
+            left["path"]["chosen"] != right["path"]["chosen"],
+            left["path"]["reversal_index"] != right["path"]["reversal_index"],
+            left["path"]["price_index"] != right["path"]["price_index"],
+            left["aftermath"]["price_paid"] != right["aftermath"]["price_paid"],
+        ]
+    )
+
+
+class Director:
+    def __init__(self, encounter: Encounter, translator: Any | None = None) -> None:
+        self.encounter = encounter
+        self._rng = Random(encounter.seed)
+        self._resolver = Resolver(encounter.seed)
+        # Inject any object with .render(beat, feature, technique, encounter) -> str.
+        # Default stays the deterministic template so golden tests are unaffected.
+        self._translator = translator if translator is not None else TemplateTranslator()
+
+    def run(self) -> dict[str, Any]:
+        chosen_features = self._chosen_features(list(self.encounter.features))
+        shortest = ["monster", "treasure", "ending"]
+        longest = ["safe_zone", "monster", "safe_zone", "treasure", "ending"]
+        chosen = [feature.kind for feature in chosen_features] + ["ending"]
+        reversal_index = self._pick_reversal_index(chosen_features)
+        price_index = self._pick_price_index(chosen_features, reversal_index)
+
+        attacker = self.encounter.fighters[0]
+        defender = self.encounter.fighters[1]
+        visible_techniques = [
+            technique for technique in self.encounter.techniques if technique.technique_id in attacker.techniques
+        ]
+        concealed = next(
+            technique for technique in self.encounter.techniques if technique.technique_id in attacker.concealed
+        )
+
+        momentum = 0
+        concealed_spent = False
+        beats: list[dict[str, Any]] = []
+        for idx, feature in enumerate(chosen_features):
+            phase = PHASES[min(idx + 1, len(PHASES) - 2)]
+            if idx == price_index and not concealed_spent:
+                technique = concealed
+                concealed_spent = True
+            else:
+                technique = visible_techniques[idx % len(visible_techniques)]
+
+            result = self._resolver.resolve(attacker, defender, technique, self.encounter.terrain, feature, momentum)
+            momentum = max(-5, min(5, momentum + int(result.state_shift["momentum"])))
+            beat = {
+                "beat_id": f"beat_{idx + 1:03d}",
+                "phase": phase,
+                "feature": feature.kind,
+                "roll": result.roll,
+                "margin": result.margin,
+                "band": result.band,
+                "state_shift": result.state_shift,
+            }
+            beat["prose"] = self._translator.render(beat, feature, technique, self.encounter)
+            beats.append(beat)
+
+        continuity_facts: list[str] = []
+        for beat in beats:
+            continuity_facts.extend(beat["state_shift"].get("continuity_facts", []))
+
+        return {
+            "schema": "scbe.narrative_combat.fight.v1",
+            "encounter_id": self.encounter.encounter_id,
+            "seed": self.encounter.seed,
+            "style": self.encounter.style,
+            "objective": self.encounter.objective,
+            "planned_goal": {
+                "winner": self.encounter.planned_goal.winner,
+                "price": self.encounter.planned_goal.price,
+                "aftermath": self.encounter.planned_goal.aftermath,
+            },
+            "path": {
+                "shortest": shortest,
+                "longest": longest,
+                "chosen": chosen,
+                "reversal_index": reversal_index,
+                "price_index": price_index,
+            },
+            "beats": beats,
+            "aftermath": {
+                "winner": self.encounter.planned_goal.winner,
+                "price_paid": ["concealed technique revealed", "qi backlash"],
+                "continuity_facts": continuity_facts,
+            },
+        }
+
+    def _chosen_features(self, features: list[Feature]) -> list[Feature]:
+        by_kind = {feature.kind: feature for feature in features}
+        orders = [
+            ["safe_zone", "treasure", "monster"],
+            ["treasure", "safe_zone", "monster"],
+            ["monster", "safe_zone", "treasure"],
+        ]
+        order = orders[self._rng.randrange(len(orders))]
+        return [by_kind[kind] for kind in order]
+
+    def _pick_reversal_index(self, features: list[Feature]) -> int:
+        return next((idx for idx, feature in enumerate(features) if feature.kind == "monster"), 0)
+
+    def _pick_price_index(self, features: list[Feature], reversal_index: int) -> int:
+        treasure_index = next(
+            (idx for idx, feature in enumerate(features) if feature.kind == "treasure"), len(features) - 1
+        )
+        if treasure_index == reversal_index and len(features) > 1:
+            return min(len(features) - 1, treasure_index + 1)
+        return treasure_index

--- a/src/narrative_combat/fixtures.py
+++ b/src/narrative_combat/fixtures.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from .models import Encounter, Feature, Fighter, PlannedGoal, Technique, Terrain
+
+
+def boss_duel_demo(seed: int = 1337) -> Encounter:
+    return Encounter(
+        encounter_id="boss_duel_demo",
+        seed=seed,
+        style="xianxia",
+        objective="choose",
+        fighters=[
+            Fighter(
+                name="Wu Jin",
+                tier="Iron Body",
+                stats={"body": 8, "qi": 7, "speed": 9, "focus": 6},
+                temperament=["prideful", "patient"],
+                techniques=["falling_river_cleave", "stone_breath_guard"],
+                concealed=["hidden_meridian_art"],
+                resources={"qi": 30, "stamina": 20},
+                goal="protect",
+            ),
+            Fighter(
+                name="Ash-Crowned Bailiff",
+                tier="Bronze Vein",
+                stats={"body": 9, "qi": 8, "speed": 5, "focus": 7},
+                temperament=["punitive", "certain"],
+                techniques=["ash_seal_brand"],
+                concealed=[],
+                resources={"qi": 24, "stamina": 24},
+                goal="humiliate",
+            ),
+        ],
+        techniques=[
+            Technique(
+                technique_id="falling_river_cleave",
+                name="Falling River Cleave",
+                type="saber",
+                cost=3,
+                range="mid",
+                grade="low",
+                hidden=False,
+                effect={"momentum_shift": 2, "guard_break": True},
+                narrative_tags=["flood", "weight", "pressure"],
+            ),
+            Technique(
+                technique_id="stone_breath_guard",
+                name="Stone Breath Guard",
+                type="body",
+                cost=2,
+                range="close",
+                grade="low",
+                hidden=False,
+                effect={"momentum_shift": 1, "guard": True},
+                narrative_tags=["stillness", "breath", "root"],
+            ),
+            Technique(
+                technique_id="hidden_meridian_art",
+                name="Hidden Meridian Art",
+                type="qi",
+                cost=9,
+                range="self",
+                grade="forbidden",
+                hidden=True,
+                effect={"momentum_shift": 4, "backlash": True},
+                narrative_tags=["secret", "vein", "backlash"],
+            ),
+            Technique(
+                technique_id="ash_seal_brand",
+                name="Ash Seal Brand",
+                type="curse",
+                cost=4,
+                range="mid",
+                grade="middle",
+                hidden=False,
+                effect={"momentum_shift": -2, "bind": True},
+                narrative_tags=["ash", "law", "brand"],
+            ),
+        ],
+        terrain=Terrain(
+            name="drained river shrine",
+            constraints=["the cracked shrine floor cannot flood", "ash clouds reduce sight"],
+            modifiers={"safe_zone": 1, "monster": -2, "treasure": 2},
+            narrative_tags=["dry riverbed", "broken shrine", "ash haze"],
+        ),
+        features=[
+            Feature(
+                feature_id="breathing_pillar",
+                kind="safe_zone",
+                label="fallen shrine pillar",
+                innate_test="patience",
+                consequence="regroup without ceding the whole tempo",
+            ),
+            Feature(
+                feature_id="buried_bell",
+                kind="treasure",
+                label="buried bronze bell",
+                innate_test="restraint",
+                consequence="unlock the old rhythm at the cost of an opening",
+            ),
+            Feature(
+                feature_id="ash_officer",
+                kind="monster",
+                label="ash-bound officer",
+                innate_test="resolve",
+                consequence="face the hidden phase instead of retreating",
+            ),
+        ],
+        planned_goal=PlannedGoal(
+            winner="Wu Jin",
+            price="spends the concealed meridian art and carries qi backlash",
+            aftermath=["right arm tremor", "enemy ideology disproven but not erased"],
+        ),
+    )

--- a/src/narrative_combat/loader.py
+++ b/src/narrative_combat/loader.py
@@ -1,0 +1,226 @@
+"""Load a custom Encounter from JSON so the engine can run any cast, not just the demo.
+
+stdlib-only (json + dataclasses), to match the rest of the package. The loader is
+deliberately strict: a hand- or LLM-authored encounter file fails with a path-pointing
+message ("encounter.fighters[0].concealed: ...") instead of a deep stack trace from the
+Director. The validated invariants are exactly the ones the Director silently assumes.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from .models import Encounter, Feature, Fighter, PlannedGoal, Technique, Terrain
+
+# The path orders in Director._chosen_features index features by these kinds.
+REQUIRED_FEATURE_KINDS = ("safe_zone", "treasure", "monster")
+
+
+class EncounterSpecError(ValueError):
+    """Raised when an encounter JSON file is missing or malformed, with a field path."""
+
+
+# --- small typed extractors (each reports the dotted path of the offending field) ---
+
+
+def _as_dict(value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise EncounterSpecError(f"{path}: expected an object, got {type(value).__name__}")
+    return value
+
+
+def _as_list(value: Any, path: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise EncounterSpecError(f"{path}: expected a list, got {type(value).__name__}")
+    return value
+
+
+def _req(data: dict[str, Any], key: str, path: str) -> Any:
+    if key not in data:
+        raise EncounterSpecError(f"{path}.{key}: required field is missing")
+    return data[key]
+
+
+def _req_str(data: dict[str, Any], key: str, path: str) -> str:
+    value = _req(data, key, path)
+    if not isinstance(value, str):
+        raise EncounterSpecError(f"{path}.{key}: expected a string, got {type(value).__name__}")
+    return value
+
+
+def _req_int(data: dict[str, Any], key: str, path: str) -> int:
+    value = _req(data, key, path)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise EncounterSpecError(f"{path}.{key}: expected an integer, got {type(value).__name__}")
+    return value
+
+
+def _str_list(value: Any, path: str) -> list[str]:
+    items = _as_list(value, path)
+    for idx, item in enumerate(items):
+        if not isinstance(item, str):
+            raise EncounterSpecError(f"{path}[{idx}]: expected a string, got {type(item).__name__}")
+    return list(items)
+
+
+def _int_map(value: Any, path: str) -> dict[str, int]:
+    mapping = _as_dict(value, path)
+    for key, val in mapping.items():
+        if isinstance(val, bool) or not isinstance(val, int):
+            raise EncounterSpecError(f"{path}.{key}: expected an integer, got {type(val).__name__}")
+    return dict(mapping)
+
+
+# --- per-dataclass builders ---
+
+
+def _fighter_from_dict(value: Any, path: str) -> Fighter:
+    data = _as_dict(value, path)
+    return Fighter(
+        name=_req_str(data, "name", path),
+        tier=_req_str(data, "tier", path),
+        stats=_int_map(_req(data, "stats", path), f"{path}.stats"),
+        temperament=_str_list(_req(data, "temperament", path), f"{path}.temperament"),
+        techniques=_str_list(_req(data, "techniques", path), f"{path}.techniques"),
+        concealed=_str_list(data.get("concealed", []), f"{path}.concealed"),
+        resources=_int_map(data.get("resources", {}), f"{path}.resources"),
+        injuries=_str_list(data.get("injuries", []), f"{path}.injuries"),
+        momentum=int(data.get("momentum", 0)),
+        morale=float(data.get("morale", 1.0)),
+        goal=str(data.get("goal", "win")),
+    )
+
+
+def _technique_from_dict(value: Any, path: str) -> Technique:
+    data = _as_dict(value, path)
+    return Technique(
+        technique_id=_req_str(data, "technique_id", path),
+        name=_req_str(data, "name", path),
+        type=_req_str(data, "type", path),
+        cost=_req_int(data, "cost", path),
+        range=_req_str(data, "range", path),
+        grade=_req_str(data, "grade", path),
+        hidden=bool(data.get("hidden", False)),
+        effect=dict(_as_dict(data.get("effect", {}), f"{path}.effect")),
+        narrative_tags=_str_list(data.get("narrative_tags", []), f"{path}.narrative_tags"),
+    )
+
+
+def _terrain_from_dict(value: Any, path: str) -> Terrain:
+    data = _as_dict(value, path)
+    return Terrain(
+        name=_req_str(data, "name", path),
+        constraints=_str_list(data.get("constraints", []), f"{path}.constraints"),
+        modifiers=_int_map(data.get("modifiers", {}), f"{path}.modifiers"),
+        narrative_tags=_str_list(data.get("narrative_tags", []), f"{path}.narrative_tags"),
+    )
+
+
+def _feature_from_dict(value: Any, path: str) -> Feature:
+    data = _as_dict(value, path)
+    return Feature(
+        feature_id=_req_str(data, "feature_id", path),
+        kind=_req_str(data, "kind", path),  # type: ignore[arg-type]
+        label=_req_str(data, "label", path),
+        innate_test=_req_str(data, "innate_test", path),
+        consequence=_req_str(data, "consequence", path),
+    )
+
+
+def _planned_goal_from_dict(value: Any, path: str) -> PlannedGoal:
+    data = _as_dict(value, path)
+    return PlannedGoal(
+        winner=_req_str(data, "winner", path),
+        price=_req_str(data, "price", path),
+        aftermath=_str_list(data.get("aftermath", []), f"{path}.aftermath"),
+    )
+
+
+def _validate_director_invariants(encounter: Encounter) -> None:
+    """Reject encounters the Director would crash or misbehave on, with helpful messages."""
+    technique_ids = {technique.technique_id for technique in encounter.techniques}
+    attacker = encounter.fighters[0]
+
+    visible = [tid for tid in attacker.techniques if tid in technique_ids]
+    if not visible:
+        raise EncounterSpecError(
+            "encounter.fighters[0].techniques: at least one id must match a defined technique "
+            f"(known ids: {sorted(technique_ids)})"
+        )
+
+    if not attacker.concealed:
+        raise EncounterSpecError(
+            "encounter.fighters[0].concealed: needs at least one concealed technique id "
+            "(the Director reveals it at the price beat)"
+        )
+    unknown = [tid for tid in attacker.concealed if tid not in technique_ids]
+    if unknown:
+        raise EncounterSpecError(
+            f"encounter.fighters[0].concealed: unknown technique id(s) {unknown} "
+            f"(known ids: {sorted(technique_ids)})"
+        )
+
+    kind_counts = Counter(feature.kind for feature in encounter.features)
+    missing = [kind for kind in REQUIRED_FEATURE_KINDS if kind_counts[kind] == 0]
+    if missing:
+        raise EncounterSpecError(
+            f"encounter.features: must include one feature of each kind {list(REQUIRED_FEATURE_KINDS)}; "
+            f"missing {missing}"
+        )
+    duplicated = [kind for kind in REQUIRED_FEATURE_KINDS if kind_counts[kind] > 1]
+    if duplicated:
+        raise EncounterSpecError(
+            f"encounter.features: kind(s) {duplicated} appear more than once; the Director picks exactly "
+            "one feature per required kind, so duplicates would be silently dropped"
+        )
+
+
+def encounter_from_dict(data: Any, *, seed_override: int | None = None) -> Encounter:
+    """Build (and validate) an Encounter from a parsed JSON object."""
+    payload = _as_dict(data, "encounter")
+    fighters_raw = _as_list(_req(payload, "fighters", "encounter"), "encounter.fighters")
+    if len(fighters_raw) < 2:
+        raise EncounterSpecError("encounter.fighters: need at least 2 fighters (attacker, then defender)")
+
+    encounter = Encounter(
+        encounter_id=_req_str(payload, "encounter_id", "encounter"),
+        seed=seed_override if seed_override is not None else _req_int(payload, "seed", "encounter"),
+        style=_req_str(payload, "style", "encounter"),
+        objective=_req_str(payload, "objective", "encounter"),
+        fighters=[_fighter_from_dict(f, f"encounter.fighters[{i}]") for i, f in enumerate(fighters_raw)],
+        techniques=[
+            _technique_from_dict(t, f"encounter.techniques[{i}]")
+            for i, t in enumerate(_as_list(_req(payload, "techniques", "encounter"), "encounter.techniques"))
+        ],
+        terrain=_terrain_from_dict(_req(payload, "terrain", "encounter"), "encounter.terrain"),
+        features=[
+            _feature_from_dict(f, f"encounter.features[{i}]")
+            for i, f in enumerate(_as_list(_req(payload, "features", "encounter"), "encounter.features"))
+        ],
+        planned_goal=_planned_goal_from_dict(_req(payload, "planned_goal", "encounter"), "encounter.planned_goal"),
+    )
+    _validate_director_invariants(encounter)
+    return encounter
+
+
+def load_encounter(path: str | Path, *, seed_override: int | None = None) -> Encounter:
+    """Read and validate an encounter JSON file."""
+    file_path = Path(path)
+    try:
+        raw = file_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise EncounterSpecError(f"{file_path}: could not read encounter file: {exc}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise EncounterSpecError(f"{file_path}: invalid JSON: {exc}") from exc
+    return encounter_from_dict(data, seed_override=seed_override)
+
+
+def encounter_to_dict(encounter: Encounter) -> dict[str, Any]:
+    """Serialize an Encounter back to a plain dict (every field shown, for use as a template)."""
+    return dataclasses.asdict(encounter)

--- a/src/narrative_combat/models.py
+++ b/src/narrative_combat/models.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+FeatureKind = Literal["safe_zone", "treasure", "monster", "friend", "hazard"]
+OutcomeBand = Literal[
+    "dominating_strike",
+    "strong_advantage",
+    "minor_success",
+    "clash",
+    "defensive_loss",
+    "severe_opening_exposed",
+    "catastrophic_reversal",
+]
+PhaseName = Literal[
+    "objective",
+    "first_tactic",
+    "true_rule",
+    "hidden_problem",
+    "cost_unavoidable",
+    "strategy_change",
+    "understanding_wins",
+    "aftermath",
+]
+
+
+@dataclass(frozen=True)
+class Fighter:
+    name: str
+    tier: str
+    stats: dict[str, int]
+    temperament: list[str]
+    techniques: list[str]
+    concealed: list[str] = field(default_factory=list)
+    resources: dict[str, int] = field(default_factory=dict)
+    injuries: list[str] = field(default_factory=list)
+    momentum: int = 0
+    morale: float = 1.0
+    goal: str = "win"
+
+
+@dataclass(frozen=True)
+class Technique:
+    technique_id: str
+    name: str
+    type: str
+    cost: int
+    range: str
+    grade: str
+    hidden: bool
+    effect: dict[str, int | bool | str]
+    narrative_tags: list[str]
+
+
+@dataclass(frozen=True)
+class Terrain:
+    name: str
+    constraints: list[str]
+    modifiers: dict[str, int]
+    narrative_tags: list[str]
+
+
+@dataclass(frozen=True)
+class Feature:
+    feature_id: str
+    kind: FeatureKind
+    label: str
+    innate_test: str
+    consequence: str
+
+
+@dataclass(frozen=True)
+class PlannedGoal:
+    winner: str
+    price: str
+    aftermath: list[str]
+
+
+@dataclass(frozen=True)
+class Encounter:
+    encounter_id: str
+    seed: int
+    style: str
+    objective: str
+    fighters: list[Fighter]
+    techniques: list[Technique]
+    terrain: Terrain
+    features: list[Feature]
+    planned_goal: PlannedGoal
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    roll: int
+    margin: int
+    band: OutcomeBand
+    state_shift: dict[str, object]

--- a/src/narrative_combat/resolver.py
+++ b/src/narrative_combat/resolver.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from random import Random
+
+from .models import Feature, Fighter, OutcomeBand, ResolveResult, Technique, Terrain
+
+
+def outcome_band(margin: int) -> OutcomeBand:
+    if margin >= 15:
+        return "dominating_strike"
+    if margin >= 5:
+        return "strong_advantage"
+    if margin >= 1:
+        return "minor_success"
+    if margin == 0:
+        return "clash"
+    if margin >= -5:
+        return "defensive_loss"
+    if margin >= -10:
+        return "severe_opening_exposed"
+    return "catastrophic_reversal"
+
+
+class Resolver:
+    def __init__(self, seed: int) -> None:
+        self._rng = Random(seed)
+
+    def resolve(
+        self,
+        attacker: Fighter,
+        defender: Fighter,
+        technique: Technique,
+        terrain: Terrain,
+        feature: Feature,
+        momentum: int,
+    ) -> ResolveResult:
+        roll = self._rng.randint(1, 20)
+        combat_stat = attacker.stats.get("qi", 0)
+        technique_mod = int(technique.effect.get("momentum_shift", 0))
+        terrain_mod = terrain.modifiers.get(feature.kind, 0)
+        defender_state = defender.stats.get("focus", 0)
+        margin = roll + combat_stat + technique_mod + momentum + terrain_mod - defender_state
+        band = outcome_band(margin)
+
+        momentum_delta = max(-3, min(3, margin // 5))
+        qi_key = f"{attacker.name}.qi"
+        state_shift: dict[str, object] = {
+            "momentum": momentum_delta,
+            "resources": {qi_key: -technique.cost},
+            "revealed": [technique.technique_id] if technique.hidden else [],
+            "injuries": [],
+            "continuity_facts": [],
+        }
+        if technique.hidden:
+            state_shift["injuries"] = [f"{attacker.name} suffers meridian backlash"]
+            state_shift["continuity_facts"] = [f"{attacker.name}'s right arm trembles after meridian backlash."]
+
+        return ResolveResult(roll=roll, margin=margin, band=band, state_shift=state_shift)

--- a/src/narrative_combat/translator.py
+++ b/src/narrative_combat/translator.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .models import Encounter, Feature, Technique
+
+
+class TemplateTranslator:
+    """Deterministic prose. The default renderer: no model, no network, golden-stable."""
+
+    def render(self, beat: dict[str, Any], feature: Feature, technique: Technique, encounter: Encounter) -> str:
+        band = str(beat["band"]).replace("_", " ")
+        actor = encounter.fighters[0].name
+        opponent = encounter.fighters[1].name
+        cost = technique.cost
+        test = feature.innate_test
+        consequence = feature.consequence
+        return (
+            f"{actor} meets the {test} test at the {feature.label}. "
+            f"He answers with {technique.name}, spending {cost} qi. "
+            f"The exchange lands as {band} against {opponent}: {consequence}."
+        )
+
+
+class LLMTranslator:
+    """Opt-in renderer that turns one engine-authoritative beat into styled prose.
+
+    The engine owns truth (band, technique, cost, feature, outcome). This only
+    *renders* those fixed facts as 2-4 sentences of cultivation-genre prose; it is
+    forbidden, by prompt, from inventing outcomes/injuries/winners/techniques. Any
+    failure (Ollama down, timeout, empty reply) falls back to the deterministic
+    TemplateTranslator, so a fight always produces prose. Non-determinism here is
+    expected and isolated to the prose layer (cacheable by (seed, beat_id)).
+    """
+
+    def __init__(
+        self,
+        model: str = "glm-5.1:cloud",
+        host: str = "http://127.0.0.1:11434",
+        style: str = "xianxia",
+        timeout: float = 60.0,
+        fallback: Any | None = None,
+    ) -> None:
+        self.model = model
+        self.host = host.rstrip("/")
+        self.style = style
+        self.timeout = timeout
+        self.fallback = fallback if fallback is not None else TemplateTranslator()
+
+    def render(self, beat: dict[str, Any], feature: Feature, technique: Technique, encounter: Encounter) -> str:
+        try:
+            return self._render_llm(beat, feature, technique, encounter)
+        except Exception:
+            return self.fallback.render(beat, feature, technique, encounter)
+
+    def _render_llm(self, beat: dict[str, Any], feature: Feature, technique: Technique, encounter: Encounter) -> str:
+        import json
+        import urllib.request
+
+        attacker = encounter.fighters[0]
+        defender = encounter.fighters[1]
+        actor = attacker.name
+        opponent = defender.name
+        style = self.style or encounter.style
+        facts = {
+            "actor": actor,
+            "actor_temperament": attacker.temperament,
+            "opponent": opponent,
+            "opponent_temperament": defender.temperament,
+            "phase": beat["phase"],
+            "outcome_band": str(beat["band"]).replace("_", " "),
+            "technique": technique.name,
+            "technique_feel": technique.narrative_tags,
+            "engages": feature.label,
+            "tests": feature.innate_test,
+            "consequence": feature.consequence,
+            "terrain": encounter.terrain.name,
+            "terrain_feel": encounter.terrain.narrative_tags,
+        }
+        system = (
+            f"You are a {style} combat-prose stylist. Render ONE exchange of a duel as 2-4 vivid sentences. "
+            "Use ONLY the given facts. Do NOT invent outcomes, injuries, winners, deaths, or techniques. "
+            "Let each fighter's temperament shape how they move, carry themselves, and read the moment — "
+            "color voice and posture through it, but never let it override the fixed outcome. "
+            "The result is fixed by 'outcome_band' — convey it through action and image, never with numbers "
+            "or game words (no 'band', no 'qi cost', no stats). Physical specificity over interpretation. "
+            "Output prose only: no headings, no lists, no preamble."
+        )
+        user = "Facts (authoritative — render, never change):\n" + json.dumps(facts, ensure_ascii=False, indent=2)
+        body = json.dumps(
+            {
+                "model": self.model,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(self.host + "/api/chat", data=body, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        text = str((data.get("message") or {}).get("content", "")).strip()
+        if not text:
+            raise ValueError("empty LLM response")
+        return text

--- a/tests/narrative_combat/test_llm_translator.py
+++ b/tests/narrative_combat/test_llm_translator.py
@@ -1,0 +1,43 @@
+"""LLMTranslator: opt-in renderer must degrade safely and never break the engine."""
+
+from __future__ import annotations
+
+from src.narrative_combat.director import Director
+from src.narrative_combat.fixtures import boss_duel_demo
+from src.narrative_combat.translator import LLMTranslator, TemplateTranslator
+
+
+def _beat(feature_kind: str) -> dict:
+    return {
+        "beat_id": "beat_001",
+        "phase": "first_tactic",
+        "feature": feature_kind,
+        "roll": 17,
+        "margin": 8,
+        "band": "strong_advantage",
+        "state_shift": {"momentum": 2, "resources": {}, "revealed": [], "injuries": []},
+    }
+
+
+def test_llm_translator_falls_back_to_template_when_ollama_unreachable():
+    encounter = boss_duel_demo(seed=1337)
+    feature = encounter.features[0]
+    technique = encounter.techniques[0]
+    beat = _beat(feature.kind)
+
+    # Port 9 (discard) is reliably unreachable -> fast failure -> deterministic fallback.
+    llm = LLMTranslator(host="http://127.0.0.1:9", timeout=1.0)
+    template = TemplateTranslator()
+
+    assert llm.render(beat, feature, technique, encounter) == template.render(beat, feature, technique, encounter)
+
+
+def test_director_accepts_injected_translator_without_calling_network():
+    encounter = boss_duel_demo(seed=1337)
+    # An unreachable LLM translator must still yield a full fight (every beat falls back).
+    fight = Director(encounter, translator=LLMTranslator(host="http://127.0.0.1:9", timeout=1.0)).run()
+
+    assert fight["schema"] == "scbe.narrative_combat.fight.v1"
+    assert fight["beats"]
+    for beat in fight["beats"]:
+        assert beat["prose"]

--- a/tests/narrative_combat/test_loader.py
+++ b/tests/narrative_combat/test_loader.py
@@ -1,0 +1,111 @@
+"""Custom-encounter JSON loader: round-trips the demo and rejects director footguns clearly."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from src.narrative_combat.director import Director
+from src.narrative_combat.fixtures import boss_duel_demo
+from src.narrative_combat.loader import (
+    EncounterSpecError,
+    encounter_from_dict,
+    encounter_to_dict,
+    load_encounter,
+)
+
+
+def test_dump_then_load_round_trips_the_demo():
+    original = boss_duel_demo(seed=1337)
+    rebuilt = encounter_from_dict(encounter_to_dict(original))
+    assert rebuilt == original
+
+
+def test_round_tripped_encounter_produces_identical_fight():
+    original = boss_duel_demo(seed=1337)
+    rebuilt = encounter_from_dict(encounter_to_dict(original))
+    assert Director(original).run() == Director(rebuilt).run()
+
+
+def test_load_encounter_reads_a_json_file(tmp_path):
+    path = tmp_path / "encounter.json"
+    path.write_text(json.dumps(encounter_to_dict(boss_duel_demo(seed=1337))), encoding="utf-8")
+    loaded = load_encounter(path)
+    assert loaded == boss_duel_demo(seed=1337)
+
+
+def test_seed_override_replaces_file_seed():
+    spec = encounter_to_dict(boss_duel_demo(seed=1337))
+    loaded = encounter_from_dict(spec, seed_override=42)
+    assert loaded.seed == 42
+
+
+def test_missing_required_field_points_at_the_path():
+    spec = encounter_to_dict(boss_duel_demo())
+    del spec["fighters"][0]["techniques"]
+    with pytest.raises(EncounterSpecError, match=r"encounter\.fighters\[0\]\.techniques"):
+        encounter_from_dict(spec)
+
+
+def test_fewer_than_two_fighters_is_rejected():
+    spec = encounter_to_dict(boss_duel_demo())
+    spec["fighters"] = spec["fighters"][:1]
+    with pytest.raises(EncounterSpecError, match=r"at least 2 fighters"):
+        encounter_from_dict(spec)
+
+
+def test_empty_concealed_is_rejected_before_director_crashes():
+    spec = encounter_to_dict(boss_duel_demo())
+    spec["fighters"][0]["concealed"] = []
+    with pytest.raises(EncounterSpecError, match=r"concealed"):
+        encounter_from_dict(spec)
+
+
+def test_concealed_pointing_at_unknown_technique_is_rejected():
+    spec = encounter_to_dict(boss_duel_demo())
+    spec["fighters"][0]["concealed"] = ["no_such_art"]
+    with pytest.raises(EncounterSpecError, match=r"unknown technique id"):
+        encounter_from_dict(spec)
+
+
+def test_missing_required_feature_kind_is_rejected():
+    spec = encounter_to_dict(boss_duel_demo())
+    spec["features"] = [f for f in spec["features"] if f["kind"] != "monster"]
+    with pytest.raises(EncounterSpecError, match=r"missing \['monster'\]"):
+        encounter_from_dict(spec)
+
+
+def test_wrong_type_is_rejected_with_type_name():
+    spec = encounter_to_dict(boss_duel_demo())
+    spec["fighters"][0]["stats"]["body"] = "strong"
+    with pytest.raises(EncounterSpecError, match=r"expected an integer, got str"):
+        encounter_from_dict(spec)
+
+
+def test_duplicate_required_feature_kind_is_rejected():
+    spec = encounter_to_dict(boss_duel_demo())
+    duplicate = dict(spec["features"][0])  # a second safe_zone
+    duplicate["feature_id"] = "second_safe_zone"
+    spec["features"].append(duplicate)
+    with pytest.raises(EncounterSpecError, match=r"appear more than once"):
+        encounter_from_dict(spec)
+
+
+def test_cli_reports_bad_encounter_to_stderr_with_exit_code_2(tmp_path):
+    bad = tmp_path / "bad.json"
+    spec = encounter_to_dict(boss_duel_demo())
+    spec["fighters"][0]["concealed"] = []  # director footgun the loader must catch
+    bad.write_text(json.dumps(spec), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "src.narrative_combat.cli", "--encounter", str(bad)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "concealed" in result.stderr
+    assert result.stdout.strip() == ""

--- a/tests/narrative_combat/test_vertical_slice.py
+++ b/tests/narrative_combat/test_vertical_slice.py
@@ -1,0 +1,129 @@
+import json
+import subprocess
+import sys
+
+from src.narrative_combat.fixtures import boss_duel_demo
+from src.narrative_combat.director import Director, structurally_different
+from src.narrative_combat.resolver import Resolver, outcome_band
+from src.narrative_combat.translator import TemplateTranslator
+
+
+def test_boss_duel_fixture_has_required_vertical_slice_parts():
+    encounter = boss_duel_demo(seed=1337)
+
+    assert encounter.encounter_id == "boss_duel_demo"
+    assert encounter.seed == 1337
+    assert encounter.objective == "choose"
+    assert len(encounter.fighters) == 2
+    assert len(encounter.techniques) == 4
+    assert len(encounter.features) == 3
+    assert {feature.kind for feature in encounter.features} == {"safe_zone", "treasure", "monster"}
+
+
+def test_outcome_band_mapping_uses_narrative_bands_not_damage():
+    assert outcome_band(15) == "dominating_strike"
+    assert outcome_band(8) == "strong_advantage"
+    assert outcome_band(2) == "minor_success"
+    assert outcome_band(0) == "clash"
+    assert outcome_band(-3) == "defensive_loss"
+    assert outcome_band(-8) == "severe_opening_exposed"
+    assert outcome_band(-15) == "catastrophic_reversal"
+
+
+def test_resolver_is_seeded_and_never_emits_damage():
+    encounter = boss_duel_demo(seed=1337)
+    resolver_a = Resolver(seed=encounter.seed)
+    resolver_b = Resolver(seed=encounter.seed)
+    attacker = encounter.fighters[0]
+    defender = encounter.fighters[1]
+    technique = encounter.techniques[0]
+    feature = encounter.features[0]
+
+    result_a = resolver_a.resolve(attacker, defender, technique, encounter.terrain, feature, momentum=0)
+    result_b = resolver_b.resolve(attacker, defender, technique, encounter.terrain, feature, momentum=0)
+
+    assert result_a == result_b
+    assert "damage" not in result_a.state_shift
+    assert 1 <= result_a.roll <= 20
+
+
+def test_template_translator_is_deterministic_and_mentions_feature_cost_or_rule():
+    encounter = boss_duel_demo(seed=1337)
+    feature = encounter.features[0]
+    technique = encounter.techniques[0]
+    beat = {
+        "beat_id": "beat_001",
+        "phase": "first_tactic",
+        "feature": feature.kind,
+        "roll": 17,
+        "margin": 8,
+        "band": "strong_advantage",
+        "state_shift": {"momentum": 2, "resources": {"Wu Jin.qi": -3}, "revealed": [], "injuries": []},
+    }
+    translator = TemplateTranslator()
+
+    rendered_a = translator.render(beat, feature, technique, encounter)
+    rendered_b = translator.render(beat, feature, technique, encounter)
+
+    assert rendered_a == rendered_b
+    assert feature.label in rendered_a
+    assert technique.name in rendered_a
+    assert "strong advantage" in rendered_a
+
+
+def test_director_emits_required_packet_shape_and_invariants():
+    fight = Director(boss_duel_demo(seed=1337)).run()
+
+    assert fight["schema"] == "scbe.narrative_combat.fight.v1"
+    assert fight["encounter_id"] == "boss_duel_demo"
+    assert fight["seed"] == 1337
+    assert fight["path"]["chosen"] != fight["path"]["shortest"]
+    assert fight["path"]["chosen"] != fight["path"]["longest"]
+    assert fight["path"]["reversal_index"] >= 0
+    assert fight["path"]["price_index"] >= 0
+    assert fight["aftermath"]["winner"] == "Wu Jin"
+    assert fight["aftermath"]["price_paid"]
+
+    for beat in fight["beats"]:
+        assert {"beat_id", "phase", "feature", "roll", "margin", "band", "state_shift", "prose"} <= set(beat)
+
+
+def test_structural_reroll_uses_more_than_different_wording():
+    fight_a = Director(boss_duel_demo(seed=1337)).run()
+    fight_b = Director(boss_duel_demo(seed=2026)).run()
+
+    assert structurally_different(fight_a, fight_b)
+
+
+def test_fight_never_spends_negative_qi_and_reveals_hidden_card_once():
+    fight = Director(boss_duel_demo(seed=1337)).run()
+    qi_spent = 0
+    hidden_reveals = []
+
+    for beat in fight["beats"]:
+        resources = beat["state_shift"]["resources"]
+        qi_spent += abs(sum(resources.values()))
+        hidden_reveals.extend(beat["state_shift"].get("revealed", []))
+
+    assert qi_spent <= 30
+    assert hidden_reveals == ["hidden_meridian_art"]
+
+
+def test_aftermath_carries_continuity_fact_from_price():
+    fight = Director(boss_duel_demo(seed=1337)).run()
+
+    assert any("right arm trembles" in fact for fact in fight["aftermath"]["continuity_facts"])
+
+
+def test_cli_writes_json_packet_to_stdout():
+    result = subprocess.run(
+        [sys.executable, "-m", "src.narrative_combat.cli", "--seed", "1337"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    packet = json.loads(result.stdout)
+
+    assert packet["schema"] == "scbe.narrative_combat.fight.v1"
+    assert packet["seed"] == 1337
+    assert packet["beats"]


### PR DESCRIPTION
## Summary

- **Six-phase deterministic combat director** (`director.py`, `resolver.py`, `models.py`): d20+modifier → outcome-band resolver, momentum −5..+5, state-shifts for qi/emotion/injury/terrain/perception across six phases (intent → battlefield → exchange → escalation → turning-point → resolution).
- **Custom encounter loading** (`loader.py`): JSON spec → typed encounter, with validation (required feature kinds, non-empty concealed techniques, technique id integrity, duplicate-kind guard). CLI gains `--encounter <path>` and `--dump-template` flags.
- **Fighter temperament in LLM translator**: each combatant's temperament vector shapes voice and posture in the LLM prompt, without overriding the resolved outcome.
- **23 tests**: loader round-trip + validation edge-cases (12), LLM translator fallback (2), deterministic vertical-slice with seed override (9).
- **Design doc**: `docs/superpowers/plans/2026-05-21-narrative-combat-generator-vertical-slice.md`

## Relationship to PR #1823 (go-board)

The go-board SCBE Board Kernel (`src/narrative_combat/go_board/`) landed in PR #1823 and is already on `main`. This PR adds only the maze engine. `src/narrative_combat/__init__.py` is updated from the minimal stub (introduced in #1823) to the full maze public API — this is a clean edit, no conflict.

## Test plan

- [x] `python -m pytest tests/narrative_combat/ -q` → 45 passed (all 22 go-board + all 23 maze)
- [x] `black --check` → 11 files unchanged
- [x] `flake8` → silent
- [x] `python -m src.narrative_combat.cli` → deterministic packet with template translator
- [x] `python -m src.narrative_combat.cli --dump-template` → valid encounter skeleton

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command-line interface to generate narrative combat fight packets as JSON
  * Narrative combat generator with deterministic seeding and customizable encounters
  * Optional LLM-based prose generation for narrative beats with fallback to template rendering

* **Documentation**
  * Added implementation plan for narrative combat generator vertical slice

* **Tests**
  * Comprehensive test coverage for encounter loading, translation, and end-to-end workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->