### PR TITLE
feat(benchmarks): add local writing score lane

### DIFF
--- a/config/eval/aether_writing_score.v1.json
+++ b/config/eval/aether_writing_score.v1.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "aether_writing_score_v1",
+  "purpose": "Local/free writing benchmark for AI-assisted product, editing, fiction, and governance writing. This is a usability and constraint-following score, not a claim of literary quality.",
+  "policy": {
+    "default_provider": "ollama_local",
+    "hosted_api_allowed": false,
+    "judge": "deterministic_checks"
+  },
+  "tasks": [
+    {
+      "task_id": "free_local_product_note",
+      "title": "Free/local product framing",
+      "prompt": "Write a concise product-management note for SCBE. Use exactly these Markdown headings, in this order: Problem, System, Next Step. Explain that the service should work with free/local AI, no API by default, and receipts for proof. Keep it practical for a non-coder. Length: 120-220 words. Do not use these words: revolutionary, magic, guaranteed.",
+      "min_words": 120,
+      "max_words": 220,
+      "required_terms": ["free/local", "no API", "receipt"],
+      "required_headings": ["Problem", "System", "Next Step"],
+      "forbidden_terms": ["revolutionary", "magic", "guaranteed"]
+    },
+    {
+      "task_id": "typo_repair_with_ledger",
+      "title": "Typo repair with change ledger",
+      "prompt": "Correct this text while preserving the original meaning: \"we need teh ai to write stuff but not lie abotu what it did and keep teh old words in a log.\" Return exactly two sections: Corrected: and Ledger:. The Ledger section must be a JSON array of objects with old, new, and reason fields. Length: 80-180 words.",
+      "min_words": 80,
+      "max_words": 180,
+      "required_terms": ["original meaning"],
+      "required_line_prefixes": ["Corrected:", "Ledger:"],
+      "required_json_array_fields": ["old", "new", "reason"]
+    },
+    {
+      "task_id": "fact_retention_long_context",
+      "title": "Long-context fact retention",
+      "prompt": "Write one coherent status update that preserves every numbered fact below. Mention each fact ID exactly once: F01 local-first, F02 no hosted API by default, F03 Ollama allowed, F04 receipts required, F05 user cannot code, F06 commands must be simple, F07 failed runs create repair tasks, F08 passes get quality upgrades, F09 YouTube videos need end checks, F10 transcripts matter, F11 benchmark claims need evidence, F12 unpaid routes come first. Length: 180-280 words.",
+      "min_words": 180,
+      "max_words": 280,
+      "required_terms": ["F01", "F02", "F03", "F04", "F05", "F06", "F07", "F08", "F09", "F10", "F11", "F12"],
+      "exactly_once_terms": ["F01", "F02", "F03", "F04", "F05", "F06", "F07", "F08", "F09", "F10", "F11", "F12"]
+    },
+    {
+      "task_id": "constrained_story_scene",
+      "title": "Constrained fiction scene",
+      "prompt": "Write a short fiction scene, not a summary. Requirements: 220-360 words, at least one line of dialogue, and include these exact words: rain, terminal, bell, ledger, shore. The scene should feel human and grounded. Do not mention AI, model, prompt, or benchmark.",
+      "min_words": 220,
+      "max_words": 360,
+      "required_terms": ["rain", "terminal", "bell", "ledger", "shore"],
+      "forbidden_terms": ["AI", "model", "prompt", "benchmark"],
+      "requires_dialogue": true
+    },
+    {
+      "task_id": "safety_case_explainer",
+      "title": "Safety case explainer",
+      "prompt": "Explain why constraints are the safety case for an embodied or agentic system. Write for a practical builder, not a philosopher. Include simulation, closed environment, audit log, free/local, and liability. Length: 150-260 words. Do not claim the system is perfect.",
+      "min_words": 150,
+      "max_words": 260,
+      "required_terms": ["simulation", "closed environment", "audit log", "free/local", "liability"],
+      "forbidden_terms": ["perfect"]
+    }
+  ]
+}

--- a/docs/benchmarks/AETHER_WRITING_SCORE_100.md
+++ b/docs/benchmarks/AETHER_WRITING_SCORE_100.md
@@ -1,0 +1,65 @@
+# Aether Writing Score 100
+
+Status: v1 local/free benchmark lane.
+
+This benchmark tests whether a local AI writing route can follow practical writing constraints for product, editing, fiction, and governance copy. It is not a literary-quality leaderboard. It is a usability score: can the system produce text that obeys the requested structure, preserves required facts, avoids banned terms, and leaves evidence?
+
+## Policy
+
+- Provider path: local Ollama only.
+- Hosted API usage: none.
+- Judge: deterministic checks, not a paid LLM judge.
+- Output artifact: `artifacts/benchmarks/aether_writing_score/writing_benchmark_20260523T231225Z.json`.
+
+## Task Set
+
+| Task | What It Tests |
+| --- | --- |
+| `free_local_product_note` | Product framing with exact headings, free/local policy, and no-hype terms |
+| `typo_repair_with_ledger` | Human typo correction plus JSON change ledger |
+| `fact_retention_long_context` | Long-context retention of twelve required fact IDs |
+| `constrained_story_scene` | Fiction scene constraints, sensory nouns, dialogue, and forbidden-topic avoidance |
+| `safety_case_explainer` | Practical safety/liability explanation with required terms |
+
+## 2026-05-23 Local Run
+
+Command:
+
+```powershell
+python scripts\benchmark\local_writing_benchmark.py --models qwen2.5:7b-instruct,openclaw:latest,qwen2.5-coder:1.5b,scbe-geoseal-coder:q8 --timeout 90 --num-predict 360
+```
+
+Results:
+
+| Rank | Model | Score | Pass Rate | Passed Tasks | Runtime |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 1 | `openclaw:latest` | 88.52 | 100% | 5/5 | 30.762s |
+| 2 | `qwen2.5-coder:1.5b` | 80.92 | 80% | 4/5 | 28.341s |
+| 3 | `scbe-geoseal-coder:q8` | 73.85 | 60% | 3/5 | 18.101s |
+| 4 | `qwen2.5:7b-instruct` | 0.00 | 0% | 0/5 | 21.484s |
+
+## Caveats
+
+`qwen2.5:7b-instruct` returned Ollama HTTP 500 on all five tasks. Treat that as a local runtime/model-load failure, not proof that the model cannot write.
+
+The v1 score is intentionally mechanical. It can catch missing facts, wrong section shape, forbidden words, bad JSON ledgers, and word-count failures. It cannot yet measure prose taste, emotional effect, or whether a reader would buy the product.
+
+Several passed outputs still had partial misses. For example, `openclaw:latest` won but missed exact terms like `no API`, `bell`, and `simulation` on individual tasks. That means it is usable, not finished.
+
+## Readiness Score
+
+Current local/free writing route readiness: 76/100.
+
+Reasoning:
+
+- Best local model clears the benchmark at 88.52/100.
+- The model pool average is pulled down by one runtime-failing model.
+- Ledger-writing and exact-policy wording are still brittle.
+- The benchmark is now repeatable and artifact-backed.
+
+## Next Repairs
+
+1. Add a preflight that tests each Ollama model with a one-token call before benchmark runs. Runtime-failing models should be marked `unavailable`, not mixed into writing-quality averages.
+2. Add a repair loop for failed tasks: rerun only the missed task with the failed checks injected as constraints.
+3. Add a human-review column for style quality after deterministic checks pass.
+4. Add transcript/video task variants so the same writing benchmark can score YouTube endings, descriptions, captions, and CTA treatment.

--- a/scripts/benchmark/local_writing_benchmark.py
+++ b/scripts/benchmark/local_writing_benchmark.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Run a local/free writing benchmark against Ollama models.
+
+This harness intentionally avoids hosted APIs. It compares locally installed
+Ollama models on deterministic writing constraints and saves a JSON receipt.
+The score is useful for usability and instruction-following triage; it is not
+an automated literary-quality judgment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = REPO_ROOT / "config" / "eval" / "aether_writing_score.v1.json"
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "artifacts" / "benchmarks" / "aether_writing_score"
+DEFAULT_LOCAL_MODELS = (
+    "qwen2.5:7b-instruct",
+    "openclaw:latest",
+    "qwen2.5-coder:1.5b",
+    "scbe-geoseal-coder:q8",
+)
+
+WORD_RE = re.compile(r"\b[\w'-]+\b", re.UNICODE)
+
+
+@dataclass
+class TaskScore:
+    task_id: str
+    title: str
+    score: float
+    passed: bool
+    word_count: int
+    latency_s: float
+    checks: dict[str, Any]
+    output: str
+    error: str | None = None
+
+
+@dataclass
+class ModelScore:
+    model: str
+    score: float
+    pass_rate: float
+    passed_tasks: int
+    total_tasks: int
+    total_latency_s: float
+    tasks: list[TaskScore]
+
+
+def load_config(path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def list_downloaded_ollama_models() -> set[str]:
+    try:
+        proc = subprocess.run(["ollama", "list"], capture_output=True, text=True, timeout=20, check=False)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return set()
+    models: set[str] = set()
+    for line in proc.stdout.splitlines()[1:]:
+        parts = line.split()
+        if parts:
+            name = parts[0].strip()
+            if name and ":cloud" not in name:
+                models.add(name)
+    return models
+
+
+def select_models(requested: list[str] | None) -> list[str]:
+    downloaded = list_downloaded_ollama_models()
+    candidates = requested or list(DEFAULT_LOCAL_MODELS)
+    return [model for model in candidates if model in downloaded and ":cloud" not in model]
+
+
+def call_ollama(
+    model: str,
+    prompt: str,
+    *,
+    timeout_s: int = 120,
+    num_predict: int = 420,
+    temperature: float = 0.2,
+) -> tuple[str, str | None, float]:
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+        "options": {
+            "num_predict": num_predict,
+            "temperature": temperature,
+            "top_p": 0.9,
+        },
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        "http://localhost:11434/api/generate",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    started = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+        return str(body.get("response", "")).strip(), None, time.monotonic() - started
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        return "", f"{type(exc).__name__}: {exc}", time.monotonic() - started
+
+
+def word_count(text: str) -> int:
+    return len(WORD_RE.findall(text))
+
+
+def _contains_term(text: str, term: str) -> bool:
+    if term.isupper() and len(term) <= 4:
+        return term in text
+    return term.casefold() in text.casefold()
+
+
+def _line_prefix_present(text: str, prefix: str) -> bool:
+    return any(line.strip().startswith(prefix) for line in text.splitlines())
+
+
+def _heading_present(text: str, heading: str) -> bool:
+    markers = {heading, f"# {heading}", f"## {heading}", f"### {heading}", f"**{heading}**"}
+    return any(line.strip().rstrip(":") in markers for line in text.splitlines())
+
+
+def _extract_json_array(text: str) -> Any:
+    fenced = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, re.IGNORECASE | re.DOTALL)
+    if fenced:
+        return json.loads(fenced.group(1))
+    start = text.find("[")
+    end = text.rfind("]")
+    if start >= 0 and end > start:
+        return json.loads(text[start : end + 1])
+    raise ValueError("no JSON array found")
+
+
+def score_output(task: dict[str, Any], output: str, latency_s: float, error: str | None = None) -> TaskScore:
+    checks: dict[str, Any] = {}
+    if error:
+        return TaskScore(
+            task_id=task["task_id"],
+            title=task["title"],
+            score=0.0,
+            passed=False,
+            word_count=0,
+            latency_s=round(latency_s, 3),
+            checks={"runtime_error": error},
+            output=output,
+            error=error,
+        )
+
+    wc = word_count(output)
+    min_words = int(task.get("min_words", 0))
+    max_words = int(task.get("max_words", 10**9))
+    checks["word_count"] = {"value": wc, "min": min_words, "max": max_words, "pass": min_words <= wc <= max_words}
+
+    required_terms = list(task.get("required_terms", []))
+    checks["required_terms"] = {term: _contains_term(output, term) for term in required_terms}
+
+    forbidden_terms = list(task.get("forbidden_terms", []))
+    checks["forbidden_terms_absent"] = {term: not _contains_term(output, term) for term in forbidden_terms}
+
+    required_headings = list(task.get("required_headings", []))
+    if required_headings:
+        checks["required_headings"] = {heading: _heading_present(output, heading) for heading in required_headings}
+
+    required_line_prefixes = list(task.get("required_line_prefixes", []))
+    if required_line_prefixes:
+        checks["required_line_prefixes"] = {
+            prefix: _line_prefix_present(output, prefix) for prefix in required_line_prefixes
+        }
+
+    exactly_once_terms = list(task.get("exactly_once_terms", []))
+    if exactly_once_terms:
+        checks["exactly_once_terms"] = {term: output.count(term) == 1 for term in exactly_once_terms}
+
+    if task.get("requires_dialogue"):
+        checks["dialogue"] = bool(re.search(r'"[^"]+"|“[^”]+”', output))
+
+    json_fields = list(task.get("required_json_array_fields", []))
+    if json_fields:
+        try:
+            parsed = _extract_json_array(output)
+            valid = isinstance(parsed, list) and bool(parsed)
+            if valid:
+                valid = all(isinstance(item, dict) and all(field in item for field in json_fields) for item in parsed)
+            checks["json_array_fields"] = {
+                "pass": bool(valid),
+                "fields": json_fields,
+                "items": len(parsed) if isinstance(parsed, list) else 0,
+            }
+        except (ValueError, json.JSONDecodeError) as exc:
+            checks["json_array_fields"] = {"pass": False, "fields": json_fields, "error": str(exc)}
+
+    leaf_results: list[bool] = []
+    for value in checks.values():
+        if isinstance(value, bool):
+            leaf_results.append(value)
+        elif isinstance(value, dict) and "pass" in value:
+            leaf_results.append(bool(value["pass"]))
+        elif isinstance(value, dict):
+            leaf_results.extend(bool(v) for v in value.values() if isinstance(v, bool))
+
+    score = round((sum(leaf_results) / len(leaf_results) * 100.0) if leaf_results else 0.0, 2)
+    return TaskScore(
+        task_id=task["task_id"],
+        title=task["title"],
+        score=score,
+        passed=score >= 80.0,
+        word_count=wc,
+        latency_s=round(latency_s, 3),
+        checks=checks,
+        output=output,
+    )
+
+
+def run_benchmark(
+    *,
+    config_path: Path = DEFAULT_CONFIG,
+    models: list[str] | None = None,
+    timeout_s: int = 120,
+    num_predict: int = 420,
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+) -> dict[str, Any]:
+    config = load_config(config_path)
+    selected = select_models(models)
+    started_at = datetime.now(timezone.utc).isoformat()
+    model_scores: list[ModelScore] = []
+
+    for model in selected:
+        task_scores: list[TaskScore] = []
+        for task in config["tasks"]:
+            output, error, latency = call_ollama(
+                model,
+                task["prompt"],
+                timeout_s=timeout_s,
+                num_predict=num_predict,
+            )
+            task_scores.append(score_output(task, output, latency, error))
+        total = len(task_scores)
+        passed = sum(1 for task_score in task_scores if task_score.passed)
+        avg = round(sum(task_score.score for task_score in task_scores) / total, 2) if total else 0.0
+        model_scores.append(
+            ModelScore(
+                model=model,
+                score=avg,
+                pass_rate=round(passed / total, 3) if total else 0.0,
+                passed_tasks=passed,
+                total_tasks=total,
+                total_latency_s=round(sum(task_score.latency_s for task_score in task_scores), 3),
+                tasks=task_scores,
+            )
+        )
+
+    ranked = sorted(model_scores, key=lambda item: (item.score, item.pass_rate, -item.total_latency_s), reverse=True)
+    report = {
+        "schema_version": config["schema_version"],
+        "created_at": started_at,
+        "policy": config.get("policy", {}),
+        "config_path": str(config_path.relative_to(REPO_ROOT)),
+        "models_requested": models or list(DEFAULT_LOCAL_MODELS),
+        "models_run": [score.model for score in model_scores],
+        "ranking": [
+            {
+                "rank": index + 1,
+                "model": score.model,
+                "score": score.score,
+                "pass_rate": score.pass_rate,
+                "passed_tasks": score.passed_tasks,
+                "total_tasks": score.total_tasks,
+                "total_latency_s": score.total_latency_s,
+            }
+            for index, score in enumerate(ranked)
+        ],
+        "results": [asdict(score) for score in model_scores],
+    }
+
+    output_root.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_path = output_root / f"writing_benchmark_{stamp}.json"
+    out_path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    report["artifact_path"] = str(out_path.relative_to(REPO_ROOT))
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--models", help="comma-separated local Ollama model names")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--num-predict", type=int, default=420)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--json", action="store_true", help="print full JSON report")
+    args = parser.parse_args()
+
+    models = [item.strip() for item in args.models.split(",")] if args.models else None
+    report = run_benchmark(
+        config_path=args.config,
+        models=models,
+        timeout_s=args.timeout,
+        num_predict=args.num_predict,
+        output_root=args.out_dir,
+    )
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        return
+
+    print(f"Aether Writing Score v1 — {report['artifact_path']}")
+    print("Policy: local/free Ollama only; hosted_api_allowed=false")
+    if not report["models_run"]:
+        print("No downloaded local Ollama models matched the requested model list.")
+        return
+    for row in report["ranking"]:
+        print(
+            f"{row['rank']}. {row['model']}: {row['score']}/100 "
+            f"({row['passed_tasks']}/{row['total_tasks']} pass, {row['total_latency_s']}s)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/test_local_writing_benchmark.py
+++ b/tests/benchmark/test_local_writing_benchmark.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from scripts.benchmark.local_writing_benchmark import score_output, select_models
+
+
+def test_score_output_passes_constrained_product_note() -> None:
+    task = {
+        "task_id": "free_local_product_note",
+        "title": "Free/local product framing",
+        "min_words": 10,
+        "max_words": 80,
+        "required_terms": ["free/local", "no API", "receipt"],
+        "required_headings": ["Problem", "System", "Next Step"],
+        "forbidden_terms": ["magic"],
+    }
+    output = """## Problem
+People need simple tools.
+
+## System
+Use free/local AI, no API by default, and write a receipt for every run.
+
+## Next Step
+Run the local path first."""
+    result = score_output(task, output, 0.1)
+    assert result.passed
+    assert result.score == 100.0
+
+
+def test_score_output_catches_forbidden_and_missing_terms() -> None:
+    task = {
+        "task_id": "bad",
+        "title": "Bad",
+        "min_words": 1,
+        "max_words": 20,
+        "required_terms": ["receipt"],
+        "forbidden_terms": ["magic"],
+    }
+    result = score_output(task, "This is magic.", 0.1)
+    assert not result.passed
+    assert result.checks["required_terms"]["receipt"] is False
+    assert result.checks["forbidden_terms_absent"]["magic"] is False
+
+
+def test_score_output_validates_ledger_json_array() -> None:
+    task = {
+        "task_id": "ledger",
+        "title": "Ledger",
+        "min_words": 1,
+        "max_words": 80,
+        "required_line_prefixes": ["Corrected:", "Ledger:"],
+        "required_json_array_fields": ["old", "new", "reason"],
+    }
+    output = """Corrected: We need the AI to preserve meaning.
+
+Ledger:
+[
+  {"old": "teh", "new": "the", "reason": "spelling correction"}
+]"""
+    result = score_output(task, output, 0.1)
+    assert result.passed
+    assert result.checks["json_array_fields"]["pass"] is True
+
+
+def test_select_models_filters_cloud_entries(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "scripts.benchmark.local_writing_benchmark.list_downloaded_ollama_models",
+        lambda: {"local:1b", "remote:cloud"},
+    )
+    assert select_models(["local:1b", "remote:cloud", "missing:1b"]) == ["local:1b"]


### PR DESCRIPTION
## Summary
- Add Aether Writing Score v1: a local/free writing benchmark for product, editing, fiction, fact-retention, and safety-case writing tasks.
- Add an Ollama-only runner that excludes `*:cloud` models and uses deterministic scoring instead of a hosted judge.
- Add focused tests for scoring, JSON ledger validation, forbidden-term checks, and cloud-model filtering.
- Add a benchmark doc with the first local run results.

## Local benchmark result
Command:
`python scripts\benchmark\local_writing_benchmark.py --models qwen2.5:7b-instruct,openclaw:latest,qwen2.5-coder:1.5b,scbe-geoseal-coder:q8 --timeout 90 --num-predict 360`

Ranking:
1. `openclaw:latest` — 88.52/100, 5/5 pass, 30.762s
2. `qwen2.5-coder:1.5b` — 80.92/100, 4/5 pass, 28.341s
3. `scbe-geoseal-coder:q8` — 73.85/100, 3/5 pass, 18.101s
4. `qwen2.5:7b-instruct` — 0/100 due to Ollama HTTP 500 on all tasks

## Test evidence
- `python -m pytest tests\benchmark\test_local_writing_benchmark.py -q` — 4 passed
- `python -m black --check --line-length 120 scripts\benchmark\local_writing_benchmark.py tests\benchmark\test_local_writing_benchmark.py` — passed
- `python -m ruff check scripts\benchmark\local_writing_benchmark.py tests\benchmark\test_local_writing_benchmark.py` — passed

## Caveats
- This is a deterministic usability/constraint-following score, not a literary-quality leaderboard.
- Hosted/API providers are intentionally excluded.
- Runtime-failing local models should get a preflight classification in the next iteration so model-load failures do not distort writing-quality averages.

## Rollback
Revert commit `b134d0179`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Aether Writing Score—a new evaluation benchmark for assessing writing constraint adherence on locally-run models.
  * Added a local benchmarking tool that runs against Ollama models, scoring outputs based on word counts, required/forbidden terms, headings, and other structural constraints.

* **Documentation**
  * Added comprehensive benchmark documentation including methodology, task definitions, and baseline results across multiple models.

* **Tests**
  * Added test coverage for constraint validation and model filtering logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->