### PR TITLE
feat(units): QUDT IRIs on named units + NIST TN 1943 pathology locks

### DIFF
--- a/python/scbe/units.py
+++ b/python/scbe/units.py
@@ -19,7 +19,13 @@ Design:
     pattern used elsewhere in this repo (RDKit, liboqs).
 
 It does not (v1) model affine units (degC/degF offsets) -- temperature is treated
-as kelvin-scaled only; that limitation is explicit, not silent.
+as kelvin-scaled only -- nor distinguish quantity kinds that share a dimension
+(radian vs steradian, Hz vs Bq). Those limitations are explicit, not silent, and
+pinned in tests/test_units_pathology.py against the NIST TN 1943 taxonomy.
+
+Named units also carry their canonical QUDT IRI (``Unit.qudt``) so a receipt can
+state unit semantics in a resolvable, machine-checkable form via
+``unit_descriptor()``; derived units carry ``None`` rather than a fabricated IRI.
 """
 
 from __future__ import annotations
@@ -76,6 +82,16 @@ def dim_name(d: Dimension) -> str:
     return "·".join(parts) if parts else "1"
 
 
+# QUDT (qudt.org) unit-vocabulary IRIs for the named units below. QUDT is
+# CC BY 4.0 (https://qudt.org); these are stable vocab IRIs of the form
+# http://qudt.org/vocab/unit/<CODE>. Carrying the IRI in a packet lets an
+# external verifier resolve exact unit semantics instead of guessing from a
+# free-text symbol -- the interop half of the Orbiter lesson. Units composed by
+# Unit.__mul__/__truediv__ carry no IRI (None): a derived scale has no single
+# canonical QUDT term, and inventing one would be a false claim.
+_QUDT = "http://qudt.org/vocab/unit/"
+
+
 @dataclass(frozen=True)
 class Unit:
     """A named unit: a dimension plus an EXACT multiplicative scale to SI base."""
@@ -83,6 +99,7 @@ class Unit:
     name: str
     dimension: Dimension
     to_si: Fraction  # SI_magnitude = magnitude * to_si
+    qudt: str | None = None  # canonical QUDT IRI for named units; None when derived
 
     def __mul__(self, other: "Unit") -> "Unit":
         return Unit(f"({self.name}*{other.name})", dim_mul(self.dimension, other.dimension), self.to_si * other.to_si)
@@ -92,24 +109,24 @@ class Unit:
 
 
 # ---- registry: SI + the two force/impulse units that demonstrate the catch --- #
-KILOGRAM = Unit("kg", MASS, Fraction(1))
-GRAM = Unit("g", MASS, Fraction(1, 1000))
-METER = Unit("m", LENGTH, Fraction(1))
-SECOND = Unit("s", TIME, Fraction(1))
-KELVIN = Unit("K", TEMPERATURE, Fraction(1))
-MOLE = Unit("mol", AMOUNT, Fraction(1))
-PER_MOLE = Unit("1/mol", dim(mol=-1), Fraction(1))
-DIMLESS = Unit("1", DIMENSIONLESS, Fraction(1))
+KILOGRAM = Unit("kg", MASS, Fraction(1), _QUDT + "KiloGM")
+GRAM = Unit("g", MASS, Fraction(1, 1000), _QUDT + "GM")
+METER = Unit("m", LENGTH, Fraction(1), _QUDT + "M")
+SECOND = Unit("s", TIME, Fraction(1), _QUDT + "SEC")
+KELVIN = Unit("K", TEMPERATURE, Fraction(1), _QUDT + "K")
+MOLE = Unit("mol", AMOUNT, Fraction(1), _QUDT + "MOL")
+PER_MOLE = Unit("1/mol", dim(mol=-1), Fraction(1), _QUDT + "PER-MOL")
+DIMLESS = Unit("1", DIMENSIONLESS, Fraction(1), _QUDT + "UNITLESS")
 
-NEWTON = Unit("N", FORCE, Fraction(1))
-POUND_FORCE = Unit("lbf", FORCE, Fraction(444822, 100000))  # 4.44822 N (exact rational)
-NEWTON_SECOND = Unit("N*s", IMPULSE, Fraction(1))
-LBF_SECOND = Unit("lbf*s", IMPULSE, POUND_FORCE.to_si)  # same dimension, 4.448x scale
+NEWTON = Unit("N", FORCE, Fraction(1), _QUDT + "N")
+POUND_FORCE = Unit("lbf", FORCE, Fraction(444822, 100000), _QUDT + "LB_F")  # 4.44822 N (exact rational)
+NEWTON_SECOND = Unit("N*s", IMPULSE, Fraction(1), _QUDT + "N-SEC")
+LBF_SECOND = Unit("lbf*s", IMPULSE, POUND_FORCE.to_si)  # no canonical QUDT term; the Orbiter "wrong unit"
 
-JOULE = Unit("J", ENERGY, Fraction(1))
-G_PER_MOL = Unit("g/mol", MOLAR_MASS, Fraction(1, 1000))  # kg/mol = (g/mol)/1000
-LITER = Unit("L", VOLUME, Fraction(1, 1000))
-MOL_PER_L = Unit("mol/L", CONCENTRATION, Fraction(1000))  # mol/L = 1000 mol/m^3
+JOULE = Unit("J", ENERGY, Fraction(1), _QUDT + "J")
+G_PER_MOL = Unit("g/mol", MOLAR_MASS, Fraction(1, 1000), _QUDT + "GM-PER-MOL")  # kg/mol = (g/mol)/1000
+LITER = Unit("L", VOLUME, Fraction(1, 1000), _QUDT + "L")
+MOL_PER_L = Unit("mol/L", CONCENTRATION, Fraction(1000), _QUDT + "MOL-PER-L")  # mol/L = 1000 mol/m^3
 
 AVOGADRO = Unit("1/mol", dim(mol=-1), Fraction(602214076, 1) * Fraction(10) ** 15)  # 6.02214076e23 /mol
 
@@ -172,6 +189,25 @@ def mul(a: Quantity, b: Quantity) -> Quantity:
 
 def div(a: Quantity, b: Quantity) -> Quantity:
     return Quantity(a.magnitude / b.magnitude, a.unit / b.unit)
+
+
+def unit_descriptor(unit: Unit) -> dict:
+    """A packet-ready, self-describing view of a unit for receipt metadata.
+
+    Carries the QUDT IRI (``None`` for derived units), the base-dimension
+    exponent vector, and the exact SI scale as a string ``"num/den"`` so a
+    verifier reconstructs the Fraction without float drift::
+
+        {"symbol": "g/mol", "qudt": "http://qudt.org/vocab/unit/GM-PER-MOL",
+         "dimension": "kg^1·mol^-1", "si_scale": "1/1000"}
+    """
+    scale = Fraction(unit.to_si)
+    return {
+        "symbol": unit.name,
+        "qudt": unit.qudt,
+        "dimension": dim_name(unit.dimension),
+        "si_scale": f"{scale.numerator}/{scale.denominator}",
+    }
 
 
 def assert_dim(value: Quantity, expected: Dimension) -> Quantity:

--- a/scripts/system/run_core_python_checks.py
+++ b/scripts/system/run_core_python_checks.py
@@ -43,6 +43,7 @@ CORE_SMOKE_PATHS: tuple[str, ...] = (
     "tests/test_jcs_canonicalization.py",
     "tests/test_acta_receipt_export.py",
     "tests/test_units.py",
+    "tests/test_units_pathology.py",
     "tests/test_reaction_balance.py",
     "tests/test_geometry_view.py",
     "tests/test_controlled_substance_screen.py",

--- a/tests/test_units_pathology.py
+++ b/tests/test_units_pathology.py
@@ -1,0 +1,163 @@
+"""Unit-pathology locks, framed on the NIST TN 1943 failure taxonomy.
+
+NIST Technical Note 1943 ("A Classification of Quantity Value Errors")
+enumerates the ways a dimensional check can pass while the computation is still
+wrong. This file pins, for each relevant class, EITHER the engine's catch OR --
+honestly -- the limitation it does not yet cover, so a regression in either
+direction is visible. The units engine is exact and stdlib-only; it is a
+dimension+scale checker, not a full affine/quantity-kind system, and these tests
+say exactly where that line falls.
+
+Also pins the QUDT IRI surface added for receipt interop.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+
+from python.scbe import units as U
+
+# Units constructed only to demonstrate a pathology class (not part of the
+# shipped registry).
+RADIAN = U.Unit("rad", U.DIMENSIONLESS, Fraction(1))
+STERADIAN = U.Unit("sr", U.DIMENSIONLESS, Fraction(1))
+HERTZ = U.Unit("Hz", U.dim(s=-1), Fraction(1))
+BECQUEREL = U.Unit("Bq", U.dim(s=-1), Fraction(1))
+PERCENT = U.Unit("%", U.DIMENSIONLESS, Fraction(1, 100))
+PPM = U.Unit("ppm", U.DIMENSIONLESS, Fraction(1, 1_000_000))
+
+
+# --------------------------------------------------------------------------- #
+# Class A: pathologies the engine CATCHES (the scale check earns its keep).
+# --------------------------------------------------------------------------- #
+
+
+def test_catch_same_dimension_different_scale_is_refused():
+    """TN 1943 'wrong unit, right dimension' -- the Mars Climate Orbiter loss."""
+    with pytest.raises(U.UnitError):
+        U.add(U.q(100, U.NEWTON_SECOND), U.q(100, U.LBF_SECOND))
+
+
+def test_catch_dimension_mismatch_is_refused():
+    with pytest.raises(U.UnitError):
+        U.add(U.q(1, U.KILOGRAM), U.q(1, U.METER))
+
+
+def test_catch_unitized_scaling_factor_against_bare_ratio():
+    """A '%' is a SCALED dimensionless: adding 50% to a bare 1 is refused
+    because the SI scales differ (1/100 vs 1) even though both are
+    dimensionless -- the 'unitized scaling factor' pathology."""
+    with pytest.raises(U.UnitError):
+        U.add(U.q(1, U.DIMLESS), U.q(50, PERCENT))
+    with pytest.raises(U.UnitError):
+        U.add(U.q(50, PERCENT), U.q(50, PPM))
+
+
+def test_catch_count_density_vs_reciprocal_amount():
+    """Avogadro's number (per mole, huge scale) and a bare 1/mol share the
+    dimension mol^-1 but differ by ~6e23x -- refused."""
+    with pytest.raises(U.UnitError):
+        U.add(U.q(1, U.AVOGADRO), U.q(1, U.PER_MOLE))
+
+
+def test_catch_is_exact_no_float_coercion():
+    """Conversions ride Fraction scales: no float drift (TN 1943 'rounding /
+    representation' class). 100 lbf*s -> N*s stays an exact rational."""
+    converted = U.convert(U.q(100, U.LBF_SECOND), U.NEWTON_SECOND)
+    assert converted.magnitude == Fraction(100) * Fraction(444822, 100000)
+    assert isinstance(converted.magnitude, Fraction)
+
+
+# --------------------------------------------------------------------------- #
+# Class B: pathologies the engine does NOT cover -- documented limitations.
+# These tests pin the CURRENT behavior so the gap is explicit, not silent.
+# --------------------------------------------------------------------------- #
+
+
+def test_limitation_dimensionless_collision_plane_vs_solid_angle():
+    """Radian and steradian are both dimension-1 with scale 1, so the engine
+    cannot tell a plane angle from a solid angle from a pure count. This is the
+    TN 1943 'dimensionless collision' / 'angle erasure' class -- unmodeled."""
+    total = U.add(U.q(1, RADIAN), U.q(1, STERADIAN))  # erroneously allowed
+    assert total.magnitude == 2
+    assert U.same_dimension(U.q(1, RADIAN), U.q(1, U.DIMLESS))  # angle erased to a number
+
+
+def test_limitation_hertz_ambiguity_cycles_vs_events():
+    """Hz (cycles/s) and Bq (events/s) are both s^-1 with scale 1; the engine
+    treats them as identical. TN 1943 'same dimension, distinct quantity kind'
+    -- a quantity-kind system would separate them; this engine does not."""
+    total = U.add(U.q(1, HERTZ), U.q(1, BECQUEREL))  # erroneously allowed
+    assert total.magnitude == 2
+
+
+def test_limitation_temperature_is_interval_scaled_no_affine_zero_point():
+    """Temperature is K-scaled only: the engine has no affine (offset) units, so
+    it models temperature INTERVALS correctly but cannot express an absolute
+    Celsius zero point (0 degC = 273.15 K). TN 1943 'interval vs ratio scale'."""
+    # A 1 K interval and a 1 degC interval coincide (scale 1) -- this it gets right.
+    assert U.KELVIN.to_si == Fraction(1)
+    # There is deliberately no Celsius/Fahrenheit unit in the registry.
+    assert not hasattr(U, "CELSIUS")
+    assert not hasattr(U, "FAHRENHEIT")
+
+
+# --------------------------------------------------------------------------- #
+# QUDT IRI surface (receipt interop).
+# --------------------------------------------------------------------------- #
+
+_QUDT_PREFIX = "http://qudt.org/vocab/unit/"
+# IRIs confirmed to resolve against the live QUDT vocabulary (CC BY 4.0).
+_VERIFIED_QUDT = {
+    U.KILOGRAM: "KiloGM",
+    U.GRAM: "GM",
+    U.METER: "M",
+    U.SECOND: "SEC",
+    U.KELVIN: "K",
+    U.MOLE: "MOL",
+    U.PER_MOLE: "PER-MOL",
+    U.DIMLESS: "UNITLESS",
+    U.NEWTON: "N",
+    U.POUND_FORCE: "LB_F",
+    U.NEWTON_SECOND: "N-SEC",
+    U.JOULE: "J",
+    U.G_PER_MOL: "GM-PER-MOL",
+    U.LITER: "L",
+    U.MOL_PER_L: "MOL-PER-L",
+}
+
+
+@pytest.mark.parametrize("unit,code", list(_VERIFIED_QUDT.items()), ids=lambda x: getattr(x, "name", x))
+def test_named_units_carry_their_verified_qudt_iri(unit, code):
+    assert unit.qudt == _QUDT_PREFIX + code
+
+
+def test_orbiter_wrong_unit_has_no_invented_iri():
+    """lbf*s has no canonical QUDT term (the IRI 404s), so it carries None
+    rather than a fabricated code -- the honest half of the interop claim."""
+    assert U.LBF_SECOND.qudt is None
+
+
+def test_derived_units_carry_no_iri():
+    """A unit composed by * or / has no single canonical QUDT term."""
+    speed = U.METER / U.SECOND
+    work = U.NEWTON * U.METER
+    assert speed.qudt is None
+    assert work.qudt is None
+
+
+def test_unit_descriptor_is_packet_ready_and_exact():
+    d = U.unit_descriptor(U.G_PER_MOL)
+    assert d == {
+        "symbol": "g/mol",
+        "qudt": _QUDT_PREFIX + "GM-PER-MOL",
+        "dimension": "kg·mol^-1",
+        "si_scale": "1/1000",
+    }
+    # si_scale round-trips to the exact Fraction with no float drift.
+    num, den = d["si_scale"].split("/")
+    assert Fraction(int(num), int(den)) == U.G_PER_MOL.to_si
+    # Derived units report a null IRI honestly.
+    assert U.unit_descriptor(U.METER / U.SECOND)["qudt"] is None


### PR DESCRIPTION
Receipt-interop + rigor items from the market comparison: resolvable unit semantics in receipts, and an honest pathology test suite for the units engine.

## QUDT interop

- `Unit` gains an optional `qudt` field — the canonical QUDT vocab IRI (`http://qudt.org/vocab/unit/<CODE>`, CC BY 4.0) for each named unit.
- **Every attached IRI was confirmed to resolve** against the live QUDT vocabulary (KiloGM, GM, M, SEC, K, MOL, PER-MOL, UNITLESS, N, LB_F, N-SEC, J, GM-PER-MOL, L, MOL-PER-L).
- `lbf*s` carries `None` — its IRI 404s, so no code is fabricated — and units composed by `*`/`/` carry `None` (no single canonical term). A made-up IRI is exactly the false claim the engine exists to prevent.
- `unit_descriptor(unit)` emits a packet-ready view `{symbol, qudt, dimension, si_scale}` where `si_scale` is `"num/den"` so a verifier reconstructs the exact `Fraction` with no float drift.

```
{"symbol": "g/mol", "qudt": "http://qudt.org/vocab/unit/GM-PER-MOL", "dimension": "kg·mol^-1", "si_scale": "1/1000"}
{"symbol": "lbf*s",  "qudt": null, ...}        # 404 → honest null
{"symbol": "(m/s)",  "qudt": null, ...}        # derived → null
```

## NIST TN 1943 pathology locks

`tests/test_units_pathology.py` pins, per failure class, **either** the engine's catch **or** — honestly — the limitation it does not cover, so a regression in either direction is visible.

- **Catches**: wrong-unit/right-dimension (Mars Climate Orbiter), dimension mismatch, unitized scaling factors (`50%` vs bare `1`, `%` vs `ppm`), reciprocal-amount scale (Avogadro vs `1/mol`), Fraction-exact conversion (no float coercion).
- **Documented limitations**: dimensionless collision / angle erasure (rad vs sr vs count), Hz-vs-Bq quantity-kind ambiguity, and the absence of affine (offset) temperature units. The engine is a dimension+scale checker, not a full quantity-kind system, and the tests say exactly where that line falls.

## Verification

26 pathology tests + 8 existing units tests + 9 packet tests green; PR-gated via `CORE_SMOKE_PATHS`; black + flake8 clean. Live `unit_descriptor` output confirmed for resolvable and null cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
