### PR TITLE
feat(site): redesign CLI terminal workbench

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -4,738 +4,1100 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
-    <title>Try the SCBE Terminal — in your browser</title>
+    <title>SCBE Terminal - governed CLI workbench</title>
     <meta
       name="description"
-      content="Test the SCBE governed-CLI terminal frontend live in your browser — the real rendering code, not a mockup. Type scbe term, --detail, --json, /run, and compare it against a plain shell."
+      content="Use the SCBE governed terminal frontend in your browser. Slash commands, bracket instructions, receipt summaries, status panels, and the real CLI renderer."
     />
     <meta name="robots" content="index, follow, max-image-preview:large" />
-    <meta property="og:title" content="Try the SCBE Terminal" />
+    <meta property="og:title" content="SCBE Terminal" />
     <meta
       property="og:description"
-      content="The real CLI rendering code, running in your browser. Type commands, see governed receipts, compare to a plain shell."
+      content="A governed CLI workbench for humans and AI agents: command routes, receipt summaries, status panels, and the real terminal renderer."
     />
     <meta property="og:type" content="website" />
     <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/cli.html" />
     <style>
       :root {
-        --bg: #0b0d12;
-        --bg-soft: #11161f;
-        --panel: rgba(18, 23, 32, 0.92);
-        --line: rgba(214, 167, 86, 0.18);
-        --text: #f2f0ea;
-        --muted: #a3acb9;
-        --accent: #d6a756;
-        --accent-strong: #f0bf67;
-        --cool: #8cb4ff;
-        --term-bg: #0a0c11;
-        --max: 1180px;
-        --shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+        color-scheme: dark;
+        --bg: #07090d;
+        --bg-2: #0b0f15;
+        --pane: #0f141c;
+        --pane-2: #121923;
+        --line: #252e3b;
+        --line-soft: rgba(148, 163, 184, 0.16);
+        --text: #f3f7fb;
+        --muted: #8d9bab;
+        --soft: #c2cbd6;
+        --accent: #38f7bf;
+        --accent-2: #69a7ff;
+        --warn: #f5b24a;
+        --bad: #ff6b6b;
+        --ok: #39d98a;
+        --term: #080b10;
         --mono:
-          ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+          "SFMono-Regular", "Cascadia Code", "Cascadia Mono", Consolas, "Liberation Mono",
+          monospace;
+        --sans:
+          "Segoe UI Variable", "Segoe UI", -apple-system, BlinkMacSystemFont, system-ui,
+          sans-serif;
       }
+
       * {
         box-sizing: border-box;
-        margin: 0;
-        padding: 0;
       }
+
       html {
-        scroll-behavior: smooth;
+        min-height: 100%;
+        background: var(--bg);
       }
+
       body {
-        font-family: Georgia, 'Times New Roman', serif;
-        background:
-          radial-gradient(circle at top, rgba(214, 167, 86, 0.1), transparent 36%),
-          linear-gradient(180deg, #0b0d12 0%, #0e131b 42%, #0b0d12 100%);
+        min-height: 100%;
+        margin: 0;
         color: var(--text);
-        line-height: 1.6;
+        font-family: var(--sans);
+        background:
+          linear-gradient(rgba(255, 255, 255, 0.026) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px),
+          linear-gradient(180deg, #080a0f 0%, #0b0f15 44%, #06080c 100%);
+        background-size:
+          38px 38px,
+          38px 38px,
+          auto;
+        line-height: 1.45;
       }
+
       a {
         color: inherit;
         text-decoration: none;
       }
 
+      button,
+      input {
+        font: inherit;
+      }
+
+      button {
+        cursor: pointer;
+      }
+
       .topbar {
         position: sticky;
         top: 0;
-        z-index: 40;
-        backdrop-filter: blur(14px);
-        background: rgba(11, 13, 18, 0.82);
-        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+        z-index: 50;
+        border-bottom: 1px solid var(--line-soft);
+        background: rgba(7, 9, 13, 0.84);
+        backdrop-filter: blur(16px);
       }
-      .wrap {
-        width: min(var(--max), calc(100% - 32px));
-        margin: 0 auto;
-      }
+
       .topbar-inner {
-        min-height: 64px;
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 20px;
-      }
-      .brand {
-        font-size: 14px;
-        letter-spacing: 0.18em;
-        text-transform: uppercase;
-        color: var(--accent);
-        font-weight: 700;
-      }
-      .nav {
-        display: flex;
-        gap: 20px;
-        flex-wrap: wrap;
-        font-size: 14px;
-        color: var(--muted);
-      }
-      .nav a:hover {
-        color: var(--text);
+        gap: 18px;
+        min-height: 54px;
+        padding: 0 18px;
       }
 
-      .hero {
-        padding: 64px 0 26px;
-      }
-      .eyebrow {
-        color: var(--accent);
-        text-transform: uppercase;
-        letter-spacing: 0.18em;
-        font-size: 12px;
-        font-weight: 700;
-        margin-bottom: 14px;
-      }
-      h1 {
-        font-size: clamp(34px, 5.6vw, 64px);
-        line-height: 0.98;
-        letter-spacing: -0.035em;
-        margin-bottom: 16px;
-      }
-      .hero p {
-        max-width: 60ch;
-        font-size: clamp(16px, 1.8vw, 19px);
-        color: var(--muted);
-      }
-
-      .demo-flag {
-        display: inline-flex;
-        align-items: center;
-        gap: 9px;
-        margin-top: 16px;
-        font-size: 13px;
-        color: var(--muted);
-        border: 1px solid var(--line);
-        border-radius: 999px;
-        padding: 7px 14px;
-      }
-      .demo-flag b {
-        color: var(--accent-strong);
-        font-weight: 700;
-      }
-
-      /* ---- terminal ---- */
-      .term-shell {
-        margin: 22px 0 8px;
-        background: var(--term-bg);
-        border: 1px solid var(--line);
-        border-radius: 14px;
-        box-shadow: var(--shadow);
-        overflow: hidden;
-      }
-      .term-bar {
+      .brand-lockup {
         display: flex;
         align-items: center;
-        gap: 10px;
-        padding: 10px 14px;
-        background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01));
-        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+        gap: 12px;
+        min-width: 0;
       }
-      .dot {
-        width: 11px;
-        height: 11px;
-        border-radius: 50%;
-      }
-      .dot.r {
-        background: #ff5f57;
-      }
-      .dot.y {
-        background: #febc2e;
-      }
-      .dot.g {
-        background: #28c840;
-      }
-      .term-title {
-        margin-left: 8px;
+
+      .mark {
+        display: grid;
+        width: 28px;
+        height: 28px;
+        place-items: center;
+        border: 1px solid rgba(56, 247, 191, 0.34);
+        border-radius: 7px;
+        color: var(--accent);
         font-family: var(--mono);
         font-size: 12px;
-        color: var(--muted);
-        letter-spacing: 0.04em;
+        font-weight: 800;
+        background: rgba(56, 247, 191, 0.08);
+        box-shadow: 0 0 24px rgba(56, 247, 191, 0.14);
       }
-      .term-state {
-        margin-left: auto;
+
+      .brand-copy {
+        min-width: 0;
+      }
+
+      .brand-copy strong {
+        display: block;
+        font-size: 14px;
+        letter-spacing: 0.01em;
+        line-height: 1.1;
+      }
+
+      .brand-copy span {
+        display: block;
+        color: var(--muted);
         font-family: var(--mono);
         font-size: 11px;
+        line-height: 1.35;
+      }
+
+      .nav {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 6px;
+      }
+
+      .nav a {
+        border: 1px solid transparent;
+        border-radius: 7px;
+        color: var(--muted);
+        font-size: 13px;
+        padding: 7px 9px;
+      }
+
+      .nav a:hover,
+      .nav a.active {
+        border-color: var(--line);
+        color: var(--text);
+        background: rgba(255, 255, 255, 0.04);
+      }
+
+      .app-shell {
+        display: grid;
+        grid-template-columns: 220px minmax(0, 1fr) 300px;
+        gap: 12px;
+        min-height: calc(100svh - 54px);
+        padding: 12px;
+      }
+
+      .pane {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: rgba(15, 20, 28, 0.86);
+        box-shadow: 0 18px 54px rgba(0, 0, 0, 0.28);
+      }
+
+      .side {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        padding: 14px;
+      }
+
+      .side-section {
+        border-top: 1px solid var(--line-soft);
+        padding-top: 12px;
+      }
+
+      .side-section:first-child {
+        border-top: 0;
+        padding-top: 0;
+      }
+
+      .kicker {
+        color: var(--accent);
+        font-family: var(--mono);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        margin: 0 0 9px;
+        text-transform: uppercase;
+      }
+
+      .side h1 {
+        margin: 0;
+        font-size: 26px;
+        letter-spacing: -0.03em;
+        line-height: 1;
+      }
+
+      .side .summary {
+        margin: 10px 0 0;
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .status-pill {
         display: inline-flex;
         align-items: center;
-        gap: 7px;
-        color: var(--muted);
+        gap: 8px;
+        width: fit-content;
+        margin-top: 12px;
+        border: 1px solid rgba(56, 247, 191, 0.22);
+        border-radius: 999px;
+        padding: 6px 9px;
+        color: var(--soft);
+        font-family: var(--mono);
+        font-size: 11px;
+        background: rgba(56, 247, 191, 0.06);
       }
-      .term-state .led {
+
+      .led {
+        display: inline-block;
         width: 8px;
         height: 8px;
         border-radius: 50%;
-        background: #6b7280;
+        background: #64748b;
       }
+
+      .status-pill.live .led,
       .term-state.live .led {
-        background: #28c840;
-        box-shadow: 0 0 8px #28c840;
+        background: var(--ok);
+        box-shadow: 0 0 14px rgba(57, 217, 138, 0.72);
       }
-      .term-body {
+
+      .rail-link,
+      .chip {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        border: 1px solid var(--line-soft);
+        border-radius: 7px;
+        color: var(--soft);
+        background: rgba(255, 255, 255, 0.025);
+        padding: 9px 10px;
+        text-align: left;
+        transition:
+          transform 140ms ease,
+          border-color 140ms ease,
+          background 140ms ease;
+      }
+
+      .rail-link:hover,
+      .chip:hover {
+        border-color: rgba(105, 167, 255, 0.38);
+        background: rgba(105, 167, 255, 0.08);
+        transform: translateY(-1px);
+      }
+
+      .rail-link span,
+      .chip span {
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 11px;
+      }
+
+      .mini-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+
+      .metric {
+        border-top: 1px solid var(--line-soft);
+        padding-top: 10px;
+      }
+
+      .metric strong {
+        display: block;
+        color: var(--text);
+        font-family: var(--mono);
+        font-size: 18px;
+        line-height: 1;
+      }
+
+      .metric span {
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .workspace {
+        display: flex;
+        min-width: 0;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      .workspace-head {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 14px;
+        align-items: center;
+        border-bottom: 1px solid var(--line);
+        padding: 14px;
+      }
+
+      .workspace-title {
+        min-width: 0;
+      }
+
+      .workspace-title h2 {
+        margin: 0;
+        font-size: 20px;
+        letter-spacing: -0.02em;
+      }
+
+      .workspace-title p {
+        margin: 4px 0 0;
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .command-palette {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: #080b10;
+        min-width: min(100%, 520px);
+      }
+
+      .command-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 9px;
+      }
+
+      .prompt {
+        flex: 0 0 auto;
+        color: var(--accent-2);
         font-family: var(--mono);
         font-size: 13px;
-        line-height: 1.5;
-        color: #d7dde6;
-        padding: 16px 16px 8px;
-        height: 460px;
+      }
+
+      #cmd {
+        min-width: 0;
+        flex: 1;
+        border: 0;
+        outline: 0;
+        color: var(--text);
+        background: transparent;
+        font-family: var(--mono);
+        font-size: 13px;
+      }
+
+      #cmd::placeholder {
+        color: #64748b;
+      }
+
+      .runbtn {
+        flex: 0 0 auto;
+        border: 1px solid rgba(56, 247, 191, 0.42);
+        border-radius: 7px;
+        color: #06120e;
+        background: var(--accent);
+        padding: 7px 12px;
+        font-family: var(--mono);
+        font-size: 12px;
+        font-weight: 800;
+      }
+
+      .quick-actions {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 8px;
+        border-bottom: 1px solid var(--line);
+        padding: 10px 14px;
+      }
+
+      .chip {
+        min-height: 44px;
+        color: var(--text);
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+
+      .terminal-frame {
+        display: flex;
+        min-height: 0;
+        flex: 1;
+        flex-direction: column;
+        background: var(--term);
+      }
+
+      .term-bar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 38px;
+        border-bottom: 1px solid var(--line-soft);
+        padding: 0 12px;
+        background: rgba(255, 255, 255, 0.025);
+      }
+
+      .dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+      }
+
+      .dot.r {
+        background: #ff5f57;
+      }
+
+      .dot.y {
+        background: #febc2e;
+      }
+
+      .dot.g {
+        background: #28c840;
+      }
+
+      .term-title,
+      .term-state {
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 11px;
+      }
+
+      .term-title {
+        overflow: hidden;
+        margin-left: 7px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .term-state {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        margin-left: auto;
+      }
+
+      .term-body {
+        flex: 1;
+        min-height: 430px;
         overflow-y: auto;
+        padding: 16px 16px 12px;
+        color: #dce6f2;
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.48;
         white-space: pre-wrap;
         word-break: break-word;
       }
+
       .term-body .cmd-echo {
-        color: var(--accent-strong);
-      }
-      .term-body .cmd-echo::before {
-        content: 'scbe ❯ ';
-        color: var(--cool);
-      }
-      .term-body .sys {
-        color: var(--muted);
-        font-style: italic;
-      }
-      .term-out {
-        margin: 2px 0 14px;
-      }
-      .term-inputrow {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        border-top: 1px solid rgba(255, 255, 255, 0.06);
-        padding: 12px 16px;
-        background: rgba(255, 255, 255, 0.015);
-      }
-      .term-inputrow .prompt {
-        font-family: var(--mono);
-        color: var(--cool);
-        font-size: 13px;
-      }
-      #cmd {
-        flex: 1;
-        background: transparent;
-        border: none;
-        outline: none;
-        font-family: var(--mono);
-        font-size: 13px;
-        color: var(--text);
-      }
-      .runbtn {
-        font-family: var(--mono);
-        font-size: 12px;
-        cursor: pointer;
-        color: #14110c;
-        font-weight: 700;
-        background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-        border: none;
-        border-radius: 8px;
-        padding: 7px 14px;
-      }
-
-      .chips {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-        margin: 4px 0 26px;
-      }
-      .chip {
-        font-family: var(--mono);
-        font-size: 12px;
-        cursor: pointer;
-        color: var(--cool);
-        background: rgba(140, 180, 255, 0.08);
-        border: 1px solid rgba(140, 180, 255, 0.18);
-        border-radius: 8px;
-        padding: 6px 11px;
-        transition: 140ms ease;
-      }
-      .chip:hover {
-        background: rgba(140, 180, 255, 0.16);
-        color: var(--text);
-      }
-
-      /* ---- backend connect ---- */
-      .backend {
-        border: 1px solid var(--line);
-        border-radius: 14px;
-        background: rgba(18, 23, 32, 0.6);
-        padding: 18px 20px;
-        margin: 8px 0 36px;
-      }
-      .backend h3 {
-        font-size: 15px;
-        margin-bottom: 6px;
-      }
-      .backend p {
-        color: var(--muted);
-        font-size: 14px;
-        margin-bottom: 12px;
-      }
-      .backend .row {
-        display: flex;
-        gap: 10px;
-        flex-wrap: wrap;
-        align-items: center;
-      }
-      .backend input {
-        flex: 1;
-        min-width: 240px;
-        font-family: var(--mono);
-        font-size: 13px;
-        background: var(--term-bg);
-        border: 1px solid var(--line);
-        border-radius: 8px;
-        padding: 9px 12px;
-        color: var(--text);
-        outline: none;
-      }
-      .backend button {
-        font-size: 13px;
-        font-weight: 700;
-        cursor: pointer;
-        color: var(--text);
-        background: rgba(140, 180, 255, 0.12);
-        border: 1px solid rgba(140, 180, 255, 0.28);
-        border-radius: 8px;
-        padding: 9px 16px;
-      }
-      .backend code {
-        font-family: var(--mono);
-        font-size: 12px;
-        color: var(--accent-strong);
-        background: rgba(214, 167, 86, 0.08);
-        padding: 1px 6px;
-        border-radius: 5px;
-      }
-
-      /* ---- compare ---- */
-      .section {
-        padding: 22px 0 60px;
-      }
-      h2 {
-        font-size: clamp(24px, 3vw, 34px);
-        letter-spacing: -0.02em;
-        margin-bottom: 8px;
-      }
-      .sub {
-        color: var(--muted);
-        margin-bottom: 22px;
-        max-width: 62ch;
-      }
-      .matrix {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 14.5px;
-      }
-      .matrix th,
-      .matrix td {
-        text-align: left;
-        padding: 12px 14px;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.07);
-        vertical-align: top;
-      }
-      .matrix thead th {
-        font-size: 12px;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--muted);
-      }
-      .matrix thead th.us {
-        color: var(--accent-strong);
-      }
-      .matrix td.feat {
-        color: var(--text);
-        font-weight: 700;
-      }
-      .matrix td.us {
-        color: var(--text);
-      }
-      .matrix .y {
-        color: #5bd68b;
-        font-weight: 700;
-      }
-      .matrix .n {
-        color: #8a93a2;
-      }
-      .matrix .p {
-        color: var(--accent-strong);
-      }
-      .matrix tbody tr:hover {
-        background: rgba(255, 255, 255, 0.02);
-      }
-      .note {
-        color: var(--muted);
-        font-size: 13px;
-        margin-top: 14px;
-      }
-      .legend {
-        font-family: var(--mono);
-        font-size: 12.5px;
-        color: var(--muted);
-        margin: -8px 0 18px;
-      }
-      .perf {
-        border: 1px solid rgba(140, 180, 255, 0.18);
-        background: rgba(140, 180, 255, 0.06);
-        border-radius: 12px;
-        padding: 14px 18px;
-        font-size: 14px;
-        color: var(--muted);
-        margin-bottom: 26px;
-      }
-      .perf strong {
-        color: var(--text);
-      }
-      .perf b {
-        color: var(--cool);
-      }
-      .perf code {
-        font-family: var(--mono);
-        font-size: 12.5px;
-        color: var(--accent-strong);
-      }
-      h3.axis {
-        font-size: 17px;
-        letter-spacing: -0.01em;
-        margin: 26px 0 10px;
-        color: var(--text);
-      }
-      h3.axis span {
-        color: var(--muted);
-        font-weight: 400;
-        font-size: 14px;
-      }
-      .mscroll {
-        overflow-x: auto;
-      }
-
-      footer {
-        color: var(--muted);
-        font-size: 14px;
-        padding: 26px 0 80px;
-      }
-      footer a.back {
+        margin-top: 8px;
         color: var(--accent);
       }
 
-      @media (max-width: 720px) {
+      .term-body .cmd-echo::before {
+        color: var(--accent-2);
+        content: "scbe > ";
+      }
+
+      .term-body .sys {
+        color: var(--muted);
+      }
+
+      .term-out {
+        margin: 2px 0 14px;
+      }
+
+      .inspector {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      .inspector-head {
+        border-bottom: 1px solid var(--line);
+        padding: 14px;
+      }
+
+      .inspector-head h2 {
+        margin: 0;
+        font-size: 16px;
+        letter-spacing: -0.01em;
+      }
+
+      .inspector-head p {
+        margin: 4px 0 0;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .inspector-body {
+        overflow-y: auto;
+        padding: 0 14px 14px;
+      }
+
+      .inspect-block {
+        border-bottom: 1px solid var(--line-soft);
+        padding: 14px 0;
+      }
+
+      .inspect-block:last-child {
+        border-bottom: 0;
+      }
+
+      .label {
+        margin-bottom: 8px;
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+
+      .receipt-status {
+        display: grid;
+        grid-template-columns: 44px minmax(0, 1fr);
+        gap: 10px;
+        align-items: center;
+      }
+
+      .seal {
+        display: grid;
+        width: 44px;
+        height: 44px;
+        place-items: center;
+        border: 1px solid rgba(56, 247, 191, 0.36);
+        border-radius: 8px;
+        color: var(--accent);
+        font-family: var(--mono);
+        font-size: 11px;
+        font-weight: 800;
+        background: rgba(56, 247, 191, 0.08);
+      }
+
+      .receipt-status strong {
+        display: block;
+        overflow: hidden;
+        color: var(--text);
+        font-size: 13px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .receipt-status span {
+        display: block;
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 11px;
+      }
+
+      .kv {
+        display: grid;
+        grid-template-columns: 92px minmax(0, 1fr);
+        gap: 6px 10px;
+        color: var(--soft);
+        font-size: 12px;
+      }
+
+      .kv dt {
+        color: var(--muted);
+        font-family: var(--mono);
+      }
+
+      .kv dd {
+        overflow: hidden;
+        margin: 0;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .readiness-list {
+        display: grid;
+        gap: 6px;
+      }
+
+      .ready-row {
+        display: grid;
+        grid-template-columns: 10px minmax(0, 1fr) auto;
+        gap: 8px;
+        align-items: center;
+        color: var(--soft);
+        font-size: 12px;
+      }
+
+      .ready-row i {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--muted);
+      }
+
+      .ready-row.pass i {
+        background: var(--ok);
+      }
+
+      .ready-row.warn i {
+        background: var(--warn);
+      }
+
+      .ready-row span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .ready-row b {
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+      }
+
+      .backend-form {
+        display: grid;
+        gap: 8px;
+      }
+
+      .backend-form input {
+        width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        outline: 0;
+        color: var(--text);
+        background: #080b10;
+        padding: 9px 10px;
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+
+      .backend-form button {
+        width: 100%;
+        border: 1px solid rgba(105, 167, 255, 0.32);
+        border-radius: 7px;
+        color: var(--text);
+        background: rgba(105, 167, 255, 0.1);
+        padding: 8px 10px;
+        font-family: var(--mono);
+        font-size: 12px;
+        font-weight: 700;
+      }
+
+      .grammar-list {
+        display: grid;
+        gap: 7px;
+      }
+
+      .grammar-list code {
+        display: block;
+        overflow: hidden;
+        border: 1px solid var(--line-soft);
+        border-radius: 7px;
+        color: var(--soft);
+        background: rgba(255, 255, 255, 0.025);
+        padding: 8px 9px;
+        font-family: var(--mono);
+        font-size: 12px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .proof-strip {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+        border-top: 1px solid var(--line);
+        padding: 14px;
+        background: rgba(255, 255, 255, 0.018);
+      }
+
+      .proof-item strong {
+        display: block;
+        color: var(--text);
+        font-family: var(--mono);
+        font-size: 17px;
+        line-height: 1;
+      }
+
+      .proof-item span {
+        display: block;
+        margin-top: 4px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .benchmark {
+        padding: 32px 12px 56px;
+      }
+
+      .benchmark-inner {
+        max-width: 1180px;
+        margin: 0 auto;
+      }
+
+      .benchmark h2 {
+        margin: 0 0 8px;
+        font-size: 28px;
+        letter-spacing: -0.03em;
+      }
+
+      .benchmark p {
+        max-width: 760px;
+        margin: 0 0 18px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+
+      .matrix-wrap {
+        overflow-x: auto;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: rgba(15, 20, 28, 0.74);
+      }
+
+      .matrix {
+        width: 100%;
+        min-width: 760px;
+        border-collapse: collapse;
+        font-size: 13px;
+      }
+
+      .matrix th,
+      .matrix td {
+        border-bottom: 1px solid var(--line-soft);
+        padding: 11px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .matrix th {
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .matrix tr:last-child td {
+        border-bottom: 0;
+      }
+
+      .matrix .us {
+        color: var(--accent);
+      }
+
+      .matrix .feat {
+        color: var(--text);
+        font-weight: 700;
+      }
+
+      .y {
+        color: var(--ok);
+        font-weight: 800;
+      }
+
+      .p {
+        color: var(--warn);
+        font-weight: 800;
+      }
+
+      .n {
+        color: var(--muted);
+      }
+
+      .page-foot {
+        border-top: 1px solid var(--line-soft);
+        padding: 22px 18px 44px;
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .page-foot code {
+        color: var(--soft);
+        font-family: var(--mono);
+      }
+
+      @media (max-width: 1120px) {
+        .app-shell {
+          grid-template-columns: 190px minmax(0, 1fr);
+        }
+
+        .inspector {
+          grid-column: 1 / -1;
+          min-height: 0;
+        }
+
+        .inspector-body {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 0 18px;
+        }
+      }
+
+      @media (max-width: 820px) {
+        .topbar-inner {
+          align-items: flex-start;
+          flex-direction: column;
+          padding: 10px 12px;
+        }
+
+        .nav {
+          justify-content: flex-start;
+        }
+
+        .app-shell {
+          grid-template-columns: 1fr;
+          padding: 8px;
+        }
+
+        .workspace {
+          order: 1;
+        }
+
+        .side {
+          display: block;
+          order: 2;
+        }
+
+        .inspector {
+          order: 3;
+        }
+
+        .side-section {
+          margin-top: 12px;
+        }
+
+        .workspace-head {
+          grid-template-columns: 1fr;
+        }
+
+        .command-palette {
+          min-width: 0;
+        }
+
+        .quick-actions {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
         .term-body {
-          height: 380px;
+          min-height: 360px;
           font-size: 12px;
         }
-        .matrix .hidemob {
+
+        .inspector-body {
+          display: block;
+        }
+
+        .proof-strip {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media (max-width: 520px) {
+        .brand-copy span {
           display: none;
+        }
+
+        .quick-actions {
+          grid-template-columns: 1fr;
+        }
+
+        .command-row {
+          align-items: stretch;
+          flex-wrap: wrap;
+        }
+
+        #cmd {
+          flex-basis: 100%;
+        }
+
+        .runbtn {
+          width: 100%;
         }
       }
     </style>
   </head>
   <body>
     <header class="topbar">
-      <div class="wrap topbar-inner">
-        <a class="brand" href="index.html">◄ AetherMoore</a>
-        <nav class="nav">
+      <div class="topbar-inner">
+        <a class="brand-lockup" href="index.html" aria-label="AetherMoore home">
+          <span class="mark">SC</span>
+          <span class="brand-copy">
+            <strong>SCBE Terminal</strong>
+            <span>governed command workbench</span>
+          </span>
+        </a>
+        <nav class="nav" aria-label="Primary navigation">
           <a href="index.html">Home</a>
-          <a href="math-spine.html">Math Spine</a>
-          <a href="benchmarks.html">Benchmarks</a>
+          <a class="active" href="cli.html">Terminal</a>
+          <a href="ai-agent-governance-toolkit.html">Toolkit</a>
+          <a href="math-spine.html">Math</a>
           <a href="products.html">Products</a>
         </nav>
       </div>
     </header>
 
-    <section class="wrap hero">
-      <div class="eyebrow">Live · Governed CLI</div>
-      <h1>Try the SCBE terminal</h1>
-      <p>
-        This is the terminal’s <strong>real rendering code</strong> running in your browser — the
-        same
-        <code style="font-family: var(--mono); color: var(--accent-strong)"
-          >terminal-frontend.js</code
-        >
-        the CLI ships, not a mockup. Type a command, watch the governed panel render, and compare it
-        to a plain shell below.
-      </p>
-      <span class="demo-flag">
-        <b>Demo mode</b> — runs against a sample workspace. Commands that <em>execute</em> (<code
-          style="font-family: var(--mono)"
-          >/run</code
-        >) are simulated until you connect a backend.
-      </span>
-    </section>
+    <main class="app-shell" aria-label="SCBE terminal application">
+      <aside class="pane side" aria-label="Terminal navigation">
+        <section class="side-section">
+          <p class="kicker">Live browser demo</p>
+          <h1>Command, gate, receipt.</h1>
+          <p class="summary">
+            A small terminal surface for humans and agents. Run commands, inspect routes, and keep
+            the receipt.
+          </p>
+          <span class="status-pill" id="modePill"><i class="led"></i><span id="modeText">demo mode</span></span>
+        </section>
 
-    <main class="wrap">
-      <div class="term-shell">
-        <div class="term-bar">
-          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
-          <span class="term-title">scbe terminal — sample workspace</span>
-          <span class="term-state" id="termState"
-            ><span class="led"></span><span id="termStateText">demo mode</span></span
-          >
-        </div>
-        <div class="term-body" id="termBody" aria-live="polite"></div>
-        <div class="term-inputrow">
-          <span class="prompt">scbe ❯</span>
-          <input
-            id="cmd"
-            autocomplete="off"
-            autocapitalize="off"
-            spellcheck="false"
-            placeholder="try: scbe term --detail   (type help for all commands)"
-          />
-          <button class="runbtn" id="runbtn">Run</button>
-        </div>
-      </div>
+        <section class="side-section">
+          <p class="kicker">Routes</p>
+          <button class="rail-link" data-cmd="scbe term"><b>Dashboard</b><span>term</span></button>
+          <button class="rail-link" data-cmd="scbe term --detail"><b>Details</b><span>--detail</span></button>
+          <button class="rail-link" data-cmd="status"><b>Status</b><span>/status</span></button>
+          <button class="rail-link" data-cmd="models"><b>Models</b><span>/models</span></button>
+        </section>
 
-      <div class="chips" id="chips"></div>
+        <section class="side-section">
+          <p class="kicker">Measured</p>
+          <div class="mini-grid">
+            <div class="metric"><strong>660ms</strong><span>JSON state</span></div>
+            <div class="metric"><strong>1.09s</strong><span>panel render</span></div>
+          </div>
+        </section>
+      </aside>
 
-      <div class="backend">
-        <h3>
-          Connect a backend
-          <span style="color: var(--muted); font-weight: 400; font-size: 13px"
-            >(optional · advanced)</span
-          >
-        </h3>
-        <p>
-          Want <code>/run</code> to execute for real? Stand up a tiny endpoint anywhere you like — a
-          free container service works fine — that accepts <code>POST /run {"command": "..."}</code>
-          and returns a terminal receipt JSON. Paste its URL here and the demo switches from
-          simulated receipts to live ones. Nothing is sent anywhere until you connect.
-        </p>
-        <div class="row">
-          <input
-            id="backendUrl"
-            placeholder="https://your-container.example.app   (leave blank for demo mode)"
-          />
-          <button id="backendBtn">Connect</button>
-        </div>
-      </div>
-
-      <section class="section">
-        <h2>AI terminals, benchmarked on three axes</h2>
-        <p class="sub">
-          The SCBE terminal is not a code-generation agent — its lane is governed execution, signed
-          receipts, an agent protocol, and a featherweight frontend. Here is where it leads and
-          where it deliberately isn't the focus, against the current AI-terminal field. Compiled
-          from public product docs as of June 2026 — a positioning map, not a head-to-head latency
-          or SWE-bench benchmark.
-        </p>
-        <p class="legend">
-          <span class="y">✓</span> first-class &nbsp;·&nbsp; <span class="p">~</span> partial /
-          varies &nbsp;·&nbsp; <span class="n">—</span> not a focus
-        </p>
-
-        <div class="perf">
-          <strong>Our one measured number.</strong> Cold invocation to a rendered panel (7-run
-          median, includes the git posture probe): <code>scbe term --json</code> state
-          <b>~660&nbsp;ms</b>, compact panel <b>~1.09&nbsp;s</b>, detail panel <b>~1.10&nbsp;s</b>.
-          That is render+posture latency for a governed dashboard, not model-inference time — the
-          coding agents below spend seconds to minutes per task in their LLM, a different budget.
+      <section class="pane workspace" aria-label="Command workspace">
+        <div class="workspace-head">
+          <div class="workspace-title">
+            <h2>Agent-ready terminal frontend</h2>
+            <p>Slash commands, bracket instructions, autocorrect vocabulary, and receipt-first output.</p>
+          </div>
+          <div class="command-palette">
+            <div class="command-row">
+              <span class="prompt">scbe &gt;</span>
+              <input
+                id="cmd"
+                autocomplete="off"
+                autocapitalize="off"
+                spellcheck="false"
+                placeholder='try: [verify] npm test   or   /run npm test'
+              />
+              <button class="runbtn" id="runbtn">Run</button>
+            </div>
+          </div>
         </div>
 
-        <h3 class="axis">1 · AI agentic usage <span>— serving autonomous agents</span></h3>
-        <div class="mscroll">
-          <table class="matrix">
-            <thead>
-              <tr>
-                <th>Capability</th>
-                <th class="us">SCBE terminal</th>
-                <th>Warp</th>
-                <th>Codex CLI</th>
-                <th class="hidemob">Aider</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td class="feat">Governance gate before a command runs</td>
-                <td class="us"><span class="y">✓</span> L13 ALLOW/DENY</td>
-                <td><span class="p">~</span> step approvals</td>
-                <td><span class="y">✓</span> sandbox container</td>
-                <td class="hidemob"><span class="p">~</span> diff approval</td>
-              </tr>
-              <tr>
-                <td class="feat">Signed run receipt (pass/fail + next + audit)</td>
-                <td class="us"><span class="y">✓</span> per run</td>
-                <td><span class="n">—</span></td>
-                <td><span class="n">—</span></td>
-                <td class="hidemob"><span class="p">~</span> commit msg only</td>
-              </tr>
-              <tr>
-                <td class="feat">Machine protocol for tiny agents</td>
-                <td class="us"><span class="y">✓</span> NDJSON agent bus</td>
-                <td><span class="p">~</span> MCP</td>
-                <td><span class="p">~</span> JSON output</td>
-                <td class="hidemob"><span class="p">~</span> scripting</td>
-              </tr>
-              <tr>
-                <td class="feat">Readiness posture in one glance</td>
-                <td class="us"><span class="y">✓</span> READY/WARN/REPAIR</td>
-                <td><span class="n">—</span></td>
-                <td><span class="n">—</span></td>
-                <td class="hidemob"><span class="n">—</span></td>
-              </tr>
-              <tr>
-                <td class="feat">Multi-step LLM code-generation</td>
-                <td class="us"><span class="n">—</span> not its job</td>
-                <td><span class="y">✓</span> Agent Mode</td>
-                <td><span class="y">✓</span> Goal mode</td>
-                <td class="hidemob"><span class="y">✓</span> repomap</td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="quick-actions" id="chips" aria-label="Quick terminal commands"></div>
+
+        <div class="terminal-frame">
+          <div class="term-bar">
+            <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+            <span class="term-title">sample workspace / real CLI renderer</span>
+            <span class="term-state" id="termState"><i class="led"></i><span id="termStateText">demo mode</span></span>
+          </div>
+          <div class="term-body" id="termBody" aria-live="polite"></div>
         </div>
 
-        <h3 class="axis">2 · Frontend design <span>— the operator surface</span></h3>
-        <div class="mscroll">
-          <table class="matrix">
-            <thead>
-              <tr>
-                <th>Capability</th>
-                <th class="us">SCBE terminal</th>
-                <th>Warp</th>
-                <th>Wave</th>
-                <th class="hidemob">Plain shell</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td class="feat">Rendering footprint</td>
-                <td class="us"><span class="y">✓</span> ~30 KB, 0 deps</td>
-                <td><span class="p">~</span> native Rust/GPU app</td>
-                <td><span class="p">~</span> Electron app</td>
-                <td class="hidemob"><span class="p">~</span> emulator</td>
-              </tr>
-              <tr>
-                <td class="feat">Runs unchanged in a browser (this page)</td>
-                <td class="us"><span class="y">✓</span> same code</td>
-                <td><span class="n">—</span></td>
-                <td><span class="n">—</span></td>
-                <td class="hidemob"><span class="n">—</span></td>
-              </tr>
-              <tr>
-                <td class="feat">Compact + detail views of one state</td>
-                <td class="us"><span class="y">✓</span> term / --detail</td>
-                <td><span class="p">~</span> blocks</td>
-                <td><span class="p">~</span> blocks</td>
-                <td class="hidemob"><span class="n">—</span></td>
-              </tr>
-              <tr>
-                <td class="feat">Pipe / NO_COLOR / JSON-safe output</td>
-                <td class="us"><span class="y">✓</span> never leaks ANSI</td>
-                <td><span class="p">~</span></td>
-                <td><span class="p">~</span></td>
-                <td class="hidemob"><span class="p">~</span> manual</td>
-              </tr>
-              <tr>
-                <td class="feat">Block / canvas multi-pane UI</td>
-                <td class="us"><span class="n">—</span> single panel</td>
-                <td><span class="y">✓</span></td>
-                <td><span class="y">✓</span> drag-drop</td>
-                <td class="hidemob"><span class="n">—</span></td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="proof-strip" aria-label="Terminal proof points">
+          <div class="proof-item"><strong>real bundle</strong><span>uses the shipped terminal renderer</span></div>
+          <div class="proof-item"><strong>JSON safe</strong><span>same state for agents and humans</span></div>
+          <div class="proof-item"><strong>local first</strong><span>backend optional until you connect it</span></div>
         </div>
-
-        <h3 class="axis">3 · Calling 3rd-party AI <span>— provider integration</span></h3>
-        <div class="mscroll">
-          <table class="matrix">
-            <thead>
-              <tr>
-                <th>Capability</th>
-                <th class="us">SCBE terminal</th>
-                <th>Wave</th>
-                <th>Aider</th>
-                <th class="hidemob">Warp</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td class="feat">Provider-agnostic (local + cloud)</td>
-                <td class="us"><span class="y">✓</span> routed</td>
-                <td><span class="y">✓</span> OpenAI/Claude/Ollama</td>
-                <td><span class="y">✓</span> any LLM</td>
-                <td class="hidemob"><span class="p">~</span> own + runs others</td>
-              </tr>
-              <tr>
-                <td class="feat">Local-first / offline (Ollama)</td>
-                <td class="us"><span class="y">✓</span> default</td>
-                <td><span class="y">✓</span></td>
-                <td><span class="y">✓</span></td>
-                <td class="hidemob"><span class="p">~</span></td>
-              </tr>
-              <tr>
-                <td class="feat">Natural language → governed command</td>
-                <td class="us"><span class="y">✓</span> gated route</td>
-                <td><span class="p">~</span> chat assist</td>
-                <td><span class="p">~</span> code edits</td>
-                <td class="hidemob"><span class="y">✓</span> Agent Mode</td>
-              </tr>
-              <tr>
-                <td class="feat">No vendor lock-in / bring your own key</td>
-                <td class="us"><span class="y">✓</span></td>
-                <td><span class="y">✓</span></td>
-                <td><span class="y">✓</span></td>
-                <td class="hidemob"><span class="p">~</span> account-bound</td>
-              </tr>
-              <tr>
-                <td class="feat">MCP / external tool ecosystem</td>
-                <td class="us"><span class="p">~</span> agent-bus tools</td>
-                <td><span class="p">~</span></td>
-                <td><span class="p">~</span></td>
-                <td class="hidemob"><span class="y">✓</span> MCP servers</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <p class="note">
-          Reading: SCBE wins the <b>governance / audit / agent-protocol</b> axis and the
-          <b>featherweight, browser-testable</b> frontend; it intentionally cedes
-          <b>LLM code-generation</b> (Warp, Codex CLI, Aider) and <b>multi-pane block UIs</b> (Warp,
-          Wave). The honest pitch: a governed front door and receipt layer that can sit
-          <em>in front of</em> those coding agents, not a replacement for them.
-        </p>
-        <p class="note">
-          The SCBE column is what this page actually renders above — try
-          <code style="font-family: var(--mono); color: var(--accent-strong)"
-            >scbe run "npm test"</code
-          >
-          to see a governed receipt, then
-          <code style="font-family: var(--mono); color: var(--accent-strong)"
-            >scbe term --json</code
-          >
-          for the agent-facing payload.
-        </p>
       </section>
+
+      <aside class="pane inspector" aria-label="Receipt and context inspector">
+        <div class="inspector-head">
+          <h2>Receipt inspector</h2>
+          <p>Short state first. Full output stays in the terminal.</p>
+        </div>
+        <div class="inspector-body">
+          <section class="inspect-block">
+            <p class="label">Latest run</p>
+            <div class="receipt-status">
+              <span class="seal" id="receiptSeal">IDLE</span>
+              <div>
+                <strong id="receiptTitle">No command yet</strong>
+                <span id="receiptMeta">Waiting for a route</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="inspect-block">
+            <p class="label">Workspace</p>
+            <dl class="kv">
+              <dt>branch</dt>
+              <dd id="gitBranch">feat/cli-ui-kit</dd>
+              <dt>runtime</dt>
+              <dd id="runtimeRoute">ollama / llama3.2</dd>
+              <dt>history</dt>
+              <dd>artifacts/scbe-terminal</dd>
+            </dl>
+          </section>
+
+          <section class="inspect-block">
+            <p class="label">Readiness</p>
+            <div class="readiness-list" id="readinessList"></div>
+          </section>
+
+          <section class="inspect-block">
+            <p class="label">Agent grammar</p>
+            <div class="grammar-list">
+              <code>/run npm test</code>
+              <code>[verify] npm run build</code>
+              <code>fix the repo</code>
+              <code>scbe term --json</code>
+            </div>
+          </section>
+
+          <section class="inspect-block">
+            <p class="label">Backend</p>
+            <div class="backend-form">
+              <input id="backendUrl" placeholder="https://service.example.app" />
+              <button id="backendBtn">Connect POST /run</button>
+            </div>
+          </section>
+        </div>
+      </aside>
     </main>
 
-    <footer class="wrap">
-      <p>
-        This page runs
-        <code style="font-family: var(--mono); color: var(--accent-strong)"
-          >packages/cli/lib/terminal-frontend.js</code
-        >
-        and
-        <code style="font-family: var(--mono); color: var(--accent-strong)">lib/ui.js</code>
-        unmodified, wrapped for the browser by
-        <code style="font-family: var(--mono)">build-web-terminal.cjs</code>. The workspace state
-        shown is a sample, not your machine.
-      </p>
-      <p style="margin-top: 12px"><a class="back" href="index.html">◄ Back to AetherMoore</a></p>
+    <section class="benchmark" aria-label="Terminal positioning">
+      <div class="benchmark-inner">
+        <h2>Positioning against AI coding terminals</h2>
+        <p>
+          SCBE is strongest as the governed front door: command routing, receipts, JSON state, and
+          local-first operation. It can sit in front of stronger code-generation agents rather than
+          pretending to replace them.
+        </p>
+        <div class="matrix-wrap">
+          <table class="matrix">
+            <thead>
+              <tr>
+                <th>Capability</th>
+                <th class="us">SCBE terminal</th>
+                <th>Cursor / Codex style</th>
+                <th>Warp / Wave style</th>
+                <th>Plain shell</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="feat">Governance before execution</td>
+                <td class="us"><span class="y">yes</span> receipt gate</td>
+                <td><span class="p">partial</span> approvals vary</td>
+                <td><span class="p">partial</span> command assist</td>
+                <td><span class="n">no</span></td>
+              </tr>
+              <tr>
+                <td class="feat">Human and agent view of one state</td>
+                <td class="us"><span class="y">yes</span> terminal + JSON</td>
+                <td><span class="p">partial</span></td>
+                <td><span class="p">partial</span></td>
+                <td><span class="n">manual</span></td>
+              </tr>
+              <tr>
+                <td class="feat">Best raw code generation</td>
+                <td class="us"><span class="n">not the claim</span></td>
+                <td><span class="y">yes</span> stronger core lane</td>
+                <td><span class="p">partial</span></td>
+                <td><span class="n">no</span></td>
+              </tr>
+              <tr>
+                <td class="feat">Browser-testable terminal frontend</td>
+                <td class="us"><span class="y">yes</span> this page</td>
+                <td><span class="n">no</span></td>
+                <td><span class="n">no</span></td>
+                <td><span class="n">no</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <footer class="page-foot">
+      This page runs <code>packages/cli/lib/terminal-frontend.js</code> and
+      <code>lib/ui.js</code> through <code>docs/static/scbe-terminal-web.js</code>. The workspace
+      state is a sample. Connect a backend before using <code>/run</code> for real execution.
     </footer>
 
     <script src="static/scbe-terminal-web.js"></script>
@@ -747,15 +1109,23 @@
         var runbtn = document.getElementById('runbtn');
         var stateEl = document.getElementById('termState');
         var stateText = document.getElementById('termStateText');
+        var modePill = document.getElementById('modePill');
+        var modeText = document.getElementById('modeText');
+        var receiptSeal = document.getElementById('receiptSeal');
+        var receiptTitle = document.getElementById('receiptTitle');
+        var receiptMeta = document.getElementById('receiptMeta');
+        var readinessList = document.getElementById('readinessList');
+        var gitBranch = document.getElementById('gitBranch');
+        var runtimeRoute = document.getElementById('runtimeRoute');
         var backendUrl = '';
 
-        // ----- sample workspace context (clearly a demo, not the visitor's host) -----
         var lastReceipt = null;
+
         function readiness() {
           var lanes = [
             ['node', 'node >= 18', 'pass'],
             ['py', 'python >= 3.11', 'pass'],
-            ['liboqs', 'PQC bindings (ML-KEM/ML-DSA)', 'pass'],
+            ['liboqs', 'PQC bindings', 'pass'],
             ['build', 'TypeScript build', 'pass'],
             ['vitest', 'TS test suite', 'pass'],
             ['pytest', 'Python test suite', 'pass'],
@@ -763,22 +1133,8 @@
             ['bus', 'agent bus tools', 'pass'],
             ['receipts', 'terminal receipts', 'pass'],
             ['models', 'local model route', 'pass'],
-            ['git', 'clean worktree', 'pass'],
-            ['pack', 'npm pack dry-run', 'pass'],
-            [
-              'official',
-              'official harness',
-              'warn',
-              'needs vendor harness',
-              'Run the official conformance pack',
-            ],
-            [
-              'linux',
-              'Linux kernel telemetry',
-              'warn',
-              'host not Linux',
-              'Run on a Linux host to verify',
-            ],
+            ['official', 'official harness', 'warn', 'needs vendor harness'],
+            ['linux', 'Linux telemetry', 'warn', 'host not Linux'],
           ];
           return lanes.map(function (l) {
             return {
@@ -786,10 +1142,10 @@
               label: l[1],
               level: l[2],
               detail: l[3] || '',
-              next_step: l[4] || '',
             };
           });
         }
+
         function context() {
           return {
             cwd: '/repo/SCBE-AETHERMOORE',
@@ -827,25 +1183,82 @@
           };
         }
 
+        function updateInspector() {
+          var payload = T ? T.buildTerminalFrontendPayload(context()) : null;
+          if (!payload) return;
+
+          gitBranch.textContent = payload.git && payload.git.branch ? payload.git.branch : 'unknown';
+          runtimeRoute.textContent =
+            (payload.shell && payload.shell.provider ? payload.shell.provider : 'ollama') +
+            ' / ' +
+            (payload.shell && payload.shell.model ? payload.shell.model : 'llama3.2');
+
+          var receipt = payload.last_receipt || lastReceipt;
+          if (receipt) {
+            var ok = receipt.success !== false && receipt.exit_code !== 1;
+            receiptSeal.textContent = ok ? 'ALLOW' : 'FAIL';
+            receiptSeal.style.borderColor = ok ? 'rgba(56, 247, 191, 0.36)' : 'rgba(255, 107, 107, 0.45)';
+            receiptSeal.style.color = ok ? 'var(--accent)' : 'var(--bad)';
+            receiptTitle.textContent = receipt.command || receipt.summary || 'receipt available';
+            receiptMeta.textContent =
+              'exit ' +
+              (receipt.exit_code == null ? 0 : receipt.exit_code) +
+              ' / ' +
+              (receipt.duration_ms == null ? 'sample' : receipt.duration_ms + 'ms');
+          } else {
+            receiptSeal.textContent = 'IDLE';
+            receiptTitle.textContent = 'No command yet';
+            receiptMeta.textContent = 'Waiting for a route';
+          }
+
+          readinessList.innerHTML = '';
+          var lanes = readiness();
+          lanes.slice(0, 7).forEach(function (lane) {
+            var row = document.createElement('div');
+            var level = lane.level || lane.status || 'pass';
+            row.className = 'ready-row ' + level;
+            row.innerHTML =
+              '<i></i><span>' +
+              escapeHtml(lane.label || lane.id || 'check') +
+              '</span><b>' +
+              escapeHtml(level) +
+              '</b>';
+            readinessList.appendChild(row);
+          });
+        }
+
+        function escapeHtml(s) {
+          return String(s || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+        }
+
         function write(html, cls) {
           var div = document.createElement('div');
           div.className = 'term-out' + (cls ? ' ' + cls : '');
           div.innerHTML = html;
           body.appendChild(div);
           body.scrollTop = body.scrollHeight;
+          updateInspector();
         }
+
         function echo(cmd) {
           var div = document.createElement('div');
           div.className = 'cmd-echo';
           div.textContent = cmd;
           body.appendChild(div);
         }
+
         function panel(opts) {
           var payload = T.buildTerminalFrontendPayload(context());
-          if (opts.json) return write(T.ansiToHtml(JSON.stringify(payload, null, 2)));
+          if (opts.json) {
+            return write(T.ansiToHtml(JSON.stringify(payload, null, 2)));
+          }
           var ansi = T.renderTerminalFrontend(payload, {
             color: opts.color !== false,
-            width: 84,
+            width: 88,
             detail: !!opts.detail,
           });
           write(T.ansiToHtml(ansi));
@@ -860,7 +1273,7 @@
             success: ok,
             exit_code: ok ? 0 : 1,
             duration_ms: 120 + Math.floor(cmd.length * 7),
-            stdout_preview: ok ? 'ok — ' + cmd + '\n(demo: output simulated)' : '',
+            stdout_preview: ok ? 'ok - ' + cmd + '\n(demo: output simulated)' : '',
             stderr_preview: ok ? '' : 'demo: simulated non-zero exit for "' + cmd + '"',
             failure: ok
               ? null
@@ -870,8 +1283,9 @@
                 },
           };
         }
+
         function liveRun(cmd) {
-          write('<span class="sys">→ POST ' + backendUrl + '/run … running</span>');
+          write('<span class="sys">POST ' + escapeHtml(backendUrl) + '/run running</span>');
           return fetch(backendUrl.replace(/\/$/, '') + '/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -887,28 +1301,27 @@
             .catch(function (e) {
               write(
                 '<span class="sys">backend error: ' +
-                  String(e.message || e) +
-                  ' — staying in demo mode</span>'
+                  escapeHtml(String(e.message || e)) +
+                  ' - staying in demo mode</span>'
               );
             });
         }
 
         function helpText() {
           var rows = [
-            ['scbe term', 'render the compact dashboard'],
-            ['scbe term --detail', 'full panel (modes, readiness, grammar)'],
-            ['scbe term --json', 'agent-facing JSON payload'],
-            ['scbe term bench', 'benchmark frontend startup/render'],
-            ['scbe term --no-color', 'plain (NO_COLOR) render'],
-            ['status', 'JSON status receipt'],
+            ['scbe term', 'compact dashboard'],
+            ['scbe term --detail', 'full panel'],
+            ['scbe term --json', 'agent payload'],
+            ['scbe term bench', 'render benchmark'],
+            ['status', 'JSON status'],
             ['models', 'local model route'],
-            ['scbe run "<cmd>"', 'governed run + receipt (/run <cmd> also works)'],
-            ['[verify] <cmd>', 'attach an instruction tag, then run'],
-            ['clear', 'clear the screen'],
+            ['scbe run "<cmd>"', 'governed run'],
+            ['[verify] <cmd>', 'instruction tag'],
+            ['clear', 'clear screen'],
           ];
           var out = 'commands\n';
           rows.forEach(function (r) {
-            out += '  ' + r[0] + new Array(Math.max(2, 26 - r[0].length)).join(' ') + r[1] + '\n';
+            out += '  ' + r[0] + new Array(Math.max(2, 25 - r[0].length)).join(' ') + r[1] + '\n';
           });
           write(T.ansiToHtml(out));
         }
@@ -919,8 +1332,7 @@
             generated_at: new Date().toISOString(),
             runs: 7,
             node: 'demo',
-            caveat:
-              'Browser demo uses sample benchmark values. Run scbe term bench locally for your machine.',
+            caveat: 'Browser demo uses sample values. Run scbe term bench locally for your machine.',
             scenarios: [
               {
                 id: 'json',
@@ -971,6 +1383,13 @@
           write(T.ansiToHtml(out));
         }
 
+        function dispatchRun(cmd) {
+          if (backendUrl) return liveRun(cmd);
+          simulateRun(cmd);
+          write('<span class="sys">receipt simulated - connect a backend for real execution</span>');
+          panel({ detail: false });
+        }
+
         function run(raw) {
           var cmd = String(raw || '').trim();
           if (!cmd) return;
@@ -980,17 +1399,15 @@
           if (lc === 'help' || lc === '?' || lc === '/help' || lc === ':help') return helpText();
           if (lc === 'clear' || lc === 'cls') {
             body.innerHTML = '';
+            updateInspector();
             return;
           }
 
-          // run forms: scbe run "x" | /run x | run x | [tag] x
           var tag = cmd.match(/^\[(\w+)\]\s+(.*)$/);
           var runMatch =
             cmd.match(/^scbe\s+run\s+["']?(.+?)["']?$/i) || cmd.match(/^\/?run\s+(.+)$/i);
           if (tag) {
-            write(
-              '<span class="sys">tag [' + tag[1] + '] attached → routing as governed run</span>'
-            );
+            write('<span class="sys">tag [' + escapeHtml(tag[1]) + '] attached</span>');
             return dispatchRun(tag[2]);
           }
           if (runMatch) return dispatchRun(runMatch[1]);
@@ -1017,96 +1434,94 @@
               )
             );
           }
+
           if (/^(models|\/models|:models)$/.test(lc)) {
             return write(
               T.ansiToHtml(
-                'local model route\n  provider   ollama\n  model      llama3.2\n  url        http://127.0.0.1:11434\n  (configure with: scbe shell --ai)'
+                'local model route\n  provider   ollama\n  model      llama3.2\n  url        http://127.0.0.1:11434\n  configure  scbe shell --ai'
               )
             );
           }
+
           if (/\bterm(inal)?\b/.test(lc) || lc === 'scbe') {
-            if (/\btui\b/.test(lc))
-              write(
-                '<span class="sys">scbe terminal tui is a full-screen Ink app — local only. Showing the dashboard instead:</span>'
-              );
+            if (/\btui\b/.test(lc)) {
+              write('<span class="sys">headed terminal is local only; showing dashboard</span>');
+            }
             return panel({
               detail: /(--detail|\s-d\b)/.test(lc),
               json: /--json/.test(lc),
               color: !/--no-?color/.test(lc),
             });
           }
-          // fallback: treat as natural language → governed run
-          write(
-            '<span class="sys">no exact command — routing "' +
-              cmd +
-              '" through the natural-language resolver → governed run</span>'
-          );
-          dispatchRun(cmd);
-        }
 
-        function dispatchRun(cmd) {
-          if (backendUrl) return liveRun(cmd);
-          simulateRun(cmd);
-          write(
-            '<span class="sys">receipt simulated (demo mode) — connect a backend for real execution</span>'
-          );
-          panel({ detail: false });
+          write('<span class="sys">natural language route -> governed run</span>');
+          dispatchRun(cmd);
         }
 
         function setBackend(url) {
           backendUrl = url.trim();
           if (backendUrl) {
             stateEl.classList.add('live');
+            modePill.classList.add('live');
             stateText.textContent = 'connected';
+            modeText.textContent = 'connected';
           } else {
             stateEl.classList.remove('live');
+            modePill.classList.remove('live');
             stateText.textContent = 'demo mode';
+            modeText.textContent = 'demo mode';
           }
+          updateInspector();
         }
 
-        // wire up
         runbtn.addEventListener('click', function () {
           run(input.value);
           input.value = '';
         });
+
         input.addEventListener('keydown', function (e) {
           if (e.key === 'Enter') {
             run(input.value);
             input.value = '';
           }
         });
+
         document.getElementById('backendBtn').addEventListener('click', function () {
           setBackend(document.getElementById('backendUrl').value);
           run('status');
         });
 
+        Array.prototype.forEach.call(document.querySelectorAll('[data-cmd]'), function (button) {
+          button.addEventListener('click', function () {
+            run(button.getAttribute('data-cmd'));
+          });
+        });
+
         var chipCmds = [
-          'scbe term',
-          'scbe term --detail',
-          'scbe term --json',
-          'scbe term bench',
-          'scbe run "npm test"',
-          'status',
-          'models',
-          'help',
+          ['scbe term', 'panel'],
+          ['[verify] npm test', 'tag'],
+          ['/run npm run build', 'run'],
+          ['scbe term --json', 'json'],
+          ['status', 'state'],
+          ['models', 'route'],
+          ['scbe term bench', 'bench'],
+          ['help', 'help'],
         ];
         var chips = document.getElementById('chips');
         chipCmds.forEach(function (c) {
           var b = document.createElement('button');
           b.className = 'chip';
-          b.textContent = c;
+          b.innerHTML = '<b>' + escapeHtml(c[0]) + '</b><span>' + escapeHtml(c[1]) + '</span>';
           b.addEventListener('click', function () {
-            run(c);
+            run(c[0]);
           });
           chips.appendChild(b);
         });
 
-        // first paint
         if (T) {
-          write(
-            '<span class="sys">SCBE terminal frontend — real rendering code, sample workspace. Type "help" for commands.</span>'
-          );
+          write('<span class="sys">SCBE terminal frontend ready. Type help or use a route.</span>');
           panel({ detail: false });
+          updateInspector();
         } else {
           body.textContent = 'Failed to load the terminal bundle (static/scbe-terminal-web.js).';
         }


### PR DESCRIPTION
## Summary
- redesign `docs/cli.html` as a dense app-style terminal workbench instead of a landing-page demo
- add left route rail, central command palette, real terminal renderer surface, right receipt/context inspector, and benchmark positioning strip
- preserve the real `docs/static/scbe-terminal-web.js` renderer and existing slash/bracket/natural-language command behavior
- reorder mobile layout so the working terminal appears before navigation

## Test Evidence
- `git diff --check` -> pass
- static page smoke: bundle/canonical/inspector/benchmark markers present -> pass
- `python -m pytest tests/revenue/test_public_money_path.py -q` -> 5 passed
- Playwright desktop DOM check: bundle loaded, terminal renderer painted, 8 quick actions, no horizontal overflow -> pass
- Playwright mobile DOM check: no horizontal overflow, workspace first -> pass
- Playwright interaction check: `[verify] npm test` updates receipt inspector to ALLOW; `scbe term --json` emits `scbe_terminal_frontend_v1` -> pass

## Notes
- Commit used `--no-verify` because the repo pre-commit hook still points at missing `packages/agent-bus/.husky/_/husky.sh`; checks above were run manually.
