### PR TITLE
feat(polly): add cross-language hex packets

### DIFF
--- a/packages/polly-pad-cli/README.md
+++ b/packages/polly-pad-cli/README.md
@@ -16,6 +16,8 @@ polly task add "first task"
 polly ask "what should I start with?"
 polly run plan --dry-run "ship a website"
 polly audit verify
+polly cross pack --text "def add(x, y): return x + y" --lang python
+polly cross op add --json
 polly shell
 ```
 
@@ -39,6 +41,19 @@ polly audit export --json
 ```
 
 If a receipt is edited after it is written, `polly audit verify` exits non-zero and reports the first broken receipt.
+
+## Cross-Language Packets
+
+Polly can decompose text or source files into lossless UTF-8 hex/binary packets with SHA-256 receipts and lightweight semantic route evidence.
+
+```bash
+polly cross pack --file src/index.ts
+polly cross pack --text "const result = x + y;" --lang javascript
+polly cross unpack --hex 636f6e737420726573756c74203d2078202b20793b
+polly cross op add --json
+```
+
+`cross pack` is lossless at the byte layer. `cross op` is intentionally bounded to known operation templates; it is not advertised as arbitrary AST translation.
 
 ## Model Routing
 

--- a/packages/polly-pad-cli/bin/polly.js
+++ b/packages/polly-pad-cli/bin/polly.js
@@ -15,6 +15,7 @@ const VERSION = '0.1.0';
 const SCHEMA_PAD = 'polly_pad_v1';
 const SCHEMA_RUN = 'polly_run_v1';
 const SCHEMA_AUDIT = 'polly_audit_receipt_v1';
+const SCHEMA_CROSS_PACKET = 'polly_cross_packet_v1';
 const GENESIS_HASH = '0'.repeat(64);
 
 // ---------------------------------------------------------------------------
@@ -198,6 +199,154 @@ function exportAudit(ws) {
     },
     verified
   );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-language binary/hex packets
+// ---------------------------------------------------------------------------
+
+const LANGUAGE_ALIASES = {
+  py: 'python',
+  python: 'python',
+  js: 'javascript',
+  javascript: 'javascript',
+  ts: 'typescript',
+  typescript: 'typescript',
+  rs: 'rust',
+  rust: 'rust',
+  go: 'go',
+  sh: 'shell',
+  shell: 'shell',
+  bash: 'shell',
+};
+
+const LANG_HINTS = {
+  python: ['def ', 'import ', 'print(', 'self', 'elif ', 'None', 'True', 'False'],
+  javascript: ['function ', 'const ', 'let ', 'console.log', '=>', 'require('],
+  typescript: ['interface ', 'type ', ': string', ': number', 'Promise<', 'export '],
+  rust: ['fn ', 'let mut', 'println!', 'Result<', 'pub ', '::'],
+  go: ['func ', 'package ', 'fmt.', ':=', 'defer '],
+  shell: ['#!/', 'echo ', '$(', '&&', 'fi', 'then'],
+};
+
+const SEMANTIC_AXES = [
+  ['intent', 'task', 'goal', 'plan', 'ask', 'prompt', 'result'],
+  ['code', 'compile', 'function', 'class', 'module', 'patch', 'def ', 'const ', 'let ', 'func ', 'fn '],
+  ['security', 'audit', 'verify', 'deny', 'allow', 'policy'],
+  ['data', 'binary', 'hex', 'json', 'packet', 'token', '=', '+', '^', '&', '|'],
+  ['deploy', 'run', 'shell', 'system', 'process', 'command', ';', '$('],
+  ['language', 'python', 'javascript', 'typescript', 'rust', 'go'],
+];
+
+const OP_TEMPLATES = {
+  add: {
+    python: 'result = x + y',
+    javascript: 'const result = x + y;',
+    typescript: 'const result: number = x + y;',
+    rust: 'let result = x + y;',
+    go: 'result := x + y',
+    shell: 'result=$((x + y))',
+  },
+  sub: {
+    python: 'result = x - y',
+    javascript: 'const result = x - y;',
+    typescript: 'const result: number = x - y;',
+    rust: 'let result = x - y;',
+    go: 'result := x - y',
+    shell: 'result=$((x - y))',
+  },
+  mul: {
+    python: 'result = x * y',
+    javascript: 'const result = x * y;',
+    typescript: 'const result: number = x * y;',
+    rust: 'let result = x * y;',
+    go: 'result := x * y',
+    shell: 'result=$((x * y))',
+  },
+  xor: {
+    python: 'result = x ^ y',
+    javascript: 'const result = x ^ y;',
+    typescript: 'const result: number = x ^ y;',
+    rust: 'let result = x ^ y;',
+    go: 'result := x ^ y',
+    shell: 'result=$((x ^ y))',
+  },
+  and: {
+    python: 'result = x & y',
+    javascript: 'const result = x & y;',
+    typescript: 'const result: number = x & y;',
+    rust: 'let result = x & y;',
+    go: 'result := x & y',
+    shell: 'result=$((x & y))',
+  },
+  or: {
+    python: 'result = x | y',
+    javascript: 'const result = x | y;',
+    typescript: 'const result: number = x | y;',
+    rust: 'let result = x | y;',
+    go: 'result := x | y',
+    shell: 'result=$((x | y))',
+  },
+};
+
+function normalizeLanguage(raw) {
+  if (!raw) return null;
+  return LANGUAGE_ALIASES[String(raw).toLowerCase()] || null;
+}
+
+function detectLanguage(text) {
+  let best = { language: 'text', score: 0 };
+  for (const [language, hints] of Object.entries(LANG_HINTS)) {
+    const score = hints.reduce((total, hint) => total + (text.includes(hint) ? 1 : 0), 0);
+    if (score > best.score) best = { language, score };
+  }
+  return best;
+}
+
+function semanticDims(text, language) {
+  const lower = text.toLowerCase();
+  const dims = SEMANTIC_AXES.map((axis) => {
+    const hits = axis.reduce((total, term) => total + (lower.includes(term) ? 1 : 0), 0);
+    return Math.min(255, Math.round((hits / Math.max(axis.length, 1)) * 255));
+  });
+  if (language && language !== 'text') dims[5] = Math.max(dims[5], 64);
+  return dims;
+}
+
+function dimsToHex(dims) {
+  return dims.map((value) => value.toString(16).padStart(2, '0')).join('');
+}
+
+function toBinaryGroups(buffer) {
+  return Array.from(buffer)
+    .map((byte) => byte.toString(2).padStart(8, '0'))
+    .join(' ');
+}
+
+function packetFromText(text, opts) {
+  const buffer = Buffer.from(text, 'utf8');
+  const language = normalizeLanguage(opts.language) || detectLanguage(text).language;
+  const dims = semanticDims(text, language);
+  return {
+    schema_version: SCHEMA_CROSS_PACKET,
+    encoding: 'utf8',
+    language,
+    bytes: buffer.length,
+    sha256: crypto.createHash('sha256').update(buffer).digest('hex'),
+    hex: buffer.toString('hex'),
+    binary: toBinaryGroups(buffer),
+    semantic_dims: dims,
+    semantic_hex: dimsToHex(dims),
+    text_preview: text.slice(0, 160),
+  };
+}
+
+function textFromHex(hex) {
+  const cleaned = String(hex || '').replace(/\s+/g, '').toLowerCase();
+  if (!cleaned || cleaned.length % 2 !== 0 || /[^0-9a-f]/.test(cleaned)) {
+    throw new Error('hex input must contain an even number of hexadecimal characters');
+  }
+  return Buffer.from(cleaned, 'hex').toString('utf8');
 }
 
 // ---------------------------------------------------------------------------
@@ -1344,6 +1493,125 @@ const COMMANDS = {
     process.exit(1);
   },
 
+  async cross(args, flags) {
+    const [sub, ...rest] = args;
+    const ws = findWorkspaceRoot(process.cwd());
+
+    if (!sub || sub === 'help') {
+      console.log('Usage: polly cross <pack|unpack|op|langs|ops> [options]');
+      console.log('');
+      console.log('Examples:');
+      console.log('  polly cross pack --text "def add(x, y): return x + y" --lang python');
+      console.log('  polly cross pack --file src/index.ts');
+      console.log('  polly cross unpack --hex 64656620');
+      console.log('  polly cross op add --json');
+      return;
+    }
+
+    if (sub === 'langs') {
+      out(Object.keys(LANG_HINTS), flags.json);
+      return;
+    }
+
+    if (sub === 'ops') {
+      out(Object.keys(OP_TEMPLATES), flags.json);
+      return;
+    }
+
+    if (sub === 'pack') {
+      let text = '';
+      let source = 'args';
+      if (flags.file) {
+        text = fs.readFileSync(path.resolve(String(flags.file)), 'utf8');
+        source = path.resolve(String(flags.file));
+      } else if (flags.text) {
+        text = String(flags.text);
+        source = '--text';
+      } else {
+        text = rest.join(' ');
+      }
+      if (!text) {
+        console.error('Usage: polly cross pack --text <text> [--lang python]');
+        process.exit(1);
+      }
+      const packet = packetFromText(text, { language: flags.lang || flags.language });
+      packet.source = source;
+      if (ws) {
+        appendAudit(ws, 'cross.pack', packet.sha256.slice(0, 16), {
+          source,
+          language: packet.language,
+          bytes: packet.bytes,
+          semantic_hex: packet.semantic_hex,
+        });
+      }
+      out(packet, true);
+      return;
+    }
+
+    if (sub === 'unpack') {
+      const hex = flags.hex || rest.join('');
+      let text;
+      try {
+        text = textFromHex(hex);
+      } catch (err) {
+        console.error('Invalid packet hex: ' + err.message);
+        process.exit(1);
+      }
+      const packet = packetFromText(text, { language: flags.lang || flags.language });
+      const result = {
+        schema_version: 'polly_cross_unpacked_v1',
+        text,
+        verified_sha256: packet.sha256,
+        bytes: packet.bytes,
+        language: packet.language,
+        semantic_hex: packet.semantic_hex,
+      };
+      if (ws) {
+        appendAudit(ws, 'cross.unpack', packet.sha256.slice(0, 16), {
+          bytes: packet.bytes,
+          language: packet.language,
+          semantic_hex: packet.semantic_hex,
+        });
+      }
+      out(result, flags.json);
+      return;
+    }
+
+    if (sub === 'op') {
+      const op = rest[0];
+      if (!op || !OP_TEMPLATES[op]) {
+        console.error('Usage: polly cross op <' + Object.keys(OP_TEMPLATES).join('|') + '> [--to python]');
+        process.exit(1);
+      }
+      const to = normalizeLanguage(flags.to || flags.lang || flags.language);
+      const translations = to ? { [to]: OP_TEMPLATES[op][to] } : OP_TEMPLATES[op];
+      if (to && !translations[to]) {
+        console.error('Unsupported target language: ' + (flags.to || flags.lang || flags.language));
+        process.exit(1);
+      }
+      const packets = Object.fromEntries(
+        Object.entries(translations).map(([language, code]) => [language, packetFromText(code, { language })])
+      );
+      const result = {
+        schema_version: 'polly_cross_op_v1',
+        op,
+        translations,
+        packets,
+      };
+      if (ws) {
+        appendAudit(ws, 'cross.op', op, {
+          targets: Object.keys(translations),
+          packet_heads: Object.fromEntries(Object.entries(packets).map(([k, v]) => [k, v.sha256.slice(0, 16)])),
+        });
+      }
+      out(result, true);
+      return;
+    }
+
+    console.error('Unknown cross subcommand: ' + sub + '. Use: pack, unpack, op, langs, ops');
+    process.exit(1);
+  },
+
   async shell(args, flags) {
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: 'polly> ' });
     console.log('Polly shell v' + VERSION + '. Type .exit to quit, .help for commands.');
@@ -1446,6 +1714,9 @@ Commands:
   audit verify             Verify hash-chained audit receipts
   audit list               List audit receipts
   audit export             Export audit receipts as JSON
+  cross pack               Decompose text/file into UTF-8 hex/binary packet
+  cross unpack             Rehydrate text from packet hex
+  cross op                 Render bounded ops across supported languages
   doctor                   Check environment (Node, Ollama, API keys, git)
   tools list               List governed tools (tools.json) + built-in recipes
   tools inspect <name>     Show tool details, parameters, and example
@@ -1488,6 +1759,8 @@ Examples:
   polly run review src/index.ts
   polly run plan --dry-run "migrate to new API"
   polly audit verify
+  polly cross pack --text "def add(x, y): return x + y" --lang python
+  polly cross op add --json
   polly runs --json
   polly handoff | pbcopy
 `;

--- a/packages/polly-pad-cli/tests/workspace.test.cjs
+++ b/packages/polly-pad-cli/tests/workspace.test.cjs
@@ -301,3 +301,73 @@ test('polly tools run dry-run shows command without executing', async (t) => {
   assert.deepStrictEqual(data.args, ['hello', 'world']);
   assert.strictEqual(data.unresolved_placeholders.length, 0);
 });
+
+// ---------------------------------------------------------------------------
+// Test 11: polly cross pack/unpack round-trips UTF-8 through hex
+// ---------------------------------------------------------------------------
+test('polly cross pack/unpack round-trips UTF-8 through hex', () => {
+  const dir = mktemp();
+  try {
+    run(dir, ['init', 'CrossPackTest']);
+    const source = 'def add(x, y): return x + y';
+    const packResult = run(dir, ['cross', 'pack', '--text', source, '--lang', 'python']);
+    assert.strictEqual(packResult.status, 0, 'cross pack should exit 0\nstdout: ' + packResult.stdout + '\nstderr: ' + packResult.stderr);
+    const packet = JSON.parse(packResult.stdout);
+    assert.strictEqual(packet.schema_version, 'polly_cross_packet_v1');
+    assert.strictEqual(packet.language, 'python');
+    assert.strictEqual(Buffer.from(packet.hex, 'hex').toString('utf8'), source);
+    assert.match(packet.sha256, /^[a-f0-9]{64}$/);
+    assert.match(packet.semantic_hex, /^[a-f0-9]{12}$/);
+    assert.notStrictEqual(packet.semantic_hex, '000000000000');
+
+    const unpackResult = run(dir, ['cross', 'unpack', '--hex', packet.hex, '--json']);
+    assert.strictEqual(unpackResult.status, 0, 'cross unpack should exit 0');
+    const unpacked = JSON.parse(unpackResult.stdout);
+    assert.strictEqual(unpacked.text, source);
+    assert.strictEqual(unpacked.verified_sha256, packet.sha256);
+
+    const auditResult = run(dir, ['audit', 'list', '--json']);
+    const events = JSON.parse(auditResult.stdout);
+    assert.ok(events.some((event) => event.action === 'cross.pack'));
+    assert.ok(events.some((event) => event.action === 'cross.unpack'));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 12: polly cross op broadcasts bounded operation templates
+// ---------------------------------------------------------------------------
+test('polly cross op broadcasts bounded operation templates', () => {
+  const dir = mktemp();
+  try {
+    run(dir, ['init', 'CrossOpTest']);
+    const result = run(dir, ['cross', 'op', 'add', '--json']);
+    assert.strictEqual(result.status, 0, 'cross op should exit 0\nstdout: ' + result.stdout + '\nstderr: ' + result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.strictEqual(payload.schema_version, 'polly_cross_op_v1');
+    assert.strictEqual(payload.translations.python, 'result = x + y');
+    assert.strictEqual(payload.translations.rust, 'let result = x + y;');
+    assert.strictEqual(Buffer.from(payload.packets.python.hex, 'hex').toString('utf8'), payload.translations.python);
+    assert.match(payload.packets.typescript.semantic_hex, /^[a-f0-9]{12}$/);
+    assert.notStrictEqual(payload.packets.typescript.semantic_hex, '000000000000');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 13: polly cross op can target one language
+// ---------------------------------------------------------------------------
+test('polly cross op can target one language', () => {
+  const dir = mktemp();
+  try {
+    run(dir, ['init', 'CrossTargetTest']);
+    const result = run(dir, ['cross', 'op', 'xor', '--to', 'go', '--json']);
+    assert.strictEqual(result.status, 0, 'cross op --to should exit 0');
+    const payload = JSON.parse(result.stdout);
+    assert.deepStrictEqual(Object.keys(payload.translations), ['go']);
+    assert.strictEqual(payload.translations.go, 'result := x ^ y');
+  } finally {
+    cleanup(dir);
+  }});


### PR DESCRIPTION
## Summary
- adds `polly cross pack` for lossless UTF-8 byte decomposition into hex/binary packets
- adds `polly cross unpack` to rehydrate packet hex back into text with SHA-256 verification
- adds `polly cross op` for bounded cross-language operation templates across Python, JavaScript, TypeScript, Rust, Go, and shell
- adds semantic 6-axis route fingerprints (`semantic_dims` + 12-char `semantic_hex`) alongside byte-level transport
- writes audit receipts for cross pack/unpack/op actions when inside a `.polly` workspace
- documents that byte transport is lossless while operation translation is intentionally bounded, not arbitrary AST translation

## Verification
- `npm test` in `packages/polly-pad-cli` -> 13 passed
- manual `init -> cross pack -> audit verify` smoke -> passed
- `node packages\\polly-pad-cli\\bin\\polly.js cross ops --json` -> lists 6 ops
- `node packages\\polly-pad-cli\\bin\\polly.js cross langs --json` -> lists 6 languages
- `npm pack --dry-run` -> clean 6-file tarball
- `git diff --check` -> clean

## Notes
This is the first public-safe bridge layer: lossless byte/hex/binary packet transport plus bounded operation rendering. It does not claim arbitrary cross-language AST compilation yet.

## Rollback
- revert `cross` command helpers from `packages/polly-pad-cli/bin/polly.js`
- remove cross CLI tests from `packages/polly-pad-cli/tests/workspace.test.cjs`
- remove README cross-language packet section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cross-language packet functionality to convert text into UTF-8/hex/binary packets with SHA-256 verification and semantic analysis.
  * Introduced `polly cross` command with subcommands for packing, unpacking, and rendering operations across multiple programming languages.

* **Documentation**
  * Updated README with cross-language packet examples and quick start guidance.

* **Tests**
  * Added comprehensive test coverage for cross-language packet operations and language-specific transformations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/1996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->