### PR TITLE
feat(agent-bus): salvage capillary gate + bridge planners from stale #2066

### DIFF
--- a/agents/kernel_antivirus_gate.py
+++ b/agents/kernel_antivirus_gate.py
@@ -18,13 +18,14 @@ Expected integration:
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import asdict, dataclass
 from typing import Any, Iterable, Literal
 import re
 
 from agents.antivirus_membrane import ThreatScan, scan_text_for_threats
+from agents.hyperbolic_scanner import scan_boundary_state
 from hydra.turnstile import TurnstileOutcome, resolve_turnstile
-
 
 KernelAction = Literal["ALLOW", "THROTTLE", "QUARANTINE", "KILL", "HONEYPOT"]
 
@@ -286,4 +287,55 @@ def evaluate_kernel_event(
         isolate_process=isolate_process,
         quarantine_target=quarantine_target,
         notes=tuple(notes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hyperbolic-scanner adapter — auto-computes geometry_norm from a numeric
+# state vector so callers do not have to supply it manually.
+# ---------------------------------------------------------------------------
+
+
+def geometry_norm_from_state(state_vector: Iterable[float]) -> float:
+    """Return the Poincaré-ball norm for *state_vector* via hyperbolic_scanner."""
+    return scan_boundary_state(state_vector)["norm"]
+
+
+def evaluate_kernel_event_with_state(
+    event: KernelEvent | dict[str, Any],
+    state_vector: Iterable[float] | None = None,
+    *,
+    previous_antibody_load: float = 0.0,
+    extra_prompt_patterns: Iterable[str] = (),
+    extra_malware_patterns: Iterable[str] = (),
+) -> KernelGateResult:
+    """
+    Evaluate a kernel event with optional automatic geometry_norm computation.
+
+    If *state_vector* is supplied, the Poincaré-ball norm is computed via
+    hyperbolic_scanner and *replaces* any geometry_norm already on the event.
+    This is the preferred call path for inter-system handoffs where a numeric
+    payload is available.
+
+    If *state_vector* is None, the event's geometry_norm field is used
+    unchanged — callers that compute geometry_norm themselves and set it on
+    the KernelEvent directly are still fully supported.
+
+    Policy: scanner-computed norm always wins over event-embedded norm when
+    state_vector is provided.  If you need the reverse, compute the norm
+    yourself via geometry_norm_from_state() and pass it on the event instead
+    of using this wrapper.
+    """
+    if not isinstance(event, KernelEvent):
+        event = KernelEvent.from_dict(event)
+
+    if state_vector is not None:
+        scanner_norm = geometry_norm_from_state(state_vector)
+        event = dataclasses.replace(event, geometry_norm=scanner_norm)
+
+    return evaluate_kernel_event(
+        event,
+        previous_antibody_load=previous_antibody_load,
+        extra_prompt_patterns=extra_prompt_patterns,
+        extra_malware_patterns=extra_malware_patterns,
     )

--- a/api/main.py
+++ b/api/main.py
@@ -27,6 +27,9 @@ import uuid
 
 # Add examples/ to path for spiralverse_core/spiralverse_sdk imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "examples"))
+_AGENT_BUS_PY_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "packages", "agent-bus-py", "src"))
+if _AGENT_BUS_PY_SRC not in sys.path:
+    sys.path.insert(0, _AGENT_BUS_PY_SRC)
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -44,6 +47,7 @@ from api.metering import (
 )
 from api.audit_export import build_signed_bundle, canonical_json, filter_records_by_range, sha256_hex
 from api.validation import run_nextgen_action_validation
+from scbe_agent_bus import scan_agent_request
 
 try:
     from src.api.mesh_routes import mesh_router
@@ -98,8 +102,7 @@ except ImportError:
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='{"timestamp":"%(asctime)s","level":"%(levelname)s","message":"%(message)s"}'
+    level=logging.INFO, format='{"timestamp":"%(asctime)s","level":"%(levelname)s","message":"%(message)s"}'
 )
 logger = logging.getLogger("scbe-api")
 
@@ -143,6 +146,7 @@ if darpa_prep_router is not None:
 API_KEY_HEADER = APIKeyHeader(name="SCBE_api_key", auto_error=False)
 API_KEY_HEADER_LEGACY = APIKeyHeader(name="X-API-Key", auto_error=False)
 
+
 def _load_api_keys() -> dict:
     """
     Load API keys from environment. No hardcoded defaults.
@@ -162,6 +166,7 @@ def _load_api_keys() -> dict:
             keys[key] = f"tenant_{i}"
     return keys
 
+
 VALID_API_KEYS = _load_api_keys()
 
 # In-memory stores (replace with database in production)
@@ -176,6 +181,7 @@ SESSION_MANAGER: Optional[Any] = None
 # =============================================================================
 # Models
 # =============================================================================
+
 
 class Decision(str, Enum):
     ALLOW = "ALLOW"
@@ -195,7 +201,7 @@ class AuthorizeRequest(BaseModel):
                 "agent_id": "fraud-detector-001",
                 "action": "READ",
                 "target": "transaction_stream",
-                "context": {"sensitivity": 0.3}
+                "context": {"sensitivity": 0.3},
             }
         }
 
@@ -215,6 +221,32 @@ class AgentRegisterRequest(BaseModel):
     role: str
     initial_trust: float = Field(default=0.5, ge=0.0, le=1.0)
     metadata: Optional[Dict[str, Any]] = {}
+
+
+class GovernanceScanRequest(BaseModel):
+    agent_id: str = Field(default="agent", description="Agent or workflow identifier")
+    action: str = Field(default="EXECUTE", description="Framework action, tool call, or command verb")
+    target: str = Field(default="", description="Resource or business object being touched")
+    command: str = Field(default="", description="Concrete command/tool input when available")
+    observed: str = Field(default="", description="Optional observed output for drift/error scoring")
+    context: Dict[str, Any] = Field(default_factory=dict, description="Optional caller metadata")
+
+
+class GovernanceScanResponse(BaseModel):
+    schema_version: str
+    decision: Decision
+    tier: Decision
+    score: float
+    d_H: float
+    pattern_drift: float
+    role: str
+    action: str
+    target: str
+    command: str
+    policy_version: str
+    receipt_hash: str
+    scanned_at: str
+    explanation: Dict[str, Any]
 
 
 class AgentResponse(BaseModel):
@@ -282,6 +314,7 @@ class SessionStartRequest(BaseModel):
 # Authentication
 # =============================================================================
 
+
 async def verify_api_key(
     api_key: str = Security(API_KEY_HEADER),
     api_key_legacy: str = Security(API_KEY_HEADER_LEGACY),
@@ -319,11 +352,12 @@ def _get_session_manager() -> Optional[Any]:
 # SCBE Core Logic (14-Layer Pipeline)
 # =============================================================================
 
+
 def hyperbolic_distance(p1: tuple, p2: tuple) -> float:
     """Poincaré ball distance calculation."""
     norm1_sq = sum(x**2 for x in p1)
     norm2_sq = sum(x**2 for x in p2)
-    diff_sq = sum((a - b)**2 for a, b in zip(p1, p2))
+    diff_sq = sum((a - b) ** 2 for a, b in zip(p1, p2))
 
     norm1_sq = min(norm1_sq, 0.9999)
     norm2_sq = min(norm2_sq, 0.9999)
@@ -332,7 +366,7 @@ def hyperbolic_distance(p1: tuple, p2: tuple) -> float:
     denominator = (1 - norm1_sq) * (1 - norm2_sq)
 
     if denominator <= 0:
-        return float('inf')
+        return float("inf")
 
     delta = numerator / denominator
     return math.acosh(1 + delta) if delta >= 0 else 0.0
@@ -345,16 +379,12 @@ def agent_to_6d_position(agent_id: str, action: str, target: str, trust: float) 
     for i in range(6):
         val = seed[i] / 255.0
         radius = (1 - trust) * 0.8 + 0.1
-        coords.append(val * radius - radius/2)
+        coords.append(val * radius - radius / 2)
     return tuple(coords)
 
 
 def scbe_14_layer_pipeline(
-    agent_id: str,
-    action: str,
-    target: str,
-    trust_score: float,
-    sensitivity: float = 0.5
+    agent_id: str, action: str, target: str, trust_score: float, sensitivity: float = 0.5
 ) -> tuple:
     """
     Full 14-layer SCBE governance pipeline.
@@ -386,7 +416,7 @@ def scbe_14_layer_pipeline(
     # Layer 12: Harmonic Scaling
     R = 2
     d = int(sensitivity * 3) + 1
-    H = R ** d
+    H = R**d
     risk_factor = (1 - realm_trust) * sensitivity * 0.5
     explanation["layers"]["L12"] = f"H(d={d},R={R})={H}, risk: {risk_factor:.2f}"
 
@@ -428,11 +458,9 @@ def generate_noise() -> str:
 # API Endpoints
 # =============================================================================
 
+
 @app.post("/v1/authorize", response_model=AuthorizeResponse, tags=["Governance"])
-async def authorize(
-    request: AuthorizeRequest,
-    tenant: str = Depends(verify_api_key)
-):
+async def authorize(request: AuthorizeRequest, tenant: str = Depends(verify_api_key)):
     """
     Main governance decision endpoint.
 
@@ -451,7 +479,7 @@ async def authorize(
             "trust_score": 0.5,
             "created_at": datetime.utcnow().isoformat(),
             "decision_count": 0,
-            "tenant": tenant
+            "tenant": tenant,
         }
 
     agent = AGENTS_STORE[store_key]
@@ -545,15 +573,19 @@ async def authorize(
     agent["last_activity"] = datetime.utcnow().isoformat()
 
     # Log decision
-    logger.info(json.dumps({
-        "event": "governance_decision",
-        "decision_id": decision_id,
-        "agent_id": request.agent_id,
-        "action": request.action,
-        "decision": decision.value,
-        "score": round(score, 3),
-        "latency_ms": DECISIONS_STORE[decision_id]["latency_ms"]
-    }))
+    logger.info(
+        json.dumps(
+            {
+                "event": "governance_decision",
+                "decision_id": decision_id,
+                "agent_id": request.agent_id,
+                "action": request.action,
+                "decision": decision.value,
+                "score": round(score, 3),
+                "latency_ms": DECISIONS_STORE[decision_id]["latency_ms"],
+            }
+        )
+    )
 
     metering_store.increment_metric(tenant_id=tenant, metric_name=GOVERNANCE_EVALUATIONS)
 
@@ -568,13 +600,13 @@ async def authorize(
             trust_score=trust_score,
             risk_level=risk_level,
             context=request.context or {},
-            consensus_result={"single_decision": True}
+            consensus_result={"single_decision": True},
         )
         persistence.record_trust(
             agent_id=request.agent_id,
             trust_score=trust_score,
             factors={"score": score, "sensitivity": sensitivity},
-            decision=decision.value
+            decision=decision.value,
         )
     except Exception as e:
         logger.warning(f"Persistence error (non-fatal): {e}")
@@ -585,15 +617,30 @@ async def authorize(
         score=round(score, 3),
         explanation=explanation,
         token=token,
-        expires_at=expires_at
+        expires_at=expires_at,
     )
 
 
-@app.post("/v1/agents", response_model=AgentResponse, tags=["Agents"])
-async def register_agent(
-    request: AgentRegisterRequest,
-    tenant: str = Depends(verify_api_key)
+@app.post("/v1/governance/scan", response_model=GovernanceScanResponse, tags=["Governance"])
+async def governance_scan(
+    request: GovernanceScanRequest,
+    tenant: str = Depends(verify_api_key),
 ):
+    """Lightweight SDK-compatible governance scan for existing agent frameworks."""
+    receipt = scan_agent_request(
+        action=request.action,
+        target=request.target,
+        command=request.command,
+        observed=request.observed,
+        context={**(request.context or {}), "tenant": tenant, "agent_id": request.agent_id},
+        policy_version=POLICY_VERSION,
+    )
+    metering_store.increment_metric(tenant_id=tenant, metric_name=GOVERNANCE_EVALUATIONS)
+    return GovernanceScanResponse(**receipt)
+
+
+@app.post("/v1/agents", response_model=AgentResponse, tags=["Agents"])
+async def register_agent(request: AgentRegisterRequest, tenant: str = Depends(verify_api_key)):
     """Register a new agent with initial trust score."""
     # Use composite key for tenant isolation
     store_key = f"{tenant}:{request.agent_id}"
@@ -609,26 +656,27 @@ async def register_agent(
         "last_activity": None,
         "decision_count": 0,
         "metadata": request.metadata,
-        "tenant": tenant  # Store tenant for ownership verification
+        "tenant": tenant,  # Store tenant for ownership verification
     }
     AGENTS_STORE[store_key] = agent
 
-    logger.info(json.dumps({
-        "event": "agent_registered",
-        "agent_id": request.agent_id,
-        "tenant": tenant,
-        "role": request.role,
-        "initial_trust": request.initial_trust
-    }))
+    logger.info(
+        json.dumps(
+            {
+                "event": "agent_registered",
+                "agent_id": request.agent_id,
+                "tenant": tenant,
+                "role": request.role,
+                "initial_trust": request.initial_trust,
+            }
+        )
+    )
 
     return AgentResponse(**agent)
 
 
 @app.get("/v1/agents/{agent_id}", response_model=AgentResponse, tags=["Agents"])
-async def get_agent(
-    agent_id: str,
-    tenant: str = Depends(verify_api_key)
-):
+async def get_agent(agent_id: str, tenant: str = Depends(verify_api_key)):
     """Get agent information and current trust score."""
     # Use composite key for tenant-scoped lookup
     store_key = f"{tenant}:{agent_id}"
@@ -639,10 +687,7 @@ async def get_agent(
 
 
 @app.post("/v1/consensus", response_model=ConsensusResponse, tags=["Governance"])
-async def request_consensus(
-    request: ConsensusRequest,
-    tenant: str = Depends(verify_api_key)
-):
+async def request_consensus(request: ConsensusRequest, tenant: str = Depends(verify_api_key)):
     """
     Request multi-signature consensus for sensitive operations.
 
@@ -665,11 +710,7 @@ async def request_consensus(
 
         # Run pipeline for each validator
         decision, score, _ = scbe_14_layer_pipeline(
-            agent_id=validator_id,
-            action=request.action,
-            target=request.target,
-            trust_score=trust,
-            sensitivity=0.5
+            agent_id=validator_id, action=request.action, target=request.target, trust_score=trust, sensitivity=0.5
         )
 
         # ALLOW and QUARANTINE count as approval
@@ -680,12 +721,9 @@ async def request_consensus(
         else:
             rejections += 1
 
-        votes.append({
-            "validator_id": validator_id,
-            "decision": decision.value,
-            "score": round(score, 3),
-            "approved": is_approve
-        })
+        votes.append(
+            {"validator_id": validator_id, "decision": decision.value, "score": round(score, 3), "approved": is_approve}
+        )
 
     # Determine consensus status
     if approvals >= request.required_approvals:
@@ -701,16 +739,20 @@ async def request_consensus(
         "rejections": rejections,
         "required": request.required_approvals,
         "votes": votes,
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": datetime.utcnow().isoformat(),
     }
 
-    logger.info(json.dumps({
-        "event": "consensus_decision",
-        "consensus_id": consensus_id,
-        "status": status,
-        "approvals": approvals,
-        "required": request.required_approvals
-    }))
+    logger.info(
+        json.dumps(
+            {
+                "event": "consensus_decision",
+                "consensus_id": consensus_id,
+                "status": status,
+                "approvals": approvals,
+                "required": request.required_approvals,
+            }
+        )
+    )
 
     return ConsensusResponse(
         consensus_id=consensus_id,
@@ -718,15 +760,12 @@ async def request_consensus(
         approvals=approvals,
         rejections=rejections,
         required=request.required_approvals,
-        votes=votes
+        votes=votes,
     )
 
 
 @app.get("/v1/audit/{decision_id}", tags=["Audit"])
-async def get_audit(
-    decision_id: str,
-    tenant: str = Depends(verify_api_key)
-):
+async def get_audit(decision_id: str, tenant: str = Depends(verify_api_key)):
     """Retrieve full audit trail for a governance decision."""
     if decision_id not in DECISIONS_STORE:
         raise HTTPException(status_code=404, detail="Decision not found")
@@ -746,14 +785,15 @@ async def health_check():
             "api": "ok",
             "pipeline": "ok",
             "storage": "ok" if len(AGENTS_STORE) >= 0 else "degraded",
-            "firebase": "connected" if persistence.is_connected else "disconnected"
-        }
+            "firebase": "connected" if persistence.is_connected else "disconnected",
+        },
     )
 
 
 # =============================================================================
 # Mesh / Multi-Cloud Endpoints
 # =============================================================================
+
 
 @app.post("/v1/spiralverse/mesh", tags=["Spiralverse"])
 async def spiralverse_mesh(
@@ -902,6 +942,7 @@ async def end_cloud_session(
 # Metrics & Monitoring Endpoints
 # =============================================================================
 
+
 class MetricsResponse(BaseModel):
     total_decisions: int
     allow_count: int
@@ -927,6 +968,7 @@ async def get_metrics(tenant: str = Depends(verify_api_key)):
 # Webhook/Zapier Integration Endpoints
 # =============================================================================
 
+
 class WebhookConfig(BaseModel):
     webhook_url: str
     events: List[str] = ["decision_deny", "decision_quarantine", "trust_decline"]
@@ -949,10 +991,7 @@ WEBHOOK_STORE: Dict[str, dict] = {}
 
 
 @app.post("/v1/webhooks", tags=["Webhooks"])
-async def register_webhook(
-    config: WebhookConfig,
-    tenant: str = Depends(verify_api_key)
-):
+async def register_webhook(config: WebhookConfig, tenant: str = Depends(verify_api_key)):
     """
     Register a webhook URL for alert notifications.
 
@@ -965,14 +1004,12 @@ async def register_webhook(
         "url": config.webhook_url,
         "events": config.events,
         "min_severity": config.min_severity,
-        "created_at": datetime.utcnow().isoformat()
+        "created_at": datetime.utcnow().isoformat(),
     }
 
-    logger.info(json.dumps({
-        "event": "webhook_registered",
-        "webhook_id": webhook_id,
-        "url": config.webhook_url[:50] + "..."
-    }))
+    logger.info(
+        json.dumps({"event": "webhook_registered", "webhook_id": webhook_id, "url": config.webhook_url[:50] + "..."})
+    )
 
     return {"webhook_id": webhook_id, "status": "registered"}
 
@@ -984,10 +1021,7 @@ async def list_webhooks(tenant: str = Depends(verify_api_key)):
 
 
 @app.delete("/v1/webhooks/{webhook_id}", tags=["Webhooks"])
-async def delete_webhook(
-    webhook_id: str,
-    tenant: str = Depends(verify_api_key)
-):
+async def delete_webhook(webhook_id: str, tenant: str = Depends(verify_api_key)):
     """Remove a registered webhook."""
     if webhook_id not in WEBHOOK_STORE:
         raise HTTPException(status_code=404, detail="Webhook not found")
@@ -999,11 +1033,7 @@ async def delete_webhook(
 
 
 @app.get("/v1/alerts", response_model=List[AlertResponse], tags=["Alerts"])
-async def get_alerts(
-    tenant: str = Depends(verify_api_key),
-    limit: int = 50,
-    pending_only: bool = True
-):
+async def get_alerts(tenant: str = Depends(verify_api_key), limit: int = 50, pending_only: bool = True):
     """
     Get alerts for webhook delivery.
 
@@ -1019,25 +1049,24 @@ async def get_alerts(
         logs = persistence.get_audit_logs(limit=limit)
         for log in logs:
             if log["decision"] in ["DENY", "QUARANTINE"]:
-                alerts.append({
-                    "alert_id": f"alert-{log['audit_id']}",
-                    "timestamp": log["timestamp"],
-                    "severity": "high" if log["decision"] == "DENY" else "medium",
-                    "alert_type": f"decision_{log['decision'].lower()}",
-                    "message": f"Agent {log['agent_id']} request was {log['decision']}",
-                    "agent_id": log["agent_id"],
-                    "audit_id": log["audit_id"],
-                    "data": {"trust_score": log["trust_score"]}
-                })
+                alerts.append(
+                    {
+                        "alert_id": f"alert-{log['audit_id']}",
+                        "timestamp": log["timestamp"],
+                        "severity": "high" if log["decision"] == "DENY" else "medium",
+                        "alert_type": f"decision_{log['decision'].lower()}",
+                        "message": f"Agent {log['agent_id']} request was {log['decision']}",
+                        "agent_id": log["agent_id"],
+                        "audit_id": log["audit_id"],
+                        "data": {"trust_score": log["trust_score"]},
+                    }
+                )
 
     return alerts
 
 
 @app.post("/v1/alerts/{alert_id}/ack", tags=["Alerts"])
-async def acknowledge_alert(
-    alert_id: str,
-    tenant: str = Depends(verify_api_key)
-):
+async def acknowledge_alert(alert_id: str, tenant: str = Depends(verify_api_key)):
     """
     Acknowledge an alert (mark as sent/processed).
 
@@ -1055,6 +1084,7 @@ async def acknowledge_alert(
 # =============================================================================
 # AetherNet Game Bridge (n8n <-> Aethermoor Game)
 # =============================================================================
+
 
 class GameActionRequest(BaseModel):
     action_type: str = Field(
@@ -1109,12 +1139,16 @@ async def push_game_action(
     if not queued:
         raise HTTPException(status_code=429, detail="Action queue full")
 
-    logger.info(json.dumps({
-        "event": "aethernet_action_queued",
-        "action_id": action_id,
-        "action_type": request.action_type,
-        "tenant": tenant,
-    }))
+    logger.info(
+        json.dumps(
+            {
+                "event": "aethernet_action_queued",
+                "action_id": action_id,
+                "action_type": request.action_type,
+                "tenant": tenant,
+            }
+        )
+    )
 
     return {"action_id": action_id, "status": "queued"}
 
@@ -1137,22 +1171,15 @@ async def game_bridge_status(tenant: str = Depends(verify_api_key)):
 # Trust History Endpoints
 # =============================================================================
 
+
 @app.get("/v1/agents/{agent_id}/trust-history", tags=["Agents"])
-async def get_trust_history(
-    agent_id: str,
-    tenant: str = Depends(verify_api_key),
-    limit: int = 30
-):
+async def get_trust_history(agent_id: str, tenant: str = Depends(verify_api_key), limit: int = 30):
     """Get trust score history for an agent."""
     persistence = get_persistence()
     history = persistence.get_trust_history(agent_id, limit=limit)
     trend = persistence.get_trust_trend(agent_id)
 
-    return {
-        "agent_id": agent_id,
-        "trend": trend,
-        "history": history
-    }
+    return {"agent_id": agent_id, "trend": trend, "history": history}
 
 
 @app.get("/v1/audit", tags=["Audit"])
@@ -1160,21 +1187,18 @@ async def list_audit_logs(
     tenant: str = Depends(verify_api_key),
     agent_id: Optional[str] = None,
     decision: Optional[str] = None,
-    limit: int = 100
+    limit: int = 100,
 ):
     """Query audit logs with optional filters."""
     persistence = get_persistence()
-    logs = persistence.get_audit_logs(
-        agent_id=agent_id,
-        decision=decision,
-        limit=limit
-    )
+    logs = persistence.get_audit_logs(agent_id=agent_id, decision=decision, limit=limit)
     return {"count": len(logs), "logs": logs}
 
 
 # =============================================================================
 # Fleet Scenario Endpoint (Pilot Demo)
 # =============================================================================
+
 
 class FleetAgent(BaseModel):
     agent_id: str
@@ -1202,15 +1226,25 @@ class FleetScenario(BaseModel):
             "example": {
                 "scenario_name": "fraud-detection-fleet",
                 "agents": [
-                    {"agent_id": "fraud-detector-001", "name": "Fraud Detector", "role": "analyzer", "initial_trust": 0.8},
+                    {
+                        "agent_id": "fraud-detector-001",
+                        "name": "Fraud Detector",
+                        "role": "analyzer",
+                        "initial_trust": 0.8,
+                    },
                     {"agent_id": "risk-scorer-002", "name": "Risk Scorer", "role": "scorer", "initial_trust": 0.7},
-                    {"agent_id": "alert-bot-003", "name": "Alert Bot", "role": "notifier", "initial_trust": 0.6}
+                    {"agent_id": "alert-bot-003", "name": "Alert Bot", "role": "notifier", "initial_trust": 0.6},
                 ],
                 "actions": [
-                    {"agent_id": "fraud-detector-001", "action": "READ", "target": "transaction_stream", "sensitivity": 0.3},
+                    {
+                        "agent_id": "fraud-detector-001",
+                        "action": "READ",
+                        "target": "transaction_stream",
+                        "sensitivity": 0.3,
+                    },
                     {"agent_id": "risk-scorer-002", "action": "WRITE", "target": "risk_scores_db", "sensitivity": 0.6},
-                    {"agent_id": "alert-bot-003", "action": "EXECUTE", "target": "send_alert", "sensitivity": 0.4}
-                ]
+                    {"agent_id": "alert-bot-003", "action": "EXECUTE", "target": "send_alert", "sensitivity": 0.4},
+                ],
             }
         }
 
@@ -1250,10 +1284,7 @@ class MonthlyUsageExportResponse(BaseModel):
 
 
 @app.post("/v1/fleet/run-scenario", response_model=FleetScenarioResponse, tags=["Fleet"])
-async def run_fleet_scenario(
-    scenario: FleetScenario,
-    tenant: str = Depends(verify_api_key)
-):
+async def run_fleet_scenario(scenario: FleetScenario, tenant: str = Depends(verify_api_key)):
     """
     Run a complete fleet scenario through SCBE.
 
@@ -1279,7 +1310,7 @@ async def run_fleet_scenario(
                 "created_at": datetime.utcnow().isoformat(),
                 "last_activity": None,
                 "decision_count": 0,
-                "tenant": tenant
+                "tenant": tenant,
             }
 
     # Process all actions
@@ -1303,7 +1334,7 @@ async def run_fleet_scenario(
             action=action.action,
             target=action.target,
             trust_score=trust_score,
-            sensitivity=action.sensitivity
+            sensitivity=action.sensitivity,
         )
 
         # Track metrics
@@ -1316,15 +1347,17 @@ async def run_fleet_scenario(
 
         total_score += score
 
-        decisions.append(FleetDecision(
-            agent_id=action.agent_id,
-            action=action.action,
-            target=action.target,
-            decision=decision.value,
-            score=round(score, 3),
-            trust_score=trust_score,
-            risk_factor=explanation.get("risk_factor", 0)
-        ))
+        decisions.append(
+            FleetDecision(
+                agent_id=action.agent_id,
+                action=action.action,
+                target=action.target,
+                decision=decision.value,
+                score=round(score, 3),
+                trust_score=trust_score,
+                risk_factor=explanation.get("risk_factor", 0),
+            )
+        )
 
         # Update agent stats
         agent["decision_count"] += 1
@@ -1332,17 +1365,21 @@ async def run_fleet_scenario(
 
     elapsed_ms = (time.time() - start_time) * 1000
 
-    logger.info(json.dumps({
-        "event": "fleet_scenario_completed",
-        "scenario_id": scenario_id,
-        "scenario_name": scenario.scenario_name,
-        "agents": len(scenario.agents),
-        "actions": len(scenario.actions),
-        "allow": allow_count,
-        "deny": deny_count,
-        "quarantine": quarantine_count,
-        "elapsed_ms": round(elapsed_ms, 2)
-    }))
+    logger.info(
+        json.dumps(
+            {
+                "event": "fleet_scenario_completed",
+                "scenario_id": scenario_id,
+                "scenario_name": scenario.scenario_name,
+                "agents": len(scenario.agents),
+                "actions": len(scenario.actions),
+                "allow": allow_count,
+                "deny": deny_count,
+                "quarantine": quarantine_count,
+                "elapsed_ms": round(elapsed_ms, 2),
+            }
+        )
+    )
 
     metering_store.increment_metric(tenant_id=tenant, metric_name=WORKFLOW_EXECUTIONS)
 
@@ -1354,20 +1391,21 @@ async def run_fleet_scenario(
             "total_actions": len(scenario.actions),
             "allowed": allow_count,
             "denied": deny_count,
-            "quarantined": quarantine_count
+            "quarantined": quarantine_count,
         },
         decisions=decisions,
         metrics={
             "avg_score": round(total_score / max(len(decisions), 1), 3),
             "allow_rate": round(allow_count / max(len(decisions), 1), 3),
-            "elapsed_ms": round(elapsed_ms, 2)
-        }
+            "elapsed_ms": round(elapsed_ms, 2),
+        },
     )
 
 
 # =============================================================================
 # Demo Endpoints (For Promotion & Sales)
 # =============================================================================
+
 
 class RogueDetectionResponse(BaseModel):
     simulation_id: str
@@ -1391,17 +1429,10 @@ class SwarmCoordinationResponse(BaseModel):
     coordination_score: float
 
 
-
-
 @app.get("/v1/audit/report", response_model=AuditReportResponse, tags=["Audit"])
-async def generate_audit_report(
-    tenant: str = Depends(verify_api_key)
-):
+async def generate_audit_report(tenant: str = Depends(verify_api_key)):
     """Generate an audit summary report for the current tenant."""
-    decisions = [
-        d for d in DECISIONS_STORE.values()
-        if d.get("tenant") == tenant
-    ]
+    decisions = [d for d in DECISIONS_STORE.values() if d.get("tenant") == tenant]
     by_outcome = {
         "ALLOW": sum(1 for d in decisions if d.get("decision") == "ALLOW"),
         "DENY": sum(1 for d in decisions if d.get("decision") == "DENY"),
@@ -1432,9 +1463,7 @@ async def export_audit_bundle(
             detail="SCBE_AUDIT_EXPORT_SIGNING_KEY is not configured",
         )
 
-    tenant_records = [
-        record for record in DECISIONS_STORE.values() if record.get("tenant") == tenant
-    ]
+    tenant_records = [record for record in DECISIONS_STORE.values() if record.get("tenant") == tenant]
     filtered_records = filter_records_by_range(tenant_records, from_ts=from_, to_ts=to)
 
     bundle, manifest = build_signed_bundle(
@@ -1458,6 +1487,7 @@ async def export_monthly_usage(
     target_tenant = None if include_all_tenants else tenant
     return MonthlyUsageExportResponse(**export_monthly_billable_usage(year=year, month=month, tenant_id=target_tenant))
 
+
 @app.get("/v1/demo/rogue-detection", response_model=RogueDetectionResponse, tags=["Demo"])
 async def demo_rogue_detection(steps: int = 25):
     """
@@ -1469,10 +1499,10 @@ async def demo_rogue_detection(steps: int = 25):
     The swarm "smells" the intruder through mathematical anomaly detection.
     """
     import numpy as np
+
     np.random.seed(int(time.time()) % 10000)
 
-    TONGUES = {'KO': 0, 'AV': np.pi/3, 'RU': 2*np.pi/3,
-               'CA': np.pi, 'UM': 4*np.pi/3, 'DR': 5*np.pi/3}
+    TONGUES = {"KO": 0, "AV": np.pi / 3, "RU": 2 * np.pi / 3, "CA": np.pi, "UM": 4 * np.pi / 3, "DR": 5 * np.pi / 3}
 
     class Agent:
         def __init__(self, id, tongue, pos, is_rogue=False):
@@ -1496,7 +1526,7 @@ async def demo_rogue_detection(steps: int = 25):
         diff_sq = np.linalg.norm(u - v) ** 2
         denom = (1 - nu**2) * (1 - nv**2)
         if denom <= 1e-10:
-            return float('inf')
+            return float("inf")
         return float(np.arccosh(max(1 + 2 * diff_sq / denom, 1.0)))
 
     def project(pos, max_n=0.95):
@@ -1505,8 +1535,8 @@ async def demo_rogue_detection(steps: int = 25):
 
     # Create agents
     agents = []
-    for i, t in enumerate(['KO', 'AV', 'RU', 'CA', 'UM', 'DR']):
-        pos = np.array([0.02 + i*0.01] * 3)
+    for i, t in enumerate(["KO", "AV", "RU", "CA", "UM", "DR"]):
+        pos = np.array([0.02 + i * 0.01] * 3)
         agents.append(Agent(i, t, pos))
 
     # Add rogue
@@ -1556,23 +1586,24 @@ async def demo_rogue_detection(steps: int = 25):
             agent.position = project(agent.position)
 
     # Calculate final metrics
-    rogue_distances = [hyperbolic_dist(a.position, rogue.position)
-                       for a in agents if not a.is_rogue]
+    rogue_distances = [hyperbolic_dist(a.position, rogue.position) for a in agents if not a.is_rogue]
     avg_rogue_dist = float(np.mean(rogue_distances))
 
     false_positives = sum(1 for a in agents if not a.is_rogue and len(a.flagged_by) > 0)
 
     final_positions = []
     for a in agents:
-        final_positions.append({
-            "id": a.id,
-            "tongue": a.tongue or "NULL",
-            "position": [round(float(x), 4) for x in a.position],
-            "norm": round(a.norm, 4),
-            "is_rogue": a.is_rogue,
-            "flagged_by": len(a.flagged_by),
-            "quarantined": a.is_quarantined
-        })
+        final_positions.append(
+            {
+                "id": a.id,
+                "tongue": a.tongue or "NULL",
+                "position": [round(float(x), 4) for x in a.position],
+                "norm": round(a.norm, 4),
+                "is_rogue": a.is_rogue,
+                "flagged_by": len(a.flagged_by),
+                "quarantined": a.is_quarantined,
+            }
+        )
 
     return RogueDetectionResponse(
         simulation_id=f"demo_{uuid.uuid4().hex[:8]}",
@@ -1586,8 +1617,8 @@ async def demo_rogue_detection(steps: int = 25):
         metrics={
             "avg_isolation_distance": round(avg_rogue_dist, 3),
             "rogue_final_norm": round(rogue.norm, 3),
-            "detection_rate": 1.0 if rogue.is_quarantined else len(rogue.flagged_by) / 6
-        }
+            "detection_rate": 1.0 if rogue.is_quarantined else len(rogue.flagged_by) / 6,
+        },
     )
 
 
@@ -1602,6 +1633,7 @@ async def demo_swarm_coordination(agents: int = 12, steps: int = 30):
     Demonstrates jam-resistant, decentralized coordination.
     """
     import numpy as np
+
     np.random.seed(int(time.time()) % 10000)
 
     # Initialize agents in tight cluster
@@ -1616,7 +1648,7 @@ async def demo_swarm_coordination(agents: int = 12, steps: int = 30):
         diff_sq = np.linalg.norm(u - v) ** 2
         denom = (1 - nu**2) * (1 - nv**2)
         if denom <= 1e-10:
-            return float('inf')
+            return float("inf")
         return float(np.arccosh(max(1 + 2 * diff_sq / denom, 1.0)))
 
     def project(pos, max_n=0.95):
@@ -1626,7 +1658,7 @@ async def demo_swarm_coordination(agents: int = 12, steps: int = 30):
     # Calculate initial distances
     initial_distances = []
     for i in range(agents):
-        for j in range(i+1, agents):
+        for j in range(i + 1, agents):
             initial_distances.append(hyperbolic_dist(positions[i], positions[j]))
     initial_avg = float(np.mean(initial_distances))
 
@@ -1638,7 +1670,7 @@ async def demo_swarm_coordination(agents: int = 12, steps: int = 30):
         forces = [np.zeros(3) for _ in range(agents)]
 
         for i in range(agents):
-            for j in range(i+1, agents):
+            for j in range(i + 1, agents):
                 d = hyperbolic_dist(positions[i], positions[j])
 
                 if d < 0.1:
@@ -1662,7 +1694,7 @@ async def demo_swarm_coordination(agents: int = 12, steps: int = 30):
     # Calculate final distances
     final_distances = []
     for i in range(agents):
-        for j in range(i+1, agents):
+        for j in range(i + 1, agents):
             final_distances.append(hyperbolic_dist(positions[i], positions[j]))
     final_avg = float(np.mean(final_distances))
 
@@ -1676,16 +1708,12 @@ async def demo_swarm_coordination(agents: int = 12, steps: int = 30):
         final_avg_distance=round(final_avg, 4),
         collisions=collisions,
         boundary_breaches=boundary_breaches,
-        coordination_score=round(max(0, coord_score), 3)
+        coordination_score=round(max(0, coord_score), 3),
     )
 
 
 @app.get("/v1/demo/pipeline-layers", tags=["Demo"])
-async def demo_pipeline_layers(
-    action: str = "READ",
-    trust: float = 0.7,
-    sensitivity: float = 0.5
-):
+async def demo_pipeline_layers(action: str = "READ", trust: float = 0.7, sensitivity: float = 0.5):
     """
     **LIVE DEMO: 14-Layer Pipeline Visualization**
 
@@ -1703,7 +1731,7 @@ async def demo_pipeline_layers(
     complex_coords = [(seed[i] - 128) / 128.0 for i in range(6)]
     layers["L1_complex_context"] = {
         "description": "Embed request as complex numbers",
-        "output": [round(c, 4) for c in complex_coords]
+        "output": [round(c, 4) for c in complex_coords],
     }
 
     # Layer 2-4: Realification & Weighting
@@ -1712,13 +1740,13 @@ async def demo_pipeline_layers(
     layers["L2-4_realification"] = {
         "description": "Map to real manifold with trust weighting",
         "trust_radius": round(radius, 4),
-        "position": [round(p, 4) for p in position]
+        "position": [round(p, 4) for p in position],
     }
 
     # Layer 5-7: Hyperbolic Geometry
     safe_center = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     norm1_sq = sum(x**2 for x in position)
-    diff_sq = sum((a - b)**2 for a, b in zip(position, safe_center))
+    diff_sq = sum((a - b) ** 2 for a, b in zip(position, safe_center))
     denom = (1 - min(norm1_sq, 0.9999)) * 1.0
     delta = 2 * diff_sq / denom if denom > 0 else 0
     distance = math.acosh(1 + delta) if delta >= 0 else 0.0
@@ -1727,7 +1755,7 @@ async def demo_pipeline_layers(
         "description": "Calculate Poincaré ball distance from safe center",
         "position_norm": round(math.sqrt(norm1_sq), 4),
         "hyperbolic_distance": round(distance, 4),
-        "interpretation": "closer to 0 = safer, higher = riskier"
+        "interpretation": "closer to 0 = safer, higher = riskier",
     }
 
     # Layer 8: Realm Trust
@@ -1736,7 +1764,7 @@ async def demo_pipeline_layers(
         "description": "Compute realm-adjusted trust",
         "base_trust": trust,
         "sensitivity_penalty": round(sensitivity * 0.5, 4),
-        "realm_trust": round(realm_trust, 4)
+        "realm_trust": round(realm_trust, 4),
     }
 
     # Layer 9-10: Spectral/Spin Coherence
@@ -1744,26 +1772,23 @@ async def demo_pipeline_layers(
     layers["L9-10_coherence"] = {
         "description": "Spectral and spin coherence analysis",
         "coherence_score": round(coherence, 4),
-        "interpretation": "measures stability of request pattern"
+        "interpretation": "measures stability of request pattern",
     }
 
     # Layer 11: Temporal Pattern
     temporal_score = trust * 0.9 + 0.1
-    layers["L11_temporal"] = {
-        "description": "Temporal pattern analysis",
-        "temporal_score": round(temporal_score, 4)
-    }
+    layers["L11_temporal"] = {"description": "Temporal pattern analysis", "temporal_score": round(temporal_score, 4)}
 
     # Layer 12: Harmonic Scaling
     R = 2
     d = int(sensitivity * 3) + 1
-    H = R ** d
+    H = R**d
     risk_factor = (1 - realm_trust) * sensitivity * 0.5
     layers["L12_harmonic"] = {
         "description": "Harmonic scaling and risk computation",
         "dimension": d,
         "harmonic_value": H,
-        "risk_factor": round(risk_factor, 4)
+        "risk_factor": round(risk_factor, 4),
     }
 
     # Layer 13: Final Score
@@ -1781,34 +1806,29 @@ async def demo_pipeline_layers(
         "risk_penalty": round(risk_factor, 4),
         "final_score": round(final_score, 4),
         "decision": decision,
-        "thresholds": {"ALLOW": "> 0.6", "QUARANTINE": "0.3 - 0.6", "DENY": "< 0.3"}
+        "thresholds": {"ALLOW": "> 0.6", "QUARANTINE": "0.3 - 0.6", "DENY": "< 0.3"},
     }
 
     # Layer 14: Telemetry
     layers["L14_telemetry"] = {
         "description": "Audit logging and telemetry",
         "timestamp": datetime.utcnow().isoformat() + "Z",
-        "logged": True
+        "logged": True,
     }
 
     return {
         "demo_id": f"pipeline_{uuid.uuid4().hex[:8]}",
-        "input": {
-            "agent_id": agent_id,
-            "action": action,
-            "target": target,
-            "trust": trust,
-            "sensitivity": sensitivity
-        },
+        "input": {"agent_id": agent_id, "action": action, "target": target, "trust": trust, "sensitivity": sensitivity},
         "layers": layers,
         "final_decision": decision,
-        "final_score": round(final_score, 4)
+        "final_score": round(final_score, 4),
     }
 
 
 # =============================================================================
 # Startup
 # =============================================================================
+
 
 @app.on_event("startup")
 async def startup():
@@ -1818,14 +1838,19 @@ async def startup():
         except Exception as exc:
             logger.warning(json.dumps({"event": "billing_db_init_failed", "error": str(exc)}))
     persistence = get_persistence()
-    logger.info(json.dumps({
-        "event": "api_startup",
-        "version": "1.0.0",
-        "endpoints": 14,
-        "firebase_connected": persistence.is_connected
-    }))
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_startup",
+                "version": "1.0.0",
+                "endpoints": 14,
+                "firebase_connected": persistence.is_connected,
+            }
+        )
+    )
 
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/hydra/turnstile.py
+++ b/hydra/turnstile.py
@@ -1,0 +1,66 @@
+"""
+Domain-aware turnstile resolution for SCBE antivirus and extension gates.
+
+Turnstile maps a governance decision + suspicion signals to a containment
+action and updates the running antibody load (immune memory across calls).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TurnstileOutcome:
+    action: str
+    antibody_load: float
+    membrane_stress: float
+
+
+_DECISION_TO_ACTION = {
+    "DENY": "STOP",
+    "ESCALATE": "ISOLATE",
+    "QUARANTINE": "HOLD",
+    "ALLOW": "ALLOW",
+}
+
+
+def resolve_turnstile(
+    *,
+    decision: str,
+    domain: str,
+    suspicion: float,
+    geometry_norm: float,
+    previous_antibody_load: float = 0.0,
+    quorum_ok: bool = True,
+) -> TurnstileOutcome:
+    """
+    Map governance decision + live signals to a containment action.
+
+    antibody_load decays toward 0 when suspicion is low and accumulates when
+    suspicion is high (immune memory across successive calls for the same process).
+
+    membrane_stress reflects current load: a weighted blend of suspicion and
+    geometry_norm that indicates how hard the membrane is working right now.
+    """
+
+    def _clamp(x):
+        return min(1.0, max(0.0, float(x)))
+
+    antibody_load = _clamp(0.65 * previous_antibody_load + 0.35 * suspicion)
+    membrane_stress = _clamp(0.60 * suspicion + 0.40 * geometry_norm)
+
+    # Escalate to honeypot when immune memory is saturated and active suspicion is high.
+    if antibody_load >= 0.85 and suspicion >= 0.60:
+        action = "HONEYPOT"
+    else:
+        action = _DECISION_TO_ACTION.get(decision.upper(), "HOLD")
+        # Downgrade ALLOW to HOLD when quorum is not satisfied.
+        if not quorum_ok and action == "ALLOW":
+            action = "HOLD"
+
+    return TurnstileOutcome(
+        action=action,
+        antibody_load=round(antibody_load, 4),
+        membrane_stress=round(membrane_stress, 4),
+    )

--- a/packages/agent-bus-py/src/scbe_agent_bus/__init__.py
+++ b/packages/agent-bus-py/src/scbe_agent_bus/__init__.py
@@ -28,6 +28,13 @@ from pathlib import Path
 from typing import Any, Iterable, Literal, Optional, TypedDict
 
 from .companions import COMPANION_PACKAGES, recommend_companion_packages
+from .governance import (
+    GovernanceScan,
+    harmonic_score,
+    risk_tier,
+    scan_agent_request,
+    scan_command,
+)
 from .lineage import (
     LINEAGE_SCHEMA,
     REPORT_SCHEMA,
@@ -66,6 +73,12 @@ __all__ = [
     "AgentBusError",
     "COMPANION_PACKAGES",
     "recommend_companion_packages",
+    # governance SDK
+    "GovernanceScan",
+    "scan_command",
+    "scan_agent_request",
+    "harmonic_score",
+    "risk_tier",
     # workspace audit chain
     "WorkspaceError",
     "workspace_new",
@@ -154,23 +167,13 @@ def _normalize_event(event: AgentBusEvent | dict, index: int) -> dict:
         raise AgentBusError(f"event {index} missing task/text")
     return {
         "task": task,
-        "operation_command": str(
-            event.get("operation_command") or event.get("operationCommand") or ""
-        ).strip(),
-        "task_type": str(
-            event.get("task_type") or event.get("taskType") or "general"
-        ).strip(),
-        "series_id": str(
-            event.get("series_id") or event.get("seriesId") or f"pipe-event-{index}"
-        ).strip(),
+        "operation_command": str(event.get("operation_command") or event.get("operationCommand") or "").strip(),
+        "task_type": str(event.get("task_type") or event.get("taskType") or "general").strip(),
+        "series_id": str(event.get("series_id") or event.get("seriesId") or f"pipe-event-{index}").strip(),
         "privacy": str(event.get("privacy") or "local_only").strip(),
-        "budget_cents": float(
-            event.get("budget_cents", event.get("budgetCents", 0)) or 0
-        ),
+        "budget_cents": float(event.get("budget_cents", event.get("budgetCents", 0)) or 0),
         "dispatch": event.get("dispatch") is not False,
-        "dispatch_provider": str(
-            event.get("dispatch_provider") or event.get("dispatchProvider") or "offline"
-        ).strip(),
+        "dispatch_provider": str(event.get("dispatch_provider") or event.get("dispatchProvider") or "offline").strip(),
     }
 
 
@@ -191,8 +194,7 @@ def _run_one(
     runner = _resolve_runner(repo_root)
     if not runner.exists():
         raise AgentBusError(
-            f"agent-bus runner not found at {runner}. "
-            "Pass repo_root pointing at a SCBE-AETHERMOORE checkout."
+            f"agent-bus runner not found at {runner}. " "Pass repo_root pointing at a SCBE-AETHERMOORE checkout."
         )
 
     argv = [

--- a/packages/agent-bus-py/src/scbe_agent_bus/__main__.py
+++ b/packages/agent-bus-py/src/scbe_agent_bus/__main__.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from . import AgentBusError, run_batch
+from . import AgentBusError, run_batch, scan_agent_request
 
 
 def _read_input(input_path: str) -> str:
@@ -44,6 +44,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", default="")
     parser.add_argument("--python", default="")
     parser.add_argument("--continue-on-error", action="store_true")
+    parser.add_argument(
+        "--scan",
+        action="store_true",
+        help="Run the lightweight governance scan instead of the full agent-bus runner.",
+    )
     args = parser.parse_args(argv)
 
     raw = _read_input(args.input)
@@ -51,6 +56,26 @@ def main(argv: list[str] | None = None) -> int:
     if not events:
         print("scbe-agent-bus: no events provided", file=sys.stderr)
         return 2
+
+    if args.scan:
+        rows = [
+            scan_agent_request(
+                action=str(event.get("action") or event.get("task_type") or "EXECUTE"),
+                target=str(event.get("target") or event.get("task") or ""),
+                command=str(event.get("command") or event.get("operation_command") or ""),
+                observed=str(event.get("observed") or ""),
+                context=(event.get("context") if isinstance(event.get("context"), dict) else {}),
+            )
+            for event in events
+        ]
+        output = "\n".join(json.dumps(row) for row in rows) + "\n"
+        if args.output:
+            out_path = Path(args.output).resolve()
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(output, encoding="utf-8")
+        else:
+            sys.stdout.write(output)
+        return 0 if all(row["decision"] != "DENY" for row in rows) else 1
 
     try:
         rows = run_batch(

--- a/packages/agent-bus-py/src/scbe_agent_bus/governance.py
+++ b/packages/agent-bus-py/src/scbe_agent_bus/governance.py
@@ -1,0 +1,247 @@
+"""Deterministic SCBE governance scan primitives.
+
+This module is intentionally small: SDK callers and REST endpoints can use it
+without launching the full agent-bus runner. The output is a stable receipt that
+can be stored now and rendered into compliance reports later.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from datetime import datetime, timezone
+from typing import Any, Literal, TypedDict
+
+PHI = (1 + math.sqrt(5)) / 2
+
+Decision = Literal["ALLOW", "QUARANTINE", "DENY"]
+
+
+class GovernanceScan(TypedDict):
+    schema_version: Literal["scbe-governance-scan-v1"]
+    decision: Decision
+    tier: Decision
+    score: float
+    d_H: float
+    pattern_drift: float
+    role: str
+    action: str
+    target: str
+    command: str
+    policy_version: str
+    receipt_hash: str
+    scanned_at: str
+    explanation: dict[str, Any]
+
+
+_ROLE_REACTIVITY: dict[str, float] = {
+    "observe": 0.20,
+    "measure": 0.25,
+    "report": 0.20,
+    "hold": 0.05,
+    "compute": 0.65,
+    "move": 0.70,
+    "repair": 0.45,
+    "transmit": 0.80,
+}
+
+_COMMAND_ROLES: dict[str, str] = {
+    "cat": "observe",
+    "head": "observe",
+    "tail": "observe",
+    "ls": "observe",
+    "pwd": "observe",
+    "whoami": "observe",
+    "wc": "measure",
+    "ps": "measure",
+    "du": "measure",
+    "df": "measure",
+    "echo": "report",
+    "printf": "report",
+    "sleep": "hold",
+    "python": "compute",
+    "python3": "compute",
+    "node": "compute",
+    "npm": "compute",
+    "pytest": "compute",
+    "git": "repair",
+    "pip": "repair",
+    "mkdir": "move",
+    "cp": "move",
+    "mv": "move",
+    "rm": "move",
+    "chmod": "move",
+    "curl": "transmit",
+    "wget": "transmit",
+    "ssh": "transmit",
+    "scp": "transmit",
+    "nc": "transmit",
+}
+
+_HARD_DANGER: list[tuple[str, float, float, str]] = [
+    (r":\(\)\{.*:\|:&", 0.99, 0.95, "fork_bomb"),
+    (r">/dev/(sda|hda|nvme)", 0.98, 0.92, "disk_wipe"),
+    (r"\brm\s+-rf\s+/[^/]", 0.95, 0.88, "root_delete"),
+    (r"nc\s+-e\s+/bin", 0.95, 0.88, "reverse_shell"),
+    (r"curl.*\|\s*(ba)?sh", 0.90, 0.85, "remote_pipe_shell"),
+    (r"wget.*\|\s*(ba)?sh", 0.90, 0.85, "remote_pipe_shell"),
+    (r"base64.*decode.*\|.*sh", 0.85, 0.80, "encoded_shell"),
+    (r"(dd|mkfs)\b.*\bif=", 0.85, 0.78, "raw_disk_operation"),
+]
+
+_SOFT_DANGER: list[tuple[str, float, str]] = [
+    (r"\brm\s+-rf\b", 0.55, "recursive_delete"),
+    (r"chmod\s+[+]?s\b", 0.80, "setuid_change"),
+]
+
+_ERROR_RE = re.compile(
+    r"\b(error|errno|fail(ed)?|fatal|traceback|exception|denied|not found|no such file)\b",
+    re.IGNORECASE,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _hash(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _first_token(command: str) -> str:
+    text = command.strip()
+    if not text:
+        return ""
+    return text.split()[0].replace("\\", "/").rsplit("/", 1)[-1].lower()
+
+
+def _role_for_command(command: str) -> str:
+    return _COMMAND_ROLES.get(_first_token(command), "compute")
+
+
+def _output_deviation(observed: str) -> float:
+    if not observed:
+        return 0.0
+    lines = [line for line in observed.splitlines() if line.strip()]
+    if not lines:
+        return 0.0
+    tail = "\n".join(lines[-8:])
+    error_density = min(len(_ERROR_RE.findall(tail)) / 5, 1.0)
+    volume_signal = min(len(observed) / 8000, 0.5)
+    return min(error_density * 0.75 + volume_signal * 0.25, 1.0)
+
+
+def harmonic_score(d_h: float, pattern_drift: float) -> float:
+    """SCBE L12 score: H(d,pd)=1/(1+phi*d+2*pd)."""
+    return 1.0 / (1.0 + PHI * d_h + 2.0 * pattern_drift)
+
+
+def risk_tier(score: float) -> Decision:
+    if score >= 0.60:
+        return "ALLOW"
+    if score >= 0.30:
+        return "QUARANTINE"
+    return "DENY"
+
+
+def scan_command(
+    command: str,
+    *,
+    action: str = "EXECUTE",
+    target: str = "",
+    observed: str = "",
+    context: dict[str, Any] | None = None,
+    policy_version: str = "scbe-governance-sdk-v1",
+) -> GovernanceScan:
+    """Scan one proposed agent command and return a receipt-ready decision."""
+    command = str(command or "").strip()
+    action = str(action or "EXECUTE").strip().upper()
+    target = str(target or "").strip()
+    ctx = dict(context or {})
+    lowered = command.lower()
+
+    role = _role_for_command(command)
+    d_h = _ROLE_REACTIVITY.get(role, _ROLE_REACTIVITY["compute"])
+    pattern_drift = _output_deviation(observed)
+    reason_codes: list[str] = [f"ROLE_{role.upper()}"]
+
+    for pattern, hard_d_h, hard_pd, reason in _HARD_DANGER:
+        if re.search(pattern, lowered):
+            d_h = max(d_h, hard_d_h)
+            pattern_drift = max(pattern_drift, hard_pd)
+            reason_codes.append(f"HARD_{reason.upper()}")
+            break
+    else:
+        for pattern, soft_d_h, reason in _SOFT_DANGER:
+            if re.search(pattern, lowered):
+                d_h = max(d_h, soft_d_h)
+                reason_codes.append(f"SOFT_{reason.upper()}")
+                break
+
+    score = round(harmonic_score(d_h, pattern_drift), 6)
+    tier = risk_tier(score)
+    scanned_at = _now_iso()
+    receipt_material = {
+        "schema_version": "scbe-governance-scan-v1",
+        "action": action,
+        "target": target,
+        "command": command,
+        "context": ctx,
+        "policy_version": policy_version,
+        "score": score,
+        "tier": tier,
+        "d_H": round(d_h, 6),
+        "pattern_drift": round(pattern_drift, 6),
+    }
+    receipt_hash = _hash(receipt_material)
+    return GovernanceScan(
+        schema_version="scbe-governance-scan-v1",
+        decision=tier,
+        tier=tier,
+        score=score,
+        d_H=round(d_h, 6),
+        pattern_drift=round(pattern_drift, 6),
+        role=role,
+        action=action,
+        target=target,
+        command=command,
+        policy_version=policy_version,
+        receipt_hash=receipt_hash,
+        scanned_at=scanned_at,
+        explanation={
+            "formula": "1/(1+phi*d_H+2*pattern_drift)",
+            "reason_codes": reason_codes + [f"DECISION_{tier}"],
+            "context_sha256": _hash(ctx),
+        },
+    )
+
+
+def scan_agent_request(
+    *,
+    action: str,
+    target: str = "",
+    command: str = "",
+    observed: str = "",
+    context: dict[str, Any] | None = None,
+    policy_version: str = "scbe-governance-sdk-v1",
+) -> GovernanceScan:
+    """Scan a framework-agnostic agent action.
+
+    If no explicit command is provided, the action and target are joined so
+    LangChain/CrewAI/AutoGen/n8n callers can still get a tier decision.
+    """
+    material = command or " ".join(part for part in [action, target] if part).strip()
+    return scan_command(
+        material,
+        action=action,
+        target=target,
+        observed=observed,
+        context=context,
+        policy_version=policy_version,
+    )

--- a/packages/agent-bus-py/tests/test_smoke.py
+++ b/packages/agent-bus-py/tests/test_smoke.py
@@ -13,17 +13,17 @@ if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
 import scbe_agent_bus  # noqa: E402
-from scbe_agent_bus import (
+from scbe_agent_bus import (  # noqa: E402
     AgentBusError,
     recommend_companion_packages,
     run_batch,
     run_event,
-)  # noqa: E402
+)
 from scbe_agent_bus.__main__ import _parse_events, main  # noqa: E402
 
 
 def test_module_exports_version():
-    assert scbe_agent_bus.__version__ == "0.2.0"
+    assert scbe_agent_bus.__version__ == "0.3.0"
 
 
 def test_recommend_companion_packages_skips_installed_package():

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -36,6 +36,9 @@ import os
 
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+_AGENT_BUS_PY_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "../..", "packages", "agent-bus-py", "src"))
+if _AGENT_BUS_PY_SRC not in sys.path:
+    sys.path.insert(0, _AGENT_BUS_PY_SRC)
 
 
 def _load_local_env_if_explicitly_enabled() -> None:
@@ -94,6 +97,7 @@ from src.api.search_routes import search_router
 from src.api.llm_routes import llm_router
 from src.api.polly_routes import polly_router
 from src.api.free_llm_routes import free_llm_router
+from scbe_agent_bus import scan_agent_request
 
 try:
     from src.api.mesh_routes import mesh_router
@@ -329,6 +333,32 @@ class PollyChatRequest(BaseModel):
     context: List[PollyChatMessage] = Field(default_factory=list)
 
 
+class GovernanceScanRequest(BaseModel):
+    agent_id: str = Field(default="agent", max_length=256)
+    action: str = Field(default="EXECUTE", max_length=128)
+    target: str = Field(default="", max_length=4096)
+    command: str = Field(default="", max_length=16000)
+    observed: str = Field(default="", max_length=32000)
+    context: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GovernanceScanResponse(BaseModel):
+    schema_version: str
+    decision: str
+    tier: str
+    score: float
+    d_H: float
+    pattern_drift: float
+    role: str
+    action: str
+    target: str
+    command: str
+    policy_version: str
+    receipt_hash: str
+    scanned_at: str
+    explanation: Dict[str, Any]
+
+
 def _build_runtime_deck_payload(
     *,
     language: str,
@@ -395,7 +425,8 @@ def _polly_local_chat_response(message: str) -> dict[str, Any]:
     return {
         "response": (
             "Polly Pad local mode is online. "
-            "For coding tasks, send code or ask for a system-card deck and GeoSeal will route it through the bounded control plane."
+            "For coding tasks, send code or ask for a system-card deck and "
+            "GeoSeal will route it through the bounded control plane."
         ),
         "domain": "hybrid",
         "tentacle": "local",
@@ -585,6 +616,24 @@ async def verify_api_key(
         raise HTTPException(429, "Rate limit exceeded (100 req/min)")
 
     return VALID_API_KEYS[resolved_key]
+
+
+@app.post("/v1/governance/scan", response_model=GovernanceScanResponse, tags=["Governance"])
+async def governance_scan(request: GovernanceScanRequest, user: str = Depends(verify_api_key)):
+    """SDK-compatible governance scan for wrapping existing agent frameworks."""
+    receipt = scan_agent_request(
+        action=request.action,
+        target=request.target,
+        command=request.command,
+        observed=request.observed,
+        context={**(request.context or {}), "user": user, "agent_id": request.agent_id},
+        policy_version="scbe-governance-sdk-v1",
+    )
+    metrics_store.agent_requests[request.agent_id] += 1
+    metrics_store.risk_scores.append(float(receipt["score"]))
+    if receipt["decision"] == "DENY":
+        metrics_store.total_denials += 1
+    return GovernanceScanResponse(**receipt)
 
 
 # ============================================================================

--- a/src/api/stripe_billing.py
+++ b/src/api/stripe_billing.py
@@ -66,14 +66,47 @@ PLANS: Dict[str, Dict[str, Any]] = {
     },
 }
 
-# In-memory mapping: stripe_customer_id -> tenant record
-# In production this would be a database table.
-BILLING_CUSTOMERS: Dict[str, Dict[str, Any]] = {}
-
-# API keys issued via billing (api_key -> {customer_id, plan, tenant_id, ...})
-BILLING_API_KEYS: Dict[str, Dict[str, Any]] = {}
-
 LOGGER = logging.getLogger("scbe.billing")
+
+_KEYS_FILE = Path(__file__).resolve().parents[2] / "artifacts" / "revenue" / "api_keys.jsonl"
+
+
+def _load_keys() -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Load persisted billing records from disk on startup."""
+    customers: Dict[str, Any] = {}
+    keys: Dict[str, Any] = {}
+    if not _KEYS_FILE.exists():
+        return customers, keys
+    try:
+        with open(_KEYS_FILE, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                cid = record.get("customer_id", "")
+                key = record.get("api_key", "")
+                if cid:
+                    customers[cid] = record
+                if key:
+                    keys[key] = record
+    except Exception as exc:
+        LOGGER.warning("Failed to load billing keys from disk: %s", exc)
+    return customers, keys
+
+
+def _persist_key(record: Dict[str, Any]) -> None:
+    """Append an API key record to disk."""
+    _KEYS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(_KEYS_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception as exc:
+        LOGGER.warning("Failed to persist API key record: %s", exc)
+
+
+# Load persisted state on import
+BILLING_CUSTOMERS, BILLING_API_KEYS = _load_keys()
 
 
 def _owner_token() -> str:
@@ -350,11 +383,15 @@ def _handle_checkout_completed(session: Dict[str, Any]) -> None:
 
     BILLING_CUSTOMERS[customer_id] = record
     BILLING_API_KEYS[api_key] = record
+    _persist_key(record)
 
     # Also register in the SaaS API key store so endpoints accept it
-    from src.api.saas_routes import VALID_API_KEYS
+    try:
+        from src.api.saas_routes import VALID_API_KEYS
 
-    VALID_API_KEYS[api_key] = email or customer_id
+        VALID_API_KEYS[api_key] = email or customer_id
+    except ImportError:
+        pass
 
 
 def _handle_subscription_updated(subscription: Dict[str, Any]) -> None:
@@ -525,10 +562,10 @@ def _send_delivery_email(
     from email.mime.multipart import MIMEMultipart
     from email.mime.text import MIMEText
 
-    smtp_host = os.getenv("SCBE_SMTP_HOST", "smtp.porkbun.com")
+    smtp_host = os.getenv("SCBE_SMTP_HOST", "smtp.protonmail.ch")
     smtp_port = int(os.getenv("SCBE_SMTP_PORT", "587"))
-    smtp_user = os.getenv("SCBE_SMTP_USER", "ai@aethermoore.com")
-    smtp_pass = os.getenv("SCBE_SMTP_PASS", "")
+    smtp_user = os.getenv("SCBE_SMTP_USER") or os.getenv("PM_USER", "")
+    smtp_pass = os.getenv("SCBE_SMTP_PASS") or os.getenv("PM_PW", "")
 
     subject = f"Your {product_name} is ready"
     html_body = f"""<html><body style="font-family: Georgia, serif; color: #333; max-width: 600px;">
@@ -548,7 +585,8 @@ If you have any questions, reply to this email or reach us at ai@aethermoore.com
 
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
-    msg["From"] = f"AetherMoore <{smtp_user}>"
+    from_addr = os.getenv("PM_FROM") or smtp_user
+    msg["From"] = f"AetherMoore <{from_addr}>"
     msg["To"] = to_email
     msg["Reply-To"] = "ai@aethermoore.com"
     msg.attach(

--- a/tests/agents/test_kernel_antivirus_gate_capillary.py
+++ b/tests/agents/test_kernel_antivirus_gate_capillary.py
@@ -1,0 +1,151 @@
+"""
+Regression tests for the hyperbolic_scanner -> kernel_antivirus_gate wire.
+
+Three cases:
+  1. Benign handoff:  state vector near origin  -> low geometry_norm -> ALLOW preserved
+  2. Adversarial payload: state vector near ball boundary -> elevated geometry_norm
+  3. Explicit caller-supplied geometry_norm (no state_vector) -> respected, not overridden
+"""
+
+from __future__ import annotations
+
+from agents.kernel_antivirus_gate import (
+    KernelEvent,
+    evaluate_kernel_event_with_state,
+    geometry_norm_from_state,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _safe_event(**overrides) -> KernelEvent:
+    """Minimally suspicious kernel event (signed, hashed, boring operation)."""
+    defaults = dict(
+        host="test-host",
+        pid=1234,
+        process_name="python.exe",
+        operation="open",
+        target="/home/user/data.csv",
+        command_line="python script.py",
+        parent_process="bash",
+        signer_trusted=True,
+        hash_sha256="a" * 64,
+        geometry_norm=0.0,
+    )
+    defaults.update(overrides)
+    return KernelEvent(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Case 1: benign state vector -> low geometry_norm -> decision stays ALLOW
+# ---------------------------------------------------------------------------
+
+
+def test_benign_handoff_keeps_allow():
+    """
+    A state vector near the Poincaré-ball origin yields a low geometry_norm.
+    Combined with a safe kernel event the decision must be ALLOW and the cell
+    state must be HEALTHY or PRIMED (not INFLAMED/NECROTIC).
+    """
+    # Small values; L2 norm << 0.95 threshold in hyperbolic_scanner
+    benign_state = [0.05, 0.05, 0.05, 0.05]
+
+    result = evaluate_kernel_event_with_state(_safe_event(), state_vector=benign_state)
+
+    assert result.decision == "ALLOW", f"Expected ALLOW for benign state, got {result.decision}"
+    assert result.cell_state in ("HEALTHY", "PRIMED"), f"Expected healthy/primed cell, got {result.cell_state}"
+    assert result.geometry_norm < 0.50, f"Expected low geometry_norm for benign state, got {result.geometry_norm}"
+
+
+# ---------------------------------------------------------------------------
+# Case 2: adversarial payload -> elevated geometry_norm -> suspicion increases
+# ---------------------------------------------------------------------------
+
+
+def test_adversarial_payload_elevates_suspicion():
+    """
+    A state vector near the Poincaré-ball boundary (L2 norm >= 0.95) is
+    clipped and yields a high geometry_norm that measurably raises suspicion.
+
+    Note: geometry_norm carries 15% weight in the suspicion blend, so a
+    maxed norm contributes at most 0.15 to suspicion. A clean event (trusted
+    signer, good hash, benign operation) has a very low base suspicion, so
+    the decision can still be ALLOW — that is intentional. What matters is:
+    (1) the scanner correctly clips the out-of-ball state to a norm near 1.0,
+    (2) suspicion is meaningfully higher than the same event with a zero norm.
+    """
+    # L2 norm of [0.6, 0.6, 0.6] = 0.6 * sqrt(3) ≈ 1.039 -> clipped to ~0.999
+    adversarial_state = [0.6, 0.6, 0.6]
+    computed_norm = geometry_norm_from_state(adversarial_state)
+
+    # Scanner should have clipped this near the boundary
+    assert computed_norm >= 0.90, f"Expected high norm from near-boundary state, got {computed_norm}"
+
+    result_high = evaluate_kernel_event_with_state(_safe_event(), state_vector=adversarial_state)
+    result_zero = evaluate_kernel_event_with_state(_safe_event(geometry_norm=0.0), state_vector=None)
+
+    # geometry_norm on result must reflect what the scanner computed
+    assert (
+        result_high.geometry_norm >= computed_norm * 0.90
+    ), f"Result geometry_norm {result_high.geometry_norm} should track scanner norm {computed_norm}"
+
+    # Suspicion must be higher with the elevated geometry_norm
+    suspicion_lift = result_high.suspicion - result_zero.suspicion
+    assert suspicion_lift > 0.05, f"Expected >=0.05 suspicion lift from near-boundary norm, got {suspicion_lift:.4f}"
+    assert result_high.suspicion > 0.10, f"Expected elevated absolute suspicion, got {result_high.suspicion}"
+
+
+# ---------------------------------------------------------------------------
+# Case 3: explicit caller-supplied geometry_norm, no state_vector -> respected
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_geometry_norm_respected_without_state_vector():
+    """
+    When no state_vector is passed, the geometry_norm already on the KernelEvent
+    is used unchanged.  This confirms backward compatibility for callers that
+    compute geometry_norm themselves (e.g. from a different scanner or sensor).
+    """
+    manual_norm = 0.42
+    event = _safe_event(geometry_norm=manual_norm)
+
+    # Call the wrapper with NO state_vector
+    result = evaluate_kernel_event_with_state(event, state_vector=None)
+
+    # The gate's internal geometry_norm computation blends the observed_norm
+    # with suspicion (line 241 in gate: geometry_norm = clamp(max(observed, 0.20 + 0.75*s))).
+    # What we check: the reported geometry_norm is >= the manually set value
+    # (the gate may raise it, but must never drop it below the caller's signal).
+    assert result.geometry_norm >= manual_norm * 0.90, (
+        f"Caller-supplied norm {manual_norm} should be reflected in result, " f"got {result.geometry_norm}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 4: scanner overrides event norm when state_vector is provided
+# ---------------------------------------------------------------------------
+
+
+def test_scanner_overrides_event_norm_when_state_vector_provided():
+    """
+    When state_vector is provided, the scanner-computed norm replaces the
+    event's geometry_norm field (scanner takes precedence per policy docstring).
+    """
+    # Event has a hand-set high norm
+    event = _safe_event(geometry_norm=0.85)
+
+    # But the state vector is clearly benign
+    benign_state = [0.02, 0.02, 0.02]
+    scanner_norm = geometry_norm_from_state(benign_state)
+    assert scanner_norm < 0.10, f"Expected benign scanner norm, got {scanner_norm}"
+
+    result = evaluate_kernel_event_with_state(event, state_vector=benign_state)
+
+    # The gate's reported geometry_norm must reflect the scanner result, not 0.85.
+    # (Gate may raise it via internal blend but the starting observed_norm is scanner_norm.)
+    assert (
+        result.geometry_norm < 0.80
+    ), f"Scanner-computed low norm should replace the event's 0.85; got {result.geometry_norm}"
+    assert result.decision == "ALLOW", f"Benign state should yield ALLOW, got {result.decision}"

--- a/workflows/n8n/scbe_n8n_bridge.py
+++ b/workflows/n8n/scbe_n8n_bridge.py
@@ -4,6 +4,8 @@ SCBE n8n Bridge — FastAPI service connecting n8n workflows to SCBE Web Agent
 
 Endpoints:
   POST /v1/governance/scan        — Semantic antivirus scan
+  POST /v1/govern/check           — L12 harmonic wall: single command → tier+score
+  POST /v1/govern/batch           — L12 harmonic wall: list of commands in one call
   GET  /v1/automations/health     — Self-hosted automation hub health
   GET  /v1/automations/rules      — List local automation rules
   POST /v1/automations/rules      — Register local automation rule
@@ -67,6 +69,19 @@ except ImportError:
     print("pip install fastapi uvicorn  # required for n8n bridge")
     raise
 
+try:
+    from scripts.benchmark.scbe_governance_core import (
+        semantic_distance as _gov_d_H,
+        danger_drift as _gov_pd,
+        harmonic_score as _gov_score,
+        risk_tier as _gov_tier,
+        atomic_role_for_command as _gov_role,
+    )
+
+    _GOV_CORE_AVAILABLE = True
+except Exception:
+    _GOV_CORE_AVAILABLE = False
+
 from symphonic_cipher.scbe_aethermoore.concept_blocks.web_agent import (
     SemanticAntivirus,
     ContentBuffer,
@@ -96,6 +111,7 @@ app = FastAPI(
 
 # CORS — allow the mobile app (Capacitor webview) and local dev
 from starlette.middleware.cors import CORSMiddleware
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -114,11 +130,7 @@ for plat in Platform:
     _buffer.register_publisher(PlatformPublisher(plat))
 
 # API key validation
-_API_KEYS = set(
-    k.strip()
-    for k in os.environ.get("SCBE_API_KEYS", "scbe-dev-key,test-key").split(",")
-    if k.strip()
-)
+_API_KEYS = set(k.strip() for k in os.environ.get("SCBE_API_KEYS", "scbe-dev-key,test-key").split(",") if k.strip())
 _BROWSER_SERVICE_URL = os.environ.get(
     "SCBE_BROWSER_SERVICE_URL",
     "http://127.0.0.1:8011",
@@ -152,13 +164,9 @@ _ANTHROPIC_DEFAULT_MODEL = os.environ.get(
 ).strip()
 _XAI_DEFAULT_MODEL = os.environ.get("SCBE_XAI_MODEL", "grok-beta").strip()
 _HF_DEFAULT_MODEL = os.environ.get("SCBE_HF_MODEL", "Qwen/Qwen2.5-7B-Instruct").strip()
-_HF_DATASET_REPO_RE = re.compile(
-    r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}/[A-Za-z0-9][A-Za-z0-9._-]{0,95}$"
-)
+_HF_DATASET_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,95}/[A-Za-z0-9][A-Za-z0-9._-]{0,95}$")
 _HF_ALLOWED_DATASET_REPOS = {
-    repo.strip().lower()
-    for repo in os.environ.get("SCBE_HF_ALLOWED_DATASET_REPOS", "").split(",")
-    if repo.strip()
+    repo.strip().lower() for repo in os.environ.get("SCBE_HF_ALLOWED_DATASET_REPOS", "").split(",") if repo.strip()
 }
 _HF_COMMIT_MESSAGE_MAX_LEN = 120
 _AUTOMATION_RULES_PATH = Path(
@@ -198,9 +206,7 @@ _SECRET_PREFIX_FRAGMENTS = (
     "shpat_",
     "AKIA",
 )
-_PUBLIC_SECRET_RE = re.compile(
-    r"(?:" + "|".join(_SECRET_PREFIX_FRAGMENTS) + r")[A-Za-z0-9_\-]{8,}"
-)
+_PUBLIC_SECRET_RE = re.compile(r"(?:" + "|".join(_SECRET_PREFIX_FRAGMENTS) + r")[A-Za-z0-9_\-]{8,}")
 
 
 def _redact_public_text(value: Any) -> str:
@@ -236,10 +242,32 @@ def _check_key(api_key: Optional[str] = None):
 #  Request/response models
 # ---------------------------------------------------------------------------
 
+
 class ScanRequest(BaseModel):
     content: str
     platforms: Optional[List[str]] = None
     scan_mode: str = "full"
+
+
+class GoverCheckRequest(BaseModel):
+    command: str = Field(..., description="Shell command or agent action to score")
+    context: Optional[str] = Field(None, description="Optional surrounding context")
+    agent_id: Optional[str] = Field(None, description="Optional agent identifier for audit log")
+
+
+class GoverCheckResponse(BaseModel):
+    tier: str
+    score: float
+    d_H: float
+    pd: float
+    role: str
+    command: str
+    agent_id: Optional[str]
+
+
+class GoverBatchRequest(BaseModel):
+    commands: List[str] = Field(..., description="List of commands to score")
+    agent_id: Optional[str] = Field(None)
 
 
 class TongueEncodeRequest(BaseModel):
@@ -278,6 +306,7 @@ class TelemetryRequest(BaseModel):
 
 class TrainingIngestRequest(BaseModel):
     """Game event forwarded from n8n for training data collection."""
+
     event_type: str
     context: str = ""
     outcome: str = ""
@@ -287,6 +316,7 @@ class TrainingIngestRequest(BaseModel):
 
 class N8nBrowseAction(BaseModel):
     """Compact action payload expected by browser integration endpoint."""
+
     action: str
     target: str
     value: Optional[str] = None
@@ -296,6 +326,7 @@ class N8nBrowseAction(BaseModel):
 
 class N8nBrowseRequest(BaseModel):
     """Bridge request used by n8n workflows for Playwright browsing."""
+
     actions: List[N8nBrowseAction]
     session_id: Optional[str] = None
     dry_run: bool = False
@@ -306,6 +337,7 @@ class N8nBrowseRequest(BaseModel):
 
 class CouncilRequest(BaseModel):
     """AI Round Table — fan out a query to multiple LLMs with governance."""
+
     query: str
     system: Optional[str] = None
     providers: List[str] = ["anthropic", "openai", "xai"]
@@ -317,6 +349,7 @@ class CouncilRequest(BaseModel):
 
 class LLMDispatchRequest(BaseModel):
     """Unified provider dispatch for OpenAI, Anthropic, xAI, and HF router."""
+
     provider: str
     model: Optional[str] = None
     messages: List[Dict[str, Any]] = []
@@ -399,6 +432,7 @@ class CodeExecRequest(BaseModel):
 #  Endpoints
 # ---------------------------------------------------------------------------
 
+
 @app.get("/health")
 async def health():
     return {
@@ -477,10 +511,7 @@ def _extract_openai_style_response(resp: Dict[str, Any]) -> Dict[str, Any]:
     message = choices[0].get("message", {}) or {}
     content = message.get("content", "")
     if isinstance(content, list):
-        content = "\n".join(
-            str(block.get("text", "")) if isinstance(block, dict) else str(block)
-            for block in content
-        )
+        content = "\n".join(str(block.get("text", "")) if isinstance(block, dict) else str(block) for block in content)
     return {
         "text": content or "",
         "tool_calls": message.get("tool_calls", []) or [],
@@ -593,6 +624,7 @@ def _send_zapier_event(event_payload: Dict[str, Any]) -> Dict[str, Any]:
         return {"status": "skipped", "reason": "missing_hook_url"}
     # SSRF protection: only allow known webhook domains
     from urllib.parse import urlparse
+
     parsed = urlparse(hook_url)
     _ALLOWED_WEBHOOK_HOSTS = {
         "hooks.zapier.com",
@@ -703,15 +735,60 @@ async def llm_dispatch(req: LLMDispatchRequest, x_api_key: Optional[str] = Heade
 
 # Map app seat IDs → provider + base_url + key + default model
 _ARENA_PROVIDERS = {
-    "groq":          {"base_url": "https://api.groq.com/openai/v1/chat/completions",          "key_fn": lambda: _GROQ_API_KEY,         "model": "llama-3.3-70b-versatile", "style": "openai"},
-    "cerebras":      {"base_url": "https://api.cerebras.ai/v1/chat/completions",               "key_fn": lambda: _CEREBRAS_API_KEY,     "model": "llama3.1-8b",             "style": "openai"},
-    "google_ai":     {"base_url": "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", "key_fn": lambda: _GOOGLE_AI_KEY, "model": "gemini-2.5-flash", "style": "openai"},
-    "claude":        {"base_url": None,                                                        "key_fn": lambda: _ANTHROPIC_API_KEY,    "model": _ANTHROPIC_DEFAULT_MODEL,  "style": "anthropic"},
-    "xai":           {"base_url": "https://api.x.ai/v1/chat/completions",                      "key_fn": lambda: _XAI_API_KEY,          "model": "grok-3-mini-fast",        "style": "openai"},
-    "openrouter":    {"base_url": "https://openrouter.ai/api/v1/chat/completions",             "key_fn": lambda: _OPENROUTER_API_KEY,   "model": "moonshotai/kimi-k2",      "style": "openai"},
-    "github_models": {"base_url": "https://models.inference.ai.azure.com/chat/completions",    "key_fn": lambda: _GITHUB_MODELS_TOKEN,  "model": "gpt-4o-mini",             "style": "openai"},
-    "huggingface":   {"base_url": "https://router.huggingface.co/v1/chat/completions",         "key_fn": lambda: _HF_ROUTER_TOKEN,      "model": _HF_DEFAULT_MODEL,         "style": "openai"},
-    "ollama":        {"base_url": "http://127.0.0.1:11434/v1/chat/completions",                "key_fn": lambda: "ollama",              "model": "llama3.2",                "style": "openai"},
+    "groq": {
+        "base_url": "https://api.groq.com/openai/v1/chat/completions",
+        "key_fn": lambda: _GROQ_API_KEY,
+        "model": "llama-3.3-70b-versatile",
+        "style": "openai",
+    },
+    "cerebras": {
+        "base_url": "https://api.cerebras.ai/v1/chat/completions",
+        "key_fn": lambda: _CEREBRAS_API_KEY,
+        "model": "llama3.1-8b",
+        "style": "openai",
+    },
+    "google_ai": {
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+        "key_fn": lambda: _GOOGLE_AI_KEY,
+        "model": "gemini-2.5-flash",
+        "style": "openai",
+    },
+    "claude": {
+        "base_url": None,
+        "key_fn": lambda: _ANTHROPIC_API_KEY,
+        "model": _ANTHROPIC_DEFAULT_MODEL,
+        "style": "anthropic",
+    },
+    "xai": {
+        "base_url": "https://api.x.ai/v1/chat/completions",
+        "key_fn": lambda: _XAI_API_KEY,
+        "model": "grok-3-mini-fast",
+        "style": "openai",
+    },
+    "openrouter": {
+        "base_url": "https://openrouter.ai/api/v1/chat/completions",
+        "key_fn": lambda: _OPENROUTER_API_KEY,
+        "model": "moonshotai/kimi-k2",
+        "style": "openai",
+    },
+    "github_models": {
+        "base_url": "https://models.inference.ai.azure.com/chat/completions",
+        "key_fn": lambda: _GITHUB_MODELS_TOKEN,
+        "model": "gpt-4o-mini",
+        "style": "openai",
+    },
+    "huggingface": {
+        "base_url": "https://router.huggingface.co/v1/chat/completions",
+        "key_fn": lambda: _HF_ROUTER_TOKEN,
+        "model": _HF_DEFAULT_MODEL,
+        "style": "openai",
+    },
+    "ollama": {
+        "base_url": "http://127.0.0.1:11434/v1/chat/completions",
+        "key_fn": lambda: "ollama",
+        "model": "llama3.2",
+        "style": "openai",
+    },
 }
 
 
@@ -850,12 +927,14 @@ async def execute_code(req: CodeExecRequest):
             "scripts": {"test": "node index.js"},
         }
 
-    payload = json.dumps({
-        "files": files,
-        "packageJson": pkg,
-        "runCommand": run_command,
-        "runTimeoutMs": timeout * 1000,
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "files": files,
+            "packageJson": pkg,
+            "runCommand": run_command,
+            "runTimeoutMs": timeout * 1000,
+        }
+    ).encode("utf-8")
 
     url = f"{_KERNEL_RUNNER_URL}/api/run"
     http_req = urllib_request.Request(
@@ -1056,11 +1135,66 @@ async def governance_scan(req: ScanRequest, x_api_key: Optional[str] = Header(No
     return profile.to_dict()
 
 
+@app.post("/v1/govern/check", response_model=GoverCheckResponse)
+async def govern_check(req: GoverCheckRequest, x_api_key: Optional[str] = Header(None)):
+    """L12 harmonic wall score for a single command or agent action.
+
+    Returns tier (ALLOW / QUARANTINE / DENY), score ∈ (0,1], and the
+    component distances so callers can log full governance provenance.
+    No API key required in dev mode (SCBE_API_KEYS not set); required in prod.
+    """
+    if _API_KEYS - {"scbe-dev-key", "test-key"}:
+        _check_key(x_api_key)
+    if not _GOV_CORE_AVAILABLE:
+        raise HTTPException(status_code=503, detail="scbe_governance_core not importable")
+    d_H = _gov_d_H(req.command)
+    pd = _gov_pd(req.command)
+    score = _gov_score(d_H, pd)
+    tier = _gov_tier(score)
+    role, _ = _gov_role(req.command)
+    return GoverCheckResponse(
+        tier=tier,
+        score=round(score, 4),
+        d_H=round(d_H, 4),
+        pd=round(pd, 4),
+        role=role,
+        command=req.command,
+        agent_id=req.agent_id,
+    )
+
+
+@app.post("/v1/govern/batch")
+async def govern_batch(req: GoverBatchRequest, x_api_key: Optional[str] = Header(None)):
+    """Score a list of commands in one call. Returns list in same order."""
+    if _API_KEYS - {"scbe-dev-key", "test-key"}:
+        _check_key(x_api_key)
+    if not _GOV_CORE_AVAILABLE:
+        raise HTTPException(status_code=503, detail="scbe_governance_core not importable")
+    results = []
+    for cmd in req.commands:
+        d_H = _gov_d_H(cmd)
+        pd = _gov_pd(cmd)
+        score = _gov_score(d_H, pd)
+        role, _ = _gov_role(cmd)
+        results.append(
+            {
+                "command": cmd,
+                "tier": _gov_tier(score),
+                "score": round(score, 4),
+                "d_H": round(d_H, 4),
+                "pd": round(pd, 4),
+                "role": role,
+            }
+        )
+    return {"results": results, "agent_id": req.agent_id, "count": len(results)}
+
+
 @app.post("/v1/tongue/encode")
 async def tongue_encode(req: TongueEncodeRequest, x_api_key: Optional[str] = Header(None)):
     _check_key(x_api_key)
     try:
         from symphonic_cipher.scbe_aethermoore.concept_blocks.web_agent.tongue_transport import TongueTransport
+
         transport = TongueTransport()
         if req.seal and req.context:
             env = transport.seal(req.text, tongue=req.tongue, context=req.context)
@@ -1091,6 +1225,7 @@ async def buffer_post(req: BufferPostRequest, x_api_key: Optional[str] = Header(
     if req.tongue_encode:
         try:
             from symphonic_cipher.scbe_aethermoore.concept_blocks.web_agent.tongue_transport import TongueTransport
+
             transport = TongueTransport()
             tongue = req.tongue or "KO"
             env = transport.encode(text, tongue=tongue)
@@ -1116,10 +1251,7 @@ async def buffer_post(req: BufferPostRequest, x_api_key: Optional[str] = Header(
     results = []
     if not req.schedule_at:
         publish_results = _buffer.publish_due()
-        results = [
-            {"platform": r.platform.value, "success": r.success, "url": r.post_url}
-            for r in publish_results
-        ]
+        results = [{"platform": r.platform.value, "success": r.success, "url": r.post_url} for r in publish_results]
 
     return {
         "post_id": post.post_id,
@@ -1162,8 +1294,7 @@ async def n8n_browse_proxy(req: N8nBrowseRequest, x_api_key: Optional[str] = Hea
     """Proxy n8n browse payloads to Playwright browser service."""
     _check_key(x_api_key)
     serialized_actions = [
-        action.model_dump() if hasattr(action, "model_dump") else action.dict()
-        for action in req.actions
+        action.model_dump() if hasattr(action, "model_dump") else action.dict() for action in req.actions
     ]
     payload = {
         "actions": serialized_actions,
@@ -1241,13 +1372,19 @@ def _dispatch_single_provider(provider: str, prompt: str, system_prompt: str, ma
             temperature=0.3,
         )
         if p == "openai":
-            raw = _dispatch_openai_compatible(req, "https://api.openai.com/v1/chat/completions", _OPENAI_API_KEY, _OPENAI_DEFAULT_MODEL)
+            raw = _dispatch_openai_compatible(
+                req, "https://api.openai.com/v1/chat/completions", _OPENAI_API_KEY, _OPENAI_DEFAULT_MODEL
+            )
             return {"provider": p, "text": _extract_openai_style_response(raw).get("text", ""), "status": "ok"}
         elif p == "xai":
-            raw = _dispatch_openai_compatible(req, "https://api.x.ai/v1/chat/completions", _XAI_API_KEY, _XAI_DEFAULT_MODEL)
+            raw = _dispatch_openai_compatible(
+                req, "https://api.x.ai/v1/chat/completions", _XAI_API_KEY, _XAI_DEFAULT_MODEL
+            )
             return {"provider": p, "text": _extract_openai_style_response(raw).get("text", ""), "status": "ok"}
         elif p == "huggingface":
-            raw = _dispatch_openai_compatible(req, "https://router.huggingface.co/v1/chat/completions", _HF_ROUTER_TOKEN, _HF_DEFAULT_MODEL)
+            raw = _dispatch_openai_compatible(
+                req, "https://router.huggingface.co/v1/chat/completions", _HF_ROUTER_TOKEN, _HF_DEFAULT_MODEL
+            )
             return {"provider": p, "text": _extract_openai_style_response(raw).get("text", ""), "status": "ok"}
         elif p == "anthropic":
             raw = _dispatch_anthropic(req)
@@ -1338,8 +1475,7 @@ async def council_deliberate(req: CouncilRequest, x_api_key: Optional[str] = Hea
         synthesis = all_texts[-1] if all_texts else ""
     elif req.strategy == "debate":
         synthesis = "\n\n---\n\n".join(
-            f"[{r.get('provider', '?')}]: {r.get('text', '')}"
-            for r in responses if r.get("text")
+            f"[{r.get('provider', '?')}]: {r.get('text', '')}" for r in responses if r.get("text")
         )
     else:  # consensus
         synthesis = " | ".join(all_texts) if len(all_texts) <= 2 else all_texts[0] if all_texts else ""
@@ -1504,11 +1640,9 @@ async def training_status(x_api_key: Optional[str] = Header(None)):
 #  Hyperbolic Lattice 2.5D Workflow Route
 # ---------------------------------------------------------------------------
 
+
 def _notion_token() -> str:
-    token = (
-        os.environ.get("NOTION_TOKEN", "").strip()
-        or os.environ.get("NOTION_API_KEY", "").strip()
-    )
+    token = os.environ.get("NOTION_TOKEN", "").strip() or os.environ.get("NOTION_API_KEY", "").strip()
     return token
 
 
@@ -1911,8 +2045,10 @@ async def workflow_lattice25d(
 #  ChoiceScript Branching Workflow Engine
 # ---------------------------------------------------------------------------
 
+
 class BranchExploreRequest(BaseModel):
     """Execute a branching scene graph with multi-path exploration."""
+
     graph_name: str = "research_pipeline"
     topic: str = ""
     strategy: str = "all_paths"
@@ -1925,6 +2061,7 @@ class BranchExploreRequest(BaseModel):
 
 class BranchActionRequest(BaseModel):
     """Single scene action callback from n8n branching workflow."""
+
     scene: str
     action: str
     params: Dict[str, Any] = {}
@@ -1950,6 +2087,7 @@ async def workflow_branch_explore(req: BranchExploreRequest, x_api_key: Optional
     except ImportError:
         # Fallback: direct import from same directory
         import importlib.util
+
         spec = importlib.util.spec_from_file_location(
             "choicescript_branching_engine",
             os.path.join(os.path.dirname(__file__), "choicescript_branching_engine.py"),
@@ -1971,7 +2109,9 @@ async def workflow_branch_explore(req: BranchExploreRequest, x_api_key: Optional
 
     builder = graph_builders.get(req.graph_name)
     if not builder:
-        raise HTTPException(status_code=400, detail=f"Unknown graph: {req.graph_name}. Available: {list(graph_builders.keys())}")
+        raise HTTPException(
+            status_code=400, detail=f"Unknown graph: {req.graph_name}. Available: {list(graph_builders.keys())}"
+        )
 
     graph = builder()
     engine = BranchingEngine(
@@ -1996,11 +2136,15 @@ async def workflow_branch_explore(req: BranchExploreRequest, x_api_key: Optional
         "total_scenes": result.total_scenes,
         "coverage": round(result.coverage, 3),
         "paths_explored": len(result.paths),
-        "best_path": {
-            "scenes": result.best_path.scenes_visited,
-            "score": result.best_path.score,
-            "actions": len(result.best_path.actions_taken),
-        } if result.best_path else None,
+        "best_path": (
+            {
+                "scenes": result.best_path.scenes_visited,
+                "score": result.best_path.score,
+                "actions": len(result.best_path.actions_taken),
+            }
+            if result.best_path
+            else None
+        ),
         "all_paths": [
             {
                 "id": p.path_id,
@@ -2117,14 +2261,16 @@ async def list_agents(x_api_key: Optional[str] = Header(None)):
     agents = []
     for slug, meta in _AGENT_PERSONAS.items():
         seat = _first_available_seat(meta["preferred_seats"])
-        agents.append({
-            "id": slug,
-            "name": meta["name"],
-            "role": meta["role"],
-            "available": seat is not None,
-            "seat": seat,
-            "preferred_seats": meta["preferred_seats"],
-        })
+        agents.append(
+            {
+                "id": slug,
+                "name": meta["name"],
+                "role": meta["role"],
+                "available": seat is not None,
+                "seat": seat,
+                "preferred_seats": meta["preferred_seats"],
+            }
+        )
     return {"agents": agents}
 
 
@@ -2140,12 +2286,14 @@ async def bus_events(limit: int = 50, x_api_key: Optional[str] = Header(None)):
         ts = ev.get("ts") or ev.get("timestamp") or ""
         verdict = ev.get("verdict") or ev.get("governance_verdict") or "ALLOW"
         summary = ev.get("summary") or ev.get("text") or ev.get("post_url") or ""
-        normalized.append({
-            "ts": ts,
-            "verdict": verdict,
-            "summary": summary,
-            "raw": ev,
-        })
+        normalized.append(
+            {
+                "ts": ts,
+                "verdict": verdict,
+                "summary": summary,
+                "raw": ev,
+            }
+        )
     return {"events": normalized, "count": len(normalized)}
 
 
@@ -2181,7 +2329,10 @@ async def agents_dispatch(req: AgentDispatchRequest, x_api_key: Optional[str] = 
 
     seat = req.seat or _first_available_seat(persona["preferred_seats"])
     if not seat:
-        raise HTTPException(503, "No free-tier seat is configured. Set GROQ_API_KEY, OPENROUTER_API_KEY, GOOGLE_AI_KEY, GITHUB_MODELS_TOKEN, HF_TOKEN, or run ollama.")
+        raise HTTPException(
+            503,
+            "No free-tier seat is configured. Set GROQ_API_KEY, OPENROUTER_API_KEY, GOOGLE_AI_KEY, GITHUB_MODELS_TOKEN, HF_TOKEN, or run ollama.",
+        )
     cfg = _ARENA_PROVIDERS[seat]
 
     messages: List[Dict[str, Any]] = [{"role": "system", "content": persona["system"]}]
@@ -2233,6 +2384,7 @@ async def agents_dispatch(req: AgentDispatchRequest, x_api_key: Optional[str] = 
 #  processes.
 # ---------------------------------------------------------------------------
 
+
 def _taskmgr_or_503():
     if _taskmgr_core is None:
         raise HTTPException(503, "tools.taskmgr_core unavailable (psutil not installed)")
@@ -2241,6 +2393,7 @@ def _taskmgr_or_503():
 
 def _jsonable(obj: Any) -> Any:
     import dataclasses as _dc
+
     if _dc.is_dataclass(obj):
         return _dc.asdict(obj)
     if isinstance(obj, list):


### PR DESCRIPTION
Clean, conflict-free replacement for the genuinely-useful code in #2066.

## Why
#2066 (`feat/runtime-gate-durable-state`, 504 files, **CONFLICTING**) audited as:
- **255 files already landed** on `main` (incl. its advertised RuntimeGate durable-state work + `tests/governance/test_runtime_gate_persistence.py`)
- **174 docs/notes** (`docs/legal` patent workbench, `docs/proposals` DARPA, `notes/prime-fog`) that don't belong on `main`
- a small useful code core buried under **105 conflicts** (mostly research-script churn)

So #2066 should be closed, not merged/rebased. This PR ports only the conflict-free, genuinely-unlanded code onto a fresh branch off current `main`.

## What's included
- `agents/kernel_antivirus_gate.py` — capillary antibody/membrane hardening
- `hydra/turnstile.py` *(new)* — `TurnstileOutcome` / `resolve_turnstile` containment
- `tests/agents/test_kernel_antivirus_gate_capillary.py` *(new)* — 4 tests
- `packages/agent-bus-py` — `governance.py` *(new)* + package wiring + 7 smoke tests
- `api/main.py`, `src/api/main.py` — Polly Pad local-mode bridge route
- `src/api/stripe_billing.py`, `workflows/n8n/scbe_n8n_bridge.py` — bridge/billing additions

## Excluded (deliberately)
agent-bus TS core (main's version is newer — avoids regression), all docs/notes/proposals/legal, already-landed files, stale conflicts.

## Verification
`black` + `flake8` clean (`src/ tests/ hydra/`); **11 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added governance scanning endpoints to evaluate command risk and security compliance
  * Added `--scan` mode to CLI for governance assessment of command batches
  * Introduced governance scoring with risk tiers and decision mapping capabilities
  * Enhanced billing key persistence and SMTP email configuration with improved environment support

* **Tests**
  * Added regression tests for kernel antivirus gate integration scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->