### PR TITLE
feat(agent-bus): add PollyBrief — operator brief renderer

### DIFF
--- a/packages/agent-bus/src/eva.ts
+++ b/packages/agent-bus/src/eva.ts
@@ -1,0 +1,337 @@
+/**
+ * @file eva.ts
+ * @module agent-bus/eva
+ * @layer Operator interface
+ * @component EVA - station status narrator and CLI brief renderer
+ *
+ * EVA is deliberately read-only. It does not repair, route, execute, or mutate
+ * station state. It turns StationManifest, KeeperSweepResult/KeeperRunResult,
+ * and DamageReport records into structured operator briefs plus stable CLI text.
+ */
+
+import { reportDamage, summarizeStation } from './station-manifest.js';
+import type {
+  DamageReport,
+  HealthColor,
+  KeeperSweepResult,
+  StationManifest,
+  StationSummary,
+} from './station-manifest.js';
+import type { KeeperRunResult, KeeperStatus } from './keeper-agent.js';
+
+export type EvaMode = 'status' | 'watch' | 'damage' | 'handoff';
+
+export type EvaSeverity = 'info' | 'notice' | 'warning' | 'critical';
+
+export interface EvaAlert {
+  id: string;
+  severity: EvaSeverity;
+  source: 'station' | 'keeper' | 'damage';
+  title: string;
+  detail: string;
+  zone_ids: string[];
+}
+
+export interface EvaAction {
+  id: string;
+  priority: EvaSeverity;
+  command: string;
+  reason: string;
+  requires_human: boolean;
+}
+
+export interface EvaBrief {
+  schema_version: 'scbe_eva_brief_v1';
+  station_id: string;
+  generated_at: string;
+  mode: EvaMode;
+  health: HealthColor;
+  headline: string;
+  summary: StationSummary;
+  damage: DamageReport;
+  keeper?: {
+    keeper_id?: string;
+    last_sweep?: string;
+    zones_repaired: number;
+    zones_escalated: number;
+    open_escalations?: number;
+    queued_repairs?: number;
+  };
+  alerts: EvaAlert[];
+  actions: EvaAction[];
+  cli_lines: string[];
+}
+
+export interface EvaBriefOptions {
+  now?: string;
+  mode?: EvaMode;
+  sweep?: KeeperSweepResult;
+  keeperRun?: KeeperRunResult;
+  keeperStatus?: KeeperStatus;
+  damage?: DamageReport;
+  maxAlerts?: number;
+  maxActions?: number;
+}
+
+const SEVERITY_RANK: Record<EvaSeverity, number> = {
+  info: 0,
+  notice: 1,
+  warning: 2,
+  critical: 3,
+};
+
+const HEALTH_TO_SEVERITY: Record<HealthColor, EvaSeverity> = {
+  green: 'info',
+  amber: 'notice',
+  red: 'warning',
+  critical: 'critical',
+};
+
+function sortBySeverity<T extends { priority?: EvaSeverity; severity?: EvaSeverity; id: string }>(
+  items: T[]
+): T[] {
+  return [...items].sort((a, b) => {
+    const sa = a.priority ?? a.severity ?? 'info';
+    const sb = b.priority ?? b.severity ?? 'info';
+    const delta = SEVERITY_RANK[sb] - SEVERITY_RANK[sa];
+    return delta === 0 ? a.id.localeCompare(b.id) : delta;
+  });
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+export function buildEvaAlerts(
+  summary: StationSummary,
+  damage: DamageReport,
+  sweep?: KeeperSweepResult,
+  keeperRun?: KeeperRunResult
+): EvaAlert[] {
+  const alerts: EvaAlert[] = [];
+
+  if (damage.overall_health !== 'green') {
+    alerts.push({
+      id: 'damage.overall-health',
+      severity: HEALTH_TO_SEVERITY[damage.overall_health],
+      source: 'damage',
+      title: `station health ${damage.overall_health}`,
+      detail: `${damage.critical_zones.length} critical zone(s), ${damage.isolated_zones.length} isolated zone(s), ${damage.security_breaches.length} security breach(es)`,
+      zone_ids: unique([...damage.critical_zones, ...damage.isolated_zones]),
+    });
+  }
+
+  if (damage.security_breaches.length > 0) {
+    alerts.push({
+      id: 'damage.security-breaches',
+      severity: 'critical',
+      source: 'damage',
+      title: 'security boundary conflict',
+      detail: `${damage.security_breaches.length} clearance/boundary conflict(s) detected`,
+      zone_ids: [],
+    });
+  }
+
+  if (summary.fog_of_war_count > 0) {
+    alerts.push({
+      id: 'station.fog-of-war',
+      severity: 'notice',
+      source: 'station',
+      title: 'fog of war remains',
+      detail: `${summary.fog_of_war_count} zone(s) have not been observed`,
+      zone_ids: [],
+    });
+  }
+
+  const activeSweep = keeperRun?.sweep ?? sweep;
+  if (activeSweep && activeSweep.escalations.length > 0) {
+    alerts.push({
+      id: 'keeper.escalations',
+      severity: 'warning',
+      source: 'keeper',
+      title: 'keeper escalation required',
+      detail: `${activeSweep.escalations.length} zone(s) need operator or governance review`,
+      zone_ids: activeSweep.escalations,
+    });
+  }
+
+  if (keeperRun && keeperRun.zones_repaired > 0) {
+    alerts.push({
+      id: 'keeper.repairs-applied',
+      severity: 'info',
+      source: 'keeper',
+      title: 'keeper repairs applied',
+      detail: `${keeperRun.zones_repaired} zone(s) repaired this sweep`,
+      zone_ids: keeperRun.repairs.filter((r) => r.applied).map((r) => r.action.zone_id),
+    });
+  }
+
+  return sortBySeverity(alerts);
+}
+
+export function buildEvaActions(
+  summary: StationSummary,
+  damage: DamageReport,
+  sweep?: KeeperSweepResult,
+  keeperRun?: KeeperRunResult
+): EvaAction[] {
+  const actions: EvaAction[] = [];
+  const activeSweep = keeperRun?.sweep ?? sweep;
+
+  if (damage.security_breaches.length > 0) {
+    actions.push({
+      id: 'action.security-review',
+      priority: 'critical',
+      command: 'scbe station damage --review-security',
+      reason: 'security boundary conflicts require operator review before further execution',
+      requires_human: true,
+    });
+  }
+
+  if (damage.critical_zones.length > 0) {
+    actions.push({
+      id: 'action.inspect-critical-zones',
+      priority: 'warning',
+      command: `scbe station inspect --zones ${damage.critical_zones.join(',')}`,
+      reason: 'critical zones are quarantined or offline',
+      requires_human: true,
+    });
+  }
+
+  if (activeSweep && activeSweep.repair_actions.length > 0) {
+    actions.push({
+      id: 'action.keeper-sweep',
+      priority: activeSweep.escalations.length > 0 ? 'warning' : 'notice',
+      command: 'scbe keeper sweep --dry-run',
+      reason: `${activeSweep.repair_actions.length} keeper repair action(s) are available`,
+      requires_human: false,
+    });
+  }
+
+  if (damage.isolated_zones.length > 0) {
+    actions.push({
+      id: 'action.add-transit',
+      priority: 'notice',
+      command: `scbe station transit plan --repair ${damage.isolated_zones.join(',')}`,
+      reason: 'isolated active zones reduce route reliability',
+      requires_human: true,
+    });
+  }
+
+  if (summary.fog_of_war_count > 0) {
+    actions.push({
+      id: 'action.observe-fog',
+      priority: 'info',
+      command: 'scbe station observe --fog',
+      reason: 'unobserved zones reduce operator confidence',
+      requires_human: false,
+    });
+  }
+
+  if (actions.length === 0) {
+    actions.push({
+      id: 'action.hold-green',
+      priority: 'info',
+      command: 'scbe eva watch',
+      reason: 'station is green; continue passive watch',
+      requires_human: false,
+    });
+  }
+
+  return sortBySeverity(actions);
+}
+
+export function buildEvaHeadline(
+  summary: StationSummary,
+  damage: DamageReport,
+  alerts: EvaAlert[]
+): string {
+  if (damage.overall_health === 'critical') {
+    return `Critical station damage: ${damage.critical_zones.length} critical zone(s)`;
+  }
+  if (damage.overall_health === 'red') {
+    return `Station needs review: ${damage.critical_zones.length} critical zone(s), ${damage.security_breaches.length} security conflict(s)`;
+  }
+  if (alerts.some((a) => a.severity === 'warning')) {
+    return `Station is operational with ${alerts.filter((a) => a.severity === 'warning').length} warning(s)`;
+  }
+  if (summary.fog_of_war_count > 0) {
+    return `Station is operational; ${summary.fog_of_war_count} zone(s) remain unobserved`;
+  }
+  return `Station ${summary.station_id} is green`;
+}
+
+export function renderEvaCliLines(brief: Omit<EvaBrief, 'cli_lines'>): string[] {
+  const lines = [
+    `EVA ${brief.mode}: ${brief.headline}`,
+    `health=${brief.health} zones=${brief.summary.total_zones} active=${brief.summary.active_zones} docked=${brief.summary.total_agents_docked} routes=${brief.summary.available_routes}`,
+  ];
+
+  if (brief.keeper) {
+    lines.push(
+      `keeper=${brief.keeper.keeper_id ?? 'unknown'} repaired=${brief.keeper.zones_repaired} escalated=${brief.keeper.zones_escalated} open=${brief.keeper.open_escalations ?? 0} queued=${brief.keeper.queued_repairs ?? 0}`
+    );
+  }
+
+  if (brief.alerts.length > 0) {
+    lines.push('alerts:');
+    for (const alert of brief.alerts) {
+      const zones = alert.zone_ids.length > 0 ? ` zones=${alert.zone_ids.join(',')}` : '';
+      lines.push(`- [${alert.severity}] ${alert.title}: ${alert.detail}${zones}`);
+    }
+  }
+
+  lines.push('next:');
+  for (const action of brief.actions) {
+    const gate = action.requires_human ? 'human' : 'auto';
+    lines.push(`- [${action.priority}/${gate}] ${action.command} # ${action.reason}`);
+  }
+
+  return lines;
+}
+
+export function buildEvaBrief(manifest: StationManifest, opts: EvaBriefOptions = {}): EvaBrief {
+  const now = opts.now ?? new Date().toISOString();
+  const mode = opts.mode ?? 'status';
+  const sweep = opts.keeperRun?.sweep ?? opts.sweep;
+  const summary = summarizeStation(manifest, sweep, { now });
+  const damage = opts.damage ?? reportDamage(manifest, { now });
+  const maxAlerts = opts.maxAlerts ?? 8;
+  const maxActions = opts.maxActions ?? 6;
+
+  const alerts = buildEvaAlerts(summary, damage, sweep, opts.keeperRun).slice(0, maxAlerts);
+  const actions = buildEvaActions(summary, damage, sweep, opts.keeperRun).slice(0, maxActions);
+  const headline = buildEvaHeadline(summary, damage, alerts);
+
+  const keeper =
+    opts.keeperRun || opts.keeperStatus
+      ? {
+          keeper_id: opts.keeperRun?.keeper_id ?? opts.keeperStatus?.keeper_id,
+          last_sweep: opts.keeperRun?.run_at ?? opts.keeperStatus?.last_sweep,
+          zones_repaired: opts.keeperRun?.zones_repaired ?? 0,
+          zones_escalated: opts.keeperRun?.zones_escalated ?? 0,
+          open_escalations: opts.keeperStatus?.open_escalations,
+          queued_repairs: opts.keeperStatus?.queued_repairs,
+        }
+      : undefined;
+
+  const partial: Omit<EvaBrief, 'cli_lines'> = {
+    schema_version: 'scbe_eva_brief_v1',
+    station_id: manifest.station_id,
+    generated_at: now,
+    mode,
+    health: damage.overall_health,
+    headline,
+    summary,
+    damage,
+    keeper,
+    alerts,
+    actions,
+  };
+
+  return { ...partial, cli_lines: renderEvaCliLines(partial) };
+}
+
+export function renderEvaBrief(brief: EvaBrief): string {
+  return brief.cli_lines.join('\n');
+}

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -2219,3 +2219,18 @@ export {
   toFlightView,
   toDrivingView,
 } from './control-intent.js';
+
+export {
+  type EvaMode,
+  type EvaSeverity,
+  type EvaAlert,
+  type EvaAction,
+  type EvaBrief,
+  type EvaBriefOptions,
+  buildEvaAlerts,
+  buildEvaActions,
+  buildEvaHeadline,
+  renderEvaCliLines,
+  buildEvaBrief,
+  renderEvaBrief,
+} from './eva.js';

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -2221,6 +2221,19 @@ export {
 } from './control-intent.js';
 
 export {
+  type PollyBriefMode,
+  type PollyBriefSeverity,
+  type PollyAlert,
+  type PollyAction,
+  type PollyBrief,
+  type PollyBriefOptions,
+  buildPollyAlerts,
+  buildPollyActions,
+  buildPollyHeadline,
+  renderPollyCliLines,
+  buildPollyBrief,
+  renderPollyBrief,
+  // EVA compatibility aliases
   type EvaMode,
   type EvaSeverity,
   type EvaAlert,
@@ -2233,4 +2246,4 @@ export {
   renderEvaCliLines,
   buildEvaBrief,
   renderEvaBrief,
-} from './eva.js';
+} from './polly-brief.js';

--- a/packages/agent-bus/src/polly-brief.ts
+++ b/packages/agent-bus/src/polly-brief.ts
@@ -1,0 +1,368 @@
+/**
+ * @file polly-brief.ts
+ * @module agent-bus/polly-brief
+ * @layer Operator interface
+ * @component Polly Brief — station status narrator and CLI brief renderer
+ *
+ * Polly is deliberately read-only. It does not repair, route, execute, or mutate
+ * station state. It turns StationManifest, KeeperSweepResult/KeeperRunResult,
+ * and DamageReport records into structured operator briefs plus stable CLI text.
+ */
+
+import { reportDamage, summarizeStation } from './station-manifest.js';
+import type {
+  DamageReport,
+  HealthColor,
+  KeeperSweepResult,
+  StationManifest,
+  StationSummary,
+} from './station-manifest.js';
+import type { KeeperRunResult, KeeperStatus } from './keeper-agent.js';
+
+export type PollyBriefMode = 'status' | 'watch' | 'damage' | 'handoff';
+
+export type PollyBriefSeverity = 'info' | 'notice' | 'warning' | 'critical';
+
+export interface PollyAlert {
+  id: string;
+  severity: PollyBriefSeverity;
+  source: 'station' | 'keeper' | 'damage';
+  title: string;
+  detail: string;
+  zone_ids: string[];
+}
+
+export interface PollyAction {
+  id: string;
+  priority: PollyBriefSeverity;
+  command: string;
+  reason: string;
+  requires_human: boolean;
+}
+
+export interface PollyBrief {
+  schema_version: 'scbe_polly_brief_v1';
+  station_id: string;
+  generated_at: string;
+  mode: PollyBriefMode;
+  health: HealthColor;
+  headline: string;
+  summary: StationSummary;
+  damage: DamageReport;
+  keeper?: {
+    keeper_id?: string;
+    last_sweep?: string;
+    zones_repaired: number;
+    zones_escalated: number;
+    open_escalations?: number;
+    queued_repairs?: number;
+  };
+  alerts: PollyAlert[];
+  actions: PollyAction[];
+  cli_lines: string[];
+}
+
+export interface PollyBriefOptions {
+  now?: string;
+  mode?: PollyBriefMode;
+  sweep?: KeeperSweepResult;
+  keeperRun?: KeeperRunResult;
+  keeperStatus?: KeeperStatus;
+  damage?: DamageReport;
+  maxAlerts?: number;
+  maxActions?: number;
+}
+
+const SEVERITY_RANK: Record<PollyBriefSeverity, number> = {
+  info: 0,
+  notice: 1,
+  warning: 2,
+  critical: 3,
+};
+
+const HEALTH_TO_SEVERITY: Record<HealthColor, PollyBriefSeverity> = {
+  green: 'info',
+  amber: 'notice',
+  red: 'warning',
+  critical: 'critical',
+};
+
+function sortBySeverity<
+  T extends { priority?: PollyBriefSeverity; severity?: PollyBriefSeverity; id: string },
+>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    const sa = a.priority ?? a.severity ?? 'info';
+    const sb = b.priority ?? b.severity ?? 'info';
+    const delta = SEVERITY_RANK[sb] - SEVERITY_RANK[sa];
+    return delta === 0 ? a.id.localeCompare(b.id) : delta;
+  });
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+export function buildPollyAlerts(
+  summary: StationSummary,
+  damage: DamageReport,
+  sweep?: KeeperSweepResult,
+  keeperRun?: KeeperRunResult
+): PollyAlert[] {
+  const alerts: PollyAlert[] = [];
+
+  if (damage.overall_health !== 'green') {
+    alerts.push({
+      id: 'damage.overall-health',
+      severity: HEALTH_TO_SEVERITY[damage.overall_health],
+      source: 'damage',
+      title: `station health ${damage.overall_health}`,
+      detail: `${damage.critical_zones.length} critical zone(s), ${damage.isolated_zones.length} isolated zone(s), ${damage.security_breaches.length} security breach(es)`,
+      zone_ids: unique([...damage.critical_zones, ...damage.isolated_zones]),
+    });
+  }
+
+  if (damage.security_breaches.length > 0) {
+    alerts.push({
+      id: 'damage.security-breaches',
+      severity: 'critical',
+      source: 'damage',
+      title: 'security boundary conflict',
+      detail: `${damage.security_breaches.length} clearance/boundary conflict(s) detected`,
+      zone_ids: [],
+    });
+  }
+
+  if (summary.fog_of_war_count > 0) {
+    alerts.push({
+      id: 'station.fog-of-war',
+      severity: 'notice',
+      source: 'station',
+      title: 'fog of war remains',
+      detail: `${summary.fog_of_war_count} zone(s) have not been observed`,
+      zone_ids: [],
+    });
+  }
+
+  const activeSweep = keeperRun?.sweep ?? sweep;
+  if (activeSweep && activeSweep.escalations.length > 0) {
+    alerts.push({
+      id: 'keeper.escalations',
+      severity: 'warning',
+      source: 'keeper',
+      title: 'keeper escalation required',
+      detail: `${activeSweep.escalations.length} zone(s) need operator or governance review`,
+      zone_ids: activeSweep.escalations,
+    });
+  }
+
+  if (keeperRun && keeperRun.zones_repaired > 0) {
+    alerts.push({
+      id: 'keeper.repairs-applied',
+      severity: 'info',
+      source: 'keeper',
+      title: 'keeper repairs applied',
+      detail: `${keeperRun.zones_repaired} zone(s) repaired this sweep`,
+      zone_ids: keeperRun.repairs.filter((r) => r.applied).map((r) => r.action.zone_id),
+    });
+  }
+
+  return sortBySeverity(alerts);
+}
+
+export function buildPollyActions(
+  summary: StationSummary,
+  damage: DamageReport,
+  sweep?: KeeperSweepResult,
+  keeperRun?: KeeperRunResult
+): PollyAction[] {
+  const actions: PollyAction[] = [];
+  const activeSweep = keeperRun?.sweep ?? sweep;
+
+  if (damage.security_breaches.length > 0) {
+    actions.push({
+      id: 'action.security-review',
+      priority: 'critical',
+      command: 'scbe station damage --review-security',
+      reason: 'security boundary conflicts require operator review before further execution',
+      requires_human: true,
+    });
+  }
+
+  if (damage.critical_zones.length > 0) {
+    actions.push({
+      id: 'action.inspect-critical-zones',
+      priority: 'warning',
+      command: `scbe station inspect --zones ${damage.critical_zones.join(',')}`,
+      reason: 'critical zones are quarantined or offline',
+      requires_human: true,
+    });
+  }
+
+  if (activeSweep && activeSweep.repair_actions.length > 0) {
+    actions.push({
+      id: 'action.keeper-sweep',
+      priority: activeSweep.escalations.length > 0 ? 'warning' : 'notice',
+      command: 'scbe keeper sweep --dry-run',
+      reason: `${activeSweep.repair_actions.length} keeper repair action(s) are available`,
+      requires_human: false,
+    });
+  }
+
+  if (damage.isolated_zones.length > 0) {
+    actions.push({
+      id: 'action.add-transit',
+      priority: 'notice',
+      command: `scbe station transit plan --repair ${damage.isolated_zones.join(',')}`,
+      reason: 'isolated active zones reduce route reliability',
+      requires_human: true,
+    });
+  }
+
+  if (summary.fog_of_war_count > 0) {
+    actions.push({
+      id: 'action.observe-fog',
+      priority: 'info',
+      command: 'scbe station observe --fog',
+      reason: 'unobserved zones reduce operator confidence',
+      requires_human: false,
+    });
+  }
+
+  if (actions.length === 0) {
+    actions.push({
+      id: 'action.hold-green',
+      priority: 'info',
+      command: 'scbe polly watch',
+      reason: 'station is green; continue passive watch',
+      requires_human: false,
+    });
+  }
+
+  return sortBySeverity(actions);
+}
+
+export function buildPollyHeadline(
+  summary: StationSummary,
+  damage: DamageReport,
+  alerts: PollyAlert[]
+): string {
+  if (damage.overall_health === 'critical') {
+    return `Critical station damage: ${damage.critical_zones.length} critical zone(s)`;
+  }
+  if (damage.overall_health === 'red') {
+    return `Station needs review: ${damage.critical_zones.length} critical zone(s), ${damage.security_breaches.length} security conflict(s)`;
+  }
+  if (alerts.some((a) => a.severity === 'warning')) {
+    return `Station is operational with ${alerts.filter((a) => a.severity === 'warning').length} warning(s)`;
+  }
+  if (summary.fog_of_war_count > 0) {
+    return `Station is operational; ${summary.fog_of_war_count} zone(s) remain unobserved`;
+  }
+  return `Station ${summary.station_id} is green`;
+}
+
+export function renderPollyCliLines(brief: Omit<PollyBrief, 'cli_lines'>): string[] {
+  const lines = [
+    `Polly ${brief.mode}: ${brief.headline}`,
+    `health=${brief.health} zones=${brief.summary.total_zones} active=${brief.summary.active_zones} docked=${brief.summary.total_agents_docked} routes=${brief.summary.available_routes}`,
+  ];
+
+  if (brief.keeper) {
+    lines.push(
+      `keeper=${brief.keeper.keeper_id ?? 'unknown'} repaired=${brief.keeper.zones_repaired} escalated=${brief.keeper.zones_escalated} open=${brief.keeper.open_escalations ?? 0} queued=${brief.keeper.queued_repairs ?? 0}`
+    );
+  }
+
+  if (brief.alerts.length > 0) {
+    lines.push('alerts:');
+    for (const alert of brief.alerts) {
+      const zones = alert.zone_ids.length > 0 ? ` zones=${alert.zone_ids.join(',')}` : '';
+      lines.push(`- [${alert.severity}] ${alert.title}: ${alert.detail}${zones}`);
+    }
+  }
+
+  lines.push('next:');
+  for (const action of brief.actions) {
+    const gate = action.requires_human ? 'human' : 'auto';
+    lines.push(`- [${action.priority}/${gate}] ${action.command} # ${action.reason}`);
+  }
+
+  return lines;
+}
+
+export function buildPollyBrief(
+  manifest: StationManifest,
+  opts: PollyBriefOptions = {}
+): PollyBrief {
+  const now = opts.now ?? new Date().toISOString();
+  const mode = opts.mode ?? 'status';
+  const sweep = opts.keeperRun?.sweep ?? opts.sweep;
+  const summary = summarizeStation(manifest, sweep, { now });
+  const damage = opts.damage ?? reportDamage(manifest, { now });
+  const maxAlerts = opts.maxAlerts ?? 8;
+  const maxActions = opts.maxActions ?? 6;
+
+  const alerts = buildPollyAlerts(summary, damage, sweep, opts.keeperRun).slice(0, maxAlerts);
+  const actions = buildPollyActions(summary, damage, sweep, opts.keeperRun).slice(0, maxActions);
+  const headline = buildPollyHeadline(summary, damage, alerts);
+
+  const keeper =
+    opts.keeperRun || opts.keeperStatus
+      ? {
+          keeper_id: opts.keeperRun?.keeper_id ?? opts.keeperStatus?.keeper_id,
+          last_sweep: opts.keeperRun?.run_at ?? opts.keeperStatus?.last_sweep,
+          zones_repaired: opts.keeperRun?.zones_repaired ?? 0,
+          zones_escalated: opts.keeperRun?.zones_escalated ?? 0,
+          open_escalations: opts.keeperStatus?.open_escalations,
+          queued_repairs: opts.keeperStatus?.queued_repairs,
+        }
+      : undefined;
+
+  const partial: Omit<PollyBrief, 'cli_lines'> = {
+    schema_version: 'scbe_polly_brief_v1',
+    station_id: manifest.station_id,
+    generated_at: now,
+    mode,
+    health: damage.overall_health,
+    headline,
+    summary,
+    damage,
+    keeper,
+    alerts,
+    actions,
+  };
+
+  return { ...partial, cli_lines: renderPollyCliLines(partial) };
+}
+
+export function renderPollyBrief(brief: PollyBrief): string {
+  return brief.cli_lines.join('\n');
+}
+
+// ─── EVA compatibility aliases ────────────────────────────────────────────────
+
+/** @deprecated Use PollyBriefMode */
+export type EvaMode = PollyBriefMode;
+/** @deprecated Use PollyBriefSeverity */
+export type EvaSeverity = PollyBriefSeverity;
+/** @deprecated Use PollyAlert */
+export type EvaAlert = PollyAlert;
+/** @deprecated Use PollyAction */
+export type EvaAction = PollyAction;
+/** @deprecated Use PollyBrief */
+export type EvaBrief = PollyBrief;
+/** @deprecated Use PollyBriefOptions */
+export type EvaBriefOptions = PollyBriefOptions;
+
+/** @deprecated Use buildPollyAlerts */
+export const buildEvaAlerts = buildPollyAlerts;
+/** @deprecated Use buildPollyActions */
+export const buildEvaActions = buildPollyActions;
+/** @deprecated Use buildPollyHeadline */
+export const buildEvaHeadline = buildPollyHeadline;
+/** @deprecated Use renderPollyCliLines */
+export const renderEvaCliLines = renderPollyCliLines;
+/** @deprecated Use buildPollyBrief */
+export const buildEvaBrief = buildPollyBrief;
+/** @deprecated Use renderPollyBrief */
+export const renderEvaBrief = renderPollyBrief;

--- a/packages/agent-bus/tests/eva.test.ts
+++ b/packages/agent-bus/tests/eva.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addZone,
+  buildEvaActions,
+  buildEvaAlerts,
+  buildEvaBrief,
+  createKeeper,
+  createStation,
+  defaultGravityFrame,
+  observeZone,
+  renderEvaBrief,
+  reportDamage,
+  runSweep,
+  type StationZone,
+} from '../src/index.js';
+
+const NOW = '2026-05-30T12:00:00.000Z';
+const STALE = '2026-06-01T12:00:00.000Z';
+
+function makeZone(id: string, overrides: Partial<StationZone> = {}): StationZone {
+  return {
+    id,
+    label: `Zone ${id}`,
+    district: 'code',
+    state: 'active',
+    gravity: defaultGravityFrame(id),
+    clearance: 'none',
+    capacity: 4,
+    occupants: [],
+    linked_zones: ['hub'],
+    updated_at: NOW,
+    ...overrides,
+  };
+}
+
+describe('buildEvaBrief', () => {
+  it('renders a green operator brief with watch as the next action', () => {
+    let station = createStation('STATION-EVA', { now: NOW });
+    station = addZone(station, makeZone('hub', { linked_zones: ['ops'] }), { now: NOW });
+    station = addZone(station, makeZone('ops', { linked_zones: ['hub'] }), { now: NOW });
+    station = observeZone(observeZone(station, 'hub', { now: NOW }), 'ops', { now: NOW });
+
+    const brief = buildEvaBrief(station, { now: NOW });
+    const rendered = renderEvaBrief(brief);
+
+    expect(brief.schema_version).toBe('scbe_eva_brief_v1');
+    expect(brief.health).toBe('green');
+    expect(brief.headline).toBe('Station STATION-EVA is green');
+    expect(brief.actions[0].command).toBe('scbe eva watch');
+    expect(rendered).toContain('EVA status: Station STATION-EVA is green');
+  });
+
+  it('prioritizes security and critical-zone actions over passive observation', () => {
+    let station = createStation('STATION-EVA', { now: NOW });
+    station = addZone(
+      station,
+      makeZone('security-core', {
+        state: 'quarantined',
+        clearance: 'admin',
+        linked_zones: ['hub'],
+      }),
+      { now: NOW }
+    );
+    station = {
+      ...station,
+      security_boundaries: {
+        boundary: {
+          id: 'boundary',
+          zone_ids: ['security-core'],
+          min_clearance: 'read_only',
+          allowed_lanes: ['keeper'],
+        },
+      },
+    };
+
+    const brief = buildEvaBrief(station, { now: NOW, mode: 'damage' });
+
+    expect(brief.health).toBe('critical');
+    expect(brief.alerts.map((alert) => alert.id)).toContain('damage.security-breaches');
+    expect(brief.actions[0].id).toBe('action.security-review');
+    expect(brief.actions[1].id).toBe('action.inspect-critical-zones');
+    expect(brief.cli_lines.join('\n')).toContain('scbe station damage --review-security');
+  });
+
+  it('turns keeper sweep results into repaired and escalation status lines', () => {
+    let station = createStation('STATION-EVA', { now: NOW });
+    station = addZone(
+      station,
+      makeZone('stale-zone', {
+        linked_zones: ['hub'],
+        updated_at: NOW,
+      }),
+      { now: NOW }
+    );
+    station = addZone(
+      station,
+      makeZone('quarantine-zone', {
+        state: 'quarantined',
+        linked_zones: ['hub'],
+        updated_at: NOW,
+      }),
+      { now: NOW }
+    );
+
+    const keeper = createKeeper('keeper-eva', { stale_threshold_ms: 1 });
+    const run = runSweep(keeper, station, { now: STALE });
+    const brief = buildEvaBrief(run.manifest, {
+      now: STALE,
+      keeperRun: run.result,
+    });
+
+    expect(brief.keeper?.keeper_id).toBe('keeper-eva');
+    expect(brief.keeper?.zones_repaired).toBe(2);
+    expect(brief.keeper?.zones_escalated).toBe(1);
+    expect(brief.alerts.map((a) => a.id)).toContain('keeper.escalations');
+    expect(brief.alerts.map((a) => a.id)).toContain('keeper.repairs-applied');
+    expect(brief.cli_lines.join('\n')).toContain('keeper=keeper-eva repaired=2 escalated=1');
+  });
+
+  it('caps alerts and actions for compact CLI output', () => {
+    let station = createStation('STATION-EVA', { now: NOW });
+    station = addZone(station, makeZone('a', { state: 'quarantined' }), { now: NOW });
+    station = addZone(station, makeZone('b', { linked_zones: [] }), { now: NOW });
+
+    const brief = buildEvaBrief(station, {
+      now: NOW,
+      maxAlerts: 1,
+      maxActions: 1,
+    });
+
+    expect(brief.alerts).toHaveLength(1);
+    expect(brief.actions).toHaveLength(1);
+  });
+});
+
+describe('buildEvaAlerts / buildEvaActions', () => {
+  it('keeps alert/action builders deterministic from supplied reports', () => {
+    let station = createStation('STATION-EVA', { now: NOW });
+    station = addZone(station, makeZone('isolated', { linked_zones: [] }), { now: NOW });
+
+    const brief = buildEvaBrief(station, { now: NOW });
+    const damage = reportDamage(station, { now: NOW });
+    const alerts = buildEvaAlerts(brief.summary, damage);
+    const actions = buildEvaActions(brief.summary, damage);
+
+    expect(alerts.map((a) => a.id)).toEqual(['damage.overall-health', 'station.fog-of-war']);
+    expect(actions.map((a) => a.id)).toContain('action.add-transit');
+    expect(actions.map((a) => a.id)).toContain('action.observe-fog');
+  });
+});

--- a/packages/agent-bus/tests/eva.test.ts
+++ b/packages/agent-bus/tests/eva.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
   addZone,
-  buildEvaActions,
-  buildEvaAlerts,
-  buildEvaBrief,
+  buildPollyActions,
+  buildPollyAlerts,
+  buildPollyBrief,
   createKeeper,
   createStation,
   defaultGravityFrame,
   observeZone,
-  renderEvaBrief,
+  renderPollyBrief,
   reportDamage,
   runSweep,
   type StationZone,
@@ -33,21 +33,21 @@ function makeZone(id: string, overrides: Partial<StationZone> = {}): StationZone
   };
 }
 
-describe('buildEvaBrief', () => {
+describe('buildPollyBrief', () => {
   it('renders a green operator brief with watch as the next action', () => {
     let station = createStation('STATION-EVA', { now: NOW });
     station = addZone(station, makeZone('hub', { linked_zones: ['ops'] }), { now: NOW });
     station = addZone(station, makeZone('ops', { linked_zones: ['hub'] }), { now: NOW });
     station = observeZone(observeZone(station, 'hub', { now: NOW }), 'ops', { now: NOW });
 
-    const brief = buildEvaBrief(station, { now: NOW });
-    const rendered = renderEvaBrief(brief);
+    const brief = buildPollyBrief(station, { now: NOW });
+    const rendered = renderPollyBrief(brief);
 
-    expect(brief.schema_version).toBe('scbe_eva_brief_v1');
+    expect(brief.schema_version).toBe('scbe_polly_brief_v1');
     expect(brief.health).toBe('green');
     expect(brief.headline).toBe('Station STATION-EVA is green');
-    expect(brief.actions[0].command).toBe('scbe eva watch');
-    expect(rendered).toContain('EVA status: Station STATION-EVA is green');
+    expect(brief.actions[0].command).toBe('scbe polly watch');
+    expect(rendered).toContain('Polly status: Station STATION-EVA is green');
   });
 
   it('prioritizes security and critical-zone actions over passive observation', () => {
@@ -73,7 +73,7 @@ describe('buildEvaBrief', () => {
       },
     };
 
-    const brief = buildEvaBrief(station, { now: NOW, mode: 'damage' });
+    const brief = buildPollyBrief(station, { now: NOW, mode: 'damage' });
 
     expect(brief.health).toBe('critical');
     expect(brief.alerts.map((alert) => alert.id)).toContain('damage.security-breaches');
@@ -104,7 +104,7 @@ describe('buildEvaBrief', () => {
 
     const keeper = createKeeper('keeper-eva', { stale_threshold_ms: 1 });
     const run = runSweep(keeper, station, { now: STALE });
-    const brief = buildEvaBrief(run.manifest, {
+    const brief = buildPollyBrief(run.manifest, {
       now: STALE,
       keeperRun: run.result,
     });
@@ -122,7 +122,7 @@ describe('buildEvaBrief', () => {
     station = addZone(station, makeZone('a', { state: 'quarantined' }), { now: NOW });
     station = addZone(station, makeZone('b', { linked_zones: [] }), { now: NOW });
 
-    const brief = buildEvaBrief(station, {
+    const brief = buildPollyBrief(station, {
       now: NOW,
       maxAlerts: 1,
       maxActions: 1,
@@ -133,15 +133,15 @@ describe('buildEvaBrief', () => {
   });
 });
 
-describe('buildEvaAlerts / buildEvaActions', () => {
+describe('buildPollyAlerts / buildPollyActions', () => {
   it('keeps alert/action builders deterministic from supplied reports', () => {
     let station = createStation('STATION-EVA', { now: NOW });
     station = addZone(station, makeZone('isolated', { linked_zones: [] }), { now: NOW });
 
-    const brief = buildEvaBrief(station, { now: NOW });
+    const brief = buildPollyBrief(station, { now: NOW });
     const damage = reportDamage(station, { now: NOW });
-    const alerts = buildEvaAlerts(brief.summary, damage);
-    const actions = buildEvaActions(brief.summary, damage);
+    const alerts = buildPollyAlerts(brief.summary, damage);
+    const actions = buildPollyActions(brief.summary, damage);
 
     expect(alerts.map((a) => a.id)).toEqual(['damage.overall-health', 'station.fog-of-war']);
     expect(actions.map((a) => a.id)).toContain('action.add-transit');


### PR DESCRIPTION
## Summary

- Adds `polly-brief.ts` — read-only operator narrator that turns `StationManifest`, `KeeperRunResult`, and `DamageReport` into structured `PollyBrief` objects with CLI-ready text output
- Aligns naming with existing Polly brand (`polly-pad`, `polly-pad-runtime`)
- Exports all Polly types/functions from `index.ts`; EVA names kept as `@deprecated` aliases for backward compatibility
- 5 tests covering green station, security/critical-zone scenarios, keeper sweep integration, caps, and deterministic alert/action ordering

## Test plan
- [x] `npx vitest run tests/eva.test.ts` — 5/5 pass
- [x] `npx tsc --noEmit` — clean
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)