### PR TITLE
fix(storage): make spin-voxel cost intensive (drop extensive Hamiltonian)

### DIFF
--- a/src/storage/spin_voxel.py
+++ b/src/storage/spin_voxel.py
@@ -148,7 +148,15 @@ def harmonic_scaling_spin_voxel(
     base = r ** (d**2)
     i_norm = max(intent_norm, cfg.epsilon)
     disorder = spin_disorder(spins, edges=edges, epsilon=cfg.epsilon)
-    h_spin = spin_hamiltonian(spins, edges=edges, config=cfg)
-    # Disorder drives penalty; Hamiltonian contributes soft stabilization signal.
-    spin_penalty = max(0.0, disorder + (h_spin / max(cfg.spin_reference, cfg.epsilon)))
+    # Penalty is the intensive per-edge disorder density (mean of 1 - cos over the
+    # edge set). Because it is normalized by edge count it is scale-free: the cost
+    # depends on the spin *configuration*, not the voxel count. The earlier term
+    # mixed in spin_hamiltonian(), an *extensive* magnetic energy (a sum over edges
+    # and sites). That sum grows with size and is signed, so at 16^3 it dominated
+    # the bounded cost and could drive it negative -- and a same-inventory shuffle
+    # null shows the magnetic structure is decorative for separation anyway
+    # (scripts/eval/spin_voxel_null_gate.py). The extensive term is therefore no
+    # longer fed into the cost; spin_hamiltonian() remains available as a physics
+    # observable for callers that want the raw energy.
+    spin_penalty = max(0.0, disorder)
     return base * (t_phase_factor(phase) / i_norm) * (1.0 + (cfg.alpha * spin_penalty))

--- a/tests/test_spin_voxel.py
+++ b/tests/test_spin_voxel.py
@@ -53,3 +53,21 @@ def test_harmonic_cost_increases_with_disorder() -> None:
         config=cfg,
     )
     assert cost_disordered >= cost_aligned
+
+
+def test_harmonic_cost_is_scale_free() -> None:
+    # Regression for the extensivity bug: the spin penalty is now the intensive
+    # per-edge disorder density, so a configuration with the same per-edge disorder
+    # yields the same cost regardless of how many voxels it spans. The earlier
+    # extensive Hamiltonian term made cost grow with size (and go negative at 16^3).
+    cfg = SpinVoxelConfig(alpha=0.5, spin_reference=2.0)
+    kwargs = {"d": 6.0, "r": 1.35, "intent_norm": 1.0, "phase": "fast", "config": cfg}
+
+    def alternating(n: int) -> list[tuple[float, float, float]]:
+        return [normalize_spin((1.0, 0.0, 0.0)), normalize_spin((-1.0, 0.0, 0.0))] * (n // 2)
+
+    cost_small = harmonic_scaling_spin_voxel(spins=alternating(16), edges=build_ring_edges(16), **kwargs)
+    cost_large = harmonic_scaling_spin_voxel(spins=alternating(256), edges=build_ring_edges(256), **kwargs)
+    # Intensive => costs match to ~11 sig-figs (residual is the epsilon guard in the
+    # disorder denominator, not size growth). The old extensive term differed by ~16x.
+    assert abs(cost_large - cost_small) / cost_small < 1e-6


### PR DESCRIPTION
## What

`harmonic_scaling_spin_voxel` mixed `spin_hamiltonian` — an **extensive**, signed magnetic energy summed over edges and sites — into the **bounded per-decision** cost. The two quantities are dimensionally incompatible:

- `spin_disorder` (wall density) is **intensive** — divided by edge count, bounded in ~[0,2].
- `spin_hamiltonian` (Heisenberg sum) is **extensive** — grows with voxel count, and is negative for aligned ferromagnetic fields.

At the note's own 16³ scale the extensive term dominated and could drive the cost negative (a wall that gets *cheaper* the larger the system). A same-inventory shuffle null (`scripts/eval/spin_voxel_null_gate.py`, which already zeroes the magnetic terms) confirms the magnetic structure contributes **nothing** to separation — all signal comes from the intensive disorder.

## Fix

Drop the extensive term from the cost. The penalty is now `max(0, disorder)` — the intensive per-edge disorder density alone (the null-survivor). `spin_hamiltonian` stays defined as a raw-energy observable; it's simply no longer fed into the bounded cost.

## Test

`tests/test_spin_voxel.py::test_harmonic_cost_is_scale_free` pins it: an alternating ring at 16 vs 256 voxels now yields costs equal to ~1e-11 relative (residual is the epsilon guard in the disorder denominator, not size growth). The old extensive term differed by ~the size ratio. The two pre-existing tests (disorder raises cost; coherence separates aligned from disordered) stay green — surviving signal unchanged.

`black` + `flake8` clean; 4/4 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spin voxel cost calculation by streamlining penalty computation for more consistent and accurate results.

* **Tests**
  * Added regression test to verify cost calculations maintain consistency across different configuration scales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->