### PR TITLE
Fix 7 broken polyglot faces; prove cross-language identity by execution

### DIFF
--- a/.github/workflows/polyglot-faces.yml
+++ b/.github/workflows/polyglot-faces.yml
@@ -1,0 +1,58 @@
+name: polyglot-faces
+
+# Proves the cross-language identity claim: emit every polyglot face, compile+run
+# it, and assert it computes the SAME number as the Python reference. The local
+# dev box only has python/node/rust; this job adds c, c++, go, ruby, php, lua,
+# haskell, zig, deno(ts) so the faces fixed without a local toolchain are verified
+# for real — and can never silently regress.
+
+on:
+  push:
+    paths:
+      - "python/scbe/polyglot.py"
+      - "python/scbe/polyglot_dialects.json"
+      - "tests/test_polyglot_execution.py"
+      - ".github/workflows/polyglot-faces.yml"
+  pull_request:
+    paths:
+      - "python/scbe/polyglot.py"
+      - "python/scbe/polyglot_dialects.json"
+      - "tests/test_polyglot_execution.py"
+      - ".github/workflows/polyglot-faces.yml"
+  workflow_dispatch:
+
+jobs:
+  faces:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python deps
+        run: pip install --quiet pytest numpy jsonschema
+
+      - name: Install language toolchains (c, c++, php, lua, haskell)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends lua5.4 ghc php-cli
+          # gcc, g++, go, ruby, node are preinstalled on the ubuntu runner.
+
+      - uses: mlugg/setup-zig@v1
+        with:
+          version: 0.13.0
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Report which faces will be executed
+        run: |
+          for t in python3 node gcc g++ go ruby php lua5.4 runghc zig deno javac; do
+            if command -v "$t" >/dev/null 2>&1; then echo "present: $t"; else echo "MISSING: $t (face will be skipped)"; fi
+          done
+
+      - name: Execute every installed polyglot face and assert identical output
+        run: python -m pytest tests/test_polyglot_execution.py -v

--- a/python/scbe/polyglot.py
+++ b/python/scbe/polyglot.py
@@ -71,8 +71,11 @@ class Dialect:
     func1: Dict[str, str]  # unary: "{a}" -> expr
     func2: Dict[str, str]  # binary: "{a}","{b}" -> expr
     binop_over: Dict[str, str] = field(default_factory=dict)  # op_name -> override operator
+    cmp_over: Dict[str, str] = field(default_factory=dict)  # cmp_name -> override (Lua "~=", Haskell "/=")
     cmp_tmpl: str = "(1.0 if {cond} else 0.0)"  # ternary keeping number stack
     main_tmpl: Tuple[str, ...] = ()  # optional runnable main(); {fn} placeholder
+    var_a: str = "a"  # temp-var name the push expr uses; sigil langs override (PHP: "$a")
+    var_b: str = "b"  # second-operand temp-var name; must match what pop2 binds
 
 
 def _ternary(d: Dialect) -> str:
@@ -89,25 +92,29 @@ def _ternary(d: Dialect) -> str:
 # language so traffic routes around instead of crashing (py raises / js NaN).
 #   div/mod by zero -> 0.0 ;  sqrt of negative -> 0.0
 def _render(name: str, d: Dialect, safe: bool = False) -> Tuple[str, bool]:
-    """Return (push-expression using temp vars a/b, is_binary)."""
+    """Return (push-expression using the dialect's temp var names, is_binary)."""
+    va, vb = d.var_a, d.var_b  # "a"/"b" everywhere except sigil langs (PHP: "$a"/"$b")
     if name in BINOPS:
         op = d.binop_over.get(name, BINOPS[name])
-        expr = f"a {op} b"
+        expr = f"{va} {op} {vb}"
         if safe and name == "div":
-            expr = _sub(_ternary(d), cond="b == 0.0", t="0.0", f="a / b")
+            expr = _sub(_ternary(d), cond=f"{vb} == 0.0", t="0.0", f=f"{va} / {vb}")
         return expr, True
     if name in CMPS:
-        op = CMPS[name]
-        return _sub(d.cmp_tmpl, cond=f"a {op} b"), True
+        # NOTE: `round` (FUNC1) intentionally uses each language's native rounding —
+        # Python is round-half-to-even, JS round-half-up, Rust round-half-away — so faces
+        # can diverge on exact .5 values. Tracked as a known divergence, not yet unified.
+        op = d.cmp_over.get(name, CMPS[name])
+        return _sub(d.cmp_tmpl, cond=f"{va} {op} {vb}"), True
     if name in FUNC2:
-        expr = _sub(d.func2[name], a="a", b="b")
+        expr = _sub(d.func2[name], a=va, b=vb)
         if safe and name == "mod":
-            expr = _sub(_ternary(d), cond="b == 0.0", t="0.0", f=expr)
+            expr = _sub(_ternary(d), cond=f"{vb} == 0.0", t="0.0", f=expr)
         return expr, True
     if name in FUNC1:
-        expr = _sub(d.func1[name], a="a")
+        expr = _sub(d.func1[name], a=va)
         if safe and name == "sqrt":
-            expr = _sub(_ternary(d), cond="a < 0.0", t="0.0", f=expr)
+            expr = _sub(_ternary(d), cond=f"{va} < 0.0", t="0.0", f=expr)
         return expr, False
     raise KeyError(f"op {name!r} not in v1 scalar core")
 
@@ -265,7 +272,7 @@ register(
         },
         func2={"pow": "pow({a}, {b})", "min": "cmin({a}, {b})", "max": "cmax({a}, {b})", "mod": "fmod({a}, {b})"},
         cmp_tmpl="(({cond}) ? 1.0 : 0.0)",
-        main_tmpl=("int main(void) {", '    printf("%g\\n", {fn}(2.0, 3.0, 4.0));', "    return 0;", "}"),
+        main_tmpl=("int main(void) {", '    printf("%.17g\\n", {fn}(2.0, 3.0, 4.0));', "    return 0;", "}"),
     )
 )
 

--- a/python/scbe/polyglot_dialects.json
+++ b/python/scbe/polyglot_dialects.json
@@ -87,7 +87,9 @@
    "#include <iostream>",
    "#include <cmath>",
    "#include <vector>",
-   "#include <algorithm>"
+   "#include <algorithm>",
+   "#include <charconv>",
+   "#include <string>"
   ],
   "fn_open": "double {fn}(double a0, double b0, double c0) {",
   "stack_init": "std::vector<double> s; s.push_back(a0); s.push_back(b0); s.push_back(c0);",
@@ -117,7 +119,8 @@
   "cmp_tmpl": "(({cond}) ? 1.0 : 0.0)",
   "main_tmpl": [
    "int main() {",
-   "    std::cout << {fn}(2.0, 3.0, 4.0) << std::endl;",
+   "    char _b[32]; auto _r = std::to_chars(_b, _b + sizeof(_b), {fn}(2.0, 3.0, 4.0));",
+   "    std::cout << std::string(_b, _r.ptr) << \"\\n\";",
    "    return 0;",
    "}"
   ],
@@ -344,7 +347,8 @@
   "comment": "//",
   "indent": "    ",
   "prelude": [
-   "<?php"
+   "<?php",
+   "ini_set('precision', -1);"
   ],
   "fn_open": "function {fn}($a0, $b0, $c0) {",
   "stack_init": "$s = array($a0, $b0, $c0);",
@@ -375,7 +379,9 @@
   "main_tmpl": [
    "echo {fn}(2.0, 3.0, 4.0), \"\\n\";"
   ],
-  "binop_over": {}
+  "binop_over": {},
+  "var_a": "$a",
+  "var_b": "$b"
  },
  {
   "name": "lua",
@@ -412,7 +418,10 @@
   "main_tmpl": [
    "print({fn}(2.0, 3.0, 4.0))"
   ],
-  "binop_over": {}
+  "binop_over": {},
+  "cmp_over": {
+   "neq": "~="
+  }
  },
  {
   "name": "scala",
@@ -532,7 +541,10 @@
   "main_tmpl": [
    "main :: IO ()",
    "main = print ({fn} 2.0 3.0 4.0)"
-  ]
+  ],
+  "cmp_over": {
+   "neq": "/="
+  }
  },
  {
   "name": "zig",
@@ -565,7 +577,7 @@
    "pow": "std.math.pow(f64, {a}, {b})",
    "min": "@min({a}, {b})",
    "max": "@max({a}, {b})",
-   "mod": "@rem({a}, {b})"
+   "mod": "@mod({a}, {b})"
   },
   "cmp_tmpl": "(if ({cond}) @as(f64, 1.0) else @as(f64, 0.0))",
   "binop_over": {},

--- a/tests/test_polyglot_execution.py
+++ b/tests/test_polyglot_execution.py
@@ -1,0 +1,231 @@
+"""Cross-language identity PROOF: emit each face, compile+run it, and assert it
+computes the SAME number as the Python reference.
+
+The old test only checked that ``emit()`` does not raise — so a face could emit
+code that does not compile or computes the wrong value and still pass (this is how
+the PHP face shipped emitting bare ``a``/``b`` instead of ``$a``/``$b``). This test
+actually executes the emitted source. Faces whose compiler/runtime is not installed
+on the current machine are SKIPPED, not failed, so the suite is green locally with
+only python/node/rustc and gets stronger as CI adds toolchains.
+"""
+
+import math
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+from python.scbe import polyglot as P
+
+INPUTS = (2.0, 3.0, 4.0)
+
+
+class _NoTool(Exception):
+    """Raised by a runner when its toolchain is absent -> the case is skipped."""
+
+
+def _which(*names: str):
+    for n in names:
+        p = shutil.which(n)
+        if p:
+            return p
+    return None
+
+
+def _run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=180, **kw)
+
+
+def _last_number(stdout: str) -> float:
+    return float(stdout.strip().splitlines()[-1])
+
+
+def _write(td: str, name: str, src: str) -> str:
+    path = os.path.join(td, name)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(src)
+    return path
+
+
+# --- per-language compile+run -------------------------------------------------
+def _interp(tool_names, fname):
+    def run(src, td):
+        exe = _which(*tool_names)
+        if not exe:
+            raise _NoTool(tool_names[0])
+        path = _write(td, fname, src)
+        r = _run([exe, path])
+        if r.returncode:
+            raise RuntimeError(f"{tool_names[0]} failed:\n{r.stderr or r.stdout}")
+        return _last_number(r.stdout)
+
+    return run
+
+
+def _compiled(tool_names, fname, compile_argv, run_argv):
+    def run(src, td):
+        cc = _which(*tool_names)
+        if not cc:
+            raise _NoTool(tool_names[0])
+        src_path = _write(td, fname, src)
+        exe = os.path.join(td, "face.exe")
+        rc = _run([cc] + compile_argv(src_path, exe, td))
+        if rc.returncode:
+            raise RuntimeError(f"{tool_names[0]} compile failed:\n{rc.stderr or rc.stdout}")
+        rr = _run(run_argv(exe, td))
+        if rr.returncode:
+            raise RuntimeError(f"run failed:\n{rr.stderr or rr.stdout}")
+        return _last_number(rr.stdout)
+
+    return run
+
+
+def _java(src, td):
+    if not (_which("javac") and _which("java")):
+        raise _NoTool("javac")
+    _write(td, "Main.java", src)  # public class Main -> filename must match
+    rc = _run([_which("javac"), os.path.join(td, "Main.java")])
+    if rc.returncode:
+        raise RuntimeError(f"javac failed:\n{rc.stderr}")
+    rr = _run([_which("java"), "-cp", td, "Main"])
+    if rr.returncode:
+        raise RuntimeError(f"java run failed:\n{rr.stderr}")
+    return _last_number(rr.stdout)
+
+
+def _kotlin(src, td):
+    if not (_which("kotlinc") and _which("java")):
+        raise _NoTool("kotlinc")
+    kt = _write(td, "face.kt", src)
+    jar = os.path.join(td, "face.jar")
+    rc = _run([_which("kotlinc"), kt, "-include-runtime", "-d", jar])
+    if rc.returncode:
+        raise RuntimeError(f"kotlinc failed:\n{rc.stderr}")
+    rr = _run([_which("java"), "-jar", jar])
+    if rr.returncode:
+        raise RuntimeError(f"kotlin run failed:\n{rr.stderr}")
+    return _last_number(rr.stdout)
+
+
+RUNNERS = {
+    "javascript": _interp(["node"], "face.js"),
+    "typescript": _interp(["deno"], "face.ts"),  # deno runs .ts directly
+    "ruby": _interp(["ruby"], "face.rb"),
+    "php": _interp(["php"], "face.php"),
+    "lua": _interp(["lua", "lua5.4", "lua5.3", "luajit"], "face.lua"),
+    "julia": _interp(["julia"], "face.jl"),
+    "haskell": _interp(["runghc", "runhaskell"], "face.hs"),
+    "swift": _interp(["swift"], "face.swift"),
+    "rust": _compiled(
+        ["rustc"], "face.rs",
+        lambda s, e, td: ["-O", "-o", e, s],
+        lambda e, td: [e],
+    ),
+    "c": _compiled(
+        ["gcc", "clang", "cc"], "face.c",
+        lambda s, e, td: [s, "-O2", "-lm", "-o", e],
+        lambda e, td: [e],
+    ),
+    "cpp": _compiled(
+        ["g++", "clang++"], "face.cpp",
+        lambda s, e, td: [s, "-O2", "-o", e],
+        lambda e, td: [e],
+    ),
+    "go": _compiled(
+        ["go"], "face.go",
+        lambda s, e, td: ["build", "-o", e, s],
+        lambda e, td: [e],
+    ),
+    "zig": _interp(["zig"], "face.zig"),  # handled specially below via 'run'
+    "java": _java,
+    "kotlin": _kotlin,
+}
+
+
+def _zig(src, td):
+    exe = _which("zig")
+    if not exe:
+        raise _NoTool("zig")
+    path = _write(td, "face.zig", src)
+    r = _run([exe, "run", path])
+    if r.returncode:
+        raise RuntimeError(f"zig failed:\n{r.stderr or r.stdout}")
+    return _last_number(r.stdout)
+
+
+RUNNERS["zig"] = _zig
+
+# Languages we can actually execute on THIS machine (others -> not collected).
+_AVAILABLE = sorted(
+    lang for lang in RUNNERS
+    if _which(*{
+        "javascript": ("node",), "typescript": ("deno",), "ruby": ("ruby",),
+        "php": ("php",), "lua": ("lua", "lua5.4", "lua5.3", "luajit"),
+        "julia": ("julia",), "haskell": ("runghc", "runhaskell"),
+        "swift": ("swift",), "rust": ("rustc",), "c": ("gcc", "clang", "cc"),
+        "cpp": ("g++", "clang++"), "go": ("go",), "zig": ("zig",),
+        "java": ("javac",), "kotlin": ("kotlinc",),
+    }[lang])
+)
+
+
+def _programs():
+    """Every scalar op exercised at least once, plus chains that actually TAKE the
+    div-by-zero and sqrt-of-negative roundabout branches."""
+    progs = [(op, [op]) for op in sorted(P.SCALAR_OPS)]
+    progs += [
+        ("chain_mix", ["add", "mul", "sqrt", "inc"]),
+        ("chain_unary", ["neg", "abs", "dec"]),
+        ("chain_cmp", ["lt", "add"]),
+        ("roundabout_div0", ["eq", "div"]),  # 3==4 -> 0.0 ; 2 / 0.0 -> 0.0
+        ("roundabout_sqrtneg", ["sub", "sqrt"]),  # 3-4 -> -1 ; sqrt(-1) -> 0.0
+    ]
+    return progs
+
+
+def _ref(prog) -> float:
+    src = P.emit(P.program_bytes(*prog), "python", safe=True)
+    ns: dict = {}
+    exec(compile(src, "ref.py", "exec"), ns)  # noqa: S102 - test oracle
+    return ns["tongue_fn"](*INPUTS)
+
+
+PROGRAMS = _programs()
+
+
+def test_at_least_python_runs():
+    """Sanity floor: the oracle itself must produce the known value."""
+    assert math.isclose(_ref(["add", "mul", "sqrt", "inc"]), 4.741657386773941, rel_tol=1e-12)
+
+
+@pytest.mark.parametrize("lang", _AVAILABLE)
+@pytest.mark.parametrize("prog_id,prog", PROGRAMS, ids=[p[0] for p in PROGRAMS])
+def test_face_executes_identically(lang, prog_id, prog):
+    """Each installed face must compute the same number as the Python reference."""
+    ref = _ref(prog)
+    src = P.emit(P.program_bytes(*prog), lang, runnable=True, safe=True)
+    td = tempfile.mkdtemp(prefix=f"face_{lang}_")
+    try:
+        try:
+            val = RUNNERS[lang](src, td)
+        except _NoTool as exc:  # pragma: no cover - filtered by _AVAILABLE
+            pytest.skip(f"{lang}: toolchain {exc} not installed")
+        # Faces now print full round-trip precision, so require near-exact agreement
+        # (1e-9), not a loose display tolerance — this is the real identity proof.
+        assert math.isclose(val, ref, rel_tol=1e-9, abs_tol=1e-12), (
+            f"{lang} face of {prog} produced {val}, reference is {ref}\n--- emitted ---\n{src}"
+        )
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+
+
+def test_emit_var_binding_invariant():
+    """Static guard for the PHP-class bug: the temp-var names the push expression
+    uses MUST be the names pop2/pop1 bind. Catches a broken face even with no
+    toolchain present."""
+    for lang in P.languages():
+        d = P.REGISTRY[lang]
+        assert d.var_a in d.pop2 and d.var_b in d.pop2, f"{lang}: pop2 does not bind {d.var_a!r}/{d.var_b!r}"
+        assert d.var_a in d.pop1, f"{lang}: pop1 does not bind {d.var_a!r}"


### PR DESCRIPTION
## What this fixes

The \"identical across 18 languages\" claim was **unverified** — the only test checked that `emit()` doesn't raise, and never executed the non-Python faces. A strict 18-language audit (compile+run where a toolchain exists, independent expert review otherwise, with an adversarial verify pass that rejected the csharp/kotlin/scala false alarms) found **7 faces that did not actually work**:

| Face | Bug | Effect |
|------|-----|--------|
| **php** | emitted bare `a + b` instead of `$a + $b` | undefined constants → wrong/error |
| **lua** | `neq` → `!=` | **Lua syntax error** (needs `~=`) |
| **haskell** | `neq` → `!=` | does not compile (needs `/=`) |
| **zig** | `mod` → `@rem` | wrong sign for negative operands (needs `@mod`) |
| **c** | print `%g` | 6 sig-figs, truncates the value |
| **cpp** | `std::cout` default | 6 sig-figs, truncates the value |
| **php** | default `precision=14` | truncated output |

## How it's fixed

- **`Dialect.var_a`/`var_b`** — the push expression now uses the temp-var names `pop2`/`pop1` actually bind (PHP → `$a`/`$b`); every other face keeps `a`/`b`.
- **`Dialect.cmp_over`** (mirrors the existing `binop_over`) — per-dialect comparison operators: lua `neq`→`~=`, haskell `neq`→`/=`.
- zig `mod`→`@mod`; c print→`%.17g`; cpp print→`std::to_chars` (shortest round-trip); php→`ini_set('precision', -1)`.

## How it's proven (this is the important part)

`tests/test_polyglot_execution.py` emits every face, **compiles + runs** the ones whose toolchain is installed, and asserts the **same number as the Python reference** (`rel_tol 1e-9` — a real identity proof, not a loose display tolerance). It exercises all 22 scalar ops plus chains that actually take the div-by-zero and sqrt-of-negative roundabout branches.

- Locally (python/node/rust) → **115 polyglot tests pass**.
- New **`polyglot-faces` CI job** installs c, c++, go, ruby, php, lua, haskell, zig, deno(ts) so the faces fixed *without* a local toolchain are verified for real on every change.
- A structural-invariant test catches the PHP-class bug (expr vars must match bound vars) even with **no** toolchain present.

## Known divergence (documented, not silently \"fixed\")

`round` uses each language's native mode — round-half-to-even (Python) vs half-up (JS) vs half-away (Rust) — so faces can differ on exact `.5` values. Flagged in-code and here rather than rewriting 15 untestable faces and hoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive cross-language testing to validate consistent behavior across all supported programming languages.

* **Improvements**
  * Enhanced numerical precision in generated code output for more accurate calculations.
  * Improved handling of language-specific operators and syntax variations.

* **Chores**
  * Updated configuration for C++, PHP, Lua, Haskell, and Zig language backends to ensure compatibility with latest language features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->