### PR TITLE
feat(agentic): add DCP GitHub Copilot Tetris route

### DIFF
--- a/docs/ops/DCP_GITHUB_COPILOT_ROUTE.md
+++ b/docs/ops/DCP_GITHUB_COPILOT_ROUTE.md
@@ -1,0 +1,209 @@
+# DCP GitHub + Copilot Route
+
+Status: operating route.
+Last updated: 2026-05-23.
+
+This route turns "fix it and push it" into a Deploy Condition Packet (DCP). The DCP is the sealed envelope: tools are scoped, secrets stay local, completion gates are explicit, and the watcher receipt is written before dispatch.
+
+Copilot is allowed as a proposer/explainer. It is not allowed to decide completion.
+
+## Route Spine
+
+```text
+human goal
+  -> DCP envelope
+  -> proposed operation pieces
+  -> Tetris-tree route lock
+  -> local patch / command execution
+  -> diff/lint/test gate pieces
+  -> GitHub PR piece
+  -> CI watcher receipt piece
+  -> merge verification piece
+  -> sync main
+  -> prune branch
+```
+
+The important line: external tools can propose, SCBE verifies.
+
+## Tetris-Tree Operation
+
+The route is not "do every suggested command in order." Models and tools propose pieces. The system decides whether each piece locks into a route slot.
+
+```text
+piece proposed: Copilot suggests a shell command
+slot available: candidate-proposal slot
+lock checks: lane match + required artifacts + tool trust + risk capacity + geometry fit
+result: locked piece can advance; loose piece is discarded or sent to triage
+```
+
+The default PR tree has four slots:
+
+| Slot | Accepted piece lane | Required state | Output |
+| --- | --- | --- | --- |
+| `inspect` | `inspect` | clean root intent | `repo_state` |
+| `propose` | `propose` | `repo_state` | `candidate_patch` |
+| `verify` | `verify` | `candidate_patch` | `local_gate_report` |
+| `publish` | `publish` | `local_gate_report` | `pr_number`, `watcher_receipt` |
+
+The lock is geometric but mechanical: each piece and slot carries `(context_fit, verification_fit, safety_fit)`. The score also includes risk capacity and lane compatibility. A proposal that sounds good but does not fit the slot does not execute.
+
+This is the difference between chat and an operating system:
+
+- chat gives you pieces,
+- DCP defines the board,
+- Tetris-tree routing decides lock-in,
+- completion gates decide whether the locked route actually worked.
+
+## Approved Tool Roles
+
+| Tool | Role | Scope | Completion authority |
+| --- | --- | --- | --- |
+| `git` | branch, diff, commit, sync, prune | allowed | no |
+| `gh` | PRs, issues, workflow runs, CI logs | allowed | no |
+| GitHub MCP | issue/PR/repo API route through Codex | restricted | no |
+| Copilot CLI | suggest commands, explain failures, propose candidate patches | restricted | no |
+| shell | run local gates and repo scripts | restricted | no |
+| DCP gates | decide whether the route can advance | deterministic | yes |
+
+Secrets that must stay local:
+
+- `CODEX_GITHUB_PERSONAL_ACCESS_TOKEN`
+- `.env`
+- `config/connector_oauth/.env.connector.oauth`
+- `.home/.codex`
+
+Do not paste secrets into Copilot prompts, issue bodies, PR bodies, or logs.
+
+## PowerShell Commands
+
+Start from a clean root:
+
+```powershell
+git status --short --branch
+git fetch origin --prune
+git switch main
+git reset --hard refs/remotes/origin/main
+```
+
+Create a branch:
+
+```powershell
+git switch -c feat/example-dcp-route
+```
+
+Optional Copilot proposer route:
+
+```powershell
+gh extension list
+gh extension install github/gh-copilot
+gh copilot suggest "fix the failing lint with the smallest safe patch" --target shell
+gh copilot explain "the pytest failure output or GitHub Actions failure snippet"
+```
+
+The Copilot output is only a candidate. Apply only the part that survives review.
+
+Run local gates:
+
+```powershell
+git diff --check HEAD
+npm run lint
+python -m pytest tests\agentic\test_dcp.py tests\agentic\test_dcp_routes.py -q
+npx vitest run tests/cross-language/nsm-primes-parity.test.ts
+```
+
+Commit and push:
+
+```powershell
+git add src\agentic\dcp_routes.py tests\agentic\test_dcp_routes.py docs\ops\DCP_GITHUB_COPILOT_ROUTE.md
+git commit -m "feat(agentic): add DCP GitHub Copilot route"
+git push -u origin feat/example-dcp-route
+```
+
+Open a PR:
+
+```powershell
+gh pr create --head feat/example-dcp-route --base main --title "feat(agentic): add DCP GitHub Copilot route" --body-file .scbe\ops\pr_body.md
+```
+
+Stamp/watch the downstream state:
+
+```powershell
+gh pr view --json number,url,state,statusCheckRollup,mergeCommit
+gh run view <run-id> --json status,conclusion,url,jobs
+gh run watch <run-id> --interval 10
+```
+
+If a check fails:
+
+```powershell
+gh run view <run-id> --log
+gh pr checks <pr-number>
+```
+
+After merge and late checks are green:
+
+```powershell
+git fetch origin --prune
+git switch main
+git reset --hard refs/remotes/origin/main
+git branch -d feat/example-dcp-route
+git push origin --delete feat/example-dcp-route
+git status --short --branch
+```
+
+## Python Route Builder
+
+The executable route factories live in `src/agentic/dcp_routes.py`.
+
+Example:
+
+```python
+from src.agentic.dcp_routes import create_github_pr_dcp
+
+dcp = create_github_pr_dcp(
+    intent="fix CI and ship a clean PR",
+    branch="fix/ci-route",
+    title="fix(ci): route cleanup",
+    test_commands=[
+        "python -m pytest tests/agentic/test_dcp.py tests/agentic/test_dcp_routes.py -q",
+        "npm run lint",
+    ],
+)
+
+print(dcp.watcher_receipt.watch_command)
+```
+
+Tetris-tree route example:
+
+```python
+from src.agentic.dcp_routes import (
+    TETRIS_TREE_PR_PIECES,
+    TETRIS_TREE_PR_SLOTS,
+    approved_agentic_tools,
+    route_tetris_tree,
+)
+
+decisions = route_tetris_tree(
+    TETRIS_TREE_PR_PIECES,
+    TETRIS_TREE_PR_SLOTS,
+    approved_agentic_tools(include_copilot=True),
+)
+
+assert all(decision.locked for decision in decisions)
+```
+
+## Completion Rule
+
+A task is not complete at commit, push, PR creation, or auto-merge.
+
+It is complete only when:
+
+1. local gates pass,
+2. PR exists with evidence,
+3. GitHub checks finish green,
+4. merged commit is visible on `origin/main`,
+5. local `main` is synced,
+6. feature branch is pruned,
+7. final local smoke still passes.
+
+That is operation fullness. Anything earlier is a stage, not completion.

--- a/src/agentic/__init__.py
+++ b/src/agentic/__init__.py
@@ -12,3 +12,13 @@ from .meet_in_the_middle import (  # noqa: F401
     SeamContract,
     merge_halves,
 )
+from .dcp_routes import (  # noqa: F401
+    GITHUB_COPILOT_PR_COMBO,
+    TETRIS_TREE_PR_PIECES,
+    TETRIS_TREE_PR_SLOTS,
+    approved_agentic_tools,
+    copilot_command_route,
+    create_github_pr_dcp,
+    github_command_route,
+    route_tetris_tree,
+)

--- a/src/agentic/dcp_routes.py
+++ b/src/agentic/dcp_routes.py
@@ -1,0 +1,672 @@
+"""Deploy Condition Packet routes for GitHub and Copilot-assisted work.
+
+These helpers turn common agentic operations into sealed DCPs with:
+- approved tool sources,
+- exact shell/GitHub commands,
+- completion gates,
+- watcher receipts written before dispatch,
+- Copilot as a proposer route, never as the completion judge.
+"""
+
+from __future__ import annotations
+
+import shlex
+import math
+from dataclasses import dataclass, field
+
+from .dcp import (
+    CompletionGate,
+    ComputeTarget,
+    ContextPolicy,
+    DeployConditionPacket,
+    DeployTarget,
+    DeployTargetKind,
+    FailureSemantics,
+    FullnessStage,
+    GoalSpec,
+    KnownFailure,
+    ProcessingSpace,
+    PushPullRules,
+    RecoveryRoute,
+    RepoState,
+    SecretsBoundary,
+    StorageState,
+    ToolCombo,
+    ToolEntry,
+    ToolMove,
+    ToolScope,
+    TrustLevel,
+    TrustState,
+    create_dcp,
+)
+
+DEFAULT_REPO = "issdandavis/SCBE-AETHERMOORE"
+
+
+@dataclass(frozen=True)
+class CommandRoute:
+    """Human-readable command lane that can be attached to docs or a runner."""
+
+    name: str
+    description: str
+    commands: list[str] = field(default_factory=list)
+    expected_artifacts: list[str] = field(default_factory=list)
+    required_tools: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class OperationPiece:
+    """A proposed operation piece.
+
+    This is the Tetris-tree unit: a model, Copilot, or human can propose the
+    piece, but it does not execute until a route slot locks it into place.
+    geometry_vector is intentionally small and deterministic:
+    (context_fit, verification_fit, safety_fit), each in [0, 1].
+    """
+
+    name: str
+    lane: str
+    command: str
+    tool_name: str
+    requires: list[str] = field(default_factory=list)
+    produces: list[str] = field(default_factory=list)
+    geometry_vector: tuple[float, float, float] = (0.5, 0.5, 0.5)
+    risk_score: float = 0.25
+
+
+@dataclass(frozen=True)
+class RouteSlot:
+    """A route slot where an operation piece can lock."""
+
+    name: str
+    lane: str
+    accepts: list[str] = field(default_factory=list)
+    available: list[str] = field(default_factory=list)
+    geometry_vector: tuple[float, float, float] = (0.5, 0.5, 0.5)
+    risk_capacity: float = 0.5
+
+
+@dataclass(frozen=True)
+class LockDecision:
+    """Deterministic decision for a proposed piece and slot."""
+
+    piece: str
+    slot: str
+    locked: bool
+    score: float
+    reasons: list[str] = field(default_factory=list)
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _geometry_distance(a: tuple[float, float, float], b: tuple[float, float, float]) -> float:
+    return math.sqrt(sum((_clamp01(x) - _clamp01(y)) ** 2 for x, y in zip(a, b, strict=True)))
+
+
+def lock_operation_piece(piece: OperationPiece, slot: RouteSlot, tools: list[ToolEntry]) -> LockDecision:
+    """Decide whether a proposed piece locks into a route slot.
+
+    The lock is deliberately mechanical. It does not ask whether the proposal
+    sounds good; it checks:
+    - lane compatibility,
+    - required artifacts available in the slot,
+    - tool trust/scope,
+    - risk capacity,
+    - geometry fit.
+    """
+
+    reasons: list[str] = []
+    tool = next((entry for entry in tools if entry.name == piece.tool_name), None)
+
+    if slot.accepts and piece.lane not in slot.accepts:
+        reasons.append(f"lane {piece.lane!r} is not accepted by slot {slot.name!r}")
+
+    missing = [requirement for requirement in piece.requires if requirement not in slot.available]
+    if missing:
+        reasons.append(f"missing required artifacts: {missing}")
+
+    if tool is None:
+        reasons.append(f"tool {piece.tool_name!r} is not in the approved bucket")
+    elif tool.trust_state == TrustState.DENY or tool.scope == ToolScope.DENIED:
+        reasons.append(f"tool {piece.tool_name!r} is not allowed to execute")
+
+    if piece.risk_score > slot.risk_capacity:
+        reasons.append(f"risk {piece.risk_score:.3f} exceeds slot capacity {slot.risk_capacity:.3f}")
+
+    distance = _geometry_distance(piece.geometry_vector, slot.geometry_vector)
+    geometry_fit = max(0.0, 1.0 - (distance / math.sqrt(3.0)))
+    risk_fit = 1.0 if slot.risk_capacity <= 0 else max(0.0, 1.0 - (piece.risk_score / slot.risk_capacity))
+    lane_fit = 1.0 if not slot.accepts or piece.lane in slot.accepts else 0.0
+    score = round((0.60 * geometry_fit) + (0.25 * risk_fit) + (0.15 * lane_fit), 6)
+
+    if score < 0.55:
+        reasons.append(f"geometry score {score:.3f} below lock threshold 0.550")
+
+    return LockDecision(piece=piece.name, slot=slot.name, locked=not reasons, score=score, reasons=reasons)
+
+
+def route_tetris_tree(
+    pieces: list[OperationPiece],
+    slots: list[RouteSlot],
+    tools: list[ToolEntry],
+) -> list[LockDecision]:
+    """Greedily lock operation pieces into a route tree.
+
+    Each slot receives the highest-scoring valid piece. Produced artifacts from
+    a locked piece become available to downstream slots.
+    """
+
+    decisions: list[LockDecision] = []
+    remaining = list(pieces)
+    carried_artifacts: set[str] = set()
+
+    for slot in slots:
+        live_slot = RouteSlot(
+            name=slot.name,
+            lane=slot.lane,
+            accepts=slot.accepts,
+            available=[*slot.available, *sorted(carried_artifacts)],
+            geometry_vector=slot.geometry_vector,
+            risk_capacity=slot.risk_capacity,
+        )
+        candidates = [lock_operation_piece(piece, live_slot, tools) for piece in remaining]
+        locked = [candidate for candidate in candidates if candidate.locked]
+        if not locked:
+            decisions.append(
+                LockDecision(
+                    piece="",
+                    slot=slot.name,
+                    locked=False,
+                    score=0.0,
+                    reasons=["no proposed piece fit this slot"],
+                )
+            )
+            continue
+
+        best = max(locked, key=lambda candidate: candidate.score)
+        decisions.append(best)
+        chosen = next(piece for piece in remaining if piece.name == best.piece)
+        carried_artifacts.update(chosen.produces)
+        remaining = [piece for piece in remaining if piece.name != chosen.name]
+
+    return decisions
+
+
+def approved_agentic_tools(*, include_copilot: bool = True) -> list[ToolEntry]:
+    """Return the approved tools for a GitHub PR workcell.
+
+    Copilot is deliberately restricted. It can produce candidate text or a
+    suggested shell command, but its output must go through review, lint, tests,
+    and the GitHub watcher before the DCP can complete.
+    """
+
+    tools = [
+        ToolEntry(
+            name="git",
+            scope=ToolScope.ALLOWED,
+            trust_level=TrustLevel.VERIFIED_PRIMARY,
+            trust_state=TrustState.ALLOW,
+            source_roots=["https://git-scm.com/", "local git executable"],
+            failure_semantics=FailureSemantics(
+                tool_failure="local git command failed or repo state changed",
+                source_contract_failure="git behavior or repository policy changed",
+                source_integrity_failure="signed commit/ref verification should be inspected",
+            ),
+        ),
+        ToolEntry(
+            name="github-cli",
+            scope=ToolScope.ALLOWED,
+            trust_level=TrustLevel.VERIFIED_PRIMARY,
+            trust_state=TrustState.ALLOW,
+            source_roots=["https://cli.github.com/", "https://github.com/cli/cli"],
+            failure_semantics=FailureSemantics(
+                tool_failure="gh CLI auth, network, or local extension failed",
+                source_contract_failure="GitHub API or gh JSON shape changed",
+                source_integrity_failure="GitHub API identity or repo trust boundary should be rechecked",
+            ),
+        ),
+        ToolEntry(
+            name="codex-github-mcp",
+            scope=ToolScope.RESTRICTED,
+            trust_level=TrustLevel.VERIFIED_PRIMARY,
+            trust_state=TrustState.ALLOW,
+            source_roots=[
+                "C:/Users/issda/.codex/config.toml",
+                "CODEX_GITHUB_PERSONAL_ACCESS_TOKEN",
+            ],
+            failure_semantics=FailureSemantics(
+                tool_failure="MCP server failed to start or token env var was not visible",
+                source_contract_failure="GitHub MCP API surface changed",
+                source_integrity_failure="token must be revoked/replaced if exposed outside env storage",
+            ),
+        ),
+        ToolEntry(
+            name="shell",
+            scope=ToolScope.RESTRICTED,
+            trust_level=TrustLevel.VERIFIED_PRIMARY,
+            trust_state=TrustState.ALLOW,
+            source_roots=["Windows PowerShell", "repository package scripts"],
+            failure_semantics=FailureSemantics(
+                tool_failure="command failed in the local shell",
+                source_contract_failure="repo script contract changed",
+                source_integrity_failure="shell output may include secrets and must be scrubbed before push",
+            ),
+        ),
+    ]
+
+    if include_copilot:
+        tools.append(
+            ToolEntry(
+                name="github-copilot",
+                scope=ToolScope.RESTRICTED,
+                trust_level=TrustLevel.VERIFIED_SECONDARY,
+                trust_state=TrustState.ALLOW,
+                source_roots=[
+                    "https://github.com/features/copilot",
+                    "gh extension install github/gh-copilot",
+                ],
+                failure_semantics=FailureSemantics(
+                    tool_failure="Copilot extension unavailable, unauthenticated, or produced unusable output",
+                    source_contract_failure="Copilot CLI command contract changed",
+                    source_integrity_failure="Copilot output is untrusted generated code until SCBE gates pass",
+                ),
+            )
+        )
+
+    return tools
+
+
+def github_command_route(
+    *,
+    branch: str,
+    title: str,
+    repo: str = DEFAULT_REPO,
+    body_file: str = ".scbe/ops/pr_body.md",
+) -> CommandRoute:
+    """Return the exact GitHub commands for branch-to-PR operation."""
+
+    quoted_title = shlex.quote(title)
+    return CommandRoute(
+        name="github_pr_commands",
+        description="Create, push, inspect, watch, merge-check, and clean a GitHub PR.",
+        required_tools=["git", "github-cli"],
+        expected_artifacts=["commit_sha", "remote_ref", "pr_url", "ci_status"],
+        commands=[
+            "git status --short --branch",
+            f"git switch -c {shlex.quote(branch)}",
+            "git diff --check HEAD",
+            "npm run lint",
+            "git add <changed paths>",
+            f"git commit -m {quoted_title}",
+            f"git push -u origin {shlex.quote(branch)}",
+            (
+                f"gh pr create --repo {shlex.quote(repo)} --head {shlex.quote(branch)} "
+                f"--base main --title {quoted_title} --body-file {shlex.quote(body_file)}"
+            ),
+            "gh pr view --json number,url,state,statusCheckRollup,mergeCommit",
+            "gh run watch <run-id> --interval 10",
+            "git fetch origin --prune",
+            "git switch main",
+            "git reset --hard refs/remotes/origin/main",
+            f"git branch -d {shlex.quote(branch)}",
+            f"git push origin --delete {shlex.quote(branch)}",
+        ],
+    )
+
+
+def copilot_command_route(
+    *,
+    prompt: str,
+    target: str = "shell",
+) -> CommandRoute:
+    """Return a governed Copilot route.
+
+    The route intentionally ends with SCBE verification commands. Copilot can
+    suggest commands or explain failures, but it cannot mark work complete.
+    """
+
+    quoted_prompt = shlex.quote(prompt)
+    quoted_target = shlex.quote(target)
+    return CommandRoute(
+        name="copilot_proposer_commands",
+        description="Use GitHub Copilot as a restricted proposer/explainer under SCBE verification.",
+        required_tools=["github-cli", "github-copilot", "shell"],
+        expected_artifacts=["candidate_command_or_patch", "review_notes", "test_evidence"],
+        commands=[
+            "gh extension list",
+            "gh extension install github/gh-copilot",
+            f"gh copilot suggest {quoted_prompt} --target {quoted_target}",
+            f"gh copilot explain {quoted_prompt}",
+            "git diff --check HEAD",
+            "npm run lint",
+            "python -m pytest tests/agentic/test_dcp.py tests/tokenizer/test_domain_tokenizer.py -q",
+        ],
+    )
+
+
+GITHUB_COPILOT_PR_COMBO = ToolCombo(
+    name="github_copilot_pr",
+    description="GitHub PR lane with Copilot as a candidate proposer and SCBE as the judge.",
+    required_tools=["git", "github-cli", "github-copilot", "shell"],
+    moves=[
+        ToolMove(
+            name="inspect_repo",
+            produces=["repo_state", "branch_state"],
+            frame_advantage=["repo_state"],
+            on_success=["optional_copilot_suggest"],
+            timeout_seconds=30,
+        ),
+        ToolMove(
+            name="optional_copilot_suggest",
+            requires=["repo_state"],
+            produces=["candidate_suggestion"],
+            on_success=["apply_patch"],
+            on_fail=["manual_patch"],
+            unsafe_if=["secrets_in_prompt", "copilot_unavailable"],
+            timeout_seconds=120,
+        ),
+        ToolMove(
+            name="apply_patch",
+            requires=["candidate_suggestion"],
+            produces=["working_tree_diff"],
+            on_success=["verify_local"],
+            on_fail=["manual_patch"],
+            timeout_seconds=300,
+        ),
+        ToolMove(
+            name="manual_patch",
+            requires=["repo_state"],
+            produces=["working_tree_diff"],
+            on_success=["verify_local"],
+            timeout_seconds=300,
+        ),
+        ToolMove(
+            name="verify_local",
+            requires=["working_tree_diff"],
+            produces=["local_gate_report"],
+            on_success=["commit_push_pr"],
+            on_fail=["triage_failure"],
+            cancel_condition="unrelated_dirty_tree",
+            timeout_seconds=600,
+            frame_advantage=["local_gate_report"],
+        ),
+        ToolMove(
+            name="commit_push_pr",
+            requires=["local_gate_report"],
+            produces=["pr_number", "watcher_receipt"],
+            on_success=["watch_ci"],
+            unsafe_if=["required_gate_failed", "secrets_in_diff"],
+            timeout_seconds=180,
+            frame_advantage=["watcher_receipt"],
+        ),
+        ToolMove(
+            name="watch_ci",
+            requires=["watcher_receipt"],
+            produces=["ci_status"],
+            on_success=["sync_and_prune"],
+            on_fail=["fetch_failed_job_log"],
+            timeout_seconds=1800,
+        ),
+    ],
+)
+
+
+TETRIS_TREE_PR_SLOTS = [
+    RouteSlot(
+        name="inspect",
+        lane="root",
+        accepts=["inspect"],
+        available=[],
+        geometry_vector=(0.90, 0.65, 0.80),
+        risk_capacity=0.20,
+    ),
+    RouteSlot(
+        name="propose",
+        lane="candidate",
+        accepts=["propose"],
+        available=["repo_state"],
+        geometry_vector=(0.75, 0.55, 0.55),
+        risk_capacity=0.45,
+    ),
+    RouteSlot(
+        name="verify",
+        lane="gate",
+        accepts=["verify"],
+        available=["repo_state", "candidate_patch"],
+        geometry_vector=(0.80, 0.95, 0.90),
+        risk_capacity=0.25,
+    ),
+    RouteSlot(
+        name="publish",
+        lane="github",
+        accepts=["publish"],
+        available=["repo_state", "candidate_patch", "local_gate_report"],
+        geometry_vector=(0.60, 0.85, 0.85),
+        risk_capacity=0.30,
+    ),
+]
+
+
+TETRIS_TREE_PR_PIECES = [
+    OperationPiece(
+        name="git_status_piece",
+        lane="inspect",
+        command="git status --short --branch",
+        tool_name="git",
+        produces=["repo_state"],
+        geometry_vector=(0.92, 0.60, 0.82),
+        risk_score=0.05,
+    ),
+    OperationPiece(
+        name="copilot_candidate_piece",
+        lane="propose",
+        command='gh copilot suggest "propose the smallest safe patch" --target shell',
+        tool_name="github-copilot",
+        requires=["repo_state"],
+        produces=["candidate_patch"],
+        geometry_vector=(0.72, 0.55, 0.50),
+        risk_score=0.35,
+    ),
+    OperationPiece(
+        name="local_gate_piece",
+        lane="verify",
+        command="git diff --check HEAD && npm run lint",
+        tool_name="shell",
+        requires=["candidate_patch"],
+        produces=["local_gate_report"],
+        geometry_vector=(0.78, 0.97, 0.88),
+        risk_score=0.10,
+    ),
+    OperationPiece(
+        name="github_pr_piece",
+        lane="publish",
+        command="gh pr create --head <branch> --base main --title <title> --body-file .scbe/ops/pr_body.md",
+        tool_name="github-cli",
+        requires=["local_gate_report"],
+        produces=["pr_number", "watcher_receipt"],
+        geometry_vector=(0.62, 0.84, 0.88),
+        risk_score=0.20,
+    ),
+]
+
+
+def create_github_pr_dcp(
+    *,
+    intent: str,
+    branch: str,
+    title: str,
+    test_commands: list[str],
+    repo: str = DEFAULT_REPO,
+    include_copilot: bool = True,
+) -> DeployConditionPacket:
+    """Create a DCP for a governed GitHub issue/PR task."""
+
+    dcp = create_dcp(
+        intent,
+        GoalSpec(
+            description="Branch pushed, PR opened, local gates pass, CI reaches green, and local main is resynced.",
+            success_evidence=[
+                "git diff --check HEAD",
+                "npm run lint",
+                *test_commands,
+                "gh pr view --json state,statusCheckRollup,mergeCommit",
+            ],
+            failure_modes=[
+                "dirty unrelated files before patch",
+                "Copilot unavailable or produces invalid suggestion",
+                "lint or format failure",
+                "targeted test failure",
+                "CI check failure after merge",
+            ],
+        ),
+    )
+    dcp.known_failures = [
+        KnownFailure(
+            id="copilot-not-judge",
+            description="Copilot output can be useful but is not trusted until deterministic gates pass.",
+            affected_files=["generated patch", "shell command suggestion"],
+            workaround="treat Copilot as a proposer; run SCBE gates and inspect diff before push",
+        ),
+        KnownFailure(
+            id="late-ci-after-merge",
+            description="Some GitHub checks complete after auto-merge; completion requires late status polling.",
+            workaround="watch PR statusCheckRollup after merge, then sync main and prune only when green",
+        ),
+    ]
+    dcp.tools = approved_agentic_tools(include_copilot=include_copilot)
+    dcp.processing_space = ProcessingSpace(
+        compute=ComputeTarget.LOCAL,
+        constraints=[
+            "do not expose secrets to Copilot prompts",
+            "do not push generated caches",
+            "do not let external proposers decide completion",
+        ],
+    )
+    dcp.storage_state = StorageState(
+        repo_state=RepoState.CLEAN,
+        branch=branch,
+        has_uncommitted_changes=False,
+        secrets_boundary=SecretsBoundary.LOCAL_ONLY,
+        artifact_paths=[".scbe/ops/", "artifacts/"],
+    )
+    dcp.context_policy = ContextPolicy(
+        active_keys=["intent", "goal", "branch", "completion_gates", "watcher_receipt"],
+        compactable=["old terminal output", "prior failed candidate patches"],
+        pull_on_demand=["full CI logs", "GitHub PR status", "CodeRabbit status", "Vercel status"],
+    )
+    dcp.deploy_target = DeployTarget(kind=DeployTargetKind.PR, branch=branch, push_url=f"https://github.com/{repo}")
+    dcp.push_pull_rules = PushPullRules(
+        can_push=["source changes", "tests", "docs", "workflow fixes", "DCP receipts"],
+        must_stay_local=[
+            "CODEX_GITHUB_PERSONAL_ACCESS_TOKEN",
+            ".env",
+            "config/connector_oauth/.env.connector.oauth",
+            ".home/.codex",
+        ],
+        evidence_to_pull=["statusCheckRollup", "failed job logs", "merge commit", "local smoke output"],
+    )
+
+    dcp.completion_gates = [
+        CompletionGate(
+            id="diff_check",
+            description="No trailing whitespace or conflict markers in staged diff",
+            command="git diff --check HEAD",
+            timeout_seconds=30,
+        ),
+        CompletionGate(
+            id="lint",
+            description="TypeScript formatting/lint check passes",
+            command="npm run lint",
+            timeout_seconds=180,
+        ),
+        *[
+            CompletionGate(
+                id=f"test_{index + 1}",
+                description=f"Targeted test command {index + 1} passes",
+                command=command,
+                timeout_seconds=600,
+            )
+            for index, command in enumerate(test_commands)
+        ],
+        CompletionGate(
+            id="github_pr_green",
+            description="GitHub PR has no failed required checks",
+            command=f"gh pr view --repo {repo} --json state,statusCheckRollup,mergeCommit,url",
+            timeout_seconds=120,
+        ),
+    ]
+    dcp.recovery_routes = [
+        RecoveryRoute(
+            on_gate_id="diff_check", action="normalize line endings or remove conflict markers", max_retries=2
+        ),
+        RecoveryRoute(on_gate_id="lint", action="run formatter/linter, inspect diff, rerun lint", max_retries=2),
+        RecoveryRoute(
+            on_gate_id="github_pr_green", action="fetch failed job log with gh run view --log", max_retries=3
+        ),
+    ]
+    dcp.stamp_watcher_receipt(
+        operation_type="github_pr",
+        watch_command=f"gh pr view --repo {repo} --json state,statusCheckRollup,mergeCommit,url",
+        on_success="sync_main_and_prune_branch",
+        on_failure="fetch_failed_job_log_and_downgrade_failed_tool",
+        poll_interval_seconds=45,
+        max_wait_minutes=30,
+    )
+    dcp.advance_fullness(FullnessStage.LOCAL_CHANGE)
+    return dcp
+
+
+def route_packet_for_docs(
+    *,
+    branch: str = "feat/example-dcp-route",
+    title: str = "feat(agentic): example governed GitHub route",
+    repo: str = DEFAULT_REPO,
+) -> dict[str, object]:
+    """Build a compact docs-friendly packet with DCP plus command routes."""
+
+    dcp = create_github_pr_dcp(
+        intent="ship a governed GitHub PR through SCBE DCP gates",
+        branch=branch,
+        title=title,
+        repo=repo,
+        test_commands=[
+            "python -m pytest tests/agentic/test_dcp.py tests/agentic/test_dcp_routes.py -q",
+            "npx vitest run tests/cross-language/nsm-primes-parity.test.ts",
+        ],
+    )
+    return {
+        "dcp": dcp.to_dict(),
+        "github": github_command_route(branch=branch, title=title, repo=repo).__dict__,
+        "copilot": copilot_command_route(
+            prompt="Explain the failing lint/test output and propose a minimal patch"
+        ).__dict__,
+        "tetris_tree": [
+            decision.__dict__
+            for decision in route_tetris_tree(
+                TETRIS_TREE_PR_PIECES,
+                TETRIS_TREE_PR_SLOTS,
+                approved_agentic_tools(include_copilot=True),
+            )
+        ],
+    }
+
+
+__all__ = [
+    "CommandRoute",
+    "DEFAULT_REPO",
+    "GITHUB_COPILOT_PR_COMBO",
+    "LockDecision",
+    "OperationPiece",
+    "RouteSlot",
+    "TETRIS_TREE_PR_PIECES",
+    "TETRIS_TREE_PR_SLOTS",
+    "approved_agentic_tools",
+    "copilot_command_route",
+    "create_github_pr_dcp",
+    "github_command_route",
+    "lock_operation_piece",
+    "route_packet_for_docs",
+    "route_tetris_tree",
+]

--- a/tests/agentic/test_dcp_routes.py
+++ b/tests/agentic/test_dcp_routes.py
@@ -1,0 +1,183 @@
+"""Tests for governed GitHub/Copilot DCP routes."""
+
+from src.agentic.dcp import DeployTargetKind, GateResult, TrustLevel, TrustState, validate_dcp
+from src.agentic.dcp_routes import (
+    GITHUB_COPILOT_PR_COMBO,
+    OperationPiece,
+    RouteSlot,
+    TETRIS_TREE_PR_PIECES,
+    TETRIS_TREE_PR_SLOTS,
+    approved_agentic_tools,
+    copilot_command_route,
+    create_github_pr_dcp,
+    github_command_route,
+    lock_operation_piece,
+    route_packet_for_docs,
+    route_tetris_tree,
+)
+
+
+def test_approved_tools_include_github_mcp_and_restricted_copilot():
+    tools = {tool.name: tool for tool in approved_agentic_tools(include_copilot=True)}
+
+    assert "github-cli" in tools
+    assert "codex-github-mcp" in tools
+    assert "github-copilot" in tools
+    assert tools["github-copilot"].trust_level == TrustLevel.VERIFIED_SECONDARY
+    assert tools["github-copilot"].trust_state == TrustState.ALLOW
+    assert tools["github-copilot"].scope.value == "restricted"
+    assert any("gh-copilot" in source for source in tools["github-copilot"].source_roots)
+
+
+def test_copilot_can_be_excluded_for_no_external_ai_routes():
+    tool_names = {tool.name for tool in approved_agentic_tools(include_copilot=False)}
+    assert "github-copilot" not in tool_names
+    assert "github-cli" in tool_names
+
+
+def test_github_command_route_contains_push_pr_watch_and_cleanup_commands():
+    route = github_command_route(branch="feat/test-route", title="feat(agentic): test route")
+    joined = "\n".join(route.commands)
+
+    assert "git switch -c feat/test-route" in joined
+    assert "git push -u origin feat/test-route" in joined
+    assert "gh pr create" in joined
+    assert "gh pr view --json number,url,state,statusCheckRollup,mergeCommit" in joined
+    assert "git push origin --delete feat/test-route" in joined
+
+
+def test_copilot_command_route_keeps_scbe_verification_after_suggestion():
+    route = copilot_command_route(prompt="fix the failing lint")
+    joined = "\n".join(route.commands)
+
+    assert "gh extension install github/gh-copilot" in joined
+    assert "gh copilot suggest" in joined
+    assert "git diff --check HEAD" in joined
+    assert "npm run lint" in joined
+    assert "python -m pytest tests/agentic/test_dcp.py" in joined
+
+
+def test_github_copilot_combo_validates():
+    assert GITHUB_COPILOT_PR_COMBO.validate_chain() == []
+
+
+def test_create_github_pr_dcp_has_watcher_before_dispatch_and_validates():
+    dcp = create_github_pr_dcp(
+        intent="fix a failing CI lane",
+        branch="fix/example",
+        title="fix(ci): example",
+        test_commands=["python -m pytest tests/agentic/test_dcp_routes.py -q"],
+    )
+
+    assert validate_dcp(dcp) == []
+    assert dcp.deploy_target.kind == DeployTargetKind.PR
+    assert dcp.deploy_target.branch == "fix/example"
+    assert dcp.watcher_receipt is not None
+    assert dcp.watcher_receipt.operation_type == "github_pr"
+    assert "statusCheckRollup" in dcp.watcher_receipt.watch_command
+    assert dcp.is_complete() is False
+    assert all(gate.result == GateResult.PENDING for gate in dcp.completion_gates)
+
+
+def test_create_github_pr_dcp_marks_secrets_local_only():
+    dcp = create_github_pr_dcp(
+        intent="route with secrets protected",
+        branch="feat/secrets-protected",
+        title="feat(agentic): protect secrets",
+        test_commands=[],
+    )
+
+    assert "CODEX_GITHUB_PERSONAL_ACCESS_TOKEN" in dcp.push_pull_rules.must_stay_local
+    assert "config/connector_oauth/.env.connector.oauth" in dcp.push_pull_rules.must_stay_local
+    assert any(tool.name == "codex-github-mcp" for tool in dcp.tools)
+
+
+def test_route_packet_for_docs_is_serializable_and_contains_commands():
+    packet = route_packet_for_docs(branch="feat/doc-route", title="feat(agentic): doc route")
+
+    assert packet["dcp"]["deploy_target"]["kind"] == "pr"
+    assert packet["github"]["name"] == "github_pr_commands"
+    assert packet["copilot"]["name"] == "copilot_proposer_commands"
+    assert any("gh pr create" in command for command in packet["github"]["commands"])
+    assert all(decision["locked"] for decision in packet["tetris_tree"])
+
+
+def test_lock_operation_piece_accepts_matching_geometry_and_tool():
+    piece = OperationPiece(
+        name="lint_piece",
+        lane="verify",
+        command="npm run lint",
+        tool_name="shell",
+        requires=["patch"],
+        produces=["lint_report"],
+        geometry_vector=(0.8, 0.9, 0.9),
+        risk_score=0.1,
+    )
+    slot = RouteSlot(
+        name="verify_slot",
+        lane="gate",
+        accepts=["verify"],
+        available=["patch"],
+        geometry_vector=(0.8, 0.95, 0.9),
+        risk_capacity=0.25,
+    )
+
+    decision = lock_operation_piece(piece, slot, approved_agentic_tools())
+
+    assert decision.locked is True
+    assert decision.score >= 0.55
+    assert decision.reasons == []
+
+
+def test_lock_operation_piece_rejects_missing_artifacts_and_unapproved_tool():
+    piece = OperationPiece(
+        name="unsafe_piece",
+        lane="publish",
+        command="deploy everything",
+        tool_name="unknown-tool",
+        requires=["green_ci"],
+        risk_score=0.9,
+    )
+    slot = RouteSlot(
+        name="publish_slot",
+        lane="github",
+        accepts=["publish"],
+        available=[],
+        risk_capacity=0.25,
+    )
+
+    decision = lock_operation_piece(piece, slot, approved_agentic_tools())
+
+    assert decision.locked is False
+    assert any("missing required artifacts" in reason for reason in decision.reasons)
+    assert any("not in the approved bucket" in reason for reason in decision.reasons)
+    assert any("exceeds slot capacity" in reason for reason in decision.reasons)
+
+
+def test_tetris_tree_route_locks_default_pr_sequence_in_order():
+    decisions = route_tetris_tree(
+        TETRIS_TREE_PR_PIECES,
+        TETRIS_TREE_PR_SLOTS,
+        approved_agentic_tools(include_copilot=True),
+    )
+
+    assert [decision.slot for decision in decisions] == ["inspect", "propose", "verify", "publish"]
+    assert [decision.piece for decision in decisions] == [
+        "git_status_piece",
+        "copilot_candidate_piece",
+        "local_gate_piece",
+        "github_pr_piece",
+    ]
+    assert all(decision.locked for decision in decisions)
+
+
+def test_tetris_tree_rejects_copilot_piece_when_copilot_not_in_bucket():
+    decisions = route_tetris_tree(
+        TETRIS_TREE_PR_PIECES,
+        TETRIS_TREE_PR_SLOTS,
+        approved_agentic_tools(include_copilot=False),
+    )
+
+    propose = next(decision for decision in decisions if decision.slot == "propose")
+    assert propose.locked is False
+    assert propose.piece == ""


### PR DESCRIPTION
## Summary
- add a DCP route layer for governed GitHub PR work
- include explicit GitHub CLI commands and a restricted Copilot proposer route
- add Tetris-tree operation routing: proposed pieces only execute when lane, artifacts, tool trust, risk capacity, and geometry fit lock into a route slot
- document PowerShell GitHub/Copilot commands and operation-fullness completion rules

## Test Evidence
- python -m pytest tests\\agentic\\test_dcp.py tests\\agentic\\test_dcp_routes.py -q
- python -m black --check --target-version py311 --line-length 120 src\\agentic\\__init__.py src\\agentic\\dcp_routes.py tests\\agentic\\test_dcp_routes.py
- python -m ruff check src\\agentic\\__init__.py src\\agentic\\dcp_routes.py tests\\agentic\\test_dcp_routes.py
- npx vitest run tests/cross-language/nsm-primes-parity.test.ts
- npm run lint
- git diff --check HEAD

## Notes
- Copilot is treated as a proposer/explainer, not a completion judge.
- DCP gates and watcher receipts decide operation fullness.
- Existing local modification in packages/agent-bus/src/index.ts was not touched by this PR.

## Rollback
Revert this PR to remove the route factories/docs/tests; DCP core remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added operational documentation for the DCP GitHub + Copilot Route workflow, including initialization, branch management, local testing, PR creation, CI tracking, secret management, and branch cleanup guidance.

* **New Features**
  * Introduced agentic module enhancements for GitHub PR workflows with artifact management, tool approval controls, geometric routing, and deterministic completion gates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->