### PR TITLE
feat(site): 3-axis AI-terminal benchmark on the CLI demo page

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -31,10 +31,17 @@
         --term-bg: #0a0c11;
         --max: 1180px;
         --shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
-        --mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+        --mono:
+          ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
       }
-      * { box-sizing: border-box; margin: 0; padding: 0; }
-      html { scroll-behavior: smooth; }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        scroll-behavior: smooth;
+      }
       body {
         font-family: Georgia, 'Times New Roman', serif;
         background:
@@ -43,43 +50,86 @@
         color: var(--text);
         line-height: 1.6;
       }
-      a { color: inherit; text-decoration: none; }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
 
       .topbar {
-        position: sticky; top: 0; z-index: 40;
+        position: sticky;
+        top: 0;
+        z-index: 40;
         backdrop-filter: blur(14px);
         background: rgba(11, 13, 18, 0.82);
         border-bottom: 1px solid rgba(255, 255, 255, 0.06);
       }
-      .wrap { width: min(var(--max), calc(100% - 32px)); margin: 0 auto; }
+      .wrap {
+        width: min(var(--max), calc(100% - 32px));
+        margin: 0 auto;
+      }
       .topbar-inner {
-        min-height: 64px; display: flex; align-items: center;
-        justify-content: space-between; gap: 20px;
+        min-height: 64px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 20px;
       }
       .brand {
-        font-size: 14px; letter-spacing: 0.18em; text-transform: uppercase;
-        color: var(--accent); font-weight: 700;
+        font-size: 14px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--accent);
+        font-weight: 700;
       }
-      .nav { display: flex; gap: 20px; flex-wrap: wrap; font-size: 14px; color: var(--muted); }
-      .nav a:hover { color: var(--text); }
+      .nav {
+        display: flex;
+        gap: 20px;
+        flex-wrap: wrap;
+        font-size: 14px;
+        color: var(--muted);
+      }
+      .nav a:hover {
+        color: var(--text);
+      }
 
-      .hero { padding: 64px 0 26px; }
+      .hero {
+        padding: 64px 0 26px;
+      }
       .eyebrow {
-        color: var(--accent); text-transform: uppercase; letter-spacing: 0.18em;
-        font-size: 12px; font-weight: 700; margin-bottom: 14px;
+        color: var(--accent);
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        font-size: 12px;
+        font-weight: 700;
+        margin-bottom: 14px;
       }
       h1 {
-        font-size: clamp(34px, 5.6vw, 64px); line-height: 0.98;
-        letter-spacing: -0.035em; margin-bottom: 16px;
+        font-size: clamp(34px, 5.6vw, 64px);
+        line-height: 0.98;
+        letter-spacing: -0.035em;
+        margin-bottom: 16px;
       }
-      .hero p { max-width: 60ch; font-size: clamp(16px, 1.8vw, 19px); color: var(--muted); }
+      .hero p {
+        max-width: 60ch;
+        font-size: clamp(16px, 1.8vw, 19px);
+        color: var(--muted);
+      }
 
       .demo-flag {
-        display: inline-flex; align-items: center; gap: 9px; margin-top: 16px;
-        font-size: 13px; color: var(--muted);
-        border: 1px solid var(--line); border-radius: 999px; padding: 7px 14px;
+        display: inline-flex;
+        align-items: center;
+        gap: 9px;
+        margin-top: 16px;
+        font-size: 13px;
+        color: var(--muted);
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 7px 14px;
       }
-      .demo-flag b { color: var(--accent-strong); font-weight: 700; }
+      .demo-flag b {
+        color: var(--accent-strong);
+        font-weight: 700;
+      }
 
       /* ---- terminal ---- */
       .term-shell {
@@ -91,110 +141,306 @@
         overflow: hidden;
       }
       .term-bar {
-        display: flex; align-items: center; gap: 10px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
         padding: 10px 14px;
-        background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01));
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01));
         border-bottom: 1px solid rgba(255, 255, 255, 0.06);
       }
-      .dot { width: 11px; height: 11px; border-radius: 50%; }
-      .dot.r { background: #ff5f57; } .dot.y { background: #febc2e; } .dot.g { background: #28c840; }
+      .dot {
+        width: 11px;
+        height: 11px;
+        border-radius: 50%;
+      }
+      .dot.r {
+        background: #ff5f57;
+      }
+      .dot.y {
+        background: #febc2e;
+      }
+      .dot.g {
+        background: #28c840;
+      }
       .term-title {
-        margin-left: 8px; font-family: var(--mono); font-size: 12px;
-        color: var(--muted); letter-spacing: 0.04em;
+        margin-left: 8px;
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--muted);
+        letter-spacing: 0.04em;
       }
       .term-state {
-        margin-left: auto; font-family: var(--mono); font-size: 11px;
-        display: inline-flex; align-items: center; gap: 7px; color: var(--muted);
+        margin-left: auto;
+        font-family: var(--mono);
+        font-size: 11px;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        color: var(--muted);
       }
-      .term-state .led { width: 8px; height: 8px; border-radius: 50%; background: #6b7280; }
-      .term-state.live .led { background: #28c840; box-shadow: 0 0 8px #28c840; }
+      .term-state .led {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #6b7280;
+      }
+      .term-state.live .led {
+        background: #28c840;
+        box-shadow: 0 0 8px #28c840;
+      }
       .term-body {
         font-family: var(--mono);
-        font-size: 13px; line-height: 1.5;
+        font-size: 13px;
+        line-height: 1.5;
         color: #d7dde6;
         padding: 16px 16px 8px;
-        height: 460px; overflow-y: auto;
-        white-space: pre-wrap; word-break: break-word;
+        height: 460px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
       }
-      .term-body .cmd-echo { color: var(--accent-strong); }
-      .term-body .cmd-echo::before { content: 'scbe ❯ '; color: var(--cool); }
-      .term-body .sys { color: var(--muted); font-style: italic; }
-      .term-out { margin: 2px 0 14px; }
+      .term-body .cmd-echo {
+        color: var(--accent-strong);
+      }
+      .term-body .cmd-echo::before {
+        content: 'scbe ❯ ';
+        color: var(--cool);
+      }
+      .term-body .sys {
+        color: var(--muted);
+        font-style: italic;
+      }
+      .term-out {
+        margin: 2px 0 14px;
+      }
       .term-inputrow {
-        display: flex; align-items: center; gap: 8px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
         border-top: 1px solid rgba(255, 255, 255, 0.06);
-        padding: 12px 16px; background: rgba(255,255,255,0.015);
+        padding: 12px 16px;
+        background: rgba(255, 255, 255, 0.015);
       }
-      .term-inputrow .prompt { font-family: var(--mono); color: var(--cool); font-size: 13px; }
+      .term-inputrow .prompt {
+        font-family: var(--mono);
+        color: var(--cool);
+        font-size: 13px;
+      }
       #cmd {
-        flex: 1; background: transparent; border: none; outline: none;
-        font-family: var(--mono); font-size: 13px; color: var(--text);
+        flex: 1;
+        background: transparent;
+        border: none;
+        outline: none;
+        font-family: var(--mono);
+        font-size: 13px;
+        color: var(--text);
       }
       .runbtn {
-        font-family: var(--mono); font-size: 12px; cursor: pointer;
-        color: #14110c; font-weight: 700;
+        font-family: var(--mono);
+        font-size: 12px;
+        cursor: pointer;
+        color: #14110c;
+        font-weight: 700;
         background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-        border: none; border-radius: 8px; padding: 7px 14px;
+        border: none;
+        border-radius: 8px;
+        padding: 7px 14px;
       }
 
-      .chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 4px 0 26px; }
-      .chip {
-        font-family: var(--mono); font-size: 12px; cursor: pointer; color: var(--cool);
-        background: rgba(140, 180, 255, 0.08); border: 1px solid rgba(140, 180, 255, 0.18);
-        border-radius: 8px; padding: 6px 11px; transition: 140ms ease;
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 4px 0 26px;
       }
-      .chip:hover { background: rgba(140, 180, 255, 0.16); color: var(--text); }
+      .chip {
+        font-family: var(--mono);
+        font-size: 12px;
+        cursor: pointer;
+        color: var(--cool);
+        background: rgba(140, 180, 255, 0.08);
+        border: 1px solid rgba(140, 180, 255, 0.18);
+        border-radius: 8px;
+        padding: 6px 11px;
+        transition: 140ms ease;
+      }
+      .chip:hover {
+        background: rgba(140, 180, 255, 0.16);
+        color: var(--text);
+      }
 
       /* ---- backend connect ---- */
       .backend {
-        border: 1px solid var(--line); border-radius: 14px;
-        background: rgba(18, 23, 32, 0.6); padding: 18px 20px; margin: 8px 0 36px;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        background: rgba(18, 23, 32, 0.6);
+        padding: 18px 20px;
+        margin: 8px 0 36px;
       }
-      .backend h3 { font-size: 15px; margin-bottom: 6px; }
-      .backend p { color: var(--muted); font-size: 14px; margin-bottom: 12px; }
-      .backend .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+      .backend h3 {
+        font-size: 15px;
+        margin-bottom: 6px;
+      }
+      .backend p {
+        color: var(--muted);
+        font-size: 14px;
+        margin-bottom: 12px;
+      }
+      .backend .row {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
       .backend input {
-        flex: 1; min-width: 240px; font-family: var(--mono); font-size: 13px;
-        background: var(--term-bg); border: 1px solid var(--line); border-radius: 8px;
-        padding: 9px 12px; color: var(--text); outline: none;
+        flex: 1;
+        min-width: 240px;
+        font-family: var(--mono);
+        font-size: 13px;
+        background: var(--term-bg);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 9px 12px;
+        color: var(--text);
+        outline: none;
       }
       .backend button {
-        font-size: 13px; font-weight: 700; cursor: pointer; color: var(--text);
-        background: rgba(140, 180, 255, 0.12); border: 1px solid rgba(140, 180, 255, 0.28);
-        border-radius: 8px; padding: 9px 16px;
+        font-size: 13px;
+        font-weight: 700;
+        cursor: pointer;
+        color: var(--text);
+        background: rgba(140, 180, 255, 0.12);
+        border: 1px solid rgba(140, 180, 255, 0.28);
+        border-radius: 8px;
+        padding: 9px 16px;
       }
       .backend code {
-        font-family: var(--mono); font-size: 12px; color: var(--accent-strong);
-        background: rgba(214,167,86,0.08); padding: 1px 6px; border-radius: 5px;
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--accent-strong);
+        background: rgba(214, 167, 86, 0.08);
+        padding: 1px 6px;
+        border-radius: 5px;
       }
 
       /* ---- compare ---- */
-      .section { padding: 22px 0 60px; }
-      h2 { font-size: clamp(24px, 3vw, 34px); letter-spacing: -0.02em; margin-bottom: 8px; }
-      .sub { color: var(--muted); margin-bottom: 22px; max-width: 62ch; }
-      .matrix { width: 100%; border-collapse: collapse; font-size: 14.5px; }
-      .matrix th, .matrix td {
-        text-align: left; padding: 12px 14px;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.07); vertical-align: top;
+      .section {
+        padding: 22px 0 60px;
+      }
+      h2 {
+        font-size: clamp(24px, 3vw, 34px);
+        letter-spacing: -0.02em;
+        margin-bottom: 8px;
+      }
+      .sub {
+        color: var(--muted);
+        margin-bottom: 22px;
+        max-width: 62ch;
+      }
+      .matrix {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14.5px;
+      }
+      .matrix th,
+      .matrix td {
+        text-align: left;
+        padding: 12px 14px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+        vertical-align: top;
       }
       .matrix thead th {
-        font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted);
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
       }
-      .matrix thead th.us { color: var(--accent-strong); }
-      .matrix td.feat { color: var(--text); font-weight: 700; }
-      .matrix td.us { color: var(--text); }
-      .matrix .y { color: #5bd68b; font-weight: 700; }
-      .matrix .n { color: #8a93a2; }
-      .matrix .p { color: var(--accent-strong); }
-      .matrix tbody tr:hover { background: rgba(255, 255, 255, 0.02); }
-      .note { color: var(--muted); font-size: 13px; margin-top: 14px; }
+      .matrix thead th.us {
+        color: var(--accent-strong);
+      }
+      .matrix td.feat {
+        color: var(--text);
+        font-weight: 700;
+      }
+      .matrix td.us {
+        color: var(--text);
+      }
+      .matrix .y {
+        color: #5bd68b;
+        font-weight: 700;
+      }
+      .matrix .n {
+        color: #8a93a2;
+      }
+      .matrix .p {
+        color: var(--accent-strong);
+      }
+      .matrix tbody tr:hover {
+        background: rgba(255, 255, 255, 0.02);
+      }
+      .note {
+        color: var(--muted);
+        font-size: 13px;
+        margin-top: 14px;
+      }
+      .legend {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        color: var(--muted);
+        margin: -8px 0 18px;
+      }
+      .perf {
+        border: 1px solid rgba(140, 180, 255, 0.18);
+        background: rgba(140, 180, 255, 0.06);
+        border-radius: 12px;
+        padding: 14px 18px;
+        font-size: 14px;
+        color: var(--muted);
+        margin-bottom: 26px;
+      }
+      .perf strong {
+        color: var(--text);
+      }
+      .perf b {
+        color: var(--cool);
+      }
+      .perf code {
+        font-family: var(--mono);
+        font-size: 12.5px;
+        color: var(--accent-strong);
+      }
+      h3.axis {
+        font-size: 17px;
+        letter-spacing: -0.01em;
+        margin: 26px 0 10px;
+        color: var(--text);
+      }
+      h3.axis span {
+        color: var(--muted);
+        font-weight: 400;
+        font-size: 14px;
+      }
+      .mscroll {
+        overflow-x: auto;
+      }
 
-      footer { color: var(--muted); font-size: 14px; padding: 26px 0 80px; }
-      footer a.back { color: var(--accent); }
+      footer {
+        color: var(--muted);
+        font-size: 14px;
+        padding: 26px 0 80px;
+      }
+      footer a.back {
+        color: var(--accent);
+      }
 
       @media (max-width: 720px) {
-        .term-body { height: 380px; font-size: 12px; }
-        .matrix .hidemob { display: none; }
+        .term-body {
+          height: 380px;
+          font-size: 12px;
+        }
+        .matrix .hidemob {
+          display: none;
+        }
       }
     </style>
   </head>
@@ -215,13 +461,19 @@
       <div class="eyebrow">Live · Governed CLI</div>
       <h1>Try the SCBE terminal</h1>
       <p>
-        This is the terminal’s <strong>real rendering code</strong> running in your browser —
-        the same <code style="font-family: var(--mono); color: var(--accent-strong)">terminal-frontend.js</code>
+        This is the terminal’s <strong>real rendering code</strong> running in your browser — the
+        same
+        <code style="font-family: var(--mono); color: var(--accent-strong)"
+          >terminal-frontend.js</code
+        >
         the CLI ships, not a mockup. Type a command, watch the governed panel render, and compare it
         to a plain shell below.
       </p>
       <span class="demo-flag">
-        <b>Demo mode</b> — runs against a sample workspace. Commands that <em>execute</em> (<code style="font-family: var(--mono)">/run</code>) are simulated until you connect a backend.
+        <b>Demo mode</b> — runs against a sample workspace. Commands that <em>execute</em> (<code
+          style="font-family: var(--mono)"
+          >/run</code
+        >) are simulated until you connect a backend.
       </span>
     </section>
 
@@ -230,13 +482,20 @@
         <div class="term-bar">
           <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
           <span class="term-title">scbe terminal — sample workspace</span>
-          <span class="term-state" id="termState"><span class="led"></span><span id="termStateText">demo mode</span></span>
+          <span class="term-state" id="termState"
+            ><span class="led"></span><span id="termStateText">demo mode</span></span
+          >
         </div>
         <div class="term-body" id="termBody" aria-live="polite"></div>
         <div class="term-inputrow">
           <span class="prompt">scbe ❯</span>
-          <input id="cmd" autocomplete="off" autocapitalize="off" spellcheck="false"
-                 placeholder="try: scbe term --detail   (type help for all commands)" />
+          <input
+            id="cmd"
+            autocomplete="off"
+            autocapitalize="off"
+            spellcheck="false"
+            placeholder="try: scbe term --detail   (type help for all commands)"
+          />
           <button class="runbtn" id="runbtn">Run</button>
         </div>
       </div>
@@ -244,87 +503,239 @@
       <div class="chips" id="chips"></div>
 
       <div class="backend">
-        <h3>Connect a backend <span style="color: var(--muted); font-weight: 400; font-size: 13px;">(optional · advanced)</span></h3>
+        <h3>
+          Connect a backend
+          <span style="color: var(--muted); font-weight: 400; font-size: 13px"
+            >(optional · advanced)</span
+          >
+        </h3>
         <p>
-          Want <code>/run</code> to execute for real? Stand up a tiny endpoint anywhere you like —
-          a free container service works fine — that accepts <code>POST /run {"command": "..."}</code>
+          Want <code>/run</code> to execute for real? Stand up a tiny endpoint anywhere you like — a
+          free container service works fine — that accepts <code>POST /run {"command": "..."}</code>
           and returns a terminal receipt JSON. Paste its URL here and the demo switches from
           simulated receipts to live ones. Nothing is sent anywhere until you connect.
         </p>
         <div class="row">
-          <input id="backendUrl" placeholder="https://your-container.example.app   (leave blank for demo mode)" />
+          <input
+            id="backendUrl"
+            placeholder="https://your-container.example.app   (leave blank for demo mode)"
+          />
           <button id="backendBtn">Connect</button>
         </div>
       </div>
 
       <section class="section">
-        <h2>Same task, different tools</h2>
+        <h2>AI terminals, benchmarked on three axes</h2>
         <p class="sub">
-          What you get from the SCBE terminal versus a plain shell and a typical AI coding CLI.
-          The other columns describe common behavior — they are a positioning guide, not a benchmark.
+          The SCBE terminal is not a code-generation agent — its lane is governed execution, signed
+          receipts, an agent protocol, and a featherweight frontend. Here is where it leads and
+          where it deliberately isn't the focus, against the current AI-terminal field. Compiled
+          from public product docs as of June 2026 — a positioning map, not a head-to-head latency
+          or SWE-bench benchmark.
         </p>
-        <table class="matrix">
-          <thead>
-            <tr>
-              <th>Capability</th>
-              <th class="us">SCBE terminal</th>
-              <th>Plain shell</th>
-              <th class="hidemob">Typical AI CLI</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="feat">Governed run receipt (pass/fail + next step)</td>
-              <td class="us"><span class="y">✓</span> built in</td>
-              <td><span class="n">—</span> raw exit code</td>
-              <td class="hidemob"><span class="n">—</span> usually none</td>
-            </tr>
-            <tr>
-              <td class="feat">Readiness posture (one-glance decision)</td>
-              <td class="us"><span class="y">✓</span> READY / WARN / REPAIR</td>
-              <td><span class="n">—</span></td>
-              <td class="hidemob"><span class="n">—</span></td>
-            </tr>
-            <tr>
-              <td class="feat">Natural-language routing</td>
-              <td class="us"><span class="y">✓</span> local + provider models</td>
-              <td><span class="n">—</span></td>
-              <td class="hidemob"><span class="p">~</span> model-dependent</td>
-            </tr>
-            <tr>
-              <td class="feat">Machine protocol (NDJSON / --json)</td>
-              <td class="us"><span class="y">✓</span> agent bus + JSON mode</td>
-              <td><span class="p">~</span> pipes only</td>
-              <td class="hidemob"><span class="p">~</span> varies</td>
-            </tr>
-            <tr>
-              <td class="feat">Colored UI with zero dependencies</td>
-              <td class="us"><span class="y">✓</span> 0 deps</td>
-              <td><span class="p">~</span> depends on tool</td>
-              <td class="hidemob"><span class="p">~</span> heavy deps</td>
-            </tr>
-            <tr>
-              <td class="feat">Pipe / NO_COLOR / JSON safety</td>
-              <td class="us"><span class="y">✓</span> never leaks ANSI to JSON</td>
-              <td><span class="p">~</span> manual</td>
-              <td class="hidemob"><span class="p">~</span> varies</td>
-            </tr>
-          </tbody>
-        </table>
+        <p class="legend">
+          <span class="y">✓</span> first-class &nbsp;·&nbsp; <span class="p">~</span> partial /
+          varies &nbsp;·&nbsp; <span class="n">—</span> not a focus
+        </p>
+
+        <div class="perf">
+          <strong>Our one measured number.</strong> Cold invocation to a rendered panel (7-run
+          median, includes the git posture probe): <code>scbe term --json</code> state
+          <b>~660&nbsp;ms</b>, compact panel <b>~1.09&nbsp;s</b>, detail panel <b>~1.10&nbsp;s</b>.
+          That is render+posture latency for a governed dashboard, not model-inference time — the
+          coding agents below spend seconds to minutes per task in their LLM, a different budget.
+        </div>
+
+        <h3 class="axis">1 · AI agentic usage <span>— serving autonomous agents</span></h3>
+        <div class="mscroll">
+          <table class="matrix">
+            <thead>
+              <tr>
+                <th>Capability</th>
+                <th class="us">SCBE terminal</th>
+                <th>Warp</th>
+                <th>Codex CLI</th>
+                <th class="hidemob">Aider</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="feat">Governance gate before a command runs</td>
+                <td class="us"><span class="y">✓</span> L13 ALLOW/DENY</td>
+                <td><span class="p">~</span> step approvals</td>
+                <td><span class="y">✓</span> sandbox container</td>
+                <td class="hidemob"><span class="p">~</span> diff approval</td>
+              </tr>
+              <tr>
+                <td class="feat">Signed run receipt (pass/fail + next + audit)</td>
+                <td class="us"><span class="y">✓</span> per run</td>
+                <td><span class="n">—</span></td>
+                <td><span class="n">—</span></td>
+                <td class="hidemob"><span class="p">~</span> commit msg only</td>
+              </tr>
+              <tr>
+                <td class="feat">Machine protocol for tiny agents</td>
+                <td class="us"><span class="y">✓</span> NDJSON agent bus</td>
+                <td><span class="p">~</span> MCP</td>
+                <td><span class="p">~</span> JSON output</td>
+                <td class="hidemob"><span class="p">~</span> scripting</td>
+              </tr>
+              <tr>
+                <td class="feat">Readiness posture in one glance</td>
+                <td class="us"><span class="y">✓</span> READY/WARN/REPAIR</td>
+                <td><span class="n">—</span></td>
+                <td><span class="n">—</span></td>
+                <td class="hidemob"><span class="n">—</span></td>
+              </tr>
+              <tr>
+                <td class="feat">Multi-step LLM code-generation</td>
+                <td class="us"><span class="n">—</span> not its job</td>
+                <td><span class="y">✓</span> Agent Mode</td>
+                <td><span class="y">✓</span> Goal mode</td>
+                <td class="hidemob"><span class="y">✓</span> repomap</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3 class="axis">2 · Frontend design <span>— the operator surface</span></h3>
+        <div class="mscroll">
+          <table class="matrix">
+            <thead>
+              <tr>
+                <th>Capability</th>
+                <th class="us">SCBE terminal</th>
+                <th>Warp</th>
+                <th>Wave</th>
+                <th class="hidemob">Plain shell</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="feat">Rendering footprint</td>
+                <td class="us"><span class="y">✓</span> ~30 KB, 0 deps</td>
+                <td><span class="p">~</span> native Rust/GPU app</td>
+                <td><span class="p">~</span> Electron app</td>
+                <td class="hidemob"><span class="p">~</span> emulator</td>
+              </tr>
+              <tr>
+                <td class="feat">Runs unchanged in a browser (this page)</td>
+                <td class="us"><span class="y">✓</span> same code</td>
+                <td><span class="n">—</span></td>
+                <td><span class="n">—</span></td>
+                <td class="hidemob"><span class="n">—</span></td>
+              </tr>
+              <tr>
+                <td class="feat">Compact + detail views of one state</td>
+                <td class="us"><span class="y">✓</span> term / --detail</td>
+                <td><span class="p">~</span> blocks</td>
+                <td><span class="p">~</span> blocks</td>
+                <td class="hidemob"><span class="n">—</span></td>
+              </tr>
+              <tr>
+                <td class="feat">Pipe / NO_COLOR / JSON-safe output</td>
+                <td class="us"><span class="y">✓</span> never leaks ANSI</td>
+                <td><span class="p">~</span></td>
+                <td><span class="p">~</span></td>
+                <td class="hidemob"><span class="p">~</span> manual</td>
+              </tr>
+              <tr>
+                <td class="feat">Block / canvas multi-pane UI</td>
+                <td class="us"><span class="n">—</span> single panel</td>
+                <td><span class="y">✓</span></td>
+                <td><span class="y">✓</span> drag-drop</td>
+                <td class="hidemob"><span class="n">—</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3 class="axis">3 · Calling 3rd-party AI <span>— provider integration</span></h3>
+        <div class="mscroll">
+          <table class="matrix">
+            <thead>
+              <tr>
+                <th>Capability</th>
+                <th class="us">SCBE terminal</th>
+                <th>Wave</th>
+                <th>Aider</th>
+                <th class="hidemob">Warp</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="feat">Provider-agnostic (local + cloud)</td>
+                <td class="us"><span class="y">✓</span> routed</td>
+                <td><span class="y">✓</span> OpenAI/Claude/Ollama</td>
+                <td><span class="y">✓</span> any LLM</td>
+                <td class="hidemob"><span class="p">~</span> own + runs others</td>
+              </tr>
+              <tr>
+                <td class="feat">Local-first / offline (Ollama)</td>
+                <td class="us"><span class="y">✓</span> default</td>
+                <td><span class="y">✓</span></td>
+                <td><span class="y">✓</span></td>
+                <td class="hidemob"><span class="p">~</span></td>
+              </tr>
+              <tr>
+                <td class="feat">Natural language → governed command</td>
+                <td class="us"><span class="y">✓</span> gated route</td>
+                <td><span class="p">~</span> chat assist</td>
+                <td><span class="p">~</span> code edits</td>
+                <td class="hidemob"><span class="y">✓</span> Agent Mode</td>
+              </tr>
+              <tr>
+                <td class="feat">No vendor lock-in / bring your own key</td>
+                <td class="us"><span class="y">✓</span></td>
+                <td><span class="y">✓</span></td>
+                <td><span class="y">✓</span></td>
+                <td class="hidemob"><span class="p">~</span> account-bound</td>
+              </tr>
+              <tr>
+                <td class="feat">MCP / external tool ecosystem</td>
+                <td class="us"><span class="p">~</span> agent-bus tools</td>
+                <td><span class="p">~</span></td>
+                <td><span class="p">~</span></td>
+                <td class="hidemob"><span class="y">✓</span> MCP servers</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
         <p class="note">
-          The SCBE column is what this page actually renders above — try <code style="font-family: var(--mono); color: var(--accent-strong)">scbe run "npm test"</code>
-          to see a governed receipt, then <code style="font-family: var(--mono); color: var(--accent-strong)">scbe term --json</code> for the agent-facing payload.
+          Reading: SCBE wins the <b>governance / audit / agent-protocol</b> axis and the
+          <b>featherweight, browser-testable</b> frontend; it intentionally cedes
+          <b>LLM code-generation</b> (Warp, Codex CLI, Aider) and <b>multi-pane block UIs</b> (Warp,
+          Wave). The honest pitch: a governed front door and receipt layer that can sit
+          <em>in front of</em> those coding agents, not a replacement for them.
+        </p>
+        <p class="note">
+          The SCBE column is what this page actually renders above — try
+          <code style="font-family: var(--mono); color: var(--accent-strong)"
+            >scbe run "npm test"</code
+          >
+          to see a governed receipt, then
+          <code style="font-family: var(--mono); color: var(--accent-strong)"
+            >scbe term --json</code
+          >
+          for the agent-facing payload.
         </p>
       </section>
     </main>
 
     <footer class="wrap">
       <p>
-        This page runs <code style="font-family: var(--mono); color: var(--accent-strong)">packages/cli/lib/terminal-frontend.js</code>
-        and <code style="font-family: var(--mono); color: var(--accent-strong)">lib/ui.js</code> unmodified, wrapped for the browser by
-        <code style="font-family: var(--mono)">build-web-terminal.cjs</code>. The workspace state shown is a sample, not your machine.
+        This page runs
+        <code style="font-family: var(--mono); color: var(--accent-strong)"
+          >packages/cli/lib/terminal-frontend.js</code
+        >
+        and
+        <code style="font-family: var(--mono); color: var(--accent-strong)">lib/ui.js</code>
+        unmodified, wrapped for the browser by
+        <code style="font-family: var(--mono)">build-web-terminal.cjs</code>. The workspace state
+        shown is a sample, not your machine.
       </p>
-      <p style="margin-top: 12px;"><a class="back" href="index.html">◄ Back to AetherMoore</a></p>
+      <p style="margin-top: 12px"><a class="back" href="index.html">◄ Back to AetherMoore</a></p>
     </footer>
 
     <script src="static/scbe-terminal-web.js"></script>
@@ -342,17 +753,41 @@
         var lastReceipt = null;
         function readiness() {
           var lanes = [
-            ['node', 'node >= 18', 'pass'], ['py', 'python >= 3.11', 'pass'],
-            ['liboqs', 'PQC bindings (ML-KEM/ML-DSA)', 'pass'], ['build', 'TypeScript build', 'pass'],
-            ['vitest', 'TS test suite', 'pass'], ['pytest', 'Python test suite', 'pass'],
-            ['gate', 'governance gate', 'pass'], ['bus', 'agent bus tools', 'pass'],
-            ['receipts', 'terminal receipts', 'pass'], ['models', 'local model route', 'pass'],
-            ['git', 'clean worktree', 'pass'], ['pack', 'npm pack dry-run', 'pass'],
-            ['official', 'official harness', 'warn', 'needs vendor harness', 'Run the official conformance pack'],
-            ['linux', 'Linux kernel telemetry', 'warn', 'host not Linux', 'Run on a Linux host to verify'],
+            ['node', 'node >= 18', 'pass'],
+            ['py', 'python >= 3.11', 'pass'],
+            ['liboqs', 'PQC bindings (ML-KEM/ML-DSA)', 'pass'],
+            ['build', 'TypeScript build', 'pass'],
+            ['vitest', 'TS test suite', 'pass'],
+            ['pytest', 'Python test suite', 'pass'],
+            ['gate', 'governance gate', 'pass'],
+            ['bus', 'agent bus tools', 'pass'],
+            ['receipts', 'terminal receipts', 'pass'],
+            ['models', 'local model route', 'pass'],
+            ['git', 'clean worktree', 'pass'],
+            ['pack', 'npm pack dry-run', 'pass'],
+            [
+              'official',
+              'official harness',
+              'warn',
+              'needs vendor harness',
+              'Run the official conformance pack',
+            ],
+            [
+              'linux',
+              'Linux kernel telemetry',
+              'warn',
+              'host not Linux',
+              'Run on a Linux host to verify',
+            ],
           ];
           return lanes.map(function (l) {
-            return { id: l[0], label: l[1], level: l[2], detail: l[3] || '', next_step: l[4] || '' };
+            return {
+              id: l[0],
+              label: l[1],
+              level: l[2],
+              detail: l[3] || '',
+              next_step: l[4] || '',
+            };
           });
         }
         function context() {
@@ -360,13 +795,34 @@
             cwd: '/repo/SCBE-AETHERMOORE',
             repoRoot: '/repo/SCBE-AETHERMOORE',
             historyPath: 'artifacts/scbe-terminal/history.jsonl',
-            version: { cli_package: 'scbe-aethermoore-cli', cli_version: '4.0.3', core_version: '4.0.3', node: 'v20.11.0', platform: 'linux' },
-            git: { branch: 'feat/cli-ui-kit', commit: 'c0208af', dirty: true, upstream: 'origin/feat/cli-ui-kit' },
+            version: {
+              cli_package: 'scbe-aethermoore-cli',
+              cli_version: '4.0.3',
+              core_version: '4.0.3',
+              node: 'v20.11.0',
+              platform: 'linux',
+            },
+            git: {
+              branch: 'feat/cli-ui-kit',
+              commit: 'c0208af',
+              dirty: true,
+              upstream: 'origin/feat/cli-ui-kit',
+            },
             shellConfig: { provider: 'ollama', model: 'llama3.2' },
             platform: { readiness: readiness() },
-            naturalLanguage: { autocorrect: true, word_count: 412, learned_tools: 7,
-              examples: [['fix the repo', 'natural-language resolver'], ['show status', 'maps to status'], ['run the tests', 'governed run']].map(function (e) { return { phrase: e[0], use: e[1] }; }),
-              sources: ['static command vocabulary', 'local confirmed utterance log'] },
+            naturalLanguage: {
+              autocorrect: true,
+              word_count: 412,
+              learned_tools: 7,
+              examples: [
+                ['fix the repo', 'natural-language resolver'],
+                ['show status', 'maps to status'],
+                ['run the tests', 'governed run'],
+              ].map(function (e) {
+                return { phrase: e[0], use: e[1] };
+              }),
+              sources: ['static command vocabulary', 'local confirmed utterance log'],
+            },
             lastReceipt: lastReceipt,
           };
         }
@@ -387,29 +843,54 @@
         function panel(opts) {
           var payload = T.buildTerminalFrontendPayload(context());
           if (opts.json) return write(T.ansiToHtml(JSON.stringify(payload, null, 2)));
-          var ansi = T.renderTerminalFrontend(payload, { color: opts.color !== false, width: 84, detail: !!opts.detail });
+          var ansi = T.renderTerminalFrontend(payload, {
+            color: opts.color !== false,
+            width: 84,
+            detail: !!opts.detail,
+          });
           write(T.ansiToHtml(ansi));
         }
 
         function simulateRun(cmd) {
           var ok = !/\bfail|error|false\b/i.test(cmd);
           lastReceipt = {
-            started_at: new Date().toISOString(), command: cmd, cwd: '/repo/SCBE-AETHERMOORE',
-            success: ok, exit_code: ok ? 0 : 1, duration_ms: 120 + Math.floor(cmd.length * 7),
+            started_at: new Date().toISOString(),
+            command: cmd,
+            cwd: '/repo/SCBE-AETHERMOORE',
+            success: ok,
+            exit_code: ok ? 0 : 1,
+            duration_ms: 120 + Math.floor(cmd.length * 7),
             stdout_preview: ok ? 'ok — ' + cmd + '\n(demo: output simulated)' : '',
             stderr_preview: ok ? '' : 'demo: simulated non-zero exit for "' + cmd + '"',
-            failure: ok ? null : { summary: 'simulated failure', next_step: 'Connect a backend for real execution.' },
+            failure: ok
+              ? null
+              : {
+                  summary: 'simulated failure',
+                  next_step: 'Connect a backend for real execution.',
+                },
           };
         }
         function liveRun(cmd) {
           write('<span class="sys">→ POST ' + backendUrl + '/run … running</span>');
           return fetch(backendUrl.replace(/\/$/, '') + '/run', {
-            method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: cmd }),
-          }).then(function (r) { return r.json(); }).then(function (receipt) {
-            lastReceipt = receipt; panel({ detail: false });
-          }).catch(function (e) {
-            write('<span class="sys">backend error: ' + String(e.message || e) + ' — staying in demo mode</span>');
-          });
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ command: cmd }),
+          })
+            .then(function (r) {
+              return r.json();
+            })
+            .then(function (receipt) {
+              lastReceipt = receipt;
+              panel({ detail: false });
+            })
+            .catch(function (e) {
+              write(
+                '<span class="sys">backend error: ' +
+                  String(e.message || e) +
+                  ' — staying in demo mode</span>'
+              );
+            });
         }
 
         function helpText() {
@@ -417,6 +898,7 @@
             ['scbe term', 'render the compact dashboard'],
             ['scbe term --detail', 'full panel (modes, readiness, grammar)'],
             ['scbe term --json', 'agent-facing JSON payload'],
+            ['scbe term bench', 'benchmark frontend startup/render'],
             ['scbe term --no-color', 'plain (NO_COLOR) render'],
             ['status', 'JSON status receipt'],
             ['models', 'local model route'],
@@ -425,7 +907,67 @@
             ['clear', 'clear the screen'],
           ];
           var out = 'commands\n';
-          rows.forEach(function (r) { out += '  ' + r[0] + new Array(Math.max(2, 26 - r[0].length)).join(' ') + r[1] + '\n'; });
+          rows.forEach(function (r) {
+            out += '  ' + r[0] + new Array(Math.max(2, 26 - r[0].length)).join(' ') + r[1] + '\n';
+          });
+          write(T.ansiToHtml(out));
+        }
+
+        function sampleBenchmark() {
+          return {
+            schema_version: 'scbe_terminal_frontend_benchmark_v1',
+            generated_at: new Date().toISOString(),
+            runs: 7,
+            node: 'demo',
+            caveat:
+              'Browser demo uses sample benchmark values. Run scbe term bench locally for your machine.',
+            scenarios: [
+              {
+                id: 'json',
+                label: 'JSON state',
+                command: 'scbe term --json',
+                ok: true,
+                runs: 7,
+                median_ms: 660.52,
+                p95_ms: 724.29,
+              },
+              {
+                id: 'compact',
+                label: 'Compact panel',
+                command: 'scbe term --no-color',
+                ok: true,
+                runs: 7,
+                median_ms: 1093.83,
+                p95_ms: 1120.77,
+              },
+              {
+                id: 'detail',
+                label: 'Detail panel',
+                command: 'scbe term --detail --no-color',
+                ok: true,
+                runs: 7,
+                median_ms: 1097.11,
+                p95_ms: 1110.49,
+              },
+            ],
+          };
+        }
+
+        function benchmarkView(json) {
+          var payload = sampleBenchmark();
+          if (json) return write(T.ansiToHtml(JSON.stringify(payload, null, 2)));
+          var out = 'SCBE terminal benchmark (sample)\n';
+          out += payload.caveat + '\n\n';
+          out += '  surface          median     p95      command\n';
+          payload.scenarios.forEach(function (s) {
+            out +=
+              '  ' +
+              s.label.padEnd(16) +
+              String(s.median_ms + 'ms').padEnd(11) +
+              String(s.p95_ms + 'ms').padEnd(9) +
+              s.command +
+              '\n';
+          });
           write(T.ansiToHtml(out));
         }
 
@@ -436,71 +978,134 @@
           var lc = cmd.toLowerCase();
 
           if (lc === 'help' || lc === '?' || lc === '/help' || lc === ':help') return helpText();
-          if (lc === 'clear' || lc === 'cls') { body.innerHTML = ''; return; }
+          if (lc === 'clear' || lc === 'cls') {
+            body.innerHTML = '';
+            return;
+          }
 
           // run forms: scbe run "x" | /run x | run x | [tag] x
           var tag = cmd.match(/^\[(\w+)\]\s+(.*)$/);
-          var runMatch = cmd.match(/^scbe\s+run\s+["']?(.+?)["']?$/i) || cmd.match(/^\/?run\s+(.+)$/i);
+          var runMatch =
+            cmd.match(/^scbe\s+run\s+["']?(.+?)["']?$/i) || cmd.match(/^\/?run\s+(.+)$/i);
           if (tag) {
-            write('<span class="sys">tag [' + tag[1] + '] attached → routing as governed run</span>');
+            write(
+              '<span class="sys">tag [' + tag[1] + '] attached → routing as governed run</span>'
+            );
             return dispatchRun(tag[2]);
           }
           if (runMatch) return dispatchRun(runMatch[1]);
 
+          if (/^(scbe\s+)?term(inal)?\s+bench(?:mark)?/.test(lc) || lc === 'bench') {
+            return benchmarkView(/--json/.test(lc));
+          }
+
           if (/^(status|\/status|:status)$/.test(lc)) {
             var p = T.buildTerminalFrontendPayload(context());
-            return write(T.ansiToHtml(JSON.stringify({ schema_version: p.schema_version, readiness: p.readiness, git: p.git, runtime: p.runtime, last_receipt: p.last_receipt }, null, 2)));
+            return write(
+              T.ansiToHtml(
+                JSON.stringify(
+                  {
+                    schema_version: p.schema_version,
+                    readiness: p.readiness,
+                    git: p.git,
+                    runtime: p.runtime,
+                    last_receipt: p.last_receipt,
+                  },
+                  null,
+                  2
+                )
+              )
+            );
           }
           if (/^(models|\/models|:models)$/.test(lc)) {
-            return write(T.ansiToHtml('local model route\n  provider   ollama\n  model      llama3.2\n  url        http://127.0.0.1:11434\n  (configure with: scbe shell --ai)'));
+            return write(
+              T.ansiToHtml(
+                'local model route\n  provider   ollama\n  model      llama3.2\n  url        http://127.0.0.1:11434\n  (configure with: scbe shell --ai)'
+              )
+            );
           }
-          if (/\bterm(inal)?\b/.test(lc) || lc === 'scbe' ) {
-            if (/\btui\b/.test(lc)) write('<span class="sys">scbe terminal tui is a full-screen Ink app — local only. Showing the dashboard instead:</span>');
-            return panel({ detail: /(--detail|\s-d\b)/.test(lc), json: /--json/.test(lc), color: !/--no-?color/.test(lc) });
+          if (/\bterm(inal)?\b/.test(lc) || lc === 'scbe') {
+            if (/\btui\b/.test(lc))
+              write(
+                '<span class="sys">scbe terminal tui is a full-screen Ink app — local only. Showing the dashboard instead:</span>'
+              );
+            return panel({
+              detail: /(--detail|\s-d\b)/.test(lc),
+              json: /--json/.test(lc),
+              color: !/--no-?color/.test(lc),
+            });
           }
           // fallback: treat as natural language → governed run
-          write('<span class="sys">no exact command — routing "' + cmd + '" through the natural-language resolver → governed run</span>');
+          write(
+            '<span class="sys">no exact command — routing "' +
+              cmd +
+              '" through the natural-language resolver → governed run</span>'
+          );
           dispatchRun(cmd);
         }
 
         function dispatchRun(cmd) {
           if (backendUrl) return liveRun(cmd);
           simulateRun(cmd);
-          write('<span class="sys">receipt simulated (demo mode) — connect a backend for real execution</span>');
+          write(
+            '<span class="sys">receipt simulated (demo mode) — connect a backend for real execution</span>'
+          );
           panel({ detail: false });
         }
 
         function setBackend(url) {
           backendUrl = url.trim();
           if (backendUrl) {
-            stateEl.classList.add('live'); stateText.textContent = 'connected';
+            stateEl.classList.add('live');
+            stateText.textContent = 'connected';
           } else {
-            stateEl.classList.remove('live'); stateText.textContent = 'demo mode';
+            stateEl.classList.remove('live');
+            stateText.textContent = 'demo mode';
           }
         }
 
         // wire up
-        runbtn.addEventListener('click', function () { run(input.value); input.value = ''; });
+        runbtn.addEventListener('click', function () {
+          run(input.value);
+          input.value = '';
+        });
         input.addEventListener('keydown', function (e) {
-          if (e.key === 'Enter') { run(input.value); input.value = ''; }
+          if (e.key === 'Enter') {
+            run(input.value);
+            input.value = '';
+          }
         });
         document.getElementById('backendBtn').addEventListener('click', function () {
           setBackend(document.getElementById('backendUrl').value);
           run('status');
         });
 
-        var chipCmds = ['scbe term', 'scbe term --detail', 'scbe term --json', 'scbe run "npm test"', 'status', 'models', 'help'];
+        var chipCmds = [
+          'scbe term',
+          'scbe term --detail',
+          'scbe term --json',
+          'scbe term bench',
+          'scbe run "npm test"',
+          'status',
+          'models',
+          'help',
+        ];
         var chips = document.getElementById('chips');
         chipCmds.forEach(function (c) {
           var b = document.createElement('button');
-          b.className = 'chip'; b.textContent = c;
-          b.addEventListener('click', function () { run(c); });
+          b.className = 'chip';
+          b.textContent = c;
+          b.addEventListener('click', function () {
+            run(c);
+          });
           chips.appendChild(b);
         });
 
         // first paint
         if (T) {
-          write('<span class="sys">SCBE terminal frontend — real rendering code, sample workspace. Type "help" for commands.</span>');
+          write(
+            '<span class="sys">SCBE terminal frontend — real rendering code, sample workspace. Type "help" for commands.</span>'
+          );
           panel({ detail: false });
         } else {
           body.textContent = 'Failed to load the terminal bundle (static/scbe-terminal-web.js).';

--- a/docs/static/scbe-terminal-web.js
+++ b/docs/static/scbe-terminal-web.js
@@ -561,11 +561,58 @@
         return receipt.success ? 'allow' : 'deny';
       }
 
+      function renderCompactTerminalFrontend(payload, u) {
+        const receipt = payload.last_receipt || {};
+        const receiptStatus = receipt.available
+          ? receipt.success
+            ? u.badge('pass', 'allow')
+            : u.badge('fail', 'deny')
+          : u.badge('empty', 'warn');
+        const command = receipt.command ? u.truncate(receipt.command, 50) : u.dim('none yet');
+        const quickRows = (payload.quick_commands || [])
+          .slice(0, 4)
+          .map((entry) => [u.cyan(entry.command), entry.use]);
+        const grammarRows = [
+          [u.cyan('say it'), 'natural language + autocorrect'],
+          [u.cyan('/run <cmd>'), 'governed receipt'],
+          [u.cyan('[verify] <cmd>'), 'extra instruction tag'],
+          [u.cyan('tab:2:run:<cmd>'), 'room routing'],
+        ];
+
+        return [
+          u.box(
+            [
+              `${u.badge(payload.readiness?.decision || 'unknown', decisionTone(payload.readiness?.decision))} ${payload.git?.branch || 'unknown'}${payload.git?.dirty ? '*' : ''} ${u.dim(`${payload.shell?.provider || 'offline'}:${payload.shell?.model || 'offline'}`)}`,
+              `${u.dim('next')} ${u.cyan(payload.launch?.headed || 'scbe term tui')} ${u.dim('|')} ${u.cyan(payload.launch?.governed_run || 'scbe run "<command>" --json')}`,
+            ],
+            { title: 'SCBE TERMINAL', color: u.cyan }
+          ),
+          '',
+          u.bold('Quick nav'),
+          u.table(quickRows, { head: ['type', 'does'] }),
+          '',
+          u.bold('Last receipt'),
+          u.kv([
+            ['status', receiptStatus],
+            ['command', command],
+            ['next', receipt.next_step || 'Run a governed command to create a receipt.'],
+          ]),
+          '',
+          u.bold('Inputs'),
+          u.table(grammarRows, { head: ['form', 'meaning'] }),
+          '',
+          u.dim('More: scbe term --detail  |  Agents: scbe term --json  |  Benchmark: scbe term bench'),
+        ].join('\n');
+      }
+
       function renderTerminalFrontend(payload, options = {}) {
         const u = options.ui || ui({ json: options.json, color: options.color });
         const width = options.width || 88;
         const detail = Boolean(options.detail);
         const receipt = payload.last_receipt || {};
+
+        if (!detail) return renderCompactTerminalFrontend(payload, u);
+
         const modeRows = (payload.modes || []).map((mode) => [
           u.badge(
             mode.mode,


### PR DESCRIPTION
Reworks the live `cli.html` comparison into a researched **3-axis benchmark** of the SCBE terminal vs the current AI-terminal field, and refreshes the in-browser bundle to the compact-default + `scbe term bench` rendering.

## Axes (vs Warp · Wave · Codex CLI · Aider · plain shell)
1. **AI agentic usage** — governance gate, signed receipts, NDJSON agent bus, readiness posture, (and honestly: — on LLM code-gen, which Warp/Codex/Aider own).
2. **Frontend design** — ~30KB zero-dep, runs unchanged in a browser, compact/detail, NO_COLOR/JSON-safe; cedes block/canvas UIs to Warp/Wave.
3. **Calling 3rd-party AI** — provider-agnostic, local-first (Ollama), NL→governed command, no lock-in; cedes MCP-native ecosystem to Warp.

Honest framing throughout: compiled from public docs (June 2026), labelled a positioning map (not a latency/SWE-bench benchmark). Includes our one measured number (render+posture latency ~660 ms JSON / ~1.1 s panel) with the explicit caveat that it isn't model-inference time.

Verified rendering via Playwright: 3 axis tables, legend, perf callout, ✓/~/— coding, terminal demo still drives the real bundle.

Note: this also brings Codex's compact-default + `scbe term bench` improvements (commit 9902ede on feat/cli-ui-kit) to the live bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)