### PR TITLE
feat(agent-bus): add ReactionChain workflow engine

### DIFF
--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1958,3 +1958,23 @@ export async function runAgentBusTerminalUi(options: AgentBusClientOptions = {})
     rl.close();
   }
 }
+
+export {
+  type ReactionSpec,
+  type ReactionChain,
+  type ReactionStepStatus,
+  type ReactionStepState,
+  type ChainRunStatus,
+  type ReactionChainState,
+  type ChainStartResult,
+  type ChainAdvanceResult,
+  type ReactionRunnerFn,
+  type ReactionChainRunOptions,
+  type ReactionChainRunResult,
+  startChain,
+  getReadyReactions,
+  advanceChain,
+  renderTask,
+  buildReactionEvent,
+  runReactionChain,
+} from './reaction-chain.js';

--- a/packages/agent-bus/src/reaction-chain.ts
+++ b/packages/agent-bus/src/reaction-chain.ts
@@ -1,0 +1,328 @@
+/**
+ * @file reaction-chain.ts
+ * @module agent-bus/reaction-chain
+ * @layer Cross-layer workflow orchestration
+ * @component ReactionChain — chemical-reaction-style verified workflow chains
+ *
+ * Each "reaction" is one governed AgentBusEvent step. When a step completes,
+ * downstream steps whose deps are now satisfied are automatically enqueued.
+ * Small AI can execute long verified chains at low cost because each step is
+ * independently minimal and the chain state is fully serializable.
+ *
+ * Security: task_template supports ${step.<id>.result|status|ok} interpolation
+ * for passing prior outputs forward as NL context. operationCommand is NEVER
+ * interpolated — it flows verbatim to shell execution to prevent injection.
+ *
+ * Cost routing: model_tier ('local'|'free'|'paid') maps to dispatchProvider
+ * on each enqueued event, enabling the free-first routing policy per step.
+ */
+
+import crypto from 'node:crypto';
+import type { AgentBusEvent, RunOptions } from './index.js';
+import { enqueueEvent, processOneEvent, getEventStatus } from './queue.js';
+
+// ─── Spec types (workflow definition) ────────────────────────────────────────
+
+/**
+ * One reaction step in a chain.
+ *
+ * id             — unique within the chain; used as the dependency key.
+ * task_template  — NL prompt. Supports ${step.<id>.result|status|ok}.
+ * operation_command — static shell stub. Never interpolated.
+ * model_tier     — cost-routing hint: 'local' → Ollama, 'free' → Cerebras/Groq, 'paid' → Anthropic.
+ * depends_on     — IDs that must be 'done' before this step fires.
+ */
+export interface ReactionSpec {
+  id: string;
+  task_template: string;
+  task_type?: string;
+  operation_command?: string;
+  model_tier?: 'local' | 'free' | 'paid';
+  depends_on?: string[];
+}
+
+/** Versioned, named workflow spec. */
+export interface ReactionChain {
+  schema_version: 'scbe_reaction_chain_v1';
+  chain_id: string;
+  reactions: ReactionSpec[];
+}
+
+// ─── Runtime state types ──────────────────────────────────────────────────────
+
+export type ReactionStepStatus = 'pending' | 'running' | 'done' | 'blocked';
+export type ChainRunStatus = 'running' | 'complete' | 'blocked';
+
+export interface ReactionStepState {
+  id: string;
+  status: ReactionStepStatus;
+  queue_run_id?: string;
+  result?: unknown;
+  started_at?: string;
+  finished_at?: string;
+  error?: string;
+}
+
+export interface ReactionChainState {
+  schema_version: 'scbe_reaction_chain_state_v1';
+  chain_id: string;
+  run_id: string;
+  started_at: string;
+  status: ChainRunStatus;
+  steps: Record<string, ReactionStepState>;
+}
+
+// ─── Pure state machine ───────────────────────────────────────────────────────
+
+export interface ChainStartResult {
+  state: ReactionChainState;
+  /** IDs of reactions that are immediately ready to fire. */
+  ready: string[];
+}
+
+export interface ChainAdvanceResult {
+  state: ReactionChainState;
+  /** IDs that became ready after this step completed (empty if step was blocked). */
+  newly_ready: string[];
+  done: boolean;
+}
+
+/**
+ * Initialize a chain run. Empty chains start with status 'complete' and ready=[].
+ * All steps start as 'pending'; reactions with no deps are immediately ready.
+ */
+export function startChain(chain: ReactionChain): ChainStartResult {
+  const now = new Date().toISOString();
+  const steps: Record<string, ReactionStepState> = {};
+  for (const r of chain.reactions) {
+    steps[r.id] = { id: r.id, status: 'pending' };
+  }
+  const status: ChainRunStatus = chain.reactions.length === 0 ? 'complete' : 'running';
+  const state: ReactionChainState = {
+    schema_version: 'scbe_reaction_chain_state_v1',
+    chain_id: chain.chain_id,
+    run_id: crypto.randomBytes(6).toString('hex'),
+    started_at: now,
+    status,
+    steps,
+  };
+  return { state, ready: getReadyReactions(state, chain) };
+}
+
+/**
+ * Return IDs of pending reactions whose every dependency is 'done'.
+ * Pure — no mutations, safe to call repeatedly.
+ */
+export function getReadyReactions(state: ReactionChainState, chain: ReactionChain): string[] {
+  return chain.reactions
+    .filter((r) => {
+      const step = state.steps[r.id];
+      if (!step || step.status !== 'pending') return false;
+      return (r.depends_on ?? []).every((dep) => state.steps[dep]?.status === 'done');
+    })
+    .map((r) => r.id);
+}
+
+/**
+ * Record that a step completed and return the updated state + newly ready IDs.
+ *
+ * ok=false marks the step 'blocked'. Any step whose deps include a blocked
+ * step can never become ready. When no pending or running steps remain
+ * reachable, the chain transitions to 'blocked'.
+ */
+export function advanceChain(
+  state: ReactionChainState,
+  chain: ReactionChain,
+  completedId: string,
+  result: unknown,
+  ok: boolean
+): ChainAdvanceResult {
+  const now = new Date().toISOString();
+  const updated: ReactionChainState = {
+    ...state,
+    steps: {
+      ...state.steps,
+      [completedId]: {
+        ...state.steps[completedId]!,
+        status: ok ? 'done' : 'blocked',
+        result,
+        finished_at: now,
+        ...(ok ? {} : { error: 'step completed with ok=false' }),
+      },
+    },
+  };
+
+  const newly_ready = ok ? getReadyReactions(updated, chain) : [];
+
+  // Determine overall chain status
+  const allDone = chain.reactions.every((r) => updated.steps[r.id]?.status === 'done');
+  if (allDone) {
+    updated.status = 'complete';
+  } else {
+    const anyBlocked = Object.values(updated.steps).some((s) => s.status === 'blocked');
+    if (anyBlocked) {
+      const stillReachable = getReadyReactions(updated, chain).length > 0;
+      const stillRunning = Object.values(updated.steps).some((s) => s.status === 'running');
+      if (!stillReachable && !stillRunning && newly_ready.length === 0) {
+        updated.status = 'blocked';
+      }
+    }
+  }
+
+  return { state: updated, newly_ready, done: updated.status === 'complete' };
+}
+
+// ─── Task template rendering ──────────────────────────────────────────────────
+
+const STEP_REF_RE = /\$\{step\.([a-zA-Z0-9_-]+)\.(result|status|ok)\}/g;
+
+/**
+ * Render a task_template by substituting ${step.<id>.result|status|ok} from state.
+ *
+ * Only task_template is ever passed to this function.
+ * operation_command MUST NOT be rendered here — it flows to shell argv.
+ */
+export function renderTask(template: string, state: ReactionChainState): string {
+  return template.replace(STEP_REF_RE, (_match, stepId, field) => {
+    const step = state.steps[stepId];
+    if (!step) return _match;
+    if (field === 'result') {
+      const v = step.result;
+      return v === undefined ? _match : typeof v === 'string' ? v : JSON.stringify(v);
+    }
+    if (field === 'status') return step.status;
+    // field === 'ok'
+    return step.status === 'done' ? 'true' : 'false';
+  });
+}
+
+// ─── Event builder ────────────────────────────────────────────────────────────
+
+const TIER_MAP: Record<string, string> = {
+  local: 'ollama',
+  free: 'cerebras',
+  paid: 'anthropic',
+};
+
+/**
+ * Build an AgentBusEvent from a ReactionSpec and current chain state.
+ *
+ * seriesId encodes the chain run and reaction ID so completion can be
+ * traced back to the right step.
+ *
+ * task_template is rendered (NL interpolation allowed).
+ * operation_command is passed verbatim (no interpolation, no exceptions).
+ */
+export function buildReactionEvent(
+  spec: ReactionSpec,
+  state: ReactionChainState,
+  chainRunId: string
+): AgentBusEvent {
+  return {
+    task: renderTask(spec.task_template, state),
+    seriesId: `${chainRunId}-${spec.id}`,
+    ...(spec.task_type ? { taskType: spec.task_type } : {}),
+    ...(spec.operation_command ? { operationCommand: spec.operation_command } : {}),
+    ...(spec.model_tier ? { dispatchProvider: TIER_MAP[spec.model_tier] ?? 'offline' } : {}),
+  };
+}
+
+// ─── Queue runner ─────────────────────────────────────────────────────────────
+
+/** Signature for an injectable event runner (primarily for testing). */
+export type ReactionRunnerFn = (event: AgentBusEvent) => Promise<{ ok: boolean; result: unknown }>;
+
+export interface ReactionChainRunOptions extends RunOptions {
+  /**
+   * Override the event runner. When omitted, events route through the
+   * filesystem queue: enqueueEvent → processOneEvent → getEventStatus.
+   *
+   * Note: the default queue runner assumes the queue is idle before the
+   * chain starts. For a shared queue, inject a custom runEvent that
+   * dispatches to a specific handler.
+   */
+  runEvent?: ReactionRunnerFn;
+}
+
+export interface ReactionChainRunResult {
+  schema_version: 'scbe_reaction_chain_run_v1';
+  chain_id: string;
+  run_id: string;
+  state: ReactionChainState;
+  ok: boolean;
+  steps_completed: number;
+  steps_blocked: number;
+}
+
+function defaultQueueRunner(options: RunOptions): ReactionRunnerFn {
+  return async (event: AgentBusEvent) => {
+    const runId = enqueueEvent(event, options);
+    await processOneEvent();
+    const queued = getEventStatus(runId);
+    return {
+      ok: queued?.result?.ok ?? false,
+      result: queued?.result?.result ?? null,
+    };
+  };
+}
+
+/**
+ * Execute a ReactionChain, returning the final run state and summary.
+ *
+ * Steps are processed in dependency order. A batch of ready steps (all with
+ * no unmet deps) runs sequentially; after the batch completes, the next
+ * batch of newly-ready steps runs, and so on.
+ *
+ * When a step fails (ok=false), all steps that depend on it (directly or
+ * transitively) become permanently unreachable and the chain terminates as
+ * 'blocked'.
+ */
+export async function runReactionChain(
+  chain: ReactionChain,
+  options: ReactionChainRunOptions = {}
+): Promise<ReactionChainRunResult> {
+  const runner = options.runEvent ?? defaultQueueRunner(options);
+  let { state, ready } = startChain(chain);
+
+  while (ready.length > 0 && state.status === 'running') {
+    const batch = [...ready];
+
+    for (const id of batch) {
+      const spec = chain.reactions.find((r) => r.id === id);
+      if (!spec) continue;
+
+      state = {
+        ...state,
+        steps: {
+          ...state.steps,
+          [id]: {
+            ...state.steps[id]!,
+            status: 'running',
+            started_at: new Date().toISOString(),
+          },
+        },
+      };
+
+      const event = buildReactionEvent(spec, state, state.run_id);
+      const { ok, result } = await runner(event);
+
+      const { state: next } = advanceChain(state, chain, id, result, ok);
+      state = next;
+    }
+
+    ready = state.status === 'running' ? getReadyReactions(state, chain) : [];
+  }
+
+  const completed = Object.values(state.steps).filter((s) => s.status === 'done').length;
+  const blocked = Object.values(state.steps).filter((s) => s.status === 'blocked').length;
+
+  return {
+    schema_version: 'scbe_reaction_chain_run_v1',
+    chain_id: chain.chain_id,
+    run_id: state.run_id,
+    state,
+    ok: state.status === 'complete',
+    steps_completed: completed,
+    steps_blocked: blocked,
+  };
+}

--- a/packages/agent-bus/tests/reaction-chain.test.ts
+++ b/packages/agent-bus/tests/reaction-chain.test.ts
@@ -1,0 +1,453 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type ReactionChain,
+  type ReactionChainState,
+  startChain,
+  getReadyReactions,
+  advanceChain,
+  renderTask,
+  buildReactionEvent,
+  runReactionChain,
+} from '../src/reaction-chain.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function linearChain(): ReactionChain {
+  return {
+    schema_version: 'scbe_reaction_chain_v1',
+    chain_id: 'linear',
+    reactions: [
+      { id: 'A', task_template: 'Do A' },
+      { id: 'B', task_template: 'Do B', depends_on: ['A'] },
+    ],
+  };
+}
+
+function parallelChain(): ReactionChain {
+  return {
+    schema_version: 'scbe_reaction_chain_v1',
+    chain_id: 'parallel',
+    reactions: [
+      { id: 'A', task_template: 'Do A' },
+      { id: 'B', task_template: 'Do B' },
+      { id: 'C', task_template: 'Do C', depends_on: ['A', 'B'] },
+    ],
+  };
+}
+
+function mockRunner(ok = true): import('../src/reaction-chain.js').ReactionRunnerFn {
+  return async (_event) => ({ ok, result: { fired: _event.task } });
+}
+
+// ─── startChain ───────────────────────────────────────────────────────────────
+
+describe('startChain', () => {
+  it('initializes all steps as pending', () => {
+    const { state } = startChain(linearChain());
+    expect(state.steps['A']!.status).toBe('pending');
+    expect(state.steps['B']!.status).toBe('pending');
+  });
+
+  it('sets status to running for non-empty chain', () => {
+    const { state } = startChain(linearChain());
+    expect(state.status).toBe('running');
+  });
+
+  it('sets status to complete for empty chain', () => {
+    const empty: ReactionChain = {
+      schema_version: 'scbe_reaction_chain_v1',
+      chain_id: 'empty',
+      reactions: [],
+    };
+    const { state, ready } = startChain(empty);
+    expect(state.status).toBe('complete');
+    expect(ready).toHaveLength(0);
+  });
+
+  it('returns only dep-free reactions as ready', () => {
+    const { ready } = startChain(linearChain());
+    expect(ready).toEqual(['A']);
+  });
+
+  it('returns all dep-free reactions when multiple have no deps', () => {
+    const { ready } = startChain(parallelChain());
+    expect(ready).toContain('A');
+    expect(ready).toContain('B');
+    expect(ready).not.toContain('C');
+  });
+
+  it('assigns a unique run_id each call', () => {
+    const { state: s1 } = startChain(linearChain());
+    const { state: s2 } = startChain(linearChain());
+    expect(s1.run_id).not.toBe(s2.run_id);
+  });
+
+  it('carries the chain_id into state', () => {
+    const { state } = startChain(linearChain());
+    expect(state.chain_id).toBe('linear');
+  });
+});
+
+// ─── getReadyReactions ────────────────────────────────────────────────────────
+
+describe('getReadyReactions', () => {
+  it('returns step once its dep is done', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const withADone: ReactionChainState = {
+      ...state,
+      steps: { ...state.steps, A: { id: 'A', status: 'done' } },
+    };
+    expect(getReadyReactions(withADone, chain)).toEqual(['B']);
+  });
+
+  it('does not return a running step', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const withARunning: ReactionChainState = {
+      ...state,
+      steps: { ...state.steps, A: { id: 'A', status: 'running' } },
+    };
+    expect(getReadyReactions(withARunning, chain)).toEqual([]);
+  });
+
+  it('does not return a step with an unmet dep', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    expect(getReadyReactions(state, chain)).not.toContain('B');
+  });
+
+  it('returns a step only when ALL deps are done', () => {
+    const chain = parallelChain();
+    const { state } = startChain(chain);
+    const withADone: ReactionChainState = {
+      ...state,
+      steps: { ...state.steps, A: { id: 'A', status: 'done' } },
+    };
+    // C needs both A and B — B is still pending, so C is not ready
+    expect(getReadyReactions(withADone, chain)).not.toContain('C');
+  });
+});
+
+// ─── advanceChain ─────────────────────────────────────────────────────────────
+
+describe('advanceChain', () => {
+  it('marks a successful step as done', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { state: next } = advanceChain(state, chain, 'A', 'output', true);
+    expect(next.steps['A']!.status).toBe('done');
+    expect(next.steps['A']!.result).toBe('output');
+  });
+
+  it('returns newly ready steps after success', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { newly_ready } = advanceChain(state, chain, 'A', null, true);
+    expect(newly_ready).toEqual(['B']);
+  });
+
+  it('marks a failed step as blocked', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { state: next } = advanceChain(state, chain, 'A', null, false);
+    expect(next.steps['A']!.status).toBe('blocked');
+  });
+
+  it('returns no newly_ready steps when a step fails', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { newly_ready } = advanceChain(state, chain, 'A', null, false);
+    expect(newly_ready).toHaveLength(0);
+  });
+
+  it('sets chain status to complete when all steps are done', () => {
+    const chain = linearChain();
+    const { state: s0 } = startChain(chain);
+    const { state: s1 } = advanceChain(s0, chain, 'A', null, true);
+    const { state: s2, done } = advanceChain(s1, chain, 'B', null, true);
+    expect(s2.status).toBe('complete');
+    expect(done).toBe(true);
+  });
+
+  it('sets chain status to blocked when a failure makes no steps reachable', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    // A fails → B depends on A → nothing reachable
+    const { state: next } = advanceChain(state, chain, 'A', null, false);
+    expect(next.status).toBe('blocked');
+  });
+
+  it('does NOT set blocked if other independent steps are still reachable', () => {
+    // Chain: A (no deps), B (no deps), C (depends_on: [A, B])
+    // A fails but B is still pending (no dep on A)
+    const chain = parallelChain();
+    const { state } = startChain(chain);
+    const { state: next } = advanceChain(state, chain, 'A', null, false);
+    // B is still pending and reachable → chain should still be 'running'
+    expect(next.status).toBe('running');
+  });
+
+  it('sets chain to blocked when all remaining steps transitively depend on a blocked step', () => {
+    // Parallel chain: A fails, then B succeeds, C depends on [A, B] so C can never run
+    const chain = parallelChain();
+    const { state: s0 } = startChain(chain);
+    const { state: s1 } = advanceChain(s0, chain, 'A', null, false); // A blocked
+    const { state: s2 } = advanceChain(s1, chain, 'B', null, true); // B done
+    // C depends on A (blocked) and B (done) — C is permanently unreachable
+    expect(s2.status).toBe('blocked');
+  });
+
+  it('attaches finished_at to the completed step', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { state: next } = advanceChain(state, chain, 'A', null, true);
+    expect(typeof next.steps['A']!.finished_at).toBe('string');
+  });
+});
+
+// ─── renderTask ───────────────────────────────────────────────────────────────
+
+describe('renderTask', () => {
+  function stateWithDoneStep(id: string, result: unknown): ReactionChainState {
+    return {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'r1',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: { [id]: { id, status: 'done', result } },
+    };
+  }
+
+  it('replaces ${step.<id>.result} with string values', () => {
+    const state = stateWithDoneStep('fetch', 'some content');
+    expect(renderTask('Process: ${step.fetch.result}', state)).toBe('Process: some content');
+  });
+
+  it('JSON-serializes non-string result values', () => {
+    const state = stateWithDoneStep('fetch', { data: [1, 2] });
+    expect(renderTask('Got: ${step.fetch.result}', state)).toBe('Got: {"data":[1,2]}');
+  });
+
+  it('replaces ${step.<id>.status}', () => {
+    const state = stateWithDoneStep('step1', null);
+    expect(renderTask('Status: ${step.step1.status}', state)).toBe('Status: done');
+  });
+
+  it('replaces ${step.<id>.ok} with true when step is done', () => {
+    const state = stateWithDoneStep('step1', null);
+    expect(renderTask('${step.step1.ok}', state)).toBe('true');
+  });
+
+  it('replaces ${step.<id>.ok} with false for non-done status', () => {
+    const state: ReactionChainState = {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'r1',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: { s: { id: 's', status: 'blocked' } },
+    };
+    expect(renderTask('${step.s.ok}', state)).toBe('false');
+  });
+
+  it('leaves unknown step references unchanged', () => {
+    const state: ReactionChainState = {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'r1',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: {},
+    };
+    const template = 'Missing: ${step.unknown.result}';
+    expect(renderTask(template, state)).toBe(template);
+  });
+
+  it('handles multiple references in one template', () => {
+    const state: ReactionChainState = {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'r1',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: {
+        a: { id: 'a', status: 'done', result: 'hello' },
+        b: { id: 'b', status: 'done', result: 'world' },
+      },
+    };
+    expect(renderTask('${step.a.result} ${step.b.result}', state)).toBe('hello world');
+  });
+});
+
+// ─── buildReactionEvent ───────────────────────────────────────────────────────
+
+describe('buildReactionEvent', () => {
+  function emptyRunState(): ReactionChainState {
+    return {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'run-abc',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: {},
+    };
+  }
+
+  it('sets task from rendered task_template', () => {
+    const event = buildReactionEvent(
+      { id: 'step1', task_template: 'Do the thing' },
+      emptyRunState(),
+      'run-abc'
+    );
+    expect(event.task).toBe('Do the thing');
+  });
+
+  it('encodes seriesId as chainRunId-reactionId', () => {
+    const event = buildReactionEvent(
+      { id: 'step1', task_template: 'x' },
+      emptyRunState(),
+      'run-abc'
+    );
+    expect(event.seriesId).toBe('run-abc-step1');
+  });
+
+  it('maps model_tier local to ollama dispatchProvider', () => {
+    const event = buildReactionEvent(
+      { id: 's', task_template: 'x', model_tier: 'local' },
+      emptyRunState(),
+      'r'
+    );
+    expect(event.dispatchProvider).toBe('ollama');
+  });
+
+  it('maps model_tier free to cerebras dispatchProvider', () => {
+    const event = buildReactionEvent(
+      { id: 's', task_template: 'x', model_tier: 'free' },
+      emptyRunState(),
+      'r'
+    );
+    expect(event.dispatchProvider).toBe('cerebras');
+  });
+
+  it('maps model_tier paid to anthropic dispatchProvider', () => {
+    const event = buildReactionEvent(
+      { id: 's', task_template: 'x', model_tier: 'paid' },
+      emptyRunState(),
+      'r'
+    );
+    expect(event.dispatchProvider).toBe('anthropic');
+  });
+
+  it('omits dispatchProvider when model_tier is not set', () => {
+    const event = buildReactionEvent({ id: 's', task_template: 'x' }, emptyRunState(), 'r');
+    expect(event.dispatchProvider).toBeUndefined();
+  });
+
+  it('NEVER interpolates operation_command (security invariant)', () => {
+    const state: ReactionChainState = {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'run-abc',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: { prior: { id: 'prior', status: 'done', result: 'injected-value' } },
+    };
+    const event = buildReactionEvent(
+      {
+        id: 'step1',
+        task_template: 'Use ${step.prior.result}',
+        operation_command: 'node ${step.prior.result}',
+      },
+      state,
+      'run-abc'
+    );
+    // task IS interpolated (NL context)
+    expect(event.task).toBe('Use injected-value');
+    // operationCommand is NEVER interpolated
+    expect(event.operationCommand).toBe('node ${step.prior.result}');
+  });
+});
+
+// ─── runReactionChain ─────────────────────────────────────────────────────────
+
+describe('runReactionChain', () => {
+  it('runs a linear chain to completion', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner() });
+    expect(result.ok).toBe(true);
+    expect(result.state.status).toBe('complete');
+    expect(result.steps_completed).toBe(2);
+    expect(result.steps_blocked).toBe(0);
+  });
+
+  it('returns correct schema_version', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner() });
+    expect(result.schema_version).toBe('scbe_reaction_chain_run_v1');
+  });
+
+  it('stops when first step fails and marks chain blocked', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner(false) });
+    expect(result.ok).toBe(false);
+    expect(result.state.status).toBe('blocked');
+    expect(result.steps_completed).toBe(0);
+    expect(result.steps_blocked).toBe(1);
+  });
+
+  it('runs parallel reactions then the join step', async () => {
+    const fired: string[] = [];
+    const runner = async (event: import('../src/index.js').AgentBusEvent) => {
+      fired.push(event.seriesId ?? '');
+      return { ok: true, result: null };
+    };
+    const result = await runReactionChain(parallelChain(), { runEvent: runner });
+    expect(result.ok).toBe(true);
+    expect(result.steps_completed).toBe(3);
+    // A and B fire before C
+    const cIdx = fired.findIndex((s) => s.endsWith('-C'));
+    const aIdx = fired.findIndex((s) => s.endsWith('-A'));
+    const bIdx = fired.findIndex((s) => s.endsWith('-B'));
+    expect(cIdx).toBeGreaterThan(aIdx);
+    expect(cIdx).toBeGreaterThan(bIdx);
+  });
+
+  it('completes an empty chain immediately', async () => {
+    const empty: ReactionChain = {
+      schema_version: 'scbe_reaction_chain_v1',
+      chain_id: 'empty',
+      reactions: [],
+    };
+    const result = await runReactionChain(empty);
+    expect(result.ok).toBe(true);
+    expect(result.state.status).toBe('complete');
+    expect(result.steps_completed).toBe(0);
+  });
+
+  it('passes prior step results forward via task_template interpolation', async () => {
+    const received: string[] = [];
+    const runner = async (event: import('../src/index.js').AgentBusEvent) => {
+      received.push(event.task);
+      return { ok: true, result: 'step-output' };
+    };
+    const chain: ReactionChain = {
+      schema_version: 'scbe_reaction_chain_v1',
+      chain_id: 'passthrough',
+      reactions: [
+        { id: 'fetch', task_template: 'Fetch the data' },
+        { id: 'process', task_template: 'Process: ${step.fetch.result}', depends_on: ['fetch'] },
+      ],
+    };
+    await runReactionChain(chain, { runEvent: runner });
+    expect(received[1]).toBe('Process: step-output');
+  });
+
+  it('marks the run_id consistently between state and result', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner() });
+    expect(result.run_id).toBe(result.state.run_id);
+  });
+
+  it('carries the chain_id into the result', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner() });
+    expect(result.chain_id).toBe('linear');
+  });
+});


### PR DESCRIPTION
## Summary

- **Reaction chain spec format** (`ReactionChain`, `ReactionSpec`) — define multi-step workflows where each step is one governed `AgentBusEvent`, with explicit `depends_on` for sequencing
- **Pure state machine** (`startChain`, `getReadyReactions`, `advanceChain`) — fully I/O-free, serializable between steps; transitive blocked-dep detection ensures a failed step correctly terminates all downstream work
- **Queue wiring** (`runReactionChain`) — processes ready batches in order, pipes prior step outputs forward via `${step.<id>.result}` interpolation in `task_template`, routes each step to the right cost tier via `model_tier` → `dispatchProvider`

**Security invariant tested explicitly:** `operationCommand` is NEVER interpolated — only `task_template` (NL prompt) receives prior-step output substitution. Shell argv stays static.

## What this enables

Small AI agents can execute long, verified, multi-step workflows at low cost:
- Each step is independently minimal
- Chain state is serializable (checkpoint between steps)
- Cheap models handle simple steps (`model_tier: 'local'` or `'free'`); expensive models only where needed
- Step failure cleanly blocks dependent work rather than silently proceeding

## Test plan

- [x] 42 tests: `startChain`, `getReadyReactions`, `advanceChain`, `renderTask`, `buildReactionEvent`, `runReactionChain` with injected mock runner
- [x] Linear chain (A → B), parallel+join (A, B → C), failure propagation, empty chain
- [x] `operationCommand` never-interpolate security test
- [x] 302/302 full agent-bus suite passing
- [x] TypeScript typecheck clean, Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)