### PR TITLE
fix(research): strip trailing whitespace in mtef-cell README

### DIFF
--- a/research/mtef-cell/README.md
+++ b/research/mtef-cell/README.md
@@ -1,6 +1,6 @@
 # M-TEF Cell — Magneto-Triboelectric Fluid Cell
 
-**Status:** concept research + prototype-planning scaffold.  
+**Status:** concept research + prototype-planning scaffold.
 **Maturity:** component-level literature support exists, but the integrated M-TEF Cell is still unbuilt / unvalidated hardware. Treat this folder as a technical research package and prototype roadmap, not as a flight-qualified design.
 
 ## Core idea


### PR DESCRIPTION
## What

Strips the two trailing spaces from line 3 of `research/mtef-cell/README.md`:

```
**Status:** concept research + prototype-planning scaffold.··  ->  ...scaffold.
```

## Why this is needed (the part that wasn't obvious)

PR #2195 auto-merged ~17 seconds after it opened (the "Auto-Approve / Enable Auto-Merge for Trusted PRs" workflows). The `claude-review` deterministic gate — `git diff --check` — didn't start until ~8 minutes *after* the merge had already completed, so its failure never blocked anything and the trailing whitespace rode straight into `main`.

A subsequent fix commit pushed to the `research/mtef-cell-scaffold` branch landed *after* #2195 was already closed/merged, so it was orphaned and never reached `main`. This PR lands the fix on `main` properly.

## Verification

`git diff --check $(git merge-base main HEAD) HEAD` returns exit 0 (clean) on this branch.

https://claude.ai/code/session_01HDHfAsJz2RbgfsNmVGMY96

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDHfAsJz2RbgfsNmVGMY96)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation formatting to maintain consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->