### PR TITLE
docs(marketing): package terminal sales campaign

### DIFF
--- a/.github/workflows/terminal-sales-post.yml
+++ b/.github/workflows/terminal-sales-post.yml
@@ -1,0 +1,62 @@
+name: Terminal Sales Post
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Where to post"
+        required: true
+        default: "both"
+        type: choice
+        options:
+          - x
+          - bluesky
+          - both
+      publish:
+        description: "Post live instead of dry-run"
+        required: true
+        default: false
+        type: boolean
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Post X thread
+        if: ${{ inputs.channel == 'x' || inputs.channel == 'both' }}
+        env:
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+          args=(--thread content/articles/promo/x_thread_ai_workflow_snapshot_no_ads.md)
+          if [ "$PUBLISH" != "true" ]; then
+            args+=(--dry-run)
+          fi
+          python scripts/publish/post_to_x.py "${args[@]}"
+
+      - name: Post Bluesky
+        if: ${{ inputs.channel == 'bluesky' || inputs.channel == 'both' }}
+        env:
+          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+          BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+          PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+          text="$(cat content/articles/promo/bluesky_ai_workflow_snapshot_no_ads.txt)"
+          args=(--text "$text")
+          if [ "$PUBLISH" != "true" ]; then
+            args+=(--dry-run)
+          fi
+          python scripts/publish/post_to_bluesky.py "${args[@]}"

--- a/content/articles/promo/bluesky_ai_workflow_snapshot_no_ads.txt
+++ b/content/articles/promo/bluesky_ai_workflow_snapshot_no_ads.txt
@@ -1,0 +1,5 @@
+I am selling one simple AI safety service first: $99 AI Agent Workflow Snapshot.
+
+Send one agent workflow, prompt chain, repo link, MCP stack, automation flow, or diagram. I send back a written risk read + next 3 fixes.
+
+https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html

--- a/content/articles/promo/x_thread_ai_workflow_snapshot_no_ads.md
+++ b/content/articles/promo/x_thread_ai_workflow_snapshot_no_ads.md
@@ -1,0 +1,46 @@
+# X Thread: AI Workflow Snapshot
+
+## 1/5
+I am selling one simple AI safety service first:
+
+$99 AI Agent Workflow Snapshot.
+
+Send one agent workflow, prompt chain, repo link, MCP stack, automation flow, or diagram. I send back a concise written risk read and the next 3 fixes.
+
+## 2/5
+The problem is not "AI is bad."
+
+The problem is that small teams wire models to tools, files, billing, email, browsers, and customer data before they have a failure map.
+
+That is where prompt injection, unsafe tool paths, missing logs, and brittle automation show up.
+
+## 3/5
+What you get:
+
+- one concise findings memo
+- the top drift/tooling/security risks
+- 3 prioritized fixes
+- upgrade credit toward a deeper $500 Governance Snapshot if the workflow needs it
+
+No secrets required. Redacted examples are fine.
+
+## 4/5
+This is built from SCBE-AETHERMOORE, my open-source AI governance stack:
+
+- local-first scanner
+- audit receipts
+- post-quantum crypto lane
+- CAGE 1EXD5 / SAM UEI J4NXHM6N5F59 for procurement conversations
+
+Repo:
+https://github.com/issdandavis/SCBE-AETHERMOORE
+
+## 5/5
+Buy the $99 Workflow Snapshot:
+https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+
+Scope page:
+https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
+
+If you need a regulated/custom AI build instead, start here:
+https://aethermoore.com/SCBE-AETHERMOORE/hire.html

--- a/docs/marketing/TERMINAL_SALES_PACKET_AI_WORKFLOW_SNAPSHOT.md
+++ b/docs/marketing/TERMINAL_SALES_PACKET_AI_WORKFLOW_SNAPSHOT.md
@@ -1,0 +1,111 @@
+# Terminal Sales Packet: AI Workflow Snapshot
+
+## Offer To Push
+
+Sell the **AI Agent Workflow Snapshot** first.
+
+This is the front-door paid offer because it is small, concrete, and deliverable without inventory, ads, shipping, or a long sales call.
+
+- Price: **$99 one time**
+- Checkout: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+- Scope page: https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
+- Upsell: **$500 Governance Snapshot** or custom AI build
+- Custom AI / CAGE lane: https://aethermoore.com/SCBE-AETHERMOORE/hire.html
+
+## One-Sentence Pitch
+
+I review one AI workflow before it breaks billing, tool permissions, files, or customer trust.
+
+## Buyer
+
+Best first buyers:
+
+- solo founders wiring AI agents to tools
+- small teams using MCP, n8n, LangGraph, CrewAI, browser agents, or custom scripts
+- agencies building AI automations for clients
+- regulated teams that need an audit trail before expanding AI use
+- founders who are not ready for a full platform or large audit
+
+## What They Get
+
+- one concise findings memo
+- top risks around prompt injection, unsafe tool paths, missing logs, brittle automations, and billing/data exposure
+- three prioritized fixes
+- upgrade credit toward the $500 Governance Snapshot if deeper review is needed
+
+## Boundary
+
+No secrets or production data are required. Redacted examples are preferred. For regulated, export-controlled, or classified environments, the work starts with a scoping call and stays inside the client's approved process.
+
+## Direct Message
+
+Quick one: I am offering a $99 AI Agent Workflow Snapshot.
+
+If you have an AI workflow, prompt chain, agent setup, MCP stack, automation flow, or repo that is starting to touch tools/files/customers, I can review one workflow and send back a concise risk memo with the top failure paths and 3 fixes.
+
+Checkout: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+Scope: https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
+
+No secrets needed; redacted examples are fine.
+
+## Cold Email
+
+Subject: quick AI workflow risk read
+
+Hi,
+
+I am offering a small fixed-scope AI Agent Workflow Snapshot.
+
+If your team is connecting AI to tools, files, browsers, billing, email, customer data, or internal automations, I can review one workflow and send back a concise written memo: what can go wrong, what evidence is missing, and the next three fixes.
+
+It is $99 one time, no subscription, and no secrets are required. Redacted examples are fine.
+
+Checkout: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+Scope: https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
+
+For regulated or procurement-heavy work, I also have a CAGE/SAM route for custom AI governance builds.
+
+Issac Davis
+CAGE 1EXD5 / SAM UEI J4NXHM6N5F59
+
+## Public Post
+
+I am selling one simple AI safety service first:
+
+**$99 AI Agent Workflow Snapshot**
+
+Send one AI workflow, prompt chain, repo link, MCP stack, automation flow, or diagram. I send back a concise written risk read and the next 3 fixes.
+
+This is for teams wiring models to tools, files, billing, email, browsers, or customer workflows before they have a failure map.
+
+Checkout:
+https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+
+Scope:
+https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
+
+## Terminal Commands
+
+Dry-run the X thread locally:
+
+```bash
+python scripts/publish/post_to_x.py --thread content/articles/promo/x_thread_ai_workflow_snapshot_no_ads.md --dry-run
+```
+
+Dry-run the Bluesky post locally:
+
+```bash
+python scripts/publish/post_to_bluesky.py --file content/articles/promo/bluesky_ai_workflow_snapshot_no_ads.txt --dry-run
+```
+
+Post through GitHub Actions secrets after this workflow is merged:
+
+```bash
+gh workflow run terminal-sales-post.yml -f channel=both -f publish=true
+```
+
+Safe preview through GitHub Actions:
+
+```bash
+gh workflow run terminal-sales-post.yml -f channel=both -f publish=false
+```


### PR DESCRIPTION
## Summary
- Packages the  AI Agent Workflow Snapshot as the primary no-ad sales wedge.
- Adds X thread and Bluesky post copy for the offer.
- Adds a terminal sales packet with pitch, buyer profile, cold DM/email copy, and commands.
- Adds a manual GitHub Actions workflow that can dry-run or live-post through repository secrets.

## Verification
- python scripts/publish/post_to_x.py --thread content/articles/promo/x_thread_ai_workflow_snapshot_no_ads.md --dry-run
- BLUESKY_HANDLE=dryrun.example BLUESKY_APP_PASSWORD=dry-run-password python scripts/publish/post_to_bluesky.py --file content/articles/promo/bluesky_ai_workflow_snapshot_no_ads.txt --dry-run
- git diff --check