### PR TITLE
feat(chem): add audio field observable bridge

### DIFF
--- a/docs/research/audio_field_observable_bridge_2026-05-31.md
+++ b/docs/research/audio_field_observable_bridge_2026-05-31.md
@@ -1,0 +1,69 @@
+# Audio Field Observable Bridge
+
+Date: 2026-05-31
+
+## Claim Boundary
+
+Audio is a wave-observation lane. This bridge does **not** claim that arbitrary
+sound can reveal an arbitrary magnetic field. It extracts acoustic observables
+and only emits magnetic or field-coupling proxies when a physical context is
+declared.
+
+## Research Basis
+
+- SCBE already has Layer 14 Audio Axis telemetry: frame energy, spectral
+  centroid, spectral flux, high-frequency ratio, and audio stability.
+- Magnetoelastic research gives a real bridge between strain/acoustic phonons
+  and magnetization in magnetic materials.
+- Magnetosonic plasma waves give a real bridge between compressibility, sound
+  speed, Alfven speed, propagation angle, and magnetic pressure.
+- NASA plasma-wave communication is usually sonification of electric/magnetic
+  field measurements, not ordinary air sound in vacuum.
+
+## Product Use
+
+The implementation lives in `python/scbe/audio_field_observables.py`.
+
+It extracts:
+
+- `energy_log`
+- `spectral_centroid_hz`
+- `spectral_bandwidth_hz`
+- `high_frequency_ratio`
+- `stability`
+- `dispersion_proxy`
+- `reverberation_decay_s`
+- `modal_count`
+- `phase_wrap_count`
+- `field_coupling_proxy`, only for declared `magnetoelastic` or
+  `magnetosonic` models
+
+This can later be inserted into reaction packets as an observable relation lane:
+
+```text
+audio frame
+-> acoustic observables
+-> declared model-bound field proxy
+-> quasi-integer recoupling
+-> reaction packet receipt
+```
+
+## Safe Interpretation
+
+- Generic audio: acoustic observation only.
+- Magnetoelastic model: bounded proxy for strain-magnetization coupling.
+- Magnetosonic model: bounded proxy for compressibility-magnetic-pressure
+  coupling using declared sound and Alfven speeds.
+
+## Sources
+
+- Yi Li et al., "Advances in coherent coupling between magnons and acoustic
+  phonons," APL Materials 9, 060902 (2021).
+  https://pubs.aip.org/aip/apm/article/9/6/060902/123131/Advances-in-coherent-coupling-between-magnons-and
+- Y. Chen et al., "Resonance zones for interactions of magnetosonic waves with
+  radiation belt electrons and protons," Geoscience Letters (2017).
+  https://link.springer.com/article/10.1186/s40562-017-0086-3
+- NASA, "Eavesdropping in Space: How NASA records eerie sounds around Earth."
+  https://science.nasa.gov/blogs/the-sun-spot/2018/12/11/eavesdropping-in-space-how-nasa-records-eerie-sounds-around-earth/
+- NASA, "In Solar System's Symphony, Earth's Magnetic Field Drops the Beat."
+  https://www.nasa.gov/solar-system/in-solar-systems-symphony-earths-magnetic-field-drops-the-beat/

--- a/python/scbe/__init__.py
+++ b/python/scbe/__init__.py
@@ -76,7 +76,12 @@ __all__ = [
     "TaskGateResult",
 ]
 from .atomic_tokenization import AtomicTokenState, Element as AtomicElement
-from .atomic_tokenization import TritVector, atomic_drift_scale, element_to_tau, element_to_trit_vector
+from .atomic_tokenization import (
+    TritVector,
+    atomic_drift_scale,
+    element_to_tau,
+    element_to_trit_vector,
+)
 from .atomic_tokenization import map_token_to_atomic_state, map_token_to_element
 from .chemical_fusion import FusionParams, FusionResult, fuse_atomic_states, fuse_tokens
 from .ca_opcode_table import (
@@ -95,9 +100,18 @@ from .history_reducer import (
     reduce_atomic_history,
     reduce_years,
 )
-from .ingestion_rights import classify_ingestion_rights_record, get_source_record, load_source_registry
+from .ingestion_rights import (
+    classify_ingestion_rights_record,
+    get_source_record,
+    load_source_registry,
+)
 from .rhombic_bridge import rhombic_fusion, rhombic_score
-from .semantic_gate import SemanticBlendPolicy, SemanticGateRecord, SemanticSignal, evaluate_semantic_gate
+from .semantic_gate import (
+    SemanticBlendPolicy,
+    SemanticGateRecord,
+    SemanticSignal,
+    evaluate_semantic_gate,
+)
 from .tongue_code_lanes import (
     CODE_LANE_REGISTRY,
     classify_code_lane_alignment,
@@ -128,6 +142,13 @@ from .quasi_integer_recoupling import (
     recouple_formal_charge,
     recouple_to_integer,
     recouple_to_states,
+)
+from .audio_field_observables import (
+    AudioFieldModel,
+    AudioFieldObservables,
+    analyze_audio_field,
+    generate_decaying_sine,
+    generate_sine,
 )
 
 __all__ += [
@@ -187,4 +208,9 @@ __all__ += [
     "recouple_to_integer",
     "recouple_bond_order",
     "recouple_formal_charge",
+    "AudioFieldModel",
+    "AudioFieldObservables",
+    "analyze_audio_field",
+    "generate_sine",
+    "generate_decaying_sine",
 ]

--- a/python/scbe/audio_field_observables.py
+++ b/python/scbe/audio_field_observables.py
@@ -1,0 +1,282 @@
+"""Audio-field observable bridge.
+
+This module treats audio as a wave-observation lane. It does not infer a
+magnetic field from sound alone. Instead it extracts stable acoustic features
+and, when a physical model is declared, emits bounded field-coupling proxies
+that can be carried by reaction packets or benchmark reports.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+from .quasi_integer_recoupling import (
+    QuasiIntegerRecoupling,
+    recouple_to_integer,
+)
+
+EPS = 1e-12
+FieldModelKind = Literal["generic", "magnetoelastic", "magnetosonic"]
+
+
+@dataclass(frozen=True, slots=True)
+class AudioFieldModel:
+    """Declared context for interpreting audio features as field proxies."""
+
+    kind: FieldModelKind = "generic"
+    name: str = "generic-acoustic"
+    coupling_gain: float = 1.0
+    sound_speed_mps: float | None = None
+    alfven_speed_mps: float | None = None
+    magnetic_field_tesla: float | None = None
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class AudioFieldObservables:
+    """Auditable acoustic features plus optional field-coupling proxies."""
+
+    sample_rate_hz: float
+    sample_count: int
+    energy_log: float
+    spectral_centroid_hz: float
+    spectral_bandwidth_hz: float
+    high_frequency_ratio: float
+    stability: float
+    dispersion_proxy: float
+    reverberation_decay_s: float | None
+    modal_count: int
+    phase_wrap_count: int
+    modal_count_state: QuasiIntegerRecoupling
+    field_model: AudioFieldModel
+    field_coupling_proxy: float | None
+    field_relationship: str
+    claim_boundary: tuple[str, ...] = field(
+        default=(
+            "audio observables are wave features, not standalone magnetic-field measurements",
+            "field coupling requires a declared physical model or sensor context",
+        )
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["modal_count_state"] = self.modal_count_state.to_dict()
+        data["field_model"] = self.field_model.to_dict()
+        return data
+
+
+def _dft_complex(signal: list[float]) -> list[complex]:
+    n_samples = len(signal)
+    spectrum: list[complex] = []
+    for k in range(n_samples // 2 + 1):
+        real = 0.0
+        imag = 0.0
+        for n, value in enumerate(signal):
+            angle = -2.0 * math.pi * k * n / n_samples
+            real += value * math.cos(angle)
+            imag += value * math.sin(angle)
+        spectrum.append(complex(real, imag))
+    return spectrum
+
+
+def _unwrap_phase(phases: list[float]) -> list[float]:
+    if not phases:
+        return []
+    unwrapped = [phases[0]]
+    offset = 0.0
+    previous = phases[0]
+    for phase in phases[1:]:
+        delta = phase - previous
+        if delta > math.pi:
+            offset -= 2.0 * math.pi
+        elif delta < -math.pi:
+            offset += 2.0 * math.pi
+        unwrapped.append(phase + offset)
+        previous = phase
+    return unwrapped
+
+
+def _count_peaks(powers: list[float], *, threshold_ratio: float = 0.1) -> int:
+    if len(powers) < 3:
+        return 0
+    peak_power = max(powers)
+    if peak_power <= EPS:
+        return 0
+    threshold = peak_power * threshold_ratio
+    count = 0
+    for index in range(1, len(powers) - 1):
+        if (
+            powers[index] >= threshold
+            and powers[index] >= powers[index - 1]
+            and powers[index] >= powers[index + 1]
+        ):
+            count += 1
+    return count
+
+
+def _estimate_decay_seconds(signal: list[float], sample_rate_hz: float) -> float | None:
+    window = max(8, min(128, len(signal) // 8))
+    if len(signal) < window * 3:
+        return None
+    points: list[tuple[float, float]] = []
+    for start in range(0, len(signal) - window + 1, window):
+        frame = signal[start : start + window]
+        energy = sum(value * value for value in frame) / window
+        if energy > EPS:
+            t = (start + window / 2.0) / sample_rate_hz
+            points.append((t, math.log(energy)))
+    if len(points) < 3:
+        return None
+    n = len(points)
+    sum_t = sum(point[0] for point in points)
+    sum_y = sum(point[1] for point in points)
+    sum_tt = sum(point[0] * point[0] for point in points)
+    sum_ty = sum(point[0] * point[1] for point in points)
+    denom = n * sum_tt - sum_t * sum_t
+    if abs(denom) <= EPS:
+        return None
+    slope = (n * sum_ty - sum_t * sum_y) / denom
+    if slope >= -EPS:
+        return None
+    # Energy decay: ln(E) slope. Time to -60 dB energy is ln(1e-6)/slope.
+    return math.log(1e-6) / slope
+
+
+def _compute_field_coupling(
+    *,
+    model: AudioFieldModel,
+    stability: float,
+    dispersion_proxy: float,
+) -> tuple[float | None, str]:
+    if model.kind == "generic":
+        return None, "unmodeled-acoustic-observation"
+    if model.kind == "magnetoelastic":
+        coupling = max(
+            0.0, min(1.0, model.coupling_gain * stability / (1.0 + dispersion_proxy))
+        )
+        return coupling, "strain-magnetization coupling proxy"
+    if model.kind == "magnetosonic":
+        if model.sound_speed_mps is None or model.alfven_speed_mps is None:
+            return (
+                None,
+                "magnetosonic model missing sound_speed_mps or alfven_speed_mps",
+            )
+        sound = abs(model.sound_speed_mps)
+        alfven = abs(model.alfven_speed_mps)
+        magnetosonic_speed = math.sqrt(sound * sound + alfven * alfven)
+        if magnetosonic_speed <= EPS:
+            return None, "magnetosonic model has zero wave speed"
+        magnetic_share = alfven / magnetosonic_speed
+        coupling = max(0.0, min(1.0, model.coupling_gain * magnetic_share * stability))
+        return coupling, "compressibility-magnetic-pressure coupling proxy"
+    return None, "unsupported field model"
+
+
+def analyze_audio_field(
+    signal: list[float] | tuple[float, ...],
+    *,
+    sample_rate_hz: float = 44100.0,
+    high_frequency_cutoff_ratio: float = 0.5,
+    model: AudioFieldModel | None = None,
+) -> AudioFieldObservables:
+    """Extract acoustic observables and optional model-bound field proxies."""
+
+    samples = [float(value) for value in signal]
+    if not samples:
+        raise ValueError("signal must not be empty")
+    if sample_rate_hz <= 0:
+        raise ValueError("sample_rate_hz must be > 0")
+    if not 0.0 <= high_frequency_cutoff_ratio <= 1.0:
+        raise ValueError("high_frequency_cutoff_ratio must be in [0, 1]")
+
+    spectrum = _dft_complex(samples)
+    powers = [value.real * value.real + value.imag * value.imag for value in spectrum]
+    total_power = sum(powers) + EPS
+    bin_width = sample_rate_hz / len(samples)
+    frequencies = [index * bin_width for index in range(len(powers))]
+
+    energy_log = math.log(EPS + sum(value * value for value in samples))
+    centroid = (
+        sum(freq * power for freq, power in zip(frequencies, powers)) / total_power
+    )
+    variance = (
+        sum(
+            ((freq - centroid) ** 2) * power for freq, power in zip(frequencies, powers)
+        )
+        / total_power
+    )
+    bandwidth = math.sqrt(max(0.0, variance))
+    cutoff_index = int(len(powers) * high_frequency_cutoff_ratio)
+    high_frequency_ratio = sum(powers[cutoff_index:]) / total_power
+    high_frequency_ratio = max(0.0, min(1.0, high_frequency_ratio))
+    stability = 1.0 - high_frequency_ratio
+    dispersion_proxy = bandwidth / (centroid + EPS) if centroid > EPS else 0.0
+    modal_count = _count_peaks(powers)
+    modal_state = recouple_to_integer(
+        modal_count, min_value=0, max_value=64, tolerance=0.0
+    )
+
+    phases = _unwrap_phase([math.atan2(value.imag, value.real) for value in spectrum])
+    phase_wrap_count = 0
+    for previous, current in zip(phases, phases[1:]):
+        if abs(current - previous) > math.pi:
+            phase_wrap_count += 1
+
+    field_model = model or AudioFieldModel()
+    coupling, relationship = _compute_field_coupling(
+        model=field_model,
+        stability=stability,
+        dispersion_proxy=dispersion_proxy,
+    )
+
+    return AudioFieldObservables(
+        sample_rate_hz=sample_rate_hz,
+        sample_count=len(samples),
+        energy_log=energy_log,
+        spectral_centroid_hz=centroid,
+        spectral_bandwidth_hz=bandwidth,
+        high_frequency_ratio=high_frequency_ratio,
+        stability=stability,
+        dispersion_proxy=dispersion_proxy,
+        reverberation_decay_s=_estimate_decay_seconds(samples, sample_rate_hz),
+        modal_count=modal_count,
+        phase_wrap_count=phase_wrap_count,
+        modal_count_state=modal_state,
+        field_model=field_model,
+        field_coupling_proxy=coupling,
+        field_relationship=relationship,
+    )
+
+
+def generate_sine(
+    frequency_hz: float,
+    *,
+    sample_rate_hz: float = 44100.0,
+    duration_s: float = 0.02,
+    amplitude: float = 1.0,
+) -> list[float]:
+    sample_count = max(1, int(sample_rate_hz * duration_s))
+    return [
+        amplitude * math.sin(2.0 * math.pi * frequency_hz * index / sample_rate_hz)
+        for index in range(sample_count)
+    ]
+
+
+def generate_decaying_sine(
+    frequency_hz: float,
+    *,
+    sample_rate_hz: float = 44100.0,
+    duration_s: float = 0.08,
+    decay_seconds: float = 0.02,
+) -> list[float]:
+    sample_count = max(1, int(sample_rate_hz * duration_s))
+    return [
+        math.exp(-(index / sample_rate_hz) / decay_seconds)
+        * math.sin(2.0 * math.pi * frequency_hz * index / sample_rate_hz)
+        for index in range(sample_count)
+    ]

--- a/tests/test_audio_field_observables.py
+++ b/tests/test_audio_field_observables.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from python.scbe.audio_field_observables import (
+    AudioFieldModel,
+    analyze_audio_field,
+    generate_decaying_sine,
+    generate_sine,
+)
+
+
+def test_high_frequency_ratio_tracks_signal_band() -> None:
+    low = analyze_audio_field(
+        generate_sine(100.0, sample_rate_hz=2048.0, duration_s=0.25),
+        sample_rate_hz=2048.0,
+        high_frequency_cutoff_ratio=0.5,
+    )
+    high = analyze_audio_field(
+        generate_sine(800.0, sample_rate_hz=2048.0, duration_s=0.25),
+        sample_rate_hz=2048.0,
+        high_frequency_cutoff_ratio=0.5,
+    )
+
+    assert low.high_frequency_ratio < 0.05
+    assert high.high_frequency_ratio > 0.95
+    assert low.stability > high.stability
+
+
+def test_reverberation_decay_proxy_detects_decay() -> None:
+    observed = analyze_audio_field(
+        generate_decaying_sine(
+            220.0,
+            sample_rate_hz=4096.0,
+            duration_s=0.12,
+            decay_seconds=0.025,
+        ),
+        sample_rate_hz=4096.0,
+    )
+
+    assert observed.reverberation_decay_s is not None
+    assert observed.reverberation_decay_s > 0
+
+
+def test_generic_model_does_not_claim_magnetic_field() -> None:
+    observed = analyze_audio_field(
+        generate_sine(440.0, sample_rate_hz=4096.0, duration_s=0.05),
+        sample_rate_hz=4096.0,
+    )
+
+    assert observed.field_coupling_proxy is None
+    assert observed.field_relationship == "unmodeled-acoustic-observation"
+    assert "not standalone magnetic-field measurements" in observed.claim_boundary[0]
+
+
+def test_magnetoelastic_model_emits_bounded_coupling_proxy() -> None:
+    observed = analyze_audio_field(
+        generate_sine(440.0, sample_rate_hz=4096.0, duration_s=0.05),
+        sample_rate_hz=4096.0,
+        model=AudioFieldModel(
+            kind="magnetoelastic", name="thin-film-saw", coupling_gain=0.8
+        ),
+    )
+
+    assert observed.field_relationship == "strain-magnetization coupling proxy"
+    assert observed.field_coupling_proxy is not None
+    assert 0.0 <= observed.field_coupling_proxy <= 1.0
+
+
+def test_magnetosonic_model_requires_wave_speeds() -> None:
+    missing = analyze_audio_field(
+        generate_sine(120.0, sample_rate_hz=2048.0, duration_s=0.05),
+        sample_rate_hz=2048.0,
+        model=AudioFieldModel(kind="magnetosonic", name="plasma-no-speeds"),
+    )
+    with_speeds = analyze_audio_field(
+        generate_sine(120.0, sample_rate_hz=2048.0, duration_s=0.05),
+        sample_rate_hz=2048.0,
+        model=AudioFieldModel(
+            kind="magnetosonic",
+            name="declared-plasma",
+            sound_speed_mps=10_000.0,
+            alfven_speed_mps=30_000.0,
+        ),
+    )
+
+    assert missing.field_coupling_proxy is None
+    assert "missing" in missing.field_relationship
+    assert (
+        with_speeds.field_relationship
+        == "compressibility-magnetic-pressure coupling proxy"
+    )
+    assert with_speeds.field_coupling_proxy is not None
+    assert 0.0 <= with_speeds.field_coupling_proxy <= 1.0
+
+
+def test_modal_count_is_recoupled_to_integer_state() -> None:
+    signal = [
+        a + b
+        for a, b in zip(
+            generate_sine(128.0, sample_rate_hz=2048.0, duration_s=0.25),
+            generate_sine(384.0, sample_rate_hz=2048.0, duration_s=0.25, amplitude=0.6),
+        )
+    ]
+    observed = analyze_audio_field(signal, sample_rate_hz=2048.0)
+
+    assert observed.modal_count >= 2
+    assert observed.modal_count_state.ok is True
+    assert observed.modal_count_state.recoupled_value == pytest.approx(
+        float(observed.modal_count)
+    )


### PR DESCRIPTION
## Summary
- adds a model-bound audio field observable bridge for acoustic dispersion, reverberation decay, modal count, and field-coupling proxies
- exports the bridge through python.scbe
- documents the claim boundary: generic audio is not a standalone magnetic-field measurement; coupling proxies require declared magnetoelastic or magnetosonic context

## Test evidence
- pytest tests/test_audio_field_observables.py tests/test_quasi_integer_recoupling.py tests/test_reaction_harness.py -q -> 19 passed
- python.scbe import smoke -> magnetoelastic proxy emitted with stability 0.999616