### PR TITLE
feat(governance): real ML-DSA-65 authority signatures for decision envelopes (deploy-blocker #3)

### DIFF
--- a/src/crypto/pqc_liboqs.py
+++ b/src/crypto/pqc_liboqs.py
@@ -471,6 +471,25 @@ class MLDSA65:
 
         return instance
 
+    @staticmethod
+    def verify_with_public_key(public_key: bytes, message: bytes, signature: bytes) -> bool:
+        """Verify an ML-DSA-65 signature against a public key only (no secret key).
+
+        For verifiers that hold the signer's public key but not its secret — e.g.
+        governance-authority verification, where the secret never leaves the signer.
+        Fail-closed: refuses (raises) rather than fake a result if no real backend.
+        """
+        if LIBOQS_AVAILABLE:
+            alg = _select_mldsa_algorithm() or "ML-DSA-65"
+            with oqs.Signature(alg) as verifier:
+                return bool(verifier.verify(message, signature, public_key))
+        if PURE_PQC_AVAILABLE:
+            return bool(_DilithiumPure.verify(public_key, message, signature))
+        raise RuntimeError(
+            "ML-DSA-65 verify_with_public_key requires a real PQC backend (liboqs or "
+            "pure-PQC); refusing to fake a verification result."
+        )
+
 
 # =============================================================================
 # DUAL LATTICE CONSENSUS HELPERS

--- a/src/governance/decision_envelope_v1.py
+++ b/src/governance/decision_envelope_v1.py
@@ -4,7 +4,8 @@ Decision Envelope v1 (protobuf-first governance contract).
 This module implements:
 1) Dynamic protobuf message classes for DecisionEnvelopeV1.
 2) Deterministic canonical protobuf bytes for signing.
-3) HMAC-SHA256 signing/verification (dev placeholder for ML-DSA).
+3) HMAC-SHA256 MAC (symmetric integrity) + real ML-DSA-65 signing/verification
+   (asymmetric authority non-repudiation, via src/crypto/pqc_liboqs).
 4) Deterministic MMR leaf hash canonicalization.
 5) JSON / JSON-LD projection with signed protobuf hash reference.
 6) Resource-aware envelope check: "given state, is action inside envelope?"
@@ -667,8 +668,11 @@ def sign_envelope_hmac(envelope: Any, signing_key: bytes | str, *, set_mmr_hook:
     """
     Sign envelope with deterministic protobuf payload hash.
 
-    Dev placeholder signature:
-      HMAC-SHA256(signing_key, signed_payload_hash)
+    Symmetric authenticity tag: HMAC-SHA256(signing_key, signed_payload_hash). This is
+    a real MAC for shared-secret integrity, NOT an asymmetric signature — anyone holding
+    the key can produce it, so it provides no non-repudiation. For real authority
+    signatures use :func:`sign_envelope_mldsa` (asymmetric ML-DSA-65, verified with the
+    public key alone).
     """
     key = signing_key.encode("utf-8") if isinstance(signing_key, str) else bytes(signing_key)
     env = _copy_envelope(envelope)
@@ -714,6 +718,81 @@ def verify_envelope_hmac(
 
     expected_sig = hmac.new(key_bytes, expected_payload_hash, hashlib.sha256).digest()
     if not hmac.compare_digest(expected_sig, bytes(envelope.authority.signature)):
+        return False, "signature mismatch"
+
+    if len(envelope.audit.mmr_fields) > 0 and bytes(envelope.audit.mmr_leaf_hash):
+        expected_mmr = mmr_leaf_hash(envelope, mmr_fields=tuple(envelope.audit.mmr_fields))
+        if bytes(envelope.audit.mmr_leaf_hash) != expected_mmr:
+            return False, "mmr_leaf_hash mismatch"
+
+    return True, "ok"
+
+
+def sign_envelope_mldsa(envelope: Any, keypair: Any, *, set_mmr_hook: bool = True) -> Any:
+    """Sign the envelope authority with a real ML-DSA-65 signature (FIPS 204).
+
+    Unlike :func:`sign_envelope_hmac` (a symmetric MAC — anyone holding the shared key
+    can forge), this is asymmetric: verification needs only the PUBLIC key, giving real
+    authority non-repudiation. ``keypair`` is an ``MLDSAKeyPair`` (public_key,
+    secret_key) from ``src/crypto/pqc_liboqs``; the secret never leaves the signer.
+    """
+    from src.crypto.pqc_liboqs import MLDSA65, MLDSAKeyPair  # lazy: keep module importable without liboqs
+
+    kp = keypair if isinstance(keypair, MLDSAKeyPair) else MLDSAKeyPair(*keypair)
+    env = _copy_envelope(envelope)
+    if int(env.authority.issued_at_ms) == 0:
+        env.authority.issued_at_ms = _now_ms()
+    if set_mmr_hook and len(env.audit.mmr_fields) == 0:
+        env.audit.mmr_fields.extend(MMR_REQUIRED_FIELDS_V1)
+
+    payload_hash = signed_payload_hash(env)
+    env.authority.signed_payload_hash = payload_hash
+    env.authority.signature = MLDSA65.from_keypair(kp).sign(payload_hash)
+
+    if set_mmr_hook:
+        env.audit.mmr_leaf_hash = mmr_leaf_hash(env, mmr_fields=tuple(env.audit.mmr_fields))
+    return env
+
+
+def verify_envelope_mldsa(
+    envelope: Any,
+    public_key_lookup: Callable[[str, str], bytes | None],
+    *,
+    now_ms: int | None = None,
+) -> tuple[bool, str]:
+    """Verify an envelope signed by :func:`sign_envelope_mldsa` using the issuer's PUBLIC key.
+
+    ``public_key_lookup(issuer, key_id)`` returns the ML-DSA-65 public key bytes (or
+    None). The secret key is never needed to verify, so a forged signature or a tampered
+    payload (which changes ``signed_payload_hash``) is rejected.
+    """
+    from src.crypto.pqc_liboqs import MLDSA65
+
+    errors = validate_envelope_schema(envelope)
+    if errors:
+        return False, "; ".join(errors)
+
+    current_ms = int(now_ms if now_ms is not None else _now_ms())
+    if current_ms < int(envelope.authority.valid_from_ms):
+        return False, "envelope not yet valid"
+    if current_ms > int(envelope.authority.valid_until_ms):
+        return False, "envelope expired"
+
+    public_key = public_key_lookup(str(envelope.authority.issuer), str(envelope.authority.key_id))
+    if public_key is None:
+        return False, "no public key available for issuer/key_id"
+
+    expected_payload_hash = signed_payload_hash(envelope)
+    if bytes(envelope.authority.signed_payload_hash) != expected_payload_hash:
+        return False, "signed_payload_hash mismatch"
+
+    try:
+        ok = MLDSA65.verify_with_public_key(
+            bytes(public_key), expected_payload_hash, bytes(envelope.authority.signature)
+        )
+    except Exception as exc:  # backend missing / malformed signature
+        return False, f"signature verification error: {exc}"
+    if not ok:
         return False, "signature mismatch"
 
     if len(envelope.audit.mmr_fields) > 0 and bytes(envelope.audit.mmr_leaf_hash):

--- a/tests/test_decision_envelope_mldsa.py
+++ b/tests/test_decision_envelope_mldsa.py
@@ -1,0 +1,90 @@
+"""Real ML-DSA-65 authority signatures for decision envelopes — green must mean working.
+
+Asserts the asymmetric properties HMAC cannot give: verification with the PUBLIC key
+only, a forged signature rejected, a tampered payload rejected, and a wrong key rejected.
+Requires a real PQC backend (liboqs); skips otherwise.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import google.protobuf
+
+    assert hasattr(google.protobuf, "__version__")
+except ImportError:
+    pytest.skip("google.protobuf not installed", allow_module_level=True)
+
+pytest.importorskip("oqs", reason="real ML-DSA-65 requires liboqs (oqs)")
+
+from src.crypto.pqc_liboqs import MLDSA65, MLDSAKeyPair
+from src.governance.decision_envelope_v1 import (
+    AUTO_ALLOW,
+    HIGH,
+    make_envelope_v1,
+    sign_envelope_mldsa,
+    verify_envelope_mldsa,
+)
+
+NOW_MS = 1_700_000_000_000
+
+
+def _mk_env():
+    return make_envelope_v1(
+        envelope_id="env-mldsa-001",
+        mission_id="mars-sol-48",
+        swarm_id="swarm-a",
+        issuer="ground-control",
+        key_id="k-mldsa-01",
+        valid_from_ms=NOW_MS - 1_000,
+        valid_until_ms=NOW_MS + 60_000,
+        agent_allowlist=["agent-1"],
+        capability_allowlist=["nav.move"],
+        target_allowlist=["site-A"],
+        mission_phase_allowlist=["SURFACE_OPS"],
+        max_risk_tier=HIGH,
+        power_min=40.0,
+        bandwidth_min=10.0,
+        thermal_max=85.0,
+        rules=[{"capability": "nav.move", "target": "site-A", "boundary": AUTO_ALLOW}],
+    )
+
+
+def _keypair():
+    dsa = MLDSA65()
+    return MLDSAKeyPair(public_key=dsa.public_key, secret_key=dsa.secret_key)
+
+
+def test_mldsa_envelope_roundtrips_with_public_key_only():
+    kp = _keypair()
+    signed = sign_envelope_mldsa(_mk_env(), kp)
+    # real ML-DSA-65 signature, not a 32-byte HMAC tag
+    assert len(bytes(signed.authority.signature)) > 1000
+    ok, reason = verify_envelope_mldsa(signed, lambda i, k: kp.public_key, now_ms=NOW_MS)
+    assert ok, reason
+
+
+def test_mldsa_envelope_rejects_forged_signature():
+    kp = _keypair()
+    signed = sign_envelope_mldsa(_mk_env(), kp)
+    signed.authority.signature = b"\x00" * len(bytes(signed.authority.signature))
+    ok, reason = verify_envelope_mldsa(signed, lambda i, k: kp.public_key, now_ms=NOW_MS)
+    assert not ok
+
+
+def test_mldsa_envelope_rejects_tampered_payload():
+    kp = _keypair()
+    signed = sign_envelope_mldsa(_mk_env(), kp)
+    # mutate a signed field after signing -> signed_payload_hash no longer matches
+    signed.identity.mission_id = "tampered-mission"
+    ok, reason = verify_envelope_mldsa(signed, lambda i, k: kp.public_key, now_ms=NOW_MS)
+    assert not ok
+
+
+def test_mldsa_envelope_rejects_wrong_public_key():
+    kp = _keypair()
+    other = _keypair()
+    signed = sign_envelope_mldsa(_mk_env(), kp)
+    ok, reason = verify_envelope_mldsa(signed, lambda i, k: other.public_key, now_ms=NOW_MS)
+    assert not ok


### PR DESCRIPTION
## What
Closes the last fake-signature on an active path (system-reality audit **blocker #3**).

`decision_envelope_v1` signed the governance **authority** with HMAC-SHA256 labelled *"dev placeholder for ML-DSA"*. HMAC is a real *symmetric* MAC — integrity only, **no non-repudiation**: anyone holding the shared key can forge an authority envelope. Governance authority needs an **asymmetric** signature.

## Now real (FIPS 204 ML-DSA-65, via liboqs)
- `pqc_liboqs.MLDSA65.verify_with_public_key(pub, msg, sig)` — **public-key-only** verification (the verifier never needs the secret); fail-closed if no real PQC backend.
- `sign_envelope_mldsa(env, keypair)` / `verify_envelope_mldsa(env, public_key_lookup)` — real ML-DSA-65 authority signatures over `signed_payload_hash`.
- HMAC path **relabelled honestly** (real symmetric MAC, not a PQC placeholder) and left **unchanged** — existing callers + its 9 tests stay green.

## Verified (definition of done: forged rejected + tamper changes result)
New `tests/test_decision_envelope_mldsa.py` (4/4):
- public-key-only roundtrip ✓ (~3.3 KB real ML-DSA sig, not a 32-byte HMAC tag)
- forged signature rejected ✓
- tampered payload rejected ✓
- wrong public key rejected ✓

Branched fresh off latest `main` (isolated from the #2301 triage). black + flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)