### PR TITLE
feat(tokenizer): bridge semantic atoms to workflow threads and code IR

### DIFF
--- a/docs/SEMANTIC_ATOM_TOKENIZER.md
+++ b/docs/SEMANTIC_ATOM_TOKENIZER.md
@@ -24,11 +24,12 @@ The vector is a projection. The relation tree remains explicit metadata so the s
 
 The first implementation defines three atoms:
 
-| Atom | Nucleus | Code Reading |
-| --- | --- | --- |
-| `FLOW` | directed movement through a medium, path, process, or system | control flow, data flow, event stream, pipeline |
-| `WATER` | fluid material that flows, carries, dissolves, cools, erodes, and changes phase | stream, buffer, pipe, event bus |
-| `BLOCK` | obstruction or constraint that prevents a flow from completing | exception, type error, failed test, policy denial |
+| Atom        | Nucleus                                                                            | Code Reading                                                    |
+| ----------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `FLOW`      | directed movement through a medium, path, process, or system                       | control flow, data flow, event stream, pipeline                 |
+| `WATER`     | fluid material that flows, carries, dissolves, cools, erodes, and changes phase    | stream, buffer, pipe, event bus                                 |
+| `BLOCK`     | obstruction or constraint that prevents a flow from completing                     | exception, type error, failed test, policy denial               |
+| `TRANSFORM` | bounded operation that changes representation or state while preserving invariants | function, arithmetic operation, compiler pass, verified rewrite |
 
 These are intentionally small. They prove the structure before broad vocabulary expansion.
 
@@ -69,15 +70,15 @@ The first implementation emits:
 
 Channel types:
 
-| Channel | Meaning |
-| --- | --- |
-| `pipe` | bounded state movement that preserves payload identity |
-| `funnel` | many inputs narrowing into one validation or dispatch point |
-| `dot_to_dot` | explicit next-node progression |
-| `websocket` | bidirectional session state across a handoff boundary |
-| `agent_handoff` | authority transfer with source, target, task, and receipt |
-| `bifurcation` | a flow splits under a rule; continuing, halted, and exiting lanes are ledgered |
-| `merge` | split lanes realign only when state rules agree on shared invariants |
+| Channel         | Meaning                                                                        |
+| --------------- | ------------------------------------------------------------------------------ |
+| `pipe`          | bounded state movement that preserves payload identity                         |
+| `funnel`        | many inputs narrowing into one validation or dispatch point                    |
+| `dot_to_dot`    | explicit next-node progression                                                 |
+| `websocket`     | bidirectional session state across a handoff boundary                          |
+| `agent_handoff` | authority transfer with source, target, task, and receipt                      |
+| `bifurcation`   | a flow splits under a rule; continuing, halted, and exiting lanes are ledgered |
+| `merge`         | split lanes realign only when state rules agree on shared invariants           |
 
 Example thread:
 
@@ -93,19 +94,76 @@ WATER --pipe--> FLOW --bifurcation--> BLOCK --merge--> FLOW
 
 This is the grounded version of braided long workflows, pipes/funnels, underpass/tunnel splits, websocket handoffs, and city-planning flow control. The metaphor is allowed only because the emitted object has explicit nodes, edges, state rules, and receipts.
 
+## Cross-Language Code Bridge
+
+`src/tokenizer/semantic_code_bridge.py` connects the semantic atom layer to the existing code-weight packet system.
+
+Current proof:
+
+- Python, TypeScript, Rust, and C implementations of the same `add(a, b)` function produce the same `interchange_key`.
+- Each language still keeps its own source hash, lexical tokens, transport tongue, and transport token hash.
+- The shared operation path maps into semantic atoms:
+
+```text
+function_definition/2 -> return_flow -> arithmetic:add/2
+FLOW -> FLOW -> TRANSFORM
+```
+
+This proves semantic realignment across language-specific syntax while preserving source-specific packets.
+
+## Aperiodic Token Realignment
+
+Aperiodic token realignment is a governance pass over token boundaries and semantic weights. It lets the substrate move without becoming noise.
+
+Definition:
+
+```text
+T_n = Align(BaseTokenize(x), phase_n, drift_n, pressure_n)
+```
+
+Where:
+
+- `BaseTokenize(x)` is SS1, byte/subword, or another tokenizer surface.
+- `phase_n` is a deterministic phase offset derived from logged context, not an unrecorded random value.
+- `drift_n` is the detected semantic or structural deviation.
+- `pressure_n` is the governance pressure from the harmonic wall, route checks, or quarantine rules.
+- `T_n` is the realigned token stream with receipts.
+
+The point is not to make the tokenizer unpredictable to the verifier. The point is to make it non-locking to an attacker while remaining reproducible to the ledger.
+
+Checks before re-alignment:
+
+| Check                  | Meaning                                                           | Possible action                                |
+| ---------------------- | ----------------------------------------------------------------- | ---------------------------------------------- |
+| boundary instability   | suspicious or lossy token splits                                  | split, merge, or route through byte transport  |
+| semantic drift         | meaning diverges from prior context or declared task              | re-weight atoms, add review edge, quarantine   |
+| attack rhythm          | repeated prompt-injection cadence or exploitable phrase structure | rotate tongue mapping or isolate span          |
+| entropy anomaly        | stream is too structured or too chaotic for the claimed surface   | lower trust, preserve raw bytes, add receipt   |
+| tongue mismatch        | token stream routes to the wrong symbolic chamber                 | remap chamber or force source-language packet  |
+| binary/hexa loss check | encoded view cannot reconstruct the source bytes or operation     | deny transform, keep source packet, quarantine |
+
+Data-loss rule: every realignment must carry the original bytes, source token spans, semantic atoms, emitted form, hashes, and a loss classification. Binary and hexadecimal compiler lanes are useful only as proof surfaces if they preserve this receipt chain.
+
+Current boundary:
+
+- This is not yet a full source-code compiler.
+- It does not yet generate target-language code.
+- It does not yet prove arbitrary Turing-complete equivalence.
+- It proves the bridge layer: language-specific packets can bifurcate, align on a shared semantic operation signature, and preserve enough source evidence for verification.
+
 ## Atomic Analogy
 
 The atom analogy is implemented as concrete fields:
 
-| Analogy | Implementation |
-| --- | --- |
-| nucleus | `nucleus.meaning` and `nucleus.invariants` |
+| Analogy            | Implementation                                                                    |
+| ------------------ | --------------------------------------------------------------------------------- |
+| nucleus            | `nucleus.meaning` and `nucleus.invariants`                                        |
 | electrons/orbitals | `orbitals[]` scoped by natural/code/workflow/physical/chemical/governance domains |
-| bonds | `bonds[]` with relation kind, target, domain, and evidence |
-| isotopes | `isotopes[]` for same core meaning in different domains |
-| valence | `atomicProxy.valence` |
-| reaction | future transformation rules between atoms |
-| spectral line | deterministic embedding and bucket id |
+| bonds              | `bonds[]` with relation kind, target, domain, and evidence                        |
+| isotopes           | `isotopes[]` for same core meaning in different domains                           |
+| valence            | `atomicProxy.valence`                                                             |
+| reaction           | future transformation rules between atoms                                         |
+| spectral line      | deterministic embedding and bucket id                                             |
 
 ## Boundary With SS1
 

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -47,6 +47,11 @@ export {
 } from './ss1.js';
 
 // SS2 Semantic Atom Layer
+// NOTE: SemanticWorkflowThread is intentionally NOT re-exported from
+// semantic-atom.js here. The name is claimed by the richer
+// semantic-workflow-thread.ts module below (schema 'scbe-workflow-thread-v1').
+// Callers that need the simpler SemanticWorkflowThread from semantic-atom.ts
+// can import it directly from './semantic-atom.js'.
 export {
   SEMANTIC_ATOMS,
   getSemanticAtom,
@@ -69,8 +74,26 @@ export {
   type SemanticLedgerEntry,
   type SemanticWorkflowNode,
   type SemanticWorkflowEdge,
-  type SemanticWorkflowThread,
 } from './semantic-atom.js';
+
+// SS3 Semantic Workflow Thread — multi-lane highway model
+export {
+  // Builder class
+  WorkflowThreadBuilder,
+
+  // Factory and utilities
+  createWorkflowThread,
+  serializeThread,
+  validateThread,
+
+  // Types
+  type ThreadEdgeKind,
+  type ThreadNode,
+  type ThreadEdge,
+  type TunnelSegment,
+  type WorkflowThreadReceipt,
+  type SemanticWorkflowThread,
+} from './semantic-workflow-thread.js';
 
 // Quantum Lattice Integration
 export {

--- a/src/tokenizer/semantic-atom.ts
+++ b/src/tokenizer/semantic-atom.ts
@@ -282,6 +282,102 @@ export const SEMANTIC_ATOMS: Record<string, SemanticAtom> = {
       refinements: ['initial atom-like semantic tokenizer layer'],
     },
   },
+  TRANSFORM: {
+    schemaVersion: 'scbe-semantic-atom-v1',
+    semanticId: 'TRANSFORM',
+    bucketId: 'CORE:OPERATION:STATE_CHANGE',
+    surfaceForms: [
+      'transform',
+      'transforms',
+      'change',
+      'convert',
+      'compile',
+      'compute',
+      'add',
+      'subtract',
+      'multiply',
+      'divide',
+      'map',
+    ],
+    tongues: ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'],
+    nucleus: {
+      meaning:
+        'A bounded operation that changes representation or state while preserving required invariants.',
+      invariants: ['input_state', 'operation', 'output_state', 'preservation_rule'],
+    },
+    orbitals: [
+      {
+        domain: 'code',
+        role: 'operation',
+        terms: ['function call', 'arithmetic', 'compiler pass'],
+        stability: 0.96,
+      },
+      {
+        domain: 'workflow',
+        role: 'work-step',
+        terms: ['convert', 'compile', 'process'],
+        stability: 0.92,
+      },
+      {
+        domain: 'chemical',
+        role: 'reaction',
+        terms: ['reactants', 'products', 'conservation'],
+        stability: 0.9,
+      },
+    ],
+    bonds: [
+      {
+        kind: 'enables',
+        target: 'FLOW',
+        domain: 'workflow',
+        evidence: 'transforms move state from one valid representation to another',
+      },
+      {
+        kind: 'guards',
+        target: 'BLOCK',
+        domain: 'governance',
+        evidence: 'invalid transforms must be blocked by invariant checks',
+      },
+      {
+        kind: 'analogous_to',
+        target: 'REACTION',
+        domain: 'chemical',
+        evidence: 'reactants become products while conservation rules hold',
+      },
+    ],
+    isotopes: [
+      {
+        domain: 'code',
+        id: 'TRANSFORM:CODE:FUNCTION',
+        examples: ['add(a,b)', 'parse(input)', 'compile(source)'],
+      },
+      {
+        domain: 'workflow',
+        id: 'TRANSFORM:WORKFLOW:PROCESS',
+        examples: ['ingest', 'normalize', 'export'],
+      },
+      { domain: 'chemical', id: 'TRANSFORM:CHEMICAL:REACTION', examples: ['2H2 + O2 -> 2H2O'] },
+    ],
+    codeRelations: {
+      patterns: [
+        'input -> transform -> output',
+        'source -> compiler_pass -> artifact',
+        'operands -> operator -> result',
+      ],
+      blockers: ['invariant violation', 'type mismatch', 'unbalanced transformation'],
+      accelerators: ['cached intermediate', 'compiler IR', 'verified rewrite'],
+      analogies: [
+        'reaction:chemistry :: function:code',
+        'compiler_pass:source :: catalyst:reaction',
+      ],
+    },
+    atomicProxy: { symbol: 'C', role: 'operator', valence: 4, stableCore: true },
+    lineage: {
+      preseeded: true,
+      version: '2026-05-23',
+      refinements: ['added to ground cross-language operation signatures into semantic atoms'],
+    },
+  },
   WATER: {
     schemaVersion: 'scbe-semantic-atom-v1',
     semanticId: 'WATER',

--- a/src/tokenizer/semantic-workflow-thread.ts
+++ b/src/tokenizer/semantic-workflow-thread.ts
@@ -1,0 +1,879 @@
+/**
+ * @file semantic-workflow-thread.ts
+ * @module tokenizer/semantic-workflow-thread
+ * @layer L1, L14
+ *
+ * SemanticWorkflowThread — models workflow as a multi-lane highway.
+ *
+ * Structural primitives:
+ *   Thread     = a directed workflow with multiple parallel lanes
+ *   Pipe       = linear sequential flow, A→B→C
+ *   Funnel     = N:1 convergence, many lanes merge to one
+ *   Bifurcate  = 1:N split, one lane becomes many
+ *   Merge      = bijective re-alignment of diverged branches via shared key
+ *   Websocket  = bidirectional channel between two nodes
+ *   Handoff    = agent-to-agent transfer, tongue/domain changes
+ *   Tunnel     = hidden processing context (lanes go below grade)
+ *   Ramp       = side-path entry/exit from main thread
+ *
+ * Sacred Tongue routing labels (labels only, no logic):
+ *   KO = intent/origin
+ *   AV = dispatch/motion
+ *   RU = governance/rule-check
+ *   CA = verify/harmony/convergence
+ *   UM = scan/intake
+ *   DR = receipt/lineage/record
+ */
+
+import { createHash } from 'crypto';
+import type { TongueCode } from './ss1.js';
+import type { SemanticDomain } from './semantic-atom.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ThreadEdgeKind =
+  | 'pipe' // A→B linear, one-in one-out
+  | 'funnel' // N→1 convergence
+  | 'bifurcate' // 1→N split
+  | 'websocket' // bidirectional A↔B
+  | 'handoff' // agent-to-agent, tongue/domain changes
+  | 'merge' // bijective re-alignment of diverged branches
+  | 'ramp_in' // side path joins main thread
+  | 'ramp_out' // lane exits to side path
+  | 'tunnel_enter' // thread enters hidden processing context
+  | 'tunnel_exit'; // thread emerges from processing context
+
+export interface ThreadNode {
+  id: string;
+  label: string;
+  semanticAtomId: string; // e.g. 'FLOW', 'GOVERNANCE', 'VERIFY'
+  tongue: TongueCode;
+  domain: SemanticDomain;
+  laneIndex: number; // horizontal lane position (0-based)
+  depth: number; // vertical level: 0=surface, negative=below grade (tunnel), positive=elevated
+  carriedState: Record<string, unknown>;
+}
+
+export interface ThreadEdge {
+  id: string;
+  kind: ThreadEdgeKind;
+  from: string; // source node id
+  to: string | string[]; // target node id(s) — array for bifurcate/funnel
+  bijectiveKey?: string; // shared key for bifurcate+merge pairs; used for re-alignment check
+  ruleGuard?: string; // rule that must hold for this edge to fire
+  metadata: Record<string, unknown>;
+}
+
+export interface TunnelSegment {
+  id: string;
+  label: string;
+  depth: number; // how far below grade (negative depth)
+  inboundNodes: string[]; // nodes entering the tunnel
+  outboundNodes: string[]; // nodes exiting the tunnel
+  sideExits: string[]; // nodes that leave via ramp_out inside the tunnel
+  emergentNodes: string[]; // nodes that appear inside the tunnel without a corresponding inbound
+  internalMerges: Array<{ fromNodes: string[]; toNode: string; bijectiveKey: string }>;
+}
+
+export interface WorkflowThreadReceipt {
+  schema: 'scbe.workflow_thread.v1';
+  threadId: string;
+  label: string;
+  tongue: TongueCode;
+  nodeCount: number;
+  edgeCount: number;
+  tunnelCount: number;
+  laneCount: number;
+  depthRange: [number, number]; // [min depth, max depth]
+  bijectiveKeys: string[];
+  handoffCount: number;
+  websocketCount: number;
+  createdAt: string;
+  threadSha256: string; // sha256 of canonical JSON of nodes+edges
+}
+
+/**
+ * SemanticWorkflowThread (builder output form).
+ *
+ * NOTE: The name `SemanticWorkflowThread` is also exported from
+ * `./semantic-atom.js` under schema `'scbe-semantic-workflow-thread-v1'`.
+ * That is a different, simpler interface used for text-tokenization workflow
+ * graphs. This interface (schema `'scbe-workflow-thread-v1'`) represents a
+ * full multi-lane highway with tunnels, bijective merge verification, and
+ * receipt generation. They coexist; when you import from index.ts this one
+ * takes precedence.
+ */
+export interface SemanticWorkflowThread {
+  schemaVersion: 'scbe-workflow-thread-v1';
+  threadId: string;
+  label: string;
+  tongue: TongueCode;
+  nodes: Map<string, ThreadNode>;
+  edges: ThreadEdge[];
+  tunnels: TunnelSegment[];
+}
+
+// ============================================================================
+// Builder
+// ============================================================================
+
+export class WorkflowThreadBuilder {
+  private thread: SemanticWorkflowThread;
+  private nextLane: number = 0;
+  private edgeCounter: number = 0;
+  private nodeCounter: number = 0;
+
+  // Track which bijectiveKey each node inherited (set by bifurcate, cleared by merge)
+  private nodeKeyMap: Map<string, string> = new Map();
+
+  // Track open tunnels: tunnelId -> { segment, baseDepth, trackedInboundSet }
+  private openTunnels: Map<
+    string,
+    { segment: TunnelSegment; depth: number; inboundSet: Set<string> }
+  > = new Map();
+
+  // Track which nodes were created while a tunnel was open
+  private tunnelCreatedNodes: Map<string, string> = new Map(); // nodeId -> tunnelId
+
+  constructor(label: string, tongue: TongueCode) {
+    this.thread = {
+      schemaVersion: 'scbe-workflow-thread-v1',
+      threadId: this._genId('thread'),
+      label,
+      tongue,
+      nodes: new Map(),
+      edges: [],
+      tunnels: [],
+    };
+  }
+
+  // --------------------------------------------------------------------------
+  // Private helpers
+  // --------------------------------------------------------------------------
+
+  private _genId(prefix: string): string {
+    return `${prefix}-${Date.now().toString(36)}-${(++this.nodeCounter).toString(36).padStart(4, '0')}`;
+  }
+
+  private _genEdgeId(): string {
+    return `edge-${Date.now().toString(36)}-${(++this.edgeCounter).toString(36).padStart(4, '0')}`;
+  }
+
+  private _activeTunnelDepth(): number {
+    if (this.openTunnels.size === 0) return 0;
+    // Use the deepest open tunnel
+    let minDepth = 0;
+    for (const { depth } of this.openTunnels.values()) {
+      if (depth < minDepth) minDepth = depth;
+    }
+    return minDepth;
+  }
+
+  private _registerInTunnel(nodeId: string): void {
+    for (const [tunnelId, { inboundSet }] of this.openTunnels.entries()) {
+      if (!inboundSet.has(nodeId)) {
+        this.tunnelCreatedNodes.set(nodeId, tunnelId);
+      }
+    }
+  }
+
+  private addNode(opts: Omit<ThreadNode, 'id'>): string {
+    const id = this._genId('node');
+    const depth = this._activeTunnelDepth() !== 0 ? this._activeTunnelDepth() : opts.depth;
+    const node: ThreadNode = { ...opts, id, depth };
+    this.thread.nodes.set(id, node);
+    this._registerInTunnel(id);
+    return id;
+  }
+
+  private addEdge(opts: Omit<ThreadEdge, 'id'>): string {
+    const id = this._genEdgeId();
+    const edge: ThreadEdge = { ...opts, id };
+    this.thread.edges.push(edge);
+    return id;
+  }
+
+  // --------------------------------------------------------------------------
+  // Public builder methods
+  // --------------------------------------------------------------------------
+
+  /**
+   * Seed (create root node): adds the first node to the thread.
+   * All other builder methods require a pre-existing node id; call this once
+   * (or more) to establish root nodes before chaining.
+   * Returns the new node id.
+   */
+  seed(
+    atomId: string,
+    opts?: {
+      label?: string;
+      tongue?: TongueCode;
+      domain?: SemanticDomain;
+      laneIndex?: number;
+      state?: Record<string, unknown>;
+    }
+  ): string {
+    return this.addNode({
+      label: opts?.label ?? atomId,
+      semanticAtomId: atomId,
+      tongue: opts?.tongue ?? this.thread.tongue,
+      domain: opts?.domain ?? 'workflow',
+      laneIndex: opts?.laneIndex ?? this.nextLane++,
+      depth: 0,
+      carriedState: opts?.state ?? {},
+    });
+  }
+
+  /**
+   * Linear pipe: creates a new node downstream of fromId.
+   * Returns the new node id.
+   */
+  pipe(
+    fromId: string,
+    atomId: string,
+    opts?: {
+      label?: string;
+      tongue?: TongueCode;
+      domain?: SemanticDomain;
+      state?: Record<string, unknown>;
+      ruleGuard?: string;
+    }
+  ): string {
+    const from = this.thread.nodes.get(fromId);
+    if (!from) throw new Error(`pipe: source node '${fromId}' not found`);
+
+    const toId = this.addNode({
+      label: opts?.label ?? atomId,
+      semanticAtomId: atomId,
+      tongue: opts?.tongue ?? from.tongue,
+      domain: opts?.domain ?? from.domain,
+      laneIndex: from.laneIndex,
+      depth: from.depth,
+      carriedState: opts?.state ?? {},
+    });
+
+    // Propagate bijectiveKey along pipe chains
+    const inheritedKey = this.nodeKeyMap.get(fromId);
+    if (inheritedKey) this.nodeKeyMap.set(toId, inheritedKey);
+
+    this.addEdge({
+      kind: 'pipe',
+      from: fromId,
+      to: toId,
+      ruleGuard: opts?.ruleGuard,
+      metadata: {},
+    });
+
+    return toId;
+  }
+
+  /**
+   * Bifurcate: splits one node into N branches.
+   * Each branch gets a new lane. All edges carry the bijectiveKey.
+   * Returns array of new node ids (one per branch).
+   */
+  bifurcate(
+    fromId: string,
+    branches: Array<{
+      atomId: string;
+      label?: string;
+      tongue?: TongueCode;
+      domain?: SemanticDomain;
+      state?: Record<string, unknown>;
+    }>,
+    bijectiveKey: string
+  ): string[] {
+    const from = this.thread.nodes.get(fromId);
+    if (!from) throw new Error(`bifurcate: source node '${fromId}' not found`);
+
+    const branchIds: string[] = [];
+
+    for (const branch of branches) {
+      const laneIndex = this.nextLane++;
+      const toId = this.addNode({
+        label: branch.label ?? branch.atomId,
+        semanticAtomId: branch.atomId,
+        tongue: branch.tongue ?? from.tongue,
+        domain: branch.domain ?? from.domain,
+        laneIndex,
+        depth: from.depth,
+        carriedState: branch.state ?? {},
+      });
+
+      this.nodeKeyMap.set(toId, bijectiveKey);
+      branchIds.push(toId);
+    }
+
+    this.addEdge({
+      kind: 'bifurcate',
+      from: fromId,
+      to: branchIds,
+      bijectiveKey,
+      metadata: {},
+    });
+
+    return branchIds;
+  }
+
+  /**
+   * Funnel: N nodes converge into one new node.
+   * Returns the new node id.
+   */
+  funnel(
+    fromIds: string[],
+    atomId: string,
+    opts?: {
+      label?: string;
+      tongue?: TongueCode;
+      domain?: SemanticDomain;
+      bijectiveKey?: string;
+    }
+  ): string {
+    if (fromIds.length === 0) throw new Error('funnel: fromIds must not be empty');
+
+    const firstFrom = this.thread.nodes.get(fromIds[0]);
+    if (!firstFrom) throw new Error(`funnel: source node '${fromIds[0]}' not found`);
+
+    const toId = this.addNode({
+      label: opts?.label ?? atomId,
+      semanticAtomId: atomId,
+      tongue: opts?.tongue ?? firstFrom.tongue,
+      domain: opts?.domain ?? firstFrom.domain,
+      laneIndex: firstFrom.laneIndex,
+      depth: firstFrom.depth,
+      carriedState: {},
+    });
+
+    // Add one funnel edge per source so every source node is connected.
+    // The first edge carries the full sourceIds list in metadata; subsequent
+    // edges carry role:'secondary' so validateThread doesn't report orphans.
+    for (let i = 0; i < fromIds.length; i++) {
+      const srcId = fromIds[i];
+      if (!this.thread.nodes.has(srcId)) {
+        throw new Error(`funnel: source node '${srcId}' not found`);
+      }
+      this.addEdge({
+        kind: 'funnel',
+        from: srcId,
+        to: toId,
+        bijectiveKey: opts?.bijectiveKey,
+        metadata: i === 0 ? { sourceIds: fromIds } : { role: 'secondary', sourceIds: fromIds },
+      });
+    }
+
+    if (opts?.bijectiveKey) this.nodeKeyMap.set(toId, opts.bijectiveKey);
+
+    return toId;
+  }
+
+  /**
+   * Websocket: bidirectional channel between two nodes.
+   * Adds two edges (A→B and B→A).
+   */
+  websocket(nodeA: string, nodeB: string, opts?: { ruleGuard?: string }): void {
+    if (!this.thread.nodes.has(nodeA)) throw new Error(`websocket: node '${nodeA}' not found`);
+    if (!this.thread.nodes.has(nodeB)) throw new Error(`websocket: node '${nodeB}' not found`);
+
+    this.addEdge({
+      kind: 'websocket',
+      from: nodeA,
+      to: nodeB,
+      ruleGuard: opts?.ruleGuard,
+      metadata: { direction: 'A->B' },
+    });
+
+    this.addEdge({
+      kind: 'websocket',
+      from: nodeB,
+      to: nodeA,
+      ruleGuard: opts?.ruleGuard,
+      metadata: { direction: 'B->A' },
+    });
+  }
+
+  /**
+   * Handoff: passes work from one tongue/domain to another.
+   * The new node gets the specified tongue, breaking tongue inheritance.
+   * Returns the new node id.
+   */
+  handoff(
+    fromId: string,
+    toTongue: TongueCode,
+    atomId: string,
+    opts?: {
+      label?: string;
+      domain?: SemanticDomain;
+      state?: Record<string, unknown>;
+    }
+  ): string {
+    const from = this.thread.nodes.get(fromId);
+    if (!from) throw new Error(`handoff: source node '${fromId}' not found`);
+
+    const toId = this.addNode({
+      label: opts?.label ?? atomId,
+      semanticAtomId: atomId,
+      tongue: toTongue,
+      domain: opts?.domain ?? from.domain,
+      laneIndex: from.laneIndex,
+      depth: from.depth,
+      carriedState: opts?.state ?? {},
+    });
+
+    this.addEdge({
+      kind: 'handoff',
+      from: fromId,
+      to: toId,
+      metadata: { fromTongue: from.tongue, toTongue },
+    });
+
+    return toId;
+  }
+
+  /**
+   * Ramp out: a lane branches off to a side path.
+   * The side-path node gets a fresh lane.
+   * Returns the new side-path node id.
+   */
+  rampOut(
+    fromId: string,
+    atomId: string,
+    opts?: {
+      label?: string;
+      tongue?: TongueCode;
+      domain?: SemanticDomain;
+    }
+  ): string {
+    const from = this.thread.nodes.get(fromId);
+    if (!from) throw new Error(`rampOut: source node '${fromId}' not found`);
+
+    const laneIndex = this.nextLane++;
+    const toId = this.addNode({
+      label: opts?.label ?? atomId,
+      semanticAtomId: atomId,
+      tongue: opts?.tongue ?? from.tongue,
+      domain: opts?.domain ?? from.domain,
+      laneIndex,
+      depth: from.depth,
+      carriedState: {},
+    });
+
+    this.addEdge({
+      kind: 'ramp_out',
+      from: fromId,
+      to: toId,
+      metadata: {},
+    });
+
+    // Register as side exit if inside tunnel
+    for (const { segment, inboundSet } of this.openTunnels.values()) {
+      if (inboundSet.has(fromId)) {
+        if (!segment.sideExits.includes(toId)) segment.sideExits.push(toId);
+      }
+    }
+
+    return toId;
+  }
+
+  /**
+   * Ramp in: a side-path node merges back into the main thread.
+   * Creates a convergence node at the main lane.
+   * Returns the new merged node id.
+   */
+  rampIn(
+    mainId: string,
+    sideId: string,
+    atomId: string,
+    opts?: {
+      label?: string;
+      bijectiveKey?: string;
+    }
+  ): string {
+    const main = this.thread.nodes.get(mainId);
+    const side = this.thread.nodes.get(sideId);
+    if (!main) throw new Error(`rampIn: main node '${mainId}' not found`);
+    if (!side) throw new Error(`rampIn: side node '${sideId}' not found`);
+
+    const toId = this.addNode({
+      label: opts?.label ?? atomId,
+      semanticAtomId: atomId,
+      tongue: main.tongue,
+      domain: main.domain,
+      laneIndex: main.laneIndex,
+      depth: main.depth,
+      carriedState: {},
+    });
+
+    this.addEdge({
+      kind: 'ramp_in',
+      from: mainId,
+      to: toId,
+      bijectiveKey: opts?.bijectiveKey,
+      metadata: { sideId },
+    });
+
+    this.addEdge({
+      kind: 'ramp_in',
+      from: sideId,
+      to: toId,
+      bijectiveKey: opts?.bijectiveKey,
+      metadata: { role: 'side' },
+    });
+
+    return toId;
+  }
+
+  /**
+   * Merge: re-aligns bijective branches created by bifurcate.
+   * Verifies that all fromIds carry the same bijectiveKey.
+   * Returns the merged node id.
+   */
+  merge(
+    fromIds: string[],
+    atomId: string,
+    bijectiveKey: string,
+    opts?: {
+      label?: string;
+      tongue?: TongueCode;
+      domain?: SemanticDomain;
+    }
+  ): string {
+    if (fromIds.length === 0) throw new Error('merge: fromIds must not be empty');
+
+    for (const fromId of fromIds) {
+      const node = this.thread.nodes.get(fromId);
+      if (!node) throw new Error(`merge: node '${fromId}' not found`);
+      const key = this.nodeKeyMap.get(fromId);
+      if (key !== bijectiveKey) {
+        throw new Error(
+          `merge: node '${fromId}' has bijectiveKey '${key ?? '(none)'}' but expected '${bijectiveKey}'`
+        );
+      }
+    }
+
+    const firstFrom = this.thread.nodes.get(fromIds[0])!;
+
+    const toId = this.addNode({
+      label: opts?.label ?? atomId,
+      semanticAtomId: atomId,
+      tongue: opts?.tongue ?? firstFrom.tongue,
+      domain: opts?.domain ?? firstFrom.domain,
+      laneIndex: firstFrom.laneIndex,
+      depth: firstFrom.depth,
+      carriedState: {},
+    });
+
+    this.addEdge({
+      kind: 'merge',
+      from: fromIds[0],
+      to: toId,
+      bijectiveKey,
+      metadata: { allFromIds: fromIds },
+    });
+
+    // Check if this merge is occurring inside a tunnel
+    for (const { segment, inboundSet } of this.openTunnels.values()) {
+      const allInside = fromIds.every((id) => {
+        const tunnelId = this.tunnelCreatedNodes.get(id);
+        return tunnelId !== undefined || inboundSet.has(id);
+      });
+      if (allInside) {
+        segment.internalMerges.push({ fromNodes: fromIds, toNode: toId, bijectiveKey });
+      }
+    }
+
+    return toId;
+  }
+
+  /**
+   * Enter a tunnel segment. All nodes added while this tunnel is open
+   * receive a negative depth. Returns the tunnel id.
+   */
+  enterTunnel(label: string, entryNodeIds: string[]): string {
+    const tunnelId = this._genId('tunnel');
+    const depth = -(this.openTunnels.size + 1);
+    const segment: TunnelSegment = {
+      id: tunnelId,
+      label,
+      depth,
+      inboundNodes: [...entryNodeIds],
+      outboundNodes: [],
+      sideExits: [],
+      emergentNodes: [],
+      internalMerges: [],
+    };
+    this.openTunnels.set(tunnelId, { segment, depth, inboundSet: new Set(entryNodeIds) });
+    return tunnelId;
+  }
+
+  /**
+   * Close a tunnel segment. Nodes in exitNodeIds are registered as outbound.
+   * Any nodes that were created inside the tunnel without a corresponding
+   * inbound link are registered as emergent.
+   */
+  exitTunnel(tunnelId: string, exitNodeIds: string[]): void {
+    const entry = this.openTunnels.get(tunnelId);
+    if (!entry) throw new Error(`exitTunnel: tunnel '${tunnelId}' is not open`);
+
+    const { segment, inboundSet } = entry;
+    segment.outboundNodes = [...exitNodeIds];
+
+    // Find emergent nodes: created inside the tunnel, not in inboundNodes, not reached by tunnel_enter edge
+    const inboundNodeIds = new Set(segment.inboundNodes);
+    for (const [nodeId, tId] of this.tunnelCreatedNodes.entries()) {
+      if (tId === tunnelId && !inboundNodeIds.has(nodeId)) {
+        // Check if this node has any inbound edge from an inbound node
+        const hasInboundEdge = this.thread.edges.some(
+          (e) => e.to === nodeId && inboundSet.has(e.from as string)
+        );
+        if (!hasInboundEdge && !segment.emergentNodes.includes(nodeId)) {
+          segment.emergentNodes.push(nodeId);
+        }
+      }
+    }
+
+    this.thread.tunnels.push(segment);
+    this.openTunnels.delete(tunnelId);
+  }
+
+  /**
+   * Build and return the final thread.
+   */
+  build(): SemanticWorkflowThread {
+    // Close any still-open tunnels automatically
+    for (const [tunnelId, { segment }] of this.openTunnels.entries()) {
+      this.thread.tunnels.push(segment);
+      this.openTunnels.delete(tunnelId);
+    }
+    return this.thread;
+  }
+
+  /**
+   * Generate a WorkflowThreadReceipt for the thread.
+   * Call after build() or on the builder directly.
+   */
+  receipt(): WorkflowThreadReceipt {
+    const nodes = [...this.thread.nodes.values()];
+    const edges = this.thread.edges;
+
+    const depths = nodes.map((n) => n.depth);
+    const minDepth = depths.length ? Math.min(...depths) : 0;
+    const maxDepth = depths.length ? Math.max(...depths) : 0;
+
+    const lanes = new Set(nodes.map((n) => n.laneIndex));
+
+    const bijectiveKeySet = new Set<string>();
+    for (const e of edges) {
+      if (e.bijectiveKey) bijectiveKeySet.add(e.bijectiveKey);
+    }
+
+    const handoffCount = edges.filter((e) => e.kind === 'handoff').length;
+    const websocketCount = edges.filter((e) => e.kind === 'websocket').length;
+
+    // threadSha256: canonical JSON of sorted nodes+edges
+    const canonicalNodes = [...this.thread.nodes.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([, node]) => node);
+    const canonicalEdges = [...edges].sort((a, b) => a.id.localeCompare(b.id));
+    const canonicalJson = JSON.stringify({ nodes: canonicalNodes, edges: canonicalEdges });
+    const threadSha256 = createHash('sha256').update(canonicalJson).digest('hex');
+
+    return {
+      schema: 'scbe.workflow_thread.v1',
+      threadId: this.thread.threadId,
+      label: this.thread.label,
+      tongue: this.thread.tongue,
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      tunnelCount: this.thread.tunnels.length,
+      laneCount: lanes.size,
+      depthRange: [minDepth, maxDepth],
+      bijectiveKeys: [...bijectiveKeySet],
+      handoffCount,
+      websocketCount,
+      createdAt: new Date().toISOString(),
+      threadSha256,
+    };
+  }
+
+  /**
+   * Render an ASCII highway diagram of the thread.
+   * Safe ASCII only: uses ->, |, +, -- only.
+   */
+  render(): string {
+    const t = this.thread;
+    const sep = '='.repeat(60);
+    const divider = '-'.repeat(60);
+    const lines: string[] = [];
+
+    lines.push(sep);
+    lines.push(`THREAD: ${t.label}  [${t.tongue}]`);
+    lines.push(sep);
+
+    // Group nodes by depth: surface (0+) first, then tunnels
+    const surfaceNodes = [...t.nodes.values()].filter((n) => n.depth >= 0);
+    const tunnelNodes = [...t.nodes.values()].filter((n) => n.depth < 0);
+
+    // Helper: get outgoing edges for a node
+    const outEdges = (nodeId: string): ThreadEdge[] => t.edges.filter((e) => e.from === nodeId);
+
+    // Simple surface rendering: iterate surface nodes in insertion order
+    if (surfaceNodes.length > 0) {
+      // Group by lane
+      const byLane = new Map<number, ThreadNode[]>();
+      for (const n of surfaceNodes) {
+        if (!byLane.has(n.laneIndex)) byLane.set(n.laneIndex, []);
+        byLane.get(n.laneIndex)!.push(n);
+      }
+
+      for (const [lane, laneNodes] of [...byLane.entries()].sort(([a], [b]) => a - b)) {
+        let row = `Lane ${lane}  |  `;
+        for (let i = 0; i < laneNodes.length; i++) {
+          const node = laneNodes[i];
+          row += `${node.label} [${node.tongue}]`;
+          const edges = outEdges(node.id);
+          if (edges.length > 0) {
+            const kind = edges[0].kind;
+            row += ` --${kind}--> `;
+          }
+        }
+        lines.push(row);
+      }
+    }
+
+    // Render tunnels
+    for (const tunnel of t.tunnels) {
+      lines.push(divider);
+      lines.push(`[TUNNEL: ${tunnel.label}]`);
+
+      const tNodes = tunnelNodes.filter(
+        (n) =>
+          tunnel.inboundNodes.includes(n.id) ||
+          tunnel.outboundNodes.includes(n.id) ||
+          tunnel.emergentNodes.includes(n.id) ||
+          tunnel.sideExits.includes(n.id)
+      );
+
+      if (tNodes.length === 0) {
+        lines.push('  (empty)');
+      } else {
+        const byLane = new Map<number, ThreadNode[]>();
+        for (const n of tNodes) {
+          if (!byLane.has(n.laneIndex)) byLane.set(n.laneIndex, []);
+          byLane.get(n.laneIndex)!.push(n);
+        }
+        for (const [lane, laneNodes] of [...byLane.entries()].sort(([a], [b]) => a - b)) {
+          let row = `  Lane ${lane}  |  `;
+          for (let i = 0; i < laneNodes.length; i++) {
+            const node = laneNodes[i];
+            const prefix = tunnel.emergentNodes.includes(node.id) ? '(emergent) ' : '';
+            const suffix = tunnel.sideExits.includes(node.id) ? ' (exits tunnel)' : '';
+            row += `${prefix}${node.label} [${node.tongue}]${suffix}`;
+            if (i < laneNodes.length - 1) row += ' -> ';
+          }
+          lines.push(row);
+        }
+      }
+      lines.push(divider);
+    }
+
+    lines.push(sep);
+    return lines.join('\n');
+  }
+}
+
+// ============================================================================
+// Helper functions
+// ============================================================================
+
+/**
+ * Create a new WorkflowThreadBuilder.
+ */
+export function createWorkflowThread(label: string, tongue: TongueCode): WorkflowThreadBuilder {
+  return new WorkflowThreadBuilder(label, tongue);
+}
+
+/**
+ * Serialize a SemanticWorkflowThread to a JSON-serializable object.
+ * Converts Maps to arrays.
+ */
+export function serializeThread(thread: SemanticWorkflowThread): object {
+  return {
+    schemaVersion: thread.schemaVersion,
+    threadId: thread.threadId,
+    label: thread.label,
+    tongue: thread.tongue,
+    nodes: [...thread.nodes.values()],
+    edges: thread.edges,
+    tunnels: thread.tunnels,
+  };
+}
+
+/**
+ * Validate a SemanticWorkflowThread.
+ * Checks:
+ * - Every edge references existing node ids
+ * - bifurcate+merge pairs have matching bijectiveKeys (via edge inspection)
+ * - No orphan nodes (nodes with no edge in or out, except the very first node)
+ *
+ * Returns an array of error strings. Empty array = valid.
+ */
+export function validateThread(thread: SemanticWorkflowThread): string[] {
+  const errors: string[] = [];
+  const nodeIds = new Set(thread.nodes.keys());
+
+  // Check all edge node references exist
+  for (const edge of thread.edges) {
+    if (!nodeIds.has(edge.from)) {
+      errors.push(`Edge '${edge.id}' references unknown source node '${edge.from}'`);
+    }
+    const targets = Array.isArray(edge.to) ? edge.to : [edge.to];
+    for (const t of targets) {
+      if (!nodeIds.has(t)) {
+        errors.push(`Edge '${edge.id}' references unknown target node '${t}'`);
+      }
+    }
+  }
+
+  // Check bijective key consistency: every bifurcate edge should have a corresponding merge edge with the same key
+  const bifurcateKeys = new Map<string, string>(); // bijectiveKey -> bifurcate edge id
+  const mergeKeys = new Map<string, string>(); // bijectiveKey -> merge edge id
+
+  for (const edge of thread.edges) {
+    if (edge.kind === 'bifurcate' && edge.bijectiveKey) {
+      bifurcateKeys.set(edge.bijectiveKey, edge.id);
+    }
+    if (edge.kind === 'merge' && edge.bijectiveKey) {
+      mergeKeys.set(edge.bijectiveKey, edge.id);
+    }
+  }
+
+  for (const [key] of bifurcateKeys) {
+    if (!mergeKeys.has(key)) {
+      errors.push(`bijectiveKey '${key}' has a bifurcate but no corresponding merge edge`);
+    }
+  }
+  for (const [key] of mergeKeys) {
+    if (!bifurcateKeys.has(key)) {
+      errors.push(`bijectiveKey '${key}' has a merge but no corresponding bifurcate edge`);
+    }
+  }
+
+  // Check orphan nodes (skip if only one node or zero edges)
+  if (thread.nodes.size > 1 && thread.edges.length > 0) {
+    const connectedNodes = new Set<string>();
+    for (const edge of thread.edges) {
+      connectedNodes.add(edge.from);
+      const targets = Array.isArray(edge.to) ? edge.to : [edge.to];
+      for (const t of targets) connectedNodes.add(t);
+    }
+    for (const nodeId of nodeIds) {
+      if (!connectedNodes.has(nodeId)) {
+        errors.push(`Node '${nodeId}' is an orphan (no edges connect to it)`);
+      }
+    }
+  }
+
+  return errors;
+}

--- a/src/tokenizer/semantic_code_bridge.py
+++ b/src/tokenizer/semantic_code_bridge.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from src.cli.cross_build_ir import QuarantineError, cross_build
+from src.tokenizer.code_weight_packets import build_code_weight_packet
+
+SCHEMA_VERSION = "scbe-semantic-code-bridge-v1"
+
+OPERATION_ATOM_MAP = {
+    "function_definition": "FLOW",
+    "return_flow": "FLOW",
+    "arithmetic": "TRANSFORM",
+    "assignment": "TRANSFORM",
+    "iteration_flow": "FLOW",
+    "control_guard": "BLOCK",
+    "comparison": "BLOCK",
+    "semantic_operation": "TRANSFORM",
+}
+
+
+def _operation_kind(path_item: str) -> str:
+    return path_item.split(":", 1)[0].split("/", 1)[0]
+
+
+def semantic_atom_for_operation(path_item: str) -> str:
+    """Map a language-agnostic operation path item into a semantic atom id."""
+
+    return OPERATION_ATOM_MAP.get(_operation_kind(path_item), "TRANSFORM")
+
+
+def _channel_between(left: str, right: str) -> str:
+    if left == "FLOW" and right == "BLOCK":
+        return "bifurcation"
+    if left == "BLOCK" and right == "FLOW":
+        return "merge"
+    if right == "TRANSFORM":
+        return "pipe"
+    if left == "TRANSFORM" and right == "FLOW":
+        return "pipe"
+    return "dot_to_dot"
+
+
+def build_semantic_code_bridge(
+    sources: dict[str, str],
+    *,
+    source_prefix: str = "sample",
+) -> dict[str, Any]:
+    """Align source snippets by semantic operation path while preserving source packets.
+
+    This is not a full source-code compiler. It proves the bridge layer:
+    language-specific source packets remain hash-bound, while equivalent code
+    operations converge to the same interchange key and semantic atom path.
+    """
+
+    packets = {
+        language: build_code_weight_packet(source, language=language, source_name=f"{source_prefix}.{language}")
+        for language, source in sources.items()
+    }
+    signatures = {language: packet["semantic_operation_signature"] for language, packet in packets.items()}
+    interchange_keys = {signature["interchange_key"] for signature in signatures.values()}
+    operation_paths = {tuple(signature["operation_path"]) for signature in signatures.values()}
+    reference_path = list(next(iter(operation_paths))) if operation_paths else []
+    semantic_atoms = [semantic_atom_for_operation(item) for item in reference_path]
+    workflow_edges = [
+        {
+            "from": semantic_atoms[index],
+            "to": semantic_atoms[index + 1],
+            "channel": _channel_between(semantic_atoms[index], semantic_atoms[index + 1]),
+            "operation_from": reference_path[index],
+            "operation_to": reference_path[index + 1],
+        }
+        for index in range(max(len(semantic_atoms) - 1, 0))
+    ]
+
+    bridge_payload = {
+        "schema_version": SCHEMA_VERSION,
+        "languages": sorted(sources),
+        "interchange_keys": sorted(interchange_keys),
+        "operation_paths": [list(path) for path in sorted(operation_paths)],
+        "semantic_atoms": semantic_atoms,
+        "workflow_edges": workflow_edges,
+    }
+    bridge_hash = hashlib.sha256(repr(bridge_payload).encode("utf-8")).hexdigest()
+
+    return {
+        **bridge_payload,
+        "bridge_hash": bridge_hash,
+        "aligned": len(interchange_keys) == 1 and len(operation_paths) == 1,
+        "bijective_packet_preservation": {
+            language: {
+                "source_sha256": packet["source_sha256"],
+                "transport_tongue": packet["transport"]["tongue"],
+                "transport_token_sha256": packet["transport"]["token_sha256"],
+                "lexical_tokens_preserved": signature["preservation"]["lexical_tokens_preserved"],
+                "identifier_names_preserved_in_atoms": signature["preservation"]["identifier_names_preserved_in_atoms"],
+            }
+            for language, packet in packets.items()
+            for signature in [signatures[language]]
+        },
+        "packets": packets,
+    }
+
+
+def semantic_atom_for_lattice_band(band: str) -> str:
+    """Map the lexicon-bounded cross-build IR band into semantic atom space."""
+
+    normalized = band.upper()
+    if normalized in {"ARITHMETIC", "AGGREGATION"}:
+        return "TRANSFORM"
+    if normalized in {"COMPARISON", "LOGIC"}:
+        return "BLOCK"
+    return "TRANSFORM"
+
+
+def build_lexicon_cross_compile_bridge(src_code: str, src_tongue: str, dst_tongue: str) -> dict[str, Any]:
+    """Prove the lexicon-bounded cross-compile path and attach semantic atoms.
+
+    This wraps the existing Tier 1 cross-build sphere:
+    source tongue -> shared LatticeOp IR -> destination tongue.
+
+    It deliberately returns quarantine as data so cloud agents can try a move
+    safely without pretending arbitrary source parsing succeeded.
+    """
+
+    try:
+        result = cross_build(src_code, src_tongue, dst_tongue)
+    except QuarantineError as exc:
+        return {
+            "schema_version": "scbe-semantic-lexicon-cross-compile-v1",
+            "aligned": False,
+            "quarantined": True,
+            "error": type(exc).__name__,
+            "message": str(exc),
+            "src_code": src_code,
+            "src_tongue": src_tongue,
+            "dst_tongue": dst_tongue,
+        }
+
+    semantic_atom = semantic_atom_for_lattice_band(result.ir.band)
+    payload = {
+        "schema_version": "scbe-semantic-lexicon-cross-compile-v1",
+        "aligned": True,
+        "quarantined": False,
+        "src_code": result.src_code,
+        "src_tongue": result.src_tongue,
+        "src_language": result.src_language,
+        "dst_code": result.dst_code,
+        "dst_tongue": result.dst_tongue,
+        "dst_language": result.dst_language,
+        "ir": result.ir.model_dump(),
+        "semantic_atoms": [semantic_atom],
+        "workflow_edges": [
+            {
+                "from": result.src_tongue,
+                "to": "LatticeOp",
+                "channel": "bifurcation",
+                "state_rule": "lift source syntax into the shared frozen IR or quarantine",
+            },
+            {
+                "from": "LatticeOp",
+                "to": result.dst_tongue,
+                "channel": "merge",
+                "state_rule": "emit destination syntax only when the IR contains all required bindings",
+            },
+        ],
+    }
+    payload["bridge_hash"] = hashlib.sha256(repr(payload).encode("utf-8")).hexdigest()
+    return payload
+
+
+__all__ = [
+    "build_lexicon_cross_compile_bridge",
+    "build_semantic_code_bridge",
+    "semantic_atom_for_lattice_band",
+    "semantic_atom_for_operation",
+]

--- a/tests/tokenizer/semantic-atom.test.ts
+++ b/tests/tokenizer/semantic-atom.test.ts
@@ -10,6 +10,7 @@ import {
 describe('semantic atom tokenizer', () => {
   it('defines flow as a stable nucleus with code and natural orbitals', () => {
     const flow = getSemanticAtom('FLOW');
+    const transform = getSemanticAtom('TRANSFORM');
 
     expect(flow?.nucleus.invariants).toEqual([
       'direction',
@@ -21,6 +22,8 @@ describe('semantic atom tokenizer', () => {
     expect(flow?.orbitals.map((orbital) => orbital.domain)).toContain('natural');
     expect(flow?.codeRelations.blockers).toContain('type error');
     expect(flow?.codeRelations.patterns).toContain('input -> function -> output');
+    expect(transform?.nucleus.invariants).toContain('preservation_rule');
+    expect(transform?.codeRelations.patterns).toContain('operands -> operator -> result');
   });
 
   it('keeps water and flow related without collapsing them into the same atom', () => {

--- a/tests/tokenizer/semantic-workflow-thread.test.ts
+++ b/tests/tokenizer/semantic-workflow-thread.test.ts
@@ -1,0 +1,432 @@
+/**
+ * @file semantic-workflow-thread.test.ts
+ * Tests for the SemanticWorkflowThread builder system.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  createWorkflowThread,
+  serializeThread,
+  validateThread,
+  type ThreadEdge,
+} from '../../src/tokenizer/semantic-workflow-thread.js';
+
+// ============================================================================
+// Fixture helper: build a minimal single-node thread for validateThread tests
+// (bypasses the builder by directly inserting into the returned Map)
+// ============================================================================
+
+function buildSingleNodeThread() {
+  const b = createWorkflowThread('fixture', 'AV');
+  const thread = b.build();
+  const rootId = 'node-root-001';
+  thread.nodes.set(rootId, {
+    id: rootId,
+    label: 'ROOT',
+    semanticAtomId: 'FLOW',
+    tongue: 'AV',
+    domain: 'workflow',
+    laneIndex: 0,
+    depth: 0,
+    carriedState: {},
+  });
+  return { thread, rootId };
+}
+
+// ============================================================================
+// Test 1: createWorkflowThread produces correct schema
+// ============================================================================
+
+describe('createWorkflowThread', () => {
+  it('produces a builder that yields the correct schema version and structure', () => {
+    const builder = createWorkflowThread('test-thread', 'AV');
+    const thread = builder.build();
+
+    expect(thread.schemaVersion).toBe('scbe-workflow-thread-v1');
+    expect(thread.label).toBe('test-thread');
+    expect(thread.tongue).toBe('AV');
+    expect(thread.threadId).toMatch(/^thread-/);
+    expect(thread.nodes).toBeInstanceOf(Map);
+    expect(thread.edges).toBeInstanceOf(Array);
+    expect(thread.tunnels).toBeInstanceOf(Array);
+  });
+});
+
+// ============================================================================
+// Test 2: pipe adds node and edge correctly
+// ============================================================================
+
+describe('pipe', () => {
+  it('adds a downstream node with pipe edge and correct properties', () => {
+    const b = createWorkflowThread('pipe-test', 'KO');
+    const rootId = b.seed('INTENT', { tongue: 'KO', domain: 'workflow' });
+
+    const nextId = b.pipe(rootId, 'DISPATCH', {
+      label: 'dispatch-step',
+      tongue: 'AV',
+      domain: 'workflow',
+    });
+
+    const thread = b.build();
+
+    expect(thread.nodes.has(rootId)).toBe(true);
+    expect(thread.nodes.has(nextId)).toBe(true);
+    expect(thread.nodes.get(nextId)?.tongue).toBe('AV');
+    expect(thread.nodes.get(nextId)?.label).toBe('dispatch-step');
+    expect(thread.nodes.get(nextId)?.semanticAtomId).toBe('DISPATCH');
+
+    expect(thread.edges).toHaveLength(1);
+    expect(thread.edges[0].kind).toBe('pipe');
+    expect(thread.edges[0].from).toBe(rootId);
+    expect(thread.edges[0].to).toBe(nextId);
+  });
+
+  it('throws when source node id does not exist', () => {
+    const b = createWorkflowThread('pipe-err', 'KO');
+    expect(() => b.pipe('nonexistent-id', 'FLOW')).toThrow(
+      "pipe: source node 'nonexistent-id' not found"
+    );
+  });
+});
+
+// ============================================================================
+// Test 3: bifurcate creates N branches with correct bijectiveKey
+// ============================================================================
+
+describe('bifurcate', () => {
+  it('creates N branches with bijectiveKey on the bifurcate edge', () => {
+    const b = createWorkflowThread('bif-test', 'AV');
+    const rootId = b.seed('FLOW', { tongue: 'AV', domain: 'workflow' });
+
+    const branchIds = b.bifurcate(
+      rootId,
+      [
+        { atomId: 'ALLOW', label: 'allow-path', tongue: 'CA' },
+        { atomId: 'QUARANTINE', label: 'quarantine-path', tongue: 'RU' },
+        { atomId: 'DENY', label: 'deny-path', tongue: 'UM' },
+      ],
+      'governance-split-key'
+    );
+
+    const thread = b.build();
+
+    expect(branchIds).toHaveLength(3);
+    for (const id of branchIds) {
+      expect(thread.nodes.has(id)).toBe(true);
+    }
+
+    const bifEdge = thread.edges.find((e) => e.kind === 'bifurcate');
+    expect(bifEdge).toBeDefined();
+    expect(bifEdge?.bijectiveKey).toBe('governance-split-key');
+    expect(Array.isArray(bifEdge?.to)).toBe(true);
+    expect((bifEdge?.to as string[]).length).toBe(3);
+
+    // Branches get distinct lane indices
+    const laneIndices = branchIds.map((id) => thread.nodes.get(id)!.laneIndex);
+    expect(new Set(laneIndices).size).toBe(3);
+  });
+});
+
+// ============================================================================
+// Test 4: funnel creates N:1 convergence
+// ============================================================================
+
+describe('funnel', () => {
+  it('creates convergence edges from N sources to 1 target and validates cleanly', () => {
+    const b = createWorkflowThread('funnel-test', 'CA');
+    const r1 = b.seed('FLOW', { tongue: 'AV', domain: 'workflow' });
+    const r2 = b.seed('BLOCK', { tongue: 'RU', domain: 'governance' });
+    const r3 = b.seed('VERIFY', { tongue: 'CA', domain: 'governance' });
+
+    const mergedId = b.funnel([r1, r2, r3], 'MERGED', {
+      label: 'combined',
+      bijectiveKey: 'funnel-key',
+    });
+
+    const thread = b.build();
+
+    expect(thread.nodes.has(mergedId)).toBe(true);
+    expect(thread.nodes.get(mergedId)?.label).toBe('combined');
+
+    // One funnel edge per source node
+    const funnelEdges = thread.edges.filter((e) => e.kind === 'funnel');
+    expect(funnelEdges).toHaveLength(3);
+    expect(funnelEdges.every((e) => e.to === mergedId)).toBe(true);
+
+    // First edge carries sourceIds metadata
+    const primaryEdge = funnelEdges.find((e) => !e.metadata['role']);
+    expect(primaryEdge?.metadata['sourceIds']).toEqual([r1, r2, r3]);
+
+    // All sources are connected — validateThread should report zero errors
+    expect(validateThread(thread)).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Test 5: websocket creates two edges (both directions)
+// ============================================================================
+
+describe('websocket', () => {
+  it('creates exactly two edges in both directions', () => {
+    const b = createWorkflowThread('ws-test', 'KO');
+    const aId = b.seed('SENDER', { tongue: 'KO', domain: 'workflow' });
+    const bId = b.seed('RECEIVER', { tongue: 'DR', domain: 'workflow' });
+
+    b.websocket(aId, bId);
+    const thread = b.build();
+
+    const wsEdges = thread.edges.filter((e) => e.kind === 'websocket');
+    expect(wsEdges).toHaveLength(2);
+
+    expect(wsEdges.find((e) => e.from === aId && e.to === bId)).toBeDefined();
+    expect(wsEdges.find((e) => e.from === bId && e.to === aId)).toBeDefined();
+  });
+
+  it('throws when either node does not exist', () => {
+    const b = createWorkflowThread('ws-err', 'KO');
+    expect(() => b.websocket('a', 'b')).toThrow("websocket: node 'a' not found");
+  });
+});
+
+// ============================================================================
+// Test 6: handoff changes tongue on the new node
+// ============================================================================
+
+describe('handoff', () => {
+  it('creates a new node with a different tongue and a handoff edge', () => {
+    const b = createWorkflowThread('handoff-test', 'AV');
+    const sourceId = b.seed('DISPATCH', { tongue: 'AV', domain: 'workflow' });
+
+    const targetId = b.handoff(sourceId, 'RU', 'GOVERNANCE_CHECK', {
+      label: 'rule-check',
+      domain: 'governance',
+    });
+
+    const thread = b.build();
+    const sourceNode = thread.nodes.get(sourceId)!;
+    const targetNode = thread.nodes.get(targetId)!;
+
+    expect(sourceNode.tongue).toBe('AV');
+    expect(targetNode.tongue).toBe('RU');
+    expect(targetNode.label).toBe('rule-check');
+    expect(targetNode.domain).toBe('governance');
+
+    const handoffEdge = thread.edges.find((e) => e.kind === 'handoff');
+    expect(handoffEdge).toBeDefined();
+    expect(handoffEdge?.from).toBe(sourceId);
+    expect(handoffEdge?.to).toBe(targetId);
+    expect(handoffEdge?.metadata['fromTongue']).toBe('AV');
+    expect(handoffEdge?.metadata['toTongue']).toBe('RU');
+  });
+});
+
+// ============================================================================
+// Test 7: merge creates re-alignment edge and validates bijectiveKey
+// ============================================================================
+
+describe('merge', () => {
+  it('creates a merge edge after bifurcate+pipe chain with matching bijectiveKey', () => {
+    const b = createWorkflowThread('merge-test', 'AV');
+    const rootId = b.seed('ROOT', { tongue: 'AV', domain: 'workflow' });
+    const biKey = 'split-merge-key';
+
+    const [branch1, branch2] = b.bifurcate(
+      rootId,
+      [{ atomId: 'BRANCH_A' }, { atomId: 'BRANCH_B' }],
+      biKey
+    );
+
+    // Pipe each branch forward — key is inherited
+    const leaf1 = b.pipe(branch1, 'PROCESSED_A');
+    const leaf2 = b.pipe(branch2, 'PROCESSED_B');
+
+    // Merge the leaves via bijectiveKey
+    const mergedId = b.merge([leaf1, leaf2], 'UNIFIED', biKey);
+
+    const thread = b.build();
+    expect(thread.nodes.has(mergedId)).toBe(true);
+
+    const mergeEdge = thread.edges.find((e) => e.kind === 'merge');
+    expect(mergeEdge).toBeDefined();
+    expect(mergeEdge?.bijectiveKey).toBe(biKey);
+    expect(mergeEdge?.to).toBe(mergedId);
+
+    // Full thread should be structurally valid
+    expect(validateThread(thread)).toEqual([]);
+  });
+
+  it('throws when bijectiveKey does not match node inheritance', () => {
+    const b = createWorkflowThread('bad-merge', 'AV');
+    const r1 = b.seed('A', { tongue: 'AV', domain: 'workflow' });
+    expect(() => b.merge([r1], 'MERGED', 'some-key')).toThrow(
+      "merge: node '" + r1 + "' has bijectiveKey '(none)' but expected 'some-key'"
+    );
+  });
+});
+
+// ============================================================================
+// Test 8: validateThread catches missing node reference in an edge
+// ============================================================================
+
+describe('validateThread', () => {
+  it('returns no errors for a valid single-node thread', () => {
+    const { thread } = buildSingleNodeThread();
+    expect(validateThread(thread)).toHaveLength(0);
+  });
+
+  it('catches edge referencing a non-existent source node', () => {
+    const { thread } = buildSingleNodeThread();
+    const badEdge: ThreadEdge = {
+      id: 'edge-bad-001',
+      kind: 'pipe',
+      from: 'nonexistent-node',
+      to: 'node-root-001',
+      metadata: {},
+    };
+    thread.edges.push(badEdge);
+
+    const errors = validateThread(thread);
+    expect(errors.some((e) => e.includes('nonexistent-node'))).toBe(true);
+  });
+
+  it('catches edge referencing a non-existent target node', () => {
+    const { thread } = buildSingleNodeThread();
+    const badEdge: ThreadEdge = {
+      id: 'edge-bad-002',
+      kind: 'pipe',
+      from: 'node-root-001',
+      to: 'nonexistent-target',
+      metadata: {},
+    };
+    thread.edges.push(badEdge);
+
+    const errors = validateThread(thread);
+    expect(errors.some((e) => e.includes('nonexistent-target'))).toBe(true);
+  });
+
+  it('catches bifurcate with no corresponding merge edge', () => {
+    const { thread } = buildSingleNodeThread();
+
+    const node2 = 'node-branch-001';
+    thread.nodes.set(node2, {
+      id: node2,
+      label: 'BRANCH',
+      semanticAtomId: 'BLOCK',
+      tongue: 'RU',
+      domain: 'governance',
+      laneIndex: 1,
+      depth: 0,
+      carriedState: {},
+    });
+
+    thread.edges.push({
+      id: 'edge-bif-001',
+      kind: 'bifurcate',
+      from: 'node-root-001',
+      to: [node2],
+      bijectiveKey: 'orphan-bk',
+      metadata: {},
+    });
+
+    const errors = validateThread(thread);
+    expect(errors.some((e) => e.includes('orphan-bk') && e.includes('bifurcate'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// Test 9: receipt has correct nodeCount, edgeCount, bijectiveKeys
+// ============================================================================
+
+describe('receipt', () => {
+  it('returns correct nodeCount, edgeCount, bijectiveKeys, and a valid sha256', () => {
+    const b = createWorkflowThread('receipt-test', 'DR');
+    const rootId = b.seed('ORIGIN', { tongue: 'DR', domain: 'workflow' });
+    const biKey = 'receipt-bk';
+
+    const [br1, br2] = b.bifurcate(rootId, [{ atomId: 'PATH_A' }, { atomId: 'PATH_B' }], biKey);
+    b.merge([br1, br2], 'FINAL', biKey);
+
+    const r = b.receipt();
+
+    // 4 nodes: root + 2 branches + merged
+    expect(r.nodeCount).toBe(4);
+    // 2 edges: bifurcate + merge
+    expect(r.edgeCount).toBe(2);
+    expect(r.bijectiveKeys).toContain(biKey);
+    expect(r.schema).toBe('scbe.workflow_thread.v1');
+    expect(r.threadSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(r.tongue).toBe('DR');
+    expect(r.label).toBe('receipt-test');
+    expect(typeof r.createdAt).toBe('string');
+  });
+});
+
+// ============================================================================
+// Test 10: render output contains the thread label and at least one node label
+// ============================================================================
+
+describe('render', () => {
+  it('contains the thread label, tongue, and at least one node label', () => {
+    const b = createWorkflowThread('render-test', 'KO');
+    const rootId = b.seed('INTAKE', { tongue: 'KO', domain: 'workflow' });
+    b.pipe(rootId, 'PROCESS', { label: 'process-step', tongue: 'AV' });
+
+    const output = b.render();
+
+    expect(output).toContain('render-test');
+    expect(output).toContain('[KO]');
+    expect(output).toContain('INTAKE');
+  });
+});
+
+// ============================================================================
+// serializeThread — Map to array conversion
+// ============================================================================
+
+describe('serializeThread', () => {
+  it('converts Map nodes to an array in the serialized form', () => {
+    const { thread } = buildSingleNodeThread();
+    const serialized = serializeThread(thread) as Record<string, unknown>;
+
+    expect(Array.isArray(serialized['nodes'])).toBe(true);
+    expect(serialized['schemaVersion']).toBe('scbe-workflow-thread-v1');
+    expect(serialized['threadId']).toBeDefined();
+    expect(serialized['edges']).toBeInstanceOf(Array);
+    expect(serialized['tunnels']).toBeInstanceOf(Array);
+  });
+
+  it('serialized nodes contain all ThreadNode fields', () => {
+    const { thread } = buildSingleNodeThread();
+    const serialized = serializeThread(thread) as { nodes: Array<Record<string, unknown>> };
+    const rootNode = serialized.nodes.find((n) => n['id'] === 'node-root-001');
+    expect(rootNode).toBeDefined();
+    expect(rootNode?.['label']).toBe('ROOT');
+    expect(rootNode?.['tongue']).toBe('AV');
+    expect(rootNode?.['semanticAtomId']).toBe('FLOW');
+  });
+});
+
+// ============================================================================
+// seed() public API
+// ============================================================================
+
+describe('seed', () => {
+  it('creates a root node accessible by the returned id', () => {
+    const b = createWorkflowThread('seed-test', 'UM');
+    const id = b.seed('SCAN_ENTRY', { tongue: 'UM', domain: 'workflow' });
+    const thread = b.build();
+
+    expect(thread.nodes.has(id)).toBe(true);
+    expect(thread.nodes.get(id)?.tongue).toBe('UM');
+    expect(thread.nodes.get(id)?.semanticAtomId).toBe('SCAN_ENTRY');
+    expect(thread.nodes.get(id)?.label).toBe('SCAN_ENTRY');
+  });
+
+  it('defaults tongue to the thread tongue and domain to workflow', () => {
+    const b = createWorkflowThread('seed-default', 'DR');
+    const id = b.seed('RECEIPT');
+    const thread = b.build();
+
+    expect(thread.nodes.get(id)?.tongue).toBe('DR');
+    expect(thread.nodes.get(id)?.domain).toBe('workflow');
+  });
+});

--- a/tests/tokenizer/test_semantic_code_bridge.py
+++ b/tests/tokenizer/test_semantic_code_bridge.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from src.tokenizer.semantic_code_bridge import (
+    build_lexicon_cross_compile_bridge,
+    build_semantic_code_bridge,
+    semantic_atom_for_lattice_band,
+    semantic_atom_for_operation,
+)
+
+
+def test_semantic_code_bridge_aligns_add_function_across_languages() -> None:
+    bridge = build_semantic_code_bridge(
+        {
+            "python": "def add(a, b):\n    return a + b\n",
+            "typescript": "function add(a, b) { return a + b; }\n",
+            "rust": "fn add(a: i32, b: i32) -> i32 { return a + b }\n",
+            "c": "int add(int a, int b) { return a + b; }\n",
+        }
+    )
+
+    assert bridge["schema_version"] == "scbe-semantic-code-bridge-v1"
+    assert bridge["aligned"] is True
+    assert bridge["operation_paths"] == [["function_definition/2", "return_flow", "arithmetic:add/2"]]
+    assert bridge["semantic_atoms"] == ["FLOW", "FLOW", "TRANSFORM"]
+    assert bridge["workflow_edges"] == [
+        {
+            "from": "FLOW",
+            "to": "FLOW",
+            "channel": "dot_to_dot",
+            "operation_from": "function_definition/2",
+            "operation_to": "return_flow",
+        },
+        {
+            "from": "FLOW",
+            "to": "TRANSFORM",
+            "channel": "pipe",
+            "operation_from": "return_flow",
+            "operation_to": "arithmetic:add/2",
+        },
+    ]
+    assert len(set(bridge["interchange_keys"])) == 1
+    for preservation in bridge["bijective_packet_preservation"].values():
+        assert preservation["lexical_tokens_preserved"] is True
+        assert preservation["identifier_names_preserved_in_atoms"] is True
+        assert len(preservation["source_sha256"]) == 64
+        assert len(preservation["transport_token_sha256"]) == 64
+
+
+def test_semantic_code_bridge_surfaces_control_guard_as_block_and_merge_flow() -> None:
+    bridge = build_semantic_code_bridge(
+        {
+            "python": "def guarded(x):\n    if x >= 0:\n        return x\n",
+        }
+    )
+
+    assert bridge["aligned"] is True
+    assert bridge["semantic_atoms"] == ["FLOW", "FLOW", "BLOCK", "BLOCK"]
+    assert {edge["channel"] for edge in bridge["workflow_edges"]} >= {"bifurcation"}
+
+
+def test_semantic_atom_for_operation_defaults_unknown_operations_to_transform() -> None:
+    assert semantic_atom_for_operation("function_definition/2") == "FLOW"
+    assert semantic_atom_for_operation("comparison:gte/2") == "BLOCK"
+    assert semantic_atom_for_operation("custom_rewrite") == "TRANSFORM"
+
+
+def test_lexicon_cross_compile_bridge_proves_bijective_ir_path() -> None:
+    bridge = build_lexicon_cross_compile_bridge("(x + y)", "KO", "RU")
+
+    assert bridge["schema_version"] == "scbe-semantic-lexicon-cross-compile-v1"
+    assert bridge["aligned"] is True
+    assert bridge["quarantined"] is False
+    assert bridge["dst_code"] == "x.wrapping_add(y)"
+    assert bridge["ir"]["op_name"] == "add"
+    assert bridge["semantic_atoms"] == ["TRANSFORM"]
+    assert [edge["channel"] for edge in bridge["workflow_edges"]] == ["bifurcation", "merge"]
+    assert len(bridge["bridge_hash"]) == 64
+
+
+def test_lexicon_cross_compile_bridge_quarantines_non_lexicon_source() -> None:
+    bridge = build_lexicon_cross_compile_bridge("console.log(secret)", "AV", "KO")
+
+    assert bridge["aligned"] is False
+    assert bridge["quarantined"] is True
+    assert bridge["error"] == "LiftFailure"
+    assert "no lexicon op template matched" in bridge["message"]
+
+
+def test_semantic_atom_for_lattice_band_maps_operation_bands() -> None:
+    assert semantic_atom_for_lattice_band("ARITHMETIC") == "TRANSFORM"
+    assert semantic_atom_for_lattice_band("COMPARISON") == "BLOCK"
+    assert semantic_atom_for_lattice_band("LOGIC") == "BLOCK"


### PR DESCRIPTION
## Summary
- adds the public semantic workflow-thread builder for pipes, funnels, bifurcations, websocket handoffs, merges, tunnels, receipts, and validation
- adds a Python semantic code bridge that maps existing code-weight packets and cross-build IR into semantic atoms while preserving source hashes and transport receipts
- documents Aperiodic Token Realignment as deterministic token-boundary/weight realignment with a binary/hexa loss-check rule

## Honest Boundary
- this proves bounded semantic alignment and lexicon IR cross-build; it does not claim arbitrary Turing-complete source translation yet
- non-lexicon code is quarantined with the original source evidence preserved

## Test Evidence
- `npm run lint` -> passed
- `npm run typecheck` -> passed
- `python -m pytest tests\tokenizer\test_semantic_code_bridge.py tests\tokenizer\test_code_weight_semantic_operation_signature.py tests\cli\test_cross_build_ir.py tests\cli\test_cross_build_cli.py -q` -> 38 passed
- `npx vitest run tests/tokenizer/semantic-atom.test.ts tests/tokenizer/semantic-workflow-thread.test.ts` -> 27 passed
- `npm run build` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced the `TRANSFORM` semantic atom, expanding semantic vocabulary coverage
  * Added workflow thread builder system supporting multi-lane workflows with pipes, bifurcations, funnels, merges, and cross-language transitions
  * Implemented semantic code bridge for aligning code across programming languages via semantic operation paths

* **Documentation**
  * Extended tokenizer documentation with workflow channel types, code bridge connectivity, and token realignment governance sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->