### PR TITLE
feat: session work — /clean cmd, prime-vibration experiment, agent-bus cost, geoseal hardening, roadmap

### DIFF
--- a/.claude/commands/clean.md
+++ b/.claude/commands/clean.md
@@ -1,0 +1,36 @@
+---
+name: clean
+description: 'Safely clean repo artifacts: dry-run first, targeted deletes only, never tracked files'
+argument-hint: '[deep]'
+allowed-tools: Bash(git clean:*), Bash(git status:*), Bash(npm run clean:*), Bash(rm -rf .benchmarks:*), Bash(rm -rf .pytest_cache:*), Bash(rm -rf coverage:*), Bash(rm -rf htmlcov:*), Bash(rm -rf dist-gateway:*), Bash(find . -name __pycache__:*)
+---
+
+## Context (live dry-run)
+
+- Untracked files git would remove: !`git clean -nd`
+- Working tree status: !`git status --short`
+
+## Task
+
+Clean the repository working tree, safety-first. Arguments: `$ARGUMENTS`
+
+### Rules (non-negotiable)
+
+1. **Targeted deletes only.** Remove ONLY these known artifact paths if present:
+   - `.benchmarks/` (pytest-benchmark)
+   - `__pycache__/` dirs and `.pytest_cache/`
+   - `coverage/`, `htmlcov/`, `.coverage`, `coverage.json`
+   - `dist/` — via the existing `npm run clean` script, not rm
+   - `dist-gateway/`
+   - `*.log` files at repo root (NOT `config/tor/tor.log` paths inside tracked config)
+2. **NEVER run blanket `git clean -fd` or `git clean -fdx`.** That would delete
+   `node_modules/`, `.env`, local configs, and any in-progress untracked work.
+3. **Protect in-progress work.** If the dry-run above lists untracked files that are
+   not on the artifact list (source files, docs, notes), list them and ASK before
+   touching anything — default is leave them alone.
+4. **`deep` argument** (`$ARGUMENTS` contains `deep`): additionally clear
+   `node_modules/.cache/`, `.ruff_cache/`, and stale `*.tsbuildinfo` files.
+5. **Report.** End with exactly what was deleted (paths + approximate space freed)
+   and what was intentionally left alone.
+
+If the dry-run shows nothing removable, say so and stop — do not invent work.

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Thumbs.db
 *.egg-info/
 .pytest_cache/
 .mypy_cache/
+.benchmarks/
 
 # Test temp artifacts
 artifacts/pytest_tmp/

--- a/agents/agent_bus.py
+++ b/agents/agent_bus.py
@@ -49,6 +49,7 @@ BUS_LOG = Path("artifacts/agent-bus/events.jsonl")
 # Re-export the canonical schema version from the dedicated module so callers
 # see the single source of truth, even when importing from agent_bus directly.
 from agents.agent_bus_schema import CURRENT_SCHEMA_VERSION as SCHEMA_VERSION  # noqa: E402
+from agents.agent_bus_cost import CostMeter  # noqa: E402
 
 RETRY_BASE_SECONDS = 1.0
 RETRY_MAX_ATTEMPTS = 5
@@ -170,6 +171,7 @@ class BusEvent:
     llm_model: str = ""
     tokens_in: int = 0
     tokens_out: int = 0
+    cost_usd: float = 0.0
     duration_seconds: float = 0
     success: bool = True
     error: Optional[str] = None
@@ -200,6 +202,7 @@ class AgentBus:
         agent_id: str = "agent-bus-default",
         sign_events: bool = True,
         write_to_ledger: bool = True,
+        budget_usd: float = 0.0,
     ) -> None:
         self.hf_model = hf_model
         self.ollama_model = ollama_model
@@ -209,6 +212,8 @@ class AgentBus:
         self.agent_id = agent_id
         self.sign_events = sign_events
         self.write_to_ledger = write_to_ledger
+        # Session cost meter; budget_usd == 0 keeps the historical unbounded behavior.
+        self.cost = CostMeter(budget_usd=budget_usd)
 
         self._runtime = None
         self._scraper = None
@@ -324,6 +329,7 @@ class AgentBus:
         event.llm_model = answer["model"]
         event.tokens_in = int(answer.get("tokens_in", 0) or 0)
         event.tokens_out = int(answer.get("tokens_out", 0) or 0)
+        event.cost_usd = float(answer.get("cost_usd", 0.0) or 0.0)
         event.duration_seconds = time.monotonic() - start
         event.success = not answer.get("error")
         event.error = answer.get("error")
@@ -338,6 +344,7 @@ class AgentBus:
             "model": answer["model"],
             "tokens_in": event.tokens_in,
             "tokens_out": event.tokens_out,
+            "cost_usd": event.cost_usd,
             "duration_seconds": round(event.duration_seconds, 1),
         }
 
@@ -378,6 +385,7 @@ class AgentBus:
         event.llm_model = answer["model"]
         event.tokens_in = int(answer.get("tokens_in", 0) or 0)
         event.tokens_out = int(answer.get("tokens_out", 0) or 0)
+        event.cost_usd = float(answer.get("cost_usd", 0.0) or 0.0)
         event.duration_seconds = time.monotonic() - start
         event.breaker_state = self._breaker_snapshot()
         self._log_event(event)
@@ -391,6 +399,7 @@ class AgentBus:
             "provider": answer["provider"],
             "tokens_in": event.tokens_in,
             "tokens_out": event.tokens_out,
+            "cost_usd": event.cost_usd,
             "duration_seconds": round(event.duration_seconds, 1),
         }
 
@@ -426,6 +435,7 @@ class AgentBus:
         event.llm_model = answer["model"]
         event.tokens_in = int(answer.get("tokens_in", 0) or 0)
         event.tokens_out = int(answer.get("tokens_out", 0) or 0)
+        event.cost_usd = float(answer.get("cost_usd", 0.0) or 0.0)
         event.duration_seconds = time.monotonic() - start
         event.breaker_state = self._breaker_snapshot()
         self._log_event(event)
@@ -441,6 +451,7 @@ class AgentBus:
             "provider": answer["provider"],
             "tokens_in": event.tokens_in,
             "tokens_out": event.tokens_out,
+            "cost_usd": event.cost_usd,
         }
 
     async def monitor(self, urls: List[str]) -> Dict[str, Any]:
@@ -627,31 +638,48 @@ class AgentBus:
         Generate text using free LLMs.
 
         Priority: Ollama (local) → HuggingFace (free API) → Offline fallback
+
+        Budget-gated: once the session cost meter reaches the configured
+        budget, no further provider calls are made and a budget_exceeded
+        result is returned (logged like any other failed event).
         """
+        if self.cost.exceeded:
+            return {
+                "text": "[budget exceeded — no LLM call made]",
+                "provider": "budget",
+                "model": "none",
+                "cost_usd": 0.0,
+                "error": (f"budget_exceeded: spent ${self.cost.spent_usd:.4f} of ${self.cost.budget_usd:.2f} budget"),
+            }
+
+        result: Optional[Dict[str, Any]] = None
         # Try Ollama first if prefer_local
         if self.prefer_local:
             result = await self._try_ollama(prompt)
-            if result:
-                return result
 
         # Try HuggingFace
-        result = await self._try_huggingface(prompt)
-        if result:
-            return result
+        if not result:
+            result = await self._try_huggingface(prompt)
 
         # Try Ollama as fallback if not preferred
-        if not self.prefer_local:
+        if not result and not self.prefer_local:
             result = await self._try_ollama(prompt)
-            if result:
-                return result
 
-        # Offline fallback
-        return {
-            "text": f"[LLM unavailable — raw context returned]\n\n{prompt[:2000]}",
-            "provider": "offline",
-            "model": "none",
-            "error": "No LLM provider available (set HF_TOKEN or run Ollama)",
-        }
+        if not result:
+            # Offline fallback
+            result = {
+                "text": f"[LLM unavailable — raw context returned]\n\n{prompt[:2000]}",
+                "provider": "offline",
+                "model": "none",
+                "error": "No LLM provider available (set HF_TOKEN or run Ollama)",
+            }
+
+        result["cost_usd"] = self.cost.charge(
+            result["provider"],
+            int(result.get("tokens_in", 0) or 0),
+            int(result.get("tokens_out", 0) or 0),
+        )
+        return result
 
     async def _try_ollama(self, prompt: str) -> Optional[Dict[str, Any]]:
         """Try Ollama local inference (async via httpx, retried, breaker-gated)."""

--- a/agents/agent_bus_cli.py
+++ b/agents/agent_bus_cli.py
@@ -31,7 +31,7 @@ def _parse_args() -> argparse.Namespace:
     run.add_argument("prompt")
     run.add_argument("--mode", choices=common_modes, default="headless")
     run.add_argument("--max-sources", type=int, default=3)
-    run.add_argument("--budget", type=float, default=0.0, help="Max USD-equivalent (0 = unbounded; advisory)")
+    run.add_argument("--budget", type=float, default=0.0, help="Max USD-equivalent (0 = unbounded; enforced)")
     run.add_argument("--no-search", action="store_true")
     run.add_argument("--agent-id", default="agent-bus-cli")
 
@@ -39,11 +39,13 @@ def _parse_args() -> argparse.Namespace:
     summ.add_argument("query")
     summ.add_argument("--mode", choices=common_modes, default="headless")
     summ.add_argument("--max-sources", type=int, default=5)
+    summ.add_argument("--budget", type=float, default=0.0, help="Max USD-equivalent (0 = unbounded; enforced)")
     summ.add_argument("--agent-id", default="agent-bus-cli")
 
     ana = sub.add_parser("analyze", help="Analyze a single page")
     ana.add_argument("url")
     ana.add_argument("--mode", choices=common_modes, default="headless")
+    ana.add_argument("--budget", type=float, default=0.0, help="Max USD-equivalent (0 = unbounded; enforced)")
     ana.add_argument("--agent-id", default="agent-bus-cli")
 
     sub.add_parser("perf", help="Show recent performance window")
@@ -77,7 +79,7 @@ def _parse_args() -> argparse.Namespace:
 async def _run(args: argparse.Namespace) -> Dict[str, Any]:
     from agents.agent_bus import AgentBus
 
-    bus = AgentBus(browser_mode=args.mode, agent_id=args.agent_id)
+    bus = AgentBus(browser_mode=args.mode, agent_id=args.agent_id, budget_usd=args.budget)
     await bus.start()
     try:
         result = await bus.ask(
@@ -85,6 +87,7 @@ async def _run(args: argparse.Namespace) -> Dict[str, Any]:
             search_first=not args.no_search,
             max_sources=args.max_sources,
         )
+        result["session_cost_usd"] = round(bus.cost.spent_usd, 6)
     finally:
         await bus.stop()
     return result
@@ -93,7 +96,7 @@ async def _run(args: argparse.Namespace) -> Dict[str, Any]:
 async def _summarize(args: argparse.Namespace) -> Dict[str, Any]:
     from agents.agent_bus import AgentBus
 
-    bus = AgentBus(browser_mode=args.mode, agent_id=args.agent_id)
+    bus = AgentBus(browser_mode=args.mode, agent_id=args.agent_id, budget_usd=args.budget)
     await bus.start()
     try:
         return await bus.search_and_summarize(args.query, max_sources=args.max_sources)
@@ -104,7 +107,7 @@ async def _summarize(args: argparse.Namespace) -> Dict[str, Any]:
 async def _analyze(args: argparse.Namespace) -> Dict[str, Any]:
     from agents.agent_bus import AgentBus
 
-    bus = AgentBus(browser_mode=args.mode, agent_id=args.agent_id)
+    bus = AgentBus(browser_mode=args.mode, agent_id=args.agent_id, budget_usd=args.budget)
     await bus.start()
     try:
         return await bus.analyze_page(args.url)

--- a/agents/agent_bus_cost.py
+++ b/agents/agent_bus_cost.py
@@ -1,0 +1,112 @@
+"""
+Agent Bus cost metering + budget enforcement.
+
+Closes the "cost tracking" gap from AGENT_BUS_NOTES.md: every LLM call is
+priced in USD-equivalent from per-provider token rates, accumulated on a
+session meter, and the `--budget` CLI flag becomes a hard gate instead of
+advisory. The bus's default providers (Ollama local, HuggingFace free
+serverless) price at $0.00 — the meter exists so paid endpoints can be
+dropped in without re-plumbing, and so events carry an auditable
+`cost_usd` field either way.
+
+Rates are overridable without code changes via the AGENT_BUS_RATES_JSON
+environment variable:
+
+    AGENT_BUS_RATES_JSON='{"huggingface": {"in": 0.30, "out": 1.20}}'
+
+where "in"/"out" are USD per 1k tokens.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+logger = logging.getLogger("scbe.agent_bus.cost")
+
+RATES_ENV_VAR = "AGENT_BUS_RATES_JSON"
+
+
+@dataclass(frozen=True)
+class ProviderRates:
+    """USD per 1k tokens, split by direction."""
+
+    usd_per_1k_in: float = 0.0
+    usd_per_1k_out: float = 0.0
+
+
+# The bus is free-tier by design (see agent_bus module docstring); rates are
+# zero until a paid provider is configured. Unknown providers also price at
+# zero rather than blocking — cost tracking must never take the bus down.
+DEFAULT_RATES: Dict[str, ProviderRates] = {
+    "ollama": ProviderRates(),
+    "huggingface": ProviderRates(),
+    "offline": ProviderRates(),
+}
+
+
+def load_rates(env: Optional[Dict[str, str]] = None) -> Dict[str, ProviderRates]:
+    """Build the rate table: defaults overlaid with AGENT_BUS_RATES_JSON.
+
+    Malformed JSON or entries are logged and skipped — never raises.
+    """
+    rates = dict(DEFAULT_RATES)
+    raw = (env if env is not None else os.environ).get(RATES_ENV_VAR)
+    if not raw:
+        return rates
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("%s is not valid JSON (%s); using default rates", RATES_ENV_VAR, exc)
+        return rates
+    if not isinstance(parsed, dict):
+        logger.warning("%s must be a JSON object; using default rates", RATES_ENV_VAR)
+        return rates
+    for provider, entry in parsed.items():
+        try:
+            rates[str(provider)] = ProviderRates(
+                usd_per_1k_in=float(entry.get("in", 0.0)),
+                usd_per_1k_out=float(entry.get("out", 0.0)),
+            )
+        except (AttributeError, TypeError, ValueError) as exc:
+            logger.warning("%s entry %r is malformed (%s); skipped", RATES_ENV_VAR, provider, exc)
+    return rates
+
+
+@dataclass
+class CostMeter:
+    """Session cost accumulator with an optional hard budget.
+
+    budget_usd == 0 means unbounded (the historical default), matching the
+    CLI's `--budget 0` semantics.
+    """
+
+    budget_usd: float = 0.0
+    rates: Dict[str, ProviderRates] = field(default_factory=load_rates)
+    spent_usd: float = 0.0
+
+    def price(self, provider: str, tokens_in: int, tokens_out: int) -> float:
+        """USD-equivalent price of one call. Unknown providers price at 0."""
+        r = self.rates.get(provider, ProviderRates())
+        return (tokens_in / 1000.0) * r.usd_per_1k_in + (tokens_out / 1000.0) * r.usd_per_1k_out
+
+    def charge(self, provider: str, tokens_in: int, tokens_out: int) -> float:
+        """Price one call, add it to the session total, and return the cost."""
+        cost = self.price(provider, tokens_in, tokens_out)
+        self.spent_usd += cost
+        return cost
+
+    @property
+    def exceeded(self) -> bool:
+        """True once spending has reached a nonzero budget."""
+        return self.budget_usd > 0 and self.spent_usd >= self.budget_usd
+
+    @property
+    def remaining_usd(self) -> Optional[float]:
+        """Budget headroom, or None when unbounded."""
+        if self.budget_usd <= 0:
+            return None
+        return max(0.0, self.budget_usd - self.spent_usd)

--- a/agents/agent_bus_replay.py
+++ b/agents/agent_bus_replay.py
@@ -93,6 +93,10 @@ def replay_log(
     durations = [float(e.get("duration_seconds", 0) or 0) for e in events]
     tokens_in = [int(e.get("tokens_in", 0) or 0) for e in events]
     tokens_out = [int(e.get("tokens_out", 0) or 0) for e in events]
+    # cost_usd is additive in schema 1.1.0; pre-1.1.0 events price at 0.
+    cost_by_provider: Dict[str, float] = defaultdict(float)
+    for e in events:
+        cost_by_provider[e.get("llm_provider") or "(none)"] += float(e.get("cost_usd", 0) or 0)
 
     by_provider = Counter(e.get("llm_provider") or "(none)" for e in events)
     by_task = Counter(e.get("task_type", "?") for e in events)
@@ -131,6 +135,10 @@ def replay_log(
             "in_total": sum(tokens_in),
             "out_total": sum(tokens_out),
             "out_per_event_mean": round(statistics.fmean(tokens_out), 1) if tokens_out else 0.0,
+        },
+        "cost_usd": {
+            "total": round(sum(cost_by_provider.values()), 6),
+            "by_provider": {p: round(c, 6) for p, c in cost_by_provider.items()},
         },
         "providers": dict(by_provider),
         "tasks": dict(by_task),

--- a/agents/agent_bus_schema.py
+++ b/agents/agent_bus_schema.py
@@ -11,9 +11,14 @@ Versioning rule (semver-ish):
   - MINOR bump = additive field. Old readers warn but proceed.
   - PATCH bump = doc-only. No validation impact.
 
-Today's events are all `1.0.0`. As we add fields (e.g., `cost_usd`, signed
-trace_id, etc.) we'll bump MINOR. If we ever rename or remove a required
-field we'll bump MAJOR and ship a migration.
+Version history:
+  - 1.0.0 — initial event shape.
+  - 1.1.0 — additive `cost_usd` field (USD-equivalent per call, see
+    agent_bus_cost). No migration needed: 1.0.0 events stay valid because
+    the field is optional and required fields are unchanged.
+
+If we ever rename or remove a required field we'll bump MAJOR and ship a
+migration.
 """
 
 from __future__ import annotations
@@ -26,15 +31,15 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("scbe.agent_bus.schema")
 
-CURRENT_SCHEMA_VERSION = "1.0.0"
+CURRENT_SCHEMA_VERSION = "1.1.0"
 
 # Required top-level fields for v1 events. The signing/audit fields are added
 # by the signer at log time — they're checked separately.
 V1_REQUIRED_FIELDS = ("task_type", "query", "timestamp", "success")
 
 # Migration registry. Maps "from_version" -> callable(record) -> migrated record.
-# Empty for now. When v1.1.0 lands we register an entry here so v1.0.0 events
-# round-trip cleanly into the new shape.
+# Empty: only MAJOR bumps need migrations. 1.0.0 → 1.1.0 was additive
+# (cost_usd is optional), so 1.0.0 events validate as-is.
 MIGRATIONS: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]]] = {}
 
 

--- a/docs/PRODUCTIZATION_ROADMAP.md
+++ b/docs/PRODUCTIZATION_ROADMAP.md
@@ -1,0 +1,105 @@
+# Productization Roadmap — SCBE-AETHERMOORE Subcomponents
+
+> Status: living document. Maturity claims below are grounded in the repo as of
+> June 2026 — file paths and test counts were verified by running the suites,
+> not estimated.
+
+## 1. The honest framing
+
+**A pre-revenue repository has no objective dollar valuation.** Value = market
+size × execution × traction, and traction is currently zero: Stripe is wired,
+packages are published (npm + PyPI v4.2.1), but there is no evidence of paying
+users. Patent-pending status, CAGE code, and SAM registration are *credibility
+signals* that shorten enterprise sales conversations — they are not revenue and
+no acquirer prices them as such.
+
+Two further honest constraints:
+
+- The repo is a hybrid of production code, research proposals, and
+  worldbuilding (by the README's own admission). The sellable surface is a
+  **subset**, and buyers will judge the subset, not the whole.
+- The hyperbolic-geometry / Sacred Tongues novelty is a **differentiator to
+  defend in a technical deep-dive, not the pitch**. The market category with
+  actual pull is *AI agent governance / guardrails* — a funded, named category
+  (Lakera, Protect AI, Robust Intelligence→Cisco, Guardrails AI, NVIDIA NeMo
+  Guardrails). Lead with the problem those buyers already have.
+
+## 2. Candidate inventory (verified)
+
+| Subsystem | What it does | Maturity (verified) | Market analog | Extractability |
+|---|---|---|---|---|
+| **Governance gate / 14-layer pipeline** | Deterministic ALLOW / QUARANTINE / ESCALATE / DENY decisions over agent behavior, with signed receipts | `src/harmonic/` (50+ files), npm export `scbe-aethermoore/harmonic`; L1–L6 tiered test suites | Guardrails AI, NeMo Guardrails, Lakera Guard | Medium — core is clean; needs a thin, zero-config wrapper |
+| **GeoSeal** | Geometric RAG immune system: quarantines adversarial/off-grammar retrievals via Poincaré-ball repulsion + phase discipline | `src/geoseal*.py` + TS ports; **303 tests passing across 8 suites** (v1, v2, routing, cursor, compass, operator-space, CLI); RAG integration (`src/geosealRAG.ts`); now deployment-tunable via `GeoSealConfig` | No direct analog — adjacent: RAG security filters (Lakera RAG, Protect AI) | **High — most self-contained mature piece in the repo** |
+| **Agent Bus** | Thin agent coordination spine: routed ops, ML-DSA-65–signed append-only audit log, schema-versioned events, replay/verify CLI, circuit breakers, cost metering + enforced budgets | `agents/agent_bus*.py` (10 modules + CLI); schema 1.1.0; 32 dedicated tests; notes file tracks Tier 1–4 queue | LangSmith/LangFuse (observability), AgentOps | Medium — depends on scraper/browser modules for full ops |
+| **code_prism** | Code analysis / IR emitter, multi-language | `src/code_prism/`, PyPI CLI `scbe-code-prism` | Semgrep-lite territory (crowded) | Medium |
+| **PQC crypto layer** | ML-KEM-768 / ML-DSA-65 envelopes, spiral seal | `src/crypto/`, npm export, liboqs-backed | Many (PQC libraries are commoditizing) | Low as standalone; high as *feature* of the above |
+| **Symphonic/audio, gacha, game, story systems** | Worldbuilding + research | Various | — | Not product candidates; keep out of the pitch |
+
+## 3. Top two candidates
+
+### #1 — "Signed-receipt guardrail" (governance gate, open-core)
+
+The wedge: **a drop-in guardrail that produces a cryptographically signed audit
+trail for every AI decision.** This is the dev-tool → compliance bridge: the
+same engine serves both buyers.
+
+- Free (MIT, drives adoption): local CLI + library — score/gate prompts and
+  outputs, deterministic decisions, local JSONL receipts. Zero config, one
+  `npx`/`pipx` command to first result.
+- Paid: hosted API, multi-tenant dashboard, **audit retention + receipt
+  verification service**, policy management, SSO, SLA. The compliance buyer
+  pays for retention and attestation, not for the math.
+- Differentiators to hold in reserve for deep-dives: deterministic decisions
+  (replayable — auditors care), PQC-signed receipts (ML-DSA-65 — quantum-safe
+  audit trail is a real procurement checkbox), exponential cost-scaling of
+  adversarial drift (the hyperbolic story, told last).
+
+### #2 — GeoSeal as a focused RAG-security dev tool
+
+Today's audit confirms GeoSeal is the **most extractable mature component**:
+dual-language, 300+ passing tests, self-contained math, a working RAG filter
+(`filterRetrievals`), and now per-deployment tuning. Position: "an immune
+system for your RAG pipeline — quarantines poisoned retrievals before they
+reach the context window." RAG poisoning is a named OWASP-LLM risk with no
+dominant tooling. Ship as its own small package (the `packages/sixtongues`
+pattern already exists for standalone extraction).
+
+## 4. Go-to-market for #1 (first 90 days)
+
+1. **Weeks 1–3 — harden the wedge.** Extract a single package with one
+   command: `scbe-gate check <input>` → decision + signed receipt. No config
+   required, sane defaults. Kill every import that drags in worldbuilding.
+2. **Weeks 3–5 — proof page.** A public benchmark page: detection rates on
+   known prompt-injection corpora vs. NeMo Guardrails / Guardrails AI, plus
+   "what a signed receipt proves" one-pager. Honest numbers or no page.
+3. **Weeks 5–7 — launch.** Show HN / Product Hunt / r/LocalLLaMA with the
+   receipt story. Instrument the CLI (opt-in telemetry) to find the retention
+   curve.
+4. **Weeks 7–13 — convert.** 3–5 design partners from inbound (target: teams
+   shipping agents under SOC 2 / EU AI Act pressure). Their audit-retention
+   needs define the first paid tier.
+
+**Pricing model (shape, not numbers):** usage-based API tier (per-decision),
+seat-based dashboard, enterprise tier keyed to **audit retention duration +
+attestation**. Compliance buyers anchor on retention; that's the line item.
+
+## 5. Hardening gaps (from the verified state)
+
+- **Governance gate**: no standalone package yet (the npm export drags the
+  full module graph); no zero-config entrypoint; benchmark corpus runs are
+  ad-hoc rather than a published page.
+- **GeoSeal**: TS/Python parity is manual (config dataclass exists in Python
+  only as of this week — mirror `GeoSealConfig` into `geoseal.ts`); the RAG
+  filter needs an `embedFn` failure path (currently uncaught).
+- **Agent bus**: budget gate only bites once paid rates are configured;
+  ledger HMAC (not PQC) under the signed events; browser-module coupling
+  blocks slim extraction.
+- **Repo-level**: a public-facing repo split (or aggressive README surgery)
+  so a buyer's first 10 minutes land on the product subset, not the cosmology.
+
+## 6. What this document deliberately does not do
+
+- Invent a valuation figure.
+- Lead with hyperbolic geometry, Sacred Tongues, or lore as the pitch.
+- Treat patent filings, CAGE, or SAM as traction.
+- Recommend the government/defense channel for this pass (per scope decision).

--- a/docs/archive/agent_bus_notes.md
+++ b/docs/archive/agent_bus_notes.md
@@ -31,7 +31,7 @@ This file documents what is in place and what is staged for later work.
 
 ### Tier 1 — needed for production / NASA-SpaceX bar
 
-- [ ] **Schema versioning enforcement** — `_schema_version` is written, but the reader currently doesn't gate on it. Add a migration table and reject events with unknown future versions.
+- [x] **Schema versioning enforcement** — done: `agent_bus_schema.py` (migration table, future-major rejection); replay + training readers gate via `validate_event`; `verify` CLI subcommand audits whole logs.
 - [ ] **Store-and-forward for deep-space comms** — local queue with priority lanes, sync when uplink is available. DTN-compatible. Build on top of existing JSONL.
 - [ ] **Bandwidth-aware compression** — compress `events.jsonl` deltas with zstd before transmit; protobuf encoding for the ledger sync wire format.
 - [ ] **Time discipline** — split monotonic clock for ordering vs. wall clock for display. Already mostly in place; add explicit field separation.
@@ -50,8 +50,8 @@ This file documents what is in place and what is staged for later work.
 
 - [ ] **Trace export** — Playwright traces uploaded as Tier-1 audit substrate per 2026 SOTA. Wrap each browser action in `tracing.start()/stop()` and link to the BusEvent.
 - [ ] **Metrics endpoint** — Prometheus-format metrics: requests, success rate, latency p50/p99, tokens, breaker state, by-task-type.
-- [ ] **Replay tool** — read `events.jsonl`, deterministically replay any operation. Critical for postmortems and for training replayability.
-- [ ] **Cost tracking** — populate USD-equivalent cost per call; the `--budget` flag is currently advisory.
+- [x] **Replay tool** — done: `agent_bus_replay.py` + `replay` CLI subcommand (success rates, latency percentiles, provider/task/agent breakdowns, time-windowed).
+- [x] **Cost tracking** — done: `agent_bus_cost.py` prices every call (schema 1.1.0 adds `cost_usd`), `--budget` is now a hard gate at `_llm_generate`, rates overridable via `AGENT_BUS_RATES_JSON`, replay aggregates cost by provider.
 
 ### Tier 4 — research-y / nice-to-have
 
@@ -65,7 +65,7 @@ This file documents what is in place and what is staged for later work.
 - **No live test of generated tools** — only static validation. Don't expose `generate_tool` to untrusted callers.
 - **Training trigger is conservative** — by design, but means perf can degrade for up to one cooldown window before retraining kicks in.
 - **HYDRA ledger uses HMAC, not PQC** — the existing ledger signs with HMAC-SHA256. Bus events ride on top with ML-DSA-65 signatures, so they're double-protected, but the ledger itself isn't quantum-resistant. Tier 1 future work.
-- **Schema versioning not enforced on read** — `SCHEMA_VERSION = "1.0.0"` is written; the reader doesn't yet reject unknown versions.
+- **Default providers price at $0.00** — the budget gate only bites once paid rates are configured (`AGENT_BUS_RATES_JSON`); with free-tier Ollama/HF the meter records zeros by design.
 
 ## Pre-flight before each release
 

--- a/scripts/experiments/prime_vibration_edge_system.py
+++ b/scripts/experiments/prime_vibration_edge_system.py
@@ -1,0 +1,348 @@
+"""Prime-Vibration Edge System v3 — corrected-formula experiment.
+
+Executable reference implementation built from the formula verification report
+(website vs. spec). Every formula here is the SPEC-CORRECT form, including the
+two critical corrections the report found:
+
+1. Nonresonance margin Delta(S, B) uses the l-infinity coefficient bound
+   (max_p |b_p| <= B, Baker/Matveev convention), NOT the l1 bound the website
+   displayed. The two norms define different optimization problems; this module
+   computes both to demonstrate they disagree.
+2. Forward encoding and Lane B drift are SEPARATE formulas. The website's
+   hybrid `log n = sum k * alpha * log p` asserts log n = alpha * log n (false
+   for alpha != 1). Correct pair:
+       forward encoding:  log n = sum_{p in S} v_p(n) * log p      (no alpha)
+       Lane B drift:      omega_n = alpha * log n
+
+Formula reference (spec notation):
+    Lane A lock:        f_p = p * f0                       (prime p)
+    GCD repeat:         T_repeat = T / gcd(a, b)
+    LCM overtone:       f_common = lcm(a, b) * f0
+    Lane B drift:       omega_p = alpha * log p             (omega, not f^(B))
+    Factorization:      n = prod_{p in S} p^{v_p(n)}
+    Composite drift:    omega_n = alpha * sum v_p(n) log p
+    Nonresonance:       Delta(S, B) = min_{0 < max|b_p| <= B} |sum b_p log p|
+    Certificate:        Delta(S, B) > eps_num + eps_sensor
+    Canary products:    p + q, |p - q|, 2p (2nd order, even bins); 2p +/- q (3rd)
+    Fermat lane:        F_k = 2^(2^k) + 1, |(Z/F_k Z)^x| = F_k - 1 = 2^(2^k)
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import math
+from dataclasses import asdict, dataclass
+from math import gcd, lcm
+from typing import Sequence
+
+DEFAULT_SUPPORT: tuple[int, ...] = (2, 3, 5)
+DEFAULT_BOUND = 2
+F4 = 65537
+F4_GROUP_ORDER = 65536
+
+
+# ---------------------------------------------------------------------------
+# Lane A — integer frequency locks
+# ---------------------------------------------------------------------------
+
+
+def lane_a_frequency(p: int, f0: float) -> float:
+    """Lane A lock frequency f_p = p * f0 for a prime edge address p."""
+    return p * f0
+
+
+def repeat_period(a: int, b: int, base_period: float) -> float:
+    """GCD repeat period T_repeat = T / gcd(a, b) of two locked edges."""
+    return base_period / gcd(a, b)
+
+
+def common_overtone(a: int, b: int, f0: float) -> float:
+    """LCM common overtone f_common = lcm(a, b) * f0 of two locked edges."""
+    return lcm(a, b) * f0
+
+
+# ---------------------------------------------------------------------------
+# Lane B — logarithmic drift
+# ---------------------------------------------------------------------------
+
+
+def prime_valuations(n: int) -> dict[int, int]:
+    """p-adic valuations of n: returns {p: v_p(n)} with n = prod p^v_p(n).
+
+    Args:
+        n: Integer >= 2.
+
+    Returns:
+        Mapping of each prime factor p to its exponent v_p(n).
+    """
+    if n < 2:
+        raise ValueError(f"n must be >= 2, got {n}")
+    valuations: dict[int, int] = {}
+    remainder = n
+    factor = 2
+    while factor * factor <= remainder:
+        while remainder % factor == 0:
+            valuations[factor] = valuations.get(factor, 0) + 1
+            remainder //= factor
+        factor += 1
+    if remainder > 1:
+        valuations[remainder] = valuations.get(remainder, 0) + 1
+    return valuations
+
+
+def lane_b_frequency(p: int, alpha: float) -> float:
+    """Lane B drift frequency omega_p = alpha * log p (spec's omega notation)."""
+    return alpha * math.log(p)
+
+
+def forward_encoding(n: int) -> float:
+    """Forward encoding log n = sum_{p} v_p(n) * log p — deliberately NO alpha.
+
+    The verification report's critical finding #2: mixing alpha into this
+    identity asserts log n = alpha * log n, which is false for alpha != 1.
+    """
+    return sum(v * math.log(p) for p, v in prime_valuations(n).items())
+
+
+def lane_b_drift(n: int, alpha: float) -> float:
+    """Composite Lane B drift omega_n = alpha * log n = alpha * sum v_p(n) log p."""
+    return alpha * forward_encoding(n)
+
+
+# ---------------------------------------------------------------------------
+# Nonresonance certificate Delta(S, B)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeltaResult:
+    """Minimum |sum b_p log p| with its arg-min vector and the norm used."""
+
+    value: float
+    vector: tuple[int, ...]
+    norm: str
+
+
+def _coefficient_vectors(size: int, bound: int, norm: str) -> "itertools.product":
+    if bound < 1:
+        raise ValueError(f"bound must be >= 1, got {bound}")
+    if norm not in ("linf", "l1"):
+        raise ValueError(f"norm must be 'linf' or 'l1', got {norm!r}")
+    return itertools.product(range(-bound, bound + 1), repeat=size)
+
+
+def delta_certificate(support: Sequence[int], bound: int, norm: str = "linf") -> DeltaResult:
+    """Compute Delta(S, B) = min over nonzero integer vectors of |sum b_p log p|.
+
+    Args:
+        support: Prime support S.
+        bound: Coefficient bound B.
+        norm: 'linf' (spec-correct: max |b_p| <= B) or 'l1' (the website's
+            incorrect sum |b_p| <= B), kept to demonstrate the difference.
+
+    Returns:
+        DeltaResult with the minimum value and a vector attaining it.
+    """
+    logs = [math.log(p) for p in support]
+    best_value = math.inf
+    best_vector: tuple[int, ...] = ()
+    for vector in _coefficient_vectors(len(support), bound, norm):
+        if not any(vector):
+            continue
+        if norm == "l1" and sum(abs(c) for c in vector) > bound:
+            continue
+        value = abs(sum(c * lg for c, lg in zip(vector, logs)))
+        if value < best_value:
+            best_value = value
+            best_vector = vector
+    return DeltaResult(value=best_value, vector=best_vector, norm=norm)
+
+
+def numerical_epsilon(support: Sequence[int], bound: int) -> float:
+    """Conservative roundoff budget for the Delta(S, B) sum in float64."""
+    return len(support) * bound * max(math.log(p) for p in support) * 2.0**-50
+
+
+def certificate_holds(support: Sequence[int], bound: int, eps_sensor: float) -> bool:
+    """Certificate inequality Delta(S, B) > eps_num + eps_sensor (l-inf norm)."""
+    delta = delta_certificate(support, bound, norm="linf")
+    return delta.value > numerical_epsilon(support, bound) + eps_sensor
+
+
+def recover_coefficients(target: float, support: Sequence[int], bound: int, tol: float) -> tuple[int, ...] | None:
+    """Bounded-support recovery: find b with |sum b_p log p - target| < tol.
+
+    Uniqueness is guaranteed when tol < Delta(S, 2B) / 2, since two distinct
+    candidates differ by a nonzero vector with max coefficient <= 2B.
+
+    Returns:
+        The recovered coefficient vector, or None if nothing lands within tol.
+    """
+    logs = [math.log(p) for p in support]
+    for vector in _coefficient_vectors(len(support), bound, "linf"):
+        if abs(sum(c * lg for c, lg in zip(vector, logs)) - target) < tol:
+            return vector
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Canary distortion products
+# ---------------------------------------------------------------------------
+
+
+def second_order_products(p: int, q: int) -> tuple[int, int, int]:
+    """Second-order distortion products (p + q, |p - q|, 2p) — all even bins."""
+    return (p + q, abs(p - q), 2 * p)
+
+
+def third_order_products(p: int, q: int) -> tuple[int, int]:
+    """Third-order distortion products (2p + q, 2p - q) — odd bins."""
+    return (2 * p + q, 2 * p - q)
+
+
+# ---------------------------------------------------------------------------
+# Fermat / NTT lane
+# ---------------------------------------------------------------------------
+
+
+def fermat_number(k: int) -> int:
+    """Fermat number F_k = 2^(2^k) + 1."""
+    return 2 ** (2**k) + 1
+
+
+def multiplicative_group_order(k: int) -> int:
+    """Order of (Z/F_k Z)^x = F_k - 1 = 2^(2^k); valid while F_k is prime (k <= 4)."""
+    if k > 4:
+        raise ValueError("F_k is composite for known k > 4; group order is not F_k - 1")
+    return fermat_number(k) - 1
+
+
+def is_primitive_root_mod_f4(g: int) -> bool:
+    """True iff g generates (Z/65537 Z)^x.
+
+    The group order 65536 = 2^16 has the single prime factor 2, so g is a
+    generator iff g^(65536/2) != 1 (mod 65537).
+    """
+    return pow(g, F4_GROUP_ORDER // 2, F4) != 1
+
+
+# ---------------------------------------------------------------------------
+# Self-verifying experiment
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    passed: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class ExperimentReport:
+    passed: bool
+    checks: tuple[Check, ...]
+
+
+def run_experiment(
+    support: Sequence[int] = DEFAULT_SUPPORT,
+    bound: int = DEFAULT_BOUND,
+    alpha: float = 0.5,
+    eps_sensor: float = 1e-6,
+) -> ExperimentReport:
+    """Run all corrected-formula verifications and return a pass/fail report."""
+    checks: list[Check] = []
+
+    def check(name: str, passed: bool, detail: str) -> None:
+        checks.append(Check(name=name, passed=passed, detail=detail))
+
+    # Lane A identities.
+    check(
+        "lane_a_gcd_lcm",
+        repeat_period(6, 10, 1.0) == 0.5 and common_overtone(6, 10, 2.0) == 60.0,
+        "T/gcd(6,10)=0.5, lcm(6,10)*f0=60",
+    )
+
+    # Forward encoding matches log n exactly (fundamental theorem of arithmetic).
+    n = 360
+    encoding_error = abs(forward_encoding(n) - math.log(n))
+    check("forward_encoding_identity", encoding_error < 1e-12, f"|sum v_p log p - log {n}| = {encoding_error:.2e}")
+
+    # The website's conflated formula would force log n = alpha * log n.
+    conflated = alpha * forward_encoding(n)
+    check(
+        "alpha_conflation_bug_demonstrated",
+        abs(conflated - math.log(n)) > 0.1 and abs(lane_b_drift(n, alpha) - alpha * math.log(n)) < 1e-12,
+        f"alpha*sum = {conflated:.4f} != log n = {math.log(n):.4f}; omega_n = alpha*log n holds",
+    )
+
+    # l-inf vs l1 define different Delta(S, B) objects.
+    delta_linf = delta_certificate(support, bound, norm="linf")
+    delta_l1 = delta_certificate(support, bound, norm="l1")
+    check(
+        "linf_vs_l1_differ",
+        delta_linf.value < delta_l1.value - 1e-9,
+        f"Delta_linf={delta_linf.value:.6f} via {delta_linf.vector}, "
+        f"Delta_l1={delta_l1.value:.6f} via {delta_l1.vector}",
+    )
+
+    # Certificate inequality with explicit numeric budget.
+    check(
+        "certificate_holds",
+        certificate_holds(support, bound, eps_sensor),
+        f"Delta(S,B)={delta_linf.value:.6f} > eps_num+eps_sensor",
+    )
+
+    # Bounded-support recovery roundtrip.
+    true_vector = (2, -1, 1)[: len(support)]
+    target = sum(c * math.log(p) for c, p in zip(true_vector, support))
+    recovered = recover_coefficients(target, support, bound, tol=1e-9)
+    check("reverse_recovery_roundtrip", recovered == true_vector, f"recovered {recovered} == {true_vector}")
+
+    # Canary parity: 2nd-order products land on even bins, 3rd-order on odd.
+    p, q = 3, 7
+    second = second_order_products(p, q)
+    third = third_order_products(p, q)
+    check(
+        "canary_bin_parity",
+        all(x % 2 == 0 for x in second) and all(x % 2 == 1 for x in third),
+        f"2nd-order {second} even; 3rd-order {third} odd",
+    )
+
+    # Fermat lane: F_4 structure and primitive root.
+    check(
+        "fermat_f4_structure",
+        fermat_number(4) == F4 and multiplicative_group_order(4) == F4_GROUP_ORDER,
+        "F_4 = 65537, |(Z/F_4 Z)^x| = 65536 = 2^16",
+    )
+    check(
+        "primitive_root_mod_f4",
+        is_primitive_root_mod_f4(3) and not is_primitive_root_mod_f4(2),
+        "ord(3) = 65536 (generator); ord(2) = 32 (not a generator)",
+    )
+
+    return ExperimentReport(passed=all(c.passed for c in checks), checks=tuple(checks))
+
+
+def main() -> int:
+    """CLI entry: run the experiment and print a human or JSON report."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true", help="emit the report as JSON")
+    parser.add_argument("--bound", type=int, default=DEFAULT_BOUND, help="coefficient bound B")
+    parser.add_argument("--alpha", type=float, default=0.5, help="Lane B drift scale alpha")
+    args = parser.parse_args()
+
+    report = run_experiment(bound=args.bound, alpha=args.alpha)
+    if args.json:
+        print(json.dumps(asdict(report), indent=2))
+    else:
+        for c in report.checks:
+            print(f"[{'PASS' if c.passed else 'FAIL'}] {c.name}: {c.detail}")
+        print(f"\nresult: {'PASS' if report.passed else 'FAIL'} ({len(report.checks)} checks)")
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/geoseal.py
+++ b/src/geoseal.py
@@ -32,11 +32,41 @@ TONGUE_PHASES: Dict[str, float] = {
     "DR": 5 * math.pi / 3,
 }
 
-# Suspicion / quarantine parameters
+# Suspicion / quarantine parameters (defaults; tune per deployment via GeoSealConfig)
 SUSPICION_DECAY = 0.5
 SUSPICION_THRESHOLD = 3
 QUARANTINE_CONSENSUS = 3
 TRUST_DENOMINATOR = 20.0
+
+
+@dataclass(frozen=True)
+class GeoSealConfig:
+    """Tunable GeoSeal parameters. Defaults preserve historical behavior exactly.
+
+    Lets deployments (and hyperparameter sweeps) tune suspicion dynamics
+    without editing module constants.
+    """
+
+    suspicion_decay: float = SUSPICION_DECAY
+    suspicion_threshold: float = SUSPICION_THRESHOLD
+    quarantine_consensus: int = QUARANTINE_CONSENSUS
+    trust_denominator: float = TRUST_DENOMINATOR
+    ball_radius: float = 0.99
+
+    def __post_init__(self) -> None:
+        if self.suspicion_decay < 0:
+            raise ValueError(f"suspicion_decay must be >= 0, got {self.suspicion_decay}")
+        if self.suspicion_threshold <= 0:
+            raise ValueError(f"suspicion_threshold must be > 0, got {self.suspicion_threshold}")
+        if self.quarantine_consensus < 1:
+            raise ValueError(f"quarantine_consensus must be >= 1, got {self.quarantine_consensus}")
+        if self.trust_denominator <= 0:
+            raise ValueError(f"trust_denominator must be > 0, got {self.trust_denominator}")
+        if not 0.0 < self.ball_radius < 1.0:
+            raise ValueError(f"ball_radius must be in (0, 1), got {self.ball_radius}")
+
+
+DEFAULT_CONFIG = GeoSealConfig()
 
 
 # ---------------------------------------------------------------------------
@@ -74,7 +104,12 @@ def hyperbolic_distance(u: List[float], v: List[float]) -> float:
     """Compute hyperbolic distance in Poincaré ball model.
 
     d_H(u, v) = arcosh(1 + 2 * ||u - v||² / ((1 - ||u||²)(1 - ||v||²)))
+
+    Raises ValueError on dimension mismatch (zip would silently truncate;
+    the TypeScript port throws RangeError — behavior is now consistent).
     """
+    if len(u) != len(v):
+        raise ValueError(f"dimension mismatch: len(u)={len(u)} != len(v)={len(v)}")
     diff = [a - b for a, b in zip(u, v)]
     diff_norm_sq = _norm_sq(diff)
     u_norm_sq = _norm_sq(u)
@@ -155,18 +190,24 @@ def compute_repel_force(
 # ---------------------------------------------------------------------------
 
 
-def update_suspicion(agent: Agent, neighbor_id: str, is_anomaly: bool) -> None:
+def update_suspicion(
+    agent: Agent,
+    neighbor_id: str,
+    is_anomaly: bool,
+    config: Optional[GeoSealConfig] = None,
+) -> None:
     """Update suspicion counters and quarantine status."""
+    cfg = config or DEFAULT_CONFIG
     if is_anomaly:
         agent.suspicion_count[neighbor_id] = agent.suspicion_count.get(neighbor_id, 0) + 1
     else:
-        agent.suspicion_count[neighbor_id] = max(0, agent.suspicion_count.get(neighbor_id, 0) - SUSPICION_DECAY)
+        agent.suspicion_count[neighbor_id] = max(0, agent.suspicion_count.get(neighbor_id, 0) - cfg.suspicion_decay)
 
-    suspicious_neighbors = sum(1 for c in agent.suspicion_count.values() if c >= SUSPICION_THRESHOLD)
-    agent.is_quarantined = suspicious_neighbors >= QUARANTINE_CONSENSUS
+    suspicious_neighbors = sum(1 for c in agent.suspicion_count.values() if c >= cfg.suspicion_threshold)
+    agent.is_quarantined = suspicious_neighbors >= cfg.quarantine_consensus
 
     total_suspicion = sum(agent.suspicion_count.values())
-    agent.trust_score = max(0, 1.0 - total_suspicion / TRUST_DENOMINATOR)
+    agent.trust_score = max(0, 1.0 - total_suspicion / cfg.trust_denominator)
 
 
 # ---------------------------------------------------------------------------
@@ -174,13 +215,25 @@ def update_suspicion(agent: Agent, neighbor_id: str, is_anomaly: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
-def swarm_step(agents: List[Agent], drift_rate: float = 0.01) -> List[Agent]:
-    """Run one swarm update step for all agents."""
+def swarm_step(
+    agents: List[Agent],
+    drift_rate: float = 0.01,
+    config: Optional[GeoSealConfig] = None,
+) -> List[Agent]:
+    """Run one swarm update step for all agents.
+
+    Raises ValueError if agents carry positions of different dimensions —
+    catching embedding mismatches here instead of deep in the force loop.
+    """
+    cfg = config or DEFAULT_CONFIG
     n = len(agents)
     if n == 0:
         return agents
 
     dim = len(agents[0].position)
+    for a in agents:
+        if len(a.position) != dim:
+            raise ValueError(f"agent {a.id!r} has dimension {len(a.position)}, expected {dim} (from {agents[0].id!r})")
 
     for i in range(n):
         net_force = [0.0] * dim
@@ -195,14 +248,14 @@ def swarm_step(agents: List[Agent], drift_rate: float = 0.01) -> List[Agent]:
 
             # Update suspicion on the TARGET (j) from the SOURCE (i)
             # When i flags j as anomalous, j's suspicion record grows
-            update_suspicion(agents[j], agents[i].id, anomaly)
+            update_suspicion(agents[j], agents[i].id, anomaly, cfg)
 
         # Apply force
         for k in range(dim):
             agents[i].position[k] += net_force[k] * drift_rate
 
         # Clamp to Poincaré ball
-        agents[i].position = clamp_to_ball(agents[i].position, 0.99)
+        agents[i].position = clamp_to_ball(agents[i].position, cfg.ball_radius)
 
     return agents
 
@@ -211,10 +264,11 @@ def run_swarm(
     agents: List[Agent],
     num_steps: int = 10,
     drift_rate: float = 0.01,
+    config: Optional[GeoSealConfig] = None,
 ) -> List[Agent]:
     """Run multiple swarm steps."""
     for _ in range(num_steps):
-        swarm_step(agents, drift_rate)
+        swarm_step(agents, drift_rate, config)
     return agents
 
 
@@ -234,15 +288,20 @@ class GeoSealMetrics:
     final_trust_scores: Dict[str, float]
 
 
-def compute_metrics(agents: List[Agent], rogue_id: str) -> GeoSealMetrics:
+def compute_metrics(
+    agents: List[Agent],
+    rogue_id: str,
+    config: Optional[GeoSealConfig] = None,
+) -> GeoSealMetrics:
     """Compute GeoSeal metrics for a completed swarm run."""
+    cfg = config or DEFAULT_CONFIG
     rogue = next((a for a in agents if a.id == rogue_id), None)
     if rogue is None:
         raise ValueError(f"Rogue agent not found: {rogue_id}")
 
     norm = _norm(rogue.position)
 
-    suspicious = sum(1 for c in rogue.suspicion_count.values() if c >= SUSPICION_THRESHOLD)
+    suspicious = sum(1 for c in rogue.suspicion_count.values() if c >= cfg.suspicion_threshold)
     total_neighbors = len(rogue.suspicion_count)
     consensus = suspicious / total_neighbors if total_neighbors > 0 else 0.0
 

--- a/src/geoseal_v2.py
+++ b/src/geoseal_v2.py
@@ -112,8 +112,19 @@ def fuse_scores(
     anchor: MixedAgent,
     candidate: MixedAgent,
     weights: Tuple[float, float, float] = DEFAULT_WEIGHTS,
+    *,
+    allow_threshold: float = MEMORY_WRITE_THRESHOLD,
+    quarantine_threshold: float = QUARANTINE_TRUST_THRESHOLD,
 ) -> FusedScore:
-    """Fuse three geometry scores into a single trust value."""
+    """Fuse three geometry scores into a single trust value.
+
+    Action thresholds are tunable per call site; defaults preserve the
+    historical ALLOW >= 0.7 / QUARANTINE >= 0.3 / DENY bands.
+    """
+    if allow_threshold < quarantine_threshold:
+        raise ValueError(
+            f"allow_threshold ({allow_threshold}) must be >= quarantine_threshold ({quarantine_threshold})"
+        )
     w_h, w_s, w_g = weights
     s_h = score_hyperbolic(anchor, candidate)
     s_s = score_phase(anchor, candidate)
@@ -122,9 +133,9 @@ def fuse_scores(
     trust = w_h * s_h + w_s * s_s + w_g * s_g
     anomaly = s_s < 0.5 or s_g < 0.5
 
-    if trust >= MEMORY_WRITE_THRESHOLD:
+    if trust >= allow_threshold:
         action: Action = "ALLOW"
-    elif trust >= QUARANTINE_TRUST_THRESHOLD:
+    elif trust >= quarantine_threshold:
         action = "QUARANTINE"
     else:
         action = "DENY"
@@ -219,7 +230,14 @@ def swarm_step_v2(
     sigma_decay: float = 0.01,
     weights: Tuple[float, float, float] = DEFAULT_WEIGHTS,
 ) -> List[MixedAgent]:
-    """One v2 swarm update step with uncertainty evolution."""
+    """One v2 swarm update step with uncertainty evolution.
+
+    sigma_decay must be >= 0: it is a decay magnitude, and a negative value
+    would invert the uncertainty dynamics (suspected agents would become
+    MORE certain).
+    """
+    if sigma_decay < 0:
+        raise ValueError(f"sigma_decay must be >= 0, got {sigma_decay}")
     n = len(agents)
     if n == 0:
         return agents
@@ -291,7 +309,14 @@ def score_all_candidates(
     candidates: List[MixedAgent],
     weights: Tuple[float, float, float] = DEFAULT_WEIGHTS,
 ) -> List[ScoredCandidate]:
-    """Score all candidates against tongue anchors. Returns sorted by trust desc."""
+    """Score all candidates against tongue anchors. Returns sorted by trust desc.
+
+    Raises ValueError when candidates exist but the anchor list is empty —
+    previously every candidate was silently dropped, which callers could
+    not distinguish from "nothing scored well".
+    """
+    if candidates and not anchors:
+        raise ValueError("score_all_candidates: anchors list is empty — every candidate would be silently dropped")
     results: List[ScoredCandidate] = []
 
     for candidate in candidates:

--- a/tests/agents/test_agent_bus_cost.py
+++ b/tests/agents/test_agent_bus_cost.py
@@ -1,0 +1,201 @@
+"""
+Cost metering + budget enforcement tests.
+
+Covers agent_bus_cost (meter math, env rate overrides), the budget gate in
+AgentBus._llm_generate, schema 1.1.0 acceptance of cost_usd events, and the
+replay reader's cost aggregation.
+"""
+
+import json
+
+import pytest
+
+from agents.agent_bus import AgentBus
+from agents.agent_bus_cost import (
+    RATES_ENV_VAR,
+    CostMeter,
+    ProviderRates,
+    load_rates,
+)
+from agents.agent_bus_replay import replay_log
+from agents.agent_bus_schema import CURRENT_SCHEMA_VERSION, validate_event
+
+PAID_RATES = {"huggingface": ProviderRates(usd_per_1k_in=0.30, usd_per_1k_out=1.20)}
+
+
+class TestCostMeter:
+    def test_price_math(self):
+        meter = CostMeter(rates=PAID_RATES)
+        # 2000 in @ $0.30/1k + 500 out @ $1.20/1k = 0.60 + 0.60
+        assert meter.price("huggingface", 2000, 500) == pytest.approx(1.20)
+
+    def test_unknown_provider_prices_at_zero(self):
+        meter = CostMeter(rates=PAID_RATES)
+        assert meter.price("mystery", 10_000, 10_000) == 0.0
+
+    def test_charge_accumulates(self):
+        meter = CostMeter(rates=PAID_RATES)
+        meter.charge("huggingface", 1000, 0)
+        meter.charge("huggingface", 1000, 0)
+        assert meter.spent_usd == pytest.approx(0.60)
+
+    def test_zero_budget_is_unbounded(self):
+        meter = CostMeter(budget_usd=0.0, rates=PAID_RATES)
+        meter.charge("huggingface", 1_000_000, 1_000_000)
+        assert not meter.exceeded
+        assert meter.remaining_usd is None
+
+    def test_budget_trips_when_reached(self):
+        meter = CostMeter(budget_usd=0.50, rates=PAID_RATES)
+        assert not meter.exceeded
+        meter.charge("huggingface", 2000, 0)  # $0.60
+        assert meter.exceeded
+        assert meter.remaining_usd == 0.0
+
+    def test_remaining_headroom(self):
+        meter = CostMeter(budget_usd=1.00, rates=PAID_RATES)
+        meter.charge("huggingface", 1000, 0)  # $0.30
+        assert meter.remaining_usd == pytest.approx(0.70)
+
+    def test_default_providers_are_free(self):
+        meter = CostMeter()
+        assert meter.charge("ollama", 5000, 5000) == 0.0
+        assert meter.charge("offline", 5000, 5000) == 0.0
+
+
+class TestRatesEnv:
+    def test_env_override(self):
+        env = {RATES_ENV_VAR: json.dumps({"huggingface": {"in": 0.10, "out": 0.40}})}
+        rates = load_rates(env)
+        assert rates["huggingface"] == ProviderRates(0.10, 0.40)
+        assert rates["ollama"] == ProviderRates()  # defaults preserved
+
+    def test_malformed_json_falls_back_to_defaults(self):
+        rates = load_rates({RATES_ENV_VAR: "{not json"})
+        assert rates["huggingface"] == ProviderRates()
+
+    def test_non_object_json_falls_back(self):
+        rates = load_rates({RATES_ENV_VAR: "[1, 2]"})
+        assert rates["ollama"] == ProviderRates()
+
+    def test_malformed_entry_skipped_others_kept(self):
+        env = {RATES_ENV_VAR: json.dumps({"bad": "nope", "good": {"in": 1.0, "out": 2.0}})}
+        rates = load_rates(env)
+        assert "bad" not in rates or rates.get("bad") == ProviderRates()
+        assert rates["good"] == ProviderRates(1.0, 2.0)
+
+    def test_missing_env_uses_defaults(self):
+        assert load_rates({}).keys() >= {"ollama", "huggingface", "offline"}
+
+
+class TestBudgetGate:
+    async def test_llm_generate_refuses_when_budget_exceeded(self, monkeypatch):
+        bus = AgentBus(budget_usd=0.01)
+        bus.cost.spent_usd = 0.02  # already over
+
+        async def _fail(*a, **k):  # providers must never be called
+            raise AssertionError("provider called despite exceeded budget")
+
+        monkeypatch.setattr(bus, "_try_ollama", _fail)
+        monkeypatch.setattr(bus, "_try_huggingface", _fail)
+
+        result = await bus._llm_generate("hello")
+        assert result["provider"] == "budget"
+        assert "budget_exceeded" in result["error"]
+        assert result["cost_usd"] == 0.0
+
+    async def test_llm_generate_charges_offline_fallback(self, monkeypatch):
+        bus = AgentBus(budget_usd=0.0)
+
+        async def _none(*a, **k):
+            return None
+
+        monkeypatch.setattr(bus, "_try_ollama", _none)
+        monkeypatch.setattr(bus, "_try_huggingface", _none)
+
+        result = await bus._llm_generate("hello")
+        assert result["provider"] == "offline"
+        assert result["cost_usd"] == 0.0  # offline is free, but the field is present
+
+    async def test_llm_generate_charges_provider_result(self, monkeypatch):
+        bus = AgentBus(budget_usd=1.00)
+        bus.cost.rates = dict(PAID_RATES)
+
+        async def _hf(*a, **k):
+            return {"text": "hi", "provider": "huggingface", "model": "m", "tokens_in": 1000, "tokens_out": 1000}
+
+        async def _none(*a, **k):
+            return None
+
+        monkeypatch.setattr(bus, "_try_ollama", _none)
+        monkeypatch.setattr(bus, "_try_huggingface", _hf)
+
+        result = await bus._llm_generate("hello")
+        assert result["cost_usd"] == pytest.approx(1.50)
+        assert bus.cost.spent_usd == pytest.approx(1.50)
+        assert bus.cost.exceeded  # next call would be gated
+
+
+class TestSchemaCompat:
+    def _event(self, **overrides):
+        record = {
+            "task_type": "ask",
+            "query": "q",
+            "timestamp": "2026-06-11T00:00:00+0000",
+            "success": True,
+            "_schema_version": CURRENT_SCHEMA_VERSION,
+        }
+        record.update(overrides)
+        return record
+
+    def test_current_version_is_1_1(self):
+        assert CURRENT_SCHEMA_VERSION == "1.1.0"
+
+    def test_event_with_cost_usd_validates(self):
+        result = validate_event(self._event(cost_usd=0.0042))
+        assert result.ok
+
+    def test_legacy_1_0_0_event_without_cost_still_validates(self):
+        result = validate_event(self._event(_schema_version="1.0.0"))
+        assert result.ok
+        assert not result.migrated  # additive minor needs no migration
+
+
+class TestReplayCostAggregation:
+    def test_replay_aggregates_cost_by_provider(self, tmp_path):
+        log = tmp_path / "events.jsonl"
+        events = [
+            {
+                "task_type": "ask",
+                "query": "a",
+                "timestamp": "2026-06-11T00:00:01+0000",
+                "success": True,
+                "llm_provider": "huggingface",
+                "cost_usd": 0.25,
+                "_schema_version": "1.1.0",
+            },
+            {
+                "task_type": "ask",
+                "query": "b",
+                "timestamp": "2026-06-11T00:00:02+0000",
+                "success": True,
+                "llm_provider": "huggingface",
+                "cost_usd": 0.50,
+                "_schema_version": "1.1.0",
+            },
+            {  # legacy event without cost_usd prices at 0
+                "task_type": "ask",
+                "query": "c",
+                "timestamp": "2026-06-11T00:00:03+0000",
+                "success": True,
+                "llm_provider": "ollama",
+                "_schema_version": "1.0.0",
+            },
+        ]
+        log.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+        report = replay_log(log)
+        assert report["total_events"] == 3
+        assert report["cost_usd"]["total"] == pytest.approx(0.75)
+        assert report["cost_usd"]["by_provider"]["huggingface"] == pytest.approx(0.75)
+        assert report["cost_usd"]["by_provider"]["ollama"] == 0.0

--- a/tests/experiments/test_prime_vibration_edge_system.py
+++ b/tests/experiments/test_prime_vibration_edge_system.py
@@ -1,0 +1,139 @@
+"""Tests for the corrected Prime-Vibration Edge System v3 experiment.
+
+Locks in the two critical corrections from the formula verification report:
+l-infinity (not l1) coefficient bound in Delta(S, B), and the separation of
+forward encoding (no alpha) from Lane B drift (alpha-scaled).
+"""
+
+import math
+
+import pytest
+
+from scripts.experiments.prime_vibration_edge_system import (
+    F4,
+    F4_GROUP_ORDER,
+    certificate_holds,
+    common_overtone,
+    delta_certificate,
+    fermat_number,
+    forward_encoding,
+    is_primitive_root_mod_f4,
+    lane_a_frequency,
+    lane_b_drift,
+    lane_b_frequency,
+    multiplicative_group_order,
+    numerical_epsilon,
+    prime_valuations,
+    recover_coefficients,
+    repeat_period,
+    run_experiment,
+    second_order_products,
+    third_order_products,
+)
+
+SUPPORT = (2, 3, 5)
+
+
+class TestLaneA:
+    def test_lock_frequency(self):
+        assert lane_a_frequency(7, 100.0) == 700.0
+
+    def test_gcd_repeat_period(self):
+        assert repeat_period(6, 10, 1.0) == pytest.approx(0.5)
+
+    def test_lcm_common_overtone(self):
+        assert common_overtone(6, 10, 2.0) == pytest.approx(60.0)
+
+
+class TestLaneB:
+    def test_prime_valuations(self):
+        assert prime_valuations(360) == {2: 3, 3: 2, 5: 1}
+
+    def test_prime_valuations_rejects_small_n(self):
+        with pytest.raises(ValueError):
+            prime_valuations(1)
+
+    def test_forward_encoding_is_log_n_without_alpha(self):
+        assert forward_encoding(360) == pytest.approx(math.log(360), abs=1e-12)
+
+    def test_alpha_conflation_bug(self):
+        """The website's hybrid formula asserts log n = alpha*log n — must NOT hold."""
+        alpha, n = 0.5, 360
+        conflated = alpha * forward_encoding(n)
+        assert conflated != pytest.approx(math.log(n), abs=1e-6)
+        assert lane_b_drift(n, alpha) == pytest.approx(alpha * math.log(n), abs=1e-12)
+
+    def test_omega_notation_frequency(self):
+        assert lane_b_frequency(3, 2.0) == pytest.approx(2.0 * math.log(3))
+
+
+class TestDeltaCertificate:
+    def test_linf_and_l1_are_different_objects(self):
+        """Report critical finding #1: the norms give different minima at B=2."""
+        linf = delta_certificate(SUPPORT, 2, norm="linf")
+        l1 = delta_certificate(SUPPORT, 2, norm="l1")
+        assert linf.value < l1.value
+        # l1 ball is a subset of the l-inf cube, so the l-inf min can only be <=.
+        assert linf.vector != l1.vector
+
+    def test_linf_minimum_is_log_ten_ninths(self):
+        """At S={2,3,5}, B=2 the l-inf minimizer is (-1,2,-1): |log(9/10)|."""
+        result = delta_certificate(SUPPORT, 2, norm="linf")
+        assert result.value == pytest.approx(math.log(10 / 9), abs=1e-12)
+        assert result.vector in ((-1, 2, -1), (1, -2, 1))
+
+    def test_certificate_inequality(self):
+        assert certificate_holds(SUPPORT, 2, eps_sensor=1e-6)
+        assert numerical_epsilon(SUPPORT, 2) < 1e-12
+
+    def test_rejects_bad_inputs(self):
+        with pytest.raises(ValueError):
+            delta_certificate(SUPPORT, 0)
+        with pytest.raises(ValueError):
+            delta_certificate(SUPPORT, 2, norm="l2")
+
+    def test_reverse_recovery_roundtrip(self):
+        true_vector = (2, -1, 1)
+        target = sum(c * math.log(p) for c, p in zip(true_vector, SUPPORT))
+        assert recover_coefficients(target, SUPPORT, 2, tol=1e-9) == true_vector
+
+    def test_reverse_recovery_returns_none_when_out_of_reach(self):
+        assert recover_coefficients(100.0, SUPPORT, 2, tol=1e-9) is None
+
+
+class TestCanary:
+    def test_second_order_products_even(self):
+        assert second_order_products(3, 7) == (10, 4, 6)
+        assert all(x % 2 == 0 for x in second_order_products(11, 13))
+
+    def test_third_order_products_odd(self):
+        assert third_order_products(3, 7) == (13, -1)
+        assert all(x % 2 == 1 for x in third_order_products(11, 13))
+
+
+class TestFermatLane:
+    def test_fermat_numbers(self):
+        assert [fermat_number(k) for k in range(5)] == [3, 5, 17, 257, F4]
+
+    def test_group_orders_are_powers_of_two(self):
+        for k in range(5):
+            assert multiplicative_group_order(k) == 2 ** (2**k)
+
+    def test_group_order_refuses_composite_fermat(self):
+        with pytest.raises(ValueError):
+            multiplicative_group_order(5)
+
+    def test_three_generates_f4_but_two_does_not(self):
+        assert is_primitive_root_mod_f4(3)
+        assert not is_primitive_root_mod_f4(2)
+        assert pow(2, 32, F4) == 1  # ord(2) = 32
+
+    def test_f4_constants(self):
+        assert F4 == 2**16 + 1
+        assert F4_GROUP_ORDER == 2**16
+
+
+def test_full_experiment_passes():
+    report = run_experiment()
+    failures = [c.name for c in report.checks if not c.passed]
+    assert report.passed, f"failing checks: {failures}"

--- a/tests/test_geoseal_config.py
+++ b/tests/test_geoseal_config.py
@@ -1,0 +1,151 @@
+"""GeoSeal hardening tests: GeoSealConfig tuning, dimension validation,
+empty-anchor guard, and v2 parameter contracts.
+
+Companion to tests/test_geoseal.py / test_geoseal_v2.py — covers the gaps
+those suites left: parametrized thresholds, mismatched vector dimensions,
+and silent-failure edges in batch scoring.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.geoseal import (  # noqa: E402
+    DEFAULT_CONFIG,
+    Agent,
+    GeoSealConfig,
+    compute_metrics,
+    hyperbolic_distance,
+    run_swarm,
+    swarm_step,
+    update_suspicion,
+)
+from src.geoseal_v2 import (  # noqa: E402
+    MixedAgent,
+    fuse_scores,
+    score_all_candidates,
+    swarm_step_v2,
+)
+
+
+def _agent(aid: str, pos, phase=0.0) -> Agent:
+    return Agent(id=aid, position=list(pos), phase=phase)
+
+
+class TestGeoSealConfig:
+    def test_defaults_match_historical_constants(self):
+        cfg = GeoSealConfig()
+        assert cfg.suspicion_decay == 0.5
+        assert cfg.suspicion_threshold == 3
+        assert cfg.quarantine_consensus == 3
+        assert cfg.trust_denominator == 20.0
+        assert cfg.ball_radius == 0.99
+        assert cfg == DEFAULT_CONFIG
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"suspicion_decay": -0.1},
+            {"suspicion_threshold": 0},
+            {"quarantine_consensus": 0},
+            {"trust_denominator": 0.0},
+            {"ball_radius": 0.0},
+            {"ball_radius": 1.0},
+        ],
+    )
+    def test_invalid_values_rejected(self, kwargs):
+        with pytest.raises(ValueError):
+            GeoSealConfig(**kwargs)
+
+    def test_custom_decay_changes_suspicion_dynamics(self):
+        fast_forgive = GeoSealConfig(suspicion_decay=5.0)
+        a_default = _agent("a", [0.1, 0.1])
+        a_custom = _agent("b", [0.1, 0.1])
+        for agent, cfg in ((a_default, None), (a_custom, fast_forgive)):
+            update_suspicion(agent, "n", True, cfg)
+            update_suspicion(agent, "n", True, cfg)
+            update_suspicion(agent, "n", False, cfg)
+        # default decay 0.5: 2 - 0.5 = 1.5; custom decay 5.0 floors at 0
+        assert a_default.suspicion_count["n"] == pytest.approx(1.5)
+        assert a_custom.suspicion_count["n"] == 0
+
+    def test_custom_consensus_quarantines_earlier(self):
+        eager = GeoSealConfig(suspicion_threshold=1, quarantine_consensus=1)
+        agent = _agent("a", [0.1, 0.1])
+        update_suspicion(agent, "n", True, eager)
+        assert agent.is_quarantined
+        # same single flag under defaults would NOT quarantine
+        strict = _agent("b", [0.1, 0.1])
+        update_suspicion(strict, "n", True)
+        assert not strict.is_quarantined
+
+    def test_swarm_respects_custom_ball_radius(self):
+        cfg = GeoSealConfig(ball_radius=0.5)
+        agents = [
+            _agent("a", [0.49, 0.0]),
+            Agent(id="rogue", position=[0.48, 0.01], phase=None),
+        ]
+        run_swarm(agents, num_steps=5, config=cfg)
+        for a in agents:
+            norm = sum(x * x for x in a.position) ** 0.5
+            assert norm <= 0.5 + 1e-9
+
+    def test_compute_metrics_uses_config_threshold(self):
+        agent = _agent("rogue", [0.1, 0.1])
+        agent.suspicion_count = {"n1": 1.0, "n2": 1.0}
+        loose = GeoSealConfig(suspicion_threshold=1)
+        m_default = compute_metrics([agent], "rogue")
+        m_loose = compute_metrics([agent], "rogue", loose)
+        assert m_default.suspicion_consensus == 0.0  # nothing reaches 3
+        assert m_loose.suspicion_consensus == 1.0  # everything reaches 1
+
+
+class TestDimensionValidation:
+    def test_hyperbolic_distance_rejects_mismatch(self):
+        with pytest.raises(ValueError, match="dimension mismatch"):
+            hyperbolic_distance([0.1, 0.2], [0.1, 0.2, 0.3])
+
+    def test_swarm_step_rejects_mixed_dimensions(self):
+        agents = [_agent("a", [0.1, 0.1]), _agent("b", [0.1, 0.1, 0.1])]
+        with pytest.raises(ValueError, match="dimension"):
+            swarm_step(agents)
+
+    def test_swarm_step_accepts_uniform_dimensions(self):
+        agents = [_agent("a", [0.1, 0.1]), _agent("b", [-0.1, 0.2])]
+        swarm_step(agents)  # must not raise
+
+    def test_empty_swarm_is_noop(self):
+        assert swarm_step([]) == []
+
+
+class TestV2Guards:
+    def _mixed(self, aid: str, sigma=0.0) -> MixedAgent:
+        return MixedAgent(id=aid, position=[0.1, 0.1], phase=0.0, sigma=sigma)
+
+    def test_empty_anchors_with_candidates_raises(self):
+        with pytest.raises(ValueError, match="anchors list is empty"):
+            score_all_candidates([], [self._mixed("c1")])
+
+    def test_empty_candidates_returns_empty_regardless(self):
+        assert score_all_candidates([], []) == []
+        assert score_all_candidates([self._mixed("a1")], []) == []
+
+    def test_negative_sigma_decay_rejected(self):
+        with pytest.raises(ValueError, match="sigma_decay"):
+            swarm_step_v2([self._mixed("a")], sigma_decay=-0.01)
+
+    def test_fuse_scores_custom_thresholds(self):
+        anchor = self._mixed("anchor")
+        candidate = self._mixed("cand")  # identical -> trust 1.0
+        default = fuse_scores(anchor, candidate)
+        assert default.action == "ALLOW"
+        # raise the bar above attainable trust -> same pair now quarantines
+        strict = fuse_scores(anchor, candidate, allow_threshold=1.5, quarantine_threshold=0.3)
+        assert strict.action == "QUARANTINE"
+
+    def test_fuse_scores_inverted_thresholds_rejected(self):
+        with pytest.raises(ValueError, match="allow_threshold"):
+            fuse_scores(self._mixed("a"), self._mixed("b"), allow_threshold=0.2, quarantine_threshold=0.5)


### PR DESCRIPTION
Single-commit port of the session work onto main. The clean-lineage branch (`claude/amazing-bell-5b5l8i`, PR #2165) cannot merge directly — its post-rewrite history diverges from main at the root — so this carries the identical, fully-tested content through the protected path.

## Contents
- **`/clean` slash command** + `.benchmarks/` gitignore fix
- **Prime-Vibration Edge System v3 experiment** (corrected formulas, 22 tests)
- **Agent-bus cost metering**: enforced `--budget`, schema 1.1.0 additive `cost_usd`, replay aggregation, CLI wiring (19 tests)
- **GeoSeal hardening**: `GeoSealConfig` tunables, dimension validation, empty-anchor/sigma guards (17 tests)
- **Productization roadmap** (`docs/PRODUCTIZATION_ROADMAP.md`)

## Verification
- All files byte-identical to the tested clean branch
- 114 tests pass on this main-based combination (cost, schema, geoseal v1/v2/config suites)

https://claude.ai/code/session_011MgY4vDsmDRTTpEfhSnxyv

---
_Generated by [Claude Code](https://claude.ai/code/session_011MgY4vDsmDRTTpEfhSnxyv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-call LLM cost tracking (USD) and hard budget enforcement via `--budget` flag in CLI commands.
  * Introduced configurable GeoSeal swarm dynamics via new configuration objects.
  * Added Prime-Vibration Edge System v3 experiment with formula verification.

* **Documentation**
  * Added productization roadmap document.
  * Added repo cleanup command documentation with safety-first procedures.
  * Updated schema version to 1.1.0 with cost tracking support.

* **Improvements**
  * Enhanced input validation for vector dimensionality checks.
  * Better error handling for budget exceeded and invalid candidate/anchor scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->