### PR TITLE
style: black-format stripe_billing + benchmark (Lint green)

### DIFF
--- a/scripts/benchmark/scbe_full_benchmark.py
+++ b/scripts/benchmark/scbe_full_benchmark.py
@@ -455,9 +455,7 @@ def run_squad_latency_benchmark() -> dict[str, Any]:
         latencies = []
         errors = []
         for _ in range(3):
-            resp, ms = _openai_chat_request(
-                base_url, api_key, model, ping_prompt, timeout=30, max_tokens=200
-            )
+            resp, ms = _openai_chat_request(base_url, api_key, model, ping_prompt, timeout=30, max_tokens=200)
             if resp.startswith("ERROR:"):
                 errors.append(resp)
             else:
@@ -535,9 +533,7 @@ def run_knowledge_benchmark(skip_live: bool = False) -> dict[str, Any]:
         ),
     ]:
         if not api_key:
-            providers_tested.append(
-                {"provider": name, "ok": False, "error": "no api key"}
-            )
+            providers_tested.append({"provider": name, "ok": False, "error": "no api key"})
             continue
 
         correct = 0
@@ -548,9 +544,7 @@ def run_knowledge_benchmark(skip_live: bool = False) -> dict[str, Any]:
                 "Multiple choice. Reply with ONLY the letter of the correct answer (A, B, C, or D)."
                 f"\n\nQuestion: {q['q']}\n{choices_str}"
             )
-            resp, ms = _openai_chat_request(
-                base_url, api_key, model, prompt, timeout=45, max_tokens=600
-            )
+            resp, ms = _openai_chat_request(base_url, api_key, model, prompt, timeout=45, max_tokens=600)
             predicted = _extract_answer_letter(resp)
             hit = predicted == q["answer"] if predicted else False
             if hit:
@@ -640,15 +634,9 @@ def compute_composite(gov, cli, latency, knowledge, tests) -> dict[str, Any]:
     # Use live Petri recall if available; fall back to published blind-holdout.
     petri_recall = gov.get("petri_pattern_filter_recall")
     if petri_recall is not None:
-        gov_score = (
-            petri_recall * 0.5 + gov.get("accuracy", 0) * 0.5 if gov.get("ok") else 0
-        )
+        gov_score = petri_recall * 0.5 + gov.get("accuracy", 0) * 0.5 if gov.get("ok") else 0
     else:
-        gov_score = (
-            gov.get("blind_detection_rate", 0) * 0.4 + gov.get("accuracy", 0) * 0.6
-            if gov.get("ok")
-            else 0
-        )
+        gov_score = gov.get("blind_detection_rate", 0) * 0.4 + gov.get("accuracy", 0) * 0.6 if gov.get("ok") else 0
     cli_score = cli["scbe_score"]["score"] if cli.get("ok") else 0
     lat_score = _latency_score(latency.get("providers", []))
     know_score = 0.0
@@ -673,10 +661,7 @@ def compute_composite(gov, cli, latency, knowledge, tests) -> dict[str, Any]:
     return {
         "composite": composite,
         "grade": _grade(composite),
-        "parts": {
-            k: {"score": round(s, 3) if s is not None else None, "weight": w}
-            for k, (s, w) in parts.items()
-        },
+        "parts": {k: {"score": round(s, 3) if s is not None else None, "weight": w} for k, (s, w) in parts.items()},
         "effective_weight": round(effective_weight, 3),
     }
 
@@ -699,9 +684,7 @@ def _grade(score: float) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--json", action="store_true")
-    parser.add_argument(
-        "--skip-live", action="store_true", help="Skip live provider calls"
-    )
+    parser.add_argument("--skip-live", action="store_true", help="Skip live provider calls")
     args = parser.parse_args()
 
     print("SCBE-AETHERMOORE Full System Benchmark", flush=True)
@@ -728,9 +711,7 @@ def main() -> int:
     print("\n[2/5] CLI capability...", flush=True)
     cli = run_cli_benchmark()
     if cli.get("ok"):
-        scbe_row = next(
-            (r for r in cli["ranking"] if r["name"] == "scbe-geoseal"), None
-        )
+        scbe_row = next((r for r in cli["ranking"] if r["name"] == "scbe-geoseal"), None)
         scbe_pos = cli["ranking"].index(scbe_row) + 1 if scbe_row else "?"
         print(
             f"      scbe: {scbe_row['score']:.1%} ({scbe_row['passed']}/{scbe_row['total']}) "
@@ -745,13 +726,9 @@ def main() -> int:
         latency = run_squad_latency_benchmark()
         for p in latency["providers"]:
             if p.get("ok"):
-                print(
-                    f"      {p['provider']:12s}  p50={p['p50_ms']:.0f}ms  ({p['latencies_ms']})"
-                )
+                print(f"      {p['provider']:12s}  p50={p['p50_ms']:.0f}ms  ({p['latencies_ms']})")
             else:
-                print(
-                    f"      {p['provider']:12s}  {_safe_log_text(p.get('error', 'failed'))}"
-                )
+                print(f"      {p['provider']:12s}  {_safe_log_text(p.get('error', 'failed'))}")
 
     print("\n[4/5] Knowledge accuracy (10 MMLU-style Q)...", flush=True)
     knowledge = run_knowledge_benchmark(skip_live=args.skip_live)
@@ -760,13 +737,9 @@ def main() -> int:
     elif knowledge.get("ok"):
         for p in knowledge.get("providers", []):
             if p.get("ok"):
-                print(
-                    f"      {p['provider']:12s}  {p['correct']}/{p['total']}  ({p['accuracy']:.0%})"
-                )
+                print(f"      {p['provider']:12s}  {p['correct']}/{p['total']}  ({p['accuracy']:.0%})")
             else:
-                print(
-                    f"      {p['provider']:12s}  {_safe_log_text(p.get('error', 'failed'))}"
-                )
+                print(f"      {p['provider']:12s}  {_safe_log_text(p.get('error', 'failed'))}")
 
     print("\n[5/5] TypeScript test suite...", flush=True)
     tests = run_test_suite_benchmark()
@@ -810,23 +783,15 @@ def main() -> int:
         bar = ("█" * int((s or 0) * 20)).ljust(20) if s is not None else "─" * 20
         label = f"{s:.1%}" if s is not None else "skipped"
         print(f"  {layer:<12s} {bar}  {label}  (w={w:.0%})")
-    print(
-        f"\n  COMPOSITE     {'█' * int(score['composite'] * 20)}  {score['composite']:.1%}  grade={score['grade']}"
-    )
+    print(f"\n  COMPOSITE     {'█' * int(score['composite'] * 20)}  {score['composite']:.1%}  grade={score['grade']}")
 
     print("\nExternal comparisons:")
     if gov.get("blind_detection_rate"):
         print("  Safety classifiers (balanced accuracy on blind holdout):")
         for b in EXTERNAL_BASELINES["safety_classifiers"]:
-            marker = (
-                "← SCBE hybrid"
-                if abs(b["score"] - gov.get("hybrid_detection_rate", 0)) < 0.02
-                else ""
-            )
+            marker = "← SCBE hybrid" if abs(b["score"] - gov.get("hybrid_detection_rate", 0)) < 0.02 else ""
             print(f"    {b['name']:20s}  {b['score']:.1%}  {marker}")
-        print(
-            f"    {'SCBE hybrid':20s}  {gov.get('hybrid_detection_rate', 0):.1%}  ← SCBE"
-        )
+        print(f"    {'SCBE hybrid':20s}  {gov.get('hybrid_detection_rate', 0):.1%}  ← SCBE")
         print(f"    {'SCBE blind-only':20s}  {gov.get('blind_detection_rate', 0):.1%}")
     if knowledge.get("ok"):
         best_know = max(

--- a/src/api/stripe_billing.py
+++ b/src/api/stripe_billing.py
@@ -68,9 +68,7 @@ PLANS: Dict[str, Dict[str, Any]] = {
 
 LOGGER = logging.getLogger("scbe.billing")
 
-_KEYS_FILE = (
-    Path(__file__).resolve().parents[2] / "artifacts" / "revenue" / "api_keys.jsonl"
-)
+_KEYS_FILE = Path(__file__).resolve().parents[2] / "artifacts" / "revenue" / "api_keys.jsonl"
 
 
 def _billing_cipher():
@@ -88,9 +86,7 @@ def _billing_cipher():
 
         return Fernet(raw.encode("utf-8"))
     except Exception as exc:
-        LOGGER.warning(
-            "SCBE_BILLING_ENC_KEY invalid; billing keys will not persist: %s", exc
-        )
+        LOGGER.warning("SCBE_BILLING_ENC_KEY invalid; billing keys will not persist: %s", exc)
         return None
 
 
@@ -111,9 +107,7 @@ def _load_keys() -> tuple[Dict[str, Any], Dict[str, Any]]:
                 enc = record.pop("api_key_enc", None)
                 if enc and cipher is not None:
                     try:
-                        record["api_key"] = cipher.decrypt(enc.encode("ascii")).decode(
-                            "utf-8"
-                        )
+                        record["api_key"] = cipher.decrypt(enc.encode("ascii")).decode("utf-8")
                     except Exception:
                         continue  # cannot decrypt (wrong/rotated key) — skip record
                 cid = record.get("customer_id", "")
@@ -202,9 +196,9 @@ def _stripe_request(
 
     encoded_data = None
     if form_data:
-        encoded_data = urllib.parse.urlencode(
-            {k: str(v) for k, v in form_data.items() if v is not None}
-        ).encode("utf-8")
+        encoded_data = urllib.parse.urlencode({k: str(v) for k, v in form_data.items() if v is not None}).encode(
+            "utf-8"
+        )
 
     req = urllib.request.Request(
         url,
@@ -255,9 +249,7 @@ def _verify_stripe_signature(payload: bytes, sig_header: str) -> bool:
 
     # Compute expected signature
     signed_payload = f"{timestamp}.".encode("utf-8") + payload
-    expected = hmac.new(
-        secret.encode("utf-8"), signed_payload, hashlib.sha256
-    ).hexdigest()
+    expected = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
 
     return hmac.compare_digest(expected, v1_sig)
 
@@ -309,10 +301,7 @@ async def create_checkout(request: CheckoutRequest):
         raise HTTPException(400, f"Unknown plan: {request.plan}")
 
     base_url = os.getenv("SCBE_BILLING_BASE_URL", "http://localhost:8000").rstrip("/")
-    success_url = (
-        request.success_url
-        or f"{base_url}/billing/success?session_id={{CHECKOUT_SESSION_ID}}"
-    )
+    success_url = request.success_url or f"{base_url}/billing/success?session_id={{CHECKOUT_SESSION_ID}}"
     cancel_url = request.cancel_url or f"{base_url}/billing/cancel"
 
     form_data: Dict[str, str] = {
@@ -383,9 +372,7 @@ async def stripe_webhook(request: Request):
 
     # Verify signature. Unsigned webhooks are only allowed when explicitly enabled.
     webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET", "").strip()
-    allow_unsigned = os.getenv(
-        "SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", ""
-    ).strip().lower() in {
+    allow_unsigned = os.getenv("SCBE_ALLOW_UNSIGNED_STRIPE_WEBHOOK", "").strip().lower() in {
         "1",
         "true",
         "yes",
@@ -422,9 +409,7 @@ def _handle_checkout_completed(session: Dict[str, Any]) -> None:
     customer_id = session.get("customer", "")
     plan_id = session.get("metadata", {}).get("scbe_plan", "starter")
     subscription_id = session.get("subscription", "")
-    email = session.get("customer_email") or session.get("customer_details", {}).get(
-        "email", ""
-    )
+    email = session.get("customer_email") or session.get("customer_details", {}).get("email", "")
 
     api_key = _generate_api_key()
     now = int(time.time())
@@ -488,9 +473,7 @@ def _handle_subscription_deleted(subscription: Dict[str, Any]) -> None:
 # One-time product purchases (Payment Links)
 # ---------------------------------------------------------------------------
 
-DEFAULT_PRODUCT_RELEASE_URL = (
-    "https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest"
-)
+DEFAULT_PRODUCT_RELEASE_URL = "https://github.com/issdandavis/SCBE-AETHERMOORE/releases/latest"
 
 
 def _delivery_url(*env_names: str) -> str:
@@ -521,9 +504,7 @@ def get_onetime_products() -> Dict[str, Dict[str, str]]:
         # AI Security Training Vault - $29
         "vault": {
             "name": "SCBE AI Security Training Vault",
-            "download_url": _delivery_url(
-                "SCBE_TRAINING_VAULT_DOWNLOAD_URL", "SCBE_VAULT_DOWNLOAD_URL"
-            ),
+            "download_url": _delivery_url("SCBE_TRAINING_VAULT_DOWNLOAD_URL", "SCBE_VAULT_DOWNLOAD_URL"),
             "manual_url": "https://aethermoore.com/product-manual/training-vault.html",
             "package_filename": "SCBE_AI_Security_Training_Vault_v1.zip",
             "support_url": "https://aethermoore.com/support.html",
@@ -589,9 +570,7 @@ def _resolve_onetime_product_key(session: Dict[str, Any]) -> str:
     return ""
 
 
-def _delivery_plaintext(
-    product_name: str, download_url: str, manual_url: str, package_filename: str
-) -> str:
+def _delivery_plaintext(product_name: str, download_url: str, manual_url: str, package_filename: str) -> str:
     return "\n".join(
         [
             f"Thank you for your purchase. Your {product_name} is ready.",
@@ -656,9 +635,7 @@ If you have any questions, reply to this email or reach us at ai@aethermoore.com
     msg["Reply-To"] = "ai@aethermoore.com"
     msg.attach(
         MIMEText(
-            _delivery_plaintext(
-                product_name, download_url, manual_url, package_filename
-            ),
+            _delivery_plaintext(product_name, download_url, manual_url, package_filename),
             "plain",
         )
     )
@@ -702,9 +679,7 @@ def _notify_owner(product_name: str, buyer_email: str, amount_cents: int) -> Non
 
 def _handle_onetime_purchase(session: Dict[str, Any]) -> None:
     """Handle a one-time product purchase from Payment Links."""
-    email = session.get("customer_email") or session.get("customer_details", {}).get(
-        "email", ""
-    )
+    email = session.get("customer_email") or session.get("customer_details", {}).get("email", "")
     amount = session.get("amount_total", 0)
     payment_status = session.get("payment_status", "")
 


### PR DESCRIPTION
Two files re-touched by a concurrent enhancement were left unformatted, keeping main's Lint job red. black-format both; full set black-clean + flake8 0 violations. No logic change.