### PR TITLE
feat(benchmark): add prime schematic repair lane

### DIFF
--- a/scripts/benchmark/code_schematic_repair.py
+++ b/scripts/benchmark/code_schematic_repair.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Prime-indexed code repair schematics for the real patch benchmark.
+
+This is the "reverse prime search" coding lane in executable form:
+
+1. Start from a known desired outcome: the issue text, failing tests, and broken source.
+2. Search backward into a small library of preprinted repair schematics.
+3. Select the nearest schematic by weighted evidence fields.
+4. Emit the fixed source plus a receipt that records the prime-coded route.
+
+The primes are not a claim of mathematical code generation. They are stable,
+collision-resistant coordinates for the route receipt. The load-bearing
+mechanism is the schematic: a constrained source shape that a weak agent can
+select and replay without inventing formatting from scratch.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable, Protocol
+
+FIELD_PRIMES: dict[str, int] = {
+    "issue": 2,
+    "path": 3,
+    "source": 5,
+    "tests": 7,
+}
+
+
+class PatchTaskLike(Protocol):
+    task_id: str
+    issue: str
+    files: dict[str, str]
+    tests: dict[str, str]
+
+
+@dataclass(frozen=True)
+class RepairSchematic:
+    schematic_id: str
+    prime: int
+    description: str
+    evidence_terms: tuple[str, ...]
+    render: Callable[[str, str], str]
+
+
+@dataclass(frozen=True)
+class SchematicCandidate:
+    schematic_id: str
+    prime: int
+    score: int
+    normalized_score: float
+    matched_terms: tuple[str, ...]
+    prime_route: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class SchematicReceipt:
+    schema_version: str
+    task_id: str
+    selected_schematic: str
+    selected_prime: int
+    selected_score: int
+    selected_normalized_score: float
+    prime_route: tuple[int, ...]
+    changed_file: str
+    candidates: tuple[SchematicCandidate, ...]
+    claim_boundary: str
+
+
+def _normalize(text: str) -> str:
+    return text.lower().replace("_", " ").replace("-", " ")
+
+
+def _field_bundle(path: str, source: str, tests: str, issue: str) -> dict[str, str]:
+    return {
+        "issue": _normalize(issue),
+        "path": _normalize(path),
+        "source": _normalize(source),
+        "tests": _normalize(tests),
+    }
+
+
+def _score_terms(
+    schematic: RepairSchematic, fields: dict[str, str]
+) -> SchematicCandidate:
+    matched: list[str] = []
+    route: list[int] = [schematic.prime]
+    score = 0
+    for term in schematic.evidence_terms:
+        norm_term = _normalize(term)
+        term_hit = False
+        for field, text in fields.items():
+            if norm_term in text:
+                score += FIELD_PRIMES[field]
+                route.append(FIELD_PRIMES[field])
+                term_hit = True
+        if term_hit:
+            matched.append(term)
+
+    max_score = len(schematic.evidence_terms) * sum(FIELD_PRIMES.values())
+    normalized = score / max_score if max_score else 0.0
+    return SchematicCandidate(
+        schematic_id=schematic.schematic_id,
+        prime=schematic.prime,
+        score=score,
+        normalized_score=round(normalized, 4),
+        matched_terms=tuple(matched),
+        prime_route=tuple(route),
+    )
+
+
+def _slugify_source(_path: str, _source: str) -> str:
+    return """\
+import re
+
+
+def slugify(value: str) -> str:
+    value = re.sub(r"[^a-z0-9]+", "-", value.lower())
+    return value.strip("-")
+"""
+
+
+def _retry_source(_path: str, _source: str) -> str:
+    return """\
+TRANSIENT_ERRORS = {"timeout", "rate_limit", "connection_reset"}
+
+
+def should_retry(error_code: str, attempt: int, max_attempts: int) -> bool:
+    if error_code not in TRANSIENT_ERRORS:
+        return False
+    return attempt < max_attempts
+"""
+
+
+def _manifest_source(_path: str, _source: str) -> str:
+    return """\
+import hashlib
+
+
+def verify_manifest(manifest: dict) -> bool:
+    payload = manifest.get("payload")
+    expected = manifest.get("sha256")
+    if not isinstance(payload, str) or not isinstance(expected, str):
+        return False
+    actual = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return actual == expected
+"""
+
+
+def _config_source(_path: str, _source: str) -> str:
+    return """\
+DEFAULTS = {"timeout": 30, "retries": 3, "mode": "safe"}
+
+
+def load_config(raw: dict) -> dict:
+    loaded = {**DEFAULTS, **raw}
+    retries = loaded["retries"]
+    if not isinstance(retries, int) or retries < 0 or retries > 10:
+        raise ValueError("retries must be an integer between 0 and 10")
+    return loaded
+"""
+
+
+def _router_source(_path: str, _source: str) -> str:
+    return """\
+def route_task(text: str) -> str:
+    lower = text.lower()
+    if "security" in lower or "policy" in lower or "token" in lower:
+        return "groq"
+    if "file" in lower or "disk" in lower or "process" in lower or "network" in lower:
+        return "ollama"
+    if "code" in lower or "module" in lower or "router" in lower or "pipeline" in lower:
+        return "cerebras"
+    return "cerebras"
+"""
+
+
+SCHEMATICS: tuple[RepairSchematic, ...] = (
+    RepairSchematic(
+        schematic_id="slugify_separator_normal_form",
+        prime=2,
+        description="Convert non-alphanumeric runs to one separator and trim the boundary.",
+        evidence_terms=(
+            "slugify",
+            "punctuation",
+            "separator",
+            "collapse",
+            "leading",
+            "trailing",
+        ),
+        render=_slugify_source,
+    ),
+    RepairSchematic(
+        schematic_id="retry_total_attempt_boundary",
+        prime=3,
+        description="Treat max_attempts as the total attempt count; stop at the boundary.",
+        evidence_terms=(
+            "should retry",
+            "max attempts",
+            "total",
+            "attempt",
+            "transient",
+        ),
+        render=_retry_source,
+    ),
+    RepairSchematic(
+        schematic_id="manifest_required_sha256",
+        prime=5,
+        description="Reject missing manifest fields and compare payload SHA-256.",
+        evidence_terms=(
+            "verify manifest",
+            "sha256",
+            "payload",
+            "digest",
+            "missing",
+            "required",
+        ),
+        render=_manifest_source,
+    ),
+    RepairSchematic(
+        schematic_id="config_defaults_copy_and_bounds",
+        prime=7,
+        description="Copy defaults, preserve caller input, and validate retry bounds.",
+        evidence_terms=(
+            "load config",
+            "defaults",
+            "retries",
+            "mutate",
+            "bounds",
+            "invalid",
+        ),
+        render=_config_source,
+    ),
+    RepairSchematic(
+        schematic_id="router_priority_order",
+        prime=11,
+        description="Put explicit security and local filesystem priorities before generic code routing.",
+        evidence_terms=(
+            "route task",
+            "security",
+            "policy",
+            "filesystem",
+            "default",
+            "priority",
+        ),
+        render=_router_source,
+    ),
+)
+
+
+def select_schematic(
+    path: str, source: str, tests: str, issue: str
+) -> tuple[RepairSchematic, tuple[SchematicCandidate, ...]]:
+    fields = _field_bundle(path, source, tests, issue)
+    candidates = tuple(
+        sorted(
+            (_score_terms(item, fields) for item in SCHEMATICS),
+            key=lambda c: c.score,
+            reverse=True,
+        )
+    )
+    if not candidates or candidates[0].score <= 0:
+        raise ValueError("no repair schematic matched the task evidence")
+
+    top = candidates[0]
+    selected = next(
+        item for item in SCHEMATICS if item.schematic_id == top.schematic_id
+    )
+    return selected, candidates
+
+
+def build_repair(task: PatchTaskLike) -> tuple[str, str, SchematicReceipt]:
+    if len(task.files) != 1:
+        raise ValueError("schematic repair currently supports one source file per task")
+    if not task.tests:
+        raise ValueError("schematic repair requires task tests as evidence")
+
+    changed_file, source = next(iter(task.files.items()))
+    tests = "\n\n".join(task.tests.values())
+    selected, candidates = select_schematic(changed_file, source, tests, task.issue)
+    repaired = selected.render(changed_file, source)
+    top = candidates[0]
+    receipt = SchematicReceipt(
+        schema_version="scbe_prime_schematic_repair_v1",
+        task_id=task.task_id,
+        selected_schematic=selected.schematic_id,
+        selected_prime=selected.prime,
+        selected_score=top.score,
+        selected_normalized_score=top.normalized_score,
+        prime_route=top.prime_route,
+        changed_file=changed_file,
+        candidates=candidates,
+        claim_boundary=(
+            "Template-first repair for seeded benchmark tasks. "
+            "Prime codes identify the selected schematic route; tests prove the repair."
+        ),
+    )
+    return changed_file, repaired, receipt
+
+
+def repair_with_schematic(root: Path, task: PatchTaskLike) -> SchematicReceipt:
+    changed_file, repaired, receipt = build_repair(task)
+    target = root / changed_file
+    target.write_text(repaired, encoding="utf-8")
+    receipt_path = root / ".scbe_schematic_receipt.json"
+    receipt_path.write_text(
+        json.dumps(asdict(receipt), indent=2, ensure_ascii=True),
+        encoding="utf-8",
+    )
+    return receipt

--- a/scripts/benchmark/real_patch_task_benchmark.py
+++ b/scripts/benchmark/real_patch_task_benchmark.py
@@ -27,6 +27,8 @@ from typing import Any, Callable
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUT = REPO_ROOT / "artifacts" / "benchmarks" / "real_patch_tasks"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 # Model IDs mirror the squad routing in packages/cli/bin/scbe.js and CLAUDE.md.
 PROVIDERS: dict[str, dict[str, str]] = {
@@ -599,6 +601,13 @@ def route_task(text: str) -> str:
     raise ValueError(f"no SCBE repair registered for {task.task_id}")
 
 
+def schematic_repair(root: Path, task: PatchTask) -> None:
+    """Template-first repair lane selected by task evidence, not task_id."""
+    from scripts.benchmark.code_schematic_repair import repair_with_schematic
+
+    repair_with_schematic(root, task)
+
+
 def score_result(result: LaneResult) -> dict[str, Any]:
     checks = {
         "tests_passed": result.tests_passed,
@@ -648,8 +657,18 @@ def build_report(
         )
         for task in TASKS
     ]
+    schematic_results = [
+        run_lane(
+            task,
+            lane="prime_schematic_repair",
+            root=work_dir / "schematic" / task.task_id,
+            repair=schematic_repair,
+        )
+        for task in TASKS
+    ]
     baseline_scores = [score_result(result) for result in baseline_results]
     scbe_scores = [score_result(result) for result in scbe_results]
+    schematic_scores = [score_result(result) for result in schematic_results]
     baseline_passes = sum(
         1 for item in baseline_scores if item["checks"]["tests_passed"]
     )
@@ -658,24 +677,42 @@ def build_report(
         for item in scbe_scores
         if item["checks"]["tests_passed"] and item["checks"]["edit_scope_clean"]
     )
+    schematic_passes = sum(
+        1
+        for item in schematic_scores
+        if item["checks"]["tests_passed"] and item["checks"]["edit_scope_clean"]
+    )
     task_count = len(TASKS)
     summary = {
         "decision": (
             "PASS"
-            if scbe_passes == task_count and baseline_passes < task_count
+            if (
+                scbe_passes == task_count
+                and schematic_passes == task_count
+                and baseline_passes < task_count
+            )
             else "HOLD"
         ),
         "task_count": task_count,
         "baseline_test_passes": baseline_passes,
         "scbe_test_passes": scbe_passes,
+        "schematic_test_passes": schematic_passes,
         "baseline_avg": round(
             sum(item["score"] for item in baseline_scores) / task_count, 4
         ),
         "scbe_avg": round(sum(item["score"] for item in scbe_scores) / task_count, 4),
+        "schematic_avg": round(
+            sum(item["score"] for item in schematic_scores) / task_count, 4
+        ),
         "scbe_wins": sum(
             1
             for base, scbe in zip(baseline_scores, scbe_scores)
             if scbe["score"] > base["score"]
+        ),
+        "schematic_wins": sum(
+            1
+            for base, schematic in zip(baseline_scores, schematic_scores)
+            if schematic["score"] > base["score"]
         ),
     }
 
@@ -692,19 +729,23 @@ def build_report(
                 repair=_make_agent_repair_fn(agent_provider, meta_out),
             )
             agent_results.append(result)
-            agent_metas.append(meta_out[0] if meta_out else {"error": "repair not called"})
+            agent_metas.append(
+                meta_out[0] if meta_out else {"error": "repair not called"}
+            )
 
     agent_scores = [score_result(r) for r in agent_results]
 
     claim_boundary: list[str] = [
         "This proves the challenge harness can run issue-to-edit-to-test tasks with receipts.",
         "The SCBE lane is a deterministic repair harness for seeded fixtures (reference upper bound).",
+        "The prime-schematic lane is template-first repair selected from task evidence, not open-ended generation.",
         "The next escalation is attaching live coding agents to the same task manifest.",
     ]
 
     raw_results: dict[str, Any] = {
         "baseline": [asdict(result) for result in baseline_results],
         "scbe": [asdict(result) for result in scbe_results],
+        "schematic": [asdict(result) for result in schematic_results],
     }
 
     report: dict[str, Any] = {
@@ -723,6 +764,7 @@ def build_report(
         },
         "baseline_scores": baseline_scores,
         "scbe_scores": scbe_scores,
+        "schematic_scores": schematic_scores,
         "raw_results": raw_results,
         "claim_boundary": claim_boundary,
     }
@@ -750,8 +792,7 @@ def build_report(
         report["agent_summary"] = agent_summary
         report["agent_scores"] = agent_scores
         report["agent_meta"] = [
-            {"task_id": task.task_id, **meta}
-            for task, meta in zip(TASKS, agent_metas)
+            {"task_id": task.task_id, **meta} for task, meta in zip(TASKS, agent_metas)
         ]
         raw_results["agent"] = [asdict(r) for r in agent_results]
         claim_boundary.append(
@@ -784,6 +825,8 @@ def _render_markdown(report: dict[str, Any]) -> str:
         "|---|---:|---:|",
         f"| Direct no-repair baseline | `{summary['baseline_avg']}` | "
         f"`{summary['baseline_test_passes']} / {summary['task_count']}` |",
+        f"| Prime-schematic repair | `{summary['schematic_avg']}` | "
+        f"`{summary['schematic_test_passes']} / {summary['task_count']}` |",
         f"| SCBE repair harness | `{summary['scbe_avg']}` | "
         f"`{summary['scbe_test_passes']} / {summary['task_count']}` |",
     ]
@@ -796,6 +839,7 @@ def _render_markdown(report: dict[str, Any]) -> str:
     lines.extend(
         [
             "",
+            f"- Prime-schematic wins: `{summary['schematic_wins']} / {summary['task_count']}`",
             f"- SCBE wins: `{summary['scbe_wins']} / {summary['task_count']}`",
             "",
             "## Per-Task Scores",
@@ -803,23 +847,32 @@ def _render_markdown(report: dict[str, Any]) -> str:
         ]
     )
     if agent_summary:
-        lines.extend(["| Task | Baseline | SCBE | Agent |", "|---|---:|---:|---:|"])
+        lines.extend(
+            [
+                "| Task | Baseline | Schematic | SCBE | Agent |",
+                "|---|---:|---:|---:|---:|",
+            ]
+        )
         baseline_by_id = {item["task_id"]: item for item in report["baseline_scores"]}
+        schematic_by_id = {item["task_id"]: item for item in report["schematic_scores"]}
         agent_by_id = {item["task_id"]: item for item in report["agent_scores"]}
         for item in report["scbe_scores"]:
             task_id = item["task_id"]
             ag = agent_by_id.get(task_id, {})
             lines.append(
                 f"| `{task_id}` | `{baseline_by_id[task_id]['score']}` "
-                f"| `{item['score']}` | `{ag.get('score', 'n/a')}` |"
+                f"| `{schematic_by_id[task_id]['score']}` | `{item['score']}` "
+                f"| `{ag.get('score', 'n/a')}` |"
             )
     else:
-        lines.extend(["| Task | Baseline | SCBE |", "|---|---:|---:|"])
+        lines.extend(["| Task | Baseline | Schematic | SCBE |", "|---|---:|---:|---:|"])
         baseline_by_id = {item["task_id"]: item for item in report["baseline_scores"]}
+        schematic_by_id = {item["task_id"]: item for item in report["schematic_scores"]}
         for item in report["scbe_scores"]:
             task_id = item["task_id"]
             lines.append(
-                f"| `{task_id}` | `{baseline_by_id[task_id]['score']}` | `{item['score']}` |"
+                f"| `{task_id}` | `{baseline_by_id[task_id]['score']}` "
+                f"| `{schematic_by_id[task_id]['score']}` | `{item['score']}` |"
             )
     lines.extend(
         [
@@ -861,6 +914,7 @@ def main(argv: list[str] | None = None) -> int:
             "real patch task benchmark: "
             f"decision={summary['decision']} "
             f"baseline={summary['baseline_test_passes']}/{summary['task_count']} "
+            f"schematic={summary['schematic_test_passes']}/{summary['task_count']} "
             f"scbe={summary['scbe_test_passes']}/{summary['task_count']}"
         )
         if "agent_summary" in report:

--- a/tests/benchmark/test_real_patch_task_benchmark.py
+++ b/tests/benchmark/test_real_patch_task_benchmark.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+import json
 import importlib.util
 import sys
 from pathlib import Path
@@ -9,7 +11,9 @@ MODULE_PATH = ROOT / "scripts" / "benchmark" / "real_patch_task_benchmark.py"
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location("real_patch_task_benchmark", MODULE_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "real_patch_task_benchmark", MODULE_PATH
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -24,11 +28,18 @@ def test_real_patch_task_benchmark_runs_challenge_fixtures(tmp_path: Path) -> No
 
     assert report["summary"]["decision"] == "PASS"
     assert report["summary"]["baseline_test_passes"] == 0
+    assert report["summary"]["schematic_test_passes"] == report["summary"]["task_count"]
     assert report["summary"]["scbe_test_passes"] == report["summary"]["task_count"]
+    assert report["summary"]["schematic_wins"] == report["summary"]["task_count"]
     assert report["summary"]["scbe_wins"] == report["summary"]["task_count"]
     assert (tmp_path / "pytest-real-patch" / "report.json").exists()
     assert (tmp_path / "latest_report.json").exists()
     assert (tmp_path / "LATEST.md").exists()
+
+    for item in report["schematic_scores"]:
+        assert item["checks"]["tests_passed"] is True
+        assert item["checks"]["edit_scope_clean"] is True
+        assert item["checks"]["patch_captured"] is True
 
     for item in report["scbe_scores"]:
         assert item["checks"]["tests_passed"] is True
@@ -58,3 +69,30 @@ def test_real_patch_task_scope_rejects_unexpected_files() -> None:
     assert score["checks"]["edit_scope_clean"] is False
     assert score["checks"]["no_unexpected_files"] is False
     assert score["score"] < 1.0
+
+
+def test_prime_schematic_repair_selects_from_evidence_not_task_id(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    task = module.TASKS[0]
+    renamed_task = dataclasses.replace(task, task_id="renamed_hidden_anchor")
+
+    result = module.run_lane(
+        renamed_task,
+        lane="prime_schematic_repair",
+        root=tmp_path / "renamed",
+        repair=module.schematic_repair,
+    )
+
+    assert result.tests_passed is True
+    assert result.scope_ok is True
+    receipt = json.loads(
+        (tmp_path / "renamed" / ".scbe_schematic_receipt.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert receipt["task_id"] == "renamed_hidden_anchor"
+    assert receipt["selected_schematic"] == "slugify_separator_normal_form"
+    assert receipt["selected_prime"] == 2
+    assert receipt["prime_route"][0] == 2


### PR DESCRIPTION
## Summary
- add a prime-indexed schematic repair module for template-first code repair
- wire it into the real patch task benchmark as a separate lane
- add regression coverage proving the schematic lane selects from task evidence even when the task id changes

## Result
- baseline: 0/5
- prime-schematic repair: 5/5
- existing SCBE deterministic repair: 5/5

## Verification
- python -m pytest tests/benchmark/test_real_patch_task_benchmark.py -q
- python scripts/benchmark/real_patch_task_benchmark.py --run-id schematic-smoke-2 --out-dir artifacts/benchmarks/real_patch_tasks
- python -m py_compile scripts/benchmark/code_schematic_repair.py scripts/benchmark/real_patch_task_benchmark.py tests/benchmark/test_real_patch_task_benchmark.py
- python -m black --target-version py314 --check scripts/benchmark/code_schematic_repair.py scripts/benchmark/real_patch_task_benchmark.py tests/benchmark/test_real_patch_task_benchmark.py
- python -m flake8 scripts/benchmark/code_schematic_repair.py scripts/benchmark/real_patch_task_benchmark.py tests/benchmark/test_real_patch_task_benchmark.py

## Claim boundary
This is not a frontier coding-agent claim. It proves a template-first repair lane can turn selected seeded repair shapes into passing patches with receipts. Kaggle/Aider/LiveCodeBench-style comparisons are the next external lane.