### PR TITLE
fix(cli): make agent-json useful for piped hosted runs

### DIFF
--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -956,7 +956,10 @@ async function streamLLM(prompt, cfg, history, onToken) {
   let apiUrl, headers;
 
   if (isFireworks) {
-    const base = cfg.url || cfg.fireworks_base_url || FIREWORKS_BASE_URL;
+    const configuredUrl = cfg.url || '';
+    const base =
+      cfg.fireworks_base_url ||
+      (configuredUrl && !/^https?:\/\/localhost:11434\/?$/i.test(configuredUrl) ? configuredUrl : FIREWORKS_BASE_URL);
     apiUrl = `${base.replace(/\/$/, '')}/chat/completions`;
     const key = cfg.fireworks_api_key || cfg.api_key || process.env.FIREWORKS_API_KEY || '';
     headers = { 'content-type': 'application/json', authorization: `Bearer ${key}` };
@@ -1115,6 +1118,7 @@ function runInteractiveShell(flags = {}) {
     const history = [];
     let instruction = null;
     let busy = false;
+    let stdinClosed = false;
 
     process.stdout.write(JSON.stringify({ ready: true }) + '\n');
 
@@ -1143,10 +1147,15 @@ function runInteractiveShell(flags = {}) {
       let full;
       try {
         // SCBE_MOCK_RESPONSE bypasses LLM for testing — never set in production
+        const mockDelayMs = Number(process.env.SCBE_MOCK_RESPONSE_DELAY_MS || 0);
+        if (mockDelayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, mockDelayMs));
+        }
         full = process.env.SCBE_MOCK_RESPONSE || await streamLLM(prompt, cfg, history, () => {});
       } catch (err) {
         process.stdout.write(JSON.stringify({ error: err.message, done: false, commands: [] }) + '\n');
         busy = false;
+        if (stdinClosed) process.exit(0);
         rl.resume();
         return;
       }
@@ -1161,6 +1170,7 @@ function runInteractiveShell(flags = {}) {
       if (!cmdMatch) {
         process.stdout.write(JSON.stringify({ commands: [], done: doneSignal, rationale: full.slice(0, 500) }) + '\n');
         busy = false;
+        if (stdinClosed) process.exit(0);
         if (!doneSignal) rl.resume();
         return;
       }
@@ -1199,6 +1209,7 @@ function runInteractiveShell(flags = {}) {
           governance,
         }) + '\n');
         busy = false;
+        if (stdinClosed) process.exit(0);
         rl.resume();
         return;
       }
@@ -1212,10 +1223,14 @@ function runInteractiveShell(flags = {}) {
       }) + '\n');
 
       busy = false;
+      if (stdinClosed) process.exit(0);
       if (!doneSignal) rl.resume();
     });
 
-    rl.on('close', () => process.exit(0));
+    rl.on('close', () => {
+      stdinClosed = true;
+      if (!busy) process.exit(0);
+    });
     return;
   }
 

--- a/packages/cli/scripts/shell_benchmark.cjs
+++ b/packages/cli/scripts/shell_benchmark.cjs
@@ -231,6 +231,38 @@ function main() {
     };
   }));
 
+  cases.push(caseResult('agent_json_waits_for_async_response_after_stdin_close', () => {
+    // Regression: piped harness input closes stdin immediately. The process must
+    // still wait for the async model/governance turn before exiting.
+    const { spawnSync: spawn } = require('node:child_process');
+    const mockResponse = '<cmd>git status --short --branch</cmd> task complete';
+    const inputLines = [
+      JSON.stringify({ instruction: 'inspect repo state', terminal_state: '$ ' }),
+      '',
+    ].join('\n');
+    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: inputLines,
+      encoding: 'utf8',
+      timeout: 20_000,
+      env: {
+        ...process.env,
+        NO_COLOR: '1',
+        SCBE_MOCK_RESPONSE: mockResponse,
+        SCBE_MOCK_RESPONSE_DELAY_MS: '250',
+      },
+    });
+    assert.equal(r.status, 0, r.stderr || r.stdout);
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    assert.ok(lines.length >= 2, `expected ready + delayed response, got: ${r.stdout}`);
+    const ready = JSON.parse(lines[0]);
+    const resp = JSON.parse(lines[1]);
+    assert.equal(ready.ready, true);
+    assert.equal(resp.done, true);
+    assert.equal(resp.commands[0].keystrokes, 'git status --short --branch');
+    return { lines_received: lines.length, command: resp.commands[0].keystrokes };
+  }));
+
   const total = cases.reduce((sum, row) => sum + row.points, 0);
   const earned = cases.reduce((sum, row) => sum + row.earned, 0);
   const report = {


### PR DESCRIPTION
## Summary
- Keep `scbe shell --agent-json` alive after stdin closes while an async model/governance turn is still running.
- Route Fireworks to the Fireworks base URL when provider is Fireworks and the saved shell config still contains the default Ollama URL.
- Add a regression benchmark proving piped harness input waits for a delayed async response.

## Dogfood evidence
- `node packages\cli\scripts\shell_benchmark.cjs` -> 12/12, 100%, ready=true
- Fireworks live agent-json route returned governed command: `git status --short --branch`
- `node packages\cli\bin\scbe.js run "git status --short --branch" --json` -> ALLOW, exit 0
- `node packages\cli\bin\scbe.js run "rm -rf C:/" --json` -> DENY, exit 126
- `npm pack --dry-run --json` from `packages/cli` -> 10 files, no cache files

## Rollback
- Revert this commit; agent-json remains available but piped hosted calls can exit before async completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved endpoint URL handling for cloud provider integration with enhanced localhost support.
  * Enhanced input handling in agent-json mode for more reliable process shutdown after input ends.

* **Tests**
  * Added benchmark test for agent-json mode asynchronous response handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->