### PR TITLE
fix(bench): commit-based freshness gate for --last-artifact

### DIFF
--- a/packages/cli/scripts/shell_benchmark.cjs
+++ b/packages/cli/scripts/shell_benchmark.cjs
@@ -877,8 +877,9 @@ function main() {
   process.exit(report.ready ? 0 : 1);
 }
 
-// --last-artifact: read the most recent bench JSON and exit 0/1 based on score.
-// Used by workflow verifiers so they don't re-run the full suite.
+// --last-artifact: read the most recent bench JSON and exit 0/1.
+// Fails if the artifact was produced on a different commit than HEAD (stale guard).
+// Pass --allow-stale to skip the commit check (e.g. in detached-HEAD CI contexts).
 if (process.argv.includes('--last-artifact')) {
   if (!fs.existsSync(OUT_DIR)) {
     process.stderr.write('No bench artifacts found\n');
@@ -893,8 +894,23 @@ if (process.argv.includes('--last-artifact')) {
     process.exit(1);
   }
   const last = JSON.parse(fs.readFileSync(path.join(OUT_DIR, files[files.length - 1]), 'utf8'));
+
+  if (!process.argv.includes('--allow-stale')) {
+    const headCommit = spawnSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    }).stdout.trim();
+    const artifactCommit = (last.commit || '').trim();
+    if (headCommit && artifactCommit && headCommit !== artifactCommit) {
+      process.stderr.write(
+        `Stale artifact: bench was run on ${artifactCommit}, HEAD is ${headCommit}. Run the bench first.\n`
+      );
+      process.exit(1);
+    }
+  }
+
   const { earned = 0, total = 0, percent = 0 } = last.score || {};
-  process.stdout.write(`${earned}/${total} (${percent}%) — ${last.generated_at}\n`);
+  process.stdout.write(`${earned}/${total} (${percent}%) — ${last.generated_at} — commit ${last.commit || 'unknown'}\n`);
   process.exit(percent === 100 ? 0 : 1);
 }
 


### PR DESCRIPTION
## Summary

Closes the stale-artifact gap in `--last-artifact`: the verifier now compares the artifact's `commit` field against the current `git rev-parse --short HEAD`. If they differ it exits 1 with a clear error before checking the score.

```
Stale artifact: bench was run on d6f02e5f6, HEAD is c54296440. Run the bench first.
```

`--allow-stale` bypasses the check for detached-HEAD CI contexts.

## Test plan

- [ ] Fresh artifact (just ran bench on HEAD) → exits 0, prints score + commit
- [ ] Stale artifact (committed code change since last bench run) → exits 1, prints stale message
- [ ] `--allow-stale` → always proceeds to score check regardless of commit mismatch
- [ ] GitHub CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark tool now validates artifact freshness by comparing recorded commits against current HEAD, preventing stale results.
  * Updated benchmark output to display commit information for better tracking.
  * Added `--allow-stale` flag option for scenarios requiring legacy artifact usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->