### PR TITLE
feat(polly): route through free-first terminal models

### DIFF
--- a/config/governance/terminal_ai_router_profiles.json
+++ b/config/governance/terminal_ai_router_profiles.json
@@ -1,6 +1,9 @@
 {
-  "version": "2026-03-04",
+  "version": "2026-05-30",
   "provider_order": [
+    "cerebras",
+    "groq",
+    "huggingface",
     "openai",
     "anthropic",
     "xai"
@@ -104,6 +107,40 @@
       ],
       "health_endpoint": "https://huggingface.co/api/whoami-v2",
       "daily_cap_usd": 2.0
+    },
+    "cerebras": {
+      "enabled": true,
+      "env_keys": [
+        "CEREBRAS_API_KEY"
+      ],
+      "health_endpoint": "https://api.cerebras.ai/v1/models",
+      "chat_endpoint": "https://api.cerebras.ai/v1/chat/completions",
+      "daily_cap_usd": 2.0,
+      "timeout_sec": 15,
+      "note": "Squad fast-ops unit. Free tier; use for triage and code-translation planning.",
+      "tiers": {
+        "cheap": {
+          "model": "gpt-oss-120b",
+          "estimated_cents": 0.0
+        }
+      }
+    },
+    "groq": {
+      "enabled": true,
+      "env_keys": [
+        "GROQ_API_KEY"
+      ],
+      "health_endpoint": "https://api.groq.com/openai/v1/models",
+      "chat_endpoint": "https://api.groq.com/openai/v1/chat/completions",
+      "daily_cap_usd": 2.0,
+      "timeout_sec": 20,
+      "note": "Squad safety/auth/policy unit. Free tier; use for policy decisions.",
+      "tiers": {
+        "cheap": {
+          "model": "llama-3.3-70b-versatile",
+          "estimated_cents": 0.0
+        }
+      }
     }
   },
   "default_system_prompt": "You are an SCBE terminal assistant. Keep answers short, practical, and evidence-aware."

--- a/packages/polly-pad-cli/bin/polly.js
+++ b/packages/polly-pad-cli/bin/polly.js
@@ -509,6 +509,7 @@ const TRANSLATE_BENCH = [
     from: 'python',
     to: 'javascript',
     source: 'def add(x, y):\n    return x + y',
+    fixture_translation: 'function add(x, y) {\n  return x + y;\n}',
     verify_js: function(translation, x, y) {
       return translation + '\nconsole.log(add(' + x + ', ' + y + '));';
     },
@@ -521,6 +522,7 @@ const TRANSLATE_BENCH = [
     from: 'python',
     to: 'javascript',
     source: 'def factorial(n):\n    if n <= 1:\n        return 1\n    return n * factorial(n - 1)',
+    fixture_translation: 'function factorial(n) {\n  if (n <= 1) return 1;\n  return n * factorial(n - 1);\n}',
     verify_js: function(translation, n) {
       return translation + '\nconsole.log(factorial(' + n + '));';
     },
@@ -533,6 +535,8 @@ const TRANSLATE_BENCH = [
     from: 'python',
     to: 'javascript',
     source: 'def fizzbuzz(n):\n    result = []\n    for i in range(1, n + 1):\n        if i % 15 == 0:\n            result.append("FizzBuzz")\n        elif i % 3 == 0:\n            result.append("Fizz")\n        elif i % 5 == 0:\n            result.append("Buzz")\n        else:\n            result.append(str(i))\n    return result',
+    fixture_translation:
+      'function fizzbuzz(n) {\n  const result = [];\n  for (let i = 1; i <= n; i++) {\n    if (i % 15 === 0) result.push("FizzBuzz");\n    else if (i % 3 === 0) result.push("Fizz");\n    else if (i % 5 === 0) result.push("Buzz");\n    else result.push(String(i));\n  }\n  return result;\n}',
     verify_js: function(translation, n) {
       return translation + '\nconsole.log(fizzbuzz(' + n + ').join(","));';
     },
@@ -545,8 +549,11 @@ const TRANSLATE_BENCH = [
     from: 'python',
     to: 'javascript',
     source: 'def is_palindrome(s):\n    s = s.lower().replace(" ", "")\n    return s == s[::-1]',
+    fixture_translation:
+      'function isPalindrome(s) {\n  s = s.toLowerCase().replace(/ /g, "");\n  return s === s.split("").reverse().join("");\n}',
     verify_js: function(translation, s) {
-      return translation + '\nconsole.log(is_palindrome(' + JSON.stringify(s) + ').toString());';
+      const fn = resolveJsFunctionName(translation, ['is_palindrome', 'isPalindrome']);
+      return translation + '\nconsole.log(' + fn + '(' + JSON.stringify(s) + ').toString());';
     },
     inputs: ['racecar'],
     expected: 'true',
@@ -561,6 +568,17 @@ const TRANSLATE_BENCH = [
     expected: '5',
   },
 ];
+
+function resolveJsFunctionName(source, candidates) {
+  for (const candidate of candidates) {
+    const escaped = candidate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(
+      '(function\\s+' + escaped + '\\s*\\(|(?:const|let|var)\\s+' + escaped + '\\s*=|' + escaped + '\\s*=\\s*function)'
+    );
+    if (pattern.test(source)) return candidate;
+  }
+  return candidates[0];
+}
 
 function buildTranslatePrompt(fromLang, toLang, sourceCode) {
   return (
@@ -606,9 +624,14 @@ async function runTranslateBench(opts) {
         translated = '(direct source run — no translation needed for baseline)';
         if (execMatch) passed++;
       } else {
-        const llmResult = await translateCode(bench.from, bench.to, bench.source);
-        translated = llmResult ? llmResult.text : '';
-        modelUsed = llmResult ? (llmResult.model_used || 'unknown') : 'none';
+        if (opts.dryRun && bench.fixture_translation) {
+          translated = bench.fixture_translation;
+          modelUsed = 'fixture';
+        } else {
+          const llmResult = await translateCode(bench.from, bench.to, bench.source);
+          translated = llmResult ? llmResult.text : '';
+          modelUsed = llmResult ? (llmResult.model_used || 'unknown') : 'none';
+        }
         // Strip markdown fences if model wrapped the code
         translated = translated.replace(/^```[a-zA-Z]*\n?/, '').replace(/\n?```$/, '').trim();
         if (bench.to === 'javascript' && bench.verify_js && translated && bench.inputs.length > 0) {
@@ -1072,6 +1095,53 @@ async function tryAnthropic(prompt) {
   }
 }
 
+function hasAnyEnv(names) {
+  return names.some((name) => Boolean(process.env[name]));
+}
+
+function findRepoRootForRouter() {
+  return detectGitRoot(process.cwd()) || detectGitRoot(__dirname);
+}
+
+async function tryTerminalAiRouter(prompt) {
+  if (process.env.POLLY_DISABLE_TERMINAL_ROUTER === '1') return null;
+  if (!hasAnyEnv(['CEREBRAS_API_KEY', 'GROQ_API_KEY', 'HF_TOKEN'])) return null;
+
+  const repoRoot = findRepoRootForRouter();
+  if (!repoRoot) return null;
+  const routerPath = path.join(repoRoot, 'scripts', 'system', 'terminal_ai_router.py');
+  if (!fs.existsSync(routerPath)) return null;
+
+  try {
+    const result = spawnSync(
+      process.env.PYTHON || 'python',
+      [
+        routerPath,
+        'call',
+        '--prompt',
+        prompt,
+        '--providers',
+        'cerebras,groq,huggingface',
+        '--max-output-tokens',
+        '2048',
+        '--response-only',
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        timeout: 45000,
+        maxBuffer: 1024 * 1024 * 4,
+        env: Object.assign({}, process.env),
+      }
+    );
+    const text = String(result.stdout || '').trim();
+    if (result.status !== 0 || !text) return null;
+    return { text, model_used: 'terminal-ai-router', source: 'free-first-router' };
+  } catch (_) {
+    return null;
+  }
+}
+
 async function tryOpenAI(prompt) {
   const key = process.env.OPENAI_API_KEY;
   if (!key) return null;
@@ -1130,6 +1200,8 @@ function templateFallback(prompt) {
 async function routeToModel(prompt) {
   const ollama = await tryOllama(prompt);
   if (ollama && ollama.text) return ollama;
+  const terminalRouter = await tryTerminalAiRouter(prompt);
+  if (terminalRouter && terminalRouter.text) return terminalRouter;
   const anthropic = await tryAnthropic(prompt);
   if (anthropic && anthropic.text) return anthropic;
   const openai = await tryOpenAI(prompt);

--- a/packages/polly-pad-cli/tests/workspace.test.cjs
+++ b/packages/polly-pad-cli/tests/workspace.test.cjs
@@ -554,7 +554,26 @@ test('polly cross bench translate returns correct schema', async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Test 24: polly cross translate --dry-run shows prompt
+// Test 24: polly cross bench translate --dry-run verifies fixture translations
+// ---------------------------------------------------------------------------
+test('polly cross bench translate --dry-run verifies fixture translations', async () => {
+  const result = spawnSync('node', [BIN, 'cross', 'bench', 'translate', '--dry-run', '--json'], {
+    encoding: 'utf8',
+    timeout: 60000,
+    env: { ...process.env, POLLY_DISABLE_TERMINAL_ROUTER: '1' },
+  });
+  assert.strictEqual(result.status, 0, 'bench translate dry-run should exit 0\n' + result.stderr);
+  const data = JSON.parse(result.stdout);
+  assert.strictEqual(data.schema_version, 'polly_cross_bench_v1');
+  assert.strictEqual(data.execution_match_rate, 1);
+  const palindrome = data.results.find((entry) => entry.id === 'bench_palindrome');
+  assert.ok(palindrome, 'palindrome bench result should exist');
+  assert.strictEqual(palindrome.model, 'fixture');
+  assert.strictEqual(palindrome.exec_match, true);
+});
+
+// ---------------------------------------------------------------------------
+// Test 25: polly cross translate --dry-run shows prompt
 // ---------------------------------------------------------------------------
 test('polly cross translate --dry-run shows prompt', () => {
   const result = spawnSync(

--- a/scripts/system/terminal_ai_router.py
+++ b/scripts/system/terminal_ai_router.py
@@ -31,6 +31,8 @@ ALIAS_SYNC_MAP: dict[str, list[str]] = {
     "ANTHROPIC_API_KEY": ["CLAUDE_API_KEY"],
     "XAI_API_KEY": ["GROK_API_KEY"],
     "HF_TOKEN": ["HUGGINGFACE_TOKEN", "HUGGING_FACE_HUB_TOKEN"],
+    "CEREBRAS_API_KEY": [],
+    "GROQ_API_KEY": [],
 }
 
 DEFAULT_PROVIDER_KEYS: dict[str, list[str]] = {
@@ -38,9 +40,11 @@ DEFAULT_PROVIDER_KEYS: dict[str, list[str]] = {
     "anthropic": ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"],
     "xai": ["XAI_API_KEY", "GROK_API_KEY"],
     "huggingface": ["HF_TOKEN", "HUGGINGFACE_TOKEN", "HUGGING_FACE_HUB_TOKEN"],
+    "cerebras": ["CEREBRAS_API_KEY"],
+    "groq": ["GROQ_API_KEY"],
 }
 
-DEFAULT_PROVIDER_ORDER = ["openai", "anthropic", "xai"]
+DEFAULT_PROVIDER_ORDER = ["cerebras", "groq", "huggingface", "openai", "anthropic", "xai"]
 DEFAULT_COMPLEXITY_TIERS = {
     "easy": ["cheap"],
     "medium": ["cheap", "standard"],
@@ -53,6 +57,8 @@ DEFAULT_PROVIDER_HOSTS: dict[str, set[str]] = {
     "xai": {"api.x.ai"},
     "huggingface": {"huggingface.co"},
     "hf": {"huggingface.co"},
+    "cerebras": {"api.cerebras.ai"},
+    "groq": {"api.groq.com"},
 }
 
 
@@ -324,15 +330,15 @@ def _status_from_http(http_status: int | None) -> str:
     return "degraded"
 
 
-def _health_openai(provider_cfg: dict[str, Any]) -> dict[str, Any]:
-    env_keys = _provider_env_keys("openai", provider_cfg)
+def _health_openai_like(provider: str, provider_cfg: dict[str, Any], default_endpoint: str) -> dict[str, Any]:
+    env_keys = _provider_env_keys(provider, provider_cfg)
     key_name, key_value, key_source = _pick_secret_value(env_keys)
     if not key_value:
         return {"status": "requires_auth", "detail": {"reason": "missing_key", "accepted_keys": env_keys}}
 
     url = _validate_provider_endpoint(
-        str(provider_cfg.get("health_endpoint") or "https://api.openai.com/v1/models").strip(),
-        "openai",
+        str(provider_cfg.get("health_endpoint") or default_endpoint).strip(),
+        provider,
         provider_cfg,
     )
     status, body, error = _request_json(url, headers={"Authorization": f"Bearer {key_value}"}, timeout=20)
@@ -351,6 +357,10 @@ def _health_openai(provider_cfg: dict[str, Any]) -> dict[str, Any]:
     else:
         _attach_response_summary(detail, body)
     return {"status": _status_from_http(status), "detail": detail}
+
+
+def _health_openai(provider_cfg: dict[str, Any]) -> dict[str, Any]:
+    return _health_openai_like("openai", provider_cfg, "https://api.openai.com/v1/models")
 
 
 def _health_anthropic(provider_cfg: dict[str, Any]) -> dict[str, Any]:
@@ -387,32 +397,15 @@ def _health_anthropic(provider_cfg: dict[str, Any]) -> dict[str, Any]:
 
 
 def _health_xai(provider_cfg: dict[str, Any]) -> dict[str, Any]:
-    env_keys = _provider_env_keys("xai", provider_cfg)
-    key_name, key_value, key_source = _pick_secret_value(env_keys)
-    if not key_value:
-        return {"status": "requires_auth", "detail": {"reason": "missing_key", "accepted_keys": env_keys}}
+    return _health_openai_like("xai", provider_cfg, "https://api.x.ai/v1/models")
 
-    url = _validate_provider_endpoint(
-        str(provider_cfg.get("health_endpoint") or "https://api.x.ai/v1/models").strip(),
-        "xai",
-        provider_cfg,
-    )
-    status, body, error = _request_json(url, headers={"Authorization": f"Bearer {key_value}"}, timeout=20)
-    detail = {
-        "http_status": status,
-        "key_preview": _mask_value(key_value),
-        "key_source": key_source,
-        "error": error,
-    }
-    if isinstance(body, dict):
-        data = body.get("data")
-        if isinstance(data, list):
-            detail["sample_models"] = [str(item.get("id", "")) for item in data[:8] if isinstance(item, dict)]
-        else:
-            _attach_response_summary(detail, body)
-    else:
-        _attach_response_summary(detail, body)
-    return {"status": _status_from_http(status), "detail": detail}
+
+def _health_cerebras(provider_cfg: dict[str, Any]) -> dict[str, Any]:
+    return _health_openai_like("cerebras", provider_cfg, "https://api.cerebras.ai/v1/models")
+
+
+def _health_groq(provider_cfg: dict[str, Any]) -> dict[str, Any]:
+    return _health_openai_like("groq", provider_cfg, "https://api.groq.com/openai/v1/models")
 
 
 def _health_hf(provider_cfg: dict[str, Any]) -> dict[str, Any]:
@@ -472,6 +465,10 @@ def run_health(args: argparse.Namespace) -> int:
             status_map[provider] = _health_xai(provider_cfg)
         elif provider in {"huggingface", "hf"}:
             status_map["huggingface"] = _health_hf(provider_cfg)
+        elif provider == "cerebras":
+            status_map[provider] = _health_cerebras(provider_cfg)
+        elif provider == "groq":
+            status_map[provider] = _health_groq(provider_cfg)
         else:
             status_map[provider] = {
                 "status": "degraded",
@@ -803,7 +800,7 @@ def run_call(args: argparse.Namespace) -> int:
                 )
                 continue
 
-            if provider in {"openai", "xai"}:
+            if provider in {"openai", "xai", "cerebras", "groq"}:
                 ok, text, http_status, body, error = _call_openai_like(
                     endpoint=endpoint,
                     api_key=api_key,
@@ -890,11 +887,16 @@ def run_call(args: argparse.Namespace) -> int:
         "ledger_path": str(ledger_path.resolve()),
     }
     _write_json(output_path, result)
+    if args.response_only:
+        if final_text:
+            print(final_text)
+        return 0 if selected else 1
+
     print(json.dumps(_sanitize_for_report({**result, "output_path": str(output_path)}), indent=2))
 
     if args.print_response and final_text:
         print("")
-        print(json.dumps({"response_metadata": _response_metadata(final_text)}, indent=2))
+        print(final_text)
 
     return 0 if selected else 1
 
@@ -911,7 +913,7 @@ def build_parser() -> argparse.ArgumentParser:
     health = sub.add_parser("health", help="Run provider health checks.")
     health.add_argument(
         "--checks",
-        default="openai,anthropic,xai,huggingface",
+        default="cerebras,groq,huggingface,openai,anthropic,xai",
         help="Comma-separated checks.",
     )
     health.add_argument(
@@ -946,6 +948,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     call.add_argument("--sync-aliases", action="store_true", help="Sync alias keys into canonical names first.")
     call.add_argument("--print-response", action="store_true", help="Print final response text to stdout.")
+    call.add_argument("--response-only", action="store_true", help="Print only final response text to stdout.")
     call.set_defaults(func=run_call)
 
     return parser

--- a/tests/test_system_script_security.py
+++ b/tests/test_system_script_security.py
@@ -371,6 +371,20 @@ def test_terminal_ai_router_guards_endpoint_and_output_path():
     )
     assert validated == "https://api.openai.com/v1/models"
 
+    cerebras = terminal_ai_router._validate_provider_endpoint(
+        "https://api.cerebras.ai/v1/models",
+        "cerebras",
+        {},
+    )
+    assert cerebras == "https://api.cerebras.ai/v1/models"
+
+    groq = terminal_ai_router._validate_provider_endpoint(
+        "https://api.groq.com/openai/v1/models",
+        "groq",
+        {},
+    )
+    assert groq == "https://api.groq.com/openai/v1/models"
+
     try:
         terminal_ai_router._validate_provider_endpoint("http://localhost:8000", "openai", {})
     except ValueError as exc:


### PR DESCRIPTION
## Summary
- routes Polly `ask` / recipe calls through the SCBE terminal AI router before paid provider APIs
- updates terminal AI router support for Cerebras and Groq OpenAI-compatible chat/health endpoints
- updates router profile to free-first order: Cerebras -> Groq -> HuggingFace -> OpenAI -> Anthropic -> xAI
- fixes translation benchmark palindrome verification to accept idiomatic `isPalindrome` output
- makes `polly cross bench translate --dry-run` deterministic with fixture translations, so verifier behavior can be tested without live model calls

## Why
The smoke test showed Polly fell back to templates when local Ollama had no models and Anthropic API credits were unavailable, even though the repo has a free-first router stack. This makes Polly use the repo's provider-neutral routing layer instead of becoming a thin paid-provider wrapper.

## Verification
- `node --test packages/polly-pad-cli/tests/workspace.test.cjs` -> 25 passed
- `python -m pytest tests/test_system_script_security.py -q` -> 14 passed
- `python scripts/system/terminal_ai_router.py health --checks cerebras,groq,huggingface --output artifacts/ai_router/free_first_health.json` -> command passed; HuggingFace ok, Cerebras/Groq return 403 in this shell
- `git diff --check` -> clean

## Live provider note
`terminal_ai_router.py call --providers cerebras,groq,huggingface --response-only` is wired, but current Cerebras/Groq env credentials return HTTP 403 in this shell. The code path is ready; keys/quota need repair before live text generation succeeds on those lanes.