### PR TITLE
fix(format): align agent move packet python with CI

### DIFF
--- a/scripts/system/agent_move_packet.py
+++ b/scripts/system/agent_move_packet.py
@@ -114,11 +114,7 @@ def build_packet(input_payload: dict[str, Any]) -> dict[str, Any]:
     head = Path(tokens[0]).name.lower() if tokens else ""
     head_role = ROLE_BY_HEAD.get(head, "compute")
     atomic_units = [
-        _compact_unit(
-            build_atomic_workflow_unit(
-                token, explicit_role=_role_for(index, token, head_role)
-            )
-        )
+        _compact_unit(build_atomic_workflow_unit(token, explicit_role=_role_for(index, token, head_role)))
         for index, token in enumerate(tokens)
     ]
 
@@ -129,9 +125,7 @@ def build_packet(input_payload: dict[str, Any]) -> dict[str, Any]:
             "translated": translated,
             "turn": move.get("turn"),
             "path_policy": move.get("path_policy", "non_optimal_correct"),
-            "objective_sha256": hashlib.sha256(
-                str(move.get("objective") or "").encode("utf-8")
-            ).hexdigest(),
+            "objective_sha256": hashlib.sha256(str(move.get("objective") or "").encode("utf-8")).hexdigest(),
         },
         "governance": input_payload.get("governance") or {},
         "tokens": tokens,
@@ -157,11 +151,7 @@ def main() -> int:
     try:
         packet = build_packet(_read_stdin_json())
     except Exception as exc:  # pragma: no cover - exercised via CLI failure path.
-        print(
-            json.dumps(
-                {"schema_version": SCHEMA_VERSION, "ok": False, "error": str(exc)}
-            )
-        )
+        print(json.dumps({"schema_version": SCHEMA_VERSION, "ok": False, "error": str(exc)}))
         return 2
     print(
         json.dumps(

--- a/tests/system/test_agent_move_packet.py
+++ b/tests/system/test_agent_move_packet.py
@@ -55,9 +55,7 @@ def test_agent_move_packet_layers_shell_move_into_atomic_and_bijective_views() -
     assert packet["tokens"][:2] == ["npm", "test"]
     assert packet["atomic_units"][0]["role"] == "compute"
     assert packet["atomic_units"][0]["hex"]
-    assert packet["boundaries"]["not_claimed"].startswith(
-        "not a source-to-source compiler"
-    )
+    assert packet["boundaries"]["not_claimed"].startswith("not a source-to-source compiler")
 
 
 def test_agent_move_packet_rejects_missing_move() -> None:


### PR DESCRIPTION
## Summary
- Applies the same Black settings used by CI (`--target-version py311 --line-length 120`) to the agent move packet script and tests.
- Follow-up to #1944, which auto-merged before the format amend landed.

## Tests
- `python -m black --check --target-version py311 --line-length 120 tests/system/test_agent_move_packet.py scripts/system/agent_move_packet.py`
- `python -m ruff check --config ruff.toml tests/system/test_agent_move_packet.py scripts/system/agent_move_packet.py`
- `python -m pytest tests/system/test_agent_move_packet.py tests/test_sacred_tongue_payload_bijection.py tests/tokenizer/test_atomic_workflow_units.py -q`
- `npx prettier --check "src/**/*.ts" "tests/**/*.ts"`
- `node packages/cli/scripts/shell_benchmark.cjs` -> 21/21, 100%

## Rollback
Revert this PR to return to the formatting from #1944.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code formatting improvements and test assertion refinements. No user-facing changes or functional modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->