### PR TITLE
feat(agent-bus): ResumePacket + ToolLoopDetector (lanes 52, 55)

### DIFF
--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -140,6 +140,16 @@ export {
   runRubixBrowserBenchmark,
 } from './rubix-browser.js';
 
+export {
+  type ResumePacket,
+  type ResumePacketOptions,
+  type ToolCallRecord,
+  type ToolLoopDetection,
+  type ToolLoopDetectorOptions,
+  createResumePacket,
+  createToolLoopDetector,
+} from './task-ledger.js';
+
 export type AgentBusPrivacy = 'local_only' | 'remote_allowed' | string;
 
 export interface AgentBusEvent {

--- a/packages/agent-bus/src/task-ledger.ts
+++ b/packages/agent-bus/src/task-ledger.ts
@@ -1,0 +1,189 @@
+/**
+ * @file task-ledger.ts
+ * @module agent-bus/task-ledger
+ * @layer Cross-layer stateful task tracking
+ * @component TaskLedger — resume packets and tool-loop detection
+ *
+ * Lanes 52 + 55 of the 100-lane improvement map.
+ *
+ * ResumePacket (Lane 52): captures session goal, open files, last passing
+ * tests, blockers, and next command — enough for any continuation to pick
+ * up exactly where the interrupted session left off.
+ *
+ * ToolLoopDetector (Lane 55): detects when repeated tool calls add no new
+ * evidence. Comparison rule: a call adds evidence when its result_hash
+ * differs from every prior result for the same tool. When the proportion
+ * of zero-delta calls for a single tool exceeds the threshold, the
+ * detector fires. This catches same-args repeats AND the common failure
+ * mode where args vary slightly but results are equivalent.
+ */
+
+import crypto from 'node:crypto';
+
+// ─── ResumePacket ─────────────────────────────────────────────────────────────
+
+export interface ResumePacket {
+  schema_version: 'scbe_resume_packet_v1';
+  session_id: string;
+  goal: string;
+  open_files: string[];
+  last_passing_tests: string[];
+  blockers: string[];
+  next_command: string;
+  generated_at_utc: string;
+}
+
+export interface ResumePacketOptions {
+  session_id?: string;
+  goal: string;
+  open_files?: string[];
+  last_passing_tests?: string[];
+  blockers?: string[];
+  next_command?: string;
+}
+
+export function createResumePacket(opts: ResumePacketOptions): ResumePacket {
+  return {
+    schema_version: 'scbe_resume_packet_v1',
+    session_id: opts.session_id ?? crypto.randomBytes(8).toString('hex'),
+    goal: opts.goal,
+    open_files: opts.open_files ?? [],
+    last_passing_tests: opts.last_passing_tests ?? [],
+    blockers: opts.blockers ?? [],
+    next_command: opts.next_command ?? '',
+    generated_at_utc: new Date().toISOString(),
+  };
+}
+
+// ─── ToolLoopDetector ─────────────────────────────────────────────────────────
+
+export interface ToolCallRecord {
+  tool: string;
+  /** Truncated SHA-256 of the JSON-serialized result. */
+  result_hash: string;
+  /** 0 = duplicate result; 1 = new result not seen before for this tool. */
+  evidence_delta: number;
+  called_at: string;
+}
+
+export interface ToolLoopDetection {
+  is_looping: boolean;
+  loop_tool: string | null;
+  /** Number of zero-delta calls on loop_tool. */
+  repeat_count: number;
+  recommendation: 'continue' | 'stop' | 'escalate';
+  evidence: string;
+}
+
+export interface ToolLoopDetectorOptions {
+  /** Proportion of zero-delta calls that triggers a loop [0,1]. Default: 0.75 */
+  threshold?: number;
+  /** Minimum calls to a single tool before loop detection can fire. Default: 3 */
+  min_calls?: number;
+}
+
+export function createToolLoopDetector(options: ToolLoopDetectorOptions = {}): {
+  record: (tool: string, result: unknown) => ToolCallRecord;
+  check: () => ToolLoopDetection;
+  reset: () => void;
+  history: () => ToolCallRecord[];
+} {
+  const threshold = options.threshold ?? 0.75;
+  const min_calls = options.min_calls ?? 3;
+
+  const seenHashes = new Map<string, Set<string>>();
+  const calls: ToolCallRecord[] = [];
+
+  function hashResult(result: unknown): string {
+    const json = JSON.stringify(result ?? null);
+    return crypto.createHash('sha256').update(json).digest('hex').slice(0, 16);
+  }
+
+  function record(tool: string, result: unknown): ToolCallRecord {
+    const result_hash = hashResult(result);
+    const seen = seenHashes.get(tool);
+    let evidence_delta: number;
+
+    if (!seen) {
+      seenHashes.set(tool, new Set([result_hash]));
+      evidence_delta = 1;
+    } else if (seen.has(result_hash)) {
+      evidence_delta = 0;
+    } else {
+      seen.add(result_hash);
+      evidence_delta = 1;
+    }
+
+    const rec: ToolCallRecord = {
+      tool,
+      result_hash,
+      evidence_delta,
+      called_at: new Date().toISOString(),
+    };
+    calls.push(rec);
+    return rec;
+  }
+
+  function check(): ToolLoopDetection {
+    const perTool = new Map<string, { total: number; zero: number }>();
+    for (const c of calls) {
+      const s = perTool.get(c.tool) ?? { total: 0, zero: 0 };
+      s.total++;
+      if (c.evidence_delta === 0) s.zero++;
+      perTool.set(c.tool, s);
+    }
+
+    let worst_tool: string | null = null;
+    let worst_ratio = 0;
+    let worst_zero = 0;
+    let worst_total = 0;
+
+    for (const [tool, stat] of perTool.entries()) {
+      if (stat.total < min_calls) continue;
+      const ratio = stat.zero / stat.total;
+      if (ratio > worst_ratio) {
+        worst_ratio = ratio;
+        worst_tool = tool;
+        worst_zero = stat.zero;
+        worst_total = stat.total;
+      }
+    }
+
+    if (worst_tool === null || worst_ratio < threshold) {
+      const callCount = calls.length;
+      const minMsg =
+        callCount < min_calls
+          ? `${callCount} call(s); need ${min_calls} to evaluate`
+          : `no tool exceeds ${Math.round(threshold * 100)}% zero-delta threshold`;
+      return {
+        is_looping: false,
+        loop_tool: null,
+        repeat_count: 0,
+        recommendation: 'continue',
+        evidence: minMsg,
+      };
+    }
+
+    const recommendation: ToolLoopDetection['recommendation'] =
+      worst_ratio >= 0.9 ? 'escalate' : 'stop';
+
+    return {
+      is_looping: true,
+      loop_tool: worst_tool,
+      repeat_count: worst_zero,
+      recommendation,
+      evidence: `'${worst_tool}' produced no new evidence in ${worst_zero} of ${worst_total} calls (${Math.round(worst_ratio * 100)}%)`,
+    };
+  }
+
+  function reset(): void {
+    seenHashes.clear();
+    calls.length = 0;
+  }
+
+  function history(): ToolCallRecord[] {
+    return [...calls];
+  }
+
+  return { record, check, reset, history };
+}

--- a/packages/agent-bus/tests/task-ledger.test.ts
+++ b/packages/agent-bus/tests/task-ledger.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { createResumePacket, createToolLoopDetector } from '../src/task-ledger.js';
+
+// ─── ResumePacket ─────────────────────────────────────────────────────────────
+
+describe('createResumePacket', () => {
+  it('sets schema_version', () => {
+    const pkt = createResumePacket({ goal: 'fix the bug' });
+    expect(pkt.schema_version).toBe('scbe_resume_packet_v1');
+  });
+
+  it('carries the provided goal and fields', () => {
+    const pkt = createResumePacket({
+      goal: 'refactor pipeline',
+      open_files: ['src/pipeline.ts'],
+      last_passing_tests: ['tests/pipeline.test.ts'],
+      blockers: ['missing type'],
+      next_command: 'npm test',
+    });
+    expect(pkt.goal).toBe('refactor pipeline');
+    expect(pkt.open_files).toEqual(['src/pipeline.ts']);
+    expect(pkt.last_passing_tests).toEqual(['tests/pipeline.test.ts']);
+    expect(pkt.blockers).toEqual(['missing type']);
+    expect(pkt.next_command).toBe('npm test');
+  });
+
+  it('generates a unique session_id when none provided', () => {
+    const a = createResumePacket({ goal: 'a' });
+    const b = createResumePacket({ goal: 'b' });
+    expect(typeof a.session_id).toBe('string');
+    expect(a.session_id.length).toBeGreaterThan(0);
+    expect(a.session_id).not.toBe(b.session_id);
+  });
+
+  it('uses the provided session_id', () => {
+    const pkt = createResumePacket({ goal: 'x', session_id: 'ses-42' });
+    expect(pkt.session_id).toBe('ses-42');
+  });
+
+  it('defaults arrays and next_command to empty', () => {
+    const pkt = createResumePacket({ goal: 'minimal' });
+    expect(pkt.open_files).toEqual([]);
+    expect(pkt.last_passing_tests).toEqual([]);
+    expect(pkt.blockers).toEqual([]);
+    expect(pkt.next_command).toBe('');
+  });
+
+  it('generated_at_utc is a valid ISO timestamp', () => {
+    const pkt = createResumePacket({ goal: 'ts check' });
+    expect(() => new Date(pkt.generated_at_utc)).not.toThrow();
+    expect(new Date(pkt.generated_at_utc).toISOString()).toBe(pkt.generated_at_utc);
+  });
+});
+
+// ─── ToolLoopDetector ─────────────────────────────────────────────────────────
+
+describe('createToolLoopDetector', () => {
+  it('does not fire below min_calls', () => {
+    const det = createToolLoopDetector({ min_calls: 3 });
+    det.record('read', { content: 'abc' });
+    det.record('read', { content: 'abc' });
+    expect(det.check().is_looping).toBe(false);
+    expect(det.check().evidence).toMatch(/need 3/);
+  });
+
+  it('fires when repeated calls produce no new evidence', () => {
+    const det = createToolLoopDetector({ min_calls: 3, threshold: 0.6 });
+    const same = { content: 'same' };
+    det.record('grep', same);
+    det.record('grep', same);
+    det.record('grep', same);
+    const result = det.check();
+    expect(result.is_looping).toBe(true);
+    expect(result.loop_tool).toBe('grep');
+    // first call has delta=1 (new); next two are delta=0
+    expect(result.repeat_count).toBe(2);
+  });
+
+  it('does not fire when every call produces new evidence', () => {
+    const det = createToolLoopDetector({ min_calls: 3, threshold: 0.75 });
+    det.record('read', { a: 1 });
+    det.record('read', { b: 2 });
+    det.record('read', { c: 3 });
+    expect(det.check().is_looping).toBe(false);
+  });
+
+  it('tracks distinct tools independently, fires only on the looping one', () => {
+    const det = createToolLoopDetector({ min_calls: 3, threshold: 0.6 });
+    det.record('toolA', 'same');
+    det.record('toolA', 'same');
+    det.record('toolA', 'same');
+    det.record('toolB', { new: 1 });
+    det.record('toolB', { new: 2 });
+    det.record('toolB', { new: 3 });
+    const result = det.check();
+    expect(result.is_looping).toBe(true);
+    expect(result.loop_tool).toBe('toolA');
+  });
+
+  it('recommends escalate when zero-delta ratio is >= 90%', () => {
+    const det = createToolLoopDetector({ min_calls: 5, threshold: 0.6 });
+    // 10 identical calls: first has delta=1, next 9 have delta=0 → 9/10 = 90%
+    for (let i = 0; i < 10; i++) det.record('grep', 'same_result');
+    const result = det.check();
+    expect(result.is_looping).toBe(true);
+    expect(result.recommendation).toBe('escalate');
+  });
+
+  it('recommends stop when zero-delta ratio is between threshold and 90%', () => {
+    const det = createToolLoopDetector({ min_calls: 3, threshold: 0.5 });
+    // 3 identical calls: first has delta=1, next 2 have delta=0 → 2/3 = 66%, below 90%
+    det.record('search', 'dup');
+    det.record('search', 'dup');
+    det.record('search', 'dup');
+    const result = det.check();
+    expect(result.is_looping).toBe(true);
+    expect(result.recommendation).toBe('stop');
+  });
+
+  it('reset clears history and detection state', () => {
+    const det = createToolLoopDetector({ min_calls: 3, threshold: 0.5 });
+    det.record('read', 'x');
+    det.record('read', 'x');
+    det.record('read', 'x');
+    expect(det.check().is_looping).toBe(true);
+    det.reset();
+    expect(det.history()).toHaveLength(0);
+    expect(det.check().is_looping).toBe(false);
+  });
+
+  it('history returns all recorded calls in order', () => {
+    const det = createToolLoopDetector();
+    det.record('a', 1);
+    det.record('b', 2);
+    const h = det.history();
+    expect(h).toHaveLength(2);
+    expect(h[0].tool).toBe('a');
+    expect(h[1].tool).toBe('b');
+  });
+
+  it('evidence_delta is 1 for first call, 0 for repeated result', () => {
+    const det = createToolLoopDetector();
+    const r1 = det.record('grep', 'result');
+    const r2 = det.record('grep', 'result');
+    const r3 = det.record('grep', 'new-result');
+    expect(r1.evidence_delta).toBe(1);
+    expect(r2.evidence_delta).toBe(0);
+    expect(r3.evidence_delta).toBe(1);
+  });
+
+  it('result_hash is a hex string', () => {
+    const det = createToolLoopDetector();
+    const rec = det.record('tool', { data: 'value' });
+    expect(rec.result_hash).toMatch(/^[0-9a-f]+$/);
+    expect(rec.result_hash.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Lane 52 — Resume packet**: `createResumePacket()` captures goal, open files, last passing tests, blockers, and next command as a portable `scbe_resume_packet_v1` JSON object. Any continuation session can pick up exactly where an interrupted session left off without re-reading state.
- **Lane 55 — Tool-loop detector**: `createToolLoopDetector()` hashes the result of every tool call and tracks unique results per tool. When the zero-delta ratio (calls that produced no new result hash) for a single tool exceeds the threshold, the detector fires. Catches exact-repeat loops and the common failure mode where args vary slightly but results are equivalent. Evidence thresholds: ≥75% → `stop`, ≥90% → `escalate`.
- No overlap with existing types: `life-ledger.ts` (agent biography) and `GovernedPipelineState` (governance execution state) are orthogonal to session-level task context.

## Test plan

- [ ] `packages/agent-bus/` — `npm test` passes 260/260 (16 new task-ledger tests added)
- [ ] `tsc --noEmit` clean
- [ ] `prettier --check` clean
- [ ] CI: `agent-bus-lint-and-test` workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)