### PR TITLE
feat(product): package SCBE Black Box self-serve offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The installable package surface is the simplest public entry point.
 
 Neither Python nor npm package requires a server, API key, or external network call. The full pipeline runs locally.
 
+**Self-serve product:** [SCBE Black Box](https://aethermoore.com/SCBE-AETHERMOORE/black-box.html) is the buyer-ready workstation failure report: run it locally before long AI/browser/build jobs and get a plain-English report for shutdown, BSOD, disk, memory, WHEA, and storage-warning signals.
+
 **Free local use + paid hosted runs:** The packages are free under `MIT OR Apache-2.0`. If you want SCBE to run hosted routing, a governed report, or a benchmark pass:
 
 - Hosted run intake: [aethermoore.com/SCBE-AETHERMOORE/hosted-run.html](https://aethermoore.com/SCBE-AETHERMOORE/hosted-run.html)

--- a/api/polly/commerce.js
+++ b/api/polly/commerce.js
@@ -24,6 +24,28 @@ function checkoutUrlFromEnv(envName, fallback) {
 
 const PRODUCT_CATALOG = [
   {
+    sku: 'scbe-black-box',
+    name: 'SCBE Black Box',
+    priceLabel: '$19 self-serve',
+    short:
+      'Local workstation failure report for Windows shutdowns, BSOD signals, low disk, memory pressure, storage warnings, WHEA, service crashes, and long AI job failure risk.',
+    checkoutUrl: 'https://ko-fi.com/izdandavis',
+    deliveryUrl: 'https://aethermoore.com/SCBE-AETHERMOORE/black-box.html',
+    keywords: [
+      'black box',
+      'pc crash',
+      'computer crash',
+      'windows shutdown',
+      'bsod',
+      'event 41',
+      'workstation',
+      'ai workstation',
+      'why did my pc shut down',
+      'diagnose pc',
+      'failure report',
+    ],
+  },
+  {
     sku: 'scbe-service-credits',
     name: 'SCBE Service Credits',
     priceLabel: '$5+ pay-as-you-go',

--- a/docs/black-box.html
+++ b/docs/black-box.html
@@ -1,0 +1,397 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <title>SCBE Black Box | PC shutdown and AI workstation failure report</title>
+    <meta
+      name="description"
+      content="SCBE Black Box is a local self-serve report for Windows shutdowns, BSOD signals, low disk, memory pressure, WHEA, storage warnings, and long AI job failure risk."
+    />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/black-box.html" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #080b0f;
+        --panel: #111821;
+        --panel-soft: #0d1219;
+        --line: rgba(236, 185, 84, 0.24);
+        --text: #f7f1e6;
+        --muted: #aeb8c5;
+        --gold: #e2b560;
+        --green: #2ed3a3;
+        --red: #ff786f;
+        --blue: #8db7ff;
+        --max: 1120px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background:
+          linear-gradient(rgba(8, 11, 15, 0.82), rgba(8, 11, 15, 0.96)),
+          url('hero.svg') center top / cover fixed,
+          var(--bg);
+        color: var(--text);
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+        line-height: 1.55;
+      }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+      .topbar {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background: rgba(8, 11, 15, 0.9);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        backdrop-filter: blur(14px);
+      }
+      .topbar-inner,
+      .section-inner {
+        width: min(var(--max), calc(100% - 32px));
+        margin: 0 auto;
+      }
+      .topbar-inner {
+        min-height: 66px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 18px;
+      }
+      .brand {
+        color: var(--gold);
+        font-size: 13px;
+        font-weight: 900;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+      .nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 16px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .hero {
+        min-height: calc(100vh - 66px);
+        display: grid;
+        align-items: center;
+        padding: 70px 0 54px;
+      }
+      .hero-grid {
+        width: min(var(--max), calc(100% - 32px));
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.95fr);
+        gap: 28px;
+        align-items: center;
+      }
+      .eyebrow {
+        margin: 0 0 14px;
+        color: var(--gold);
+        font-size: 12px;
+        font-weight: 900;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+      }
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+      h1 {
+        max-width: 12ch;
+        margin-bottom: 20px;
+        font-size: clamp(44px, 8vw, 88px);
+        line-height: 0.94;
+        letter-spacing: 0;
+      }
+      h2 {
+        margin-bottom: 14px;
+        font-size: clamp(28px, 4vw, 46px);
+        line-height: 1.04;
+      }
+      h3 {
+        margin-bottom: 8px;
+        font-size: 19px;
+      }
+      .lead {
+        max-width: 66ch;
+        color: #d4dde4;
+        font-size: clamp(18px, 2.1vw, 22px);
+      }
+      .cta-row,
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 22px;
+      }
+      .btn {
+        display: inline-flex;
+        min-height: 48px;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        border-radius: 8px;
+        padding: 12px 18px;
+        font-weight: 900;
+      }
+      .btn-primary {
+        border-color: var(--gold);
+        background: var(--gold);
+        color: #12110d;
+      }
+      .btn-secondary {
+        background: rgba(255, 255, 255, 0.06);
+      }
+      .terminal {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: rgba(13, 18, 25, 0.94);
+        padding: 18px;
+        box-shadow: 0 24px 70px rgba(0, 0, 0, 0.32);
+      }
+      .terminal pre {
+        overflow: auto;
+        margin: 0;
+        color: #dbe8ef;
+        white-space: pre-wrap;
+        font-size: 14px;
+      }
+      .high {
+        color: var(--red);
+      }
+      .ok {
+        color: var(--green);
+      }
+      section {
+        padding: 68px 0;
+        background: rgba(8, 11, 15, 0.94);
+      }
+      section:nth-of-type(even) {
+        background: rgba(13, 18, 25, 0.96);
+      }
+      .grid-3,
+      .grid-2 {
+        display: grid;
+        gap: 16px;
+      }
+      .grid-3 {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+      .grid-2 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .card {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 22px;
+      }
+      .card p,
+      li {
+        color: var(--muted);
+      }
+      .price {
+        display: block;
+        margin: 10px 0;
+        color: var(--gold);
+        font-size: 32px;
+        font-weight: 950;
+      }
+      .steps {
+        display: grid;
+        gap: 12px;
+        margin-top: 18px;
+      }
+      .step {
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 8px;
+        background: var(--panel-soft);
+        padding: 18px;
+      }
+      code {
+        color: var(--blue);
+      }
+      @media (max-width: 860px) {
+        .hero-grid,
+        .grid-3,
+        .grid-2 {
+          grid-template-columns: 1fr;
+        }
+        .hero {
+          min-height: auto;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="index.html">AetherMoore</a>
+        <nav class="nav" aria-label="Primary navigation">
+          <a href="products.html">Products</a>
+          <a href="payments.html">Payments</a>
+          <a href="support.html">Support</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-grid">
+          <div>
+            <p class="eyebrow">Self-serve workstation black box</p>
+            <h1>Find out why the machine failed.</h1>
+            <p class="lead">
+              SCBE Black Box is a local report for Windows shutdowns, BSOD signals, low disk, memory
+              pressure, storage warnings, and long AI job failure risk. The buyer runs it. It writes
+              a plain-English report. No support call required.
+            </p>
+            <div class="cta-row">
+              <a
+                class="btn btn-primary"
+                href="https://ko-fi.com/izdandavis"
+                target="_blank"
+                rel="noopener"
+                >Buy / tip on Ko-fi</a
+              >
+              <a class="btn btn-secondary" href="payments.html#cash-app">Cash App $IzzyDDavis7</a>
+              <a class="btn btn-secondary" href="downloads/scbe-black-box-quickstart.md"
+                >Read quickstart</a
+              >
+            </div>
+          </div>
+          <div class="terminal" aria-label="Example SCBE Black Box report">
+            <pre>SCBE Black Box Report
+
+Action needed: SCBE Black Box found a likely failure or pre-failure signal.
+
+- <span class="high">[HIGH]</span> Windows recorded an unexpected shutdown
+  Why: Event 41 means Windows restarted without a clean shutdown.
+  Do:  Correlate the minutes before this event with disk, driver, WHEA,
+       BugCheck, and power events below.
+
+- <span class="ok">[MEDIUM]</span> C:\ has limited free space
+  Why: This is the common pre-failure state for long local jobs.</pre>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-inner">
+          <p class="eyebrow">What it actually does</p>
+          <h2>A local scanner that turns crash clues into next actions.</h2>
+          <div class="grid-3">
+            <article class="card">
+              <h3>Checks failure signals</h3>
+              <p>
+                Disk space, memory pressure, Event 41 unexpected shutdowns, bugcheck events, storage
+                warnings, WHEA hardware warnings, service crashes, and top memory users.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Writes buyer-visible files</h3>
+              <p>
+                The tool writes <code>latest_black_box_report.txt</code> for humans and
+                <code>latest_black_box_report.json</code> for automation.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Runs without a server</h3>
+              <p>
+                No account, no dashboard, no API key, no remote upload. It runs on the buyer's
+                machine and leaves the report on disk.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-inner">
+          <p class="eyebrow">Offer</p>
+          <h2>One product. Three clear paths.</h2>
+          <div class="grid-3">
+            <article class="card">
+              <h3>Self-serve Black Box</h3>
+              <span class="price">$19</span>
+              <p>Download ZIP, run the scanner, read the report. Best for one workstation.</p>
+            </article>
+            <article class="card">
+              <h3>Report explanation</h3>
+              <span class="price">$99</span>
+              <p>
+                Buyer sends the generated report and receives a concise explanation and next steps.
+              </p>
+            </article>
+            <article class="card">
+              <h3>AI lab reliability audit</h3>
+              <span class="price">$499+</span>
+              <p>
+                For teams running local agents, browser fleets, model jobs, or build workstations.
+              </p>
+            </article>
+          </div>
+          <div class="actions">
+            <a
+              class="btn btn-primary"
+              href="https://ko-fi.com/izdandavis"
+              target="_blank"
+              rel="noopener"
+              >Buy on Ko-fi</a
+            >
+            <a
+              class="btn btn-secondary"
+              href="mailto:aethermoregames@pm.me?subject=SCBE%20Black%20Box%20purchase"
+              >Request card link / invoice</a
+            >
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-inner">
+          <p class="eyebrow">Use</p>
+          <h2>Buyer path after payment.</h2>
+          <div class="steps">
+            <div class="step">
+              <strong>1. Download the ZIP.</strong>
+              <p>
+                The bundle contains the scanner, quickstart, Windows script, Unix script, manifest,
+                and sample output.
+              </p>
+            </div>
+            <div class="step">
+              <strong>2. Run one command.</strong>
+              <p>
+                Windows: <code>powershell -ExecutionPolicy Bypass -File .\run-windows.ps1</code>
+              </p>
+            </div>
+            <div class="step">
+              <strong>3. Read the report.</strong>
+              <p>
+                Open <code>report/latest_black_box_report.txt</code>. If it flags high severity, act
+                before long jobs.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/downloads/scbe-black-box-quickstart.md
+++ b/docs/downloads/scbe-black-box-quickstart.md
@@ -7,6 +7,12 @@ It is self-serve. No installation service is required.
 
 ## Run
 
+From the downloadable Black Box bundle:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\run-windows.ps1
+```
+
 From the repository or Workcell bundle:
 
 ```powershell

--- a/docs/offers.json
+++ b/docs/offers.json
@@ -50,6 +50,28 @@
       "stripe_payment_link_id": "plink_1Tj3CyJTF2SuUODIq1uPTEqY"
     },
     {
+      "id": "black_box_self_serve",
+      "name": "SCBE Black Box",
+      "price_label": "$19 self-serve",
+      "type": "digital_download",
+      "checkout_url": "https://ko-fi.com/izdandavis",
+      "alternate_checkout": {
+        "cash_app": "$IzzyDDavis7",
+        "cash_app_qr_url": "https://aethermoore.com/SCBE-AETHERMOORE/static/cash-app-payment.png",
+        "manual_invoice": "mailto:aethermoregames@pm.me?subject=SCBE%20Black%20Box%20purchase"
+      },
+      "proof_url": "https://aethermoore.com/SCBE-AETHERMOORE/black-box.html",
+      "quickstart_url": "https://aethermoore.com/SCBE-AETHERMOORE/downloads/scbe-black-box-quickstart.md",
+      "status": "live",
+      "scope": [
+        "self-serve local workstation failure report",
+        "Windows shutdown, BSOD, disk, memory, storage, WHEA, service-crash, and top-process signals",
+        "plain-English text report plus JSON report",
+        "no installation service, no remote upload, no API key"
+      ],
+      "checkout_note": "Ko-fi and Cash App are active low-friction purchase paths. Use payment note: SCBE Black Box."
+    },
+    {
       "id": "service_credits",
       "name": "SCBE Service Credits",
       "price_label": "$5+ pay-as-you-go",

--- a/docs/payments.html
+++ b/docs/payments.html
@@ -31,7 +31,7 @@
           system-ui,
           -apple-system,
           BlinkMacSystemFont,
-          "Segoe UI",
+          'Segoe UI',
           sans-serif;
         color: var(--ink);
         background:
@@ -206,7 +206,11 @@
             monthly.
           </p>
           <div class="hero-actions">
-            <a class="btn btn-primary" href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
+            <a
+              class="btn btn-primary"
+              href="https://ko-fi.com/izdandavis"
+              target="_blank"
+              rel="noopener"
               >Support on Ko-fi</a
             >
             <a class="btn secondary" href="#cash-app">Cash App $IzzyDDavis7</a>
@@ -271,6 +275,18 @@
             >
           </article>
           <article class="card">
+            <h3>SCBE Black Box</h3>
+            <div class="price">$19 self-serve</div>
+            <p>
+              Local shutdown, BSOD, disk, memory, WHEA, and storage-warning report for AI
+              workstations.
+            </p>
+            <a class="btn" href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
+              >Buy Black Box</a
+            >
+            <a class="btn secondary" href="black-box.html">See product</a>
+          </article>
+          <article class="card">
             <h3>Tip Jar</h3>
             <div class="price">$5 one time</div>
             <a
@@ -317,7 +333,9 @@
           <article class="card">
             <h3>Behind-The-Scenes Process Pack</h3>
             <div class="price">$7 one time</div>
-            <p>Redirects after Stripe checkout to a protected ZIP download for the process files.</p>
+            <p>
+              Redirects after Stripe checkout to a protected ZIP download for the process files.
+            </p>
             <a
               class="btn"
               href="https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n"
@@ -348,8 +366,9 @@
       <section id="includes" class="section panel" aria-label="What the payment center handles">
         <h2>What this payment center handles</h2>
         <p>
-          The payment route is not the product by itself. It connects the buyer to the right delivery
-          lane, support record, and manual review path before any sensitive files are requested.
+          The payment route is not the product by itself. It connects the buyer to the right
+          delivery lane, support record, and manual review path before any sensitive files are
+          requested.
         </p>
         <p>
           Service purchases can route into a decision record, threshold worksheet, pilot checklist,
@@ -359,8 +378,8 @@
           <article class="card">
             <h3>Receipt to delivery</h3>
             <p>
-              Payment note, receipt, and buyer email become the delivery record so the right offer is
-              matched without a long intake form.
+              Payment note, receipt, and buyer email become the delivery record so the right offer
+              is matched without a long intake form.
             </p>
           </article>
           <article class="card">
@@ -486,8 +505,8 @@
         <h2>After payment</h2>
         <p>
           Keep the receipt. For manual Ko-fi or Cash App service payments, include the offer name
-          and buyer email in the note. Do not send secrets, regulated customer data, private keys, or
-          protected files until handling rules are confirmed.
+          and buyer email in the note. Do not send secrets, regulated customer data, private keys,
+          or protected files until handling rules are confirmed.
         </p>
         <div class="actions">
           <a class="btn secondary" href="product-manual/delivery-and-access.html"
@@ -506,7 +525,11 @@
           work, buy the Snapshot Starter or request an invoice with the offer name and buyer email.
         </p>
         <div class="actions">
-          <a class="btn btn-primary" href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener"
+          <a
+            class="btn btn-primary"
+            href="https://ko-fi.com/izdandavis"
+            target="_blank"
+            rel="noopener"
             >Support on Ko-fi</a
           >
           <a
@@ -516,7 +539,9 @@
             rel="noopener"
             >Buy Snapshot Starter</a
           >
-          <a class="btn secondary" href="mailto:aethermoregames@pm.me?subject=AetherMoore%20payment%20question"
+          <a
+            class="btn secondary"
+            href="mailto:aethermoregames@pm.me?subject=AetherMoore%20payment%20question"
             >Ask a payment question</a
           >
         </div>

--- a/docs/products.html
+++ b/docs/products.html
@@ -1062,6 +1062,35 @@
           </article>
 
           <article class="product featured">
+            <div class="badge">Self-serve product</div>
+            <div class="pname">SCBE Black Box</div>
+            <div class="pprice">$19 self-serve</div>
+            <p class="ppitch">
+              A local black-box report for Windows shutdowns, BSOD signals, low disk, memory
+              pressure, storage warnings, WHEA, and long AI job failure risk.
+            </p>
+            <p class="pwho">
+              <strong>Who it's for:</strong> anyone running local AI, browser automation, builds,
+              indexing, or model jobs who wants to know why the machine failed before asking for
+              help.
+            </p>
+            <div class="pgive">
+              <strong>What you get:</strong>
+              <ul>
+                <li>Downloadable ZIP with the scanner and run scripts</li>
+                <li>Plain-English text report</li>
+                <li>JSON report for automation</li>
+                <li>No account, no install service, no remote upload</li>
+              </ul>
+            </div>
+            <div class="pactions">
+              <a class="primary" href="black-box.html">Open Black Box</a>
+              <a href="https://ko-fi.com/izdandavis" target="_blank" rel="noopener">Buy on Ko-fi</a>
+              <a href="payments.html#cash-app">Cash App</a>
+            </div>
+          </article>
+
+          <article class="product featured">
             <div class="badge">Best first service</div>
             <div class="pname">AI Agent Workflow Snapshot</div>
             <div class="pprice">$99 starter</div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -73,6 +73,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/black-box.html</loc>
+    <lastmod>2026-06-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.95</priority>
+  </url>
+  <url>
     <loc>https://aethermoore.com/SCBE-AETHERMOORE/ai-agent-governance-toolkit.html</loc>
     <lastmod>2026-06-08</lastmod>
     <changefreq>weekly</changefreq>

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "writing:package": "python scripts/package_products.py --product writing",
     "writing:package:all": "python scripts/package_products.py --product all",
     "release:workcell": "python scripts/system/build_workcell_download.py",
+    "release:blackbox": "python scripts/system/build_black_box_download.py",
     "blackbox:report": "python scripts/system/scbe_black_box.py --no-fail-on-high",
     "video:verify": "node scripts/video/verify.js",
     "video:quality-gate": "node scripts/video/quality_gate.js",

--- a/scripts/system/build_black_box_download.py
+++ b/scripts/system/build_black_box_download.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCANNER = REPO_ROOT / "scripts" / "system" / "scbe_black_box.py"
+QUICKSTART = REPO_ROOT / "docs" / "downloads" / "scbe-black-box-quickstart.md"
+DEFAULT_OUT = REPO_ROOT / "artifacts" / "black_box_download"
+VERSION = "1.0.0"
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _run(args: list[str], *, cwd: Path, timeout: int = 120) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=str(cwd),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _command_block(command: list[str], result: subprocess.CompletedProcess[str]) -> str:
+    rendered = " ".join(command)
+    return (
+        f"### `{rendered}`\n\n"
+        f"Exit code: `{result.returncode}`\n\n"
+        "stdout:\n\n"
+        "```text\n"
+        f"{result.stdout.strip()}\n"
+        "```\n\n"
+        "stderr:\n\n"
+        "```text\n"
+        f"{result.stderr.strip()}\n"
+        "```\n"
+    )
+
+
+def _verify_bundle(bundle_dir: Path) -> dict[str, Any]:
+    transcript_parts = [
+        "# SCBE Black Box Verification Transcript",
+        "",
+        f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "This runs the exact bundled scanner and verifies that buyer-visible reports are written.",
+        "",
+    ]
+    commands: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="scbe-black-box-verify-") as tmp:
+        verify_dir = Path(tmp) / "report"
+        command = [
+            sys.executable,
+            str(bundle_dir / "scbe_black_box.py"),
+            "--no-fail-on-high",
+            "--out-dir",
+            str(verify_dir),
+        ]
+        result = _run(command, cwd=bundle_dir, timeout=120)
+        transcript_parts.append(
+            _command_block(["python", "scbe_black_box.py", "--no-fail-on-high", "--out-dir", "<temp>"], result)
+        )
+        commands.append({"name": "run scanner", "exit_code": result.returncode})
+        json_path = verify_dir / "latest_black_box_report.json"
+        text_path = verify_dir / "latest_black_box_report.txt"
+        schema = ""
+        finding_count = 0
+        if json_path.exists():
+            payload = json.loads(json_path.read_text(encoding="utf-8"))
+            schema = str(payload.get("schema", ""))
+            finding_count = len(payload.get("findings", []))
+        output_ok = (
+            json_path.exists() and text_path.exists() and schema == "scbe_black_box_report_v1" and finding_count > 0
+        )
+        commands.append({"name": "report files + schema", "exit_code": 0 if output_ok else 1})
+    ok = all(item["exit_code"] == 0 for item in commands)
+    _write_text(bundle_dir / "verification_transcript.md", "\n".join(transcript_parts))
+    return {"ok": ok, "commands": commands}
+
+
+def build_black_box_download(out_root: Path = DEFAULT_OUT, verify: bool = True) -> dict[str, Any]:
+    bundle_name = f"SCBE-Black-Box-v{VERSION}"
+    bundle_dir = out_root / bundle_name
+    if bundle_dir.exists():
+        shutil.rmtree(bundle_dir)
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy2(SCANNER, bundle_dir / "scbe_black_box.py")
+    shutil.copy2(QUICKSTART, bundle_dir / "QUICKSTART.md")
+
+    _write_text(
+        bundle_dir / "run-windows.ps1",
+        """$ErrorActionPreference = "Stop"
+$Out = Join-Path $PSScriptRoot "report"
+py -3 (Join-Path $PSScriptRoot "scbe_black_box.py") --no-fail-on-high --out-dir $Out
+Write-Host ""
+Write-Host "Report written to: $Out"
+Write-Host "Open report\\latest_black_box_report.txt"
+""",
+    )
+    _write_text(
+        bundle_dir / "run-unix.sh",
+        """#!/usr/bin/env sh
+set -eu
+OUT="$(dirname "$0")/report"
+python3 "$(dirname "$0")/scbe_black_box.py" --no-fail-on-high --out-dir "$OUT"
+printf '\\nReport written to: %s\\nOpen report/latest_black_box_report.txt\\n' "$OUT"
+""",
+    )
+    _write_text(
+        bundle_dir / "README.txt",
+        """SCBE Black Box
+
+Run this before long AI, browser automation, model, build, or indexing jobs.
+It writes a plain-English report explaining local workstation failure signals.
+
+Windows:
+  powershell -ExecutionPolicy Bypass -File .\\run-windows.ps1
+
+macOS/Linux:
+  sh ./run-unix.sh
+
+Output:
+  report/latest_black_box_report.txt
+  report/latest_black_box_report.json
+
+No server is required. No API key is required. No remote upload is performed.
+""",
+    )
+
+    sample_dir = bundle_dir / "sample-output"
+    sample = _run(
+        [
+            sys.executable,
+            str(bundle_dir / "scbe_black_box.py"),
+            "--no-fail-on-high",
+            "--out-dir",
+            str(sample_dir),
+        ],
+        cwd=bundle_dir,
+        timeout=120,
+    )
+    if sample.returncode != 0:
+        raise RuntimeError(f"sample report generation failed:\nSTDOUT:\n{sample.stdout}\nSTDERR:\n{sample.stderr}")
+
+    manifest: dict[str, Any] = {
+        "schema": "scbe_black_box_download_v1",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "bundle_name": bundle_name,
+        "version": VERSION,
+        "product": {
+            "name": "SCBE Black Box",
+            "one_liner": "A local black-box report for Windows workstation shutdown, crash, and pre-failure signals.",
+            "buyer_result": "report/latest_black_box_report.txt",
+        },
+        "files": {},
+        "verification": {"ok": None, "commands": []},
+    }
+    for path in sorted(bundle_dir.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(bundle_dir).as_posix()
+            manifest["files"][rel] = {"sha256": _sha256(path), "bytes": path.stat().st_size}
+
+    if verify:
+        manifest["verification"] = _verify_bundle(bundle_dir)
+        transcript = bundle_dir / "verification_transcript.md"
+        manifest["files"][transcript.relative_to(bundle_dir).as_posix()] = {
+            "sha256": _sha256(transcript),
+            "bytes": transcript.stat().st_size,
+        }
+
+    _write_text(bundle_dir / "manifest.json", json.dumps(manifest, indent=2) + "\n")
+    archive_base = out_root / bundle_name
+    archive_path = Path(shutil.make_archive(str(archive_base), "zip", root_dir=bundle_dir))
+    manifest["archive"] = {
+        "file": archive_path.name,
+        "path": str(archive_path),
+        "sha256": _sha256(archive_path),
+        "bytes": archive_path.stat().st_size,
+    }
+    _write_text(bundle_dir / "manifest.json", json.dumps(manifest, indent=2) + "\n")
+    _write_text(out_root / f"{bundle_name}.manifest.json", json.dumps(manifest, indent=2) + "\n")
+    return manifest
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build the downloadable SCBE Black Box product bundle.")
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT), help="Output directory for bundle artifacts.")
+    parser.add_argument("--skip-verify", action="store_true", help="Build the ZIP without temp-run verification.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        manifest = build_black_box_download(Path(args.out_dir), verify=not args.skip_verify)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(manifest, indent=2))
+    return 0 if manifest["verification"]["ok"] is not False else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/polly_commerce.py
+++ b/src/api/polly_commerce.py
@@ -60,6 +60,31 @@ class Product:
 
 PRODUCT_CATALOG: Tuple[Product, ...] = (
     Product(
+        sku="scbe-black-box",
+        name="SCBE Black Box",
+        price_label="$19 self-serve",
+        short=(
+            "A local workstation failure report for Windows shutdowns, BSOD signals, "
+            "low disk, memory pressure, storage warnings, WHEA, service crashes, and "
+            "long AI job failure risk. Runs locally; writes text and JSON reports."
+        ),
+        checkout_url="https://ko-fi.com/izdandavis",
+        delivery_url="https://aethermoore.com/SCBE-AETHERMOORE/black-box.html",
+        keywords=(
+            "black box",
+            "pc crash",
+            "computer crash",
+            "windows shutdown",
+            "bsod",
+            "event 41",
+            "workstation",
+            "ai workstation",
+            "why did my pc shut down",
+            "diagnose pc",
+            "failure report",
+        ),
+    ),
+    Product(
         sku="scbe-service-credits",
         name="SCBE Service Credits",
         price_label="$5+ pay-as-you-go",

--- a/tests/api/polly_commerce_js.test.ts
+++ b/tests/api/polly_commerce_js.test.ts
@@ -202,7 +202,7 @@ describe('polly lead handler — anti-abuse', () => {
 
 describe('polly commerce intent classification', () => {
   it('catalog has live products with valid checkout urls', () => {
-    expect(commerce.PRODUCT_CATALOG).toHaveLength(10);
+    expect(commerce.PRODUCT_CATALOG).toHaveLength(11);
     for (const product of commerce.PRODUCT_CATALOG) {
       expect(product.checkoutUrl).toMatch(/^(https:\/\/(buy\.stripe\.com|ko-fi\.com)|mailto:)/);
       expect(product.keywords.length).toBeGreaterThan(0);

--- a/tests/api/test_polly_commerce.py
+++ b/tests/api/test_polly_commerce.py
@@ -57,6 +57,7 @@ def test_catalog_is_nonempty_and_has_real_stripe_links() -> None:
         ("Add to cart please", "buy"),
         ("Sign me up for the toolkit", "buy"),
         ("I want to buy service credits", "buy"),
+        ("I want to buy the black box for my crashed PC", "buy"),
         ("hosted routing credits", "buy"),
         ("toolkit", "buy"),
         ("training vault", "buy"),
@@ -97,6 +98,13 @@ def test_classify_intent_buy_resolves_service_credits() -> None:
     assert intent.name == "buy"
     assert intent.product is not None
     assert intent.product.sku == "scbe-service-credits"
+
+
+def test_classify_intent_buy_resolves_black_box() -> None:
+    intent = classify_intent("My Windows PC shut down during an AI job. Buy the black box.")
+    assert intent.name == "buy"
+    assert intent.product is not None
+    assert intent.product.sku == "scbe-black-box"
 
 
 def test_classify_intent_buy_without_product_keyword() -> None:

--- a/tests/system/test_build_black_box_download.py
+++ b/tests/system/test_build_black_box_download.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+import zipfile
+
+from scripts.system.build_black_box_download import build_black_box_download
+
+
+def test_build_black_box_download_creates_verified_zip(tmp_path):
+    manifest = build_black_box_download(tmp_path)
+
+    assert manifest["schema"] == "scbe_black_box_download_v1"
+    assert manifest["verification"]["ok"] is True
+    assert manifest["archive"]["bytes"] > 0
+
+    archive_path = tmp_path / manifest["archive"]["file"]
+    assert archive_path.exists()
+
+    bundle_dir = tmp_path / manifest["bundle_name"]
+    report = json.loads((bundle_dir / "sample-output" / "latest_black_box_report.json").read_text(encoding="utf-8"))
+    assert report["schema"] == "scbe_black_box_report_v1"
+    assert report["findings"]
+    assert (bundle_dir / "sample-output" / "latest_black_box_report.txt").exists()
+
+    with zipfile.ZipFile(archive_path) as zf:
+        names = set(zf.namelist())
+    assert "scbe_black_box.py" in names
+    assert "run-windows.ps1" in names
+    assert "run-unix.sh" in names
+    assert "QUICKSTART.md" in names
+    assert "manifest.json" in names


### PR DESCRIPTION
## What\n\nTurns SCBE Black Box into a buyer-ready self-serve product instead of only a script.\n\n- Adds a verified downloadable bundle builder: \
pm run release:blackbox\\n- Adds \docs/black-box.html\ landing page\n- Wires Black Box into offers.json, payments, products, sitemap, README\n- Adds Python + JS Polly commerce catalog entries so buyer intent routes to the product\n- Adds regression tests for bundle generation and commerce routing\n\n## Verified\n\n- \
pm run release:blackbox\\n- \python -m pytest tests\\system\\test_build_black_box_download.py tests\\system\\test_scbe_black_box.py tests\\api\\test_polly_commerce.py -q\\n- \
pm test -- tests/api/polly_commerce_js.test.ts\\n- Browser check with Edge headless: desktop + mobile \lack-box.html\ returned 200, correct title/H1, Ko-fi buy link present, no horizontal overflow, no console errors.\n\n## Artifact\n\nBuilt locally: \rtifacts/black_box_download/SCBE-Black-Box-v1.0.0.zip\\n\nThe bundle contains the scanner, quickstart, Windows/Unix run scripts, sample output, manifest, and verification transcript.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced SCBE Black Box, a $19 self-serve diagnostic tool available for download and local offline execution.

* **Documentation**
  * Added product landing page with feature overview, pricing, and purchasing options (Ko-fi and Cash App).
  * Included quickstart guide with step-by-step local setup and execution instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->