### PR TITLE
fix main code defects + feat: 'scbe octree' command browser

### DIFF
--- a/scbe.py
+++ b/scbe.py
@@ -46,7 +46,18 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-VERSION = "2.0.0"
+def _resolve_version() -> str:
+    # Single source of truth: the installed package metadata (pyproject = 4.2.1).
+    # Falls back to the literal when running from a source tree that isn't installed.
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        return _pkg_version("scbe-aethermoore")
+    except Exception:
+        return "4.2.1"
+
+
+VERSION = _resolve_version()
 REPO_ROOT = Path(__file__).resolve().parent
 FORWARDED_SYSTEM_COMMANDS = {
     "pollypad": ["pollypad"],

--- a/src/coding_spine/router.py
+++ b/src/coding_spine/router.py
@@ -35,7 +35,7 @@ _python_path = str(_repo_root / "python")
 if _python_path not in sys.path:
     sys.path.insert(0, _python_path)
 
-from scbe.atomic_tokenization import (
+from python.scbe.atomic_tokenization import (
     TONGUES,
     AtomicTokenState,
     map_token_to_atomic_state,


### PR DESCRIPTION
Real, verified code fixes to `main` — found by an adversarial audit, then **each claim re-verified by execution** before shipping (no docs, no false positives).

## Fixes (4)

| # | File | Defect | Fix |
|---|------|--------|-----|
| 1 | `src/coding_spine/router.py` | `from scbe.atomic_tokenization` resolved `scbe` to the root **module** not the `python/scbe` **package** → `ModuleNotFoundError: 'scbe' is not a package`, **aborting pytest collection** for every test importing the router | use canonical `from python.scbe.atomic_tokenization` |
| 2 | `scbe.py` | hardcoded `VERSION='2.0.0'`, drifted from `4.2.1` in pyproject | derive from `importlib.metadata` with `'4.2.1'` fallback → `scbe -V` prints `4.2.1` |
| 3 | `src/harmonic/__init__.py` (new) | no `__init__.py` → `find_packages('src', include=['harmonic*'])` skipped it → `pip install .` wouldn't ship `harmonic.*` | add package marker (find_packages now discovers it; dev imports unaffected) |
| 4 | `src/aaoe/ephemeral_prompt.py` | `is_expired` used strict `>`; a `ttl=0` nudge checked within one clock tick read as not-expired → `test_nudge_expiry` **fails deterministically on Windows** (~15ms `time.time()` resolution) | use `>=` (ttl=0 == expired now; platform-independent) |

## Verification (by execution, not assertion)
- `router import OK`; `scbe -V` → `scbe 4.2.1`
- Test collection no longer errors: **1697 passed / 44 skipped** (the lone failure, `test_agent_router_coding_smoke_passes`, needs gitignored HuggingFace training data — pre-existing/environmental)
- `find_packages('src', include=['harmonic*'])` → `harmonic discovered: True`; **261 harmonic-importing tests pass**
- `test_aaoe.py` **65/65** (was 1 failed)

## Audit false positives caught (NOT changed)
- `setup_assistant.py:574` `from scbe.ai_orchestration` — inside a triple-quoted **help-message string**, not executed code
- `governance.runtime_gate`, `crypto.sacred_tongues`, `crypto.dual_lattice` — all resolve fine (`src/` on path, `__init__.py` present)
- `hydra.switchboard` 'broken test' — `test_hallpass.py` is **already module-skipped** (missing `skill_card_forge`), so the import never runs

## Deferred (needs a design decision, not a blind fix)
- `src/api/__init__.py`: there's **also a root `api/` package** (where `metering.py` lives). Adding `src/api/__init__.py` could shadow it and **break** `from api.metering`. The api packaging needs a real decision (consolidate root vs src api/), so I left it untouched rather than ship a risky change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)