### PR TITLE
feat(site): add conversion-focused snapshot telemetry

### DIFF
--- a/docs/ai-workflow-snapshot.html
+++ b/docs/ai-workflow-snapshot.html
@@ -483,6 +483,8 @@
               href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
               target="_blank"
               rel="noopener"
+              data-funnel-event="cta_click_buy"
+              data-funnel-label="ai-workflow-price-card-stripe"
               style="width: 100%; justify-content: center"
               >Start for $99 with Stripe →</a
             >
@@ -618,8 +620,24 @@
             ></textarea>
 
             <div class="actions">
-              <button class="btn" type="button" id="downloadPacket">Download intake JSON</button>
-              <button class="btn secondary" type="button" id="copyPacket">Copy packet</button>
+              <button
+                class="btn"
+                type="button"
+                id="downloadPacket"
+                data-funnel-event="snapshot_intake_ok"
+                data-funnel-label="download-intake-json"
+              >
+                Download intake JSON
+              </button>
+              <button
+                class="btn secondary"
+                type="button"
+                id="copyPacket"
+                data-funnel-event="snapshot_intake_ok"
+                data-funnel-label="copy-intake-json"
+              >
+                Copy packet
+              </button>
             </div>
           </form>
         </div>
@@ -654,6 +672,8 @@
                 href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
                 target="_blank"
                 rel="noopener"
+                data-funnel-event="cta_click_buy"
+                data-funnel-label="ai-workflow-pay-section-stripe"
                 >$99 with Stripe →</a
               >
               <a class="btn secondary" href="workflow-snapshot.html">Full $99 offer</a>
@@ -730,7 +750,7 @@
           return {
             packet_type: 'aethermoore_ai_workflow_snapshot_intake_v1',
             offer: 'AI Workflow Snapshot',
-            price_usd: 39,
+            price_usd: 99,
             created_at: new Date().toISOString(),
             contact: value('contact'),
             workflow_name: value('workflow'),
@@ -794,6 +814,7 @@
     <script>
       window.POLLY_STATIC_ONLY = true;
     </script>
+    <script src="static/polly-funnel.js" data-page="ai-workflow-snapshot"></script>
     <script
       src="static/polly-sidebar-agent.js"
       data-polly-api="."

--- a/docs/index.html
+++ b/docs/index.html
@@ -4034,6 +4034,7 @@ npm run benchmark:vector-field-nav -- --skip-ablation --show-comparison</pre
       </div>
     </footer>
 
+    <script src="static/polly-funnel.js" data-page="home"></script>
     <script src="static/polly-sidebar-agent.js"></script>
     <script src="static/polly-hint.js" defer></script>
     <script src="static/ticker.js" defer></script>

--- a/docs/static/polly-funnel.js
+++ b/docs/static/polly-funnel.js
@@ -1,4 +1,4 @@
-/* Polly funnel beacons — operator-only telemetry for /hire and /governance-snapshot.
+/* Polly funnel beacons — operator-only telemetry for buyer and service pages.
  *
  * Fires named events to /v1/polly/funnel so the operator dashboard can
  * see fall-off per stage. Designed to be drop-in: include this script
@@ -104,6 +104,45 @@
     }
   }
 
+  function attr(el, name) {
+    return (el && el.getAttribute && el.getAttribute(name)) || '';
+  }
+
+  function inferClickEvent(el) {
+    var explicit = attr(el, 'data-funnel-event');
+    if (explicit) return explicit.toLowerCase();
+    var href = attr(el, 'href').toLowerCase();
+    if (href.indexOf('buy.stripe.com') !== -1 || href.indexOf('#cash-app') !== -1) {
+      return 'cta_click_buy';
+    }
+    if (href.indexOf('mailto:') === 0) return 'cta_click_email';
+    if (href.indexOf('chat.html') !== -1 || href.indexOf('#chat') !== -1) return 'cta_click_chat';
+    return '';
+  }
+
+  function clickMeta(el) {
+    var label = attr(el, 'data-funnel-label') || (el.textContent || '').trim();
+    var href = attr(el, 'href');
+    return {
+      label: label.slice(0, 96),
+      href: href.slice(0, 180),
+    };
+  }
+
+  function autoAttachClicks() {
+    document.addEventListener(
+      'click',
+      function (ev) {
+        var target = ev.target && ev.target.closest ? ev.target.closest('a,button') : null;
+        if (!target) return;
+        var event = inferClickEvent(target);
+        if (!event) return;
+        fire(event, clickMeta(target));
+      },
+      { capture: true }
+    );
+  }
+
   // Auto-attach scroll thresholds. Calls scroll_50 once and scroll_90 once
   // when the corresponding doc-fraction is reached. No-op on pages too
   // short to scroll (avoids firing on widget-only modals).
@@ -133,10 +172,12 @@
       document.addEventListener('DOMContentLoaded', function () {
         fire('arrival');
         autoAttachScroll();
+        autoAttachClicks();
       });
     } else {
       fire('arrival');
       autoAttachScroll();
+      autoAttachClicks();
     }
   }
 

--- a/docs/workflow-snapshot.html
+++ b/docs/workflow-snapshot.html
@@ -125,6 +125,21 @@
         gap: 12px;
         margin-top: 28px;
       }
+      .trust-row {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 10px;
+        margin-top: 18px;
+      }
+      .trust-chip {
+        border: 1px solid rgba(45, 211, 166, 0.26);
+        border-radius: 7px;
+        background: rgba(45, 211, 166, 0.08);
+        padding: 12px 14px;
+        color: var(--ink);
+        font-size: 14px;
+        font-weight: 750;
+      }
       .price-box {
         border: 1px solid var(--line);
         background: rgba(21, 26, 35, 0.84);
@@ -202,6 +217,7 @@
       }
       @media (max-width: 780px) {
         .price-strip,
+        .trust-row,
         .grid,
         .steps,
         .pay-grid {
@@ -227,27 +243,35 @@
 
     <header id="offer" class="hero">
       <div class="wrap">
-        <div class="eyebrow">First paid step</div>
-        <h1>Find the weak points in one AI agent workflow.</h1>
+        <div class="eyebrow">First paid step · $99 one-time</div>
+        <h1>
+          Get a risk read before your AI workflow calls tools, writes files, or touches customers.
+        </h1>
         <p class="lead">
           Send one agent setup, prompt chain, repo link, MCP stack, automation flow, or workflow
-          diagram. AetherMoore returns a concise starter read: drift risks, unsafe tool paths,
-          missing recovery states, observability gaps, and three next fixes.
+          diagram. AetherMoore returns one written starter read: what can go wrong, what evidence is
+          missing, and the next three fixes.
         </p>
         <div class="actions">
-          <a class="btn secondary" href="ai-workflow-snapshot.html#intake"
-            >Build the intake packet first</a
-          >
           <a
             class="btn btn-primary"
             href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
             target="_blank"
             rel="noopener"
+            data-funnel-event="cta_click_buy"
+            data-funnel-label="workflow-snapshot-hero-stripe"
             >Start for $99 with Stripe</a
           >
-          <a class="btn secondary" href="#cash-app">Pay with Cash App</a>
-          <a class="btn secondary" href="#free-check">Run the free self-check</a>
-          <a class="btn secondary" href="governance-snapshot.html">Need the $500 review?</a>
+          <a class="btn secondary" href="ai-workflow-snapshot.html#receipt">See sample receipt</a>
+          <a class="btn secondary" href="ai-workflow-snapshot.html#intake"
+            >Build the intake packet first</a
+          >
+        </div>
+        <div class="trust-row" aria-label="Buyer trust signals">
+          <div class="trust-chip">No secrets required</div>
+          <div class="trust-chip">Manual delivery after intake</div>
+          <div class="trust-chip">Upgrade credit toward $500 review</div>
+          <div class="trust-chip">Live Stripe checkout</div>
         </div>
         <div class="price-strip" aria-label="Offer ladder">
           <div class="price-box"><strong>Free</strong><span>Self-check and public docs.</span></div>
@@ -500,6 +524,8 @@
               href="https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l"
               target="_blank"
               rel="noopener"
+              data-funnel-event="cta_click_buy"
+              data-funnel-label="workflow-snapshot-final-stripe"
               >Start the $99 read</a
             >
             <a class="btn secondary" href="payments.html">Open payment center</a>

--- a/tests/api/polly_funnel_js.test.ts
+++ b/tests/api/polly_funnel_js.test.ts
@@ -17,6 +17,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const funnelHandler = require('../../api/polly/funnel.js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const hfUpload = require('../../api/_polly_hf_upload.js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const rateLimit = require('../../api/_polly_rate_limit.js');
@@ -182,5 +184,17 @@ describe('polly funnel — allowed events', () => {
     ]) {
       expect(events.has(e)).toBe(true);
     }
+  });
+});
+
+describe('polly funnel — static buyer click instrumentation', () => {
+  it('auto-tracks buy and intake CTA clicks without page-specific inline JS', () => {
+    const src = fs.readFileSync('docs/static/polly-funnel.js', 'utf8');
+
+    expect(src).toContain('autoAttachClicks');
+    expect(src).toContain("closest('a,button')");
+    expect(src).toContain('data-funnel-event');
+    expect(src).toContain('buy.stripe.com');
+    expect(src).toContain('cta_click_buy');
   });
 });

--- a/tests/revenue/test_public_money_path.py
+++ b/tests/revenue/test_public_money_path.py
@@ -29,6 +29,8 @@ def test_workflow_snapshot_checkout_is_consistent_and_live_wired() -> None:
 
     assert CHECKOUT_URL in workflow
     assert CHECKOUT_URL in intake
+    assert 'data-funnel-event="cta_click_buy"' in workflow
+    assert 'data-funnel-event="cta_click_buy"' in intake
     assert config["endpoints"]["workflow_snapshot_checkout"] == CHECKOUT_URL
     assert config["endpoints"]["workflow_snapshot_page"].endswith("/workflow-snapshot.html")
 
@@ -40,3 +42,15 @@ def test_ai_workflow_snapshot_has_no_stale_39_dollar_copy() -> None:
     assert "$39" not in intake
     assert "cheaper $39" not in workflow
     assert "$99 AI Workflow Snapshot" in intake
+    assert "price_usd: 99" in intake
+
+
+def test_money_path_pages_load_funnel_telemetry() -> None:
+    homepage = read_doc("index.html")
+    workflow = read_doc("workflow-snapshot.html")
+    intake = read_doc("ai-workflow-snapshot.html")
+
+    assert 'src="static/polly-funnel.js"' in homepage
+    assert 'src="static/polly-funnel.js"' in workflow
+    assert 'src="static/polly-funnel.js"' in intake
+    assert 'data-funnel-event="snapshot_intake_ok"' in intake


### PR DESCRIPTION
Summary:
- sharpens the $99 Workflow Snapshot hero around one buyer risk and one primary checkout CTA
- adds above-fold trust chips: no secrets required, manual delivery, upgrade credit, live Stripe checkout
- fixes the AI intake JSON packet price from 39 to 99
- loads first-party Polly funnel telemetry on homepage and intake page
- auto-tracks Stripe/Cash App/chat/email CTA clicks through docs/static/polly-funnel.js
- pins the money path and telemetry wiring with Python + Vitest regressions

Verification:
- python -m pytest tests/revenue/test_public_money_path.py tests/api/test_polly_widget_contract.py -q -> 12 passed
- NODE_PATH=C:\Users\issda\SCBE-AETHERMOORE\node_modules vitest run tests/api/polly_funnel_js.test.ts -> 11 passed (temporary worktree module-resolution warning; exit 0)
- npx prettier --check docs/index.html docs/workflow-snapshot.html docs/ai-workflow-snapshot.html docs/static/polly-funnel.js tests/api/polly_funnel_js.test.ts -> pass
- python -m black --check --target-version py311 --line-length 120 tests/revenue/test_public_money_path.py tests/api/test_polly_widget_contract.py -> pass
- python -m ruff check tests/revenue/test_public_money_path.py tests/api/test_polly_widget_contract.py -> pass
- node --check docs/static/polly-funnel.js -> pass
- git diff --check -> pass

Notes:
- Commit used --no-verify because this temporary worktree hits the known missing packages/agent-bus/.husky/_/husky.sh helper. Manual gates above passed before bypassing.

Rollback:
- revert this PR to restore the prior Workflow Snapshot hero and funnel telemetry behavior.