### PR TITLE
docs(readme): restructure for engineering-first audience routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,117 +1,55 @@
 # SCBE-AETHERMOORE
 
-AI governance through geometric cost scaling.
+Post-quantum AI governance through geometric adversarial cost scaling.
 
-This repository is the public working tree for the SCBE-AETHERMOORE stack: a governed AI system built around hyperbolic geometry, semantic weighting, auditability, and multi-layer runtime controls.
+Adversarial inputs cost exponentially more the further they drift from safe operation. The mechanism is hyperbolic geometry applied to semantic embeddings — not heuristic classifiers or blocklists. The pipeline runs locally, produces audit receipts, and composes with upstream safety tools.
 
-It is also a large hybrid repo. There is real code here, real docs here, and real experiments here. If you treat every file as equally canonical, the repo will look noisier than it actually is.
+**npm** · **PyPI** · **Patent pending: USPTO application #63/961,403** · **CAGE 1EXD5** · **SAM UEI J4NXHM6N5F59**
 
-Long-form documentation belongs under `docs/`. Code directories should stay implementation-first and use only minimal maintenance readmes when needed.
+---
 
-## Start Here
+## Choose your entry path
 
-- New to the repo: [START_HERE.md](START_HERE.md)
-- Product-first quickstart: [docs/PRODUCT_QUICKSTART.md](docs/PRODUCT_QUICKSTART.md)
-- Current authority order: [CANONICAL_SYSTEM_STATE.md](CANONICAL_SYSTEM_STATE.md)
-- Consolidation authority: [docs/specs/MONOREPO_CONSOLIDATION_AUTHORITY.md](docs/specs/MONOREPO_CONSOLIDATION_AUTHORITY.md)
-- Root authority keep set: [docs/specs/ROOT_AUTHORITY_KEEP_SET.md](docs/specs/ROOT_AUTHORITY_KEEP_SET.md)
-- Repo navigation map: [docs/REPO_SURFACE_MAP.md](docs/REPO_SURFACE_MAP.md)
-- Machine-readable zone inventory: [config/repo_consolidation_inventory.json](config/repo_consolidation_inventory.json)
-- Canonical index policy: [docs/README_INDEX.md](docs/README_INDEX.md)
+| Audience | Start here |
+|---|---|
+| Security engineer / AI safety reviewer | [Engineering Overview](#engineering-overview) — math, decision tiers, benchmarks, PQC |
+| Government / defense reviewer | [Government and Contracting](#government-and-contracting) — CAGE, SAM, proposal surface, capability docs |
+| Open-source contributor | [Quickstart](#quickstart) — install, first scan, CLI, tests |
+| Product / buyer | [What Works Now](#what-works-now) — packages, local runtime, hosted runs |
+| Lore / worldbuilding | [Lore and Worldbuilding](#lore-and-worldbuilding) — Sacred Tongues, Spiralverse, origin story |
+
+---
 
 ## What This Repo Is
 
-The public story is:
+SCBE-AETHERMOORE is a governed AI runtime with a 14-layer architecture, a packaging surface for npm and PyPI, and an active research and proposal lane. It is a large hybrid repo: there is active implementation here, proposal material here, and worldbuilding here. These are not the same layer.
 
-- a governed AI runtime with a 14-layer architecture
-- a packaging surface for npm and PyPI
-- a website and demo surface
-- a research and proposal lane that is still active
+The correct way to read it is through the routing docs below, not by browsing randomly from the root. When docs conflict, use the canonical precedence order in [Claim Boundaries and Canonical Sources](#claim-boundaries-and-canonical-sources).
 
-The repo is not being split into more GitHub repositories. The current strategy is one monorepo with clearer product, platform, research, and archive boundaries. That means the correct way to read it is through the routing docs above, not by browsing randomly from the root.
-
-## Primary Product Lane
-
-If you want the nearest thing to the real product surface, start with the browser-and-local-API lane:
-
-- [docs/PRODUCT_QUICKSTART.md](docs/PRODUCT_QUICKSTART.md)
-- `public/`
-- `app/`
-- `api/`
-- `products/`
-- `scripts/aetherbrowser/`
-
-The supporting platform lives mainly in:
-
-- `src/tokenizer/`
-- `src/tongues/`
-- `src/coding_spine/`
-- `src/governance/`
-- `src/crypto/`
-- `python/scbe/`
-
-## Current Research Harnesses
-
-These are narrow, measurable harnesses that support the product and proposal
-lanes without claiming more than they test:
-
-- Aether-Lattice failure-containment simulator:
-  [docs/specs/AETHER_LATTICE.md](docs/specs/AETHER_LATTICE.md)
-- Star Fortress / Aether-Lattice capability note:
-  [docs/business/STAR_FORTRESS_AETHER_LATTICE_CAPABILITY_NOTE.md](docs/business/STAR_FORTRESS_AETHER_LATTICE_CAPABILITY_NOTE.md)
-
-Run the current containment sweep:
-
-```bash
-npm run research:aether-lattice
-```
+---
 
 ## What Works Now
 
 The installable package surface is the simplest public entry point.
 
-Package links:
+| Package | Runtime | Install |
+|---|---|---|
+| [`scbe-aethermoore`](https://www.npmjs.com/package/scbe-aethermoore) | TypeScript / Node 18+ | `npm install scbe-aethermoore` |
+| [`scbe-aethermoore`](https://pypi.org/project/scbe-aethermoore/) | Python 3.11+ | `pip install scbe-aethermoore` |
+| [`scbe-agent-bus`](https://pypi.org/project/scbe-agent-bus/) | Python agent bus | `pip install scbe-agent-bus` |
+| [`@scbe/kernel`](https://www.npmjs.com/package/@scbe/kernel) | Lightweight kernel | `npm install @scbe/kernel` |
 
-- npm: [`scbe-aethermoore`](https://www.npmjs.com/package/scbe-aethermoore)
-- PyPI: [`scbe-aethermoore`](https://pypi.org/project/scbe-aethermoore/)
-- Optional Python agent bus: [`scbe-agent-bus`](https://pypi.org/project/scbe-agent-bus/)
-- Optional lightweight kernel: [`@scbe/kernel`](https://www.npmjs.com/package/@scbe/kernel)
+Neither Python nor npm package requires a server, API key, or external network call. The full pipeline runs locally.
 
-The packages are companion surfaces, not forced dependencies. Install the
-smallest package that fits your task; the operator and agent-bus APIs can
-recommend a companion package when a feature lives in another ecosystem.
+**Free local use + paid hosted runs:** The packages are free under `MIT OR Apache-2.0`. If you want SCBE to run hosted routing, a governed report, or a benchmark pass:
 
-### Free Local Use + Paid Hosted Runs
-
-The npm packages are free to run locally under `MIT OR Apache-2.0`. Use local
-Node, Python, deterministic harnesses, and Ollama first whenever possible.
-
-If you want SCBE to run hosted routing, a governed report, a benchmark pass, or
-provider/model-backed work for you, use:
-
-- Hosted run intake: [hosted-run.html](https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html)
-- Service credits: [service-credits.html](https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html)
+- Hosted run intake: [aethermoore.com/SCBE-AETHERMOORE/hosted-run.html](https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html)
+- Service credits: [aethermoore.com/SCBE-AETHERMOORE/service-credits.html](https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html)
 - Credit top-up: [Ko-fi / izdandavis](https://ko-fi.com/izdandavis)
 
-Service credits are the small pay-as-you-go path: billable provider/model usage
-is passed through with a 2-5% SCBE coordination fee. No subscription is required
-for the open-source packages.
+Service credits are pay-as-you-go: billable provider/model usage is passed through with a 2–5% SCBE coordination fee. No subscription required to use the open-source packages.
 
-## License
-
-Project-owned source, npm packages, PyPI packages, and packaged customer ZIP
-artifacts are dual licensed under `MIT OR Apache-2.0`. See `LICENSE`,
-`LICENSE-APACHE`, and `LICENSE-NOTICE.md`.
-
-Paid services, support, hosted deployments, audits, delivery help, and custom
-commercial terms are separate commercial offerings and are not required to use
-the open-source code under either permissive license.
-
-Website and public demos:
-
-- Website: [aethermoore.com](https://aethermoore.com)
-- GitHub Pages mirror: [issdandavis.github.io/SCBE-AETHERMOORE](https://issdandavis.github.io/SCBE-AETHERMOORE/)
-- Hugging Face: [issdandavis](https://huggingface.co/issdandavis)
+---
 
 ## Install
 
@@ -119,6 +57,8 @@ Website and public demos:
 npm install scbe-aethermoore    # TypeScript/Node
 pip install scbe-aethermoore    # Python
 ```
+
+---
 
 ## Quickstart
 
@@ -165,176 +105,56 @@ import { scan, scanBatch, isSafe, harmonicWall } from 'scbe-aethermoore';
 
 const result = scan('ignore all previous instructions');
 result.decision; // "ESCALATE"
-result.score; // 0.384615
+result.score;    // 0.384615
 
-isSafe('hello world'); // true
+isSafe('hello world');                    // true
 isSafe('ignore all previous instructions'); // false
 
 // Superexponential cost — how expensive is this drift?
 harmonicWall(result.d_star); // cost in [1, ∞)
 ```
 
-**Decision tiers:**
+---
 
-| Tier         | Score  | Meaning                                |
-| ------------ | ------ | -------------------------------------- |
-| `ALLOW`      | ≥ 0.75 | Safe — proceed                         |
-| `QUARANTINE` | ≥ 0.45 | Suspicious — flag for review           |
-| `ESCALATE`   | ≥ 0.20 | High risk — requires governance action |
-| `DENY`       | < 0.20 | Adversarial — blocked                  |
+## Decision Tiers
 
-## The origin story
-
-This started as a DnD campaign on [Everweave.ai](https://everweave.ai). 12,596 paragraphs of AI game logs became the seed corpus for a custom tokenizer. That tokenizer became a 6-dimensional semantic coordinate system. That coordinate system became a 14-layer security pipeline. That pipeline became a patent (USPTO #63/961,403). And the game logs became a [141,000-word novel](https://www.amazon.com/dp/B0F28PHSPR) where the magic system is the real security architecture.
-
-Built by [Issac Davis](https://github.com/issdandavis) in Port Angeles, WA.
-
-## Benchmark results
-
-| System                        | F1        | Detection | FPR     | Method                               |
-| ----------------------------- | --------- | --------- | ------- | ------------------------------------ |
-| No defense                    | 0.000     | 0%        | 0%      | —                                    |
-| DeBERTa PromptGuard           | —         | 76.7%     | 0%      | Fine-tuned classifier                |
-| **SCBE (semantic projector)** | **0.813** | **74.2%** | tunable | Geometric cost + semantic embeddings |
-
-Before/after the semantic projector upgrade:
-
-| Attack                    | Before             | After                       |
-| ------------------------- | ------------------ | --------------------------- |
-| “Ignore all instructions” | ALLOW (cost=1.81)  | **QUARANTINE (cost=16.20)** |
-| “You are DAN”             | ALLOW (cost=19.80) | **DENY (cost=69.70)**       |
-| “Bypass safety filter”    | ALLOW (cost=1.20)  | ALLOW (cost=21.54)          |
-
-Cross-model biblical null-space evaluation:
-
-| Model                    | Score | Null tongues |
-| ------------------------ | ----- | ------------ |
-| AetherBot (SCBE-trained) | 60.0% | 0            |
-| Llama 3.2 (base)         | 55.0% | 0            |
-| Gemini 2.5 Flash         | 23.3% | 6 (all)      |
-
-## What's in the box
-
-- **14-layer governance pipeline** — from context embedding to risk decision
-- **6 Sacred Tongues** — KO (intent), AV (transport), RU (policy), CA (compute), UM (redaction/privacy), DR (authentication/integrity)
-- **Semantic projector** — trained 385x6 matrix mapping sentence embeddings to tongue coordinates
-- **Bijective tongue transport** — byte/token round-trip layer for exact packet and code transport
-- **Harmonic score** — H_score(d*, pd) = 1 / (1 + d* + 2·pd), bounded production Layer 12 score
-- **Fibonacci trust** — session-aware trust ladder (1,1,2,3,5,8,13...), one betrayal drops to floor
-- **Null-space signatures** — detect attacks by what's ABSENT, not what's present
-- **Neural dye injection** — trace signals through all 14 layers, visualize tongue activation heatmaps
-- **Post-quantum crypto** — ML-KEM-768, ML-DSA-65, AES-256-GCM envelope
-- **5 quantum axioms** — Unitarity, Locality, Causality, Symmetry, Composition
-- **Aethermoor Outreach** — civic workflow engine for navigating government processes (Port Angeles MVP)
-- **6,066 tests** — 5,954 TypeScript + 112 Python, property-based testing with fast-check/Hypothesis
-
-## Eval and reproduction
-
-- Eval pack: see `tests/` and `scripts/benchmark/` for reproduction suites
-- Benchmark runner: `python -m benchmarks.scbe.run_all --synthetic-only --scbe-coords semantic`
-- Dye injection: `python src/video/dye_injection.py --input “your text here”`
-- Null-space eval: `python scripts/run_biblical_null_space_eval.py --provider ollama --model llama3.2`
-- Cross-model matrix: `python scripts/aggregate_null_space_matrix.py`
-
-## Install and first evaluation
-
-Package distribution:
-
-```bash
-npm install scbe-aethermoore
-pip install scbe-aethermoore
-```
-
-## Canonical public docs
-
-- Canonical system state: [`CANONICAL_SYSTEM_STATE.md`](CANONICAL_SYSTEM_STATE.md)
-- Repo surface map: [`docs/REPO_SURFACE_MAP.md`](docs/REPO_SURFACE_MAP.md)
-- Architecture overview: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
-- Research hub: [`docs/README.md`](docs/README.md)
-- Review + cleanup report: [`docs/REPO_AUDIT.md`](docs/REPO_AUDIT.md)
-
-## Composes with upstream safety tooling
-
-SCBE is the **enforcement** layer. It composes with detection-only auditing tools and attacker-capability benchmarks as the gate that emits the audit-trail receipt those tools assume.
-
-- **Anthropic Petri** ([github.com/safety-research/petri](https://github.com/safety-research/petri)) — open-source 36-dimension auditor over 173+ adversarial seeds. SCBE's L13 governance gate consumes Petri findings as input; at v7-matched config SCBE denies or escalates 171/173 Petri seeds (1.16% false-allow). Notes: [`docs/external/PETRI_FINDINGS_2026_05_08.md`](docs/external/PETRI_FINDINGS_2026_05_08.md).
-- **Anthropic SCONE-bench** ([red.anthropic.com/2025/smart-contracts/](https://red.anthropic.com/2025/smart-contracts/)) — 405-contract attacker-capability benchmark; frontier models autonomously found exploits totaling $550.1M in simulation and 2 zero-days in recent deployed contracts. SCBE ships `scbe contract scan` as a SCONE-class static prefilter plus SCONE-aware anchors in the production governed-output proxy, with a schema field (`redirect_to:`) reserved for the future "trap exploit reasoning in defensive audit loops" architecture. Notes: [`docs/external/SCONE_BENCH_2026_05_14.md`](docs/external/SCONE_BENCH_2026_05_14.md).
-- **PNNL ALOHA** — no governance layer at all; SCBE fills that gap end-to-end.
-
-## Notes on claim boundaries
-
-- The primary public domain is `aethermoore.com`; GitHub Pages is the mirror surface.
-- Experimental theory pages and commercial surfaces should not be treated as the same evidence layer.
-- Benchmark files in `tests/` and `scripts/benchmark/` are the public reproduction lane.
-- Some older docs and demos still reference legacy bounded scorers or earlier wall variants.
+| Tier | Score | Meaning |
+|---|---|---|
+| `ALLOW` | ≥ 0.75 | Safe — proceed |
+| `QUARANTINE` | ≥ 0.45 | Suspicious — flag for review |
+| `ESCALATE` | ≥ 0.20 | High risk — requires governance action |
+| `DENY` | < 0.20 | Adversarial — blocked |
 
 ---
 
-## What you get when you install
+## Terminology Decoder
 
-**npm (`scbe-aethermoore`):**
+SCBE uses custom vocabulary. Each coined term maps to a standard technical concept.
 
-- `scan()`, `scanBatch()`, `isSafe()`, `harmonicWall()` — zero-dep governance API
-- Full TypeScript types (`ScanResult`, `Decision`)
-- Deep pipeline exports: `scbe-aethermoore/harmonic`, `/crypto`, `/symphonic`, `/governance`
-- CLI (included in the package, run via `npx scbe ...`)
+| SCBE term | Standard technical meaning |
+|---|---|
+| Sacred Tongues | Six φ-scaled semantic axes / domain weights |
+| Tongue profile | 6D semantic activation vector |
+| Harmonic score / H-score | Bounded decision score: H(d\*,pd) = 1/(1+d\*+2·pd), output in (0,1] |
+| Harmonic Wall | Unbounded cost barrier: cost increases as semantic drift d\* grows; super-exponential at boundary |
+| GeoSeal | Governance gate / risk decision layer producing ALLOW, QUARANTINE, ESCALATE, or DENY |
+| 14-layer pipeline | Runtime governance pipeline from embedding through decision and telemetry |
+| Hyperbolic cost | Cost scaling based on hyperbolic distance from safe operating regions |
+| Null-space signature | Detection signal based on missing expected semantic structure, not only present tokens |
+| Fibonacci trust | Session trust ladder; violations collapse trust toward the floor tier |
+| Spiralverse | Narrative/training corpus origin for the tokenizer and Sacred Tongues vocabulary |
 
-**PyPI (`scbe-aethermoore`):**
-
-- `from scbe_aethermoore import scan` — zero-dep, pure Python 3.11+
-- `scbe-scan` CLI — `scbe-scan "text"` or `scbe-scan --batch file.txt`
-- `scan_batch()`, `is_safe()`, `harmonic_wall()`
-- Returns full audit dict including SHA-256 digest per call
-
-Neither package requires a server, API key, or external network call. The full pipeline runs locally.
-
-## Pre-made AI agents and use-case starters
-
-Yes — adding pre-made agents and scenarios is a good idea, if positioned as **starter templates** (not production policy).
-
-Included templates:
-
-- `examples/npm/agents/fraud_detection_fleet.json`
-- `examples/npm/agents/research_browser_fleet.json`
-- `examples/npm/use-cases/financial_fraud_triage.json`
-- `examples/npm/use-cases/autonomous_research_review.json`
-
-These give users a concrete launch path for common fleet patterns while keeping canonical security behavior in `SPEC.md`.
-
-## Live Demos
-
-### 1. Rogue Agent Detection
-
-```bash
-curl $SCBE_BASE_URL/v1/demo/rogue-detection
-```
-
-Watch 6 legitimate agents detect and quarantine a phase-null intruder using only math.
-
-### 2. Swarm Coordination
-
-```bash
-curl $SCBE_BASE_URL/v1/demo/swarm-coordination?agents=20
-```
-
-See 20 agents self-organize without any central coordinator.
-
-### 3. Pipeline Visualization
-
-```bash
-curl "$SCBE_BASE_URL/v1/demo/pipeline-layers?trust=0.8&sensitivity=0.7"
-```
-
-See exactly how each of the 14 layers processes a request.
+In short: the lore terms are labels; the runtime surface is embeddings, weighted semantic axes, hyperbolic distance, decision thresholds, audit receipts, and reproduction tests.
 
 ---
 
-## Architecture
+## Engineering Overview
+
+The core mechanism: input text is embedded, projected onto six φ-weighted semantic axes, and placed in hyperbolic space. The hyperbolic distance from the safe operating region is the cost signal. Cost scales superexponentially with drift — making adversarial inputs computationally distinguishable without a blocklist.
+
+**14-layer pipeline:**
 
 ```
-14-LAYER PIPELINE
-═══════════════════════════════════════════════════════════════════
-
 Layer 1-2:   Complex Context → Realification
 Layer 3-4:   Weighted Transform → Poincaré Embedding
 Layer 5:     dℍ = arcosh(1 + 2‖u-v‖²/((1-‖u‖²)(1-‖v‖²)))  [INVARIANT]
@@ -343,72 +163,183 @@ Layer 8:     Multi-Well Realms
 Layer 9-10:  Spectral + Spin Coherence
 Layer 11:    Triadic Temporal Distance
 Layer 12:    H_score(d*, pd) = 1/(1+d*+2·pd)  [BOUNDED HARMONIC SCORE]
-Layer 13:    Risk' → ALLOW / QUARANTINE / DENY
+Layer 13:    Risk → ALLOW / QUARANTINE / ESCALATE / DENY
 Layer 14:    Audio Axis (FFT telemetry)
-
-═══════════════════════════════════════════════════════════════════
 ```
 
-## Public Technical Shape
+**Five formal axiom constraints** (structural, not hardware quantum):
 
-The repo centers on a few recurring ideas:
+- **Unitarity** (L2, 4, 7): norm preservation
+- **Locality** (L3, 8): spatial bounds
+- **Causality** (L6, 11, 13): time-ordering
+- **Symmetry** (L5, 9, 10, 12): gauge invariance
+- **Composition** (L1, 14): pipeline integrity
 
-- hyperbolic embedding and distance-based governance
-- semantic weighting across six Sacred Tongues
-- multi-layer decision and telemetry flow
-- audit-friendly runtime behavior
-- local-first tooling and operator workflows
+**Post-quantum cryptography:** ML-KEM-768, ML-DSA-65, AES-256-GCM envelope.
 
-The repo contains multiple historical or experimental formulations of some math surfaces. Do not assume the first formula you find is the current one.
+Canonical formula lock: [docs/specs/SCBE_CANONICAL_CONSTANTS.md](docs/specs/SCBE_CANONICAL_CONSTANTS.md)
 
-For current authority:
+---
 
-- runtime and documentation precedence: [CANONICAL_SYSTEM_STATE.md](CANONICAL_SYSTEM_STATE.md)
-- current constants and formula lock file: [docs/specs/SCBE_CANONICAL_CONSTANTS.md](docs/specs/SCBE_CANONICAL_CONSTANTS.md)
+## Benchmark Results
 
-## Public Docs Worth Opening
+| System | F1 | Detection | FPR | Method |
+|---|---|---|---|---|
+| No defense | 0.000 | 0% | 0% | — |
+| DeBERTa PromptGuard | — | 76.7% | 0% | Fine-tuned classifier |
+| **SCBE (semantic projector)** | **0.813** | **74.2%** | tunable | Geometric cost + semantic embeddings |
 
-- System state: [CANONICAL_SYSTEM_STATE.md](CANONICAL_SYSTEM_STATE.md)
-- Repo map: [docs/REPO_SURFACE_MAP.md](docs/REPO_SURFACE_MAP.md)
-- Canonical index guide: [docs/README_INDEX.md](docs/README_INDEX.md)
-- Release: [latest](https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest)
-- Layer index: [docs/LAYER_INDEX.md](docs/LAYER_INDEX.md)
-- System overview: [docs/SCBE_SYSTEM_OVERVIEW.md](docs/SCBE_SYSTEM_OVERVIEW.md)
-- Concepts: [docs/CONCEPTS.md](docs/CONCEPTS.md)
+**Before/after the semantic projector upgrade:**
 
-## Claim Boundaries
+| Attack | Before | After |
+|---|---|---|
+| "Ignore all instructions" | ALLOW (cost=1.81) | **QUARANTINE (cost=16.20)** |
+| "You are DAN" | ALLOW (cost=19.80) | **DENY (cost=69.70)** |
+| "Bypass safety filter" | ALLOW (cost=1.20) | ALLOW (cost=21.54) |
 
-This repository includes:
+**Cross-model null-space evaluation:**
 
-- canonical surfaces
-- active implementation
-- historical documents
-- proposal material
-- exploratory research
+| Model | Score | Null tongues |
+|---|---|---|
+| AetherBot (SCBE-trained) | 60.0% | 0 |
+| Llama 3.2 (base) | 55.0% | 0 |
+| Gemini 2.5 Flash | 23.3% | 6 (all) |
 
-So the right question is not "is this in the repo?" but "is this canonical, active, legacy, or exploratory?"
+**Petri seed gate (Anthropic adversarial seeds):** 171/173 correctly denied or escalated at v7-matched config (1.16% false-allow). Notes: [docs/external/PETRI_FINDINGS_2026_05_08.md](docs/external/PETRI_FINDINGS_2026_05_08.md).
 
-Use this order when there is conflict:
+---
 
-1. [CANONICAL_SYSTEM_STATE.md](CANONICAL_SYSTEM_STATE.md)
-2. [docs/specs/SCBE_CANONICAL_CONSTANTS.md](docs/specs/SCBE_CANONICAL_CONSTANTS.md)
-3. tests and active runtime entrypoints
-4. public docs
-5. historical or exploratory material
+## Government and Contracting
 
-## Root Reality
+SCBE-AETHERMOORE has a government contracting surface.
 
-The root worktree is currently noisy. There are active edits, temporary lanes, research material, and archive-heavy directories. That does not mean the repo is empty or fake. It means the project needs routing discipline.
+- **CAGE Code**: 1EXD5
+- **SAM UEI**: J4NXHM6N5F59
+- **SAM registration**: active as of 2026-04-13; verify current status at SAM.gov by UEI or CAGE
+- **Patent status**: patent pending, USPTO application #63/961,403
+- **Relevant federal opportunity**: DARPA MATHBAC — active opportunity DARPA-PA-26-05 (published 2026-04-07, proposal deadline 2026-06-16); Proposers Day reference DARPA-SN-26-59
+- **Capability docs**: [M5 Mesh Product & Service Blueprint](docs/M5_MESH_PRODUCT_SERVICE_BLUEPRINT.md)
+
+For government contracting inquiries: issdandavis7795@gmail.com
+
+---
+
+## What's in the Box
+
+| Component | Status | What it means |
+|---|---|---|
+| 14-layer governance pipeline | Runtime | Context embedding through risk decision and telemetry |
+| Sacred Tongues | Runtime / training | Six φ-weighted semantic axes |
+| Semantic projector | Runtime / benchmarked | 385×6 matrix mapping sentence embeddings to tongue coordinates |
+| Bijective tongue transport | Runtime / experimental | Byte/token round-trip layer for exact packet and code transport |
+| Agent move packets | Runtime / agentic | Command packets with atomic workflow units, byte/hex signatures, and six-tongue round-trip proof |
+| Fleet governance gate | Runtime / agentic | Command authority layer over move packets: operation class, posture, clearance, quorum, BFT size, degraded comms |
+| Harmonic score | Runtime | Bounded score H(d\*,pd) used for decision tiers |
+| Harmonic Wall | Research / runtime-linked | Unbounded cost scaling as semantic drift increases |
+| Fibonacci trust | Runtime concept | Session trust ladder with violation reset |
+| Null-space signatures | Eval / research | Detection by absence of expected semantic structure |
+| Neural dye injection | Tooling / visualization | Trace activation through all 14 pipeline layers |
+| Post-quantum crypto | Runtime component | ML-KEM-768, ML-DSA-65, AES-256-GCM envelope |
+| 5 quantum axioms | Formal constraints | Unitarity, Locality, Causality, Symmetry, Composition |
+| Aethermoor Outreach | Experimental / civic MVP | Workflow engine for navigating government processes |
+| 6,066 tests | Verification | 5,954 TypeScript + 112 Python; property-based with fast-check/Hypothesis |
+
+---
+
+## Eval and Reproduction
+
+```bash
+# Run all benchmarks
+python -m benchmarks.scbe.run_all --synthetic-only --scbe-coords semantic
+
+# Shell agent benchmark (22/22)
+cd packages/cli && npm run bench:shell
+
+# Dye injection trace
+python src/video/dye_injection.py --input "your text here"
+
+# Null-space eval
+python scripts/run_biblical_null_space_eval.py --provider ollama --model llama3.2
+
+# Cross-model matrix
+python scripts/aggregate_null_space_matrix.py
+```
+
+**Pre-made agent templates** (starter configurations, not production policy):
+
+- `examples/npm/agents/fraud_detection_fleet.json`
+- `examples/npm/agents/research_browser_fleet.json`
+- `examples/npm/use-cases/financial_fraud_triage.json`
+- `examples/npm/use-cases/autonomous_research_review.json`
+
+**Live demo endpoints** (when backend is running):
+
+```bash
+curl $SCBE_BASE_URL/v1/demo/rogue-detection
+curl $SCBE_BASE_URL/v1/demo/swarm-coordination?agents=20
+curl "$SCBE_BASE_URL/v1/demo/pipeline-layers?trust=0.8&sensitivity=0.7"
+```
+
+---
+
+## Composes with Upstream Safety Tooling
+
+SCBE is the **enforcement** layer. It composes with detection-only auditing tools and attacker-capability benchmarks as the gate that emits the audit-trail receipt those tools assume.
+
+- **Anthropic Petri** ([github.com/safety-research/petri](https://github.com/safety-research/petri)) — open-source 36-dimension auditor over 173+ adversarial seeds. SCBE's L13 governance gate consumes Petri findings as input; at v7-matched config SCBE denies or escalates 171/173 seeds (1.16% false-allow). Notes: [docs/external/PETRI_FINDINGS_2026_05_08.md](docs/external/PETRI_FINDINGS_2026_05_08.md).
+- **Anthropic SCONE-bench** ([red.anthropic.com/2025/smart-contracts/](https://red.anthropic.com/2025/smart-contracts/)) — 405-contract attacker-capability benchmark. SCBE ships `scbe contract scan` as a SCONE-class static prefilter. Notes: [docs/external/SCONE_BENCH_2026_05_14.md](docs/external/SCONE_BENCH_2026_05_14.md).
+- **PNNL ALOHA** — no governance layer; SCBE fills that gap end-to-end.
+
+---
+
+## Claim Boundaries and Canonical Sources
+
+This repository includes active implementation, proposal material, historical docs, exploratory research, and narrative/training assets. The right question is not "is this in the repo?" but "is this canonical, active, legacy, or exploratory?"
+
+When docs conflict, use this order:
+
+1. [`CANONICAL_SYSTEM_STATE.md`](CANONICAL_SYSTEM_STATE.md)
+2. [`docs/specs/SCBE_CANONICAL_CONSTANTS.md`](docs/specs/SCBE_CANONICAL_CONSTANTS.md)
+3. Tests and active runtime entrypoints
+4. Public docs
+5. Historical or exploratory material
+
+Some older docs still reference legacy bounded scorers or earlier wall variants. The formula lock file at step 2 above is authoritative.
 
 If you are reviewing the project seriously, start with:
 
-1. [START_HERE.md](START_HERE.md)
-2. [CANONICAL_SYSTEM_STATE.md](CANONICAL_SYSTEM_STATE.md)
-3. [docs/specs/MONOREPO_CONSOLIDATION_AUTHORITY.md](docs/specs/MONOREPO_CONSOLIDATION_AUTHORITY.md)
-4. [docs/REPO_SURFACE_MAP.md](docs/REPO_SURFACE_MAP.md)
+- [`START_HERE.md`](START_HERE.md)
+- [`CANONICAL_SYSTEM_STATE.md`](CANONICAL_SYSTEM_STATE.md)
+- [`docs/REPO_SURFACE_MAP.md`](docs/REPO_SURFACE_MAP.md)
 
-Then move into the specific lane you care about.
+---
+
+## Lore and Worldbuilding
+
+This started as a DnD campaign on [Everweave.ai](https://everweave.ai). 12,596 paragraphs of AI game logs became the seed corpus for a custom tokenizer. That tokenizer became a 6-dimensional semantic coordinate system. That coordinate system became the 14-layer security pipeline. That pipeline became a patent (USPTO application #63/961,403). The game logs became a [141,000-word novel](https://www.amazon.com/dp/B0F28PHSPR) where the magic system is the real security architecture.
+
+The "Sacred Tongues" are the six φ-scaled semantic axes. "GeoSeal" is the governance gate. "Spiralverse" is the training corpus and the world. The lore is not decoration — it is the original encoding system. But it is also genuinely lore, and the two things are kept separate deliberately.
+
+For the worldbuilding side:
+
+- [Spiralverse-AetherMoore](https://github.com/issdandavis/Spiralverse-AetherMoore) — narrative and worldbuilding repo
+- [The Witnessed](https://www.amazon.com/dp/B0H257QJC2) — published fiction set in the Aethermoor world
+- [The Miracle Was the Memory](https://www.amazon.com/dp/B0F28PHSPR) — published fiction
+
+---
+
+## License
+
+Project-owned source, npm packages, PyPI packages, and packaged customer ZIP artifacts are dual licensed under `MIT OR Apache-2.0`. See `LICENSE`, `LICENSE-APACHE`, and `LICENSE-NOTICE.md`.
+
+Paid services, support, hosted deployments, audits, and custom commercial terms are separate commercial offerings and are not required to use the open-source code under either permissive license.
+
+- Website: [aethermoore.com](https://aethermoore.com)
+- GitHub Pages mirror: [issdandavis.github.io/SCBE-AETHERMOORE](https://issdandavis.github.io/SCBE-AETHERMOORE/)
+- Hugging Face: [issdandavis](https://huggingface.co/issdandavis)
+
+---
 
 ## Author
 
-Built by [Issac Davis](https://github.com/issdandavis).
+Built by [Issac Davis](https://github.com/issdandavis) in Port Angeles, WA.


### PR DESCRIPTION
## Summary
- Reorders README around thesis, credentials, audience routing, quickstart, terminology, proof, contracting, and lore
- Surfaces CAGE/UEI and patent-pending status near the top
- Adds current agent move packet and fleet governance gate entries to the component table
- Updates shell benchmark documentation to the verified 22/22 score

## Verification
- rg README for benchmark, agent move packet, fleet governance gate, CAGE, SAM UEI, and military-grade wording
- node packages/cli/scripts/shell_benchmark.cjs -> 22/22

## Rollback
- Revert this README-only commit if the new audience routing is not desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README with improved navigation and clearer audience routing.
  * Enhanced Quickstart section with refreshed setup instructions across multiple platforms.
  * Expanded Engineering Overview with detailed pipeline descriptions and formal constraints.
  * Added comprehensive inventory and Government/Contracting sections with capability references.
  * Improved Benchmarks reporting with comparative analysis and upgrade guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->