### PR TITLE
feat(agent-bus): add BoardFields agentic board layer

### DIFF
--- a/packages/agent-bus/src/board-fields.ts
+++ b/packages/agent-bus/src/board-fields.ts
@@ -1,0 +1,334 @@
+/**
+ * @file board-fields.ts
+ * @module agent-bus/board-fields
+ * @layer Cross-layer agentic board state
+ * @component BoardFields — multi-domain governed map for agentic workflows
+ *
+ * Wraps a ReactionChain with a spatial/epistemic board so each step has a
+ * declared domain, clearance requirement, tick cost, and known_state.
+ *
+ * Domains model the layers where work happens:
+ *   surface    — files, tasks, docs, UI (everyday read/write)
+ *   air        — model calls, summaries, fast routing
+ *   sea        — long-running workflows, queues, pipelines
+ *   subground  — secrets, provenance, dependency roots, poisoned inputs
+ *   space      — high-level goals, mission state, global strategy
+ *   personal   — each agent's private Polly Pad state
+ *   shared     — squad board, leader state, shared memory
+ *
+ * Security invariant: cells tagged 'poisoned' are never entered — they block
+ * the step immediately without calling the inner runner. This is the board-level
+ * quarantine before the 14-layer promotion pipeline sees the content.
+ *
+ * Clearance levels form a total order: none < read_only < write < execute < admin.
+ * An agent can only enter a cell if its clearance >= cell.clearance.
+ *
+ * Tick cost accumulates across the run and provides a cheap budget signal.
+ * The board state is serializable — checkpoint it between runs.
+ */
+
+import type { AgentBusEvent } from './index.js';
+import { enqueueEvent, processOneEvent, getEventStatus } from './queue.js';
+import type {
+  ReactionChain,
+  ReactionRunnerFn,
+  ReactionChainRunOptions,
+  ReactionChainRunResult,
+} from './reaction-chain.js';
+import { runReactionChain } from './reaction-chain.js';
+
+// ─── Core board types ─────────────────────────────────────────────────────────
+
+export type BoardDomain = 'surface' | 'air' | 'sea' | 'subground' | 'space' | 'personal' | 'shared';
+
+export type BoardOccupancy = 'empty' | 'agent' | 'task' | 'artifact' | 'blocked';
+
+/**
+ * Epistemic state of a cell from the agent's perspective.
+ *
+ * unknown   — never observed; contents are fog-of-war
+ * observed  — a step is or was operating here; data not yet verified
+ * verified  — a step completed successfully; output passed governance
+ * poisoned  — malicious or tainted content detected; entry permanently blocked
+ * blocked   — structurally inaccessible (topology constraint, not data quality)
+ */
+export type BoardKnownState = 'unknown' | 'observed' | 'verified' | 'poisoned' | 'blocked';
+
+/**
+ * Ordered clearance levels. Higher index = higher privilege.
+ * An agent with clearance C can enter any cell requiring C or lower.
+ */
+export type ClearanceLevel = 'none' | 'read_only' | 'write' | 'execute' | 'admin';
+
+const CLEARANCE_RANK: Record<ClearanceLevel, number> = {
+  none: 0,
+  read_only: 1,
+  write: 2,
+  execute: 3,
+  admin: 4,
+};
+
+export interface BoardCell {
+  id: string;
+  domain: BoardDomain;
+  occupancy: BoardOccupancy;
+  /** Minimum clearance required to enter this cell. */
+  clearance: ClearanceLevel;
+  /** Tick cost to operate here. Adds to the run's total_cost. */
+  cost_ticks: number;
+  /** Risk tags (e.g. 'tainted_source', 'unverified', 'external_input'). */
+  risk: string[];
+  known_state: BoardKnownState;
+  /** IDs of cells this cell is linked to (bidirectional traversal not implied). */
+  links: string[];
+}
+
+export interface BoardState {
+  schema_version: 'scbe_board_state_v1';
+  board_id: string;
+  cells: Record<string, BoardCell>;
+  /** Current board clock tick. Advances by each step's cost_ticks. */
+  tick: number;
+  /** Cumulative tick cost across all steps run on this board. */
+  total_cost: number;
+}
+
+// ─── Pure board operations ────────────────────────────────────────────────────
+
+export function createBoard(board_id: string, cells: BoardCell[] = []): BoardState {
+  const cellMap: Record<string, BoardCell> = {};
+  for (const c of cells) {
+    cellMap[c.id] = c;
+  }
+  return {
+    schema_version: 'scbe_board_state_v1',
+    board_id,
+    cells: cellMap,
+    tick: 0,
+    total_cost: 0,
+  };
+}
+
+export function getCell(state: BoardState, cellId: string): BoardCell | null {
+  return state.cells[cellId] ?? null;
+}
+
+/** Immutable cell update — returns a new BoardState. */
+export function setCell(state: BoardState, cell: BoardCell): BoardState {
+  return { ...state, cells: { ...state.cells, [cell.id]: cell } };
+}
+
+/** True if an agent with the given clearance is permitted to enter the cell. */
+export function canEnter(cell: BoardCell, agentClearance: ClearanceLevel): boolean {
+  if (cell.known_state === 'poisoned' || cell.known_state === 'blocked') return false;
+  if (cell.occupancy === 'blocked') return false;
+  return CLEARANCE_RANK[agentClearance] >= CLEARANCE_RANK[cell.clearance];
+}
+
+/**
+ * Minimum tick-distance between two cells via Dijkstra over the links graph.
+ * Edge weight = destination cell's cost_ticks.
+ * Returns null if toId is not reachable from fromId.
+ */
+export function measureTickDistance(
+  state: BoardState,
+  fromId: string,
+  toId: string
+): number | null {
+  if (fromId === toId) return 0;
+  const dist: Record<string, number> = { [fromId]: 0 };
+  const visited = new Set<string>();
+  // [cellId, accumulated_cost]
+  const queue: Array<[string, number]> = [[fromId, 0]];
+
+  while (queue.length > 0) {
+    queue.sort((a, b) => a[1] - b[1]);
+    const [current, cost] = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    if (current === toId) return cost;
+
+    const cell = state.cells[current];
+    if (!cell) continue;
+
+    for (const linkId of cell.links) {
+      if (visited.has(linkId)) continue;
+      const linkCell = state.cells[linkId];
+      if (!linkCell) continue;
+      const newCost = cost + linkCell.cost_ticks;
+      if (newCost < (dist[linkId] ?? Infinity)) {
+        dist[linkId] = newCost;
+        queue.push([linkId, newCost]);
+      }
+    }
+  }
+  return null;
+}
+
+// ─── Boarded chain integration ────────────────────────────────────────────────
+
+/**
+ * Board-placement metadata for one reaction step.
+ * Steps without a placement entry run with no board constraints.
+ */
+export interface BoardPlacement {
+  /** Cell this reaction operates on. */
+  cell_id?: string;
+  /** Required clearance. Defaults to cell.clearance if omitted. */
+  requires_clearance?: ClearanceLevel;
+  /** Override tick cost. Defaults to cell.cost_ticks if omitted. */
+  cost_ticks?: number;
+  /** Risk tags this step may produce (informational; stored on the result). */
+  risk?: string[];
+  /** Cell occupancy to set after a successful step. Default: 'artifact'. */
+  result_occupancy?: BoardOccupancy;
+}
+
+/** A ReactionChain decorated with per-step board placements. */
+export interface BoardedChain {
+  schema_version: 'scbe_boarded_chain_v1';
+  chain: ReactionChain;
+  /** Keyed by reaction spec id. Steps with no entry run without board constraints. */
+  placements: Record<string, BoardPlacement>;
+  /** Clearance level of the agent running this chain. Default: 'none'. */
+  agent_clearance?: ClearanceLevel;
+}
+
+export interface BoardedChainRunResult {
+  schema_version: 'scbe_boarded_chain_run_v1';
+  board_state: BoardState;
+  chain_result: ReactionChainRunResult;
+  tick_total: number;
+  /** Reaction IDs that were blocked by insufficient clearance. */
+  clearance_blocks: string[];
+  /** Reaction IDs that were blocked because their target cell was poisoned. */
+  poison_encounters: string[];
+}
+
+// Duplicated from reaction-chain.ts to avoid a circular import through the re-export in index.ts
+function makeQueueRunner(options: ReactionChainRunOptions): ReactionRunnerFn {
+  return async (event: AgentBusEvent) => {
+    const runId = enqueueEvent(event, options);
+    await processOneEvent();
+    const queued = getEventStatus(runId);
+    return { ok: queued?.result?.ok ?? false, result: queued?.result?.result ?? null };
+  };
+}
+
+/**
+ * Extract the reaction ID from a seriesId produced by buildReactionEvent.
+ * Format: "${12-hex-runId}-${reactionId}" — the runId is pure hex so the
+ * first '-' is always the separator, even if reactionId contains dashes.
+ */
+function extractReactionId(event: AgentBusEvent): string | null {
+  const sid = event.seriesId;
+  if (!sid) return null;
+  const idx = sid.indexOf('-');
+  return idx === -1 ? null : sid.slice(idx + 1);
+}
+
+function meetsClearance(agent: ClearanceLevel, required: ClearanceLevel): boolean {
+  return CLEARANCE_RANK[agent] >= CLEARANCE_RANK[required];
+}
+
+/**
+ * Run a ReactionChain with board-field governance.
+ *
+ * Before each step with a cell_id placement:
+ *   1. Block immediately if the cell is poisoned (poison_encounters logged).
+ *   2. Block immediately if agent clearance < required clearance (clearance_blocks logged).
+ *   3. Mark cell occupancy='task', known_state='observed' (if unknown).
+ *
+ * After each step completes:
+ *   - ok=true  → cell occupancy set to result_occupancy (default 'artifact'), known_state='verified'
+ *   - ok=false → cell occupancy reset to 'empty', known_state unchanged
+ *   - Board tick advances by step's cost_ticks.
+ *
+ * Steps with no placement entry are passed through to the inner runner unchanged.
+ */
+export async function runBoardedChain(
+  boardedChain: BoardedChain,
+  boardState: BoardState,
+  options: ReactionChainRunOptions = {}
+): Promise<BoardedChainRunResult> {
+  let board = boardState;
+  const clearance_blocks: string[] = [];
+  const poison_encounters: string[] = [];
+  const agentClearance: ClearanceLevel = boardedChain.agent_clearance ?? 'none';
+  const baseRunner: ReactionRunnerFn = options.runEvent ?? makeQueueRunner(options);
+
+  const boardRunner: ReactionRunnerFn = async (event: AgentBusEvent) => {
+    const reactionId = extractReactionId(event);
+    const placement = reactionId != null ? boardedChain.placements[reactionId] : undefined;
+
+    if (placement?.cell_id) {
+      const cell = getCell(board, placement.cell_id);
+      if (cell) {
+        // Poison blocks before clearance — even admins cannot enter poisoned cells
+        if (cell.known_state === 'poisoned') {
+          if (reactionId != null) poison_encounters.push(reactionId);
+          return {
+            ok: false,
+            result: { blocked: true, reason: 'poisoned_cell', cell_id: placement.cell_id },
+          };
+        }
+
+        const requiredClearance = placement.requires_clearance ?? cell.clearance;
+        if (!meetsClearance(agentClearance, requiredClearance)) {
+          if (reactionId != null) clearance_blocks.push(reactionId);
+          return {
+            ok: false,
+            result: {
+              blocked: true,
+              reason: 'clearance_denied',
+              cell_id: placement.cell_id,
+              required: requiredClearance,
+              agent: agentClearance,
+            },
+          };
+        }
+
+        // Mark cell as being operated on
+        board = setCell(board, {
+          ...cell,
+          occupancy: 'task',
+          known_state: cell.known_state === 'unknown' ? 'observed' : cell.known_state,
+        });
+      }
+    }
+
+    const stepResult = await baseRunner(event);
+
+    if (placement?.cell_id) {
+      const cell = getCell(board, placement.cell_id);
+      if (cell) {
+        const costTicks = placement.cost_ticks ?? cell.cost_ticks;
+        board = {
+          ...setCell(board, {
+            ...cell,
+            occupancy: stepResult.ok ? (placement.result_occupancy ?? 'artifact') : 'empty',
+            known_state: stepResult.ok ? 'verified' : cell.known_state,
+          }),
+          tick: board.tick + costTicks,
+          total_cost: board.total_cost + costTicks,
+        };
+      }
+    }
+
+    return stepResult;
+  };
+
+  const chain_result = await runReactionChain(boardedChain.chain, {
+    ...options,
+    runEvent: boardRunner,
+  });
+
+  return {
+    schema_version: 'scbe_boarded_chain_run_v1',
+    board_state: board,
+    chain_result,
+    tick_total: board.tick,
+    clearance_blocks,
+    poison_encounters,
+  };
+}

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1960,6 +1960,24 @@ export async function runAgentBusTerminalUi(options: AgentBusClientOptions = {})
 }
 
 export {
+  type BoardDomain,
+  type BoardOccupancy,
+  type BoardKnownState,
+  type ClearanceLevel,
+  type BoardCell,
+  type BoardState,
+  type BoardPlacement,
+  type BoardedChain,
+  type BoardedChainRunResult,
+  createBoard,
+  getCell,
+  setCell,
+  canEnter,
+  measureTickDistance,
+  runBoardedChain,
+} from './board-fields.js';
+
+export {
   type ReactionSpec,
   type ReactionChain,
   type ReactionStepStatus,

--- a/packages/agent-bus/tests/board-fields.test.ts
+++ b/packages/agent-bus/tests/board-fields.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type BoardCell,
+  type BoardState,
+  type BoardedChain,
+  type ClearanceLevel,
+  createBoard,
+  getCell,
+  setCell,
+  canEnter,
+  measureTickDistance,
+  runBoardedChain,
+} from '../src/board-fields.js';
+import type { ReactionChain } from '../src/reaction-chain.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function cell(id: string, overrides: Partial<BoardCell> = {}): BoardCell {
+  return {
+    id,
+    domain: 'surface',
+    occupancy: 'empty',
+    clearance: 'none',
+    cost_ticks: 1,
+    risk: [],
+    known_state: 'unknown',
+    links: [],
+    ...overrides,
+  };
+}
+
+function twoStepChain(): ReactionChain {
+  return {
+    schema_version: 'scbe_reaction_chain_v1',
+    chain_id: 'two-step',
+    reactions: [
+      { id: 'fetch', task_template: 'Fetch the data' },
+      { id: 'process', task_template: 'Process: ${step.fetch.result}', depends_on: ['fetch'] },
+    ],
+  };
+}
+
+function mockRunner(ok = true) {
+  return async (_event: import('../src/index.js').AgentBusEvent) => ({
+    ok,
+    result: { output: 'done' },
+  });
+}
+
+// ─── createBoard ──────────────────────────────────────────────────────────────
+
+describe('createBoard', () => {
+  it('creates a board with an empty cell map', () => {
+    const board = createBoard('test');
+    expect(board.schema_version).toBe('scbe_board_state_v1');
+    expect(board.board_id).toBe('test');
+    expect(Object.keys(board.cells)).toHaveLength(0);
+    expect(board.tick).toBe(0);
+    expect(board.total_cost).toBe(0);
+  });
+
+  it('indexes provided cells by id', () => {
+    const board = createBoard('b', [cell('A'), cell('B')]);
+    expect(board.cells['A']?.id).toBe('A');
+    expect(board.cells['B']?.id).toBe('B');
+  });
+});
+
+// ─── getCell / setCell ────────────────────────────────────────────────────────
+
+describe('getCell', () => {
+  it('returns the cell for a known id', () => {
+    const board = createBoard('b', [cell('X')]);
+    expect(getCell(board, 'X')?.id).toBe('X');
+  });
+
+  it('returns null for an unknown id', () => {
+    const board = createBoard('b');
+    expect(getCell(board, 'missing')).toBeNull();
+  });
+});
+
+describe('setCell', () => {
+  it('returns a new board with the updated cell', () => {
+    const board = createBoard('b', [cell('X', { occupancy: 'empty' })]);
+    const updated = setCell(board, { ...board.cells['X']!, occupancy: 'task' });
+    expect(updated.cells['X']!.occupancy).toBe('task');
+  });
+
+  it('does not mutate the original board', () => {
+    const board = createBoard('b', [cell('X')]);
+    setCell(board, { ...board.cells['X']!, occupancy: 'task' });
+    expect(board.cells['X']!.occupancy).toBe('empty');
+  });
+
+  it('adds a new cell when the id does not exist', () => {
+    const board = createBoard('b');
+    const updated = setCell(board, cell('new'));
+    expect(updated.cells['new']?.id).toBe('new');
+  });
+});
+
+// ─── canEnter ─────────────────────────────────────────────────────────────────
+
+describe('canEnter', () => {
+  it('allows entry when agent clearance meets cell clearance', () => {
+    const c = cell('A', { clearance: 'read_only' });
+    expect(canEnter(c, 'read_only')).toBe(true);
+    expect(canEnter(c, 'write')).toBe(true);
+    expect(canEnter(c, 'admin')).toBe(true);
+  });
+
+  it('denies entry when agent clearance is below cell clearance', () => {
+    const c = cell('A', { clearance: 'write' });
+    expect(canEnter(c, 'none')).toBe(false);
+    expect(canEnter(c, 'read_only')).toBe(false);
+  });
+
+  it('denies entry to a poisoned cell regardless of clearance', () => {
+    const c = cell('A', { clearance: 'none', known_state: 'poisoned' });
+    expect(canEnter(c, 'admin')).toBe(false);
+  });
+
+  it('denies entry to a blocked known_state cell', () => {
+    const c = cell('A', { clearance: 'none', known_state: 'blocked' });
+    expect(canEnter(c, 'admin')).toBe(false);
+  });
+
+  it('denies entry to a cell with blocked occupancy', () => {
+    const c = cell('A', { clearance: 'none', occupancy: 'blocked' });
+    expect(canEnter(c, 'admin')).toBe(false);
+  });
+
+  it('allows entry to a verified cell with sufficient clearance', () => {
+    const c = cell('A', { clearance: 'read_only', known_state: 'verified' });
+    expect(canEnter(c, 'read_only')).toBe(true);
+  });
+});
+
+// ─── measureTickDistance ──────────────────────────────────────────────────────
+
+describe('measureTickDistance', () => {
+  // Board:  A --(cost B=2)--> B --(cost C=1)--> C
+  //                            \--(cost D=3)--> D
+  function routeBoard(): BoardState {
+    return createBoard('route', [
+      cell('A', { cost_ticks: 0, links: ['B'] }),
+      cell('B', { cost_ticks: 2, links: ['A', 'C', 'D'] }),
+      cell('C', { cost_ticks: 1, links: ['B'] }),
+      cell('D', { cost_ticks: 3, links: ['B'] }),
+    ]);
+  }
+
+  it('returns 0 for the same cell', () => {
+    expect(measureTickDistance(routeBoard(), 'A', 'A')).toBe(0);
+  });
+
+  it('returns the cost of entering the destination', () => {
+    // A → B: cost = B.cost_ticks = 2
+    expect(measureTickDistance(routeBoard(), 'A', 'B')).toBe(2);
+  });
+
+  it('returns the sum of destination costs along the path', () => {
+    // A → B → C: B.cost + C.cost = 2 + 1 = 3
+    expect(measureTickDistance(routeBoard(), 'A', 'C')).toBe(3);
+  });
+
+  it('finds the shortest path when multiple routes exist', () => {
+    // A → B → C and A → B → D: 3 vs 5 — C is shorter
+    expect(measureTickDistance(routeBoard(), 'A', 'C')).toBeLessThan(
+      measureTickDistance(routeBoard(), 'A', 'D')!
+    );
+  });
+
+  it('returns null when cells are not connected', () => {
+    const board = createBoard('disconnected', [cell('X'), cell('Y')]);
+    expect(measureTickDistance(board, 'X', 'Y')).toBeNull();
+  });
+
+  it('returns null for an unknown cell id', () => {
+    expect(measureTickDistance(routeBoard(), 'A', 'Z')).toBeNull();
+  });
+});
+
+// ─── runBoardedChain ──────────────────────────────────────────────────────────
+
+describe('runBoardedChain', () => {
+  it('runs an unplaced chain without board interaction', async () => {
+    const board = createBoard('empty-board');
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: {},
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.ok).toBe(true);
+    expect(result.clearance_blocks).toHaveLength(0);
+    expect(result.poison_encounters).toHaveLength(0);
+    expect(result.tick_total).toBe(0); // no cells operated on
+  });
+
+  it('blocks a step when agent clearance is below cell requirement', async () => {
+    const board = createBoard('b', [cell('target', { clearance: 'write' })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: { fetch: { cell_id: 'target' } },
+      agent_clearance: 'read_only',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.ok).toBe(false);
+    expect(result.clearance_blocks).toContain('fetch');
+  });
+
+  it('allows a step when agent clearance meets the cell requirement', async () => {
+    const board = createBoard('b', [cell('target', { clearance: 'read_only', cost_ticks: 2 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: { fetch: { cell_id: 'target' }, process: {} },
+      agent_clearance: 'write',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.ok).toBe(true);
+    expect(result.clearance_blocks).toHaveLength(0);
+  });
+
+  it('blocks a step whose cell is poisoned, even with admin clearance', async () => {
+    const board = createBoard('b', [
+      cell('poison-cell', { clearance: 'none', known_state: 'poisoned' }),
+    ]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: { fetch: { cell_id: 'poison-cell' } },
+      agent_clearance: 'admin',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.ok).toBe(false);
+    expect(result.poison_encounters).toContain('fetch');
+    expect(result.clearance_blocks).toHaveLength(0);
+  });
+
+  it('marks cell as verified and artifact after successful step', async () => {
+    const board = createBoard('b', [cell('work-cell', { clearance: 'none', cost_ticks: 3 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 'single',
+        reactions: [{ id: 'step1', task_template: 'Do it' }],
+      },
+      placements: { step1: { cell_id: 'work-cell' } },
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner(true) });
+    const cell_after = getCell(result.board_state, 'work-cell')!;
+    expect(cell_after.known_state).toBe('verified');
+    expect(cell_after.occupancy).toBe('artifact');
+  });
+
+  it('resets cell occupancy to empty after failed step', async () => {
+    const board = createBoard('b', [cell('work-cell', { clearance: 'none', cost_ticks: 1 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 'single',
+        reactions: [{ id: 'step1', task_template: 'Do it' }],
+      },
+      placements: { step1: { cell_id: 'work-cell' } },
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner(false) });
+    const cell_after = getCell(result.board_state, 'work-cell')!;
+    expect(cell_after.occupancy).toBe('empty');
+  });
+
+  it('accumulates tick cost from placed steps', async () => {
+    const board = createBoard('b', [
+      cell('c1', { clearance: 'none', cost_ticks: 3 }),
+      cell('c2', { clearance: 'none', cost_ticks: 5 }),
+    ]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: {
+        fetch: { cell_id: 'c1' },
+        process: { cell_id: 'c2' },
+      },
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.tick_total).toBe(8); // 3 + 5
+    expect(result.board_state.total_cost).toBe(8);
+  });
+
+  it('uses placement.cost_ticks override instead of cell.cost_ticks', async () => {
+    const board = createBoard('b', [cell('c', { clearance: 'none', cost_ticks: 10 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 's',
+        reactions: [{ id: 'step1', task_template: 'x' }],
+      },
+      placements: { step1: { cell_id: 'c', cost_ticks: 2 } }, // override
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.tick_total).toBe(2);
+  });
+
+  it('uses placement.result_occupancy when provided', async () => {
+    const board = createBoard('b', [cell('c', { clearance: 'none', cost_ticks: 1 })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 's',
+        reactions: [{ id: 'step1', task_template: 'x' }],
+      },
+      placements: { step1: { cell_id: 'c', result_occupancy: 'agent' } },
+      agent_clearance: 'none',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner(true) });
+    expect(getCell(result.board_state, 'c')!.occupancy).toBe('agent');
+  });
+
+  it('transitions unknown cell to observed during step, then verified on success', async () => {
+    const board = createBoard('b', [cell('c', { clearance: 'none', known_state: 'unknown' })]);
+    let stateAfterStart: import('../src/board-fields.js').BoardKnownState | null = null;
+
+    const runner = async (event: import('../src/index.js').AgentBusEvent) => {
+      // We can't easily inspect mid-step; just verify post-step is 'verified'
+      void event;
+      return { ok: true, result: null };
+    };
+
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 's',
+        reactions: [{ id: 'step1', task_template: 'x' }],
+      },
+      placements: { step1: { cell_id: 'c' } },
+      agent_clearance: 'none',
+    };
+
+    const result = await runBoardedChain(bc, board, { runEvent: runner });
+    stateAfterStart = getCell(result.board_state, 'c')!.known_state;
+    expect(stateAfterStart).toBe('verified');
+  });
+
+  it('carries chain_id and run_id through to the result', async () => {
+    const board = createBoard('b');
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: {},
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.chain_result.chain_id).toBe('two-step');
+    expect(typeof result.chain_result.run_id).toBe('string');
+  });
+
+  it('respects requires_clearance override on placement', async () => {
+    // Cell requires 'none' but placement overrides to 'write'
+    const board = createBoard('b', [cell('c', { clearance: 'none' })]);
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: {
+        schema_version: 'scbe_reaction_chain_v1',
+        chain_id: 's',
+        reactions: [{ id: 'step1', task_template: 'x' }],
+      },
+      placements: { step1: { cell_id: 'c', requires_clearance: 'write' } },
+      agent_clearance: 'read_only',
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.clearance_blocks).toContain('step1');
+  });
+
+  it('uses schema_version scbe_boarded_chain_run_v1', async () => {
+    const board = createBoard('b');
+    const bc: BoardedChain = {
+      schema_version: 'scbe_boarded_chain_v1',
+      chain: twoStepChain(),
+      placements: {},
+    };
+    const result = await runBoardedChain(bc, board, { runEvent: mockRunner() });
+    expect(result.schema_version).toBe('scbe_boarded_chain_run_v1');
+  });
+});


### PR DESCRIPTION
## Summary
- adds BoardFields, a multi-domain board-state layer for ReactionChain workflows
- models surface, air, sea, subground, space, personal, and shared squad domains
- blocks poisoned cells and insufficient-clearance moves before inner event execution
- tracks tick cost, fog-of-war state transitions, and verified artifact occupancy

## Why
This is the clean PR for the agentic Go-board/workroom idea on top of the merged ReactionChain engine. It replaces #1975, which was closed because its branch was based on the pre-merge ReactionChain commit and reintroduced already-merged files.

## Tests
- `npm test -- --run tests/board-fields.test.ts tests/reaction-chain.test.ts` -> 74 passed
- `npm run build` -> pass
- `npm run format:check` -> pass
- `npm test` -> 334 passed
- `npm audit --audit-level=moderate` -> 0 vulnerabilities

## Rollback
Revert this PR; it only adds `board-fields.ts`, exports it from agent-bus, and adds tests.
