### PR TITLE
fix(arena): route operator commands through safe harness

### DIFF
--- a/packages/kernel/src/adaptiveNavigator.ts
+++ b/packages/kernel/src/adaptiveNavigator.ts
@@ -33,12 +33,12 @@ const PHI = (1 + Math.sqrt(5)) / 2; // Golden ratio
 
 /** Sacred Tongue realm centers in 6D Poincaré ball */
 export const REALM_CENTERS: Record<string, number[]> = {
-  KO: [0.3, 0.0, 0.0, 0.0, 0.0, 0.0],   // Knowledge - axis 0
-  AV: [0.0, 0.3, 0.0, 0.0, 0.0, 0.0],   // Avatara - axis 1
-  RU: [0.0, 0.0, 0.3, 0.0, 0.0, 0.0],   // Runes - axis 2
-  CA: [0.0, 0.0, 0.0, 0.3, 0.0, 0.0],   // Cascade - axis 3
-  UM: [0.0, 0.0, 0.0, 0.0, 0.3, 0.0],   // Umbra - axis 4
-  DR: [0.0, 0.0, 0.0, 0.0, 0.0, 0.3],   // Draconic - axis 5
+  KO: [0.3, 0.0, 0.0, 0.0, 0.0, 0.0], // Knowledge - axis 0
+  AV: [0.0, 0.3, 0.0, 0.0, 0.0, 0.0], // Avatara - axis 1
+  RU: [0.0, 0.0, 0.3, 0.0, 0.0, 0.0], // Runes - axis 2
+  CA: [0.0, 0.0, 0.0, 0.3, 0.0, 0.0], // Cascade - axis 3
+  UM: [0.0, 0.0, 0.0, 0.0, 0.3, 0.0], // Umbra - axis 4
+  DR: [0.0, 0.0, 0.0, 0.0, 0.0, 0.3], // Draconic - axis 5
 };
 
 /** Tongue weights (golden ratio based) */
@@ -166,9 +166,7 @@ export class AdaptiveHyperbolicNavigator {
 
   constructor(config: Partial<AdaptiveNavigatorConfig> = {}, initialPosition?: number[]) {
     this.config = { ...DEFAULT_CONFIG, ...config };
-    this.position = initialPosition
-      ? [...initialPosition]
-      : zeros(this.config.dimension);
+    this.position = initialPosition ? [...initialPosition] : zeros(this.config.dimension);
     this.velocity = zeros(this.config.dimension);
     this.history = [this.position.slice()];
     this.coherenceHistory = [1.0];
@@ -437,9 +435,7 @@ export class AdaptiveHyperbolicNavigator {
     const center = REALM_CENTERS[tongue];
     if (!center) return Infinity;
 
-    const kappa = coherence !== undefined
-      ? this.getCurrentKappa(coherence)
-      : -1;
+    const kappa = coherence !== undefined ? this.getCurrentKappa(coherence) : -1;
 
     return this.hyperbolicDistanceKappa(this.position, center, kappa);
   }
@@ -452,9 +448,7 @@ export class AdaptiveHyperbolicNavigator {
     let closest = 'KO';
 
     for (const [tongue, center] of Object.entries(REALM_CENTERS)) {
-      const kappa = coherence !== undefined
-        ? this.getCurrentKappa(coherence)
-        : -1;
+      const kappa = coherence !== undefined ? this.getCurrentKappa(coherence) : -1;
       const dist = this.hyperbolicDistanceKappa(this.position, center, kappa);
 
       if (dist < minDist) {
@@ -578,9 +572,7 @@ export class AdaptiveHyperbolicNavigator {
    * Reset navigator to initial state
    */
   reset(initialPosition?: number[]): void {
-    this.position = initialPosition
-      ? [...initialPosition]
-      : zeros(this.config.dimension);
+    this.position = initialPosition ? [...initialPosition] : zeros(this.config.dimension);
     this.velocity = zeros(this.config.dimension);
     this.history = [this.position.slice()];
     this.coherenceHistory = [1.0];
@@ -637,10 +629,7 @@ export function createAdaptiveNavigator(
  * @param spinCoherence - Spin coherence from consensus
  * @returns Combined coherence score
  */
-export function computeCoherence(
-  spectralCoherence: number,
-  spinCoherence: number = 1.0
-): number {
+export function computeCoherence(spectralCoherence: number, spinCoherence: number = 1.0): number {
   // Geometric mean for balanced weighting
   return Math.sqrt(spectralCoherence * spinCoherence);
 }

--- a/packages/kernel/src/entropicLayer.ts
+++ b/packages/kernel/src/entropicLayer.ts
@@ -219,7 +219,7 @@ export function detectEscape(
   if (currentNorm > EPSILON) {
     // Dot product of -gradient (drift direction) with radial unit vector
     for (let i = 0; i < 6; i++) {
-      radialVelocity += (-grad[i]) * (state.position[i] / currentNorm);
+      radialVelocity += -grad[i] * (state.position[i] / currentNorm);
     }
   }
 
@@ -277,10 +277,7 @@ export function computeThreatLevel(state: CHSFNState): number {
   const energyThreat = 1 / (1 + Math.exp(-0.5 * (energy - 3)));
 
   // Weighted combination
-  return Math.min(
-    0.4 * distThreat + 0.3 * avgImpedance + 0.3 * energyThreat,
-    1
-  );
+  return Math.min(0.4 * distThreat + 0.3 * avgImpedance + 0.3 * energyThreat, 1);
 }
 
 /**
@@ -532,8 +529,8 @@ export function assess(
 
   // Composite entropic risk
   const escapeRisk = escape.escaping ? 0.8 : escape.basinFraction * 0.3;
-  const expansionRisk = expansion.accelerating ? 0.6 : (expansion.growthRate > 0 ? 0.3 : 0);
-  const loopRisk = dilation.hostile ? 0.9 : (dilation.loopCount > 0 ? dilation.loopCount * 0.15 : 0);
+  const expansionRisk = expansion.accelerating ? 0.6 : expansion.growthRate > 0 ? 0.3 : 0;
+  const loopRisk = dilation.hostile ? 0.9 : dilation.loopCount > 0 ? dilation.loopCount * 0.15 : 0;
   const threatRisk = ak.threatLevel;
 
   const entropicRisk = Math.min(

--- a/packages/kernel/src/entropySurface.ts
+++ b/packages/kernel/src/entropySurface.ts
@@ -216,7 +216,7 @@ export function detectTemporalRegularity(
 
   // Low CV = regular timing = suspicious
   // Map CV to [0, 1]: sigmoid centered at jitterThreshold-normalized CV
-  const normalizedCV = cv * mean / Math.max(jitterThreshold, 1);
+  const normalizedCV = (cv * mean) / Math.max(jitterThreshold, 1);
   return 1 / (1 + normalizedCV);
 }
 
@@ -228,10 +228,7 @@ export function detectTemporalRegularity(
  *
  * @returns Coverage in [0, 1]
  */
-export function computeCoverageBreadth(
-  positions: Vector6D[],
-  binCount: number = 5
-): number {
+export function computeCoverageBreadth(positions: Vector6D[], binCount: number = 5): number {
   if (positions.length === 0) return 0;
 
   const visited = new Set<string>();
@@ -252,10 +249,7 @@ export function computeCoverageBreadth(
  *
  * @returns Score in [0, 1] — higher = more repetitive
  */
-export function computeRepetitionScore(
-  positions: Vector6D[],
-  distThreshold: number = 0.1
-): number {
+export function computeRepetitionScore(positions: Vector6D[], distThreshold: number = 0.1): number {
   if (positions.length < 2) return 0;
 
   let nearPairs = 0;
@@ -332,9 +326,9 @@ export function detectProbing(
   const confidence = Math.min(
     1,
     0.25 * entropySignal +
-    0.25 * temporalRegularity +
-    0.25 * Math.min(coverageBreadth / Math.max(config.coverageThreshold, EPSILON), 1) +
-    0.25 * repetitionScore
+      0.25 * temporalRegularity +
+      0.25 * Math.min(coverageBreadth / Math.max(config.coverageThreshold, EPSILON), 1) +
+      0.25 * repetitionScore
   );
 
   let classification: ProbingSignature['classification'];
@@ -432,11 +426,7 @@ export function computeLeakageBudget(
  * @param theta - Threshold center (default: 0.5)
  * @returns Signal retention in [0, 1]
  */
-export function sigmoidGate(
-  pressure: number,
-  k: number = 10,
-  theta: number = 0.5
-): number {
+export function sigmoidGate(pressure: number, k: number = 10, theta: number = 0.5): number {
   return 1 / (1 + Math.exp(k * (pressure - theta)));
 }
 
@@ -556,13 +546,13 @@ export function assessEntropySurface(
   // Defense posture
   let posture: EntropySurfaceAssessment['posture'];
   if (nullification.strength > 0.9 || leakage.exhausted) {
-    posture = 'SILENT';        // Near-zero information emission
+    posture = 'SILENT'; // Near-zero information emission
   } else if (nullification.strength > 0.5) {
-    posture = 'OPAQUE';        // Heavily degraded output
+    posture = 'OPAQUE'; // Heavily degraded output
   } else if (nullification.active) {
-    posture = 'GUARDED';       // Partial signal degradation
+    posture = 'GUARDED'; // Partial signal degradation
   } else {
-    posture = 'TRANSPARENT';   // Full signal, normal operation
+    posture = 'TRANSPARENT'; // Full signal, normal operation
   }
 
   return {

--- a/packages/kernel/src/fluxState.ts
+++ b/packages/kernel/src/fluxState.ts
@@ -354,16 +354,21 @@ export class FluxStateGate {
    * @param ctx - Optional dynamics context for L6 breathing + phase-lock
    * @returns FluxGateResult with allowed/denied status
    */
-  checkNavigation(targetRealm: RealmID, stepVector: number[], ctx?: FluxDynamicsContext): FluxGateResult {
+  checkNavigation(
+    targetRealm: RealmID,
+    stepVector: number[],
+    ctx?: FluxDynamicsContext
+  ): FluxGateResult {
     const policy = this.deriveEffectivePolicy(ctx);
 
     // Check operation type
-    const requiredOp = policy.allowedRealms === null
-      ? NavigationOp.FULL_NAVIGATE
-      : NavigationOp.REALM_NAVIGATE;
+    const requiredOp =
+      policy.allowedRealms === null ? NavigationOp.FULL_NAVIGATE : NavigationOp.REALM_NAVIGATE;
 
-    if (!policy.allowedOps.includes(requiredOp) &&
-        !policy.allowedOps.includes(NavigationOp.LIMBIC_ONLY)) {
+    if (
+      !policy.allowedOps.includes(requiredOp) &&
+      !policy.allowedOps.includes(NavigationOp.LIMBIC_ONLY)
+    ) {
       return {
         allowed: false,
         reason: `Operation ${requiredOp} not permitted in ${this.state} state`,

--- a/packages/kernel/src/gyroscopicInterlattice.ts
+++ b/packages/kernel/src/gyroscopicInterlattice.ts
@@ -340,10 +340,7 @@ export function evolveStep(
  * @param sublattices - All 6 sublattices (for computing surrounding bond angles)
  * @returns Chern number (+1 or -1)
  */
-export function computeChernNumber(
-  tongue: TongueLabel,
-  sublattices: TongueSublattice[]
-): number {
+export function computeChernNumber(tongue: TongueLabel, sublattices: TongueSublattice[]): number {
   // Sum of bond angles to all neighbors
   let angleSum = 0;
   for (const neighbor of sublattices) {
@@ -496,9 +493,7 @@ export function gyroscopicBreathingFactor(
  * @param sublattices - Current sublattice states
  * @returns Array of 6 breathing factors, one per tongue
  */
-export function perTongueBreathingFactors(
-  sublattices: TongueSublattice[]
-): number[] {
+export function perTongueBreathingFactors(sublattices: TongueSublattice[]): number[] {
   return sublattices.map((sub) => {
     const psiSq = sub.state.real * sub.state.real + sub.state.imag * sub.state.imag;
     return Math.min(2.0, 1.0 + psiSq * sub.precessionFreq);
@@ -524,10 +519,7 @@ export function perTongueBreathingFactors(
  * @param gamma - Chern number influence strength (default: 0.2)
  * @returns Array of 6 Chern-modulated weights
  */
-export function chernWeights(
-  sublattices: TongueSublattice[],
-  gamma: number = 0.2
-): number[] {
+export function chernWeights(sublattices: TongueSublattice[], gamma: number = 0.2): number[] {
   const g = Math.max(0, Math.min(0.5, gamma));
   return sublattices.map((sub) => 1.0 + g * sub.chernNumber);
 }

--- a/packages/kernel/src/hyperbolic.ts
+++ b/packages/kernel/src/hyperbolic.ts
@@ -489,10 +489,7 @@ export function multiWellGradient(p: number[], wells: Well[]): number[] {
  * @param phase2 - Second phase value (or null for unknown)
  * @returns Deviation in [0, 1]
  */
-export function phaseDeviation(
-  phase1: number | null,
-  phase2: number | null
-): number {
+export function phaseDeviation(phase1: number | null, phase2: number | null): number {
   // Unknown phase = maximum deviation
   if (phase1 === null || phase2 === null) return 1.0;
 

--- a/packages/kernel/src/hyperbolicRAG.ts
+++ b/packages/kernel/src/hyperbolicRAG.ts
@@ -282,9 +282,7 @@ const TONGUE_NAMES = ['KO', 'AV', 'RU', 'CA', 'DR', 'UM'] as const;
  * @param position - 6D position in Poincaré ball
  * @returns { tongue, distance } of nearest anchor
  */
-export function nearestTongueAnchor(
-  position: Vector6D
-): { tongue: string; distance: number } {
+export function nearestTongueAnchor(position: Vector6D): { tongue: string; distance: number } {
   let bestTongue = 'KO';
   let bestDist = Infinity;
 
@@ -338,10 +336,7 @@ export function proximityScore(
  * @param queryPhase - Phase vector of the query (or expected alignment)
  * @returns Phase score in [0, 1]
  */
-export function phaseConsistencyScore(
-  chunkPhase: Vector6D,
-  queryPhase: Vector6D
-): number {
+export function phaseConsistencyScore(chunkPhase: Vector6D, queryPhase: Vector6D): number {
   let sum = 0;
   for (let i = 0; i < 6; i++) {
     sum += Math.cos(chunkPhase[i] - queryPhase[i]);
@@ -403,8 +398,7 @@ export function scoreChunk(
   const trustScore = Math.max(0, Math.min(1, raw));
   const anomalyProb = 1 - trustScore;
   const quarantineFlag =
-    trustScore < config.quarantineThreshold ||
-    chunk.uncertainty > config.maxUncertainty;
+    trustScore < config.quarantineThreshold || chunk.uncertainty > config.maxUncertainty;
 
   // Soft attention gating: trust² ensures quarantined chunks get near-zero weight
   const attentionWeight = quarantineFlag ? 0 : trustScore * trustScore;
@@ -521,12 +515,10 @@ export function quarantineReport(
   const trusted = scored.filter((s) => !s.quarantineFlag);
   const quarantined = scored.filter((s) => s.quarantineFlag);
 
-  const avgTrust = scored.length > 0
-    ? scored.reduce((s, t) => s + t.trustScore, 0) / scored.length
-    : 0;
-  const avgAnomaly = scored.length > 0
-    ? scored.reduce((s, t) => s + t.anomalyProb, 0) / scored.length
-    : 0;
+  const avgTrust =
+    scored.length > 0 ? scored.reduce((s, t) => s + t.trustScore, 0) / scored.length : 0;
+  const avgAnomaly =
+    scored.length > 0 ? scored.reduce((s, t) => s + t.anomalyProb, 0) / scored.length : 0;
 
   return {
     trusted,

--- a/packages/kernel/src/quasiSphereOverlap.ts
+++ b/packages/kernel/src/quasiSphereOverlap.ts
@@ -300,7 +300,7 @@ export const PAD_GEODESIC_CONSTRAINTS: Record<PadMode, GeodesicConstraint> = {
  */
 export function localCurvature(position: Vector6D): number {
   const normSq = position.reduce((sum, x) => sum + x * x, 0);
-  const denom = (1 - normSq);
+  const denom = 1 - normSq;
   if (denom <= 0) return Infinity;
   return 2 / (denom * denom);
 }
@@ -385,8 +385,14 @@ export function padAccessibilityMap(
           center[4] + r * Math.cos(angle * 2.1) * 0.1,
           center[5] + r * Math.sin(angle * 1.7) * 0.1,
         ] as Vector6D,
-        phase: [(2 * Math.PI * 0) / 6, (2 * Math.PI * 1) / 6, (2 * Math.PI * 2) / 6,
-                (2 * Math.PI * 3) / 6, (2 * Math.PI * 4) / 6, (2 * Math.PI * 5) / 6] as Vector6D,
+        phase: [
+          (2 * Math.PI * 0) / 6,
+          (2 * Math.PI * 1) / 6,
+          (2 * Math.PI * 2) / 6,
+          (2 * Math.PI * 3) / 6,
+          (2 * Math.PI * 4) / 6,
+          (2 * Math.PI * 5) / 6,
+        ] as Vector6D,
         mass: 1.0,
       };
 

--- a/packages/kernel/src/quasiSphereSlice.ts
+++ b/packages/kernel/src/quasiSphereSlice.ts
@@ -303,10 +303,7 @@ export function simulateDrift2D(
  * @param driftPath - Optional drift path to overlay (shown as '*')
  * @returns Multi-line string of ASCII art
  */
-export function renderSliceASCII(
-  slice: SliceData,
-  driftPath?: [number, number][]
-): string {
+export function renderSliceASCII(slice: SliceData, driftPath?: [number, number][]): string {
   const chars = [' ', '·', '░', '▒', '▓', '█'];
   const step = (slice.range[1] - slice.range[0]) / (slice.resolution - 1);
 

--- a/packages/kernel/src/resonanceGate.ts
+++ b/packages/kernel/src/resonanceGate.ts
@@ -100,7 +100,7 @@ export const BASELINE_RESONANCE_CONFIG: Required<ResonanceConfig> = {
  */
 export const EVOLVED_RESONANCE_CONFIG: Required<ResonanceConfig> = {
   R: 1.731,
-  passThreshold: 0.30,
+  passThreshold: 0.3,
   rejectThreshold: 0.213,
   weights: TONGUE_WEIGHTS,
   signalPhaseOffset: 0,
@@ -124,7 +124,7 @@ export const EVOLVED_V1_CONFIG = EVOLVED_RESONANCE_CONFIG;
  */
 export const EVOLVED_V2_CONFIG: Required<ResonanceConfig> = {
   R: 1.731,
-  passThreshold: 0.30,
+  passThreshold: 0.3,
   rejectThreshold: 0.213,
   weights: TONGUE_WEIGHTS,
   signalPhaseOffset: 0,
@@ -211,7 +211,7 @@ function crossCorrelate(actual: number[], expected: number[]): number {
  */
 function matchedFilterPhaseScore(
   contributions: Record<string, number>,
-  phaseReferenceOffset: number,
+  phaseReferenceOffset: number
 ): { phaseScore: number; phaseCorrelation: number } {
   const actual = TONGUE_NAMES.map((name) => Math.abs(contributions[name] ?? 0));
   const referencePattern = expectedTonguePattern(phaseReferenceOffset);
@@ -251,7 +251,8 @@ export function tongueWave(
     const phaseAlignment = (1 + Math.cos(signalPhaseOffset - tonguePhase)) / 2;
     const effectiveWeight = w[l] * (0.3 + 0.7 * phaseAlignment);
 
-    const value = effectiveWeight * Math.cos(2 * Math.PI * freq * t + tonguePhase + signalPhaseOffset);
+    const value =
+      effectiveWeight * Math.cos(2 * Math.PI * freq * t + tonguePhase + signalPhaseOffset);
     contributions[TONGUE_NAMES[l]] = value;
     sum += value;
     totalWeight += effectiveWeight;
@@ -284,7 +285,8 @@ export function resonanceGate(
   const geoDecay = cfg.geometryDecay ?? PHI;
   const wavePow = cfg.wavePower ?? 1.0;
   const geoFloor = cfg.geometryFloor ?? 0.0;
-  const phaseStrategy = cfg.phaseStrategy ?? (cfg.preset === 'evolved_v2' ? 'matched_filter' : 'weighted_wave');
+  const phaseStrategy =
+    cfg.phaseStrategy ?? (cfg.preset === 'evolved_v2' ? 'matched_filter' : 'weighted_wave');
   const phaseReferenceOffset = cfg.phaseReferenceOffset ?? 0;
 
   const boundedDStar = Math.max(0, dStar);
@@ -293,12 +295,13 @@ export function resonanceGate(
 
   const waveAlignment = Math.max(0, Math.min(1, (combined + 1) / 2));
   const geometryAlignment = geometryAlignmentFor(boundedDStar, geoDecay, geoFloor);
-  const matchedPhase = phaseStrategy === 'matched_filter'
-    ? matchedFilterPhaseScore(contributions, phaseReferenceOffset)
-    : null;
+  const matchedPhase =
+    phaseStrategy === 'matched_filter'
+      ? matchedFilterPhaseScore(contributions, phaseReferenceOffset)
+      : null;
   const phaseScore = matchedPhase?.phaseScore ?? waveAlignment;
   const phaseCorrelation = matchedPhase?.phaseCorrelation ?? null;
-  const rho = Math.max(0, Math.min(1, (phaseScore ** wavePow) * geometryAlignment));
+  const rho = Math.max(0, Math.min(1, phaseScore ** wavePow * geometryAlignment));
   const rawAmplitude = envelope * waveAlignment;
   const barrierCost = envelope / Math.max(rho, 1e-6);
 

--- a/packages/kernel/src/sacredEggs.ts
+++ b/packages/kernel/src/sacredEggs.ts
@@ -311,7 +311,8 @@ export function predicateGeo(egg: SacredEgg, state: VerifierState): boolean {
     const minDistance = Math.min(
       ...policy.attractors.map((attractor) => {
         const attractorNorm = Math.sqrt(attractor.reduce((sum, x) => sum + x * x, 0));
-        const projectedAttractor = attractorNorm >= 1.0 ? projectEmbeddingToBall(attractor) : attractor;
+        const projectedAttractor =
+          attractorNorm >= 1.0 ? projectEmbeddingToBall(attractor) : attractor;
         return hyperbolicDistance(pos, projectedAttractor);
       })
     );
@@ -457,9 +458,13 @@ export async function predicateCrypto(
     const key = await deriveKey(state.sharedSecret, egg, state);
 
     // Import key for AES-GCM
-    const aesKey = await crypto.subtle.importKey('raw', new Uint8Array(key).buffer, { name: 'AES-GCM' }, false, [
-      'decrypt',
-    ]);
+    const aesKey = await crypto.subtle.importKey(
+      'raw',
+      new Uint8Array(key).buffer,
+      { name: 'AES-GCM' },
+      false,
+      ['decrypt']
+    );
 
     // Decrypt
     const plaintext = await crypto.subtle.decrypt(
@@ -581,9 +586,13 @@ export async function createEgg(
   const key = await deriveKey(sharedSecret, partialEgg, expectedState);
 
   // Import key for AES-GCM
-  const aesKey = await crypto.subtle.importKey('raw', new Uint8Array(key).buffer, { name: 'AES-GCM' }, false, [
-    'encrypt',
-  ]);
+  const aesKey = await crypto.subtle.importKey(
+    'raw',
+    new Uint8Array(key).buffer,
+    { name: 'AES-GCM' },
+    false,
+    ['encrypt']
+  );
 
   // Encrypt
   const ciphertext = await crypto.subtle.encrypt(

--- a/packages/kernel/src/scbe_voxel_types.ts
+++ b/packages/kernel/src/scbe_voxel_types.ts
@@ -20,13 +20,7 @@ export type Lang = 'KO' | 'AV' | 'RU' | 'CA' | 'UM' | 'DR';
 export const LANGS: readonly Lang[] = ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'] as const;
 
 /** Polly Pad operational modes — one per tongue-function */
-export type PadMode =
-  | 'ENGINEERING'
-  | 'NAVIGATION'
-  | 'SYSTEMS'
-  | 'SCIENCE'
-  | 'COMMS'
-  | 'MISSION';
+export type PadMode = 'ENGINEERING' | 'NAVIGATION' | 'SYSTEMS' | 'SCIENCE' | 'COMMS' | 'MISSION';
 
 /** All valid pad modes */
 export const PAD_MODES: readonly PadMode[] = [

--- a/packages/kernel/src/securityInvariants.ts
+++ b/packages/kernel/src/securityInvariants.ts
@@ -226,10 +226,7 @@ export function verifyNodalStability(
  * @param targetPosition - Position being accessed
  * @returns Combined security cost (higher = harder to access)
  */
-export function combinedSecurityCost(
-  state: CHSFNState,
-  targetPosition: Vector6D
-): number {
+export function combinedSecurityCost(state: CHSFNState, targetPosition: Vector6D): number {
   // Distance cost: π^(φ·d*)
   const dist = hyperbolicDistance6D(state.position, targetPosition);
   const distanceCost = accessCost(dist);
@@ -258,10 +255,7 @@ export function combinedSecurityCost(
  * @param targetPosition - Target position
  * @returns Equivalent security bits
  */
-export function securityBitsEquivalent(
-  state: CHSFNState,
-  targetPosition: Vector6D
-): number {
+export function securityBitsEquivalent(state: CHSFNState, targetPosition: Vector6D): number {
   const cost = combinedSecurityCost(state, targetPosition);
   return Math.log2(Math.max(cost, 1));
 }
@@ -292,11 +286,10 @@ export function verifyTongueBijectionUnderDrift(
   stepSize: number = 0.001
 ): { holds: boolean; initialOrder: number[]; finalOrder: number[] } {
   // Compute initial impedance ordering
-  const initialImpedances = Array.from({ length: 6 }, (_, i) =>
-    tongueImpedanceAt(state, i)
+  const initialImpedances = Array.from({ length: 6 }, (_, i) => tongueImpedanceAt(state, i));
+  const initialOrder = Array.from({ length: 6 }, (_, i) => i).sort(
+    (a, b) => initialImpedances[a] - initialImpedances[b]
   );
-  const initialOrder = Array.from({ length: 6 }, (_, i) => i)
-    .sort((a, b) => initialImpedances[a] - initialImpedances[b]);
 
   // Drift the state
   let current = state;
@@ -305,11 +298,10 @@ export function verifyTongueBijectionUnderDrift(
   }
 
   // Compute final impedance ordering
-  const finalImpedances = Array.from({ length: 6 }, (_, i) =>
-    tongueImpedanceAt(current, i)
+  const finalImpedances = Array.from({ length: 6 }, (_, i) => tongueImpedanceAt(current, i));
+  const finalOrder = Array.from({ length: 6 }, (_, i) => i).sort(
+    (a, b) => finalImpedances[a] - finalImpedances[b]
   );
-  const finalOrder = Array.from({ length: 6 }, (_, i) => i)
-    .sort((a, b) => finalImpedances[a] - finalImpedances[b]);
 
   // Check if ordering is preserved
   const holds = initialOrder.every((v, i) => v === finalOrder[i]);

--- a/packages/kernel/src/tBraid.ts
+++ b/packages/kernel/src/tBraid.ts
@@ -320,10 +320,7 @@ export function triadicBraidedDistance(projected: ProjectedVariants): number {
  * @param variants — Raw temporal variants
  * @param tetradic — If true, include predictive strand (default true)
  */
-export function braidedMetaTime(
-  variants: BraidVariants,
-  tetradic: boolean = true
-): number {
+export function braidedMetaTime(variants: BraidVariants, tetradic: boolean = true): number {
   const triadic = variants.immediate * variants.memory * variants.governance;
   return tetradic ? triadic * variants.predictive : triadic;
 }
@@ -343,11 +340,7 @@ export function braidedMetaTime(
  * @param x — Intent persistence factor (from computeXFactor)
  * @param R — Harmonic ratio (default 1.5)
  */
-export function harmonicWallBraid(
-  dBraid: number,
-  x: number = 1.0,
-  R: number = R_HARMONIC
-): number {
+export function harmonicWallBraid(dBraid: number, x: number = 1.0, R: number = R_HARMONIC): number {
   const exponent = dBraid * dBraid * x;
   // Cap exponent to prevent Infinity (log-safe up to ~700 for doubles)
   if (exponent > 500) return Number.MAX_VALUE;
@@ -408,16 +401,8 @@ function totalPairwiseDistance(values: number[]): number {
  * @param projected — Projected variant values
  * @param tolerance — Numerical tolerance (default 1e-8)
  */
-export function checkYangBaxter(
-  projected: ProjectedVariants,
-  tolerance: number = 1e-8
-): boolean {
-  const vals = [
-    projected.immediate,
-    projected.memory,
-    projected.governance,
-    projected.predictive,
-  ];
+export function checkYangBaxter(projected: ProjectedVariants, tolerance: number = 1e-8): boolean {
+  const vals = [projected.immediate, projected.memory, projected.governance, projected.predictive];
 
   // Check: σ_1 σ_2 σ_1 vs σ_2 σ_1 σ_2
   const lhs = applyGenerator(applyGenerator(applyGenerator(vals, 0), 1), 0);
@@ -535,9 +520,9 @@ export function variantsFromClocks(
 
   return computeVariants(
     T,
-    fastIntent,      // intent = fast clock's accumulated intent
-    govIntent,        // context = governance clock's accumulated intent
-    t                 // t = memory clock's tick count
+    fastIntent, // intent = fast clock's accumulated intent
+    govIntent, // context = governance clock's accumulated intent
+    t // t = memory clock's tick count
   );
 }
 
@@ -567,7 +552,11 @@ export function braidFromClocks(
   const skipYB = options.skipYangBaxter ?? true;
 
   const variants = variantsFromClocks(
-    fastIntent, memoryTick, memoryIntent, govIntent, breathingFactor
+    fastIntent,
+    memoryTick,
+    memoryIntent,
+    govIntent,
+    breathingFactor
   );
   const projected = projectVariants(variants, alpha);
   const edges = computePairwiseDistances(projected);
@@ -621,11 +610,7 @@ export function edgeWeight(from: BraidVariant, to: BraidVariant): number {
 /**
  * Look up weight from BraidEdgeWeights config for an edge.
  */
-function lookupWeight(
-  from: BraidVariant,
-  to: BraidVariant,
-  weights: BraidEdgeWeights
-): number {
+function lookupWeight(from: BraidVariant, to: BraidVariant, weights: BraidEdgeWeights): number {
   // Normalize order (alphabetical by variant name)
   const [a, b] = [from, to].sort();
   // Sorted pairs: governance < immediate < memory < predictive
@@ -655,10 +640,7 @@ export function weightedBraidedDistance(edges: BraidEdge[]): number {
 /**
  * Compute weighted braided distance using configurable BraidEdgeWeights.
  */
-function weightedBraidedDistanceWithConfig(
-  edges: BraidEdge[],
-  weights: BraidEdgeWeights
-): number {
+function weightedBraidedDistanceWithConfig(edges: BraidEdge[], weights: BraidEdgeWeights): number {
   let sum = 0;
   for (const edge of edges) {
     const w = lookupWeight(edge.from, edge.to, weights);

--- a/packages/kernel/src/temporalIntent.ts
+++ b/packages/kernel/src/temporalIntent.ts
@@ -112,11 +112,7 @@ export interface IntentSample extends IntentSampleInput {
 /**
  * Compute triadic temporal distance (L11) — geometric mean of 3 time scales.
  */
-export function computeDTri(
-  immediate: number,
-  medium: number,
-  long: number
-): number {
+export function computeDTri(immediate: number, medium: number, long: number): number {
   return Math.cbrt(Math.abs(immediate) * Math.abs(medium) * Math.abs(long));
 }
 
@@ -166,11 +162,7 @@ export function buildSample(input: IntentSampleInput): IntentSample {
     dTriImmediate: input.dTriImmediate ?? 0,
     dTriMedium: input.dTriMedium ?? 0,
     dTriLong: input.dTriLong ?? 0,
-    dTri: computeDTri(
-      input.dTriImmediate ?? 0,
-      input.dTriMedium ?? 0,
-      input.dTriLong ?? 0
-    ),
+    dTri: computeDTri(input.dTriImmediate ?? 0, input.dTriMedium ?? 0, input.dTriLong ?? 0),
     rawIntent: computeRawIntent(input),
   };
 }
@@ -345,7 +337,7 @@ export function compareScaling(
 
 /** Decision thresholds from AC-2.3.4 */
 export const ALLOW_THRESHOLD = 0.85;
-export const QUARANTINE_THRESHOLD = 0.40;
+export const QUARANTINE_THRESHOLD = 0.4;
 
 /** Possible gate decisions */
 export type GateDecision = 'ALLOW' | 'QUARANTINE' | 'DENY' | 'EXILE';
@@ -390,10 +382,7 @@ export function computeOmega(
   }
 
   // Get latest distance
-  const d =
-    history.samples.length > 0
-      ? history.samples[history.samples.length - 1].distance
-      : 0;
+  const d = history.samples.length > 0 ? history.samples[history.samples.length - 1].distance : 0;
 
   const x = computeXFactor(history);
   const hTemporal = harmonicWallTemporal(d, x);

--- a/packages/kernel/src/temporalPhase.ts
+++ b/packages/kernel/src/temporalPhase.ts
@@ -64,32 +64,32 @@ export interface TPhaseConfig {
 /** Default configurations for each T-phase */
 export const DEFAULT_PHASE_CONFIGS: Record<TPhaseType, TPhaseConfig> = {
   [TPhaseType.FAST]: {
-    decayRate: 0.99,        // Very slow decay per step — anomalies linger
-    breathAmplitude: 0.0,   // No breathing at inference scale
+    decayRate: 0.99, // Very slow decay per step — anomalies linger
+    breathAmplitude: 0.0, // No breathing at inference scale
     breathPeriod: 1,
-    tongueAffinity: [1, 1, 1, 1, 1, 1],  // Uniform — all tongues equal
+    tongueAffinity: [1, 1, 1, 1, 1, 1], // Uniform — all tongues equal
   },
   [TPhaseType.MEMORY]: {
-    decayRate: 0.90,        // Moderate decay — session-scale forgetting
-    breathAmplitude: 0.05,  // Gentle breathing
-    breathPeriod: 20,       // 20 turns per cycle
+    decayRate: 0.9, // Moderate decay — session-scale forgetting
+    breathAmplitude: 0.05, // Gentle breathing
+    breathPeriod: 20, // 20 turns per cycle
     tongueAffinity: [1, 1, 1, 1, 1, 1],
   },
   [TPhaseType.GOVERNANCE]: {
-    decayRate: 0.80,        // Faster decay — old epochs matter less
-    breathAmplitude: 0.1,   // Moderate breathing
-    breathPeriod: 100,      // 100 epochs per cycle
+    decayRate: 0.8, // Faster decay — old epochs matter less
+    breathAmplitude: 0.1, // Moderate breathing
+    breathPeriod: 100, // 100 epochs per cycle
     tongueAffinity: [1, 1, 1, 1, 1, 1],
   },
   [TPhaseType.CIRCADIAN]: {
     decayRate: 0.95,
-    breathAmplitude: 0.3,   // Strong breathing — day/night rhythm
-    breathPeriod: 24,       // 24-unit cycle (hours, or abstract)
+    breathAmplitude: 0.3, // Strong breathing — day/night rhythm
+    breathPeriod: 24, // 24-unit cycle (hours, or abstract)
     // Day phase: favor interactive tongues (KO, AV); Night: maintenance (UM, DR)
-    tongueAffinity: [1, 1, 1, 1, 1, 1],  // Overridden by circadian logic
+    tongueAffinity: [1, 1, 1, 1, 1, 1], // Overridden by circadian logic
   },
   [TPhaseType.SET]: {
-    decayRate: 0.5,         // Aggressive decay — set events are punctuated
+    decayRate: 0.5, // Aggressive decay — set events are punctuated
     breathAmplitude: 0.0,
     breathPeriod: 1,
     tongueAffinity: [1, 1, 1, 1, 1, 1],
@@ -149,14 +149,9 @@ export function createClock(type: TPhaseType): TPhaseClockState {
  *
  * Controls realm expansion/contraction on this clock's timescale.
  */
-export function computeBreathingFactor(
-  tick: number,
-  config: TPhaseConfig
-): number {
+export function computeBreathingFactor(tick: number, config: TPhaseConfig): number {
   if (config.breathAmplitude === 0 || config.breathPeriod <= 0) return 1.0;
-  return 1.0 + config.breathAmplitude * Math.sin(
-    2 * Math.PI * tick / config.breathPeriod
-  );
+  return 1.0 + config.breathAmplitude * Math.sin((2 * Math.PI * tick) / config.breathPeriod);
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -177,17 +172,17 @@ export function circadianTongueAffinity(
 ): [number, number, number, number, number, number] {
   if (period <= 0) return [1, 1, 1, 1, 1, 1];
   const phase = (2 * Math.PI * tick) / period;
-  const dayFactor = (1 + Math.cos(phase)) / 2;     // 1 at day, 0 at night
-  const nightFactor = (1 - Math.cos(phase)) / 2;   // 0 at day, 1 at night
+  const dayFactor = (1 + Math.cos(phase)) / 2; // 1 at day, 0 at night
+  const nightFactor = (1 - Math.cos(phase)) / 2; // 0 at day, 1 at night
 
   // KO, AV, RU are interactive (day); CA, DR, UM are maintenance (night)
   return [
-    0.5 + dayFactor,       // KO: peaks at day
-    0.5 + dayFactor,       // AV: peaks at day
-    0.5 + 0.5 * dayFactor + 0.5 * nightFactor,  // RU: always moderate
-    0.5 + nightFactor,     // CA: peaks at night
-    0.5 + nightFactor,     // DR: peaks at night
-    0.5 + nightFactor,     // UM: peaks at night
+    0.5 + dayFactor, // KO: peaks at day
+    0.5 + dayFactor, // AV: peaks at day
+    0.5 + 0.5 * dayFactor + 0.5 * nightFactor, // RU: always moderate
+    0.5 + nightFactor, // CA: peaks at night
+    0.5 + nightFactor, // DR: peaks at night
+    0.5 + nightFactor, // UM: peaks at night
   ];
 }
 
@@ -270,10 +265,7 @@ export interface ContextEvent {
  * Apply a context event (T_set) to a clock.
  * Returns a new clock state (immutable).
  */
-export function applyContextEvent(
-  clock: TPhaseClockState,
-  event: ContextEvent
-): TPhaseClockState {
+export function applyContextEvent(clock: TPhaseClockState, event: ContextEvent): TPhaseClockState {
   // Check if this clock is targeted
   if (event.targetClocks.length > 0 && !event.targetClocks.includes(clock.type)) {
     return clock;
@@ -377,10 +369,7 @@ export function tickPhases(
 /**
  * Apply a context event to the multi-clock system.
  */
-export function injectContext(
-  state: MultiClockState,
-  event: ContextEvent
-): MultiClockState {
+export function injectContext(state: MultiClockState, event: ContextEvent): MultiClockState {
   const clocks = { ...state.clocks };
   for (const phase of Object.values(TPhaseType)) {
     clocks[phase] = applyContextEvent(state.clocks[phase], event);
@@ -456,8 +445,8 @@ export function combinedXFactor(state: MultiClockState): number {
 
   // Minimum trust across active clocks
   const trusts = Object.values(clocks)
-    .filter(c => c.active)
-    .map(c => c.trustScore);
+    .filter((c) => c.active)
+    .map((c) => c.trustScore);
   const minTrust = trusts.length > 0 ? Math.min(...trusts) : 1.0;
 
   const trustModifier = 1.0 + (1.0 - minTrust);
@@ -495,9 +484,11 @@ export function computeMultiPhaseRisk(state: MultiClockState): MultiPhaseRisk {
   const breathing = circClock.breathingFactor;
 
   // Decision: strictest across all clocks
-  const trusts = Object.values(clocks).filter(c => c.active).map(c => c.trustScore);
+  const trusts = Object.values(clocks)
+    .filter((c) => c.active)
+    .map((c) => c.trustScore);
   const minTrust = trusts.length > 0 ? Math.min(...trusts) : 1.0;
-  const maxIntent = Math.max(...Object.values(clocks).map(c => c.accumulatedIntent));
+  const maxIntent = Math.max(...Object.values(clocks).map((c) => c.accumulatedIntent));
 
   let decision: 'ALLOW' | 'QUARANTINE' | 'DENY' | 'EXILE';
   if (minTrust < 0.1 || maxIntent >= 9.0) {

--- a/packages/kernel/src/triDirectionalPlanner.ts
+++ b/packages/kernel/src/triDirectionalPlanner.ts
@@ -372,9 +372,11 @@ export function planTriDirectional(
 ): TriDirectionalResult {
   const directions: TraceDirection[] = ['STRUCTURE', 'CONFLICT', 'TIME'];
 
-  const traces = directions.map((dir) =>
-    planTrace(graph, dir, state, dStar, configs?.[dir])
-  ) as [TraceOutput, TraceOutput, TraceOutput];
+  const traces = directions.map((dir) => planTrace(graph, dir, state, dStar, configs?.[dir])) as [
+    TraceOutput,
+    TraceOutput,
+    TraceOutput,
+  ];
 
   // Layer 11: triadic temporal aggregation
   const triadicDist = triadicTemporalDistance(traces[0].cost, traces[1].cost, traces[2].cost);

--- a/packages/kernel/src/triMechanismDetector.ts
+++ b/packages/kernel/src/triMechanismDetector.ts
@@ -137,7 +137,7 @@ export const TONGUE_INDEX: Record<TongueCode, number> = {
 export const DEFAULT_CONFIG: TriDetectorConfig = {
   wPhase: 0.35,
   wTonic: 0.35,
-  wDrift: 0.30,
+  wDrift: 0.3,
   baseFreq: 0.1,
   chirpRate: 0.05,
   baselineSamples: 100,
@@ -172,11 +172,7 @@ export function phaseDeviation(observed: number, expected: number): number {
  * @param v - Point in the ball
  * @param eps - Numerical stability epsilon
  */
-export function hyperbolicDistance(
-  u: Float64Array,
-  v: Float64Array,
-  eps: number = 1e-10
-): number {
+export function hyperbolicDistance(u: Float64Array, v: Float64Array, eps: number = 1e-10): number {
   let diffNormSq = 0;
   let uNormSq = 0;
   let vNormSq = 0;
@@ -334,7 +330,7 @@ function computeFrequencyMatch(
   let peakFreq = 0;
 
   for (let k = 1; k <= numFreqs; k++) {
-    const freq = (k / radii.length) / dt;
+    const freq = k / radii.length / dt;
     let re = 0;
     let im = 0;
     for (let n = 0; n < centered.length; n++) {
@@ -457,7 +453,7 @@ export function computeDriftSignature(
       const mantissa = s.split('e')[0].replace('.', '').replace(/0+$/, '');
       totalPrecision += mantissa.length;
     }
-    sig[16] = (totalPrecision / inputData.length) / 15.0;
+    sig[16] = totalPrecision / inputData.length / 15.0;
   } else {
     sig[13] = 0.5;
     sig[14] = 0.5;
@@ -607,8 +603,7 @@ export class TriMechanismDetector {
     let sumSecond = 0;
     for (let i = 0; i < halfLen; i++) sumFirst += inputData[i];
     for (let i = halfLen; i < inputData.length; i++) sumSecond += inputData[i];
-    const observedPhase = Math.atan2(sumSecond / (inputData.length - halfLen),
-                                     sumFirst / halfLen);
+    const observedPhase = Math.atan2(sumSecond / (inputData.length - halfLen), sumFirst / halfLen);
     const phase = phaseDistanceScore(uFinal, tongueIdx, this.tongueCentroids, observedPhase);
 
     // Mechanism 2: 6-tonic temporal coherence

--- a/public/arena.html
+++ b/public/arena.html
@@ -702,7 +702,7 @@
       <input
         class="deal-input"
         id="dealInput"
-        placeholder="Deal to all players or Deliberate for consensus..."
+        placeholder='Deal to all, or use /bus "task" and /code "intent"...'
         autocomplete="off"
       />
       <button class="deal-btn" id="dealBtn" onclick="dealToAll()">Deal</button>
@@ -1327,7 +1327,9 @@
 
       function renderMessageContent(div, role, text) {
         const raw = String(text || '');
-        const shouldCompact = role === 'ai' && (raw.length > 700 || raw.split('\n').length > 9);
+        const shouldCompact =
+          (role === 'ai' || role === 'synthesis') &&
+          (raw.length > 700 || raw.split('\n').length > 9);
         if (!shouldCompact) {
           let content = escHtml(raw);
           content = content.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre>$2</pre>');
@@ -1344,7 +1346,7 @@
         const details = document.createElement('details');
         details.className = 'raw-toggle';
         const label = document.createElement('summary');
-        label.textContent = 'Raw model output';
+        label.textContent = role === 'synthesis' ? 'Raw operator output' : 'Raw model output';
         const pre = document.createElement('pre');
         pre.textContent = raw;
         details.appendChild(label);
@@ -1353,7 +1355,39 @@
         div.appendChild(details);
       }
 
-      function handleArenaCommand(text, sourceLabel = 'Command') {
+      function formatCliResult(command, data) {
+        const payload =
+          data && typeof data === 'object' && data.result !== undefined ? data.result : data;
+        const body =
+          typeof payload === 'string' ? payload : JSON.stringify(payload ?? data ?? {}, null, 2);
+        const status = data && data.ok === false ? 'FAILED' : 'OK';
+        const stderr = data && data.stderr ? `\n\nSTDERR:\n${data.stderr}` : '';
+        const stdout = data && data.stdout ? `\n\nSTDOUT:\n${data.stdout}` : '';
+        return `[OPERATOR ${status}] ${command}${stdout || `\n\n${body}`}${stderr}`;
+      }
+
+      async function runArenaCliCommand(command, sourceLabel = 'Command') {
+        const seatId = narratorSeatId();
+        addMessage(seatId, 'synthesis', `[${sourceLabel}] Running: ${command}`, 'operator cli');
+        try {
+          const resp = await fetch(API + '/api/cli/run', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ command }),
+          });
+          const data = await resp.json();
+          addMessage(
+            seatId,
+            data.ok === false ? 'error' : 'synthesis',
+            formatCliResult(command, data),
+            'operator cli'
+          );
+        } catch (err) {
+          addMessage(seatId, 'error', `[${sourceLabel}] CLI error: ${err.message || 'failed'}`);
+        }
+      }
+
+      async function handleArenaCommand(text, sourceLabel = 'Command') {
         const value = String(text || '').trim();
         if (!value) return false;
         const seatId = narratorSeatId();
@@ -1370,7 +1404,7 @@
           addMessage(
             seatId,
             'synthesis',
-            '[COMMAND HELP]\n/open keys - open provider keys\n/clear - clear seat transcripts\nA bare number is treated as a UI selection, not a creative prompt.',
+            '[COMMAND HELP]\n/open keys - open provider keys\n/clear - clear seat transcripts\n/bus <agent-bus command> - run safe Agent Bus verbs\n/code <intent> - compile a safe coding harness plan\n/cli <safe command> - run the allowlisted AetherBrowser CLI\nA bare number is treated as a UI selection, not a creative prompt.',
             'local parser'
           );
           return true;
@@ -1386,6 +1420,21 @@
             if (chat) chat.replaceChildren();
           });
           addMessage(seatId, 'synthesis', '[COMMAND] Cleared visible transcripts.', 'local parser');
+          return true;
+        }
+        if (value.startsWith('/bus ')) {
+          await runArenaCliCommand('bus ' + value.slice(5).trim(), sourceLabel);
+          return true;
+        }
+        if (value.startsWith('/code ')) {
+          await runArenaCliCommand(
+            'harness plan ' + JSON.stringify(value.slice(6).trim()),
+            sourceLabel
+          );
+          return true;
+        }
+        if (value.startsWith('/cli ')) {
+          await runArenaCliCommand(value.slice(5).trim(), sourceLabel);
           return true;
         }
         return false;
@@ -1739,7 +1788,7 @@
         const input = document.getElementById('input-' + playerId);
         const text = message || (input ? input.value.trim() : '');
         if (!text) return null;
-        if (!message && handleArenaCommand(text, playerId)) {
+        if (!message && (await handleArenaCommand(text, playerId))) {
           if (input) input.value = '';
           return null;
         }
@@ -1798,7 +1847,7 @@
         const text = input.value.trim();
         if (!text) return;
         input.value = '';
-        if (handleArenaCommand(text, 'Deal')) return;
+        if (await handleArenaCommand(text, 'Deal')) return;
 
         document.getElementById('dealBtn').disabled = true;
         document.getElementById('dealBtn').textContent = 'Dealing...';
@@ -1816,7 +1865,7 @@
         const text = input.value.trim();
         if (!text) return;
         input.value = '';
-        if (handleArenaCommand(text, 'Relay')) return;
+        if (await handleArenaCommand(text, 'Relay')) return;
 
         const btn = document.getElementById('relayBtn');
         btn.disabled = true;
@@ -1859,7 +1908,7 @@
         const topic = input.value.trim();
         if (!topic) return;
         input.value = '';
-        if (handleArenaCommand(topic, 'Debate')) return;
+        if (await handleArenaCommand(topic, 'Debate')) return;
 
         const btn = document.getElementById('debateBtn');
         btn.disabled = true;
@@ -1905,7 +1954,7 @@
         const text = input.value.trim();
         if (!text) return;
         input.value = '';
-        if (handleArenaCommand(text, 'Deliberate')) return;
+        if (await handleArenaCommand(text, 'Deliberate')) return;
 
         const btn = document.getElementById('deliberateBtn');
         btn.disabled = true;

--- a/public/index.html
+++ b/public/index.html
@@ -642,7 +642,7 @@
       <input
         class="deal-input"
         id="dealInput"
-        placeholder="Deal to all players or Deliberate for consensus..."
+        placeholder='Deal to all, or use /bus "task" and /code "intent"...'
         autocomplete="off"
       />
       <button class="deal-btn" id="dealBtn" onclick="dealToAll()">Deal</button>
@@ -1050,7 +1050,9 @@
 
       function renderMessageContent(div, role, text) {
         const raw = String(text || '');
-        const shouldCompact = role === 'ai' && (raw.length > 700 || raw.split('\n').length > 9);
+        const shouldCompact =
+          (role === 'ai' || role === 'synthesis') &&
+          (raw.length > 700 || raw.split('\n').length > 9);
         if (!shouldCompact) {
           let content = escHtml(raw);
           content = content.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre>$2</pre>');
@@ -1067,7 +1069,7 @@
         const details = document.createElement('details');
         details.className = 'raw-toggle';
         const label = document.createElement('summary');
-        label.textContent = 'Raw model output';
+        label.textContent = role === 'synthesis' ? 'Raw operator output' : 'Raw model output';
         const pre = document.createElement('pre');
         pre.textContent = raw;
         details.appendChild(label);
@@ -1076,7 +1078,39 @@
         div.appendChild(details);
       }
 
-      function handleArenaCommand(text, sourceLabel = 'Command') {
+      function formatCliResult(command, data) {
+        const payload =
+          data && typeof data === 'object' && data.result !== undefined ? data.result : data;
+        const body =
+          typeof payload === 'string' ? payload : JSON.stringify(payload ?? data ?? {}, null, 2);
+        const status = data && data.ok === false ? 'FAILED' : 'OK';
+        const stderr = data && data.stderr ? `\n\nSTDERR:\n${data.stderr}` : '';
+        const stdout = data && data.stdout ? `\n\nSTDOUT:\n${data.stdout}` : '';
+        return `[OPERATOR ${status}] ${command}${stdout || `\n\n${body}`}${stderr}`;
+      }
+
+      async function runArenaCliCommand(command, sourceLabel = 'Command') {
+        const seatId = narratorSeatId();
+        addMessage(seatId, 'synthesis', `[${sourceLabel}] Running: ${command}`, 'operator cli');
+        try {
+          const resp = await fetch(API + '/api/cli/run', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ command }),
+          });
+          const data = await resp.json();
+          addMessage(
+            seatId,
+            data.ok === false ? 'error' : 'synthesis',
+            formatCliResult(command, data),
+            'operator cli'
+          );
+        } catch (err) {
+          addMessage(seatId, 'error', `[${sourceLabel}] CLI error: ${err.message || 'failed'}`);
+        }
+      }
+
+      async function handleArenaCommand(text, sourceLabel = 'Command') {
         const value = String(text || '').trim();
         if (!value) return false;
         const seatId = narratorSeatId();
@@ -1093,7 +1127,7 @@
           addMessage(
             seatId,
             'synthesis',
-            '[COMMAND HELP]\n/clear - clear seat transcripts\nA bare number is treated as a UI selection, not a creative prompt.',
+            '[COMMAND HELP]\n/clear - clear seat transcripts\n/bus <agent-bus command> - run safe Agent Bus verbs\n/code <intent> - compile a safe coding harness plan\n/cli <safe command> - run the allowlisted AetherBrowser CLI\nA bare number is treated as a UI selection, not a creative prompt.',
             'local parser'
           );
           return true;
@@ -1104,6 +1138,21 @@
             if (chat) chat.replaceChildren();
           });
           addMessage(seatId, 'synthesis', '[COMMAND] Cleared visible transcripts.', 'local parser');
+          return true;
+        }
+        if (value.startsWith('/bus ')) {
+          await runArenaCliCommand('bus ' + value.slice(5).trim(), sourceLabel);
+          return true;
+        }
+        if (value.startsWith('/code ')) {
+          await runArenaCliCommand(
+            'harness plan ' + JSON.stringify(value.slice(6).trim()),
+            sourceLabel
+          );
+          return true;
+        }
+        if (value.startsWith('/cli ')) {
+          await runArenaCliCommand(value.slice(5).trim(), sourceLabel);
           return true;
         }
         return false;
@@ -1216,7 +1265,7 @@
         const input = document.getElementById('input-' + playerId);
         const text = message || (input ? input.value.trim() : '');
         if (!text) return null;
-        if (!message && handleArenaCommand(text, playerId)) {
+        if (!message && (await handleArenaCommand(text, playerId))) {
           if (input) input.value = '';
           return null;
         }
@@ -1311,7 +1360,7 @@
         const text = input.value.trim();
         if (!text) return;
         input.value = '';
-        if (handleArenaCommand(text, 'Deal')) return;
+        if (await handleArenaCommand(text, 'Deal')) return;
 
         document.getElementById('dealBtn').disabled = true;
         document.getElementById('dealBtn').textContent = 'Dealing...';
@@ -1329,7 +1378,7 @@
         const text = input.value.trim();
         if (!text) return;
         input.value = '';
-        if (handleArenaCommand(text, 'Relay')) return;
+        if (await handleArenaCommand(text, 'Relay')) return;
 
         const btn = document.getElementById('relayBtn');
         btn.disabled = true;
@@ -1372,7 +1421,7 @@
         const topic = input.value.trim();
         if (!topic) return;
         input.value = '';
-        if (handleArenaCommand(topic, 'Debate')) return;
+        if (await handleArenaCommand(topic, 'Debate')) return;
 
         const btn = document.getElementById('debateBtn');
         btn.disabled = true;
@@ -1418,7 +1467,7 @@
         const text = input.value.trim();
         if (!text) return;
         input.value = '';
-        if (handleArenaCommand(text, 'Deliberate')) return;
+        if (await handleArenaCommand(text, 'Deliberate')) return;
 
         const btn = document.getElementById('deliberateBtn');
         btn.disabled = true;

--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -3211,6 +3211,20 @@ def _cli_command_registry() -> list[dict[str, Any]]:
             "example": "ops tests",
         },
         {
+            "cmd": "bus run|summarize|analyze|perf|verify|replay ...",
+            "lane": "agent-bus",
+            "interop": {"web": True, "python": True, "node": False, "connectors": True},
+            "desc": "Dispatch safe Agent Bus operations through the existing CLI harness.",
+            "example": 'bus run "check the repo health" --no-search',
+        },
+        {
+            "cmd": "harness plan <intent...> [--permission-mode observe|assist] [--language python|typescript]",
+            "lane": "coding-harness",
+            "interop": {"web": True, "python": True, "node": False, "connectors": False},
+            "desc": "Compile an operator intent into a policy-checked coding harness plan. Read-only from the browser.",
+            "example": 'harness plan "fix failing lint in public arena" --permission-mode observe',
+        },
+        {
             "cmd": "momentum run <train_id> [--flow X] [--execute] [--max-parallel N]",
             "lane": "momentum",
             "interop": {"web": True, "python": True, "node": False, "connectors": False},
@@ -3256,6 +3270,13 @@ def _cli_help_text() -> str:
         '  vault search "query"',
         "  vault sync",
         "  ops email|youtube|tor|tests|git",
+        '  bus run "task..." [--no-search]',
+        '  bus summarize "query..."',
+        "  bus analyze <url>",
+        "  bus perf",
+        "  bus verify [events.jsonl]",
+        "  bus replay [events.jsonl] [--by-task]",
+        '  harness plan "intent..." [--permission-mode observe|assist] [--language python|typescript]',
         "  momentum run <train_id> [--flow X] [--execute] [--max-parallel N]",
         "  momentum latest [train_id]",
         '  chessboard generate "goal..."',
@@ -3267,6 +3288,8 @@ def _cli_help_text() -> str:
         "  trust aethermoore.com",
         '  vault search "phi poincare"',
         "  ops tests",
+        '  bus run "inspect current repo health" --no-search',
+        '  harness plan "add a regression test for the arena command parser"',
         "  momentum run daily_ops --execute --max-parallel 3",
         '  chessboard generate "Improve long-running agent workflows"',
         "  docs show aetherbrowser-config",
@@ -3307,7 +3330,7 @@ def _cli_docs_show(key: str, max_chars: int = 9000) -> dict[str, Any]:
 
 
 def _cli_parse_flags(parts: list[str]) -> dict[str, Any]:
-    """Very small flag parser for: --flow, --execute, --max-parallel."""
+    """Very small flag parser for safe allowlisted CLI verbs."""
     out: dict[str, Any] = {"args": []}
     i = 0
     while i < len(parts):
@@ -3328,9 +3351,157 @@ def _cli_parse_flags(parts: list[str]) -> dict[str, Any]:
                 out["max_parallel"] = parts[i + 1]
             i += 2
             continue
+        if p == "--permission-mode" and i + 1 < len(parts):
+            out["permission_mode"] = parts[i + 1]
+            i += 2
+            continue
+        if p == "--language" and i + 1 < len(parts):
+            out["language"] = parts[i + 1]
+            i += 2
+            continue
+        if p == "--tool" and i + 1 < len(parts):
+            out["tool"] = parts[i + 1]
+            i += 2
+            continue
+        if p == "--no-search":
+            out["no_search"] = True
+            i += 1
+            continue
+        if p == "--by-task":
+            out["by_task"] = True
+            i += 1
+            continue
         out["args"].append(p)
         i += 1
     return out
+
+
+def _cli_limited_subprocess_payload(
+    *,
+    lane: str,
+    cmd: list[str],
+    timeout: int,
+    stdout_chars: int = 5000,
+    stderr_chars: int = 1200,
+) -> dict[str, Any]:
+    result = _run_subprocess(cmd, timeout=timeout)
+    return {
+        "ok": result.get("exit_code", -1) == 0,
+        "lane": lane,
+        "exit_code": result.get("exit_code", -1),
+        "stdout": (result.get("stdout") or "")[:stdout_chars],
+        "stderr": (result.get("stderr") or "")[:stderr_chars] if result.get("stderr") else None,
+    }
+
+
+async def _cli_agent_bus(rest: list[str]) -> dict[str, Any]:
+    if not rest:
+        return {
+            "ok": False,
+            "error": "Usage: bus run|summarize|analyze|perf|verify|replay ...",
+        }
+
+    sub = rest[0].lower()
+    flags = _cli_parse_flags(rest[1:])
+    args = [str(x) for x in flags.get("args", [])]
+    base = [sys.executable, "-m", "agents.agent_bus_cli"]
+
+    if sub in {"run", "ask"}:
+        prompt = " ".join(args).strip().strip('"')
+        if not prompt:
+            return {"ok": False, "error": 'Usage: bus run "task..." [--no-search]'}
+        cmd = base + ["run", prompt, "--mode", "headless", "--max-sources", "3", "--budget", "0"]
+        if flags.get("no_search"):
+            cmd.append("--no-search")
+        return await asyncio.to_thread(
+            _cli_limited_subprocess_payload,
+            lane="agent-bus",
+            cmd=cmd,
+            timeout=180,
+        )
+
+    if sub == "summarize":
+        query = " ".join(args).strip().strip('"')
+        if not query:
+            return {"ok": False, "error": 'Usage: bus summarize "query..."'}
+        cmd = base + ["summarize", query, "--mode", "headless", "--max-sources", "5"]
+        return await asyncio.to_thread(
+            _cli_limited_subprocess_payload,
+            lane="agent-bus",
+            cmd=cmd,
+            timeout=180,
+        )
+
+    if sub == "analyze":
+        if not args:
+            return {"ok": False, "error": "Usage: bus analyze <url>"}
+        cmd = base + ["analyze", args[0], "--mode", "headless"]
+        return await asyncio.to_thread(
+            _cli_limited_subprocess_payload,
+            lane="agent-bus",
+            cmd=cmd,
+            timeout=180,
+        )
+
+    if sub == "perf":
+        return await asyncio.to_thread(
+            _cli_limited_subprocess_payload,
+            lane="agent-bus",
+            cmd=base + ["perf"],
+            timeout=30,
+        )
+
+    if sub == "verify":
+        path = args[0] if args else "artifacts/agent-bus/events.jsonl"
+        cmd = base + ["verify", path]
+        return await asyncio.to_thread(
+            _cli_limited_subprocess_payload,
+            lane="agent-bus",
+            cmd=cmd,
+            timeout=60,
+        )
+
+    if sub == "replay":
+        path = args[0] if args else "artifacts/agent-bus/events.jsonl"
+        cmd = base + ["replay", path]
+        if flags.get("by_task"):
+            cmd.append("--by-task")
+        return await asyncio.to_thread(
+            _cli_limited_subprocess_payload,
+            lane="agent-bus",
+            cmd=cmd,
+            timeout=60,
+        )
+
+    return {"ok": False, "error": f"Unknown bus subcommand: {sub}"}
+
+
+def _cli_harness_plan(rest: list[str]) -> dict[str, Any]:
+    if not rest or rest[0].lower() != "plan":
+        return {"ok": False, "error": "Usage: harness plan <intent...> [--permission-mode observe|assist]"}
+
+    flags = _cli_parse_flags(rest[1:])
+    intent = " ".join(str(x) for x in flags.get("args", [])).strip().strip('"')
+    if not intent:
+        return {"ok": False, "error": "Usage: harness plan <intent...>"}
+
+    permission_mode = str(flags.get("permission_mode") or "observe")
+    language = str(flags.get("language") or "python")
+    requested_tool = flags.get("tool")
+    if permission_mode not in {"observe", "assist"}:
+        return {"ok": False, "error": "Browser harness supports permission modes: observe, assist"}
+    if language not in {"python", "typescript", "go"}:
+        return {"ok": False, "error": "Supported harness languages: python, typescript, go"}
+
+    from src.coding_spine.command_compiler import compile_intent_to_plan
+
+    plan = compile_intent_to_plan(
+        intent=intent,
+        permission_mode=permission_mode,
+        preferred_language=language,
+        requested_tool=str(requested_tool) if requested_tool else None,
+    )
+    return {"ok": True, "lane": "coding-harness", "result": plan}
 
 
 async def _cli_dispatch(parts: list[str]) -> dict[str, Any]:
@@ -3381,6 +3552,12 @@ async def _cli_dispatch(parts: list[str]) -> dict[str, Any]:
         if op in {"git", "status"}:
             return await ops_git_status()
         return {"ok": False, "error": f"Unknown ops subcommand: {op}"}
+
+    if cmd == "bus":
+        return await _cli_agent_bus(rest)
+
+    if cmd in {"harness", "code"}:
+        return _cli_harness_plan(rest)
 
     if cmd == "momentum":
         if not rest:

--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import logging
 import math
 import os
 import re
@@ -52,6 +53,8 @@ import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+logging.getLogger("oqs.oqs").disabled = True
 
 if __package__ in (None, ""):
     repo_root = Path(__file__).resolve().parent.parent

--- a/src/tokenizer/code_weight_packets.py
+++ b/src/tokenizer/code_weight_packets.py
@@ -108,6 +108,49 @@ def _feature_vector(element: dict[str, Any], semantic_class: str) -> list[float]
     ]
 
 
+def resolve_element(token: str, semantic_class: str | None = None) -> dict[str, Any]:
+    """Resolve a token into the STISA element proxy shape used by GeoSeal CLI."""
+
+    semantic = semantic_class or _semantic_class(token)
+    element = dict(_element_for(token, semantic))
+    element["feat"] = _feature_vector(element, semantic)
+    return element
+
+
+def analyze_chemical_composition(
+    tokens: list[str],
+    elements: list[dict[str, Any]],
+    *,
+    operation_path: list[str] | None = None,
+) -> dict[str, Any]:
+    """Summarize the token-element proxy mix for STISA/GeoSeal packet surfaces."""
+
+    symbol_counts: dict[str, int] = {}
+    total_z = 0.0
+    total_valence = 0.0
+    stable_witnesses = 0
+    for element in elements:
+        symbol = str(element.get("symbol", "?"))
+        symbol_counts[symbol] = symbol_counts.get(symbol, 0) + 1
+        total_z += float(element.get("Z", 0.0))
+        total_valence += float(element.get("valence", 0.0))
+        if element.get("witness_stable"):
+            stable_witnesses += 1
+
+    count = max(len(elements), 1)
+    return {
+        "schema_version": "scbe-stisa-chemical-composition-v1",
+        "token_count": len(tokens),
+        "element_count": len(elements),
+        "symbol_counts": symbol_counts,
+        "dominant_symbol": max(symbol_counts, key=symbol_counts.get) if symbol_counts else None,
+        "average_z": total_z / count,
+        "average_valence": total_valence / count,
+        "stable_witness_count": stable_witnesses,
+        "operation_path": operation_path or [],
+    }
+
+
 def _transport_tokens(source: str, tongue: str) -> list[str]:
     prefix = TONGUE_PREFIX.get(tongue, "tok")
     names = ("a", "e", "i", "o", "u", "y", "en", "ul", "la", "sa")
@@ -389,7 +432,9 @@ def build_code_weight_packet(source: str, *, language: str, source_name: str = "
 
 
 __all__ = [
+    "analyze_chemical_composition",
     "build_code_weight_packet",
     "build_semantic_operation_signature",
+    "resolve_element",
     "semantic_operation_signature_from_tokens",
 ]

--- a/tests/aetherbrowser/test_api_server_operator_cli.py
+++ b/tests/aetherbrowser/test_api_server_operator_cli.py
@@ -1,0 +1,58 @@
+import pytest
+
+from scripts.aetherbrowser import api_server
+
+
+def test_arena_numeric_input_stays_local_command() -> None:
+    response = api_server._arena_local_command_response("2")
+
+    assert response is not None
+    assert "No model deliberation is needed" in response
+    assert "active numbered menu" in response
+
+
+@pytest.mark.asyncio
+async def test_cli_dispatch_compiles_coding_harness_plan() -> None:
+    result = await api_server._cli_dispatch(["harness", "plan", "explain", "arena", "route"])
+
+    assert result["ok"] is True
+    assert result["lane"] == "coding-harness"
+    plan = result["result"]
+    assert plan["schema_version"] == "scbe_command_plan_v1"
+    assert plan["intent"]["permission_mode"] == "observe"
+    assert plan["policy"]["decision"] != "DENY"
+
+
+@pytest.mark.asyncio
+async def test_cli_dispatch_rejects_mutating_harness_mode() -> None:
+    result = await api_server._cli_dispatch(["harness", "plan", "delete", "everything", "--permission-mode", "execute"])
+
+    assert result["ok"] is False
+    assert "observe, assist" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_cli_dispatch_agent_bus_uses_allowlisted_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run_subprocess(cmd: list[str], timeout: int = 60) -> dict[str, object]:
+        seen["cmd"] = cmd
+        seen["timeout"] = timeout
+        return {"stdout": '{"perf": null, "reason": "no_events"}', "stderr": "", "exit_code": 0}
+
+    monkeypatch.setattr(api_server, "_run_subprocess", fake_run_subprocess)
+
+    result = await api_server._cli_dispatch(["bus", "perf"])
+
+    assert result["ok"] is True
+    assert result["lane"] == "agent-bus"
+    assert seen["cmd"] == [api_server.sys.executable, "-m", "agents.agent_bus_cli", "perf"]
+    assert seen["timeout"] == 30
+
+
+@pytest.mark.asyncio
+async def test_cli_dispatch_does_not_allow_raw_shell_commands() -> None:
+    result = await api_server._cli_dispatch(["powershell", "-Command", "Get-ChildItem"])
+
+    assert result["ok"] is False
+    assert "Unknown command" in result["error"]


### PR DESCRIPTION
## Summary
- Adds safe Arena commands for /bus, /code, and /cli using the existing allowlisted AetherBrowser CLI dispatcher.
- Wires Agent Bus verbs and read-only coding harness planning into /api/cli/run without arbitrary shell execution.
- Restores GeoSeal CLI import compatibility for STISA chemical composition helpers and suppresses liboqs stdout noise so JSON CLI smoke tests remain parseable.
- Runs Prettier formatting needed for the current package lint gate.

## Test Evidence
- npm run lint
- npm run typecheck
- npm test
- npm run build
- python -m pytest tests\\aetherbrowser\\test_api_server_operator_cli.py -q
- python -m pytest tests\\test_geoseal_agent_routing.py tests\\test_geoseal_cursor.py tests\\test_semantic_atomic_braid.py tests\\aetherbrowser\\test_api_server_operator_cli.py -q
- python -m pytest tests/ --collect-only -q
- Playwright live smoke at http://127.0.0.1:8100 verified numeric local parser, /code, /bus perf, and blocked raw powershell command.

## Notes
- npm run test:python exceeded the 10 minute local tool timeout during full execution; collection is clean and the affected focused Python suites pass.
- Local untracked apps/aether-desktop/.scbe/ was left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added in-browser CLI-style command support (`/bus`, `/code`, `/cli`) with operator-level actions in the Arena UI.
  * Introduced code analysis helpers for chemical composition and element resolution.
  * Enhanced message rendering to distinguish synthesis output ("Raw operator output") from standard model output.

* **Documentation**
  * Updated help text to document new CLI command syntax.

* **Tests**
  * Added comprehensive test coverage for operator CLI dispatch and command validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->