### PR TITLE
docs(ops): add agentic vine branch workflow

### DIFF
--- a/docs/benchmarks/AETHER_PROGRAMMER_INDEX.md
+++ b/docs/benchmarks/AETHER_PROGRAMMER_INDEX.md
@@ -13,6 +13,8 @@ The Aether Programmer Index measures whether an AI coding system is actually usa
 
 The config lives at `config/eval/aether_programmer_index.v1.json`. The scorer lives at `scripts/eval/aether_programmer_index.py`.
 
+Branch operating model: see `docs/ops/AGENTIC_VINE_BRANCH_WORKFLOW.md`. Index improvement should move through small vine/ring branches so failures, fixes, format cleanup, and benchmark evidence do not overwrite each other.
+
 ## Core Rule
 
 Every task has a binary entry gate:

--- a/docs/ops/AGENTIC_VINE_BRANCH_WORKFLOW.md
+++ b/docs/ops/AGENTIC_VINE_BRANCH_WORKFLOW.md
@@ -1,0 +1,104 @@
+# Agentic Vine Branch Workflow
+
+Status: operating model.
+Last updated: 2026-05-23.
+
+This workflow keeps agentic Git work from turning into overwritten, compartmentalized branches. The model is not a traditional tree where each branch grows away from the trunk until merge day. It is closer to bamboo, bonsai, and vines: repeated nodes, living rings, visible roots, and flowers that map back to the root that fed them.
+
+## Core Idea
+
+Every agent branch must preserve a root-to-flower map:
+
+```text
+root intent -> branch lane -> action node -> verification ring -> merge flower -> cleanup/root update
+```
+
+The branch is not a private compartment. It is a temporary growth node on the shared system.
+
+## Branch Lanes
+
+| Lane | Prefix | Purpose | Merge condition |
+| --- | --- | --- | --- |
+| Feature vine | `feat/` | New behavior or new executable system surface. | Tests prove behavior and docs show how to use it. |
+| Fix vine | `fix/` | Repair a broken behavior or CI failure. | Failing check turns green and regression exists where practical. |
+| Style/format ring | `style/` | Formatting, lint, import cleanup, no behavior change. | Format/lint jobs pass; diff is mechanical. |
+| Docs flower | `docs/` | Public/operator docs, claim fences, runbooks. | Claim status is clear; no unverified claim promoted. |
+| Experiment shoot | `exp/` | Fenced R&D, prototype, measurement probe. | Explicit status says experimental; not merged into canonical architecture without evidence. |
+| Bench ring | `bench/` | Benchmark harness, scorecard, evidence packet. | Score is reproducible or explicitly marked as smoke/planned. |
+
+## Standard Agent Verbs
+
+Agents should use the same verbs for every branch:
+
+| Verb | Meaning | Required output |
+| --- | --- | --- |
+| `inspect` | Read current branch, dirty tree, PR state, relevant files. | Branch name, changed paths, open PR if any. |
+| `pull` | Sync the root before adding new growth. | Confirm `main` or base ref is current. |
+| `sprout` | Create a scoped branch from the correct root. | Branch name with lane prefix. |
+| `shape` | Make the smallest useful change. | Changed file list. |
+| `triage` | Convert failures into cause + next action. | Failure mode and recovery command. |
+| `format` | Run repo formatting/lint gates before review. | Commands and pass/fail. |
+| `review` | Check the diff against claim scope and tests. | Risk notes and missing evidence. |
+| `push` | Push the branch and open/update PR. | PR number and URL. |
+| `flower` | Merge only after checks are green or auto-merge does it. | Merge commit or PR state. |
+| `prune` | Delete merged branch and sync local root. | Clean branch status. |
+
+## Root-To-Flower Packet
+
+Every non-trivial PR should be explainable as:
+
+```json
+{
+  "root_intent": "what problem this branch solves",
+  "branch_lane": "feat|fix|style|docs|exp|bench",
+  "changed_paths": ["..."],
+  "verification": ["commands that passed"],
+  "claim_fences": ["what this does not prove"],
+  "recovery_path": "what to run or revert if it fails",
+  "merge_flower": "PR number or merge commit"
+}
+```
+
+This is the branch version of the Aether Programmer Index: passes have quality; failures have solution paths; negative exploration is allowed only when recovery is visible.
+
+## Vine Rules
+
+1. Do not start from a stale root unless the point is conflict resolution.
+2. Do not mix unrelated flowers on one vine. If a formatter fix follows a feature merge, use a `style/` ring branch.
+3. Do not overwrite another agent's unmerged work. Inspect first, then branch from the right root.
+4. Do not treat auto-merge as completion. Check the late CI status after merge.
+5. Do not delete local evidence branches until the merge commit is visible on `origin/main`.
+6. Do not promote experimental branches into canonical docs without an evidence gate.
+7. Keep branch names boring enough for agents to route: `feat/aether-programmer-index`, `style/black-nsm-after-programmer-index`, `docs/vine-branch-workflow`.
+
+## Bamboo Node Pattern
+
+For multi-agent work, use short stacked nodes instead of one huge branch:
+
+```text
+docs/research-claim-gate
+  -> style/python-lint-after-nsm
+  -> feat/aether-programmer-index
+  -> style/black-nsm-after-programmer-index
+  -> docs/vine-branch-workflow
+```
+
+Each node is small. The system keeps growing because each node leaves the root cleaner for the next node.
+
+## NSM / Experimental Work Fence
+
+NSM geometric outputs such as row/column heat maps, phi-extrapolated empty sites, or "INSIDE -> HAVE" style matches are structural predictions from the current geometry. They are not proven semantic facts by themselves.
+
+Allowed language:
+
+- "The current NSM geometry predicts this slot."
+- "This is a candidate sub-prime family."
+- "This local run ranks the gap as high confidence."
+
+Not allowed without external evidence or additional validation:
+
+- "The geometry proved the semantic relationship."
+- "This is publishable" as a standalone claim.
+- "Wierzbicka left this unaddressed" without a citation and careful wording.
+
+Experimental vines can be rich. Canonical flowers need evidence.


### PR DESCRIPTION
## Summary
- add vine/bamboo branch operating model for agentic push/pull/inspect/review/triage/format workflows
- add root-to-flower PR packet shape and branch lane naming rules
- fence NSM heat-map/geodesic outputs as structural predictions, not proven semantic facts
- link Aether Programmer Index to the branch workflow

## Verification
- python -m pytest tests\\benchmark\\test_aether_programmer_index.py tests\\benchmark\\test_aether_coding_score_config.py -q
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the agentic vine branch operating model, including branching strategies, merge conditions, and workflow guidelines.
  * Updated benchmark documentation with branch operating model guidance for standardized improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->