### PR TITLE
docs(marketing): wire one-dollar workcell cli offer

### DIFF
--- a/content/articles/2026-06-16-scbe-command-line-workcell.md
+++ b/content/articles/2026-06-16-scbe-command-line-workcell.md
@@ -27,6 +27,9 @@ This is not a Cursor clone. Cursor helps a developer type code interactively. SC
 
 ## Offer ladder
 
+Self-serve: **$1 SCBE Workcell CLI lifetime**
+https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o
+
 Starter: **$99 AI Workflow Snapshot**  
 https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
 
@@ -35,6 +38,8 @@ https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j
 
 Custom / regulated work:  
 https://aethermoore.com/SCBE-AETHERMOORE/hire.html
+
+The $1 CLI offer is self-serve access to the public command-line workcell tooling and docs. It is not unlimited support, managed runs, private repo work, or custom engineering.
 
 No secrets are required for the starter review. Redacted examples are preferred.
 

--- a/content/articles/2026-06-16-workcell-cli-dollar-lifetime.md
+++ b/content/articles/2026-06-16-workcell-cli-dollar-lifetime.md
@@ -1,0 +1,34 @@
+# SCBE Workcell CLI is $1 lifetime
+
+I am making the self-serve version simple:
+
+**SCBE Workcell CLI - $1 lifetime**
+
+Buy it once, use the public command-line workcell tooling and docs yourself.
+
+Checkout: https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o
+
+CLI page: https://aethermoore.com/SCBE-AETHERMOORE/cli.html
+
+## What it is
+
+SCBE Workcell CLI is the self-serve command-line path around the workcell idea:
+
+- inspect AI-built repos and workflows
+- think in commands, tests, and receipts
+- use the public workcell docs and tooling
+- keep the tool instead of renting another subscription
+
+## What it is not
+
+The $1 lifetime checkout is not unlimited support, private repo work, managed runs, regulated deployment, emergency incident response, or custom engineering.
+
+Those are separate:
+
+- $99 AI Workflow Snapshot: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
+- $500 Command-Line Workcell Pilot / Governance Snapshot: https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j
+- Custom/regulated work: https://aethermoore.com/SCBE-AETHERMOORE/hire.html
+
+## Why $1
+
+The point is to remove the excuse. If someone wants the self-serve tool, they can get it. If they want me to review, run, patch, or manage the workcell for them, that becomes a higher-scope service.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -63,6 +63,8 @@ Free path:
 Low-cost path:
 
 - $5+ service credits.
+- $1 lifetime SCBE Workcell CLI self-serve checkout: https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o.
+- Workcell CLI boundary: lifetime self-serve access to the public command-line workcell tooling/docs; support, managed runs, private repo work, and regulated deployments are separate.
 - Ko-fi support and service-credit path: https://ko-fi.com/izdandavis.
 - Cash App manual payment: $IzzyDDavis7.
 - $20/month AetherMoore Supporter checkout: https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i.

--- a/docs/marketing/SCBE_COMMAND_LINE_WORKCELL_OFFER.md
+++ b/docs/marketing/SCBE_COMMAND_LINE_WORKCELL_OFFER.md
@@ -29,7 +29,24 @@ People can generate a repo quickly now. They still need someone to answer:
 
 ## Offer Ladder
 
-### 1. AI Workflow Snapshot - $99
+### 1. SCBE Workcell CLI - $1 lifetime
+
+Use this when the buyer wants the self-serve command-line tool and docs so they can run it themselves.
+
+Buyer gets:
+
+- lifetime self-serve access path for the public SCBE command-line workcell tooling and docs
+- the right to use the public CLI/workcell materials themselves
+- future public updates through the repo/site
+- no subscription
+
+Boundary: this is not unlimited support, private repo work, managed runs, regulated deployment, or custom engineering.
+
+Checkout: https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o
+
+CLI page: https://aethermoore.com/SCBE-AETHERMOORE/cli.html
+
+### 2. AI Workflow Snapshot - $99
 
 Use this when the buyer only needs a first-pass read.
 
@@ -43,7 +60,7 @@ Checkout: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
 
 Scope: https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
 
-### 2. Command-Line Workcell Pilot - $500 fixed scope
+### 3. Command-Line Workcell Pilot - $500 fixed scope
 
 Use this when the buyer wants the repo/workflow inspected by the CLI system, not just read.
 
@@ -62,7 +79,7 @@ Checkout: https://buy.stripe.com/eVqeVeaWu79ZgJi11Ydby0j
 
 Hire page: https://aethermoore.com/SCBE-AETHERMOORE/hire.html
 
-### 3. Managed Workcell - custom
+### 4. Managed Workcell - custom
 
 Use this for recurring CLI operations, regulated/offline work, private repos, client-controlled systems, or federal/subcontract contexts.
 
@@ -99,6 +116,7 @@ Send a repo, AI workflow, prompt chain, MCP stack, or automation script. I run a
 
 This is for teams that built fast with AI and now need to know what breaks, what is unsafe, and what to fix first.
 
+Self-serve: $1 Workcell CLI
 Starter: $99 Workflow Snapshot  
 Pilot: $500 Command-Line Workcell  
 Custom: regulated/offline/federal-ready AI work
@@ -108,6 +126,8 @@ Custom: regulated/offline/federal-ready AI work
 I am testing a service called SCBE Command-Line Workcell.
 
 If you have an AI-built repo, agent workflow, MCP stack, or automation script that you do not fully trust yet, I can run a governed CLI review and send back a concise memo: what breaks first, what is risky, what tests/commands prove it, and the next fixes.
+
+Self-serve Workcell CLI is $1 lifetime: https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o
 
 Starter read is $99: https://buy.stripe.com/aFafZiggOdyn9gQ11Ydby0l
 
@@ -131,8 +151,9 @@ If you have a repo, workflow, MCP stack, n8n automation, prompt chain, or agent 
 - next three fixes
 - command evidence where feasible
 
-The starter read is $99. The deeper Command-Line Workcell pilot is $500 fixed scope.
+The self-serve CLI is $1 lifetime. The starter read is $99. The deeper Command-Line Workcell pilot is $500 fixed scope.
 
+Self-serve: https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o
 Starter: https://aethermoore.com/SCBE-AETHERMOORE/workflow-snapshot.html
 Custom/pilot: https://aethermoore.com/SCBE-AETHERMOORE/hire.html
 

--- a/docs/offers.json
+++ b/docs/offers.json
@@ -30,6 +30,26 @@
   },
   "offers": [
     {
+      "id": "workcell_cli_lifetime",
+      "name": "SCBE Workcell CLI",
+      "price_label": "$1 lifetime",
+      "type": "digital_access",
+      "checkout_url": "https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o",
+      "alternate_checkout": {
+        "cash_app": "$IzzyDDavis7",
+        "cash_app_qr_url": "https://aethermoore.com/SCBE-AETHERMOORE/static/cash-app-payment.png"
+      },
+      "proof_url": "https://aethermoore.com/SCBE-AETHERMOORE/cli.html",
+      "status": "live",
+      "scope": [
+        "lifetime self-serve access path for the public SCBE command-line workcell tooling and docs",
+        "run the CLI, inspect workflows, and use the public workcell materials yourself",
+        "support, custom review, managed runs, private repo work, and regulated deployments sold separately"
+      ],
+      "checkout_note": "Stripe checkout is live. This is self-serve lifetime access, not unlimited support.",
+      "stripe_payment_link_id": "plink_1Tj3CyJTF2SuUODIq1uPTEqY"
+    },
+    {
       "id": "service_credits",
       "name": "SCBE Service Credits",
       "price_label": "$5+ pay-as-you-go",

--- a/docs/offers/index.html
+++ b/docs/offers/index.html
@@ -216,6 +216,22 @@
           <a class="btn btn-secondary" href="../service-credits.html">How Credits Work</a>
         </article>
         <article class="card">
+          <h2>SCBE Workcell CLI</h2>
+          <p>
+            Self-serve lifetime access path for the public command-line workcell tooling and docs.
+            Use the CLI yourself; support, private repo work, and managed runs are separate.
+          </p>
+          <div class="price">$1 lifetime</div>
+          <a
+            class="btn btn-primary"
+            href="https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o"
+            target="_blank"
+            rel="noopener"
+            >Buy Workcell CLI</a
+          >
+          <a class="btn btn-secondary" href="../cli.html">View CLI</a>
+        </article>
+        <article class="card">
           <h2>SCBE AI Governance Toolkit</h2>
           <p>
             Includes governance templates, decision record examples, threshold notes, pilot

--- a/docs/payments.html
+++ b/docs/payments.html
@@ -259,6 +259,18 @@
         <p>These are the structured checkout links already wired into the public offer registry.</p>
         <div class="grid">
           <article class="card">
+            <h3>SCBE Workcell CLI</h3>
+            <div class="price">$1 lifetime</div>
+            <p>Self-serve command-line workcell tooling and docs. Managed help is separate.</p>
+            <a
+              class="btn"
+              href="https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o"
+              target="_blank"
+              rel="noopener"
+              >Buy Workcell CLI</a
+            >
+          </article>
+          <article class="card">
             <h3>Tip Jar</h3>
             <div class="price">$5 one time</div>
             <a

--- a/docs/robot.md
+++ b/docs/robot.md
@@ -135,6 +135,7 @@ Tell users:
 Use the live offers from `offers.json` as the source of truth. As of this map:
 
 - $5+ SCBE Service Credits: pay-as-you-go support for hosted routing, reports, delivery, storage, and provider/model usage where billable.
+- $1 lifetime SCBE Workcell CLI: self-serve command-line workcell tooling/docs. Stripe checkout is live: https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o
 - Ko-fi support: https://ko-fi.com/izdandavis. Use this as the primary low-pressure payment/support path.
 - Cash App manual payment: $IzzyDDavis7. For service purchases, include the offer name in the note.
 - Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html. Use this when the user wants every live payment path in one place.


### PR DESCRIPTION
## Summary
- wires the real $1 lifetime Stripe checkout into the offer catalog, payment page, robot/LLM discovery docs, and command-line workcell marketing copy
- adds a public article for the self-serve `SCBE Workcell CLI - $1 lifetime` offer
- points buyers to GitHub Discussion #2289 as the launch thread

Checkout: https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o
Discussion: https://github.com/issdandavis/SCBE-AETHERMOORE/discussions/2289

## Boundary
This is self-serve lifetime access to public SCBE workcell CLI tooling/docs. It is not unlimited support, managed implementation, or regulated/custom delivery.

## Validation
- `python -m json.tool docs\offers.json > $null`
- `python scripts\system\remote_app_config_smoke.py`
- `git diff --check`