### PR TITLE
feat(tokenizer/nsm): proximity confidence + sub-prime anchor generator

### DIFF
--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -111,9 +111,11 @@ export {
   phiExtrapolate,
   phiExtrapolateAll,
   findEmptyLatticeSites,
+  generateSubprimeAnchors,
   type NSMPrime,
   type PrimeSpan,
   type PhiExtrapolation,
+  type SubPrimeAnchor,
   type CoverageReport,
 } from './nsmPrimes.js';
 

--- a/src/tokenizer/nsmPrimes.ts
+++ b/src/tokenizer/nsmPrimes.ts
@@ -85,6 +85,21 @@ export interface PhiExtrapolation {
   readonly matchedPrime: string | null;
 }
 
+/** A semantic position on a root prime's own tongue axis, scaled by φⁿ in arctanh space. */
+export interface SubPrimeAnchor {
+  readonly rootId: string;
+  readonly n: number;
+  readonly tongue: TongueCode;
+  readonly r: number;
+  readonly theta: number;
+  readonly gridRow: number;
+  readonly gridCol: number;
+  readonly candidateLabel: string;
+  readonly proximityConfidence: number;
+  readonly isKnownPrime: boolean;
+  readonly matchedPrime: string | null;
+}
+
 export interface CoverageReport {
   readonly total: number;
   readonly primaryOnly: number;
@@ -563,6 +578,26 @@ function poincareExpMap(x: [number, number], v: [number, number]): [number, numb
   return [newR * Math.cos(vTheta), newR * Math.sin(vTheta)];
 }
 
+/** Soft confidence for an empty lattice site: exp(-dist/scale) to nearest known primary. */
+function proximityConfidence(
+  tongue: TongueCode,
+  r: number,
+  gridRow: number,
+  gridCol: number,
+  scale = 0.18
+): number {
+  let best = Infinity;
+  for (const p of NSM_PRIMES) {
+    if (p.spans[0].tongue !== tongue) continue;
+    const dr = Math.abs(p.r - r);
+    const drow = Math.abs(p.gridRow - gridRow);
+    const dcol = Math.min(Math.abs(p.gridCol - gridCol), GRID_SIZE - Math.abs(p.gridCol - gridCol));
+    const dist = dr + (drow + dcol) / GRID_SIZE;
+    if (dist < best) best = dist;
+  }
+  return isFinite(best) ? Math.exp(-best / scale) : 0;
+}
+
 /**
  * Walk the geodesic from `p` for `steps` phi-scaled steps.
  *
@@ -612,7 +647,9 @@ export function phiExtrapolate(p: NSMPrime, steps = 3): PhiExtrapolation[] {
       gridRow: gRow,
       gridCol: gCol,
       candidateLabel: knownMatch?.label ?? `[CANDIDATE: ${nextTongue}·${step}]`,
-      confidence: knownMatch ? primaryConfidence(knownMatch) : 0,
+      confidence: knownMatch
+        ? primaryConfidence(knownMatch)
+        : proximityConfidence(nextTongue, newR, gRow, gCol),
       isKnownPrime: knownMatch !== null,
       matchedPrime: knownMatch?.id ?? null,
     });
@@ -636,4 +673,52 @@ export function findEmptyLatticeSites(steps = 2): PhiExtrapolation[] {
     }
   }
   return empty;
+}
+
+/**
+ * Generate sub-prime anchors by φⁿ-ratioed scaling from a root prime.
+ *
+ * Each anchor n sits at r_n = tanh(arctanh(r₀) × φⁿ), staying on the root's
+ * own tongue axis. The series predicts "more of the same prime" — deeper,
+ * stronger, or more abstract versions of the root concept.
+ */
+export function generateSubprimeAnchors(prime: NSMPrime, steps = 4): SubPrimeAnchor[] {
+  const anchors: SubPrimeAnchor[] = [];
+  const tongue = primaryTongue(prime);
+  const theta = TONGUE_PHASE[tongue];
+  const rootArctanh = Math.atanh(Math.min(prime.r, 1 - POINCARE_EPSILON));
+
+  for (let n = 1; n <= steps; n++) {
+    const scaledArctanh = rootArctanh * PHI ** n;
+    const rN = Math.min(Math.tanh(Math.min(scaledArctanh, 10)), 1 - POINCARE_EPSILON);
+
+    const gRow = Math.min(Math.floor(rN * GRID_SIZE), GRID_SIZE - 1);
+    const gCol =
+      Math.floor(
+        ((((theta % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)) / (2 * Math.PI)) * GRID_SIZE
+      ) % GRID_SIZE;
+
+    const knownMatch =
+      primesForTongue(tongue).find((c) => c.gridRow === gRow && Math.abs(c.r - rN) < 0.08) ?? null;
+
+    const prox = knownMatch
+      ? primaryConfidence(knownMatch)
+      : proximityConfidence(tongue, rN, gRow, gCol);
+
+    anchors.push({
+      rootId: prime.id,
+      n,
+      tongue,
+      r: rN,
+      theta,
+      gridRow: gRow,
+      gridCol: gCol,
+      candidateLabel: knownMatch?.label ?? `[SUB: ${prime.label}.phi${n}]`,
+      proximityConfidence: prox,
+      isKnownPrime: knownMatch !== null,
+      matchedPrime: knownMatch?.id ?? null,
+    });
+  }
+
+  return anchors;
 }

--- a/src/tokenizer/nsm_primes.py
+++ b/src/tokenizer/nsm_primes.py
@@ -459,6 +459,28 @@ def _poincare_exp_map(x: tuple[float, float], v: tuple[float, float]) -> tuple[f
     return (new_r * math.cos(v_theta), new_r * math.sin(v_theta))
 
 
+def _proximity_confidence(
+    tongue: TongueCode,
+    r: float,
+    grid_row: int,
+    grid_col: int,
+    *,
+    scale: float = 0.18,
+) -> float:
+    """Soft confidence for an empty lattice site: exp(-d/scale) to nearest known primary."""
+    best = math.inf
+    for p in NSM_PRIMES:
+        if p.primary_tongue != tongue:
+            continue
+        dr = abs(p.r - r)
+        drow = abs(p.grid_row - grid_row)
+        dcol = min(abs(p.grid_col - grid_col), GRID_SIZE - abs(p.grid_col - grid_col))
+        dist = dr + (drow + dcol) / GRID_SIZE
+        if dist < best:
+            best = dist
+    return math.exp(-best / scale) if math.isfinite(best) else 0.0
+
+
 @dataclass(frozen=True)
 class PhiExtrapolation:
     """
@@ -549,7 +571,9 @@ def phi_extrapolate(prime: NSMPrime, steps: int = 3) -> list[PhiExtrapolation]:
                 grid_row=grid_row,
                 grid_col=grid_col,
                 candidate_label=cand_label,
-                confidence=known_match.primary_confidence if known_match else 0.0,
+                confidence=known_match.primary_confidence
+                if known_match
+                else _proximity_confidence(next_tongue, new_r, grid_row, grid_col),
                 is_known_prime=known_match is not None,
                 matched_prime=known_match.id if known_match else None,
             )
@@ -581,11 +605,112 @@ def find_empty_lattice_sites(steps: int = 2) -> list[PhiExtrapolation]:
     return empty
 
 
+# ---------------------------------------------------------------------------
+# Sub-prime anchors — ratioed phi entry points along a root prime's axis
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SubPrimeAnchor:
+    """
+    A semantic position derived from a root prime by φⁿ-ratioed radial scaling.
+
+    Unlike PhiExtrapolation (which cycles tongues), sub-prime anchors stay on
+    the root prime's own tongue axis and walk radially outward by powers of φ
+    in arctanh space:
+
+        r_n = tanh(arctanh(r₀) × φⁿ)
+
+    This generates a family of deeper primes sharing the root's intentional axis.
+    Example from WANT (r₀=0.22, KO tongue):
+        n=1 → r≈0.35  (NEED — desire with urgency)
+        n=2 → r≈0.53  (COMPEL — drive beyond preference)
+        n=3 → r≈0.74  (MUST — drive approaching necessity)
+        n=4 → r≈0.91  (INEVITABILITY — boundary of representable desire)
+
+    The "ratioed" framing means sub-prime n is always measured relative to the
+    root, not the previous step — making the series a single generative formula.
+    """
+
+    root_id: str
+    n: int
+    tongue: TongueCode
+    r: float
+    theta: float
+    grid_row: int
+    grid_col: int
+    candidate_label: str
+    proximity_confidence: float
+    is_known_prime: bool = False
+    matched_prime: str | None = None
+
+
+def generate_subprime_anchors(prime: NSMPrime, steps: int = 4) -> list[SubPrimeAnchor]:
+    """
+    Generate sub-prime anchors by φⁿ-ratioed scaling from a root prime.
+
+    Each anchor n sits at r_n = tanh(arctanh(r₀) × φⁿ), staying on the root's
+    own tongue axis (same θ = tongue phase angle).  The series predicts semantic
+    concepts that are "more of the same prime" — stronger, deeper, or more
+    abstract versions of the root concept.
+
+    Args:
+        prime: The root NSM prime to extrapolate from.
+        steps: How many φⁿ sub-prime anchors to generate (default 4).
+
+    Returns:
+        List of SubPrimeAnchor, one per step.
+    """
+    anchors: list[SubPrimeAnchor] = []
+    r0 = prime.r
+    theta = prime.poincare_theta
+    root_arctanh = math.atanh(min(r0, 1.0 - POINCARE_EPSILON))
+
+    for n in range(1, steps + 1):
+        scaled_arctanh = root_arctanh * (PHI**n)
+        r_n = math.tanh(min(scaled_arctanh, 10.0))
+        r_n = min(r_n, 1.0 - POINCARE_EPSILON)
+
+        grid_row = min(int(r_n * GRID_SIZE), GRID_SIZE - 1)
+        grid_col = int((theta % (2 * math.pi)) / (2 * math.pi) * GRID_SIZE) % GRID_SIZE
+
+        known_match: NSMPrime | None = None
+        for candidate in primes_for_tongue(prime.primary_tongue):
+            if candidate.grid_row == grid_row and abs(candidate.r - r_n) < 0.08:
+                known_match = candidate
+                break
+
+        prox = (
+            known_match.primary_confidence
+            if known_match
+            else _proximity_confidence(prime.primary_tongue, r_n, grid_row, grid_col)
+        )
+
+        anchors.append(
+            SubPrimeAnchor(
+                root_id=prime.id,
+                n=n,
+                tongue=prime.primary_tongue,
+                r=r_n,
+                theta=theta,
+                grid_row=grid_row,
+                grid_col=grid_col,
+                candidate_label=known_match.label if known_match else f"[SUB: {prime.label}.phi{n}]",
+                proximity_confidence=prox,
+                is_known_prime=known_match is not None,
+                matched_prime=known_match.id if known_match else None,
+            )
+        )
+
+    return anchors
+
+
 __all__ = [
     # Types
     "NSMPrime",
     "PrimeSpan",
     "PhiExtrapolation",
+    "SubPrimeAnchor",
     "CoverageReport",
     "TongueCode",
     # Data
@@ -607,4 +732,5 @@ __all__ = [
     "phi_extrapolate",
     "phi_extrapolate_all",
     "find_empty_lattice_sites",
+    "generate_subprime_anchors",
 ]

--- a/tests/tokenizer/test_nsm_primes.py
+++ b/tests/tokenizer/test_nsm_primes.py
@@ -11,9 +11,11 @@ from src.tokenizer.nsm_primes import (
     TONGUE_PHASE,
     CoverageReport,
     PhiExtrapolation,
+    SubPrimeAnchor,
     all_primes,
     coverage_report,
     find_empty_lattice_sites,
+    generate_subprime_anchors,
     get_prime,
     grid_index,
     phi_extrapolate,
@@ -318,3 +320,107 @@ def test_derived_primes_have_larger_r():
     order2 = [p.r for p in NSM_PRIMES if p.phi_order == 2]
     if order0 and order2:
         assert max(order0) < max(order2) + 0.05, "phi_order=2 primes should reach further than phi_order=0"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Proximity confidence
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_empty_extrapolation_sites_have_nonzero_confidence():
+    """Empty lattice sites should now carry proximity confidence, not 0."""
+    p = get_prime("av.say")
+    assert p is not None
+    results = phi_extrapolate(p, steps=2)
+    empty = [ex for ex in results if not ex.is_known_prime]
+    assert len(empty) > 0, "SAY extrapolation should produce at least one empty site"
+    for ex in empty:
+        assert ex.confidence > 0.0, (
+            f"Empty site step {ex.n} tongue {ex.derived_tongue} should have nonzero proximity confidence"
+        )
+
+
+def test_known_prime_match_has_high_confidence():
+    """When extrapolation hits a known prime the confidence should equal that prime's span confidence."""
+    # Walk all primes a few steps and check any known hit is >= 0.5
+    for p in NSM_PRIMES:
+        for ex in phi_extrapolate(p, steps=3):
+            if ex.is_known_prime:
+                assert ex.confidence >= 0.5, (
+                    f"{p.id} step {ex.n}: matched {ex.matched_prime} but conf={ex.confidence}"
+                )
+
+
+def test_proximity_confidence_decays_with_steps():
+    """First step from SAY is closer to known primes than later steps — conf should be higher."""
+    say = get_prime("av.say")
+    assert say is not None
+    results = phi_extrapolate(say, steps=3)
+    empty = [ex for ex in results if not ex.is_known_prime]
+    if len(empty) >= 2:
+        assert empty[0].confidence >= empty[1].confidence, (
+            f"Confidence should decay along geodesic: step 1 conf={empty[0].confidence} "
+            f"should be >= step 2 conf={empty[1].confidence}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sub-prime anchors
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_generate_subprime_anchors_count():
+    p = get_prime("ko.want")
+    assert p is not None
+    anchors = generate_subprime_anchors(p, steps=4)
+    assert len(anchors) == 4
+
+
+def test_subprime_anchors_stay_on_root_tongue():
+    for prime in NSM_PRIMES[:10]:
+        for anchor in generate_subprime_anchors(prime, steps=3):
+            assert anchor.tongue == prime.primary_tongue, (
+                f"{prime.id}: sub-prime should stay on {prime.primary_tongue}, got {anchor.tongue}"
+            )
+
+
+def test_subprime_radii_strictly_increasing():
+    p = get_prime("ko.want")
+    assert p is not None
+    anchors = generate_subprime_anchors(p, steps=5)
+    for i in range(1, len(anchors)):
+        assert anchors[i].r > anchors[i - 1].r, (
+            f"Sub-prime radii should increase: step {i} r={anchors[i-1].r} >= step {i+1} r={anchors[i].r}"
+        )
+
+
+def test_subprime_radii_in_open_ball():
+    for p in NSM_PRIMES:
+        for anchor in generate_subprime_anchors(p, steps=4):
+            assert 0.0 < anchor.r < 1.0, (
+                f"{p.id} phi^{anchor.n}: r={anchor.r} outside (0,1)"
+            )
+
+
+def test_subprime_anchor_is_dataclass():
+    p = get_prime("av.say")
+    assert p is not None
+    anchors = generate_subprime_anchors(p, steps=2)
+    for a in anchors:
+        assert isinstance(a, SubPrimeAnchor)
+        assert isinstance(a.proximity_confidence, float)
+        assert a.root_id == p.id
+        assert a.n in (1, 2)
+
+
+def test_subprime_phi1_radius_matches_formula():
+    """phi^1 sub-prime radius = tanh(arctanh(r0) * phi)."""
+    import math
+
+    p = get_prime("ko.want")
+    assert p is not None
+    expected_r1 = math.tanh(math.atanh(p.r) * PHI)
+    anchors = generate_subprime_anchors(p, steps=1)
+    assert abs(anchors[0].r - expected_r1) < 1e-6, (
+        f"phi^1 radius should be tanh(arctanh({p.r}) * phi) = {expected_r1:.6f}, got {anchors[0].r:.6f}"
+    )


### PR DESCRIPTION
## Summary

- **Proximity confidence** wired into `phi_extrapolate`: empty lattice sites carry `exp(-d/scale)` confidence to nearest known prime, enabling decay-plot analysis along geodesics.

- **`generate_subprime_anchors`** (Python + TypeScript): walks a root prime's own tongue axis via `r_n = tanh(arctanh(r₀) × φⁿ)`. WANT·φ¹≈NEED (r=0.35), WANT·φ²≈COMPEL (r=0.53), WANT·φ³≈MUST (r=0.74). Distinct from phiExtrapolate (which cycles tongues) — this is radial depth along one semantic axis.

- **`SubPrimeAnchor`** type/dataclass with `proximity_confidence` field.

- **9 new tests** (59 total, 0.53s). TypeScript clean.

## AV column 2 finding
NOT/WANT/MAYBE/IF/THINK all extrapolate to AV column 2 at increasing rows — predicting a family of externalized mental state primes Wierzbicka doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)