### PR TITLE
feat(pianist): add mechanical AI pianist module (reland from #2122)

### DIFF
--- a/src/pianist/__init__.py
+++ b/src/pianist/__init__.py
@@ -1,0 +1,36 @@
+"""AI pianist module: a mechanical piano + 10-finger pianist driven by swappable operators."""
+
+from .operators import CloudOperator, HumanOperator, MarkovOperator, Operator
+from .piano import (
+    ALL_FINGERS,
+    LEFT_FINGERS,
+    MAX_HAND_SPAN,
+    MAX_KEY,
+    MIN_FINGER_REUSE_MS,
+    MIN_KEY,
+    PEDALS,
+    RIGHT_FINGERS,
+    Action,
+    PhysicalError,
+    Pianist,
+    PianoState,
+)
+
+__all__ = [
+    "ALL_FINGERS",
+    "Action",
+    "CloudOperator",
+    "HumanOperator",
+    "LEFT_FINGERS",
+    "MarkovOperator",
+    "MAX_HAND_SPAN",
+    "MAX_KEY",
+    "MIN_FINGER_REUSE_MS",
+    "MIN_KEY",
+    "Operator",
+    "PEDALS",
+    "PhysicalError",
+    "Pianist",
+    "PianoState",
+    "RIGHT_FINGERS",
+]

--- a/src/pianist/__main__.py
+++ b/src/pianist/__main__.py
@@ -1,0 +1,70 @@
+"""CLI entry point: ``python -m pianist [--operator human|markov|cloud] [--out file.jsonl]``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Iterable, Optional
+
+from .operators import CloudOperator, HumanOperator, MarkovOperator, Operator
+from .piano import Pianist, PhysicalError
+
+
+def _build_operator(name: str, stdin: Iterable[str]) -> Operator:
+    if name == "human":
+        return HumanOperator(lines=iter(stdin), echo=lambda m: print(m, file=sys.stderr))
+    if name == "markov":
+        return MarkovOperator()
+    if name == "cloud":
+        return CloudOperator()
+    raise SystemExit(f"unknown operator {name!r}; choose human, markov, or cloud")
+
+
+def _serialize_event(t_ms: int, action) -> str:
+    payload = {"t_ms": t_ms, "kind": action.kind}
+    for attr in ("finger", "key", "velocity", "pedal", "pedal_value", "duration_ms"):
+        value = getattr(action, attr)
+        if value not in (None, 0, 0.0, 80) or (attr == "velocity" and action.kind == "press"):
+            payload[attr] = value
+    return json.dumps(payload)
+
+
+def run(operator: Operator, pianist: Pianist, out_stream: Optional[object] = None) -> int:
+    """Drive ``pianist`` with ``operator`` until the operator returns None."""
+    actions_executed = 0
+    while True:
+        action = operator.next_action(pianist.state())
+        if action is None:
+            break
+        try:
+            pianist.execute(action)
+        except PhysicalError as exc:
+            print(f"[pianist] refused: {exc}", file=sys.stderr)
+            continue
+        actions_executed += 1
+        if out_stream is not None:
+            out_stream.write(_serialize_event(pianist.now_ms, action) + "\n")
+    return actions_executed
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(prog="pianist", description="Drive a mechanical pianist.")
+    parser.add_argument("--operator", default="markov", choices=("human", "markov", "cloud"))
+    parser.add_argument("--out", help="write a JSONL event log to this path (default: stdout)")
+    args = parser.parse_args(argv)
+
+    operator = _build_operator(args.operator, sys.stdin)
+    pianist = Pianist()
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as out_stream:
+            n = run(operator, pianist, out_stream)
+    else:
+        n = run(operator, pianist, sys.stdout)
+    print(f"[pianist] {n} actions executed, final time {pianist.now_ms} ms", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/pianist/operators.py
+++ b/src/pianist/operators.py
@@ -1,0 +1,217 @@
+"""Operators that drive the Pianist.
+
+Each operator implements the same minimal interface: given the current
+``PianoState``, yield the next ``Action`` (or ``None`` to stop). The
+Pianist enforces physical constraints, so operators only need to issue
+intent.
+"""
+
+from __future__ import annotations
+
+import random
+import shlex
+from dataclasses import dataclass
+from typing import Callable, Iterator, List, Optional, Protocol
+
+from .piano import (
+    ALL_FINGERS,
+    LEFT_FINGERS,
+    MAX_KEY,
+    MIN_KEY,
+    PEDALS,
+    RIGHT_FINGERS,
+    Action,
+    PianoState,
+)
+
+
+class Operator(Protocol):
+    """Anything that can decide the next mechanical action."""
+
+    name: str
+
+    def next_action(self, state: PianoState) -> Optional[Action]:  # pragma: no cover - protocol
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Human operator: text commands on stdin or any line iterator.
+# ---------------------------------------------------------------------------
+
+_HUMAN_HELP = """\
+commands:
+  press <finger> <midi-key> [velocity]   e.g. press R3 60 80
+  release <finger>                        e.g. release R3
+  pedal <name> <0.0-1.0>                  e.g. pedal sustain 1.0
+  wait <ms>                               e.g. wait 250
+  help                                    print this message
+  stop                                    end the session
+"""
+
+
+@dataclass
+class HumanOperator:
+    """Drive the piano from a stream of text commands."""
+
+    lines: Iterator[str]
+    name: str = "human"
+    echo: Optional[Callable[[str], None]] = None
+
+    def next_action(self, state: PianoState) -> Optional[Action]:
+        for raw in self.lines:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            try:
+                parts = shlex.split(line)
+            except ValueError as exc:
+                self._echo(f"parse error: {exc}")
+                continue
+            head = parts[0].lower()
+            if head == "stop":
+                return None
+            if head == "help":
+                self._echo(_HUMAN_HELP)
+                continue
+            try:
+                return _parse_command(parts)
+            except ValueError as exc:
+                self._echo(f"bad command: {exc}")
+        return None
+
+    def _echo(self, msg: str) -> None:
+        if self.echo is not None:
+            self.echo(msg)
+
+
+def _parse_command(parts: List[str]) -> Action:
+    head = parts[0].lower()
+    if head == "press":
+        if not 3 <= len(parts) <= 4:
+            raise ValueError("press <finger> <key> [velocity]")
+        finger = parts[1].upper()
+        key = int(parts[2])
+        velocity = int(parts[3]) if len(parts) == 4 else 80
+        return Action(kind="press", finger=finger, key=key, velocity=velocity)
+    if head == "release":
+        if len(parts) != 2:
+            raise ValueError("release <finger>")
+        return Action(kind="release", finger=parts[1].upper())
+    if head == "pedal":
+        if len(parts) != 3:
+            raise ValueError("pedal <name> <value>")
+        return Action(kind="pedal", pedal=parts[1].lower(), pedal_value=float(parts[2]))  # type: ignore[arg-type]
+    if head == "wait":
+        if len(parts) != 2:
+            raise ValueError("wait <ms>")
+        return Action(kind="wait", duration_ms=int(parts[1]))
+    raise ValueError(f"unknown command {head!r}")
+
+
+# ---------------------------------------------------------------------------
+# Local Markov operator: stays offline, deterministic given a seed.
+# ---------------------------------------------------------------------------
+
+# A small C-major / A-minor pool. Each tuple is (left-hand root, right-hand
+# chord tones). MIDI numbers: C4=60.
+_CHORD_POOL = [
+    (36, (60, 64, 67)),  # C2, C-E-G
+    (43, (60, 64, 67)),  # G2, C-E-G
+    (45, (60, 64, 69)),  # A2, C-E-A
+    (41, (60, 65, 69)),  # F2, C-F-A
+]
+
+
+@dataclass
+class MarkovOperator:
+    """Tiny local operator: walks a chord pool, no model weights, no I/O."""
+
+    seed: int = 0
+    bars: int = 4
+    bar_ms: int = 1200
+    velocity: int = 78
+    name: str = "markov"
+
+    def __post_init__(self) -> None:
+        self._rng = random.Random(self.seed)
+        self._queue: List[Action] = []
+        self._bars_remaining = self.bars
+        self._enqueue_next_bar()
+
+    def next_action(self, state: PianoState) -> Optional[Action]:
+        if self._queue:
+            return self._queue.pop(0)
+        if self._bars_remaining <= 0:
+            return None
+        self._enqueue_next_bar()
+        return self._queue.pop(0) if self._queue else None
+
+    def _enqueue_next_bar(self) -> None:
+        if self._bars_remaining <= 0:
+            return
+        left_root, right_tones = self._rng.choice(_CHORD_POOL)
+        right_tones = tuple(right_tones)
+        per_note_ms = self.bar_ms // (len(right_tones) + 1)
+
+        # Pedal down at the start of the bar, lift at the end.
+        self._queue.append(Action(kind="pedal", pedal="sustain", pedal_value=1.0))
+        self._queue.append(Action(kind="press", finger="L3", key=left_root, velocity=self.velocity - 6))
+        finger_map = ("R1", "R3", "R5")
+        for finger, tone in zip(finger_map, right_tones):
+            self._queue.append(Action(kind="press", finger=finger, key=tone, velocity=self.velocity))
+            self._queue.append(Action(kind="wait", duration_ms=per_note_ms))
+            self._queue.append(Action(kind="release", finger=finger))
+        self._queue.append(Action(kind="wait", duration_ms=per_note_ms))
+        self._queue.append(Action(kind="release", finger="L3"))
+        self._queue.append(Action(kind="pedal", pedal="sustain", pedal_value=0.0))
+        self._bars_remaining -= 1
+
+
+# ---------------------------------------------------------------------------
+# Cloud operator: hosted model issues commands; falls back to Markov if no
+# key is configured, so the demo always runs.
+# ---------------------------------------------------------------------------
+
+CLOUD_OPERATOR_SYSTEM_PROMPT = (
+    "You are the operator of a mechanical pianist with 10 fingers "
+    f"({', '.join(ALL_FINGERS)}), three pedals ({', '.join(PEDALS)}), and an "
+    f"88-key piano (MIDI {MIN_KEY}-{MAX_KEY}). Issue ONE command per turn from: "
+    "press <finger> <key> [vel], release <finger>, pedal <name> <0..1>, wait <ms>, stop. "
+    f"Left-hand fingers: {', '.join(LEFT_FINGERS)}. Right-hand fingers: "
+    f"{', '.join(RIGHT_FINGERS)}. Each hand's held keys must span <= 14 semitones."
+)
+
+
+@dataclass
+class CloudOperator:
+    """Operator that asks a hosted model for the next command.
+
+    The real network call is delegated to a ``responder`` callable so this
+    class stays test-friendly and free of SDK imports. If no responder is
+    supplied and no ``ANTHROPIC_API_KEY``/``OPENAI_API_KEY`` is set in the
+    environment, it falls back to ``MarkovOperator`` so demos still play.
+    """
+
+    responder: Optional[Callable[[str, PianoState], Optional[str]]] = None
+    fallback: Optional[Operator] = None
+    name: str = "cloud"
+    system_prompt: str = CLOUD_OPERATOR_SYSTEM_PROMPT
+
+    def __post_init__(self) -> None:
+        # Without a responder, we always need a fallback — otherwise next_action
+        # immediately returns None and the operator no-ops. Whether API keys
+        # exist is irrelevant: the responder callable is what actually makes
+        # the network call.
+        if self.responder is None and self.fallback is None:
+            self.fallback = MarkovOperator()
+
+    def next_action(self, state: PianoState) -> Optional[Action]:
+        if self.responder is None:
+            return self.fallback.next_action(state) if self.fallback is not None else None
+        reply = self.responder(self.system_prompt, state)
+        if reply is None:
+            return None
+        text = reply.strip()
+        if not text or text.lower() == "stop":
+            return None
+        return _parse_command(shlex.split(text))

--- a/src/pianist/piano.py
+++ b/src/pianist/piano.py
@@ -1,0 +1,158 @@
+"""Mechanical piano: 88 keys + 3 pedals + 10 fingers across two hands.
+
+The Pianist enforces real-world constraints (one finger per key, hand-span
+limits, finger reuse latency, 10-finger ceiling) so any operator -- human,
+local model, or cloud model -- has to play within human physical bounds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional, Tuple
+
+# MIDI key range for an 88-key piano: A0 (21) .. C8 (108).
+MIN_KEY = 21
+MAX_KEY = 108
+
+# Hand layout: 5 fingers per hand, thumb = 1, pinky = 5.
+LEFT_FINGERS = ("L1", "L2", "L3", "L4", "L5")
+RIGHT_FINGERS = ("R1", "R2", "R3", "R4", "R5")
+ALL_FINGERS = LEFT_FINGERS + RIGHT_FINGERS
+
+# Maximum span between the lowest and highest key held by a single hand,
+# in semitones. A real adult hand reaches a 9th to a 10th; we allow 14.
+MAX_HAND_SPAN = 14
+
+# Minimum time, in milliseconds, a finger must rest before being reused.
+MIN_FINGER_REUSE_MS = 15
+
+PedalName = Literal["sustain", "sostenuto", "soft"]
+PEDALS: Tuple[PedalName, ...] = ("sustain", "sostenuto", "soft")
+
+
+class PhysicalError(ValueError):
+    """Raised when an operator requests an action a real pianist cannot do."""
+
+
+@dataclass
+class Action:
+    """A single mechanical command issued by an operator."""
+
+    kind: Literal["press", "release", "pedal", "wait"]
+    finger: Optional[str] = None
+    key: Optional[int] = None
+    velocity: int = 80
+    pedal: Optional[PedalName] = None
+    pedal_value: float = 0.0
+    duration_ms: int = 0
+
+
+@dataclass
+class _HeldNote:
+    finger: str
+    key: int
+    velocity: int
+    pressed_at_ms: int
+
+
+@dataclass
+class PianoState:
+    """Public, read-only view of the piano at a moment in time."""
+
+    now_ms: int
+    held: Dict[str, Tuple[int, int]]  # finger -> (key, velocity)
+    pedals: Dict[PedalName, float]
+
+
+@dataclass
+class Pianist:
+    """Two hands, 10 fingers, 3 pedals, one piano."""
+
+    now_ms: int = 0
+    _held: Dict[str, _HeldNote] = field(default_factory=dict)
+    _last_release_ms: Dict[str, int] = field(default_factory=dict)
+    _pedals: Dict[PedalName, float] = field(default_factory=lambda: {p: 0.0 for p in PEDALS})
+    events: List[Tuple[int, Action]] = field(default_factory=list)
+
+    # --- queries --------------------------------------------------------
+
+    def state(self) -> PianoState:
+        return PianoState(
+            now_ms=self.now_ms,
+            held={f: (n.key, n.velocity) for f, n in self._held.items()},
+            pedals=dict(self._pedals),
+        )
+
+    def held_keys(self) -> List[int]:
+        return sorted(n.key for n in self._held.values())
+
+    # --- execution ------------------------------------------------------
+
+    def execute(self, action: Action) -> None:
+        """Apply ``action`` or raise :class:`PhysicalError` if impossible."""
+        if action.kind == "wait":
+            if action.duration_ms < 0:
+                raise PhysicalError("wait duration must be non-negative")
+            self.now_ms += action.duration_ms
+            self.events.append((self.now_ms, action))
+            return
+
+        if action.kind == "press":
+            self._press(action)
+        elif action.kind == "release":
+            self._release(action)
+        elif action.kind == "pedal":
+            self._pedal(action)
+        else:  # pragma: no cover - dataclass Literal enforces this
+            raise PhysicalError(f"unknown action kind: {action.kind!r}")
+        self.events.append((self.now_ms, action))
+
+    # --- internal -------------------------------------------------------
+
+    def _press(self, action: Action) -> None:
+        finger = action.finger
+        key = action.key
+        if finger not in ALL_FINGERS:
+            raise PhysicalError(f"unknown finger {finger!r}")
+        if key is None or not (MIN_KEY <= key <= MAX_KEY):
+            raise PhysicalError(f"key {key} outside piano range {MIN_KEY}-{MAX_KEY}")
+        if not (1 <= action.velocity <= 127):
+            raise PhysicalError(f"velocity {action.velocity} outside MIDI range 1-127")
+        if finger in self._held:
+            raise PhysicalError(f"finger {finger} is already pressing a key")
+        if len(self._held) >= 10:
+            raise PhysicalError("all 10 fingers are already pressing keys")
+        last_release = self._last_release_ms.get(finger)
+        if last_release is not None and self.now_ms - last_release < MIN_FINGER_REUSE_MS:
+            raise PhysicalError(
+                f"finger {finger} needs {MIN_FINGER_REUSE_MS} ms rest before reuse "
+                f"(only {self.now_ms - last_release} ms since release)"
+            )
+
+        # Hand-span check: pretend the press has happened, then verify the
+        # owning hand's keys still fit inside MAX_HAND_SPAN.
+        owning_hand = LEFT_FINGERS if finger in LEFT_FINGERS else RIGHT_FINGERS
+        hand_keys = [n.key for f, n in self._held.items() if f in owning_hand] + [key]
+        if max(hand_keys) - min(hand_keys) > MAX_HAND_SPAN:
+            raise PhysicalError(
+                f"{('left' if finger in LEFT_FINGERS else 'right')} hand span "
+                f"{max(hand_keys) - min(hand_keys)} > {MAX_HAND_SPAN} semitones"
+            )
+
+        self._held[finger] = _HeldNote(finger=finger, key=key, velocity=action.velocity, pressed_at_ms=self.now_ms)
+
+    def _release(self, action: Action) -> None:
+        finger = action.finger
+        if finger not in ALL_FINGERS:
+            raise PhysicalError(f"unknown finger {finger!r}")
+        if finger not in self._held:
+            raise PhysicalError(f"finger {finger} is not pressing any key")
+        del self._held[finger]
+        self._last_release_ms[finger] = self.now_ms
+
+    def _pedal(self, action: Action) -> None:
+        if action.pedal not in PEDALS:
+            raise PhysicalError(f"unknown pedal {action.pedal!r}")
+        if not (0.0 <= action.pedal_value <= 1.0):
+            raise PhysicalError(f"pedal value {action.pedal_value} outside 0.0-1.0")
+        self._pedals[action.pedal] = action.pedal_value

--- a/tests/test_pianist.py
+++ b/tests/test_pianist.py
@@ -1,0 +1,172 @@
+"""Tests for the mechanical pianist: physical constraints and operators."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from pianist import (
+    Action,
+    CloudOperator,
+    HumanOperator,
+    MarkovOperator,
+    PhysicalError,
+    Pianist,
+)
+from pianist.__main__ import run
+
+# ---------------------------------------------------------------------------
+# Physical constraints
+# ---------------------------------------------------------------------------
+
+
+def test_press_and_release_round_trip():
+    p = Pianist()
+    p.execute(Action(kind="press", finger="R3", key=60, velocity=80))
+    assert p.held_keys() == [60]
+    p.execute(Action(kind="release", finger="R3"))
+    assert p.held_keys() == []
+
+
+def test_finger_cannot_press_twice():
+    p = Pianist()
+    p.execute(Action(kind="press", finger="R3", key=60))
+    with pytest.raises(PhysicalError, match="already pressing"):
+        p.execute(Action(kind="press", finger="R3", key=64))
+
+
+def test_release_unpressed_finger_rejected():
+    p = Pianist()
+    with pytest.raises(PhysicalError, match="not pressing"):
+        p.execute(Action(kind="release", finger="L1"))
+
+
+def test_eleventh_finger_rejected():
+    p = Pianist()
+    for i, finger in enumerate(("L1", "L2", "L3", "L4", "L5", "R1", "R2", "R3", "R4", "R5")):
+        p.execute(Action(kind="press", finger=finger, key=40 + i))
+    with pytest.raises(PhysicalError, match="unknown finger"):
+        p.execute(Action(kind="press", finger="X1", key=80))
+
+
+def test_hand_span_rejected_when_too_wide():
+    p = Pianist()
+    p.execute(Action(kind="press", finger="R1", key=60))
+    with pytest.raises(PhysicalError, match="hand span"):
+        p.execute(Action(kind="press", finger="R5", key=80))  # span 20 > 14
+
+
+def test_hand_span_allows_octave_plus():
+    p = Pianist()
+    p.execute(Action(kind="press", finger="R1", key=60))
+    # Span 14 (C4 to D5) is the documented allowed maximum.
+    p.execute(Action(kind="press", finger="R5", key=74))
+    assert p.held_keys() == [60, 74]
+
+
+def test_finger_reuse_requires_rest():
+    p = Pianist()
+    p.execute(Action(kind="press", finger="R3", key=60))
+    p.execute(Action(kind="release", finger="R3"))
+    # Same tick: must reject reuse.
+    with pytest.raises(PhysicalError, match="rest before reuse"):
+        p.execute(Action(kind="press", finger="R3", key=62))
+
+
+def test_finger_reuse_after_wait_succeeds():
+    p = Pianist()
+    p.execute(Action(kind="press", finger="R3", key=60))
+    p.execute(Action(kind="release", finger="R3"))
+    p.execute(Action(kind="wait", duration_ms=20))
+    p.execute(Action(kind="press", finger="R3", key=62))
+    assert p.held_keys() == [62]
+
+
+def test_key_outside_range_rejected():
+    p = Pianist()
+    with pytest.raises(PhysicalError, match="outside piano range"):
+        p.execute(Action(kind="press", finger="R3", key=200))
+
+
+def test_velocity_bounds_enforced():
+    p = Pianist()
+    with pytest.raises(PhysicalError, match="velocity"):
+        p.execute(Action(kind="press", finger="R3", key=60, velocity=0))
+
+
+def test_pedal_value_bounds_enforced():
+    p = Pianist()
+    with pytest.raises(PhysicalError, match="pedal value"):
+        p.execute(Action(kind="pedal", pedal="sustain", pedal_value=2.0))
+
+
+def test_wait_advances_clock():
+    p = Pianist()
+    p.execute(Action(kind="wait", duration_ms=500))
+    assert p.now_ms == 500
+
+
+# ---------------------------------------------------------------------------
+# Operators
+# ---------------------------------------------------------------------------
+
+
+def test_human_operator_parses_press_release_pedal_wait():
+    commands = io.StringIO("press R3 60 90\nwait 100\nrelease R3\npedal sustain 1.0\nstop\n")
+    op = HumanOperator(lines=iter(commands))
+    p = Pianist()
+    run(op, p, out_stream=None)
+    # Expect: press, wait, release, pedal -> 4 events recorded (stop ends loop).
+    kinds = [a.kind for _, a in p.events]
+    assert kinds == ["press", "wait", "release", "pedal"]
+    assert p.now_ms == 100
+    assert p.state().pedals["sustain"] == 1.0
+
+
+def test_human_operator_skips_blank_and_comment_lines():
+    commands = io.StringIO("\n# this is a comment\npress L3 40\nstop\n")
+    op = HumanOperator(lines=iter(commands))
+    p = Pianist()
+    run(op, p, out_stream=None)
+    assert [a.kind for _, a in p.events] == ["press"]
+
+
+def test_markov_operator_plays_within_constraints():
+    op = MarkovOperator(seed=42, bars=2, bar_ms=800)
+    p = Pianist()
+    run(op, p, out_stream=None)
+    assert p.events, "markov operator should produce events"
+    assert p.now_ms > 0
+    # By the end of a bar all fingers should be released.
+    assert p.held_keys() == []
+
+
+def test_markov_operator_deterministic_with_seed():
+    p1 = Pianist()
+    p2 = Pianist()
+    run(MarkovOperator(seed=7, bars=1), p1, out_stream=None)
+    run(MarkovOperator(seed=7, bars=1), p2, out_stream=None)
+    assert [a.kind for _, a in p1.events] == [a.kind for _, a in p2.events]
+    assert p1.now_ms == p2.now_ms
+
+
+def test_cloud_operator_falls_back_to_markov_without_api_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    op = CloudOperator()
+    p = Pianist()
+    run(op, p, out_stream=None)
+    assert p.events, "cloud operator should fall back to Markov when no key is set"
+
+
+def test_cloud_operator_uses_custom_responder():
+    replies = iter(["press R3 60 80", "wait 50", "release R3", "stop"])
+
+    def responder(prompt, state):
+        return next(replies, None)
+
+    op = CloudOperator(responder=responder)
+    p = Pianist()
+    run(op, p, out_stream=None)
+    assert [a.kind for _, a in p.events] == ["press", "wait", "release"]


### PR DESCRIPTION
Relands the self-contained `src/pianist/` module from #2122, which is being closed as superseded (781 commits behind main; its headline PQC iteration-cap fix already landed on main; the 20k-line diff was mostly stale-base noise).

This is the one unique, code-clean piece — extracted to a fresh branch off **current main** to avoid the stale-base regression risk of conflict-resolving #2122.

## Module
Mechanical piano model: 88 keys, 3 pedals, 10 fingers across 2 hands, hand-span ≤ 14 semitones, finger-reuse cooldown — enforced via `PhysicalError` regardless of operator. Swappable operators: `HumanOperator`, `MarkovOperator` (local, deterministic), `CloudOperator` (Markov fallback). CLI: `python -m pianist --operator markov|human|cloud`, JSONL event log.

## Verification (on current main)
- `tests/test_pianist.py` — **18/18 pass**
- `black --check --line-length 120` — clean
- `flake8 --max-line-length 120` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)