### PR TITLE
docs(site): make homepage proof-first

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
     </title>
     <meta
       name="description"
-      content="Buy the AetherMoore governed AI toolkit, tip $5, support monthly, try the live demos, and inspect the public proof stack. The system includes The Six Tongues Protocol, a narrative training layer that teaches the same SCBE mechanics to humans and models."
+      content="SCBE-AETHERMOORE is an experimental agentic operating system for durable workflows, governed tool use, audit trails, cross-language transformation, and evidence-backed automation. Inspect the demos, run the commands, and buy only what is useful."
     />
     <meta
       name="robots"
@@ -18,7 +18,7 @@
     <meta property="og:title" content="AetherMoore Governed AI Toolkit" />
     <meta
       property="og:description"
-      content="Governed AI workflow starter pack, live proof demos, and a narrative training layer through The Six Tongues Protocol."
+      content="An evidence-first agentic CLI and governed automation stack: durable workflows, audit receipts, pathfinding harnesses, and practical starter packs."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://aethermoore.com/" />
@@ -27,7 +27,7 @@
     <meta name="twitter:title" content="AetherMoore Governed AI Toolkit" />
     <meta
       name="twitter:description"
-      content="Starter packs, live demos, public proof, and a narrative training layer for governed AI workflows."
+      content="Experimental agentic OS tools with public demos, reproducible proof packets, and practical automation lanes."
     />
     <meta name="twitter:image" content="https://aethermoore.com/hero.svg" />
     <link rel="canonical" href="https://aethermoore.com/" />
@@ -913,8 +913,7 @@
     <div class="quick-support-bar" aria-label="Fast support links">
       <div class="quick-support-inner">
         <span
-          ><strong>Live now:</strong> $99 Workflow Snapshot, Ko-fi support, Cash App direct
-          payments, and Polly agent routing. No sales call.</span
+          ><strong>Live now:</strong> <code style="background:rgba(255,255,255,0.08);border-radius:4px;padding:1px 6px;font-size:13px">scbe shell --squad</code> (free 3-slot AI CLI), public proof packets, $99 Workflow Snapshot, agent bus on npm. Run it before you trust it.</span
         >
         <div class="quick-support-actions">
           <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
@@ -933,19 +932,26 @@
       <section class="hero" id="offer">
         <div class="hero-grid">
           <div class="hero-copy">
-            <div class="eyebrow">Governed AI tools for builders</div>
-            <h1>The toolkit, analysis, and training data to run AI agents safely.</h1>
+            <div class="eyebrow">Evidence-first AI tools for builders</div>
+            <h1>Build, test, and keep what survives contact with reality.</h1>
             <p>
-              <strong>AetherMoore</strong> sells three things: a <strong>$29 governance toolkit</strong>
+              SCBE-AETHERMOORE is an experimental agentic operating system focused on durable workflows, governed tool use, audit trails, cross-language transformation, and evidence-backed automation. The rule is simple: unusual ideas are allowed, but public claims need commands, artifacts, and boundaries.
+            </p>
+            <p>
+              The open-source core runs today for free: <strong>agent bus</strong> (54 governed tools on npm), <strong>squad shell</strong> (3-slot agentic CLI that auto-routes tasks to the right AI model), and a <strong>governed pathfinding harness</strong> with SHA-256 receipt chains. Inspect, fork, and run them before spending anything.
+            </p>
+            <p>
+              <strong>AetherMoore</strong> also sells three packaged starter lanes: a <strong>$29 governance toolkit</strong>
               (templates, a buyer manual, and live pipeline demos you can use in an afternoon), a
               <strong>$99 Workflow Snapshot</strong> (send your agent setup, get a clear action plan
               back), and a <strong>$29 Training Vault</strong> (fine-tune your own governed model
               with clean SFT data and a Colab notebook). One-time purchases, no subscription.
             </p>
             <p style="max-width: 58ch; font-size: 16px; color: var(--text); margin-top: -8px">
-              Built by Issac Davis. SAM.gov registered, CAGE-code verified (UEI J4NXHM6N5F59,
-              CAGE 1EXD5). Live demos and Polly chat are public — inspect the system and test it
-              before you spend a dollar.
+              Built by Issac Davis: I explore unusual models, implement them, test them, and keep
+              what survives. SAM.gov registered, CAGE-code verified (UEI J4NXHM6N5F59, CAGE
+              1EXD5). Live demos and Polly chat are public — inspect the system and test it before
+              you spend a dollar.
             </p>
             <div
               role="region"
@@ -1067,10 +1073,15 @@
             </div>
             <p style="margin-top: 14px; font-size: 14px; color: var(--muted); max-width: 56ch">
               For buyers: starter tools and manuals. For researchers: the live pipeline and proof
-              trail. For partners: a real system with measurable behavior, not just a deck.
+              trail. For partners: working software with measurable behavior, not a claim without
+              receipts.
             </p>
             <div class="proof-strip" aria-label="Proof highlights">
               <div class="proof-kicker">Proof before purchase</div>
+              <p style="color: var(--muted); font-size: 14px; max-width: 76ch; margin: 0 0 14px">
+                These are executable local results and scoped artifacts, not universal guarantees.
+                The standard is: model, command, artifact, commit, and claim boundary.
+              </p>
               <div class="proof-grid">
                 <div class="proof-cell">
                   <strong>31% better code training</strong>


### PR DESCRIPTION
Updates the homepage positioning to match the evidence-first stance: unusual ideas are allowed, but public claims need commands, artifacts, and boundaries.\n\nChanges:\n- Rewrites SEO/social descriptions toward practical agentic CLI utility and evidence-backed automation.\n- Updates hero copy to: build, test, and keep what survives contact with reality.\n- Adds explicit proof-boundary language before the proof cells.\n- Keeps the existing product paths and CTAs intact.\n\nEvidence:\n- Parsed docs/index.html with Python html.parser.\n- git diff --check -- docs/index.html: clean.