### PR TITLE
chore(submodules): dedupe .gitmodules + code-locality rule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "aws-lambda-simple-web-app"]
-	path = aws-lambda-simple-web-app
-	url = https://github.com/issdandavis/aws-lambda-simple-web-app.git
 [submodule "external/Entropicdefenseengineproposal"]
 	path = external/Entropicdefenseengineproposal
 	url = https://github.com/issdandavis/Entropicdefenseengineproposal.git
@@ -16,21 +13,12 @@
 [submodule "external_repos/aws-lambda-simple-web-app"]
 	path = external_repos/aws-lambda-simple-web-app
 	url = https://github.com/issdandavis/aws-lambda-simple-web-app.git
-[submodule "external_repos/aws-lambda-simple-web-app-fresh"]
-	path = external_repos/aws-lambda-simple-web-app-fresh
-	url = https://github.com/issdandavis/aws-lambda-simple-web-app.git
 [submodule "external_repos/scbe-quantum-prototype"]
 	path = external_repos/scbe-quantum-prototype
 	url = https://github.com/issdandavis/scbe-quantum-prototype.git
 [submodule "external_repos/scbe-security-gate"]
 	path = external_repos/scbe-security-gate
 	url = https://github.com/issdandavis/scbe-security-gate.git
-[submodule "hioujhn"]
-	path = hioujhn
-	url = https://github.com/issdandavis/hioujhn.git
-[submodule "scbe-aethermoore"]
-	path = scbe-aethermoore
-	url = https://github.com/issdandavis/scbe-aethermoore.git
 [submodule "spiralverse-protocol"]
 	path = spiralverse-protocol
 	url = https://github.com/issdandavis/spiralverse-protocol.git
@@ -43,6 +31,3 @@
 [submodule "external_repos/spiralverse-protocol"]
 	path = external_repos/spiralverse-protocol
 	url = https://github.com/issdandavis/spiralverse-protocol.git
-[submodule "packages/six-tongues-geoseal"]
-	path = packages/six-tongues-geoseal
-	url = https://github.com/issdandavis/six-tongues-geoseal.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,11 @@ Add axiom compliance comments where applicable: `// A4: Clamping` or `# A2: Unit
 - **TypeScript is canonical** (production). Update TS first, then Python.
 - Cross-language parity tests in `tests/cross-language/` and `tests/interop/`.
 
+### Code Locality
+- A command's logic lives **inside its package** (e.g. `packages/cli/`, `packages/agent-bus/`), not scattered into root-level scripts or a parallel sibling file. Fold new behavior into the existing module that owns that surface.
+- The repo root is for **standard project files only** (README, LICENSE, CHANGELOG, CONTRIBUTING, SECURITY, agent-instruction files, build/config manifests). Do not add new top-level scripts or docs there — put scripts under `scripts/`, docs under `docs/`.
+- Before declaring a path a submodule, confirm there is a tracked gitlink for it; a `.gitmodules` stanza with no gitlink is dead and should not be added.
+
 ### When Adding Features
 1. Tag files with `@layer` comments
 2. Document which axiom your code satisfies


### PR DESCRIPTION
## What

Final cleanup pass: dedupe `.gitmodules` cruft and document the convention that keeps it from regrowing.

### `.gitmodules`: 16 → 11 entries
- **Removed `external_repos/aws-lambda-simple-web-app-fresh`** — an exact duplicate gitlink (same commit SHA `67604bc...` as `external_repos/aws-lambda-simple-web-app`), with **zero references** anywhere in the tree. The duplicate gitlink was also dropped from the index.
- **Removed 4 stale stanzas with no tracked gitlink** (functionally dead — `git submodule` operations key off gitlinks in the index, not `.gitmodules` text): root `aws-lambda-simple-web-app`, `hioujhn`, root `scbe-aethermoore`, `packages/six-tongues-geoseal`.

After the change, `git submodule status` lists 11 entries and the `.gitmodules` submodule count matches the tracked-gitlink count (11 = 11).

### `CLAUDE.md`: "Code Locality" rule
Anti-regrowth convention — command logic stays inside its package, the repo root is for standard project files only, and a `.gitmodules` stanza must have a tracked gitlink.

## Soundness / why this is safe
Grepped every removed path against the whole tree before removing:
- `aws-lambda-simple-web-app-fresh` → no references outside `.gitmodules`.
- `hioujhn` → appears only in ignore-rules (`.npmignore`, `.github/dependabot.yml`) and historical notes (`CHANGELOG.md`, `docs/archive/cleanup_notes.md`) — none depend on the submodule declaration.
- `six-tongues-geoseal` → the optional `src/integrations/six-tongues.ts` CLI path is `config.cliPath`-overridable and was **never provisioned by the dead stanza** (no gitlink), so its behavior is unchanged.

No tracked source files were touched.

## Verification
- `git submodule status` → parses cleanly, 11 entries
- `.gitmodules` submodule count = tracked gitlink count = 11
- pre-commit hook passed (not bypassed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)