### PR TITLE
refactor(tests): tranche 1 — 56 redundant test fns → 15 parametrized (coverage preserved)

### DIFF
--- a/tests/aetherbrowser/test_agents.py
+++ b/tests/aetherbrowser/test_agents.py
@@ -5,10 +5,12 @@ from src.aetherbrowser.ws_feed import WsFeed
 
 
 class TestSquadCreation:
-    def test_squad_has_six_agents(self):
+    def test_squad_structure_six_agents_all_idle(self):
         feed = WsFeed()
         squad = AgentSquad(feed)
         assert len(squad.agents) == 6
+        for agent in squad.agents.values():
+            assert agent.state == AgentState.IDLE
 
     def test_all_tongues_present(self):
         feed = WsFeed()
@@ -22,12 +24,6 @@ class TestSquadCreation:
             TongueRole.UM,
             TongueRole.DR,
         }
-
-    def test_all_start_idle(self):
-        feed = WsFeed()
-        squad = AgentSquad(feed)
-        for agent in squad.agents.values():
-            assert agent.state == AgentState.IDLE
 
 
 class TestTaskDecomposition:

--- a/tests/aetherbrowser/test_hyperlane_py.py
+++ b/tests/aetherbrowser/test_hyperlane_py.py
@@ -1,5 +1,7 @@
 """Tests for the Python port of HyperLane governance."""
 
+import pytest
+
 from src.aetherbrowser.hyperlane_py import HyperLanePy, Zone, Decision
 
 
@@ -63,9 +65,10 @@ class TestDecisionMaking:
 
 
 class TestRateLimiting:
-    def test_rate_limit_after_burst(self):
-        hl = HyperLanePy(rate_limit_per_min=3)
-        for _ in range(3):
+    @pytest.mark.parametrize("burst", [1, 3, 5])
+    def test_rate_limit_after_burst(self, burst):
+        hl = HyperLanePy(rate_limit_per_min=burst)
+        for _ in range(burst):
             hl.evaluate("https://github.com/test", action="read", agent_id="AV")
         d = hl.evaluate("https://github.com/test", action="read", agent_id="AV")
         assert d.decision == Decision.DENY
@@ -73,12 +76,14 @@ class TestRateLimiting:
 
 
 class TestCustomZones:
-    def test_add_domain_to_green(self):
+    @pytest.mark.parametrize(
+        "domain, url, zone",
+        [
+            ("safe.example.com", "https://safe.example.com/api", Zone.GREEN),
+            ("semi-trusted.com", "https://semi-trusted.com/write", Zone.YELLOW),
+        ],
+    )
+    def test_add_domain_to_zone(self, domain, url, zone):
         hl = HyperLanePy()
-        hl.add_domain("safe.example.com", Zone.GREEN)
-        assert hl.classify_zone("https://safe.example.com/api") == Zone.GREEN
-
-    def test_add_domain_to_yellow(self):
-        hl = HyperLanePy()
-        hl.add_domain("semi-trusted.com", Zone.YELLOW)
-        assert hl.classify_zone("https://semi-trusted.com/write") == Zone.YELLOW
+        hl.add_domain(domain, zone)
+        assert hl.classify_zone(url) == zone

--- a/tests/aetherbrowser/test_remote_display.py
+++ b/tests/aetherbrowser/test_remote_display.py
@@ -68,30 +68,46 @@ def test_canvas_coords_no_bounds():
     assert cy == 300.0
 
 
-def test_get_display_not_found():
+def _err_get_display_not_found():
     """Accessing a nonexistent display raises ValueError."""
     from agents.remote_display import RemoteDisplayManager
 
     mgr = RemoteDisplayManager()
-    with pytest.raises(ValueError, match="not found"):
-        mgr._get_display("nonexistent")
+    mgr._get_display("nonexistent")
 
 
-def test_require_browser_not_launched():
+def _err_require_browser_not_launched():
     """Operations before launch() raise RuntimeError."""
     from agents.remote_display import RemoteDisplayManager
 
     mgr = RemoteDisplayManager()
-    with pytest.raises(RuntimeError, match="not launched"):
-        mgr._require_browser()
+    mgr._require_browser()
 
 
-def test_playwright_runtime_remote_not_open():
+def _err_playwright_runtime_remote_not_open():
     """remote_screenshot before open_remote_display raises RuntimeError."""
+    import asyncio
+
     from agents.playwright_runtime import PlaywrightRuntime
 
     rt = PlaywrightRuntime()
-    with pytest.raises(RuntimeError, match="No remote displays"):
-        import asyncio
+    asyncio.run(rt.remote_screenshot("test"))
 
-        asyncio.run(rt.remote_screenshot("test"))
+
+@pytest.mark.parametrize(
+    "invoke, exc_type, match",
+    [
+        (_err_get_display_not_found, ValueError, "not found"),
+        (_err_require_browser_not_launched, RuntimeError, "not launched"),
+        (_err_playwright_runtime_remote_not_open, RuntimeError, "No remote displays"),
+    ],
+    ids=[
+        "get_display_not_found",
+        "require_browser_not_launched",
+        "playwright_runtime_remote_not_open",
+    ],
+)
+def test_error_paths(invoke, exc_type, match):
+    """Error-path operations raise the expected exception with the expected message."""
+    with pytest.raises(exc_type, match=match):
+        invoke()

--- a/tests/aetherbrowser/test_trilane_router.py
+++ b/tests/aetherbrowser/test_trilane_router.py
@@ -21,52 +21,50 @@ def router():
 
 
 class TestIntentClassification:
-    def test_scrape_intent(self, router):
-        assert router.classify_intent("scrape the top 50 arXiv papers") == TaskIntent.SCRAPE
-        assert router.classify_intent("extract all links from this page") == TaskIntent.SCRAPE
-        assert router.classify_intent("crawl github.com for repos") == TaskIntent.SCRAPE
-        assert router.classify_intent("bulk download PDFs") == TaskIntent.SCRAPE
-
-    def test_interact_intent(self, router):
-        assert router.classify_intent("click the login button") == TaskIntent.INTERACT
-        assert router.classify_intent("fill out the contact form") == TaskIntent.INTERACT
-        assert router.classify_intent("navigate to github.com and open settings") == TaskIntent.INTERACT
-        assert router.classify_intent("type my username into the field") == TaskIntent.INTERACT
-
-    def test_verify_intent(self, router):
-        assert router.classify_intent("check if the shopify store looks right") == TaskIntent.VERIFY
-        assert router.classify_intent("verify the homepage screenshot") == TaskIntent.VERIFY
-        assert router.classify_intent("inspect the layout visually") == TaskIntent.VERIFY
-
-    def test_post_intent(self, router):
-        assert router.classify_intent("post this article to dev.to") == TaskIntent.POST
-        assert router.classify_intent("publish the blog post") == TaskIntent.POST
-        assert router.classify_intent("tweet about the new release") == TaskIntent.POST
-        assert router.classify_intent("share the new release on twitter") == TaskIntent.POST
-
-    def test_monitor_intent(self, router):
-        assert router.classify_intent("watch for price changes on amazon") == TaskIntent.MONITOR
-        assert router.classify_intent("monitor the CI pipeline") == TaskIntent.MONITOR
-        assert router.classify_intent("track when the page updates") == TaskIntent.MONITOR
-
-    def test_research_intent(self, router):
-        assert router.classify_intent("research AI safety papers") == TaskIntent.RESEARCH
-        assert router.classify_intent("find information about transformers") == TaskIntent.RESEARCH
-        assert router.classify_intent("search for competitor products") == TaskIntent.RESEARCH
-
-    def test_train_intent(self, router):
-        assert router.classify_intent("train the model by watching me browse") == TaskIntent.TRAIN
-        assert router.classify_intent("capture this session for SFT dataset") == TaskIntent.TRAIN
-        assert router.classify_intent("shadow learn from this interaction") == TaskIntent.TRAIN
-
-    def test_default_to_research(self, router):
-        assert router.classify_intent("tell me about the weather") == TaskIntent.RESEARCH
-
-    def test_url_boosts_scrape(self, router):
-        assert router.classify_intent("https://arxiv.org/list/cs.AI") == TaskIntent.SCRAPE
-
-    def test_large_number_boosts_scrape(self, router):
-        assert router.classify_intent("get 100 papers from arxiv") == TaskIntent.SCRAPE
+    @pytest.mark.parametrize(
+        "text,expected_intent",
+        [
+            # scrape intent
+            ("scrape the top 50 arXiv papers", TaskIntent.SCRAPE),
+            ("extract all links from this page", TaskIntent.SCRAPE),
+            ("crawl github.com for repos", TaskIntent.SCRAPE),
+            ("bulk download PDFs", TaskIntent.SCRAPE),
+            # interact intent
+            ("click the login button", TaskIntent.INTERACT),
+            ("fill out the contact form", TaskIntent.INTERACT),
+            ("navigate to github.com and open settings", TaskIntent.INTERACT),
+            ("type my username into the field", TaskIntent.INTERACT),
+            # verify intent
+            ("check if the shopify store looks right", TaskIntent.VERIFY),
+            ("verify the homepage screenshot", TaskIntent.VERIFY),
+            ("inspect the layout visually", TaskIntent.VERIFY),
+            # post intent
+            ("post this article to dev.to", TaskIntent.POST),
+            ("publish the blog post", TaskIntent.POST),
+            ("tweet about the new release", TaskIntent.POST),
+            ("share the new release on twitter", TaskIntent.POST),
+            # monitor intent
+            ("watch for price changes on amazon", TaskIntent.MONITOR),
+            ("monitor the CI pipeline", TaskIntent.MONITOR),
+            ("track when the page updates", TaskIntent.MONITOR),
+            # research intent
+            ("research AI safety papers", TaskIntent.RESEARCH),
+            ("find information about transformers", TaskIntent.RESEARCH),
+            ("search for competitor products", TaskIntent.RESEARCH),
+            # train intent
+            ("train the model by watching me browse", TaskIntent.TRAIN),
+            ("capture this session for SFT dataset", TaskIntent.TRAIN),
+            ("shadow learn from this interaction", TaskIntent.TRAIN),
+            # default to research
+            ("tell me about the weather", TaskIntent.RESEARCH),
+            # url boosts scrape
+            ("https://arxiv.org/list/cs.AI", TaskIntent.SCRAPE),
+            # large number boosts scrape
+            ("get 100 papers from arxiv", TaskIntent.SCRAPE),
+        ],
+    )
+    def test_classify_intent(self, router, text, expected_intent):
+        assert router.classify_intent(text) == expected_intent
 
 
 # =============================================================================

--- a/tests/aetherbrowser/test_ws_feed.py
+++ b/tests/aetherbrowser/test_ws_feed.py
@@ -5,16 +5,64 @@ import pytest
 from src.aetherbrowser.ws_feed import WsFeed, Agent, Zone
 
 
+def _make_chat(feed):
+    msg = feed.chat(Agent.KO, "Hello world", model="opus")
+    assert msg["agent"] == "KO"
+    assert msg["payload"]["text"] == "Hello world"
+    assert msg["model"] == "opus"
+    assert "ts" in msg
+    assert "seq" in msg
+    return msg
+
+
+def _make_agent_status(feed):
+    msg = feed.agent_status(Agent.AV, "scouting", model="flash")
+    assert msg["agent"] == "AV"
+    assert msg["payload"]["state"] == "scouting"
+    return msg
+
+
+def _make_zone_request(feed):
+    msg = feed.zone_request(
+        Agent.RU,
+        Zone.YELLOW,
+        url="https://api.example.com",
+        action="write",
+        description="Post to external API",
+    )
+    assert msg["zone"] == "YELLOW"
+    assert msg["payload"]["url"] == "https://api.example.com"
+    return msg
+
+
+def _make_progress(feed):
+    msg = feed.progress(Agent.CA, current=3, total=10, label="Extracting pages")
+    assert msg["payload"]["current"] == 3
+    assert msg["payload"]["total"] == 10
+    return msg
+
+
+def _make_error(feed):
+    msg = feed.error("Connection failed", agent=Agent.KO)
+    assert msg["payload"]["reason"] == "Connection failed"
+    return msg
+
+
 class TestMessageCreation:
-    def test_create_chat_message(self):
+    @pytest.mark.parametrize(
+        "factory,expected_type",
+        [
+            (_make_chat, "chat"),
+            (_make_agent_status, "agent_status"),
+            (_make_zone_request, "zone_request"),
+            (_make_progress, "progress"),
+            (_make_error, "error"),
+        ],
+    )
+    def test_create_message(self, factory, expected_type):
         feed = WsFeed()
-        msg = feed.chat(Agent.KO, "Hello world", model="opus")
-        assert msg["type"] == "chat"
-        assert msg["agent"] == "KO"
-        assert msg["payload"]["text"] == "Hello world"
-        assert msg["model"] == "opus"
-        assert "ts" in msg
-        assert "seq" in msg
+        msg = factory(feed)
+        assert msg["type"] == expected_type
 
     def test_create_chat_message_with_structured_payload(self):
         feed = WsFeed()
@@ -31,39 +79,6 @@ class TestMessageCreation:
         m1 = feed.chat(Agent.KO, "first")
         m2 = feed.chat(Agent.AV, "second")
         assert m2["seq"] == m1["seq"] + 1
-
-    def test_create_agent_status(self):
-        feed = WsFeed()
-        msg = feed.agent_status(Agent.AV, "scouting", model="flash")
-        assert msg["type"] == "agent_status"
-        assert msg["agent"] == "AV"
-        assert msg["payload"]["state"] == "scouting"
-
-    def test_create_zone_request(self):
-        feed = WsFeed()
-        msg = feed.zone_request(
-            Agent.RU,
-            Zone.YELLOW,
-            url="https://api.example.com",
-            action="write",
-            description="Post to external API",
-        )
-        assert msg["type"] == "zone_request"
-        assert msg["zone"] == "YELLOW"
-        assert msg["payload"]["url"] == "https://api.example.com"
-
-    def test_create_progress(self):
-        feed = WsFeed()
-        msg = feed.progress(Agent.CA, current=3, total=10, label="Extracting pages")
-        assert msg["type"] == "progress"
-        assert msg["payload"]["current"] == 3
-        assert msg["payload"]["total"] == 10
-
-    def test_create_error(self):
-        feed = WsFeed()
-        msg = feed.error("Connection failed", agent=Agent.KO)
-        assert msg["type"] == "error"
-        assert msg["payload"]["reason"] == "Connection failed"
 
     def test_parse_command(self):
         raw = json.dumps(

--- a/tests/benchmark/test_bench_scorer.py
+++ b/tests/benchmark/test_bench_scorer.py
@@ -3,6 +3,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from scripts.benchmark.bench_scorer import score_report
@@ -12,52 +14,67 @@ def _report(schema: str, summary: dict, **kwargs) -> dict:
     return {"schema_version": schema, "summary": summary, **kwargs}
 
 
-def test_hard_agentic_schema():
-    report = _report(
-        "scbe_hard_agentic_benchmark_pretest_v1",
-        {"target_count": 14, "ready_or_pass": 12, "blocked_or_failed": 2, "decision": "READY"},
-        generated_at_utc="2026-05-29T00:00:00Z",
-        claim_boundary="local readiness lanes",
-    )
+@pytest.mark.parametrize(
+    "report, expectations",
+    [
+        # test_hard_agentic_schema
+        (
+            _report(
+                "scbe_hard_agentic_benchmark_pretest_v1",
+                {"target_count": 14, "ready_or_pass": 12, "blocked_or_failed": 2, "decision": "READY"},
+                generated_at_utc="2026-05-29T00:00:00Z",
+                claim_boundary="local readiness lanes",
+            ),
+            {
+                "lane": "hard-agentic",
+                "pass_count": 12,
+                "total": 14,
+                "pass_rate": pytest.approx(12 / 14, abs=1e-6),
+                "decision": "READY",
+                "boundary": "local readiness lanes",
+            },
+        ),
+        # test_research_schema
+        (
+            _report(
+                "scbe_research_agent_fixture_benchmark_v1",
+                {"total": 10, "passed": 7, "failed": 3, "decision": "PASS"},
+                claim_boundary="local BrowseComp-style fixtures",
+            ),
+            {
+                "lane": "research",
+                "pass_count": 7,
+                "pass_rate": 7 / 10,
+            },
+        ),
+        # test_rubix_schema
+        (
+            _report(
+                "scbe_rubix_browser_hypercube_benchmark_v1",
+                {"total_paths": 5, "valid_paths": 5, "decision": "PASS"},
+            ),
+            {
+                "lane": "rubix-browser",
+                "pass_rate": 1.0,
+            },
+        ),
+        # test_arc_style_grid_schema
+        (
+            _report(
+                "scbe_arc_style_grid_benchmark_v1",
+                {"total": 8, "passed": 6, "decision": "PASS"},
+            ),
+            {
+                "lane": "arc-style-grid",
+                "pass_count": 6,
+            },
+        ),
+    ],
+)
+def test_schema_normalization(report, expectations):
     s = score_report(report)
-    assert s.lane == "hard-agentic"
-    assert s.pass_count == 12
-    assert s.total == 14
-    assert abs(s.pass_rate - 12 / 14) < 1e-6
-    assert s.decision == "READY"
-    assert s.boundary == "local readiness lanes"
-
-
-def test_research_schema():
-    report = _report(
-        "scbe_research_agent_fixture_benchmark_v1",
-        {"total": 10, "passed": 7, "failed": 3, "decision": "PASS"},
-        claim_boundary="local BrowseComp-style fixtures",
-    )
-    s = score_report(report)
-    assert s.lane == "research"
-    assert s.pass_count == 7
-    assert s.pass_rate == 7 / 10
-
-
-def test_rubix_schema():
-    report = _report(
-        "scbe_rubix_browser_hypercube_benchmark_v1",
-        {"total_paths": 5, "valid_paths": 5, "decision": "PASS"},
-    )
-    s = score_report(report)
-    assert s.lane == "rubix-browser"
-    assert s.pass_rate == 1.0
-
-
-def test_arc_style_grid_schema():
-    report = _report(
-        "scbe_arc_style_grid_benchmark_v1",
-        {"total": 8, "passed": 6, "decision": "PASS"},
-    )
-    s = score_report(report)
-    assert s.lane == "arc-style-grid"
-    assert s.pass_count == 6
+    for attr, expected in expectations.items():
+        assert getattr(s, attr) == expected
 
 
 def test_generic_fallback():

--- a/tests/benchmark/test_bfcl_tool_call_adapter.py
+++ b/tests/benchmark/test_bfcl_tool_call_adapter.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
@@ -90,23 +92,21 @@ def test_all_schemas_have_description():
 # ── Param extraction ───────────────────────────────────────────────────────────
 
 
-def test_extract_params_single():
-    assert _extract_params(["-m", "module", "{task}"]) == ["task"]
-
-
-def test_extract_params_multi():
-    params = _extract_params(["--task", "{task}", "--type", "{taskType}", "--id", "{seriesId}"])
-    assert params == ["task", "taskType", "seriesId"]
-
-
-def test_extract_params_empty():
-    assert _extract_params(["--self-check"]) == []
-
-
-def test_extract_params_deduplicated():
-    # {task} appears twice but should only appear once in output
-    params = _extract_params(["{task}", "--also", "{task}"])
-    assert params == ["task"]
+@pytest.mark.parametrize(
+    "args, expected_params",
+    [
+        # single param
+        (["-m", "module", "{task}"], ["task"]),
+        # multiple params, order preserved
+        (["--task", "{task}", "--type", "{taskType}", "--id", "{seriesId}"], ["task", "taskType", "seriesId"]),
+        # no params
+        (["--self-check"], []),
+        # {task} appears twice but should only appear once in output (deduplicated)
+        (["{task}", "--also", "{task}"], ["task"]),
+    ],
+)
+def test_extract_params(args, expected_params):
+    assert _extract_params(args) == expected_params
 
 
 # ── AST validator ──────────────────────────────────────────────────────────────

--- a/tests/benchmark/test_provider_health_matrix.py
+++ b/tests/benchmark/test_provider_health_matrix.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from scripts.benchmark.provider_health_matrix import (
@@ -37,12 +39,46 @@ def test_tier_coverage():
     assert "paid" in tiers
 
 
-def test_key_missing_status_when_no_env_var(monkeypatch):
-    monkeypatch.delenv("CEREBRAS_API_KEY", raising=False)
-    spec = _spec(name="cerebras", env_vars=["CEREBRAS_API_KEY"])
-    h = check_provider(spec, probe=False)
-    assert h.status == "KEY_MISSING"
-    assert h.key_configured is False
+@pytest.mark.parametrize(
+    "condition, expected_status",
+    [
+        ("key_missing", "KEY_MISSING"),
+        ("probe_succeeds", "READY"),
+        ("probe_fails", "UNREACHABLE"),
+    ],
+)
+def test_health_status_matrix(monkeypatch, condition, expected_status):
+    if condition == "key_missing":
+        # No env var set -> KEY_MISSING, key not configured, no probe.
+        monkeypatch.delenv("CEREBRAS_API_KEY", raising=False)
+        spec = _spec(name="cerebras", env_vars=["CEREBRAS_API_KEY"])
+        h = check_provider(spec, probe=False)
+        assert h.status == expected_status
+        assert h.key_configured is False
+        return
+
+    # Probe-path cases: key configured, probe enabled, _PROBE_MAP patched.
+    monkeypatch.setenv("TEST_KEY_XYZ", "fake-key")
+    spec = _spec(name="fake", tier="free", env_vars=["TEST_KEY_XYZ"])
+
+    if condition == "probe_succeeds":
+
+        def fake_probe(s):
+            return True, 42, None
+
+    else:  # probe_fails
+
+        def fake_probe(s):
+            return False, None, "connection refused"
+
+    with patch.dict("scripts.benchmark.provider_health_matrix._PROBE_MAP", {"_probe_openai_compat": fake_probe}):
+        h = check_provider(spec, probe=True)
+
+    assert h.status == expected_status
+    if condition == "probe_succeeds":
+        assert h.latency_ms == 42
+    else:  # probe_fails
+        assert "connection refused" in (h.error or "")
 
 
 def test_no_key_required_for_local():
@@ -50,32 +86,6 @@ def test_no_key_required_for_local():
     h = check_provider(spec, probe=False)
     assert h.key_configured is True
     assert h.status != "KEY_MISSING"
-
-
-def test_ready_when_probe_succeeds(monkeypatch):
-    monkeypatch.setenv("TEST_KEY_XYZ", "fake-key")
-    spec = _spec(name="fake", tier="free", env_vars=["TEST_KEY_XYZ"])
-
-    def fake_probe(s):
-        return True, 42, None
-
-    with patch.dict("scripts.benchmark.provider_health_matrix._PROBE_MAP", {"_probe_openai_compat": fake_probe}):
-        h = check_provider(spec, probe=True)
-    assert h.status == "READY"
-    assert h.latency_ms == 42
-
-
-def test_unreachable_when_probe_fails(monkeypatch):
-    monkeypatch.setenv("TEST_KEY_XYZ", "fake-key")
-    spec = _spec(name="fake", tier="free", env_vars=["TEST_KEY_XYZ"])
-
-    def fake_probe(s):
-        return False, None, "connection refused"
-
-    with patch.dict("scripts.benchmark.provider_health_matrix._PROBE_MAP", {"_probe_openai_compat": fake_probe}):
-        h = check_provider(spec, probe=True)
-    assert h.status == "UNREACHABLE"
-    assert "connection refused" in (h.error or "")
 
 
 def test_build_matrix_schema(monkeypatch):

--- a/tests/benchmark/test_tau_bench_policy_adapter.py
+++ b/tests/benchmark/test_tau_bench_policy_adapter.py
@@ -111,24 +111,33 @@ def test_all_expected_decisions_are_valid():
 # ── Decision detection ─────────────────────────────────────────────────────────
 
 
-def test_detect_deny_from_refusal():
-    text = "I'm sorry, I cannot and will not help with that. This violates policy."
-    assert _detect_decision(text) == "DENY"
-
-
-def test_detect_quarantine_from_flag():
-    text = "I'm flagging this request for review. I cannot proceed until it's approved."
-    assert _detect_decision(text) == "QUARANTINE"
-
-
-def test_detect_escalate_from_escalation():
-    text = "This requires human governance review. I'm escalating this request."
-    assert _detect_decision(text) == "ESCALATE"
-
-
-def test_detect_allow_from_proceed():
-    text = "Sure, I'll help you with that. Here are the papers on hyperbolic geometry:"
-    assert _detect_decision(text) == "ALLOW"
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        pytest.param(
+            "I'm sorry, I cannot and will not help with that. This violates policy.",
+            "DENY",
+            id="deny_from_refusal",
+        ),
+        pytest.param(
+            "I'm flagging this request for review. I cannot proceed until it's approved.",
+            "QUARANTINE",
+            id="quarantine_from_flag",
+        ),
+        pytest.param(
+            "This requires human governance review. I'm escalating this request.",
+            "ESCALATE",
+            id="escalate_from_escalation",
+        ),
+        pytest.param(
+            "Sure, I'll help you with that. Here are the papers on hyperbolic geometry:",
+            "ALLOW",
+            id="allow_from_proceed",
+        ),
+    ],
+)
+def test_detect_decision_from_text(text, expected):
+    assert _detect_decision(text) == expected
 
 
 def test_detect_none_from_empty():

--- a/tests/crypto/test_gallery_chromatics.py
+++ b/tests/crypto/test_gallery_chromatics.py
@@ -83,19 +83,34 @@ class TestPerpEchoFormula:
 
 class TestFrequencyToHarmonicNumber:
 
-    def test_unison_is_zero(self):
-        """Ratio 1.0 → harmonic 0 (no movement)."""
+    def test_harmonic_constants(self):
+        """Pure algebraic identities of the log-phi harmonic + polar origin.
+
+        Consolidates the single-assertion constant tests
+        (test_unison_is_zero, test_phi_is_one, test_phi_squared_is_two,
+        test_zero_ratio, test_negative_ratio, test_zero_harmonic_at_origin)
+        into one — every original assertion is preserved verbatim.
+        """
+        # Ratio 1.0 → harmonic 0 (no movement).
         assert frequency_to_harmonic_number(1.0) == 0.0
 
-    def test_phi_is_one(self):
-        """Ratio phi → harmonic 1 (by definition of log-phi)."""
+        # Ratio phi → harmonic 1 (by definition of log-phi).
         h = frequency_to_harmonic_number(PHI)
         assert abs(h - 1.0) < 1e-10
 
-    def test_phi_squared_is_two(self):
-        """Ratio phi² → harmonic 2."""
+        # Ratio phi² → harmonic 2.
         h = frequency_to_harmonic_number(PHI**2)
         assert abs(h - 2.0) < 1e-10
+
+        # Zero ratio → harmonic 0 (edge case).
+        assert frequency_to_harmonic_number(0.0) == 0.0
+
+        # Negative ratio → harmonic 0 (edge case).
+        assert frequency_to_harmonic_number(-1.0) == 0.0
+
+        # Harmonic 0 → near origin (r ≈ 0).
+        theta, r = harmonic_to_polar(0.0)
+        assert r < 1.0  # very close to center
 
     def test_dead_tones_are_irrational(self):
         """Dead tone harmonics should NOT be integers (they're gaps)."""
@@ -110,14 +125,6 @@ class TestFrequencyToHarmonicNumber:
         h_seventh = frequency_to_harmonic_number(16 / 9)
         assert h_fifth < h_sixth < h_seventh
 
-    def test_zero_ratio(self):
-        """Zero ratio → harmonic 0 (edge case)."""
-        assert frequency_to_harmonic_number(0.0) == 0.0
-
-    def test_negative_ratio(self):
-        """Negative ratio → harmonic 0 (edge case)."""
-        assert frequency_to_harmonic_number(-1.0) == 0.0
-
 
 # ---------------------------------------------------------------------------
 # Polar Mapping
@@ -125,11 +132,6 @@ class TestFrequencyToHarmonicNumber:
 
 
 class TestHarmonicToPolar:
-
-    def test_zero_harmonic_at_origin(self):
-        """Harmonic 0 → near origin (r ≈ 0)."""
-        theta, r = harmonic_to_polar(0.0)
-        assert r < 1.0  # very close to center
 
     def test_radius_saturates(self):
         """Large harmonics → radius approaches max."""

--- a/tests/crypto/test_rwp_v3.py
+++ b/tests/crypto/test_rwp_v3.py
@@ -130,11 +130,18 @@ class TestRWPv3Protocol:
         assert tokenizer.validate_section_integrity("ct", envelope.ct)
         assert tokenizer.validate_section_integrity("tag", envelope.tag)
 
-    def test_encrypt_decrypt_roundtrip(self):
-        """Message should encrypt and decrypt correctly."""
+    @pytest.mark.parametrize(
+        "plaintext",
+        [
+            pytest.param(b"Hello, Mars!", id="basic"),
+            pytest.param(b"", id="empty"),
+            pytest.param(secrets.token_bytes(10000), id="large"),
+        ],
+    )
+    def test_encrypt_decrypt_roundtrip(self, plaintext):
+        """Message should encrypt and decrypt correctly (basic, empty, and large plaintexts)."""
         protocol = RWPv3Protocol(enable_pqc=False)
         password = b"test-password"
-        plaintext = b"Hello, Mars!"
 
         envelope = protocol.encrypt(password, plaintext)
         decrypted = protocol.decrypt(password, envelope)
@@ -205,21 +212,6 @@ class TestRWPv3Protocol:
         salt = SACRED_TONGUE_TOKENIZER.decode_section("salt", envelope.salt)
         assert len(salt) == 16
 
-    def test_empty_plaintext(self):
-        """Empty plaintext should work."""
-        protocol = RWPv3Protocol(enable_pqc=False)
-        envelope = protocol.encrypt(b"password", b"")
-        decrypted = protocol.decrypt(b"password", envelope)
-        assert decrypted == b""
-
-    def test_large_plaintext(self):
-        """Large plaintext should work."""
-        protocol = RWPv3Protocol(enable_pqc=False)
-        plaintext = secrets.token_bytes(10000)
-        envelope = protocol.encrypt(b"password", plaintext)
-        decrypted = protocol.decrypt(b"password", envelope)
-        assert decrypted == plaintext
-
     def test_derive_key_fallback_is_not_fast_hashing(self, monkeypatch):
         """Argon2 fallback should remain a real KDF, not a fast digest."""
         protocol = object.__new__(RWPv3Protocol)
@@ -252,11 +244,18 @@ class TestConvenienceAPI:
         assert "ct" in result
         assert "tag" in result
 
-    def test_encrypt_decrypt_message_roundtrip(self):
-        """String message should roundtrip through convenience API."""
-        envelope = rwp_encrypt_message("password", "Hello, Mars!")
-        message = rwp_decrypt_message("password", envelope)
-        assert message == "Hello, Mars!"
+    @pytest.mark.parametrize(
+        "message",
+        [
+            pytest.param("Hello, Mars!", id="ascii"),
+            pytest.param("Hello, 火星! 🚀", id="unicode"),
+        ],
+    )
+    def test_encrypt_decrypt_message_roundtrip(self, message):
+        """String message should roundtrip through convenience API (ascii and unicode)."""
+        envelope = rwp_encrypt_message("password", message)
+        decrypted = rwp_decrypt_message("password", envelope)
+        assert decrypted == message
 
     def test_encrypt_with_metadata(self):
         """Metadata should be included as AAD."""
@@ -267,13 +266,6 @@ class TestConvenienceAPI:
         aad_bytes = SACRED_TONGUE_TOKENIZER.decode_section("aad", envelope["aad"])
         aad_dict = json.loads(aad_bytes.decode("utf-8"))
         assert aad_dict == metadata
-
-    def test_unicode_message(self):
-        """Unicode messages should work."""
-        message = "Hello, 火星! 🚀"
-        envelope = rwp_encrypt_message("password", message)
-        decrypted = rwp_decrypt_message("password", envelope)
-        assert decrypted == message
 
     def test_wrong_password_message(self):
         """Wrong password should raise ValueError."""

--- a/tests/crypto/test_rwp_v3_properties.py
+++ b/tests/crypto/test_rwp_v3_properties.py
@@ -279,58 +279,14 @@ class TestNonceUniqueness:
 class TestSacredTongueBijectivity:
     """Property: Sacred Tongue encoding is bijective for all bytes."""
 
+    @pytest.mark.parametrize("tongue", ["ko", "av", "ru", "ca", "um", "dr"])
     @given(data=st.binary(min_size=1, max_size=512))
     @settings(max_examples=100, deadline=None)
-    def test_all_bytes_roundtrip_ko(self, data: bytes):
-        """Kor'aelin encoding should be bijective."""
+    def test_all_bytes_roundtrip(self, tongue: str, data: bytes):
+        """Each Sacred Tongue (KO, AV, RU, CA, UM, DR) encoding should be bijective."""
         tokenizer = SACRED_TONGUE_TOKENIZER
-        tokens = tokenizer.encode_bytes("ko", data)
-        decoded = tokenizer.decode_tokens("ko", tokens)
-        assert decoded == data
-
-    @given(data=st.binary(min_size=1, max_size=512))
-    @settings(max_examples=100, deadline=None)
-    def test_all_bytes_roundtrip_av(self, data: bytes):
-        """Avali encoding should be bijective."""
-        tokenizer = SACRED_TONGUE_TOKENIZER
-        tokens = tokenizer.encode_bytes("av", data)
-        decoded = tokenizer.decode_tokens("av", tokens)
-        assert decoded == data
-
-    @given(data=st.binary(min_size=1, max_size=512))
-    @settings(max_examples=100, deadline=None)
-    def test_all_bytes_roundtrip_ru(self, data: bytes):
-        """Runethic encoding should be bijective."""
-        tokenizer = SACRED_TONGUE_TOKENIZER
-        tokens = tokenizer.encode_bytes("ru", data)
-        decoded = tokenizer.decode_tokens("ru", tokens)
-        assert decoded == data
-
-    @given(data=st.binary(min_size=1, max_size=512))
-    @settings(max_examples=100, deadline=None)
-    def test_all_bytes_roundtrip_ca(self, data: bytes):
-        """Cassisivadan encoding should be bijective."""
-        tokenizer = SACRED_TONGUE_TOKENIZER
-        tokens = tokenizer.encode_bytes("ca", data)
-        decoded = tokenizer.decode_tokens("ca", tokens)
-        assert decoded == data
-
-    @given(data=st.binary(min_size=1, max_size=512))
-    @settings(max_examples=100, deadline=None)
-    def test_all_bytes_roundtrip_um(self, data: bytes):
-        """Umbroth encoding should be bijective."""
-        tokenizer = SACRED_TONGUE_TOKENIZER
-        tokens = tokenizer.encode_bytes("um", data)
-        decoded = tokenizer.decode_tokens("um", tokens)
-        assert decoded == data
-
-    @given(data=st.binary(min_size=1, max_size=512))
-    @settings(max_examples=100, deadline=None)
-    def test_all_bytes_roundtrip_dr(self, data: bytes):
-        """Draumric encoding should be bijective."""
-        tokenizer = SACRED_TONGUE_TOKENIZER
-        tokens = tokenizer.encode_bytes("dr", data)
-        decoded = tokenizer.decode_tokens("dr", tokens)
+        tokens = tokenizer.encode_bytes(tongue, data)
+        decoded = tokenizer.decode_tokens(tongue, tokens)
         assert decoded == data
 
 


### PR DESCRIPTION
**Goal: improve the test-code-to-coverage ratio** — fewer, denser test functions covering the same behavior, not a smaller raw count.

## Result (12 mechanical files, all verified green)
- **56 test-function defs → 15** (−41 redundant functions)
- **Coverage preserved**: every assertion still runs as a parametrized case. 247 collected tests pass (was 234 — parametrize expands into finer per-case items, so failures isolate better).
- LOC ~flat (+16): parametrize removes function *boilerplate*, keeps all test *data*.

| file | functions | note |
|---|---|---|
| `test_trilane_router` | 10 → 1 | intent classification → `@parametrize` (27 cases) |
| `test_gallery_chromatics` | 6 → 1 | math-constant identities consolidated |
| `test_rwp_v3_properties` | 6 → 1 | per-tongue bijectivity → `@parametrize` |
| `test_rwp_v3` | 5 → 2 | encrypt/decrypt roundtrip variants |
| `test_bfcl` / `test_tau` / `test_ws_feed` / `test_bench_scorer` / `test_provider_health` | each N → 1 | identical-body adapter/scorer tests |
| `test_agents` / `test_remote_display` / `test_hyperlane_py` | consolidated | structure/error-path trivia |

## Safety
- Money / marketing / claim-guard tests **deliberately untouched** (they catch real revenue regressions).
- Each file re-run green individually **and** all 12 together (`247 passed`).
- No behavioral assertion weakened or dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite organization across multiple modules to consolidate related test cases into unified, data-driven tests for improved maintainability and coverage clarity. No changes to tested functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->