### PR TITLE
feat(chem): add quasi-integer recoupling

### DIFF
--- a/docs/research/quasi_integer_recoupling_2026-05-31.md
+++ b/docs/research/quasi_integer_recoupling_2026-05-31.md
@@ -1,0 +1,90 @@
+# Quasi-Integer Recoupling
+
+Generated: 2026-05-31
+
+## Definition
+
+Quasi-integer recoupling is the SCBE middle-layer operation that maps a continuous,
+fractional, or method-dependent value back into a declared discrete state while
+preserving the raw value, error, tolerance, confidence, and loss boundary.
+
+It is not plain rounding. Rounding discards uncertainty. Recoupling records the
+uncertainty and lets the reaction packet decide whether the transform remains
+bijective, recoverable, ambiguous, or invalid.
+
+## Why This Is Chemically Reasonable
+
+Chemistry already moves between continuous and symbolic representations:
+
+- formal charge is an integer-like Lewis-structure accounting value;
+- partial charge is method-dependent and fractional;
+- bond order can be formal/integer-like, aromatic/resonance-like, or fractional
+  depending on the model;
+- molecular graphs need discrete bond/charge states even when upstream evidence
+  comes from electron-density proxies or descriptor models.
+
+RDKit exposes this split directly. It stores formal charges and bond/aromaticity
+states on molecular graphs, and it can compute Gasteiger partial charges as atom
+properties named `_GasteigerCharge`.
+
+## Packet Rule
+
+Every recoupling result should carry:
+
+```json
+{
+  "raw_value": 1.49,
+  "recoupled_value": 1.5,
+  "label": "aromatic-or-resonance-like",
+  "error": 0.01,
+  "tolerance": 0.1,
+  "confidence": 0.9,
+  "decision": "RECOUPLED",
+  "reason": "nearest state within tolerance"
+}
+```
+
+Allowed decisions:
+
+- `RECOUPLED`: nearest state is within tolerance;
+- `AMBIGUOUS`: raw value is equidistant between states;
+- `OUT_OF_RANGE`: nearest state exists but exceeds tolerance;
+- `INVALID`: raw value is not finite or cannot be evaluated.
+
+## Current Implementation
+
+Code:
+
+- `python/scbe/quasi_integer_recoupling.py`
+
+Presets:
+
+- integer ladder for formal-charge-like states;
+- half-integer ladder;
+- chemical bond-order ladder: `0`, `1`, `1.5`, `2`, `3`;
+- formal-charge ladder: `-4` through `4`.
+
+Harness integration:
+
+- `evaluate_bijective_reaction()` accepts recoupling objects as field values.
+- If the recoupling is valid, the recoupled value participates in identity
+  comparison.
+- The full raw recoupling object remains engraved in the field check.
+
+## Claim Boundary
+
+This is a computational representation bridge. It does not claim that every
+fractional quantum-chemical value has one true integer state. It claims that a
+declared tolerance and state ladder can safely convert continuous evidence into
+auditable symbolic packets.
+
+## Sources
+
+- RDKit `rdPartialCharges.ComputeGasteigerCharges` documentation: computes
+  Gasteiger charges and stores them under `_GasteigerCharge`.
+- IUPAC Gold Book formal charge entry: formal charge is a Lewis-structure
+  accounting quantity using valence electrons, lone pairs, and half bond count.
+- RDKit `rdDetermineBonds.DetermineBondOrders` documentation: assigns
+  connectivity and bond orders from coordinates and charge context.
+- IUPAC Gold Book bond order entry: valence-bond bond order can be treated as a
+  weighted average of formal bond orders.

--- a/python/scbe/__init__.py
+++ b/python/scbe/__init__.py
@@ -117,6 +117,18 @@ from .reaction_harness import (
     ReactionFieldCheck,
     evaluate_bijective_reaction,
 )
+from .quasi_integer_recoupling import (
+    CHEMICAL_BOND_ORDER_STATES,
+    FORMAL_CHARGE_STATES,
+    QuasiIntegerRecoupling,
+    RecouplingState,
+    half_integer_states,
+    integer_states,
+    recouple_bond_order,
+    recouple_formal_charge,
+    recouple_to_integer,
+    recouple_to_states,
+)
 
 __all__ += [
     "AtomicElement",
@@ -165,4 +177,14 @@ __all__ += [
     "ReactionFieldCheck",
     "BijectiveReactionResult",
     "evaluate_bijective_reaction",
+    "RecouplingState",
+    "QuasiIntegerRecoupling",
+    "CHEMICAL_BOND_ORDER_STATES",
+    "FORMAL_CHARGE_STATES",
+    "integer_states",
+    "half_integer_states",
+    "recouple_to_states",
+    "recouple_to_integer",
+    "recouple_bond_order",
+    "recouple_formal_charge",
 ]

--- a/python/scbe/quasi_integer_recoupling.py
+++ b/python/scbe/quasi_integer_recoupling.py
@@ -1,0 +1,194 @@
+"""Quasi-integer recoupling utilities.
+
+This module bridges continuous or fractional values back into auditable
+integer-like symbolic states without pretending the approximation is exact.
+Examples include partial charges, fractional/aromatic bond orders, model
+confidence scores, and manifold coordinates that need to be packetized as
+discrete states.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from math import isfinite
+from typing import Any, Literal
+
+
+RecouplingDecision = Literal["RECOUPLED", "AMBIGUOUS", "OUT_OF_RANGE", "INVALID"]
+
+
+@dataclass(frozen=True, slots=True)
+class RecouplingState:
+    """A named discrete state available to the recoupler."""
+
+    value: float
+    label: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class QuasiIntegerRecoupling:
+    """Result of snapping a continuous value to a declared discrete state."""
+
+    raw_value: float
+    recoupled_value: float | None
+    label: str | None
+    error: float | None
+    tolerance: float
+    confidence: float
+    decision: RecouplingDecision
+    reason: str
+    state_metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.decision == "RECOUPLED"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def integer_states(min_value: int, max_value: int) -> list[RecouplingState]:
+    if min_value > max_value:
+        raise ValueError("min_value must be <= max_value")
+    return [
+        RecouplingState(float(value), str(value))
+        for value in range(min_value, max_value + 1)
+    ]
+
+
+def half_integer_states(min_value: int, max_value: int) -> list[RecouplingState]:
+    if min_value > max_value:
+        raise ValueError("min_value must be <= max_value")
+    states: list[RecouplingState] = []
+    current = min_value * 2
+    final = max_value * 2
+    while current <= final:
+        value = current / 2
+        states.append(RecouplingState(float(value), f"{value:g}"))
+        current += 1
+    return states
+
+
+CHEMICAL_BOND_ORDER_STATES: tuple[RecouplingState, ...] = (
+    RecouplingState(0.0, "no-bond"),
+    RecouplingState(1.0, "single-bond-like"),
+    RecouplingState(1.5, "aromatic-or-resonance-like"),
+    RecouplingState(2.0, "double-bond-like"),
+    RecouplingState(3.0, "triple-bond-like"),
+)
+
+FORMAL_CHARGE_STATES: tuple[RecouplingState, ...] = tuple(integer_states(-4, 4))
+
+
+def recouple_to_states(
+    raw_value: float,
+    states: list[RecouplingState] | tuple[RecouplingState, ...],
+    *,
+    tolerance: float,
+    tie_tolerance: float = 1e-12,
+) -> QuasiIntegerRecoupling:
+    """Snap raw_value to the nearest declared state with error accounting."""
+
+    if not isfinite(raw_value):
+        return QuasiIntegerRecoupling(
+            raw_value=raw_value,
+            recoupled_value=None,
+            label=None,
+            error=None,
+            tolerance=tolerance,
+            confidence=0.0,
+            decision="INVALID",
+            reason="raw value is not finite",
+        )
+    if tolerance < 0:
+        raise ValueError("tolerance must be >= 0")
+    if not states:
+        raise ValueError("states must not be empty")
+
+    ranked = sorted(
+        ((abs(raw_value - state.value), state) for state in states),
+        key=lambda item: (item[0], item[1].value, item[1].label),
+    )
+    best_error, best_state = ranked[0]
+    tied = [
+        state
+        for error, state in ranked
+        if abs(error - best_error) <= tie_tolerance
+    ]
+    if len(tied) > 1:
+        return QuasiIntegerRecoupling(
+            raw_value=raw_value,
+            recoupled_value=None,
+            label=None,
+            error=best_error,
+            tolerance=tolerance,
+            confidence=0.0,
+            decision="AMBIGUOUS",
+            reason="raw value is equidistant between multiple states",
+        )
+    if best_error > tolerance:
+        return QuasiIntegerRecoupling(
+            raw_value=raw_value,
+            recoupled_value=best_state.value,
+            label=best_state.label,
+            error=best_error,
+            tolerance=tolerance,
+            confidence=0.0,
+            decision="OUT_OF_RANGE",
+            reason="nearest state exceeds tolerance",
+            state_metadata=dict(best_state.metadata),
+        )
+    confidence = 1.0 if tolerance == 0 else max(0.0, 1.0 - best_error / tolerance)
+    return QuasiIntegerRecoupling(
+        raw_value=raw_value,
+        recoupled_value=best_state.value,
+        label=best_state.label,
+        error=best_error,
+        tolerance=tolerance,
+        confidence=confidence,
+        decision="RECOUPLED",
+        reason="nearest state within tolerance",
+        state_metadata=dict(best_state.metadata),
+    )
+
+
+def recouple_to_integer(
+    raw_value: float,
+    *,
+    min_value: int,
+    max_value: int,
+    tolerance: float,
+) -> QuasiIntegerRecoupling:
+    return recouple_to_states(
+        raw_value,
+        integer_states(min_value, max_value),
+        tolerance=tolerance,
+    )
+
+
+def recouple_bond_order(
+    raw_value: float,
+    *,
+    tolerance: float = 0.2,
+) -> QuasiIntegerRecoupling:
+    return recouple_to_states(
+        raw_value,
+        CHEMICAL_BOND_ORDER_STATES,
+        tolerance=tolerance,
+    )
+
+
+def recouple_formal_charge(
+    raw_value: float,
+    *,
+    tolerance: float = 0.25,
+) -> QuasiIntegerRecoupling:
+    return recouple_to_states(
+        raw_value,
+        FORMAL_CHARGE_STATES,
+        tolerance=tolerance,
+    )

--- a/python/scbe/reaction_harness.py
+++ b/python/scbe/reaction_harness.py
@@ -18,6 +18,7 @@ from .reaction_state import (
     ReactionStatePacket,
     build_reaction_state_packet,
 )
+from .quasi_integer_recoupling import QuasiIntegerRecoupling
 
 FieldStatus = Literal["preserved", "recovered", "lost", "changed", "ignored_loss"]
 
@@ -72,6 +73,20 @@ def _field_present(fields: dict[str, Any], name: str) -> bool:
     return name in fields and fields[name] is not None
 
 
+def _field_value(fields: dict[str, Any], name: str) -> Any:
+    value = fields.get(name)
+    if isinstance(value, QuasiIntegerRecoupling):
+        return value.recoupled_value if value.ok else None
+    return value
+
+
+def _field_raw(fields: dict[str, Any], name: str) -> Any:
+    value = fields.get(name)
+    if isinstance(value, QuasiIntegerRecoupling):
+        return value.to_dict()
+    return value
+
+
 def evaluate_bijective_reaction(
     *,
     domain: ReactionDomain,
@@ -110,10 +125,10 @@ def evaluate_bijective_reaction(
     ignored_loss: list[str] = []
 
     for field_name in required_identity_fields:
-        source_value = source_fields.get(field_name)
+        source_value = _field_value(source_fields, field_name)
         target_has_value = _field_present(target_fields, field_name)
-        target_value = target_fields.get(field_name)
-        recovered_value = recoverable_fields.get(field_name)
+        target_value = _field_value(target_fields, field_name)
+        recovered_value = _field_value(recoverable_fields, field_name)
 
         if target_has_value and target_value == source_value:
             preserved.append(field_name)
@@ -121,8 +136,8 @@ def evaluate_bijective_reaction(
                 ReactionFieldCheck(
                     field=field_name,
                     status="preserved",
-                    source_value=source_value,
-                    target_value=target_value,
+                    source_value=_field_raw(source_fields, field_name),
+                    target_value=_field_raw(target_fields, field_name),
                 )
             )
         elif field_name in recoverable_fields and recovered_value == source_value:
@@ -131,9 +146,9 @@ def evaluate_bijective_reaction(
                 ReactionFieldCheck(
                     field=field_name,
                     status="recovered",
-                    source_value=source_value,
-                    target_value=target_value,
-                    recovered_value=recovered_value,
+                    source_value=_field_raw(source_fields, field_name),
+                    target_value=_field_raw(target_fields, field_name),
+                    recovered_value=_field_raw(recoverable_fields, field_name),
                     note="identity restored from recovery lane",
                 )
             )
@@ -143,7 +158,7 @@ def evaluate_bijective_reaction(
                 ReactionFieldCheck(
                     field=field_name,
                     status="lost",
-                    source_value=source_value,
+                    source_value=_field_raw(source_fields, field_name),
                     note="required identity field absent from target and recovery lanes",
                 )
             )
@@ -153,8 +168,8 @@ def evaluate_bijective_reaction(
                 ReactionFieldCheck(
                     field=field_name,
                     status="changed",
-                    source_value=source_value,
-                    target_value=target_value,
+                    source_value=_field_raw(source_fields, field_name),
+                    target_value=_field_raw(target_fields, field_name),
                     note="required identity field changed without matching recovery evidence",
                 )
             )
@@ -168,7 +183,7 @@ def evaluate_bijective_reaction(
                 ReactionFieldCheck(
                     field=field_name,
                     status="ignored_loss",
-                    source_value=source_fields.get(field_name),
+                    source_value=_field_raw(source_fields, field_name),
                     note="allowed loss recorded for audit; not identity-breaking",
                 )
             )

--- a/tests/test_quasi_integer_recoupling.py
+++ b/tests/test_quasi_integer_recoupling.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from python.scbe.quasi_integer_recoupling import (
+    RecouplingState,
+    half_integer_states,
+    integer_states,
+    recouple_bond_order,
+    recouple_formal_charge,
+    recouple_to_integer,
+    recouple_to_states,
+)
+
+
+def test_integer_recoupling_preserves_error_and_confidence() -> None:
+    result = recouple_to_integer(1.92, min_value=0, max_value=4, tolerance=0.25)
+
+    assert result.ok is True
+    assert result.recoupled_value == 2.0
+    assert result.label == "2"
+    assert result.error == pytest.approx(0.08)
+    assert 0.67 < result.confidence < 0.69
+
+
+def test_integer_recoupling_out_of_range_keeps_nearest_state() -> None:
+    result = recouple_to_integer(1.62, min_value=0, max_value=4, tolerance=0.1)
+
+    assert result.ok is False
+    assert result.decision == "OUT_OF_RANGE"
+    assert result.recoupled_value == 2.0
+    assert result.error == pytest.approx(0.38)
+    assert result.confidence == 0.0
+
+
+def test_half_integer_ladder_supports_aromatic_like_values() -> None:
+    states = half_integer_states(0, 3)
+    result = recouple_to_states(1.49, states, tolerance=0.08)
+
+    assert result.ok is True
+    assert result.recoupled_value == 1.5
+    assert result.label == "1.5"
+
+
+def test_bond_order_preset_recouples_aromatic_state() -> None:
+    result = recouple_bond_order(1.48, tolerance=0.1)
+
+    assert result.ok is True
+    assert result.recoupled_value == 1.5
+    assert result.label == "aromatic-or-resonance-like"
+
+
+def test_formal_charge_preset_recouples_integer_charge() -> None:
+    result = recouple_formal_charge(-0.91, tolerance=0.2)
+
+    assert result.ok is True
+    assert result.recoupled_value == -1.0
+    assert result.label == "-1"
+
+
+def test_equidistant_value_is_ambiguous() -> None:
+    result = recouple_to_states(
+        0.5,
+        [RecouplingState(0.0, "zero"), RecouplingState(1.0, "one")],
+        tolerance=0.6,
+    )
+
+    assert result.ok is False
+    assert result.decision == "AMBIGUOUS"
+    assert result.recoupled_value is None
+
+
+def test_non_finite_value_is_invalid() -> None:
+    result = recouple_to_integer(math.nan, min_value=-1, max_value=1, tolerance=0.1)
+
+    assert result.ok is False
+    assert result.decision == "INVALID"
+    assert result.error is None
+
+
+def test_state_validation() -> None:
+    with pytest.raises(ValueError, match="states must not be empty"):
+        recouple_to_states(1.0, [], tolerance=0.1)
+    with pytest.raises(ValueError, match="min_value"):
+        integer_states(2, 1)

--- a/tests/test_reaction_harness.py
+++ b/tests/test_reaction_harness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from python.scbe.reaction_harness import evaluate_bijective_reaction
 from python.scbe.reaction_state import ReactionEndpoint, ReactionRecalculation
+from python.scbe.quasi_integer_recoupling import recouple_bond_order
 
 
 def endpoint(identity: str, representation: str = "field-map") -> ReactionEndpoint:
@@ -104,3 +105,24 @@ def test_failed_recalculation_marks_result_invalid() -> None:
     assert result.ok is False
     assert result.packet.classification == "INVALID"
     assert result.preserved_fields == ["behavior_hash"]
+
+
+def test_recoupled_fractional_fields_can_preserve_identity() -> None:
+    result = evaluate_bijective_reaction(
+        domain="chem",
+        bounded_operation="fractional_bond_order_to_symbolic_state",
+        source=endpoint("aromatic-fragment", "field-map"),
+        target=endpoint("aromatic-fragment", "field-map"),
+        source_fields={
+            "bond_order_state": recouple_bond_order(1.49, tolerance=0.1),
+        },
+        target_fields={
+            "bond_order_state": 1.5,
+        },
+        required_identity_fields=("bond_order_state",),
+        generated_at_utc="2026-05-31T00:00:00Z",
+    )
+
+    assert result.ok is True
+    assert result.packet.classification == "BIJECTIVE"
+    assert result.field_checks[0].source_value["label"] == "aromatic-or-resonance-like"


### PR DESCRIPTION
## Summary
- Adds a quasi-integer recoupling utility for converting continuous/fractional evidence into auditable symbolic states
- Adds integer, half-integer, bond-order, and formal-charge presets
- Integrates recoupling objects into the bijective reaction harness field comparisons while retaining raw recoupling metadata in field checks
- Adds research notes and source-backed claim boundaries

## Research basis
- RDKit Gasteiger charge docs: partial charges are computed and stored as _GasteigerCharge
- IUPAC formal charge: formal Lewis-structure accounting is integer-like
- RDKit DetermineBondOrders: bond-order assignment depends on coordinates/charge context
- IUPAC bond-order entry: bond order can be a weighted average of formal bond orders

## Verification
- pytest tests/test_quasi_integer_recoupling.py tests/test_reaction_harness.py tests/test_reaction_state_packet.py tests/benchmark/test_compound_decomposition_recomposition.py -q -> 21 passed
- node --check packages/cli/bin/scbe.js
- node --test packages/cli/tests/react.test.cjs packages/cli/tests/bench.test.cjs -> 18 passed
- scbe bench compound-decompose --json -> PASS 30/30
- scbe react audit latest compound report -> ok true, 30 packets

## Claim boundary
Computational representation bridge only. It records approximation error and tolerance; it does not assert one true integer state for every quantum or chemical observable.