### PR TITLE
Standalone scbe CLI binaries (PyInstaller, win/linux/mac)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,75 @@
+name: build-binaries
+
+# Build the standalone `scbe` CLI as a single self-contained executable for
+# Windows / Linux / macOS (no Python install needed) and attach them to the
+# GitHub Release on a version tag. Also runnable on demand via workflow_dispatch,
+# which uploads the binaries as build artifacts.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: build ${{ matrix.asset }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: scbe-linux-x64
+          - os: windows-latest
+            asset: scbe-windows-x64.exe
+          - os: macos-latest
+            asset: scbe-macos-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade pip
+          # Minimal runtime deps the cube CLI needs (numpy for the geometric router,
+          # jsonschema for ingestion_rights validators), plus the bundler.
+          python -m pip install pyinstaller numpy jsonschema
+
+      - name: Build binary
+        run: pyinstaller scbe.spec
+
+      - name: Smoke test (the cube system must actually run)
+        shell: bash
+        run: |
+          BIN=dist/scbe
+          [ -f dist/scbe.exe ] && BIN=dist/scbe.exe
+          "$BIN" code "+ sqrt * inc"
+          "$BIN" think "+ sqrt *"
+          "$BIN" illuminate --gens 2 --batch 40
+          "$BIN" fold --fortune "+ * sqrt inc" --pick 4 3 2
+
+      - name: Stage asset
+        shell: bash
+        run: |
+          mkdir -p out
+          if [ -f dist/scbe.exe ]; then cp dist/scbe.exe "out/${{ matrix.asset }}"; else cp dist/scbe "out/${{ matrix.asset }}"; fi
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: out/${{ matrix.asset }}
+          if-no-files-found: error
+
+      - name: Attach to Release (on tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: out/${{ matrix.asset }}

--- a/scbe.spec
+++ b/scbe.spec
@@ -1,0 +1,51 @@
+# -*- mode: python ; coding: utf-8 -*-
+# PyInstaller spec for the standalone `scbe` CLI — one self-contained binary per
+# platform (no Python install needed).  Build:  pyinstaller scbe.spec
+# Bundles the data the cube system loads at import: the 18-language dialect table +
+# python/scbe data dir (collect_data_files) and the root schemas/ dir (ingestion_rights
+# validates against it at import). Cross-platform: datas are (src, dest) tuples.
+from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_submodules
+
+datas = [('schemas', 'schemas')]
+hiddenimports = []
+datas += collect_data_files('python.scbe')
+hiddenimports += collect_submodules('python.scbe')
+hiddenimports += collect_submodules('src.crypto')
+
+
+a = Analysis(
+    ['scbe.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=['matplotlib', 'torch', 'tensorflow'],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='scbe',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
Builds the `scbe` CLI as a single self-contained executable per platform so it can be **distributed as a downloadable binary — no Python install needed.** Branched off current `main`; **new files only**, so it merges clean.

## What it adds
- **`scbe.spec`** — PyInstaller build spec. Bundles the data the cube system loads at import: the 18-language dialect table + `python/scbe` data (`collect_data_files`), and the root `schemas/` dir (`ingestion_rights` validates against it at import). Cross-platform `(src, dest)` tuples — no path-separator issues.
- **`.github/workflows/build-binaries.yml`** — matrix build on `ubuntu-latest` / `windows-latest` / `macos-latest`:
  - installs minimal deps (`pyinstaller numpy jsonschema`),
  - runs `pyinstaller scbe.spec`,
  - **smoke-tests the frozen binary** (`scbe code` / `think` / `illuminate` / `fold` must run),
  - uploads each as a build artifact, and on a `v*.*.*` tag **attaches the executables to the GitHub Release**.

## Validation
Built and smoke-tested locally (Windows): the frozen `scbe.exe` runs the cube system end-to-end —
`scbe code "+ sqrt *"` renders the cube panel (`runs → 5.2915`), `scbe think "+ sqrt *"` localizes the divergence to `sqrt`.

## How to release binaries
Push a tag (e.g. `git tag v4.2.2 && git push --tags`) or run the workflow manually (`workflow_dispatch`). Three platform executables land on the Releases page / as artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)