### PR TITLE
ci(tests): gate RWP v3 PQC tests on rwp_v3's effective OQS availability

### DIFF
--- a/tests/crypto/test_rwp_v3_pqc.py
+++ b/tests/crypto/test_rwp_v3_pqc.py
@@ -26,9 +26,17 @@ try:
 except Exception:
     _HAVE_OQS = False
 
-from src.crypto.rwp_v3 import _KEM_ALG, _SIG_ALG, RWPv3Protocol  # noqa: E402
+from src.crypto.rwp_v3 import _KEM_ALG, _SIG_ALG, OQS_AVAILABLE, RWPv3Protocol  # noqa: E402
 
-pytestmark = pytest.mark.skipif(not _HAVE_OQS, reason="native liboqs not available")
+# Gate on the module's EFFECTIVE PQC availability, not just `import oqs`:
+# rwp_v3 honors SCBE_FORCE_SKIP_LIBOQS (set by the CI python job, which tests
+# the deterministic fallback path), so with liboqs-python installed but the
+# env var set, `import oqs` succeeds while RWPv3Protocol(enable_pqc=True)
+# raises ImportError. Real-PQC coverage lives in the native-liboqs workflow.
+pytestmark = pytest.mark.skipif(
+    not (_HAVE_OQS and OQS_AVAILABLE),
+    reason="native liboqs not available (or PQC disabled via SCBE_FORCE_SKIP_LIBOQS)",
+)
 
 SECRET = b"correct horse battery staple"
 PLAINTEXT = b'{"decision":"ALLOW","score":0.07,"audit_id":"c04741dbc3c8165c"}'


### PR DESCRIPTION
## Summary
Main's CI (`Test Python Components`) has been red since #2168 landed: `tests/crypto/test_rwp_v3_pqc.py` fails 5 tests with `ImportError: liboqs-python required for PQC`.

Root cause: the test's skip-guard checks only `import oqs`, but `rwp_v3` honors `SCBE_FORCE_SKIP_LIBOQS` — which the CI python job **sets deliberately** (PR CI exercises the deterministic fallback path; real PQC is covered by the dedicated native-liboqs workflow). With `liboqs-python` installed and the env var set, the import succeeds, the skip never fires, and `RWPv3Protocol(enable_pqc=True)` raises.

## Change
Skip now keys on `rwp_v3.OQS_AVAILABLE` — the effective gate the module under test actually uses.

## Verification
- Forced-skip (CI conditions): **6 skipped** (was 5 failed / 1 passed)
- liboqs active (local): **6 passed** — real-PQC coverage unchanged
- `scripts/system/run_core_python_checks.py` under `SCBE_FORCE_SKIP_LIBOQS=1`: exit 0 (replicates the failing CI job end-to-end)
- `test_geoseal_pqc.py` audited for the same pattern: its module imports oqs directly (doesn't honor the env var), so it genuinely runs and passes in CI — left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)