### PR TITLE
chore(lineup): bring the last 4 unique artifacts onto main

### DIFF
--- a/articles/SHOW_HN_materials_bench.md
+++ b/articles/SHOW_HN_materials_bench.md
@@ -1,0 +1,69 @@
+# Show HN launch kit — AI Materials Bench
+
+Post on a weekday morning US-Eastern (Tue–Thu ~8–10am ET tends to do best). No URL in the
+title. Post the "first comment" immediately yourself. Reply to every comment fast, and never
+ask for upvotes.
+
+---
+
+## Title
+```
+Show HN: Materials Bench – type a coil/tube build, get physics + BOM, in-browser
+```
+
+## URL
+```
+<your live demo URL — e.g. https://aethermoore.com/ai-materials-bench>
+```
+
+## Text (the post body)
+
+I built a small tool that turns a plain build description — a fiber/coil/tube concept — into
+a first-pass engineering concept report. You type something like "quartz tube, copper
+micro-winding, ferrite flux guide," set a few numbers, and it returns:
+
+- conductor-aware physics: coil resistance, solenoid field, power, skin depth, optical NA
+  (the numbers actually change if you say silver vs copper vs aluminum — it's not a label)
+- a costed bill of materials with a price range
+- a safety envelope: operating voltage, and the max continuous current that keeps the coil
+  inside a 5 W bench-thermal budget
+- a measurement test plan with target values
+- a downloadable .md report with a provenance receipt
+
+The part I care about: it runs **100% in your browser**. No signup, no account, no backend.
+The physics is ~200 lines of plain JS you can read in devtools — every number comes from an
+explicit formula, not an LLM black box. It works offline and on a static host.
+
+Honest about what it is: these are first-pass estimates. The field math is an ideal-solenoid
+model, so real coils read lower; the BOM is rough hobbyist pricing, not quotes; nothing here
+replaces real engineering or a current-limited bench test. It's meant to get you from "vague
+idea" to "buildable first sketch with a parts list," fast.
+
+I'm a solo builder and I'd genuinely like to be told where the physics is wrong — that's the
+feedback I want most.
+
+## First comment (post this yourself, right after submitting)
+
+Context on the "why": I've been building a pile of "AI tool" front ends and got tired of
+demos that return vague hand-waving you can't check or act on. So the rule for this one was:
+every output has to be a real number from a real formula, inspectable and exportable — and
+the demo can't require a signup or a server, because a demo that 404s or gates you is worse
+than no demo.
+
+It's deliberately client-side and boring under the hood — there's no model call in the demo
+path at all. Open devtools and you can read the whole engine. Please tear the physics apart,
+especially the solenoid-field estimate and the skin-depth calc; I want to know what I got
+wrong before anyone builds off it.
+
+---
+
+## Notes before you post
+- **Fill the URL** with wherever you deploy it (the page is static + client-side, so GitHub
+  Pages or any host works — it won't 404 or gate the demo).
+- **The honesty is the strategy.** The "ideal-solenoid, real coils read lower / BOM is rough
+  / not a substitute for engineering" lines aren't hedging — on HN they're trust. Keep them.
+- **Be there for the first 2 hours.** Answer every technical comment plainly; if someone
+  finds a physics bug, thank them and say you'll fix it (then fix it — that thread becomes
+  your best advertisement).
+- Cross-post the same thing to r/AskElectronics or r/diyelectronics afterward; that's closer
+  to this tool's actual audience than HN's core.

--- a/docs/SYSTEMS_CATALOG.md
+++ b/docs/SYSTEMS_CATALOG.md
@@ -1,0 +1,60 @@
+# SCBE-AETHERMOORE — Systems Catalog
+
+A curated map of the systems in this project. The **9 canonical engine systems** are the
+authoritative inventory emitted by `scbe systems` (run it for the live list); the families
+around them are the larger surfaces built on top. Not exhaustive — the engine alone ships
+~59 modules under `python/scbe/`.
+
+_Verified 2026-06-16: `scbe -V` → `scbe 4.2.1`; CLI smoke green; wheel installs + runs._
+
+## Core engine — the 9 canonical systems (`scbe systems`)
+
+| System | What it is | Path | Commands |
+|---|---|---|---|
+| **bit_spine** | byte-exact binary/hex/trit + tiny Turing-machine substrate | `python/scbe/bit_spine.py` | `bits` `hex` `trits` `inc` |
+| **sacred_tongues** | bijective six-tongue byte tokenization (the "keyboard") | `scbe.py` | `enc` `dec` `map` |
+| **atomic_tokenization** | semantic element mapping → 6-channel trit state | `python/scbe/atomic_tokenization.py` | `chem atomize` `map` |
+| **chemical_fusion** | atomic-state fusion, tau_hat reconstruction, edge tension, valence pressure | `python/scbe/chemical_fusion.py` | `chem atomize` `map` |
+| **chemistry_command_stack** | reversible semantic chemistry command primitives | `src/tokenizer/chemistry_command_stack.py` | `map` |
+| **atomic_workflow_units** | role/resource/valence/structural workflow units | `src/tokenizer/atomic_workflow_units.py` | `map` |
+| **tongue_code_lanes** | tongue→code-lane contract + mismatch classification | `python/scbe/tongue_code_lanes.py` | `map` |
+| **ast_cube** | Python AST → cube-token vector matrix | `python/scbe/ast_cube_encoder.py` | `encode-code` `stereo` |
+| **rust_ast_cube_hot_loop** | Rust AST encoder hot loop + binary transport | `rust/ast_cube` | `encode` |
+
+## Families built around the engine
+
+- **Cube system** — `cube_token` (one core, many faces), `cube_faces` (7 faces:
+  bits/chemistry/roles/audio/code/governance/wolfram), `wolfram_face` (256 elementary-CA
+  rules → 256 token values), `tongue_roles`.
+- **Geometry / routing** — `geometric_router` (Finsler / Poincaré-ball cost),
+  `geometric_scheduler` (streaming + M4 multi-model fleet), `fleet_models`, `board.py`
+  (reversible address), `torus.py` (periodic locality + wormhole seams, Q₆), `poly_mountain`
+  (Z3-gated route packet).
+- **Governance / safety** — **GeoSeal** execution gate (pre-exec policy, fail-closed,
+  HMAC-sealed audit), `blocks.py` (Scratch-style destructive double-check),
+  `block-destructive.ps1` (machine-wide AI-terminal guard).
+- **Polyglot / codegen** — `polyglot.py` (18-language emitter from one CA-opcode core),
+  `frontdoor.py` (Sacred-Tongue keyboard round-trip), **CodeCube** (`geoseal code-cube`,
+  incl. `--target manifold` twist schedule).
+
+## Product & delivery layer
+
+- **CLIs** — `scbe` (Python, ~30 commands, pip-installable, **v4.2.1**) ·
+  `geoseal` + `scbe-patent` + `scbe-scan` (Node, npm bins).
+- **Web / product** — landing `docs/index.html` + labs: **ai-materials-bench** (flagship,
+  runs 100% in-browser, no signup), `ai-chemistry-set`, `ai-waves-lab`, `atomic-lab`,
+  `geoseal-hermes`.
+- **Packaging** — PyPI (`numpy` core + extras `[crypto] [api] [science] [browser] [net]
+  [dev] [all]`) · npm (`publishConfig` provenance).
+
+## Research & infrastructure
+
+- **Benchmarking** — `scripts/benchmarks/encoder_bench.py`,
+  `research/benchmarks/benchmarking-reference.md` + `score-template.json`, `rust/parse_bench`,
+  the **corridor-test** design (`research/benchmarks/coordination-test.md`), the Kaggle
+  kernel builder (`scripts/kaggle/build_encoder_kernel.py`).
+- **Research docs** — `research/aether-manifold/` (fluidic-computer design + rotation
+  algebra), `research/marketing/playbook.md`, `articles/` (build-in-public posts).
+
+---
+_Regenerate the canonical list anytime with `scbe systems` (or `scbe systems --json`)._

--- a/research/marketing/playbook.md
+++ b/research/marketing/playbook.md
@@ -1,0 +1,78 @@
+# Marketing playbook — solo, $0 budget, time-rich
+
+**Situation:** one builder, no ad budget, runway (time > money), a deep pile of built work,
+no audience yet. The bottleneck is **distribution, not building.** This is the plan that
+fits that exact shape. Sources at the bottom; numbers are industry figures, not promises.
+
+## The one principle
+
+**Distribution is product-agnostic, so start it now — before the product is even picked.**
+An audience is portable across everything you might ship. With time and no money, the move
+is to run distribution as a *background process* the whole time you build, so that when you
+do have something to sell, people already trust you. Build-in-public shortens the gap between
+*discovery* and *trust* — which is the gap that actually costs money to cross.
+
+## Channel mix (all $0)
+
+| Channel | Why it works here | Cadence |
+|---|---|---|
+| **Build-in-public** (X/dev.to + your `issdandavis.github.io` devlog) | turns the thing you already do (build) into the marketing; honesty compounds into trust | 1 honest post/week |
+| **Open-source the core** (GitHub) | open-source dev tools grow ~8× faster than closed; the repo *is* a landing page | ongoing |
+| **Show HN** (Hacker News) when a tool is demo-ready | dev-tool Show HN posts average ~800 signups in the first 24h | once per real launch |
+| **Niche communities** (r/rust, r/SideProject, relevant Discords) | answer questions value-first, link only in profile bio; trust → profile clicks → signups | 20 min/day |
+| **Owned newsletter** (beehiiv/substack, free tier) | the only audience a platform can't take from you | start at ~50 subs |
+
+Avoid: paid ads (no budget, no product-market fit yet), cold-DM spam (low trust, your time
+is better spent on content that compounds).
+
+## The honesty edge (your unfair advantage)
+
+The market is saturated with "100× AI" hype nobody believes. You just published *"I tested
+my own 109× claim, it was really 4.5×, here's the receipt."* That post is the strategy in a
+nutshell: **radical honesty is the cheapest trust you can manufacture, and almost no one does
+it.** Every benchmark, every "this didn't work," every real number — that's content that
+makes the right people believe you. Lean into it as the brand voice.
+
+## Realistic timeline (so you don't quit at week 3)
+
+- **Content/SEO payoff:** 4–6 months. It's a slow compounder, not a faucet.
+- **First 1,000 users:** achievable in ~60 days *if* you combine build-in-public + a Show HN
+  launch + open-source — not from one post.
+- **$0 → ~$10k MRR:** the realistic indie figure is ~6 months *with* consistent distribution,
+  and most of that is the distribution, not the code.
+- Tooling cost to run all this: **$0–$500/mo** (domain, free-tier email/analytics, Stripe's
+  per-transaction only). You already have the domain and the site.
+
+## Landing-page rules (applied to docs/index.html)
+
+From the conversion research, applied to the surface:
+- **Value clear in ~10 seconds, above the fold.** Visitors leave in 10–20s; say what it does
+  and for whom immediately. (Done: hero now says "type a task in, get a working output.")
+- **One primary CTA.** Single-CTA pages convert ~13.5% vs ~10.5% for 5+. (Done: one dominant
+  "Try a live tool — no signup," secondary demoted.)
+- **Low friction beats clever.** "No signup" on the CTA removes the #1 objection.
+- **Interactive demo above the fold** is a defining trait of high-converting dev pages — and
+  your labs *are* interactive. Drive straight into the live tool.
+- **Dark mode** suits the developer ICP (already there).
+- **Pricing transparency** as a trust signal (pricing cards already present).
+
+## The 30-day starter (do this, in order)
+
+1. **Publish post #1** (the honest 109× story, already drafted) to the devlog + cross-post to
+   dev.to and an X thread. This is the first turn of the engine.
+2. **Pick ONE tool** to be the public face (the live, interactive one — Atomic Lab or
+   Materials Bench) and make sure its demo runs flawlessly with no signup.
+3. **Open-source that tool's core** cleanly (README that *is* a pitch, one-line "try it").
+4. **Post weekly** — alternate "here's what I built/learned" and "here's a real number."
+   Keep the honesty; it's the differentiator.
+5. **20 min/day** in one niche community, answering, never pitching, link in bio.
+6. When the demo is genuinely solid → **Show HN** with the honest framing.
+7. Add a one-field **email capture** to the site so traffic becomes an owned list.
+
+The goal of month 1 isn't revenue — it's the first 100 people who believe you. Revenue is a
+lagging indicator of that trust.
+
+## Sources
+- [Zero-budget user acquisition playbook](https://padezhnov.com/en/blog/zero-budget-user-acquisition-for-solo-founders-a-developers-playbook/) · [Solo-founder SaaS metrics / timelines](https://www.softwareseni.com/solo-founder-saas-metrics-from-0-to-10k-mrr-in-6-months-with-realistic-timelines/)
+- [Dev tool first 1000 users](https://revenuefast.in/grow/developer-tool-first-1000-users) · [Complete developer marketing guide 2026](https://www.strategicnerds.com/blog/the-complete-developer-marketing-guide-2026) · [Build-in-public strategies](https://www.builtthisweek.com/blog/build-in-public-strategies)
+- [SaaS landing page best practices 2026](https://smartclick.agency/blog/saas-landing-page-best-practices/) · [Why most SaaS landing pages fail](https://www.pravinkumar.co/blog/saas-landing-page-conversion-strategies-2026)

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,47 @@
+"""Regression: the `scbe` version flag must print the package version and exit 0,
+and must NEVER route into the AI/catalog/default-command path.
+
+A version flag that emits a system overview is the exact "feels unprofessional"
+bug this guards against.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+EXPECTED = "4.2.1"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "scbe.py", *args],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_version_short_flag() -> None:
+    result = _run("-V")
+    assert result.returncode == 0
+    assert EXPECTED in result.stdout
+    # must short-circuit, not fall through to the assistant / `systems` catalog path
+    assert "tongue" not in result.stdout.lower()
+    assert "system" not in result.stdout.lower()
+
+
+def test_version_long_flag() -> None:
+    result = _run("--version")
+    assert result.returncode == 0
+    assert EXPECTED in result.stdout
+
+
+def test_version_constant_matches() -> None:
+    if str(REPO) not in sys.path:
+        sys.path.insert(0, str(REPO))
+    import scbe
+
+    assert scbe.VERSION == EXPECTED


### PR DESCRIPTION
Reconciliation against `main` (the source of truth). Nearly all of this session's work
already landed on main via #2253–#2260; this closes the only remaining gap — **4 files**
that weren't on main yet — as **1 clean commit off `origin/main`, zero conflicts**.

- `docs/SYSTEMS_CATALOG.md` — curated systems catalog (9 canonical engine systems + families)
- `tests/test_cli_version.py` — regression guard: `scbe -V/--version` print 4.2.1, exit 0, never route into the assistant/catalog path
- `research/marketing/playbook.md` — solo/$0 go-to-market playbook
- `articles/SHOW_HN_materials_bench.md` — Show HN launch kit

No code paths touched; docs + one test. After merge, `main` holds 100% of the session's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)