### PR TITLE
feat(aether-desktop): deploy-ready — auth gate, Groq LLM, localStorage VFS, Fly.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,3 +281,4 @@ content/projects/
 
 # Personal research scratch (paste dumps, half-written notes with date prefixes)
 notes/2026-*.md
+apps/aether-desktop/.scbe/

--- a/apps/aether-desktop/Dockerfile
+++ b/apps/aether-desktop/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ ./backend/
+
+ENV AETHER_DESKTOP_AUDIT_DIR=/app/audit
+
+EXPOSE 8001
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/apps/aether-desktop/backend/audit.py
+++ b/apps/aether-desktop/backend/audit.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
 from .models import AuditRecord, AuditResultSummary, OperationDecision, OperationRequest, OperationResult
 
-_REDACTED_KEYS: frozenset[str] = frozenset(
-    {"api_key", "secret", "password", "token", "bearer", "credential"}
-)
+_REDACTED_KEYS: frozenset[str] = frozenset({"api_key", "secret", "password", "token", "bearer", "credential"})
 
 
 def _redact_args(args: dict) -> dict:
@@ -18,7 +17,7 @@ def _redact_args(args: dict) -> dict:
 class AuditWriter:
     def __init__(self, audit_dir: Path | None = None) -> None:
         if audit_dir is None:
-            audit_dir = Path(".scbe")
+            audit_dir = Path(os.getenv("AETHER_DESKTOP_AUDIT_DIR", ".scbe"))
         self._log_path = Path(audit_dir) / "audit.jsonl"
         self._log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/apps/aether-desktop/backend/auth.py
+++ b/apps/aether-desktop/backend/auth.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import os
+
+from fastapi import HTTPException, Query, Request
+
+
+async def require_api_key(
+    request: Request,
+    query_key: str | None = Query(None, alias="api_key"),
+) -> None:
+    required = os.getenv("AETHER_DESKTOP_API_KEY", "")
+    if not required:
+        return  # dev mode: open
+    actual = request.headers.get("X-API-Key") or query_key
+    if actual != required:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")

--- a/apps/aether-desktop/backend/handlers/llm_chat.py
+++ b/apps/aether-desktop/backend/handlers/llm_chat.py
@@ -8,8 +8,92 @@ import httpx
 
 from ..models import OperationError, OperationRequest, OperationResult
 
-OLLAMA_URL = os.getenv("AETHER_DESKTOP_OLLAMA_URL", os.getenv("OLLAMA_URL", "http://localhost:11434/api/chat"))
-DEFAULT_MODEL = os.getenv("AETHER_DESKTOP_DEFAULT_MODEL", "llama3")
+# ── provider constants ────────────────────────────────────────────────────────
+
+_GROQ_URL = "https://api.groq.com/openai/v1/chat/completions"
+_GROQ_DEFAULT_MODEL = "llama-3.3-70b-versatile"
+
+_OLLAMA_URL = "http://localhost:11434/api/chat"
+_OLLAMA_DEFAULT_MODEL = "llama3"
+
+
+def _llm_config(provider_url: str | None) -> tuple[str, str, dict[str, str], bool]:
+    """Return (url, default_model, extra_headers, is_openai_compat).
+
+    Priority: explicit provider_url > GROQ_API_KEY > OLLAMA_URL env > localhost Ollama.
+    Computed at call time so monkeypatch.setenv works in tests.
+    """
+    groq_key = os.getenv("GROQ_API_KEY", "")
+    ollama_url = os.getenv("AETHER_DESKTOP_OLLAMA_URL", os.getenv("OLLAMA_URL", _OLLAMA_URL))
+
+    if provider_url:
+        url = provider_url
+    elif groq_key:
+        url = _GROQ_URL
+    else:
+        url = ollama_url
+
+    headers: dict[str, str] = {}
+    if "groq.com" in url and groq_key:
+        headers["Authorization"] = f"Bearer {groq_key}"
+
+    is_openai_compat = "openai" in url or "groq.com" in url
+    default_model = _GROQ_DEFAULT_MODEL if is_openai_compat else _OLLAMA_DEFAULT_MODEL
+    default_model = os.getenv("AETHER_DESKTOP_DEFAULT_MODEL", default_model)
+
+    return url, default_model, headers, is_openai_compat
+
+
+# ── streaming helpers ─────────────────────────────────────────────────────────
+
+
+async def _stream_openai_compat(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: dict[str, str],
+    body: dict,
+    event_queue: asyncio.Queue | None,
+    request_id: str,
+    content_parts: list[str],
+) -> None:
+    async with client.stream("POST", url, headers=headers, json=body) as resp:
+        resp.raise_for_status()
+        async for line in resp.aiter_lines():
+            if not line.startswith("data: "):
+                continue
+            payload = line[6:]
+            if payload == "[DONE]":
+                break
+            chunk = json.loads(payload)
+            token = chunk.get("choices", [{}])[0].get("delta", {}).get("content", "")
+            if token:
+                content_parts.append(token)
+                if event_queue is not None:
+                    await event_queue.put({"type": "token", "request_id": request_id, "content": token})
+
+
+async def _stream_ollama(
+    client: httpx.AsyncClient,
+    url: str,
+    body: dict,
+    event_queue: asyncio.Queue | None,
+    request_id: str,
+    content_parts: list[str],
+) -> None:
+    async with client.stream("POST", url, json=body) as resp:
+        resp.raise_for_status()
+        async for line in resp.aiter_lines():
+            if not line:
+                continue
+            chunk = json.loads(line)
+            token = chunk.get("message", {}).get("content", "")
+            if token:
+                content_parts.append(token)
+                if event_queue is not None:
+                    await event_queue.put({"type": "token", "request_id": request_id, "content": token})
+
+
+# ── handler ───────────────────────────────────────────────────────────────────
 
 
 async def llm_chat_handler(
@@ -17,35 +101,27 @@ async def llm_chat_handler(
     event_queue: asyncio.Queue | None = None,
 ) -> OperationResult:
     messages = req.args.get("messages", [])
-    model = req.args.get("model", DEFAULT_MODEL)
+    provider_url = str(req.args["provider_url"]) if "provider_url" in req.args else None
+    url, default_model, headers, is_openai_compat = _llm_config(provider_url)
+    model = str(req.args.get("model") or default_model)
     content_parts: list[str] = []
-    url = str(req.args.get("provider_url") or OLLAMA_URL)
+
+    body: dict = {"model": model, "messages": messages, "stream": True}
 
     try:
         async with httpx.AsyncClient(timeout=120.0) as client:
-            async with client.stream(
-                "POST",
-                url,
-                json={"model": model, "messages": messages, "stream": True},
-            ) as resp:
-                resp.raise_for_status()
-                async for line in resp.aiter_lines():
-                    if not line:
-                        continue
-                    chunk = json.loads(line)
-                    token = chunk.get("message", {}).get("content", "")
-                    if token:
-                        content_parts.append(token)
-                        if event_queue is not None:
-                            await event_queue.put({"type": "token", "request_id": req.request_id, "content": token})
+            if is_openai_compat:
+                await _stream_openai_compat(client, url, headers, body, event_queue, req.request_id, content_parts)
+            else:
+                await _stream_ollama(client, url, body, event_queue, req.request_id, content_parts)
     except httpx.ConnectError:
-        await _emit_done(event_queue, req.request_id, "OLLAMA_UNAVAILABLE")
+        await _emit_done(event_queue, req.request_id, "LLM_UNAVAILABLE")
         return OperationResult(
             request_id=req.request_id,
             ok=False,
             error=OperationError(
-                code="OLLAMA_UNAVAILABLE",
-                message=f"Could not connect to Ollama at {url}",
+                code="LLM_UNAVAILABLE",
+                message=f"Could not connect to LLM at {url}",
             ),
         )
     except (httpx.HTTPError, json.JSONDecodeError) as exc:
@@ -57,7 +133,6 @@ async def llm_chat_handler(
         )
 
     await _emit_done(event_queue, req.request_id)
-
     return OperationResult(
         request_id=req.request_id,
         ok=True,

--- a/apps/aether-desktop/backend/main.py
+++ b/apps/aether-desktop/backend/main.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import os
 
-from fastapi import FastAPI, WebSocket
+from fastapi import Depends, FastAPI, WebSocket
 
 from .audit import AuditWriter
+from .auth import require_api_key
 from .gate import govern
 from .handlers.echo import echo_handler
 from .handlers.llm_chat import llm_chat_handler
@@ -35,7 +37,7 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@app.post("/v1/op")
+@app.post("/v1/op", dependencies=[Depends(require_api_key)])
 async def op_endpoint(req: OperationRequest) -> OperationResult:
     decision = govern(req)
     _audit.write_request(req, decision)
@@ -74,7 +76,11 @@ async def op_endpoint(req: OperationRequest) -> OperationResult:
 
 
 @app.websocket("/v1/events")
-async def events_ws(websocket: WebSocket, request_id: str) -> None:
+async def events_ws(websocket: WebSocket, request_id: str, api_key: str | None = None) -> None:
+    required_key = os.getenv("AETHER_DESKTOP_API_KEY", "")
+    if required_key and api_key != required_key:
+        await websocket.close(code=4001)
+        return
     await websocket.accept()
     queue: asyncio.Queue = asyncio.Queue()
     _event_queues[request_id] = queue

--- a/apps/aether-desktop/backend/tests/test_auth.py
+++ b/apps/aether-desktop/backend/tests/test_auth.py
@@ -1,0 +1,60 @@
+import os
+
+
+def test_health_always_open(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_op_open_in_dev_mode(client, monkeypatch):
+    monkeypatch.delenv("AETHER_DESKTOP_API_KEY", raising=False)
+    payload = {
+        "op": "echo",
+        "args": {"msg": "hello"},
+        "request_id": "auth-dev-001",
+        "origin": {"kind": "app", "id": "test"},
+        "privacy": "local_only",
+    }
+    resp = client.post("/v1/op", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+def test_op_rejects_missing_key(client, monkeypatch):
+    monkeypatch.setenv("AETHER_DESKTOP_API_KEY", "secret123")
+    payload = {
+        "op": "echo",
+        "args": {"msg": "hello"},
+        "request_id": "auth-missing-001",
+        "origin": {"kind": "app", "id": "test"},
+        "privacy": "local_only",
+    }
+    resp = client.post("/v1/op", json=payload)
+    assert resp.status_code == 401
+
+
+def test_op_rejects_wrong_key(client, monkeypatch):
+    monkeypatch.setenv("AETHER_DESKTOP_API_KEY", "secret123")
+    payload = {
+        "op": "echo",
+        "args": {"msg": "hello"},
+        "request_id": "auth-wrong-001",
+        "origin": {"kind": "app", "id": "test"},
+        "privacy": "local_only",
+    }
+    resp = client.post("/v1/op", json=payload, headers={"X-API-Key": "wrongkey"})
+    assert resp.status_code == 401
+
+
+def test_op_accepts_correct_key(client, monkeypatch):
+    monkeypatch.setenv("AETHER_DESKTOP_API_KEY", "secret123")
+    payload = {
+        "op": "echo",
+        "args": {"msg": "hello"},
+        "request_id": "auth-ok-001",
+        "origin": {"kind": "app", "id": "test"},
+        "privacy": "local_only",
+    }
+    resp = client.post("/v1/op", json=payload, headers={"X-API-Key": "secret123"})
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True

--- a/apps/aether-desktop/backend/tests/test_op_endpoint.py
+++ b/apps/aether-desktop/backend/tests/test_op_endpoint.py
@@ -85,6 +85,9 @@ def test_escalated_op_does_not_dispatch(client, monkeypatch):
     assert data["error"]["code"] == "ESCALATE"
 
 
+_OLLAMA_URL = "http://localhost:11434/api/chat"
+
+
 @respx.mock
 def test_llm_chat_calls_ollama_and_returns_ok(client):
     stream_lines = (
@@ -92,10 +95,14 @@ def test_llm_chat_calls_ollama_and_returns_ok(client):
         b'{"model":"llama3","message":{"role":"assistant","content":" world"},"done":false}\n'
         b'{"model":"llama3","message":{"role":"assistant","content":""},"done":true}\n'
     )
-    respx.post("http://localhost:11434/api/chat").mock(return_value=httpx.Response(200, content=stream_lines))
+    respx.post(_OLLAMA_URL).mock(return_value=httpx.Response(200, content=stream_lines))
     payload = {
         "op": "llm.chat",
-        "args": {"messages": [{"role": "user", "content": "hi"}], "model": "llama3"},
+        "args": {
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "llama3",
+            "provider_url": _OLLAMA_URL,
+        },
         "request_id": "test-chat-001",
         "origin": {"kind": "app", "id": "chat-window"},
         "privacy": "local_only",
@@ -109,9 +116,7 @@ def test_llm_chat_calls_ollama_and_returns_ok(client):
 
 @respx.mock
 def test_dry_run_llm_chat_does_not_call_ollama(client):
-    route = respx.post("http://localhost:11434/api/chat").mock(
-        return_value=httpx.Response(500, text="should not be called")
-    )
+    route = respx.post(_OLLAMA_URL).mock(return_value=httpx.Response(500, text="should not be called"))
     payload = {
         "op": "llm.chat",
         "args": {"messages": [{"role": "user", "content": "hi"}], "model": "llama3"},
@@ -131,10 +136,10 @@ def test_dry_run_llm_chat_does_not_call_ollama(client):
 
 @respx.mock
 def test_llm_chat_returns_error_when_ollama_unavailable(client):
-    respx.post("http://localhost:11434/api/chat").mock(side_effect=httpx.ConnectError("refused"))
+    respx.post(_OLLAMA_URL).mock(side_effect=httpx.ConnectError("refused"))
     payload = {
         "op": "llm.chat",
-        "args": {"messages": [{"role": "user", "content": "hi"}]},
+        "args": {"messages": [{"role": "user", "content": "hi"}], "provider_url": _OLLAMA_URL},
         "request_id": "test-chat-002",
         "origin": {"kind": "app", "id": "chat-window"},
         "privacy": "local_only",
@@ -143,17 +148,17 @@ def test_llm_chat_returns_error_when_ollama_unavailable(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["ok"] is False
-    assert data["error"]["code"] == "OLLAMA_UNAVAILABLE"
+    assert data["error"]["code"] == "LLM_UNAVAILABLE"
 
 
 @respx.mock
 def test_llm_chat_error_emits_done_event():
     async def run():
-        respx.post("http://localhost:11434/api/chat").mock(side_effect=httpx.ConnectError("refused"))
+        respx.post(_OLLAMA_URL).mock(side_effect=httpx.ConnectError("refused"))
         queue = asyncio.Queue()
         req = {
             "op": "llm.chat",
-            "args": {"messages": [{"role": "user", "content": "hi"}]},
+            "args": {"messages": [{"role": "user", "content": "hi"}], "provider_url": _OLLAMA_URL},
             "request_id": "test-chat-events-error-001",
             "origin": {"kind": "app", "id": "chat-window"},
             "privacy": "local_only",
@@ -167,4 +172,4 @@ def test_llm_chat_error_emits_done_event():
     result, event = asyncio.run(run())
     assert result.ok is False
     assert event["type"] == "done"
-    assert event["error_code"] == "OLLAMA_UNAVAILABLE"
+    assert event["error_code"] == "LLM_UNAVAILABLE"

--- a/apps/aether-desktop/fly.toml
+++ b/apps/aether-desktop/fly.toml
@@ -1,0 +1,32 @@
+# Deploy: cd apps/aether-desktop && fly deploy
+# First time: fly launch --no-deploy (then set secrets, then fly deploy)
+#
+# Required secrets (set once):
+#   fly secrets set AETHER_DESKTOP_API_KEY=<your-key>
+#   fly secrets set GROQ_API_KEY=<your-groq-key>
+
+app = "aether-desktop-backend"
+primary_region = "sea"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8001
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1
+
+[env]
+  AETHER_DESKTOP_AUDIT_DIR = "/app/audit"
+
+[[mounts]]
+  source = "aether_audit"
+  destination = "/app/audit"
+  initial_size = "1gb"

--- a/apps/aether-desktop/shell/src/App.tsx
+++ b/apps/aether-desktop/shell/src/App.tsx
@@ -6,6 +6,7 @@ import { createToolBus } from './toolBus';
 
 const BACKEND_URL =
   (import.meta.env['VITE_BACKEND_URL'] as string | undefined) ?? 'http://localhost:8001';
+const BACKEND_API_KEY = import.meta.env['VITE_BACKEND_API_KEY'] as string | undefined;
 
 type Tab = 'chat' | 'tools';
 
@@ -22,7 +23,7 @@ const TAB_BTN = (active: boolean): React.CSSProperties => ({
 
 export function App() {
   const [tab, setTab] = useState<Tab>('chat');
-  const client = useMemo(() => createBackendClient(BACKEND_URL), []);
+  const client = useMemo(() => createBackendClient(BACKEND_URL, BACKEND_API_KEY), []);
   const bus = useMemo(() => createToolBus(client), [client]);
 
   return (

--- a/apps/aether-desktop/shell/src/BackendClient.ts
+++ b/apps/aether-desktop/shell/src/BackendClient.ts
@@ -33,21 +33,24 @@ export interface EventSubscription {
   unsubscribe: () => void;
 }
 
-export function createBackendClient(baseUrl: string): BackendClient {
+export function createBackendClient(baseUrl: string, apiKey?: string): BackendClient {
   const wsBase = baseUrl.replace(/^http/, 'ws');
 
   return {
     async runOp(req: OperationRequest): Promise<OperationResult> {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (apiKey) headers['X-API-Key'] = apiKey;
       const resp = await fetch(`${baseUrl}/v1/op`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify(req),
       });
       return resp.json() as Promise<OperationResult>;
     },
 
     subscribeEvents(requestId, onEvent, onDone) {
-      const ws = new WebSocket(`${wsBase}/v1/events?request_id=${requestId}`);
+      const keyParam = apiKey ? `&api_key=${encodeURIComponent(apiKey)}` : '';
+      const ws = new WebSocket(`${wsBase}/v1/events?request_id=${requestId}${keyParam}`);
       const ready = new Promise<void>((resolve, reject) => {
         ws.onopen = () => resolve();
         ws.onerror = () =>

--- a/apps/aether-desktop/shell/src/toolBus.ts
+++ b/apps/aether-desktop/shell/src/toolBus.ts
@@ -40,9 +40,30 @@ async function sha256(text: string): Promise<string> {
     .join('');
 }
 
+const VFS_KEY = 'aether-desktop:vfs';
+
+function vfsLoad(): Map<string, string> {
+  try {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(VFS_KEY) : null;
+    return raw ? new Map(Object.entries(JSON.parse(raw) as Record<string, string>)) : new Map();
+  } catch {
+    return new Map();
+  }
+}
+
+function vfsSave(vfs: Map<string, string>): void {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(VFS_KEY, JSON.stringify(Object.fromEntries(vfs)));
+    }
+  } catch {
+    // storage quota or SSR — silently no-op
+  }
+}
+
 export function createToolBus(client: BackendClient): ToolBus {
   const registry = new Map<string, ToolDef>();
-  const vfs = new Map<string, string>();
+  const vfs = vfsLoad();
 
   function register(def: ToolDef): void {
     registry.set(def.name, def);
@@ -138,6 +159,7 @@ export function createToolBus(client: BackendClient): ToolBus {
       const path = args['path'] as string;
       const content = args['content'] as string;
       vfs.set(path, content);
+      vfsSave(vfs);
       return { path, bytes: content.length };
     },
   });


### PR DESCRIPTION
## Summary

- **Auth gate** (backend/auth.py): reads AETHER_DESKTOP_API_KEY at request time; empty = dev-open. /v1/op uses X-API-Key header, /v1/events WebSocket uses ?api_key= query param. 5 new tests.
- **Groq as primary LLM** (handlers/llm_chat.py): GROQ_API_KEY env routes to Groq OpenAI-compat SSE; falls back to local Ollama. Error code unified to LLM_UNAVAILABLE.
- **Fly.io deploy config** (Dockerfile + fly.toml): python:3.11-slim, port 8001, auto_stop_machines=stop (sleeps at zero traffic = $0/month), persistent /app/audit volume, primary_region=sea.
- **localStorage VFS** (toolBus.ts): virtual filesystem survives page refreshes; graceful no-op in Node/jsdom so tests are unaffected.

## Deploy (first time)
cd apps/aether-desktop && fly launch --no-deploy && fly secrets set AETHER_DESKTOP_API_KEY=key GROQ_API_KEY=key && fly deploy

## Test plan
- [x] 27 Python backend tests pass
- [x] 21 TypeScript shell tests pass
- [x] Auth: open in dev mode, 401 on wrong key, 200 on correct key

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key authentication for secure backend access
  * Support for multiple LLM provider backends
  * Persistent virtual filesystem storage across browser sessions
  * Docker container and deployment configuration added

* **Bug Fixes**
  * Standardized error reporting for LLM connection failures

* **Tests**
  * Added comprehensive authentication tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->