### PR TITLE
docs(marketing): package command-line workcell offer

### DIFF
--- a/content/articles/2026-06-16-ai-workflow-snapshot-launch.md
+++ b/content/articles/2026-06-16-ai-workflow-snapshot-launch.md
@@ -1,0 +1,59 @@
+# AI Agent Workflow Snapshot: a $99 first-pass risk read for one AI workflow
+
+I am selling one simple AI safety service first: **AI Agent Workflow Snapshot**.
+
+Send one agent workflow, prompt chain, repo link, MCP stack, automation flow, browser automation, or diagram. I send back one concise written risk read and the next three fixes.
+
+Checkout: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+
+Scope page: https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
+
+## Why this offer exists
+
+The hard part is no longer writing another AI script. The hard part is knowing whether the workflow is safe enough to run near tools, files, browsers, email, billing, customer data, or production systems.
+
+Small teams are building fast. That is good. The failure modes are also moving fast:
+
+- prompt injection through retrieved text or user-controlled inputs
+- unsafe tool paths
+- missing logs and audit evidence
+- brittle automations that silently do the wrong thing
+- billing or webhook confusion
+- secrets or customer data landing in places they should not
+- workflows that work once but cannot be explained, reviewed, or repeated
+
+The Snapshot is the small paid step before a bigger audit or build.
+
+## What you get
+
+- one concise findings memo
+- the main risks I see in one AI workflow
+- three prioritized fixes
+- evidence gaps to close before scaling
+- upgrade credit toward a deeper $500 Governance Snapshot if the workflow needs it
+
+No secrets are required. Redacted examples are preferred.
+
+## Good fit
+
+This is for:
+
+- solo founders wiring AI agents to tools
+- teams using MCP, n8n, LangGraph, CrewAI, browser agents, or custom scripts
+- agencies building AI automations for clients
+- developers who know a workflow is brittle but need a clean failure map
+- regulated teams that need a lightweight first-pass review before a bigger engagement
+
+## Not for
+
+This is not emergency incident response, legal certification, a compliance stamp, or a guarantee that a system is safe. It is a practical first-pass risk read.
+
+For classified, export-controlled, or otherwise restricted data, do not send the data through public channels. Start with the hire page and keep controlled material inside the client's approved process.
+
+Custom AI / CAGE lane: https://aethermoore.com/SCBE-AETHERMOORE/hire.html
+
+## Buy
+
+AI Agent Workflow Snapshot: **$99 one time**
+
+https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l

--- a/content/articles/2026-06-16-scbe-command-line-workcell.md
+++ b/content/articles/2026-06-16-scbe-command-line-workcell.md
@@ -1,0 +1,41 @@
+# SCBE Command-Line Workcell: a terminal-first worker service for AI-built repos and workflows
+
+I am packaging SCBE as a terminal-first service:
+
+**SCBE Command-Line Workcell**
+
+Send a repo, AI workflow, prompt chain, MCP stack, automation script, or agent runbook. I run a governed command-line review and return a receipt-style memo: what breaks first, what is unsafe, what evidence exists, and what to fix next.
+
+This is not a Cursor clone. Cursor helps a developer type code interactively. SCBE Workcell is the command-line service around the work: inspect, gate, test, patch or recommend patches, and leave a proof trail.
+
+## Who this is for
+
+- solo founders with AI-generated code they do not fully trust
+- agencies shipping automations for clients
+- small teams using Cursor, Claude Code, Codex, Lovable, Replit, n8n, MCP, LangGraph, CrewAI, or browser agents
+- regulated teams that need redacted/offline review before letting agents touch internal systems
+- contractors that need CAGE/SAM vendor routing for custom AI work
+
+## What I check
+
+- does the workflow run?
+- where are secrets, billing, file writes, or unsafe tool calls exposed?
+- what can be tested quickly?
+- what needs human approval before an agent continues?
+- where are logs, receipts, and rollback points missing?
+- what are the next three fixes?
+
+## Offer ladder
+
+Starter: **$99 AI Workflow Snapshot**  
+https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+
+Pilot: **$500 Command-Line Workcell / Governance Snapshot**  
+https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j
+
+Custom / regulated work:  
+https://aethermoore.com/SCBE-AETHERMOORE/hire.html
+
+No secrets are required for the starter review. Redacted examples are preferred.
+
+For regulated, export-controlled, or classified environments, do not send controlled data through public channels. The work must stay inside the client's approved process.

--- a/docs/marketing/SCBE_COMMAND_LINE_WORKCELL_OFFER.md
+++ b/docs/marketing/SCBE_COMMAND_LINE_WORKCELL_OFFER.md
@@ -1,0 +1,172 @@
+# SCBE Command-Line Workcell
+
+## Short Version
+
+**SCBE Command-Line Workcell** is a managed CLI worker service for teams with AI-generated code, agent workflows, or automation scripts that are not safe enough to trust yet.
+
+It is not a Cursor clone. Cursor helps a developer type code interactively. This service runs a governed command-line worker cell around a repo or workflow and returns proof: findings, patches, tests, risk receipts, and next commands.
+
+## Buyer
+
+Best first buyers:
+
+- solo founders with an AI-built app they do not fully trust
+- agencies shipping automations for clients
+- small teams using Cursor, Claude Code, Codex, Lovable, Replit, n8n, MCP, LangGraph, CrewAI, or browser agents
+- regulated teams that need redacted/offline review before letting agents touch internal systems
+- contractors that need CAGE/SAM vendor routing for custom AI work
+
+## The Pain
+
+People can generate a repo quickly now. They still need someone to answer:
+
+- does it run?
+- what breaks first?
+- where are secrets, billing, file writes, or unsafe tool calls exposed?
+- what test proves the fix?
+- what should a human approve before the agent continues?
+- what is the receipt trail if this goes wrong?
+
+## Offer Ladder
+
+### 1. AI Workflow Snapshot - $99
+
+Use this when the buyer only needs a first-pass read.
+
+- one workflow, prompt chain, repo link, MCP stack, automation flow, or diagram
+- concise findings memo
+- top risks
+- three prioritized fixes
+- upgrade credit toward deeper work
+
+Checkout: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+
+Scope: https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
+
+### 2. Command-Line Workcell Pilot - $500 fixed scope
+
+Use this when the buyer wants the repo/workflow inspected by the CLI system, not just read.
+
+Deliverables:
+
+- repo/workflow intake
+- one governed CLI run plan
+- one risk and tool-permission map
+- one patch or patch plan, depending on access and scope
+- test/run evidence where feasible
+- receipt-style memo with exact commands, outcomes, and next steps
+
+Checkout route: use the Governance Snapshot checkout and include `Command-Line Workcell Pilot` in the intake.
+
+Checkout: https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j
+
+Hire page: https://aethermoore.com/SCBE-AETHERMOORE/hire.html
+
+### 3. Managed Workcell - custom
+
+Use this for recurring CLI operations, regulated/offline work, private repos, client-controlled systems, or federal/subcontract contexts.
+
+Deliverables can include:
+
+- recurring repo/workflow checks
+- agent/fleet runbooks
+- approval gates
+- test harnesses
+- sealed/bijective payload receipts
+- custom coding-system or chemistry-system decoders
+- weekly proof packets
+
+Start through the hire page: https://aethermoore.com/SCBE-AETHERMOORE/hire.html
+
+## How The Fleet Pieces Map
+
+Do not lead with all of this in sales copy. Use it as proof after the buyer understands the offer.
+
+- **Fleet systems**: multiple worker lanes for inspect, patch, test, document, and review.
+- **Bijective coding**: exact input/output receipt logic; source and payload recovery matter.
+- **Chemistry systems**: typed transforms and domain-specific decoders; useful for scientific, materials, chemistry, and safety workflows.
+- **Coding systems**: source-order AST, CLI checks, benchmark lanes, agentic coding readiness.
+- **Swarm systems**: independent lanes can run in parallel when their scopes do not overlap; overlapping work serializes.
+- **Governance gates**: risky commands, secrets, billing, destructive operations, and external calls require explicit boundaries.
+
+## Public Pitch
+
+I am packaging SCBE as a terminal-first worker service:
+
+**SCBE Command-Line Workcell**
+
+Send a repo, AI workflow, prompt chain, MCP stack, or automation script. I run a governed CLI review and return the findings, patch/test evidence, and next commands.
+
+This is for teams that built fast with AI and now need to know what breaks, what is unsafe, and what to fix first.
+
+Starter: $99 Workflow Snapshot  
+Pilot: $500 Command-Line Workcell  
+Custom: regulated/offline/federal-ready AI work
+
+## DM
+
+I am testing a service called SCBE Command-Line Workcell.
+
+If you have an AI-built repo, agent workflow, MCP stack, or automation script that you do not fully trust yet, I can run a governed CLI review and send back a concise memo: what breaks first, what is risky, what tests/commands prove it, and the next fixes.
+
+Starter read is $99: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+
+For deeper repo/workflow work, the $500 pilot starts here: https://aethermoore.com/SCBE-AETHERMOORE/hire.html
+
+No secrets needed; redacted examples are fine.
+
+## Cold Email
+
+Subject: CLI review for AI-built workflows
+
+Hi,
+
+I am offering a small terminal-first service for teams building with AI agents or code generators.
+
+If you have a repo, workflow, MCP stack, n8n automation, prompt chain, or agent script that is starting to touch tools/files/customers, I can run a governed command-line review and return:
+
+- what breaks first
+- unsafe tool or file paths
+- missing tests/logs/receipts
+- next three fixes
+- command evidence where feasible
+
+The starter read is $99. The deeper Command-Line Workcell pilot is $500 fixed scope.
+
+Starter: https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
+Custom/pilot: https://aethermoore.com/SCBE-AETHERMOORE/hire.html
+
+No secrets required. Redacted examples are fine.
+
+Issac Davis  
+CAGE 1EXD5 / SAM UEI J4NXHM6N5F59
+
+## Operational Boundary
+
+No buyer should send secrets, production credentials, regulated data, export-controlled data, or classified material through public intake. For controlled environments, the work must be scoped inside the client's approved process.
+
+## First Manual Fulfillment Run
+
+For a paid pilot:
+
+1. Create a private work folder.
+2. Record intake and allowed actions.
+3. Run read-only repo/workflow inspection first.
+4. Map risky tool/file/billing/network paths.
+5. Run tests or dry-runs only inside agreed scope.
+6. Produce a receipt memo with commands, outputs, findings, and fixes.
+7. If patching is allowed, open a patch branch or provide a patch file.
+
+## Repo Proof Surfaces
+
+- `docs/agents.html`
+- `docs/AETHERBROWSER_PACK.md`
+- `docs/archive/agent_bus_notes.md`
+- `docs/ai-workflow-snapshot.html`
+- `scripts/system/sell_from_terminal.py`
+- `scripts/publish/publish_discussions.py`
+- `scripts/benchmark/cli_competitive_benchmark.py`
+- `scripts/eval/functional_coding_agent_benchmark.py`
+- `python/scbe/toroidal_braid.py`
+- `rust/ast_cube/src/main.rs`
+- `rust/ast_cube_ruff/src/main.rs`


### PR DESCRIPTION
## Summary
- Packages SCBE Command-Line Workcell as a sellable service, distinct from a Cursor clone.
- Defines buyer, pain, offer ladder, delivery artifacts, fleet/bijective/chemistry/coding/swarm mapping, and outreach copy.
- Adds the source article used for the live GitHub Discussion launch.

Live discussion:
https://github.com/issdandavis/SCBE-AETHERMOORE/discussions/2285

## Verification
- python scripts/publish/publish_discussions.py --file content/articles/2026-06-16-scbe-command-line-workcell.md --category General --skip-existing --dry-run
- python scripts/publish/publish_discussions.py --file content/articles/2026-06-16-scbe-command-line-workcell.md --category General --skip-existing
- git diff --check