### PR TITLE
feat(polly-pad): add audit receipt ledger

### DIFF
--- a/packages/polly-pad-py/README.md
+++ b/packages/polly-pad-py/README.md
@@ -15,6 +15,9 @@ scbe-polly-pad modes
 scbe-polly-pad decide --d-star 0.4 --coherence 0.9 --h-eff 12
 scbe-polly-pad namespace --unit-id polly-1 --mode ENGINEERING --lang CA --epoch 1
 scbe-polly-pad trace --state 0.1,0.2,0.0,0.0,0.0,0.0 --d-star 0.2
+scbe-polly-pad audit append --actor human --action task.add --subject youtube --payload-json "{\"step\":\"title\"}"
+scbe-polly-pad audit verify
+scbe-polly-pad audit export
 ```
 
 ## Python
@@ -30,3 +33,7 @@ print(pad.assist("code review", state, squad))
 ```
 
 This package is intentionally runtime-only. Patent workbench files, training corpora, private notes, generated artifacts, and repository-local automation are not included in the wheel.
+
+## Audit Receipts
+
+Polly Pad audit ledgers are append-only JSONL files under `.polly/audit.jsonl` by default. Each event stores a canonical SHA-256 hash and the previous event hash, so edits to old receipts are detected by `scbe-polly-pad audit verify`.

--- a/packages/polly-pad-py/src/scbe_polly_pad/__init__.py
+++ b/packages/polly-pad-py/src/scbe_polly_pad/__init__.py
@@ -1,5 +1,16 @@
 """Public Polly Pad Python interface."""
 
+from .audit import (
+    GENESIS_HASH,
+    AuditReceipt,
+    AuditVerification,
+    append_event,
+    compute_event_hash,
+    default_ledger_path,
+    export_ledger,
+    iter_events,
+    verify_ledger,
+)
 from .runtime import (
     LANGS,
     MODE_TOOLS,
@@ -43,6 +54,7 @@ __all__ = [
     "CodeZone",
     "DIRECTION_WEIGHTS",
     "Decision",
+    "GENESIS_HASH",
     "LANGS",
     "Lang",
     "MODE_TOOLS",
@@ -65,15 +77,23 @@ __all__ = [
     "Voxel6",
     "VoxelRecord",
     "access_cost",
+    "append_event",
     "cube_id",
     "cymatic_field_6d",
+    "default_ledger_path",
     "dist",
+    "export_ledger",
     "harmonic_cost",
     "hyperbolic_distance_6d",
+    "iter_events",
     "pad_namespace_key",
     "plan_trace",
     "plan_tri_directional",
     "quasi_sphere_volume",
     "scbe_decide",
     "triadic_temporal_distance",
+    "verify_ledger",
+    "AuditReceipt",
+    "AuditVerification",
+    "compute_event_hash",
 ]

--- a/packages/polly-pad-py/src/scbe_polly_pad/audit.py
+++ b/packages/polly-pad-py/src/scbe_polly_pad/audit.py
@@ -1,0 +1,185 @@
+"""Append-only Polly Pad audit receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+from uuid import uuid4
+
+GENESIS_HASH = "0" * 64
+
+
+@dataclass(frozen=True)
+class AuditReceipt:
+    """One canonical audit event in a hash-chained JSONL ledger."""
+
+    event_id: str
+    ts: str
+    actor: str
+    action: str
+    subject: str
+    payload: dict[str, Any]
+    prev_hash: str
+    event_hash: str
+
+
+@dataclass(frozen=True)
+class AuditVerification:
+    """Integrity summary for a Polly Pad audit ledger."""
+
+    ok: bool
+    count: int
+    head_hash: str
+    broken_at: int | None = None
+    reason: str | None = None
+
+
+def default_ledger_path(base_dir: str | Path | None = None) -> Path:
+    """Return the default Polly audit ledger path."""
+
+    root = Path(base_dir) if base_dir is not None else Path.cwd()
+    return root / ".polly" / "audit.jsonl"
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    """Serialize payload deterministically for hashing."""
+
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_event_hash(event: dict[str, Any]) -> str:
+    """Compute the canonical SHA-256 event hash."""
+
+    material = {key: value for key, value in event.items() if key != "event_hash"}
+    return hashlib.sha256(canonical_json(material).encode("utf-8")).hexdigest()
+
+
+def _read_events(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                value = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid JSON at line {line_no}: {exc}") from exc
+            if not isinstance(value, dict):
+                raise ValueError(f"ledger line {line_no} is not an object")
+            events.append(value)
+    return events
+
+
+def iter_events(path: str | Path) -> Iterable[AuditReceipt]:
+    """Yield audit receipts from a JSONL ledger."""
+
+    for event in _read_events(Path(path)):
+        yield AuditReceipt(
+            event_id=str(event["event_id"]),
+            ts=str(event["ts"]),
+            actor=str(event["actor"]),
+            action=str(event["action"]),
+            subject=str(event["subject"]),
+            payload=dict(event.get("payload", {})),
+            prev_hash=str(event["prev_hash"]),
+            event_hash=str(event["event_hash"]),
+        )
+
+
+def append_event(
+    path: str | Path,
+    *,
+    actor: str,
+    action: str,
+    subject: str,
+    payload: dict[str, Any] | None = None,
+    event_id: str | None = None,
+    ts: str | None = None,
+) -> AuditReceipt:
+    """Append a receipt to the ledger and return it."""
+
+    ledger = Path(path)
+    prior = _read_events(ledger)
+    prev_hash = str(prior[-1]["event_hash"]) if prior else GENESIS_HASH
+    event: dict[str, Any] = {
+        "event_id": event_id or f"evt-{uuid4().hex}",
+        "ts": ts or datetime.now(timezone.utc).isoformat(),
+        "actor": actor,
+        "action": action,
+        "subject": subject,
+        "payload": payload or {},
+        "prev_hash": prev_hash,
+    }
+    event["event_hash"] = compute_event_hash(event)
+
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    with ledger.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(canonical_json(event) + "\n")
+
+    return AuditReceipt(
+        event_id=str(event["event_id"]),
+        ts=str(event["ts"]),
+        actor=str(event["actor"]),
+        action=str(event["action"]),
+        subject=str(event["subject"]),
+        payload=dict(event["payload"]),
+        prev_hash=str(event["prev_hash"]),
+        event_hash=str(event["event_hash"]),
+    )
+
+
+def verify_ledger(path: str | Path) -> AuditVerification:
+    """Verify hash continuity and event hashes for a ledger."""
+
+    ledger = Path(path)
+    try:
+        events = _read_events(ledger)
+    except ValueError as exc:
+        return AuditVerification(ok=False, count=0, head_hash=GENESIS_HASH, broken_at=1, reason=str(exc))
+
+    prev_hash = GENESIS_HASH
+    for index, event in enumerate(events, start=1):
+        actual_prev = str(event.get("prev_hash", ""))
+        if actual_prev != prev_hash:
+            return AuditVerification(
+                ok=False,
+                count=len(events),
+                head_hash=prev_hash,
+                broken_at=index,
+                reason="previous hash mismatch",
+            )
+        expected_hash = compute_event_hash(event)
+        actual_hash = str(event.get("event_hash", ""))
+        if actual_hash != expected_hash:
+            return AuditVerification(
+                ok=False,
+                count=len(events),
+                head_hash=prev_hash,
+                broken_at=index,
+                reason="event hash mismatch",
+            )
+        prev_hash = actual_hash
+
+    return AuditVerification(ok=True, count=len(events), head_hash=prev_hash)
+
+
+def export_ledger(path: str | Path) -> dict[str, Any]:
+    """Return a portable ledger export with integrity status."""
+
+    verification = verify_ledger(path)
+    return {
+        "ledger": str(Path(path)),
+        "ok": verification.ok,
+        "count": verification.count,
+        "head_hash": verification.head_hash,
+        "broken_at": verification.broken_at,
+        "reason": verification.reason,
+        "events": [receipt.__dict__ for receipt in iter_events(path)] if verification.ok else [],
+    }

--- a/packages/polly-pad-py/src/scbe_polly_pad/cli.py
+++ b/packages/polly-pad-py/src/scbe_polly_pad/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from typing import Sequence
 
+from .audit import append_event, default_ledger_path, export_ledger, iter_events, verify_ledger
 from .runtime import (
     LANGS,
     MODE_TOOLS,
@@ -56,6 +57,25 @@ def build_parser() -> argparse.ArgumentParser:
     trace = sub.add_parser("trace", help="Run tri-directional trace planning.")
     trace.add_argument("--state", type=_parse_state, required=True)
     trace.add_argument("--d-star", type=float, required=True)
+
+    audit = sub.add_parser("audit", help="Manage Polly Pad audit receipts.")
+    audit_sub = audit.add_subparsers(dest="audit_command", required=True)
+
+    audit_append = audit_sub.add_parser("append", help="Append one audit receipt.")
+    audit_append.add_argument("--ledger", default=str(default_ledger_path()))
+    audit_append.add_argument("--actor", required=True)
+    audit_append.add_argument("--action", required=True)
+    audit_append.add_argument("--subject", required=True)
+    audit_append.add_argument("--payload-json", default="{}")
+
+    audit_list = audit_sub.add_parser("list", help="List audit receipts.")
+    audit_list.add_argument("--ledger", default=str(default_ledger_path()))
+
+    audit_verify = audit_sub.add_parser("verify", help="Verify audit hash continuity.")
+    audit_verify.add_argument("--ledger", default=str(default_ledger_path()))
+
+    audit_export = audit_sub.add_parser("export", help="Export audit ledger as JSON.")
+    audit_export.add_argument("--ledger", default=str(default_ledger_path()))
 
     return parser
 
@@ -121,5 +141,36 @@ def main(argv: Sequence[str] | None = None) -> int:
             }
         )
         return 0
+
+    if args.command == "audit":
+        if args.audit_command == "append":
+            try:
+                payload = json.loads(args.payload_json)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"invalid --payload-json: {exc}") from exc
+            if not isinstance(payload, dict):
+                raise SystemExit("--payload-json must decode to a JSON object")
+            receipt = append_event(
+                args.ledger,
+                actor=args.actor,
+                action=args.action,
+                subject=args.subject,
+                payload=payload,
+            )
+            _print_json(receipt.__dict__)
+            return 0
+
+        if args.audit_command == "list":
+            _print_json([receipt.__dict__ for receipt in iter_events(args.ledger)])
+            return 0
+
+        if args.audit_command == "verify":
+            result = verify_ledger(args.ledger)
+            _print_json(result.__dict__)
+            return 0 if result.ok else 2
+
+        if args.audit_command == "export":
+            _print_json(export_ledger(args.ledger))
+            return 0
 
     raise AssertionError(f"unhandled command: {args.command}")

--- a/packages/polly-pad-py/tests/test_audit_trail.py
+++ b/packages/polly-pad-py/tests/test_audit_trail.py
@@ -1,0 +1,96 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scbe_polly_pad import append_event, export_ledger, verify_ledger
+
+
+def test_audit_receipts_hash_chain_and_export(tmp_path):
+    ledger = tmp_path / "audit.jsonl"
+
+    first = append_event(ledger, actor="human", action="init", subject="pad")
+    second = append_event(ledger, actor="polly", action="note.add", subject="video", payload={"title": "demo"})
+
+    assert second.prev_hash == first.event_hash
+    verified = verify_ledger(ledger)
+    assert verified.ok is True
+    assert verified.count == 2
+    assert verified.head_hash == second.event_hash
+
+    exported = export_ledger(ledger)
+    assert exported["ok"] is True
+    assert exported["events"][1]["payload"]["title"] == "demo"
+
+
+def test_audit_verify_detects_tampering(tmp_path):
+    ledger = tmp_path / "audit.jsonl"
+    append_event(ledger, actor="human", action="init", subject="pad")
+
+    line = ledger.read_text(encoding="utf-8").strip()
+    event = json.loads(line)
+    event["subject"] = "tampered"
+    ledger.write_text(json.dumps(event, sort_keys=True) + "\n", encoding="utf-8")
+
+    verified = verify_ledger(ledger)
+    assert verified.ok is False
+    assert verified.broken_at == 1
+    assert verified.reason == "event hash mismatch"
+
+
+def test_cli_audit_append_list_verify(tmp_path):
+    ledger = tmp_path / "audit.jsonl"
+    append_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scbe_polly_pad",
+            "audit",
+            "append",
+            "--ledger",
+            str(ledger),
+            "--actor",
+            "human",
+            "--action",
+            "task.add",
+            "--subject",
+            "youtube",
+            "--payload-json",
+            '{"step":"title"}',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    receipt = json.loads(append_result.stdout)
+    assert receipt["actor"] == "human"
+
+    list_result = subprocess.run(
+        [sys.executable, "-m", "scbe_polly_pad", "audit", "list", "--ledger", str(ledger)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(list_result.stdout)[0]["payload"]["step"] == "title"
+
+    verify_result = subprocess.run(
+        [sys.executable, "-m", "scbe_polly_pad", "audit", "verify", "--ledger", str(ledger)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(verify_result.stdout)["ok"] is True
+
+
+def test_cli_audit_verify_returns_nonzero_on_tamper(tmp_path):
+    ledger = Path(tmp_path / "audit.jsonl")
+    append_event(ledger, actor="human", action="init", subject="pad")
+    ledger.write_text(ledger.read_text(encoding="utf-8").replace('"pad"', '"changed"'), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "scbe_polly_pad", "audit", "verify", "--ledger", str(ledger)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert json.loads(result.stdout)["ok"] is False


### PR DESCRIPTION
## Summary
- adds append-only Polly Pad audit receipts with canonical SHA-256 event hashes
- adds hash-chain verification, ledger export, and receipt iteration APIs
- adds CLI commands: `audit append`, `audit list`, `audit verify`, `audit export`
- documents the `.polly/audit.jsonl` default ledger path

## Verification
- `python -m pytest packages\\polly-pad-py\\tests -q` -> 8 passed
- `python -m compileall -q packages\\polly-pad-py\\src packages\\polly-pad-py\\tests` -> passed
- `python -m build` in `packages/polly-pad-py` -> built wheel + sdist
- `python -m twine check dist\\*` -> passed
- manual CLI append/verify/export on temp ledger -> passed
- `git diff --check` -> clean

## Rollback
- remove `packages/polly-pad-py/src/scbe_polly_pad/audit.py`
- remove audit subcommands from `packages/polly-pad-py/src/scbe_polly_pad/cli.py`
- remove `packages/polly-pad-py/tests/test_audit_trail.py`
