### PR TITLE
feat(agent-bus): n8n-style multi-step workflow protocol for --agent-json

### DIFF
--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -988,7 +988,10 @@ function buildBoardPromptBlock(board) {
   if (!board.objective) return '';
   const _failPattern = /error|FAIL|not found|No such|permission denied|command not found/i;
   const lines = ['--- Task Board ---', `Objective: ${board.objective.slice(0, 200)}`];
-  lines.push(`Turn: ${board.turn}`);
+  if (board.step_index != null && board.step_total != null) {
+    lines.push(`Step: ${board.step_index}/${board.step_total}`);
+  }
+  lines.push(`Turn: ${board.turn}${board.max_turns != null ? `/${board.max_turns}` : ''}`);
   if (board.attempts.length > 0) {
     const failCount = board.attempts.filter(
       (a) => a.observation != null && _failPattern.test(a.observation)
@@ -1344,6 +1347,10 @@ function runInteractiveShell(flags = {}) {
       done: false,
       ko_bans: [],
       turn: 0,
+      // Workflow step tracking (set by harness on multi-step workflows)
+      step_index: null,
+      step_total: null,
+      max_turns: null,
       // Execution strategy: verified forward progress over optimality.
       // See docs/specs/SCBE_AGENT_PATH_POLICY.md
       path_policy: 'non_optimal_correct',
@@ -1371,11 +1378,34 @@ function runInteractiveShell(flags = {}) {
         return;
       }
 
+      // reset_context: harness signals a new workflow step — clear per-step state,
+      // keep process alive, inject optional summary from previous step.
+      if (msg.reset_context) {
+        history.length = 0;
+        taskBoard.attempts = [];
+        taskBoard.ko_bans = [];
+        taskBoard.turn = 0;
+        taskBoard.done = false;
+        taskBoard.last_observation = null;
+        taskBoard.done_if = null;
+        instruction = null;
+        if (msg.step_context) {
+          history.push({
+            role: 'user',
+            content: `[Previous step]: ${msg.step_context.slice(0, 300)}`,
+          });
+          history.push({ role: 'assistant', content: 'Understood. Starting the next step.' });
+        }
+      }
+
       if (msg.instruction) {
         instruction = msg.instruction;
-        if (!taskBoard.objective) taskBoard.objective = instruction;
+        taskBoard.objective = instruction;
       }
-      if (msg.done_if && !taskBoard.done_if) taskBoard.done_if = msg.done_if;
+      if (msg.done_if) taskBoard.done_if = msg.done_if;
+      if (msg.step_index != null) taskBoard.step_index = msg.step_index;
+      if (msg.step_total != null) taskBoard.step_total = msg.step_total;
+      if (msg.max_turns != null) taskBoard.max_turns = msg.max_turns;
       if (msg.task_board && !taskBoard.objective) Object.assign(taskBoard, msg.task_board);
       if (msg.fleet_posture) taskBoard.fleet_posture = msg.fleet_posture;
       if (msg.fleet_authority) taskBoard.fleet_authority = msg.fleet_authority;
@@ -1389,6 +1419,24 @@ function runInteractiveShell(flags = {}) {
       busy = true;
       rl.pause();
       taskBoard.turn++;
+
+      // max_turns guard: hard step turn limit
+      if (taskBoard.max_turns != null && taskBoard.turn > taskBoard.max_turns) {
+        process.stdout.write(
+          JSON.stringify({
+            commands: [],
+            done: false,
+            max_turns_reached: true,
+            rationale: `Step max_turns (${taskBoard.max_turns}) reached without completing objective.`,
+            governance: { decision: 'ALLOW', reason: 'max-turns' },
+            board: { ...taskBoard },
+          }) + '\n'
+        );
+        busy = false;
+        if (stdinClosed) process.exit(0);
+        rl.resume();
+        return;
+      }
 
       const terminalState = msg.terminal_state || '';
 
@@ -1490,6 +1538,7 @@ function runInteractiveShell(flags = {}) {
           JSON.stringify({
             commands: [],
             done: taskBoard.done || doneSignal,
+            ...(taskBoard.done ? { step_complete: true } : {}),
             rationale: full.slice(0, 500),
             governance: { decision: 'ALLOW', reason: 'no-cmd' },
             board: { ...taskBoard },
@@ -1661,6 +1710,7 @@ function runInteractiveShell(flags = {}) {
         JSON.stringify({
           commands: [{ keystrokes: translated, is_blocking: true, timeout_sec: 30 }],
           done: taskBoard.done || doneSignal,
+          ...(taskBoard.done ? { step_complete: true } : {}),
           rationale,
           governance,
           move_packet: movePacket,

--- a/packages/cli/scripts/scbe_workflow.cjs
+++ b/packages/cli/scripts/scbe_workflow.cjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+/**
+ * SCBE workflow driver.
+ *
+ * Drives `scbe shell --agent-json` through a multi-step workflow.
+ * The harness owns step transitions — the model only sees the current step.
+ * Each step gets a clean context; only a one-line summary from the previous
+ * step is passed forward. No context clutter across steps.
+ *
+ * Workflow file format (JSON):
+ * {
+ *   "name": "fix failing tests",
+ *   "steps": [
+ *     {
+ *       "id": "read_errors",
+ *       "instruction": "Identify which tests are failing and why",
+ *       "done_if": "test -f /tmp/scbe_errors.txt",
+ *       "loop": false,
+ *       "max_turns": 5
+ *     },
+ *     {
+ *       "id": "fix_code",
+ *       "instruction": "Fix the errors identified in the previous step",
+ *       "done_if": "npm test && echo SCBE_PASS",
+ *       "loop": true,
+ *       "max_turns": 20
+ *     }
+ *   ]
+ * }
+ *
+ * loop: false — advance after first model response regardless of done_if
+ * loop: true  — retry until done_if passes or max_turns hit
+ *
+ * Usage:
+ *   node scripts/scbe_workflow.cjs path/to/workflow.json
+ *   SCBE_MODEL=groq/llama-3.3-70b-versatile node scripts/scbe_workflow.cjs workflow.json
+ *   node scripts/scbe_workflow.cjs --example     # print example workflow and exit
+ */
+
+'use strict';
+
+const { spawnSync, spawn } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const CLI = path.resolve(__dirname, '..', 'bin', 'scbe.js');
+const OUT_DIR = path.join(REPO_ROOT, 'artifacts', 'workflow');
+
+const BASH =
+  process.platform === 'win32'
+    ? (() => {
+        const r = spawnSync('where', ['bash'], { encoding: 'utf8' });
+        return (
+          r.stdout
+            .split('\n')
+            .map((l) => l.trim())
+            .find(
+              (l) =>
+                l &&
+                !/\\windows\\system32\\bash\.exe$/i.test(l) &&
+                !/\\WindowsApps\\bash\.exe$/i.test(l)
+            ) || 'bash'
+        ).trim();
+      })()
+    : '/bin/bash';
+
+function runBash(cmd) {
+  const r = spawnSync(BASH, ['-c', cmd], { encoding: 'utf8', timeout: 30000 });
+  return {
+    stdout: (r.stdout || '').trim(),
+    stderr: (r.stderr || '').trim(),
+    status: r.status ?? 1,
+  };
+}
+
+function extractSummary(lastObservation, rationale) {
+  const obs = (lastObservation || '').slice(-300).replace(/\n/g, ' ').trim();
+  const rat = (rationale || '').slice(0, 150).trim();
+  if (obs && rat) return `${rat} | output: ${obs.slice(0, 150)}`;
+  return obs || rat || '(no output)';
+}
+
+function sendLine(proc, obj) {
+  proc.stdin.write(JSON.stringify(obj) + '\n');
+}
+
+function recvLine(proc, timeoutMs = 30000) {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    const timer = setTimeout(() => {
+      proc.stdout.off('data', onData);
+      reject(new Error(`recv timeout after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onData = (chunk) => {
+      buf += chunk;
+      const nl = buf.indexOf('\n');
+      if (nl !== -1) {
+        clearTimeout(timer);
+        proc.stdout.off('data', onData);
+        const line = buf.slice(0, nl).trim();
+        try {
+          resolve(JSON.parse(line));
+        } catch (e) {
+          reject(new Error(`bad JSON from agent: ${line.slice(0, 200)}`));
+        }
+      }
+    };
+    proc.stdout.on('data', onData);
+  });
+}
+
+async function runStep(proc, step, stepIndex, totalSteps, prevSummary, initialTerminalState) {
+  const stepNum = stepIndex + 1;
+  const isFirst = stepIndex === 0;
+  const maxTurns = step.max_turns ?? (step.loop ? 20 : 5);
+
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log(`Step ${stepNum}/${totalSteps}: ${step.id}`);
+  console.log(`Instruction: ${step.instruction.slice(0, 120)}`);
+  console.log(`Loop: ${step.loop ? 'yes' : 'no'}  Max turns: ${maxTurns}`);
+  if (prevSummary) console.log(`Context from prev: ${prevSummary.slice(0, 100)}`);
+
+  // Send step init message (reset_context for all steps after the first)
+  sendLine(proc, {
+    instruction: step.instruction,
+    terminal_state: initialTerminalState || '$ ',
+    done_if: step.done_if || null,
+    reset_context: !isFirst,
+    step_context: isFirst ? null : prevSummary,
+    step_index: stepNum,
+    step_total: totalSteps,
+    max_turns: maxTurns,
+  });
+
+  let terminalState = initialTerminalState || '$ ';
+  let lastRationale = '';
+  let stepComplete = false;
+  let turns = 0;
+
+  while (turns < maxTurns) {
+    let resp;
+    try {
+      resp = await recvLine(proc, 60000);
+    } catch (e) {
+      console.error(`  [TIMEOUT] ${e.message}`);
+      break;
+    }
+
+    turns++;
+
+    if (resp.error) {
+      console.error(`  [ERROR] ${resp.error}`);
+      break;
+    }
+    if (resp.max_turns_reached) {
+      console.log(`  [MAX_TURNS] Step hit turn limit (${maxTurns})`);
+      break;
+    }
+
+    const cmd = resp.commands && resp.commands[0] ? resp.commands[0].keystrokes : null;
+    lastRationale = resp.rationale || '';
+
+    console.log(
+      `  Turn ${turns}: ${cmd ? `cmd=${cmd.slice(0, 70)}` : '(no cmd)'} | done=${resp.done}`
+    );
+
+    if (resp.step_complete || resp.done) {
+      stepComplete = true;
+      console.log(`  [COMPLETE] Step ${stepNum} verified complete`);
+      break;
+    }
+
+    if (!step.loop) {
+      // Non-loop: capture output and advance immediately
+      if (cmd) {
+        const exec = runBash(cmd);
+        terminalState = `$ ${cmd}\n${exec.stdout}${exec.stderr ? '\n' + exec.stderr : ''}`;
+        console.log(`  Exec: ${exec.stdout.slice(0, 80) || '(empty)'}`);
+      }
+      break;
+    }
+
+    // Loop step: execute command and send next turn
+    if (cmd) {
+      const exec = runBash(cmd);
+      terminalState = `$ ${cmd}\n${exec.stdout}${exec.stderr ? '\n' + exec.stderr : ''}`;
+      console.log(`  Exec: ${exec.stdout.slice(0, 80) || '(empty)'}`);
+    }
+
+    if (resp.blocked) {
+      console.log(
+        `  [BLOCKED] ${resp.rationale ? resp.rationale.slice(0, 80) : 'governance/ko-ban'}`
+      );
+    }
+
+    sendLine(proc, { terminal_state: terminalState });
+  }
+
+  const summary = extractSummary(terminalState, lastRationale);
+  return { step_id: step.id, completed: stepComplete, turns, summary };
+}
+
+async function runWorkflow(workflowPath) {
+  const wf = JSON.parse(fs.readFileSync(workflowPath, 'utf8'));
+  const steps = wf.steps || [];
+  if (!steps.length) throw new Error('Workflow has no steps');
+
+  console.log(`\nWorkflow: ${wf.name || workflowPath}`);
+  console.log(`Steps: ${steps.length}`);
+
+  const proc = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+    cwd: REPO_ROOT,
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+
+  // Wait for ready signal
+  const ready = await recvLine(proc, 10000);
+  if (!ready.ready) throw new Error(`Expected ready signal, got: ${JSON.stringify(ready)}`);
+
+  const results = [];
+  let prevSummary = null;
+  let terminalState = wf.initial_terminal_state || '$ ';
+
+  for (let i = 0; i < steps.length; i++) {
+    const result = await runStep(proc, steps[i], i, steps.length, prevSummary, terminalState);
+    results.push(result);
+    prevSummary = result.summary;
+    // Terminal state passes forward (harness owns the environment)
+  }
+
+  proc.stdin.end();
+  proc.kill();
+
+  const completed = results.filter((r) => r.completed).length;
+  console.log(`\n${'═'.repeat(60)}`);
+  console.log(`Workflow complete: ${completed}/${steps.length} steps verified`);
+  for (const r of results) {
+    console.log(`  ${r.completed ? '[OK]' : '[--]'} ${r.step_id} (${r.turns} turns)`);
+  }
+
+  if (!fs.existsSync(OUT_DIR)) fs.mkdirSync(OUT_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const reportPath = path.join(
+    OUT_DIR,
+    `${stamp}-${(wf.name || 'workflow').replace(/\s+/g, '-')}.json`
+  );
+  fs.writeFileSync(
+    reportPath,
+    JSON.stringify(
+      { workflow: wf.name, steps: results, timestamp: new Date().toISOString() },
+      null,
+      2
+    )
+  );
+  console.log(`Receipt: ${reportPath}`);
+
+  return results;
+}
+
+// ── Example workflow output ──────────────────────────────────────────────────
+
+function printExample() {
+  const example = {
+    name: 'fix-failing-tests',
+    steps: [
+      {
+        id: 'identify',
+        instruction: 'Run the tests and write any failures to /tmp/scbe_errors.txt',
+        done_if: 'test -f /tmp/scbe_errors.txt && test -s /tmp/scbe_errors.txt',
+        loop: false,
+        max_turns: 5,
+      },
+      {
+        id: 'fix',
+        instruction: 'Fix the test failures listed in /tmp/scbe_errors.txt',
+        done_if: ':test npm test',
+        loop: true,
+        max_turns: 20,
+      },
+      {
+        id: 'verify',
+        instruction: 'Run the full test suite and confirm all tests pass',
+        done_if: 'npm test',
+        loop: false,
+        max_turns: 3,
+      },
+    ],
+  };
+  console.log(JSON.stringify(example, null, 2));
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+(async () => {
+  const arg = process.argv[2];
+  if (!arg || arg === '--help') {
+    console.log('Usage: node scbe_workflow.cjs <workflow.json>');
+    console.log('       node scbe_workflow.cjs --example');
+    process.exit(0);
+  }
+  if (arg === '--example') {
+    printExample();
+    process.exit(0);
+  }
+  try {
+    const results = await runWorkflow(path.resolve(arg));
+    const allDone = results.every((r) => r.completed);
+    process.exit(allDone ? 0 : 1);
+  } catch (e) {
+    console.error('Workflow error:', e.message);
+    process.exit(1);
+  }
+})();

--- a/packages/cli/scripts/shell_benchmark.cjs
+++ b/packages/cli/scripts/shell_benchmark.cjs
@@ -541,6 +541,206 @@ function main() {
   );
 
   cases.push(
+    caseResult('agent_json_reset_context_clears_board', () => {
+      // reset_context: true must wipe attempts, ko_bans, and turn; new instruction takes effect.
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Working on it. <cmd>echo step</cmd>';
+      const msg1 = JSON.stringify({ instruction: 'first step task', terminal_state: '$ ' });
+      const msg2 = JSON.stringify({
+        reset_context: true,
+        instruction: 'second step task',
+        terminal_state: '$ ',
+        step_context: 'first step completed',
+      });
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: msg1 + '\n' + msg2 + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 3, `expected ready + 2 responses, got ${lines.length} lines`);
+      const resp2 = JSON.parse(lines[2]);
+      assert.ok(resp2.board, 'second response must include board');
+      // Reset cleared step-1 state; turn was reset to 0 then incremented, so it must be 1 now.
+      assert.strictEqual(
+        resp2.board.turn,
+        1,
+        `reset_context must reset turn to 1, got ${resp2.board.turn}`
+      );
+      assert.strictEqual(resp2.board.ko_bans.length, 0, 'reset_context must clear ko_bans');
+      // Any attempts present belong to the new step only (turn ≤ 1).
+      const staleAttempts = (resp2.board.attempts || []).filter((a) => a.turn > 1);
+      assert.strictEqual(
+        staleAttempts.length,
+        0,
+        `stale attempts from previous step must be gone, got: ${JSON.stringify(staleAttempts)}`
+      );
+      assert.strictEqual(
+        resp2.board.objective,
+        'second step task',
+        'new instruction must be board objective'
+      );
+      return {
+        turn: resp2.board.turn,
+        attempts: resp2.board.attempts.length,
+        objective: resp2.board.objective,
+      };
+    })
+  );
+
+  cases.push(
+    caseResult('agent_json_step_index_shown_in_board', () => {
+      // step_index + step_total sent in message must appear in the returned board.
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Processing. <cmd>echo progress</cmd>';
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input:
+          JSON.stringify({
+            instruction: 'workflow step task',
+            terminal_state: '$ ',
+            step_index: 2,
+            step_total: 5,
+          }) + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 2, `expected ready + response, got ${lines.length}`);
+      const resp = JSON.parse(lines[1]);
+      assert.ok(resp.board, 'response must include board');
+      assert.strictEqual(
+        resp.board.step_index,
+        2,
+        `expected step_index=2, got ${resp.board.step_index}`
+      );
+      assert.strictEqual(
+        resp.board.step_total,
+        5,
+        `expected step_total=5, got ${resp.board.step_total}`
+      );
+      return { step_index: resp.board.step_index, step_total: resp.board.step_total };
+    })
+  );
+
+  cases.push(
+    caseResult('agent_json_max_turns_emits_limit_signal', () => {
+      // After the turn budget is exhausted, the next response must be max_turns_reached=true.
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Working. <cmd>echo working</cmd>';
+      const msg1 = JSON.stringify({
+        instruction: 'task with tight limit',
+        terminal_state: '$ ',
+        max_turns: 1,
+      });
+      const msg2 = JSON.stringify({ terminal_state: '$ echo working\nworking' });
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: msg1 + '\n' + msg2 + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 3, `expected ready + 2 responses, got ${lines.length} lines`);
+      const resp2 = JSON.parse(lines[2]);
+      assert.strictEqual(
+        resp2.max_turns_reached,
+        true,
+        `expected max_turns_reached=true, got: ${JSON.stringify(resp2).slice(0, 200)}`
+      );
+      assert.strictEqual(resp2.done, false, 'max_turns_reached response must have done=false');
+      assert.deepStrictEqual(
+        resp2.commands,
+        [],
+        'max_turns_reached response must have empty commands'
+      );
+      return {
+        max_turns_reached: resp2.max_turns_reached,
+        rationale: resp2.rationale?.slice(0, 60),
+      };
+    })
+  );
+
+  cases.push(
+    caseResult('agent_json_two_step_workflow_passes_context', () => {
+      // Two-step workflow: second step receives reset_context + step_context from step 1.
+      // Board must reflect new objective, empty attempts, and correct step_index.
+      const { spawnSync: spawn } = require('node:child_process');
+      const mock = 'Understood. <cmd>echo ok</cmd>';
+      const msg1 = JSON.stringify({
+        instruction: 'step one: identify issues',
+        terminal_state: '$ ',
+        step_index: 1,
+        step_total: 2,
+      });
+      const msg2 = JSON.stringify({
+        reset_context: true,
+        instruction: 'step two: fix the issues',
+        terminal_state: '$ ',
+        step_context: 'step one identified failing tests',
+        step_index: 2,
+        step_total: 2,
+      });
+      const r = spawn(process.execPath, [CLI, 'shell', '--agent-json'], {
+        cwd: REPO_ROOT,
+        input: msg1 + '\n' + msg2 + '\n\n',
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { ...process.env, NO_COLOR: '1', SCBE_MOCK_RESPONSE: mock },
+      });
+      const lines = (r.stdout || '')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      assert.ok(lines.length >= 3, `expected ready + 2 responses, got ${lines.length} lines`);
+      const resp2 = JSON.parse(lines[2]);
+      assert.ok(resp2.board, 'second step response must include board');
+      assert.strictEqual(
+        resp2.board.step_index,
+        2,
+        'board step_index must be 2 after context reset'
+      );
+      assert.strictEqual(resp2.board.step_total, 2, 'board step_total must be 2');
+      assert.strictEqual(
+        resp2.board.objective,
+        'step two: fix the issues',
+        'board objective must be updated'
+      );
+      // Reset cleared step-1 history; turn must be 1 (reset to 0, incremented once for this step).
+      assert.strictEqual(
+        resp2.board.turn,
+        1,
+        `turn must reset to 1 for new step, got ${resp2.board.turn}`
+      );
+      // No stale attempts from step 1.
+      const stale = (resp2.board.attempts || []).filter((a) => a.turn > 1);
+      assert.strictEqual(
+        stale.length,
+        0,
+        `step-1 attempts must not bleed into step-2 board, got: ${JSON.stringify(stale)}`
+      );
+      return {
+        step: `${resp2.board.step_index}/${resp2.board.step_total}`,
+        turn: resp2.board.turn,
+        objective: resp2.board.objective.slice(0, 40),
+      };
+    })
+  );
+
+  cases.push(
     caseResult('agent_json_patch_tool_translates_to_patch_command', () => {
       const { spawnSync: spawn } = require('node:child_process');
       const mock = 'Applying patch. <cmd>:patch /tmp/fix.patch</cmd>';


### PR DESCRIPTION
## Summary
- Adds an n8n-style multi-step workflow protocol for `scbe shell --agent-json`
- Adds step metadata, context reset behavior, max-turn limit signaling, and cross-step context handoff
- Adds `packages/cli/scripts/scbe_workflow.cjs` as a workflow driver surface
- Expands shell benchmark coverage from 22/22 to 26/26

## Verification
- `npx prettier --check packages/cli/bin/scbe.js packages/cli/scripts/scbe_workflow.cjs packages/cli/scripts/shell_benchmark.cjs`
- `node packages/cli/scripts/shell_benchmark.cjs` -> 26/26

## Rollback
- Revert this commit to restore the previous single-step `--agent-json` behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow step progress tracking for agent-JSON tasks with step indices and completion status.
  * Introduced multi-step workflow orchestration that chains together automated agent tasks with terminal state passing between steps.
  * Added turn/step limits with hard guards to prevent excessive processing in workflows.

* **Tests**
  * Added benchmark tests for workflow state management, step progress tracking, and turn limit enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->