### PR TITLE
Make Dependabot watch every nested manifest (fix monorepo coverage)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,52 +1,65 @@
 # Dependabot configuration for SCBE-AETHERMOORE
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# This is a monorepo: ~25 Python manifests and ~15 npm lockfiles live in nested
+# sub-apps (packages/*, apps/*, game/*, conference-app, examples/*, ...). The old
+# config used singular `directory: "/"` (root only) plus an `exclude-paths:` key
+# that Dependabot does not recognize, so the nested lockfiles were never watched —
+# their advisories just sat open. `directories: ["/**"]` watches every manifest
+# recursively; `groups` batches the bumps so we get a few PRs per ecosystem, not
+# dozens. Vendored / archived lanes are excluded with `!` negation globs.
 version: 2
 updates:
-  # Python dependencies
+  # ── Python (every manifest, recursively) ──────────────────────────────────
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/**"
+      - "!/archive/**"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "security"
+    groups:
+      pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      pip-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
-  # NPM dependencies (main)
+  # ── npm (every manifest, recursively, minus vendored / submodule lanes) ───
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/**"
+      - "!/external/**"
+      - "!/external_repos/**"
+      - "!/archive/**"
+      - "!/spiralverse-protocol/**"
+      - "!/aws-lambda-simple-web-app/**"
+      - "!/hioujhn/**"
+      - "!/scbe-aethermoore/**"
+      - "!/packages/six-tongues-geoseal/**"
     schedule:
       interval: "weekly"
-    exclude-paths:
-      # These are vendored or submodule lanes. Dependabot's recursive checkout can
-      # leave them dirty after root npm security updates, which turns a useful
-      # advisory check into a red background run.
-      - "external/**"
-      - "external_repos/**"
-      - "spiralverse-protocol/**"
-      - "aws-lambda-simple-web-app/**"
-      - "hioujhn/**"
-      - "scbe-aethermoore/**"
-      - "packages/six-tongues-geoseal/**"
-      - "archive/**"
-      - "archive/test-install/**"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "security"
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      npm-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
-  # NPM dependencies (visual system)
-  - package-ecosystem: "npm"
-    directory: "/scbe-visual-system"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "security"
-
-  # Dev containers
+  # ── Dev containers ────────────────────────────────────────────────────────
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:


### PR DESCRIPTION
## The real bug: Dependabot was only watching the repo root

50 advisories sat open not because the code is unpatched, but because `dependabot.yml` couldn't see most of the manifests:

- it used singular **`directory: "/"`** (root only), and
- an **`exclude-paths:`** key that Dependabot doesn't recognize (silently ignored).

So the ~12 nested npm lockfiles (`packages/cli`, `game/spiral-engine`, `apps/mobile/pwa`, `apps/aether-desktop/shell`, `conference-app`, `services/scbe-shim`, …) and `examples/SCBEAgent/uv.lock` were **never watched** → no update PRs ever opened.

## Fix

- `pip` + `npm` now use **`directories: ["/**"]`** — watch every manifest recursively — with `!` negation globs for vendored / archived / submodule lanes.
- **`groups`** (security + version) batch the bumps into a few PRs per ecosystem instead of dozens.

## Honest triage of the 50 alerts

| group | count | reality |
|-------|-------|---------|
| **pip** (cryptography, starlette, python-multipart, pyjwt) | ~19 | **Already remediated in-tree.** `requirements.txt` pins `starlette>=1.3.1`, `python-multipart>=0.0.32`, `cryptography>=48.0.1`, `PyJWT==2.13.0` — all ≥ each advisory's first-patched version. These are stale (one even mis-points at the word "cryptography" in `[project] keywords`). They clear on dependency-graph refresh. |
| **npm** (vite, esbuild, hono, …) | ~31 | **Dev-dependencies** (build tools) in sub-apps — exploitable during local `npm run dev`, not in shipped artifacts. This coverage fix lets Dependabot bump them safely (it tests each in its own PR; hand-bumping 12 lockfiles blind would be riskier). |

## To actually open the fix PRs now

This config enables scheduled version updates. To also have GitHub open **security** PRs for the existing backlog immediately, enable Dependabot security updates (repo setting):

```bash
gh api -X PUT /repos/issdandavis/SCBE-AETHERMOORE/automated-security-fixes
# undo: gh api -X DELETE /repos/issdandavis/SCBE-AETHERMOORE/automated-security-fixes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management automation configuration to improve coverage consistency across the repository and streamline dependency update notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->