### PR TITLE
feat(agent-bus): add Rubix browser planning adapter

### DIFF
--- a/packages/agent-bus/bin/scbe-agent-bus.cjs
+++ b/packages/agent-bus/bin/scbe-agent-bus.cjs
@@ -23,6 +23,7 @@ const {
   autoDiscoverTools,
   compilePlan,
   runPipeline,
+  buildRubixBrowserPlan,
 } = require('../dist/index.js');
 
 const HOSTED_INTAKE_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html';
@@ -112,6 +113,7 @@ Usage:
   scbe-agent-bus queue worker
   scbe-agent-bus plugins list --json
   scbe-agent-bus tools list --json
+  scbe-agent-bus rubix-browser plan --task "open docs and click download" --permissions visual.read,dom.read,tool.call --json
   scbe-agent-bus workspace new --hint customer-smoke --json
   scbe-agent-bus workspace ingest --workspace-root <path> --source-path <file> --json
   scbe-agent-bus workspace export --workspace-root <path> --json
@@ -131,6 +133,7 @@ Commands:
   queue     Inspect or run the event queue.
   plugins   List registered bus plugins.
   tools     List registered CLI tools (set SCBE_BUS_TOOLS=./tools.json to load).
+  rubix-browser Plan browser-control routes as permission-defined cube/tesseract faces.
   pipeline  Compile and run natural-language intents through GeoSeal governance.
   workspace Create, export, verify, and clean bus workspaces.
   upgrade   Show how to enable hosted runs (intake, credits, top-up).
@@ -628,6 +631,45 @@ async function main() {
       return;
     }
     process.stderr.write('Usage: scbe-agent-bus tools list [--json]\n');
+    process.exitCode = 2;
+    return;
+  }
+  if (command === 'rubix-browser') {
+    const action = String(flags._action || process.argv[3] || 'plan').trim();
+    if (action === 'plan') {
+      const task = String(flags.task || '').trim();
+      if (!task) {
+        process.stderr.write(
+          'Usage: scbe-agent-bus rubix-browser plan --task "..." [--permissions visual.read,dom.read] [--json]\n'
+        );
+        process.exitCode = 2;
+        return;
+      }
+      const permissions = String(flags.permissions || 'observe,visual.read,dom.read')
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean);
+      const payload = buildRubixBrowserPlan({ task, permissions });
+      if (flags.json) {
+        process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+      } else {
+        process.stdout.write(
+          [
+            `Rubix browser plan: ${payload.audit.verdict}`,
+            `Route: ${payload.route.map((move) => `${move.from}->${move.to}`).join(' | ')}`,
+            `Blocked moves: ${payload.blocked_moves.length}`,
+            `Route sha256: ${payload.audit.route_sha256}`,
+            payload.audit.reason,
+            '',
+          ].join('\n')
+        );
+      }
+      process.exitCode = payload.audit.verdict === 'PASS' ? 0 : 1;
+      return;
+    }
+    process.stderr.write(
+      'Usage: scbe-agent-bus rubix-browser plan --task "..." [--permissions visual.read,dom.read] [--json]\n'
+    );
     process.exitCode = 2;
     return;
   }

--- a/packages/agent-bus/docs/RUBIX_BROWSER_ADAPTER.md
+++ b/packages/agent-bus/docs/RUBIX_BROWSER_ADAPTER.md
@@ -1,0 +1,67 @@
+# Rubix Browser Adapter
+
+The Rubix browser adapter is an AI-native browser-control planning lane. It does not
+replace Playwright or a normal browser yet. It wraps browser work in a permission-defined
+cube/tesseract map so an agent can prove which faces of the browser it needs before any
+side effect happens.
+
+## Model
+
+The adapter treats browser control as a set of faces:
+
+| Face       | Axis      | Permission     | Purpose                             |
+| ---------- | --------- | -------------- | ----------------------------------- |
+| `viewport` | visual    | `visual.read`  | pixels, screenshots, visible text   |
+| `dom`      | structure | `dom.read`     | elements, labels, forms, attributes |
+| `network`  | transport | `network.read` | requests, responses, navigation     |
+| `storage`  | state     | `storage.read` | cookies, local storage, cache       |
+| `auth`     | identity  | `auth.read`    | login/session/account boundary      |
+| `tool`     | execution | `tool.call`    | clicks, typing, upload/download     |
+| `memory`   | memory    | `observe`      | deferred work, receipts, loop state |
+
+Each face has a four-dimensional coordinate. A task becomes a route through those faces.
+The route is allowed only when the required permissions are present. Missing permissions
+do not crash the plan; they produce `HOLD` with blocked-move evidence.
+
+## CLI
+
+```powershell
+node packages/agent-bus/bin/scbe-agent-bus.cjs rubix-browser plan `
+  --task "inspect the pricing page and summarize visible labels" `
+  --permissions observe,visual.read,dom.read `
+  --json
+```
+
+Side-effectful tasks hold unless the execution face is explicitly opened:
+
+```powershell
+node packages/agent-bus/bin/scbe-agent-bus.cjs rubix-browser plan `
+  --task "open the upload page, fill the form, and submit the video" `
+  --permissions observe,visual.read,dom.read `
+  --json
+```
+
+## Bus Tool
+
+`packages/agent-bus/tools.json` registers:
+
+```json
+{
+  "name": "rubix-browser-plan",
+  "description": "Plan a browser-control route as permission-defined Rubix/tesseract faces with blocked-move audit evidence"
+}
+```
+
+Any agent bus event can route to that tool before live browser execution.
+
+## Next Benchmark Step
+
+The next lane is a Playwright-backed benchmark adapter:
+
+1. Convert a task into a Rubix browser plan.
+2. Execute only `PASS` moves in Playwright.
+3. Write screenshots, DOM snapshots, and route receipts.
+4. Score browser-control pathfinding by completion, blocked moves, retries, and route hash.
+
+This keeps the claim narrow: SCBE can prove browser-control permission geometry before
+execution, then measure whether that geometry improves live browser automation.

--- a/packages/agent-bus/package-lock.json
+++ b/packages/agent-bus/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "husky": "^8.0.0",
-        "lint-staged": "^14.0.0",
+        "lint-staged": "^15.5.2",
         "prettier": "^3.2.0",
         "typescript": "^6.0.2",
         "vitest": "^4.0.17"
@@ -527,16 +527,16 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "type-fest": "^1.0.2"
+        "environment": "^1.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -615,33 +615,33 @@
       }
     },
     "node_modules/cli-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "restore-cursor": "^4.0.0"
+        "restore-cursor": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "slice-ansi": "^5.0.0",
-        "string-width": "^5.0.0"
+        "string-width": "^7.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -655,13 +655,13 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/convert-source-map": {
@@ -687,13 +687,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -714,19 +714,25 @@
         "node": ">=8"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
@@ -753,24 +759,24 @@
       "license": "MIT"
     },
     "node_modules/execa": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^4.3.0",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
         "is-stream": "^3.0.0",
         "merge-stream": "^2.0.0",
         "npm-run-path": "^5.1.0",
         "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
+        "signal-exit": "^4.1.0",
         "strip-final-newline": "^3.0.0"
       },
       "engines": {
-        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+        "node": ">=16.17"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -832,27 +838,40 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/human-signals": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.17.0"
       }
     },
     "node_modules/husky": {
@@ -1176,97 +1195,115 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lint-staged": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-14.0.1.tgz",
-      "integrity": "sha512-Mw0cL6HXnHN1ag0mN/Dg4g6sr8uf8sn98w2Oc1ECtFto9tvRF7nkXGJRbx8gPlHyoR0pLyBr2lQHbWwmUHe1Sw==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "5.3.0",
-        "commander": "11.0.0",
-        "debug": "4.3.4",
-        "execa": "7.2.0",
-        "lilconfig": "2.1.0",
-        "listr2": "6.6.1",
-        "micromatch": "4.0.5",
-        "pidtree": "0.6.0",
-        "string-argv": "0.3.2",
-        "yaml": "2.3.1"
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": ">=18.12.0"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
       }
     },
-    "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/listr2": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-6.6.1.tgz",
-      "integrity": "sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^3.1.0",
+        "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
         "eventemitter3": "^5.0.1",
-        "log-update": "^5.0.1",
-        "rfdc": "^1.3.0",
-        "wrap-ansi": "^8.1.0"
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
-      },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
+        "node": ">=18.0.0"
       }
     },
     "node_modules/log-update": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
-      "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^5.0.0",
-        "cli-cursor": "^4.0.0",
-        "slice-ansi": "^5.0.0",
-        "strip-ansi": "^7.0.1",
-        "wrap-ansi": "^8.0.1"
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/magic-string": {
@@ -1287,13 +1324,13 @@
       "license": "MIT"
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -1326,10 +1363,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1504,43 +1554,33 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/restore-cursor/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/restore-cursor/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mimic-fn": "^2.1.0"
+        "mimic-function": "^5.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1618,11 +1658,17 @@
       "license": "ISC"
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
@@ -1676,18 +1722,18 @@
       }
     },
     "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1786,19 +1832,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -2023,21 +2056,37 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -64,11 +64,11 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^6.0.2",
-    "vitest": "^4.0.17",
-    "prettier": "^3.2.0",
     "husky": "^8.0.0",
-    "lint-staged": "^14.0.0"
+    "lint-staged": "^15.5.2",
+    "prettier": "^3.2.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.0.17"
   },
   "lint-staged": {
     "*.{ts,js,json,md}": [

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -126,6 +126,15 @@ export {
   autoDiscoverTools,
 } from './tools.js';
 
+export {
+  type RubixBrowserFace,
+  type RubixBrowserMove,
+  type RubixBrowserPermission,
+  type RubixBrowserPlan,
+  RUBIX_BROWSER_FACES,
+  buildRubixBrowserPlan,
+} from './rubix-browser.js';
+
 export type AgentBusPrivacy = 'local_only' | 'remote_allowed' | string;
 
 export interface AgentBusEvent {

--- a/packages/agent-bus/src/rubix-browser.ts
+++ b/packages/agent-bus/src/rubix-browser.ts
@@ -1,0 +1,291 @@
+import crypto from 'node:crypto';
+
+export type RubixBrowserPermission =
+  | 'observe'
+  | 'visual.read'
+  | 'dom.read'
+  | 'dom.write'
+  | 'network.read'
+  | 'network.write'
+  | 'storage.read'
+  | 'storage.write'
+  | 'auth.read'
+  | 'auth.write'
+  | 'tool.call'
+  | 'external.open'
+  | string;
+
+export interface RubixBrowserFace {
+  id: string;
+  label: string;
+  axis: 'visual' | 'structure' | 'transport' | 'state' | 'identity' | 'execution' | 'memory';
+  coordinate: [number, number, number, number];
+  required_permission: RubixBrowserPermission;
+  risk: 'low' | 'medium' | 'high';
+  description: string;
+}
+
+export interface RubixBrowserMove {
+  index: number;
+  from: string;
+  to: string;
+  direction: string;
+  required_permission: RubixBrowserPermission;
+  allowed: boolean;
+  reason: string;
+}
+
+export interface RubixBrowserPlan {
+  schema_version: 'scbe.rubix_browser_plan.v1';
+  task: string;
+  mode: 'plan';
+  generated_at: string;
+  permissions: RubixBrowserPermission[];
+  faces: RubixBrowserFace[];
+  demanded_faces: string[];
+  route: RubixBrowserMove[];
+  blocked_moves: RubixBrowserMove[];
+  closed_loop: boolean;
+  route_reversible: boolean;
+  cube_projection: {
+    dimension_count: number;
+    root_face: string;
+    tip: [number, number];
+    fog_of_war: string[];
+    visible_faces: string[];
+  };
+  audit: {
+    route_sha256: string;
+    permission_sha256: string;
+    verdict: 'PASS' | 'HOLD';
+    reason: string;
+  };
+}
+
+export interface BuildRubixBrowserPlanOptions {
+  task: string;
+  permissions?: Iterable<RubixBrowserPermission>;
+  generatedAt?: string;
+}
+
+export const RUBIX_BROWSER_FACES: readonly RubixBrowserFace[] = [
+  {
+    id: 'viewport',
+    label: 'Viewport Face',
+    axis: 'visual',
+    coordinate: [0, 0, 1, 0],
+    required_permission: 'visual.read',
+    risk: 'low',
+    description: 'Pixels, visible text, screenshots, and spatial focus.',
+  },
+  {
+    id: 'dom',
+    label: 'DOM Face',
+    axis: 'structure',
+    coordinate: [1, 0, 0, 0],
+    required_permission: 'dom.read',
+    risk: 'low',
+    description: 'Elements, attributes, labels, forms, and page structure.',
+  },
+  {
+    id: 'network',
+    label: 'Network Face',
+    axis: 'transport',
+    coordinate: [0, 1, 0, 0],
+    required_permission: 'network.read',
+    risk: 'medium',
+    description: 'Requests, responses, external fetches, and navigation traffic.',
+  },
+  {
+    id: 'storage',
+    label: 'Storage Face',
+    axis: 'state',
+    coordinate: [-1, 0, 0, 0],
+    required_permission: 'storage.read',
+    risk: 'medium',
+    description: 'Cookies, local storage, cache, and durable browser state.',
+  },
+  {
+    id: 'auth',
+    label: 'Auth Face',
+    axis: 'identity',
+    coordinate: [0, -1, 0, 0],
+    required_permission: 'auth.read',
+    risk: 'high',
+    description: 'Session identity, login state, account boundaries, and credentials.',
+  },
+  {
+    id: 'tool',
+    label: 'Tool Face',
+    axis: 'execution',
+    coordinate: [0, 0, -1, 0],
+    required_permission: 'tool.call',
+    risk: 'high',
+    description: 'Clicks, typing, downloads, uploads, and side-effectful browser actions.',
+  },
+  {
+    id: 'memory',
+    label: 'Memory Face',
+    axis: 'memory',
+    coordinate: [0, 0, 0, 1],
+    required_permission: 'observe',
+    risk: 'low',
+    description: 'Deferred work, task ticker state, receipts, and loop context.',
+  },
+];
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: unknown): string {
+  return crypto.createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+function normalizePermissions(values: Iterable<RubixBrowserPermission> | undefined): Set<string> {
+  const permissions = new Set<string>(['observe']);
+  for (const value of values || []) {
+    const trimmed = String(value || '').trim();
+    if (trimmed) permissions.add(trimmed);
+  }
+  if (permissions.has('visual')) permissions.add('visual.read');
+  if (permissions.has('dom')) permissions.add('dom.read');
+  if (permissions.has('network')) permissions.add('network.read');
+  if (permissions.has('storage')) permissions.add('storage.read');
+  if (permissions.has('auth')) permissions.add('auth.read');
+  if (permissions.has('tool')) permissions.add('tool.call');
+  return permissions;
+}
+
+function wants(task: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(task));
+}
+
+function inferDemandedFaces(task: string): string[] {
+  const text = task.toLowerCase();
+  const demanded = new Set<string>(['viewport', 'dom', 'memory']);
+  if (
+    wants(text, [/\bclick\b/, /\btype\b/, /\bsubmit\b/, /\bupload\b/, /\bdownload\b/, /\bfill\b/])
+  ) {
+    demanded.add('tool');
+  }
+  if (wants(text, [/\blogin\b/, /\bsign[ -]?in\b/, /\bauth\b/, /\baccount\b/, /\bcredential\b/])) {
+    demanded.add('auth');
+  }
+  if (wants(text, [/\bcookie\b/, /\blocal\s*storage\b/, /\bsession\b/, /\bcache\b/, /\bstate\b/])) {
+    demanded.add('storage');
+  }
+  if (
+    wants(text, [/\bapi\b/, /\bfetch\b/, /\brequest\b/, /\bnetwork\b/, /\bwebhook\b/, /\burl\b/])
+  ) {
+    demanded.add('network');
+  }
+  return Array.from(demanded);
+}
+
+function directionBetween(from: RubixBrowserFace, to: RubixBrowserFace): string {
+  const delta = to.coordinate.map((value, index) => value - from.coordinate[index]);
+  const names = ['x', 'y', 'z', 'w'];
+  return (
+    delta
+      .map((value, index) => (value === 0 ? '' : `${value > 0 ? '+' : '-'}${names[index]}`))
+      .filter(Boolean)
+      .join('/') || 'hold'
+  );
+}
+
+function canUse(face: RubixBrowserFace, permissions: Set<string>): boolean {
+  return permissions.has(face.required_permission) || permissions.has('*');
+}
+
+function permissionForMove(face: RubixBrowserFace): RubixBrowserPermission {
+  return face.required_permission;
+}
+
+export function buildRubixBrowserPlan(options: BuildRubixBrowserPlanOptions): RubixBrowserPlan {
+  const task = String(options.task || '').trim();
+  if (!task) {
+    throw new Error('rubix browser plan requires a non-empty task');
+  }
+
+  const generatedAt = options.generatedAt || new Date().toISOString();
+  const permissions = normalizePermissions(options.permissions);
+  const demandedFaces = inferDemandedFaces(task);
+  const faceById = new Map(RUBIX_BROWSER_FACES.map((face) => [face.id, face]));
+  const routeIds = [
+    'viewport',
+    ...Array.from(new Set(demandedFaces.filter((id) => id !== 'viewport'))),
+    'viewport',
+  ];
+  const route: RubixBrowserMove[] = [];
+
+  for (let i = 0; i < routeIds.length - 1; i += 1) {
+    const from = faceById.get(routeIds[i]);
+    const to = faceById.get(routeIds[i + 1]);
+    if (!from || !to) continue;
+    const required = permissionForMove(to);
+    const allowed = canUse(to, permissions);
+    route.push({
+      index: i + 1,
+      from: from.id,
+      to: to.id,
+      direction: directionBetween(from, to),
+      required_permission: required,
+      allowed,
+      reason: allowed
+        ? `permission ${required} opens ${to.id}`
+        : `missing permission ${required} for ${to.id}`,
+    });
+  }
+
+  const visibleFaces = RUBIX_BROWSER_FACES.filter((face) => canUse(face, permissions)).map(
+    (face) => face.id
+  );
+  const blockedMoves = route.filter((move) => !move.allowed);
+  const closedLoop =
+    route.length > 0 && route[0].from === 'viewport' && route.at(-1)?.to === 'viewport';
+  const routeReversible = closedLoop && blockedMoves.length === 0;
+  const routeSha = sha256({ task, route, demandedFaces });
+  const permissionSha = sha256(Array.from(permissions).sort());
+
+  return {
+    schema_version: 'scbe.rubix_browser_plan.v1',
+    task,
+    mode: 'plan',
+    generated_at: generatedAt,
+    permissions: Array.from(permissions).sort(),
+    faces: [...RUBIX_BROWSER_FACES],
+    demanded_faces: demandedFaces,
+    route,
+    blocked_moves: blockedMoves,
+    closed_loop: closedLoop,
+    route_reversible: routeReversible,
+    cube_projection: {
+      dimension_count: 4,
+      root_face: 'viewport',
+      tip: [0, 0],
+      fog_of_war: RUBIX_BROWSER_FACES.filter((face) => !canUse(face, permissions)).map(
+        (face) => face.id
+      ),
+      visible_faces: visibleFaces,
+    },
+    audit: {
+      route_sha256: routeSha,
+      permission_sha256: permissionSha,
+      verdict: routeReversible ? 'PASS' : 'HOLD',
+      reason: routeReversible
+        ? 'closed browser-control route is permission-complete'
+        : 'route has blocked faces; add permissions or lower task scope',
+    },
+  };
+}

--- a/packages/agent-bus/tests/rubix-browser.test.ts
+++ b/packages/agent-bus/tests/rubix-browser.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { buildRubixBrowserPlan, RUBIX_BROWSER_FACES } from '../src/rubix-browser.js';
+
+describe('rubix browser adapter', () => {
+  it('builds a closed read-only browser route for inspection tasks', () => {
+    const plan = buildRubixBrowserPlan({
+      task: 'inspect the pricing page and summarize visible labels',
+      permissions: ['observe', 'visual.read', 'dom.read'],
+      generatedAt: '2026-05-30T00:00:00.000Z',
+    });
+
+    expect(plan.schema_version).toBe('scbe.rubix_browser_plan.v1');
+    expect(plan.audit.verdict).toBe('PASS');
+    expect(plan.closed_loop).toBe(true);
+    expect(plan.route_reversible).toBe(true);
+    expect(plan.route.map((move) => `${move.from}->${move.to}`)).toEqual([
+      'viewport->dom',
+      'dom->memory',
+      'memory->viewport',
+    ]);
+    expect(plan.blocked_moves).toHaveLength(0);
+    expect(plan.audit.route_sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('holds a side-effectful route when tool permissions are missing', () => {
+    const plan = buildRubixBrowserPlan({
+      task: 'open the upload page, fill the form, and submit the video',
+      permissions: ['observe', 'visual.read', 'dom.read'],
+      generatedAt: '2026-05-30T00:00:00.000Z',
+    });
+
+    expect(plan.audit.verdict).toBe('HOLD');
+    expect(plan.route_reversible).toBe(false);
+    expect(plan.demanded_faces).toContain('tool');
+    expect(plan.blocked_moves.map((move) => move.to)).toContain('tool');
+    expect(plan.cube_projection.fog_of_war).toContain('tool');
+  });
+
+  it('opens auth, network, storage, and tool faces only when permissions allow them', () => {
+    const plan = buildRubixBrowserPlan({
+      task: 'login, read session storage, call the API URL, then click save',
+      permissions: [
+        'observe',
+        'visual.read',
+        'dom.read',
+        'auth.read',
+        'storage.read',
+        'network.read',
+        'tool.call',
+      ],
+      generatedAt: '2026-05-30T00:00:00.000Z',
+    });
+
+    expect(plan.audit.verdict).toBe('PASS');
+    expect(plan.demanded_faces).toEqual([
+      'viewport',
+      'dom',
+      'memory',
+      'tool',
+      'auth',
+      'storage',
+      'network',
+    ]);
+    expect(plan.cube_projection.visible_faces).toEqual(
+      expect.arrayContaining(['viewport', 'dom', 'memory', 'tool', 'auth', 'storage', 'network'])
+    );
+  });
+
+  it('keeps every face on a four-dimensional tesseract coordinate', () => {
+    expect(RUBIX_BROWSER_FACES.length).toBeGreaterThanOrEqual(6);
+    for (const face of RUBIX_BROWSER_FACES) {
+      expect(face.coordinate).toHaveLength(4);
+      expect(face.required_permission.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('rejects empty tasks instead of producing ambiguous routes', () => {
+    expect(() => buildRubixBrowserPlan({ task: '   ' })).toThrow(/non-empty task/);
+  });
+});

--- a/packages/agent-bus/tools.json
+++ b/packages/agent-bus/tools.json
@@ -112,5 +112,18 @@
     "description": "Run SCBE CLI harness control matrix: protocol, offline scaffold corpus, and missing-model negative control",
     "command": "node",
     "args": ["packages/cli/scripts/bench_harness_matrix.cjs"]
+  },
+  {
+    "name": "rubix-browser-plan",
+    "description": "Plan a browser-control route as permission-defined Rubix/tesseract faces with blocked-move audit evidence",
+    "command": "node",
+    "args": [
+      "packages/agent-bus/bin/scbe-agent-bus.cjs",
+      "rubix-browser",
+      "plan",
+      "--task",
+      "{task}",
+      "--json"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add Rubix browser planner for permission-defined browser-control faces
- expose `scbe-agent-bus rubix-browser plan` and `rubix-browser-plan` bus tool
- document the adapter and next Playwright benchmark lane
- update `lint-staged` to 15.5.2 to clear package audit advisories while keeping Node 18 compatibility

## Verification
- `npm run build` in `packages/agent-bus`
- `npm test` in `packages/agent-bus` -> 242 passed
- `npm audit --audit-level=moderate` in `packages/agent-bus` -> 0 vulnerabilities
- `npx prettier --check src/rubix-browser.ts src/index.ts tests/rubix-browser.test.ts bin/scbe-agent-bus.cjs tools.json package.json package-lock.json docs/RUBIX_BROWSER_ADAPTER.md`
- CLI smoke: read-only task returned `PASS`, closed loop true, route reversible true
- CLI smoke: upload/submit task without `tool.call` returned `HOLD` with blocked move evidence

## Rollback
- Revert commit `53a335e59` to remove the adapter, CLI command, docs, tests, and lint-staged update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Rubix browser planning: generates permission-gated execution routes from natural-language tasks with audit verdicts and exit code feedback.
  * Added CLI subcommand for browser operation planning with configurable permissions.
  * New tool available for integrating browser planning into workflows.

* **Documentation**
  * Added comprehensive documentation for the Rubix browser adapter concept and usage.

* **Chores**
  * Updated lint-staged dependency.

* **Tests**
  * Added test coverage for browser planning functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->