### PR TITLE
feat(chem): add bijective reaction harness

### DIFF
--- a/docs/specs/CROSS_LANGUAGE_REACTION_STATE_MODEL.md
+++ b/docs/specs/CROSS_LANGUAGE_REACTION_STATE_MODEL.md
@@ -124,6 +124,34 @@ After transformation, do not trust the translation. Recalculate it:
 
 This is where standard analytical/scientific tools enter. SCBE does not need to be the chemistry engine. It needs to call the engine, hash the result, and classify the transform.
 
+## Bijective Reaction Harness
+
+The reusable harness lives in `python/scbe/reaction_harness.py`. It compares a transform as a set of declared fields:
+
+- `source_fields`: what the input state claims to carry;
+- `target_fields`: what survived into the output state;
+- `required_identity_fields`: values that must survive for identity to hold;
+- `recoverable_fields`: values restored through a side lane such as fragments, tests, descriptors, or call-site rewrites;
+- `allowed_loss_fields`: loss that should be engraved but does not break the declared identity.
+
+The harness emits a normal `ReactionStatePacket`, so code, chemistry, data, tokenizer, and agent transformations can all share the same classification surface.
+
+Example:
+
+```python
+result = evaluate_bijective_reaction(
+    domain="chem",
+    bounded_operation="atom_mud_recover_with_fragment_cards",
+    source_fields={"formula": "C2H6O", "canonical_smiles": "CCO", "connectivity": "C-C-O"},
+    target_fields={"formula": "C2H6O"},
+    recoverable_fields={"canonical_smiles": "CCO"},
+    required_identity_fields=("formula", "canonical_smiles"),
+    allowed_loss_fields=("connectivity",),
+)
+```
+
+That result is `LOSSY_RECOVERABLE`: topology was lost, but the required identity was restored through a declared recovery lane. Without the recovery lane, the same atom bag becomes `LOSSY_AMBIGUOUS`.
+
 ## Multi-Language Chemical Composition Analogy
 
 Coding languages are like different atomic families in this model:
@@ -160,4 +188,3 @@ scbe bench chemistry --json
 ## Claim Boundary
 
 This model supports governed cross-language and computational-chemistry transformations with explicit loss accounting. It does not prove biological efficacy, validate wet-lab chemistry, or guarantee semantic identity unless the packet classifies the path as bijective under a declared representation.
-

--- a/python/scbe/__init__.py
+++ b/python/scbe/__init__.py
@@ -111,6 +111,11 @@ from .reaction_state import (
     build_reaction_state_packet,
     classify_reaction,
 )
+from .reaction_harness import (
+    BijectiveReactionResult,
+    ReactionFieldCheck,
+    evaluate_bijective_reaction,
+)
 
 __all__ += [
     "AtomicElement",
@@ -155,4 +160,7 @@ __all__ += [
     "ReactionStatePacket",
     "build_reaction_state_packet",
     "classify_reaction",
+    "ReactionFieldCheck",
+    "BijectiveReactionResult",
+    "evaluate_bijective_reaction",
 ]

--- a/python/scbe/reaction_harness.py
+++ b/python/scbe/reaction_harness.py
@@ -1,0 +1,229 @@
+"""Reusable bijective reaction harness.
+
+The harness scores whether a transform preserves identity, loses identity, or
+loses information that can be restored through declared recovery fields. It is
+domain-neutral: chemistry, code translation, tokenizer routing, and agent
+workflow transforms can all use the same field-comparison surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+from .reaction_state import (
+    ReactionDomain,
+    ReactionEndpoint,
+    ReactionRecalculation,
+    ReactionStatePacket,
+    build_reaction_state_packet,
+)
+
+FieldStatus = Literal["preserved", "recovered", "lost", "changed", "ignored_loss"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReactionFieldCheck:
+    """One field-level comparison inside a bounded reaction."""
+
+    field: str
+    status: FieldStatus
+    source_value: Any = None
+    target_value: Any = None
+    recovered_value: Any = None
+    note: str = ""
+
+    @property
+    def ok_for_identity(self) -> bool:
+        return self.status in {"preserved", "recovered", "ignored_loss"}
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class BijectiveReactionResult:
+    """Result of a reaction-harness evaluation."""
+
+    ok: bool
+    packet: ReactionStatePacket
+    field_checks: list[ReactionFieldCheck]
+    preserved_fields: list[str] = field(default_factory=list)
+    recovered_fields: list[str] = field(default_factory=list)
+    changed_fields: list[str] = field(default_factory=list)
+    lost_fields: list[str] = field(default_factory=list)
+    ignored_loss_fields: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "classification": self.packet.classification,
+            "packet": self.packet.to_dict(),
+            "field_checks": [check.to_dict() for check in self.field_checks],
+            "preserved_fields": list(self.preserved_fields),
+            "recovered_fields": list(self.recovered_fields),
+            "changed_fields": list(self.changed_fields),
+            "lost_fields": list(self.lost_fields),
+            "ignored_loss_fields": list(self.ignored_loss_fields),
+        }
+
+
+def _field_present(fields: dict[str, Any], name: str) -> bool:
+    return name in fields and fields[name] is not None
+
+
+def evaluate_bijective_reaction(
+    *,
+    domain: ReactionDomain,
+    bounded_operation: str,
+    source: ReactionEndpoint,
+    target: ReactionEndpoint,
+    source_fields: dict[str, Any],
+    target_fields: dict[str, Any],
+    required_identity_fields: list[str] | tuple[str, ...],
+    recoverable_fields: dict[str, Any] | None = None,
+    allowed_loss_fields: list[str] | tuple[str, ...] = (),
+    step: int = 1,
+    recalculation: ReactionRecalculation | None = None,
+    semantic_engravings: list[str] | tuple[str, ...] = (),
+    claim_boundary: list[str] | tuple[str, ...] = (),
+    previous_packet_hash: str | None = None,
+    generated_at_utc: str | None = None,
+) -> BijectiveReactionResult:
+    """Evaluate a field-preserving or field-recovering transform.
+
+    A required identity field may pass in two ways:
+    - the target field equals the source field;
+    - a recovery field equals the source field, proving the value survived in a
+      different lane.
+
+    Allowed-loss fields are recorded as loss notes but do not break identity.
+    """
+
+    recoverable_fields = recoverable_fields or {}
+    checks: list[ReactionFieldCheck] = []
+
+    preserved: list[str] = []
+    recovered: list[str] = []
+    changed: list[str] = []
+    lost: list[str] = []
+    ignored_loss: list[str] = []
+
+    for field_name in required_identity_fields:
+        source_value = source_fields.get(field_name)
+        target_has_value = _field_present(target_fields, field_name)
+        target_value = target_fields.get(field_name)
+        recovered_value = recoverable_fields.get(field_name)
+
+        if target_has_value and target_value == source_value:
+            preserved.append(field_name)
+            checks.append(
+                ReactionFieldCheck(
+                    field=field_name,
+                    status="preserved",
+                    source_value=source_value,
+                    target_value=target_value,
+                )
+            )
+        elif field_name in recoverable_fields and recovered_value == source_value:
+            recovered.append(field_name)
+            checks.append(
+                ReactionFieldCheck(
+                    field=field_name,
+                    status="recovered",
+                    source_value=source_value,
+                    target_value=target_value,
+                    recovered_value=recovered_value,
+                    note="identity restored from recovery lane",
+                )
+            )
+        elif not target_has_value:
+            lost.append(field_name)
+            checks.append(
+                ReactionFieldCheck(
+                    field=field_name,
+                    status="lost",
+                    source_value=source_value,
+                    note="required identity field absent from target and recovery lanes",
+                )
+            )
+        else:
+            changed.append(field_name)
+            checks.append(
+                ReactionFieldCheck(
+                    field=field_name,
+                    status="changed",
+                    source_value=source_value,
+                    target_value=target_value,
+                    note="required identity field changed without matching recovery evidence",
+                )
+            )
+
+    for field_name in allowed_loss_fields:
+        if _field_present(source_fields, field_name) and not _field_present(
+            target_fields, field_name
+        ):
+            ignored_loss.append(field_name)
+            checks.append(
+                ReactionFieldCheck(
+                    field=field_name,
+                    status="ignored_loss",
+                    source_value=source_fields.get(field_name),
+                    note="allowed loss recorded for audit; not identity-breaking",
+                )
+            )
+
+    identity_preserved = not changed and not lost
+    recalculation = recalculation or ReactionRecalculation(
+        identity_ok=True if identity_preserved else None,
+        extra={"identity_preserved": identity_preserved},
+    )
+    if identity_preserved and recalculation.identity_ok is None:
+        recalculation = ReactionRecalculation(
+            syntax_ok=recalculation.syntax_ok,
+            tests_ok=recalculation.tests_ok,
+            scientific_checks_ok=recalculation.scientific_checks_ok,
+            unit_checks_ok=recalculation.unit_checks_ok,
+            identity_ok=identity_preserved,
+            extra=dict(recalculation.extra),
+        )
+
+    loss_notes = [
+        f"required identity field changed: {field_name}" for field_name in changed
+    ] + [
+        f"required identity field lost: {field_name}" for field_name in lost
+    ] + [
+        f"allowed field lost: {field_name}" for field_name in ignored_loss
+    ]
+    recovery_evidence = [f"recovered field: {field_name}" for field_name in recovered]
+
+    packet = build_reaction_state_packet(
+        domain=domain,
+        step=step,
+        bounded_operation=bounded_operation,
+        source=source,
+        target=target,
+        semantic_engravings=[
+            *semantic_engravings,
+            *[f"preserved field: {field_name}" for field_name in preserved],
+            *recovery_evidence,
+        ],
+        loss_notes=loss_notes,
+        recalculation=recalculation,
+        identity_preserved=identity_preserved,
+        recovery_evidence=recovery_evidence,
+        claim_boundary=claim_boundary,
+        previous_packet_hash=previous_packet_hash,
+        generated_at_utc=generated_at_utc,
+    )
+
+    return BijectiveReactionResult(
+        ok=identity_preserved and not recalculation.has_failure,
+        packet=packet,
+        field_checks=checks,
+        preserved_fields=preserved,
+        recovered_fields=recovered,
+        changed_fields=changed,
+        lost_fields=lost,
+        ignored_loss_fields=ignored_loss,
+    )

--- a/tests/test_reaction_harness.py
+++ b/tests/test_reaction_harness.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from python.scbe.reaction_harness import evaluate_bijective_reaction
+from python.scbe.reaction_state import ReactionEndpoint, ReactionRecalculation
+
+
+def endpoint(identity: str, representation: str = "field-map") -> ReactionEndpoint:
+    return ReactionEndpoint(identity=identity, representation=representation)
+
+
+def test_exact_field_round_trip_is_bijective() -> None:
+    result = evaluate_bijective_reaction(
+        domain="code",
+        bounded_operation="python_to_js_behavior_roundtrip",
+        source=endpoint("is_palindrome", "python:function"),
+        target=endpoint("isPalindrome", "javascript:function"),
+        source_fields={
+            "behavior_hash": "sha256:abc",
+            "test_vector_hash": "sha256:cases",
+        },
+        target_fields={
+            "behavior_hash": "sha256:abc",
+            "test_vector_hash": "sha256:cases",
+        },
+        required_identity_fields=("behavior_hash", "test_vector_hash"),
+        generated_at_utc="2026-05-31T00:00:00Z",
+    )
+
+    assert result.ok is True
+    assert result.packet.classification == "BIJECTIVE"
+    assert result.preserved_fields == ["behavior_hash", "test_vector_hash"]
+    assert result.packet.verify_hash() is True
+
+
+def test_atom_bag_without_topology_recovery_stays_ambiguous() -> None:
+    result = evaluate_bijective_reaction(
+        domain="chem",
+        bounded_operation="formula_only_recompose",
+        source=endpoint("ethanol", "canonical_smiles"),
+        target=endpoint("formula-bag", "formula"),
+        source_fields={
+            "formula": "C2H6O",
+            "canonical_smiles": "CCO",
+            "hydroxyl_count": 1,
+        },
+        target_fields={"formula": "C2H6O"},
+        required_identity_fields=("formula", "canonical_smiles"),
+        allowed_loss_fields=("hydroxyl_count",),
+        claim_boundary=("computational chemistry only",),
+        generated_at_utc="2026-05-31T00:00:00Z",
+    )
+
+    assert result.ok is False
+    assert result.packet.classification == "LOSSY_AMBIGUOUS"
+    assert result.preserved_fields == ["formula"]
+    assert result.lost_fields == ["canonical_smiles"]
+    assert result.ignored_loss_fields == ["hydroxyl_count"]
+
+
+def test_recovery_lane_restores_identity_after_mud_step() -> None:
+    result = evaluate_bijective_reaction(
+        domain="chem",
+        bounded_operation="atom_mud_recover_with_fragment_cards",
+        source=endpoint("ethanol", "canonical_smiles"),
+        target=endpoint("formula-bag", "formula"),
+        source_fields={
+            "formula": "C2H6O",
+            "canonical_smiles": "CCO",
+            "hydroxyl_count": 1,
+            "connectivity": "C-C-O",
+        },
+        target_fields={"formula": "C2H6O"},
+        recoverable_fields={
+            "canonical_smiles": "CCO",
+            "hydroxyl_count": 1,
+        },
+        required_identity_fields=("formula", "canonical_smiles", "hydroxyl_count"),
+        allowed_loss_fields=("connectivity",),
+        semantic_engravings=("fragment cards carried hydroxyl identity",),
+        claim_boundary=("computational chemistry only",),
+        generated_at_utc="2026-05-31T00:00:00Z",
+    )
+
+    assert result.ok is True
+    assert result.packet.classification == "LOSSY_RECOVERABLE"
+    assert result.preserved_fields == ["formula"]
+    assert result.recovered_fields == ["canonical_smiles", "hydroxyl_count"]
+    assert result.ignored_loss_fields == ["connectivity"]
+
+
+def test_failed_recalculation_marks_result_invalid() -> None:
+    result = evaluate_bijective_reaction(
+        domain="code",
+        bounded_operation="translate_with_test_failure",
+        source=endpoint("add", "python:function"),
+        target=endpoint("add", "javascript:function"),
+        source_fields={"behavior_hash": "sha256:abc"},
+        target_fields={"behavior_hash": "sha256:abc"},
+        required_identity_fields=("behavior_hash",),
+        recalculation=ReactionRecalculation(syntax_ok=True, tests_ok=False),
+        generated_at_utc="2026-05-31T00:00:00Z",
+    )
+
+    assert result.ok is False
+    assert result.packet.classification == "INVALID"
+    assert result.preserved_fields == ["behavior_hash"]


### PR DESCRIPTION
## Summary
- Adds a reusable bijective reaction harness for chemistry, code, tokenizer, data, and agent transforms
- Compares required identity fields, recoverable fields, and allowed loss fields
- Emits the existing ReactionStatePacket classification: BIJECTIVE, LOSSY_RECOVERABLE, LOSSY_AMBIGUOUS, or INVALID
- Documents the harness in the cross-language reaction-state model spec

## Verification
- pytest tests/test_reaction_harness.py tests/test_reaction_state_packet.py tests/benchmark/test_compound_decomposition_recomposition.py -q -> 11 passed
- python scripts/benchmark/compound_decomposition_recomposition.py --json -> PASS 3/3 with RDKit

## Claim boundary
- Computational field-preservation harness only
- Chemistry usage remains computational and does not imply wet-lab synthesis, biological efficacy, dosing, or medical advice