### PR TITLE
feat(agent-bus): add agent life ledger

### DIFF
--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1978,6 +1978,30 @@ export {
 } from './board-fields.js';
 
 export {
+  type AgentIdentity,
+  type SkillLevel,
+  type CareerEntry,
+  type AgentLifeRecord,
+  type EncounterResult,
+  type LifeSummary,
+  createLifeRecord,
+  encounter,
+  gainSkillXP,
+  startCareer,
+  endCareer,
+  completeTask,
+  joinGroup,
+  leaveGroup,
+  isKnown,
+  getAlignmentScore,
+  getKnownAgents,
+  getCurrentRole,
+  summarize,
+  serializeLifeRecord,
+  deserializeLifeRecord,
+} from './life-ledger.js';
+
+export {
   type ReactionSpec,
   type ReactionChain,
   type ReactionStepStatus,

--- a/packages/agent-bus/src/life-ledger.ts
+++ b/packages/agent-bus/src/life-ledger.ts
@@ -1,0 +1,258 @@
+/**
+ * @file life-ledger.ts
+ * @module agent-bus/life-ledger
+ * @layer Cross-layer agent lifecycle
+ * @component LifeLedger — AI agent life simulation
+ *
+ * Per-agent persistent identity ledger.
+ * Key capability: O(1) known/unknown person detection — each agent carries
+ * a signed record of every agent they have ever encountered.
+ *
+ * Alignment, careers, skills, and group membership accrete over time.
+ * This is the biographical record that persists across sessions.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface AgentIdentity {
+  id: string;
+  display_name?: string;
+  first_seen_ts: number;
+  last_seen_ts: number;
+  interaction_count: number;
+}
+
+export interface SkillLevel {
+  name: string;
+  xp: number;
+  level: number;
+}
+
+export interface CareerEntry {
+  role: string;
+  joined_ts: number;
+  left_ts?: number;
+  tasks_completed: number;
+}
+
+export interface AgentLifeRecord {
+  agent_id: string;
+  display_name?: string;
+  birth_ts: number;
+  /** O(1) known/unknown check — keyed by encountered agent_id. */
+  known_agents: Record<string, AgentIdentity>;
+  /** Per-relationship alignment score in [-1, 1]. */
+  alignment_scores: Record<string, number>;
+  skills: Record<string, SkillLevel>;
+  career: CareerEntry[];
+  groups: string[];
+  total_encounters: number;
+  total_new_encounters: number;
+}
+
+export interface EncounterResult {
+  /** True when this agent_id has never been seen before — the ledger's main primitive. */
+  is_new: boolean;
+  identity: AgentIdentity;
+  alignment_score: number;
+  alignment_delta: number;
+}
+
+export interface LifeSummary {
+  agent_id: string;
+  display_name?: string;
+  age_ms: number;
+  known_count: number;
+  top_skills: SkillLevel[];
+  current_role?: string;
+  groups: string[];
+  total_encounters: number;
+  total_new_encounters: number;
+  avg_alignment: number;
+}
+
+// ─── Create ───────────────────────────────────────────────────────────────────
+
+export function createLifeRecord(agent_id: string, display_name?: string): AgentLifeRecord {
+  return {
+    agent_id,
+    ...(display_name !== undefined ? { display_name } : {}),
+    birth_ts: Date.now(),
+    known_agents: {},
+    alignment_scores: {},
+    skills: {},
+    career: [],
+    groups: [],
+    total_encounters: 0,
+    total_new_encounters: 0,
+  };
+}
+
+// ─── Encounter ────────────────────────────────────────────────────────────────
+
+/**
+ * Record an encounter with another agent.
+ * Returns `is_new: true` on first contact — the signal that this is an unknown person.
+ *
+ * Alignment update: early interactions have outsized weight (1/sqrt(n) decay),
+ * so the first contact sets the baseline tone. Later interactions converge it.
+ */
+export function encounter(
+  record: AgentLifeRecord,
+  encountered_id: string,
+  alignment_signal?: number,
+  display_name?: string
+): EncounterResult {
+  const now = Date.now();
+  const is_new = !(encountered_id in record.known_agents);
+
+  if (is_new) {
+    record.known_agents[encountered_id] = {
+      id: encountered_id,
+      ...(display_name !== undefined ? { display_name } : {}),
+      first_seen_ts: now,
+      last_seen_ts: now,
+      interaction_count: 1,
+    };
+    record.total_new_encounters++;
+  } else {
+    const identity = record.known_agents[encountered_id]!;
+    identity.last_seen_ts = now;
+    identity.interaction_count++;
+    if (display_name !== undefined) identity.display_name = display_name;
+  }
+  record.total_encounters++;
+
+  let alignment_delta = 0;
+  if (alignment_signal !== undefined) {
+    const clamped = Math.max(-1, Math.min(1, alignment_signal));
+    const n = record.known_agents[encountered_id]!.interaction_count;
+    // 1/sqrt(n) decay: first encounter fully weights, later ones average in
+    const weight = 1 / Math.sqrt(n);
+    const prev = record.alignment_scores[encountered_id] ?? 0;
+    alignment_delta = clamped * weight;
+    record.alignment_scores[encountered_id] = Math.max(-1, Math.min(1, prev + alignment_delta));
+  }
+
+  return {
+    is_new,
+    identity: { ...record.known_agents[encountered_id]! },
+    alignment_score: record.alignment_scores[encountered_id] ?? 0,
+    alignment_delta,
+  };
+}
+
+// ─── Skills ───────────────────────────────────────────────────────────────────
+
+/** Award XP in a skill. Level increases every 100 XP, soft-capped at 100. */
+export function gainSkillXP(record: AgentLifeRecord, skill_name: string, xp: number): SkillLevel {
+  if (!(skill_name in record.skills)) {
+    record.skills[skill_name] = { name: skill_name, xp: 0, level: 0 };
+  }
+  const skill = record.skills[skill_name]!;
+  skill.xp = Math.max(0, skill.xp + xp);
+  skill.level = Math.min(100, Math.floor(skill.xp / 100));
+  return { ...skill };
+}
+
+// ─── Career ───────────────────────────────────────────────────────────────────
+
+export function startCareer(record: AgentLifeRecord, role: string): CareerEntry {
+  const entry: CareerEntry = { role, joined_ts: Date.now(), tasks_completed: 0 };
+  record.career.push(entry);
+  return { ...entry };
+}
+
+export function endCareer(record: AgentLifeRecord, role: string): boolean {
+  const entry = [...record.career]
+    .reverse()
+    .find((e) => e.role === role && e.left_ts === undefined);
+  if (!entry) return false;
+  entry.left_ts = Date.now();
+  return true;
+}
+
+export function completeTask(record: AgentLifeRecord, role: string): boolean {
+  const entry = [...record.career]
+    .reverse()
+    .find((e) => e.role === role && e.left_ts === undefined);
+  if (!entry) return false;
+  entry.tasks_completed++;
+  return true;
+}
+
+// ─── Groups ───────────────────────────────────────────────────────────────────
+
+export function joinGroup(record: AgentLifeRecord, group_id: string): boolean {
+  if (record.groups.includes(group_id)) return false;
+  record.groups.push(group_id);
+  return true;
+}
+
+export function leaveGroup(record: AgentLifeRecord, group_id: string): boolean {
+  const idx = record.groups.indexOf(group_id);
+  if (idx === -1) return false;
+  record.groups.splice(idx, 1);
+  return true;
+}
+
+// ─── Queries ──────────────────────────────────────────────────────────────────
+
+export function isKnown(record: AgentLifeRecord, agent_id: string): boolean {
+  return agent_id in record.known_agents;
+}
+
+export function getAlignmentScore(record: AgentLifeRecord, agent_id: string): number | null {
+  return agent_id in record.alignment_scores ? (record.alignment_scores[agent_id] ?? null) : null;
+}
+
+export function getKnownAgents(record: AgentLifeRecord): AgentIdentity[] {
+  return Object.values(record.known_agents);
+}
+
+export function getCurrentRole(record: AgentLifeRecord): string | undefined {
+  return [...record.career].reverse().find((e) => e.left_ts === undefined)?.role;
+}
+
+export function summarize(record: AgentLifeRecord): LifeSummary {
+  const now = Date.now();
+  const skills = Object.values(record.skills).sort((a, b) => b.level - a.level);
+  const alignmentValues = Object.values(record.alignment_scores);
+  const avgAlignment =
+    alignmentValues.length > 0
+      ? alignmentValues.reduce((s, v) => s + v, 0) / alignmentValues.length
+      : 0;
+  const currentRole = getCurrentRole(record);
+
+  return {
+    agent_id: record.agent_id,
+    ...(record.display_name !== undefined ? { display_name: record.display_name } : {}),
+    age_ms: now - record.birth_ts,
+    known_count: Object.keys(record.known_agents).length,
+    top_skills: skills.slice(0, 5),
+    ...(currentRole !== undefined ? { current_role: currentRole } : {}),
+    groups: [...record.groups],
+    total_encounters: record.total_encounters,
+    total_new_encounters: record.total_new_encounters,
+    avg_alignment: parseFloat(avgAlignment.toFixed(4)),
+  };
+}
+
+// ─── Serialization ────────────────────────────────────────────────────────────
+
+export function serializeLifeRecord(record: AgentLifeRecord): string {
+  return JSON.stringify(record, null, 2);
+}
+
+export function deserializeLifeRecord(json: string): AgentLifeRecord {
+  const parsed = JSON.parse(json) as AgentLifeRecord;
+  // migration safety: ensure all required fields exist
+  if (!parsed.groups) parsed.groups = [];
+  if (!parsed.skills) parsed.skills = {};
+  if (!parsed.career) parsed.career = [];
+  if (!parsed.known_agents) parsed.known_agents = {};
+  if (!parsed.alignment_scores) parsed.alignment_scores = {};
+  if (typeof parsed.total_encounters !== 'number') parsed.total_encounters = 0;
+  if (typeof parsed.total_new_encounters !== 'number') parsed.total_new_encounters = 0;
+  return parsed;
+}

--- a/packages/agent-bus/tests/life-ledger.test.ts
+++ b/packages/agent-bus/tests/life-ledger.test.ts
@@ -1,0 +1,396 @@
+/**
+ * @file life-ledger.test.ts
+ * Tests for per-agent life simulation — known/unknown detection,
+ * alignment tracking, skills, career, groups, serialization.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  createLifeRecord,
+  encounter,
+  gainSkillXP,
+  startCareer,
+  endCareer,
+  completeTask,
+  joinGroup,
+  leaveGroup,
+  isKnown,
+  getAlignmentScore,
+  getKnownAgents,
+  summarize,
+  serializeLifeRecord,
+  deserializeLifeRecord,
+  type AgentLifeRecord,
+} from '../src/index.js';
+
+// ─── createLifeRecord ─────────────────────────────────────────────────────────
+
+describe('createLifeRecord', () => {
+  it('creates a record with empty known_agents', () => {
+    const r = createLifeRecord('agent-0');
+    expect(Object.keys(r.known_agents)).toHaveLength(0);
+  });
+
+  it('sets birth_ts to a recent timestamp', () => {
+    const before = Date.now();
+    const r = createLifeRecord('agent-0');
+    expect(r.birth_ts).toBeGreaterThanOrEqual(before);
+  });
+
+  it('stores display_name when provided', () => {
+    const r = createLifeRecord('agent-0', 'Polly');
+    expect(r.display_name).toBe('Polly');
+  });
+
+  it('omits display_name when not provided', () => {
+    const r = createLifeRecord('agent-0');
+    expect('display_name' in r).toBe(false);
+  });
+
+  it('starts with zero encounter counts', () => {
+    const r = createLifeRecord('agent-0');
+    expect(r.total_encounters).toBe(0);
+    expect(r.total_new_encounters).toBe(0);
+  });
+});
+
+// ─── encounter / known-unknown detection ──────────────────────────────────────
+
+describe('encounter — known/unknown detection', () => {
+  it('first encounter is marked is_new=true', () => {
+    const r = createLifeRecord('agent-0');
+    const result = encounter(r, 'agent-1');
+    expect(result.is_new).toBe(true);
+  });
+
+  it('second encounter with same agent is is_new=false', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'agent-1');
+    const result = encounter(r, 'agent-1');
+    expect(result.is_new).toBe(false);
+  });
+
+  it('total_new_encounters increments only on first encounter', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'agent-1');
+    encounter(r, 'agent-1');
+    encounter(r, 'agent-1');
+    expect(r.total_new_encounters).toBe(1);
+  });
+
+  it('total_encounters increments on every encounter', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'agent-1');
+    encounter(r, 'agent-1');
+    encounter(r, 'agent-2');
+    expect(r.total_encounters).toBe(3);
+  });
+
+  it('interaction_count increments on repeat encounters', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'agent-1');
+    encounter(r, 'agent-1');
+    encounter(r, 'agent-1');
+    expect(r.known_agents['agent-1']!.interaction_count).toBe(3);
+  });
+
+  it('stores display_name on first encounter', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'agent-1', undefined, 'Zara');
+    expect(r.known_agents['agent-1']!.display_name).toBe('Zara');
+  });
+
+  it('updates display_name on repeat encounter', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'agent-1', undefined, 'Old Name');
+    encounter(r, 'agent-1', undefined, 'New Name');
+    expect(r.known_agents['agent-1']!.display_name).toBe('New Name');
+  });
+
+  it('multiple different agents tracked independently', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'agent-1');
+    encounter(r, 'agent-2');
+    encounter(r, 'agent-3');
+    expect(Object.keys(r.known_agents)).toHaveLength(3);
+    expect(r.total_new_encounters).toBe(3);
+  });
+});
+
+// ─── alignment tracking ───────────────────────────────────────────────────────
+
+describe('alignment tracking', () => {
+  it('no alignment score before any encounter', () => {
+    const r = createLifeRecord('agent-0');
+    expect(getAlignmentScore(r, 'agent-1')).toBeNull();
+  });
+
+  it('positive signal produces positive alignment on first encounter', () => {
+    const r = createLifeRecord('agent-0');
+    const result = encounter(r, 'agent-1', 1.0);
+    expect(result.alignment_score).toBeGreaterThan(0);
+  });
+
+  it('negative signal produces negative alignment', () => {
+    const r = createLifeRecord('agent-0');
+    const result = encounter(r, 'agent-1', -1.0);
+    expect(result.alignment_score).toBeLessThan(0);
+  });
+
+  it('alignment stays in [-1, 1] after many positive signals', () => {
+    const r = createLifeRecord('agent-0');
+    for (let i = 0; i < 20; i++) encounter(r, 'agent-1', 1.0);
+    const score = getAlignmentScore(r, 'agent-1')!;
+    expect(score).toBeLessThanOrEqual(1);
+    expect(score).toBeGreaterThanOrEqual(-1);
+  });
+
+  it('early interactions outweigh later ones (1/sqrt(n) decay)', () => {
+    const r1 = createLifeRecord('a');
+    const r2 = createLifeRecord('b');
+    // r1: moderate positive first, then neutral — stays at ~0.5
+    encounter(r1, 'x', 0.5);
+    for (let i = 0; i < 10; i++) encounter(r1, 'x', 0.0);
+    // r2: neutral first, then small positives — accumulates to ~0.43 (below 0.5)
+    encounter(r2, 'x', 0.0);
+    for (let i = 0; i < 10; i++) encounter(r2, 'x', 0.1);
+    // r1 should have higher alignment: first encounter (1/sqrt(1)=full weight) dominates
+    expect(getAlignmentScore(r1, 'x')!).toBeGreaterThan(getAlignmentScore(r2, 'x')!);
+  });
+
+  it('alignment_delta is 0 when no signal provided', () => {
+    const r = createLifeRecord('agent-0');
+    const result = encounter(r, 'agent-1');
+    expect(result.alignment_delta).toBe(0);
+  });
+});
+
+// ─── isKnown ──────────────────────────────────────────────────────────────────
+
+describe('isKnown', () => {
+  it('returns false before any encounter', () => {
+    const r = createLifeRecord('agent-0');
+    expect(isKnown(r, 'agent-1')).toBe(false);
+  });
+
+  it('returns true after encounter', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'agent-1');
+    expect(isKnown(r, 'agent-1')).toBe(true);
+  });
+
+  it('does not affect other agents', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'agent-1');
+    expect(isKnown(r, 'agent-2')).toBe(false);
+  });
+});
+
+// ─── skills ───────────────────────────────────────────────────────────────────
+
+describe('gainSkillXP', () => {
+  it('creates new skill at level 0 with given xp', () => {
+    const r = createLifeRecord('agent-0');
+    const sk = gainSkillXP(r, 'governance', 50);
+    expect(sk.xp).toBe(50);
+    expect(sk.level).toBe(0);
+  });
+
+  it('level advances at 100 xp intervals', () => {
+    const r = createLifeRecord('agent-0');
+    gainSkillXP(r, 'navigation', 100);
+    expect(r.skills['navigation']!.level).toBe(1);
+    gainSkillXP(r, 'navigation', 100);
+    expect(r.skills['navigation']!.level).toBe(2);
+  });
+
+  it('level soft-caps at 100', () => {
+    const r = createLifeRecord('agent-0');
+    gainSkillXP(r, 'overdrive', 999_999);
+    expect(r.skills['overdrive']!.level).toBe(100);
+  });
+
+  it('negative xp reduces xp but not below 0', () => {
+    const r = createLifeRecord('agent-0');
+    gainSkillXP(r, 'nav', 50);
+    gainSkillXP(r, 'nav', -100);
+    expect(r.skills['nav']!.xp).toBe(0);
+  });
+
+  it('multiple skills tracked independently', () => {
+    const r = createLifeRecord('agent-0');
+    gainSkillXP(r, 'skill-a', 100);
+    gainSkillXP(r, 'skill-b', 200);
+    expect(r.skills['skill-a']!.level).toBe(1);
+    expect(r.skills['skill-b']!.level).toBe(2);
+  });
+});
+
+// ─── career ───────────────────────────────────────────────────────────────────
+
+describe('career', () => {
+  it('startCareer adds entry with joined_ts', () => {
+    const r = createLifeRecord('agent-0');
+    const before = Date.now();
+    startCareer(r, 'navigator');
+    expect(r.career[0]!.role).toBe('navigator');
+    expect(r.career[0]!.joined_ts).toBeGreaterThanOrEqual(before);
+    expect(r.career[0]!.left_ts).toBeUndefined();
+  });
+
+  it('endCareer sets left_ts on matching role', () => {
+    const r = createLifeRecord('agent-0');
+    startCareer(r, 'navigator');
+    const result = endCareer(r, 'navigator');
+    expect(result).toBe(true);
+    expect(r.career[0]!.left_ts).toBeDefined();
+  });
+
+  it('endCareer returns false for nonexistent role', () => {
+    const r = createLifeRecord('agent-0');
+    expect(endCareer(r, 'ghost-role')).toBe(false);
+  });
+
+  it('completeTask increments tasks_completed', () => {
+    const r = createLifeRecord('agent-0');
+    startCareer(r, 'pilot');
+    completeTask(r, 'pilot');
+    completeTask(r, 'pilot');
+    expect(r.career[0]!.tasks_completed).toBe(2);
+  });
+
+  it('completeTask returns false for inactive role', () => {
+    const r = createLifeRecord('agent-0');
+    expect(completeTask(r, 'ghost-role')).toBe(false);
+  });
+});
+
+// ─── groups ───────────────────────────────────────────────────────────────────
+
+describe('groups', () => {
+  it('joinGroup adds group_id', () => {
+    const r = createLifeRecord('agent-0');
+    const result = joinGroup(r, 'scbe-fleet');
+    expect(result).toBe(true);
+    expect(r.groups).toContain('scbe-fleet');
+  });
+
+  it('joinGroup is idempotent — returns false on duplicate', () => {
+    const r = createLifeRecord('agent-0');
+    joinGroup(r, 'scbe-fleet');
+    const result = joinGroup(r, 'scbe-fleet');
+    expect(result).toBe(false);
+    expect(r.groups.filter((g) => g === 'scbe-fleet')).toHaveLength(1);
+  });
+
+  it('leaveGroup removes group_id', () => {
+    const r = createLifeRecord('agent-0');
+    joinGroup(r, 'scbe-fleet');
+    const result = leaveGroup(r, 'scbe-fleet');
+    expect(result).toBe(true);
+    expect(r.groups).not.toContain('scbe-fleet');
+  });
+
+  it('leaveGroup returns false for nonexistent group', () => {
+    const r = createLifeRecord('agent-0');
+    expect(leaveGroup(r, 'ghost-group')).toBe(false);
+  });
+
+  it('multiple groups tracked independently', () => {
+    const r = createLifeRecord('agent-0');
+    joinGroup(r, 'fleet-alpha');
+    joinGroup(r, 'fleet-beta');
+    leaveGroup(r, 'fleet-alpha');
+    expect(r.groups).toContain('fleet-beta');
+    expect(r.groups).not.toContain('fleet-alpha');
+  });
+});
+
+// ─── summarize ────────────────────────────────────────────────────────────────
+
+describe('summarize', () => {
+  it('known_count reflects number of encountered agents', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'a1');
+    encounter(r, 'a2');
+    encounter(r, 'a3');
+    const s = summarize(r);
+    expect(s.known_count).toBe(3);
+  });
+
+  it('top_skills sorted by level descending', () => {
+    const r = createLifeRecord('agent-0');
+    gainSkillXP(r, 'alpha', 300);
+    gainSkillXP(r, 'beta', 100);
+    gainSkillXP(r, 'gamma', 200);
+    const s = summarize(r);
+    expect(s.top_skills[0]!.name).toBe('alpha');
+    expect(s.top_skills[1]!.name).toBe('gamma');
+    expect(s.top_skills[2]!.name).toBe('beta');
+  });
+
+  it('top_skills capped at 5 entries', () => {
+    const r = createLifeRecord('agent-0');
+    for (let i = 0; i < 8; i++) gainSkillXP(r, `skill-${i}`, 100 * (i + 1));
+    const s = summarize(r);
+    expect(s.top_skills.length).toBeLessThanOrEqual(5);
+  });
+
+  it('current_role present when career is active', () => {
+    const r = createLifeRecord('agent-0');
+    startCareer(r, 'navigator');
+    const s = summarize(r);
+    expect(s.current_role).toBe('navigator');
+  });
+
+  it('current_role absent after career ends', () => {
+    const r = createLifeRecord('agent-0');
+    startCareer(r, 'navigator');
+    endCareer(r, 'navigator');
+    const s = summarize(r);
+    expect(s.current_role).toBeUndefined();
+  });
+
+  it('avg_alignment is 0 when no encounters with signals', () => {
+    const r = createLifeRecord('agent-0');
+    encounter(r, 'a1');
+    const s = summarize(r);
+    expect(s.avg_alignment).toBe(0);
+  });
+});
+
+// ─── serialization ────────────────────────────────────────────────────────────
+
+describe('serialize / deserialize', () => {
+  it('round-trips a complete life record', () => {
+    const r = createLifeRecord('agent-0', 'Polly');
+    encounter(r, 'agent-1', 0.5, 'Zara');
+    gainSkillXP(r, 'navigation', 250);
+    startCareer(r, 'navigator');
+    joinGroup(r, 'scbe-fleet');
+
+    const json = serializeLifeRecord(r);
+    const restored = deserializeLifeRecord(json);
+
+    expect(restored.agent_id).toBe('agent-0');
+    expect(restored.display_name).toBe('Polly');
+    expect(restored.known_agents['agent-1']!.display_name).toBe('Zara');
+    expect(restored.skills['navigation']!.level).toBe(2);
+    expect(restored.groups).toContain('scbe-fleet');
+  });
+
+  it('deserialize handles record with missing optional fields gracefully', () => {
+    const minimal = JSON.stringify({ agent_id: 'x', birth_ts: 0, known_agents: {} });
+    const r = deserializeLifeRecord(minimal);
+    expect(r.groups).toEqual([]);
+    expect(r.skills).toEqual({});
+    expect(r.career).toEqual([]);
+    expect(r.total_encounters).toBe(0);
+  });
+
+  it('serialized form is valid JSON', () => {
+    const r = createLifeRecord('agent-0');
+    const json = serializeLifeRecord(r);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add `life-ledger` agent biography records for Polly Pads / squad memory
- track known/unknown encounters, alignment, skills, careers, and groups
- export the ledger API through `packages/agent-bus/src/index.ts`

## Test evidence
- `npm test -- --run tests/life-ledger.test.ts tests/board-fields.test.ts tests/reaction-chain.test.ts` -> 120 passed
- `npm run build` -> passed
- `npm run format:check` -> passed
- `npm audit --audit-level=moderate` -> 0 vulnerabilities
- `npm test` -> 380 passed

## Rollback
- revert commit `85ec89836`