### PR TITLE
feat(polly): add HuggingFace router fallback

### DIFF
--- a/config/governance/terminal_ai_router_profiles.json
+++ b/config/governance/terminal_ai_router_profiles.json
@@ -106,7 +106,16 @@
         "HUGGING_FACE_HUB_TOKEN"
       ],
       "health_endpoint": "https://huggingface.co/api/whoami-v2",
-      "daily_cap_usd": 2.0
+      "chat_endpoint": "https://router.huggingface.co/v1/chat/completions",
+      "daily_cap_usd": 0.0,
+      "timeout_sec": 45,
+      "note": "Included-credit fallback through HuggingFace Router when Cerebras/Groq are unavailable.",
+      "tiers": {
+        "cheap": {
+          "model": "Qwen/Qwen2.5-Coder-32B-Instruct",
+          "estimated_cents": 0.0
+        }
+      }
     },
     "cerebras": {
       "enabled": true,

--- a/packages/polly-pad-cli/bin/polly.js
+++ b/packages/polly-pad-cli/bin/polly.js
@@ -1028,6 +1028,7 @@ async function fetchWithTimeout(url, opts, timeoutMs) {
 }
 
 async function tryOllama(prompt) {
+  if (process.env.POLLY_DISABLE_OLLAMA === '1') return null;
   const base = (process.env.OLLAMA_BASE_URL || 'http://localhost:11434').replace(/\/$/, '');
   const apiKey = process.env.OLLAMA_API_KEY || '';
   const model = process.env.OLLAMA_MODEL || 'llama3.2';
@@ -1192,7 +1193,7 @@ function templateFallback(prompt) {
     '- [ ] Assign priorities',
     '- [ ] Set success criteria',
     '',
-    '_Configure Ollama (localhost:11434), ANTHROPIC_API_KEY, or OPENAI_API_KEY to get real model responses._',
+    '_Configure Ollama (localhost:11434), free router keys, ANTHROPIC_API_KEY, or OPENAI_API_KEY to get real model responses._',
   ].join('\n');
   return { text, model_used: 'template', source: 'fallback' };
 }
@@ -1202,6 +1203,7 @@ async function routeToModel(prompt) {
   if (ollama && ollama.text) return ollama;
   const terminalRouter = await tryTerminalAiRouter(prompt);
   if (terminalRouter && terminalRouter.text) return terminalRouter;
+  if (process.env.POLLY_DISABLE_PAID_APIS === '1') return templateFallback(prompt);
   const anthropic = await tryAnthropic(prompt);
   if (anthropic && anthropic.text) return anthropic;
   const openai = await tryOpenAI(prompt);
@@ -2510,9 +2512,13 @@ Global flags:
 
 LLM routing priority:
   1. Ollama (localhost:11434, llama3.2, 8s timeout)
-  2. Anthropic (ANTHROPIC_API_KEY, claude-haiku-4-5-20251001, 30s)
-  3. OpenAI   (OPENAI_API_KEY, gpt-4o-mini, 30s)
-  4. Template fallback (no model required)
+  2. Free-first terminal router (Cerebras -> Groq -> HuggingFace)
+  3. Anthropic (ANTHROPIC_API_KEY, claude-haiku-4-5-20251001, 30s)
+  4. OpenAI   (OPENAI_API_KEY, gpt-4o-mini, 30s)
+  5. Template fallback (no model required)
+
+Set POLLY_DISABLE_PAID_APIS=1 to stop after Ollama/free-router attempts.
+Set POLLY_DISABLE_OLLAMA=1 to skip local/Ollama-cloud routing.
 
 Examples:
   polly init MyProject

--- a/packages/polly-pad-cli/tests/workspace.test.cjs
+++ b/packages/polly-pad-cli/tests/workspace.test.cjs
@@ -189,7 +189,30 @@ test('polly snapshot creates snapshot file', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Test 9: polly audit verify validates receipt chain
+// Test 9: polly ask can force free/local-only routing before template fallback
+// ---------------------------------------------------------------------------
+test('polly ask respects POLLY_DISABLE_PAID_APIS fallback', () => {
+  const dir = mktemp();
+  try {
+    run(dir, ['init', 'FreeOnlyAskTest']);
+    const result = run(dir, ['ask', 'make a short checklist', '--json'], {
+      POLLY_DISABLE_TERMINAL_ROUTER: '1',
+      POLLY_DISABLE_OLLAMA: '1',
+      POLLY_DISABLE_PAID_APIS: '1',
+      ANTHROPIC_API_KEY: '',
+      OPENAI_API_KEY: '',
+    });
+    assert.strictEqual(result.status, 0, 'ask should succeed\nstdout: ' + result.stdout + '\nstderr: ' + result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.strictEqual(payload.model_used, 'template');
+    assert.strictEqual(payload.source, 'fallback');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 10: polly audit verify validates receipt chain
 // ---------------------------------------------------------------------------
 test('polly audit verify validates receipt chain', () => {
   const dir = mktemp();
@@ -221,7 +244,7 @@ test('polly audit verify validates receipt chain', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Test 10: polly audit verify fails on tampered receipt
+// Test 11: polly audit verify fails on tampered receipt
 // ---------------------------------------------------------------------------
 test('polly audit verify fails on tampered receipt', () => {
   const dir = mktemp();

--- a/scripts/system/terminal_ai_router.py
+++ b/scripts/system/terminal_ai_router.py
@@ -55,8 +55,8 @@ DEFAULT_PROVIDER_HOSTS: dict[str, set[str]] = {
     "openai": {"api.openai.com"},
     "anthropic": {"api.anthropic.com"},
     "xai": {"api.x.ai"},
-    "huggingface": {"huggingface.co"},
-    "hf": {"huggingface.co"},
+    "huggingface": {"huggingface.co", "router.huggingface.co"},
+    "hf": {"huggingface.co", "router.huggingface.co"},
     "cerebras": {"api.cerebras.ai"},
     "groq": {"api.groq.com"},
 }
@@ -249,6 +249,7 @@ def _request_json(
     timeout: int = 45,
 ) -> tuple[int | None, dict[str, Any], str]:
     request_headers = dict(headers or {})
+    request_headers.setdefault("User-Agent", "scbe-terminal-ai-router/1.0")
     data: bytes | None = None
     if body is not None:
         data = json.dumps(body).encode("utf-8")
@@ -800,7 +801,7 @@ def run_call(args: argparse.Namespace) -> int:
                 )
                 continue
 
-            if provider in {"openai", "xai", "cerebras", "groq"}:
+            if provider in {"openai", "xai", "cerebras", "groq", "huggingface", "hf"}:
                 ok, text, http_status, body, error = _call_openai_like(
                     endpoint=endpoint,
                     api_key=api_key,

--- a/tests/test_system_script_security.py
+++ b/tests/test_system_script_security.py
@@ -385,6 +385,13 @@ def test_terminal_ai_router_guards_endpoint_and_output_path():
     )
     assert groq == "https://api.groq.com/openai/v1/models"
 
+    huggingface_router = terminal_ai_router._validate_provider_endpoint(
+        "https://router.huggingface.co/v1/chat/completions",
+        "huggingface",
+        {},
+    )
+    assert huggingface_router == "https://router.huggingface.co/v1/chat/completions"
+
     try:
         terminal_ai_router._validate_provider_endpoint("http://localhost:8000", "openai", {})
     except ValueError as exc:


### PR DESCRIPTION
## Summary
- Adds HuggingFace Router as the third free/included-credit terminal-router provider after Cerebras and Groq.
- Allows `router.huggingface.co` in the endpoint guard and sends a stable User-Agent for urllib requests.
- Adds `POLLY_DISABLE_PAID_APIS=1` and `POLLY_DISABLE_OLLAMA=1` controls so Polly can stay local/free-only before template fallback.

## Test evidence
- `python -m pytest tests/test_system_script_security.py -q` -> 14 passed
- `node --test packages/polly-pad-cli/tests/workspace.test.cjs` -> 26 passed
- `git diff --check` -> clean
- Live free-first Polly smoke: `POLLY_DISABLE_OLLAMA=1 POLLY_DISABLE_PAID_APIS=1 polly ask ... --json` -> selected terminal-ai-router via Cerebras, returned requested text

## Live provider notes
- Cerebras health: OK, `gpt-oss-120b` reachable.
- Groq health: requires auth in this shell.
- HuggingFace account health: OK, but direct Router chat returned HTTP 402 because monthly included Inference Provider credits are depleted.

## Rollback
- Revert this commit to remove HF Router call support and the Polly free-only env switches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added environment variable controls (`POLLY_DISABLE_OLLAMA`, `POLLY_DISABLE_PAID_APIS`) to manage LLM provider selection
  * Configured HuggingFace provider with tier-based pricing and daily spending limits
  * HuggingFace now available as a fallback when other providers are unavailable

* **Documentation**
  * Updated CLI help text to reflect LLM routing priority and provider configuration options

* **Tests**
  * Added coverage for new provider routing behavior and fallback scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/issdandavis/SCBE-AETHERMOORE/pull/2005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->