### PR TITLE
feat(geoseal): operator system-space model — access plane + auth state → ring, FS topology, governance flags

### DIFF
--- a/src/geosealOperatorSpace.ts
+++ b/src/geosealOperatorSpace.ts
@@ -1,0 +1,442 @@
+/**
+ * @file geosealOperatorSpace.ts
+ * @module geosealOperatorSpace
+ * @layer Layer 3, Layer 13
+ *
+ * GeoSeal Operator System-Space Model
+ *
+ * Extends GeoSeal's geographic ring model to cover the operator's position in
+ * **system topology space** — not physical coordinates, but the structural
+ * location of the operator: which access plane they arrived through (web /
+ * terminal / app / API) and whether they are authenticated.
+ *
+ * The access plane + auth state together determine:
+ *   - A file-system topology (what paths are reachable and writable)
+ *   - A governance ring (core / outer / restricted / blocked)
+ *   - A deterministic space ID analogous to the geographic geoid
+ *   - Governance flags that surface cross-plane claims and auth anomalies
+ *
+ * Why this matters:
+ *   A web-anonymous operator claiming access to /home/user/documents is
+ *   structurally impossible — their sandbox grants no native FS at all.
+ *   The governance layer should catch the claim before it reaches the FS.
+ *   Similarly, a terminal+sudo operator carries elevated risk that warrants
+ *   its own flag even at high trust, so downstream layers can gate writes.
+ */
+
+import * as crypto from 'node:crypto';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Enumerations
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The structural plane through which an operator connects to the system.
+ * Each plane has a fixed, deterministic FS topology regardless of auth state.
+ */
+export type OperatorAccessPlane = 'web' | 'terminal' | 'app' | 'api';
+
+/**
+ * Authentication status of the operator at session time.
+ * Drives trust score and writable-path access within each plane.
+ */
+export type OperatorAuthState = 'authenticated' | 'anonymous' | 'service_account' | 'sudo';
+
+/** Degree to which the operator's file-system access is sandboxed. */
+export type SandboxLevel = 'none' | 'partial' | 'full';
+
+/** GeoSeal governance ring — mirrors the geographic ring vocabulary. */
+export type OperatorRing = 'core' | 'outer' | 'restricted' | 'blocked';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FS Topology
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * File-system access topology derived from the operator's system-space position.
+ * Describes structural constraints, not a list of guaranteed paths.
+ */
+export interface FsTopology {
+  /** How tightly sandboxed is this operator's FS access? */
+  sandboxLevel: SandboxLevel;
+  /**
+   * Root paths reachable in principle for this plane+auth combination.
+   * Empty for full-sandbox planes (browser context).
+   * These are canonical examples — real enforcement is the caller's job.
+   */
+  accessibleRoots: string[];
+  /** Subset of accessibleRoots where writes are permitted by default. */
+  writablePaths: string[];
+  /** Whether FS state persists after the session ends. */
+  persistsAcrossSessions: boolean;
+  /**
+   * True when the operator can only write to a temporary/ephemeral location
+   * (e.g. /tmp or browser OPFS without explicit permission grant).
+   */
+  tempOnly: boolean;
+  /**
+   * OS-level mount points visible to this operator.
+   * Empty for browser and anonymous-API planes.
+   */
+  mountPoints: string[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input / Output types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OperatorSpaceInput {
+  /** How the operator is connected. */
+  accessPlane: OperatorAccessPlane;
+  /** Auth state at session time. */
+  authState: OperatorAuthState;
+  /**
+   * Opaque session fingerprint for space-ID derivation (e.g. session cookie
+   * hash, terminal session UUID, app install ID). Must NOT contain PII.
+   * If omitted, an anonymous fingerprint is derived from plane+auth only.
+   */
+  sessionFingerprint?: string;
+  /** Unix epoch ms when the session was authenticated. Null for anonymous. */
+  loginTimeMs?: number;
+  /**
+   * Paths the operator is claiming access to.
+   * Used for cross-plane claim validation.
+   */
+  claimedPaths?: string[];
+}
+
+/** Governance flags surfaced by the space evaluation. */
+export type GovernanceFlag =
+  | 'ELEVATED_TERMINAL' // terminal + sudo
+  | 'UNAUTHENTICATED_WEB' // web + anonymous (highest risk profile)
+  | 'UNAUTHENTICATED_API' // api + anonymous
+  | 'CROSS_PLANE_CLAIM' // claimed paths inconsistent with access plane
+  | 'SESSION_MISSING_LOGIN_TIME' // auth says authenticated but no loginTimeMs
+  | 'TEMP_FS_ONLY' // full sandbox, all writes are ephemeral
+  | 'SERVICE_ACCOUNT_ELEVATED'; // service_account on terminal plane
+
+export interface OperatorSpaceDecision {
+  /** Canonical ring for downstream governance gates. */
+  ring: OperatorRing;
+  /** Composite trust score [0.0, 1.0]. Higher = more trusted. */
+  trustScore: number;
+  /**
+   * Deterministic identifier for this operator's system-space position.
+   * Analogous to the geographic geoid — stable across calls with the same
+   * plane+auth+fingerprint, usable as a receipt anchor.
+   */
+  spaceId: string;
+  /** Derived FS topology for this plane + auth combination. */
+  fsTopology: FsTopology;
+  /** Governance flags raised during evaluation. */
+  governanceFlags: GovernanceFlag[];
+  /** Machine-readable status tag. */
+  status: string;
+  /** Human-readable explanation. */
+  reason: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FS topology derivation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the structural FS topology for a given plane + auth combination.
+ * These are deterministic governance constraints, not live filesystem probes.
+ */
+export function derivefsTopology(plane: OperatorAccessPlane, auth: OperatorAuthState): FsTopology {
+  switch (plane) {
+    case 'web':
+      // Browser context — OPFS only (sandboxed, origin-scoped, no native FS)
+      return {
+        sandboxLevel: 'full',
+        accessibleRoots: [], // no native root access
+        writablePaths: [], // OPFS is not representable as a native path
+        persistsAcrossSessions: auth === 'authenticated', // OPFS persists when logged in
+        tempOnly: auth === 'anonymous',
+        mountPoints: [], // no mount points visible in browser
+      };
+
+    case 'terminal':
+      if (auth === 'sudo') {
+        return {
+          sandboxLevel: 'none',
+          accessibleRoots: ['/', 'C:\\'],
+          writablePaths: ['/', 'C:\\'],
+          persistsAcrossSessions: true,
+          tempOnly: false,
+          mountPoints: ['/', '/proc', '/sys', '/dev', 'C:\\', 'D:\\'],
+        };
+      }
+      if (auth === 'authenticated' || auth === 'service_account') {
+        return {
+          sandboxLevel: 'none',
+          accessibleRoots: ['~', '/home', '/var', '/tmp', 'C:\\Users', 'C:\\ProgramData'],
+          writablePaths: ['~', '/tmp', 'C:\\Users\\{user}', 'C:\\Temp'],
+          persistsAcrossSessions: true,
+          tempOnly: false,
+          mountPoints: ['/', 'C:\\', 'D:\\'],
+        };
+      }
+      // anonymous terminal — /tmp only, no persistent FS
+      return {
+        sandboxLevel: 'partial',
+        accessibleRoots: ['/tmp', 'C:\\Temp'],
+        writablePaths: ['/tmp', 'C:\\Temp'],
+        persistsAcrossSessions: false,
+        tempOnly: true,
+        mountPoints: [],
+      };
+
+    case 'app':
+      if (auth === 'anonymous') {
+        return {
+          sandboxLevel: 'partial',
+          accessibleRoots: [],
+          writablePaths: [],
+          persistsAcrossSessions: false,
+          tempOnly: true,
+          mountPoints: [],
+        };
+      }
+      // app sandbox — app-data directory only (no system paths)
+      return {
+        sandboxLevel: 'partial',
+        accessibleRoots: ['~/AppData', '~/.local/share', '~/Library/Application Support'],
+        writablePaths: ['~/AppData/{app}', '~/.local/share/{app}'],
+        persistsAcrossSessions: true,
+        tempOnly: false,
+        mountPoints: [],
+      };
+
+    case 'api':
+      // API callers have no direct FS — server-side FS only, mediated by the service
+      return {
+        sandboxLevel: auth === 'anonymous' ? 'full' : 'partial',
+        accessibleRoots: [],
+        writablePaths: [],
+        persistsAcrossSessions: false,
+        tempOnly: true,
+        mountPoints: [],
+      };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ring + trust derivation
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RingProfile {
+  ring: OperatorRing;
+  trustScore: number;
+}
+
+/** Lookup table: plane → auth → ring + trust */
+const RING_TABLE: Record<OperatorAccessPlane, Record<OperatorAuthState, RingProfile>> = {
+  terminal: {
+    sudo: { ring: 'core', trustScore: 0.95 },
+    authenticated: { ring: 'core', trustScore: 0.85 },
+    service_account: { ring: 'core', trustScore: 0.8 },
+    anonymous: { ring: 'restricted', trustScore: 0.35 },
+  },
+  app: {
+    authenticated: { ring: 'outer', trustScore: 0.7 },
+    service_account: { ring: 'outer', trustScore: 0.65 },
+    anonymous: { ring: 'restricted', trustScore: 0.25 },
+    sudo: { ring: 'outer', trustScore: 0.7 }, // apps don't have sudo; treat as authenticated
+  },
+  api: {
+    service_account: { ring: 'core', trustScore: 0.8 },
+    authenticated: { ring: 'outer', trustScore: 0.7 },
+    anonymous: { ring: 'blocked', trustScore: 0.05 },
+    sudo: { ring: 'outer', trustScore: 0.7 }, // API + sudo treated as authenticated
+  },
+  web: {
+    authenticated: { ring: 'outer', trustScore: 0.6 },
+    anonymous: { ring: 'blocked', trustScore: 0.05 },
+    service_account: { ring: 'outer', trustScore: 0.55 },
+    sudo: { ring: 'outer', trustScore: 0.6 }, // web + sudo treated as authenticated
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Space ID
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Deterministic space identifier for this operator's system-space position.
+ * Analogous to the geographic geoid — stable across calls with the same inputs,
+ * usable as a receipt anchor in audit logs.
+ */
+function deriveSpaceId(
+  plane: OperatorAccessPlane,
+  auth: OperatorAuthState,
+  fingerprint: string
+): string {
+  const payload = `${plane}|${auth}|${fingerprint}`;
+  return crypto.createHash('sha256').update(payload, 'utf8').digest('hex').slice(0, 16);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cross-plane claim validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+const WEB_NATIVE_PATH_PATTERN = /^[/\\]|^[A-Za-z]:\\/;
+const URL_PATTERN = /^https?:\/\//i;
+const UNC_PATTERN = /^\\\\/;
+
+/**
+ * Returns true if the claimed path is structurally inconsistent with the
+ * operator's access plane.
+ *
+ * - Web operators cannot claim native FS paths.
+ * - API-anonymous operators cannot claim any paths.
+ * - Terminal operators cannot claim bare HTTP URLs as file paths.
+ */
+function isPathCrossPlane(path: string, plane: OperatorAccessPlane): boolean {
+  switch (plane) {
+    case 'web':
+      // Browser has no native FS — claiming any local or UNC path is a violation
+      return WEB_NATIVE_PATH_PATTERN.test(path) || UNC_PATTERN.test(path);
+    case 'api':
+      // API callers have no direct FS at all
+      return true;
+    case 'terminal':
+    case 'app':
+      // Terminal/app operators should not be claiming bare HTTP URLs as file paths
+      return URL_PATTERN.test(path);
+    default:
+      return false;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Governance flag evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function evaluateFlags(
+  plane: OperatorAccessPlane,
+  auth: OperatorAuthState,
+  fsTopology: FsTopology,
+  claimedPaths: string[],
+  loginTimeMs: number | undefined
+): GovernanceFlag[] {
+  const flags: GovernanceFlag[] = [];
+
+  if (plane === 'terminal' && auth === 'sudo') flags.push('ELEVATED_TERMINAL');
+  if (plane === 'terminal' && auth === 'service_account') flags.push('SERVICE_ACCOUNT_ELEVATED');
+  if (plane === 'web' && auth === 'anonymous') flags.push('UNAUTHENTICATED_WEB');
+  if (plane === 'api' && auth === 'anonymous') flags.push('UNAUTHENTICATED_API');
+  if (fsTopology.tempOnly) flags.push('TEMP_FS_ONLY');
+
+  if ((auth === 'authenticated' || auth === 'sudo') && loginTimeMs == null) {
+    flags.push('SESSION_MISSING_LOGIN_TIME');
+  }
+
+  const crossPlanePaths = claimedPaths.filter((p) => isPathCrossPlane(p, plane));
+  if (crossPlanePaths.length > 0) flags.push('CROSS_PLANE_CLAIM');
+
+  return flags;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Primary evaluation function
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate an operator's system-space position and return a governance decision.
+ *
+ * The decision integrates with GeoSeal's ring model: `ring` maps directly to
+ * the same ALLOW/QUARANTINE/ESCALATE/DENY tier thresholds used in L13.
+ *
+ * @example
+ * ```ts
+ * const decision = evaluateOperatorSpace({
+ *   accessPlane: 'terminal',
+ *   authState: 'authenticated',
+ *   sessionFingerprint: sessionUUID,
+ *   loginTimeMs: Date.now(),
+ *   claimedPaths: ['/home/user/docs'],
+ * });
+ * // decision.ring === 'core', decision.trustScore === 0.85
+ * ```
+ */
+export function evaluateOperatorSpace(input: OperatorSpaceInput): OperatorSpaceDecision {
+  const { accessPlane, authState, sessionFingerprint, loginTimeMs, claimedPaths = [] } = input;
+
+  const fingerprint =
+    sessionFingerprint && sessionFingerprint.length > 0
+      ? sessionFingerprint
+      : `${accessPlane}:${authState}:anon`;
+
+  const spaceId = deriveSpaceId(accessPlane, authState, fingerprint);
+  const fsTopology = derivefsTopology(accessPlane, authState);
+  const { ring, trustScore } = RING_TABLE[accessPlane][authState];
+
+  const flags = evaluateFlags(accessPlane, authState, fsTopology, claimedPaths, loginTimeMs);
+
+  // Penalize trust score for governance violations
+  let effectiveTrust = trustScore;
+  if (flags.includes('CROSS_PLANE_CLAIM')) effectiveTrust = Math.max(0, effectiveTrust - 0.3);
+  if (flags.includes('SESSION_MISSING_LOGIN_TIME'))
+    effectiveTrust = Math.max(0, effectiveTrust - 0.15);
+
+  const effectiveRing: OperatorRing =
+    effectiveTrust < 0.1 ? 'blocked' : effectiveTrust <= 0.4 ? 'restricted' : ring;
+
+  const status = `operator_space_${accessPlane}_${authState}`;
+  const reason =
+    `plane=${accessPlane} auth=${authState} sandbox=${fsTopology.sandboxLevel}` +
+    (flags.length > 0 ? ` flags=[${flags.join(',')}]` : '');
+
+  return {
+    ring: effectiveRing,
+    trustScore: Math.round(effectiveTrust * 10000) / 10000,
+    spaceId,
+    fsTopology,
+    governanceFlags: flags,
+    status,
+    reason,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Serialisation helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Convert an OperatorSpaceDecision to a JSON-friendly plain object. */
+export function operatorSpaceToRecord(decision: OperatorSpaceDecision): Record<string, unknown> {
+  return {
+    ring: decision.ring,
+    trust_score: decision.trustScore,
+    space_id: decision.spaceId,
+    sandbox_level: decision.fsTopology.sandboxLevel,
+    accessible_roots: decision.fsTopology.accessibleRoots,
+    writable_paths: decision.fsTopology.writablePaths,
+    persists_across_sessions: decision.fsTopology.persistsAcrossSessions,
+    temp_only: decision.fsTopology.tempOnly,
+    mount_points: decision.fsTopology.mountPoints,
+    governance_flags: decision.governanceFlags,
+    status: decision.status,
+    reason: decision.reason,
+  };
+}
+
+/**
+ * Maps an OperatorRing to the L13 governance tier vocabulary.
+ * Integrates operator-space decisions into the main 14-layer pipeline.
+ */
+export function ringToGovernanceTier(
+  ring: OperatorRing
+): 'ALLOW' | 'QUARANTINE' | 'ESCALATE' | 'DENY' {
+  switch (ring) {
+    case 'core':
+      return 'ALLOW';
+    case 'outer':
+      return 'QUARANTINE';
+    case 'restricted':
+      return 'ESCALATE';
+    case 'blocked':
+      return 'DENY';
+  }
+}

--- a/src/geoseal_operator_space.py
+++ b/src/geoseal_operator_space.py
@@ -1,0 +1,413 @@
+"""GeoSeal Operator System-Space Model (Python reference implementation).
+
+Extends GeoSeal's geographic ring model to cover the operator's position in
+**system topology space** — not physical coordinates, but the structural
+location of the operator: which access plane they arrived through (web /
+terminal / app / API) and whether they are authenticated.
+
+The access plane + auth state together determine:
+  - A file-system topology (what paths are reachable and writable)
+  - A governance ring (core / outer / restricted / blocked)
+  - A deterministic space ID analogous to the geographic geoid
+  - Governance flags that surface cross-plane claims and auth anomalies
+
+Why this matters:
+  A web-anonymous operator claiming /home/user/documents is structurally
+  impossible — their sandbox grants no native FS at all. The governance layer
+  should catch the claim before it reaches the FS.  Similarly, a terminal+sudo
+  operator carries elevated risk that warrants its own flag even at high trust.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional
+
+# ---------------------------------------------------------------------------
+# Types / enumerations
+# ---------------------------------------------------------------------------
+
+AccessPlane = Literal["web", "terminal", "app", "api"]
+AuthState = Literal["authenticated", "anonymous", "service_account", "sudo"]
+SandboxLevel = Literal["none", "partial", "full"]
+OperatorRing = Literal["core", "outer", "restricted", "blocked"]
+GovernanceTier = Literal["ALLOW", "QUARANTINE", "ESCALATE", "DENY"]
+
+GOVERNANCE_FLAGS = {
+    "ELEVATED_TERMINAL",
+    "UNAUTHENTICATED_WEB",
+    "UNAUTHENTICATED_API",
+    "CROSS_PLANE_CLAIM",
+    "SESSION_MISSING_LOGIN_TIME",
+    "TEMP_FS_ONLY",
+    "SERVICE_ACCOUNT_ELEVATED",
+}
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FsTopology:
+    """File-system access topology for an operator's plane + auth combination."""
+
+    sandbox_level: SandboxLevel
+    accessible_roots: List[str]
+    writable_paths: List[str]
+    persists_across_sessions: bool
+    temp_only: bool
+    mount_points: List[str]
+
+
+@dataclass(frozen=True)
+class OperatorSpaceInput:
+    """Input to the operator space evaluator."""
+
+    access_plane: AccessPlane
+    auth_state: AuthState
+    session_fingerprint: Optional[str] = None
+    login_time_ms: Optional[int] = None
+    claimed_paths: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class OperatorSpaceDecision:
+    """Governance decision for an operator's system-space position."""
+
+    ring: OperatorRing
+    trust_score: float
+    space_id: str
+    fs_topology: FsTopology
+    governance_flags: List[str]
+    status: str
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# FS topology derivation
+# ---------------------------------------------------------------------------
+
+_FS_TOPOLOGY: dict[tuple[AccessPlane, AuthState], FsTopology] = {
+    # --- web ---
+    ("web", "anonymous"): FsTopology(
+        sandbox_level="full",
+        accessible_roots=[],
+        writable_paths=[],
+        persists_across_sessions=False,
+        temp_only=True,
+        mount_points=[],
+    ),
+    ("web", "authenticated"): FsTopology(
+        sandbox_level="full",
+        accessible_roots=[],
+        writable_paths=[],
+        persists_across_sessions=True,
+        temp_only=False,
+        mount_points=[],
+    ),
+    ("web", "service_account"): FsTopology(
+        sandbox_level="full",
+        accessible_roots=[],
+        writable_paths=[],
+        persists_across_sessions=True,
+        temp_only=False,
+        mount_points=[],
+    ),
+    ("web", "sudo"): FsTopology(
+        sandbox_level="full",
+        accessible_roots=[],
+        writable_paths=[],
+        persists_across_sessions=True,
+        temp_only=False,
+        mount_points=[],
+    ),
+    # --- terminal ---
+    ("terminal", "sudo"): FsTopology(
+        sandbox_level="none",
+        accessible_roots=["/", "C:\\"],
+        writable_paths=["/", "C:\\"],
+        persists_across_sessions=True,
+        temp_only=False,
+        mount_points=["/", "/proc", "/sys", "/dev", "C:\\", "D:\\"],
+    ),
+    ("terminal", "authenticated"): FsTopology(
+        sandbox_level="none",
+        accessible_roots=["~", "/home", "/var", "/tmp", "C:\\Users", "C:\\ProgramData"],
+        writable_paths=["~", "/tmp", "C:\\Users\\{user}", "C:\\Temp"],
+        persists_across_sessions=True,
+        temp_only=False,
+        mount_points=["/", "C:\\", "D:\\"],
+    ),
+    ("terminal", "service_account"): FsTopology(
+        sandbox_level="none",
+        accessible_roots=["~", "/home", "/var", "/tmp", "C:\\Users", "C:\\ProgramData"],
+        writable_paths=["~", "/tmp", "C:\\Users\\{user}", "C:\\Temp"],
+        persists_across_sessions=True,
+        temp_only=False,
+        mount_points=["/", "C:\\", "D:\\"],
+    ),
+    ("terminal", "anonymous"): FsTopology(
+        sandbox_level="partial",
+        accessible_roots=["/tmp", "C:\\Temp"],
+        writable_paths=["/tmp", "C:\\Temp"],
+        persists_across_sessions=False,
+        temp_only=True,
+        mount_points=[],
+    ),
+    # --- app ---
+    ("app", "authenticated"): FsTopology(
+        sandbox_level="partial",
+        accessible_roots=["~/AppData", "~/.local/share", "~/Library/Application Support"],
+        writable_paths=["~/AppData/{app}", "~/.local/share/{app}"],
+        persists_across_sessions=True,
+        temp_only=False,
+        mount_points=[],
+    ),
+    ("app", "service_account"): FsTopology(
+        sandbox_level="partial",
+        accessible_roots=["~/AppData", "~/.local/share", "~/Library/Application Support"],
+        writable_paths=["~/AppData/{app}", "~/.local/share/{app}"],
+        persists_across_sessions=True,
+        temp_only=False,
+        mount_points=[],
+    ),
+    ("app", "anonymous"): FsTopology(
+        sandbox_level="partial",
+        accessible_roots=[],
+        writable_paths=[],
+        persists_across_sessions=False,
+        temp_only=True,
+        mount_points=[],
+    ),
+    ("app", "sudo"): FsTopology(
+        sandbox_level="partial",
+        accessible_roots=["~/AppData", "~/.local/share", "~/Library/Application Support"],
+        writable_paths=["~/AppData/{app}", "~/.local/share/{app}"],
+        persists_across_sessions=True,
+        temp_only=False,
+        mount_points=[],
+    ),
+    # --- api ---
+    ("api", "service_account"): FsTopology(
+        sandbox_level="partial",
+        accessible_roots=[],
+        writable_paths=[],
+        persists_across_sessions=False,
+        temp_only=True,
+        mount_points=[],
+    ),
+    ("api", "authenticated"): FsTopology(
+        sandbox_level="partial",
+        accessible_roots=[],
+        writable_paths=[],
+        persists_across_sessions=False,
+        temp_only=True,
+        mount_points=[],
+    ),
+    ("api", "anonymous"): FsTopology(
+        sandbox_level="full",
+        accessible_roots=[],
+        writable_paths=[],
+        persists_across_sessions=False,
+        temp_only=True,
+        mount_points=[],
+    ),
+    ("api", "sudo"): FsTopology(
+        sandbox_level="partial",
+        accessible_roots=[],
+        writable_paths=[],
+        persists_across_sessions=False,
+        temp_only=True,
+        mount_points=[],
+    ),
+}
+
+
+def derive_fs_topology(plane: AccessPlane, auth: AuthState) -> FsTopology:
+    """Return the FS topology for a given plane + auth combination."""
+    return _FS_TOPOLOGY[(plane, auth)]
+
+
+# ---------------------------------------------------------------------------
+# Ring + trust lookup
+# ---------------------------------------------------------------------------
+
+_RING_TABLE: dict[tuple[AccessPlane, AuthState], tuple[OperatorRing, float]] = {
+    ("terminal", "sudo"): ("core", 0.95),
+    ("terminal", "authenticated"): ("core", 0.85),
+    ("terminal", "service_account"): ("core", 0.80),
+    ("terminal", "anonymous"): ("restricted", 0.35),
+    ("app", "authenticated"): ("outer", 0.70),
+    ("app", "service_account"): ("outer", 0.65),
+    ("app", "anonymous"): ("restricted", 0.25),
+    ("app", "sudo"): ("outer", 0.70),
+    ("api", "service_account"): ("core", 0.80),
+    ("api", "authenticated"): ("outer", 0.70),
+    ("api", "anonymous"): ("blocked", 0.05),
+    ("api", "sudo"): ("outer", 0.70),
+    ("web", "authenticated"): ("outer", 0.60),
+    ("web", "anonymous"): ("blocked", 0.05),
+    ("web", "service_account"): ("outer", 0.55),
+    ("web", "sudo"): ("outer", 0.60),
+}
+
+
+# ---------------------------------------------------------------------------
+# Space ID
+# ---------------------------------------------------------------------------
+
+_WEB_NATIVE_PATH = re.compile(r"^[/\\]|^[A-Za-z]:\\")
+_URL = re.compile(r"^https?://", re.IGNORECASE)
+_UNC = re.compile(r"^\\\\")
+
+
+def _derive_space_id(plane: AccessPlane, auth: AuthState, fingerprint: str) -> str:
+    payload = f"{plane}|{auth}|{fingerprint}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Cross-plane claim validation
+# ---------------------------------------------------------------------------
+
+
+def _is_path_cross_plane(path: str, plane: AccessPlane) -> bool:
+    if plane == "web":
+        return bool(_WEB_NATIVE_PATH.match(path) or _UNC.match(path))
+    if plane == "api":
+        return True  # API callers have no direct FS
+    # terminal / app
+    return bool(_URL.match(path))
+
+
+# ---------------------------------------------------------------------------
+# Flag evaluation
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_flags(
+    plane: AccessPlane,
+    auth: AuthState,
+    fs_topology: FsTopology,
+    claimed_paths: List[str],
+    login_time_ms: Optional[int],
+) -> List[str]:
+    flags: List[str] = []
+
+    if plane == "terminal" and auth == "sudo":
+        flags.append("ELEVATED_TERMINAL")
+    if plane == "terminal" and auth == "service_account":
+        flags.append("SERVICE_ACCOUNT_ELEVATED")
+    if plane == "web" and auth == "anonymous":
+        flags.append("UNAUTHENTICATED_WEB")
+    if plane == "api" and auth == "anonymous":
+        flags.append("UNAUTHENTICATED_API")
+    if fs_topology.temp_only:
+        flags.append("TEMP_FS_ONLY")
+    if auth in ("authenticated", "sudo") and login_time_ms is None:
+        flags.append("SESSION_MISSING_LOGIN_TIME")
+
+    if any(_is_path_cross_plane(p, plane) for p in claimed_paths):
+        flags.append("CROSS_PLANE_CLAIM")
+
+    return flags
+
+
+# ---------------------------------------------------------------------------
+# Primary evaluator
+# ---------------------------------------------------------------------------
+
+
+def evaluate_operator_space(inp: OperatorSpaceInput) -> OperatorSpaceDecision:
+    """Evaluate an operator's system-space position and return a governance decision.
+
+    The decision integrates with GeoSeal's ring model: ``ring`` maps directly
+    to the same ALLOW/QUARANTINE/ESCALATE/DENY tier thresholds used in L13.
+
+    Examples::
+
+        decision = evaluate_operator_space(OperatorSpaceInput(
+            access_plane="terminal",
+            auth_state="authenticated",
+            session_fingerprint="sess-uuid-123",
+            login_time_ms=1716000000000,
+            claimed_paths=["/home/user/docs"],
+        ))
+        assert decision.ring == "core"
+        assert decision.trust_score == 0.85
+    """
+    plane = inp.access_plane
+    auth = inp.auth_state
+    fingerprint = inp.session_fingerprint or f"{plane}:{auth}:anon"
+
+    space_id = _derive_space_id(plane, auth, fingerprint)
+    fs_topology = derive_fs_topology(plane, auth)
+    ring, trust_score = _RING_TABLE[(plane, auth)]
+
+    flags = _evaluate_flags(plane, auth, fs_topology, inp.claimed_paths, inp.login_time_ms)
+
+    # Penalise trust for violations
+    effective_trust = trust_score
+    if "CROSS_PLANE_CLAIM" in flags:
+        effective_trust = max(0.0, effective_trust - 0.30)
+    if "SESSION_MISSING_LOGIN_TIME" in flags:
+        effective_trust = max(0.0, effective_trust - 0.15)
+
+    if effective_trust < 0.1:
+        effective_ring: OperatorRing = "blocked"
+    elif effective_trust <= 0.4:
+        effective_ring = "restricted"
+    else:
+        effective_ring = ring  # type: ignore[assignment]
+
+    status = f"operator_space_{plane}_{auth}"
+    flag_str = f" flags=[{','.join(flags)}]" if flags else ""
+    reason = f"plane={plane} auth={auth} sandbox={fs_topology.sandbox_level}{flag_str}"
+
+    return OperatorSpaceDecision(
+        ring=effective_ring,
+        trust_score=round(effective_trust, 4),
+        space_id=space_id,
+        fs_topology=fs_topology,
+        governance_flags=flags,
+        status=status,
+        reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def ring_to_governance_tier(ring: OperatorRing) -> GovernanceTier:
+    """Map an OperatorRing to the L13 governance tier vocabulary."""
+    mapping: dict[OperatorRing, GovernanceTier] = {
+        "core": "ALLOW",
+        "outer": "QUARANTINE",
+        "restricted": "ESCALATE",
+        "blocked": "DENY",
+    }
+    return mapping[ring]
+
+
+def decision_to_metadata(decision: OperatorSpaceDecision) -> dict:
+    """Convert a decision to a JSON-friendly plain dict (receipt format)."""
+    return {
+        "ring": decision.ring,
+        "trust_score": decision.trust_score,
+        "space_id": decision.space_id,
+        "sandbox_level": decision.fs_topology.sandbox_level,
+        "accessible_roots": decision.fs_topology.accessible_roots,
+        "writable_paths": decision.fs_topology.writable_paths,
+        "persists_across_sessions": decision.fs_topology.persists_across_sessions,
+        "temp_only": decision.fs_topology.temp_only,
+        "mount_points": decision.fs_topology.mount_points,
+        "governance_flags": decision.governance_flags,
+        "status": decision.status,
+        "reason": decision.reason,
+    }

--- a/tests/geoseal-operator-space.test.ts
+++ b/tests/geoseal-operator-space.test.ts
@@ -1,0 +1,359 @@
+/**
+ * @file geoseal-operator-space.test.ts
+ * @module tests/geoseal-operator-space
+ *
+ * Tests for the GeoSeal Operator System-Space Model.
+ * Covers: ring derivation, FS topology, cross-plane claim detection,
+ * governance flags, trust penalty, space ID determinism.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  derivefsTopology,
+  evaluateOperatorSpace,
+  operatorSpaceToRecord,
+  ringToGovernanceTier,
+  type OperatorAccessPlane,
+  type OperatorAuthState,
+  type OperatorSpaceDecision,
+} from '../src/geosealOperatorSpace.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FS topology
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('derivefsTopology', () => {
+  it('web+anonymous → full sandbox, temp only, no roots', () => {
+    const topo = derivefsTopology('web', 'anonymous');
+    expect(topo.sandboxLevel).toBe('full');
+    expect(topo.accessibleRoots).toHaveLength(0);
+    expect(topo.tempOnly).toBe(true);
+    expect(topo.persistsAcrossSessions).toBe(false);
+    expect(topo.mountPoints).toHaveLength(0);
+  });
+
+  it('web+authenticated → full sandbox but persists', () => {
+    const topo = derivefsTopology('web', 'authenticated');
+    expect(topo.sandboxLevel).toBe('full');
+    expect(topo.persistsAcrossSessions).toBe(true);
+    expect(topo.tempOnly).toBe(false);
+  });
+
+  it('terminal+sudo → no sandbox, full root access', () => {
+    const topo = derivefsTopology('terminal', 'sudo');
+    expect(topo.sandboxLevel).toBe('none');
+    expect(topo.accessibleRoots).toContain('/');
+    expect(topo.writablePaths).toContain('/');
+    expect(topo.persistsAcrossSessions).toBe(true);
+    expect(topo.tempOnly).toBe(false);
+    expect(topo.mountPoints.length).toBeGreaterThan(0);
+  });
+
+  it('terminal+authenticated → no sandbox, home+tmp writable', () => {
+    const topo = derivefsTopology('terminal', 'authenticated');
+    expect(topo.sandboxLevel).toBe('none');
+    expect(topo.accessibleRoots.some((r) => r.includes('home') || r === '~')).toBe(true);
+    expect(topo.writablePaths.some((p) => p.includes('tmp') || p === '~')).toBe(true);
+  });
+
+  it('terminal+anonymous → partial sandbox, temp only', () => {
+    const topo = derivefsTopology('terminal', 'anonymous');
+    expect(topo.sandboxLevel).toBe('partial');
+    expect(topo.tempOnly).toBe(true);
+    expect(topo.persistsAcrossSessions).toBe(false);
+  });
+
+  it('app+authenticated → partial sandbox, app-data roots', () => {
+    const topo = derivefsTopology('app', 'authenticated');
+    expect(topo.sandboxLevel).toBe('partial');
+    expect(topo.persistsAcrossSessions).toBe(true);
+    expect(topo.mountPoints).toHaveLength(0);
+  });
+
+  it('app+anonymous → partial sandbox, no roots', () => {
+    const topo = derivefsTopology('app', 'anonymous');
+    expect(topo.sandboxLevel).toBe('partial');
+    expect(topo.accessibleRoots).toHaveLength(0);
+    expect(topo.tempOnly).toBe(true);
+  });
+
+  it('api+anonymous → full sandbox', () => {
+    const topo = derivefsTopology('api', 'anonymous');
+    expect(topo.sandboxLevel).toBe('full');
+    expect(topo.accessibleRoots).toHaveLength(0);
+  });
+
+  it('api+service_account → partial sandbox, no FS', () => {
+    const topo = derivefsTopology('api', 'service_account');
+    expect(topo.sandboxLevel).toBe('partial');
+    expect(topo.accessibleRoots).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ring and trust score
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('evaluateOperatorSpace — ring derivation', () => {
+  const cases: Array<[OperatorAccessPlane, OperatorAuthState, string, number]> = [
+    ['terminal', 'sudo', 'core', 0.95],
+    ['terminal', 'authenticated', 'core', 0.85],
+    ['terminal', 'service_account', 'core', 0.8],
+    ['terminal', 'anonymous', 'restricted', 0.35],
+    ['app', 'authenticated', 'outer', 0.7],
+    ['app', 'service_account', 'outer', 0.65],
+    ['app', 'anonymous', 'restricted', 0.25],
+    ['api', 'service_account', 'core', 0.8],
+    ['api', 'authenticated', 'outer', 0.7],
+    ['api', 'anonymous', 'blocked', 0.05],
+    ['web', 'authenticated', 'outer', 0.6],
+    ['web', 'anonymous', 'blocked', 0.05],
+  ];
+
+  it.each(cases)('%s+%s → ring=%s trust=%f', (plane, auth, expectedRing, expectedTrust) => {
+    const decision = evaluateOperatorSpace({
+      accessPlane: plane,
+      authState: auth,
+      sessionFingerprint: 'test-sess-001',
+      loginTimeMs: auth === 'anonymous' ? undefined : Date.now(),
+    });
+    expect(decision.ring).toBe(expectedRing);
+    expect(decision.trustScore).toBe(expectedTrust);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Governance flags
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('evaluateOperatorSpace — governance flags', () => {
+  it('terminal+sudo raises ELEVATED_TERMINAL', () => {
+    const d = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'sudo',
+      sessionFingerprint: 'sudo-sess',
+      loginTimeMs: Date.now(),
+    });
+    expect(d.governanceFlags).toContain('ELEVATED_TERMINAL');
+  });
+
+  it('web+anonymous raises UNAUTHENTICATED_WEB and TEMP_FS_ONLY', () => {
+    const d = evaluateOperatorSpace({ accessPlane: 'web', authState: 'anonymous' });
+    expect(d.governanceFlags).toContain('UNAUTHENTICATED_WEB');
+    expect(d.governanceFlags).toContain('TEMP_FS_ONLY');
+  });
+
+  it('api+anonymous raises UNAUTHENTICATED_API and TEMP_FS_ONLY', () => {
+    const d = evaluateOperatorSpace({ accessPlane: 'api', authState: 'anonymous' });
+    expect(d.governanceFlags).toContain('UNAUTHENTICATED_API');
+    expect(d.governanceFlags).toContain('TEMP_FS_ONLY');
+  });
+
+  it('terminal+service_account raises SERVICE_ACCOUNT_ELEVATED', () => {
+    const d = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'service_account',
+      sessionFingerprint: 'svc-sess',
+    });
+    expect(d.governanceFlags).toContain('SERVICE_ACCOUNT_ELEVATED');
+  });
+
+  it('authenticated without loginTimeMs raises SESSION_MISSING_LOGIN_TIME', () => {
+    const d = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'sess-no-time',
+      // loginTimeMs intentionally omitted
+    });
+    expect(d.governanceFlags).toContain('SESSION_MISSING_LOGIN_TIME');
+  });
+
+  it('web operator claiming native path raises CROSS_PLANE_CLAIM', () => {
+    const d = evaluateOperatorSpace({
+      accessPlane: 'web',
+      authState: 'authenticated',
+      sessionFingerprint: 'web-sess',
+      loginTimeMs: Date.now(),
+      claimedPaths: ['/home/user/documents', 'C:\\Users\\user\\Desktop'],
+    });
+    expect(d.governanceFlags).toContain('CROSS_PLANE_CLAIM');
+  });
+
+  it('terminal operator claiming HTTP URL raises CROSS_PLANE_CLAIM', () => {
+    const d = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'term-sess',
+      loginTimeMs: Date.now(),
+      claimedPaths: ['http://example.com/file.txt'],
+    });
+    expect(d.governanceFlags).toContain('CROSS_PLANE_CLAIM');
+  });
+
+  it('terminal operator claiming local path does NOT raise CROSS_PLANE_CLAIM', () => {
+    const d = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'term-sess-ok',
+      loginTimeMs: Date.now(),
+      claimedPaths: ['/home/user/documents'],
+    });
+    expect(d.governanceFlags).not.toContain('CROSS_PLANE_CLAIM');
+  });
+
+  it('API operator claiming any path raises CROSS_PLANE_CLAIM', () => {
+    const d = evaluateOperatorSpace({
+      accessPlane: 'api',
+      authState: 'service_account',
+      sessionFingerprint: 'api-svc',
+      claimedPaths: ['/tmp/output.json'],
+    });
+    expect(d.governanceFlags).toContain('CROSS_PLANE_CLAIM');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trust penalty and effective ring downgrade
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('evaluateOperatorSpace — trust penalty', () => {
+  it('CROSS_PLANE_CLAIM reduces trust by 0.30', () => {
+    const baseline = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'base',
+      loginTimeMs: Date.now(),
+    });
+    const withClaim = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'base',
+      loginTimeMs: Date.now(),
+      claimedPaths: ['http://evil.com/file'],
+    });
+    expect(withClaim.trustScore).toBeCloseTo(baseline.trustScore - 0.3, 4);
+  });
+
+  it('SESSION_MISSING_LOGIN_TIME reduces trust by 0.15', () => {
+    const baseline = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'base',
+      loginTimeMs: Date.now(),
+    });
+    const withMissing = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'base',
+      // no loginTimeMs
+    });
+    expect(withMissing.trustScore).toBeCloseTo(baseline.trustScore - 0.15, 4);
+  });
+
+  it('sufficient trust penalty downgrades ring from core to restricted', () => {
+    // terminal+authenticated starts at 0.85 — if we subtract 0.45 it goes below 0.4
+    // Use combined penalty: CROSS_PLANE_CLAIM (0.30) + SESSION_MISSING_LOGIN_TIME (0.15) = 0.45
+    const d = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'penalized',
+      // no loginTimeMs → SESSION_MISSING_LOGIN_TIME
+      claimedPaths: ['http://external.example.com/bad'], // → CROSS_PLANE_CLAIM
+    });
+    expect(d.ring).toBe('restricted');
+    expect(d.trustScore).toBeCloseTo(0.4, 4);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Space ID determinism
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('evaluateOperatorSpace — space ID', () => {
+  it('same inputs produce the same spaceId', () => {
+    const input = {
+      accessPlane: 'terminal' as OperatorAccessPlane,
+      authState: 'authenticated' as OperatorAuthState,
+      sessionFingerprint: 'fixed-fingerprint-abc',
+      loginTimeMs: 1716000000000,
+    };
+    const a = evaluateOperatorSpace(input);
+    const b = evaluateOperatorSpace(input);
+    expect(a.spaceId).toBe(b.spaceId);
+  });
+
+  it('different fingerprints produce different spaceIds', () => {
+    const a = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'fp-aaa',
+      loginTimeMs: Date.now(),
+    });
+    const b = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'fp-bbb',
+      loginTimeMs: Date.now(),
+    });
+    expect(a.spaceId).not.toBe(b.spaceId);
+  });
+
+  it('different planes produce different spaceIds even with same fingerprint', () => {
+    const fp = 'shared-fp-xyz';
+    const a = evaluateOperatorSpace({
+      accessPlane: 'web',
+      authState: 'authenticated',
+      sessionFingerprint: fp,
+    });
+    const b = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: fp,
+    });
+    expect(a.spaceId).not.toBe(b.spaceId);
+  });
+
+  it('spaceId is 16 hex characters', () => {
+    const d = evaluateOperatorSpace({
+      accessPlane: 'api',
+      authState: 'service_account',
+      sessionFingerprint: 'api-svc-001',
+    });
+    expect(d.spaceId).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Serialisation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('operatorSpaceToRecord', () => {
+  it('produces a flat JSON-serialisable record', () => {
+    const d = evaluateOperatorSpace({
+      accessPlane: 'terminal',
+      authState: 'authenticated',
+      sessionFingerprint: 'ser-test',
+      loginTimeMs: Date.now(),
+    });
+    const rec = operatorSpaceToRecord(d);
+    expect(typeof rec['ring']).toBe('string');
+    expect(typeof rec['trust_score']).toBe('number');
+    expect(typeof rec['space_id']).toBe('string');
+    expect(Array.isArray(rec['governance_flags'])).toBe(true);
+    // Should be JSON-serialisable without error
+    expect(() => JSON.stringify(rec)).not.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// L13 tier mapping
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ringToGovernanceTier', () => {
+  it('maps rings to L13 governance tiers', () => {
+    expect(ringToGovernanceTier('core')).toBe('ALLOW');
+    expect(ringToGovernanceTier('outer')).toBe('QUARANTINE');
+    expect(ringToGovernanceTier('restricted')).toBe('ESCALATE');
+    expect(ringToGovernanceTier('blocked')).toBe('DENY');
+  });
+});

--- a/tests/test_geoseal_operator_space.py
+++ b/tests/test_geoseal_operator_space.py
@@ -1,0 +1,331 @@
+"""Tests for the GeoSeal Operator System-Space Model (Python reference)."""
+
+import pytest
+from src.geoseal_operator_space import (
+    OperatorSpaceInput,
+    decision_to_metadata,
+    derive_fs_topology,
+    evaluate_operator_space,
+    ring_to_governance_tier,
+)
+
+
+# ---------------------------------------------------------------------------
+# FS topology
+# ---------------------------------------------------------------------------
+
+
+def test_web_anonymous_topology():
+    topo = derive_fs_topology("web", "anonymous")
+    assert topo.sandbox_level == "full"
+    assert topo.accessible_roots == []
+    assert topo.temp_only is True
+    assert topo.persists_across_sessions is False
+    assert topo.mount_points == []
+
+
+def test_web_authenticated_topology():
+    topo = derive_fs_topology("web", "authenticated")
+    assert topo.sandbox_level == "full"
+    assert topo.persists_across_sessions is True
+    assert topo.temp_only is False
+
+
+def test_terminal_sudo_topology():
+    topo = derive_fs_topology("terminal", "sudo")
+    assert topo.sandbox_level == "none"
+    assert "/" in topo.accessible_roots
+    assert "/" in topo.writable_paths
+    assert topo.persists_across_sessions is True
+    assert len(topo.mount_points) > 0
+
+
+def test_terminal_authenticated_topology():
+    topo = derive_fs_topology("terminal", "authenticated")
+    assert topo.sandbox_level == "none"
+    assert any("home" in r or r == "~" for r in topo.accessible_roots)
+    assert topo.persists_across_sessions is True
+
+
+def test_terminal_anonymous_topology():
+    topo = derive_fs_topology("terminal", "anonymous")
+    assert topo.sandbox_level == "partial"
+    assert topo.temp_only is True
+    assert topo.persists_across_sessions is False
+
+
+def test_app_authenticated_topology():
+    topo = derive_fs_topology("app", "authenticated")
+    assert topo.sandbox_level == "partial"
+    assert topo.persists_across_sessions is True
+    assert topo.mount_points == []
+
+
+def test_app_anonymous_topology():
+    topo = derive_fs_topology("app", "anonymous")
+    assert topo.accessible_roots == []
+    assert topo.temp_only is True
+
+
+def test_api_anonymous_topology():
+    topo = derive_fs_topology("api", "anonymous")
+    assert topo.sandbox_level == "full"
+
+
+# ---------------------------------------------------------------------------
+# Ring + trust
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "plane, auth, expected_ring, expected_trust",
+    [
+        ("terminal", "sudo", "core", 0.95),
+        ("terminal", "authenticated", "core", 0.85),
+        ("terminal", "service_account", "core", 0.80),
+        ("terminal", "anonymous", "restricted", 0.35),
+        ("app", "authenticated", "outer", 0.70),
+        ("app", "service_account", "outer", 0.65),
+        ("app", "anonymous", "restricted", 0.25),
+        ("api", "service_account", "core", 0.80),
+        ("api", "authenticated", "outer", 0.70),
+        ("api", "anonymous", "blocked", 0.05),
+        ("web", "authenticated", "outer", 0.60),
+        ("web", "anonymous", "blocked", 0.05),
+    ],
+)
+def test_ring_derivation(plane, auth, expected_ring, expected_trust):
+    inp = OperatorSpaceInput(
+        access_plane=plane,
+        auth_state=auth,
+        session_fingerprint="test-sess-001",
+        login_time_ms=None if auth == "anonymous" else 1716000000000,
+    )
+    d = evaluate_operator_space(inp)
+    assert d.ring == expected_ring
+    assert d.trust_score == expected_trust
+
+
+# ---------------------------------------------------------------------------
+# Governance flags
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_sudo_elevated_flag():
+    d = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="terminal",
+            auth_state="sudo",
+            session_fingerprint="sudo-sess",
+            login_time_ms=1716000000000,
+        )
+    )
+    assert "ELEVATED_TERMINAL" in d.governance_flags
+
+
+def test_web_anonymous_unauthenticated_and_temp_flags():
+    d = evaluate_operator_space(OperatorSpaceInput(access_plane="web", auth_state="anonymous"))
+    assert "UNAUTHENTICATED_WEB" in d.governance_flags
+    assert "TEMP_FS_ONLY" in d.governance_flags
+
+
+def test_api_anonymous_unauthenticated_flag():
+    d = evaluate_operator_space(OperatorSpaceInput(access_plane="api", auth_state="anonymous"))
+    assert "UNAUTHENTICATED_API" in d.governance_flags
+
+
+def test_terminal_service_account_elevated_flag():
+    d = evaluate_operator_space(
+        OperatorSpaceInput(access_plane="terminal", auth_state="service_account", session_fingerprint="svc")
+    )
+    assert "SERVICE_ACCOUNT_ELEVATED" in d.governance_flags
+
+
+def test_missing_login_time_flag():
+    d = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="terminal",
+            auth_state="authenticated",
+            session_fingerprint="sess-no-time",
+            # login_time_ms intentionally None
+        )
+    )
+    assert "SESSION_MISSING_LOGIN_TIME" in d.governance_flags
+
+
+def test_web_native_path_cross_plane_claim():
+    d = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="web",
+            auth_state="authenticated",
+            session_fingerprint="web-sess",
+            login_time_ms=1716000000000,
+            claimed_paths=["/home/user/documents"],
+        )
+    )
+    assert "CROSS_PLANE_CLAIM" in d.governance_flags
+
+
+def test_terminal_http_url_cross_plane_claim():
+    d = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="terminal",
+            auth_state="authenticated",
+            session_fingerprint="term-sess",
+            login_time_ms=1716000000000,
+            claimed_paths=["http://example.com/file.txt"],
+        )
+    )
+    assert "CROSS_PLANE_CLAIM" in d.governance_flags
+
+
+def test_terminal_local_path_no_cross_plane():
+    d = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="terminal",
+            auth_state="authenticated",
+            session_fingerprint="term-ok",
+            login_time_ms=1716000000000,
+            claimed_paths=["/home/user/documents"],
+        )
+    )
+    assert "CROSS_PLANE_CLAIM" not in d.governance_flags
+
+
+def test_api_any_path_is_cross_plane():
+    d = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="api",
+            auth_state="service_account",
+            session_fingerprint="api-svc",
+            claimed_paths=["/tmp/output.json"],
+        )
+    )
+    assert "CROSS_PLANE_CLAIM" in d.governance_flags
+
+
+# ---------------------------------------------------------------------------
+# Trust penalty + ring downgrade
+# ---------------------------------------------------------------------------
+
+
+def test_cross_plane_claim_reduces_trust():
+    baseline = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="terminal",
+            auth_state="authenticated",
+            session_fingerprint="base",
+            login_time_ms=1716000000000,
+        )
+    )
+    with_claim = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="terminal",
+            auth_state="authenticated",
+            session_fingerprint="base",
+            login_time_ms=1716000000000,
+            claimed_paths=["http://evil.com/file"],
+        )
+    )
+    assert abs(with_claim.trust_score - (baseline.trust_score - 0.30)) < 1e-4
+
+
+def test_combined_penalty_downgrades_ring():
+    # terminal+authenticated = 0.85 base; -0.30 cross-plane -0.15 missing login = 0.40 → restricted
+    d = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="terminal",
+            auth_state="authenticated",
+            session_fingerprint="penalized",
+            # no login_time_ms
+            claimed_paths=["http://external.example.com/bad"],
+        )
+    )
+    assert d.ring == "restricted"
+    assert abs(d.trust_score - 0.40) < 1e-4
+
+
+# ---------------------------------------------------------------------------
+# Space ID determinism
+# ---------------------------------------------------------------------------
+
+
+def test_space_id_is_deterministic():
+    inp = OperatorSpaceInput(
+        access_plane="terminal",
+        auth_state="authenticated",
+        session_fingerprint="fixed-fp-abc",
+        login_time_ms=1716000000000,
+    )
+    a = evaluate_operator_space(inp)
+    b = evaluate_operator_space(inp)
+    assert a.space_id == b.space_id
+
+
+def test_different_fingerprints_different_space_ids():
+    a = evaluate_operator_space(
+        OperatorSpaceInput(access_plane="terminal", auth_state="authenticated", session_fingerprint="fp-aaa")
+    )
+    b = evaluate_operator_space(
+        OperatorSpaceInput(access_plane="terminal", auth_state="authenticated", session_fingerprint="fp-bbb")
+    )
+    assert a.space_id != b.space_id
+
+
+def test_different_planes_different_space_ids():
+    a = evaluate_operator_space(
+        OperatorSpaceInput(access_plane="web", auth_state="authenticated", session_fingerprint="shared-fp")
+    )
+    b = evaluate_operator_space(
+        OperatorSpaceInput(access_plane="terminal", auth_state="authenticated", session_fingerprint="shared-fp")
+    )
+    assert a.space_id != b.space_id
+
+
+def test_space_id_is_16_hex_chars():
+    d = evaluate_operator_space(
+        OperatorSpaceInput(access_plane="api", auth_state="service_account", session_fingerprint="api-svc-001")
+    )
+    assert len(d.space_id) == 16
+    assert all(c in "0123456789abcdef" for c in d.space_id)
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_decision_to_metadata():
+    d = evaluate_operator_space(
+        OperatorSpaceInput(
+            access_plane="terminal",
+            auth_state="authenticated",
+            session_fingerprint="ser-test",
+            login_time_ms=1716000000000,
+        )
+    )
+    meta = decision_to_metadata(d)
+    assert isinstance(meta["ring"], str)
+    assert isinstance(meta["trust_score"], float)
+    assert isinstance(meta["space_id"], str)
+    assert isinstance(meta["governance_flags"], list)
+    import json
+    json.dumps(meta)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# L13 tier mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ring, expected_tier",
+    [
+        ("core", "ALLOW"),
+        ("outer", "QUARANTINE"),
+        ("restricted", "ESCALATE"),
+        ("blocked", "DENY"),
+    ],
+)
+def test_ring_to_governance_tier(ring, expected_tier):
+    assert ring_to_governance_tier(ring) == expected_tier


### PR DESCRIPTION
## Summary

Extends GeoSeal's geographic ring model to cover the operator's **system-space position** — the structural location of the operator (web/terminal/app/API) crossed with their auth state (authenticated/anonymous/service_account/sudo).

**Key outputs per evaluation:**
- `ring` — core/outer/restricted/blocked, maps directly to L13 ALLOW/QUARANTINE/ESCALATE/DENY
- `spaceId` — 16-hex deterministic identifier (geoid analog) for receipt anchoring
- `fsTopology` — sandboxLevel/accessibleRoots/writablePaths/mountPoints/persistence flags
- `governanceFlags` — ELEVATED_TERMINAL, UNAUTHENTICATED_WEB, CROSS_PLANE_CLAIM, SESSION_MISSING_LOGIN_TIME, TEMP_FS_ONLY, SERVICE_ACCOUNT_ELEVATED, UNAUTHENTICATED_API

**Cross-plane path validation:** a web-anonymous operator claiming `/home/user/docs` is structurally impossible (no native FS in browser sandbox) — the claim raises `CROSS_PLANE_CLAIM` and reduces trust by 0.30. API operators claiming any path, terminal operators claiming HTTP URLs — same logic.

**Trust penalties:** CROSS_PLANE_CLAIM → −0.30, SESSION_MISSING_LOGIN_TIME → −0.15. Sufficient penalty downgrades the ring.

Both TypeScript (canonical, `src/geosealOperatorSpace.ts`) and Python (reference, `src/geoseal_operator_space.py`) implementations, parity-tested.

## Test plan
- [ ] `npx vitest run tests/geoseal-operator-space.test.ts` — 39 tests pass
- [ ] `PYTHONPATH=. python -m pytest tests/test_geoseal_operator_space.py -v` — 40 tests pass
- [ ] `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added operator space governance system that evaluates access planes and authentication states to assign trust levels and governance decisions (ALLOW, QUARANTINE, ESCALATE, DENY)
  * Governance evaluation now supports web, terminal, app, and API access modes with deterministic trust scoring

* **Tests**
  * Added comprehensive test coverage for operator space governance logic in TypeScript and Python

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->