### PR TITLE
style: black + flake8 clean on main (unblock Lint and Format Check)

### DIFF
--- a/scripts/aetherbrowser/api_server.py
+++ b/scripts/aetherbrowser/api_server.py
@@ -516,6 +516,7 @@ async def _guard_operator_endpoints(request: Request, call_next):
             return JSONResponse({"detail": "invalid or missing X-Admin-Token"}, status_code=401)
     return await call_next(request)
 
+
 if PUBLIC_DIR.exists():
     static_dir = PUBLIC_DIR / "static"
     if static_dir.exists():

--- a/scripts/polyglot_divergence.py
+++ b/scripts/polyglot_divergence.py
@@ -94,7 +94,9 @@ def main() -> int:
                 else:
                     cells[lang] = {"status": "DIVERGE", "value": v}
                     n_div += 1
-                    divergences.append({"program": name, "lang": lang, "value": v, "ref": ref, "reason": reason_for(prog)})
+                    divergences.append(
+                        {"program": name, "lang": lang, "value": v, "ref": ref, "reason": reason_for(prog)}
+                    )
             except Exception as exc:  # build/run failure = a real ship problem
                 cells[lang] = {"status": "BUILDFAIL", "detail": str(exc).splitlines()[0][:70]}
                 n_fail += 1
@@ -127,8 +129,10 @@ def main() -> int:
             marks.append(f"{lang}:{tag}")
         print(f"{r['program']:<20} {r['ref']:>12.6g}  {'  '.join(marks)}")
     print()
-    print(f"SUMMARY  programs={summary['programs']}  faces={len(langs)}  "
-          f"agree={n_agree}  diverge={n_div}  build-fail={n_fail}")
+    print(
+        f"SUMMARY  programs={summary['programs']}  faces={len(langs)}  "
+        f"agree={n_agree}  diverge={n_div}  build-fail={n_fail}"
+    )
     if divergences:
         print("\nDIVERGENCES (language-intrinsic, intent held constant):")
         for d in divergences:

--- a/scripts/system/mechanical_eliza_support.py
+++ b/scripts/system/mechanical_eliza_support.py
@@ -40,19 +40,16 @@ def _read_text(args: argparse.Namespace) -> str:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("text", nargs="*", help="Support request text.")
-    parser.add_argument(
-        "--text-file", help="Read support request text from a UTF-8 file."
-    )
+    parser.add_argument("--text-file", help="Read support request text from a UTF-8 file.")
     parser.add_argument(
         "--history-file",
-        help="Read prior dialogue turns from a UTF-8 file, one turn per line. The request text is appended as the latest turn.",
+        help=(
+            "Read prior dialogue turns from a UTF-8 file, one turn per line. "
+            "The request text is appended as the latest turn."
+        ),
     )
-    parser.add_argument(
-        "--stdin", action="store_true", help="Read support request text from stdin."
-    )
-    parser.add_argument(
-        "--pretty", action="store_true", help="Pretty-print JSON output."
-    )
+    parser.add_argument("--stdin", action="store_true", help="Read support request text from stdin.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
     parser.add_argument(
         "--response-only",
         action="store_true",
@@ -83,9 +80,7 @@ def main(argv: list[str] | None = None) -> int:
         default="offline",
         help="Free LLM provider id for request/dispatch.",
     )
-    parser.add_argument(
-        "--model", default=None, help="Optional model override for Free LLM routing."
-    )
+    parser.add_argument("--model", default=None, help="Optional model override for Free LLM routing.")
     parser.add_argument(
         "--live-model",
         action="store_true",
@@ -96,9 +91,7 @@ def main(argv: list[str] | None = None) -> int:
     text = _read_text(args)
     if args.history_file:
         history = [
-            line.strip()
-            for line in Path(args.history_file).read_text(encoding="utf-8").splitlines()
-            if line.strip()
+            line.strip() for line in Path(args.history_file).read_text(encoding="utf-8").splitlines() if line.strip()
         ]
         packet = route_dialogue(history + ([text] if text else []))
     else:

--- a/tests/test_mechanical_eliza.py
+++ b/tests/test_mechanical_eliza.py
@@ -31,9 +31,7 @@ def test_denies_destructive_command_shape():
 
 
 def test_secret_and_money_routes_to_probe():
-    packet = route_support(
-        "help my chatbot use the Stripe sk_live secret to make a checkout"
-    )
+    packet = route_support("help my chatbot use the Stripe sk_live secret to make a checkout")
 
     assert packet.route.command_switch == "probe"
     assert packet.route.allowed is True
@@ -46,9 +44,7 @@ def test_agent_loop_breaker_switch():
 
     assert packet.route.route == "agent_support_loop_breaker"
     assert packet.route.command_switch == "loop_break"
-    assert any(
-        row["switch"] == "loop_break" and row["enabled"] for row in packet.switchboard
-    )
+    assert any(row["switch"] == "loop_break" and row["enabled"] for row in packet.switchboard)
 
 
 def test_dialogue_repetition_breaks_loop_even_without_keywords():
@@ -79,9 +75,7 @@ def test_packet_is_json_ready():
 
 def test_builds_free_llm_dispatch_request_after_mechanical_route():
     packet = route_support("true eliza should use a cheap local model route")
-    bridge = build_free_llm_dispatch_request(
-        packet, provider="offline", model="scbe-offline-control-plane"
-    )
+    bridge = build_free_llm_dispatch_request(packet, provider="offline", model="scbe-offline-control-plane")
 
     assert bridge["bridge_version"] == MODEL_BRIDGE_VERSION
     dispatch = bridge["dispatch"]
@@ -99,9 +93,7 @@ def test_builds_semantic_navigation_array():
 
     assert nav["version"] == NAVIGATION_VERSION
     assert nav["active_switch"] == "loop_break"
-    assert any(
-        node["id"] == "switch:loop_break" and node["active"] for node in nav["nodes"]
-    )
+    assert any(node["id"] == "switch:loop_break" and node["active"] for node in nav["nodes"])
     assert any(edge["from"] == "start" for edge in nav["edges"])
 
 


### PR DESCRIPTION
The NameError fix (#2291) made **Test Python Components** green, but main's **Lint and Format Check** stayed red. Root cause: a concurrent-merge tangle left **4 files unformatted on current main** — `api_server.py`, `polyglot_divergence.py` (my #2291 format got clobbered by a parallel merge of the same files), plus `mechanical_eliza_support.py` + `tests/test_mechanical_eliza.py` from a *different* merge — and one E501.

**Fix:** black-format all four + wrap the long `--history-file` help string. Verified: full CI set black-clean (2277 unchanged), **flake8 0 violations**. No logic change.

After this merges, main's Lint job goes green (the NameError half is already green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)