### PR TITLE
feat(swarm): risk-gate clicks + governed headless (unattended) use mode

### DIFF
--- a/agents/agent_bus_browser.py
+++ b/agents/agent_bus_browser.py
@@ -78,11 +78,18 @@ class HeadedBackend:
 
 
 class SwarmBackend:
-    """SwarmBrowser with six Sacred Tongue agents and Byzantine roundtable."""
+    """SwarmBrowser with six Sacred Tongue agents and Byzantine roundtable.
 
-    def __init__(self) -> None:
+    Pass ``unattended=True`` for governed headless use (batch/CI/AI-driven):
+    every action is still risk-gated and consensus-governed, but a decision
+    that asks for a human (ESCALATE/QUARANTINE) fails closed with an audit
+    reason instead of dangling, since no operator is present.
+    """
+
+    def __init__(self, unattended: bool = False) -> None:
         self.runtime: Any = None
         self.swarm: Any = None
+        self.unattended = unattended
 
     async def launch(self, *, headless: bool = True) -> None:
         from agents.playwright_runtime import PlaywrightRuntime
@@ -90,9 +97,9 @@ class SwarmBackend:
 
         self.runtime = PlaywrightRuntime()
         await self.runtime.launch(headless=headless)
-        self.swarm = SwarmBrowser(browser_backend=self.runtime)
+        self.swarm = SwarmBrowser(browser_backend=self.runtime, unattended=self.unattended)
         await self.swarm.initialize()
-        logger.info("swarm backend ready (6 Sacred Tongue agents)")
+        logger.info("swarm backend ready (6 Sacred Tongue agents, unattended=%s)", self.unattended)
 
     async def close(self) -> None:
         if self.runtime is not None:
@@ -106,12 +113,16 @@ class SwarmBackend:
         return await self.swarm.roundtable_consensus(action_id, action, context)
 
 
-def make_backend(mode: str) -> BrowserBackend:
-    """Factory: pick a backend by name. Raises ValueError on unknown modes."""
+def make_backend(mode: str, *, unattended: bool = False) -> BrowserBackend:
+    """Factory: pick a backend by name. Raises ValueError on unknown modes.
+
+    ``unattended`` only affects the governed ``swarm`` backend (governed
+    headless use); the raw ``headless`` and ``headed`` backends ignore it.
+    """
     if mode not in VALID_MODES:
         raise ValueError(f"browser_mode={mode!r} not in {VALID_MODES}")
     if mode == "headless":
         return HeadlessBackend()
     if mode == "headed":
         return HeadedBackend()
-    return SwarmBackend()
+    return SwarmBackend(unattended=unattended)

--- a/agents/swarm_browser.py
+++ b/agents/swarm_browser.py
@@ -449,6 +449,45 @@ class ClickerAgent(SwarmAgent):
 
         return None
 
+    def _assess_target_risk(self, target: str) -> float:
+        """Assess click-target risk so the Judge can veto a dangerous click.
+
+        Mirrors ScoutAgent._assess_url_risk: a click is only as safe as what it
+        commits. Destructive and authorizing actions score highest.
+        """
+        t = (target or "").lower()
+
+        # Destructive / irreversible
+        if any(x in t for x in ["delete", "remove", "destroy", "wipe", "erase", "drop", "format"]):
+            return 0.95
+        # Financial / authorization commits
+        if any(
+            x in t
+            for x in [
+                "transfer",
+                "withdraw",
+                "send money",
+                "pay",
+                "purchase",
+                "buy",
+                "checkout",
+                "authorize",
+                "approve",
+                "grant",
+            ]
+        ):
+            return 0.9
+        # Credential / submission surfaces
+        if any(x in t for x in ["password", "login", "sign in", "signin", "submit", "confirm", "2fa", "otp"]):
+            return 0.7
+        # Account / admin surfaces
+        if any(x in t for x in ["account", "settings", "admin", "billing", "permission"]):
+            return 0.5
+        # Benign navigation-ish clicks
+        if any(x in t for x in ["search", "next", "back", "home", "menu", "close", "cancel"]):
+            return 0.2
+        return 0.4  # Default
+
 
 class TyperAgent(SwarmAgent):
     """UM - Text input and form filling specialist."""
@@ -626,9 +665,14 @@ class SwarmBrowser:
         scbe_url: str = "http://127.0.0.1:8080",
         hub_primary_path: str = "artifacts/swarm_hub/primary.jsonl",
         hub_replica_paths: Optional[List[str]] = None,
+        unattended: bool = False,
     ):
         self.browser = browser_backend
         self.scbe_url = scbe_url
+        # Headless / unattended use: no human operator is present, so a decision
+        # that asks for one (ESCALATE/QUARANTINE) cannot be satisfied and must
+        # fail closed with an explicit reason rather than dangling as "pending".
+        self.unattended = unattended
         self.hub = DecentralizedHub(
             primary_path=hub_primary_path,
             replica_paths=hub_replica_paths,
@@ -655,6 +699,26 @@ class SwarmBrowser:
             "payload": payload,
         }
         return self.hub.write(record)
+
+    def _resolve_execution(self, decision: str) -> Dict[str, Any]:
+        """Decide whether a consensus decision may execute, and record why.
+
+        Only ALLOW ever executes. In unattended (headless) mode there is no
+        operator to approve an ESCALATE/QUARANTINE, so those fail closed --
+        the effective decision becomes DENY with an explicit audit reason --
+        instead of silently not executing or waiting on a prompt that will
+        never come. Attended mode keeps the literal decision (a human can act
+        on an ESCALATE later).
+        """
+        if decision == "ALLOW":
+            return {"execute": True, "effective_decision": "ALLOW", "auto_resolution": None}
+        if self.unattended and decision in ("ESCALATE", "QUARANTINE"):
+            return {
+                "execute": False,
+                "effective_decision": "DENY",
+                "auto_resolution": (f"headless: {decision} needs an operator; none present -> withheld (fail-closed)"),
+            }
+        return {"execute": False, "effective_decision": decision, "auto_resolution": None}
 
     async def initialize(self) -> bool:
         """Activate all agents (Megazord assembly)."""
@@ -734,15 +798,20 @@ class SwarmBrowser:
         # Get consensus
         consensus = await self.roundtable_consensus(action_id, "navigate", {"url": url, "risk_score": risk_score})
 
+        gate = self._resolve_execution(consensus["final_decision"])
         result = {
             "action": "navigate",
             "url": url,
             "decision": consensus["final_decision"],
+            "effective_decision": gate["effective_decision"],
+            "unattended": self.unattended,
             "risk_score": risk_score,
             "executed": False,
         }
+        if gate["auto_resolution"]:
+            result["auto_resolution"] = gate["auto_resolution"]
 
-        if consensus["final_decision"] == "ALLOW":
+        if gate["execute"]:
             # Execute navigation via browser backend
             if self.browser:
                 await self.browser.navigate(url)
@@ -764,18 +833,30 @@ class SwarmBrowser:
         vision_result = await self.agents[SacredTongue.AV].process(vision_msg)
         coordinates = vision_result.payload.get("coordinates", [0, 0])
 
-        # Get consensus
-        consensus = await self.roundtable_consensus(action_id, "click", {"target": target, "coordinates": coordinates})
+        # A click is only as safe as what it commits -- risk-score the target so
+        # the Judge can veto a destructive/authorizing click, just like navigate.
+        risk_score = self.agents[SacredTongue.CA]._assess_target_risk(target)
 
+        # Get consensus
+        consensus = await self.roundtable_consensus(
+            action_id, "click", {"target": target, "coordinates": coordinates, "risk_score": risk_score}
+        )
+
+        gate = self._resolve_execution(consensus["final_decision"])
         result = {
             "action": "click",
             "target": target,
             "coordinates": coordinates,
             "decision": consensus["final_decision"],
+            "effective_decision": gate["effective_decision"],
+            "unattended": self.unattended,
+            "risk_score": risk_score,
             "executed": False,
         }
+        if gate["auto_resolution"]:
+            result["auto_resolution"] = gate["auto_resolution"]
 
-        if consensus["final_decision"] == "ALLOW":
+        if gate["execute"]:
             # Execute click via Clicker agent
             click_msg = SwarmMessage(
                 id=action_id,

--- a/tests/test_swarm_click_risk_headless.py
+++ b/tests/test_swarm_click_risk_headless.py
@@ -1,0 +1,85 @@
+"""Click actions are risk-gated, and headless (unattended) use fails closed.
+
+Two governance gaps closed together:
+  * click() passed no risk_score, so the Judge could never veto a click --
+    only navigate() was risk-scored. Now a destructive/authorizing click is
+    scored and the Judge's binding veto applies.
+  * there was no governed headless mode: with no operator present, an
+    ESCALATE/QUARANTINE has nobody to approve it, so it must fail closed with
+    an audit reason rather than dangle. SwarmBrowser(unattended=True) does that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from agents.swarm_browser import ClickerAgent, SwarmBrowser
+
+# --- click target risk scoring (mirrors ScoutAgent._assess_url_risk) -------- #
+
+
+def test_destructive_and_auth_clicks_score_high_benign_low():
+    ca = ClickerAgent(swarm=None)
+    assert ca._assess_target_risk("Delete account") >= 0.9
+    assert ca._assess_target_risk("Confirm transfer of funds") >= 0.9
+    assert ca._assess_target_risk("search results") <= 0.3
+    assert ca._assess_target_risk("next page") <= 0.3
+    # unknown target gets the cautious default, not zero
+    assert ca._assess_target_risk("mystery widget") == 0.4
+
+
+def test_judge_vetoes_a_destructive_click_end_to_end():
+    swarm = SwarmBrowser()  # attended, no browser backend
+    res = asyncio.run(swarm.click("delete everything"))
+    assert res["risk_score"] >= 0.9
+    assert res["decision"] == "DENY"  # Judge veto now reachable for clicks
+    assert res["executed"] is False
+
+
+def test_benign_click_is_allowed_and_executes():
+    swarm = SwarmBrowser()
+    res = asyncio.run(swarm.click("search results"))
+    assert res["risk_score"] <= 0.3
+    assert res["decision"] == "ALLOW"
+    assert res["executed"] is True
+
+
+# --- headless / unattended fail-closed policy ------------------------------- #
+
+
+def test_resolve_execution_allow_executes_in_both_modes():
+    for unattended in (False, True):
+        sw = SwarmBrowser(unattended=unattended)
+        gate = sw._resolve_execution("ALLOW")
+        assert gate["execute"] is True
+        assert gate["effective_decision"] == "ALLOW"
+        assert gate["auto_resolution"] is None
+
+
+def test_attended_escalate_is_held_for_a_human_not_denied():
+    sw = SwarmBrowser(unattended=False)
+    gate = sw._resolve_execution("ESCALATE")
+    assert gate["execute"] is False
+    assert gate["effective_decision"] == "ESCALATE"  # a human can still act on it
+    assert gate["auto_resolution"] is None
+
+
+def test_headless_escalate_and_quarantine_fail_closed():
+    sw = SwarmBrowser(unattended=True)
+    for decision in ("ESCALATE", "QUARANTINE"):
+        gate = sw._resolve_execution(decision)
+        assert gate["execute"] is False
+        assert gate["effective_decision"] == "DENY"  # no operator -> fail closed
+        assert "headless" in gate["auto_resolution"]
+
+
+def test_headless_navigate_escalation_is_withheld_with_receipt():
+    """End-to-end: a Judge ESCALATE (risk 0.8) under unattended use is withheld
+    with effective DENY + an audit reason, and never executes."""
+    swarm = SwarmBrowser(unattended=True)
+    consensus = asyncio.run(swarm.roundtable_consensus("nav-x", "navigate", {"risk_score": 0.8}))
+    assert consensus["final_decision"] == "ESCALATE"  # Judge escalates, veto fix keeps it
+    gate = swarm._resolve_execution(consensus["final_decision"])
+    assert gate["execute"] is False
+    assert gate["effective_decision"] == "DENY"
+    assert gate["auto_resolution"]


### PR DESCRIPTION
Closes two governance gaps in the swarm browser, both surfaced by the multi-agent
dispensation audit. Builds on the now-binding Judge veto (#2188).

## 1. Clicks are now risk-gated

`navigate()` gets a `risk_score` from the Scout (`_assess_url_risk`), so the Judge
can veto a dangerous navigation. `click()` passed **no** `risk_score` — it defaulted
to 0.5 — so the Judge's `DENY` veto (`risk > 0.9`) could **never fire on a click**.
A destructive click was structurally un-vetoable.

Added `ClickerAgent._assess_target_risk(target)`, mirroring `ScoutAgent._assess_url_risk`:

| target contains | risk |
|---|---|
| delete / remove / destroy / wipe / drop / format | 0.95 |
| transfer / withdraw / pay / purchase / authorize / approve / grant | 0.90 |
| password / login / submit / confirm / 2fa / otp | 0.70 |
| account / settings / admin / billing | 0.50 |
| search / next / back / home / menu / close | 0.20 |
| (default) | 0.40 |

`click()` injects this into the consensus context, so the binding Judge veto now
covers clicks too.

## 2. Governed headless (unattended) use mode

The backend literally named `headless` is **ungoverned** (raw Playwright), and the
governed path had no way to run unattended: an `ESCALATE`/`QUARANTINE` ("requires
human approval") with no operator present would just dangle as "pending."

`SwarmBrowser(unattended=True)` adds a **fail-closed** execution policy
(`_resolve_execution`):

- `ALLOW` → executes (both modes).
- `ESCALATE` / `QUARANTINE` under `unattended` → **withheld**, effective decision
  becomes `DENY`, with an explicit `auto_resolution` audit reason. Never waits on a
  prompt that will never come.
- Attended mode is unchanged — a human can still act on an `ESCALATE`.

`navigate()`/`click()` now record `decision`, `effective_decision`, `unattended`,
and `auto_resolution` on every action + hub receipt. Threaded through
`SwarmBackend(unattended=...)` and `make_backend(mode, unattended=...)` so it's a
reachable use mode, not just an internal flag.

## Verified

- `tests/test_swarm_click_risk_headless.py` — 7 cases (risk assessor; destructive
  click vetoed e2e; benign click allowed/executes; `_resolve_execution` in both
  modes; headless ESCALATE/QUARANTINE fail closed; headless navigate escalation
  withheld with receipt). **7 passed**, +6 veto regression, +22 reaction = **35 green**.
- E2E proof: `click("delete account")` (risk 0.95) → Judge veto → `DENY`, not
  executed; headless `navigate` risk 0.8 → `ESCALATE` → effective `DENY`, withheld,
  receipt `"headless: ESCALATE needs an operator; none present -> withheld (fail-closed)"`;
  attended `ESCALATE` stays `ESCALATE`.
- `black` + `flake8` (120) clean; diff scoped (no full-file reflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
