### PR TITLE
feat(agent-bus): add governed trajectory state gate

### DIFF
--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -73,11 +73,21 @@ export {
   type GeoSealPlanPolicy,
   type GeoSealPlanCommand,
   type PipelineRunResult,
+  type GovernedMoveClass,
+  type GovernedMoveRecord,
+  type GovernedPipelineState,
+  type TrajectoryGateResult,
   compilePlan,
   execPlan,
   runPipeline,
   parseShellTemplate,
   resolveRepoRoot,
+  createGovernedPipelineState,
+  loadGovernedPipelineState,
+  saveGovernedPipelineState,
+  classifyGovernedMove,
+  reachableMoveSet,
+  evaluateTrajectoryGate,
 } from './pipeline.js';
 
 // Structured output contracts
@@ -135,6 +145,19 @@ export interface RunOptions {
   geosealBin?: string;
   python?: string;
   continueOnError?: boolean;
+  /**
+   * Optional persisted trajectory gate for GeoSeal pipelines.
+   * When enabled, the pipeline checks whether the compiled plan is reachable
+   * from the session's current governed state before execution.
+   */
+  governedState?:
+    | boolean
+    | {
+        enabled?: boolean;
+        sessionId?: string;
+        statePath?: string;
+        root?: string;
+      };
 }
 
 export interface AgentBusResult {

--- a/packages/agent-bus/src/pipeline.ts
+++ b/packages/agent-bus/src/pipeline.ts
@@ -17,6 +17,7 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import crypto from 'node:crypto';
 import type { AgentBusResult, RunOptions } from './index.js';
 import { checkCircuit, recordSuccess, recordFailure } from './resilience.js';
 import { decompose, type DecompositionResult } from './semantic-bridge.js';
@@ -170,6 +171,53 @@ export interface PipelineRunResult {
   semantic_escalation?: string;
   /** Populated when blocked=false. */
   result?: AgentBusResult;
+  /** Populated when the optional trajectory gate evaluated the plan. */
+  trajectory_gate?: TrajectoryGateResult;
+}
+
+export type GovernedMoveClass =
+  | 'observe'
+  | 'read'
+  | 'verify'
+  | 'write'
+  | 'network'
+  | 'deploy'
+  | 'destructive'
+  | 'unknown';
+
+export interface GovernedMoveRecord {
+  at: string;
+  intent_sha256: string;
+  plan_sha256: string;
+  command_key: string;
+  move_class: GovernedMoveClass;
+  decision: 'ACCEPT' | 'REJECT';
+  reason: string;
+}
+
+export interface GovernedPipelineState {
+  schema_version: 'scbe.agent_bus.governed_state.v1';
+  session_id: string;
+  created_at: string;
+  updated_at: string;
+  accepted_moves: GovernedMoveRecord[];
+  rejected_moves: GovernedMoveRecord[];
+}
+
+export interface TrajectoryGateResult {
+  enabled: boolean;
+  allowed: boolean;
+  session_id: string;
+  state_path: string;
+  move_class: GovernedMoveClass;
+  reachable_set: GovernedMoveClass[];
+  reason: string;
+}
+
+interface GovernedStateConfig {
+  enabled: boolean;
+  sessionId: string;
+  statePath: string;
 }
 
 // ─── Shell template parser ────────────────────────────────────────────────────
@@ -206,6 +254,193 @@ export function parseShellTemplate(template: string): string[] {
   }
   if (current.length > 0) args.push(current);
   return args;
+}
+
+// ─── Persisted trajectory gate ────────────────────────────────────────────────
+
+function slugifyStateId(value: string): string {
+  return (
+    String(value || 'default')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80) || 'default'
+  );
+}
+
+function resolveGovernedStateConfig(options: RunOptions): GovernedStateConfig | null {
+  const raw = options.governedState;
+  if (!raw) return null;
+  if (raw === true) {
+    const root = path.join(resolveRepoRoot(options), '.aethermoor-bus', 'governed-state');
+    return {
+      enabled: true,
+      sessionId: 'default',
+      statePath: path.join(root, 'default.json'),
+    };
+  }
+  if (typeof raw !== 'object' || raw.enabled === false) return null;
+  const sessionId = slugifyStateId(raw.sessionId || 'default');
+  const root = path.resolve(
+    raw.root || path.join(resolveRepoRoot(options), '.aethermoor-bus', 'governed-state')
+  );
+  return {
+    enabled: true,
+    sessionId,
+    statePath: path.resolve(raw.statePath || path.join(root, `${sessionId}.json`)),
+  };
+}
+
+export function createGovernedPipelineState(sessionId = 'default'): GovernedPipelineState {
+  const now = new Date().toISOString();
+  return {
+    schema_version: 'scbe.agent_bus.governed_state.v1',
+    session_id: slugifyStateId(sessionId),
+    created_at: now,
+    updated_at: now,
+    accepted_moves: [],
+    rejected_moves: [],
+  };
+}
+
+export function loadGovernedPipelineState(
+  statePath: string,
+  sessionId = 'default'
+): GovernedPipelineState {
+  if (!fs.existsSync(statePath)) {
+    return createGovernedPipelineState(sessionId);
+  }
+  const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8')) as GovernedPipelineState;
+  if (parsed.schema_version !== 'scbe.agent_bus.governed_state.v1') {
+    throw new Error(`unsupported governed state schema at ${statePath}`);
+  }
+  return parsed;
+}
+
+export function saveGovernedPipelineState(statePath: string, state: GovernedPipelineState): void {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}
+
+function hasRecentAccepted(state: GovernedPipelineState, classes: GovernedMoveClass[]): boolean {
+  return state.accepted_moves
+    .slice(-8)
+    .some((move) => classes.includes(move.move_class) && move.decision === 'ACCEPT');
+}
+
+export function classifyGovernedMove(plan: GeoSealPlan): GovernedMoveClass {
+  const haystack = [
+    plan.intent.text,
+    plan.intent.requested_tool || '',
+    plan.tool.class,
+    plan.tool.contract.tool,
+    plan.tool.contract.risk,
+    plan.command.key,
+    plan.command.template,
+  ]
+    .join(' ')
+    .toLowerCase();
+
+  if (
+    /(^|\s)(rm\s+-rf|remove-item|delete|destroy|drop\s+table|wipe|purge|reset\s+--hard)(\s|$)/.test(
+      haystack
+    )
+  ) {
+    return 'destructive';
+  }
+  if (
+    /\b(deploy|release|publish|upload|vercel|netlify|railway|docker\s+push|kubectl)\b/.test(
+      haystack
+    )
+  ) {
+    return 'deploy';
+  }
+  if (/\b(curl|invoke-webrequest|wget|fetch|http|https|api|gh\s+pr|git\s+push)\b/.test(haystack)) {
+    return 'network';
+  }
+  if (
+    /\b(test|verify|lint|format|check|pytest|vitest|npm\s+test|npm\s+run\s+lint)\b/.test(haystack)
+  ) {
+    return 'verify';
+  }
+  if (/\b(write|edit|patch|apply|commit|create|mkdir|copy|move)\b/.test(haystack)) {
+    return 'write';
+  }
+  if (/\b(read|cat|type|get-content|grep|rg|find|list|ls|dir|inspect|summarize)\b/.test(haystack)) {
+    return 'read';
+  }
+  if (/\b(observe|status|health|scan|measure|explain)\b/.test(haystack)) {
+    return 'observe';
+  }
+  return 'unknown';
+}
+
+export function reachableMoveSet(state: GovernedPipelineState): GovernedMoveClass[] {
+  const base: GovernedMoveClass[] = ['observe', 'read', 'verify'];
+
+  if (hasRecentAccepted(state, ['observe', 'read', 'verify', 'write'])) {
+    base.push('write');
+  }
+  if (hasRecentAccepted(state, ['verify'])) {
+    base.push('network');
+  }
+  if (hasRecentAccepted(state, ['verify']) && hasRecentAccepted(state, ['network'])) {
+    base.push('deploy');
+  }
+  return Array.from(new Set(base));
+}
+
+export function evaluateTrajectoryGate(
+  plan: GeoSealPlan,
+  state: GovernedPipelineState,
+  config: Pick<GovernedStateConfig, 'sessionId' | 'statePath'>
+): TrajectoryGateResult {
+  const moveClass = classifyGovernedMove(plan);
+  const reachable = reachableMoveSet(state);
+  const allowed = reachable.includes(moveClass);
+  return {
+    enabled: true,
+    allowed,
+    session_id: config.sessionId,
+    state_path: config.statePath,
+    move_class: moveClass,
+    reachable_set: reachable,
+    reason: allowed
+      ? `move class ${moveClass} is reachable from governed state`
+      : `move class ${moveClass} is not reachable; allowed next classes: ${reachable.join(', ')}`,
+  };
+}
+
+function recordGovernedMove(
+  state: GovernedPipelineState,
+  plan: GeoSealPlan,
+  moveClass: GovernedMoveClass,
+  decision: 'ACCEPT' | 'REJECT',
+  reason: string
+): GovernedPipelineState {
+  const next: GovernedPipelineState = {
+    ...state,
+    updated_at: new Date().toISOString(),
+    accepted_moves: [...state.accepted_moves],
+    rejected_moves: [...state.rejected_moves],
+  };
+  const record: GovernedMoveRecord = {
+    at: next.updated_at,
+    intent_sha256:
+      plan.hashes.intent_sha256 ||
+      crypto.createHash('sha256').update(plan.intent.text).digest('hex'),
+    plan_sha256: plan.hashes.plan_sha256,
+    command_key: plan.command.key,
+    move_class: moveClass,
+    decision,
+    reason,
+  };
+  if (decision === 'ACCEPT') next.accepted_moves.push(record);
+  else next.rejected_moves.push(record);
+  next.accepted_moves = next.accepted_moves.slice(-64);
+  next.rejected_moves = next.rejected_moves.slice(-64);
+  return next;
 }
 
 // ─── Core functions ───────────────────────────────────────────────────────────
@@ -373,6 +608,42 @@ export async function runPipeline(
     };
   }
 
+  const governedConfig = resolveGovernedStateConfig(options);
+  let trajectoryGate: TrajectoryGateResult | undefined;
+  let governedState: GovernedPipelineState | undefined;
+  if (governedConfig?.enabled) {
+    governedState = loadGovernedPipelineState(governedConfig.statePath, governedConfig.sessionId);
+    trajectoryGate = evaluateTrajectoryGate(plan, governedState, governedConfig);
+    if (!trajectoryGate.allowed) {
+      const rejected = recordGovernedMove(
+        governedState,
+        plan,
+        trajectoryGate.move_class,
+        'REJECT',
+        trajectoryGate.reason
+      );
+      saveGovernedPipelineState(governedConfig.statePath, rejected);
+      return {
+        plan,
+        blocked: true,
+        block_reason: `trajectory gate: ${trajectoryGate.reason}`,
+        trajectory_gate: trajectoryGate,
+      };
+    }
+  }
+
   const result = execPlan(plan, options);
-  return { plan, blocked: false, result };
+  if (governedConfig?.enabled && governedState && trajectoryGate) {
+    const nextState = recordGovernedMove(
+      governedState,
+      plan,
+      trajectoryGate.move_class,
+      result.ok ? 'ACCEPT' : 'REJECT',
+      result.ok
+        ? trajectoryGate.reason
+        : `execution failed after trajectory allow: exit ${result.exit_code}`
+    );
+    saveGovernedPipelineState(governedConfig.statePath, nextState);
+  }
+  return { plan, blocked: false, result, trajectory_gate: trajectoryGate };
 }

--- a/packages/agent-bus/tests/pipeline.test.ts
+++ b/packages/agent-bus/tests/pipeline.test.ts
@@ -1,5 +1,18 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, it, expect } from 'vitest';
-import { parseShellTemplate, execPlan, type GeoSealPlan } from '../src/pipeline.js';
+import {
+  parseShellTemplate,
+  execPlan,
+  createGovernedPipelineState,
+  saveGovernedPipelineState,
+  loadGovernedPipelineState,
+  classifyGovernedMove,
+  reachableMoveSet,
+  evaluateTrajectoryGate,
+  type GeoSealPlan,
+} from '../src/pipeline.js';
 
 // ─── parseShellTemplate ───────────────────────────────────────────────────────
 
@@ -127,5 +140,108 @@ describe('runPipeline policy gate', async () => {
     expect(result.blocked).toBe(true);
     expect(result.plan).toBeNull();
     expect(result.block_reason).toMatch(/geoseal compile failed/);
+  });
+});
+
+// ─── persisted trajectory gate ───────────────────────────────────────────────
+
+describe('governed trajectory gate', () => {
+  const basePlan: GeoSealPlan = {
+    schema_version: 'scbe_command_plan_v1',
+    intent: { text: 'inspect repo status', permission_mode: 'observe' },
+    tool: {
+      class: 'read',
+      contract: { tool: 'read', risk: 'low', approval: 'auto' },
+    },
+    policy: { ok: true, decision: 'ALLOW', reason: 'profile_allows' },
+    command: { key: 'status', template: 'git status --short', runnable: true },
+    hashes: { intent_sha256: 'intent-a', plan_sha256: 'plan-a' },
+  };
+
+  it('starts with only low-risk classes reachable', () => {
+    const state = createGovernedPipelineState('session one');
+    expect(state.session_id).toBe('session-one');
+    expect(reachableMoveSet(state)).toEqual(['observe', 'read', 'verify']);
+  });
+
+  it('classifies destructive and deployment commands before execution', () => {
+    expect(
+      classifyGovernedMove({
+        ...basePlan,
+        intent: { text: 'deploy to production', permission_mode: 'execute' },
+        command: { key: 'deploy', template: 'vercel deploy --prod', runnable: true },
+      })
+    ).toBe('deploy');
+
+    expect(
+      classifyGovernedMove({
+        ...basePlan,
+        intent: { text: 'delete generated cache', permission_mode: 'execute' },
+        command: { key: 'delete', template: 'rm -rf .cache', runnable: true },
+      })
+    ).toBe('destructive');
+  });
+
+  it('blocks deploy until verification and network moves have been accepted', () => {
+    const deployPlan: GeoSealPlan = {
+      ...basePlan,
+      intent: { text: 'deploy the app', permission_mode: 'execute' },
+      command: { key: 'deploy', template: 'vercel deploy --prod', runnable: true },
+      hashes: { intent_sha256: 'intent-deploy', plan_sha256: 'plan-deploy' },
+    };
+
+    const state = createGovernedPipelineState('release-lane');
+    let gate = evaluateTrajectoryGate(deployPlan, state, {
+      sessionId: state.session_id,
+      statePath: 'state.json',
+    });
+    expect(gate.allowed).toBe(false);
+    expect(gate.reachable_set).not.toContain('deploy');
+
+    state.accepted_moves.push({
+      at: new Date().toISOString(),
+      intent_sha256: 'intent-verify',
+      plan_sha256: 'plan-verify',
+      command_key: 'test',
+      move_class: 'verify',
+      decision: 'ACCEPT',
+      reason: 'tests passed',
+    });
+    state.accepted_moves.push({
+      at: new Date().toISOString(),
+      intent_sha256: 'intent-network',
+      plan_sha256: 'plan-network',
+      command_key: 'push',
+      move_class: 'network',
+      decision: 'ACCEPT',
+      reason: 'remote check passed',
+    });
+
+    gate = evaluateTrajectoryGate(deployPlan, state, {
+      sessionId: state.session_id,
+      statePath: 'state.json',
+    });
+    expect(gate.allowed).toBe(true);
+    expect(gate.reachable_set).toContain('deploy');
+  });
+
+  it('round-trips governed state to the filesystem', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scbe-governed-state-'));
+    const statePath = path.join(dir, 'lane.json');
+    const state = createGovernedPipelineState('lane');
+    state.rejected_moves.push({
+      at: new Date().toISOString(),
+      intent_sha256: 'intent-bad',
+      plan_sha256: 'plan-bad',
+      command_key: 'deploy',
+      move_class: 'deploy',
+      decision: 'REJECT',
+      reason: 'not reachable',
+    });
+
+    saveGovernedPipelineState(statePath, state);
+    const restored = loadGovernedPipelineState(statePath, 'lane');
+    expect(restored.rejected_moves[0]?.move_class).toBe('deploy');
+    expect(restored.schema_version).toBe('scbe.agent_bus.governed_state.v1');
   });
 });


### PR DESCRIPTION
## Summary
- adds an opt-in persisted governed-state gate to agent-bus pipelines
- classifies each compiled plan as observe/read/verify/write/network/deploy/destructive and checks the reachable next-move set before execution
- records accepted and rejected moves to a session state file so completion depends on trajectory, not model self-report

## Test evidence
- npm test --prefix packages/agent-bus (235/235 passed)
- npm run build --prefix packages/agent-bus
- npm run lint --prefix packages/agent-bus
- git diff --check -- packages/agent-bus/src/index.ts packages/agent-bus/src/pipeline.ts packages/agent-bus/tests/pipeline.test.ts

## Rollback
- disable by omitting options.governedState; the gate is opt-in and does not affect default pipeline execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trajectory gate governance layer to control plan execution based on operation history
  * Plans are now evaluated against reachable move sets to prevent unauthorized execution
  * Added persistent state tracking to record accepted and rejected moves across sessions
  * New `governedState` configuration option enables governance with customizable session identifiers and state paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->