### PR TITLE
fix(chem): make the audio reaction-state recalc checks real, not hard-coded True

### DIFF
--- a/scripts/reaction_cli.py
+++ b/scripts/reaction_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import sys
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from python.scbe.audio_field_observables import (
     AudioFieldModel,
+    AudioFieldObservables,
     analyze_audio_field,
     generate_decaying_sine,
     generate_sine,
@@ -28,6 +30,7 @@ from python.scbe.controlled_substances import ControlledSubstanceDenied, screen_
 from python.scbe.geometry_view import GeometryEngineError, geometry_view_packet
 from python.scbe.reaction_balance import BalanceError, balance_reaction_packet
 from python.scbe.reaction_language import ReactionPlan, plan_from_text
+from python.scbe import units as _U
 from python.scbe.reaction_state import (
     ReactionEndpoint,
     ReactionLedger,
@@ -35,6 +38,7 @@ from python.scbe.reaction_state import (
     build_reaction_state_packet,
     packet_from_dict,
     rekor_hashedrekord_entry,
+    unit_check,
 )
 
 # Every packet this CLI emits is signed under one stable identity so receipts
@@ -200,6 +204,63 @@ def build_code_packet(source_path: str, target_path: str) -> dict[str, Any]:
     }
 
 
+def _audio_unit_checks_ok(model: AudioFieldModel) -> bool | None:
+    """Honest source for ``unit_checks_ok`` on an audio-field packet.
+
+    Most acoustic observables are dimensionless ratios or read-off frequencies, so
+    there is no dimensional-arithmetic chain to verify and the honest value is
+    ``None`` ("no unit-bearing computation"). The one exception is the magnetosonic
+    coupling, which combines two velocities exactly as ``_compute_field_coupling``
+    does: ``magnetosonic_speed = sqrt(v_sound**2 + v_alfven**2)`` then
+    ``magnetic_share = v_alfven / magnetosonic_speed``. We re-express that in
+    ``Quantity`` arithmetic so the check can actually FAIL: ``add`` is the Mars
+    Climate Orbiter catch (it raises if the two speeds carry the same dimension but
+    a different unit), and the share must come out dimensionless. A ``True`` here
+    means a real dimensional relation held, not that a flag was set.
+    """
+    if model.kind != "magnetosonic" or model.sound_speed_mps is None or model.alfven_speed_mps is None:
+        return None
+
+    mps = _U.METER / _U.SECOND
+
+    def _consistent() -> object:
+        v_s = _U.q(abs(model.sound_speed_mps), mps)
+        v_a = _U.q(abs(model.alfven_speed_mps), mps)
+        # v_sound**2 + v_alfven**2 — add() raises on a same-dimension/different-unit mix.
+        v_sq_sum = _U.add(_U.mul(v_s, v_s), _U.mul(v_a, v_a))
+        _U.assert_dim(v_sq_sum, _U.dim(m=2, s=-2))  # velocity squared
+        # magnetic_share**2 = v_alfven**2 / (v_sound**2 + v_alfven**2) must be dimensionless.
+        return _U.assert_dim(_U.div(_U.mul(v_a, v_a), v_sq_sum), _U.DIMENSIONLESS)
+
+    return unit_check(_consistent)[0]
+
+
+def _audio_scientific_checks_ok(observables: AudioFieldObservables) -> bool:
+    """Honest source for ``scientific_checks_ok``: every emitted observable must be
+    finite and within its declared range. Replaces a hard-coded ``True`` so the flag
+    can fail on a degenerate spectrum (non-finite energy/centroid, an out-of-range
+    ratio, or a coupling proxy that escaped [0, 1])."""
+    finite_fields = (
+        observables.energy_log,
+        observables.spectral_centroid_hz,
+        observables.spectral_bandwidth_hz,
+        observables.high_frequency_ratio,
+        observables.stability,
+        observables.dispersion_proxy,
+    )
+    if not all(math.isfinite(value) for value in finite_fields):
+        return False
+    if observables.spectral_centroid_hz < 0.0 or observables.spectral_bandwidth_hz < 0.0:
+        return False
+    if not (0.0 <= observables.high_frequency_ratio <= 1.0):
+        return False
+    if not (0.0 <= observables.stability <= 1.0):
+        return False
+    if observables.field_coupling_proxy is not None and not (0.0 <= observables.field_coupling_proxy <= 1.0):
+        return False
+    return True
+
+
 def build_audio_packet(
     *,
     frequency_hz: float,
@@ -268,8 +329,8 @@ def build_audio_packet(
             [] if observables.field_coupling_proxy is not None else ["no declared field coupling proxy emitted"]
         ),
         recalculation=ReactionRecalculation(
-            scientific_checks_ok=True,
-            unit_checks_ok=True,
+            scientific_checks_ok=_audio_scientific_checks_ok(observables),
+            unit_checks_ok=_audio_unit_checks_ok(model),
             identity_ok=observables.modal_count_state.ok,
             extra={"observables": observables.to_dict()},
         ),

--- a/tests/test_reaction_language.py
+++ b/tests/test_reaction_language.py
@@ -182,3 +182,78 @@ def test_build_ask_checkpoint_missing_file_does_not_crash():
     assert payload["verb"] == "checkpoint" and payload["executed"] is True
     assert payload["ok"] is False
     assert "file not found" in payload["result"]["error"]
+
+
+# --- audio-packet recalculation honesty (unit/scientific checks must be REAL) --- #
+
+
+def _audio_recalc(model_kind, sound=None, alfven=None):
+    from scripts.reaction_cli import build_audio_packet
+
+    packet = build_audio_packet(
+        frequency_hz=440.0,
+        sample_rate_hz=8000.0,
+        duration_s=0.02,
+        decay_seconds=None,
+        model_kind=model_kind,
+        coupling_gain=1.0,
+        sound_speed_mps=sound,
+        alfven_speed_mps=alfven,
+    )
+    return packet["reaction_state_packet"]["recalculation"]
+
+
+def test_audio_unit_check_is_real_for_magnetosonic_model():
+    # A magnetosonic packet runs a genuine dimensional check on the velocity
+    # combination sqrt(v_s^2 + v_a^2); unit_checks_ok=True means it HELD, not that
+    # a flag was set. scientific_checks_ok=True means every observable was finite
+    # and in range.
+    recalc = _audio_recalc("magnetosonic", sound=340.0, alfven=1200.0)
+    assert recalc["unit_checks_ok"] is True
+    assert recalc["scientific_checks_ok"] is True
+
+
+def test_audio_unit_check_is_none_when_no_dimensional_chain_exists():
+    # Generic and magnetoelastic projections do only dimensionless arithmetic, and a
+    # magnetosonic model missing its wave speeds has nothing to combine. The honest
+    # value is None ("not computed") -- never a fabricated True.
+    assert _audio_recalc("generic")["unit_checks_ok"] is None
+    assert _audio_recalc("magnetoelastic", sound=340.0, alfven=1200.0)["unit_checks_ok"] is None
+    assert _audio_recalc("magnetosonic", sound=340.0, alfven=None)["unit_checks_ok"] is None
+
+
+def test_audio_unit_check_has_teeth_against_a_mixed_unit_velocity_combination():
+    # Soundness: the magnetosonic dimensional check would FAIL if the two speeds
+    # carried the same dimension but a different unit (the Mars Climate Orbiter
+    # class). Re-run the same add() shape with a km/h speed and assert it is caught.
+    from fractions import Fraction
+
+    from python.scbe import units as _U
+    from python.scbe.reaction_state import unit_check
+
+    kmph = _U.Unit("km/h", _U.VELOCITY, Fraction(1000, 3600))
+
+    def mixed():
+        v_s = _U.q(340.0, _U.METER / _U.SECOND)
+        v_a = _U.q(4320.0, kmph)  # same dimension (velocity), different unit
+        return _U.add(_U.mul(v_s, v_s), _U.mul(v_a, v_a))
+
+    ok, problems = unit_check(mixed)
+    assert ok is False
+    assert problems and "Mars Climate Orbiter" in problems[0]
+
+
+def test_audio_scientific_check_rejects_a_non_finite_observable():
+    # Soundness: scientific_checks_ok must drop to False on a degenerate spectrum.
+    from scripts.reaction_cli import _audio_scientific_checks_ok
+
+    class _Obs:
+        energy_log = float("nan")
+        spectral_centroid_hz = 1.0
+        spectral_bandwidth_hz = 1.0
+        high_frequency_ratio = 0.5
+        stability = 0.5
+        dispersion_proxy = 0.1
+        field_coupling_proxy = None
+
+    assert _audio_scientific_checks_ok(_Obs()) is False


### PR DESCRIPTION
## Problem

`build_audio_packet` (`scripts/reaction_cli.py`) emits a **signed** reaction-state receipt, but its `ReactionRecalculation` hard-set:

```python
scientific_checks_ok=True,
unit_checks_ok=True,
```

The dimensional engine in `python/scbe/units.py` was invoked **zero times**. The receipt asserted that two checks had passed when neither had run — the unsound-verifier failure mode (a flag that *cannot fail* certifies nothing). `unit_checks_ok` already supports `None` ("not computed") in the dataclass, so the fake `True` was strictly worse than honest.

## Fix

**`unit_checks_ok` → `_audio_unit_checks_ok(model)`**
- Most acoustic observables are dimensionless ratios or read-off frequencies — no dimensional-arithmetic chain to verify → honest `None`.
- The **magnetosonic** coupling is the one genuine case. `_compute_field_coupling` computes `magnetosonic_speed = sqrt(v_sound² + v_alfven²)` then `magnetic_share = v_alfven / magnetosonic_speed`. That exact computation is re-expressed in `Quantity` arithmetic so the check **can fail**: `add()` is the Mars Climate Orbiter catch (raises on a same-dimension/different-unit mix), and `magnetic_share²` must come out dimensionless. `True` now means a dimensional relation actually held.

**`scientific_checks_ok` → `_audio_scientific_checks_ok(observables)`**
- Every emitted observable must be finite and within its declared range, so the flag drops to `False` on a degenerate spectrum instead of always asserting `True`.

## Tests (`tests/test_reaction_language.py`, the existing reaction_cli test home)

- magnetosonic model → `unit_checks_ok is True` (real check held), `scientific_checks_ok is True`
- generic / magnetoelastic / magnetosonic-missing-speeds → `unit_checks_ok is None` (honest "not computed")
- **teeth**: a km/h-vs-m/s velocity combination in the same `add()` shape is rejected (`Mars Climate Orbiter` in the problem text)
- **teeth**: a non-finite observable drives `scientific_checks_ok` to `False`

`pytest tests/test_reaction_language.py tests/test_audio_field_observables.py tests/test_units.py tests/test_units_pathology.py` → **66 passed**. black + flake8 clean.

Follows the established pattern at `scripts/benchmark/compound_decomposition_recomposition.py:620` (real `unit_check(...)` thunk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)