### PR TITLE
feat(netlify): persist governance receipts in blobs

### DIFF
--- a/netlify/functions/_shared/governance.ts
+++ b/netlify/functions/_shared/governance.ts
@@ -1,3 +1,5 @@
+import type { JsonValue } from './response';
+
 export type GovernancePayload = {
   intent?: unknown;
   source?: unknown;
@@ -7,7 +9,7 @@ export type GovernancePayload = {
 export type NormalizedGovernancePayload = {
   intent: string;
   source: string;
-  metadata: Record<string, unknown>;
+  metadata: Record<string, JsonValue>;
 };
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
@@ -28,8 +30,37 @@ export function normalizeGovernancePayload(
   return {
     intent: payload.intent.trim(),
     source: typeof payload.source === 'string' ? payload.source : 'netlify',
-    metadata: isRecord(payload.metadata) ? payload.metadata : {},
+    metadata: isRecord(payload.metadata) ? normalizeJsonRecord(payload.metadata) : {},
   };
+}
+
+function normalizeJsonValue(value: unknown): JsonValue | undefined {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return Number.isFinite(value as number) || typeof value !== 'number' ? value : null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeJsonValue(item) ?? null);
+  }
+
+  if (isRecord(value)) {
+    return normalizeJsonRecord(value);
+  }
+
+  return undefined;
+}
+
+function normalizeJsonRecord(record: Record<string, unknown>): Record<string, JsonValue> {
+  return Object.fromEntries(
+    Object.entries(record)
+      .map(([key, value]) => [key, normalizeJsonValue(value)] as const)
+      .filter((entry): entry is readonly [string, JsonValue] => entry[1] !== undefined)
+  );
 }
 
 export function stableStringify(value: unknown): string {

--- a/netlify/functions/_shared/receipt-store.ts
+++ b/netlify/functions/_shared/receipt-store.ts
@@ -1,0 +1,138 @@
+import type { Context } from '@netlify/functions';
+import { getStore } from '@netlify/blobs';
+import type { NormalizedGovernancePayload } from './governance';
+
+const RECEIPT_STORE = 'scbe-governance-receipts';
+
+export type GovernanceReceiptRecord = {
+  receipt: string;
+  status: 'queued' | 'processed';
+  payload: NormalizedGovernancePayload;
+  requestId: string;
+  createdAt: string;
+  storageKey: string;
+  netlify: {
+    deployContext?: string;
+    deployId?: string;
+    siteId?: string;
+    siteName?: string;
+  };
+};
+
+export type GovernanceRollupRecord = {
+  ok: true;
+  day: string;
+  receiptCount: number;
+  receipts: string[];
+  generatedAt: string;
+  storageKey: string;
+};
+
+function receiptDay(createdAt: string): string {
+  return createdAt.slice(0, 10);
+}
+
+export function governanceReceiptKey(receipt: string, createdAt: string): string {
+  return `receipts/${receiptDay(createdAt)}/${receipt}.json`;
+}
+
+export function governanceRollupKey(day: string): string {
+  return `rollups/${day}.json`;
+}
+
+function governanceReceiptIndexKey(receipt: string): string {
+  return `indexes/receipts/${receipt}.json`;
+}
+
+function receiptStore() {
+  return getStore({ name: RECEIPT_STORE, consistency: 'strong' });
+}
+
+export async function saveGovernanceReceipt(input: {
+  receipt: string;
+  payload: NormalizedGovernancePayload;
+  context: Context;
+  createdAt?: string;
+}): Promise<GovernanceReceiptRecord> {
+  const createdAt = input.createdAt ?? new Date().toISOString();
+  const storageKey = governanceReceiptKey(input.receipt, createdAt);
+  const record: GovernanceReceiptRecord = {
+    receipt: input.receipt,
+    status: 'queued',
+    payload: input.payload,
+    requestId: input.context.requestId,
+    createdAt,
+    storageKey,
+    netlify: {
+      deployContext: input.context.deploy?.context,
+      deployId: input.context.deploy?.id,
+      siteId: input.context.site?.id,
+      siteName: input.context.site?.name,
+    },
+  };
+
+  await receiptStore().setJSON(storageKey, record, {
+    metadata: {
+      receipt: input.receipt,
+      status: record.status,
+      day: receiptDay(createdAt),
+      source: input.payload.source,
+    },
+  });
+  await receiptStore().setJSON(governanceReceiptIndexKey(input.receipt), {
+    receipt: input.receipt,
+    storageKey,
+    createdAt,
+  });
+
+  return record;
+}
+
+export async function findGovernanceReceipt(
+  receipt: string
+): Promise<GovernanceReceiptRecord | null> {
+  const store = receiptStore();
+  const index = (await store.get(governanceReceiptIndexKey(receipt), { type: 'json' })) as {
+    storageKey?: unknown;
+  } | null;
+  if (typeof index?.storageKey !== 'string') {
+    return null;
+  }
+
+  return (await store.get(index.storageKey, { type: 'json' })) as GovernanceReceiptRecord | null;
+}
+
+export async function buildDailyGovernanceRollup(
+  day = new Date().toISOString().slice(0, 10)
+): Promise<GovernanceRollupRecord> {
+  const store = receiptStore();
+  const listing = await store.list({ prefix: `receipts/${day}/` });
+  const receipts = listing.blobs
+    .map((blob) =>
+      blob.key
+        .split('/')
+        .pop()
+        ?.replace(/\.json$/, '')
+    )
+    .filter((receipt): receipt is string => Boolean(receipt))
+    .sort();
+  const storageKey = governanceRollupKey(day);
+  const rollup: GovernanceRollupRecord = {
+    ok: true,
+    day,
+    receiptCount: receipts.length,
+    receipts,
+    generatedAt: new Date().toISOString(),
+    storageKey,
+  };
+
+  await store.setJSON(storageKey, rollup, {
+    metadata: {
+      day,
+      receiptCount: String(receipts.length),
+      generatedAt: rollup.generatedAt,
+    },
+  });
+
+  return rollup;
+}

--- a/netlify/functions/governance-receipt.ts
+++ b/netlify/functions/governance-receipt.ts
@@ -1,0 +1,30 @@
+import type { Config } from '@netlify/functions';
+import { findGovernanceReceipt } from './_shared/receipt-store';
+import { corsPreflight, json, methodNotAllowed, withCors } from './_shared/response';
+
+export default async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return corsPreflight(['GET']);
+  }
+
+  if (req.method !== 'GET') {
+    return withCors(methodNotAllowed(req.method, ['GET']));
+  }
+
+  const receipt = new URL(req.url).pathname.split('/').pop() ?? '';
+  if (!/^[a-f0-9]{64}$/.test(receipt)) {
+    return withCors(json({ ok: false, error: 'invalid_receipt' }, { status: 400 }));
+  }
+
+  const record = await findGovernanceReceipt(receipt);
+  if (!record) {
+    return withCors(json({ ok: false, error: 'receipt_not_found' }, { status: 404 }));
+  }
+
+  return withCors(json({ ok: true, record }));
+};
+
+export const config: Config = {
+  path: '/api/governance/receipts/:receipt',
+  method: ['OPTIONS', 'GET'],
+};

--- a/netlify/functions/governance-rollup.ts
+++ b/netlify/functions/governance-rollup.ts
@@ -1,0 +1,16 @@
+import type { Config, Context } from '@netlify/functions';
+import { buildDailyGovernanceRollup } from './_shared/receipt-store';
+
+export default async (_req: Request, context: Context) => {
+  const rollup = await buildDailyGovernanceRollup();
+  console.log('governance_rollup_written', {
+    requestId: context.requestId,
+    day: rollup.day,
+    receiptCount: rollup.receiptCount,
+    storageKey: rollup.storageKey,
+  });
+};
+
+export const config: Config = {
+  schedule: '@daily',
+};

--- a/netlify/functions/governance-submit.ts
+++ b/netlify/functions/governance-submit.ts
@@ -4,6 +4,7 @@ import {
   governanceReceipt,
   normalizeGovernancePayload,
 } from './_shared/governance';
+import { saveGovernanceReceipt } from './_shared/receipt-store';
 import { corsPreflight, json, methodNotAllowed, withCors } from './_shared/response';
 
 export default async (req: Request, context: Context) => {
@@ -37,6 +38,11 @@ export default async (req: Request, context: Context) => {
   }
 
   const receipt = await governanceReceipt(normalized);
+  const record = await saveGovernanceReceipt({
+    receipt,
+    payload: normalized,
+    context,
+  });
 
   context.waitUntil(
     Promise.resolve().then(() => {
@@ -44,6 +50,7 @@ export default async (req: Request, context: Context) => {
         receipt,
         requestId: context.requestId,
         source: normalized.source,
+        storageKey: record.storageKey,
       });
     })
   );
@@ -55,6 +62,7 @@ export default async (req: Request, context: Context) => {
         decision: 'queued',
         receipt,
         requestId: context.requestId,
+        storageKey: record.storageKey,
       },
       { status: 202 }
     )

--- a/netlify/functions/system-manifest.ts
+++ b/netlify/functions/system-manifest.ts
@@ -8,6 +8,8 @@ const capabilities = [
   'agentic-memory-health',
   'skill-recovery',
   'governance-submit',
+  'governance-receipts',
+  'governance-rollups',
 ];
 
 export default async (req: Request, context: Context) => {
@@ -24,6 +26,7 @@ export default async (req: Request, context: Context) => {
       health: '/api/health',
       manifest: '/api/system/manifest',
       governanceSubmit: '/api/governance/submit',
+      governanceReceipt: '/api/governance/receipts/:receipt',
       governanceSelftest: '/api/governance/selftest',
       governanceWorker: '/api/governance/process',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
+        "@netlify/blobs": "^10.7.9",
         "@noble/hashes": "^2.0.1",
         "@noble/post-quantum": "^0.6.0",
         "@notionhq/client": "^5.9.0",
@@ -210,6 +211,25 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@envelop/instrumentation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+      "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
     },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "3.23.0",
@@ -403,6 +423,45 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@netlify/blobs": {
+      "version": "10.7.9",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.7.9.tgz",
+      "integrity": "sha512-NEM8aNAMZCCWBWymomMM/fn5wmPGyGE8pendgsSu5mL7UNz+aXqGcHS0MiHWU/osyg+geiZuS+Rx956SVrMM/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/dev-utils": "4.4.6",
+        "@netlify/otel": "^6.0.3",
+        "@netlify/runtime-utils": "2.3.0"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@netlify/dev-utils": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.4.6.tgz",
+      "integrity": "sha512-P6X+xS3glvhiTX6AAocYvnZtqXtWhvxMX4AdPgv2iw6cXjGL2criUveX7bSjp6DiyHfvQpNdG0ZRpeBEVAFf1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/server": "^0.10.0",
+        "ansis": "^4.1.0",
+        "atomically": "^2.0.3",
+        "chokidar": "^4.0.1",
+        "decache": "^4.6.2",
+        "dettle": "^1.0.5",
+        "dot-prop": "9.0.0",
+        "empathic": "^2.0.0",
+        "env-paths": "^3.0.0",
+        "image-size": "^2.0.2",
+        "js-image-generator": "^1.0.4",
+        "parse-gitignore": "^2.0.0",
+        "semver": "^7.7.2",
+        "tmp-promise": "^3.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || >=20"
+      }
+    },
     "node_modules/@netlify/functions": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-5.3.0.tgz",
@@ -414,6 +473,31 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@netlify/otel": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-6.0.3.tgz",
+      "integrity": "sha512-NIjIjB/aItiXKB6+wzSwfSyYqbNsVSzzlEPryxxTC5ZJiYSYSm82wAOcQ+9VdiufQyZO5t8jzHVPULo7a9L9sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/instrumentation": "^0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-node": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || >=20.6.1"
+      }
+    },
+    "node_modules/@netlify/runtime-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-2.3.0.tgz",
+      "integrity": "sha512-cW8weDvsKV7zfia2m5EcBy6KILGoPD+eYZ3qWNGnIo05DGF28goPES0xKSDkNYgAF/2rRSIhie2qcBhbGVgSRg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || >=20"
       }
     },
     "node_modules/@netlify/types": {
@@ -489,6 +573,130 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.217.0.tgz",
+      "integrity": "sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
+      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.217.0.tgz",
+      "integrity": "sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
+      "integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.7.1",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1493,6 +1701,75 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@whatwg-node/disposablestack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+      "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.13.tgz",
+      "integrity": "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.8.3",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.8.6.tgz",
+      "integrity": "sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.1.1",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/server": {
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.10.18.tgz",
+      "integrity": "sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@envelop/instrumentation": "^1.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.13",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1510,13 +1787,21 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-walk": {
@@ -1591,6 +1876,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1649,6 +1943,16 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "node_modules/balanced-match": {
@@ -1794,6 +2098,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1821,6 +2133,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -1836,6 +2163,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -2010,6 +2343,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decache": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.2.tgz",
+      "integrity": "sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==",
+      "license": "MIT",
+      "dependencies": {
+        "callsite": "^1.0.0"
       }
     },
     "node_modules/deep-extend": {
@@ -2224,6 +2566,12 @@
         "typescript": "^5.4.4"
       }
     },
+    "node_modules/dettle": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/dettle/-/dettle-1.0.5.tgz",
+      "integrity": "sha512-ZVyjhAJ7sCe1PNXEGveObOH9AC8QvMga3HJIghHawtG7mE4K5pW9nz/vDGAr/U7a3LWgdOzEE7ac9MURnyfaTA==",
+      "license": "MIT"
+    },
     "node_modules/diff": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
@@ -2232,6 +2580,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dunder-proto": {
@@ -2253,6 +2616,15 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2288,6 +2660,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -2921,6 +3305,33 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.2.tgz",
+      "integrity": "sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3185,6 +3596,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-image-generator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/js-image-generator/-/js-image-generator-1.0.4.tgz",
+      "integrity": "sha512-ckb7kyVojGAnArouVR+5lBIuwU1fcrn7E/YYSd0FK7oIngAkMmRvHASLro9Zt5SQdWToaI66NybG+OGxPw/HlQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jpeg-js": "^0.4.2"
       }
     },
     "node_modules/js-tokens": {
@@ -3764,6 +4190,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/module-lookup-amd": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.1.1.tgz",
@@ -3938,6 +4370,15 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-gitignore": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz",
+      "integrity": "sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/parse-ms": {
       "version": "2.1.0",
@@ -4350,6 +4791,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4357,6 +4811,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/requirejs": {
@@ -4560,7 +5027,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4862,6 +5328,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "license": "MIT"
+    },
     "node_modules/stylus-lookup": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-6.1.0.tgz",
@@ -4970,6 +5451,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
       }
     },
     "node_modules/toidentifier": {
@@ -5083,9 +5582,19 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -5161,6 +5670,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -5387,6 +5902,12 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -294,6 +294,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "@netlify/blobs": "^10.7.9",
     "@noble/hashes": "^2.0.1",
     "@noble/post-quantum": "^0.6.0",
     "@notionhq/client": "^5.9.0",

--- a/tests/netlify_functions.test.ts
+++ b/tests/netlify_functions.test.ts
@@ -1,9 +1,48 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import governanceReceipt from '../netlify/functions/governance-receipt';
+import governanceRollup from '../netlify/functions/governance-rollup';
 import governanceSubmit from '../netlify/functions/governance-submit';
 import governanceSelftest from '../netlify/functions/governance-selftest';
 import governanceWorker from '../netlify/functions/governance-worker-background';
 import health from '../netlify/functions/health';
 import systemManifest from '../netlify/functions/system-manifest';
+
+const blobMock = vi.hoisted(() => {
+  const data = new Map<string, { value: unknown; metadata?: Record<string, string> }>();
+  const store = {
+    setJSON: vi.fn(
+      async (key: string, value: unknown, options?: { metadata?: Record<string, string> }) => {
+        data.set(key, { value, metadata: options?.metadata });
+      }
+    ),
+    get: vi.fn(async (key: string, options?: { type?: string }) => {
+      const record = data.get(key);
+      if (!record) {
+        return null;
+      }
+      return options?.type === 'json' ? record.value : JSON.stringify(record.value);
+    }),
+    list: vi.fn(async (options?: { prefix?: string }) => ({
+      blobs: Array.from(data.keys())
+        .filter((key) => !options?.prefix || key.startsWith(options.prefix))
+        .sort()
+        .map((key) => ({ key, etag: `etag-${key}` })),
+      directories: [],
+    })),
+    delete: vi.fn(async (key: string) => {
+      data.delete(key);
+    }),
+  };
+
+  return {
+    data,
+    getStore: vi.fn(() => store),
+  };
+});
+
+vi.mock('@netlify/blobs', () => ({
+  getStore: blobMock.getStore,
+}));
 
 const context = {
   requestId: 'req_test',
@@ -18,6 +57,11 @@ const context = {
 } as any;
 
 describe('Netlify functions', () => {
+  beforeEach(() => {
+    blobMock.data.clear();
+    vi.clearAllMocks();
+  });
+
   it('returns API health', async () => {
     const res = await health(new Request('https://example.com/api/health'), context);
     const body = await res.json();
@@ -36,7 +80,9 @@ describe('Netlify functions', () => {
 
     expect(res.status).toBe(200);
     expect(body.capabilities).toContain('governance-submit');
+    expect(body.capabilities).toContain('governance-receipts');
     expect(body.endpoints.governanceSubmit).toBe('/api/governance/submit');
+    expect(body.endpoints.governanceReceipt).toBe('/api/governance/receipts/:receipt');
     expect(body.endpoints.governanceSelftest).toBe('/api/governance/selftest');
     expect(body.endpoints.governanceWorker).toBe('/api/governance/process');
   });
@@ -70,6 +116,48 @@ describe('Netlify functions', () => {
     expect(firstBody.decision).toBe('queued');
     expect(firstBody.receipt).toMatch(/^[a-f0-9]{64}$/);
     expect(firstBody.receipt).toBe(secondBody.receipt);
+    expect(firstBody.storageKey).toMatch(
+      new RegExp(`^receipts/\\d{4}-\\d{2}-\\d{2}/${firstBody.receipt}\\.json$`)
+    );
+  });
+
+  it('stores and returns a governance receipt record', async () => {
+    const submit = await governanceSubmit(
+      new Request('https://example.com/api/governance/submit', {
+        method: 'POST',
+        body: JSON.stringify({
+          intent: 'persist receipt in blobs',
+          source: 'vitest',
+          metadata: { subsystem: 'netlify' },
+        }),
+      }),
+      context
+    );
+    const submitBody = await submit.json();
+
+    const res = await governanceReceipt(
+      new Request(`https://example.com/api/governance/receipts/${submitBody.receipt}`)
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.record.receipt).toBe(submitBody.receipt);
+    expect(body.record.status).toBe('queued');
+    expect(body.record.payload.intent).toBe('persist receipt in blobs');
+    expect(body.record.netlify.siteId).toBe('site_test');
+  });
+
+  it('returns 404 for missing governance receipts', async () => {
+    const res = await governanceReceipt(
+      new Request(
+        'https://example.com/api/governance/receipts/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      )
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('receipt_not_found');
   });
 
   it('rejects empty governance submissions', async () => {
@@ -97,6 +185,39 @@ describe('Netlify functions', () => {
     expect(body.ok).toBe(true);
     expect(body.checks.receiptHex64).toBe(true);
     expect(body.receipt).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('writes a daily governance rollup from stored receipts', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const submitted = await governanceSubmit(
+      new Request('https://example.com/api/governance/submit', {
+        method: 'POST',
+        body: JSON.stringify({ intent: 'daily rollup receipt', source: 'test' }),
+      }),
+      context
+    );
+    const submitBody = await submitted.json();
+
+    const res = await governanceRollup(
+      new Request('https://example.com/.netlify/functions/governance-rollup'),
+      context
+    );
+
+    expect(res).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(
+      'governance_rollup_written',
+      expect.objectContaining({
+        requestId: 'req_test',
+        receiptCount: 1,
+      })
+    );
+    expect(
+      Array.from(blobMock.data.values()).some((record) => {
+        const value = record.value as { receipts?: string[] };
+        return value.receipts?.includes(submitBody.receipt);
+      })
+    ).toBe(true);
+    log.mockRestore();
   });
 
   it('processes background governance payloads without returning a body', async () => {


### PR DESCRIPTION
## Summary
- persist governance submit receipts into Netlify Blobs with date-partitioned keys and receipt indexes
- add a receipt lookup endpoint plus a scheduled daily rollup function
- update the system manifest and focused Netlify function tests

## Verification
- npm test -- tests/netlify_functions.test.ts
- npx tsc --ignoreConfig --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --skipLibCheck netlify/functions/_shared/response.ts netlify/functions/_shared/governance.ts netlify/functions/_shared/receipt-store.ts netlify/functions/health.ts netlify/functions/system-manifest.ts netlify/functions/governance-submit.ts netlify/functions/governance-selftest.ts netlify/functions/governance-worker-background.ts netlify/functions/governance-receipt.ts netlify/functions/governance-rollup.ts tests/netlify_functions.test.ts
- npx prettier --check netlify/functions/**/*.ts tests/netlify_functions.test.ts
- git diff --check