### PR TITLE
chore(format): black 120-char on 36 pre-existing unformatted files

### DIFF
--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -4724,68 +4724,92 @@ _SKILL_TIER_LABELS: Dict[str, str] = {
 
 # (tier, tongue, band, deps, description)
 _SKILL_TREE_META: Dict[str, Tuple[str, str, str, List[str], str]] = {
-    "ops":                   ("L1", "KO", "LEXICON",       [],                             "List all 64 lexicon ops"),
-    "atomic":                ("L1", "KO", "LEXICON",       ["ops"],                        "Inspect atomic substrate row for an op"),
-    "emit":                  ("L1", "KO", "LEXICON",       ["ops"],                        "Emit code for an op in any tongue"),
-    "encode-cmd":            ("L1", "KO", "TOKENIZER",     [],                             "Encode payload via Sacred Tongue tokenizer"),
-    "decode-cmd":            ("L1", "KO", "TOKENIZER",     ["encode-cmd"],                 "Decode Sacred Tongue token stream to plaintext"),
-    "xlate-cmd":             ("L1", "AV", "TOKENIZER",     ["encode-cmd", "decode-cmd"],   "Translate token stream across tongues"),
-    "binary-to-tokenizer":   ("L1", "KO", "TOKENIZER",     ["encode-cmd"],                 "Map binary bytes to Sacred Tongue token rows"),
-    "yin-yang-dual":         ("L2", "DR", "TOKENIZER",     ["encode-cmd", "decode-cmd"],   "Build KO/DR yin-yang dual token packet"),
-    "tongue-compile":        ("L2", "KO", "TOOLCHAIN",     ["encode-cmd"],                 "Compile Sacred Tongues .sts assembly to VM bytecode"),
-    "tongue-run":            ("L4", "KO", "TOOLCHAIN",     ["tongue-compile"],             "Run Sacred Tongues .sts program in bounded VM"),
-    "code-packet":           ("L2", "KO", "ANALYSIS",      ["emit"],                       "Build SCBE weighted code packet from source"),
-    "braille-lane":          ("L2", "KO", "ANALYSIS",      ["code-packet"],                "Build braille/polyhedral cell lane from source"),
-    "interaction-graph":     ("L2", "AV", "ANALYSIS",      ["code-packet"],                "Build source/token/STISA/atomic interaction graph"),
-    "topology-view":         ("L2", "AV", "ANALYSIS",      ["interaction-graph"],          "Build topology view with polygons and leylines"),
-    "cluster-graph":         ("L2", "RU", "ANALYSIS",      ["topology-view"],              "Build cross-lattice cluster graph"),
-    "formation-graph":       ("L2", "RU", "ANALYSIS",      ["cluster-graph"],              "Build cross-lattice formation graph"),
-    "cross-domain-sequence": ("L2", "CA", "ANALYSIS",      ["topology-view"],              "Build cross-domain route sequence"),
-    "honeycomb-analysis":    ("L2", "CA", "ANALYSIS",      ["topology-view"],              "Analyze route cell execution stability"),
-    "cognition-map":         ("L2", "UM", "ANALYSIS",      ["topology-view"],              "Build cognitive well/ternary overlay map"),
-    "mars-mission":          ("L2", "KO", "ANALYSIS",      ["topology-view"],              "Build Mars mission compass/minimap packet"),
-    "api-graph":             ("L2", "DR", "ANALYSIS",      [],                             "Self-describing skill tree of the GeoSeal CLI"),
-    "seal":                  ("L3", "KO", "GOVERNANCE",    ["emit"],                       "Apply GeoSeal phase signature to a payload"),
-    "verify":                ("L3", "KO", "GOVERNANCE",    ["seal"],                       "Verify a GeoSeal signature"),
-    "seal-here":             ("L3", "KO", "GOVERNANCE",    ["seal"],                       "Geo-fence seal (PowerShell parameter-bound)"),
-    "backend-registry":      ("L3", "KO", "ROUTING",       [],                             "List backend providers and lane support"),
-    "portal-box":            ("L3", "KO", "ROUTING",       ["code-packet"],                "Build local portal-box route packet"),
-    "stream-wheel":          ("L3", "AV", "ROUTING",       ["portal-box"],                 "Build local stream-wheel route packet"),
-    "code-roundtrip":        ("L3", "RU", "TOOLCHAIN",     ["encode-cmd", "decode-cmd"],   "Encode/decode/execute code roundtrip through tongue"),
-    "explain-route":         ("L3", "KO", "ROUTING",       ["backend-registry"],           "Explain route IR and backend chain for a source"),
-    "route":                 ("L3", "KO", "ROUTING",       ["explain-route"],              "Route intent via SLM (auto or manual)"),
-    "run":                   ("L4", "KO", "EXECUTION",     ["emit", "seal"],               "Run lexicon op in one tongue subprocess"),
-    "swarm":                 ("L4", "KO", "EXECUTION",     ["run"],                        "Dispatch op to swarm of tongue bots with BFT consensus"),
-    "cross-build":           ("L4", "RU", "EXECUTION",     ["emit"],                       "Bijective A→lattice IR→B tongue translation"),
-    "swarm-exec":            ("L4", "RU", "EXECUTION",     ["swarm", "cross-build"],       "Meet-in-the-middle codegen through bijective seam"),
-    "exec":                  ("L4", "CA", "EXECUTION",     ["seal"],                       "Run command through GeoSeal execution gate"),
-    "shell":                 ("L4", "CA", "EXECUTION",     ["exec"],                       "Run nested GeoSeal command string"),
-    "arc":                   ("L4", "UM", "EXECUTION",     ["run"],                        "Synthesize + apply ARC task program"),
-    "agent":                 ("L4", "KO", "AGENT",         ["route", "backend-registry"],  "Route coding task via Polly → GeoSeal stamp"),
-    "cursor":                ("L4", "DR", "AGENT",         ["agent"],                      "Delegate bounded repo task to Cursor Agent"),
-    "testing-cli":           ("L4", "KO", "TESTING",       ["run", "seal"],                "Build testing playback packet and execute"),
-    "project-scaffold":      ("L4", "KO", "SCAFFOLD",      ["agent", "route"],             "Create lightweight project scaffold from intent"),
-    "legitimacy-trial":      ("L5", "KO", "GOVERNANCE",    ["seal", "exec"],               "Evaluate time/location/workspace/intent context"),
-    "coding-trial":          ("L5", "KO", "GOVERNANCE",    ["legitimacy-trial"],           "Legitimacy trial plus compiler/test probe"),
-    "validate-line":         ("L5", "KO", "GOVERNANCE",    ["exec"],                       "Preflight command line — PSReadLine-style verdict"),
-    "history":               ("L5", "KO", "AUDIT",         ["run", "swarm"],               "Show execution history from ledger"),
-    "replay":                ("L5", "KO", "AUDIT",         ["history"],                    "Replay a previous ledger record"),
-    "workflow":              ("L5", "DR", "GOVERNANCE",    ["agent", "seal"],              "Declarative .geoseal.yaml workflow runner"),
-    "promotions":            ("L5", "KO", "PROMOTION",     ["route"],                      "List dispatch patterns above promotion threshold"),
-    "promote":               ("L5", "KO", "PROMOTION",     ["promotions"],                 "Register recurring dispatch as a named alias"),
-    "aliases":               ("L5", "KO", "PROMOTION",     ["promote"],                    "List registered alias names and dispatch shape"),
-    "alias":                 ("L5", "KO", "PROMOTION",     ["promote"],                    "Invoke a registered alias deterministically"),
-    "unpromote":             ("L5", "KO", "PROMOTION",     ["promote"],                    "Remove a registered alias"),
-    "compile":               ("L6", "AV", "ORCHESTRATION", ["route", "agent-harness"],     "Compile intent into agent-bus command plan"),
-    "agent-harness":         ("L6", "KO", "ORCHESTRATION", ["route", "backend-registry"],  "Emit model-neutral agent harness manifest"),
-    "agent-endurance-pack":  ("L6", "KO", "ORCHESTRATION", ["agent-harness"],              "Generate Agent Endurance v1 spec bundle"),
-    "call-switchboard":      ("L6", "CA", "ORCHESTRATION", ["route", "seal"],              "Evaluate multi-agent call reservation"),
-    "lightning-indexer":     ("L6", "RU", "ORCHESTRATION", ["call-switchboard"],           "Select sparse agent context candidates"),
-    "loop-dispatch":         ("L6", "AV", "ORCHESTRATION", ["agent", "legitimacy-trial"],  "Policy-gated external agent loop dispatch"),
-    "assist":                ("L6", "KO", "ORCHESTRATION", ["route", "compile"],           "Local micro-assist for terminal agents"),
-    "domino":                ("L6", "DR", "ORCHESTRATION", ["workflow"],                   "Arrange domino workflow tiles with contact transfer"),
-    "terminus-training":     ("L6", "UM", "TRAINING",      ["swarm", "agent"],             "Run Terminus guild agent training"),
-    "pair-agent-training":   ("L6", "KO", "TRAINING",      ["agent", "workflow"],          "Build GeoShell pair-agent SFT dataset"),
+    "ops": ("L1", "KO", "LEXICON", [], "List all 64 lexicon ops"),
+    "atomic": ("L1", "KO", "LEXICON", ["ops"], "Inspect atomic substrate row for an op"),
+    "emit": ("L1", "KO", "LEXICON", ["ops"], "Emit code for an op in any tongue"),
+    "encode-cmd": ("L1", "KO", "TOKENIZER", [], "Encode payload via Sacred Tongue tokenizer"),
+    "decode-cmd": ("L1", "KO", "TOKENIZER", ["encode-cmd"], "Decode Sacred Tongue token stream to plaintext"),
+    "xlate-cmd": ("L1", "AV", "TOKENIZER", ["encode-cmd", "decode-cmd"], "Translate token stream across tongues"),
+    "binary-to-tokenizer": ("L1", "KO", "TOKENIZER", ["encode-cmd"], "Map binary bytes to Sacred Tongue token rows"),
+    "yin-yang-dual": ("L2", "DR", "TOKENIZER", ["encode-cmd", "decode-cmd"], "Build KO/DR yin-yang dual token packet"),
+    "tongue-compile": ("L2", "KO", "TOOLCHAIN", ["encode-cmd"], "Compile Sacred Tongues .sts assembly to VM bytecode"),
+    "tongue-run": ("L4", "KO", "TOOLCHAIN", ["tongue-compile"], "Run Sacred Tongues .sts program in bounded VM"),
+    "code-packet": ("L2", "KO", "ANALYSIS", ["emit"], "Build SCBE weighted code packet from source"),
+    "braille-lane": ("L2", "KO", "ANALYSIS", ["code-packet"], "Build braille/polyhedral cell lane from source"),
+    "interaction-graph": ("L2", "AV", "ANALYSIS", ["code-packet"], "Build source/token/STISA/atomic interaction graph"),
+    "topology-view": ("L2", "AV", "ANALYSIS", ["interaction-graph"], "Build topology view with polygons and leylines"),
+    "cluster-graph": ("L2", "RU", "ANALYSIS", ["topology-view"], "Build cross-lattice cluster graph"),
+    "formation-graph": ("L2", "RU", "ANALYSIS", ["cluster-graph"], "Build cross-lattice formation graph"),
+    "cross-domain-sequence": ("L2", "CA", "ANALYSIS", ["topology-view"], "Build cross-domain route sequence"),
+    "honeycomb-analysis": ("L2", "CA", "ANALYSIS", ["topology-view"], "Analyze route cell execution stability"),
+    "cognition-map": ("L2", "UM", "ANALYSIS", ["topology-view"], "Build cognitive well/ternary overlay map"),
+    "mars-mission": ("L2", "KO", "ANALYSIS", ["topology-view"], "Build Mars mission compass/minimap packet"),
+    "api-graph": ("L2", "DR", "ANALYSIS", [], "Self-describing skill tree of the GeoSeal CLI"),
+    "seal": ("L3", "KO", "GOVERNANCE", ["emit"], "Apply GeoSeal phase signature to a payload"),
+    "verify": ("L3", "KO", "GOVERNANCE", ["seal"], "Verify a GeoSeal signature"),
+    "seal-here": ("L3", "KO", "GOVERNANCE", ["seal"], "Geo-fence seal (PowerShell parameter-bound)"),
+    "backend-registry": ("L3", "KO", "ROUTING", [], "List backend providers and lane support"),
+    "portal-box": ("L3", "KO", "ROUTING", ["code-packet"], "Build local portal-box route packet"),
+    "stream-wheel": ("L3", "AV", "ROUTING", ["portal-box"], "Build local stream-wheel route packet"),
+    "code-roundtrip": (
+        "L3",
+        "RU",
+        "TOOLCHAIN",
+        ["encode-cmd", "decode-cmd"],
+        "Encode/decode/execute code roundtrip through tongue",
+    ),
+    "explain-route": ("L3", "KO", "ROUTING", ["backend-registry"], "Explain route IR and backend chain for a source"),
+    "route": ("L3", "KO", "ROUTING", ["explain-route"], "Route intent via SLM (auto or manual)"),
+    "run": ("L4", "KO", "EXECUTION", ["emit", "seal"], "Run lexicon op in one tongue subprocess"),
+    "swarm": ("L4", "KO", "EXECUTION", ["run"], "Dispatch op to swarm of tongue bots with BFT consensus"),
+    "cross-build": ("L4", "RU", "EXECUTION", ["emit"], "Bijective A→lattice IR→B tongue translation"),
+    "swarm-exec": (
+        "L4",
+        "RU",
+        "EXECUTION",
+        ["swarm", "cross-build"],
+        "Meet-in-the-middle codegen through bijective seam",
+    ),
+    "exec": ("L4", "CA", "EXECUTION", ["seal"], "Run command through GeoSeal execution gate"),
+    "shell": ("L4", "CA", "EXECUTION", ["exec"], "Run nested GeoSeal command string"),
+    "arc": ("L4", "UM", "EXECUTION", ["run"], "Synthesize + apply ARC task program"),
+    "agent": ("L4", "KO", "AGENT", ["route", "backend-registry"], "Route coding task via Polly → GeoSeal stamp"),
+    "cursor": ("L4", "DR", "AGENT", ["agent"], "Delegate bounded repo task to Cursor Agent"),
+    "testing-cli": ("L4", "KO", "TESTING", ["run", "seal"], "Build testing playback packet and execute"),
+    "project-scaffold": ("L4", "KO", "SCAFFOLD", ["agent", "route"], "Create lightweight project scaffold from intent"),
+    "legitimacy-trial": ("L5", "KO", "GOVERNANCE", ["seal", "exec"], "Evaluate time/location/workspace/intent context"),
+    "coding-trial": ("L5", "KO", "GOVERNANCE", ["legitimacy-trial"], "Legitimacy trial plus compiler/test probe"),
+    "validate-line": ("L5", "KO", "GOVERNANCE", ["exec"], "Preflight command line — PSReadLine-style verdict"),
+    "history": ("L5", "KO", "AUDIT", ["run", "swarm"], "Show execution history from ledger"),
+    "replay": ("L5", "KO", "AUDIT", ["history"], "Replay a previous ledger record"),
+    "workflow": ("L5", "DR", "GOVERNANCE", ["agent", "seal"], "Declarative .geoseal.yaml workflow runner"),
+    "promotions": ("L5", "KO", "PROMOTION", ["route"], "List dispatch patterns above promotion threshold"),
+    "promote": ("L5", "KO", "PROMOTION", ["promotions"], "Register recurring dispatch as a named alias"),
+    "aliases": ("L5", "KO", "PROMOTION", ["promote"], "List registered alias names and dispatch shape"),
+    "alias": ("L5", "KO", "PROMOTION", ["promote"], "Invoke a registered alias deterministically"),
+    "unpromote": ("L5", "KO", "PROMOTION", ["promote"], "Remove a registered alias"),
+    "compile": ("L6", "AV", "ORCHESTRATION", ["route", "agent-harness"], "Compile intent into agent-bus command plan"),
+    "agent-harness": (
+        "L6",
+        "KO",
+        "ORCHESTRATION",
+        ["route", "backend-registry"],
+        "Emit model-neutral agent harness manifest",
+    ),
+    "agent-endurance-pack": ("L6", "KO", "ORCHESTRATION", ["agent-harness"], "Generate Agent Endurance v1 spec bundle"),
+    "call-switchboard": ("L6", "CA", "ORCHESTRATION", ["route", "seal"], "Evaluate multi-agent call reservation"),
+    "lightning-indexer": ("L6", "RU", "ORCHESTRATION", ["call-switchboard"], "Select sparse agent context candidates"),
+    "loop-dispatch": (
+        "L6",
+        "AV",
+        "ORCHESTRATION",
+        ["agent", "legitimacy-trial"],
+        "Policy-gated external agent loop dispatch",
+    ),
+    "assist": ("L6", "KO", "ORCHESTRATION", ["route", "compile"], "Local micro-assist for terminal agents"),
+    "domino": ("L6", "DR", "ORCHESTRATION", ["workflow"], "Arrange domino workflow tiles with contact transfer"),
+    "terminus-training": ("L6", "UM", "TRAINING", ["swarm", "agent"], "Run Terminus guild agent training"),
+    "pair-agent-training": ("L6", "KO", "TRAINING", ["agent", "workflow"], "Build GeoShell pair-agent SFT dataset"),
 }
 
 
@@ -4823,9 +4847,7 @@ def _build_api_skill_tree(
             p = build_parser()
             for action_group in p._subparsers._group_actions:
                 for name, sub_p in action_group.choices.items():
-                    param_counts[name] = sum(
-                        1 for a in sub_p._actions if a.dest not in ("help",)
-                    )
+                    param_counts[name] = sum(1 for a in sub_p._actions if a.dest not in ("help",))
         except Exception:
             pass
 
@@ -4886,11 +4908,13 @@ def _build_api_skill_tree(
         nodes.append(node)
         for dep in deps:
             if dep in active:
-                edges.append({
-                    "source": f"cmd:{dep}",
-                    "target": f"cmd:{cmd_name}",
-                    "relation": "unlocks",
-                })
+                edges.append(
+                    {
+                        "source": f"cmd:{dep}",
+                        "target": f"cmd:{cmd_name}",
+                        "relation": "unlocks",
+                    }
+                )
 
     by_tier: Dict[str, List[str]] = {}
     by_band: Dict[str, List[str]] = {}
@@ -4939,7 +4963,7 @@ def _skill_tree_to_mermaid(tree: Dict[str, Any], *, direction: str = "LR") -> st
     for tier in sorted(set(n["tier"] for n in tree["nodes"])):
         tier_label = _SKILL_TIER_LABELS.get(tier, tier)
         tier_nodes = [n for n in tree["nodes"] if n["tier"] == tier]
-        lines.append(f"  subgraph {tier}[\"{tier}: {tier_label}\"]")
+        lines.append(f'  subgraph {tier}["{tier}: {tier_label}"]')
         for n in tier_nodes:
             nid = re.sub(r"[^A-Za-z0-9_]", "_", n["id"])
             entry_mark = " ★" if n["entry_point"] else ""
@@ -4955,16 +4979,24 @@ def _skill_tree_to_mermaid(tree: Dict[str, Any], *, direction: str = "LR") -> st
 
 def _skill_tree_to_dot(tree: Dict[str, Any]) -> str:
     tier_colors = {
-        "L1": "#e0f2fe", "L2": "#dbeafe", "L3": "#ede9fe",
-        "L4": "#fce7f3", "L5": "#fee2e2", "L6": "#fef3c7",
+        "L1": "#e0f2fe",
+        "L2": "#dbeafe",
+        "L3": "#ede9fe",
+        "L4": "#fce7f3",
+        "L5": "#fee2e2",
+        "L6": "#fef3c7",
     }
     tier_borders = {
-        "L1": "#0ea5e9", "L2": "#3b82f6", "L3": "#8b5cf6",
-        "L4": "#ec4899", "L5": "#ef4444", "L6": "#f59e0b",
+        "L1": "#0ea5e9",
+        "L2": "#3b82f6",
+        "L3": "#8b5cf6",
+        "L4": "#ec4899",
+        "L5": "#ef4444",
+        "L6": "#f59e0b",
     }
     lines = [
         "digraph GeoSealSkillTree {",
-        '  rankdir=LR;',
+        "  rankdir=LR;",
         '  graph [fontname="Courier" fontsize=11];',
         '  node [shape=box fontname="Courier" fontsize=10 style=filled];',
         '  edge [fontname="Courier" fontsize=9];',
@@ -4974,7 +5006,7 @@ def _skill_tree_to_dot(tree: Dict[str, Any]) -> str:
         tier_nodes = [n for n in tree["nodes"] if n["tier"] == tier]
         fill = tier_colors.get(tier, "#ffffff")
         border = tier_borders.get(tier, "#999999")
-        lines.append(f'  subgraph cluster_{tier} {{')
+        lines.append(f"  subgraph cluster_{tier} {{")
         lines.append(f'    label="{tier}: {tier_label}";')
         lines.append(f'    style=filled; fillcolor="{fill}"; color="{border}"; penwidth=2;')
         for n in tier_nodes:
@@ -4988,7 +5020,7 @@ def _skill_tree_to_dot(tree: Dict[str, Any]) -> str:
     for edge in tree["edges"]:
         src = re.sub(r"[^A-Za-z0-9_]", "_", edge["source"])
         dst = re.sub(r"[^A-Za-z0-9_]", "_", edge["target"])
-        lines.append(f"  {src} -> {dst} [color=\"#94a3b8\"];")
+        lines.append(f'  {src} -> {dst} [color="#94a3b8"];')
     lines.append("}")
     return "\n".join(lines) + "\n"
 
@@ -5006,7 +5038,9 @@ def _skill_tree_to_ascii(tree: Dict[str, Any]) -> str:
 
     # Header stats
     entries = ", ".join(s["entry_points"][:6]) + ("…" if len(s["entry_points"]) > 6 else "")
-    lines.append(f"  {s['total_commands']} commands  {s['total_edges']} edges  depth={s['max_depth']}  entries: {entries}")
+    lines.append(
+        f"  {s['total_commands']} commands  {s['total_edges']} edges  depth={s['max_depth']}  entries: {entries}"
+    )
     top = "  top: " + "  ".join(f"{r['cmd']}(+{r['unlocks']})" for r in s["top_unlocking"][:5])
     lines.append(top)
     lines.append("─" * W)
@@ -5029,7 +5063,7 @@ def _skill_tree_to_ascii(tree: Dict[str, Any]) -> str:
             band_cmds_sorted = sorted(band_cmds)
             for i, cmd in enumerate(band_cmds_sorted):
                 n = node_map[cmd]
-                is_last = (i == len(band_cmds_sorted) - 1)
+                is_last = i == len(band_cmds_sorted) - 1
                 branch = "└─" if is_last else "├─"
                 entry_star = "★ " if n["entry_point"] else "  "
                 unlock_tag = f"+{n['unlocks_count']}" if n["unlocks_count"] else "  "
@@ -5044,8 +5078,7 @@ def _skill_tree_to_ascii(tree: Dict[str, Any]) -> str:
                 desc = n["description"]
                 lines.append(
                     f"      {branch} {entry_star}{cmd:<26} {n['tongue']} d={n['depth']} "
-                    f"[{unlock_tag:>3}] {desc}"
-                    + req_s
+                    f"[{unlock_tag:>3}] {desc}" + req_s
                 )
 
     lines.append("\n" + "─" * W)
@@ -5130,6 +5163,7 @@ def cmd_bench_api(args: argparse.Namespace) -> int:
     # --- format rendering ---
     tree_full = _build_api_skill_tree()
     for fmt in formats:
+
         def _render(f=fmt, t=tree_full):
             if f == "mermaid":
                 _skill_tree_to_mermaid(t)
@@ -5147,6 +5181,7 @@ def cmd_bench_api(args: argparse.Namespace) -> int:
 
     # --- tier filters ---
     for tf in ["L1", "L3", "L6"]:
+
         def _build_tier(t=tf):
             _build_api_skill_tree(tier_filter=t)
 
@@ -5157,6 +5192,7 @@ def cmd_bench_api(args: argparse.Namespace) -> int:
 
     # --- tongue filters ---
     for tng in ["KO", "DR"]:
+
         def _build_tongue(tn=tng):
             _build_api_skill_tree(tongue_filter=tn)
 
@@ -6053,7 +6089,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_api_graph.add_argument("--tier", default=None, help="Filter by skill tier L1-L6")
     p_api_graph.add_argument("--tongue", default=None, help="Filter by tongue KO|AV|RU|CA|UM|DR")
-    p_api_graph.add_argument("--band", default=None, help="Filter by band e.g. LEXICON|ANALYSIS|ROUTING|EXECUTION|GOVERNANCE|ORCHESTRATION")
+    p_api_graph.add_argument(
+        "--band", default=None, help="Filter by band e.g. LEXICON|ANALYSIS|ROUTING|EXECUTION|GOVERNANCE|ORCHESTRATION"
+    )
     p_api_graph.add_argument(
         "--show-params",
         action="store_true",

--- a/src/geoseed/orbital_model.py
+++ b/src/geoseed/orbital_model.py
@@ -33,12 +33,12 @@ PHI = (1.0 + math.sqrt(5.0)) / 2.0  # ≈ 1.6180339887
 # 6 GeoSeed tongues → orbital shell mapping
 # weight = φⁿ,  l = angular momentum quantum number,  m_count = 2l+1
 TONGUES = [
-    {"name": "Kor'aelin",    "abbr": "KO", "n": 0, "weight": PHI**0, "l": 0},
-    {"name": "Avali",        "abbr": "AV", "n": 1, "weight": PHI**1, "l": 1},
-    {"name": "Runethic",     "abbr": "RU", "n": 2, "weight": PHI**2, "l": 2},
+    {"name": "Kor'aelin", "abbr": "KO", "n": 0, "weight": PHI**0, "l": 0},
+    {"name": "Avali", "abbr": "AV", "n": 1, "weight": PHI**1, "l": 1},
+    {"name": "Runethic", "abbr": "RU", "n": 2, "weight": PHI**2, "l": 2},
     {"name": "Cassisivadan", "abbr": "CA", "n": 3, "weight": PHI**3, "l": 3},
-    {"name": "Umbroth",      "abbr": "UM", "n": 4, "weight": PHI**4, "l": 4},
-    {"name": "Draumric",     "abbr": "DR", "n": 5, "weight": PHI**5, "l": 5},
+    {"name": "Umbroth", "abbr": "UM", "n": 4, "weight": PHI**4, "l": 4},
+    {"name": "Draumric", "abbr": "DR", "n": 5, "weight": PHI**5, "l": 5},
 ]
 
 # 21 Sacred Egg positions per shell (21D canonical state lift)
@@ -47,6 +47,7 @@ _SACRED_EGG_COUNT = 21
 
 
 # ── Hyperbolic geometry ────────────────────────────────────────────────────────
+
 
 def phi_to_poincare_r(n: int) -> float:
     """
@@ -103,9 +104,7 @@ def radial_wavefunction(rho: float, l: int, n_radial: int = 1) -> float:
     x = 2.0 * alpha * rho
     laguerre = float(eval_genlaguerre(p, 2 * l + 1, x))
     norm = math.sqrt(
-        (2.0 * alpha) ** 3
-        * float(factorial(p))
-        / (2.0 * (n_radial + l) * float(factorial(p + 2 * l + 1)))
+        (2.0 * alpha) ** 3 * float(factorial(p)) / (2.0 * (n_radial + l) * float(factorial(p + 2 * l + 1)))
     )
     return norm * (math.sinh(rho) ** l) * math.exp(-alpha * rho) * laguerre
 
@@ -118,8 +117,7 @@ def angular_wavefunction(theta: float, phi_angle: float, l: int, m: int) -> comp
     return sph_harm_y(l, m, theta, phi_angle)
 
 
-def orbital_density(rho: float, theta: float, phi_angle: float,
-                    l: int, m: int, n_radial: int = 1) -> float:
+def orbital_density(rho: float, theta: float, phi_angle: float, l: int, m: int, n_radial: int = 1) -> float:
     """
     Probability density |ψ|² × hyperbolic volume element sinh²(ρ).
 
@@ -134,6 +132,7 @@ def orbital_density(rho: float, theta: float, phi_angle: float,
 
 
 # ── Sacred Egg node positions ─────────────────────────────────────────────────
+
 
 def sacred_egg_nodes(tongue_idx: int) -> List[Tuple[float, float, float]]:
     """
@@ -161,18 +160,20 @@ def sacred_egg_nodes(tongue_idx: int) -> List[Tuple[float, float, float]]:
 
 # ── GeoSeedOrbital dataclass ──────────────────────────────────────────────────
 
+
 @dataclass
 class GeoSeedOrbital:
     """One orbital shell — one tongue, one l, one Poincaré-ball depth."""
+
     tongue: str
     abbr: str
-    n_phi: int                       # phi-weight index (0..5)
-    weight: float                    # φⁿ
-    l: int                           # angular momentum
-    poincare_r: float                # Euclidean radius in Poincaré ball
-    hyperbolic_rho: float            # ρ = n·ln(φ)  (hyperbolic distance from centre)
-    lb_eigenvalue: float             # Laplace-Beltrami eigenvalue
-    m_states: int                    # 2l+1 magnetic sub-states
+    n_phi: int  # phi-weight index (0..5)
+    weight: float  # φⁿ
+    l: int  # angular momentum
+    poincare_r: float  # Euclidean radius in Poincaré ball
+    hyperbolic_rho: float  # ρ = n·ln(φ)  (hyperbolic distance from centre)
+    lb_eigenvalue: float  # Laplace-Beltrami eigenvalue
+    m_states: int  # 2l+1 magnetic sub-states
     egg_nodes: List[Tuple[float, float, float]] = field(repr=False)
 
     @property
@@ -209,6 +210,7 @@ class GeoSeedOrbital:
 
 # ── Build the 6-orbital system ────────────────────────────────────────────────
 
+
 def build_geoseed_orbitals() -> List[GeoSeedOrbital]:
     """Construct all 6 GeoSeed hyperbolic orbital shells."""
     orbitals = []
@@ -217,22 +219,25 @@ def build_geoseed_orbitals() -> List[GeoSeedOrbital]:
         l = t["l"]
         rho = n * math.log(PHI)
         r = phi_to_poincare_r(n)
-        orbitals.append(GeoSeedOrbital(
-            tongue=t["name"],
-            abbr=t["abbr"],
-            n_phi=n,
-            weight=t["weight"],
-            l=l,
-            poincare_r=r,
-            hyperbolic_rho=rho,
-            lb_eigenvalue=laplace_beltrami_eigenvalue(l),
-            m_states=2 * l + 1,
-            egg_nodes=sacred_egg_nodes(n),
-        ))
+        orbitals.append(
+            GeoSeedOrbital(
+                tongue=t["name"],
+                abbr=t["abbr"],
+                n_phi=n,
+                weight=t["weight"],
+                l=l,
+                poincare_r=r,
+                hyperbolic_rho=rho,
+                lb_eigenvalue=laplace_beltrami_eigenvalue(l),
+                m_states=2 * l + 1,
+                egg_nodes=sacred_egg_nodes(n),
+            )
+        )
     return orbitals
 
 
 # ── Inter-shell coupling ───────────────────────────────────────────────────────
+
 
 def inter_shell_geodesic(orbitals: List[GeoSeedOrbital]) -> List[dict]:
     """
@@ -245,18 +250,21 @@ def inter_shell_geodesic(orbitals: List[GeoSeedOrbital]) -> List[dict]:
     for i in range(len(orbitals) - 1):
         a, b = orbitals[i], orbitals[i + 1]
         d = hyperbolic_distance(a.poincare_r, b.poincare_r)
-        gaps.append({
-            "from": a.abbr,
-            "to": b.abbr,
-            "from_l": a.l,
-            "to_l": b.l,
-            "geodesic_distance": round(d, 6),
-            "phi_ratio": round(b.weight / a.weight, 6),
-        })
+        gaps.append(
+            {
+                "from": a.abbr,
+                "to": b.abbr,
+                "from_l": a.l,
+                "to_l": b.l,
+                "geodesic_distance": round(d, 6),
+                "phi_ratio": round(b.weight / a.weight, 6),
+            }
+        )
     return gaps
 
 
 # ── Summary / entrypoint ──────────────────────────────────────────────────────
+
 
 def orbital_summary() -> dict:
     """Full model summary — orbitals, inter-shell gaps, golden-ratio checkpoint."""
@@ -292,18 +300,23 @@ def orbital_summary() -> dict:
 
 def main():
     import json
+
     summary = orbital_summary()
     print(json.dumps(summary, indent=2))
 
     # Print compact table
     print("\n── GeoSeed Hyperbolic Orbitals ────────────────────────────────")
-    print(f"{'Tongue':<15} {'Abbr':<5} {'l':<4} {'Type':<5} {'φⁿ':<8} "
-          f"{'r (ball)':<10} {'ρ (hyp)':<10} {'LB λ':<8} {'m-states'}")
+    print(
+        f"{'Tongue':<15} {'Abbr':<5} {'l':<4} {'Type':<5} {'φⁿ':<8} "
+        f"{'r (ball)':<10} {'ρ (hyp)':<10} {'LB λ':<8} {'m-states'}"
+    )
     print("-" * 75)
     for o in build_geoseed_orbitals():
-        print(f"{o.tongue:<15} {o.abbr:<5} {o.l:<4} {o.orbital_name:<5} "
-              f"{o.weight:<8.3f} {o.poincare_r:<10.6f} {o.hyperbolic_rho:<10.6f} "
-              f"{o.lb_eigenvalue:<8.0f} {o.m_states}")
+        print(
+            f"{o.tongue:<15} {o.abbr:<5} {o.l:<4} {o.orbital_name:<5} "
+            f"{o.weight:<8.3f} {o.poincare_r:<10.6f} {o.hyperbolic_rho:<10.6f} "
+            f"{o.lb_eigenvalue:<8.0f} {o.m_states}"
+        )
     print("-" * 75)
     print(f"  CA (l=3) sits at r = {build_geoseed_orbitals()[3].poincare_r:.9f}")
     print(f"  1/φ          =    {1/PHI:.9f}  ← exact match")

--- a/src/geoseed/shell_duality.py
+++ b/src/geoseed/shell_duality.py
@@ -60,6 +60,7 @@ PHI = (1.0 + math.sqrt(5.0)) / 2.0
 
 # ── ShellDuality ──────────────────────────────────────────────────────────────
 
+
 @dataclass
 class ShellDuality:
     """
@@ -68,9 +69,10 @@ class ShellDuality:
     k runs from 1 to 6 (= l+1, where l is angular momentum 0..5).
     A is the common anchor (default: RYDBERG_EV = 13.606 eV).
     """
-    A: float                      # common anchor (eV)
-    shell_k: List[int]            # [1, 2, 3, 4, 5, 6]
-    tongue_labels: List[str]      # ["KO", "AV", "RU", "CA", "UM", "DR"]
+
+    A: float  # common anchor (eV)
+    shell_k: List[int]  # [1, 2, 3, 4, 5, 6]
+    tongue_labels: List[str]  # ["KO", "AV", "RU", "CA", "UM", "DR"]
 
     def bind(self, k: int) -> float:
         """E_bind(k) = A / k²   (binding depth, decays outward)"""
@@ -150,14 +152,15 @@ class ShellDuality:
         return {
             "schema_version": "geoseed_shell_duality_v1",
             "anchor_A_ev": round(self.A, 9),
-            "A_squared_ev2": round(self.A ** 2, 9),
+            "A_squared_ev2": round(self.A**2, 9),
             "geometric_center_ev": round(self.A, 9),
             "invariant_cv": self.invariant_cv(),
             "is_invariant_flat": self.is_invariant_flat(),
             "derivation": "E_bind*E_curv=A² from H³ radial metric (1/k²) + LB angular stiffness (k²)",
             "shells": [
                 {
-                    "k": k, "tongue": tongues[i],
+                    "k": k,
+                    "tongue": tongues[i],
                     "bind_ev": round(self.bind(k), 9),
                     "curv_ev": round(self.curv(k), 9),
                     "invariant": round(self.invariant(k), 9),
@@ -176,6 +179,7 @@ def build_shell_duality(anchor_ev: Optional[float] = None) -> ShellDuality:
     """Build the GeoSeed ShellDuality object with optional custom anchor."""
     if anchor_ev is None:
         from src.geoseed.theory_comparison import RYDBERG_EV
+
         anchor_ev = RYDBERG_EV
     return ShellDuality(
         A=anchor_ev,
@@ -186,22 +190,25 @@ def build_shell_duality(anchor_ev: Optional[float] = None) -> ShellDuality:
 
 # ── PerturbationTest ──────────────────────────────────────────────────────────
 
+
 @dataclass
 class PerturbationResult:
     """Results of one perturbation scenario."""
+
     name: str
     description: str
     invariant_values: List[float]
     invariant_cv: float
-    invariant_survived: bool   # CV < tolerance
-    bind_exponent: float       # fitted p (expect ~2)
-    curv_exponent: float       # fitted q (expect ~2)
-    exponents_survived: bool   # both p,q within tolerance of 2
+    invariant_survived: bool  # CV < tolerance
+    bind_exponent: float  # fitted p (expect ~2)
+    curv_exponent: float  # fitted q (expect ~2)
+    exponents_survived: bool  # both p,q within tolerance of 2
 
 
 @dataclass
 class PerturbationTest:
     """Collection of perturbation scenarios testing invariant robustness."""
+
     scenarios: List[PerturbationResult]
 
     def all_survived(self) -> bool:
@@ -226,42 +233,49 @@ class PerturbationTest:
         }
 
 
-def _fit_p_q(bind_vals: List[float], curv_vals: List[float],
-             k_vals: List[float]) -> Tuple[float, float]:
+def _fit_p_q(bind_vals: List[float], curv_vals: List[float], k_vals: List[float]) -> Tuple[float, float]:
     """Quick log-linear regression to estimate exponents p, q."""
+
     def log_slope(y_vals, x_vals):
         n = len(x_vals)
         log_x = [math.log(abs(x) + 1e-30) for x in x_vals]
         log_y = [math.log(abs(y) + 1e-30) for y in y_vals]
         sx = sum(log_x)
         sy = sum(log_y)
-        sxx = sum(lx ** 2 for lx in log_x)
+        sxx = sum(lx**2 for lx in log_x)
         sxy = sum(lx * ly for lx, ly in zip(log_x, log_y))
         denom = n * sxx - sx * sx
         if abs(denom) < 1e-20:
             return 0.0
         return (n * sxy - sx * sy) / denom
 
-    p = -log_slope(bind_vals, k_vals)   # bind decays → p should be +2
-    q = log_slope(curv_vals, k_vals)    # curv grows → q should be +2
+    p = -log_slope(bind_vals, k_vals)  # bind decays → p should be +2
+    q = log_slope(curv_vals, k_vals)  # curv grows → q should be +2
     return p, q
 
 
-def _make_scenario(name: str, description: str,
-                   bind_vals: List[float], curv_vals: List[float],
-                   k_vals: List[float],
-                   cv_tol: float = 0.02,
-                   exp_tol: float = 0.2) -> PerturbationResult:
+def _make_scenario(
+    name: str,
+    description: str,
+    bind_vals: List[float],
+    curv_vals: List[float],
+    k_vals: List[float],
+    cv_tol: float = 0.02,
+    exp_tol: float = 0.2,
+) -> PerturbationResult:
     products = [b * c for b, c in zip(bind_vals, curv_vals)]
     mean_p = sum(products) / len(products)
     var_p = sum((v - mean_p) ** 2 for v in products) / len(products)
     cv = math.sqrt(var_p) / mean_p if mean_p > 0 else float("inf")
     p, q = _fit_p_q(bind_vals, curv_vals, k_vals)
     return PerturbationResult(
-        name=name, description=description,
-        invariant_values=products, invariant_cv=cv,
+        name=name,
+        description=description,
+        invariant_values=products,
+        invariant_cv=cv,
         invariant_survived=cv < cv_tol,
-        bind_exponent=p, curv_exponent=q,
+        bind_exponent=p,
+        curv_exponent=q,
         exponents_survived=abs(p - 2) < exp_tol and abs(q - 2) < exp_tol,
     )
 
@@ -278,6 +292,7 @@ def run_perturbation_tests(seed: int = 42) -> PerturbationTest:
       7. Large-anchor stress: A = 1000.0 eV
     """
     from src.geoseed.theory_comparison import RYDBERG_EV
+
     A = RYDBERG_EV
 
     rng = random.Random(seed)
@@ -287,70 +302,108 @@ def run_perturbation_tests(seed: int = 42) -> PerturbationTest:
     ks = list(range(1, 7))
     bind = [A / (k * k) for k in ks]
     curv = [A * (k * k) for k in ks]
-    scenarios.append(_make_scenario(
-        "exact_baseline", "k=1..6, A=Rydberg, no noise",
-        bind, curv, [float(k) for k in ks], cv_tol=1e-9,
-    ))
+    scenarios.append(
+        _make_scenario(
+            "exact_baseline",
+            "k=1..6, A=Rydberg, no noise",
+            bind,
+            curv,
+            [float(k) for k in ks],
+            cv_tol=1e-9,
+        )
+    )
 
     # 2. Alternate indexing k = 2..7
     ks2 = list(range(2, 8))
     bind2 = [A / (k * k) for k in ks2]
     curv2 = [A * (k * k) for k in ks2]
-    scenarios.append(_make_scenario(
-        "offset_indexing", "k=2..7 (offset by 1 from standard)",
-        bind2, curv2, [float(k) for k in ks2],
-    ))
+    scenarios.append(
+        _make_scenario(
+            "offset_indexing",
+            "k=2..7 (offset by 1 from standard)",
+            bind2,
+            curv2,
+            [float(k) for k in ks2],
+        )
+    )
 
     # 3. Rescaled anchor: A' = 3.7 * A
     A3 = 3.7 * A
     ks3 = list(range(1, 7))
     bind3 = [A3 / (k * k) for k in ks3]
     curv3 = [A3 * (k * k) for k in ks3]
-    scenarios.append(_make_scenario(
-        "rescaled_anchor", f"A = 3.7 × Rydberg = {A3:.2f} eV",
-        bind3, curv3, [float(k) for k in ks3],
-    ))
+    scenarios.append(
+        _make_scenario(
+            "rescaled_anchor",
+            f"A = 3.7 × Rydberg = {A3:.2f} eV",
+            bind3,
+            curv3,
+            [float(k) for k in ks3],
+        )
+    )
 
     # 4. Non-hydrogen anchor
     A4 = 10.0
     bind4 = [A4 / (k * k) for k in ks]
     curv4 = [A4 * (k * k) for k in ks]
-    scenarios.append(_make_scenario(
-        "non_hydrogen_anchor", "A = 10.0 eV (arbitrary non-Rydberg anchor)",
-        bind4, curv4, [float(k) for k in ks],
-    ))
+    scenarios.append(
+        _make_scenario(
+            "non_hydrogen_anchor",
+            "A = 10.0 eV (arbitrary non-Rydberg anchor)",
+            bind4,
+            curv4,
+            [float(k) for k in ks],
+        )
+    )
 
     # 5. Noisy k: k + ε, ε ~ N(0, 0.1)
     noisy_ks = [k + rng.gauss(0, 0.1) for k in range(1, 7)]
     bind5 = [A / (k * k) for k in noisy_ks]
     curv5 = [A * (k * k) for k in noisy_ks]
-    scenarios.append(_make_scenario(
-        "noisy_k_sigma01", "k + Gaussian noise σ=0.1",
-        bind5, curv5, noisy_ks, cv_tol=0.05,
-    ))
+    scenarios.append(
+        _make_scenario(
+            "noisy_k_sigma01",
+            "k + Gaussian noise σ=0.1",
+            bind5,
+            curv5,
+            noisy_ks,
+            cv_tol=0.05,
+        )
+    )
 
     # 6. Half-integer indexing: k = 0.5, 1.5, …, 5.5
     half_ks = [n + 0.5 for n in range(6)]
     bind6 = [A / (k * k) for k in half_ks]
     curv6 = [A * (k * k) for k in half_ks]
-    scenarios.append(_make_scenario(
-        "half_integer_k", "k = 0.5, 1.5, ..., 5.5 (fractional shells)",
-        bind6, curv6, half_ks,
-    ))
+    scenarios.append(
+        _make_scenario(
+            "half_integer_k",
+            "k = 0.5, 1.5, ..., 5.5 (fractional shells)",
+            bind6,
+            curv6,
+            half_ks,
+        )
+    )
 
     # 7. Large-anchor stress: A = 1000 eV
     A7 = 1000.0
     bind7 = [A7 / (k * k) for k in ks]
     curv7 = [A7 * (k * k) for k in ks]
-    scenarios.append(_make_scenario(
-        "large_anchor", "A = 1000 eV (stress test)",
-        bind7, curv7, [float(k) for k in ks],
-    ))
+    scenarios.append(
+        _make_scenario(
+            "large_anchor",
+            "A = 1000 eV (stress test)",
+            bind7,
+            curv7,
+            [float(k) for k in ks],
+        )
+    )
 
     return PerturbationTest(scenarios=scenarios)
 
 
 # ── ShellStateField ───────────────────────────────────────────────────────────
+
 
 @dataclass
 class ShellStateField:
@@ -367,6 +420,7 @@ class ShellStateField:
       - The locus of states traces a hyperbola in (bind, curv) space
         with the invariant I = A² as the hyperbolic constant.
     """
+
     duality: ShellDuality
 
     def states(self) -> List[Tuple[float, float]]:
@@ -374,16 +428,14 @@ class ShellStateField:
 
     def trajectory_angles_deg(self) -> List[float]:
         """Angle of each shell state vector from the bind axis."""
-        return [math.degrees(self.duality.relation_angle(k))
-                for k in self.duality.shell_k]
+        return [math.degrees(self.duality.relation_angle(k)) for k in self.duality.shell_k]
 
     def balance_point(self) -> Tuple[int, float]:
         """
         Shell k where |E_bind - E_curv| is minimized = the "balanced" shell.
         By construction this is always KO (k=1) where bind=curv=A.
         """
-        diffs = [abs(self.duality.bind(k) - self.duality.curv(k))
-                 for k in self.duality.shell_k]
+        diffs = [abs(self.duality.bind(k) - self.duality.curv(k)) for k in self.duality.shell_k]
         idx = min(range(6), key=lambda i: diffs[i])
         return self.duality.shell_k[idx], diffs[idx]
 
@@ -400,7 +452,7 @@ class ShellStateField:
 
     def hyperbola_constant(self) -> float:
         """The hyperbolic constant of the (bind, curv) locus = A²."""
-        return self.duality.A ** 2
+        return self.duality.A**2
 
     def to_dict(self) -> dict:
         states = self.states()
@@ -433,6 +485,7 @@ def build_shell_state_field(anchor_ev: Optional[float] = None) -> ShellStateFiel
 
 # ── RelationTerm ──────────────────────────────────────────────────────────────
 
+
 @dataclass
 class RelationTerm:
     """
@@ -457,6 +510,7 @@ class RelationTerm:
     (bind, compton) plane gives the direction of the Compton model relative
     to the algebraic bind direction.
     """
+
     A: float
     shell_k: List[int]
     tongue_labels: List[str]
@@ -522,6 +576,7 @@ def build_relation_term(anchor_ev: Optional[float] = None) -> RelationTerm:
     """Build the RelationTerm coupling object for the six GeoSeed shells."""
     if anchor_ev is None:
         from src.geoseed.theory_comparison import RYDBERG_EV
+
         anchor_ev = RYDBERG_EV
     return RelationTerm(
         A=anchor_ev,
@@ -532,6 +587,7 @@ def build_relation_term(anchor_ev: Optional[float] = None) -> RelationTerm:
 
 # ── Clean top-level API ───────────────────────────────────────────────────────
 
+
 def compute_invariant(bind_ev: float, curv_ev: float) -> float:
     """Shell invariant I = E_bind × E_curv. Constant at A² for all k."""
     return bind_ev * curv_ev
@@ -541,29 +597,28 @@ def shell_state_at(k: int, A: Optional[float] = None) -> Tuple[float, float]:
     """(E_bind, E_curv) at shell k with anchor A (default: Rydberg)."""
     if A is None:
         from src.geoseed.theory_comparison import RYDBERG_EV
+
         A = RYDBERG_EV
     return A / (k * k), A * (k * k)
 
 
-def fit_binding_law(
-    shells: List[float], values: List[float]
-) -> Tuple[float, float, float, float]:
+def fit_binding_law(shells: List[float], values: List[float]) -> Tuple[float, float, float, float]:
     """
     Fit E = A / (k+δ)^p to binding energy values.
     Returns (A, delta, p, rms).
     """
     from src.geoseed.theory_fit import fit_power_law
+
     return fit_power_law(values, ns=shells)
 
 
-def fit_curvature_law(
-    shells: List[float], values: List[float]
-) -> Tuple[float, float, float, float]:
+def fit_curvature_law(shells: List[float], values: List[float]) -> Tuple[float, float, float, float]:
     """
     Fit E = B · (k+δ)^q to curvature energy values.
     Returns (B, delta, q, rms).
     """
     from src.geoseed.theory_fit import _fit_growth_law
+
     return _fit_growth_law(values, ns=shells)
 
 
@@ -573,6 +628,7 @@ def perturbation_sweep(seed: int = 42) -> "PerturbationTest":
 
 
 # ── Visualization ─────────────────────────────────────────────────────────────
+
 
 def plot_duality(out_dir: Optional[str] = None) -> str:
     """
@@ -593,6 +649,7 @@ def plot_duality(out_dir: Optional[str] = None) -> str:
 
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
     except ImportError:
@@ -610,19 +667,16 @@ def plot_duality(out_dir: Optional[str] = None) -> str:
 
     fig, axes = plt.subplots(3, 1, figsize=(8, 10))
     fig.suptitle(
-        "GeoSeed Shell Duality Field\n"
-        f"I(k) = E_bind × E_curv = A² = {dual.A ** 2:.4f} eV²  (constant for all k)",
-        fontsize=11, fontweight="bold",
+        "GeoSeed Shell Duality Field\n" f"I(k) = E_bind × E_curv = A² = {dual.A ** 2:.4f} eV²  (constant for all k)",
+        fontsize=11,
+        fontweight="bold",
     )
 
     # ── Panel 1: dual energy curves ──
     ax = axes[0]
-    ax.semilogy(ks, bind_vals, "o-", color="#2196F3", lw=2,
-                label="E_bind(k) = A/k²  (decays)")
-    ax.semilogy(ks, curv_vals, "s-", color="#F44336", lw=2,
-                label="E_curv(k) = A·k²  (grows)")
-    ax.axhline(dual.A, ls="--", color="#888888", lw=1.2,
-               label=f"Rydberg A = {dual.A:.4f} eV")
+    ax.semilogy(ks, bind_vals, "o-", color="#2196F3", lw=2, label="E_bind(k) = A/k²  (decays)")
+    ax.semilogy(ks, curv_vals, "s-", color="#F44336", lw=2, label="E_curv(k) = A·k²  (grows)")
+    ax.axhline(dual.A, ls="--", color="#888888", lw=1.2, label=f"Rydberg A = {dual.A:.4f} eV")
     ax.set_xticks(ks)
     ax.set_xticklabels(xlabels, fontsize=9)
     ax.set_ylabel("Energy (eV, log scale)")
@@ -632,27 +686,30 @@ def plot_duality(out_dir: Optional[str] = None) -> str:
 
     # ── Panel 2: invariant flatness ──
     ax = axes[1]
-    ax.plot(ks, inv_vals, "D-", color="#4CAF50", lw=2,
-            ms=8, label="I(k) = E_bind × E_curv")
-    ax.axhline(dual.A ** 2, ls="--", color="#888888", lw=1.5,
-               label=f"A² = {dual.A ** 2:.4f} eV²  (constant)")
+    ax.plot(ks, inv_vals, "D-", color="#4CAF50", lw=2, ms=8, label="I(k) = E_bind × E_curv")
+    ax.axhline(dual.A**2, ls="--", color="#888888", lw=1.5, label=f"A² = {dual.A ** 2:.4f} eV²  (constant)")
     ax.set_xticks(ks)
     ax.set_xticklabels(xlabels, fontsize=9)
     ax.set_ylabel("Invariant I(k)  (eV²)")
     ax.set_title("Shell Invariant — Constant at A² Across All Shells")
     ax.legend(fontsize=9)
     ax.grid(True, alpha=0.3)
-    ax.text(0.98, 0.06, f"CV = {dual.invariant_cv():.2e}",
-            ha="right", va="bottom", transform=ax.transAxes,
-            fontsize=10, color="#4CAF50",
-            bbox=dict(boxstyle="round,pad=0.3", facecolor="white", alpha=0.85))
+    ax.text(
+        0.98,
+        0.06,
+        f"CV = {dual.invariant_cv():.2e}",
+        ha="right",
+        va="bottom",
+        transform=ax.transAxes,
+        fontsize=10,
+        color="#4CAF50",
+        bbox=dict(boxstyle="round,pad=0.3", facecolor="white", alpha=0.85),
+    )
 
     # ── Panel 3: Compton coupling ratio ──
     ax = axes[2]
-    ax.bar(ks, rho_vals, color="#FF9800", alpha=0.82,
-           label="ρ(k) = k²/φ^(k−1)  (Compton/dual ratio)")
-    ax.axhline(1.0, ls="--", color="#555555", lw=1.5,
-               label="ρ = 1  (ground-state resonance)")
+    ax.bar(ks, rho_vals, color="#FF9800", alpha=0.82, label="ρ(k) = k²/φ^(k−1)  (Compton/dual ratio)")
+    ax.axhline(1.0, ls="--", color="#555555", lw=1.5, label="ρ = 1  (ground-state resonance)")
     ax.set_xticks(ks)
     ax.set_xticklabels(xlabels, fontsize=9)
     ax.set_ylabel("Coupling ratio ρ(k)")
@@ -662,8 +719,10 @@ def plot_duality(out_dir: Optional[str] = None) -> str:
     peak_k, peak_rho = rel.peak_coupling_shell()
     ax.annotate(
         f"peak k={peak_k}\nρ = {peak_rho:.2f}",
-        xy=(peak_k, peak_rho), xytext=(peak_k + 0.5, peak_rho - 0.4),
-        fontsize=8, arrowprops=dict(arrowstyle="->", color="gray"),
+        xy=(peak_k, peak_rho),
+        xytext=(peak_k + 0.5, peak_rho - 0.4),
+        fontsize=8,
+        arrowprops=dict(arrowstyle="->", color="gray"),
         bbox=dict(boxstyle="round,pad=0.3", facecolor="white", alpha=0.85),
     )
 
@@ -675,6 +734,7 @@ def plot_duality(out_dir: Optional[str] = None) -> str:
 
 
 # ── JSON artifact ─────────────────────────────────────────────────────────────
+
 
 def export_duality_artifact(out_dir: Optional[str] = None) -> str:
     """
@@ -709,7 +769,7 @@ def export_duality_artifact(out_dir: Optional[str] = None) -> str:
         "generated_by": "shell_duality.export_duality_artifact",
         "summary": {
             "anchor_A_ev": round(dual.A, 9),
-            "A_squared_ev2": round(dual.A ** 2, 9),
+            "A_squared_ev2": round(dual.A**2, 9),
             "invariant_cv": dual.invariant_cv(),
             "is_invariant_flat": dual.is_invariant_flat(),
             "all_perturbations_survived": pert.all_survived(),
@@ -738,6 +798,7 @@ def export_duality_artifact(out_dir: Optional[str] = None) -> str:
 
 # ── ASCII summary ─────────────────────────────────────────────────────────────
 
+
 def duality_field_report() -> str:
     from src.geoseed.theory_comparison import RYDBERG_EV
 
@@ -755,8 +816,7 @@ def duality_field_report() -> str:
     lines.append("")
 
     lines.append(
-        f"  {'Shell':<10}  {'E_bind':>10}  {'E_curv':>12}  "
-        f"{'I(k)=A²':>14}  {'angle°':>8}  {'dominant':>10}"
+        f"  {'Shell':<10}  {'E_bind':>10}  {'E_curv':>12}  " f"{'I(k)=A²':>14}  {'angle°':>8}  {'dominant':>10}"
     )
     lines.append("  " + "-" * 70)
     for i, k in enumerate(dual.shell_k):
@@ -764,8 +824,7 @@ def duality_field_report() -> str:
         ang = math.degrees(dual.relation_angle(k))
         dom = "BINDING" if b >= c else "CURVATURE"
         lines.append(
-            f"  {tongues[i]:<10}  {b:>10.4f}  {c:>12.4f}"
-            f"  {dual.invariant(k):>14.6f}  {ang:>8.2f}°  {dom:>10}"
+            f"  {tongues[i]:<10}  {b:>10.4f}  {c:>12.4f}" f"  {dual.invariant(k):>14.6f}  {ang:>8.2f}°  {dom:>10}"
         )
     lines.append("")
     lines.append(f"  Product CV = {dual.invariant_cv():.2e}  (flat = invariant holds)")
@@ -775,10 +834,7 @@ def duality_field_report() -> str:
     lines.append("=" * 72)
     lines.append("  PERTURBATION TEST (invariant robustness)")
     lines.append("=" * 72)
-    lines.append(
-        f"  {'Scenario':<24}  {'CV':>12}  {'Survived':>10}  "
-        f"{'p':>8}  {'q':>8}  {'exp±ok':>8}"
-    )
+    lines.append(f"  {'Scenario':<24}  {'CV':>12}  {'Survived':>10}  " f"{'p':>8}  {'q':>8}  {'exp±ok':>8}")
     lines.append("  " + "-" * 72)
     for s in pert.scenarios:
         lines.append(

--- a/src/geoseed/theory_comparison.py
+++ b/src/geoseed/theory_comparison.py
@@ -25,40 +25,38 @@ from typing import List, Dict
 
 # ── Physical constants ────────────────────────────────────────────────────────
 
-PHI         = (1.0 + math.sqrt(5.0)) / 2.0
-HBAR        = 1.054571817e-34   # J·s
-H_PLANCK    = 6.62607015e-34    # J·s
-M_ELECTRON  = 9.1093837015e-31  # kg
-C_LIGHT     = 2.99792458e8      # m/s
-EV          = 1.602176634e-19   # J per eV
-RYDBERG_EV  = 13.605693122994   # eV  (hydrogen ground state binding energy)
-ALPHA       = 7.2973525693e-3   # fine-structure constant
-A0          = 5.29177210903e-11 # Bohr radius (m)
+PHI = (1.0 + math.sqrt(5.0)) / 2.0
+HBAR = 1.054571817e-34  # J·s
+H_PLANCK = 6.62607015e-34  # J·s
+M_ELECTRON = 9.1093837015e-31  # kg
+C_LIGHT = 2.99792458e8  # m/s
+EV = 1.602176634e-19  # J per eV
+RYDBERG_EV = 13.605693122994  # eV  (hydrogen ground state binding energy)
+ALPHA = 7.2973525693e-3  # fine-structure constant
+A0 = 5.29177210903e-11  # Bohr radius (m)
 
 # Derived
-COMPTON_WAVELENGTH  = H_PLANCK / (M_ELECTRON * C_LIGHT)   # ≈ 2.426e-12 m
-COMPTON_FREQUENCY   = M_ELECTRON * C_LIGHT**2 / H_PLANCK  # ≈ 1.236e20 Hz
-COMPTON_ENERGY_EV   = M_ELECTRON * C_LIGHT**2 / EV        # ≈ 511 keV
+COMPTON_WAVELENGTH = H_PLANCK / (M_ELECTRON * C_LIGHT)  # ≈ 2.426e-12 m
+COMPTON_FREQUENCY = M_ELECTRON * C_LIGHT**2 / H_PLANCK  # ≈ 1.236e20 Hz
+COMPTON_ENERGY_EV = M_ELECTRON * C_LIGHT**2 / EV  # ≈ 511 keV
 
 TONGUE_ORDER = ["KO", "AV", "RU", "CA", "UM", "DR"]
 
 # Measured hydrogen binding energies (eV) for n = 1..6
 # (positive = energy to remove electron)
-HYDROGEN_MEASURED_EV = [
-    RYDBERG_EV / (n**2)
-    for n in range(1, 7)
-]
+HYDROGEN_MEASURED_EV = [RYDBERG_EV / (n**2) for n in range(1, 7)]
 
 
 # ── Result types ──────────────────────────────────────────────────────────────
+
 
 @dataclass
 class ShellPrediction:
     shell_index: int
     tongue: str
-    energy_ev: float        # binding energy magnitude (eV)
-    frequency_hz: float     # characteristic frequency (Hz)
-    orbital_radius_m: float # implied orbital radius (m)
+    energy_ev: float  # binding energy magnitude (eV)
+    frequency_hz: float  # characteristic frequency (Hz)
+    orbital_radius_m: float  # implied orbital radius (m)
 
 
 @dataclass
@@ -66,8 +64,8 @@ class TheoryResult:
     name: str
     description: str
     shells: List[ShellPrediction]
-    residuals_ev: List[float]       # theory - hydrogen_measured (eV per shell)
-    rms_residual_ev: float          # root-mean-square residual
+    residuals_ev: List[float]  # theory - hydrogen_measured (eV per shell)
+    rms_residual_ev: float  # root-mean-square residual
     note: str = ""
 
     def energies_ev(self) -> List[float]:
@@ -99,11 +97,15 @@ class TheoryResult:
 
 # ── Theory implementations ────────────────────────────────────────────────────
 
-def _make_result(name: str, description: str,
-                 energies_ev: List[float],
-                 frequencies_hz: List[float],
-                 radii_m: List[float],
-                 note: str = "") -> TheoryResult:
+
+def _make_result(
+    name: str,
+    description: str,
+    energies_ev: List[float],
+    frequencies_hz: List[float],
+    radii_m: List[float],
+    note: str = "",
+) -> TheoryResult:
     shells = [
         ShellPrediction(
             shell_index=i,
@@ -116,9 +118,9 @@ def _make_result(name: str, description: str,
     ]
     residuals = [energies_ev[i] - HYDROGEN_MEASURED_EV[i] for i in range(6)]
     rms = math.sqrt(sum(r**2 for r in residuals) / 6)
-    return TheoryResult(name=name, description=description,
-                        shells=shells, residuals_ev=residuals,
-                        rms_residual_ev=rms, note=note)
+    return TheoryResult(
+        name=name, description=description, shells=shells, residuals_ev=residuals, rms_residual_ev=rms, note=note
+    )
 
 
 def theory_compton_orbital() -> TheoryResult:
@@ -147,7 +149,9 @@ def theory_compton_orbital() -> TheoryResult:
     return _make_result(
         "compton_orbital",
         "Compton oscillation as orbital frequency (phi-scaled subharmonics)",
-        energies, freqs, radii,
+        energies,
+        freqs,
+        radii,
         note=(
             f"Base: f_C={COMPTON_FREQUENCY:.4e} Hz, E_C={COMPTON_ENERGY_EV:.1f} keV. "
             "Energy normalised to Rydberg at KO shell."
@@ -173,7 +177,9 @@ def theory_bohr() -> TheoryResult:
     return _make_result(
         "bohr",
         "Bohr hydrogen model: E = 13.6/n²  (n = shell+1)",
-        energies, freqs, radii,
+        energies,
+        freqs,
+        radii,
         note="Residual is zero by definition — this is the reference.",
     )
 
@@ -203,7 +209,9 @@ def theory_de_broglie() -> TheoryResult:
     return _make_result(
         "de_broglie",
         "de Broglie standing wave on GeoSeed phi-radii (n wavelengths/orbit)",
-        energies, freqs, radii,
+        energies,
+        freqs,
+        radii,
         note="GeoSeed Poincaré radii rescaled to physical units at Bohr radius.",
     )
 
@@ -213,7 +221,7 @@ def theory_geoseed_lb() -> TheoryResult:
     GeoSeed Laplace-Beltrami ladder: |λ_l| = (l+1)² = 1,4,9,16,25,36.
     Normalise so shell 0 (KO, l=0) = Rydberg energy.
     """
-    lam = [(l + 1)**2 for l in range(6)]
+    lam = [(l + 1) ** 2 for l in range(6)]
     scale = RYDBERG_EV / lam[0]
     energies, freqs, radii = [], [], []
     for l in range(6):
@@ -226,7 +234,9 @@ def theory_geoseed_lb() -> TheoryResult:
     return _make_result(
         "geoseed_lb",
         "GeoSeed Laplace-Beltrami eigenvalues: E ∝ (l+1)²",
-        energies, freqs, radii,
+        energies,
+        freqs,
+        radii,
         note="LB ladder grows as perfect squares — steeper than Bohr (1/n²).",
     )
 
@@ -251,7 +261,9 @@ def theory_harmonic() -> TheoryResult:
     return _make_result(
         "harmonic",
         "QM harmonic oscillator rungs at Compton frequency (normalised)",
-        energies, freqs, radii,
+        energies,
+        freqs,
+        radii,
         note="Linear energy ladder — flattest possible slope on the comparison chart.",
     )
 
@@ -280,7 +292,9 @@ def theory_pilot_wave() -> TheoryResult:
     return _make_result(
         "pilot_wave",
         "Bohm quantum potential: E ≈ ℏ²/(2m·r²) on GeoSeed phi-radii",
-        energies, freqs, radii,
+        energies,
+        freqs,
+        radii,
         note="Quantum potential dominates at small r — peaks at inner shells.",
     )
 
@@ -307,18 +321,15 @@ def comparison_table(results: Dict[str, TheoryResult]) -> str:
     col_w = 14
     lines = []
     lines.append("Theory Comparison: Binding Energy (eV) per GeoSeed Shell")
-    lines.append("  vs hydrogen measured: " +
-                 "  ".join(f"{e:.4f}" for e in HYDROGEN_MEASURED_EV))
+    lines.append("  vs hydrogen measured: " + "  ".join(f"{e:.4f}" for e in HYDROGEN_MEASURED_EV))
     lines.append("")
-    header = f"{'Theory':<22}" + "".join(
-        f"{t:>{col_w}}" for t in TONGUE_ORDER
-    ) + f"{'RMS Δ(eV)':>{col_w}}"
+    header = f"{'Theory':<22}" + "".join(f"{t:>{col_w}}" for t in TONGUE_ORDER) + f"{'RMS Δ(eV)':>{col_w}}"
     lines.append(header)
     lines.append("-" * len(header))
     for t in theories:
-        row = f"{t.name:<22}" + "".join(
-            f"{e:>{col_w}.4f}" for e in t.energies_ev()
-        ) + f"{t.rms_residual_ev:>{col_w}.4f}"
+        row = (
+            f"{t.name:<22}" + "".join(f"{e:>{col_w}.4f}" for e in t.energies_ev()) + f"{t.rms_residual_ev:>{col_w}.4f}"
+        )
         lines.append(row)
     lines.append("-" * len(header))
     lines.append("")
@@ -327,15 +338,14 @@ def comparison_table(results: Dict[str, TheoryResult]) -> str:
     lines.append(freq_header)
     lines.append("-" * (len(freq_header)))
     for t in theories:
-        row = f"{t.name:<22}" + "".join(
-            f"{math.log10(f):>{col_w}.2f}" for f in t.frequencies_hz()
-        )
+        row = f"{t.name:<22}" + "".join(f"{math.log10(f):>{col_w}.2f}" for f in t.frequencies_hz())
         lines.append(row)
     return "\n".join(lines)
 
 
 def main():
     import json
+
     results = run_all()
     print(comparison_table(results))
     print()

--- a/src/geoseed/theory_fit.py
+++ b/src/geoseed/theory_fit.py
@@ -39,8 +39,8 @@ PHI = (1.0 + math.sqrt(5.0)) / 2.0
 # ── Minimal curve fitting (no scipy required) via Nelder-Mead ─────────────────
 # This way the module works with stdlib only.
 
-def _nelder_mead(f, x0: List[float], tol: float = 1e-9,
-                 max_iter: int = 5000) -> List[float]:
+
+def _nelder_mead(f, x0: List[float], tol: float = 1e-9, max_iter: int = 5000) -> List[float]:
     """Nelder-Mead simplex minimizer (stdlib only)."""
     n = len(x0)
     alpha, beta, gamma, delta = 1.0, 0.5, 2.0, 0.5
@@ -101,10 +101,7 @@ def _nelder_mead(f, x0: List[float], tol: float = 1e-9,
 
         # Shrink
         best = simplex[0]
-        simplex = [best] + [
-            [best[j] + delta * (simplex[i][j] - best[j]) for j in range(n)]
-            for i in range(1, n + 1)
-        ]
+        simplex = [best] + [[best[j] + delta * (simplex[i][j] - best[j]) for j in range(n)] for i in range(1, n + 1)]
         scores = [score(pt) for pt in simplex]
 
     return simplex[0]
@@ -112,12 +109,13 @@ def _nelder_mead(f, x0: List[float], tol: float = 1e-9,
 
 # ── Fit functions ─────────────────────────────────────────────────────────────
 
+
 def _power_law(n: int, A: float, delta: float, p: float) -> float:
     """E = A / (n + delta)^p"""
     base = n + delta
     if base <= 0:
         return float("inf")
-    return A / (base ** p)
+    return A / (base**p)
 
 
 def _exponential(n: int, A: float, lam: float) -> float:
@@ -127,8 +125,7 @@ def _exponential(n: int, A: float, lam: float) -> float:
     return A * (lam ** (-n))
 
 
-def fit_power_law(energies: List[float], ns: Optional[List[int]] = None
-                  ) -> Tuple[float, float, float, float]:
+def fit_power_law(energies: List[float], ns: Optional[List[int]] = None) -> Tuple[float, float, float, float]:
     """
     Fit E_n = A / (n + delta)^p to the given energy list.
     Returns (A, delta, p, residual_rms).
@@ -155,8 +152,7 @@ def fit_power_law(energies: List[float], ns: Optional[List[int]] = None
     return A, delta, p, rms
 
 
-def fit_exponential(energies: List[float], ns: Optional[List[int]] = None
-                    ) -> Tuple[float, float, float]:
+def fit_exponential(energies: List[float], ns: Optional[List[int]] = None) -> Tuple[float, float, float]:
     """
     Fit E_n = A * lambda^{-n} to the given energy list.
     Returns (A, lambda, residual_rms).
@@ -184,6 +180,7 @@ def fit_exponential(energies: List[float], ns: Optional[List[int]] = None
 
 # ── FitResult ─────────────────────────────────────────────────────────────────
 
+
 @dataclass
 class FitResult:
     theory_name: str
@@ -197,8 +194,8 @@ class FitResult:
     exp_lambda: float
     exp_rms: float
     # Diagnosis
-    better_fit: str   # "power_law" or "exponential"
-    observable: str   # "binding" or "curvature"
+    better_fit: str  # "power_law" or "exponential"
+    observable: str  # "binding" or "curvature"
     notes: str = ""
 
     def predicted_power_law(self, n: int) -> float:
@@ -273,8 +270,13 @@ def fit_all_theories() -> Dict[str, FitResult]:
 
         fit_results[name] = FitResult(
             theory_name=name,
-            pl_A=pl_A, pl_delta=pl_delta, pl_p=pl_p, pl_rms=pl_rms,
-            exp_A=exp_A, exp_lambda=exp_lam, exp_rms=exp_rms,
+            pl_A=pl_A,
+            pl_delta=pl_delta,
+            pl_p=pl_p,
+            pl_rms=pl_rms,
+            exp_A=exp_A,
+            exp_lambda=exp_lam,
+            exp_rms=exp_rms,
             better_fit=better,
             observable=obs,
             notes=" | ".join(notes_parts),
@@ -285,13 +287,15 @@ def fit_all_theories() -> Dict[str, FitResult]:
 
 # ── Crossover analysis ────────────────────────────────────────────────────────
 
+
 @dataclass
 class CrossoverAnalysis:
     """Where Bohr and Compton-orbital diverge from the same anchor point."""
-    shell_ratios: List[float]        # compton_ev[n] / bohr_ev[n] per shell
-    divergence_pct: List[float]      # (compton - bohr) / bohr * 100
-    first_significant_shell: int     # first shell where |ratio - 1| > 0.5 (50%)
-    peak_divergence_shell: int       # shell with maximum ratio
+
+    shell_ratios: List[float]  # compton_ev[n] / bohr_ev[n] per shell
+    divergence_pct: List[float]  # (compton - bohr) / bohr * 100
+    first_significant_shell: int  # first shell where |ratio - 1| > 0.5 (50%)
+    peak_divergence_shell: int  # shell with maximum ratio
     peak_ratio: float
     compton_ev: List[float]
     bohr_ev: List[float]
@@ -318,9 +322,7 @@ def crossover_analysis() -> CrossoverAnalysis:
     The crossover point is where the ratio compton/bohr becomes large enough
     to be experimentally distinguishable (here: >50% divergence threshold).
     """
-    from src.geoseed.theory_comparison import (
-        theory_compton_orbital, theory_bohr
-    )
+    from src.geoseed.theory_comparison import theory_compton_orbital, theory_bohr
 
     compton = theory_compton_orbital()
     bohr = theory_bohr()
@@ -331,10 +333,7 @@ def crossover_analysis() -> CrossoverAnalysis:
     ratios = [c / b for c, b in zip(c_evs, b_evs)]
     div_pct = [(r - 1.0) * 100 for r in ratios]
 
-    first_sig = next(
-        (i for i, r in enumerate(ratios) if abs(r - 1.0) > 0.5),
-        len(ratios) - 1
-    )
+    first_sig = next((i for i, r in enumerate(ratios) if abs(r - 1.0) > 0.5), len(ratios) - 1)
     peak_shell = max(range(6), key=lambda i: ratios[i])
     peak_ratio = ratios[peak_shell]
 
@@ -362,6 +361,7 @@ def crossover_analysis() -> CrossoverAnalysis:
 
 # ── Combined energy model ──────────────────────────────────────────────────────
 
+
 @dataclass
 class CombinedEnergy:
     """
@@ -374,11 +374,12 @@ class CombinedEnergy:
     Alternatively, normalise E_curv separately so that it represents a
     fractional overhead on E_bind.
     """
+
     shell_indices: List[int]
-    bind_ev: List[float]      # Compton-orbital
-    curv_ev: List[float]      # GeoSeed-LB
-    total_ev: List[float]     # sum
-    bohr_ev: List[float]      # reference
+    bind_ev: List[float]  # Compton-orbital
+    curv_ev: List[float]  # GeoSeed-LB
+    total_ev: List[float]  # sum
+    bohr_ev: List[float]  # reference
     curv_fraction: List[float]  # E_curv / E_total per shell
 
     def to_dict(self) -> dict:
@@ -388,7 +389,8 @@ class CombinedEnergy:
             "description": "E_total = E_bind(Compton) + E_curv(GeoSeed-LB)",
             "shells": [
                 {
-                    "shell": i, "tongue": tongues[i],
+                    "shell": i,
+                    "tongue": tongues[i],
                     "bind_ev": round(self.bind_ev[i], 4),
                     "curv_ev": round(self.curv_ev[i], 4),
                     "total_ev": round(self.total_ev[i], 4),
@@ -408,10 +410,7 @@ def combined_energy_model(curv_scale: float = 0.1) -> CombinedEnergy:
     Default 0.1 makes the curvature term a 10% overhead at the ground shell —
     small enough to not dominate binding but measurable at outer shells.
     """
-    from src.geoseed.theory_comparison import (
-        theory_compton_orbital, theory_geoseed_lb, theory_bohr,
-        RYDBERG_EV
-    )
+    from src.geoseed.theory_comparison import theory_compton_orbital, theory_geoseed_lb, theory_bohr, RYDBERG_EV
 
     bind = theory_compton_orbital().energies_ev()
     lb = theory_geoseed_lb().energies_ev()
@@ -436,6 +435,7 @@ def combined_energy_model(curv_scale: float = 0.1) -> CombinedEnergy:
 
 
 # ── ASCII summary ─────────────────────────────────────────────────────────────
+
 
 def fit_report() -> str:
     fits = fit_all_theories()
@@ -482,10 +482,7 @@ def fit_report() -> str:
     lines.append("  (Compton binding + 10%-scaled GeoSeed-LB curvature)")
     lines.append("=" * 72)
     lines.append("")
-    lines.append(
-        f"  {'Shell':<10}  {'E_bind':<12}  {'E_curv':<12}  "
-        f"{'E_total':<12}  {'E_Bohr':<12}  {'curv%':<8}"
-    )
+    lines.append(f"  {'Shell':<10}  {'E_bind':<12}  {'E_curv':<12}  " f"{'E_total':<12}  {'E_Bohr':<12}  {'curv%':<8}")
     lines.append("  " + "-" * 68)
     for i, t in enumerate(tongues):
         lines.append(
@@ -499,6 +496,7 @@ def fit_report() -> str:
 
 # ── Independent dual fit ──────────────────────────────────────────────────────
 
+
 @dataclass
 class DualFitResult:
     """
@@ -506,6 +504,7 @@ class DualFitResult:
     E_bind = A / (n + delta_b)^p
     E_curv = B * (n + delta_c)^q    (positive q = grows outward)
     """
+
     # Binding fit
     bind_A: float
     bind_delta: float
@@ -517,11 +516,11 @@ class DualFitResult:
     curv_q: float
     curv_rms: float
     # Dual check
-    p_near_2: bool          # bind exponent converges to 2
-    q_near_2: bool          # curv exponent converges to 2
+    p_near_2: bool  # bind exponent converges to 2
+    q_near_2: bool  # curv exponent converges to 2
     product_constant: bool  # I(l) = E_bind(l) * E_curv(l) is flat
     product_values: List[float]
-    product_cv: float       # coefficient of variation (std/mean), near 0 = flat
+    product_cv: float  # coefficient of variation (std/mean), near 0 = flat
 
     def predicted_bind(self, n: int) -> float:
         return _power_law(n, self.bind_A, self.bind_delta, self.bind_p)
@@ -530,7 +529,7 @@ class DualFitResult:
         base = n + self.curv_delta
         if base <= 0:
             return 0.0
-        return self.curv_B * (base ** self.curv_q)
+        return self.curv_B * (base**self.curv_q)
 
     def to_dict(self) -> dict:
         return {
@@ -559,8 +558,7 @@ class DualFitResult:
         }
 
 
-def _fit_growth_law(energies: List[float], ns: Optional[List[int]] = None
-                    ) -> Tuple[float, float, float, float]:
+def _fit_growth_law(energies: List[float], ns: Optional[List[int]] = None) -> Tuple[float, float, float, float]:
     """
     Fit E_n = B * (n + delta)^q  (positive exponent, grows outward).
     Returns (B, delta, q, rms).
@@ -576,7 +574,7 @@ def _fit_growth_law(energies: List[float], ns: Optional[List[int]] = None
             base = n + delta
             if base <= 0 or B <= 0:
                 return 1e18
-            pred = B * (base ** q)
+            pred = B * (base**q)
             if not math.isfinite(pred):
                 return 1e18
             total += (pred - energies[i]) ** 2
@@ -597,11 +595,9 @@ def independent_dual_fit() -> DualFitResult:
     Checks whether the exponents converge to ±2 without being told to,
     and whether I(l) = E_bind(l) * E_curv(l) is flat across shells.
     """
-    from src.geoseed.theory_comparison import (
-        HYDROGEN_MEASURED_EV, theory_geoseed_lb
-    )
+    from src.geoseed.theory_comparison import HYDROGEN_MEASURED_EV, theory_geoseed_lb
 
-    bind_evs = HYDROGEN_MEASURED_EV          # measured hydrogen — source of truth
+    bind_evs = HYDROGEN_MEASURED_EV  # measured hydrogen — source of truth
     curv_evs = theory_geoseed_lb().energies_ev()
 
     # Fit binding (decay law)
@@ -610,17 +606,20 @@ def independent_dual_fit() -> DualFitResult:
     c_B, c_delta, c_q, c_rms = _fit_growth_law(curv_evs)
 
     # Product invariant
-    product = [
-        _power_law(n, b_A, b_delta, b_p) * (c_B * max(n + c_delta, 1e-10) ** c_q)
-        for n in range(6)
-    ]
+    product = [_power_law(n, b_A, b_delta, b_p) * (c_B * max(n + c_delta, 1e-10) ** c_q) for n in range(6)]
     mean_p = sum(product) / len(product)
     var_p = sum((v - mean_p) ** 2 for v in product) / len(product)
     cv = math.sqrt(var_p) / mean_p if mean_p > 0 else float("inf")
 
     return DualFitResult(
-        bind_A=b_A, bind_delta=b_delta, bind_p=b_p, bind_rms=b_rms,
-        curv_B=c_B, curv_delta=c_delta, curv_q=c_q, curv_rms=c_rms,
+        bind_A=b_A,
+        bind_delta=b_delta,
+        bind_p=b_p,
+        bind_rms=b_rms,
+        curv_B=c_B,
+        curv_delta=c_delta,
+        curv_q=c_q,
+        curv_rms=c_rms,
         p_near_2=abs(b_p - 2.0) < 0.15,
         q_near_2=abs(c_q - 2.0) < 0.15,
         product_constant=cv < 0.05,
@@ -631,20 +630,22 @@ def independent_dual_fit() -> DualFitResult:
 
 # ── Product invariant ─────────────────────────────────────────────────────────
 
+
 @dataclass
 class ProductInvariant:
     """
     I(l) = E_bind(l) * E_curv(l) per shell.
     Measures how flat the product is — flatness = dual law is structural.
     """
-    shell_values: List[float]   # I(l) per shell
+
+    shell_values: List[float]  # I(l) per shell
     mean: float
     std: float
-    cv: float                   # coefficient of variation: std/mean
-    is_flat: bool               # cv < 0.02 (2% variation)
+    cv: float  # coefficient of variation: std/mean
+    is_flat: bool  # cv < 0.02 (2% variation)
     bohr_evs: List[float]
     lb_evs: List[float]
-    rydberg_sq: float           # theoretical prediction: I = RYDBERG²
+    rydberg_sq: float  # theoretical prediction: I = RYDBERG²
 
     def to_dict(self) -> dict:
         return {
@@ -652,13 +653,12 @@ class ProductInvariant:
             "description": "I(l) = E_bind(l) * E_curv(l) — tests dual-law flatness",
             "shells": [
                 {
-                    "shell": i, "tongue": ["KO", "AV", "RU", "CA", "UM", "DR"][i],
+                    "shell": i,
+                    "tongue": ["KO", "AV", "RU", "CA", "UM", "DR"][i],
                     "bind_ev": round(self.bohr_evs[i], 6),
                     "curv_ev": round(self.lb_evs[i], 6),
                     "product": round(self.shell_values[i], 6),
-                    "deviation_from_mean_pct": round(
-                        (self.shell_values[i] - self.mean) / self.mean * 100, 4
-                    ),
+                    "deviation_from_mean_pct": round((self.shell_values[i] - self.mean) / self.mean * 100, 4),
                 }
                 for i in range(6)
             ],
@@ -677,9 +677,7 @@ def compute_product_invariant() -> ProductInvariant:
     Both use the same anchor (RYDBERG_EV), so the product should equal
     RYDBERG_EV² = 185.11 eV² exactly.
     """
-    from src.geoseed.theory_comparison import (
-        theory_bohr, theory_geoseed_lb, RYDBERG_EV
-    )
+    from src.geoseed.theory_comparison import theory_bohr, theory_geoseed_lb, RYDBERG_EV
 
     bind_evs = theory_bohr().energies_ev()
     curv_evs = theory_geoseed_lb().energies_ev()
@@ -694,14 +692,15 @@ def compute_product_invariant() -> ProductInvariant:
         mean=mean_v,
         std=std_v,
         cv=cv,
-        is_flat=cv < 1e-6,      # exact by construction if both normalised the same
+        is_flat=cv < 1e-6,  # exact by construction if both normalised the same
         bohr_evs=bind_evs,
         lb_evs=curv_evs,
-        rydberg_sq=RYDBERG_EV ** 2,
+        rydberg_sq=RYDBERG_EV**2,
     )
 
 
 # ── Weighted-sum fit ──────────────────────────────────────────────────────────
+
 
 @dataclass
 class WeightedSumFit:
@@ -710,7 +709,8 @@ class WeightedSumFit:
     and  log(E_target) = α' * log(E_bind) + β' * log(E_curv)  (log-additive / geometric)
     to find the best combination weights.
     """
-    target: str              # what we're fitting against (e.g. "measured_hydrogen")
+
+    target: str  # what we're fitting against (e.g. "measured_hydrogen")
     # Linear fit
     alpha_lin: float
     beta_lin: float
@@ -718,10 +718,10 @@ class WeightedSumFit:
     # Log-additive fit
     alpha_log: float
     beta_log: float
-    log_rms: float           # rms in log space
-    log_rms_ev: float        # rms back in eV space
+    log_rms: float  # rms in log space
+    log_rms_ev: float  # rms back in eV space
     # Which form wins?
-    better_form: str         # "linear" or "log_additive"
+    better_form: str  # "linear" or "log_additive"
     # Predictions
     linear_predictions: List[float]
     logadd_predictions: List[float]
@@ -738,10 +738,7 @@ class WeightedSumFit:
                 "rms_ev": round(self.lin_rms, 6),
             },
             "log_additive": {
-                "formula": (
-                    f"log(E) = {self.alpha_log:.4f}*log(E_bind) + "
-                    f"{self.beta_log:.4f}*log(E_curv)"
-                ),
+                "formula": (f"log(E) = {self.alpha_log:.4f}*log(E_bind) + " f"{self.beta_log:.4f}*log(E_curv)"),
                 "alpha": round(self.alpha_log, 6),
                 "beta": round(self.beta_log, 6),
                 "rms_log": round(self.log_rms, 6),
@@ -768,10 +765,7 @@ def weighted_sum_fit(target: str = "measured_hydrogen") -> WeightedSumFit:
 
     This tests whether the decomposition is physically useful or just convenient.
     """
-    from src.geoseed.theory_comparison import (
-        theory_compton_orbital, theory_geoseed_lb,
-        HYDROGEN_MEASURED_EV
-    )
+    from src.geoseed.theory_comparison import theory_compton_orbital, theory_geoseed_lb, HYDROGEN_MEASURED_EV
 
     bind_evs = theory_compton_orbital().energies_ev()
     curv_evs = theory_geoseed_lb().energies_ev()
@@ -780,10 +774,7 @@ def weighted_sum_fit(target: str = "measured_hydrogen") -> WeightedSumFit:
     # ── Linear fit: E = α*bind + β*curv ──────────────────────────────
     def lin_residual(params):
         alpha, beta = params
-        total = sum(
-            (alpha * bind_evs[i] + beta * curv_evs[i] - target_evs[i]) ** 2
-            for i in range(6)
-        )
+        total = sum((alpha * bind_evs[i] + beta * curv_evs[i] - target_evs[i]) ** 2 for i in range(6))
         return total / 6
 
     lin_params = _nelder_mead(lin_residual, [1.0, 0.0])
@@ -798,29 +789,26 @@ def weighted_sum_fit(target: str = "measured_hydrogen") -> WeightedSumFit:
 
     def log_residual(params):
         alpha, beta = params
-        total = sum(
-            (alpha * log_bind[i] + beta * log_curv[i] - log_target[i]) ** 2
-            for i in range(6)
-        )
+        total = sum((alpha * log_bind[i] + beta * log_curv[i] - log_target[i]) ** 2 for i in range(6))
         return total / 6
 
     log_params = _nelder_mead(log_residual, [0.5, 0.5])
     alo, blo = log_params
     log_rms = math.sqrt(log_residual(log_params))
-    logadd_preds = [
-        math.exp(alo * log_bind[i] + blo * log_curv[i])
-        for i in range(6)
-    ]
-    log_rms_ev = math.sqrt(
-        sum((logadd_preds[i] - target_evs[i]) ** 2 for i in range(6)) / 6
-    )
+    logadd_preds = [math.exp(alo * log_bind[i] + blo * log_curv[i]) for i in range(6)]
+    log_rms_ev = math.sqrt(sum((logadd_preds[i] - target_evs[i]) ** 2 for i in range(6)) / 6)
 
     better = "linear" if lin_rms <= log_rms_ev else "log_additive"
 
     return WeightedSumFit(
         target=target,
-        alpha_lin=al, beta_lin=bl, lin_rms=lin_rms,
-        alpha_log=alo, beta_log=blo, log_rms=log_rms, log_rms_ev=log_rms_ev,
+        alpha_lin=al,
+        beta_lin=bl,
+        lin_rms=lin_rms,
+        alpha_log=alo,
+        beta_log=blo,
+        log_rms=log_rms,
+        log_rms_ev=log_rms_ev,
         better_form=better,
         linear_predictions=lin_preds,
         logadd_predictions=logadd_preds,
@@ -829,6 +817,7 @@ def weighted_sum_fit(target: str = "measured_hydrogen") -> WeightedSumFit:
 
 
 # ── Extended report ───────────────────────────────────────────────────────────
+
 
 def duality_report() -> str:
     """Full report: independent dual fit + product invariant + weighted sum."""
@@ -850,9 +839,7 @@ def duality_report() -> str:
         f"  E_curv = {dual.curv_B:.4f} * (n + {dual.curv_delta:.4f})^{dual.curv_q:.4f}"
         f"   rms={dual.curv_rms:.6f}  q_near_2={dual.q_near_2}"
     )
-    lines.append(
-        f"  Product CV = {dual.product_cv:.6f}  (near 0 = flat invariant)"
-    )
+    lines.append(f"  Product CV = {dual.product_cv:.6f}  (near 0 = flat invariant)")
     lines.append("")
 
     lines.append("=" * 72)
@@ -877,19 +864,11 @@ def duality_report() -> str:
     lines.append("  WEIGHTED-SUM FIT  E_total = α·E_bind + β·E_curv")
     lines.append("  (fitting against measured hydrogen; bind=Compton, curv=GeoSeed-LB)")
     lines.append("=" * 72)
-    lines.append(
-        f"  Linear:      α={ws.alpha_lin:.6f}  β={ws.beta_lin:.6f}  rms={ws.lin_rms:.6f} eV"
-    )
-    lines.append(
-        f"  Log-additive: α={ws.alpha_log:.6f}  β={ws.beta_log:.6f}  "
-        f"rms={ws.log_rms_ev:.6f} eV"
-    )
+    lines.append(f"  Linear:      α={ws.alpha_lin:.6f}  β={ws.beta_lin:.6f}  rms={ws.lin_rms:.6f} eV")
+    lines.append(f"  Log-additive: α={ws.alpha_log:.6f}  β={ws.beta_log:.6f}  " f"rms={ws.log_rms_ev:.6f} eV")
     lines.append(f"  Better form: {ws.better_form}")
     lines.append("")
-    lines.append(
-        f"  {'Shell':<10}  {'Target':>10}  {'Linear':>10}  {'LogAdd':>10}  "
-        f"{'LinErr':>10}  {'LogErr':>10}"
-    )
+    lines.append(f"  {'Shell':<10}  {'Target':>10}  {'Linear':>10}  {'LogAdd':>10}  " f"{'LinErr':>10}  {'LogErr':>10}")
     lines.append("  " + "-" * 64)
     for i, t in enumerate(tongues):
         lines.append(
@@ -904,6 +883,7 @@ def duality_report() -> str:
 
 def main():
     import json
+
     print(fit_report())
     print()
     print(duality_report())

--- a/src/geoseed/transfer_recorder.py
+++ b/src/geoseed/transfer_recorder.py
@@ -39,15 +39,17 @@ TONGUE_NAMES = {
 
 # ── Core types ────────────────────────────────────────────────────────────────
 
+
 @dataclass
 class TransferEvent:
     """One atom/token moving from one orbital shell to another."""
-    from_tongue: str        # e.g. "KO"
-    to_tongue: str          # e.g. "AV"
-    token: str              # the token that transferred
-    geodesic_cost: float    # n·ln(φ), n = |from_idx - to_idx|
-    is_self: bool           # True when from == to (no hop)
-    step: int               # sequence number within this recording session
+
+    from_tongue: str  # e.g. "KO"
+    to_tongue: str  # e.g. "AV"
+    token: str  # the token that transferred
+    geodesic_cost: float  # n·ln(φ), n = |from_idx - to_idx|
+    is_self: bool  # True when from == to (no hop)
+    step: int  # sequence number within this recording session
     metadata: dict = field(default_factory=dict)
 
 
@@ -57,12 +59,13 @@ class TransferMatrix:
     6×6 count matrix M[from_idx][to_idx] and derived rate/cost matrices.
     Rows = source shell, columns = destination shell.
     """
-    counts: List[List[int]]         # raw hop counts
-    rates: List[List[float]]        # counts / total_events (row-normalised)
-    costs: List[List[float]]        # geodesic cost per cell (n·ln(φ))
+
+    counts: List[List[int]]  # raw hop counts
+    rates: List[List[float]]  # counts / total_events (row-normalised)
+    costs: List[List[float]]  # geodesic cost per cell (n·ln(φ))
     total_events: int
-    self_transfer_count: int        # diagonal sum
-    cross_transfer_count: int       # off-diagonal sum
+    self_transfer_count: int  # diagonal sum
+    cross_transfer_count: int  # off-diagonal sum
 
     def dominant_flow(self) -> List[Tuple[str, str, int]]:
         """Top-5 (from, to) pairs by count, excluding self-transfers."""
@@ -84,14 +87,12 @@ class TransferMatrix:
             "total_events": self.total_events,
             "self_transfer_count": self.self_transfer_count,
             "cross_transfer_count": self.cross_transfer_count,
-            "dominant_flow": [
-                {"from": f, "to": t, "count": c}
-                for f, t, c in self.dominant_flow()
-            ],
+            "dominant_flow": [{"from": f, "to": t, "count": c} for f, t, c in self.dominant_flow()],
         }
 
 
 # ── Geodesic cost helper ──────────────────────────────────────────────────────
+
 
 def transfer_cost(from_tongue: str, to_tongue: str) -> float:
     """
@@ -107,6 +108,7 @@ def transfer_cost(from_tongue: str, to_tongue: str) -> float:
 
 
 # ── Recorder ─────────────────────────────────────────────────────────────────
+
 
 class AtomTransferRecorder:
     """
@@ -213,10 +215,7 @@ class AtomTransferRecorder:
             else:
                 rates.append([c / row_sum for c in row])
 
-        costs = [
-            [abs(i - j) * LN_PHI for j in range(n)]
-            for i in range(n)
-        ]
+        costs = [[abs(i - j) * LN_PHI for j in range(n)] for i in range(n)]
 
         self_count = sum(counts[i][i] for i in range(n))
         cross_count = total - self_count
@@ -249,9 +248,7 @@ class AtomTransferRecorder:
             "        " + "  ".join(f"{t:>4}" for t in TONGUE_ORDER),
         ]
         for i, row in enumerate(mx.counts):
-            lines.append(
-                f"  {TONGUE_ORDER[i]:<4}  " + "  ".join(f"{c:>4}" for c in row)
-            )
+            lines.append(f"  {TONGUE_ORDER[i]:<4}  " + "  ".join(f"{c:>4}" for c in row))
 
         if mx.dominant_flow():
             lines.append("")

--- a/src/geoseed/visualize.py
+++ b/src/geoseed/visualize.py
@@ -19,7 +19,7 @@ PHI = (1.0 + math.sqrt(5.0)) / 2.0
 
 _BAR_WIDTH = 50
 _ORBITAL_SYMBOLS = {0: "●", 1: "◉", 2: "⊕", 3: "✦", 4: "⊛", 5: "❋"}
-_ORBITAL_NAMES   = {0: "s", 1: "p", 2: "d", 3: "f", 4: "g", 5: "h"}
+_ORBITAL_NAMES = {0: "s", 1: "p", 2: "d", 3: "f", 4: "g", 5: "h"}
 
 
 def ascii_shell_map(orbitals) -> str:
@@ -72,6 +72,7 @@ def ascii_radial_profile(orbital, width: int = 60, height: int = 12) -> str:
         # Fall back to radial_wavefunction²
         try:
             from src.geoseed.orbital_model import radial_wavefunction
+
             vals = [radial_wavefunction(rho, orbital.l) ** 2 for rho in rhos]
         except Exception:
             vals = [0.0] * n_samples
@@ -83,7 +84,7 @@ def ascii_radial_profile(orbital, width: int = 60, height: int = 12) -> str:
     col_vals = []
     step = n_samples // width
     for i in range(width):
-        chunk = norm[i * step:(i + 1) * step]
+        chunk = norm[i * step : (i + 1) * step]
         col_vals.append(max(chunk) if chunk else 0.0)
 
     # Build grid
@@ -141,6 +142,7 @@ def ascii_poincare_disk(orbitals, radius: int = 20) -> str:
 
 # ── Matplotlib plots (optional) ───────────────────────────────────────────────
 
+
 def _ensure_artifacts_dir(base: str = ".") -> str:
     path = os.path.join(base, "artifacts", "geoseed")
     os.makedirs(path, exist_ok=True)
@@ -151,6 +153,7 @@ def plot_shell_positions(orbitals, out_dir: str = ".") -> str:
     """Save shell position bar chart as PNG. Returns path."""
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
         import numpy as np
@@ -163,8 +166,7 @@ def plot_shell_positions(orbitals, out_dir: str = ".") -> str:
     rs = [o.poincare_r for o in orbitals]
 
     ax.barh(labels, rs, color=colors, edgecolor="white", height=0.6)
-    ax.axvline(1.0 / PHI, color="gold", linestyle="--", linewidth=1.5,
-               label=f"1/φ = {1/PHI:.3f} (CA anchor)")
+    ax.axvline(1.0 / PHI, color="gold", linestyle="--", linewidth=1.5, label=f"1/φ = {1/PHI:.3f} (CA anchor)")
     ax.axvline(1.0, color="grey", linestyle=":", linewidth=1, label="Ball boundary")
     ax.set_xlim(0, 1.05)
     ax.set_xlabel("Poincaré ball radius r")
@@ -174,8 +176,7 @@ def plot_shell_positions(orbitals, out_dir: str = ".") -> str:
     # Annotate gaps
     for i in range(1, len(orbitals)):
         mid = (rs[i] + rs[i - 1]) / 2
-        ax.annotate("Δρ=ln φ", xy=(mid, i - 0.5), fontsize=7,
-                    ha="center", color="grey")
+        ax.annotate("Δρ=ln φ", xy=(mid, i - 0.5), fontsize=7, ha="center", color="grey")
 
     plt.tight_layout()
     path = os.path.join(_ensure_artifacts_dir(out_dir), "shell_positions.png")
@@ -188,6 +189,7 @@ def plot_radial_profiles(orbitals, out_dir: str = ".") -> str:
     """Save radial wavefunction profiles as PNG. Returns path."""
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
         import numpy as np
@@ -202,16 +204,15 @@ def plot_radial_profiles(orbitals, out_dir: str = ".") -> str:
         rho_max = max(4.0, 3.0 * o.hyperbolic_rho)
         rhos = np.linspace(1e-4, rho_max, 500)
         R = np.array([radial_wavefunction(float(r), o.l) for r in rhos])
-        R2 = R ** 2
+        R2 = R**2
         # Hyperbolic volume-weighted density: |R|² × sinh²(ρ)
         vol_R2 = R2 * np.sinh(rhos) ** 2
 
-        ax.plot(rhos, R2 / (R2.max() + 1e-30), color=colors[idx],
-                label="|R|²", linewidth=1.5)
-        ax.plot(rhos, vol_R2 / (vol_R2.max() + 1e-30), color=colors[idx],
-                linestyle="--", alpha=0.6, label="|R|²·sinh²ρ")
-        ax.axvline(o.hyperbolic_rho, color="gold", linestyle=":", linewidth=1,
-                   label=f"ρ_seed={o.hyperbolic_rho:.2f}")
+        ax.plot(rhos, R2 / (R2.max() + 1e-30), color=colors[idx], label="|R|²", linewidth=1.5)
+        ax.plot(
+            rhos, vol_R2 / (vol_R2.max() + 1e-30), color=colors[idx], linestyle="--", alpha=0.6, label="|R|²·sinh²ρ"
+        )
+        ax.axvline(o.hyperbolic_rho, color="gold", linestyle=":", linewidth=1, label=f"ρ_seed={o.hyperbolic_rho:.2f}")
         ax.set_title(f"{o.abbr} — {_ORBITAL_NAMES[o.l]}-orbital (l={o.l})")
         ax.set_xlabel("ρ (hyperbolic distance)")
         ax.set_ylabel("normalised density")
@@ -234,6 +235,7 @@ def plot_poincare_disk(orbitals, out_dir: str = ".") -> str:
     """Save 2D Poincaré disk cross-section as PNG. Returns path."""
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
         import numpy as np
@@ -251,26 +253,39 @@ def plot_poincare_disk(orbitals, out_dir: str = ".") -> str:
     for idx, o in enumerate(orbitals):
         r = o.poincare_r
         if r == 0.0:
-            ax.plot(0, 0, "o", color=colors[idx], markersize=10,
-                    label=f"{o.abbr} ({_ORBITAL_NAMES[o.l]}, r=0)")
+            ax.plot(0, 0, "o", color=colors[idx], markersize=10, label=f"{o.abbr} ({_ORBITAL_NAMES[o.l]}, r=0)")
             continue
-        ax.plot(r * np.cos(theta), r * np.sin(theta),
-                color=colors[idx], linewidth=2,
-                label=f"{o.abbr} ({_ORBITAL_NAMES[o.l]}, r={r:.3f})")
+        ax.plot(
+            r * np.cos(theta),
+            r * np.sin(theta),
+            color=colors[idx],
+            linewidth=2,
+            label=f"{o.abbr} ({_ORBITAL_NAMES[o.l]}, r={r:.3f})",
+        )
         # Egg nodes (project to 2D equatorial plane)
         for x, y, z in o.egg_nodes:
             eq_r = math.sqrt(x**2 + z**2)
             eq_theta = math.atan2(z, x)
-            ax.plot(eq_r * math.cos(eq_theta), eq_r * math.sin(eq_theta),
-                    ".", color=colors[idx], markersize=3, alpha=0.5)
+            ax.plot(
+                eq_r * math.cos(eq_theta), eq_r * math.sin(eq_theta), ".", color=colors[idx], markersize=3, alpha=0.5
+            )
 
     # 1/φ reference
-    ax.plot(1.0 / PHI * np.cos(theta), 1.0 / PHI * np.sin(theta),
-            "gold", linestyle="--", linewidth=1, alpha=0.7, label="r = 1/φ (CA)")
+    ax.plot(
+        1.0 / PHI * np.cos(theta),
+        1.0 / PHI * np.sin(theta),
+        "gold",
+        linestyle="--",
+        linewidth=1,
+        alpha=0.7,
+        label="r = 1/φ (CA)",
+    )
 
     ax.set_aspect("equal")
-    ax.set_title("GeoSeed Orbitals — Poincaré Disk Cross-Section\n"
-                 "Dots = Sacred Egg quantisation nodes (equatorial projection)")
+    ax.set_title(
+        "GeoSeed Orbitals — Poincaré Disk Cross-Section\n"
+        "Dots = Sacred Egg quantisation nodes (equatorial projection)"
+    )
     ax.legend(loc="upper right", fontsize=8)
     ax.set_xlim(-1.15, 1.15)
     ax.set_ylim(-1.15, 1.15)
@@ -285,20 +300,20 @@ def plot_poincare_disk(orbitals, out_dir: str = ".") -> str:
 # ── Theory comparison plot ────────────────────────────────────────────────────
 
 _THEORY_COLORS = {
-    "compton_orbital": "#FF6B6B",   # warm red
-    "bohr":            "#4ECDC4",   # teal (reference)
-    "de_broglie":      "#45B7D1",   # sky blue
-    "geoseed_lb":      "#96CEB4",   # sage green
-    "harmonic":        "#FFEAA7",   # yellow
-    "pilot_wave":      "#DDA0DD",   # plum
+    "compton_orbital": "#FF6B6B",  # warm red
+    "bohr": "#4ECDC4",  # teal (reference)
+    "de_broglie": "#45B7D1",  # sky blue
+    "geoseed_lb": "#96CEB4",  # sage green
+    "harmonic": "#FFEAA7",  # yellow
+    "pilot_wave": "#DDA0DD",  # plum
 }
 _THEORY_LABELS = {
     "compton_orbital": "Compton-as-orbital (φ-ladder)",
-    "bohr":            "Bohr / measured H  [reference]",
-    "de_broglie":      "de Broglie standing wave",
-    "geoseed_lb":      "GeoSeed LB eigenvalues",
-    "harmonic":        "QM harmonic oscillator",
-    "pilot_wave":      "Bohm pilot wave (Q-potential)",
+    "bohr": "Bohr / measured H  [reference]",
+    "de_broglie": "de Broglie standing wave",
+    "geoseed_lb": "GeoSeed LB eigenvalues",
+    "harmonic": "QM harmonic oscillator",
+    "pilot_wave": "Bohm pilot wave (Q-potential)",
 }
 
 THEORY_COMPARISON_CAPTION = (
@@ -339,15 +354,15 @@ def ascii_theory_comparison() -> str:
             continue
         r = results[name]
         tag = " ← REF" if name == "bohr" else ""
-        row = f"  {(name + tag):<22}" + "".join(
-            f"{e:>{col_w}.3f}" for e in r.energies_ev()
-        ) + f"{r.rms_residual_ev:>{col_w}.3f}"
+        row = (
+            f"  {(name + tag):<22}"
+            + "".join(f"{e:>{col_w}.3f}" for e in r.energies_ev())
+            + f"{r.rms_residual_ev:>{col_w}.3f}"
+        )
         lines.append(row)
 
     lines.append("  " + "-" * (len(header) - 2))
-    lines.append(f"  {'H measured':<22}" + "".join(
-        f"{e:>{col_w}.3f}" for e in HYDROGEN_MEASURED_EV
-    ))
+    lines.append(f"  {'H measured':<22}" + "".join(f"{e:>{col_w}.3f}" for e in HYDROGEN_MEASURED_EV))
     lines.append("")
 
     # Log10 frequency row
@@ -357,9 +372,7 @@ def ascii_theory_comparison() -> str:
         if name not in results:
             continue
         r = results[name]
-        row = f"  {name:<22}" + "".join(
-            f"{math.log10(f):>{col_w}.2f}" for f in r.frequencies_hz()
-        )
+        row = f"  {name:<22}" + "".join(f"{math.log10(f):>{col_w}.2f}" for f in r.frequencies_hz())
         lines.append(row)
     lines.append("")
 
@@ -393,6 +406,7 @@ def plot_theory_comparison(out_dir: str = ".") -> str:
     """
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
         import numpy as np
@@ -422,10 +436,14 @@ def plot_theory_comparison(out_dir: str = ".") -> str:
         lw = 2.5 if name == "bohr" else 1.5
         alpha = 1.0 if name in ("bohr", "compton_orbital") else 0.75
         ax1.semilogy(
-            x, evs,
+            x,
+            evs,
             color=_THEORY_COLORS.get(name, "grey"),
-            linestyle=ls, linewidth=lw, alpha=alpha,
-            marker="o", markersize=5,
+            linestyle=ls,
+            linewidth=lw,
+            alpha=alpha,
+            marker="o",
+            markersize=5,
             label=_THEORY_LABELS.get(name, name),
         )
 
@@ -447,10 +465,13 @@ def plot_theory_comparison(out_dir: str = ".") -> str:
         lw = 2.5 if name == "bohr" else 1.5
         alpha = 1.0 if name in ("bohr", "compton_orbital") else 0.75
         ax2.plot(
-            x, freqs,
+            x,
+            freqs,
             color=_THEORY_COLORS.get(name, "grey"),
-            linewidth=lw, alpha=alpha,
-            marker="s", markersize=5,
+            linewidth=lw,
+            alpha=alpha,
+            marker="s",
+            markersize=5,
             label=_THEORY_LABELS.get(name, name),
         )
 
@@ -465,28 +486,28 @@ def plot_theory_comparison(out_dir: str = ".") -> str:
     # Annotate Compton frequency line
     compton_log = math.log10(1.2356e20)
     ax2.axhline(compton_log, color="#FF6B6B", linestyle=":", linewidth=1, alpha=0.5)
-    ax2.annotate(f"f_Compton ≈ 10^{compton_log:.1f} Hz",
-                 xy=(0.01, compton_log + 0.3),
-                 xycoords=("axes fraction", "data"),
-                 fontsize=7, color="#FF6B6B", alpha=0.8)
+    ax2.annotate(
+        f"f_Compton ≈ 10^{compton_log:.1f} Hz",
+        xy=(0.01, compton_log + 0.3),
+        xycoords=("axes fraction", "data"),
+        fontsize=7,
+        color="#FF6B6B",
+        alpha=0.8,
+    )
 
     # ── Panel 3: Residuals as grouped bars ────────────────────────────────
     ax3 = axes[2]
     non_bohr = [n for n in order if n != "bohr"]
     n_theories = len(non_bohr)
     bar_width = 0.12
-    offsets = np.linspace(-(n_theories - 1) / 2 * bar_width,
-                          (n_theories - 1) / 2 * bar_width,
-                          n_theories)
+    offsets = np.linspace(-(n_theories - 1) / 2 * bar_width, (n_theories - 1) / 2 * bar_width, n_theories)
 
     for idx, name in enumerate(non_bohr):
         r = results[name]
-        residuals = np.array([
-            r.shells[i].energy_ev - measured[i]
-            for i in range(6)
-        ])
+        residuals = np.array([r.shells[i].energy_ev - measured[i] for i in range(6)])
         ax3.bar(
-            x + offsets[idx], residuals,
+            x + offsets[idx],
+            residuals,
             width=bar_width,
             color=_THEORY_COLORS.get(name, "grey"),
             alpha=0.8,
@@ -510,6 +531,7 @@ def plot_theory_comparison(out_dir: str = ".") -> str:
 
 
 # ── CLI entrypoint ────────────────────────────────────────────────────────────
+
 
 def main(out_dir: str = "."):
     from src.geoseed.orbital_model import build_geoseed_orbitals

--- a/src/harmonic/contact_lattice.py
+++ b/src/harmonic/contact_lattice.py
@@ -51,10 +51,10 @@ class ContactNode:
 class ContactLatticeOutput:
     """Return type for one ContactLatticeLayer forward pass."""
 
-    enriched: np.ndarray                      # (seq_len, 3) contact-weighted embeddings
-    contacts: List[List[ContactNode]]          # per-token contact node lists
-    plane_embeddings: Dict[str, np.ndarray]    # {tongue: (seq_len, 3)}
-    contact_counts: List[int]                  # surviving contacts per token
+    enriched: np.ndarray  # (seq_len, 3) contact-weighted embeddings
+    contacts: List[List[ContactNode]]  # per-token contact node lists
+    plane_embeddings: Dict[str, np.ndarray]  # {tongue: (seq_len, 3)}
+    contact_counts: List[int]  # surviving contacts per token
 
 
 # ---------------------------------------------------------------------------
@@ -88,7 +88,7 @@ class TonguePlaneProjector:
         """
         result: Dict[str, np.ndarray] = {}
         for tongue, W in self._W.items():
-            h = embeddings @ W                               # (seq_len, 3)
+            h = embeddings @ W  # (seq_len, 3)
             norms = np.linalg.norm(h, axis=-1, keepdims=True) + 1e-8
             result[tongue] = (h / norms) * np.tanh(norms * 0.5)  # smooth ball compression
         return result
@@ -151,9 +151,7 @@ class ContactLatticeLayer:
         contact_counts: List[int] = []
 
         for t in range(seq_len):
-            positions: Dict[str, np.ndarray] = {
-                tongue: plane_embeddings[tongue][t] for tongue in TONGUES
-            }
+            positions: Dict[str, np.ndarray] = {tongue: plane_embeddings[tongue][t] for tongue in TONGUES}
 
             # Group tongues by contact cell (same Morton prefix)
             cell_groups: Dict[int, List[str]] = {}
@@ -172,9 +170,7 @@ class ContactLatticeLayer:
                         ContactNode(
                             cell_code=cell_code,
                             tongues=list(tongues_here),
-                            positions=[
-                                (float(p[0]), float(p[1]), float(p[2])) for p in pos_here
-                            ],
+                            positions=[(float(p[0]), float(p[1]), float(p[2])) for p in pos_here],
                             survival_score=score,
                         )
                     )

--- a/src/longform/context_bridge.py
+++ b/src/longform/context_bridge.py
@@ -39,8 +39,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-
 # ── Core data structures ──────────────────────────────────────────────────────
+
 
 @dataclass
 class PrincipleSet:
@@ -53,6 +53,7 @@ class PrincipleSet:
     open_questions:   Unresolved questions that must carry forward.
     next_footholds:   Concrete next steps.
     """
+
     mission: str
     invariants: List[str] = field(default_factory=list)
     claim_boundaries: List[str] = field(default_factory=list)
@@ -76,6 +77,7 @@ class PrincipleSet:
 @dataclass
 class ContextBrick:
     """A named context snapshot — the unit of longform memory."""
+
     brick_id: str
     kind: str  # always "brick"
     ts: str
@@ -102,6 +104,7 @@ class LedgerEvent:
     event_hash is computed over the canonical JSON of this event
     with event_hash set to the empty string, then SHA-256'd.
     """
+
     event_id: str
     kind: str
     ts: str
@@ -137,6 +140,7 @@ class ContextLanding:
     plus the brick count and a cryptographic hash of the landing content.
     Any future session can verify integrity and resume from this point.
     """
+
     landing_id: str
     ts: str
     landing_hash: str
@@ -160,7 +164,8 @@ class ContextLanding:
         """Verify this landing's hash matches its content."""
         content = json.dumps(
             {k: v for k, v in self.to_dict().items() if k != "landing_hash"},
-            sort_keys=True, separators=(",", ":"),
+            sort_keys=True,
+            separators=(",", ":"),
         )
         expected = hashlib.sha256(content.encode()).hexdigest()
         return expected == self.landing_hash
@@ -174,6 +179,7 @@ class ResumePack:
     External sessions use this to resume without re-reading the full ledger.
     The pack is NOT authoritative — the JSONL ledger always is.
     """
+
     pack_id: str
     ts: str
     landing: ContextLanding
@@ -193,6 +199,7 @@ class ResumePack:
 
 
 # ── Validation ────────────────────────────────────────────────────────────────
+
 
 def validate_principles(principles: PrincipleSet, context: str) -> bool:
     """
@@ -220,6 +227,7 @@ def validate_principles(principles: PrincipleSet, context: str) -> bool:
 
 
 # ── JsonlWorkflowLedger ───────────────────────────────────────────────────────
+
 
 class JsonlWorkflowLedger:
     """
@@ -268,8 +276,7 @@ class JsonlWorkflowLedger:
         last = self._read_last_event()
         return (last.sequence + 1) if last else 1
 
-    def append(self, kind: str, payload: Dict[str, Any],
-                parent_hashes: Optional[List[str]] = None) -> LedgerEvent:
+    def append(self, kind: str, payload: Dict[str, Any], parent_hashes: Optional[List[str]] = None) -> LedgerEvent:
         """Append an event to the ledger. Returns the committed event."""
         self._ensure_dirs()
         last = self._read_last_event()
@@ -390,13 +397,17 @@ class JsonlWorkflowLedger:
 
 # ── Factory functions ─────────────────────────────────────────────────────────
 
+
 def _longform_dir(workspace_dir: str) -> str:
     return os.path.join(workspace_dir, ".scbe-longform")
 
 
-def new_ledger(workspace_dir: str, mission: str,
-               invariants: Optional[List[str]] = None,
-               claim_boundaries: Optional[List[str]] = None) -> JsonlWorkflowLedger:
+def new_ledger(
+    workspace_dir: str,
+    mission: str,
+    invariants: Optional[List[str]] = None,
+    claim_boundaries: Optional[List[str]] = None,
+) -> JsonlWorkflowLedger:
     """
     Create a new longform workflow workspace and return the ledger.
     Emits an initial 'brick' event with the PrincipleSet.
@@ -410,14 +421,17 @@ def new_ledger(workspace_dir: str, mission: str,
         claim_boundaries=claim_boundaries or [],
     )
     ledger.save_principles(principles)
-    ledger.append("brick", {
-        "mission": mission,
-        "invariants": principles.invariants,
-        "claim_boundaries": principles.claim_boundaries,
-        "open_questions": [],
-        "next_footholds": [],
-        "metadata": {"event": "workspace_init"},
-    })
+    ledger.append(
+        "brick",
+        {
+            "mission": mission,
+            "invariants": principles.invariants,
+            "claim_boundaries": principles.claim_boundaries,
+            "open_questions": [],
+            "next_footholds": [],
+            "metadata": {"event": "workspace_init"},
+        },
+    )
     return ledger
 
 
@@ -425,10 +439,7 @@ def load_ledger(workspace_dir: str) -> JsonlWorkflowLedger:
     """Load an existing longform workspace ledger."""
     lf_dir = _longform_dir(workspace_dir)
     if not os.path.exists(lf_dir):
-        raise FileNotFoundError(
-            f"No .scbe-longform workspace at {workspace_dir}. "
-            "Run `scbe work init` first."
-        )
+        raise FileNotFoundError(f"No .scbe-longform workspace at {workspace_dir}. " "Run `scbe work init` first.")
     return JsonlWorkflowLedger(lf_dir)
 
 
@@ -465,7 +476,8 @@ def create_landing(
     }
     content = json.dumps(
         {k: v for k, v in landing_data.items() if k != "landing_hash"},
-        sort_keys=True, separators=(",", ":"),
+        sort_keys=True,
+        separators=(",", ":"),
     )
     landing_hash = hashlib.sha256(content.encode()).hexdigest()
     landing_data["landing_hash"] = landing_hash
@@ -480,13 +492,16 @@ def create_landing(
         json.dump(landing.to_dict(), f, indent=2)
 
     # Append landing event to ledger
-    ledger.append("landing", {
-        "landing_id": landing_id,
-        "landing_hash": landing_hash,
-        "brick_count": bc,
-        "last_sequence": last_seq,
-        "principles_validated": True,
-    })
+    ledger.append(
+        "landing",
+        {
+            "landing_id": landing_id,
+            "landing_hash": landing_hash,
+            "brick_count": bc,
+            "last_sequence": last_seq,
+            "principles_validated": True,
+        },
+    )
 
     return landing
 

--- a/src/longform/longform_cli.py
+++ b/src/longform/longform_cli.py
@@ -42,8 +42,8 @@ from src.longform.context_bridge import (
     build_resume_pack,
 )
 
-
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
 
 def _workspace(args) -> str:
     return os.path.abspath(getattr(args, "workspace", None) or os.getcwd())
@@ -72,7 +72,7 @@ def _extract_json(text: str) -> dict:
         end = raw.rfind("}")
         if start >= 0 and end > start:
             try:
-                return json.loads(raw[start:end + 1])
+                return json.loads(raw[start : end + 1])
             except json.JSONDecodeError:
                 return {}
     return {}
@@ -248,6 +248,7 @@ def _print_do_complete(d: dict) -> None:
 
 # ── Commands ──────────────────────────────────────────────────────────────────
 
+
 def cmd_work_init(args) -> None:
     ws = _workspace(args)
     mission = args.mission or getattr(args, "objective", "") or "Accomplish the objective."
@@ -307,11 +308,15 @@ def cmd_work_status(args) -> None:
         "principles": principles.to_dict() if principles else {},
         "open_questions": principles.open_questions if principles else [],
         "next_footholds": principles.next_footholds if principles else [],
-        "last_landing": {
-            "hash": last_l.landing_hash,
-            "ts": last_l.ts,
-            "brick_count": last_l.brick_count,
-        } if last_l else None,
+        "last_landing": (
+            {
+                "hash": last_l.landing_hash,
+                "ts": last_l.ts,
+                "brick_count": last_l.brick_count,
+            }
+            if last_l
+            else None
+        ),
     }
     _emit(result, args.json)
 
@@ -332,11 +337,14 @@ def cmd_work_resume(args) -> None:
         sys.exit(1)
 
     # Append resume event
-    ledger.append("resume", {
-        "landing_hash": pack.landing.landing_hash,
-        "session_id": str(uuid.uuid4()),
-        "resumed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-    })
+    ledger.append(
+        "resume",
+        {
+            "landing_hash": pack.landing.landing_hash,
+            "session_id": str(uuid.uuid4()),
+            "resumed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        },
+    )
 
     result = {
         "kind": "work_resume",
@@ -484,13 +492,16 @@ def cmd_agent_spawn(args) -> None:
         "status": "active",
     }
     ledger.save_agent(agent_id, contract)
-    ledger.append("agent_spawn", {
-        "agent_id": agent_id,
-        "role": role,
-        "mandate": args.mandate,
-        "allowed_tools": allowed_tools,
-        "budget": budget,
-    })
+    ledger.append(
+        "agent_spawn",
+        {
+            "agent_id": agent_id,
+            "role": role,
+            "mandate": args.mandate,
+            "allowed_tools": allowed_tools,
+            "budget": budget,
+        },
+    )
 
     result = {"kind": "agent_spawn", **contract}
     _emit(result, args.json)
@@ -541,12 +552,15 @@ def cmd_do(args) -> None:
         principles = ledger.load_principles()
 
     # Record objective
-    ledger.append("objective", {
-        "objective": objective,
-        "loops_requested": loops,
-        "land_every_stage": land_every,
-        "backend": getattr(args, "backend", "local"),
-    })
+    ledger.append(
+        "objective",
+        {
+            "objective": objective,
+            "loops_requested": loops,
+            "land_every_stage": land_every,
+            "backend": getattr(args, "backend", "local"),
+        },
+    )
 
     if not emit_json:
         print(f"  SCBE Longform — do: {objective[:60]}")
@@ -560,40 +574,50 @@ def cmd_do(args) -> None:
             print(f"  ── Stage {loop_n}/{loops} ──────────────────────────────")
 
         # Stage intent
-        ledger.append("stage_intent", {
-            "loop": loop_n,
-            "objective": objective,
-            "phase": "execute",
-        })
+        ledger.append(
+            "stage_intent",
+            {
+                "loop": loop_n,
+                "objective": objective,
+                "phase": "execute",
+            },
+        )
 
         if args.squad:
             dispatch_result = _run_agent_bus_stage(ws, objective, loop_n, args)
             ledger.append("agentbus_dispatch", dispatch_result)
-            ledger.append("stage_complete", {
-                "loop": loop_n,
-                "status": dispatch_result["status"],
-                "squad": True,
-                "dispatch_enabled": bool(dispatch_result.get("dispatch", {}).get("enabled")),
-                "selected_provider": dispatch_result.get("selected_provider"),
-                "series_id": dispatch_result.get("series_id"),
-                "artifact_summary": dispatch_result.get("artifacts", {}),
-            })
+            ledger.append(
+                "stage_complete",
+                {
+                    "loop": loop_n,
+                    "status": dispatch_result["status"],
+                    "squad": True,
+                    "dispatch_enabled": bool(dispatch_result.get("dispatch", {}).get("enabled")),
+                    "selected_provider": dispatch_result.get("selected_provider"),
+                    "series_id": dispatch_result.get("series_id"),
+                    "artifact_summary": dispatch_result.get("artifacts", {}),
+                },
+            )
         else:
-            ledger.append("stage_complete", {
-                "loop": loop_n,
-                "status": "stub",
-                "squad": False,
-                "note": (
-                    "Execution stub. Pass `--squad` to dispatch through the SCBE agent bus."
-                ),
-            })
+            ledger.append(
+                "stage_complete",
+                {
+                    "loop": loop_n,
+                    "status": "stub",
+                    "squad": False,
+                    "note": ("Execution stub. Pass `--squad` to dispatch through the SCBE agent bus."),
+                },
+            )
 
         # Audit: validate principles
         audit_ok = True  # in phase 1, always passes (stub)
-        ledger.append("audit_pass" if audit_ok else "audit_fail", {
-            "loop": loop_n,
-            "principles_validated": audit_ok,
-        })
+        ledger.append(
+            "audit_pass" if audit_ok else "audit_fail",
+            {
+                "loop": loop_n,
+                "principles_validated": audit_ok,
+            },
+        )
 
         if not emit_json:
             print(f"    brick emitted  loop={loop_n}  audit={'pass' if audit_ok else 'FAIL'}")
@@ -631,9 +655,9 @@ def cmd_do(args) -> None:
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
+
 def _ws_arg(p: argparse.ArgumentParser) -> None:
-    p.add_argument("--workspace", "-w", default=None,
-                   help="Workspace directory (default: cwd)")
+    p.add_argument("--workspace", "-w", default=None, help="Workspace directory (default: cwd)")
 
 
 def _json_arg(p: argparse.ArgumentParser) -> None:
@@ -651,22 +675,27 @@ def build_parser() -> argparse.ArgumentParser:
     p_do = sub.add_parser("do", help="Run a durable governed agentic workflow")
     p_do.add_argument("objective", help="The objective to accomplish")
     p_do.add_argument("--loops", default="6", help="Max stage iterations (default 6)")
-    p_do.add_argument("--land", default="",
-                      help="Compatibility alias; use 'every-stage' to land every stage")
-    p_do.add_argument("--land-every-stage", action="store_true",
-                      help="Create a landing after each stage")
-    p_do.add_argument("--squad", action="store_true",
-                      help="Route each stage to the multi-agent squad (phase 2)")
-    p_do.add_argument("--dispatch-provider", default="offline",
-                      help="Agent-bus dispatch provider for --squad (default offline)")
-    p_do.add_argument("--dispatch-timeout", type=int, default=120,
-                      help="Seconds before a squad dispatch stage times out")
-    p_do.add_argument("--resume-policy", default="latest-safe",
-                      choices=["latest-safe", "explicit-hash"],
-                      help="Resume policy (default latest-safe)")
-    p_do.add_argument("--backend", default="local",
-                      choices=["local", "local-jsonl", "temporal"],
-                      help="Execution backend (default local)")
+    p_do.add_argument("--land", default="", help="Compatibility alias; use 'every-stage' to land every stage")
+    p_do.add_argument("--land-every-stage", action="store_true", help="Create a landing after each stage")
+    p_do.add_argument("--squad", action="store_true", help="Route each stage to the multi-agent squad (phase 2)")
+    p_do.add_argument(
+        "--dispatch-provider", default="offline", help="Agent-bus dispatch provider for --squad (default offline)"
+    )
+    p_do.add_argument(
+        "--dispatch-timeout", type=int, default=120, help="Seconds before a squad dispatch stage times out"
+    )
+    p_do.add_argument(
+        "--resume-policy",
+        default="latest-safe",
+        choices=["latest-safe", "explicit-hash"],
+        help="Resume policy (default latest-safe)",
+    )
+    p_do.add_argument(
+        "--backend",
+        default="local",
+        choices=["local", "local-jsonl", "temporal"],
+        help="Execution backend (default local)",
+    )
     _ws_arg(p_do)
     _json_arg(p_do)
 
@@ -677,23 +706,26 @@ def build_parser() -> argparse.ArgumentParser:
     p_init = ws_sub.add_parser("init", help="Initialize a new workspace")
     p_init.add_argument("--mission", "-m", default="", help="Mission statement")
     p_init.add_argument("--objective", default="", help="Compatibility alias for --mission")
-    p_init.add_argument("--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger")
-    p_init.add_argument("--invariant", "-i", action="append", default=[],
-                        help="Add an invariant (repeatable)")
-    p_init.add_argument("--claim", "-c", action="append", default=[],
-                        help="Add a claim boundary (repeatable)")
+    p_init.add_argument(
+        "--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger"
+    )
+    p_init.add_argument("--invariant", "-i", action="append", default=[], help="Add an invariant (repeatable)")
+    p_init.add_argument("--claim", "-c", action="append", default=[], help="Add a claim boundary (repeatable)")
     _ws_arg(p_init)
     _json_arg(p_init)
 
     p_status = ws_sub.add_parser("status", help="Show workspace status")
-    p_status.add_argument("--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger")
+    p_status.add_argument(
+        "--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger"
+    )
     _ws_arg(p_status)
     _json_arg(p_status)
 
     p_resume = ws_sub.add_parser("resume", help="Resume from a landing")
-    p_resume.add_argument("--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger")
-    p_resume.add_argument("--hash", default=None,
-                          help="Landing hash prefix (default: latest)")
+    p_resume.add_argument(
+        "--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger"
+    )
+    p_resume.add_argument("--hash", default=None, help="Landing hash prefix (default: latest)")
     _ws_arg(p_resume)
     _json_arg(p_resume)
 
@@ -702,8 +734,12 @@ def build_parser() -> argparse.ArgumentParser:
     land_sub = p_land.add_subparsers(dest="land_cmd")
 
     p_lc = land_sub.add_parser("create", help="Create a verified context landing")
-    p_lc.add_argument("--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger")
-    p_lc.add_argument("--summary", default="", help="Compatibility summary; landing content is captured from the ledger")
+    p_lc.add_argument(
+        "--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger"
+    )
+    p_lc.add_argument(
+        "--summary", default="", help="Compatibility summary; landing content is captured from the ledger"
+    )
     p_lc.add_argument("--stage", default="", help="Compatibility stage label")
     _ws_arg(p_lc)
     _json_arg(p_lc)
@@ -728,15 +764,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_asp = agent_sub.add_parser("spawn", help="Spawn a governed agent")
     p_asp.add_argument("role", nargs="?", help="Agent role (architect/tester/prover/etc.)")
-    p_asp.add_argument("--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger")
+    p_asp.add_argument(
+        "--workflow", default="", help="Compatibility workflow label; ignored by the single-workspace ledger"
+    )
     p_asp.add_argument("--role", dest="role_flag", default="", help="Compatibility alias for positional role")
     p_asp.add_argument("--mandate", required=True, help="Agent mandate/objective")
-    p_asp.add_argument("--tools", default="",
-                       help="Comma-separated allowed tools")
-    p_asp.add_argument("--allowed-tools", default="",
-                       help="Compatibility alias for --tools")
-    p_asp.add_argument("--budget", default="20",
-                       help="Max invocations before escalation (default 20)")
+    p_asp.add_argument("--tools", default="", help="Comma-separated allowed tools")
+    p_asp.add_argument("--allowed-tools", default="", help="Compatibility alias for --tools")
+    p_asp.add_argument("--budget", default="20", help="Max invocations before escalation (default 20)")
     _ws_arg(p_asp)
     _json_arg(p_asp)
 

--- a/src/video_lattice/__init__.py
+++ b/src/video_lattice/__init__.py
@@ -23,6 +23,7 @@ Modules:
   tiny_engine       — compact pocket-dimension world/render state
   gpt_world         — GPT director + round-table multi-model coherence
 """
+
 from .poincare_lattice import PoincareLattice
 from .multi_lattice import MultiLattice, LatticeAxis
 from .temporal_tracker import TemporalTracker, FrameState, IntentAnchor

--- a/src/video_lattice/frame_corrector.py
+++ b/src/video_lattice/frame_corrector.py
@@ -35,13 +35,14 @@ _PHI = (1 + math.sqrt(5)) / 2
 @dataclass
 class CorrectionSignal:
     """Structured correction output for one frame."""
+
     frame_index: int
     aggregate_drift: float
-    cost_signal: float                        # R^(d²) scaling factor
-    axis_corrections: Dict[str, float]        # axis → signed correction magnitude
-    latent_nudge: Optional[np.ndarray]        # delta for diffusion latent space
-    condition_signal: Dict[str, Any]          # structured hint for UE5 / generator
-    severity: str                             # "none" | "mild" | "moderate" | "severe"
+    cost_signal: float  # R^(d²) scaling factor
+    axis_corrections: Dict[str, float]  # axis → signed correction magnitude
+    latent_nudge: Optional[np.ndarray]  # delta for diffusion latent space
+    condition_signal: Dict[str, Any]  # structured hint for UE5 / generator
+    severity: str  # "none" | "mild" | "moderate" | "severe"
     # Trijective audit fields (empty/False when no intent anchor is set)
     intent_violated: bool = False
     intent_drift: float = 0.0
@@ -194,9 +195,7 @@ class FrameCorrector:
             "severity": severity,
             "drift": state.aggregate_drift,
             "cost_multiplier": cost,
-            "top_drift_axes": [
-                {"axis": name, "drift": round(d, 4)} for name, d in top_drift_axes
-            ],
+            "top_drift_axes": [{"axis": name, "drift": round(d, 4)} for name, d in top_drift_axes],
             "axis_corrections": {k: round(v, 4) for k, v in axis_corrections.items()},
             # Trijective audit: human-intent vs machine-representation leg
             "intent": {

--- a/src/video_lattice/gpt_world.py
+++ b/src/video_lattice/gpt_world.py
@@ -60,10 +60,10 @@ COMMAND_SCHEMA = {
             "items": {
                 "type": "object",
                 "properties": {
-                    "type": {"type": "string", "enum": [
-                        "move", "set_tile", "add_entity", "remove_entity",
-                        "set_entity_state", "narrate"
-                    ]},
+                    "type": {
+                        "type": "string",
+                        "enum": ["move", "set_tile", "add_entity", "remove_entity", "set_entity_state", "narrate"],
+                    },
                     "entity_id": {"type": "string"},
                     "dx": {"type": "integer"},
                     "dy": {"type": "integer"},
@@ -111,9 +111,11 @@ Respond ONLY with the JSON object. No other text.
 # Data structures
 # ------------------------------------------------------------------
 
+
 @dataclass
 class WorldCommand:
     """One parsed command from a GPT delta."""
+
     type: str
     data: Dict[str, Any] = field(default_factory=dict)
 
@@ -121,6 +123,7 @@ class WorldCommand:
 @dataclass
 class WorldDelta:
     """GPT's response for one step: commands + narrative."""
+
     commands: List[WorldCommand]
     narrative: str
     model: str
@@ -140,6 +143,7 @@ class WorldDelta:
 @dataclass
 class RoundTableReport:
     """Multi-model comparison result."""
+
     winner_model: str
     winner_delta: WorldDelta
     winner_drift: float
@@ -155,6 +159,7 @@ class RoundTableReport:
 # ------------------------------------------------------------------
 # WorldDirector
 # ------------------------------------------------------------------
+
 
 class WorldDirector:
     """GPT-powered operator for a TinyWorld.
@@ -177,16 +182,14 @@ class WorldDirector:
         self.temperature = temperature
         self.max_tokens = max_tokens
         self._api_key = api_key or _load_api_key()
-        self._client = None   # lazy init — don't import openai at module load
+        self._client = None  # lazy init — don't import openai at module load
 
     def _get_client(self):
         if self._client is None:
             try:
                 from openai import OpenAI
             except ImportError as exc:
-                raise ImportError(
-                    "openai package required: pip install openai"
-                ) from exc
+                raise ImportError("openai package required: pip install openai") from exc
             self._client = OpenAI(api_key=self._api_key)
         return self._client
 
@@ -201,6 +204,7 @@ class WorldDirector:
         Falls back to demo_world() if parsing fails.
         """
         from .tiny_engine import demo_world
+
         system = """\
 You are a pocket-dimension architect. Given a description, return a JSON object
 that matches the scbe_tiny_world_v1 schema exactly:
@@ -266,6 +270,7 @@ Use single-character glyphs. Keep it small and symbolic. Respond ONLY with JSON.
         Lower = more coherent continuation.
         """
         import copy
+
         world_copy = TinyWorld.from_json(world.to_json())
         self.apply_delta(world_copy, delta)
         v_before = _world_feature_vector(world)
@@ -301,12 +306,11 @@ Use single-character glyphs. Keep it small and symbolic. Respond ONLY with JSON.
             "width": world.width,
             "height": world.height,
             "frame": world.frame_index,
-            "tiles": {k: {"glyph": t.glyph, "solid": t.solid, "tags": list(t.tags)}
-                      for k, t in world.tiles.items()},
+            "tiles": {k: {"glyph": t.glyph, "solid": t.solid, "tags": list(t.tags)} for k, t in world.tiles.items()},
             "sprites": {k: {"glyph": s.glyph} for k, s in world.sprites.items()},
-            "entities": {k: {"sprite": e.sprite_id, "x": e.x, "y": e.y,
-                             "state": e.state}
-                         for k, e in world.entities.items()},
+            "entities": {
+                k: {"sprite": e.sprite_id, "x": e.x, "y": e.y, "state": e.state} for k, e in world.entities.items()
+            },
         }
         parts = [
             f"GRID:\n{grid_str}",
@@ -357,12 +361,13 @@ Use single-character glyphs. Keep it small and symbolic. Respond ONLY with JSON.
             entity = world.entities[d["entity_id"]]
             entity.state[d["state_key"]] = d.get("state_value")
         elif cmd.type == "narrate":
-            pass   # narrate-only commands are captured in delta.narrative
+            pass  # narrate-only commands are captured in delta.narrative
 
 
 # ------------------------------------------------------------------
 # Round-table director
 # ------------------------------------------------------------------
+
 
 class RoundTableDirector:
     """Run a step through multiple models, keep the most coherent delta.
@@ -379,9 +384,7 @@ class RoundTableDirector:
             raise ValueError("need at least one director")
         self.directors = directors
 
-    def step(
-        self, world: TinyWorld, director_note: str = ""
-    ) -> Tuple[WorldDelta, RoundTableReport]:
+    def step(self, world: TinyWorld, director_note: str = "") -> Tuple[WorldDelta, RoundTableReport]:
         """Run all models, return (best_delta, report).
 
         Args:
@@ -417,6 +420,7 @@ class RoundTableDirector:
 # World feature vector for lattice coherence scoring
 # ------------------------------------------------------------------
 
+
 def _world_feature_vector(world: TinyWorld) -> np.ndarray:
     """Compact numeric descriptor of a world state.
 
@@ -437,8 +441,7 @@ def _world_feature_vector(world: TinyWorld) -> np.ndarray:
         xs = [e.x / world.width for e in world.entities.values()]
         ys = [e.y / world.height for e in world.entities.values()]
         centroid = np.array([np.mean(xs), np.mean(ys)], dtype=np.float64)
-        spread = np.array([np.std(xs) if len(xs) > 1 else 0.0,
-                           np.std(ys) if len(ys) > 1 else 0.0], dtype=np.float64)
+        spread = np.array([np.std(xs) if len(xs) > 1 else 0.0, np.std(ys) if len(ys) > 1 else 0.0], dtype=np.float64)
     else:
         centroid = np.zeros(2, dtype=np.float64)
         spread = np.zeros(2, dtype=np.float64)
@@ -458,6 +461,7 @@ def _world_feature_vector(world: TinyWorld) -> np.ndarray:
 # ------------------------------------------------------------------
 # API key loader
 # ------------------------------------------------------------------
+
 
 def _load_api_key() -> Optional[str]:
     key = os.environ.get("OPENAI_API_KEY")

--- a/src/video_lattice/multi_lattice.py
+++ b/src/video_lattice/multi_lattice.py
@@ -40,11 +40,11 @@ class LatticeAxis(Enum):
 
 # Default weights in phi-scaled progression (low→high importance)
 DEFAULT_WEIGHTS: Dict[LatticeAxis, float] = {
-    LatticeAxis.IDENTITY: _PHI**0,   # 1.000
-    LatticeAxis.MOTION: _PHI**1,     # 1.618
-    LatticeAxis.SCENE: _PHI**2,      # 2.618
-    LatticeAxis.COLOR: _PHI**3,      # 4.236
-    LatticeAxis.DEPTH: _PHI**4,      # 6.854
+    LatticeAxis.IDENTITY: _PHI**0,  # 1.000
+    LatticeAxis.MOTION: _PHI**1,  # 1.618
+    LatticeAxis.SCENE: _PHI**2,  # 2.618
+    LatticeAxis.COLOR: _PHI**3,  # 4.236
+    LatticeAxis.DEPTH: _PHI**4,  # 6.854
     LatticeAxis.STRUCTURE: _PHI**5,  # 11.09
 }
 
@@ -60,6 +60,7 @@ class AxisObservation:
 @dataclass
 class MultiLatticeFrame:
     """Result of observing one frame across all axes."""
+
     frame_index: int
     observations: Dict[LatticeAxis, AxisObservation] = field(default_factory=dict)
     aggregate_drift: float = 0.0
@@ -94,8 +95,7 @@ class MultiLattice:
 
         axis_dims = axis_dims or {}
         self._lattices: Dict[LatticeAxis, PoincareLattice] = {
-            ax: PoincareLattice(dim=axis_dims.get(ax, dim), name=ax.value)
-            for ax in LatticeAxis
+            ax: PoincareLattice(dim=axis_dims.get(ax, dim), name=ax.value) for ax in LatticeAxis
         }
 
     # ------------------------------------------------------------------
@@ -175,7 +175,7 @@ class MultiLattice:
         }
 
     def reset(self, axes: Optional[List[LatticeAxis]] = None) -> None:
-        for ax in (axes or list(LatticeAxis)):
+        for ax in axes or list(LatticeAxis):
             self._lattices[ax].reset()
         if axes is None:
             self._frame_count = 0

--- a/src/video_lattice/poincare_lattice.py
+++ b/src/video_lattice/poincare_lattice.py
@@ -26,7 +26,7 @@ from typing import List, Optional
 
 import numpy as np
 
-_EPS = 1e-6   # boundary guard — keep ||x|| < 1 strictly
+_EPS = 1e-6  # boundary guard — keep ||x|| < 1 strictly
 _MAX_NORM = 1.0 - _EPS
 
 
@@ -61,7 +61,7 @@ class PoincareLattice:
             return np.zeros(self.dim, dtype=np.float64)
         # exp_0(v) = tanh(||v||/2) * v/||v||
         r = math.tanh(norm / 2.0)
-        r = min(r, _MAX_NORM)   # epsilon clamp
+        r = min(r, _MAX_NORM)  # epsilon clamp
         return (r / norm) * v
 
     def project(self, p: np.ndarray) -> np.ndarray:
@@ -87,7 +87,7 @@ class PoincareLattice:
         denom = (1.0 - float(np.dot(u, u))) * (1.0 - float(np.dot(v, v)))
         denom = max(denom, _EPS)
         arg = 1.0 + 2.0 * diff_sq / denom
-        arg = max(arg, 1.0)   # arccosh domain guard
+        arg = max(arg, 1.0)  # arccosh domain guard
         return math.acosh(arg)
 
     # ------------------------------------------------------------------

--- a/src/video_lattice/pose_checker.py
+++ b/src/video_lattice/pose_checker.py
@@ -40,27 +40,29 @@ _PHI = (1 + math.sqrt(5)) / 2
 
 
 class PoseVerdict(Enum):
-    PASS = "pass"          # drift below soft threshold — generator is on track
-    SOFT_FAIL = "soft"     # drift above soft but below hard — inject mild correction
-    HARD_FAIL = "hard"     # drift above hard threshold — regenerate or use correction
+    PASS = "pass"  # drift below soft threshold — generator is on track
+    SOFT_FAIL = "soft"  # drift above soft but below hard — inject mild correction
+    HARD_FAIL = "hard"  # drift above hard threshold — regenerate or use correction
 
 
 @dataclass
 class ChainCheck:
     """Per-body-part drift result."""
-    name: str                          # "left_arm", "thumb", etc.
-    reference_angle: float             # joint angle in radians
+
+    name: str  # "left_arm", "thumb", etc.
+    reference_angle: float  # joint angle in radians
     generated_angle: float
-    angle_delta: float                 # |ref - gen| in radians
-    hyperbolic_distance: float         # full feature-vector distance in Poincaré ball
+    angle_delta: float  # |ref - gen| in radians
+    hyperbolic_distance: float  # full feature-vector distance in Poincaré ball
 
 
 @dataclass
 class PoseCheckResult:
     """Full result of one pose check comparison."""
-    pose_type: str                     # "hand" or "body"
-    overall_drift: float               # hyperbolic distance between feature vectors
-    cost_signal: float                 # R^(d²) nonlinear scaling
+
+    pose_type: str  # "hand" or "body"
+    overall_drift: float  # hyperbolic distance between feature vectors
+    cost_signal: float  # R^(d²) nonlinear scaling
     verdict: PoseVerdict
     chain_checks: List[ChainCheck] = field(default_factory=list)
     worst_chain: Optional[str] = None
@@ -200,13 +202,15 @@ class PoseChecker:
             gen_tip_vec = gen_pts[-1] - gen_pts[1]
             re = chain_lattice.embed(ref_tip_vec)
             ge = chain_lattice.embed(gen_tip_vec)
-            checks.append(ChainCheck(
-                name=name,
-                reference_angle=ref_angle,
-                generated_angle=gen_angle,
-                angle_delta=abs(ref_angle - gen_angle),
-                hyperbolic_distance=chain_lattice.distance(re, ge),
-            ))
+            checks.append(
+                ChainCheck(
+                    name=name,
+                    reference_angle=ref_angle,
+                    generated_angle=gen_angle,
+                    angle_delta=abs(ref_angle - gen_angle),
+                    hyperbolic_distance=chain_lattice.distance(re, ge),
+                )
+            )
         return checks
 
     def _body_chain_checks(
@@ -230,11 +234,13 @@ class PoseChecker:
             gen_seg = gen_pts[2] - gen_pts[1]
             re = chain_lattice.embed(ref_seg)
             ge = chain_lattice.embed(gen_seg)
-            checks.append(ChainCheck(
-                name=name,
-                reference_angle=ref_angle,
-                generated_angle=gen_angle,
-                angle_delta=abs(ref_angle - gen_angle),
-                hyperbolic_distance=chain_lattice.distance(re, ge),
-            ))
+            checks.append(
+                ChainCheck(
+                    name=name,
+                    reference_angle=ref_angle,
+                    generated_angle=gen_angle,
+                    angle_delta=abs(ref_angle - gen_angle),
+                    hyperbolic_distance=chain_lattice.distance(re, ge),
+                )
+            )
         return checks

--- a/src/video_lattice/pose_polygons.py
+++ b/src/video_lattice/pose_polygons.py
@@ -175,7 +175,9 @@ def _point(landmarks: Mapping[int, Landmark], index: IntEnum) -> Landmark:
         raise ValueError(f"missing landmark {index.name} ({int(index)})") from exc
 
 
-def polygon_points(landmarks: Sequence[Landmark] | Mapping[IntEnum, Landmark], indices: Iterable[IntEnum]) -> np.ndarray:
+def polygon_points(
+    landmarks: Sequence[Landmark] | Mapping[IntEnum, Landmark], indices: Iterable[IntEnum]
+) -> np.ndarray:
     mapped = _as_landmark_map(landmarks)
     return np.array([_point(mapped, index).xy() for index in indices], dtype=np.float64)
 
@@ -252,10 +254,7 @@ def hand_polygon_features(landmarks: Sequence[Landmark] | Mapping[IntEnum, Landm
     mapped = _as_landmark_map(landmarks)
     palm = polygon_points(mapped, HAND_PALM_POLYGON)
     wrist = _point(mapped, HandLandmark.WRIST).xy()
-    finger_points = {
-        name: polygon_points(mapped, chain)
-        for name, chain in HAND_FINGERS.items()
-    }
+    finger_points = {name: polygon_points(mapped, chain) for name, chain in HAND_FINGERS.items()}
     curls = [finger_curl(finger_points[name]) for name in ("thumb", "index", "middle", "ring", "pinky")]
     tip_indices = (
         HandLandmark.THUMB_TIP,
@@ -265,8 +264,12 @@ def hand_polygon_features(landmarks: Sequence[Landmark] | Mapping[IntEnum, Landm
         HandLandmark.PINKY_TIP,
     )
     tip_distances = [float(np.linalg.norm(_point(mapped, index).xy() - wrist)) for index in tip_indices]
-    thumb_index_spread = float(np.linalg.norm(_point(mapped, HandLandmark.THUMB_TIP).xy() - _point(mapped, HandLandmark.INDEX_TIP).xy()))
-    index_pinky_spread = float(np.linalg.norm(_point(mapped, HandLandmark.INDEX_TIP).xy() - _point(mapped, HandLandmark.PINKY_TIP).xy()))
+    thumb_index_spread = float(
+        np.linalg.norm(_point(mapped, HandLandmark.THUMB_TIP).xy() - _point(mapped, HandLandmark.INDEX_TIP).xy())
+    )
+    index_pinky_spread = float(
+        np.linalg.norm(_point(mapped, HandLandmark.INDEX_TIP).xy() - _point(mapped, HandLandmark.PINKY_TIP).xy())
+    )
     visibility = float(np.mean([point.visibility for point in mapped.values()]))
     centroid = polygon_centroid(palm)
     return np.array(

--- a/src/video_lattice/realtime_perception.py
+++ b/src/video_lattice/realtime_perception.py
@@ -243,7 +243,9 @@ def _undefined_depth_score(view_count: int, confidence: float, has_defined_depth
     return float(np.clip(score, 0.0, 1.0))
 
 
-def _missing_view_penalty(total_views: int, grouped_values: Iterable[Sequence[tuple[ViewFrame, LandmarkObservation]]]) -> float:
+def _missing_view_penalty(
+    total_views: int, grouped_values: Iterable[Sequence[tuple[ViewFrame, LandmarkObservation]]]
+) -> float:
     if total_views <= 1:
         return 0.25
     penalties = [1.0 - (len(group) / total_views) for group in grouped_values]

--- a/src/video_lattice/sketch_pad.py
+++ b/src/video_lattice/sketch_pad.py
@@ -53,7 +53,14 @@ class SketchPad:
             self.margin + y * (self.height - 2 * self.margin),
         )
 
-    def line(self, a: Landmark | Sequence[float], b: Landmark | Sequence[float], *, color: str = "#e7edf8", width: float = 3.0) -> None:
+    def line(
+        self,
+        a: Landmark | Sequence[float],
+        b: Landmark | Sequence[float],
+        *,
+        color: str = "#e7edf8",
+        width: float = 3.0,
+    ) -> None:
         pa = self.map_point(a)
         pb = self.map_point(b)
         self.strokes.append(
@@ -61,7 +68,9 @@ class SketchPad:
             f'stroke="{escape(color)}" stroke-width="{width:.2f}" stroke-linecap="round" />'
         )
 
-    def polyline(self, points: Iterable[Landmark | Sequence[float]], *, color: str = "#e7edf8", width: float = 3.0) -> None:
+    def polyline(
+        self, points: Iterable[Landmark | Sequence[float]], *, color: str = "#e7edf8", width: float = 3.0
+    ) -> None:
         mapped = [self.map_point(point) for point in points]
         if len(mapped) < 2:
             return
@@ -226,17 +235,16 @@ def render_body_sketch(
     return pad
 
 
-def _map_landmarks(landmarks: Sequence[Landmark] | Mapping[HandLandmark | BodyLandmark, Landmark]) -> dict[int, Landmark]:
+def _map_landmarks(
+    landmarks: Sequence[Landmark] | Mapping[HandLandmark | BodyLandmark, Landmark],
+) -> dict[int, Landmark]:
     if isinstance(landmarks, Mapping):
         return {int(key): value for key, value in landmarks.items()}
     return {index: value for index, value in enumerate(landmarks)}
 
 
 def _svg_attrs(command: str) -> dict[str, str]:
-    return {
-        match.group(1): match.group(2)
-        for match in re.finditer(r'([a-zA-Z0-9:-]+)="([^"]*)"', command)
-    }
+    return {match.group(1): match.group(2) for match in re.finditer(r'([a-zA-Z0-9:-]+)="([^"]*)"', command)}
 
 
 def _parse_svg_points(points: str) -> list[tuple[float, float]]:

--- a/src/video_lattice/ue5_bridge.py
+++ b/src/video_lattice/ue5_bridge.py
@@ -33,14 +33,14 @@ from .frame_corrector import CorrectionSignal
 from .pose_checker import PoseCheckResult, PoseVerdict
 
 DEFAULT_HOST = "127.0.0.1"
-DEFAULT_PORT = 7621   # distinct from UE5's own ports (6766 multicast, 6776 command)
+DEFAULT_PORT = 7621  # distinct from UE5's own ports (6766 multicast, 6776 command)
 RECV_BUF = 4096
 TIMEOUT_S = 5.0
 
 
 @dataclass
 class BridgeResponse:
-    status: str        # "ok" or "error"
+    status: str  # "ok" or "error"
     seq: int
     msg: str
     latency_ms: float
@@ -143,9 +143,7 @@ class UE5Bridge:
         """
         payload = result.to_dict()
         payload["correction_vector"] = (
-            result.correction_vector.tolist()
-            if result.correction_vector is not None
-            else None
+            result.correction_vector.tolist() if result.correction_vector is not None else None
         )
         return self._send("pose_check", payload)
 

--- a/tests/benchmark/test_bfcl_tool_call_adapter.py
+++ b/tests/benchmark/test_bfcl_tool_call_adapter.py
@@ -38,6 +38,7 @@ TOOLS_JSON = ROOT / "packages" / "agent-bus" / "tools.json"
 
 # ── Schema export ──────────────────────────────────────────────────────────────
 
+
 def test_export_count():
     schemas = tools_to_bfcl_schemas(TOOLS_JSON)
     assert len(schemas) == 54, f"expected 54 tools, got {len(schemas)}"
@@ -81,9 +82,7 @@ def test_reporoot_excluded_from_required():
     """repoRoot is a bus-substituted variable, never caller-supplied."""
     schemas = tools_to_bfcl_schemas(TOOLS_JSON)
     for schema in schemas:
-        assert "repoRoot" not in schema["parameters"]["required"], (
-            f"{schema['name']} has repoRoot in required"
-        )
+        assert "repoRoot" not in schema["parameters"]["required"], f"{schema['name']} has repoRoot in required"
 
 
 def test_all_schemas_have_description():
@@ -93,6 +92,7 @@ def test_all_schemas_have_description():
 
 
 # ── Param extraction ───────────────────────────────────────────────────────────
+
 
 def test_extract_params_single():
     assert _extract_params(["-m", "module", "{task}"]) == ["task"]
@@ -114,6 +114,7 @@ def test_extract_params_deduplicated():
 
 
 # ── AST validator ──────────────────────────────────────────────────────────────
+
 
 def test_validate_good_schema():
     schema = {
@@ -167,6 +168,7 @@ def test_validate_required_not_in_properties():
 
 # ── Test cases ─────────────────────────────────────────────────────────────────
 
+
 def test_test_cases_have_required_fields():
     for case in TEST_CASES:
         assert "id" in case
@@ -180,9 +182,9 @@ def test_irrelevance_cases_have_none_tool():
     irrelevance = [c for c in TEST_CASES if c["category"] == "irrelevance"]
     assert len(irrelevance) >= 2, "need at least 2 irrelevance cases"
     for case in irrelevance:
-        assert case["ground_truth_tool"] is None, (
-            f"{case['id']} is tagged irrelevance but has a non-None ground_truth_tool"
-        )
+        assert (
+            case["ground_truth_tool"] is None
+        ), f"{case['id']} is tagged irrelevance but has a non-None ground_truth_tool"
 
 
 def test_no_duplicate_case_ids():
@@ -198,20 +200,18 @@ def test_question_does_not_restate_tool_name():
         if expected is None:
             continue
         assert expected not in case["question"], (
-            f"{case['id']} question contains the tool name '{expected}' verbatim — "
-            "this is a tautological test case"
+            f"{case['id']} question contains the tool name '{expected}' verbatim — " "this is a tautological test case"
         )
 
 
 # ── Receipt chaining ───────────────────────────────────────────────────────────
 
+
 def test_receipt_is_deterministic():
     ts = "2026-01-01T00:00:00Z"
     prev = "0" * 64
-    r1 = _make_receipt("tc_01", "q", "geoseal-compile", "geoseal-compile",
-                        {"task": "t"}, True, prev, ts)
-    r2 = _make_receipt("tc_01", "q", "geoseal-compile", "geoseal-compile",
-                        {"task": "t"}, True, prev, ts)
+    r1 = _make_receipt("tc_01", "q", "geoseal-compile", "geoseal-compile", {"task": "t"}, True, prev, ts)
+    r2 = _make_receipt("tc_01", "q", "geoseal-compile", "geoseal-compile", {"task": "t"}, True, prev, ts)
     assert r1["receipt_hash"] == r2["receipt_hash"]
 
 
@@ -240,19 +240,18 @@ def test_receipt_hash_is_sha256_length():
 
 def test_receipt_near_miss_field_present():
     ts = "2026-01-01T00:00:00Z"
-    r = _make_receipt("tc_01", "q", "geoseal-compile", "geoseal-seal", {}, False,
-                      "0" * 64, ts, near_miss=True)
+    r = _make_receipt("tc_01", "q", "geoseal-compile", "geoseal-seal", {}, False, "0" * 64, ts, near_miss=True)
     assert r["near_miss"] is True
 
 
 def test_receipt_near_miss_default_false():
     ts = "2026-01-01T00:00:00Z"
-    r = _make_receipt("tc_01", "q", "geoseal-compile", "geoseal-compile", {}, True,
-                      "0" * 64, ts)
+    r = _make_receipt("tc_01", "q", "geoseal-compile", "geoseal-compile", {}, True, "0" * 64, ts)
     assert r["near_miss"] is False
 
 
 # ── Near-miss namespace detection ─────────────────────────────────────────────
+
 
 def test_same_namespace_true():
     assert _same_namespace("geoseal-compile", "geoseal-seal") is True

--- a/tests/benchmark/test_chemistry_cli_capability.py
+++ b/tests/benchmark/test_chemistry_cli_capability.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "benchmark" / "chemistry_cli_capability.py"
 

--- a/tests/benchmark/test_compound_decomposition_recomposition.py
+++ b/tests/benchmark/test_compound_decomposition_recomposition.py
@@ -10,9 +10,7 @@ MODULE_PATH = ROOT / "scripts" / "benchmark" / "compound_decomposition_recomposi
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location(
-        "compound_decomposition_recomposition", MODULE_PATH
-    )
+    spec = importlib.util.spec_from_file_location("compound_decomposition_recomposition", MODULE_PATH)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -44,17 +42,12 @@ def test_atom_only_mud_step_exposes_ambiguity() -> None:
 
     ethanol_case = next(case for case in module.CASES if case.name == "ethanol")
     result = module.run_case(ethanol_case)
-    recomposition = next(
-        step for step in result["steps"] if step["name"] == "recomposition_search"
-    )
+    recomposition = next(step for step in result["steps"] if step["name"] == "recomposition_search")
 
     assert recomposition["output"]["atom_only_ambiguous"] is True
     assert "dimethyl ether" in recomposition["output"]["atom_only_candidates"]
     assert recomposition["output"]["selected"]["name"] == "ethanol"
-    assert (
-        result["reaction_state_packet"]["recalculation"]["extra"]["atom_only_ambiguous"]
-        is True
-    )
+    assert result["reaction_state_packet"]["recalculation"]["extra"]["atom_only_ambiguous"] is True
 
 
 def test_expanded_corpus_covers_multiple_functional_families() -> None:

--- a/tests/benchmark/test_swe_local_benchmark.py
+++ b/tests/benchmark/test_swe_local_benchmark.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/tests/benchmark/test_tau_bench_policy_adapter.py
+++ b/tests/benchmark/test_tau_bench_policy_adapter.py
@@ -34,8 +34,8 @@ from scripts.benchmark._bench_common import (
     same_namespace,
 )
 
-
 # ── Fixture validation ─────────────────────────────────────────────────────────
+
 
 def test_fixture_validation_passes():
     result = validate_fixtures()
@@ -62,8 +62,7 @@ def test_tier_distribution():
 
 
 def test_all_cases_have_required_fields():
-    required = ("id", "tier", "user_request", "expected_first_tool",
-                 "expected_decision", "policy_clause")
+    required = ("id", "tier", "user_request", "expected_first_tool", "expected_decision", "policy_clause")
     for case in POLICY_CASES:
         for f in required:
             assert f in case, f"{case['id']} missing field '{f}'"
@@ -71,9 +70,7 @@ def test_all_cases_have_required_fields():
 
 def test_tool_responses_cover_all_cases():
     for case in POLICY_CASES:
-        assert case["id"] in _TOOL_RESPONSES, (
-            f"{case['id']} has no simulated tool response"
-        )
+        assert case["id"] in _TOOL_RESPONSES, f"{case['id']} has no simulated tool response"
 
 
 def test_tool_responses_are_valid_json():
@@ -86,8 +83,7 @@ def test_tool_responses_are_valid_json():
         # "decision" is intentionally absent — the model must apply the threshold
         # from the system prompt; pre-resolving it would make this a JSON-copy test
         assert "decision" not in parsed, (
-            f"{case_id}: response must NOT contain 'decision' field "
-            "(degenerate verifier — model would just echo it)"
+            f"{case_id}: response must NOT contain 'decision' field " "(degenerate verifier — model would just echo it)"
         )
         assert "flags" in parsed, f"{case_id}: response missing 'flags' field"
 
@@ -96,29 +92,24 @@ def test_no_tautological_requests_tool():
     """user_request must not contain the expected first tool name."""
     for case in POLICY_CASES:
         et = case["expected_first_tool"]
-        assert et not in case["user_request"], (
-            f"{case['id']}: user_request contains expected_first_tool '{et}'"
-        )
+        assert et not in case["user_request"], f"{case['id']}: user_request contains expected_first_tool '{et}'"
 
 
 def test_no_tautological_requests_decision():
     """user_request must not contain the expected decision word."""
     for case in POLICY_CASES:
         dec = case["expected_decision"].lower()
-        assert dec not in case["user_request"].lower(), (
-            f"{case['id']}: user_request contains expected_decision '{dec}'"
-        )
+        assert dec not in case["user_request"].lower(), f"{case['id']}: user_request contains expected_decision '{dec}'"
 
 
 def test_all_expected_decisions_are_valid():
     valid = {"ALLOW", "QUARANTINE", "ESCALATE", "DENY"}
     for case in POLICY_CASES:
-        assert case["expected_decision"] in valid, (
-            f"{case['id']}: unexpected decision '{case['expected_decision']}'"
-        )
+        assert case["expected_decision"] in valid, f"{case['id']}: unexpected decision '{case['expected_decision']}'"
 
 
 # ── Decision detection ─────────────────────────────────────────────────────────
+
 
 def test_detect_deny_from_refusal():
     text = "I'm sorry, I cannot and will not help with that. This violates policy."
@@ -153,6 +144,7 @@ def test_detect_none_from_ambiguous():
 
 # ── Minimal tool schemas ───────────────────────────────────────────────────────
 
+
 def test_minimal_schemas_include_governance_tools():
     schemas = _build_tool_schemas_minimal()
     names = {s["name"] for s in schemas}
@@ -171,6 +163,7 @@ def test_minimal_schemas_valid_structure():
 
 
 # ── _bench_common helpers ──────────────────────────────────────────────────────
+
 
 def test_sha256_deterministic():
     assert _sha256("hello") == _sha256("hello")
@@ -192,11 +185,12 @@ def test_same_namespace_false():
 def test_make_receipt_chain():
     ts = "2026-01-01T00:00:00Z"
     prev = "0" * 64
-    r1 = make_receipt("tp_01", "request 1", "scbe-compass|ALLOW",
-                      "scbe-compass|ALLOW", {"tier": "ALLOW"}, True, prev, ts)
-    r2 = make_receipt("tp_02", "request 2", "scbe-compass|DENY",
-                      "scbe-compass|DENY", {"tier": "DENY"}, True,
-                      r1["receipt_hash"], ts)
+    r1 = make_receipt(
+        "tp_01", "request 1", "scbe-compass|ALLOW", "scbe-compass|ALLOW", {"tier": "ALLOW"}, True, prev, ts
+    )
+    r2 = make_receipt(
+        "tp_02", "request 2", "scbe-compass|DENY", "scbe-compass|DENY", {"tier": "DENY"}, True, r1["receipt_hash"], ts
+    )
     assert r2["prev_hash"] == r1["receipt_hash"]
     assert r2["receipt_hash"] != r1["receipt_hash"]
 

--- a/tests/benchmark/test_terminal_bench_adapter.py
+++ b/tests/benchmark/test_terminal_bench_adapter.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "benchmark" / "terminal_bench_adapter.py"
 

--- a/tests/geoseed/test_orbital_model.py
+++ b/tests/geoseed/test_orbital_model.py
@@ -27,6 +27,7 @@ LN_PHI = math.log(PHI)
 
 # ── Import under test ─────────────────────────────────────────────────────────
 
+
 def _import():
     """Import orbital_model regardless of scipy availability."""
     try:
@@ -40,6 +41,7 @@ def _import():
             TONGUES,
             PHI as MODEL_PHI,
         )
+
         return {
             "build": build_geoseed_orbitals,
             "summary": orbital_summary,
@@ -56,13 +58,16 @@ def _import():
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="module")
 def mod():
     return _import()
 
+
 @pytest.fixture(scope="module")
 def orbitals(mod):
     return mod["build"]()
+
 
 @pytest.fixture(scope="module")
 def summary(mod):
@@ -71,23 +76,25 @@ def summary(mod):
 
 # ── 1. Golden ratio checkpoint ────────────────────────────────────────────────
 
+
 def test_ca_tongue_at_one_over_phi(orbitals):
     """CA (Cassisivadan, l=3) must sit exactly at r = 1/φ in the Poincaré ball."""
     ca = orbitals[3]
     assert ca.abbr == "CA", f"Expected CA at index 3, got {ca.abbr}"
     assert ca.l == 3
-    assert abs(ca.poincare_r - 1.0 / PHI) < 1e-9, (
-        f"CA poincare_r={ca.poincare_r} ≠ 1/φ={1/PHI}"
-    )
+    assert abs(ca.poincare_r - 1.0 / PHI) < 1e-9, f"CA poincare_r={ca.poincare_r} ≠ 1/φ={1/PHI}"
+
 
 def test_summary_golden_checkpoint(summary):
     assert summary["golden_ratio_checkpoint"]["exact"] is True
+
 
 def test_phi_value_matches(mod):
     assert abs(mod["phi"] - PHI) < 1e-12
 
 
 # ── 2. Uniform inter-shell geodesic gap ───────────────────────────────────────
+
 
 def test_inter_shell_gaps_are_uniform(summary):
     """All 5 adjacent-shell geodesic distances must be identical."""
@@ -96,61 +103,61 @@ def test_inter_shell_gaps_are_uniform(summary):
     distances = [g["geodesic_distance"] for g in gaps]
     first = distances[0]
     for i, d in enumerate(distances):
-        assert abs(d - first) < 1e-9, (
-            f"Gap {i} distance {d} ≠ gap 0 distance {first} — uniform spacing broken"
-        )
+        assert abs(d - first) < 1e-9, f"Gap {i} distance {d} ≠ gap 0 distance {first} — uniform spacing broken"
+
 
 def test_inter_shell_gap_equals_ln_phi(summary):
     """Each geodesic step = ln(φ) (the hyperbolic step size for tanh(n·ln(φ)/2))."""
     gaps = summary["inter_shell_gaps"]
     step = gaps[0]["geodesic_distance"]
-    assert abs(step - LN_PHI) < 1e-6, (
-        f"Gap {step} ≠ ln(φ)={LN_PHI:.6f}"
-    )
+    assert abs(step - LN_PHI) < 1e-6, f"Gap {step} ≠ ln(φ)={LN_PHI:.6f}"
+
 
 def test_inter_shell_phi_ratios_all_equal_phi(summary):
     """Adjacent shell phi-weight ratios must all equal φ."""
     for g in summary["inter_shell_gaps"]:
-        assert abs(g["phi_ratio"] - PHI) < 1e-6, (
-            f"{g['from']}→{g['to']} phi_ratio={g['phi_ratio']} ≠ φ={PHI}"
-        )
+        assert abs(g["phi_ratio"] - PHI) < 1e-6, f"{g['from']}→{g['to']} phi_ratio={g['phi_ratio']} ≠ φ={PHI}"
 
 
 # ── 3. Laplace-Beltrami eigenvalues ──────────────────────────────────────────
 
-@pytest.mark.parametrize("l,expected", [
-    (0, -1.0),
-    (1, -4.0),
-    (2, -9.0),
-    (3, -16.0),
-    (4, -25.0),
-    (5, -36.0),
-])
+
+@pytest.mark.parametrize(
+    "l,expected",
+    [
+        (0, -1.0),
+        (1, -4.0),
+        (2, -9.0),
+        (3, -16.0),
+        (4, -25.0),
+        (5, -36.0),
+    ],
+)
 def test_lb_eigenvalue(mod, l, expected):
     """LB eigenvalue on H³ = -(l+1)²."""
     assert mod["lb_eigen"](l) == expected
 
+
 def test_orbital_lb_eigenvalues(orbitals):
     for o in orbitals:
         expected = -float((o.l + 1) ** 2)
-        assert o.lb_eigenvalue == expected, (
-            f"{o.abbr} LB eigenvalue {o.lb_eigenvalue} ≠ {expected}"
-        )
+        assert o.lb_eigenvalue == expected, f"{o.abbr} LB eigenvalue {o.lb_eigenvalue} ≠ {expected}"
 
 
 # ── 4. Magnetic sub-state counts ─────────────────────────────────────────────
+
 
 def test_m_states_per_orbital(orbitals):
     """Each orbital must have 2l+1 magnetic sub-states."""
     for o in orbitals:
         expected = 2 * o.l + 1
-        assert o.m_states == expected, (
-            f"{o.abbr} m_states={o.m_states} ≠ 2l+1={expected}"
-        )
+        assert o.m_states == expected, f"{o.abbr} m_states={o.m_states} ≠ 2l+1={expected}"
+
 
 def test_total_m_states_equals_36(summary):
     """1+3+5+7+9+11 = 36 total magnetic sub-states."""
     assert summary["total_m_states"] == 36
+
 
 def test_m_states_sequence(orbitals):
     """m-states must be 1, 3, 5, 7, 9, 11."""
@@ -159,10 +166,12 @@ def test_m_states_sequence(orbitals):
 
 # ── 5. Tongue ordering and radial geometry ────────────────────────────────────
 
+
 def test_tongues_in_phi_order(orbitals):
     """Tongues must be ordered KO→AV→RU→CA→UM→DR."""
     abbrs = [o.abbr for o in orbitals]
     assert abbrs == ["KO", "AV", "RU", "CA", "UM", "DR"]
+
 
 def test_ko_at_centre(orbitals):
     """KO (n=0) must be at the ball centre r=0."""
@@ -170,18 +179,19 @@ def test_ko_at_centre(orbitals):
     assert ko.poincare_r == 0.0
     assert ko.hyperbolic_rho == 0.0
 
+
 def test_poincare_r_strictly_increasing(orbitals):
     """Shell radii must increase strictly outward."""
     rs = [o.poincare_r for o in orbitals]
     for i in range(1, len(rs)):
-        assert rs[i] > rs[i - 1], (
-            f"Shell {i} r={rs[i]} not > shell {i-1} r={rs[i-1]}"
-        )
+        assert rs[i] > rs[i - 1], f"Shell {i} r={rs[i]} not > shell {i-1} r={rs[i-1]}"
+
 
 def test_all_shells_inside_poincare_ball(orbitals):
     """All shells must sit strictly inside the unit ball (r < 1)."""
     for o in orbitals:
         assert o.poincare_r < 1.0, f"{o.abbr} poincare_r={o.poincare_r} ≥ 1"
+
 
 def test_dr_outermost_shell(orbitals):
     """DR (Draumric) must be the outermost shell."""
@@ -191,21 +201,20 @@ def test_dr_outermost_shell(orbitals):
 
 # ── 6. Sacred Egg nodes ───────────────────────────────────────────────────────
 
+
 def test_egg_node_count_per_shell(orbitals):
     """Each shell must have exactly 21 Sacred Egg nodes."""
     for o in orbitals:
-        assert len(o.egg_nodes) == 21, (
-            f"{o.abbr} has {len(o.egg_nodes)} egg nodes, expected 21"
-        )
+        assert len(o.egg_nodes) == 21, f"{o.abbr} has {len(o.egg_nodes)} egg nodes, expected 21"
+
 
 def test_egg_nodes_inside_poincare_ball(orbitals):
     """All egg nodes must lie inside the Poincaré ball (Euclidean |r| < 1)."""
     for o in orbitals:
         for x, y, z in o.egg_nodes:
             r = math.sqrt(x**2 + y**2 + z**2)
-            assert r < 1.0 + 1e-9, (
-                f"{o.abbr} egg node at r={r:.6f} outside unit ball"
-            )
+            assert r < 1.0 + 1e-9, f"{o.abbr} egg node at r={r:.6f} outside unit ball"
+
 
 def test_egg_nodes_at_correct_shell_radius(orbitals):
     """Egg nodes must lie on their shell's Poincaré sphere (r ≈ poincare_r)."""
@@ -214,9 +223,8 @@ def test_egg_nodes_at_correct_shell_radius(orbitals):
             continue  # KO is at centre — all eggs at origin
         for x, y, z in o.egg_nodes:
             r = math.sqrt(x**2 + y**2 + z**2)
-            assert abs(r - o.poincare_r) < 1e-9, (
-                f"{o.abbr} egg node r={r:.9f} ≠ shell r={o.poincare_r:.9f}"
-            )
+            assert abs(r - o.poincare_r) < 1e-9, f"{o.abbr} egg node r={r:.9f} ≠ shell r={o.poincare_r:.9f}"
+
 
 def test_ko_eggs_at_origin(orbitals):
     """KO eggs must all be at the origin."""
@@ -227,13 +235,16 @@ def test_ko_eggs_at_origin(orbitals):
 
 # ── 7. Hyperbolic distance helper ─────────────────────────────────────────────
 
+
 def test_hyperbolic_distance_zero_to_zero(mod):
     assert mod["hyp_dist"](0.0, 0.0) == 0.0
+
 
 def test_hyperbolic_distance_symmetric(mod):
     d1 = mod["hyp_dist"](0.2, 0.6)
     d2 = mod["hyp_dist"](0.6, 0.2)
     assert abs(d1 - d2) < 1e-12
+
 
 def test_hyperbolic_distance_grows_near_boundary(mod):
     """Points near the boundary are farther apart than points near the centre."""
@@ -244,13 +255,16 @@ def test_hyperbolic_distance_grows_near_boundary(mod):
 
 # ── 8. phi_to_poincare_r mapping ──────────────────────────────────────────────
 
+
 @pytest.mark.parametrize("n", [0, 1, 2, 3, 4, 5])
 def test_phi_to_poincare_r_in_unit_interval(mod, n):
     r = mod["phi_to_r"](n)
     assert 0.0 <= r < 1.0, f"phi_to_poincare_r({n}) = {r} outside [0,1)"
 
+
 def test_phi_to_poincare_r_n0_is_zero(mod):
     assert mod["phi_to_r"](0) == 0.0
+
 
 def test_phi_to_poincare_r_n3_is_one_over_phi(mod):
     r = mod["phi_to_r"](3)
@@ -259,8 +273,10 @@ def test_phi_to_poincare_r_n3_is_one_over_phi(mod):
 
 # ── 9. Schema version ─────────────────────────────────────────────────────────
 
+
 def test_summary_schema_version(summary):
     assert summary["schema_version"] == "geoseed_orbital_v1"
+
 
 def test_summary_manifold(summary):
     assert "H3" in summary["manifold"] or "Poincare" in summary["manifold"]

--- a/tests/geoseed/test_shell_duality.py
+++ b/tests/geoseed/test_shell_duality.py
@@ -26,80 +26,85 @@ PHI = (1.0 + math.sqrt(5.0)) / 2.0
 @pytest.fixture(scope="module")
 def rydberg():
     from src.geoseed.theory_comparison import RYDBERG_EV
+
     return RYDBERG_EV
 
 
 @pytest.fixture(scope="module")
 def dual(rydberg):
     from src.geoseed.shell_duality import build_shell_duality
+
     return build_shell_duality()
 
 
 @pytest.fixture(scope="module")
 def field_obj(dual):
     from src.geoseed.shell_duality import ShellStateField
+
     return ShellStateField(dual)
 
 
 @pytest.fixture(scope="module")
 def pert():
     from src.geoseed.shell_duality import run_perturbation_tests
+
     return run_perturbation_tests()
 
 
 # ── ShellDuality invariant ────────────────────────────────────────────────────
 
+
 def test_invariant_equals_a_squared(dual, rydberg):
     """I(k) = A² exactly for all shells."""
-    a2 = rydberg ** 2
+    a2 = rydberg**2
     for k in range(1, 7):
-        assert abs(dual.invariant(k) - a2) < 1e-9, (
-            f"k={k}: I={dual.invariant(k):.9f} ≠ A²={a2:.9f}"
-        )
+        assert abs(dual.invariant(k) - a2) < 1e-9, f"k={k}: I={dual.invariant(k):.9f} ≠ A²={a2:.9f}"
+
 
 def test_invariant_cv_zero(dual):
     """Product must be perfectly flat."""
     assert dual.invariant_cv() < 1e-12
 
+
 def test_is_invariant_flat(dual):
     assert dual.is_invariant_flat()
+
 
 def test_geometric_center_equals_rydberg(dual, rydberg):
     """GM(k) = sqrt(I(k)) = A = Rydberg for all shells."""
     for k in range(1, 7):
         gm = dual.geometric_center(k)
-        assert abs(gm - rydberg) < 1e-9, (
-            f"k={k}: geometric_center={gm:.9f} ≠ Rydberg={rydberg:.9f}"
-        )
+        assert abs(gm - rydberg) < 1e-9, f"k={k}: geometric_center={gm:.9f} ≠ Rydberg={rydberg:.9f}"
+
 
 def test_coupling_ratio_is_one_over_k4(dual):
     """R(k) = E_bind/E_curv = 1/k^4."""
     for k in range(1, 7):
-        expected = 1.0 / (k ** 4)
+        expected = 1.0 / (k**4)
         actual = dual.coupling_ratio(k)
-        assert abs(actual - expected) < 1e-12, (
-            f"k={k}: ratio={actual:.12f} ≠ 1/k^4={expected:.12f}"
-        )
+        assert abs(actual - expected) < 1e-12, f"k={k}: ratio={actual:.12f} ≠ 1/k^4={expected:.12f}"
 
 
 # ── Shell balance ─────────────────────────────────────────────────────────────
+
 
 def test_ko_shell_is_balanced(dual, rydberg):
     """At KO (k=1): E_bind = E_curv = A."""
     assert abs(dual.bind(1) - rydberg) < 1e-9
     assert abs(dual.curv(1) - rydberg) < 1e-9
 
+
 def test_outer_shells_curv_dominates(dual):
     """For k > 1, curvature must exceed binding."""
     for k in range(2, 7):
-        assert dual.curv(k) > dual.bind(k), (
-            f"k={k}: curv={dual.curv(k):.4f} not > bind={dual.bind(k):.4f}"
-        )
+        assert dual.curv(k) > dual.bind(k), f"k={k}: curv={dual.curv(k):.4f} not > bind={dual.bind(k):.4f}"
+
 
 def test_bind_monotone_decreasing(dual):
     """Binding falls outward."""
     for k in range(1, 6):
         assert dual.bind(k) > dual.bind(k + 1)
+
 
 def test_curv_monotone_increasing(dual):
     """Curvature rises outward."""
@@ -109,18 +114,19 @@ def test_curv_monotone_increasing(dual):
 
 # ── Shell state angles ────────────────────────────────────────────────────────
 
+
 def test_ko_angle_is_45_deg(dual):
     """At KO (k=1): bind=curv → angle = 45°."""
     angle = math.degrees(dual.relation_angle(1))
     assert abs(angle - 45.0) < 1e-6, f"KO angle={angle:.6f}° ≠ 45°"
 
+
 def test_angles_monotone_increasing(dual):
     """Shell angle grows outward as curvature dominates."""
     angles = [math.degrees(dual.relation_angle(k)) for k in range(1, 7)]
     for i in range(1, 6):
-        assert angles[i] > angles[i - 1], (
-            f"angle not increasing at k={i+1}: {angles[i]:.2f} <= {angles[i-1]:.2f}"
-        )
+        assert angles[i] > angles[i - 1], f"angle not increasing at k={i+1}: {angles[i]:.2f} <= {angles[i-1]:.2f}"
+
 
 def test_angles_approach_90(dual):
     """DR shell (k=6) should be near 90°."""
@@ -130,18 +136,22 @@ def test_angles_approach_90(dual):
 
 # ── Bind/curv fractions ───────────────────────────────────────────────────────
 
+
 def test_ko_fractions_equal(dual):
     """At KO: bind_fraction = curv_fraction = 0.5."""
     assert abs(dual.bind_fraction(1) - 0.5) < 1e-9
     assert abs(dual.curv_fraction(1) - 0.5) < 1e-9
 
+
 def test_bind_fraction_decreases_outward(dual):
     for k in range(1, 6):
         assert dual.bind_fraction(k) > dual.bind_fraction(k + 1)
 
+
 def test_curv_fraction_increases_outward(dual):
     for k in range(1, 6):
         assert dual.curv_fraction(k) < dual.curv_fraction(k + 1)
+
 
 def test_fractions_sum_to_one(dual):
     for k in range(1, 7):
@@ -151,44 +161,52 @@ def test_fractions_sum_to_one(dual):
 
 # ── Perturbation tests ────────────────────────────────────────────────────────
 
+
 def test_pert_has_seven_scenarios(pert):
     assert len(pert.scenarios) == 7
+
 
 def test_pert_exact_baseline_flat(pert):
     base = next(s for s in pert.scenarios if s.name == "exact_baseline")
     assert base.invariant_cv < 1e-9
+
 
 def test_pert_rescaled_anchor_flat(pert):
     """Rescaling A still gives a flat invariant (different A², same structure)."""
     s = next(s for s in pert.scenarios if s.name == "rescaled_anchor")
     assert s.invariant_survived, f"rescaled_anchor CV={s.invariant_cv:.6f}"
 
+
 def test_pert_non_hydrogen_anchor_flat(pert):
     s = next(s for s in pert.scenarios if s.name == "non_hydrogen_anchor")
     assert s.invariant_survived, f"non_hydrogen_anchor CV={s.invariant_cv:.6f}"
+
 
 def test_pert_noisy_k_approximately_flat(pert):
     """Gaussian noise σ=0.1 on k should keep CV < 0.05."""
     s = next(s for s in pert.scenarios if s.name == "noisy_k_sigma01")
     assert s.invariant_cv < 0.05, f"noisy_k CV={s.invariant_cv:.4f}"
 
+
 def test_pert_offset_indexing_flat(pert):
     s = next(s for s in pert.scenarios if s.name == "offset_indexing")
     assert s.invariant_survived
+
 
 def test_pert_half_integer_flat(pert):
     s = next(s for s in pert.scenarios if s.name == "half_integer_k")
     assert s.invariant_survived
 
+
 def test_pert_large_anchor_flat(pert):
     s = next(s for s in pert.scenarios if s.name == "large_anchor")
     assert s.invariant_survived
 
+
 def test_pert_baseline_exponents_near_2(pert):
     base = next(s for s in pert.scenarios if s.name == "exact_baseline")
-    assert base.exponents_survived, (
-        f"p={base.bind_exponent:.3f}, q={base.curv_exponent:.3f} — not near 2"
-    )
+    assert base.exponents_survived, f"p={base.bind_exponent:.3f}, q={base.curv_exponent:.3f} — not near 2"
+
 
 def test_pert_to_dict(pert):
     d = pert.to_dict()
@@ -198,25 +216,30 @@ def test_pert_to_dict(pert):
 
 # ── ShellStateField ───────────────────────────────────────────────────────────
 
+
 def test_field_balance_at_ko(field_obj):
     """Balance point must be at KO (k=1)."""
     bal_k, diff = field_obj.balance_point()
     assert bal_k == 1, f"Balance at k={bal_k}, expected k=1"
     assert diff < 1e-9
 
+
 def test_field_crossover_at_ko(field_obj):
     """Exact crossover (bind=curv) happens at k=1."""
     cx_k, cx_e = field_obj.crossover_shell()
     assert cx_k == 1
 
+
 def test_field_hyperbola_constant_equals_a_sq(field_obj, rydberg):
-    assert abs(field_obj.hyperbola_constant() - rydberg ** 2) < 1e-9
+    assert abs(field_obj.hyperbola_constant() - rydberg**2) < 1e-9
+
 
 def test_field_all_outer_shells_curv_dominant(field_obj):
     states = field_obj.states()
     for i in range(1, 6):
         bind, curv = states[i]
         assert curv > bind, f"Shell {i+1} not curv-dominant: bind={bind}, curv={curv}"
+
 
 def test_field_to_dict(field_obj, rydberg):
     d = field_obj.to_dict()
@@ -228,18 +251,20 @@ def test_field_to_dict(field_obj, rydberg):
 
 # ── Custom anchor ─────────────────────────────────────────────────────────────
 
+
 def test_custom_anchor_preserves_structure():
     """The dual structure works for any positive anchor A."""
     from src.geoseed.shell_duality import build_shell_duality
+
     for A in [1.0, 5.5, 100.0, 0.01]:
         d = build_shell_duality(anchor_ev=A)
         for k in range(1, 7):
-            assert abs(d.invariant(k) - A ** 2) < 1e-9, (
-                f"A={A}, k={k}: I={d.invariant(k):.9f} ≠ A²={A**2:.9f}"
-            )
+            assert abs(d.invariant(k) - A**2) < 1e-9, f"A={A}, k={k}: I={d.invariant(k):.9f} ≠ A²={A**2:.9f}"
+
 
 def test_custom_anchor_geometric_center_equals_a():
     from src.geoseed.shell_duality import build_shell_duality
+
     A = 7.77
     d = build_shell_duality(anchor_ev=A)
     for k in range(1, 7):
@@ -249,11 +274,13 @@ def test_custom_anchor_geometric_center_equals_a():
 
 # ── Serialisation ─────────────────────────────────────────────────────────────
 
+
 def test_dual_to_dict_schema(dual):
     d = dual.to_dict()
     assert d["schema_version"] == "geoseed_shell_duality_v1"
     assert d["is_invariant_flat"] is True
     assert len(d["shells"]) == 6
+
 
 def test_dual_to_dict_ko_balanced(dual):
     d = dual.to_dict()
@@ -262,8 +289,10 @@ def test_dual_to_dict_ko_balanced(dual):
     assert abs(ko["bind_ev"] - ko["curv_ev"]) < 1e-9
     assert abs(ko["relation_angle_deg"] - 45.0) < 1e-4
 
+
 def test_duality_field_report_non_empty():
     from src.geoseed.shell_duality import duality_field_report
+
     report = duality_field_report()
     assert len(report) > 400
     assert "SHELL DUALITY FIELD" in report
@@ -273,9 +302,11 @@ def test_duality_field_report_non_empty():
 
 # ── RelationTerm ──────────────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="module")
 def rel():
     from src.geoseed.shell_duality import build_relation_term
+
     return build_relation_term()
 
 
@@ -294,9 +325,7 @@ def test_rel_compton_phi_scaling(rel, rydberg):
     """Each successive Compton shell is 1/φ of the previous."""
     for k in range(1, 6):
         ratio = rel.compton_ev(k) / rel.compton_ev(k + 1)
-        assert abs(ratio - PHI) < 1e-9, (
-            f"Compton k={k}→{k+1} ratio {ratio} ≠ φ"
-        )
+        assert abs(ratio - PHI) < 1e-9, f"Compton k={k}→{k+1} ratio {ratio} ≠ φ"
 
 
 def test_rel_coupling_formula(rel):
@@ -304,9 +333,7 @@ def test_rel_coupling_formula(rel):
     for k in range(1, 7):
         expected = (k * k) / (PHI ** (k - 1))
         actual = rel.coupling_ratio(k)
-        assert abs(actual - expected) < 1e-12, (
-            f"k={k}: ρ={actual:.12f} ≠ k²/φ^(k-1)={expected:.12f}"
-        )
+        assert abs(actual - expected) < 1e-12, f"k={k}: ρ={actual:.12f} ≠ k²/φ^(k-1)={expected:.12f}"
 
 
 def test_rel_resonance_shell_is_ko(rel):
@@ -332,9 +359,7 @@ def test_rel_peak_coupling_above_3(rel):
 def test_rel_all_outer_coupling_above_one(rel):
     """For k > 1, Compton always exceeds the dual-law bind (ρ > 1)."""
     for k in range(2, 7):
-        assert rel.coupling_ratio(k) > 1.0, (
-            f"k={k}: coupling ρ={rel.coupling_ratio(k):.4f} ≤ 1"
-        )
+        assert rel.coupling_ratio(k) > 1.0, f"k={k}: coupling ρ={rel.coupling_ratio(k):.4f} ≤ 1"
 
 
 def test_rel_phase_angles_positive(rel):
@@ -368,23 +393,25 @@ def test_rel_to_dict_ko_deviation_zero(rel):
 
 # ── Clean API ─────────────────────────────────────────────────────────────────
 
+
 def test_compute_invariant_returns_product():
     from src.geoseed.shell_duality import compute_invariant
+
     assert abs(compute_invariant(5.0, 20.0) - 100.0) < 1e-12
 
 
 def test_compute_invariant_rydberg_shells(rydberg):
     from src.geoseed.shell_duality import compute_invariant, shell_state_at
+
     for k in range(1, 7):
         b, c = shell_state_at(k)
         inv = compute_invariant(b, c)
-        assert abs(inv - rydberg ** 2) < 1e-9, (
-            f"k={k}: compute_invariant={inv:.9f} ≠ Rydberg²"
-        )
+        assert abs(inv - rydberg**2) < 1e-9, f"k={k}: compute_invariant={inv:.9f} ≠ Rydberg²"
 
 
 def test_shell_state_at_ko_balanced(rydberg):
     from src.geoseed.shell_duality import shell_state_at
+
     b, c = shell_state_at(1)
     assert abs(b - rydberg) < 1e-9
     assert abs(c - rydberg) < 1e-9
@@ -392,6 +419,7 @@ def test_shell_state_at_ko_balanced(rydberg):
 
 def test_fit_binding_law_recovers_p2(rydberg):
     from src.geoseed.shell_duality import fit_binding_law
+
     shells = [float(k) for k in range(1, 7)]
     values = [rydberg / (k * k) for k in range(1, 7)]
     A, delta, p, rms = fit_binding_law(shells, values)
@@ -401,6 +429,7 @@ def test_fit_binding_law_recovers_p2(rydberg):
 
 def test_perturbation_sweep_returns_7(rydberg):
     from src.geoseed.shell_duality import perturbation_sweep
+
     pt = perturbation_sweep(seed=0)
     assert len(pt.scenarios) == 7
     assert pt.all_survived()
@@ -408,20 +437,23 @@ def test_perturbation_sweep_returns_7(rydberg):
 
 # ── export_duality_artifact ───────────────────────────────────────────────────
 
+
 def test_export_artifact_creates_file(tmp_path, rydberg):
     from src.geoseed.shell_duality import export_duality_artifact
     import json
+
     out = str(tmp_path)
     path = export_duality_artifact(out_dir=out)
     assert path.endswith(".json")
     import os
+
     assert os.path.isfile(path)
     with open(path, encoding="utf-8") as f:
         data = json.load(f)
     assert data["schema_version"] == "geoseed_shell_duality_artifact_v1"
     assert data["summary"]["is_invariant_flat"] is True
     assert data["summary"]["all_perturbations_survived"] is True
-    assert abs(data["summary"]["A_squared_ev2"] - rydberg ** 2) < 1e-6
+    assert abs(data["summary"]["A_squared_ev2"] - rydberg**2) < 1e-6
     assert data["summary"]["resonance_shell_k"] == 1
     assert data["summary"]["peak_coupling_shell_k"] == 4
     # all four sections present

--- a/tests/geoseed/test_theory_comparison.py
+++ b/tests/geoseed/test_theory_comparison.py
@@ -37,6 +37,7 @@ def mod():
         COMPTON_ENERGY_EV,
         TONGUE_ORDER,
     )
+
     return {
         "run_all": run_all,
         "compton": theory_compton_orbital,
@@ -56,23 +57,29 @@ def mod():
 
 # ── Physical constants sanity ─────────────────────────────────────────────────
 
+
 def test_rydberg_value(mod):
     """Rydberg constant must be near 13.606 eV."""
     assert abs(mod["rydberg"] - 13.6057) < 0.001
+
 
 def test_compton_frequency_order_of_magnitude(mod):
     """Compton frequency must be ~1.236×10²⁰ Hz."""
     assert 1.2e20 < mod["f_c"] < 1.3e20
 
+
 def test_compton_energy_is_511kev(mod):
     """Electron rest energy must be ~511 keV (510999 eV)."""
     assert abs(mod["e_c"] - 510999.0) < 1.0
 
+
 def test_hydrogen_has_6_shells(mod):
     assert len(mod["hydrogen_ev"]) == 6
 
+
 def test_hydrogen_ground_state_equals_rydberg(mod):
     assert abs(mod["hydrogen_ev"][0] - mod["rydberg"]) < 1e-9
+
 
 def test_hydrogen_shells_monotone_decreasing(mod):
     ev = mod["hydrogen_ev"]
@@ -82,18 +89,22 @@ def test_hydrogen_shells_monotone_decreasing(mod):
 
 # ── run_all ───────────────────────────────────────────────────────────────────
 
+
 def test_run_all_returns_six_theories(mod):
     results = mod["run_all"]()
     assert len(results) == 6
+
 
 def test_run_all_has_expected_keys(mod):
     results = mod["run_all"]()
     expected = {"compton_orbital", "bohr", "de_broglie", "geoseed_lb", "harmonic", "pilot_wave"}
     assert set(results.keys()) == expected
 
+
 def test_run_all_all_have_six_shells(mod):
     for name, result in mod["run_all"]().items():
         assert len(result.shells) == 6, f"{name} has {len(result.shells)} shells"
+
 
 def test_run_all_shell_tongues_ordered(mod):
     for name, result in mod["run_all"]().items():
@@ -103,19 +114,20 @@ def test_run_all_shell_tongues_ordered(mod):
 
 # ── Bohr model ────────────────────────────────────────────────────────────────
 
+
 def test_bohr_energies_match_hydrogen(mod):
     """Bohr is the reference — all residuals should be ~0."""
     result = mod["bohr"]()
     for shell in result.shells:
         n = shell.shell_index + 1
         expected = mod["rydberg"] / (n**2)
-        assert abs(shell.energy_ev - expected) < 1e-6, (
-            f"Bohr shell {n}: {shell.energy_ev} ≠ {expected}"
-        )
+        assert abs(shell.energy_ev - expected) < 1e-6, f"Bohr shell {n}: {shell.energy_ev} ≠ {expected}"
+
 
 def test_bohr_rms_residual_near_zero(mod):
     result = mod["bohr"]()
     assert result.rms_residual_ev < 1e-6
+
 
 def test_bohr_frequencies_decreasing(mod):
     """Higher shells have lower orbital frequency in Bohr model."""
@@ -126,11 +138,13 @@ def test_bohr_frequencies_decreasing(mod):
 
 # ── Compton orbital model ─────────────────────────────────────────────────────
 
+
 def test_compton_orbital_ko_matches_rydberg(mod):
     """KO (shell 0) anchored to Rydberg energy."""
     result = mod["compton"]()
     ko = result.shells[0]
     assert abs(ko.energy_ev - mod["rydberg"]) < 1e-9
+
 
 def test_compton_orbital_phi_scaling(mod):
     """Each successive shell energy = previous / φ."""
@@ -138,9 +152,8 @@ def test_compton_orbital_phi_scaling(mod):
     evs = [s.energy_ev for s in result.shells]
     for i in range(1, 6):
         ratio = evs[i - 1] / evs[i]
-        assert abs(ratio - PHI) < 1e-6, (
-            f"Shell {i-1}→{i} energy ratio {ratio} ≠ φ={PHI}"
-        )
+        assert abs(ratio - PHI) < 1e-6, f"Shell {i-1}→{i} energy ratio {ratio} ≠ φ={PHI}"
+
 
 def test_compton_frequency_phi_scaling(mod):
     """Each successive shell frequency = previous / φ."""
@@ -148,14 +161,14 @@ def test_compton_frequency_phi_scaling(mod):
     freqs = result.frequencies_hz()
     for i in range(1, 6):
         ratio = freqs[i - 1] / freqs[i]
-        assert abs(ratio - PHI) < 1e-6, (
-            f"Shell {i-1}→{i} frequency ratio {ratio} ≠ φ={PHI}"
-        )
+        assert abs(ratio - PHI) < 1e-6, f"Shell {i-1}→{i} frequency ratio {ratio} ≠ φ={PHI}"
+
 
 def test_compton_frequencies_monotone_decreasing(mod):
     freqs = mod["compton"]().frequencies_hz()
     for i in range(1, 6):
         assert freqs[i] < freqs[i - 1]
+
 
 def test_compton_energies_monotone_decreasing(mod):
     evs = mod["compton"]().energies_ev()
@@ -165,20 +178,23 @@ def test_compton_energies_monotone_decreasing(mod):
 
 # ── GeoSeed LB model ──────────────────────────────────────────────────────────
 
+
 def test_geoseed_lb_ko_equals_rydberg(mod):
     result = mod["lb"]()
     assert abs(result.shells[0].energy_ev - mod["rydberg"]) < 1e-9
+
 
 def test_geoseed_lb_energies_grow_as_squares(mod):
     """LB ladder: E_l / E_0 = (l+1)² / 1."""
     result = mod["lb"]()
     e0 = result.shells[0].energy_ev
     for l, shell in enumerate(result.shells):
-        expected_ratio = (l + 1)**2
+        expected_ratio = (l + 1) ** 2
         actual_ratio = shell.energy_ev / e0
-        assert abs(actual_ratio - expected_ratio) < 1e-6, (
-            f"l={l}: energy ratio {actual_ratio} ≠ (l+1)²={expected_ratio}"
-        )
+        assert (
+            abs(actual_ratio - expected_ratio) < 1e-6
+        ), f"l={l}: energy ratio {actual_ratio} ≠ (l+1)²={expected_ratio}"
+
 
 def test_geoseed_lb_energies_monotone_increasing(mod):
     """LB model predicts more energy for outer shells (unlike Bohr)."""
@@ -189,9 +205,11 @@ def test_geoseed_lb_energies_monotone_increasing(mod):
 
 # ── Harmonic model ────────────────────────────────────────────────────────────
 
+
 def test_harmonic_ko_equals_rydberg(mod):
     result = mod["harmonic"]()
     assert abs(result.shells[0].energy_ev - mod["rydberg"]) < 1e-9
+
 
 def test_harmonic_energies_linearly_increasing(mod):
     """Harmonic oscillator: E_n ∝ n+½ — nearly linear in shell index."""
@@ -202,9 +220,11 @@ def test_harmonic_energies_linearly_increasing(mod):
 
 # ── de Broglie model ──────────────────────────────────────────────────────────
 
+
 def test_de_broglie_six_shells(mod):
     result = mod["de_broglie"]()
     assert len(result.shells) == 6
+
 
 def test_de_broglie_all_energies_positive(mod):
     result = mod["de_broglie"]()
@@ -214,40 +234,40 @@ def test_de_broglie_all_energies_positive(mod):
 
 # ── Pilot wave model ──────────────────────────────────────────────────────────
 
+
 def test_pilot_wave_six_shells(mod):
     result = mod["pilot_wave"]()
     assert len(result.shells) == 6
+
 
 def test_pilot_wave_energies_decrease_outward(mod):
     """Quantum potential E ∝ 1/r² — outer shells have lower energy."""
     evs = mod["pilot_wave"]().energies_ev()
     for i in range(1, 6):
-        assert evs[i] < evs[i - 1], (
-            f"Pilot wave energy not decreasing at shell {i}: {evs[i]} >= {evs[i-1]}"
-        )
+        assert evs[i] < evs[i - 1], f"Pilot wave energy not decreasing at shell {i}: {evs[i]} >= {evs[i-1]}"
 
 
 # ── Cross-theory invariants ───────────────────────────────────────────────────
 
+
 def test_all_energies_positive_finite(mod):
     for name, result in mod["run_all"]().items():
         for s in result.shells:
-            assert s.energy_ev > 0 and math.isfinite(s.energy_ev), (
-                f"{name} shell {s.shell_index}: E={s.energy_ev}"
-            )
+            assert s.energy_ev > 0 and math.isfinite(s.energy_ev), f"{name} shell {s.shell_index}: E={s.energy_ev}"
+
 
 def test_all_frequencies_positive_finite(mod):
     for name, result in mod["run_all"]().items():
         for s in result.shells:
-            assert s.frequency_hz > 0 and math.isfinite(s.frequency_hz), (
-                f"{name} shell {s.shell_index}: f={s.frequency_hz}"
-            )
+            assert s.frequency_hz > 0 and math.isfinite(
+                s.frequency_hz
+            ), f"{name} shell {s.shell_index}: f={s.frequency_hz}"
+
 
 def test_all_rms_residuals_finite(mod):
     for name, result in mod["run_all"]().items():
-        assert math.isfinite(result.rms_residual_ev), (
-            f"{name}: RMS residual is not finite"
-        )
+        assert math.isfinite(result.rms_residual_ev), f"{name}: RMS residual is not finite"
+
 
 def test_bohr_rms_lowest_by_definition(mod):
     """Bohr is the reference — it should have the lowest RMS (zero)."""
@@ -255,9 +275,11 @@ def test_bohr_rms_lowest_by_definition(mod):
     bohr_rms = results["bohr"].rms_residual_ev
     assert bohr_rms < 1e-6
 
+
 def test_ko_shell_is_tongue_KO(mod):
     for name, result in mod["run_all"]().items():
         assert result.shells[0].tongue == "KO", f"{name} shell 0 not KO"
+
 
 def test_dr_shell_is_tongue_DR(mod):
     for name, result in mod["run_all"]().items():
@@ -265,6 +287,7 @@ def test_dr_shell_is_tongue_DR(mod):
 
 
 # ── Serialization ─────────────────────────────────────────────────────────────
+
 
 def test_to_dict_schema_version(mod):
     for name, result in mod["run_all"]().items():
@@ -274,12 +297,21 @@ def test_to_dict_schema_version(mod):
         assert "rms_residual_ev" in d
         assert len(d["shells"]) == 6
 
+
 def test_to_dict_shell_has_required_keys(mod):
     result = mod["compton"]()
     shell_dict = result.to_dict()["shells"][0]
-    required = {"tongue", "shell", "energy_ev", "frequency_hz",
-                "orbital_radius_m", "residual_ev", "hydrogen_measured_ev"}
+    required = {
+        "tongue",
+        "shell",
+        "energy_ev",
+        "frequency_hz",
+        "orbital_radius_m",
+        "residual_ev",
+        "hydrogen_measured_ev",
+    }
     assert required.issubset(set(shell_dict.keys()))
+
 
 def test_to_dict_compton_ko_residual_zero(mod):
     """KO shell: compton_orbital anchored to Bohr n=1, so residual should be 0."""
@@ -291,16 +323,19 @@ def test_to_dict_compton_ko_residual_zero(mod):
 
 # ── Comparison table ──────────────────────────────────────────────────────────
 
+
 def test_comparison_table_non_empty(mod):
     results = mod["run_all"]()
     table = mod["table"](results)
     assert len(table) > 200
+
 
 def test_comparison_table_has_all_theory_names(mod):
     results = mod["run_all"]()
     table = mod["table"](results)
     for name in results:
         assert name in table, f"Theory {name} missing from table"
+
 
 def test_comparison_table_has_tongue_headers(mod):
     results = mod["run_all"]()

--- a/tests/geoseed/test_theory_fit.py
+++ b/tests/geoseed/test_theory_fit.py
@@ -32,6 +32,7 @@ def mod():
         OBSERVABLE_A_BINDING,
         OBSERVABLE_B_CURVATURE,
     )
+
     return {
         "fit_all": fit_all_theories,
         "crossover": crossover_analysis,
@@ -61,17 +62,21 @@ def comb(mod):
 
 # ── Power-law fitter unit tests ───────────────────────────────────────────────
 
+
 def test_power_law_recovers_bohr(mod):
     """Fitting exact Bohr values should return p ≈ 2."""
     from src.geoseed.theory_comparison import RYDBERG_EV
-    evs = [RYDBERG_EV / ((n + 1)**2) for n in range(6)]
+
+    evs = [RYDBERG_EV / ((n + 1) ** 2) for n in range(6)]
     A, delta, p, rms = mod["fit_pl"](evs)
     assert abs(p - 2.0) < 0.05, f"Bohr power-law p={p} should be near 2"
     assert rms < 0.01, f"Bohr fit rms={rms} unexpectedly large"
 
+
 def test_exponential_recovers_phi_decay(mod):
     """Fitting phi-decay series should return λ ≈ φ."""
     from src.geoseed.theory_comparison import RYDBERG_EV
+
     evs = [RYDBERG_EV / (PHI**n) for n in range(6)]
     A, lam, rms = mod["fit_exp"](evs)
     assert abs(lam - PHI) < 0.01, f"Compton exp λ={lam} should be near φ={PHI}"
@@ -80,15 +85,19 @@ def test_exponential_recovers_phi_decay(mod):
 
 # ── Bohr fit ──────────────────────────────────────────────────────────────────
 
+
 def test_bohr_power_law_p_near_2(fits):
     f = fits["bohr"]
     assert abs(f.pl_p - 2.0) < 0.1, f"Bohr PL p={f.pl_p} expected ~2"
 
+
 def test_bohr_observable_is_binding(fits):
     assert fits["bohr"].observable == "binding"
 
+
 def test_bohr_pl_rms_small(fits):
     assert fits["bohr"].pl_rms < 0.1
+
 
 def test_bohr_fit_rms_finite(fits):
     assert math.isfinite(fits["bohr"].pl_rms)
@@ -97,21 +106,21 @@ def test_bohr_fit_rms_finite(fits):
 
 # ── Compton-orbital fit ───────────────────────────────────────────────────────
 
+
 def test_compton_exp_lambda_near_phi(fits):
     f = fits["compton_orbital"]
-    assert abs(f.exp_lambda - PHI) < 0.05, (
-        f"Compton exp λ={f.exp_lambda:.4f} should be near φ={PHI:.4f}"
-    )
+    assert abs(f.exp_lambda - PHI) < 0.05, f"Compton exp λ={f.exp_lambda:.4f} should be near φ={PHI:.4f}"
+
 
 def test_compton_better_fit_is_exponential(fits):
     """The phi-decay IS an exponential — exponential fit should win."""
     f = fits["compton_orbital"]
-    assert f.better_fit == "exponential", (
-        f"Expected exponential to win for Compton, got {f.better_fit}"
-    )
+    assert f.better_fit == "exponential", f"Expected exponential to win for Compton, got {f.better_fit}"
+
 
 def test_compton_observable_is_binding(fits):
     assert fits["compton_orbital"].observable == "binding"
+
 
 def test_compton_exp_rms_smaller_than_pl_rms(fits):
     f = fits["compton_orbital"]
@@ -120,12 +129,12 @@ def test_compton_exp_rms_smaller_than_pl_rms(fits):
 
 # ── GeoSeed LB fit ────────────────────────────────────────────────────────────
 
+
 def test_geoseed_lb_power_law_p_negative(fits):
     """LB grows outward → fitted power-law exponent p must be negative."""
     f = fits["geoseed_lb"]
-    assert f.pl_p < 0, (
-        f"GeoSeed LB PL p={f.pl_p:.4f} should be negative (grows outward)"
-    )
+    assert f.pl_p < 0, f"GeoSeed LB PL p={f.pl_p:.4f} should be negative (grows outward)"
+
 
 def test_geoseed_lb_observable_is_curvature(fits):
     assert fits["geoseed_lb"].observable == "curvature"
@@ -133,35 +142,30 @@ def test_geoseed_lb_observable_is_curvature(fits):
 
 # ── Observable classification ─────────────────────────────────────────────────
 
+
 def test_all_binding_theories_classified(fits, mod):
     for name in mod["obs_a"]:
-        assert fits[name].observable == "binding", (
-            f"{name} classified as {fits[name].observable}, expected binding"
-        )
+        assert fits[name].observable == "binding", f"{name} classified as {fits[name].observable}, expected binding"
+
 
 def test_all_curvature_theories_classified(fits, mod):
     for name in mod["obs_b"]:
-        assert fits[name].observable == "curvature", (
-            f"{name} classified as {fits[name].observable}, expected curvature"
-        )
+        assert fits[name].observable == "curvature", f"{name} classified as {fits[name].observable}, expected curvature"
+
 
 def test_no_theory_is_both(fits):
     for name, f in fits.items():
-        assert f.observable in ("binding", "curvature"), (
-            f"{name} has unknown observable: {f.observable}"
-        )
+        assert f.observable in ("binding", "curvature"), f"{name} has unknown observable: {f.observable}"
 
 
 # ── All fits are finite ───────────────────────────────────────────────────────
 
+
 def test_all_fit_rms_finite_nonneg(fits):
     for name, f in fits.items():
-        assert math.isfinite(f.pl_rms) and f.pl_rms >= 0, (
-            f"{name} PL rms={f.pl_rms}"
-        )
-        assert math.isfinite(f.exp_rms) and f.exp_rms >= 0, (
-            f"{name} exp rms={f.exp_rms}"
-        )
+        assert math.isfinite(f.pl_rms) and f.pl_rms >= 0, f"{name} PL rms={f.pl_rms}"
+        assert math.isfinite(f.exp_rms) and f.exp_rms >= 0, f"{name} exp rms={f.exp_rms}"
+
 
 def test_all_fit_lambdas_positive(fits):
     for name, f in fits.items():
@@ -170,64 +174,66 @@ def test_all_fit_lambdas_positive(fits):
 
 # ── Crossover analysis ────────────────────────────────────────────────────────
 
+
 def test_crossover_has_six_shells(cx):
     assert len(cx.shell_ratios) == 6
     assert len(cx.divergence_pct) == 6
+
 
 def test_crossover_shell0_ratio_near_one(cx):
     """Both anchored at shell 0 = Rydberg, so ratio must be exactly 1."""
     assert abs(cx.shell_ratios[0] - 1.0) < 1e-9
 
+
 def test_crossover_all_outer_ratios_above_one(cx):
     """Compton retains more energy than Bohr at all outer shells."""
     for i in range(1, 6):
-        assert cx.shell_ratios[i] > 1.0, (
-            f"Shell {i} ratio={cx.shell_ratios[i]:.4f} expected > 1"
-        )
+        assert cx.shell_ratios[i] > 1.0, f"Shell {i} ratio={cx.shell_ratios[i]:.4f} expected > 1"
+
 
 def test_crossover_first_significant_shell_is_one(cx):
     """Divergence >50% appears immediately at shell 1 (AV, p-orbital)."""
-    assert cx.first_significant_shell == 1, (
-        f"Expected first_significant_shell=1, got {cx.first_significant_shell}"
-    )
+    assert cx.first_significant_shell == 1, f"Expected first_significant_shell=1, got {cx.first_significant_shell}"
+
 
 def test_crossover_peak_ratio_above_3(cx):
     """At peak, Compton retains >3x Bohr energy."""
     assert cx.peak_ratio > 3.0, f"Peak ratio={cx.peak_ratio:.2f} expected > 3"
 
+
 def test_crossover_notes_non_empty(cx):
     assert len(cx.notes) > 50
 
+
 def test_crossover_compton_always_higher(cx):
     for i in range(6):
-        assert cx.compton_ev[i] >= cx.bohr_ev[i], (
-            f"Shell {i}: Compton={cx.compton_ev[i]} < Bohr={cx.bohr_ev[i]}"
-        )
+        assert cx.compton_ev[i] >= cx.bohr_ev[i], f"Shell {i}: Compton={cx.compton_ev[i]} < Bohr={cx.bohr_ev[i]}"
 
 
 # ── Combined energy model ─────────────────────────────────────────────────────
 
+
 def test_combined_has_six_shells(comb):
     assert len(comb.total_ev) == 6
+
 
 def test_combined_total_gt_bind(comb):
     """E_total must exceed E_bind at every shell (curvature is additive)."""
     for i in range(6):
-        assert comb.total_ev[i] > comb.bind_ev[i], (
-            f"Shell {i}: total={comb.total_ev[i]} not > bind={comb.bind_ev[i]}"
-        )
+        assert comb.total_ev[i] > comb.bind_ev[i], f"Shell {i}: total={comb.total_ev[i]} not > bind={comb.bind_ev[i]}"
+
 
 def test_combined_curv_fraction_increasing(comb):
     """LB grows faster than Compton-bind → curvature fraction must grow outward."""
     fracs = comb.curv_fraction
     for i in range(1, 6):
-        assert fracs[i] > fracs[i - 1], (
-            f"curv_fraction not increasing at shell {i}: {fracs[i]:.4f} <= {fracs[i-1]:.4f}"
-        )
+        assert fracs[i] > fracs[i - 1], f"curv_fraction not increasing at shell {i}: {fracs[i]:.4f} <= {fracs[i-1]:.4f}"
+
 
 def test_combined_all_totals_positive(comb):
     for i, e in enumerate(comb.total_ev):
         assert e > 0, f"Shell {i} total_ev={e}"
+
 
 def test_combined_schema_version(comb):
     d = comb.to_dict()
@@ -236,6 +242,7 @@ def test_combined_schema_version(comb):
 
 
 # ── Serialisation ─────────────────────────────────────────────────────────────
+
 
 def test_fit_to_dict_has_required_keys(fits):
     for name, f in fits.items():
@@ -247,6 +254,7 @@ def test_fit_to_dict_has_required_keys(fits):
         assert "exponential" in d
         assert "lambda_vs_phi" in d["exponential"]
 
+
 def test_fit_report_non_empty(mod):
     report = mod["report"]()
     assert len(report) > 500
@@ -257,30 +265,36 @@ def test_fit_report_non_empty(mod):
 
 # ── Independent dual fit ──────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="module")
 def dual(mod):
     from src.geoseed.theory_fit import independent_dual_fit
+
     return independent_dual_fit()
+
 
 def test_dual_bind_p_near_2(dual):
     """Binding fit must converge to p ≈ 2 without being told (1/n²)."""
     assert dual.p_near_2, f"bind_p={dual.bind_p:.4f} not near 2"
 
+
 def test_dual_curv_q_near_2(dual):
     """Curvature fit must converge to q ≈ 2 without being told ((l+1)²)."""
     assert dual.q_near_2, f"curv_q={dual.curv_q:.4f} not near 2"
 
+
 def test_dual_product_cv_low(dual):
     """Product I(l) should be near-flat after independent fit."""
-    assert dual.product_cv < 0.5, (
-        f"Product CV={dual.product_cv:.4f}; not a clean invariant"
-    )
+    assert dual.product_cv < 0.5, f"Product CV={dual.product_cv:.4f}; not a clean invariant"
+
 
 def test_dual_bind_rms_small(dual):
     assert dual.bind_rms < 0.05, f"bind rms={dual.bind_rms:.6f} too high"
 
+
 def test_dual_curv_rms_small(dual):
     assert dual.curv_rms < 0.05, f"curv rms={dual.curv_rms:.6f} too high"
+
 
 def test_dual_to_dict_has_schema(dual):
     d = dual.to_dict()
@@ -290,25 +304,30 @@ def test_dual_to_dict_has_schema(dual):
 
 # ── Product invariant ─────────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="module")
 def inv():
     from src.geoseed.theory_fit import compute_product_invariant
+
     return compute_product_invariant()
+
 
 def test_invariant_has_six_shells(inv):
     assert len(inv.shell_values) == 6
+
 
 def test_invariant_is_flat(inv):
     """I(l) = E_bind * E_curv should be exactly flat when both use same anchor."""
     assert inv.is_flat, f"Product invariant CV={inv.cv:.2e} not flat"
 
+
 def test_invariant_equals_rydberg_sq(inv):
     """Product must equal RYDBERG² ≈ 185.11 eV² when both anchored the same."""
     from src.geoseed.theory_comparison import RYDBERG_EV
+
     for i, v in enumerate(inv.shell_values):
-        assert abs(v - RYDBERG_EV**2) < 1e-6, (
-            f"Shell {i}: I(l)={v:.6f} ≠ Rydberg²={RYDBERG_EV**2:.6f}"
-        )
+        assert abs(v - RYDBERG_EV**2) < 1e-6, f"Shell {i}: I(l)={v:.6f} ≠ Rydberg²={RYDBERG_EV**2:.6f}"
+
 
 def test_invariant_to_dict(inv):
     d = inv.to_dict()
@@ -320,29 +339,37 @@ def test_invariant_to_dict(inv):
 
 # ── Weighted sum fit ──────────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="module")
 def ws():
     from src.geoseed.theory_fit import weighted_sum_fit
+
     return weighted_sum_fit()
+
 
 def test_ws_better_form_is_valid(ws):
     assert ws.better_form in ("linear", "log_additive")
 
+
 def test_ws_lin_rms_finite(ws):
     assert math.isfinite(ws.lin_rms) and ws.lin_rms >= 0
+
 
 def test_ws_log_rms_finite(ws):
     assert math.isfinite(ws.log_rms_ev) and ws.log_rms_ev >= 0
 
+
 def test_ws_six_shells(ws):
     assert len(ws.linear_predictions) == 6
     assert len(ws.logadd_predictions) == 6
+
 
 def test_ws_to_dict_schema(ws):
     d = ws.to_dict()
     assert d["schema_version"] == "geoseed_weighted_sum_v1"
     assert "linear" in d and "log_additive" in d
     assert d["better_form"] in ("linear", "log_additive")
+
 
 def test_ws_alpha_beta_finite(ws):
     assert math.isfinite(ws.alpha_lin) and math.isfinite(ws.beta_lin)
@@ -351,8 +378,10 @@ def test_ws_alpha_beta_finite(ws):
 
 # ── Duality report ────────────────────────────────────────────────────────────
 
+
 def test_duality_report_non_empty():
     from src.geoseed.theory_fit import duality_report
+
     report = duality_report()
     assert len(report) > 400
     assert "INDEPENDENT DUAL FIT" in report

--- a/tests/geoseed/test_transfer_recorder.py
+++ b/tests/geoseed/test_transfer_recorder.py
@@ -10,9 +10,14 @@ LN_PHI = math.log(PHI)
 @pytest.fixture
 def mod():
     from src.geoseed.transfer_recorder import (
-        AtomTransferRecorder, transfer_cost, TransferMatrix,
-        TONGUE_ORDER, TONGUE_INDEX, LN_PHI as MODEL_LN_PHI,
+        AtomTransferRecorder,
+        transfer_cost,
+        TransferMatrix,
+        TONGUE_ORDER,
+        TONGUE_INDEX,
+        LN_PHI as MODEL_LN_PHI,
     )
+
     return {
         "Recorder": AtomTransferRecorder,
         "cost": transfer_cost,
@@ -22,6 +27,7 @@ def mod():
         "ln_phi": MODEL_LN_PHI,
     }
 
+
 @pytest.fixture
 def rec(mod):
     return mod["Recorder"](session_id="test")
@@ -29,9 +35,11 @@ def rec(mod):
 
 # ── transfer_cost ─────────────────────────────────────────────────────────────
 
+
 def test_cost_self_is_zero(mod):
     for t in mod["order"]:
         assert mod["cost"](t, t) == 0.0
+
 
 def test_cost_adjacent_equals_ln_phi(mod):
     pairs = list(zip(mod["order"], mod["order"][1:]))
@@ -39,11 +47,14 @@ def test_cost_adjacent_equals_ln_phi(mod):
         assert abs(mod["cost"](a, b) - LN_PHI) < 1e-12
         assert abs(mod["cost"](b, a) - LN_PHI) < 1e-12
 
+
 def test_cost_symmetric(mod):
     assert abs(mod["cost"]("KO", "DR") - mod["cost"]("DR", "KO")) < 1e-12
 
+
 def test_cost_ko_to_dr_is_5_ln_phi(mod):
     assert abs(mod["cost"]("KO", "DR") - 5 * LN_PHI) < 1e-12
+
 
 def test_cost_unknown_tongue_raises(mod):
     with pytest.raises(ValueError):
@@ -52,10 +63,12 @@ def test_cost_unknown_tongue_raises(mod):
 
 # ── record + basic queries ────────────────────────────────────────────────────
 
+
 def test_empty_recorder(rec):
     assert rec.event_count == 0
     assert rec.total_geodesic_cost() == 0.0
     assert rec.mean_hop_distance() == 0.0
+
 
 def test_record_single_event(rec):
     evt = rec.record("KO", "AV", "def")
@@ -67,14 +80,17 @@ def test_record_single_event(rec):
     assert evt.is_self is False
     assert evt.step == 0
 
+
 def test_record_self_transfer(rec):
     evt = rec.record("CA", "CA", "heapq")
     assert evt.is_self is True
     assert evt.geodesic_cost == 0.0
 
+
 def test_record_batch(rec):
     rec.record_batch([("KO", "AV", "x"), ("AV", "RU", "y"), ("RU", "CA", "z")])
     assert rec.event_count == 3
+
 
 def test_steps_increment(rec):
     rec.record("KO", "AV", "a")
@@ -82,10 +98,12 @@ def test_steps_increment(rec):
     steps = [e.step for e in rec.events]
     assert steps == [0, 1]
 
+
 def test_reset_clears(rec):
     rec.record("KO", "AV", "tok")
     rec.reset()
     assert rec.event_count == 0
+
 
 def test_events_for_token(rec):
     rec.record("KO", "AV", "import")
@@ -94,16 +112,19 @@ def test_events_for_token(rec):
     evts = rec.events_for_token("import")
     assert len(evts) == 2
 
+
 def test_events_from(rec):
     rec.record("KO", "AV", "a")
     rec.record("KO", "CA", "b")
     rec.record("AV", "RU", "c")
     assert len(rec.events_from("KO")) == 2
 
+
 def test_events_to(rec):
     rec.record("KO", "AV", "a")
     rec.record("RU", "AV", "b")
     assert len(rec.events_to("AV")) == 2
+
 
 def test_unknown_tongue_raises(rec):
     with pytest.raises(ValueError):
@@ -112,19 +133,22 @@ def test_unknown_tongue_raises(rec):
 
 # ── geodesic cost accumulation ────────────────────────────────────────────────
 
+
 def test_total_geodesic_cost(rec):
-    rec.record("KO", "AV", "a")   # 1·ln(φ)
-    rec.record("AV", "CA", "b")   # 2·ln(φ)
-    rec.record("KO", "KO", "c")   # 0
+    rec.record("KO", "AV", "a")  # 1·ln(φ)
+    rec.record("AV", "CA", "b")  # 2·ln(φ)
+    rec.record("KO", "KO", "c")  # 0
     expected = 3 * LN_PHI
     assert abs(rec.total_geodesic_cost() - expected) < 1e-12
 
+
 def test_mean_hop_excludes_self(rec):
-    rec.record("KO", "AV", "a")   # 1·ln(φ)
-    rec.record("AV", "DR", "b")   # 4·ln(φ)
-    rec.record("KO", "KO", "c")   # self — excluded from mean
+    rec.record("KO", "AV", "a")  # 1·ln(φ)
+    rec.record("AV", "DR", "b")  # 4·ln(φ)
+    rec.record("KO", "KO", "c")  # self — excluded from mean
     expected_mean = (1 + 4) * LN_PHI / 2
     assert abs(rec.mean_hop_distance() - expected_mean) < 1e-12
+
 
 def test_mean_hop_all_self_returns_zero(rec):
     rec.record("CA", "CA", "x")
@@ -134,11 +158,13 @@ def test_mean_hop_all_self_returns_zero(rec):
 
 # ── transfer matrix ───────────────────────────────────────────────────────────
 
+
 def test_matrix_shape_is_6x6(rec, mod):
     rec.record("KO", "AV", "tok")
     mx = rec.transfer_matrix()
     assert len(mx.counts) == 6
     assert all(len(row) == 6 for row in mx.counts)
+
 
 def test_matrix_counts_correct(rec):
     rec.record("KO", "AV", "a")
@@ -149,10 +175,12 @@ def test_matrix_counts_correct(rec):
     assert mx.counts[1][2] == 1  # AV→RU
     assert mx.counts[1][0] == 0  # AV→KO = 0
 
+
 def test_matrix_total_events(rec):
     rec.record_batch([("KO", "AV", "a"), ("RU", "CA", "b"), ("DR", "DR", "c")])
     mx = rec.transfer_matrix()
     assert mx.total_events == 3
+
 
 def test_matrix_self_cross_split(rec):
     rec.record("KO", "KO", "self1")
@@ -162,12 +190,14 @@ def test_matrix_self_cross_split(rec):
     assert mx.self_transfer_count == 2
     assert mx.cross_transfer_count == 1
 
+
 def test_matrix_rates_row_normalised(rec):
     rec.record("KO", "AV", "a")
     rec.record("KO", "CA", "b")
     mx = rec.transfer_matrix()
     row_sum = sum(mx.rates[0])  # KO row
     assert abs(row_sum - 1.0) < 1e-9
+
 
 def test_matrix_costs_are_n_ln_phi(rec, mod):
     rec.record("KO", "AV", "tok")
@@ -177,23 +207,31 @@ def test_matrix_costs_are_n_ln_phi(rec, mod):
             expected = abs(i - j) * LN_PHI
             assert abs(mx.costs[i][j] - expected) < 1e-12
 
+
 def test_matrix_costs_diagonal_zero(rec, mod):
     rec.record("KO", "AV", "tok")
     mx = rec.transfer_matrix()
     for i in range(6):
         assert mx.costs[i][i] == 0.0
 
+
 def test_dominant_flow_excludes_self(rec):
-    rec.record_batch([
-        ("KO", "KO", "s1"), ("KO", "KO", "s2"),  # self — should NOT appear
-        ("KO", "AV", "c1"), ("KO", "AV", "c2"), ("KO", "AV", "c3"),
-    ])
+    rec.record_batch(
+        [
+            ("KO", "KO", "s1"),
+            ("KO", "KO", "s2"),  # self — should NOT appear
+            ("KO", "AV", "c1"),
+            ("KO", "AV", "c2"),
+            ("KO", "AV", "c3"),
+        ]
+    )
     mx = rec.transfer_matrix()
     flows = mx.dominant_flow()
     froms = [f for f, t, c in flows]
-    tos   = [t for f, t, c in flows]
+    tos = [t for f, t, c in flows]
     for f, t in zip(froms, tos):
         assert f != t
+
 
 def test_empty_matrix_total_zero(mod):
     rec = mod["Recorder"]()
@@ -205,21 +243,25 @@ def test_empty_matrix_total_zero(mod):
 
 # ── serialisation ─────────────────────────────────────────────────────────────
 
+
 def test_to_dict_schema_version(rec):
     rec.record("KO", "AV", "tok")
     d = rec.to_dict()
     assert d["schema_version"] == "geoseed_transfer_recorder_v1"
+
 
 def test_to_dict_matrix_schema_version(rec):
     rec.record("KO", "AV", "tok")
     d = rec.to_dict()
     assert d["matrix"]["schema_version"] == "geoseed_transfer_matrix_v1"
 
+
 def test_summary_string_non_empty(rec):
     rec.record("KO", "AV", "tok")
     s = rec.summary()
     assert len(s) > 50
     assert "KO" in s
+
 
 def test_summary_empty_recorder(rec):
     s = rec.summary()

--- a/tests/longform/test_context_bridge.py
+++ b/tests/longform/test_context_bridge.py
@@ -41,8 +41,8 @@ from src.longform.context_bridge import (
     validate_principles,
 )
 
-
 # ── Fixtures ──────────────────────────────────────────────────────────────────
+
 
 @pytest.fixture
 def ws(tmp_path):
@@ -69,6 +69,7 @@ def ps():
 
 # ── PrincipleSet ──────────────────────────────────────────────────────────────
 
+
 def test_principle_set_roundtrip(ps):
     d = ps.to_dict()
     restored = PrincipleSet.from_dict(d)
@@ -93,11 +94,17 @@ def test_principle_set_empty_lists():
 
 # ── LedgerEvent / hash chain ──────────────────────────────────────────────────
 
+
 def test_ledger_event_hash_deterministic():
     ev = LedgerEvent(
-        event_id="test-id", kind="brick", ts="2026-01-01T00:00:00Z",
-        sequence=1, previous_hash=None, parent_hashes=[],
-        payload={"mission": "x"}, event_hash="",
+        event_id="test-id",
+        kind="brick",
+        ts="2026-01-01T00:00:00Z",
+        sequence=1,
+        previous_hash=None,
+        parent_hashes=[],
+        payload={"mission": "x"},
+        event_hash="",
     )
     h1 = ev.compute_hash()
     h2 = ev.compute_hash()
@@ -107,23 +114,38 @@ def test_ledger_event_hash_deterministic():
 
 def test_ledger_event_hash_changes_with_payload():
     ev = LedgerEvent(
-        event_id="test-id", kind="brick", ts="2026-01-01T00:00:00Z",
-        sequence=1, previous_hash=None, parent_hashes=[],
-        payload={"mission": "x"}, event_hash="",
+        event_id="test-id",
+        kind="brick",
+        ts="2026-01-01T00:00:00Z",
+        sequence=1,
+        previous_hash=None,
+        parent_hashes=[],
+        payload={"mission": "x"},
+        event_hash="",
     )
     ev2 = LedgerEvent(
-        event_id="test-id", kind="brick", ts="2026-01-01T00:00:00Z",
-        sequence=1, previous_hash=None, parent_hashes=[],
-        payload={"mission": "y"}, event_hash="",
+        event_id="test-id",
+        kind="brick",
+        ts="2026-01-01T00:00:00Z",
+        sequence=1,
+        previous_hash=None,
+        parent_hashes=[],
+        payload={"mission": "y"},
+        event_hash="",
     )
     assert ev.compute_hash() != ev2.compute_hash()
 
 
 def test_ledger_event_roundtrip():
     ev = LedgerEvent(
-        event_id="abc", kind="brick", ts="2026-01-01Z",
-        sequence=5, previous_hash="aaaa", parent_hashes=["bbbb"],
-        payload={"k": "v"}, event_hash="xxxx",
+        event_id="abc",
+        kind="brick",
+        ts="2026-01-01Z",
+        sequence=5,
+        previous_hash="aaaa",
+        parent_hashes=["bbbb"],
+        payload={"k": "v"},
+        event_hash="xxxx",
     )
     d = ev.to_dict()
     ev2 = LedgerEvent.from_dict(d)
@@ -135,6 +157,7 @@ def test_ledger_event_roundtrip():
 
 
 # ── JsonlWorkflowLedger ───────────────────────────────────────────────────────
+
 
 def test_new_ledger_creates_workspace(ws):
     ledger = new_ledger(ws, "Mission A")
@@ -230,6 +253,7 @@ def test_load_principles_none_when_missing(tmp_path):
 
 # ── ContextLanding ────────────────────────────────────────────────────────────
 
+
 def test_create_landing_persists_file(ledger):
     ps = ledger.load_principles()
     landing = create_landing(ledger, ps)
@@ -312,6 +336,7 @@ def test_load_landing_none_for_unknown(ledger):
 
 # ── ResumePack ────────────────────────────────────────────────────────────────
 
+
 def test_build_resume_pack_requires_landing(ledger):
     with pytest.raises(ValueError, match="No landings"):
         build_resume_pack(ledger)
@@ -351,6 +376,7 @@ def test_build_resume_pack_by_hash(ledger):
 
 
 # ── validate_principles ───────────────────────────────────────────────────────
+
 
 def test_validate_principles_passes_full_match():
     ps = PrincipleSet(
@@ -404,6 +430,7 @@ def test_validate_principles_case_insensitive():
 
 
 # ── Agent spawn/list ──────────────────────────────────────────────────────────
+
 
 def test_agent_save_and_list(ledger):
     contract = {

--- a/tests/longform/test_longform_cli_squad.py
+++ b/tests/longform/test_longform_cli_squad.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 CLI = ROOT / "src" / "longform" / "longform_cli.py"
 

--- a/tests/test_audio_field_observables.py
+++ b/tests/test_audio_field_observables.py
@@ -57,9 +57,7 @@ def test_magnetoelastic_model_emits_bounded_coupling_proxy() -> None:
     observed = analyze_audio_field(
         generate_sine(440.0, sample_rate_hz=4096.0, duration_s=0.05),
         sample_rate_hz=4096.0,
-        model=AudioFieldModel(
-            kind="magnetoelastic", name="thin-film-saw", coupling_gain=0.8
-        ),
+        model=AudioFieldModel(kind="magnetoelastic", name="thin-film-saw", coupling_gain=0.8),
     )
 
     assert observed.field_relationship == "strain-magnetization coupling proxy"
@@ -86,10 +84,7 @@ def test_magnetosonic_model_requires_wave_speeds() -> None:
 
     assert missing.field_coupling_proxy is None
     assert "missing" in missing.field_relationship
-    assert (
-        with_speeds.field_relationship
-        == "compressibility-magnetic-pressure coupling proxy"
-    )
+    assert with_speeds.field_relationship == "compressibility-magnetic-pressure coupling proxy"
     assert with_speeds.field_coupling_proxy is not None
     assert 0.0 <= with_speeds.field_coupling_proxy <= 1.0
 
@@ -106,6 +101,4 @@ def test_modal_count_is_recoupled_to_integer_state() -> None:
 
     assert observed.modal_count >= 2
     assert observed.modal_count_state.ok is True
-    assert observed.modal_count_state.recoupled_value == pytest.approx(
-        float(observed.modal_count)
-    )
+    assert observed.modal_count_state.recoupled_value == pytest.approx(float(observed.modal_count))

--- a/tests/test_reaction_state_packet.py
+++ b/tests/test_reaction_state_packet.py
@@ -9,15 +9,9 @@ from python.scbe.reaction_state import (
 
 
 def test_bijective_packet_hash_verifies() -> None:
-    source = ReactionEndpoint(
-        identity="is_palindrome", representation="python:function", tongue="KO"
-    )
-    target = ReactionEndpoint(
-        identity="isPalindrome", representation="javascript:function", tongue="DR"
-    )
-    recalculation = ReactionRecalculation(
-        syntax_ok=True, tests_ok=True, identity_ok=True
-    )
+    source = ReactionEndpoint(identity="is_palindrome", representation="python:function", tongue="KO")
+    target = ReactionEndpoint(identity="isPalindrome", representation="javascript:function", tongue="DR")
+    recalculation = ReactionRecalculation(syntax_ok=True, tests_ok=True, identity_ok=True)
 
     packet = build_reaction_state_packet(
         domain="code",
@@ -69,9 +63,7 @@ def test_ambiguous_atom_bag_stays_ambiguous_without_recovery() -> None:
 
 
 def test_failed_recalculation_is_invalid() -> None:
-    recalculation = ReactionRecalculation(
-        syntax_ok=True, tests_ok=False, identity_ok=True
-    )
+    recalculation = ReactionRecalculation(syntax_ok=True, tests_ok=False, identity_ok=True)
 
     classification = classify_reaction(
         recalculation=recalculation,

--- a/tests/video_lattice/test_video_lattice.py
+++ b/tests/video_lattice/test_video_lattice.py
@@ -352,13 +352,18 @@ def test_ue5_bridge_send_correction_via_stub() -> None:
         sig = CorrectionSignal(
             frame_index=5,
             aggregate_drift=2.8,
-            cost_signal=1.618 ** (2.8 ** 2),
+            cost_signal=1.618 ** (2.8**2),
             axis_corrections={"motion": -1.2, "depth": -0.3},
             latent_nudge=None,
-            condition_signal={"severity": "moderate", "ue5": {"rerender_priority": 2,
-                              "apply_motion_blur_correction": True,
-                              "apply_depth_correction": False,
-                              "suggest_keyframe": False}},
+            condition_signal={
+                "severity": "moderate",
+                "ue5": {
+                    "rerender_priority": 2,
+                    "apply_motion_blur_correction": True,
+                    "apply_depth_correction": False,
+                    "suggest_keyframe": False,
+                },
+            },
             severity="moderate",
         )
         resp = bridge.send_correction(sig)
@@ -395,6 +400,7 @@ def test_ue5_bridge_send_pose_check_via_stub() -> None:
 # ------------------------------------------------------------------
 # Stub UE5 server for testing (no unreal dependency)
 # ------------------------------------------------------------------
+
 
 class _StubUE5Server:
     def __init__(self, port: int) -> None:
@@ -484,6 +490,7 @@ def test_world_director_apply_delta_move() -> None:
     initial_y = world.entities["hero"].y
 
     from src.video_lattice.gpt_world import WorldCommand, WorldDelta
+
     delta = WorldDelta(
         commands=[WorldCommand(type="move", data={"entity_id": "hero", "dx": 1, "dy": 0})],
         narrative="The hero steps east.",
@@ -501,6 +508,7 @@ def test_world_director_apply_delta_skips_solid_moves() -> None:
     director.model = "stub"
 
     from src.video_lattice.gpt_world import WorldCommand, WorldDelta
+
     # hero is at (2,2); wall is at (0,y) — move hero left until wall
     delta = WorldDelta(
         commands=[WorldCommand(type="move", data={"entity_id": "hero", "dx": -3, "dy": 0})],
@@ -520,6 +528,7 @@ def test_world_director_score_delta_no_op_is_zero() -> None:
     director.model = "stub"
 
     from src.video_lattice.gpt_world import WorldDelta
+
     delta = WorldDelta(commands=[], narrative="Nothing happens.", model="stub", raw_response="{}")
     drift = director.score_delta(world, delta)
     assert drift == pytest_approx(0.0)
@@ -531,6 +540,7 @@ def test_world_director_score_delta_move_is_positive() -> None:
     director.model = "stub"
 
     from src.video_lattice.gpt_world import WorldCommand, WorldDelta
+
     delta = WorldDelta(
         commands=[WorldCommand(type="move", data={"entity_id": "hero", "dx": 1, "dy": 0})],
         narrative="Hero moves.",
@@ -553,6 +563,7 @@ def test_round_table_director_picks_most_coherent() -> None:
             self.max_tokens = 64
             self._api_key = None
             self._client = None
+
         def step(self, world, note=""):
             return WorldDelta(commands=[], narrative="Nothing.", model=self.model, raw_response="{}")
 
@@ -563,6 +574,7 @@ def test_round_table_director_picks_most_coherent() -> None:
             self.max_tokens = 64
             self._api_key = None
             self._client = None
+
         def step(self, world, note=""):
             return WorldDelta(
                 commands=[WorldCommand(type="move", data={"entity_id": "hero", "dx": 1, "dy": 0})],


### PR DESCRIPTION
Fixes the CI \"Check Python formatting\" failure introduced when these files landed without black formatting. No logic changes.

Files: `src/geoseed/`, `src/harmonic/contact_lattice.py`, `src/longform/`, `src/geoseal_cli.py`, `src/video_lattice/`, `tests/benchmark/` (6 files), `tests/geoseed/`, `tests/longform/`, `tests/video_lattice/`, `tests/test_audio_field_observables.py`, `tests/test_reaction_state_packet.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for orbital model import error handling and shell duality perturbation scenarios.
  * Improved organization of test assertions across theory fitting, comparison, and transfer recording modules.
  * Added new self-transfer event validation test.

* **Chores**
  * Comprehensive code formatting and style improvements across the codebase for better readability and maintainability.
  * Aligned whitespace, line-wrapping, and indentation conventions consistently throughout modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->