### PR TITLE
feat(netlify): add serverless API functions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[functions]
+  directory = "netlify/functions"
+  node_bundler = "esbuild"
+

--- a/netlify/functions/_shared/response.ts
+++ b/netlify/functions/_shared/response.ts
@@ -1,0 +1,55 @@
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export function json(data: JsonValue, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set('Content-Type', 'application/json; charset=utf-8');
+  headers.set('Cache-Control', 'no-store');
+
+  return new Response(JSON.stringify(data, null, 2), {
+    ...init,
+    headers,
+  });
+}
+
+export function methodNotAllowed(method: string, allowed: string[]): Response {
+  return json(
+    {
+      ok: false,
+      error: 'method_not_allowed',
+      method,
+      allowed,
+    },
+    {
+      status: 405,
+      headers: { Allow: allowed.join(', ') },
+    }
+  );
+}
+
+export function corsPreflight(methods: string[]): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Methods': ['OPTIONS', ...methods].join(', '),
+      'Access-Control-Max-Age': '86400',
+    },
+  });
+}
+
+export function withCors(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('Access-Control-Allow-Origin', '*');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/netlify/functions/governance-submit.ts
+++ b/netlify/functions/governance-submit.ts
@@ -1,0 +1,103 @@
+import type { Config, Context } from '@netlify/functions';
+import { corsPreflight, json, methodNotAllowed, withCors } from './_shared/response';
+
+type GovernancePayload = {
+  intent?: unknown;
+  source?: unknown;
+  metadata?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hash))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export default async (req: Request, context: Context) => {
+  if (req.method === 'OPTIONS') {
+    return corsPreflight(['POST']);
+  }
+
+  if (req.method !== 'POST') {
+    return withCors(methodNotAllowed(req.method, ['POST']));
+  }
+
+  let payload: GovernancePayload;
+  try {
+    payload = (await req.json()) as GovernancePayload;
+  } catch {
+    return withCors(json({ ok: false, error: 'invalid_json' }, { status: 400 }));
+  }
+
+  if (
+    !isRecord(payload) ||
+    typeof payload.intent !== 'string' ||
+    payload.intent.trim().length === 0
+  ) {
+    return withCors(
+      json(
+        {
+          ok: false,
+          error: 'invalid_payload',
+          required: ['intent:string'],
+        },
+        { status: 422 }
+      )
+    );
+  }
+
+  const normalized = {
+    intent: payload.intent.trim(),
+    source: typeof payload.source === 'string' ? payload.source : 'netlify',
+    metadata: isRecord(payload.metadata) ? payload.metadata : {},
+  };
+  const receipt = await sha256Hex(stableStringify(normalized));
+
+  context.waitUntil(
+    Promise.resolve().then(() => {
+      console.log('governance_submit', {
+        receipt,
+        requestId: context.requestId,
+        source: normalized.source,
+      });
+    })
+  );
+
+  return withCors(
+    json(
+      {
+        ok: true,
+        decision: 'queued',
+        receipt,
+        requestId: context.requestId,
+      },
+      { status: 202 }
+    )
+  );
+};
+
+export const config: Config = {
+  path: '/api/governance/submit',
+  method: ['OPTIONS', 'POST'],
+};

--- a/netlify/functions/health.ts
+++ b/netlify/functions/health.ts
@@ -1,0 +1,35 @@
+import type { Config, Context } from '@netlify/functions';
+import { json, methodNotAllowed } from './_shared/response';
+
+export default async (req: Request, context: Context) => {
+  if (req.method !== 'GET') {
+    return methodNotAllowed(req.method, ['GET']);
+  }
+
+  return json({
+    ok: true,
+    service: 'scbe-aethermoore',
+    status: 'ready',
+    requestId: context.requestId,
+    deploy: {
+      context: context.deploy.context ?? null,
+      id: context.deploy.id ?? null,
+      published: context.deploy.published ?? false,
+    },
+    site: {
+      id: context.site.id ?? null,
+      name: context.site.name ?? null,
+      url: context.site.url ?? null,
+    },
+    geo: {
+      city: context.geo.city ?? null,
+      country: context.geo.country?.code ?? null,
+      timezone: context.geo.timezone ?? null,
+    },
+  });
+};
+
+export const config: Config = {
+  path: '/api/health',
+  method: ['GET'],
+};

--- a/netlify/functions/system-manifest.ts
+++ b/netlify/functions/system-manifest.ts
@@ -1,0 +1,34 @@
+import type { Config, Context } from '@netlify/functions';
+import { json, methodNotAllowed } from './_shared/response';
+
+const capabilities = [
+  'geoseal-pqc',
+  'scbe-cli',
+  'chemistry-tokenizer',
+  'agentic-memory-health',
+  'skill-recovery',
+  'governance-submit',
+];
+
+export default async (req: Request, context: Context) => {
+  if (req.method !== 'GET') {
+    return methodNotAllowed(req.method, ['GET']);
+  }
+
+  return json({
+    ok: true,
+    name: 'SCBE-AETHERMOORE Netlify API',
+    requestId: context.requestId,
+    capabilities,
+    endpoints: {
+      health: '/api/health',
+      manifest: '/api/system/manifest',
+      governanceSubmit: '/api/governance/submit',
+    },
+  });
+};
+
+export const config: Config = {
+  path: '/api/system/manifest',
+  method: ['GET'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "scbe-scan": "bin/scbe-scan.cjs"
       },
       "devDependencies": {
+        "@netlify/functions": "^5.3.0",
         "@playwright/test": "^1.58.2",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
@@ -400,6 +401,29 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@netlify/functions": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-5.3.0.tgz",
+      "integrity": "sha512-FP+xCoZMkMOUsKa4UdG/oiK/2md1/TxuXvqqieaMVMgDbFFMaHI8h0oHCViUY73kPbKV6HyzayaSXGYXKpBSoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/types": "2.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@netlify/types": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@netlify/types/-/types-2.8.0.tgz",
+      "integrity": "sha512-8/g0Pt6y6wXj5Ia5eeYLiXhRfWeqZXGXpGFeCiiQdUOem+FPtXdA4+YdGxqzWc7D0AvptKSO01KGeeVWHSu8Kg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || >=20"
       }
     },
     "node_modules/@noble/ciphers": {

--- a/package.json
+++ b/package.json
@@ -301,6 +301,7 @@
     "express-rate-limit": "^8.3.1"
   },
   "devDependencies": {
+    "@netlify/functions": "^5.3.0",
     "@playwright/test": "^1.58.2",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",

--- a/tests/netlify_functions.test.ts
+++ b/tests/netlify_functions.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import governanceSubmit from '../netlify/functions/governance-submit';
+import health from '../netlify/functions/health';
+import systemManifest from '../netlify/functions/system-manifest';
+
+const context = {
+  requestId: 'req_test',
+  waitUntil: vi.fn(),
+  deploy: { context: 'dev', id: 'deploy_test', published: false },
+  site: { id: 'site_test', name: 'scbe-test', url: 'https://example.netlify.app' },
+  geo: {
+    city: 'Test City',
+    country: { code: 'US', name: 'United States' },
+    timezone: 'America/Los_Angeles',
+  },
+} as any;
+
+describe('Netlify functions', () => {
+  it('returns API health', async () => {
+    const res = await health(new Request('https://example.com/api/health'), context);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.service).toBe('scbe-aethermoore');
+  });
+
+  it('returns a system manifest', async () => {
+    const res = await systemManifest(
+      new Request('https://example.com/api/system/manifest'),
+      context
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.capabilities).toContain('governance-submit');
+    expect(body.endpoints.governanceSubmit).toBe('/api/governance/submit');
+  });
+
+  it('accepts governance submissions with deterministic receipts', async () => {
+    const req = new Request('https://example.com/api/governance/submit', {
+      method: 'POST',
+      body: JSON.stringify({
+        intent: 'run chemistry tokenizer preflight',
+        source: 'test',
+        metadata: { b: 2, a: 1 },
+      }),
+    });
+
+    const first = await governanceSubmit(req, context);
+    const firstBody = await first.json();
+    const second = await governanceSubmit(
+      new Request('https://example.com/api/governance/submit', {
+        method: 'POST',
+        body: JSON.stringify({
+          metadata: { a: 1, b: 2 },
+          source: 'test',
+          intent: 'run chemistry tokenizer preflight',
+        }),
+      }),
+      context
+    );
+    const secondBody = await second.json();
+
+    expect(first.status).toBe(202);
+    expect(firstBody.decision).toBe('queued');
+    expect(firstBody.receipt).toMatch(/^[a-f0-9]{64}$/);
+    expect(firstBody.receipt).toBe(secondBody.receipt);
+  });
+
+  it('rejects empty governance submissions', async () => {
+    const res = await governanceSubmit(
+      new Request('https://example.com/api/governance/submit', {
+        method: 'POST',
+        body: JSON.stringify({ intent: '' }),
+      }),
+      context
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body.error).toBe('invalid_payload');
+  });
+});


### PR DESCRIPTION
## Summary
- Add Netlify Functions config and three modern function endpoints: `/api/health`, `/api/system/manifest`, and `/api/governance/submit`.
- Add shared JSON/CORS response helpers for serverless endpoints.
- Add Vitest coverage for health, manifest, deterministic governance receipts, and invalid payloads.

## Validation
- `npm test -- tests/netlify_functions.test.ts`
- `npx tsc --ignoreConfig --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --skipLibCheck netlify/functions/_shared/response.ts netlify/functions/health.ts netlify/functions/system-manifest.ts netlify/functions/governance-submit.ts tests/netlify_functions.test.ts`
- `npx prettier --check "netlify/functions/**/*.ts" tests/netlify_functions.test.ts`
