### PR TITLE
fix(chem): name the conservation failure instead of reporting raw nullity

### DIFF
--- a/python/scbe/reaction_balance.py
+++ b/python/scbe/reaction_balance.py
@@ -229,7 +229,7 @@ def balance(reactants: Sequence[str], products: Sequence[str]) -> List[int]:
     rows.append([Fraction(sign * q) for (_, q), sign in zip(comps, signs)])  # charge row
     null = _rational_nullspace(rows, len(species))
     if len(null) != 1:
-        raise BalanceError(f"reaction has no unique balance (nullity={len(null)})")
+        raise BalanceError(_diagnose_no_unique_balance(comps, signs, rows, null, len(species)))
     vec = null[0]
     lcm = 1
     for v in vec:
@@ -243,8 +243,57 @@ def balance(reactants: Sequence[str], products: Sequence[str]) -> List[int]:
     if all(v <= 0 for v in ints):
         ints = [-v for v in ints]
     if not all(v > 0 for v in ints):
+        one_sided = _one_sided_elements(comps, signs)
+        if one_sided:
+            raise BalanceError(f"no balance exists: element(s) appear on one side only — {', '.join(one_sided)}")
         raise BalanceError(f"no positive balance with the given sides: {ints}")
     return ints
+
+
+def _one_sided_elements(comps: List[Tuple[Counter, int]], signs: List[int]) -> List[str]:
+    """Elements present among reactants xor products — instantly unbalanceable."""
+    one_sided = []
+    for el in sorted({el for comp, _ in comps for el in comp}):
+        on_left = any(comp.get(el) for (comp, _), sign in zip(comps, signs) if sign > 0)
+        on_right = any(comp.get(el) for (comp, _), sign in zip(comps, signs) if sign < 0)
+        if on_left != on_right:
+            side = "reactants" if on_left else "products"
+            one_sided.append(f"{el} (only in {side})")
+    return one_sided
+
+
+def _diagnose_no_unique_balance(
+    comps: List[Tuple[Counter, int]],
+    signs: List[int],
+    rows: List[List[Fraction]],
+    null: List[List[Fraction]],
+    n_species: int,
+) -> str:
+    """Name the actual conservation failure instead of reporting raw nullity.
+
+    The use-case audit flagged this: a charge-violating ionic reaction was
+    rejected with ``nullity=0``, which tells a chemist nothing. Diagnose in
+    order of usefulness: an element present on only one side, then a charge
+    row that alone blocks an otherwise-balanceable reaction, then the
+    underdetermined (multiple independent reactions) case.
+    """
+    if len(null) == 0:
+        one_sided = _one_sided_elements(comps, signs)
+        if one_sided:
+            return f"no balance exists: element(s) appear on one side only — {', '.join(one_sided)}"
+        # rows[-1] is the charge row; if dropping it makes the reaction
+        # balanceable, charge conservation is the specific blocker.
+        if len(_rational_nullspace(rows[:-1], n_species)) >= 1:
+            return (
+                "no balance exists: charge is not conserved as written "
+                "(atoms can balance, net charge cannot); check ion charges or "
+                "add the missing charge carriers (e.g. H^+, OH^-, e^-)"
+            )
+        return "no balance exists: element conservation cannot be satisfied with these species"
+    return (
+        f"reaction is underdetermined: it mixes {len(null)} independent reactions; "
+        "balance each sub-reaction separately or fix more species"
+    )
 
 
 def _rational_nullspace(matrix: List[List[Fraction]], ncols: int) -> List[List[Fraction]]:

--- a/tests/test_reaction_balance.py
+++ b/tests/test_reaction_balance.py
@@ -98,3 +98,22 @@ def test_forbidden_request_text_is_denied_before_balancing():
     pytest.importorskip("python.scbe.chem_code")
     with pytest.raises(HazardDenied, match="denied unsafe chemistry request"):
         balance_reaction_packet(["sarin"], ["H2O"])
+
+
+def test_charge_violation_names_charge_not_nullity():
+    """The use-case-audit gap: charge violations used to say 'nullity=0'."""
+    with pytest.raises(BalanceError, match="charge is not conserved"):
+        balance(["Fe^2+"], ["Fe^3+"])
+
+
+def test_one_sided_element_is_named():
+    with pytest.raises(BalanceError, match=r"N \(only in products\)"):
+        balance(["H2", "O2"], ["H2O", "N2"])
+    with pytest.raises(BalanceError, match=r"O \(only in products\)"):
+        balance(["H2"], ["H2O"])
+
+
+def test_underdetermined_reaction_says_so():
+    # C + O2 -> CO + CO2 mixes two independent oxidations (nullity 2).
+    with pytest.raises(BalanceError, match="underdetermined: it mixes 2 independent reactions"):
+        balance(["C", "O2"], ["CO", "CO2"])


### PR DESCRIPTION
## Problem

Second diagnostic gap from the use-case audit: `scbe react balance` rejected a charge-violating ionic reaction with **"reaction has no unique balance (nullity=0)"** — linear-algebra jargon that tells a chemist nothing about what's wrong.

## Fix

`balance()` now names the actual conservation failure, in order of usefulness:

| Input class | Old message | New message |
|---|---|---|
| `Fe^2+ -> Fe^3+` | `nullity=0` | `charge is not conserved as written (atoms can balance, net charge cannot); check ion charges or add the missing charge carriers (e.g. H^+, OH^-, e^-)` |
| `H2 -> H2O` | `nullity=0` / zero-coefficient error | `element(s) appear on one side only — O (only in products)` |
| `C + O2 -> CO + CO2` | `nullity=2` | `underdetermined: it mixes 2 independent reactions; balance each sub-reaction separately` |

The one-sided-element check is also wired into the no-positive-balance branch, where forced-zero coefficients actually land.

## Verification

14 passed + 1 skip in `tests/test_reaction_balance.py` (3 new tests, one per branch); messages verified live through the CLI; black + flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reaction balancing error messages with specific diagnostics when balancing fails, now identifying issues such as one-sided elements, charge conservation violations, and underdetermined reaction systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->