### PR TITLE
fix(agent-bus): schema-gate the training perf reader + cover gating logic

### DIFF
--- a/agents/agent_bus_training.py
+++ b/agents/agent_bus_training.py
@@ -172,10 +172,19 @@ class TrainingTrigger:
         except OSError as exc:
             logger.warning("could not read %s: %s", self.events_log, exc)
             return []
+        # Schema-gate like the replay reader (agent_bus_replay.replay_log): skip
+        # events the validator rejects — e.g. a future major-version payload whose
+        # shape we don't understand — so an incompatible record can't silently
+        # skew the perf window that drives autonomous training.
+        from agents.agent_bus_schema import validate_event
+
         out: List[Dict[str, Any]] = []
         for line in lines[-n:]:
             try:
-                out.append(json.loads(line))
+                rec = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            if not validate_event(rec).ok:
+                continue
+            out.append(rec)
         return out

--- a/tests/agents/test_agent_bus_schema.py
+++ b/tests/agents/test_agent_bus_schema.py
@@ -1,0 +1,166 @@
+"""Tests for agent bus event schema versioning + reader gating.
+
+Covers agents/agent_bus_schema.py (validate_event / validate_log / parse_version)
+and the training reader's schema gate (agent_bus_training.TrainingTrigger), which
+must skip events the validator rejects so an incompatible payload can't skew the
+perf window that drives autonomous training.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agents.agent_bus_schema import (
+    CURRENT_SCHEMA_VERSION,
+    MIGRATIONS,
+    parse_version,
+    validate_event,
+    validate_log,
+)
+
+
+def _v1_event(**overrides):
+    """A minimal, valid current-version event."""
+    event = {
+        "task_type": "ask",
+        "query": "hello",
+        "timestamp": "2026-06-10T00:00:00Z",
+        "success": True,
+        "_schema_version": CURRENT_SCHEMA_VERSION,
+    }
+    event.update(overrides)
+    return event
+
+
+# ── parse_version ───────────────────────────────────────────────────────────
+
+
+def test_parse_version_splits_semver():
+    assert parse_version("1.2.3") == (1, 2, 3)
+    assert parse_version(" 10.0.4 ") == (10, 0, 4)
+
+
+def test_parse_version_rejects_garbage():
+    with pytest.raises(ValueError):
+        parse_version("1.0")
+    with pytest.raises(ValueError):
+        parse_version("not.a.version")
+
+
+# ── validate_event ───────────────────────────────────────────────────────────
+
+
+def test_valid_current_event_accepted():
+    result = validate_event(_v1_event())
+    assert result.ok is True
+    assert result.version == CURRENT_SCHEMA_VERSION
+    assert result.migrated is False
+
+
+def test_missing_version_treated_as_current():
+    event = _v1_event()
+    del event["_schema_version"]
+    result = validate_event(event)
+    assert result.ok is True
+    assert result.version == CURRENT_SCHEMA_VERSION
+
+
+def test_future_major_version_rejected():
+    result = validate_event(_v1_event(_schema_version="2.0.0"))
+    assert result.ok is False
+    assert "future major version" in (result.reason or "")
+
+
+def test_older_major_without_migration_rejected():
+    result = validate_event(_v1_event(_schema_version="0.9.0"))
+    assert result.ok is False
+    assert "no migration registered" in (result.reason or "")
+
+
+def test_older_major_with_registered_migration_accepted(monkeypatch):
+    calls = {}
+
+    def _migrate(record):
+        calls["ran"] = True
+        return record
+
+    monkeypatch.setitem(MIGRATIONS, "0.9.0", _migrate)
+    result = validate_event(_v1_event(_schema_version="0.9.0"))
+    assert result.ok is True
+    assert result.migrated is True
+    assert calls.get("ran") is True
+
+
+def test_newer_minor_accepted_with_warning():
+    result = validate_event(_v1_event(_schema_version="1.99.0"))
+    assert result.ok is True
+    assert "newer minor version" in (result.reason or "")
+
+
+def test_unparseable_version_rejected():
+    result = validate_event(_v1_event(_schema_version="banana"))
+    assert result.ok is False
+    assert "unparseable version" in (result.reason or "")
+
+
+def test_missing_required_v1_field_rejected():
+    event = _v1_event()
+    del event["success"]
+    result = validate_event(event)
+    assert result.ok is False
+    assert "missing required v1 fields" in (result.reason or "")
+    assert "success" in (result.reason or "")
+
+
+# ── validate_log ──────────────────────────────────────────────────────────────
+
+
+def test_validate_log_counts_accept_reject_warn(tmp_path):
+    log = tmp_path / "events.jsonl"
+    lines = [
+        json.dumps(_v1_event()),  # accepted
+        json.dumps(_v1_event(_schema_version="1.99.0")),  # accepted + warning
+        json.dumps(_v1_event(_schema_version="2.0.0")),  # rejected (future major)
+        "{not valid json",  # rejected (bad JSON)
+        "",  # blank, skipped
+    ]
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    report = validate_log(log)
+    assert report.accepted == 2
+    assert report.rejected == 2
+    assert report.warnings == 1
+    assert len(report.rejections) == 2
+    assert report.version_counts.get(CURRENT_SCHEMA_VERSION) == 1
+
+
+def test_validate_log_missing_file_is_empty_report(tmp_path):
+    report = validate_log(tmp_path / "does_not_exist.jsonl")
+    assert report.total == 0
+    assert report.accepted == 0
+    assert report.rejected == 0
+
+
+# ── training reader gate (the fix) ───────────────────────────────────────────
+
+
+def test_training_reader_skips_incompatible_events(tmp_path):
+    from agents.agent_bus_training import TrainingTrigger
+
+    log = tmp_path / "events.jsonl"
+    lines = [
+        json.dumps(_v1_event(success=True)),
+        json.dumps(_v1_event(success=False)),
+        json.dumps(_v1_event(success=True)),
+        # future major version — must NOT be counted in the perf window
+        json.dumps(_v1_event(_schema_version="2.0.0", success=False)),
+    ]
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    perf = TrainingTrigger(events_log=log).measure()
+    assert perf is not None
+    assert perf.total == 3  # the 2.0.0 event was gated out
+    assert perf.successes == 2
+    assert perf.failures == 1


### PR DESCRIPTION
## What

Closes the one genuinely-actionable gap from the archived agent-bus roadmap (`docs/archive/agent_bus_notes.md`, Tier 1: *"schema versioning not enforced on read"*).

The replay reader (`agent_bus_replay.replay_log`) already validates every event and skips rejected ones. But the **training trigger's** `_tail_events` read its perf window **raw** — JSON-parsing lines and skipping only decode errors, never calling `validate_event`. So a future major-version event (a payload shape the reader doesn't understand) would still be counted toward the success-rate window that decides whether to fire an **autonomous training run**.

## Changes

- **`agents/agent_bus_training.py`** — `_tail_events` now gates on `validate_event` like the replay reader, skipping events the validator rejects. Mirrors the established pattern exactly; local import avoids a load-time cycle.
- **`tests/agents/test_agent_bus_schema.py`** (new, 13 tests) — the gating logic in `agent_bus_schema.py` had **no dedicated unit coverage**. Now covered: `parse_version` happy/garbage paths, future-major rejection, older-major migration (both registered and missing), newer-minor warn-accept, unparseable version, missing required v1 fields, `validate_log` accept/reject/warn tallies + bad-JSON handling, and a regression test proving the training reader excludes an incompatible event from the perf window.

## Safety / scope

- **No change** to the on-disk event format or the writer. Current `1.0.0` events validate unchanged.
- Existing reader tests (`test_agent_workcell_demo`, `test_mirror_room_agent_bus`) still pass.
- flake8 + black clean on both files.

## Verification
- `tests/agents/test_agent_bus_schema.py` → 13 passed
- `tests/system/test_agent_workcell_demo.py` + `tests/test_mirror_room_agent_bus.py` → 10 passed
- `flake8 --max-line-length 120` + `black --check` → clean

https://claude.ai/code/session_011MgY4vDsmDRTTpEfhSnxyv

---
_Generated by [Claude Code](https://claude.ai/code/session_011MgY4vDsmDRTTpEfhSnxyv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened event validation in the training system to filter out incompatible or malformed events, preventing them from affecting training performance metrics.

* **Tests**
  * Added comprehensive test coverage for schema validation, event versioning, and training system robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->