### PR TITLE
ci: make npm publish workflows idempotent

### DIFF
--- a/.github/workflows/npm-publish-agent-bus.yml
+++ b/.github/workflows/npm-publish-agent-bus.yml
@@ -51,6 +51,12 @@ jobs:
           echo "Publishing scbe-agent-bus@$PKG_VER"
 
       - name: Publish
-        run: npm publish --access public
+        run: |
+          PKG_VER=$(node -p "require('./package.json').version")
+          if npm view "scbe-agent-bus@$PKG_VER" version 2>/dev/null | grep -qx "$PKG_VER"; then
+            echo "::notice::scbe-agent-bus@$PKG_VER already published — skipping."
+            exit 0
+          fi
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -48,6 +48,12 @@ jobs:
           echo "Publishing scbe-aethermoore-cli@$PKG_VER"
 
       - name: Publish
-        run: npm publish --access public
+        run: |
+          PKG_VER=$(node -p "require('./package.json').version")
+          if npm view "scbe-aethermoore-cli@$PKG_VER" version 2>/dev/null | grep -qx "$PKG_VER"; then
+            echo "::notice::scbe-aethermoore-cli@$PKG_VER already published — skipping."
+            exit 0
+          fi
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary\n- replay the unique idempotency-guard commit from stale PR #1842 onto current main\n- skip npm publish successfully when the target package version already exists\n- leaves the original stale PR conflict branch untouched\n\n## Validation\n- git diff --check origin/main..HEAD\n- inspected workflow publish steps for scbe-agent-bus and scbe-aethermoore-cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm publishing workflows to check if package versions already exist on the registry before publishing. If a version is found, the workflow exits successfully without attempting to publish.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->