### PR TITLE
fix(repo): restore lint and pocket tutor tests

### DIFF
--- a/src/geoseal_cli.py
+++ b/src/geoseal_cli.py
@@ -5130,6 +5130,7 @@ def cmd_bench_api(args: argparse.Namespace) -> int:
     verbose = bool(getattr(args, "verbose", False))
 
     formats = ["json", "mermaid", "dot", "tree"]
+
     def _time_n(fn, n: int) -> Dict[str, float]:
         times = []
         for _ in range(n):

--- a/tests/benchmark/test_real_patch_task_benchmark.py
+++ b/tests/benchmark/test_real_patch_task_benchmark.py
@@ -11,9 +11,7 @@ MODULE_PATH = ROOT / "scripts" / "benchmark" / "real_patch_task_benchmark.py"
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location(
-        "real_patch_task_benchmark", MODULE_PATH
-    )
+    spec = importlib.util.spec_from_file_location("real_patch_task_benchmark", MODULE_PATH)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -87,11 +85,7 @@ def test_prime_schematic_repair_selects_from_evidence_not_task_id(
 
     assert result.tests_passed is True
     assert result.scope_ok is True
-    receipt = json.loads(
-        (tmp_path / "renamed" / ".scbe_schematic_receipt.json").read_text(
-            encoding="utf-8"
-        )
-    )
+    receipt = json.loads((tmp_path / "renamed" / ".scbe_schematic_receipt.json").read_text(encoding="utf-8"))
     assert receipt["task_id"] == "renamed_hidden_anchor"
     assert receipt["selected_schematic"] == "slugify_separator_normal_form"
     assert receipt["selected_prime"] == 2


### PR DESCRIPTION
## Summary
- apply the Black formatting fix that PR #2105 needed after it auto-merged
- fix the repo-wide Ruff failures exposed by CI
- repair invalid `packages/agent-bus/tools.json` so BFCL export tests can parse the tool registry
- add the missing deterministic `pocket_drawing_tutor.py` module required by `pocket_video_gen.py` and video-lattice tests

## Verification
- `python -m ruff check src tests scripts/benchmark scripts/video_lattice`
- `python -m black --check --target-version py311 --line-length 120 src/ tests/`
- `python -m pytest tests/benchmark/test_real_patch_task_benchmark.py tests/benchmark/test_bfcl_tool_call_adapter.py tests/geoseed/test_theory_fit.py tests/longform/test_context_bridge.py tests/video_lattice/test_video_lattice.py -q` (155 passed)
- `python scripts/benchmark/real_patch_task_benchmark.py --run-id schematic-smoke-main-hygiene --out-dir artifacts/benchmarks/real_patch_tasks`
- `python -m py_compile ...` for touched Python modules/scripts/tests
- `python -m json.tool packages/agent-bus/tools.json`
- `git diff --check`

## Notes
PR #2105 merged before the formatting commit reached its branch. This PR repairs the lint gate and the small repo breakages surfaced while validating the affected tests.
