### PR TITLE
docs(benchmarks): add open-source agent task lanes

### DIFF
--- a/config/eval/aether_external_task_lanes.v1.json
+++ b/config/eval/aether_external_task_lanes.v1.json
@@ -1,0 +1,213 @@
+{
+  "schema_version": "aether_external_task_lanes_v1",
+  "last_researched": "2026-05-23",
+  "purpose": "Open-source task pools for running Aether Programmer Index evaluations outside the SCBE repo.",
+  "selection_rule": "Prefer task pools with public tasks, reproducible harnesses, pass/fail graders, and artifacts that can be replayed.",
+  "strong_coding_assistant_model": {
+    "base_model": "Provides reasoning and code generation, but is not sufficient by itself.",
+    "context_system": "Fetches the right files, symbols, docs, issues, and prior failures before generation.",
+    "task_harness": "Defines what done means for each task: tests, build, lint, format, deploy, browser/desktop state, policy compliance.",
+    "tool_runtime": "Runs shell, git, browser, GitHub, package managers, and optional external agents such as Copilot under bounded permissions.",
+    "verification_loop": "Reruns tests, records evidence, converts failures to candidate fixes, and tracks trend/recovery.",
+    "governance_layer": "Keeps model outputs inside tool scope, policy scope, secret rules, and audit receipts."
+  },
+  "model_orchestration": {
+    "principle": "Do not make the strongest model do every task. Use the strongest available model as leader, judge, and context router; use cheaper or free models as workers under the same harness.",
+    "leader_role": [
+      "interpret root intent",
+      "select task lane",
+      "assign worker agents",
+      "resolve disagreements",
+      "approve implementation plan before write",
+      "judge whether failure triage is sufficient"
+    ],
+    "worker_role": [
+      "inspect files",
+      "generate candidate fixes",
+      "run local commands",
+      "produce focused patches",
+      "summarize evidence",
+      "attempt reruns under budget"
+    ],
+    "scaling_rule": "For 3-1000 agents in flight, model quality is allocated by decision importance, not by task count. Expensive models guard the root and branch points; cheap models do leaf work with verification.",
+    "completion_authority": "The harness, tests, policy gate, and evidence packet decide completion. No model is completion authority by itself."
+  },
+  "optional_external_tools": [
+    {
+      "tool": "GitHub Copilot coding agent",
+      "use": "Can be called as a harness participant for issue-to-PR work, but SCBE remains the verifier and completion authority.",
+      "expectation": "Copilot may propose or patch; SCBE must run build, lint, format, tests, security checks, and evidence scoring before accepting."
+    },
+    {
+      "tool": "Sourcegraph/Cody or open-source code search stack",
+      "use": "Can supply codebase search, symbol context, and cross-repo navigation.",
+      "expectation": "Context retrieval improves agent performance only if retrieved evidence is attached to the run packet."
+    }
+  ],
+  "retrieval_stack": [
+    {
+      "tool": "ripgrep",
+      "role": "Fast text search and fallback retrieval.",
+      "mvp_use": "Find terms from issue titles, stack traces, imports, and error messages."
+    },
+    {
+      "tool": "universal-ctags",
+      "role": "Fast symbol index.",
+      "mvp_use": "Map names to files before asking a model to inspect code."
+    },
+    {
+      "tool": "tree-sitter",
+      "source_url": "https://github.com/tree-sitter/tree-sitter",
+      "role": "Incremental source parser and syntax tree builder.",
+      "mvp_use": "Extract functions/classes/imports for issue-to-file retrieval and patch impact checks."
+    },
+    {
+      "tool": "SCIP",
+      "source_url": "https://github.com/sourcegraph/scip",
+      "role": "Language-agnostic code intelligence protocol used for precise code navigation.",
+      "mvp_use": "Production path for Sourcegraph-style references, definitions, and cross-repo code graph."
+    },
+    {
+      "tool": "Semgrep",
+      "role": "Pattern-based static analysis.",
+      "mvp_use": "Find similar bugs, policy violations, and security-sensitive code paths."
+    },
+    {
+      "tool": "LSP",
+      "role": "Language server go-to-definition and find-references.",
+      "mvp_use": "Use installed language tooling where available instead of parsing everything manually."
+    }
+  ],
+  "lanes": [
+    {
+      "lane_id": "swe_bench_repo_repair",
+      "track_id": "real_repo_repair",
+      "source_name": "SWE-bench",
+      "source_url": "https://github.com/swe-bench",
+      "task_pool": "Real GitHub issues with repository snapshots and test-based evaluation.",
+      "first_run_plan": "Run 1-3 SWE-bench Lite or Verified tasks through an adapter that emits patch, tests, cost, logs, and failure mode.",
+      "completion_rule": "Patch applies and benchmark tests pass in the official or equivalent Docker harness.",
+      "why_it_matters": "Closest public proxy for real repository repair."
+    },
+    {
+      "lane_id": "swe_agent_harness_reference",
+      "track_id": "real_repo_repair",
+      "source_name": "SWE-agent / SWE-ReX",
+      "source_url": "https://github.com/SWE-agent",
+      "task_pool": "Open-source software-engineering agent and sandbox execution stack.",
+      "first_run_plan": "Inspect SWE-agent/SWE-ReX task packaging and reuse compatible sandbox/evidence ideas instead of inventing every wrapper.",
+      "completion_rule": "SCBE can launch or emulate an issue-solving task with captured trajectory and replayable execution evidence.",
+      "why_it_matters": "Shows the harness shape that makes the same model more useful."
+    },
+    {
+      "lane_id": "terminal_bench_cli",
+      "track_id": "terminal_execution",
+      "source_name": "Terminal-Bench",
+      "source_url": "https://terminalbench.lol/",
+      "task_pool": "Terminal tasks with instructions, Docker image, tests, and oracle solution.",
+      "first_run_plan": "Run a small Docker-backed subset with SCBE CLI/agent-bus as the terminal operator.",
+      "completion_rule": "Task tests pass and shell transcript is preserved.",
+      "why_it_matters": "Measures the thing chat demos miss: operating the machine."
+    },
+    {
+      "lane_id": "aider_polyglot_exercism",
+      "track_id": "multi_language_editing",
+      "source_name": "Aider Polyglot",
+      "source_url": "https://aider.chat/2024/12/21/polyglot.html",
+      "task_pool": "Exercism-based edit tasks across C++, Go, Java, JavaScript, Python, and Rust.",
+      "first_run_plan": "Start with the prior Rust failure, then run one Python and one JavaScript task to test language routing.",
+      "completion_rule": "Language-specific test suite passes after code edits.",
+      "why_it_matters": "Stops us from overfitting to TypeScript/Python comfort zones."
+    },
+    {
+      "lane_id": "evalplus_function_correctness",
+      "track_id": "function_correctness",
+      "source_name": "EvalPlus",
+      "source_url": "https://evalplus.github.io/",
+      "task_pool": "HumanEval+ and MBPP+ function-level tasks with stronger generated tests.",
+      "first_run_plan": "Add a cheap local lane for generated function correctness before expensive repo agents.",
+      "completion_rule": "Generated solution passes EvalPlus tests.",
+      "why_it_matters": "Fast sanity check for code correctness and edge cases."
+    },
+    {
+      "lane_id": "defects4j_java_repair",
+      "track_id": "real_repo_repair",
+      "source_name": "Defects4J",
+      "source_url": "https://github.com/rjust/defects4j",
+      "task_pool": "Curated real Java bugs with triggering tests and human patches.",
+      "first_run_plan": "Run one small Java bug-fix task after the multi-language edit harness can run Maven/Gradle-style tests.",
+      "completion_rule": "Triggering tests pass and no regression tests fail in the Defects4J harness.",
+      "why_it_matters": "Adds Java repair evidence outside Python-heavy SWE-bench lanes."
+    },
+    {
+      "lane_id": "bigcodebench_function_calling",
+      "track_id": "fresh_algorithmic_coding",
+      "source_name": "BigCodeBench",
+      "source_url": "https://github.com/bigcode-project/bigcodebench",
+      "task_pool": "1,140 practical code generation tasks with diverse function calls and libraries.",
+      "first_run_plan": "Run a tiny instruct split sample to test library-use and function-call reasoning.",
+      "completion_rule": "Generated code passes the benchmark evaluator.",
+      "why_it_matters": "Measures practical code generation beyond toy HumanEval functions."
+    },
+    {
+      "lane_id": "livecodebench_fresh_coding",
+      "track_id": "fresh_algorithmic_coding",
+      "source_name": "LiveCodeBench",
+      "source_url": "https://github.com/LiveCodeBench/LiveCodeBench",
+      "task_pool": "Fresh contest-style coding tasks with code generation, repair, execution, and test-output prediction scenarios.",
+      "first_run_plan": "Use custom-output evaluation for a small release slice so SCBE can score generated outputs without a custom runner first.",
+      "completion_rule": "Submitted JSON outputs pass LiveCodeBench evaluator for selected scenario.",
+      "why_it_matters": "Reduces contamination risk and exercises self-repair."
+    },
+    {
+      "lane_id": "agentdojo_prompt_injection",
+      "track_id": "security_governance",
+      "source_name": "AgentDojo",
+      "source_url": "https://github.com/ethz-spylab/agentdojo",
+      "task_pool": "Agent tasks with prompt injection attacks and defenses.",
+      "first_run_plan": "Run one tool-use prompt-injection subset against SCBE's gate and record attack success/failure.",
+      "completion_rule": "Benign task succeeds while injected instruction fails to control tools or exfiltrate.",
+      "why_it_matters": "This is where SCBE should compete: governed tool use, not just better chat."
+    },
+    {
+      "lane_id": "osworld_desktop",
+      "track_id": "browser_desktop_operation",
+      "source_name": "OSWorld",
+      "source_url": "https://os-world.github.io/",
+      "task_pool": "Real desktop OS tasks across common applications and settings.",
+      "first_run_plan": "Treat as later-stage lane after browser/desktop operator stabilizes; start with one low-risk file/config task.",
+      "completion_rule": "Programmatic grader confirms final OS state.",
+      "why_it_matters": "Measures whether the agent can use the computer, not just write code."
+    },
+    {
+      "lane_id": "webarena_browser",
+      "track_id": "browser_desktop_operation",
+      "source_name": "WebArena",
+      "source_url": "https://webarena.dev/",
+      "task_pool": "Web tasks across realistic sites with action-based evaluation.",
+      "first_run_plan": "Use after the Aether desktop/browser harness can reliably capture screenshots, actions, and receipts.",
+      "completion_rule": "Browser task success according to benchmark grader or equivalent state check.",
+      "why_it_matters": "Connects coding harness to browser work, deployment, and operator workflows."
+    },
+    {
+      "lane_id": "exercism_direct_custom",
+      "track_id": "multi_language_editing",
+      "source_name": "Exercism",
+      "source_url": "https://exercism.org/",
+      "task_pool": "Open-source programming exercises and language tracks.",
+      "first_run_plan": "Create SCBE-owned mini subsets from public exercises to test weaker models cheaply before full Aider Polyglot.",
+      "completion_rule": "Track-specific tests pass and generated diff is minimal.",
+      "why_it_matters": "Cheap, understandable tasks for usability testing with weak/free models."
+    },
+    {
+      "lane_id": "github_good_first_issue_live",
+      "track_id": "real_repo_repair",
+      "source_name": "GitHub good first issues",
+      "source_url": "https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests",
+      "task_pool": "Live public GitHub issues labeled by maintainers.",
+      "first_run_plan": "Use gh issue list on selected repositories, create task packets, run agent branch locally, and open PR only after evidence gates pass.",
+      "completion_rule": "Maintainer-style PR packet exists with passing local checks, clear diff, and issue closure note.",
+      "why_it_matters": "Tests real-world usability and PR workflow beyond fixed benchmarks."
+    }
+  ]
+}

--- a/docs/benchmarks/AETHER_PROGRAMMER_INDEX.md
+++ b/docs/benchmarks/AETHER_PROGRAMMER_INDEX.md
@@ -15,6 +15,8 @@ The config lives at `config/eval/aether_programmer_index.v1.json`. The scorer li
 
 Branch operating model: see `docs/ops/AGENTIC_VINE_BRANCH_WORKFLOW.md`. Index improvement should move through small vine/ring branches so failures, fixes, format cleanup, and benchmark evidence do not overwrite each other.
 
+External task lanes: see `docs/benchmarks/OPEN_SOURCE_AGENT_TASK_LANES.md` and `config/eval/aether_external_task_lanes.v1.json`. The index should run against open-source task pools, not only this repo's current state.
+
 ## Core Rule
 
 Every task has a binary entry gate:

--- a/docs/benchmarks/OPEN_SOURCE_AGENT_TASK_LANES.md
+++ b/docs/benchmarks/OPEN_SOURCE_AGENT_TASK_LANES.md
@@ -1,0 +1,121 @@
+# Open-Source Agent Task Lanes
+
+Status: external task map for Aether Programmer Index.
+Last researched: 2026-05-23.
+
+This file lists open-source task pools we can run against so SCBE is not limited by the current state of this repo. The source of truth is `config/eval/aether_external_task_lanes.v1.json`.
+
+## What Makes A Strong Coding Assistant
+
+The base model matters, but it is not the whole product. Strong coding assistants are usually strong because the model is wrapped in a better system:
+
+| Layer | What it does | What paid products win on |
+| --- | --- | --- |
+| Base model | Generates code and reasons through patches. | Access to frontier models and large context. |
+| Context system | Finds the right files, symbols, docs, issues, and past failures. | Cursor/Sourcegraph-style codebase retrieval. |
+| Task harness | Defines "done" for each task. | Issue-to-PR flow, hidden tests, shell execution. |
+| Tool runtime | Runs git, shell, browser, package managers, GitHub, deploy checks. | Cloud workspaces and IDE integration. |
+| Verification loop | Runs build, lint, format, test, deploy smoke, and reruns. | Managed automation and polished UX. |
+| Governance layer | Keeps tool use scoped and auditable. | This is where SCBE can compete now. |
+
+So the strategy is not "make a better base model." It is: use available models, then make the harness, context, completion rules, and recovery loop better than the default agent workflow.
+
+## Model Orchestration
+
+Do not spend the largest model on every task. With many agents in flight, the highest-context model should be the leader/judge/router:
+
+| Role | Model tier | Job |
+| --- | --- | --- |
+| Leader | strongest available model | Interpret root intent, select lane, assign workers, resolve disagreement, approve plan. |
+| Specialist | medium model or tool-specific agent | Handle code search, docs lookup, benchmark interpretation, security review. |
+| Worker | cheap/free/local model | Inspect files, generate candidate fixes, run commands, summarize evidence. |
+| External tool | Copilot, Cody/Sourcegraph, other agent | Propose or retrieve; never decide completion alone. |
+| Harness | deterministic scripts/tests/policy | Decide pass/fail, evidence quality, and whether rerun is required. |
+
+This is how SCBE can improve beyond base-model limits. If Opus-class reasoning is too expensive for 1000 agents, use it at the trunk and branch points. Let smaller agents do leaf work, then force every leaf through the same completion rules.
+
+## Lanes To Run
+
+| Lane | Task pool | First SCBE run |
+| --- | --- | --- |
+| Real repo repair | SWE-bench | 1-3 Lite/Verified tasks with patch, tests, logs, cost, and failure mode. |
+| Harness reference | SWE-agent / SWE-ReX | Reuse compatible sandbox and trajectory ideas where practical. |
+| Terminal execution | Terminal-Bench | Small Docker-backed subset through SCBE CLI/agent-bus. |
+| Multi-language editing | Aider Polyglot | Re-run the known Rust failure, then one Python and one JS task. |
+| Cheap language drills | Exercism direct | SCBE-owned mini subset for weak/free models before full Polyglot. |
+| Function correctness | EvalPlus | Cheap local correctness lane for HumanEval+/MBPP+. |
+| Java repair | Defects4J | One small Java bug-fix task after Maven/Gradle harness support exists. |
+| Practical generation | BigCodeBench | Tiny instruct split sample for library/function-call tasks. |
+| Fresh coding | LiveCodeBench | Custom-output JSON evaluation for a small release slice. |
+| Security/governance | AgentDojo | One prompt-injection/tool-use subset through SCBE gate. |
+| Browser/desktop | WebArena / OSWorld | Later lane after the browser/desktop operator is stable. |
+| Live issues | GitHub good first issues | Convert maintainer-labeled public issues into task packets and PRs. |
+
+## GitHub Issue And PR Harness
+
+SCBE should support this issue-to-PR loop:
+
+1. Import GitHub issue or external benchmark task.
+2. Build a task packet with repo URL, base commit, instructions, allowed tools, completion tests, and policy limits.
+3. Let an agent propose changes on a vine branch.
+4. Run pre-lint, format, typecheck, unit tests, and target benchmark tests.
+5. Optionally call GitHub Copilot coding agent as a tool, not as the judge.
+6. Score the result with Aether Programmer Index.
+7. If failed, generate procedural solution triage and rerun.
+8. If passed, raise pass quality: usability, minimality, verification, governance, cost/time.
+9. Open or update PR only with evidence attached.
+
+The key distinction: external tools can propose. SCBE decides completion.
+
+## Sourcegraph-Style Context
+
+We should either use open-source code search/context tools or build the minimum local version:
+
+| Tool | Use |
+| --- | --- |
+| `ripgrep` | Fast text search for issue terms, stack traces, imports, and error strings. |
+| `universal-ctags` | Quick symbol index for MVP retrieval. |
+| `tree-sitter` | Parse source into syntax trees; extract functions, classes, imports, and call sites. |
+| `SCIP` | Sourcegraph-style language-agnostic code intelligence and cross-reference graph. |
+| `Semgrep` | Pattern search for similar bugs, policy violations, and security-sensitive paths. |
+| `LSP` | Go-to-definition and find-references through existing language servers. |
+
+Minimum local version:
+
+1. `ripgrep` issue terms.
+2. `ctags` symbol map.
+3. file shortlist.
+4. test ownership guess.
+5. prior failure memory.
+6. API/doc lookup when the issue depends on current external behavior.
+
+This is probably one of the biggest deltas between weak agents and strong agents. The model often fails because it is looking at the wrong slice of the codebase, not because it cannot write code.
+
+## Near-Term Order
+
+1. **Exercism direct mini subset**: cheapest cross-language usability lane.
+2. **EvalPlus**: cheap function correctness lane.
+3. **Terminal-Bench tiny subset**: proves the terminal operator.
+4. **Aider Polyglot re-run**: directly attacks the known Rust failure.
+5. **Retrieval MVP**: `ripgrep` + `ctags` issue-to-file shortlist.
+6. **AgentDojo tiny subset**: proves governed tool use.
+7. **SWE-bench Lite/Verified 1-task run**: public repo repair evidence.
+8. **GitHub good-first-issue packet**: live issue-to-branch-to-PR workflow.
+9. **Defects4J one-bug run**: Java repair evidence.
+10. **LiveCodeBench/BigCodeBench**: fresh and practical code generation.
+11. **SCIP/tree-sitter graph**: Sourcegraph-style context upgrade.
+12. **WebArena/OSWorld**: only after browser/desktop harness is stable.
+
+## Claim Guardrails
+
+Allowed:
+
+- "SCBE has mapped open-source external task lanes for Aether Programmer Index."
+- "SCBE can evaluate against public task pools outside its own repo once adapters exist."
+- "SCBE treats Copilot/other agents as tools whose outputs must still pass SCBE verification."
+
+Not allowed yet:
+
+- "SCBE beats Cursor/Devin/Copilot" without external task scores.
+- "SCBE passes SWE-bench/Terminal-Bench/Aider" before run packets exist.
+- "SCBE has Sourcegraph-level code intelligence" before a real index/search layer exists.

--- a/tests/benchmark/test_aether_external_task_lanes.py
+++ b/tests/benchmark/test_aether_external_task_lanes.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG = ROOT / "config" / "eval" / "aether_external_task_lanes.v1.json"
+DOC = ROOT / "docs" / "benchmarks" / "OPEN_SOURCE_AGENT_TASK_LANES.md"
+PROGRAMMER_INDEX = ROOT / "docs" / "benchmarks" / "AETHER_PROGRAMMER_INDEX.md"
+
+
+def _config() -> dict:
+    return json.loads(CONFIG.read_text(encoding="utf-8"))
+
+
+def test_external_task_lanes_are_public_and_actionable() -> None:
+    data = _config()
+
+    assert data["schema_version"] == "aether_external_task_lanes_v1"
+    assert "open-source task pools" in data["purpose"].lower()
+    assert len(data["lanes"]) >= 10
+    for lane in data["lanes"]:
+        assert lane["lane_id"]
+        assert lane["track_id"]
+        assert lane["source_name"]
+        assert lane["source_url"].startswith("https://")
+        assert lane["task_pool"]
+        assert lane["first_run_plan"]
+        assert lane["completion_rule"]
+        assert lane["why_it_matters"]
+
+
+def test_external_task_lanes_cover_core_programmer_index_tracks() -> None:
+    data = _config()
+
+    covered = {lane["track_id"] for lane in data["lanes"]}
+    assert {
+        "real_repo_repair",
+        "terminal_execution",
+        "multi_language_editing",
+        "function_correctness",
+        "fresh_algorithmic_coding",
+        "security_governance",
+        "browser_desktop_operation",
+    }.issubset(covered)
+
+
+def test_strong_assistant_model_names_non_model_layers() -> None:
+    data = _config()
+
+    model = data["strong_coding_assistant_model"]
+    assert "base_model" in model
+    assert "context_system" in model
+    assert "task_harness" in model
+    assert "tool_runtime" in model
+    assert "verification_loop" in model
+    assert "governance_layer" in model
+
+
+def test_model_orchestration_uses_leader_worker_harness_split() -> None:
+    data = _config()
+
+    orchestration = data["model_orchestration"]
+    assert "strongest available model as leader" in orchestration["principle"]
+    assert "assign worker agents" in orchestration["leader_role"]
+    assert "generate candidate fixes" in orchestration["worker_role"]
+    assert "3-1000 agents" in orchestration["scaling_rule"]
+    assert "No model is completion authority" in orchestration["completion_authority"]
+
+
+def test_retrieval_stack_includes_mvp_and_sourcegraph_path() -> None:
+    data = _config()
+
+    tools = {tool["tool"]: tool for tool in data["retrieval_stack"]}
+    assert "ripgrep" in tools
+    assert "universal-ctags" in tools
+    assert "tree-sitter" in tools
+    assert tools["tree-sitter"]["source_url"].startswith("https://")
+    assert "SCIP" in tools
+    assert "Sourcegraph-style" in tools["SCIP"]["mvp_use"]
+
+
+def test_optional_external_tools_are_tools_not_judges() -> None:
+    data = _config()
+
+    tools = {tool["tool"]: tool for tool in data["optional_external_tools"]}
+    assert "GitHub Copilot coding agent" in tools
+    assert "SCBE remains the verifier" in tools["GitHub Copilot coding agent"]["use"]
+    assert "Sourcegraph/Cody or open-source code search stack" in tools
+
+
+def test_docs_link_external_task_lanes_and_guard_claims() -> None:
+    doc = DOC.read_text(encoding="utf-8")
+    index = PROGRAMMER_INDEX.read_text(encoding="utf-8")
+
+    assert "What Makes A Strong Coding Assistant" in doc
+    assert "Model Orchestration" in doc
+    assert "highest-context model should be the leader" in doc
+    assert "Sourcegraph-Style Context" in doc
+    assert "GitHub good first issues" in doc
+    assert "external tools can propose" in doc.lower()
+    assert "SCBE decides completion" in doc
+    assert "Not allowed yet" in doc
+    assert "OPEN_SOURCE_AGENT_TASK_LANES.md" in index


### PR DESCRIPTION
## Summary
- add external open-source task lanes for Aether Programmer Index so testing is not limited to this repo
- map SWE-bench, SWE-agent, Terminal-Bench, Aider Polyglot, Exercism, EvalPlus, BigCodeBench, LiveCodeBench, AgentDojo, OSWorld/WebArena, Defects4J, and live GitHub issues
- define strong coding assistant stack: base model + context system + task harness + tool runtime + verification loop + governance layer
- add model orchestration rule: strongest model at trunk/branch decisions, cheaper/free agents at leaves under harness verification
- add retrieval stack path from ripgrep/ctags MVP to tree-sitter/SCIP Sourcegraph-style context

## Verification
- python -m pytest tests\\benchmark\\test_aether_external_task_lanes.py tests\\benchmark\\test_aether_programmer_index.py tests\\benchmark\\test_aether_coding_score_config.py -q
- python -m black --check --target-version py311 --line-length 120 tests\\benchmark\\test_aether_external_task_lanes.py tests\\benchmark\\test_aether_programmer_index.py tests\\benchmark\\test_aether_coding_score_config.py
- python -m ruff check tests\\benchmark\\test_aether_external_task_lanes.py tests\\benchmark\\test_aether_programmer_index.py tests\\benchmark\\test_aether_coding_score_config.py
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for external task evaluation lanes supporting multiple open-source benchmarks (SWE-bench, Terminal-Bench, Aider Polyglot, EvalPlus, BigCodeBench, and others).
  * Updated Programmer Index documentation to reference new external evaluation framework and claim guardrails.

* **Tests**
  * Added validation tests for external task lanes configuration and documentation alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->