### PR TITLE
fix(swarm): honor the Judge's binding veto in roundtable consensus

### DIFF
--- a/agents/swarm_browser.py
+++ b/agents/swarm_browser.py
@@ -511,34 +511,70 @@ class JudgeAgent(SwarmAgent):
             votes = payload.get("votes", [])
             decision = self._aggregate_votes(votes)
 
+            # judge_override is True exactly when the Judge's binding vote
+            # tightened the outcome away from the count-only Byzantine tally.
+            counts = self._count_decisions(votes)
+            judge_override = decision != self._tally_consensus(counts)
+
             return self.create_message(
-                "final_decision", {"decision": decision, "votes": votes, "judge_override": False}
+                "final_decision",
+                {"decision": decision, "votes": votes, "judge_override": judge_override},
             )
 
         return None
 
-    def _aggregate_votes(self, votes: List[Dict]) -> str:
-        """Aggregate votes using Byzantine-safe consensus."""
-        decision_counts = {"ALLOW": 0, "QUARANTINE": 0, "ESCALATE": 0, "DENY": 0}
-
+    @staticmethod
+    def _count_decisions(votes: List[Dict]) -> Dict[str, int]:
+        counts = {"ALLOW": 0, "QUARANTINE": 0, "ESCALATE": 0, "DENY": 0}
         for vote in votes:
             decision = vote.get("decision", "DENY")
-            decision_counts[decision] = decision_counts.get(decision, 0) + 1
+            counts[decision] = counts.get(decision, 0) + 1
+        return counts
 
+    @staticmethod
+    def _tally_consensus(decision_counts: Dict[str, int]) -> str:
+        """Count-only Byzantine rule (no Judge override) -- f=2 safe."""
         # Need 4/6 for ALLOW (Byzantine safe with f=2)
         if decision_counts["ALLOW"] >= 4:
             return "ALLOW"
-
-        # Any DENY is concerning
+        # Any two DENY votes are concerning
         if decision_counts["DENY"] >= 2:
             return "DENY"
-
         # Escalate if uncertain
         if decision_counts["ESCALATE"] >= 2:
             return "ESCALATE"
-
         # Default to quarantine
         return "QUARANTINE"
+
+    def _aggregate_votes(self, votes: List[Dict]) -> str:
+        """Aggregate votes using Byzantine-safe consensus with a BINDING Judge veto.
+
+        The Judge (DR) only ever *tightens* the count-only tally, as its
+        ``vote()`` docstring promises ("veto power for high-risk actions"):
+          * a Judge DENY (its risk>0.9 veto path) denies the action outright,
+            even if every other agent voted ALLOW;
+          * a Judge ESCALATE (risk>0.7) cannot be overridden into a plain
+            ALLOW by a 4/6 majority -- the action escalates for review.
+        The Judge can never *loosen* a denial reached on the tally.
+        """
+        decision_counts = self._count_decisions(votes)
+
+        judge_decision = None
+        for vote in votes:
+            if vote.get("agent") == SacredTongue.DR.value:
+                judge_decision = vote.get("decision", "DENY")
+
+        # Binding veto: a Judge DENY overrides the tally entirely.
+        if judge_decision == "DENY":
+            return "DENY"
+
+        tally = self._tally_consensus(decision_counts)
+
+        # A Judge escalation cannot be voted down into an ALLOW.
+        if judge_decision == "ESCALATE" and tally == "ALLOW":
+            return "ESCALATE"
+
+        return tally
 
     async def vote(self, action_id: str, action: str, context: Dict[str, Any]) -> SwarmVote:
         """Judge has veto power for high-risk actions."""

--- a/tests/test_swarm_judge_veto.py
+++ b/tests/test_swarm_judge_veto.py
@@ -1,0 +1,81 @@
+"""The Judge (DR) holds a binding veto in swarm roundtable consensus.
+
+Regression for a real governance hole: the count-only aggregator returned
+ALLOW on a 4/6 majority even when the Judge cast its risk>0.9 DENY veto, so
+the "veto power" promised by JudgeAgent.vote()'s docstring was never honored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from agents.swarm_browser import JudgeAgent, SacredTongue, SwarmMessage
+
+
+def _vote(agent: str, decision: str) -> dict:
+    return {"agent": agent, "decision": decision, "confidence": 0.9, "reasoning": ""}
+
+
+def _judge() -> JudgeAgent:
+    # _aggregate_votes never touches self.swarm, so a bare instance is enough.
+    return JudgeAgent(swarm=None)
+
+
+def test_judge_deny_veto_overrides_a_4_of_6_allow_majority():
+    judge = _judge()
+    votes = [_vote(t, "ALLOW") for t in ("KO", "AV", "RU", "CA", "UM")]
+    votes.append(_vote(SacredTongue.DR.value, "DENY"))  # the risk>0.9 veto
+    assert judge._aggregate_votes(votes) == "DENY"
+
+
+def test_judge_escalate_cannot_be_overridden_into_allow():
+    judge = _judge()
+    votes = [_vote(t, "ALLOW") for t in ("KO", "AV", "RU", "CA")]  # 4/6 ALLOW
+    votes.append(_vote("UM", "ALLOW"))
+    votes.append(_vote(SacredTongue.DR.value, "ESCALATE"))
+    assert judge._aggregate_votes(votes) == "ESCALATE"
+
+
+def test_unanimous_allow_still_allows_when_judge_agrees():
+    judge = _judge()
+    votes = [_vote(t, "ALLOW") for t in ("KO", "AV", "RU", "CA", "UM", SacredTongue.DR.value)]
+    assert judge._aggregate_votes(votes) == "ALLOW"
+
+
+def test_two_non_judge_denies_still_deny_via_tally():
+    judge = _judge()
+    votes = [_vote("KO", "DENY"), _vote("AV", "DENY")]
+    votes += [_vote(t, "ALLOW") for t in ("RU", "CA")]
+    votes.append(_vote(SacredTongue.DR.value, "ALLOW"))
+    assert judge._aggregate_votes(votes) == "DENY"
+
+
+def test_judge_cannot_loosen_a_tally_denial():
+    """A Judge ALLOW must not rescue an action two other agents denied."""
+    judge = _judge()
+    votes = [_vote("KO", "DENY"), _vote("AV", "DENY"), _vote("RU", "ALLOW")]
+    votes.append(_vote(SacredTongue.DR.value, "ALLOW"))
+    assert judge._aggregate_votes(votes) == "DENY"
+
+
+def test_judge_override_flag_is_honest():
+    judge = _judge()
+
+    # veto changed the outcome -> override True
+    veto_votes = [_vote(t, "ALLOW") for t in ("KO", "AV", "RU", "CA", "UM")]
+    veto_votes.append(_vote(SacredTongue.DR.value, "DENY"))
+    msg = SwarmMessage(
+        id="t", from_agent=SacredTongue.DR, to_agent=None, action="request_approval", payload={"votes": veto_votes}
+    )
+    out = asyncio.run(judge.process(msg))
+    assert out.payload["decision"] == "DENY"
+    assert out.payload["judge_override"] is True
+
+    # plain unanimous ALLOW -> Judge agreed, no override
+    allow_votes = [_vote(t, "ALLOW") for t in ("KO", "AV", "RU", "CA", "UM", SacredTongue.DR.value)]
+    msg2 = SwarmMessage(
+        id="t2", from_agent=SacredTongue.DR, to_agent=None, action="request_approval", payload={"votes": allow_votes}
+    )
+    out2 = asyncio.run(judge.process(msg2))
+    assert out2.payload["decision"] == "ALLOW"
+    assert out2.payload["judge_override"] is False


### PR DESCRIPTION
## The bug

In the swarm roundtable (`agents/swarm_browser.py`), the Judge agent (DR) is the
"Final decision and safety approval specialist". Its `vote()` method documents
**"Judge has veto power for high-risk actions"** and casts a `DENY` (confidence
0.99, reasoning `"Judge veto: risk score … exceeds threshold"`) whenever
`risk_score > 0.9`.

But `_aggregate_votes` was a pure tally with no notion of *who* voted:

```python
if decision_counts["ALLOW"] >= 4:   # 4/6 majority
    return "ALLOW"
if decision_counts["DENY"] >= 2:    # needs TWO denies
    return "DENY"
```

So when 5 agents voted ALLOW and the Judge cast its lone veto, the result was
`ALLOW` — the documented veto was **silently dropped**. The governance authority
could not actually block. (`judge_override` was also hardcoded `False`, so the
receipt hid it.)

This was surfaced by a multi-agent task-dispensation audit and reproduced live:
`[DR] DENY (0.99): Judge veto …` → `Final decision: ALLOW`.

## The fix

`_aggregate_votes` now treats the Judge (DR) as a **one-way tightening
authority**:

- a Judge **DENY** denies the action outright, regardless of the tally;
- a Judge **ESCALATE** cannot be voted down into a plain `ALLOW`;
- the Judge can **never loosen** a denial the tally already reached (a Judge
  ALLOW can't rescue an action two other agents denied).

The count-only Byzantine rule is factored into `_tally_consensus` (unchanged
semantics), and `judge_override` now honestly reports when the Judge's vote
changed the outcome.

## Verified

- New `tests/test_swarm_judge_veto.py` — 6 cases (veto overrides 4/6 majority;
  escalate can't be overridden; unanimous allow still allows; two non-judge
  denies still deny via tally; judge can't loosen a tally denial;
  `judge_override` flag honesty). **6 passed.**
- End-to-end through the real `roundtable_consensus` at `risk_score=0.95`:
  5 ALLOW + Judge DENY → **final `DENY`** (was `ALLOW`).
- `black` + `flake8` (120) clean. First-ever test coverage for this aggregator
  (there was none before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
