### PR TITLE
feat(geoseed): add orbital shell model

### DIFF
--- a/docs/research/geoseed_orbital_model.md
+++ b/docs/research/geoseed_orbital_model.md
@@ -1,0 +1,77 @@
+# GeoSeed Orbital Model
+
+This note preserves the electron-orbital pattern as a GeoSeed geometry model.
+It is not a claim that the SCBE stack computes real electron orbitals. The
+useful result is a deterministic structural analogy:
+
+- the six Sacred Tongues map to `s/p/d/f/g/h` shells;
+- the tongue phi ladder maps to radial depth in the Poincare ball;
+- adjacent shells have a uniform hyperbolic gap of `ln(phi)`;
+- the Cassisivadan shell lands at `r = 1/phi`;
+- the magnetic sub-state counts form `1 + 3 + 5 + 7 + 9 + 11 = 36`.
+
+The model is implemented in `src/geoseed/orbital_model.py`. It intentionally
+uses only Python standard-library math so it can run in the CLI and CI without
+adding NumPy or SciPy.
+
+## Interpretation
+
+Electron orbitals are standing-wave solutions to a quantum Hamiltonian. In flat
+space, the angular part is described by spherical harmonics and the radial part
+depends on the potential and boundary conditions. In a hyperbolic manifold, the
+Laplacian becomes the Laplace-Beltrami operator and the geometry changes the
+spacing, volume growth, and node density.
+
+GeoSeed uses that as a pattern language:
+
+| Tongue | Orbital | l | m-states | Phi weight |
+| --- | --- | ---: | ---: | ---: |
+| KO | s | 0 | 1 | phi^0 |
+| AV | p | 1 | 3 | phi^1 |
+| RU | d | 2 | 5 | phi^2 |
+| CA | f | 3 | 7 | phi^3 |
+| UM | g | 4 | 9 | phi^4 |
+| DR | h | 5 | 11 | phi^5 |
+
+The radial map is:
+
+```text
+rho(n) = n * ln(phi)
+r(n)   = tanh(rho(n) / 2)
+```
+
+That gives the clean invariant:
+
+```text
+distance(shell_n, shell_n+1) = ln(phi)
+```
+
+and the Cassisivadan checkpoint:
+
+```text
+r(3) = tanh(3 * ln(phi) / 2) = 1 / phi
+```
+
+## Use
+
+Run:
+
+```bash
+python -m src.geoseed.orbital_model
+```
+
+Test:
+
+```bash
+python -m pytest tests/test_geoseed_orbital_model.py -q
+```
+
+Next useful step: render the `density_profiles` field into a small SVG or HTML
+plot so the standing-wave analogy can be inspected visually before wiring it
+into larger governance or training lanes.
+
+Render:
+
+```bash
+python scripts/research/render_geoseed_orbitals.py
+```

--- a/scripts/research/render_geoseed_orbitals.py
+++ b/scripts/research/render_geoseed_orbitals.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Render the GeoSeed orbital model as a self-contained HTML/SVG report."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.geoseed.orbital_model import orbital_summary  # noqa: E402
+
+
+def _polyline(points: list[dict[str, float]], width: int, height: int, max_density: float) -> str:
+    if not points:
+        return ""
+    max_rho = max(point["rho"] for point in points) or 1.0
+    coords: list[str] = []
+    for point in points:
+        x = 28 + (point["rho"] / max_rho) * (width - 56)
+        y = height - 24 - (point["density"] / max_density) * (height - 52)
+        coords.append(f"{x:.2f},{y:.2f}")
+    return " ".join(coords)
+
+
+def build_html() -> str:
+    summary = orbital_summary(include_profiles=True)
+    orbitals = summary["orbitals"]
+    profiles = summary["density_profiles"]
+    max_density = max(point["density"] for rows in profiles.values() for point in rows) or 1.0
+    width = 760
+    row_height = 78
+    chart_height = row_height * len(orbitals)
+
+    colors = {
+        "KO": "#2563eb",
+        "AV": "#059669",
+        "RU": "#d97706",
+        "CA": "#dc2626",
+        "UM": "#7c3aed",
+        "DR": "#0891b2",
+    }
+
+    rows: list[str] = []
+    for index, orbital in enumerate(orbitals):
+        abbr = orbital["abbr"]
+        y_base = index * row_height
+        line = _polyline(profiles[abbr], width, row_height, max_density)
+        label = (
+            f"{abbr} / {orbital['orbital_type']}-shell / "
+            f"r={orbital['poincare_r']} / m={orbital['m_states']}"
+        )
+        rows.append(
+            "\n".join(
+                [
+                    f'<g transform="translate(0,{y_base})">',
+                    f'<text x="28" y="18" class="label">{html.escape(label)}</text>',
+                    f'<line x1="28" y1="{row_height - 24}" x2="{width - 28}" y2="{row_height - 24}" class="axis" />',
+                    f'<polyline points="{line}" fill="none" stroke="{colors[abbr]}" stroke-width="2.5" />',
+                    "</g>",
+                ]
+            )
+        )
+
+    table_rows = "\n".join(
+        "<tr>"
+        f"<td>{html.escape(row['abbr'])}</td>"
+        f"<td>{html.escape(row['tongue'])}</td>"
+        f"<td>{html.escape(row['orbital_type'])}</td>"
+        f"<td>{row['phi_weight']}</td>"
+        f"<td>{row['poincare_r']}</td>"
+        f"<td>{row['hyperbolic_rho']}</td>"
+        f"<td>{row['m_states']}</td>"
+        "</tr>"
+        for row in orbitals
+    )
+
+    gaps = "\n".join(
+        f"<li>{gap['from']} -> {gap['to']}: d={gap['geodesic_distance']}, ratio={gap['phi_ratio']}</li>"
+        for gap in summary["inter_shell_gaps"]
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>GeoSeed Orbital Model</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 32px; color: #172033; background: #fbfaf7; }}
+    h1 {{ margin-bottom: 4px; }}
+    .scope {{ max-width: 860px; color: #465264; }}
+    svg {{ width: 100%; max-width: {width}px; background: #fff; border: 1px solid #d7dce2; border-radius: 8px; }}
+    .axis {{ stroke: #ccd3dd; stroke-width: 1; }}
+    .label {{ fill: #263244; font-size: 13px; font-weight: 650; }}
+    table {{ border-collapse: collapse; margin-top: 18px; background: #fff; }}
+    th, td {{ border: 1px solid #d7dce2; padding: 7px 10px; text-align: left; }}
+    th {{ background: #eef2f6; }}
+    code {{ background: #eef2f6; padding: 1px 4px; border-radius: 4px; }}
+  </style>
+</head>
+<body>
+  <h1>GeoSeed Orbital Model</h1>
+  <p class="scope">{html.escape(summary["model_scope"])}</p>
+  <p>
+    Uniform hyperbolic gap: <code>{summary["uniform_gap"]["hyperbolic_distance"]}</code>.
+    CA checkpoint: <code>r={summary["golden_ratio_checkpoint"]["poincare_r"]}=1/phi</code>.
+    Total m-states: <code>{summary["total_m_states"]}</code>.
+  </p>
+  <h2>Density Profiles</h2>
+  <svg viewBox="0 0 {width} {chart_height}" role="img" aria-label="GeoSeed radial density profiles">
+    {''.join(rows)}
+  </svg>
+  <h2>Shell Table</h2>
+  <table>
+    <thead>
+      <tr><th>Abbr</th><th>Tongue</th><th>Orbital</th><th>Phi weight</th><th>r</th><th>rho</th><th>m-states</th></tr>
+    </thead>
+    <tbody>{table_rows}</tbody>
+  </table>
+  <h2>Inter-Shell Gaps</h2>
+  <ul>{gaps}</ul>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default=str(REPO_ROOT / "artifacts" / "geoseed" / "orbital_model.html"),
+        help="Output HTML path",
+    )
+    args = parser.parse_args()
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(build_html(), encoding="utf-8")
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/geoseed/__init__.py
+++ b/src/geoseed/__init__.py
@@ -1,0 +1,26 @@
+"""GeoSeed geometry helpers.
+
+The package keeps imports lazy so `python -m src.geoseed.orbital_model` can run
+without re-import warnings.
+"""
+
+from typing import Any
+
+__all__ = [
+    "PHI",
+    "TONGUES",
+    "GeoSeedOrbital",
+    "build_geoseed_orbitals",
+    "hyperbolic_distance",
+    "inter_shell_geodesic",
+    "orbital_summary",
+    "phi_to_poincare_r",
+]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        from . import orbital_model
+
+        return getattr(orbital_model, name)
+    raise AttributeError(name)

--- a/src/geoseed/orbital_model.py
+++ b/src/geoseed/orbital_model.py
@@ -1,0 +1,248 @@
+"""GeoSeed orbital-shell model for the six Sacred Tongues.
+
+This module is a deterministic geometry model, not a claim that SCBE models
+actual electron orbitals. It maps the six tongue anchors onto a Poincare-ball
+phi ladder and then annotates each shell with the familiar orbital sequence
+s/p/d/f/g/h. The useful invariant is structural: adjacent phi shells are
+uniformly spaced in hyperbolic distance while their Euclidean radii compress
+toward the boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+PHI = (1.0 + math.sqrt(5.0)) / 2.0
+SACRED_EGG_COUNT = 21
+
+TONGUES: tuple[dict[str, Any], ...] = (
+    {"name": "Kor'aelin", "abbr": "KO", "phi_index": 0, "l": 0, "orbital": "s"},
+    {"name": "Avali", "abbr": "AV", "phi_index": 1, "l": 1, "orbital": "p"},
+    {"name": "Runethic", "abbr": "RU", "phi_index": 2, "l": 2, "orbital": "d"},
+    {"name": "Cassisivadan", "abbr": "CA", "phi_index": 3, "l": 3, "orbital": "f"},
+    {"name": "Umbroth", "abbr": "UM", "phi_index": 4, "l": 4, "orbital": "g"},
+    {"name": "Draumric", "abbr": "DR", "phi_index": 5, "l": 5, "orbital": "h"},
+)
+
+
+def phi_to_hyperbolic_rho(phi_index: int) -> float:
+    """Map phi index n to hyperbolic radial depth rho = n * ln(phi)."""
+
+    if phi_index < 0:
+        raise ValueError("phi_index must be non-negative")
+    return float(phi_index) * math.log(PHI)
+
+
+def phi_to_poincare_r(phi_index: int) -> float:
+    """Map phi index n to Euclidean radius inside the Poincare ball.
+
+    The Poincare radial coordinate is r = tanh(rho / 2). For n=3, this
+    simplifies to 1 / phi, which is the Cassisivadan f-shell checkpoint.
+    """
+
+    return math.tanh(phi_to_hyperbolic_rho(phi_index) / 2.0)
+
+
+def hyperbolic_distance(r1: float, r2: float) -> float:
+    """Collinear geodesic distance between two Poincare-ball radii."""
+
+    if not (0.0 <= r1 < 1.0 and 0.0 <= r2 < 1.0):
+        raise ValueError("Poincare radii must be in [0, 1)")
+    numerator = abs(r1 - r2)
+    denominator = 1.0 - r1 * r2
+    if numerator == 0.0:
+        return 0.0
+    return 2.0 * math.atanh(numerator / denominator)
+
+
+def laplace_beltrami_shell_value(l_value: int) -> float:
+    """Simple shell label derived from the hyperbolic angular ladder.
+
+    Full hyperbolic Schrodinger problems require a Hamiltonian and boundary
+    conditions. For this model, -(l+1)^2 is only a stable shell label for the
+    Laplace-Beltrami analogy, not a physical energy prediction.
+    """
+
+    if l_value < 0:
+        raise ValueError("l_value must be non-negative")
+    return -float((l_value + 1) ** 2)
+
+
+def radial_standing_wave(rho: float, l_value: int, radial_mode: int = 1) -> float:
+    """Dependency-free standing-wave proxy on a hyperbolic radial coordinate."""
+
+    if rho < 0.0:
+        raise ValueError("rho must be non-negative")
+    if radial_mode < 1:
+        raise ValueError("radial_mode must be at least 1")
+    if rho == 0.0 and l_value > 0:
+        return 0.0
+
+    envelope = (math.sinh(rho) ** l_value) * math.exp(-rho / (l_value + radial_mode))
+    oscillation = math.sin(radial_mode * math.pi * rho / (rho + 1.0))
+    return envelope * oscillation
+
+
+def radial_density(rho: float, l_value: int, radial_mode: int = 1) -> float:
+    """Density proxy including the H3 volume element sinh(rho)^2."""
+
+    wave = radial_standing_wave(rho, l_value, radial_mode)
+    volume = math.sinh(rho) ** 2
+    return wave * wave * volume
+
+
+def sacred_egg_nodes(phi_index: int, count: int = SACRED_EGG_COUNT) -> list[tuple[float, float, float]]:
+    """Return deterministic Fibonacci-lattice nodes on a shell sphere."""
+
+    if count < 2:
+        raise ValueError("count must be at least 2")
+    radius = phi_to_poincare_r(phi_index)
+    golden_angle = math.pi * (3.0 - math.sqrt(5.0))
+    nodes: list[tuple[float, float, float]] = []
+    for index in range(count):
+        y = 1.0 - (2.0 * index / (count - 1))
+        ring_radius = math.sqrt(max(0.0, 1.0 - y * y))
+        theta = golden_angle * index
+        x = math.cos(theta) * ring_radius
+        z = math.sin(theta) * ring_radius
+        nodes.append((radius * x, radius * y, radius * z))
+    return nodes
+
+
+@dataclass(frozen=True)
+class GeoSeedOrbital:
+    """One tongue shell in the GeoSeed orbital analogy."""
+
+    tongue: str
+    abbr: str
+    phi_index: int
+    phi_weight: float
+    l_value: int
+    orbital_type: str
+    poincare_r: float
+    hyperbolic_rho: float
+    shell_value: float
+    m_states: int
+    egg_nodes: tuple[tuple[float, float, float], ...] = field(repr=False)
+
+    def density_profile(self, samples: int = 32, radial_mode: int = 1) -> list[dict[str, float]]:
+        """Sample a compact radial density profile for visualization."""
+
+        if samples < 2:
+            raise ValueError("samples must be at least 2")
+        rho_max = max(self.hyperbolic_rho * 3.0, 1.0)
+        profile: list[dict[str, float]] = []
+        for index in range(samples):
+            rho = rho_max * index / (samples - 1)
+            profile.append(
+                {
+                    "rho": round(rho, 9),
+                    "density": round(radial_density(rho, self.l_value, radial_mode), 12),
+                }
+            )
+        return profile
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tongue": self.tongue,
+            "abbr": self.abbr,
+            "phi_index": self.phi_index,
+            "phi_weight": round(self.phi_weight, 9),
+            "l": self.l_value,
+            "orbital_type": self.orbital_type,
+            "poincare_r": round(self.poincare_r, 9),
+            "hyperbolic_rho": round(self.hyperbolic_rho, 9),
+            "shell_value": self.shell_value,
+            "m_states": self.m_states,
+            "egg_node_count": len(self.egg_nodes),
+        }
+
+
+def build_geoseed_orbitals() -> list[GeoSeedOrbital]:
+    """Construct the six GeoSeed orbital shells."""
+
+    orbitals: list[GeoSeedOrbital] = []
+    for tongue in TONGUES:
+        phi_index = int(tongue["phi_index"])
+        l_value = int(tongue["l"])
+        rho = phi_to_hyperbolic_rho(phi_index)
+        radius = phi_to_poincare_r(phi_index)
+        orbitals.append(
+            GeoSeedOrbital(
+                tongue=str(tongue["name"]),
+                abbr=str(tongue["abbr"]),
+                phi_index=phi_index,
+                phi_weight=PHI**phi_index,
+                l_value=l_value,
+                orbital_type=str(tongue["orbital"]),
+                poincare_r=radius,
+                hyperbolic_rho=rho,
+                shell_value=laplace_beltrami_shell_value(l_value),
+                m_states=2 * l_value + 1,
+                egg_nodes=tuple(sacred_egg_nodes(phi_index)),
+            )
+        )
+    return orbitals
+
+
+def inter_shell_geodesic(orbitals: list[GeoSeedOrbital] | None = None) -> list[dict[str, Any]]:
+    """Return adjacent shell distances and phi ratios."""
+
+    shells = orbitals or build_geoseed_orbitals()
+    gaps: list[dict[str, Any]] = []
+    for left, right in zip(shells, shells[1:]):
+        gaps.append(
+            {
+                "from": left.abbr,
+                "to": right.abbr,
+                "geodesic_distance": round(hyperbolic_distance(left.poincare_r, right.poincare_r), 9),
+                "expected_ln_phi": round(math.log(PHI), 9),
+                "phi_ratio": round(right.phi_weight / left.phi_weight, 9),
+            }
+        )
+    return gaps
+
+
+def orbital_summary(include_profiles: bool = False) -> dict[str, Any]:
+    """Build a JSON-serializable summary of the GeoSeed orbital model."""
+
+    orbitals = build_geoseed_orbitals()
+    ca = orbitals[3]
+    result: dict[str, Any] = {
+        "schema_version": "geoseed_orbital_v1",
+        "model_scope": "structural analogy; not a physical atomic-orbital claim",
+        "manifold": "Poincare_ball_H3",
+        "phi": round(PHI, 12),
+        "uniform_gap": {
+            "hyperbolic_distance": round(math.log(PHI), 9),
+            "reason": "rho(n+1)-rho(n) = ln(phi)",
+        },
+        "golden_ratio_checkpoint": {
+            "tongue": "Cassisivadan",
+            "abbr": "CA",
+            "poincare_r": round(ca.poincare_r, 9),
+            "expected_1_over_phi": round(1.0 / PHI, 9),
+            "exact_within_1e_12": abs(ca.poincare_r - (1.0 / PHI)) < 1e-12,
+        },
+        "orbitals": [orbital.to_dict() for orbital in orbitals],
+        "inter_shell_gaps": inter_shell_geodesic(orbitals),
+        "total_m_states": sum(orbital.m_states for orbital in orbitals),
+    }
+    if include_profiles:
+        result["density_profiles"] = {
+            orbital.abbr: orbital.density_profile(samples=32, radial_mode=2) for orbital in orbitals
+        }
+    return result
+
+
+def main() -> None:
+    """Print the model summary as JSON."""
+
+    print(json.dumps(orbital_summary(include_profiles=True), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_geoseed_orbital_model.py
+++ b/tests/test_geoseed_orbital_model.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.geoseed.orbital_model import (
+    PHI,
+    build_geoseed_orbitals,
+    hyperbolic_distance,
+    inter_shell_geodesic,
+    orbital_summary,
+    phi_to_poincare_r,
+)
+from scripts.research.render_geoseed_orbitals import build_html
+
+
+def test_ca_shell_sits_at_inverse_phi_checkpoint() -> None:
+    ca_radius = phi_to_poincare_r(3)
+    assert ca_radius == pytest.approx(1.0 / PHI, abs=1e-12)
+
+
+def test_adjacent_shells_have_uniform_hyperbolic_gap() -> None:
+    orbitals = build_geoseed_orbitals()
+    expected = math.log(PHI)
+    distances = [
+        hyperbolic_distance(left.poincare_r, right.poincare_r)
+        for left, right in zip(orbitals, orbitals[1:])
+    ]
+    assert distances == pytest.approx([expected] * 5, abs=1e-12)
+
+
+def test_orbital_state_ladder_matches_odd_sequence() -> None:
+    orbitals = build_geoseed_orbitals()
+    assert [orbital.orbital_type for orbital in orbitals] == ["s", "p", "d", "f", "g", "h"]
+    assert [orbital.m_states for orbital in orbitals] == [1, 3, 5, 7, 9, 11]
+    assert sum(orbital.m_states for orbital in orbitals) == 36
+
+
+def test_sacred_egg_nodes_stay_inside_poincare_ball() -> None:
+    for orbital in build_geoseed_orbitals():
+        assert len(orbital.egg_nodes) == 21
+        for x, y, z in orbital.egg_nodes:
+            assert math.sqrt(x * x + y * y + z * z) < 1.0 or orbital.phi_index == 0
+
+
+def test_summary_is_explicit_about_scope_and_gap() -> None:
+    summary = orbital_summary(include_profiles=True)
+    assert summary["schema_version"] == "geoseed_orbital_v1"
+    assert "not a physical atomic-orbital claim" in summary["model_scope"]
+    assert summary["golden_ratio_checkpoint"]["exact_within_1e_12"] is True
+    assert summary["inter_shell_gaps"] == inter_shell_geodesic()
+    assert set(summary["density_profiles"]) == {"KO", "AV", "RU", "CA", "UM", "DR"}
+
+
+def test_visual_report_contains_core_invariants() -> None:
+    html = build_html()
+    assert "GeoSeed Orbital Model" in html
+    assert "0.481211825" in html
+    assert "r=0.618033989=1/phi" in html
+    assert "Total m-states" in html


### PR DESCRIPTION
## Summary
- Adds a dependency-free GeoSeed orbital-shell model for the six Sacred Tongues.
- Preserves the electron-orbital framing as a structural analogy, not a physical atomic-orbital claim.
- Captures the verified invariants: adjacent shells have uniform hyperbolic gap `ln(phi)`, CA lands at `r = 1/phi`, and m-states sum to 36.
- Adds an HTML/SVG renderer for density-profile inspection.

## Test evidence
- `python -m pytest tests/test_geoseed_orbital_model.py -q` -> 6 passed
- `python -m src.geoseed.orbital_model` -> emits JSON summary cleanly
- `python scripts/research/render_geoseed_orbitals.py` -> writes `artifacts/geoseed/orbital_model.html`
- `git diff --check` -> clean

## Rollback
- Revert this commit to remove the GeoSeed orbital model, renderer, tests, and research note.