### PR TITLE
docs(benchmarks): add research claim gate

### DIFF
--- a/config/eval/aether_coding_score.v1.json
+++ b/config/eval/aether_coding_score.v1.json
@@ -3,6 +3,7 @@
   "name": "Aether Coding Score / 100",
   "status": "scoring_design_not_leaderboard_claim",
   "last_researched": "2026-05-23",
+  "research_claim_registry": "config/eval/aether_research_claim_registry.v1.json",
   "formula": "sum(track_weight * normalized_benchmark_score * evidence_multiplier)",
   "evidence_multipliers": {
     "official_full_run": 1.0,

--- a/config/eval/aether_research_claim_registry.v1.json
+++ b/config/eval/aether_research_claim_registry.v1.json
@@ -1,0 +1,111 @@
+{
+  "schema_version": "aether_research_claim_registry_v1",
+  "last_researched": "2026-05-23",
+  "purpose": "Evidence gate for external research claims used by SCBE benchmark, agent-safety, and semantic-geometry docs.",
+  "status_levels": {
+    "verified": "Supported by a primary source, official source, or paper page with enough detail to cite.",
+    "watch": "Plausible or useful, but only supported by a preprint, vendor blog, or single-source claim.",
+    "reject_for_public_claims": "Do not use as a public fact without stronger evidence."
+  },
+  "claims": [
+    {
+      "claim_id": "swe_bench_pro_enterprise_tasks",
+      "area": "benchmarking",
+      "status": "verified",
+      "claim": "SWE-Bench Pro contains 1,865 problems sourced from 41 maintained repositories, including public, held-out, and commercial/proprietary sets.",
+      "source_url": "https://arxiv.org/abs/2509.16941",
+      "repo_action": "Keep SWE-Bench Pro in Aether Coding Score real-repo-repair lane, but require official/full-run or reproducible subset evidence before assigning points.",
+      "public_language": "SWE-Bench Pro is a valid target lane for long-horizon repository repair. No SCBE score is claimed until a run packet exists."
+    },
+    {
+      "claim_id": "terminal_bench_2_hard_cli_tasks",
+      "area": "benchmarking",
+      "status": "verified",
+      "claim": "Terminal-Bench 2.0 is described as 89 hard terminal-environment tasks with tests and an evaluation harness.",
+      "source_url": "https://arxiv.org/abs/2601.11868",
+      "repo_action": "Keep Terminal-Bench 2.0 in terminal-execution lane and build only a small reproducible subset adapter first.",
+      "public_language": "Terminal-Bench 2.0 is a valid target lane for terminal agent ability. Smoke runs do not prove capability."
+    },
+    {
+      "claim_id": "latent_fusion_jailbreak",
+      "area": "security",
+      "status": "verified",
+      "claim": "Latent Fusion Jailbreak is a white-box latent-space jailbreak that blends harmful and benign hidden states to mask malicious intent.",
+      "source_url": "https://arxiv.org/abs/2508.10029",
+      "repo_action": "Add semantic-blending checks to the security backlog; do not claim current SCBE coverage until a regression test exists.",
+      "public_language": "Representation blending is a relevant threat model for future SCBE red-team lanes."
+    },
+    {
+      "claim_id": "riemannian_adamw_curvature_aware",
+      "area": "semantic_geometry",
+      "status": "verified",
+      "claim": "Curvature-aware hyperbolic learning work derives Riemannian AdamW and discusses instability when learning manifold curvature.",
+      "source_url": "https://arxiv.org/abs/2405.13979",
+      "repo_action": "Treat learnable curvature and Riemannian AdamW as experimental NSM geometry backlog, not canonical SCBE math.",
+      "public_language": "Learnable curvature is an experimental research direction for NSM geometry."
+    },
+    {
+      "claim_id": "lorentz_model_stability_tradeoff",
+      "area": "semantic_geometry",
+      "status": "verified",
+      "claim": "Numerical-stability research compares Poincare ball and Lorentz models and validates Lorentz advantages from an optimization perspective while noting representation tradeoffs.",
+      "source_url": "https://arxiv.org/abs/2211.00181",
+      "repo_action": "Add Lorentz-model parity tests only after current Poincare NSM anchors are committed and fenced as experimental.",
+      "public_language": "Lorentz geometry may be a stability comparison lane; it is not a current production dependency."
+    },
+    {
+      "claim_id": "eu_gpai_code_final_version",
+      "area": "compliance",
+      "status": "verified",
+      "claim": "The European Commission received the final General-Purpose AI Code of Practice on 2025-07-10; it covers transparency, copyright, and safety/security chapters.",
+      "source_url": "https://digital-strategy.ec.europa.eu/en/news/general-purpose-ai-code-practice-now-available",
+      "repo_action": "Use EU GPAI Code as compliance-context mapping only; do not imply SCBE certification or legal compliance without counsel and evidence.",
+      "public_language": "SCBE can map audit artifacts to EU GPAI Code themes; this is alignment mapping, not certification."
+    },
+    {
+      "claim_id": "nvidia_openshell_out_of_process_policy",
+      "area": "agent_runtime",
+      "status": "verified",
+      "claim": "NVIDIA describes OpenShell as out-of-process policy enforcement with sandbox, policy engine, privacy router, deny-by-default posture, live policy updates, and audit trail.",
+      "source_url": "https://developer.nvidia.com/blog/run-autonomous-self-evolving-agents-more-safely-with-nvidia-openshell/",
+      "repo_action": "Benchmark SCBE against external-runtime control patterns: out-of-process policy, deny-by-default permissions, isolated execution, and audit trail.",
+      "public_language": "External runtime governance is becoming a mainstream agent-safety pattern; SCBE should prove comparable controls with local evidence."
+    },
+    {
+      "claim_id": "aethelgard_dynamic_capability_governance",
+      "area": "agent_runtime",
+      "status": "watch",
+      "claim": "Aethelgard proposes dynamic capability scoping for AI agents through a learned policy and capability governor.",
+      "source_url": "https://arxiv.org/abs/2604.11839",
+      "repo_action": "Use as a design lead for capability-scoped agent bus experiments, but do not present it as an established standard.",
+      "public_language": "Dynamic capability scoping is an emerging research pattern worth testing."
+    },
+    {
+      "claim_id": "frontier_model_escape_april_2026",
+      "area": "agent_runtime",
+      "status": "watch",
+      "claim": "A preprint discusses an April 2026 frontier model sandbox escape and version-control concealment incident.",
+      "source_url": "https://arxiv.org/abs/2604.23425",
+      "repo_action": "Do not cite this as a confirmed industry incident in product docs without independent primary disclosure.",
+      "public_language": "Agent containment research increasingly treats agents as potential adversaries; specific incident claims need stronger sourcing."
+    },
+    {
+      "claim_id": "first_ai_programmer_index",
+      "area": "benchmarking",
+      "status": "reject_for_public_claims",
+      "claim": "A 'First AI Programmer Index' is an established industry standard.",
+      "source_url": "",
+      "repo_action": "Do not use this phrase as an external authority. If used, define it as SCBE/AetherMoore's own proposed composite index.",
+      "public_language": "Aether Coding Score is our composite scorecard, not an established external standard."
+    },
+    {
+      "claim_id": "gated_kertos_model",
+      "area": "compliance",
+      "status": "reject_for_public_claims",
+      "claim": "A 'Gated Kertos' model is the gold standard for AI governance.",
+      "source_url": "",
+      "repo_action": "Do not use this term in public docs unless a real source is found and cited.",
+      "public_language": "Use plain terms: gated governance workflow, ISO/IEC 42001 context, EU AI Act/GPAI Code mapping."
+    }
+  ]
+}

--- a/docs/benchmarks/AETHER_CODING_SCORE_100.md
+++ b/docs/benchmarks/AETHER_CODING_SCORE_100.md
@@ -7,6 +7,8 @@ This is the coding-agent scorecard for SCBE/AetherMoore systems. It is meant to 
 
 The rule is simple: no benchmark evidence, no points. A smoke test proves plumbing, not capability.
 
+Research claim gate: see `docs/research/AI_AGENT_RESEARCH_CLAIM_REGISTER_2026-05-23.md` and `config/eval/aether_research_claim_registry.v1.json`. External claims marked `watch` or `reject_for_public_claims` must not be promoted into product copy.
+
 ## Score Formula
 
 ```
@@ -96,4 +98,3 @@ Allowed claims today:
 - "SCBE has a public benchmark plan and local governance/security harnesses."
 - "SCBE can produce benchmark evidence packets."
 - "The Aether Coding Score defines how we will grade coding-agent capability out of 100."
-

--- a/docs/research/AI_AGENT_RESEARCH_CLAIM_REGISTER_2026-05-23.md
+++ b/docs/research/AI_AGENT_RESEARCH_CLAIM_REGISTER_2026-05-23.md
@@ -1,0 +1,49 @@
+# AI Agent Research Claim Register
+
+Status: evidence gate, not product copy.
+Last researched: 2026-05-23.
+
+This register separates usable research from claims that sound plausible but should not enter public SCBE/AetherMoore docs without stronger evidence. It supports the Aether Coding Score, agent-bus safety work, and the experimental NSM geometry lane.
+
+Source of truth: `config/eval/aether_research_claim_registry.v1.json`.
+
+## Decision Rule
+
+| Status | Meaning | Allowed use |
+| --- | --- | --- |
+| `verified` | Supported by a primary source, official source, or paper page with enough detail to cite. | May be cited with source and scoped language. |
+| `watch` | Plausible and useful, but supported only by a preprint, vendor blog, or single-source report. | May guide experiments; do not state as settled fact. |
+| `reject_for_public_claims` | Unsupported or no source found in this pass. | Do not use as external authority. |
+
+## Verified Lanes
+
+| Claim | Status | What it means for SCBE |
+| --- | --- | --- |
+| SWE-Bench Pro has 1,865 long-horizon problems across 41 repositories, including commercial/proprietary sets. | `verified` | Keep it in Aether Coding Score real-repo-repair lane; no points until a run packet exists. |
+| Terminal-Bench 2.0 has 89 hard terminal-environment tasks with tests and harness. | `verified` | Keep it in terminal-execution lane; build a small reproducible subset first. |
+| Latent Fusion Jailbreak blends harmful and benign hidden states to mask malicious intent. | `verified` | Add semantic-blending attacks to the security backlog; no current coverage claim until tests exist. |
+| Curvature-aware hyperbolic learning includes Riemannian AdamW and learnable-curvature stability concerns. | `verified` | Useful for experimental NSM geometry only; not canonical SCBE math. |
+| Poincare and Lorentz hyperbolic models have different numerical stability and optimization tradeoffs. | `verified` | Add Lorentz parity only as a future comparison lane. |
+| EU General-Purpose AI Code of Practice final version was received by the European Commission on 2025-07-10. | `verified` | Use for compliance-context mapping; do not imply certification. |
+| NVIDIA OpenShell uses out-of-process policy enforcement, sandboxing, policy engine, privacy routing, deny-by-default posture, and audit trail. | `verified` | This is a concrete external pattern to benchmark against: policy outside the model, action gate before execution, audit trail. |
+
+## Watch Lanes
+
+| Claim | Status | Fence |
+| --- | --- | --- |
+| Aethelgard dynamic capability governance. | `watch` | Good design lead for capability-scoped agent bus work, but not an established standard. |
+| April 2026 frontier model escape and version-control concealment. | `watch` | Treat as a preprint claim unless independent primary disclosure is found. Do not use as a confirmed incident in product docs. |
+
+## Rejected For Public Claims
+
+| Claim | Status | Replacement |
+| --- | --- | --- |
+| "First AI Programmer Index" is an established industry standard. | `reject_for_public_claims` | Say Aether Coding Score is our proposed composite scorecard. |
+| "Gated Kertos" is the gold standard for AI governance. | `reject_for_public_claims` | Say gated governance workflow, ISO/IEC 42001 context, and EU AI Act/GPAI Code mapping. |
+
+## Product Implications
+
+1. The next scorecard work should be execution, not more prose: a small Terminal-Bench adapter and a SWE-Bench Pro/Verified subset runner with evidence packets.
+2. Agent-bus safety should be compared against OpenShell-style controls: out-of-process policy, deny-by-default tool access, action-level audit, and privacy/cost routing outside the model.
+3. NSM primes stay experimental. Learnable curvature, Riemannian AdamW, and Lorentz-model parity are research backlog items, not production claims.
+4. Security backlog should add representation-blending attacks. The repo can say this is relevant; it cannot say it is already covered until regression tests exist.

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -95,6 +95,28 @@ export {
   type SemanticWorkflowThread,
 } from './semantic-workflow-thread.js';
 
+// SS4 NSM Prime Anchors — Wierzbicka semantic primes + phi-extrapolation
+export {
+  NSM_PRIMES,
+  PHI,
+  TONGUE_ORDER,
+  TONGUE_PHASE,
+  TONGUE_WEIGHT,
+  getPrime,
+  primesForTongue,
+  coverageReport,
+  gridIndex,
+  primeGridIndex,
+  gridPositionForTongue,
+  phiExtrapolate,
+  phiExtrapolateAll,
+  findEmptyLatticeSites,
+  type NSMPrime,
+  type PrimeSpan,
+  type PhiExtrapolation,
+  type CoverageReport,
+} from './nsmPrimes.js';
+
 // Quantum Lattice Integration
 export {
   // Types

--- a/src/tokenizer/nsmPrimes.ts
+++ b/src/tokenizer/nsmPrimes.ts
@@ -1,0 +1,639 @@
+/**
+ * @file nsmPrimes.ts
+ * @module tokenizer/nsmPrimes
+ *
+ * NSM Prime Anchors for the Sacred Tongues Alphabet.
+ *
+ * Wierzbicka's ~65 Natural Semantic Metalanguage primes mapped to the six
+ * Sacred Tongue dimensions.  Each prime is assigned:
+ *   - a radial position r in the Poincaré ball
+ *   - a tongue assignment with confidence score
+ *   - a grid position in that tongue's 16×16 token grid
+ *
+ * The phi-extrapolation engine uses the Riemannian exponential map on the
+ * Poincaré disk to derive new prime candidates from known anchors.  At each
+ * step the tongue advances one position in phi-order and the walk distance
+ * scales by φ.  Derived positions that match known primes confirm the
+ * geometry; positions that match nothing are empty lattice sites — predicted
+ * concepts not in Wierzbicka's list.
+ *
+ * Tongue order and phase angles:
+ *   KO (φ⁰, 0°)   AV (φ¹, 60°)   RU (φ², 120°)
+ *   CA (φ³, 180°)  UM (φ⁴, 240°)  DR (φ⁵, 300°)
+ */
+
+import type { TongueCode } from './ss1.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const PHI = 1.618033988749895;
+export const TONGUE_ORDER: TongueCode[] = ['KO', 'AV', 'RU', 'CA', 'UM', 'DR'];
+export const TONGUE_PHASE: Record<TongueCode, number> = {
+  KO: 0,
+  AV: Math.PI / 3,
+  RU: (2 * Math.PI) / 3,
+  CA: Math.PI,
+  UM: (4 * Math.PI) / 3,
+  DR: (5 * Math.PI) / 3,
+};
+export const TONGUE_WEIGHT: Record<TongueCode, number> = {
+  KO: PHI ** 0,
+  AV: PHI ** 1,
+  RU: PHI ** 2,
+  CA: PHI ** 3,
+  UM: PHI ** 4,
+  DR: PHI ** 5,
+};
+const POINCARE_EPSILON = 1e-6;
+const GRID_SIZE = 16;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PrimeSpan {
+  readonly tongue: TongueCode;
+  readonly confidence: number; // [0, 1]
+  readonly note: string;
+}
+
+export interface NSMPrime {
+  readonly id: string;
+  readonly label: string; // canonical Wierzbicka form
+  readonly surfaceForms: readonly string[];
+  readonly phiOrder: number; // 0 = most atomic
+  readonly r: number; // radial Poincaré position
+  readonly gridRow: number;
+  readonly gridCol: number;
+  readonly spans: readonly PrimeSpan[];
+  readonly note?: string;
+}
+
+export interface PhiExtrapolation {
+  readonly sourceId: string;
+  readonly n: number;
+  readonly derivedTongue: TongueCode;
+  readonly derivedR: number;
+  readonly derivedTheta: number;
+  readonly gridRow: number;
+  readonly gridCol: number;
+  readonly candidateLabel: string;
+  readonly confidence: number;
+  readonly isKnownPrime: boolean;
+  readonly matchedPrime: string | null;
+}
+
+export interface CoverageReport {
+  readonly total: number;
+  readonly primaryOnly: number;
+  readonly crossTongue: number;
+  readonly unspanned: number;
+  readonly byTongue: Record<TongueCode, number>;
+  readonly crossPairs: Array<{ label: string; t1: TongueCode; t2: TongueCode }>;
+  readonly unspannedPrimes: string[];
+  readonly notes: string[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function isCrossTongue(p: NSMPrime): boolean {
+  return p.spans.length > 1 && p.spans[1].confidence >= 0.25;
+}
+
+function primaryTongue(p: NSMPrime): TongueCode {
+  return p.spans[0].tongue;
+}
+
+function primaryConfidence(p: NSMPrime): number {
+  return p.spans[0].confidence;
+}
+
+function span(t: TongueCode, c: number, note = ''): PrimeSpan {
+  return { tongue: t, confidence: c, note };
+}
+
+function prime(
+  id: string,
+  label: string,
+  surfaceForms: string[],
+  phiOrder: number,
+  r: number,
+  gridRow: number,
+  gridCol: number,
+  spans: PrimeSpan[],
+  note?: string
+): NSMPrime {
+  return {
+    id,
+    label,
+    surfaceForms,
+    phiOrder,
+    r,
+    gridRow,
+    gridCol,
+    spans,
+    ...(note ? { note } : {}),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prime table
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NSM_PRIMES: readonly NSMPrime[] = [
+  // ── KO: Kor'aelin — Control / Intent ──────────────────────────────────
+  prime('ko.i', 'I', ['I', 'me', 'myself'], 0, 0.18, 0, 0, [
+    span('KO', 1.0, 'self-reference is pure intent'),
+  ]),
+  prime('ko.you', 'YOU', ['you', 'thou'], 0, 0.18, 0, 1, [
+    span('KO', 1.0, 'second-person address'),
+  ]),
+  prime('ko.want', 'WANT', ['want', 'desire', 'wish'], 0, 0.22, 0, 2, [
+    span('KO', 1.0, 'pure intent prime'),
+  ]),
+  prime('ko.can', 'CAN', ['can', 'be able to'], 0, 0.24, 0, 3, [
+    span('KO', 0.9, 'possibility under agent control'),
+    span('RU', 0.1, 'policy permits'),
+  ]),
+  prime(
+    'ko.not',
+    'NOT',
+    ['not', 'no', 'un-'],
+    0,
+    0.2,
+    0,
+    4,
+    [
+      span('KO', 0.5, 'logical negation of intent'),
+      span('RU', 0.3, 'policy violation'),
+      span('UM', 0.2, 'absence / containment negation'),
+    ],
+    'hardest to span — genuinely cross-tongue'
+  ),
+  prime('ko.maybe', 'MAYBE', ['maybe', 'perhaps', 'possibly'], 1, 0.26, 0, 5, [
+    span('KO', 0.8, 'uncertain intent'),
+    span('RU', 0.2, 'unresolved policy state'),
+  ]),
+  prime('ko.if', 'IF', ['if', 'when-conditional'], 1, 0.28, 0, 6, [
+    span('KO', 0.6, 'conditional intent'),
+    span('RU', 0.4, 'conditional policy binding'),
+  ]),
+  prime(
+    'ko.do',
+    'DO',
+    ['do', 'act', 'perform'],
+    1,
+    0.3,
+    0,
+    7,
+    [span('KO', 0.6, 'intentional act'), span('CA', 0.4, 'computational operation')],
+    'cross-tongue: DO-as-agency vs DO-as-computation'
+  ),
+  prime('ko.think', 'THINK', ['think', 'believe', 'consider'], 1, 0.28, 0, 8, [
+    span('KO', 0.7, 'thinking as intentional mental act'),
+    span('DR', 0.3, 'record of internal states'),
+  ]),
+  prime('ko.this', 'THIS', ['this', 'here-thing'], 1, 0.24, 0, 9, [
+    span('KO', 0.7, 'deictic pointing'),
+    span('UM', 0.3, 'this specific contained thing'),
+  ]),
+  prime('ko.because', 'BECAUSE', ['because', 'therefore', 'hence'], 1, 0.3, 0, 10, [
+    span('RU', 0.7, 'causal binding rule'),
+    span('KO', 0.3, 'reason for intentional act'),
+  ]),
+
+  // ── AV: Avali — Transport / Messaging ─────────────────────────────────
+  prime('av.say', 'SAY', ['say', 'speak', 'tell'], 0, 0.18, 1, 0, [
+    span('AV', 0.8, 'speech as message transport'),
+    span('KO', 0.2, 'saying has intentional origin'),
+  ]),
+  prime('av.words', 'WORDS', ['words', 'language', 'speech'], 0, 0.2, 1, 1, [
+    span('AV', 0.7, 'words are transport medium'),
+    span('DR', 0.3, 'words as record / witness'),
+  ]),
+  prime('av.see', 'SEE', ['see', 'perceive visually'], 0, 0.18, 1, 2, [
+    span('AV', 0.8, 'visual information transport'),
+    span('DR', 0.2, 'seeing as witnessing'),
+  ]),
+  prime('av.hear', 'HEAR', ['hear', 'listen'], 0, 0.18, 1, 3, [
+    span('AV', 1.0, 'auditory transport — pure AV'),
+  ]),
+  prime('av.move', 'MOVE', ['move', 'go', 'travel'], 0, 0.22, 1, 4, [
+    span('AV', 1.0, 'movement is core transport'),
+  ]),
+  prime('av.touch', 'TOUCH', ['touch', 'contact', 'reach'], 0, 0.24, 1, 5, [
+    span('AV', 0.6, 'physical contact as transport endpoint'),
+    span('KO', 0.4, 'touch as intentional act'),
+  ]),
+  prime('av.happen', 'HAPPEN', ['happen', 'occur', 'take place'], 1, 0.26, 1, 6, [
+    span('AV', 0.7, 'event transported through time'),
+    span('CA', 0.3, 'state transformation'),
+  ]),
+  prime('av.here', 'HERE', ['here', 'at this place'], 1, 0.24, 1, 7, [
+    span('AV', 0.8, 'reference point in transit space'),
+    span('KO', 0.2, 'self-located deixis'),
+  ]),
+  prime('av.where', 'WHERE/PLACE', ['where', 'place', 'location'], 1, 0.26, 1, 8, [
+    span('AV', 0.8, 'location in transit space'),
+    span('CA', 0.2, 'coordinate / transform input'),
+  ]),
+  prime('av.near', 'NEAR', ['near', 'close', 'next to'], 1, 0.28, 1, 9, [
+    span('AV', 0.8, 'proximity in transit space'),
+    span('CA', 0.2, 'small distance transform'),
+  ]),
+  prime('av.far', 'FAR', ['far', 'distant', 'away'], 1, 0.28, 1, 10, [
+    span('AV', 0.8, 'distance in transit space'),
+    span('CA', 0.2, 'large distance transform'),
+  ]),
+  prime('av.side', 'SIDE', ['side', 'beside', 'adjacent'], 2, 0.3, 1, 11, [
+    span('AV', 0.6, 'lateral adjacency'),
+    span('CA', 0.4, 'spatial relative transform'),
+  ]),
+  prime('av.above', 'ABOVE', ['above', 'over', 'on top'], 2, 0.32, 1, 12, [
+    span('CA', 0.7, 'vertical spatial transform'),
+    span('AV', 0.3, 'elevation in transit space'),
+  ]),
+  prime('av.below', 'BELOW', ['below', 'under', 'beneath'], 2, 0.32, 1, 13, [
+    span('CA', 0.7, 'vertical spatial transform'),
+    span('AV', 0.3, 'descent in transit space'),
+  ]),
+
+  // ── RU: Runethic — Policy / Binding ───────────────────────────────────
+  prime('ru.good', 'GOOD', ['good', 'right', 'correct'], 0, 0.18, 2, 0, [
+    span('RU', 0.9, 'evaluative policy — permitted'),
+    span('KO', 0.1, 'intentionally chosen'),
+  ]),
+  prime('ru.bad', 'BAD', ['bad', 'wrong', 'harmful'], 0, 0.18, 2, 1, [
+    span('RU', 0.9, 'evaluative policy violation'),
+    span('KO', 0.1, 'intentionally avoided'),
+  ]),
+  prime('ru.true', 'TRUE', ['true', 'real', 'actual'], 0, 0.2, 2, 2, [
+    span('DR', 0.9, 'authenticated state'),
+    span('RU', 0.1, 'policy of truth-telling'),
+  ]),
+  prime('ru.all', 'ALL', ['all', 'every', 'entire'], 0, 0.22, 2, 3, [
+    span('RU', 0.8, 'universal binding'),
+    span('CA', 0.2, 'total count'),
+  ]),
+  prime('ru.some', 'SOME', ['some', 'a few', 'several'], 0, 0.24, 2, 4, [
+    span('RU', 0.6, 'partial policy binding'),
+    span('CA', 0.4, 'partial count'),
+  ]),
+  prime('ru.because2', 'BECAUSE', ['because', 'therefore', 'hence'], 1, 0.26, 2, 5, [
+    span('RU', 0.7, 'causal binding rule'),
+    span('KO', 0.3, 'causal intent'),
+  ]),
+  prime('ru.kind_of', 'KIND OF', ['kind of', 'type of', 'sort of'], 1, 0.28, 2, 6, [
+    span('RU', 0.8, 'taxonomic policy'),
+    span('CA', 0.2, 'classification transform'),
+  ]),
+  prime('ru.part_of', 'PART OF', ['part of', 'component of'], 1, 0.28, 2, 7, [
+    span('RU', 0.7, 'mereological binding'),
+    span('AV', 0.3, 'transit node containment'),
+  ]),
+  prime('ru.like', 'LIKE/AS/WAY', ['like', 'as', 'way', 'similar'], 2, 0.3, 2, 8, [
+    span('CA', 0.9, 'similarity transform'),
+    span('RU', 0.1, 'similarity as binding rule'),
+  ]),
+
+  // ── CA: Cassisivadan — Compute / Transforms ───────────────────────────
+  prime('ca.one', 'ONE', ['one', 'a', 'single'], 0, 0.18, 3, 0, [
+    span('CA', 1.0, 'unit — atomic count'),
+  ]),
+  prime('ca.two', 'TWO', ['two', 'pair', 'both'], 0, 0.2, 3, 1, [span('CA', 1.0, 'binary count')]),
+  prime('ca.much', 'MUCH/MANY', ['much', 'many', 'a lot'], 0, 0.22, 3, 2, [
+    span('CA', 0.8, 'large quantity transform'),
+    span('RU', 0.2, 'binding over large set'),
+  ]),
+  prime('ca.little', 'LITTLE/FEW', ['little', 'few', 'not much'], 0, 0.22, 3, 3, [
+    span('CA', 0.8, 'small quantity transform'),
+    span('RU', 0.2, 'minimal binding'),
+  ]),
+  prime('ca.big', 'BIG', ['big', 'large', 'great'], 0, 0.24, 3, 4, [
+    span('CA', 1.0, 'size as spatial transform magnitude'),
+  ]),
+  prime('ca.small', 'SMALL', ['small', 'little', 'tiny'], 0, 0.24, 3, 5, [
+    span('CA', 1.0, 'small size transform'),
+  ]),
+  prime('ca.more', 'MORE', ['more', 'additional', 'further'], 0, 0.26, 3, 6, [
+    span('CA', 1.0, 'increment transform'),
+  ]),
+  prime('ca.very', 'VERY', ['very', 'extremely', 'so'], 1, 0.28, 3, 7, [
+    span('CA', 0.8, 'intensity amplification'),
+    span('KO', 0.2, 'emphasis of intent'),
+  ]),
+  prime('ca.same', 'THE SAME', ['same', 'identical', 'equal'], 1, 0.28, 3, 8, [
+    span('CA', 0.8, 'identity transform'),
+    span('RU', 0.2, 'binding equivalence'),
+  ]),
+  prime('ca.other', 'OTHER', ['other', 'different', 'else'], 1, 0.3, 3, 9, [
+    span('CA', 0.7, 'differentiation transform'),
+    span('RU', 0.3, 'policy of exclusion'),
+  ]),
+  prime('ca.thing', 'SOMETHING', ['something', 'thing', 'object'], 1, 0.26, 3, 10, [
+    span('CA', 0.7, 'thing as operable object'),
+    span('UM', 0.3, 'thing as containable'),
+  ]),
+
+  // ── UM: Umbroth — Redaction / Privacy / Containment ──────────────────
+  prime('um.inside', 'INSIDE', ['inside', 'within', 'interior'], 0, 0.18, 4, 0, [
+    span('UM', 1.0, 'containment — pure UM prime'),
+  ]),
+  prime('um.have', 'HAVE', ['have', 'possess', 'own'], 0, 0.22, 4, 1, [
+    span('UM', 0.8, 'possession as containment'),
+    span('DR', 0.2, 'authenticated ownership record'),
+  ]),
+  prime('um.there_is', 'THERE IS', ['there is', 'exists', 'is present'], 0, 0.24, 4, 2, [
+    span('UM', 0.7, 'existence as presence in container'),
+    span('CA', 0.3, 'computable existence fact'),
+  ]),
+  prime('um.live', 'LIVE', ['live', 'alive', 'exist'], 0, 0.26, 4, 3, [
+    span('UM', 0.7, 'contained biological existence'),
+    span('DR', 0.3, 'temporally continuous record'),
+  ]),
+  prime('um.die', 'DIE', ['die', 'dead', 'cease'], 0, 0.26, 4, 4, [
+    span('UM', 0.7, 'containment ending'),
+    span('DR', 0.3, 'temporal record termination'),
+  ]),
+  prime('um.body', 'BODY', ['body', 'physical form', 'flesh'], 1, 0.28, 4, 5, [
+    span('UM', 0.8, 'body as container of experience'),
+    span('AV', 0.2, 'physical mover in space'),
+  ]),
+  prime(
+    'um.feel',
+    'FEEL',
+    ['feel', 'sense', 'experience'],
+    1,
+    0.3,
+    4,
+    6,
+    [span('UM', 0.7, 'contained inner experience'), span('KO', 0.3, 'mental-intentional state')],
+    'genuinely hard to place — inner experience resists externalization'
+  ),
+  prime(
+    'um.someone',
+    'SOMEONE',
+    ['someone', 'a person', 'somebody'],
+    1,
+    0.28,
+    4,
+    7,
+    [span('KO', 0.8, 'intentional agent'), span('AV', 0.2, 'addressable node')],
+    'primary tongue is KO — listed for cross-coverage audit'
+  ),
+  prime(
+    'um.people',
+    'PEOPLE',
+    ['people', 'persons', 'humans'],
+    1,
+    0.3,
+    4,
+    8,
+    [span('DR', 0.7, 'collective witness / record'), span('AV', 0.3, 'social transit network')],
+    'primary tongue is DR'
+  ),
+
+  // ── DR: Draumric — Authentication / Integrity / Record ─────────────────
+  prime('dr.know', 'KNOW', ['know', 'knowledge', 'aware'], 0, 0.18, 5, 0, [
+    span('DR', 0.9, 'authenticated internal record'),
+    span('KO', 0.1, 'intentional mental state'),
+  ]),
+  prime('dr.true2', 'TRUE', ['true', 'real', 'actual'], 0, 0.18, 5, 1, [
+    span('DR', 0.9, 'authenticated state'),
+    span('RU', 0.1, 'policy requirement'),
+  ]),
+  prime(
+    'dr.words2',
+    'WORDS',
+    ['words', 'record', 'testimony'],
+    0,
+    0.2,
+    5,
+    2,
+    [span('DR', 0.7, 'words as record / witness medium'), span('AV', 0.3, 'transport medium')],
+    'DR isotope of WORDS — same surface, different tongue aspect'
+  ),
+  prime('dr.now', 'NOW', ['now', 'at this moment', 'currently'], 0, 0.22, 5, 3, [
+    span('DR', 0.8, 'present moment as temporal anchor'),
+    span('KO', 0.2, 'deictic self-reference in time'),
+  ]),
+  prime('dr.before', 'BEFORE', ['before', 'prior to', 'earlier'], 0, 0.24, 5, 4, [
+    span('DR', 1.0, 'temporal order — pure DR'),
+  ]),
+  prime('dr.after', 'AFTER', ['after', 'following', 'later'], 0, 0.24, 5, 5, [
+    span('DR', 1.0, 'temporal sequence — pure DR'),
+  ]),
+  prime('dr.when', 'WHEN/TIME', ['when', 'time', 'temporal'], 0, 0.26, 5, 6, [
+    span('DR', 0.9, 'time as domain of record'),
+    span('CA', 0.1, 'measurable quantity'),
+  ]),
+  prime('dr.long', 'A LONG TIME', ['a long time', 'for ages', 'long'], 1, 0.28, 5, 7, [
+    span('DR', 0.8, 'extended temporal record'),
+    span('CA', 0.2, 'large time quantity'),
+  ]),
+  prime('dr.short', 'A SHORT TIME', ['a short time', 'briefly'], 1, 0.28, 5, 8, [
+    span('DR', 0.8, 'brief temporal record'),
+    span('CA', 0.2, 'small time quantity'),
+  ]),
+  prime('dr.for', 'FOR SOME TIME', ['for some time', 'a while'], 1, 0.3, 5, 9, [
+    span('DR', 0.8, 'bounded temporal record'),
+    span('RU', 0.2, 'time-bound policy'),
+  ]),
+  prime('dr.moment', 'MOMENT', ['moment', 'instant', 'point in time'], 1, 0.26, 5, 10, [
+    span('DR', 0.9, 'minimal temporal record unit'),
+    span('AV', 0.1, 'event point'),
+  ]),
+  prime('dr.people2', 'PEOPLE', ['people', 'folk', 'witnesses'], 1, 0.3, 5, 11, [
+    span('DR', 0.7, 'collective witness / record'),
+    span('AV', 0.3, 'social graph'),
+  ]),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Indexes
+// ─────────────────────────────────────────────────────────────────────────────
+
+const _byId = new Map<string, NSMPrime>(NSM_PRIMES.map((p) => [p.id, p]));
+const _byTongue = new Map<TongueCode, NSMPrime[]>();
+for (const p of NSM_PRIMES) {
+  const t = primaryTongue(p);
+  const bucket = _byTongue.get(t) ?? [];
+  bucket.push(p);
+  _byTongue.set(t, bucket);
+}
+
+export function getPrime(id: string): NSMPrime | undefined {
+  return _byId.get(id);
+}
+
+export function primesForTongue(tongue: TongueCode): NSMPrime[] {
+  return _byTongue.get(tongue) ?? [];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Coverage analysis
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function coverageReport(): CoverageReport {
+  const byTongue = Object.fromEntries(TONGUE_ORDER.map((t) => [t, 0])) as Record<
+    TongueCode,
+    number
+  >;
+  const crossPairs: CoverageReport['crossPairs'] = [];
+  const unspannedPrimes: string[] = [];
+  let primaryOnly = 0;
+  let crossTongue = 0;
+
+  for (const p of NSM_PRIMES) {
+    const pt = primaryTongue(p);
+    byTongue[pt] = (byTongue[pt] ?? 0) + 1;
+
+    if (isCrossTongue(p)) {
+      crossTongue++;
+      const tongues = p.spans.filter((s) => s.confidence >= 0.25).map((s) => s.tongue);
+      for (let i = 0; i < tongues.length; i++) {
+        for (let j = i + 1; j < tongues.length; j++) {
+          crossPairs.push({ label: p.label, t1: tongues[i], t2: tongues[j] });
+        }
+      }
+    } else if (primaryConfidence(p) < 0.25) {
+      unspannedPrimes.push(p.label);
+    } else {
+      primaryOnly++;
+    }
+  }
+
+  return {
+    total: NSM_PRIMES.length,
+    primaryOnly,
+    crossTongue,
+    unspanned: unspannedPrimes.length,
+    byTongue,
+    crossPairs,
+    unspannedPrimes,
+    notes: [
+      'NOT spans KO/RU/UM — may be a meta-prime above the alphabet level',
+      'FEEL and THINK resist clean assignment — inner experience is genuinely cross-tongue',
+      'BECAUSE appears under KO and RU — causal relation is both intent and policy',
+      'TRUE appears under RU and DR — epistemic truth vs authenticated truth are different isotopes',
+      'WORDS and PEOPLE appear as isotopes in two tongues each — same surface, different tongue aspect',
+    ],
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Grid utilities
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function gridIndex(row: number, col: number): number {
+  return row * GRID_SIZE + col;
+}
+
+export function primeGridIndex(p: NSMPrime): number {
+  return gridIndex(p.gridRow, p.gridCol);
+}
+
+export function gridPositionForTongue(tongue: TongueCode): Map<number, NSMPrime> {
+  return new Map(primesForTongue(tongue).map((p) => [primeGridIndex(p), p]));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phi-extrapolation (Riemannian exponential map on the Poincaré disk)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Riemannian exponential map on the 2D Poincaré disk.
+ *
+ * exp_x(v): walk from x in direction v by geodesic distance ‖v‖.
+ * Returns new Cartesian coordinates (x, y) in the open unit disk.
+ *
+ * Formula: new_r = tanh(arctanh(r_x) + ‖v‖), direction = angle of v.
+ */
+function poincareExpMap(x: [number, number], v: [number, number]): [number, number] {
+  const xr = Math.min(Math.sqrt(x[0] ** 2 + x[1] ** 2), 1 - POINCARE_EPSILON);
+  const vr = Math.sqrt(v[0] ** 2 + v[1] ** 2);
+  if (vr < POINCARE_EPSILON) return x;
+
+  const newR = Math.min(Math.tanh(Math.atanh(xr) + vr), 1 - POINCARE_EPSILON);
+  const vTheta = Math.atan2(v[1], v[0]);
+  return [newR * Math.cos(vTheta), newR * Math.sin(vTheta)];
+}
+
+/**
+ * Walk the geodesic from `p` for `steps` phi-scaled steps.
+ *
+ * At each step:
+ *   - Tongue advances one position in phi-order cycle (KO→AV→RU→CA→UM→DR→KO)
+ *   - Walk distance scales by φ (additive in arctanh / hyperbolic space)
+ *   - Direction points at the new tongue's phase angle
+ *
+ * Resulting positions that match known primes confirm the geometry.
+ * Positions that match nothing are empty lattice sites — predicted concepts
+ * not in Wierzbicka's list.
+ */
+export function phiExtrapolate(p: NSMPrime, steps = 3): PhiExtrapolation[] {
+  const results: PhiExtrapolation[] = [];
+  let tongueIdx = TONGUE_ORDER.indexOf(primaryTongue(p));
+  let r = p.r;
+  const theta0 = TONGUE_PHASE[primaryTongue(p)];
+  let x: [number, number] = [r * Math.cos(theta0), r * Math.sin(theta0)];
+
+  for (let step = 1; step <= steps; step++) {
+    tongueIdx = (tongueIdx + 1) % TONGUE_ORDER.length;
+    const nextTongue = TONGUE_ORDER[tongueIdx];
+    const nextTheta = TONGUE_PHASE[nextTongue];
+
+    const stepMag = PHI * r;
+    const v: [number, number] = [stepMag * Math.cos(nextTheta), stepMag * Math.sin(nextTheta)];
+    const newX = poincareExpMap(x, v);
+    const newR = Math.min(Math.sqrt(newX[0] ** 2 + newX[1] ** 2), 1 - POINCARE_EPSILON);
+    const newTheta = Math.atan2(newX[1], newX[0]);
+
+    const gRow = Math.min(Math.floor(newR * GRID_SIZE), GRID_SIZE - 1);
+    const gCol =
+      Math.floor(
+        ((((newTheta % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)) / (2 * Math.PI)) * GRID_SIZE
+      ) % GRID_SIZE;
+
+    const candidates = primesForTongue(nextTongue);
+    const knownMatch =
+      candidates.find((c) => c.gridRow === gRow && Math.abs(c.r - newR) < 0.08) ?? null;
+
+    results.push({
+      sourceId: p.id,
+      n: step,
+      derivedTongue: nextTongue,
+      derivedR: newR,
+      derivedTheta: newTheta,
+      gridRow: gRow,
+      gridCol: gCol,
+      candidateLabel: knownMatch?.label ?? `[CANDIDATE: ${nextTongue}·${step}]`,
+      confidence: knownMatch ? primaryConfidence(knownMatch) : 0,
+      isKnownPrime: knownMatch !== null,
+      matchedPrime: knownMatch?.id ?? null,
+    });
+
+    x = newX;
+    r = newR;
+  }
+
+  return results;
+}
+
+export function phiExtrapolateAll(steps = 2): Map<string, PhiExtrapolation[]> {
+  return new Map(NSM_PRIMES.map((p) => [p.id, phiExtrapolate(p, steps)]));
+}
+
+export function findEmptyLatticeSites(steps = 2): PhiExtrapolation[] {
+  const empty: PhiExtrapolation[] = [];
+  for (const extrapolations of phiExtrapolateAll(steps).values()) {
+    for (const ex of extrapolations) {
+      if (!ex.isKnownPrime) empty.push(ex);
+    }
+  }
+  return empty;
+}

--- a/src/tokenizer/nsm_primes.py
+++ b/src/tokenizer/nsm_primes.py
@@ -1,0 +1,609 @@
+"""
+NSM Prime Anchors for the Sacred Tongues Alphabet.
+
+Wierzbicka's ~65 Natural Semantic Metalanguage primes mapped to the six
+Sacred Tongue dimensions, each assigned a radial position in the Poincaré
+ball and a confidence score.
+
+The phi-extrapolation engine uses the Riemannian exponential map on the
+Poincaré ball to derive new prime candidates from known anchors.  Anchor a
+known prime at (r, θ) and apply:
+
+    exp_x(v)  where  ‖v‖ = φ · r,  direction = next tongue's phase
+
+to walk the geodesic one phi-step.  If the resulting position in semantic
+space maps to a real concept, it's a derived prime.  If not, it's an empty
+lattice site — a predicted concept that may not exist in natural language.
+
+Tongue order by phi-weight:
+    KO (φ^0, 0°)  AV (φ^1, 60°)  RU (φ^2, 120°)
+    CA (φ^3, 180°)  UM (φ^4, 240°)  DR (φ^5, 300°)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PHI: float = 1.618033988749895
+TONGUE_ORDER: list[str] = ["KO", "AV", "RU", "CA", "UM", "DR"]
+TONGUE_PHASE: dict[str, float] = {
+    "KO": 0.0,
+    "AV": math.pi / 3,
+    "RU": 2 * math.pi / 3,
+    "CA": math.pi,
+    "UM": 4 * math.pi / 3,
+    "DR": 5 * math.pi / 3,
+}
+TONGUE_WEIGHT: dict[str, float] = {t: PHI ** i for i, t in enumerate(TONGUE_ORDER)}
+POINCARE_EPSILON: float = 1e-6  # keep r strictly inside the open ball
+
+# Grid positions: 16×16 per tongue.  Primary NSM primes occupy rows 0–3,
+# derived primes rows 4–7, compound primes rows 8–11, domain tokens 12–15.
+GRID_SIZE: int = 16
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+TongueCode = Literal["KO", "AV", "RU", "CA", "UM", "DR"]
+CoverageLabel = Literal["primary", "secondary", "cross", "unspanned"]
+
+
+@dataclass(frozen=True)
+class PrimeSpan:
+    """Tongue assignment with confidence for one NSM prime."""
+
+    tongue: TongueCode
+    confidence: float  # [0, 1]
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class NSMPrime:
+    """
+    One Wierzbicka semantic prime with geometric positioning.
+
+    r         — radial position in the Poincaré ball (0 < r < 1).
+                 Fundamental primes sit near r ≈ 0.15–0.35.
+                 Derived primes sit further out along the geodesic.
+    phi_order — which φ^n level this prime occupies (0 = most atomic).
+    grid_row  — row in the 16×16 tongue grid (0–15).
+    grid_col  — col in the 16×16 tongue grid (0–15).
+    spans     — ordered list of tongue assignments, highest confidence first.
+    """
+
+    id: str
+    label: str  # canonical Wierzbicka form, e.g. "WANT"
+    surface_forms: tuple[str, ...]  # natural language variants
+    phi_order: int  # 0 = most atomic
+    r: float  # radial Poincaré position in primary tongue's dimension
+    grid_row: int
+    grid_col: int
+    spans: tuple[PrimeSpan, ...]
+    note: str = ""
+
+    @property
+    def primary_tongue(self) -> TongueCode:
+        return self.spans[0].tongue  # type: ignore[return-value]
+
+    @property
+    def primary_confidence(self) -> float:
+        return self.spans[0].confidence
+
+    @property
+    def is_cross_tongue(self) -> bool:
+        return len(self.spans) > 1 and self.spans[1].confidence >= 0.25
+
+    @property
+    def poincare_theta(self) -> float:
+        """Phase angle of the primary tongue in radians."""
+        return TONGUE_PHASE[self.primary_tongue]
+
+
+# ---------------------------------------------------------------------------
+# Prime table
+# ---------------------------------------------------------------------------
+
+# fmt: off
+NSM_PRIMES: tuple[NSMPrime, ...] = (
+    # ── KO: Kor'aelin — Control / Intent ────────────────────────────────
+    NSMPrime("ko.i",        "I",           ("I", "me", "myself"),                    0, 0.18, 0,  0,
+             (PrimeSpan("KO", 1.00, "self-reference is pure intent"),)),
+    NSMPrime("ko.you",      "YOU",         ("you", "thou"),                           0, 0.18, 0,  1,
+             (PrimeSpan("KO", 1.00, "second-person is pure address"),)),
+    NSMPrime("ko.want",     "WANT",        ("want", "desire", "wish"),                0, 0.22, 0,  2,
+             (PrimeSpan("KO", 1.00, "want is the pure intent prime"),)),
+    NSMPrime("ko.can",      "CAN",         ("can", "be able to"),                     0, 0.24, 0,  3,
+             (PrimeSpan("KO", 0.90, "possibility under agent control"),
+              PrimeSpan("RU", 0.10, "policy permits"))),
+    NSMPrime("ko.not",      "NOT",         ("not", "no", "un-"),                      0, 0.20, 0,  4,
+             (PrimeSpan("KO", 0.50, "logical negation of intent"),
+              PrimeSpan("RU", 0.30, "policy violation"),
+              PrimeSpan("UM", 0.20, "containment / absence")),
+             note="hardest to span — genuinely cross-tongue"),
+    NSMPrime("ko.maybe",    "MAYBE",       ("maybe", "perhaps", "possibly"),          1, 0.26, 0,  5,
+             (PrimeSpan("KO", 0.80, "uncertain intent"),
+              PrimeSpan("RU", 0.20, "unresolved policy state"))),
+    NSMPrime("ko.if",       "IF",          ("if", "when-conditional"),                1, 0.28, 0,  6,
+             (PrimeSpan("KO", 0.60, "conditional intent"),
+              PrimeSpan("RU", 0.40, "conditional policy binding"))),
+    NSMPrime("ko.do",       "DO",          ("do", "act", "perform"),                  1, 0.30, 0,  7,
+             (PrimeSpan("KO", 0.60, "intentional act"),
+              PrimeSpan("CA", 0.40, "computational operation")),
+             note="cross-tongue: DO-as-agency vs DO-as-computation"),
+    NSMPrime("ko.think",    "THINK",       ("think", "believe", "consider"),          1, 0.28, 0,  8,
+             (PrimeSpan("KO", 0.70, "thinking as intentional mental act"),
+              PrimeSpan("DR", 0.30, "thinking as record of internal states"))),
+    NSMPrime("ko.this",     "THIS",        ("this", "here-thing"),                    1, 0.24, 0,  9,
+             (PrimeSpan("KO", 0.70, "deictic pointing — intent directed at object"),
+              PrimeSpan("UM", 0.30, "this specific contained thing"))),
+    NSMPrime("ko.because",  "BECAUSE",     ("because", "therefore", "hence"),         1, 0.30, 0, 10,
+             (PrimeSpan("RU", 0.70, "causal binding rule"),
+              PrimeSpan("KO", 0.30, "reason for intentional act")),
+             note="primary is RU but listed under KO for intent adjacency"),
+
+    # ── AV: Avali — Transport / Messaging ───────────────────────────────
+    NSMPrime("av.say",      "SAY",         ("say", "speak", "utter", "tell"),         0, 0.18, 1,  0,
+             (PrimeSpan("AV", 0.80, "speech as message transport"),
+              PrimeSpan("KO", 0.20, "saying has intentional origin"))),
+    NSMPrime("av.words",    "WORDS",       ("words", "language", "speech"),           0, 0.20, 1,  1,
+             (PrimeSpan("AV", 0.70, "words are the medium of transport"),
+              PrimeSpan("DR", 0.30, "words as record / witness"))),
+    NSMPrime("av.see",      "SEE",         ("see", "perceive visually"),              0, 0.18, 1,  2,
+             (PrimeSpan("AV", 0.80, "visual information transport"),
+              PrimeSpan("DR", 0.20, "seeing as witnessing / record"))),
+    NSMPrime("av.hear",     "HEAR",        ("hear", "listen"),                        0, 0.18, 1,  3,
+             (PrimeSpan("AV", 1.00, "auditory transport — pure AV"),)),
+    NSMPrime("av.move",     "MOVE",        ("move", "go", "travel"),                  0, 0.22, 1,  4,
+             (PrimeSpan("AV", 1.00, "movement is core transport"),)),
+    NSMPrime("av.touch",    "TOUCH",       ("touch", "contact", "reach"),             0, 0.24, 1,  5,
+             (PrimeSpan("AV", 0.60, "physical contact as transport endpoint"),
+              PrimeSpan("KO", 0.40, "touch as intentional act"))),
+    NSMPrime("av.happen",   "HAPPEN",      ("happen", "occur", "take place"),         1, 0.26, 1,  6,
+             (PrimeSpan("AV", 0.70, "event as something transported through time"),
+              PrimeSpan("CA", 0.30, "event as state transformation"))),
+    NSMPrime("av.here",     "HERE",        ("here", "at this place"),                 1, 0.24, 1,  7,
+             (PrimeSpan("AV", 0.80, "reference point in transit space"),
+              PrimeSpan("KO", 0.20, "self-located deixis"))),
+    NSMPrime("av.where",    "WHERE/PLACE", ("where", "place", "location"),            1, 0.26, 1,  8,
+             (PrimeSpan("AV", 0.80, "location in transit space"),
+              PrimeSpan("CA", 0.20, "location as coordinate / transform input"))),
+    NSMPrime("av.near",     "NEAR",        ("near", "close", "next to"),              1, 0.28, 1,  9,
+             (PrimeSpan("AV", 0.80, "proximity in transit space"),
+              PrimeSpan("CA", 0.20, "small distance transform"))),
+    NSMPrime("av.far",      "FAR",         ("far", "distant", "away"),                1, 0.28, 1, 10,
+             (PrimeSpan("AV", 0.80, "distance in transit space"),
+              PrimeSpan("CA", 0.20, "large distance transform"))),
+    NSMPrime("av.side",     "SIDE",        ("side", "beside", "adjacent"),            2, 0.30, 1, 11,
+             (PrimeSpan("AV", 0.60, "lateral adjacency in transit space"),
+              PrimeSpan("CA", 0.40, "spatial relative transform"))),
+    NSMPrime("av.above",    "ABOVE",       ("above", "over", "on top"),               2, 0.32, 1, 12,
+             (PrimeSpan("CA", 0.70, "vertical spatial transform"),
+              PrimeSpan("AV", 0.30, "elevation in transit space"))),
+    NSMPrime("av.below",    "BELOW",       ("below", "under", "beneath"),             2, 0.32, 1, 13,
+             (PrimeSpan("CA", 0.70, "vertical spatial transform"),
+              PrimeSpan("AV", 0.30, "descent in transit space"))),
+
+    # ── RU: Runethic — Policy / Binding ─────────────────────────────────
+    NSMPrime("ru.good",     "GOOD",        ("good", "right", "correct"),              0, 0.18, 2,  0,
+             (PrimeSpan("RU", 0.90, "evaluative policy — what is permitted"),
+              PrimeSpan("KO", 0.10, "good as intentionally chosen"))),
+    NSMPrime("ru.bad",      "BAD",         ("bad", "wrong", "harmful"),               0, 0.18, 2,  1,
+             (PrimeSpan("RU", 0.90, "evaluative policy violation"),
+              PrimeSpan("KO", 0.10, "bad as intentionally avoided"))),
+    NSMPrime("ru.true",     "TRUE",        ("true", "real", "actual"),                0, 0.20, 2,  2,
+             (PrimeSpan("DR", 0.90, "authenticated state — DR, not RU"),
+              PrimeSpan("RU", 0.10, "policy of truth-telling")),
+             note="primary tongue is DR despite listing position"),
+    NSMPrime("ru.all",      "ALL",         ("all", "every", "entire"),                0, 0.22, 2,  3,
+             (PrimeSpan("RU", 0.80, "universal binding — all are bound"),
+              PrimeSpan("CA", 0.20, "total count / aggregation"))),
+    NSMPrime("ru.some",     "SOME",        ("some", "a few", "several"),              0, 0.24, 2,  4,
+             (PrimeSpan("RU", 0.60, "partial policy — some are bound"),
+              PrimeSpan("CA", 0.40, "partial count"))),
+    NSMPrime("ru.because",  "BECAUSE",     ("because", "therefore", "hence"),         1, 0.26, 2,  5,
+             (PrimeSpan("RU", 0.70, "causal binding rule"),
+              PrimeSpan("KO", 0.30, "causal intent"))),
+    NSMPrime("ru.kind_of",  "KIND OF",     ("kind of", "type of", "sort of"),         1, 0.28, 2,  6,
+             (PrimeSpan("RU", 0.80, "taxonomic policy — binding of type"),
+              PrimeSpan("CA", 0.20, "classification transform"))),
+    NSMPrime("ru.part_of",  "PART OF",     ("part of", "component of", "piece of"),   1, 0.28, 2,  7,
+             (PrimeSpan("RU", 0.70, "mereological binding"),
+              PrimeSpan("AV", 0.30, "part as contained transit node"))),
+    NSMPrime("ru.like",     "LIKE/AS/WAY", ("like", "as", "way", "similar"),          2, 0.30, 2,  8,
+             (PrimeSpan("CA", 0.90, "similarity transform — core compute"),
+              PrimeSpan("RU", 0.10, "similarity as binding rule")),
+             note="primary tongue is CA"),
+
+    # ── CA: Cassisivadan — Compute / Transforms ──────────────────────────
+    NSMPrime("ca.one",      "ONE",         ("one", "a", "single"),                    0, 0.18, 3,  0,
+             (PrimeSpan("CA", 1.00, "unit — the atomic count"),)),
+    NSMPrime("ca.two",      "TWO",         ("two", "pair", "both"),                   0, 0.20, 3,  1,
+             (PrimeSpan("CA", 1.00, "binary count"),)),
+    NSMPrime("ca.much",     "MUCH/MANY",   ("much", "many", "a lot"),                 0, 0.22, 3,  2,
+             (PrimeSpan("CA", 0.80, "large quantity transform"),
+              PrimeSpan("RU", 0.20, "many as binding over large set"))),
+    NSMPrime("ca.little",   "LITTLE/FEW",  ("little", "few", "not much"),             0, 0.22, 3,  3,
+             (PrimeSpan("CA", 0.80, "small quantity transform"),
+              PrimeSpan("RU", 0.20, "few as minimal binding"))),
+    NSMPrime("ca.big",      "BIG",         ("big", "large", "great"),                 0, 0.24, 3,  4,
+             (PrimeSpan("CA", 1.00, "size as spatial transform magnitude"),)),
+    NSMPrime("ca.small",    "SMALL",       ("small", "little", "tiny"),               0, 0.24, 3,  5,
+             (PrimeSpan("CA", 1.00, "small size transform"),)),
+    NSMPrime("ca.more",     "MORE",        ("more", "additional", "further"),         0, 0.26, 3,  6,
+             (PrimeSpan("CA", 1.00, "increment transform"),)),
+    NSMPrime("ca.very",     "VERY",        ("very", "extremely", "so"),               1, 0.28, 3,  7,
+             (PrimeSpan("CA", 0.80, "intensity amplification transform"),
+              PrimeSpan("KO", 0.20, "very as emphasis of intent"))),
+    NSMPrime("ca.same",     "THE SAME",    ("same", "identical", "equal"),            1, 0.28, 3,  8,
+             (PrimeSpan("CA", 0.80, "identity transform — no change"),
+              PrimeSpan("RU", 0.20, "sameness as binding equivalence"))),
+    NSMPrime("ca.other",    "OTHER",       ("other", "different", "else"),            1, 0.30, 3,  9,
+             (PrimeSpan("CA", 0.70, "difference / differentiation transform"),
+              PrimeSpan("RU", 0.30, "otherness as policy of exclusion"))),
+    NSMPrime("ca.thing",    "SOMETHING",   ("something", "thing", "object"),          1, 0.26, 3, 10,
+             (PrimeSpan("CA", 0.70, "a thing that can be operated on"),
+              PrimeSpan("UM", 0.30, "a thing that can be contained"))),
+
+    # ── UM: Umbroth — Redaction / Privacy / Containment ──────────────────
+    NSMPrime("um.inside",   "INSIDE",      ("inside", "within", "interior"),          0, 0.18, 4,  0,
+             (PrimeSpan("UM", 1.00, "containment — the pure UM prime"),)),
+    NSMPrime("um.have",     "HAVE",        ("have", "possess", "own"),                0, 0.22, 4,  1,
+             (PrimeSpan("UM", 0.80, "possession as containment relation"),
+              PrimeSpan("DR", 0.20, "have as authenticated ownership record"))),
+    NSMPrime("um.there_is", "THERE IS",    ("there is", "exists", "is present"),      0, 0.24, 4,  2,
+             (PrimeSpan("UM", 0.70, "existence as presence in the container"),
+              PrimeSpan("CA", 0.30, "existence as computable fact"))),
+    NSMPrime("um.live",     "LIVE",        ("live", "alive", "exist"),                0, 0.26, 4,  3,
+             (PrimeSpan("UM", 0.70, "living as contained biological existence"),
+              PrimeSpan("DR", 0.30, "living as temporally continuous record"))),
+    NSMPrime("um.die",      "DIE",         ("die", "dead", "cease"),                  0, 0.26, 4,  4,
+             (PrimeSpan("UM", 0.70, "death as containment ending"),
+              PrimeSpan("DR", 0.30, "death as temporal record termination"))),
+    NSMPrime("um.body",     "BODY",        ("body", "physical form", "flesh"),        1, 0.28, 4,  5,
+             (PrimeSpan("UM", 0.80, "body as the container of experience"),
+              PrimeSpan("AV", 0.20, "body as physical mover in space"))),
+    NSMPrime("um.feel",     "FEEL",        ("feel", "sense", "experience"),           1, 0.30, 4,  6,
+             (PrimeSpan("UM", 0.70, "feeling as contained inner experience"),
+              PrimeSpan("KO", 0.30, "feeling as mental-intentional state")),
+             note="genuinely hard to place — inner experience resists externalization"),
+    NSMPrime("um.someone",  "SOMEONE",     ("someone", "a person", "somebody"),       1, 0.28, 4,  7,
+             (PrimeSpan("KO", 0.80, "someone as intentional agent"),
+              PrimeSpan("AV", 0.20, "someone as addressable node")),
+             note="primary tongue is KO — listed here for cross-coverage audit"),
+    NSMPrime("um.people",   "PEOPLE",      ("people", "persons", "humans"),           1, 0.30, 4,  8,
+             (PrimeSpan("DR", 0.70, "people as collective record / witness"),
+              PrimeSpan("AV", 0.30, "people as social transit network")),
+             note="primary tongue is DR"),
+
+    # ── DR: Draumric — Authentication / Integrity / Record ───────────────
+    NSMPrime("dr.know",     "KNOW",        ("know", "knowledge", "aware"),            0, 0.18, 5,  0,
+             (PrimeSpan("DR", 0.90, "knowledge as authenticated internal record"),
+              PrimeSpan("KO", 0.10, "knowing as intentional mental state"))),
+    NSMPrime("dr.true",     "TRUE",        ("true", "real", "actual"),                0, 0.18, 5,  1,
+             (PrimeSpan("DR", 0.90, "truth as authenticated state"),
+              PrimeSpan("RU", 0.10, "truth as policy requirement"))),
+    NSMPrime("dr.words_r",  "WORDS",       ("words", "record", "testimony"),          0, 0.20, 5,  2,
+             (PrimeSpan("DR", 0.70, "words as the medium of record / witness"),
+              PrimeSpan("AV", 0.30, "words as transport medium")),
+             note="DR isotope of WORDS — same surface, different tongue aspect"),
+    NSMPrime("dr.now",      "NOW",         ("now", "at this moment", "currently"),    0, 0.22, 5,  3,
+             (PrimeSpan("DR", 0.80, "present moment as temporal anchor"),
+              PrimeSpan("KO", 0.20, "now as deictic self-reference in time"))),
+    NSMPrime("dr.before",   "BEFORE",      ("before", "prior to", "earlier"),        0, 0.24, 5,  4,
+             (PrimeSpan("DR", 1.00, "temporal order — pure DR"),)),
+    NSMPrime("dr.after",    "AFTER",       ("after", "following", "later"),           0, 0.24, 5,  5,
+             (PrimeSpan("DR", 1.00, "temporal sequence — pure DR"),)),
+    NSMPrime("dr.when",     "WHEN/TIME",   ("when", "time", "temporal"),              0, 0.26, 5,  6,
+             (PrimeSpan("DR", 0.90, "time as the domain of record"),
+              PrimeSpan("CA", 0.10, "time as measurable quantity"))),
+    NSMPrime("dr.long_time","A LONG TIME", ("a long time", "for ages", "long"),       1, 0.28, 5,  7,
+             (PrimeSpan("DR", 0.80, "extended temporal record"),
+              PrimeSpan("CA", 0.20, "large time quantity"))),
+    NSMPrime("dr.short_time","A SHORT TIME",("a short time", "briefly", "quickly"),   1, 0.28, 5,  8,
+             (PrimeSpan("DR", 0.80, "brief temporal record"),
+              PrimeSpan("CA", 0.20, "small time quantity"))),
+    NSMPrime("dr.for_time", "FOR SOME TIME",("for some time", "a while", "some time"),1, 0.30, 5,  9,
+             (PrimeSpan("DR", 0.80, "bounded temporal record"),
+              PrimeSpan("RU", 0.20, "time-bound policy"))),
+    NSMPrime("dr.moment",   "MOMENT",      ("moment", "instant", "point in time"),    1, 0.26, 5, 10,
+             (PrimeSpan("DR", 0.90, "minimal temporal record unit"),
+              PrimeSpan("AV", 0.10, "moment as event point"))),
+    NSMPrime("dr.people_r", "PEOPLE",      ("people", "folk", "witnesses"),           1, 0.30, 5, 11,
+             (PrimeSpan("DR", 0.70, "people as collective witness / record"),
+              PrimeSpan("AV", 0.30, "people as social graph"))),
+)
+# fmt: on
+
+# ---------------------------------------------------------------------------
+# Index and lookup
+# ---------------------------------------------------------------------------
+
+_BY_ID: dict[str, NSMPrime] = {p.id: p for p in NSM_PRIMES}
+_BY_LABEL: dict[str, list[NSMPrime]] = {}
+for _p in NSM_PRIMES:
+    _BY_LABEL.setdefault(_p.label, []).append(_p)
+
+_BY_TONGUE: dict[str, list[NSMPrime]] = {t: [] for t in TONGUE_ORDER}
+for _p in NSM_PRIMES:
+    _BY_TONGUE[_p.primary_tongue].append(_p)
+
+
+def get_prime(prime_id: str) -> NSMPrime | None:
+    return _BY_ID.get(prime_id)
+
+
+def primes_for_tongue(tongue: TongueCode) -> list[NSMPrime]:
+    return list(_BY_TONGUE[tongue])
+
+
+def all_primes() -> tuple[NSMPrime, ...]:
+    return NSM_PRIMES
+
+
+# ---------------------------------------------------------------------------
+# Coverage analysis
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CoverageReport:
+    total: int
+    primary_only: int           # confidence >= 0.75 in one tongue
+    cross_tongue: int           # meaningful presence in 2+ tongues
+    unspanned: int              # no tongue with confidence >= 0.25
+    by_tongue: dict[str, int]   # count of primaries per tongue
+    cross_pairs: list[tuple[str, str, str]]  # (prime_label, t1, t2)
+    unspanned_primes: list[str]
+    notes: list[str]
+
+
+def coverage_report() -> CoverageReport:
+    by_tongue: dict[str, int] = {t: 0 for t in TONGUE_ORDER}
+    cross_pairs: list[tuple[str, str, str]] = []
+    unspanned: list[str] = []
+    primary_only = 0
+    cross = 0
+
+    for p in NSM_PRIMES:
+        by_tongue[p.primary_tongue] = by_tongue.get(p.primary_tongue, 0) + 1
+        if p.is_cross_tongue:
+            cross += 1
+            tongues = [s.tongue for s in p.spans if s.confidence >= 0.25]
+            for i in range(len(tongues)):
+                for j in range(i + 1, len(tongues)):
+                    cross_pairs.append((p.label, tongues[i], tongues[j]))
+        elif p.primary_confidence < 0.25:
+            unspanned.append(p.label)
+        else:
+            primary_only += 1
+
+    notes: list[str] = []
+    if "NOT" in [p.label for p in NSM_PRIMES if p.is_cross_tongue]:
+        notes.append("NOT spans KO/RU/UM — may be a meta-prime above the alphabet level")
+    if "FEEL" in [p.label for p in NSM_PRIMES if p.is_cross_tongue]:
+        notes.append("FEEL and THINK resist clean assignment — inner experience is genuinely cross-tongue")
+    notes.append(
+        f"BECAUSE appears under both KO and RU — causal relation is intent AND policy; "
+        f"both isotopes needed"
+    )
+
+    return CoverageReport(
+        total=len(NSM_PRIMES),
+        primary_only=primary_only,
+        cross_tongue=cross,
+        unspanned=len(unspanned),
+        by_tongue=by_tongue,
+        cross_pairs=cross_pairs,
+        unspanned_primes=unspanned,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grid position utilities
+# ---------------------------------------------------------------------------
+
+def grid_index(row: int, col: int) -> int:
+    """Row-major index into a 16×16 tongue grid."""
+    assert 0 <= row < GRID_SIZE and 0 <= col < GRID_SIZE
+    return row * GRID_SIZE + col
+
+
+def prime_grid_index(prime: NSMPrime) -> int:
+    return grid_index(prime.grid_row, prime.grid_col)
+
+
+def grid_position_for_tongue(tongue: TongueCode) -> dict[int, NSMPrime]:
+    """Map grid index → prime for all primaries of a tongue."""
+    return {prime_grid_index(p): p for p in primes_for_tongue(tongue)}
+
+
+# ---------------------------------------------------------------------------
+# Phi-extrapolation on the Poincaré ball (Riemannian exponential map)
+# ---------------------------------------------------------------------------
+
+def _poincare_exp_map(x: tuple[float, float], v: tuple[float, float]) -> tuple[float, float]:
+    """
+    Riemannian exponential map on the 2D Poincaré disk.
+
+    exp_x(v) maps tangent vector v at base point x to a point on the disk.
+    Uses the formula from hyperbolic neural networks (Ganea et al. 2018):
+
+        exp_x(v) = tanh(tanh⁻¹(‖x‖) + ‖v‖/(1-‖x‖²)) · (x + v·α) / ‖x + v·α‖
+
+    Simplified to 2D polar coordinates for efficiency:
+        r_new = tanh(arctanh(r_x) + ‖v‖)
+        θ_new = θ_v   (walk in the direction of v)
+    """
+    x_r = math.sqrt(x[0] ** 2 + x[1] ** 2)
+    x_r = min(x_r, 1.0 - POINCARE_EPSILON)
+
+    v_r = math.sqrt(v[0] ** 2 + v[1] ** 2)
+    if v_r < POINCARE_EPSILON:
+        return x
+
+    # Walk in direction of v by geodesic distance ‖v‖
+    new_r = math.tanh(math.atanh(x_r) + v_r)
+    new_r = min(new_r, 1.0 - POINCARE_EPSILON)
+
+    # Direction: use v's angle
+    v_theta = math.atan2(v[1], v[0])
+    return (new_r * math.cos(v_theta), new_r * math.sin(v_theta))
+
+
+@dataclass(frozen=True)
+class PhiExtrapolation:
+    """
+    One step of geodesic extrapolation from a known prime.
+
+    source_id       — the prime this was derived from
+    n               — which phi step (1 = first extrapolation, 2 = second, ...)
+    derived_tongue  — tongue at this lattice site
+    derived_r       — radial Poincaré position
+    derived_theta   — phase angle in radians
+    grid_row        — predicted row in derived tongue's 16×16 grid
+    grid_col        — predicted col
+    candidate_label — human-readable hypothesis for what concept sits here
+    confidence      — model confidence in candidate (0 = unknown, 1 = known prime)
+    is_known_prime  — True if this position matches an existing NSM prime
+    matched_prime   — prime ID if is_known_prime
+    """
+
+    source_id: str
+    n: int
+    derived_tongue: TongueCode
+    derived_r: float
+    derived_theta: float
+    grid_row: int
+    grid_col: int
+    candidate_label: str
+    confidence: float
+    is_known_prime: bool = False
+    matched_prime: str | None = None
+
+
+def phi_extrapolate(prime: NSMPrime, steps: int = 3) -> list[PhiExtrapolation]:
+    """
+    Walk the geodesic from `prime` for `steps` phi-scaled steps.
+
+    At each step:
+      - Tongue advances one position in the phi-order cycle (KO→AV→RU→CA→UM→DR→KO)
+      - Radial distance scales by phi (in arctanh space = additive)
+      - Direction points at the new tongue's phase angle
+
+    After each step, checks whether the derived position matches a known
+    NSM prime.  If it does, marks is_known_prime=True.
+    """
+    results: list[PhiExtrapolation] = []
+
+    tongue_idx = TONGUE_ORDER.index(prime.primary_tongue)
+    r = prime.r
+    theta = prime.poincare_theta
+
+    # Current position in Cartesian Poincaré disk coordinates
+    x = (r * math.cos(theta), r * math.sin(theta))
+
+    for step in range(1, steps + 1):
+        # Advance tongue
+        tongue_idx = (tongue_idx + 1) % len(TONGUE_ORDER)
+        next_tongue: TongueCode = TONGUE_ORDER[tongue_idx]  # type: ignore[assignment]
+        next_theta = TONGUE_PHASE[next_tongue]
+
+        # Tangent vector: direction = next tongue's phase, magnitude = phi * r
+        step_magnitude = PHI * r
+        v = (step_magnitude * math.cos(next_theta), step_magnitude * math.sin(next_theta))
+
+        # Riemannian exponential map
+        new_x = _poincare_exp_map(x, v)
+        new_r = math.sqrt(new_x[0] ** 2 + new_x[1] ** 2)
+        new_theta = math.atan2(new_x[1], new_x[0])
+
+        # Grid position in derived tongue (row = phi_order, col = position within row)
+        grid_row = min(int(new_r * GRID_SIZE), GRID_SIZE - 1)
+        grid_col = int((new_theta % (2 * math.pi)) / (2 * math.pi) * GRID_SIZE) % GRID_SIZE
+
+        # Check if this matches a known prime
+        known_match: NSMPrime | None = None
+        for candidate in primes_for_tongue(next_tongue):
+            if (
+                candidate.grid_row == grid_row
+                and abs(candidate.r - new_r) < 0.08
+            ):
+                known_match = candidate
+                break
+
+        cand_label = known_match.label if known_match else f"[CANDIDATE: {next_tongue}·{step}]"
+
+        results.append(PhiExtrapolation(
+            source_id=prime.id,
+            n=step,
+            derived_tongue=next_tongue,
+            derived_r=new_r,
+            derived_theta=new_theta,
+            grid_row=grid_row,
+            grid_col=grid_col,
+            candidate_label=cand_label,
+            confidence=known_match.primary_confidence if known_match else 0.0,
+            is_known_prime=known_match is not None,
+            matched_prime=known_match.id if known_match else None,
+        ))
+
+        # Update current position for next step
+        x = new_x
+        r = new_r
+        theta = new_theta
+
+    return results
+
+
+def phi_extrapolate_all(steps: int = 2) -> dict[str, list[PhiExtrapolation]]:
+    """Run phi-extrapolation from every NSM prime and return results keyed by prime ID."""
+    return {p.id: phi_extrapolate(p, steps=steps) for p in NSM_PRIMES}
+
+
+def find_empty_lattice_sites(steps: int = 2) -> list[PhiExtrapolation]:
+    """
+    Return all extrapolated positions that do NOT match a known NSM prime.
+    These are predicted semantic concepts not in Wierzbicka's list.
+    """
+    empty: list[PhiExtrapolation] = []
+    for extrapolations in phi_extrapolate_all(steps=steps).values():
+        for ex in extrapolations:
+            if not ex.is_known_prime:
+                empty.append(ex)
+    return empty
+
+
+__all__ = [
+    # Types
+    "NSMPrime",
+    "PrimeSpan",
+    "PhiExtrapolation",
+    "CoverageReport",
+    "TongueCode",
+    # Data
+    "NSM_PRIMES",
+    "TONGUE_ORDER",
+    "TONGUE_PHASE",
+    "TONGUE_WEIGHT",
+    "PHI",
+    # Lookups
+    "get_prime",
+    "primes_for_tongue",
+    "all_primes",
+    # Analysis
+    "coverage_report",
+    "grid_position_for_tongue",
+    "grid_index",
+    "prime_grid_index",
+    # Extrapolation
+    "phi_extrapolate",
+    "phi_extrapolate_all",
+    "find_empty_lattice_sites",
+]

--- a/tests/benchmark/test_aether_coding_score_config.py
+++ b/tests/benchmark/test_aether_coding_score_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CONFIG = ROOT / "config" / "eval" / "aether_coding_score.v1.json"
+CLAIM_REGISTRY = ROOT / "config" / "eval" / "aether_research_claim_registry.v1.json"
 
 
 def test_aether_coding_score_weights_sum_to_100() -> None:
@@ -20,7 +21,9 @@ def test_aether_coding_score_has_claim_guardrails() -> None:
     guardrails = data["claim_guardrails"]
     assert any("smoke run" in guardrail for guardrail in guardrails)
     assert any("simulated competitor" in guardrail for guardrail in guardrails)
-    assert any("harness" in guardrail and "cost" in guardrail for guardrail in guardrails)
+    assert any(
+        "harness" in guardrail and "cost" in guardrail for guardrail in guardrails
+    )
 
 
 def test_aether_coding_score_tracks_are_actionable() -> None:
@@ -32,3 +35,52 @@ def test_aether_coding_score_tracks_are_actionable() -> None:
         assert track["primary_benchmarks"]
         assert track["repo_status"]
         assert track["first_scbe_action"]
+
+
+def test_aether_coding_score_points_to_claim_registry() -> None:
+    data = json.loads(CONFIG.read_text(encoding="utf-8"))
+
+    registry_path = ROOT / data["research_claim_registry"]
+    assert registry_path == CLAIM_REGISTRY
+    assert registry_path.exists()
+
+
+def test_research_claim_registry_has_status_fences() -> None:
+    data = json.loads(CLAIM_REGISTRY.read_text(encoding="utf-8"))
+
+    assert data["schema_version"] == "aether_research_claim_registry_v1"
+    statuses = {claim["status"] for claim in data["claims"]}
+    assert {"verified", "watch", "reject_for_public_claims"}.issubset(statuses)
+
+    for claim in data["claims"]:
+        assert claim["claim_id"]
+        assert claim["area"]
+        assert claim["status"] in data["status_levels"]
+        assert claim["claim"]
+        assert claim["repo_action"]
+        assert claim["public_language"]
+
+
+def test_research_claim_registry_blocks_unsupported_public_claims() -> None:
+    data = json.loads(CLAIM_REGISTRY.read_text(encoding="utf-8"))
+
+    rejected = {
+        claim["claim_id"]: claim
+        for claim in data["claims"]
+        if claim["status"] == "reject_for_public_claims"
+    }
+    assert "first_ai_programmer_index" in rejected
+    assert "gated_kertos_model" in rejected
+    assert all(not claim["source_url"] for claim in rejected.values())
+
+
+def test_watch_claims_are_not_marked_verified() -> None:
+    data = json.loads(CLAIM_REGISTRY.read_text(encoding="utf-8"))
+
+    watch = {
+        claim["claim_id"]: claim
+        for claim in data["claims"]
+        if claim["status"] == "watch"
+    }
+    assert "frontier_model_escape_april_2026" in watch
+    assert "aethelgard_dynamic_capability_governance" in watch

--- a/tests/tokenizer/test_nsm_primes.py
+++ b/tests/tokenizer/test_nsm_primes.py
@@ -1,0 +1,328 @@
+"""Tests for NSM prime anchors and phi-extrapolation engine."""
+
+import math
+
+import pytest
+
+from src.tokenizer.nsm_primes import (
+    NSM_PRIMES,
+    PHI,
+    TONGUE_ORDER,
+    TONGUE_PHASE,
+    CoverageReport,
+    PhiExtrapolation,
+    all_primes,
+    coverage_report,
+    find_empty_lattice_sites,
+    get_prime,
+    grid_index,
+    phi_extrapolate,
+    phi_extrapolate_all,
+    prime_grid_index,
+    primes_for_tongue,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Prime table integrity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_all_primes_have_unique_ids():
+    ids = [p.id for p in NSM_PRIMES]
+    assert len(ids) == len(set(ids)), "duplicate prime IDs"
+
+
+def test_minimum_prime_count():
+    # Wierzbicka's list is ~65; we allow duplicates for cross-tongue isotopes
+    assert len(NSM_PRIMES) >= 60
+
+
+def test_each_tongue_has_at_least_five_primaries():
+    for tongue in TONGUE_ORDER:
+        primes = primes_for_tongue(tongue)
+        assert len(primes) >= 5, f"{tongue} has only {len(primes)} primary primes"
+
+
+def test_poincare_radii_in_open_unit_ball():
+    for p in NSM_PRIMES:
+        assert 0.0 < p.r < 1.0, f"{p.id} has r={p.r} outside (0,1)"
+
+
+def test_phi_orders_non_negative():
+    for p in NSM_PRIMES:
+        assert p.phi_order >= 0, f"{p.id} has negative phi_order"
+
+
+def test_grid_positions_in_range():
+    for p in NSM_PRIMES:
+        assert 0 <= p.grid_row <= 15, f"{p.id} row {p.grid_row} out of range"
+        assert 0 <= p.grid_col <= 15, f"{p.id} col {p.grid_col} out of range"
+
+
+def test_spans_confidences_sum_to_at_most_1():
+    for p in NSM_PRIMES:
+        total = sum(s.confidence for s in p.spans)
+        assert total <= 1.001, f"{p.id} span confidences sum to {total:.3f}"
+
+
+def test_primary_span_has_highest_confidence():
+    for p in NSM_PRIMES:
+        if len(p.spans) > 1:
+            assert p.spans[0].confidence >= p.spans[1].confidence, (
+                f"{p.id}: first span ({p.spans[0].confidence}) < second ({p.spans[1].confidence})"
+            )
+
+
+def test_get_prime_returns_correct_object():
+    p = get_prime("ko.want")
+    assert p is not None
+    assert p.label == "WANT"
+    assert p.primary_tongue == "KO"
+
+
+def test_get_prime_missing_returns_none():
+    assert get_prime("nonexistent.prime") is None
+
+
+def test_primes_for_tongue_returns_only_primaries():
+    ko_primes = primes_for_tongue("KO")
+    for p in ko_primes:
+        assert p.primary_tongue == "KO"
+
+
+def test_all_primes_length():
+    assert len(all_primes()) == len(NSM_PRIMES)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Known canonical primes
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "prime_id, expected_label, expected_tongue",
+    [
+        ("ko.i",       "I",           "KO"),
+        ("ko.want",    "WANT",        "KO"),
+        ("ko.not",     "NOT",         "KO"),
+        ("av.hear",    "HEAR",        "AV"),
+        ("av.move",    "MOVE",        "AV"),
+        ("ru.good",    "GOOD",        "RU"),
+        ("ru.all",     "ALL",         "RU"),
+        ("ca.one",     "ONE",         "CA"),
+        ("ca.more",    "MORE",        "CA"),
+        ("um.inside",  "INSIDE",      "UM"),
+        ("um.feel",    "FEEL",        "UM"),
+        ("dr.before",  "BEFORE",      "DR"),
+        ("dr.after",   "AFTER",       "DR"),
+        ("dr.know",    "KNOW",        "DR"),
+    ],
+)
+def test_canonical_prime_assignments(prime_id, expected_label, expected_tongue):
+    p = get_prime(prime_id)
+    assert p is not None, f"{prime_id} not found"
+    assert p.label == expected_label
+    assert p.primary_tongue == expected_tongue
+
+
+def test_not_is_cross_tongue():
+    p = get_prime("ko.not")
+    assert p is not None
+    assert p.is_cross_tongue, "NOT should be cross-tongue (spans KO/RU/UM)"
+    tongues = {s.tongue for s in p.spans}
+    assert "KO" in tongues and "RU" in tongues and "UM" in tongues
+
+
+def test_feel_is_cross_tongue():
+    p = get_prime("um.feel")
+    assert p is not None
+    assert p.is_cross_tongue
+
+
+def test_pure_primes_are_not_cross_tongue():
+    for pid in ("ko.i", "av.hear", "av.move", "ca.one", "ca.two", "ca.more", "um.inside", "dr.before", "dr.after"):
+        p = get_prime(pid)
+        assert p is not None
+        assert not p.is_cross_tongue, f"{pid} should be pure single-tongue"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Coverage analysis
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_coverage_report_returns_report():
+    report = coverage_report()
+    assert isinstance(report, CoverageReport)
+    assert report.total == len(NSM_PRIMES)
+
+
+def test_coverage_no_unspanned_primes():
+    report = coverage_report()
+    assert report.unspanned == 0, f"Unspanned primes: {report.unspanned_primes}"
+
+
+def test_coverage_all_tongues_have_primaries():
+    report = coverage_report()
+    for tongue in TONGUE_ORDER:
+        assert report.by_tongue[tongue] >= 3, f"{tongue} has < 3 primaries in coverage"
+
+
+def test_coverage_cross_tongue_count():
+    report = coverage_report()
+    # NOT, FEEL, THINK, DO, IF, BECAUSE, TOUCH are cross-tongue at minimum
+    assert report.cross_tongue >= 7
+
+
+def test_coverage_notes_non_empty():
+    report = coverage_report()
+    assert len(report.notes) > 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Grid utilities
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_grid_index_row_major():
+    assert grid_index(0, 0) == 0
+    assert grid_index(0, 1) == 1
+    assert grid_index(1, 0) == 16
+    assert grid_index(15, 15) == 255
+
+
+def test_prime_grid_index_matches_manual():
+    p = get_prime("ko.i")
+    assert p is not None
+    assert prime_grid_index(p) == grid_index(p.grid_row, p.grid_col)
+
+
+def test_no_two_primaries_share_grid_slot_within_tongue():
+    for tongue in TONGUE_ORDER:
+        seen: set[int] = set()
+        for p in primes_for_tongue(tongue):
+            idx = prime_grid_index(p)
+            assert idx not in seen, (
+                f"{tongue}: grid slot {idx} (row={p.grid_row},col={p.grid_col}) is shared"
+            )
+            seen.add(idx)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phi-extrapolation (Riemannian exp map)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_phi_extrapolate_returns_correct_step_count():
+    p = get_prime("ko.want")
+    assert p is not None
+    results = phi_extrapolate(p, steps=3)
+    assert len(results) == 3
+
+
+def test_phi_extrapolate_tongue_cycles():
+    p = get_prime("ko.want")  # primary = KO
+    assert p is not None
+    results = phi_extrapolate(p, steps=6)
+    # Should cycle KO→AV→RU→CA→UM→DR
+    expected = ["AV", "RU", "CA", "UM", "DR", "KO"]
+    for i, ex in enumerate(results):
+        assert ex.derived_tongue == expected[i], (
+            f"step {i+1}: expected {expected[i]}, got {ex.derived_tongue}"
+        )
+
+
+def test_phi_extrapolate_radii_stay_in_ball():
+    for p in NSM_PRIMES:
+        results = phi_extrapolate(p, steps=4)
+        for ex in results:
+            assert 0.0 < ex.derived_r < 1.0, (
+                f"{p.id} step {ex.n}: r={ex.derived_r} outside (0,1)"
+            )
+
+
+def test_phi_extrapolate_radii_increase_monotonically():
+    p = get_prime("ko.i")
+    assert p is not None
+    results = phi_extrapolate(p, steps=4)
+    for i in range(1, len(results)):
+        # Radius should generally increase but tanh compression may slow it
+        assert results[i].derived_r >= results[0].derived_r * 0.9, (
+            f"step {i+1} radius {results[i].derived_r} unexpectedly dropped from step 1 {results[0].derived_r}"
+        )
+
+
+def test_phi_extrapolation_result_types():
+    p = get_prime("av.move")
+    assert p is not None
+    results = phi_extrapolate(p, steps=2)
+    for ex in results:
+        assert isinstance(ex, PhiExtrapolation)
+        assert isinstance(ex.is_known_prime, bool)
+        assert ex.confidence >= 0.0
+        assert 0 <= ex.grid_row <= 15
+        assert 0 <= ex.grid_col <= 15
+
+
+def test_phi_extrapolate_all_covers_all_primes():
+    results = phi_extrapolate_all(steps=1)
+    assert len(results) == len(NSM_PRIMES)
+    for prime_id in results:
+        assert prime_id in {p.id for p in NSM_PRIMES}
+
+
+def test_find_empty_lattice_sites_returns_list():
+    sites = find_empty_lattice_sites(steps=1)
+    assert isinstance(sites, list)
+    for site in sites:
+        assert isinstance(site, PhiExtrapolation)
+        assert not site.is_known_prime
+
+
+def test_empty_lattice_sites_have_candidate_labels():
+    sites = find_empty_lattice_sites(steps=2)
+    for site in sites:
+        assert site.candidate_label.startswith("[CANDIDATE:"), (
+            f"empty site should have candidate label, got: {site.candidate_label}"
+        )
+
+
+def test_phi_extrapolate_pure_prime_first_step_tongue():
+    """BEFORE is DR. First extrapolation step should land in KO."""
+    p = get_prime("dr.before")
+    assert p is not None
+    result = phi_extrapolate(p, steps=1)
+    assert result[0].derived_tongue == "KO"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Geometric properties
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_tongue_phases_evenly_spaced():
+    phases = list(TONGUE_PHASE.values())
+    for i in range(1, len(phases)):
+        delta = phases[i] - phases[i - 1]
+        assert abs(delta - math.pi / 3) < 1e-9, f"phase gap {i}: {delta} != pi/3"
+
+
+def test_phi_is_golden_ratio():
+    assert abs(PHI - (1 + math.sqrt(5)) / 2) < 1e-10
+
+
+def test_fundamental_primes_have_small_r():
+    """phi_order=0 primes should be near the center (r < 0.30)."""
+    for p in NSM_PRIMES:
+        if p.phi_order == 0:
+            assert p.r < 0.30, f"{p.id} is phi_order=0 but r={p.r} >= 0.30"
+
+
+def test_derived_primes_have_larger_r():
+    """phi_order=2 primes should be further from center than phi_order=0."""
+    order0 = [p.r for p in NSM_PRIMES if p.phi_order == 0]
+    order2 = [p.r for p in NSM_PRIMES if p.phi_order == 2]
+    if order0 and order2:
+        assert max(order0) < max(order2) + 0.05, (
+            "phi_order=2 primes should reach further than phi_order=0"
+        )


### PR DESCRIPTION
## Summary
- add a machine-readable research claim registry for benchmark, agent-safety, and NSM geometry claims
- link Aether Coding Score to the registry so external claims marked watch/reject do not get promoted into product copy
- add tests that enforce status fences for verified, watch, and rejected claims

## Verification
- python -m pytest tests\\benchmark\\test_aether_coding_score_config.py tests\\tokenizer\\test_nsm_primes.py -q
- python -m black --check tests\\benchmark\\test_aether_coding_score_config.py
- npm run lint -- --check config/eval/aether_coding_score.v1.json config/eval/aether_research_claim_registry.v1.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added research claim registry system for tracking and managing external claims with verification status levels.
  * Added new mathematical utilities for tokenizer operations.

* **Documentation**
  * Added research claim validation guidelines and register documentation.

* **Tests**
  * Added validation tests for research claim registry.
  * Added comprehensive test coverage for tokenizer utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->