### PR TITLE
docs(geoboard): tighten model-independent dispatch claim

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Architecture Overview
 
 **Core model:** SCBE is a model-agnostic execution board. Any AI proposes an action;
-the board decides whether it is a legal move. Safety holds regardless of model quality
-because the model does not decide what executes — the board does.
+the board decides whether it is a legal move. Dispatch control is model-independent:
+the model proposes, but the board decides what executes.
 
 Pipeline: `state → proposed move → legality check → simulation → receipt → dispatch or deny`
 

--- a/docs/SCBE_AETHERMOORE_ONE_PAGER.md
+++ b/docs/SCBE_AETHERMOORE_ONE_PAGER.md
@@ -11,20 +11,20 @@ recruiters, and reviewers. Last updated 2026-05-23. Canonical source:
 SCBE-AETHERMOORE is a **model-agnostic execution board**: any AI model can
 propose an action, but actions only execute if they are legal moves inside a
 typed workflow space. The board enforces legality — the model does not. This
-removes the dependency on model alignment: even a noisy or adversarial model
-cannot advance system state past an illegal move.
+keeps dispatch control outside the model: even a noisy or adversarial model
+cannot advance system state through an illegal move.
 
-The board runs on hyperbolic geometry (the Poincaré ball model) so adversarial
-drift costs exponentially more than legitimate use. A 14-layer processing
-pipeline emits cryptographic receipts for every gate decision so auditors can
-replay any action months later. The receipt mechanism (GeoSeal) plus the local
-operator console (AetherDesk) plus the mechanical coding mechanism (compile-CA →
+The board uses hyperbolic geometry (the Poincaré ball model) to make drift
+measurable as distance from trusted state. A 14-layer processing pipeline emits
+cryptographic receipts for every gate decision so auditors can replay any
+action months later. The receipt mechanism (GeoSeal) plus the local operator
+console (AetherDesk) plus the mechanical coding mechanism (compile-CA →
 bijective source in Python/TypeScript/Go without an LLM call) together form a
 deployable governance overlay that works in front of any LLM API. Author is a
 self-taught engineer with active SAM.gov / CAGE registration, two DARPA
 submissions on file (CLARA + MATHBAC), and a published prior-art book on KDP
-(ASIN B0GSSFQD9G). Repo is open source; the governance overlay and
-managed-ops services are the revenue surface.
+(ASIN B0GSSFQD9G). Repo is open source; the governance overlay and managed-ops
+services are the revenue surface.
 
 ### 1.1 The GeoBoard execution model
 


### PR DESCRIPTION
## Summary
- tighten the GeoBoard front-door claim from broad safety language to model-independent dispatch control
- keep the legal-move framing while avoiding absolute model-quality and attacker-cost overclaims
- describe hyperbolic geometry as measurable drift from trusted state

## Test evidence
- docs-only change; no runtime tests required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified system architecture documentation to better explain dispatch control flow between model and execution components.
  * Updated product overview to emphasize external dispatch control mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->