### PR TITLE
feat(agent-bus): add BoardFields agentic board layer

### DIFF
--- a/packages/agent-bus/src/board-fields.ts
+++ b/packages/agent-bus/src/board-fields.ts
@@ -1,0 +1,334 @@
+/**
+ * @file board-fields.ts
+ * @module agent-bus/board-fields
+ * @layer Cross-layer agentic board state
+ * @component BoardFields — multi-domain governed map for agentic workflows
+ *
+ * Wraps a ReactionChain with a spatial/epistemic board so each step has a
+ * declared domain, clearance requirement, tick cost, and known_state.
+ *
+ * Domains model the layers where work happens:
+ *   surface    — files, tasks, docs, UI (everyday read/write)
+ *   air        — model calls, summaries, fast routing
+ *   sea        — long-running workflows, queues, pipelines
+ *   subground  — secrets, provenance, dependency roots, poisoned inputs
+ *   space      — high-level goals, mission state, global strategy
+ *   personal   — each agent's private Polly Pad state
+ *   shared     — squad board, leader state, shared memory
+ *
+ * Security invariant: cells tagged 'poisoned' are never entered — they block
+ * the step immediately without calling the inner runner. This is the board-level
+ * quarantine before the 14-layer promotion pipeline sees the content.
+ *
+ * Clearance levels form a total order: none < read_only < write < execute < admin.
+ * An agent can only enter a cell if its clearance >= cell.clearance.
+ *
+ * Tick cost accumulates across the run and provides a cheap budget signal.
+ * The board state is serializable — checkpoint it between runs.
+ */
+
+import type { AgentBusEvent } from './index.js';
+import { enqueueEvent, processOneEvent, getEventStatus } from './queue.js';
+import type {
+  ReactionChain,
+  ReactionRunnerFn,
+  ReactionChainRunOptions,
+  ReactionChainRunResult,
+} from './reaction-chain.js';
+import { runReactionChain } from './reaction-chain.js';
+
+// ─── Core board types ─────────────────────────────────────────────────────────
+
+export type BoardDomain = 'surface' | 'air' | 'sea' | 'subground' | 'space' | 'personal' | 'shared';
+
+export type BoardOccupancy = 'empty' | 'agent' | 'task' | 'artifact' | 'blocked';
+
+/**
+ * Epistemic state of a cell from the agent's perspective.
+ *
+ * unknown   — never observed; contents are fog-of-war
+ * observed  — a step is or was operating here; data not yet verified
+ * verified  — a step completed successfully; output passed governance
+ * poisoned  — malicious or tainted content detected; entry permanently blocked
+ * blocked   — structurally inaccessible (topology constraint, not data quality)
+ */
+export type BoardKnownState = 'unknown' | 'observed' | 'verified' | 'poisoned' | 'blocked';
+
+/**
+ * Ordered clearance levels. Higher index = higher privilege.
+ * An agent with clearance C can enter any cell requiring C or lower.
+ */
+export type ClearanceLevel = 'none' | 'read_only' | 'write' | 'execute' | 'admin';
+
+const CLEARANCE_RANK: Record<ClearanceLevel, number> = {
+  none: 0,
+  read_only: 1,
+  write: 2,
+  execute: 3,
+  admin: 4,
+};
+
+export interface BoardCell {
+  id: string;
+  domain: BoardDomain;
+  occupancy: BoardOccupancy;
+  /** Minimum clearance required to enter this cell. */
+  clearance: ClearanceLevel;
+  /** Tick cost to operate here. Adds to the run's total_cost. */
+  cost_ticks: number;
+  /** Risk tags (e.g. 'tainted_source', 'unverified', 'external_input'). */
+  risk: string[];
+  known_state: BoardKnownState;
+  /** IDs of cells this cell is linked to (bidirectional traversal not implied). */
+  links: string[];
+}
+
+export interface BoardState {
+  schema_version: 'scbe_board_state_v1';
+  board_id: string;
+  cells: Record<string, BoardCell>;
+  /** Current board clock tick. Advances by each step's cost_ticks. */
+  tick: number;
+  /** Cumulative tick cost across all steps run on this board. */
+  total_cost: number;
+}
+
+// ─── Pure board operations ────────────────────────────────────────────────────
+
+export function createBoard(board_id: string, cells: BoardCell[] = []): BoardState {
+  const cellMap: Record<string, BoardCell> = {};
+  for (const c of cells) {
+    cellMap[c.id] = c;
+  }
+  return {
+    schema_version: 'scbe_board_state_v1',
+    board_id,
+    cells: cellMap,
+    tick: 0,
+    total_cost: 0,
+  };
+}
+
+export function getCell(state: BoardState, cellId: string): BoardCell | null {
+  return state.cells[cellId] ?? null;
+}
+
+/** Immutable cell update — returns a new BoardState. */
+export function setCell(state: BoardState, cell: BoardCell): BoardState {
+  return { ...state, cells: { ...state.cells, [cell.id]: cell } };
+}
+
+/** True if an agent with the given clearance is permitted to enter the cell. */
+export function canEnter(cell: BoardCell, agentClearance: ClearanceLevel): boolean {
+  if (cell.known_state === 'poisoned' || cell.known_state === 'blocked') return false;
+  if (cell.occupancy === 'blocked') return false;
+  return CLEARANCE_RANK[agentClearance] >= CLEARANCE_RANK[cell.clearance];
+}
+
+/**
+ * Minimum tick-distance between two cells via Dijkstra over the links graph.
+ * Edge weight = destination cell's cost_ticks.
+ * Returns null if toId is not reachable from fromId.
+ */
+export function measureTickDistance(
+  state: BoardState,
+  fromId: string,
+  toId: string
+): number | null {
+  if (fromId === toId) return 0;
+  const dist: Record<string, number> = { [fromId]: 0 };
+  const visited = new Set<string>();
+  // [cellId, accumulated_cost]
+  const queue: Array<[string, number]> = [[fromId, 0]];
+
+  while (queue.length > 0) {
+    queue.sort((a, b) => a[1] - b[1]);
+    const [current, cost] = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    if (current === toId) return cost;
+
+    const cell = state.cells[current];
+    if (!cell) continue;
+
+    for (const linkId of cell.links) {
+      if (visited.has(linkId)) continue;
+      const linkCell = state.cells[linkId];
+      if (!linkCell) continue;
+      const newCost = cost + linkCell.cost_ticks;
+      if (newCost < (dist[linkId] ?? Infinity)) {
+        dist[linkId] = newCost;
+        queue.push([linkId, newCost]);
+      }
+    }
+  }
+  return null;
+}
+
+// ─── Boarded chain integration ────────────────────────────────────────────────
+
+/**
+ * Board-placement metadata for one reaction step.
+ * Steps without a placement entry run with no board constraints.
+ */
+export interface BoardPlacement {
+  /** Cell this reaction operates on. */
+  cell_id?: string;
+  /** Required clearance. Defaults to cell.clearance if omitted. */
+  requires_clearance?: ClearanceLevel;
+  /** Override tick cost. Defaults to cell.cost_ticks if omitted. */
+  cost_ticks?: number;
+  /** Risk tags this step may produce (informational; stored on the result). */
+  risk?: string[];
+  /** Cell occupancy to set after a successful step. Default: 'artifact'. */
+  result_occupancy?: BoardOccupancy;
+}
+
+/** A ReactionChain decorated with per-step board placements. */
+export interface BoardedChain {
+  schema_version: 'scbe_boarded_chain_v1';
+  chain: ReactionChain;
+  /** Keyed by reaction spec id. Steps with no entry run without board constraints. */
+  placements: Record<string, BoardPlacement>;
+  /** Clearance level of the agent running this chain. Default: 'none'. */
+  agent_clearance?: ClearanceLevel;
+}
+
+export interface BoardedChainRunResult {
+  schema_version: 'scbe_boarded_chain_run_v1';
+  board_state: BoardState;
+  chain_result: ReactionChainRunResult;
+  tick_total: number;
+  /** Reaction IDs that were blocked by insufficient clearance. */
+  clearance_blocks: string[];
+  /** Reaction IDs that were blocked because their target cell was poisoned. */
+  poison_encounters: string[];
+}
+
+// Duplicated from reaction-chain.ts to avoid a circular import through the re-export in index.ts
+function makeQueueRunner(options: ReactionChainRunOptions): ReactionRunnerFn {
+  return async (event: AgentBusEvent) => {
+    const runId = enqueueEvent(event, options);
+    await processOneEvent();
+    const queued = getEventStatus(runId);
+    return { ok: queued?.result?.ok ?? false, result: queued?.result?.result ?? null };
+  };
+}
+
+/**
+ * Extract the reaction ID from a seriesId produced by buildReactionEvent.
+ * Format: "${12-hex-runId}-${reactionId}" — the runId is pure hex so the
+ * first '-' is always the separator, even if reactionId contains dashes.
+ */
+function extractReactionId(event: AgentBusEvent): string | null {
+  const sid = event.seriesId;
+  if (!sid) return null;
+  const idx = sid.indexOf('-');
+  return idx === -1 ? null : sid.slice(idx + 1);
+}
+
+function meetsClearance(agent: ClearanceLevel, required: ClearanceLevel): boolean {
+  return CLEARANCE_RANK[agent] >= CLEARANCE_RANK[required];
+}
+
+/**
+ * Run a ReactionChain with board-field governance.
+ *
+ * Before each step with a cell_id placement:
+ *   1. Block immediately if the cell is poisoned (poison_encounters logged).
+ *   2. Block immediately if agent clearance < required clearance (clearance_blocks logged).
+ *   3. Mark cell occupancy='task', known_state='observed' (if unknown).
+ *
+ * After each step completes:
+ *   - ok=true  → cell occupancy set to result_occupancy (default 'artifact'), known_state='verified'
+ *   - ok=false → cell occupancy reset to 'empty', known_state unchanged
+ *   - Board tick advances by step's cost_ticks.
+ *
+ * Steps with no placement entry are passed through to the inner runner unchanged.
+ */
+export async function runBoardedChain(
+  boardedChain: BoardedChain,
+  boardState: BoardState,
+  options: ReactionChainRunOptions = {}
+): Promise<BoardedChainRunResult> {
+  let board = boardState;
+  const clearance_blocks: string[] = [];
+  const poison_encounters: string[] = [];
+  const agentClearance: ClearanceLevel = boardedChain.agent_clearance ?? 'none';
+  const baseRunner: ReactionRunnerFn = options.runEvent ?? makeQueueRunner(options);
+
+  const boardRunner: ReactionRunnerFn = async (event: AgentBusEvent) => {
+    const reactionId = extractReactionId(event);
+    const placement = reactionId != null ? boardedChain.placements[reactionId] : undefined;
+
+    if (placement?.cell_id) {
+      const cell = getCell(board, placement.cell_id);
+      if (cell) {
+        // Poison blocks before clearance — even admins cannot enter poisoned cells
+        if (cell.known_state === 'poisoned') {
+          if (reactionId != null) poison_encounters.push(reactionId);
+          return {
+            ok: false,
+            result: { blocked: true, reason: 'poisoned_cell', cell_id: placement.cell_id },
+          };
+        }
+
+        const requiredClearance = placement.requires_clearance ?? cell.clearance;
+        if (!meetsClearance(agentClearance, requiredClearance)) {
+          if (reactionId != null) clearance_blocks.push(reactionId);
+          return {
+            ok: false,
+            result: {
+              blocked: true,
+              reason: 'clearance_denied',
+              cell_id: placement.cell_id,
+              required: requiredClearance,
+              agent: agentClearance,
+            },
+          };
+        }
+
+        // Mark cell as being operated on
+        board = setCell(board, {
+          ...cell,
+          occupancy: 'task',
+          known_state: cell.known_state === 'unknown' ? 'observed' : cell.known_state,
+        });
+      }
+    }
+
+    const stepResult = await baseRunner(event);
+
+    if (placement?.cell_id) {
+      const cell = getCell(board, placement.cell_id);
+      if (cell) {
+        const costTicks = placement.cost_ticks ?? cell.cost_ticks;
+        board = {
+          ...setCell(board, {
+            ...cell,
+            occupancy: stepResult.ok ? (placement.result_occupancy ?? 'artifact') : 'empty',
+            known_state: stepResult.ok ? 'verified' : cell.known_state,
+          }),
+          tick: board.tick + costTicks,
+          total_cost: board.total_cost + costTicks,
+        };
+      }
+    }
+
+    return stepResult;
+  };
+
+  const chain_result = await runReactionChain(boardedChain.chain, {
+    ...options,
+    runEvent: boardRunner,
+  });
+
+  return {
+    schema_version: 'scbe_boarded_chain_run_v1',
+    board_state: board,
+    chain_result,
+    tick_total: board.tick,
+    clearance_blocks,
+    poison_encounters,
+  };
+}

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1960,6 +1960,24 @@ export async function runAgentBusTerminalUi(options: AgentBusClientOptions = {})
 }
 
 export {
+  type BoardDomain,
+  type BoardOccupancy,
+  type BoardKnownState,
+  type ClearanceLevel,
+  type BoardCell,
+  type BoardState,
+  type BoardPlacement,
+  type BoardedChain,
+  type BoardedChainRunResult,
+  createBoard,
+  getCell,
+  setCell,
+  canEnter,
+  measureTickDistance,
+  runBoardedChain,
+} from './board-fields.js';
+
+export {
   type ReactionSpec,
   type ReactionChain,
   type ReactionStepStatus,

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1958,3 +1958,23 @@ export async function runAgentBusTerminalUi(options: AgentBusClientOptions = {})
     rl.close();
   }
 }
+
+export {
+  type ReactionSpec,
+  type ReactionChain,
+  type ReactionStepStatus,
+  type ReactionStepState,
+  type ChainRunStatus,
+  type ReactionChainState,
+  type ChainStartResult,
+  type ChainAdvanceResult,
+  type ReactionRunnerFn,
+  type ReactionChainRunOptions,
+  type ReactionChainRunResult,
+  startChain,
+  getReadyReactions,
+  advanceChain,
+  renderTask,
+  buildReactionEvent,
+  runReactionChain,
+} from './reaction-chain.js';

--- a/packages/agent-bus/src/reaction-chain.ts
+++ b/packages/agent-bus/src/reaction-chain.ts
@@ -1,0 +1,328 @@
+/**
+ * @file reaction-chain.ts
+ * @module agent-bus/reaction-chain
+ * @layer Cross-layer workflow orchestration
+ * @component ReactionChain — chemical-reaction-style verified workflow chains
+ *
+ * Each "reaction" is one governed AgentBusEvent step. When a step completes,
+ * downstream steps whose deps are now satisfied are automatically enqueued.
+ * Small AI can execute long verified chains at low cost because each step is
+ * independently minimal and the chain state is fully serializable.
+ *
+ * Security: task_template supports ${step.<id>.result|status|ok} interpolation
+ * for passing prior outputs forward as NL context. operationCommand is NEVER
+ * interpolated — it flows verbatim to shell execution to prevent injection.
+ *
+ * Cost routing: model_tier ('local'|'free'|'paid') maps to dispatchProvider
+ * on each enqueued event, enabling the free-first routing policy per step.
+ */
+
+import crypto from 'node:crypto';
+import type { AgentBusEvent, RunOptions } from './index.js';
+import { enqueueEvent, processOneEvent, getEventStatus } from './queue.js';
+
+// ─── Spec types (workflow definition) ────────────────────────────────────────
+
+/**
+ * One reaction step in a chain.
+ *
+ * id             — unique within the chain; used as the dependency key.
+ * task_template  — NL prompt. Supports ${step.<id>.result|status|ok}.
+ * operation_command — static shell stub. Never interpolated.
+ * model_tier     — cost-routing hint: 'local' → Ollama, 'free' → Cerebras/Groq, 'paid' → Anthropic.
+ * depends_on     — IDs that must be 'done' before this step fires.
+ */
+export interface ReactionSpec {
+  id: string;
+  task_template: string;
+  task_type?: string;
+  operation_command?: string;
+  model_tier?: 'local' | 'free' | 'paid';
+  depends_on?: string[];
+}
+
+/** Versioned, named workflow spec. */
+export interface ReactionChain {
+  schema_version: 'scbe_reaction_chain_v1';
+  chain_id: string;
+  reactions: ReactionSpec[];
+}
+
+// ─── Runtime state types ──────────────────────────────────────────────────────
+
+export type ReactionStepStatus = 'pending' | 'running' | 'done' | 'blocked';
+export type ChainRunStatus = 'running' | 'complete' | 'blocked';
+
+export interface ReactionStepState {
+  id: string;
+  status: ReactionStepStatus;
+  queue_run_id?: string;
+  result?: unknown;
+  started_at?: string;
+  finished_at?: string;
+  error?: string;
+}
+
+export interface ReactionChainState {
+  schema_version: 'scbe_reaction_chain_state_v1';
+  chain_id: string;
+  run_id: string;
+  started_at: string;
+  status: ChainRunStatus;
+  steps: Record<string, ReactionStepState>;
+}
+
+// ─── Pure state machine ───────────────────────────────────────────────────────
+
+export interface ChainStartResult {
+  state: ReactionChainState;
+  /** IDs of reactions that are immediately ready to fire. */
+  ready: string[];
+}
+
+export interface ChainAdvanceResult {
+  state: ReactionChainState;
+  /** IDs that became ready after this step completed (empty if step was blocked). */
+  newly_ready: string[];
+  done: boolean;
+}
+
+/**
+ * Initialize a chain run. Empty chains start with status 'complete' and ready=[].
+ * All steps start as 'pending'; reactions with no deps are immediately ready.
+ */
+export function startChain(chain: ReactionChain): ChainStartResult {
+  const now = new Date().toISOString();
+  const steps: Record<string, ReactionStepState> = {};
+  for (const r of chain.reactions) {
+    steps[r.id] = { id: r.id, status: 'pending' };
+  }
+  const status: ChainRunStatus = chain.reactions.length === 0 ? 'complete' : 'running';
+  const state: ReactionChainState = {
+    schema_version: 'scbe_reaction_chain_state_v1',
+    chain_id: chain.chain_id,
+    run_id: crypto.randomBytes(6).toString('hex'),
+    started_at: now,
+    status,
+    steps,
+  };
+  return { state, ready: getReadyReactions(state, chain) };
+}
+
+/**
+ * Return IDs of pending reactions whose every dependency is 'done'.
+ * Pure — no mutations, safe to call repeatedly.
+ */
+export function getReadyReactions(state: ReactionChainState, chain: ReactionChain): string[] {
+  return chain.reactions
+    .filter((r) => {
+      const step = state.steps[r.id];
+      if (!step || step.status !== 'pending') return false;
+      return (r.depends_on ?? []).every((dep) => state.steps[dep]?.status === 'done');
+    })
+    .map((r) => r.id);
+}
+
+/**
+ * Record that a step completed and return the updated state + newly ready IDs.
+ *
+ * ok=false marks the step 'blocked'. Any step whose deps include a blocked
+ * step can never become ready. When no pending or running steps remain
+ * reachable, the chain transitions to 'blocked'.
+ */
+export function advanceChain(
+  state: ReactionChainState,
+  chain: ReactionChain,
+  completedId: string,
+  result: unknown,
+  ok: boolean
+): ChainAdvanceResult {
+  const now = new Date().toISOString();
+  const updated: ReactionChainState = {
+    ...state,
+    steps: {
+      ...state.steps,
+      [completedId]: {
+        ...state.steps[completedId]!,
+        status: ok ? 'done' : 'blocked',
+        result,
+        finished_at: now,
+        ...(ok ? {} : { error: 'step completed with ok=false' }),
+      },
+    },
+  };
+
+  const newly_ready = ok ? getReadyReactions(updated, chain) : [];
+
+  // Determine overall chain status
+  const allDone = chain.reactions.every((r) => updated.steps[r.id]?.status === 'done');
+  if (allDone) {
+    updated.status = 'complete';
+  } else {
+    const anyBlocked = Object.values(updated.steps).some((s) => s.status === 'blocked');
+    if (anyBlocked) {
+      const stillReachable = getReadyReactions(updated, chain).length > 0;
+      const stillRunning = Object.values(updated.steps).some((s) => s.status === 'running');
+      if (!stillReachable && !stillRunning && newly_ready.length === 0) {
+        updated.status = 'blocked';
+      }
+    }
+  }
+
+  return { state: updated, newly_ready, done: updated.status === 'complete' };
+}
+
+// ─── Task template rendering ──────────────────────────────────────────────────
+
+const STEP_REF_RE = /\$\{step\.([a-zA-Z0-9_-]+)\.(result|status|ok)\}/g;
+
+/**
+ * Render a task_template by substituting ${step.<id>.result|status|ok} from state.
+ *
+ * Only task_template is ever passed to this function.
+ * operation_command MUST NOT be rendered here — it flows to shell argv.
+ */
+export function renderTask(template: string, state: ReactionChainState): string {
+  return template.replace(STEP_REF_RE, (_match, stepId, field) => {
+    const step = state.steps[stepId];
+    if (!step) return _match;
+    if (field === 'result') {
+      const v = step.result;
+      return v === undefined ? _match : typeof v === 'string' ? v : JSON.stringify(v);
+    }
+    if (field === 'status') return step.status;
+    // field === 'ok'
+    return step.status === 'done' ? 'true' : 'false';
+  });
+}
+
+// ─── Event builder ────────────────────────────────────────────────────────────
+
+const TIER_MAP: Record<string, string> = {
+  local: 'ollama',
+  free: 'cerebras',
+  paid: 'anthropic',
+};
+
+/**
+ * Build an AgentBusEvent from a ReactionSpec and current chain state.
+ *
+ * seriesId encodes the chain run and reaction ID so completion can be
+ * traced back to the right step.
+ *
+ * task_template is rendered (NL interpolation allowed).
+ * operation_command is passed verbatim (no interpolation, no exceptions).
+ */
+export function buildReactionEvent(
+  spec: ReactionSpec,
+  state: ReactionChainState,
+  chainRunId: string
+): AgentBusEvent {
+  return {
+    task: renderTask(spec.task_template, state),
+    seriesId: `${chainRunId}-${spec.id}`,
+    ...(spec.task_type ? { taskType: spec.task_type } : {}),
+    ...(spec.operation_command ? { operationCommand: spec.operation_command } : {}),
+    ...(spec.model_tier ? { dispatchProvider: TIER_MAP[spec.model_tier] ?? 'offline' } : {}),
+  };
+}
+
+// ─── Queue runner ─────────────────────────────────────────────────────────────
+
+/** Signature for an injectable event runner (primarily for testing). */
+export type ReactionRunnerFn = (event: AgentBusEvent) => Promise<{ ok: boolean; result: unknown }>;
+
+export interface ReactionChainRunOptions extends RunOptions {
+  /**
+   * Override the event runner. When omitted, events route through the
+   * filesystem queue: enqueueEvent → processOneEvent → getEventStatus.
+   *
+   * Note: the default queue runner assumes the queue is idle before the
+   * chain starts. For a shared queue, inject a custom runEvent that
+   * dispatches to a specific handler.
+   */
+  runEvent?: ReactionRunnerFn;
+}
+
+export interface ReactionChainRunResult {
+  schema_version: 'scbe_reaction_chain_run_v1';
+  chain_id: string;
+  run_id: string;
+  state: ReactionChainState;
+  ok: boolean;
+  steps_completed: number;
+  steps_blocked: number;
+}
+
+function defaultQueueRunner(options: RunOptions): ReactionRunnerFn {
+  return async (event: AgentBusEvent) => {
+    const runId = enqueueEvent(event, options);
+    await processOneEvent();
+    const queued = getEventStatus(runId);
+    return {
+      ok: queued?.result?.ok ?? false,
+      result: queued?.result?.result ?? null,
+    };
+  };
+}
+
+/**
+ * Execute a ReactionChain, returning the final run state and summary.
+ *
+ * Steps are processed in dependency order. A batch of ready steps (all with
+ * no unmet deps) runs sequentially; after the batch completes, the next
+ * batch of newly-ready steps runs, and so on.
+ *
+ * When a step fails (ok=false), all steps that depend on it (directly or
+ * transitively) become permanently unreachable and the chain terminates as
+ * 'blocked'.
+ */
+export async function runReactionChain(
+  chain: ReactionChain,
+  options: ReactionChainRunOptions = {}
+): Promise<ReactionChainRunResult> {
+  const runner = options.runEvent ?? defaultQueueRunner(options);
+  let { state, ready } = startChain(chain);
+
+  while (ready.length > 0 && state.status === 'running') {
+    const batch = [...ready];
+
+    for (const id of batch) {
+      const spec = chain.reactions.find((r) => r.id === id);
+      if (!spec) continue;
+
+      state = {
+        ...state,
+        steps: {
+          ...state.steps,
+          [id]: {
+            ...state.steps[id]!,
+            status: 'running',
+            started_at: new Date().toISOString(),
+          },
+        },
+      };
+
+      const event = buildReactionEvent(spec, state, state.run_id);
+      const { ok, result } = await runner(event);
+
+      const { state: next } = advanceChain(state, chain, id, result, ok);
+      state = next;
+    }
+
+    ready = state.status === 'running' ? getReadyReactions(state, chain) : [];
+  }
+
+  const completed = Object.values(state.steps).filter((s) => s.status === 'done').length;
+  const blocked = Object.values(state.steps).filter((s) => s.status === 'blocked').length;
+
+  return {
+    schema_version: 'scbe_reaction_chain_run_v1',
+    chain_id: chain.chain_id,
+    run_id: state.run_id,
+    state,
+    ok: state.status === 'complete',
+    steps_completed: completed,
+    steps_blocked: blocked,
+  };
+}

--- a/packages/agent-bus/tests/board-fields.test.ts
+++ b/packages/agent-bus/tests/board-fields.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type BoardCell,
+  type BoardState,
+  type BoardedChain,
+  type ClearanceLevel,
+  createBoard,
+  getCell,
+  setCell,
+  canEnter,
+  measureTickDistance,
+  runBoardedChain,
+} from '../src/board-fields.js';
+import type { ReactionChain } from '../src/reaction-chain.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function cell(id: string, overrides: Partial<BoardCell> = {}): BoardCell {
+  return {
+    id,
+    domain: 'surface',
+    occupancy: 'empty',
+    clearance: 'none',
+    cost_ticks: 1,
+    risk: [],
+    known_state: 'unknown',
+    links: [],
+    ...overrides,
+  };
+}
+
+function twoStepChain(): ReactionChain {
+  return {
+    schema_version: 'scbe_reaction_chain_v1',
+    chain_id: 'two-step',
+    reactions: [
+      { id: 'fetch', task_template: 'Fetch the data' },
+      { id: 'process', task_template: 'Process: ${step.fetch.result}', depends_on: ['fetch'] },
+    ],
+  };
+}
+
+function mockRunner(ok = true) {
+  return async (_event: import('../src/index.js').AgentBusEvent) => ({
+    ok,
+    result: { output: 'done' },
+  });
+}
+
+// ─── createBoard ──────────────────────────────────────────────────────────────
+
+describe('createBoard', () => {
+  it('creates a board with an empty cell map', () => {
+    const board = createBoard('test');
+    expect(board.schema_version).toBe('scbe_board_state_v1');
+    expect(board.board_id).toBe('test');
+    expect(Object.keys(board.cells)).toHaveLength(0);
+    expect(board.tick).toBe(0);
+    expect(board.total_cost).toBe(0);
+  });
+
+  it('indexes provided cells by id', () => {
+    const board = createBoard('b', [cell('A'), cell('B')]);
+    expect(board.cells['A']?.id).toBe('A');
+    expect(board.cells['B']?.id).toBe('B');
+  });
+});
+
+// ─── getCell / setCell ────────────────────────────────────────────────────────
+
+describe('getCell', () => {
+  it('returns the cell for a known id', () => {
+    const board = createBoard('b', [cell('X')]);
+    expect(getCell(board, 'X')?.id).toBe('X');
+  });
+
+  it('returns null for an unknown id', () => {
+    const board = createBoard('b');
+    expect(getCell(board, 'missing')).toBeNull();
+  });
+});
+
+describe('setCell', () => {
+  it('returns a new board with the updated cell', () => {
+    const board = createBoard('b', [cell('X', { occupancy: 'empty' })]);
+    const updated = setCell(board, { ...board.cells['X']!, occupancy: 'task' });
+    expect(updated.cells['X']!.occupancy).toBe('task');
+  });
+
+  it('does not mutate the original board', () => {
+    const board = createBoard('b', [cell('X')]);
+    setCell(board, { ...board.cells['X']!, occupancy: 'task' });
+    expect(board.cells['X']!.occupancy).toBe('empty');
+  });
+
+  it('adds a new cell when the id does not exist', () => {
+    const board = createBoard('b');
+    const updated = setCell(board, cell('new'));
+    expect(updated.cells['new']?.id).toBe('new');
+  });
+});
+
+// ─── canEnter ─────────────────────────────────────────────────────────────────
+
+describe('canEnter', () => {
+  it('allows entry when agent clearance meets cell clearance', () => {
+    const c = cell('A', { clearance: 'read_only' });
+    expect(canEnter(c, 'read_only')).toBe(true);
+    expect(canEnter(c, 'write')).toBe(true);
+    expect(canEnter(c, 'admin')).toBe(true);
+  });
+
+  it('denies entry when agent clearance is below cell clearance', () => {
+    const c = cell('A', { clearance: 'write' });
+    expect(canEnter(c, 'none')).toBe(false);
+    expect(canEnter(c, 'read_only')).toBe(false);
+  });
+
+  it('denies entry to a poisoned cell regardless of clearance', () => {
+    const c = cell('A', { clearance: 'none', known_state: 'poisoned' });
+    expect(canEnter(c, 'admin')).toBe(false);
+  });
+
+  it('denies entry to a blocked known_state cell', () => {
+    const c = cell('A', { clearance: 'none', known_state: 'blocked' });
+    expect(canEnter(c, 'admin')).toBe(false);
+  });
+
+  it('denies entry to a cell with blocked occupancy', () => {
+    const c = cell('A', { clearance: 'none', occupancy: 'blocked' });
+    expect(canEnter(c, 'admin')).toBe(false);
+  });
+
+  it('allows entry to a verified cell with sufficient clearance', () => {
+    const c = cell('A', { clearance: 'read_only', known_state: 'verified' });
+    expect(canEnter(c, 'read_only')).toBe(true);
+  });
+});
+
+// ─── measureTickDistance ──────────────────────────────────────────────────────
+
+describe('measureTickDistance', () => {
+  // Board:  A --(cost B=2)--> B --(cost C=1)--> C
+  //                            \--(cost D=3)--> D
+  function routeBoard(): BoardState {
+    return createBoard('route', [
+      cell('A', { cost_ticks: 0, links: ['B'] }),
+      cell('B', { cost_ticks: 2, links: ['A', 'C', 'D'] }),
+      cell('C', { cost_ticks: 1, links: ['B'] }),
+      cell('D', { cost_ticks: 3, links: ['B'] }),
+    ]);
+  }
+
+  it('returns 0 for the same cell', () => {
+    expect(measureTickDistance(routeBoard(), 'A', 'A')).toBe(0);
+  });
+
+  it('returns the cost of entering the destination', () => {
+    // A → B: cost = B.cost_ticks = 2
+    expect(measureTickDistance(routeBoard(), 'A', 'B')).toBe(2);
+  });
+
+  it('returns the sum of destination costs along the path', () => {
+    // A → B → C: B.cost + C.cost = 2 + 1 = 3
+    expect(measureTickDistance(routeBoard(), 'A', 'C')).toBe(3);
+  });
+
+  it('finds the shortest path when multiple routes exist', () => {
+    // A → B → C and A → B → D: 3 vs 5 — C is shorter
+    expect(measureTickDistance(routeBoard(), 'A', 'C')).toBeLessThan(
+      measureTickDistance(routeBoard(), 'A', 'D')!
+    );
+  });
+
+  it('returns null when cells are not connected', () => {
+    const board = createBoard('disconnected', [cell('X'), cell('Y')]);
+    expect(measureTickDistance(board, 'X', 'Y')).toBeNull();
+  });
+
+  it('returns null for an unknown cell id', () => {
+    expect(measureTickDistance(routeBoard(), 'A', 'Z')).toBeNull();
+  });
+});
+
+// ─── runBoardedChain ──────────────────────────────────────────────────────────
+
+describe('runBoardedChain', () => {
+  it('runs an unplaced chain without board interaction', async () => {
+    const board = createBoard('empty-board');
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: {},
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.ok).toBe(true);
+    expect(result.clearance_blocks).toHaveLength(0);
+    expect(result.poison_encounters).toHaveLength(0);
+    expect(result.tick_total).toBe(0); // no cells operated on
+  });
+
+  it('blocks a step when agent clearance is below cell requirement', async () => {
+    const board = createBoard('b', [cell('target', { clearance: 'write' })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: { fetch: { cell_id: 'target' } },
+      agent_clearance: 'read_only',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.ok).toBe(false);
+    expect(result.clearance_blocks).toContain('fetch');
+  });
+
+  it('allows a step when agent clearance meets the cell requirement', async () => {
+    const board = createBoard('b', [cell('target', { clearance: 'read_only', cost_ticks: 2 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: { fetch: { cell_id: 'target' }, process: {} },
+      agent_clearance: 'write',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.ok).toBe(true);
+    expect(result.clearance_blocks).toHaveLength(0);
+  });
+
+  it('blocks a step whose cell is poisoned, even with admin clearance', async () => {
+    const board = createBoard('b', [
+      cell('poison-cell', { clearance: 'none', known_state: 'poisoned' }),
+    ]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: { fetch: { cell_id: 'poison-cell' } },
+      agent_clearance: 'admin',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.ok).toBe(false);
+    expect(result.poison_encounters).toContain('fetch');
+    expect(result.clearance_blocks).toHaveLength(0);
+  });
+
+  it('marks cell as verified and artifact after successful step', async () => {
+    const board = createBoard('b', [cell('work-cell', { clearance: 'none', cost_ticks: 3 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 'single',
+        reactions: [{ id: 'step1', task_template: 'Do it' }],
+      },
+      placements: { step1: { cell_id: 'work-cell' } },
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner(true) });
+    const cell_after = getCell(result.board_state, 'work-cell')!;
+    expect(cell_after.known_state).toBe('verified');
+    expect(cell_after.occupancy).toBe('artifact');
+  });
+
+  it('resets cell occupancy to empty after failed step', async () => {
+    const board = createBoard('b', [cell('work-cell', { clearance: 'none', cost_ticks: 1 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 'single',
+        reactions: [{ id: 'step1', task_template: 'Do it' }],
+      },
+      placements: { step1: { cell_id: 'work-cell' } },
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner(false) });
+    const cell_after = getCell(result.board_state, 'work-cell')!;
+    expect(cell_after.occupancy).toBe('empty');
+  });
+
+  it('accumulates tick cost from placed steps', async () => {
+    const board = createBoard('b', [
+      cell('c1', { clearance: 'none', cost_ticks: 3 }),
+      cell('c2', { clearance: 'none', cost_ticks: 5 }),
+    ]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: {
+        fetch: { cell_id: 'c1' },
+        process: { cell_id: 'c2' },
+      },
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.tick_total).toBe(8); // 3 + 5
+    expect(result.board_state.total_cost).toBe(8);
+  });
+
+  it('uses placement.cost_ticks override instead of cell.cost_ticks', async () => {
+    const board = createBoard('b', [cell('c', { clearance: 'none', cost_ticks: 10 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 's',
+        reactions: [{ id: 'step1', task_template: 'x' }],
+      },
+      placements: { step1: { cell_id: 'c', cost_ticks: 2 } }, // override
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.tick_total).toBe(2);
+  });
+
+  it('uses placement.result_occupancy when provided', async () => {
+    const board = createBoard('b', [cell('c', { clearance: 'none', cost_ticks: 1 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 's',
+        reactions: [{ id: 'step1', task_template: 'x' }],
+      },
+      placements: { step1: { cell_id: 'c', result_occupancy: 'agent' } },
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner(true) });
+    expect(getCell(result.board_state, 'c')!.occupancy).toBe('agent');
+  });
+
+  it('transitions unknown cell to observed during step, then verified on success', async () => {
+    const board = createBoard('b', [cell('c', { clearance: 'none', known_state: 'unknown' })]);
+    let stateAfterStart: import('../src/board-fields.js').BoardKnownState | null = null;
+
+    const runner = async (event: import('../src/index.js').AgentBusEvent) => {
+      // We can't easily inspect mid-step; just verify post-step is 'verified'
+      void event;
+      return { ok: true, result: null };
+    };
+
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 's',
+        reactions: [{ id: 'step1', task_template: 'x' }],
+      },
+      placements: { step1: { cell_id: 'c' } },
+      agent_clearance: 'none',
+    };
+
+    const result = await runBoardedChain(bc, board, { runEvent: runner });
+    stateAfterStart = getCell(result.board_state, 'c')!.known_state;
+    expect(stateAfterStart).toBe('verified');
+  });
+
+  it('carries chain_id and run_id through to the result', async () => {
+    const board = createBoard('b');
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: {},
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.chain_id).toBe('two-step');
+    expect(typeof result.chain_result.run_id).toBe('string');
+  });
+
+  it('respects requires_clearance override on placement', async () => {
+    // Cell requires 'none' but placement overrides to 'write'
+    const board = createBoard('b', [cell('c', { clearance: 'none' })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 's',
+        reactions: [{ id: 'step1', task_template: 'x' }],
+      },
+      placements: { step1: { cell_id: 'c', requires_clearance: 'write' } },
+      agent_clearance: 'read_only',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.clearance_blocks).toContain('step1');
+  });
+
+  it('uses schema_version scbe_boarded_chain_run_v1', async () => {
+    const board = createBoard('b');
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: {},
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.schema_version).toBe('scbe_boarded_chain_run_v1');
+  });
+});

--- a/packages/agent-bus/tests/reaction-chain.test.ts
+++ b/packages/agent-bus/tests/reaction-chain.test.ts
@@ -1,0 +1,453 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type ReactionChain,
+  type ReactionChainState,
+  startChain,
+  getReadyReactions,
+  advanceChain,
+  renderTask,
+  buildReactionEvent,
+  runReactionChain,
+} from '../src/reaction-chain.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function linearChain(): ReactionChain {
+  return {
+    schema_version: 'scbe_reaction_chain_v1',
+    chain_id: 'linear',
+    reactions: [
+      { id: 'A', task_template: 'Do A' },
+      { id: 'B', task_template: 'Do B', depends_on: ['A'] },
+    ],
+  };
+}
+
+function parallelChain(): ReactionChain {
+  return {
+    schema_version: 'scbe_reaction_chain_v1',
+    chain_id: 'parallel',
+    reactions: [
+      { id: 'A', task_template: 'Do A' },
+      { id: 'B', task_template: 'Do B' },
+      { id: 'C', task_template: 'Do C', depends_on: ['A', 'B'] },
+    ],
+  };
+}
+
+function mockRunner(ok = true): import('../src/reaction-chain.js').ReactionRunnerFn {
+  return async (_event) => ({ ok, result: { fired: _event.task } });
+}
+
+// ─── startChain ───────────────────────────────────────────────────────────────
+
+describe('startChain', () => {
+  it('initializes all steps as pending', () => {
+    const { state } = startChain(linearChain());
+    expect(state.steps['A']!.status).toBe('pending');
+    expect(state.steps['B']!.status).toBe('pending');
+  });
+
+  it('sets status to running for non-empty chain', () => {
+    const { state } = startChain(linearChain());
+    expect(state.status).toBe('running');
+  });
+
+  it('sets status to complete for empty chain', () => {
+    const empty: ReactionChain = {
+      schema_version: 'scbe_reaction_chain_v1',
+      chain_id: 'empty',
+      reactions: [],
+    };
+    const { state, ready } = startChain(empty);
+    expect(state.status).toBe('complete');
+    expect(ready).toHaveLength(0);
+  });
+
+  it('returns only dep-free reactions as ready', () => {
+    const { ready } = startChain(linearChain());
+    expect(ready).toEqual(['A']);
+  });
+
+  it('returns all dep-free reactions when multiple have no deps', () => {
+    const { ready } = startChain(parallelChain());
+    expect(ready).toContain('A');
+    expect(ready).toContain('B');
+    expect(ready).not.toContain('C');
+  });
+
+  it('assigns a unique run_id each call', () => {
+    const { state: s1 } = startChain(linearChain());
+    const { state: s2 } = startChain(linearChain());
+    expect(s1.run_id).not.toBe(s2.run_id);
+  });
+
+  it('carries the chain_id into state', () => {
+    const { state } = startChain(linearChain());
+    expect(state.chain_id).toBe('linear');
+  });
+});
+
+// ─── getReadyReactions ────────────────────────────────────────────────────────
+
+describe('getReadyReactions', () => {
+  it('returns step once its dep is done', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const withADone: ReactionChainState = {
+      ...state,
+      steps: { ...state.steps, A: { id: 'A', status: 'done' } },
+    };
+    expect(getReadyReactions(withADone, chain)).toEqual(['B']);
+  });
+
+  it('does not return a running step', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const withARunning: ReactionChainState = {
+      ...state,
+      steps: { ...state.steps, A: { id: 'A', status: 'running' } },
+    };
+    expect(getReadyReactions(withARunning, chain)).toEqual([]);
+  });
+
+  it('does not return a step with an unmet dep', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    expect(getReadyReactions(state, chain)).not.toContain('B');
+  });
+
+  it('returns a step only when ALL deps are done', () => {
+    const chain = parallelChain();
+    const { state } = startChain(chain);
+    const withADone: ReactionChainState = {
+      ...state,
+      steps: { ...state.steps, A: { id: 'A', status: 'done' } },
+    };
+    // C needs both A and B — B is still pending, so C is not ready
+    expect(getReadyReactions(withADone, chain)).not.toContain('C');
+  });
+});
+
+// ─── advanceChain ─────────────────────────────────────────────────────────────
+
+describe('advanceChain', () => {
+  it('marks a successful step as done', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { state: next } = advanceChain(state, chain, 'A', 'output', true);
+    expect(next.steps['A']!.status).toBe('done');
+    expect(next.steps['A']!.result).toBe('output');
+  });
+
+  it('returns newly ready steps after success', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { newly_ready } = advanceChain(state, chain, 'A', null, true);
+    expect(newly_ready).toEqual(['B']);
+  });
+
+  it('marks a failed step as blocked', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { state: next } = advanceChain(state, chain, 'A', null, false);
+    expect(next.steps['A']!.status).toBe('blocked');
+  });
+
+  it('returns no newly_ready steps when a step fails', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { newly_ready } = advanceChain(state, chain, 'A', null, false);
+    expect(newly_ready).toHaveLength(0);
+  });
+
+  it('sets chain status to complete when all steps are done', () => {
+    const chain = linearChain();
+    const { state: s0 } = startChain(chain);
+    const { state: s1 } = advanceChain(s0, chain, 'A', null, true);
+    const { state: s2, done } = advanceChain(s1, chain, 'B', null, true);
+    expect(s2.status).toBe('complete');
+    expect(done).toBe(true);
+  });
+
+  it('sets chain status to blocked when a failure makes no steps reachable', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    // A fails → B depends on A → nothing reachable
+    const { state: next } = advanceChain(state, chain, 'A', null, false);
+    expect(next.status).toBe('blocked');
+  });
+
+  it('does NOT set blocked if other independent steps are still reachable', () => {
+    // Chain: A (no deps), B (no deps), C (depends_on: [A, B])
+    // A fails but B is still pending (no dep on A)
+    const chain = parallelChain();
+    const { state } = startChain(chain);
+    const { state: next } = advanceChain(state, chain, 'A', null, false);
+    // B is still pending and reachable → chain should still be 'running'
+    expect(next.status).toBe('running');
+  });
+
+  it('sets chain to blocked when all remaining steps transitively depend on a blocked step', () => {
+    // Parallel chain: A fails, then B succeeds, C depends on [A, B] so C can never run
+    const chain = parallelChain();
+    const { state: s0 } = startChain(chain);
+    const { state: s1 } = advanceChain(s0, chain, 'A', null, false); // A blocked
+    const { state: s2 } = advanceChain(s1, chain, 'B', null, true); // B done
+    // C depends on A (blocked) and B (done) — C is permanently unreachable
+    expect(s2.status).toBe('blocked');
+  });
+
+  it('attaches finished_at to the completed step', () => {
+    const chain = linearChain();
+    const { state } = startChain(chain);
+    const { state: next } = advanceChain(state, chain, 'A', null, true);
+    expect(typeof next.steps['A']!.finished_at).toBe('string');
+  });
+});
+
+// ─── renderTask ───────────────────────────────────────────────────────────────
+
+describe('renderTask', () => {
+  function stateWithDoneStep(id: string, result: unknown): ReactionChainState {
+    return {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'r1',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: { [id]: { id, status: 'done', result } },
+    };
+  }
+
+  it('replaces ${step.<id>.result} with string values', () => {
+    const state = stateWithDoneStep('fetch', 'some content');
+    expect(renderTask('Process: ${step.fetch.result}', state)).toBe('Process: some content');
+  });
+
+  it('JSON-serializes non-string result values', () => {
+    const state = stateWithDoneStep('fetch', { data: [1, 2] });
+    expect(renderTask('Got: ${step.fetch.result}', state)).toBe('Got: {"data":[1,2]}');
+  });
+
+  it('replaces ${step.<id>.status}', () => {
+    const state = stateWithDoneStep('step1', null);
+    expect(renderTask('Status: ${step.step1.status}', state)).toBe('Status: done');
+  });
+
+  it('replaces ${step.<id>.ok} with true when step is done', () => {
+    const state = stateWithDoneStep('step1', null);
+    expect(renderTask('${step.step1.ok}', state)).toBe('true');
+  });
+
+  it('replaces ${step.<id>.ok} with false for non-done status', () => {
+    const state: ReactionChainState = {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'r1',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: { s: { id: 's', status: 'blocked' } },
+    };
+    expect(renderTask('${step.s.ok}', state)).toBe('false');
+  });
+
+  it('leaves unknown step references unchanged', () => {
+    const state: ReactionChainState = {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'r1',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: {},
+    };
+    const template = 'Missing: ${step.unknown.result}';
+    expect(renderTask(template, state)).toBe(template);
+  });
+
+  it('handles multiple references in one template', () => {
+    const state: ReactionChainState = {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'r1',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: {
+        a: { id: 'a', status: 'done', result: 'hello' },
+        b: { id: 'b', status: 'done', result: 'world' },
+      },
+    };
+    expect(renderTask('${step.a.result} ${step.b.result}', state)).toBe('hello world');
+  });
+});
+
+// ─── buildReactionEvent ───────────────────────────────────────────────────────
+
+describe('buildReactionEvent', () => {
+  function emptyRunState(): ReactionChainState {
+    return {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'run-abc',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: {},
+    };
+  }
+
+  it('sets task from rendered task_template', () => {
+    const event = buildReactionEvent(
+      { id: 'step1', task_template: 'Do the thing' },
+      emptyRunState(),
+      'run-abc'
+    );
+    expect(event.task).toBe('Do the thing');
+  });
+
+  it('encodes seriesId as chainRunId-reactionId', () => {
+    const event = buildReactionEvent(
+      { id: 'step1', task_template: 'x' },
+      emptyRunState(),
+      'run-abc'
+    );
+    expect(event.seriesId).toBe('run-abc-step1');
+  });
+
+  it('maps model_tier local to ollama dispatchProvider', () => {
+    const event = buildReactionEvent(
+      { id: 's', task_template: 'x', model_tier: 'local' },
+      emptyRunState(),
+      'r'
+    );
+    expect(event.dispatchProvider).toBe('ollama');
+  });
+
+  it('maps model_tier free to cerebras dispatchProvider', () => {
+    const event = buildReactionEvent(
+      { id: 's', task_template: 'x', model_tier: 'free' },
+      emptyRunState(),
+      'r'
+    );
+    expect(event.dispatchProvider).toBe('cerebras');
+  });
+
+  it('maps model_tier paid to anthropic dispatchProvider', () => {
+    const event = buildReactionEvent(
+      { id: 's', task_template: 'x', model_tier: 'paid' },
+      emptyRunState(),
+      'r'
+    );
+    expect(event.dispatchProvider).toBe('anthropic');
+  });
+
+  it('omits dispatchProvider when model_tier is not set', () => {
+    const event = buildReactionEvent({ id: 's', task_template: 'x' }, emptyRunState(), 'r');
+    expect(event.dispatchProvider).toBeUndefined();
+  });
+
+  it('NEVER interpolates operation_command (security invariant)', () => {
+    const state: ReactionChainState = {
+      schema_version: 'scbe_reaction_chain_state_v1',
+      chain_id: 'test',
+      run_id: 'run-abc',
+      started_at: new Date().toISOString(),
+      status: 'running',
+      steps: { prior: { id: 'prior', status: 'done', result: 'injected-value' } },
+    };
+    const event = buildReactionEvent(
+      {
+        id: 'step1',
+        task_template: 'Use ${step.prior.result}',
+        operation_command: 'node ${step.prior.result}',
+      },
+      state,
+      'run-abc'
+    );
+    // task IS interpolated (NL context)
+    expect(event.task).toBe('Use injected-value');
+    // operationCommand is NEVER interpolated
+    expect(event.operationCommand).toBe('node ${step.prior.result}');
+  });
+});
+
+// ─── runReactionChain ─────────────────────────────────────────────────────────
+
+describe('runReactionChain', () => {
+  it('runs a linear chain to completion', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner() });
+    expect(result.ok).toBe(true);
+    expect(result.state.status).toBe('complete');
+    expect(result.steps_completed).toBe(2);
+    expect(result.steps_blocked).toBe(0);
+  });
+
+  it('returns correct schema_version', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner() });
+    expect(result.schema_version).toBe('scbe_reaction_chain_run_v1');
+  });
+
+  it('stops when first step fails and marks chain blocked', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner(false) });
+    expect(result.ok).toBe(false);
+    expect(result.state.status).toBe('blocked');
+    expect(result.steps_completed).toBe(0);
+    expect(result.steps_blocked).toBe(1);
+  });
+
+  it('runs parallel reactions then the join step', async () => {
+    const fired: string[] = [];
+    const runner = async (event: import('../src/index.js').AgentBusEvent) => {
+      fired.push(event.seriesId ?? '');
+      return { ok: true, result: null };
+    };
+    const result = await runReactionChain(parallelChain(), { runEvent: runner });
+    expect(result.ok).toBe(true);
+    expect(result.steps_completed).toBe(3);
+    // A and B fire before C
+    const cIdx = fired.findIndex((s) => s.endsWith('-C'));
+    const aIdx = fired.findIndex((s) => s.endsWith('-A'));
+    const bIdx = fired.findIndex((s) => s.endsWith('-B'));
+    expect(cIdx).toBeGreaterThan(aIdx);
+    expect(cIdx).toBeGreaterThan(bIdx);
+  });
+
+  it('completes an empty chain immediately', async () => {
+    const empty: ReactionChain = {
+      schema_version: 'scbe_reaction_chain_v1',
+      chain_id: 'empty',
+      reactions: [],
+    };
+    const result = await runReactionChain(empty);
+    expect(result.ok).toBe(true);
+    expect(result.state.status).toBe('complete');
+    expect(result.steps_completed).toBe(0);
+  });
+
+  it('passes prior step results forward via task_template interpolation', async () => {
+    const received: string[] = [];
+    const runner = async (event: import('../src/index.js').AgentBusEvent) => {
+      received.push(event.task);
+      return { ok: true, result: 'step-output' };
+    };
+    const chain: ReactionChain = {
+      schema_version: 'scbe_reaction_chain_v1',
+      chain_id: 'passthrough',
+      reactions: [
+        { id: 'fetch', task_template: 'Fetch the data' },
+        { id: 'process', task_template: 'Process: ${step.fetch.result}', depends_on: ['fetch'] },
+      ],
+    };
+    await runReactionChain(chain, { runEvent: runner });
+    expect(received[1]).toBe('Process: step-output');
+  });
+
+  it('marks the run_id consistently between state and result', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner() });
+    expect(result.run_id).toBe(result.state.run_id);
+  });
+
+  it('carries the chain_id into the result', async () => {
+    const result = await runReactionChain(linearChain(), { runEvent: mockRunner() });
+    expect(result.chain_id).toBe('linear');
+  });
+});


### PR DESCRIPTION
## Summary
- adds BoardFields, a multi-domain board-state layer for ReactionChain workflows
- models domains for surface, air, sea, subground, space, personal, and shared squad state
- enforces clearance and poisoned-cell blocking before inner event execution
- tracks tick cost, fog-of-war state transitions, and verified artifact occupancy

## Why
This is the clean extraction of the agentic board idea on top of the merged ReactionChain engine. It keeps the useful executable code separate from the conflicted/policy-heavy #1965 branch.

## Tests
- `npm test -- --run tests/board-fields.test.ts tests/reaction-chain.test.ts` -> 74 passed
- `npm run build` -> pass
- `npm test` -> 334 passed
- `npm run format:check` -> pass
- `npm audit --audit-level=moderate` -> 0 vulnerabilities

## Rollback
Revert this PR; it only adds `board-fields.ts`, exports it from agent-bus, and adds tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a board governance layer for workflow execution management with clearance-based access control, occupancy tracking, and cost/tick accounting to prevent unauthorized or resource-intensive operations.
  * Added a reaction chain workflow engine supporting dependency-based task orchestration with automatic step sequencing, template rendering for dynamic task generation, and flexible event-based execution patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->