### PR TITLE
style(docs): remove trailing whitespace from LLM notes

### DIFF
--- a/docs/research/LLM_EMERGING_ARCHITECTURES_SCBE_NOTES.md
+++ b/docs/research/LLM_EMERGING_ARCHITECTURES_SCBE_NOTES.md
@@ -1,7 +1,7 @@
 # Notes on Large Language Models and Emerging Architectures
 
-Status: research note  
-Source: `C:\Users\issda\Downloads\SCBE Ecosystem Growth.pdf`  
+Status: research note
+Source: `C:\Users\issda\Downloads\SCBE Ecosystem Growth.pdf`
 Purpose: preserve the useful architecture discussion in repo-native Markdown without treating speculative ideas as proven implementation.
 
 ## 1. Autoregressive Language Models


### PR DESCRIPTION
## Summary
- Removes trailing Markdown line-break whitespace from the LLM emerging architectures research note.
- Keeps LF line endings so deterministic review gate passes.

## Verification
- git diff --check

## Rollback
- Revert this docs-only whitespace cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Normalized formatting in research documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->