### PR TITLE
feat(swarm): risk-gate type_text too (content scan + field sensitivity)

### DIFF
--- a/agents/swarm_browser.py
+++ b/agents/swarm_browser.py
@@ -533,6 +533,35 @@ class TyperAgent(SwarmAgent):
             agent=self.tongue, action_id=action_id, decision="ALLOW", confidence=0.85, reasoning="Non-sensitive input"
         )
 
+    def _assess_input_risk(self, text: str, field_type: str = "text") -> float:
+        """Assess typed-input risk so the Judge can veto a dangerous type.
+
+        Two dimensions, take the max:
+          * WHERE it is typed -- a credential/financial field sits in the
+            ESCALATE band (0.8), matching this agent's own sensitive-field
+            vote (typing a password is approve-worthy, not forbidden).
+          * WHAT is typed -- the membrane scanner scores the content for
+            injection/exfil; a genuine threat reaches the veto band (>0.9).
+        The raw text never leaves this method (only the score is returned),
+        preserving the "never include actual text in context" rule.
+        """
+        field = (field_type or "text").lower()
+        if field in ("password", "ssn", "credit_card", "bank_account", "secret", "api_key"):
+            field_risk = 0.8
+        elif field in ("email", "phone", "address", "name"):
+            field_risk = 0.5
+        else:
+            field_risk = 0.3
+
+        content_risk = 0.0
+        try:
+            scan = scan_text_for_threats(text or "")
+            content_risk = float(getattr(scan, "risk_score", 0.0) or 0.0)
+        except Exception:  # noqa: BLE001 - a scanner failure must not crash a type
+            content_risk = 0.0
+
+        return min(1.0, max(field_risk, content_risk))
+
 
 class JudgeAgent(SwarmAgent):
     """DR - Final decision and safety approval specialist."""
@@ -872,8 +901,14 @@ class SwarmBrowser:
         self._hub_event("swarm_action", result)
         return result
 
-    async def type_text(self, selector: str, text: str) -> Dict[str, Any]:
-        """Type with swarm consensus."""
+    async def type_text(self, selector: str, text: str, field_type: str = "text") -> Dict[str, Any]:
+        """Type with swarm consensus.
+
+        Pass field_type (e.g. "password", "credit_card") so the swarm can treat
+        credential/financial fields as sensitive. Input is risk-scored by the
+        Typer (membrane scan of content + field sensitivity) so the Judge's
+        binding veto applies; the raw text never enters the context or receipt.
+        """
         action_id = f"type-{len(self.action_history)}"
 
         # Reader analyzes the form field
@@ -887,20 +922,33 @@ class SwarmBrowser:
 
         await self.agents[SacredTongue.RU].process(reader_msg)
 
+        # A type is only as safe as its content + target field. Score it so the
+        # Judge can veto, exactly like navigate/click. (Score only -- no text.)
+        risk_score = self.agents[SacredTongue.UM]._assess_input_risk(text, field_type)
+
         # Get consensus (never include actual text in context)
         consensus = await self.roundtable_consensus(
-            action_id, "type", {"selector": selector, "text_length": len(text), "field_type": "text"}
+            action_id,
+            "type",
+            {"selector": selector, "text_length": len(text), "field_type": field_type, "risk_score": risk_score},
         )
 
+        gate = self._resolve_execution(consensus["final_decision"])
         result = {
             "action": "type",
             "selector": selector,
             "text_length": len(text),
+            "field_type": field_type,
             "decision": consensus["final_decision"],
+            "effective_decision": gate["effective_decision"],
+            "unattended": self.unattended,
+            "risk_score": risk_score,
             "executed": False,
         }
+        if gate["auto_resolution"]:
+            result["auto_resolution"] = gate["auto_resolution"]
 
-        if consensus["final_decision"] == "ALLOW":
+        if gate["execute"]:
             # Execute typing via Typer agent
             type_msg = SwarmMessage(
                 id=action_id, from_agent=SacredTongue.UM, to_agent=None, action="type", payload={"text": text}

--- a/tests/test_swarm_type_risk.py
+++ b/tests/test_swarm_type_risk.py
@@ -1,0 +1,72 @@
+"""type_text() is risk-gated, so the Judge veto + headless policy cover typing.
+
+Completes the set: navigate (url risk), click (target risk), and now type
+(content scan + field sensitivity). The raw text is never put in the consensus
+context or the receipt -- only the score and a length.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import agents.swarm_browser as sb
+from agents.swarm_browser import SwarmBrowser, TyperAgent
+
+# --- input risk scoring: field sensitivity + content threat (max) ----------- #
+
+
+def test_field_sensitivity_sets_the_floor():
+    um = TyperAgent(swarm=None)
+    assert um._assess_input_risk("hunter2", "password") >= 0.8  # ESCALATE band
+    assert um._assess_input_risk("me@example.com", "email") == 0.5
+    assert um._assess_input_risk("hello world", "text") == 0.3  # benign floor
+
+
+def test_high_threat_content_drives_risk_into_the_veto_band(monkeypatch):
+    """A hostile content score from the membrane reaches the Judge's veto band,
+    even on a benign field type."""
+
+    class FakeScan:
+        risk_score = 0.97
+
+    monkeypatch.setattr(sb, "scan_text_for_threats", lambda text, **k: FakeScan())
+    um = TyperAgent(swarm=None)
+    assert um._assess_input_risk("anything", "text") >= 0.95  # content dominates the max
+
+
+# --- end-to-end through the governed type path ------------------------------ #
+
+
+def test_password_field_escalates_and_is_held_when_attended():
+    swarm = SwarmBrowser()  # attended, no browser
+    res = asyncio.run(swarm.type_text("#pw", "hunter2", field_type="password"))
+    assert res["risk_score"] >= 0.8
+    assert res["decision"] == "ESCALATE"
+    assert res["effective_decision"] == "ESCALATE"  # a human can still approve
+    assert res["executed"] is False
+
+
+def test_password_field_fails_closed_when_headless():
+    swarm = SwarmBrowser(unattended=True)
+    res = asyncio.run(swarm.type_text("#pw", "hunter2", field_type="password"))
+    assert res["decision"] == "ESCALATE"
+    assert res["effective_decision"] == "DENY"  # no operator -> withheld
+    assert res["executed"] is False
+    assert "headless" in res["auto_resolution"]
+
+
+def test_benign_text_is_allowed_and_executes():
+    swarm = SwarmBrowser()
+    res = asyncio.run(swarm.type_text("#q", "hello", field_type="text"))
+    assert res["risk_score"] == 0.3
+    assert res["decision"] == "ALLOW"
+    assert res["executed"] is True
+
+
+def test_raw_text_never_leaks_into_result_or_receipt():
+    secret = "SuperSecretPass-9z!"
+    swarm = SwarmBrowser()
+    res = asyncio.run(swarm.type_text("#pw", secret, field_type="password"))
+    assert secret not in json.dumps(res)
+    assert res["text_length"] == len(secret)


### PR DESCRIPTION
Completes the swarm action set — every governed action is now risk-scored so the
binding Judge veto (#2188) and headless fail-closed policy (#2189) apply uniformly:

| action | risk source |
|---|---|
| `navigate` | `ScoutAgent._assess_url_risk(url)` |
| `click` | `ClickerAgent._assess_target_risk(target)` (#2189) |
| **`type`** | **`TyperAgent._assess_input_risk(text, field_type)`** ← this PR |

## The gap

`type_text()` hardcoded `field_type="text"` and passed **no `risk_score`**, so:
- the Typer's own sensitive-field escalation (`password`/`ssn`/`credit_card`/…)
  **never fired** — callers couldn't declare a sensitive field; and
- the Judge defaulted to risk 0.5 and **could never veto a type**.

It also still used the pre-policy `ALLOW`-only check, so it missed the headless
fail-closed behavior.

## The fix

`TyperAgent._assess_input_risk(text, field_type)` takes the **max** of two signals:
- **where** it's typed — credential/financial field → `0.8` (ESCALATE band,
  matching the Typer's own `vote()` semantics: a password is approve-worthy, not
  forbidden);
- **what** is typed — the membrane scanner (`scan_text_for_threats`) scores the
  content; a genuine injection/exfil reaches the `>0.9` veto band.

`type_text(selector, text, field_type="text")` now injects this score into
consensus and uses the shared `_resolve_execution` (fail-closed when unattended).
The **raw text never enters the context or the receipt** — only the score and a
length — preserving the existing "never include actual text" rule.

## Verified

- `tests/test_swarm_type_risk.py` — 6 cases: field-sensitivity floors;
  monkeypatched high-threat content drives risk into the veto band; password
  field escalates (held when attended, **fail-closed when headless**); benign
  text allowed/executes; **raw text never leaks** into result/receipt.
- 19 green with the click/headless (7) + veto (6) regression.
- E2E: password field → Typer **and** Judge both `ESCALATE` → `effective=ESCALATE`
  attended, `effective=DENY` (withheld, receipt) headless; benign text → `ALLOW`,
  executed.
- `black` + `flake8` (120) clean; diff scoped to one source file + the test.

Note: the membrane scanner's own calibration is unchanged here — this PR only
*surfaces* its score into the gate. (E.g. it scored an `"ignore instructions … rm
-rf /"` string at ~0.45; tuning the scanner is a separate concern.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Typing now includes input risk assessment based on field type and content threat analysis.
* Added optional field-type parameter to typing method for enhanced security evaluation.
* Sensitive field operations follow consensus protocols with mode-specific execution controls and risk scoring in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->