### PR TITLE
feat(receipts): sign every react CLI receipt; keep oqs banner off stdout

### DIFF
--- a/scripts/reaction_cli.py
+++ b/scripts/reaction_cli.py
@@ -33,6 +33,11 @@ from python.scbe.reaction_state import (
     packet_from_dict,
 )
 
+# Every packet this CLI emits is signed under one stable identity so receipts
+# are attributable and chainable across runs. sign() degrades to an unsigned
+# packet (signature stays None) where no signer backend is available.
+SIGNER_AGENT_ID = "scbe-react-cli"
+
 
 def load_json(path: str) -> dict[str, Any]:
     return json.loads(Path(path).read_text(encoding="utf-8"))
@@ -160,7 +165,7 @@ def build_code_packet(source_path: str, target_path: str) -> dict[str, Any]:
             "hash equality proves byte identity only",
             "semantic equivalence requires tests or a language-specific analyzer",
         ],
-    )
+    ).sign(SIGNER_AGENT_ID)
     return {
         "schema_version": "scbe_react_code_v1",
         "ok": identity_preserved,
@@ -246,7 +251,7 @@ def build_audio_packet(
         identity_preserved=observables.modal_count_state.ok,
         recovery_evidence=["field coupling proxy emitted"] if observables.field_coupling_proxy is not None else (),
         claim_boundary=list(observables.claim_boundary),
-    )
+    ).sign(SIGNER_AGENT_ID)
     return {
         "schema_version": "scbe_react_audio_v1",
         "ok": observables.modal_count_state.ok,
@@ -302,7 +307,7 @@ def build_balance(reactants: str, products: str) -> dict[str, Any]:
     react = [s.strip() for s in reactants.split(",") if s.strip()]
     prod = [s.strip() for s in products.split(",") if s.strip()]
     try:
-        packet = balance_reaction_packet(react, prod)
+        packet = balance_reaction_packet(react, prod).sign(SIGNER_AGENT_ID)
     except BalanceError as exc:
         return {
             "schema_version": "scbe_react_balance_v1",
@@ -330,7 +335,7 @@ def print_human_balance(payload: dict[str, Any]) -> None:
 
 def build_geometry(smiles: str) -> dict[str, Any]:
     try:
-        packet = geometry_view_packet(smiles)
+        packet = geometry_view_packet(smiles).sign(SIGNER_AGENT_ID)
     except GeometryEngineError as exc:
         return {"schema_version": "scbe_react_geometry_v1", "ok": False, "error": str(exc), "smiles": smiles}
     meta = packet.target.metadata

--- a/src/crypto/pqc_liboqs.py
+++ b/src/crypto/pqc_liboqs.py
@@ -24,8 +24,16 @@ from dataclasses import dataclass
 
 def _load_oqs_module():
     """Load liboqs-python without letting optional backend bootstrap kill import."""
+    import contextlib
+    import sys
+
     try:
-        import oqs as oqs_module
+        # liboqs-python prints an informational banner to STDOUT on import
+        # ("liboqs-python faulthandler is disabled"). Consumers of this module
+        # sign lazily from CLIs whose stdout is a machine-readable JSON
+        # contract, so route the banner to stderr where diagnostics belong.
+        with contextlib.redirect_stdout(sys.stderr):
+            import oqs as oqs_module
 
         return oqs_module
     except (Exception, SystemExit):

--- a/tests/crypto/test_pqc_liboqs_status.py
+++ b/tests/crypto/test_pqc_liboqs_status.py
@@ -83,3 +83,26 @@ def test_mldsa65_from_keypair_loaded_key_signs_and_verifies():
     assert verifier.verify(message, signature) is True
     # Tamper is still caught.
     assert loaded.verify(message + b"x", signature) is False
+
+
+def test_oqs_import_keeps_stdout_clean():
+    """Regression: liboqs-python prints an informational banner to STDOUT on
+    import ("liboqs-python faulthandler is disabled"). Consumers sign lazily
+    from CLIs whose stdout is a machine-readable JSON contract (e.g.
+    ``scbe react balance --json``), so the loader must route the banner to
+    stderr. A fresh interpreter is required because oqs may already be in
+    sys.modules here."""
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys; sys.path.insert(0, '.'); " "from src.crypto.pqc_liboqs import _load_oqs_module; _load_oqs_module()"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "", f"oqs import leaked onto stdout: {result.stdout!r}"


### PR DESCRIPTION
## Summary
Follow-up to #2172/#2174 — makes the receipt promise real at the product surface: every packet `scripts/reaction_cli.py` emits (`code`, `audio`, `balance`, `geometry`) is now **signed at the emission point** under one stable identity (`scbe-react-cli`), so receipts are attributable and chainable, not just tamper-evident. `sign()` degrades gracefully to an unsigned packet where no signer backend exists, so the CLI still runs anywhere.

## The bug this flushed out
`liboqs-python` prints an informational banner to **stdout** on import (`liboqs-python faulthandler is disabled`). Once the CLI signs lazily, that banner landed in front of `--json` output and corrupted the machine-readable contract. Fixed in `_load_oqs_module` by routing the import-time banner to stderr — protects every consumer whose stdout is a JSON contract, not just this CLI.

## Verification
- 16/16 `tests/crypto/test_pqc_liboqs_status.py` + reaction packet suite on this base
- New fresh-interpreter regression test: the oqs loader must leave stdout empty
- Live: `reaction_cli.py balance --reactants CH4,O2 --products CO2,H2O --json` → parseable JSON, `sig_alg=ML-DSA-65`, banner on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reaction packets generated by the CLI are now cryptographically signed.

* **Bug Fixes**
  * Resolved stdout pollution from import messages that could interfere with machine-readable output streams.

* **Tests**
  * Added regression test to verify clean stdout behavior during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->