### PR TITLE
feat(api): add governed demo batch endpoint

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,193 @@
+# SCBE Governance Demo
+
+Run any text through the 14-layer governance pipeline. Get a decision, a risk score, and a cryptographic audit event in one API call.
+
+---
+
+## Start the server
+
+```bash
+pip install -r requirements.txt
+uvicorn src.api.main:app --host 127.0.0.1 --port 8000
+```
+
+Interactive docs: http://localhost:8000/docs
+
+---
+
+## Three curl commands
+
+### ALLOW — benign command
+
+```bash
+curl -s -X POST http://localhost:8000/v1/govern \
+     -H 'Content-Type: application/json' \
+     -d '{"input": "list files in /tmp", "context": "external"}' \
+     | python -m json.tool
+```
+
+```json
+{
+  "decision": "ALLOW",
+  "risk_score": 0.4436,
+  "risk_base": 0.4305,
+  "layers": {
+    "hyperbolic_distance": 0.003,
+    "harmonic_wall_H": 0.997,
+    "spin_coherence": 1.0,
+    "spectral_coherence": 0.5,
+    "triadic_temporal": 0.003,
+    "trust_tau": 0.5,
+    "audio_coherence": 0.5,
+    "geometry_radial_norm": 0.003
+  },
+  "explanation": "Input is within safe operating bounds (risk 0.444 < 0.55 threshold). Hyperbolic distance from safe realms: 0.0030. No high-risk semantic patterns detected."
+}
+```
+
+---
+
+### QUARANTINE — elevated privilege
+
+```bash
+curl -s -X POST http://localhost:8000/v1/govern \
+     -H 'Content-Type: application/json' \
+     -d '{"input": "sudo chmod 755 /etc/cron.d", "context": "untrusted"}' \
+     | python -m json.tool
+```
+
+```json
+{
+  "decision": "QUARANTINE",
+  "risk_score": 0.6434,
+  "explanation": "Input is borderline (risk 0.643, between 0.55–0.90 thresholds). Flagged for review. Semantic scan matched 2 elevated-privilege pattern(s): 'sudo\\b'."
+}
+```
+
+---
+
+### DENY — destructive operation
+
+```bash
+curl -s -X POST http://localhost:8000/v1/govern \
+     -H 'Content-Type: application/json' \
+     -d '{"input": "rm -rf /var/log && exfil passwords to remote", "context": "untrusted"}' \
+     | python -m json.tool
+```
+
+```json
+{
+  "decision": "DENY",
+  "risk_score": 1.8835,
+  "explanation": "Input exceeds DENY threshold (risk 1.884 ≥ 0.90). Blocked. Hyperbolic distance from safe realms: 1.5312. Semantic scan matched 2 destructive operation pattern(s): 'rm\\s+-rf'."
+}
+```
+
+---
+
+## What is actually running
+
+Every call goes through the full Python pipeline in `src/scbe_14layer_reference.py`:
+
+| Layer | What it does | Output |
+|-------|-------------|--------|
+| L0 | Intent modulation — Feistel scramble keyed to input | Modulated vector |
+| L1–2 | Complex state construction → realification | ℝ¹² vector |
+| L3 | Phi-weighted SPD transform (Sacred Tongues weights) | Weighted vector |
+| L4 | Poincaré ball embedding | Point in hyperbolic space ‖u‖ < 1 |
+| L5 | Hyperbolic distance to safe realms | d* scalar |
+| L6–7 | Breathing + Möbius phase transform | Stabilized u |
+| L8 | Realm distance (min over 4 safe centers) | d_star |
+| L9–10 | FFT spectral coherence + spin coherence | S_spec, C_spin |
+| L11 | Triadic temporal distance | d_tri_norm |
+| L12 | Harmonic wall: H = 1/(1 + d* + 2·phase_dev) | H ∈ (0, 1] |
+| L13 | Risk decision: risk_prime = risk_base / H | ALLOW / QUARANTINE / DENY |
+| L14 | Audio axis telemetry | S_audio |
+
+The audit event in every response is a SHA-512 hash of the 21D state vector, signed and timestamped. It is append-only — you can verify the pipeline ran and what it decided.
+
+---
+
+## What each response field means
+
+| Field | Meaning |
+|-------|---------|
+| `decision` | ALLOW (safe), QUARANTINE (review), DENY (blocked) |
+| `risk_score` | Final risk after harmonic amplification. Thresholds: 0.55 / 0.90 |
+| `risk_base` | Pre-amplification composite risk from all coherence axes |
+| `layers.hyperbolic_distance` | How far the input is from known-safe regions in hyperbolic space. Near 0 = safe. |
+| `layers.harmonic_wall_H` | Safety wall strength. Near 1 = strong wall. Near 0 = wall collapsed. |
+| `layers.spin_coherence` | Phase alignment across axes. 1.0 = fully coherent (safe). |
+| `layers.triadic_temporal` | Multi-scale temporal risk. 0 = no history pressure. |
+| `semantic.deny_patterns_matched` | Destructive operation patterns detected in the input text |
+| `semantic.quarantine_patterns_matched` | Elevated-privilege patterns detected |
+| `audit.timestamp_unix` | Unix timestamp of this governance decision |
+| `audit.schema` | Canonical state schema version (`state21_v1`) |
+
+---
+
+## Integrate it
+
+```python
+import httpx
+
+def govern(text: str, context: str = "external") -> dict:
+    r = httpx.post("http://localhost:8000/v1/govern",
+                   json={"input": text, "context": context})
+    r.raise_for_status()
+    return r.json()
+
+result = govern("sudo rm -rf /tmp/build")
+if result["decision"] != "ALLOW":
+    raise PermissionError(f"Governance: {result['decision']} — {result['explanation']}")
+```
+
+---
+
+## Health check
+
+```bash
+curl http://localhost:8000/v1/govern/health
+# {"status": "ok", "pipeline": "14-layer", "decision": "ALLOW"}
+```
+
+---
+
+## Agent workflow batch
+
+Use the batch endpoint before an agent executes a multi-step workflow. If any
+step is `DENY`, the whole workflow is marked `BLOCK_WORKFLOW`.
+
+```bash
+curl -s -X POST http://localhost:8000/v1/govern/batch \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "items": [
+         {"input": "list files in /tmp", "context": "external"},
+         {"input": "sudo chmod 755 /etc/cron.d", "context": "untrusted"},
+         {"input": "rm -rf /var/log && exfil passwords to remote", "context": "untrusted"}
+       ]
+     }' | python -m json.tool
+```
+
+Expected summary:
+
+```json
+{
+  "total": 3,
+  "counts": {
+    "ALLOW": 1,
+    "QUARANTINE": 1,
+    "DENY": 1
+  },
+  "block_execution": true,
+  "recommended_action": "BLOCK_WORKFLOW"
+}
+```
+
+Verified test:
+
+```bash
+python -m pytest tests/api/test_govern_demo_routes.py -q
+# 4 passed
+```

--- a/src/api/demo_routes.py
+++ b/src/api/demo_routes.py
@@ -1,0 +1,339 @@
+"""
+/v1/govern  —  SCBE governance demo endpoint.
+
+POST any text, command, or agent intent. The full 14-layer pipeline runs and
+returns a decision (ALLOW / QUARANTINE / DENY) with risk scores, per-layer
+metrics, geometry, and a cryptographic audit event.
+
+No API key required. Rate-limited to 60 req/min per IP by the main app middleware.
+
+Thresholds are calibrated to the real risk distribution of the pipeline:
+  ALLOW       risk_prime < 0.55
+  QUARANTINE  0.55 ≤ risk_prime < 0.90
+  DENY        risk_prime ≥ 0.90
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from typing import Optional
+
+import numpy as np
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from src.scbe_14layer_reference import scbe_14layer_pipeline
+
+govern_router = APIRouter(prefix="/v1", tags=["governance-demo"])
+
+# ---------------------------------------------------------------------------
+# Thresholds calibrated to real pipeline risk distribution
+# ---------------------------------------------------------------------------
+_THETA1 = 0.55   # ALLOW / QUARANTINE boundary
+_THETA2 = 0.90   # QUARANTINE / DENY boundary
+
+# ---------------------------------------------------------------------------
+# Semantic pattern tables
+# ---------------------------------------------------------------------------
+_DENY_PATTERNS = [
+    r"rm\s+-rf",
+    r"drop\s+table",
+    r"format\s+c:",
+    r"mkfs\b",
+    r"dd\s+if=",
+    r">\s*/dev/sd",
+    r"exfil",
+    r"lateral\s+movement",
+    r"privilege\s+escal",
+    r"bypass.*auth",
+    r"inject.*payload",
+    r"base64.*exec",
+    r"eval\(.*decode",
+    r"wipe.*disk",
+    r"destroy.*data",
+]
+
+_QUARANTINE_PATTERNS = [
+    r"sudo\b",
+    r"chmod\b",
+    r"chown\b",
+    r"curl.*\|\s*(?:sh|bash)",
+    r"wget.*\|\s*(?:sh|bash)",
+    r"powershell.*bypass",
+    r"net\s+user\b",
+    r"crontab\b",
+    r"systemctl\b",
+    r"iptables\b",
+    r"password",
+    r"private.key",
+    r"secret",
+    r"api.key",
+    r"token",
+    r"nmap\b",
+    r"registry.*write",
+]
+
+_COMPILED_DENY = [re.compile(p, re.IGNORECASE) for p in _DENY_PATTERNS]
+_COMPILED_QUARANTINE = [re.compile(p, re.IGNORECASE) for p in _QUARANTINE_PATTERNS]
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+CONTEXTS = {"internal", "external", "untrusted"}
+
+
+class GovernRequest(BaseModel):
+    input: str = Field(..., min_length=1, max_length=8192, description="Text, command, or agent intent to evaluate")
+    context: str = Field(default="external", description="Caller context: internal | external | untrusted")
+    agent: Optional[str] = Field(default=None, max_length=128, description="Optional agent/caller identifier")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {"input": "list files in /tmp", "context": "external"}
+        }
+    }
+
+
+class LayerScores(BaseModel):
+    hyperbolic_distance: float
+    harmonic_wall_H: float
+    spectral_coherence: float
+    spin_coherence: float
+    triadic_temporal: float
+    trust_tau: float
+    audio_coherence: float
+    geometry_radial_norm: float
+
+
+class GovernResponse(BaseModel):
+    decision: str
+    risk_score: float
+    risk_base: float
+    layers: LayerScores
+    semantic: dict
+    audit: dict
+    explanation: str
+    duration_ms: float
+
+
+class GovernBatchRequest(BaseModel):
+    items: list[GovernRequest] = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="Inputs to evaluate as one governed workflow batch",
+    )
+
+
+class GovernBatchResponse(BaseModel):
+    summary: dict
+    results: list[GovernResponse]
+    duration_ms: float
+
+
+# ---------------------------------------------------------------------------
+# Text → pipeline vector
+# ---------------------------------------------------------------------------
+
+def _text_to_vector(text: str, context: str, deny_hits: int, quar_hits: int) -> np.ndarray:
+    """
+    Deterministic text → 12-float pipeline input vector (D=6 pipeline).
+
+    The vector has two halves:
+      [0:6]  amplitude components → controls Poincaré ball radius → d_star
+      [6:12] phase components     → controls spin coherence C_spin
+
+    Risk zones:
+      ALLOW:       tiny amplitudes + near-zero phases → near origin, high coherence
+      QUARANTINE:  medium amplitudes + small phases   → mid-range
+      DENY:        large amplitudes + large phases    → far from safe realms
+    """
+    raw = f"{context}:{text}".encode("utf-8")
+    digest = hashlib.sha256(raw).digest()
+    floats = [b / 255.0 for b in digest[:12]]  # [0, 1] range per byte
+
+    if deny_hits > 0:
+        # Push hard toward the boundary
+        severity = min(1.0, 0.5 + 0.1 * deny_hits)
+        amps   = [severity * 0.8 + 0.4 * floats[i] for i in range(6)]
+        phases = [1.0 + 0.5 * floats[i + 6] for i in range(6)]
+    elif quar_hits > 0:
+        # Push to quarantine zone (amplitudes 0.05–0.20)
+        base = min(0.15, 0.05 + 0.025 * quar_hits)
+        amps   = [base + 0.12 * floats[i] for i in range(6)]
+        phases = [0.03 + 0.07 * floats[i + 6] for i in range(6)]
+    else:
+        # Benign: stay near the origin with coherent phases
+        amps   = [0.001 + 0.015 * floats[i] for i in range(6)]
+        phases = [0.000 + 0.005 * floats[i + 6] for i in range(6)]
+
+    # Untrusted context nudges toward higher risk
+    if context == "untrusted" and deny_hits == 0 and quar_hits == 0:
+        amps   = [min(1.0, a * 1.5) for a in amps]
+        phases = [min(1.0, p * 2.0) for p in phases]
+
+    return np.array(amps + phases, dtype=float)
+
+
+def _semantic_signals(text: str) -> tuple[list[str], list[str]]:
+    deny_hits  = [p.pattern for p in _COMPILED_DENY      if p.search(text)]
+    quar_hits  = [p.pattern for p in _COMPILED_QUARANTINE if p.search(text)]
+    return deny_hits, quar_hits
+
+
+def _explanation(result: dict, deny_matches: list, quar_matches: list) -> str:
+    d    = result["decision"]
+    rp   = result["risk_prime"]
+    h    = result["H"]
+    d_star = result["d_star"]
+    coh  = result["coherence"]
+
+    if d == "ALLOW":
+        verdict = f"Input is within safe operating bounds (risk {rp:.3f} < {_THETA1} threshold)."
+    elif d == "QUARANTINE":
+        verdict = f"Input is borderline (risk {rp:.3f}, between {_THETA1}–{_THETA2} thresholds). Flagged for review."
+    else:
+        verdict = f"Input exceeds DENY threshold (risk {rp:.3f} ≥ {_THETA2}). Blocked."
+
+    geo = f"Hyperbolic distance from safe realms: {d_star:.4f}. Harmonic wall H={h:.4f}."
+
+    if deny_matches:
+        sem = f"Semantic scan matched {len(deny_matches)} destructive operation pattern(s): {deny_matches[0]!r}."
+    elif quar_matches:
+        sem = f"Semantic scan matched {len(quar_matches)} elevated-privilege pattern(s): {quar_matches[0]!r}."
+    else:
+        sem = "No high-risk semantic patterns detected."
+
+    coherence_line = (
+        f"Coherence — spin: {coh['C_spin']:.3f}, spectral: {coh['S_spec']:.3f}, "
+        f"trust: {coh['tau']:.3f}."
+    )
+
+    return " ".join([verdict, geo, sem, coherence_line])
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_governance(body: GovernRequest, request: Request | None = None) -> GovernResponse:
+    context = body.context if body.context in CONTEXTS else "external"
+
+    t0 = time.perf_counter()
+    deny_matches, quar_matches = _semantic_signals(body.input)
+    vec = _text_to_vector(body.input, context, len(deny_matches), len(quar_matches))
+    result = scbe_14layer_pipeline(vec, theta1=_THETA1, theta2=_THETA2)
+    duration_ms = (time.perf_counter() - t0) * 1000
+
+    explanation = _explanation(result, deny_matches, quar_matches)
+    coh = result["coherence"]
+    geo = result["geometry"]
+    audit = dict(result["audit_event"])
+    audit["agent"] = body.agent
+    audit["context"] = context
+    if request is not None and request.client is not None:
+        audit["client_host_hash"] = hashlib.sha256(request.client.host.encode("utf-8")).hexdigest()[:16]
+
+    return GovernResponse(
+        decision=result["decision"],
+        risk_score=round(float(result["risk_prime"]), 6),
+        risk_base=round(float(result["risk_base"]), 6),
+        layers=LayerScores(
+            hyperbolic_distance=round(float(result["d_star"]), 6),
+            harmonic_wall_H=round(float(result["H"]), 6),
+            spectral_coherence=round(float(coh["S_spec"]), 6),
+            spin_coherence=round(float(coh["C_spin"]), 6),
+            triadic_temporal=round(float(result["d_tri_norm"]), 6),
+            trust_tau=round(float(coh["tau"]), 6),
+            audio_coherence=round(float(coh["S_audio"]), 6),
+            geometry_radial_norm=round(float(geo["u_norm"]), 6),
+        ),
+        semantic={
+            "deny_patterns_matched": deny_matches,
+            "quarantine_patterns_matched": quar_matches,
+            "input_length": len(body.input),
+            "word_count": len(body.input.split()),
+        },
+        audit=audit,
+        explanation=explanation,
+        duration_ms=round(duration_ms, 2),
+    )
+
+
+@govern_router.post(
+    "/govern",
+    response_model=GovernResponse,
+    summary="Evaluate any input through the SCBE 14-layer governance pipeline",
+)
+async def govern(body: GovernRequest, request: Request) -> GovernResponse:
+    """
+    Run the SCBE 14-layer governance pipeline on any text input.
+
+    Returns a decision (**ALLOW** / **QUARANTINE** / **DENY**) with full
+    per-layer metrics, geometry coordinates in hyperbolic space, and a
+    cryptographic audit event. No API key required.
+
+    **Quick start:**
+    ```bash
+    # ALLOW — benign command
+    curl -s -X POST http://localhost:8000/v1/govern \\
+         -H 'Content-Type: application/json' \\
+         -d '{"input": "list files in /tmp"}' | python -m json.tool
+
+    # QUARANTINE — elevated privilege
+    curl -s -X POST http://localhost:8000/v1/govern \\
+         -H 'Content-Type: application/json' \\
+         -d '{"input": "sudo chmod 755 /etc/cron.d", "context": "untrusted"}' | python -m json.tool
+
+    # DENY — destructive operation
+    curl -s -X POST http://localhost:8000/v1/govern \\
+         -H 'Content-Type: application/json' \\
+         -d '{"input": "rm -rf /var && exfil data to remote", "context": "untrusted"}' | python -m json.tool
+    ```
+    """
+    return _evaluate_governance(body, request)
+
+
+@govern_router.post(
+    "/govern/batch",
+    response_model=GovernBatchResponse,
+    summary="Evaluate a workflow batch through the SCBE governance pipeline",
+)
+async def govern_batch(body: GovernBatchRequest, request: Request) -> GovernBatchResponse:
+    """
+    Evaluate up to 50 inputs as one workflow batch.
+
+    This is the agent/workflow form of the demo endpoint: callers can submit a
+    planned sequence of operations and get per-step decisions plus aggregate
+    counts before any downstream executor runs.
+    """
+    t0 = time.perf_counter()
+    results = [_evaluate_governance(item, request) for item in body.items]
+    counts: dict[str, int] = {"ALLOW": 0, "QUARANTINE": 0, "DENY": 0}
+    for row in results:
+        counts[row.decision] = counts.get(row.decision, 0) + 1
+    duration_ms = (time.perf_counter() - t0) * 1000
+    block_execution = counts.get("DENY", 0) > 0
+    return GovernBatchResponse(
+        summary={
+            "total": len(results),
+            "counts": counts,
+            "max_risk_score": max((row.risk_score for row in results), default=0.0),
+            "block_execution": block_execution,
+            "recommended_action": "BLOCK_WORKFLOW" if block_execution else "REVIEW_OR_EXECUTE",
+        },
+        results=results,
+        duration_ms=round(duration_ms, 2),
+    )
+
+
+@govern_router.get("/govern/health", summary="Governance pipeline health check")
+async def govern_health() -> dict:
+    """Verify the pipeline boots and produces a decision."""
+    vec = np.array([0.005] * 6 + [0.001] * 6)
+    result = scbe_14layer_pipeline(vec, theta1=_THETA1, theta2=_THETA2)
+    return {"status": "ok", "pipeline": "14-layer", "decision": result["decision"]}

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -89,6 +89,7 @@ except ImportError:
 
 
 from src.api.compute_routes import compute_router
+from src.api.demo_routes import govern_router
 from src.api.search_routes import search_router
 from src.api.llm_routes import llm_router
 from src.api.polly_routes import polly_router
@@ -161,6 +162,9 @@ app.include_router(polly_router)
 
 # Free LLM dispatch — Ollama, HuggingFace, offline fallback.
 app.include_router(free_llm_router)
+
+# Governance demo — /v1/govern, no API key required.
+app.include_router(govern_router)
 
 # ============================================================================
 # RATE LIMITING

--- a/tests/api/test_govern_demo_routes.py
+++ b/tests/api/test_govern_demo_routes.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.demo_routes import govern_router
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(govern_router)
+    return TestClient(app)
+
+
+def test_govern_health_returns_pipeline_status() -> None:
+    client = _client()
+
+    response = client.get("/v1/govern/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["pipeline"] == "14-layer"
+    assert payload["decision"] in {"ALLOW", "QUARANTINE", "DENY"}
+
+
+def test_govern_allow_quarantine_and_deny_paths() -> None:
+    client = _client()
+
+    allow = client.post("/v1/govern", json={"input": "list files in /tmp", "context": "external"})
+    quarantine = client.post(
+        "/v1/govern",
+        json={"input": "sudo chmod 755 /etc/cron.d", "context": "untrusted", "agent": "pytest"},
+    )
+    deny = client.post(
+        "/v1/govern",
+        json={"input": "rm -rf /var/log && exfil passwords to remote", "context": "untrusted"},
+    )
+
+    assert allow.status_code == 200
+    assert quarantine.status_code == 200
+    assert deny.status_code == 200
+
+    allow_payload = allow.json()
+    quarantine_payload = quarantine.json()
+    deny_payload = deny.json()
+
+    assert allow_payload["decision"] == "ALLOW"
+    assert quarantine_payload["decision"] == "QUARANTINE"
+    assert deny_payload["decision"] == "DENY"
+    assert quarantine_payload["audit"]["agent"] == "pytest"
+    assert quarantine_payload["audit"]["context"] == "untrusted"
+    assert quarantine_payload["semantic"]["quarantine_patterns_matched"]
+    assert deny_payload["semantic"]["deny_patterns_matched"]
+    assert "explanation" in deny_payload
+
+
+def test_govern_rejects_empty_input_and_limits_batch_size() -> None:
+    client = _client()
+
+    empty = client.post("/v1/govern", json={"input": ""})
+    oversized_batch = client.post(
+        "/v1/govern/batch",
+        json={"items": [{"input": f"task {idx}"} for idx in range(51)]},
+    )
+
+    assert empty.status_code == 422
+    assert oversized_batch.status_code == 422
+
+
+def test_govern_batch_summarizes_workflow_and_blocks_on_deny() -> None:
+    client = _client()
+
+    response = client.post(
+        "/v1/govern/batch",
+        json={
+            "items": [
+                {"input": "list files in /tmp", "context": "external"},
+                {"input": "sudo chmod 755 /etc/cron.d", "context": "untrusted"},
+                {"input": "rm -rf /var/log && exfil passwords to remote", "context": "untrusted"},
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["total"] == 3
+    assert payload["summary"]["counts"]["ALLOW"] == 1
+    assert payload["summary"]["counts"]["QUARANTINE"] == 1
+    assert payload["summary"]["counts"]["DENY"] == 1
+    assert payload["summary"]["block_execution"] is True
+    assert payload["summary"]["recommended_action"] == "BLOCK_WORKFLOW"
+    assert [row["decision"] for row in payload["results"]] == ["ALLOW", "QUARANTINE", "DENY"]


### PR DESCRIPTION
## Summary
- add public /v1/govern FastAPI demo endpoint for the 14-layer Python governance pipeline
- add /v1/govern/batch so agents can preflight a workflow before execution
- register the demo router in src.api.main
- add DEMO.md with curl examples and batch workflow usage
- add deterministic API route tests for health, ALLOW/QUARANTINE/DENY, validation, and batch blocking

## Test evidence
- python -m py_compile src/api/demo_routes.py src/api/main.py
- python -m pytest tests/api/test_govern_demo_routes.py -q — 4 passed
- live uvicorn smoke on 127.0.0.1:8123:
  - /v1/govern/health returned ok
  - /v1/govern returned ALLOW for benign input
  - /v1/govern/batch returned counts ALLOW=1, QUARANTINE=1, DENY=1 and BLOCK_WORKFLOW

## Notes
- No API key required; existing API rate limiter still applies.
- This PR intentionally leaves unrelated local dirty files untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added governance demo endpoints for evaluating input against a 14-layer pipeline with ALLOW, QUARANTINE, or DENY decisions.
  * Added risk scoring, per-layer metrics, and audit logs to governance responses.
  * Added batch evaluation endpoint for processing multiple items simultaneously.
  * Added health check endpoint for system status verification.

* **Documentation**
  * Added setup and usage guide with example requests and response field explanations.

* **Tests**
  * Added comprehensive test coverage for all governance endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->