### PR TITLE
ci(blob-size): stop the oversized-blob gate from false-failing on force-updated main

### DIFF
--- a/.github/workflows/blob-size-policy.yml
+++ b/.github/workflows/blob-size-policy.yml
@@ -32,8 +32,17 @@ jobs:
           ALLOW_PREFIXES: 'kindle-app/ docs/proposals/'
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
-          base="$(git merge-base HEAD "origin/$BASE_REF")"
+          # The checkout above used fetch-depth: 0, so full history is already present.
+          # A shallow (--depth=1) re-fetch here breaks `git merge-base` whenever main
+          # has been force-updated (the merge-base isn't in the 1-commit history), which
+          # under `set -e` fails this gate at exit 1 BEFORE any file size is inspected.
+          # Fetch the base fully, and fall back gracefully if no merge-base resolves.
+          git fetch --no-tags origin "$BASE_REF"
+          base="$(git merge-base HEAD "origin/$BASE_REF" 2>/dev/null || true)"
+          if [ -z "$base" ]; then
+            echo "No merge-base found (base may have been force-updated); comparing against origin/$BASE_REF directly."
+            base="origin/$BASE_REF"
+          fi
           echo "Comparing against base $base ($BASE_REF)"
 
           violations=0


### PR DESCRIPTION
## Problem
The `Reject oversized new blobs` check keeps showing **red on PRs that add only tiny files** (tranche 1 #2305, tranche 2 #2309), making merged PRs look rejected. Root cause: it does `git fetch --no-tags --depth=1 origin main` then `git merge-base HEAD origin/main` under `set -euo pipefail`. When `main` is force-updated (frequent here — squash-merges + the auto-format bot), the merge-base isn't in that **1-commit shallow history**, so `merge-base` returns empty and the script **exits 1 before inspecting a single file**.

## Fix
The `checkout` step already uses `fetch-depth: 0` (full history), so the shallow re-fetch is redundant. Drop `--depth=1` (full fetch) and guard the merge-base with a graceful fallback to `origin/main`. The actual >5 MB size check is unchanged — it still rejects genuine oversized blobs, it just stops dying first.

```diff
- git fetch --no-tags --depth=1 origin "$BASE_REF"
- base="$(git merge-base HEAD "origin/$BASE_REF")"
+ git fetch --no-tags origin "$BASE_REF"
+ base="$(git merge-base HEAD "origin/$BASE_REF" 2>/dev/null || true)"
+ if [ -z "$base" ]; then base="origin/$BASE_REF"; fi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)