### PR TITLE
docs(gov): add custom AI CAGE contracting lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ SCBE-AETHERMOORE has a government contracting surface.
 - **Relevant federal opportunity**: DARPA MATHBAC — active opportunity DARPA-PA-26-05 (published 2026-04-07, proposal deadline 2026-06-16); Proposers Day reference DARPA-SN-26-59
 - **Capability docs**: [M5 Mesh Product & Service Blueprint](docs/M5_MESH_PRODUCT_SERVICE_BLUEPRINT.md)
 
+Custom AI work is available for clients that need procurement-ready, clearance-sensitive, or regulated workflow support: private AI governance overlays, air-gapped/offline deployments, redacted-data evaluation harnesses, audit receipts, and client-specific agent controls. CAGE/SAM registration supports vendor and subcontract routing; any classified, export-controlled, or otherwise restricted data must stay inside the client's approved environment under the client's security process.
+
 For government contracting inquiries: issdandavis7795@gmail.com
 
 ---

--- a/docs/hire-b.html
+++ b/docs/hire-b.html
@@ -456,6 +456,17 @@
           </div>
 
           <div class="service-card">
+            <h3>Custom AI for regulated teams</h3>
+            <div class="price">Scoped contract - procurement-ready</div>
+            <p>
+              I can build private AI tooling for clients that need CAGE/SAM vendor routing,
+              clearance-sensitive workflows, air-gapped/offline operation, redacted-data evals,
+              audit receipts, or client-specific governance controls. Classified or controlled data
+              stays inside the client's approved environment and security process.
+            </p>
+          </div>
+
+          <div class="service-card">
             <h3>Open-source feature work</h3>
             <div class="price">$100 – $300 / hour · contract</div>
             <p>

--- a/docs/hire.html
+++ b/docs/hire.html
@@ -466,6 +466,17 @@
           </div>
 
           <div class="service-card">
+            <h3>Custom AI for regulated teams</h3>
+            <div class="price">Scoped contract - procurement-ready</div>
+            <p>
+              I can build private AI tooling for clients that need CAGE/SAM vendor routing,
+              clearance-sensitive workflows, air-gapped/offline operation, redacted-data evals,
+              audit receipts, or client-specific governance controls. Classified or controlled data
+              stays inside the client's approved environment and security process.
+            </p>
+          </div>
+
+          <div class="service-card">
             <h3>Open-source feature work</h3>
             <div class="price">$100 – $300 / hour · contract</div>
             <p>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -88,6 +88,8 @@ Federal posture:
 - Issac Davis is a CAGE-code verified small business owner.
 - CAGE: 1EXD5.
 - UEI: J4NXHM6N5F59.
+- Custom AI work is available for procurement-ready, clearance-sensitive, regulated, air-gapped, or client-controlled environments.
+- Boundary language: CAGE/SAM supports vendor/subcontract routing; classified, export-controlled, or restricted data must stay inside the client's approved environment and security process.
 - Good fit language: post-quantum cryptographic metamaterial prototype, autonomous swarm hardware security, subcontracting, SBIR collaboration, and Small Business Liaison Officer conversations.
 
 Advanced path:


### PR DESCRIPTION
## Summary
- Adds a careful government/custom AI lane around CAGE/SAM procurement readiness.
- Updates README, hire pages, and bot-facing docs to mention regulated, clearance-sensitive, air-gapped, and client-controlled work.
- Preserves the important boundary: CAGE/SAM supports vendor routing, while classified/export-controlled/restricted data stays inside the client's approved environment and security process.

## Verification
- git diff --check