### PR TITLE
fix(ci): claude-review uses merge-base, not raw base SHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,16 +29,25 @@ jobs:
           git cat-file -e "${base}^{commit}" || git fetch --no-tags --prune origin "${{ github.event.pull_request.base.ref }}"
           git cat-file -e "${head}^{commit}" || git fetch --no-tags --prune origin "pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-${{ github.event.pull_request.number }}"
 
+          # Compare against the merge-base, not the raw base SHA. base.sha
+          # advances with the base branch (e.g. on `synchronize`); if main moves
+          # ahead of the branch's actual fork point, `git diff base head` lights
+          # up with files the PR never touched — including whitespace flagged
+          # by `--check`. The merge-base restricts the gate to what the PR
+          # genuinely contributed.
+          range_base="$(git merge-base "$base" "$head")"
+
           echo "## Local deterministic review gate" >> "$GITHUB_STEP_SUMMARY"
           echo >> "$GITHUB_STEP_SUMMARY"
           echo "- External AI invoked: no" >> "$GITHUB_STEP_SUMMARY"
           echo "- Repository comment written: no" >> "$GITHUB_STEP_SUMMARY"
           echo "- Base: \`${base}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Head: \`${head}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Merge-base: \`${range_base}\`" >> "$GITHUB_STEP_SUMMARY"
           echo >> "$GITHUB_STEP_SUMMARY"
 
-          git diff --check "$base" "$head"
-          git diff --name-only "$base" "$head" > changed-files.txt
+          git diff --check "$range_base" "$head"
+          git diff --name-only "$range_base" "$head" > changed-files.txt
 
           if git grep -nE '^(<<<<<<<|>>>>>>>)' -- \
             ':!node_modules/**' \


### PR DESCRIPTION
## Diagnosis

The "Claude Code Review" deterministic gate runs:

```bash
git diff --check "$base" "$head"
```

where `$base = github.event.pull_request.base.sha` — the tip of the base branch at the time of the push event. When `main` moves forward between PR creation and a `synchronize` event, `base.sha` advances ahead of the branch's actual fork point. The diff then includes **every file that landed on main in the interim**, and `--check` flags any whitespace in those (unrelated) additions as if the PR introduced them.

## Concrete case: PR #2157

`port/optical-grounding` actually touches only `src/physics_sim/optical_transistor.py` and its test. But its claude-review run (`27290223566`) failed with **3,860 lines** of whitespace warnings across `scripts/training/generate_agentic_sft.py`, `scripts/training/ingest_open_datasets.py`, `docs/legal/patent-workbench/...md`, etc.

What happened: PR #2129 (a sweeping lint cleanup, `scripts/agents lint 3,574 → 0`) landed on main between when `port/optical-grounding` forked (`af43ea612`) and when its `base.sha` was last recorded (`5b8069134`). So `git diff 5b8069134 5bedfd27d` showed the branch as "regressing" the cleanup — every whitespace fix on main looked like a new whitespace error on the branch.

## Fix

One line: anchor the diff at `git merge-base "$base" "$head"` instead of raw `$base`. Replayed against PR #2157:

| | Old logic | New logic |
|---|---|---|
| Whitespace lines flagged | 3,860 | **0** |
| Files in `changed-files.txt` | many irrelevant | the 2 files the PR actually changed |

## Verification
- YAML parses cleanly
- Replayed against the failing run locally — `--check` is empty, `--name-only` returns exactly the two PR files
- Comment in the workflow explains why merge-base is correct

https://claude.ai/code/session_01T8zrRfQbAES9sTwE5kj32k

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8zrRfQbAES9sTwE5kj32k)_