### PR TITLE
ci(agent-bus): align package workflows with Node 20

### DIFF
--- a/.github/workflows/agent-bus-auto-format.yml
+++ b/.github/workflows/agent-bus-auto-format.yml
@@ -17,11 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref || github.ref_name }}
           persist-credentials: true
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: npm install --ignore-scripts
       - name: Run Prettier
@@ -33,7 +34,7 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add -A
             git commit -m "chore(format): apply Prettier formatting [agent-bus]"
-            git push
+            git push origin HEAD:${{ github.head_ref || github.ref_name }}
           else
             echo "No formatting changes"
           fi

--- a/.github/workflows/agent-bus-auto-format.yml
+++ b/.github/workflows/agent-bus-auto-format.yml
@@ -3,7 +3,9 @@ name: agent-bus · Auto-format PR
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths: ["packages/agent-bus/**"]
+    paths:
+      - "packages/agent-bus/**"
+      - ".github/workflows/agent-bus-*.yml"
   workflow_dispatch: {}
 
 defaults:

--- a/.github/workflows/agent-bus-format-check.yml
+++ b/.github/workflows/agent-bus-format-check.yml
@@ -3,10 +3,14 @@ name: agent-bus · Format Check
 on:
   pull_request:
     branches: ["main", "master", "dev"]
-    paths: ["packages/agent-bus/**"]
+    paths:
+      - "packages/agent-bus/**"
+      - ".github/workflows/agent-bus-*.yml"
   push:
     branches: ["main", "master", "dev"]
-    paths: ["packages/agent-bus/**"]
+    paths:
+      - "packages/agent-bus/**"
+      - ".github/workflows/agent-bus-*.yml"
 
 defaults:
   run:

--- a/.github/workflows/agent-bus-format-check.yml
+++ b/.github/workflows/agent-bus-format-check.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
           cache-dependency-path: packages/agent-bus/package-lock.json
       - name: Install dependencies

--- a/.github/workflows/agent-bus-lint-and-test.yml
+++ b/.github/workflows/agent-bus-lint-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
           cache-dependency-path: packages/agent-bus/package-lock.json
       - name: Install dependencies

--- a/.github/workflows/agent-bus-lint-and-test.yml
+++ b/.github/workflows/agent-bus-lint-and-test.yml
@@ -3,10 +3,14 @@ name: agent-bus · Lint and Test
 on:
   push:
     branches: ["main", "master", "dev"]
-    paths: ["packages/agent-bus/**"]
+    paths:
+      - "packages/agent-bus/**"
+      - ".github/workflows/agent-bus-*.yml"
   pull_request:
     branches: ["main", "master", "dev"]
-    paths: ["packages/agent-bus/**"]
+    paths:
+      - "packages/agent-bus/**"
+      - ".github/workflows/agent-bus-*.yml"
 
 defaults:
   run:

--- a/packages/agent-bus/tests/workspace.test.ts
+++ b/packages/agent-bus/tests/workspace.test.ts
@@ -213,6 +213,25 @@ describe('agent-bus workspace lifecycle', () => {
       expect(paths.some((p: string) => p.includes('40_refs'))).toBe(true);
     });
 
+    it('should refuse runtime folders even when explicitly requested', () => {
+      const receipt = createAgentWorkspace({ root: tmpDir, hint: 'test' });
+      const root = receipt.workspace_root;
+
+      fs.writeFileSync(path.join(root, '00_inbox', 'inbox.txt'), 'inbox');
+      fs.writeFileSync(path.join(root, '30_exports', 'export.txt'), 'export');
+      fs.writeFileSync(path.join(root, '90_tmp', 'tmp.txt'), 'tmp');
+
+      const exportReceipt = exportAgentWorkspace({
+        workspaceRoot: root,
+        include: ['00_inbox', '30_exports', '90_tmp'],
+      });
+      const manifest = JSON.parse(fs.readFileSync(exportReceipt.manifest_path, 'utf8'));
+
+      expect(manifest.included_folders).toEqual(['00_inbox']);
+      expect(manifest.excluded_folders).toEqual(['30_exports', '90_tmp']);
+      expect(manifest.files.map((f: { path: string }) => f.path)).toEqual(['00_inbox/inbox.txt']);
+    });
+
     it('should write export receipt to 20_receipts', () => {
       const receipt = createAgentWorkspace({ root: tmpDir, hint: 'test' });
       const root = receipt.workspace_root;


### PR DESCRIPTION
## Summary
- run agent-bus package workflows on Node 20, matching the runtime used by main CI and current Vitest dependencies
- fix auto-format PR pushes so they target the PR branch instead of detached HEAD
- include agent-bus workflow files in their own path filters
- add a regression assertion that runtime export folders stay excluded even if explicitly requested

## Test Evidence
- npm test (packages/agent-bus): 27 passed
- npm run build (packages/agent-bus): passed
- npm run lint (packages/agent-bus): passed

## Rollback
- revert this PR to restore the previous agent-bus workflow settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification for workspace export behavior to ensure runtime folders are properly excluded.

* **Chores**
  * Upgraded Node.js from version 18 to 20 in CI workflows.
  * Enhanced workflow trigger configuration with path-based filtering for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->