### PR TITLE
style(benchmarks): format Aether score config test

### DIFF
--- a/tests/benchmark/test_aether_coding_score_config.py
+++ b/tests/benchmark/test_aether_coding_score_config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 CONFIG = ROOT / "config" / "eval" / "aether_coding_score.v1.json"
 


### PR DESCRIPTION
## Summary
- formats the Aether Coding Score config test so CI Black passes

## Verification
- black --target-version py311 --line-length 120 tests\\benchmark\\test_aether_coding_score_config.py
- python -m pytest tests\\benchmark\\test_aether_coding_score_config.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor formatting adjustment to test file structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->