### PR TITLE
feat(agent): bridge mechanical eliza to free llm and rpg routing

### DIFF
--- a/docs/MECHANICAL_ELIZA_SUPPORT.md
+++ b/docs/MECHANICAL_ELIZA_SUPPORT.md
@@ -29,6 +29,9 @@ The output is a `scbe.mechanical_eliza.v1` JSON packet with:
 - command hints;
 - a support contract;
 - the full switchboard state.
+- an optional Free LLM bridge request.
+- an optional semantic navigation array.
+- an optional ChoiceScript-style scene.
 
 ## Switches
 
@@ -57,6 +60,31 @@ Response-only mode:
 python scripts/system/mechanical_eliza_support.py --response-only "the assistant is confused and looping"
 ```
 
+Free LLM routing request without calling a model:
+
+```powershell
+python scripts/system/mechanical_eliza_support.py --pretty --free-llm-request "true eliza should use the free llm route"
+```
+
+Call the repo's Free LLM dispatcher through ELIZA. This defaults to dry-run unless
+`--live-model` is set:
+
+```powershell
+python scripts/system/mechanical_eliza_support.py --pretty --dispatch-free-llm --provider offline "true eliza should call the free llm route"
+```
+
+ChoiceScript-style navigation:
+
+```powershell
+python scripts/system/mechanical_eliza_support.py --choicescript "customer asks what to buy"
+```
+
+Semantic navigation array:
+
+```powershell
+python scripts/system/mechanical_eliza_support.py --semantic-map --pretty "chatbot is looping and confused"
+```
+
 Multi-turn loop detection:
 
 ```powershell
@@ -71,8 +99,9 @@ python scripts/system/mechanical_eliza_support.py --history-file .\history.txt -
 ## Product Boundary
 
 This is a deterministic support switchboard. It does not execute commands, call
-Stripe, read secrets, or browse the web. It is meant to sit in front of those
-systems and tell the calling AI which route is allowed next.
+Stripe, read secrets, or browse the web. When `--dispatch-free-llm` is used, it
+calls the existing free/open LLM router only after the mechanical route is
+chosen. Without `--live-model`, that dispatch is a dry-run route receipt.
 
 That makes it suitable for the $1 self-serve Workcell CLI path: buyers can use
 it as a simple mechanical support layer for their own chatbots before they need

--- a/python/scbe/__init__.py
+++ b/python/scbe/__init__.py
@@ -154,6 +154,9 @@ from .mechanical_eliza import (
     ElizaLayer,
     ElizaRoute,
     ElizaSupportPacket,
+    build_choicescript_navigation,
+    build_free_llm_dispatch_request,
+    build_semantic_navigation,
     route_dialogue,
     route_support,
 )
@@ -223,6 +226,9 @@ __all__ += [
     "ElizaLayer",
     "ElizaRoute",
     "ElizaSupportPacket",
+    "build_choicescript_navigation",
+    "build_free_llm_dispatch_request",
+    "build_semantic_navigation",
     "route_dialogue",
     "route_support",
 ]

--- a/python/scbe/mechanical_eliza.py
+++ b/python/scbe/mechanical_eliza.py
@@ -14,6 +14,8 @@ import re
 from typing import Iterable, Mapping, Sequence
 
 SCHEMA_VERSION = "scbe.mechanical_eliza.v1"
+MODEL_BRIDGE_VERSION = "scbe.mechanical_eliza.free_llm_bridge.v1"
+NAVIGATION_VERSION = "scbe.mechanical_eliza.semantic_navigation.v1"
 
 
 @dataclass(frozen=True)
@@ -563,3 +565,209 @@ def route_dialogue(turns: Sequence[str]) -> ElizaSupportPacket:
     if not turns:
         return route_support("")
     return route_support(turns[-1], history=turns[:-1])
+
+
+def build_free_llm_dispatch_request(
+    packet: ElizaSupportPacket,
+    *,
+    provider: str | None = "offline",
+    model: str | None = None,
+    dry_run: bool = True,
+    require_free: bool = True,
+) -> dict:
+    """Build a Free LLM router request after Mechanical ELIZA has chosen a route.
+
+    This keeps ELIZA as the first switch. The model is asked to support the
+    chosen route, not to decide the route from scratch.
+    """
+
+    system = (
+        "You are SCBE Mechanical ELIZA, a secondary support layer for chatbots. "
+        "Follow the route packet. Do not execute commands, request secrets, or "
+        "invent capabilities. Return one concise next action."
+    )
+    prompt = "\n".join(
+        [
+            f"User text: {packet.user_text}",
+            f"Mechanical route: {packet.route.route}",
+            f"Command switch: {packet.route.command_switch}",
+            f"Allowed: {packet.route.allowed}",
+            f"Requires human: {packet.route.needs_human}",
+            f"Reason: {packet.route.reason}",
+            f"Mechanical response: {packet.response}",
+            "Next questions:",
+            *[f"- {question}" for question in packet.next_questions],
+            "Command hints:",
+            *[f"- {hint}" for hint in packet.command_hints],
+        ]
+    )
+    return {
+        "bridge_version": MODEL_BRIDGE_VERSION,
+        "dispatch": {
+            "prompt": prompt,
+            "provider": provider,
+            "model": model,
+            "system": system,
+            "temperature": 0.2,
+            "max_tokens": 512,
+            "require_free": require_free,
+            "dry_run": dry_run,
+            "metadata": {
+                "source": "mechanical_eliza",
+                "request_id": packet.request_id,
+                "route": packet.route.route,
+                "command_switch": packet.route.command_switch,
+                "allowed": packet.route.allowed,
+                "needs_human": packet.route.needs_human,
+            },
+        },
+    }
+
+
+def build_semantic_navigation(packet: ElizaSupportPacket) -> dict:
+    """Render the ELIZA switchboard as a semantic navigation array."""
+
+    nodes = [
+        {
+            "id": "start",
+            "kind": "scene",
+            "label": "ELIZA intake",
+            "text": packet.response,
+            "active": True,
+        }
+    ]
+    edges = []
+    for switch in packet.switchboard:
+        switch_id = f"switch:{switch['switch']}"
+        nodes.append(
+            {
+                "id": switch_id,
+                "kind": "switch",
+                "label": switch["switch"],
+                "text": switch["use_when"],
+                "output": switch["output"],
+                "active": bool(switch["enabled"]),
+            }
+        )
+        edges.append(
+            {
+                "from": "start",
+                "to": switch_id,
+                "condition": "enabled" if switch["enabled"] else "available",
+                "weight": 1.0 if switch["enabled"] else 0.25,
+            }
+        )
+
+    for idx, question in enumerate(packet.next_questions, start=1):
+        node_id = f"question:{idx}"
+        nodes.append(
+            {
+                "id": node_id,
+                "kind": "question",
+                "label": f"Question {idx}",
+                "text": question,
+                "active": True,
+            }
+        )
+        edges.append(
+            {
+                "from": f"switch:{packet.route.command_switch}",
+                "to": node_id,
+                "condition": "ask_next",
+                "weight": 0.8,
+            }
+        )
+
+    for idx, hint in enumerate(packet.command_hints, start=1):
+        node_id = f"hint:{idx}"
+        nodes.append(
+            {
+                "id": node_id,
+                "kind": "command_hint",
+                "label": f"Hint {idx}",
+                "text": hint,
+                "active": packet.route.allowed,
+            }
+        )
+        edges.append(
+            {
+                "from": f"switch:{packet.route.command_switch}",
+                "to": node_id,
+                "condition": "allowed_hint" if packet.route.allowed else "blocked_hint",
+                "weight": 0.7,
+            }
+        )
+
+    return {
+        "version": NAVIGATION_VERSION,
+        "request_id": packet.request_id,
+        "route": packet.route.route,
+        "active_switch": packet.route.command_switch,
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+
+def build_choicescript_navigation(packet: ElizaSupportPacket) -> str:
+    """Export a ChoiceScript-flavored support map for RPG-style navigation."""
+
+    lines = [
+        "*title Mechanical ELIZA Support Switchboard",
+        "*scene_list",
+        "  start",
+        "  route",
+        "  questions",
+        "  hints",
+        "  finish",
+        "",
+        "*label start",
+        packet.response,
+        "",
+        "*choice",
+    ]
+    for switch in packet.switchboard:
+        prefix = "[ACTIVE] " if switch["enabled"] else ""
+        lines.extend(
+            [
+                f"  #{prefix}{switch['switch']} - {switch['output']}",
+                "    *goto route",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "*label route",
+            f"*comment route: {packet.route.route}",
+            f"*comment action: {packet.route.action}",
+            f"*comment allowed: {str(packet.route.allowed).lower()}",
+            f"*comment reason: {packet.route.reason}",
+            "",
+            "*choice",
+            "  #Ask the next support question",
+            "    *goto questions",
+            "  #Inspect command hints",
+            "    *goto hints",
+            "  #End with the mechanical route receipt",
+            "    *goto finish",
+            "",
+            "*label questions",
+        ]
+    )
+    for question in packet.next_questions:
+        lines.append(f"- {question}")
+    lines.extend(["", "*goto finish", "", "*label hints"])
+    for hint in packet.command_hints:
+        lines.append(f"- {hint}")
+    lines.extend(
+        [
+            "",
+            "*goto finish",
+            "",
+            "*label finish",
+            f"Mechanical ELIZA selected `${packet.route.command_switch}`.",
+            "*finish",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/scripts/system/mechanical_eliza_support.py
+++ b/scripts/system/mechanical_eliza_support.py
@@ -17,7 +17,13 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from python.scbe.mechanical_eliza import route_dialogue, route_support
+from python.scbe.mechanical_eliza import (
+    build_choicescript_navigation,
+    build_free_llm_dispatch_request,
+    build_semantic_navigation,
+    route_dialogue,
+    route_support,
+)
 
 
 def _read_text(args: argparse.Namespace) -> str:
@@ -52,6 +58,39 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print only the ELIZA-style support response.",
     )
+    parser.add_argument(
+        "--choicescript",
+        action="store_true",
+        help="Print a ChoiceScript-style navigation scene.",
+    )
+    parser.add_argument(
+        "--semantic-map",
+        action="store_true",
+        help="Print the semantic navigation array.",
+    )
+    parser.add_argument(
+        "--free-llm-request",
+        action="store_true",
+        help="Include a Free LLM dispatch request in the JSON.",
+    )
+    parser.add_argument(
+        "--dispatch-free-llm",
+        action="store_true",
+        help="Call the repo's Free LLM dispatcher after ELIZA routes.",
+    )
+    parser.add_argument(
+        "--provider",
+        default="offline",
+        help="Free LLM provider id for request/dispatch.",
+    )
+    parser.add_argument(
+        "--model", default=None, help="Optional model override for Free LLM routing."
+    )
+    parser.add_argument(
+        "--live-model",
+        action="store_true",
+        help="Actually call the selected provider. Without this, dispatch uses dry-run.",
+    )
     args = parser.parse_args(argv)
 
     text = _read_text(args)
@@ -67,9 +106,38 @@ def main(argv: list[str] | None = None) -> int:
     if args.response_only:
         print(packet.response)
         return 0
+    if args.choicescript:
+        print(build_choicescript_navigation(packet))
+        return 0
+    if args.semantic_map:
+        print(
+            json.dumps(
+                build_semantic_navigation(packet),
+                indent=2 if args.pretty else None,
+                sort_keys=True,
+            )
+        )
+        return 0
 
     indent = 2 if args.pretty else None
-    print(json.dumps(packet.as_dict(), indent=indent, sort_keys=True))
+    payload = packet.as_dict()
+    if args.free_llm_request or args.dispatch_free_llm:
+        payload["free_llm_bridge"] = build_free_llm_dispatch_request(
+            packet,
+            provider=args.provider,
+            model=args.model,
+            dry_run=not args.live_model,
+        )
+    if args.dispatch_free_llm:
+        from src.api import free_llm_routes
+
+        dispatch = payload["free_llm_bridge"]["dispatch"]
+        payload["free_llm_result"] = free_llm_routes.dispatch_free_llm_request(
+            free_llm_routes.FreeLLMDispatchRequest(**dispatch),
+            user="mechanical-eliza",
+            origin="inside",
+        )
+    print(json.dumps(payload, indent=indent, sort_keys=True))
     return 0
 
 

--- a/tests/test_mechanical_eliza.py
+++ b/tests/test_mechanical_eliza.py
@@ -1,4 +1,13 @@
-from python.scbe.mechanical_eliza import SCHEMA_VERSION, route_dialogue, route_support
+from python.scbe.mechanical_eliza import (
+    MODEL_BRIDGE_VERSION,
+    NAVIGATION_VERSION,
+    SCHEMA_VERSION,
+    build_choicescript_navigation,
+    build_free_llm_dispatch_request,
+    build_semantic_navigation,
+    route_dialogue,
+    route_support,
+)
 
 
 def test_routes_cli_request_to_command_switch():
@@ -66,3 +75,40 @@ def test_packet_is_json_ready():
     assert data["schema_version"] == SCHEMA_VERSION
     assert isinstance(data["layers"], list)
     assert data["route"]["command_switch"] == "offer"
+
+
+def test_builds_free_llm_dispatch_request_after_mechanical_route():
+    packet = route_support("true eliza should use a cheap local model route")
+    bridge = build_free_llm_dispatch_request(
+        packet, provider="offline", model="scbe-offline-control-plane"
+    )
+
+    assert bridge["bridge_version"] == MODEL_BRIDGE_VERSION
+    dispatch = bridge["dispatch"]
+    assert dispatch["provider"] == "offline"
+    assert dispatch["dry_run"] is True
+    assert dispatch["require_free"] is True
+    assert dispatch["metadata"]["source"] == "mechanical_eliza"
+    assert dispatch["metadata"]["command_switch"] == packet.route.command_switch
+    assert "Mechanical route:" in dispatch["prompt"]
+
+
+def test_builds_semantic_navigation_array():
+    packet = route_support("chatbot is looping and confused")
+    nav = build_semantic_navigation(packet)
+
+    assert nav["version"] == NAVIGATION_VERSION
+    assert nav["active_switch"] == "loop_break"
+    assert any(
+        node["id"] == "switch:loop_break" and node["active"] for node in nav["nodes"]
+    )
+    assert any(edge["from"] == "start" for edge in nav["edges"])
+
+
+def test_builds_choicescript_navigation_scene():
+    packet = route_support("customer asks what to buy")
+    scene = build_choicescript_navigation(packet)
+
+    assert "*title Mechanical ELIZA Support Switchboard" in scene
+    assert "#[ACTIVE] offer" in scene
+    assert "*comment route: commerce_support" in scene


### PR DESCRIPTION
## Summary
- adds a Mechanical ELIZA -> Free LLM bridge request so ELIZA can route model calls after deterministic classification
- adds semantic navigation arrays for AI/system routing maps
- adds ChoiceScript-style RPG scene export for navigating support switches and semantic arrays
- exposes CLI flags: `--free-llm-request`, `--dispatch-free-llm`, `--choicescript`, and `--semantic-map`
- documents the true-ELIZA / RPG navigation usage

## Validation
- `python -m pytest tests\test_mechanical_eliza.py tests\api\test_free_llm_routes.py -q`
- `python -m black --check --target-version py312 python\scbe\mechanical_eliza.py scripts\system\mechanical_eliza_support.py tests\test_mechanical_eliza.py`
- `git diff --check`
- `python scripts\system\mechanical_eliza_support.py --dispatch-free-llm --provider offline "true eliza should call the free llm route" | python -m json.tool > $null`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Free LLM dispatcher routing with new CLI flags (`--free-llm-request`, `--dispatch-free-llm`, `--provider`, `--live-model`).
  * Introduced ChoiceScript and semantic navigation output formats.

* **Documentation**
  * Updated CLI documentation with new routing options and output format guidance.

* **Tests**
  * Added unit tests for Free LLM dispatch, semantic navigation, and ChoiceScript functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->