### PR TITLE
feat(agent-bus): add KeeperAgent — maintenance daemon for station upkeep

### DIFF
--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -2166,3 +2166,21 @@ export {
   summarizeStation,
   reportDamage,
 } from './station-manifest.js';
+
+export {
+  type KeeperConfig,
+  type KeeperEscalation,
+  type KeeperAgent,
+  type KeeperRepairResult,
+  type KeeperRunResult,
+  type KeeperStatus,
+  createKeeper,
+  queueRepair,
+  clearRepairQueue,
+  escalate as escalateToKeeper,
+  resolveEscalation,
+  applyRepair as applyKeeperRepair,
+  drainRepairQueue,
+  runSweep,
+  getKeeperStatus,
+} from './keeper-agent.js';

--- a/packages/agent-bus/src/keeper-agent.ts
+++ b/packages/agent-bus/src/keeper-agent.ts
@@ -1,0 +1,386 @@
+/**
+ * @file keeper-agent.ts
+ * @module agent-bus/keeper-agent
+ * @layer Cross-layer maintenance
+ * @component KeeperAgent — low-permission background daemon for station upkeep
+ *
+ * Keepers run periodic sweeps of the StationManifest, apply safe repairs
+ * autonomously, and escalate anything requiring higher authority. They
+ * operate in the 'keeper' architecture lane — repair authority only, no
+ * creative or governance decisions.
+ *
+ * Repair authority matrix:
+ *   schedule_audit          → AUTO: stamp zone with generated receipt ID
+ *   evict_excess_occupants  → AUTO: trim occupants to zone.capacity
+ *   review_quarantine       → ESCALATE: requires governance clearance
+ *   add_transit_link        → ESCALATE: keeper cannot determine topology
+ *
+ * All state is immutable — every function returns new objects.
+ * KeeperAgent and all result types are JSON-serializable.
+ */
+
+import { sweepKeepers, updateZone, getZone } from './station-manifest.js';
+import type {
+  StationManifest,
+  StationZone,
+  KeeperRepairAction,
+  KeeperSweepResult,
+} from './station-manifest.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface KeeperConfig {
+  /** Sweep interval hint in milliseconds (informational; callers drive timing). */
+  sweep_interval_ms: number;
+  /** Max repairs applied per sweep before the remainder stays queued. */
+  max_repairs_per_sweep: number;
+  /** Zone staleness threshold forwarded to sweepKeepers. */
+  stale_threshold_ms: number;
+  /** When true, repairs are planned but the manifest is not modified. */
+  dry_run: boolean;
+}
+
+export interface KeeperEscalation {
+  zone_id: string;
+  action: string;
+  reason: string;
+  escalated_at: string;
+  resolved: boolean;
+}
+
+export interface KeeperAgent {
+  schema_version: 'scbe_keeper_agent_v1';
+  keeper_id: string;
+  config: KeeperConfig;
+  /** Pending repairs queued for the next drain. */
+  repair_queue: KeeperRepairAction[];
+  /** Accumulated escalations (resolved + unresolved). */
+  escalation_log: KeeperEscalation[];
+  /** ISO timestamp of most recent sweep. */
+  last_sweep?: string;
+  total_sweeps: number;
+  total_repairs_applied: number;
+  total_escalations: number;
+}
+
+export interface KeeperRepairResult {
+  action: KeeperRepairAction;
+  applied: boolean;
+  skipped: boolean;
+  skip_reason?: string;
+  dry_run: boolean;
+}
+
+export interface KeeperRunResult {
+  schema_version: 'scbe_keeper_run_v1';
+  keeper_id: string;
+  run_at: string;
+  sweep: KeeperSweepResult;
+  repairs: KeeperRepairResult[];
+  new_escalations: KeeperEscalation[];
+  zones_repaired: number;
+  zones_escalated: number;
+  dry_run: boolean;
+}
+
+// ─── Repair classification ────────────────────────────────────────────────────
+
+/** Actions the keeper can apply automatically without escalation. */
+const AUTO_REPAIRABLE = new Set<string>(['schedule_audit', 'evict_excess_occupants']);
+
+/** Actions that require escalation — keeper cannot safely resolve alone. */
+const MUST_ESCALATE = new Set<string>(['review_quarantine', 'add_transit_link']);
+
+function escalationReason(action: string): string {
+  if (action === 'review_quarantine') return 'quarantine_review_requires_governance_clearance';
+  if (action === 'add_transit_link') return 'transit_topology_change_requires_station_authority';
+  return 'unknown_action';
+}
+
+// ─── Lifecycle ────────────────────────────────────────────────────────────────
+
+export function createKeeper(keeperId: string, opts: Partial<KeeperConfig> = {}): KeeperAgent {
+  return {
+    schema_version: 'scbe_keeper_agent_v1',
+    keeper_id: keeperId,
+    config: {
+      sweep_interval_ms: opts.sweep_interval_ms ?? 300_000, // 5 min default
+      max_repairs_per_sweep: opts.max_repairs_per_sweep ?? 20,
+      stale_threshold_ms: opts.stale_threshold_ms ?? 86_400_000, // 24 h
+      dry_run: opts.dry_run ?? false,
+    },
+    repair_queue: [],
+    escalation_log: [],
+    total_sweeps: 0,
+    total_repairs_applied: 0,
+    total_escalations: 0,
+  };
+}
+
+// ─── Repair queue ─────────────────────────────────────────────────────────────
+
+/** Enqueue a repair action. Returns new KeeperAgent (immutable). */
+export function queueRepair(keeper: KeeperAgent, action: KeeperRepairAction): KeeperAgent {
+  return { ...keeper, repair_queue: [...keeper.repair_queue, action] };
+}
+
+/** Clear all queued repairs without applying them. */
+export function clearRepairQueue(keeper: KeeperAgent): KeeperAgent {
+  return { ...keeper, repair_queue: [] };
+}
+
+// ─── Escalation ───────────────────────────────────────────────────────────────
+
+export function escalate(
+  keeper: KeeperAgent,
+  zoneId: string,
+  action: string,
+  reason: string,
+  opts: { now?: string } = {}
+): KeeperAgent {
+  const now = opts.now ?? new Date().toISOString();
+  const entry: KeeperEscalation = {
+    zone_id: zoneId,
+    action,
+    reason,
+    escalated_at: now,
+    resolved: false,
+  };
+  return {
+    ...keeper,
+    escalation_log: [...keeper.escalation_log, entry],
+    total_escalations: keeper.total_escalations + 1,
+  };
+}
+
+export function resolveEscalation(
+  keeper: KeeperAgent,
+  zoneId: string,
+  action: string
+): KeeperAgent {
+  const escalation_log = keeper.escalation_log.map((e) =>
+    e.zone_id === zoneId && e.action === action && !e.resolved ? { ...e, resolved: true } : e
+  );
+  return { ...keeper, escalation_log };
+}
+
+// ─── Single repair application ────────────────────────────────────────────────
+
+function generateReceiptId(keeperId: string, zoneId: string, now: string): string {
+  const ts = new Date(now).getTime().toString(36);
+  return `rcpt-${keeperId.slice(0, 8)}-${zoneId.slice(0, 8)}-${ts}`;
+}
+
+/**
+ * Apply one repair action to the manifest.
+ *
+ * Returns updated keeper, manifest, and a result record.
+ * If dry_run (from action override or keeper config), manifest is unchanged.
+ */
+export function applyRepair(
+  keeper: KeeperAgent,
+  manifest: StationManifest,
+  action: KeeperRepairAction,
+  opts: { now?: string; dry_run?: boolean } = {}
+): { keeper: KeeperAgent; manifest: StationManifest; result: KeeperRepairResult } {
+  const now = opts.now ?? new Date().toISOString();
+  const isDryRun = opts.dry_run ?? keeper.config.dry_run;
+
+  // Actions requiring escalation are never applied
+  if (MUST_ESCALATE.has(action.action)) {
+    const reason = escalationReason(action.action);
+    const updatedKeeper = escalate(keeper, action.zone_id, action.action, reason, { now });
+    return {
+      keeper: updatedKeeper,
+      manifest,
+      result: { action, applied: false, skipped: true, skip_reason: reason, dry_run: isDryRun },
+    };
+  }
+
+  // Unknown actions are skipped with a note
+  if (!AUTO_REPAIRABLE.has(action.action)) {
+    return {
+      keeper,
+      manifest,
+      result: {
+        action,
+        applied: false,
+        skipped: true,
+        skip_reason: 'unknown_repair_action',
+        dry_run: isDryRun,
+      },
+    };
+  }
+
+  // Dry run: plan the repair but don't mutate
+  if (isDryRun) {
+    return {
+      keeper,
+      manifest,
+      result: { action, applied: false, skipped: false, dry_run: true },
+    };
+  }
+
+  // Apply the repair
+  let updatedManifest = manifest;
+  let applied = false;
+
+  if (action.action === 'schedule_audit') {
+    const zone = getZone(manifest, action.zone_id);
+    if (zone) {
+      const receiptId = generateReceiptId(keeper.keeper_id, action.zone_id, now);
+      const updatedZone: StationZone = {
+        ...zone,
+        audit_receipt: receiptId,
+        updated_at: now,
+      };
+      updatedManifest = updateZone(manifest, updatedZone, { now });
+      applied = true;
+    }
+  } else if (action.action === 'evict_excess_occupants') {
+    const zone = getZone(manifest, action.zone_id);
+    if (zone && zone.occupants.length > zone.capacity) {
+      const updatedZone: StationZone = {
+        ...zone,
+        // Evict from the tail — oldest occupants first (FIFO assumption)
+        occupants: zone.occupants.slice(0, zone.capacity),
+        updated_at: now,
+      };
+      updatedManifest = updateZone(manifest, updatedZone, { now });
+      applied = true;
+    }
+  }
+
+  const updatedKeeper: KeeperAgent = applied
+    ? { ...keeper, total_repairs_applied: keeper.total_repairs_applied + 1 }
+    : keeper;
+
+  return {
+    keeper: updatedKeeper,
+    manifest: updatedManifest,
+    result: { action, applied, skipped: !applied, dry_run: false },
+  };
+}
+
+// ─── Drain repair queue ───────────────────────────────────────────────────────
+
+/**
+ * Apply all queued repairs in order, up to config.max_repairs_per_sweep.
+ * Returns updated keeper (queue drained), updated manifest, and results.
+ */
+export function drainRepairQueue(
+  keeper: KeeperAgent,
+  manifest: StationManifest,
+  opts: { now?: string; dry_run?: boolean } = {}
+): { keeper: KeeperAgent; manifest: StationManifest; results: KeeperRepairResult[] } {
+  const now = opts.now ?? new Date().toISOString();
+  const isDryRun = opts.dry_run ?? keeper.config.dry_run;
+  const limit = keeper.config.max_repairs_per_sweep;
+
+  let currentKeeper = keeper;
+  let currentManifest = manifest;
+  const results: KeeperRepairResult[] = [];
+
+  const toApply = keeper.repair_queue.slice(0, limit);
+  const remaining = keeper.repair_queue.slice(limit);
+
+  for (const action of toApply) {
+    const out = applyRepair(currentKeeper, currentManifest, action, { now, dry_run: isDryRun });
+    currentKeeper = out.keeper;
+    currentManifest = out.manifest;
+    results.push(out.result);
+  }
+
+  // Replace queue with any that didn't fit the limit
+  currentKeeper = { ...currentKeeper, repair_queue: remaining };
+
+  return { keeper: currentKeeper, manifest: currentManifest, results };
+}
+
+// ─── Full sweep cycle ─────────────────────────────────────────────────────────
+
+/**
+ * Run a complete sweep-and-repair cycle:
+ *   1. Call sweepKeepers on the manifest
+ *   2. Convert sweep.repair_actions into the repair queue
+ *   3. Drain the queue (up to max_repairs_per_sweep)
+ *   4. Any sweep escalations that remain in the queue become keeper escalations
+ *   5. Return updated keeper, manifest, and full run result
+ */
+export function runSweep(
+  keeper: KeeperAgent,
+  manifest: StationManifest,
+  opts: { now?: string; dry_run?: boolean } = {}
+): { keeper: KeeperAgent; manifest: StationManifest; result: KeeperRunResult } {
+  const now = opts.now ?? new Date().toISOString();
+  const isDryRun = opts.dry_run ?? keeper.config.dry_run;
+
+  const sweep = sweepKeepers(manifest, {
+    stale_threshold_ms: keeper.config.stale_threshold_ms,
+    now,
+  });
+
+  // Load sweep actions into the queue (replace any pre-existing queue for this cycle)
+  let currentKeeper: KeeperAgent = { ...keeper, repair_queue: sweep.repair_actions };
+
+  // Drain
+  const {
+    keeper: afterDrain,
+    manifest: updatedManifest,
+    results,
+  } = drainRepairQueue(currentKeeper, manifest, { now, dry_run: isDryRun });
+  currentKeeper = afterDrain;
+
+  // Collect new escalations produced this cycle
+  const prevEscalationCount = keeper.total_escalations;
+  const newEscalations = currentKeeper.escalation_log.slice(prevEscalationCount);
+
+  // Advance sweep stats
+  currentKeeper = {
+    ...currentKeeper,
+    last_sweep: now,
+    total_sweeps: currentKeeper.total_sweeps + 1,
+  };
+
+  const result: KeeperRunResult = {
+    schema_version: 'scbe_keeper_run_v1',
+    keeper_id: keeper.keeper_id,
+    run_at: now,
+    sweep,
+    repairs: results,
+    new_escalations: newEscalations,
+    zones_repaired: results.filter((r) => r.applied).length,
+    zones_escalated: newEscalations.length,
+    dry_run: isDryRun,
+  };
+
+  return { keeper: currentKeeper, manifest: updatedManifest, result };
+}
+
+// ─── Introspection ────────────────────────────────────────────────────────────
+
+export interface KeeperStatus {
+  schema_version: 'scbe_keeper_status_v1';
+  keeper_id: string;
+  last_sweep?: string;
+  total_sweeps: number;
+  total_repairs_applied: number;
+  total_escalations: number;
+  open_escalations: number;
+  queued_repairs: number;
+  config: KeeperConfig;
+}
+
+export function getKeeperStatus(keeper: KeeperAgent): KeeperStatus {
+  return {
+    schema_version: 'scbe_keeper_status_v1',
+    keeper_id: keeper.keeper_id,
+    last_sweep: keeper.last_sweep,
+    total_sweeps: keeper.total_sweeps,
+    total_repairs_applied: keeper.total_repairs_applied,
+    total_escalations: keeper.total_escalations,
+    open_escalations: keeper.escalation_log.filter((e) => !e.resolved).length,
+    queued_repairs: keeper.repair_queue.length,
+    config: keeper.config,
+  };
+}

--- a/packages/agent-bus/tests/keeper-agent.test.ts
+++ b/packages/agent-bus/tests/keeper-agent.test.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createKeeper,
+  queueRepair,
+  clearRepairQueue,
+  escalate,
+  resolveEscalation,
+  applyRepair,
+  drainRepairQueue,
+  runSweep,
+  getKeeperStatus,
+  type KeeperAgent,
+} from '../src/keeper-agent.js';
+import {
+  createStation,
+  addZone,
+  type StationZone,
+  defaultGravityFrame,
+} from '../src/station-manifest.js';
+import type { KeeperRepairAction } from '../src/station-manifest.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const NOW = '2026-05-30T00:00:00.000Z';
+const STALE_NOW = '2026-06-01T00:00:00.000Z';
+
+function makeZone(id: string, overrides: Partial<StationZone> = {}): StationZone {
+  return {
+    id,
+    label: `Zone ${id}`,
+    district: 'code',
+    state: 'active',
+    gravity: defaultGravityFrame(id),
+    clearance: 'none',
+    capacity: 4,
+    occupants: [],
+    linked_zones: [],
+    updated_at: NOW,
+    ...overrides,
+  };
+}
+
+function freshStation() {
+  return createStation('STATION-TEST', { now: NOW });
+}
+
+// ─── createKeeper ─────────────────────────────────────────────────────────────
+
+describe('createKeeper', () => {
+  it('produces a valid keeper agent', () => {
+    const k = createKeeper('keeper-alpha');
+    expect(k.schema_version).toBe('scbe_keeper_agent_v1');
+    expect(k.keeper_id).toBe('keeper-alpha');
+    expect(k.repair_queue).toHaveLength(0);
+    expect(k.escalation_log).toHaveLength(0);
+    expect(k.total_sweeps).toBe(0);
+    expect(k.total_repairs_applied).toBe(0);
+    expect(k.total_escalations).toBe(0);
+    expect(k.config.dry_run).toBe(false);
+  });
+
+  it('accepts config overrides', () => {
+    const k = createKeeper('k', {
+      dry_run: true,
+      max_repairs_per_sweep: 5,
+      sweep_interval_ms: 60_000,
+    });
+    expect(k.config.dry_run).toBe(true);
+    expect(k.config.max_repairs_per_sweep).toBe(5);
+    expect(k.config.sweep_interval_ms).toBe(60_000);
+  });
+});
+
+// ─── queueRepair / clearRepairQueue ──────────────────────────────────────────
+
+describe('queueRepair', () => {
+  it('appends an action to the repair queue', () => {
+    const k = createKeeper('k');
+    const action: KeeperRepairAction = { zone_id: 'z1', action: 'schedule_audit', priority: 'low' };
+    const k2 = queueRepair(k, action);
+    expect(k2.repair_queue).toHaveLength(1);
+    expect(k2.repair_queue[0]).toEqual(action);
+  });
+
+  it('is immutable — original queue unchanged', () => {
+    const k = createKeeper('k');
+    queueRepair(k, { zone_id: 'z1', action: 'schedule_audit', priority: 'low' });
+    expect(k.repair_queue).toHaveLength(0);
+  });
+});
+
+describe('clearRepairQueue', () => {
+  it('empties the queue', () => {
+    let k = createKeeper('k');
+    k = queueRepair(k, { zone_id: 'z1', action: 'schedule_audit', priority: 'low' });
+    k = clearRepairQueue(k);
+    expect(k.repair_queue).toHaveLength(0);
+  });
+});
+
+// ─── escalate / resolveEscalation ─────────────────────────────────────────────
+
+describe('escalate', () => {
+  it('appends to escalation log and increments counter', () => {
+    const k = createKeeper('k');
+    const k2 = escalate(k, 'z1', 'review_quarantine', 'quarantine_requires_governance', {
+      now: NOW,
+    });
+    expect(k2.escalation_log).toHaveLength(1);
+    expect(k2.escalation_log[0].zone_id).toBe('z1');
+    expect(k2.escalation_log[0].resolved).toBe(false);
+    expect(k2.total_escalations).toBe(1);
+  });
+
+  it('is immutable', () => {
+    const k = createKeeper('k');
+    escalate(k, 'z1', 'review_quarantine', 'reason', { now: NOW });
+    expect(k.escalation_log).toHaveLength(0);
+  });
+});
+
+describe('resolveEscalation', () => {
+  it('marks matching escalation as resolved', () => {
+    let k = createKeeper('k');
+    k = escalate(k, 'z1', 'review_quarantine', 'reason', { now: NOW });
+    k = resolveEscalation(k, 'z1', 'review_quarantine');
+    expect(k.escalation_log[0].resolved).toBe(true);
+  });
+
+  it('does not resolve different actions', () => {
+    let k = createKeeper('k');
+    k = escalate(k, 'z1', 'review_quarantine', 'reason', { now: NOW });
+    k = resolveEscalation(k, 'z1', 'add_transit_link');
+    expect(k.escalation_log[0].resolved).toBe(false);
+  });
+});
+
+// ─── applyRepair ──────────────────────────────────────────────────────────────
+
+describe('applyRepair — schedule_audit', () => {
+  it('stamps zone with a receipt ID and marks applied', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1', { updated_at: NOW }), { now: NOW });
+    const k = createKeeper('k');
+    const action: KeeperRepairAction = {
+      zone_id: 'z1',
+      action: 'schedule_audit',
+      priority: 'medium',
+    };
+    const { keeper: k2, manifest: m2, result } = applyRepair(k, m, action, { now: NOW });
+    expect(result.applied).toBe(true);
+    expect(result.skipped).toBe(false);
+    expect(m2.zones['z1'].audit_receipt).toBeTruthy();
+    expect(k2.total_repairs_applied).toBe(1);
+  });
+
+  it('does not mutate on dry_run', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1'), { now: NOW });
+    const k = createKeeper('k', { dry_run: true });
+    const action: KeeperRepairAction = {
+      zone_id: 'z1',
+      action: 'schedule_audit',
+      priority: 'medium',
+    };
+    const { manifest: m2, result } = applyRepair(k, m, action, { now: NOW });
+    expect(result.applied).toBe(false);
+    expect(result.dry_run).toBe(true);
+    expect(m2.zones['z1'].audit_receipt).toBeUndefined();
+  });
+
+  it('skips if zone does not exist', () => {
+    const m = freshStation();
+    const k = createKeeper('k');
+    const action: KeeperRepairAction = {
+      zone_id: 'ghost',
+      action: 'schedule_audit',
+      priority: 'low',
+    };
+    const { result } = applyRepair(k, m, action, { now: NOW });
+    expect(result.applied).toBe(false);
+    expect(result.skipped).toBe(true);
+  });
+});
+
+describe('applyRepair — evict_excess_occupants', () => {
+  it('trims occupants to capacity', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1', { capacity: 2, occupants: ['a', 'b', 'c', 'd'] }), { now: NOW });
+    const k = createKeeper('k');
+    const action: KeeperRepairAction = {
+      zone_id: 'z1',
+      action: 'evict_excess_occupants',
+      priority: 'medium',
+    };
+    const { manifest: m2, result } = applyRepair(k, m, action, { now: NOW });
+    expect(result.applied).toBe(true);
+    expect(m2.zones['z1'].occupants).toHaveLength(2);
+    expect(m2.zones['z1'].occupants).toEqual(['a', 'b']);
+  });
+
+  it('no-ops when occupants <= capacity', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1', { capacity: 4, occupants: ['a'] }), { now: NOW });
+    const k = createKeeper('k');
+    const action: KeeperRepairAction = {
+      zone_id: 'z1',
+      action: 'evict_excess_occupants',
+      priority: 'low',
+    };
+    const { manifest: m2, result } = applyRepair(k, m, action, { now: NOW });
+    expect(result.applied).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(m2.zones['z1'].occupants).toHaveLength(1);
+  });
+});
+
+describe('applyRepair — escalation-only actions', () => {
+  it('escalates review_quarantine without modifying manifest', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1', { state: 'quarantined' }), { now: NOW });
+    const k = createKeeper('k');
+    const action: KeeperRepairAction = {
+      zone_id: 'z1',
+      action: 'review_quarantine',
+      priority: 'high',
+    };
+    const { keeper: k2, manifest: m2, result } = applyRepair(k, m, action, { now: NOW });
+    expect(result.applied).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(k2.total_escalations).toBe(1);
+    expect(m2.zones['z1'].state).toBe('quarantined'); // untouched
+  });
+
+  it('escalates add_transit_link', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1'), { now: NOW });
+    const k = createKeeper('k');
+    const action: KeeperRepairAction = {
+      zone_id: 'z1',
+      action: 'add_transit_link',
+      priority: 'low',
+    };
+    const { keeper: k2, result } = applyRepair(k, m, action, { now: NOW });
+    expect(result.applied).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(k2.escalation_log[0].action).toBe('add_transit_link');
+  });
+
+  it('skips unknown action with note', () => {
+    const m = freshStation();
+    const k = createKeeper('k');
+    const action: KeeperRepairAction = {
+      zone_id: 'z1',
+      action: 'warp_reality' as string,
+      priority: 'low',
+    };
+    const { result } = applyRepair(k, m, action, { now: NOW });
+    expect(result.applied).toBe(false);
+    expect(result.skip_reason).toBe('unknown_repair_action');
+  });
+});
+
+// ─── drainRepairQueue ─────────────────────────────────────────────────────────
+
+describe('drainRepairQueue', () => {
+  it('applies all queued repairs and empties the queue', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1'), { now: NOW });
+    m = addZone(m, makeZone('z2'), { now: NOW });
+
+    let k = createKeeper('k');
+    k = queueRepair(k, { zone_id: 'z1', action: 'schedule_audit', priority: 'low' });
+    k = queueRepair(k, { zone_id: 'z2', action: 'schedule_audit', priority: 'low' });
+
+    const { keeper: k2, manifest: m2, results } = drainRepairQueue(k, m, { now: NOW });
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.applied)).toBe(true);
+    expect(k2.repair_queue).toHaveLength(0);
+    expect(m2.zones['z1'].audit_receipt).toBeTruthy();
+    expect(m2.zones['z2'].audit_receipt).toBeTruthy();
+  });
+
+  it('respects max_repairs_per_sweep limit', () => {
+    let m = freshStation();
+    for (let i = 0; i < 5; i++) m = addZone(m, makeZone(`z${i}`), { now: NOW });
+
+    let k = createKeeper('k', { max_repairs_per_sweep: 2 });
+    for (let i = 0; i < 5; i++) {
+      k = queueRepair(k, { zone_id: `z${i}`, action: 'schedule_audit', priority: 'low' });
+    }
+
+    const { keeper: k2, results } = drainRepairQueue(k, m, { now: NOW });
+    expect(results).toHaveLength(2);
+    expect(k2.repair_queue).toHaveLength(3); // 3 left in queue
+  });
+});
+
+// ─── runSweep ─────────────────────────────────────────────────────────────────
+
+describe('runSweep — clean station', () => {
+  it('produces a valid run result with no repairs', () => {
+    const m = freshStation();
+    const k = createKeeper('k');
+    const { keeper: k2, result } = runSweep(k, m, { now: NOW });
+    expect(result.schema_version).toBe('scbe_keeper_run_v1');
+    expect(result.zones_repaired).toBe(0);
+    expect(result.zones_escalated).toBe(0);
+    expect(k2.total_sweeps).toBe(1);
+    expect(k2.last_sweep).toBe(NOW);
+  });
+});
+
+describe('runSweep — stale zones', () => {
+  it('stamps stale zones with audit receipts', () => {
+    let m = freshStation();
+    // Zone updated 2 days ago, no audit receipt
+    m = addZone(m, makeZone('z1', { updated_at: NOW }), { now: NOW });
+
+    const k = createKeeper('k', { stale_threshold_ms: 3_600_000 }); // 1-hour threshold
+    // Run sweep 2 days later → z1 is stale
+    const { manifest: m2, result } = runSweep(k, m, { now: STALE_NOW });
+
+    expect(result.zones_repaired).toBeGreaterThan(0);
+    expect(m2.zones['z1'].audit_receipt).toBeTruthy();
+  });
+});
+
+describe('runSweep — overcrowded zones', () => {
+  it('evicts excess occupants', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1', { capacity: 2, occupants: ['a', 'b', 'c'] }), { now: NOW });
+
+    const k = createKeeper('k');
+    const { manifest: m2, result } = runSweep(k, m, { now: NOW });
+
+    expect(result.zones_repaired).toBe(1);
+    expect(m2.zones['z1'].occupants).toHaveLength(2);
+  });
+});
+
+describe('runSweep — quarantined zones', () => {
+  it('escalates quarantined zones without repairing them', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1', { state: 'quarantined' }), { now: NOW });
+
+    const k = createKeeper('k');
+    const { keeper: k2, manifest: m2, result } = runSweep(k, m, { now: NOW });
+
+    expect(result.zones_escalated).toBeGreaterThan(0);
+    expect(m2.zones['z1'].state).toBe('quarantined'); // not repaired
+    expect(k2.total_escalations).toBeGreaterThan(0);
+  });
+});
+
+describe('runSweep — unroutable zones', () => {
+  it('escalates unroutable active zones', () => {
+    let m = freshStation();
+    // Active zone with no links and no transit nodes
+    m = addZone(m, makeZone('z1', { linked_zones: [], state: 'active' }), { now: NOW });
+
+    const k = createKeeper('k');
+    const { result } = runSweep(k, m, { now: NOW });
+
+    expect(result.zones_escalated).toBeGreaterThan(0);
+  });
+});
+
+describe('runSweep — dry_run', () => {
+  it('plans repairs but does not modify manifest', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1', { capacity: 1, occupants: ['a', 'b'] }), { now: NOW });
+
+    const k = createKeeper('k', { dry_run: true });
+    const { manifest: m2, result } = runSweep(k, m, { now: NOW });
+
+    expect(result.dry_run).toBe(true);
+    expect(result.zones_repaired).toBe(0); // nothing applied
+    expect(m2.zones['z1'].occupants).toHaveLength(2); // unchanged
+  });
+});
+
+describe('runSweep — counters accumulate across sweeps', () => {
+  it('increments total_sweeps on each call', () => {
+    let m = freshStation();
+    m = addZone(m, makeZone('z1'), { now: NOW });
+    let k = createKeeper('k');
+    ({ keeper: k } = runSweep(k, m, { now: NOW }));
+    ({ keeper: k } = runSweep(k, m, { now: NOW }));
+    ({ keeper: k } = runSweep(k, m, { now: NOW }));
+    expect(k.total_sweeps).toBe(3);
+  });
+});
+
+// ─── getKeeperStatus ──────────────────────────────────────────────────────────
+
+describe('getKeeperStatus', () => {
+  it('returns correct status fields', () => {
+    let k = createKeeper('k');
+    k = escalate(k, 'z1', 'review_quarantine', 'reason', { now: NOW });
+    k = queueRepair(k, { zone_id: 'z2', action: 'schedule_audit', priority: 'low' });
+
+    const status = getKeeperStatus(k);
+    expect(status.schema_version).toBe('scbe_keeper_status_v1');
+    expect(status.keeper_id).toBe('k');
+    expect(status.open_escalations).toBe(1);
+    expect(status.queued_repairs).toBe(1);
+    expect(status.total_escalations).toBe(1);
+  });
+
+  it('open_escalations decrements after resolve', () => {
+    let k = createKeeper('k');
+    k = escalate(k, 'z1', 'review_quarantine', 'reason', { now: NOW });
+    k = resolveEscalation(k, 'z1', 'review_quarantine');
+    expect(getKeeperStatus(k).open_escalations).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `keeper-agent.ts`: low-permission background daemon that sweeps `StationManifest` and applies safe repairs autonomously
- Repair authority matrix: `schedule_audit` + `evict_excess_occupants` → AUTO apply; `review_quarantine` + `add_transit_link` → ESCALATE
- `dry_run` mode plans repairs without touching the manifest
- 28 new tests, 586 total passing

## Key exports

| Function | Purpose |
|----------|---------|
| `createKeeper` | Create keeper with config |
| `applyRepair` | Apply one repair action (or escalate) |
| `drainRepairQueue` | Bulk drain up to `max_repairs_per_sweep` |
| `runSweep` | Full sweep-and-repair cycle using `sweepKeepers` |
| `escalate` / `resolveEscalation` | Escalation log management |
| `getKeeperStatus` | Serializable status snapshot |

## Test plan

- [x] `createKeeper`: schema, defaults, config overrides
- [x] `queueRepair` / `clearRepairQueue`: immutability
- [x] `escalate` / `resolveEscalation`: log append, selective resolve
- [x] `applyRepair` — `schedule_audit`: stamps zone, dry_run no-op, missing zone skip
- [x] `applyRepair` — `evict_excess_occupants`: trims to capacity, no-op when within limit
- [x] `applyRepair` — escalation-only: `review_quarantine` + `add_transit_link` never modify manifest
- [x] `applyRepair` — unknown action: skipped with reason
- [x] `drainRepairQueue`: applies all, respects `max_repairs_per_sweep` limit, leaves remainder
- [x] `runSweep`: clean station, stale zones repaired, overcrowded evicted, quarantined escalated, dry_run, counter accumulation

Generated with Claude Code