### PR TITLE
feat(chem): exact units + reaction balancer + geometry views; PQC-sign reaction receipts

### DIFF
--- a/python/scbe/geometry_view.py
+++ b/python/scbe/geometry_view.py
@@ -1,0 +1,168 @@
+"""Geometry view — wrap RDKit to express a molecule's 3D geometry as a spine view.
+
+Real molecular geometry (3D coordinates, rotor type, shape, point group) comes
+from REAL engines -- RDKit for the conformer/descriptors, pymatgen for the point
+group when installed -- never hand-rolled. This is the "wrap the real engine,
+govern it" path: SMILES -> 3D conformer -> geometry descriptors, emitted as a
+``domain='geometry'`` ReactionStatePacket and classified by the shared spine.
+
+A single embedded conformer is one sample of the conformational ensemble, so the
+transform is LOSSY_RECOVERABLE: connectivity is preserved (the canonical SMILES
+round-trips), but the specific 3D pose is a choice, recorded as a loss note.
+
+This is a geometry/shape descriptor lane, not a quantum-accurate structure.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .reaction_state import (
+    ReactionEndpoint,
+    ReactionRecalculation,
+    ReactionStatePacket,
+    build_reaction_state_packet,
+)
+
+# rotor classification tolerance (relative to the largest principal moment)
+ROTOR_TOL = 0.05
+
+
+class GeometryEngineError(RuntimeError):
+    """Raised when no real geometry engine (RDKit) is available or embedding fails."""
+
+
+def _require_rdkit():
+    try:
+        from rdkit import Chem
+        from rdkit.Chem import AllChem, rdMolDescriptors
+    except Exception as exc:  # pragma: no cover - environment specific
+        raise GeometryEngineError(f"RDKit is required for the geometry view: {exc!r}") from exc
+    return Chem, AllChem, rdMolDescriptors
+
+
+def rotor_type(moments: list[float], tol: float = ROTOR_TOL) -> str:
+    """Classify a rigid rotor from ascending principal moments of inertia.
+
+    Pure function (no RDKit) so it is independently testable:
+      linear (one ~zero moment) / spherical_top (all equal) /
+      symmetric_top (two equal) / asymmetric_top (all distinct).
+    """
+    a, b, c = sorted(moments)
+    scale = max(abs(c), 1e-12)
+    a_n, b_n, c_n = a / scale, b / scale, c / scale
+    if a_n < tol:
+        return "linear"
+    if abs(a_n - b_n) < tol and abs(b_n - c_n) < tol:
+        return "spherical_top"
+    if abs(a_n - b_n) < tol or abs(b_n - c_n) < tol:
+        return "symmetric_top"
+    return "asymmetric_top"
+
+
+def _principal_moments(mol, conf) -> list[float]:
+    import numpy as np
+
+    n = mol.GetNumAtoms()
+    coords = np.array(
+        [[conf.GetAtomPosition(i).x, conf.GetAtomPosition(i).y, conf.GetAtomPosition(i).z] for i in range(n)]
+    )
+    masses = np.array([atom.GetMass() for atom in mol.GetAtoms()])
+    com = (coords * masses[:, None]).sum(axis=0) / masses.sum()
+    r = coords - com
+    inertia = np.zeros((3, 3))
+    for m, (x, y, z) in zip(masses, r):
+        inertia[0, 0] += m * (y * y + z * z)
+        inertia[1, 1] += m * (x * x + z * z)
+        inertia[2, 2] += m * (x * x + y * y)
+        inertia[0, 1] -= m * x * y
+        inertia[0, 2] -= m * x * z
+        inertia[1, 2] -= m * y * z
+    inertia[1, 0], inertia[2, 0], inertia[2, 1] = inertia[0, 1], inertia[0, 2], inertia[1, 2]
+    return sorted(float(w) for w in np.linalg.eigvalsh(inertia))
+
+
+def _point_group(symbols: list[str], coords: list[list[float]]) -> str | None:
+    """Point group via pymatgen if installed; None (with honest fallback) otherwise."""
+    try:
+        from pymatgen.core import Molecule
+        from pymatgen.symmetry.analyzer import PointGroupAnalyzer
+    except Exception:
+        return None
+    try:
+        return PointGroupAnalyzer(Molecule(symbols, coords)).get_pointgroup().sch_symbol
+    except Exception:
+        return None
+
+
+def geometry_descriptors(smiles: str, *, seed: int = 0xC0FFEE) -> dict[str, Any]:
+    """RDKit 3D embedding -> geometry descriptors for one conformer."""
+    Chem, AllChem, rdMolDescriptors = _require_rdkit()
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise GeometryEngineError(f"invalid SMILES: {smiles!r}")
+    canonical = Chem.MolToSmiles(mol, canonical=True)
+    formula = rdMolDescriptors.CalcMolFormula(mol)
+    mol_h = Chem.AddHs(mol)
+    params = AllChem.ETKDGv3()
+    params.randomSeed = seed
+    if AllChem.EmbedMolecule(mol_h, params) != 0:
+        raise GeometryEngineError(f"3D embedding failed for {smiles!r}")
+    AllChem.MMFFOptimizeMolecule(mol_h)
+    conf = mol_h.GetConformer()
+    moments = _principal_moments(mol_h, conf)
+    symbols = [atom.GetSymbol() for atom in mol_h.GetAtoms()]
+    coords = [
+        [conf.GetAtomPosition(i).x, conf.GetAtomPosition(i).y, conf.GetAtomPosition(i).z]
+        for i in range(mol_h.GetNumAtoms())
+    ]
+    pg = _point_group(symbols, coords)
+    return {
+        "canonical_smiles": canonical,
+        "formula": formula,
+        "n_atoms_with_h": mol_h.GetNumAtoms(),
+        "principal_moments": [round(m, 6) for m in moments],
+        "rotor_type": rotor_type(moments),
+        "npr1": round(float(rdMolDescriptors.CalcNPR1(mol_h)), 6),
+        "npr2": round(float(rdMolDescriptors.CalcNPR2(mol_h)), 6),
+        "point_group": pg,
+        "point_group_engine": "pymatgen" if pg is not None else "absent(pymatgen):rotor_type_proxy",
+    }
+
+
+def geometry_view_packet(smiles: str, *, seed: int = 0xC0FFEE) -> ReactionStatePacket:
+    """Wrap a molecule's 3D geometry as a hash-signed domain='geometry' packet."""
+    desc = geometry_descriptors(smiles, seed=seed)
+    pg_line = f"point_group={desc['point_group']} ({desc['point_group_engine']})"
+    return build_reaction_state_packet(
+        domain="geometry",
+        step=1,
+        bounded_operation="smiles_to_3d_geometry",
+        source=ReactionEndpoint(
+            identity=smiles,
+            representation="smiles",
+            language="chem",
+            tongue="KO",
+        ),
+        target=ReactionEndpoint(
+            identity=desc["canonical_smiles"],
+            representation="geometry_descriptors",
+            language="geometry",
+            tongue="DR",
+            metadata=desc,
+        ),
+        semantic_engravings=[
+            f"rotor_type={desc['rotor_type']}",
+            f"NPR=({desc['npr1']}, {desc['npr2']})",
+            pg_line,
+        ],
+        loss_notes=["single conformer sampled; full conformational ensemble not retained"],
+        recalculation=ReactionRecalculation(scientific_checks_ok=True, identity_ok=True),
+        identity_preserved=True,
+        recovery_evidence=["canonical SMILES retained (connectivity recoverable from 3D)"],
+        claim_boundary=[
+            "geometry from RDKit ETKDG + MMFF (one conformer)",
+            "point group requires pymatgen; rotor type is an inertial proxy when absent",
+            "shape/geometry descriptor lane, not a quantum-accurate structure",
+        ],
+    )

--- a/python/scbe/reaction_balance.py
+++ b/python/scbe/reaction_balance.py
@@ -1,0 +1,248 @@
+"""Exact reaction balancer — atom + charge conservation via rational nullspace.
+
+The chemistry stack already *decomposes* a single compound (RDKit) but never
+*balances* a multi-species reaction. This module fills that gap: given reactant
+and product formulas it finds the smallest positive integer coefficients that
+conserve every element and total charge, with ZERO model calls (the balance is
+the exact-rational nullspace of the composition matrix — the same move as the
+Mason backward solver), and emits a ``ReactionStatePacket`` receipt.
+
+Stdlib-only (``fractions``), so it runs anywhere the reaction CLI runs. It is a
+conservation/identity engine, not a thermodynamic-feasibility or kinetics claim;
+those defer to real engines (Cantera, NASA CEA) at the middle layer.
+
+Formula syntax: nested groups ``Ca(OH)2`` / ``[Fe(CN)6]``, hydrate dots
+``CuSO4.5H2O``, and charge as ``SO4^2-`` / ``(2-)`` / a bare trailing ``+``/``-``
+(= +/-1). Subscripts are counts; charge must be explicit (caret/paren/bare sign)
+to stay unambiguous (``O2-`` = 2 oxygens, charge -1; write ``Ca^2+`` not ``Ca2+``).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from fractions import Fraction
+from math import gcd
+from typing import List, Sequence, Tuple
+
+from .reaction_state import (
+    ReactionEndpoint,
+    ReactionRecalculation,
+    ReactionStatePacket,
+    build_reaction_state_packet,
+)
+
+
+class BalanceError(ValueError):
+    """Raised when a reaction cannot be uniquely balanced as written."""
+
+
+# --------------------------------------------------------------------------- #
+# Formula parsing
+# --------------------------------------------------------------------------- #
+
+
+def parse_formula(formula: str) -> Tuple[Counter, int]:
+    """Parse a chemical formula into ``(element_counts, charge)`` (exact ints)."""
+    body, charge = _split_charge(formula.strip())
+    counts: Counter = Counter()
+    for part in re.split(r"[.·]", body):
+        if not part:
+            continue
+        mult = 1
+        m = re.match(r"^(\d+)", part)
+        if m:
+            mult = int(m.group(1))
+            part = part[m.end() :]
+        for el, n in _parse_group(part).items():
+            counts[el] += n * mult
+    return counts, charge
+
+
+def _split_charge(formula: str) -> Tuple[str, int]:
+    m = re.search(r"\^(\d*)([+-])$", formula)  # ^2+, ^-, ^3-
+    if m:
+        mag = int(m.group(1)) if m.group(1) else 1
+        return formula[: m.start()], mag if m.group(2) == "+" else -mag
+    m = re.search(r"\((\d*)([+-])\)$", formula)  # (2-), (3+)
+    if m:
+        mag = int(m.group(1)) if m.group(1) else 1
+        return formula[: m.start()], mag if m.group(2) == "+" else -mag
+    m = re.search(r"([+-])$", formula)  # bare trailing sign => +/-1
+    if m:
+        return formula[: m.start()], 1 if m.group(1) == "+" else -1
+    return formula, 0
+
+
+def _parse_group(s: str) -> Counter:
+    counts: Counter = Counter()
+    stack: List[Counter] = [counts]
+    i, n = 0, len(s)
+    while i < n:
+        c = s[i]
+        if c in "([":
+            stack.append(Counter())
+            i += 1
+        elif c in ")]":
+            i += 1
+            m = re.match(r"\d+", s[i:])
+            mult = int(m.group()) if m else 1
+            if m:
+                i += m.end()
+            grp = stack.pop()
+            for el, k in grp.items():
+                stack[-1][el] += k * mult
+        else:
+            m = re.match(r"([A-Z][a-z]{0,2})(\d*)", s[i:])
+            if not m:
+                raise BalanceError(f"cannot parse formula fragment: {s[i:]!r}")
+            el = m.group(1)
+            k = int(m.group(2)) if m.group(2) else 1
+            stack[-1][el] += k
+            i += m.end()
+    if len(stack) != 1:
+        raise BalanceError(f"unbalanced parentheses in {s!r}")
+    return counts
+
+
+# --------------------------------------------------------------------------- #
+# Balancing
+# --------------------------------------------------------------------------- #
+
+
+def is_conserved(
+    reactants: Sequence[Tuple[int, str]],
+    products: Sequence[Tuple[int, str]],
+) -> Tuple[bool, dict]:
+    """Return ``(ok, deltas)`` for a coefficiented reaction (atoms + charge)."""
+    left: Counter = Counter()
+    right: Counter = Counter()
+    lq = rq = 0
+    for coeff, f in reactants:
+        comp, q = parse_formula(f)
+        for el, k in comp.items():
+            left[el] += coeff * k
+        lq += coeff * q
+    for coeff, f in products:
+        comp, q = parse_formula(f)
+        for el, k in comp.items():
+            right[el] += coeff * k
+        rq += coeff * q
+    deltas = {el: right[el] - left[el] for el in set(left) | set(right) if right[el] - left[el] != 0}
+    if lq != rq:
+        deltas["charge"] = rq - lq
+    return (not deltas), deltas
+
+
+def balance(reactants: Sequence[str], products: Sequence[str]) -> List[int]:
+    """Smallest positive integer coefficients conserving all atoms + charge.
+
+    Zero model calls: the exact-rational nullspace of the composition matrix.
+    Raises ``BalanceError`` if there is no unique positive balance as written.
+    """
+    species = list(reactants) + list(products)
+    if len(species) < 2:
+        raise BalanceError("need at least one reactant and one product")
+    signs = [1] * len(reactants) + [-1] * len(products)
+    comps = [parse_formula(f) for f in species]
+    elements = sorted({el for comp, _ in comps for el in comp})
+    rows: List[List[Fraction]] = []
+    for el in elements:
+        rows.append([Fraction(sign * comp.get(el, 0)) for (comp, _), sign in zip(comps, signs)])
+    rows.append([Fraction(sign * q) for (_, q), sign in zip(comps, signs)])  # charge row
+    null = _rational_nullspace(rows, len(species))
+    if len(null) != 1:
+        raise BalanceError(f"reaction has no unique balance (nullity={len(null)})")
+    vec = null[0]
+    lcm = 1
+    for v in vec:
+        lcm = lcm * v.denominator // gcd(lcm, v.denominator)
+    ints = [int(v * lcm) for v in vec]
+    g = 0
+    for v in ints:
+        g = gcd(g, abs(v))
+    if g:
+        ints = [v // g for v in ints]
+    if all(v <= 0 for v in ints):
+        ints = [-v for v in ints]
+    if not all(v > 0 for v in ints):
+        raise BalanceError(f"no positive balance with the given sides: {ints}")
+    return ints
+
+
+def _rational_nullspace(matrix: List[List[Fraction]], ncols: int) -> List[List[Fraction]]:
+    M = [row[:] for row in matrix]
+    nrows = len(M)
+    pivots: List[int] = []
+    r = 0
+    for c in range(ncols):
+        piv = next((rr for rr in range(r, nrows) if M[rr][c] != 0), None)
+        if piv is None:
+            continue
+        M[r], M[piv] = M[piv], M[r]
+        inv = M[r][c]
+        M[r] = [x / inv for x in M[r]]
+        for rr in range(nrows):
+            if rr != r and M[rr][c] != 0:
+                factor = M[rr][c]
+                M[rr] = [a - factor * b for a, b in zip(M[rr], M[r])]
+        pivots.append(c)
+        r += 1
+        if r == nrows:
+            break
+    free = [c for c in range(ncols) if c not in pivots]
+    basis: List[List[Fraction]] = []
+    for fc in free:
+        vec = [Fraction(0)] * ncols
+        vec[fc] = Fraction(1)
+        for pr, pc in enumerate(pivots):
+            vec[pc] = -M[pr][fc]
+        basis.append(vec)
+    return basis
+
+
+def format_equation(coeffs: Sequence[int], reactants: Sequence[str], products: Sequence[str]) -> str:
+    nr = len(reactants)
+
+    def side(cs: Sequence[int], fs: Sequence[str]) -> str:
+        return " + ".join((f if c == 1 else f"{c} {f}") for c, f in zip(cs, fs))
+
+    return f"{side(coeffs[:nr], reactants)} -> {side(coeffs[nr:], products)}"
+
+
+def balance_reaction_packet(reactants: Sequence[str], products: Sequence[str]) -> ReactionStatePacket:
+    """Balance a reaction and wrap the result in a hash-signed ReactionStatePacket."""
+    coeffs = balance(reactants, products)
+    nr = len(reactants)
+    equation = format_equation(coeffs, reactants, products)
+    ok, deltas = is_conserved(list(zip(coeffs[:nr], reactants)), list(zip(coeffs[nr:], products)))
+    return build_reaction_state_packet(
+        domain="chem",
+        step=1,
+        bounded_operation="balance_reaction",
+        source=ReactionEndpoint(
+            identity=" + ".join(reactants),
+            representation="reactant_formulas",
+            language="chem",
+            tongue="KO",
+        ),
+        target=ReactionEndpoint(
+            identity=" + ".join(products),
+            representation="product_formulas",
+            language="chem",
+            tongue="DR",
+            metadata={"equation": equation, "coefficients": list(coeffs)},
+        ),
+        semantic_engravings=[
+            f"balanced: {equation}",
+            f"coefficients: {list(coeffs)}",
+            "atom + charge conservation by exact rational nullspace",
+        ],
+        loss_notes=[] if ok else [f"not conserved: {deltas}"],
+        recalculation=ReactionRecalculation(scientific_checks_ok=ok, identity_ok=ok),
+        identity_preserved=ok,
+        claim_boundary=[
+            "exact atom + charge conservation (stoichiometry) only",
+            "not a thermodynamic-feasibility, equilibrium, or kinetics claim",
+        ],
+    )

--- a/python/scbe/reaction_state.py
+++ b/python/scbe/reaction_state.py
@@ -11,14 +11,12 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-ReactionClassification = Literal[
-    "BIJECTIVE", "LOSSY_RECOVERABLE", "LOSSY_AMBIGUOUS", "INVALID"
-]
-ReactionDomain = Literal["code", "chem", "audio", "agent", "data", "mixed"]
+ReactionClassification = Literal["BIJECTIVE", "LOSSY_RECOVERABLE", "LOSSY_AMBIGUOUS", "INVALID"]
+ReactionDomain = Literal["code", "chem", "audio", "agent", "data", "geometry", "mixed"]
 
 TONGUE_COLUMNS = {
     "KO": "identity",
@@ -31,12 +29,7 @@ TONGUE_COLUMNS = {
 
 
 def utc_now() -> str:
-    return (
-        datetime.now(timezone.utc)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def canonical_json(value: Any) -> str:
@@ -45,6 +38,20 @@ def canonical_json(value: Any) -> str:
 
 def sha256_value(value: Any) -> str:
     return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def unit_check(computation: Any) -> tuple[bool, tuple[str, ...]]:
+    """Honest source for ``ReactionRecalculation.unit_checks_ok``.
+
+    ``computation`` is a zero-arg thunk that performs ``python.scbe.units``
+    Quantity arithmetic; it raises on any dimensional/unit inconsistency
+    (including the Mars-Climate-Orbiter same-dimension/different-unit class).
+    Returns ``(ok, problems)``. The ``units`` engine is imported lazily so this
+    shared substrate stays stdlib-only at import time.
+    """
+    from .units import check
+
+    return check(computation)
 
 
 def packet_from_dict(data: dict[str, Any]) -> "ReactionStatePacket":
@@ -69,6 +76,9 @@ def packet_from_dict(data: dict[str, Any]) -> "ReactionStatePacket":
         claim_boundary=list(data.get("claim_boundary") or []),
         previous_packet_hash=data.get("previous_packet_hash"),
         packet_hash=data.get("packet_hash"),
+        signature=data.get("signature"),
+        signature_alg=data.get("signature_alg"),
+        signer_public_key=data.get("signer_public_key"),
     )
 
 
@@ -134,41 +144,77 @@ class ReactionStatePacket:
     claim_boundary: list[str] = field(default_factory=list)
     previous_packet_hash: str | None = None
     packet_hash: str | None = None
+    signature: str | None = None
+    signature_alg: str | None = None
+    signer_public_key: str | None = None
 
     def unsigned_dict(self) -> dict[str, Any]:
+        """Content for the integrity hash: drops the hash and signature fields so
+        signing a packet never invalidates its content hash (and old, unsigned
+        packets hash identically)."""
         data = asdict(self)
-        data.pop("packet_hash", None)
+        for key in ("packet_hash", "signature", "signature_alg", "signer_public_key"):
+            data.pop(key, None)
+        return data
+
+    def _signable_payload(self) -> dict[str, Any]:
+        """Payload the signature is computed over: everything except the signature
+        fields themselves. Includes ``packet_hash`` so the signature binds the hash
+        (and therefore the previous_packet_hash chain link)."""
+        data = asdict(self)
+        for key in ("signature", "signature_alg", "signer_public_key"):
+            data.pop(key, None)
         return data
 
     def compute_hash(self) -> str:
         return sha256_value(self.unsigned_dict())
 
     def to_dict(self) -> dict[str, Any]:
-        data = asdict(self)
-        return data
+        return asdict(self)
 
     def with_hash(self) -> "ReactionStatePacket":
-        packet_hash = self.compute_hash()
-        return ReactionStatePacket(
-            schema_version=self.schema_version,
-            generated_at_utc=self.generated_at_utc,
-            domain=self.domain,
-            step=self.step,
-            bounded_operation=self.bounded_operation,
-            source=self.source,
-            target=self.target,
-            semantic_engravings=list(self.semantic_engravings),
-            loss_notes=list(self.loss_notes),
-            recalculation=self.recalculation,
-            classification=self.classification,
-            tongue_columns=dict(self.tongue_columns),
-            claim_boundary=list(self.claim_boundary),
-            previous_packet_hash=self.previous_packet_hash,
-            packet_hash=packet_hash,
-        )
+        return replace(self, packet_hash=self.compute_hash())
 
     def verify_hash(self) -> bool:
         return bool(self.packet_hash) and self.compute_hash() == self.packet_hash
+
+    def sign(self, agent_id: str = "scbe-reaction-state") -> "ReactionStatePacket":
+        """Attach a real signature using the agent-bus EventSigner (ML-DSA-65 PQC,
+        Ed25519, or HMAC-SHA512 fallback). Never raises: if no signer is available
+        the packet is returned unchanged (signature stays None)."""
+        try:
+            from agents.agent_bus_signing import EventSigner
+        except Exception:  # pragma: no cover - signer module unavailable
+            return self
+        signer = EventSigner(agent_id)
+        try:
+            if not signer.initialize():
+                return self
+            sig_b64, pk_b64, alg = signer.sign(self._signable_payload())
+        except Exception:  # pragma: no cover - defensive: signing must not break a flow
+            return self
+        if not sig_b64:
+            return self
+        return replace(self, signature=sig_b64, signature_alg=alg, signer_public_key=pk_b64)
+
+    def verify_signature(self) -> bool | None:
+        """Public-key verify the signature. Returns True/False for asymmetric
+        signatures (ML-DSA-65, Ed25519), and None when the packet is unsigned or
+        carries only a symmetric (HMAC) signature that cannot be publicly verified."""
+        if not self.signature or self.signature_alg in (None, "unsigned", "HMAC-SHA512-sim"):
+            return None
+        try:
+            from agents.agent_bus_signing import EventSigner
+        except Exception:  # pragma: no cover
+            return None
+        return bool(
+            EventSigner.verify(
+                self._signable_payload(),
+                self.signature,
+                self.signer_public_key or "",
+                self.signature_alg,
+            )
+        )
 
 
 def classify_reaction(
@@ -178,11 +224,7 @@ def classify_reaction(
     loss_notes: list[str] | tuple[str, ...] = (),
     recovery_evidence: list[str] | tuple[str, ...] = (),
 ) -> ReactionClassification:
-    if (
-        recalculation.has_failure
-        or identity_preserved is False
-        and not recovery_evidence
-    ):
+    if recalculation.has_failure or identity_preserved is False and not recovery_evidence:
         return "INVALID" if recalculation.has_failure else "LOSSY_AMBIGUOUS"
     if not loss_notes and identity_preserved:
         return "BIJECTIVE"
@@ -229,3 +271,51 @@ def build_reaction_state_packet(
         previous_packet_hash=previous_packet_hash,
     )
     return packet.with_hash()
+
+
+class ReactionLedger:
+    """An append-only chain of reaction-state packets.
+
+    Each appended packet's ``previous_packet_hash`` is anchored to the prior
+    packet's ``packet_hash`` (so the chain is hash-linked) and, when a signer is
+    available, the packet is signed (so the chain is tamper-proof, not just
+    tamper-evident). ``verify()`` re-checks every hash, every link, and every
+    asymmetric signature.
+    """
+
+    def __init__(self, agent_id: str = "scbe-reaction-state", sign: bool = True) -> None:
+        self.agent_id = agent_id
+        self.sign = sign
+        self.packets: list[ReactionStatePacket] = []
+        self._last_hash: str | None = None
+
+    def append(self, **build_kwargs: Any) -> ReactionStatePacket:
+        build_kwargs.setdefault("previous_packet_hash", self._last_hash)
+        return self._anchor(build_reaction_state_packet(**build_kwargs))
+
+    def append_packet(self, packet: ReactionStatePacket) -> ReactionStatePacket:
+        """Chain an already-built packet (e.g. from ``balance_reaction_packet`` or
+        ``geometry_view_packet``): re-anchor its ``previous_packet_hash`` to the
+        prior packet, recompute the content hash, and sign. Lets domain builders
+        stay single-purpose while the ledger owns chaining + signing."""
+        return self._anchor(replace(packet, previous_packet_hash=self._last_hash))
+
+    def _anchor(self, packet: ReactionStatePacket) -> ReactionStatePacket:
+        packet = packet.with_hash()
+        if self.sign:
+            packet = packet.sign(self.agent_id)
+        self.packets.append(packet)
+        self._last_hash = packet.packet_hash
+        return packet
+
+    def verify(self) -> bool:
+        prev: str | None = None
+        for packet in self.packets:
+            if not packet.verify_hash():
+                return False
+            if packet.previous_packet_hash != prev:
+                return False
+            if packet.verify_signature() is False:  # None (unsigned/symmetric) is allowed
+                return False
+            prev = packet.packet_hash
+        return True

--- a/python/scbe/units.py
+++ b/python/scbe/units.py
@@ -1,0 +1,226 @@
+"""Exact, stdlib-only dimensional/unit engine for SCBE reaction-state checks.
+
+This is the missing piece that makes ``ReactionRecalculation.unit_checks_ok`` a
+REAL check instead of a hand-set boolean. Today callers set it to things like
+``isfinite(moles)``, which cannot catch the failure that actually destroys
+spacecraft: two quantities of the SAME dimension but a DIFFERENT unit, added
+without conversion. That is the Mars Climate Orbiter loss (1999, $125M): impulse
+in pound-force-seconds fed where newton-seconds were expected -- dimensionally
+valid, numerically wrong by 4.448x.
+
+Design:
+  * Exact: unit scales are ``fractions.Fraction``; no float drift in conversions.
+  * Stdlib-only: the shared reaction-state substrate stays dependency-free and
+    runs anywhere (as ``reaction_cli.py`` promises).
+  * Orbiter-safe: ``add``/``sub`` raise on a dimension mismatch AND on a
+    same-dimension/different-unit mix unless the caller converts explicitly.
+  * Optional Pint backend: if ``pint`` is installed, ``pint_agrees()`` cross-checks
+    against the community-standard catalog -- the "real engine when available"
+    pattern used elsewhere in this repo (RDKit, liboqs).
+
+It does not (v1) model affine units (degC/degF offsets) -- temperature is treated
+as kelvin-scaled only; that limitation is explicit, not silent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+from typing import Callable, Iterable
+
+# SI base dimensions, in fixed order.
+_BASE = ("kg", "m", "s", "A", "K", "mol", "cd")
+Dimension = tuple  # tuple[Fraction, ...] of length 7
+
+
+class UnitError(ValueError):
+    """Raised when a dimensional or unit-consistency invariant is violated."""
+
+
+def dim(**exponents: int) -> Dimension:
+    """Build a dimension from base-unit exponents, e.g. ``dim(kg=1, m=1, s=-2)``."""
+    return tuple(Fraction(exponents.get(b, 0)) for b in _BASE)
+
+
+DIMENSIONLESS = dim()
+MASS = dim(kg=1)
+LENGTH = dim(m=1)
+TIME = dim(s=1)
+TEMPERATURE = dim(K=1)
+AMOUNT = dim(mol=1)
+VELOCITY = dim(m=1, s=-1)
+ACCELERATION = dim(m=1, s=-2)
+FORCE = dim(kg=1, m=1, s=-2)
+ENERGY = dim(kg=1, m=2, s=-2)
+IMPULSE = dim(kg=1, m=1, s=-1)
+MOLAR_MASS = dim(kg=1, mol=-1)
+VOLUME = dim(m=3)
+CONCENTRATION = dim(mol=1, m=-3)
+
+
+def dim_mul(a: Dimension, b: Dimension) -> Dimension:
+    return tuple(x + y for x, y in zip(a, b))
+
+
+def dim_div(a: Dimension, b: Dimension) -> Dimension:
+    return tuple(x - y for x, y in zip(a, b))
+
+
+def dim_pow(a: Dimension, n) -> Dimension:
+    f = Fraction(n)
+    return tuple(x * f for x in a)
+
+
+def dim_name(d: Dimension) -> str:
+    parts = [f"{b}^{x}" if x != 1 else b for b, x in zip(_BASE, d) if x != 0]
+    return "·".join(parts) if parts else "1"
+
+
+@dataclass(frozen=True)
+class Unit:
+    """A named unit: a dimension plus an EXACT multiplicative scale to SI base."""
+
+    name: str
+    dimension: Dimension
+    to_si: Fraction  # SI_magnitude = magnitude * to_si
+
+    def __mul__(self, other: "Unit") -> "Unit":
+        return Unit(f"({self.name}*{other.name})", dim_mul(self.dimension, other.dimension), self.to_si * other.to_si)
+
+    def __truediv__(self, other: "Unit") -> "Unit":
+        return Unit(f"({self.name}/{other.name})", dim_div(self.dimension, other.dimension), self.to_si / other.to_si)
+
+
+# ---- registry: SI + the two force/impulse units that demonstrate the catch --- #
+KILOGRAM = Unit("kg", MASS, Fraction(1))
+GRAM = Unit("g", MASS, Fraction(1, 1000))
+METER = Unit("m", LENGTH, Fraction(1))
+SECOND = Unit("s", TIME, Fraction(1))
+KELVIN = Unit("K", TEMPERATURE, Fraction(1))
+MOLE = Unit("mol", AMOUNT, Fraction(1))
+PER_MOLE = Unit("1/mol", dim(mol=-1), Fraction(1))
+DIMLESS = Unit("1", DIMENSIONLESS, Fraction(1))
+
+NEWTON = Unit("N", FORCE, Fraction(1))
+POUND_FORCE = Unit("lbf", FORCE, Fraction(444822, 100000))  # 4.44822 N (exact rational)
+NEWTON_SECOND = Unit("N*s", IMPULSE, Fraction(1))
+LBF_SECOND = Unit("lbf*s", IMPULSE, POUND_FORCE.to_si)  # same dimension, 4.448x scale
+
+JOULE = Unit("J", ENERGY, Fraction(1))
+G_PER_MOL = Unit("g/mol", MOLAR_MASS, Fraction(1, 1000))  # kg/mol = (g/mol)/1000
+LITER = Unit("L", VOLUME, Fraction(1, 1000))
+MOL_PER_L = Unit("mol/L", CONCENTRATION, Fraction(1000))  # mol/L = 1000 mol/m^3
+
+AVOGADRO = Unit("1/mol", dim(mol=-1), Fraction(602214076, 1) * Fraction(10) ** 15)  # 6.02214076e23 /mol
+
+
+@dataclass(frozen=True)
+class Quantity:
+    """A magnitude tagged with a unit. Magnitudes may be Fraction/int/float."""
+
+    magnitude: object
+    unit: Unit
+
+    @property
+    def dimension(self) -> Dimension:
+        return self.unit.dimension
+
+    def to_si(self) -> object:
+        return self.magnitude * self.unit.to_si
+
+
+def q(magnitude, unit: Unit) -> Quantity:
+    return Quantity(magnitude, unit)
+
+
+def same_dimension(a: Quantity, b: Quantity) -> bool:
+    return a.unit.dimension == b.unit.dimension
+
+
+def convert(value: Quantity, target: Unit) -> Quantity:
+    """Convert to ``target`` (must share dimension). The ONLY sanctioned way to
+    bring two same-dimension/different-unit quantities into one unit."""
+    if value.unit.dimension != target.dimension:
+        raise UnitError(
+            f"cannot convert {value.unit.name} ({dim_name(value.unit.dimension)}) "
+            f"-> {target.name} ({dim_name(target.dimension)}): different dimension"
+        )
+    return Quantity(value.to_si() / target.to_si, target)
+
+
+def add(a: Quantity, b: Quantity) -> Quantity:
+    """Add two quantities. Raises UnitError on a dimension mismatch, and on a
+    same-dimension/DIFFERENT-unit mix (the Orbiter bug) -- convert first."""
+    if a.unit.dimension != b.unit.dimension:
+        raise UnitError(f"dimension mismatch: {a.unit.name} + {b.unit.name}")
+    if a.unit.to_si != b.unit.to_si:
+        raise UnitError(
+            f"unit mismatch (same dimension '{dim_name(a.unit.dimension)}', different unit): "
+            f"{a.unit.name} + {b.unit.name} -- convert() first "
+            f"(this is the Mars Climate Orbiter class of error)"
+        )
+    return Quantity(a.magnitude + b.magnitude, a.unit)
+
+
+def sub(a: Quantity, b: Quantity) -> Quantity:
+    return add(a, Quantity(-b.magnitude, b.unit))
+
+
+def mul(a: Quantity, b: Quantity) -> Quantity:
+    return Quantity(a.magnitude * b.magnitude, a.unit * b.unit)
+
+
+def div(a: Quantity, b: Quantity) -> Quantity:
+    return Quantity(a.magnitude / b.magnitude, a.unit / b.unit)
+
+
+def assert_dim(value: Quantity, expected: Dimension) -> Quantity:
+    """Assert that ``value`` carries the expected dimension; return it unchanged."""
+    if value.unit.dimension != expected:
+        raise UnitError(
+            f"dimension check failed: got {dim_name(value.unit.dimension)} "
+            f"({value.unit.name}), expected {dim_name(expected)}"
+        )
+    return value
+
+
+def check(fn: Callable[[], object]) -> tuple[bool, tuple[str, ...]]:
+    """Run a units-bearing computation and report whether it stayed consistent.
+
+    Callers express their computation in ``Quantity`` arithmetic (which raises
+    ``UnitError`` on any inconsistency) and pass it as a thunk. The result is a
+    ``(ok, problems)`` pair suitable for setting ``unit_checks_ok`` honestly::
+
+        ok, problems = check(lambda: assert_dim(
+            div(q(32.0, GRAM), q(32.0, G_PER_MOL)), AMOUNT))   # g / (g/mol) = mol
+    """
+    try:
+        fn()
+        return True, ()
+    except UnitError as exc:
+        return False, (str(exc),)
+
+
+def pint_agrees(magnitude, unit_expr: str, expected_dim_expr: str) -> bool | None:
+    """Optional cross-check against Pint, if installed. Returns None if Pint is
+    absent (so callers can treat it as "not evaluated", never as a failure)."""
+    try:
+        import pint  # type: ignore
+    except Exception:
+        return None
+    try:
+        ureg = pint.UnitRegistry()
+        quantity = magnitude * ureg(unit_expr)
+        return bool(quantity.check(expected_dim_expr))
+    except Exception:
+        return False
+
+
+def consistency_problems(steps: Iterable[Callable[[], object]]) -> tuple[str, ...]:
+    """Run several units-bearing steps; collect all problems (empty == all ok)."""
+    problems: list[str] = []
+    for step in steps:
+        ok, errs = check(step)
+        if not ok:
+            problems.extend(errs)
+    return tuple(problems)

--- a/scripts/benchmark/compound_decomposition_recomposition.py
+++ b/scripts/benchmark/compound_decomposition_recomposition.py
@@ -34,10 +34,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from python.scbe import units as _U
 from python.scbe.reaction_state import (
     ReactionEndpoint,
     ReactionRecalculation,
     build_reaction_state_packet,
+    unit_check,
 )
 
 OUT_DIR = REPO_ROOT / "artifacts" / "benchmarks" / "compound_decomposition_recomposition"
@@ -613,7 +615,22 @@ def run_case(case: CompoundCase) -> dict[str, Any]:
         ],
         recalculation=ReactionRecalculation(
             scientific_checks_ok=ok,
-            unit_checks_ok=math.isfinite(dim["moles"]) and math.isfinite(dim["molecules"]),
+            # Real dimensional check (not just isfinite): grams / (g/mol) must be
+            # moles, and moles * Avogadro must be a dimensionless molecule count.
+            unit_checks_ok=unit_check(
+                lambda: _U.assert_dim(
+                    _U.mul(
+                        _U.div(
+                            _U.q(case.sample_grams, _U.GRAM),
+                            _U.q(desc["mol_wt"], _U.G_PER_MOL),
+                        ),
+                        _U.q(1, _U.AVOGADRO),
+                    ),
+                    _U.DIMENSIONLESS,
+                )
+            )[0]
+            and math.isfinite(dim["moles"])
+            and math.isfinite(dim["molecules"]),
             identity_ok=selected["canonical_smiles"] == expected_canonical,
             extra={
                 "formula_ok": desc["formula"] == case.expected_formula,

--- a/scripts/reaction_cli.py
+++ b/scripts/reaction_cli.py
@@ -24,6 +24,8 @@ from python.scbe.audio_field_observables import (
     generate_decaying_sine,
     generate_sine,
 )
+from python.scbe.geometry_view import GeometryEngineError, geometry_view_packet
+from python.scbe.reaction_balance import BalanceError, balance_reaction_packet
 from python.scbe.reaction_state import (
     ReactionEndpoint,
     ReactionRecalculation,
@@ -75,6 +77,8 @@ def audit_packet(path: str) -> dict[str, Any]:
                 "loss_count": len(packet.loss_notes),
                 "engraving_count": len(packet.semantic_engravings),
                 "claim_boundary": packet.claim_boundary,
+                "signature_alg": packet.signature_alg,
+                "signature_verified": packet.verify_signature(),
             }
         )
     return {
@@ -254,8 +258,9 @@ def build_audio_packet(
 def print_human_audit(payload: dict[str, Any]) -> None:
     print(f"reaction audit: ok={payload['ok']} packets={payload['packet_count']}")
     for row in payload["packets"]:
+        sig = f" sig={row['signature_alg']}/{row['signature_verified']}" if row.get("signature_alg") else ""
         print(
-            f"- #{row['index']} {row['classification']} hash_ok={row['hash_ok']} "
+            f"- #{row['index']} {row['classification']} hash_ok={row['hash_ok']}{sig} "
             f"{row['source_identity']} -> {row['target_identity']}"
         )
 
@@ -293,6 +298,62 @@ def print_human_audio(payload: dict[str, Any]) -> None:
     )
 
 
+def build_balance(reactants: str, products: str) -> dict[str, Any]:
+    react = [s.strip() for s in reactants.split(",") if s.strip()]
+    prod = [s.strip() for s in products.split(",") if s.strip()]
+    try:
+        packet = balance_reaction_packet(react, prod)
+    except BalanceError as exc:
+        return {
+            "schema_version": "scbe_react_balance_v1",
+            "ok": False,
+            "error": str(exc),
+            "reactants": react,
+            "products": prod,
+        }
+    return {
+        "schema_version": "scbe_react_balance_v1",
+        "ok": bool(packet.recalculation.identity_ok),
+        "equation": packet.target.metadata.get("equation"),
+        "coefficients": packet.target.metadata.get("coefficients"),
+        "reaction_state_packet": packet.to_dict(),
+    }
+
+
+def print_human_balance(payload: dict[str, Any]) -> None:
+    if not payload.get("ok"):
+        print(f"reaction balance: FAILED {payload.get('error', '')}")
+        return
+    print(f"reaction balance: {payload['equation']}")
+    print(f"coefficients: {payload['coefficients']}")
+
+
+def build_geometry(smiles: str) -> dict[str, Any]:
+    try:
+        packet = geometry_view_packet(smiles)
+    except GeometryEngineError as exc:
+        return {"schema_version": "scbe_react_geometry_v1", "ok": False, "error": str(exc), "smiles": smiles}
+    meta = packet.target.metadata
+    return {
+        "schema_version": "scbe_react_geometry_v1",
+        "ok": True,
+        "formula": meta.get("formula"),
+        "rotor_type": meta.get("rotor_type"),
+        "point_group": meta.get("point_group"),
+        "reaction_state_packet": packet.to_dict(),
+    }
+
+
+def print_human_geometry(payload: dict[str, Any]) -> None:
+    if not payload.get("ok"):
+        print(f"reaction geometry: FAILED {payload.get('error', '')}")
+        return
+    print(
+        f"reaction geometry: {payload['formula']} "
+        f"rotor={payload['rotor_type']} point_group={payload['point_group']}"
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(prog="scbe react")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -307,6 +368,13 @@ def main() -> int:
     code.add_argument("--source", required=True)
     code.add_argument("--target", required=True)
     code.add_argument("--json", action="store_true")
+    balance_parser = sub.add_parser("balance")
+    balance_parser.add_argument("--reactants", required=True, help="comma-separated formulas, e.g. C3H8,O2")
+    balance_parser.add_argument("--products", required=True, help="comma-separated formulas, e.g. CO2,H2O")
+    balance_parser.add_argument("--json", action="store_true")
+    geometry_parser = sub.add_parser("geometry")
+    geometry_parser.add_argument("--smiles", required=True, help="SMILES string, e.g. CCO")
+    geometry_parser.add_argument("--json", action="store_true")
     audio = sub.add_parser("audio")
     audio.add_argument("--frequency", type=float, default=440.0)
     audio.add_argument("--sample-rate", type=float, default=4096.0)
@@ -343,6 +411,20 @@ def main() -> int:
             print(json.dumps(payload, indent=2))
         else:
             print_human_code(payload)
+        return 0 if payload["ok"] else 1
+    if args.cmd == "balance":
+        payload = build_balance(args.reactants, args.products)
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print_human_balance(payload)
+        return 0 if payload["ok"] else 1
+    if args.cmd == "geometry":
+        payload = build_geometry(args.smiles)
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print_human_geometry(payload)
         return 0 if payload["ok"] else 1
     if args.cmd == "audio":
         payload = build_audio_packet(

--- a/tests/test_geometry_view.py
+++ b/tests/test_geometry_view.py
@@ -1,0 +1,63 @@
+"""Regression locks for the geometry view (python/scbe/geometry_view.py).
+
+The rotor classifier is a pure function and always runs; the RDKit-backed paths
+skip cleanly where RDKit is not installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from python.scbe.geometry_view import GeometryEngineError, rotor_type
+
+
+def test_rotor_type_pure_classification():
+    assert rotor_type([0.0, 1.0, 1.0]) == "linear"
+    assert rotor_type([1.0, 1.0, 1.0]) == "spherical_top"
+    assert rotor_type([1.0, 1.0, 2.0]) == "symmetric_top"
+    assert rotor_type([1.0, 2.0, 3.0]) == "asymmetric_top"
+
+
+def test_rotor_type_is_order_independent():
+    assert rotor_type([2.0, 0.0, 2.0]) == "linear"
+
+
+def test_geometry_descriptors_co2_is_linear():
+    pytest.importorskip("rdkit")
+    from python.scbe.geometry_view import geometry_descriptors
+
+    desc = geometry_descriptors("O=C=O")
+    assert desc["rotor_type"] == "linear"
+    assert desc["formula"] == "CO2"
+
+
+def test_geometry_descriptors_methane_is_spherical():
+    pytest.importorskip("rdkit")
+    from python.scbe.geometry_view import geometry_descriptors
+
+    desc = geometry_descriptors("C")
+    assert desc["rotor_type"] == "spherical_top"
+
+
+def test_geometry_packet_is_lossy_recoverable_and_hash_verifies():
+    pytest.importorskip("rdkit")
+    from python.scbe.geometry_view import geometry_view_packet
+
+    packet = geometry_view_packet("CCO")
+    assert packet.domain == "geometry"
+    assert packet.classification == "LOSSY_RECOVERABLE"
+    assert packet.verify_hash()
+    assert packet.target.metadata["rotor_type"] in {
+        "linear",
+        "spherical_top",
+        "symmetric_top",
+        "asymmetric_top",
+    }
+
+
+def test_invalid_smiles_raises():
+    pytest.importorskip("rdkit")
+    from python.scbe.geometry_view import geometry_descriptors
+
+    with pytest.raises(GeometryEngineError):
+        geometry_descriptors("not_a_smiles@@@")

--- a/tests/test_reaction_balance.py
+++ b/tests/test_reaction_balance.py
@@ -1,0 +1,58 @@
+"""Regression locks for the exact reaction balancer (python/scbe/reaction_balance.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from python.scbe.reaction_balance import (
+    BalanceError,
+    balance,
+    balance_reaction_packet,
+    format_equation,
+    is_conserved,
+    parse_formula,
+)
+
+
+def test_parse_formula_handles_groups_and_charge():
+    counts, charge = parse_formula("Ca(OH)2")
+    assert dict(counts) == {"Ca": 1, "O": 2, "H": 2} and charge == 0
+    counts, charge = parse_formula("(NH4)2SO4")
+    assert dict(counts) == {"N": 2, "H": 8, "S": 1, "O": 4} and charge == 0
+    counts, charge = parse_formula("SO4^2-")
+    assert dict(counts) == {"S": 1, "O": 4} and charge == -2
+    counts, charge = parse_formula("CuSO4.5H2O")
+    assert dict(counts) == {"Cu": 1, "S": 1, "O": 9, "H": 10} and charge == 0
+
+
+def test_balance_combustion_propane():
+    assert balance(["C3H8", "O2"], ["CO2", "H2O"]) == [1, 5, 3, 4]
+
+
+def test_balance_water_and_rust():
+    assert balance(["H2", "O2"], ["H2O"]) == [2, 1, 2]
+    assert balance(["Fe", "O2"], ["Fe2O3"]) == [4, 3, 2]
+
+
+def test_balance_conserves_charge_precipitation():
+    coeffs = balance(["Ag^+", "Cl^-"], ["AgCl"])
+    ok, deltas = is_conserved(list(zip(coeffs[:2], ["Ag^+", "Cl^-"])), list(zip(coeffs[2:], ["AgCl"])))
+    assert ok and deltas == {}
+
+
+def test_unbalanceable_raises():
+    with pytest.raises(BalanceError):
+        balance(["H2"], ["O2"])  # no shared element, impossible to conserve
+
+
+def test_format_equation_drops_unit_coefficients():
+    eq = format_equation([1, 5, 3, 4], ["C3H8", "O2"], ["CO2", "H2O"])
+    assert eq == "C3H8 + 5 O2 -> 3 CO2 + 4 H2O"
+
+
+def test_balance_packet_is_bijective_and_hash_verifies():
+    packet = balance_reaction_packet(["C3H8", "O2"], ["CO2", "H2O"])
+    assert packet.classification == "BIJECTIVE"
+    assert packet.verify_hash()
+    assert packet.recalculation.identity_ok is True
+    assert packet.target.metadata["coefficients"] == [1, 5, 3, 4]

--- a/tests/test_reaction_state_packet.py
+++ b/tests/test_reaction_state_packet.py
@@ -1,11 +1,37 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
+import pytest
+
 from python.scbe.reaction_state import (
     ReactionEndpoint,
+    ReactionLedger,
     ReactionRecalculation,
     build_reaction_state_packet,
     classify_reaction,
 )
+
+
+def _kwargs(**overrides):
+    base = dict(
+        domain="code",
+        step=1,
+        bounded_operation="op",
+        source=ReactionEndpoint(identity="a", representation="x", tongue="KO"),
+        target=ReactionEndpoint(identity="b", representation="y", tongue="DR"),
+        semantic_engravings=["e"],
+        loss_notes=[],
+        recalculation=ReactionRecalculation(identity_ok=True),
+        identity_preserved=True,
+        generated_at_utc="2026-06-11T00:00:00Z",
+    )
+    base.update(overrides)
+    return base
+
+
+def _sample_packet(**overrides):
+    return build_reaction_state_packet(**_kwargs(**overrides))
 
 
 def test_bijective_packet_hash_verifies() -> None:
@@ -73,3 +99,68 @@ def test_failed_recalculation_is_invalid() -> None:
     )
 
     assert classification == "INVALID"
+
+
+def test_signing_preserves_the_content_hash() -> None:
+    # Signing must never invalidate the integrity hash: the hash is computed over
+    # content that excludes the signature fields, so an unsigned packet and its
+    # signed self carry the identical packet_hash (backward compatibility).
+    packet = _sample_packet()
+    signed = packet.sign("scbe-test-signing")
+
+    assert signed.packet_hash == packet.packet_hash
+    assert signed.verify_hash() is True
+
+
+def test_packet_signature_verifies_and_tamper_is_caught() -> None:
+    signed = _sample_packet().sign("scbe-test-signing")
+
+    if signed.signature_alg in (None, "unsigned", "HMAC-SHA512-sim"):
+        pytest.skip(f"no public-key signer available (alg={signed.signature_alg})")
+
+    assert signed.signature
+    assert signed.signer_public_key
+    # Real public-key signature over the content verifies...
+    assert signed.verify_signature() is True
+    # ...and any tamper to signed content flips verification to not-True.
+    tampered = replace(signed, semantic_engravings=["e", "tampered"])
+    assert tampered.verify_signature() is not True
+
+
+def test_reaction_ledger_anchors_chain_and_verifies() -> None:
+    ledger = ReactionLedger("scbe-test-ledger")
+    p1 = ledger.append(**_kwargs(step=1, bounded_operation="first"))
+    p2 = ledger.append(**_kwargs(step=2, bounded_operation="second"))
+
+    # The chain is hash-linked: each packet anchors the prior packet's hash.
+    assert p1.previous_packet_hash is None
+    assert p2.previous_packet_hash == p1.packet_hash
+    assert p2.packet_hash != p1.packet_hash
+    assert ledger.verify() is True
+
+
+def test_reaction_ledger_chains_prebuilt_packets() -> None:
+    # Domain builders return standalone packets (each with previous_packet_hash
+    # = None); append_packet re-anchors and signs them into one chain.
+    ledger = ReactionLedger("scbe-test-ledger")
+    standalone_a = _sample_packet(step=1, bounded_operation="balance")
+    standalone_b = _sample_packet(step=2, bounded_operation="geometry")
+    assert standalone_a.previous_packet_hash is None
+    assert standalone_b.previous_packet_hash is None
+
+    a = ledger.append_packet(standalone_a)
+    b = ledger.append_packet(standalone_b)
+
+    assert a.previous_packet_hash is None
+    assert b.previous_packet_hash == a.packet_hash
+    assert ledger.verify() is True
+
+
+def test_reaction_ledger_detects_a_broken_link() -> None:
+    ledger = ReactionLedger("scbe-test-ledger")
+    ledger.append(**_kwargs(step=1, bounded_operation="first"))
+    ledger.append(**_kwargs(step=2, bounded_operation="second"))
+
+    # Snap the chain by rewriting the second packet's anchor; verify() must fail.
+    ledger.packets[1] = replace(ledger.packets[1], previous_packet_hash="deadbeef")
+    assert ledger.verify() is False

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,78 @@
+"""Regression locks for the exact units engine (python/scbe/units.py).
+
+These freeze the behaviour that makes ``unit_checks_ok`` a real check: the
+Mars-Climate-Orbiter catch (same dimension, different unit, no conversion), exact
+conversion, and chemistry dimensional consistency (g / (g/mol) = mol).
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+
+from python.scbe import units as U
+from python.scbe.reaction_state import unit_check
+
+
+def test_orbiter_catch_same_dimension_different_unit_raises():
+    # N*s and lbf*s share the IMPULSE dimension but differ by 4.448x.
+    with pytest.raises(U.UnitError):
+        U.add(U.q(100, U.NEWTON_SECOND), U.q(100, U.LBF_SECOND))
+
+
+def test_explicit_conversion_is_exact_then_add_ok():
+    converted = U.convert(U.q(100, U.LBF_SECOND), U.NEWTON_SECOND)
+    # exact rational: 100 lbf*s = 100 * 4.44822 N*s
+    assert converted.magnitude == Fraction(100) * Fraction(444822, 100000)
+    total = U.add(U.q(100, U.NEWTON_SECOND), converted)
+    assert total.unit is U.NEWTON_SECOND
+    assert total.magnitude == Fraction(100) + Fraction(100) * Fraction(444822, 100000)
+
+
+def test_dimension_mismatch_raises():
+    with pytest.raises(U.UnitError):
+        U.add(U.q(1, U.NEWTON), U.q(1, U.JOULE))  # force + energy
+
+
+def test_chemistry_dimensional_consistency_grams_over_molar_mass_is_moles():
+    # 32.0 g / (32.0 g/mol) = 1 mol, then * Avogadro/mol = dimensionless count.
+    def computation():
+        moles = U.div(U.q(Fraction(32), U.GRAM), U.q(Fraction(32), U.G_PER_MOL))
+        U.assert_dim(moles, U.AMOUNT)
+        count = U.mul(moles, U.q(1, U.AVOGADRO))
+        U.assert_dim(count, U.DIMENSIONLESS)
+        return count
+
+    ok, problems = U.check(computation)
+    assert ok and problems == ()
+
+
+def test_null_scrambled_computation_is_flagged():
+    # grams + seconds is nonsense; check() must report not-ok rather than raise.
+    ok, problems = U.check(lambda: U.add(U.q(1, U.GRAM), U.q(1, U.SECOND)))
+    assert not ok and problems
+
+
+def test_reaction_state_unit_check_wrapper_flags_orbiter_and_passes_valid():
+    bad_ok, bad_problems = unit_check(lambda: U.add(U.q(100, U.NEWTON_SECOND), U.q(100, U.LBF_SECOND)))
+    assert not bad_ok and bad_problems
+
+    good_ok, good_problems = unit_check(
+        lambda: U.assert_dim(U.div(U.q(Fraction(46), U.GRAM), U.q(Fraction(46), U.G_PER_MOL)), U.AMOUNT)
+    )
+    assert good_ok and good_problems == ()
+
+
+def test_pint_backend_is_optional_never_a_hard_failure():
+    # Returns None when pint is absent; True/False when present. Never raises.
+    result = U.pint_agrees(100, "newton * second", "[mass] * [length] / [time]")
+    assert result in (None, True, False)
+
+
+def test_unit_compose_dimensions_are_exact():
+    # (kg/s) * (m/s) has the dimension of force.
+    mdot = U.Unit("kg/s", U.dim(kg=1, s=-1), Fraction(1))
+    v = U.Unit("m/s", U.VELOCITY, Fraction(1))
+    thrust = mdot * v
+    assert thrust.dimension == U.FORCE


### PR DESCRIPTION
## Summary
Chemistry verifier lanes for the reaction-state spine, plus an honesty upgrade to the receipts: they were *tamper-evident* (unkeyed SHA-256) and described as "hash-signed" — now they carry **real signatures** (ML-DSA-65 PQC via the agent-bus `EventSigner` where liboqs is present, Ed25519/HMAC fallback tiers otherwise).

## What's in it
- **`python/scbe/units.py`** — exact stdlib dimensional/unit engine (Fraction-scaled SI base dimensions). `add()` rejects dimension mismatches **and** the Mars-Climate-Orbiter class (same dimension, different unit — N·s vs lbf·s). Optional pint cross-check.
- **`python/scbe/reaction_balance.py`** — exact reaction balancer via rational nullspace of the composition matrix (atom + charge conservation, zero model calls). Formula parser handles parens, hydrate dots, charges.
- **`python/scbe/geometry_view.py`** — RDKit (ETKDG+MMFF) 3D geometry as a `domain='geometry'` spine view; principal-moments rotor classifier; point group via pymatgen when installed (honest proxy note when not).
- **`python/scbe/reaction_state.py`** — `signature`/`signature_alg`/`signer_public_key` fields + `sign()`/`verify_signature()`; the signature binds `packet_hash` and therefore the `previous_packet_hash` chain link. `ReactionLedger` chains, signs, and re-verifies whole receipt chains. `unsigned_dict()` excludes signature fields so **pre-existing unsigned packets hash byte-identically** (backward compatible).
- **`scripts/reaction_cli.py`** — `react balance` + `react geometry` subcommands; `react audit` surfaces `signature_alg`/`signature_verified`.
- **Compound benchmark** — `unit_checks_ok` now computed by the real units engine instead of `isfinite()`.

Depends on the `MLDSA65.from_keypair` fix (#2172, already on main) — without it, persisted signing identities produced unverifiable signatures after a process restart.

## Verification (on this exact base)
- 30 tests green in **both** normal and `SCBE_FORCE_SKIP_LIBOQS=1` (CI) modes
- CLI smoke: `balance` → `C3H8 + 5 O2 -> 3 CO2 + 4 H2O`; `geometry O=C=O` → linear rotor
- Signed methalox chain previously proven end-to-end: fresh-process re-verify True; tamper flips both signature and content hash to False
- flake8 clean; only the 10 intended files are touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)