### PR TITLE
fix(crypto): close two silent-allow holes in the GeoSeal exec gate

### DIFF
--- a/src/crypto/geoseal_execution_gate.py
+++ b/src/crypto/geoseal_execution_gate.py
@@ -153,8 +153,22 @@ def scan_command(command: str, *, claimed_paths: Optional[Sequence[str]] = None)
         )
 
     deny_patterns: list[tuple[str, str, str]] = [
-        (r"\brm\s+-rf\b", "destructive-rm", "recursive force delete"),
-        (r"\bremove-item\b.*\b-recurse\b", "destructive-remove-item", "recursive PowerShell delete"),
+        # destructive-rm must catch recursive+force in ANY flag form/order, not just the
+        # literal "-rf". The old `\brm\s+-rf\b` ALLOWED `rm -fr`, `rm -r -f`, and
+        # `rm --recursive --force` (a real bypass — confirmed via scan_command). Require
+        # an `rm` token plus a recursive flag AND a force flag anywhere after it: bundled
+        # (-rf/-fr/-vrf), split (-r -f), or long (--recursive/--force). The `\s-` (not \b)
+        # before each flag avoids the same boundary trap that disabled -recurse below.
+        # Plain `rm`, `rm -f`, and `rm -r` stay ALLOWED (each lookahead needs the other).
+        (
+            r"\brm\b(?=.*(?:\s-[a-z]*r[a-z]*\b|\s--recursive\b))(?=.*(?:\s-[a-z]*f[a-z]*\b|\s--force\b))",
+            "destructive-rm",
+            "recursive force delete",
+        ),
+        # The leading boundary before "-recurse" must NOT be \b — \b never matches
+        # between a space and a hyphen, so `\b-recurse` silently disabled this rule and
+        # `Remove-Item -Recurse -Force` (and the `rm`/`ri` aliases) were ALLOWED.
+        (r"\b(?:remove-item|ri|rm)\b.*(?:\s|^)-recurse\b", "destructive-remove-item", "recursive PowerShell delete"),
         (r"\binvoke-expression\b|\biex\b", "powershell-iex", "dynamic PowerShell execution"),
         (r"\bcurl\b.*\|\s*(sh|bash|powershell|pwsh|iex)\b", "curl-pipe-exec", "download-to-exec chain"),
         (r"\bwget\b.*\|\s*(sh|bash|powershell|pwsh|iex)\b", "wget-pipe-exec", "download-to-exec chain"),

--- a/tests/crypto/test_geoseal_execution_gate.py
+++ b/tests/crypto/test_geoseal_execution_gate.py
@@ -19,6 +19,61 @@ def test_scan_blocks_shell_chaining_before_execution() -> None:
     assert any(finding.rule == "shell-metachar" for finding in decision.findings)
 
 
+def test_recursive_force_rm_is_denied_in_any_flag_form() -> None:
+    # Security regression: the destructive-rm rule used the literal `\brm\s+-rf\b`,
+    # which ONLY matched `rm -rf` and silently ALLOWED every other spelling of the same
+    # recursive-force delete: `rm -fr`, `rm -r -f`, `rm --recursive --force`, flag
+    # bundles, and capital -R. Lock that the rule now requires a recursive flag AND a
+    # force flag in any order/form.
+    for cmd in (
+        "rm -rf /tmp/x",
+        "rm -fr /tmp/x",
+        "rm -r -f /tmp/x",
+        "rm -f -r /tmp/x",
+        "rm --recursive --force /tmp/x",
+        "rm --force --recursive /tmp/x",
+        "rm -rfv /tmp/x",
+        "rm -vrf /tmp/x",
+        "rm -R -f /tmp/x",
+        "rm --recursive -f /tmp/x",
+        "rm -r --force /tmp/x",
+    ):
+        decision = scan_command(cmd)
+        assert decision.tier == "DENY", cmd
+        assert not decision.allowed, cmd
+        assert any(f.rule == "destructive-rm" for f in decision.findings), cmd
+
+
+def test_non_recursive_rm_is_not_flagged_as_destructive() -> None:
+    # The broadened rule must not over-block: plain delete, force-only, and
+    # recursive-only each lack the other required flag and must NOT be flagged.
+    for cmd in (
+        "rm /tmp/x",
+        "rm -f /tmp/x",
+        "rm -r /tmp/x",
+        "rm -i /tmp/x",
+        "ls -rf",
+    ):
+        decision = scan_command(cmd)
+        assert not any(f.rule == "destructive-rm" for f in decision.findings), cmd
+
+
+def test_recursive_powershell_delete_is_denied() -> None:
+    # Security regression: the deny rule used `\b-recurse`, but \b never matches
+    # between a space and a hyphen, so the rule was dead and `Remove-Item -Recurse
+    # -Force` (plus the `rm`/`ri` aliases) were silently ALLOWED. Lock the fix.
+    for cmd in (
+        "Remove-Item -Recurse -Force C:\\Users",
+        "remove-item -recurse -force C:/Users",
+        "rm -Recurse -Force ./build",
+        "ri -Recurse ./dist",
+    ):
+        decision = scan_command(cmd)
+        assert decision.tier == "DENY", cmd
+        assert not decision.allowed, cmd
+        assert any(f.rule == "destructive-remove-item" for f in decision.findings), cmd
+
+
 def test_inline_interpreter_is_quarantine_not_deny() -> None:
     decision = scan_command(f"{sys.executable} -c \"print('ok')\"")
 


### PR DESCRIPTION
## Problem

The GeoSeal execution gate's dangerous-pattern scan (`src/crypto/geoseal_execution_gate.py`) had **two deny rules that silently ALLOWED the exact destructive commands they were meant to block**. Both were confirmed live via `scan_command()` on `origin/main`.

### 1. `destructive-rm` only caught the literal `rm -rf`

The rule `\brm\s+-rf\b` matched **only** `rm -rf`. Every other spelling of the same recursive-force delete returned `tier=ALLOW`:

| Command | Before | After |
|---|---|---|
| `rm -rf /tmp/x` | DENY | DENY |
| `rm -fr /tmp/x` | **ALLOW** | DENY |
| `rm -r -f /tmp/x` | **ALLOW** | DENY |
| `rm --recursive --force /tmp/x` | **ALLOW** | DENY |
| `rm -rfv` / `rm -vrf` (bundles) | **ALLOW** | DENY |
| `rm -R -f` (capital R) | **ALLOW** | DENY |

### 2. `destructive-remove-item` was completely dead

The rule `\bremove-item\b.*\b-recurse\b` never fired: `\b` does not match between a space and a hyphen, so `\b-recurse` matched nothing. `Remove-Item -Recurse -Force` (and the `rm`/`ri` aliases) was silently ALLOWED — a total bypass of recursive PowerShell-delete blocking.

## Fix

Both rules are now structural over flag form/order, not a single literal:

- **rm**: requires an `rm` token **plus** a recursive flag (`-r`, `-R`, bundled, or `--recursive`) **and** a force flag (`-f`, bundled, or `--force`), in any order. `\s-` (not `\b`) before each flag avoids the same boundary trap.
- **remove-item**: `(?:\s|^)` instead of `\b` before `-recurse`, and the rule now covers the `rm`/`ri` aliases.

Plain `rm`, `rm -f`, and `rm -r` stay **ALLOWED** — each rm lookahead requires the other, so single-flag deletes are not over-blocked.

## Tests

Adds three regression tests (`tests/crypto/test_geoseal_execution_gate.py`):
- 11 recursive-force spellings → all DENY with the `destructive-rm` finding
- 5 benign forms (`rm`, `rm -f`, `rm -r`, `rm -i`, `ls -rf`) → no false positive
- recursive PowerShell-delete aliases (`Remove-Item`/`rm`/`ri` `-Recurse -Force`) → DENY

`pytest tests/crypto/test_geoseal_execution_gate.py` → **13 passed**. black + flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of dangerous recursive deletion commands to prevent accidental data loss. Enhanced pattern matching for command variations and flag combinations across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->