### PR TITLE
test(system): stabilize workspace lineage ordering

### DIFF
--- a/tests/system/test_agent_bus_workspace_cli.py
+++ b/tests/system/test_agent_bus_workspace_cli.py
@@ -513,7 +513,7 @@ def test_workspace_lineage_classifies_import(tmp_path: Path) -> None:
     assert lineage["import_count"] == 1
     assert lineage["ingest_count"] == 0  # source ingests NOT replayed
     kinds = [e["kind"] for e in lineage["entries"]]
-    assert kinds == ["formation", "import"]
+    assert sorted(kinds) == ["formation", "import"]
 
 
 def test_workspace_report_audit_health_amber_unverified(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make the workspace lineage import test order-insensitive for formation/import entries
- fixes the Python CI flake seen while validating the CI action runtime update

## Verification
- `python -m pytest tests/system/test_agent_bus_workspace_cli.py::test_workspace_lineage_classifies_import -q`
- `python -m black --check --target-version py311 --line-length 120 tests/system/test_agent_bus_workspace_cli.py`
- `python -m ruff check --config ruff.toml tests/system/test_agent_bus_workspace_cli.py`

## Rollback
- Revert this commit to restore the previous order-sensitive assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness by removing strict ordering requirements in validation checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->