### PR TITLE
style(tokenizer): satisfy python lint after NSM merge

### DIFF
--- a/src/tokenizer/nsm_primes.py
+++ b/src/tokenizer/nsm_primes.py
@@ -23,7 +23,7 @@ Tongue order by phi-weight:
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Literal
 
 # ---------------------------------------------------------------------------
@@ -40,7 +40,7 @@ TONGUE_PHASE: dict[str, float] = {
     "UM": 4 * math.pi / 3,
     "DR": 5 * math.pi / 3,
 }
-TONGUE_WEIGHT: dict[str, float] = {t: PHI ** i for i, t in enumerate(TONGUE_ORDER)}
+TONGUE_WEIGHT: dict[str, float] = {t: PHI**i for i, t in enumerate(TONGUE_ORDER)}
 POINCARE_EPSILON: float = 1e-6  # keep r strictly inside the open ball
 
 # Grid positions: 16×16 per tongue.  Primary NSM primes occupy rows 0–3,
@@ -351,13 +351,14 @@ def all_primes() -> tuple[NSMPrime, ...]:
 # Coverage analysis
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class CoverageReport:
     total: int
-    primary_only: int           # confidence >= 0.75 in one tongue
-    cross_tongue: int           # meaningful presence in 2+ tongues
-    unspanned: int              # no tongue with confidence >= 0.25
-    by_tongue: dict[str, int]   # count of primaries per tongue
+    primary_only: int  # confidence >= 0.75 in one tongue
+    cross_tongue: int  # meaningful presence in 2+ tongues
+    unspanned: int  # no tongue with confidence >= 0.25
+    by_tongue: dict[str, int]  # count of primaries per tongue
     cross_pairs: list[tuple[str, str, str]]  # (prime_label, t1, t2)
     unspanned_primes: list[str]
     notes: list[str]
@@ -389,8 +390,7 @@ def coverage_report() -> CoverageReport:
     if "FEEL" in [p.label for p in NSM_PRIMES if p.is_cross_tongue]:
         notes.append("FEEL and THINK resist clean assignment — inner experience is genuinely cross-tongue")
     notes.append(
-        f"BECAUSE appears under both KO and RU — causal relation is intent AND policy; "
-        f"both isotopes needed"
+        f"BECAUSE appears under both KO and RU — causal relation is intent AND policy; " f"both isotopes needed"
     )
 
     return CoverageReport(
@@ -408,6 +408,7 @@ def coverage_report() -> CoverageReport:
 # ---------------------------------------------------------------------------
 # Grid position utilities
 # ---------------------------------------------------------------------------
+
 
 def grid_index(row: int, col: int) -> int:
     """Row-major index into a 16×16 tongue grid."""
@@ -427,6 +428,7 @@ def grid_position_for_tongue(tongue: TongueCode) -> dict[int, NSMPrime]:
 # ---------------------------------------------------------------------------
 # Phi-extrapolation on the Poincaré ball (Riemannian exponential map)
 # ---------------------------------------------------------------------------
+
 
 def _poincare_exp_map(x: tuple[float, float], v: tuple[float, float]) -> tuple[float, float]:
     """
@@ -531,28 +533,27 @@ def phi_extrapolate(prime: NSMPrime, steps: int = 3) -> list[PhiExtrapolation]:
         # Check if this matches a known prime
         known_match: NSMPrime | None = None
         for candidate in primes_for_tongue(next_tongue):
-            if (
-                candidate.grid_row == grid_row
-                and abs(candidate.r - new_r) < 0.08
-            ):
+            if candidate.grid_row == grid_row and abs(candidate.r - new_r) < 0.08:
                 known_match = candidate
                 break
 
         cand_label = known_match.label if known_match else f"[CANDIDATE: {next_tongue}·{step}]"
 
-        results.append(PhiExtrapolation(
-            source_id=prime.id,
-            n=step,
-            derived_tongue=next_tongue,
-            derived_r=new_r,
-            derived_theta=new_theta,
-            grid_row=grid_row,
-            grid_col=grid_col,
-            candidate_label=cand_label,
-            confidence=known_match.primary_confidence if known_match else 0.0,
-            is_known_prime=known_match is not None,
-            matched_prime=known_match.id if known_match else None,
-        ))
+        results.append(
+            PhiExtrapolation(
+                source_id=prime.id,
+                n=step,
+                derived_tongue=next_tongue,
+                derived_r=new_r,
+                derived_theta=new_theta,
+                grid_row=grid_row,
+                grid_col=grid_col,
+                candidate_label=cand_label,
+                confidence=known_match.primary_confidence if known_match else 0.0,
+                is_known_prime=known_match is not None,
+                matched_prime=known_match.id if known_match else None,
+            )
+        )
 
         # Update current position for next step
         x = new_x

--- a/tests/benchmark/test_aether_coding_score_config.py
+++ b/tests/benchmark/test_aether_coding_score_config.py
@@ -21,9 +21,7 @@ def test_aether_coding_score_has_claim_guardrails() -> None:
     guardrails = data["claim_guardrails"]
     assert any("smoke run" in guardrail for guardrail in guardrails)
     assert any("simulated competitor" in guardrail for guardrail in guardrails)
-    assert any(
-        "harness" in guardrail and "cost" in guardrail for guardrail in guardrails
-    )
+    assert any("harness" in guardrail and "cost" in guardrail for guardrail in guardrails)
 
 
 def test_aether_coding_score_tracks_are_actionable() -> None:
@@ -64,11 +62,7 @@ def test_research_claim_registry_has_status_fences() -> None:
 def test_research_claim_registry_blocks_unsupported_public_claims() -> None:
     data = json.loads(CLAIM_REGISTRY.read_text(encoding="utf-8"))
 
-    rejected = {
-        claim["claim_id"]: claim
-        for claim in data["claims"]
-        if claim["status"] == "reject_for_public_claims"
-    }
+    rejected = {claim["claim_id"]: claim for claim in data["claims"] if claim["status"] == "reject_for_public_claims"}
     assert "first_ai_programmer_index" in rejected
     assert "gated_kertos_model" in rejected
     assert all(not claim["source_url"] for claim in rejected.values())
@@ -77,10 +71,6 @@ def test_research_claim_registry_blocks_unsupported_public_claims() -> None:
 def test_watch_claims_are_not_marked_verified() -> None:
     data = json.loads(CLAIM_REGISTRY.read_text(encoding="utf-8"))
 
-    watch = {
-        claim["claim_id"]: claim
-        for claim in data["claims"]
-        if claim["status"] == "watch"
-    }
+    watch = {claim["claim_id"]: claim for claim in data["claims"] if claim["status"] == "watch"}
     assert "frontier_model_escape_april_2026" in watch
     assert "aethelgard_dynamic_capability_governance" in watch

--- a/tests/tokenizer/test_nsm_primes.py
+++ b/tests/tokenizer/test_nsm_primes.py
@@ -68,9 +68,9 @@ def test_spans_confidences_sum_to_at_most_1():
 def test_primary_span_has_highest_confidence():
     for p in NSM_PRIMES:
         if len(p.spans) > 1:
-            assert p.spans[0].confidence >= p.spans[1].confidence, (
-                f"{p.id}: first span ({p.spans[0].confidence}) < second ({p.spans[1].confidence})"
-            )
+            assert (
+                p.spans[0].confidence >= p.spans[1].confidence
+            ), f"{p.id}: first span ({p.spans[0].confidence}) < second ({p.spans[1].confidence})"
 
 
 def test_get_prime_returns_correct_object():
@@ -102,20 +102,20 @@ def test_all_primes_length():
 @pytest.mark.parametrize(
     "prime_id, expected_label, expected_tongue",
     [
-        ("ko.i",       "I",           "KO"),
-        ("ko.want",    "WANT",        "KO"),
-        ("ko.not",     "NOT",         "KO"),
-        ("av.hear",    "HEAR",        "AV"),
-        ("av.move",    "MOVE",        "AV"),
-        ("ru.good",    "GOOD",        "RU"),
-        ("ru.all",     "ALL",         "RU"),
-        ("ca.one",     "ONE",         "CA"),
-        ("ca.more",    "MORE",        "CA"),
-        ("um.inside",  "INSIDE",      "UM"),
-        ("um.feel",    "FEEL",        "UM"),
-        ("dr.before",  "BEFORE",      "DR"),
-        ("dr.after",   "AFTER",       "DR"),
-        ("dr.know",    "KNOW",        "DR"),
+        ("ko.i", "I", "KO"),
+        ("ko.want", "WANT", "KO"),
+        ("ko.not", "NOT", "KO"),
+        ("av.hear", "HEAR", "AV"),
+        ("av.move", "MOVE", "AV"),
+        ("ru.good", "GOOD", "RU"),
+        ("ru.all", "ALL", "RU"),
+        ("ca.one", "ONE", "CA"),
+        ("ca.more", "MORE", "CA"),
+        ("um.inside", "INSIDE", "UM"),
+        ("um.feel", "FEEL", "UM"),
+        ("dr.before", "BEFORE", "DR"),
+        ("dr.after", "AFTER", "DR"),
+        ("dr.know", "KNOW", "DR"),
     ],
 )
 def test_canonical_prime_assignments(prime_id, expected_label, expected_tongue):
@@ -202,9 +202,7 @@ def test_no_two_primaries_share_grid_slot_within_tongue():
         seen: set[int] = set()
         for p in primes_for_tongue(tongue):
             idx = prime_grid_index(p)
-            assert idx not in seen, (
-                f"{tongue}: grid slot {idx} (row={p.grid_row},col={p.grid_col}) is shared"
-            )
+            assert idx not in seen, f"{tongue}: grid slot {idx} (row={p.grid_row},col={p.grid_col}) is shared"
             seen.add(idx)
 
 
@@ -227,18 +225,14 @@ def test_phi_extrapolate_tongue_cycles():
     # Should cycle KO→AV→RU→CA→UM→DR
     expected = ["AV", "RU", "CA", "UM", "DR", "KO"]
     for i, ex in enumerate(results):
-        assert ex.derived_tongue == expected[i], (
-            f"step {i+1}: expected {expected[i]}, got {ex.derived_tongue}"
-        )
+        assert ex.derived_tongue == expected[i], f"step {i+1}: expected {expected[i]}, got {ex.derived_tongue}"
 
 
 def test_phi_extrapolate_radii_stay_in_ball():
     for p in NSM_PRIMES:
         results = phi_extrapolate(p, steps=4)
         for ex in results:
-            assert 0.0 < ex.derived_r < 1.0, (
-                f"{p.id} step {ex.n}: r={ex.derived_r} outside (0,1)"
-            )
+            assert 0.0 < ex.derived_r < 1.0, f"{p.id} step {ex.n}: r={ex.derived_r} outside (0,1)"
 
 
 def test_phi_extrapolate_radii_increase_monotonically():
@@ -247,9 +241,9 @@ def test_phi_extrapolate_radii_increase_monotonically():
     results = phi_extrapolate(p, steps=4)
     for i in range(1, len(results)):
         # Radius should generally increase but tanh compression may slow it
-        assert results[i].derived_r >= results[0].derived_r * 0.9, (
-            f"step {i+1} radius {results[i].derived_r} unexpectedly dropped from step 1 {results[0].derived_r}"
-        )
+        assert (
+            results[i].derived_r >= results[0].derived_r * 0.9
+        ), f"step {i+1} radius {results[i].derived_r} unexpectedly dropped from step 1 {results[0].derived_r}"
 
 
 def test_phi_extrapolation_result_types():
@@ -282,9 +276,9 @@ def test_find_empty_lattice_sites_returns_list():
 def test_empty_lattice_sites_have_candidate_labels():
     sites = find_empty_lattice_sites(steps=2)
     for site in sites:
-        assert site.candidate_label.startswith("[CANDIDATE:"), (
-            f"empty site should have candidate label, got: {site.candidate_label}"
-        )
+        assert site.candidate_label.startswith(
+            "[CANDIDATE:"
+        ), f"empty site should have candidate label, got: {site.candidate_label}"
 
 
 def test_phi_extrapolate_pure_prime_first_step_tongue():
@@ -323,6 +317,4 @@ def test_derived_primes_have_larger_r():
     order0 = [p.r for p in NSM_PRIMES if p.phi_order == 0]
     order2 = [p.r for p in NSM_PRIMES if p.phi_order == 2]
     if order0 and order2:
-        assert max(order0) < max(order2) + 0.05, (
-            "phi_order=2 primes should reach further than phi_order=0"
-        )
+        assert max(order0) < max(order2) + 0.05, "phi_order=2 primes should reach further than phi_order=0"


### PR DESCRIPTION
## Summary
- format NSM prime Python implementation and tests with repo Black settings
- remove unused dataclasses.field import flagged by Ruff
- reformat Aether scorecard test after claim-gate merge

## Verification
- python -m black --check --target-version py311 --line-length 120 src/ tests/
- python -m ruff check src/ tests/
- python -m pytest tests\\benchmark\\test_aether_coding_score_config.py tests\\tokenizer\\test_nsm_primes.py -q
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code formatting and alignment improvements across the codebase for enhanced readability and consistency.
  * Optimized multi-line expression formatting in tests for cleaner presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->