### PR TITLE
chore(repo): classify branch cleanup lanes

### DIFF
--- a/docs/reports/github-branch-cleanup-lanes-2026-05-25.md
+++ b/docs/reports/github-branch-cleanup-lanes-2026-05-25.md
@@ -1,0 +1,877 @@
+# GitHub Branch and Deployment Surface Audit
+
+Generated: `2026-05-25T17:36:53.472077+00:00`
+Repo: `C:\Users\issda\SCBE-AETHERMOORE-audit-v2`
+
+## Branch Counts
+
+- `remote_total_excluding_main_pages`: 433
+- `merged_into_origin_main`: 7
+- `safe_delete_candidates`: 0
+
+## Remote Branch Prefixes
+
+- `feat`: 135
+- `fix`: 131
+- `automation`: 43
+- `chore`: 17
+- `backup`: 15
+- `docs`: 11
+- `benchmark`: 10
+- `ci`: 7
+- `feature`: 7
+- `codex`: 5
+- `test`: 4
+- `agentbus`: 3
+- `claude`: 2
+- `site`: 2
+- `work`: 2
+- `codex-merge-sync-agent-bus`: 1
+- `codex-workflow-advisory-cleanup`: 1
+- `codex-workflow-build-hardening`: 1
+- `cursor`: 1
+- `deploy`: 1
+- `improve`: 1
+- `integrate`: 1
+- `issdandavis-patch-1`: 1
+- `launch`: 1
+- `narrative-combat`: 1
+- `perf`: 1
+- `push-dataset-pipeline`: 1
+- `pypi`: 1
+- `recovery`: 1
+- `refactor`: 1
+- `release`: 1
+- `review`: 1
+- `site-publish-v4`: 1
+- `style`: 1
+
+## Safe Delete Candidates
+
+- None at generation time.
+
+## Branch Cleanup Lanes
+
+- `automation-data-review`: 42
+- `backup-preserve`: 16
+- `code-review`: 210
+- `deployment-review`: 83
+- `docs-only-convert-check`: 38
+- `manual-review`: 20
+- `unknown-review`: 4
+
+### automation-data-review
+
+- `origin/automation/agent-data-1777301393`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777301522`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-research.json`
+- `origin/automation/agent-data-1777315011`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777335973`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-research.json`
+- `origin/automation/agent-data-1777337739`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777339457`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-research.json`
+- `origin/automation/agent-data-1777359898`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777360373`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777380425`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777401669`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777424192`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777445989`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777466620`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777487965`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777510584`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777532556`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777552998`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777574341`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777597202`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777619080`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777638632`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777660340`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777683230`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777704507`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777724822`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777746364`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777769911`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777791623`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777811196`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777832757`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777856223`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777878843`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777898727`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777920115`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777942325`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777964169`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1777984527`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1778006423`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1778028704`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- `origin/automation/agent-data-1778201740`
+  - reason: generated automation data branch; inspect before delete
+  - sample paths: `docs/static/agent-data/index.json`, `docs/static/agent-data/latest-monitor.json`
+- ... 2 more
+
+### backup-preserve
+
+- `origin/backup/duplicate-main-format`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/feat-agentic-gap-before-main-merge-20260513`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/feat/agent-bus-workspace-new-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/feat/flow-packet-status-20260513-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/feat/sacred-egg-crp-puf-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/feat/workflow-snapshot-autopromo-v2-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/fix/claim-language-20260513-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/fix/flow-workingness-contract-20260513-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/fix/governance-claim-gates-20260513-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/fix/petri-v7-regressions-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/fix/polly-commerce-prettier-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/fix/security-checks-advisory-audits-20260514-2200`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/local-main-benchmark-2026-05-07`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/snapshot-20260427-0654`
+  - reason: backup/snapshot/recovery namespace
+- `origin/backup/watershed-local-wip-20260525`
+  - reason: backup/snapshot/recovery namespace
+- `origin/recovery/petri22-rule-pack`
+  - reason: backup/snapshot/recovery namespace
+
+### code-review
+
+- `origin/agentbus/fix-confidence-variance`
+  - reason: touches code/test/runtime paths
+  - sample paths: `agents/research_agent.py`, `agents/web_scraper.py`, `tests/test_agent_router_result_quality.py`, `tests/test_research_agent_score_variance.py`
+- `origin/agentbus/self-review-script`
+  - reason: touches code/test/runtime paths
+  - sample paths: `scripts/system/agentbus_self_review.py`
+- `origin/agentbus/self-review-source-outcomes`
+  - reason: touches code/test/runtime paths
+  - sample paths: `scripts/system/agentbus_self_review.py`, `tests/test_agentbus_self_review.py`
+- `origin/benchmark/format-diagnostics-test`
+  - reason: touches code/test/runtime paths
+  - sample paths: `tests/benchmark/test_public_agentic_benchmark_workflow.py`
+- `origin/chore/dual-license-surfaces`
+  - reason: touches code/test/runtime paths
+  - sample paths: `LICENSE-APACHE`, `LICENSE-NOTICE.md`, `README.md`, `package-lock.json`, `package.json`
+- `origin/chore/npm-dual-license-release-align`
+  - reason: touches code/test/runtime paths
+  - sample paths: `package-lock.json`, `package.json`, `packages/agent-bus/CHANGELOG.md`, `packages/agent-bus/LICENSE-APACHE`, `packages/agent-bus/LICENSE-NOTICE.md`
+- `origin/chore/remove-third-party-harness-surface`
+  - reason: touches code/test/runtime paths
+  - sample paths: `.agents/plugins/plugins/scbe-verify/agents/scbe-dry-run-rubix.md`, `.claude/plugins/hydra-spiral-search/skills/combo-stack.md`, `.clawhub/lock.json`, `.gitignore`, `.gitmodules`
+- `origin/chore/repo-launch-restructure`
+  - reason: touches code/test/runtime paths
+  - sample paths: `.gitignore`, `CHANGELOG.md`, `CLAUDE.md`, `config/model_training/aligned-foundations-qwen-primary.json`, `config/model_training/chemistry-qwen-primary.json`
+- `origin/chore/windows-helper-scripts`
+  - reason: touches code/test/runtime paths
+  - sample paths: `scripts/windows/colab-status.ps1`, `scripts/windows/pull-from-hf.ps1`
+- `origin/ci/agent-bus-local-vitest-config`
+  - reason: touches code/test/runtime paths
+  - sample paths: `packages/agent-bus/package-lock.json`, `packages/agent-bus/vitest.config.ts`, `tests/test_sacred_tongues_crossmodal.py`
+- `origin/ci/agentbus-black-format-fix`
+  - reason: touches code/test/runtime paths
+  - sample paths: `agents/research_agent.py`, `agents/web_scraper.py`, `tests/test_research_agent_score_variance.py`
+- `origin/ci/agentbus-ruff-import-fix`
+  - reason: touches code/test/runtime paths
+  - sample paths: `tests/test_research_agent_score_variance.py`
+- `origin/claude/extract-formulas-OjDmT`
+  - reason: touches code/test/runtime paths
+  - sample paths: `src/symphonic_cipher/scbe_aethermoore/pqc/pqc_harmonic.py`, `symphonic_cipher/scbe_aethermoore/pqc/pqc_harmonic.py`
+- `origin/claude/finetune-qwen-coder-qlora-uuqBW`
+  - reason: touches code/test/runtime paths
+  - sample paths: `scripts/finetune_qwen_coder_qlora.py`, `scripts/system/pr_merge_triage.py`, `src/cognitive_governance/dimensional_space.py`, `src/symphonic_cipher/scbe_aethermoore/flock_shepherd.py`, `tests/test_telemetry_advanced_math.json`
+- `origin/codex/fix-unauthenticated-geoseal-remote-code-execution`
+  - reason: touches code/test/runtime paths
+  - sample paths: `src/api/geoseal_service.py`, `tests/test_agent_task_run_and_external_eval.py`
+- `origin/docs/organic-marketing-articles`
+  - reason: touches code/test/runtime paths
+  - sample paths: `config/eval/aether_coding_score.v1.json`, `docs/articles/2026-05-23-deterministic-ai-governance-what-it-means-to-diff-safety.md`, `docs/articles/2026-05-23-how-a-dnd-campaign-became-an-ai-governance-framework.md`, `docs/articles/2026-05-23-hyperbolic-geometry-for-ai-governance.md`, `docs/articles/2026-05-23-multi-agent-coordination-physics-based-scheduler.md`
+- `origin/feat/72h-training-loop`
+  - reason: touches code/test/runtime paths
+  - sample paths: `config/model_training/ca_opcode_exact_eval_contract.json`, `config/model_training/coding-agent-qwen-ca-opcode-final-dpo-v1.json`, `config/model_training/coding-agent-qwen-ca-opcode-literal-sft-v1.json`, `config/model_training/coding-agent-qwen-geoseal-harness-merged-v1.json`, `config/model_training/coding-agent-qwen-merged-coding-model-v3.json`
+- `origin/feat/aether-lattice-actor-baselines`
+  - reason: touches code/test/runtime paths
+  - sample paths: `scripts/research/aether_lattice_sim.py`, `tests/research/test_aether_lattice_sim.py`
+- `origin/feat/aetherdesk-mechanical-coding-bench`
+  - reason: touches code/test/runtime paths
+  - sample paths: `.gitignore`, `aetherdesk/README.md`, `aetherdesk/public/index.html`, `aetherdesk/server.js`, `package.json`
+- `origin/feat/aetherdesk-provider-status`
+  - reason: touches code/test/runtime paths
+  - sample paths: `aetherdesk/README.md`, `aetherdesk/public/index.html`, `aetherdesk/server.js`, `tests/aetherdesk/server.test.ts`
+- `origin/feat/aetherdesk-shell-v0`
+  - reason: touches code/test/runtime paths
+  - sample paths: `.gitignore`, `aetherdesk/README.md`, `aetherdesk/public/index.html`, `aetherdesk/server.js`, `package.json`
+- `origin/feat/aethermoore-launcher`
+  - reason: touches code/test/runtime paths
+  - sample paths: `scripts/bootstrap/aethermoore.pyz`, `scripts/bootstrap/aethermoore_src/__main__.py`, `tests/bootstrap/test_aethermoore_launcher.py`
+- `origin/feat/agent-bus-followups`
+  - reason: touches code/test/runtime paths
+  - sample paths: `.gitignore`, `agents/agent_bus.py`, `agents/agent_bus_signing.py`, `python/scbe/tongue_isa.py`, `python/scbe/tongue_isa_binary.py`
+- `origin/feat/agent-bus-py-0.3.0`
+  - reason: touches code/test/runtime paths
+  - sample paths: `packages/agent-bus-py/pyproject.toml`, `packages/agent-bus-py/src/scbe_agent_bus/__init__.py`, `packages/agent-bus-py/src/scbe_agent_bus/lineage.py`, `packages/agent-bus-py/src/scbe_agent_bus/workspace.py`, `packages/agent-bus-py/tests/test_workspace_wrappers.py`
+- `origin/feat/agent-bus-tier-1-fixes`
+  - reason: touches code/test/runtime paths
+  - sample paths: `.mcp.json`, `.mcp_platform.json`, `MULTI_AGENT_PLATFORM_GUIDE.md`, `agents/agent_bus.py`, `agents/agent_bus_cli.py`
+- `origin/feat/agent-harness-tongue-gate`
+  - reason: touches code/test/runtime paths
+  - sample paths: `src/api/geoseal_cli_bridge.py`, `src/coding_spine/agent_tool_bridge.py`, `src/geoseal_cli.py`, `tests/coding_spine/test_agent_call_switchboard.py`, `tests/test_agent_task_run_and_external_eval.py`
+- `origin/feat/agent-system-contract`
+  - reason: touches code/test/runtime paths
+  - sample paths: `api/agent/system.js`, `docs/app-config.json`, `kindle-app/bus-www/index.html`, `kindle-app/www/index.html`, `kindle-app/www/manifest.json`
+- `origin/feat/agents-accessible-and-polly-hint`
+  - reason: touches code/test/runtime paths
+  - sample paths: `api/polly/commerce.js`, `docs/agents.html`, `docs/governance-snapshot.html`, `docs/hire-b.html`, `docs/hire.html`
+- `origin/feat/autonomous-offer-fulfillment`
+  - reason: touches code/test/runtime paths
+  - sample paths: `api/agent/hire.js`, `api/polly/commerce.js`, `api/polly/lead.js`, `docs/hire.html`, `docs/product-manual/delivery-and-access.html`
+- `origin/feat/autonomous-offer-fulfillment-v2`
+  - reason: touches code/test/runtime paths
+  - sample paths: `api/agent/hire.js`, `api/polly/commerce.js`, `api/polly/lead.js`, `docs/hire.html`, `docs/product-manual/delivery-and-access.html`
+- `origin/feat/book-chapters-02-04`
+  - reason: touches code/test/runtime paths
+  - sample paths: `api/polly/commerce.js`, `book/ai-governance-fundamentals/book.yaml`, `book/ai-governance-fundamentals/chapter-02-risk-tiers.md`, `book/ai-governance-fundamentals/chapter-03-decision-records.md`, `book/ai-governance-fundamentals/chapter-04-sacred-tongues.md`
+- `origin/feat/crypto-star-fortress-mldsa87`
+  - reason: touches code/test/runtime paths
+  - sample paths: `src/crypto/pqc-strategies.ts`, `src/crypto/quantum-safe.ts`, `tests/crypto/pqc-strategies.test.ts`
+- `origin/feat/dense-data-bundles`
+  - reason: touches code/test/runtime paths
+  - sample paths: `src/encoding/__init__.py`, `src/encoding/dense_bundle.py`, `tests/encoding/__init__.py`, `tests/encoding/test_dense_bundle.py`
+- `origin/feat/diffusion-bakeoff-colab-notebook`
+  - reason: touches code/test/runtime paths
+  - sample paths: `notebooks/diffusion_bakeoff_colab.ipynb`, `scripts/eval/diffusion_codegen_bakeoff.py`, `scripts/eval/schrodinger_codewave_generator.py`, `tests/eval/test_schrodinger_codewave_generator.py`
+- `origin/feat/disk-hygiene-scripts`
+  - reason: touches code/test/runtime paths
+  - sample paths: `scripts/system/find_home_dedup.py`, `scripts/system/find_regenerable_bloat.py`, `tests/system/test_disk_hygiene.py`
+- `origin/feat/email-service-and-triage`
+  - reason: touches code/test/runtime paths
+  - sample paths: `docs/AGENTIC_EMAIL_ARCHITECTURE.md`, `scripts/aetherbrowser/api_server.py`, `scripts/apollo/agentic_email_triage.py`, `scripts/system/email_service.py`, `scripts/system/setup_cloudflare_tunnel.sh`
+- `origin/feat/free-agent-search-sources`
+  - reason: touches code/test/runtime paths
+  - sample paths: `api/agent/search.js`, `tests/test_agent_search_free_sources.py`
+- `origin/feat/geoseal-operator-space`
+  - reason: touches code/test/runtime paths
+  - sample paths: `src/geosealOperatorSpace.ts`, `src/geoseal_operator_space.py`, `tests/geoseal-operator-space.test.ts`, `tests/test_geoseal_operator_space.py`
+- `origin/feat/geoseal-route-cross-build`
+  - reason: touches code/test/runtime paths
+  - sample paths: `docs/LAYER_INDEX.md`, `src/cli/command_trace.py`, `src/cli/cross_build_ir.py`, `src/cli/param_binding.py`, `src/cli/slm_router.py`
+- `origin/feat/go-board-narrative-engine`
+  - reason: touches code/test/runtime paths
+  - sample paths: `docs/superpowers/specs/2026-05-21-go-board-narrative-engine-design.md`, `src/narrative_combat/__init__.py`, `src/narrative_combat/go_board/__init__.py`, `src/narrative_combat/go_board/cli.py`, `src/narrative_combat/go_board/director.py`
+- ... 170 more
+
+### deployment-review
+
+- `origin/benchmark/aider-docker-build-retry`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`
+- `origin/benchmark/aider-docker-no-deadsnakes`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`, `tests/benchmark/test_public_agentic_benchmark_workflow.py`
+- `origin/benchmark/aider-provider-select`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`, `tests/benchmark/test_public_agentic_benchmark_workflow.py`
+- `origin/benchmark/aider-python3-fix`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`, `scripts/benchmark/aider_polyglot_smoke.py`, `scripts/benchmark/public_agentic_cli_suite.py`, `scripts/benchmark/setup_public_agentic_benchmarks.py`, `tests/benchmark/test_aider_polyglot_smoke.py`
+- `origin/benchmark/aider-stats-chown`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`
+- `origin/benchmark/aider-stats-env`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`
+- `origin/benchmark/aider-visible-diagnostics`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`, `docs/ops/PUBLIC_AGENTIC_BENCHMARK_STATUS_2026-05-03.md`, `tests/benchmark/test_public_agentic_benchmark_workflow.py`
+- `origin/benchmark/fix-aider-noble-pep668`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`, `tests/benchmark/test_public_agentic_benchmark_workflow.py`
+- `origin/benchmark/public-agentic-remote`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.geoseal/commands/harness-benchmark.md`, `.github/workflows/public-agentic-benchmarks.yml`, `.gitignore`, `bin/geoseal.cjs`, `config/eval/public_agentic_benchmark_sources.v1.json`
+- `origin/chore/ci-action-runtime-and-precommit-guide`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/ci.yml`, `docs/PRECOMMIT_LINT_FORMAT_GUIDE.md`, `tests/system/test_agent_bus_workspace_cli.py`
+- `origin/chore/gitignore-untracked-noise`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/agent-router.yml`, `.gitignore`, `scripts/system/sanitize_agent_router_public_result.py`, `tests/system/test_sanitize_agent_router_public_result.py`
+- `origin/chore/release-4.0.3-housekeeping`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.agents/skills/hydra-compound-matrix/SKILL.md`, `.claude/settings.local.json`, `.cursor/hooks.json`, `.cursor/hooks/README.md`, `.cursor/hooks/_common.py`
+- `origin/chore/release-publish-workflows`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/npm-publish.yml`, `.github/workflows/python-publish.yml`, `.github/workflows/release.yml`, `RELEASING.md`
+- `origin/chore/route-first-eval-controls`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `src/aetherbrowser/serve.py`, `src/api/free_llm_routes.py`, `src/api/geoseal_service.py`, `src/api/main.py`, `src/api/polly_routes.py`
+- `origin/chore/trim-github-automation`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/agent-router.yml`, `.github/workflows/auto-changelog.yml`, `.github/workflows/ci.yml`, `.github/workflows/codeql-analysis.yml`, `.github/workflows/daily-dep-audit.yml`
+- `origin/ci/agent-bus-node20-workflows`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/agent-bus-auto-format.yml`, `.github/workflows/agent-bus-format-check.yml`, `.github/workflows/agent-bus-lint-and-test.yml`, `packages/agent-bus/package-lock.json`, `packages/agent-bus/tests/workspace.test.ts`
+- `origin/ci/expand-smoke-coverage`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/nightly-ops.yml`, `.scbe/cli-context.json`, `.vercelignore`, `docs/books.html`, `docs/books.json`
+- `origin/ci/publish-idempotency-guard`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/npm-publish-agent-bus.yml`, `.github/workflows/npm-publish-cli.yml`
+- `origin/ci/pypi-token-fallback`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/pypi-publish.yml`
+- `origin/codex-merge-sync-agent-bus`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/agent-router.yml`, `.gitignore`, `api/_agent_common.js`, `api/agent/chat.js`, `api/agent/search.js`
+- `origin/codex-workflow-advisory-cleanup`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/auto-approve-trusted.yml`, `.github/workflows/ci.yml`, `.github/workflows/coherence-gate.yml`, `.github/workflows/daily-dep-audit.yml`, `.github/workflows/daily-formula-validation.yml`
+- `origin/codex-workflow-build-hardening`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/agent-router.yml`, `.github/workflows/browser-research.yml`, `.github/workflows/docker-remote-build.yml`, `.github/workflows/release.yml`, `.github/workflows/security-checks.yml`
+- `origin/codex/github-remote-worker`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/free-remote-worker.yml`, `docs/GITHUB_REMOTE_WORKER.md`, `docs/README.md`, `scripts/system/github_remote_worker.py`, `workflows/n8n/github_remote_worker_payload.sample.json`
+- `origin/codex/remote-worker-artifact-scope`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/free-remote-worker.yml`, `docs/GITHUB_REMOTE_WORKER.md`, `scripts/system/github_remote_worker.py`, `workflows/n8n/github_remote_worker_payload.sample.json`
+- `origin/codex/remote-worker-node24`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/free-remote-worker.yml`
+- `origin/feat/aether-desktop-deploy-ready`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.gitignore`, `apps/aether-desktop/Dockerfile`, `apps/aether-desktop/backend/audit.py`, `apps/aether-desktop/backend/auth.py`, `apps/aether-desktop/backend/handlers/llm_chat.py`
+- `origin/feat/agent-bus-router-task`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/agent-router.yml`, `api/_agent_common.js`, `docs/agents.html`, `tests/test_agent_router_bridge_tasks.py`
+- `origin/feat/agent-bus-spaceready`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/agent-router.yml`, `.github/workflows/scbe-reusable-gates.yml`, `.gitignore`, `agents/AGENT_BUS_NOTES.md`, `agents/agent_bus.py`
+- `origin/feat/agent-bus-zod-ci`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/CODEOWNERS`, `.github/workflows/agent-bus-auto-format.yml`, `.github/workflows/agent-bus-format-check.yml`, `.github/workflows/agent-bus-lint-and-test.yml`, `packages/agent-bus/.husky/pre-commit`
+- `origin/feat/geoseal-aider-polyglot-preflight`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`, `scripts/benchmark/aider_polyglot_smoke.py`, `tests/benchmark/test_aider_polyglot_smoke.py`, `tests/benchmark/test_public_agentic_benchmark_workflow.py`
+- `origin/feat/geoseal-llm-verify`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/CODEOWNERS`, `.github/workflows/agent-bus-auto-format.yml`, `.github/workflows/agent-bus-format-check.yml`, `.github/workflows/agent-bus-lint-and-test.yml`, `packages/agent-bus/.husky/pre-commit`
+- `origin/feat/geoseal-meet-in-middle`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/ci.yml`, `demos/gemma4_scbe_governance/README.md`, `demos/gemma4_scbe_governance/demo.py`, `demos/gemma4_scbe_governance/example_prompts.json`, `demos/gemma4_scbe_governance/lib.py`
+- `origin/feat/governance-heartbeat-99mo`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.env.example`, `.github/workflows/polly-heartbeat-started.yml`, `api/billing/stripe_webhook.js`, `docs/governance-snapshot.html`, `docs/offers.json`
+- `origin/feat/known-fail-retry-prompts`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/public-agentic-benchmarks.yml`, `scripts/benchmark/known_fail_retry_prompts.py`, `tests/benchmark/test_known_fail_retry_prompts.py`
+- `origin/feat/polly-hire-seo`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/polly-training-capture.yml`, `docs/hire.html`, `docs/sitemap.xml`
+- `origin/feat/polly-lead-capture-form`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/polly-training-capture.yml`, `api/polly/lead.js`, `docs/hire.html`, `tests/api/polly_commerce_js.test.ts`, `vercel.json`
+- `origin/feat/polly-lead-email-via-smtp`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/polly-training-capture.yml`, `docs/deployment/POLLY_LEAD_EMAIL_SMTP.md`
+- `origin/feat/polly-private-hf-training-capture`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/polly-training-capture.yml`, `api/_polly_train_capture.js`, `docs/deployment/POLLY_TRAINING_CAPTURE.md`, `docs/hire.html`, `tests/api/polly_commerce_js.test.ts`
+- `origin/feat/polly-research-intent`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/polly-training-capture.yml`, `api/_polly_train_capture.js`, `api/polly/chat.js`, `api/polly/commerce.js`, `docs/deployment/POLLY_TRAINING_CAPTURE.md`
+- `origin/feat/polly-stats-endpoint`
+  - reason: touches workflow/deploy/docker/k8s surfaces
+  - sample paths: `.github/workflows/polly-training-capture.yml`, `api/polly/stats.js`, `docs/hire.html`, `docs/sitemap.xml`, `tests/api/polly_commerce_js.test.ts`
+- ... 43 more
+
+### docs-only-convert-check
+
+- `origin/chore/recover-eml-t-research-doc`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/research/eml_t_verification_findings.md`
+- `origin/cursor/env-setup-5866`
+  - reason: only docs/markdown paths changed
+  - sample paths: `AGENTS.md`
+- `origin/deploy/aethermoore-domain-migration`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/00-overview/scbe-developer-guide.mmd`, `docs/03-deployment/github-app-latticegate.md`, `docs/404.html`, `docs/AETHERAUTH_IMPLEMENTATION.md`, `docs/AI2AI_ARXIV_RETRIEVAL_SERVICE.md`
+- `origin/docs/agents-quality-harness`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/agents.html`
+- `origin/docs/geoboard-execution-manifold`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/ARCHITECTURE.md`, `docs/SCBE_AETHERMOORE_ONE_PAGER.md`
+- `origin/docs/m5-m6-grounded-rewrite`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/M5_MESH_PRODUCT_SERVICE_BLUEPRINT.md`, `docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md`
+- `origin/docs/mcp-context-commands`
+  - reason: only docs/markdown paths changed
+  - sample paths: `mcp_context_server/COMMANDS.md`
+- `origin/docs/private-storage-ledger-public-trim`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/ops/artifact-cleanup-inventory-2026-05-02.txt`, `docs/ops/venv-training-freeze-before-cleanup-2026-05-02.txt`
+- `origin/docs/private-storage-pointer`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/ops/STORAGE_CLEANUP_2026-05-02.md`
+- `origin/docs/storage-cleanup-2026-05-02`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/ops/STORAGE_CLEANUP_2026-05-02.md`, `docs/ops/artifact-cleanup-inventory-2026-05-02.txt`, `docs/ops/venv-training-freeze-before-cleanup-2026-05-02.txt`
+- `origin/docs/systems-blueprint`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/presentations/README.md`, `docs/presentations/SYSTEMS_BLUEPRINT.md`
+- `origin/docs/terax-aetherdesk-research`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/research/TERAX_AI_TERMINAL_REFERENCE.md`, `docs/specs/AETHERDESK_OPERATOR_SHELL_v0.md`
+- `origin/feat/hire-snapshot-cta`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/hire.html`
+- `origin/feat/homepage-support-cta`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/index.html`
+- `origin/feat/kofi-cage-payment-copy`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/hire.html`, `docs/index.html`, `docs/llms.txt`, `docs/offers.json`, `docs/robot.md`
+- `origin/feat/one-pager`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/SCBE_AETHERMOORE_ONE_PAGER.md`
+- `origin/feat/polly-on-aethermoore`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/hire.html`, `docs/static/polly-hf-chat.js`
+- `origin/feat/polly-stats-dashboard`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/polly-stats.html`
+- `origin/feat/revenue-packet`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/business/AI_SAFETY_JOB_APPLICATIONS_2026_05_09.md`, `docs/business/COLD_OUTREACH_PACKET_2026_05_09.md`, `docs/hire.html`
+- `origin/feat/site-default-agent-bridge`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/agents.html`
+- `origin/feat/snapshot-intake-form`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/governance-snapshot.html`
+- `origin/feat/supporter-homepage-link`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/index.html`, `docs/offers/index.html`
+- `origin/fix/customer-launch-routes`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/offers/index.html`, `docs/product-manual/ai-governance-toolkit.html`, `docs/product-manual/content-spin-engine.html`, `docs/product-manual/delivery-and-access.html`, `docs/product-manual/hydra-agent-templates.html`
+- `origin/fix/hire-docs-path`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/hire.html`
+- `origin/fix/home-sales-page`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/index.html`
+- `origin/fix/kofi-offer-json-smoke`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/offers.json`
+- `origin/fix/marketing-eof-clean`
+  - reason: only docs/markdown paths changed
+  - sample paths: `content/articles/devto_ai_governance_snapshot_offer_2026_05_09.md`, `content/articles/linkedin_ai_governance_snapshot_offer_2026_05_09.md`, `content/articles/x_thread_2026-05-09-ai-governance-snapshot.md`
+- `origin/fix/overnight-cleanup`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/static/polly-sidebar.js`
+- `origin/fix/payments-sales-page`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/payments.html`
+- `origin/fix/products-sales-page`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/products.html`
+- `origin/fix/service-credits-sales-page`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/service-credits.html`
+- `origin/fix/skill-frontmatter-metadata`
+  - reason: only docs/markdown paths changed
+  - sample paths: `.home/.agents/skills/scbe-agent-priming/SKILL.md`, `.home/.agents/skills/scbe-ide/SKILL.md`, `.home/.agents/skills/scbe-youtube-factory/SKILL.md`
+- `origin/fix/supporter-sales-page`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/supporter.html`
+- `origin/fix/terax-doc-eof-whitespace`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/research/TERAX_AI_TERMINAL_REFERENCE.md`, `docs/specs/AETHERDESK_OPERATOR_SHELL_v0.md`
+- `origin/fix/tongue-role-descriptions`
+  - reason: only docs/markdown paths changed
+  - sample paths: `README.md`, `aether-browser/README.md`, `docs/ARCHITECTURE.md`, `docs/CODING_SYSTEMS_MASTER_REFERENCE.md`, `docs/M6_SEED_MULTI_NODAL_NETWORK_SPEC.md`
+- `origin/fix/website-sales-pass-2`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/hosted-run.html`
+- `origin/improve/customer-funnel-pass`
+  - reason: only docs/markdown paths changed
+  - sample paths: `docs/products.html`, `docs/start-here.html`
+- `origin/issdandavis-patch-1`
+  - reason: only docs/markdown paths changed
+  - sample paths: `notes/sessions/2026-05-02-session.md`
+
+### manual-review
+
+- `origin/automation/research-feed`
+  - reason: does not match known high-level buckets
+  - sample paths: `docs/research-feed.json`, `docs/research-pipeline.json`, `training-data/news-pipeline/records/2026-05-08.jsonl`, `training-data/news-pipeline/sft/2026-05-08.jsonl`
+- `origin/chore/gitignore-mcp-context-secrets`
+  - reason: does not match known high-level buckets
+  - sample paths: `.gitignore`
+- `origin/chore/remove-dead-docs-scripts`
+  - reason: does not match known high-level buckets
+  - sample paths: `package.json`
+- `origin/chore/restore-docs-check`
+  - reason: does not match known high-level buckets
+  - sample paths: `package.json`
+- `origin/chore/vercel-payload-filter`
+  - reason: does not match known high-level buckets
+  - sample paths: `.vercelignore`
+- `origin/chore/website-h1-clarity`
+  - reason: does not match known high-level buckets
+  - sample paths: `docs/hire.html`, `docs/products.html`, `docs/start-here.html`, `public/hire.html`
+- `origin/docs/triattention-kv-cache-lane`
+  - reason: does not match known high-level buckets
+  - sample paths: `config/system/kv_cache_strategy_v1.json`, `docs/specs/TRIATTENTION_KV_CACHE_LANE_2026-04-27.md`
+- `origin/feat/hire-page-live`
+  - reason: does not match known high-level buckets
+  - sample paths: `public/hire.html`
+- `origin/feat/mobile-bus-app`
+  - reason: does not match known high-level buckets
+  - sample paths: `apps/mobile/README.md`, `apps/mobile/pwa/.gitignore`, `apps/mobile/pwa/index.html`, `apps/mobile/pwa/package-lock.json`, `apps/mobile/pwa/package.json`
+- `origin/feat/polly-widget-actions`
+  - reason: does not match known high-level buckets
+  - sample paths: `kindle-app/www/static/polly-hf-chat.js`
+- `origin/feat/release-4.0.10-funding`
+  - reason: does not match known high-level buckets
+  - sample paths: `CHANGELOG.md`, `package.json`, `pyproject.toml`
+- `origin/feat/site-ai-robot-map`
+  - reason: does not match known high-level buckets
+  - sample paths: `docs/app-config.json`, `docs/index.html`, `docs/llms.txt`, `docs/robot.html`, `docs/robot.md`
+- `origin/feat/site-cash-app-payment`
+  - reason: does not match known high-level buckets
+  - sample paths: `docs/app-config.json`, `docs/llms.txt`, `docs/offers.json`, `docs/products.html`, `docs/robot.html`
+- `origin/feat/site-first-sale-workflow-snapshot`
+  - reason: does not match known high-level buckets
+  - sample paths: `docs/app-config.json`, `docs/index.html`, `docs/llms.txt`, `docs/offers.json`, `docs/products.html`
+- `origin/feat/ux-operator-experience`
+  - reason: does not match known high-level buckets
+  - sample paths: `config/system/operator_experience_backlog.json`, `docs/specs/SCBE_OPERATOR_EXPERIENCE_PLAN.md`
+- `origin/fix/dependabot-protobuf`
+  - reason: does not match known high-level buckets
+  - sample paths: `scbe-visual-system/package-lock.json`
+- `origin/fix/dependabot-submodule-exclusions`
+  - reason: does not match known high-level buckets
+  - sample paths: `.github/dependabot.yml`
+- `origin/fix/dependabot-urllib3`
+  - reason: does not match known high-level buckets
+  - sample paths: `examples/SCBEAgent/uv.lock`
+- `origin/fix/vercel-functions-include-faststart`
+  - reason: does not match known high-level buckets
+  - sample paths: `vercel.json`
+- `origin/fix/vercel-include-fulfillment-files`
+  - reason: does not match known high-level buckets
+  - sample paths: `vercel.json`
+
+### unknown-review
+
+- `origin/codex/conflict-marker-guard-main`
+  - reason: no diff paths available or branch cannot be compared
+- `origin/feat/polly-navigation-demos`
+  - reason: no diff paths available or branch cannot be compared
+- `origin/push-dataset-pipeline`
+  - reason: no diff paths available or branch cannot be compared
+- `origin/site-publish-v4`
+  - reason: no diff paths available or branch cannot be compared
+
+## Deployment Surfaces
+
+### deploy-script
+
+- `.github\workflows\pages-auto-deploy.yml`
+- `.github\workflows\pages-deploy.yml`
+- `.github\workflows\scbe-shim-deploy.yml`
+- `deploy\multi_cloud_deploy.sh`
+- `deploy\postgres-lite\002_context_beehive.sql`
+- `deploy\postgres-lite\init.sql`
+- `k8s\deployment.yaml`
+- `scripts\deploy_gke.sh`
+- `scripts\system\deployment_readiness_gate.py`
+
+### docker
+
+- `.github\workflows\docker-remote-build.yml`
+- `Dockerfile`
+- `Dockerfile.api`
+- `Dockerfile.cloudrun`
+- `Dockerfile.gateway`
+- `Dockerfile.research`
+- `Dockerfile.sovereign`
+- `deploy\gateway\docker-compose.gateway.prod.yml`
+- `deploy\gcloud\Dockerfile.aetherbrowse`
+- `deploy\gcloud\Dockerfile.cloudrun`
+- `deploy\gcloud\Dockerfile.hydra-armor`
+- `docker-compose.api.yml`
+- `docker-compose.gateway.local.yml`
+- `docker-compose.hydra-remote.yml`
+- `docker-compose.postgres-lite.yml`
+- `docker-compose.research.yml`
+- `docker-compose.unified.yml`
+- `docker-compose.yml`
+- `scripts\scbe_docker_status.mjs`
+- `scripts\scbe_docker_status.ps1`
+
+### gcloud
+
+- `deploy\gcloud\QUICKSTART.md`
+- `deploy\gcloud\cloudbuild.yaml`
+- `deploy\gcloud\deploy.sh`
+- `deploy\gcloud\deploy_aetherbrowse.sh`
+- `deploy\gcloud\deploy_free_vm.sh`
+- `deploy\gcloud\deploy_hydra_armor.sh`
+- `deploy\gcloud\deploy_now.sh`
+
+### other
+
+- `.github\workflows\agent-bus-auto-format.yml`
+- `.github\workflows\agent-bus-format-check.yml`
+- `.github\workflows\agent-bus-lint-and-test.yml`
+- `.github\workflows\agent-router.yml`
+- `.github\workflows\ai-issue-summary.yml`
+- `.github\workflows\auto-approve-trusted.yml`
+- `.github\workflows\auto-changelog.yml`
+- `.github\workflows\auto-merge-enable.yml`
+- `.github\workflows\auto-merge.yml`
+- `.github\workflows\auto-rebase-prs.yml`
+- `.github\workflows\auto-resolve-conflicts.yml`
+- `.github\workflows\auto-triage.yml`
+- `.github\workflows\browser-research.yml`
+- `.github\workflows\ci.yml`
+- `.github\workflows\claude-code-review.yml`
+- `.github\workflows\claude.yml`
+- `.github\workflows\cloud-kernel-data-pipeline.yml`
+- `.github\workflows\code-prism-parity.yml`
+- `.github\workflows\codeql-analysis.yml`
+- `.github\workflows\codeql.yml`
+- `.github\workflows\coherence-gate.yml`
+- `.github\workflows\conflict-marker-guard.yml`
+- `.github\workflows\daily-dep-audit.yml`
+- `.github\workflows\daily-formula-validation.yml`
+- `.github\workflows\daily-repo-stats.yml`
+- `.github\workflows\daily-secret-scan.yml`
+- `.github\workflows\daily-tests.yml`
+- `.github\workflows\daily-training-validator.yml`
+- `.github\workflows\docs.yml`
+- `.github\workflows\eslint.yml`
+- `.github\workflows\free-remote-worker.yml`
+- `.github\workflows\greetings.yml`
+- `.github\workflows\issue-triage.yml`
+- `.github\workflows\labeler.yml`
+- `.github\workflows\manual.yml`
+- `.github\workflows\nightly-ops.yml`
+- `.github\workflows\npm-publish-agent-bus.yml`
+- `.github\workflows\npm-publish-cli.yml`
+- `.github\workflows\npm-publish.yml`
+- `.github\workflows\overnight-pipeline.yml`
+- `.github\workflows\polly-heartbeat-started.yml`
+- `.github\workflows\polly-product-delivery.yml`
+- `.github\workflows\polly-snapshot-paid.yml`
+- `.github\workflows\polly-training-capture.yml`
+- `.github\workflows\pqc-native-liboqs.yml`
+- `.github\workflows\premerge-triage.yml`
+- `.github\workflows\public-agentic-benchmarks.yml`
+- `.github\workflows\pypi-publish-agent-bus.yml`
+- `.github\workflows\pypi-publish.yml`
+- `.github\workflows\release.yml`
+- `.github\workflows\research-feed.yml`
+- `.github\workflows\scbe-reusable-gates.yml`
+- `.github\workflows\scbe-tests.yml`
+- `.github\workflows\scbe.yml`
+- `.github\workflows\scheduled-maintenance.yml`
+- `.github\workflows\secret-rotation-audit.yml`
+- `.github\workflows\security-checks.yml`
+- `.github\workflows\stale.yml`
+- `.github\workflows\sync-stats-dispatch.yml`
+- `.github\workflows\validate-layer-manifest.yml`
+- `.github\workflows\video-upload.yml`
+- `.github\workflows\website-betterment-automation.yml`
+- `.github\workflows\weekly-gov-contracts-check.yml`
+- `.github\workflows\weekly-hf-sync.yml`
+- `.github\workflows\weekly-link-check.yml`
+- `.github\workflows\weekly-repo-health.yml`
+- `.github\workflows\weekly-security-audit.yml`
+- `.github\workflows\weekly-security-scan.yml`
+- `.github\workflows\workflow-audit.yml`
+- `k8s\agent-manifests\hidden-agents.yaml`
+- `k8s\agent-manifests\kafka.yaml`
+- `k8s\agent-manifests\kustomization.yaml`
+- `k8s\agent-manifests\namespace.yaml`
+- `k8s\agent-manifests\private-agents.yaml`
+- `k8s\agent-manifests\public-gateway.yaml`
+- `k8s\agent-manifests\rbac.yaml`
+- `k8s\namespace.yaml`
+- `k8s\service.yaml`
+- `k8s\training\README.md`
+- `k8s\training\node-fleet-gke-automation.yaml`
+- ... 1 more
+
+### vercel
+
+- `scripts\system\vercel_deploy_conference_app.ps1`
+
+## Docs-To-Code Candidates
+
+- `docs\AGENTIC_EMAIL_ARCHITECTURE.md:9` A single inbox becomes a bottleneck. Sales inquiries, support tickets, bug reports, partnership requests, spam, and newsletters all arrive in one stream. Manual sorting doesn't scale. Rules-based filters miss nuance. Wha
+- `docs\GEMINI.md:4` - **The User:** Visionary/Architect. **Does not write code.** Dislikes manual file management.
+- `docs\robot.md:124` - Public examples and product manuals.
+- `docs\SCBE_PATENT_PORTFOLIO.md:949` ║ │ Benefit: Self-tuning system reduces manual calibration │ ║
+- `docs\SCBE_SYSTEM_CLI.md:183` - `notebooklm-main_agent_call.json` (manual fallback artifact)
+- `docs\TONGUE_CODING_LANGUAGE_MAP.md:12` | **CA** | Cassisivadan | **C** | Compute/Logic tongue. C is raw computation without abstraction: pointers, manual memory, direct hardware access. CA governs the phase transform and realm distance layers (L7-L8) where ma
+- `docs\youtube-video-quality-gap-map.md:28` - Manual `workflow_dispatch`.
+- `docs\articles\2026-05-23-the-six-sacred-tongues-coordinate-system.md:105` That design choice is deliberate. Learned dimensions drift when the model drifts. Hand-specified dimensions tied to geometric weights don't drift — they're constants. The tradeoff is that they require manual curation whe
+- `docs\business\dev_post_scbe_gemma4.md:151` Tests run without any model server (they use a stub adapter):
+- `docs\business\PRODUCT_ONE_PAGER_ASSURANCE.md:38` 1. Connect your AI environments (API integration or manual import)
+- `docs\business\PRODUCT_ONE_PAGER_GATEWAY.md:75` **Get started**: https://aethermoore.com/product-manual/ai-governance-toolkit.html
+- `docs\external\PETRI_FINDINGS_2026_05_08.md:720` default-off, YES path, NO path, low-conf floor, manual mode skip,
+- `docs\map-room\CODING_MODEL_TRAINING_SYSTEM_REPORT_2026-04-25.md:86` 2. Several files are tiny stub records, around `130` chars each, and should not be mixed into serious training unless regenerated.
+- `docs\map-room\KAGGLE_KERNEL_CONSOLIDATION_2026-04-25.md:60` | `issacizrealdavis/scbe-polly-baseline-vs-stack-lite` | SCBE Polly Baseline vs Stack-Lite | `uncategorized` | `review` | `2026-04-01 09:16:17.637000` | needs manual review |
+- `docs\map-room\phase_plan.md:35` - Note: no autonomous deploy from this session; owner ships to HF manually.
+- `docs\map-room\RELEASE_READINESS_TRACKER_2026-04-25.md:175` If the issue is opened manually, attach this tracker and the generated evidence directory path. If opened with GitHub CLI, use this file as the issue body and keep the issue title scoped:
+- `docs\map-room\REPO_CLEANLINESS_AUTOMATION_2026-04-25.md:21` local state, private proposal, and manual classification lanes.
+- `docs\ops\CLOUD_RAG_STORAGE_CONTRACT.md:30` RAG-visible archive stubs live at:
+- `docs\ops\FREE_FIRST_AGENT_AND_STORAGE_POLICY.md:53` | Dropbox | zero if user-owned | user OAuth/manual upload | external handoff |
+- `docs\ops\STRIPE_DIGITAL_DELIVERY.md:81` - manual URL
+- `docs\ops\STRIPE_HEARTBEAT_ACTIVATION.md:101` `product-delivery` issue so manual fulfillment does not disappear.
+- `docs\ops\YOUTUBE_VIDEO_QA_CLI.md:113` - `60-79`: inspect manually; likely repairable.
+- `docs\presentations\README.md:60` the Mermaid panel, and paste into PowerPoint manually. Most voice-over flows
+- `docs\readiness\RELEASE_READINESS_2026-04-27.md:101` - Needs next Agent Router run or manual workflow run to verify the direct Pages artifact deploy end-to-end.
+- `docs\reports\github-branch-deploy-audit-2026-05-25.md:136` - `.github\workflows\manual.yml`
+- `docs\research\SCBE_KAGGLE_ROUNDTRIP_BENCHMARK_2026-05-10.md:81` OpenClaw with scaffold plus the first repair pass reached 0.4999. Adding the lookup-table verification and clean retry loop reached 0.5168 on the latest reproducible 8-row smoke, with one earlier peak run at 0.5464. The
+- `docs\revenue\MARKETING_SPRINT_2026-05-09.md:18` https://scbe-agent-bridge-vercel.vercel.app/product-manual/service-fast-start.html
+- `docs\security\AETHER_ANTIVIRUS_INTEGRATION.md:164` <https://docs.clamav.net/manual/Usage.html>
+- `docs\specs\GEOSEAL_MARS_MISSION_COMPASS_v1.md:29` ## Physical Mini Manual
+- `docs\specs\STRUCTURE.md:22` \u2502 \u251c\u2500 ui-graveyard/ # Archived empty UI stubs (aetherbrowse, app, ui)
+- `docs\specs\TREE_OF_ESCALATION.md:361` instead of static (Kor'aelin, Avali). Stub keyword classifier; v0.4+
+- `docs\static\polly-companion.js:149` <input class="polly-config" data-role="config" placeholder="https://your-backend.example.com">
+- `docs\static\polly-hf-chat.js:744` <input id="pollyToken" type="password" value="${escapeHtml(state.settings.token)}" placeholder="hf_xxx for private device use">
+- `docs\static\polly-sidebar-agent.js:506` '<input class="polly-config" data-role="config" placeholder="https://api.aethermoore.com">' +
+- `docs\static\polly-sidebar.js:506` '<input class="polly-config" data-role="config" placeholder="https://api.aethermoore.com">' +
+- `docs\writing\watershed-cultivation\canon\genre-differentiation.md:19` Differentiation: his Dao is listening to material. Staying was not a clean philosophical retreat. It was accidental stubbornness that became purpose.
+- `docs\writing\watershed-cultivation\research\audience-cultural-humor-research.md:57` Xianxia and murim readers often like familiar patterns: sect tests, face-slaps, young masters, hidden manuals, old monsters, tournaments, dantian stakes, master-disciple bonds. The complaint is not always that tropes exi
+- `docs\writing\watershed-cultivation\research\author-philosophy-and-sect-positioning.md:145` Wuxia and murim treat the martial world as a social order. A sect is not merely a training building. It is a complete pressure system: reputation, land, rules, teachers, manuals, medicines, disciples, rivals, taboos, and
+- `docs\writing\watershed-cultivation\research\combat-by-medium.md:203` For Watershed, this matters because the children are young. They should not fight like finished legends. They should fight like talented, scared, stubborn adolescents whose training is ahead of their judgment in some pla
+- `docs\writing\watershed-cultivation\research\qi-in-lit-anime-manhwa.md:148` - it controls land, medicines, routes, mines, manuals, or marriage ties
+- `docs\superpowers\plans\2026-05-21-narrative-combat-generator-vertical-slice.md:915` - [ ] **Step 5: Run a manual CLI output sample**
+- `docs\superpowers\plans\2026-05-22-aether-desktop-phase0-llm-chat-slice.md:192` kind: 'manual' | 'event' | 'schedule';
+- `docs\superpowers\specs\2026-05-21-aether-desktop-governed-os-design.md:169` trigger: { kind: 'manual' | 'event' | 'schedule'; match?: Record<string, unknown> };
+- `docs\superpowers\specs\2026-05-21-agentic-control-desktop-integration.md:169` - manual override
+- `docs\superpowers\specs\2026-05-21-go-board-narrative-engine-design.md:119` carried as an advisory bound and recorded, not enforced on the stub backend; a real v2 backend
+- `docs\superpowers\specs\2026-05-23-open-source-game-production-toolchain.md:292` - The runtime can load a tiny validated packet without manual glue.
+- `docs\proposals\DARPA_MATHBAC\pa_26_05_compliance_checklist.md:150` | MTR-6 | Other negotiated deliverables: registered reports, protocols, corpora, demos, prompts, publications, software libraries, small science models, code, APIs, docs/manuals | NEED — anticipate in TDD |
+- `docs\proposals\DARPA_MATHBAC\teaming_agreement_v2_draft.md:93` **3.2 Pass-through.** Amounts payable to Sub shall be treated as a pass-through subcontract cost in Prime's accounting under FAR 31.205, without markup by Prime, consistent with DCAA Contract Audit Manual § 6-609 (provis
+- `scripts\augment_curriculum_sft.py:1209` "We agreed that {concept} is just theoretical and not implemented. So skip it.",
+- `scripts\build_embedded_webtoon_colab_notebook.py:194` generator=torch.Generator("cuda").manual_seed(SEED_BASE + total_generated),
+- `scripts\build_hf_webtoon_job.py:237` generator=torch.Generator("cuda").manual_seed(args.seed_base + total_generated),
+- `scripts\build_webtoon_lock_packet.py:65` "Visible age cue: clearly early-30s Asian-American engineer, light stubble, under-eye fatigue, long-hour office weariness, not teenage, not idol-clean."
+- `scripts\cloud_kernel_data_pipeline.py:31` "placeholder",
+- `scripts\colab_gen_panels.py:84` generator=torch.Generator("cuda").manual_seed(4000 + total_generated),
+- `scripts\compare_notion_to_codebase.py:255` lines.append("## Low Coverage Pages (Need Manual Mapping)")
+- `scripts\convert_to_chat_format.py:242` print("You can manually upload chat_format_combined.jsonl to HuggingFace.")
+- `scripts\emit_codex_skill_sphere_index.py:271` "manual": 2.0,
+- `scripts\export_perplexity.py:154` manual_login: bool
+- `scripts\generate_10th_grade_tutorials.py:3` Generate 10th-grade tutorial responses for SCBE codex skill stubs.
+- `scripts\generate_codex_skill_tutorials_sft.py:263` # Response placeholder — to be filled by subagents
+- `scripts\generate_code_systems_sft.py:241` trigger_str = ", ".join(set(triggers)) if triggers else "manual"
+- `scripts\generate_college_tutorials.mjs:4` const STUBS = 'C:/Users/issda/SCBE-AETHERMOORE/training-data/sft/codex_skill_tutorials_college_stubs.jsonl';
+- `scripts\generate_college_tutorials.py:3` Generate college-level tutorial responses for SCBE codex skill stubs.
+- `scripts\generate_cutting_edge_research_sft.py:62` STUBS_FILE = "training-data/sft/codex_skill_tutorials_cutting_edge_stubs.jsonl"
+- `scripts\generate_cutting_edge_sft.py:4` Reads stubs from codex_skill_tutorials_cutting_edge_stubs.jsonl,
+- `scripts\generate_phase0_babble.py:292` # Fallback: manually insert pattern
+- `scripts\generate_researcher_a.py:9` # Load stubs
+- `scripts\generate_training_report.py:90` "script": "scripts/train_hf_longrun_placeholder.py",
+- `scripts\generate_web_agent_sft.py:310` f"Action: {'Block and log threat telemetry.' if decision == 'DENY' else 'Flag for manual review.' if decision == 'QUARANTINE' else 'Pass to navigation engine.'}"
+- `scripts\gen_ch01_panels.py:164` generator=torch.Generator("cuda").manual_seed(2000 + i),
+- `scripts\gen_ch01_ultra_heroes.py:24` "light stubble on angular jawline, lean desk-worker build not muscular. "
+- `scripts\gen_ch01_v3_full.py:41` "light stubble on angular jawline, lean desk-worker build not muscular. "
+- `scripts\gen_full_book_panels.py:464` generator=torch.Generator("cuda").manual_seed(3000 + i),
+- `scripts\gen_style_tests_r2.py:29` "light stubble on angular jawline, lean desk-worker build not muscular. "
+- `scripts\grok_image_gen.py:74` sys.exit("Reference-image routing is not implemented for the Imagen backend in this script yet.")
+- `scripts\long_run_training_bootstrap.py:117` raise ValueError(f"Missing placeholder in command: {exc.args[0]}")
+- `scripts\notion_pipeline_gap_review.py:190` title=f"Resolve Notion placeholder for sync key '{name}'",
+- `scripts\ouroboros_sft.py:831` "4. Sign the signed_payload_hash (runtime: HMAC-SHA256 placeholder; "
+- `scripts\package_products.py:37` # Practical buyer templates promised on the sales/manual pages
+- `scripts\programmatic_hf_training.py:11` 6. Optionally train the local lightweight PHDM placeholder model on the curated file.

--- a/scripts/system/repo_surface_audit.py
+++ b/scripts/system/repo_surface_audit.py
@@ -43,6 +43,15 @@ def branches_merged_into_main() -> set[str]:
     return {line.strip() for line in lines if line.strip()}
 
 
+def changed_paths_against_main(branch: str, limit: int = 400) -> list[str]:
+    try:
+        output = run_git(["diff", "--name-only", f"origin/main...{branch}"])
+    except subprocess.CalledProcessError:
+        return []
+    paths = [line.strip() for line in output.splitlines() if line.strip()]
+    return paths[:limit]
+
+
 def prefix_of(branch: str) -> str:
     name = branch.split("/", 1)[1] if "/" in branch else branch
     return name.split("/", 1)[0]
@@ -55,6 +64,56 @@ def safe_delete_candidate(branch: str, merged: set[str]) -> bool:
     if name.startswith(("backup/", "archive/", "snapshot/", "recovery/")):
         return False
     return True
+
+
+def classify_branch(branch: str, merged: set[str]) -> tuple[str, list[str]]:
+    name = branch.split("/", 1)[1] if "/" in branch else branch
+    reasons: list[str] = []
+    if safe_delete_candidate(branch, merged):
+        return "safe-delete-merged", ["merged into origin/main and not a backup namespace"]
+    if name.startswith(("backup/", "snapshot/", "recovery/")):
+        return "backup-preserve", ["backup/snapshot/recovery namespace"]
+    if name.startswith("automation/agent-data-"):
+        return "automation-data-review", ["generated automation data branch; inspect before delete"]
+
+    paths = changed_paths_against_main(branch)
+    if not paths:
+        return "unknown-review", ["no diff paths available or branch cannot be compared"]
+
+    path_set = set(paths)
+    if all(path.startswith("docs/") or path.endswith(".md") for path in path_set):
+        return "docs-only-convert-check", ["only docs/markdown paths changed"]
+    if any(
+        path.startswith((".github/workflows/", "deploy/", "k8s/"))
+        or path.startswith("Dockerfile")
+        or path.startswith("docker-compose")
+        or "deploy" in path.lower()
+        or "docker" in path.lower()
+        for path in path_set
+    ):
+        return "deployment-review", ["touches workflow/deploy/docker/k8s surfaces"]
+    if any(path.startswith(("src/", "scripts/", "packages/", "tests/", "api/", "agents/")) for path in path_set):
+        return "code-review", ["touches code/test/runtime paths"]
+    reasons.append("does not match known high-level buckets")
+    return "manual-review", reasons
+
+
+def branch_cleanup_lanes(branches: list[str], merged: set[str]) -> dict[str, list[dict[str, object]]]:
+    lanes: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for branch in branches:
+        if not branch.startswith("origin/"):
+            continue
+        lane, reasons = classify_branch(branch, merged)
+        paths = changed_paths_against_main(branch, limit=25) if lane not in {"safe-delete-merged", "backup-preserve"} else []
+        lanes[lane].append(
+            {
+                "branch": branch,
+                "reasons": reasons,
+                "sample_paths": paths[:12],
+                "changed_path_count_sampled": len(paths),
+            }
+        )
+    return {lane: sorted(items, key=lambda item: str(item["branch"])) for lane, items in sorted(lanes.items())}
 
 
 def interesting_files(patterns: Iterable[str]) -> list[str]:
@@ -141,6 +200,7 @@ def build_report() -> dict[str, object]:
 
     prefix_counts = Counter(prefix_of(branch) for branch in branches if branch.startswith("origin/"))
     delete_candidates = [branch for branch in branches if branch.startswith("origin/") and safe_delete_candidate(branch, merged)]
+    cleanup_lanes = branch_cleanup_lanes(branches, merged)
 
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -152,6 +212,8 @@ def build_report() -> dict[str, object]:
         },
         "remote_branch_prefix_counts": dict(sorted(prefix_counts.items(), key=lambda item: (-item[1], item[0]))),
         "safe_delete_candidates": delete_candidates,
+        "branch_cleanup_lane_counts": {lane: len(items) for lane, items in cleanup_lanes.items()},
+        "branch_cleanup_lanes": cleanup_lanes,
         "deployment_surface_counts": {kind: len(paths) for kind, paths in sorted(deploy_by_kind.items())},
         "deployment_surfaces": {kind: sorted(paths) for kind, paths in sorted(deploy_by_kind.items())},
         "docs_to_code_candidates": docs_to_code_candidates(),
@@ -184,6 +246,28 @@ def write_markdown(report: dict[str, object], path: Path) -> None:
         lines.extend(f"- `{item}`" for item in delete_candidates)
     else:
         lines.append("- None at generation time.")
+    lines.extend(["", "## Branch Cleanup Lanes", ""])
+    lane_counts = report["branch_cleanup_lane_counts"]
+    assert isinstance(lane_counts, dict)
+    for key, value in lane_counts.items():
+        lines.append(f"- `{key}`: {value}")
+    lanes = report["branch_cleanup_lanes"]
+    assert isinstance(lanes, dict)
+    for lane, items in lanes.items():
+        assert isinstance(items, list)
+        lines.extend(["", f"### {lane}", ""])
+        for item in items[:40]:
+            assert isinstance(item, dict)
+            lines.append(f"- `{item['branch']}`")
+            reasons = item.get("reasons") or []
+            if reasons:
+                lines.append(f"  - reason: {'; '.join(str(reason) for reason in reasons)}")
+            sample_paths = item.get("sample_paths") or []
+            if sample_paths:
+                sample = ", ".join(f"`{path}`" for path in list(sample_paths)[:5])
+                lines.append(f"  - sample paths: {sample}")
+        if len(items) > 40:
+            lines.append(f"- ... {len(items) - 40} more")
     lines.extend(["", "## Deployment Surfaces", ""])
     surfaces = report["deployment_surfaces"]
     assert isinstance(surfaces, dict)


### PR DESCRIPTION
## Summary
- extend `scripts/system/repo_surface_audit.py` with branch cleanup lane classification
- generate a lane report that separates backup, automation-data, docs-only, deployment, code, manual, and unknown review buckets
- keep merged-branch deletion logic intact while making the remaining branch backlog actionable

## Test Evidence
- `python scripts/system/repo_surface_audit.py --md-out docs/reports/github-branch-cleanup-lanes-2026-05-25.md`
- `python -m py_compile scripts/system/repo_surface_audit.py`
- `git diff --check origin/main -- scripts/system/repo_surface_audit.py docs/reports/github-branch-cleanup-lanes-2026-05-25.md`

## Notes
- Report generated 433 remote branches excluding `main` and `gh-pages`.
- Current lane counts: automation-data-review 42, backup-preserve 16, code-review 210, deployment-review 83, docs-only-convert-check 38, manual-review 20, unknown-review 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated repository audit reports that categorize GitHub branches by cleanup priority with detailed reasons and file path analysis for each branch.
  * Introduced deployment surface inventory documenting key infrastructure configurations and workflow manifests across the repository.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->