### PR TITLE
feat(site): tighten workflow snapshot money path

### DIFF
--- a/docs/ai-workflow-snapshot.html
+++ b/docs/ai-workflow-snapshot.html
@@ -3,13 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>$39 AI Workflow Snapshot | AetherMoore</title>
+    <title>$99 AI Workflow Snapshot | AetherMoore</title>
     <meta
       name="description"
-      content="A $39 AI workflow risk receipt: three failure risks, unsafe tool paths, missing receipt points, and next fixes. Static intake form, no backend required."
+      content="A $99 AI workflow risk receipt: three failure risks, unsafe tool paths, missing receipt points, and next fixes. Static intake form, no backend required."
     />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/ai-workflow-snapshot.html" />
+    <link
+      rel="canonical"
+      href="https://aethermoore.com/SCBE-AETHERMOORE/ai-workflow-snapshot.html"
+    />
     <link rel="stylesheet" href="static/polly-sidebar-agent.css" />
     <style>
       :root {
@@ -41,9 +44,14 @@
           radial-gradient(circle at 82% 14%, rgba(140, 180, 255, 0.2), transparent 34%),
           radial-gradient(circle at 12% 2%, rgba(214, 167, 86, 0.18), transparent 30%),
           linear-gradient(180deg, #0a0b0d 0%, #111720 52%, #090a0c 100%);
-        background-size: 44px 44px, 44px 44px, auto, auto, auto;
+        background-size:
+          44px 44px,
+          44px 44px,
+          auto,
+          auto,
+          auto;
         color: var(--text);
-        font-family: "Aptos", "Segoe UI", system-ui, sans-serif;
+        font-family: 'Aptos', 'Segoe UI', system-ui, sans-serif;
         line-height: 1.55;
       }
 
@@ -127,7 +135,7 @@
       h1 {
         max-width: 11ch;
         margin-bottom: 18px;
-        font-family: Georgia, "Times New Roman", serif;
+        font-family: Georgia, 'Times New Roman', serif;
         font-size: clamp(46px, 8vw, 86px);
         line-height: 0.94;
         letter-spacing: 0;
@@ -198,14 +206,14 @@
       }
 
       .price {
-        font-family: Georgia, "Times New Roman", serif;
+        font-family: Georgia, 'Times New Roman', serif;
         font-size: 72px;
         line-height: 0.95;
       }
 
       .price small {
         color: var(--soft);
-        font-family: "Aptos", "Segoe UI", system-ui, sans-serif;
+        font-family: 'Aptos', 'Segoe UI', system-ui, sans-serif;
         font-size: 15px;
         font-weight: 700;
       }
@@ -286,7 +294,7 @@
 
       .receipt code,
       .mono {
-        font-family: "Cascadia Code", "SF Mono", Consolas, monospace;
+        font-family: 'Cascadia Code', 'SF Mono', Consolas, monospace;
       }
 
       .receipt .body {
@@ -378,7 +386,7 @@
 
       .copy-box code {
         color: var(--text);
-        font-family: "Cascadia Code", "SF Mono", Consolas, monospace;
+        font-family: 'Cascadia Code', 'SF Mono', Consolas, monospace;
         font-size: 13px;
       }
 
@@ -435,12 +443,12 @@
     <main>
       <section class="hero">
         <div>
-          <p class="eyebrow">No-backend starter offer</p>
+          <p class="eyebrow">Static intake starter offer</p>
           <h1>AI Workflow Snapshot</h1>
           <p class="lead">
-            A cheaper first read for one AI workflow. You get a receipt-style failure map:
-            what can go wrong, what evidence is missing, and the next three fixes. No
-            subscription, no sales call, no secrets required.
+            A first paid read for one AI workflow. Build the intake packet locally, pay with the
+            live $99 checkout, and get a receipt-style failure map: what can go wrong, what evidence
+            is missing, and the next three fixes.
           </p>
           <div class="actions">
             <a class="btn" href="#intake">Build intake packet</a>
@@ -449,13 +457,13 @@
           </div>
         </div>
 
-        <aside class="price-card" aria-label="$39 AI Workflow Snapshot offer">
+        <aside class="price-card" aria-label="$99 AI Workflow Snapshot offer">
           <div>
             <p class="eyebrow">Entry offer</p>
-            <div class="price">$39 <small>one workflow</small></div>
+            <div class="price">$99 <small>one workflow</small></div>
             <p>
-              Best for solo builders, small automations, MCP experiments, prompt chains,
-              local Ollama flows, n8n automations, and early agent prototypes.
+              Best for solo builders, small automations, MCP experiments, prompt chains, local
+              Ollama flows, n8n automations, and early agent prototypes.
             </p>
           </div>
           <div>
@@ -463,11 +471,21 @@
               <li><span class="dot"></span><span>One receipt-style failure memo.</span></li>
               <li><span class="dot"></span><span>Three practical fixes.</span></li>
               <li><span class="dot"></span><span>Upgrade credit toward the $500 review.</span></li>
-              <li><span class="dot"></span><span>Delivered manually after payment and intake arrive.</span></li>
+              <li>
+                <span class="dot"></span
+                ><span>Delivered manually after payment and intake arrive.</span>
+              </li>
             </ul>
           </div>
           <div>
-            <a class="btn" href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l" target="_blank" rel="noopener" style="width:100%;justify-content:center">Start for $99 with Stripe →</a>
+            <a
+              class="btn"
+              href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
+              target="_blank"
+              rel="noopener"
+              style="width: 100%; justify-content: center"
+              >Start for $99 with Stripe →</a
+            >
           </div>
         </aside>
       </section>
@@ -477,22 +495,22 @@
           <article class="card">
             <h3>Good fit</h3>
             <p>
-              One workflow that already exists or can be described clearly: prompts, tools,
-              model calls, files, APIs, browser actions, or handoff steps.
+              One workflow that already exists or can be described clearly: prompts, tools, model
+              calls, files, APIs, browser actions, or handoff steps.
             </p>
           </article>
           <article class="card">
             <h3>Not a fit</h3>
             <p>
-              Legal certification, emergency incident response, compliance attestation,
-              secret handling, or unlimited consulting. This is a first read.
+              Legal certification, emergency incident response, compliance attestation, secret
+              handling, or unlimited consulting. This is a first read.
             </p>
           </article>
           <article class="card">
-            <h3>Why this is cheaper</h3>
+            <h3>Why this is fast</h3>
             <p>
-              The intake is structured, the deliverable is bounded, and the first pass is
-              manual. That keeps the entry offer small enough to buy without a meeting.
+              The intake is structured, the deliverable is bounded, and the first pass is manual.
+              That keeps the offer clear enough to buy without a meeting.
             </p>
           </article>
         </div>
@@ -508,14 +526,26 @@
               <code>example-only / no certification</code>
             </header>
             <div class="body">
-              <p><strong>Workflow:</strong> local research assistant that reads notes, drafts a summary, and can write files.</p>
-              <p><strong>Primary risk:</strong> retrieved content can influence a write action without a human checkpoint.</p>
-              <p><strong>Missing evidence:</strong> no joined log connecting prompt, retrieved source, tool call, file path, and final output.</p>
+              <p>
+                <strong>Workflow:</strong> local research assistant that reads notes, drafts a
+                summary, and can write files.
+              </p>
+              <p>
+                <strong>Primary risk:</strong> retrieved content can influence a write action
+                without a human checkpoint.
+              </p>
+              <p>
+                <strong>Missing evidence:</strong> no joined log connecting prompt, retrieved
+                source, tool call, file path, and final output.
+              </p>
               <p><strong>Next three fixes:</strong></p>
               <ol>
                 <li>Add an explicit review gate before file writes.</li>
                 <li>Log prompt, source id, tool call, and destination path in one receipt.</li>
-                <li>Block tool calls when retrieved text requests secrets, credentials, or policy bypass.</li>
+                <li>
+                  Block tool calls when retrieved text requests secrets, credentials, or policy
+                  bypass.
+                </li>
               </ol>
               <div class="pill-row" aria-label="Example receipt labels">
                 <span class="pill">ALLOW with review</span>
@@ -534,12 +564,12 @@
             <p class="eyebrow">No backend intake</p>
             <h2>Build the JSON packet locally.</h2>
             <p class="lead">
-              Fill this out in the browser, download the JSON, then send that file after
-              payment. Nothing is submitted from this page.
+              Fill this out in the browser, download the JSON, then send that file after payment.
+              Nothing is submitted from this page.
             </p>
             <div class="note">
-              Keep secrets out. Redact keys, tokens, private customer data, and anything
-              you would not put in an email.
+              Keep secrets out. Redact keys, tokens, private customer data, and anything you would
+              not put in an email.
             </div>
           </div>
 
@@ -560,16 +590,32 @@
             </select>
 
             <label for="description">What it does</label>
-            <textarea id="description" name="description" placeholder="Describe the workflow in plain language."></textarea>
+            <textarea
+              id="description"
+              name="description"
+              placeholder="Describe the workflow in plain language."
+            ></textarea>
 
             <label for="tools">Tools it can call</label>
-            <textarea id="tools" name="tools" placeholder="Files, browser, email, Slack, APIs, database, shell, MCP tools, etc."></textarea>
+            <textarea
+              id="tools"
+              name="tools"
+              placeholder="Files, browser, email, Slack, APIs, database, shell, MCP tools, etc."
+            ></textarea>
 
             <label for="worry">What you are worried could go wrong</label>
-            <textarea id="worry" name="worry" placeholder="Prompt injection, bad tool calls, data leak, wrong file write, cost runaway, etc."></textarea>
+            <textarea
+              id="worry"
+              name="worry"
+              placeholder="Prompt injection, bad tool calls, data leak, wrong file write, cost runaway, etc."
+            ></textarea>
 
             <label for="links">Safe links or references</label>
-            <textarea id="links" name="links" placeholder="Public repo, docs, diagram link, screenshots list, or 'none'."></textarea>
+            <textarea
+              id="links"
+              name="links"
+              placeholder="Public repo, docs, diagram link, screenshots list, or 'none'."
+            ></textarea>
 
             <div class="actions">
               <button class="btn" type="button" id="downloadPacket">Download intake JSON</button>
@@ -585,8 +631,8 @@
             <p class="eyebrow">Generated packet</p>
             <h2>Preview before you send.</h2>
             <p>
-              This is the exact structured intake. The clearer this is, the faster the
-              receipt can be written.
+              This is the exact structured intake. The clearer this is, the faster the receipt can
+              be written.
             </p>
           </div>
           <pre id="packetOutput" class="output" aria-live="polite"></pre>
@@ -596,23 +642,28 @@
       <section id="pay" class="band">
         <div class="wrap grid">
           <article class="card">
-            <h3>Pay — $39 Cash App or $99 Stripe</h3>
+            <h3>Pay — $99 Stripe or manual alternate</h3>
             <p>
-              Cash App <strong>$IzzyDDavis7</strong> for the $39 entry — put
-              <strong>AI Workflow Snapshot</strong> in the note. Or use Stripe for the
-              formal $99 receipt-backed review with upgrade credit toward the $500 Governance Snapshot.
+              Use Stripe for the formal $99 receipt-backed review with upgrade credit toward the
+              $500 Governance Snapshot. Cash App <strong>$IzzyDDavis7</strong> remains available as
+              a manual alternate; put <strong>AI Workflow Snapshot</strong> in the note.
             </p>
             <div class="actions">
-              <a class="btn" href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l" target="_blank" rel="noopener">$99 with Stripe →</a>
+              <a
+                class="btn"
+                href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
+                target="_blank"
+                rel="noopener"
+                >$99 with Stripe →</a
+              >
               <a class="btn secondary" href="workflow-snapshot.html">Full $99 offer</a>
             </div>
           </article>
           <article class="card">
             <h3>Send after payment</h3>
             <p>
-              Download the JSON intake packet above, then email it after checkout.
-              That pairs your payment to a specific workflow so the review starts
-              immediately.
+              Download the JSON intake packet above, then email it after checkout. That pairs your
+              payment to a specific workflow so the review starts immediately.
             </p>
             <div class="copy-box">
               <code id="snapshotEmail">issdandavis7795@gmail.com</code>
@@ -622,10 +673,10 @@
           <article class="card">
             <h3>Upgrade path</h3>
             <p>
-              If the first read surfaces a deeper issue, the $99 can be credited
-              toward the <a href="governance-snapshot.html">$500 Governance Snapshot</a>.
-              Cash App <strong>$IzzyDDavis7</strong> is available for the entry read
-              if Stripe is not convenient.
+              If the first read surfaces a deeper issue, the $99 can be credited toward the
+              <a href="governance-snapshot.html">$500 Governance Snapshot</a>. Cash App
+              <strong>$IzzyDDavis7</strong> is available as the manual alternate if Stripe is not
+              convenient.
             </p>
           </article>
         </div>
@@ -636,23 +687,23 @@
           <article class="card">
             <h3>Newsletter without a platform</h3>
             <p>
-              Ask for "updates" in the intake packet or email subject. Updates can go out
-              from Proton/Gmail manually: new receipt examples, new checklists, and small
-              governance lessons from real workflows.
+              Ask for "updates" in the intake packet or email subject. Updates can go out from
+              Proton/Gmail manually: new receipt examples, new checklists, and small governance
+              lessons from real workflows.
             </p>
           </article>
           <article class="card">
             <h3>Good first mailing</h3>
             <p>
-              "3 ways AI workflows fail before the model is the problem." It points to the
-              free self-check, this $39 intake, and one public proof receipt.
+              "3 ways AI workflows fail before the model is the problem." It points to the free
+              self-check, this $99 intake, and one public proof receipt.
             </p>
           </article>
           <article class="card">
             <h3>Simple rule</h3>
             <p>
-              No scraped list, no spam blast. Only people who asked for updates, bought a
-              snapshot, or directly requested follow-up.
+              No scraped list, no spam blast. Only people who asked for updates, bought a snapshot,
+              or directly requested follow-up.
             </p>
           </article>
         </div>
@@ -661,33 +712,35 @@
 
     <footer>
       <div class="wrap">
-        AetherMoore / SCBE-AETHERMOORE. Static page, local intake packet, no backend form submission.
+        AetherMoore / SCBE-AETHERMOORE. Static page, local intake packet, no backend form
+        submission.
       </div>
     </footer>
 
     <script>
       (function () {
-        var form = document.getElementById("snapshotForm");
-        var output = document.getElementById("packetOutput");
+        var form = document.getElementById('snapshotForm');
+        var output = document.getElementById('packetOutput');
 
         function value(id) {
-          return (document.getElementById(id).value || "").trim();
+          return (document.getElementById(id).value || '').trim();
         }
 
         function packet() {
           return {
-            packet_type: "aethermoore_ai_workflow_snapshot_intake_v1",
-            offer: "AI Workflow Snapshot",
+            packet_type: 'aethermoore_ai_workflow_snapshot_intake_v1',
+            offer: 'AI Workflow Snapshot',
             price_usd: 39,
             created_at: new Date().toISOString(),
-            contact: value("contact"),
-            workflow_name: value("workflow"),
-            stage: value("stage"),
-            description: value("description"),
-            tools: value("tools"),
-            primary_worry: value("worry"),
-            safe_links_or_references: value("links"),
-            redaction_ack: "Do not include secrets, credentials, private customer data, or API keys.",
+            contact: value('contact'),
+            workflow_name: value('workflow'),
+            stage: value('stage'),
+            description: value('description'),
+            tools: value('tools'),
+            primary_worry: value('worry'),
+            safe_links_or_references: value('links'),
+            redaction_ack:
+              'Do not include secrets, credentials, private customer data, or API keys.',
           };
         }
 
@@ -696,15 +749,18 @@
         }
 
         function filename() {
-          var name = value("workflow").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-          return "ai-workflow-snapshot-intake-" + (name || Date.now()) + ".json";
+          var name = value('workflow')
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-|-$/g, '');
+          return 'ai-workflow-snapshot-intake-' + (name || Date.now()) + '.json';
         }
 
-        document.getElementById("downloadPacket").addEventListener("click", function () {
+        document.getElementById('downloadPacket').addEventListener('click', function () {
           render();
-          var blob = new Blob([output.textContent + "\n"], { type: "application/json" });
+          var blob = new Blob([output.textContent + '\n'], { type: 'application/json' });
           var url = URL.createObjectURL(blob);
-          var a = document.createElement("a");
+          var a = document.createElement('a');
           a.href = url;
           a.download = filename();
           document.body.appendChild(a);
@@ -715,29 +771,33 @@
           }, 800);
         });
 
-        document.getElementById("copyPacket").addEventListener("click", function () {
+        document.getElementById('copyPacket').addEventListener('click', function () {
           render();
           if (navigator.clipboard) {
             navigator.clipboard.writeText(output.textContent);
           }
         });
 
-        document.querySelectorAll("[data-copy]").forEach(function (button) {
-          button.addEventListener("click", function () {
-            var target = document.getElementById(button.getAttribute("data-copy"));
+        document.querySelectorAll('[data-copy]').forEach(function (button) {
+          button.addEventListener('click', function () {
+            var target = document.getElementById(button.getAttribute('data-copy'));
             if (target && navigator.clipboard) {
               navigator.clipboard.writeText(target.textContent.trim());
             }
           });
         });
 
-        form.addEventListener("input", render);
+        form.addEventListener('input', render);
         render();
       })();
     </script>
     <script>
       window.POLLY_STATIC_ONLY = true;
     </script>
-    <script src="static/polly-sidebar-agent.js" data-polly-api="." data-polly-static="true"></script>
+    <script
+      src="static/polly-sidebar-agent.js"
+      data-polly-api="."
+      data-polly-static="true"
+    ></script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -857,9 +857,12 @@
           <a href="start-here.html">Start Here</a>
           <a class="nav-feature" href="cli.html">Terminal</a>
           <a class="nav-feature" href="math-spine.html">Math Spine</a>
-          <a href="guard.html" style="color:#17c6cf;font-weight:700;">AetherGuard</a>
+          <a href="guard.html" style="color: #17c6cf; font-weight: 700">AetherGuard</a>
           <a href="products.html">Products</a>
-          <a href="https://scbe-agent-bridge-vercel.vercel.app/console" target="_blank" rel="noopener"
+          <a
+            href="https://scbe-agent-bridge-vercel.vercel.app/console"
+            target="_blank"
+            rel="noopener"
             >Hosted Tools</a
           >
           <a href="solutions.html">Solutions</a>
@@ -927,15 +930,27 @@
     <div class="quick-support-bar" aria-label="Fast support links">
       <div class="quick-support-inner">
         <span
-          ><strong>Live now:</strong> <code style="background:rgba(255,255,255,0.08);border-radius:4px;padding:1px 6px;font-size:13px">scbe shell --squad</code> (free 3-slot AI CLI), public proof packets, $99 Workflow Snapshot, agent bus on npm. Run it before you trust it.</span
+          ><strong>Live now:</strong>
+          <code
+            style="
+              background: rgba(255, 255, 255, 0.08);
+              border-radius: 4px;
+              padding: 1px 6px;
+              font-size: 13px;
+            "
+            >scbe shell --squad</code
+          >
+          (free 3-slot AI CLI), public proof packets, $99 Workflow Snapshot, agent bus on npm. Run
+          it before you trust it.</span
         >
         <div class="quick-support-actions">
-          <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
-            >Support on Ko-fi</a
-          >
+          <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener">Support on Ko-fi</a>
           <a href="payments.html#cash-app">Cash App $IzzyDDavis7</a>
           <a href="payments.html">All payment paths</a>
-          <a href="https://scbe-agent-bridge-vercel.vercel.app/console" target="_blank" rel="noopener"
+          <a
+            href="https://scbe-agent-bridge-vercel.vercel.app/console"
+            target="_blank"
+            rel="noopener"
             >Open hosted tools</a
           >
         </div>
@@ -949,23 +964,27 @@
             <div class="eyebrow">Evidence-first AI tools for builders</div>
             <h1>Build, test, and keep what survives contact with reality.</h1>
             <p>
-              SCBE-AETHERMOORE is an experimental agentic operating system focused on durable workflows, governed tool use, audit trails, cross-language transformation, and evidence-backed automation. The rule is simple: unusual ideas are allowed, but public claims need commands, artifacts, and boundaries.
+              SCBE-AETHERMOORE is an experimental agentic operating system focused on durable
+              workflows, governed tool use, audit trails, cross-language transformation, and
+              evidence-backed automation. The rule is simple: unusual ideas are allowed, but public
+              claims need commands, artifacts, and boundaries.
             </p>
             <p>
-              The open-source core runs today for free: <strong>agent bus</strong> (54 governed tools on npm), <strong>squad shell</strong> (3-slot agentic CLI that auto-routes tasks to the right AI model), and a <strong>governed pathfinding harness</strong> with SHA-256 receipt chains. Inspect, fork, and run them before spending anything.
+              The open-source core runs today for free: <strong>agent bus</strong> (54 governed
+              tools on npm), <strong>squad shell</strong> (3-slot agentic CLI that auto-routes tasks
+              to the right AI model), and a <strong>governed pathfinding harness</strong> with
+              SHA-256 receipt chains. Inspect, fork, and run them before spending anything.
             </p>
             <p>
-              <strong>AetherMoore</strong> also sells three packaged starter lanes: a <strong>$29 governance toolkit</strong>
-              (templates, a buyer manual, and live pipeline demos you can use in an afternoon), a
-              <strong>$99 Workflow Snapshot</strong> (send your agent setup, get a clear action plan
-              back), and a <strong>$29 Training Vault</strong> (fine-tune your own governed model
-              with clean SFT data and a Colab notebook). One-time purchases, no subscription.
+              The fastest paid path is the <strong>$99 Workflow Snapshot</strong>: send one agent
+              setup, repo link, MCP stack, prompt chain, or automation flow; get back a concise
+              failure map and the next three fixes. One workflow, one receipt, no subscription.
             </p>
             <p style="max-width: 58ch; font-size: 16px; color: var(--text); margin-top: -8px">
               Built by Issac Davis: I explore unusual models, implement them, test them, and keep
-              what survives. SAM.gov registered, CAGE-code verified (UEI J4NXHM6N5F59, CAGE
-              1EXD5). Live demos and Polly chat are public — inspect the system and test it before
-              you spend a dollar.
+              what survives. SAM.gov registered, CAGE-code verified (UEI J4NXHM6N5F59, CAGE 1EXD5).
+              Live demos and Polly chat are public — inspect the system and test it before you spend
+              a dollar.
             </p>
             <div
               role="region"
@@ -987,10 +1006,12 @@
                 align-items: center;
               "
             >
-              <strong style="color: var(--accent-strong)">First time here?</strong>
+              <strong style="color: var(--accent-strong)"
+                >Have one workflow you don't trust?</strong
+              >
               <span style="color: var(--text); font-size: 15px"
-                >Three questions, one recommendation — picks the right tool in about 60
-                seconds.</span
+                >Buy the $99 Snapshot, send the intake packet, and get a risk memo with the next
+                three fixes.</span
               >
               <a
                 href="workflow-snapshot.html"
@@ -1003,10 +1024,10 @@
                   text-decoration: none;
                   white-space: nowrap;
                 "
-                >Get the $99 starter read</a
+                >Start the $99 Snapshot</a
               >
               <a
-                href="solutions.html"
+                href="ai-workflow-snapshot.html#intake"
                 style="
                   color: var(--text);
                   text-decoration: underline;
@@ -1014,10 +1035,10 @@
                   font-size: 14px;
                   white-space: nowrap;
                 "
-                >See buyer-ready services</a
+                >Build the intake packet</a
               >
               <a
-                href="start-here.html"
+                href="workflow-snapshot.html#free-check"
                 style="
                   color: var(--text);
                   text-decoration: underline;
@@ -1025,60 +1046,26 @@
                   font-size: 14px;
                   white-space: nowrap;
                 "
-                >Or see the three starter routes</a
+                >Run the free self-check</a
               >
             </div>
             <div class="cta-row">
               <a class="btn btn-primary" href="workflow-snapshot.html"
-                >Get Workflow Snapshot - $99</a
+                >Start $99 Workflow Snapshot</a
               >
-              <a class="btn btn-soft" href="governance-snapshot.html"
-                >Full Governance Snapshot - $500</a
+              <a class="btn btn-soft" href="ai-workflow-snapshot.html#receipt"
+                >See sample receipt</a
               >
-              <a
-                class="btn btn-strong"
-                href="#recent-milestones"
-                style="background: linear-gradient(135deg, #2dd3a6, #17c6cf)"
-                >See the Results</a
-              >
-              <a class="btn btn-soft" href="solutions.html">See Buyer Services</a>
-              <a class="btn btn-soft" href="products.html">View Products</a>
-              <a
-                class="btn btn-soft"
-                href="https://scbe-agent-bridge-vercel.vercel.app/console"
-                target="_blank"
-                rel="noopener"
-                >Open Hosted Tools</a
-              >
-              <a class="btn btn-soft" href="packages.html">Developer Packages</a>
-              <a class="btn btn-soft" href="books.html">Books</a>
-              <a class="btn btn-soft" href="guides.html">Guides</a>
-              <a class="btn btn-soft" href="chat.html">Open Polly Chat</a>
-              <a
-                class="btn btn-soft"
-                href="https://github.com/issdandavis/SCBE-AETHERMOORE"
-                target="_blank"
-                rel="noopener"
-                >Try the Demos</a
-              >
-              <a
-                class="btn btn-soft"
-                href="https://buy.stripe.com/cNibJ25Ca2TJ9gQ3a6dby06"
-                target="_blank"
-                rel="noopener"
-                >Explore the Toolkit ($29)</a
-              >
-              <a class="btn btn-soft" href="enterprise-license.html">Enterprise Licensing</a>
+              <a class="btn btn-soft" href="proof-workbench.html">See proof</a>
+              <a class="btn btn-soft" href="payments.html">Payment center</a>
             </div>
             <div class="support-strip" aria-label="Low-friction support lane">
               <strong>Lowest-friction payment:</strong>
               <span
-                >Ko-fi is the soft support path. Cash App is direct. Card checkout and invoices
-                are on the payment center.</span
+                >Ko-fi is the soft support path. Cash App is direct. Card checkout and invoices are
+                on the payment center.</span
               >
-              <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
-                >Open Ko-fi</a
-              >
+              <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener">Open Ko-fi</a>
               <a href="payments.html">Open payment center</a>
             </div>
             <p style="margin-top: 14px; font-size: 14px; color: var(--muted); max-width: 56ch">
@@ -1113,8 +1100,8 @@
                   <strong>91 / 91 attacks denied by policy gate</strong>
                   <span
                     >In the published harness, hyperbolic cost scaling + multi-factor omega gate
-                    denied the full attack corpus. 85.7% detection, 0% false positives in that
-                    test set — not a universal safety guarantee.</span
+                    denied the full attack corpus. 85.7% detection, 0% false positives in that test
+                    set — not a universal safety guarantee.</span
                   >
                 </div>
                 <div class="proof-cell">
@@ -1133,7 +1120,7 @@
                     layer behind the training and delivery workflow.</span
                   >
                 </div>
-                <div class="proof-cell" style="border-color: rgba(45,211,166,0.3)">
+                <div class="proof-cell" style="border-color: rgba(45, 211, 166, 0.3)">
                   <strong>scbe shell --squad &middot; 3-slot AI routing live</strong>
                   <span
                     >Agentic PowerShell shell with deterministic per-task routing: policy/safety
@@ -1142,14 +1129,20 @@
                     turn.</span
                   >
                 </div>
-                <div class="proof-cell" style="border-color: rgba(140,180,255,0.25)">
-                  <strong>Governed pathfinding &middot; ensemble-beam 100% / multi-lattice 75% / oracle 100%</strong>
+                <div class="proof-cell" style="border-color: rgba(140, 180, 255, 0.25)">
+                  <strong
+                    >Governed pathfinding &middot; ensemble-beam 100% / multi-lattice 75% / oracle
+                    100%</strong
+                  >
                   <span
-                    >8-field multi-lattice APF under partial observation: 75% baseline. Ensemble-beam
-                    search: 100% solve / 0.988 efficiency (12/12). Oracle BFS upper bound: 100%.
-                    SHA-256 receipt chain per step. Memory field is load-bearing (−0.75 without it).
-                    415 tests green. Commit <code style="font-size:11px">33266f0f5</code> —
-                    <code style="font-size:11px">npm run benchmark:vector-field-nav -- --skip-ablation --show-comparison</code></span
+                    >8-field multi-lattice APF under partial observation: 75% baseline.
+                    Ensemble-beam search: 100% solve / 0.988 efficiency (12/12). Oracle BFS upper
+                    bound: 100%. SHA-256 receipt chain per step. Memory field is load-bearing (−0.75
+                    without it). 415 tests green. Commit
+                    <code style="font-size: 11px">33266f0f5</code> —
+                    <code style="font-size: 11px"
+                      >npm run benchmark:vector-field-nav -- --skip-ablation --show-comparison</code
+                    ></span
                   >
                 </div>
               </div>
@@ -1200,8 +1193,9 @@
                 >
               </div>
               <p style="font-size: 14px; color: var(--muted); margin-bottom: 14px">
-                Type any AI prompt or task below. The live governed-chat preflight checks the request
-                before model dispatch. If the API is unreachable, the panel clearly marks browser fallback mode.
+                Type any AI prompt or task below. The live governed-chat preflight checks the
+                request before model dispatch. If the API is unreachable, the panel clearly marks
+                browser fallback mode.
               </p>
               <div style="display: grid; gap: 10px">
                 <textarea
@@ -1221,10 +1215,62 @@
                   "
                 ></textarea>
                 <div style="display: flex; gap: 8px; flex-wrap: wrap">
-                  <button type="button" onclick="setGovernanceSample('safePaid')" style="background: rgba(255,255,255,0.05); border: 1px solid var(--line); border-radius: 999px; padding: 7px 12px; color: var(--text); cursor: pointer;">Safe paid run</button>
-                  <button type="button" onclick="setGovernanceSample('unsafePaid')" style="background: rgba(255,255,255,0.05); border: 1px solid var(--line); border-radius: 999px; padding: 7px 12px; color: var(--text); cursor: pointer;">Payment theft</button>
-                  <button type="button" onclick="setGovernanceSample('agentBus')" style="background: rgba(255,255,255,0.05); border: 1px solid var(--line); border-radius: 999px; padding: 7px 12px; color: var(--text); cursor: pointer;">Agent handoff</button>
-                  <button type="button" onclick="setGovernanceSample('codePatch')" style="background: rgba(255,255,255,0.05); border: 1px solid var(--line); border-radius: 999px; padding: 7px 12px; color: var(--text); cursor: pointer;">Code patch</button>
+                  <button
+                    type="button"
+                    onclick="setGovernanceSample('safePaid')"
+                    style="
+                      background: rgba(255, 255, 255, 0.05);
+                      border: 1px solid var(--line);
+                      border-radius: 999px;
+                      padding: 7px 12px;
+                      color: var(--text);
+                      cursor: pointer;
+                    "
+                  >
+                    Safe paid run
+                  </button>
+                  <button
+                    type="button"
+                    onclick="setGovernanceSample('unsafePaid')"
+                    style="
+                      background: rgba(255, 255, 255, 0.05);
+                      border: 1px solid var(--line);
+                      border-radius: 999px;
+                      padding: 7px 12px;
+                      color: var(--text);
+                      cursor: pointer;
+                    "
+                  >
+                    Payment theft
+                  </button>
+                  <button
+                    type="button"
+                    onclick="setGovernanceSample('agentBus')"
+                    style="
+                      background: rgba(255, 255, 255, 0.05);
+                      border: 1px solid var(--line);
+                      border-radius: 999px;
+                      padding: 7px 12px;
+                      color: var(--text);
+                      cursor: pointer;
+                    "
+                  >
+                    Agent handoff
+                  </button>
+                  <button
+                    type="button"
+                    onclick="setGovernanceSample('codePatch')"
+                    style="
+                      background: rgba(255, 255, 255, 0.05);
+                      border: 1px solid var(--line);
+                      border-radius: 999px;
+                      padding: 7px 12px;
+                      color: var(--text);
+                      cursor: pointer;
+                    "
+                  >
+                    Code patch
+                  </button>
                 </div>
                 <div style="display: flex; gap: 10px; flex-wrap: wrap; align-items: center">
                   <select
@@ -1435,9 +1481,18 @@
                 'https://scbe-agent-bridge-vercel.vercel.app/v1/governed/chat/completions',
               ];
               const CRITICAL_THREAT_PATTERNS = [
-                { label: 'credential/payment theft', pattern: /credit\s*card|card\s*number|cvv|bank\s+login/i },
-                { label: 'secret extraction', pattern: /api\s*key|secret|password|token|private\s*key/i },
-                { label: 'abusive sexual demand', pattern: /eat\s+ass|suck\s+(my|a)|blow\s+(me|job)/i },
+                {
+                  label: 'credential/payment theft',
+                  pattern: /credit\s*card|card\s*number|cvv|bank\s+login/i,
+                },
+                {
+                  label: 'secret extraction',
+                  pattern: /api\s*key|secret|password|token|private\s*key/i,
+                },
+                {
+                  label: 'abusive sexual demand',
+                  pattern: /eat\s+ass|suck\s+(my|a)|blow\s+(me|job)/i,
+                },
                 { label: 'violent harm request', pattern: /\b(kill|murder|shoot|stab|bomb)\b/i },
               ];
               const THREAT_PATTERNS = [
@@ -1534,20 +1589,17 @@
                 'customer-vault': {
                   label: 'Customer token vault',
                   riskOffset: -0.04,
-                  rule:
-                    'SCBE never stores or spends user tokens; it records allow/deny receipts before the customer vault authorizes provider spend.',
+                  rule: 'SCBE never stores or spends user tokens; it records allow/deny receipts before the customer vault authorizes provider spend.',
                 },
                 byok: {
                   label: 'BYOK provider account',
                   riskOffset: 0,
-                  rule:
-                    'Provider key remains customer-owned; SCBE routes the decision and logs the preflight result.',
+                  rule: 'Provider key remains customer-owned; SCBE routes the decision and logs the preflight result.',
                 },
                 'platform-managed': {
                   label: 'Platform managed',
                   riskOffset: 0.12,
-                  rule:
-                    'Higher liability path: platform custody requires stricter review and billing controls.',
+                  rule: 'Higher liability path: platform custody requires stricter review and billing controls.',
                 },
               };
               const GOVERNANCE_SAMPLES = {
@@ -1566,14 +1618,16 @@
                   custody: 'customer-vault',
                 },
                 agentBus: {
-                  input: 'Route this repo review request to the agent bus and return a receipt before dispatch.',
+                  input:
+                    'Route this repo review request to the agent bus and return a receipt before dispatch.',
                   useCase: 'agent-bus',
                   actor: 'ai-agent',
                   resource: 'internal',
                   custody: 'byok',
                 },
                 codePatch: {
-                  input: 'Propose a patch for the tokenizer tests, but do not write outside the repository.',
+                  input:
+                    'Propose a patch for the tokenizer tests, but do not write outside the repository.',
                   useCase: 'code-harness',
                   actor: 'ai-agent',
                   resource: 'internal',
@@ -1843,7 +1897,9 @@
                       ? 'PLATFORM_BILLING_REVIEW'
                       : 'NO_TOKEN_SPEND';
                 const dispatchText =
-                  decision === 'ALLOW' ? useCaseProfile.normalDispatch : useCaseProfile.deniedDispatch;
+                  decision === 'ALLOW'
+                    ? useCaseProfile.normalDispatch
+                    : useCaseProfile.deniedDispatch;
                 const receiptSeed = [
                   input,
                   actor,
@@ -2010,9 +2066,9 @@
         aria-label="By the numbers"
         style="
           padding: 28px 0;
-          border-top: 1px solid rgba(255,255,255,0.06);
-          border-bottom: 1px solid rgba(255,255,255,0.06);
-          background: rgba(0,0,0,0.18);
+          border-top: 1px solid rgba(255, 255, 255, 0.06);
+          border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+          background: rgba(0, 0, 0, 0.18);
         "
       >
         <div class="section-inner">
@@ -2023,96 +2079,379 @@
               gap: 0;
             "
           >
-            <div style="padding: 12px 18px; text-align: center; border-right: 1px solid rgba(255,255,255,0.06)">
-              <div style="font-size: 28px; font-weight: 800; color: #2dd3a6; line-height: 1">859+</div>
-              <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #5a6578; margin-top: 4px">Tests</div>
+            <div
+              style="
+                padding: 12px 18px;
+                text-align: center;
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+              "
+            >
+              <div style="font-size: 28px; font-weight: 800; color: #2dd3a6; line-height: 1">
+                859+
+              </div>
+              <div
+                style="
+                  font-size: 11px;
+                  text-transform: uppercase;
+                  letter-spacing: 0.12em;
+                  color: #5a6578;
+                  margin-top: 4px;
+                "
+              >
+                Tests
+              </div>
             </div>
-            <div style="padding: 12px 18px; text-align: center; border-right: 1px solid rgba(255,255,255,0.06)">
-              <div style="font-size: 28px; font-weight: 800; color: #2dd3a6; line-height: 1">14</div>
-              <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #5a6578; margin-top: 4px">Security Layers</div>
+            <div
+              style="
+                padding: 12px 18px;
+                text-align: center;
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+              "
+            >
+              <div style="font-size: 28px; font-weight: 800; color: #2dd3a6; line-height: 1">
+                14
+              </div>
+              <div
+                style="
+                  font-size: 11px;
+                  text-transform: uppercase;
+                  letter-spacing: 0.12em;
+                  color: #5a6578;
+                  margin-top: 4px;
+                "
+              >
+                Security Layers
+              </div>
             </div>
-            <div style="padding: 12px 18px; text-align: center; border-right: 1px solid rgba(255,255,255,0.06)">
+            <div
+              style="
+                padding: 12px 18px;
+                text-align: center;
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+              "
+            >
               <div style="font-size: 28px; font-weight: 800; color: #2dd3a6; line-height: 1">6</div>
-              <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #5a6578; margin-top: 4px">Sacred Tongues</div>
+              <div
+                style="
+                  font-size: 11px;
+                  text-transform: uppercase;
+                  letter-spacing: 0.12em;
+                  color: #5a6578;
+                  margin-top: 4px;
+                "
+              >
+                Sacred Tongues
+              </div>
             </div>
-            <div style="padding: 12px 18px; text-align: center; border-right: 1px solid rgba(255,255,255,0.06)">
-              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">60</div>
-              <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #5a6578; margin-top: 4px">HF Models</div>
+            <div
+              style="
+                padding: 12px 18px;
+                text-align: center;
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+              "
+            >
+              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">
+                60
+              </div>
+              <div
+                style="
+                  font-size: 11px;
+                  text-transform: uppercase;
+                  letter-spacing: 0.12em;
+                  color: #5a6578;
+                  margin-top: 4px;
+                "
+              >
+                HF Models
+              </div>
             </div>
-            <div style="padding: 12px 18px; text-align: center; border-right: 1px solid rgba(255,255,255,0.06)">
-              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">21</div>
-              <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #5a6578; margin-top: 4px">Datasets</div>
+            <div
+              style="
+                padding: 12px 18px;
+                text-align: center;
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+              "
+            >
+              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">
+                21
+              </div>
+              <div
+                style="
+                  font-size: 11px;
+                  text-transform: uppercase;
+                  letter-spacing: 0.12em;
+                  color: #5a6578;
+                  margin-top: 4px;
+                "
+              >
+                Datasets
+              </div>
             </div>
-            <div style="padding: 12px 18px; text-align: center; border-right: 1px solid rgba(255,255,255,0.06)">
-              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">3.5K</div>
-              <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #5a6578; margin-top: 4px">npm / mo</div>
+            <div
+              style="
+                padding: 12px 18px;
+                text-align: center;
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+              "
+            >
+              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">
+                3.5K
+              </div>
+              <div
+                style="
+                  font-size: 11px;
+                  text-transform: uppercase;
+                  letter-spacing: 0.12em;
+                  color: #5a6578;
+                  margin-top: 4px;
+                "
+              >
+                npm / mo
+              </div>
             </div>
-            <div style="padding: 12px 18px; text-align: center; border-right: 1px solid rgba(255,255,255,0.06)">
-              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">12K+</div>
-              <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #5a6578; margin-top: 4px">Dataset pulls</div>
+            <div
+              style="
+                padding: 12px 18px;
+                text-align: center;
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+              "
+            >
+              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">
+                12K+
+              </div>
+              <div
+                style="
+                  font-size: 11px;
+                  text-transform: uppercase;
+                  letter-spacing: 0.12em;
+                  color: #5a6578;
+                  margin-top: 4px;
+                "
+              >
+                Dataset pulls
+              </div>
             </div>
-            <div style="padding: 12px 18px; text-align: center; border-right: 1px solid rgba(255,255,255,0.06)">
-              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">54</div>
-              <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #5a6578; margin-top: 4px">Bus Tools</div>
+            <div
+              style="
+                padding: 12px 18px;
+                text-align: center;
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+              "
+            >
+              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">
+                54
+              </div>
+              <div
+                style="
+                  font-size: 11px;
+                  text-transform: uppercase;
+                  letter-spacing: 0.12em;
+                  color: #5a6578;
+                  margin-top: 4px;
+                "
+              >
+                Bus Tools
+              </div>
             </div>
             <div style="padding: 12px 18px; text-align: center">
-              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">372K</div>
-              <div style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.12em; color: #5a6578; margin-top: 4px">Lines of Code</div>
+              <div style="font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1">
+                372K
+              </div>
+              <div
+                style="
+                  font-size: 11px;
+                  text-transform: uppercase;
+                  letter-spacing: 0.12em;
+                  color: #5a6578;
+                  margin-top: 4px;
+                "
+              >
+                Lines of Code
+              </div>
             </div>
           </div>
           <div style="text-align: center; font-size: 11px; color: #3a4050; margin-top: 10px">
-            Counts from <a href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener" style="color: #4a5568">GitHub</a>, <a href="https://www.npmjs.com/package/scbe-aethermoore" target="_blank" rel="noopener" style="color: #4a5568">npm</a> &amp; <a href="https://huggingface.co/issdandavis" target="_blank" rel="noopener" style="color: #4a5568">HuggingFace</a> &middot; updated periodically
+            Counts from
+            <a
+              href="https://github.com/issdandavis/SCBE-AETHERMOORE"
+              target="_blank"
+              rel="noopener"
+              style="color: #4a5568"
+              >GitHub</a
+            >,
+            <a
+              href="https://www.npmjs.com/package/scbe-aethermoore"
+              target="_blank"
+              rel="noopener"
+              style="color: #4a5568"
+              >npm</a
+            >
+            &amp;
+            <a
+              href="https://huggingface.co/issdandavis"
+              target="_blank"
+              rel="noopener"
+              style="color: #4a5568"
+              >HuggingFace</a
+            >
+            &middot; updated periodically
           </div>
         </div>
       </section>
 
-      <section id="use-today" style="padding: 48px 0; border-top: 1px solid var(--line); background: rgba(45,211,166,0.02)">
+      <section
+        id="use-today"
+        style="
+          padding: 48px 0;
+          border-top: 1px solid var(--line);
+          background: rgba(45, 211, 166, 0.02);
+        "
+      >
         <div class="section-inner">
           <div class="section-head">
             <div class="eyebrow">Open source &middot; run today</div>
             <h2>Four things you can use right now — no checkout required.</h2>
             <p>
-              The paid products are the packaged starter lane. These are the working tools underneath —
-              free, open-source, and running today.
+              The paid products are the packaged starter lane. These are the working tools
+              underneath — free, open-source, and running today.
             </p>
           </div>
           <div class="split" style="grid-template-columns: repeat(2, 1fr)">
-            <article class="slab" style="border-color: rgba(45,211,166,0.35)">
-              <div style="font-size: 11px; color: #2dd3a6; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px">CLI &middot; Free</div>
+            <article class="slab" style="border-color: rgba(45, 211, 166, 0.35)">
+              <div
+                style="
+                  font-size: 11px;
+                  color: #2dd3a6;
+                  letter-spacing: 0.08em;
+                  text-transform: uppercase;
+                  margin-bottom: 10px;
+                "
+              >
+                CLI &middot; Free
+              </div>
               <h3>scbe shell --squad</h3>
               <p>
                 Agentic PowerShell with three named AI slots. Every task auto-routes:
-                <strong>policy/safety → Groq</strong>, <strong>code &amp; architecture → Cerebras</strong>,
-                <strong>disk/system ops → Ollama</strong> (free/local). Status bar shows which slot is
-                live on every turn. No configuration needed.
+                <strong>policy/safety → Groq</strong>,
+                <strong>code &amp; architecture → Cerebras</strong>,
+                <strong>disk/system ops → Ollama</strong> (free/local). Status bar shows which slot
+                is live on every turn. No configuration needed.
               </p>
-              <pre style="background: rgba(0,0,0,0.4); border-radius: 8px; padding: 12px; font-size: 12px; color: #d6a756; margin: 14px 0; overflow: auto; white-space: pre-wrap">git clone https://github.com/issdandavis/SCBE-AETHERMOORE
+              <pre
+                style="
+                  background: rgba(0, 0, 0, 0.4);
+                  border-radius: 8px;
+                  padding: 12px;
+                  font-size: 12px;
+                  color: #d6a756;
+                  margin: 14px 0;
+                  overflow: auto;
+                  white-space: pre-wrap;
+                "
+              >
+git clone https://github.com/issdandavis/SCBE-AETHERMOORE
 npm install &amp;&amp; npm run build
-node packages/cli/bin/scbe.js shell --squad</pre>
-              <a class="btn btn-soft" href="https://github.com/issdandavis/SCBE-AETHERMOORE" target="_blank" rel="noopener">Open repo &rarr;</a>
+node packages/cli/bin/scbe.js shell --squad</pre
+              >
+              <a
+                class="btn btn-soft"
+                href="https://github.com/issdandavis/SCBE-AETHERMOORE"
+                target="_blank"
+                rel="noopener"
+                >Open repo &rarr;</a
+              >
             </article>
-            <article class="slab" style="border-color: rgba(214,167,86,0.35)">
-              <div style="font-size: 11px; color: var(--accent); letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px">NPM &middot; Free</div>
+            <article class="slab" style="border-color: rgba(214, 167, 86, 0.35)">
+              <div
+                style="
+                  font-size: 11px;
+                  color: var(--accent);
+                  letter-spacing: 0.08em;
+                  text-transform: uppercase;
+                  margin-bottom: 10px;
+                "
+              >
+                NPM &middot; Free
+              </div>
               <h3>Agent Bus (54 governed tools)</h3>
               <p>
-                Bounded task packets with verification receipts before every dispatch. 54 tools registered.
-                Use as a library in your own project or run the benchmark harness directly from the repo.
+                Bounded task packets with verification receipts before every dispatch. 54 tools
+                registered. Use as a library in your own project or run the benchmark harness
+                directly from the repo.
               </p>
-              <pre style="background: rgba(0,0,0,0.4); border-radius: 8px; padding: 12px; font-size: 12px; color: #d6a756; margin: 14px 0; overflow: auto">npm install scbe-agent-bus</pre>
-              <a class="btn btn-soft" href="https://www.npmjs.com/package/scbe-agent-bus" target="_blank" rel="noopener">Open on npm &rarr;</a>
+              <pre
+                style="
+                  background: rgba(0, 0, 0, 0.4);
+                  border-radius: 8px;
+                  padding: 12px;
+                  font-size: 12px;
+                  color: #d6a756;
+                  margin: 14px 0;
+                  overflow: auto;
+                "
+              >
+npm install scbe-agent-bus</pre
+              >
+              <a
+                class="btn btn-soft"
+                href="https://www.npmjs.com/package/scbe-agent-bus"
+                target="_blank"
+                rel="noopener"
+                >Open on npm &rarr;</a
+              >
             </article>
             <article class="slab">
-              <div style="font-size: 11px; color: var(--muted); letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px">Benchmark &middot; Free</div>
+              <div
+                style="
+                  font-size: 11px;
+                  color: var(--muted);
+                  letter-spacing: 0.08em;
+                  text-transform: uppercase;
+                  margin-bottom: 10px;
+                "
+              >
+                Benchmark &middot; Free
+              </div>
               <h3>Governed pathfinding harness</h3>
               <p>
-                Ensemble-beam: <strong>100% solve / 0.988 efficiency</strong>. Multi-lattice baseline: 75%.
-                Oracle: 100%. SHA-256 receipt chain per step. 8-field ablation table. 415 tests green.
+                Ensemble-beam: <strong>100% solve / 0.988 efficiency</strong>. Multi-lattice
+                baseline: 75%. Oracle: 100%. SHA-256 receipt chain per step. 8-field ablation table.
+                415 tests green.
               </p>
-              <pre style="background: rgba(0,0,0,0.4); border-radius: 8px; padding: 10px; font-size: 11px; color: #d6a756; margin: 12px 0; overflow: auto; white-space: pre-wrap">npm run benchmark:vector-field-nav -- --skip-ablation --show-comparison</pre>
-              <a class="btn btn-soft" href="https://github.com/issdandavis/SCBE-AETHERMOORE/tree/main/packages/agent-bus" target="_blank" rel="noopener">View benchmark code &rarr;</a>
+              <pre
+                style="
+                  background: rgba(0, 0, 0, 0.4);
+                  border-radius: 8px;
+                  padding: 10px;
+                  font-size: 11px;
+                  color: #d6a756;
+                  margin: 12px 0;
+                  overflow: auto;
+                  white-space: pre-wrap;
+                "
+              >
+npm run benchmark:vector-field-nav -- --skip-ablation --show-comparison</pre
+              >
+              <a
+                class="btn btn-soft"
+                href="https://github.com/issdandavis/SCBE-AETHERMOORE/tree/main/packages/agent-bus"
+                target="_blank"
+                rel="noopener"
+                >View benchmark code &rarr;</a
+              >
             </article>
             <article class="slab">
-              <div style="font-size: 11px; color: var(--muted); letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px">Browser &middot; Free</div>
+              <div
+                style="
+                  font-size: 11px;
+                  color: var(--muted);
+                  letter-spacing: 0.08em;
+                  text-transform: uppercase;
+                  margin-bottom: 10px;
+                "
+              >
+                Browser &middot; Free
+              </div>
               <h3>Live governance demo</h3>
               <p>
                 Type any AI task into the panel above. The preflight checks it through the 14-layer
@@ -2214,23 +2553,29 @@ node packages/cli/bin/scbe.js shell --squad</pre>
                   broader schema coverage, not this gate.</span
                 >
               </div>
-              <div class="proof-cell" style="border-color: rgba(45,211,166,0.3)">
+              <div class="proof-cell" style="border-color: rgba(45, 211, 166, 0.3)">
                 <strong>scbe shell --squad &middot; 3-slot agentic CLI shipped (May 2026)</strong>
                 <span
                   >Deterministic per-task AI routing: policy/safety → Groq, code/architecture →
                   Cerebras, disk/system ops → Ollama (free/local). Status bar shows the active slot
-                  every turn. Squad routing wired into the agent bus via tools.json. Runs from
-                  the repo today.</span
+                  every turn. Squad routing wired into the agent bus via tools.json. Runs from the
+                  repo today.</span
                 >
               </div>
-              <div class="proof-cell" style="border-color: rgba(140,180,255,0.2)">
-                <strong>Governed pathfinding &middot; ensemble-beam 100% / multi-lattice 75% / oracle 100% (May 2026)</strong>
+              <div class="proof-cell" style="border-color: rgba(140, 180, 255, 0.2)">
+                <strong
+                  >Governed pathfinding &middot; ensemble-beam 100% / multi-lattice 75% / oracle
+                  100% (May 2026)</strong
+                >
                 <span
-                  >8-field APF (goal, obstacle, frontier, security, importance, memory, edge-channel,
-                  kernel-convolution) with SHA-256 receipt chain per step. Ensemble-beam: 100% solve /
-                  0.988 efficiency (12/12). Multi-lattice baseline: 75%. Oracle BFS upper bound: 100%.
-                  Memory field ablation: −0.75 without it. 415 tests green. Commit <code style="font-size:11px">33266f0f5</code>.
-                  Run: <code style="font-size:11px">npm run benchmark:vector-field-nav -- --skip-ablation --show-comparison</code></span
+                  >8-field APF (goal, obstacle, frontier, security, importance, memory,
+                  edge-channel, kernel-convolution) with SHA-256 receipt chain per step.
+                  Ensemble-beam: 100% solve / 0.988 efficiency (12/12). Multi-lattice baseline: 75%.
+                  Oracle BFS upper bound: 100%. Memory field ablation: −0.75 without it. 415 tests
+                  green. Commit <code style="font-size: 11px">33266f0f5</code>. Run:
+                  <code style="font-size: 11px"
+                    >npm run benchmark:vector-field-nav -- --skip-ablation --show-comparison</code
+                  ></span
                 >
               </div>
             </div>
@@ -2428,8 +2773,8 @@ node packages/cli/bin/scbe.js shell --squad</pre>
               <p>
                 Example: put a policy gate in front of unsafe tool calls so drift, intent
                 accumulation, or context mismatch can trigger DENY, QUARANTINE, or ESCALATE before
-                the action runs. The toolkit gives you the decision record, threshold worksheet,
-                and manual path; the demo hub shows the geometry and gate behavior in public.
+                the action runs. The toolkit gives you the decision record, threshold worksheet, and
+                manual path; the demo hub shows the geometry and gate behavior in public.
               </p>
             </article>
             <article class="slab">
@@ -2755,9 +3100,7 @@ node packages/cli/bin/scbe.js shell --squad</pre>
           <div class="section-head">
             <div class="eyebrow">Watch</div>
             <h2>See the system in action.</h2>
-            <p>
-              Video walkthroughs, project updates, and live demos of the governance pipeline.
-            </p>
+            <p>Video walkthroughs, project updates, and live demos of the governance pipeline.</p>
           </div>
           <div class="split">
             <article class="slab" style="padding: 0; overflow: hidden; border-radius: 24px">
@@ -2827,16 +3170,16 @@ node packages/cli/bin/scbe.js shell --squad</pre>
             <article class="slab">
               <h3>AI Writing Guides</h3>
               <p>
-                Scene packets, voice anchors, dry reads, humanization checks, and serial tension passes for writers
-                using AI without flattening their voice.
+                Scene packets, voice anchors, dry reads, humanization checks, and serial tension
+                passes for writers using AI without flattening their voice.
               </p>
               <a class="btn btn-soft" href="guides.html#ai-writing-system">Read Writing Guide</a>
             </article>
             <article class="slab">
               <h3>Security Guides</h3>
               <p>
-                Reference monitors, action contracts, cutoff rules, and receipt trails for people wiring AI to real
-                tools.
+                Reference monitors, action contracts, cutoff rules, and receipt trails for people
+                wiring AI to real tools.
               </p>
               <a class="btn btn-soft" href="guides.html#security-governance">Read Security Guide</a>
             </article>
@@ -2862,10 +3205,10 @@ node packages/cli/bin/scbe.js shell --squad</pre>
               <div style="font-size: 12px; color: #2dd3a6; margin-bottom: 8px">May 2026</div>
               <h3>Squad shell + governed pathfinding</h3>
               <p>
-                <code style="font-size:12px">scbe shell --squad</code> ships with deterministic
+                <code style="font-size: 12px">scbe shell --squad</code> ships with deterministic
                 3-slot routing. Vector-field-nav harness: ensemble-beam 100% / 0.988 efficiency,
                 multi-lattice 75%, oracle 100%. SHA-256 receipt chain per step. 415 tests green.
-                Commit <code style="font-size:11px">33266f0f5</code>.
+                Commit <code style="font-size: 11px">33266f0f5</code>.
               </p>
               <a
                 href="#use-today"
@@ -3673,7 +4016,12 @@ node packages/cli/bin/scbe.js shell --squad</pre>
             >Source (GitHub)</a
           >
           <a href="https://medium.com/@issdandavis7795" target="_blank" rel="noopener">Medium</a>
-          <a href="https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ" target="_blank" rel="noopener">YouTube</a>
+          <a
+            href="https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ"
+            target="_blank"
+            rel="noopener"
+            >YouTube</a
+          >
           <a href="https://www.linkedin.com/in/issdandavis" target="_blank" rel="noopener"
             >LinkedIn</a
           >

--- a/docs/workflow-snapshot.html
+++ b/docs/workflow-snapshot.html
@@ -235,8 +235,14 @@
           missing recovery states, observability gaps, and three next fixes.
         </p>
         <div class="actions">
-          <a class="btn secondary" href="ai-workflow-snapshot.html">Need the cheaper $39 starter?</a>
-          <a class="btn btn-primary" href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l" target="_blank" rel="noopener"
+          <a class="btn secondary" href="ai-workflow-snapshot.html#intake"
+            >Build the intake packet first</a
+          >
+          <a
+            class="btn btn-primary"
+            href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
+            target="_blank"
+            rel="noopener"
             >Start for $99 with Stripe</a
           >
           <a class="btn secondary" href="#cash-app">Pay with Cash App</a>
@@ -246,20 +252,19 @@
         <div class="price-strip" aria-label="Offer ladder">
           <div class="price-box"><strong>Free</strong><span>Self-check and public docs.</span></div>
           <div class="price-box">
-            <strong>$99 one-time</strong><span>Concise first-pass workflow read. No subscription.</span>
+            <strong>$99 one-time</strong
+            ><span>Concise first-pass workflow read. No subscription.</span>
           </div>
           <div class="price-box">
             <strong>$500 full</strong><span>Fixed-scope written Governance Snapshot.</span>
           </div>
         </div>
         <div class="note">
-          Stripe checkout is live for the exact $99 Workflow Snapshot SKU. Cash App <strong>$IzzyDDavis7</strong> remains available as a manual alternate payment path; include "Workflow Snapshot" in the note.
+          Stripe checkout is live for the exact $99 Workflow Snapshot SKU. Cash App
+          <strong>$IzzyDDavis7</strong> remains available as a manual alternate payment path;
+          include "Workflow Snapshot" in the note.
         </div>
-        <img
-          class="hero-image"
-          src="hero.svg"
-          alt="AetherMoore governed AI workflow visual"
-        />
+        <img class="hero-image" src="hero.svg" alt="AetherMoore governed AI workflow visual" />
       </div>
     </header>
 
@@ -306,19 +311,31 @@
             <article class="card good">
               <h3>Delivery package</h3>
               <ul>
-                <li>One short decision record describing the workflow, risk level, and next move.</li>
-                <li>Threshold notes for when the workflow should stop, retry, escalate, or ask for help.</li>
+                <li>
+                  One short decision record describing the workflow, risk level, and next move.
+                </li>
+                <li>
+                  Threshold notes for when the workflow should stop, retry, escalate, or ask for
+                  help.
+                </li>
                 <li>A pilot checklist for the next safe test run.</li>
-                <li>Review notes on tool boundaries, logs, recovery paths, and missing evidence.</li>
-                <li>A plain manual-style handoff so a technical or non-technical buyer can act on it.</li>
-                <li>Delivery through email or agreed handoff route after payment and intake are matched.</li>
+                <li>
+                  Review notes on tool boundaries, logs, recovery paths, and missing evidence.
+                </li>
+                <li>
+                  A plain manual-style handoff so a technical or non-technical buyer can act on it.
+                </li>
+                <li>
+                  Delivery through email or agreed handoff route after payment and intake are
+                  matched.
+                </li>
               </ul>
             </article>
             <article class="card">
               <h3>Good fit / not for</h3>
               <p>
-                Good fit: one agent workflow that already exists or is close enough to describe. Best
-                when you want a practical first read before buying a larger review.
+                Good fit: one agent workflow that already exists or is close enough to describe.
+                Best when you want a practical first read before buying a larger review.
               </p>
               <p>
                 Not for: legal certification, compliance attestation, emergency incident response,
@@ -336,7 +353,10 @@
           <div class="steps">
             <div class="step">
               <strong>1. Pay</strong>
-              <p>Use the Stripe checkout link for the $99 Workflow Snapshot. Cash App remains available as a manual alternate path.</p>
+              <p>
+                Use the Stripe checkout link for the $99 Workflow Snapshot. Cash App remains
+                available as a manual alternate path.
+              </p>
             </div>
             <div class="step">
               <strong>2. Send</strong>
@@ -411,7 +431,11 @@
                 video walkthrough.
               </p>
               <div class="actions">
-                <a class="btn" href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l" target="_blank" rel="noopener"
+                <a
+                  class="btn"
+                  href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
+                  target="_blank"
+                  rel="noopener"
                   >Start the $99 read</a
                 >
                 <a class="btn secondary" href="hire.html">Ask first</a>
@@ -429,22 +453,23 @@
             <article class="card">
               <h3>Do I need to send secrets?</h3>
               <p>
-                No. Start with a public repo, diagram, prompt chain, tool list, or redacted screenshots.
-                If deeper access is needed, handling rules are agreed first.
+                No. Start with a public repo, diagram, prompt chain, tool list, or redacted
+                screenshots. If deeper access is needed, handling rules are agreed first.
               </p>
             </article>
             <article class="card">
               <h3>What is the success check?</h3>
               <p>
-                The first win is a clear list of failure points plus three fixes you can run next. If
-                the workflow is too thin to review, the memo says that instead of padding the report.
+                The first win is a clear list of failure points plus three fixes you can run next.
+                If the workflow is too thin to review, the memo says that instead of padding the
+                report.
               </p>
             </article>
             <article class="card">
               <h3>Can I use Cash App or Ko-fi?</h3>
               <p>
-                Yes. Stripe is the structured checkout, Cash App is the direct manual path, and Ko-fi is
-                the low-pressure support path. The payment center lists all current routes.
+                Yes. Stripe is the structured checkout, Cash App is the direct manual path, and
+                Ko-fi is the low-pressure support path. The payment center lists all current routes.
               </p>
             </article>
             <article class="card">
@@ -466,11 +491,15 @@
           <div class="eyebrow">Final CTA</div>
           <h2>Start with one workflow and one written read.</h2>
           <p class="lead">
-            The starter Snapshot is the smallest paid step: one workflow, one memo, three fixes,
-            and an upgrade path only if a deeper review is actually useful.
+            The starter Snapshot is the smallest paid step: one workflow, one memo, three fixes, and
+            an upgrade path only if a deeper review is actually useful.
           </p>
           <div class="actions">
-            <a class="btn btn-primary" href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l" target="_blank" rel="noopener"
+            <a
+              class="btn btn-primary"
+              href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
+              target="_blank"
+              rel="noopener"
               >Start the $99 read</a
             >
             <a class="btn secondary" href="payments.html">Open payment center</a>

--- a/tests/api/test_polly_widget_contract.py
+++ b/tests/api/test_polly_widget_contract.py
@@ -85,9 +85,9 @@ def test_sidebar_has_pre_ai_routes_for_zero_cost_chat() -> None:
 
 
 def test_ai_workflow_snapshot_page_is_static_intake() -> None:
-    """The $39 intake page must work without a backend form service."""
+    """The $99 intake page must work without a backend form service."""
     src = _read(ROOT / "docs" / "ai-workflow-snapshot.html")
-    assert "$39" in src
+    assert "$99" in src
     assert "Download intake JSON" in src
     assert "packet_type" in src
     assert "aethermoore_ai_workflow_snapshot_intake_v1" in src

--- a/tests/revenue/test_public_money_path.py
+++ b/tests/revenue/test_public_money_path.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKOUT_URL = "https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
+
+
+def read_doc(name: str) -> str:
+    path = ROOT / "docs" / name
+    assert path.exists(), f"missing public page: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_homepage_focuses_first_buyer_path_on_workflow_snapshot() -> None:
+    homepage = read_doc("index.html")
+
+    assert "Start $99 Workflow Snapshot" in homepage
+    assert "ai-workflow-snapshot.html#receipt" in homepage
+    assert "payments.html" in homepage
+    assert "briefing-room.html" not in homepage
+
+
+def test_workflow_snapshot_checkout_is_consistent_and_live_wired() -> None:
+    workflow = read_doc("workflow-snapshot.html")
+    intake = read_doc("ai-workflow-snapshot.html")
+    config = json.loads((ROOT / "docs" / "app-config.json").read_text(encoding="utf-8"))
+
+    assert CHECKOUT_URL in workflow
+    assert CHECKOUT_URL in intake
+    assert config["endpoints"]["workflow_snapshot_checkout"] == CHECKOUT_URL
+    assert config["endpoints"]["workflow_snapshot_page"].endswith("/workflow-snapshot.html")
+
+
+def test_ai_workflow_snapshot_has_no_stale_39_dollar_copy() -> None:
+    intake = read_doc("ai-workflow-snapshot.html")
+    workflow = read_doc("workflow-snapshot.html")
+
+    assert "$39" not in intake
+    assert "cheaper $39" not in workflow
+    assert "$99 AI Workflow Snapshot" in intake


### PR DESCRIPTION
Summary:
- focuses the homepage first-viewport CTA on the $99 Workflow Snapshot
- removes stale $39/cheaper copy from the AI workflow intake path
- adds a revenue regression test for the public money path, live Stripe URL, and dead briefing-room link

Verification:
- python -m pytest tests/revenue tests/api/test_polly_widget_contract.py tests/test_public_claim_language.py -q -> 22 passed
- python -m black --check --target-version py311 --line-length 120 tests/revenue tests/api/test_polly_widget_contract.py tests/test_public_claim_language.py -> pass
- python -m ruff check tests/revenue/test_public_money_path.py tests/api/test_polly_widget_contract.py -> pass
- npx prettier --check docs/index.html docs/workflow-snapshot.html docs/ai-workflow-snapshot.html -> pass
- git diff --check -> pass

Rollback:
- revert this PR to restore the prior homepage CTA spread and intake copy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product pages and pricing to reflect $99 AI Workflow Snapshot offering
  * Refreshed homepage messaging, pricing cards, and call-to-action links
  * Enhanced intake form flow and updated product navigation

* **Tests**
  * Updated pricing assertions in regression tests to match new $99 pricing
  * Added new revenue validation tests to verify pricing consistency across documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->