### PR TITLE
ci(agent-bus): isolate Vitest config for package tests

### DIFF
--- a/packages/agent-bus/vitest.config.ts
+++ b/packages/agent-bus/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- add package-local Vitest config for packages/agent-bus
- prevents the agent-bus-only workflow from walking up to the repo-root Vitest config when only package dependencies are installed

## Test Evidence
- npm test (packages/agent-bus): 27 passed
- npm run lint (packages/agent-bus): passed
- npm run build (packages/agent-bus): passed

## Rollback
- remove packages/agent-bus/vitest.config.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added test configuration for the agent-bus package to support test discovery and execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->