### PR TITLE
feat(downloads): build verified SCBE Workcell bundle

### DIFF
--- a/docs/downloads/downloadable-app-packaging-research-2026-06-16.md
+++ b/docs/downloads/downloadable-app-packaging-research-2026-06-16.md
@@ -1,0 +1,165 @@
+# Downloadable App Packaging Research
+
+Date: 2026-06-16
+Status: decision memo
+
+## Decision
+
+Ship a downloadable **SCBE Workcell** in two steps:
+
+1. **Fast product:** packaged CLI download.
+   - Buyer gets `scbe` / `geoseal` as a local tool they can run without cloning the repo.
+   - Use the existing `packages/cli` surface first.
+   - Publish via GitHub Releases, npm, and the existing $1 lifetime link.
+
+2. **Next product:** desktop shell that wraps the CLI/backend.
+   - Use `apps/aether-desktop/shell` as the existing UI base.
+   - Package with Electron Builder first, because it fits the current React/Vite/Node repo with the least rewrite.
+   - Revisit Tauri after the first downloadable app works and the Rust side is stable.
+
+Do not start with mobile app stores. App stores add signing, review, in-app purchase rules, and support load before the product is proven.
+
+## What People Download
+
+### Product A: SCBE Workcell CLI
+
+Positioning: "A governed command-line workcell for AI operators."
+
+What it gives:
+
+- natural-language command routing over existing legal SCBE verbs
+- GeoSeal command gate and receipts
+- Mechanical ELIZA support/router layer
+- Code Prism safe-subset translation
+- local audit trails and deterministic workcell records
+
+Packaging:
+
+- npm package: already aligned through `packages/cli/package.json`
+- GitHub Release ZIP/TAR: include `packages/cli`, README, examples, and starter scripts
+- optional single executable later with Node single executable application support
+
+Why first:
+
+- fastest to ship
+- no GUI bugs
+- no native signing blocker
+- customers who need clearance/custom AI work are more likely to tolerate CLI tools
+
+### Product B: SCBE Workcell Desktop
+
+Positioning: "A desktop control panel for governed AI workflows."
+
+What it gives:
+
+- chat/support window
+- tool console
+- local workspace state
+- buttons that call the same governed CLI/backend
+- installable Windows/macOS/Linux app
+
+Repo base:
+
+- `apps/aether-desktop/shell`
+- `scripts/aetherbrowser/api_server.py`
+- `src/api/geoseal_service.py`
+- `packages/cli`
+
+Recommended packaging:
+
+- Electron Builder for v1 installers
+- Windows: NSIS installer or portable `.exe`
+- macOS: `.dmg` / `.zip`
+- Linux: AppImage first, `.deb` later
+
+Why Electron first:
+
+- current shell is React/Vite/TypeScript
+- current CLI is Node-based
+- easiest route to call local Node/Python services
+- larger app size is acceptable for v1; getting a download into users' hands matters more
+
+## Packaging Stack Comparison
+
+| Stack | Best For | Pros | Cons | SCBE Fit |
+|---|---|---|---|---|
+| npm package | CLI users | already present, fastest, public distribution | requires Node | immediate |
+| GitHub Release ZIP | direct buyers | no store, no review, easy download link | manual trust/signing issue | immediate |
+| Node SEA | single-file CLI | no Node install for user | still maturing, one-script constraint | good later |
+| PyInstaller | Python CLI/tools | bundles Python runtime, known path | must build per OS; Python dependency edge cases | useful for Python-only tools |
+| Briefcase | native Python apps | native installers, mobile options | more structure/rewrite | not first |
+| Electron Builder | desktop app | installer formats across OSes, fits React/Node | big binaries | best desktop v1 |
+| Tauri 2 | small desktop/mobile app | smaller, Rust backend, app-store path | more setup, WebView dependencies, Rust integration | good v2 |
+| MSIX | Windows enterprise install | clean install/uninstall, identity, updates | Windows-specific, cert/signing ceremony | enterprise later |
+
+## Minimum Shippable Download
+
+The smallest real thing to sell:
+
+```text
+SCBE Workcell v0.1
++-- scbe / geoseal CLI
++-- starter commands
++-- Mechanical ELIZA support router
++-- Code Prism translator
++-- local receipts folder
++-- one-page buyer guide
+```
+
+Release path:
+
+1. Build `packages/cli` with `npm pack`.
+2. Create a GitHub Release with:
+   - `.tgz` npm package
+   - `SCBE-Workcell-Windows.zip`
+   - `SCBE-Workcell-README.pdf` or `.md`
+3. Add a public download page under `docs/downloads`.
+4. Wire the $1 Stripe link to "SCBE Workcell lifetime download."
+5. After payment, buyer gets download link plus install instructions.
+
+## First Desktop Release Path
+
+Use Electron Builder unless a blocker appears.
+
+Steps:
+
+1. Add Electron main/preload files under `apps/aether-desktop/shell`.
+2. Keep the existing Vite app as renderer.
+3. Add an IPC bridge that calls allowlisted CLI commands only.
+4. Add `electron-builder` config:
+   - Windows: `nsis`, `portable`
+   - macOS: `dmg`, `zip`
+   - Linux: `AppImage`
+5. Add GitHub Actions matrix builds on Windows, macOS, Linux.
+6. Upload artifacts to GitHub Releases.
+
+## Safety Boundary
+
+The downloadable app must not be "an agent that can run anything." It should be a governed workcell:
+
+- allowlisted commands only
+- explain-before-run
+- local receipt for each action
+- API keys stay in environment or OS keychain later
+- no cloud model call unless user configures a provider key or chooses a free/local route
+
+This is a sellable difference: "downloadable AI tooling that does not silently take over your machine."
+
+## Recommendation
+
+Start with the CLI product this week. It is already closest to real.
+
+Then wrap it in desktop. The desktop app is the sales surface; the CLI is the engine. This keeps the build honest and lets users download something before the full app-store path exists.
+
+## Sources
+
+- Tauri distribution docs: https://v2.tauri.app/distribute/
+- Tauri Windows installer docs: https://v2.tauri.app/distribute/windows-installer/
+- Electron Forge packaging docs: https://www.electronforge.io/
+- Electron Forge makers docs: https://www.electronforge.io/config/makers
+- Electron Builder docs: https://www.electron.build/docs/
+- Node.js single executable application docs: https://nodejs.org/api/single-executable-applications.html
+- PyInstaller manual: https://www.pyinstaller.org/
+- BeeWare Briefcase project page: https://pypi.org/project/briefcase/
+- Microsoft MSIX docs: https://learn.microsoft.com/en-us/windows/msix/
+- GitHub Actions artifact docs: https://docs.github.com/en/actions/tutorials/store-and-share-data

--- a/docs/downloads/scbe-workcell-quickstart.md
+++ b/docs/downloads/scbe-workcell-quickstart.md
@@ -1,0 +1,72 @@
+# SCBE Workcell Quickstart
+
+SCBE Workcell is a downloadable command-line workcell for governed AI operations.
+
+It gives you the `scbe`, `geoseal`, and `scbe-geoseal` commands without cloning
+the full SCBE-AETHERMOORE repository.
+
+## Requirements
+
+- Node.js 20 or newer
+- npm
+- Windows PowerShell, macOS Terminal, or Linux shell
+
+## Install From The Download Bundle
+
+Unzip the download. Inside the folder you will see an npm package named like:
+
+```text
+scbe-aethermoore-cli-4.4.0.tgz
+```
+
+Install it globally:
+
+```powershell
+npm install -g .\scbe-aethermoore-cli-4.4.0.tgz
+```
+
+On macOS/Linux:
+
+```bash
+npm install -g ./scbe-aethermoore-cli-4.4.0.tgz
+```
+
+## First Commands
+
+```bash
+scbe version
+scbe demo --json
+scbe tools --json
+scbe selftest
+```
+
+## What It Does
+
+- `scbe version` proves the command is installed.
+- `scbe demo --json` shows the governed AI-tool-call safety demo.
+- `scbe tools --json` lists the command manifest for humans or agents.
+- `scbe selftest` checks the installed command path.
+
+## Buyer Promise
+
+SCBE Workcell is not a magic cloud agent. It is a local governed command surface:
+
+- commands are explicit
+- risky operations go through GeoSeal-style gating
+- outputs can be recorded as receipts
+- local/free routes come first
+- paid or cloud routes require user configuration
+
+## Update
+
+When a new bundle is released, install the new `.tgz` the same way:
+
+```bash
+npm install -g ./scbe-aethermoore-cli-NEW_VERSION.tgz
+```
+
+## Uninstall
+
+```bash
+npm uninstall -g scbe-aethermoore-cli
+```

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "cash:launch-readiness:gate": "python scripts/system/product_launch_readiness.py --fail-on-not-ready",
     "writing:package": "python scripts/package_products.py --product writing",
     "writing:package:all": "python scripts/package_products.py --product all",
+    "release:workcell": "python scripts/system/build_workcell_download.py",
     "video:verify": "node scripts/video/verify.js",
     "video:quality-gate": "node scripts/video/quality_gate.js",
     "video:manifest": "node scripts/video/package_manifest.js",

--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -851,6 +851,9 @@ function inferCompass(command) {
 }
 
 function gateCommand(command, options = {}) {
+  if (process.env.SCBE_FORCE_GATE_FALLBACK === '1') {
+    return fallbackGateCommand(command, 'forced_fallback');
+  }
   // shellContext=true relaxes the blanket pipe/`;` block for paths that run the
   // command THROUGH a shell (scbe run -> PowerShell), while the dangerous-pattern
   // denies (recursive delete, curl|iex, encoded PS, secret paths) still apply.
@@ -867,25 +870,60 @@ function gateCommand(command, options = {}) {
     timeout: 5000,
   });
   if (child.status !== 0) {
-    return {
-      allowed: true,
-      tier: 'WARN',
-      parser_ok: false,
-      findings: ['GeoSeal execution gate unavailable; command allowed with warning'],
+    return fallbackGateCommand(command, 'python_gate_unavailable', {
       stderr_preview: String(child.stderr || '').slice(0, 500),
-    };
+    });
   }
   const parsed = parseJsonFromText(child.stdout);
   if (parsed) return parsed;
   {
-    return {
-      allowed: true,
-      tier: 'WARN',
-      parser_ok: false,
-      findings: ['GeoSeal execution gate returned non-JSON; command allowed with warning'],
+    return fallbackGateCommand(command, 'python_gate_non_json', {
       stdout_preview: String(child.stdout || '').slice(0, 500),
+    });
+  }
+}
+
+function fallbackGateCommand(command, source, extra = {}) {
+  const lower = String(command || '').toLowerCase();
+  const findings = [];
+  if (/\b(remove-item|rm|del|rmdir)\b/.test(lower) && /\b(-recurse|-r|\/s)\b/.test(lower)) {
+    findings.push({ rule: 'fallback.recursive_delete', message: 'recursive delete command' });
+  }
+  if (/\b(force|\/q|-f)\b/.test(lower) && /\b(remove-item|rm|del|rmdir)\b/.test(lower)) {
+    findings.push({ rule: 'fallback.force_delete', message: 'forced delete command' });
+  }
+  if (/(secret|secrets|credential|credentials|connector_oauth|\.env|api[_-]?key|token)/.test(lower)) {
+    findings.push({ rule: 'fallback.secret_path', message: 'command touches a secret or credential path' });
+  }
+  if (/(curl|wget|irm|iwr|invoke-webrequest|invoke-restmethod).*(iex|invoke-expression|sh|bash|powershell)/.test(lower)) {
+    findings.push({ rule: 'fallback.download_to_exec', message: 'download-to-execute chain' });
+  }
+  if (/(encodedcommand|-enc)\b/.test(lower)) {
+    findings.push({ rule: 'fallback.encoded_powershell', message: 'encoded PowerShell command' });
+  }
+  if (findings.length) {
+    return {
+      allowed: false,
+      tier: 'DENY',
+      parser_ok: false,
+      findings,
+      fallback_source: source,
+      ...extra,
     };
   }
+  return {
+    allowed: true,
+    tier: 'WARN',
+    parser_ok: false,
+    findings: [
+      {
+        rule: `fallback.${source}`,
+        message: 'Python GeoSeal execution gate unavailable; allowed by limited JavaScript fallback scan',
+      },
+    ],
+    fallback_source: source,
+    ...extra,
+  };
 }
 
 function normalizeFindings(gate) {

--- a/packages/cli/tests/demo.test.cjs
+++ b/packages/cli/tests/demo.test.cjs
@@ -1,0 +1,22 @@
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const test = require('node:test');
+
+const BIN = path.resolve(__dirname, '..', 'bin', 'scbe.js');
+
+test('demo fallback denies the built-in destructive secret-cleanup command', () => {
+  const result = spawnSync(process.execPath, [BIN, 'demo', '--json'], {
+    cwd: path.resolve(__dirname, '..'),
+    encoding: 'utf8',
+    env: { ...process.env, SCBE_FORCE_GATE_FALLBACK: '1' },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const packet = JSON.parse(result.stdout);
+  assert.equal(packet.decision, 'DENY');
+  assert.equal(packet.geoseal.allowed, false);
+  assert.equal(packet.output, 'Blocked unsafe tool execution request before it reached the shell.');
+  assert.match(packet.suggested_correction, /Do not execute/);
+  assert(packet.reasons.some((reason) => reason.includes('fallback.secret_path')));
+});

--- a/scripts/system/build_workcell_download.py
+++ b/scripts/system/build_workcell_download.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_DIR = REPO_ROOT / "packages" / "cli"
+QUICKSTART = REPO_ROOT / "docs" / "downloads" / "scbe-workcell-quickstart.md"
+PACKAGING_RESEARCH = (
+    REPO_ROOT / "docs" / "downloads" / "downloadable-app-packaging-research-2026-06-16.md"
+)
+DEFAULT_OUT = REPO_ROOT / "artifacts" / "workcell_download"
+
+
+def _resolve_executable(name: str) -> str:
+    candidates = [name]
+    if os.name == "nt":
+        candidates = [f"{name}.cmd", f"{name}.exe", f"{name}.bat", f"{name}.ps1", name]
+    for candidate in candidates:
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    raise FileNotFoundError(f"Could not find required executable: {name}")
+
+
+NPM = _resolve_executable("npm")
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    timeout: int = 120,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _load_cli_metadata() -> dict[str, Any]:
+    package_json = json.loads((CLI_DIR / "package.json").read_text(encoding="utf-8"))
+    return {
+        "name": package_json["name"],
+        "version": package_json["version"],
+        "description": package_json.get("description", ""),
+    }
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def _copy_if_exists(source: Path, target: Path) -> None:
+    if source.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def _extract_pack_output(stdout: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"npm pack did not return JSON: {stdout[:500]!r}") from exc
+    if not isinstance(parsed, list) or not parsed:
+        raise RuntimeError(f"npm pack returned an unexpected payload: {parsed!r}")
+    return parsed[0]
+
+
+def _command_block(command: list[str], result: subprocess.CompletedProcess[str]) -> str:
+    rendered = " ".join(command)
+    return (
+        f"### `{rendered}`\n\n"
+        f"Exit code: `{result.returncode}`\n\n"
+        "stdout:\n\n"
+        "```text\n"
+        f"{result.stdout.strip()}\n"
+        "```\n\n"
+        "stderr:\n\n"
+        "```text\n"
+        f"{result.stderr.strip()}\n"
+        "```\n"
+    )
+
+
+def _verify_bundle(tarball: Path, out_dir: Path, package_name: str) -> dict[str, Any]:
+    transcript_parts = [
+        "# SCBE Workcell Verification Transcript",
+        "",
+        f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "This installs the packed Workcell CLI into a temporary npm prefix and runs the first buyer commands.",
+        "",
+    ]
+    commands: list[dict[str, Any]] = []
+
+    with tempfile.TemporaryDirectory(prefix="scbe-workcell-verify-") as tmp:
+        prefix = Path(tmp) / "prefix"
+        install = _run(
+            [NPM, "install", "--prefix", str(prefix), str(tarball), "--omit=dev", "--no-audit", "--no-fund"],
+            cwd=REPO_ROOT,
+            timeout=180,
+        )
+        transcript_parts.append(_command_block(["npm", "install", "--prefix", "<temp>", tarball.name], install))
+        commands.append({"name": "install", "exit_code": install.returncode})
+        if install.returncode != 0:
+            _write_text(out_dir / "verification_transcript.md", "\n".join(transcript_parts))
+            return {"ok": False, "commands": commands}
+
+        bin_dir = prefix / "node_modules" / ".bin"
+        scbe = bin_dir / ("scbe.cmd" if os.name == "nt" else "scbe")
+        verification_commands = [
+            [str(scbe), "version", "--json"],
+            [str(scbe), "demo", "--json"],
+            [str(scbe), "tools", "--json"],
+            [str(scbe), "selftest"],
+        ]
+        for command in verification_commands:
+            result = _run(command, cwd=REPO_ROOT, timeout=120)
+            display_command = ["scbe", *command[1:]]
+            transcript_parts.append(_command_block(display_command, result))
+            commands.append({"name": " ".join(display_command), "exit_code": result.returncode})
+
+    ok = all(item["exit_code"] == 0 for item in commands)
+    _write_text(out_dir / "verification_transcript.md", "\n".join(transcript_parts))
+    return {"ok": ok, "commands": commands, "package_name": package_name}
+
+
+def build_workcell_download(out_root: Path = DEFAULT_OUT, verify: bool = True) -> dict[str, Any]:
+    metadata = _load_cli_metadata()
+    version = metadata["version"]
+    package_name = metadata["name"]
+    bundle_name = f"SCBE-Workcell-v{version}"
+    bundle_dir = out_root / bundle_name
+    pack_dir = out_root / "npm-pack"
+
+    if bundle_dir.exists():
+        shutil.rmtree(bundle_dir)
+    if pack_dir.exists():
+        shutil.rmtree(pack_dir)
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    pack_dir.mkdir(parents=True, exist_ok=True)
+
+    pack = _run([NPM, "pack", "--json", "--pack-destination", str(pack_dir)], cwd=CLI_DIR, timeout=180)
+    if pack.returncode != 0:
+        raise RuntimeError(f"npm pack failed:\nSTDOUT:\n{pack.stdout}\nSTDERR:\n{pack.stderr}")
+    pack_info = _extract_pack_output(pack.stdout)
+    tarball = pack_dir / pack_info["filename"]
+    bundled_tarball = bundle_dir / tarball.name
+    shutil.copy2(tarball, bundled_tarball)
+
+    _copy_if_exists(QUICKSTART, bundle_dir / "QUICKSTART.md")
+    _copy_if_exists(PACKAGING_RESEARCH, bundle_dir / "PACKAGING_RESEARCH.md")
+    _copy_if_exists(CLI_DIR / "README.md", bundle_dir / "CLI_README.md")
+    _copy_if_exists(CLI_DIR / "LICENSE", bundle_dir / "LICENSE")
+    _copy_if_exists(CLI_DIR / "LICENSE-APACHE", bundle_dir / "LICENSE-APACHE")
+    _copy_if_exists(CLI_DIR / "LICENSE-NOTICE.md", bundle_dir / "LICENSE-NOTICE.md")
+
+    _write_text(
+        bundle_dir / "install-windows.ps1",
+        f"""$ErrorActionPreference = "Stop"
+npm install -g .\\{tarball.name}
+scbe version
+scbe demo --json
+""",
+    )
+    _write_text(
+        bundle_dir / "install-unix.sh",
+        f"""#!/usr/bin/env sh
+set -eu
+npm install -g ./{tarball.name}
+scbe version
+scbe demo --json
+""",
+    )
+
+    manifest: dict[str, Any] = {
+        "schema": "scbe_workcell_download_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "bundle_name": bundle_name,
+        "package": metadata,
+        "tarball": {
+            "file": tarball.name,
+            "sha256": _sha256(bundled_tarball),
+            "bytes": bundled_tarball.stat().st_size,
+            "npm_pack": pack_info,
+        },
+        "verification": {"ok": None, "commands": []},
+    }
+
+    if verify:
+        manifest["verification"] = _verify_bundle(bundled_tarball, bundle_dir, package_name)
+
+    _write_text(bundle_dir / "manifest.json", json.dumps(manifest, indent=2) + "\n")
+    archive_base = out_root / bundle_name
+    archive_path = Path(shutil.make_archive(str(archive_base), "zip", root_dir=bundle_dir))
+    manifest["archive"] = {
+        "file": archive_path.name,
+        "path": str(archive_path),
+        "sha256": _sha256(archive_path),
+        "bytes": archive_path.stat().st_size,
+    }
+    _write_text(bundle_dir / "manifest.json", json.dumps(manifest, indent=2) + "\n")
+    _write_text(out_root / f"{bundle_name}.manifest.json", json.dumps(manifest, indent=2) + "\n")
+    return manifest
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build the downloadable SCBE Workcell bundle.")
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT), help="Output directory for bundle artifacts.")
+    parser.add_argument("--skip-verify", action="store_true", help="Build the ZIP without temp-install verification.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        manifest = build_workcell_download(Path(args.out_dir), verify=not args.skip_verify)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(manifest, indent=2))
+    return 0 if manifest["verification"]["ok"] is not False else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary
- adds a repeatable `npm run release:workcell` builder for the downloadable SCBE Workcell ZIP
- bundles the CLI `.tgz`, quickstart, licenses, packaging memo, install scripts, manifest, and verification transcript
- verifies the built bundle by installing from the packed tarball into a temp npm prefix and running first-use commands
- hardens the packaged CLI demo with a JavaScript fallback gate so destructive secret-cleanup commands are denied even without a source checkout

## Built artifact from local verification
- `artifacts/workcell_download/SCBE-Workcell-v4.4.0.zip`
- latest local ZIP sha256: `681094b92eb112bd203010c830e3648e75ea168bf87bd49372b5c8f6d578b1e2`
- verification transcript: `artifacts/workcell_download/SCBE-Workcell-v4.4.0/verification_transcript.md`

## What first use looks like
The bundle verification installs the `.tgz` and runs:
- `scbe version --json`
- `scbe demo --json`
- `scbe tools --json`
- `scbe selftest`

The demo now shows `decision: DENY`, `allowed: false`, and fallback findings for forced delete + secret path when the Python GeoSeal source parser is unavailable from the npm install.

## Validation
- `npm run release:workcell`
- `node --check packages\cli\bin\scbe.js`
- `node --test packages\cli\tests\demo.test.cjs packages\cli\tests\tools-manifest.test.cjs`
- `python -m py_compile scripts\system\build_workcell_download.py`
- `git diff --check`

## Known unrelated full-suite status
`npm test` in `packages/cli` was run with a longer timeout. The changed demo test passed, but the existing full suite still reports unrelated failures in MCP stdio, two 60s react packet tests, and `tui.mjs` import of `react` in the package test environment.
