### PR TITLE
feat(agentic): add fleet governance gate for agent moves

### DIFF
--- a/docs/specs/SCBE_FLEET_GOVERNANCE_GATE.md
+++ b/docs/specs/SCBE_FLEET_GOVERNANCE_GATE.md
@@ -1,0 +1,64 @@
+# SCBE Fleet Governance Gate
+
+Status: implemented as a deterministic guardrail, not a certification claim.
+
+The fleet governance gate sits after the agent move packet:
+
+```text
+model output
+  -> command extraction
+  -> GeoSeal policy compile
+  -> agent move packet
+  -> fleet governance gate
+  -> harness execution / block / escalation
+```
+
+## Purpose
+
+This advances SCBE toward higher-assurance fleet operation by making every
+agent command answer four questions before it is treated as runnable:
+
+1. What operation class is this move?
+2. Is the actor cleared for that class?
+3. Does the fleet posture require quorum?
+4. Does the current fleet state force quarantine or denial?
+
+The gate is deliberately fail-closed. If a move packet is missing, not
+bijective, carries secret material, lacks quorum, or targets a degraded remote
+lane, it is not silently accepted.
+
+## Operation Classes
+
+| Class | Examples | Default Meaning |
+| --- | --- | --- |
+| `observe` | `ls`, `cat`, `rg` | Read-only inspection. |
+| `measure` | `pytest`, `npm test`, `gh pr checks` | Verification or scoring. |
+| `modify` | `patch`, `git add`, formatters | Local workspace changes. |
+| `network` | `curl`, `gh api`, `ssh` | Remote I/O or external calls. |
+| `deploy` | `git push`, `npm publish`, `gh pr merge` | Release or shared-state change. |
+| `destructive` | `rm -rf`, `kubectl delete`, `drop database` | Destructive action. |
+
+## Fleet Postures
+
+| Posture | Intended Use |
+| --- | --- |
+| `training` | Local/default harness development. |
+| `canary` | Limited-scope external or pre-release run. |
+| `production` | Shared system state or public release lanes. |
+| `mission_critical` | Highest caution profile for fleet orchestration. |
+
+## Outputs
+
+The gate emits:
+
+- `StateVector`: operation class, posture, clearance, quorum, BFT minimum node
+  count, degraded-comms state, command hash, and move ID.
+- `DecisionRecord`: `ALLOW`, `QUARANTINE`, `ESCALATE`, or `DENY`, with reason,
+  confidence, deterministic signature, timestamp, and findings.
+
+## Boundary
+
+This is not a military certification, FedRAMP authorization, weapons system, or
+deployment approval by itself. It is a deterministic command-authority layer
+that can be composed with DCP receipts, GeoSeal policy, CI evidence, and fleet
+health monitoring.

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -1058,6 +1058,33 @@ function buildAgentMovePacket(move, governance, board) {
   }
 }
 
+function buildFleetGovernanceGate(movePacket, posture, authority) {
+  if (!movePacket || movePacket.ok === false) return null;
+  const script = resolveRepoScript('scripts/system/fleet_governance_gate.py');
+  if (!script) return null;
+  try {
+    const r = spawnSync(pythonCommand(), [script], {
+      cwd: repoRoot(),
+      input: JSON.stringify({
+        schema_version: 'scbe_fleet_governance_gate_input_v1',
+        move_packet: movePacket,
+        posture: posture || {},
+        authority: authority || {},
+      }),
+      encoding: 'utf8',
+      timeout: 10000,
+      maxBuffer: 1024 * 1024,
+    });
+    if (r.status !== 0) {
+      const err = ((r.stdout || '') + (r.stderr || '')).trim().slice(0, 300);
+      return { ok: false, error: err || `fleet_governance_gate exited ${r.status}` };
+    }
+    return JSON.parse(r.stdout);
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+}
+
 // ─── Input classifier ─────────────────────────────────────────────────────────
 
 const _PS_PREFIX = /^(!|ps:)\s*/;
@@ -1350,6 +1377,8 @@ function runInteractiveShell(flags = {}) {
       }
       if (msg.done_if && !taskBoard.done_if) taskBoard.done_if = msg.done_if;
       if (msg.task_board && !taskBoard.objective) Object.assign(taskBoard, msg.task_board);
+      if (msg.fleet_posture) taskBoard.fleet_posture = msg.fleet_posture;
+      if (msg.fleet_authority) taskBoard.fleet_authority = msg.fleet_authority;
       if (!instruction) {
         process.stdout.write(
           JSON.stringify({ error: 'no instruction yet', done: false, commands: [] }) + '\n'
@@ -1484,6 +1513,11 @@ function runInteractiveShell(flags = {}) {
           governance,
           taskBoard
         );
+        const fleetGovernance = buildFleetGovernanceGate(
+          movePacket,
+          taskBoard.fleet_posture,
+          taskBoard.fleet_authority
+        );
         process.stdout.write(
           JSON.stringify({
             commands: [],
@@ -1492,6 +1526,7 @@ function runInteractiveShell(flags = {}) {
             rationale: `ko-ban: command+observation repeated — try a different approach. Banned: "${translated.slice(0, 80)}"`,
             governance,
             move_packet: movePacket,
+            fleet_governance: fleetGovernance,
             board: { ...taskBoard },
           }) + '\n'
         );
@@ -1540,6 +1575,11 @@ function runInteractiveShell(flags = {}) {
           governance,
           taskBoard
         );
+        const fleetGovernance = buildFleetGovernanceGate(
+          movePacket,
+          taskBoard.fleet_posture,
+          taskBoard.fleet_authority
+        );
         process.stdout.write(
           JSON.stringify({
             commands: [],
@@ -1548,6 +1588,7 @@ function runInteractiveShell(flags = {}) {
             rationale: `governance blocked: ${governance.reason}`,
             governance,
             move_packet: movePacket,
+            fleet_governance: fleetGovernance,
             board: { ...taskBoard },
           }) + '\n'
         );
@@ -1572,6 +1613,11 @@ function runInteractiveShell(flags = {}) {
             governance,
             taskBoard
           );
+          const fleetGovernance = buildFleetGovernanceGate(
+            movePacket,
+            taskBoard.fleet_posture,
+            taskBoard.fleet_authority
+          );
           history.push({
             role: 'user',
             content: `VERIFY FAILED: ${verifyOut}\nThe objective is not yet complete. Continue working.`,
@@ -1586,6 +1632,7 @@ function runInteractiveShell(flags = {}) {
               rationale: `done signal received but objective verifier failed: ${verifyOut}`,
               governance,
               move_packet: movePacket,
+              fleet_governance: fleetGovernance,
               board: { ...taskBoard },
             }) + '\n'
           );
@@ -1605,6 +1652,11 @@ function runInteractiveShell(flags = {}) {
         .trim()
         .slice(0, 500);
       const movePacket = buildAgentMovePacket({ cmd: proposed, translated }, governance, taskBoard);
+      const fleetGovernance = buildFleetGovernanceGate(
+        movePacket,
+        taskBoard.fleet_posture,
+        taskBoard.fleet_authority
+      );
       process.stdout.write(
         JSON.stringify({
           commands: [{ keystrokes: translated, is_blocking: true, timeout_sec: 30 }],
@@ -1612,6 +1664,7 @@ function runInteractiveShell(flags = {}) {
           rationale,
           governance,
           move_packet: movePacket,
+          fleet_governance: fleetGovernance,
           board: { ...taskBoard },
         }) + '\n'
       );

--- a/packages/cli/scripts/shell_benchmark.cjs
+++ b/packages/cli/scripts/shell_benchmark.cjs
@@ -603,6 +603,50 @@ function main() {
     })
   );
 
+  cases.push(
+    caseResult('agent_json_command_includes_fleet_governance_gate', () => {
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Push to main. <cmd>git push origin main</cmd>';
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input:
+          JSON.stringify({
+            instruction: 'push changes',
+            terminal_state: '$ ',
+            fleet_posture: {
+              posture: 'production',
+              fleet_size: 4,
+              byzantine_faults_tolerated: 1,
+            },
+            fleet_authority: {
+              actor_id: 'bench-agent',
+              clearance: 2,
+              approved_by: ['bench-agent'],
+            },
+          }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response, got: ${r.stdout}`);
+      const resp = JSON.parse(lines[1]);
+      assert.ok(resp.fleet_governance, 'response must include fleet_governance');
+      assert.equal(resp.fleet_governance.ok, true);
+      assert.equal(resp.fleet_governance.state_vector.operation_class, 'deploy');
+      assert.equal(resp.fleet_governance.decision_record.decision, 'ESCALATE');
+      assert.equal(resp.fleet_governance.decision_record.reason, 'quorum_not_met');
+      return {
+        operation_class: resp.fleet_governance.state_vector.operation_class,
+        decision: resp.fleet_governance.decision_record.decision,
+        reason: resp.fleet_governance.decision_record.reason,
+      };
+    })
+  );
+
   const total = cases.reduce((sum, row) => sum + row.points, 0);
   const earned = cases.reduce((sum, row) => sum + row.earned, 0);
   const report = {

--- a/scripts/system/fleet_governance_gate.py
+++ b/scripts/system/fleet_governance_gate.py
@@ -1,0 +1,49 @@
+"""CLI wrapper for SCBE fleet governance over an agent move packet."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.system.agent_move_packet import build_packet
+from src.agentic.fleet_governance import authority_from_dict, evaluate_fleet_move, posture_from_dict
+
+
+def _read_json() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise ValueError("expected JSON on stdin")
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("expected JSON object")
+    return data
+
+
+def main() -> int:
+    try:
+        payload = _read_json()
+        move_packet = payload.get("move_packet")
+        if not isinstance(move_packet, dict):
+            move_packet = build_packet(payload) if "move" in payload else None
+        if not isinstance(move_packet, dict):
+            raise ValueError("expected move_packet or move payload")
+        out = evaluate_fleet_move(
+            move_packet,
+            posture=posture_from_dict(payload.get("posture")),
+            authority=authority_from_dict(payload.get("authority")),
+        )
+    except Exception as exc:
+        print(json.dumps({"schema_version": "scbe_fleet_governance_gate_v1", "ok": False, "error": str(exc)}))
+        return 2
+    print(json.dumps({"ok": True, **out}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agentic/fleet_governance.py
+++ b/src/agentic/fleet_governance.py
@@ -1,0 +1,359 @@
+"""Fleet-grade governance gate for SCBE agent moves.
+
+This module sits after the agent move packet. It does not trust the model's
+claim that a command is safe; it classifies the move, checks fleet posture,
+requires quorum where appropriate, and emits a deterministic StateVector plus
+DecisionRecord.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+SCHEMA_VERSION = "scbe_fleet_governance_gate_v1"
+
+
+class FleetDecision(str, Enum):
+    ALLOW = "ALLOW"
+    QUARANTINE = "QUARANTINE"
+    ESCALATE = "ESCALATE"
+    DENY = "DENY"
+
+
+class FleetPosture(str, Enum):
+    TRAINING = "training"
+    CANARY = "canary"
+    PRODUCTION = "production"
+    MISSION_CRITICAL = "mission_critical"
+
+
+class OperationClass(str, Enum):
+    OBSERVE = "observe"
+    MEASURE = "measure"
+    MODIFY = "modify"
+    DEPLOY = "deploy"
+    NETWORK = "network"
+    DESTRUCTIVE = "destructive"
+
+
+@dataclass(frozen=True)
+class FleetAuthority:
+    actor_id: str = "unknown"
+    clearance: int = 0
+    approved_by: list[str] = field(default_factory=list)
+    human_confirmed: bool = False
+    emergency_rollback: bool = False
+
+
+@dataclass(frozen=True)
+class FleetPostureState:
+    posture: FleetPosture = FleetPosture.TRAINING
+    fleet_size: int = 1
+    byzantine_faults_tolerated: int = 0
+    degraded_comms: bool = False
+    offline_mode: bool = True
+
+
+@dataclass(frozen=True)
+class StateVector:
+    schema_version: str
+    operation_class: str
+    posture: str
+    clearance: int
+    required_clearance: int
+    quorum_observed: int
+    quorum_required: int
+    bft_min_nodes: int
+    fleet_size: int
+    degraded_comms: bool
+    fail_closed: bool
+    move_id: str
+    command_hash: str
+
+
+@dataclass(frozen=True)
+class DecisionRecord:
+    decision: str
+    reason: str
+    timestamp: float
+    signature: str
+    confidence: float
+    findings: list[str] = field(default_factory=list)
+
+
+_DESTRUCTIVE_PATTERNS = [
+    r"\brm\s+-rf\b",
+    r"\bRemove-Item\b.*\b-Recurse\b.*\b-Force\b",
+    r"\bdel\s+/[sq]\b",
+    r"\bformat\b",
+    r"\bdrop\s+database\b",
+    r"\bkubectl\s+delete\b",
+]
+
+_DEPLOY_PATTERNS = [
+    r"\bgit\s+push\b",
+    r"\bgh\s+pr\s+merge\b",
+    r"\bnpm\s+publish\b",
+    r"\btwine\s+upload\b",
+    r"\bvercel\s+--prod\b",
+    r"\bkubectl\s+(apply|rollout|set)\b",
+]
+
+_NETWORK_PATTERNS = [
+    r"\bcurl\b",
+    r"\bwget\b",
+    r"\bInvoke-WebRequest\b",
+    r"\bgh\s+api\b",
+    r"\bssh\b",
+    r"\bscp\b",
+]
+
+_MODIFY_PATTERNS = [
+    r"\bpatch\b",
+    r"\bapply_patch\b",
+    r"\bgit\s+(commit|add)\b",
+    r"\bpython\b.*\b(write|format|black)\b",
+    r"\bnpx\s+prettier\s+--write\b",
+]
+
+_MEASURE_PATTERNS = [
+    r"\btest\b",
+    r"\bpytest\b",
+    r"\bnpm\s+(test|run\s+test|run\s+lint|run\s+typecheck)\b",
+    r"\bnode\s+--check\b",
+    r"\bgh\s+pr\s+checks\b",
+]
+
+_SECRET_PATTERNS = [
+    r"(?i)(api[_-]?key|secret|password|token|bearer)\s*=",
+    r"(?i)authorization:\s*bearer",
+]
+
+_CLEARANCE_BY_OPERATION = {
+    OperationClass.OBSERVE: 0,
+    OperationClass.MEASURE: 0,
+    OperationClass.MODIFY: 1,
+    OperationClass.NETWORK: 1,
+    OperationClass.DEPLOY: 2,
+    OperationClass.DESTRUCTIVE: 4,
+}
+
+_POSTURE_QUORUM = {
+    FleetPosture.TRAINING: {
+        OperationClass.OBSERVE: 0,
+        OperationClass.MEASURE: 0,
+        OperationClass.MODIFY: 0,
+        OperationClass.NETWORK: 1,
+        OperationClass.DEPLOY: 2,
+        OperationClass.DESTRUCTIVE: 999,
+    },
+    FleetPosture.CANARY: {
+        OperationClass.OBSERVE: 0,
+        OperationClass.MEASURE: 0,
+        OperationClass.MODIFY: 1,
+        OperationClass.NETWORK: 1,
+        OperationClass.DEPLOY: 2,
+        OperationClass.DESTRUCTIVE: 999,
+    },
+    FleetPosture.PRODUCTION: {
+        OperationClass.OBSERVE: 0,
+        OperationClass.MEASURE: 0,
+        OperationClass.MODIFY: 2,
+        OperationClass.NETWORK: 2,
+        OperationClass.DEPLOY: 3,
+        OperationClass.DESTRUCTIVE: 999,
+    },
+    FleetPosture.MISSION_CRITICAL: {
+        OperationClass.OBSERVE: 0,
+        OperationClass.MEASURE: 1,
+        OperationClass.MODIFY: 3,
+        OperationClass.NETWORK: 3,
+        OperationClass.DEPLOY: 4,
+        OperationClass.DESTRUCTIVE: 999,
+    },
+}
+
+
+def classify_operation(command: str, move_packet: dict[str, Any] | None = None) -> OperationClass:
+    """Classify a shell move into a fleet governance operation class."""
+    normalized = command.strip()
+    if any(re.search(pattern, normalized, re.IGNORECASE) for pattern in _DESTRUCTIVE_PATTERNS):
+        return OperationClass.DESTRUCTIVE
+    if any(re.search(pattern, normalized, re.IGNORECASE) for pattern in _DEPLOY_PATTERNS):
+        return OperationClass.DEPLOY
+    if any(re.search(pattern, normalized, re.IGNORECASE) for pattern in _NETWORK_PATTERNS):
+        return OperationClass.NETWORK
+    if any(re.search(pattern, normalized, re.IGNORECASE) for pattern in _MODIFY_PATTERNS):
+        return OperationClass.MODIFY
+    if any(re.search(pattern, normalized, re.IGNORECASE) for pattern in _MEASURE_PATTERNS):
+        return OperationClass.MEASURE
+
+    roles = {
+        str(unit.get("role", "")).lower()
+        for unit in (move_packet or {}).get("atomic_units", [])
+        if isinstance(unit, dict)
+    }
+    if "repair" in roles:
+        return OperationClass.MODIFY
+    if "transmit" in roles:
+        return OperationClass.NETWORK
+    if "measure" in roles:
+        return OperationClass.MEASURE
+    return OperationClass.OBSERVE
+
+
+def _unique_quorum(approved_by: list[str]) -> int:
+    return len({actor.strip().lower() for actor in approved_by if actor.strip()})
+
+
+def _bft_min_nodes(faults: int) -> int:
+    return max(1, (3 * max(0, int(faults))) + 1)
+
+
+def _command_from_move(move_packet: dict[str, Any]) -> str:
+    move = move_packet.get("move") if isinstance(move_packet, dict) else None
+    if isinstance(move, dict):
+        return str(move.get("translated") or move.get("cmd") or "")
+    return ""
+
+
+def _stable_signature(state: StateVector, decision: str, reason: str, findings: list[str]) -> str:
+    payload = {
+        "state": asdict(state),
+        "decision": decision,
+        "reason": reason,
+        "findings": findings,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def evaluate_fleet_move(
+    move_packet: dict[str, Any],
+    *,
+    posture: FleetPostureState | None = None,
+    authority: FleetAuthority | None = None,
+) -> dict[str, Any]:
+    """Evaluate one agent move under fleet-grade command authority rules."""
+    posture = posture or FleetPostureState()
+    authority = authority or FleetAuthority()
+    command = _command_from_move(move_packet)
+    op_class = classify_operation(command, move_packet)
+    required_clearance = _CLEARANCE_BY_OPERATION[op_class]
+    quorum_required = _POSTURE_QUORUM[posture.posture][op_class]
+    quorum_observed = _unique_quorum(authority.approved_by)
+    bft_min_nodes = _bft_min_nodes(posture.byzantine_faults_tolerated)
+    command_hash = hashlib.sha256(command.encode("utf-8")).hexdigest()
+    move_id = str(move_packet.get("move_id") or command_hash[:16])
+
+    findings: list[str] = []
+    decision = FleetDecision.ALLOW
+    reason = "fleet_gate_clear"
+
+    if not command:
+        decision = FleetDecision.DENY
+        reason = "missing_command"
+        findings.append("move packet did not contain a translated command")
+    if not move_packet.get("round_trip_ok", False):
+        decision = FleetDecision.DENY
+        reason = "move_packet_not_bijective"
+        findings.append("move packet failed Sacred Tongue transport round trip")
+    if any(re.search(pattern, command, re.IGNORECASE) for pattern in _SECRET_PATTERNS):
+        decision = FleetDecision.DENY
+        reason = "secret_material_in_command"
+        findings.append("command appears to carry secret material")
+    if posture.fleet_size < bft_min_nodes:
+        decision = FleetDecision.ESCALATE if decision == FleetDecision.ALLOW else decision
+        reason = "insufficient_bft_fleet_size" if decision == FleetDecision.ESCALATE else reason
+        findings.append(f"fleet_size={posture.fleet_size} below bft_min_nodes={bft_min_nodes}")
+    if authority.clearance < required_clearance:
+        decision = FleetDecision.ESCALATE if decision == FleetDecision.ALLOW else decision
+        reason = "insufficient_clearance" if decision == FleetDecision.ESCALATE else reason
+        findings.append(f"clearance={authority.clearance} below required={required_clearance}")
+    if quorum_required >= 999:
+        if not (authority.emergency_rollback and authority.human_confirmed and quorum_observed >= 4):
+            decision = FleetDecision.DENY
+            reason = "destructive_move_not_authorized"
+            findings.append("destructive commands require emergency rollback, human confirmation, and 4 approvals")
+    elif quorum_observed < quorum_required:
+        decision = FleetDecision.ESCALATE if decision == FleetDecision.ALLOW else decision
+        reason = "quorum_not_met" if decision == FleetDecision.ESCALATE else reason
+        findings.append(f"quorum={quorum_observed} below required={quorum_required}")
+    if posture.degraded_comms and op_class in {OperationClass.DEPLOY, OperationClass.NETWORK}:
+        decision = FleetDecision.QUARANTINE if decision == FleetDecision.ALLOW else decision
+        reason = "degraded_comms_blocks_remote_move" if decision == FleetDecision.QUARANTINE else reason
+        findings.append("degraded comms forbids remote/network/deploy moves")
+
+    state = StateVector(
+        schema_version=SCHEMA_VERSION,
+        operation_class=op_class.value,
+        posture=posture.posture.value,
+        clearance=authority.clearance,
+        required_clearance=required_clearance,
+        quorum_observed=quorum_observed,
+        quorum_required=quorum_required,
+        bft_min_nodes=bft_min_nodes,
+        fleet_size=posture.fleet_size,
+        degraded_comms=posture.degraded_comms,
+        fail_closed=True,
+        move_id=move_id,
+        command_hash=command_hash,
+    )
+    signature = _stable_signature(state, decision.value, reason, findings)
+    confidence = 0.98 if decision == FleetDecision.ALLOW else 0.93
+    if findings:
+        confidence = max(0.70, confidence - (0.03 * math.log1p(len(findings))))
+    record = DecisionRecord(
+        decision=decision.value,
+        reason=reason,
+        timestamp=time.time(),
+        signature=signature,
+        confidence=round(confidence, 4),
+        findings=findings,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "state_vector": asdict(state),
+        "decision_record": asdict(record),
+    }
+
+
+def posture_from_dict(data: dict[str, Any] | None) -> FleetPostureState:
+    data = data or {}
+    return FleetPostureState(
+        posture=FleetPosture(str(data.get("posture", FleetPosture.TRAINING.value))),
+        fleet_size=int(data.get("fleet_size", 1)),
+        byzantine_faults_tolerated=int(data.get("byzantine_faults_tolerated", 0)),
+        degraded_comms=bool(data.get("degraded_comms", False)),
+        offline_mode=bool(data.get("offline_mode", True)),
+    )
+
+
+def authority_from_dict(data: dict[str, Any] | None) -> FleetAuthority:
+    data = data or {}
+    return FleetAuthority(
+        actor_id=str(data.get("actor_id", "unknown")),
+        clearance=int(data.get("clearance", 0)),
+        approved_by=[str(actor) for actor in data.get("approved_by", [])],
+        human_confirmed=bool(data.get("human_confirmed", False)),
+        emergency_rollback=bool(data.get("emergency_rollback", False)),
+    )
+
+
+__all__ = [
+    "FleetAuthority",
+    "FleetDecision",
+    "FleetPosture",
+    "FleetPostureState",
+    "OperationClass",
+    "classify_operation",
+    "evaluate_fleet_move",
+    "posture_from_dict",
+    "authority_from_dict",
+]

--- a/tests/agentic/test_fleet_governance.py
+++ b/tests/agentic/test_fleet_governance.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.system.agent_move_packet import build_packet
+from src.agentic.fleet_governance import (
+    FleetAuthority,
+    FleetPosture,
+    FleetPostureState,
+    OperationClass,
+    classify_operation,
+    evaluate_fleet_move,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _move_packet(command: str) -> dict:
+    return build_packet(
+        {
+            "move": {
+                "cmd": command,
+                "translated": command,
+                "turn": 1,
+                "objective": "fleet gate test",
+                "path_policy": "non_optimal_correct",
+            },
+            "governance": {"decision": "ALLOW", "reason": "test"},
+        }
+    )
+
+
+def test_observe_move_allowed_in_mission_critical_when_bft_size_is_valid() -> None:
+    packet = _move_packet("ls docs")
+
+    out = evaluate_fleet_move(
+        packet,
+        posture=FleetPostureState(
+            posture=FleetPosture.MISSION_CRITICAL,
+            fleet_size=4,
+            byzantine_faults_tolerated=1,
+            offline_mode=True,
+        ),
+        authority=FleetAuthority(actor_id="codex", clearance=0),
+    )
+
+    assert out["state_vector"]["operation_class"] == "observe"
+    assert out["decision_record"]["decision"] == "ALLOW"
+    assert out["state_vector"]["fail_closed"] is True
+    assert out["decision_record"]["signature"]
+
+
+def test_deploy_move_escalates_without_quorum_in_production() -> None:
+    packet = _move_packet("git push origin main")
+
+    out = evaluate_fleet_move(
+        packet,
+        posture=FleetPostureState(posture=FleetPosture.PRODUCTION, fleet_size=4, byzantine_faults_tolerated=1),
+        authority=FleetAuthority(actor_id="agent-a", clearance=2, approved_by=["agent-a"]),
+    )
+
+    assert out["state_vector"]["operation_class"] == "deploy"
+    assert out["state_vector"]["quorum_required"] == 3
+    assert out["decision_record"]["decision"] == "ESCALATE"
+    assert out["decision_record"]["reason"] == "quorum_not_met"
+
+
+def test_destructive_move_denied_even_with_normal_clearance() -> None:
+    packet = _move_packet("rm -rf artifacts/cache")
+
+    out = evaluate_fleet_move(
+        packet,
+        posture=FleetPostureState(posture=FleetPosture.PRODUCTION, fleet_size=7, byzantine_faults_tolerated=2),
+        authority=FleetAuthority(actor_id="agent-a", clearance=4, approved_by=["a", "b", "c"]),
+    )
+
+    assert out["state_vector"]["operation_class"] == "destructive"
+    assert out["decision_record"]["decision"] == "DENY"
+    assert out["decision_record"]["reason"] == "destructive_move_not_authorized"
+
+
+def test_degraded_comms_quarantines_network_move() -> None:
+    packet = _move_packet("curl https://example.com/health")
+
+    out = evaluate_fleet_move(
+        packet,
+        posture=FleetPostureState(posture=FleetPosture.CANARY, fleet_size=4, degraded_comms=True),
+        authority=FleetAuthority(actor_id="agent-a", clearance=1, approved_by=["agent-a"]),
+    )
+
+    assert out["state_vector"]["operation_class"] == "network"
+    assert out["decision_record"]["decision"] == "QUARANTINE"
+    assert out["decision_record"]["reason"] == "degraded_comms_blocks_remote_move"
+
+
+def test_secret_material_in_command_is_denied() -> None:
+    packet = _move_packet("curl -H 'Authorization: Bearer abc123' https://example.com")
+
+    out = evaluate_fleet_move(packet, authority=FleetAuthority(clearance=4, approved_by=["a", "b", "c", "d"]))
+
+    assert out["decision_record"]["decision"] == "DENY"
+    assert out["decision_record"]["reason"] == "secret_material_in_command"
+
+
+def test_classify_operation_falls_back_to_move_packet_atomic_roles() -> None:
+    packet = _move_packet("custom-tool --dry-run")
+    packet["atomic_units"][0]["role"] = "measure"
+
+    assert classify_operation("custom-tool --dry-run", packet) == OperationClass.MEASURE
+
+
+def test_cli_accepts_move_payload_and_emits_state_vector() -> None:
+    payload = {
+        "move": {
+            "cmd": "npm test",
+            "translated": "npm test",
+            "objective": "verify fleet gate",
+            "turn": 1,
+        },
+        "governance": {"decision": "ALLOW", "reason": "test"},
+        "posture": {"posture": "training", "fleet_size": 1},
+        "authority": {"actor_id": "codex", "clearance": 0},
+    }
+    proc = subprocess.run(
+        [sys.executable, "scripts/system/fleet_governance_gate.py"],
+        cwd=REPO_ROOT,
+        input=json.dumps(payload),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    out = json.loads(proc.stdout)
+    assert out["ok"] is True
+    assert out["state_vector"]["operation_class"] == "measure"
+    assert out["decision_record"]["decision"] == "ALLOW"


### PR DESCRIPTION
## Summary
- Adds a deterministic fleet governance gate after SCBE agent move packets.
- Classifies commands as observe/measure/modify/network/deploy/destructive and evaluates posture, clearance, quorum, BFT fleet size, degraded comms, secret leakage, and bijective packet validity.
- Emits `StateVector` and `DecisionRecord` for fleet-grade command authority receipts.
- Wires `scbe shell --agent-json` responses to include `fleet_governance` alongside `move_packet`, with optional `fleet_posture` and `fleet_authority` fields from the caller.
- Documents the boundary: this is not a military certification or deployment approval by itself.

## Tests
- `python -m black --check --target-version py311 --line-length 120 src/agentic/fleet_governance.py scripts/system/fleet_governance_gate.py tests/agentic/test_fleet_governance.py`
- `python -m ruff check --config ruff.toml src/agentic/fleet_governance.py scripts/system/fleet_governance_gate.py tests/agentic/test_fleet_governance.py`
- `npx prettier --check packages/cli/bin/scbe.js packages/cli/scripts/shell_benchmark.cjs`
- `python -m pytest tests/agentic/test_fleet_governance.py tests/system/test_agent_move_packet.py -q` -> 9 passed
- `node --check packages/cli/bin/scbe.js; node --check packages/cli/scripts/shell_benchmark.cjs`
- `node packages/cli/scripts/shell_benchmark.cjs` -> 22/22, 100%

## Rollback
Revert commit `504ebfcc7` to remove the fleet gate and restore agent-json responses to GeoSeal + move packet only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced fleet governance gate that evaluates agent moves for operability, clearance, quorum, and fleet state before execution
  * CLI now includes fleet governance metadata and decision records in command responses

* **Documentation**
  * Added comprehensive fleet governance gate specification document

* **Tests**
  * Added test coverage for governance evaluation logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->