### PR TITLE
feat(geoseal): concurrent multi-LLM verification harness (NVIDIA + Ollama + 8 providers)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,9 @@ src/governance/ @issdandavis
 # Agents
 agents/ @issdandavis
 
+# Packages
+packages/agent-bus/** @issdandavis
+
 # Package config
 package.json @issdandavis
 tsconfig.json @issdandavis

--- a/.github/workflows/agent-bus-auto-format.yml
+++ b/.github/workflows/agent-bus-auto-format.yml
@@ -1,0 +1,39 @@
+name: agent-bus · Auto-format PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths: ["packages/agent-bus/**"]
+  workflow_dispatch: {}
+
+defaults:
+  run:
+    working-directory: packages/agent-bus
+
+jobs:
+  auto-format:
+    if: ${{ github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+      - name: Run Prettier
+        run: npm run format
+      - name: Commit and push if changed
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "chore(format): apply Prettier formatting [agent-bus]"
+            git push
+          else
+            echo "No formatting changes"
+          fi

--- a/.github/workflows/agent-bus-format-check.yml
+++ b/.github/workflows/agent-bus-format-check.yml
@@ -1,0 +1,28 @@
+name: agent-bus · Format Check
+
+on:
+  pull_request:
+    branches: ["main", "master", "dev"]
+    paths: ["packages/agent-bus/**"]
+  push:
+    branches: ["main", "master", "dev"]
+    paths: ["packages/agent-bus/**"]
+
+defaults:
+  run:
+    working-directory: packages/agent-bus
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: packages/agent-bus/package-lock.json
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+      - name: Prettier check
+        run: npm run format:check

--- a/.github/workflows/agent-bus-lint-and-test.yml
+++ b/.github/workflows/agent-bus-lint-and-test.yml
@@ -1,0 +1,30 @@
+name: agent-bus · Lint and Test
+
+on:
+  push:
+    branches: ["main", "master", "dev"]
+    paths: ["packages/agent-bus/**"]
+  pull_request:
+    branches: ["main", "master", "dev"]
+    paths: ["packages/agent-bus/**"]
+
+defaults:
+  run:
+    working-directory: packages/agent-bus
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: packages/agent-bus/package-lock.json
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+      - name: Prettier check
+        run: npm run format:check
+      - name: Run tests
+        run: npm test

--- a/packages/agent-bus/.husky/pre-commit
+++ b/packages/agent-bus/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+cd packages/agent-bus && ./node_modules/.bin/lint-staged

--- a/packages/agent-bus/docs/BRANCH_PROTECTION.md
+++ b/packages/agent-bus/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,10 @@
+Branch protection recommendations for packages/agent-bus
+
+- Protect branches: main, master, dev
+- Require status checks: `Lint and Test`, `Format Check`
+- Require pull request reviews (1 or 2 reviewers)
+- Enforce CODEOWNERS
+- Require branches to be up-to-date before merging
+- Restrict who can push to protected branches
+
+Apply via repository Settings -> Branches -> Add rule.

--- a/packages/agent-bus/package-lock.json
+++ b/packages/agent-bus/package-lock.json
@@ -1,0 +1,1343 @@
+{
+  "name": "scbe-agent-bus",
+  "version": "0.3.10",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scbe-agent-bus",
+      "version": "0.3.10",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "zod": "^4.0.0"
+      },
+      "bin": {
+        "scbe-agent-bus": "bin/scbe-agent-bus.cjs"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^6.0.2",
+        "vitest": "^4.0.17"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/agent-bus/package-lock.json
+++ b/packages/agent-bus/package-lock.json
@@ -16,6 +16,9 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "husky": "^8.0.0",
+        "lint-staged": "^14.0.0",
+        "prettier": "^3.2.0",
         "typescript": "^6.0.2",
         "vitest": "^4.0.17"
       },
@@ -541,6 +544,48 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -549,6 +594,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/chai": {
@@ -561,12 +619,108 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
+      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -577,6 +731,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
@@ -593,6 +761,37 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/expect-type": {
@@ -623,6 +822,19 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -637,6 +849,88 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -911,6 +1205,100 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-14.0.1.tgz",
+      "integrity": "sha512-Mw0cL6HXnHN1ag0mN/Dg4g6sr8uf8sn98w2Oc1ECtFto9tvRF7nkXGJRbx8gPlHyoR0pLyBr2lQHbWwmUHe1Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.3.0",
+        "commander": "11.0.0",
+        "debug": "4.3.4",
+        "execa": "7.2.0",
+        "lilconfig": "2.1.0",
+        "listr2": "6.6.1",
+        "micromatch": "4.0.5",
+        "pidtree": "0.6.0",
+        "string-argv": "0.3.2",
+        "yaml": "2.3.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-6.6.1.tgz",
+      "integrity": "sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^3.1.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^5.0.1",
+        "rfdc": "^1.3.0",
+        "wrap-ansi": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/log-update": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
+      "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "slice-ansi": "^5.0.0",
+        "strip-ansi": "^7.0.1",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -920,6 +1308,60 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -940,6 +1382,35 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -950,6 +1421,32 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -976,6 +1473,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/postcss": {
@@ -1006,6 +1516,72 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.2",
@@ -1041,12 +1617,59 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1071,6 +1694,63 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1116,6 +1796,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1123,6 +1816,19 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -1313,6 +2019,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1328,6 +2050,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/zod": {

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -28,7 +28,7 @@
     "pack:dry": "npm pack --dry-run --json",
     "prepublishOnly": "npm run build",
     "prepack": "npm run build",
-    "prepare": "husky install"
+    "prepare": "cd ../.. && husky install packages/agent-bus/.husky"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -20,10 +20,15 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "prettier --check .",
     "agentbus:pipe": "node ../../scripts/system/agentbus_pipe.mjs",
     "pack:dry": "npm pack --dry-run --json",
     "prepublishOnly": "npm run build",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "prepare": "husky install"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -54,8 +59,20 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "zod": "^4.0.0"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^4.0.17",
+    "prettier": "^3.2.0",
+    "husky": "^8.0.0",
+    "lint-staged": "^14.0.0"
+  },
+  "lint-staged": {
+    "*.{ts,js,json,md}": [
+      "prettier --write"
+    ]
   }
 }

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -5,6 +5,7 @@ import { createInterface } from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import path from 'node:path';
+import { WorkspaceExportManifestSchema, parseReceipt } from './schemas.js';
 
 export type AgentBusPrivacy = 'local_only' | 'remote_allowed' | string;
 
@@ -185,6 +186,22 @@ function sha256OfFile(filePath: string): { hash: string; bytes: number } {
   return { hash: hash.digest('hex'), bytes: data.length };
 }
 
+/** Streaming variant — constant memory regardless of file size. */
+function sha256OfFileAsync(filePath: string): Promise<{ hash: string; bytes: number }> {
+  return new Promise((resolve, reject) => {
+    const hasher = crypto.createHash('sha256');
+    let bytes = 0;
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', (chunk: Buffer | string) => {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      bytes += buf.length;
+      hasher.update(buf);
+    });
+    stream.on('end', () => resolve({ hash: hasher.digest('hex'), bytes }));
+    stream.on('error', reject);
+  });
+}
+
 function walkFiles(root: string, relPrefix = ''): string[] {
   const out: string[] = [];
   const stack: Array<{ abs: string; rel: string }> = [{ abs: root, rel: relPrefix }];
@@ -299,6 +316,109 @@ export function exportAgentWorkspace(options: WorkspaceExportOptions): AgentWork
   return receipt;
 }
 
+/**
+ * Async (streaming) variant of {@link exportAgentWorkspace}.
+ * Hashes each file via createReadStream — safe for large files, no OOM risk.
+ */
+export async function exportAgentWorkspaceAsync(
+  options: WorkspaceExportOptions
+): Promise<AgentWorkspaceExportReceipt> {
+  const workspaceRoot = path.resolve(options.workspaceRoot);
+  if (!fs.existsSync(workspaceRoot) || !fs.statSync(workspaceRoot).isDirectory()) {
+    throw new Error(`workspace not found at ${workspaceRoot}`);
+  }
+  let workspaceId = path.basename(workspaceRoot);
+  const formationReceiptPath = path.join(workspaceRoot, '20_receipts', 'workspace.json');
+  if (fs.existsSync(formationReceiptPath)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(formationReceiptPath, 'utf8')) as {
+        workspace_id?: string;
+      };
+      if (parsed.workspace_id) workspaceId = parsed.workspace_id;
+    } catch {
+      /* tolerate */
+    }
+  }
+
+  const requestedInclude = (
+    options.include && options.include.length > 0 ? options.include : DEFAULT_EXPORT_INCLUDE
+  ).filter((folder) => !NEVER_EXPORT.has(folder));
+
+  const exportId = `${timestampId()}-${crypto.randomBytes(3).toString('hex')}`;
+  const exportBase = options.out
+    ? path.resolve(options.out)
+    : path.join(workspaceRoot, '30_exports');
+  const exportPath = path.join(exportBase, exportId);
+  fs.mkdirSync(exportPath, { recursive: true });
+
+  const includedFolders: string[] = [];
+  const excludedFolders: string[] = [];
+  const manifestEntries: WorkspaceExportManifestEntry[] = [];
+  let totalBytes = 0;
+
+  for (const folder of WORKSPACE_FORMATION.folders.map((f) => f.path)) {
+    if (NEVER_EXPORT.has(folder)) {
+      excludedFolders.push(folder);
+      continue;
+    }
+    if (!requestedInclude.includes(folder)) {
+      excludedFolders.push(folder);
+      continue;
+    }
+    includedFolders.push(folder);
+    const srcFolder = path.join(workspaceRoot, folder);
+    if (!fs.existsSync(srcFolder)) continue;
+    for (const rel of walkFiles(srcFolder)) {
+      const srcAbs = path.join(srcFolder, rel);
+      const destRel = `${folder}/${rel}`;
+      const destAbs = path.join(exportPath, destRel);
+      fs.mkdirSync(path.dirname(destAbs), { recursive: true });
+      fs.copyFileSync(srcAbs, destAbs);
+      const { hash, bytes } = await sha256OfFileAsync(destAbs);
+      manifestEntries.push({ path: destRel, sha256: hash, bytes });
+      totalBytes += bytes;
+    }
+  }
+
+  const manifest: WorkspaceExportManifest = {
+    schema_version: 'aethermoor.bus.workspace_export_manifest.v1',
+    export_id: exportId,
+    workspace_id: workspaceId,
+    workspace_root: workspaceRoot,
+    created_at: new Date().toISOString(),
+    included_folders: includedFolders,
+    excluded_folders: excludedFolders,
+    file_count: manifestEntries.length,
+    total_bytes: totalBytes,
+    files: manifestEntries,
+  };
+  const manifestPath = path.join(exportPath, 'manifest.json');
+  const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
+  fs.writeFileSync(manifestPath, manifestJson, 'utf8');
+  const manifestSha256 = crypto.createHash('sha256').update(manifestJson).digest('hex');
+
+  const receiptPath = path.join(workspaceRoot, '20_receipts', `export-${exportId}.json`);
+  fs.mkdirSync(path.dirname(receiptPath), { recursive: true });
+  const receipt: AgentWorkspaceExportReceipt = {
+    schema_version: 'aethermoor.bus.workspace_export.v1',
+    receipt: 'SCBE_WORKSPACE_EXPORT=1',
+    workspace_id: workspaceId,
+    workspace_root: workspaceRoot,
+    export_id: exportId,
+    export_path: exportPath,
+    manifest_path: manifestPath,
+    manifest_sha256: manifestSha256,
+    created_at: manifest.created_at,
+    file_count: manifest.file_count,
+    total_bytes: manifest.total_bytes,
+    included_folders: includedFolders,
+    excluded_folders: excludedFolders,
+    receipt_path: receiptPath,
+  };
+  fs.writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+  return receipt;
+}
+
 export interface WorkspaceVerifyOptions {
   exportPath: string;
   /**
@@ -364,7 +484,15 @@ export function verifyAgentWorkspaceExport(
   }
   const manifestBytes = fs.readFileSync(manifestPath);
   const manifestActualSha = crypto.createHash('sha256').update(manifestBytes).digest('hex');
-  const manifest: WorkspaceExportManifest = JSON.parse(manifestBytes.toString('utf8'));
+  const manifestParsed = parseReceipt(
+    JSON.parse(manifestBytes.toString('utf8')),
+    WorkspaceExportManifestSchema,
+    manifestPath
+  );
+  if (!manifestParsed.ok) {
+    throw new Error(`manifest schema validation failed: ${manifestParsed.error}`);
+  }
+  const manifest: WorkspaceExportManifest = manifestParsed.data;
 
   // The manifest carries the export receipt's record of its own sha256 only
   // indirectly — read the matching export receipt under 20_receipts when
@@ -472,6 +600,128 @@ export function verifyAgentWorkspaceExport(
     } catch {
       // persistence is best-effort; never block a verify result on a write
       // failure. receipt_path stays "" if we couldn't write.
+      receipt.receipt_path = '';
+    }
+  }
+
+  return receipt;
+}
+
+/**
+ * Async (streaming) variant of {@link verifyAgentWorkspaceExport}.
+ * Hashes each file via createReadStream — safe for large exports, no OOM risk.
+ */
+export async function verifyAgentWorkspaceExportAsync(
+  options: WorkspaceVerifyOptions
+): Promise<AgentWorkspaceVerifyReceipt> {
+  const exportPath = path.resolve(options.exportPath);
+  const manifestPath = path.join(exportPath, 'manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`manifest not found at ${manifestPath}`);
+  }
+  const manifestBytes = fs.readFileSync(manifestPath);
+  const manifestActualSha = crypto.createHash('sha256').update(manifestBytes).digest('hex');
+  const manifestParsed = parseReceipt(
+    JSON.parse(manifestBytes.toString('utf8')),
+    WorkspaceExportManifestSchema,
+    manifestPath
+  );
+  if (!manifestParsed.ok) {
+    throw new Error(`manifest schema validation failed: ${manifestParsed.error}`);
+  }
+  const manifest: WorkspaceExportManifest = manifestParsed.data;
+
+  let manifestClaimedSha = '';
+  try {
+    const receiptDir = path.join(manifest.workspace_root, '20_receipts');
+    const receiptName = `export-${manifest.export_id}.json`;
+    const receiptPath = path.join(receiptDir, receiptName);
+    if (fs.existsSync(receiptPath)) {
+      const exportReceipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+      if (typeof exportReceipt.manifest_sha256 === 'string') {
+        manifestClaimedSha = exportReceipt.manifest_sha256;
+      }
+    }
+  } catch {
+    /* tolerate */
+  }
+
+  const mismatches: WorkspaceVerifyMismatch[] = [];
+  const presentFiles = walkFiles(exportPath).filter((rel) => rel !== 'manifest.json');
+  const manifestPaths = new Set(manifest.files.map((f) => f.path));
+
+  let actualBytes = 0;
+  for (const entry of manifest.files) {
+    const abs = path.join(exportPath, entry.path);
+    if (!fs.existsSync(abs)) {
+      mismatches.push({
+        path: entry.path,
+        reason: 'missing_file',
+        expected_sha256: entry.sha256,
+        expected_bytes: entry.bytes,
+      });
+      continue;
+    }
+    const { hash, bytes } = await sha256OfFileAsync(abs);
+    actualBytes += bytes;
+    if (hash !== entry.sha256) {
+      mismatches.push({
+        path: entry.path,
+        reason: 'sha256_mismatch',
+        expected_sha256: entry.sha256,
+        actual_sha256: hash,
+        expected_bytes: entry.bytes,
+        actual_bytes: bytes,
+      });
+    } else if (bytes !== entry.bytes) {
+      mismatches.push({
+        path: entry.path,
+        reason: 'bytes_mismatch',
+        expected_bytes: entry.bytes,
+        actual_bytes: bytes,
+      });
+    }
+  }
+
+  for (const rel of presentFiles) {
+    if (!manifestPaths.has(rel)) {
+      mismatches.push({ path: rel, reason: 'extra_file' });
+    }
+  }
+
+  const manifestIntact =
+    manifestClaimedSha === '' ? true : manifestActualSha === manifestClaimedSha;
+  const passed = mismatches.length === 0 && manifestIntact;
+
+  const receipt: AgentWorkspaceVerifyReceipt = {
+    schema_version: 'aethermoor.bus.workspace_verify.v1',
+    receipt: passed ? 'SCBE_WORKSPACE_VERIFY_PASS=1' : 'SCBE_WORKSPACE_VERIFY_PASS=0',
+    export_path: exportPath,
+    manifest_path: manifestPath,
+    manifest_sha256_claimed: manifestClaimedSha,
+    manifest_sha256_actual: manifestActualSha,
+    manifest_intact: manifestIntact,
+    file_count_claimed: manifest.file_count,
+    file_count_actual: presentFiles.length,
+    total_bytes_claimed: manifest.total_bytes,
+    total_bytes_actual: actualBytes,
+    mismatches,
+    verified_at: new Date().toISOString(),
+    receipt_path: '',
+  };
+
+  const shouldPersist = options.persistReceipt !== false;
+  if (shouldPersist && manifest.workspace_root && manifest.export_id) {
+    try {
+      const receiptsDir = path.join(manifest.workspace_root, '20_receipts');
+      if (fs.existsSync(receiptsDir)) {
+        const ts = receipt.verified_at.replace(/[:.]/g, '-');
+        const receiptName = `verify-${manifest.export_id}-${ts}.json`;
+        const receiptPath = path.join(receiptsDir, receiptName);
+        receipt.receipt_path = receiptPath;
+        fs.writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+      }
+    } catch {
       receipt.receipt_path = '';
     }
   }

--- a/packages/agent-bus/src/schemas.ts
+++ b/packages/agent-bus/src/schemas.ts
@@ -1,0 +1,284 @@
+/**
+ * @file schemas.ts
+ * @module agent-bus/schemas
+ *
+ * Zod v4 schemas for every agent-bus receipt, manifest, and event shape.
+ * Use safeParse at disk-read boundaries; parse() when we own the data.
+ *
+ * parseFromDisk() is the standard boundary helper — returns a typed Result
+ * rather than throwing, so callers decide whether to quarantine or propagate.
+ */
+
+import { z } from 'zod';
+
+// ─── primitive helpers ────────────────────────────────────────────────────────
+
+const sha256Hex = z.string().regex(/^[0-9a-f]{64}$/, 'expected 64-char lowercase hex sha256');
+const isoTs = z.string().min(1, 'expected ISO timestamp string');
+const nonNegInt = z.number().int().nonnegative();
+
+// ─── AgentBusEvent ───────────────────────────────────────────────────────────
+
+export const AgentBusEventSchema = z.object({
+  task: z.string().min(1),
+  taskType: z.string().optional(),
+  operationCommand: z.string().optional(),
+  seriesId: z.string().optional(),
+  privacy: z.string().optional(),
+  budgetCents: z.number().nonnegative().optional(),
+  dispatch: z.boolean().optional(),
+  dispatchProvider: z.string().optional(),
+});
+
+export type AgentBusEventParsed = z.infer<typeof AgentBusEventSchema>;
+
+// ─── WorkspaceExportManifest ──────────────────────────────────────────────────
+
+export const WorkspaceExportManifestEntrySchema = z.object({
+  path: z.string().min(1),
+  sha256: sha256Hex,
+  bytes: nonNegInt,
+});
+
+export const WorkspaceExportManifestSchema = z.object({
+  schema_version: z.literal('aethermoor.bus.workspace_export_manifest.v1'),
+  export_id: z.string().min(1),
+  workspace_id: z.string().min(1),
+  workspace_root: z.string().min(1),
+  created_at: isoTs,
+  included_folders: z.array(z.string()),
+  excluded_folders: z.array(z.string()),
+  file_count: nonNegInt,
+  total_bytes: nonNegInt,
+  files: z.array(WorkspaceExportManifestEntrySchema),
+});
+
+export type WorkspaceExportManifestParsed = z.infer<typeof WorkspaceExportManifestSchema>;
+
+// ─── AgentWorkspaceReceipt (formation) ───────────────────────────────────────
+
+export const AgentWorkspaceReceiptSchema = z.object({
+  schema_version: z.literal('aethermoor.bus.workspace_receipt.v1'),
+  receipt: z.literal('SCBE_WORKSPACE_READY=1'),
+  workspace_id: z.string().min(1),
+  workspace_root: z.string().min(1),
+  created_at: isoTs,
+  formation: z.object({
+    schema_version: z.literal('aethermoor.bus.workspace_formation.v1'),
+    default_root: z.string(),
+    folders: z.array(z.object({ path: z.string(), purpose: z.string() })),
+  }),
+  receipt_path: z.string(),
+});
+
+export type AgentWorkspaceReceiptParsed = z.infer<typeof AgentWorkspaceReceiptSchema>;
+
+// ─── AgentWorkspaceExportReceipt ─────────────────────────────────────────────
+
+export const AgentWorkspaceExportReceiptSchema = z.object({
+  schema_version: z.literal('aethermoor.bus.workspace_export.v1'),
+  receipt: z.literal('SCBE_WORKSPACE_EXPORT=1'),
+  workspace_id: z.string().min(1),
+  workspace_root: z.string().min(1),
+  export_id: z.string().min(1),
+  export_path: z.string().min(1),
+  manifest_path: z.string().min(1),
+  manifest_sha256: sha256Hex,
+  created_at: isoTs,
+  file_count: nonNegInt,
+  total_bytes: nonNegInt,
+  included_folders: z.array(z.string()),
+  excluded_folders: z.array(z.string()),
+  receipt_path: z.string(),
+});
+
+export type AgentWorkspaceExportReceiptParsed = z.infer<typeof AgentWorkspaceExportReceiptSchema>;
+
+// ─── WorkspaceVerifyMismatch ──────────────────────────────────────────────────
+
+export const WorkspaceVerifyMismatchSchema = z.object({
+  path: z.string(),
+  reason: z.enum(['sha256_mismatch', 'missing_file', 'extra_file', 'bytes_mismatch']),
+  expected_sha256: z.string().optional(),
+  actual_sha256: z.string().optional(),
+  expected_bytes: nonNegInt.optional(),
+  actual_bytes: nonNegInt.optional(),
+});
+
+export type WorkspaceVerifyMismatchParsed = z.infer<typeof WorkspaceVerifyMismatchSchema>;
+
+// ─── AgentWorkspaceVerifyReceipt ─────────────────────────────────────────────
+
+export const AgentWorkspaceVerifyReceiptSchema = z.object({
+  schema_version: z.literal('aethermoor.bus.workspace_verify.v1'),
+  receipt: z.enum(['SCBE_WORKSPACE_VERIFY_PASS=1', 'SCBE_WORKSPACE_VERIFY_PASS=0']),
+  export_path: z.string(),
+  manifest_path: z.string(),
+  manifest_sha256_claimed: z.string(),
+  manifest_sha256_actual: z.string(),
+  manifest_intact: z.boolean(),
+  file_count_claimed: nonNegInt,
+  file_count_actual: nonNegInt,
+  total_bytes_claimed: nonNegInt,
+  total_bytes_actual: nonNegInt,
+  mismatches: z.array(WorkspaceVerifyMismatchSchema),
+  verified_at: isoTs,
+  receipt_path: z.string(),
+});
+
+export type AgentWorkspaceVerifyReceiptParsed = z.infer<typeof AgentWorkspaceVerifyReceiptSchema>;
+
+// ─── AgentWorkspaceIngestReceipt ─────────────────────────────────────────────
+
+export const AgentWorkspaceIngestReceiptSchema = z.object({
+  schema_version: z.literal('aethermoor.bus.workspace_ingest.v1'),
+  receipt: z.literal('SCBE_WORKSPACE_INGEST=1'),
+  workspace_id: z.string().min(1),
+  workspace_root: z.string().min(1),
+  source_path: z.string().min(1),
+  destination_path: z.string().min(1),
+  destination_rel: z.string().min(1),
+  source_sha256: sha256Hex,
+  destination_sha256: sha256Hex,
+  bytes: nonNegInt,
+  ingested_at: isoTs,
+  receipt_path: z.string(),
+});
+
+export type AgentWorkspaceIngestReceiptParsed = z.infer<typeof AgentWorkspaceIngestReceiptSchema>;
+
+// ─── AgentWorkspaceVerifyAllReceipt ──────────────────────────────────────────
+
+export const AgentWorkspaceVerifyAllReceiptSchema = z.object({
+  schema_version: z.literal('aethermoor.bus.workspace_verify_all.v1'),
+  receipt: z.enum(['SCBE_WORKSPACE_VERIFY_ALL_PASS=1', 'SCBE_WORKSPACE_VERIFY_ALL_PASS=0']),
+  workspace_root: z.string(),
+  workspace_id: z.string(),
+  verified_at: isoTs,
+  export_count: nonNegInt,
+  passed_count: nonNegInt,
+  failed_count: nonNegInt,
+  results: z.array(AgentWorkspaceVerifyReceiptSchema),
+});
+
+export type AgentWorkspaceVerifyAllReceiptParsed = z.infer<
+  typeof AgentWorkspaceVerifyAllReceiptSchema
+>;
+
+// ─── AgentWorkspaceImportReceipt ─────────────────────────────────────────────
+
+export const AgentWorkspaceImportReceiptSchema = z.object({
+  schema_version: z.literal('aethermoor.bus.workspace_import.v1'),
+  receipt: z.enum(['SCBE_WORKSPACE_IMPORT=1', 'SCBE_WORKSPACE_IMPORT=0']),
+  source_export_path: z.string(),
+  source_export_id: z.string(),
+  source_manifest_sha256: z.string(),
+  source_workspace_id: z.string(),
+  target_workspace_id: z.string(),
+  target_workspace_root: z.string(),
+  imported_files: nonNegInt,
+  imported_bytes: nonNegInt,
+  imported_at: isoTs,
+  verify_pass: z.boolean(),
+  verify_mismatches: z.array(WorkspaceVerifyMismatchSchema),
+  receipt_path: z.string(),
+});
+
+export type AgentWorkspaceImportReceiptParsed = z.infer<typeof AgentWorkspaceImportReceiptSchema>;
+
+// ─── LineageEntry ─────────────────────────────────────────────────────────────
+
+export const LineageEntrySchema = z.object({
+  kind: z.enum(['formation', 'ingest', 'export', 'verify', 'import', 'trap_dispatch', 'unknown']),
+  receipt_path: z.string(),
+  receipt_name: z.string(),
+  timestamp: z.string(),
+  schema_version: z.string(),
+  receipt: z.string(),
+  export_id: z.string().optional(),
+  manifest_sha256: z.string().optional(),
+  manifest_intact: z.boolean().optional(),
+  mismatch_count: nonNegInt.optional(),
+  gate_decision: z.string().optional(),
+  redirect_emitted: z.boolean().optional(),
+  parse_error: z.string().optional(),
+});
+
+export type LineageEntryParsed = z.infer<typeof LineageEntrySchema>;
+
+// ─── AgentWorkspaceLineageReceipt ────────────────────────────────────────────
+
+export const AgentWorkspaceLineageReceiptSchema = z.object({
+  schema_version: z.literal('aethermoor.bus.workspace_lineage.v1'),
+  receipt: z.literal('SCBE_WORKSPACE_LINEAGE=1'),
+  workspace_root: z.string(),
+  workspace_id: z.string(),
+  generated_at: isoTs,
+  entries: z.array(LineageEntrySchema),
+  formation_count: nonNegInt,
+  ingest_count: nonNegInt,
+  export_count: nonNegInt,
+  verify_count: nonNegInt,
+  import_count: nonNegInt,
+  trap_dispatch_count: nonNegInt,
+  trap_redirect_count: nonNegInt,
+  unverified_exports: z.array(z.string()),
+  failed_verifies: nonNegInt,
+});
+
+export type AgentWorkspaceLineageReceiptParsed = z.infer<typeof AgentWorkspaceLineageReceiptSchema>;
+
+// ─── AgentWorkspaceReportReceipt ─────────────────────────────────────────────
+
+export const FolderStatSchema = z.object({
+  path: z.string(),
+  file_count: nonNegInt,
+  total_bytes: nonNegInt,
+});
+
+export const AgentWorkspaceReportReceiptSchema = z.object({
+  schema_version: z.literal('aethermoor.bus.workspace_report.v1'),
+  receipt: z.literal('SCBE_WORKSPACE_REPORT=1'),
+  workspace_id: z.string(),
+  workspace_root: z.string(),
+  generated_at: isoTs,
+  created_at: z.string(),
+  folders: z.array(FolderStatSchema),
+  lineage_summary: z.object({
+    formation_count: nonNegInt,
+    ingest_count: nonNegInt,
+    export_count: nonNegInt,
+    verify_count: nonNegInt,
+    import_count: nonNegInt,
+    trap_dispatch_count: nonNegInt,
+    trap_redirect_count: nonNegInt,
+    failed_verifies: nonNegInt,
+    unverified_exports: z.array(z.string()),
+  }),
+  last_activity: z.string(),
+  audit_health: z.enum(['green', 'amber', 'red']),
+});
+
+export type AgentWorkspaceReportReceiptParsed = z.infer<typeof AgentWorkspaceReportReceiptSchema>;
+
+// ─── Boundary helper ─────────────────────────────────────────────────────────
+
+export type ParseResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+/**
+ * Parse arbitrary data against a Zod schema and return a typed Result.
+ * Never throws. Use at every disk-read boundary before trusting JSON content.
+ */
+export function parseReceipt<T>(
+  raw: unknown,
+  schema: z.ZodSchema<T>,
+  label = 'receipt'
+): ParseResult<T> {
+  const result = schema.safeParse(raw);
+  if (result.success) return { ok: true, data: result.data };
+  const summary = result.error.issues
+    .slice(0, 3)
+    .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+    .join('; ');
+  return { ok: false, error: `${label}: ${summary}` };
+}

--- a/scripts/system/geoseal_llm_verify.py
+++ b/scripts/system/geoseal_llm_verify.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""geoseal_llm_verify.py — concurrent multi-LLM verification harness for GeoSeal outputs.
+
+Reads a GeoSeal governance record, fans it out to N tiny cloud LLMs in two
+interlocked phases, collects independent verdicts, reduces to a quorum decision,
+and writes a receipted JSON artifact.
+
+Three-phase concurrent architecture:
+  Phase 1 (fast triage, ~1s):   Cerebras + Groq/8B fired simultaneously
+  Phase 2 (focused review, ~3s): Together/Fireworks 3-8B with Phase-1-informed prompt
+  Phase 3 (synthesis, ~0.1s):   MultiModelModalMatrix reducer → receipt
+
+Independent streams: each provider call is isolated — different base URLs, models,
+API keys, and timeout budgets. Failure of one stream never blocks others.
+
+Providers (all via env vars):
+  CEREBRAS_API_KEY    → api.cerebras.ai    (llama-4-scout-17b-16e default)
+  GROQ_API_KEY        → api.groq.com       (llama3-8b-8192 default)
+  TOGETHER_API_KEY    → api.together.xyz   (Llama-3.2-3B-Instruct-Turbo default)
+  FIREWORKS_API_KEY   → api.fireworks.ai   (llama-v3p2-3b-instruct default)
+  OPENROUTER_API_KEY  → openrouter.ai/api  (meta-llama/llama-3.2-3b-instruct default)
+
+Usage:
+  python -m scripts.system.geoseal_llm_verify --last
+  python -m scripts.system.geoseal_llm_verify --record .scbe/geoseal_calls.jsonl
+  python -m scripts.system.geoseal_llm_verify --json '{"op":"add","tongue":"KO","output":"def add..."}'
+  python -m scripts.system.geoseal_llm_verify --last --dry-run   # mock responses
+  python -m scripts.system.geoseal_llm_verify --last --phase 1   # phase 1 only
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import sys
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+import urllib.error
+import urllib.request
+
+# ─── Provider registry ───────────────────────────────────────────────────────
+
+@dataclass
+class ProviderSpec:
+    name: str
+    base_url: str
+    api_key_env: str
+    default_model: str
+    phase: int        # 1 = fast triage, 2 = focused review
+    timeout_s: int = 15
+    max_tokens: int = 256
+
+PROVIDERS: list[ProviderSpec] = [
+    # ── Phase 1: fast triage (fire first, ~1s) ────────────────────────────────
+    ProviderSpec(
+        name="cerebras",
+        base_url="https://api.cerebras.ai/v1",
+        api_key_env="CEREBRAS_API_KEY",
+        default_model="llama-4-scout-17b-16e",
+        phase=1,
+        timeout_s=10,
+    ),
+    ProviderSpec(
+        name="groq-8b",
+        base_url="https://api.groq.com/openai/v1",
+        api_key_env="GROQ_API_KEY",
+        default_model="llama3-8b-8192",
+        phase=1,
+        timeout_s=12,
+    ),
+    # NVIDIA NIM free tier — many small models, no cost
+    ProviderSpec(
+        name="nvidia-llama3b",
+        base_url="https://integrate.api.nvidia.com/v1",
+        api_key_env="NVIDIA_API_KEY",
+        default_model="meta/llama-3.2-3b-instruct",
+        phase=1,
+        timeout_s=15,
+    ),
+    # Ollama local — zero cost, any pulled model
+    ProviderSpec(
+        name="ollama-local",
+        base_url="http://localhost:11434/v1",
+        api_key_env="OLLAMA_API_KEY",   # set to "ollama" or any string; checked for existence
+        default_model="llama3.2:3b",
+        phase=1,
+        timeout_s=30,
+    ),
+    # ── Phase 2: focused review — interlocked, uses Phase 1 output ────────────
+    ProviderSpec(
+        name="groq-gemma",
+        base_url="https://api.groq.com/openai/v1",
+        api_key_env="GROQ_API_KEY",
+        default_model="gemma2-9b-it",
+        phase=2,
+        timeout_s=15,
+    ),
+    # NVIDIA Phi-3 mini — 3.8B, very fast on NIM
+    ProviderSpec(
+        name="nvidia-phi3",
+        base_url="https://integrate.api.nvidia.com/v1",
+        api_key_env="NVIDIA_API_KEY",
+        default_model="microsoft/phi-3-mini-128k-instruct",
+        phase=2,
+        timeout_s=20,
+    ),
+    # NVIDIA Gemma-2 2B — weakest model, good for stress-testing consensus
+    ProviderSpec(
+        name="nvidia-gemma2b",
+        base_url="https://integrate.api.nvidia.com/v1",
+        api_key_env="NVIDIA_API_KEY",
+        default_model="google/gemma-2-2b-it",
+        phase=2,
+        timeout_s=20,
+    ),
+    ProviderSpec(
+        name="together-3b",
+        base_url="https://api.together.xyz/v1",
+        api_key_env="TOGETHER_API_KEY",
+        default_model="meta-llama/Llama-3.2-3B-Instruct-Turbo",
+        phase=2,
+        timeout_s=20,
+    ),
+    ProviderSpec(
+        name="fireworks-3b",
+        base_url="https://api.fireworks.ai/inference/v1",
+        api_key_env="FIREWORKS_API_KEY",
+        default_model="accounts/fireworks/models/llama-v3p2-3b-instruct",
+        phase=2,
+        timeout_s=20,
+    ),
+    ProviderSpec(
+        name="openrouter-3b",
+        base_url="https://openrouter.ai/api/v1",
+        api_key_env="OPENROUTER_API_KEY",
+        default_model="meta-llama/llama-3.2-3b-instruct",
+        phase=2,
+        timeout_s=20,
+    ),
+    # Ollama second model — independent stream from ollama-local
+    ProviderSpec(
+        name="ollama-phi",
+        base_url="http://localhost:11434/v1",
+        api_key_env="OLLAMA_API_KEY",
+        default_model="phi3:mini",
+        phase=2,
+        timeout_s=30,
+    ),
+]
+
+# ─── Verdict schema ───────────────────────────────────────────────────────────
+
+@dataclass
+class ProviderVerdict:
+    provider: str
+    model: str
+    phase: int
+    decision: str          # ALLOW | QUARANTINE | DENY | ERROR
+    confidence: float      # 0.0–1.0
+    rationale: str
+    latency_ms: float
+    raw_response: str
+    error: Optional[str] = None
+
+@dataclass
+class VerifyReceipt:
+    schema_version: str = "scbe.geoseal.verify.v1"
+    receipt: str = "SCBE_GEOSEAL_VERIFY=0"
+    verify_id: str = field(default_factory=lambda: str(uuid.uuid4())[:12])
+    record_sha256: str = ""
+    created_at: str = ""
+    phase_1_verdicts: list[dict[str, Any]] = field(default_factory=list)
+    phase_2_verdicts: list[dict[str, Any]] = field(default_factory=list)
+    quorum_decision: str = "UNKNOWN"
+    quorum_confidence: float = 0.0
+    quorum_support: dict[str, int] = field(default_factory=dict)
+    provider_count: int = 0
+    error_count: int = 0
+    total_latency_ms: float = 0.0
+
+# ─── HTTP call (sync, runs in executor) ──────────────────────────────────────
+
+def _chat_sync(
+    spec: ProviderSpec,
+    messages: list[dict[str, str]],
+    dry_run: bool = False,
+) -> tuple[str, Optional[str], float]:
+    """Returns (response_text, error_or_None, latency_ms)."""
+    if dry_run:
+        time.sleep(0.05)
+        return f"ALLOW confidence:0.82 — dry-run mock from {spec.name}", None, 50.0
+
+    is_local = spec.base_url.startswith("http://localhost")
+    key = os.environ.get(spec.api_key_env, "ollama" if is_local else "")
+    if not key and not is_local:
+        return "", f"missing env var {spec.api_key_env}", 0.0
+
+    url = spec.base_url.rstrip("/") + "/chat/completions"
+    body = {
+        "model": spec.default_model,
+        "messages": messages,
+        "max_tokens": spec.max_tokens,
+        "temperature": 0.0,
+    }
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    if not is_local:
+        headers["HTTP-Referer"] = "https://github.com/issdandavis/SCBE-AETHERMOORE"
+        headers["X-Title"] = "SCBE GeoSeal Verify"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    t0 = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=spec.timeout_s) as r:
+            d = json.loads(r.read().decode("utf-8", errors="replace"))
+        latency = (time.monotonic() - t0) * 1000
+        text = d["choices"][0]["message"]["content"]
+        return text, None, latency
+    except urllib.error.HTTPError as e:
+        latency = (time.monotonic() - t0) * 1000
+        try:
+            err = e.read().decode("utf-8", errors="replace")[:400]
+        except Exception:
+            err = ""
+        return "", f"HTTP {e.code}: {err}", latency
+    except Exception as exc:
+        latency = (time.monotonic() - t0) * 1000
+        return "", f"{type(exc).__name__}: {exc}", latency
+
+# ─── Prompt builders ─────────────────────────────────────────────────────────
+
+_TRIAGE_SYSTEM = (
+    "You are a governance auditor for an AI safety system called SCBE-AETHERMOORE. "
+    "You review GeoSeal CLI outputs — code generated by a multi-tongue tokenizer system. "
+    "Assess whether the output is SAFE (ALLOW), SUSPICIOUS (QUARANTINE), or UNSAFE (DENY). "
+    "Reply in exactly this format:\n"
+    "DECISION: <ALLOW|QUARANTINE|DENY>\n"
+    "CONFIDENCE: <0.0–1.0>\n"
+    "REASON: <one sentence>\n"
+    "Do not add any other text."
+)
+
+_FOCUSED_SYSTEM = (
+    "You are a governance auditor for SCBE-AETHERMOORE. "
+    "Phase 1 reviewers flagged concerns about this GeoSeal output. "
+    "Your job: confirm or reject the concern with specific evidence. "
+    "Reply in exactly this format:\n"
+    "DECISION: <ALLOW|QUARANTINE|DENY>\n"
+    "CONFIDENCE: <0.0–1.0>\n"
+    "REASON: <one sentence citing specific evidence>\n"
+    "Do not add any other text."
+)
+
+def _build_triage_messages(record: dict[str, Any]) -> list[dict[str, str]]:
+    content_lines = [
+        "GeoSeal output to review:",
+        f"  op: {record.get('op', record.get('operation', 'unknown'))}",
+        f"  tongue: {record.get('tongue', record.get('tongue_code', 'unknown'))}",
+        f"  language: {record.get('language', 'unknown')}",
+    ]
+    output = record.get("output") or record.get("code") or record.get("result") or ""
+    if output:
+        snippet = str(output)[:600]
+        content_lines.append(f"  output:\n```\n{snippet}\n```")
+    seal = record.get("seal") or record.get("geoseal") or {}
+    if seal:
+        content_lines.append(f"  seal: {json.dumps(seal)[:200]}")
+    return [
+        {"role": "system", "content": _TRIAGE_SYSTEM},
+        {"role": "user", "content": "\n".join(content_lines)},
+    ]
+
+def _build_focused_messages(
+    record: dict[str, Any],
+    phase1_concern: str,
+) -> list[dict[str, str]]:
+    base = _build_triage_messages(record)
+    base[0] = {"role": "system", "content": _FOCUSED_SYSTEM}
+    base.append({
+        "role": "user",
+        "content": f"Phase 1 concern flagged: {phase1_concern}\nDo you confirm this concern?",
+    })
+    return base
+
+# ─── Response parser ─────────────────────────────────────────────────────────
+
+def _parse_verdict(text: str, spec: ProviderSpec, latency_ms: float, error: Optional[str]) -> ProviderVerdict:
+    if error:
+        return ProviderVerdict(
+            provider=spec.name,
+            model=spec.default_model,
+            phase=spec.phase,
+            decision="ERROR",
+            confidence=0.0,
+            rationale=error,
+            latency_ms=latency_ms,
+            raw_response="",
+            error=error,
+        )
+    decision = "ALLOW"
+    confidence = 0.5
+    rationale = text.strip()[:200]
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("DECISION:"):
+            d = line.split(":", 1)[1].strip().upper()
+            if d in {"ALLOW", "QUARANTINE", "DENY"}:
+                decision = d
+        elif line.startswith("CONFIDENCE:"):
+            try:
+                confidence = max(0.0, min(1.0, float(line.split(":", 1)[1].strip())))
+            except ValueError:
+                pass
+        elif line.startswith("REASON:"):
+            rationale = line.split(":", 1)[1].strip()[:200]
+    return ProviderVerdict(
+        provider=spec.name,
+        model=spec.default_model,
+        phase=spec.phase,
+        decision=decision,
+        confidence=confidence,
+        rationale=rationale,
+        latency_ms=latency_ms,
+        raw_response=text[:500],
+    )
+
+# ─── Phase runners ────────────────────────────────────────────────────────────
+
+async def _run_phase(
+    specs: list[ProviderSpec],
+    messages_per_spec: dict[str, list[dict[str, str]]],
+    executor: ThreadPoolExecutor,
+    dry_run: bool,
+) -> list[ProviderVerdict]:
+    loop = asyncio.get_running_loop()
+
+    async def _call(spec: ProviderSpec) -> ProviderVerdict:
+        msgs = messages_per_spec[spec.name]
+        text, err, latency = await loop.run_in_executor(
+            executor, _chat_sync, spec, msgs, dry_run
+        )
+        return _parse_verdict(text, spec, latency, err)
+
+    return list(await asyncio.gather(*[_call(s) for s in specs]))
+
+# ─── Quorum reducer ───────────────────────────────────────────────────────────
+
+def _reduce_quorum(verdicts: list[ProviderVerdict]) -> tuple[str, float, dict[str, int]]:
+    """Weighted vote: error verdicts contribute 0 weight."""
+    weights = {"ALLOW": 0.0, "QUARANTINE": 0.0, "DENY": 0.0}
+    support: dict[str, int] = {"ALLOW": 0, "QUARANTINE": 0, "DENY": 0, "ERROR": 0}
+    for v in verdicts:
+        support[v.decision] = support.get(v.decision, 0) + 1
+        if v.decision in weights:
+            # Phase 2 verdicts have 1.5× weight (more focused)
+            phase_weight = 1.5 if v.phase == 2 else 1.0
+            weights[v.decision] += v.confidence * phase_weight
+    total = sum(weights.values())
+    if total == 0.0:
+        return "UNKNOWN", 0.0, support
+    # Normalize
+    norm = {k: v / total for k, v in weights.items()}
+    decision = max(norm, key=lambda k: norm[k])
+    return decision, round(norm[decision], 3), support
+
+# ─── Main verification flow ───────────────────────────────────────────────────
+
+async def verify_async(
+    record: dict[str, Any],
+    *,
+    dry_run: bool = False,
+    max_phase: int = 2,
+    providers: Optional[list[str]] = None,
+) -> VerifyReceipt:
+    t_start = time.monotonic()
+    receipt = VerifyReceipt(
+        created_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        record_sha256=hashlib.sha256(
+            json.dumps(record, sort_keys=True).encode("utf-8")
+        ).hexdigest(),
+    )
+
+    active = [s for s in PROVIDERS if providers is None or s.name in providers]
+    # Filter out providers with no API key (unless dry-run)
+    if not dry_run:
+        active = [
+            s for s in active
+            # Ollama: skip key check, just needs localhost reachable
+            if s.base_url.startswith("http://localhost") or os.environ.get(s.api_key_env)
+        ]
+
+    if not active:
+        receipt.receipt = "SCBE_GEOSEAL_VERIFY=0"
+        receipt.quorum_decision = "NO_PROVIDERS"
+        return receipt
+
+    with ThreadPoolExecutor(max_workers=len(active)) as executor:
+        # ── Phase 1: fast triage ─────────────────────────────────────────────
+        p1_specs = [s for s in active if s.phase == 1]
+        p1_msgs = {s.name: _build_triage_messages(record) for s in p1_specs}
+        p1_verdicts: list[ProviderVerdict] = []
+        if p1_specs and max_phase >= 1:
+            p1_verdicts = await _run_phase(p1_specs, p1_msgs, executor, dry_run)
+            receipt.phase_1_verdicts = [asdict(v) for v in p1_verdicts]
+
+        # Derive concern summary from Phase 1 for interlocked Phase 2 prompt
+        p1_concerns = [v.rationale for v in p1_verdicts if v.decision in {"QUARANTINE", "DENY"}]
+        phase1_concern = "; ".join(p1_concerns[:2]) if p1_concerns else "no concern flagged in phase 1"
+
+        # ── Phase 2: focused review (interlocked — uses Phase 1 output) ──────
+        p2_specs = [s for s in active if s.phase == 2]
+        p2_verdicts: list[ProviderVerdict] = []
+        if p2_specs and max_phase >= 2:
+            p2_msgs = {
+                s.name: _build_focused_messages(record, phase1_concern)
+                for s in p2_specs
+            }
+            p2_verdicts = await _run_phase(p2_specs, p2_msgs, executor, dry_run)
+            receipt.phase_2_verdicts = [asdict(v) for v in p2_verdicts]
+
+    # ── Phase 3: reduce ───────────────────────────────────────────────────────
+    all_verdicts = p1_verdicts + p2_verdicts
+    receipt.provider_count = len(all_verdicts)
+    receipt.error_count = sum(1 for v in all_verdicts if v.decision == "ERROR")
+    receipt.total_latency_ms = round((time.monotonic() - t_start) * 1000, 1)
+
+    decision, confidence, support = _reduce_quorum(all_verdicts)
+    receipt.quorum_decision = decision
+    receipt.quorum_confidence = confidence
+    receipt.quorum_support = support
+    receipt.receipt = f"SCBE_GEOSEAL_VERIFY={'1' if decision == 'ALLOW' else '0'}"
+
+    return receipt
+
+# ─── CLI ─────────────────────────────────────────────────────────────────────
+
+def _load_last_record(path: str = ".scbe/geoseal_calls.jsonl") -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"GeoSeal log not found: {path}")
+    last = None
+    with p.open() as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    last = json.loads(line)
+                except json.JSONDecodeError:
+                    pass
+    if last is None:
+        raise ValueError(f"No records in {path}")
+    return last
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--last", action="store_true", help="verify last record from .scbe/geoseal_calls.jsonl")
+    src.add_argument("--record", metavar="PATH", help="path to a JSONL or JSON file")
+    src.add_argument("--json", metavar="JSON", help="inline JSON record string")
+    ap.add_argument("--dry-run", action="store_true", help="mock all LLM calls")
+    ap.add_argument("--phase", type=int, choices=[1, 2], default=2, help="run only up to this phase")
+    ap.add_argument("--providers", metavar="NAMES", help="comma-separated provider names to include")
+    ap.add_argument("--out", metavar="PATH", help="write receipt JSON to this path")
+    ap.add_argument("--quiet", action="store_true", help="suppress progress output")
+    args = ap.parse_args()
+
+    # Load record
+    if args.last:
+        record = _load_last_record()
+    elif args.json:
+        record = json.loads(args.json)
+    else:
+        p = Path(args.record)
+        if p.suffix == ".jsonl":
+            record = _load_last_record(str(p))
+        else:
+            record = json.loads(p.read_text())
+
+    providers = [x.strip() for x in args.providers.split(",")] if args.providers else None
+
+    if not args.quiet:
+        active_count = len([
+            s for s in PROVIDERS
+            if (providers is None or s.name in providers)
+            and (args.dry_run or os.environ.get(s.api_key_env))
+            and s.phase <= args.phase
+        ])
+        print(f"[geoseal-verify] Firing {active_count} providers across {args.phase} phase(s)…", flush=True)
+
+    receipt = asyncio.run(
+        verify_async(
+            record,
+            dry_run=args.dry_run,
+            max_phase=args.phase,
+            providers=providers,
+        )
+    )
+
+    receipt_dict = asdict(receipt)
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(receipt_dict, indent=2))
+        if not args.quiet:
+            print(f"[geoseal-verify] Receipt written → {args.out}", flush=True)
+
+    # Always print summary
+    print(json.dumps(receipt_dict, indent=2))
+
+    # Exit non-zero if DENY or UNKNOWN
+    if receipt.quorum_decision in {"DENY", "UNKNOWN", "NO_PROVIDERS"}:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent-bus/workspace.test.ts
+++ b/tests/agent-bus/workspace.test.ts
@@ -1,0 +1,264 @@
+/**
+ * @file workspace.test.ts
+ * @module agent-bus/workspace
+ *
+ * Covers: createAgentWorkspace, ingestIntoAgentWorkspace,
+ * exportAgentWorkspaceAsync, verifyAgentWorkspaceExportAsync,
+ * lineageAgentWorkspace, and Zod schema validation at disk-read boundaries.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createAgentWorkspace,
+  exportAgentWorkspaceAsync,
+  ingestIntoAgentWorkspace,
+  lineageAgentWorkspace,
+  verifyAgentWorkspaceExportAsync,
+  WORKSPACE_FORMATION,
+} from '../../packages/agent-bus/src/index.js';
+
+import {
+  AgentWorkspaceExportReceiptSchema,
+  AgentWorkspaceIngestReceiptSchema,
+  AgentWorkspaceReceiptSchema,
+  AgentWorkspaceVerifyReceiptSchema,
+  WorkspaceExportManifestSchema,
+  parseReceipt,
+} from '../../packages/agent-bus/src/schemas.js';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+let tmpBase: string;
+
+function writeTmp(name: string, content: string): string {
+  const p = path.join(tmpBase, name);
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+beforeEach(() => {
+  tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-bus-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpBase, { recursive: true, force: true });
+});
+
+// ─── createAgentWorkspace ─────────────────────────────────────────────────────
+
+describe('createAgentWorkspace', () => {
+  it('creates all formation folders', () => {
+    const receipt = createAgentWorkspace({ root: tmpBase, hint: 'test' });
+    expect(receipt.receipt).toBe('SCBE_WORKSPACE_READY=1');
+    for (const folder of WORKSPACE_FORMATION.folders) {
+      expect(fs.existsSync(path.join(receipt.workspace_root, folder.path))).toBe(true);
+    }
+  });
+
+  it('writes a Zod-valid workspace.json receipt', () => {
+    const receipt = createAgentWorkspace({ root: tmpBase });
+    const raw = JSON.parse(fs.readFileSync(receipt.receipt_path, 'utf8'));
+    const parsed = parseReceipt(raw, AgentWorkspaceReceiptSchema, 'workspace.json');
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.data.workspace_id).toBe(receipt.workspace_id);
+  });
+
+  it('produces unique workspace_id per call', () => {
+    const a = createAgentWorkspace({ root: tmpBase, hint: 'a' });
+    const b = createAgentWorkspace({ root: tmpBase, hint: 'b' });
+    expect(a.workspace_id).not.toBe(b.workspace_id);
+  });
+});
+
+// ─── ingestIntoAgentWorkspace ─────────────────────────────────────────────────
+
+describe('ingestIntoAgentWorkspace', () => {
+  it('copies file into 00_inbox with matching hashes', () => {
+    const ws = createAgentWorkspace({ root: tmpBase, hint: 'ingest' });
+    const src = writeTmp('payload.txt', 'hello agent bus');
+    const receipt = ingestIntoAgentWorkspace({ workspaceRoot: ws.workspace_root, sourcePath: src });
+
+    expect(receipt.receipt).toBe('SCBE_WORKSPACE_INGEST=1');
+    expect(receipt.source_sha256).toBe(receipt.destination_sha256);
+    expect(fs.existsSync(receipt.destination_path)).toBe(true);
+  });
+
+  it('persists a Zod-valid ingest receipt under 20_receipts', () => {
+    const ws = createAgentWorkspace({ root: tmpBase, hint: 'ingest' });
+    const src = writeTmp('data.bin', crypto.randomBytes(128).toString('hex'));
+    const receipt = ingestIntoAgentWorkspace({ workspaceRoot: ws.workspace_root, sourcePath: src });
+
+    const raw = JSON.parse(fs.readFileSync(receipt.receipt_path, 'utf8'));
+    const parsed = parseReceipt(raw, AgentWorkspaceIngestReceiptSchema, 'ingest receipt');
+    expect(parsed.ok).toBe(true);
+  });
+
+  it('rename option changes inbox filename', () => {
+    const ws = createAgentWorkspace({ root: tmpBase });
+    const src = writeTmp('original.txt', 'content');
+    const receipt = ingestIntoAgentWorkspace({
+      workspaceRoot: ws.workspace_root,
+      sourcePath: src,
+      rename: 'aliased.txt',
+    });
+    expect(receipt.destination_rel).toBe('00_inbox/aliased.txt');
+  });
+});
+
+// ─── exportAgentWorkspaceAsync + verifyAgentWorkspaceExportAsync ──────────────
+
+describe('exportAgentWorkspaceAsync + verifyAgentWorkspaceExportAsync', () => {
+  it('exports a Zod-valid manifest and export receipt', async () => {
+    const ws = createAgentWorkspace({ root: tmpBase, hint: 'export' });
+    const src = writeTmp('report.txt', 'governance report');
+    ingestIntoAgentWorkspace({ workspaceRoot: ws.workspace_root, sourcePath: src });
+
+    const exportReceipt = await exportAgentWorkspaceAsync({ workspaceRoot: ws.workspace_root });
+
+    // Validate the export receipt schema
+    const receiptParsed = parseReceipt(exportReceipt, AgentWorkspaceExportReceiptSchema, 'export');
+    expect(receiptParsed.ok).toBe(true);
+
+    // Validate the manifest on disk
+    const manifestRaw = JSON.parse(fs.readFileSync(exportReceipt.manifest_path, 'utf8'));
+    const manifestParsed = parseReceipt(manifestRaw, WorkspaceExportManifestSchema, 'manifest');
+    expect(manifestParsed.ok).toBe(true);
+  });
+
+  it('clean workspace verifies PASS', async () => {
+    const ws = createAgentWorkspace({ root: tmpBase, hint: 'verify' });
+    const src = writeTmp('clean.txt', 'clean content');
+    ingestIntoAgentWorkspace({ workspaceRoot: ws.workspace_root, sourcePath: src });
+
+    const exportReceipt = await exportAgentWorkspaceAsync({ workspaceRoot: ws.workspace_root });
+    const verifyReceipt = await verifyAgentWorkspaceExportAsync({
+      exportPath: exportReceipt.export_path,
+      persistReceipt: false,
+    });
+
+    expect(verifyReceipt.receipt).toBe('SCBE_WORKSPACE_VERIFY_PASS=1');
+    expect(verifyReceipt.mismatches).toHaveLength(0);
+
+    // Verify the verify receipt is itself Zod-valid
+    const verifyParsed = parseReceipt(
+      verifyReceipt,
+      AgentWorkspaceVerifyReceiptSchema,
+      'verify receipt'
+    );
+    expect(verifyParsed.ok).toBe(true);
+  });
+
+  it('detects tampered file — FAIL with sha256_mismatch', async () => {
+    const ws = createAgentWorkspace({ root: tmpBase, hint: 'tamper' });
+    const src = writeTmp('secret.txt', 'original content');
+    ingestIntoAgentWorkspace({ workspaceRoot: ws.workspace_root, sourcePath: src });
+
+    const exportReceipt = await exportAgentWorkspaceAsync({ workspaceRoot: ws.workspace_root });
+    fs.writeFileSync(
+      path.join(exportReceipt.export_path, '00_inbox', 'secret.txt'),
+      'tampered',
+      'utf8'
+    );
+
+    const verifyReceipt = await verifyAgentWorkspaceExportAsync({
+      exportPath: exportReceipt.export_path,
+      persistReceipt: false,
+    });
+    expect(verifyReceipt.receipt).toBe('SCBE_WORKSPACE_VERIFY_PASS=0');
+    const mm = verifyReceipt.mismatches.find((m) => m.path.includes('secret.txt'));
+    expect(mm?.reason).toBe('sha256_mismatch');
+  });
+
+  it('detects injected extra file — FAIL with extra_file', async () => {
+    const ws = createAgentWorkspace({ root: tmpBase, hint: 'inject' });
+    fs.writeFileSync(path.join(ws.workspace_root, '10_work', 'work.txt'), 'work');
+
+    const exportReceipt = await exportAgentWorkspaceAsync({ workspaceRoot: ws.workspace_root });
+    fs.writeFileSync(path.join(exportReceipt.export_path, '10_work', 'injected.txt'), 'evil');
+
+    const verifyReceipt = await verifyAgentWorkspaceExportAsync({
+      exportPath: exportReceipt.export_path,
+      persistReceipt: false,
+    });
+    expect(verifyReceipt.receipt).toBe('SCBE_WORKSPACE_VERIFY_PASS=0');
+    expect(verifyReceipt.mismatches.some((m) => m.reason === 'extra_file')).toBe(true);
+  });
+
+  it('byte counts match between export and verify receipts', async () => {
+    const ws = createAgentWorkspace({ root: tmpBase, hint: 'bytes' });
+    const src = writeTmp('large.txt', 'x'.repeat(4096));
+    ingestIntoAgentWorkspace({ workspaceRoot: ws.workspace_root, sourcePath: src });
+
+    const exportReceipt = await exportAgentWorkspaceAsync({ workspaceRoot: ws.workspace_root });
+    const verifyReceipt = await verifyAgentWorkspaceExportAsync({
+      exportPath: exportReceipt.export_path,
+      persistReceipt: false,
+    });
+    expect(verifyReceipt.total_bytes_claimed).toBe(verifyReceipt.total_bytes_actual);
+  });
+});
+
+// ─── Zod schema boundary validation ──────────────────────────────────────────
+
+describe('Zod parseReceipt boundary helper', () => {
+  it('returns ok:false with error summary for invalid manifest', () => {
+    const bad = { schema_version: 'wrong', files: 'not-an-array' };
+    const result = parseReceipt(bad, WorkspaceExportManifestSchema, 'test manifest');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('test manifest');
+    }
+  });
+
+  it('catches corrupted sha256 field', () => {
+    // Pure schema validation — no real export needed.
+    const badEntry = { path: '00_inbox/x.txt', sha256: 'not-a-hex-string', bytes: 5 };
+    const result = parseReceipt(
+      {
+        schema_version: 'aethermoor.bus.workspace_export_manifest.v1',
+        export_id: 'x',
+        workspace_id: 'ws',
+        workspace_root: '/tmp/ws',
+        created_at: new Date().toISOString(),
+        included_folders: [],
+        excluded_folders: [],
+        file_count: 1,
+        total_bytes: 5,
+        files: [badEntry],
+      },
+      WorkspaceExportManifestSchema,
+      'bad manifest'
+    );
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ─── lineageAgentWorkspace ────────────────────────────────────────────────────
+
+describe('lineageAgentWorkspace', () => {
+  it('reflects the full create→ingest→export→verify cycle', async () => {
+    const ws = createAgentWorkspace({ root: tmpBase, hint: 'lineage' });
+    const src = writeTmp('artifact.txt', 'lineage content');
+    ingestIntoAgentWorkspace({ workspaceRoot: ws.workspace_root, sourcePath: src });
+
+    const exportReceipt = await exportAgentWorkspaceAsync({ workspaceRoot: ws.workspace_root });
+    await verifyAgentWorkspaceExportAsync({
+      exportPath: exportReceipt.export_path,
+      persistReceipt: true,
+    });
+
+    const lineage = lineageAgentWorkspace({ workspaceRoot: ws.workspace_root });
+    expect(lineage.workspace_id).toBe(ws.workspace_id);
+    expect(lineage.export_count).toBeGreaterThanOrEqual(1);
+    expect(lineage.verify_count).toBeGreaterThanOrEqual(1);
+    const exportEntry = lineage.entries.find(
+      (e) => e.kind === 'export' && e.export_id === exportReceipt.export_id
+    );
+    expect(exportEntry).toBeDefined();
+  });
+});

--- a/tests/system/test_geoseal_llm_verify.py
+++ b/tests/system/test_geoseal_llm_verify.py
@@ -1,0 +1,267 @@
+"""Tests for scripts/system/geoseal_llm_verify.py.
+
+All tests use --dry-run mode so no real API keys are needed.
+Covers: provider filtering, phase execution, quorum reduction, receipt schema,
+CLI exit codes, and interlocked Phase 2 prompt construction.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure script is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+from scripts.system.geoseal_llm_verify import (
+    PROVIDERS,
+    ProviderSpec,
+    ProviderVerdict,
+    VerifyReceipt,
+    _build_focused_messages,
+    _build_triage_messages,
+    _parse_verdict,
+    _reduce_quorum,
+    verify_async,
+)
+
+# ─── Sample record ────────────────────────────────────────────────────────────
+
+SAMPLE_RECORD = {
+    "op": "add",
+    "tongue": "KO",
+    "language": "python",
+    "output": "def add(a, b):\n    return a + b",
+    "seal": {"phase": 0.0, "trust": 0.97},
+}
+
+# ─── Provider registry ────────────────────────────────────────────────────────
+
+def test_providers_have_required_fields() -> None:
+    for p in PROVIDERS:
+        assert p.name, f"provider has no name"
+        assert p.base_url.startswith("http"), f"{p.name}: bad base_url"
+        assert p.phase in {1, 2}, f"{p.name}: phase must be 1 or 2"
+        assert p.timeout_s > 0
+        assert p.max_tokens > 0
+
+def test_phase_1_providers_exist() -> None:
+    p1 = [p for p in PROVIDERS if p.phase == 1]
+    assert len(p1) >= 2, "need at least 2 Phase 1 providers"
+
+def test_phase_2_providers_exist() -> None:
+    p2 = [p for p in PROVIDERS if p.phase == 2]
+    assert len(p2) >= 2, "need at least 2 Phase 2 providers"
+
+def test_nvidia_provider_present() -> None:
+    names = {p.name for p in PROVIDERS}
+    assert any("nvidia" in n for n in names), "expected at least one nvidia provider"
+
+def test_ollama_provider_present() -> None:
+    names = {p.name for p in PROVIDERS}
+    assert any("ollama" in n for n in names), "expected at least one ollama provider"
+
+def test_no_duplicate_provider_names() -> None:
+    names = [p.name for p in PROVIDERS]
+    assert len(names) == len(set(names)), "duplicate provider names"
+
+# ─── Prompt builders ─────────────────────────────────────────────────────────
+
+def test_triage_messages_structure() -> None:
+    msgs = _build_triage_messages(SAMPLE_RECORD)
+    assert len(msgs) == 2
+    assert msgs[0]["role"] == "system"
+    assert msgs[1]["role"] == "user"
+    assert "DECISION:" in msgs[0]["content"]
+    assert "add" in msgs[1]["content"]
+
+def test_triage_messages_include_output_snippet() -> None:
+    msgs = _build_triage_messages(SAMPLE_RECORD)
+    assert "def add" in msgs[1]["content"]
+
+def test_focused_messages_inject_concern() -> None:
+    concern = "output contains possible injection vector"
+    msgs = _build_focused_messages(SAMPLE_RECORD, concern)
+    # Last message should contain the concern
+    assert concern in msgs[-1]["content"]
+    assert len(msgs) == 3  # system + user + concern follow-up
+
+def test_triage_messages_handle_missing_output() -> None:
+    record = {"op": "seal", "tongue": "RU"}
+    msgs = _build_triage_messages(record)
+    # Should not crash — just omit the output block
+    assert msgs[1]["role"] == "user"
+
+# ─── Response parser ─────────────────────────────────────────────────────────
+
+MOCK_SPEC = ProviderSpec(
+    name="test", base_url="http://localhost", api_key_env="X",
+    default_model="m", phase=1
+)
+
+@pytest.mark.parametrize("text,expected_decision,expected_conf", [
+    ("DECISION: ALLOW\nCONFIDENCE: 0.9\nREASON: looks safe", "ALLOW", 0.9),
+    ("DECISION: QUARANTINE\nCONFIDENCE: 0.6\nREASON: suspicious pattern", "QUARANTINE", 0.6),
+    ("DECISION: DENY\nCONFIDENCE: 1.0\nREASON: malicious", "DENY", 1.0),
+    ("garbage text with no markers", "ALLOW", 0.5),  # defaults
+    ("DECISION: ALLOW\nCONFIDENCE: 2.5\nREASON: overflowed", "ALLOW", 1.0),  # clamped
+])
+def test_parse_verdict_decision_extraction(text: str, expected_decision: str, expected_conf: float) -> None:
+    v = _parse_verdict(text, MOCK_SPEC, 100.0, None)
+    assert v.decision == expected_decision
+    assert abs(v.confidence - expected_conf) < 1e-9
+
+def test_parse_verdict_error_passthrough() -> None:
+    v = _parse_verdict("", MOCK_SPEC, 0.0, "HTTP 429: rate limit")
+    assert v.decision == "ERROR"
+    assert v.error == "HTTP 429: rate limit"
+    assert v.confidence == 0.0
+
+def test_parse_verdict_case_insensitive_decision() -> None:
+    v = _parse_verdict("DECISION: allow\nCONFIDENCE: 0.8\nREASON: ok", MOCK_SPEC, 50.0, None)
+    # Parser uppercases before checking — should parse correctly
+    assert v.decision == "ALLOW"
+
+# ─── Quorum reducer ───────────────────────────────────────────────────────────
+
+def _make_verdict(decision: str, confidence: float, phase: int = 1) -> ProviderVerdict:
+    return ProviderVerdict(
+        provider="test", model="m", phase=phase,
+        decision=decision, confidence=confidence,
+        rationale="test", latency_ms=100.0, raw_response="",
+    )
+
+def test_reduce_quorum_unanimous_allow() -> None:
+    verdicts = [_make_verdict("ALLOW", 0.9) for _ in range(3)]
+    decision, conf, support = _reduce_quorum(verdicts)
+    assert decision == "ALLOW"
+    assert conf > 0.8
+    assert support["ALLOW"] == 3
+
+def test_reduce_quorum_unanimous_deny() -> None:
+    verdicts = [_make_verdict("DENY", 0.95) for _ in range(3)]
+    decision, _, support = _reduce_quorum(verdicts)
+    assert decision == "DENY"
+    assert support["DENY"] == 3
+
+def test_reduce_quorum_phase2_weight() -> None:
+    # 1 DENY at phase 2 (1.5× weight) vs 2 ALLOWs at phase 1
+    p1_allow = _make_verdict("ALLOW", 0.7, phase=1)
+    p2_deny = _make_verdict("DENY", 1.0, phase=2)
+    decision, conf, _ = _reduce_quorum([p1_allow, p1_allow, p2_deny])
+    # 2×0.7 = 1.4 ALLOW weight, 1.0×1.5 = 1.5 DENY weight → DENY wins
+    assert decision == "DENY"
+
+def test_reduce_quorum_errors_excluded_from_weight() -> None:
+    errors = [_make_verdict("ERROR", 0.0) for _ in range(5)]
+    one_allow = _make_verdict("ALLOW", 0.8)
+    decision, _, support = _reduce_quorum(errors + [one_allow])
+    assert decision == "ALLOW"
+    assert support["ERROR"] == 5
+
+def test_reduce_quorum_all_errors() -> None:
+    errors = [_make_verdict("ERROR", 0.0) for _ in range(3)]
+    decision, conf, _ = _reduce_quorum(errors)
+    assert decision == "UNKNOWN"
+    assert conf == 0.0
+
+# ─── Async verify (dry-run) ───────────────────────────────────────────────────
+
+def test_verify_dry_run_produces_receipt() -> None:
+    receipt = asyncio.run(verify_async(SAMPLE_RECORD, dry_run=True))
+    assert isinstance(receipt, VerifyReceipt)
+    assert receipt.schema_version == "scbe.geoseal.verify.v1"
+    assert receipt.record_sha256 != ""
+    assert receipt.quorum_decision in {"ALLOW", "QUARANTINE", "DENY", "UNKNOWN"}
+    assert receipt.receipt.startswith("SCBE_GEOSEAL_VERIFY=")
+
+def test_verify_dry_run_both_phases() -> None:
+    receipt = asyncio.run(verify_async(SAMPLE_RECORD, dry_run=True, max_phase=2))
+    assert len(receipt.phase_1_verdicts) >= 1
+    assert len(receipt.phase_2_verdicts) >= 1
+
+def test_verify_dry_run_phase1_only() -> None:
+    receipt = asyncio.run(verify_async(SAMPLE_RECORD, dry_run=True, max_phase=1))
+    assert len(receipt.phase_1_verdicts) >= 1
+    assert receipt.phase_2_verdicts == []
+
+def test_verify_dry_run_provider_filter() -> None:
+    receipt = asyncio.run(
+        verify_async(SAMPLE_RECORD, dry_run=True, providers=["cerebras"])
+    )
+    assert receipt.provider_count == 1
+
+def test_verify_dry_run_receipt_is_pass_on_allow() -> None:
+    # Dry-run mock returns ALLOW — verify the receipt code reflects this
+    receipt = asyncio.run(verify_async(SAMPLE_RECORD, dry_run=True))
+    if receipt.quorum_decision == "ALLOW":
+        assert receipt.receipt == "SCBE_GEOSEAL_VERIFY=1"
+    else:
+        assert receipt.receipt == "SCBE_GEOSEAL_VERIFY=0"
+
+def test_verify_dry_run_total_latency_recorded() -> None:
+    receipt = asyncio.run(verify_async(SAMPLE_RECORD, dry_run=True))
+    assert receipt.total_latency_ms > 0
+
+def test_verify_no_providers_returns_gracefully() -> None:
+    # Pass a provider name that doesn't exist → active list empty
+    receipt = asyncio.run(
+        verify_async(SAMPLE_RECORD, dry_run=False, providers=["nonexistent"])
+    )
+    assert receipt.quorum_decision == "NO_PROVIDERS"
+    assert receipt.receipt == "SCBE_GEOSEAL_VERIFY=0"
+
+def test_verify_record_sha256_is_deterministic() -> None:
+    r1 = asyncio.run(verify_async(SAMPLE_RECORD, dry_run=True))
+    r2 = asyncio.run(verify_async(SAMPLE_RECORD, dry_run=True))
+    assert r1.record_sha256 == r2.record_sha256
+
+def test_verify_receipt_serializable_to_json() -> None:
+    from dataclasses import asdict
+    receipt = asyncio.run(verify_async(SAMPLE_RECORD, dry_run=True))
+    d = asdict(receipt)
+    # Must be JSON-serializable
+    json.dumps(d)
+
+# ─── CLI smoke (dry-run) ──────────────────────────────────────────────────────
+
+def test_cli_json_flag_dry_run(tmp_path: Path, capsys) -> None:
+    import subprocess
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/system/geoseal_llm_verify.py",
+            "--json", json.dumps(SAMPLE_RECORD),
+            "--dry-run",
+            "--quiet",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).resolve().parent.parent.parent),
+    )
+    # Exit 0 = ALLOW quorum, exit 1 = DENY/UNKNOWN (both valid in dry-run)
+    assert result.returncode in {0, 1}
+    out = json.loads(result.stdout)
+    assert out["schema_version"] == "scbe.geoseal.verify.v1"
+
+def test_cli_out_flag_writes_file(tmp_path: Path) -> None:
+    import subprocess
+    out_path = tmp_path / "receipt.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/system/geoseal_llm_verify.py",
+            "--json", json.dumps(SAMPLE_RECORD),
+            "--dry-run",
+            "--quiet",
+            "--out", str(out_path),
+        ],
+        capture_output=True,
+        cwd=str(Path(__file__).resolve().parent.parent.parent),
+    )
+    assert out_path.exists()
+    d = json.loads(out_path.read_text())
+    assert "quorum_decision" in d


### PR DESCRIPTION
## Summary

Adds `scripts/system/geoseal_llm_verify.py` — a concurrent multi-LLM verification harness that fans GeoSeal CLI outputs to many tiny/free cloud and local models simultaneously.

### Architecture

Three interlocked phases:

| Phase | Models | Concurrent | ~Latency |
|---|---|---|---|
| 1 — Fast Triage | Cerebras Scout-17B, Groq Llama-8B, NVIDIA Llama-3.2-3B, Ollama | Yes | ~1s |
| 2 — Focused Review | Groq Gemma-9B, NVIDIA Phi-3-mini, NVIDIA Gemma-2-2B, Together-3B, Fireworks-3B, OpenRouter-3B, Ollama-phi | Yes (interlocked: uses Phase 1 concern) | ~3s |
| 3 — Synthesis | Weighted quorum (Phase 2 = 1.5× weight) → receipt | Sequential | ~0.1s |

**Interlocked**: Phase 2 prompt is constructed from Phase 1 flagged concerns — Phase 2 models are asked to confirm or reject the specific concern, not just re-evaluate from scratch.

**Independent streams**: each provider call is isolated. Provider failure never blocks others.

### Provider coverage (all free/local)

- **NVIDIA NIM**: 3 models (Llama-3.2-3B, Phi-3-mini, Gemma-2-2B) — free tier via `NVIDIA_API_KEY`
- **Ollama**: 2 local streams (llama3.2:3b + phi3:mini) — no API key, auto-detected from `http://localhost`
- **Cerebras / Groq**: existing keys
- **Together / Fireworks / OpenRouter**: plug in when keys are available

### Usage

```bash
# Verify last geoseal call (keys auto-detected from env)
python -m scripts.system.geoseal_llm_verify --last

# Dry-run (no API calls, useful for CI)
python -m scripts.system.geoseal_llm_verify --last --dry-run

# Phase 1 only (fast triage, ~1s)
python -m scripts.system.geoseal_llm_verify --last --phase 1

# Specific providers
python -m scripts.system.geoseal_llm_verify --last --providers cerebras,groq-8b,nvidia-llama3b

# Inline JSON
python -m scripts.system.geoseal_llm_verify --json '{"op":"add","tongue":"KO","output":"def add(a,b): return a+b"}'
```

## Test plan

- [ ] 33 tests pass: `pytest tests/system/test_geoseal_llm_verify.py -v`
- [ ] Dry-run produces valid JSON receipt
- [ ] `--phase 1` skips Phase 2 verdicts
- [ ] Provider filter works (single provider)
- [ ] No-providers case exits gracefully (`NO_PROVIDERS`)
- [ ] Phase 2 weight advantage verified (DENY at phase 2 beats 2× ALLOW at phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added async workspace export/verification with streaming file hashing for improved performance on large workspaces.
  * Introduced GeoSeal governance verification system with multi-provider LLM consensus voting.
  * Enabled automated code formatting checks and auto-fixing in CI/CD pipeline.

* **Bug Fixes**
  * Workspace manifest validation now properly validates structure against schema.

* **Tests**
  * Added comprehensive workspace lifecycle and schema validation tests.
  * Added GeoSeal verification test suite.

* **Chores**
  * Enhanced CI/CD workflows with format checking and linting.
  * Added branch protection documentation and code ownership assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->