### PR TITLE
feat: mirror-hallway divergence view, rubix-cubit primitive, forced show-thinking mode

### DIFF
--- a/python/scbe/rubix_cubit.py
+++ b/python/scbe/rubix_cubit.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""rubix_cubit.py
+
+Deterministic 4D CodeCube / Tesseract / Rubix-Cubit primitive.
+
+- CodeCube : a software planning cube (the idea).
+- Tesseract: 4D state container, 16 vertices in {-1, +1}^4.
+- Rubix    : twist operations = controlled, auditable transforms.
+- Cubit    : the smallest addressable code-state unit (one tesseract vertex).
+
+Concretely:
+- 16 vertices of a tesseract: coordinates in {-1, +1}^4.
+- 8 cubic cells / faces: x+, x-, y+, y-, z+, z-, w+, w- (a vertex belongs to four).
+- A "cubit" is one addressable code-state unit at a tesseract vertex.
+- A "twist" is a signed coordinate-plane rotation (a quarter turn maps (a, b) -> (-b, a));
+  because coordinates are only +/-1, every twist is an exact permutation of vertices.
+- A "receipt" is the SHA-256 of the canonical cubit state — it proves exact state.
+
+This is a software planning / governance primitive, not a physics claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any, Dict, Iterable, List, Literal, Tuple
+
+Axis = Literal["x", "y", "z", "w"]
+Sign = Literal[-1, 1]
+Coord4 = Tuple[int, int, int, int]
+
+AXES: Tuple[Axis, ...] = ("x", "y", "z", "w")
+AXIS_INDEX: Dict[Axis, int] = {"x": 0, "y": 1, "z": 2, "w": 3}
+
+
+@dataclass(frozen=True)
+class Cubit:
+    """One code-addressable unit at a tesseract vertex.
+
+    coord:   one of the 16 tesseract vertices, e.g. (-1, +1, -1, +1)
+    face:    the cell label this vertex sits on (frontend/backend/tests/deploy/core)
+    payload: the content attached to this cubit (a task, a spec fragment, ...)
+    role:    governance role for this cubit (e.g. empty, builder, verifier, gate)
+    """
+
+    coord: Coord4
+    face: str
+    payload: str
+    role: str
+
+    def canonical(self) -> Dict[str, Any]:
+        return {
+            "coord": list(self.coord),
+            "face": self.face,
+            "payload": self.payload,
+            "role": self.role,
+        }
+
+
+class TesseractRubixCubit:
+    """A 4D state container of 16 cubits.
+
+    The important part:
+    - geometry gives deterministic addressing (each cubit has an exact vertex),
+    - twists give auditable transformations (signed-coordinate rotations / permutations),
+    - receipts prove exact state (a hash anyone can recompute).
+    """
+
+    def __init__(self, cubits: Iterable[Cubit] | None = None) -> None:
+        self.cubits: Dict[Coord4, Cubit] = {}
+        if cubits is None:
+            for coord in self.vertices():
+                self.cubits[coord] = Cubit(
+                    coord=coord,
+                    face=self.cell_name(coord),
+                    payload="",
+                    role="empty",
+                )
+        else:
+            for cubit in cubits:
+                self.cubits[cubit.coord] = cubit
+            missing = set(self.vertices()) - set(self.cubits)
+            if missing:
+                raise ValueError(f"missing cubits for coordinates: {sorted(missing)}")
+
+    @staticmethod
+    def vertices() -> List[Coord4]:
+        out: List[Coord4] = []
+        for x in (-1, 1):
+            for y in (-1, 1):
+                for z in (-1, 1):
+                    for w in (-1, 1):
+                        out.append((x, y, z, w))
+        return out
+
+    @staticmethod
+    def cell_name(coord: Coord4) -> str:
+        """A simple, deterministic default face/cell label for a vertex."""
+        x, y, z, w = coord
+        if w == 1:
+            return "deploy"
+        if z == 1:
+            return "tests"
+        if y == 1:
+            return "backend"
+        if x == 1:
+            return "frontend"
+        return "core"
+
+    def set_cubit(self, coord: Coord4, *, payload: str, role: str) -> "TesseractRubixCubit":
+        """Attach content/role to a vertex (returns self for chaining)."""
+        if coord not in self.cubits:
+            raise KeyError(f"not a tesseract vertex: {coord}")
+        old = self.cubits[coord]
+        self.cubits[coord] = Cubit(coord=coord, face=old.face, payload=payload, role=role)
+        return self
+
+    def to_dict(self) -> Dict[str, Any]:
+        ordered = [self.cubits[c].canonical() for c in sorted(self.cubits)]
+        return {
+            "schema": "tesseract_rubix_cubit_v1",
+            "vertices": 16,
+            "axes": list(AXES),
+            "cubits": ordered,
+        }
+
+    def receipt(self) -> str:
+        blob = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+        return sha256(blob.encode("utf-8")).hexdigest()
+
+    def twist(
+        self,
+        plane: Tuple[Axis, Axis],
+        *,
+        layer_axis: Axis | None = None,
+        layer_sign: Sign | None = None,
+        turns: int = 1,
+    ) -> "TesseractRubixCubit":
+        """Rotate cubits in a coordinate plane and return a NEW container.
+
+        A quarter turn in plane (a, b) maps (coord[a], coord[b]) -> (-coord[b], coord[a]).
+        Because coordinates are only +/-1, every twist is an exact permutation, so:
+          - 4 quarter turns in the same plane = identity,
+          - the inverse of `turns` is `-turns` (mod 4).
+
+        Optionally restrict the twist to one layer: only cubits whose `layer_axis`
+        coordinate equals `layer_sign` are rotated; the rest stay put.
+        """
+        a, b = plane
+        if a == b:
+            raise ValueError("plane axes must be different")
+        if a not in AXIS_INDEX or b not in AXIS_INDEX:
+            raise ValueError(f"plane axes must be in {AXES}, got {plane!r}")
+        turns %= 4
+        if turns == 0:
+            return TesseractRubixCubit(self.cubits.values())
+
+        ai, bi = AXIS_INDEX[a], AXIS_INDEX[b]
+        layer_i = AXIS_INDEX[layer_axis] if layer_axis is not None else None
+
+        moved: Dict[Coord4, Cubit] = {}
+        for coord, cubit in self.cubits.items():
+            in_layer = layer_i is None or coord[layer_i] == layer_sign
+            if not in_layer:
+                moved[coord] = cubit
+                continue
+            new = list(coord)
+            for _ in range(turns):
+                va, vb = new[ai], new[bi]
+                new[ai], new[bi] = -vb, va
+            new_coord: Coord4 = (new[0], new[1], new[2], new[3])
+            moved[new_coord] = Cubit(
+                coord=new_coord,
+                face=self.cell_name(new_coord),
+                payload=cubit.payload,
+                role=cubit.role,
+            )
+        return TesseractRubixCubit(moved.values())
+
+
+def _demo() -> int:
+    cube = TesseractRubixCubit()
+    cube.set_cubit((1, 1, 1, 1), payload="ship the release", role="gate")
+    cube.set_cubit((-1, -1, -1, -1), payload="core invariant", role="verifier")
+    before = cube.receipt()
+    twisted = cube.twist(("x", "y"))
+    once = twisted.receipt()
+    full = cube.twist(("x", "y"), turns=4).receipt()
+    print(f"vertices            : {len(cube.cubits)}")
+    print(f"receipt (start)     : {before}")
+    print(f"receipt (1 twist)   : {once}")
+    print(f"1 twist changed it  : {once != before}")
+    print(f"4 twists == identity: {full == before}")
+    return 0
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Tesseract Rubix-Cubit: 4D code-state cube")
+    parser.add_argument("--twist", help="comma plane, e.g. x,y", default=None)
+    parser.add_argument("--turns", type=int, default=1)
+    parser.add_argument("--layer-axis", default=None)
+    parser.add_argument("--layer-sign", type=int, choices=[-1, 1], default=None)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args(argv)
+
+    if args.twist is None and not args.as_json:
+        return _demo()
+
+    cube = TesseractRubixCubit()
+    if args.twist:
+        a, b = (s.strip() for s in args.twist.split(","))
+        cube = cube.twist((a, b), layer_axis=args.layer_axis, layer_sign=args.layer_sign, turns=args.turns)
+    if args.as_json:
+        print(json.dumps({"receipt": cube.receipt(), **cube.to_dict()}, indent=2))
+    else:
+        print(cube.receipt())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scbe.py
+++ b/scbe.py
@@ -2408,20 +2408,53 @@ def _ask_ollama(prompt: str, model: Optional[str]) -> str:
     return _run_backend_cli(["ollama", "run", model or "llama3.2", prompt])
 
 
-def _ask_api(prompt: str, model: Optional[str], provider: str) -> str:
+# Forced "show thinking" mode (2026 API). Adaptive thinking is the supported
+# mechanism (budget_tokens is rejected on Opus 4.7/4.8). display:"summarized" is
+# REQUIRED to actually surface reasoning on the latest models, where thinking.display
+# defaults to "omitted" (the thinking field comes back empty). See:
+# https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+THINK_EFFORT = "high"
+
+
+def _anthropic_body(prompt: str, model: Optional[str], think: bool) -> Dict[str, Any]:
+    body: Dict[str, Any] = {
+        "model": model or "claude-sonnet-4-6",
+        "max_tokens": 8000 if think else 1024,  # thinking shares the max_tokens budget
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if think:
+        body["thinking"] = {"type": "adaptive", "display": "summarized"}
+        body["output_config"] = {"effort": THINK_EFFORT}
+    return body
+
+
+def _anthropic_extract(data: Dict[str, Any], think: bool) -> str:
+    content = data.get("content", [])
+    answer = "".join(b.get("text", "") for b in content if b.get("type") == "text").strip()
+    if not think:
+        return answer
+    thinking = "\n".join(
+        b.get("thinking", "") for b in content
+        if b.get("type") == "thinking" and b.get("thinking")
+    ).strip()
+    if thinking:
+        return f"[thinking]\n{thinking}\n\n[answer]\n{answer}"
+    return f"[thinking: none surfaced - model answered directly]\n\n{answer}"
+
+
+def _ask_api(prompt: str, model: Optional[str], provider: str, think: bool = False) -> str:
     import urllib.request
     if provider == "anthropic":
-        body = {"model": model or "claude-sonnet-4-6", "max_tokens": 1024,
-                "messages": [{"role": "user", "content": prompt}]}
+        body = _anthropic_body(prompt, model, think)
         req = urllib.request.Request(
             "https://api.anthropic.com/v1/messages",
             data=json.dumps(body).encode(),
             headers={"x-api-key": os.environ["ANTHROPIC_API_KEY"],
                      "anthropic-version": "2023-06-01", "content-type": "application/json"})
         try:
-            with urllib.request.urlopen(req, timeout=120) as resp:
+            with urllib.request.urlopen(req, timeout=180) as resp:
                 data = json.loads(resp.read())
-            return "".join(b.get("text", "") for b in data.get("content", [])).strip()
+            return _anthropic_extract(data, think)
         except Exception as e:  # network/auth errors shouldn't crash the CLI
             return f"(anthropic API error: {e})"
     if provider == "openai":
@@ -2442,7 +2475,7 @@ def _ask_api(prompt: str, model: Optional[str], provider: str) -> str:
 
 
 def ai_ask(prompt: str, backend: Optional[str] = None,
-           model: Optional[str] = None) -> Tuple[str, str]:
+           model: Optional[str] = None, think: bool = False) -> Tuple[str, str]:
     """Return (answer, backend_used). Picks the first available backend."""
     available = _detect_backends()
     if not available:
@@ -2461,7 +2494,7 @@ def ai_ask(prompt: str, backend: Optional[str] = None,
         return _ask_codex(prompt, model), chosen
     if chosen == "ollama":
         return _ask_ollama(prompt, model), chosen
-    return _ask_api(prompt, model, chosen), chosen
+    return _ask_api(prompt, model, chosen, think=think), chosen
 
 
 def _render_history(history: List[Tuple[str, str]], new_q: str) -> str:
@@ -2489,7 +2522,7 @@ def cmd_ask(args: argparse.Namespace) -> int:
         return 2
     # ask = explain, never act — wrap so agentic backends just answer.
     answer, backend = ai_ask(_ANSWER_ONLY + prompt, getattr(args, "backend", None),
-                             getattr(args, "model", None))
+                             getattr(args, "model", None), think=getattr(args, "think", False))
     if getattr(args, "json_output", False):
         print(json.dumps({"prompt": prompt, "backend": backend, "answer": answer}))
     else:
@@ -3273,6 +3306,8 @@ Legacy (backward compat):
     ak.add_argument("--backend", choices=list(AI_BACKENDS), help="force a backend (default: auto)")
     ak.add_argument("--model", help="model name for the chosen backend")
     ak.add_argument("--json", dest="json_output", action="store_true")
+    ak.add_argument("--think", action="store_true",
+                    help="force adaptive thinking and SHOW the reasoning (anthropic backend)")
     ak.set_defaults(func=cmd_ask)
 
     ch = sub.add_parser("chat", help="Interactive AI chat with memory (any available model)")

--- a/scripts/polyglot_divergence.py
+++ b/scripts/polyglot_divergence.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""The mirror hallway, made inspectable.
+
+One CA-opcode blueprint -> every language face -> run them all -> show where they
+agree and where they diverge. Because the blueprint is held constant, any
+difference is the LANGUAGE, not the intent.
+
+Reuses the proven per-language runners from tests/test_polyglot_execution.py, so
+"how to run a face" has a single source of truth. Faces whose toolchain isn't
+installed locally are marked ABSENT (they're verified on the polyglot-faces CI job).
+
+Honest scope: the emitter's runnable `main` calls the function with fixed inputs
+(2, 3, 4). Some documented seams (e.g. round-on-exact-.5, modulo sign) only appear
+with inputs the current emitter can't supply, so they show as ABSENT-here / CI, not
+DIVERGE. What this proves at fixed inputs: cross-build/ship conformance — does the
+identical blueprint build and run to the same number in every available language.
+
+Usage:
+    python scripts/polyglot_divergence.py            # table
+    python scripts/polyglot_divergence.py --json     # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import python.scbe.polyglot as P  # noqa: E402
+from tests.test_polyglot_execution import RUNNERS, _AVAILABLE  # noqa: E402
+
+PROGRAMS = [(op, [op]) for op in sorted(P.SCALAR_OPS)] + [
+    ("chain_mix", ["add", "mul", "sqrt", "inc"]),
+    ("roundabout_div0", ["eq", "div"]),
+    ("roundabout_sqrtneg", ["sub", "sqrt"]),
+    ("neg_then_mod", ["sub", "mod"]),  # reaches a negative operand: probes mod-sign
+]
+
+
+def ref_value(prog: list[str]) -> float:
+    src = P.emit(P.program_bytes(*prog), "python", runnable=False, safe=True)
+    ns: dict = {}
+    exec(compile(src, "ref.py", "exec"), ns)  # noqa: S102 - local oracle
+    return float(ns["tongue_fn"](2.0, 3.0, 4.0))
+
+
+def run_lang(lang: str, prog: list[str]) -> float:
+    src = P.emit(P.program_bytes(*prog), lang, runnable=True, safe=True)
+    with tempfile.TemporaryDirectory() as td:
+        return RUNNERS[lang](src, td)
+
+
+def reason_for(ops: list[str]) -> str:
+    s = set(ops)
+    if "round" in s:
+        return "native rounding (banker's vs half-up)"
+    if "mod" in s:
+        return "modulo sign on negative operands"
+    if "div" in s:
+        return "float division / divide-by-zero handling"
+    if "pow" in s:
+        return "pow precision / domain"
+    return "language-intrinsic numeric behavior"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", action="store_true", dest="as_json")
+    ap.add_argument("--tol", type=float, default=1e-9)
+    args = ap.parse_args()
+
+    langs = list(_AVAILABLE)
+    all_langs = sorted(RUNNERS)
+    absent = [x for x in all_langs if x not in langs]
+
+    rows = []
+    n_agree = n_div = n_fail = 0
+    divergences = []
+    for name, prog in PROGRAMS:
+        ref = ref_value(prog)
+        cells = {}
+        for lang in langs:
+            try:
+                v = run_lang(lang, prog)
+                if (abs(v - ref) <= args.tol) or (math.isnan(v) and math.isnan(ref)):
+                    cells[lang] = {"status": "agree", "value": v}
+                    n_agree += 1
+                else:
+                    cells[lang] = {"status": "DIVERGE", "value": v}
+                    n_div += 1
+                    divergences.append({"program": name, "lang": lang, "value": v, "ref": ref, "reason": reason_for(prog)})
+            except Exception as exc:  # build/run failure = a real ship problem
+                cells[lang] = {"status": "BUILDFAIL", "detail": str(exc).splitlines()[0][:70]}
+                n_fail += 1
+        rows.append({"program": name, "ops": prog, "ref": ref, "cells": cells})
+
+    summary = {
+        "available_languages": langs,
+        "absent_languages": absent,
+        "programs": len(PROGRAMS),
+        "agree": n_agree,
+        "diverge": n_div,
+        "buildfail": n_fail,
+    }
+
+    if args.as_json:
+        print(json.dumps({"summary": summary, "rows": rows, "divergences": divergences}, indent=2))
+        return 0
+
+    print("MIRROR HALLWAY — polyglot divergence view (inputs fixed at 2,3,4)")
+    print(f"available faces: {', '.join(langs) or '(none)'}")
+    print(f"absent here (CI proves these): {', '.join(absent) or '(none)'}\n")
+    header = f"{'program':<20} {'ref':>12}  per-language"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        marks = []
+        for lang in langs:
+            c = r["cells"][lang]
+            tag = {"agree": "ok", "DIVERGE": "DIVERGE", "BUILDFAIL": "BUILD-FAIL"}[c["status"]]
+            marks.append(f"{lang}:{tag}")
+        print(f"{r['program']:<20} {r['ref']:>12.6g}  {'  '.join(marks)}")
+    print()
+    print(f"SUMMARY  programs={summary['programs']}  faces={len(langs)}  "
+          f"agree={n_agree}  diverge={n_div}  build-fail={n_fail}")
+    if divergences:
+        print("\nDIVERGENCES (language-intrinsic, intent held constant):")
+        for d in divergences:
+            print(f"  {d['program']:<18} {d['lang']:<10} got {d['value']!r} vs ref {d['ref']!r}  — {d['reason']}")
+    else:
+        print("\nNo divergence at fixed inputs — every available face builds, runs, and agrees.")
+        print("Documented seams (round-on-.5, mod-sign) need inputs the emitter's fixed main")
+        print("can't supply yet; that's a known limit, not a pass.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ai_think_mode.py
+++ b/tests/test_ai_think_mode.py
@@ -1,0 +1,52 @@
+"""Forced 'show thinking' mode for `scbe ask --think`.
+
+Tested without a live API call: the request-body builder and the response parser
+are pure functions. This proves (a) think=True forces adaptive thinking with
+display:summarized + effort (the 2026 mechanism — budget_tokens is rejected on
+Opus 4.7/4.8 and thinking.display defaults to "omitted"), and (b) the parser
+surfaces the reasoning instead of dropping it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import scbe  # noqa: E402
+
+
+def test_body_without_think_is_plain() -> None:
+    body = scbe._anthropic_body("hi", None, think=False)
+    assert "thinking" not in body
+    assert "output_config" not in body
+    assert body["max_tokens"] == 1024
+
+
+def test_body_with_think_forces_visible_adaptive_thinking() -> None:
+    body = scbe._anthropic_body("hi", None, think=True)
+    # adaptive (not budget_tokens) + display:summarized is what makes reasoning VISIBLE
+    assert body["thinking"] == {"type": "adaptive", "display": "summarized"}
+    assert body["output_config"]["effort"] == "high"
+    assert body["max_tokens"] > 1024  # thinking shares the budget; needs room
+
+
+def test_extract_without_think_returns_answer_only() -> None:
+    data = {"content": [{"type": "thinking", "thinking": "secret"}, {"type": "text", "text": "42"}]}
+    assert scbe._anthropic_extract(data, think=False) == "42"
+
+
+def test_extract_with_think_surfaces_reasoning() -> None:
+    data = {"content": [{"type": "thinking", "thinking": "step 1; step 2"}, {"type": "text", "text": "42"}]}
+    out = scbe._anthropic_extract(data, think=True)
+    assert "[thinking]" in out and "step 1; step 2" in out and "42" in out
+
+
+def test_extract_with_think_handles_omitted_empty_thinking() -> None:
+    # Latest models default display:"omitted" -> thinking block present but empty.
+    data = {"content": [{"type": "thinking", "thinking": ""}, {"type": "text", "text": "42"}]}
+    out = scbe._anthropic_extract(data, think=True)
+    assert "42" in out and "none surfaced" in out

--- a/tests/test_rubix_cubit.py
+++ b/tests/test_rubix_cubit.py
@@ -1,0 +1,57 @@
+"""Prove the Rubix-Cubit geometry: twists are exact permutations, receipts are
+deterministic, and a full turn is the identity."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from python.scbe.rubix_cubit import TesseractRubixCubit  # noqa: E402
+
+
+def test_sixteen_distinct_vertices() -> None:
+    cube = TesseractRubixCubit()
+    assert len(cube.cubits) == 16
+    assert len(set(cube.cubits)) == 16
+    assert all(all(c in (-1, 1) for c in coord) for coord in cube.cubits)
+
+
+def test_receipt_is_deterministic() -> None:
+    assert TesseractRubixCubit().receipt() == TesseractRubixCubit().receipt()
+
+
+def test_one_twist_changes_state() -> None:
+    cube = TesseractRubixCubit().set_cubit((1, 1, 1, 1), payload="x", role="gate")
+    assert cube.twist(("x", "y")).receipt() != cube.receipt()
+
+
+def test_four_quarter_turns_is_identity() -> None:
+    cube = TesseractRubixCubit().set_cubit((1, 1, 1, 1), payload="x", role="gate")
+    assert cube.twist(("x", "y"), turns=4).receipt() == cube.receipt()
+
+
+def test_twist_is_a_permutation() -> None:
+    cube = TesseractRubixCubit()
+    twisted = cube.twist(("z", "w"))
+    assert set(twisted.cubits) == set(cube.cubits)  # same 16 vertices, rearranged
+    assert len(twisted.cubits) == 16
+
+
+def test_inverse_twist_restores() -> None:
+    cube = TesseractRubixCubit().set_cubit((-1, 1, -1, 1), payload="p", role="verifier")
+    once = cube.twist(("x", "w"), turns=1)
+    back = once.twist(("x", "w"), turns=3)  # -1 mod 4
+    assert back.receipt() == cube.receipt()
+
+
+def test_layer_twist_leaves_other_layer_fixed() -> None:
+    cube = TesseractRubixCubit()
+    twisted = cube.twist(("x", "y"), layer_axis="w", layer_sign=1)
+    # w=-1 cubits must be untouched (same coord -> same face/payload/role)
+    for coord, cubit in cube.cubits.items():
+        if coord[3] == -1:
+            assert twisted.cubits[coord] == cubit


### PR DESCRIPTION
Three small, tested features off `main`. Docs/tooling + one CLI flag; no existing code paths changed destructively.

**1. Mirror-hallway divergence view** (`scripts/polyglot_divergence.py`)
Runs one CA-opcode blueprint through every available language face (reusing the proven `RUNNERS`) and shows a grid: agree / DIVERGE(reason) / BUILD-FAIL / toolchain-ABSENT. Because intent is held constant, any difference is language-intrinsic. Honest scope: emitter inputs are fixed (2,3,4) → proves cross-build/ship conformance here; seams needing custom inputs (round-on-.5) are flagged not-reachable, not passed. Local run (js+rust): 26 programs, 0 diverge, 0 build-fail.

**2. Rubix-Cubit primitive** (`python/scbe/rubix_cubit.py` + 7 tests)
CodeCube(planning)/Tesseract(16-vertex 4D container)/Rubix(twist transforms)/Cubit(smallest addressable unit). Software-core, not physics. Twist = signed coordinate-plane quarter turn `(a,b)→(-b,a)`; coords are ±1 so every twist is an exact permutation (4 turns = identity, invertible mod 4). `receipt()` = sha256 of canonical state. Tests prove permutation/identity/inverse/determinism/layer-fixed.

**3. `scbe ask --think` — forced show-thinking mode** (+ 5 tests)
Research-grounded on the 2026 API: `budget_tokens` is rejected on Opus 4.7/4.8; adaptive thinking + `effort` is the mechanism, and `display:"summarized"` is required to surface reasoning (defaults to `"omitted"`). Sets `thinking:{type:adaptive,display:summarized}` + `effort:high` + larger `max_tokens`, and renders `[thinking] … [answer]`. Pure helpers → unit-tested without a live call.

All tests pass locally; `scbe.py` parses; authors noreply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)