### PR TITLE
security: address codeql secret handling and dependency alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
-      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
+      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -609,9 +609,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -641,12 +641,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/core": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -657,13 +657,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
-      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -674,14 +674,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
-      "integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.8.0.tgz",
+      "integrity": "sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.7.1",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
+        "@opentelemetry/context-async-hooks": "2.8.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"

--- a/package.json
+++ b/package.json
@@ -324,6 +324,10 @@
     "qs": "^6.15.2",
     "minimatch@10.2.5": {
       "brace-expansion": "^5.0.6"
-    }
+    },
+    "@opentelemetry/core": "2.8.0",
+    "@opentelemetry/resources": "2.8.0",
+    "@opentelemetry/sdk-trace-base": "2.8.0",
+    "@opentelemetry/sdk-trace-node": "2.8.0"
   }
 }

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -145,7 +145,7 @@ opentelemetry-processor-baggage==0.63b1
 opentelemetry-propagator-aws-xray==1.0.2
 opentelemetry-propagator-b3==1.42.1
 opentelemetry-propagator-jaeger==1.42.1
-opentelemetry-propagator-ot-trace==0.62b0
+opentelemetry-propagator-ot-trace==0.63b1
 opentelemetry-proto==1.42.1
 opentelemetry-sdk==1.42.1
 opentelemetry-sdk-extension-aws==2.1.0

--- a/scripts/benchmark/scbe_full_benchmark.py
+++ b/scripts/benchmark/scbe_full_benchmark.py
@@ -30,33 +30,118 @@ from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _safe_log_text(value: object) -> str:
+    text = str(value)
+    for marker in ("sk-", "rk_", "ghp_", "hf_", "xai-", "SAM-"):
+        if marker in text:
+            return "[redacted-sensitive-error]"
+    return text.replace("\r", "\\r").replace("\n", "\\n")[:240]
+
+
 sys.path.insert(0, str(REPO_ROOT))
 
 # ── External published baselines ──────────────────────────────────────────────
 
 EXTERNAL_BASELINES = {
     "safety_classifiers": [
-        {"name": "WildGuard", "score": 0.877, "metric": "balanced_accuracy", "source": "arxiv:2406.18495"},
-        {"name": "LlamaGuard-3", "score": 0.825, "metric": "balanced_accuracy", "source": "Meta AI, 2024"},
-        {"name": "GPT-4-based", "score": 0.860, "metric": "balanced_accuracy", "source": "OpenAI safety eval, 2024"},
-        {"name": "ShieldLM", "score": 0.803, "metric": "balanced_accuracy", "source": "arxiv:2402.09571"},
+        {
+            "name": "WildGuard",
+            "score": 0.877,
+            "metric": "balanced_accuracy",
+            "source": "arxiv:2406.18495",
+        },
+        {
+            "name": "LlamaGuard-3",
+            "score": 0.825,
+            "metric": "balanced_accuracy",
+            "source": "Meta AI, 2024",
+        },
+        {
+            "name": "GPT-4-based",
+            "score": 0.860,
+            "metric": "balanced_accuracy",
+            "source": "OpenAI safety eval, 2024",
+        },
+        {
+            "name": "ShieldLM",
+            "score": 0.803,
+            "metric": "balanced_accuracy",
+            "source": "arxiv:2402.09571",
+        },
     ],
     "llm_quality_mmlu": [
-        {"name": "llama-3.3-70b", "score": 0.832, "metric": "5-shot MMLU", "source": "Meta AI blog 2024"},
-        {"name": "gpt-4o-mini", "score": 0.820, "metric": "5-shot MMLU", "source": "OpenAI evals 2024"},
-        {"name": "gpt-4o", "score": 0.887, "metric": "5-shot MMLU", "source": "OpenAI evals 2024"},
-        {"name": "claude-3.5-sonnet", "score": 0.889, "metric": "5-shot MMLU", "source": "Anthropic evals 2024"},
+        {
+            "name": "llama-3.3-70b",
+            "score": 0.832,
+            "metric": "5-shot MMLU",
+            "source": "Meta AI blog 2024",
+        },
+        {
+            "name": "gpt-4o-mini",
+            "score": 0.820,
+            "metric": "5-shot MMLU",
+            "source": "OpenAI evals 2024",
+        },
+        {
+            "name": "gpt-4o",
+            "score": 0.887,
+            "metric": "5-shot MMLU",
+            "source": "OpenAI evals 2024",
+        },
+        {
+            "name": "claude-3.5-sonnet",
+            "score": 0.889,
+            "metric": "5-shot MMLU",
+            "source": "Anthropic evals 2024",
+        },
     ],
     "cli_capability": [
-        {"name": "claude-code", "score": 1.0, "metric": "11/11 criteria", "source": "docs.claude.com"},
-        {"name": "gemini-cli", "score": 0.909, "metric": "10/11 criteria", "source": "geminicli.com/docs"},
-        {"name": "codex-cli", "score": 0.818, "metric": "9/11 criteria", "source": "help.openai.com"},
-        {"name": "aider", "score": 0.727, "metric": "8/11 criteria", "source": "aider.chat/docs"},
+        {
+            "name": "claude-code",
+            "score": 1.0,
+            "metric": "11/11 criteria",
+            "source": "docs.claude.com",
+        },
+        {
+            "name": "gemini-cli",
+            "score": 0.909,
+            "metric": "10/11 criteria",
+            "source": "geminicli.com/docs",
+        },
+        {
+            "name": "codex-cli",
+            "score": 0.818,
+            "metric": "9/11 criteria",
+            "source": "help.openai.com",
+        },
+        {
+            "name": "aider",
+            "score": 0.727,
+            "metric": "8/11 criteria",
+            "source": "aider.chat/docs",
+        },
     ],
     "latency_p50_ms": [
-        {"name": "cerebras llama", "score": 920, "metric": "p50 TTFT ms", "source": "artificialanalysis.ai 2025"},
-        {"name": "groq llama", "score": 2659, "metric": "p50 TTFT ms", "source": "artificialanalysis.ai 2025"},
-        {"name": "openai gpt-4o-mini", "score": 1500, "metric": "p50 TTFT ms", "source": "artificialanalysis.ai 2025"},
+        {
+            "name": "cerebras llama",
+            "score": 920,
+            "metric": "p50 TTFT ms",
+            "source": "artificialanalysis.ai 2025",
+        },
+        {
+            "name": "groq llama",
+            "score": 2659,
+            "metric": "p50 TTFT ms",
+            "source": "artificialanalysis.ai 2025",
+        },
+        {
+            "name": "openai gpt-4o-mini",
+            "score": 1500,
+            "metric": "p50 TTFT ms",
+            "source": "artificialanalysis.ai 2025",
+        },
     ],
 }
 
@@ -65,7 +150,12 @@ EXTERNAL_BASELINES = {
 KNOWLEDGE_QUESTIONS = [
     {
         "q": "What is the speed of light in a vacuum (approximate)?",
-        "choices": {"A": "3×10^8 m/s", "B": "3×10^6 m/s", "C": "3×10^10 m/s", "D": "1×10^6 m/s"},
+        "choices": {
+            "A": "3×10^8 m/s",
+            "B": "3×10^6 m/s",
+            "C": "3×10^10 m/s",
+            "D": "1×10^6 m/s",
+        },
         "answer": "A",
         "category": "physics",
     },
@@ -110,7 +200,12 @@ KNOWLEDGE_QUESTIONS = [
         "answer": "B",
         "category": "biology",
     },
-    {"q": "What is √144?", "choices": {"A": "12", "B": "14", "C": "11", "D": "13"}, "answer": "A", "category": "math"},
+    {
+        "q": "What is √144?",
+        "choices": {"A": "12", "B": "14", "C": "11", "D": "13"},
+        "answer": "A",
+        "category": "math",
+    },
     {
         "q": "What does HTTP stand for?",
         "choices": {
@@ -197,7 +292,10 @@ def _measure_petri_recall() -> dict[str, Any]:
         return {"recall": None, "hit": 0, "total": 0, "corpus_available": False}
 
     try:
-        from src.cli.petri_pattern_filter import is_meta_ai_auditor_phrasing, is_non_latin_script_input
+        from src.cli.petri_pattern_filter import (
+            is_meta_ai_auditor_phrasing,
+            is_non_latin_script_input,
+        )
 
         total, hit, regex_only, tongue_only, both_hit = 0, 0, 0, 0, 0
         for f in sorted(seeds_dir.glob("*.md")):
@@ -227,7 +325,13 @@ def _measure_petri_recall() -> dict[str, Any]:
             "both": both_hit,
         }
     except Exception as exc:
-        return {"recall": None, "hit": 0, "total": 0, "corpus_available": False, "error": str(exc)}
+        return {
+            "recall": None,
+            "hit": 0,
+            "total": 0,
+            "corpus_available": False,
+            "error": str(exc),
+        }
 
 
 # ── Layer 2: CLI capability ───────────────────────────────────────────────────
@@ -256,7 +360,10 @@ def run_cli_benchmark() -> dict[str, Any]:
                     full_data = json.loads(Path(summary["json"]).read_text())
                 except Exception:
                     pass
-            scbe_row = next((r for r in ranking if r["name"] == "scbe-geoseal"), ranking[0] if ranking else {})
+            scbe_row = next(
+                (r for r in ranking if r["name"] == "scbe-geoseal"),
+                ranking[0] if ranking else {},
+            )
             return {
                 "ok": True,
                 "scbe_score": scbe_row,
@@ -265,7 +372,12 @@ def run_cli_benchmark() -> dict[str, Any]:
                 "elapsed_s": elapsed,
             }
         except Exception as exc:
-            return {"ok": False, "error": str(exc), "raw": proc.stdout[:500], "elapsed_s": elapsed}
+            return {
+                "ok": False,
+                "error": str(exc),
+                "raw": proc.stdout[:500],
+                "elapsed_s": elapsed,
+            }
     return {"ok": False, "error": proc.stderr[:500], "elapsed_s": elapsed}
 
 
@@ -273,7 +385,12 @@ def run_cli_benchmark() -> dict[str, Any]:
 
 
 def _openai_chat_request(
-    base_url: str, api_key: str, model: str, prompt: str, timeout: int = 30, max_tokens: int = 500
+    base_url: str,
+    api_key: str,
+    model: str,
+    prompt: str,
+    timeout: int = 30,
+    max_tokens: int = 500,
 ) -> tuple[str, float]:
     """Fire a single chat completion request and return (response_text, latency_ms).
     max_tokens=500 required for reasoning models (zai-glm-4.7, gpt-oss-*) to complete chain-of-thought.
@@ -325,13 +442,22 @@ def run_squad_latency_benchmark() -> dict[str, Any]:
         ("groq", "https://api.groq.com/openai/v1", groq_key, "llama-3.3-70b-versatile"),
     ]:
         if not api_key:
-            providers.append({"provider": name, "ok": False, "error": "no api key", "latencies_ms": []})
+            providers.append(
+                {
+                    "provider": name,
+                    "ok": False,
+                    "error": "no api key",
+                    "latencies_ms": [],
+                }
+            )
             continue
 
         latencies = []
         errors = []
         for _ in range(3):
-            resp, ms = _openai_chat_request(base_url, api_key, model, ping_prompt, timeout=30, max_tokens=200)
+            resp, ms = _openai_chat_request(
+                base_url, api_key, model, ping_prompt, timeout=30, max_tokens=200
+            )
             if resp.startswith("ERROR:"):
                 errors.append(resp)
             else:
@@ -395,11 +521,23 @@ def run_knowledge_benchmark(skip_live: bool = False) -> dict[str, Any]:
     providers_tested = []
 
     for name, base_url, api_key, model in [
-        ("cerebras", "https://api.cerebras.ai/v1", os.environ.get("CEREBRAS_API_KEY", ""), "zai-glm-4.7"),
-        ("groq", "https://api.groq.com/openai/v1", os.environ.get("GROQ_API_KEY", ""), "llama-3.3-70b-versatile"),
+        (
+            "cerebras",
+            "https://api.cerebras.ai/v1",
+            os.environ.get("CEREBRAS_API_KEY", ""),
+            "zai-glm-4.7",
+        ),
+        (
+            "groq",
+            "https://api.groq.com/openai/v1",
+            os.environ.get("GROQ_API_KEY", ""),
+            "llama-3.3-70b-versatile",
+        ),
     ]:
         if not api_key:
-            providers_tested.append({"provider": name, "ok": False, "error": "no api key"})
+            providers_tested.append(
+                {"provider": name, "ok": False, "error": "no api key"}
+            )
             continue
 
         correct = 0
@@ -410,7 +548,9 @@ def run_knowledge_benchmark(skip_live: bool = False) -> dict[str, Any]:
                 "Multiple choice. Reply with ONLY the letter of the correct answer (A, B, C, or D)."
                 f"\n\nQuestion: {q['q']}\n{choices_str}"
             )
-            resp, ms = _openai_chat_request(base_url, api_key, model, prompt, timeout=45, max_tokens=600)
+            resp, ms = _openai_chat_request(
+                base_url, api_key, model, prompt, timeout=45, max_tokens=600
+            )
             predicted = _extract_answer_letter(resp)
             hit = predicted == q["answer"] if predicted else False
             if hit:
@@ -500,9 +640,15 @@ def compute_composite(gov, cli, latency, knowledge, tests) -> dict[str, Any]:
     # Use live Petri recall if available; fall back to published blind-holdout.
     petri_recall = gov.get("petri_pattern_filter_recall")
     if petri_recall is not None:
-        gov_score = petri_recall * 0.5 + gov.get("accuracy", 0) * 0.5 if gov.get("ok") else 0
+        gov_score = (
+            petri_recall * 0.5 + gov.get("accuracy", 0) * 0.5 if gov.get("ok") else 0
+        )
     else:
-        gov_score = gov.get("blind_detection_rate", 0) * 0.4 + gov.get("accuracy", 0) * 0.6 if gov.get("ok") else 0
+        gov_score = (
+            gov.get("blind_detection_rate", 0) * 0.4 + gov.get("accuracy", 0) * 0.6
+            if gov.get("ok")
+            else 0
+        )
     cli_score = cli["scbe_score"]["score"] if cli.get("ok") else 0
     lat_score = _latency_score(latency.get("providers", []))
     know_score = 0.0
@@ -527,7 +673,10 @@ def compute_composite(gov, cli, latency, knowledge, tests) -> dict[str, Any]:
     return {
         "composite": composite,
         "grade": _grade(composite),
-        "parts": {k: {"score": round(s, 3) if s is not None else None, "weight": w} for k, (s, w) in parts.items()},
+        "parts": {
+            k: {"score": round(s, 3) if s is not None else None, "weight": w}
+            for k, (s, w) in parts.items()
+        },
         "effective_weight": round(effective_weight, 3),
     }
 
@@ -550,7 +699,9 @@ def _grade(score: float) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--json", action="store_true")
-    parser.add_argument("--skip-live", action="store_true", help="Skip live provider calls")
+    parser.add_argument(
+        "--skip-live", action="store_true", help="Skip live provider calls"
+    )
     args = parser.parse_args()
 
     print("SCBE-AETHERMOORE Full System Benchmark", flush=True)
@@ -577,7 +728,9 @@ def main() -> int:
     print("\n[2/5] CLI capability...", flush=True)
     cli = run_cli_benchmark()
     if cli.get("ok"):
-        scbe_row = next((r for r in cli["ranking"] if r["name"] == "scbe-geoseal"), None)
+        scbe_row = next(
+            (r for r in cli["ranking"] if r["name"] == "scbe-geoseal"), None
+        )
         scbe_pos = cli["ranking"].index(scbe_row) + 1 if scbe_row else "?"
         print(
             f"      scbe: {scbe_row['score']:.1%} ({scbe_row['passed']}/{scbe_row['total']}) "
@@ -592,9 +745,13 @@ def main() -> int:
         latency = run_squad_latency_benchmark()
         for p in latency["providers"]:
             if p.get("ok"):
-                print(f"      {p['provider']:12s}  p50={p['p50_ms']:.0f}ms  ({p['latencies_ms']})")
+                print(
+                    f"      {p['provider']:12s}  p50={p['p50_ms']:.0f}ms  ({p['latencies_ms']})"
+                )
             else:
-                print(f"      {p['provider']:12s}  {p.get('error', 'failed')}")
+                print(
+                    f"      {p['provider']:12s}  {_safe_log_text(p.get('error', 'failed'))}"
+                )
 
     print("\n[4/5] Knowledge accuracy (10 MMLU-style Q)...", flush=True)
     knowledge = run_knowledge_benchmark(skip_live=args.skip_live)
@@ -603,9 +760,13 @@ def main() -> int:
     elif knowledge.get("ok"):
         for p in knowledge.get("providers", []):
             if p.get("ok"):
-                print(f"      {p['provider']:12s}  {p['correct']}/{p['total']}  ({p['accuracy']:.0%})")
+                print(
+                    f"      {p['provider']:12s}  {p['correct']}/{p['total']}  ({p['accuracy']:.0%})"
+                )
             else:
-                print(f"      {p['provider']:12s}  {p.get('error', 'failed')}")
+                print(
+                    f"      {p['provider']:12s}  {_safe_log_text(p.get('error', 'failed'))}"
+                )
 
     print("\n[5/5] TypeScript test suite...", flush=True)
     tests = run_test_suite_benchmark()
@@ -649,18 +810,29 @@ def main() -> int:
         bar = ("█" * int((s or 0) * 20)).ljust(20) if s is not None else "─" * 20
         label = f"{s:.1%}" if s is not None else "skipped"
         print(f"  {layer:<12s} {bar}  {label}  (w={w:.0%})")
-    print(f"\n  COMPOSITE     {'█' * int(score['composite'] * 20)}  {score['composite']:.1%}  grade={score['grade']}")
+    print(
+        f"\n  COMPOSITE     {'█' * int(score['composite'] * 20)}  {score['composite']:.1%}  grade={score['grade']}"
+    )
 
     print("\nExternal comparisons:")
     if gov.get("blind_detection_rate"):
         print("  Safety classifiers (balanced accuracy on blind holdout):")
         for b in EXTERNAL_BASELINES["safety_classifiers"]:
-            marker = "← SCBE hybrid" if abs(b["score"] - gov.get("hybrid_detection_rate", 0)) < 0.02 else ""
+            marker = (
+                "← SCBE hybrid"
+                if abs(b["score"] - gov.get("hybrid_detection_rate", 0)) < 0.02
+                else ""
+            )
             print(f"    {b['name']:20s}  {b['score']:.1%}  {marker}")
-        print(f"    {'SCBE hybrid':20s}  {gov.get('hybrid_detection_rate', 0):.1%}  ← SCBE")
+        print(
+            f"    {'SCBE hybrid':20s}  {gov.get('hybrid_detection_rate', 0):.1%}  ← SCBE"
+        )
         print(f"    {'SCBE blind-only':20s}  {gov.get('blind_detection_rate', 0):.1%}")
     if knowledge.get("ok"):
-        best_know = max((p["accuracy"] for p in knowledge.get("providers", []) if p.get("ok")), default=None)
+        best_know = max(
+            (p["accuracy"] for p in knowledge.get("providers", []) if p.get("ok")),
+            default=None,
+        )
         if best_know is not None:
             print("  LLM knowledge (MMLU-style 10Q):")
             for b in EXTERNAL_BASELINES["llm_quality_mmlu"]:

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -23,7 +23,10 @@ PATTERNS = [
     (r"hf_[A-Za-z0-9]{30,}", "HuggingFace token"),
     (r"KGAT_[A-Za-z0-9]{20,}", "Kaggle token"),
     (r"xai-[A-Za-z0-9]{20,}", "xAI API key"),
-    (r"SAM-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "SAM.gov API key"),
+    (
+        r"SAM-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        "SAM.gov API key",
+    ),
     (r"glpat-[A-Za-z0-9_-]{20,}", "GitLab PAT"),
     (r"eyJ[A-Za-z0-9_-]{50,}\.[A-Za-z0-9_-]{50,}", "JWT token"),
 ]
@@ -31,13 +34,12 @@ PATTERNS = [
 
 def staged_files() -> list[str]:
     result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only"],
-        capture_output=True, text=True
+        ["git", "diff", "--cached", "--name-only"], capture_output=True, text=True
     )
     return [f.strip() for f in result.stdout.splitlines() if f.strip()]
 
 
-def check_secrets(files: list[str]) -> list[tuple[str, str, str]]:
+def check_secrets(files: list[str]) -> list[tuple[str, str]]:
     found = []
     for filepath in files:
         try:
@@ -46,7 +48,7 @@ def check_secrets(files: list[str]) -> list[tuple[str, str, str]]:
             for pattern, name in PATTERNS:
                 for m in re.findall(pattern, content):
                     if "[SCRUBBED" not in m:
-                        found.append((filepath, name, m[:20] + "..."))
+                        found.append((filepath, name))
         except FileNotFoundError:
             pass
     return found
@@ -65,12 +67,15 @@ def run_prettier(files: list[str]) -> bool:
         return True
 
     if not PRETTIER_BIN.exists():
-        print("[pre-commit] prettier not found at node_modules/prettier/bin/prettier.cjs — skipping format step")
+        print(
+            "[pre-commit] prettier not found at node_modules/prettier/bin/prettier.cjs — skipping format step"
+        )
         return True
 
     result = subprocess.run(
         ["node", str(PRETTIER_BIN), "--write", *ts_files],
-        capture_output=True, text=True
+        capture_output=True,
+        text=True,
     )
     if result.returncode != 0:
         print(f"[pre-commit] prettier failed:\n{result.stderr}")
@@ -102,7 +107,7 @@ if __name__ == "__main__":
         print(f"\n{'='*60}")
         print(f"BLOCKED: {len(secrets)} SECRET(S) DETECTED")
         print(f"{'='*60}")
-        for path, name, _preview in secrets:
+        for path, name in secrets:
             # Do NOT echo the matched secret value — report only where + what type.
             print(f"  [{name}] {path}")
         print("\nReplace secrets with [SCRUBBED:type] before committing.")

--- a/services/scbe-shim/package-lock.json
+++ b/services/scbe-shim/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260101.0",
         "typescript": "^5.4.0",
-        "wrangler": "^4.90.1"
+        "wrangler": "^4.101.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260508.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260508.1.tgz",
-      "integrity": "sha512-IT3r6VgiSwIesL4AJbxjgxvIxwWZqM7BKkhYAzOKHl4GF2M0TxeOahUIXd+CYXVZgHX8ceEg+MXbEehPelJyNg==",
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260616.1.tgz",
+      "integrity": "sha512-8QaDRQABkwkwoeviNiyScol7EQgXfGsPNSyUn52GiXObthY4XPiokoJsgDSDNcAelHjEvDLmdvQBHPK8YvGn4A==",
       "cpu": [
         "x64"
       ],
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260508.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260508.1.tgz",
-      "integrity": "sha512-JTVsisOJPcNKw0qovPjqyBWYahfdhUh7/9NICiG5wxaEQ45PYKdoqNq0hOAAIqvqoxsKZBvTgcPTJREPqk7avA==",
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260616.1.tgz",
+      "integrity": "sha512-xEhiZQ62CBJ+vyKSmM13rkK/wB1kLP5sKFkF3+P+3R/c2bmnSG3Vcd5FfXUu9V0PdC+KlR02nByvZjqEw2N6Ag==",
       "cpu": [
         "arm64"
       ],
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260508.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260508.1.tgz",
-      "integrity": "sha512-zO38pCc27YlsZiPYcaZnosy0/t7abXrRU3VEO1oKfUvnaCpHgphDG+VsrmHL+kntda6hrtNwg2jLeMAqqIjnjw==",
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260616.1.tgz",
+      "integrity": "sha512-p5laSYPiRUMHaLkneaZ9ZfIkNpmEnGFwgYmXtfcHJutTfEd8o3IBnsUVRSbPL+phcshKqmapLsQSxDEX6WSFfA==",
       "cpu": [
         "x64"
       ],
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260508.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260508.1.tgz",
-      "integrity": "sha512-XhJa780Ia6MNIrtxn/ruZHS79b9pu5EKPfRNReaUqxy8erPT2fs93axMfFoS9kIkcaRRj/1TOUKcTeAMoywY7w==",
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260616.1.tgz",
+      "integrity": "sha512-XQ7GonEl8ORvbz5fhe8Eyw2t/j09Li0KbXJxaldA318E+syF+PPTc4IRQudgqPWzzdzkH5nF7PuMOGySLSjFFw==",
       "cpu": [
         "arm64"
       ],
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260508.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260508.1.tgz",
-      "integrity": "sha512-QdDOK3B/Ul1s3QmIwDrFyx9230to6LsNmWcVR8w+TYjNZuRPzqQBgusp78LO7MlqCoEl9dvIcN00jkJnLtBSfw==",
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260616.1.tgz",
+      "integrity": "sha512-RaDVF9bSbPiPTq6vHYrgnv1TcQEcYnOr0WB3hWJ4yg2fBfpi2ygU6cYPuFeDwyFE9aPW5S6FBAkNmpKYueK4DQ==",
       "cpu": [
         "x64"
       ],
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260511.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260511.1.tgz",
-      "integrity": "sha512-FA+si7cOq9i/gtCHhIc0XJL0l1F/ApF+m00752Aj7WZFJrj3ZulT2T8/+rT3BabMT0QEnqFEGIqCgrmqhgEfMg==",
+      "version": "4.20260616.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260616.1.tgz",
+      "integrity": "sha512-AHyA0NC2/gNOHiMN6vzS25xenMaQ0XTzfw+MUQSQHXQDjLldxCBwjjtbNfKhBg540qGXIEx31kM1+L84GyECJw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -258,9 +258,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -360,9 +360,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -377,9 +377,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -394,9 +394,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -411,9 +411,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -445,9 +445,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -462,9 +462,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -496,9 +496,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -513,9 +513,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -530,9 +530,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1206,9 +1206,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1254,9 +1254,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1267,32 +1267,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/fsevents": {
@@ -1321,17 +1321,17 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260508.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260508.0.tgz",
-      "integrity": "sha512-h3aG+PA8jEH76V4ZtBAbs3g7kjMfHJUF8hPvxeeajLTKwir+G+dqfBODg5yF9MT29LqrZKCRQRqzfHPWX4kCIg==",
+      "version": "4.20260616.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260616.0.tgz",
+      "integrity": "sha512-cEpzoNgSWjedzYmhJvttUPmL4Jk6nSzzeNNi118T5zwnmYP9fnM8UXwFU/Qa/1qoQ4SzGqtM1Q7tinHvHvIGtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
+        "sharp": "0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260508.1",
-        "ws": "8.18.0",
+        "workerd": "1.20260616.1",
+        "ws": "8.20.1",
         "youch": "4.1.0-beta.10"
       },
       "bin": {
@@ -1356,9 +1356,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260508.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260508.1.tgz",
-      "integrity": "sha512-VlnjyH3AjVddpSK7J54nsCVgf8i2733pl8GjKttfNi7vN/hEjjAk20d2b1nDToOLKvRQpTewRnVkqaaeGHCaAw==",
+      "version": "1.20260616.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260616.1.tgz",
+      "integrity": "sha512-aRGWYxviSjYZwyu97pCr5GyJ9ObpgmNcfZZs3/o+kG7Wz3SBTqA8d8uhNueY5u7ADeUp2ibJvK6mXkFLrUmPgg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1482,17 +1482,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260508.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260508.1",
-        "@cloudflare/workerd-linux-64": "1.20260508.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260508.1",
-        "@cloudflare/workerd-windows-64": "1.20260508.1"
+        "@cloudflare/workerd-darwin-64": "1.20260616.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260616.1",
+        "@cloudflare/workerd-linux-64": "1.20260616.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260616.1",
+        "@cloudflare/workerd-windows-64": "1.20260616.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.90.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.90.1.tgz",
-      "integrity": "sha512-u2KrieKSMfRM0toTst/CfDtcRraeoVjmcExcMWgILM/ytq3qcDhuOAULoZSyPHzma43lfLJy1BC544drFyqe1A==",
+      "version": "4.101.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.101.0.tgz",
+      "integrity": "sha512-dZDDiRcT7MiA09lBDxWKmiL/iybEZ+SZe3IZmnVx1m1n1DOo730vOY5SeO7z9xFK8a/+vhGKDYB8mDXrvzEr5g==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1500,12 +1500,13 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260508.0",
+        "miniflare": "4.20260616.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260508.1"
+        "workerd": "1.20260616.1"
       },
       "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
@@ -1513,10 +1514,10 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260508.1"
+        "@cloudflare/workers-types": "^4.20260616.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -1525,9 +1526,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/services/scbe-shim/package.json
+++ b/services/scbe-shim/package.json
@@ -14,6 +14,10 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260101.0",
     "typescript": "^5.4.0",
-    "wrangler": "^4.90.1"
+    "wrangler": "^4.101.0"
+  },
+  "overrides": {
+    "esbuild": "0.28.1",
+    "ws": "8.21.0"
   }
 }

--- a/src/api/stripe_billing.py
+++ b/src/api/stripe_billing.py
@@ -68,7 +68,9 @@ PLANS: Dict[str, Dict[str, Any]] = {
 
 LOGGER = logging.getLogger("scbe.billing")
 
-_KEYS_FILE = Path(__file__).resolve().parents[2] / "artifacts" / "revenue" / "api_keys.jsonl"
+_KEYS_FILE = (
+    Path(__file__).resolve().parents[2] / "artifacts" / "revenue" / "api_keys.jsonl"
+)
 
 
 def _billing_cipher():
@@ -86,7 +88,9 @@ def _billing_cipher():
 
         return Fernet(raw.encode("utf-8"))
     except Exception as exc:
-        LOGGER.warning("SCBE_BILLING_ENC_KEY invalid; billing keys will not persist: %s", exc)
+        LOGGER.warning(
+            "SCBE_BILLING_ENC_KEY invalid; billing keys will not persist: %s", exc
+        )
         return None
 
 
@@ -107,7 +111,9 @@ def _load_keys() -> tuple[Dict[str, Any], Dict[str, Any]]:
                 enc = record.pop("api_key_enc", None)
                 if enc and cipher is not None:
                     try:
-                        record["api_key"] = cipher.decrypt(enc.encode("ascii")).decode("utf-8")
+                        record["api_key"] = cipher.decrypt(enc.encode("ascii")).decode(
+                            "utf-8"
+                        )
                     except Exception:
                         continue  # cannot decrypt (wrong/rotated key) — skip record
                 cid = record.get("customer_id", "")
@@ -131,13 +137,20 @@ def _persist_key(record: Dict[str, Any]) -> None:
     if cipher is None:
         return
     _KEYS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    safe = dict(record)
-    api_key = safe.pop("api_key", "")
-    if api_key:
-        safe["api_key_enc"] = cipher.encrypt(api_key.encode("utf-8")).decode("ascii")
+    raw_api_key = str(record.get("api_key") or "")
+    if not raw_api_key:
+        return
+    stored_record = {
+        "customer_id": record.get("customer_id", ""),
+        "subscription_id": record.get("subscription_id", ""),
+        "plan": record.get("plan", ""),
+        "email": record.get("email", ""),
+        "created_at": record.get("created_at", int(time.time())),
+        "api_key_enc": cipher.encrypt(raw_api_key.encode("utf-8")).decode("ascii"),
+    }
     try:
         with open(_KEYS_FILE, "a", encoding="utf-8") as f:
-            f.write(json.dumps(safe) + "\n")
+            f.write(json.dumps(stored_record, sort_keys=True) + "\n")
     except Exception as exc:
         LOGGER.warning("Failed to persist API key record: %s", exc)
 
@@ -189,9 +202,9 @@ def _stripe_request(
 
     encoded_data = None
     if form_data:
-        encoded_data = urllib.parse.urlencode({k: str(v) for k, v in form_data.items() if v is not None}).encode(
-            "utf-8"
-        )
+        encoded_data = urllib.parse.urlencode(
+            {k: str(v) for k, v in form_data.items() if v is not None}
+        ).encode("utf-8")
 
     req = urllib.request.Request(
         url,
@@ -242,7 +255,9 @@ def _verify_stripe_signature(payload: bytes, sig_header: str) -> bool:
 
     # Compute expected signature
     signed_payload = f"{timestamp}.".encode("utf-8") + payload
-    expected = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
+    expected = hmac.new(
+        secret.encode("utf-8"), signed_payload, hashlib.sha256
+    ).hexdigest()
 
     return hmac.compare_digest(expected, v1_sig)
 
@@ -294,7 +309,10 @@ async def create_checkout(request: CheckoutRequest):
         raise HTTPException(400, f"Unknown plan: {request.plan}")
 
     base_url = os.getenv("SCBE_BILLING_BASE_URL", "http://localhost:8000").rstrip("/")
-    success_url = request.success_url or f"{base_url}/billing/success?session_id={{CHECKOUT_SESSION_ID}}"
+    success_url = (
+        request.success_url
+        or f"{base_url}/billing/success?session_id={{CHECKOUT_SESSION_ID}}"
+    )
     cancel_url = request.cancel_url or f"{base_url}/billing/cancel"
 
     form_data: Dict[str, str] = {
@@ -365,7 +383,9 @@ async def stripe_webhook(request: Request):
 
     # Verify signature. Unsigned webhooks are only allowed when explicitly enabled.
     webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET", "").strip()
-    allow_unsigned = os.getenv("SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", "").strip().lower() in {
+    allow_unsigned = os.getenv(
+        "SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", ""
+    ).strip().lower() in {
         "1",
         "true",
         "yes",
@@ -402,7 +422,9 @@ def _handle_checkout_completed(session: Dict[str, Any]) -> None:
     customer_id = session.get("customer", "")
     plan_id = session.get("metadata", {}).get("scbe_plan", "starter")
     subscription_id = session.get("subscription", "")
-    email = session.get("customer_email") or session.get("customer_details", {}).get("email", "")
+    email = session.get("customer_email") or session.get("customer_details", {}).get(
+        "email", ""
+    )
 
     api_key = _generate_api_key()
     now = int(time.time())
@@ -466,7 +488,9 @@ def _handle_subscription_deleted(subscription: Dict[str, Any]) -> None:
 # One-time product purchases (Payment Links)
 # ---------------------------------------------------------------------------
 
-DEFAULT_PRODUCT_RELEASE_URL = "https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest"
+DEFAULT_PRODUCT_RELEASE_URL = (
+    "https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest"
+)
 
 
 def _delivery_url(*env_names: str) -> str:
@@ -497,7 +521,9 @@ def get_onetime_products() -> Dict[str, Dict[str, str]]:
         # AI Security Training Vault - $29
         "vault": {
             "name": "SCBE AI Security Training Vault",
-            "download_url": _delivery_url("SCBE_TRAINING_VAULT_DOWNLOAD_URL", "SCBE_VAULT_DOWNLOAD_URL"),
+            "download_url": _delivery_url(
+                "SCBE_TRAINING_VAULT_DOWNLOAD_URL", "SCBE_VAULT_DOWNLOAD_URL"
+            ),
             "manual_url": "https://aethermoore.com/product-manual/training-vault.html",
             "package_filename": "SCBE_AI_Security_Training_Vault_v1.zip",
             "support_url": "https://aethermoore.com/support.html",
@@ -563,7 +589,9 @@ def _resolve_onetime_product_key(session: Dict[str, Any]) -> str:
     return ""
 
 
-def _delivery_plaintext(product_name: str, download_url: str, manual_url: str, package_filename: str) -> str:
+def _delivery_plaintext(
+    product_name: str, download_url: str, manual_url: str, package_filename: str
+) -> str:
     return "\n".join(
         [
             f"Thank you for your purchase. Your {product_name} is ready.",
@@ -628,7 +656,9 @@ If you have any questions, reply to this email or reach us at ai@aethermoore.com
     msg["Reply-To"] = "ai@aethermoore.com"
     msg.attach(
         MIMEText(
-            _delivery_plaintext(product_name, download_url, manual_url, package_filename),
+            _delivery_plaintext(
+                product_name, download_url, manual_url, package_filename
+            ),
             "plain",
         )
     )
@@ -672,7 +702,9 @@ def _notify_owner(product_name: str, buyer_email: str, amount_cents: int) -> Non
 
 def _handle_onetime_purchase(session: Dict[str, Any]) -> None:
     """Handle a one-time product purchase from Payment Links."""
-    email = session.get("customer_email") or session.get("customer_details", {}).get("email", "")
+    email = session.get("customer_email") or session.get("customer_details", {}).get(
+        "email", ""
+    )
     amount = session.get("amount_total", 0)
     payment_status = session.get("payment_status", "")
 


### PR DESCRIPTION
## Summary
- fixes CodeQL #5208 by persisting only an explicit allowlisted billing record with encrypted API key material, never a request-shaped record
- fixes CodeQL #5207 by removing secret previews from the pre-commit hook's in-memory finding tuples
- fixes CodeQL #5202/#5204 by sanitizing benchmark provider error output before printing
- updates Python lock for `opentelemetry-propagator-ot-trace` to `0.63b1`
- updates root npm OpenTelemetry packages to `2.8.0` through lockfile overrides
- updates `services/scbe-shim` Wrangler and overrides `esbuild` to `0.28.1` plus `ws` to `8.21.0`

## Alert Mapping
- CodeQL #5208: `src/api/stripe_billing.py`
- CodeQL #5207: `scripts/hooks/pre-commit`
- CodeQL #5202/#5204: `scripts/benchmark/scbe_full_benchmark.py`
- Dependabot #245/#242: `services/scbe-shim/package-lock.json` esbuild
- Dependabot #268: root OpenTelemetry JS lock + Python `opentelemetry-propagator-ot-trace`

## Validation
- `python -m pytest tests\api\test_stripe_billing_hardening.py -q`
- `python -m black --check --target-version py312 src\api\stripe_billing.py scripts\benchmark\scbe_full_benchmark.py scripts\hooks\pre-commit`
- `python -m py_compile src\api\stripe_billing.py scripts\benchmark\scbe_full_benchmark.py scripts\hooks\pre-commit`
- `npm audit --json`
- `npm audit --omit=dev --json`
- `npm run build` in `services/scbe-shim`
- `npm audit --json` in `services/scbe-shim`
- `git diff --check`
