### PR TITLE
style(tests): format operator space test

### DIFF
--- a/tests/test_geoseal_operator_space.py
+++ b/tests/test_geoseal_operator_space.py
@@ -9,7 +9,6 @@ from src.geoseal_operator_space import (
     ring_to_governance_tier,
 )
 
-
 # ---------------------------------------------------------------------------
 # FS topology
 # ---------------------------------------------------------------------------
@@ -310,6 +309,7 @@ def test_decision_to_metadata():
     assert isinstance(meta["space_id"], str)
     assert isinstance(meta["governance_flags"], list)
     import json
+
     json.dumps(meta)  # must not raise
 
 


### PR DESCRIPTION
## Summary
- formats tests/test_geoseal_operator_space.py with Black so CI lint no longer trips on current main

## Test Evidence
- python -m black --check --target-version py311 --line-length 120 tests\\test_geoseal_operator_space.py -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test module imports restructured with formatting improvements and syntax cleanup for better code organization.
  * Whitespace adjustments applied to enhance readability throughout test files without modifying any test logic, assertions, or expected outcomes.

* **Chores**
  * Code maintenance activities performed to maintain consistent formatting standards across test suites. Includes alignment corrections for proper code structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->