### PR TITLE
docs(agent-bus): update README and keywords to v0.3.10 surface

### DIFF
--- a/docs/product/FREE_AI_AGENT_BOARD.md
+++ b/docs/product/FREE_AI_AGENT_BOARD.md
@@ -1,0 +1,159 @@
+# Free AI on Rails: No Custom Model Required
+
+> SCBE makes cheap AI useful by moving intelligence out of the model and into
+> the governed workspace, legal-move system, and audit chain.
+
+---
+
+## The problem with agent platforms today
+
+Models chat. They don't act safely, remember context, or leave clean audit
+trails. Most agent platforms solve this by training a better model. That is
+expensive, fragile, and requires you to trust someone else's alignment work.
+
+SCBE solves it differently.
+
+**Don't replace the model. Put it on rails.**
+
+---
+
+## How it works
+
+```
+Free AI proposes.
+SCBE validates.
+The agent bus executes.
+Receipts prove what happened.
+```
+
+Any LLM can propose an action — which file to ingest, which export to ship,
+which task to run. SCBE controls whether that action is a legal move. The model
+quality determines how good the suggestions are. The board determines what
+actually executes.
+
+---
+
+## 1. No Custom Model Required
+
+SCBE is model-agnostic. You do not need a fine-tuned or specially-aligned model
+to get governed behavior. Bring what you already have:
+
+- **Pollinations** — free, no API key
+- **Ollama** — local, offline, no account
+- **Groq** — fast free-tier inference
+- **OpenAI / Claude / Gemini** — BYOK
+- **Any OpenAI-compatible endpoint**
+
+Use whatever AI you already have. SCBE sits underneath them as the rules
+engine, action bus, audit chain, and workspace memory.
+
+---
+
+## 2. Free/Local First
+
+Pollinations and Ollama can run useful production workflows through SCBE
+because the board supplies all the structure the model lacks:
+
+| What the model can't provide | What SCBE provides |
+|---|---|
+| Memory across runs | Persistent workspace (`00_inbox → 30_exports`) |
+| Proof of what happened | Governance receipts (sha256-anchored, replayable) |
+| Safe action boundaries | Legal-move catalog (only known verbs execute) |
+| Tamper detection | Export + verify chain |
+| Compliance trail | Lineage audit (`formation → ingest → export → verify`) |
+
+A free Ollama model calling `workspace ingest → export → verify` produces a
+cryptographically-auditable handoff package. The free model did not need to
+understand sha256 or tamper detection — SCBE did that.
+
+---
+
+## 3. Model Upgrade Path
+
+Better models improve proposal quality. They do not change the safety or audit
+architecture.
+
+| Tier | Model | What changes |
+|---|---|---|
+| **Free local** | Ollama / Pollinations | Slower, rougher suggestions; same governed execution |
+| **Free cloud** | Groq free-tier | Faster suggestions; same governed execution |
+| **Paid BYOK** | GPT-4o / Claude / Gemini | Higher-quality proposals; same governed execution |
+| **Custom fine-tune** | Your own adapter | Domain-specific suggestions; same governed execution |
+
+The board is the constant. The model is a dial.
+
+Custom model training becomes optional later — useful for narrowing the
+suggestion space in a specific domain, not required for the product to have value.
+
+---
+
+## 4. The Agent Bus: Legal Verbs Only
+
+Models interact with SCBE through a fixed verb catalog. They cannot pass raw
+shell strings or escalate beyond their permitted scope.
+
+**Workspace verbs:**
+
+| Verb | What it does |
+|---|---|
+| `workspace new` | Create an auditable working area |
+| `workspace ingest` | Pull a file in with provenance receipt |
+| `workspace export` | Package work with sha256 manifest |
+| `workspace verify` | Re-hash every file, confirm tamper status |
+| `workspace import` | Cold-restore from a verified export |
+| `workspace lineage` | Read the full chronological audit chain |
+| `workspace report` | Dashboard: folder counts, audit health color |
+
+**Event verbs:**
+
+| Verb | What it does |
+|---|---|
+| `send` | Dispatch one governed task through the harmonic-wall pipeline |
+| `batch` | Sequence of governed tasks, stops on first failure by default |
+| `health` | Backend liveness check |
+
+The model proposes which verb to call and with what arguments. SCBE validates
+that the call is a legal move before it executes. If the proposed move is not in
+the catalog or fails a precondition, it does not execute — period.
+
+---
+
+## 5. Why This Sells
+
+**Same buyer category as agent platforms, eval tools, and code-review
+assistants — but cheaper to start.**
+
+The pitch to a buyer who already has AI fatigue:
+
+> You have a model. It's already expensive. You don't need a different model.
+> You need the thing that makes your model safe to hand tasks to, keeps receipts
+> of what it did, and lets your auditors replay any decision without re-running
+> the model.
+
+**Competitive positioning:**
+
+| What others sell | What SCBE adds |
+|---|---|
+| "Better model" | Model-independent execution control |
+| "Safer fine-tune" | Tamper-evident audit chain regardless of model |
+| "Agent platform" | Governed workspace with legal-move enforcement |
+| "Eval harness" | Production enforcement, not just measurement |
+
+**Pricing consequence:** Because Ollama and Pollinations work out of the box,
+the entry point is zero compute cost. The buyer proves the workflow is valuable
+before spending on a paid model or hosted run. That removes the main objection
+("what if this doesn't work for my use case") before any money changes hands.
+
+---
+
+## The one-line version
+
+> SCBE doesn't replace your AI. It tells your AI what it's allowed to do —
+> and writes down everything that happened.
+
+---
+
+*See also:*
+- `docs/SCBE_AETHERMOORE_ONE_PAGER.md §1.1` — GeoBoard execution model
+- `packages/agent-bus/README.md` — full CLI and TypeScript API reference
+- `docs/SPEC.md` — canonical governance specification

--- a/packages/agent-bus/README.md
+++ b/packages/agent-bus/README.md
@@ -2,9 +2,9 @@
 
 Typed Node surface over the SCBE governed event runner.
 
-This package routes AI, human, and automation events through the existing
-`scripts/system/agentbus_pipe.mjs` runner and returns typed result envelopes for
-Node callers.
+Routes AI, human, and automation events through the SCBE harmonic-wall pipeline and
+returns typed result envelopes. Includes a local HTTP backend, a terminal UI, a full
+workspace audit-chain CLI, and TypeScript APIs for building governed agentic workflows.
 
 ## Install
 
@@ -12,7 +12,7 @@ Node callers.
 npm i scbe-agent-bus
 ```
 
-## Usage
+## Quick start
 
 ```ts
 import { runEvent } from 'scbe-agent-bus';
@@ -26,6 +26,26 @@ const result = await runEvent({
 console.log(result.ok, result.result);
 ```
 
+## CLI reference
+
+```
+scbe-agent-bus serve --port 8787
+scbe-agent-bus ui --base-url http://127.0.0.1:8787
+scbe-agent-bus send --task "review changed files" --task-type review --json
+scbe-agent-bus health --base-url http://127.0.0.1:8787 --json
+scbe-agent-bus workspace new --hint customer-smoke --json
+scbe-agent-bus workspace ingest --workspace-root <path> --source-path <file> --json
+scbe-agent-bus workspace export --workspace-root <path> --json
+scbe-agent-bus workspace import --export-path <path> --json
+scbe-agent-bus workspace verify --export-path <path> --json
+scbe-agent-bus workspace verify --all --workspace-root <path> --json
+scbe-agent-bus workspace lineage --workspace-root <path> --json
+scbe-agent-bus workspace report --workspace-root <path> --json
+scbe-agent-bus upgrade
+```
+
+---
+
 ## Backend
 
 ```bash
@@ -38,34 +58,289 @@ Routes:
 - `POST /v1/events`
 - `POST /v1/batch`
 
-## Frontend
+---
+
+## Terminal UI
 
 ```bash
 scbe-agent-bus ui --base-url http://127.0.0.1:8787
 ```
 
-The terminal frontend can health-check the backend and send governed local-only
-tasks through the bus. It does not expose shell execution.
+Interactive prompt that health-checks the backend and sends governed `local_only` tasks
+through the bus. Does not expose shell execution.
 
-## Hosted Runs and Service Credits
+---
 
-`scbe-agent-bus` is free for local/private routing. Keep sensitive work on your
-machine with `privacy: "local_only"` and use Ollama or deterministic harnesses
-first.
+## Send (one-shot CLI dispatch)
 
-If you want AetherMoore to run a hosted governed pass, report, benchmark, or
-provider/model-backed route, submit a scoped hosted-run request:
+```bash
+scbe-agent-bus send \
+  --task "review the changed training files" \
+  --task-type review \
+  --privacy local_only \
+  --json
+```
+
+Flags: `--task`, `--task-type` (`coding|review|research|governance|training|general`),
+`--privacy` (`local_only|remote_allowed`), `--budget-cents`, `--dispatch-provider`,
+`--operation-command`, `--series-id`, `--json`.
+
+Non-local providers require `SCBE_API_KEY` — see `upgrade`.
+
+---
+
+## Workspace CLI
+
+Workspaces are temporary, auditable working areas with a six-folder shape:
+
+| Folder | Purpose |
+|---|---|
+| `00_inbox` | Raw drops, uploads, imports, unclassified files |
+| `10_work` | Active editable working files |
+| `20_receipts` | Governance receipts, hashes, run records |
+| `30_exports` | Customer-ready packets and handoff bundles |
+| `40_refs` | Non-secret reference files and source notes |
+| `90_tmp` | Scratch files, deleted after offload verification |
+
+Every workspace command writes a structured JSON receipt so the full audit chain is
+replayable without re-running any model.
+
+### `workspace new`
+
+```bash
+scbe-agent-bus workspace new --hint customer-smoke --json
+```
+
+Creates `.aethermoor-bus/workspaces/<id>/` with the six-folder shape and writes
+`SCBE_WORKSPACE_READY=1` into `20_receipts/workspace.json`.
+
+Flags: `--root <parent-dir>`, `--hint <label>`, `--json`.
+
+### `workspace ingest`
+
+```bash
+scbe-agent-bus workspace ingest \
+  --workspace-root .aethermoor-bus/workspaces/<id> \
+  --source-path /path/to/file.csv \
+  --rename report.csv \
+  --json
+```
+
+Copies a file into `00_inbox/` with a sha256 provenance receipt. Source and
+destination hashes must match — mismatch throws. Closes the audit chain at the
+entry point.
+
+Flags: `--workspace-root`, `--source-path`, `--rename`, `--json`.
+
+### `workspace export`
+
+```bash
+scbe-agent-bus workspace export \
+  --workspace-root .aethermoor-bus/workspaces/<id> \
+  --out delivery-v1 \
+  --json
+```
+
+Copies `00_inbox`, `10_work`, `20_receipts`, `40_refs` into
+`30_exports/<export-id>/`, writes a `manifest.json` with per-file sha256, and
+anchors the manifest's sha256 in the export receipt. `30_exports` and `90_tmp`
+are never exported.
+
+Flags: `--workspace-root`, `--out <name>`, `--include <comma-separated>`, `--json`.
+
+### `workspace verify`
+
+```bash
+# Single export
+scbe-agent-bus workspace verify \
+  --export-path .aethermoor-bus/workspaces/<id>/30_exports/<eid> \
+  --json
+
+# All exports in a workspace
+scbe-agent-bus workspace verify \
+  --all \
+  --workspace-root .aethermoor-bus/workspaces/<id> \
+  --json
+```
+
+Re-hashes every file, checks against `manifest.json`, and re-anchors the manifest
+against the export receipt. Detects four tamper classes: `sha256_mismatch`,
+`bytes_mismatch`, `missing_file`, `extra_file`. Exits 1 on any failure — usable as
+a CI gate. Persists a verify receipt so `lineage` picks it up automatically.
+
+Flags: `--export-path` (single) or `--all --workspace-root` (batch), `--no-persist`,
+`--json`.
+
+### `workspace import`
+
+```bash
+scbe-agent-bus workspace import \
+  --export-path .aethermoor-bus/workspaces/<id>/30_exports/<eid> \
+  --target-root /other/dir \
+  --hint restored \
+  --json
+```
+
+Cold-restores a workspace from a previously-exported manifest. Runs verify FIRST and
+refuses (exits 1) to import any export that fails any tamper class. The source's
+`20_receipts/` is not replayed — the new workspace has its own audit chain anchored
+by the import receipt's `source_manifest_sha256`.
+
+Flags: `--export-path`, `--target-root`, `--hint`, `--json`.
+
+### `workspace lineage`
+
+```bash
+scbe-agent-bus workspace lineage \
+  --workspace-root .aethermoor-bus/workspaces/<id> \
+  --json
+```
+
+Walks `20_receipts/`, classifies each receipt by schema, and returns the
+chronological audit chain plus summary counters: `formation_count`, `ingest_count`,
+`export_count`, `verify_count`, `import_count`, `trap_dispatch_count`,
+`trap_redirect_count`, `failed_verifies`, `unverified_exports[]`.
+
+Read-only — never writes.
+
+### `workspace report`
+
+```bash
+scbe-agent-bus workspace report \
+  --workspace-root .aethermoor-bus/workspaces/<id> \
+  --json
+```
+
+Operator dashboard: folder file/byte counts, lineage summary, workspace metadata,
+and an `audit_health` color (`green` = all exports verified clean, `amber` =
+unverified exports present, `red` = any failed verify). Read-only.
+
+---
+
+## Upgrade / hosted dispatch
+
+```bash
+scbe-agent-bus upgrade
+```
+
+Local routing is free. Hosted runs (provider/model-backed, signed reports, stored
+history) require `SCBE_API_KEY`. The `upgrade` command prints the intake path and
+detects whether the key is currently set.
+
+```bash
+export SCBE_API_KEY=your-key   # issued after credit purchase
+scbe-agent-bus send --task "..." --dispatch-provider groq --json
+```
 
 - Hosted run intake: https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html
 - Service credits: https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html
 - Credit top-up: https://ko-fi.com/izdandavis
 
-Credits are only for hosted capacity, report delivery, storage, and
-provider/model usage. Billable provider/model cost is passed through with a
-2-5% SCBE coordination fee.
+Credits cover hosted capacity, report delivery, storage, and provider/model usage.
+Billable provider/model cost is passed through with a 2–5% SCBE coordination fee.
+
+---
+
+## TypeScript API
+
+### `runEvent(event, options?)`
+
+Send one governed event. Spawns the SCBE system CLI synchronously.
+
+```ts
+import { runEvent } from 'scbe-agent-bus';
+
+const result = await runEvent({
+  task: 'Check for drift in the training manifest.',
+  taskType: 'governance',
+  privacy: 'local_only',
+});
+// result.ok, result.result, result.exit_code, result.stderr_tail
+```
+
+### `runBatch(events, options?)`
+
+Send a sequence of events. Stops on first failure unless `continueOnError: true`.
+
+```ts
+import { runBatch } from 'scbe-agent-bus';
+
+const rows = await runBatch([
+  { task: 'step one', taskType: 'coding', privacy: 'local_only' },
+  { task: 'step two', taskType: 'review', privacy: 'local_only' },
+]);
+```
+
+### `startAgentBusServer(options?)` / `postAgentBusEvent(event, options?)`
+
+Embed the server in your own Node process.
+
+```ts
+import { startAgentBusServer, postAgentBusEvent } from 'scbe-agent-bus';
+
+const handle = await startAgentBusServer({ port: 9000 });
+const result = await postAgentBusEvent(
+  { task: 'review', taskType: 'review', privacy: 'local_only' },
+  { baseUrl: handle.url }
+);
+await handle.close();
+```
+
+### Workspace API
+
+All workspace functions mirror the CLI commands and return typed receipts.
+
+```ts
+import {
+  createAgentWorkspace,
+  ingestIntoAgentWorkspace,
+  exportAgentWorkspace,
+  verifyAgentWorkspaceExport,
+  verifyAllAgentWorkspaceExports,
+  importAgentWorkspace,
+  lineageAgentWorkspace,
+  reportAgentWorkspace,
+} from 'scbe-agent-bus';
+
+// Create
+const ws = createAgentWorkspace({ hint: 'smoke-test' });
+
+// Ingest
+const ingest = ingestIntoAgentWorkspace({
+  workspaceRoot: ws.workspace_root,
+  sourcePath: './data.csv',
+});
+
+// Export
+const exp = exportAgentWorkspace({ workspaceRoot: ws.workspace_root });
+
+// Verify (single)
+const verify = verifyAgentWorkspaceExport({ exportPath: exp.export_path });
+
+// Verify (all)
+const verifyAll = verifyAllAgentWorkspaceExports({ workspaceRoot: ws.workspace_root });
+
+// Import (cold-restore from an export)
+const imported = importAgentWorkspace({ exportPath: exp.export_path });
+
+// Lineage
+const lineage = lineageAgentWorkspace({ workspaceRoot: ws.workspace_root });
+// lineage.unverified_exports → exports without a passing verify receipt
+// lineage.trap_dispatch_count / trap_redirect_count → governed inputs that hit DENY
+
+// Report (dashboard)
+const report = reportAgentWorkspace({ workspaceRoot: ws.workspace_root });
+// report.audit_health → 'green' | 'amber' | 'red'
+```
+
+---
 
 ## Notes
 
 - The repo-local runner remains the source of truth.
 - `privacy: "local_only"` should be used for sensitive data.
-- Remote dispatch should be explicit with budget and provider fields.
+- Remote dispatch must be explicit with `dispatchProvider` and a valid `SCBE_API_KEY`.
+- Verify receipts persist by default so `lineage` always reflects the latest state;
+  pass `--no-persist` for read-only CI checks that must not mutate the workspace.
+- `trap_dispatch` lineage entries expose `gate_decision` and `redirect_emitted` so
+  compliance reviewers can spot adversarial inputs without reading the raw envelope.

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -34,7 +34,11 @@
     "governance",
     "harmonic-wall",
     "agent-orchestration",
-    "ai-safety"
+    "ai-safety",
+    "workspace",
+    "audit-chain",
+    "agentic-cli",
+    "chain-of-custody"
   ],
   "author": "Issac Daniel Davis <issdandavis@gmail.com>",
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## Summary

README was frozen at 0.3.1 (serve / ui / hosted-runs only). This brings it to parity with the current 0.3.10 surface.

**Added to README:**
- Full CLI reference table (all 12 command forms)
- Workspace subcommands with flags and examples: `new`, `ingest`, `export`, `import`, `verify`, `verify --all`, `lineage`, `report`
- `send`, `health`, `upgrade` commands
- `runBatch()` API
- Full workspace TypeScript API with usage examples
- Workspace folder shape table
- `trap_dispatch` lineage counter docs

**package.json keywords:** added `workspace`, `audit-chain`, `agentic-cli`, `chain-of-custody` so the npm search surface matches what the package actually does.

## Test plan

- [ ] `npm pack --dry-run` in `packages/agent-bus/` — confirm README is included
- [ ] Read through the rendered README on GitHub and verify no broken command references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded agent-bus documentation with comprehensive CLI reference, API guides, and workspace command documentation
  * Added new product documentation detailing the "Free AI on Rails" concept with model-agnostic support and local-first workflow
  * Updated package keywords for improved discoverability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->