### PR TITLE
ci: self-healing auto-format bot (ends the black churn on main)

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,55 @@
+name: auto-format
+
+# Self-healing formatter. Many agents merge to main concurrently; some land
+# unformatted Python, which turns the "Lint and Format Check" job red. Instead of
+# anyone hand-formatting after the fact, this runs black on every push to main and
+# commits the result back — so main's code stays black-clean automatically and the
+# formatting churn stops. Uses the SAME black version + dirs as the CI lint check,
+# so "auto-format made it clean" == "CI black --check passes".
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.py"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-format-main
+  cancel-in-progress: false
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    # Don't re-run on the bot's own format commit (belt-and-suspenders; pushes made
+    # with GITHUB_TOKEN don't trigger workflows anyway, so no loop).
+    if: ${{ !contains(github.event.head_commit.message, '[auto-format]') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install black (pinned to match the CI lint check)
+        run: pip install --quiet "black==26.5.1"
+
+      - name: Format the same dirs CI's black --check covers
+        run: black --target-version py311 --line-length 120 src/ tests/ scripts/ agents/ || true
+
+      - name: Commit + push if anything changed
+        run: |
+          if git diff --quiet; then
+            echo "Already black-clean — nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style: auto-format python with black [auto-format]"
+          git push origin HEAD:main
+          echo "Formatted and pushed. main is black-clean again."


### PR DESCRIPTION
**The durable fix for the recurring Lint failures.**

Today main's `Lint and Format Check` went red repeatedly because multiple agents merge concurrently and some land **unformatted Python** — I had to hand-format it three times (#2291, #2297, #2299) and a new merge re-broke it each time. The only required check on main is `conflict-marker-guard`, so nothing gates formatting.

This adds a **self-healing formatter**: on every push to `main` that touches `**.py`, it runs **black** (pinned `26.5.1`, the exact CI version, on the exact dirs CI's `black --check` covers) and **commits the formatting back**. Main stays black-clean automatically — no one has to hand-format after a messy merge.

- **Loop-safe:** pushes made with `GITHUB_TOKEN` don't re-trigger workflows, plus an `[auto-format]` commit-message guard.
- **No blocking:** unlike making Lint a required check, this doesn't block any agent's merge — it just cleans up after.
- **Permissions:** `contents: write` (to push the format commit); direct pushes to main are already allowed (no required PR).

After this merges, the formatting whack-a-mole is over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)