### PR TITLE
feat(benchmarks): add Aether Programmer Index

### DIFF
--- a/config/eval/aether_programmer_index.v1.json
+++ b/config/eval/aether_programmer_index.v1.json
@@ -1,0 +1,196 @@
+{
+  "schema_version": "aether_programmer_index_v1",
+  "name": "Aether Programmer Index",
+  "status": "owned_index_not_external_standard",
+  "last_updated": "2026-05-23",
+  "purpose": "Measure whether an AI coding system is usable, verifiable, and improvable across real programming workflows.",
+  "research_claim_registry": "config/eval/aether_research_claim_registry.v1.json",
+  "score_formula": "sum(track_weight * track_pass_quality * evidence_multiplier)",
+  "entry_gate": {
+    "description": "A task enters quality scoring only after it passes the binary gate.",
+    "required_checks": ["tests_passed", "policy_clean", "artifact_complete"],
+    "failed_task_score": 0,
+    "failure_output": "procedural_solution_triage"
+  },
+  "failure_refinement_loop": {
+    "name": "100-agentic-solution-triage",
+    "description": "Failures are rerun through procedurally generated solution candidates before implementation.",
+    "candidate_solution_budget": 100,
+    "stages": [
+      {
+        "id": "context_quality_scan",
+        "description": "Read the failing task, artifacts, logs, surrounding code, and system intention before proposing fixes."
+      },
+      {
+        "id": "solution_space_generation",
+        "description": "Generate candidate fixes that fit the observed solution space, not random ideas."
+      },
+      {
+        "id": "web_research",
+        "description": "Use web search for current docs, benchmark rules, API behavior, or external error references when the failure depends on changing outside facts."
+      },
+      {
+        "id": "web_research_refinement",
+        "description": "Refine candidates against retrieved sources and reject stale or unsupported assumptions."
+      },
+      {
+        "id": "multi_model_deliberation",
+        "description": "Compare candidate fixes across model/persona lanes and keep disagreement notes."
+      },
+      {
+        "id": "security_check",
+        "description": "Run policy, secret, injection, and blast-radius checks before implementation."
+      },
+      {
+        "id": "implementation",
+        "description": "Apply the smallest candidate patch that satisfies the evidence."
+      },
+      {
+        "id": "rerun",
+        "description": "Rerun the failing benchmark or nearest focused regression."
+      },
+      {
+        "id": "improvement_ledger",
+        "description": "Record before/after score, changed files, pass/fail transition, and quality delta."
+      }
+    ],
+    "promotion_rule": "A failure is not closed when it merely passes; after pass conversion, the next loop maintains score above the true-negative floor and attempts quality recovery when trend decay appears.",
+    "trend_control": {
+      "true_negative_floor": 0.0,
+      "allowed_single_turn_negative_delta": -0.1,
+      "decline_window_turns": 3,
+      "recovery_required_below_floor": true,
+      "completion_rule": "Exploration is complete only when the route is recorded, the result stays above the true-negative floor, or a recovery path is executed.",
+      "rule": "A single negative delta is allowed if the result remains above the true-negative floor. Multi-turn downward decline must include a cause note and a recovery attempt. Exploration can dive, but it must carry a recovery mechanism."
+    }
+  },
+  "quality_dimensions": [
+    {
+      "id": "correctness",
+      "weight": 35,
+      "description": "The patch or answer satisfies the benchmark tests and expected behavior."
+    },
+    {
+      "id": "verification",
+      "weight": 20,
+      "description": "The system ran relevant checks and preserved command/output evidence."
+    },
+    {
+      "id": "usability",
+      "weight": 15,
+      "description": "A human or weak LLM can understand and operate the workflow without hidden steps."
+    },
+    {
+      "id": "minimality",
+      "weight": 10,
+      "description": "The solution is scoped, readable, and avoids unrelated churn."
+    },
+    {
+      "id": "governance",
+      "weight": 10,
+      "description": "The run respects policy, tool scope, provenance, and audit logging."
+    },
+    {
+      "id": "cost_time",
+      "weight": 10,
+      "description": "The run is practical in time, token cost, retries, and local reproducibility."
+    }
+  ],
+  "evidence_multipliers": {
+    "official_full_run": 1.0,
+    "reproducible_full_local_run": 0.85,
+    "reproducible_subset_run": 0.6,
+    "smoke_or_plumbing_run": 0.25,
+    "unrun_or_planned": 0.0
+  },
+  "tracks": [
+    {
+      "track_id": "real_repo_repair",
+      "weight": 20,
+      "benchmark_family": ["SWE-bench Verified", "SWE-bench Pro"],
+      "usability_target": "Can fix real repository issues with patch, tests, and rollback notes."
+    },
+    {
+      "track_id": "terminal_execution",
+      "weight": 15,
+      "benchmark_family": ["Terminal-Bench 2.0", "TerminalWorld"],
+      "usability_target": "Can inspect shell state, run commands, recover, and verify without handholding."
+    },
+    {
+      "track_id": "multi_language_editing",
+      "weight": 12,
+      "benchmark_family": ["Aider Polyglot"],
+      "usability_target": "Can edit across languages without silently narrowing to Python or TypeScript."
+    },
+    {
+      "track_id": "fresh_algorithmic_coding",
+      "weight": 8,
+      "benchmark_family": ["LiveCodeBench"],
+      "usability_target": "Can solve fresh algorithmic tasks with recorded tests and limits."
+    },
+    {
+      "track_id": "function_correctness",
+      "weight": 5,
+      "benchmark_family": ["EvalPlus HumanEval+", "EvalPlus MBPP+"],
+      "usability_target": "Can produce small correct functions with edge-case coverage."
+    },
+    {
+      "track_id": "tool_policy_behavior",
+      "weight": 10,
+      "benchmark_family": ["tau-bench", "tau2-bench"],
+      "usability_target": "Can call tools under business rules, state constraints, and receipts."
+    },
+    {
+      "track_id": "browser_desktop_operation",
+      "weight": 8,
+      "benchmark_family": ["WebArena", "OSWorld"],
+      "usability_target": "Can operate browser and desktop workflows without brittle chat-only behavior."
+    },
+    {
+      "track_id": "security_governance",
+      "weight": 12,
+      "benchmark_family": ["AgentDojo", "CyberSecEval", "HarmBench", "garak", "promptfoo"],
+      "usability_target": "Can keep tool use, prompt injection, exfiltration, and policy bypass inside the safety envelope."
+    },
+    {
+      "track_id": "reproducibility",
+      "weight": 10,
+      "benchmark_family": ["internal evidence packet"],
+      "usability_target": "Can emit enough artifacts for another operator to replay or audit the run."
+    }
+  ],
+  "rings": [
+    {
+      "ring": 0,
+      "name": "Harness Ring",
+      "condition": "Task packet validates and produces a score/backlog artifact."
+    },
+    {
+      "ring": 1,
+      "name": "Subset Ring",
+      "condition": "At least one reproducible subset run exists for a track."
+    },
+    {
+      "ring": 2,
+      "name": "Usability Ring",
+      "condition": "Passing tasks average at least 0.75 usability quality."
+    },
+    {
+      "ring": 3,
+      "name": "Benchmark Ring",
+      "condition": "Official or full local benchmark evidence exists."
+    },
+    {
+      "ring": 4,
+      "name": "Refinement Ring",
+      "condition": "Prior failures become passing tasks and then improve pass quality."
+    }
+  ],
+  "readiness_bands": [
+    { "min": 90, "max": 100, "label": "production-grade programmer" },
+    { "min": 75, "max": 89.999, "label": "pilot-ready programmer" },
+    { "min": 60, "max": 74.999, "label": "guided operator" },
+    { "min": 40, "max": 59.999, "label": "scaffold with evidence" },
+    { "min": 0, "max": 39.999, "label": "demo or unproven" }
+  ]
+}

--- a/docs/benchmarks/AETHER_PROGRAMMER_INDEX.md
+++ b/docs/benchmarks/AETHER_PROGRAMMER_INDEX.md
@@ -1,0 +1,144 @@
+# Aether Programmer Index
+
+Status: SCBE/AetherMoore-owned index, not an external standard.
+Last updated: 2026-05-23.
+
+The Aether Programmer Index measures whether an AI coding system is actually usable. It is not just a coding leaderboard number. It is a loop:
+
+1. A task either enters the gate or fails.
+2. Passing tasks get quality scored.
+3. Failed tasks become solution backlog entries.
+4. Fixed failures become passes.
+5. Passes are then improved for quality.
+
+The config lives at `config/eval/aether_programmer_index.v1.json`. The scorer lives at `scripts/eval/aether_programmer_index.py`.
+
+## Core Rule
+
+Every task has a binary entry gate:
+
+```text
+entry_pass = passed
+  and tests_passed
+  and policy_clean
+  and artifact_complete
+```
+
+If the entry gate fails, the task score is `0`. That is not wasted data. The failure becomes a solution backlog entry with a failure mode and proposed fix.
+
+If the entry gate passes, the task receives a quality score:
+
+| Quality dimension | Weight | Meaning |
+| --- | ---: | --- |
+| Correctness | 35 | The patch or answer satisfies the tests and expected behavior. |
+| Verification | 20 | The run preserved command/output evidence. |
+| Usability | 15 | A human or weak LLM can operate the workflow without hidden steps. |
+| Minimality | 10 | The solution is scoped and avoids unrelated churn. |
+| Governance | 10 | Policy, provenance, tool scope, and audit logging are intact. |
+| Cost/time | 10 | Time, token cost, retry count, and replay cost are practical. |
+
+## Tracks
+
+The index keeps the benchmark lanes from the Aether Coding Score but makes usability explicit:
+
+| Track | Weight | What it proves |
+| --- | ---: | --- |
+| Real repo repair | 20 | Fixes real repository issues with patch, tests, and rollback notes. |
+| Terminal execution | 15 | Uses the shell, inspects state, recovers, and verifies work. |
+| Multi-language editing | 12 | Works outside the easiest language lane. |
+| Fresh algorithmic coding | 8 | Handles unseen coding tasks with recorded tests. |
+| Function correctness | 5 | Writes small correct functions with edge-case coverage. |
+| Tool/policy behavior | 10 | Calls tools under state and business constraints. |
+| Browser/desktop operation | 8 | Completes UI workflows, not just chat. |
+| Security/governance | 12 | Resists prompt injection, exfiltration, and policy bypass. |
+| Reproducibility | 10 | Emits enough evidence for another operator to replay the result. |
+
+## Saturn Rings
+
+Use the rings as the improvement path around the core system:
+
+| Ring | Name | Meaning |
+| ---: | --- | --- |
+| 0 | Harness Ring | The packet validates and produces score/backlog output. |
+| 1 | Subset Ring | A track has at least one reproducible subset run. |
+| 2 | Usability Ring | Passing tasks average at least 0.75 usability. |
+| 3 | Benchmark Ring | Official or full local benchmark evidence exists. |
+| 4 | Refinement Ring | Prior failures are converted into passes, then pass quality rises. |
+
+This is the workflow version of the user's rule: passes have quality, failures have solutions. A failure is not a dead end; it is a binary entry into continued refinement.
+
+## Failure Refinement Loop
+
+Failures are not just stored. They are rerun through procedural solution triage:
+
+1. Scan context quality: failing task, logs, artifacts, nearby code, and system intention.
+2. Generate up to 100 candidate solutions that fit the solution space.
+3. Use web search when the failure depends on current docs, benchmark rules, APIs, or external errors.
+4. Refine candidates against the sources; reject stale assumptions.
+5. Run multi-model deliberation and preserve disagreement notes.
+6. Security-check candidate changes before implementation.
+7. Apply the smallest patch that fits the evidence.
+8. Rerun the failed benchmark or nearest focused regression.
+9. Mark changed files, before/after result, pass/fail transition, and quality delta.
+
+The loop does not require every turn to be positive. A small negative delta can be valid exploration if the result stays above the true-negative floor and the run records what changed.
+
+The trend rule is stricter than the single-turn rule:
+
+- A single `-0.1` style quality delta is acceptable if the run remains above the true-negative floor.
+- Multi-turn downward decline is not acceptable without a cause note and recovery attempt.
+- The objective is controlled refinement, not fake monotonic improvement.
+
+Think of the loop like a lake dive: going deeper is allowed, but the system must carry the mechanism to surface. Exploration completion means the route is recorded, the risk floor was maintained, or the recovery path was executed.
+
+A converted failure enters the quality-maintenance lane: usability, verification, minimality, governance, and cost/time are monitored over time. When quality decays, the next loop must attempt re-elevation.
+
+## Run Packet Shape
+
+```json
+{
+  "schema_version": "aether_programmer_run_v1",
+  "run_id": "local-smoke-001",
+  "evidence_level": "reproducible_subset_run",
+  "tasks": [
+    {
+      "task_id": "terminal.echo",
+      "track_id": "terminal_execution",
+      "passed": true,
+      "checks": {
+        "tests_passed": true,
+        "policy_clean": true,
+        "artifact_complete": true
+      },
+      "quality": {
+        "correctness": 1.0,
+        "verification": 0.9,
+        "usability": 0.8,
+        "minimality": 0.9,
+        "governance": 1.0,
+        "cost_time": 0.8
+      }
+    }
+  ]
+}
+```
+
+Run:
+
+```powershell
+python scripts/eval/aether_programmer_index.py path\to\run_packet.json --out artifacts\benchmarks\aether_programmer_index\report.json
+```
+
+## Claim Guardrails
+
+Allowed:
+
+- "Aether Programmer Index is SCBE/AetherMoore's own usability and benchmark refinement index."
+- "The index converts failed benchmark tasks into solution backlog entries."
+- "A task only receives quality points after it passes the binary gate."
+
+Not allowed:
+
+- "First AI Programmer Index" as an external industry standard.
+- "Best coding agent" without official or reproducible full-run evidence.
+- Treating smoke tests as benchmark capability.

--- a/scripts/eval/aether_programmer_index.py
+++ b/scripts/eval/aether_programmer_index.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = ROOT / "config" / "eval" / "aether_programmer_index.v1.json"
+
+
+@dataclass(frozen=True)
+class TaskScore:
+    task_id: str
+    track_id: str
+    entry_pass: bool
+    quality_score: float
+    weighted_quality: float
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _clamp01(value: Any) -> float:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, number))
+
+
+def _readiness_label(score: float, bands: list[dict[str, Any]]) -> str:
+    for band in bands:
+        if float(band["min"]) <= score <= float(band["max"]):
+            return str(band["label"])
+    return "unclassified"
+
+
+def _trend_status(history: list[dict[str, Any]], trend_control: dict[str, Any]) -> dict[str, Any]:
+    if not history:
+        return {
+            "status": "no_history",
+            "above_true_negative_floor": True,
+            "requires_recovery": False,
+            "exploration_complete": False,
+            "message": "No trend history supplied.",
+        }
+
+    floor = float(trend_control["true_negative_floor"])
+    decline_window = int(trend_control["decline_window_turns"])
+    latest = history[-1]
+    latest_score = float(latest.get("score", 0.0))
+    above_floor = latest_score >= floor
+
+    if len(history) < decline_window:
+        return {
+            "status": "insufficient_history",
+            "above_true_negative_floor": above_floor,
+            "requires_recovery": not above_floor,
+            "exploration_complete": above_floor,
+            "message": "Not enough turns to judge multi-turn decline.",
+        }
+
+    window = history[-decline_window:]
+    scores = [float(turn.get("score", 0.0)) for turn in window]
+    declining = all(scores[i] < scores[i - 1] for i in range(1, len(scores)))
+    cause_supplied = any(str(turn.get("cause_note", "")).strip() for turn in window)
+    recovery_attempted = any(bool(turn.get("recovery_attempted")) for turn in window)
+    requires_recovery = (not above_floor) or (declining and not (cause_supplied and recovery_attempted))
+
+    if requires_recovery:
+        status = "recovery_required"
+    elif declining:
+        status = "controlled_decline"
+    else:
+        status = "stable_or_recovering"
+
+    return {
+        "status": status,
+        "above_true_negative_floor": above_floor,
+        "requires_recovery": requires_recovery,
+        "exploration_complete": above_floor and not requires_recovery,
+        "window_scores": scores,
+        "message": trend_control["rule"],
+    }
+
+
+def _entry_pass(task: dict[str, Any], required_checks: list[str]) -> bool:
+    checks = task.get("checks", {})
+    return bool(task.get("passed")) and all(bool(checks.get(check)) for check in required_checks)
+
+
+def _quality_score(task: dict[str, Any], dimensions: list[dict[str, Any]]) -> float:
+    quality = task.get("quality", {})
+    total_weight = sum(float(dim["weight"]) for dim in dimensions)
+    if total_weight <= 0:
+        return 0.0
+    weighted = sum(_clamp01(quality.get(dim["id"], 0.0)) * float(dim["weight"]) for dim in dimensions)
+    return weighted / total_weight
+
+
+def score_run(run_packet: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+    evidence_level = run_packet.get("evidence_level", "unrun_or_planned")
+    evidence_multiplier = float(config["evidence_multipliers"].get(evidence_level, 0.0))
+    required_checks = list(config["entry_gate"]["required_checks"])
+    dimensions = list(config["quality_dimensions"])
+    track_weights = {track["track_id"]: float(track["weight"]) for track in config["tracks"]}
+    refinement_loop = config["failure_refinement_loop"]
+    refinement_stages = [stage["id"] for stage in refinement_loop["stages"]]
+
+    task_scores: list[TaskScore] = []
+    solution_backlog: list[dict[str, Any]] = []
+
+    for task in run_packet.get("tasks", []):
+        track_id = str(task.get("track_id", ""))
+        task_id = str(task.get("task_id", ""))
+        entry_pass = _entry_pass(task, required_checks)
+        quality = _quality_score(task, dimensions) if entry_pass else 0.0
+        task_scores.append(
+            TaskScore(
+                task_id=task_id,
+                track_id=track_id,
+                entry_pass=entry_pass,
+                quality_score=quality,
+                weighted_quality=quality * track_weights.get(track_id, 0.0),
+            )
+        )
+        if not entry_pass:
+            solution_backlog.append(
+                {
+                    "task_id": task_id,
+                    "track_id": track_id,
+                    "failure_mode": task.get("failure_mode", "unspecified"),
+                    "proposed_solution": task.get("proposed_solution", "add a focused regression and rerun"),
+                    "candidate_solution_budget": refinement_loop["candidate_solution_budget"],
+                    "rerun_strategy": refinement_loop["name"],
+                    "required_stages": refinement_stages,
+                }
+            )
+
+    track_reports: list[dict[str, Any]] = []
+    raw_score = 0.0
+    for track in config["tracks"]:
+        track_id = track["track_id"]
+        scores = [task for task in task_scores if task.track_id == track_id]
+        if not scores:
+            pass_rate = 0.0
+            average_quality = 0.0
+        else:
+            passed = [task for task in scores if task.entry_pass]
+            pass_rate = len(passed) / len(scores)
+            average_quality = sum(task.quality_score for task in passed) / len(passed) if passed else 0.0
+        track_score = float(track["weight"]) * pass_rate * average_quality * evidence_multiplier
+        raw_score += track_score
+        track_reports.append(
+            {
+                "track_id": track_id,
+                "weight": track["weight"],
+                "task_count": len(scores),
+                "pass_rate": round(pass_rate, 4),
+                "average_pass_quality": round(average_quality, 4),
+                "score": round(track_score, 4),
+            }
+        )
+
+    final_score = round(raw_score, 4)
+    return {
+        "schema_version": "aether_programmer_index_report_v1",
+        "run_id": run_packet.get("run_id", "unknown"),
+        "evidence_level": evidence_level,
+        "evidence_multiplier": evidence_multiplier,
+        "score": final_score,
+        "readiness": _readiness_label(final_score, config["readiness_bands"]),
+        "trend": _trend_status(run_packet.get("history", []), config["failure_refinement_loop"]["trend_control"]),
+        "tracks": track_reports,
+        "solution_backlog": solution_backlog,
+        "task_scores": [
+            {
+                "task_id": task.task_id,
+                "track_id": task.track_id,
+                "entry_pass": task.entry_pass,
+                "quality_score": round(task.quality_score, 4),
+            }
+            for task in task_scores
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Score an Aether Programmer Index run packet.")
+    parser.add_argument("run_packet", type=Path)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+
+    report = score_run(_load_json(args.run_packet), _load_json(args.config))
+    output = json.dumps(report, indent=2, sort_keys=True)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(output + "\n", encoding="utf-8")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tokenizer/index.ts
+++ b/src/tokenizer/index.ts
@@ -111,9 +111,11 @@ export {
   phiExtrapolate,
   phiExtrapolateAll,
   findEmptyLatticeSites,
+  generateSubprimeAnchors,
   type NSMPrime,
   type PrimeSpan,
   type PhiExtrapolation,
+  type SubPrimeAnchor,
   type CoverageReport,
 } from './nsmPrimes.js';
 

--- a/src/tokenizer/nsmPrimes.ts
+++ b/src/tokenizer/nsmPrimes.ts
@@ -85,6 +85,21 @@ export interface PhiExtrapolation {
   readonly matchedPrime: string | null;
 }
 
+/** A semantic position on a root prime's own tongue axis, scaled by φⁿ in arctanh space. */
+export interface SubPrimeAnchor {
+  readonly rootId: string;
+  readonly n: number;
+  readonly tongue: TongueCode;
+  readonly r: number;
+  readonly theta: number;
+  readonly gridRow: number;
+  readonly gridCol: number;
+  readonly candidateLabel: string;
+  readonly proximityConfidence: number;
+  readonly isKnownPrime: boolean;
+  readonly matchedPrime: string | null;
+}
+
 export interface CoverageReport {
   readonly total: number;
   readonly primaryOnly: number;
@@ -563,6 +578,26 @@ function poincareExpMap(x: [number, number], v: [number, number]): [number, numb
   return [newR * Math.cos(vTheta), newR * Math.sin(vTheta)];
 }
 
+/** Soft confidence for an empty lattice site: exp(-dist/scale) to nearest known primary. */
+function proximityConfidence(
+  tongue: TongueCode,
+  r: number,
+  gridRow: number,
+  gridCol: number,
+  scale = 0.18
+): number {
+  let best = Infinity;
+  for (const p of NSM_PRIMES) {
+    if (p.spans[0].tongue !== tongue) continue;
+    const dr = Math.abs(p.r - r);
+    const drow = Math.abs(p.gridRow - gridRow);
+    const dcol = Math.min(Math.abs(p.gridCol - gridCol), GRID_SIZE - Math.abs(p.gridCol - gridCol));
+    const dist = dr + (drow + dcol) / GRID_SIZE;
+    if (dist < best) best = dist;
+  }
+  return isFinite(best) ? Math.exp(-best / scale) : 0;
+}
+
 /**
  * Walk the geodesic from `p` for `steps` phi-scaled steps.
  *
@@ -612,7 +647,9 @@ export function phiExtrapolate(p: NSMPrime, steps = 3): PhiExtrapolation[] {
       gridRow: gRow,
       gridCol: gCol,
       candidateLabel: knownMatch?.label ?? `[CANDIDATE: ${nextTongue}·${step}]`,
-      confidence: knownMatch ? primaryConfidence(knownMatch) : 0,
+      confidence: knownMatch
+        ? primaryConfidence(knownMatch)
+        : proximityConfidence(nextTongue, newR, gRow, gCol),
       isKnownPrime: knownMatch !== null,
       matchedPrime: knownMatch?.id ?? null,
     });
@@ -636,4 +673,52 @@ export function findEmptyLatticeSites(steps = 2): PhiExtrapolation[] {
     }
   }
   return empty;
+}
+
+/**
+ * Generate sub-prime anchors by φⁿ-ratioed scaling from a root prime.
+ *
+ * Each anchor n sits at r_n = tanh(arctanh(r₀) × φⁿ), staying on the root's
+ * own tongue axis. The series predicts "more of the same prime" — deeper,
+ * stronger, or more abstract versions of the root concept.
+ */
+export function generateSubprimeAnchors(prime: NSMPrime, steps = 4): SubPrimeAnchor[] {
+  const anchors: SubPrimeAnchor[] = [];
+  const tongue = primaryTongue(prime);
+  const theta = TONGUE_PHASE[tongue];
+  const rootArctanh = Math.atanh(Math.min(prime.r, 1 - POINCARE_EPSILON));
+
+  for (let n = 1; n <= steps; n++) {
+    const scaledArctanh = rootArctanh * PHI ** n;
+    const rN = Math.min(Math.tanh(Math.min(scaledArctanh, 10)), 1 - POINCARE_EPSILON);
+
+    const gRow = Math.min(Math.floor(rN * GRID_SIZE), GRID_SIZE - 1);
+    const gCol =
+      Math.floor(
+        ((((theta % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI)) / (2 * Math.PI)) * GRID_SIZE
+      ) % GRID_SIZE;
+
+    const knownMatch =
+      primesForTongue(tongue).find((c) => c.gridRow === gRow && Math.abs(c.r - rN) < 0.08) ?? null;
+
+    const prox = knownMatch
+      ? primaryConfidence(knownMatch)
+      : proximityConfidence(tongue, rN, gRow, gCol);
+
+    anchors.push({
+      rootId: prime.id,
+      n,
+      tongue,
+      r: rN,
+      theta,
+      gridRow: gRow,
+      gridCol: gCol,
+      candidateLabel: knownMatch?.label ?? `[SUB: ${prime.label}.phi${n}]`,
+      proximityConfidence: prox,
+      isKnownPrime: knownMatch !== null,
+      matchedPrime: knownMatch?.id ?? null,
+    });
+  }
+
+  return anchors;
 }

--- a/src/tokenizer/nsm_primes.py
+++ b/src/tokenizer/nsm_primes.py
@@ -459,6 +459,28 @@ def _poincare_exp_map(x: tuple[float, float], v: tuple[float, float]) -> tuple[f
     return (new_r * math.cos(v_theta), new_r * math.sin(v_theta))
 
 
+def _proximity_confidence(
+    tongue: TongueCode,
+    r: float,
+    grid_row: int,
+    grid_col: int,
+    *,
+    scale: float = 0.18,
+) -> float:
+    """Soft confidence for an empty lattice site: exp(-d/scale) to nearest known primary."""
+    best = math.inf
+    for p in NSM_PRIMES:
+        if p.primary_tongue != tongue:
+            continue
+        dr = abs(p.r - r)
+        drow = abs(p.grid_row - grid_row)
+        dcol = min(abs(p.grid_col - grid_col), GRID_SIZE - abs(p.grid_col - grid_col))
+        dist = dr + (drow + dcol) / GRID_SIZE
+        if dist < best:
+            best = dist
+    return math.exp(-best / scale) if math.isfinite(best) else 0.0
+
+
 @dataclass(frozen=True)
 class PhiExtrapolation:
     """
@@ -549,7 +571,9 @@ def phi_extrapolate(prime: NSMPrime, steps: int = 3) -> list[PhiExtrapolation]:
                 grid_row=grid_row,
                 grid_col=grid_col,
                 candidate_label=cand_label,
-                confidence=known_match.primary_confidence if known_match else 0.0,
+                confidence=known_match.primary_confidence
+                if known_match
+                else _proximity_confidence(next_tongue, new_r, grid_row, grid_col),
                 is_known_prime=known_match is not None,
                 matched_prime=known_match.id if known_match else None,
             )
@@ -581,11 +605,112 @@ def find_empty_lattice_sites(steps: int = 2) -> list[PhiExtrapolation]:
     return empty
 
 
+# ---------------------------------------------------------------------------
+# Sub-prime anchors — ratioed phi entry points along a root prime's axis
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SubPrimeAnchor:
+    """
+    A semantic position derived from a root prime by φⁿ-ratioed radial scaling.
+
+    Unlike PhiExtrapolation (which cycles tongues), sub-prime anchors stay on
+    the root prime's own tongue axis and walk radially outward by powers of φ
+    in arctanh space:
+
+        r_n = tanh(arctanh(r₀) × φⁿ)
+
+    This generates a family of deeper primes sharing the root's intentional axis.
+    Example from WANT (r₀=0.22, KO tongue):
+        n=1 → r≈0.35  (NEED — desire with urgency)
+        n=2 → r≈0.53  (COMPEL — drive beyond preference)
+        n=3 → r≈0.74  (MUST — drive approaching necessity)
+        n=4 → r≈0.91  (INEVITABILITY — boundary of representable desire)
+
+    The "ratioed" framing means sub-prime n is always measured relative to the
+    root, not the previous step — making the series a single generative formula.
+    """
+
+    root_id: str
+    n: int
+    tongue: TongueCode
+    r: float
+    theta: float
+    grid_row: int
+    grid_col: int
+    candidate_label: str
+    proximity_confidence: float
+    is_known_prime: bool = False
+    matched_prime: str | None = None
+
+
+def generate_subprime_anchors(prime: NSMPrime, steps: int = 4) -> list[SubPrimeAnchor]:
+    """
+    Generate sub-prime anchors by φⁿ-ratioed scaling from a root prime.
+
+    Each anchor n sits at r_n = tanh(arctanh(r₀) × φⁿ), staying on the root's
+    own tongue axis (same θ = tongue phase angle).  The series predicts semantic
+    concepts that are "more of the same prime" — stronger, deeper, or more
+    abstract versions of the root concept.
+
+    Args:
+        prime: The root NSM prime to extrapolate from.
+        steps: How many φⁿ sub-prime anchors to generate (default 4).
+
+    Returns:
+        List of SubPrimeAnchor, one per step.
+    """
+    anchors: list[SubPrimeAnchor] = []
+    r0 = prime.r
+    theta = prime.poincare_theta
+    root_arctanh = math.atanh(min(r0, 1.0 - POINCARE_EPSILON))
+
+    for n in range(1, steps + 1):
+        scaled_arctanh = root_arctanh * (PHI**n)
+        r_n = math.tanh(min(scaled_arctanh, 10.0))
+        r_n = min(r_n, 1.0 - POINCARE_EPSILON)
+
+        grid_row = min(int(r_n * GRID_SIZE), GRID_SIZE - 1)
+        grid_col = int((theta % (2 * math.pi)) / (2 * math.pi) * GRID_SIZE) % GRID_SIZE
+
+        known_match: NSMPrime | None = None
+        for candidate in primes_for_tongue(prime.primary_tongue):
+            if candidate.grid_row == grid_row and abs(candidate.r - r_n) < 0.08:
+                known_match = candidate
+                break
+
+        prox = (
+            known_match.primary_confidence
+            if known_match
+            else _proximity_confidence(prime.primary_tongue, r_n, grid_row, grid_col)
+        )
+
+        anchors.append(
+            SubPrimeAnchor(
+                root_id=prime.id,
+                n=n,
+                tongue=prime.primary_tongue,
+                r=r_n,
+                theta=theta,
+                grid_row=grid_row,
+                grid_col=grid_col,
+                candidate_label=known_match.label if known_match else f"[SUB: {prime.label}.phi{n}]",
+                proximity_confidence=prox,
+                is_known_prime=known_match is not None,
+                matched_prime=known_match.id if known_match else None,
+            )
+        )
+
+    return anchors
+
+
 __all__ = [
     # Types
     "NSMPrime",
     "PrimeSpan",
     "PhiExtrapolation",
+    "SubPrimeAnchor",
     "CoverageReport",
     "TongueCode",
     # Data
@@ -607,4 +732,5 @@ __all__ = [
     "phi_extrapolate",
     "phi_extrapolate_all",
     "find_empty_lattice_sites",
+    "generate_subprime_anchors",
 ]

--- a/tests/benchmark/test_aether_programmer_index.py
+++ b/tests/benchmark/test_aether_programmer_index.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.eval.aether_programmer_index import DEFAULT_CONFIG, score_run
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG = ROOT / "config" / "eval" / "aether_programmer_index.v1.json"
+DOC = ROOT / "docs" / "benchmarks" / "AETHER_PROGRAMMER_INDEX.md"
+SCRIPT = ROOT / "scripts" / "eval" / "aether_programmer_index.py"
+
+
+def _config() -> dict:
+    return json.loads(CONFIG.read_text(encoding="utf-8"))
+
+
+def test_programmer_index_config_weights_are_valid() -> None:
+    data = _config()
+
+    assert data["schema_version"] == "aether_programmer_index_v1"
+    assert data["status"] == "owned_index_not_external_standard"
+    assert sum(track["weight"] for track in data["tracks"]) == 100
+    assert sum(dim["weight"] for dim in data["quality_dimensions"]) == 100
+    assert data["entry_gate"]["failed_task_score"] == 0
+    assert data["entry_gate"]["failure_output"] == "procedural_solution_triage"
+    assert set(data["entry_gate"]["required_checks"]) == {"tests_passed", "policy_clean", "artifact_complete"}
+    assert data["failure_refinement_loop"]["candidate_solution_budget"] == 100
+    assert data["failure_refinement_loop"]["trend_control"]["allowed_single_turn_negative_delta"] == -0.1
+    assert data["failure_refinement_loop"]["trend_control"]["recovery_required_below_floor"] is True
+    assert "Exploration is complete" in data["failure_refinement_loop"]["trend_control"]["completion_rule"]
+    stage_ids = {stage["id"] for stage in data["failure_refinement_loop"]["stages"]}
+    assert {"web_research", "multi_model_deliberation", "security_check", "rerun", "improvement_ledger"}.issubset(
+        stage_ids
+    )
+
+
+def test_programmer_index_doc_carries_claim_guardrail() -> None:
+    text = DOC.read_text(encoding="utf-8")
+
+    assert "SCBE/AetherMoore-owned index" in text
+    assert "not an external standard" in text
+    assert "up to 100 candidate solutions" in text
+    assert "Security-check candidate changes before implementation" in text
+    assert "lake dive" in text
+
+
+def test_score_run_binary_entry_then_quality() -> None:
+    packet = {
+        "schema_version": "aether_programmer_run_v1",
+        "run_id": "unit-test",
+        "evidence_level": "reproducible_subset_run",
+        "tasks": [
+            {
+                "task_id": "terminal.pass",
+                "track_id": "terminal_execution",
+                "passed": True,
+                "checks": {"tests_passed": True, "policy_clean": True, "artifact_complete": True},
+                "quality": {
+                    "correctness": 1.0,
+                    "verification": 1.0,
+                    "usability": 0.8,
+                    "minimality": 0.8,
+                    "governance": 1.0,
+                    "cost_time": 0.6,
+                },
+            },
+            {
+                "task_id": "terminal.fail",
+                "track_id": "terminal_execution",
+                "passed": False,
+                "checks": {"tests_passed": False, "policy_clean": True, "artifact_complete": True},
+                "failure_mode": "tests failed",
+                "proposed_solution": "fix command parser and rerun terminal subset",
+                "quality": {
+                    "correctness": 1.0,
+                    "verification": 1.0,
+                    "usability": 1.0,
+                    "minimality": 1.0,
+                    "governance": 1.0,
+                    "cost_time": 1.0,
+                },
+            },
+        ],
+    }
+
+    report = score_run(packet, _config())
+
+    assert report["evidence_multiplier"] == 0.6
+    assert report["solution_backlog"] == [
+        {
+            "task_id": "terminal.fail",
+            "track_id": "terminal_execution",
+            "failure_mode": "tests failed",
+            "proposed_solution": "fix command parser and rerun terminal subset",
+            "candidate_solution_budget": 100,
+            "rerun_strategy": "100-agentic-solution-triage",
+            "required_stages": [
+                "context_quality_scan",
+                "solution_space_generation",
+                "web_research",
+                "web_research_refinement",
+                "multi_model_deliberation",
+                "security_check",
+                "implementation",
+                "rerun",
+                "improvement_ledger",
+            ],
+        }
+    ]
+    terminal = next(track for track in report["tracks"] if track["track_id"] == "terminal_execution")
+    assert terminal["pass_rate"] == 0.5
+    assert terminal["average_pass_quality"] == 0.91
+    assert terminal["score"] == 4.095
+    assert report["trend"]["status"] == "no_history"
+
+
+def test_trend_allows_exploratory_negative_delta_with_cause_and_recovery() -> None:
+    packet = {
+        "schema_version": "aether_programmer_run_v1",
+        "run_id": "trend-test",
+        "evidence_level": "smoke_or_plumbing_run",
+        "history": [
+            {"turn": 1, "score": 0.9},
+            {"turn": 2, "score": 0.8, "cause_note": "tested stricter parser"},
+            {"turn": 3, "score": 0.7, "recovery_attempted": True},
+        ],
+        "tasks": [],
+    }
+
+    report = score_run(packet, _config())
+
+    assert report["trend"]["status"] == "controlled_decline"
+    assert report["trend"]["above_true_negative_floor"] is True
+    assert report["trend"]["requires_recovery"] is False
+    assert report["trend"]["exploration_complete"] is True
+
+
+def test_trend_requires_recovery_for_unexplained_multi_turn_decline() -> None:
+    packet = {
+        "schema_version": "aether_programmer_run_v1",
+        "run_id": "trend-fail",
+        "evidence_level": "smoke_or_plumbing_run",
+        "history": [
+            {"turn": 1, "score": 0.9},
+            {"turn": 2, "score": 0.8},
+            {"turn": 3, "score": 0.7},
+        ],
+        "tasks": [],
+    }
+
+    report = score_run(packet, _config())
+
+    assert report["trend"]["status"] == "recovery_required"
+    assert report["trend"]["requires_recovery"] is True
+    assert report["trend"]["exploration_complete"] is False
+
+
+def test_programmer_index_cli_writes_report(tmp_path: Path) -> None:
+    packet = {
+        "schema_version": "aether_programmer_run_v1",
+        "run_id": "cli-test",
+        "evidence_level": "smoke_or_plumbing_run",
+        "tasks": [],
+    }
+    packet_path = tmp_path / "packet.json"
+    out_path = tmp_path / "report.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(packet_path), "--config", str(DEFAULT_CONFIG), "--out", str(out_path)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout == ""
+    report = json.loads(out_path.read_text(encoding="utf-8"))
+    assert report["schema_version"] == "aether_programmer_index_report_v1"
+    assert report["run_id"] == "cli-test"

--- a/tests/tokenizer/test_nsm_primes.py
+++ b/tests/tokenizer/test_nsm_primes.py
@@ -11,9 +11,11 @@ from src.tokenizer.nsm_primes import (
     TONGUE_PHASE,
     CoverageReport,
     PhiExtrapolation,
+    SubPrimeAnchor,
     all_primes,
     coverage_report,
     find_empty_lattice_sites,
+    generate_subprime_anchors,
     get_prime,
     grid_index,
     phi_extrapolate,
@@ -318,3 +320,107 @@ def test_derived_primes_have_larger_r():
     order2 = [p.r for p in NSM_PRIMES if p.phi_order == 2]
     if order0 and order2:
         assert max(order0) < max(order2) + 0.05, "phi_order=2 primes should reach further than phi_order=0"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Proximity confidence
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_empty_extrapolation_sites_have_nonzero_confidence():
+    """Empty lattice sites should now carry proximity confidence, not 0."""
+    p = get_prime("av.say")
+    assert p is not None
+    results = phi_extrapolate(p, steps=2)
+    empty = [ex for ex in results if not ex.is_known_prime]
+    assert len(empty) > 0, "SAY extrapolation should produce at least one empty site"
+    for ex in empty:
+        assert ex.confidence > 0.0, (
+            f"Empty site step {ex.n} tongue {ex.derived_tongue} should have nonzero proximity confidence"
+        )
+
+
+def test_known_prime_match_has_high_confidence():
+    """When extrapolation hits a known prime the confidence should equal that prime's span confidence."""
+    # Walk all primes a few steps and check any known hit is >= 0.5
+    for p in NSM_PRIMES:
+        for ex in phi_extrapolate(p, steps=3):
+            if ex.is_known_prime:
+                assert ex.confidence >= 0.5, (
+                    f"{p.id} step {ex.n}: matched {ex.matched_prime} but conf={ex.confidence}"
+                )
+
+
+def test_proximity_confidence_decays_with_steps():
+    """First step from SAY is closer to known primes than later steps — conf should be higher."""
+    say = get_prime("av.say")
+    assert say is not None
+    results = phi_extrapolate(say, steps=3)
+    empty = [ex for ex in results if not ex.is_known_prime]
+    if len(empty) >= 2:
+        assert empty[0].confidence >= empty[1].confidence, (
+            f"Confidence should decay along geodesic: step 1 conf={empty[0].confidence} "
+            f"should be >= step 2 conf={empty[1].confidence}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sub-prime anchors
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_generate_subprime_anchors_count():
+    p = get_prime("ko.want")
+    assert p is not None
+    anchors = generate_subprime_anchors(p, steps=4)
+    assert len(anchors) == 4
+
+
+def test_subprime_anchors_stay_on_root_tongue():
+    for prime in NSM_PRIMES[:10]:
+        for anchor in generate_subprime_anchors(prime, steps=3):
+            assert anchor.tongue == prime.primary_tongue, (
+                f"{prime.id}: sub-prime should stay on {prime.primary_tongue}, got {anchor.tongue}"
+            )
+
+
+def test_subprime_radii_strictly_increasing():
+    p = get_prime("ko.want")
+    assert p is not None
+    anchors = generate_subprime_anchors(p, steps=5)
+    for i in range(1, len(anchors)):
+        assert anchors[i].r > anchors[i - 1].r, (
+            f"Sub-prime radii should increase: step {i} r={anchors[i-1].r} >= step {i+1} r={anchors[i].r}"
+        )
+
+
+def test_subprime_radii_in_open_ball():
+    for p in NSM_PRIMES:
+        for anchor in generate_subprime_anchors(p, steps=4):
+            assert 0.0 < anchor.r < 1.0, (
+                f"{p.id} phi^{anchor.n}: r={anchor.r} outside (0,1)"
+            )
+
+
+def test_subprime_anchor_is_dataclass():
+    p = get_prime("av.say")
+    assert p is not None
+    anchors = generate_subprime_anchors(p, steps=2)
+    for a in anchors:
+        assert isinstance(a, SubPrimeAnchor)
+        assert isinstance(a.proximity_confidence, float)
+        assert a.root_id == p.id
+        assert a.n in (1, 2)
+
+
+def test_subprime_phi1_radius_matches_formula():
+    """phi^1 sub-prime radius = tanh(arctanh(r0) * phi)."""
+    import math
+
+    p = get_prime("ko.want")
+    assert p is not None
+    expected_r1 = math.tanh(math.atanh(p.r) * PHI)
+    anchors = generate_subprime_anchors(p, steps=1)
+    assert abs(anchors[0].r - expected_r1) < 1e-6, (
+        f"phi^1 radius should be tanh(arctanh({p.r}) * phi) = {expected_r1:.6f}, got {anchors[0].r:.6f}"
+    )


### PR DESCRIPTION
## Summary
- add Aether Programmer Index as an owned usability/refinement index, not an external-standard claim
- add binary entry gate, quality scoring for passes, and procedural failure rerun loop with 100-candidate solution triage
- add trend control so negative exploratory deltas are allowed above the true-negative floor, while unexplained multi-turn decline requires recovery
- add executable scorer that turns run packets into score, track report, trend status, and solution backlog

## Verification
- python -m pytest tests\\benchmark\\test_aether_programmer_index.py tests\\benchmark\\test_aether_coding_score_config.py -q
- python -m black --check --target-version py311 --line-length 120 scripts\\eval\\aether_programmer_index.py tests\\benchmark\\test_aether_programmer_index.py tests\\benchmark\\test_aether_coding_score_config.py
- python -m ruff check scripts\\eval\\aether_programmer_index.py tests\\benchmark\\test_aether_programmer_index.py tests\\benchmark\\test_aether_coding_score_config.py
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced new evaluation framework with configurable quality scoring, benchmark tracking, and refinement loop management
  - Enhanced tokenizer capabilities with sub-prime anchor generation and proximity-based confidence scoring

* **Documentation**
  - Added detailed specification for the evaluation framework including scoring dimensions and readiness bands

* **Tests**
  - Added comprehensive test suites for evaluation framework and tokenizer functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->