### PR TITLE
feat(receipts): Merkle checkpoints, RFC 8785 JCS, ACTA export, Rekor-ready anchoring

### DIFF
--- a/agents/agent_bus_signing.py
+++ b/agents/agent_bus_signing.py
@@ -255,6 +255,15 @@ class EventSigner:
         sig = self._impl.sign(canonical)
         return (base64.b64encode(sig).decode(), self.public_key_b64, self._impl.algorithm)
 
+    def sign_bytes(self, message: bytes) -> Tuple[str, str, str]:
+        """Sign exact caller-provided bytes. For interop formats where the
+        canonical form is fixed by an external spec (e.g. RFC 8785 JCS in ACTA
+        receipts) rather than this module's json.dumps convention."""
+        if self._impl is None:
+            return ("", "", ALG_UNSIGNED)
+        sig = self._impl.sign(message)
+        return (base64.b64encode(sig).decode(), self.public_key_b64, self._impl.algorithm)
+
     def verify_own(self, payload: Dict[str, Any], signature_b64: str) -> bool:
         """Verify a signature against this signer's loaded identity. Works in all tiers."""
         if self._impl is None or not signature_b64:
@@ -281,9 +290,26 @@ class EventSigner:
         if not signature_b64 or not public_key_b64:
             return False
         try:
+            canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        except (ValueError, AttributeError) as exc:
+            logger.warning("verify canonicalization failed: %s", exc)
+            return False
+        return EventSigner.verify_bytes(canonical, signature_b64, public_key_b64, algorithm)
+
+    @staticmethod
+    def verify_bytes(
+        message: bytes,
+        signature_b64: str,
+        public_key_b64: str,
+        algorithm: str,
+    ) -> bool:
+        """Public-key-only verification over exact caller-provided bytes
+        (counterpart of ``sign_bytes``). Returns False for HMAC sim."""
+        if not signature_b64 or not public_key_b64:
+            return False
+        try:
             sig = base64.b64decode(signature_b64)
             pk = base64.b64decode(public_key_b64)
-            canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
         except (ValueError, AttributeError) as exc:
             logger.warning("verify decode failed: %s", exc)
             return False
@@ -296,7 +322,7 @@ class EventSigner:
                     return False
                 v = MLDSA65()
                 v._public_key = pk
-                return bool(v.verify(canonical, sig))
+                return bool(v.verify(message, sig))
             except (ImportError, RuntimeError, OSError, AttributeError):
                 return False
 
@@ -305,7 +331,7 @@ class EventSigner:
                 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
                 pk_obj = Ed25519PublicKey.from_public_bytes(pk)
-                pk_obj.verify(sig, canonical)
+                pk_obj.verify(sig, message)
                 return True
             except Exception:  # noqa: BLE001
                 return False

--- a/python/scbe/reaction_state.py
+++ b/python/scbe/reaction_state.py
@@ -9,6 +9,7 @@ declared representation.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 from dataclasses import asdict, dataclass, field, replace
@@ -319,3 +320,353 @@ class ReactionLedger:
                 return False
             prev = packet.packet_hash
         return True
+
+    def merkle_root(self) -> str:
+        return merkle_tree_head([p.packet_hash or "" for p in self.packets])
+
+    def inclusion_proof(self, index: int) -> dict[str, Any]:
+        """Compact proof that packet ``index`` is committed by the current root —
+        verifiable with ``verify_merkle_inclusion`` and nothing else."""
+        hashes = [p.packet_hash or "" for p in self.packets]
+        return {
+            "schema_version": "scbe_merkle_inclusion_proof_v1",
+            "packet_hash": hashes[index],
+            "leaf_index": index,
+            "tree_size": len(hashes),
+            "audit_path": merkle_audit_path(hashes, index),
+            "merkle_root": merkle_tree_head(hashes),
+        }
+
+    def checkpoint(self) -> dict[str, Any]:
+        """Signed commitment to the exact set and count of packets so far.
+
+        The linear chain proves order; the checkpoint adds omission-resistance
+        (a dropped or truncated packet changes the root and the tree_size).
+        Signed with the same EventSigner identity as the packets; unsigned
+        (signature None) when no signer backend is available — never raises.
+        """
+        unsigned: dict[str, Any] = {
+            "schema_version": "scbe_reaction_ledger_checkpoint_v1",
+            "generated_at_utc": utc_now(),
+            "agent_id": self.agent_id,
+            "tree_size": len(self.packets),
+            "merkle_root": self.merkle_root(),
+            "first_packet_hash": self.packets[0].packet_hash if self.packets else None,
+            "last_packet_hash": self._last_hash,
+            "chain_verified": self.verify(),
+        }
+        signed = dict(unsigned)
+        signed.update({"signature": None, "signature_alg": None, "signer_public_key": None})
+        if not self.sign:
+            return signed
+        try:
+            from agents.agent_bus_signing import EventSigner
+
+            signer = EventSigner(self.agent_id)
+            if signer.initialize():
+                sig_b64, pk_b64, alg = signer.sign(unsigned)
+                if sig_b64:
+                    signed.update({"signature": sig_b64, "signature_alg": alg, "signer_public_key": pk_b64})
+        except Exception:  # pragma: no cover - checkpointing must not break a flow
+            pass
+        return signed
+
+    def acta_chain(self, issuer_id: str | None = None) -> list[dict[str, Any]]:
+        """Export the ledger as an ACTA-compatible receipt chain (one signed
+        envelope per packet, linked by previousReceiptHash per the draft)."""
+        receipts: list[dict[str, Any]] = []
+        prev: str | None = None
+        for packet in self.packets:
+            receipt = packet_to_acta_receipt(packet, issuer_id or self.agent_id, prev)
+            receipts.append(receipt)
+            prev = acta_receipt_hash(receipt)
+        return receipts
+
+
+def verify_checkpoint(checkpoint: dict[str, Any]) -> bool | None:
+    """Public-key verify a ledger checkpoint. True/False for asymmetric
+    signatures; None when unsigned or symmetric (mirrors verify_signature)."""
+    signature = checkpoint.get("signature")
+    alg = checkpoint.get("signature_alg")
+    if not signature or alg in (None, "unsigned", "HMAC-SHA512-sim"):
+        return None
+    payload = {k: v for k, v in checkpoint.items() if k not in ("signature", "signature_alg", "signer_public_key")}
+    try:
+        from agents.agent_bus_signing import EventSigner
+    except Exception:  # pragma: no cover
+        return None
+    return bool(EventSigner.verify(payload, signature, checkpoint.get("signer_public_key") or "", alg))
+
+
+# --------------------------------------------------------------------------- #
+# Merkle checkpointing (RFC 6962 tree shape)
+# --------------------------------------------------------------------------- #
+#
+# A linear hash chain proves order and linkage but cannot prove COMPLETENESS:
+# an operator who drops the tail of a chain (or a contiguous suffix) leaves no
+# trace. A signed Merkle checkpoint over the packet hashes fixes that — the
+# root commits to the exact set and count, and any packet can carry a compact
+# inclusion proof against it. Leaf/node inputs are domain-separated (0x00/0x01
+# prefixes, RFC 6962) so a node can never be replayed as a leaf.
+
+
+def _merkle_leaf_hash(packet_hash: str) -> str:
+    return hashlib.sha256(b"\x00" + bytes.fromhex(packet_hash)).hexdigest()
+
+
+def _merkle_node_hash(left: str, right: str) -> str:
+    return hashlib.sha256(b"\x01" + bytes.fromhex(left) + bytes.fromhex(right)).hexdigest()
+
+
+def merkle_tree_head(packet_hashes: list[str]) -> str:
+    """RFC 6962 Merkle Tree Head over an ordered list of packet hashes."""
+    n = len(packet_hashes)
+    if n == 0:
+        return hashlib.sha256(b"").hexdigest()
+    if n == 1:
+        return _merkle_leaf_hash(packet_hashes[0])
+    k = 1
+    while k * 2 < n:
+        k *= 2
+    return _merkle_node_hash(merkle_tree_head(packet_hashes[:k]), merkle_tree_head(packet_hashes[k:]))
+
+
+def merkle_audit_path(packet_hashes: list[str], index: int) -> list[str]:
+    """RFC 6962 section 2.1.1 inclusion (audit) path for the leaf at ``index``."""
+    n = len(packet_hashes)
+    if not 0 <= index < n:
+        raise IndexError(f"leaf index {index} out of range for tree of size {n}")
+    if n == 1:
+        return []
+    k = 1
+    while k * 2 < n:
+        k *= 2
+    if index < k:
+        return merkle_audit_path(packet_hashes[:k], index) + [merkle_tree_head(packet_hashes[k:])]
+    return merkle_audit_path(packet_hashes[k:], index - k) + [merkle_tree_head(packet_hashes[:k])]
+
+
+def verify_merkle_inclusion(
+    packet_hash: str,
+    leaf_index: int,
+    tree_size: int,
+    audit_path: list[str],
+    merkle_root: str,
+) -> bool:
+    """RFC 9162 section 2.1.3.2 inclusion-proof verification."""
+    if not 0 <= leaf_index < tree_size:
+        return False
+    fn, sn = leaf_index, tree_size - 1
+    result = _merkle_leaf_hash(packet_hash)
+    for sibling in audit_path:
+        if sn == 0:
+            return False
+        if fn % 2 == 1 or fn == sn:
+            result = _merkle_node_hash(sibling, result)
+            if fn % 2 == 0:
+                while fn % 2 == 0 and fn != 0:
+                    fn >>= 1
+                    sn >>= 1
+        else:
+            result = _merkle_node_hash(result, sibling)
+        fn >>= 1
+        sn >>= 1
+    return sn == 0 and result == merkle_root
+
+
+# --------------------------------------------------------------------------- #
+# RFC 8785 (JCS) canonicalization + ACTA receipt interop
+# --------------------------------------------------------------------------- #
+#
+# ``canonical_json``/``sha256_value`` above are this module's frozen internal
+# convention — existing packet hashes must stay byte-identical, so they are
+# untouched. JCS (RFC 8785) is the canonicalization the receipt-interop field
+# converged on (the ACTA signed-receipts draft mandates it); it differs from
+# json.dumps in number formatting (ECMA-262 shortest round-trip), raw-UTF-8
+# strings, and UTF-16-code-unit key order. It is used ONLY for the new export
+# views below, never for packet hashing.
+
+_JCS_ESCAPES = {0x08: "\\b", 0x09: "\\t", 0x0A: "\\n", 0x0C: "\\f", 0x0D: "\\r", 0x22: '\\"', 0x5C: "\\\\"}
+
+
+def _jcs_number(value: float) -> str:
+    """ECMA-262 Number::toString (shortest round-trip form), per RFC 8785 3.2.2.3."""
+    if value != value or value in (float("inf"), float("-inf")):
+        raise ValueError("NaN and Infinity are not allowed in JCS (RFC 8785)")
+    if value == 0:
+        return "0"  # IEEE -0 serializes as "0"
+    sign = "-" if value < 0 else ""
+    rep = repr(abs(value))  # Python repr is already shortest-round-trip
+    if "e" in rep:
+        mantissa, _, exp_str = rep.partition("e")
+        exponent = int(exp_str)
+    else:
+        mantissa, exponent = rep, 0
+    int_part, _, frac_part = mantissa.partition(".")
+    if int_part != "0":
+        point = len(int_part) + exponent  # decimal point position vs first significant digit
+    else:
+        point = exponent - (len(frac_part) - len(frac_part.lstrip("0")))
+    digits = (int_part + frac_part).strip("0")
+    k = len(digits)
+    if k <= point <= 21:
+        body = digits + "0" * (point - k)
+    elif 0 < point <= 21:
+        body = digits[:point] + "." + digits[point:]
+    elif -6 < point <= 0:
+        body = "0." + "0" * (-point) + digits
+    else:
+        e = point - 1
+        suffix = f"e+{e}" if e >= 0 else f"e-{-e}"
+        body = digits[0] + ("." + digits[1:] if k > 1 else "") + suffix
+    return sign + body
+
+
+def _jcs_string(value: str) -> str:
+    parts = ['"']
+    for ch in value:
+        cp = ord(ch)
+        esc = _JCS_ESCAPES.get(cp)
+        if esc is not None:
+            parts.append(esc)
+        elif cp < 0x20:
+            parts.append(f"\\u{cp:04x}")
+        else:
+            parts.append(ch)
+    parts.append('"')
+    return "".join(parts)
+
+
+def jcs_dumps(value: Any) -> str:
+    """RFC 8785 JSON Canonicalization Scheme serializer (stdlib-only)."""
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        return _jcs_string(value)
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return _jcs_number(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(jcs_dumps(item) for item in value) + "]"
+    if isinstance(value, dict):
+        # RFC 8785 3.2.3: keys sorted as arrays of UTF-16 code units.
+        keys = sorted(value.keys(), key=lambda k: k.encode("utf-16-be"))
+        return "{" + ",".join(_jcs_string(k) + ":" + jcs_dumps(value[k]) for k in keys) + "}"
+    raise TypeError(f"type not representable in JCS: {type(value).__name__}")
+
+
+# ACTA = draft-farley-acta-signed-receipts-01 (IETF, Apr 2026): signed decision
+# receipts with JCS canonicalization, hex-encoded signatures, and
+# previousReceiptHash chaining. It RECOMMENDS ML-DSA-65 for new deployments —
+# which is exactly our primary signer tier, so the mapping is direct.
+
+ACTA_RECEIPT_TYPE = "scbe:reaction-state"
+_ACTA_ALG_BY_SIGNER = {"Ed25519": "EdDSA", "ML-DSA-65": "ML-DSA-65"}
+
+
+def acta_receipt_hash(receipt: dict[str, Any]) -> str:
+    """draft 5.7: lowercase hex SHA-256 of JCS of the ENTIRE signed receipt
+    (payload + signature), so re-signing an identical payload still yields a
+    distinct chain link."""
+    return hashlib.sha256(jcs_dumps(receipt).encode("utf-8")).hexdigest()
+
+
+def packet_to_acta_receipt(
+    packet: ReactionStatePacket,
+    issuer_id: str = "scbe-reaction-state",
+    previous_receipt_hash: str | None = None,
+) -> dict[str, Any]:
+    """Export a packet as an ACTA-compatible signed receipt envelope.
+
+    The signature is computed over the exact JCS bytes of the payload (the
+    draft's signing procedure), hex-encoded. Unsigned envelopes (signature
+    None) are returned when no asymmetric signer backend is available.
+    """
+    payload: dict[str, Any] = {
+        "type": ACTA_RECEIPT_TYPE,
+        "issued_at": packet.generated_at_utc,
+        "issuer_id": issuer_id,
+        "action_ref": hashlib.sha256(jcs_dumps(packet.unsigned_dict()).encode("utf-8")).hexdigest(),
+        "packet_hash": packet.packet_hash,
+        "bounded_operation": packet.bounded_operation,
+        "domain": packet.domain,
+        "classification": packet.classification,
+    }
+    if previous_receipt_hash:
+        payload["previousReceiptHash"] = previous_receipt_hash
+    receipt: dict[str, Any] = {"payload": payload, "signature": None}
+    try:
+        from agents.agent_bus_signing import EventSigner
+
+        signer = EventSigner(issuer_id)
+        if signer.initialize():
+            sig_b64, _pk_b64, alg = signer.sign_bytes(jcs_dumps(payload).encode("utf-8"))
+            acta_alg = _ACTA_ALG_BY_SIGNER.get(alg)
+            if sig_b64 and acta_alg:
+                receipt["signature"] = {
+                    "alg": acta_alg,
+                    "kid": issuer_id,
+                    "sig": base64.b64decode(sig_b64).hex(),
+                }
+    except Exception:  # pragma: no cover - export must not break a flow
+        pass
+    return receipt
+
+
+def verify_acta_receipt(receipt: dict[str, Any], public_key_b64: str) -> bool | None:
+    """Verify an ACTA receipt's signature over JCS(payload). The caller resolves
+    ``kid`` to a public key (the draft keeps keys out of the receipt). Returns
+    None for unsigned envelopes."""
+    signature = receipt.get("signature")
+    if not signature:
+        return None
+    signer_alg = {v: k for k, v in _ACTA_ALG_BY_SIGNER.items()}.get(signature.get("alg"))
+    if not signer_alg:
+        return False
+    try:
+        from agents.agent_bus_signing import EventSigner
+    except Exception:  # pragma: no cover
+        return None
+    sig_b64 = base64.b64encode(bytes.fromhex(signature.get("sig", ""))).decode()
+    message = jcs_dumps(receipt.get("payload", {})).encode("utf-8")
+    return bool(EventSigner.verify_bytes(message, sig_b64, public_key_b64, signer_alg))
+
+
+def verify_acta_chain(receipts: list[dict[str, Any]]) -> bool:
+    """Keyless integrity check of the previousReceiptHash linkage (signature
+    verification is per-receipt via ``verify_acta_receipt``)."""
+    prev: str | None = None
+    for receipt in receipts:
+        link = receipt.get("payload", {}).get("previousReceiptHash")
+        if link != prev:
+            return False
+        prev = acta_receipt_hash(receipt)
+    return True
+
+
+def rekor_hashedrekord_entry(
+    checkpoint: dict[str, Any],
+    signature_b64: str | None = None,
+    public_key_pem_b64: str | None = None,
+) -> dict[str, Any]:
+    """Anchor-READY Sigstore Rekor proposed entry over the checkpoint's JCS digest.
+
+    Dry-run by design: this module performs no network I/O, and the public
+    Rekor instance only verifies PKIX keys (ECDSA / Ed25519ph) — it cannot
+    verify ML-DSA today — so submission requires the caller to countersign the
+    digest with a PKIX identity and POST the entry explicitly.
+    """
+    digest = hashlib.sha256(jcs_dumps(checkpoint).encode("utf-8")).hexdigest()
+    return {
+        "apiVersion": "0.0.1",
+        "kind": "hashedrekord",
+        "spec": {
+            "data": {"hash": {"algorithm": "sha256", "value": digest}},
+            "signature": {"content": signature_b64, "publicKey": {"content": public_key_pem_b64}},
+        },
+    }

--- a/scripts/reaction_cli.py
+++ b/scripts/reaction_cli.py
@@ -28,9 +28,11 @@ from python.scbe.geometry_view import GeometryEngineError, geometry_view_packet
 from python.scbe.reaction_balance import BalanceError, balance_reaction_packet
 from python.scbe.reaction_state import (
     ReactionEndpoint,
+    ReactionLedger,
     ReactionRecalculation,
     build_reaction_state_packet,
     packet_from_dict,
+    rekor_hashedrekord_entry,
 )
 
 # Every packet this CLI emits is signed under one stable identity so receipts
@@ -362,6 +364,51 @@ def print_human_geometry(payload: dict[str, Any]) -> None:
     )
 
 
+def build_checkpoint(path: str, rekor_dry_run: bool = False) -> dict[str, Any]:
+    """Merkle-checkpoint every packet found in a packet/report file.
+
+    The checkpoint commits to the exact set, order, and count (the omission
+    attack a linear prev-hash chain cannot see) and is signed under the CLI
+    identity. chain_verified is True only when the packets form an unbroken
+    prev-hash chain in file order.
+    """
+    data = load_json(path)
+    found = find_packets(data)
+    if not found:
+        return {"schema_version": "scbe_react_checkpoint_v1", "ok": False, "error": "no packets found", "path": path}
+    ledger = ReactionLedger(agent_id=SIGNER_AGENT_ID)
+    ledger.packets = [packet_from_dict(p) for p in found]
+    ledger._last_hash = ledger.packets[-1].packet_hash
+    checkpoint = ledger.checkpoint()
+    payload: dict[str, Any] = {
+        "schema_version": "scbe_react_checkpoint_v1",
+        "ok": True,
+        "path": path,
+        "packets": len(found),
+        "checkpoint": checkpoint,
+        "inclusion_proofs": [ledger.inclusion_proof(i) for i in range(len(found))],
+    }
+    if rekor_dry_run:
+        # Anchor-READY only: no network I/O, and the public Rekor instance
+        # verifies PKIX keys (ECDSA/Ed25519ph), not ML-DSA - countersign the
+        # digest with a PKIX identity before actually submitting.
+        payload["rekor_dry_run"] = rekor_hashedrekord_entry(checkpoint)
+    return payload
+
+
+def print_human_checkpoint(payload: dict[str, Any]) -> None:
+    if not payload.get("ok"):
+        print(f"reaction checkpoint: FAILED {payload.get('error', '')}")
+        return
+    cp = payload["checkpoint"]
+    print(f"reaction checkpoint: {payload['packets']} packets")
+    print(f"merkle root: {cp['merkle_root']}")
+    print(f"chain verified: {cp['chain_verified']}")
+    print(f"signed: {cp['signature_alg'] or 'no'}")
+    if payload.get("rekor_dry_run"):
+        print(f"rekor digest (dry-run): {payload['rekor_dry_run']['spec']['data']['hash']['value']}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(prog="scbe react")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -383,6 +430,10 @@ def main() -> int:
     geometry_parser = sub.add_parser("geometry")
     geometry_parser.add_argument("--smiles", required=True, help="SMILES string, e.g. CCO")
     geometry_parser.add_argument("--json", action="store_true")
+    checkpoint_parser = sub.add_parser("checkpoint")
+    checkpoint_parser.add_argument("--packets", required=True, help="packet or report JSON file to checkpoint")
+    checkpoint_parser.add_argument("--rekor-dry-run", action="store_true")
+    checkpoint_parser.add_argument("--json", action="store_true")
     audio = sub.add_parser("audio")
     audio.add_argument("--frequency", type=float, default=440.0)
     audio.add_argument("--sample-rate", type=float, default=4096.0)
@@ -433,6 +484,13 @@ def main() -> int:
             print(json.dumps(payload, indent=2))
         else:
             print_human_geometry(payload)
+        return 0 if payload["ok"] else 1
+    if args.cmd == "checkpoint":
+        payload = build_checkpoint(args.packets, rekor_dry_run=args.rekor_dry_run)
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print_human_checkpoint(payload)
         return 0 if payload["ok"] else 1
     if args.cmd == "audio":
         payload = build_audio_packet(

--- a/scripts/system/run_core_python_checks.py
+++ b/scripts/system/run_core_python_checks.py
@@ -39,6 +39,9 @@ CORE_SMOKE_PATHS: tuple[str, ...] = (
     # exact units, balancer, geometry view). rdkit-dependent geometry
     # tests importorskip cleanly where rdkit is absent.
     "tests/test_reaction_state_packet.py",
+    "tests/test_reaction_ledger_checkpoint.py",
+    "tests/test_jcs_canonicalization.py",
+    "tests/test_acta_receipt_export.py",
     "tests/test_units.py",
     "tests/test_reaction_balance.py",
     "tests/test_geometry_view.py",

--- a/tests/test_acta_receipt_export.py
+++ b/tests/test_acta_receipt_export.py
@@ -1,0 +1,115 @@
+"""ACTA (draft-farley-acta-signed-receipts-01) export locks.
+
+The receipt envelope is {payload, signature}; signatures are computed over the
+exact JCS bytes of the payload and hex-encoded; chains link via
+previousReceiptHash = SHA-256(JCS(entire signed receipt)).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from python.scbe.reaction_state import (
+    ReactionEndpoint,
+    ReactionLedger,
+    ReactionRecalculation,
+    acta_receipt_hash,
+    jcs_dumps,
+    packet_to_acta_receipt,
+    rekor_hashedrekord_entry,
+    verify_acta_chain,
+    verify_acta_receipt,
+)
+
+
+def _kwargs(**overrides):
+    base = dict(
+        domain="chem",
+        step=1,
+        bounded_operation="balance_reaction",
+        source=ReactionEndpoint(identity="a", representation="x", tongue="KO"),
+        target=ReactionEndpoint(identity="b", representation="y", tongue="DR"),
+        semantic_engravings=["e"],
+        loss_notes=[],
+        recalculation=ReactionRecalculation(identity_ok=True),
+        identity_preserved=True,
+        generated_at_utc="2026-06-12T00:00:00Z",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_acta_receipt_envelope_shape_and_action_ref():
+    ledger = ReactionLedger(agent_id="test-acta")
+    packet = ledger.append(**_kwargs())
+    receipt = packet_to_acta_receipt(packet, issuer_id="test-acta")
+    payload = receipt["payload"]
+    assert payload["type"] == "scbe:reaction-state"
+    assert payload["issued_at"].endswith("Z")  # RFC 3339 with timezone designator
+    assert payload["issuer_id"] == "test-acta"
+    assert payload["packet_hash"] == packet.packet_hash
+    assert payload["classification"] == "BIJECTIVE"
+    # action_ref is the SHA-256 of the JCS canonicalization of the action.
+    expected_ref = hashlib.sha256(jcs_dumps(packet.unsigned_dict()).encode("utf-8")).hexdigest()
+    assert payload["action_ref"] == expected_ref
+    # First receipt in a chain has no previousReceiptHash key at all.
+    assert "previousReceiptHash" not in payload
+    # Signature, when present, uses ACTA algorithm identifiers and hex encoding.
+    if receipt["signature"] is not None:
+        assert receipt["signature"]["alg"] in ("ML-DSA-65", "EdDSA")
+        assert receipt["signature"]["kid"] == "test-acta"
+        sig = receipt["signature"]["sig"]
+        assert sig == sig.lower() and int(sig, 16) >= 0  # lowercase hex
+
+
+def test_acta_chain_links_by_receipt_hash_and_detects_tamper():
+    ledger = ReactionLedger(agent_id="test-acta-chain")
+    for i in range(3):
+        ledger.append(**_kwargs(step=i + 1, generated_at_utc=f"2026-06-12T00:00:0{i}Z"))
+    chain = ledger.acta_chain()
+    assert len(chain) == 3
+    assert verify_acta_chain(chain) is True
+    # Each link is the hash of the ENTIRE previous signed receipt (draft 5.7).
+    assert chain[1]["payload"]["previousReceiptHash"] == acta_receipt_hash(chain[0])
+    assert chain[2]["payload"]["previousReceiptHash"] == acta_receipt_hash(chain[1])
+    # Tampering with any receipt breaks the keyless linkage check.
+    tampered = [dict(chain[0]), chain[1], chain[2]]
+    tampered[0] = {"payload": dict(chain[0]["payload"]), "signature": chain[0]["signature"]}
+    tampered[0]["payload"]["bounded_operation"] = "forged"
+    assert verify_acta_chain(tampered) is False
+    # Dropping a middle receipt also breaks linkage.
+    assert verify_acta_chain([chain[0], chain[2]]) is False
+
+
+def test_acta_signature_verifies_over_exact_jcs_bytes():
+    ledger = ReactionLedger(agent_id="test-acta-sig")
+    packet = ledger.append(**_kwargs())
+    receipt = packet_to_acta_receipt(packet, issuer_id="test-acta-sig")
+    if receipt["signature"] is None:
+        import pytest
+
+        pytest.skip("no asymmetric signer backend available")
+    from agents.agent_bus_signing import EventSigner
+
+    signer = EventSigner("test-acta-sig")
+    assert signer.initialize()
+    assert verify_acta_receipt(receipt, signer.public_key_b64) is True
+    # A flipped payload field must fail against the same signature.
+    forged = {"payload": dict(receipt["payload"]), "signature": receipt["signature"]}
+    forged["payload"]["classification"] = "INVALID"
+    assert verify_acta_receipt(forged, signer.public_key_b64) is False
+
+
+def test_rekor_entry_is_anchor_ready_and_offline():
+    ledger = ReactionLedger(agent_id="test-rekor", sign=False)
+    ledger.append(**_kwargs())
+    cp = ledger.checkpoint()
+    entry = rekor_hashedrekord_entry(cp)
+    assert entry["apiVersion"] == "0.0.1"
+    assert entry["kind"] == "hashedrekord"
+    digest = entry["spec"]["data"]["hash"]
+    assert digest["algorithm"] == "sha256"
+    assert digest["value"] == hashlib.sha256(jcs_dumps(cp).encode("utf-8")).hexdigest()
+    # Dry-run by design: no signature material is invented.
+    assert entry["spec"]["signature"]["content"] is None
+    assert entry["spec"]["signature"]["publicKey"]["content"] is None

--- a/tests/test_jcs_canonicalization.py
+++ b/tests/test_jcs_canonicalization.py
@@ -1,0 +1,85 @@
+"""RFC 8785 (JCS) conformance locks, pinned to the spec's own test vectors.
+
+Number vectors are the IEEE-754 bit patterns from RFC 8785 Appendix B; the
+end-to-end object vector is from the cyberphone/json-canonicalization README.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from python.scbe.reaction_state import jcs_dumps
+
+# (IEEE-754 hex bit pattern, expected JCS serialization) — RFC 8785 Appendix B.
+RFC8785_NUMBER_VECTORS = [
+    ("0000000000000000", "0"),  # zero
+    ("8000000000000000", "0"),  # minus zero
+    ("0000000000000001", "5e-324"),  # min positive subnormal
+    ("8000000000000001", "-5e-324"),
+    ("7fefffffffffffff", "1.7976931348623157e+308"),  # max double
+    ("ffefffffffffffff", "-1.7976931348623157e+308"),
+    ("4340000000000000", "9007199254740992"),  # 2^53
+    ("c340000000000000", "-9007199254740992"),
+    ("4430000000000000", "295147905179352830000"),  # ~2^68, still plain notation
+    ("44b52d02c7e14af5", "9.999999999999997e+22"),
+    ("44b52d02c7e14af6", "1e+23"),
+    ("44b52d02c7e14af7", "1.0000000000000001e+23"),
+    ("444b1ae4d6e2ef4e", "999999999999999700000"),  # below 10^21 stays plain
+    ("444b1ae4d6e2ef4f", "999999999999999900000"),
+    ("444b1ae4d6e2ef50", "1e+21"),  # 10^21 boundary flips to exponent
+    ("3eb0c6f7a0b5ed8c", "9.999999999999997e-7"),  # below 10^-6 is exponent
+    ("3eb0c6f7a0b5ed8d", "0.000001"),  # 10^-6 boundary is decimal
+    ("41b3de4355555553", "333333333.3333332"),
+    ("41b3de4355555554", "333333333.33333325"),
+    ("41b3de4355555555", "333333333.3333333"),
+    ("41b3de4355555556", "333333333.3333334"),
+    ("41b3de4355555557", "333333333.33333343"),
+    ("becbf647612f3696", "-0.0000033333333333333333"),
+    ("43143ff3c1cb0959", "1424953923781206.2"),  # round-to-even case
+]
+
+
+def _double(hex_bits: str) -> float:
+    return struct.unpack(">d", bytes.fromhex(hex_bits))[0]
+
+
+@pytest.mark.parametrize("hex_bits,expected", RFC8785_NUMBER_VECTORS)
+def test_rfc8785_number_vectors(hex_bits: str, expected: str):
+    assert jcs_dumps(_double(hex_bits)) == expected
+
+
+def test_nan_and_infinity_are_rejected():
+    for bits in ("7fffffffffffffff", "7ff0000000000000"):
+        with pytest.raises(ValueError):
+            jcs_dumps(_double(bits))
+
+
+def test_readme_end_to_end_vector():
+    """The cyberphone/json-canonicalization README vector: exercises lowercase
+    \\u escapes, predefined escapes, raw UTF-8 passthrough, unescaped solidus,
+    number normalization, and key sorting in one object."""
+    value = {
+        "numbers": [333333333.33333329, 1e30, 4.50, 2e-3, 0.000000000000000000000000001],
+        "string": '€$\x0f\nA\'B"\\\\"/',
+        "literals": [None, True, False],
+    }
+    expected = (
+        '{"literals":[null,true,false],'
+        '"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],'
+        '"string":"€$\\u000f\\nA\'B\\"\\\\\\\\\\"/"}'
+    )
+    assert jcs_dumps(value) == expected
+
+
+def test_keys_sort_by_utf16_code_units_not_code_points():
+    """U+1D306 (surrogate pair, first unit 0xD834) sorts BEFORE U+FF61 in
+    UTF-16 code-unit order even though its code point is larger — the exact
+    case where naive code-point sorting diverges from RFC 8785."""
+    serialized = jcs_dumps({"｡": 1, "\U0001d306": 2})
+    assert serialized.index("\U0001d306") < serialized.index("｡")
+
+
+def test_integers_and_nesting_are_stable():
+    assert jcs_dumps({"b": [1, 2], "a": {"y": None, "x": -7}}) == '{"a":{"x":-7,"y":null},"b":[1,2]}'

--- a/tests/test_reaction_ledger_checkpoint.py
+++ b/tests/test_reaction_ledger_checkpoint.py
@@ -1,0 +1,102 @@
+"""Merkle checkpointing locks for the reaction ledger (RFC 6962 tree shape)."""
+
+from __future__ import annotations
+
+import hashlib
+
+from python.scbe.reaction_state import (
+    ReactionEndpoint,
+    ReactionLedger,
+    ReactionRecalculation,
+    merkle_audit_path,
+    merkle_tree_head,
+    verify_checkpoint,
+    verify_merkle_inclusion,
+)
+
+
+def _kwargs(**overrides):
+    base = dict(
+        domain="code",
+        step=1,
+        bounded_operation="op",
+        source=ReactionEndpoint(identity="a", representation="x", tongue="KO"),
+        target=ReactionEndpoint(identity="b", representation="y", tongue="DR"),
+        semantic_engravings=["e"],
+        loss_notes=[],
+        recalculation=ReactionRecalculation(identity_ok=True),
+        identity_preserved=True,
+        generated_at_utc="2026-06-12T00:00:00Z",
+    )
+    base.update(overrides)
+    return base
+
+
+def _fake_hashes(n: int) -> list[str]:
+    return [hashlib.sha256(f"packet-{i}".encode()).hexdigest() for i in range(n)]
+
+
+def test_merkle_inclusion_proofs_verify_for_every_leaf_at_every_size():
+    """Property lock: RFC 6962 head + audit path + RFC 9162 verify agree for
+    every leaf index at every tree size 1..16 (covers perfect and ragged trees)."""
+    for size in range(1, 17):
+        hashes = _fake_hashes(size)
+        root = merkle_tree_head(hashes)
+        for index in range(size):
+            path = merkle_audit_path(hashes, index)
+            assert verify_merkle_inclusion(hashes[index], index, size, path, root), (size, index)
+            # A tampered leaf must fail against the same path + root.
+            tampered = _fake_hashes(size + 1)[size]
+            assert not verify_merkle_inclusion(tampered, index, size, path, root)
+            # A wrong index must fail.
+            if size > 1:
+                assert not verify_merkle_inclusion(hashes[index], (index + 1) % size, size, path, root)
+
+
+def test_merkle_root_changes_on_omission_and_reorder():
+    hashes = _fake_hashes(5)
+    full = merkle_tree_head(hashes)
+    assert merkle_tree_head(hashes[:-1]) != full
+    assert merkle_tree_head(hashes[1:]) != full
+    swapped = [hashes[1], hashes[0], *hashes[2:]]
+    assert merkle_tree_head(swapped) != full
+
+
+def test_ledger_checkpoint_commits_count_root_and_chain():
+    ledger = ReactionLedger(agent_id="test-checkpoint")
+    for i in range(4):
+        ledger.append(**_kwargs(step=i + 1, generated_at_utc=f"2026-06-12T00:00:0{i}Z"))
+    cp = ledger.checkpoint()
+    assert cp["schema_version"] == "scbe_reaction_ledger_checkpoint_v1"
+    assert cp["tree_size"] == 4
+    assert cp["merkle_root"] == ledger.merkle_root()
+    assert cp["chain_verified"] is True
+    assert cp["last_packet_hash"] == ledger.packets[-1].packet_hash
+    for i in range(4):
+        proof = ledger.inclusion_proof(i)
+        assert proof["merkle_root"] == cp["merkle_root"]
+        assert verify_merkle_inclusion(
+            proof["packet_hash"], proof["leaf_index"], proof["tree_size"], proof["audit_path"], cp["merkle_root"]
+        )
+    # Signature mirrors the packets: True (asymmetric) or None (no signer backend),
+    # never False for an honest checkpoint.
+    assert verify_checkpoint(cp) in (True, None)
+    if cp["signature"]:
+        forged = dict(cp)
+        forged["tree_size"] = 5
+        assert verify_checkpoint(forged) is False
+
+
+def test_checkpoint_detects_truncated_ledger():
+    """The omission attack the linear chain cannot see: re-checkpointing a
+    truncated ledger yields a different root and size than the original."""
+    ledger = ReactionLedger(agent_id="test-truncate", sign=False)
+    for i in range(5):
+        ledger.append(**_kwargs(step=i + 1))
+    before = ledger.checkpoint()
+    ledger.packets.pop()
+    ledger._last_hash = ledger.packets[-1].packet_hash
+    assert ledger.verify() is True  # linear chain is blind to the omission
+    after = ledger.checkpoint()
+    assert after["tree_size"] != before["tree_size"]
+    assert after["merkle_root"] != before["merkle_root"]


### PR DESCRIPTION
Implements the receipt-interop roadmap from the adversarially-verified market comparison.

## What lands

1. **Merkle checkpointing** (RFC 6962 tree shape): `ReactionLedger.checkpoint()` signs a commitment to the exact set/order/count of packets — omission-resistance a linear prev-hash chain cannot provide. A test proves the attack: a truncated ledger still chain-verifies, but cannot reproduce the checkpoint. Inclusion proofs verify via the RFC 9162 algorithm, property-locked for every leaf at every tree size 1..16.
2. **RFC 8785 JCS canonicalizer** (stdlib-only): pinned to the spec's own Appendix B IEEE-754 vectors (24 cases, all notation boundaries) + the cyberphone end-to-end vector + a UTF-16-vs-code-point key-sort edge case. The existing packet-hash canonicalization is untouched — **old hashes stay byte-identical** (live methalox chain re-verifies).
3. **ACTA-compatible export** (draft-farley-acta-signed-receipts-01): `{payload, signature}` envelopes signed over exact JCS bytes via new `EventSigner.sign_bytes`/`verify_bytes`, hex sigs, `previousReceiptHash = SHA-256(JCS(entire signed receipt))`, ML-DSA-65 mapped directly (the draft RECOMMENDS it).
4. **Rekor-ready anchoring, dry-run by design**: anchor-ready `hashedrekord` entries over the checkpoint's JCS digest. No network I/O — public Rekor cannot verify ML-DSA today, so submission deliberately requires a PKIX countersignature.
5. **CLI**: `scbe react checkpoint --packets FILE [--rekor-dry-run] [--json]` — proven live on the methalox signed chain (ML-DSA-65 checkpoint, `chain_verified: True`).

## Verification

- 73 passed + 1 importorskip across receipt suites (`test_reaction_state_packet`, `test_reaction_ledger_checkpoint`, `test_jcs_canonicalization`, `test_acta_receipt_export`, `test_reaction_balance`, `test_units`, `test_geometry_view`)
- Signer-adjacent crypto + agent-bus suites 60/60 (covers the `verify()` refactor)
- black + flake8 clean; new test files PR-gated via `CORE_SMOKE_PATHS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkpoint functionality for reaction packets with Merkle tree verification support
  * Added ACTA receipt export and chain verification capabilities
  * Added Rekor integration for offline/dry-run transaction anchoring
  * Enhanced cryptographic signing and verification for raw byte data
  * New `checkpoint` command in the CLI tool for creating and verifying Merkle checkpoints

* **Tests**
  * Added comprehensive test coverage for Merkle proofs, receipt exports, and canonical JSON serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->