### PR TITLE
feat(agentic): add Deploy Condition Packet schema

### DIFF
--- a/src/agentic/dcp.py
+++ b/src/agentic/dcp.py
@@ -1,0 +1,768 @@
+"""Deploy Condition Packet (DCP) — sealed operating envelope for agentic tasks.
+
+A DCP converts "make this work" into a governed workcell:
+  goal + expectations + known_failures + tools + space + storage +
+  context_policy + deploy_target + push_pull_rules + completion_gates +
+  recovery_routes + watcher_receipt
+
+The watcher receipt is written on *dispatch*, not on completion.
+If the agent crashes mid-operation, the receipt already exists and
+a restart knows exactly where to resume without replaying full context.
+
+The DCP is also a training artifact: every executed DCP that reaches
+a verified terminal state produces a (packet, action_trace, evidence)
+triple suitable for SFT/DPO.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+# ─── Trust / scope enums ─────────────────────────────────────────────────────
+
+
+class TrustLevel(str, Enum):
+    VERIFIED_PRIMARY = "verified_primary"  # official repo / signed release
+    VERIFIED_SECONDARY = "verified_secondary"  # known-good mirror / checksum
+    UNVERIFIED = "unverified"  # untested external source
+    QUARANTINED = "quarantined"  # failed its own contract once
+    DENIED = "denied"  # known-bad; never use
+
+
+class TrustState(str, Enum):
+    """Maps to L13 risk decision tiers."""
+
+    ALLOW = "allow"
+    QUARANTINE = "quarantine"
+    ESCALATE = "escalate"
+    DENY = "deny"
+
+
+class ToolScope(str, Enum):
+    ALLOWED = "allowed"
+    RESTRICTED = "restricted"  # allowed but must log every call
+    DENIED = "denied"
+
+
+# ─── Compute / storage enums ─────────────────────────────────────────────────
+
+
+class ComputeTarget(str, Enum):
+    LOCAL = "local"
+    CI = "ci"
+    CLOUD_RUNNER = "cloud_runner"
+    CONTAINER = "container"
+    BROWSER = "browser"
+
+
+class RepoState(str, Enum):
+    CLEAN = "clean"  # no uncommitted changes
+    DIRTY = "dirty"  # uncommitted changes present
+    DETACHED = "detached"  # detached HEAD
+
+
+class SecretsBoundary(str, Enum):
+    LOCAL_ONLY = "local_only"  # secrets never leave the machine
+    VAULT = "vault"  # secrets go through a secrets manager
+    NONE = "none"  # no secrets in scope
+
+
+class DeployTargetKind(str, Enum):
+    LOCAL = "local"
+    PR = "pr"
+    MAIN = "main"
+    NPM = "npm"
+    PYPI = "pypi"
+    HUGGING_FACE = "hugging_face"
+    VERCEL = "vercel"
+    DOCKER = "docker"
+    K8S = "k8s"
+    CUSTOM = "custom"
+
+
+# ─── Operation fullness ───────────────────────────────────────────────────────
+
+
+class FullnessStage(str, Enum):
+    """Downstream pipeline stage — a task is only done when it reaches a terminal."""
+
+    LOCAL_CHANGE = "local_change"
+    COMMITTED = "committed"
+    PUSHED = "pushed"
+    PR_CREATED = "pr_created"
+    CI_RUNNING = "ci_running"
+    CI_COMPLETE = "ci_complete"
+    MERGED = "merged"
+    DEPLOYED = "deployed"
+    VERIFIED = "verified"  # terminal: post-deploy smoke passed
+
+
+class GateResult(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    SKIP = "skip"
+    PENDING = "pending"
+
+
+# ─── Leaf dataclasses ────────────────────────────────────────────────────────
+
+
+@dataclass
+class GoalSpec:
+    """What completion means — concrete, not aspirational."""
+
+    description: str
+    success_evidence: list[str] = field(default_factory=list)  # commands/artifacts that prove it
+    failure_modes: list[str] = field(default_factory=list)  # known ways it can fail to complete
+
+
+@dataclass
+class Expectation:
+    """What the user hopes is true — not yet verified."""
+
+    description: str
+    verified: bool = False
+    verification_command: str | None = None  # command that would prove it
+
+
+@dataclass
+class KnownFailure:
+    """Prior breakpoints, flaky tests, weak lanes documented before action starts."""
+
+    id: str
+    description: str
+    affected_files: list[str] = field(default_factory=list)
+    workaround: str | None = None
+
+
+@dataclass
+class FailureSemantics:
+    """What a failure means for a given tool/source."""
+
+    tool_failure: str = "the tool wrapper may be broken"
+    source_contract_failure: str = "upstream source behavior changed"
+    source_integrity_failure: str = "trusted source may no longer be trusted"
+
+
+@dataclass
+class ToolEntry:
+    """A tool the agent may use, with its trust level and allowed scope."""
+
+    name: str
+    scope: ToolScope = ToolScope.ALLOWED
+    trust_level: TrustLevel = TrustLevel.VERIFIED_PRIMARY
+    trust_state: TrustState = TrustState.ALLOW
+    source_roots: list[str] = field(default_factory=list)
+    failure_semantics: FailureSemantics = field(default_factory=FailureSemantics)
+
+    def downgrade(self, reason: str = "") -> ToolEntry:
+        """Return a copy quarantined one level down. Does not mutate in place."""
+        next_state = {
+            TrustState.ALLOW: TrustState.QUARANTINE,
+            TrustState.QUARANTINE: TrustState.ESCALATE,
+            TrustState.ESCALATE: TrustState.DENY,
+            TrustState.DENY: TrustState.DENY,
+        }[self.trust_state]
+        return ToolEntry(
+            name=self.name,
+            scope=self.scope,
+            trust_level=self.trust_level,
+            trust_state=next_state,
+            source_roots=self.source_roots,
+            failure_semantics=self.failure_semantics,
+        )
+
+
+@dataclass
+class ProcessingSpace:
+    compute: ComputeTarget = ComputeTarget.LOCAL
+    constraints: list[str] = field(default_factory=list)  # e.g. "no network", "read-only fs"
+
+
+@dataclass
+class StorageState:
+    repo_state: RepoState = RepoState.CLEAN
+    branch: str = "main"
+    has_uncommitted_changes: bool = False
+    secrets_boundary: SecretsBoundary = SecretsBoundary.LOCAL_ONLY
+    artifact_paths: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ContextPolicy:
+    """What the agent keeps hot, what it compacts, what it pulls on demand."""
+
+    active_keys: list[str] = field(default_factory=list)  # stay in live context
+    compactable: list[str] = field(default_factory=list)  # can be summarized away
+    pull_on_demand: list[str] = field(default_factory=list)  # retrieve only when needed
+
+    def __post_init__(self) -> None:
+        overlap = set(self.active_keys) & set(self.compactable)
+        if overlap:
+            raise ValueError(f"Keys cannot be both active and compactable: {overlap}")
+
+
+@dataclass
+class DeployTarget:
+    kind: DeployTargetKind = DeployTargetKind.LOCAL
+    branch: str | None = None
+    pr_number: int | None = None
+    push_url: str | None = None
+    environment: str | None = None  # e.g. "staging", "production"
+
+
+@dataclass
+class PushPullRules:
+    can_push: list[str] = field(default_factory=list)  # what is allowed to leave
+    must_stay_local: list[str] = field(default_factory=list)  # secrets, keys, creds
+    evidence_to_pull: list[str] = field(default_factory=list)  # CI logs, test results, deploy status
+
+
+@dataclass
+class CompletionGate:
+    """A verification step that must pass before the task counts as done."""
+
+    id: str
+    description: str
+    command: str  # exact shell command to run
+    expected_exit_code: int = 0
+    timeout_seconds: int = 120
+    required: bool = True  # if False, failure is a warning not a block
+    result: GateResult = GateResult.PENDING
+    output: str = ""  # captured stdout/stderr from last run
+
+
+@dataclass
+class RecoveryRoute:
+    """What happens when a gate fails."""
+
+    on_gate_id: str  # which gate triggers this route
+    action: str  # command or strategy description
+    max_retries: int = 1
+    cancel_condition: str | None = None  # early-abort: cancel if this is true
+    cancel_into: str | None = None  # move to cancel into (like a Tekken cancel window)
+
+
+@dataclass
+class WatcherReceipt:
+    """Written on dispatch, not on completion.
+
+    A cheap watcher process reads this file and polls until terminal state,
+    then writes a result back — without dragging the full conversation along.
+    """
+
+    operation_id: str
+    operation_type: str  # "github_pr", "npm_publish", "ci_run", etc.
+    fullness_stage: FullnessStage = FullnessStage.LOCAL_CHANGE
+    terminal_stages: list[str] = field(default_factory=lambda: ["verified", "denied"])
+    watch_command: str = ""  # e.g. "gh pr view 1863 --json state,statusCheckRollup"
+    poll_interval_seconds: int = 90
+    max_wait_minutes: int = 30
+    on_success: str = ""  # action when terminal reached green
+    on_failure: str = ""  # action when terminal reached red
+    resume_without_full_context: bool = True
+    written_at: float = field(default_factory=time.time)
+    completed_at: float | None = None
+    final_stage: FullnessStage | None = None
+
+
+# ─── Tool chain: Tekken combo system ─────────────────────────────────────────
+
+
+@dataclass
+class ToolMove:
+    """A single move in a tool chain combo.
+
+    frame_advantage: artifact(s) this move produces that give the next move
+    a head start — e.g. repo_map.json from build_context_map lets all
+    downstream tools skip the scan.
+    """
+
+    name: str
+    requires: list[str] = field(default_factory=list)  # artifacts/states needed to start
+    produces: list[str] = field(default_factory=list)  # artifacts/states this creates
+    on_success: list[str] = field(default_factory=list)  # legal next moves
+    on_fail: list[str] = field(default_factory=list)  # legal recovery moves
+    cancel_condition: str | None = None  # abort early if this evaluates true
+    cancel_into: str | None = None  # move to enter if cancel fires
+    unsafe_if: list[str] = field(default_factory=list)  # guard conditions that block this move
+    recovery: list[str] = field(default_factory=list)  # moves to restore state after failure
+    timeout_seconds: int = 120
+    frame_advantage: list[str] = field(default_factory=list)  # context artifacts passed forward
+
+
+@dataclass
+class ToolCombo:
+    """A named sequence of ToolMoves — a reusable agent macro."""
+
+    name: str
+    description: str
+    moves: list[ToolMove] = field(default_factory=list)
+    required_tools: list[str] = field(default_factory=list)
+
+    def validate_chain(self) -> list[str]:
+        """Return a list of broken links in the combo (move requires X but prior move doesn't produce X)."""
+        errors: list[str] = []
+        available: set[str] = set()
+        for move in self.moves:
+            missing = [r for r in move.requires if r not in available]
+            if missing:
+                errors.append(f"{move.name} requires {missing} but they are not yet produced")
+            available.update(move.produces)
+            available.update(move.frame_advantage)
+        return errors
+
+
+# ─── Top-level packet ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class DeployConditionPacket:
+    """Sealed operating envelope for a single agentic task.
+
+    Fields follow the conversation spec:
+      intent → goal → expectations → known_failures → tools →
+      processing_space → storage_state → context_policy →
+      deploy_target → push_pull_rules → completion_gates →
+      recovery_routes → [watcher_receipt written on dispatch]
+    """
+
+    # Identity
+    packet_id: str
+    schema_version: str
+    created_at: float
+
+    # What and why
+    intent: str
+    goal: GoalSpec
+
+    # Pre-conditions
+    expectations: list[Expectation] = field(default_factory=list)
+    known_failures: list[KnownFailure] = field(default_factory=list)
+
+    # Operating environment
+    tools: list[ToolEntry] = field(default_factory=list)
+    processing_space: ProcessingSpace = field(default_factory=ProcessingSpace)
+    storage_state: StorageState = field(default_factory=StorageState)
+    context_policy: ContextPolicy = field(default_factory=ContextPolicy)
+
+    # Destination and movement rules
+    deploy_target: DeployTarget = field(default_factory=DeployTarget)
+    push_pull_rules: PushPullRules = field(default_factory=PushPullRules)
+
+    # Verification
+    completion_gates: list[CompletionGate] = field(default_factory=list)
+    recovery_routes: list[RecoveryRoute] = field(default_factory=list)
+
+    # Async tracking — stamp before dispatch
+    watcher_receipt: WatcherReceipt | None = None
+
+    def stamp_watcher_receipt(
+        self,
+        operation_type: str,
+        watch_command: str,
+        *,
+        on_success: str = "",
+        on_failure: str = "",
+        poll_interval_seconds: int = 90,
+        max_wait_minutes: int = 30,
+    ) -> WatcherReceipt:
+        """Create and attach the watcher receipt. Call this BEFORE the push.
+
+        If the agent crashes after this point, the receipt exists and a restart
+        can poll to completion without replaying full context.
+        """
+        receipt = WatcherReceipt(
+            operation_id=self.packet_id,
+            operation_type=operation_type,
+            fullness_stage=FullnessStage.LOCAL_CHANGE,
+            watch_command=watch_command,
+            on_success=on_success,
+            on_failure=on_failure,
+            poll_interval_seconds=poll_interval_seconds,
+            max_wait_minutes=max_wait_minutes,
+        )
+        self.watcher_receipt = receipt
+        return receipt
+
+    def advance_fullness(self, stage: FullnessStage) -> None:
+        """Record downstream progress without full context reload."""
+        if self.watcher_receipt is not None:
+            self.watcher_receipt.fullness_stage = stage
+            if stage in (FullnessStage.VERIFIED,):
+                self.watcher_receipt.completed_at = time.time()
+                self.watcher_receipt.final_stage = stage
+
+    def required_gates_pending(self) -> list[CompletionGate]:
+        return [g for g in self.completion_gates if g.required and g.result == GateResult.PENDING]
+
+    def required_gates_failed(self) -> list[CompletionGate]:
+        return [g for g in self.completion_gates if g.required and g.result == GateResult.FAIL]
+
+    def is_complete(self) -> bool:
+        """True only when all required gates have passed."""
+        return all(g.result == GateResult.PASS for g in self.completion_gates if g.required)
+
+    def recovery_for(self, gate_id: str) -> list[RecoveryRoute]:
+        return [r for r in self.recovery_routes if r.on_gate_id == gate_id]
+
+    def tool(self, name: str) -> ToolEntry | None:
+        return next((t for t in self.tools if t.name == name), None)
+
+    def downgrade_tool(self, name: str) -> bool:
+        """Quarantine a tool one trust level down. Returns True if found."""
+        for i, t in enumerate(self.tools):
+            if t.name == name:
+                self.tools[i] = t.downgrade()
+                return True
+        return False
+
+    # ── Serialization ────────────────────────────────────────────────────────
+
+    def to_dict(self) -> dict[str, Any]:
+        return _to_dict(self)
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DeployConditionPacket:
+        return _from_dict(data)
+
+    @classmethod
+    def from_json(cls, text: str) -> DeployConditionPacket:
+        return cls.from_dict(json.loads(text))
+
+
+# ─── Factory ─────────────────────────────────────────────────────────────────
+
+
+def create_dcp(
+    intent: str,
+    goal: GoalSpec,
+    *,
+    schema_version: str = "dcp-v1",
+) -> DeployConditionPacket:
+    """Stamp a new Deploy Condition Packet with a fresh UUID and timestamp."""
+    return DeployConditionPacket(
+        packet_id=str(uuid.uuid4()),
+        schema_version=schema_version,
+        created_at=time.time(),
+        intent=intent,
+        goal=goal,
+    )
+
+
+def validate_dcp(dcp: DeployConditionPacket) -> list[str]:
+    """Return a list of validation errors. Empty list = valid."""
+    errors: list[str] = []
+
+    if not dcp.intent.strip():
+        errors.append("intent must not be empty")
+
+    if not dcp.goal.description.strip():
+        errors.append("goal.description must not be empty")
+
+    if not dcp.completion_gates:
+        errors.append("at least one completion gate is required")
+
+    gate_ids = {g.id for g in dcp.completion_gates}
+    for route in dcp.recovery_routes:
+        if route.on_gate_id not in gate_ids:
+            errors.append(f"recovery route references unknown gate: {route.on_gate_id!r}")
+
+    for tool in dcp.tools:
+        if tool.trust_state == TrustState.DENY and tool.scope == ToolScope.ALLOWED:
+            errors.append(f"tool {tool.name!r} is DENY trust but scope is ALLOWED — fix the scope")
+
+    overlap = set(dcp.context_policy.active_keys) & set(dcp.context_policy.compactable)
+    if overlap:
+        errors.append(f"context_policy: keys in both active and compactable: {overlap}")
+
+    return errors
+
+
+# ─── Built-in combos ─────────────────────────────────────────────────────────
+
+
+CLEAN_PR_COMBO = ToolCombo(
+    name="clean_pr",
+    description="Standard PR flow: format → lint → test → security → commit → push → PR",
+    required_tools=["shell", "git", "github"],
+    moves=[
+        ToolMove(
+            name="format",
+            produces=["formatted_files"],
+            on_success=["lint"],
+            on_fail=["triage_format_error"],
+            timeout_seconds=60,
+        ),
+        ToolMove(
+            name="lint",
+            requires=["formatted_files"],
+            produces=["lint_report"],
+            on_success=["test"],
+            on_fail=["triage_lint_error"],
+            cancel_condition="dirty_unrelated_files",
+            recovery=["format", "re_lint"],
+            timeout_seconds=60,
+            frame_advantage=["lint_report"],
+        ),
+        ToolMove(
+            name="test",
+            requires=["lint_report"],
+            produces=["test_report"],
+            on_success=["security_check"],
+            on_fail=["triage_test_failure"],
+            cancel_condition="lint_failure_detected",
+            cancel_into="triage_lint_error",
+            timeout_seconds=300,
+            frame_advantage=["test_report"],
+        ),
+        ToolMove(
+            name="security_check",
+            requires=["test_report"],
+            produces=["security_report"],
+            on_success=["commit"],
+            on_fail=["block_on_security"],
+            unsafe_if=["secrets_in_diff"],
+            timeout_seconds=120,
+        ),
+        ToolMove(
+            name="commit",
+            requires=["security_report"],
+            produces=["commit_sha"],
+            on_success=["push"],
+            on_fail=["triage_commit_error"],
+            unsafe_if=["detached_head"],
+            timeout_seconds=30,
+        ),
+        ToolMove(
+            name="push",
+            requires=["commit_sha"],
+            produces=["remote_ref"],
+            on_success=["pr_create"],
+            on_fail=["triage_push_error"],
+            timeout_seconds=60,
+        ),
+        ToolMove(
+            name="pr_create",
+            requires=["remote_ref"],
+            produces=["pr_number", "watcher_receipt"],
+            on_success=["watch_ci"],
+            on_fail=["triage_pr_error"],
+            frame_advantage=["watcher_receipt"],
+            timeout_seconds=30,
+        ),
+        ToolMove(
+            name="watch_ci",
+            requires=["watcher_receipt"],
+            produces=["ci_result"],
+            on_success=["sync_main"],
+            on_fail=["fetch_failed_job_log"],
+            timeout_seconds=1800,
+        ),
+    ],
+)
+
+BENCHMARK_COMBO = ToolCombo(
+    name="benchmark",
+    description="Load task → run agent → run harness → score → triage → rerun if needed",
+    required_tools=["shell", "benchmark_harness"],
+    moves=[
+        ToolMove(
+            name="load_task",
+            produces=["task_packet"],
+            on_success=["run_agent"],
+            on_fail=["abort_missing_task"],
+            timeout_seconds=30,
+        ),
+        ToolMove(
+            name="run_agent",
+            requires=["task_packet"],
+            produces=["patch"],
+            on_success=["run_harness"],
+            on_fail=["triage_agent_failure"],
+            timeout_seconds=600,
+        ),
+        ToolMove(
+            name="run_harness",
+            requires=["patch"],
+            produces=["score_packet"],
+            on_success=["record_score"],
+            on_fail=["triage_harness_failure"],
+            frame_advantage=["score_packet"],
+            timeout_seconds=300,
+        ),
+        ToolMove(
+            name="record_score",
+            requires=["score_packet"],
+            produces=["score_record"],
+            on_success=[],
+            on_fail=["triage_record_error"],
+            timeout_seconds=30,
+        ),
+    ],
+)
+
+
+# ─── Serialization helpers ────────────────────────────────────────────────────
+
+
+def _to_dict(obj: Any) -> Any:
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, list):
+        return [_to_dict(i) for i in obj]
+    if hasattr(obj, "__dataclass_fields__"):
+        return {k: _to_dict(getattr(obj, k)) for k in obj.__dataclass_fields__}
+    return obj
+
+
+def _from_dict(data: dict[str, Any]) -> DeployConditionPacket:
+    def parse_goal(d: dict) -> GoalSpec:
+        return GoalSpec(**d)
+
+    def parse_expectation(d: dict) -> Expectation:
+        return Expectation(**d)
+
+    def parse_known_failure(d: dict) -> KnownFailure:
+        return KnownFailure(**d)
+
+    def parse_failure_semantics(d: dict) -> FailureSemantics:
+        return FailureSemantics(**d)
+
+    def parse_tool(d: dict) -> ToolEntry:
+        return ToolEntry(
+            name=d["name"],
+            scope=ToolScope(d.get("scope", "allowed")),
+            trust_level=TrustLevel(d.get("trust_level", "verified_primary")),
+            trust_state=TrustState(d.get("trust_state", "allow")),
+            source_roots=d.get("source_roots", []),
+            failure_semantics=parse_failure_semantics(d.get("failure_semantics", {})),
+        )
+
+    def parse_processing_space(d: dict) -> ProcessingSpace:
+        return ProcessingSpace(
+            compute=ComputeTarget(d.get("compute", "local")),
+            constraints=d.get("constraints", []),
+        )
+
+    def parse_storage_state(d: dict) -> StorageState:
+        return StorageState(
+            repo_state=RepoState(d.get("repo_state", "clean")),
+            branch=d.get("branch", "main"),
+            has_uncommitted_changes=d.get("has_uncommitted_changes", False),
+            secrets_boundary=SecretsBoundary(d.get("secrets_boundary", "local_only")),
+            artifact_paths=d.get("artifact_paths", []),
+        )
+
+    def parse_context_policy(d: dict) -> ContextPolicy:
+        return ContextPolicy(
+            active_keys=d.get("active_keys", []),
+            compactable=d.get("compactable", []),
+            pull_on_demand=d.get("pull_on_demand", []),
+        )
+
+    def parse_deploy_target(d: dict) -> DeployTarget:
+        return DeployTarget(
+            kind=DeployTargetKind(d.get("kind", "local")),
+            branch=d.get("branch"),
+            pr_number=d.get("pr_number"),
+            push_url=d.get("push_url"),
+            environment=d.get("environment"),
+        )
+
+    def parse_push_pull_rules(d: dict) -> PushPullRules:
+        return PushPullRules(**d)
+
+    def parse_gate(d: dict) -> CompletionGate:
+        return CompletionGate(
+            id=d["id"],
+            description=d["description"],
+            command=d["command"],
+            expected_exit_code=d.get("expected_exit_code", 0),
+            timeout_seconds=d.get("timeout_seconds", 120),
+            required=d.get("required", True),
+            result=GateResult(d.get("result", "pending")),
+            output=d.get("output", ""),
+        )
+
+    def parse_recovery(d: dict) -> RecoveryRoute:
+        return RecoveryRoute(**d)
+
+    def parse_watcher(d: dict | None) -> WatcherReceipt | None:
+        if d is None:
+            return None
+        return WatcherReceipt(
+            operation_id=d["operation_id"],
+            operation_type=d["operation_type"],
+            fullness_stage=FullnessStage(d.get("fullness_stage", "local_change")),
+            terminal_stages=d.get("terminal_stages", ["verified", "denied"]),
+            watch_command=d.get("watch_command", ""),
+            poll_interval_seconds=d.get("poll_interval_seconds", 90),
+            max_wait_minutes=d.get("max_wait_minutes", 30),
+            on_success=d.get("on_success", ""),
+            on_failure=d.get("on_failure", ""),
+            resume_without_full_context=d.get("resume_without_full_context", True),
+            written_at=d.get("written_at", time.time()),
+            completed_at=d.get("completed_at"),
+            final_stage=FullnessStage(d["final_stage"]) if d.get("final_stage") else None,
+        )
+
+    return DeployConditionPacket(
+        packet_id=data["packet_id"],
+        schema_version=data["schema_version"],
+        created_at=data["created_at"],
+        intent=data["intent"],
+        goal=parse_goal(data["goal"]),
+        expectations=[parse_expectation(e) for e in data.get("expectations", [])],
+        known_failures=[parse_known_failure(f) for f in data.get("known_failures", [])],
+        tools=[parse_tool(t) for t in data.get("tools", [])],
+        processing_space=parse_processing_space(data.get("processing_space", {})),
+        storage_state=parse_storage_state(data.get("storage_state", {})),
+        context_policy=parse_context_policy(data.get("context_policy", {})),
+        deploy_target=parse_deploy_target(data.get("deploy_target", {})),
+        push_pull_rules=parse_push_pull_rules(data.get("push_pull_rules", {})),
+        completion_gates=[parse_gate(g) for g in data.get("completion_gates", [])],
+        recovery_routes=[parse_recovery(r) for r in data.get("recovery_routes", [])],
+        watcher_receipt=parse_watcher(data.get("watcher_receipt")),
+    )
+
+
+__all__ = [
+    "TrustLevel",
+    "TrustState",
+    "ToolScope",
+    "ComputeTarget",
+    "RepoState",
+    "SecretsBoundary",
+    "DeployTargetKind",
+    "FullnessStage",
+    "GateResult",
+    "GoalSpec",
+    "Expectation",
+    "KnownFailure",
+    "FailureSemantics",
+    "ToolEntry",
+    "ProcessingSpace",
+    "StorageState",
+    "ContextPolicy",
+    "DeployTarget",
+    "PushPullRules",
+    "CompletionGate",
+    "RecoveryRoute",
+    "WatcherReceipt",
+    "ToolMove",
+    "ToolCombo",
+    "DeployConditionPacket",
+    "create_dcp",
+    "validate_dcp",
+    "CLEAN_PR_COMBO",
+    "BENCHMARK_COMBO",
+]

--- a/src/tokenizer/code_weight_packets.py
+++ b/src/tokenizer/code_weight_packets.py
@@ -16,12 +16,25 @@ FIELD_DEFINITIONS = [
 ]
 
 LANGUAGE_TONGUES = {
+    # Natural programming languages
     "python": "KO",
     "typescript": "AV",
+    "javascript": "AV",
     "rust": "RU",
     "c": "CA",
+    "cpp": "CA",
+    "c++": "CA",
+    "csharp": "CA",
     "julia": "UM",
     "haskell": "DR",
+    # Markup / document languages
+    "html": "RU",
+    "css": "CA",
+    "markdown": "AV",
+    # Data / config languages
+    "json": "DR",
+    "yaml": "DR",
+    "toml": "DR",
 }
 
 TONGUE_PREFIX = {
@@ -40,6 +53,212 @@ def _sha256_text(value: str) -> str:
 
 def _lexical_tokens(source: str) -> list[str]:
     return re.findall(r"[A-Za-z_][A-Za-z0-9_]*|==|!=|<=|>=|->|=>|::|[^\s]", source)
+
+
+# ─── Domain-specific token classification tables ─────────────────────────────
+
+_HTML_STRUCTURE = frozenset(
+    {
+        "<div>",
+        "<span>",
+        "<section>",
+        "<article>",
+        "<header>",
+        "<footer>",
+        "<main>",
+        "<nav>",
+        "<aside>",
+        "<p>",
+        "<ul>",
+        "<ol>",
+        "<li>",
+        "<h1>",
+        "<h2>",
+        "<h3>",
+        "<h4>",
+        "<h5>",
+        "<h6>",
+        "<table>",
+        "<tr>",
+        "<td>",
+        "<th>",
+        "<form>",
+        "<button>",
+        "<select>",
+        "<input>",
+        "<label>",
+        "<figure>",
+        "<figcaption>",
+        "<blockquote>",
+    }
+)
+_HTML_ACTION = frozenset(
+    {
+        "<script>",
+        "<style>",
+        "<link>",
+        "<meta>",
+        "<iframe>",
+        "<canvas>",
+        "<video>",
+        "<audio>",
+        "<template>",
+    }
+)
+_HTML_RELATION = frozenset(
+    {
+        "href",
+        "src",
+        "id",
+        "class",
+        "type",
+        "name",
+        "value",
+        "action",
+        "method",
+        "rel",
+        "for",
+        "data",
+        "alt",
+        "title",
+        "placeholder",
+        "disabled",
+        "checked",
+        "selected",
+    }
+)
+
+_MD_STRUCTURE = frozenset({"#", "##", "###", "####", "#####", "######"})
+_MD_RELATION = frozenset({"[", "!["})
+_MD_ACTION = frozenset({"```", "`", "**", "*", "_", "__", "~~", "---"})
+
+_C_ACTION = frozenset(
+    {
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "return",
+        "break",
+        "continue",
+        "switch",
+        "case",
+        "default",
+        "goto",
+    }
+)
+_C_STRUCTURE = frozenset({"struct", "union", "enum", "typedef"})
+_C_RELATION = frozenset({"->", ".", "&"})
+_C_INERT = frozenset({"void", "null", "nullptr", "false", "true", "none"})
+
+_CPP_ACTION = _C_ACTION | frozenset(
+    {
+        "new",
+        "delete",
+        "throw",
+        "try",
+        "catch",
+        "noexcept",
+        "explicit",
+        "inline",
+        "virtual",
+        "override",
+        "final",
+    }
+)
+_CPP_STRUCTURE = _C_STRUCTURE | frozenset({"class", "template", "namespace"})
+_CPP_RELATION = _C_RELATION | frozenset({"::", ".*", "->*"})
+
+_RUST_ACTION = frozenset(
+    {
+        "fn",
+        "impl",
+        "mod",
+        "pub",
+        "use",
+        "return",
+        "if",
+        "else",
+        "for",
+        "while",
+        "loop",
+        "match",
+        "let",
+        "mut",
+        "async",
+        "await",
+        "where",
+        "dyn",
+        "move",
+        "unsafe",
+        "extern",
+        "crate",
+    }
+)
+_RUST_STRUCTURE = frozenset({"struct", "enum", "trait", "type", "union"})
+_RUST_RELATION = frozenset({"&", "->", "::", ".", "=>", "?", "ref"})
+_RUST_INERT = frozenset({"None", "false", "true", "()"})
+
+
+def semantic_class_for_domain(token: str, language: str) -> str:
+    """Return the semantic class for a token given its source language.
+
+    Returns one of: ACTION, STRUCTURE, RELATION, INERT_WITNESS, ENTITY.
+    Falls back to the generic ``_semantic_class`` for unrecognised language/token pairs.
+    """
+    lang = language.lower()
+
+    if lang == "html":
+        lower = token.lower()
+        if lower in _HTML_STRUCTURE:
+            return "STRUCTURE"
+        if lower in _HTML_ACTION:
+            return "ACTION"
+        if lower in _HTML_RELATION:
+            return "RELATION"
+
+    elif lang == "markdown":
+        if token in _MD_STRUCTURE:
+            return "STRUCTURE"
+        if token in _MD_RELATION:
+            return "RELATION"
+        if token in _MD_ACTION:
+            return "ACTION"
+
+    elif lang == "c":
+        lower = token.lower()
+        if lower in _C_ACTION:
+            return "ACTION"
+        if lower in _C_STRUCTURE:
+            return "STRUCTURE"
+        if token in _C_RELATION:
+            return "RELATION"
+        if lower in _C_INERT:
+            return "INERT_WITNESS"
+
+    elif lang in ("cpp", "c++"):
+        lower = token.lower()
+        if lower in _CPP_ACTION:
+            return "ACTION"
+        if lower in _CPP_STRUCTURE:
+            return "STRUCTURE"
+        if token in _CPP_RELATION:
+            return "RELATION"
+        if lower in _C_INERT:
+            return "INERT_WITNESS"
+
+    elif lang == "rust":
+        if token in _RUST_ACTION:
+            return "ACTION"
+        if token in _RUST_STRUCTURE:
+            return "STRUCTURE"
+        if token in _RUST_RELATION:
+            return "RELATION"
+        if token in _RUST_INERT:
+            return "INERT_WITNESS"
+
+    return _semantic_class(token)
 
 
 def _semantic_class(token: str) -> str:
@@ -432,9 +651,11 @@ def build_code_weight_packet(source: str, *, language: str, source_name: str = "
 
 
 __all__ = [
+    "LANGUAGE_TONGUES",
     "analyze_chemical_composition",
     "build_code_weight_packet",
     "build_semantic_operation_signature",
     "resolve_element",
+    "semantic_class_for_domain",
     "semantic_operation_signature_from_tokens",
 ]

--- a/tests/agentic/test_dcp.py
+++ b/tests/agentic/test_dcp.py
@@ -1,0 +1,476 @@
+"""Tests for the Deploy Condition Packet (DCP) schema."""
+
+import json
+import time
+
+import pytest
+
+from src.agentic.dcp import (
+    BENCHMARK_COMBO,
+    CLEAN_PR_COMBO,
+    CompletionGate,
+    ComputeTarget,
+    ContextPolicy,
+    DeployConditionPacket,
+    DeployTarget,
+    DeployTargetKind,
+    Expectation,
+    FailureSemantics,
+    FullnessStage,
+    GateResult,
+    GoalSpec,
+    KnownFailure,
+    ProcessingSpace,
+    PushPullRules,
+    RecoveryRoute,
+    RepoState,
+    SecretsBoundary,
+    StorageState,
+    ToolEntry,
+    ToolMove,
+    ToolCombo,
+    ToolScope,
+    TrustLevel,
+    TrustState,
+    create_dcp,
+    validate_dcp,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Factory
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_create_dcp_stamps_uuid_and_timestamp():
+    dcp = create_dcp("fix lint failures", GoalSpec("lint passes clean"))
+    assert len(dcp.packet_id) == 36  # UUID4 format
+    assert dcp.created_at <= time.time()
+    assert dcp.schema_version == "dcp-v1"
+
+
+def test_create_dcp_sets_intent_and_goal():
+    dcp = create_dcp("ship feature X", GoalSpec("all gates green", success_evidence=["npm test"]))
+    assert dcp.intent == "ship feature X"
+    assert dcp.goal.description == "all gates green"
+    assert "npm test" in dcp.goal.success_evidence
+
+
+def test_two_dcps_have_different_ids():
+    a = create_dcp("task a", GoalSpec("done a"))
+    b = create_dcp("task b", GoalSpec("done b"))
+    assert a.packet_id != b.packet_id
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _base_dcp() -> DeployConditionPacket:
+    dcp = create_dcp("run tests", GoalSpec("tests pass"))
+    dcp.completion_gates = [CompletionGate(id="test", description="pytest", command="python -m pytest tests/ -x")]
+    return dcp
+
+
+def test_valid_dcp_has_no_errors():
+    assert validate_dcp(_base_dcp()) == []
+
+
+def test_validate_rejects_empty_intent():
+    dcp = _base_dcp()
+    dcp.intent = "   "
+    errors = validate_dcp(dcp)
+    assert any("intent" in e for e in errors)
+
+
+def test_validate_rejects_empty_goal_description():
+    dcp = _base_dcp()
+    dcp.goal.description = ""
+    errors = validate_dcp(dcp)
+    assert any("goal" in e for e in errors)
+
+
+def test_validate_rejects_missing_gates():
+    dcp = create_dcp("run tests", GoalSpec("tests pass"))
+    errors = validate_dcp(dcp)
+    assert any("gate" in e for e in errors)
+
+
+def test_validate_rejects_orphan_recovery_route():
+    dcp = _base_dcp()
+    dcp.recovery_routes = [RecoveryRoute(on_gate_id="nonexistent", action="fix it")]
+    errors = validate_dcp(dcp)
+    assert any("nonexistent" in e for e in errors)
+
+
+def test_validate_rejects_denied_tool_with_allowed_scope():
+    dcp = _base_dcp()
+    dcp.tools = [ToolEntry(name="shell", scope=ToolScope.ALLOWED, trust_state=TrustState.DENY)]
+    errors = validate_dcp(dcp)
+    assert any("shell" in e for e in errors)
+
+
+def test_validate_catches_context_policy_overlap():
+    with pytest.raises(ValueError, match="repo_map"):
+        ContextPolicy(active_keys=["repo_map"], compactable=["repo_map"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Completion gates
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_is_complete_only_when_all_required_gates_pass():
+    dcp = _base_dcp()
+    dcp.completion_gates[0].result = GateResult.PASS
+    assert dcp.is_complete()
+
+
+def test_is_not_complete_with_pending_required_gate():
+    dcp = _base_dcp()
+    assert not dcp.is_complete()
+
+
+def test_is_not_complete_with_failed_required_gate():
+    dcp = _base_dcp()
+    dcp.completion_gates[0].result = GateResult.FAIL
+    assert not dcp.is_complete()
+
+
+def test_optional_gate_failure_does_not_block_completion():
+    dcp = _base_dcp()
+    dcp.completion_gates[0].result = GateResult.PASS
+    dcp.completion_gates.append(
+        CompletionGate(id="docs", description="docs build", command="make docs", required=False, result=GateResult.FAIL)
+    )
+    assert dcp.is_complete()
+
+
+def test_required_gates_pending_returns_only_pending():
+    dcp = _base_dcp()
+    dcp.completion_gates.append(
+        CompletionGate(id="lint", description="lint", command="npm run lint", result=GateResult.PASS)
+    )
+    pending = dcp.required_gates_pending()
+    assert len(pending) == 1
+    assert pending[0].id == "test"
+
+
+def test_required_gates_failed_returns_only_failed():
+    dcp = _base_dcp()
+    dcp.completion_gates[0].result = GateResult.FAIL
+    failed = dcp.required_gates_failed()
+    assert len(failed) == 1 and failed[0].id == "test"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Recovery routes
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_recovery_for_returns_matching_routes():
+    dcp = _base_dcp()
+    dcp.recovery_routes = [
+        RecoveryRoute(on_gate_id="test", action="run black and re-test", max_retries=2),
+        RecoveryRoute(on_gate_id="lint", action="run format"),
+    ]
+    routes = dcp.recovery_for("test")
+    assert len(routes) == 1
+    assert routes[0].action == "run black and re-test"
+
+
+def test_recovery_for_unknown_gate_returns_empty():
+    dcp = _base_dcp()
+    assert dcp.recovery_for("no_such_gate") == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tool trust downgrade (source quarantine)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_tool_downgrade_allow_to_quarantine():
+    tool = ToolEntry(name="swe_bench", trust_state=TrustState.ALLOW)
+    downgraded = tool.downgrade()
+    assert downgraded.trust_state == TrustState.QUARANTINE
+    assert tool.trust_state == TrustState.ALLOW  # original unchanged
+
+
+def test_tool_downgrade_chain_to_deny():
+    tool = ToolEntry(name="flaky_source", trust_state=TrustState.ESCALATE)
+    assert tool.downgrade().trust_state == TrustState.DENY
+
+
+def test_tool_downgrade_deny_stays_deny():
+    tool = ToolEntry(name="bad_source", trust_state=TrustState.DENY)
+    assert tool.downgrade().trust_state == TrustState.DENY
+
+
+def test_downgrade_tool_by_name_on_dcp():
+    dcp = _base_dcp()
+    dcp.tools = [ToolEntry(name="shell", trust_state=TrustState.ALLOW)]
+    result = dcp.downgrade_tool("shell")
+    assert result is True
+    assert dcp.tools[0].trust_state == TrustState.QUARANTINE
+
+
+def test_downgrade_tool_unknown_name_returns_false():
+    dcp = _base_dcp()
+    assert dcp.downgrade_tool("nonexistent") is False
+
+
+def test_tool_lookup_by_name():
+    dcp = _base_dcp()
+    dcp.tools = [ToolEntry(name="github")]
+    assert dcp.tool("github") is not None
+    assert dcp.tool("missing") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Watcher receipt — must be written before push
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_stamp_watcher_receipt_before_push():
+    dcp = _base_dcp()
+    t_before_stamp = time.time()
+    receipt = dcp.stamp_watcher_receipt(
+        operation_type="github_pr",
+        watch_command="gh pr view 42 --json state,statusCheckRollup",
+        on_success="sync_main_and_prune_branch",
+        on_failure="fetch_failed_job_log",
+    )
+    assert receipt.written_at >= t_before_stamp
+    assert dcp.watcher_receipt is receipt
+    assert receipt.operation_id == dcp.packet_id
+    assert receipt.fullness_stage == FullnessStage.LOCAL_CHANGE
+
+
+def test_advance_fullness_updates_receipt_stage():
+    dcp = _base_dcp()
+    dcp.stamp_watcher_receipt("npm_publish", "npm view mypackage@latest")
+    dcp.advance_fullness(FullnessStage.CI_RUNNING)
+    assert dcp.watcher_receipt.fullness_stage == FullnessStage.CI_RUNNING
+
+
+def test_advance_fullness_to_verified_sets_completed_at():
+    dcp = _base_dcp()
+    dcp.stamp_watcher_receipt("deploy", "curl health-check")
+    dcp.advance_fullness(FullnessStage.VERIFIED)
+    assert dcp.watcher_receipt.completed_at is not None
+    assert dcp.watcher_receipt.final_stage == FullnessStage.VERIFIED
+
+
+def test_receipt_written_at_precedes_any_simulated_action():
+    dcp = _base_dcp()
+    receipt = dcp.stamp_watcher_receipt("github_pr", "gh pr view 1 --json state")
+    # simulate some work time has passed
+    time_after_work = time.time()
+    assert receipt.written_at <= time_after_work
+
+
+def test_advance_fullness_without_receipt_is_safe():
+    dcp = _base_dcp()
+    dcp.advance_fullness(FullnessStage.PUSHED)  # no receipt attached — must not crash
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tool chain combos
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_tool_move_cancel_window_fields():
+    move = ToolMove(
+        name="test",
+        cancel_condition="lint_failure_detected_before_frame_12",
+        cancel_into="triage_lint_error",
+    )
+    assert move.cancel_condition is not None
+    assert move.cancel_into == "triage_lint_error"
+
+
+def test_tool_combo_validate_chain_clean():
+    combo = ToolCombo(
+        name="minimal",
+        description="two-step chain",
+        moves=[
+            ToolMove(name="step1", produces=["artifact_a"]),
+            ToolMove(name="step2", requires=["artifact_a"]),
+        ],
+    )
+    assert combo.validate_chain() == []
+
+
+def test_tool_combo_validate_chain_detects_broken_link():
+    combo = ToolCombo(
+        name="broken",
+        description="step2 needs something step1 doesn't produce",
+        moves=[
+            ToolMove(name="step1", produces=["artifact_a"]),
+            ToolMove(name="step2", requires=["artifact_b"]),  # never produced
+        ],
+    )
+    errors = combo.validate_chain()
+    assert len(errors) == 1
+    assert "artifact_b" in errors[0]
+
+
+def test_frame_advantage_counts_as_produced():
+    combo = ToolCombo(
+        name="frame_adv",
+        description="frame_advantage is also available downstream",
+        moves=[
+            ToolMove(name="build_context", frame_advantage=["repo_map"]),
+            ToolMove(name="pick_task", requires=["repo_map"]),
+        ],
+    )
+    assert combo.validate_chain() == []
+
+
+def test_clean_pr_combo_has_valid_chain():
+    assert CLEAN_PR_COMBO.validate_chain() == []
+
+
+def test_benchmark_combo_has_valid_chain():
+    assert BENCHMARK_COMBO.validate_chain() == []
+
+
+def test_clean_pr_combo_move_names():
+    move_names = [m.name for m in CLEAN_PR_COMBO.moves]
+    assert "format" in move_names
+    assert "lint" in move_names
+    assert "test" in move_names
+    assert "pr_create" in move_names
+    assert "watch_ci" in move_names
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Serialization round-trip
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _full_dcp() -> DeployConditionPacket:
+    dcp = create_dcp(
+        "deploy feature to PR",
+        GoalSpec(
+            description="PR created, CI green, no secrets",
+            success_evidence=["gh pr view --json state | jq .state == OPEN"],
+            failure_modes=["lint failure", "test timeout"],
+        ),
+    )
+    dcp.expectations = [Expectation("branch is clean", verified=True, verification_command="git status")]
+    dcp.known_failures = [KnownFailure(id="flaky-e2e", description="E2E suite flaky on Windows", workaround="skip e2e")]
+    dcp.tools = [
+        ToolEntry(
+            name="github",
+            scope=ToolScope.ALLOWED,
+            trust_level=TrustLevel.VERIFIED_PRIMARY,
+            trust_state=TrustState.ALLOW,
+            source_roots=["https://github.com"],
+            failure_semantics=FailureSemantics(
+                tool_failure="gh CLI may be misconfigured",
+                source_contract_failure="GitHub API changed",
+                source_integrity_failure="GitHub may be compromised",
+            ),
+        )
+    ]
+    dcp.processing_space = ProcessingSpace(compute=ComputeTarget.LOCAL, constraints=["no root"])
+    dcp.storage_state = StorageState(
+        repo_state=RepoState.DIRTY,
+        branch="feat/dcp",
+        has_uncommitted_changes=True,
+        secrets_boundary=SecretsBoundary.LOCAL_ONLY,
+        artifact_paths=["artifacts/dcp_test.json"],
+    )
+    dcp.context_policy = ContextPolicy(
+        active_keys=["goal", "known_failures"],
+        compactable=["prior_test_output"],
+        pull_on_demand=["full_repo_map"],
+    )
+    dcp.deploy_target = DeployTarget(kind=DeployTargetKind.PR, branch="feat/dcp", pr_number=None)
+    dcp.push_pull_rules = PushPullRules(
+        can_push=["branch"],
+        must_stay_local=[".env", "secrets/"],
+        evidence_to_pull=["ci_log", "pr_status"],
+    )
+    dcp.completion_gates = [
+        CompletionGate(id="lint", description="lint clean", command="npm run lint", required=True),
+        CompletionGate(id="test", description="tests pass", command="python -m pytest tests/ -x", required=True),
+    ]
+    dcp.recovery_routes = [
+        RecoveryRoute(on_gate_id="lint", action="npm run format && re-lint", max_retries=1),
+        RecoveryRoute(
+            on_gate_id="test",
+            action="fetch failing test output",
+            cancel_condition="known_flaky_detected",
+            cancel_into="skip_flaky_rerun",
+        ),
+    ]
+    dcp.stamp_watcher_receipt(
+        operation_type="github_pr",
+        watch_command="gh pr view --json state,statusCheckRollup",
+        on_success="sync_main",
+        on_failure="fetch_failed_log",
+    )
+    return dcp
+
+
+def test_serialization_round_trip():
+    original = _full_dcp()
+    as_dict = original.to_dict()
+    restored = DeployConditionPacket.from_dict(as_dict)
+
+    assert restored.packet_id == original.packet_id
+    assert restored.intent == original.intent
+    assert restored.goal.description == original.goal.description
+    assert len(restored.expectations) == len(original.expectations)
+    assert restored.expectations[0].verified is True
+    assert len(restored.known_failures) == 1
+    assert restored.known_failures[0].id == "flaky-e2e"
+    assert len(restored.tools) == 1
+    assert restored.tools[0].trust_state == TrustState.ALLOW
+    assert restored.processing_space.compute == ComputeTarget.LOCAL
+    assert restored.storage_state.repo_state == RepoState.DIRTY
+    assert restored.storage_state.branch == "feat/dcp"
+    assert restored.context_policy.active_keys == ["goal", "known_failures"]
+    assert restored.deploy_target.kind == DeployTargetKind.PR
+    assert restored.push_pull_rules.must_stay_local == [".env", "secrets/"]
+    assert len(restored.completion_gates) == 2
+    assert len(restored.recovery_routes) == 2
+    assert restored.watcher_receipt is not None
+    assert restored.watcher_receipt.operation_type == "github_pr"
+
+
+def test_json_round_trip_is_valid_json():
+    dcp = _full_dcp()
+    text = dcp.to_json()
+    parsed = json.loads(text)  # must not raise
+    assert parsed["schema_version"] == "dcp-v1"
+    assert "completion_gates" in parsed
+    assert "watcher_receipt" in parsed
+
+
+def test_from_json_is_inverse_of_to_json():
+    original = _full_dcp()
+    restored = DeployConditionPacket.from_json(original.to_json())
+    assert restored.packet_id == original.packet_id
+    assert restored.is_complete() == original.is_complete()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fullness stage ordering
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_fullness_stages_are_strings():
+    for stage in FullnessStage:
+        assert isinstance(stage.value, str)
+
+
+def test_verified_stage_is_terminal():
+    dcp = _base_dcp()
+    dcp.stamp_watcher_receipt("ci", "gh run view")
+    dcp.advance_fullness(FullnessStage.VERIFIED)
+    r = dcp.watcher_receipt
+    assert r.final_stage == FullnessStage.VERIFIED
+    assert r.completed_at is not None

--- a/tests/cross-language/nsm-primes-parity.test.ts
+++ b/tests/cross-language/nsm-primes-parity.test.ts
@@ -1,0 +1,402 @@
+/**
+ * @file nsm-primes-parity.test.ts
+ * @module tests/cross-language
+ *
+ * Cross-language parity: Python nsm_primes.py vs TypeScript nsmPrimes.ts.
+ *
+ * Asserts that for every probe input, both implementations return
+ * bit-identical integers and close-enough floats (tol 1e-10).
+ *
+ * Domain sections extend the probe set to tokens drawn from HTML,
+ * Markdown, C/C++, and Rust — languages that feed the code_weight_packets
+ * tongue routing and must stay consistent across both runtimes.
+ */
+
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { describe, it, expect } from 'vitest';
+
+import {
+  PHI,
+  TONGUE_ORDER,
+  TONGUE_PHASE,
+  NSM_PRIMES,
+  getPrime,
+  gridIndex,
+  primeGridIndex,
+  phiExtrapolate,
+  generateSubprimeAnchors,
+} from '../../src/tokenizer/nsmPrimes.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PYTHON_BIN = process.platform === 'win32' ? 'python' : 'python3';
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+function py(script: string): unknown {
+  const full = [
+    'import sys, json',
+    `sys.path.insert(0, ${JSON.stringify(REPO_ROOT)})`,
+    script,
+    'print(json.dumps(result))',
+  ].join('\n');
+  try {
+    const out = execFileSync(PYTHON_BIN, ['-c', full], {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, PYTHONIOENCODING: 'utf-8' },
+    });
+    return JSON.parse(out.trim());
+  } catch {
+    return null;
+  }
+}
+
+function hasPython(): boolean {
+  return py('result = 1') !== null;
+}
+
+const pythonAvailable = hasPython();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Probe sets
+// ─────────────────────────────────────────────────────────────────────────────
+
+// One per tongue + all cross-tongue primes + boundary cases
+const PRIME_PROBES = [
+  // KO face
+  'ko.i',
+  'ko.you',
+  'ko.want',
+  'ko.not',
+  'ko.think',
+  'ko.if',
+  'ko.do',
+  // AV face
+  'av.say',
+  'av.see',
+  'av.hear',
+  'av.move',
+  // RU face
+  'ru.good',
+  'ru.bad',
+  'ru.all',
+  // CA face
+  'ca.one',
+  'ca.two',
+  'ca.more',
+  // UM face
+  'um.inside',
+  'um.feel',
+  'um.have',
+  // DR face
+  'dr.know',
+  'dr.before',
+  'dr.after',
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe.skipIf(!pythonAvailable)('NSM Primes — Python / TypeScript parity', () => {
+  // ── Constants ──────────────────────────────────────────────────────────────
+
+  describe('Constants', () => {
+    it('PHI matches', () => {
+      const r = py('from src.tokenizer.nsm_primes import PHI; result = PHI') as number;
+      expect(PHI).toBeCloseTo(r, 14);
+    });
+
+    it('TONGUE_ORDER matches', () => {
+      const r = py(
+        'from src.tokenizer.nsm_primes import TONGUE_ORDER; result = list(TONGUE_ORDER)'
+      ) as string[];
+      expect(TONGUE_ORDER).toEqual(r);
+    });
+
+    it('TONGUE_PHASE values match', () => {
+      const r = py(
+        'from src.tokenizer.nsm_primes import TONGUE_PHASE; result = dict(TONGUE_PHASE)'
+      ) as Record<string, number>;
+      for (const t of TONGUE_ORDER) {
+        expect(TONGUE_PHASE[t]).toBeCloseTo(r[t], 12);
+      }
+    });
+
+    it('NSM_PRIMES length matches', () => {
+      const r = py(
+        'from src.tokenizer.nsm_primes import NSM_PRIMES; result = len(NSM_PRIMES)'
+      ) as number;
+      expect(NSM_PRIMES.length).toBe(r);
+    });
+  });
+
+  // ── Prime table fields ─────────────────────────────────────────────────────
+
+  describe('Prime table fields', () => {
+    for (const id of PRIME_PROBES) {
+      it(id, () => {
+        const ts = getPrime(id);
+        expect(ts).toBeDefined();
+
+        const r = py(`
+from src.tokenizer.nsm_primes import get_prime
+p = get_prime(${JSON.stringify(id)})
+result = {
+  'r': p.r,
+  'grid_row': p.grid_row,
+  'grid_col': p.grid_col,
+  'primary_tongue': p.primary_tongue,
+  'primary_confidence': p.primary_confidence,
+  'is_cross_tongue': p.is_cross_tongue,
+  'phi_order': p.phi_order,
+  'label': p.label,
+}
+`) as Record<string, unknown>;
+
+        expect(ts!.r).toBeCloseTo(r.r as number, 10);
+        expect(ts!.gridRow).toBe(r.grid_row as number);
+        expect(ts!.gridCol).toBe(r.grid_col as number);
+        expect(ts!.spans[0].tongue).toBe(r.primary_tongue as string);
+        expect(ts!.spans[0].confidence).toBeCloseTo(r.primary_confidence as number, 10);
+        expect(ts!.phiOrder).toBe(r.phi_order as number);
+        expect(ts!.label).toBe(r.label as string);
+      });
+    }
+  });
+
+  // ── Missing prime returns undefined / None ─────────────────────────────────
+
+  describe('Missing prime', () => {
+    it('getPrime("nonexistent") returns undefined in TS and None in Python', () => {
+      expect(getPrime('nonexistent.prime')).toBeUndefined();
+      const r = py(
+        "from src.tokenizer.nsm_primes import get_prime; result = get_prime('nonexistent.prime') is None"
+      );
+      expect(r).toBe(true);
+    });
+  });
+
+  // ── Grid index ─────────────────────────────────────────────────────────────
+
+  describe('gridIndex', () => {
+    const cases: Array<[number, number]> = [
+      [0, 0],
+      [0, 1],
+      [1, 0],
+      [15, 15],
+      [3, 7],
+      [8, 12],
+      [0, 15],
+      [15, 0],
+    ];
+    for (const [row, col] of cases) {
+      it(`gridIndex(${row}, ${col})`, () => {
+        const ts = gridIndex(row, col);
+        const r = py(
+          `from src.tokenizer.nsm_primes import grid_index; result = grid_index(${row}, ${col})`
+        ) as number;
+        expect(ts).toBe(r);
+      });
+    }
+  });
+
+  // ── primeGridIndex ─────────────────────────────────────────────────────────
+
+  describe('primeGridIndex', () => {
+    for (const id of ['ko.i', 'ko.want', 'av.say', 'dr.before']) {
+      it(id, () => {
+        const p = getPrime(id)!;
+        const ts = primeGridIndex(p);
+        const r = py(`
+from src.tokenizer.nsm_primes import get_prime, prime_grid_index
+result = prime_grid_index(get_prime(${JSON.stringify(id)}))
+`) as number;
+        expect(ts).toBe(r);
+      });
+    }
+  });
+
+  // ── phi_extrapolate step parity ────────────────────────────────────────────
+
+  describe('phiExtrapolate step parity', () => {
+    const probes = ['ko.want', 'av.say', 'ru.good', 'ca.one', 'um.inside', 'dr.before'];
+    for (const id of probes) {
+      it(`phiExtrapolate(${id}, 3)`, () => {
+        const p = getPrime(id)!;
+        const tsSteps = phiExtrapolate(p, 3);
+
+        const r = py(`
+from src.tokenizer.nsm_primes import get_prime, phi_extrapolate
+steps = phi_extrapolate(get_prime(${JSON.stringify(id)}), steps=3)
+result = [
+  {
+    'n': ex.n,
+    'derived_tongue': ex.derived_tongue,
+    'derived_r': ex.derived_r,
+    'grid_row': ex.grid_row,
+    'grid_col': ex.grid_col,
+    'is_known_prime': ex.is_known_prime,
+    'confidence': ex.confidence,
+  }
+  for ex in steps
+]
+`) as Array<Record<string, unknown>>;
+
+        expect(tsSteps.length).toBe(r.length);
+        for (let i = 0; i < r.length; i++) {
+          expect(tsSteps[i].n).toBe(r[i].n);
+          expect(tsSteps[i].derivedTongue).toBe(r[i].derived_tongue);
+          expect(tsSteps[i].derivedR).toBeCloseTo(r[i].derived_r as number, 6);
+          expect(tsSteps[i].gridRow).toBe(r[i].grid_row);
+          expect(tsSteps[i].gridCol).toBe(r[i].grid_col);
+          expect(tsSteps[i].isKnownPrime).toBe(r[i].is_known_prime);
+          expect(tsSteps[i].confidence).toBeCloseTo(r[i].confidence as number, 6);
+        }
+      });
+    }
+  });
+
+  // ── SubPrime anchor parity ─────────────────────────────────────────────────
+
+  describe('generateSubprimeAnchors parity', () => {
+    for (const id of ['ko.want', 'um.inside', 'dr.before']) {
+      it(`generateSubprimeAnchors(${id}, 3)`, () => {
+        const p = getPrime(id)!;
+        const tsAnchors = generateSubprimeAnchors(p, 3);
+
+        const r = py(`
+from src.tokenizer.nsm_primes import get_prime, generate_subprime_anchors
+anchors = generate_subprime_anchors(get_prime(${JSON.stringify(id)}), steps=3)
+result = [
+  {
+    'n': a.n,
+    'tongue': a.tongue,
+    'r': a.r,
+    'grid_row': a.grid_row,
+    'grid_col': a.grid_col,
+    'is_known_prime': a.is_known_prime,
+    'proximity_confidence': a.proximity_confidence,
+  }
+  for a in anchors
+]
+`) as Array<Record<string, unknown>>;
+
+        expect(tsAnchors.length).toBe(r.length);
+        for (let i = 0; i < r.length; i++) {
+          expect(tsAnchors[i].n).toBe(r[i].n);
+          expect(tsAnchors[i].tongue).toBe(r[i].tongue);
+          expect(tsAnchors[i].r).toBeCloseTo(r[i].r as number, 6);
+          expect(tsAnchors[i].gridRow).toBe(r[i].grid_row);
+          expect(tsAnchors[i].gridCol).toBe(r[i].grid_col);
+          expect(tsAnchors[i].isKnownPrime).toBe(r[i].is_known_prime);
+          expect(tsAnchors[i].proximityConfidence).toBeCloseTo(
+            r[i].proximity_confidence as number,
+            6
+          );
+        }
+      });
+    }
+  });
+
+  // ── Domain language tongue routing ─────────────────────────────────────────
+  //
+  // code_weight_packets.LANGUAGE_TONGUES must agree between Python and any
+  // future TypeScript port.  We treat Python as the source of truth here and
+  // assert the mapping covers all expected domain languages.
+
+  describe('Domain language tongue routing (Python source of truth)', () => {
+    const expectedMappings: Record<string, string> = {
+      // Natural programming languages
+      python: 'KO',
+      typescript: 'AV',
+      javascript: 'AV',
+      rust: 'RU',
+      c: 'CA',
+      cpp: 'CA',
+      csharp: 'CA',
+      julia: 'UM',
+      haskell: 'DR',
+      // Markup / document languages
+      html: 'RU',
+      css: 'CA',
+      markdown: 'AV',
+      // Data / config languages
+      json: 'DR',
+      yaml: 'DR',
+      toml: 'DR',
+    };
+
+    for (const [lang, expectedTongue] of Object.entries(expectedMappings)) {
+      it(`${lang} → ${expectedTongue}`, () => {
+        const r = py(`
+from src.tokenizer.code_weight_packets import LANGUAGE_TONGUES
+result = LANGUAGE_TONGUES.get(${JSON.stringify(lang)})
+`) as string | null;
+        expect(r).toBe(expectedTongue);
+      });
+    }
+  });
+
+  // ── Domain token semantic class ────────────────────────────────────────────
+
+  describe('Domain token semantic classification (Python)', () => {
+    const cases: Array<{ lang: string; token: string; expected: string }> = [
+      // HTML structural tags → STRUCTURE
+      { lang: 'html', token: '<div>', expected: 'STRUCTURE' },
+      { lang: 'html', token: '<span>', expected: 'STRUCTURE' },
+      { lang: 'html', token: '<section>', expected: 'STRUCTURE' },
+      // HTML action tags → ACTION
+      { lang: 'html', token: '<script>', expected: 'ACTION' },
+      { lang: 'html', token: '<style>', expected: 'ACTION' },
+      // HTML attributes → RELATION
+      { lang: 'html', token: 'href', expected: 'RELATION' },
+      { lang: 'html', token: 'src', expected: 'RELATION' },
+      // Markdown headers → STRUCTURE
+      { lang: 'markdown', token: '#', expected: 'STRUCTURE' },
+      { lang: 'markdown', token: '##', expected: 'STRUCTURE' },
+      // Markdown links → RELATION
+      { lang: 'markdown', token: '[', expected: 'RELATION' },
+      // Markdown code → ACTION
+      { lang: 'markdown', token: '```', expected: 'ACTION' },
+      // C/C++ control flow → ACTION
+      { lang: 'c', token: 'if', expected: 'ACTION' },
+      { lang: 'c', token: 'for', expected: 'ACTION' },
+      { lang: 'c', token: 'return', expected: 'ACTION' },
+      { lang: 'cpp', token: 'struct', expected: 'STRUCTURE' },
+      { lang: 'cpp', token: 'class', expected: 'STRUCTURE' },
+      // C/C++ operators → RELATION
+      { lang: 'c', token: '->', expected: 'RELATION' },
+      { lang: 'cpp', token: '::', expected: 'RELATION' },
+      // C types → INERT_WITNESS
+      { lang: 'c', token: 'void', expected: 'INERT_WITNESS' },
+      { lang: 'c', token: 'NULL', expected: 'INERT_WITNESS' },
+      // Rust definitions → ACTION
+      { lang: 'rust', token: 'fn', expected: 'ACTION' },
+      { lang: 'rust', token: 'impl', expected: 'ACTION' },
+      // Rust types → STRUCTURE
+      { lang: 'rust', token: 'struct', expected: 'STRUCTURE' },
+      { lang: 'rust', token: 'enum', expected: 'STRUCTURE' },
+      { lang: 'rust', token: 'trait', expected: 'STRUCTURE' },
+      // Rust borrow/ownership → RELATION
+      { lang: 'rust', token: '&', expected: 'RELATION' },
+      { lang: 'rust', token: '->', expected: 'RELATION' },
+      // Rust null-like → INERT_WITNESS
+      { lang: 'rust', token: 'None', expected: 'INERT_WITNESS' },
+    ];
+
+    for (const { lang, token, expected } of cases) {
+      it(`${lang}:${token} → ${expected}`, () => {
+        const r = py(`
+from src.tokenizer.code_weight_packets import semantic_class_for_domain
+result = semantic_class_for_domain(${JSON.stringify(token)}, ${JSON.stringify(lang)})
+`) as string | null;
+        if (r !== null) expect(r).toBe(expected);
+      });
+    }
+  });
+});

--- a/tests/tokenizer/test_domain_tokenizer.py
+++ b/tests/tokenizer/test_domain_tokenizer.py
@@ -1,0 +1,291 @@
+"""Domain-language token classification and tongue routing tests.
+
+Covers LANGUAGE_TONGUES mappings and semantic_class_for_domain() for
+HTML, Markdown, C/C++, and Rust — languages that feed tongue routing
+in code_weight_packets.
+"""
+
+import pytest
+
+from src.tokenizer.code_weight_packets import (
+    LANGUAGE_TONGUES,
+    semantic_class_for_domain,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tongue routing — LANGUAGE_TONGUES coverage
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "language, expected_tongue",
+    [
+        # Natural programming languages
+        ("python", "KO"),
+        ("typescript", "AV"),
+        ("javascript", "AV"),
+        ("rust", "RU"),
+        ("c", "CA"),
+        ("cpp", "CA"),
+        ("csharp", "CA"),
+        ("julia", "UM"),
+        ("haskell", "DR"),
+        # Markup / document
+        ("html", "RU"),
+        ("css", "CA"),
+        ("markdown", "AV"),
+        # Data / config
+        ("json", "DR"),
+        ("yaml", "DR"),
+        ("toml", "DR"),
+    ],
+)
+def test_language_tongue_routing(language: str, expected_tongue: str) -> None:
+    assert LANGUAGE_TONGUES.get(language) == expected_tongue
+
+
+def test_language_tongues_no_duplicates_across_ko_av() -> None:
+    """python and typescript should not share a tongue."""
+    assert LANGUAGE_TONGUES["python"] != LANGUAGE_TONGUES["typescript"]
+
+
+def test_javascript_shares_tongue_with_typescript() -> None:
+    assert LANGUAGE_TONGUES["javascript"] == LANGUAGE_TONGUES["typescript"]
+
+
+def test_cpp_shares_tongue_with_c() -> None:
+    assert LANGUAGE_TONGUES["cpp"] == LANGUAGE_TONGUES["c"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HTML token classification
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        # Structural tags
+        ("<div>", "STRUCTURE"),
+        ("<span>", "STRUCTURE"),
+        ("<section>", "STRUCTURE"),
+        ("<article>", "STRUCTURE"),
+        ("<header>", "STRUCTURE"),
+        ("<footer>", "STRUCTURE"),
+        ("<nav>", "STRUCTURE"),
+        ("<ul>", "STRUCTURE"),
+        ("<li>", "STRUCTURE"),
+        ("<table>", "STRUCTURE"),
+        # Action tags
+        ("<script>", "ACTION"),
+        ("<style>", "ACTION"),
+        ("<link>", "ACTION"),
+        ("<meta>", "ACTION"),
+        ("<iframe>", "ACTION"),
+        # Relation attributes
+        ("href", "RELATION"),
+        ("src", "RELATION"),
+        ("id", "RELATION"),
+        ("class", "RELATION"),
+        ("type", "RELATION"),
+        ("name", "RELATION"),
+        ("action", "RELATION"),
+        ("method", "RELATION"),
+    ],
+)
+def test_html_semantic_class(token: str, expected: str) -> None:
+    assert semantic_class_for_domain(token, "html") == expected
+
+
+def test_html_tag_matching_is_case_insensitive() -> None:
+    assert semantic_class_for_domain("<DIV>", "html") == "STRUCTURE"
+    assert semantic_class_for_domain("<SCRIPT>", "html") == "ACTION"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Markdown token classification
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        # Headers → STRUCTURE
+        ("#", "STRUCTURE"),
+        ("##", "STRUCTURE"),
+        ("###", "STRUCTURE"),
+        ("######", "STRUCTURE"),
+        # Link opener → RELATION
+        ("[", "RELATION"),
+        # Code fence → ACTION
+        ("```", "ACTION"),
+        ("`", "ACTION"),
+        # Emphasis → ACTION
+        ("**", "ACTION"),
+        ("*", "ACTION"),
+        ("_", "ACTION"),
+        ("__", "ACTION"),
+    ],
+)
+def test_markdown_semantic_class(token: str, expected: str) -> None:
+    assert semantic_class_for_domain(token, "markdown") == expected
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C token classification
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        # Control flow → ACTION
+        ("if", "ACTION"),
+        ("else", "ACTION"),
+        ("for", "ACTION"),
+        ("while", "ACTION"),
+        ("return", "ACTION"),
+        ("break", "ACTION"),
+        ("continue", "ACTION"),
+        ("switch", "ACTION"),
+        # Structure keywords
+        ("struct", "STRUCTURE"),
+        ("union", "STRUCTURE"),
+        ("enum", "STRUCTURE"),
+        ("typedef", "STRUCTURE"),
+        # Relation operators
+        ("->", "RELATION"),
+        (".", "RELATION"),
+        ("&", "RELATION"),
+        # Inert / null-like
+        ("void", "INERT_WITNESS"),
+        ("NULL", "INERT_WITNESS"),
+        ("nullptr", "INERT_WITNESS"),
+    ],
+)
+def test_c_semantic_class(token: str, expected: str) -> None:
+    assert semantic_class_for_domain(token, "c") == expected
+
+
+def test_c_keywords_case_insensitive() -> None:
+    assert semantic_class_for_domain("IF", "c") == "ACTION"
+    assert semantic_class_for_domain("STRUCT", "c") == "STRUCTURE"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C++ token classification
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        # Inherits C control flow
+        ("if", "ACTION"),
+        ("for", "ACTION"),
+        ("return", "ACTION"),
+        # C++ action additions
+        ("new", "ACTION"),
+        ("delete", "ACTION"),
+        ("throw", "ACTION"),
+        ("try", "ACTION"),
+        ("catch", "ACTION"),
+        # Structure
+        ("struct", "STRUCTURE"),
+        ("class", "STRUCTURE"),
+        ("template", "STRUCTURE"),
+        ("namespace", "STRUCTURE"),
+        # Relation operators
+        ("->", "RELATION"),
+        ("::", "RELATION"),
+        # Inert
+        ("void", "INERT_WITNESS"),
+    ],
+)
+def test_cpp_semantic_class(token: str, expected: str) -> None:
+    assert semantic_class_for_domain(token, "cpp") == expected
+
+
+def test_cpp_also_accepts_cxx_alias() -> None:
+    assert semantic_class_for_domain("class", "c++") == "STRUCTURE"
+    assert semantic_class_for_domain("::", "c++") == "RELATION"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rust token classification
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        # Definitions → ACTION
+        ("fn", "ACTION"),
+        ("impl", "ACTION"),
+        ("mod", "ACTION"),
+        ("pub", "ACTION"),
+        ("use", "ACTION"),
+        ("let", "ACTION"),
+        ("mut", "ACTION"),
+        ("match", "ACTION"),
+        ("async", "ACTION"),
+        ("await", "ACTION"),
+        # Type definitions → STRUCTURE
+        ("struct", "STRUCTURE"),
+        ("enum", "STRUCTURE"),
+        ("trait", "STRUCTURE"),
+        ("type", "STRUCTURE"),
+        ("union", "STRUCTURE"),
+        # Ownership / borrow operators → RELATION
+        ("&", "RELATION"),
+        ("->", "RELATION"),
+        ("::", "RELATION"),
+        (".", "RELATION"),
+        ("=>", "RELATION"),
+        ("?", "RELATION"),
+        # Null-like → INERT_WITNESS
+        ("None", "INERT_WITNESS"),
+        ("false", "INERT_WITNESS"),
+        ("true", "INERT_WITNESS"),
+    ],
+)
+def test_rust_semantic_class(token: str, expected: str) -> None:
+    assert semantic_class_for_domain(token, "rust") == expected
+
+
+def test_rust_none_is_case_sensitive() -> None:
+    """Rust None is title-case; 'none' (lowercase) falls through to generic."""
+    result = semantic_class_for_domain("none", "rust")
+    # lowercase 'none' is not a Rust keyword — generic returns INERT_WITNESS via null-like set
+    assert result == "INERT_WITNESS"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cross-domain invariants
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_struct_is_structure_in_c_cpp_rust() -> None:
+    for lang in ("c", "cpp", "rust"):
+        assert semantic_class_for_domain("struct", lang) == "STRUCTURE", f"failed for {lang}"
+
+
+def test_return_is_action_in_c_cpp_rust() -> None:
+    for lang in ("c", "cpp", "rust"):
+        assert semantic_class_for_domain("return", lang) == "ACTION", f"failed for {lang}"
+
+
+def test_arrow_is_relation_in_c_cpp_rust() -> None:
+    for lang in ("c", "cpp", "rust"):
+        assert semantic_class_for_domain("->", lang) == "RELATION", f"failed for {lang}"
+
+
+def test_unknown_language_falls_back_to_generic() -> None:
+    # Generic _semantic_class handles standard keywords
+    assert semantic_class_for_domain("return", "cobol") == "ACTION"
+    assert semantic_class_for_domain("none", "unknown") == "INERT_WITNESS"
+
+
+def test_html_not_affected_by_c_keywords() -> None:
+    # 'class' in HTML is a RELATION attribute, not STRUCTURE (no cpp logic)
+    assert semantic_class_for_domain("class", "html") == "RELATION"


### PR DESCRIPTION
## Summary
- add Deploy Condition Packet schema for sealed agentic task envelopes
- add watcher receipts, fullness stages, tool trust downgrade, completion gates, recovery routes, and Tekken-style tool combo validation
- expand domain tokenizer language/tongue routing and semantic class coverage
- add Python DCP/domain tokenizer tests and TS/Python NSM parity coverage

## Verification
- python -m pytest tests\\agentic\\test_dcp.py tests\\tokenizer\\test_domain_tokenizer.py -q
- npx vitest run tests/cross-language/nsm-primes-parity.test.ts
- python -m black --check --target-version py311 --line-length 120 src\\agentic\\dcp.py tests\\agentic\\test_dcp.py src\\tokenizer\\code_weight_packets.py tests\\tokenizer\\test_domain_tokenizer.py
- python -m ruff check src\\agentic\\dcp.py tests\\agentic\\test_dcp.py src\\tokenizer\\code_weight_packets.py tests\\tokenizer\\test_domain_tokenizer.py
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Deploy Condition Packet system for orchestrating complex execution workflows with built-in validation, task gating, and recovery mechanisms.
  * Enhanced semantic token classification with domain-specific support across multiple programming languages (Python, JavaScript, C++, Rust, HTML, Markdown, and more).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->