### PR TITLE
docs(monetization): publish supporter launch links

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Neither Python nor npm package requires a server, API key, or external network c
 - Hosted run intake: [aethermoore.com/SCBE-AETHERMOORE/hosted-run.html](https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html)
 - Service credits: [aethermoore.com/SCBE-AETHERMOORE/service-credits.html](https://aethermoore.com/SCBE-AETHERMOORE/service-credits.html)
 - Credit top-up: [Ko-fi / izdandavis](https://ko-fi.com/izdandavis)
+- Monthly support: [Stripe $20/month](https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i) or [support page](https://aethermoore.com/SCBE-AETHERMOORE/supporter.html)
+- Direct manual support: Cash App `$IzzyDDavis7`
 
 Service credits are pay-as-you-go: billable provider/model usage is passed through with a 2–5% SCBE coordination fee. No subscription required to use the open-source packages.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -65,7 +65,8 @@ Low-cost path:
 - $5+ service credits.
 - Ko-fi support and service-credit path: https://ko-fi.com/izdandavis.
 - Cash App manual payment: $IzzyDDavis7.
-- $20/month supporter path.
+- $20/month AetherMoore Supporter checkout: https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i.
+- AetherMoore support page with all payment paths: https://aethermoore.com/SCBE-AETHERMOORE/supporter.html.
 - $29 Toolkit.
 - $29 Training Vault.
 - Bookshelf with current Amazon/KDP status: https://aethermoore.com/SCBE-AETHERMOORE/books.html

--- a/docs/marketing/SUPPORTER_LAUNCH_POST_2026-06-16.md
+++ b/docs/marketing/SUPPORTER_LAUNCH_POST_2026-06-16.md
@@ -1,0 +1,59 @@
+# AetherMoore Supporter Launch Post
+
+## Short Post
+
+I opened a simple monthly support lane for SCBE-AETHERMOORE.
+
+The public stack stays free to inspect and run locally: the package, docs, demos, governance notes, and benchmark work are still open. The supporter tier is for people who want the work to keep moving and want a low-friction way to back cleanup, packaging, docs, delivery fixes, and new operator notes.
+
+Supporter: $20/month through Stripe  
+https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i
+
+Support page:  
+https://aethermoore.com/SCBE-AETHERMOORE/supporter.html
+
+One-time/direct paths are still available too:
+
+- Ko-fi: https://ko-fi.com/izdandavis
+- Cash App: $IzzyDDavis7
+
+Use the free repo first. If it helps, support keeps the build moving.
+
+## X / Bluesky Thread
+
+1/ I opened a simple support lane for SCBE-AETHERMOORE.
+
+The stack stays free to inspect and run locally. The supporter tier is just a clean way to back the work if the public docs, packages, demos, and governance tools are useful.
+
+2/ Supporter is $20/month through Stripe:  
+https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i
+
+Support page:  
+https://aethermoore.com/SCBE-AETHERMOORE/supporter.html
+
+3/ What it funds: cleanup, packaging, delivery fixes, benchmark runs, operator notes, decision records, and turning messy research into usable docs.
+
+4/ One-time support paths:
+
+Ko-fi: https://ko-fi.com/izdandavis  
+Cash App: $IzzyDDavis7
+
+Free repo first. Support only if the work is useful.
+
+## Direct Message
+
+I opened a simple $20/month supporter tier for SCBE-AETHERMOORE. The open-source stack is still free to run locally; this just helps fund cleanup, packaging, docs, benchmark work, and operator notes.
+
+Stripe supporter link: https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i
+
+Support page with other payment paths: https://aethermoore.com/SCBE-AETHERMOORE/supporter.html
+
+One-time options are Ko-fi at https://ko-fi.com/izdandavis or Cash App `$IzzyDDavis7`.
+
+## README Snippet
+
+SCBE-AETHERMOORE is free to inspect and run locally. If the work helps and you want to support continued cleanup, packaging, docs, benchmarks, and operator notes, use the $20/month supporter tier:
+
+https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i
+
+One-time/direct support: Ko-fi https://ko-fi.com/izdandavis or Cash App `$IzzyDDavis7`.

--- a/docs/robot.md
+++ b/docs/robot.md
@@ -140,7 +140,7 @@ Use the live offers from `offers.json` as the source of truth. As of this map:
 - Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html. Use this when the user wants every live payment path in one place.
 - Manual invoice / Square-style request: email aethermoregames@pm.me with offer name, buyer email, and preferred payment route.
 - $5 Tip Jar: one-time support.
-- $20/month AetherMoore Supporter: low-cost monthly support path.
+- $20/month AetherMoore Supporter: low-cost monthly support path. Stripe checkout is live: https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i
 - $29 SCBE AI Governance Toolkit: templates and governance starter materials.
 - $29 SCBE AI Security Training Vault: training and benchmark starter materials.
 - $99 AI Agent Workflow Snapshot: starter written read for one agent workflow. Stripe checkout is live: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l


### PR DESCRIPTION
## Summary
- Adds a ready-to-post AetherMoore Supporter launch post with the live Stripe /month checkout link.
- Surfaces the live supporter checkout in README, docs/llms.txt, and docs/robot.md.
- Keeps secret handling out of repo; uses the existing Stripe-hosted Payment Link already present in offers/supporter page.

Live supporter checkout:
https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i

## Verification
- python scripts/system/remote_app_config_smoke.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new hosted-support contact options including monthly subscription and direct payment methods
  * Updated support tier documentation with specific payment references and checkout links
  * Added marketing content for the new $20/month supporter tier, including social media and direct message versions
  * Clarified that the free open-source version remains available locally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->