### PR TITLE
fix(agent-bus): lint/format pass + CLI-as-tool feature + contracts fixes

### DIFF
--- a/packages/agent-bus/bin/scbe-agent-bus.cjs
+++ b/packages/agent-bus/bin/scbe-agent-bus.cjs
@@ -19,6 +19,8 @@ const {
   getQueueStatus,
   drainQueue,
   startQueueWorker,
+  listTools,
+  autoDiscoverTools,
 } = require('../dist/index.js');
 
 const HOSTED_INTAKE_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html';
@@ -99,11 +101,13 @@ Usage:
   scbe-agent-bus ui --base-url http://127.0.0.1:8787
   scbe-agent-bus send --task "review changed files" --task-type review --json
   scbe-agent-bus send --task "heavy job" --enqueue --json
+  scbe-agent-bus send --task "run linter" --tool lint --json
   scbe-agent-bus health --base-url http://127.0.0.1:8787 --json
   scbe-agent-bus queue status --json
   scbe-agent-bus queue drain
   scbe-agent-bus queue worker
   scbe-agent-bus plugins list --json
+  scbe-agent-bus tools list --json
   scbe-agent-bus workspace new --hint customer-smoke --json
   scbe-agent-bus workspace ingest --workspace-root <path> --source-path <file> --json
   scbe-agent-bus workspace export --workspace-root <path> --json
@@ -122,6 +126,7 @@ Commands:
   health    Check backend health.
   queue     Inspect or run the event queue.
   plugins   List registered bus plugins.
+  tools     List registered CLI tools (set SCBE_BUS_TOOLS=./tools.json to load).
   workspace Create, export, verify, and clean bus workspaces.
   upgrade   Show how to enable hosted runs (intake, credits, top-up).
 
@@ -522,6 +527,7 @@ async function main() {
       dispatchProvider: String(flags['dispatch-provider'] || 'offline'),
       dispatch: flags.dispatch !== 'false',
       enqueue: flags.enqueue === true,
+      ...(flags.tool ? { tool: String(flags.tool) } : {}),
     };
     const result = await postAgentBusEvent(event, { baseUrl });
     process.stdout.write(
@@ -588,6 +594,31 @@ async function main() {
       return;
     }
     process.stderr.write('Usage: scbe-agent-bus plugins list [--json]\n');
+    process.exitCode = 2;
+    return;
+  }
+  if (command === 'tools') {
+    autoDiscoverTools();
+    const action = String(flags._action || process.argv[3] || 'list').trim();
+    if (action === 'list') {
+      const payload = listTools().map((t) => ({
+        name: t.name,
+        command: t.command,
+        args: t.args,
+        description: t.description || '',
+      }));
+      if (flags.json) {
+        process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+      } else if (payload.length === 0) {
+        process.stdout.write('No tools registered. Set SCBE_BUS_TOOLS=./tools.json to load tools.\n');
+      } else {
+        for (const t of payload) {
+          process.stdout.write(`  ${t.name}  ${t.command} ${t.args.join(' ')}${t.description ? `  — ${t.description}` : ''}\n`);
+        }
+      }
+      return;
+    }
+    process.stderr.write('Usage: scbe-agent-bus tools list [--json]\n');
     process.exitCode = 2;
     return;
   }

--- a/packages/agent-bus/bin/scbe-agent-bus.cjs
+++ b/packages/agent-bus/bin/scbe-agent-bus.cjs
@@ -533,32 +533,58 @@ async function main() {
     const action = String(flags._action || process.argv[3] || 'help').trim();
     if (action === 'status') {
       const payload = getQueueStatus();
-      process.stdout.write(flags.json ? `${JSON.stringify(payload, null, 2)}\n` : `${JSON.stringify(payload)}\n`);
+      process.stdout.write(
+        flags.json ? `${JSON.stringify(payload, null, 2)}\n` : `${JSON.stringify(payload)}\n`
+      );
       return;
     }
     if (action === 'drain') {
       await drainQueue();
       const payload = getQueueStatus();
-      process.stdout.write(flags.json ? `${JSON.stringify({ drained: true, queue: payload }, null, 2)}\n` : 'Queue drained.\n');
+      process.stdout.write(
+        flags.json
+          ? `${JSON.stringify({ drained: true, queue: payload }, null, 2)}\n`
+          : 'Queue drained.\n'
+      );
       return;
     }
     if (action === 'worker') {
       const interval = Number(flags.interval || 5000);
       const handle = startQueueWorker(interval);
-      process.stdout.write(`Queue worker started (interval=${interval}ms). Press Ctrl+C to stop.\n`);
-      process.on('SIGINT', () => { handle.stop(); process.exit(0); });
-      process.on('SIGTERM', () => { handle.stop(); process.exit(0); });
+      process.stdout.write(
+        `Queue worker started (interval=${interval}ms). Press Ctrl+C to stop.\n`
+      );
+      process.on('SIGINT', () => {
+        handle.stop();
+        process.exit(0);
+      });
+      process.on('SIGTERM', () => {
+        handle.stop();
+        process.exit(0);
+      });
       return;
     }
-    process.stderr.write('Usage: scbe-agent-bus queue status | drain | worker [--interval <ms>] [--json]\n');
+    process.stderr.write(
+      'Usage: scbe-agent-bus queue status | drain | worker [--interval <ms>] [--json]\n'
+    );
     process.exitCode = 2;
     return;
   }
   if (command === 'plugins') {
     const action = String(flags._action || process.argv[3] || 'list').trim();
     if (action === 'list') {
-      const payload = listPlugins().map((p) => ({ name: p.name, hasBeforeRun: typeof p.beforeRun === 'function', hasAfterRun: typeof p.afterRun === 'function' }));
-      process.stdout.write(flags.json ? `${JSON.stringify(payload, null, 2)}\n` : payload.map((p) => `  ${p.name}  beforeRun=${p.hasBeforeRun} afterRun=${p.hasAfterRun}`).join('\n') + '\n');
+      const payload = listPlugins().map((p) => ({
+        name: p.name,
+        hasBeforeRun: typeof p.beforeRun === 'function',
+        hasAfterRun: typeof p.afterRun === 'function',
+      }));
+      process.stdout.write(
+        flags.json
+          ? `${JSON.stringify(payload, null, 2)}\n`
+          : payload
+              .map((p) => `  ${p.name}  beforeRun=${p.hasBeforeRun} afterRun=${p.hasAfterRun}`)
+              .join('\n') + '\n'
+      );
       return;
     }
     process.stderr.write('Usage: scbe-agent-bus plugins list [--json]\n');

--- a/packages/agent-bus/src/contracts.ts
+++ b/packages/agent-bus/src/contracts.ts
@@ -1,0 +1,90 @@
+/**
+ * @file contracts.ts
+ * @module agent-bus/contracts
+ *
+ * Structured output contracts for SCBE Agent Bus events.
+ *
+ * Research-backed: LangGraph, Pydantic AI, and Vercel AI SDK 6 all enforce
+ * JSON schema validation on agent outputs. This prevents AI agents from
+ * receiving unparseable blobs and enables reliable downstream chaining.
+ *
+ * Usage:
+ *   const event = {
+ *     task: 'Summarize',
+ *     outputSchema: z.object({ summary: z.string(), confidence: z.number() }),
+ *   };
+ *   const result = await runEvent(event);
+ *   // result.output is validated and typed
+ */
+
+import { z } from 'zod';
+
+export type JsonSchema = z.ZodTypeAny;
+
+export type ValidatedOutput<T = unknown> =
+  | {
+      ok: true;
+      data: T;
+    }
+  | {
+      ok: false;
+      error: string;
+      raw: unknown;
+    };
+
+/**
+ * Validate an arbitrary value against a Zod schema.
+ * Never throws. Returns a structured result AI agents can branch on.
+ */
+export function validateOutput<T>(raw: unknown, schema: JsonSchema): ValidatedOutput<T> {
+  const result = schema.safeParse(raw);
+  if (result.success) {
+    return { ok: true, data: result.data as T };
+  }
+  const summary = result.error.issues
+    .slice(0, 3)
+    .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+    .join('; ');
+  return { ok: false, error: summary, raw };
+}
+
+/**
+ * Pre-built contract schemas for common agent outputs.
+ * Import these to enforce consistency across task types.
+ */
+
+export const SummaryContract = z.object({
+  summary: z.string().min(1),
+  confidence: z.number().min(0).max(1).optional(),
+  sources: z.array(z.string()).optional(),
+});
+
+export const CodeReviewContract = z.object({
+  issues: z.array(
+    z.object({
+      severity: z.enum(['critical', 'warning', 'info']),
+      line: z.number().optional(),
+      message: z.string(),
+      suggestion: z.string().optional(),
+    })
+  ),
+  approved: z.boolean(),
+});
+
+export const ResearchContract = z.object({
+  findings: z.array(
+    z.object({
+      claim: z.string(),
+      evidence: z.string(),
+      confidence: z.number().min(0).max(1),
+    })
+  ),
+  gaps: z.array(z.string()).optional(),
+});
+
+export const GovernanceDecisionContract = z.object({
+  decision: z.enum(['allow', 'deny', 'quarantine']),
+  reason: z.string(),
+  risk_score: z.number().min(0).max(1).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1565,7 +1565,12 @@ export async function startAgentBusServer(
     try {
       if (req.method === 'GET' && req.url === '/health') {
         const { getQueueStatus } = await import('./queue.js');
-        sendJson(res, 200, { ok: true, service: 'scbe-agent-bus', version: 1, queue: getQueueStatus() });
+        sendJson(res, 200, {
+          ok: true,
+          service: 'scbe-agent-bus',
+          version: 1,
+          queue: getQueueStatus(),
+        });
         return;
       }
       if (req.method === 'GET' && req.url?.startsWith('/v1/events/')) {
@@ -1598,7 +1603,12 @@ export async function startAgentBusServer(
         const enqueue = !Array.isArray(body) && body.enqueue === true;
         const rows = await runBatch(items, { ...options, enqueue });
         if (enqueue) {
-          sendJson(res, 202, { ok: true, enqueued: true, count: rows.length, run_ids: rows.map((r) => (r.result as Record<string, string>)?.run_id).filter(Boolean) });
+          sendJson(res, 202, {
+            ok: true,
+            enqueued: true,
+            count: rows.length,
+            run_ids: rows.map((r) => (r.result as Record<string, string>)?.run_id).filter(Boolean),
+          });
         } else {
           sendJson(res, rows.every((row) => row.ok) ? 200 : 500, { rows });
         }

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -31,6 +31,17 @@ export {
   startQueueWorker,
 } from './queue.js';
 
+export {
+  type CliTool,
+  registerTool,
+  unregisterTool,
+  listTools,
+  getTool,
+  clearTools,
+  buildToolArgv,
+  autoDiscoverTools,
+} from './tools.js';
+
 export type AgentBusPrivacy = 'local_only' | 'remote_allowed' | string;
 
 export interface AgentBusEvent {
@@ -42,6 +53,8 @@ export interface AgentBusEvent {
   budgetCents?: number;
   dispatch?: boolean;
   dispatchProvider?: string;
+  /** Name of a registered CliTool to dispatch to instead of scbe-system-cli.py. */
+  tool?: string;
 }
 
 export interface RunOptions {
@@ -1407,6 +1420,7 @@ function normalizeEvent(event: AgentBusEvent, index: number): Required<AgentBusE
     budgetCents: Number(event.budgetCents || 0),
     dispatch: event.dispatch !== false,
     dispatchProvider: String(event.dispatchProvider || 'offline').trim(),
+    tool: event.tool ?? '',
   };
 }
 

--- a/packages/agent-bus/src/queue.ts
+++ b/packages/agent-bus/src/queue.ts
@@ -217,8 +217,12 @@ function executeEventAsync(
 
     child.stdout.setEncoding('utf-8');
     child.stderr.setEncoding('utf-8');
-    child.stdout.on('data', (chunk) => { stdout += chunk; });
-    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
 
     child.on('close', (code) => {
       let payload: Record<string, unknown> | null = null;

--- a/packages/agent-bus/src/queue.ts
+++ b/packages/agent-bus/src/queue.ts
@@ -20,6 +20,7 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import type { AgentBusEvent, AgentBusResult, RunOptions } from './index.js';
 import { runBeforeRunPlugins, runAfterRunPlugins } from './plugins.js';
+import { getTool, buildToolArgv } from './tools.js';
 
 export interface QueuedEvent {
   run_id: string;
@@ -151,14 +152,12 @@ export function getEventStatus(runId: string): QueuedEvent | null {
  */
 export function getQueueStatus(): QueueStatus {
   const d = dirs();
+  const completedReceipts = listReceipts(d.completed).map(readReceipt);
   return {
     pending: listReceipts(d.pending).length,
     running: listReceipts(d.running).length,
-    completed: listReceipts(d.completed).length,
-    failed: listReceipts(d.completed).filter((fp) => {
-      const r = readReceipt(fp);
-      return r.status === 'failed';
-    }).length,
+    completed: completedReceipts.filter((r) => r.status === 'completed').length,
+    failed: completedReceipts.filter((r) => r.status === 'failed').length,
   };
 }
 
@@ -178,39 +177,72 @@ function executeEventAsync(
 ): Promise<AgentBusResult> {
   return new Promise((resolve) => {
     const normalized = receipt.event;
-    const cli = path.join(repoRoot, 'scripts', 'scbe-system-cli.py');
-    const argv: string[] = [
-      cli,
-      '--repo-root',
-      repoRoot,
-      'agentbus',
-      'run',
-      '--task',
-      normalized.task,
-      '--task-type',
-      normalized.taskType || 'general',
-      '--series-id',
-      normalized.seriesId || receipt.run_id,
-      '--privacy',
-      normalized.privacy || 'local_only',
-      '--budget-cents',
-      String(normalized.budgetCents || 0),
-      '--dispatch-provider',
-      normalized.dispatchProvider || 'offline',
-      '--json',
-    ];
-    if (normalized.operationCommand) {
-      argv.push('--operation-command', normalized.operationCommand);
-    }
-    if (normalized.dispatch !== false) {
-      argv.push('--dispatch');
+
+    // Route to a registered CLI tool when event.tool is set; fall back to scbe-system-cli.py.
+    let spawnCmd: string;
+    let spawnArgs: string[];
+
+    if (normalized.tool) {
+      const registeredTool = getTool(normalized.tool);
+      if (!registeredTool) {
+        // Unknown tool name — resolve immediately with an error result
+        resolve({
+          schema_version: 'scbe-agentbus-node-result-v1',
+          event_index: 1,
+          started_at: new Date().toISOString(),
+          finished_at: new Date().toISOString(),
+          ok: false,
+          exit_code: null,
+          stderr_tail: `unknown tool: '${normalized.tool}' is not registered`,
+          event: {
+            task_sha256: null,
+            task_chars: normalized.task.length,
+            series_id: normalized.seriesId || receipt.run_id,
+            operation_command_chars: (normalized.operationCommand || '').length,
+          },
+          result: null,
+        });
+        return;
+      }
+      const built = buildToolArgv(registeredTool, normalized, receipt.options, receipt.run_id);
+      spawnCmd = built.command;
+      spawnArgs = built.args;
+    } else {
+      const cli = path.join(repoRoot, 'scripts', 'scbe-system-cli.py');
+      spawnCmd = python;
+      spawnArgs = [
+        cli,
+        '--repo-root',
+        repoRoot,
+        'agentbus',
+        'run',
+        '--task',
+        normalized.task,
+        '--task-type',
+        normalized.taskType || 'general',
+        '--series-id',
+        normalized.seriesId || receipt.run_id,
+        '--privacy',
+        normalized.privacy || 'local_only',
+        '--budget-cents',
+        String(normalized.budgetCents || 0),
+        '--dispatch-provider',
+        normalized.dispatchProvider || 'offline',
+        '--json',
+      ];
+      if (normalized.operationCommand) {
+        spawnArgs.push('--operation-command', normalized.operationCommand);
+      }
+      if (normalized.dispatch !== false) {
+        spawnArgs.push('--dispatch');
+      }
     }
 
     const startedAt = new Date().toISOString();
     let stdout = '';
     let stderr = '';
 
-    const child = spawn(python, argv, {
+    const child = spawn(spawnCmd, spawnArgs, {
       cwd: repoRoot,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -347,8 +379,12 @@ export async function processOneEvent(): Promise<boolean> {
     startedAt: receipt.started_at || receipt.created_at,
   });
 
-  // Retry logic
-  if (!result.ok && receipt.retry_count < receipt.max_retries) {
+  // Retry logic — skip retry for plugin-denied events (they won't pass the gate on re-run)
+  const denied =
+    result.exit_code === 403 &&
+    typeof result.result === 'object' &&
+    !!(result.result as Record<string, unknown>)?.denied;
+  if (!result.ok && !denied && receipt.retry_count < receipt.max_retries) {
     receipt.retry_count += 1;
     receipt.status = 'pending';
     receipt.error_message = `retry ${receipt.retry_count}/${receipt.max_retries}: ${result.stderr_tail}`;
@@ -361,7 +397,8 @@ export async function processOneEvent(): Promise<boolean> {
     return true;
   }
 
-  receipt.status = result.ok ? 'completed' : 'failed';
+  // Denied events are completed (bus handled them correctly), not failed (not a transient error)
+  receipt.status = result.ok || denied ? 'completed' : 'failed';
   if (!result.ok && !receipt.error_message) {
     receipt.error_message = result.stderr_tail;
   }

--- a/packages/agent-bus/src/tools.ts
+++ b/packages/agent-bus/src/tools.ts
@@ -1,0 +1,125 @@
+/**
+ * @file tools.ts
+ * @module agent-bus/tools
+ *
+ * CLI tool registry for the SCBE Agent Bus.
+ *
+ * Tools are named executables the bus can dispatch to instead of (or alongside)
+ * the default scbe-system-cli.py. This lets any CLI command become a first-class
+ * bus target without modifying core dispatch logic.
+ *
+ * Template variables substituted in `args` at dispatch time:
+ *   {task}          — event.task
+ *   {seriesId}      — event.seriesId or run_id
+ *   {taskType}      — event.taskType or 'general'
+ *   {privacy}       — event.privacy or 'local_only'
+ *   {repoRoot}      — resolved repoRoot from RunOptions
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AgentBusEvent, RunOptions } from './index.js';
+
+export interface CliTool {
+  /** Unique name used in AgentBusEvent.tool to route to this tool. */
+  name: string;
+  /** Human-readable description for `tools list`. */
+  description?: string;
+  /** Executable to spawn (e.g. 'node', 'python', 'npx'). */
+  command: string;
+  /**
+   * Argument list. Strings containing `{task}`, `{seriesId}`, `{taskType}`,
+   * `{privacy}`, or `{repoRoot}` are substituted at dispatch time.
+   */
+  args: string[];
+}
+
+const registry = new Map<string, CliTool>();
+
+/** Register a tool. Idempotent by name — re-registering replaces the previous entry. */
+export function registerTool(tool: CliTool): void {
+  registry.set(tool.name, tool);
+}
+
+/** Remove a tool by name. Returns true if removed, false if not found. */
+export function unregisterTool(name: string): boolean {
+  return registry.delete(name);
+}
+
+/** List all registered tools. */
+export function listTools(): readonly CliTool[] {
+  return Array.from(registry.values());
+}
+
+/** Look up a tool by name. */
+export function getTool(name: string): CliTool | undefined {
+  return registry.get(name);
+}
+
+/** Clear all tools. Useful in tests. */
+export function clearTools(): void {
+  registry.clear();
+}
+
+/** Substitute template variables in a single arg string. */
+function substituteArg(arg: string, vars: Record<string, string>): string {
+  return arg.replace(/\{(\w+)\}/g, (_, key) => vars[key] ?? `{${key}}`);
+}
+
+/** Build the final argv for a tool dispatch. */
+export function buildToolArgv(
+  tool: CliTool,
+  event: AgentBusEvent,
+  options: RunOptions,
+  runId: string
+): { command: string; args: string[] } {
+  const repoRoot = options.repoRoot || process.cwd();
+  const vars: Record<string, string> = {
+    task: event.task,
+    seriesId: event.seriesId || runId,
+    taskType: event.taskType || 'general',
+    privacy: event.privacy || 'local_only',
+    repoRoot,
+  };
+  return {
+    command: tool.command,
+    args: tool.args.map((a) => substituteArg(a, vars)),
+  };
+}
+
+/**
+ * Load tools from a JSON file referenced by SCBE_BUS_TOOLS env var.
+ * The file must be a JSON array of CliTool objects.
+ *
+ * Example:
+ *   SCBE_BUS_TOOLS=./my-tools.json
+ *
+ * Where my-tools.json:
+ *   [{"name":"lint","command":"npx","args":["eslint","{repoRoot}/src"],"description":"Run linter"}]
+ */
+export function autoDiscoverTools(): void {
+  const env = (process.env.SCBE_BUS_TOOLS || '').trim();
+  if (!env) return;
+  try {
+    const resolved = path.resolve(env);
+    const raw = fs.readFileSync(resolved, 'utf8');
+    const tools = JSON.parse(raw) as unknown;
+    if (!Array.isArray(tools)) {
+      process.stderr.write(`[agent-bus] SCBE_BUS_TOOLS: ${env} must contain a JSON array\n`);
+      return;
+    }
+    for (const t of tools as CliTool[]) {
+      if (typeof t.name === 'string' && typeof t.command === 'string' && Array.isArray(t.args)) {
+        registerTool(t);
+      } else {
+        process.stderr.write(
+          `[agent-bus] SCBE_BUS_TOOLS: skipping invalid tool entry (requires name, command, args)\n`
+        );
+      }
+    }
+  } catch (err) {
+    process.stderr.write(
+      `[agent-bus] SCBE_BUS_TOOLS load error (${env}): ${err instanceof Error ? err.message : String(err)}\n`
+    );
+  }
+}

--- a/packages/agent-bus/tests/plugins.test.ts
+++ b/packages/agent-bus/tests/plugins.test.ts
@@ -69,7 +69,9 @@ describe('plugin system', () => {
     let called = false;
     registerPlugin({
       name: 'logger',
-      afterRun: async () => { called = true; },
+      afterRun: async () => {
+        called = true;
+      },
     });
     const event: AgentBusEvent = { task: 'test' };
     const ctx: BusPluginContext = { event, runId: 'r1', startedAt: new Date().toISOString() };
@@ -80,7 +82,9 @@ describe('plugin system', () => {
   it('afterRun errors are swallowed', async () => {
     registerPlugin({
       name: 'thrower',
-      afterRun: async () => { throw new Error('boom'); },
+      afterRun: async () => {
+        throw new Error('boom');
+      },
     });
     const event: AgentBusEvent = { task: 'test' };
     const ctx: BusPluginContext = { event, runId: 'r1', startedAt: new Date().toISOString() };

--- a/packages/agent-bus/tests/queue.test.ts
+++ b/packages/agent-bus/tests/queue.test.ts
@@ -62,7 +62,7 @@ describe('queue', () => {
   it('processOneEvent handles a bad scbe-system-cli.py gracefully', async () => {
     // The event will fail because scbe-system-cli.py doesn't exist in tmpdir,
     // but it should still move to completed/failed.
-    const runId = enqueueEvent({ task: 'hello' }, { repoRoot: process.cwd() });
+    const runId = enqueueEvent({ task: 'hello' }, { repoRoot: process.cwd() }, 0);
     const didWork = await processOneEvent();
     expect(didWork).toBe(true);
 

--- a/packages/agent-bus/tests/tools.test.ts
+++ b/packages/agent-bus/tests/tools.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  registerTool,
+  unregisterTool,
+  listTools,
+  getTool,
+  clearTools,
+  buildToolArgv,
+  type CliTool,
+} from '../src/tools.js';
+import { enqueueEvent, processOneEvent, getEventStatus } from '../src/queue.js';
+import { clearPlugins } from '../src/plugins.js';
+
+describe('tool registry', () => {
+  beforeEach(() => clearTools());
+
+  it('registers and lists tools', () => {
+    const tool: CliTool = { name: 'echo-task', command: 'node', args: ['-e', 'console.log("ok")'] };
+    registerTool(tool);
+    expect(listTools()).toHaveLength(1);
+    expect(listTools()[0].name).toBe('echo-task');
+  });
+
+  it('replaces tools with the same name', () => {
+    registerTool({ name: 'dup', command: 'node', args: ['a.js'] });
+    registerTool({ name: 'dup', command: 'python', args: ['a.py'] });
+    expect(listTools()).toHaveLength(1);
+    expect(listTools()[0].command).toBe('python');
+  });
+
+  it('unregisters a tool', () => {
+    registerTool({ name: 'x', command: 'node', args: [] });
+    expect(unregisterTool('x')).toBe(true);
+    expect(listTools()).toHaveLength(0);
+    expect(unregisterTool('x')).toBe(false);
+  });
+
+  it('getTool returns registered tool', () => {
+    registerTool({ name: 'y', command: 'node', args: ['y.js'] });
+    expect(getTool('y')?.command).toBe('node');
+    expect(getTool('missing')).toBeUndefined();
+  });
+
+  it('buildToolArgv substitutes template variables', () => {
+    const tool: CliTool = {
+      name: 'runner',
+      command: 'node',
+      args: ['run.js', '--task', '{task}', '--series', '{seriesId}', '--root', '{repoRoot}'],
+    };
+    const event = { task: 'hello world', seriesId: 'abc123' };
+    const opts = { repoRoot: '/tmp/repo' };
+    const { command, args } = buildToolArgv(tool, event, opts, 'run-id-1');
+    expect(command).toBe('node');
+    expect(args).toContain('hello world');
+    expect(args).toContain('abc123');
+    expect(args).toContain('/tmp/repo');
+  });
+
+  it('buildToolArgv uses run_id as seriesId when event.seriesId is absent', () => {
+    const tool: CliTool = { name: 'x', command: 'echo', args: ['{seriesId}'] };
+    const { args } = buildToolArgv(tool, { task: 't' }, {}, 'fallback-id');
+    expect(args[0]).toBe('fallback-id');
+  });
+
+  it('buildToolArgv leaves unknown placeholders intact', () => {
+    const tool: CliTool = { name: 'x', command: 'echo', args: ['{unknownVar}'] };
+    const { args } = buildToolArgv(tool, { task: 't' }, {}, 'r1');
+    expect(args[0]).toBe('{unknownVar}');
+  });
+});
+
+describe('queue: tool routing', () => {
+  let queueRoot: string;
+
+  beforeEach(() => {
+    queueRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-bus-tools-test-'));
+    process.env.SCBE_BUS_QUEUE_ROOT = queueRoot;
+    clearTools();
+    clearPlugins();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(queueRoot, { recursive: true, force: true });
+    } catch {
+      // tolerate
+    }
+    delete process.env.SCBE_BUS_QUEUE_ROOT;
+  });
+
+  it('dispatches to a registered tool and captures stdout', async () => {
+    registerTool({
+      name: 'echo-json',
+      command: 'node',
+      args: ['-e', 'process.stdout.write(JSON.stringify({ok:true,task:{sha256:null}}))'],
+    });
+
+    const runId = enqueueEvent({ task: 'hi', tool: 'echo-json' }, {}, 0);
+    await processOneEvent();
+
+    const status = getEventStatus(runId);
+    expect(status).not.toBeNull();
+    expect(status!.status).toBe('completed');
+    expect(status!.result?.ok).toBe(true);
+  });
+
+  it('returns failed when tool exits with non-zero', async () => {
+    registerTool({
+      name: 'exit-1',
+      command: 'node',
+      args: ['-e', 'process.exit(1)'],
+    });
+
+    const runId = enqueueEvent({ task: 'fail', tool: 'exit-1' }, {}, 0);
+    await processOneEvent();
+
+    const status = getEventStatus(runId);
+    expect(status!.status).toBe('failed');
+    expect(status!.result?.ok).toBe(false);
+  });
+
+  it('returns failed immediately for unknown tool name', async () => {
+    const runId = enqueueEvent({ task: 'hi', tool: 'no-such-tool' }, {}, 0);
+    await processOneEvent();
+
+    const status = getEventStatus(runId);
+    expect(status!.status).toBe('failed');
+    expect(status!.result?.stderr_tail).toMatch(/unknown tool/);
+  });
+
+  it('task template variable is passed to tool args', async () => {
+    // Tool writes its received args to stdout as JSON so we can assert on them
+    registerTool({
+      name: 'echo-task',
+      command: 'node',
+      args: [
+        '-e',
+        'const t=process.argv[1]; process.stdout.write(JSON.stringify({ok:true,task:{sha256:null,echo:t}}))',
+        '{task}',
+      ],
+    });
+
+    const runId = enqueueEvent({ task: 'my-special-task', tool: 'echo-task' }, {}, 0);
+    await processOneEvent();
+
+    const status = getEventStatus(runId);
+    expect(status!.status).toBe('completed');
+    const resultPayload = status!.result?.result as Record<string, unknown> | null;
+    expect((resultPayload?.task as Record<string, unknown>)?.echo).toBe('my-special-task');
+  });
+});


### PR DESCRIPTION
## Summary

- **Format**: Prettier format pass on 5 files that had style drift after the #1932 squash merge
- **CLI-as-tool registry** (ported from feat/agent-bus-plugins-queue, missed by auto-merge): `src/tools.ts` with `registerTool`/`unregisterTool`/`listTools`/`getTool`/`buildToolArgv`/`autoDiscoverTools`; `AgentBusEvent.tool` field to dispatch to named CLI tools instead of `scbe-system-cli.py`; `{task}/{seriesId}/{taskType}/{privacy}/{repoRoot}` template substitution; `SCBE_BUS_TOOLS=./tools.json` loader
- **Queue bug fixes** (also ported): `getQueueStatus.completed` double-counted failed entries; plugin-denied events were retried unnecessarily
- **contracts.ts**: `interface ValidatedOutput` used invalid union syntax (must be `type`); `z.record(z.unknown())` → `z.record(z.string(), z.unknown())` for Zod 4 compat
- **56/56 tests pass**, lint clean, build clean

## Test plan

- [x] `npm run lint` — all files pass Prettier
- [x] `npm run build` — TypeScript clean
- [x] `npm test` — 56/56 pass
- [x] `scbe-agent-bus tools list` — responds correctly
- [x] `scbe-agent-bus queue status --json` — `{pending:0,running:0,completed:0,failed:0}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI `tools list` command to discover and display registered tools in JSON or human-readable format
  * Added optional `--tool` flag to `send` command for selecting specific tools during event processing
  * Implemented tool registry system with registration, discovery, and management capabilities
  * Added structured output validation contracts for common agent event types

* **Tests**
  * Added comprehensive test coverage for tool registry and queue execution workflows
  * Enhanced existing test suite formatting and coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->