### PR TITLE
feat(tokenizer): add semantic atom workflow layer

### DIFF
--- a/docs/SEMANTIC_ATOM_TOKENIZER.md
+++ b/docs/SEMANTIC_ATOM_TOKENIZER.md
@@ -1,0 +1,118 @@
+# Semantic Atom Tokenizer
+
+Status: implementation seed, not canonical replacement for SS1 transport.
+
+The semantic atom tokenizer sits above SS1. SS1 remains byte-stable transport. This layer models meaning as explicit semantic atoms that can be embedded, related, refined, and ledgered.
+
+## Core Rule
+
+A semantic token is not just a string and not just a vector.
+
+It is:
+
+- a stable nucleus of invariants
+- contextual orbitals by domain
+- explicit bonds to other concepts
+- domain isotopes
+- code/workflow/physical relations
+- a deterministic embedding vector
+- lineage and refinement metadata
+
+The vector is a projection. The relation tree remains explicit metadata so the system can audit why two meanings were placed near each other.
+
+## Starter Atoms
+
+The first implementation defines three atoms:
+
+| Atom | Nucleus | Code Reading |
+| --- | --- | --- |
+| `FLOW` | directed movement through a medium, path, process, or system | control flow, data flow, event stream, pipeline |
+| `WATER` | fluid material that flows, carries, dissolves, cools, erodes, and changes phase | stream, buffer, pipe, event bus |
+| `BLOCK` | obstruction or constraint that prevents a flow from completing | exception, type error, failed test, policy denial |
+
+These are intentionally small. They prove the structure before broad vocabulary expansion.
+
+## Example
+
+Input:
+
+```text
+Water can flow, but a failed test blocks deploy.
+```
+
+Semantic atom output:
+
+```text
+WATER -> FLOW -> BLOCK
+```
+
+Ledger output preserves:
+
+- original input
+- normalized input
+- semantic ids
+- bucket ids
+- spans
+- input hash
+
+## Workflow Threads
+
+Semantic atoms can also be rendered as modular workflow threads. This is the bridge from meaning tokens into board-play execution.
+
+The first implementation emits:
+
+- `nodes`: semantic atoms with bucket ids and domains
+- `edges`: typed channels between atoms
+- `braidedDomains`: all domains participating in the thread
+- `stateRules`: rule text explaining how state may move across each edge
+- `receipt`: input hash, token count, and edge count
+
+Channel types:
+
+| Channel | Meaning |
+| --- | --- |
+| `pipe` | bounded state movement that preserves payload identity |
+| `funnel` | many inputs narrowing into one validation or dispatch point |
+| `dot_to_dot` | explicit next-node progression |
+| `websocket` | bidirectional session state across a handoff boundary |
+| `agent_handoff` | authority transfer with source, target, task, and receipt |
+| `bifurcation` | a flow splits under a rule; continuing, halted, and exiting lanes are ledgered |
+| `merge` | split lanes realign only when state rules agree on shared invariants |
+
+Example thread:
+
+```text
+Water enters the flow, then a type error blocks the pipeline.
+```
+
+Produces:
+
+```text
+WATER --pipe--> FLOW --bifurcation--> BLOCK --merge--> FLOW
+```
+
+This is the grounded version of braided long workflows, pipes/funnels, underpass/tunnel splits, websocket handoffs, and city-planning flow control. The metaphor is allowed only because the emitted object has explicit nodes, edges, state rules, and receipts.
+
+## Atomic Analogy
+
+The atom analogy is implemented as concrete fields:
+
+| Analogy | Implementation |
+| --- | --- |
+| nucleus | `nucleus.meaning` and `nucleus.invariants` |
+| electrons/orbitals | `orbitals[]` scoped by natural/code/workflow/physical/chemical/governance domains |
+| bonds | `bonds[]` with relation kind, target, domain, and evidence |
+| isotopes | `isotopes[]` for same core meaning in different domains |
+| valence | `atomicProxy.valence` |
+| reaction | future transformation rules between atoms |
+| spectral line | deterministic embedding and bucket id |
+
+## Boundary With SS1
+
+Do not use this as transport encoding.
+
+- SS1: reversible byte/tongue transport
+- Semantic atom tokenizer: meaning object and relation graph
+- Compiler/GeoBoard layer: legal moves, workflows, and execution receipts
+
+The layers can connect, but they should not be collapsed.

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -46,6 +46,32 @@ export {
   SS1Tokenizer,
 } from './ss1.js';
 
+// SS2 Semantic Atom Layer
+export {
+  SEMANTIC_ATOMS,
+  getSemanticAtom,
+  buildRelationTree,
+  embedSemanticAtom,
+  tokenizeSemanticAtoms,
+  buildSemanticLedgerEntry,
+  buildSemanticWorkflowThread,
+  type SemanticDomain,
+  type SemanticRelationKind,
+  type SemanticWorkflowChannel,
+  type SemanticNucleus,
+  type SemanticOrbital,
+  type SemanticBond,
+  type SemanticIsotope,
+  type SemanticCodeRelations,
+  type AtomicProxy,
+  type SemanticAtom,
+  type SemanticToken,
+  type SemanticLedgerEntry,
+  type SemanticWorkflowNode,
+  type SemanticWorkflowEdge,
+  type SemanticWorkflowThread,
+} from './semantic-atom.js';
+
 // Quantum Lattice Integration
 export {
   // Types

--- a/src/tokenizer/semantic-atom.ts
+++ b/src/tokenizer/semantic-atom.ts
@@ -1,0 +1,709 @@
+import { createHash } from 'crypto';
+import type { TongueCode } from './ss1.js';
+
+export type SemanticDomain =
+  | 'natural'
+  | 'code'
+  | 'workflow'
+  | 'physical'
+  | 'chemical'
+  | 'governance';
+
+export type SemanticRelationKind =
+  | 'enables'
+  | 'blocked_by'
+  | 'accelerated_by'
+  | 'transforms_into'
+  | 'analogous_to'
+  | 'contains'
+  | 'guards'
+  | 'inhibits'
+  | 'self_references';
+
+export interface SemanticNucleus {
+  meaning: string;
+  invariants: string[];
+}
+
+export interface SemanticOrbital {
+  domain: SemanticDomain;
+  role: string;
+  terms: string[];
+  stability: number;
+}
+
+export interface SemanticBond {
+  kind: SemanticRelationKind;
+  target: string;
+  domain: SemanticDomain;
+  evidence: string;
+}
+
+export interface SemanticIsotope {
+  domain: SemanticDomain;
+  id: string;
+  examples: string[];
+}
+
+export interface SemanticCodeRelations {
+  patterns: string[];
+  blockers: string[];
+  accelerators: string[];
+  analogies: string[];
+}
+
+export interface AtomicProxy {
+  symbol: string;
+  role: string;
+  valence: number;
+  stableCore: boolean;
+}
+
+export interface SemanticAtom {
+  schemaVersion: 'scbe-semantic-atom-v1';
+  semanticId: string;
+  bucketId: string;
+  surfaceForms: string[];
+  tongues: TongueCode[];
+  nucleus: SemanticNucleus;
+  orbitals: SemanticOrbital[];
+  bonds: SemanticBond[];
+  isotopes: SemanticIsotope[];
+  codeRelations: SemanticCodeRelations;
+  atomicProxy: AtomicProxy;
+  lineage: {
+    preseeded: boolean;
+    version: string;
+    refinements: string[];
+  };
+}
+
+export interface SemanticToken {
+  schemaVersion: 'scbe-semantic-token-v1';
+  surface: string;
+  normalizedSurface: string;
+  semanticId: string;
+  bucketId: string;
+  tongue: TongueCode;
+  span: [number, number];
+  atom: SemanticAtom;
+  embedding: number[];
+  relationTree: {
+    near: string[];
+    far: string[];
+    blockers: string[];
+    selfReference: boolean;
+  };
+}
+
+export interface SemanticLedgerEntry {
+  schemaVersion: 'scbe-semantic-token-ledger-v1';
+  originalInput: string;
+  normalizedInput: string;
+  tokenCount: number;
+  tokens: Array<{
+    surface: string;
+    semanticId: string;
+    bucketId: string;
+    span: [number, number];
+  }>;
+  inputHash: string;
+}
+
+export type SemanticWorkflowChannel =
+  | 'pipe'
+  | 'funnel'
+  | 'dot_to_dot'
+  | 'websocket'
+  | 'agent_handoff'
+  | 'bifurcation'
+  | 'merge';
+
+export interface SemanticWorkflowNode {
+  id: string;
+  tokenIndex: number;
+  semanticId: string;
+  bucketId: string;
+  label: string;
+  domains: SemanticDomain[];
+}
+
+export interface SemanticWorkflowEdge {
+  from: string;
+  to: string;
+  channel: SemanticWorkflowChannel;
+  relation: string;
+  reversible: boolean;
+  stateRule: string;
+}
+
+export interface SemanticWorkflowThread {
+  schemaVersion: 'scbe-semantic-workflow-thread-v1';
+  threadId: string;
+  originalInput: string;
+  tongue: TongueCode;
+  nodes: SemanticWorkflowNode[];
+  edges: SemanticWorkflowEdge[];
+  braidedDomains: SemanticDomain[];
+  stateRules: string[];
+  receipt: {
+    inputHash: string;
+    tokenCount: number;
+    edgeCount: number;
+  };
+}
+
+const DOMAIN_INDEX: Record<SemanticDomain, number> = {
+  natural: 0,
+  code: 1,
+  workflow: 2,
+  physical: 3,
+  chemical: 4,
+  governance: 5,
+};
+
+const RELATION_INDEX: Record<SemanticRelationKind, number> = {
+  enables: 0,
+  blocked_by: 1,
+  accelerated_by: 2,
+  transforms_into: 3,
+  analogous_to: 4,
+  contains: 5,
+  guards: 6,
+  inhibits: 7,
+  self_references: 8,
+};
+
+const TONGUE_INDEX: Record<TongueCode, number> = {
+  KO: 0,
+  AV: 1,
+  RU: 2,
+  CA: 3,
+  UM: 4,
+  DR: 5,
+};
+
+export const SEMANTIC_ATOMS: Record<string, SemanticAtom> = {
+  FLOW: {
+    schemaVersion: 'scbe-semantic-atom-v1',
+    semanticId: 'FLOW',
+    bucketId: 'CORE:MOTION:DIRECTED_CONTINUITY',
+    surfaceForms: [
+      'flow',
+      'flows',
+      'stream',
+      'pipeline',
+      'control flow',
+      'data flow',
+      'event stream',
+    ],
+    tongues: ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'],
+    nucleus: {
+      meaning: 'Directed movement through a medium, path, process, or system.',
+      invariants: ['direction', 'continuity', 'path', 'state_transition'],
+    },
+    orbitals: [
+      {
+        domain: 'natural',
+        role: 'material-motion',
+        terms: ['river', 'current', 'waterfall'],
+        stability: 0.92,
+      },
+      {
+        domain: 'code',
+        role: 'execution-motion',
+        terms: ['control flow', 'data flow', 'event stream'],
+        stability: 0.96,
+      },
+      {
+        domain: 'workflow',
+        role: 'task-motion',
+        terms: ['handoff', 'pipeline', 'approval chain'],
+        stability: 0.9,
+      },
+    ],
+    bonds: [
+      {
+        kind: 'enables',
+        target: 'TRANSPORT',
+        domain: 'workflow',
+        evidence: 'flow carries state from one node to another',
+      },
+      {
+        kind: 'blocked_by',
+        target: 'BLOCK',
+        domain: 'code',
+        evidence: 'an exception or failed precondition interrupts flow',
+      },
+      {
+        kind: 'accelerated_by',
+        target: 'CHANNEL',
+        domain: 'natural',
+        evidence: 'a channel or slope increases directed movement',
+      },
+      {
+        kind: 'analogous_to',
+        target: 'PIPELINE',
+        domain: 'code',
+        evidence: 'input-function-output forms a directed path',
+      },
+    ],
+    isotopes: [
+      {
+        domain: 'natural',
+        id: 'FLOW:NATURAL:WATER',
+        examples: ['water in a river', 'air current'],
+      },
+      {
+        domain: 'code',
+        id: 'FLOW:CODE:CONTROL',
+        examples: ['if branch', 'return path', 'event handler'],
+      },
+      {
+        domain: 'workflow',
+        id: 'FLOW:WORKFLOW:TASK',
+        examples: ['task dependency chain', 'approval handoff'],
+      },
+    ],
+    codeRelations: {
+      patterns: [
+        'input -> function -> output',
+        'event -> handler -> effect',
+        'task -> dependency -> completion',
+      ],
+      blockers: ['exception', 'deadlock', 'type error', 'missing dependency'],
+      accelerators: ['cache', 'parallelism', 'batching', 'index'],
+      analogies: ['water:river :: data:pipeline', 'pressure:flow :: queue_demand:event_processing'],
+    },
+    atomicProxy: { symbol: 'O', role: 'carrier', valence: 2, stableCore: true },
+    lineage: {
+      preseeded: true,
+      version: '2026-05-23',
+      refinements: ['initial atom-like semantic tokenizer layer'],
+    },
+  },
+  WATER: {
+    schemaVersion: 'scbe-semantic-atom-v1',
+    semanticId: 'WATER',
+    bucketId: 'CORE:MATERIAL:FLOWING_SOLVENT',
+    surfaceForms: ['water', 'river', 'rain', 'steam', 'ice', 'liquid'],
+    tongues: ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'],
+    nucleus: {
+      meaning: 'Fluid material that flows, carries, dissolves, cools, erodes, and changes phase.',
+      invariants: ['fluidity', 'cohesion', 'phase_change', 'solvent_behavior'],
+    },
+    orbitals: [
+      {
+        domain: 'physical',
+        role: 'phase-material',
+        terms: ['liquid', 'ice', 'steam'],
+        stability: 0.95,
+      },
+      {
+        domain: 'chemical',
+        role: 'compound',
+        terms: ['H2O', 'solvent', 'polar molecule'],
+        stability: 0.98,
+      },
+      {
+        domain: 'code',
+        role: 'stream-metaphor',
+        terms: ['stream', 'buffer', 'pipe', 'event bus'],
+        stability: 0.86,
+      },
+    ],
+    bonds: [
+      {
+        kind: 'enables',
+        target: 'FLOW',
+        domain: 'natural',
+        evidence: 'liquid water commonly instantiates visible flow',
+      },
+      {
+        kind: 'transforms_into',
+        target: 'ICE',
+        domain: 'physical',
+        evidence: 'phase change under freezing conditions',
+      },
+      {
+        kind: 'transforms_into',
+        target: 'STEAM',
+        domain: 'physical',
+        evidence: 'phase change under heating conditions',
+      },
+      {
+        kind: 'analogous_to',
+        target: 'BUFFER',
+        domain: 'code',
+        evidence: 'both carry state through a bounded channel',
+      },
+    ],
+    isotopes: [
+      { domain: 'physical', id: 'WATER:PHYSICAL:LIQUID', examples: ['river', 'rain', 'container'] },
+      { domain: 'chemical', id: 'WATER:CHEMICAL:H2O', examples: ['solvent', 'reaction product'] },
+      { domain: 'code', id: 'WATER:CODE:STREAM', examples: ['byte stream', 'event stream'] },
+    ],
+    codeRelations: {
+      patterns: ['stream -> buffer -> consumer', 'source -> pipe -> sink'],
+      blockers: ['closed pipe', 'backpressure', 'overflow', 'invalid encoding'],
+      accelerators: ['larger buffer', 'streaming parser', 'pressure/throughput increase'],
+      analogies: [
+        'filter:water :: validator:input_stream',
+        'leak:container :: memory_leak:runtime_boundary',
+      ],
+    },
+    atomicProxy: { symbol: 'H2O', role: 'fluid-carrier', valence: 2, stableCore: true },
+    lineage: {
+      preseeded: true,
+      version: '2026-05-23',
+      refinements: ['initial atom-like semantic tokenizer layer'],
+    },
+  },
+  BLOCK: {
+    schemaVersion: 'scbe-semantic-atom-v1',
+    semanticId: 'BLOCK',
+    bucketId: 'CORE:CONSTRAINT:OBSTRUCTION',
+    surfaceForms: [
+      'block',
+      'blocks',
+      'blocked',
+      'barrier',
+      'dam',
+      'error',
+      'exception',
+      'deny',
+      'failed test',
+    ],
+    tongues: ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'],
+    nucleus: {
+      meaning:
+        'Obstruction, constraint, or interruption that prevents a flow or transition from completing.',
+      invariants: ['obstruction', 'interruption', 'constraint', 'resistance'],
+    },
+    orbitals: [
+      {
+        domain: 'natural',
+        role: 'physical-obstruction',
+        terms: ['dam', 'clog', 'barrier'],
+        stability: 0.9,
+      },
+      {
+        domain: 'code',
+        role: 'execution-obstruction',
+        terms: ['exception', 'type error', 'deadlock'],
+        stability: 0.97,
+      },
+      {
+        domain: 'governance',
+        role: 'policy-obstruction',
+        terms: ['deny', 'failed gate', 'missing approval'],
+        stability: 0.96,
+      },
+    ],
+    bonds: [
+      {
+        kind: 'blocked_by',
+        target: 'FLOW',
+        domain: 'workflow',
+        evidence: 'a block is defined by the flow it interrupts',
+      },
+      {
+        kind: 'guards',
+        target: 'BOUNDARY',
+        domain: 'governance',
+        evidence: 'policy blocks protect boundary conditions',
+      },
+      {
+        kind: 'inhibits',
+        target: 'DISPATCH',
+        domain: 'code',
+        evidence: 'failed tests or policy denial prevent execution',
+      },
+    ],
+    isotopes: [
+      { domain: 'natural', id: 'BLOCK:NATURAL:DAM', examples: ['dam', 'clog', 'wall'] },
+      {
+        domain: 'code',
+        id: 'BLOCK:CODE:ERROR',
+        examples: ['syntax error', 'type error', 'exception'],
+      },
+      {
+        domain: 'governance',
+        id: 'BLOCK:GOVERNANCE:DENY',
+        examples: ['policy denial', 'missing approval'],
+      },
+    ],
+    codeRelations: {
+      patterns: [
+        'condition -> reject -> halt',
+        'test -> failure -> no merge',
+        'policy -> denial -> no dispatch',
+      ],
+      blockers: ['syntax error', 'type error', 'failed test', 'missing secret', 'policy denial'],
+      accelerators: ['clear diagnostic', 'repair suggestion', 'known recovery path'],
+      analogies: ['dam:river :: type_error:pipeline', 'failed_test:merge :: wall:path'],
+    },
+    atomicProxy: { symbol: 'Fe', role: 'boundary', valence: 2, stableCore: true },
+    lineage: {
+      preseeded: true,
+      version: '2026-05-23',
+      refinements: ['initial atom-like semantic tokenizer layer'],
+    },
+  },
+};
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function hashText(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function stableUnitHash(value: string): number {
+  const hex = hashText(value).slice(0, 8);
+  return parseInt(hex, 16) / 0xffffffff;
+}
+
+export function getSemanticAtom(semanticId: string): SemanticAtom | undefined {
+  return SEMANTIC_ATOMS[semanticId.toUpperCase()];
+}
+
+export function buildRelationTree(atom: SemanticAtom): SemanticToken['relationTree'] {
+  const near = new Set<string>();
+  const blockers = new Set<string>();
+  for (const bond of atom.bonds) {
+    if (bond.kind === 'blocked_by' || bond.kind === 'inhibits') {
+      blockers.add(bond.target);
+    } else {
+      near.add(bond.target);
+    }
+  }
+  for (const orbital of atom.orbitals) {
+    for (const term of orbital.terms.slice(0, 3)) {
+      near.add(term);
+    }
+  }
+
+  return {
+    near: [...near].sort(),
+    far:
+      atom.semanticId === 'FLOW'
+        ? ['stasis', 'isolation']
+        : atom.semanticId === 'BLOCK'
+          ? ['continuity']
+          : ['dryness'],
+    blockers: [...blockers].sort(),
+    selfReference: atom.bonds.some((bond) => bond.kind === 'self_references'),
+  };
+}
+
+export function embedSemanticAtom(
+  atom: SemanticAtom,
+  tongue: TongueCode = atom.tongues[0]
+): number[] {
+  const domainMass = atom.orbitals.reduce(
+    (acc, orbital) => acc + DOMAIN_INDEX[orbital.domain] * orbital.stability,
+    0
+  );
+  const relationMass = atom.bonds.reduce(
+    (acc, bond) => acc + RELATION_INDEX[bond.kind] + DOMAIN_INDEX[bond.domain],
+    0
+  );
+  const invariantMass = atom.nucleus.invariants.length;
+  const codeMass = atom.codeRelations.patterns.length + atom.codeRelations.blockers.length;
+  return [
+    stableUnitHash(atom.semanticId),
+    stableUnitHash(atom.bucketId),
+    atom.atomicProxy.valence / 8,
+    atom.atomicProxy.stableCore ? 1 : 0,
+    invariantMass / 8,
+    atom.orbitals.length / 8,
+    atom.bonds.length / 16,
+    atom.isotopes.length / 8,
+    domainMass / Math.max(atom.orbitals.length * 5, 1),
+    relationMass / Math.max(atom.bonds.length * 14, 1),
+    codeMass / 16,
+    TONGUE_INDEX[tongue] / 5,
+  ];
+}
+
+export function tokenizeSemanticAtoms(input: string, tongue: TongueCode = 'KO'): SemanticToken[] {
+  const normalized = normalizeText(input);
+  const matches: SemanticToken[] = [];
+
+  for (const atom of Object.values(SEMANTIC_ATOMS)) {
+    const forms = [...atom.surfaceForms].sort((a, b) => b.length - a.length);
+    for (const form of forms) {
+      const normalizedForm = normalizeText(form);
+      const pattern = new RegExp(
+        `(^|\\b)${normalizedForm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\b|$)`,
+        'g'
+      );
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(normalized)) !== null) {
+        const start = match.index + match[1].length;
+        const end = start + normalizedForm.length;
+        matches.push({
+          schemaVersion: 'scbe-semantic-token-v1',
+          surface: input.slice(start, end) || normalizedForm,
+          normalizedSurface: normalizedForm,
+          semanticId: atom.semanticId,
+          bucketId: atom.bucketId,
+          tongue,
+          span: [start, end],
+          atom,
+          embedding: embedSemanticAtom(atom, tongue),
+          relationTree: buildRelationTree(atom),
+        });
+      }
+    }
+  }
+
+  const ordered = matches.sort(
+    (a, b) => a.span[0] - b.span[0] || b.normalizedSurface.length - a.normalizedSurface.length
+  );
+  const accepted: SemanticToken[] = [];
+  for (const candidate of ordered) {
+    const overlaps = accepted.some(
+      (token) => candidate.span[0] < token.span[1] && token.span[0] < candidate.span[1]
+    );
+    if (!overlaps) {
+      accepted.push(candidate);
+    }
+  }
+  return accepted;
+}
+
+export function buildSemanticLedgerEntry(
+  input: string,
+  tokens = tokenizeSemanticAtoms(input)
+): SemanticLedgerEntry {
+  return {
+    schemaVersion: 'scbe-semantic-token-ledger-v1',
+    originalInput: input,
+    normalizedInput: normalizeText(input),
+    tokenCount: tokens.length,
+    tokens: tokens.map((token) => ({
+      surface: token.surface,
+      semanticId: token.semanticId,
+      bucketId: token.bucketId,
+      span: token.span,
+    })),
+    inputHash: hashText(input),
+  };
+}
+
+function nodeIdFor(token: SemanticToken, index: number): string {
+  return `${token.semanticId.toLowerCase()}-${index}-${token.span[0]}-${token.span[1]}`;
+}
+
+function domainsFor(atom: SemanticAtom): SemanticDomain[] {
+  return [...new Set(atom.orbitals.map((orbital) => orbital.domain))].sort();
+}
+
+function inferWorkflowChannel(from: SemanticToken, to: SemanticToken): SemanticWorkflowChannel {
+  if (from.semanticId === 'WATER' && to.semanticId === 'FLOW') {
+    return 'pipe';
+  }
+  if (from.semanticId === 'FLOW' && to.semanticId === 'BLOCK') {
+    return 'bifurcation';
+  }
+  if (from.semanticId === 'BLOCK' && to.semanticId === 'FLOW') {
+    return 'merge';
+  }
+  if (
+    from.atom.orbitals.some((orbital) => orbital.domain === 'code') &&
+    to.atom.orbitals.some((orbital) => orbital.domain === 'workflow')
+  ) {
+    return 'agent_handoff';
+  }
+  if (
+    from.atom.orbitals.some((orbital) => orbital.domain === 'workflow') ||
+    to.atom.orbitals.some((orbital) => orbital.domain === 'workflow')
+  ) {
+    return 'websocket';
+  }
+  if (to.semanticId === 'BLOCK') {
+    return 'funnel';
+  }
+  return 'dot_to_dot';
+}
+
+function stateRuleFor(channel: SemanticWorkflowChannel): string {
+  switch (channel) {
+    case 'pipe':
+      return 'preserve payload identity while moving state through a bounded channel';
+    case 'funnel':
+      return 'many inputs converge into one narrower validation or dispatch point';
+    case 'dot_to_dot':
+      return 'advance only to the next explicit node in the relation chain';
+    case 'websocket':
+      return 'keep bidirectional session state synchronized across handoff boundary';
+    case 'agent_handoff':
+      return 'transfer authority with explicit source, target, task, and receipt';
+    case 'bifurcation':
+      return 'split flow under a rule and ledger which lanes continue, halt, or exit';
+    case 'merge':
+      return 'realign split lanes only when state rules agree on shared invariants';
+  }
+}
+
+function relationFor(from: SemanticToken, to: SemanticToken): string {
+  const direct = from.atom.bonds.find((bond) => bond.target === to.semanticId);
+  if (direct) {
+    return direct.kind;
+  }
+  const inverse = to.atom.bonds.find((bond) => bond.target === from.semanticId);
+  return inverse ? `inverse:${inverse.kind}` : 'sequence';
+}
+
+export function buildSemanticWorkflowThread(
+  input: string,
+  tongue: TongueCode = 'KO'
+): SemanticWorkflowThread {
+  const tokens = tokenizeSemanticAtoms(input, tongue);
+  const nodes = tokens.map((token, index) => ({
+    id: nodeIdFor(token, index),
+    tokenIndex: index,
+    semanticId: token.semanticId,
+    bucketId: token.bucketId,
+    label: token.normalizedSurface,
+    domains: domainsFor(token.atom),
+  }));
+  const edges: SemanticWorkflowEdge[] = [];
+
+  for (let index = 0; index < tokens.length - 1; index += 1) {
+    const from = tokens[index];
+    const to = tokens[index + 1];
+    const channel = inferWorkflowChannel(from, to);
+    edges.push({
+      from: nodes[index].id,
+      to: nodes[index + 1].id,
+      channel,
+      relation: relationFor(from, to),
+      reversible: channel === 'websocket' || channel === 'merge',
+      stateRule: stateRuleFor(channel),
+    });
+  }
+
+  const braidedDomains = [...new Set(nodes.flatMap((node) => node.domains))].sort();
+  const stateRules = [...new Set(edges.map((edge) => edge.stateRule))];
+  const inputHash = hashText(input);
+
+  return {
+    schemaVersion: 'scbe-semantic-workflow-thread-v1',
+    threadId: hashText(`${tongue}:${input}`).slice(0, 16),
+    originalInput: input,
+    tongue,
+    nodes,
+    edges,
+    braidedDomains,
+    stateRules,
+    receipt: {
+      inputHash,
+      tokenCount: tokens.length,
+      edgeCount: edges.length,
+    },
+  };
+}

--- a/tests/tokenizer/semantic-atom.test.ts
+++ b/tests/tokenizer/semantic-atom.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSemanticLedgerEntry,
+  buildSemanticWorkflowThread,
+  embedSemanticAtom,
+  getSemanticAtom,
+  tokenizeSemanticAtoms,
+} from '../../src/tokenizer/semantic-atom.js';
+
+describe('semantic atom tokenizer', () => {
+  it('defines flow as a stable nucleus with code and natural orbitals', () => {
+    const flow = getSemanticAtom('FLOW');
+
+    expect(flow?.nucleus.invariants).toEqual([
+      'direction',
+      'continuity',
+      'path',
+      'state_transition',
+    ]);
+    expect(flow?.orbitals.map((orbital) => orbital.domain)).toContain('code');
+    expect(flow?.orbitals.map((orbital) => orbital.domain)).toContain('natural');
+    expect(flow?.codeRelations.blockers).toContain('type error');
+    expect(flow?.codeRelations.patterns).toContain('input -> function -> output');
+  });
+
+  it('keeps water and flow related without collapsing them into the same atom', () => {
+    const water = getSemanticAtom('WATER');
+    const flow = getSemanticAtom('FLOW');
+
+    expect(water?.semanticId).toBe('WATER');
+    expect(flow?.semanticId).toBe('FLOW');
+    expect(water?.bonds).toContainEqual(
+      expect.objectContaining({ kind: 'enables', target: 'FLOW', domain: 'natural' })
+    );
+    expect(water?.codeRelations.analogies).toContain('filter:water :: validator:input_stream');
+  });
+
+  it('tokenizes plain language into semantic atoms with relation trees and embeddings', () => {
+    const tokens = tokenizeSemanticAtoms('A type error blocks data flow in the pipeline.', 'AV');
+
+    expect(tokens.map((token) => token.semanticId)).toEqual(
+      expect.arrayContaining(['BLOCK', 'FLOW'])
+    );
+    const block = tokens.find((token) => token.semanticId === 'BLOCK');
+    const flow = tokens.find((token) => token.semanticId === 'FLOW');
+
+    expect(block?.relationTree.near).toContain('BOUNDARY');
+    expect(block?.relationTree.blockers).toContain('DISPATCH');
+    expect(flow?.relationTree.blockers).toContain('BLOCK');
+    expect(flow?.embedding).toHaveLength(12);
+    expect(flow?.embedding[11]).toBeCloseTo(0.2, 10);
+  });
+
+  it('maps the same semantic bucket across tongues while preserving tongue-specific embedding lane', () => {
+    const koFlow = tokenizeSemanticAtoms('control flow', 'KO').find(
+      (token) => token.semanticId === 'FLOW'
+    );
+    const avFlow = tokenizeSemanticAtoms('control flow', 'AV').find(
+      (token) => token.semanticId === 'FLOW'
+    );
+
+    expect(koFlow?.bucketId).toBe(avFlow?.bucketId);
+    expect(koFlow?.embedding.slice(0, 11)).toEqual(avFlow?.embedding.slice(0, 11));
+    expect(koFlow?.embedding[11]).not.toBe(avFlow?.embedding[11]);
+  });
+
+  it('builds a ledger entry that preserves original input and selected semantic changes', () => {
+    const input = 'Water can flow, but a failed test blocks deploy.';
+    const tokens = tokenizeSemanticAtoms(input, 'RU');
+    const ledger = buildSemanticLedgerEntry(input, tokens);
+
+    expect(ledger.originalInput).toBe(input);
+    expect(ledger.normalizedInput).toBe('water can flow, but a failed test blocks deploy.');
+    expect(ledger.tokenCount).toBeGreaterThanOrEqual(3);
+    expect(ledger.tokens.map((token) => token.semanticId)).toEqual(
+      expect.arrayContaining(['WATER', 'FLOW', 'BLOCK'])
+    );
+    expect(ledger.inputHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('uses deterministic embeddings for the same atom and tongue', () => {
+    const block = getSemanticAtom('BLOCK');
+    expect(block).toBeDefined();
+
+    const first = embedSemanticAtom(block!, 'DR');
+    const second = embedSemanticAtom(block!, 'DR');
+    expect(first).toEqual(second);
+  });
+
+  it('builds braided workflow threads from semantic atoms and typed flow channels', () => {
+    const thread = buildSemanticWorkflowThread(
+      'Water enters the flow, then a block redirects the pipeline.',
+      'KO'
+    );
+
+    expect(thread.schemaVersion).toBe('scbe-semantic-workflow-thread-v1');
+    expect(thread.nodes.map((node) => node.semanticId)).toEqual(['WATER', 'FLOW', 'BLOCK', 'FLOW']);
+    expect(thread.edges.map((edge) => edge.channel)).toEqual(['pipe', 'bifurcation', 'merge']);
+    expect(thread.edges[1].stateRule).toBe(
+      'split flow under a rule and ledger which lanes continue, halt, or exit'
+    );
+    expect(thread.edges[2].reversible).toBe(true);
+    expect(thread.braidedDomains).toEqual(expect.arrayContaining(['code', 'natural', 'workflow']));
+    expect(thread.receipt.edgeCount).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an SS2-style semantic atom tokenizer layer above SS1 transport.
- Defines starter atoms for FLOW, WATER, and BLOCK with nuclei, orbitals, bonds, isotopes, code relations, deterministic embeddings, and ledger output.
- Adds SemanticWorkflowThread objects for braided workflow channels: pipe, funnel, dot_to_dot, websocket, agent_handoff, bifurcation, and merge.
- Documents the SS1 vs semantic atom vs GeoBoard/compiler boundary.

## Test Evidence
- npx vitest run tests/tokenizer/semantic-atom.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test

## Rollback
- Revert this PR to remove the semantic atom layer and exports. SS1 transport remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semantic atom tokenization layer with support for structured meaning representation, including nucleus/orbital/bond/isotope definitions, embedding vectors, and workflow threading.

* **Documentation**
  * Added comprehensive specification for the semantic atom layer architecture, including domain-scoped orbitals, explicit relations, workflow contexts, and ledger components.

* **Tests**
  * Added test suite validating semantic tokenization, embedding consistency, ledger generation, and workflow thread construction across multiple language contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->