### PR TITLE
feat(polly): add CLI audit receipt chain

### DIFF
--- a/packages/polly-pad-cli/LICENSE
+++ b/packages/polly-pad-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Issac Daniel Davis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/polly-pad-cli/LICENSE-APACHE
+++ b/packages/polly-pad-cli/LICENSE-APACHE
@@ -1,0 +1,163 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control
+with that entity. For the purposes of this definition, "control" means
+(i) the power, direct or indirect, to cause the direction or management
+of such entity, whether by contract or otherwise, or (ii) ownership of
+fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source,
+and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled
+object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object
+form, made available under the License, as indicated by a copyright notice
+that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent,
+as a whole, an original work of authorship. For the purposes of this
+License, Derivative Works shall not include works that remain separable
+from, or merely link (or bind by name) to the interfaces of, the Work.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Licensor or its representatives,
+including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed
+by, or on behalf of, the Licensor for the purpose of discussing and
+improving the Work, but excluding communication that is conspicuously
+marked or otherwise designated in writing by the copyright owner as
+"Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source
+or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable patent license to make,
+have made, use, offer to sell, sell, import, and otherwise transfer the
+Work, where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their Contribution(s)
+alone or by combination of their Contribution(s) with the Work to which
+such Contribution(s) was submitted. If You institute patent litigation
+against any entity alleging that the Work or a Contribution incorporated
+within the Work constitutes direct or contributory patent infringement,
+then any patent licenses granted to You under this License for that Work
+shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work
+or Derivative Works thereof in any medium, with or without modifications,
+and in Source or Object form, provided that You meet the following
+conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works
+a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating
+that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from
+the Source form of the Work, excluding those notices that do not pertain
+to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy
+of the attribution notices contained within such NOTICE file, excluding
+those notices that do not pertain to any part of the Derivative Works,
+in at least one of the following places: within a NOTICE text file
+distributed as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or, within a
+display generated by the Derivative Works, if and wherever such third-party
+notices normally appear. The contents of the NOTICE file are for
+informational purposes only and do not modify the License. You may add
+Your own attribution notices within Derivative Works that You distribute,
+alongside or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed as modifying
+the License.
+
+You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated
+in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work by You
+to the Licensor shall be under the terms and conditions of this License,
+without any additional terms or conditions. Notwithstanding the above,
+nothing herein shall supersede or modify the terms of any separate license
+agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor, except
+as required for reasonable and customary use in describing the origin of
+the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to
+in writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining
+the appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether
+in tort (including negligence), contract, or otherwise, unless required
+by applicable law (such as deliberate and grossly negligent acts) or agreed
+to in writing, shall any Contributor be liable to You for damages, including
+any direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability
+to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses), even if such Contributor has been advised
+of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the
+Work or Derivative Works thereof, You may choose to offer, and charge a fee
+for, acceptance of support, warranty, indemnity, or other liability
+obligations and/or rights consistent with this License. However, in accepting
+such obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/packages/polly-pad-cli/README.md
+++ b/packages/polly-pad-cli/README.md
@@ -1,0 +1,52 @@
+# Polly Pad CLI
+
+Polly is a governed terminal workpad for AI operators. It gives a shell session persistent task state, LLM routing, recipe prompts, run receipts, handoff packets, snapshots, and a hash-chained audit trail.
+
+## Install
+
+```bash
+npm install -g scbe-polly-pad-cli
+```
+
+## Quick Start
+
+```bash
+polly init my-project
+polly task add "first task"
+polly ask "what should I start with?"
+polly run plan --dry-run "ship a website"
+polly audit verify
+polly shell
+```
+
+## Workspace
+
+Polly stores state under `.polly/` in the current project:
+
+- `.polly/pad.json` — pad metadata, tasks, and attached repo
+- `.polly/runs/` — saved model or recipe runs
+- `.polly/snapshots/` — exported pad snapshots
+- `.polly/audit.jsonl` — append-only audit receipts
+
+## Audit Trail
+
+Every state-changing command appends a receipt to `.polly/audit.jsonl`. Receipts are canonical JSON records with a SHA-256 event hash and previous event hash.
+
+```bash
+polly audit list
+polly audit verify
+polly audit export --json
+```
+
+If a receipt is edited after it is written, `polly audit verify` exits non-zero and reports the first broken receipt.
+
+## Model Routing
+
+Polly tries model providers in this order:
+
+1. Ollama at `localhost:11434`
+2. `ANTHROPIC_API_KEY`
+3. `OPENAI_API_KEY`
+4. Template fallback with no model required
+
+The fallback keeps Polly usable even when no external model is configured.

--- a/packages/polly-pad-cli/bin/polly.js
+++ b/packages/polly-pad-cli/bin/polly.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const { spawnSync, execSync } = require('node:child_process');
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -13,6 +14,8 @@ const readline = require('node:readline');
 const VERSION = '0.1.0';
 const SCHEMA_PAD = 'polly_pad_v1';
 const SCHEMA_RUN = 'polly_run_v1';
+const SCHEMA_AUDIT = 'polly_audit_receipt_v1';
+const GENESIS_HASH = '0'.repeat(64);
 
 // ---------------------------------------------------------------------------
 // Workspace management
@@ -71,6 +74,130 @@ function initPad(name, ws) {
     run_counter: 0,
     config: {},
   };
+}
+
+// ---------------------------------------------------------------------------
+// Audit receipts
+// ---------------------------------------------------------------------------
+
+function auditPath(ws) {
+  return path.join(ws, '.polly', 'audit.jsonl');
+}
+
+function sortCanonical(value) {
+  if (Array.isArray(value)) return value.map(sortCanonical);
+  if (value && typeof value === 'object') {
+    return Object.keys(value)
+      .sort()
+      .reduce((outObj, key) => {
+        outObj[key] = sortCanonical(value[key]);
+        return outObj;
+      }, {});
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  return JSON.stringify(sortCanonical(value));
+}
+
+function computeAuditHash(receipt) {
+  const material = Object.assign({}, receipt);
+  delete material.event_hash;
+  return crypto.createHash('sha256').update(canonicalJson(material), 'utf8').digest('hex');
+}
+
+function readAuditEvents(ws) {
+  const filePath = auditPath(ws);
+  if (!fs.existsSync(filePath)) return [];
+  const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/).filter((line) => line.trim());
+  return lines.map((line, idx) => {
+    try {
+      return JSON.parse(line);
+    } catch (err) {
+      const wrapped = new Error('Invalid JSON in audit ledger at line ' + (idx + 1) + ': ' + err.message);
+      wrapped.auditLine = idx + 1;
+      throw wrapped;
+    }
+  });
+}
+
+function appendAudit(ws, action, subject, payload) {
+  const events = readAuditEvents(ws);
+  const prevHash = events.length ? events[events.length - 1].event_hash : GENESIS_HASH;
+  const receipt = {
+    schema_version: SCHEMA_AUDIT,
+    event_id: 'evt-' + Date.now().toString(36) + '-' + crypto.randomBytes(4).toString('hex'),
+    ts: new Date().toISOString(),
+    actor: 'polly',
+    action,
+    subject,
+    payload: payload || {},
+    prev_hash: prevHash,
+  };
+  receipt.event_hash = computeAuditHash(receipt);
+  const filePath = auditPath(ws);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.appendFileSync(filePath, canonicalJson(receipt) + '\n', 'utf8');
+  return receipt;
+}
+
+function verifyAudit(ws) {
+  let events;
+  try {
+    events = readAuditEvents(ws);
+  } catch (err) {
+    return {
+      ok: false,
+      count: 0,
+      head_hash: GENESIS_HASH,
+      broken_at: err.auditLine || 1,
+      reason: err.message,
+    };
+  }
+
+  let prevHash = GENESIS_HASH;
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (event.prev_hash !== prevHash) {
+      return {
+        ok: false,
+        count: events.length,
+        head_hash: prevHash,
+        broken_at: i + 1,
+        reason: 'previous hash mismatch',
+      };
+    }
+    const expected = computeAuditHash(event);
+    if (event.event_hash !== expected) {
+      return {
+        ok: false,
+        count: events.length,
+        head_hash: prevHash,
+        broken_at: i + 1,
+        reason: 'event hash mismatch',
+      };
+    }
+    prevHash = event.event_hash;
+  }
+  return {
+    ok: true,
+    count: events.length,
+    head_hash: prevHash,
+    broken_at: null,
+    reason: null,
+  };
+}
+
+function exportAudit(ws) {
+  const verified = verifyAudit(ws);
+  return Object.assign(
+    {
+      ledger: auditPath(ws),
+      events: verified.ok ? readAuditEvents(ws) : [],
+    },
+    verified
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -421,6 +548,7 @@ const COMMANDS = {
 
     const pad = initPad(name, ws);
     writePad(ws, pad);
+    appendAudit(ws, 'workspace.init', pad.pad_id, { name: pad.name, attached_repo: pad.attached_repo });
 
     if (flags.json) {
       out({ status: 'created', pad }, true);
@@ -470,6 +598,7 @@ const COMMANDS = {
     const pad = initPad(name, ws);
     pad.run_counter = old && old.run_counter ? old.run_counter : 0;
     writePad(ws, pad);
+    appendAudit(ws, 'workspace.new', pad.pad_id, { name: pad.name, previous_pad_id: old ? old.pad_id : null });
     if (flags.json) {
       out({ status: 'replaced', pad }, true);
     } else {
@@ -501,6 +630,7 @@ const COMMANDS = {
       pad = addTask(pad, text);
       writePad(ws, pad);
       const added = pad.tasks[pad.tasks.length - 1];
+      appendAudit(ws, 'task.add', added.id, { text: added.text, state: added.state });
       if (flags.json) {
         out(added, true);
       } else {
@@ -523,6 +653,7 @@ const COMMANDS = {
       }
       pad = updateTask(pad, id, 'done');
       writePad(ws, pad);
+      appendAudit(ws, 'task.done', id, { text: exists.text });
       if (flags.json) {
         out({ status: 'done', id }, true);
       } else {
@@ -545,6 +676,7 @@ const COMMANDS = {
         process.exit(1);
       }
       writePad(ws, pad);
+      appendAudit(ws, 'task.remove', id, {});
       if (flags.json) {
         out({ status: 'removed', id }, true);
       } else {
@@ -587,6 +719,12 @@ const COMMANDS = {
     saveRun(ws, run);
     pad = Object.assign({}, pad, { run_counter: (pad.run_counter || 0) + 1 });
     writePad(ws, pad);
+    appendAudit(ws, 'run.ask', run_id, {
+      source: result.source,
+      model_used: result.model_used,
+      prompt_chars: prompt.length,
+      result_chars: result.text.length,
+    });
 
     if (flags.json) {
       out(run, true);
@@ -649,6 +787,13 @@ const COMMANDS = {
     saveRun(ws, run);
     pad = Object.assign({}, pad, { run_counter: (pad.run_counter || 0) + 1 });
     writePad(ws, pad);
+    appendAudit(ws, 'run.recipe', run_id, {
+      recipe,
+      source: result.source,
+      model_used: result.model_used,
+      prompt_chars: prompt.length,
+      result_chars: result.text.length,
+    });
 
     if (flags.json) {
       out(run, true);
@@ -742,6 +887,7 @@ const COMMANDS = {
       runs: allRuns,
     };
     fs.writeFileSync(snapPath, JSON.stringify(snap, null, 2), 'utf8');
+    appendAudit(ws, 'snapshot.create', snapId, { path: snapPath, run_count: allRuns.length });
     if (flags.json) {
       out({ status: 'saved', snap_id: snapId, path: snapPath }, true);
     } else {
@@ -760,6 +906,7 @@ const COMMANDS = {
     let pad = readPad(ws);
     pad = Object.assign({}, pad, { attached_repo: gitRoot });
     writePad(ws, pad);
+    appendAudit(ws, 'repo.attach', gitRoot, {});
     if (flags.json) {
       out({ status: 'attached', attached_repo: gitRoot }, true);
     } else {
@@ -772,6 +919,7 @@ const COMMANDS = {
     let pad = readPad(ws);
     pad = Object.assign({}, pad, { attached_repo: null });
     writePad(ws, pad);
+    appendAudit(ws, 'repo.detach', 'workspace', {});
     if (flags.json) {
       out({ status: 'detached' }, true);
     } else {
@@ -884,6 +1032,51 @@ const COMMANDS = {
     process.exit(1);
   },
 
+  async audit(args, flags) {
+    const ws = requireWorkspace();
+    const [sub] = args;
+
+    if (!sub || sub === 'verify') {
+      const result = verifyAudit(ws);
+      if (flags.json) {
+        out(result, true);
+      } else if (result.ok) {
+        console.log('Audit OK: ' + result.count + ' receipts, head=' + result.head_hash);
+      } else {
+        console.log('Audit FAILED at receipt ' + result.broken_at + ': ' + result.reason);
+        console.log('Head before failure: ' + result.head_hash);
+      }
+      process.exit(result.ok ? 0 : 2);
+    }
+
+    if (sub === 'list') {
+      const events = readAuditEvents(ws);
+      if (flags.json) {
+        out(events, true);
+        return;
+      }
+      if (!events.length) {
+        console.log('No audit receipts yet.');
+        return;
+      }
+      const col = (s, w) => String(s || '').padEnd(w).slice(0, w);
+      console.log(col('event', 16) + '  ' + col('action', 18) + '  ' + col('subject', 22) + '  ' + 'time');
+      console.log('-'.repeat(82));
+      for (const event of events) {
+        console.log(col(event.event_id, 16) + '  ' + col(event.action, 18) + '  ' + col(event.subject, 22) + '  ' + event.ts);
+      }
+      return;
+    }
+
+    if (sub === 'export') {
+      out(exportAudit(ws), true);
+      return;
+    }
+
+    console.error('Unknown audit subcommand: ' + sub + '. Use: verify, list, export');
+    process.exit(1);
+  },
+
   async shell(args, flags) {
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: 'polly> ' });
     console.log('Polly shell v' + VERSION + '. Type .exit to quit, .help for commands.');
@@ -983,6 +1176,9 @@ Commands:
   attach [path]            Attach workspace to a git repo
   detach                   Detach from git repo
   handoff                  Export handoff packet (always JSON)
+  audit verify             Verify hash-chained audit receipts
+  audit list               List audit receipts
+  audit export             Export audit receipts as JSON
   doctor                   Check environment (Node, Ollama, API keys, git)
   tools list               List available recipes
   tools run <name> [args]  Run a recipe
@@ -1018,6 +1214,7 @@ Examples:
   polly run research "hyperbolic geometry in AI safety"
   polly run review src/index.ts
   polly run plan --dry-run "migrate to new API"
+  polly audit verify
   polly runs --json
   polly handoff | pbcopy
 `;

--- a/packages/polly-pad-cli/package.json
+++ b/packages/polly-pad-cli/package.json
@@ -4,7 +4,7 @@
   "description": "Polly — governed terminal workpad for AI operators. Persistent workspace, task state, LLM routing, tool recipes, and audit receipts.",
   "type": "commonjs",
   "bin": { "polly": "bin/polly.js" },
-  "files": ["bin", "tests", "README.md", "LICENSE"],
+  "files": ["bin", "tests", "README.md", "LICENSE", "LICENSE-APACHE"],
   "scripts": {
     "help": "node ./bin/polly.js --help",
     "doctor": "node ./bin/polly.js doctor",

--- a/packages/polly-pad-cli/tests/workspace.test.cjs
+++ b/packages/polly-pad-cli/tests/workspace.test.cjs
@@ -39,6 +39,12 @@ test('polly init creates .polly/pad.json', () => {
     const pad = JSON.parse(fs.readFileSync(padPath, 'utf8'));
     assert.strictEqual(pad.name, 'TestPad', 'pad.name should be TestPad');
     assert.strictEqual(pad.schema_version, 'polly_pad_v1', 'schema_version should be polly_pad_v1');
+    const auditPath = path.join(dir, '.polly', 'audit.jsonl');
+    assert.ok(fs.existsSync(auditPath), '.polly/audit.jsonl should exist');
+    const firstReceipt = JSON.parse(fs.readFileSync(auditPath, 'utf8').trim());
+    assert.strictEqual(firstReceipt.action, 'workspace.init');
+    assert.strictEqual(firstReceipt.prev_hash, '0'.repeat(64));
+    assert.match(firstReceipt.event_hash, /^[a-f0-9]{64}$/);
   } finally {
     cleanup(dir);
   }
@@ -176,6 +182,61 @@ test('polly snapshot creates snapshot file', () => {
     assert.ok(fs.existsSync(snapsDir), '.polly/snapshots should exist');
     const files = fs.readdirSync(snapsDir).filter((f) => f.endsWith('.json'));
     assert.ok(files.length > 0, 'should have at least one snapshot file');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: polly audit verify validates receipt chain
+// ---------------------------------------------------------------------------
+test('polly audit verify validates receipt chain', () => {
+  const dir = mktemp();
+  try {
+    run(dir, ['init', 'AuditTest']);
+    run(dir, ['task', 'add', 'audit this']);
+    run(dir, ['task', 'done', 'task-001']);
+
+    const verifyResult = run(dir, ['audit', 'verify', '--json']);
+    assert.strictEqual(
+      verifyResult.status,
+      0,
+      'audit verify should succeed\nstdout: ' + verifyResult.stdout + '\nstderr: ' + verifyResult.stderr
+    );
+    const verified = JSON.parse(verifyResult.stdout);
+    assert.strictEqual(verified.ok, true);
+    assert.strictEqual(verified.count, 3);
+
+    const listResult = run(dir, ['audit', 'list', '--json']);
+    assert.strictEqual(listResult.status, 0, 'audit list should succeed');
+    const events = JSON.parse(listResult.stdout);
+    assert.deepStrictEqual(
+      events.map((event) => event.action),
+      ['workspace.init', 'task.add', 'task.done']
+    );
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 10: polly audit verify fails on tampered receipt
+// ---------------------------------------------------------------------------
+test('polly audit verify fails on tampered receipt', () => {
+  const dir = mktemp();
+  try {
+    run(dir, ['init', 'TamperTest']);
+    const auditPath = path.join(dir, '.polly', 'audit.jsonl');
+    const event = JSON.parse(fs.readFileSync(auditPath, 'utf8').trim());
+    event.subject = 'tampered';
+    fs.writeFileSync(auditPath, JSON.stringify(event) + '\n', 'utf8');
+
+    const verifyResult = run(dir, ['audit', 'verify', '--json']);
+    assert.strictEqual(verifyResult.status, 2, 'tampered audit should exit 2');
+    const verified = JSON.parse(verifyResult.stdout);
+    assert.strictEqual(verified.ok, false);
+    assert.strictEqual(verified.broken_at, 1);
+    assert.strictEqual(verified.reason, 'event hash mismatch');
   } finally {
     cleanup(dir);
   }


### PR DESCRIPTION
## Summary
- adds a dependency-free hash-chained audit receipt ledger to the Polly CLI
- writes receipts for state-changing workspace operations: init, new, task add/done/remove, ask, run, snapshot, attach, detach
- adds `polly audit verify`, `polly audit list`, and `polly audit export`
- adds tamper-detection tests for edited receipts
- adds README and dual license files to the npm package tarball

## Verification
- `npm test` in `packages/polly-pad-cli` -> 10 passed
- `npm pack --dry-run` in `packages/polly-pad-cli` -> 6 clean package files, includes README and licenses
- `node packages\\polly-pad-cli\\bin\\polly.js doctor --json` -> command runs
- manual init/task/audit verify/list smoke -> passed
- `git diff --check` -> clean

## Notes
- `npm audit` was not applicable in this package because it has no dependencies and no lockfile; `npm audit` exits with ENOLOCK.

## Rollback
- revert `packages/polly-pad-cli/bin/polly.js` audit helper/command changes
- revert audit tests from `packages/polly-pad-cli/tests/workspace.test.cjs`
- remove package README/license additions if needed
