### PR TITLE
fix(netlify): trim functions config whitespace

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,3 @@
 [functions]
   directory = "netlify/functions"
   node_bundler = "esbuild"
-


### PR DESCRIPTION
## Summary
- Remove the trailing blank line in netlify.toml flagged by the deterministic review gate after PR #2239 merged.

## Validation
- git diff --check
- npm test -- tests/netlify_functions.test.ts