### PR TITLE
ci: automated publish workflow for scbe-aethermoore-cli

### DIFF
--- a/.github/workflows/npm-publish-agent-bus.yml
+++ b/.github/workflows/npm-publish-agent-bus.yml
@@ -1,0 +1,56 @@
+name: publish-agent-bus
+
+on:
+  push:
+    tags:
+      - 'agent-bus/v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.3.11). Must match package.json.'
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish scbe-agent-bus to npm
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/agent-bus
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify version
+        run: |
+          PKG_VER=$(node -p "require('./package.json').version")
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${GITHUB_REF#refs/tags/agent-bus/v}"
+          else
+            TAG="${{ inputs.version }}"
+          fi
+          if [ "$PKG_VER" != "$TAG" ]; then
+            echo "::error::package.json version ($PKG_VER) does not match expected ($TAG)"
+            exit 1
+          fi
+          echo "Publishing scbe-agent-bus@$PKG_VER"
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -1,0 +1,53 @@
+name: publish-cli
+
+on:
+  push:
+    tags:
+      - 'cli/v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 4.3.16). Must match packages/cli/package.json.'
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish scbe-aethermoore-cli to npm
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/cli
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Verify version
+        run: |
+          PKG_VER=$(node -p "require('./package.json').version")
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${GITHUB_REF#refs/tags/cli/v}"
+          else
+            TAG="${{ inputs.version }}"
+          fi
+          if [ "$PKG_VER" != "$TAG" ]; then
+            echo "::error::package.json version ($PKG_VER) does not match expected ($TAG)"
+            exit 1
+          fi
+          echo "Publishing scbe-aethermoore-cli@$PKG_VER"
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/npm-publish-cli.yml` for `packages/cli` (scbe-aethermoore-cli)
- Triggered by `cli/v*` tag push or `workflow_dispatch` with a `version` input
- Verifies `package.json` version matches the tag before publishing
- Uses `NPM_TOKEN` secret (same as agent-bus workflow)

## Test plan
- [ ] Merge this PR
- [ ] Push tag `cli/v4.3.16` → workflow triggers and publishes `scbe-aethermoore-cli@4.3.16`
- [ ] Future releases: `git tag cli/vX.Y.Z && git push origin cli/vX.Y.Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated publishing workflows for `agent-bus` and `cli` npm packages. Publishing is triggered when version tags are pushed or manually dispatched.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->