### PR TITLE
Make pip install ship a working scbe CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ license = "MIT OR Apache-2.0"
 license-files = ["LICENSE", "LICENSE-APACHE"]
 requires-python = ">=3.11"
 dependencies = [
-    # Keep Dependabot's Python dependency graph on a patched uv release.
-    "uv>=0.11.17",
+    "numpy>=1.24",
+    "jsonschema>=4.0",
 ]
 authors = [
-    {name = "Issac Daniel Davis", email = "issdandavis@gmail.com"},
+    {name = "Issac Daniel Davis", email = "issdandavis@users.noreply.github.com"},
 ]
 keywords = [
     "cryptography",
@@ -56,39 +56,7 @@ scbe-system = "scripts.scbe_system_cli:main"
 scbe-convert-to-sft = "symphonic_cipher.scbe_aethermoore.convert_to_sft:main"
 scbe-code-prism = "code_prism.cli:main"
 
-[tool.setuptools]
-py-modules = ["scbe"]
-
-[tool.setuptools.packages.find]
-where = ["src"]
-include = [
-    "neurogolf*",
-    "scbe_aethermoore*",
-    "code_prism*",
-    "flow_router*",
-    "symphonic_cipher*",
-    "api*",
-    "crypto*",
-    "harmonic*",
-    "spiralverse*",
-    "minimal*",
-    "storage*",
-]
-exclude = [
-    "tests*",
-    "agents*",
-    "training*",
-    "scripts*",
-    # Test subpackages
-    "*.tests",
-    "*.tests.*",
-    # Excluded submodules
-    "api.github_app*",
-    "api.billing*",
-    "api.keys*",
-    "symphonic_cipher.geoseal*",
-]
-
-[tool.setuptools.package-dir]
-# Root-level package not under src/
-api = "api"
+# Package discovery is in setup.py — the mixed layout (src/ packages PLUS the
+# python/scbe engine imported as python.scbe) needs two find_packages calls, which a
+# single static packages.find can't express without name-colliding on the duplicate
+# root packages (symphonic_cipher/, api/).

--- a/python/scbe/ingestion_rights.py
+++ b/python/scbe/ingestion_rights.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import hashlib
 import json
 from datetime import UTC, datetime
@@ -14,12 +15,19 @@ RIGHTS_SCHEMA_PATH = REPO_ROOT / "schemas" / "ingestion_rights_record.schema.jso
 DEFAULT_SOURCE_REGISTRY_PATH = REPO_ROOT / "config" / "research" / "source_registry.json"
 
 
+@functools.lru_cache(maxsize=None)
 def _load_validator(path: Path) -> Draft202012Validator:
-    return Draft202012Validator(json.loads(path.read_text(encoding="utf-8")))
+    # Lazy: the schema files live at the repo root and may be absent in an installed
+    # wheel, so only read them when a validator is actually used — not at import time.
+    return Draft202012Validator(json.loads(Path(path).read_text(encoding="utf-8")))
 
 
-SOURCE_VALIDATOR = _load_validator(SOURCE_SCHEMA_PATH)
-RIGHTS_VALIDATOR = _load_validator(RIGHTS_SCHEMA_PATH)
+def __getattr__(name: str):  # PEP 562 — keep SOURCE_VALIDATOR / RIGHTS_VALIDATOR lazy
+    if name == "SOURCE_VALIDATOR":
+        return _load_validator(SOURCE_SCHEMA_PATH)
+    if name == "RIGHTS_VALIDATOR":
+        return _load_validator(RIGHTS_SCHEMA_PATH)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def load_source_registry(path: Path | None = None) -> List[Dict[str, Any]]:
@@ -28,7 +36,7 @@ def load_source_registry(path: Path | None = None) -> List[Dict[str, Any]]:
     if not isinstance(records, list):
         raise ValueError("Source registry must be a JSON array of source records")
     for record in records:
-        SOURCE_VALIDATOR.validate(record)
+        _load_validator(SOURCE_SCHEMA_PATH).validate(record)
     return records
 
 
@@ -136,5 +144,5 @@ def classify_ingestion_rights_record(
         "reviewed_at": datetime.now(UTC).isoformat() if reviewed_by else None,
         "reviewer_notes": reviewer_notes,
     }
-    RIGHTS_VALIDATOR.validate(rights_record)
+    _load_validator(RIGHTS_SCHEMA_PATH).validate(rights_record)
     return rights_record

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+"""Dynamic package discovery for the mixed src/ + python.scbe layout.
+
+Metadata, deps, and entry points live in pyproject.toml. This handles the one thing
+a static [tool.setuptools.packages.find] can't: ship BOTH the src-layout packages
+(installed by their bare name, e.g. `crypto`) AND the cube engine at python/scbe/
+(imported as `python.scbe`). A single find rooted at "." would name-collide with the
+duplicate root packages (symphonic_cipher/, api/), so we run two finds and merge.
+"""
+
+from setuptools import find_namespace_packages, find_packages, setup
+
+SRC_INCLUDE = [
+    "neurogolf*", "scbe_aethermoore*", "code_prism*", "flow_router*",
+    "symphonic_cipher*", "api*", "crypto*", "harmonic*", "spiralverse*",
+    "minimal*", "storage*",
+]
+SRC_EXCLUDE = [
+    "tests*", "agents*", "training*", "scripts*", "*.tests", "*.tests.*",
+    "api.github_app*", "api.billing*", "api.keys*", "symphonic_cipher.geoseal*",
+]
+
+# src-layout packages (installed by bare name, mapped back to src/)
+src_pkgs = find_packages("src", include=SRC_INCLUDE, exclude=SRC_EXCLUDE)
+# the cube engine — a namespace package so python/ needs no __init__.py; the tight
+# include keeps the root-package collisions out.
+engine_pkgs = find_namespace_packages(".", include=["python.scbe", "python.scbe.*"])
+
+package_dir = {p: "src/" + p.replace(".", "/") for p in src_pkgs}
+package_dir["python.scbe"] = "python/scbe"
+
+setup(
+    py_modules=["scbe"],                       # the CLI entry (scbe.py at repo root)
+    packages=src_pkgs + engine_pkgs,
+    package_dir=package_dir,
+    package_data={"python.scbe": ["*.json", "data/*"]},
+    include_package_data=True,
+)


### PR DESCRIPTION
`pip install scbe-aethermoore` now produces a `scbe` command that **runs** — verified by **building the wheel → installing it in a clean venv → running the cube commands** (the only proof that counts). Branched off `main`.

## Verified (installed-wheel, not repo)
```
$ scbe code "+ sqrt * inc"   → cube panel, runs → 6.2915
$ scbe think "+ sqrt *"      → diverged, localizes to sqrt
$ scbe illuminate ...        → 11 intuitive · 11 divergent
$ scbe fold ...              → flap 'inc' → 5.0
```

## Two blockers closed
1. **Wheel shipped neither `scbe.py` nor `python/scbe/`.** Moved package discovery to `setup.py` with a **dual find**: `find_packages("src", …)` for the src-layout packages *plus* `find_namespace_packages(".", include=["python.scbe*"])` for the engine. The namespace find dodges the duplicate-root-package collision (`symphonic_cipher/`, `api/`) that a single static `packages.find` hits. `polyglot_dialects.json` ships as `package_data`.
2. **`ingestion_rights` loaded its JSON schemas at import** via a repo-root path absent in a wheel → `FileNotFoundError`. Made the validators **lazy** (load on first use; PEP 562 `__getattr__` keeps `SOURCE_VALIDATOR`/`RIGHTS_VALIDATOR` working for importers).

Also: replaced the `uv` installer-hack in `dependencies` with the real runtime deps (`numpy`, `jsonschema`); gmail → noreply in author metadata.

Dev (`PYTHONPATH=. python scbe.py`) is unchanged and cube tests pass. New files / minimal edits only — merges clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)