### PR TITLE
security: fix GHSA email-leak, encrypt billing keys, stop secret echo

### DIFF
--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -38,7 +38,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, Response
+from fastapi.responses import FileResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
@@ -490,6 +490,31 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Operator endpoints (/api/ops/*, /api/cli/*) run local subprocesses (email
+# reader, pytest, git, tor sweep, CLI) and return their output, behind wide-open
+# CORS. Without a guard they were unauthenticated remote-exec / data-leak
+# surfaces (GHSA-q986-4x7x-gx39: the /api/ops/check-email digest leak). They are
+# DISABLED unless an admin token is configured, and then require a matching
+# X-Admin-Token header — fail closed, same pattern as /runtime-gate/checkpoint.
+_OPERATOR_PREFIXES = ("/api/ops/", "/api/cli/")
+
+
+@app.middleware("http")
+async def _guard_operator_endpoints(request: Request, call_next):
+    if request.method != "OPTIONS" and any(request.url.path.startswith(p) for p in _OPERATOR_PREFIXES):
+        token = (
+            os.environ.get("SCBE_OPS_ADMIN_TOKEN", "").strip()
+            or os.environ.get("SCBE_RUNTIME_GATE_ADMIN_TOKEN", "").strip()
+        )
+        if not token:
+            return JSONResponse(
+                {"detail": "operator endpoints disabled (set SCBE_OPS_ADMIN_TOKEN to enable)"},
+                status_code=403,
+            )
+        if not hmac.compare_digest(request.headers.get("x-admin-token", ""), token):
+            return JSONResponse({"detail": "invalid or missing X-Admin-Token"}, status_code=401)
+    return await call_next(request)
 
 if PUBLIC_DIR.exists():
     static_dir = PUBLIC_DIR / "static"

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -102,8 +102,9 @@ if __name__ == "__main__":
         print(f"\n{'='*60}")
         print(f"BLOCKED: {len(secrets)} SECRET(S) DETECTED")
         print(f"{'='*60}")
-        for path, name, preview in secrets:
-            print(f"  [{name}] {path}: {preview}")
+        for path, name, _preview in secrets:
+            # Do NOT echo the matched secret value — report only where + what type.
+            print(f"  [{name}] {path}")
         print("\nReplace secrets with [SCRUBBED:type] before committing.")
         print(f"{'='*60}")
         sys.exit(1)

--- a/src/api/stripe_billing.py
+++ b/src/api/stripe_billing.py
@@ -71,12 +71,32 @@ LOGGER = logging.getLogger("scbe.billing")
 _KEYS_FILE = Path(__file__).resolve().parents[2] / "artifacts" / "revenue" / "api_keys.jsonl"
 
 
+def _billing_cipher():
+    """Fernet cipher for encrypting API keys at rest, or None if unconfigured.
+
+    Without SCBE_BILLING_ENC_KEY the store runs IN-MEMORY ONLY and never writes a
+    secret to disk in clear text. Generate a key with:
+      python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    """
+    raw = os.getenv("SCBE_BILLING_ENC_KEY", "").strip()
+    if not raw:
+        return None
+    try:
+        from cryptography.fernet import Fernet
+
+        return Fernet(raw.encode("utf-8"))
+    except Exception as exc:
+        LOGGER.warning("SCBE_BILLING_ENC_KEY invalid; billing keys will not persist: %s", exc)
+        return None
+
+
 def _load_keys() -> tuple[Dict[str, Any], Dict[str, Any]]:
     """Load persisted billing records from disk on startup."""
     customers: Dict[str, Any] = {}
     keys: Dict[str, Any] = {}
     if not _KEYS_FILE.exists():
         return customers, keys
+    cipher = _billing_cipher()
     try:
         with open(_KEYS_FILE, encoding="utf-8") as f:
             for line in f:
@@ -84,6 +104,12 @@ def _load_keys() -> tuple[Dict[str, Any], Dict[str, Any]]:
                 if not line:
                     continue
                 record = json.loads(line)
+                enc = record.pop("api_key_enc", None)
+                if enc and cipher is not None:
+                    try:
+                        record["api_key"] = cipher.decrypt(enc.encode("ascii")).decode("utf-8")
+                    except Exception:
+                        continue  # cannot decrypt (wrong/rotated key) — skip record
                 cid = record.get("customer_id", "")
                 key = record.get("api_key", "")
                 if cid:
@@ -96,11 +122,22 @@ def _load_keys() -> tuple[Dict[str, Any], Dict[str, Any]]:
 
 
 def _persist_key(record: Dict[str, Any]) -> None:
-    """Append an API key record to disk."""
+    """Append an API key record to disk with the API key ENCRYPTED at rest.
+
+    If no encryption key is configured the record is NOT written (in-memory only),
+    so a raw key is never stored in clear text.
+    """
+    cipher = _billing_cipher()
+    if cipher is None:
+        return
     _KEYS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    safe = dict(record)
+    api_key = safe.pop("api_key", "")
+    if api_key:
+        safe["api_key_enc"] = cipher.encrypt(api_key.encode("utf-8")).decode("ascii")
     try:
         with open(_KEYS_FILE, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record) + "\n")
+            f.write(json.dumps(safe) + "\n")
     except Exception as exc:
         LOGGER.warning("Failed to persist API key record: %s", exc)
 


### PR DESCRIPTION
Fixes the three **real** code-scanning / advisory findings (the rest are false-positives / test-only — see below).

## 1. GHSA-q986-4x7x-gx39 (HIGH, externally reported) — unauthenticated operator API
The AetherBrowser `/api/ops/*` endpoints (`check-email`, `run-tests`, `git-status`, `tor-sweep`, momentum, chessboard…) and `/api/cli/*` ran **local subprocesses and returned their output with no auth**, behind wide-open CORS. The reported "operator email digest" leak (`/api/ops/check-email`) was one of several — this was effectively unauthenticated remote command execution.

**Fix:** a fail-closed middleware — those prefixes are **disabled unless `SCBE_OPS_ADMIN_TOKEN` is set** and a matching `X-Admin-Token` header is sent (same pattern as the existing `/runtime-gate/checkpoint` guard). `OPTIONS` (CORS preflight) is exempt.

## 2. CodeQL #5206 (HIGH) — clear-text storage of API keys
`src/api/stripe_billing.py` wrote **raw API keys** to `artifacts/revenue/api_keys.jsonl` in clear text. Now **encrypted at rest** (Fernet via `SCBE_BILLING_ENC_KEY`); with no key configured the store runs **in-memory only and never writes a secret**. Verified round-trip: disk holds only `api_key_enc`, the raw key is recovered on load, and old clear-text records still read (back-compat).

## 3. CodeQL #5199 (HIGH) — secret scanner echoed the secret
Ironically, the `pre-commit` secret scanner **printed a preview of the secret it caught**. Now reports only path + type, never the value.

## Not fixed — honestly triaged (will dismiss with reasons)
- **#5189** path-injection (`scbe-shim-space/app.py`): **false positive** — the handler resolves the path and validates it against an allowlist of allowed roots before use.
- **#5190** URL substring sanitization: **test-only** assertion code.
- **#5200** stack-trace exposure (`demo_routes.py:343`): **stale** — the cited line is a clean health-check return; no exception is exposed.
- **#5201–5205** clear-text logging (`scbe_full_benchmark.py`): a local benchmark printing provider responses to the operator's **own terminal** — not a remote sink. Low practical risk.

> Side note: a stale husky-v9 hook (`_/husky.sh` removed) was aborting all commits; restored the bootstrap stub so hooks run instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)