### PR TITLE
feat(agent-bus): add tool-factory spec validation and registry

### DIFF
--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -2074,3 +2074,20 @@ export {
   buildReactionEvent,
   runReactionChain,
 } from './reaction-chain.js';
+
+export {
+  type ToolCommand,
+  type ToolSpec,
+  type KnownPatentSurface,
+  type ValidationResult,
+  type VerificationResult,
+  type RegistrationResult,
+  type ListResult,
+  ALLOWED_COMMANDS,
+  KNOWN_PATENT_SURFACES,
+  validateToolSpec,
+  verifyToolSpec,
+  registerTool as registerToolSpecInFile,
+  unregisterTool as unregisterToolSpecInFile,
+  listTools as listToolSpecsFromFile,
+} from './tool-factory.js';

--- a/packages/agent-bus/src/tool-factory.ts
+++ b/packages/agent-bus/src/tool-factory.ts
@@ -1,0 +1,330 @@
+/**
+ * @file tool-factory.ts
+ * @module agent-bus/tool-factory
+ *
+ * Self-registration surface: validate a tool spec, verify its command exists,
+ * and write it into tools.json atomically (temp-file → rename).
+ *
+ * Deliberately does NOT include a "generate spec from description" path. That
+ * inference layer is deferred until the register/validate/list surface is proven
+ * correct. Guessed specs that look valid but don't run are worse than no spec.
+ *
+ * Schema contract (ToolSpec):
+ *   name         — /^[a-z][a-z0-9-]+$/ — kebab-case, min 2 chars after first
+ *   description  — non-empty string
+ *   command      — "python" | "node"
+ *   args         — non-empty string[], at least one element contains "{task}"
+ *   patentSurface — optional string
+ *
+ * Extra keys are rejected at validation time.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export const ALLOWED_COMMANDS = ['python', 'node'] as const;
+export type ToolCommand = (typeof ALLOWED_COMMANDS)[number];
+
+export interface ToolSpec {
+  name: string;
+  description: string;
+  command: ToolCommand;
+  args: string[];
+  patentSurface?: string;
+}
+
+export const KNOWN_PATENT_SURFACES = [
+  'bijective-transport',
+  'agent-harness',
+  'atomic-tokenizer',
+] as const;
+export type KnownPatentSurface = (typeof KNOWN_PATENT_SURFACES)[number];
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: string[];
+  spec?: ToolSpec;
+}
+
+export interface VerificationResult {
+  ok: boolean;
+  skipped: boolean;
+  reason: string;
+}
+
+export interface RegistrationResult {
+  schema_version: 'scbe.agent_bus.tool_factory.v1';
+  ok: boolean;
+  name: string;
+  action: 'registered' | 'rejected';
+  errors: string[];
+  verification: VerificationResult;
+  tools_count_after: number;
+}
+
+export interface ListResult {
+  schema_version: 'scbe.agent_bus.tool_factory.list.v1';
+  tools_count: number;
+  tools: Array<Pick<ToolSpec, 'name' | 'command' | 'patentSurface'> & { description_head: string }>;
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+const NAME_RE = /^[a-z][a-z0-9-]+$/;
+const ALLOWED_KEYS = new Set(['name', 'description', 'command', 'args', 'patentSurface']);
+
+export function validateToolSpec(raw: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, errors: ['spec must be a JSON object'] };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  // Reject unknown keys
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_KEYS.has(key)) {
+      errors.push(
+        `unknown key: ${JSON.stringify(key)} — only ${[...ALLOWED_KEYS].join(', ')} allowed`
+      );
+    }
+  }
+
+  // name
+  if (typeof obj.name !== 'string' || !obj.name) {
+    errors.push('name must be a non-empty string');
+  } else if (!NAME_RE.test(obj.name)) {
+    errors.push(
+      `name ${JSON.stringify(obj.name)} must match /^[a-z][a-z0-9-]+$/ (lowercase kebab, min 2 chars)`
+    );
+  }
+
+  // description
+  if (typeof obj.description !== 'string' || !obj.description.trim()) {
+    errors.push('description must be a non-empty string');
+  }
+
+  // command
+  if (!ALLOWED_COMMANDS.includes(obj.command as ToolCommand)) {
+    errors.push(`command must be one of: ${ALLOWED_COMMANDS.join(', ')}`);
+  }
+
+  // args
+  if (!Array.isArray(obj.args) || obj.args.length === 0) {
+    errors.push('args must be a non-empty array');
+  } else {
+    for (let i = 0; i < obj.args.length; i++) {
+      if (typeof obj.args[i] !== 'string') {
+        errors.push(`args[${i}] must be a string`);
+      }
+    }
+    const hasTaskPlaceholder = obj.args.some((a) => typeof a === 'string' && a.includes('{task}'));
+    if (!hasTaskPlaceholder) {
+      errors.push('args must contain at least one element with the "{task}" placeholder');
+    }
+  }
+
+  // patentSurface (optional)
+  if (obj.patentSurface !== undefined && typeof obj.patentSurface !== 'string') {
+    errors.push('patentSurface must be a string if provided');
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    errors: [],
+    spec: {
+      name: obj.name as string,
+      description: (obj.description as string).trim(),
+      command: obj.command as ToolCommand,
+      args: obj.args as string[],
+      ...(obj.patentSurface !== undefined && { patentSurface: obj.patentSurface as string }),
+    },
+  };
+}
+
+// ─── Verification (pre-registration) ─────────────────────────────────────────
+
+/**
+ * Verify that the command target exists before registering.
+ * For `python` with a file path as first non-flag arg: check file exists.
+ * For `python -m module`: attempt a dry import.
+ * For `node` with a .cjs/.js/.mjs path: check file exists.
+ * If neither pattern matches, returns skipped=true (don't block unusual specs).
+ */
+export function verifyToolSpec(spec: ToolSpec, repoRoot: string): VerificationResult {
+  if (spec.command === 'node') {
+    const scriptArg = spec.args.find((a) => /\.(cjs|js|mjs)$/.test(a));
+    if (scriptArg) {
+      const full = path.resolve(repoRoot, scriptArg);
+      if (!existsSync(full)) {
+        return { ok: false, skipped: false, reason: `node script not found: ${full}` };
+      }
+    }
+    return { ok: true, skipped: scriptArg === undefined, reason: 'node script exists' };
+  }
+
+  if (spec.command === 'python') {
+    // -m module pattern
+    const mIdx = spec.args.indexOf('-m');
+    if (mIdx !== -1 && spec.args[mIdx + 1]) {
+      const moduleName = spec.args[mIdx + 1];
+      const python = process.env.PYTHON ?? (process.platform === 'win32' ? 'python' : 'python3');
+      const probe = spawnSync(
+        python,
+        [
+          '-c',
+          `import importlib.util; assert importlib.util.find_spec(${JSON.stringify(moduleName)}) is not None`,
+        ],
+        { cwd: repoRoot, encoding: 'utf8', timeout: 8_000 }
+      );
+      if (probe.status !== 0) {
+        return {
+          ok: false,
+          skipped: false,
+          reason: `python module not importable: ${moduleName} (${probe.stderr.trim().split('\n').pop() ?? ''})`,
+        };
+      }
+      return { ok: true, skipped: false, reason: `python module importable: ${moduleName}` };
+    }
+
+    // Direct script path (skip flags that start with -)
+    const scriptArg = spec.args.find((a) => !a.startsWith('-') && a.endsWith('.py'));
+    if (scriptArg) {
+      const full = path.resolve(repoRoot, scriptArg);
+      if (!existsSync(full)) {
+        return { ok: false, skipped: false, reason: `python script not found: ${full}` };
+      }
+      return { ok: true, skipped: false, reason: `python script exists: ${full}` };
+    }
+
+    return { ok: true, skipped: true, reason: 'no verifiable script path found in args; skipping' };
+  }
+
+  return { ok: true, skipped: true, reason: 'unknown command; skipping verification' };
+}
+
+// ─── Registry read/write ─────────────────────────────────────────────────────
+
+function readRegistry(toolsJsonPath: string): ToolSpec[] {
+  const raw = readFileSync(toolsJsonPath, 'utf8');
+  return JSON.parse(raw) as ToolSpec[];
+}
+
+function writeRegistryAtomic(toolsJsonPath: string, tools: ToolSpec[]): void {
+  const tmp = toolsJsonPath + '.tmp';
+  writeFileSync(tmp, JSON.stringify(tools, null, 2) + '\n', 'utf8');
+  // Re-read to confirm it round-trips before committing
+  const roundTrip = JSON.parse(readFileSync(tmp, 'utf8')) as ToolSpec[];
+  if (roundTrip.length !== tools.length) {
+    throw new Error(
+      `tools.json atomic write sanity-check failed: wrote ${tools.length} tools, re-read ${roundTrip.length}`
+    );
+  }
+  renameSync(tmp, toolsJsonPath);
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Register a new tool in tools.json.
+ *
+ * @param spec      Already-validated ToolSpec (run validateToolSpec first)
+ * @param toolsJsonPath  Absolute path to tools.json
+ * @param repoRoot  Repo root for resolving relative script paths in verify
+ * @param skipVerify  Skip pre-registration file/import check (default false)
+ */
+export function registerTool(
+  spec: ToolSpec,
+  toolsJsonPath: string,
+  repoRoot: string,
+  skipVerify = false
+): RegistrationResult {
+  const base: Omit<RegistrationResult, 'tools_count_after'> = {
+    schema_version: 'scbe.agent_bus.tool_factory.v1',
+    ok: false,
+    name: spec.name,
+    action: 'rejected',
+    errors: [],
+    verification: { ok: true, skipped: true, reason: 'not run' },
+  };
+
+  // Check duplicate
+  const existing = readRegistry(toolsJsonPath);
+  if (existing.some((t) => t.name === spec.name)) {
+    return {
+      ...base,
+      errors: [`tool name already registered: ${spec.name}`],
+      tools_count_after: existing.length,
+    };
+  }
+
+  // Verify command target
+  const verification = skipVerify
+    ? { ok: true, skipped: true, reason: 'skipped by caller' }
+    : verifyToolSpec(spec, repoRoot);
+
+  if (!verification.ok) {
+    return {
+      ...base,
+      errors: [`pre-registration verification failed: ${verification.reason}`],
+      verification,
+      tools_count_after: existing.length,
+    };
+  }
+
+  // Atomic write
+  const updated = [...existing, spec];
+  writeRegistryAtomic(toolsJsonPath, updated);
+
+  return {
+    schema_version: 'scbe.agent_bus.tool_factory.v1',
+    ok: true,
+    name: spec.name,
+    action: 'registered',
+    errors: [],
+    verification,
+    tools_count_after: updated.length,
+  };
+}
+
+/**
+ * List all registered tools. Read-only, no side effects.
+ */
+export function listTools(toolsJsonPath: string): ListResult {
+  const tools = readRegistry(toolsJsonPath);
+  return {
+    schema_version: 'scbe.agent_bus.tool_factory.list.v1',
+    tools_count: tools.length,
+    tools: tools.map((t) => ({
+      name: t.name,
+      command: t.command,
+      ...(t.patentSurface !== undefined && { patentSurface: t.patentSurface }),
+      description_head: t.description.split('.')[0]!.slice(0, 80),
+    })),
+  };
+}
+
+/**
+ * Remove a tool from tools.json by name.
+ * Returns ok=false if the name was not found.
+ */
+export function unregisterTool(
+  name: string,
+  toolsJsonPath: string
+): { ok: boolean; tools_count_after: number; error?: string } {
+  const existing = readRegistry(toolsJsonPath);
+  const filtered = existing.filter((t) => t.name !== name);
+  if (filtered.length === existing.length) {
+    return { ok: false, tools_count_after: existing.length, error: `tool not found: ${name}` };
+  }
+  writeRegistryAtomic(toolsJsonPath, filtered);
+  return { ok: true, tools_count_after: filtered.length };
+}

--- a/packages/agent-bus/tests/tool-factory.test.ts
+++ b/packages/agent-bus/tests/tool-factory.test.ts
@@ -1,0 +1,423 @@
+/**
+ * @file tool-factory.test.ts
+ *
+ * Failure-path tests are primary — silent corruption of tools.json is the worst
+ * outcome. Happy-path is covered, but the rejection gates are the value here.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  listToolSpecsFromFile,
+  registerToolSpecInFile,
+  unregisterToolSpecInFile,
+  validateToolSpec,
+  verifyToolSpec,
+  type ToolSpec,
+} from '../src/index.js';
+
+// ─── Fixture helpers ─────────────────────────────────────────────────────────
+
+const GOOD_NODE_SPEC: ToolSpec = {
+  name: 'demo-tool',
+  description: 'Demo tool for tests.',
+  command: 'node',
+  args: ['echo.cjs', '{task}'],
+  patentSurface: 'agent-harness',
+};
+
+function tempToolsJson(seed: ToolSpec[] = []): { dir: string; file: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scbe-tool-factory-'));
+  const file = path.join(dir, 'tools.json');
+  fs.writeFileSync(file, JSON.stringify(seed, null, 2) + '\n', 'utf8');
+  return { dir, file };
+}
+
+function touchScript(dir: string, name: string): string {
+  const full = path.join(dir, name);
+  fs.writeFileSync(full, '// stub\n', 'utf8');
+  return full;
+}
+
+// ─── validateToolSpec ─────────────────────────────────────────────────────────
+
+describe('validateToolSpec', () => {
+  it('accepts a minimal valid node spec', () => {
+    const { dir, file } = tempToolsJson();
+    try {
+      const script = path.join(dir, 'echo.cjs');
+      fs.writeFileSync(script, 'console.log("ok")\n', 'utf8');
+      const relativeScript = path.relative(dir, script).replace(/\\/g, '/');
+      const result = validateToolSpec({
+        name: 'demo-tool',
+        description: 'Demo tool for tests.',
+        command: 'node',
+        args: [relativeScript, '{task}'],
+        patentSurface: 'agent-harness',
+      });
+      expect(result.ok).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.spec?.name).toBe('demo-tool');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a python spec', () => {
+    const result = validateToolSpec({
+      name: 'py-tool',
+      description: 'Python tool.',
+      command: 'python',
+      args: ['scripts/run.py', '{task}'],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects non-object input (string, null, array, number)', () => {
+    expect(validateToolSpec('string').ok).toBe(false);
+    expect(validateToolSpec(null).ok).toBe(false);
+    expect(validateToolSpec([]).ok).toBe(false);
+    expect(validateToolSpec(42).ok).toBe(false);
+  });
+
+  it('rejects unknown keys', () => {
+    const result = validateToolSpec({ ...GOOD_NODE_SPEC, extra: 'bad', another: 1 });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toMatch(/unknown key/);
+  });
+
+  it('rejects unknown keys AND missing {task} — accumulates multiple errors', () => {
+    const result = validateToolSpec({
+      name: 'bad-tool',
+      description: 'Bad tool.',
+      command: 'node',
+      args: ['script.cjs'],
+      extra: true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toMatch(/unknown key/);
+    expect(result.errors.join('\n')).toMatch(/\{task\}/);
+  });
+
+  it('rejects PascalCase name', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, name: 'MyTool' }).ok).toBe(false);
+  });
+
+  it('rejects snake_case name', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, name: 'my_tool' }).ok).toBe(false);
+  });
+
+  it('rejects single-char name (min length fails regex)', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, name: 'a' }).ok).toBe(false);
+  });
+
+  it('rejects name starting with digit', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, name: '1tool' }).ok).toBe(false);
+  });
+
+  it('rejects name with spaces', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, name: 'my tool' }).ok).toBe(false);
+  });
+
+  it('accepts multi-segment kebab name', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, name: 'tool-register-v2' }).ok).toBe(true);
+  });
+
+  it('rejects empty description', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, description: '' }).ok).toBe(false);
+  });
+
+  it('rejects whitespace-only description', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, description: '   ' }).ok).toBe(false);
+  });
+
+  it('trims leading/trailing whitespace from description', () => {
+    const r = validateToolSpec({ ...GOOD_NODE_SPEC, description: '  padded  ' });
+    expect(r.ok).toBe(true);
+    expect(r.spec?.description).toBe('padded');
+  });
+
+  it('rejects bash command', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, command: 'bash' }).ok).toBe(false);
+  });
+
+  it('rejects empty command', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, command: '' }).ok).toBe(false);
+  });
+
+  it('rejects ruby command', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, command: 'ruby' }).ok).toBe(false);
+  });
+
+  it('rejects empty args array', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, args: [] }).ok).toBe(false);
+  });
+
+  it('rejects args without {task} placeholder anywhere', () => {
+    const r = validateToolSpec({ ...GOOD_NODE_SPEC, args: ['scripts/foo.cjs', '--flag'] });
+    expect(r.ok).toBe(false);
+    expect(r.errors.join(' ')).toMatch(/\{task\}/);
+  });
+
+  it('accepts {task} in any args position', () => {
+    expect(
+      validateToolSpec({ ...GOOD_NODE_SPEC, args: ['--prefix', '{task}', '--suffix'] }).ok
+    ).toBe(true);
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, args: ['{task}'] }).ok).toBe(true);
+  });
+
+  it('rejects non-string patentSurface', () => {
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, patentSurface: 42 }).ok).toBe(false);
+    expect(validateToolSpec({ ...GOOD_NODE_SPEC, patentSurface: true }).ok).toBe(false);
+  });
+
+  it('accepts absent patentSurface', () => {
+    const { patentSurface: _, ...noPat } = GOOD_NODE_SPEC;
+    expect(validateToolSpec(noPat).ok).toBe(true);
+  });
+});
+
+// ─── verifyToolSpec ───────────────────────────────────────────────────────────
+
+describe('verifyToolSpec', () => {
+  it('returns ok=false when node script does not exist', () => {
+    const spec: ToolSpec = {
+      ...GOOD_NODE_SPEC,
+      args: ['scripts/nonexistent_file_abc123.cjs', '{task}'],
+    };
+    const r = verifyToolSpec(spec, process.cwd());
+    expect(r.ok).toBe(false);
+    expect(r.skipped).toBe(false);
+  });
+
+  it('skips verification when no recognisable script path in node args', () => {
+    const spec: ToolSpec = { ...GOOD_NODE_SPEC, args: ['{task}'] };
+    const r = verifyToolSpec(spec, process.cwd());
+    expect(r.skipped).toBe(true);
+  });
+
+  it('returns ok=true for an existing node script', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..');
+    const spec: ToolSpec = {
+      ...GOOD_NODE_SPEC,
+      args: ['packages/agent-bus/bin/scbe-agent-bus.cjs', '{task}'],
+    };
+    const r = verifyToolSpec(spec, repoRoot);
+    expect(r.ok).toBe(true);
+    expect(r.skipped).toBe(false);
+  });
+
+  it('returns ok=false for a non-existent python script', () => {
+    const spec: ToolSpec = {
+      name: 'py-tool',
+      description: 'Python tool.',
+      command: 'python',
+      args: ['scripts/does_not_exist_xyz.py', '{task}'],
+    };
+    const r = verifyToolSpec(spec, process.cwd());
+    expect(r.ok).toBe(false);
+    expect(r.skipped).toBe(false);
+  });
+
+  it('skips python verification when no script or -m flag is present', () => {
+    const spec: ToolSpec = {
+      name: 'py-tool',
+      description: 'Python tool.',
+      command: 'python',
+      args: ['{task}'],
+    };
+    const r = verifyToolSpec(spec, process.cwd());
+    expect(r.skipped).toBe(true);
+  });
+});
+
+// ─── registerToolSpecInFile ───────────────────────────────────────────────────
+
+describe('registerToolSpecInFile', () => {
+  it('registers a valid spec and persists it (happy path)', () => {
+    const { dir, file } = tempToolsJson();
+    try {
+      touchScript(dir, 'echo.cjs');
+      const raw = { ...GOOD_NODE_SPEC, args: ['echo.cjs', '{task}'] };
+      const validated = validateToolSpec(raw);
+      expect(validated.ok).toBe(true);
+      const result = registerToolSpecInFile(validated.spec!, file, dir);
+
+      expect(result.ok).toBe(true);
+      expect(result.action).toBe('registered');
+      expect(result.tools_count_after).toBe(1);
+
+      const written = JSON.parse(fs.readFileSync(file, 'utf8')) as ToolSpec[];
+      expect(written).toHaveLength(1);
+      expect(written[0]!.name).toBe('demo-tool');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects duplicate tool name', () => {
+    const { dir, file } = tempToolsJson();
+    try {
+      touchScript(dir, 'echo.cjs');
+      const spec = validateToolSpec({ ...GOOD_NODE_SPEC, args: ['echo.cjs', '{task}'] }).spec!;
+      registerToolSpecInFile(spec, file, dir, true);
+      const r2 = registerToolSpecInFile(spec, file, dir, true);
+      expect(r2.ok).toBe(false);
+      expect(r2.errors[0]).toMatch(/already registered/);
+      expect(r2.tools_count_after).toBe(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not mutate registry on rejection', () => {
+    const { dir, file } = tempToolsJson();
+    try {
+      touchScript(dir, 'echo.cjs');
+      const spec = validateToolSpec({ ...GOOD_NODE_SPEC, args: ['echo.cjs', '{task}'] }).spec!;
+      registerToolSpecInFile(spec, file, dir, true);
+      registerToolSpecInFile(spec, file, dir, true); // duplicate
+      const written = JSON.parse(fs.readFileSync(file, 'utf8')) as ToolSpec[];
+      expect(written).toHaveLength(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves no .tmp file after successful write', () => {
+    const { dir, file } = tempToolsJson();
+    try {
+      touchScript(dir, 'echo.cjs');
+      const spec = validateToolSpec({ ...GOOD_NODE_SPEC, args: ['echo.cjs', '{task}'] }).spec!;
+      registerToolSpecInFile(spec, file, dir, true);
+      expect(fs.existsSync(file + '.tmp')).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects when pre-registration node script does not exist', () => {
+    const { dir, file } = tempToolsJson();
+    try {
+      const spec: ToolSpec = {
+        name: 'bad-node-tool',
+        description: 'Missing script.',
+        command: 'node',
+        args: ['scripts/nonexistent_xyz789.cjs', '{task}'],
+      };
+      const r = registerToolSpecInFile(spec, file, dir, false);
+      expect(r.ok).toBe(false);
+      expect(r.errors[0]).toMatch(/verification failed/);
+      const written = JSON.parse(fs.readFileSync(file, 'utf8')) as ToolSpec[];
+      expect(written).toHaveLength(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('skipVerify=true bypasses file check and registers anyway', () => {
+    const { dir, file } = tempToolsJson();
+    try {
+      const spec: ToolSpec = {
+        name: 'skip-verify-tool',
+        description: 'Verify skipped.',
+        command: 'node',
+        args: ['scripts/ghost_file_abc.cjs', '{task}'],
+      };
+      const r = registerToolSpecInFile(spec, file, dir, true);
+      expect(r.ok).toBe(true);
+      expect(r.verification.skipped).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── listToolSpecsFromFile ────────────────────────────────────────────────────
+
+describe('listToolSpecsFromFile', () => {
+  it('returns empty list from empty registry', () => {
+    const { dir, file } = tempToolsJson([]);
+    try {
+      const r = listToolSpecsFromFile(file);
+      expect(r.tools_count).toBe(0);
+      expect(r.tools).toHaveLength(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns summary entries without exposing full args', () => {
+    const { dir, file } = tempToolsJson([GOOD_NODE_SPEC]);
+    try {
+      const r = listToolSpecsFromFile(file);
+      expect(r.tools_count).toBe(1);
+      expect(r.tools[0]!.name).toBe('demo-tool');
+      // summary entries should not include full args
+      expect('args' in r.tools[0]!).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('description_head is the first sentence, capped at 80 chars', () => {
+    const spec: ToolSpec = {
+      ...GOOD_NODE_SPEC,
+      name: 'long-desc-tool',
+      description: 'First sentence. This is the rest.',
+    };
+    const { dir, file } = tempToolsJson([spec]);
+    try {
+      const r = listToolSpecsFromFile(file);
+      expect(r.tools[0]!.description_head).toBe('First sentence');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── unregisterToolSpecInFile ─────────────────────────────────────────────────
+
+describe('unregisterToolSpecInFile', () => {
+  it('removes an existing tool', () => {
+    const { dir, file } = tempToolsJson([GOOD_NODE_SPEC]);
+    try {
+      const r = unregisterToolSpecInFile('demo-tool', file);
+      expect(r.ok).toBe(true);
+      expect(r.tools_count_after).toBe(0);
+      const written = JSON.parse(fs.readFileSync(file, 'utf8')) as ToolSpec[];
+      expect(written).toHaveLength(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns ok=false for a name that does not exist', () => {
+    const { dir, file } = tempToolsJson([GOOD_NODE_SPEC]);
+    try {
+      const r = unregisterToolSpecInFile('does-not-exist', file);
+      expect(r.ok).toBe(false);
+      expect(r.error).toMatch(/not found/);
+      // original entry untouched
+      const written = JSON.parse(fs.readFileSync(file, 'utf8')) as ToolSpec[];
+      expect(written).toHaveLength(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write to disk on failed unregister', () => {
+    const { dir, file } = tempToolsJson([GOOD_NODE_SPEC]);
+    try {
+      const mtimeBefore = fs.statSync(file).mtimeMs;
+      unregisterToolSpecInFile('phantom-tool', file);
+      const mtimeAfter = fs.statSync(file).mtimeMs;
+      // mtime should not change — no write occurred
+      expect(mtimeAfter).toBe(mtimeBefore);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `tool-factory.ts` — self-registration surface for CliTools: validate `ToolSpec` (kebab name, description, `python`/`node` command, `{task}`-placeholder args, optional `patentSurface`), pre-registration file/import verification, and atomic `tools.json` read/write via temp-file rename
- Exports via `index.ts`: `validateToolSpec`, `verifyToolSpec`, `registerToolSpecInFile`, `unregisterToolSpecInFile`, `listToolSpecsFromFile`, all types, `ALLOWED_COMMANDS`, `KNOWN_PATENT_SURFACES`
- 39 tests focused on rejection gates: unknown keys, bad name format, missing `{task}` placeholder, non-existent scripts, duplicate registration, no `.tmp` left behind

## Test plan

- [ ] `npx vitest run tests/tool-factory.test.ts` → 39 passed
- [ ] `npm run build` → clean compile
- [ ] `npm run format:check` → all files pass
- [ ] `npm test` → full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)