### PR TITLE
feat(chem): hazard screen for the react balance lane

### DIFF
--- a/python/scbe/reaction_balance.py
+++ b/python/scbe/reaction_balance.py
@@ -37,6 +37,83 @@ class BalanceError(ValueError):
     """Raised when a reaction cannot be uniquely balanced as written."""
 
 
+class HazardDenied(BalanceError):
+    """Raised when the request text matches the chem governance deny patterns."""
+
+
+# --------------------------------------------------------------------------- #
+# Hazard governance
+# --------------------------------------------------------------------------- #
+#
+# Species-level lexical screen: acutely hazardous species flagged by formula as
+# written (after stripping charge notation). This is a warning layer, not a
+# block — a correctly balanced hazardous reaction is still exact stoichiometry
+# (e.g. NaOCl + 2 HCl -> Cl2 + NaCl + H2O is the textbook bleach+acid accident
+# and MUST carry a flag). Absence of a flag is not a safety claim.
+
+HAZARDOUS_SPECIES = {
+    "Cl2": "chlorine — toxic gas (bleach + acid releases it)",
+    "HCN": "hydrogen cyanide — highly toxic gas",
+    "CN": "cyanide — highly toxic",
+    "COCl2": "phosgene — highly toxic gas",
+    "H2S": "hydrogen sulfide — toxic gas",
+    "CO": "carbon monoxide — toxic gas",
+    "F2": "fluorine — highly toxic, corrosive gas",
+    "HF": "hydrogen fluoride — highly toxic, corrosive",
+    "ClO2": "chlorine dioxide — toxic, explosively unstable gas",
+    "NO2": "nitrogen dioxide — toxic gas",
+    "SO2": "sulfur dioxide — toxic gas",
+    "NH3": "ammonia — toxic gas (mixing with bleach forms chloramines)",
+    "NH2Cl": "chloramine — toxic gas (bleach + ammonia product)",
+    "O3": "ozone — toxic gas",
+    "PH3": "phosphine — highly toxic gas",
+    "AsH3": "arsine — highly toxic gas",
+    "N2H4": "hydrazine — highly toxic, flammable",
+    "HN3": "hydrazoic acid — toxic, explosive",
+    "NCl3": "nitrogen trichloride — explosive",
+    "ClF3": "chlorine trifluoride — violently reactive",
+}
+
+HAZARD_CLAIM_BOUNDARY = (
+    "hazard flags are a lexical screen over species formulas as written; " "absence of a flag is not a safety claim"
+)
+
+
+def _bare_formula(formula: str) -> str:
+    return re.sub(r"(\^\d*[+-]|\(\d*[+-]\)|[+-])$", "", formula.strip())
+
+
+def screen_species_hazards(reactants: Sequence[str], products: Sequence[str]) -> List[str]:
+    """Side-labelled hazard flags for every species with a HAZARDOUS_SPECIES entry."""
+    flags: List[str] = []
+    for side, formulas in (("reactant", reactants), ("product", products)):
+        for formula in formulas:
+            note = HAZARDOUS_SPECIES.get(_bare_formula(formula))
+            if note:
+                flags.append(f"hazard ({side}): {formula} — {note}")
+    return flags
+
+
+def _request_text_problems(reactants: Sequence[str], products: Sequence[str]) -> List[str]:
+    """Deny screen over the raw request text, reusing chem_code's governance.
+
+    ``chem_code`` carries the canonical FORBIDDEN_PATTERNS (synthesis routes,
+    dosing, weaponization, named agents). It is not present in every checkout;
+    where it is missing the species screen above still runs, so the lane never
+    goes hazard-blind — this hook only adds the request-text deny.
+    """
+    try:
+        from .chem_code import FORBIDDEN_PATTERNS
+    except Exception:  # never let an optional governance import break balancing
+        return []
+    text = " ".join(list(reactants) + list(products)).lower()
+    return [
+        f"denied unsafe chemistry request pattern: {pattern}"
+        for pattern in FORBIDDEN_PATTERNS
+        if re.search(pattern, text, flags=re.IGNORECASE)
+    ]
+
+
 # --------------------------------------------------------------------------- #
 # Formula parsing
 # --------------------------------------------------------------------------- #
@@ -212,6 +289,10 @@ def format_equation(coeffs: Sequence[int], reactants: Sequence[str], products: S
 
 def balance_reaction_packet(reactants: Sequence[str], products: Sequence[str]) -> ReactionStatePacket:
     """Balance a reaction and wrap the result in a hash-signed ReactionStatePacket."""
+    denied = _request_text_problems(reactants, products)
+    if denied:
+        raise HazardDenied("; ".join(denied))
+    hazards = screen_species_hazards(reactants, products)
     coeffs = balance(reactants, products)
     nr = len(reactants)
     equation = format_equation(coeffs, reactants, products)
@@ -231,12 +312,13 @@ def balance_reaction_packet(reactants: Sequence[str], products: Sequence[str]) -
             representation="product_formulas",
             language="chem",
             tongue="DR",
-            metadata={"equation": equation, "coefficients": list(coeffs)},
+            metadata={"equation": equation, "coefficients": list(coeffs), "hazards": hazards},
         ),
         semantic_engravings=[
             f"balanced: {equation}",
             f"coefficients: {list(coeffs)}",
             "atom + charge conservation by exact rational nullspace",
+            *hazards,
         ],
         loss_notes=[] if ok else [f"not conserved: {deltas}"],
         recalculation=ReactionRecalculation(scientific_checks_ok=ok, identity_ok=ok),
@@ -244,5 +326,6 @@ def balance_reaction_packet(reactants: Sequence[str], products: Sequence[str]) -
         claim_boundary=[
             "exact atom + charge conservation (stoichiometry) only",
             "not a thermodynamic-feasibility, equilibrium, or kinetics claim",
+            HAZARD_CLAIM_BOUNDARY,
         ],
     )

--- a/scripts/reaction_cli.py
+++ b/scripts/reaction_cli.py
@@ -321,6 +321,7 @@ def build_balance(reactants: str, products: str) -> dict[str, Any]:
         "ok": bool(packet.recalculation.identity_ok),
         "equation": packet.target.metadata.get("equation"),
         "coefficients": packet.target.metadata.get("coefficients"),
+        "hazards": packet.target.metadata.get("hazards", []),
         "reaction_state_packet": packet.to_dict(),
     }
 
@@ -331,6 +332,8 @@ def print_human_balance(payload: dict[str, Any]) -> None:
         return
     print(f"reaction balance: {payload['equation']}")
     print(f"coefficients: {payload['coefficients']}")
+    for flag in payload.get("hazards", []):
+        print(f"WARNING {flag}")
 
 
 def build_geometry(smiles: str) -> dict[str, Any]:

--- a/tests/test_reaction_balance.py
+++ b/tests/test_reaction_balance.py
@@ -6,11 +6,13 @@ import pytest
 
 from python.scbe.reaction_balance import (
     BalanceError,
+    HazardDenied,
     balance,
     balance_reaction_packet,
     format_equation,
     is_conserved,
     parse_formula,
+    screen_species_hazards,
 )
 
 
@@ -56,3 +58,43 @@ def test_balance_packet_is_bijective_and_hash_verifies():
     assert packet.verify_hash()
     assert packet.recalculation.identity_ok is True
     assert packet.target.metadata["coefficients"] == [1, 5, 3, 4]
+
+
+def test_bleach_acid_reaction_carries_hazard_flags():
+    """The use-case-audit gap: NaOCl + HCl -> Cl2 balanced with zero warning."""
+    packet = balance_reaction_packet(["NaOCl", "HCl"], ["Cl2", "NaCl", "H2O"])
+    hazards = packet.target.metadata["hazards"]
+    assert any("Cl2" in flag and "(product)" in flag for flag in hazards)
+    assert any("chlorine" in flag for flag in hazards)
+    # Hazard is a warning, not a correctness failure: stoichiometry stays exact.
+    assert packet.classification == "BIJECTIVE"
+    assert packet.target.metadata["coefficients"] == [1, 2, 1, 1, 1]
+    assert any(flag in packet.semantic_engravings for flag in hazards)
+    assert any("not a safety claim" in line for line in packet.claim_boundary)
+
+
+def test_benign_reaction_has_empty_hazard_list():
+    packet = balance_reaction_packet(["C3H8", "O2"], ["CO2", "H2O"])
+    assert packet.target.metadata["hazards"] == []
+    assert any("not a safety claim" in line for line in packet.claim_boundary)
+
+
+def test_hazard_screen_strips_charge_notation():
+    flags = screen_species_hazards(["CN^-"], ["HCN"])
+    assert len(flags) == 2
+    assert "hazard (reactant): CN^- — cyanide — highly toxic" in flags[0]
+    assert "hazard (product): HCN" in flags[1]
+
+
+def test_hazard_screen_is_case_sensitive_about_elements():
+    # CO (carbon monoxide) flags; Co (cobalt) must not.
+    assert screen_species_hazards(["CO"], []) != []
+    assert screen_species_hazards(["Co"], []) == []
+
+
+def test_forbidden_request_text_is_denied_before_balancing():
+    """chem_code's FORBIDDEN_PATTERNS deny the request as a governed refusal,
+    not a parse error. Only active in checkouts that carry chem_code."""
+    pytest.importorskip("python.scbe.chem_code")
+    with pytest.raises(HazardDenied, match="denied unsafe chemistry request"):
+        balance_reaction_packet(["sarin"], ["H2O"])


### PR DESCRIPTION
## Problem

The use-case validation audit found **hazard blindness**: `scbe react balance` balanced NaOCl + 2 HCl → Cl2 + NaCl + H2O (the textbook bleach+acid accident) with zero warning, while the chem governance gate existed unwired into the lane.

## What this wires

Two-layer screen in `balance_reaction_packet` (library level, so the CLI, MCP surface, and any other consumer all get it):

1. **Species screen** — always on, stdlib-pure. `HAZARDOUS_SPECIES` lexical table flags acutely hazardous species by formula as written (charge notation stripped; element-case sensitive — `CO` flags carbon monoxide, `Co` cobalt does not). Flags ride `target.metadata['hazards']` + `semantic_engravings` + a claim-boundary line — **not** `loss_notes`, so a correctly balanced hazardous reaction stays honestly BIJECTIVE. Boundary line states plainly: *absence of a flag is not a safety claim*.
2. **Request-text deny** — lazy hook on `chem_code.FORBIDDEN_PATTERNS` (synthesis routes / dosing / weaponization / named agents) raising `HazardDenied` as a governed refusal before parsing. `chem_code` is not on main yet (lives on feat/aether-harness); the hook degrades to species-screen-only where it's absent and lights up automatically when that branch merges. The import can never break balancing.

CLI: hazards surface at the top level of the balance JSON contract and as `WARNING` lines in human output.

## Verification

- Live: bleach+acid carries the chlorine flag (ML-DSA-65-signed receipt, exit 0, JSON stdout clean); propane combustion carries none; sarin request denied as a governed refusal in a chem_code checkout (proven by temporary swap into the branch environment).
- Tests: 12/12 in `tests/test_reaction_balance.py` (deny test `importorskip`s where chem_code is absent); 34 passed across the PR-gated chem smoke lanes; black + flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reactions now detect and report hazards when dangerous chemical species are involved
  * Added governance layer to block requests matching forbidden chemistry patterns
  * Hazard warnings appear in reaction results when applicable

* **Tests**
  * Added comprehensive regression tests for hazard detection and request blocking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->