### PR TITLE
fix(docs): correct UM and DR tongue role descriptions to match codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Cross-model biblical null-space evaluation:
 ## What's in the box
 
 - **14-layer governance pipeline** — from context embedding to risk decision
-- **6 Sacred Tongues** — KO (intent), AV (transport), RU (policy), CA (compute), UM (security), DR (structure)
+- **6 Sacred Tongues** — KO (intent), AV (transport), RU (policy), CA (compute), UM (redaction/privacy), DR (authentication/integrity)
 - **Semantic projector** — trained 385x6 matrix mapping sentence embeddings to tongue coordinates
 - **Bijective tongue transport** — byte/token round-trip layer for exact packet and code transport
 - **Harmonic score** — H_score(d*, pd) = 1 / (1 + d* + 2·pd), bounded production Layer 12 score

--- a/aether-browser/README.md
+++ b/aether-browser/README.md
@@ -26,7 +26,7 @@ The core insight from SCBE: **adversarial intent costs exponentially more the fu
 |  |                     |  |   WALL (boundary)   |  |  RU: Perms     | |
 |  +---------------------+  +---------------------+  |  CA: Compute   | |
 |                                                     |  UM: Privacy   | |
-|  +------------------------------------------------+ |  DR: Schema    | |
+|  +------------------------------------------------+ |  DR: AuthInteg | |
 |  |           Poincare Ball Trust Model             | +----------------+ |
 |  |                                                  |                  |
 |  |  origin (0,0) = max trust                       |                  |
@@ -79,9 +79,9 @@ Each request is analysed across six security dimensions, derived from the SCBE S
 | Runethic     | RU | Permission checking     | Does the page have permission for resources? |
 | Cassisivadan | CA | Computation safety      | Is the page running safe scripts?            |
 | Umbroth      | UM | Privacy protection      | Is the page leaking user data?               |
-| Draumric     | DR | Schema validation       | Does the page structure match expectations?  |
+| Draumric     | DR | Authentication/Integrity | Does the page identity and structure match expectations? |
 
-Scores are combined using **phi-weighted composite scoring** (Golden Ratio PHI = 1.618...), giving highest weight to intent analysis (KO) and decreasing weight through schema validation (DR).
+Scores are combined using **phi-weighted composite scoring** (Golden Ratio PHI = 1.618...), giving highest weight to intent analysis (KO) and decreasing weight through authentication/integrity checks (DR).
 
 ### Harmonic Wall
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,8 +211,8 @@ SCBE-AETHERMOORE/
 | AV | Avali | I/O & Messaging |
 | RU | Runethic | Policy & Constraints |
 | CA | Cassisivadan | Logic & Computation |
-| UM | Umbroth | Security & Privacy |
-| DR | Draumric | Types & Structures |
+| UM | Umbroth | Redaction & Privacy |
+| DR | Draumric | Authentication & Integrity |
 
 **Policy Levels:**
 - `standard` - Requires KO tongue

--- a/docs/CODING_SYSTEMS_MASTER_REFERENCE.md
+++ b/docs/CODING_SYSTEMS_MASTER_REFERENCE.md
@@ -91,8 +91,8 @@ The auto-marker (Stage 3) scores each record by analyzing:
 - **AV activation**: Type annotations, schema definitions, knowledge declarations, explanatory content
 - **RU activation**: Validation logic, constraint checking, rule enforcement, governance patterns
 - **CA activation**: Mathematical operations, algorithmic complexity, raw computation
-- **UM activation**: Error handling, security checks, defensive patterns, threat mitigation
-- **DR activation**: Architectural patterns, module structure, composition, abstraction layers
+- **UM activation**: Error handling, redaction/privacy checks, defensive patterns, threat mitigation
+- **DR activation**: Authentication patterns, integrity verification, composition, abstraction layers
 
 ### Phi-Weighting
 
@@ -114,14 +114,14 @@ This means DR-heavy records dominate the distance metric by 11x, ensuring that a
 | AV (Avali) | TypeScript | Wisdom/Knowledge | 60 deg |
 | RU (Runethic) | Rust | Governance/Entropy | 120 deg |
 | CA (Cassisivadan) | C | Compute/Logic | 180 deg |
-| UM (Umbroth) | Julia | Security/Defense | 240 deg |
-| DR (Draumric) | Haskell | Structure/Architecture | 300 deg |
+| UM (Umbroth) | Julia | Redaction/Privacy | 240 deg |
+| DR (Draumric) | Haskell | Authentication/Integrity | 300 deg |
 
 ### Mirror Pairs
 
 - KO <-> DR (Python <-> Haskell): Intent vs Architecture
 - AV <-> CA (TypeScript <-> C): Knowledge vs Compute
-- RU <-> UM (Rust <-> Julia): Governance vs Security
+- RU <-> UM (Rust <-> Julia): Governance vs Redaction/Privacy
 
 ### Foundation Trio
 
@@ -198,8 +198,8 @@ The HYDRA system uses 6 language models, one per tongue:
 | AV | meta-llama/Llama-3.1-8B-Instruct | Knowledge synthesis |
 | RU | Qwen/Qwen2.5-72B-Instruct | Governance verification |
 | CA | meta-llama/Llama-3.3-70B-Instruct | Computation analysis |
-| UM | Qwen/Qwen2.5-7B-Instruct | Security assessment |
-| DR | Qwen/Qwen2.5-Coder-32B-Instruct | Architecture evaluation |
+| UM | Qwen/Qwen2.5-7B-Instruct | Redaction/privacy assessment |
+| DR | Qwen/Qwen2.5-Coder-32B-Instruct | Authentication/integrity evaluation |
 
 ### Consensus Protocol
 

--- a/docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md
+++ b/docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md
@@ -36,7 +36,7 @@ artifacts.
 | Runethic | RU | 2.62 | policy / permissions | Rust |
 | Cassisivadan | CA | 4.24 | computation / transformation | Mathematica |
 | Umbroth | UM | 6.85 | privacy / protection | Haskell |
-| Draumric | DR | 11.09 | schema / authentication | Markdown |
+| Draumric | DR | 11.09 | authentication / integrity | Markdown |
 
 Each seed can initialize a node, role, or governance perspective. A
 multi-nodal system is valid only when the combined state remains consistent

--- a/docs/SYSTEM_STATUS.md
+++ b/docs/SYSTEM_STATUS.md
@@ -49,8 +49,8 @@
 - [x] AV (Avali) - I/O & Messaging
 - [x] RU (Runethic) - Policy & Constraints
 - [x] CA (Cassisivadan) - Logic & Computation
-- [x] UM (Umbroth) - Security & Privacy
-- [x] DR (Draumric) - Types & Structures
+- [x] UM (Umbroth) - Redaction & Privacy
+- [x] DR (Draumric) - Authentication & Integrity
 
 ### Fleet Management System
 - [x] Agent registration with spectral identity

--- a/docs/TONGUE_CODING_LANGUAGE_MAP.md
+++ b/docs/TONGUE_CODING_LANGUAGE_MAP.md
@@ -10,8 +10,8 @@
 | **AV** | Avali | **TypeScript** | Wisdom/Knowledge tongue. TypeScript encodes structural knowledge through its type system. Types are declarative wisdom about data shape. AV governs the Poincare embedding layers (L3-L4) where structure is made explicit. TypeScript's architecture orientation maps to AV's role as the "knows what it is" tongue. | 60 deg | w_AV = phi^1 = 1.618 |
 | **RU** | Runethic | **Rust** | Governance/Entropy tongue. Rust's ownership and borrow checker enforce governance at compile time. Memory safety rules are Runethic law: the compiler is the judge. RU governs the defensive verification layers (L5-L6) where constraints are checked. Rust's zero-cost abstractions embody RU's principle that governance should not add overhead. | 120 deg | w_RU = phi^2 = 2.618 |
 | **CA** | Cassisivadan | **C** | Compute/Logic tongue. C is raw computation without abstraction: pointers, manual memory, direct hardware access. CA governs the phase transform and realm distance layers (L7-L8) where mathematical computation is primary. C sits closest to the machine, and CA sits closest to pure logic. | 180 deg | w_CA = phi^3 = 4.236 |
-| **UM** | Umbroth | **Julia** | Security/Defense tongue. Julia combines high-level expressiveness with near-C performance, making it the language for defensive computation: cryptographic verification, anomaly detection, spectral analysis. UM governs the coherence layers (L9-L10) where threat patterns are detected through FFT and quaternion analysis. Julia's multiple dispatch mirrors UM's multi-vector threat assessment. | 240 deg | w_UM = phi^4 = 6.854 |
-| **DR** | Draumric | **Haskell** | Structure/Architecture tongue. Haskell is pure functional architecture: monads compose, types constrain, referential transparency guarantees structural integrity. DR governs the deepest layers (L11-L12) where triadic temporal aggregation and harmonic scaling operate. Haskell's category-theoretic foundations match DR's role as the tongue of deep pattern and structure. | 300 deg | w_DR = phi^5 = 11.090 |
+| **UM** | Umbroth | **Julia** | Redaction/Privacy tongue. Julia combines high-level expressiveness with near-C performance, making it the language for defensive computation: cryptographic verification, anomaly detection, spectral analysis. UM governs the coherence layers (L9-L10) where redaction patterns are detected through FFT and quaternion analysis. Julia's multiple dispatch mirrors UM's multi-vector privacy enforcement. | 240 deg | w_UM = phi^4 = 6.854 |
+| **DR** | Draumric | **Haskell** | Authentication/Integrity tongue. Haskell is pure functional architecture: monads compose, types constrain, referential transparency guarantees structural integrity. DR governs the deepest layers (L11-L12) where triadic temporal aggregation and harmonic scaling operate. Haskell's category-theoretic foundations match DR's role as the tongue of authentication and integrity verification. | 300 deg | w_DR = phi^5 = 11.090 |
 
 ## Phase Geometry
 
@@ -44,7 +44,7 @@ Mirror pairs cancel surface features but reveal deep structure:
 
 - **KO <-> DR** (Python <-> Haskell): Intent vs Architecture. What code DOES vs what code IS.
 - **AV <-> CA** (TypeScript <-> C): Knowledge vs Compute. What code KNOWS vs what code COMPUTES.
-- **RU <-> UM** (Rust <-> Julia): Governance vs Security. What code GOVERNS vs what code PROTECTS.
+- **RU <-> UM** (Rust <-> Julia): Governance vs Redaction/Privacy. What code GOVERNS vs what code REDACTS/PROTECTS.
 
 ### Quadrature (90 deg separation)
 
@@ -72,7 +72,7 @@ DR: phi^5 = 11.090   (11.090x weight -- rarest but most impactful)
 This means:
 
 - **KO records** (Python) are the most common but carry the lowest per-record weight. They form the broad foundation.
-- **DR records** (Haskell) are the rarest but each one carries 11x the training signal. They teach deep structural understanding.
+- **DR records** (Haskell) are the rarest but each one carries 11x the training signal. They teach deep authentication and integrity patterns.
 - The total phi-weighted training signal is balanced across tongues by adjusting sampling frequency inversely to weight.
 
 ## Extended Language Grid

--- a/docs/specs/ARCHITECTURE.md
+++ b/docs/specs/ARCHITECTURE.md
@@ -203,8 +203,8 @@ SCBE-AETHERMOORE/
 | AV | Avali | I/O & Messaging |
 | RU | Runethic | Policy & Constraints |
 | CA | Cassisivadan | Logic & Computation |
-| UM | Umbroth | Security & Privacy |
-| DR | Draumric | Types & Structures |
+| UM | Umbroth | Redaction & Privacy |
+| DR | Draumric | Authentication & Integrity |
 
 **Policy Levels:**
 - `standard` - Requires KO tongue

--- a/docs/superpowers/specs/2026-05-22-geoseed-infinity-box-runtime.md
+++ b/docs/superpowers/specs/2026-05-22-geoseed-infinity-box-runtime.md
@@ -83,8 +83,8 @@ A shape is not allowed to prove security, physics, or correctness by itself. Eve
 | AV | Transport | Spiral | Research navigation, web/video traversal, widening search |
 | RU | Entropy | Fractal | Adversarial branching, anomaly exploration, ambiguity pressure |
 | CA | Compute | Cubic | Compile checks, tests, transforms, structured tool execution |
-| UM | Security | Icosahedral | Policy gates, threat faces, denial surfaces |
-| DR | Structure | Dodecahedral | Schemas, documentation, contracts, stable interfaces |
+| UM | Redaction/Privacy | Icosahedral | Policy gates, threat faces, denial surfaces |
+| DR | Authentication/Integrity | Dodecahedral | Auth tags, documentation, contracts, stable interfaces |
 
 ### 4.2 PHDM Containment Shapes
 

--- a/packages/sixtongues/README.md
+++ b/packages/sixtongues/README.md
@@ -19,7 +19,7 @@ Each Sacred Tongue has 16 prefixes × 16 suffixes = 256 unique tokens, providing
 | RU | Runethic | Salt/Binding | 294 Hz |
 | CA | Cassisivadan | Ciphertext/Bitcraft | 659 Hz |
 | UM | Umbroth | Redaction/Veil | 196 Hz |
-| DR | Draumric | Tag/Structure | 392 Hz |
+| DR | Draumric | Auth-Tag/Integrity | 392 Hz |
 
 ## Installation
 

--- a/packages/sixtongues/docs/quickstart.md
+++ b/packages/sixtongues/docs/quickstart.md
@@ -69,7 +69,7 @@ Notice each section uses a different tongue:
 - **nonce** → Kor'aelin (flow/intent)
 - **salt** → Runethic (binding)
 - **ct** → Cassisivadan (ciphertext)
-- **tag** → Draumric (structure)
+- **tag** → Draumric (authentication/integrity)
 
 ### Step 6: Decrypt the Message
 


### PR DESCRIPTION
## Summary

- UM (Umbroth) canonical role is **Redaction/Privacy** — not Security/Secrets, Security & Privacy, or Security/Defense
- DR (Draumric) canonical role is **Authentication/Integrity** — not Schema/Structure, Types & Structures, or Structure/Architecture
- Source of truth: `src/geoseal.ts` comments (UM: Redaction/privacy, DR: Authentication/integrity)

## Files changed

- `README.md` — "UM (security), DR (structure)" corrected
- `docs/ARCHITECTURE.md` and `docs/specs/ARCHITECTURE.md` — tongue table rows
- `docs/SYSTEM_STATUS.md` — completion checklist rows
- `docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md` — "schema / authentication" corrected to "authentication / integrity"
- `docs/CODING_SYSTEMS_MASTER_REFERENCE.md` — activation descriptions, language map table, mirror pairs, model roles
- `docs/TONGUE_CODING_LANGUAGE_MAP.md` — full tongue descriptions for UM and DR, mirror pair text
- `docs/superpowers/specs/2026-05-22-geoseed-infinity-box-runtime.md` — tongue role table
- `aether-browser/README.md` — security dimension table and closing description
- `packages/sixtongues/README.md` and `packages/sixtongues/docs/quickstart.md` — crypto-packet domain labels

## Test plan

- [ ] Verify `src/geoseal.ts` still reads: UM Redaction/privacy and DR Authentication/integrity
- [ ] Confirm no test files were modified (only documentation text)
- [ ] Confirm no code logic, weights, or formulas were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated terminology across project documentation for improved clarity and consistency
  * Refined descriptions of core security mechanisms in the "Six Sacred Tongues" framework
  * Added documentation for new `TrustZoneManager.get_record()` method
  * Enhanced architecture and specification documentation for better understanding of system capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->