### PR TITLE
fix(cli): reap leaked desktop bridge + repair bench/worksheet tests

### DIFF
--- a/packages/cli/scripts/desktop_subsystem.cjs
+++ b/packages/cli/scripts/desktop_subsystem.cjs
@@ -376,7 +376,9 @@ async function launchBrowserRuntime(chromium) {
       );
     }
   }
-  throw new Error(attempts.join(' | ') || (lastError ? lastError.message : 'browser launch failed'));
+  throw new Error(
+    attempts.join(' | ') || (lastError ? lastError.message : 'browser launch failed')
+  );
 }
 
 function psSingle(value) {
@@ -475,6 +477,30 @@ function startActionBridgeProcess(port, logPath, desktopUrl = '') {
   });
   child.unref();
   return { pid: child.pid, err_path: logPath };
+}
+
+// Reap a spawned bridge AND its descendants. On Windows the bridge is launched
+// through a `Start-Process cmd.exe` wrapper (for output redirection), so the
+// recorded pid is the cmd.exe wrapper, not the node bridge grandchild — killing
+// just that pid orphans the node server (it keeps answering and holds its log
+// file open). `taskkill /T` kills the whole tree. On POSIX the bridge is a
+// detached process-group leader, so a negative-pid signal kills the group.
+function stopProcessTree(pid) {
+  if (!pid) return;
+  if (process.platform === 'win32') {
+    spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
+    return;
+  }
+  try {
+    process.kill(-pid, 'SIGTERM');
+  } catch {
+    /* group may already be gone */
+  }
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    /* process may already be gone */
+  }
 }
 
 function sendJson(res, status, payload) {
@@ -901,6 +927,18 @@ async function runBridge(args) {
   server.listen(port, '127.0.0.1', () => {
     process.stdout.write(`SCBE action bridge listening on http://127.0.0.1:${port}\n`);
   });
+  // Close the listener on a termination signal so the process exits promptly
+  // instead of lingering on an open socket (POSIX group-kill / Ctrl-C path).
+  const shutdown = () => {
+    try {
+      server.close();
+    } catch {
+      /* already closing */
+    }
+    process.exit(0);
+  };
+  process.once('SIGTERM', shutdown);
+  process.once('SIGINT', shutdown);
 }
 
 async function runOpen(args) {
@@ -1018,11 +1056,7 @@ async function runBridgeSmoke(args) {
   } catch (err) {
     payload.error = err && err.message ? err.message : String(err);
   } finally {
-    if (bridge.pid) {
-      try {
-        process.kill(bridge.pid, 'SIGTERM');
-      } catch {}
-    }
+    stopProcessTree(bridge.pid);
   }
   if (asJson) {
     process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
@@ -1039,7 +1073,9 @@ async function runBridgeSmoke(args) {
       ].join('\n')
     );
   } else {
-    process.stdout.write(`SCBE bridge smoke failed: ${payload.error || 'surface returned failure'}\n`);
+    process.stdout.write(
+      `SCBE bridge smoke failed: ${payload.error || 'surface returned failure'}\n`
+    );
   }
   process.exit(payload.success ? 0 : 1);
 }
@@ -1094,7 +1130,9 @@ async function runCapture(args) {
       ].join('\n')
     );
   } else {
-    process.stdout.write(`SCBE screen capture failed: ${result.payload?.error || 'unknown error'}\n`);
+    process.stdout.write(
+      `SCBE screen capture failed: ${result.payload?.error || 'unknown error'}\n`
+    );
   }
   process.exit(result.status === 200 && result.payload?.success ? 0 : 1);
 }

--- a/packages/cli/tests/actions.test.cjs
+++ b/packages/cli/tests/actions.test.cjs
@@ -42,6 +42,21 @@ function freePort() {
   });
 }
 
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Resolves true if the URL answers an HTTP response, false on connection
+// error/timeout. Used to confirm a bridge server is actually DOWN after teardown.
+function isReachable(url) {
+  return new Promise((resolve) => {
+    const req = http.get(url, (res) => {
+      res.resume();
+      resolve(true);
+    });
+    req.on('error', () => resolve(false));
+    req.setTimeout(1500, () => req.destroy(new Error('unreachable')));
+  });
+}
+
 function getJson(url) {
   return new Promise((resolve, reject) => {
     const req = http.get(url, (res) => {
@@ -175,7 +190,7 @@ test('action can run a governed receipt smoke', () => {
   assert.match(payload.stdout_preview, /node --version/);
 });
 
-test('action can run the integrated desktop bridge smoke', () => {
+test('action can run the integrated desktop bridge smoke', async () => {
   const result = runCli(['action', 'desktop.bridge-smoke', '--json'], { timeout: 90_000 });
 
   assert.equal(result.status, 0, result.stderr);
@@ -189,6 +204,23 @@ test('action can run the integrated desktop bridge smoke', () => {
   assert.equal(payload.stdout_json.terminal.success, true);
   assert.equal(payload.stdout_json.browser.success, true);
   assert.match(payload.stdout_json.browser.title, /Example Domain/i);
+
+  // Regression (leaked-bridge bug): the smoke must reap the bridge it spawned.
+  // On Windows the teardown previously killed the cmd.exe wrapper pid, orphaning
+  // the node bridge — it kept answering /health and held its log file open,
+  // accumulating zombie servers across runs. After the fix the server must be
+  // DOWN once the smoke returns.
+  const healthUrl = `${payload.stdout_json.bridge_url}/health`;
+  let stillUp = true;
+  for (let i = 0; i < 10 && stillUp; i += 1) {
+    stillUp = await isReachable(healthUrl);
+    if (stillUp) await delay(300);
+  }
+  assert.equal(
+    stillUp,
+    false,
+    `bridge at ${healthUrl} should be down after smoke (no orphaned process)`
+  );
 });
 
 test('desktop action bridge exposes actions and runs one action over HTTP', async () => {

--- a/packages/cli/tests/bench.test.cjs
+++ b/packages/cli/tests/bench.test.cjs
@@ -7,6 +7,24 @@ const test = require('node:test');
 
 const CLI = path.resolve(__dirname, '..', 'bin', 'scbe.js');
 
+// Single source of truth for the registered evidence lanes. Update this set when
+// a lane is intentionally added/removed; the count + presence assertions below
+// then fail LOUDLY (naming the missing/extra lane) instead of silently drifting.
+const EXPECTED_LANES = [
+  'hard-agentic',
+  'research',
+  'rubix-browser',
+  'arc-agi2',
+  'arc-style-grid',
+  'swe-local',
+  'cli-competitive',
+  'kaggle-api',
+  'compound-decompose',
+  'hydra-jobsite',
+  'providers',
+  'longform',
+];
+
 function runCli(args, options = {}) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'scbe-cli-bench-'));
   const env = {
@@ -44,18 +62,27 @@ test('bench list emits registered evidence lanes as JSON', () => {
   assert.ok(payload.lanes.some((lane) => lane.id === 'cli-competitive'));
 });
 
-test('bench list has 10 lanes', () => {
+test('bench list registers exactly the expected lane set', () => {
   const result = runCli(['bench', 'list', '--json']);
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
-  assert.equal(payload.lanes.length, 10);
-  assert.ok(payload.lanes.some((lane) => lane.id === 'providers'));
-  assert.ok(payload.lanes.some((lane) => lane.id === 'compound-decompose'));
+  const ids = payload.lanes.map((lane) => lane.id);
+  // Every expected lane is present (names the gap on failure)...
+  for (const id of EXPECTED_LANES) {
+    assert.ok(ids.includes(id), `missing registered lane: ${id}`);
+  }
+  // ...and no unexpected lane crept in (names the extra on failure).
+  for (const id of ids) {
+    assert.ok(EXPECTED_LANES.includes(id), `unexpected lane registered: ${id}`);
+  }
+  assert.equal(payload.lanes.length, EXPECTED_LANES.length);
 });
 
 test('bench compound-decompose forwards JSON flag', () => {
   const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scbe-compound-json-'));
-  const result = runCli(['bench', 'compound-decompose', '--out-dir', outDir, '--json'], { timeout: 90_000 });
+  const result = runCli(['bench', 'compound-decompose', '--out-dir', outDir, '--json'], {
+    timeout: 90_000,
+  });
 
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
@@ -85,7 +112,7 @@ test('bench latest with no args returns all lanes', () => {
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.schema_version, 'scbe_bench_latest_v1');
-  assert.equal(payload.lanes.length, 10);
+  assert.equal(payload.lanes.length, EXPECTED_LANES.length);
 });
 
 test('bench prove emits claim-safe proof packet with overclaim check', () => {
@@ -101,11 +128,11 @@ test('bench prove emits claim-safe proof packet with overclaim check', () => {
   assert.equal(payload.lanes[0].id, 'rubix-browser');
 });
 
-test('bench prove all-lanes proof packet has 10 lanes', () => {
+test('bench prove all-lanes proof packet covers every lane', () => {
   const result = runCli(['bench', 'prove', '--json']);
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
-  assert.equal(payload.lanes.length, 10);
+  assert.equal(payload.lanes.length, EXPECTED_LANES.length);
 });
 
 test('bench prove can write a portable proof packet', () => {
@@ -126,7 +153,7 @@ test('bench index emits public artifact catalog with commit hash', () => {
   assert.equal(payload.schema_version, 'scbe_bench_index_v1');
   assert.ok(typeof payload.commit === 'string');
   assert.ok(typeof payload.evidence_ready === 'number');
-  assert.equal(payload.evidence_total, 10);
+  assert.equal(payload.evidence_total, EXPECTED_LANES.length);
   assert.match(payload.proof_rule, /claim/);
   assert.ok(payload.lanes.every((l) => typeof l.claim_boundary === 'string'));
 });
@@ -153,10 +180,12 @@ test('bench dashboard emits website-ready JSON summary', () => {
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.schema_version, 'scbe_bench_dashboard_v1');
-  assert.equal(payload.evidence_total, 10);
+  assert.equal(payload.evidence_total, EXPECTED_LANES.length);
   assert.ok(payload.summary.website_claim_boundary.includes('command'));
   assert.ok(payload.lanes.every((lane) => typeof lane.claim_boundary === 'string'));
-  assert.ok(payload.lanes.every((lane) => ['evidence-ready', 'missing-artifact'].includes(lane.status)));
+  assert.ok(
+    payload.lanes.every((lane) => ['evidence-ready', 'missing-artifact'].includes(lane.status))
+  );
 });
 
 test('bench dashboard can write HTML artifact', () => {

--- a/packages/cli/tests/shell.test.cjs
+++ b/packages/cli/tests/shell.test.cjs
@@ -537,35 +537,23 @@ test('infer command routes geoseal and termux worksheets with typo tolerance', (
   assert.match(result.stdout, /execute: no/);
 });
 
-// PENDING: this asserts a bare sentence beginning with the real `geoseal` verb
-// routes to the generic worksheet fallback. Today the `geoseal` command
-// dispatch intercepts the phrase first (emits a command plan -> geoseal_cli
-// explain-route), so the worksheet fallback never fires. Resolving it means
-// reordering dispatch so a multi-word prose tail outranks a leading known verb,
-// which would ripple into the geoseal command tests — deferred to its own fix.
-test(
-  'bare sentence routes to worksheet before weak natural-language guess',
-  {
-    skip: 'worksheet fallback is shadowed by the leading geoseal verb dispatch — pending routing-order fix',
-  },
-  () => {
-    const result = runCli([
-      'geoseal',
-      'compile',
-      'intent',
-      'summarize',
-      'README',
-      'with',
-      'termunx',
-      'fallback',
-    ]);
+// A bare sentence that does NOT begin with a known command verb falls through to
+// the worksheet/NL stage, and must route to the generic worksheet — which detects
+// the skill keywords (geoseal, termux, with "termunx" typo tolerance) — rather
+// than a weak natural-language guess or a workspace ingest.
+// (An input that DOES begin with a real verb such as `geoseal` is correctly
+// handled by that command's own dispatch and is not a worksheet case — the
+// earlier skip used such an input, which was the test's bug, not a routing gap.)
+test('bare sentence routes to worksheet before weak natural-language guess', () => {
+  const result = runCli(
+    'please summarize the README using geoseal governance with a termunx fallback'.split(' ')
+  );
 
-    assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /worksheet: worksheet\.generic/);
-    assert.match(result.stdout, /skills: geoseal, termux/);
-    assert.doesNotMatch(result.stderr, /workspace ingest/);
-  }
-);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /worksheet: worksheet\.generic/);
+  assert.match(result.stdout, /skills: geoseal, termux/);
+  assert.doesNotMatch(result.stderr, /workspace ingest/);
+});
 
 test('rich shell treats run plus prose as an assistant request, not executable a.exe', () => {
   const result = runCli(['shell'], {


### PR DESCRIPTION
## What

Three CLI test/runtime hygiene fixes (the follow-ups flagged when promoting the tool surface in #2196). `packages/cli` `node --test` goes from **165 pass / 4 skip / 5 fail → 171 pass / 3 skip / 0 fail**. The 3 remaining skips are the desktop tests that legitimately need `packages/polly-pad-os` (R&D pkg, not shipped on main).

### 1. Action bridge process leak — real bug
On Windows the bridge smoke launches the bridge through a `Start-Process cmd.exe` wrapper (for output redirection) and recorded **cmd.exe's pid** — but the node bridge is cmd's *child*. Teardown `process.kill(bridge.pid, 'SIGTERM')` killed only the wrapper, **orphaning the node server**, which kept answering `/health` and held its log file open. **13 zombie bridges had accumulated across 3 days.**
- Fix: `stopProcessTree()` — `taskkill /T /F` on Windows (whole tree), negative-pid group kill on POSIX. The bridge also installs `SIGTERM`/`SIGINT` handlers to close its listener.
- Regression guard: after the smoke, `/health` must be **unreachable** (asserts no orphan).

### 2. Bench assertion drift — pre-existing rot
5 tests hard-coded "10 lanes"; the registry grew to **12 real distinct lanes**. Replaced the magic numbers with an explicit `EXPECTED_LANES` source-of-truth (verified against the live CLI) + a **set-equality** check that names the missing/extra lane on failure — so the next add/remove fails loudly instead of drifting silently.

### 3. Worksheet routing test — premise was wrong, not a routing gap
The skipped test fed `geoseal compile ...` — a phrase **leading with the real `geoseal` verb**, which that command's dispatch correctly handles (not a worksheet case). Rewrote it to use a true bare sentence (`please summarize the README using geoseal governance with a termunx fallback`) that falls through to the worksheet stage → routes to `worksheet.generic` with skills `geoseal`+`termux` (typo-tolerant `termunx`). **Un-skipped; passes.**

## Verification
- Full `packages/cli` `tests/` suite: 171 pass / 0 fail / 3 skip.
- Confirmed **0 leaked bridge processes** after the full suite run (was the bug).
- `node -c` clean on the production file; prettier-formatted; commit hooks ran (not skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced desktop bridge process cleanup on Windows and POSIX systems
  * Improved error message formatting for browser-launch failures
  * Added signal handlers for graceful server shutdown

* **Tests**
  * Added health verification for bridge endpoint availability
  * Centralized benchmark lane configuration for consistency
  * Enhanced command routing validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->