### PR TITLE
feat(geoseed): add transfer recorder stub

### DIFF
--- a/docs/research/geoseed_orbital_model.md
+++ b/docs/research/geoseed_orbital_model.md
@@ -75,3 +75,22 @@ Render:
 ```bash
 python scripts/research/render_geoseed_orbitals.py
 ```
+
+## Transfer recorder stub
+
+`src/geoseed/transfer_recorder.py` adds an audit scaffold for symbolic atom
+transfer. It records `(from_tongue, to_tongue, token)` triples, accumulates a
+6x6 transfer matrix, and prices each shell hop as `n * ln(phi)`.
+
+The future tokenizer wiring point is intentionally one call:
+
+```python
+from src.geoseed.transfer_recorder import AtomTransferRecorder
+
+rec = AtomTransferRecorder(session_id="tokenizer-run")
+for token, from_tongue, to_tongue in tokenizer.route_tokens(text):
+    rec.record(from_tongue, to_tongue, token)
+```
+
+The recorder is deterministic and standard-library only. It tracks route
+provenance without claiming physical atom transfer.

--- a/scripts/research/render_geoseed_orbitals.py
+++ b/scripts/research/render_geoseed_orbitals.py
@@ -50,10 +50,7 @@ def build_html() -> str:
         abbr = orbital["abbr"]
         y_base = index * row_height
         line = _polyline(profiles[abbr], width, row_height, max_density)
-        label = (
-            f"{abbr} / {orbital['orbital_type']}-shell / "
-            f"r={orbital['poincare_r']} / m={orbital['m_states']}"
-        )
+        label = f"{abbr} / {orbital['orbital_type']}-shell / " f"r={orbital['poincare_r']} / m={orbital['m_states']}"
         rows.append(
             "\n".join(
                 [

--- a/src/geoseed/__init__.py
+++ b/src/geoseed/__init__.py
@@ -7,20 +7,46 @@ without re-import warnings.
 from typing import Any
 
 __all__ = [
+    "AtomTransferRecorder",
     "PHI",
+    "LN_PHI",
     "TONGUES",
     "GeoSeedOrbital",
+    "TransferEvent",
+    "TransferMatrix",
     "build_geoseed_orbitals",
     "hyperbolic_distance",
     "inter_shell_geodesic",
+    "normalize_tongue",
     "orbital_summary",
     "phi_to_poincare_r",
+    "transfer_cost",
 ]
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
+    if name in {
+        "PHI",
+        "TONGUES",
+        "GeoSeedOrbital",
+        "build_geoseed_orbitals",
+        "hyperbolic_distance",
+        "inter_shell_geodesic",
+        "orbital_summary",
+        "phi_to_poincare_r",
+    }:
         from . import orbital_model
 
         return getattr(orbital_model, name)
+    if name in {
+        "AtomTransferRecorder",
+        "LN_PHI",
+        "TransferEvent",
+        "TransferMatrix",
+        "normalize_tongue",
+        "transfer_cost",
+    }:
+        from . import transfer_recorder
+
+        return getattr(transfer_recorder, name)
     raise AttributeError(name)

--- a/src/geoseed/transfer_recorder.py
+++ b/src/geoseed/transfer_recorder.py
@@ -1,0 +1,238 @@
+"""Atom-transfer recorder for GeoSeed tongue routing.
+
+This module tracks symbolic atom transfers: minimal token units moving from one
+Sacred Tongue shell to another during tokenization or compilation. It is a
+deterministic audit scaffold, not a chemistry simulator.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+PHI = (1.0 + math.sqrt(5.0)) / 2.0
+LN_PHI = math.log(PHI)
+TONGUE_ORDER = ("KO", "AV", "RU", "CA", "UM", "DR")
+TONGUE_INDEX = {tongue: index for index, tongue in enumerate(TONGUE_ORDER)}
+
+
+def normalize_tongue(tongue: str) -> str:
+    """Normalize and validate a Sacred Tongue abbreviation."""
+
+    normalized = tongue.strip().upper()
+    if normalized not in TONGUE_INDEX:
+        raise ValueError(f"unknown tongue {tongue!r}; expected one of {', '.join(TONGUE_ORDER)}")
+    return normalized
+
+
+def transfer_cost(from_tongue: str, to_tongue: str) -> float:
+    """Return the hyperbolic shell-hop cost between two tongue abbreviations."""
+
+    start = normalize_tongue(from_tongue)
+    end = normalize_tongue(to_tongue)
+    return abs(TONGUE_INDEX[end] - TONGUE_INDEX[start]) * LN_PHI
+
+
+@dataclass(frozen=True)
+class TransferEvent:
+    """One symbolic atom transfer across the GeoSeed tongue ladder."""
+
+    from_tongue: str
+    to_tongue: str
+    token: str
+    geodesic_cost: float
+    is_self: bool
+    step: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "from_tongue": self.from_tongue,
+            "to_tongue": self.to_tongue,
+            "token": self.token,
+            "geodesic_cost": round(self.geodesic_cost, 12),
+            "is_self": self.is_self,
+            "step": self.step,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class TransferMatrix:
+    """Dense 6x6 transfer matrix with counts, row rates, and shell-hop costs."""
+
+    counts: list[list[int]]
+    rates: list[list[float]]
+    costs: list[list[float]]
+    total_events: int
+    self_transfer_count: int
+    cross_transfer_count: int
+
+    def dominant_flow(self, include_self: bool = False) -> dict[str, Any] | None:
+        """Return the highest-count transfer lane."""
+
+        best: tuple[int, int, int] | None = None
+        for row_index, row in enumerate(self.counts):
+            for col_index, count in enumerate(row):
+                if count == 0:
+                    continue
+                if not include_self and row_index == col_index:
+                    continue
+                if best is None or count > best[2]:
+                    best = (row_index, col_index, count)
+        if best is None:
+            return None
+        row_index, col_index, count = best
+        return {
+            "from_tongue": TONGUE_ORDER[row_index],
+            "to_tongue": TONGUE_ORDER[col_index],
+            "count": count,
+            "rate": self.rates[row_index][col_index],
+            "geodesic_cost": self.costs[row_index][col_index],
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tongues": list(TONGUE_ORDER),
+            "counts": self.counts,
+            "rates": self.rates,
+            "costs": self.costs,
+            "total_events": self.total_events,
+            "self_transfer_count": self.self_transfer_count,
+            "cross_transfer_count": self.cross_transfer_count,
+            "dominant_flow": self.dominant_flow(),
+        }
+
+
+class AtomTransferRecorder:
+    """Record token movements through the six-shell GeoSeed tongue ladder."""
+
+    def __init__(self, session_id: str = "default") -> None:
+        self.session_id = session_id
+        self._events: list[TransferEvent] = []
+        self._step = 0
+
+    @property
+    def events(self) -> tuple[TransferEvent, ...]:
+        return tuple(self._events)
+
+    @property
+    def event_count(self) -> int:
+        return len(self._events)
+
+    def record(
+        self,
+        from_tongue: str,
+        to_tongue: str,
+        token: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> TransferEvent:
+        """Record one token transfer and return the immutable event."""
+
+        start = normalize_tongue(from_tongue)
+        end = normalize_tongue(to_tongue)
+        event = TransferEvent(
+            from_tongue=start,
+            to_tongue=end,
+            token=str(token),
+            geodesic_cost=transfer_cost(start, end),
+            is_self=start == end,
+            step=self._step,
+            metadata=dict(metadata or {}),
+        )
+        self._events.append(event)
+        self._step += 1
+        return event
+
+    def record_batch(self, records: Iterable[tuple[str, str, str] | dict[str, Any]]) -> tuple[TransferEvent, ...]:
+        """Record a batch of tuple or mapping records."""
+
+        events: list[TransferEvent] = []
+        for record in records:
+            if isinstance(record, dict):
+                events.append(
+                    self.record(
+                        str(record["from_tongue"]),
+                        str(record["to_tongue"]),
+                        str(record["token"]),
+                        metadata=dict(record.get("metadata", {})),
+                    )
+                )
+            else:
+                from_tongue, to_tongue, token = record
+                events.append(self.record(from_tongue, to_tongue, token))
+        return tuple(events)
+
+    def events_for_token(self, token: str) -> tuple[TransferEvent, ...]:
+        return tuple(event for event in self._events if event.token == token)
+
+    def events_from(self, tongue: str) -> tuple[TransferEvent, ...]:
+        start = normalize_tongue(tongue)
+        return tuple(event for event in self._events if event.from_tongue == start)
+
+    def events_to(self, tongue: str) -> tuple[TransferEvent, ...]:
+        end = normalize_tongue(tongue)
+        return tuple(event for event in self._events if event.to_tongue == end)
+
+    def total_geodesic_cost(self) -> float:
+        return sum(event.geodesic_cost for event in self._events)
+
+    def mean_hop_distance(self, include_self: bool = False) -> float:
+        events = [event for event in self._events if include_self or not event.is_self]
+        if not events:
+            return 0.0
+        return sum(event.geodesic_cost for event in events) / len(events)
+
+    def transfer_matrix(self) -> TransferMatrix:
+        counts = [[0 for _ in TONGUE_ORDER] for _ in TONGUE_ORDER]
+        for event in self._events:
+            counts[TONGUE_INDEX[event.from_tongue]][TONGUE_INDEX[event.to_tongue]] += 1
+
+        rates: list[list[float]] = []
+        for row in counts:
+            row_total = sum(row)
+            if row_total == 0:
+                rates.append([0.0 for _ in row])
+            else:
+                rates.append([count / row_total for count in row])
+
+        costs = [
+            [round(abs(col_index - row_index) * LN_PHI, 12) for col_index in range(len(TONGUE_ORDER))]
+            for row_index in range(len(TONGUE_ORDER))
+        ]
+        self_count = sum(1 for event in self._events if event.is_self)
+        return TransferMatrix(
+            counts=counts,
+            rates=rates,
+            costs=costs,
+            total_events=len(self._events),
+            self_transfer_count=self_count,
+            cross_transfer_count=len(self._events) - self_count,
+        )
+
+    def summary(self) -> dict[str, Any]:
+        matrix = self.transfer_matrix()
+        return {
+            "schema_version": "geoseed_transfer_recorder_v1",
+            "session_id": self.session_id,
+            "event_count": self.event_count,
+            "total_geodesic_cost": round(self.total_geodesic_cost(), 12),
+            "mean_cross_hop_distance": round(self.mean_hop_distance(include_self=False), 12),
+            "dominant_flow": matrix.dominant_flow(),
+            "self_transfer_count": matrix.self_transfer_count,
+            "cross_transfer_count": matrix.cross_transfer_count,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "geoseed_transfer_recorder_v1",
+            "session_id": self.session_id,
+            "events": [event.to_dict() for event in self._events],
+            "matrix": self.transfer_matrix().to_dict(),
+            "summary": self.summary(),
+        }
+
+    def reset(self) -> None:
+        self._events.clear()
+        self._step = 0

--- a/tests/test_geoseed_orbital_model.py
+++ b/tests/test_geoseed_orbital_model.py
@@ -23,10 +23,7 @@ def test_ca_shell_sits_at_inverse_phi_checkpoint() -> None:
 def test_adjacent_shells_have_uniform_hyperbolic_gap() -> None:
     orbitals = build_geoseed_orbitals()
     expected = math.log(PHI)
-    distances = [
-        hyperbolic_distance(left.poincare_r, right.poincare_r)
-        for left, right in zip(orbitals, orbitals[1:])
-    ]
+    distances = [hyperbolic_distance(left.poincare_r, right.poincare_r) for left, right in zip(orbitals, orbitals[1:])]
     assert distances == pytest.approx([expected] * 5, abs=1e-12)
 
 

--- a/tests/test_geoseed_transfer_recorder.py
+++ b/tests/test_geoseed_transfer_recorder.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+
+from src.geoseed.transfer_recorder import (
+    LN_PHI,
+    AtomTransferRecorder,
+    TransferMatrix,
+    normalize_tongue,
+    transfer_cost,
+)
+
+
+def test_normalize_tongue_accepts_case_and_spaces() -> None:
+    assert normalize_tongue(" ca ") == "CA"
+
+
+def test_normalize_tongue_rejects_unknown_abbreviation() -> None:
+    with pytest.raises(ValueError, match="unknown tongue"):
+        normalize_tongue("ZZ")
+
+
+def test_transfer_cost_uses_uniform_ln_phi_shell_hops() -> None:
+    assert transfer_cost("KO", "KO") == pytest.approx(0.0)
+    assert transfer_cost("KO", "AV") == pytest.approx(LN_PHI)
+    assert transfer_cost("KO", "DR") == pytest.approx(5 * LN_PHI)
+    assert transfer_cost("UM", "RU") == pytest.approx(2 * LN_PHI)
+
+
+def test_record_creates_immutable_transfer_event() -> None:
+    recorder = AtomTransferRecorder(session_id="unit")
+    event = recorder.record("ko", "ru", "seed", metadata={"source": "tokenizer"})
+
+    assert event.from_tongue == "KO"
+    assert event.to_tongue == "RU"
+    assert event.token == "seed"
+    assert event.step == 0
+    assert event.geodesic_cost == pytest.approx(2 * LN_PHI)
+    assert event.is_self is False
+    assert event.metadata == {"source": "tokenizer"}
+    assert event.to_dict()["geodesic_cost"] == round(2 * LN_PHI, 12)
+
+
+def test_record_batch_accepts_tuples_and_mappings() -> None:
+    recorder = AtomTransferRecorder()
+    events = recorder.record_batch(
+        [
+            ("KO", "AV", "alpha"),
+            {"from_tongue": "AV", "to_tongue": "AV", "token": "hold", "metadata": {"ok": True}},
+        ]
+    )
+
+    assert len(events) == 2
+    assert [event.step for event in events] == [0, 1]
+    assert recorder.event_count == 2
+    assert events[1].is_self is True
+    assert events[1].metadata == {"ok": True}
+
+
+def test_event_filters_track_token_source_and_destination() -> None:
+    recorder = AtomTransferRecorder()
+    recorder.record("KO", "RU", "seed")
+    recorder.record("AV", "RU", "seed")
+    recorder.record("RU", "CA", "branch")
+
+    assert len(recorder.events_for_token("seed")) == 2
+    assert [event.token for event in recorder.events_from("RU")] == ["branch"]
+    assert [event.from_tongue for event in recorder.events_to("RU")] == ["KO", "AV"]
+
+
+def test_transfer_matrix_counts_rates_and_dominant_flow() -> None:
+    recorder = AtomTransferRecorder()
+    recorder.record("KO", "RU", "a")
+    recorder.record("KO", "RU", "b")
+    recorder.record("KO", "KO", "hold")
+    recorder.record("AV", "CA", "c")
+
+    matrix = recorder.transfer_matrix()
+    assert isinstance(matrix, TransferMatrix)
+    assert len(matrix.counts) == 6
+    assert all(len(row) == 6 for row in matrix.counts)
+    assert matrix.counts[0][2] == 2
+    assert matrix.counts[0][0] == 1
+    assert matrix.rates[0][2] == pytest.approx(2 / 3)
+    assert matrix.costs[0][2] == round(2 * LN_PHI, 12)
+    assert matrix.total_events == 4
+    assert matrix.self_transfer_count == 1
+    assert matrix.cross_transfer_count == 3
+    assert matrix.dominant_flow() == {
+        "from_tongue": "KO",
+        "to_tongue": "RU",
+        "count": 2,
+        "rate": pytest.approx(2 / 3),
+        "geodesic_cost": round(2 * LN_PHI, 12),
+    }
+
+
+def test_empty_matrix_has_no_dominant_flow() -> None:
+    matrix = AtomTransferRecorder().transfer_matrix()
+    assert matrix.dominant_flow() is None
+
+
+def test_mean_hop_distance_defaults_to_cross_shell_events() -> None:
+    recorder = AtomTransferRecorder()
+    recorder.record("KO", "KO", "self")
+    recorder.record("KO", "AV", "one")
+    recorder.record("KO", "RU", "two")
+
+    assert recorder.total_geodesic_cost() == pytest.approx(3 * LN_PHI)
+    assert recorder.mean_hop_distance() == pytest.approx(1.5 * LN_PHI)
+    assert recorder.mean_hop_distance(include_self=True) == pytest.approx(LN_PHI)
+
+
+def test_summary_and_serialization_are_audit_ready() -> None:
+    recorder = AtomTransferRecorder(session_id="transfer-test")
+    recorder.record("KO", "DR", "deep")
+
+    payload = recorder.to_dict()
+    assert payload["schema_version"] == "geoseed_transfer_recorder_v1"
+    assert payload["session_id"] == "transfer-test"
+    assert payload["summary"]["event_count"] == 1
+    assert payload["summary"]["dominant_flow"]["to_tongue"] == "DR"
+    assert payload["matrix"]["counts"][0][5] == 1
+    assert payload["events"][0]["token"] == "deep"
+
+
+def test_reset_clears_events_and_step_counter() -> None:
+    recorder = AtomTransferRecorder()
+    recorder.record("KO", "AV", "first")
+    recorder.reset()
+    event = recorder.record("AV", "RU", "second")
+
+    assert recorder.event_count == 1
+    assert event.step == 0


### PR DESCRIPTION
## Summary
- add a dependency-free GeoSeed atom-transfer recorder for symbolic tongue-shell moves
- expose 6x6 transfer matrices, dominant flows, hop costs, and audit-ready serialization
- document the future tokenizer wiring point without claiming physical atom transfer

## Tests
- python -m black --check --target-version py311 --line-length 120 src\ tests\
- python -m pytest tests\test_geoseed_orbital_model.py tests\test_geoseed_transfer_recorder.py -q
- python scripts\research\render_geoseed_orbitals.py
- git diff --check origin/main...HEAD