### PR TITLE
feat(agent-bus): add headless Rubix browser benchmark

### DIFF
--- a/packages/agent-bus/bin/scbe-agent-bus.cjs
+++ b/packages/agent-bus/bin/scbe-agent-bus.cjs
@@ -24,6 +24,7 @@ const {
   compilePlan,
   runPipeline,
   buildRubixBrowserPlan,
+  runRubixBrowserBenchmark,
 } = require('../dist/index.js');
 
 const HOSTED_INTAKE_URL = 'https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html';
@@ -114,6 +115,7 @@ Usage:
   scbe-agent-bus plugins list --json
   scbe-agent-bus tools list --json
   scbe-agent-bus rubix-browser plan --task "open docs and click download" --permissions visual.read,dom.read,tool.call --json
+  scbe-agent-bus rubix-browser bench --headless --json
   scbe-agent-bus workspace new --hint customer-smoke --json
   scbe-agent-bus workspace ingest --workspace-root <path> --source-path <file> --json
   scbe-agent-bus workspace export --workspace-root <path> --json
@@ -667,8 +669,29 @@ async function main() {
       process.exitCode = payload.audit.verdict === 'PASS' ? 0 : 1;
       return;
     }
+    if (action === 'bench') {
+      const mode = flags.headed === true ? 'headed' : 'headless';
+      const payload = runRubixBrowserBenchmark({ mode });
+      if (flags.json) {
+        process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+      } else {
+        process.stdout.write(
+          [
+            `Rubix browser benchmark: ${payload.pass_count}/${payload.case_count}`,
+            `Mode: ${payload.mode}`,
+            `Score: ${payload.score.toFixed(4)}`,
+            payload.recommendation,
+            '',
+          ].join('\n')
+        );
+      }
+      process.exitCode = payload.pass_count === payload.case_count ? 0 : 1;
+      return;
+    }
     process.stderr.write(
-      'Usage: scbe-agent-bus rubix-browser plan --task "..." [--permissions visual.read,dom.read] [--json]\n'
+      'Usage:\n' +
+        '  scbe-agent-bus rubix-browser plan --task "..." [--permissions visual.read,dom.read] [--json]\n' +
+        '  scbe-agent-bus rubix-browser bench [--headless|--headed] [--json]\n'
     );
     process.exitCode = 2;
     return;

--- a/packages/agent-bus/docs/RUBIX_BROWSER_ADAPTER.md
+++ b/packages/agent-bus/docs/RUBIX_BROWSER_ADAPTER.md
@@ -41,6 +41,18 @@ node packages/agent-bus/bin/scbe-agent-bus.cjs rubix-browser plan `
   --json
 ```
 
+Run the CI-safe headless preflight benchmark:
+
+```powershell
+node packages/agent-bus/bin/scbe-agent-bus.cjs rubix-browser bench --headless --json
+```
+
+Use headed mode only for replay/debug labels over the same deterministic cases:
+
+```powershell
+node packages/agent-bus/bin/scbe-agent-bus.cjs rubix-browser bench --headed --json
+```
+
 ## Bus Tool
 
 `packages/agent-bus/tools.json` registers:
@@ -49,6 +61,15 @@ node packages/agent-bus/bin/scbe-agent-bus.cjs rubix-browser plan `
 {
   "name": "rubix-browser-plan",
   "description": "Plan a browser-control route as permission-defined Rubix/tesseract faces with blocked-move audit evidence"
+}
+```
+
+and:
+
+```json
+{
+  "name": "rubix-browser-bench",
+  "description": "Run the headless Rubix browser permission-geometry benchmark for CI-safe browser-control preflight"
 }
 ```
 

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -128,11 +128,16 @@ export {
 
 export {
   type RubixBrowserFace,
+  type RubixBrowserBenchmarkCase,
+  type RubixBrowserBenchmarkReport,
+  type RubixBrowserBenchmarkRow,
   type RubixBrowserMove,
   type RubixBrowserPermission,
   type RubixBrowserPlan,
+  RUBIX_BROWSER_BENCHMARK_CASES,
   RUBIX_BROWSER_FACES,
   buildRubixBrowserPlan,
+  runRubixBrowserBenchmark,
 } from './rubix-browser.js';
 
 export type AgentBusPrivacy = 'local_only' | 'remote_allowed' | string;

--- a/packages/agent-bus/src/rubix-browser.ts
+++ b/packages/agent-bus/src/rubix-browser.ts
@@ -62,10 +62,46 @@ export interface RubixBrowserPlan {
   };
 }
 
+export interface RubixBrowserBenchmarkCase {
+  id: string;
+  task: string;
+  permissions: RubixBrowserPermission[];
+  expected_verdict: 'PASS' | 'HOLD';
+  expected_blocked_faces?: string[];
+}
+
+export interface RubixBrowserBenchmarkRow {
+  id: string;
+  task: string;
+  verdict: 'PASS' | 'HOLD';
+  expected_verdict: 'PASS' | 'HOLD';
+  ok: boolean;
+  blocked_faces: string[];
+  expected_blocked_faces: string[];
+  route_sha256: string;
+}
+
+export interface RubixBrowserBenchmarkReport {
+  schema_version: 'scbe.rubix_browser_benchmark.v1';
+  mode: 'headless' | 'headed';
+  generated_at: string;
+  case_count: number;
+  pass_count: number;
+  score: number;
+  rows: RubixBrowserBenchmarkRow[];
+  recommendation: string;
+}
+
 export interface BuildRubixBrowserPlanOptions {
   task: string;
   permissions?: Iterable<RubixBrowserPermission>;
   generatedAt?: string;
+}
+
+export interface RunRubixBrowserBenchmarkOptions {
+  mode?: 'headless' | 'headed';
+  generatedAt?: string;
+  cases?: readonly RubixBrowserBenchmarkCase[];
 }
 
 export const RUBIX_BROWSER_FACES: readonly RubixBrowserFace[] = [
@@ -131,6 +167,43 @@ export const RUBIX_BROWSER_FACES: readonly RubixBrowserFace[] = [
     required_permission: 'observe',
     risk: 'low',
     description: 'Deferred work, task ticker state, receipts, and loop context.',
+  },
+];
+
+export const RUBIX_BROWSER_BENCHMARK_CASES: readonly RubixBrowserBenchmarkCase[] = [
+  {
+    id: 'read-visible-labels',
+    task: 'inspect the pricing page and summarize visible labels',
+    permissions: ['observe', 'visual.read', 'dom.read'],
+    expected_verdict: 'PASS',
+  },
+  {
+    id: 'submit-without-tool',
+    task: 'open the upload page, fill the form, and submit the video',
+    permissions: ['observe', 'visual.read', 'dom.read'],
+    expected_verdict: 'HOLD',
+    expected_blocked_faces: ['tool'],
+  },
+  {
+    id: 'api-without-network',
+    task: 'read the dashboard and call the API URL for account status',
+    permissions: ['observe', 'visual.read', 'dom.read'],
+    expected_verdict: 'HOLD',
+    expected_blocked_faces: ['network'],
+  },
+  {
+    id: 'stateful-auth-tool-route',
+    task: 'login, read session storage, call the API URL, then click save',
+    permissions: [
+      'observe',
+      'visual.read',
+      'dom.read',
+      'auth.read',
+      'storage.read',
+      'network.read',
+      'tool.call',
+    ],
+    expected_verdict: 'PASS',
   },
 ];
 
@@ -287,5 +360,53 @@ export function buildRubixBrowserPlan(options: BuildRubixBrowserPlanOptions): Ru
         ? 'closed browser-control route is permission-complete'
         : 'route has blocked faces; add permissions or lower task scope',
     },
+  };
+}
+
+export function runRubixBrowserBenchmark(
+  options: RunRubixBrowserBenchmarkOptions = {}
+): RubixBrowserBenchmarkReport {
+  const mode = options.mode || 'headless';
+  const generatedAt = options.generatedAt || new Date().toISOString();
+  const cases = options.cases || RUBIX_BROWSER_BENCHMARK_CASES;
+  const rows = cases.map((benchCase): RubixBrowserBenchmarkRow => {
+    const plan = buildRubixBrowserPlan({
+      task: benchCase.task,
+      permissions: benchCase.permissions,
+      generatedAt,
+    });
+    const blockedFaces = plan.blocked_moves.map((move) => move.to);
+    const expectedBlockedFaces = benchCase.expected_blocked_faces || [];
+    const expectedBlocksOk =
+      expectedBlockedFaces.length === 0
+        ? blockedFaces.length === 0
+        : expectedBlockedFaces.every((face) => blockedFaces.includes(face));
+    const ok = plan.audit.verdict === benchCase.expected_verdict && expectedBlocksOk;
+    return {
+      id: benchCase.id,
+      task: benchCase.task,
+      verdict: plan.audit.verdict,
+      expected_verdict: benchCase.expected_verdict,
+      ok,
+      blocked_faces: blockedFaces,
+      expected_blocked_faces: expectedBlockedFaces,
+      route_sha256: plan.audit.route_sha256,
+    };
+  });
+  const passCount = rows.filter((row) => row.ok).length;
+  const score = rows.length === 0 ? 0 : passCount / rows.length;
+
+  return {
+    schema_version: 'scbe.rubix_browser_benchmark.v1',
+    mode,
+    generated_at: generatedAt,
+    case_count: rows.length,
+    pass_count: passCount,
+    score,
+    rows,
+    recommendation:
+      mode === 'headless'
+        ? 'Use headless mode for CI and benchmark proof; rerun selected failures with headed replay.'
+        : 'Use headed mode only for visual diagnosis and demo replay.',
   };
 }

--- a/packages/agent-bus/tests/rubix-browser.test.ts
+++ b/packages/agent-bus/tests/rubix-browser.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildRubixBrowserPlan, RUBIX_BROWSER_FACES } from '../src/rubix-browser.js';
+import {
+  buildRubixBrowserPlan,
+  RUBIX_BROWSER_FACES,
+  runRubixBrowserBenchmark,
+} from '../src/rubix-browser.js';
 
 describe('rubix browser adapter', () => {
   it('builds a closed read-only browser route for inspection tasks', () => {
@@ -76,5 +80,37 @@ describe('rubix browser adapter', () => {
 
   it('rejects empty tasks instead of producing ambiguous routes', () => {
     expect(() => buildRubixBrowserPlan({ task: '   ' })).toThrow(/non-empty task/);
+  });
+
+  it('runs the headless benchmark as a CI-safe browser-control preflight', () => {
+    const report = runRubixBrowserBenchmark({
+      mode: 'headless',
+      generatedAt: '2026-05-30T00:00:00.000Z',
+    });
+
+    expect(report.schema_version).toBe('scbe.rubix_browser_benchmark.v1');
+    expect(report.mode).toBe('headless');
+    expect(report.pass_count).toBe(report.case_count);
+    expect(report.score).toBe(1);
+    expect(report.rows.map((row) => row.id)).toEqual([
+      'read-visible-labels',
+      'submit-without-tool',
+      'api-without-network',
+      'stateful-auth-tool-route',
+    ]);
+    expect(report.rows.find((row) => row.id === 'submit-without-tool')?.blocked_faces).toContain(
+      'tool'
+    );
+  });
+
+  it('keeps headed mode as a replay/debug label over the same deterministic cases', () => {
+    const report = runRubixBrowserBenchmark({
+      mode: 'headed',
+      generatedAt: '2026-05-30T00:00:00.000Z',
+    });
+
+    expect(report.mode).toBe('headed');
+    expect(report.score).toBe(1);
+    expect(report.recommendation).toMatch(/visual diagnosis/);
   });
 });

--- a/packages/agent-bus/tools.json
+++ b/packages/agent-bus/tools.json
@@ -125,5 +125,17 @@
       "{task}",
       "--json"
     ]
+  },
+  {
+    "name": "rubix-browser-bench",
+    "description": "Run the headless Rubix browser permission-geometry benchmark for CI-safe browser-control preflight",
+    "command": "node",
+    "args": [
+      "packages/agent-bus/bin/scbe-agent-bus.cjs",
+      "rubix-browser",
+      "bench",
+      "--headless",
+      "--json"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add a CI-safe headless Rubix browser benchmark lane
- expose `scbe-agent-bus rubix-browser bench --headless|--headed`
- register `rubix-browser-bench` in the agent-bus tool registry
- document headless-first and headed replay/debug usage

## Verification
- `npm run build` in `packages/agent-bus`
- `npm test -- rubix-browser` in `packages/agent-bus` -> 7 passed
- `npm test` in `packages/agent-bus` -> 244 passed
- `npm audit --audit-level=moderate` in `packages/agent-bus` -> 0 vulnerabilities
- `npx prettier --check src/rubix-browser.ts src/index.ts tests/rubix-browser.test.ts bin/scbe-agent-bus.cjs tools.json docs/RUBIX_BROWSER_ADAPTER.md`
- `node packages/agent-bus/bin/scbe-agent-bus.cjs rubix-browser bench --headless --json` -> 4/4, score 1.0
- `git diff --check`

## Rollback
- Revert this commit to remove the benchmark command, tool registration, docs, and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `rubix-browser bench` CLI subcommand for benchmarking browser control operations with headless and headed modes, supporting JSON and formatted text output with pass/fail counts and scoring

* **Documentation**
  * Updated documentation with usage instructions for the benchmark command

* **Tests**
  * Added test coverage for benchmark functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1971?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->