### PR TITLE
fix(deps): bump uv lock pin past advisory

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -229,7 +229,7 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2026.2
 urllib3==2.7.0
-uv==0.11.14
+uv==0.11.17
 uvicorn==0.43.0
 virtualenv==21.3.1
 watchdog==6.0.0


### PR DESCRIPTION
## Summary
- bumps `uv` in `requirements-lock.txt` from `0.11.14` to `0.11.17`
- addresses the open Dependabot advisory requiring `uv >= 0.11.15`
- leaves `requirements.txt` and `pyproject.toml` unchanged because they do not directly declare `uv`

## Verification
- `gh api repos/issdandavis/SCBE-AETHERMOORE/dependabot/alerts` showed only 3 open alerts, all for `uv < 0.11.15`
- `python -m pip index versions uv` shows `0.11.17` available
- `python -m pip install --dry-run --no-deps uv==0.11.17` -> would install `uv-0.11.17`
- `git diff --check` -> clean

## Notes
A full `pip install --dry-run -r requirements-lock.txt --no-deps` is blocked by the pre-existing editable `SCBEAgent` Git requirement path, unrelated to `uv`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a build tool dependency to the latest stable version for improved performance and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/2002?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->