### PR TITLE
feat(cli): attach bijective move packets to agent commands

### DIFF
--- a/docs/benchmarks/SCBE_SHELL_AGENTIC_BENCHMARK_PLAN.md
+++ b/docs/benchmarks/SCBE_SHELL_AGENTIC_BENCHMARK_PLAN.md
@@ -101,10 +101,10 @@ Add thin adapters, not custom score claims:
 
 ## Immediate Improvements
 
-1. ~~Add `scbe shell --agent-json` for stable machine control.~~ **DONE** — NDJSON stdin/stdout protocol; `scbe_tb_agent.py` adapter; 11/11 bench (cmd extraction + GeoSeal + done-signal paths verified).
+1. ~~Add `scbe shell --agent-json` for stable machine control.~~ **DONE** — NDJSON stdin/stdout protocol; `scbe_tb_agent.py` adapter; 17/17 bench (task-completion prompt + tool translation + loop detector + `:patch` verified). Live smoke with Groq confirmed task-completion prompt reaches LLM; Groq smoke also revealed model emits `<cmd>...<cmd>` (open tag) instead of `<cmd>...</cmd>` (close tag) — regex fix verified in `scripts/smoke_agent_json_e2e.cjs`: both formats extract valid executable commands. Objective verifier (`done_if`) added: `done=true` is gated by a shell check, not model text alone; `scripts/smoke_agent_json_e2e.cjs` proves (1) regex fix, (2) verifier blocks false-done, (3) multi-turn mock loop creates file with correct content.
 2. Add `scbe shell --script <file>` to replay workflows deterministically.
-3. Add a repository retrieval primitive: `:files <query>` backed first by ripgrep, later by SCIP/tree-sitter.
-4. Add patch commands: `:patch apply`, `:patch show`, `:patch revert-last`.
+3. ~~Add a repository retrieval primitive: `:files <query>` backed first by ripgrep, later by SCIP/tree-sitter.~~ **DONE** — `:files <pattern>` → `find`; `:read <path> <start>:<end>` → `sed`; `:test <cmd>` → cmd with SCBE_TEST_PASS/FAIL echo; `:patch <file>` → `patch -p1`; all four translate to portable shell commands in agent-json mode.
+4. ~~Add patch command.~~ **DONE** — `:patch <file>` → `patch -p1 < '<file>'`.
 5. Add workflow receipts: each multi-step run should emit `artifacts/benchmarks/scbe-shell/<run>.json`.
 6. ~~Add Terminal-Bench/SWE-bench adapters only after Level 0 and Level 1 are green.~~ **IN PROGRESS** — `packages/cli/scripts/scbe_tb_agent.py` adapter ready; requires `pip install terminal-bench` + Docker for live runs.
 
@@ -130,8 +130,9 @@ npm run bench:shell
 
 Results:
 
-- Shell ACI smoke: **11/11** (added cmd-extraction + GeoSeal + done-signal path coverage), 100%
-- Artifact: `artifacts/benchmarks/scbe-shell/2026-05-26T21-56-57-301Z-shell-agentic-benchmark.json`
+- Shell ACI smoke: **17/17** (task-completion prompt + tool translations `:files`/`:read`/`:test`/`:patch` + loop detector), 100%
+- E2E smoke (`scripts/smoke_agent_json_e2e.cjs`): regex fix proven — bad-format `<cmd>...<cmd>` and good-format `<cmd>...</cmd>` both extract executable commands; verifier gate proven — `done_if` check prevents false-done when file absent; mock multi-turn loop creates `/tmp/scbe_smoke_e2e.txt` with correct content.
+- Live smoke (Groq llama-3.3-70b-versatile, prior session): task-completion prompt reached LLM; governance returned ALLOW; revealed `<cmd>...<cmd>` tag format which prompted regex fix above.
 
 Agentic route smoke:
 

--- a/docs/specs/SCBE_AGENT_PATH_POLICY.md
+++ b/docs/specs/SCBE_AGENT_PATH_POLICY.md
@@ -1,0 +1,80 @@
+# SCBE Agent Path Policy: Non-Optimal Correct Path Finding
+
+## Definition
+
+Non-optimal correct path finding is an agentic execution strategy where the system prioritizes verified forward progress over optimality. A move is accepted if it is legal, safe, reversible or bounded, and improves or preserves task state, even if it is not the shortest or most elegant solution.
+
+## Motivation
+
+Small models fail when forced to be elegant. They succeed when allowed to take stairs.
+
+An agent demanding the best solution will get stuck in planning loops, repeat failures while hoping for a better outcome, or emit a confident-but-unverified `<done>` signal.
+
+An agent allowed to find any valid path will complete more tasks, leave verifiable evidence, and create a map of what failed — which is itself useful state.
+
+## Mechanical Rules
+
+1. A move can be ugly but must be legal.
+2. A patch can be small and boring if tests pass.
+3. A workaround can be accepted if it is documented and bounded.
+4. A failed move is allowed if it produces useful information.
+5. Repeating the same failed move is not allowed (ko-ban).
+6. Completion requires verification, not model confidence.
+7. Optimization happens after correctness.
+
+## Move Acceptance Table
+
+| Move Type              | Accepted? | Why                |
+|------------------------|-----------|--------------------|
+| Fast and correct       | yes       | best case          |
+| Slow and correct       | yes       | still progress     |
+| Ugly but verified      | yes       | can refine later   |
+| Failed but informative | yes       | improves map       |
+| Failed and repeated    | no        | loop (ko-ban)      |
+| Elegant but unverified | no        | fake completion    |
+| Risky and irreversible | no        | bad move           |
+
+## Scoring Priority
+
+When evaluating task execution, scores are applied in this order:
+
+1. **Correctness** — does the verifier pass?
+2. **Safety** — was the move legal and governed?
+3. **Reversibility** — was the move bounded and recoverable?
+4. **Efficiency** — how many turns did it take?
+5. **Elegance** — last. Irrelevant until the above four are satisfied.
+
+## Task Board Representation
+
+The policy is carried in the task board object as a machine-readable contract:
+
+```json
+{
+  "path_policy": "non_optimal_correct",
+  "acceptance": {
+    "must_be_safe": true,
+    "must_be_verifiable": true,
+    "must_not_repeat_failed_state": true,
+    "optimality_required": false
+  }
+}
+```
+
+This gives small models explicit permission to succeed imperfectly while preventing the dangerous and the dishonest.
+
+## Relation to Board Mechanics
+
+- **Ko-ban** enforces rule 5: repeated failed state is blocked, not just rationale-warned.
+- **`done_if` verifier** enforces rule 6: `<done>` from the model is a request for verification, not a completion signal.
+- **`attempts` log** makes failed-but-informative moves visible to the model in the next turn.
+- **`legal_moves`** enforces rule 1: the board defines what moves exist.
+
+## Relation to SCBE Governance
+
+Non-optimal correct path finding is consistent with SCBE's L13 risk tier model:
+
+- ALLOW: legal, safe, bounded move → accepted even if ugly
+- QUARANTINE: ko-banned or suspicious → blocked and logged
+- DENY: destructive, irreversible, or governance-blocked → hard stop
+
+The path policy does not relax governance. It relaxes quality requirements on moves that governance already allows.

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -909,6 +909,128 @@ function saveShellConfig(cfg) {
   fs.writeFileSync(shellConfigPath(), `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
 }
 
+// ─── Agent-JSON: task-completion prompt + shell tool translations ─────────────
+
+const _AGENT_JSON_SYSTEM_PROMPT = [
+  'You are a terminal task completion agent. Complete the given task, then verify it is done.',
+  '',
+  'RULES:',
+  '1. Inspect the current terminal state before choosing any command.',
+  '2. Choose ONE command per turn. Wrap it in <cmd>...</cmd>.',
+  '3. After each command\'s output, decide: is the task complete?',
+  '4. Only emit <done> after running the verification step described in the task (tests pass, file exists, expected output confirmed).',
+  '5. If a command fails: state why it failed, then try a different approach. Never repeat a failed command.',
+  '6. Do not repeat the same command if the terminal state has not changed.',
+  '',
+  'BUILT-IN TOOLS — use like any command inside <cmd>...</cmd>:',
+  '  :files <pattern>           — find files by name or grep for text in files',
+  '  :read <path> <start>:<end> — read lines start–end of a file  e.g. :read main.py 1:40',
+  '  :test <cmd>                — run test command; output includes SCBE_TEST_PASS or SCBE_TEST_FAIL',
+  '  :patch <file>              — apply a unified diff: patch -p1 < <file>',
+  '',
+  'VERIFICATION: Before emitting <done>, run the check described in the task.',
+  'Example: task says "make the tests pass" → run the tests, see them pass, then emit <done>.',
+].join('\n');
+
+function translateToolCommand(cmd) {
+  const trimmed = cmd.trim();
+  if (!trimmed.startsWith(':')) return null;
+  const space = trimmed.indexOf(' ');
+  const tool = space === -1 ? trimmed.slice(1) : trimmed.slice(1, space);
+  const args = space === -1 ? '' : trimmed.slice(space + 1).trim();
+  if (tool === 'files') {
+    const esc = args.replace(/'/g, "'\\''");
+    return `find . -name '*${esc}*' 2>/dev/null | head -30`;
+  }
+  if (tool === 'read') {
+    const parts = args.split(/\s+/);
+    const fp = (parts[0] || 'README.md').replace(/'/g, "'\\''");
+    const range = (parts[1] || '1:50').split(':');
+    return `sed -n '${range[0] || 1},${range[1] || 50}p' '${fp}'`;
+  }
+  if (tool === 'test') {
+    return `${args} && echo SCBE_TEST_PASS || echo SCBE_TEST_FAIL`;
+  }
+  if (tool === 'patch') {
+    const fp = (args || 'fix.patch').replace(/'/g, "'\\''");
+    return `patch -p1 < '${fp}'`;
+  }
+  return null;
+}
+
+function resolveBash() {
+  if (process.platform !== 'win32') return '/bin/sh';
+  const r = spawnSync('where', ['bash'], { encoding: 'utf8' });
+  return (r.stdout.split('\n').find((l) => l.trim()) || 'bash').trim();
+}
+
+function buildBoardPromptBlock(board) {
+  if (!board.objective) return '';
+  const _failPattern = /error|FAIL|not found|No such|permission denied|command not found/i;
+  const lines = ['--- Task Board ---', `Objective: ${board.objective.slice(0, 200)}`];
+  lines.push(`Turn: ${board.turn}`);
+  if (board.attempts.length > 0) {
+    const failCount = board.attempts.filter((a) => a.observation != null && _failPattern.test(a.observation)).length;
+    lines.push(`Progress: ${board.attempts.length} attempts, ${failCount} failed, ${board.ko_bans.length} ko-banned`);
+  }
+  if (board.attempts.length) {
+    const recent = board.attempts.slice(-5);
+    lines.push(`Attempts (${board.attempts.length} total, last ${recent.length}):`);
+    for (const a of recent) {
+      const cmd = (a.translated || a.cmd).slice(0, 80);
+      const obs = a.observation != null ? ` → ${a.observation.slice(0, 200).replace(/\n/g, ' ')}` : '';
+      const failed = a.observation != null && _failPattern.test(a.observation);
+      const mark = a.observation == null ? '?' : (failed ? '!' : '+');
+      lines.push(`  [T${a.turn}${mark}] ${cmd}${obs}`);
+    }
+  }
+  if (board.ko_bans.length) {
+    lines.push('Ko-banned (do not repeat — try a different approach):');
+    for (const key of board.ko_bans) lines.push(`  - ${key.split('|||')[0].slice(0, 80)}`);
+  }
+  lines.push(`Board: ${board.done ? 'COMPLETE' : 'IN PROGRESS'}`);
+  // Policy: ugly-but-verified accepted; unverified-done rejected; repeated-failed-move rejected
+  if (board.path_policy === 'non_optimal_correct') {
+    lines.push('Policy: non_optimal_correct — any legal safe move that makes progress is accepted; elegance is not required; completion requires verification.');
+  }
+  lines.push('---');
+  return lines.join('\n') + '\n\n';
+}
+
+function buildAgentMovePacket(move, governance, board) {
+  const script = resolveRepoScript('scripts/system/agent_move_packet.py');
+  if (!script) return null;
+  const payload = {
+    schema_version: 'scbe_agent_move_packet_input_v1',
+    move: {
+      cmd: move.cmd,
+      translated: move.translated || move.cmd,
+      turn: board.turn,
+      objective: board.objective,
+      legal_moves: board.legal_moves,
+      path_policy: board.path_policy,
+    },
+    governance,
+  };
+  try {
+    const r = spawnSync(pythonCommand(), [script], {
+      cwd: repoRoot(),
+      input: JSON.stringify(payload),
+      encoding: 'utf8',
+      timeout: 10000,
+      maxBuffer: 1024 * 1024,
+    });
+    if (r.status !== 0) {
+      const err = ((r.stdout || '') + (r.stderr || '')).trim().slice(0, 300);
+      return { ok: false, error: err || `agent_move_packet exited ${r.status}` };
+    }
+    const parsed = JSON.parse(r.stdout);
+    return parsed.ok ? parsed.packet : parsed;
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+}
+
 // ─── Input classifier ─────────────────────────────────────────────────────────
 
 const _PS_PREFIX = /^(!|ps:)\s*/;
@@ -1114,11 +1236,33 @@ function runInteractiveShell(flags = {}) {
     if (cfg.provider === 'fireworks' && !cfg.fireworks_api_key && process.env.FIREWORKS_API_KEY) {
       cfg.fireworks_api_key = process.env.FIREWORKS_API_KEY;
     }
+    // Task-completion mode: override conversational system prompt
+    cfg.system_prompt = _AGENT_JSON_SYSTEM_PROMPT;
 
     const history = [];
     let instruction = null;
     let busy = false;
     let stdinClosed = false;
+    // Single source of truth for task state.
+    const taskBoard = {
+      objective: null,
+      legal_moves: ['cmd', 'files', 'read', 'patch', 'test'],
+      attempts: [],
+      last_observation: null,
+      done_if: null,
+      done: false,
+      ko_bans: [],
+      turn: 0,
+      // Execution strategy: verified forward progress over optimality.
+      // See docs/specs/SCBE_AGENT_PATH_POLICY.md
+      path_policy: 'non_optimal_correct',
+      acceptance: {
+        must_be_safe: true,
+        must_be_verifiable: true,
+        must_not_repeat_failed_state: true,
+        optimality_required: false,
+      },
+    };
 
     process.stdout.write(JSON.stringify({ ready: true }) + '\n');
 
@@ -1132,7 +1276,12 @@ function runInteractiveShell(flags = {}) {
       let msg;
       try { msg = JSON.parse(line); } catch { return; }
 
-      if (msg.instruction) instruction = msg.instruction;
+      if (msg.instruction) {
+        instruction = msg.instruction;
+        if (!taskBoard.objective) taskBoard.objective = instruction;
+      }
+      if (msg.done_if && !taskBoard.done_if) taskBoard.done_if = msg.done_if;
+      if (msg.task_board && !taskBoard.objective) Object.assign(taskBoard, msg.task_board);
       if (!instruction) {
         process.stdout.write(JSON.stringify({ error: 'no instruction yet', done: false, commands: [] }) + '\n');
         return;
@@ -1140,9 +1289,27 @@ function runInteractiveShell(flags = {}) {
 
       busy = true;
       rl.pause();
+      taskBoard.turn++;
 
       const terminalState = msg.terminal_state || '';
-      const prompt = instruction + (terminalState ? `\n\nCurrent terminal state:\n${terminalState}` : '');
+
+      // Record the observation (output) of the last proposed command.
+      if (taskBoard.attempts.length > 0) {
+        const lastAttempt = taskBoard.attempts[taskBoard.attempts.length - 1];
+        if (lastAttempt.observation === undefined) {
+          lastAttempt.observation = terminalState.slice(-150);
+          taskBoard.last_observation = terminalState;
+          const pairKey = `${lastAttempt.translated || lastAttempt.cmd}|||${lastAttempt.observation}`;
+          const seenBefore = taskBoard.attempts.slice(0, -1).some(
+            (a) => `${a.translated || a.cmd}|||${(a.observation || '').slice(-150)}` === pairKey
+          );
+          if (seenBefore && !taskBoard.ko_bans.includes(pairKey)) taskBoard.ko_bans.push(pairKey);
+        }
+      }
+      if (!taskBoard.last_observation) taskBoard.last_observation = terminalState;
+
+      const boardBlock = buildBoardPromptBlock(taskBoard);
+      const prompt = boardBlock + instruction + (terminalState ? `\n\nCurrent terminal state:\n${terminalState}` : '');
 
       let full;
       try {
@@ -1153,7 +1320,7 @@ function runInteractiveShell(flags = {}) {
         }
         full = process.env.SCBE_MOCK_RESPONSE || await streamLLM(prompt, cfg, history, () => {});
       } catch (err) {
-        process.stdout.write(JSON.stringify({ error: err.message, done: false, commands: [] }) + '\n');
+        process.stdout.write(JSON.stringify({ error: err.message, done: false, commands: [], board: { ...taskBoard } }) + '\n');
         busy = false;
         if (stdinClosed) process.exit(0);
         rl.resume();
@@ -1164,18 +1331,78 @@ function runInteractiveShell(flags = {}) {
       history.push({ role: 'assistant', content: full });
       if (history.length > 20) history.splice(0, 2);
 
-      const cmdMatch = full.match(/<cmd>([\s\S]*?)<\/cmd>/);
-      const doneSignal = /task\s+(?:is\s+)?(?:complete|done|finished)/i.test(full) || /<done>/.test(full);
+      // Accept </cmd> OR the opening of a next <cmd> as closing delimiter.
+      // Some models emit <cmd>...<cmd> (open tag) instead of <cmd>...</cmd> (close tag).
+      // The lookahead stops before the next <cmd> without consuming it.
+      const cmdMatch = full.match(/<cmd>([\s\S]*?)(?:<\/cmd>|(?=\s*<cmd>))/);
+
+      const doneSignal = /\btask\s+(?:is\s+)?(?:complete|done|finished)/i.test(full) || /<done>/.test(full);
+
+      const bashBin = resolveBash();
 
       if (!cmdMatch) {
-        process.stdout.write(JSON.stringify({ commands: [], done: doneSignal, rationale: full.slice(0, 500) }) + '\n');
+        // Model <done> is a request for board verification, not completion
+        if (doneSignal && taskBoard.done_if) {
+          const check = spawnSync(bashBin, ['-c', taskBoard.done_if], { encoding: 'utf8', timeout: 10000 });
+          if (check.status !== 0) {
+            const verifyOut = ((check.stdout || '') + (check.stderr || '')).trim().slice(0, 300) || 'verifier exited non-zero';
+            history.push({ role: 'user', content: `VERIFY FAILED: ${verifyOut}\nThe objective is not yet complete. Continue working.` });
+            history.push({ role: 'assistant', content: 'Understood. I will continue.' });
+            if (history.length > 20) history.splice(0, 2);
+            process.stdout.write(JSON.stringify({
+              commands: [],
+              done: false,
+              verify_failed: true,
+              rationale: `done signal received but objective verifier failed: ${verifyOut}`,
+              governance: { decision: 'ALLOW', reason: 'no-cmd' },
+              board: { ...taskBoard },
+            }) + '\n');
+            busy = false;
+            if (stdinClosed) process.exit(0);
+            rl.resume();
+            return;
+          }
+          taskBoard.done = true;
+        }
+        process.stdout.write(JSON.stringify({
+          commands: [],
+          done: taskBoard.done || doneSignal,
+          rationale: full.slice(0, 500),
+          governance: { decision: 'ALLOW', reason: 'no-cmd' },
+          board: { ...taskBoard },
+        }) + '\n');
         busy = false;
         if (stdinClosed) process.exit(0);
-        if (!doneSignal) rl.resume();
+        if (!(taskBoard.done || doneSignal)) rl.resume();
         return;
       }
 
       const proposed = cmdMatch[1].trim();
+      const translated = translateToolCommand(proposed) || proposed;
+
+      // Ko-ban: block if this (translated_cmd, last_observation) pair was already banned
+      const koPairKey = `${translated}|||${(taskBoard.last_observation || '').slice(-150)}`;
+      if (taskBoard.ko_bans.includes(koPairKey)) {
+        process.stdout.write(JSON.stringify({
+          commands: [],
+          done: false,
+          blocked: true,
+          rationale: `ko-ban: command+observation repeated — try a different approach. Banned: "${translated.slice(0, 80)}"`,
+          governance: { decision: 'QUARANTINE', reason: 'ko-ban' },
+          board: { ...taskBoard },
+        }) + '\n');
+        busy = false;
+        if (stdinClosed) process.exit(0);
+        rl.resume();
+        return;
+      }
+
+      taskBoard.attempts.push({
+        cmd: proposed,
+        ...(translated !== proposed ? { translated } : {}),
+        turn: taskBoard.turn,
+      });
+      if (taskBoard.attempts.length > 20) taskBoard.attempts.shift();
 
       // Run through GeoSeal governance
       const busBin = resolveAgentBusBin();
@@ -1186,7 +1413,7 @@ function runInteractiveShell(flags = {}) {
         try {
           const r = spawnSync(
             process.execPath,
-            [busBin, 'pipeline', 'compile', '--intent', proposed, '--json'],
+            [busBin, 'pipeline', 'compile', '--intent', translated, '--json'],
             { encoding: 'utf8', timeout: 15000, maxBuffer: 1024 * 512 }
           );
           if (r.status === 0 && r.stdout) {
@@ -1207,6 +1434,7 @@ function runInteractiveShell(flags = {}) {
           blocked: true,
           rationale: `governance blocked: ${governance.reason}`,
           governance,
+          board: { ...taskBoard },
         }) + '\n');
         busy = false;
         if (stdinClosed) process.exit(0);
@@ -1214,17 +1442,48 @@ function runInteractiveShell(flags = {}) {
         return;
       }
 
-      const rationale = full.replace(/<cmd>[\s\S]*?<\/cmd>/g, '').trim().slice(0, 500);
+      // Objective verifier: model <done> is only a request — verify before accepting
+      if (doneSignal && taskBoard.done_if) {
+        const check = spawnSync(bashBin, ['-c', taskBoard.done_if], { encoding: 'utf8', timeout: 10000 });
+        if (check.status !== 0) {
+          const verifyOut = ((check.stdout || '') + (check.stderr || '')).trim().slice(0, 300) || 'verifier exited non-zero';
+          history.push({ role: 'user', content: `VERIFY FAILED: ${verifyOut}\nThe objective is not yet complete. Continue working.` });
+          history.push({ role: 'assistant', content: 'Understood. I will continue.' });
+          if (history.length > 20) history.splice(0, 2);
+          process.stdout.write(JSON.stringify({
+            commands: [{ keystrokes: translated, is_blocking: true, timeout_sec: 30 }],
+            done: false,
+            verify_failed: true,
+            rationale: `done signal received but objective verifier failed: ${verifyOut}`,
+            governance,
+            board: { ...taskBoard },
+          }) + '\n');
+          busy = false;
+          if (stdinClosed) process.exit(0);
+          rl.resume();
+          return;
+        }
+        taskBoard.done = true;
+      }
+
+      // Two-pass strip: (1) <cmd>...</cmd> or <cmd>...<cmd> (Groq open-tag style),
+      // (2) any trailing <cmd>... with no close tag.
+      const rationale = full
+        .replace(/<cmd>[\s\S]*?(?:<\/cmd>|(?=<cmd>))/g, '')
+        .replace(/<cmd>[\s\S]*/g, '')
+        .trim()
+        .slice(0, 500);
       process.stdout.write(JSON.stringify({
-        commands: [{ keystrokes: proposed, is_blocking: true, timeout_sec: 30 }],
-        done: doneSignal,
+        commands: [{ keystrokes: translated, is_blocking: true, timeout_sec: 30 }],
+        done: taskBoard.done || doneSignal,
         rationale,
         governance,
+        board: { ...taskBoard },
       }) + '\n');
 
       busy = false;
       if (stdinClosed) process.exit(0);
-      if (!doneSignal) rl.resume();
+      if (!(taskBoard.done || doneSignal)) rl.resume();
     });
 
     rl.on('close', () => {

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -917,7 +917,7 @@ const _AGENT_JSON_SYSTEM_PROMPT = [
   'RULES:',
   '1. Inspect the current terminal state before choosing any command.',
   '2. Choose ONE command per turn. Wrap it in <cmd>...</cmd>.',
-  '3. After each command\'s output, decide: is the task complete?',
+  "3. After each command's output, decide: is the task complete?",
   '4. Only emit <done> after running the verification step described in the task (tests pass, file exists, expected output confirmed).',
   '5. If a command fails: state why it failed, then try a different approach. Never repeat a failed command.',
   '6. Do not repeat the same command if the terminal state has not changed.',
@@ -960,8 +960,28 @@ function translateToolCommand(cmd) {
 
 function resolveBash() {
   if (process.platform !== 'win32') return '/bin/sh';
+  const candidates = [
+    process.env.SCBE_BASH,
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch {
+      /* try next */
+    }
+  }
   const r = spawnSync('where', ['bash'], { encoding: 'utf8' });
-  return (r.stdout.split('\n').find((l) => l.trim()) || 'bash').trim();
+  return (
+    r.stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .find(
+        (l) =>
+          l && !/\\windows\\system32\\bash\.exe$/i.test(l) && !/\\WindowsApps\\bash\.exe$/i.test(l)
+      ) || 'bash'
+  ).trim();
 }
 
 function buildBoardPromptBlock(board) {
@@ -970,17 +990,22 @@ function buildBoardPromptBlock(board) {
   const lines = ['--- Task Board ---', `Objective: ${board.objective.slice(0, 200)}`];
   lines.push(`Turn: ${board.turn}`);
   if (board.attempts.length > 0) {
-    const failCount = board.attempts.filter((a) => a.observation != null && _failPattern.test(a.observation)).length;
-    lines.push(`Progress: ${board.attempts.length} attempts, ${failCount} failed, ${board.ko_bans.length} ko-banned`);
+    const failCount = board.attempts.filter(
+      (a) => a.observation != null && _failPattern.test(a.observation)
+    ).length;
+    lines.push(
+      `Progress: ${board.attempts.length} attempts, ${failCount} failed, ${board.ko_bans.length} ko-banned`
+    );
   }
   if (board.attempts.length) {
     const recent = board.attempts.slice(-5);
     lines.push(`Attempts (${board.attempts.length} total, last ${recent.length}):`);
     for (const a of recent) {
       const cmd = (a.translated || a.cmd).slice(0, 80);
-      const obs = a.observation != null ? ` → ${a.observation.slice(0, 200).replace(/\n/g, ' ')}` : '';
+      const obs =
+        a.observation != null ? ` → ${a.observation.slice(0, 200).replace(/\n/g, ' ')}` : '';
       const failed = a.observation != null && _failPattern.test(a.observation);
-      const mark = a.observation == null ? '?' : (failed ? '!' : '+');
+      const mark = a.observation == null ? '?' : failed ? '!' : '+';
       lines.push(`  [T${a.turn}${mark}] ${cmd}${obs}`);
     }
   }
@@ -991,7 +1016,9 @@ function buildBoardPromptBlock(board) {
   lines.push(`Board: ${board.done ? 'COMPLETE' : 'IN PROGRESS'}`);
   // Policy: ugly-but-verified accepted; unverified-done rejected; repeated-failed-move rejected
   if (board.path_policy === 'non_optimal_correct') {
-    lines.push('Policy: non_optimal_correct — any legal safe move that makes progress is accepted; elegance is not required; completion requires verification.');
+    lines.push(
+      'Policy: non_optimal_correct — any legal safe move that makes progress is accepted; elegance is not required; completion requires verification.'
+    );
   }
   lines.push('---');
   return lines.join('\n') + '\n\n';
@@ -1074,14 +1101,17 @@ async function streamLLM(prompt, cfg, history, onToken) {
   const isFireworks = cfg.provider === 'fireworks';
   const isOllama =
     !isFireworks &&
-    (cfg.provider === 'ollama' || (!cfg.openai_api_key && !cfg.api_key && !cfg.groq_api_key && !cfg.fireworks_api_key));
+    (cfg.provider === 'ollama' ||
+      (!cfg.openai_api_key && !cfg.api_key && !cfg.groq_api_key && !cfg.fireworks_api_key));
   let apiUrl, headers;
 
   if (isFireworks) {
     const configuredUrl = cfg.url || '';
     const base =
       cfg.fireworks_base_url ||
-      (configuredUrl && !/^https?:\/\/localhost:11434\/?$/i.test(configuredUrl) ? configuredUrl : FIREWORKS_BASE_URL);
+      (configuredUrl && !/^https?:\/\/localhost:11434\/?$/i.test(configuredUrl)
+        ? configuredUrl
+        : FIREWORKS_BASE_URL);
     apiUrl = `${base.replace(/\/$/, '')}/chat/completions`;
     const key = cfg.fireworks_api_key || cfg.api_key || process.env.FIREWORKS_API_KEY || '';
     headers = { 'content-type': 'application/json', authorization: `Bearer ${key}` };
@@ -1149,10 +1179,15 @@ async function searchWeb(query) {
     const data = await res.json();
     const results = [];
     if (data.AbstractText) {
-      results.push({ title: data.Heading || 'Abstract', snippet: data.AbstractText, url: data.AbstractURL });
+      results.push({
+        title: data.Heading || 'Abstract',
+        snippet: data.AbstractText,
+        url: data.AbstractURL,
+      });
     }
     for (const r of (data.RelatedTopics || []).slice(0, 5)) {
-      if (r.Text && r.FirstURL) results.push({ title: r.Text.slice(0, 80), snippet: r.Text, url: r.FirstURL });
+      if (r.Text && r.FirstURL)
+        results.push({ title: r.Text.slice(0, 80), snippet: r.Text, url: r.FirstURL });
     }
     return { query, results: results.slice(0, 5), source: 'duckduckgo' };
   } catch (err) {
@@ -1173,7 +1208,10 @@ function formatPlanSummary(planResult) {
   const lines = [
     ansi('green', `  ✓ GeoSeal: ${policy.decision || 'ALLOW'}`) +
       ansi('gray', ` (${policy.reason || 'ok'})`),
-    ansi('gray', `    tool: ${(plan.tool || {}).class || '?'} | key: ${(plan.command || {}).key || '?'}`),
+    ansi(
+      'gray',
+      `    tool: ${(plan.tool || {}).class || '?'} | key: ${(plan.command || {}).key || '?'}`
+    ),
   ];
   if (semantic && semantic.discourseProfile) {
     lines.push(ansi('gray', `    semantic: ${semantic.dominant} → ${semantic.discourseProfile}`));
@@ -1198,19 +1236,45 @@ function runInteractiveShell(flags = {}) {
   // ── Minimal / legacy mode ─────────────────────────────────────────────────
   if (flags.minimal) {
     process.stdout.write('SCBE Terminal. Type commands normally. Use :help or :exit.\n');
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: 'scbe> ' });
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      prompt: 'scbe> ',
+    });
     rl.prompt();
     rl.on('line', (line) => {
       const command = line.trim();
-      if (!command) { rl.prompt(); return; }
-      if (command === ':exit' || command === 'exit' || command === 'quit') { rl.close(); return; }
-      if (command === ':help' || command === 'help') { process.stdout.write(CLI_HELP); rl.prompt(); return; }
-      if (command === ':status' || command === 'status') { runStatus(); rl.prompt(); return; }
-      if (command.startsWith(':history') || command === 'history') { printHistory(20); rl.prompt(); return; }
+      if (!command) {
+        rl.prompt();
+        return;
+      }
+      if (command === ':exit' || command === 'exit' || command === 'quit') {
+        rl.close();
+        return;
+      }
+      if (command === ':help' || command === 'help') {
+        process.stdout.write(CLI_HELP);
+        rl.prompt();
+        return;
+      }
+      if (command === ':status' || command === 'status') {
+        runStatus();
+        rl.prompt();
+        return;
+      }
+      if (command.startsWith(':history') || command === 'history') {
+        printHistory(20);
+        rl.prompt();
+        return;
+      }
       const scbeCmd = /^(compile|compile-ca|ca-plan|render-op|route|aetherpp)\b/.test(command)
-        ? `${process.execPath} "${__filename}" ${command}` : command;
+        ? `${process.execPath} "${__filename}" ${command}`
+        : command;
       const row = runShellCommand(scbeCmd);
-      if (!row.success && row.failure) process.stdout.write(`SCBE failure: ${row.failure.summary}\nNext: ${row.failure.next_step}\n`);
+      if (!row.success && row.failure)
+        process.stdout.write(
+          `SCBE failure: ${row.failure.summary}\nNext: ${row.failure.next_step}\n`
+        );
       rl.prompt();
     });
     return;
@@ -1274,7 +1338,11 @@ function runInteractiveShell(flags = {}) {
       if (!line) return;
 
       let msg;
-      try { msg = JSON.parse(line); } catch { return; }
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        return;
+      }
 
       if (msg.instruction) {
         instruction = msg.instruction;
@@ -1283,7 +1351,9 @@ function runInteractiveShell(flags = {}) {
       if (msg.done_if && !taskBoard.done_if) taskBoard.done_if = msg.done_if;
       if (msg.task_board && !taskBoard.objective) Object.assign(taskBoard, msg.task_board);
       if (!instruction) {
-        process.stdout.write(JSON.stringify({ error: 'no instruction yet', done: false, commands: [] }) + '\n');
+        process.stdout.write(
+          JSON.stringify({ error: 'no instruction yet', done: false, commands: [] }) + '\n'
+        );
         return;
       }
 
@@ -1300,16 +1370,21 @@ function runInteractiveShell(flags = {}) {
           lastAttempt.observation = terminalState.slice(-150);
           taskBoard.last_observation = terminalState;
           const pairKey = `${lastAttempt.translated || lastAttempt.cmd}|||${lastAttempt.observation}`;
-          const seenBefore = taskBoard.attempts.slice(0, -1).some(
-            (a) => `${a.translated || a.cmd}|||${(a.observation || '').slice(-150)}` === pairKey
-          );
+          const seenBefore = taskBoard.attempts
+            .slice(0, -1)
+            .some(
+              (a) => `${a.translated || a.cmd}|||${(a.observation || '').slice(-150)}` === pairKey
+            );
           if (seenBefore && !taskBoard.ko_bans.includes(pairKey)) taskBoard.ko_bans.push(pairKey);
         }
       }
       if (!taskBoard.last_observation) taskBoard.last_observation = terminalState;
 
       const boardBlock = buildBoardPromptBlock(taskBoard);
-      const prompt = boardBlock + instruction + (terminalState ? `\n\nCurrent terminal state:\n${terminalState}` : '');
+      const prompt =
+        boardBlock +
+        instruction +
+        (terminalState ? `\n\nCurrent terminal state:\n${terminalState}` : '');
 
       let full;
       try {
@@ -1318,9 +1393,16 @@ function runInteractiveShell(flags = {}) {
         if (mockDelayMs > 0) {
           await new Promise((resolve) => setTimeout(resolve, mockDelayMs));
         }
-        full = process.env.SCBE_MOCK_RESPONSE || await streamLLM(prompt, cfg, history, () => {});
+        full = process.env.SCBE_MOCK_RESPONSE || (await streamLLM(prompt, cfg, history, () => {}));
       } catch (err) {
-        process.stdout.write(JSON.stringify({ error: err.message, done: false, commands: [], board: { ...taskBoard } }) + '\n');
+        process.stdout.write(
+          JSON.stringify({
+            error: err.message,
+            done: false,
+            commands: [],
+            board: { ...taskBoard },
+          }) + '\n'
+        );
         busy = false;
         if (stdinClosed) process.exit(0);
         rl.resume();
@@ -1336,27 +1418,38 @@ function runInteractiveShell(flags = {}) {
       // The lookahead stops before the next <cmd> without consuming it.
       const cmdMatch = full.match(/<cmd>([\s\S]*?)(?:<\/cmd>|(?=\s*<cmd>))/);
 
-      const doneSignal = /\btask\s+(?:is\s+)?(?:complete|done|finished)/i.test(full) || /<done>/.test(full);
+      const doneSignal =
+        /\btask\s+(?:is\s+)?(?:complete|done|finished)/i.test(full) || /<done>/.test(full);
 
       const bashBin = resolveBash();
 
       if (!cmdMatch) {
         // Model <done> is a request for board verification, not completion
         if (doneSignal && taskBoard.done_if) {
-          const check = spawnSync(bashBin, ['-c', taskBoard.done_if], { encoding: 'utf8', timeout: 10000 });
+          const check = spawnSync(bashBin, ['-c', taskBoard.done_if], {
+            encoding: 'utf8',
+            timeout: 10000,
+          });
           if (check.status !== 0) {
-            const verifyOut = ((check.stdout || '') + (check.stderr || '')).trim().slice(0, 300) || 'verifier exited non-zero';
-            history.push({ role: 'user', content: `VERIFY FAILED: ${verifyOut}\nThe objective is not yet complete. Continue working.` });
+            const verifyOut =
+              ((check.stdout || '') + (check.stderr || '')).trim().slice(0, 300) ||
+              'verifier exited non-zero';
+            history.push({
+              role: 'user',
+              content: `VERIFY FAILED: ${verifyOut}\nThe objective is not yet complete. Continue working.`,
+            });
             history.push({ role: 'assistant', content: 'Understood. I will continue.' });
             if (history.length > 20) history.splice(0, 2);
-            process.stdout.write(JSON.stringify({
-              commands: [],
-              done: false,
-              verify_failed: true,
-              rationale: `done signal received but objective verifier failed: ${verifyOut}`,
-              governance: { decision: 'ALLOW', reason: 'no-cmd' },
-              board: { ...taskBoard },
-            }) + '\n');
+            process.stdout.write(
+              JSON.stringify({
+                commands: [],
+                done: false,
+                verify_failed: true,
+                rationale: `done signal received but objective verifier failed: ${verifyOut}`,
+                governance: { decision: 'ALLOW', reason: 'no-cmd' },
+                board: { ...taskBoard },
+              }) + '\n'
+            );
             busy = false;
             if (stdinClosed) process.exit(0);
             rl.resume();
@@ -1364,13 +1457,15 @@ function runInteractiveShell(flags = {}) {
           }
           taskBoard.done = true;
         }
-        process.stdout.write(JSON.stringify({
-          commands: [],
-          done: taskBoard.done || doneSignal,
-          rationale: full.slice(0, 500),
-          governance: { decision: 'ALLOW', reason: 'no-cmd' },
-          board: { ...taskBoard },
-        }) + '\n');
+        process.stdout.write(
+          JSON.stringify({
+            commands: [],
+            done: taskBoard.done || doneSignal,
+            rationale: full.slice(0, 500),
+            governance: { decision: 'ALLOW', reason: 'no-cmd' },
+            board: { ...taskBoard },
+          }) + '\n'
+        );
         busy = false;
         if (stdinClosed) process.exit(0);
         if (!(taskBoard.done || doneSignal)) rl.resume();
@@ -1383,14 +1478,23 @@ function runInteractiveShell(flags = {}) {
       // Ko-ban: block if this (translated_cmd, last_observation) pair was already banned
       const koPairKey = `${translated}|||${(taskBoard.last_observation || '').slice(-150)}`;
       if (taskBoard.ko_bans.includes(koPairKey)) {
-        process.stdout.write(JSON.stringify({
-          commands: [],
-          done: false,
-          blocked: true,
-          rationale: `ko-ban: command+observation repeated — try a different approach. Banned: "${translated.slice(0, 80)}"`,
-          governance: { decision: 'QUARANTINE', reason: 'ko-ban' },
-          board: { ...taskBoard },
-        }) + '\n');
+        const governance = { decision: 'QUARANTINE', reason: 'ko-ban' };
+        const movePacket = buildAgentMovePacket(
+          { cmd: proposed, translated },
+          governance,
+          taskBoard
+        );
+        process.stdout.write(
+          JSON.stringify({
+            commands: [],
+            done: false,
+            blocked: true,
+            rationale: `ko-ban: command+observation repeated — try a different approach. Banned: "${translated.slice(0, 80)}"`,
+            governance,
+            move_packet: movePacket,
+            board: { ...taskBoard },
+          }) + '\n'
+        );
         busy = false;
         if (stdinClosed) process.exit(0);
         rl.resume();
@@ -1422,20 +1526,31 @@ function runInteractiveShell(flags = {}) {
               governance = { decision: plan.policy.decision, reason: plan.policy.reason };
               blocked = plan.policy.decision !== 'ALLOW';
             }
-            if (plan.semantic?.discourseProfile) governance.semantic = plan.semantic.discourseProfile;
+            if (plan.semantic?.discourseProfile)
+              governance.semantic = plan.semantic.discourseProfile;
           }
-        } catch { /* stays ALLOW */ }
+        } catch {
+          /* stays ALLOW */
+        }
       }
 
       if (blocked) {
-        process.stdout.write(JSON.stringify({
-          commands: [],
-          done: false,
-          blocked: true,
-          rationale: `governance blocked: ${governance.reason}`,
+        const movePacket = buildAgentMovePacket(
+          { cmd: proposed, translated },
           governance,
-          board: { ...taskBoard },
-        }) + '\n');
+          taskBoard
+        );
+        process.stdout.write(
+          JSON.stringify({
+            commands: [],
+            done: false,
+            blocked: true,
+            rationale: `governance blocked: ${governance.reason}`,
+            governance,
+            move_packet: movePacket,
+            board: { ...taskBoard },
+          }) + '\n'
+        );
         busy = false;
         if (stdinClosed) process.exit(0);
         rl.resume();
@@ -1444,20 +1559,36 @@ function runInteractiveShell(flags = {}) {
 
       // Objective verifier: model <done> is only a request — verify before accepting
       if (doneSignal && taskBoard.done_if) {
-        const check = spawnSync(bashBin, ['-c', taskBoard.done_if], { encoding: 'utf8', timeout: 10000 });
+        const check = spawnSync(bashBin, ['-c', taskBoard.done_if], {
+          encoding: 'utf8',
+          timeout: 10000,
+        });
         if (check.status !== 0) {
-          const verifyOut = ((check.stdout || '') + (check.stderr || '')).trim().slice(0, 300) || 'verifier exited non-zero';
-          history.push({ role: 'user', content: `VERIFY FAILED: ${verifyOut}\nThe objective is not yet complete. Continue working.` });
+          const verifyOut =
+            ((check.stdout || '') + (check.stderr || '')).trim().slice(0, 300) ||
+            'verifier exited non-zero';
+          const movePacket = buildAgentMovePacket(
+            { cmd: proposed, translated },
+            governance,
+            taskBoard
+          );
+          history.push({
+            role: 'user',
+            content: `VERIFY FAILED: ${verifyOut}\nThe objective is not yet complete. Continue working.`,
+          });
           history.push({ role: 'assistant', content: 'Understood. I will continue.' });
           if (history.length > 20) history.splice(0, 2);
-          process.stdout.write(JSON.stringify({
-            commands: [{ keystrokes: translated, is_blocking: true, timeout_sec: 30 }],
-            done: false,
-            verify_failed: true,
-            rationale: `done signal received but objective verifier failed: ${verifyOut}`,
-            governance,
-            board: { ...taskBoard },
-          }) + '\n');
+          process.stdout.write(
+            JSON.stringify({
+              commands: [{ keystrokes: translated, is_blocking: true, timeout_sec: 30 }],
+              done: false,
+              verify_failed: true,
+              rationale: `done signal received but objective verifier failed: ${verifyOut}`,
+              governance,
+              move_packet: movePacket,
+              board: { ...taskBoard },
+            }) + '\n'
+          );
           busy = false;
           if (stdinClosed) process.exit(0);
           rl.resume();
@@ -1473,13 +1604,17 @@ function runInteractiveShell(flags = {}) {
         .replace(/<cmd>[\s\S]*/g, '')
         .trim()
         .slice(0, 500);
-      process.stdout.write(JSON.stringify({
-        commands: [{ keystrokes: translated, is_blocking: true, timeout_sec: 30 }],
-        done: taskBoard.done || doneSignal,
-        rationale,
-        governance,
-        board: { ...taskBoard },
-      }) + '\n');
+      const movePacket = buildAgentMovePacket({ cmd: proposed, translated }, governance, taskBoard);
+      process.stdout.write(
+        JSON.stringify({
+          commands: [{ keystrokes: translated, is_blocking: true, timeout_sec: 30 }],
+          done: taskBoard.done || doneSignal,
+          rationale,
+          governance,
+          move_packet: movePacket,
+          board: { ...taskBoard },
+        }) + '\n'
+      );
 
       busy = false;
       if (stdinClosed) process.exit(0);
@@ -1516,8 +1651,8 @@ function runInteractiveShell(flags = {}) {
       .catch((err) => {
         process.stderr.write(
           `scbe shell --tui: failed to load TUI.\n${err.message}\n\n` +
-          `Ensure ink and react are installed: npm install -g ink react\n` +
-          `Falling back to: scbe shell (no --tui)\n\n`
+            `Ensure ink and react are installed: npm install -g ink react\n` +
+            `Falling back to: scbe shell (no --tui)\n\n`
         );
         // Fallback to rich readline shell
         runInteractiveShell({ ...flags, tui: false });
@@ -1540,7 +1675,16 @@ function runInteractiveShell(flags = {}) {
     output: process.stdout,
     prompt: PROMPT,
     completer: (line) => {
-      const all = [...KNOWN_COMMANDS, ':help', ':exit', ':status', ':config', ':search', ':history', ':clear'];
+      const all = [
+        ...KNOWN_COMMANDS,
+        ':help',
+        ':exit',
+        ':status',
+        ':config',
+        ':search',
+        ':history',
+        ':clear',
+      ];
       const hits = all.filter((c) => c.startsWith(line));
       return [hits.length ? hits : all, line];
     },
@@ -1557,7 +1701,10 @@ function runInteractiveShell(flags = {}) {
 
   rl.on('line', (rawLine) => {
     const line = rawLine.trim();
-    if (!line) { rl.prompt(); return; }
+    if (!line) {
+      rl.prompt();
+      return;
+    }
 
     if (pendingApproval) {
       const proposed = pendingApproval.proposed;
@@ -1580,15 +1727,20 @@ function runInteractiveShell(flags = {}) {
       const meta = parts[0];
       const metaArgs = parts.slice(1);
 
-      if (meta === 'exit' || meta === 'quit') { rl.close(); return; }
-      if (meta === 'help') { process.stdout.write(`${CLI_HELP}\n`); }
-      else if (meta === 'status') { runStatus(); }
-      else if (meta === 'history') { printHistory(Number(metaArgs[0]) || 20); }
-      else if (meta === 'clear') {
+      if (meta === 'exit' || meta === 'quit') {
+        rl.close();
+        return;
+      }
+      if (meta === 'help') {
+        process.stdout.write(`${CLI_HELP}\n`);
+      } else if (meta === 'status') {
+        runStatus();
+      } else if (meta === 'history') {
+        printHistory(Number(metaArgs[0]) || 20);
+      } else if (meta === 'clear') {
         process.stdout.write('\x1b[2J\x1b[0f');
         printShellStatusBar(cfg);
-      }
-      else if (meta === 'config') {
+      } else if (meta === 'config') {
         if (metaArgs[0] === 'set' && metaArgs[1]) {
           const key = metaArgs[1];
           const val = metaArgs.slice(2).join(' ');
@@ -1604,10 +1756,13 @@ function runInteractiveShell(flags = {}) {
           process.stdout.write(ansi('gray', `${JSON.stringify(display, null, 2)}\n`));
           process.stdout.write(ansi('gray', '  :config set <key> <value>  to change\n'));
         }
-      }
-      else if (meta === 'search') {
+      } else if (meta === 'search') {
         const query = metaArgs.join(' ');
-        if (!query) { process.stdout.write(ansi('yellow', '  Usage: :search <query>\n')); rl.prompt(); return; }
+        if (!query) {
+          process.stdout.write(ansi('yellow', '  Usage: :search <query>\n'));
+          rl.prompt();
+          return;
+        }
         process.stdout.write(ansi('cyan', `  searching: ${query}…\n`));
         searchWeb(query).then((result) => {
           if (result.error) {
@@ -1618,15 +1773,14 @@ function runInteractiveShell(flags = {}) {
             for (const r of result.results) {
               process.stdout.write(
                 ansi('bold', `  • ${r.title}\n`) +
-                ansi('gray', `    ${r.snippet.slice(0, 140)}\n    ${r.url}\n`)
+                  ansi('gray', `    ${r.snippet.slice(0, 140)}\n    ${r.url}\n`)
               );
             }
           }
           rl.prompt();
         });
         return; // prompt called in .then()
-      }
-      else {
+      } else {
         process.stdout.write(ansi('yellow', `  unknown meta command: :${meta} — try :help\n`));
       }
       rl.prompt();
@@ -1636,7 +1790,10 @@ function runInteractiveShell(flags = {}) {
     // ── PowerShell / shell passthrough  (!cmd or ps:cmd) ──────────────────
     if (kind === 'powershell') {
       const cmd = line.replace(_PS_PREFIX, '').trim();
-      if (!cmd) { rl.prompt(); return; }
+      if (!cmd) {
+        rl.prompt();
+        return;
+      }
       process.stdout.write(ansi('dim', `  $ ${cmd}\n`));
       const row = runShellCommand(cmd, { quiet: true, capture: scriptedInput });
       if (scriptedInput && row.stdout_preview?.trim()) {
@@ -1648,7 +1805,7 @@ function runInteractiveShell(flags = {}) {
       if (!row.success && row.failure) {
         process.stdout.write(
           ansi('red', `  ✗ ${row.failure.summary}\n`) +
-          ansi('gray', `  → ${row.failure.next_step}\n`)
+            ansi('gray', `  → ${row.failure.next_step}\n`)
         );
       }
       rl.prompt();
@@ -1658,7 +1815,8 @@ function runInteractiveShell(flags = {}) {
     // ── Known scbe command ────────────────────────────────────────────────
     if (kind === 'command') {
       const scbeCmd = /^(compile|compile-ca|ca-plan|render-op|route|aetherpp)\b/.test(line)
-        ? `${process.execPath} "${__filename}" ${line}` : line;
+        ? `${process.execPath} "${__filename}" ${line}`
+        : line;
       const row = runShellCommand(scbeCmd, { capture: scriptedInput });
       if (scriptedInput && row.stdout_preview?.trim()) {
         process.stdout.write(`${row.stdout_preview.trim()}\n`);
@@ -1669,7 +1827,7 @@ function runInteractiveShell(flags = {}) {
       if (!row.success && row.failure) {
         process.stdout.write(
           ansi('red', `  ✗ ${row.failure.summary}\n`) +
-          ansi('gray', `  → ${row.failure.next_step}\n`)
+            ansi('gray', `  → ${row.failure.next_step}\n`)
         );
       }
       rl.prompt();
@@ -1690,12 +1848,14 @@ function runInteractiveShell(flags = {}) {
 
         // Extract proposed command wrapped in <cmd>…</cmd>
         const cmdMatch = full.match(/<cmd>([\s\S]*?)<\/cmd>/);
-        if (!cmdMatch) { rl.resume(); rl.prompt(); return; }
+        if (!cmdMatch) {
+          rl.resume();
+          rl.prompt();
+          return;
+        }
 
         const proposed = cmdMatch[1].trim();
-        process.stdout.write(
-          '\n' + ansi('yellow', '  proposed: ') + ansi('bold', proposed) + '\n'
-        );
+        process.stdout.write('\n' + ansi('yellow', '  proposed: ') + ansi('bold', proposed) + '\n');
 
         // Run intent through GeoSeal compile
         const busBin = resolveAgentBusBin();
@@ -1713,14 +1873,22 @@ function runInteractiveShell(flags = {}) {
               planResult = {
                 plan: parsed,
                 blocked: parsed.policy && parsed.policy.decision !== 'ALLOW',
-                block_reason: parsed.policy ? `policy ${parsed.policy.decision}: ${parsed.policy.reason}` : undefined,
+                block_reason: parsed.policy
+                  ? `policy ${parsed.policy.decision}: ${parsed.policy.reason}`
+                  : undefined,
               };
             }
-          } catch { /* parse failed, stays blocked */ }
+          } catch {
+            /* parse failed, stays blocked */
+          }
 
           process.stdout.write(formatPlanSummary(planResult) + '\n');
 
-          if (planResult.blocked) { rl.resume(); rl.prompt(); return; }
+          if (planResult.blocked) {
+            rl.resume();
+            rl.prompt();
+            return;
+          }
         }
 
         // Ask for approval
@@ -1730,8 +1898,9 @@ function runInteractiveShell(flags = {}) {
       })
       .catch((err) => {
         process.stdout.write(
-          '\n' + ansi('red', `  LLM error: ${err.message}\n`) +
-          ansi('gray', `  Is ${cfg.provider} running? Try: :config set provider offline\n`)
+          '\n' +
+            ansi('red', `  LLM error: ${err.message}\n`) +
+            ansi('gray', `  Is ${cfg.provider} running? Try: :config set provider offline\n`)
         );
         rl.resume();
         rl.prompt();
@@ -3065,7 +3234,10 @@ function runUpgrade(args) {
 }
 
 function runSelftest() {
-  const checks = [['version', '--json'], ['doctor', '--json']];
+  const checks = [
+    ['version', '--json'],
+    ['doctor', '--json'],
+  ];
   const results = checks.map((args) => {
     const child = spawnSync(process.execPath, [__filename, ...args], {
       encoding: 'utf8',

--- a/packages/cli/scripts/shell_benchmark.cjs
+++ b/packages/cli/scripts/shell_benchmark.cjs
@@ -74,374 +74,534 @@ function caseResult(name, fn, points = 1) {
 function main() {
   const cases = [];
 
-  cases.push(caseResult('help_lists_all_shell_modes', () => {
-    const r = runNodeCli(['--help']);
-    assert.equal(r.status, 0);
-    for (const needle of ['scbe shell', 'scbe shell --ai', 'scbe shell --tui', 'scbe shell --minimal']) {
-      assert.match(r.stdout, new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    }
-    return { stdout_preview: r.stdout.slice(0, 240), duration_ms: r.duration_ms };
-  }));
+  cases.push(
+    caseResult('help_lists_all_shell_modes', () => {
+      const r = runNodeCli(['--help']);
+      assert.equal(r.status, 0);
+      for (const needle of [
+        'scbe shell',
+        'scbe shell --ai',
+        'scbe shell --tui',
+        'scbe shell --minimal',
+      ]) {
+        assert.match(r.stdout, new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      }
+      return { stdout_preview: r.stdout.slice(0, 240), duration_ms: r.duration_ms };
+    })
+  );
 
-  cases.push(caseResult('minimal_shell_scriptable_exit', () => {
-    const r = runNodeCli(['shell', '--minimal'], { input: ':exit\n' });
-    assert.equal(r.status, 0);
-    assert.match(r.stdout, /SCBE Terminal/);
-    assert.doesNotMatch(r.stdout, /SCBE governed shell/);
-    return { stdout_preview: r.stdout.slice(0, 240), duration_ms: r.duration_ms };
-  }));
+  cases.push(
+    caseResult('minimal_shell_scriptable_exit', () => {
+      const r = runNodeCli(['shell', '--minimal'], { input: ':exit\n' });
+      assert.equal(r.status, 0);
+      assert.match(r.stdout, /SCBE Terminal/);
+      assert.doesNotMatch(r.stdout, /SCBE governed shell/);
+      return { stdout_preview: r.stdout.slice(0, 240), duration_ms: r.duration_ms };
+    })
+  );
 
-  cases.push(caseResult('rich_shell_config_is_local_free_by_default', () => {
-    const r = runNodeCli(['shell'], { input: ':config\n:exit\n' });
-    assert.equal(r.status, 0);
-    assert.match(r.stdout, /SCBE governed shell/);
-    assert.match(r.stdout, /"provider": "ollama"/);
-    assert.match(r.stdout, /"model": "llama3\.2"/);
-    return { stdout_preview: r.stdout.slice(0, 360), duration_ms: r.duration_ms };
-  }));
+  cases.push(
+    caseResult('rich_shell_config_is_local_free_by_default', () => {
+      const r = runNodeCli(['shell'], { input: ':config\n:exit\n' });
+      assert.equal(r.status, 0);
+      assert.match(r.stdout, /SCBE governed shell/);
+      assert.match(r.stdout, /"provider": "ollama"/);
+      assert.match(r.stdout, /"model": "llama3\.2"/);
+      return { stdout_preview: r.stdout.slice(0, 360), duration_ms: r.duration_ms };
+    })
+  );
 
-  cases.push(caseResult('rich_shell_config_set_persists_to_isolated_home', () => {
-    const home = makeHome();
-    const r = runNodeCli(['shell'], {
-      home,
-      input: ':config set provider offline\n:config\n:exit\n',
-    });
-    assert.equal(r.status, 0);
-    const cfgPath = path.join(home, '.scbe', 'shell.json');
-    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
-    assert.equal(cfg.provider, 'offline');
-    assert.match(r.stdout, /config\.provider = offline/);
-    return { config_path_exists: fs.existsSync(cfgPath), duration_ms: r.duration_ms };
-  }));
+  cases.push(
+    caseResult('rich_shell_config_set_persists_to_isolated_home', () => {
+      const home = makeHome();
+      const r = runNodeCli(['shell'], {
+        home,
+        input: ':config set provider offline\n:config\n:exit\n',
+      });
+      assert.equal(r.status, 0);
+      const cfgPath = path.join(home, '.scbe', 'shell.json');
+      const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+      assert.equal(cfg.provider, 'offline');
+      assert.match(r.stdout, /config\.provider = offline/);
+      return { config_path_exists: fs.existsSync(cfgPath), duration_ms: r.duration_ms };
+    })
+  );
 
-  cases.push(caseResult('powershell_passthrough_executes_without_ai_layer', () => {
-    const r = runNodeCli(['shell'], {
-      input: '!echo SCBE_BENCH_OK\n:exit\n',
-      isolateHome: false,
-    });
-    assert.equal(r.status, 0);
-    assert.match(r.stdout, /SCBE_BENCH_OK/);
-    assert.doesNotMatch(r.stdout, /thinking/);
-    return { stdout_preview: r.stdout.slice(0, 420), duration_ms: r.duration_ms };
-  }));
+  cases.push(
+    caseResult('powershell_passthrough_executes_without_ai_layer', () => {
+      const r = runNodeCli(['shell'], {
+        input: '!echo SCBE_BENCH_OK\n:exit\n',
+        isolateHome: false,
+      });
+      assert.equal(r.status, 0);
+      assert.match(r.stdout, /SCBE_BENCH_OK/);
+      assert.doesNotMatch(r.stdout, /thinking/);
+      return { stdout_preview: r.stdout.slice(0, 420), duration_ms: r.duration_ms };
+    })
+  );
 
-  cases.push(caseResult('governance_blocks_destructive_command', () => {
-    const r = runNodeCli(['run', 'rm -rf C:/', '--json'], { isolateHome: false });
-    assert.notEqual(r.status, 0);
-    const payload = JSON.parse(r.stdout);
-    assert.equal(payload.governance.allowed, false);
-    assert.equal(payload.governance.tier, 'DENY');
-    assert.equal(payload.exit_code, 126);
-    return {
-      tier: payload.governance.tier,
-      finding: payload.governance.findings[0],
-      duration_ms: r.duration_ms,
-    };
-  }, 2));
+  cases.push(
+    caseResult(
+      'governance_blocks_destructive_command',
+      () => {
+        const r = runNodeCli(['run', 'rm -rf C:/', '--json'], { isolateHome: false });
+        assert.notEqual(r.status, 0);
+        const payload = JSON.parse(r.stdout);
+        assert.equal(payload.governance.allowed, false);
+        assert.equal(payload.governance.tier, 'DENY');
+        assert.equal(payload.exit_code, 126);
+        return {
+          tier: payload.governance.tier,
+          finding: payload.governance.findings[0],
+          duration_ms: r.duration_ms,
+        };
+      },
+      2
+    )
+  );
 
-  cases.push(caseResult('tui_module_imports_and_exports_launcher', () => {
-    const code = "import('./packages/cli/bin/tui.mjs').then(m=>{if(typeof m.launchTui!=='function')process.exit(2); console.log('ok')})";
-    const r = spawnSync(process.execPath, ['--input-type=module', '-e', code], {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-      timeout: 20_000,
-    });
-    assert.equal(r.status, 0, r.stderr || r.stdout);
-    assert.match(r.stdout, /ok/);
-    return { stdout_preview: r.stdout.trim(), duration_ms: r.duration_ms };
-  }));
+  cases.push(
+    caseResult('tui_module_imports_and_exports_launcher', () => {
+      const code =
+        "import('./packages/cli/bin/tui.mjs').then(m=>{if(typeof m.launchTui!=='function')process.exit(2); console.log('ok')})";
+      const r = spawnSync(process.execPath, ['--input-type=module', '-e', code], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        timeout: 20_000,
+      });
+      assert.equal(r.status, 0, r.stderr || r.stdout);
+      assert.match(r.stdout, /ok/);
+      return { stdout_preview: r.stdout.trim(), duration_ms: r.duration_ms };
+    })
+  );
 
-  cases.push(caseResult('npm_package_includes_tui_runtime_files', () => {
-    const r = spawnSync('npm', ['pack', '--dry-run', '--json'], {
-      cwd: path.resolve(__dirname, '..'),
-      encoding: 'utf8',
-      timeout: 30_000,
-      shell: process.platform === 'win32',
-    });
-    assert.equal(r.status, 0, r.stderr || r.stdout);
-    const payload = JSON.parse(r.stdout);
-    const files = new Set((payload[0] && payload[0].files || []).map((row) => row.path));
-    assert.ok(files.has('bin/scbe.js'));
-    assert.ok(files.has('bin/tui.mjs'));
-    assert.ok(!Array.from(files).some((file) => file.includes('__pycache__') || file.endsWith('.pyc')));
-    return { entry_count: payload[0].entryCount, files: Array.from(files).sort() };
-  }));
+  cases.push(
+    caseResult('npm_package_includes_tui_runtime_files', () => {
+      const r = spawnSync('npm', ['pack', '--dry-run', '--json'], {
+        cwd: path.resolve(__dirname, '..'),
+        encoding: 'utf8',
+        timeout: 30_000,
+        shell: process.platform === 'win32',
+      });
+      assert.equal(r.status, 0, r.stderr || r.stdout);
+      const payload = JSON.parse(r.stdout);
+      const files = new Set(((payload[0] && payload[0].files) || []).map((row) => row.path));
+      assert.ok(files.has('bin/scbe.js'));
+      assert.ok(files.has('bin/tui.mjs'));
+      assert.ok(
+        !Array.from(files).some((file) => file.includes('__pycache__') || file.endsWith('.pyc'))
+      );
+      return { entry_count: payload[0].entryCount, files: Array.from(files).sort() };
+    })
+  );
 
-  cases.push(caseResult('agent_json_protocol_ready_signal_and_round_trip', () => {
-    // Spawn --agent-json, verify ready signal, send one instruction, read response
-    const { spawnSync: spawn } = require('node:child_process');
-    const inputLines = [
-      JSON.stringify({ instruction: 'list files in current directory', terminal_state: '$ ' }),
-      '',
-    ].join('\n');
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: inputLines,
-      encoding: 'utf8',
-      timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_PROVIDER: 'offline' },
-    });
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 1, `expected at least 1 output line, got: ${r.stdout}`);
-    const ready = JSON.parse(lines[0]);
-    assert.equal(ready.ready, true, 'first line must be {"ready":true}');
-    if (lines.length >= 2) {
+  cases.push(
+    caseResult('agent_json_protocol_ready_signal_and_round_trip', () => {
+      // Spawn --agent-json, verify ready signal, send one instruction, read response
+      const { spawnSync: spawn } = require('node:child_process');
+      const inputLines = [
+        JSON.stringify({ instruction: 'list files in current directory', terminal_state: '$ ' }),
+        '',
+      ].join('\n');
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: inputLines,
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_PROVIDER: 'offline' },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 1, `expected at least 1 output line, got: ${r.stdout}`);
+      const ready = JSON.parse(lines[0]);
+      assert.equal(ready.ready, true, 'first line must be {"ready":true}');
+      if (lines.length >= 2) {
+        const resp = JSON.parse(lines[1]);
+        assert.ok(Array.isArray(resp.commands), 'response must have commands array');
+        assert.ok(typeof resp.done === 'boolean', 'response must have done boolean');
+      }
+      return {
+        ready: ready.ready,
+        lines_received: lines.length,
+        first_response: lines[1] ? JSON.parse(lines[1]) : null,
+      };
+    })
+  );
+
+  cases.push(
+    caseResult('agent_json_cmd_extraction_governance_and_done_signal', () => {
+      // Use SCBE_MOCK_RESPONSE to inject a known LLM reply containing <cmd> and done signal.
+      // This exercises: regex extraction, governance spawn, done detection — all previously offline-only.
+      const { spawnSync: spawn } = require('node:child_process');
+      const mockResponse = 'I will list the files. <cmd>ls -la</cmd> task is complete';
+      const inputLines = [
+        JSON.stringify({ instruction: 'list files', terminal_state: '$ ' }),
+        '',
+      ].join('\n');
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: inputLines,
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResponse },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response lines, got: ${r.stdout}`);
+      const ready = JSON.parse(lines[0]);
+      assert.equal(ready.ready, true, 'first line must be {"ready":true}');
       const resp = JSON.parse(lines[1]);
       assert.ok(Array.isArray(resp.commands), 'response must have commands array');
       assert.ok(typeof resp.done === 'boolean', 'response must have done boolean');
-    }
-    return { ready: ready.ready, lines_received: lines.length, first_response: lines[1] ? JSON.parse(lines[1]) : null };
-  }));
+      // If governance is available, commands should be populated; if not, may be empty due to offline governance
+      // What matters: cmd extraction ran (rationale or commands present), done=true was detected
+      assert.equal(resp.done, true, 'done signal must be detected from mock response');
+      assert.ok(
+        (resp.commands.length > 0 && resp.commands[0].keystrokes === 'ls -la') ||
+          resp.blocked === true,
+        `expected keystrokes='ls -la' or governance block, got: ${JSON.stringify(resp)}`
+      );
+      return {
+        commands: resp.commands,
+        done: resp.done,
+        governance: resp.governance || null,
+        rationale_preview: (resp.rationale || '').slice(0, 120),
+      };
+    })
+  );
 
-  cases.push(caseResult('agent_json_cmd_extraction_governance_and_done_signal', () => {
-    // Use SCBE_MOCK_RESPONSE to inject a known LLM reply containing <cmd> and done signal.
-    // This exercises: regex extraction, governance spawn, done detection — all previously offline-only.
-    const { spawnSync: spawn } = require('node:child_process');
-    const mockResponse = 'I will list the files. <cmd>ls -la</cmd> task is complete';
-    const inputLines = [
-      JSON.stringify({ instruction: 'list files', terminal_state: '$ ' }),
-      '',
-    ].join('\n');
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: inputLines,
-      encoding: 'utf8',
-      timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResponse },
-    });
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 2, `expected ready + response lines, got: ${r.stdout}`);
-    const ready = JSON.parse(lines[0]);
-    assert.equal(ready.ready, true, 'first line must be {"ready":true}');
-    const resp = JSON.parse(lines[1]);
-    assert.ok(Array.isArray(resp.commands), 'response must have commands array');
-    assert.ok(typeof resp.done === 'boolean', 'response must have done boolean');
-    // If governance is available, commands should be populated; if not, may be empty due to offline governance
-    // What matters: cmd extraction ran (rationale or commands present), done=true was detected
-    assert.equal(resp.done, true, 'done signal must be detected from mock response');
-    assert.ok(
-      (resp.commands.length > 0 && resp.commands[0].keystrokes === 'ls -la') || resp.blocked === true,
-      `expected keystrokes='ls -la' or governance block, got: ${JSON.stringify(resp)}`
-    );
-    return {
-      commands: resp.commands,
-      done: resp.done,
-      governance: resp.governance || null,
-      rationale_preview: (resp.rationale || '').slice(0, 120),
-    };
-  }));
-
-  cases.push(caseResult('agent_json_waits_for_async_response_after_stdin_close', () => {
-    // Regression: piped harness input closes stdin immediately. The process must
-    // still wait for the async model/governance turn before exiting.
-    const { spawnSync: spawn } = require('node:child_process');
-    const mockResponse = '<cmd>git status --short --branch</cmd> task complete';
-    const inputLines = [
-      JSON.stringify({ instruction: 'inspect repo state', terminal_state: '$ ' }),
-      '',
-    ].join('\n');
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: inputLines,
-      encoding: 'utf8',
-      timeout: 20_000,
-      env: {
-        ...process.env,
-        NO_COLOR: '1',
-        SCBE_MOCK_RESPONSE: mockResponse,
-        SCBE_MOCK_RESPONSE_DELAY_MS: '250',
-      },
-    });
-    assert.equal(r.status, 0, r.stderr || r.stdout);
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 2, `expected ready + delayed response, got: ${r.stdout}`);
-    const ready = JSON.parse(lines[0]);
-    const resp = JSON.parse(lines[1]);
-    assert.equal(ready.ready, true);
-    assert.equal(resp.done, true);
-    assert.equal(resp.commands[0].keystrokes, 'git status --short --branch');
-    return { lines_received: lines.length, command: resp.commands[0].keystrokes };
-  }));
+  cases.push(
+    caseResult('agent_json_waits_for_async_response_after_stdin_close', () => {
+      // Regression: piped harness input closes stdin immediately. The process must
+      // still wait for the async model/governance turn before exiting.
+      const { spawnSync: spawn } = require('node:child_process');
+      const mockResponse = '<cmd>git status --short --branch</cmd> task complete';
+      const inputLines = [
+        JSON.stringify({ instruction: 'inspect repo state', terminal_state: '$ ' }),
+        '',
+      ].join('\n');
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: inputLines,
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: {
+          ...process.env,
+          NO_COLOR: '1',
+          SCBE_MOCK_RESPONSE: mockResponse,
+          SCBE_MOCK_RESPONSE_DELAY_MS: '250',
+        },
+      });
+      assert.equal(r.status, 0, r.stderr || r.stdout);
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + delayed response, got: ${r.stdout}`);
+      const ready = JSON.parse(lines[0]);
+      const resp = JSON.parse(lines[1]);
+      assert.equal(ready.ready, true);
+      assert.equal(resp.done, true);
+      assert.equal(resp.commands[0].keystrokes, 'git status --short --branch');
+      return { lines_received: lines.length, command: resp.commands[0].keystrokes };
+    })
+  );
 
   // ── Tool translation cases ────────────────────────────────────────────────
 
-  cases.push(caseResult('agent_json_files_tool_translates_to_find', () => {
-    const { spawnSync: spawn } = require('node:child_process');
-    const mock = 'Let me search. <cmd>:files auth.py</cmd>';
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: JSON.stringify({ instruction: 'find the auth module', terminal_state: '$ ' }) + '\n\n',
-      encoding: 'utf8', timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
-    });
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
-    const resp = JSON.parse(lines[1]);
-    assert.ok(resp.commands.length > 0 || resp.blocked, 'expected command or governance block');
-    if (resp.commands.length > 0) {
-      const ks = resp.commands[0].keystrokes;
-      assert.ok(ks.includes('find') || ks.includes('grep'), `expected find/grep translation, got: ${ks}`);
-      assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
-    }
-    return { translated: resp.commands[0]?.keystrokes || resp.rationale };
-  }));
+  cases.push(
+    caseResult('agent_json_files_tool_translates_to_find', () => {
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Let me search. <cmd>:files auth.py</cmd>';
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input:
+          JSON.stringify({ instruction: 'find the auth module', terminal_state: '$ ' }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+      const resp = JSON.parse(lines[1]);
+      assert.ok(resp.commands.length > 0 || resp.blocked, 'expected command or governance block');
+      if (resp.commands.length > 0) {
+        const ks = resp.commands[0].keystrokes;
+        assert.ok(
+          ks.includes('find') || ks.includes('grep'),
+          `expected find/grep translation, got: ${ks}`
+        );
+        assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
+      }
+      return { translated: resp.commands[0]?.keystrokes || resp.rationale };
+    })
+  );
 
-  cases.push(caseResult('agent_json_read_tool_translates_to_sed', () => {
-    const { spawnSync: spawn } = require('node:child_process');
-    const mock = 'Reading file. <cmd>:read src/index.ts 1:20</cmd>';
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: JSON.stringify({ instruction: 'read the index file', terminal_state: '$ ' }) + '\n\n',
-      encoding: 'utf8', timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
-    });
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
-    const resp = JSON.parse(lines[1]);
-    if (resp.commands.length > 0) {
-      const ks = resp.commands[0].keystrokes;
-      assert.ok(ks.includes('sed'), `expected sed translation, got: ${ks}`);
-      assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
-    }
-    return { translated: resp.commands[0]?.keystrokes || resp.rationale };
-  }));
+  cases.push(
+    caseResult('agent_json_read_tool_translates_to_sed', () => {
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Reading file. <cmd>:read src/index.ts 1:20</cmd>';
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input:
+          JSON.stringify({ instruction: 'read the index file', terminal_state: '$ ' }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+      const resp = JSON.parse(lines[1]);
+      if (resp.commands.length > 0) {
+        const ks = resp.commands[0].keystrokes;
+        assert.ok(ks.includes('sed'), `expected sed translation, got: ${ks}`);
+        assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
+      }
+      return { translated: resp.commands[0]?.keystrokes || resp.rationale };
+    })
+  );
 
-  cases.push(caseResult('agent_json_test_tool_wraps_with_pass_fail_echo', () => {
-    const { spawnSync: spawn } = require('node:child_process');
-    const mock = 'Running tests. <cmd>:test npm test</cmd>';
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: JSON.stringify({ instruction: 'run the tests', terminal_state: '$ ' }) + '\n\n',
-      encoding: 'utf8', timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
-    });
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
-    const resp = JSON.parse(lines[1]);
-    if (resp.commands.length > 0) {
-      const ks = resp.commands[0].keystrokes;
-      assert.ok(ks.includes('SCBE_TEST_PASS'), `expected SCBE_TEST_PASS echo, got: ${ks}`);
-      assert.ok(ks.includes('npm test'), `expected npm test in command, got: ${ks}`);
-    }
-    return { translated: resp.commands[0]?.keystrokes || resp.rationale };
-  }));
+  cases.push(
+    caseResult('agent_json_test_tool_wraps_with_pass_fail_echo', () => {
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Running tests. <cmd>:test npm test</cmd>';
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: JSON.stringify({ instruction: 'run the tests', terminal_state: '$ ' }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+      const resp = JSON.parse(lines[1]);
+      if (resp.commands.length > 0) {
+        const ks = resp.commands[0].keystrokes;
+        assert.ok(ks.includes('SCBE_TEST_PASS'), `expected SCBE_TEST_PASS echo, got: ${ks}`);
+        assert.ok(ks.includes('npm test'), `expected npm test in command, got: ${ks}`);
+      }
+      return { translated: resp.commands[0]?.keystrokes || resp.rationale };
+    })
+  );
 
-  cases.push(caseResult('agent_json_ko_ban_blocks_repeated_cmd_obs_pair', () => {
-    // Send 3 turns: same command, same observation each turn.
-    // On the 3rd turn the board should ko-ban the move and block it.
-    const { spawnSync: spawn } = require('node:child_process');
-    const mock = '<cmd>ls -la</cmd>';
-    const errorState = '$ ls -la\nls: cannot access: No such file or directory';
-    const inputLines = [
-      JSON.stringify({ instruction: 'list files', terminal_state: '$ ' }),
-      JSON.stringify({ terminal_state: errorState }),
-      JSON.stringify({ terminal_state: errorState }),
-      '',
-    ].join('\n');
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: inputLines,
-      encoding: 'utf8', timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
-    });
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    const responses = lines.slice(1).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
-    assert.ok(responses.length >= 1, `expected at least one response, got: ${r.stdout}`);
-    const last = responses[responses.length - 1];
-    if (responses.length >= 3) {
-      assert.equal(last.blocked, true, `expected blocked=true on 3rd turn, got: ${JSON.stringify(last)}`);
-      assert.equal(last.governance?.reason, 'ko-ban', `expected governance.reason='ko-ban', got: ${last.governance?.reason}`);
-      assert.ok(last.board, `response must include board state`);
-      assert.ok(last.board.ko_bans.length > 0, `board must have at least one ko-ban entry`);
-    }
-    return { response_count: responses.length, last };
-  }));
+  cases.push(
+    caseResult('agent_json_ko_ban_blocks_repeated_cmd_obs_pair', () => {
+      // Send 3 turns: same command, same observation each turn.
+      // On the 3rd turn the board should ko-ban the move and block it.
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = '<cmd>ls -la</cmd>';
+      const errorState = '$ ls -la\nls: cannot access: No such file or directory';
+      const inputLines = [
+        JSON.stringify({ instruction: 'list files', terminal_state: '$ ' }),
+        JSON.stringify({ terminal_state: errorState }),
+        JSON.stringify({ terminal_state: errorState }),
+        '',
+      ].join('\n');
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: inputLines,
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      const responses = lines
+        .slice(1)
+        .map((l) => {
+          try {
+            return JSON.parse(l);
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean);
+      assert.ok(responses.length >= 1, `expected at least one response, got: ${r.stdout}`);
+      const last = responses[responses.length - 1];
+      if (responses.length >= 3) {
+        assert.equal(
+          last.blocked,
+          true,
+          `expected blocked=true on 3rd turn, got: ${JSON.stringify(last)}`
+        );
+        assert.equal(
+          last.governance?.reason,
+          'ko-ban',
+          `expected governance.reason='ko-ban', got: ${last.governance?.reason}`
+        );
+        assert.ok(last.board, `response must include board state`);
+        assert.ok(last.board.ko_bans.length > 0, `board must have at least one ko-ban entry`);
+      }
+      return { response_count: responses.length, last };
+    })
+  );
 
-  cases.push(caseResult('agent_json_board_returned_every_turn', () => {
-    // Every non-error response must include a board object with the expected shape.
-    const { spawnSync: spawn } = require('node:child_process');
-    const mock = 'Listing files now. <cmd>ls</cmd>';
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: JSON.stringify({ instruction: 'list files', terminal_state: '$ ' }) + '\n\n',
-      encoding: 'utf8', timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
-    });
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 2, `expected ready + response`);
-    const resp = JSON.parse(lines[1]);
-    assert.ok(resp.board, `response must include board`);
-    assert.ok(typeof resp.board.turn === 'number', `board.turn must be a number`);
-    assert.ok(Array.isArray(resp.board.attempts), `board.attempts must be an array`);
-    assert.ok(Array.isArray(resp.board.ko_bans), `board.ko_bans must be an array`);
-    assert.ok(Array.isArray(resp.board.legal_moves), `board.legal_moves must be an array`);
-    assert.strictEqual(resp.board.done, false, `board.done must be false initially`);
-    assert.strictEqual(resp.board.path_policy, 'non_optimal_correct', `board.path_policy must be 'non_optimal_correct'`);
-    return { board: resp.board };
-  }));
+  cases.push(
+    caseResult('agent_json_board_returned_every_turn', () => {
+      // Every non-error response must include a board object with the expected shape.
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Listing files now. <cmd>ls</cmd>';
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: JSON.stringify({ instruction: 'list files', terminal_state: '$ ' }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response`);
+      const resp = JSON.parse(lines[1]);
+      assert.ok(resp.board, `response must include board`);
+      assert.ok(typeof resp.board.turn === 'number', `board.turn must be a number`);
+      assert.ok(Array.isArray(resp.board.attempts), `board.attempts must be an array`);
+      assert.ok(Array.isArray(resp.board.ko_bans), `board.ko_bans must be an array`);
+      assert.ok(Array.isArray(resp.board.legal_moves), `board.legal_moves must be an array`);
+      assert.strictEqual(resp.board.done, false, `board.done must be false initially`);
+      assert.strictEqual(
+        resp.board.path_policy,
+        'non_optimal_correct',
+        `board.path_policy must be 'non_optimal_correct'`
+      );
+      return { board: resp.board };
+    })
+  );
 
-  cases.push(caseResult('agent_json_rationale_strips_cmd_content', () => {
-    // Groq-format response (<cmd>...<cmd> — no </cmd>). Rationale must not include the cmd text.
-    const { spawnSync: spawn } = require('node:child_process');
-    const cmdText = 'echo scbe_rationale_strip_sentinel';
-    const mockResponse = `I will run the command.\n<cmd>${cmdText}<cmd>\n\nLet me check the result.`;
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: JSON.stringify({ instruction: 'run a test echo', terminal_state: '$ ' }) + '\n\n',
-      encoding: 'utf8', timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResponse },
-    });
-    assert.ok((r.stdout || '').length > 0, `no stdout from agent-json`);
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
-    const resp = JSON.parse(lines[1]);
-    assert.ok(resp.rationale != null, `response must have rationale`);
-    assert.ok(
-      !resp.rationale.includes(cmdText),
-      `rationale must not contain cmd text "${cmdText}", got: "${resp.rationale.slice(0, 200)}"`
-    );
-    return { rationale_preview: resp.rationale.slice(0, 120) };
-  }));
+  cases.push(
+    caseResult('agent_json_rationale_strips_cmd_content', () => {
+      // Groq-format response (<cmd>...<cmd> — no </cmd>). Rationale must not include the cmd text.
+      const { spawnSync: spawn } = require('node:child_process');
+      const cmdText = 'echo scbe_rationale_strip_sentinel';
+      const mockResponse = `I will run the command.\n<cmd>${cmdText}<cmd>\n\nLet me check the result.`;
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: JSON.stringify({ instruction: 'run a test echo', terminal_state: '$ ' }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResponse },
+      });
+      assert.ok((r.stdout || '').length > 0, `no stdout from agent-json`);
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+      const resp = JSON.parse(lines[1]);
+      assert.ok(resp.rationale != null, `response must have rationale`);
+      assert.ok(
+        !resp.rationale.includes(cmdText),
+        `rationale must not contain cmd text "${cmdText}", got: "${resp.rationale.slice(0, 200)}"`
+      );
+      return { rationale_preview: resp.rationale.slice(0, 120) };
+    })
+  );
 
-  cases.push(caseResult('agent_json_no_cmd_response_includes_governance', () => {
-    // No-cmd path (model explains without a command) must include a governance field for consistency.
-    const { spawnSync: spawn } = require('node:child_process');
-    const mockResponse = 'The task requires more information before I can proceed. Please clarify.';
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: JSON.stringify({ instruction: 'do something unclear', terminal_state: '$ ' }) + '\n\n',
-      encoding: 'utf8', timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResponse },
-    });
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 2, `expected ready + response`);
-    const resp = JSON.parse(lines[1]);
-    assert.ok(resp.governance, `no-cmd response must include governance field`);
-    assert.ok(resp.governance.decision, `governance must have decision`);
-    assert.strictEqual(resp.commands.length, 0, `no-cmd response must have empty commands`);
-    return { governance: resp.governance };
-  }));
+  cases.push(
+    caseResult('agent_json_no_cmd_response_includes_governance', () => {
+      // No-cmd path (model explains without a command) must include a governance field for consistency.
+      const { spawnSync: spawn } = require('node:child_process');
+      const mockResponse =
+        'The task requires more information before I can proceed. Please clarify.';
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input:
+          JSON.stringify({ instruction: 'do something unclear', terminal_state: '$ ' }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResponse },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response`);
+      const resp = JSON.parse(lines[1]);
+      assert.ok(resp.governance, `no-cmd response must include governance field`);
+      assert.ok(resp.governance.decision, `governance must have decision`);
+      assert.strictEqual(resp.commands.length, 0, `no-cmd response must have empty commands`);
+      return { governance: resp.governance };
+    })
+  );
 
-  cases.push(caseResult('agent_json_patch_tool_translates_to_patch_command', () => {
-    const { spawnSync: spawn } = require('node:child_process');
-    const mock = 'Applying patch. <cmd>:patch /tmp/fix.patch</cmd>';
-    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
-      cwd: REPO_ROOT,
-      input: JSON.stringify({ instruction: 'apply the patch file', terminal_state: '$ ' }) + '\n\n',
-      encoding: 'utf8', timeout: 20_000,
-      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
-    });
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
-    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
-    const resp = JSON.parse(lines[1]);
-    if (resp.commands.length > 0) {
-      const ks = resp.commands[0].keystrokes;
-      assert.ok(ks.includes('patch -p1'), `expected patch -p1 in keystrokes, got: ${ks}`);
-      assert.ok(ks.includes('fix.patch'), `expected fix.patch in keystrokes, got: ${ks}`);
-      assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
-    }
-    return { translated: resp.commands[0]?.keystrokes || resp.rationale };
-  }));
+  cases.push(
+    caseResult('agent_json_patch_tool_translates_to_patch_command', () => {
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Applying patch. <cmd>:patch /tmp/fix.patch</cmd>';
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input:
+          JSON.stringify({ instruction: 'apply the patch file', terminal_state: '$ ' }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+      const resp = JSON.parse(lines[1]);
+      if (resp.commands.length > 0) {
+        const ks = resp.commands[0].keystrokes;
+        assert.ok(ks.includes('patch -p1'), `expected patch -p1 in keystrokes, got: ${ks}`);
+        assert.ok(ks.includes('fix.patch'), `expected fix.patch in keystrokes, got: ${ks}`);
+        assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
+      }
+      return { translated: resp.commands[0]?.keystrokes || resp.rationale };
+    })
+  );
+
+  cases.push(
+    caseResult('agent_json_command_includes_bijective_move_packet', () => {
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Check repo state. <cmd>git status --short --branch</cmd>';
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: JSON.stringify({ instruction: 'check repo state', terminal_state: '$ ' }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+      const resp = JSON.parse(lines[1]);
+      assert.ok(resp.commands.length > 0 || resp.blocked, 'expected command or governance block');
+      assert.ok(resp.move_packet, 'response must include move_packet');
+      assert.equal(resp.move_packet.schema_version, 'scbe_agent_move_packet_v1');
+      assert.equal(resp.move_packet.round_trip_ok, true);
+      assert.equal(resp.move_packet.bijective_proof.ok, true);
+      assert.ok(
+        resp.move_packet.atomic_units?.[0]?.hex?.length > 0,
+        'expected byte/hex atomic unit'
+      );
+      assert.match(resp.move_packet.boundaries.not_claimed, /not a source-to-source compiler/);
+      return {
+        move_id: resp.move_packet.move_id,
+        tokens: resp.move_packet.tokens.slice(0, 3),
+        round_trip_ok: resp.move_packet.round_trip_ok,
+      };
+    })
+  );
 
   const total = cases.reduce((sum, row) => sum + row.points, 0);
   const earned = cases.reduce((sum, row) => sum + row.earned, 0);
@@ -449,8 +609,14 @@ function main() {
     schema: 'scbe_shell_agentic_benchmark_v1',
     generated_at: new Date().toISOString(),
     cli: CLI,
-    branch: spawnSync('git', ['branch', '--show-current'], { cwd: REPO_ROOT, encoding: 'utf8' }).stdout.trim(),
-    commit: spawnSync('git', ['rev-parse', '--short', 'HEAD'], { cwd: REPO_ROOT, encoding: 'utf8' }).stdout.trim(),
+    branch: spawnSync('git', ['branch', '--show-current'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    }).stdout.trim(),
+    commit: spawnSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    }).stdout.trim(),
     score: {
       earned,
       total,

--- a/packages/cli/scripts/shell_benchmark.cjs
+++ b/packages/cli/scripts/shell_benchmark.cjs
@@ -263,6 +263,186 @@ function main() {
     return { lines_received: lines.length, command: resp.commands[0].keystrokes };
   }));
 
+  // ── Tool translation cases ────────────────────────────────────────────────
+
+  cases.push(caseResult('agent_json_files_tool_translates_to_find', () => {
+    const { spawnSync: spawn } = require('node:child_process');
+    const mock = 'Let me search. <cmd>:files auth.py</cmd>';
+    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: JSON.stringify({ instruction: 'find the auth module', terminal_state: '$ ' }) + '\n\n',
+      encoding: 'utf8', timeout: 20_000,
+      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+    });
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+    const resp = JSON.parse(lines[1]);
+    assert.ok(resp.commands.length > 0 || resp.blocked, 'expected command or governance block');
+    if (resp.commands.length > 0) {
+      const ks = resp.commands[0].keystrokes;
+      assert.ok(ks.includes('find') || ks.includes('grep'), `expected find/grep translation, got: ${ks}`);
+      assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
+    }
+    return { translated: resp.commands[0]?.keystrokes || resp.rationale };
+  }));
+
+  cases.push(caseResult('agent_json_read_tool_translates_to_sed', () => {
+    const { spawnSync: spawn } = require('node:child_process');
+    const mock = 'Reading file. <cmd>:read src/index.ts 1:20</cmd>';
+    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: JSON.stringify({ instruction: 'read the index file', terminal_state: '$ ' }) + '\n\n',
+      encoding: 'utf8', timeout: 20_000,
+      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+    });
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+    const resp = JSON.parse(lines[1]);
+    if (resp.commands.length > 0) {
+      const ks = resp.commands[0].keystrokes;
+      assert.ok(ks.includes('sed'), `expected sed translation, got: ${ks}`);
+      assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
+    }
+    return { translated: resp.commands[0]?.keystrokes || resp.rationale };
+  }));
+
+  cases.push(caseResult('agent_json_test_tool_wraps_with_pass_fail_echo', () => {
+    const { spawnSync: spawn } = require('node:child_process');
+    const mock = 'Running tests. <cmd>:test npm test</cmd>';
+    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: JSON.stringify({ instruction: 'run the tests', terminal_state: '$ ' }) + '\n\n',
+      encoding: 'utf8', timeout: 20_000,
+      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+    });
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+    const resp = JSON.parse(lines[1]);
+    if (resp.commands.length > 0) {
+      const ks = resp.commands[0].keystrokes;
+      assert.ok(ks.includes('SCBE_TEST_PASS'), `expected SCBE_TEST_PASS echo, got: ${ks}`);
+      assert.ok(ks.includes('npm test'), `expected npm test in command, got: ${ks}`);
+    }
+    return { translated: resp.commands[0]?.keystrokes || resp.rationale };
+  }));
+
+  cases.push(caseResult('agent_json_ko_ban_blocks_repeated_cmd_obs_pair', () => {
+    // Send 3 turns: same command, same observation each turn.
+    // On the 3rd turn the board should ko-ban the move and block it.
+    const { spawnSync: spawn } = require('node:child_process');
+    const mock = '<cmd>ls -la</cmd>';
+    const errorState = '$ ls -la\nls: cannot access: No such file or directory';
+    const inputLines = [
+      JSON.stringify({ instruction: 'list files', terminal_state: '$ ' }),
+      JSON.stringify({ terminal_state: errorState }),
+      JSON.stringify({ terminal_state: errorState }),
+      '',
+    ].join('\n');
+    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: inputLines,
+      encoding: 'utf8', timeout: 20_000,
+      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+    });
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    const responses = lines.slice(1).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+    assert.ok(responses.length >= 1, `expected at least one response, got: ${r.stdout}`);
+    const last = responses[responses.length - 1];
+    if (responses.length >= 3) {
+      assert.equal(last.blocked, true, `expected blocked=true on 3rd turn, got: ${JSON.stringify(last)}`);
+      assert.equal(last.governance?.reason, 'ko-ban', `expected governance.reason='ko-ban', got: ${last.governance?.reason}`);
+      assert.ok(last.board, `response must include board state`);
+      assert.ok(last.board.ko_bans.length > 0, `board must have at least one ko-ban entry`);
+    }
+    return { response_count: responses.length, last };
+  }));
+
+  cases.push(caseResult('agent_json_board_returned_every_turn', () => {
+    // Every non-error response must include a board object with the expected shape.
+    const { spawnSync: spawn } = require('node:child_process');
+    const mock = 'Listing files now. <cmd>ls</cmd>';
+    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: JSON.stringify({ instruction: 'list files', terminal_state: '$ ' }) + '\n\n',
+      encoding: 'utf8', timeout: 20_000,
+      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+    });
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    assert.ok(lines.length >= 2, `expected ready + response`);
+    const resp = JSON.parse(lines[1]);
+    assert.ok(resp.board, `response must include board`);
+    assert.ok(typeof resp.board.turn === 'number', `board.turn must be a number`);
+    assert.ok(Array.isArray(resp.board.attempts), `board.attempts must be an array`);
+    assert.ok(Array.isArray(resp.board.ko_bans), `board.ko_bans must be an array`);
+    assert.ok(Array.isArray(resp.board.legal_moves), `board.legal_moves must be an array`);
+    assert.strictEqual(resp.board.done, false, `board.done must be false initially`);
+    assert.strictEqual(resp.board.path_policy, 'non_optimal_correct', `board.path_policy must be 'non_optimal_correct'`);
+    return { board: resp.board };
+  }));
+
+  cases.push(caseResult('agent_json_rationale_strips_cmd_content', () => {
+    // Groq-format response (<cmd>...<cmd> — no </cmd>). Rationale must not include the cmd text.
+    const { spawnSync: spawn } = require('node:child_process');
+    const cmdText = 'echo scbe_rationale_strip_sentinel';
+    const mockResponse = `I will run the command.\n<cmd>${cmdText}<cmd>\n\nLet me check the result.`;
+    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: JSON.stringify({ instruction: 'run a test echo', terminal_state: '$ ' }) + '\n\n',
+      encoding: 'utf8', timeout: 20_000,
+      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResponse },
+    });
+    assert.ok((r.stdout || '').length > 0, `no stdout from agent-json`);
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+    const resp = JSON.parse(lines[1]);
+    assert.ok(resp.rationale != null, `response must have rationale`);
+    assert.ok(
+      !resp.rationale.includes(cmdText),
+      `rationale must not contain cmd text "${cmdText}", got: "${resp.rationale.slice(0, 200)}"`
+    );
+    return { rationale_preview: resp.rationale.slice(0, 120) };
+  }));
+
+  cases.push(caseResult('agent_json_no_cmd_response_includes_governance', () => {
+    // No-cmd path (model explains without a command) must include a governance field for consistency.
+    const { spawnSync: spawn } = require('node:child_process');
+    const mockResponse = 'The task requires more information before I can proceed. Please clarify.';
+    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: JSON.stringify({ instruction: 'do something unclear', terminal_state: '$ ' }) + '\n\n',
+      encoding: 'utf8', timeout: 20_000,
+      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResponse },
+    });
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    assert.ok(lines.length >= 2, `expected ready + response`);
+    const resp = JSON.parse(lines[1]);
+    assert.ok(resp.governance, `no-cmd response must include governance field`);
+    assert.ok(resp.governance.decision, `governance must have decision`);
+    assert.strictEqual(resp.commands.length, 0, `no-cmd response must have empty commands`);
+    return { governance: resp.governance };
+  }));
+
+  cases.push(caseResult('agent_json_patch_tool_translates_to_patch_command', () => {
+    const { spawnSync: spawn } = require('node:child_process');
+    const mock = 'Applying patch. <cmd>:patch /tmp/fix.patch</cmd>';
+    const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: JSON.stringify({ instruction: 'apply the patch file', terminal_state: '$ ' }) + '\n\n',
+      encoding: 'utf8', timeout: 20_000,
+      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+    });
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+    const resp = JSON.parse(lines[1]);
+    if (resp.commands.length > 0) {
+      const ks = resp.commands[0].keystrokes;
+      assert.ok(ks.includes('patch -p1'), `expected patch -p1 in keystrokes, got: ${ks}`);
+      assert.ok(ks.includes('fix.patch'), `expected fix.patch in keystrokes, got: ${ks}`);
+      assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
+    }
+    return { translated: resp.commands[0]?.keystrokes || resp.rationale };
+  }));
+
   const total = cases.reduce((sum, row) => sum + row.points, 0);
   const earned = cases.reduce((sum, row) => sum + row.earned, 0);
   const report = {

--- a/packages/cli/scripts/smoke_agent_json_e2e.cjs
+++ b/packages/cli/scripts/smoke_agent_json_e2e.cjs
@@ -1,0 +1,261 @@
+/**
+ * End-to-end smoke for scbe shell --agent-json.
+ *
+ * Drives the NDJSON loop locally: executes each returned command in a real
+ * shell, feeds the output back as terminal_state, and validates that done=true
+ * is only accepted after the objective verifier passes.
+ *
+ * Usage:
+ *   node scripts/smoke_agent_json_e2e.cjs            # mock turns, Git Bash execution
+ *   SCBE_LIVE=1 node scripts/smoke_agent_json_e2e.cjs # real LLM (needs shell.json config)
+ */
+
+'use strict';
+
+const { spawnSync, spawn } = require('node:child_process');
+const path = require('node:path');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const CLI = path.resolve(__dirname, '../bin/scbe.js');
+
+// Bash binary for executing commands
+const BASH =
+  process.platform === 'win32'
+    ? (spawnSync('where', ['bash'], { encoding: 'utf8' }).stdout.split('\n').find((l) => l.trim()) || 'bash').trim()
+    : '/bin/bash';
+
+// Use /tmp — Git Bash maps this to a writable temp dir on Windows
+const SMOKE_FILE = '/tmp/scbe_smoke_e2e.txt';
+const SMOKE_CONTENT = 'hello_scbe';
+const INSTRUCTION = `Create the file ${SMOKE_FILE} containing exactly the text: ${SMOKE_CONTENT}`;
+const DONE_IF = `test -f '${SMOKE_FILE}' && grep -qF '${SMOKE_CONTENT}' '${SMOKE_FILE}'`;
+
+// Multi-turn mock responses. Turn 0 uses the regex-stress response (model emits <cmd> instead of </cmd>).
+// Turn 1 creates the file. Turn 2 verifies and signals done.
+const MOCK_TURNS = [
+  // Turn 0: malformed closing tag (the exact failure seen in the live Groq smoke)
+  `I'll create the file now.\n<cmd>echo "${SMOKE_CONTENT}" > ${SMOKE_FILE}<cmd>\n\nLet me verify that worked.`,
+  // Turn 1: verifies the file and signals done
+  `The file exists and has the right content. <cmd>cat ${SMOKE_FILE}</cmd>\n<done>`,
+];
+
+function runBash(cmd) {
+  const r = spawnSync(BASH, ['-c', cmd], { encoding: 'utf8', timeout: 15000 });
+  return { stdout: (r.stdout || '').trim(), stderr: (r.stderr || '').trim(), status: r.status };
+}
+
+function cleanUp() {
+  runBash(`rm -f '${SMOKE_FILE}'`);
+}
+
+function startAgent(mockTurns) {
+  const env = { ...process.env, NO_COLOR: '1' };
+  if (mockTurns) env.SCBE_MOCK_TURNS = JSON.stringify(mockTurns);
+
+  const proc = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env,
+    cwd: REPO_ROOT,
+  });
+  return proc;
+}
+
+function send(proc, msg) {
+  proc.stdin.write(JSON.stringify(msg) + '\n');
+}
+
+function recv(proc) {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    const onData = (chunk) => {
+      buf += chunk;
+      const nl = buf.indexOf('\n');
+      if (nl !== -1) {
+        proc.stdout.off('data', onData);
+        const line = buf.slice(0, nl).trim();
+        try { resolve(JSON.parse(line)); }
+        catch (e) { reject(new Error(`bad JSON: ${line.slice(0, 200)}`)); }
+      }
+    };
+    proc.stdout.on('data', onData);
+    setTimeout(() => { proc.stdout.off('data', onData); reject(new Error('recv timeout')); }, 15000);
+  });
+}
+
+// ── Mock-mode multi-turn test ──────────────────────────────────────────────
+
+async function runMockSmoke() {
+  console.log('\n═══ MOCK E2E SMOKE ═══');
+  console.log(`Instruction : ${INSTRUCTION}`);
+  console.log(`Verifier    : ${DONE_IF}`);
+  console.log(`Bash        : ${BASH}`);
+  cleanUp();
+
+  // We'll drive the loop manually using SCBE_MOCK_RESPONSE changing per turn.
+  // Since the harness only supports a single SCBE_MOCK_RESPONSE, we drive each
+  // turn as a separate one-shot process invocation (same protocol, fresh state).
+  // This tests: regex parse → command extraction → bash execution → verifier gate.
+
+  let terminalState = '$ ';
+  let turnsPassed = [];
+
+  for (let turn = 0; turn < MOCK_TURNS.length; turn++) {
+    const mockResp = MOCK_TURNS[turn];
+    console.log(`\n── Turn ${turn} ──`);
+    console.log('Mock response:', mockResp.replace(/\n/g, '\\n').slice(0, 100));
+
+    const r = spawnSync(process.execPath, [CLI, 'shell', '--agent-json'], {
+      cwd: REPO_ROOT,
+      input: JSON.stringify({ instruction: INSTRUCTION, terminal_state: terminalState, done_if: DONE_IF }) + '\n\n',
+      encoding: 'utf8',
+      timeout: 20000,
+      env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResp },
+    });
+
+    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    assert.ok(lines.length >= 2, `expected ready + response, got stdout: ${r.stdout}`);
+
+    const ready = JSON.parse(lines[0]);
+    assert.ok(ready.ready, 'first line must be {ready:true}');
+
+    const resp = JSON.parse(lines[1]);
+    console.log('Response    :', JSON.stringify(resp).slice(0, 200));
+
+    if (resp.commands && resp.commands.length > 0) {
+      const ks = resp.commands[0].keystrokes;
+      console.log('Command     :', ks);
+      assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
+
+      const exec = runBash(ks);
+      console.log('Exec stdout :', exec.stdout || '(empty)');
+      console.log('Exec status :', exec.status);
+      terminalState = `$ ${ks}\n${exec.stdout}${exec.stderr ? '\n' + exec.stderr : ''}`;
+    }
+
+    // Check if verify_failed was correctly triggered on turn 0 (file not yet created)
+    if (turn === 0) {
+      const fileExists = runBash(`test -f '${SMOKE_FILE}'`).status === 0;
+      if (!fileExists) {
+        console.log('PASS: file absent after turn 0 — verifier correctly prevented early done');
+        assert.ok(!resp.done, `turn 0 done should be false (file does not exist), got: ${resp.done}`);
+        assert.ok(resp.verify_failed, `turn 0 must have verify_failed=true because file absent`);
+      } else {
+        console.log('NOTE: file created on turn 0 (regex fix extracted valid command)');
+      }
+    }
+
+    turnsPassed.push(turn);
+  }
+
+  // Final state: verify file exists and has correct content
+  const finalCheck = runBash(`cat '${SMOKE_FILE}'`);
+  console.log('\n── Final verification ──');
+  console.log('File content:', JSON.stringify(finalCheck.stdout));
+  console.log('Expected    :', JSON.stringify(SMOKE_CONTENT));
+
+  if (finalCheck.stdout.trim() === SMOKE_CONTENT) {
+    console.log('\n✓ SMOKE PASSED: file created with correct content');
+  } else if (finalCheck.status !== 0) {
+    console.log('\n✗ SMOKE FAILED: file not created');
+    console.log('This means the regex fix did not extract a valid executable command.');
+    process.exitCode = 1;
+  } else {
+    console.log('\n✗ SMOKE FAILED: file exists but content wrong');
+    process.exitCode = 1;
+  }
+
+  cleanUp();
+}
+
+// ── Regex-stress unit test ─────────────────────────────────────────────────
+// Directly verify that the regex fix extracts the right command from the
+// known-bad Groq response format (uses <cmd> as closing tag).
+
+function testRegexFix() {
+  console.log('\n═══ REGEX FIX UNIT TEST ═══');
+
+  const badResponse = `I'll create the file.\n<cmd>echo "${SMOKE_CONTENT}" > ${SMOKE_FILE}<cmd>\n\nLet me verify.`;
+  const goodResponse = `<cmd>echo "${SMOKE_CONTENT}" > ${SMOKE_FILE}</cmd>`;
+
+  function extractCmd(full) {
+    // Same regex as scbe.js
+    const m = full.match(/<cmd>([\s\S]*?)(?:<\/cmd>|(?=\s*<cmd>))/);
+    return m ? m[1].trim() : null;
+  }
+
+  const fromBad = extractCmd(badResponse);
+  const fromGood = extractCmd(goodResponse);
+
+  console.log('Bad  (Groq-style):', fromBad);
+  console.log('Good (proper)    :', fromGood);
+
+  assert.strictEqual(fromBad, `echo "${SMOKE_CONTENT}" > ${SMOKE_FILE}`, 'regex must extract cmd from <cmd>...<cmd> format');
+  assert.strictEqual(fromGood, `echo "${SMOKE_CONTENT}" > ${SMOKE_FILE}`, 'regex must extract cmd from <cmd>...</cmd> format');
+
+  // Execute bad-format extracted command, verify result, clean up
+  cleanUp();
+  const r1 = runBash(fromBad);
+  assert.strictEqual(r1.status, 0, `bad-format cmd must execute (status 0), got stderr: ${r1.stderr}`);
+  const c1 = runBash(`cat '${SMOKE_FILE}'`);
+  assert.strictEqual(c1.stdout.trim(), SMOKE_CONTENT, `bad-format: file content must equal "${SMOKE_CONTENT}", got: "${c1.stdout.trim()}"`);
+  cleanUp();
+
+  // Execute good-format extracted command, verify result, clean up
+  const r2 = runBash(fromGood);
+  assert.strictEqual(r2.status, 0, `good-format cmd must execute (status 0), got stderr: ${r2.stderr}`);
+  const c2 = runBash(`cat '${SMOKE_FILE}'`);
+  assert.strictEqual(c2.stdout.trim(), SMOKE_CONTENT, `good-format: file content must equal "${SMOKE_CONTENT}", got: "${c2.stdout.trim()}"`);
+
+  console.log('✓ Regex fix correctly extracts executable commands from both formats');
+  cleanUp();
+}
+
+// ── Verifier gate unit test ────────────────────────────────────────────────
+// Tests that done_if prevents early done even when the model signals completion.
+
+async function testVerifierGate() {
+  console.log('\n═══ VERIFIER GATE TEST ═══');
+  cleanUp(); // ensure file does not exist
+
+  const mockDoneEarly = `I think the task is complete. <done>`;
+
+  const r = spawnSync(process.execPath, [CLI, 'shell', '--agent-json'], {
+    cwd: REPO_ROOT,
+    input: JSON.stringify({ instruction: INSTRUCTION, terminal_state: '$ ', done_if: DONE_IF }) + '\n\n',
+    encoding: 'utf8',
+    timeout: 20000,
+    env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockDoneEarly },
+  });
+
+  const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+  assert.ok(lines.length >= 2, `expected ready + response`);
+
+  const resp = JSON.parse(lines[1]);
+  console.log('Response:', JSON.stringify(resp).slice(0, 300));
+
+  assert.ok(!resp.done, `done must be false when done_if check fails (file does not exist)`);
+  assert.ok(resp.verify_failed, `verify_failed must be true`);
+  assert.ok(resp.rationale.includes('verifier'), `rationale must mention verifier`);
+
+  console.log('✓ Verifier gate correctly blocked early done signal');
+  cleanUp();
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+(async () => {
+  try {
+    testRegexFix();
+    await testVerifierGate();
+    await runMockSmoke();
+    console.log('\n═══ ALL E2E SMOKE TESTS PASSED ═══\n');
+  } catch (e) {
+    console.error('\n✗ SMOKE FAILED:', e.message);
+    if (e.stack) console.error(e.stack);
+    cleanUp();
+    process.exit(1);
+  }
+})();

--- a/packages/cli/scripts/smoke_agent_json_e2e.cjs
+++ b/packages/cli/scripts/smoke_agent_json_e2e.cjs
@@ -22,10 +22,29 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 const CLI = path.resolve(__dirname, '../bin/scbe.js');
 
 // Bash binary for executing commands
-const BASH =
-  process.platform === 'win32'
-    ? (spawnSync('where', ['bash'], { encoding: 'utf8' }).stdout.split('\n').find((l) => l.trim()) || 'bash').trim()
-    : '/bin/bash';
+function resolveBash() {
+  if (process.platform !== 'win32') return '/bin/bash';
+  const candidates = [
+    process.env.SCBE_BASH,
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  const whereOut = spawnSync('where', ['bash'], { encoding: 'utf8' }).stdout || '';
+  return (
+    whereOut
+      .split('\n')
+      .map((l) => l.trim())
+      .find(
+        (l) =>
+          l && !/\\windows\\system32\\bash\.exe$/i.test(l) && !/\\WindowsApps\\bash\.exe$/i.test(l)
+      ) || 'bash'
+  ).trim();
+}
+
+const BASH = resolveBash();
 
 // Use /tmp — Git Bash maps this to a writable temp dir on Windows
 const SMOKE_FILE = '/tmp/scbe_smoke_e2e.txt';
@@ -76,12 +95,18 @@ function recv(proc) {
       if (nl !== -1) {
         proc.stdout.off('data', onData);
         const line = buf.slice(0, nl).trim();
-        try { resolve(JSON.parse(line)); }
-        catch (e) { reject(new Error(`bad JSON: ${line.slice(0, 200)}`)); }
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(new Error(`bad JSON: ${line.slice(0, 200)}`));
+        }
       }
     };
     proc.stdout.on('data', onData);
-    setTimeout(() => { proc.stdout.off('data', onData); reject(new Error('recv timeout')); }, 15000);
+    setTimeout(() => {
+      proc.stdout.off('data', onData);
+      reject(new Error('recv timeout'));
+    }, 15000);
   });
 }
 
@@ -109,13 +134,21 @@ async function runMockSmoke() {
 
     const r = spawnSync(process.execPath, [CLI, 'shell', '--agent-json'], {
       cwd: REPO_ROOT,
-      input: JSON.stringify({ instruction: INSTRUCTION, terminal_state: terminalState, done_if: DONE_IF }) + '\n\n',
+      input:
+        JSON.stringify({
+          instruction: INSTRUCTION,
+          terminal_state: terminalState,
+          done_if: DONE_IF,
+        }) + '\n\n',
       encoding: 'utf8',
       timeout: 20000,
       env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockResp },
     });
 
-    const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+    const lines = (r.stdout || '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
     assert.ok(lines.length >= 2, `expected ready + response, got stdout: ${r.stdout}`);
 
     const ready = JSON.parse(lines[0]);
@@ -128,6 +161,17 @@ async function runMockSmoke() {
       const ks = resp.commands[0].keystrokes;
       console.log('Command     :', ks);
       assert.ok(!ks.startsWith(':'), 'translated command must not start with :');
+      assert.ok(resp.move_packet, 'command response must include an SCBE move_packet');
+      assert.strictEqual(resp.move_packet.schema_version, 'scbe_agent_move_packet_v1');
+      assert.strictEqual(
+        resp.move_packet.round_trip_ok,
+        true,
+        'move_packet must prove six-tongue round trip'
+      );
+      assert.ok(
+        resp.move_packet.atomic_units?.[0]?.hex?.length > 0,
+        'move_packet must include byte/hex atomic view'
+      );
 
       const exec = runBash(ks);
       console.log('Exec stdout :', exec.stdout || '(empty)');
@@ -140,7 +184,10 @@ async function runMockSmoke() {
       const fileExists = runBash(`test -f '${SMOKE_FILE}'`).status === 0;
       if (!fileExists) {
         console.log('PASS: file absent after turn 0 — verifier correctly prevented early done');
-        assert.ok(!resp.done, `turn 0 done should be false (file does not exist), got: ${resp.done}`);
+        assert.ok(
+          !resp.done,
+          `turn 0 done should be false (file does not exist), got: ${resp.done}`
+        );
         assert.ok(resp.verify_failed, `turn 0 must have verify_failed=true because file absent`);
       } else {
         console.log('NOTE: file created on turn 0 (regex fix extracted valid command)');
@@ -192,22 +239,46 @@ function testRegexFix() {
   console.log('Bad  (Groq-style):', fromBad);
   console.log('Good (proper)    :', fromGood);
 
-  assert.strictEqual(fromBad, `echo "${SMOKE_CONTENT}" > ${SMOKE_FILE}`, 'regex must extract cmd from <cmd>...<cmd> format');
-  assert.strictEqual(fromGood, `echo "${SMOKE_CONTENT}" > ${SMOKE_FILE}`, 'regex must extract cmd from <cmd>...</cmd> format');
+  assert.strictEqual(
+    fromBad,
+    `echo "${SMOKE_CONTENT}" > ${SMOKE_FILE}`,
+    'regex must extract cmd from <cmd>...<cmd> format'
+  );
+  assert.strictEqual(
+    fromGood,
+    `echo "${SMOKE_CONTENT}" > ${SMOKE_FILE}`,
+    'regex must extract cmd from <cmd>...</cmd> format'
+  );
 
   // Execute bad-format extracted command, verify result, clean up
   cleanUp();
   const r1 = runBash(fromBad);
-  assert.strictEqual(r1.status, 0, `bad-format cmd must execute (status 0), got stderr: ${r1.stderr}`);
+  assert.strictEqual(
+    r1.status,
+    0,
+    `bad-format cmd must execute (status 0), got stderr: ${r1.stderr}`
+  );
   const c1 = runBash(`cat '${SMOKE_FILE}'`);
-  assert.strictEqual(c1.stdout.trim(), SMOKE_CONTENT, `bad-format: file content must equal "${SMOKE_CONTENT}", got: "${c1.stdout.trim()}"`);
+  assert.strictEqual(
+    c1.stdout.trim(),
+    SMOKE_CONTENT,
+    `bad-format: file content must equal "${SMOKE_CONTENT}", got: "${c1.stdout.trim()}"`
+  );
   cleanUp();
 
   // Execute good-format extracted command, verify result, clean up
   const r2 = runBash(fromGood);
-  assert.strictEqual(r2.status, 0, `good-format cmd must execute (status 0), got stderr: ${r2.stderr}`);
+  assert.strictEqual(
+    r2.status,
+    0,
+    `good-format cmd must execute (status 0), got stderr: ${r2.stderr}`
+  );
   const c2 = runBash(`cat '${SMOKE_FILE}'`);
-  assert.strictEqual(c2.stdout.trim(), SMOKE_CONTENT, `good-format: file content must equal "${SMOKE_CONTENT}", got: "${c2.stdout.trim()}"`);
+  assert.strictEqual(
+    c2.stdout.trim(),
+    SMOKE_CONTENT,
+    `good-format: file content must equal "${SMOKE_CONTENT}", got: "${c2.stdout.trim()}"`
+  );
 
   console.log('✓ Regex fix correctly extracts executable commands from both formats');
   cleanUp();
@@ -224,13 +295,17 @@ async function testVerifierGate() {
 
   const r = spawnSync(process.execPath, [CLI, 'shell', '--agent-json'], {
     cwd: REPO_ROOT,
-    input: JSON.stringify({ instruction: INSTRUCTION, terminal_state: '$ ', done_if: DONE_IF }) + '\n\n',
+    input:
+      JSON.stringify({ instruction: INSTRUCTION, terminal_state: '$ ', done_if: DONE_IF }) + '\n\n',
     encoding: 'utf8',
     timeout: 20000,
     env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mockDoneEarly },
   });
 
-  const lines = (r.stdout || '').split('\n').map((l) => l.trim()).filter(Boolean);
+  const lines = (r.stdout || '')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
   assert.ok(lines.length >= 2, `expected ready + response`);
 
   const resp = JSON.parse(lines[1]);

--- a/scripts/system/agent_move_packet.py
+++ b/scripts/system/agent_move_packet.py
@@ -1,0 +1,176 @@
+"""Build a compact SCBE move packet for agent shell commands.
+
+This is a bridge layer, not a universal code translator. It preserves the
+move across synchronized views: shell command, token roles, byte/hex structure,
+atomic workflow units, and Sacred Tongue transport bijection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.crypto.sacred_tongue_payload_bijection import canonical_json_bytes, prove_dict
+from src.tokenizer.atomic_workflow_units import build_atomic_workflow_unit
+
+SCHEMA_VERSION = "scbe_agent_move_packet_v1"
+
+ROLE_BY_HEAD = {
+    "cat": "observe",
+    "dir": "observe",
+    "find": "observe",
+    "grep": "observe",
+    "head": "observe",
+    "ls": "observe",
+    "rg": "observe",
+    "sed": "observe",
+    "type": "observe",
+    "where": "observe",
+    "git": "measure",
+    "gh": "transmit",
+    "node": "compute",
+    "npm": "compute",
+    "npx": "compute",
+    "python": "compute",
+    "python3": "compute",
+    "pytest": "measure",
+    "vitest": "measure",
+    "patch": "repair",
+    "black": "repair",
+    "eslint": "repair",
+    "prettier": "repair",
+    "ruff": "repair",
+}
+
+
+def _read_stdin_json() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError("expected JSON on stdin")
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("expected JSON object")
+    return data
+
+
+def _tokens(command: str) -> list[str]:
+    try:
+        parts = shlex.split(command, posix=True)
+    except ValueError:
+        parts = command.split()
+    return [part for part in parts if part][:32]
+
+
+def _role_for(index: int, token: str, head_role: str) -> str:
+    if index == 0:
+        return head_role
+    lowered = token.lower()
+    if lowered in {"&&", "||", "|", ";"}:
+        return "gate"
+    if lowered.startswith("-"):
+        return "gate"
+    if any(marker in lowered for marker in ("test", "check", "verify", "status")):
+        return "measure"
+    if any(marker in lowered for marker in ("fix", "patch", "format", "lint")):
+        return "repair"
+    return "compute"
+
+
+def _compact_unit(unit: dict[str, Any]) -> dict[str, Any]:
+    byte_sig = unit["chemistry_lane"]["byte_signature"]
+    return {
+        "unit_id": unit["unit_id"],
+        "token": unit["token"],
+        "role": unit["semantic_lane"]["role"],
+        "phase": unit["semantic_lane"]["phase"],
+        "stability": unit["semantic_lane"]["stability"],
+        "chemistry_mode": unit["chemistry_lane"]["mode"],
+        "byte_count": byte_sig["byte_count"],
+        "hex": byte_sig["hex"],
+        "byte_sha256": byte_sig["byte_sha256"],
+        "resource_cost": unit["resource_cost"],
+    }
+
+
+def build_packet(input_payload: dict[str, Any]) -> dict[str, Any]:
+    move = input_payload.get("move")
+    if not isinstance(move, dict):
+        raise ValueError("payload.move must be an object")
+
+    command = str(move.get("cmd") or "").strip()
+    translated = str(move.get("translated") or command).strip()
+    if not translated:
+        raise ValueError("payload.move.translated or payload.move.cmd is required")
+
+    tokens = _tokens(translated)
+    head = Path(tokens[0]).name.lower() if tokens else ""
+    head_role = ROLE_BY_HEAD.get(head, "compute")
+    atomic_units = [
+        _compact_unit(
+            build_atomic_workflow_unit(
+                token, explicit_role=_role_for(index, token, head_role)
+            )
+        )
+        for index, token in enumerate(tokens)
+    ]
+
+    packet_base = {
+        "schema_version": SCHEMA_VERSION,
+        "move": {
+            "cmd": command,
+            "translated": translated,
+            "turn": move.get("turn"),
+            "path_policy": move.get("path_policy", "non_optimal_correct"),
+            "objective_sha256": hashlib.sha256(
+                str(move.get("objective") or "").encode("utf-8")
+            ).hexdigest(),
+        },
+        "governance": input_payload.get("governance") or {},
+        "tokens": tokens,
+        "atomic_units": atomic_units,
+        "boundaries": {
+            "semantic": "agent move intent and workflow roles",
+            "transport": "canonical JSON bytes encoded losslessly through all Sacred Tongues",
+            "not_claimed": "not a source-to-source compiler and not a proof of language equivalence",
+        },
+    }
+    digest = hashlib.sha256(canonical_json_bytes(packet_base)).hexdigest()
+    proof = prove_dict(packet_base)
+    return {
+        **packet_base,
+        "move_id": digest[:16],
+        "canonical_sha256": digest,
+        "bijective_proof": proof,
+        "round_trip_ok": bool(proof["ok"]),
+    }
+
+
+def main() -> int:
+    try:
+        packet = build_packet(_read_stdin_json())
+    except Exception as exc:  # pragma: no cover - exercised via CLI failure path.
+        print(
+            json.dumps(
+                {"schema_version": SCHEMA_VERSION, "ok": False, "error": str(exc)}
+            )
+        )
+        return 2
+    print(
+        json.dumps(
+            {"schema_version": SCHEMA_VERSION, "ok": True, "packet": packet},
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/system/test_agent_move_packet.py
+++ b/tests/system/test_agent_move_packet.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_packet(payload: dict) -> dict:
+    proc = subprocess.run(
+        [sys.executable, "scripts/system/agent_move_packet.py"],
+        cwd=REPO_ROOT,
+        input=json.dumps(payload),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return json.loads(proc.stdout)
+
+
+def test_agent_move_packet_layers_shell_move_into_atomic_and_bijective_views() -> None:
+    out = _run_packet(
+        {
+            "schema_version": "scbe_agent_move_packet_input_v1",
+            "move": {
+                "cmd": ":test npm test",
+                "translated": "npm test && echo SCBE_TEST_PASS || echo SCBE_TEST_FAIL",
+                "turn": 2,
+                "objective": "verify the harness",
+                "legal_moves": ["cmd", "files", "read", "patch", "test"],
+                "path_policy": "non_optimal_correct",
+            },
+            "governance": {"decision": "ALLOW", "reason": "ok"},
+        }
+    )
+
+    assert out["ok"] is True
+    packet = out["packet"]
+    assert packet["schema_version"] == "scbe_agent_move_packet_v1"
+    assert packet["round_trip_ok"] is True
+    assert packet["bijective_proof"]["ok"] is True
+    assert set(packet["bijective_proof"]["tongues"]) == {
+        "ko",
+        "av",
+        "ru",
+        "ca",
+        "um",
+        "dr",
+    }
+    assert packet["tokens"][:2] == ["npm", "test"]
+    assert packet["atomic_units"][0]["role"] == "compute"
+    assert packet["atomic_units"][0]["hex"]
+    assert packet["boundaries"]["not_claimed"].startswith(
+        "not a source-to-source compiler"
+    )
+
+
+def test_agent_move_packet_rejects_missing_move() -> None:
+    proc = subprocess.run(
+        [sys.executable, "scripts/system/agent_move_packet.py"],
+        cwd=REPO_ROOT,
+        input=json.dumps({"schema_version": "bad"}),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    out = json.loads(proc.stdout)
+    assert out["ok"] is False
+    assert "payload.move" in out["error"]


### PR DESCRIPTION
## Summary
- Adds `scripts/system/agent_move_packet.py` to turn each agent shell move into a compact SCBE packet with command tokens, atomic workflow units, byte/hex signatures, and six-tongue bijective transport proof.
- Wires `scbe shell --agent-json` command responses to include `move_packet` after GeoSeal/board routing.
- Extends shell smoke/benchmark coverage so command moves must include a round-trip-safe packet.
- Prefers Git Bash over Windows WSL `bash.exe` for verifier/smoke execution on Windows when WSL has no distro installed.

## Boundary
This is not claiming universal source-to-source compilation. It is a verified move packet layer: semantic/atomic/transport views for the agent command that still executes only through board state and GeoSeal governance.

## Tests
- `python -m black --check scripts/system/agent_move_packet.py tests/system/test_agent_move_packet.py`
- `npx prettier --check packages/cli/bin/scbe.js packages/cli/scripts/shell_benchmark.cjs packages/cli/scripts/smoke_agent_json_e2e.cjs`
- `python -m pytest tests/system/test_agent_move_packet.py tests/test_sacred_tongue_payload_bijection.py tests/tokenizer/test_atomic_workflow_units.py -q`
- `node --check packages/cli/bin/scbe.js; node --check packages/cli/scripts/shell_benchmark.cjs; node --check packages/cli/scripts/smoke_agent_json_e2e.cjs`
- `node packages/cli/scripts/smoke_agent_json_e2e.cjs`
- `node packages/cli/scripts/shell_benchmark.cjs` -> 21/21, 100%

## Rollback
Revert commit `6fa33be5e` to remove move packet generation and return agent-json responses to board/governance only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced agent-json mode with task completion verification gating
  * Improved command extraction supporting additional output formats
  * Tool translation system for repository operations

* **Documentation**
  * Updated benchmark plan with completion status and coverage details
  * Added agent path policy specification

* **Tests**
  * Expanded benchmark suite with comprehensive agent-json validation
  * Added end-to-end smoke tests for agent-json functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->