### PR TITLE
feat(governance): durable state + periodic autosave for RuntimeGate

### DIFF
--- a/.github/workflows/video-upload.yml
+++ b/.github/workflows/video-upload.yml
@@ -116,8 +116,7 @@ jobs:
           pip install pytest --quiet
           python -m scripts.system.geoseal_llm_verify \
             --json "{\"op\":\"upload\",\"file\":\"${{ github.event.inputs.video_path }}\",\"sha256\":\"${{ steps.verify.outputs.sha256 }}\"}" \
-            --dry-run --quiet || true
-        continue-on-error: true
+            --dry-run --quiet
 
       - name: Upload to YouTube (resumable)
         env:

--- a/docs/articles/2026-05-23-how-a-dnd-campaign-became-an-ai-governance-framework.md
+++ b/docs/articles/2026-05-23-how-a-dnd-campaign-became-an-ai-governance-framework.md
@@ -79,4 +79,4 @@ The game taught me what the dimensions were. The math just named them properly.
 
 ---
 
-*Related: [The Six Sacred Tongues as a coordinate system](/articles/the-six-sacred-tongues-coordinate-system) | [Hyperbolic geometry for AI governance](/articles/hyperbolic-geometry-for-ai-governance)*
+*Related: [The Six Sacred Tongues as a coordinate system](2026-05-23-the-six-sacred-tongues-coordinate-system.md) | [Hyperbolic geometry for AI governance](2026-05-23-hyperbolic-geometry-for-ai-governance.md)*

--- a/docs/articles/2026-05-23-hyperbolic-geometry-for-ai-governance.md
+++ b/docs/articles/2026-05-23-hyperbolic-geometry-for-ai-governance.md
@@ -90,4 +90,4 @@ The codebase: [issdandavis/SCBE-AETHERMOORE](https://github.com/issdandavis/SCBE
 
 ---
 
-*Related: [The Six Sacred Tongues as a coordinate system](/articles/the-six-sacred-tongues-coordinate-system)*
+*Related: [The Six Sacred Tongues as a coordinate system](2026-05-23-the-six-sacred-tongues-coordinate-system.md)*

--- a/docs/articles/2026-05-23-the-problem-with-probability-in-ai-safety.md
+++ b/docs/articles/2026-05-23-the-problem-with-probability-in-ai-safety.md
@@ -72,4 +72,4 @@ When a governance decision is deterministic and signed, you can do things that p
 
 The SCBE pipeline is open source. The determinism is testable. [issdandavis/SCBE-AETHERMOORE](https://github.com/issdandavis/SCBE-AETHERMOORE) — run `npm test` and watch the fixed-score assertions pass.
 
-*Related: [Deterministic AI governance: what it means to diff safety](/articles/deterministic-ai-governance-what-it-means-to-diff-safety)*
+*Related: [Deterministic AI governance: what it means to diff safety](2026-05-23-deterministic-ai-governance-what-it-means-to-diff-safety.md)*

--- a/docs/articles/2026-05-23-the-six-sacred-tongues-coordinate-system.md
+++ b/docs/articles/2026-05-23-the-six-sacred-tongues-coordinate-system.md
@@ -108,4 +108,4 @@ The full tokenizer source is in [src/tokenizer/](https://github.com/issdandavis/
 
 ---
 
-*Related: [What the harmonic wall is actually measuring](/articles/why-our-safety-system-scores-low)*
+*Related: [What the harmonic wall is actually measuring](2026-05-23-why-our-safety-system-scores-low.md)*

--- a/docs/articles/2026-05-23-why-our-safety-system-scores-low.md
+++ b/docs/articles/2026-05-23-why-our-safety-system-scores-low.md
@@ -93,4 +93,4 @@ No system catches everything. The geometry catches 74.2% in under 8ms with no in
 
 *Code: [src/harmonic/harmonicScaling.ts](https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/src/harmonic/harmonicScaling.ts)*
 
-*Related: [Hyperbolic geometry for AI governance](/articles/hyperbolic-geometry-for-ai-governance) | [The Six Sacred Tongues as a coordinate system](/articles/the-six-sacred-tongues-coordinate-system)*
+*Related: [Hyperbolic geometry for AI governance](2026-05-23-hyperbolic-geometry-for-ai-governance.md) | [The Six Sacred Tongues as a coordinate system](2026-05-23-the-six-sacred-tongues-coordinate-system.md)*

--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -214,6 +214,46 @@ def _runtime_gate_kwargs() -> dict[str, Any]:
     return kwargs
 
 
+def _runtime_gate_state_path() -> Optional[Path]:
+    """Where the gate's accumulated state is persisted, if configured.
+
+    Opt-in via SCBE_RUNTIME_GATE_STATE_PATH. There is no default location:
+    immune hashes can fingerprint observed attack patterns, so the operator
+    chooses where state lives (outside the repo by default).
+    """
+    raw = os.environ.get("SCBE_RUNTIME_GATE_STATE_PATH", "").strip()
+    return Path(raw) if raw else None
+
+
+def _restore_gate_state(gate) -> None:
+    """Restore persisted state into a freshly-created gate, if configured.
+
+    Best-effort: a missing or unreadable state file leaves the gate cold
+    rather than failing server start-up.
+    """
+    path = _runtime_gate_state_path()
+    if path is None or not path.exists():
+        return
+    try:
+        gate.load_state(path)
+        logger.info("RuntimeGate state restored from %s", path)
+    except Exception:
+        logger.warning("Failed to restore RuntimeGate state from %s; starting cold", path, exc_info=True)
+
+
+def _persist_gate_state() -> None:
+    """Persist the live gate's accumulated state, if one exists and a path is set."""
+    gate = _runtime_gate
+    path = _runtime_gate_state_path()
+    if gate is None or path is None:
+        return
+    try:
+        gate.save_state(path)
+        logger.info("RuntimeGate state saved to %s", path)
+    except Exception:
+        logger.warning("Failed to save RuntimeGate state to %s", path, exc_info=True)
+
+
 def _get_gate():
     """Return a shared RuntimeGate instance, initialised on first call."""
     global _runtime_gate
@@ -230,6 +270,8 @@ def _get_gate():
             except Exception:
                 logger.debug("RuntimeGate unavailable, governance gating disabled")
                 _runtime_gate = None
+        if _runtime_gate is not None:
+            _restore_gate_state(_runtime_gate)
     return _runtime_gate
 
 
@@ -421,6 +463,12 @@ if DOCS_DIR.exists():
     docs_static_dir = DOCS_DIR / "static"
     if docs_static_dir.exists():
         app.mount("/site/static", StaticFiles(directory=str(docs_static_dir)), name="docs-static")
+
+
+@app.on_event("shutdown")
+async def _save_gate_state_on_shutdown() -> None:
+    """Persist accumulated gate state on graceful shutdown (if configured)."""
+    _persist_gate_state()
 
 
 # =========================================================================== #

--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -17,6 +17,7 @@ import configparser
 from collections import Counter, defaultdict, deque
 import datetime
 import hashlib
+import hmac
 import json
 import logging
 import math
@@ -518,7 +519,7 @@ async def runtime_gate_checkpoint(request: Request) -> dict:
     admin_token = os.environ.get("SCBE_RUNTIME_GATE_ADMIN_TOKEN", "").strip()
     if not admin_token:
         raise HTTPException(status_code=403, detail="checkpoint endpoint disabled (no admin token configured)")
-    if request.headers.get("x-admin-token", "") != admin_token:
+    if not hmac.compare_digest(request.headers.get("x-admin-token", ""), admin_token):
         raise HTTPException(status_code=401, detail="invalid or missing X-Admin-Token")
 
     gate = _get_gate()

--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -35,7 +35,7 @@ from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -162,6 +162,7 @@ def _public_email_result(result: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 _runtime_gate = None
+_gate_eval_counter = 0
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -241,23 +242,58 @@ def _restore_gate_state(gate) -> None:
         logger.warning("Failed to restore RuntimeGate state from %s; starting cold", path, exc_info=True)
 
 
-def _persist_gate_state() -> None:
-    """Persist the live gate's accumulated state, if one exists and a path is set."""
+def _persist_gate_state(keep_previous: bool = False) -> bool:
+    """Persist the live gate's accumulated state, if one exists and a path is set.
+
+    Returns True if a save was attempted and succeeded. When ``keep_previous``
+    is set the prior snapshot is rotated to ``<name>.prev`` for rollback.
+    """
     gate = _runtime_gate
     path = _runtime_gate_state_path()
     if gate is None or path is None:
-        return
+        return False
     try:
-        gate.save_state(path)
+        gate.save_state(path, keep_previous=keep_previous)
         logger.info("RuntimeGate state saved to %s", path)
+        return True
     except Exception:
         logger.warning("Failed to save RuntimeGate state to %s", path, exc_info=True)
+        return False
+
+
+def _checkpoint_every() -> int:
+    """How many evaluate() calls between autosaves (0 disables periodic saves)."""
+    raw = os.environ.get("SCBE_RUNTIME_GATE_CHECKPOINT_EVERY", "20").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("Ignoring invalid SCBE_RUNTIME_GATE_CHECKPOINT_EVERY=%r", raw)
+        return 20
+
+
+def _gate_evaluate(gate, action_text: str):
+    """Single choke point for gate.evaluate() that drives periodic checkpoints.
+
+    Every Nth evaluation (N = SCBE_RUNTIME_GATE_CHECKPOINT_EVERY, default 20)
+    the accumulated drift/immune state is checkpointed atomically with a
+    one-deep ``.prev`` rollback snapshot. No-op when no state path is set.
+    """
+    global _gate_eval_counter
+    result = gate.evaluate(action_text)
+    every = _checkpoint_every()
+    if every and _runtime_gate_state_path() is not None:
+        _gate_eval_counter += 1
+        if _gate_eval_counter >= every:
+            _gate_eval_counter = 0
+            _persist_gate_state(keep_previous=True)
+    return result
 
 
 def _get_gate():
     """Return a shared RuntimeGate instance, initialised on first call."""
-    global _runtime_gate
+    global _runtime_gate, _gate_eval_counter
     if _runtime_gate is None:
+        _gate_eval_counter = 0
         try:
             from governance.runtime_gate import RuntimeGate
 
@@ -468,7 +504,32 @@ if DOCS_DIR.exists():
 @app.on_event("shutdown")
 async def _save_gate_state_on_shutdown() -> None:
     """Persist accumulated gate state on graceful shutdown (if configured)."""
-    _persist_gate_state()
+    _persist_gate_state(keep_previous=True)
+
+
+@app.post("/runtime-gate/checkpoint")
+async def runtime_gate_checkpoint(request: Request) -> dict:
+    """Force a state checkpoint. Admin-guarded; disabled unless a token is set.
+
+    Requires SCBE_RUNTIME_GATE_ADMIN_TOKEN to be configured and a matching
+    X-Admin-Token header. Returns {ok, path, query_count}. The server has
+    wide-open CORS and no other auth, so this fails closed when no token is set.
+    """
+    admin_token = os.environ.get("SCBE_RUNTIME_GATE_ADMIN_TOKEN", "").strip()
+    if not admin_token:
+        raise HTTPException(status_code=403, detail="checkpoint endpoint disabled (no admin token configured)")
+    if request.headers.get("x-admin-token", "") != admin_token:
+        raise HTTPException(status_code=401, detail="invalid or missing X-Admin-Token")
+
+    gate = _get_gate()
+    path = _runtime_gate_state_path()
+    if gate is None:
+        raise HTTPException(status_code=503, detail="RuntimeGate unavailable")
+    if path is None:
+        raise HTTPException(status_code=400, detail="SCBE_RUNTIME_GATE_STATE_PATH not configured")
+    if not _persist_gate_state(keep_previous=True):
+        raise HTTPException(status_code=500, detail="checkpoint failed")
+    return {"ok": True, "path": str(path), "query_count": gate._query_count}
 
 
 # =========================================================================== #
@@ -2046,7 +2107,7 @@ async def arena_compat_chat(req: ArenaCompatChatRequest):
     cost = 0.0
     if gate is not None:
         try:
-            gate_result = gate.evaluate(req.message)
+            gate_result = _gate_evaluate(gate, req.message)
             decision = gate_result.decision.value
             cost = round(gate_result.cost, 4)
         except Exception:
@@ -2337,7 +2398,7 @@ async def chat(req: ChatRequest):
 
     if gate is not None:
         try:
-            gr = gate.evaluate(req.message)
+            gr = _gate_evaluate(gate, req.message)
             decision = gr.decision.value
             trust_level = gr.trust_level
             fib_index = gr.trust_index
@@ -2445,7 +2506,7 @@ async def fact_check(req: FactCheckRequest):
     cost = 0.0
     if gate is not None:
         try:
-            gr = gate.evaluate(question)
+            gr = _gate_evaluate(gate, question)
             decision = gr.decision.value
             trust_level = gr.trust_level
             cost = round(gr.cost, 4)

--- a/scripts/connector_health_check.py
+++ b/scripts/connector_health_check.py
@@ -56,6 +56,37 @@ def _pick_env(*keys: str) -> tuple[str, str]:
     return "", ""
 
 
+def _pick_rclone_gdrive_token() -> tuple[str, str]:
+    """Fallback: read access_token from rclone gdrive config."""
+    try:
+        if os.name == "nt":
+            rclone_conf = Path(
+                os.environ.get("APPDATA", str(Path.home() / "AppData/Roaming"))
+            ) / "rclone" / "rclone.conf"
+        else:
+            rclone_conf = Path.home() / ".config" / "rclone" / "rclone.conf"
+        if not rclone_conf.exists():
+            return "", ""
+        content = rclone_conf.read_text(encoding="utf-8")
+        in_gdrive = False
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped == "[gdrive]":
+                in_gdrive = True
+                continue
+            if stripped.startswith("[") and in_gdrive:
+                break
+            if in_gdrive and stripped.startswith("token ="):
+                token_json = stripped.split("=", 1)[1].strip()
+                token_data = json.loads(token_json)
+                access_token = token_data.get("access_token", "")
+                if access_token:
+                    return "rclone_gdrive_config", access_token
+    except Exception:
+        pass
+    return "", ""
+
+
 def check_github(repo: str) -> CheckResult:
     key_name, token = _pick_env("GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT")
     if not token:
@@ -168,6 +199,8 @@ def check_notion(page_id: str = "") -> CheckResult:
 
 def check_drive() -> CheckResult:
     key_name, token = _pick_env("GOOGLE_DRIVE_ACCESS_TOKEN", "GDRIVE_ACCESS_TOKEN", "GOOGLE_OAUTH_ACCESS_TOKEN")
+    if not token:
+        key_name, token = _pick_rclone_gdrive_token()
     if not token:
         return CheckResult(
             name="drive",

--- a/scripts/security/code_governance_gate.py
+++ b/scripts/security/code_governance_gate.py
@@ -145,7 +145,7 @@ class GateResult:
 
 def run_cmd(cmd: str) -> str:
     """Run a shell command and return output."""
-    result = subprocess.run(shlex.split(cmd), capture_output=True, text=True, cwd=str(ROOT))
+    result = subprocess.run(shlex.split(cmd), capture_output=True, text=True, encoding="utf-8", cwd=str(ROOT))
     return result.stdout.strip()
 
 

--- a/src/governance/runtime_gate.py
+++ b/src/governance/runtime_gate.py
@@ -23,10 +23,12 @@ Dangerous actions are expensive. Impossible actions cost infinity.
 from __future__ import annotations
 
 import hashlib
+import json
 import math
 import os
 import re
 import time
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -471,6 +473,10 @@ class RuntimeGate:
         # Fibonacci trust history: aggregate ternary signal per query
         # +1 if spin_magnitude == 0 (clean), 0 if 1-3, -1 if 4+
         self._trust_history: List[int] = []
+
+        # Signals queued by load_state() to surface in the next evaluate()
+        # result (e.g. a config-drift warning), so audit sees the load event.
+        self._pending_load_signals: List[str] = []
 
         # Tongue coordinate backend
         self._coords_backend = (coords_backend or "stats").strip().lower()
@@ -973,6 +979,11 @@ class RuntimeGate:
         ts = time.time()
         action_hash = hashlib.blake2s(action_text.encode("utf-8", errors="replace"), digest_size=8).hexdigest()
 
+        # Drain any signals queued by load_state() (e.g. config-drift warning)
+        # so they land in this action's audit record on every decision path.
+        _carry = self._pending_load_signals
+        self._pending_load_signals = []
+
         # ---- Bijective tamper + identifier canonicality overlays (top-of-evaluate) ----
         # Both signals are monotonic — they can only RAISE severity. We compute
         # them once at the top so calibration / immune / reflex / reroute all see
@@ -1021,7 +1032,7 @@ class RuntimeGate:
         # Catastrophic short-circuit: either overlay recommending DENY ends here.
         if (tamper_decision == Decision.DENY) or (canonicality_decision == Decision.DENY):
             self._immune.add(action_hash)
-            signals_short: List[str] = []
+            signals_short: List[str] = list(_carry)
             if tamper_data is not None:
                 signals_short.append(
                     self._tamper_receipt_signal(
@@ -1135,7 +1146,7 @@ class RuntimeGate:
             self._cumulative_cost += 1.0  # nominal cost during calibration
             self._trust_history.append(1)  # calibration = +1 trust
             fib = fibonacci_trust_level(self._trust_history)
-            calib_signals = ["calibrating"]
+            calib_signals = [*_carry, "calibrating"]
             calib_decision = Decision.ALLOW
             if tamper_data is not None:
                 calib_signals.append(
@@ -1205,7 +1216,7 @@ class RuntimeGate:
 
         # Immune memory: known attack → instant DENY + noise
         if action_hash in self._immune:
-            immune_signals = ["immune_memory_hit"]
+            immune_signals = [*_carry, "immune_memory_hit"]
             if tamper_data is not None:
                 immune_signals.append(
                     self._tamper_receipt_signal(
@@ -1255,7 +1266,7 @@ class RuntimeGate:
         if action_hash in self._reflex and not classifier_quarantine:
             self._trust_history.append(1)  # known-safe = +1 trust
             fib = fibonacci_trust_level(self._trust_history)
-            reflex_signals = ["reflex_hit"]
+            reflex_signals = [*_carry, "reflex_hit"]
             reflex_decision = Decision.ALLOW
             if tamper_data is not None:
                 reflex_signals.append(
@@ -1378,7 +1389,7 @@ class RuntimeGate:
             or classifier_quarantine
             or reroute_high_confidence
         ):
-            reroute_signals = [f"reroute_match({reroute_rule.pattern})"]
+            reroute_signals = [*_carry, f"reroute_match({reroute_rule.pattern})"]
             if reroute_high_confidence:
                 reroute_signals.append("high_confidence_match")
             else:
@@ -1465,7 +1476,7 @@ class RuntimeGate:
         effective_cost_quarantine = self.cost_quarantine * trust_multiplier
         effective_cost_deny = self.cost_deny * trust_multiplier
 
-        signals: List[str] = [f"fib_trust({trust_level},w={trust_weight},idx={trust_index})"]
+        signals: List[str] = [*_carry, f"fib_trust({trust_level},w={trust_weight},idx={trust_index})"]
 
         if _is_high_confidence_override_attempt(full_text):
             signals.append("override_quarantine(high_confidence)")
@@ -2246,3 +2257,125 @@ class RuntimeGate:
             "trust_history_length": len(self._trust_history),
             "trichromatic_enabled": self._trichromatic_enabled,
         }
+
+    # ------------------------------------------------------------------ #
+    #  State persistence — durable home for accumulated session state
+    #
+    #  Persists the full drift trajectory (centroid, cumulative cost, query
+    #  count, trust history) plus immune memory, so a restarted gate continues
+    #  the same session instead of starting cold.
+    #
+    #  Deliberately NOT persisted:
+    #    - _reflex: a runtime-learned fast-path cache; rebuilt empty per
+    #      process so a tightened policy is never bypassed by a stale
+    #      "previously allowed" action.
+    #    - _audit_log: telemetry (durable audit belongs in the HYDRA Ledger).
+    #    - trichromatic engine baseline: known v1.1 gap.
+    # ------------------------------------------------------------------ #
+
+    STATE_SCHEMA = "runtime-gate-state/v1"
+
+    def _policy_fingerprint(self) -> Dict[str, Any]:
+        """Config the persisted state depends on, recorded for drift detection.
+
+        These are NOT restored by load_state (they come from the constructor).
+        They are stored so a snapshot built under one backend/threshold set can
+        be flagged — not refused — when loaded into a differently-configured gate.
+        """
+        return {
+            "coords_backend": self._coords_backend,
+            "cost_allow": self.cost_allow,
+            "cost_quarantine": self.cost_quarantine,
+            "cost_deny": self.cost_deny,
+            "spin_quarantine": self.spin_quarantine,
+            "spin_deny": self.spin_deny,
+            "cumulative_cost_quarantine": self.cumulative_cost_quarantine,
+            "cumulative_cost_deny": self.cumulative_cost_deny,
+        }
+
+    def save_state(self, path: Any) -> None:
+        """Persist accumulated session state to a JSON file via an atomic write.
+
+        The caller chooses the path; there is no default location, because immune
+        hashes can fingerprint observed attack patterns and should not be written
+        into the repo by default.
+        """
+        p = Path(path)
+        centroid = self._centroid.tolist() if self._centroid is not None else None
+        snapshot = {
+            "schema": self.STATE_SCHEMA,
+            "saved_at": time.time(),
+            "policy": self._policy_fingerprint(),
+            "state": {
+                "centroid": centroid,
+                "centroid_count": self._centroid_count,
+                "cumulative_cost": self._cumulative_cost,
+                "query_count": self._query_count,
+                "trust_history": list(self._trust_history),
+                "immune": sorted(self._immune),
+            },
+            "derived_not_persisted": ["reflex", "audit_log", "trichromatic_baseline"],
+            "notes": (
+                "reflex is rebuilt per-process; audit_log is telemetry (see HYDRA "
+                "Ledger); trichromatic baseline restore is a v1.1 gap."
+            ),
+        }
+        if p.parent and not p.parent.exists():
+            p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_name(p.name + ".tmp")
+        tmp.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+        os.replace(tmp, p)
+
+    def load_state(self, path: Any) -> None:
+        """Restore accumulated state from a save_state() snapshot into this gate.
+
+        Config (thresholds, backend, overlay flags) is NOT restored — it comes
+        from this gate's constructor. If the snapshot's policy fingerprint differs
+        from this gate's, the load still proceeds, but a RuntimeWarning is issued
+        and a ``state_loaded_config_drift`` signal is queued onto the next
+        evaluate() result so the audit trail records the mismatch.
+
+        Raises:
+            FileNotFoundError: the path does not exist.
+            ValueError: the file is empty, not valid JSON, or not a recognized
+                runtime-gate-state snapshot.
+        """
+        p = Path(path)
+        raw = p.read_text(encoding="utf-8")  # FileNotFoundError propagates if missing
+        if not raw.strip():
+            raise ValueError(f"empty runtime-gate state file: {p}")
+        try:
+            snapshot = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"corrupted runtime-gate state file {p}: {exc}") from exc
+        if not isinstance(snapshot, dict) or snapshot.get("schema") != self.STATE_SCHEMA:
+            got = snapshot.get("schema") if isinstance(snapshot, dict) else type(snapshot).__name__
+            raise ValueError(
+                f"unrecognized runtime-gate state in {p}: expected schema {self.STATE_SCHEMA!r}, got {got!r}"
+            )
+
+        state = snapshot.get("state", {})
+        centroid = state.get("centroid")
+        self._centroid = np.array(centroid, dtype=float) if centroid is not None else None
+        self._centroid_count = int(state.get("centroid_count", 0))
+        self._cumulative_cost = float(state.get("cumulative_cost", 0.0))
+        self._query_count = int(state.get("query_count", 0))
+        self._trust_history = [int(x) for x in state.get("trust_history", [])]
+        self._immune = set(state.get("immune", []))
+        # _reflex is a runtime-learned cache; rebuild empty so a tightened policy
+        # is never silently bypassed by a previously-allowed action.
+        self._reflex = {}
+
+        # Config-drift detection: warn (never refuse) and surface in audit.
+        saved_policy = snapshot.get("policy", {})
+        current_policy = self._policy_fingerprint()
+        all_keys = set(saved_policy) | set(current_policy)
+        drift = sorted(k for k in all_keys if saved_policy.get(k) != current_policy.get(k))
+        if drift:
+            warnings.warn(
+                f"runtime-gate state loaded from {p} was saved under different config; "
+                f"drifted fields: {', '.join(drift)}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            self._pending_load_signals.append(f"state_loaded_config_drift(fields={'|'.join(drift)})")

--- a/src/governance/runtime_gate.py
+++ b/src/governance/runtime_gate.py
@@ -264,7 +264,9 @@ DEFAULT_REROUTES: List[RerouteRule] = [
     ),
     RerouteRule("delete.*all|drop.*table|rm.*-rf", "soft_delete", "destructive op → soft delete"),
     RerouteRule(
-        "api.*key|client.*secret|secret.*key|access.*token|auth.*token|bearer.*token|oauth.*token|refresh.*token|session.*token|password|credential|seed.*phrase|wallet.*key|private.*key",
+        "api.*key|client.*secret|secret.*key|access.*token|auth.*token|"
+        "bearer.*token|oauth.*token|refresh.*token|session.*token|"
+        "password|credential|seed.*phrase|wallet.*key|private.*key",
         "redact_and_log",
         "credential access → redacted",
     ),
@@ -2293,12 +2295,16 @@ class RuntimeGate:
             "cumulative_cost_deny": self.cumulative_cost_deny,
         }
 
-    def save_state(self, path: Any) -> None:
+    def save_state(self, path: Any, keep_previous: bool = False) -> None:
         """Persist accumulated session state to a JSON file via an atomic write.
 
         The caller chooses the path; there is no default location, because immune
         hashes can fingerprint observed attack patterns and should not be written
         into the repo by default.
+
+        When ``keep_previous`` is set, the prior good snapshot is copied to a
+        sibling ``<name>.prev`` before the new state is written, so a checkpoint
+        always leaves a one-deep rollback target on disk.
         """
         p = Path(path)
         centroid = self._centroid.tolist() if self._centroid is not None else None
@@ -2322,6 +2328,15 @@ class RuntimeGate:
         }
         if p.parent and not p.parent.exists():
             p.parent.mkdir(parents=True, exist_ok=True)
+        if keep_previous and p.exists():
+            prev = p.with_name(p.name + ".prev")
+            prev_tmp = p.with_name(p.name + ".prev.tmp")
+            try:
+                prev_tmp.write_bytes(p.read_bytes())
+                os.replace(prev_tmp, prev)
+            except OSError:
+                # best-effort rollback snapshot; never block the primary save
+                prev_tmp.unlink(missing_ok=True)
         tmp = p.with_name(p.name + ".tmp")
         tmp.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
         os.replace(tmp, p)

--- a/tests/governance/test_runtime_gate_persistence.py
+++ b/tests/governance/test_runtime_gate_persistence.py
@@ -1,0 +1,238 @@
+"""Persistence tests for RuntimeGate.save_state / load_state.
+
+Contract:
+  1. round-trip preserves the decision path for a novel probe (same config)
+  2. _immune persists; _reflex is rebuilt empty (not a stale bypass)
+  3. centroid=None (fresh gate) round-trips
+  4. config drift warns (never refuses) and surfaces a signal in the next
+     evaluate(); the signal appears exactly once
+  5. same config => no warning, no drift signal
+  6. atomic write leaves no .tmp and a schema-tagged JSON
+  7. missing / empty / corrupted / wrong-schema files raise cleanly
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.governance.runtime_gate import Decision, RuntimeGate  # noqa: E402
+
+# Benign warm-up traffic (stats backend, dependency-free, deterministic).
+WARMUP = (
+    "read the project README file",
+    "list the files in the docs folder",
+    "open the changelog and show recent entries",
+    "summarize the contents of the config directory",
+    "count the test files under the tests folder",
+    "show the table of contents for the manual",
+    "describe the layout of the source tree",
+    "report the size of the build output",
+)
+PROBE = "summarize the meeting notes from yesterday afternoon"
+
+
+def _warm(gate: RuntimeGate) -> None:
+    for text in WARMUP:
+        gate.evaluate(text)
+
+
+# --------------------------------------------------------------------------- #
+#  1. round-trip preserves the decision path
+# --------------------------------------------------------------------------- #
+
+
+def test_round_trip_preserves_decision_for_novel_probe(tmp_path):
+    a = RuntimeGate()
+    _warm(a)
+    state_file = tmp_path / "gate.json"
+    a.save_state(state_file)
+
+    b = RuntimeGate()
+    b.load_state(state_file)
+
+    # State scalars are restored exactly.
+    assert b._query_count == a._query_count
+    assert b._centroid_count == a._centroid_count
+    assert b._cumulative_cost == pytest.approx(a._cumulative_cost)
+    assert b._trust_history == a._trust_history
+    assert b._centroid.tolist() == pytest.approx(a._centroid.tolist())
+
+    # A novel probe (not in A's reflex) takes the full path on both → identical.
+    ra = a.evaluate(PROBE)
+    rb = b.evaluate(PROBE)
+    assert ra.decision == rb.decision
+    assert ra.spin_magnitude == rb.spin_magnitude
+    assert ra.trust_level == rb.trust_level
+    assert ra.cost == pytest.approx(rb.cost)
+    assert ra.tongue_coords == pytest.approx(rb.tongue_coords)
+
+
+# --------------------------------------------------------------------------- #
+#  2. immune persists; reflex is rebuilt empty
+# --------------------------------------------------------------------------- #
+
+
+def test_immune_persists_reflex_does_not(tmp_path):
+    a = RuntimeGate()
+    _warm(a)
+    a._immune.add("deadbeefcafef00d")
+    a._reflex["abc123previouslyallowed"] = True
+    assert a._reflex  # A has a warmed reflex cache
+
+    state_file = tmp_path / "gate.json"
+    a.save_state(state_file)
+
+    b = RuntimeGate()
+    b.load_state(state_file)
+
+    assert "deadbeefcafef00d" in b._immune  # attack memory survives
+    assert b._reflex == {}  # fast-path cache rebuilt empty, no stale bypass
+
+    # The snapshot self-documents what it intentionally drops.
+    snapshot = json.loads(state_file.read_text(encoding="utf-8"))
+    assert "reflex" in snapshot["derived_not_persisted"]
+
+
+# --------------------------------------------------------------------------- #
+#  3. fresh gate (centroid None) round-trips
+# --------------------------------------------------------------------------- #
+
+
+def test_fresh_gate_centroid_none_round_trips(tmp_path):
+    a = RuntimeGate()
+    assert a._centroid is None
+    state_file = tmp_path / "fresh.json"
+    a.save_state(state_file)
+
+    b = RuntimeGate()
+    b.load_state(state_file)
+    assert b._centroid is None
+    assert b._query_count == 0
+    assert b._immune == set()
+
+
+# --------------------------------------------------------------------------- #
+#  4. config drift warns + surfaces a signal exactly once
+# --------------------------------------------------------------------------- #
+
+
+def test_config_drift_warns_and_signals_once(tmp_path):
+    a = RuntimeGate(cost_deny=200.0)
+    _warm(a)
+    state_file = tmp_path / "gate.json"
+    a.save_state(state_file)
+
+    b = RuntimeGate(cost_deny=999.0)  # drifted threshold
+    with pytest.warns(RuntimeWarning, match="different config"):
+        b.load_state(state_file)
+
+    first = b.evaluate(PROBE)
+    assert any(s.startswith("state_loaded_config_drift") for s in first.signals)
+    assert any("cost_deny" in s for s in first.signals if s.startswith("state_loaded_config_drift"))
+
+    # The warning is consumed — it does not repeat on the next action.
+    second = b.evaluate("another unrelated benign request")
+    assert not any(s.startswith("state_loaded_config_drift") for s in second.signals)
+
+
+def test_backend_drift_is_detected(tmp_path):
+    a = RuntimeGate(coords_backend="stats")
+    _warm(a)
+    state_file = tmp_path / "gate.json"
+    a.save_state(state_file)
+
+    b = RuntimeGate(coords_backend="semantic")
+    with pytest.warns(RuntimeWarning):
+        b.load_state(state_file)
+    result = b.evaluate(PROBE)
+    drift = [s for s in result.signals if s.startswith("state_loaded_config_drift")]
+    assert drift and "coords_backend" in drift[0]
+
+
+# --------------------------------------------------------------------------- #
+#  5. same config => no warning, no drift signal
+# --------------------------------------------------------------------------- #
+
+
+def test_same_config_no_warning(tmp_path):
+    a = RuntimeGate()
+    _warm(a)
+    state_file = tmp_path / "gate.json"
+    a.save_state(state_file)
+
+    b = RuntimeGate()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning fails the test
+        b.load_state(state_file)
+
+    result = b.evaluate(PROBE)
+    assert not any(s.startswith("state_loaded_config_drift") for s in result.signals)
+
+
+# --------------------------------------------------------------------------- #
+#  6. atomic write hygiene
+# --------------------------------------------------------------------------- #
+
+
+def test_atomic_write_leaves_no_tmp(tmp_path):
+    gate = RuntimeGate()
+    _warm(gate)
+    state_file = tmp_path / "nested" / "dir" / "gate.json"
+    gate.save_state(state_file)
+
+    assert state_file.exists()
+    assert not (state_file.parent / "gate.json.tmp").exists()
+    assert list(state_file.parent.glob("*.tmp")) == []
+
+    snapshot = json.loads(state_file.read_text(encoding="utf-8"))
+    assert snapshot["schema"] == RuntimeGate.STATE_SCHEMA
+    assert "immune" in snapshot["state"]
+
+
+# --------------------------------------------------------------------------- #
+#  7. bad inputs raise cleanly
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_file_raises_filenotfound(tmp_path):
+    gate = RuntimeGate()
+    with pytest.raises(FileNotFoundError):
+        gate.load_state(tmp_path / "does-not-exist.json")
+
+
+def test_empty_file_raises_valueerror(tmp_path):
+    p = tmp_path / "empty.json"
+    p.write_text("", encoding="utf-8")
+    gate = RuntimeGate()
+    with pytest.raises(ValueError, match="empty"):
+        gate.load_state(p)
+
+
+def test_corrupted_json_raises_valueerror(tmp_path):
+    p = tmp_path / "corrupt.json"
+    p.write_text("{not valid json at all", encoding="utf-8")
+    gate = RuntimeGate()
+    with pytest.raises(ValueError, match="corrupted"):
+        gate.load_state(p)
+
+
+def test_wrong_schema_raises_valueerror(tmp_path):
+    p = tmp_path / "wrong.json"
+    p.write_text(json.dumps({"schema": "something-else/v9", "state": {}}), encoding="utf-8")
+    gate = RuntimeGate()
+    with pytest.raises(ValueError, match="unrecognized"):
+        gate.load_state(p)
+
+
+def test_decision_enum_importable():
+    # Guards the import surface the persistence tests rely on.
+    assert Decision.ALLOW.value == "ALLOW"

--- a/tests/governance/test_runtime_gate_wiring.py
+++ b/tests/governance/test_runtime_gate_wiring.py
@@ -1,0 +1,187 @@
+"""Wiring tests for RuntimeGate autosave/checkpoint plumbing in the API server.
+
+These exercise the server-side helpers (not the gate methods directly):
+
+  1. periodic checkpoint fires every Nth evaluate(), and a cold restart through
+     _get_gate() continues _query_count / centroid / trust_history / immune while
+     _reflex does NOT persist  -> the user's literal acceptance test
+  2. a checkpoint rotates the prior snapshot to <name>.prev (rollback fallback)
+  3. the new-gate path resets the eval counter
+  4. the shutdown hook persists (and rotates) when configured
+  5. no state path  -> evaluate() still works, nothing is written
+  6. the manual checkpoint endpoint fails closed without an admin token,
+     401s on a bad token, and returns {ok, path, query_count} with the right one
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (REPO_ROOT, REPO_ROOT / "src"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+WARMUP = (
+    "read the project README file",
+    "list the files in the docs folder",
+    "open the changelog and show recent entries",
+    "summarize the contents of the config directory",
+    "count the test files under the tests folder",
+    "show the table of contents for the manual",
+)
+
+
+def _load_server():
+    path = (REPO_ROOT / "scripts" / "aetherbrowser" / "api_server.py").resolve()
+    spec = importlib.util.spec_from_file_location("aether_api_server_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def server():
+    return _load_server()
+
+
+@pytest.fixture
+def srv(server, monkeypatch):
+    server._runtime_gate = None
+    server._gate_eval_counter = 0
+    monkeypatch.setenv("SCBE_COORDS_BACKEND", "stats")  # dependency-free backend
+    monkeypatch.delenv("SCBE_RUNTIME_GATE_STATE_PATH", raising=False)
+    monkeypatch.delenv("SCBE_RUNTIME_GATE_ADMIN_TOKEN", raising=False)
+    monkeypatch.delenv("SCBE_RUNTIME_GATE_CHECKPOINT_EVERY", raising=False)
+    yield server
+    server._runtime_gate = None
+    server._gate_eval_counter = 0
+
+
+# --------------------------------------------------------------------------- #
+#  1. periodic checkpoint + cold-restart continuity (the acceptance test)
+# --------------------------------------------------------------------------- #
+
+
+def test_periodic_checkpoint_survives_restart(srv, monkeypatch, tmp_path):
+    state = tmp_path / "gate" / "state.json"
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_STATE_PATH", str(state))
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_CHECKPOINT_EVERY", "3")
+
+    gate = srv._get_gate()
+    assert gate is not None
+
+    # 3 evaluations -> exactly one periodic checkpoint.
+    for text in WARMUP[:3]:
+        srv._gate_evaluate(gate, text)
+    assert state.exists()
+    assert srv._gate_eval_counter == 0  # reset after firing
+
+    # Plant learned attack memory + a fast-path reflex entry, then a 2nd save.
+    gate._immune.add("feedfacecafe0000")
+    gate._reflex["should_not_persist"] = True
+    for text in WARMUP[3:6]:
+        srv._gate_evaluate(gate, text)
+
+    assert state.with_name(state.name + ".prev").exists()  # rollback snapshot
+
+    q_before = gate._query_count
+    trust_before = list(gate._trust_history)
+    centroid_before = gate._centroid.tolist()
+    assert q_before == 6
+
+    # Cold restart: drop the singleton, dirty the counter, rebuild from disk.
+    srv._runtime_gate = None
+    srv._gate_eval_counter = 99
+    gate2 = srv._get_gate()
+
+    assert gate2 is not gate
+    assert srv._gate_eval_counter == 0  # rebuilding resets the counter
+    assert gate2._query_count == q_before  # drift trajectory continued
+    assert gate2._trust_history == trust_before
+    assert gate2._centroid.tolist() == pytest.approx(centroid_before)
+    assert "feedfacecafe0000" in gate2._immune  # immune memory continued
+    assert gate2._reflex == {}  # reflex did NOT persist (no stale bypass)
+
+
+# --------------------------------------------------------------------------- #
+#  4. shutdown hook persists + rotates
+# --------------------------------------------------------------------------- #
+
+
+def test_shutdown_hook_persists_and_rotates(srv, monkeypatch, tmp_path):
+    state = tmp_path / "state.json"
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_STATE_PATH", str(state))
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_CHECKPOINT_EVERY", "0")  # periodic OFF
+
+    gate = srv._get_gate()
+    for text in WARMUP[:4]:
+        srv._gate_evaluate(gate, text)
+    assert not state.exists()  # periodic disabled -> nothing yet
+
+    asyncio.run(srv._save_gate_state_on_shutdown())
+    assert state.exists()
+    assert not state.with_name(state.name + ".prev").exists()  # first save, no prior
+
+    asyncio.run(srv._save_gate_state_on_shutdown())
+    assert state.with_name(state.name + ".prev").exists()  # rotation on 2nd save
+
+
+# --------------------------------------------------------------------------- #
+#  5. no state path -> evaluate works, nothing written
+# --------------------------------------------------------------------------- #
+
+
+def test_no_state_path_is_noop(srv, tmp_path):
+    gate = srv._get_gate()
+    for text in WARMUP:
+        result = srv._gate_evaluate(gate, text)
+        assert result.decision is not None
+    assert srv._persist_gate_state(keep_previous=True) is False
+    assert list(tmp_path.iterdir()) == []
+
+
+# --------------------------------------------------------------------------- #
+#  6. manual checkpoint endpoint is admin-guarded and fails closed
+# --------------------------------------------------------------------------- #
+
+
+def _req(token: str | None):
+    headers = {} if token is None else {"x-admin-token": token}
+    return SimpleNamespace(headers=headers)
+
+
+def test_checkpoint_endpoint_disabled_without_token(srv, monkeypatch, tmp_path):
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_STATE_PATH", str(tmp_path / "s.json"))
+    with pytest.raises(srv.HTTPException) as exc:
+        asyncio.run(srv.runtime_gate_checkpoint(_req(None)))
+    assert exc.value.status_code == 403
+
+
+def test_checkpoint_endpoint_rejects_bad_token(srv, monkeypatch, tmp_path):
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_STATE_PATH", str(tmp_path / "s.json"))
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_ADMIN_TOKEN", "correct-horse")
+    with pytest.raises(srv.HTTPException) as exc:
+        asyncio.run(srv.runtime_gate_checkpoint(_req("wrong")))
+    assert exc.value.status_code == 401
+
+
+def test_checkpoint_endpoint_saves_with_valid_token(srv, monkeypatch, tmp_path):
+    state = tmp_path / "s.json"
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_STATE_PATH", str(state))
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_ADMIN_TOKEN", "correct-horse")
+
+    gate = srv._get_gate()
+    srv._gate_evaluate(gate, WARMUP[0])
+
+    body = asyncio.run(srv.runtime_gate_checkpoint(_req("correct-horse")))
+    assert body["ok"] is True
+    assert body["path"] == str(state)
+    assert body["query_count"] == gate._query_count
+    assert state.exists()


### PR DESCRIPTION
## Summary

Gives the production governance gate (`src/governance/runtime_gate.py`) a durable, restart-surviving home for its accumulated session state, plus a real-time checkpoint net.

- **Persistence** — `save_state(path)` / `load_state(path)` write the full drift trajectory (centroid + count, cumulative cost, query count, Fibonacci `_trust_history`) and the `_immune` attack-memory set to a schema-tagged JSON via an atomic write. `_reflex` is rebuilt empty per process (no stale bypass); `_audit_log` and the trichromatic baseline are intentionally excluded. Config drift **warns, never refuses**, and surfaces a one-shot signal on the next `evaluate()`.
- **Autosave + rollback** — `save_state(keep_previous=True)` rotates the prior snapshot to `<name>.prev` before writing, leaving a one-deep rollback target. The API server routes every `gate.evaluate()` through a single `_gate_evaluate()` choke point that checkpoints every Nth call (`SCBE_RUNTIME_GATE_CHECKPOINT_EVERY`, default 20) and on shutdown. The eval counter resets when a fresh gate is built.
- **Admin checkpoint endpoint** — `POST /runtime-gate/checkpoint`. The server has `*` CORS and no other auth, so it **fails closed**: disabled (403) unless `SCBE_RUNTIME_GATE_ADMIN_TOKEN` is set, 401 on a bad `X-Admin-Token` (compared with `hmac.compare_digest`). Returns `{ok, path, query_count}`.
- **No in-repo default path** — state location is operator-supplied via `SCBE_RUNTIME_GATE_STATE_PATH`; immune hashes can fingerprint observed attack patterns, so state is never written into the repo by default.
- **flake8 E501** — the credential-reroute regex is reformatted via implicit string concatenation. Verified **byte-identical** to the original; all 14 credential terms still match.

## Test plan

- [x] 12 persistence tests (`tests/governance/test_runtime_gate_persistence.py`) — round-trip, immune-persists/reflex-resets, config-drift warn+signal, atomic-write hygiene, bad-input handling.
- [x] 6 wiring tests (`tests/governance/test_runtime_gate_wiring.py`) — the acceptance test runs through the **server helpers** (`_gate_evaluate` / `_get_gate` / `_persist_gate_state`): periodic checkpoint, cold-restart continuity (query_count / centroid / trust / immune persist, `_reflex` does **not**), `.prev` rotation, counter reset, shutdown-hook save, no-path no-op, and the endpoint auth gate (403 / 401 / 200).
- [x] 60 core gate tests (`tests/test_runtime_gate.py`) stay green (covers the reformatted regex).
- [x] `black --check` clean; **zero new flake8** violations on the touched files.

## Isolation note (pre-existing, unrelated)

The broader `tests/governance/` dir shows 7 failed / 9 errored, all in the `bijective_tamper` overlay — **not** touched by this PR. Root cause is environmental: the overlay feeds a local Windows artifact path into HuggingFace's repo-id validator:

```
huggingface_hub.errors.HFValidationError: Repo id must use alphanumeric chars, '-', '_' or '.' ...:
'C:\Users\issda\SCBE-AETHERMOORE\artifacts\extended_tokenizer\qwen25-coder-7b-sacred-tongues'.
```

The FAILEDs are downstream ("missing bijective_tamper receipt") because the overlay can't load. None reference `runtime_gate`.

## Caveat

The eval counter is a module global, not lock-guarded — correct for a single-worker dev server. Behind multiple uvicorn workers it can double-fire or skip a checkpoint (the atomic write keeps the state file itself uncorrupted). A `threading.Lock` around the increment+save is the follow-up if this runs under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured article cross-references throughout documentation to use consistent relative link paths, improving navigation and maintainability.

* **Chores**
  * Strengthened deployment workflow with enhanced safety verification that now properly enforces governance checks.
  * Improved API server with persistent state management for governance gate operations.
  * Enhanced connector health checks with additional fallback token resolution support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->