### PR TITLE
ci(security): least-privilege GITHUB_TOKEN permissions across 13 workflows

### DIFF
--- a/.github/workflows/agent-bus-auto-format.yml
+++ b/.github/workflows/agent-bus-auto-format.yml
@@ -12,6 +12,9 @@ defaults:
   run:
     working-directory: packages/agent-bus
 
+permissions:
+  contents: write
+
 jobs:
   auto-format:
     if: ${{ github.actor != 'github-actions[bot]' }}

--- a/.github/workflows/agent-bus-format-check.yml
+++ b/.github/workflows/agent-bus-format-check.yml
@@ -16,6 +16,9 @@ defaults:
   run:
     working-directory: packages/agent-bus
 
+permissions:
+  contents: read
+
 jobs:
   prettier:
     runs-on: ubuntu-latest

--- a/.github/workflows/agent-bus-lint-and-test.yml
+++ b/.github/workflows/agent-bus-lint-and-test.yml
@@ -16,6 +16,9 @@ defaults:
   run:
     working-directory: packages/agent-bus
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   update-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-prism-parity.yml
+++ b/.github/workflows/code-prism-parity.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/code-prism-parity.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   parity:
     runs-on: ubuntu-latest

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,6 +6,11 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   greeting:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -28,6 +28,9 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   manual-task:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-ops.yml
+++ b/.github/workflows/nightly-ops.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+permissions:
+  contents: read
+
 jobs:
   orchestrate:
     runs-on: ubuntu-latest

--- a/.github/workflows/research-feed.yml
+++ b/.github/workflows/research-feed.yml
@@ -8,6 +8,10 @@ on:
       - "scripts/system/generate_research_feed.py"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   generate:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/swe-local-benchmark.yml
+++ b/.github/workflows/swe-local-benchmark.yml
@@ -11,6 +11,9 @@ on:
       - 'tests/benchmark/test_swe_local_benchmark.py'
       - 'package.json'
 
+permissions:
+  contents: read
+
 jobs:
   swe-local:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Security review of `main` found the dependency surface clean (0 vulns across all npm packages + Python after #2127), no leaked secrets (the tracked `.secrets_vault.json` holds only SHA fingerprints; `config.env` is empty placeholders), and no injection sinks (every `eval`/`exec`/`shell` hit is the governance gate's own *defensive* denylist). The one real, bounded security gap was **GitHub Actions token scope**.

13 of 75 workflows ran with the repository's **default `GITHUB_TOKEN` permissions** (no explicit `permissions:` block) — the over-broad-token supply-chain risk OpenSSF Scorecard flags. This adds a **least-privilege** top-level block to each, scoped to exactly what the workflow does:

| Scope | Workflows |
|---|---|
| `contents: read` | format-check, lint-and-test, code-prism-parity, manual (echo-only), nightly-ops, swe-local-benchmark |
| `contents: write` | agent-bus-auto-format, auto-changelog (both `git push`) |
| `issues: write` + `pull-requests: write` | stale (`actions/stale`) |
| `issues: write` | issue-triage (`github-script`, issues.* only) |
| `contents: read` + `pull-requests: write` | labeler (`actions/labeler`) |
| `contents: read` + `issues`/`PR: write` | greetings (`first-interaction`) |
| `contents: write` + `pull-requests: write` | research-feed (`peter-evans/create-pull-request`) |

Each scope was derived by reading what the workflow actually invokes (git push, `gh`/github-script calls, SARIF upload, marketplace actions), not guessed — so nothing is under-scoped and breaks.

## Left as-is
`codeql.yml` and `eslint.yml` already declare **job-level** `permissions:` (`security-events: write`) — the standard template, correct, untouched.

## Verification
- All 75 workflows still parse as valid YAML (checked with PyYAML).
- 73/75 now carry a top-level block; the other 2 are the job-level-scoped pair above → every workflow's token is now explicitly scoped.

https://claude.ai/code/session_011MgY4vDsmDRTTpEfhSnxyv

---
_Generated by [Claude Code](https://claude.ai/code/session_011MgY4vDsmDRTTpEfhSnxyv)_