### PR TITLE
feat(agent): add mechanical eliza support switchboard

### DIFF
--- a/docs/MECHANICAL_ELIZA_SUPPORT.md
+++ b/docs/MECHANICAL_ELIZA_SUPPORT.md
@@ -1,0 +1,79 @@
+# Mechanical ELIZA Support Switchboard
+
+Mechanical ELIZA is a secondary support system for chatbots and command agents.
+It does not try to be smarter than the caller. It gives the caller a small,
+deterministic support layer that classifies a request, chooses a switch, and
+returns a machine-readable receipt.
+
+The purpose is to keep an AI from improvising when it should route.
+
+## Model
+
+The engine uses layered rules:
+
+| Layer | Job |
+| --- | --- |
+| intake | normalize the request and create a stable request id |
+| intent | classify command, debug, sales, research, design, or loop distress |
+| risk | detect destructive commands, secrets, money movement, and publishing |
+| context | detect human caller, AI caller, or explicit support need |
+| support_mode | choose mechanical-only, agent-to-agent, or human-visible support |
+| history | detect single-turn, multi-turn, possible loop, or repeated loop |
+
+The output is a `scbe.mechanical_eliza.v1` JSON packet with:
+
+- a route;
+- an enabled command switch;
+- one ELIZA-style support response;
+- next questions;
+- command hints;
+- a support contract;
+- the full switchboard state.
+
+## Switches
+
+| Switch | Use |
+| --- | --- |
+| `ask` | missing context; ask one clarifying question |
+| `route` | safe command/workflow lane; emit governed command hints |
+| `diagnose` | failure or traceback; request smallest reproducible receipt |
+| `offer` | pricing, checkout, or customer route |
+| `probe` | secrets, money, account state, or external publish risk |
+| `deny` | destructive command shape; stop and human-review |
+| `loop_break` | agent is confused, looping, or carrying conflicting goals |
+| `memory` | context, state, recap, or checkpoint repair |
+| `model` | select the lowest sufficient model/lane |
+| `handoff` | package work for another agent or squad |
+
+## CLI
+
+```powershell
+python scripts/system/mechanical_eliza_support.py --pretty "chatbot needs support: run pytest from the terminal"
+```
+
+Response-only mode:
+
+```powershell
+python scripts/system/mechanical_eliza_support.py --response-only "the assistant is confused and looping"
+```
+
+Multi-turn loop detection:
+
+```powershell
+@"
+what next
+what next
+"@ | Set-Content -Encoding utf8 .\history.txt
+
+python scripts/system/mechanical_eliza_support.py --history-file .\history.txt --pretty "what next"
+```
+
+## Product Boundary
+
+This is a deterministic support switchboard. It does not execute commands, call
+Stripe, read secrets, or browse the web. It is meant to sit in front of those
+systems and tell the calling AI which route is allowed next.
+
+That makes it suitable for the $1 self-serve Workcell CLI path: buyers can use
+it as a simple mechanical support layer for their own chatbots before they need
+custom implementation.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,6 +12,7 @@ Canonical repository: https://github.com/issdandavis/SCBE-AETHERMOORE
 - Buyer solutions page: https://aethermoore.com/SCBE-AETHERMOORE/solutions.html
 - Live offers JSON: https://aethermoore.com/SCBE-AETHERMOORE/offers.json
 - App config JSON: https://aethermoore.com/SCBE-AETHERMOORE/app-config.json
+- Mechanical ELIZA support switchboard: https://aethermoore.com/SCBE-AETHERMOORE/MECHANICAL_ELIZA_SUPPORT.md
 - Agent demos: https://aethermoore.com/SCBE-AETHERMOORE/agents.html
 - Chat: https://aethermoore.com/SCBE-AETHERMOORE/chat.html
 - Products: https://aethermoore.com/SCBE-AETHERMOORE/products.html
@@ -65,6 +66,7 @@ Low-cost path:
 - $5+ service credits.
 - $1 lifetime SCBE Workcell CLI self-serve checkout: https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o.
 - Workcell CLI boundary: lifetime self-serve access to the public command-line workcell tooling/docs; support, managed runs, private repo work, and regulated deployments are separate.
+- Workcell CLI includes the Mechanical ELIZA support switchboard pattern: a deterministic secondary support router for chatbots that need command routing, loop breaking, memory/context repair, model-lane selection, handoff packets, or guarded escalation.
 - Ko-fi support and service-credit path: https://ko-fi.com/izdandavis.
 - Cash App manual payment: $IzzyDDavis7.
 - $20/month AetherMoore Supporter checkout: https://buy.stripe.com/00w8wQd4CbqfgJidOKdby0i.

--- a/docs/robot.md
+++ b/docs/robot.md
@@ -22,6 +22,7 @@ Machine-readable config:
 - App config: https://aethermoore.com/SCBE-AETHERMOORE/app-config.json
 - Offers: https://aethermoore.com/SCBE-AETHERMOORE/offers.json
 - Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html
+- Mechanical ELIZA support switchboard: https://aethermoore.com/SCBE-AETHERMOORE/MECHANICAL_ELIZA_SUPPORT.md
 - Shopify Command Center: https://aethermoore.com/SCBE-AETHERMOORE/shopify-command-center.html
 - Shopify Command Center live demo: https://shopify-command-center-165664533862.us-west2.run.app
 - LLM guidance: https://aethermoore.com/SCBE-AETHERMOORE/llms.txt
@@ -136,6 +137,7 @@ Use the live offers from `offers.json` as the source of truth. As of this map:
 
 - $5+ SCBE Service Credits: pay-as-you-go support for hosted routing, reports, delivery, storage, and provider/model usage where billable.
 - $1 lifetime SCBE Workcell CLI: self-serve command-line workcell tooling/docs. Stripe checkout is live: https://buy.stripe.com/fZu4gA5Ca1PFct211Ydby0o
+- Mechanical ELIZA support switchboard: included in the public Workcell CLI path as a deterministic secondary router for chatbots and command agents. Use it when an AI needs command routing, loop breaking, memory/context repair, model-lane selection, handoff packets, or guarded escalation.
 - Ko-fi support: https://ko-fi.com/izdandavis. Use this as the primary low-pressure payment/support path.
 - Cash App manual payment: $IzzyDDavis7. For service purchases, include the offer name in the note.
 - Payment center: https://aethermoore.com/SCBE-AETHERMOORE/payments.html. Use this when the user wants every live payment path in one place.

--- a/python/scbe/__init__.py
+++ b/python/scbe/__init__.py
@@ -150,6 +150,13 @@ from .audio_field_observables import (
     generate_decaying_sine,
     generate_sine,
 )
+from .mechanical_eliza import (
+    ElizaLayer,
+    ElizaRoute,
+    ElizaSupportPacket,
+    route_dialogue,
+    route_support,
+)
 
 __all__ += [
     "AtomicElement",
@@ -213,4 +220,9 @@ __all__ += [
     "analyze_audio_field",
     "generate_sine",
     "generate_decaying_sine",
+    "ElizaLayer",
+    "ElizaRoute",
+    "ElizaSupportPacket",
+    "route_dialogue",
+    "route_support",
 ]

--- a/python/scbe/mechanical_eliza.py
+++ b/python/scbe/mechanical_eliza.py
@@ -1,0 +1,441 @@
+"""Mechanical ELIZA support router for AI-to-AI command triage.
+
+This is deliberately small and deterministic. It gives a chatbot a second
+system it can call when it needs scripted support instead of another generative
+answer: classify the request, choose a route, emit a receipt, and return an
+ELIZA-style reflection that keeps the caller inside a safe command lane.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+import re
+from typing import Iterable, Mapping, Sequence
+
+
+SCHEMA_VERSION = "scbe.mechanical_eliza.v1"
+
+
+@dataclass(frozen=True)
+class ElizaLayer:
+    name: str
+    signal: str
+    confidence: float
+    evidence: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ElizaRoute:
+    route: str
+    action: str
+    command_switch: str
+    needs_human: bool
+    allowed: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class ElizaSupportPacket:
+    schema_version: str
+    request_id: str
+    user_text: str
+    normalized_text: str
+    layers: tuple[ElizaLayer, ...]
+    route: ElizaRoute
+    response: str
+    next_questions: tuple[str, ...]
+    command_hints: tuple[str, ...]
+    support_contract: dict
+    switchboard: tuple[dict, ...]
+
+    def as_dict(self) -> dict:
+        packet = asdict(self)
+        packet["layers"] = [asdict(layer) for layer in self.layers]
+        packet["route"] = asdict(self.route)
+        return packet
+
+
+@dataclass(frozen=True)
+class PatternRule:
+    signal: str
+    patterns: tuple[str, ...]
+    confidence: float
+
+    def match(self, text: str) -> tuple[str, ...]:
+        hits = []
+        for pattern in self.patterns:
+            if re.search(pattern, text, flags=re.IGNORECASE):
+                hits.append(pattern)
+        return tuple(hits)
+
+
+INTENT_RULES: tuple[PatternRule, ...] = (
+    PatternRule("command_route", (r"\b(run|execute|shell|terminal|command|cli)\b", r"\b(scbe|pytest|npm|cargo|git)\b"), 0.82),
+    PatternRule("debug_support", (r"\b(error|failed|traceback|broken|bug|crash|does not work|stuck)\b",), 0.78),
+    PatternRule("sales_support", (r"\b(price|pay|checkout|stripe|buy|sell|customer|offer|supporter)\b",), 0.76),
+    PatternRule("research_support", (r"\b(research|look up|source|paper|notes|docs|vault)\b",), 0.72),
+    PatternRule("design_support", (r"\b(design|architecture|plan|route|system|workflow|swarm|fleet)\b",), 0.7),
+    PatternRule("agent_distress", (r"\b(confused|looping|uncertain|contradiction|conflict|can't decide|cannot decide)\b",), 0.74),
+    PatternRule("memory_support", (r"\b(memory|context|forgot|recap|summary|state|checkpoint)\b",), 0.73),
+    PatternRule("model_route", (r"\b(model|llm|fallback|cheap|local|cloud|escalate)\b",), 0.73),
+    PatternRule("handoff_support", (r"\b(handoff|handover|delegate|subagent|squad|swarm)\b",), 0.72),
+)
+
+RISK_RULES: tuple[PatternRule, ...] = (
+    PatternRule("destructive", (r"\b(rm\s+-rf|remove-item|format|delete|wipe|reset\s+--hard|drop\s+table)\b",), 0.97),
+    PatternRule("secret_handling", (r"\b(api[_ -]?key|secret|token|password|sk_live|private key)\b",), 0.91),
+    PatternRule("money_movement", (r"\b(stripe|checkout|refund|charge|payment|invoice|bank)\b",), 0.84),
+    PatternRule("external_publish", (r"\b(push|deploy|publish|post|tweet|bluesky|email)\b",), 0.8),
+)
+
+CONTEXT_RULES: tuple[PatternRule, ...] = (
+    PatternRule("ai_caller", (r"\b(chatbot|agent|model|assistant|ai)\b",), 0.82),
+    PatternRule("human_caller", (r"\b(i|me|my|we|our)\b",), 0.62),
+    PatternRule("support_need", (r"\b(help|support|triage|decide|route|switch|fallback)\b",), 0.8),
+)
+
+SUPPORT_MODE_RULES: tuple[PatternRule, ...] = (
+    PatternRule("mechanical_only", (r"\b(deterministic|mechanical|rules?|no model|no llm)\b",), 0.86),
+    PatternRule("agent_to_agent", (r"\b(chatbot|agent|assistant|model|ai)\b",), 0.82),
+    PatternRule("human_visible", (r"\b(user|customer|client|buyer|human)\b",), 0.72),
+)
+
+
+def normalize_text(text: str) -> str:
+    return " ".join(text.strip().lower().split())
+
+
+def _request_id(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "surrogatepass")).hexdigest()[:16]
+
+
+def _best_signal(rules: Sequence[PatternRule], text: str, fallback: str) -> ElizaLayer:
+    best = ElizaLayer(name="unknown", signal=fallback, confidence=0.0, evidence=())
+    for rule in rules:
+        hits = rule.match(text)
+        if hits and rule.confidence > best.confidence:
+            best = ElizaLayer(name="rule", signal=rule.signal, confidence=rule.confidence, evidence=hits)
+    return best
+
+
+def _collect_layers(text: str) -> tuple[ElizaLayer, ...]:
+    intent = _best_signal(INTENT_RULES, text, "general_support")
+    risk = _best_signal(RISK_RULES, text, "low_risk")
+    context = _best_signal(CONTEXT_RULES, text, "unknown_caller")
+    mode = _best_signal(SUPPORT_MODE_RULES, text, "default_support")
+    return (
+        ElizaLayer("intake", "normalized", 1.0, (text[:120],) if text else ()),
+        ElizaLayer("intent", intent.signal, intent.confidence or 0.5, intent.evidence),
+        ElizaLayer("risk", risk.signal, risk.confidence or 0.4, risk.evidence),
+        ElizaLayer("context", context.signal, context.confidence or 0.4, context.evidence),
+        ElizaLayer("support_mode", mode.signal, mode.confidence or 0.4, mode.evidence),
+    )
+
+
+def _history_layer(history: Sequence[str]) -> ElizaLayer:
+    if not history:
+        return ElizaLayer("history", "single_turn", 0.4, ())
+
+    normalized = [normalize_text(turn) for turn in history if normalize_text(turn)]
+    if len(normalized) >= 3 and len(set(normalized[-3:])) == 1:
+        return ElizaLayer("history", "repeated_loop", 0.9, tuple(normalized[-3:]))
+    if len(normalized) >= 2 and normalized[-1] == normalized[-2]:
+        return ElizaLayer("history", "possible_loop", 0.72, tuple(normalized[-2:]))
+    if len(normalized) >= 3:
+        return ElizaLayer("history", "multi_turn", 0.58, tuple(normalized[-3:]))
+    return ElizaLayer("history", "short_history", 0.5, tuple(normalized))
+
+
+def _layer_signal(layers: Iterable[ElizaLayer], name: str) -> str:
+    for layer in layers:
+        if layer.name == name:
+            return layer.signal
+    return ""
+
+
+def _choose_route(layers: Sequence[ElizaLayer]) -> ElizaRoute:
+    intent = _layer_signal(layers, "intent")
+    risk = _layer_signal(layers, "risk")
+    history = _layer_signal(layers, "history")
+
+    if history in {"possible_loop", "repeated_loop"}:
+        return ElizaRoute(
+            route="agent_support_loop_breaker",
+            action="freeze_and_reduce_to_one_reversible_step",
+            command_switch="loop_break",
+            needs_human=False,
+            allowed=True,
+            reason="request repeated across recent turns",
+        )
+    if risk == "destructive":
+        return ElizaRoute(
+            route="deny_or_human_review",
+            action="stop",
+            command_switch="deny",
+            needs_human=True,
+            allowed=False,
+            reason="destructive command shape detected",
+        )
+    if risk in {"secret_handling", "money_movement"}:
+        return ElizaRoute(
+            route="guarded_support",
+            action="ask_for_redacted_context",
+            command_switch="probe",
+            needs_human=True,
+            allowed=True,
+            reason=f"{risk} needs redaction and explicit confirmation",
+        )
+    if intent == "command_route":
+        return ElizaRoute(
+            route="terminal_command_support",
+            action="emit_governed_command_hint",
+            command_switch="route",
+            needs_human=False,
+            allowed=True,
+            reason="command/CLI intent detected",
+        )
+    if intent == "debug_support":
+        return ElizaRoute(
+            route="debug_triage",
+            action="request_error_receipt",
+            command_switch="diagnose",
+            needs_human=False,
+            allowed=True,
+            reason="debug/failure intent detected",
+        )
+    if intent == "sales_support":
+        return ElizaRoute(
+            route="commerce_support",
+            action="route_to_offer_or_checkout",
+            command_switch="offer",
+            needs_human=False,
+            allowed=True,
+            reason="pricing or checkout intent detected",
+        )
+    if intent == "research_support":
+        return ElizaRoute(
+            route="research_support",
+            action="ask_for_source_scope",
+            command_switch="search",
+            needs_human=False,
+            allowed=True,
+            reason="research/document request detected",
+        )
+    if intent == "agent_distress":
+        return ElizaRoute(
+            route="agent_support_loop_breaker",
+            action="reduce_to_next_safe_switch",
+            command_switch="loop_break",
+            needs_human=False,
+            allowed=True,
+            reason="agent uncertainty or loop signal detected",
+        )
+    if intent == "memory_support":
+        return ElizaRoute(
+            route="context_repair",
+            action="request_compact_state_or_checkpoint",
+            command_switch="memory",
+            needs_human=False,
+            allowed=True,
+            reason="memory/context support requested",
+        )
+    if intent == "model_route":
+        return ElizaRoute(
+            route="model_router_support",
+            action="choose_lowest_sufficient_model_lane",
+            command_switch="model",
+            needs_human=False,
+            allowed=True,
+            reason="model/fallback route requested",
+        )
+    if intent == "handoff_support":
+        return ElizaRoute(
+            route="handoff_support",
+            action="package_handoff_packet",
+            command_switch="handoff",
+            needs_human=False,
+            allowed=True,
+            reason="handoff or swarm delegation requested",
+        )
+    return ElizaRoute(
+        route="general_support",
+        action="ask_clarifying_question",
+        command_switch="ask",
+        needs_human=False,
+        allowed=True,
+        reason="no specific route dominated",
+    )
+
+
+def _response_for(text: str, route: ElizaRoute) -> str:
+    if route.command_switch == "deny":
+        return "I see a command shape that can destroy state. What exact safe outcome are you trying to preserve?"
+    if route.command_switch == "probe":
+        return "This touches secrets, money, or account state. Can you describe the goal with keys and private values redacted?"
+    if route.command_switch == "route":
+        return "You want a command lane. Should I turn this into a governed dry-run, a real run, or a receipt-only plan?"
+    if route.command_switch == "diagnose":
+        return "You are reporting a failure. What is the smallest command, error text, and changed file set?"
+    if route.command_switch == "offer":
+        return "You are asking about buying or selling. Should I route to the $1 self-serve tool, the $99 snapshot, or custom work?"
+    if route.command_switch == "search":
+        return "You want sources. Which vault, repo path, or web scope should be searched first?"
+    if route.command_switch == "loop_break":
+        return "The agent appears stuck. Reduce the task to one reversible next action, one check, and one stop condition."
+    if route.command_switch == "memory":
+        return "You need context repair. Should I request a compact state, a checkpoint, or the last verified receipt?"
+    if route.command_switch == "model":
+        return "You need a model route. What is the cheapest lane that can answer without losing correctness?"
+    if route.command_switch == "handoff":
+        return "You need a handoff. What packet should the next agent receive: goal, constraints, files, or receipts?"
+    if text:
+        return f"You said: '{text[:120]}'. What decision do you need the support layer to make?"
+    return "What should the support layer route?"
+
+
+def _questions_for(route: ElizaRoute) -> tuple[str, ...]:
+    if route.command_switch == "deny":
+        return ("What must not be deleted or overwritten?", "Can this be converted to a read-only inspection first?")
+    if route.command_switch == "probe":
+        return ("Can the input be redacted?", "Who must approve before this touches live state?")
+    if route.command_switch == "route":
+        return ("Should this be dry-run, receipt-only, or executed?", "What workspace boundary applies?")
+    if route.command_switch == "diagnose":
+        return ("What command failed?", "What exact error text should be preserved?")
+    if route.command_switch == "offer":
+        return ("Is this self-serve, snapshot, or custom service?", "Should the checkout route be shown?")
+    if route.command_switch == "search":
+        return ("Which source root should be searched?", "Do you need citations or only routing?")
+    if route.command_switch == "loop_break":
+        return ("What is the smallest reversible next action?", "What check proves the loop is broken?")
+    if route.command_switch == "memory":
+        return ("Which state should be restored?", "What is the last trusted checkpoint?")
+    if route.command_switch == "model":
+        return ("Is this classification, coding, research, or execution?", "What budget or privacy boundary applies?")
+    if route.command_switch == "handoff":
+        return ("Who is the receiving agent?", "What evidence must be included in the handoff?")
+    return ("What outcome should be routed?",)
+
+
+def _command_hints_for(route: ElizaRoute) -> tuple[str, ...]:
+    hints: Mapping[str, tuple[str, ...]] = {
+        "deny": ("do not execute", "open human review", "rewrite as read-only probe"),
+        "probe": ("redact secrets", "request confirmation", "emit audit receipt"),
+        "route": ('scbe run "<command>" --json', "scbe terminal", "scbe shell --agent-json"),
+        "diagnose": ("capture failing command", "collect traceback", "run targeted smoke test"),
+        "offer": ("open docs/payments.html", "show docs/offers.json", "route buyer to checkout"),
+        "search": ("rg <term> <path>", "open source packet", "record citation"),
+        "loop_break": ("stop broad generation", "choose one next action", "emit receipt before continuing"),
+        "memory": ("load compact state", "cite last receipt", "ask for missing checkpoint"),
+        "model": ("try local/cheap lane first", "escalate only with reason", "record model choice"),
+        "handoff": ("build handoff packet", "include goal/constraints/evidence", "name receiving lane"),
+        "ask": ("ask one clarifying question", "choose a route after reply"),
+    }
+    return hints.get(route.command_switch, hints["ask"])
+
+
+def _support_contract_for(layers: Sequence[ElizaLayer], route: ElizaRoute) -> dict:
+    mode = _layer_signal(layers, "support_mode")
+    return {
+        "role": "secondary_mechanical_support_system",
+        "mode": mode,
+        "promise": "classify, route, and ask; do not improvise facts or execute commands",
+        "caller": _layer_signal(layers, "context"),
+        "allowed": route.allowed,
+        "requires_human": route.needs_human,
+        "exit_condition": "caller receives one route, one next action, and explicit stop/escalation state",
+    }
+
+
+def _switchboard_for(route: ElizaRoute) -> tuple[dict, ...]:
+    switches = [
+        {
+            "switch": "ask",
+            "use_when": "missing route-critical context",
+            "output": "one clarifying question",
+            "enabled": route.command_switch == "ask",
+        },
+        {
+            "switch": "route",
+            "use_when": "safe command or workflow lane can be selected",
+            "output": "governed command hint",
+            "enabled": route.command_switch == "route",
+        },
+        {
+            "switch": "diagnose",
+            "use_when": "failure, traceback, or broken workflow",
+            "output": "minimal repro request",
+            "enabled": route.command_switch == "diagnose",
+        },
+        {
+            "switch": "offer",
+            "use_when": "pricing, checkout, or sales support",
+            "output": "product tier route",
+            "enabled": route.command_switch == "offer",
+        },
+        {
+            "switch": "probe",
+            "use_when": "secrets, money, account state, or external publish risk",
+            "output": "redaction and approval request",
+            "enabled": route.command_switch == "probe",
+        },
+        {
+            "switch": "deny",
+            "use_when": "destructive command shape",
+            "output": "stop and human review",
+            "enabled": route.command_switch == "deny",
+        },
+        {
+            "switch": "loop_break",
+            "use_when": "agent is stuck, looping, or carrying conflicting goals",
+            "output": "one reversible next action",
+            "enabled": route.command_switch == "loop_break",
+        },
+        {
+            "switch": "memory",
+            "use_when": "context, state, recap, or checkpoint is missing",
+            "output": "compact-state repair request",
+            "enabled": route.command_switch == "memory",
+        },
+        {
+            "switch": "model",
+            "use_when": "caller needs model/lane selection",
+            "output": "lowest sufficient model route",
+            "enabled": route.command_switch == "model",
+        },
+        {
+            "switch": "handoff",
+            "use_when": "work should move to another agent or squad",
+            "output": "handoff packet fields",
+            "enabled": route.command_switch == "handoff",
+        },
+    ]
+    return tuple(switches)
+
+
+def route_support(text: str, history: Sequence[str] = ()) -> ElizaSupportPacket:
+    """Route a chatbot/human support utterance through mechanical ELIZA layers."""
+    normalized = normalize_text(text)
+    layers = _collect_layers(normalized) + (_history_layer(tuple(history) + (text,)),)
+    route = _choose_route(layers)
+    return ElizaSupportPacket(
+        schema_version=SCHEMA_VERSION,
+        request_id=_request_id(normalized),
+        user_text=text,
+        normalized_text=normalized,
+        layers=layers,
+        route=route,
+        response=_response_for(text.strip(), route),
+        next_questions=_questions_for(route),
+        command_hints=_command_hints_for(route),
+        support_contract=_support_contract_for(layers, route),
+        switchboard=_switchboard_for(route),
+    )
+
+
+def route_dialogue(turns: Sequence[str]) -> ElizaSupportPacket:
+    """Route the latest turn with prior turns available for loop/context checks."""
+    if not turns:
+        return route_support("")
+    return route_support(turns[-1], history=turns[:-1])

--- a/scripts/system/mechanical_eliza_support.py
+++ b/scripts/system/mechanical_eliza_support.py
@@ -1,0 +1,67 @@
+"""Mechanical ELIZA support router CLI.
+
+Use this as a secondary support system for chatbots and command agents:
+
+    python scripts/system/mechanical_eliza_support.py "run tests but don't break anything"
+    python scripts/system/mechanical_eliza_support.py --text-file request.txt --pretty
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from python.scbe.mechanical_eliza import route_dialogue, route_support
+
+
+def _read_text(args: argparse.Namespace) -> str:
+    chunks: list[str] = []
+    if args.text:
+        chunks.extend(args.text)
+    if args.text_file:
+        chunks.append(Path(args.text_file).read_text(encoding="utf-8"))
+    if args.stdin:
+        chunks.append(sys.stdin.read())
+    return "\n".join(chunk for chunk in chunks if chunk is not None)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("text", nargs="*", help="Support request text.")
+    parser.add_argument("--text-file", help="Read support request text from a UTF-8 file.")
+    parser.add_argument(
+        "--history-file",
+        help="Read prior dialogue turns from a UTF-8 file, one turn per line. The request text is appended as the latest turn.",
+    )
+    parser.add_argument("--stdin", action="store_true", help="Read support request text from stdin.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    parser.add_argument("--response-only", action="store_true", help="Print only the ELIZA-style support response.")
+    args = parser.parse_args(argv)
+
+    text = _read_text(args)
+    if args.history_file:
+        history = [
+            line.strip()
+            for line in Path(args.history_file).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        packet = route_dialogue(history + ([text] if text else []))
+    else:
+        packet = route_support(text)
+    if args.response_only:
+        print(packet.response)
+        return 0
+
+    indent = 2 if args.pretty else None
+    print(json.dumps(packet.as_dict(), indent=indent, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mechanical_eliza.py
+++ b/tests/test_mechanical_eliza.py
@@ -1,0 +1,64 @@
+from python.scbe.mechanical_eliza import SCHEMA_VERSION, route_dialogue, route_support
+
+
+def test_routes_cli_request_to_command_switch():
+    packet = route_support("chatbot needs support: run pytest from the terminal")
+
+    assert packet.schema_version == SCHEMA_VERSION
+    assert packet.route.route == "terminal_command_support"
+    assert packet.route.command_switch == "route"
+    assert packet.route.allowed is True
+    assert 'scbe run "<command>" --json' in packet.command_hints
+    assert packet.support_contract["role"] == "secondary_mechanical_support_system"
+
+
+def test_denies_destructive_command_shape():
+    packet = route_support("agent wants to run rm -rf on the workspace")
+
+    assert packet.route.command_switch == "deny"
+    assert packet.route.allowed is False
+    assert packet.route.needs_human is True
+    assert "destructive" in packet.route.reason
+
+
+def test_secret_and_money_routes_to_probe():
+    packet = route_support("help my chatbot use the Stripe sk_live secret to make a checkout")
+
+    assert packet.route.command_switch == "probe"
+    assert packet.route.allowed is True
+    assert packet.route.needs_human is True
+    assert "redacted" in packet.response.lower()
+
+
+def test_agent_loop_breaker_switch():
+    packet = route_support("the assistant is confused and looping and cannot decide")
+
+    assert packet.route.route == "agent_support_loop_breaker"
+    assert packet.route.command_switch == "loop_break"
+    assert any(row["switch"] == "loop_break" and row["enabled"] for row in packet.switchboard)
+
+
+def test_dialogue_repetition_breaks_loop_even_without_keywords():
+    packet = route_dialogue(["what next", "what next", "what next"])
+
+    assert packet.route.command_switch == "loop_break"
+    assert packet.route.reason == "request repeated across recent turns"
+
+
+def test_memory_model_and_handoff_lanes():
+    memory = route_support("restore the last checkpoint and compact state")
+    model = route_support("choose a cheap local model fallback")
+    handoff = route_support("handoff this to the swarm with receipts")
+
+    assert memory.route.command_switch == "memory"
+    assert model.route.command_switch == "model"
+    assert handoff.route.command_switch == "handoff"
+
+
+def test_packet_is_json_ready():
+    packet = route_support("customer asks what to buy")
+    data = packet.as_dict()
+
+    assert data["schema_version"] == SCHEMA_VERSION
+    assert isinstance(data["layers"], list)
+    assert data["route"]["command_switch"] == "offer"


### PR DESCRIPTION
## Summary
- adds `python.scbe.mechanical_eliza`, a deterministic layered ELIZA-style support router for chatbots and command agents
- adds CLI wrapper: `python scripts/system/mechanical_eliza_support.py`
- documents the Mechanical ELIZA switchboard as part of the public Workcell CLI/tooling path
- exposes AI-readable discovery in `docs/robot.md` and `docs/llms.txt`

## What it routes
- command support
- debug triage
- checkout/sales support
- research/source support
- loop breaking
- memory/context repair
- model-lane selection
- handoff packets
- guarded escalation / deny for destructive or sensitive routes

## Validation
- `python -m pytest tests\test_mechanical_eliza.py -q`
- `git diff --check`