### PR TITLE
fix(ci): restore main test checks

### DIFF
--- a/src/tokenizer/topological_operator_tree.py
+++ b/src/tokenizer/topological_operator_tree.py
@@ -120,9 +120,7 @@ def tokenize_operation_text(
 
 
 def _leaf(token: dict[str, Any]) -> OperatorNode:
-    return OperatorNode(
-        kind="leaf", label=str(token["word"]), value=int(token["field_value"])
-    )
+    return OperatorNode(kind="leaf", label=str(token["word"]), value=int(token["field_value"]))
 
 
 def _seed_node(seed: int) -> OperatorNode:
@@ -160,9 +158,7 @@ def _hash_payload(payload: Any) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def operator_signature_packet(
-    text: str, *, lexicon: dict[str, int] | None = None
-) -> dict[str, Any]:
+def operator_signature_packet(text: str, *, lexicon: dict[str, int] | None = None) -> dict[str, Any]:
     tokens = tokenize_operation_text(text, lexicon=lexicon)
     tree = build_topological_t_tree(tokens)
     tree_payload = tree.to_dict()

--- a/tests/benchmark/test_real_patch_task_benchmark.py
+++ b/tests/benchmark/test_real_patch_task_benchmark.py
@@ -9,9 +9,7 @@ MODULE_PATH = ROOT / "scripts" / "benchmark" / "real_patch_task_benchmark.py"
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location(
-        "real_patch_task_benchmark", MODULE_PATH
-    )
+    spec = importlib.util.spec_from_file_location("real_patch_task_benchmark", MODULE_PATH)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module

--- a/tests/ci/test_harness_release_readiness.py
+++ b/tests/ci/test_harness_release_readiness.py
@@ -9,37 +9,26 @@ MODULE_PATH = ROOT / "scripts" / "ci" / "harness_release_readiness.py"
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location(
-        "harness_release_readiness", MODULE_PATH
-    )
+    spec = importlib.util.spec_from_file_location("harness_release_readiness", MODULE_PATH)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-def test_harness_release_readiness_passes_with_complete_artifacts(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_harness_release_readiness_passes_with_complete_artifacts(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
 
     (tmp_path / "artifacts/benchmarks/cli_competitive").mkdir(parents=True)
     (tmp_path / "artifacts/benchmarks/agentbus_competitive_wedge").mkdir(parents=True)
     (tmp_path / "artifacts/benchmarks/operator_agent_bus_eval").mkdir(parents=True)
-    (tmp_path / "artifacts/benchmarks/workflow_completion_checklist").mkdir(
-        parents=True
-    )
-    (
-        tmp_path
-        / "artifacts/benchmarks/cli_competitive/cli_competitive_benchmark_latest.json"
-    ).write_text(
+    (tmp_path / "artifacts/benchmarks/workflow_completion_checklist").mkdir(parents=True)
+    (tmp_path / "artifacts/benchmarks/cli_competitive/cli_competitive_benchmark_latest.json").write_text(
         json.dumps({"ok": True, "ranking": [{"name": "scbe-geoseal", "score": 1.0}]}),
         encoding="utf-8",
     )
-    (
-        tmp_path / "artifacts/benchmarks/agentbus_competitive_wedge/latest_report.json"
-    ).write_text(
+    (tmp_path / "artifacts/benchmarks/agentbus_competitive_wedge/latest_report.json").write_text(
         json.dumps(
             {
                 "summary": {"decision": "PASS", "bus_wins": 2, "task_count": 2},
@@ -51,9 +40,7 @@ def test_harness_release_readiness_passes_with_complete_artifacts(
         ),
         encoding="utf-8",
     )
-    (
-        tmp_path / "artifacts/benchmarks/operator_agent_bus_eval/latest_report.json"
-    ).write_text(
+    (tmp_path / "artifacts/benchmarks/operator_agent_bus_eval/latest_report.json").write_text(
         json.dumps(
             {
                 "decision": "PASS",
@@ -64,13 +51,8 @@ def test_harness_release_readiness_passes_with_complete_artifacts(
         ),
         encoding="utf-8",
     )
-    (
-        tmp_path
-        / "artifacts/benchmarks/workflow_completion_checklist/latest_completion_checklist.json"
-    ).write_text(
-        json.dumps(
-            {"completion_status": "ready_to_claim_done", "known_failure_count": 0}
-        ),
+    (tmp_path / "artifacts/benchmarks/workflow_completion_checklist/latest_completion_checklist.json").write_text(
+        json.dumps({"completion_status": "ready_to_claim_done", "known_failure_count": 0}),
         encoding="utf-8",
     )
 
@@ -83,9 +65,7 @@ def test_harness_release_readiness_passes_with_complete_artifacts(
     assert (tmp_path / report["markdown"]).exists()
 
 
-def test_harness_release_readiness_blocks_missing_artifacts(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_harness_release_readiness_blocks_missing_artifacts(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
 

--- a/tests/spiralverse/rwp_v3.test.ts
+++ b/tests/spiralverse/rwp_v3.test.ts
@@ -216,9 +216,9 @@ describe('RWPv3Protocol', () => {
       const password = Buffer.from('password');
       const envelope = protocol.encrypt(password, Buffer.from('message'));
 
-      // Tamper with ciphertext — ensure replacement differs from original
-      const original = envelope.ct[0];
-      envelope.ct[0] = original === "bip'u" ? "bop'a" : "bip'u";
+      const ctBytes = TOKENIZER.decodeSection('ct', envelope.ct);
+      ctBytes[0] ^= 0xff;
+      envelope.ct = TOKENIZER.encodeSection('ct', ctBytes);
 
       expect(() => {
         protocol.decrypt(password, envelope);
@@ -229,8 +229,9 @@ describe('RWPv3Protocol', () => {
       const password = Buffer.from('password');
       const envelope = protocol.encrypt(password, Buffer.from('message'));
 
-      // Tamper with tag
-      envelope.tag[0] = "anvil'u";
+      const tagBytes = TOKENIZER.decodeSection('tag', envelope.tag);
+      tagBytes[0] ^= 0xff;
+      envelope.tag = TOKENIZER.encodeSection('tag', tagBytes);
 
       expect(() => {
         protocol.decrypt(password, envelope);

--- a/tests/system/test_cloud_rag_archive.py
+++ b/tests/system/test_cloud_rag_archive.py
@@ -18,9 +18,7 @@ def _load_module():
     return module
 
 
-def test_plan_archive_reports_reclaimable_bytes_when_delete_requested(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_plan_archive_reports_reclaimable_bytes_when_delete_requested(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     monkeypatch.chdir(tmp_path)
     source = tmp_path / "source"
@@ -50,9 +48,7 @@ def test_plan_archive_reports_reclaimable_bytes_when_delete_requested(
     assert manifest.exists()
 
 
-def test_archive_verifies_catalogs_and_deletes_source(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_archive_verifies_catalogs_and_deletes_source(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     monkeypatch.chdir(tmp_path)
     source = tmp_path / "source"
@@ -85,9 +81,7 @@ def test_archive_verifies_catalogs_and_deletes_source(
     assert "RAG visible text" in catalog.read_text(encoding="utf-8")
 
 
-def test_cleanup_verified_deletes_source_from_manifest(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_cleanup_verified_deletes_source_from_manifest(tmp_path: Path, monkeypatch) -> None:
     module = _load_module()
     monkeypatch.chdir(tmp_path)
     source = tmp_path / "source"

--- a/tests/tokenizer/test_topological_operator_tree.py
+++ b/tests/tokenizer/test_topological_operator_tree.py
@@ -60,9 +60,7 @@ def test_unknown_operation_token_is_rejected() -> None:
 
 
 def test_video_story_operation_words_are_routeable() -> None:
-    packet = operator_signature_packet(
-        "video story package quality gate manifest youtube upload"
-    )
+    packet = operator_signature_packet("video story package quality gate manifest youtube upload")
 
     assert [token["word"] for token in packet["tokens"]] == [
         "video",

--- a/tests/video/test_video_quality_gate_node.py
+++ b/tests/video/test_video_quality_gate_node.py
@@ -51,9 +51,7 @@ def render_fixture_video(path: Path, *, duration: float = 5.0) -> None:
     assert result.returncode == 0, result.stderr
 
 
-def write_story_assets(
-    tmp_path: Path, *, description: str, final_caption: str
-) -> tuple[Path, Path, Path]:
+def write_story_assets(tmp_path: Path, *, description: str, final_caption: str) -> tuple[Path, Path, Path]:
     srt = tmp_path / "captions.srt"
     srt.write_text(
         "1\n"
@@ -91,9 +89,7 @@ def write_story_assets(
     return srt, metadata, source
 
 
-def run_quality_gate(
-    tmp_path: Path, *args: str
-) -> tuple[subprocess.CompletedProcess[str], dict]:
+def run_quality_gate(tmp_path: Path, *args: str) -> tuple[subprocess.CompletedProcess[str], dict]:
     out = tmp_path / "quality.json"
     result = subprocess.run(
         ["node", str(QUALITY_GATE), *args, "--out", str(out)],


### PR DESCRIPTION
## Summary\n- apply Black formatting to the Python files failing the main CI format gate\n- make RWPv3 Sacred Tongue ciphertext/tag tamper tests deterministic by flipping decoded bytes and re-encoding tokens\n\n## Test evidence\n- python -m black --check --target-version py311 --line-length 120 src/ tests/\n- npm test -- tests/spiralverse/rwp_v3.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced RWPv3 protocol security validation with improved tamper detection testing to ensure authentication failures are correctly triggered for corrupted payloads.
  * Refined test infrastructure formatting for better maintainability.

* **Style**
  * Code formatting improvements across codebase for consistency and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->