### PR TITLE
ci: make greeting bot non-blocking

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -14,7 +14,9 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@v3
+      - name: Post first-interaction greeting
+        continue-on-error: true
+        uses: actions/first-interaction@v3
         with:
           issue_message: "👋 Welcome to SCBE-AETHERMOORE! Thanks for your first issue. Please review CONTRIBUTING.md and SECURITY.md. A maintainer will review soon."
           pr_message: "🎉 Thanks for your first PR to SCBE-AETHERMOORE! Ensure CI passes and changes align with ARCHITECTURE.md. A maintainer will review shortly."


### PR DESCRIPTION
## Summary
- make the first-interaction greeting step continue-on-error so a GitHub API/comment failure does not mark PR CI red
- keeps product checks authoritative while preserving the greeting workflow when credentials work

## Verification
- python -m pytest tests\\benchmark\\test_aether_programmer_index.py tests\\benchmark\\test_aether_coding_score_config.py -q
- npm run lint

## Context
PR #1861 merged with all product checks green, but the Greetings workflow failed because actions/first-interaction received GitHub API 401 Bad credentials while checking prior contributions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for improved error handling and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->