### PR TITLE
fix(ci): restore product smoke and Python formatting

### DIFF
--- a/scripts/package_products.py
+++ b/scripts/package_products.py
@@ -61,10 +61,19 @@ TOOLKIT_FILES = [
     ("docs/specs/LAYER_MATH_COMPRESSED.md", "docs/LAYER_MATH_COMPRESSED.md"),
     # Governance templates
     ("config/scbe_core_axioms_v1.yaml", "templates/scbe_core_axioms.yaml"),
-    ("training-data/schemas/training_schema.json", "templates/training_schema.json"),
     # Quickstart
     ("docs/PRODUCT_QUICKSTART.md", "quickstart/PRODUCT_QUICKSTART.md"),
 ]
+
+TRAINING_SCHEMA_JSON = json.dumps(
+    {
+        "schema": "scbe_training_record_v1",
+        "required": ["instruction", "response"],
+        "optional": ["metadata", "source", "source_type", "quality", "track"],
+        "note": "Full training-data files live in the external Hugging Face dataset referenced by DATASET_LOCATION.md.",
+    },
+    indent=2,
+)
 
 TOOLKIT_README = """# SCBE AI Governance Toolkit
 
@@ -103,7 +112,9 @@ MIT License — use commercially, modify freely, attribution appreciated.
 
 # ---- Product: AI Security Training Vault ----
 
-# We include a curated subset of SFT data (not the massive claude exports)
+# Local SFT data was moved out of the public repository to the external
+# training-data dataset. If these ignored local files exist, package them; CI
+# and clean public checkouts should still produce a usable vault with pointers.
 VAULT_SFT_FILES = [
     "training-data/sft/aetherbrowser_commands_v1.jsonl",
     "training-data/sft/api_usage_pairs.jsonl",
@@ -116,8 +127,6 @@ VAULT_SFT_FILES = [
 ]
 
 VAULT_EXTRA_FILES = [
-    # Schema
-    ("training-data/schemas/training_schema.json", "schemas/training_schema.json"),
     # Benchmark scripts
     ("scripts/benchmark/scbe_vs_baseline.py", "benchmark/scbe_vs_baseline.py"),
     ("scripts/benchmark/scbe_vs_industry.py", "benchmark/scbe_vs_industry.py"),
@@ -131,6 +140,25 @@ VAULT_EXTRA_FILES = [
     ("docs/specs/LAYER_MATH_COMPRESSED.md", "docs/LAYER_MATH_COMPRESSED.md"),
 ]
 
+TRAINING_DATASET_URL = "https://huggingface.co/datasets/issdandavis/scbe-aethermoore-training-data"
+
+TRAINING_DATASET_NOTICE = f"""# SCBE Training Dataset Location
+
+The full SFT dataset is intentionally not stored in this public checkout.
+
+Dataset:
+{TRAINING_DATASET_URL}
+
+Why:
+- keeps the Git repository small
+- avoids committing local/generated training artifacts
+- gives buyers a stable dataset location that can be updated independently
+
+If local files under `training-data/sft/` are present when this pack is built,
+`scripts/package_products.py` includes them in `sft/`. In a clean checkout, this
+pack includes the schema, benchmark scripts, and this dataset pointer.
+"""
+
 VAULT_README = """# SCBE AI Security Training Vault
 
 Thank you for purchasing the AI Security Training Vault from AetherMoore.
@@ -138,6 +166,7 @@ Thank you for purchasing the AI Security Training Vault from AetherMoore.
 ## What's Inside
 
 - `sft/` — Curated supervised fine-tuning pairs for AI safety tasks
+- `DATASET_LOCATION.md` — Link to the full external SFT dataset
 - `benchmark/` — Benchmark scripts to evaluate your fine-tuned model
 - `schemas/` — Data format documentation
 - `docs/` — Architecture reference
@@ -145,13 +174,14 @@ Thank you for purchasing the AI Security Training Vault from AetherMoore.
 ## Quick Start
 
 1. Install dependencies: `pip install transformers datasets`
-2. Load the data:
+2. Download or mount the dataset listed in `DATASET_LOCATION.md`
+3. Load the data:
    ```python
    from datasets import load_dataset
-   ds = load_dataset("json", data_files="sft/*.jsonl")
+   ds = load_dataset("json", data_files="/path/to/sft/*.jsonl")
    ```
-3. Fine-tune with any framework (HuggingFace, Axolotl, OpenAI API)
-4. Benchmark: `python benchmark/scbe_vs_baseline.py`
+4. Fine-tune with any framework (HuggingFace, Axolotl, OpenAI API)
+5. Benchmark: `python benchmark/scbe_vs_baseline.py`
 
 ## Data Format
 
@@ -264,11 +294,10 @@ def package_toolkit(output_dir: Path) -> Path:
 
     with ZipFile(zip_path, "w", ZIP_DEFLATED) as zf:
         zf.writestr("README.md", TOOLKIT_README)
-        zf.writestr(
-            "LICENSE", "MIT License\n\nCopyright (c) 2026 Issac Davis / AetherMoore\n"
-        )
+        zf.writestr("LICENSE", "MIT License\n\nCopyright (c) 2026 Issac Davis / AetherMoore\n")
         zf.write(REPO_ROOT / "LICENSE-APACHE", "LICENSE-APACHE")
         zf.write(REPO_ROOT / "LICENSE-NOTICE.md", "LICENSE-NOTICE.md")
+        zf.writestr("templates/training_schema.json", TRAINING_SCHEMA_JSON)
 
         for src_rel, dst_rel in TOOLKIT_FILES:
             src = REPO_ROOT / src_rel
@@ -292,11 +321,11 @@ def package_vault(output_dir: Path) -> Path:
 
     with ZipFile(zip_path, "w", ZIP_DEFLATED) as zf:
         zf.writestr("README.md", VAULT_README)
-        zf.writestr(
-            "LICENSE", "MIT License\n\nCopyright (c) 2026 Issac Davis / AetherMoore\n"
-        )
+        zf.writestr("LICENSE", "MIT License\n\nCopyright (c) 2026 Issac Davis / AetherMoore\n")
         zf.write(REPO_ROOT / "LICENSE-APACHE", "LICENSE-APACHE")
         zf.write(REPO_ROOT / "LICENSE-NOTICE.md", "LICENSE-NOTICE.md")
+        zf.writestr("DATASET_LOCATION.md", TRAINING_DATASET_NOTICE)
+        zf.writestr("schemas/training_schema.json", TRAINING_SCHEMA_JSON)
 
         # SFT data files
         for sft_rel in VAULT_SFT_FILES:
@@ -331,9 +360,7 @@ def package_vault(output_dir: Path) -> Path:
         zf.writestr("metadata.json", json.dumps(metadata, indent=2))
 
     size_mb = zip_path.stat().st_size / (1024 * 1024)
-    print(
-        f"\nVault packaged: {zip_path} ({size_mb:.1f} MB, {total_records} SFT records)"
-    )
+    print(f"\nVault packaged: {zip_path} ({size_mb:.1f} MB, {total_records} SFT records)")
     return zip_path
 
 
@@ -345,9 +372,7 @@ def package_making_of(output_dir: Path) -> Path:
     with ZipFile(zip_path, "w", ZIP_DEFLATED) as zf:
         zf.writestr("README.md", MAKING_OF_README)
         zf.writestr("PROCESS_NOTES.txt", MAKING_OF_PROCESS_NOTES)
-        zf.writestr(
-            "LICENSE", "Copyright (c) 2026 Issac Davis / AetherMoore. Personal reader/writer use allowed.\n"
-        )
+        zf.writestr("LICENSE", "Copyright (c) 2026 Issac Davis / AetherMoore. Personal reader/writer use allowed.\n")
 
         for src_rel, dst_rel in MAKING_OF_FILES:
             src = REPO_ROOT / src_rel
@@ -399,9 +424,7 @@ def main() -> None:
         package_making_of(args.output_dir)
         print()
 
-    print(
-        "Done. Upload these ZIPs to your delivery system (GitHub Releases, S3, or direct email)."
-    )
+    print("Done. Upload these ZIPs to your delivery system (GitHub Releases, S3, or direct email).")
 
 
 if __name__ == "__main__":

--- a/src/security/rotating_drop_box.py
+++ b/src/security/rotating_drop_box.py
@@ -30,7 +30,9 @@ def _fingerprint(value: str | bytes, salt: bytes) -> str:
 
 
 def _derive_next_key(current: bytes, lease_id: str, returned_at: datetime, nonce: bytes) -> bytes:
-    payload = b"|".join([b"SCBE_DROP_BOX_ROTATE_V1", lease_id.encode("utf-8"), _iso(returned_at).encode("utf-8"), nonce])
+    payload = b"|".join(
+        [b"SCBE_DROP_BOX_ROTATE_V1", lease_id.encode("utf-8"), _iso(returned_at).encode("utf-8"), nonce]
+    )
     return hmac.new(current, payload, hashlib.sha256).digest()
 
 

--- a/tests/agentic/test_quarantine_lock.py
+++ b/tests/agentic/test_quarantine_lock.py
@@ -86,12 +86,8 @@ def test_deny_is_terminal_closed_state_with_no_tools() -> None:
 
 def test_time_dilation_is_bounded_and_deterministic_by_pressure() -> None:
     policy = QuarantineLockPolicy(max_time_dilation_factor=9)
-    low = create_quarantine_lock(
-        "QUARANTINE", suspicion=0.1, harmonic_cost=1.0, policy=policy
-    )
-    high = create_quarantine_lock(
-        "QUARANTINE", suspicion=0.9, harmonic_cost=8.0, policy=policy
-    )
+    low = create_quarantine_lock("QUARANTINE", suspicion=0.1, harmonic_cost=1.0, policy=policy)
+    high = create_quarantine_lock("QUARANTINE", suspicion=0.9, harmonic_cost=8.0, policy=policy)
     malicious = create_quarantine_lock(
         "QUARANTINE",
         suspicion=0.1,
@@ -114,11 +110,7 @@ def test_apply_quarantine_lock_restricts_dcp_tools_and_timeouts() -> None:
         ToolEntry(name="shell"),
         ToolEntry(name="deploy"),
     ]
-    dcp.completion_gates = [
-        CompletionGate(
-            id="unit", description="unit tests", command="pytest", timeout_seconds=120
-        )
-    ]
+    dcp.completion_gates = [CompletionGate(id="unit", description="unit tests", command="pytest", timeout_seconds=120)]
     receipt = create_quarantine_lock("QUARANTINE", suspicion=0.8, harmonic_cost=4.0)
 
     apply_quarantine_lock_to_dcp(dcp, receipt)
@@ -135,11 +127,7 @@ def test_apply_quarantine_lock_restricts_dcp_tools_and_timeouts() -> None:
 def test_apply_deny_lock_denies_every_dcp_tool() -> None:
     dcp = create_dcp("deny all", GoalSpec(description="closed state"))
     dcp.tools = [ToolEntry(name="read"), ToolEntry(name="verify")]
-    dcp.completion_gates = [
-        CompletionGate(
-            id="unit", description="unit tests", command="pytest", timeout_seconds=120
-        )
-    ]
+    dcp.completion_gates = [CompletionGate(id="unit", description="unit tests", command="pytest", timeout_seconds=120)]
 
     apply_quarantine_lock_to_dcp(dcp, create_quarantine_lock("DENY"))
 

--- a/tests/benchmark/test_arc_agi2_local_benchmark.py
+++ b/tests/benchmark/test_arc_agi2_local_benchmark.py
@@ -1,4 +1,5 @@
 """Tests for the ARC-AGI-2 local baseline benchmark."""
+
 from __future__ import annotations
 
 import importlib.util
@@ -71,9 +72,7 @@ def test_claim_boundary_present() -> None:
     import tempfile
 
     with tempfile.TemporaryDirectory() as tmp:
-        report = module.build_report(
-            split="evaluation", limit=5, out_dir=Path(tmp), run_id="pytest-claim"
-        )
+        report = module.build_report(split="evaluation", limit=5, out_dir=Path(tmp), run_id="pytest-claim")
     boundary = report["claim_boundary"]
     assert len(boundary) >= 3
     assert any("not a submission" in item.lower() or "leaderboard" in item.lower() for item in boundary)

--- a/tests/benchmark/test_arc_style_grid_benchmark.py
+++ b/tests/benchmark/test_arc_style_grid_benchmark.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "benchmark" / "arc_style_grid_benchmark.py"
 

--- a/tests/benchmark/test_bench_scorer.py
+++ b/tests/benchmark/test_bench_scorer.py
@@ -1,10 +1,11 @@
 """Tests for bench_scorer.py normalizer (Lane 10)."""
+
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from scripts.benchmark.bench_scorer import BenchScore, score_report
+from scripts.benchmark.bench_scorer import score_report
 
 
 def _report(schema: str, summary: dict, **kwargs) -> dict:
@@ -81,5 +82,3 @@ def test_list_claim_boundary_flattened():
     )
     s = score_report(report)
     assert s.boundary == "first line"
-
-

--- a/tests/benchmark/test_hard_agentic_benchmark_pretest.py
+++ b/tests/benchmark/test_hard_agentic_benchmark_pretest.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "benchmark" / "hard_agentic_benchmark_pretest.py"
 

--- a/tests/benchmark/test_provider_health_matrix.py
+++ b/tests/benchmark/test_provider_health_matrix.py
@@ -1,4 +1,5 @@
 """Tests for provider_health_matrix.py (Lane 41)."""
+
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -16,8 +17,11 @@ from scripts.benchmark.provider_health_matrix import (
 
 def _spec(name="test", tier="free", env_vars=None, probe_fn="_probe_openai_compat"):
     return ProviderSpec(
-        name=name, tier=tier, env_vars=env_vars or [],
-        sdk_package="openai", probe_fn=probe_fn,
+        name=name,
+        tier=tier,
+        env_vars=env_vars or [],
+        sdk_package="openai",
+        probe_fn=probe_fn,
     )
 
 
@@ -55,8 +59,7 @@ def test_ready_when_probe_succeeds(monkeypatch):
     def fake_probe(s):
         return True, 42, None
 
-    with patch.dict("scripts.benchmark.provider_health_matrix._PROBE_MAP",
-                    {"_probe_openai_compat": fake_probe}):
+    with patch.dict("scripts.benchmark.provider_health_matrix._PROBE_MAP", {"_probe_openai_compat": fake_probe}):
         h = check_provider(spec, probe=True)
     assert h.status == "READY"
     assert h.latency_ms == 42
@@ -69,8 +72,7 @@ def test_unreachable_when_probe_fails(monkeypatch):
     def fake_probe(s):
         return False, None, "connection refused"
 
-    with patch.dict("scripts.benchmark.provider_health_matrix._PROBE_MAP",
-                    {"_probe_openai_compat": fake_probe}):
+    with patch.dict("scripts.benchmark.provider_health_matrix._PROBE_MAP", {"_probe_openai_compat": fake_probe}):
         h = check_provider(spec, probe=True)
     assert h.status == "UNREACHABLE"
     assert "connection refused" in (h.error or "")
@@ -97,6 +99,7 @@ def test_free_first_rank_ordering():
     local_specs = [p for p in PROVIDERS if p.tier == "local"]
     paid_specs = [p for p in PROVIDERS if p.tier == "paid"]
     from scripts.benchmark.provider_health_matrix import _FREE_FIRST_RANK
+
     for s in local_specs:
         for p in paid_specs:
             assert _FREE_FIRST_RANK[s.tier] < _FREE_FIRST_RANK[p.tier]

--- a/tests/benchmark/test_real_patch_task_agent_lane.py
+++ b/tests/benchmark/test_real_patch_task_agent_lane.py
@@ -4,6 +4,7 @@ All tests use a monkeypatched _call_agent stub so they run in CI without
 any API keys. The stub delegates to scbe_repair (the known-good reference)
 to produce correct responses for each task.
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -47,9 +48,7 @@ def test_agent_lane_structure_with_mocked_api(tmp_path: Path, monkeypatch) -> No
     module = _load_module()
     monkeypatch.setattr(module, "_call_agent", _make_stub_call_agent(module))
 
-    report = module.build_report(
-        out_dir=tmp_path, run_id="pytest-agent", agent_provider="cerebras"
-    )
+    report = module.build_report(out_dir=tmp_path, run_id="pytest-agent", agent_provider="cerebras")
 
     # Existing summary keys must be present and unaffected
     assert report["summary"]["decision"] == "PASS"
@@ -97,9 +96,7 @@ def test_agent_lane_passes_all_tasks_with_correct_stub(tmp_path: Path, monkeypat
     module = _load_module()
     monkeypatch.setattr(module, "_call_agent", _make_stub_call_agent(module))
 
-    report = module.build_report(
-        out_dir=tmp_path, run_id="pytest-agent-pass", agent_provider="cerebras"
-    )
+    report = module.build_report(out_dir=tmp_path, run_id="pytest-agent-pass", agent_provider="cerebras")
 
     ag = report["agent_summary"]
     assert ag["agent_test_passes"] == report["summary"]["task_count"]

--- a/tests/benchmark/test_research_agent_fixture_benchmark.py
+++ b/tests/benchmark/test_research_agent_fixture_benchmark.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "benchmark" / "research_agent_fixture_benchmark.py"
 

--- a/tests/benchmark/test_rubix_browser_hypercube_benchmark.py
+++ b/tests/benchmark/test_rubix_browser_hypercube_benchmark.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "benchmark" / "rubix_browser_hypercube_benchmark.py"
 

--- a/tests/system/test_scbe_hook_router.py
+++ b/tests/system/test_scbe_hook_router.py
@@ -13,9 +13,7 @@ def _repo(tmp_path: Path) -> Path:
 def test_session_start_writes_state_and_context(tmp_path):
     root = _repo(tmp_path)
 
-    code, output, use_stdout = scbe_hook_router.handle_event(
-        "SessionStart", {"cwd": str(root)}, root
-    )
+    code, output, use_stdout = scbe_hook_router.handle_event("SessionStart", {"cwd": str(root)}, root)
 
     assert code == 0
     assert use_stdout is True
@@ -34,9 +32,7 @@ def test_pre_tool_use_blocks_destructive_shell(tmp_path):
         "cwd": str(root),
     }
 
-    code, output, use_stdout = scbe_hook_router.handle_event(
-        "PreToolUse", payload, root
-    )
+    code, output, use_stdout = scbe_hook_router.handle_event("PreToolUse", payload, root)
 
     assert code == 2
     assert use_stdout is False
@@ -53,9 +49,7 @@ def test_pre_tool_use_allows_read_only_command(tmp_path):
         "cwd": str(root),
     }
 
-    code, output, use_stdout = scbe_hook_router.handle_event(
-        "PreToolUse", payload, root
-    )
+    code, output, use_stdout = scbe_hook_router.handle_event("PreToolUse", payload, root)
 
     assert code == 0
     assert use_stdout is True
@@ -70,16 +64,10 @@ def test_receipts_scrub_secret_values(tmp_path):
         "tool_input": {"api_key": "sk-testsecretvalue1234567890", "safe": "value"},
     }
 
-    code, _output, _use_stdout = scbe_hook_router.handle_event(
-        "PostToolUse", payload, root
-    )
+    code, _output, _use_stdout = scbe_hook_router.handle_event("PostToolUse", payload, root)
 
     assert code == 0
-    receipt_line = (
-        (root / ".scbe" / "ops" / "tool_receipts.jsonl")
-        .read_text(encoding="utf-8")
-        .strip()
-    )
+    receipt_line = (root / ".scbe" / "ops" / "tool_receipts.jsonl").read_text(encoding="utf-8").strip()
     receipt = json.loads(receipt_line)
     assert receipt["payload"]["tool_input"]["api_key"] == "<redacted>"
     assert "sk-testsecret" not in receipt_line
@@ -92,9 +80,7 @@ def test_user_prompt_adds_route_context(tmp_path):
         "user_prompt": "publish and deploy this release",
     }
 
-    code, output, use_stdout = scbe_hook_router.handle_event(
-        "UserPromptSubmit", payload, root
-    )
+    code, output, use_stdout = scbe_hook_router.handle_event("UserPromptSubmit", payload, root)
 
     assert code == 0
     assert use_stdout is True
@@ -104,9 +90,7 @@ def test_user_prompt_adds_route_context(tmp_path):
 def test_precompact_and_stop_write_session_receipts(tmp_path):
     root = _repo(tmp_path)
 
-    compact_code, compact_output, _ = scbe_hook_router.handle_event(
-        "PreCompact", {}, root
-    )
+    compact_code, compact_output, _ = scbe_hook_router.handle_event("PreCompact", {}, root)
     stop_code, stop_output, _ = scbe_hook_router.handle_event("Stop", {}, root)
 
     assert compact_code == 0

--- a/tests/test_package_products.py
+++ b/tests/test_package_products.py
@@ -15,10 +15,6 @@ def test_packaged_product_sources_exist():
         if not (repo_root / src_rel).exists():
             missing.append(src_rel)
 
-    for src_rel in package_products.VAULT_SFT_FILES:
-        if not (repo_root / src_rel).exists():
-            missing.append(src_rel)
-
     for src_rel, _dst_rel in package_products.VAULT_EXTRA_FILES:
         if not (repo_root / src_rel).exists():
             missing.append(src_rel)
@@ -55,8 +51,23 @@ def test_toolkit_zip_contains_promised_buyer_templates(tmp_path: Path):
         "templates/threshold-worksheet.md",
         "templates/pilot-checklist.md",
         "templates/review-notes-template.md",
+        "templates/training_schema.json",
         "quickstart/README.md",
     }.issubset(names)
+
+
+def test_vault_zip_contains_external_dataset_pointer_and_schema(tmp_path: Path):
+    vault = package_products.package_vault(tmp_path)
+
+    with ZipFile(vault) as zf:
+        names = set(zf.namelist())
+        dataset_notice = zf.read("DATASET_LOCATION.md").decode("utf-8")
+        schema = json.loads(zf.read("schemas/training_schema.json").decode("utf-8"))
+
+    assert "DATASET_LOCATION.md" in names
+    assert "schemas/training_schema.json" in names
+    assert package_products.TRAINING_DATASET_URL in dataset_notice
+    assert schema["schema"] == "scbe_training_record_v1"
 
 
 def test_making_of_zip_excludes_manuscripts_and_includes_process_guides(tmp_path: Path):

--- a/tests/test_ternary_signed_architecture.py
+++ b/tests/test_ternary_signed_architecture.py
@@ -95,7 +95,8 @@ class TestTritVector:
 
     def test_double_negation_identity(self):
         tv = TritVector.from_list([1, -1, 0, 1, -1, 0])
-        assert (-(-tv)).values == tv.values
+        negated = -tv
+        assert (-negated).values == tv.values
 
     def test_repr(self):
         tv = TritVector.from_list([1, 0, -1])


### PR DESCRIPTION
## Summary
- fix product delivery smoke for clean public checkouts where `training-data/` is intentionally gitignored
- package schema + external Hugging Face dataset pointer in buyer ZIPs
- keep local SFT inclusion when ignored local `training-data/sft` files exist
- apply Black to Python files reported by CI and fix Ruff blockers

## Why CI Failed
- `Product Delivery Smoke` expected ignored `training-data/` files to exist in a clean checkout
- `Lint and Format Check` failed `black --check` on existing Python files
- `ruff` also flagged one unused import and one double-unary expression

## Verification
- `python -m black --check --target-version py311 --line-length 120 src/ tests/` -> pass
- `python -m ruff check --config ruff.toml` -> pass
- `python -m pytest tests/test_vercel_launch_bridge.py tests/smoke/test_app_deploy_config.py tests/api/test_stripe_billing_hardening.py tests/test_package_products.py -q` -> 33 passed
- `python -m pytest tests/benchmark/test_bench_scorer.py tests/test_ternary_signed_architecture.py -q` -> 103 passed
- `git diff --check` -> pass

## Rollback
- Revert this commit to restore the old packaging assumptions and formatting.