### PR TITLE
feat(game): add operator smoke for narrative combat

### DIFF
--- a/docs/superpowers/specs/2026-05-23-open-source-game-production-toolchain.md
+++ b/docs/superpowers/specs/2026-05-23-open-source-game-production-toolchain.md
@@ -1,0 +1,223 @@
+# Open Source Game Production Toolchain
+
+Date: 2026-05-23
+Status: R&D production-lane note
+Source prompt: GitHub Blog, "Beyond the engine: 10 open source projects shaping how games actually get made" (2026-05-21)
+Source URL: https://github.blog/open-source/gaming/beyond-the-engine-10-open-source-projects-shaping-how-games-actually-get-made/
+Related repo surfaces:
+- `docs/superpowers/specs/2026-05-21-narrative-combat-generator-design.md`
+- `docs/superpowers/specs/2026-05-21-go-board-narrative-engine-design.md`
+- `docs/superpowers/plans/2026-05-21-narrative-combat-generator-vertical-slice.md`
+- `src/narrative_combat/`
+- `game/godot/`
+- `public/arena.html`
+
+## Purpose
+
+The engine is not the game. The production system needs authoring tools,
+asset-prep tools, validation hooks, and an operator/debug surface. This note
+turns the open-source game-tooling survey into a concrete SCBE/AetherMoore lane:
+use stable external tools where they already solve the job, and wire our agent
+bus around validation, export, and build commands instead of asking models to
+"chat better."
+
+This is not canonical SCBE governance architecture. It is an adjacent
+game-production workflow that can reuse the same principle: agents can propose
+content or commands, but deterministic tooling verifies the artifact.
+
+## Production Shape
+
+```
+Writer / Designer
+  -> Dialogue, encounter, map, asset, and audio authoring tools
+  -> Repo import/export adapters
+  -> Deterministic validators
+  -> Agent bus operator commands
+  -> Godot / web / narrative-combat runtime
+  -> Smoke tests and playable review
+```
+
+The important boundary is simple:
+
+- Tools own file formats and content-editing ergonomics.
+- Repo code owns import, validation, deterministic runtime behavior, and tests.
+- Agent bus owns orchestration: run exporters, validators, tests, and summaries.
+- LLMs may draft or translate, but they do not decide truth.
+
+## Tool Choices
+
+### Dialogue: Yarn Spinner First
+
+Use Yarn Spinner as the first serious dialogue-authoring target because it
+separates writer-owned branching script from programmer-owned runtime wiring.
+That maps cleanly to the existing narrative-combat rule: structured truth first,
+rendering second.
+
+Initial repo target:
+- Add an export adapter from narrative-combat fight packets to dialogue nodes.
+- Validate every node has stable IDs, explicit choices, and no unreachable branch.
+- Keep generated `.yarn` output under a generated/artifact lane until we choose a
+  canonical source-of-truth location.
+
+Future operator command:
+
+```text
+/game dialogue export --encounter boss_duel_demo --format yarn
+/game dialogue validate path/to/file.yarn
+```
+
+### Maps and Encounters: LDtk or Tiled
+
+Use LDtk when entity typing matters most: encounters, doors, features, hazards,
+safe zones, and board nodes with enums. Use Tiled when the first need is broad
+tilemap compatibility.
+
+For this repo, LDtk is the better default for the narrative-combat lane because
+the existing engine is feature/entity-driven:
+- `Feature.kind`
+- `innate_test`
+- `consequence`
+- terrain constraints
+- encounter objective
+
+Initial repo target:
+- Define a small JSON schema for `EncounterMap`.
+- Write a loader that accepts LDtk-style entity JSON first, with a Tiled adapter
+  later if the Godot lane needs it.
+- Validate that map entities can round-trip into `src/narrative_combat.models`.
+
+Future operator command:
+
+```text
+/game map validate path/to/encounter.ldtk
+/game encounter build --map path/to/encounter.ldtk --seed 1337
+```
+
+### 2D Assets: Pixelorama
+
+Pixelorama fits the fast 2D lane: sprites, tilesets, animations, PNG sequences,
+and spritesheets. It is a practical first art tool for the web/Godot slice
+because it produces assets the runtime can consume without a custom art stack.
+
+Initial repo target:
+- Reserve an asset manifest format that records source file, exported frames,
+  spritesheet path, frame size, license, and intended runtime lane.
+- Add a validator that catches missing frames, inconsistent dimensions, and
+  untracked generated outputs.
+
+Future operator command:
+
+```text
+/game asset validate assets/game/manifest.json
+```
+
+### 3D Assets: Blockbench Later
+
+Blockbench is useful when the project needs low-poly 3D models, pixel-textured
+objects, or simple animated props. It is not the first dependency for the current
+narrative-combat vertical slice.
+
+Initial repo target:
+- Defer until there is a specific Godot scene or 3D prop requirement.
+- When adopted, prefer glTF export and validate scale, origin, animation names,
+  and texture paths.
+
+### Audio: Audacity For Prep, Manifest For Runtime
+
+Audacity is the practical audio-prep layer: trim, clean, loop, batch export. The
+repo should not depend on Audacity directly; it should validate the outputs.
+
+Initial repo target:
+- Add audio manifest fields for sample rate, channels, loop flag, duration,
+  loudness notes, source file, and runtime path.
+- Validate presence and basic metadata with a Python script later.
+
+Future operator command:
+
+```text
+/game audio validate assets/audio/manifest.json
+```
+
+### UI and Debug: ImGui Pattern, Browser Operator Surface Now
+
+Dear ImGui matters here less as a direct dependency and more as the product
+pattern: immediate, cheap debug controls should sit next to the running system.
+For this repo, the immediate surface is the web Arena/operator panel and the
+agent bus CLI, not a C++ ImGui dependency.
+
+Initial repo target:
+- Treat `public/arena.html` as the operator/debug surface for game generation.
+- Add command verbs that run deterministic validators and targeted smokes.
+- Keep raw model output collapsible; the default user-facing transcript should
+  show structured operator summaries and command results.
+
+Future operator commands:
+
+```text
+/game smoke narrative-combat
+/game packet render --seed 1337
+/game debug explain-failure artifacts/game/latest.json
+```
+
+## Agent Bus Contract
+
+The agent bus should make game work executable, not more verbose. A model can
+draft a scene, propose a map entity, or suggest a dialogue branch, but the bus
+must turn that into one of these bounded operations:
+
+| Operation | Deterministic check |
+|---|---|
+| Export fight packet | Seeded packet is valid JSON and matches schema |
+| Export dialogue | Branch graph has stable IDs and reachable nodes |
+| Import map | Entities map to known feature/terrain types |
+| Validate assets | Manifest paths exist and dimensions/metadata match |
+| Build runtime | Godot/web target can load referenced files |
+| Smoke play | A tiny encounter runs from input to rendered packet |
+
+No arbitrary shell from the browser. Browser/operator commands stay allowlisted
+and route through backend dispatch, matching the current `/bus`, `/code`, and
+`/cli` guardrail.
+
+## Implemented Slice
+
+The first useful implementation is intentionally small:
+
+1. Add `docs/superpowers/specs/2026-05-23-open-source-game-production-toolchain.md`.
+2. Add `/game` operator-command routing, scoped to read-only or
+   generated-artifact-safe actions.
+3. Implement one deterministic smoke command:
+
+```text
+/game smoke narrative-combat
+```
+
+Expected behavior:
+- Run the existing narrative-combat fixture.
+- Emit a compact operator summary: encounter ID, seed, beat count, winner, price.
+- Link or print the artifact path if a packet is written.
+- Fail closed if the fixture import, schema, or packet render breaks.
+
+## Fences
+
+Do not blur this note into the canonical SCBE architecture.
+
+- Not a new engine mandate. Godot already exists in `game/godot/`; narrative
+  combat already exists in `src/narrative_combat/`.
+- Not an LLM-chat feature. The point is build/test/debug tooling that models can
+  invoke through bounded commands.
+- Not a commitment to adopt all listed tools. Yarn Spinner and LDtk are the first
+  serious candidates because they match current repo data shapes.
+- Not a license to commit generated caches or bulky exports. Source manifests,
+  adapters, and small fixtures belong in repo; generated assets need explicit
+  review.
+
+## Acceptance Criteria
+
+A future implementation of this lane is credible when:
+
+- A designer can author an encounter or dialogue file outside the engine.
+- The repo can import and validate it deterministically.
+- The Arena/operator surface can run the relevant `/game` command.
+- Tests fail on invalid branches, unknown entity types, missing assets, or
+  schema drift.
+- The runtime can load a tiny validated packet without manual glue.

--- a/public/arena.html
+++ b/public/arena.html
@@ -702,7 +702,7 @@
       <input
         class="deal-input"
         id="dealInput"
-        placeholder='Deal to all, or use /bus "task" and /code "intent"...'
+        placeholder='Deal to all, or use /game smoke narrative-combat, /bus, or /code...'
         autocomplete="off"
       />
       <button class="deal-btn" id="dealBtn" onclick="dealToAll()">Deal</button>
@@ -1404,7 +1404,7 @@
           addMessage(
             seatId,
             'synthesis',
-            '[COMMAND HELP]\n/open keys - open provider keys\n/clear - clear seat transcripts\n/bus <agent-bus command> - run safe Agent Bus verbs\n/code <intent> - compile a safe coding harness plan\n/cli <safe command> - run the allowlisted AetherBrowser CLI\nA bare number is treated as a UI selection, not a creative prompt.',
+            '[COMMAND HELP]\n/open keys - open provider keys\n/clear - clear seat transcripts\n/game smoke narrative-combat [--seed N] - run deterministic game smokes\n/bus <agent-bus command> - run safe Agent Bus verbs\n/code <intent> - compile a safe coding harness plan\n/cli <safe command> - run the allowlisted AetherBrowser CLI\nA bare number is treated as a UI selection, not a creative prompt.',
             'local parser'
           );
           return true;
@@ -1431,6 +1431,10 @@
             'harness plan ' + JSON.stringify(value.slice(6).trim()),
             sourceLabel
           );
+          return true;
+        }
+        if (value.startsWith('/game ')) {
+          await runArenaCliCommand('game ' + value.slice(6).trim(), sourceLabel);
           return true;
         }
         if (value.startsWith('/cli ')) {

--- a/public/index.html
+++ b/public/index.html
@@ -642,7 +642,7 @@
       <input
         class="deal-input"
         id="dealInput"
-        placeholder='Deal to all, or use /bus "task" and /code "intent"...'
+        placeholder='Deal to all, or use /game smoke narrative-combat, /bus, or /code...'
         autocomplete="off"
       />
       <button class="deal-btn" id="dealBtn" onclick="dealToAll()">Deal</button>
@@ -1127,7 +1127,7 @@
           addMessage(
             seatId,
             'synthesis',
-            '[COMMAND HELP]\n/clear - clear seat transcripts\n/bus <agent-bus command> - run safe Agent Bus verbs\n/code <intent> - compile a safe coding harness plan\n/cli <safe command> - run the allowlisted AetherBrowser CLI\nA bare number is treated as a UI selection, not a creative prompt.',
+            '[COMMAND HELP]\n/clear - clear seat transcripts\n/game smoke narrative-combat [--seed N] - run deterministic game smokes\n/bus <agent-bus command> - run safe Agent Bus verbs\n/code <intent> - compile a safe coding harness plan\n/cli <safe command> - run the allowlisted AetherBrowser CLI\nA bare number is treated as a UI selection, not a creative prompt.',
             'local parser'
           );
           return true;
@@ -1149,6 +1149,10 @@
             'harness plan ' + JSON.stringify(value.slice(6).trim()),
             sourceLabel
           );
+          return true;
+        }
+        if (value.startsWith('/game ')) {
+          await runArenaCliCommand('game ' + value.slice(6).trim(), sourceLabel);
           return true;
         }
         if (value.startsWith('/cli ')) {

--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -3225,6 +3225,13 @@ def _cli_command_registry() -> list[dict[str, Any]]:
             "example": 'harness plan "fix failing lint in public arena" --permission-mode observe',
         },
         {
+            "cmd": "game smoke narrative-combat [--seed N]",
+            "lane": "game-production",
+            "interop": {"web": True, "python": True, "node": False, "connectors": False},
+            "desc": "Run deterministic game-production smokes through existing narrative tooling.",
+            "example": "game smoke narrative-combat --seed 1337",
+        },
+        {
             "cmd": "momentum run <train_id> [--flow X] [--execute] [--max-parallel N]",
             "lane": "momentum",
             "interop": {"web": True, "python": True, "node": False, "connectors": False},
@@ -3277,6 +3284,7 @@ def _cli_help_text() -> str:
         "  bus verify [events.jsonl]",
         "  bus replay [events.jsonl] [--by-task]",
         '  harness plan "intent..." [--permission-mode observe|assist] [--language python|typescript]',
+        "  game smoke narrative-combat [--seed N]",
         "  momentum run <train_id> [--flow X] [--execute] [--max-parallel N]",
         "  momentum latest [train_id]",
         '  chessboard generate "goal..."',
@@ -3290,6 +3298,7 @@ def _cli_help_text() -> str:
         "  ops tests",
         '  bus run "inspect current repo health" --no-search',
         '  harness plan "add a regression test for the arena command parser"',
+        "  game smoke narrative-combat --seed 1337",
         "  momentum run daily_ops --execute --max-parallel 3",
         '  chessboard generate "Improve long-running agent workflows"',
         "  docs show aetherbrowser-config",
@@ -3357,6 +3366,14 @@ def _cli_parse_flags(parts: list[str]) -> dict[str, Any]:
             continue
         if p == "--language" and i + 1 < len(parts):
             out["language"] = parts[i + 1]
+            i += 2
+            continue
+        if p == "--seed" and i + 1 < len(parts):
+            try:
+                out["seed"] = int(parts[i + 1])
+            except Exception:
+                logger.debug("Suppressed error", exc_info=True)
+                out["seed"] = parts[i + 1]
             i += 2
             continue
         if p == "--tool" and i + 1 < len(parts):
@@ -3504,6 +3521,44 @@ def _cli_harness_plan(rest: list[str]) -> dict[str, Any]:
     return {"ok": True, "lane": "coding-harness", "result": plan}
 
 
+def _cli_game(rest: list[str]) -> dict[str, Any]:
+    if len(rest) < 2 or rest[0].lower() != "smoke":
+        return {"ok": False, "error": "Usage: game smoke narrative-combat [--seed N]"}
+
+    target = rest[1].lower()
+    flags = _cli_parse_flags(rest[2:])
+    if target not in {"narrative-combat", "narrative_combat"}:
+        return {"ok": False, "error": f"Unknown game smoke target: {target}"}
+
+    seed = flags.get("seed", 1337)
+    if not isinstance(seed, int):
+        return {"ok": False, "error": "--seed must be an integer"}
+
+    from src.narrative_combat.director import Director
+    from src.narrative_combat.fixtures import boss_duel_demo
+
+    packet = Director(boss_duel_demo(seed=seed)).run()
+    artifact_dir = ROOT / "artifacts" / "game" / "smokes"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_dir / f"narrative_combat_seed_{seed}.json"
+    artifact_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    aftermath = packet.get("aftermath") if isinstance(packet, dict) else {}
+    path = packet.get("path") if isinstance(packet, dict) else {}
+    result = {
+        "schema": packet.get("schema"),
+        "encounter_id": packet.get("encounter_id"),
+        "seed": packet.get("seed"),
+        "beat_count": len(packet.get("beats", [])),
+        "phases": [beat.get("phase") for beat in packet.get("beats", []) if isinstance(beat, dict)],
+        "winner": aftermath.get("winner") if isinstance(aftermath, dict) else None,
+        "price_paid": aftermath.get("price_paid", []) if isinstance(aftermath, dict) else [],
+        "chosen_path": path.get("chosen", []) if isinstance(path, dict) else [],
+        "artifact": str(artifact_path.relative_to(ROOT)),
+    }
+    return {"ok": True, "lane": "game-production", "result": result}
+
+
 async def _cli_dispatch(parts: list[str]) -> dict[str, Any]:
     if not parts:
         return {"ok": True, "result": _cli_help_text()}
@@ -3558,6 +3613,9 @@ async def _cli_dispatch(parts: list[str]) -> dict[str, Any]:
 
     if cmd in {"harness", "code"}:
         return _cli_harness_plan(rest)
+
+    if cmd == "game":
+        return _cli_game(rest)
 
     if cmd == "momentum":
         if not rest:

--- a/src/narrative_combat/go_board/governor.py
+++ b/src/narrative_combat/go_board/governor.py
@@ -75,7 +75,11 @@ class SearchGovernor:
             results = tuple(self.backend.search(query))
         except Exception:
             results = ()
-        latency_ms = (time.perf_counter() - start) * 1000.0
+        latency_ms = (
+            0.0
+            if isinstance(self.backend, StubSearchBackend)
+            else (time.perf_counter() - start) * 1000.0
+        )
         self._cache[key] = results
         self.audit.append(StudyRecord(query, "allow", self.backend.name, latency_ms, results))
         return results

--- a/tests/aetherbrowser/test_api_server_operator_cli.py
+++ b/tests/aetherbrowser/test_api_server_operator_cli.py
@@ -13,7 +13,9 @@ def test_arena_numeric_input_stays_local_command() -> None:
 
 @pytest.mark.asyncio
 async def test_cli_dispatch_compiles_coding_harness_plan() -> None:
-    result = await api_server._cli_dispatch(["harness", "plan", "explain", "arena", "route"])
+    result = await api_server._cli_dispatch(
+        ["harness", "plan", "explain", "arena", "route"]
+    )
 
     assert result["ok"] is True
     assert result["lane"] == "coding-harness"
@@ -25,20 +27,28 @@ async def test_cli_dispatch_compiles_coding_harness_plan() -> None:
 
 @pytest.mark.asyncio
 async def test_cli_dispatch_rejects_mutating_harness_mode() -> None:
-    result = await api_server._cli_dispatch(["harness", "plan", "delete", "everything", "--permission-mode", "execute"])
+    result = await api_server._cli_dispatch(
+        ["harness", "plan", "delete", "everything", "--permission-mode", "execute"]
+    )
 
     assert result["ok"] is False
     assert "observe, assist" in result["error"]
 
 
 @pytest.mark.asyncio
-async def test_cli_dispatch_agent_bus_uses_allowlisted_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_cli_dispatch_agent_bus_uses_allowlisted_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     seen: dict[str, object] = {}
 
     def fake_run_subprocess(cmd: list[str], timeout: int = 60) -> dict[str, object]:
         seen["cmd"] = cmd
         seen["timeout"] = timeout
-        return {"stdout": '{"perf": null, "reason": "no_events"}', "stderr": "", "exit_code": 0}
+        return {
+            "stdout": '{"perf": null, "reason": "no_events"}',
+            "stderr": "",
+            "exit_code": 0,
+        }
 
     monkeypatch.setattr(api_server, "_run_subprocess", fake_run_subprocess)
 
@@ -46,8 +56,42 @@ async def test_cli_dispatch_agent_bus_uses_allowlisted_subprocess(monkeypatch: p
 
     assert result["ok"] is True
     assert result["lane"] == "agent-bus"
-    assert seen["cmd"] == [api_server.sys.executable, "-m", "agents.agent_bus_cli", "perf"]
+    assert seen["cmd"] == [
+        api_server.sys.executable,
+        "-m",
+        "agents.agent_bus_cli",
+        "perf",
+    ]
     assert seen["timeout"] == 30
+
+
+@pytest.mark.asyncio
+async def test_cli_dispatch_game_smoke_writes_narrative_packet(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(api_server, "ROOT", tmp_path)
+
+    result = await api_server._cli_dispatch(
+        ["game", "smoke", "narrative-combat", "--seed", "1337"]
+    )
+
+    assert result["ok"] is True
+    assert result["lane"] == "game-production"
+    payload = result["result"]
+    assert payload["schema"] == "scbe.narrative_combat.fight.v1"
+    assert payload["encounter_id"] == "boss_duel_demo"
+    assert payload["seed"] == 1337
+    assert payload["beat_count"] >= 1
+    assert payload["winner"] == "Wu Jin"
+    assert (tmp_path / payload["artifact"]).exists()
+
+
+@pytest.mark.asyncio
+async def test_cli_dispatch_game_smoke_rejects_unknown_target() -> None:
+    result = await api_server._cli_dispatch(["game", "smoke", "unbounded-autonomy"])
+
+    assert result["ok"] is False
+    assert "Unknown game smoke target" in result["error"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a fenced game-production toolchain note from the GitHub open-source game tooling article
- add a safe `/game smoke narrative-combat [--seed N]` operator command that renders the existing deterministic narrative-combat fixture and writes an ignored smoke artifact
- expose `/game` in Arena command help/placeholders and add operator CLI regression tests
- fix Go-board narrative determinism by making the offline stub study governor emit stable `0.0` latency

## Test evidence
- `python -m pytest tests\aetherbrowser\test_api_server_operator_cli.py -q` -> 7 passed
- `python -m pytest tests\narrative_combat tests\aetherbrowser\test_api_server_operator_cli.py -q` -> 52 passed
- `npm run lint` -> passed
- `npm run typecheck` -> passed
- `npm test` -> 188 passed, 2 skipped files; 6275 passed, 18 skipped tests
- `npm run build` -> passed
- `python -m py_compile scripts\aetherbrowser\api_server.py src\narrative_combat\go_board\governor.py` -> passed

## Rollback
- Revert this PR to remove the `/game` command and the toolchain note. Generated `artifacts/game/smokes/*.json` files are ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/game smoke narrative-combat` command to the Arena interface, supporting an optional `--seed` parameter for generating reproducible combat scenarios.
  * Updated in-app help documentation to include the new command.

* **Documentation**
  * Added game production toolchain specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->