### PR TITLE
fix(cli): tighten first-run package surface

### DIFF
--- a/docs/packages/scbe-aethermoore-cli.html
+++ b/docs/packages/scbe-aethermoore-cli.html
@@ -45,7 +45,7 @@
               <div><strong>$ scbe selftest</strong></div>
               <div>checks passed</div>
               <div><strong>$ scbe version</strong></div>
-              <div>scbe-aethermoore-cli 4.3.4</div>
+              <div>scbe-aethermoore-cli 4.4.0</div>
               <div><strong>$ scbe abacus run --d-h 0.1 --pd 0 --json</strong></div>
               <div>{ "tier": "ALLOW", "trit": 1 }</div>
               <div><strong>$ geoseal verify-file build.zip</strong></div>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,6 +15,7 @@ npm i -g scbe-aethermoore-cli
 ```bash
 scbe --help
 scbe version
+scbe version --json
 scbe demo
 scbe demo --json
 scbe selftest
@@ -25,7 +26,7 @@ scbe run "npm test"
 scbe status
 scbe history --limit 20
 scbe ca-plan --ops "abs abs add" --json
-scbe compile ca --opcodes "0x09 0x09 0x00" --target python
+scbe compile ca --opcodes "0x09 0x09 0x00" --target python --fn score --args a,b
 scbe render-op --op add --target KO --a left --b right
 scbe route --program "encode \"run tests\" in tongue KO"
 ```
@@ -34,7 +35,8 @@ The same binary is also exposed as `geoseal` and `scbe-geoseal`.
 
 ## Tool Surface
 
-- `version`: prints the installed `scbe-aethermoore` package version.
+- `version`: prints the installed CLI package version. `version --json` also
+  reports the backing `scbe-aethermoore` core version.
 - `demo`: runs the 5-minute agent safety demo. It sends a risky AI-agent tool
   request through the GeoSeal execution gate and prints the governed output
   packet: output, decision, reasons, suggested correction, and audit id.

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -8,6 +8,16 @@ const os = require('node:os');
 const path = require('node:path');
 const readline = require('node:readline');
 
+function readJsonFileSafe(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (_err) {
+    return {};
+  }
+}
+
+const CLI_PACKAGE_JSON = readJsonFileSafe(path.resolve(__dirname, '..', 'package.json'));
+
 const SERVICE_CREDITS = {
   schema_version: 'scbe_service_credits_v1',
   name: 'SCBE Service Credits',
@@ -26,6 +36,7 @@ Usage:
 
 Core commands:
   scbe version
+  scbe version --json
   scbe demo
   scbe demo --json
   scbe selftest
@@ -80,10 +91,10 @@ Trap-in-good-loops dispatcher (forwards to FREE providers — offline by default
   echo "<prompt>" | scbe trap-dispatch --json
 
 Compiler and routing commands, available from a source checkout:
-  scbe compile-ca --opcodes "0x09 0x09 0x00" --target python
+  scbe compile-ca --opcodes "0x09 0x09 0x00" --target python --fn score --args a,b
   scbe ca-plan --ops "abs abs add" --json
   scbe render-op --op add --target KO --a left --b right
-  scbe compile ca --opcodes "0x09 0x09 0x00" --target typescript
+  scbe compile ca --opcodes "0x09 0x09 0x00" --target typescript --fn score --args a,b
   scbe route --program 'encode "run tests" in tongue KO'
 
 Hosted run path:
@@ -114,6 +125,40 @@ function resolveGeosealBin() {
 
 function repoRoot() {
   return path.resolve(__dirname, '..', '..', '..');
+}
+
+function findPackageJsonFromEntry(entryPath, expectedName) {
+  let current = path.dirname(entryPath);
+  for (let i = 0; i < 8; i += 1) {
+    const candidate = path.join(current, 'package.json');
+    const parsed = readJsonFileSafe(candidate);
+    if (!expectedName || parsed.name === expectedName) return parsed;
+    const next = path.dirname(current);
+    if (next === current) break;
+    current = next;
+  }
+  return {};
+}
+
+function corePackageJson() {
+  try {
+    return findPackageJsonFromEntry(require.resolve('scbe-aethermoore'), 'scbe-aethermoore');
+  } catch (_err) {
+    return readJsonFileSafe(path.resolve(repoRoot(), 'package.json'));
+  }
+}
+
+function versionPacket() {
+  const core = corePackageJson();
+  return {
+    schema_version: 'scbe_aethermoore_cli_version_v1',
+    cli_package: CLI_PACKAGE_JSON.name || 'scbe-aethermoore-cli',
+    cli_version: CLI_PACKAGE_JSON.version || 'unknown',
+    core_package: core.name || 'scbe-aethermoore',
+    core_version: core.version || 'unknown',
+    node: process.version,
+    platform: process.platform,
+  };
 }
 
 function resolveRepoScript(relativePath) {
@@ -163,6 +208,28 @@ function firstLine(text) {
       .split(/\r?\n/)
       .filter(Boolean)[0] || ''
   );
+}
+
+function parseJsonFromText(text) {
+  const raw = String(text || '').trim();
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (_err) {
+    // Some Python/native paths print warnings before the JSON receipt. Try
+    // every line suffix so a leading warning does not turn a DENY into WARN.
+    const lines = raw.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+      const candidate = lines.slice(i).join('\n').trim();
+      if (!candidate.startsWith('{') && !candidate.startsWith('[')) continue;
+      try {
+        return JSON.parse(candidate);
+      } catch (_innerErr) {
+        // Keep scanning later suffixes.
+      }
+    }
+  }
+  return null;
 }
 
 function appendHistory(row) {
@@ -223,9 +290,9 @@ function gateCommand(command) {
       stderr_preview: String(child.stderr || '').slice(0, 500),
     };
   }
-  try {
-    return JSON.parse(String(child.stdout || '{}'));
-  } catch (_err) {
+  const parsed = parseJsonFromText(child.stdout);
+  if (parsed) return parsed;
+  {
     return {
       allowed: true,
       tier: 'WARN',
@@ -688,9 +755,8 @@ function runLiboqs(args) {
     process.exit(1);
   }
   let payload;
-  try {
-    payload = JSON.parse(result.stdout);
-  } catch (_err) {
+  payload = parseJsonFromText(result.stdout);
+  if (!payload) {
     payload = {
       schema_version: 'scbe_liboqs_receipt_v1',
       receipt: 'SCBE_LIBOQS_PASS=0',
@@ -727,6 +793,68 @@ function runLiboqs(args) {
     );
   }
   process.exit(payload.native_pass ? 0 : 1);
+}
+
+function runVersion(args) {
+  const payload = versionPacket();
+  if (args.includes('--json')) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${payload.cli_version}\n`);
+  }
+  process.exit(0);
+}
+
+function runDoctor(args) {
+  const asJson = args.includes('--json');
+  const target = resolveGeosealBin();
+  const child = spawnSync(process.execPath, [target, 'doctor', '--json'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const geosealDoctor = parseJsonFromText(child.stdout);
+  const versions = versionPacket();
+  const payload = {
+    schema_version: 'scbe_aethermoore_cli_doctor_v1',
+    ok: child.status === 0 && (!geosealDoctor || geosealDoctor.ok !== false),
+    cli_package: versions.cli_package,
+    cli_version: versions.cli_version,
+    core_package: versions.core_package,
+    core_version: versions.core_version,
+    node: process.version,
+    platform: process.platform,
+    cli_package_bin: CLI_PACKAGE_JSON.bin || {},
+    geoseal_bin: target,
+    geoseal_doctor: geosealDoctor,
+    geoseal_doctor_status: typeof child.status === 'number' ? child.status : 1,
+    stderr_preview: String(child.stderr || '').slice(0, 1000),
+  };
+  if (geosealDoctor && geosealDoctor.package_bin) {
+    payload.core_package_bin = geosealDoctor.package_bin;
+  }
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } else {
+    const apiCount =
+      geosealDoctor && Array.isArray(geosealDoctor.api_commands)
+        ? geosealDoctor.api_commands.length
+        : 0;
+    const activeService =
+      geosealDoctor && geosealDoctor.active_service
+        ? geosealDoctor.active_service.api_base
+        : 'none';
+    process.stdout.write(
+      [
+        `SCBE CLI doctor ${payload.cli_version} (core ${payload.core_version})`,
+        `Node: ${payload.node}`,
+        `GeoSeal: ${payload.geoseal_doctor_status === 0 ? 'ok' : 'fail'}`,
+        `Active service: ${activeService}`,
+        `API commands: ${apiCount}`,
+        '',
+      ].join('\n')
+    );
+  }
+  process.exit(payload.ok ? 0 : 1);
 }
 
 function runInteractiveShell() {
@@ -2096,10 +2224,9 @@ function runUpgrade(args) {
 }
 
 function runSelftest() {
-  const target = resolveGeosealBin();
-  const checks = [['version'], ['doctor', '--json']];
+  const checks = [['version', '--json'], ['doctor', '--json']];
   const results = checks.map((args) => {
-    const child = spawnSync(process.execPath, [target, ...args], {
+    const child = spawnSync(process.execPath, [__filename, ...args], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -2146,6 +2273,14 @@ if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h' || argv[0] ===
 
 if (argv[0] === 'demo' || argv[0] === 'magic') {
   runMagicDemo(argv.slice(1));
+}
+
+if (argv[0] === 'version') {
+  runVersion(argv.slice(1));
+}
+
+if (argv[0] === 'doctor') {
+  runDoctor(argv.slice(1));
 }
 
 if (argv[0] === 'credits' || argv[0] === 'hosted-run') {
@@ -2252,7 +2387,7 @@ if (argv[0] === 'compile') {
     process.stdout.write(
       [
         'Usage:',
-        '  scbe compile ca --opcodes "0x09 0x09 0x00" --target python',
+        '  scbe compile ca --opcodes "0x09 0x09 0x00" --target python --fn score --args a,b',
         '  scbe compile plan --ops "abs abs add" --json',
         '  scbe compile op --op add --target KO --a left --b right',
         '',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/issdandavis/SCBE-AETHERMOORE.git",
-    "directory": "packages/scbe-aethermoore-cli"
+    "directory": "packages/cli"
   },
   "bugs": {
     "url": "https://github.com/issdandavis/SCBE-AETHERMOORE/issues"

--- a/scripts/agents/scbe_code.py
+++ b/scripts/agents/scbe_code.py
@@ -165,7 +165,7 @@ def cmd_ca_plan(args: argparse.Namespace) -> int:
         "opcodes": opcodes,
         "hex_sequence": hex_sequence,
         "hex": ", ".join(hex_sequence),
-        "compile_hint": f"compile-ca --opcodes \"{' '.join(hex_sequence)}\"",
+        "compile_hint": f"compile-ca --opcodes \"{' '.join(hex_sequence)}\" --args a,b",
         "source": "python.scbe.ca_opcode_table.OP_TABLE",
     }
     print(json.dumps(payload, indent=2) if args.json else payload["hex"])

--- a/tests/agents/test_scbe_code.py
+++ b/tests/agents/test_scbe_code.py
@@ -77,7 +77,7 @@ def test_ca_plan_resolves_abs_abs_add_from_table():
     assert payload["source"] == "python.scbe.ca_opcode_table.OP_TABLE"
     assert payload["ops"] == ["abs", "abs", "add"]
     assert payload["hex_sequence"] == ["0x09", "0x09", "0x00"]
-    assert payload["compile_hint"] == 'compile-ca --opcodes "0x09 0x09 0x00"'
+    assert payload["compile_hint"] == 'compile-ca --opcodes "0x09 0x09 0x00" --args a,b'
 
 
 def test_ca_plan_known_abs_add_expression():

--- a/tests/system/test_scbe_npm_cli_compiler.py
+++ b/tests/system/test_scbe_npm_cli_compiler.py
@@ -30,6 +30,30 @@ def test_cli_exposes_ca_plan_compiler() -> None:
     assert payload["hex_sequence"] == ["0x09", "0x09", "0x00"]
 
 
+def test_cli_version_reports_cli_and_core_versions() -> None:
+    proc = run_cli("version", "--json")
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "scbe_aethermoore_cli_version_v1"
+    assert payload["cli_package"] == "scbe-aethermoore-cli"
+    assert payload["cli_version"]
+    assert payload["core_package"] == "scbe-aethermoore"
+    assert payload["core_version"]
+
+
+def test_cli_doctor_wraps_geoseal_with_cli_version_context() -> None:
+    proc = run_cli("doctor", "--json")
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["schema_version"] == "scbe_aethermoore_cli_doctor_v1"
+    assert payload["cli_version"]
+    assert payload["core_version"]
+    assert payload["cli_package_bin"]["scbe"] == "bin/scbe.js"
+    assert payload["geoseal_doctor"]["ok"] is True
+
+
 def test_cli_demo_outputs_governed_magic_moment() -> None:
     proc = run_cli("demo", "--json")
 

--- a/tests/test_package_product_pages.py
+++ b/tests/test_package_product_pages.py
@@ -51,7 +51,7 @@ def test_live_package_pages_include_registry_links_and_versions() -> None:
     assert "PyPI: 4.1.3" in core
     assert "governance abacus" in core
     assert "https://www.npmjs.com/package/scbe-aethermoore-cli" in cli
-    assert "scbe-aethermoore-cli 4.3.4" in cli
+    assert "scbe-aethermoore-cli 4.4.0" in cli
     assert "scbe abacus run --d-h 0.1 --pd 0 --json" in cli
     assert "https://www.npmjs.com/package/scbe-agent-bus" in bus
     assert "https://pypi.org/project/scbe-agent-bus/" in bus


### PR DESCRIPTION
## Summary
- report the CLI package version separately from the core `scbe-aethermoore` version in `scbe version --json` and `scbe doctor --json`
- parse noisy Python/native JSON receipts so liboqs warnings do not turn real DENY/PASS receipts into WARN/fail fallbacks
- fix the published compile examples and CA compile hint so the opcode sequence includes stack args
- update CLI package metadata and package product page version copy

## Test Evidence
- `node --check packages\\cli\\bin\\scbe.js`
- `node packages\\cli\\bin\\scbe.js version --json`
- `node packages\\cli\\bin\\scbe.js doctor --json`
- `node packages\\cli\\bin\\scbe.js demo --json` -> `DENY`, `allowed=false`, `parser_ok=true`
- `node packages\\cli\\bin\\scbe.js selftest`
- `node packages\\cli\\bin\\scbe.js liboqs --json`
- `node packages\\cli\\bin\\scbe.js compile ca --opcodes "0x09 0x09 0x00" --target python --fn score --args a,b`
- `pytest tests\\system\\test_scbe_npm_cli_compiler.py tests\\agents\\test_scbe_code.py tests\\test_package_product_pages.py -q` -> 32 passed
- `Push-Location packages\\cli; npm pack --dry-run --json --ignore-scripts; Pop-Location` -> `scbe-aethermoore-cli-4.4.0.tgz`, 6 entries

## Notes
- Left existing unstaged `tests/security/test_pangram_content_gate.py` edits untouched; they are unrelated to this CLI patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - `scbe version --json` command outputs structured JSON containing CLI package version, core version, and platform information
  - `scbe doctor --json` command provides system diagnostics with version context, including CLI and core package details
  
* **Documentation**
  - Updated CLI help with expanded usage examples demonstrating new features and flags

* **Tests**
  - Added system tests validating JSON schema and output formats for new version and doctor commands

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->