### PR TITLE
fix(deps): resolve dependabot vulnerability alerts

### DIFF
--- a/conference-app/package-lock.json
+++ b/conference-app/package-lock.json
@@ -2714,9 +2714,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/conference-app/package.json
+++ b/conference-app/package.json
@@ -15,16 +15,16 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "express": "^5.2.1",
-    "uuid": "^14.0.0",
     "cors": "^2.8.5",
+    "express": "^5.2.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
-    "@types/express": "^5.0.0",
     "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
     "@types/node": "^22.15.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
@@ -35,5 +35,8 @@
     "typescript": "^5.8.3",
     "vite": "^8.0.7",
     "vitest": "^4.0.17"
+  },
+  "overrides": {
+    "qs": "^6.15.2"
   }
 }

--- a/examples/SCBEAgent/uv.lock
+++ b/examples/SCBEAgent/uv.lock
@@ -895,11 +895,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,9 +1694,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4242,9 +4242,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -308,6 +308,10 @@
   },
   "overrides": {
     "fast-xml-parser": "^5.7.1",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "qs": "^6.15.2",
+    "minimatch@10.2.5": {
+      "brace-expansion": "^5.0.6"
+    }
   }
 }

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -58,7 +58,7 @@ httpx==0.28.1
 httpx-sse==0.4.3
 hypothesis==6.152.7
 identify==2.6.19
-idna==3.11
+idna==3.16
 importlib_metadata==9.0.0
 importlib_resources==7.1.0
 iniconfig==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ pyasn1>=0.6.0
 protobuf>=5.28.0
 Werkzeug>=3.1.8
 certifi>=2024.7.0
+idna>=3.16
 
 # Browser Automation & Content Extraction
 playwright>=1.59.0

--- a/scbe-visual-system/package-lock.json
+++ b/scbe-visual-system/package-lock.json
@@ -1971,9 +1971,9 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2048,13 +2048,13 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7490,9 +7490,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/scbe-visual-system/package.json
+++ b/scbe-visual-system/package.json
@@ -41,7 +41,11 @@
   "overrides": {
     "tar": ">=7.0.0",
     "esbuild": ">=0.25.0",
-    "yauzl": "^3.2.1"
+    "yauzl": "^3.2.1",
+    "ws": "^8.20.1",
+    "minimatch@10.2.5": {
+      "brace-expansion": "^5.0.6"
+    }
   },
   "build": {
     "appId": "com.aethermoorgames.scbe",


### PR DESCRIPTION
## Summary
- Update vulnerable qs locks to 6.15.2 in root and conference app
- Update scbe-visual-system websocket dependency to a patched ws release and patch minimatch's brace-expansion edge
- Pin Python idna to 3.16 in requirements surfaces and refresh the SCBEAgent uv lock

## Security verification
- npm audit --json at repo root: 0 vulnerabilities
- npm audit --json in conference-app: 0 vulnerabilities
- npm audit --json in scbe-visual-system: 0 vulnerabilities
- python -m pip_audit -r requirements.txt: no known vulnerabilities
- uv lock --locked in examples/SCBEAgent: resolved cleanly

## Build/test evidence
- npm run build at repo root
- node node_modules\\vitest\\vitest.mjs run --run
- CI-equivalent Prettier: node node_modules\\prettier\\bin\\prettier.cjs --check "src/**/*.ts" "tests/**/*.ts"
- python -m black --check --target-version py311 --line-length 120 src tests
- python -m ruff check --config ruff.toml
- npm run build in conference-app
- npm run build and npm run test:run in scbe-visual-system

## Notes
- conference-app has no Vitest test files, so its npm test exits 1 by design.
- requirements-lock.txt pip-audit is blocked by a pre-existing malformed VCS entry unrelated to this idna fix.

## Rollback
- Revert this PR commit to restore the previous dependency locks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated and pinned transitive dependency versions for enhanced security and compatibility.
  * Reorganized dependency declarations and extended override configurations across package management files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->