### PR TITLE
feat(product): add one-command Black Box proof run

### DIFF
--- a/docs/black-box.html
+++ b/docs/black-box.html
@@ -390,6 +390,11 @@ Action needed: SCBE Black Box found a likely failure or pre-failure signal.
               </p>
             </div>
           </div>
+          <p>
+            From the repo, prove it to yourself with one command:
+            <code>npm run blackbox:prove</code>. It builds the buyer ZIP, runs the bundled scanner,
+            and prints the top finding plus report paths.
+          </p>
         </div>
       </section>
     </main>

--- a/docs/downloads/scbe-black-box-quickstart.md
+++ b/docs/downloads/scbe-black-box-quickstart.md
@@ -5,6 +5,17 @@ run is likely to fail.
 
 It is self-serve. No installation service is required.
 
+## Prove It Locally
+
+From the repo:
+
+```powershell
+npm run blackbox:prove
+```
+
+That command builds the buyer ZIP, runs the bundled scanner, and prints the top
+finding plus the text/JSON report paths.
+
 ## Run
 
 From the downloadable Black Box bundle:

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "writing:package:all": "python scripts/package_products.py --product all",
     "release:workcell": "python scripts/system/build_workcell_download.py",
     "release:blackbox": "python scripts/system/build_black_box_download.py",
+    "blackbox:prove": "python scripts/system/prove_black_box_value.py",
     "blackbox:report": "python scripts/system/scbe_black_box.py --no-fail-on-high",
     "video:verify": "node scripts/video/verify.js",
     "video:quality-gate": "node scripts/video/quality_gate.js",

--- a/scripts/system/prove_black_box_value.py
+++ b/scripts/system/prove_black_box_value.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.system.build_black_box_download import DEFAULT_OUT, build_black_box_download
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build and run SCBE Black Box, then print the top finding.")
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT), help="Output directory for the buyer ZIP and proof run.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    out_dir = Path(args.out_dir)
+    manifest = build_black_box_download(out_dir, verify=True)
+    bundle_dir = out_dir / manifest["bundle_name"]
+    proof_dir = bundle_dir / "proof-run"
+    scanner = bundle_dir / "scbe_black_box.py"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(scanner),
+            "--no-fail-on-high",
+            "--out-dir",
+            str(proof_dir),
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+        return result.returncode
+
+    report_json = proof_dir / "latest_black_box_report.json"
+    report_text = proof_dir / "latest_black_box_report.txt"
+    report = json.loads(report_json.read_text(encoding="utf-8"))
+    findings = report.get("findings", [])
+    top = findings[0] if findings else {}
+
+    print("SCBE Black Box proof run")
+    print("========================")
+    print(report.get("summary", "No summary"))
+    print()
+    if top:
+        print(f"Top finding: [{top.get('severity', '?').upper()}] {top.get('title', '?')}")
+        if top.get("evidence"):
+            print(f"Evidence: {top['evidence'][0]}")
+        if top.get("action"):
+            print(f"Action: {top['action']}")
+    else:
+        print("Top finding: none")
+    print()
+    print(f"Buyer ZIP: {manifest['archive']['path']}")
+    print(f"ZIP SHA-256: {manifest['archive']['sha256']}")
+    print(f"Text report: {report_text}")
+    print(f"JSON report: {report_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/system/test_prove_black_box_value.py
+++ b/tests/system/test_prove_black_box_value.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_prove_black_box_value_command_prints_top_finding(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "scripts/system/prove_black_box_value.py", "--out-dir", str(tmp_path)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "SCBE Black Box proof run" in result.stdout
+    assert "Top finding:" in result.stdout
+    assert "Buyer ZIP:" in result.stdout
+    assert "Text report:" in result.stdout


### PR DESCRIPTION
Adds the missing hands-free proof path for SCBE Black Box.

What changed:
- adds `npm run blackbox:prove`
- builds the buyer ZIP
- runs the bundled scanner against the current machine
- prints the top finding, evidence, action, ZIP path, ZIP SHA-256, and report paths
- documents the command on the product page and quickstart

Why:
A product claim is not enough. This gives a buyer or reviewer one command that proves the tool does something useful on their own machine.

Verified:
- `python -m pytest tests\system\test_prove_black_box_value.py tests\system\test_build_black_box_download.py -q`
- `npm run blackbox:prove`

Local proof result on this machine:
- Top finding: `C:\` has limited free space
- Evidence: `15.9 GB free (6.7%)`
- Action: free space before builds, model downloads, indexing, or video/browser automation