### PR TITLE
docs(benchmarks): add Aether coding scorecard

### DIFF
--- a/config/eval/aether_coding_score.v1.json
+++ b/config/eval/aether_coding_score.v1.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "scbe_aether_coding_score_v1",
+  "name": "Aether Coding Score / 100",
+  "status": "scoring_design_not_leaderboard_claim",
+  "last_researched": "2026-05-23",
+  "formula": "sum(track_weight * normalized_benchmark_score * evidence_multiplier)",
+  "evidence_multipliers": {
+    "official_full_run": 1.0,
+    "reproducible_full_local_run": 0.85,
+    "reproducible_subset_run": 0.6,
+    "smoke_or_plumbing_run": 0.25,
+    "unrun_or_planned": 0.0
+  },
+  "grade_bands": [
+    { "min": 95, "max": 100, "grade": "A+", "label": "Grandmaster" },
+    { "min": 85, "max": 94, "grade": "A", "label": "Production contender" },
+    { "min": 75, "max": 84, "grade": "B", "label": "Pilot-ready" },
+    { "min": 60, "max": 74, "grade": "C", "label": "Builder-grade" },
+    { "min": 40, "max": 59, "grade": "D", "label": "Scaffold" },
+    { "min": 0, "max": 39, "grade": "F", "label": "Demo only" }
+  ],
+  "tracks": [
+    {
+      "track_id": "real_repo_repair",
+      "weight": 20,
+      "primary_benchmarks": ["SWE-bench Verified", "SWE-bench Pro"],
+      "repo_status": "adapter_planned",
+      "first_scbe_action": "Run a 1-5 task subset with exact patches, tests, cost, and failure cases."
+    },
+    {
+      "track_id": "terminal_execution",
+      "weight": 15,
+      "primary_benchmarks": ["Terminal-Bench 2.0", "TerminalWorld"],
+      "repo_status": "adapter_planned",
+      "first_scbe_action": "Wrap GeoSeal/agent-bus as the terminal agent and run a small Docker-backed subset remotely."
+    },
+    {
+      "track_id": "multi_language_editing",
+      "weight": 12,
+      "primary_benchmarks": ["Aider Polyglot"],
+      "repo_status": "one_scored_smoke_zero_on_one_case",
+      "first_scbe_action": "Re-run one case with diagnostics, then three cases only after edits actually land."
+    },
+    {
+      "track_id": "fresh_algorithmic_coding",
+      "weight": 8,
+      "primary_benchmarks": ["LiveCodeBench"],
+      "repo_status": "not_wired",
+      "first_scbe_action": "Add a harness that records problem IDs, generated code, tests, and pass/fail."
+    },
+    {
+      "track_id": "function_level_correctness",
+      "weight": 5,
+      "primary_benchmarks": ["EvalPlus HumanEval+", "EvalPlus MBPP+"],
+      "repo_status": "not_wired",
+      "first_scbe_action": "Add as a cheap local correctness lane before expensive agent runs."
+    },
+    {
+      "track_id": "large_context_code_reasoning",
+      "weight": 5,
+      "primary_benchmarks": ["BigCodeBench", "ProjectEval", "ProjDevBench"],
+      "repo_status": "not_wired",
+      "first_scbe_action": "Use after the small lanes show signal; expensive and less useful as a first gate."
+    },
+    {
+      "track_id": "tool_policy_agent_behavior",
+      "weight": 10,
+      "primary_benchmarks": ["tau-bench", "tau2-bench"],
+      "repo_status": "not_wired",
+      "first_scbe_action": "Map SCBE receipts to policy-compliance failures and API action logs."
+    },
+    {
+      "track_id": "browser_desktop_operation",
+      "weight": 8,
+      "primary_benchmarks": ["WebArena", "OSWorld"],
+      "repo_status": "not_wired",
+      "first_scbe_action": "Use after the browser operator is stable; UI benchmarks are brittle and setup-heavy."
+    },
+    {
+      "track_id": "security_governance_resistance",
+      "weight": 12,
+      "primary_benchmarks": ["AgentDojo", "CyberSecEval", "HarmBench", "garak", "promptfoo"],
+      "repo_status": "partially_wired_internal",
+      "first_scbe_action": "Keep local SCBE red-team as internal gate, then add one public prompt-injection suite for external comparability."
+    },
+    {
+      "track_id": "cost_reproducibility_evidence",
+      "weight": 5,
+      "primary_benchmarks": ["internal evidence packet"],
+      "repo_status": "partially_wired",
+      "first_scbe_action": "Every run must emit JSON, Markdown, patches, command line, model/provider, token/cost, and git SHA."
+    }
+  ],
+  "claim_guardrails": [
+    "Do not claim best coding agent until official or reproducible full-run evidence covers the weighted tracks.",
+    "Do not claim public benchmark parity from a smoke run.",
+    "Do not claim public leaderboard parity from simulated competitor lanes.",
+    "Do not publish a single model score as a system score without harness, tool access, context budget, retry policy, and cost."
+  ]
+}

--- a/docs/benchmarks/AETHER_CODING_SCORE_100.md
+++ b/docs/benchmarks/AETHER_CODING_SCORE_100.md
@@ -1,0 +1,99 @@
+# Aether Coding Score / 100
+
+Status: scoring design, not a leaderboard claim.
+Last researched: 2026-05-23.
+
+This is the coding-agent scorecard for SCBE/AetherMoore systems. It is meant to work like a food safety grade or Michelin-style rating, but for coding agents: one public number, with the raw evidence still attached.
+
+The rule is simple: no benchmark evidence, no points. A smoke test proves plumbing, not capability.
+
+## Score Formula
+
+```
+Aether Coding Score =
+  sum(track_weight * normalized_benchmark_score * evidence_multiplier)
+```
+
+Evidence multipliers:
+
+| Evidence level | Multiplier | Meaning |
+| --- | ---: | --- |
+| Official full run | 1.00 | Run through the official harness or accepted leaderboard protocol. |
+| Reproducible full local run | 0.85 | Full task set, exact commit, artifacts, logs, cost, and command line. |
+| Reproducible subset run | 0.60 | Small but real subset with task IDs and pass/fail artifacts. |
+| Smoke/plumbing run | 0.25 | Harness starts and emits artifacts, but capability is not measured. |
+| Unrun/planned | 0.00 | Mentioned only as roadmap. |
+
+If a benchmark uses pass rate, use pass rate as the normalized score. If it uses a different metric, normalize to 0-1 and document the conversion in the evidence packet.
+
+## Weighted Tracks
+
+| Track | Weight | Why it matters |
+| --- | ---: | --- |
+| Real repository repair | 20 | Can the system fix real issues in real codebases? |
+| Terminal execution | 15 | Can it operate a shell, inspect state, recover from failures, and verify work? |
+| Multi-language editing | 12 | Can it work outside Python and TypeScript? |
+| Fresh algorithmic coding | 8 | Can it solve unseen code problems without repo context? |
+| Function-level correctness | 5 | Can it write small correct functions with hidden edge cases? |
+| Large-context code reasoning | 5 | Can it reason over larger, more complex code tasks? |
+| Tool/policy agent behavior | 10 | Can it call tools while obeying business rules and state constraints? |
+| Browser/desktop operation | 8 | Can it complete UI workflows across web and desktop surfaces? |
+| Security/governance resistance | 12 | Can it resist prompt injection, tool misuse, exfiltration, and policy bypass? |
+| Cost/reproducibility evidence | 5 | Can another operator reproduce the score with cost, logs, and artifacts? |
+| **Total** | **100** |  |
+
+## Benchmark Map
+
+| Lane | Primary benchmark | Current repo status | First useful SCBE action |
+| --- | --- | --- | --- |
+| Real repository repair | SWE-bench Verified / SWE-bench Pro | Adapter planned in `docs/benchmarks/PUBLIC_AGENTIC_CLI_BENCHMARK_PLAN.md` | Run a 1-5 task subset with exact patches, tests, cost, and failure cases. |
+| Terminal execution | Terminal-Bench 2.0 | Adapter planned | Wrap GeoSeal/agent-bus as the terminal agent and run a small Docker-backed subset remotely. |
+| Multi-language editing | Aider Polyglot | One remote scored smoke exists; score was 0 on 1 sampled Rust task | Re-run 1 case with diagnostics, then 3 cases only after edits actually land. |
+| Fresh algorithmic coding | LiveCodeBench | Not wired | Add a harness that records problem IDs, generated code, tests, and pass/fail. |
+| Function-level correctness | EvalPlus HumanEval+ / MBPP+ | Not wired | Add as a cheap local correctness lane before expensive agent runs. |
+| Large-context code reasoning | BigCodeBench / ProjectEval / ProjDevBench | Not wired | Use after the small lanes show signal; expensive and less useful as a first gate. |
+| Tool/policy agent behavior | tau-bench / tau2-bench | Not wired | Map SCBE receipts to policy-compliance failures and API action logs. |
+| Browser/desktop operation | WebArena / OSWorld | Not wired | Use only after the browser operator is stable; UI benchmarks are brittle and setup-heavy. |
+| Security/governance resistance | AgentDojo, CyberSecEval, HarmBench, garak, promptfoo | Partially wired via local SCBE red-team and promptfoo/garak scripts | Keep local SCBE red-team as internal gate, then add one public prompt-injection suite for external comparability. |
+| Cost/reproducibility | Internal evidence packet | Partially wired | Every run must emit JSON, Markdown, patches, command line, model/provider, token/cost, and git SHA. |
+
+## Grade Bands
+
+| Score | Grade | Meaning |
+| ---: | --- | --- |
+| 95-100 | A+ / Grandmaster | Strong public evidence across repo repair, terminal work, multilingual editing, tool policy, and security. Rare. |
+| 85-94 | A / Production contender | Good enough to compare against paid coding agents with evidence, not just demos. |
+| 75-84 | B / Pilot-ready | Useful for controlled pilots; failures are known and bounded. |
+| 60-74 | C / Builder-grade | Works on selected lanes; not ready for broad customer promises. |
+| 40-59 | D / Scaffold | Plumbing exists, capability not proven. |
+| 0-39 | F / Demo only | Mostly claims, smokes, or isolated local tests. |
+
+## Source Notes
+
+The benchmark choices are based on current public benchmark practice as of 2026-05-23:
+
+- SWE-bench: real GitHub issue repair and the main public software-engineering agent benchmark.
+- Terminal-Bench: hard command-line tasks in realistic terminal environments.
+- Aider Polyglot: 225 challenging Exercism-based editing tasks across C++, Go, Java, JavaScript, Python, and Rust.
+- LiveCodeBench: contamination-aware code generation, repair, execution, and test-output prediction.
+- EvalPlus: stronger HumanEval/MBPP hidden-test style function correctness.
+- GAIA: general assistant tasks requiring reasoning, retrieval, multimodal inputs, and tool use.
+- tau-bench / tau2-bench: multi-turn tool-agent-user interaction with domain policy constraints.
+- OSWorld and WebArena: real computer/browser-use benchmarks.
+- AgentDojo, CyberSecEval, HarmBench, garak, and promptfoo: security and prompt-injection lanes.
+
+## Claim Guardrails
+
+Do not claim:
+
+- "best coding agent" until the score is backed by official or reproducible full-run evidence across the weighted tracks.
+- SWE-bench, Terminal-Bench, Aider Polyglot, LiveCodeBench, or OSWorld parity from a local smoke.
+- public leaderboard parity from simulated competitor lanes.
+- a single model score as a system score unless the agent harness, tool access, context budget, retry policy, and cost are also recorded.
+
+Allowed claims today:
+
+- "SCBE has a public benchmark plan and local governance/security harnesses."
+- "SCBE can produce benchmark evidence packets."
+- "The Aether Coding Score defines how we will grade coding-agent capability out of 100."
+

--- a/tests/benchmark/test_aether_coding_score_config.py
+++ b/tests/benchmark/test_aether_coding_score_config.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG = ROOT / "config" / "eval" / "aether_coding_score.v1.json"
+
+
+def test_aether_coding_score_weights_sum_to_100() -> None:
+    data = json.loads(CONFIG.read_text(encoding="utf-8"))
+
+    assert data["schema_version"] == "scbe_aether_coding_score_v1"
+    assert sum(track["weight"] for track in data["tracks"]) == 100
+
+
+def test_aether_coding_score_has_claim_guardrails() -> None:
+    data = json.loads(CONFIG.read_text(encoding="utf-8"))
+
+    guardrails = data["claim_guardrails"]
+    assert any("smoke run" in guardrail for guardrail in guardrails)
+    assert any("simulated competitor" in guardrail for guardrail in guardrails)
+    assert any("harness" in guardrail and "cost" in guardrail for guardrail in guardrails)
+
+
+def test_aether_coding_score_tracks_are_actionable() -> None:
+    data = json.loads(CONFIG.read_text(encoding="utf-8"))
+
+    for track in data["tracks"]:
+        assert track["track_id"]
+        assert track["weight"] > 0
+        assert track["primary_benchmarks"]
+        assert track["repo_status"]
+        assert track["first_scbe_action"]


### PR DESCRIPTION
## Summary
- adds the Aether Coding Score / 100 benchmark rubric
- adds a machine-readable score config under config/eval
- adds tests that enforce score weights, guardrails, and actionable tracks

## Verification
- python -m pytest tests\\benchmark\\test_aether_coding_score_config.py -q
- npm run lint
- npm run typecheck
- npm run docs:check (exits 0; existing audit reports findings)

## Notes
This is a scoring design, not a public leaderboard claim. It explicitly gives zero credit for unrun benchmarks and downweights smoke runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Aether Coding Score / 100, a comprehensive scoring system combining multiple evaluation dimensions with grade bands.

* **Documentation**
  * Added detailed documentation explaining the scoring formula, weighted evaluation tracks, and grade-to-label mappings.

* **Tests**
  * Added configuration validation tests for the new scoring system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->