### PR TITLE
feat(site): move Terminal + Math Spine to front of nav

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -855,9 +855,9 @@
         <a class="brand" href="index.html">AetherMoore</a>
         <nav class="nav" aria-label="Primary">
           <a href="start-here.html">Start Here</a>
-          <a href="guard.html" style="color:#17c6cf;font-weight:700;">AetherGuard</a>
           <a class="nav-feature" href="cli.html">Terminal</a>
           <a class="nav-feature" href="math-spine.html">Math Spine</a>
+          <a href="guard.html" style="color:#17c6cf;font-weight:700;">AetherGuard</a>
           <a href="products.html">Products</a>
           <a href="https://scbe-agent-bridge-vercel.vercel.app/console" target="_blank" rel="noopener"
             >Hosted Tools</a


### PR DESCRIPTION
Moves the two feature nav links (Terminal, Math Spine) to the front of the primary nav, right after **Start Here**, so the in-browser terminal demo and the Math Spine scroll guide are the first destinations visitors see.

One-line reorder; no style or content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)