### PR TITLE
ci(tests): PR-gate the reaction-state + chemistry verifier test lanes

### DIFF
--- a/scripts/system/run_core_python_checks.py
+++ b/scripts/system/run_core_python_checks.py
@@ -35,6 +35,13 @@ CORE_SMOKE_PATHS: tuple[str, ...] = (
     "tests/system/test_trap_redirect_cli.py",
     "tests/system/test_trap_dispatch_cli.py",
     "tests/system/test_trap_dispatch_workspace_cli.py",
+    # Reaction-state spine + chemistry verifier lanes (signed receipts,
+    # exact units, balancer, geometry view). rdkit-dependent geometry
+    # tests importorskip cleanly where rdkit is absent.
+    "tests/test_reaction_state_packet.py",
+    "tests/test_units.py",
+    "tests/test_reaction_balance.py",
+    "tests/test_geometry_view.py",
 )
 
 # Optional or experimental lanes that currently pull in extra services,


### PR DESCRIPTION
## Summary
Follow-up to #2174: add the four new product-surface test files to `CORE_SMOKE_PATHS` in `scripts/system/run_core_python_checks.py`, per that script's own guidance ("When you add a new product surface, add the test path here so regressions get caught on PR rather than discovered post-merge").

Newly PR-gated lanes:
- `tests/test_reaction_state_packet.py` — signed receipts, hash chain, tamper detection
- `tests/test_units.py` — exact dimensional engine (Orbiter-class catches)
- `tests/test_reaction_balance.py` — exact reaction balancer
- `tests/test_geometry_view.py` — geometry view (rdkit paths importorskip cleanly in CI where rdkit is absent)

## Verification
`run_core_python_checks.py` exit 0 under `SCBE_FORCE_SKIP_LIBOQS=1` on current main with these entries included — replicates the CI python job end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)