### PR TITLE
[codex] Fix scbe bits crash and block host-control harness commands

### DIFF
--- a/bin/geoseal.cjs
+++ b/bin/geoseal.cjs
@@ -591,9 +591,20 @@ function commandRisk(commandText) {
   let decision = "allow";
   let safety = "safe";
 
+  const hostControlPatterns = [
+    /\bwsl(?:\.exe)?\b.*(?:\s|^)--shutdown\b/i,
+    /\b(?:shutdown|restart-computer|stop-computer|poweroff|reboot)\b/i,
+    /\bpowercfg\b.*\b(?:hibernate|standby|sleep|h(?:ibernate)?\s+(?:on|off)|-h\s+(?:on|off))\b/i,
+    /\b(?:bcdedit|diskpart|format|manage-bde|reagentc)\b/i,
+    /\b(?:disable-netadapter|restart-netadapter|enable-netadapter|netsh)\b/i,
+    /\bdocker\b\s+system\s+prune\b.*(?:\s-a\b|\s--all\b)/i,
+    /\btaskkill\b.*(?:\s\/f\b|\s\/t\b).*(?:\s\/im\s+\*|\s\/pid\s+0\b|python\.exe|node\.exe|code\.exe)/i,
+    /\bstop-process\b.*(?:-force|\s-id\s+0\b|-name\s+\*|python|node|code)/i,
+    /\b(?:stress|stress-ng|sysbench)\b|\bwhile\s+(?:true\b|\(\s*\$true\s*\))/i,
+  ];
   const destructivePatterns = [
     /\brm\s+(-[a-z]*r[a-z]*f|-rf|-fr)\b/i,
-    /\bremove-item\b.*\b-recurse\b/i,
+    /\bremove-item\b.*(?:\s|^)-recurse\b/i,
     /\bdel(?:ete)?\b.*\b\/s\b/i,
     /\bformat\b/i,
     /\bdrop\s+table\b/i,
@@ -617,9 +628,16 @@ function commandRisk(commandText) {
   if (!text) {
     return { decision: "block", safety: "missing", reasons: ["No command supplied."] };
   }
+  if (hostControlPatterns.some((pattern) => pattern.test(text))) {
+    decision = "block";
+    safety = "refused";
+    reasons.push("Command controls host power, boot, disk, network, VM, process, or stress state.");
+  }
   if (destructivePatterns.some((pattern) => pattern.test(text))) {
-    decision = "confirm";
-    safety = "destructive";
+    if (decision !== "block") {
+      decision = "confirm";
+      safety = "destructive";
+    }
     reasons.push("Command matches a destructive operation pattern.");
   }
   if (protectedScopes.some((pattern) => pattern.test(text))) {

--- a/scbe.py
+++ b/scbe.py
@@ -1096,6 +1096,7 @@ def _spine_packet(text: str) -> Dict[str, Any]:
             "schema": "scbe_bit_spine_packet_v1",
             "text": text,
             "views": {
+                "bits": packet["binary"],
                 "binary": packet["binary"],
                 "hex": packet["hex"],
                 "trits": packet["trits"],

--- a/src/crypto/geoseal_execution_gate.py
+++ b/src/crypto/geoseal_execution_gate.py
@@ -150,7 +150,10 @@ def _windows_command_line_to_argv(command: str) -> list[str]:
     argc = ctypes.c_int()
     shell32 = ctypes.windll.shell32
     kernel32 = ctypes.windll.kernel32
-    shell32.CommandLineToArgvW.argtypes = [ctypes.c_wchar_p, ctypes.POINTER(ctypes.c_int)]
+    shell32.CommandLineToArgvW.argtypes = [
+        ctypes.c_wchar_p,
+        ctypes.POINTER(ctypes.c_int),
+    ]
     shell32.CommandLineToArgvW.restype = ctypes.POINTER(ctypes.c_wchar_p)
     kernel32.LocalFree.argtypes = [ctypes.c_void_p]
     kernel32.LocalFree.restype = ctypes.c_void_p
@@ -227,20 +230,35 @@ def _scan_python_payload(code: str) -> list[GateFinding]:
                     )
             elif isinstance(fn, ast.Name) and fn.id in _PY_DANGER_NAMES:
                 findings.append(
-                    GateFinding("inline-danger-call", "DENY", f"inline python calls {fn.id}()", evidence=fn.id)
+                    GateFinding(
+                        "inline-danger-call",
+                        "DENY",
+                        f"inline python calls {fn.id}()",
+                        evidence=fn.id,
+                    )
                 )
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 root = alias.name.split(".")[0]
                 if root in _PY_DANGER_MODULES:
                     findings.append(
-                        GateFinding("inline-danger-import", "DENY", f"inline python imports {root}", evidence=root)
+                        GateFinding(
+                            "inline-danger-import",
+                            "DENY",
+                            f"inline python imports {root}",
+                            evidence=root,
+                        )
                     )
         elif isinstance(node, ast.ImportFrom):
             root = (node.module or "").split(".")[0]
             if root in _PY_DANGER_MODULES:
                 findings.append(
-                    GateFinding("inline-danger-import", "DENY", f"inline python imports {root}", evidence=root)
+                    GateFinding(
+                        "inline-danger-import",
+                        "DENY",
+                        f"inline python imports {root}",
+                        evidence=root,
+                    )
                 )
     return findings
 
@@ -250,7 +268,14 @@ def _scan_node_payload(code: str) -> list[GateFinding]:
     findings: list[GateFinding] = []
     for pattern, message in _NODE_DANGER:
         if re.search(pattern, code):
-            findings.append(GateFinding("inline-danger-node", "DENY", f"inline node {message}", evidence=pattern))
+            findings.append(
+                GateFinding(
+                    "inline-danger-node",
+                    "DENY",
+                    f"inline node {message}",
+                    evidence=pattern,
+                )
+            )
     return findings
 
 
@@ -273,6 +298,51 @@ def scan_command(command: str, *, claimed_paths: Optional[Sequence[str]] = None)
         )
 
     deny_patterns: list[tuple[str, str, str]] = [
+        (
+            r"\bwsl(?:\.exe)?\b.*(?:\s|^)--shutdown\b",
+            "wsl-shutdown",
+            "WSL VM shutdown command",
+        ),
+        (
+            r"\b(?:shutdown|restart-computer|stop-computer|poweroff|reboot)\b",
+            "system-power-state",
+            "host power-state command",
+        ),
+        (
+            r"\bpowercfg\b.*\b(?:hibernate|standby|sleep|h(?:ibernate)?\s+(?:on|off)|-h\s+(?:on|off))\b",
+            "powercfg-state-change",
+            "host sleep/hibernate configuration change",
+        ),
+        (
+            r"\b(?:bcdedit|diskpart|format|manage-bde|reagentc)\b",
+            "system-disk-boot-tool",
+            "boot/disk/system configuration tool",
+        ),
+        (
+            r"\b(?:disable-netadapter|restart-netadapter|enable-netadapter|netsh)\b",
+            "network-adapter-control",
+            "network adapter or stack control",
+        ),
+        (
+            r"\bdocker\b\s+system\s+prune\b.*(?:\s-a\b|\s--all\b)",
+            "docker-system-prune-all",
+            "global Docker prune-all command",
+        ),
+        (
+            r"\btaskkill\b.*(?:\s/f\b|\s/t\b).*(?:\s/im\s+\*|\s/pid\s+0\b|python\.exe|node\.exe|code\.exe)",
+            "broad-taskkill",
+            "broad forced process kill",
+        ),
+        (
+            r"\bstop-process\b.*(?:-force|\s-id\s+0\b|-name\s+\*|python|node|code)",
+            "broad-stop-process",
+            "broad forced PowerShell process kill",
+        ),
+        (
+            r"\b(?:stress|stress-ng|sysbench)\b|\bwhile\s+(?:true\b|\(\s*\$true\s*\))",
+            "host-stress-loop",
+            "host stress or unbounded loop command",
+        ),
         # destructive-rm must catch recursive+force in ANY flag form/order, not just the
         # literal "-rf". The old `\brm\s+-rf\b` ALLOWED `rm -fr`, `rm -r -f`, and
         # `rm --recursive --force` (a real bypass — confirmed via scan_command). Require
@@ -288,11 +358,31 @@ def scan_command(command: str, *, claimed_paths: Optional[Sequence[str]] = None)
         # The leading boundary before "-recurse" must NOT be \b — \b never matches
         # between a space and a hyphen, so `\b-recurse` silently disabled this rule and
         # `Remove-Item -Recurse -Force` (and the `rm`/`ri` aliases) were ALLOWED.
-        (r"\b(?:remove-item|ri|rm)\b.*(?:\s|^)-recurse\b", "destructive-remove-item", "recursive PowerShell delete"),
-        (r"\binvoke-expression\b|\biex\b", "powershell-iex", "dynamic PowerShell execution"),
-        (r"\bcurl\b.*\|\s*(sh|bash|powershell|pwsh|iex)\b", "curl-pipe-exec", "download-to-exec chain"),
-        (r"\bwget\b.*\|\s*(sh|bash|powershell|pwsh|iex)\b", "wget-pipe-exec", "download-to-exec chain"),
-        (r"config[/\\]connector_oauth", "connector-secret-path", "connector OAuth secret path"),
+        (
+            r"\b(?:remove-item|ri|rm)\b.*(?:\s|^)-recurse\b",
+            "destructive-remove-item",
+            "recursive PowerShell delete",
+        ),
+        (
+            r"\binvoke-expression\b|\biex\b",
+            "powershell-iex",
+            "dynamic PowerShell execution",
+        ),
+        (
+            r"\bcurl\b.*\|\s*(sh|bash|powershell|pwsh|iex)\b",
+            "curl-pipe-exec",
+            "download-to-exec chain",
+        ),
+        (
+            r"\bwget\b.*\|\s*(sh|bash|powershell|pwsh|iex)\b",
+            "wget-pipe-exec",
+            "download-to-exec chain",
+        ),
+        (
+            r"config[/\\]connector_oauth",
+            "connector-secret-path",
+            "connector OAuth secret path",
+        ),
         (r"\.env(\.|$|\s)", "env-secret-path", "environment secret file path"),
     ]
     for pattern, rule, message in deny_patterns:
@@ -303,7 +393,13 @@ def scan_command(command: str, *, claimed_paths: Optional[Sequence[str]] = None)
         executable = Path(argv[0]).name.lower()
         if executable in {"powershell", "powershell.exe", "pwsh", "pwsh.exe"}:
             if any(arg.lower() in {"-encodedcommand", "-enc"} for arg in argv[1:]):
-                findings.append(GateFinding("encoded-powershell", "DENY", "encoded PowerShell commands are blocked"))
+                findings.append(
+                    GateFinding(
+                        "encoded-powershell",
+                        "DENY",
+                        "encoded PowerShell commands are blocked",
+                    )
+                )
         if executable in {"python", "python.exe", "py", "node", "node.exe"} and "-c" in argv[1:]:
             findings.append(
                 GateFinding(

--- a/tests/crypto/test_geoseal_execution_gate.py
+++ b/tests/crypto/test_geoseal_execution_gate.py
@@ -75,6 +75,35 @@ def test_recursive_powershell_delete_is_denied() -> None:
         assert any(f.rule == "destructive-remove-item" for f in decision.findings), cmd
 
 
+def test_host_power_and_system_control_commands_are_denied() -> None:
+    # These do not necessarily delete files, but they can crash, sleep, reboot,
+    # disconnect, or destabilize the host. They must never pass through a test
+    # harness as ordinary benchmark/setup commands.
+    cases = {
+        "shutdown /s /t 0": "system-power-state",
+        "Restart-Computer -Force": "system-power-state",
+        "powercfg /hibernate off": "powercfg-state-change",
+        "powercfg -h off": "powercfg-state-change",
+        "bcdedit /set hypervisorlaunchtype off": "system-disk-boot-tool",
+        "diskpart /s script.txt": "system-disk-boot-tool",
+        "format C: /q": "system-disk-boot-tool",
+        "Disable-NetAdapter -Name Wi-Fi -Confirm:$false": "network-adapter-control",
+        "netsh winsock reset": "network-adapter-control",
+        "wsl --shutdown": "wsl-shutdown",
+        "docker system prune -a -f": "docker-system-prune-all",
+        "taskkill /F /T /IM python.exe": "broad-taskkill",
+        "Stop-Process -Name node -Force": "broad-stop-process",
+        "stress-ng --cpu 8 --timeout 60s": "host-stress-loop",
+        "while ($true) { python bench.py }": "host-stress-loop",
+        "while true; do python bench.py; done": "host-stress-loop",
+    }
+    for cmd, rule in cases.items():
+        decision = scan_command(cmd)
+        assert decision.tier == "DENY", cmd
+        assert not decision.allowed, cmd
+        assert any(f.rule == rule for f in decision.findings), cmd
+
+
 def test_inline_interpreter_is_quarantine_not_deny() -> None:
     decision = scan_command(f"{sys.executable} -c \"print('ok')\"")
 

--- a/tests/smoke/test_npm_geoseal_bin.py
+++ b/tests/smoke/test_npm_geoseal_bin.py
@@ -77,6 +77,59 @@ def test_npm_geoseal_bin_permissions_json() -> None:
     assert payload["max_tier"]
 
 
+def test_npm_geoseal_command_check_blocks_host_control_commands() -> None:
+    cases = [
+        "shutdown /s /t 0",
+        "wsl --shutdown",
+        "powercfg /hibernate off",
+        "Disable-NetAdapter -Name Wi-Fi -Confirm:$false",
+        "docker system prune -a -f",
+        "taskkill /F /T /IM python.exe",
+        "while ($true) { python bench.py }",
+    ]
+    for command in cases:
+        proc = subprocess.run(
+            [
+                "node",
+                str(ROOT / "bin" / "geoseal.cjs"),
+                "command-check",
+                command,
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+            timeout=30,
+        )
+        assert proc.returncode == 2, command
+        payload = json.loads(proc.stdout)
+        assert payload["decision"] == "block", command
+        assert payload["safety"] == "refused", command
+        assert any("host" in reason.lower() for reason in payload["reasons"])
+
+
+def test_npm_geoseal_command_check_allows_normal_pytest() -> None:
+    proc = subprocess.run(
+        [
+            "node",
+            str(ROOT / "bin" / "geoseal.cjs"),
+            "command-check",
+            "python -m pytest tests\\crypto\\test_geoseal_execution_gate.py -q",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["decision"] == "allow"
+    assert payload["safety"] == "safe"
+
+
 def test_npm_geoseal_bin_doctor_uses_lightweight_python_module_probe() -> None:
     proc = subprocess.run(
         ["node", str(ROOT / "bin" / "geoseal.cjs"), "doctor", "--json"],
@@ -93,7 +146,9 @@ def test_npm_geoseal_bin_doctor_uses_lightweight_python_module_probe() -> None:
     assert str(ROOT / "src" / "geoseal_cli.py") in src_probe["origin"]
 
 
-def test_npm_geoseal_bin_service_status_is_not_python_passthrough(tmp_path: Path) -> None:
+def test_npm_geoseal_bin_service_status_is_not_python_passthrough(
+    tmp_path: Path,
+) -> None:
     env = dict(os.environ)
     env["SCBE_GEOSEAL_PYTHON"] = str(tmp_path / "missing-python.exe")
     proc = subprocess.run(
@@ -132,7 +187,13 @@ def test_npm_geoseal_bin_product_lanes_json() -> None:
     payload = json.loads(proc.stdout)
     assert payload["schema_version"] == "geoseal_product_lanes_v1"
     lane_ids = {lane["id"] for lane in payload["lanes"]}
-    assert {"agents", "providers", "chemistry", "tokenizer", "arrays-spreadsheets"} <= lane_ids
+    assert {
+        "agents",
+        "providers",
+        "chemistry",
+        "tokenizer",
+        "arrays-spreadsheets",
+    } <= lane_ids
 
 
 def test_npm_geoseal_bin_stage_renders_terminal_box() -> None:
@@ -389,11 +450,20 @@ def test_npm_geoseal_bin_provider_registry_json() -> None:
     assert payload["policy"]["default_route"] == "free_local_first"
 
 
-def test_npm_geoseal_bin_ask_alias_requires_local_service_when_not_running(tmp_path: Path) -> None:
+def test_npm_geoseal_bin_ask_alias_requires_local_service_when_not_running(
+    tmp_path: Path,
+) -> None:
     env = dict(os.environ)
     env["SCBE_GEOSEAL_SERVICE_DIR"] = str(tmp_path / "state")
     proc = subprocess.run(
-        ["node", str(ROOT / "bin" / "geoseal.cjs"), "ask", "explain", "tokenizer", "--json"],
+        [
+            "node",
+            str(ROOT / "bin" / "geoseal.cjs"),
+            "ask",
+            "explain",
+            "tokenizer",
+            "--json",
+        ],
         capture_output=True,
         text=True,
         encoding="utf-8",


### PR DESCRIPTION
﻿## What changed

- Cherry-picked the one-line `scbe bits` fix so `scbe.py bits <text>` no longer crashes with `KeyError: 'bits'`.
- Hardened GeoSeal command preflight against host-control commands that can destabilize a developer machine or test harness.
- Covered both execution surfaces:
  - Python execution gate: `src/crypto/geoseal_execution_gate.py`
  - Node CLI preflight: `bin/geoseal.cjs`
- Added regression tests for shutdown/restart, `powercfg`, boot/disk tools, network adapter controls, `wsl --shutdown`, Docker prune-all, broad process kills, and unbounded stress loops.

## Why

`origin/main` had the cube system and formatting PRs merged, but two real gaps remained:

- `python scbe.py bits "hi"` still crashed on main.
- `node bin/geoseal.cjs command-check "shutdown /s /t 0" --json` still returned `allow`.

That means a harness or agent could still pass host-level destructive/stability commands through the visible preflight path.

## Validation

Ran on the fresh branch from `origin/main`:

- `python scbe.py bits "hi"` -> `0110100001101001`
- `node bin/geoseal.cjs command-check "shutdown /s /t 0" --json` -> blocked
- `node bin/geoseal.cjs command-check "wsl --shutdown" --json` -> blocked
- `node -c bin/geoseal.cjs`
- `python -m pytest tests\smoke\test_npm_geoseal_bin.py tests\crypto\test_geoseal_execution_gate.py -q` -> 47 passed
- `python -m black --check --target-version py311 --line-length 120 src\crypto\geoseal_execution_gate.py tests\crypto\test_geoseal_execution_gate.py tests\smoke\test_npm_geoseal_bin.py`
- `python -m flake8 src\crypto\geoseal_execution_gate.py tests\crypto\test_geoseal_execution_gate.py tests\smoke\test_npm_geoseal_bin.py`
- `git diff --check`
