### PR TITLE
chore(ci): update action runtimes and precommit guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - 'CHANGELOG.md'
       - 'docs/**'
       - '*.md'
       - '.github/workflows/**'
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -48,7 +48,7 @@ jobs:
         run: npm test
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-node20
           path: dist/
@@ -62,14 +62,15 @@ jobs:
       # PR CI exercises the deterministic fallback/PQC governance path. Native
       # liboqs builds are handled by the dedicated "PQC Native liboqs" workflow,
       # which must pass for release/security validation.
-      SCBE_FORCE_SKIP_LIBOQS: "1"
+      SCBE_FORCE_SKIP_LIBOQS: '1'
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -82,13 +83,25 @@ jobs:
 
       - name: Run Python tests
         run: |
-          python scripts/system/run_core_python_checks.py
+          python scripts/system/run_core_python_checks.py -- --cov=src --cov-report=xml
+
+      - name: Check coverage report
+        id: coverage-report
+        run: |
+          if [ -s coverage.xml ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "coverage.xml was not generated; skipping Codecov upload."
+          fi
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        if: ${{ env.CODECOV_TOKEN != '' && steps.coverage-report.outputs.exists == 'true' }}
+        uses: codecov/codecov-action@v6
         # audit: advisory - non-blocking telemetry/reporting path; downstream summary or gate handles outcome
         continue-on-error: true
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: python
           name: python-3.11
@@ -100,10 +113,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -133,10 +146,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -148,7 +161,7 @@ jobs:
         run: npx prettier --check "src/**/*.ts" "tests/**/*.ts"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/docs/PRECOMMIT_LINT_FORMAT_GUIDE.md
+++ b/docs/PRECOMMIT_LINT_FORMAT_GUIDE.md
@@ -1,0 +1,55 @@
+# Precommit Lint and Format Guide
+
+This repo installs a local pre-commit hook from `scripts/hooks/pre-commit`.
+Install or refresh it with:
+
+```powershell
+npm run hooks:install
+```
+
+The hook also installs automatically through the `prepare` script when running
+`npm install`.
+
+## Before Committing
+
+Run the narrow checks that match the main CI lint gate:
+
+```powershell
+node node_modules\prettier\bin\prettier.cjs --check "src/**/*.ts" "tests/**/*.ts"
+python -m black --check --target-version py311 --line-length 120 src tests
+python -m ruff check --config ruff.toml
+```
+
+To apply formatting:
+
+```powershell
+npm run format
+npm run format:python
+```
+
+Then rerun the checks above before committing.
+
+## Wider Local Checks
+
+`npm run lint` is stricter than the current CI lint gate because it also checks
+`packages/**/*.ts`. Use it before broad package work, but treat existing package
+format drift separately from focused CI fixes.
+
+For dependency or release-adjacent changes, run:
+
+```powershell
+npm run typecheck
+npm run build
+npm test
+python scripts/system/run_core_python_checks.py
+```
+
+If Python coverage upload behavior is being changed, generate the same report
+CI expects:
+
+```powershell
+python scripts/system/run_core_python_checks.py -- --cov=src --cov-report=xml
+```
+
+Codecov upload in CI is advisory and only runs when both `coverage.xml` exists
+and the `CODECOV_TOKEN` secret is configured.


### PR DESCRIPTION
## Summary
- update CI workflow actions to current major versions that support the newer GitHub runner runtime
- generate `coverage.xml` in the Python CI lane and only run Codecov when both the report and `CODECOV_TOKEN` are present
- add a precommit lint/format guide with the exact CI-equivalent commands and local hook install path

## Verification
- `node node_modules\\prettier\\bin\\prettier.cjs --check .github/workflows/ci.yml docs/PRECOMMIT_LINT_FORMAT_GUIDE.md "src/**/*.ts" "tests/**/*.ts"`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text()) ; print('ci yaml ok')"`
- `python -m black --check --target-version py311 --line-length 120 src tests`
- `python -m ruff check --config ruff.toml`
- `npm run build`
- `npm test`
- `python scripts/system/run_core_python_checks.py -- --cov=src --cov-report=xml`

## Notes
- Codecov remains advisory and non-blocking.
- The upload is skipped cleanly when the repo secret is not configured instead of producing a noisy warning on protected `main`.
- Unrelated Aether Desktop WIP was preserved in stash and is not part of this PR.

## Rollback
- Revert this commit to restore the previous CI action pins and remove the guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI infrastructure and GitHub Actions workflow configurations
  * Bumped action dependencies to latest versions for improved stability and security

* **Documentation**
  * Added developer guide for local code quality checks and pre-commit setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->