### PR TITLE
refactor(tests): tranche 2 — trim trivia + recover 21 dead adversarial tests

### DIFF
--- a/tests/adversarial/test_core_math_adversarial.py
+++ b/tests/adversarial/test_core_math_adversarial.py
@@ -82,27 +82,61 @@ def gate_decision(ds: float, tau_allow: float = 0.72, tau_collapse: float = 0.31
 # ADVERSARIAL TEST BATTERY
 # =============================================================================
 @dataclass
-class TestResult:
+class Result:
     name: str
     passed: bool
     detail: str
 
 
-results: List[TestResult] = []
+results: List[Result] = []
+
+
+# Probes that document a KNOWN weakness in the reconstructed reference math
+# (NaN/inf propagation, near-boundary DS still "high", coarse-but-feasible
+# threshold gaming, and the stale R=0.41->0.89 narrative). For these the check
+# is *expected* to return passed=False -- that is the finding, not a regression.
+# Pytest still executes every adversarial input through the real
+# tfdd/davis_score/gate_decision logic; we just assert the documented verdict so
+# the recorded weaknesses do not turn the suite red.
+KNOWN_FINDINGS = {
+    "TFDD: NaN injection",
+    "TFDD: Negative infinity valence",
+    "DS: R = 0.41 (from benchmark narrative)",
+    "DS: Floating point collapse zone (R near 0.99)",
+    "DS: Adversarial radius to land exactly at tau_collapse boundary",
+}
 
 
 def test(name: str):
-    """Decorator to register adversarial tests."""
+    """Decorator that registers an adversarial check AND exposes it to pytest.
+
+    Each decorated check returns ``(passed, detail)``. We wrap it so that:
+      * ``main()`` can still run the whole battery and collect a report, and
+      * pytest collects a real, asserting test (named ``test_*``) for it, so a
+        regression in an attack surface fails the suite instead of being
+        silently logged. Probes listed in ``KNOWN_FINDINGS`` are expected to
+        report a weakness, so we assert their documented verdict.
+    """
 
     def decorator(func):
-        def wrapper():
+        def runner():
             try:
                 passed, detail = func()
-                results.append(TestResult(name, passed, detail))
-            except Exception as e:
-                results.append(TestResult(name, False, f"EXCEPTION: {type(e).__name__}: {e}"))
+                results.append(Result(name, passed, detail))
+            except Exception as e:  # noqa: BLE001 - record any failure as a failed attack
+                results.append(Result(name, False, f"EXCEPTION: {type(e).__name__}: {e}"))
 
-        return wrapper
+        # Expose a real pytest test that runs the check through the live math.
+        def pytest_case():
+            passed, detail = func()
+            expected = name not in KNOWN_FINDINGS
+            assert passed is expected, f"{name}: verdict flipped (passed={passed}) -- {detail}"
+
+        pytest_case.__name__ = f"test_{func.__name__}"
+        pytest_case.__doc__ = func.__doc__ or name
+        globals()[pytest_case.__name__] = pytest_case
+
+        return runner
 
     return decorator
 
@@ -387,23 +421,6 @@ def ds_attenuate_width():
     return True, detail
 
 
-@test("DS: d=21 vs d=6 sensitivity comparison")
-def ds_dimension_sensitivity():
-    """Does d=21 make DS too aggressive? Compare with d=6."""
-    R = 0.5
-    ds_21 = davis_score(R, d=21)
-    ds_6 = 1.0 - R ** (6 * 6)  # d=6 -> d^2=36
-    detail = (
-        f"At R=0.5: DS(d=21)={ds_21:.10f}, DS(d=6)={ds_6:.10f}. "
-        f"d=21 exponent is 441, d=6 exponent is 36. "
-        f"0.5^441={0.5**441:.2e}, 0.5^36={0.5**36:.2e}"
-    )
-    # For d=21, even R=0.5 gives DS very close to 1 because 0.5^441 ~ 0
-    if ds_21 > 0.9999 and ds_6 > 0.9999:
-        return True, f"Both near 1.0 at R=0.5. {detail}"
-    return True, detail
-
-
 @test("DS: Where does the cliff happen for d=21?")
 def ds_cliff_location():
     """Find the R value where DS drops from 0.99 to 0.01."""
@@ -446,24 +463,6 @@ def tfdd_accumulation():
     return True, detail
 
 
-@test("GovernanceCoin: Zero-valence farming")
-def governance_zero_farming():
-    """
-    If an agent stays at exactly E=0 (neutral), does it still accumulate coin?
-    A zero-contribution agent shouldn't earn governance weight.
-    """
-    # GovernanceCoin ~ integral of 1/(1+L) over time
-    # At E=0, L = TFDD(0) * base_metric
-    # The question is whether neutral agents accumulate value
-    tfdd_neutral = tfdd(0.0)
-    # Neutral is still > 1.0 (it's 1 + beta = 1.9923)
-    # So the cost is non-trivial even at neutral
-    detail = f"TFDD(0)={tfdd_neutral:.4f}. Neutral agent faces cost multiplier of {tfdd_neutral:.4f}x"
-    # This means V = 1/(1+L) is reduced even for neutral agents
-    # Not a failure per se, but worth noting
-    return True, detail
-
-
 # =============================================================================
 # RUN ALL TESTS
 # =============================================================================
@@ -497,10 +496,8 @@ def main():
     ds_float_collapse()
     ds_threshold_gaming()
     ds_attenuate_width()
-    ds_dimension_sensitivity()
     ds_cliff_location()
     combined_masking()
-    governance_zero_farming()
 
     # Report
     print()

--- a/tests/governance/test_tree_of_escalation.py
+++ b/tests/governance/test_tree_of_escalation.py
@@ -61,8 +61,15 @@ from src.governance.tree_of_escalation import (  # noqa: E402
 # --------------------------------------------------------------------------- #
 
 
-def test_lane_enum_has_six_tongues_plus_custom():
-    expected = {
+def test_enums_and_constants_structural():
+    """Consolidated pure enum/constant/literal invariants.
+
+    Merges twelve former one-assertion structural tests that never run
+    input through any logic. Each block below is the exact assertion from
+    the original standalone test (see git history for names).
+    """
+    # Lane enum — six tongues plus CUSTOM
+    assert {lane.value for lane in Lane} == {
         "koraelin",
         "avali",
         "runethic",
@@ -71,54 +78,23 @@ def test_lane_enum_has_six_tongues_plus_custom():
         "draumric",
         "custom",
     }
-    assert {lane.value for lane in Lane} == expected
-
-
-def test_default_ladder_excludes_custom():
+    # DEFAULT_LADDER excludes CUSTOM and has six lanes
     assert Lane.CUSTOM not in DEFAULT_LADDER
     assert len(DEFAULT_LADDER) == 6
-
-
-def test_default_ladder_in_phi_weight_ascending_order():
+    # LANE_PHI_WEIGHT ascends along the ladder
     weights = [LANE_PHI_WEIGHT[lane] for lane in DEFAULT_LADDER]
     assert weights == sorted(weights)
-
-
-def test_lane_tier_assignment_t1_to_t6():
-    tiers = [LANE_TIER[lane] for lane in DEFAULT_LADDER]
-    assert tiers == [1, 2, 3, 4, 5, 6]
-
-
-def test_custom_lane_intentionally_omitted_from_weight_and_tier():
+    # LANE_TIER assigns T1..T6 in ladder order
+    assert [LANE_TIER[lane] for lane in DEFAULT_LADDER] == [1, 2, 3, 4, 5, 6]
+    # CUSTOM intentionally absent from weight + tier maps
     assert Lane.CUSTOM not in LANE_PHI_WEIGHT
     assert Lane.CUSTOM not in LANE_TIER
-
-
-# --------------------------------------------------------------------------- #
-#  Band — three concurrent substrates
-# --------------------------------------------------------------------------- #
-
-
-def test_band_enum_has_three_substrates():
+    # Band — three concurrent substrates
     assert {b.value for b in Band} == {"infra", "audible", "ultra"}
-
-
-# --------------------------------------------------------------------------- #
-#  Posture — humble vs rigid
-# --------------------------------------------------------------------------- #
-
-
-def test_posture_enum_has_humble_and_rigid():
+    # Posture — humble vs rigid
     assert {p.value for p in Posture} == {"humble", "rigid"}
-
-
-# --------------------------------------------------------------------------- #
-#  NodeKind covers all categories from the spec
-# --------------------------------------------------------------------------- #
-
-
-def test_node_kind_covers_all_spec_categories():
-    expected = {
+    # NodeKind covers all spec categories
+    assert {k.value for k in NodeKind} == {
         "op",
         "sandbox_provisional",
         "sandbox_inspection",
@@ -126,7 +102,28 @@ def test_node_kind_covers_all_spec_categories():
         "null_bridge_void",
         "provisional_mint",
     }
-    assert {k.value for k in NodeKind} == expected
+    # Termination enum has four states
+    assert {t.value for t in Termination} == {
+        "incomplete",
+        "abridged",
+        "provisional",
+        "refused",
+    }
+    # LANE_TO_TRI_BUNDLE_CODE covers all six tongues
+    assert LANE_TO_TRI_BUNDLE_CODE == {
+        Lane.KORAELIN: "ko",
+        Lane.AVALI: "av",
+        Lane.RUNETHIC: "ru",
+        Lane.CASSISIVADAN: "ca",
+        Lane.UMBROTH: "um",
+        Lane.DRAUMRIC: "dr",
+    }
+    # BAND_FREQUENCY_MULTIPLIER tri-octave signature
+    assert BAND_FREQUENCY_MULTIPLIER[Band.INFRA] == 0.25
+    assert BAND_FREQUENCY_MULTIPLIER[Band.AUDIBLE] == 1.0
+    assert BAND_FREQUENCY_MULTIPLIER[Band.ULTRA] == 4.0
+    # SYSTEM_FUNDAMENTAL is A4
+    assert SYSTEM_FUNDAMENTAL_HZ == 440.0
 
 
 # --------------------------------------------------------------------------- #
@@ -764,15 +761,7 @@ def _all_perturbed_matrix() -> BridgeMatrix:
 
 
 # --- Termination enum ----------------------------------------------------- #
-
-
-def test_termination_enum_has_four_states():
-    assert {t.value for t in Termination} == {
-        "incomplete",
-        "abridged",
-        "provisional",
-        "refused",
-    }
+# (pure-enum membership check folded into test_enums_and_constants_structural)
 
 
 def test_tree_default_termination_is_incomplete():
@@ -976,29 +965,8 @@ def test_walker_converged_does_not_touch_registry():
 
 
 # --- Constants --------------------------------------------------------------#
-
-
-def test_lane_to_tri_bundle_code_covers_all_six_tongues():
-    expected = {
-        Lane.KORAELIN: "ko",
-        Lane.AVALI: "av",
-        Lane.RUNETHIC: "ru",
-        Lane.CASSISIVADAN: "ca",
-        Lane.UMBROTH: "um",
-        Lane.DRAUMRIC: "dr",
-    }
-    assert LANE_TO_TRI_BUNDLE_CODE == expected
-
-
-def test_band_frequency_multiplier_tri_octave_signature():
-    # INFRA = -2 octaves, AUDIBLE = fundamental, ULTRA = +2 octaves
-    assert BAND_FREQUENCY_MULTIPLIER[Band.INFRA] == 0.25
-    assert BAND_FREQUENCY_MULTIPLIER[Band.AUDIBLE] == 1.0
-    assert BAND_FREQUENCY_MULTIPLIER[Band.ULTRA] == 4.0
-
-
-def test_system_fundamental_is_a4():
-    assert SYSTEM_FUNDAMENTAL_HZ == 440.0
+# (LANE_TO_TRI_BUNDLE_CODE, BAND_FREQUENCY_MULTIPLIER, and SYSTEM_FUNDAMENTAL_HZ
+#  literal checks folded into test_enums_and_constants_structural)
 
 
 # --- AudioEvent ------------------------------------------------------------- #

--- a/tests/industry_standard/test_nist_pqc_compliance.py
+++ b/tests/industry_standard/test_nist_pqc_compliance.py
@@ -331,33 +331,26 @@ class TestQuantumSecurityLevel:
 
     @pytest.mark.xfail(reason="Requires liboqs for full NIST compliance - using fallback implementation")
     @pytest.mark.skipif(not PQC_AVAILABLE, reason="PQC module not available")
-    def test_mlkem768_nist_level_3(self):
+    @pytest.mark.parametrize(
+        ("algorithm", "accessor"),
+        [
+            ("ML-KEM-768", "get_mlkem768_security_level"),
+            ("ML-DSA-65", "get_mldsa65_security_level"),
+        ],
+    )
+    def test_nist_level_3(self, algorithm, accessor):
         """
-        ML-KEM-768 MUST provide NIST Security Level 3.
+        ML-KEM-768 and ML-DSA-65 MUST each provide NIST Security Level 3.
 
-        This means:
+        For ML-KEM-768 this means:
         - Quantum security ≥ 128 bits
         - Equivalent to breaking AES-192
 
-        This test WILL FAIL if security level is not documented or incorrect.
+        This test WILL FAIL if the security level is not documented or incorrect.
         """
-        if hasattr(pqc_core, "get_mlkem768_security_level"):
-            level = pqc_core.get_mlkem768_security_level()
-            assert level >= 3, f"ML-KEM-768 must provide NIST Level 3, got Level {level}"
-        else:
-            pytest.fail("Security level not documented - cannot verify compliance")
-
-    @pytest.mark.xfail(reason="Requires liboqs for full NIST compliance - using fallback implementation")
-    @pytest.mark.skipif(not PQC_AVAILABLE, reason="PQC module not available")
-    def test_mldsa65_nist_level_3(self):
-        """
-        ML-DSA-65 MUST provide NIST Security Level 3.
-
-        This test WILL FAIL if security level is not documented or incorrect.
-        """
-        if hasattr(pqc_core, "get_mldsa65_security_level"):
-            level = pqc_core.get_mldsa65_security_level()
-            assert level >= 3, f"ML-DSA-65 must provide NIST Level 3, got Level {level}"
+        if hasattr(pqc_core, accessor):
+            level = getattr(pqc_core, accessor)()
+            assert level >= 3, f"{algorithm} must provide NIST Level 3, got Level {level}"
         else:
             pytest.fail("Security level not documented - cannot verify compliance")
 


### PR DESCRIPTION
The delete/dedupe lever under a strict "provably zero-signal or cited-duplicate" bar. **Honest result: 7 of 10 targets came back `skipped-unsafe`** — the supposed trivia is real coverage (crypto signatures, softmax confidence, jsonschema validators, router decisions). The suite is denser than the bucketing estimated; that's a good sign, and it means tranche 1's parametrize was the right primary lever.

## 3 real, verified changes (124 passed / 4 skipped / 10 xfailed together)
- **`test_core_math_adversarial.py` — recovered 21 dead tests.** The file collected **0 tests**: a `TestResult` dataclass blocked pytest collection and the real probes weren't `test_*`. Renamed `TestResult→Result`, reworked the `@test` decorator to inject a real asserting `test_<name>` per probe (asserts each verdict vs `KNOWN_FINDINGS` = 16 resistance + 5 documented weaknesses; a flip *either* direction fails). **0 → 21 executing tests.** Removed 2 always-True probes.
- **`test_tree_of_escalation.py`** — folded 12 pure enum/constant/literal asserts into one structural test (**113→102 collected, −32 LOC**). Every `walk()`/escalation/gate/decision behavior test kept.
- **`test_nist_pqc_compliance.py`** — deduped skipif boilerplate (−7 LOC); all xfail TODO markers kept.

**Net −42 LOC; collected +10** (the 21-test recovery outweighs the 11 trivia folded). Money/claim/governance-behavior guards untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Refactored adversarial test suite with enhanced result tracking and improved test organization.
  * Consolidated multiple structural invariant tests into a single comprehensive test for better maintainability.
  * Parametrized NIST PQC compliance tests to streamline test coverage and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->