### PR TITLE
feat(cli): scbe compare — SCBE vs industry guardrails (honest, real data)

### DIFF
--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -56,6 +56,10 @@ Usage:
   upgrade                 Print upgrade instructions and SCBE_API_KEY setup
   history [--limit N]     Show recent command history from the autocorrect ledger
                           (default: --limit 20)
+  compare [--json]        Compare SCBE governance to industry prompt-injection
+                          guardrails (ProtectAI, Meta Prompt Guard): input-
+                          detection benchmark + action-governance matrix, with
+                          provenance and honest caveats
 Core commands:
   scbe version
   scbe version --json
@@ -1195,6 +1199,149 @@ function runDoctor(args) {
     );
   }
   process.exit(payload.ok ? 0 : 1);
+}
+
+// ─── compare: SCBE vs industry guardrails ────────────────────────────────────
+
+// Embedded so it ships with the bin (package.json `files` has no data/ dir).
+// Two axes: input prompt-injection DETECTION (where trained classifiers are the
+// incumbents) and runtime ACTION governance (SCBE's actual differentiator).
+// Caveats are first-class, not footnotes — the detection corpus is SCBE-authored
+// (home field), so SCBE's own score is not a neutral head-to-head. Numbers are
+// reproducible: see `provenance`.
+const COMPARE_DATA = {
+  schema_version: 'scbe_aethermoore_cli_compare_v1',
+  generated: '2026-06-12',
+  title: 'SCBE governance vs industry prompt-injection guardrails',
+  summary:
+    'Two different jobs. Trained classifiers (ProtectAI, Meta Prompt Guard) screen ' +
+    'INPUT text for prompt injection. The SCBE swarm governs ACTIONS ' +
+    '(navigate/click/type) at runtime. They are complementary, not interchangeable.',
+  detection: {
+    label: 'Input prompt-injection detection',
+    corpus: 'SCBE-authored adversarial corpus — 91 attacks, 15 clean prompts',
+    columns: ['System', 'Mechanism', 'Blocked', 'ASR', 'FP', 'Adoption (HF dl/mo)'],
+    rows: [
+      ['SCBE detection gate', 'regex + geometric heuristic', '91/91', '0.00', '0/15', 'internal (~0)'],
+      ['ProtectAI DeBERTa v2', 'trained DeBERTa classifier', '62/91', '0.319', '0/15', '277,547'],
+      ['Meta Prompt Guard 2 (86M)', 'trained mDeBERTa classifier', 'not run', '—', '—', '115,864'],
+      ['protectai/llm-guard', 'scanner toolkit (15 in / 20 out)', 'n/a (library)', '—', '—', 'widely used'],
+    ],
+  },
+  governance: {
+    label: 'Runtime action governance',
+    columns: ['Capability', 'SCBE swarm', 'Input classifiers'],
+    rows: [
+      ['Scope', 'governs actions (navigate/click/type)', 'screen input text only'],
+      ['Per-action risk score', 'yes (url / target / content)', 'no'],
+      ['Human-in-loop escalation', 'yes (ESCALATE held for operator)', 'no'],
+      ['Headless fail-closed', 'yes (unattended ESCALATE -> DENY)', 'n/a'],
+      ['Multi-agent consensus', '6 agents, 4/6 quorum + Judge veto', 'no'],
+      ['Tamper-evident receipts', 'yes (replicated JSONL ledger)', 'no'],
+      ['Test coverage', '19 swarm tests (this branch)', 'model card / library tests'],
+    ],
+  },
+  caveats: [
+    "Home-field corpus: the 91-attack / 15-clean set was authored by SCBE. SCBE's 91/91 is not a neutral head-to-head, and ProtectAI's 62/91 is on data out-of-distribution for it — so that number understates its real-world accuracy.",
+    "Mechanism, not geometry: SCBE's detection is carried by lexical regex + keyword heuristics. The hyperbolic geometry is not load-bearing for this result.",
+    'Adoption gap: ProtectAI (277,547) and Prompt Guard (115,864) have ~5-6 orders of magnitude more monthly downloads than SCBE. They are battle-tested and widely deployed.',
+    'Thin false-positive test: FP measured on only 15 clean prompts — too few to claim a low real-world false-positive rate.',
+    'Prompt Guard not run: the Meta model is stubbed in this harness; its row is "not run", not a measured score.',
+    "Consensus nuance: the Judge (DR), not the raw count, is the safety backstop. A 4/6 ALLOW majority can outvote 2 ordinary DENY votes, but the Judge's DENY/ESCALATE is binding and cannot be loosened.",
+  ],
+  provenance: {
+    detection_benchmark:
+      'scripts/benchmark/scbe_vs_industry.py — ProtectAI loaded live (deberta-v3-base-prompt-injection-v2); 62 blocked / 0.319 ASR reproduced with SCBE_BENCHMARK_USE_EXTERNAL_MODELS=1. Default mode stubs external models.',
+    action_governance:
+      'agents/swarm_browser.py — verified by tests/test_swarm_judge_veto.py, test_swarm_click_risk_headless.py, test_swarm_type_risk.py (19 passing).',
+    adoption: 'HuggingFace monthly download counts, as of 2026-03.',
+  },
+};
+
+function runCompare(args) {
+  if (args.includes('--json')) {
+    process.stdout.write(`${JSON.stringify(COMPARE_DATA, null, 2)}\n`);
+    process.exit(0);
+  }
+
+  // Self-contained colour gate: honour NO_COLOR and non-TTY pipes. No dependency
+  // on the ansi() helper (which keys on isTTY only).
+  const useColor = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+  const paint = (code, text) => (useColor ? `${code}${text}\x1b[0m` : text);
+  const bold = (t) => paint('\x1b[1m', t);
+  const dim = (t) => paint('\x1b[2m', t);
+  const cyan = (t) => paint('\x1b[36m', t);
+
+  const wrap = (text, width) => {
+    const words = String(text).split(/\s+/);
+    const lines = [];
+    let line = '';
+    for (const word of words) {
+      if (line && line.length + 1 + word.length > width) {
+        lines.push(line);
+        line = word;
+      } else {
+        line = line ? `${line} ${word}` : word;
+      }
+    }
+    if (line) lines.push(line);
+    return lines.length ? lines : [''];
+  };
+
+  const out = [];
+  const table = (columns, rows) => {
+    const widths = columns.map((c, i) =>
+      Math.max(c.length, ...rows.map((r) => String(r[i]).length))
+    );
+    const fmt = (cells, decorate) =>
+      cells
+        .map((cell, i) => {
+          const padded = String(cell).padEnd(widths[i]);
+          return decorate ? decorate(padded) : padded;
+        })
+        .join('  ');
+    const rule = '─'.repeat(widths.reduce((a, b) => a + b + 2, -2));
+    out.push(`  ${fmt(columns, bold)}`);
+    out.push(`  ${dim(rule)}`);
+    for (const row of rows) out.push(`  ${fmt(row)}`);
+  };
+
+  out.push('');
+  out.push(`  ${bold(COMPARE_DATA.title)}`);
+  out.push(`  ${dim(COMPARE_DATA.generated)}`);
+  out.push('');
+  for (const l of wrap(COMPARE_DATA.summary, 78)) out.push(`  ${l}`);
+  out.push('');
+
+  out.push(`  ${cyan(COMPARE_DATA.detection.label)}`);
+  out.push(`  ${dim(COMPARE_DATA.detection.corpus)}`);
+  out.push('');
+  table(COMPARE_DATA.detection.columns, COMPARE_DATA.detection.rows);
+  out.push('');
+
+  out.push(`  ${cyan(COMPARE_DATA.governance.label)}`);
+  out.push('');
+  table(COMPARE_DATA.governance.columns, COMPARE_DATA.governance.rows);
+  out.push('');
+
+  out.push(`  ${cyan('Caveats')}`);
+  COMPARE_DATA.caveats.forEach((cav, i) => {
+    const lines = wrap(`${i + 1}. ${cav}`, 76);
+    out.push(`  ${lines[0]}`);
+    for (const l of lines.slice(1)) out.push(`     ${l}`);
+  });
+  out.push('');
+
+  out.push(`  ${cyan('Provenance')}`);
+  for (const [key, value] of Object.entries(COMPARE_DATA.provenance)) {
+    const lines = wrap(`${key}: ${value}`, 76);
+    out.push(`  ${dim(lines[0])}`);
+    for (const l of lines.slice(1)) out.push(`     ${dim(l)}`);
+  }
+  out.push('');
+
+  process.stdout.write(`${out.join('\n')}\n`);
+  process.exit(0);
 }
 
 // ─── ANSI colour helpers ─────────────────────────────────────────────────────
@@ -5197,6 +5344,7 @@ const KNOWN_COMMANDS = [
   'magic',
   'selftest',
   'doctor',
+  'compare',
   'credits',
   'hosted-run',
   'upgrade',
@@ -6038,6 +6186,10 @@ if (argv[0] === 'bundle') {
 
 if (argv[0] === 'youtube') {
   runYoutube(argv.slice(1));
+}
+
+if (argv[0] === 'compare') {
+  runCompare(argv.slice(1));
 }
 
 if (argv[0] === 'history') {

--- a/packages/cli/tests/compare.test.cjs
+++ b/packages/cli/tests/compare.test.cjs
@@ -1,0 +1,85 @@
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const CLI = path.resolve(__dirname, '..', 'bin', 'scbe.js');
+
+function runCli(args, options = {}) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'scbe-cli-compare-'));
+  const env = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    NO_COLOR: '1',
+  };
+  if (options.color) delete env.NO_COLOR;
+  return spawnSync(process.execPath, [CLI, ...args], {
+    input: options.input || '',
+    encoding: 'utf8',
+    timeout: options.timeout || 30_000,
+    env,
+  });
+}
+
+test('compare --json emits the structured comparison and exits 0', () => {
+  const result = runCli(['compare', '--json']);
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.schema_version, 'scbe_aethermoore_cli_compare_v1');
+  assert.ok(payload.detection.rows.length >= 4);
+  assert.ok(payload.governance.rows.length >= 6);
+  assert.ok(payload.caveats.length >= 6, 'caveats are first-class, not footnotes');
+  assert.ok(payload.provenance.detection_benchmark);
+  assert.ok(payload.provenance.action_governance);
+});
+
+test('compare --json locks the honest numbers (no overclaim)', () => {
+  const payload = JSON.parse(runCli(['compare', '--json']).stdout);
+  const byName = (rows, name) => rows.find((r) => r[0] === name);
+
+  const protectai = byName(payload.detection.rows, 'ProtectAI DeBERTa v2');
+  assert.equal(protectai[2], '62/91', 'ProtectAI blocked count is the reproduced number');
+  assert.equal(protectai[3], '0.319', 'ProtectAI ASR is the reproduced number');
+
+  // Prompt Guard was stubbed in the harness — it must NOT carry a fabricated score.
+  const promptGuard = byName(payload.detection.rows, 'Meta Prompt Guard 2 (86M)');
+  assert.equal(promptGuard[2], 'not run');
+
+  // The home-field-bias and not-load-bearing-geometry caveats must be present.
+  const joined = payload.caveats.join(' ').toLowerCase();
+  assert.match(joined, /home-field/);
+  assert.match(joined, /not load-bearing/);
+  assert.match(joined, /adoption gap/);
+});
+
+test('compare (human) renders both axes and the caveats', () => {
+  const result = runCli(['compare']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Input prompt-injection detection/);
+  assert.match(result.stdout, /Runtime action governance/);
+  assert.match(result.stdout, /ProtectAI DeBERTa v2/);
+  assert.match(result.stdout, /277,547/);
+  assert.match(result.stdout, /not run/);
+  assert.match(result.stdout, /Caveats/);
+  assert.match(result.stdout, /Provenance/);
+});
+
+test('compare honours NO_COLOR (no ANSI escapes in either surface)', () => {
+  const human = runCli(['compare']);
+  assert.equal(human.status, 0, human.stderr);
+  assert.ok(!human.stdout.includes('\x1b'), 'human output has no ANSI under NO_COLOR');
+
+  const json = runCli(['compare', '--json']);
+  assert.ok(!json.stdout.includes('\x1b'), '--json output is pure JSON, no ANSI');
+});
+
+test('compare is a known command (no typo-suggestion, no NL fallthrough)', () => {
+  const result = runCli(['compare']);
+  // A near-miss like "comapre" would print a suggestion to stderr and exit 2;
+  // the real command must not.
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /is not a scbe command/);
+});


### PR DESCRIPTION
## What

A new `scbe compare` command that renders an **honest, two-axis comparison** of SCBE governance against industry prompt-injection guardrails (ProtectAI, Meta Prompt Guard, llm-guard) directly in the CLI — with **provenance and caveats as first-class output**, not footnotes.

This was built to *resist* overclaiming. An adversarial verification workflow ran first; this command ships only what survived it.

## Two axes (because they're two different jobs)

**Axis 1 — input prompt-injection detection** (on SCBE's own 91-attack / 15-clean corpus):
| System | Blocked | ASR | Adoption |
|---|---|---|---|
| SCBE detection gate | 91/91 | 0.00 | internal (~0) |
| ProtectAI deberta-v3-base-prompt-injection-v2 | 62/91 | 0.319 | 277,547 dl/mo |
| Meta Llama-Prompt-Guard-2-86M | **not run** (stubbed) | — | 115,864 dl/mo |

ProtectAI's 62/91 was **loaded live and reproduced** (`SCBE_BENCHMARK_USE_EXTERNAL_MODELS=1`). Prompt Guard is stubbed in the harness, so its row says *not run* — no fabricated score.

**Axis 2 — runtime action governance** (SCBE's genuine differentiator): per-action risk scoring, human-in-loop escalation, headless fail-closed, 6-agent consensus + **binding Judge veto**, tamper-evident receipts. Verified by 19 swarm tests on `main` (`test_swarm_judge_veto` / `click_risk_headless` / `type_risk`). Input classifiers do not govern actions at all.

## Honesty (caveats render in the output)

1. **Home-field corpus** — the 91/15 set is SCBE-authored; 91/91 is not a neutral head-to-head, and ProtectAI's 62/91 is OOD for it (understates its real accuracy).
2. **Mechanism, not geometry** — SCBE's detection is carried by lexical regex; the hyperbolic geometry is not load-bearing here.
3. **Adoption gap** — ~5-6 orders of magnitude fewer downloads than the incumbents.
4. **Thin FP test** — false-positives measured on only 15 clean prompts.
5. **Prompt Guard not run** — stubbed, not benchmarked.
6. **Consensus nuance** — the Judge (not the raw count) is the backstop: a 4/6 ALLOW majority can outvote 2 ordinary DENY votes, but the Judge's DENY/ESCALATE is binding.

## Implementation

- `runCompare()` + embedded `COMPARE_DATA` in `packages/cli/bin/scbe.js` (data embedded because the package `files` array has no `data/` dir).
- Self-contained colour gate: honours `NO_COLOR` and non-TTY pipes (no dependency on the `ansi()` helper).
- `--json` emits the full structured payload (schema `scbe_aethermoore_cli_compare_v1`).
- Registered in `KNOWN_COMMANDS`, dispatch block, and `--help`.

## Tests

`packages/cli/tests/compare.test.cjs` — 5 tests: JSON schema, **honest-number locks** (ProtectAI 62/91 + 0.319; Prompt Guard `not run`; home-field/geometry/adoption caveats present), both axes render, NO_COLOR-clean on both surfaces, known-command (no typo/NL fallthrough).

CLI suite: 56/57 green. The lone failure (`shell --tui`) is a pre-existing worktree env gap (`react` not installed there), unrelated to this change. `bin/scbe.js` stays LF; matches the file's hand-maintained single-quote style (this `.js` bin is outside the repo's `.ts`-only prettier glob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new `compare` command to the CLI for guardrail comparison analysis, supporting both JSON output (via `--json` flag) and human-readable formatted terminal reports with color awareness.

* **Tests**
  * Added comprehensive test suite validating command functionality, output formats, and data integrity across different execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->