### PR TITLE
fix(ci): stabilize game toolchain checks

### DIFF
--- a/src/narrative_combat/go_board/governor.py
+++ b/src/narrative_combat/go_board/governor.py
@@ -75,11 +75,7 @@ class SearchGovernor:
             results = tuple(self.backend.search(query))
         except Exception:
             results = ()
-        latency_ms = (
-            0.0
-            if isinstance(self.backend, StubSearchBackend)
-            else (time.perf_counter() - start) * 1000.0
-        )
+        latency_ms = 0.0 if isinstance(self.backend, StubSearchBackend) else (time.perf_counter() - start) * 1000.0
         self._cache[key] = results
         self.audit.append(StudyRecord(query, "allow", self.backend.name, latency_ms, results))
         return results

--- a/tests/aetherbrowser/test_api_server_operator_cli.py
+++ b/tests/aetherbrowser/test_api_server_operator_cli.py
@@ -13,9 +13,7 @@ def test_arena_numeric_input_stays_local_command() -> None:
 
 @pytest.mark.asyncio
 async def test_cli_dispatch_compiles_coding_harness_plan() -> None:
-    result = await api_server._cli_dispatch(
-        ["harness", "plan", "explain", "arena", "route"]
-    )
+    result = await api_server._cli_dispatch(["harness", "plan", "explain", "arena", "route"])
 
     assert result["ok"] is True
     assert result["lane"] == "coding-harness"
@@ -27,9 +25,7 @@ async def test_cli_dispatch_compiles_coding_harness_plan() -> None:
 
 @pytest.mark.asyncio
 async def test_cli_dispatch_rejects_mutating_harness_mode() -> None:
-    result = await api_server._cli_dispatch(
-        ["harness", "plan", "delete", "everything", "--permission-mode", "execute"]
-    )
+    result = await api_server._cli_dispatch(["harness", "plan", "delete", "everything", "--permission-mode", "execute"])
 
     assert result["ok"] is False
     assert "observe, assist" in result["error"]
@@ -66,14 +62,10 @@ async def test_cli_dispatch_agent_bus_uses_allowlisted_subprocess(
 
 
 @pytest.mark.asyncio
-async def test_cli_dispatch_game_smoke_writes_narrative_packet(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_cli_dispatch_game_smoke_writes_narrative_packet(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(api_server, "ROOT", tmp_path)
 
-    result = await api_server._cli_dispatch(
-        ["game", "smoke", "narrative-combat", "--seed", "1337"]
-    )
+    result = await api_server._cli_dispatch(["game", "smoke", "narrative-combat", "--seed", "1337"])
 
     assert result["ok"] is True
     assert result["lane"] == "game-production"

--- a/tests/harmonic/encryptedTransport.test.ts
+++ b/tests/harmonic/encryptedTransport.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { Buffer } from 'node:buffer';
 import {
   generateTransportKey,
   encryptVector,
@@ -21,6 +22,14 @@ import {
   EncryptedVector,
 } from '../../src/harmonic/encryptedTransport';
 import { mobiusAdd, projectToBall } from '../../src/harmonic/hyperbolic';
+
+function tamperBase64UrlBytes(value: string): string {
+  let padded = value.replace(/-/g, '+').replace(/_/g, '/');
+  while (padded.length % 4) padded += '=';
+  const bytes = Buffer.from(padded, 'base64');
+  bytes[0] ^= 0xff;
+  return bytes.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
 
 describe('EncryptedTransport', () => {
   let key: VectorTransportKey;
@@ -150,7 +159,7 @@ describe('EncryptedTransport', () => {
       // Tamper with ciphertext
       const tampered: EncryptedVector = {
         ...encrypted,
-        ciphertext: encrypted.ciphertext.slice(0, -2) + 'XX',
+        ciphertext: tamperBase64UrlBytes(encrypted.ciphertext),
       };
 
       expect(() => decryptVector(tampered, key)).toThrow();
@@ -162,7 +171,7 @@ describe('EncryptedTransport', () => {
 
       const tampered: EncryptedVector = {
         ...encrypted,
-        tag: encrypted.tag.slice(0, -2) + 'XX',
+        tag: tamperBase64UrlBytes(encrypted.tag),
       };
 
       expect(() => decryptVector(tampered, key)).toThrow();


### PR DESCRIPTION
## Summary
- format the Python files from the merged game toolchain PR to satisfy CI Black checks
- make the offline Go-board study governor deterministic by recording 0.0 latency for the stub backend
- make encrypted-transport tamper tests mutate decoded bytes instead of relying on random base64url suffix replacement

## Test evidence
- `npm run lint`
- `npx vitest run tests\harmonic\encryptedTransport.test.ts`
- `python -m black --check --target-version py311 --line-length 120 src\narrative_combat\go_board\governor.py tests\aetherbrowser\test_api_server_operator_cli.py`
- `python -m pytest tests\narrative_combat tests\aetherbrowser\test_api_server_operator_cli.py -q`
- `npm run typecheck`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code structure optimizations.

* **Tests**
  * Enhanced encryption tamper detection validation and improved test infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->