### PR TITLE
feat(agent-bus): add HandoffPacket — juggling-model agent dispatch envelope

### DIFF
--- a/packages/agent-bus/src/handoff-packet.ts
+++ b/packages/agent-bus/src/handoff-packet.ts
@@ -1,0 +1,286 @@
+/**
+ * @file handoff-packet.ts
+ * @module agent-bus/handoff-packet
+ * @layer Fleet coordination
+ * @component HandoffPacket — governance-stamped agent dispatch envelope
+ *
+ * Models task handoffs as a physics juggling system:
+ *   balls  = HandoffPackets (tasks in flight)
+ *   hands  = agents (holders/catchers)
+ *   throws = handoffs between agents
+ *   arcs   = deadline windows
+ *   drops  = failures
+ *
+ * Every state transition returns a new immutable packet; no mutation in place.
+ * The receipt chain records who touched the packet and when at each hop.
+ */
+
+export type HandoffFlightState =
+  | 'HELD' // created, not yet dispatched
+  | 'THROWN' // dispatched to a target, awaiting catch
+  | 'CAUGHT' // target agent acknowledged receipt
+  | 'VALIDATING' // target agent is verifying the payload
+  | 'DONE' // delivered; task complete
+  | 'DROPPED'; // failure; task not delivered
+
+export type HandoffAuthority =
+  | 'auto' // system-generated, no human in loop
+  | 'keeper' // keeper agent authorized
+  | 'operator' // human operator authorized
+  | 'governance'; // governance gate required and passed
+
+export type HandoffPriority = 'routine' | 'elevated' | 'urgent' | 'critical';
+
+export interface HandoffMission {
+  task: string;
+  zone_id?: string;
+  station_id?: string;
+  target_lane?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface HandoffReceipt {
+  from_state: HandoffFlightState;
+  to_state: HandoffFlightState;
+  agent_id?: string;
+  stamped_at: string;
+  note?: string;
+}
+
+export interface HandoffPacket {
+  readonly schema_version: 'scbe_handoff_v1';
+  readonly packet_id: string;
+  readonly created_at: string;
+  readonly mission: HandoffMission;
+  readonly state: HandoffFlightState;
+  readonly priority: HandoffPriority;
+  readonly authority: HandoffAuthority;
+  readonly issuer_id: string;
+  readonly holder_id?: string;
+  readonly target_id?: string;
+  readonly deadline_at?: string;
+  readonly receipts: HandoffReceipt[];
+  readonly result?: unknown;
+  readonly drop_reason?: string;
+}
+
+export interface HandoffOptions {
+  now?: string;
+  packetId?: string;
+  priority?: HandoffPriority;
+  authority?: HandoffAuthority;
+  deadlineAt?: string;
+}
+
+export interface HandoffValidation {
+  valid: boolean;
+  expired: boolean;
+  state: HandoffFlightState;
+  ms_until_deadline?: number;
+  errors: string[];
+}
+
+export interface HandoffSummary {
+  packet_id: string;
+  state: HandoffFlightState;
+  priority: HandoffPriority;
+  authority: HandoffAuthority;
+  issuer_id: string;
+  holder_id?: string;
+  target_id?: string;
+  task: string;
+  hop_count: number;
+  created_at: string;
+  last_receipt_at?: string;
+  deadline_at?: string;
+  expired: boolean;
+  drop_reason?: string;
+}
+
+let _counter = 0;
+
+function nextId(prefix: string, now: string): string {
+  _counter = (_counter + 1) % 100_000;
+  const ts = now.replace(/[-:.TZ]/g, '').slice(0, 14);
+  return `${prefix}-${ts}-${String(_counter).padStart(5, '0')}`;
+}
+
+function stamp(
+  packet: HandoffPacket,
+  toState: HandoffFlightState,
+  agentId: string | undefined,
+  now: string,
+  note?: string
+): HandoffPacket {
+  const receipt: HandoffReceipt = {
+    from_state: packet.state,
+    to_state: toState,
+    stamped_at: now,
+    ...(agentId !== undefined ? { agent_id: agentId } : {}),
+    ...(note !== undefined ? { note } : {}),
+  };
+  return { ...packet, state: toState, receipts: [...packet.receipts, receipt] };
+}
+
+function isExpiredAt(packet: HandoffPacket, now: string): boolean {
+  if (!packet.deadline_at) return false;
+  return now >= packet.deadline_at;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export function createHandoff(
+  issuerId: string,
+  mission: HandoffMission,
+  opts: HandoffOptions = {}
+): HandoffPacket {
+  const now = opts.now ?? new Date().toISOString();
+  const packetId = opts.packetId ?? nextId('hp', now);
+  const receipt: HandoffReceipt = {
+    from_state: 'HELD',
+    to_state: 'HELD',
+    agent_id: issuerId,
+    stamped_at: now,
+    note: 'created',
+  };
+  return {
+    schema_version: 'scbe_handoff_v1',
+    packet_id: packetId,
+    created_at: now,
+    mission,
+    state: 'HELD',
+    priority: opts.priority ?? 'routine',
+    authority: opts.authority ?? 'auto',
+    issuer_id: issuerId,
+    holder_id: issuerId,
+    target_id: undefined,
+    deadline_at: opts.deadlineAt,
+    receipts: [receipt],
+    result: undefined,
+    drop_reason: undefined,
+  };
+}
+
+export function throwHandoff(
+  packet: HandoffPacket,
+  targetId: string,
+  opts: { now?: string; note?: string } = {}
+): HandoffPacket {
+  if (packet.state !== 'HELD') {
+    throw new Error(`throwHandoff: packet must be HELD, got ${packet.state}`);
+  }
+  const now = opts.now ?? new Date().toISOString();
+  return stamp(
+    { ...packet, target_id: targetId },
+    'THROWN',
+    packet.holder_id,
+    now,
+    opts.note ?? `thrown to ${targetId}`
+  );
+}
+
+export function catchHandoff(
+  packet: HandoffPacket,
+  agentId: string,
+  opts: { now?: string; note?: string } = {}
+): HandoffPacket {
+  if (packet.state !== 'THROWN') {
+    throw new Error(`catchHandoff: packet must be THROWN, got ${packet.state}`);
+  }
+  const now = opts.now ?? new Date().toISOString();
+  return stamp(
+    { ...packet, holder_id: agentId },
+    'CAUGHT',
+    agentId,
+    now,
+    opts.note ?? `caught by ${agentId}`
+  );
+}
+
+export function validateHandoff(
+  packet: HandoffPacket,
+  opts: { now?: string; note?: string } = {}
+): { packet: HandoffPacket; validation: HandoffValidation } {
+  if (packet.state !== 'CAUGHT') {
+    throw new Error(`validateHandoff: packet must be CAUGHT, got ${packet.state}`);
+  }
+  const now = opts.now ?? new Date().toISOString();
+  const expired = isExpiredAt(packet, now);
+  const errors: string[] = [];
+  if (expired) errors.push('deadline exceeded');
+  if (!packet.mission.task.trim()) errors.push('empty task');
+
+  const msUntilDeadline =
+    packet.deadline_at && !expired
+      ? new Date(packet.deadline_at).getTime() - new Date(now).getTime()
+      : undefined;
+
+  const validation: HandoffValidation = {
+    valid: errors.length === 0,
+    expired,
+    state: 'VALIDATING',
+    errors,
+    ...(msUntilDeadline !== undefined ? { ms_until_deadline: msUntilDeadline } : {}),
+  };
+
+  const next = stamp(packet, 'VALIDATING', packet.holder_id, now, opts.note);
+  return { packet: next, validation };
+}
+
+export function completeHandoff(
+  packet: HandoffPacket,
+  result: unknown,
+  opts: { now?: string; note?: string } = {}
+): HandoffPacket {
+  if (packet.state !== 'VALIDATING') {
+    throw new Error(`completeHandoff: packet must be VALIDATING, got ${packet.state}`);
+  }
+  const now = opts.now ?? new Date().toISOString();
+  return stamp({ ...packet, result }, 'DONE', packet.holder_id, now, opts.note ?? 'task complete');
+}
+
+export function dropHandoff(
+  packet: HandoffPacket,
+  reason: string,
+  opts: { now?: string } = {}
+): HandoffPacket {
+  const terminal: HandoffFlightState[] = ['DONE', 'DROPPED'];
+  if (terminal.includes(packet.state)) {
+    throw new Error(`dropHandoff: packet already terminal (${packet.state})`);
+  }
+  const now = opts.now ?? new Date().toISOString();
+  return stamp({ ...packet, drop_reason: reason }, 'DROPPED', packet.holder_id, now, reason);
+}
+
+export function isHandoffExpired(packet: HandoffPacket, opts: { now?: string } = {}): boolean {
+  const now = opts.now ?? new Date().toISOString();
+  return isExpiredAt(packet, now);
+}
+
+export function getReceipts(packet: HandoffPacket): HandoffReceipt[] {
+  return packet.receipts;
+}
+
+export function summarizeHandoff(
+  packet: HandoffPacket,
+  opts: { now?: string } = {}
+): HandoffSummary {
+  const now = opts.now ?? new Date().toISOString();
+  const lastReceipt = packet.receipts[packet.receipts.length - 1];
+  return {
+    packet_id: packet.packet_id,
+    state: packet.state,
+    priority: packet.priority,
+    authority: packet.authority,
+    issuer_id: packet.issuer_id,
+    holder_id: packet.holder_id,
+    target_id: packet.target_id,
+    task: packet.mission.task,
+    hop_count: packet.receipts.length - 1, // exclude creation receipt
+    created_at: packet.created_at,
+    last_receipt_at: lastReceipt?.stamped_at,
+    deadline_at: packet.deadline_at,
+    expired: isExpiredAt(packet, now),
+    drop_reason: packet.drop_reason,
+  };
+}

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -2236,3 +2236,24 @@ export {
   buildPollyOperatorBrief,
   renderPollyOperatorBrief,
 } from './polly-operator.js';
+
+export {
+  type HandoffFlightState,
+  type HandoffAuthority,
+  type HandoffPriority,
+  type HandoffMission,
+  type HandoffReceipt,
+  type HandoffPacket,
+  type HandoffOptions,
+  type HandoffValidation,
+  type HandoffSummary,
+  createHandoff,
+  throwHandoff,
+  catchHandoff,
+  validateHandoff,
+  completeHandoff,
+  dropHandoff,
+  isHandoffExpired,
+  getReceipts,
+  summarizeHandoff,
+} from './handoff-packet.js';

--- a/packages/agent-bus/tests/handoff-packet.test.ts
+++ b/packages/agent-bus/tests/handoff-packet.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createHandoff,
+  throwHandoff,
+  catchHandoff,
+  validateHandoff,
+  completeHandoff,
+  dropHandoff,
+  isHandoffExpired,
+  getReceipts,
+  summarizeHandoff,
+} from '../src/handoff-packet.js';
+
+const NOW = '2026-05-30T10:00:00.000Z';
+const PAST = '2026-05-30T09:00:00.000Z';
+const FUTURE = '2026-05-30T11:00:00.000Z';
+
+// ─── createHandoff ────────────────────────────────────────────────────────────
+
+describe('createHandoff', () => {
+  it('creates a HELD packet with correct schema', () => {
+    const p = createHandoff('agent-alpha', { task: 'repair zone z1' }, { now: NOW });
+    expect(p.schema_version).toBe('scbe_handoff_v1');
+    expect(p.state).toBe('HELD');
+    expect(p.issuer_id).toBe('agent-alpha');
+    expect(p.holder_id).toBe('agent-alpha');
+    expect(p.mission.task).toBe('repair zone z1');
+    expect(p.receipts).toHaveLength(1);
+    expect(p.receipts[0].to_state).toBe('HELD');
+    expect(p.receipts[0].note).toBe('created');
+  });
+
+  it('respects explicit packetId', () => {
+    const p = createHandoff('a', { task: 't' }, { now: NOW, packetId: 'hp-test-001' });
+    expect(p.packet_id).toBe('hp-test-001');
+  });
+
+  it('respects priority and authority options', () => {
+    const p = createHandoff(
+      'operator-1',
+      { task: 'emergency seal' },
+      { now: NOW, priority: 'critical', authority: 'operator' }
+    );
+    expect(p.priority).toBe('critical');
+    expect(p.authority).toBe('operator');
+  });
+
+  it('sets deadline when provided', () => {
+    const p = createHandoff('a', { task: 't' }, { now: NOW, deadlineAt: FUTURE });
+    expect(p.deadline_at).toBe(FUTURE);
+  });
+
+  it('defaults to auto authority and routine priority', () => {
+    const p = createHandoff('a', { task: 't' }, { now: NOW });
+    expect(p.authority).toBe('auto');
+    expect(p.priority).toBe('routine');
+  });
+});
+
+// ─── throwHandoff ─────────────────────────────────────────────────────────────
+
+describe('throwHandoff', () => {
+  it('transitions HELD → THROWN and sets target_id', () => {
+    const held = createHandoff('alpha', { task: 't' }, { now: NOW });
+    const thrown = throwHandoff(held, 'beta', { now: NOW });
+    expect(thrown.state).toBe('THROWN');
+    expect(thrown.target_id).toBe('beta');
+    expect(thrown.holder_id).toBe('alpha');
+    expect(thrown.receipts).toHaveLength(2);
+    expect(thrown.receipts[1].from_state).toBe('HELD');
+    expect(thrown.receipts[1].to_state).toBe('THROWN');
+  });
+
+  it('rejects throw from non-HELD state', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    const thrown = throwHandoff(held, 'b', { now: NOW });
+    expect(() => throwHandoff(thrown, 'c', { now: NOW })).toThrow('must be HELD');
+  });
+
+  it('does not mutate original packet', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    throwHandoff(held, 'b', { now: NOW });
+    expect(held.state).toBe('HELD');
+  });
+});
+
+// ─── catchHandoff ─────────────────────────────────────────────────────────────
+
+describe('catchHandoff', () => {
+  it('transitions THROWN → CAUGHT and updates holder_id', () => {
+    const held = createHandoff('alpha', { task: 't' }, { now: NOW });
+    const thrown = throwHandoff(held, 'beta', { now: NOW });
+    const caught = catchHandoff(thrown, 'beta', { now: NOW });
+    expect(caught.state).toBe('CAUGHT');
+    expect(caught.holder_id).toBe('beta');
+    expect(caught.receipts).toHaveLength(3);
+  });
+
+  it('rejects catch from non-THROWN state', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    expect(() => catchHandoff(held, 'b', { now: NOW })).toThrow('must be THROWN');
+  });
+
+  it('allows a different agent to catch (intercept scenario)', () => {
+    const held = createHandoff('alpha', { task: 't' }, { now: NOW });
+    const thrown = throwHandoff(held, 'beta', { now: NOW });
+    const caught = catchHandoff(thrown, 'gamma', { now: NOW });
+    expect(caught.holder_id).toBe('gamma');
+    expect(caught.target_id).toBe('beta');
+  });
+});
+
+// ─── validateHandoff ──────────────────────────────────────────────────────────
+
+describe('validateHandoff', () => {
+  function makeCaught() {
+    const held = createHandoff(
+      'alpha',
+      { task: 'patch zone z3' },
+      { now: NOW, deadlineAt: FUTURE }
+    );
+    const thrown = throwHandoff(held, 'beta', { now: NOW });
+    return catchHandoff(thrown, 'beta', { now: NOW });
+  }
+
+  it('transitions CAUGHT → VALIDATING and returns validation', () => {
+    const caught = makeCaught();
+    const { packet, validation } = validateHandoff(caught, { now: NOW });
+    expect(packet.state).toBe('VALIDATING');
+    expect(validation.state).toBe('VALIDATING');
+    expect(validation.valid).toBe(true);
+    expect(validation.expired).toBe(false);
+    expect(validation.errors).toHaveLength(0);
+    expect(validation.ms_until_deadline).toBeGreaterThan(0);
+  });
+
+  it('marks expired when now >= deadline', () => {
+    const caught = makeCaught();
+    const { validation } = validateHandoff(caught, { now: FUTURE });
+    expect(validation.expired).toBe(true);
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toContain('deadline exceeded');
+  });
+
+  it('rejects validation from non-CAUGHT state', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    expect(() => validateHandoff(held, { now: NOW })).toThrow('must be CAUGHT');
+  });
+});
+
+// ─── completeHandoff ──────────────────────────────────────────────────────────
+
+describe('completeHandoff', () => {
+  function makeValidating() {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    const thrown = throwHandoff(held, 'b', { now: NOW });
+    const caught = catchHandoff(thrown, 'b', { now: NOW });
+    const { packet } = validateHandoff(caught, { now: NOW });
+    return packet;
+  }
+
+  it('transitions VALIDATING → DONE with result', () => {
+    const validating = makeValidating();
+    const done = completeHandoff(validating, { repaired: true }, { now: NOW });
+    expect(done.state).toBe('DONE');
+    expect(done.result).toEqual({ repaired: true });
+    expect(done.receipts[done.receipts.length - 1].to_state).toBe('DONE');
+  });
+
+  it('rejects completion from non-VALIDATING state', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    expect(() => completeHandoff(held, {}, { now: NOW })).toThrow('must be VALIDATING');
+  });
+
+  it('full happy-path lifecycle produces correct receipt chain', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    const thrown = throwHandoff(held, 'b', { now: NOW });
+    const caught = catchHandoff(thrown, 'b', { now: NOW });
+    const { packet: validating } = validateHandoff(caught, { now: NOW });
+    const done = completeHandoff(validating, 'ok', { now: NOW });
+
+    const states = done.receipts.map((r) => r.to_state);
+    expect(states).toEqual(['HELD', 'THROWN', 'CAUGHT', 'VALIDATING', 'DONE']);
+  });
+});
+
+// ─── dropHandoff ─────────────────────────────────────────────────────────────
+
+describe('dropHandoff', () => {
+  it('transitions any non-terminal state → DROPPED', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    const dropped = dropHandoff(held, 'agent offline', { now: NOW });
+    expect(dropped.state).toBe('DROPPED');
+    expect(dropped.drop_reason).toBe('agent offline');
+  });
+
+  it('can drop a THROWN packet (target never responded)', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    const thrown = throwHandoff(held, 'b', { now: NOW });
+    const dropped = dropHandoff(thrown, 'timeout', { now: NOW });
+    expect(dropped.state).toBe('DROPPED');
+  });
+
+  it('rejects drop on DONE packet', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    const thrown = throwHandoff(held, 'b', { now: NOW });
+    const caught = catchHandoff(thrown, 'b', { now: NOW });
+    const { packet: validating } = validateHandoff(caught, { now: NOW });
+    const done = completeHandoff(validating, 'ok', { now: NOW });
+    expect(() => dropHandoff(done, 'too late', { now: NOW })).toThrow('already terminal');
+  });
+
+  it('rejects double-drop', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    const dropped = dropHandoff(held, 'first drop', { now: NOW });
+    expect(() => dropHandoff(dropped, 'second drop', { now: NOW })).toThrow('already terminal');
+  });
+});
+
+// ─── isHandoffExpired ─────────────────────────────────────────────────────────
+
+describe('isHandoffExpired', () => {
+  it('returns false when no deadline', () => {
+    const p = createHandoff('a', { task: 't' }, { now: NOW });
+    expect(isHandoffExpired(p, { now: NOW })).toBe(false);
+  });
+
+  it('returns false before deadline', () => {
+    const p = createHandoff('a', { task: 't' }, { now: NOW, deadlineAt: FUTURE });
+    expect(isHandoffExpired(p, { now: NOW })).toBe(false);
+  });
+
+  it('returns true at or after deadline', () => {
+    const p = createHandoff('a', { task: 't' }, { now: NOW, deadlineAt: NOW });
+    expect(isHandoffExpired(p, { now: NOW })).toBe(true);
+    expect(isHandoffExpired(p, { now: FUTURE })).toBe(true);
+  });
+
+  it('returns false before a past-set future deadline', () => {
+    const p = createHandoff('a', { task: 't' }, { now: PAST, deadlineAt: FUTURE });
+    expect(isHandoffExpired(p, { now: NOW })).toBe(false);
+  });
+});
+
+// ─── getReceipts ─────────────────────────────────────────────────────────────
+
+describe('getReceipts', () => {
+  it('returns a stable copy of the receipt chain', () => {
+    const held = createHandoff('a', { task: 't' }, { now: NOW });
+    const thrown = throwHandoff(held, 'b', { now: NOW });
+    const receipts = getReceipts(thrown);
+    expect(receipts).toHaveLength(2);
+    expect(receipts[0].to_state).toBe('HELD');
+    expect(receipts[1].to_state).toBe('THROWN');
+  });
+});
+
+// ─── summarizeHandoff ────────────────────────────────────────────────────────
+
+describe('summarizeHandoff', () => {
+  it('returns correct hop_count (receipts - 1 for creation)', () => {
+    const held = createHandoff('a', { task: 'do the thing' }, { now: NOW });
+    const thrown = throwHandoff(held, 'b', { now: NOW });
+    const caught = catchHandoff(thrown, 'b', { now: NOW });
+    const summary = summarizeHandoff(caught, { now: NOW });
+    expect(summary.hop_count).toBe(2); // throw + catch
+    expect(summary.task).toBe('do the thing');
+    expect(summary.state).toBe('CAUGHT');
+    expect(summary.expired).toBe(false);
+  });
+
+  it('marks expired in summary when past deadline', () => {
+    const p = createHandoff('a', { task: 't' }, { now: PAST, deadlineAt: PAST });
+    const summary = summarizeHandoff(p, { now: NOW });
+    expect(summary.expired).toBe(true);
+  });
+
+  it('includes drop_reason for dropped packets', () => {
+    const p = createHandoff('a', { task: 't' }, { now: NOW });
+    const dropped = dropHandoff(p, 'zone locked', { now: NOW });
+    const summary = summarizeHandoff(dropped, { now: NOW });
+    expect(summary.drop_reason).toBe('zone locked');
+    expect(summary.state).toBe('DROPPED');
+  });
+
+  it('records last_receipt_at', () => {
+    const p = createHandoff('a', { task: 't' }, { now: NOW });
+    const summary = summarizeHandoff(p, { now: NOW });
+    expect(summary.last_receipt_at).toBe(NOW);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `handoff-packet.ts` implementing the physics juggling lifecycle named in the CLAUDE.md fleet architecture spec
- State machine: `HELD → THROWN → CAUGHT → VALIDATING → DONE / DROPPED` — every transition is a pure function returning a new immutable packet
- Receipt chain records who touched the packet and when at every hop — full audit trail without external storage
- `dropHandoff` can interrupt from any non-terminal state; terminal states (`DONE`, `DROPPED`) are protected

## Exports

`createHandoff`, `throwHandoff`, `catchHandoff`, `validateHandoff`, `completeHandoff`, `dropHandoff`, `isHandoffExpired`, `getReceipts`, `summarizeHandoff` + all types

## Test plan
- [x] 30/30 tests pass (`npx vitest run tests/handoff-packet.test.ts`)
- [x] `npx tsc --noEmit` — clean
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)