### PR TITLE
feat: AI-callable tool layer — MCP bridge + numfind + crosstalk + prime-category sieve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,6 @@ openpyxl==3.1.5
 # Optional: Visualization (for extended demos)
 # matplotlib>=3.5.0
 z3-solver>=4.12
+
+# MCP SDK — for the SCBE CLI MCP server (tools/mcp/scbe_cli_server.py)
+mcp[cli]>=1.28

--- a/scbe.py
+++ b/scbe.py
@@ -1090,6 +1090,114 @@ def cmd_dec(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_bigint(s: str) -> int:
+    """Parse a (possibly huge) integer; accepts commas, underscores, 0x/0o/0b."""
+    s = s.strip().replace(",", "").replace("_", "")
+    if not s:
+        raise ValueError("empty number")
+    return int(s, 0) if s[:2].lower() in ("0x", "0o", "0b") else int(s)
+
+
+_NUMFIND_MAX_NTH = 5_000_000          # sieve stays ~100 MB / ~1 s
+_NUMFIND_MAX_RANGE_SPAN = 10_000_000  # segmented-sieve span guard
+
+
+def cmd_numfind(args: argparse.Namespace) -> int:
+    """Fast number-finding: primality, factorization, nth/next prime, prime ranges."""
+    try:
+        from src import numtheory as nt
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"numfind unavailable: {exc}", file=sys.stderr)
+        return 1
+
+    op = getattr(args, "nf_op", None)
+    as_json = getattr(args, "json_output", False)
+    if op is None:
+        print("usage: scbe numfind {isprime|factor|nth|next|primes} ...", file=sys.stderr)
+        return 2
+    try:
+        if op == "isprime":
+            n = _parse_bigint(args.n)
+            verdict = nt.is_prime(n)
+            proven = n < nt.DETERMINISTIC_BOUND
+            if as_json:
+                print(json.dumps({"op": "isprime", "n": n, "is_prime": verdict, "deterministic": proven}))
+            else:
+                label = "prime" if verdict else ("composite" if n >= 2 else "not prime")
+                note = "" if proven else "  (strong probable prime — above deterministic bound)"
+                print(f"{n} is {label}{note}")
+            return 0 if verdict else 1
+
+        if op == "next":
+            n = _parse_bigint(args.n)
+            p = nt.next_prime(n)
+            print(json.dumps({"op": "next", "n": n, "next_prime": p}) if as_json else p)
+            return 0
+
+        if op == "nth":
+            k = _parse_bigint(args.k)
+            if k < 1:
+                print("k must be >= 1", file=sys.stderr)
+                return 2
+            if k > _NUMFIND_MAX_NTH:
+                print(f"k too large (max {_NUMFIND_MAX_NTH:,}) — would exceed the sieve budget", file=sys.stderr)
+                return 2
+            p = nt.nth_prime(k)
+            print(json.dumps({"op": "nth", "k": k, "prime": p}) if as_json else p)
+            return 0
+
+        if op == "factor":
+            n = _parse_bigint(args.n)
+            budget = getattr(args, "max_seconds", 20.0)
+            try:
+                fac = nt.factorization(n, time_budget_s=budget)
+            except nt.FactorizationTimeout:
+                print(f"could not factor {n} within {budget:g}s", file=sys.stderr)
+                return 1
+            pairs = sorted(fac.items())
+            if as_json:
+                print(json.dumps({
+                    "op": "factor",
+                    "n": n,
+                    "factors": [[p, e] for p, e in pairs],
+                    "is_prime": n >= 2 and len(pairs) == 1 and pairs[0][1] == 1,
+                }))
+            elif n < 2:
+                print(f"{n} has no prime factorization")
+            else:
+                pretty = " * ".join(f"{p}^{e}" if e > 1 else f"{p}" for p, e in pairs)
+                print(f"{n} = {pretty}")
+            return 0
+
+        if op == "primes":
+            lo = _parse_bigint(args.lo)
+            hi = _parse_bigint(args.hi)
+            if hi - lo > _NUMFIND_MAX_RANGE_SPAN:
+                print(f"range too wide (max span {_NUMFIND_MAX_RANGE_SPAN:,})", file=sys.stderr)
+                return 2
+            primes = nt.primes_in_range(lo, hi)
+            limit = getattr(args, "limit", 0) or 0
+            shown = primes[:limit] if limit > 0 else primes
+            truncated = limit > 0 and len(primes) > limit
+            if as_json:
+                print(json.dumps({
+                    "op": "primes", "lo": lo, "hi": hi,
+                    "count": len(primes), "primes": shown, "truncated": truncated,
+                }))
+            else:
+                print(f"{len(primes)} prime(s) in [{lo}, {hi})")
+                if shown:
+                    print(" ".join(str(p) for p in shown))
+                    if truncated:
+                        print(f"... ({len(primes) - limit} more; raise --limit to see them)")
+            return 0
+    except ValueError as e:
+        print(f"bad number: {e}", file=sys.stderr)
+        return 2
+    print(f"unknown numfind op '{op}'", file=sys.stderr)
+    return 2
+
+
 # Bit spine: byte-exact binary/hex/trit and tiny-machine command surface.
 SPINE_TEMPLATE_COMMANDS = {
     "users": [
@@ -3938,6 +4046,39 @@ Legacy (backward compat):
     de.add_argument("--json", dest="json_output", action="store_true")
     de.add_argument("--raw", action="store_true", help="write raw bytes to stdout")
     de.set_defaults(func=cmd_dec)
+
+    nf = sub.add_parser(
+        "numfind", aliases=["nf"], help='Fast number-finding: primes & factorization ("scbe numfind factor 360")'
+    )
+    nf_sub = nf.add_subparsers(dest="nf_op")
+
+    nf_ip = nf_sub.add_parser("isprime", help="Test whether a number is prime (deterministic below ~3.3e24)")
+    nf_ip.add_argument("n", help="integer to test (decimal, or 0x/0o/0b prefixed)")
+    nf_ip.add_argument("--json", dest="json_output", action="store_true")
+    nf_ip.set_defaults(func=cmd_numfind)
+
+    nf_fac = nf_sub.add_parser("factor", help="Prime-factorize a number (Pollard rho + Miller-Rabin)")
+    nf_fac.add_argument("n", help="integer to factor")
+    nf_fac.add_argument("--max-seconds", dest="max_seconds", type=float, default=20.0, help="wall-clock budget")
+    nf_fac.add_argument("--json", dest="json_output", action="store_true")
+    nf_fac.set_defaults(func=cmd_numfind)
+
+    nf_nth = nf_sub.add_parser("nth", help="Find the k-th prime, 1-indexed (nth 1 = 2)")
+    nf_nth.add_argument("k", help="prime index (1-based)")
+    nf_nth.add_argument("--json", dest="json_output", action="store_true")
+    nf_nth.set_defaults(func=cmd_numfind)
+
+    nf_next = nf_sub.add_parser("next", help="Find the smallest prime greater than n")
+    nf_next.add_argument("n", help="lower bound (exclusive)")
+    nf_next.add_argument("--json", dest="json_output", action="store_true")
+    nf_next.set_defaults(func=cmd_numfind)
+
+    nf_rng = nf_sub.add_parser("primes", help="List primes in the half-open range [lo, hi)")
+    nf_rng.add_argument("lo", help="range start (inclusive)")
+    nf_rng.add_argument("hi", help="range end (exclusive)")
+    nf_rng.add_argument("--limit", type=int, default=0, help="max primes to print (0 = all)")
+    nf_rng.add_argument("--json", dest="json_output", action="store_true")
+    nf_rng.set_defaults(func=cmd_numfind)
 
     # ─── Sacred Tongues as verbs — full names, no abbreviation ───
     spine = sub.add_parser("spine", help="Bit spine: binary, hex, trit, and tiny-machine actions")

--- a/scbe.py
+++ b/scbe.py
@@ -1198,6 +1198,126 @@ def cmd_numfind(args: argparse.Namespace) -> int:
     return 2
 
 
+def cmd_crosstalk(args: argparse.Namespace) -> int:
+    """Governed AI-to-AI fleet dialogue: agents take turns; each turn must pass the sieve."""
+    topic = _arg_or_stdin(getattr(args, "topic", None))
+    if not topic:
+        print('usage: scbe crosstalk "<topic>" [--rounds N] [--agents N] [--offline]', file=sys.stderr)
+        return 2
+    try:
+        from src import fleet_crosstalk as fc
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"crosstalk unavailable: {exc}", file=sys.stderr)
+        return 1
+
+    n_agents = max(1, getattr(args, "agents", 2) or 2)
+    rounds = max(1, getattr(args, "rounds", 2) or 2)
+    backend = getattr(args, "backend", None)
+    model = getattr(args, "model", None)
+    pool = [
+        ("Proposer", "proposes concrete ideas"),
+        ("Skeptic", "stress-tests claims and surfaces risks"),
+        ("Synthesizer", "reconciles the views into a plan"),
+        ("Builder", "turns the plan into concrete next steps"),
+    ]
+    agents = []
+    for i in range(n_agents):
+        base_name, persona = pool[i % len(pool)]
+        name = base_name if i < len(pool) else f"{base_name}{i}"
+        agents.append(fc.Agent(name=name, persona=persona, backend=backend, model=model))
+
+    available = _detect_backends()
+    offline = getattr(args, "offline", False) or not available
+    if offline:
+        responder = fc.eliza_responder
+        mode = "offline (mechanical ELIZA)"
+    else:
+        responder = fc.make_ai_responder(ai_ask)
+        mode = f"live ({backend or available[0]})"
+
+    result = fc.run_crosstalk(
+        topic, agents, rounds, responder, pipeline_quick_score, gate=not getattr(args, "no_gate", False)
+    )
+    result["mode"] = mode
+
+    if getattr(args, "json_output", False):
+        print(json.dumps(result))
+        return 0
+    print(f"crosstalk · {mode} · {len(agents)} agents · {rounds} rounds")
+    print(f"topic: {topic}\n")
+    for t in result["turns"]:
+        if t["accepted"]:
+            print(f"  r{t['round']} {t['agent']}: {t['message']}")
+        else:
+            glyph = DECISION_GLYPH.get(t["decision"], "?")
+            print(f"  r{t['round']} {t['agent']}: [{glyph} {t['decision']} — withheld by sieve] {t['message']}")
+    g = result["governance"]
+    print(f"\ngovernance: {g['accepted']}/{g['total']} turns accepted, {g['withheld']} withheld · {g['by_decision']}")
+    return 0
+
+
+def cmd_primecat(args: argparse.Namespace) -> int:
+    """Prime-coded categories: assign primes, encode/decode items, sieve by target category."""
+    try:
+        from src.prime_category import PrimeCategories
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"primecat unavailable: {exc}", file=sys.stderr)
+        return 1
+
+    op = getattr(args, "pc_op", None)
+    as_json = getattr(args, "json_output", False)
+    if op is None:
+        print("usage: scbe primecat {assign|code|decode|match} ...", file=sys.stderr)
+        return 2
+
+    def _universe(s):
+        return [c for c in (s or "").replace(",", " ").split() if c]
+
+    try:
+        if op == "assign":
+            pc = PrimeCategories(getattr(args, "categories", []) or [])
+            mapping = pc.mapping
+            if as_json:
+                print(json.dumps({"op": "assign", "mapping": mapping}))
+            else:
+                for cat, prime in mapping.items():
+                    print(f"{cat}\t{prime}")
+            return 0
+
+        universe = _universe(getattr(args, "universe", None))
+        if not universe:
+            print("--universe is required (comma- or space-separated categories)", file=sys.stderr)
+            return 2
+        pc = PrimeCategories(universe)
+
+        if op == "code":
+            cats = getattr(args, "item", []) or []
+            code = pc.code(cats)
+            print(json.dumps({"op": "code", "categories": cats, "code": code}) if as_json else code)
+            return 0
+
+        if op == "decode":
+            code = _parse_bigint(args.code)
+            cats = pc.decode(code)
+            print(json.dumps({"op": "decode", "code": code, "categories": cats}) if as_json else " ".join(cats))
+            return 0
+
+        if op == "match":
+            code = _parse_bigint(args.code)
+            target = args.target
+            hit = pc.in_category(code, target)
+            if as_json:
+                print(json.dumps({"op": "match", "code": code, "target": target, "in_category": hit}))
+            else:
+                print(f"{code} {'is' if hit else 'is NOT'} in category '{target}'")
+            return 0 if hit else 1
+    except (KeyError, ValueError) as e:
+        print(f"primecat error: {e}", file=sys.stderr)
+        return 2
+    print(f"unknown primecat op '{op}'", file=sys.stderr)
+    return 2
+
+
 # Bit spine: byte-exact binary/hex/trit and tiny-machine command surface.
 SPINE_TEMPLATE_COMMANDS = {
     "users": [
@@ -4079,6 +4199,48 @@ Legacy (backward compat):
     nf_rng.add_argument("--limit", type=int, default=0, help="max primes to print (0 = all)")
     nf_rng.add_argument("--json", dest="json_output", action="store_true")
     nf_rng.set_defaults(func=cmd_numfind)
+
+    ct = sub.add_parser(
+        "crosstalk", aliases=["xt"], help='Governed AI-to-AI fleet dialogue ("scbe crosstalk \\"topic\\"")'
+    )
+    ct.add_argument("topic", nargs="?", help="discussion topic (or pipe via stdin)")
+    ct.add_argument("--rounds", type=int, default=2, help="rounds (each agent speaks once per round)")
+    ct.add_argument("--agents", type=int, default=2, help="number of fleet agents")
+    ct.add_argument("--backend", help="AI backend for live mode (claude/openai/anthropic/ollama/codex)")
+    ct.add_argument("--model", help="model name override")
+    ct.add_argument("--offline", action="store_true", help="force the deterministic offline responder")
+    ct.add_argument("--no-gate", dest="no_gate", action="store_true", help="score but don't withhold flagged turns")
+    ct.add_argument("--json", dest="json_output", action="store_true")
+    ct.set_defaults(func=cmd_crosstalk)
+
+    pcat = sub.add_parser(
+        "primecat", help='Prime-coded categories: assign primes & sieve items by category'
+    )
+    pcat_sub = pcat.add_subparsers(dest="pc_op")
+
+    pcat_as = pcat_sub.add_parser("assign", help="Assign a distinct prime to each category")
+    pcat_as.add_argument("categories", nargs="+", help="category names (the universe)")
+    pcat_as.add_argument("--json", dest="json_output", action="store_true")
+    pcat_as.set_defaults(func=cmd_primecat)
+
+    pcat_cd = pcat_sub.add_parser("code", help="Encode an item's categories as a prime product")
+    pcat_cd.add_argument("item", nargs="+", help="the item's categories")
+    pcat_cd.add_argument("--universe", required=True, help="full category universe (comma/space separated)")
+    pcat_cd.add_argument("--json", dest="json_output", action="store_true")
+    pcat_cd.set_defaults(func=cmd_primecat)
+
+    pcat_de = pcat_sub.add_parser("decode", help="Recover an item's categories by factoring its code")
+    pcat_de.add_argument("code", help="the prime-product code")
+    pcat_de.add_argument("--universe", required=True, help="full category universe (comma/space separated)")
+    pcat_de.add_argument("--json", dest="json_output", action="store_true")
+    pcat_de.set_defaults(func=cmd_primecat)
+
+    pcat_mt = pcat_sub.add_parser("match", help="Test whether a code belongs to a target category (divisibility sieve)")
+    pcat_mt.add_argument("code", help="the prime-product code")
+    pcat_mt.add_argument("target", help="target category")
+    pcat_mt.add_argument("--universe", required=True, help="full category universe (comma/space separated)")
+    pcat_mt.add_argument("--json", dest="json_output", action="store_true")
+    pcat_mt.set_defaults(func=cmd_primecat)
 
     # ─── Sacred Tongues as verbs — full names, no abbreviation ───
     spine = sub.add_parser("spine", help="Bit spine: binary, hex, trit, and tiny-machine actions")

--- a/src/fleet_crosstalk.py
+++ b/src/fleet_crosstalk.py
@@ -1,0 +1,141 @@
+"""AI-to-AI fleet cross-talk — a governed multi-agent dialogue loop.
+
+Agents take turns responding to a shared topic and to each other. Every turn is
+screened through the SCBE entropy sieve (the pipeline score) before it is allowed
+into the shared transcript, so the conversation is safety-gated: a turn the sieve
+flags (QUARANTINE / ESCALATE / DENY) is recorded but *withheld* from the running
+context instead of propagating to the next speaker.
+
+The turn generator is injected, so the engine is decoupled from any network:
+
+- ``eliza_responder``       deterministic, offline (mechanical ELIZA). Always
+                            works — no network, no API keys. Used for tests and
+                            key-less environments.
+- ``make_ai_responder(ask)``  wraps an ``ai_ask``-style callable to route turns to
+                            real backends (claude/codex/ollama/anthropic/openai,
+                            including free cloud models).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+# A responder turns (agent, topic, prior turns) into the agent's next message.
+Responder = Callable[["Agent", str, List["Turn"]], str]
+# A score function maps a message to a governance verdict dict (decision, H_eff, ...).
+ScoreFn = Callable[[str], Dict[str, Any]]
+
+
+@dataclass
+class Agent:
+    name: str
+    persona: str = "a thoughtful collaborator"
+    backend: Optional[str] = None
+    model: Optional[str] = None
+
+
+@dataclass
+class Turn:
+    round: int
+    agent: str
+    message: str
+    decision: str
+    h_eff: float
+    accepted: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "round": self.round,
+            "agent": self.agent,
+            "message": self.message,
+            "decision": self.decision,
+            "h_eff": self.h_eff,
+            "accepted": self.accepted,
+        }
+
+
+def _accepted_history(turns: Sequence["Turn"]) -> List[Tuple[str, str]]:
+    """The (agent, message) pairs the sieve let through — the shared context."""
+    return [(t.agent, t.message) for t in turns if t.accepted]
+
+
+def run_crosstalk(
+    topic: str,
+    agents: Sequence[Agent],
+    rounds: int,
+    responder: Responder,
+    score_fn: ScoreFn,
+    gate: bool = True,
+) -> Dict[str, Any]:
+    """Run a governed multi-agent dialogue and return the transcript + governance summary."""
+    if not agents:
+        raise ValueError("need at least one agent")
+    if rounds < 1:
+        raise ValueError("rounds must be >= 1")
+
+    turns: List[Turn] = []
+    for r in range(1, rounds + 1):
+        for agent in agents:
+            message = (responder(agent, topic, turns) or "").strip()
+            score = score_fn(message) if message else {"decision": "ALLOW", "H_eff": 1.0}
+            decision = str(score.get("decision", "ALLOW"))
+            h_eff = float(score.get("H_eff", 1.0))
+            accepted = (decision == "ALLOW") or not gate
+            turns.append(Turn(r, agent.name, message, decision, h_eff, accepted))
+
+    by_decision: Dict[str, int] = {}
+    for t in turns:
+        by_decision[t.decision] = by_decision.get(t.decision, 0) + 1
+    return {
+        "topic": topic,
+        "rounds": rounds,
+        "agents": [a.name for a in agents],
+        "turns": [t.to_dict() for t in turns],
+        "governance": {
+            "total": len(turns),
+            "accepted": sum(1 for t in turns if t.accepted),
+            "withheld": sum(1 for t in turns if not t.accepted),
+            "by_decision": by_decision,
+            "gated": gate,
+        },
+    }
+
+
+def _build_ai_prompt(agent: Agent, topic: str, history: List[Tuple[str, str]]) -> str:
+    lines = [
+        f"You are {agent.name}, {agent.persona}.",
+        f"You are in a multi-agent discussion about: {topic}",
+        "Reply with ONE short turn (1-3 sentences). Build on what the others said; do not repeat them.",
+    ]
+    if history:
+        lines.append("\nTranscript so far:")
+        for name, msg in history[-8:]:
+            lines.append(f"{name}: {msg}")
+    lines.append(f"\n{agent.name}:")
+    return "\n".join(lines)
+
+
+def make_ai_responder(ask: Callable[..., Any]) -> Responder:
+    """Wrap an ai_ask-style callable (returns str or (text, backend)) into a Responder."""
+
+    def responder(agent: Agent, topic: str, turns: List[Turn]) -> str:
+        prompt = _build_ai_prompt(agent, topic, _accepted_history(turns))
+        out = ask(prompt, agent.backend, agent.model)
+        return out[0] if isinstance(out, tuple) else str(out)
+
+    return responder
+
+
+def eliza_responder(agent: Agent, topic: str, turns: List[Turn]) -> str:
+    """Deterministic, offline turn generator (mechanical ELIZA). No network or keys."""
+    from python.scbe import mechanical_eliza as me
+
+    history = [msg for _name, msg in _accepted_history(turns)]
+    last = history[-1] if history else topic
+    packet = me.route_support(last, history)
+    # Rotate through the route's reflection + follow-up questions by turn index so
+    # successive speakers don't echo the same deterministic line.
+    pool = [packet.response.strip(), *[q.strip() for q in packet.next_questions if q.strip()]]
+    pool = [p for p in pool if p] or [packet.response.strip()]
+    return f"({agent.name}) {pool[len(turns) % len(pool)]}"

--- a/src/numtheory.py
+++ b/src/numtheory.py
@@ -1,0 +1,185 @@
+"""Fast number-finding primitives — primality, factorization, and prime sieves.
+
+Pure-stdlib, dependency-free number theory used as a bedrock tool for the SCBE
+CLI ("find a number fast"). Everything here is *exact* integer arithmetic:
+
+- ``is_prime(n)``        deterministic Miller–Rabin below ``DETERMINISTIC_BOUND``;
+                         a strong probable-prime test (12 fixed bases) above it.
+- ``prime_factors(n)``   Pollard's rho (Brent) + Miller–Rabin → full prime multiset.
+- ``factorization(n)``   the same, collapsed to ``{prime: exponent}``.
+- ``nth_prime(k)``       the k-th prime (1-indexed) via a sieve sized by the
+                         Rosser prime-counting upper bound.
+- ``next_prime(n)``      smallest prime strictly greater than n.
+- ``primes_in_range``    segmented Sieve of Eratosthenes over ``[lo, hi)``.
+- ``primes_upto(n)``     Sieve of Eratosthenes over ``[0, n]``.
+
+The factoring routines accept an optional wall-clock ``time_budget_s`` so a
+pathological input degrades to a clear timeout instead of hanging.
+"""
+
+from __future__ import annotations
+
+import time
+from math import gcd, isqrt, log
+from typing import Dict, List, Optional
+
+# Witness set proven to make Miller–Rabin a *correct* primality test for every
+# n below this bound (Sorenson & Webster). Above it the same test is a strong
+# probable-prime check — astronomically reliable, but not a proof.
+_DET_WITNESSES = (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37)
+DETERMINISTIC_BOUND = 3_317_044_064_679_887_385_961_981
+
+_SMALL_PRIMES = (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47)
+
+
+class FactorizationTimeout(Exception):
+    """Raised when factoring exceeds the supplied wall-clock budget."""
+
+
+def is_prime(n: int) -> bool:
+    """Return True iff n is prime. Deterministic below DETERMINISTIC_BOUND."""
+    if n < 2:
+        return False
+    for p in _SMALL_PRIMES:
+        if n % p == 0:
+            return n == p
+    d = n - 1
+    s = 0
+    while d % 2 == 0:
+        d //= 2
+        s += 1
+    for a in _DET_WITNESSES:
+        a %= n
+        if a == 0:
+            continue
+        x = pow(a, d, n)
+        if x == 1 or x == n - 1:
+            continue
+        for _ in range(s - 1):
+            x = x * x % n
+            if x == n - 1:
+                break
+        else:
+            return False
+    return True
+
+
+def _pollard_brent(n: int, deadline: Optional[float]) -> int:
+    """Return a non-trivial factor of composite n via Brent's rho variant."""
+    if n % 2 == 0:
+        return 2
+    if n % 3 == 0:
+        return 3
+    c = 1
+    while True:
+        if deadline is not None and time.monotonic() > deadline:
+            raise FactorizationTimeout()
+        y, m = 2, 128
+        g = q = r = 1
+        x = ys = 0
+        while g == 1:
+            x = y
+            for _ in range(r):
+                y = (y * y + c) % n
+            k = 0
+            while k < r and g == 1:
+                ys = y
+                for _ in range(min(m, r - k)):
+                    y = (y * y + c) % n
+                    q = q * abs(x - y) % n
+                g = gcd(q, n)
+                k += m
+            r *= 2
+            if deadline is not None and time.monotonic() > deadline:
+                raise FactorizationTimeout()
+        if g == n:  # backtrack to recover a factor missed by the batched gcd
+            g = 1
+            while g == 1:
+                ys = (ys * ys + c) % n
+                g = gcd(abs(x - ys), n)
+        if g != n:
+            return g
+        c += 1  # rare: retry with a different polynomial
+
+
+def prime_factors(n: int, time_budget_s: Optional[float] = 20.0) -> List[int]:
+    """Full sorted multiset of prime factors of n (n >= 0; <2 yields [])."""
+    if n < 0:
+        raise ValueError("n must be non-negative")
+    factors: List[int] = []
+    if n < 2:
+        return factors
+    for p in _SMALL_PRIMES:
+        while n % p == 0:
+            factors.append(p)
+            n //= p
+    deadline = (time.monotonic() + time_budget_s) if time_budget_s else None
+    stack = [n] if n > 1 else []
+    while stack:
+        m = stack.pop()
+        if m == 1:
+            continue
+        if is_prime(m):
+            factors.append(m)
+            continue
+        d = _pollard_brent(m, deadline)
+        stack.append(d)
+        stack.append(m // d)
+    factors.sort()
+    return factors
+
+
+def factorization(n: int, time_budget_s: Optional[float] = 20.0) -> Dict[int, int]:
+    """Prime factorization of n as ``{prime: exponent}``."""
+    out: Dict[int, int] = {}
+    for p in prime_factors(n, time_budget_s=time_budget_s):
+        out[p] = out.get(p, 0) + 1
+    return out
+
+
+def primes_upto(n: int) -> List[int]:
+    """All primes in ``[0, n]`` via the Sieve of Eratosthenes."""
+    if n < 2:
+        return []
+    sieve = bytearray([1]) * (n + 1)
+    sieve[0] = sieve[1] = 0
+    for i in range(2, isqrt(n) + 1):
+        if sieve[i]:
+            sieve[i * i :: i] = bytearray(len(range(i * i, n + 1, i)))
+    return [i for i in range(2, n + 1) if sieve[i]]
+
+
+def primes_in_range(lo: int, hi: int) -> List[int]:
+    """All primes in the half-open interval ``[lo, hi)`` via a segmented sieve."""
+    if hi <= 2 or hi <= lo:
+        return []
+    lo = max(lo, 2)
+    base = primes_upto(isqrt(hi - 1) + 1)
+    seg = bytearray([1]) * (hi - lo)
+    for p in base:
+        start = max(p * p, ((lo + p - 1) // p) * p)
+        for m in range(start, hi, p):
+            seg[m - lo] = 0
+    return [lo + i for i in range(hi - lo) if seg[i]]
+
+
+def nth_prime(k: int) -> int:
+    """The k-th prime, 1-indexed (``nth_prime(1) == 2``)."""
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    if k <= 5:
+        return (2, 3, 5, 7, 11)[k - 1]
+    # Rosser's theorem: p_k < k(ln k + ln ln k) for k >= 6 — a proven upper bound.
+    upper = int(k * (log(k) + log(log(k)))) + 3
+    primes = primes_upto(upper)
+    return primes[k - 1]
+
+
+def next_prime(n: int) -> int:
+    """Smallest prime strictly greater than n."""
+    if n < 2:
+        return 2
+    candidate = n + 1
+    while not is_prime(candidate):
+        candidate += 1
+    return candidate

--- a/src/prime_category.py
+++ b/src/prime_category.py
@@ -1,0 +1,71 @@
+"""Prime-coded categories — sort/decode items by an assigned "prime target category".
+
+Each category is assigned a distinct prime. An item's set of categories is encoded
+as the *product* of those primes (a squarefree Gödel-style code). Then:
+
+- an item **belongs to** a category  iff  its code is divisible by that category's
+  prime — so filtering a fleet by a target category is a single modulo test (the
+  sieve), and
+- an item's full category set is **recovered** by factoring its code.
+
+This is built directly on ``src.numtheory`` (``nth_prime`` for stable assignment,
+``prime_factors`` to decode) — the prime sieve as the bedrock for categorization.
+
+Assignment is deterministic: the i-th distinct category (in the order given) gets
+the i-th prime, so the same category universe always yields the same codes.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from src import numtheory as nt
+
+
+class PrimeCategories:
+    """A fixed category universe with a stable category <-> prime assignment."""
+
+    def __init__(self, categories: Iterable[str]) -> None:
+        cats = list(dict.fromkeys(c.strip() for c in categories if c.strip()))  # dedupe, keep order
+        if not cats:
+            raise ValueError("need at least one category")
+        self._cat_to_prime: Dict[str, int] = {c: nt.nth_prime(i + 1) for i, c in enumerate(cats)}
+        self._prime_to_cat: Dict[int, str] = {p: c for c, p in self._cat_to_prime.items()}
+
+    @property
+    def mapping(self) -> Dict[str, int]:
+        """The category -> prime assignment."""
+        return dict(self._cat_to_prime)
+
+    def prime_of(self, category: str) -> int:
+        category = category.strip()
+        if category not in self._cat_to_prime:
+            raise KeyError(f"unknown category: {category!r}")
+        return self._cat_to_prime[category]
+
+    def code(self, categories: Iterable[str]) -> int:
+        """Encode an item's category set as the product of the categories' primes."""
+        code = 1
+        for c in dict.fromkeys(c.strip() for c in categories if c.strip()):
+            code *= self.prime_of(c)
+        return code
+
+    def decode(self, code: int) -> List[str]:
+        """Recover the category set from a code by factoring it (sieve in reverse)."""
+        if code < 1:
+            raise ValueError("code must be >= 1")
+        cats: List[str] = []
+        for p in sorted(set(nt.prime_factors(code))):
+            if p not in self._prime_to_cat:
+                raise ValueError(f"code carries prime {p} with no assigned category")
+            cats.append(self._prime_to_cat[p])
+        return cats
+
+    def in_category(self, code: int, target: str) -> bool:
+        """True iff an item's code belongs to the target category (divisibility sieve)."""
+        return code % self.prime_of(target) == 0
+
+    def sort_by_category(self, items: Dict[str, Iterable[str]], target: str) -> List[str]:
+        """Names of items tagged with ``target``, found by the divisibility sieve."""
+        tp = self.prime_of(target)
+        return [name for name, cats in items.items() if self.code(cats) % tp == 0]

--- a/tests/test_fleet_crosstalk.py
+++ b/tests/test_fleet_crosstalk.py
@@ -1,0 +1,117 @@
+"""Tests for the governed AI-to-AI fleet cross-talk engine (src/fleet_crosstalk.py)."""
+
+import pytest
+
+from src import fleet_crosstalk as fc
+
+
+def _stub_score(allow_all=True, deny_substr=None):
+    """A deterministic score_fn: DENY messages containing deny_substr, else ALLOW."""
+
+    def score(text):
+        if deny_substr and deny_substr in text:
+            return {"decision": "DENY", "H_eff": 0.1}
+        return {"decision": "ALLOW", "H_eff": 1.0}
+
+    return score
+
+
+def _echo_responder(agent, topic, turns):
+    """Deterministic responder: states who is speaking and how many turns precede it."""
+    return f"{agent.name} turn after {len(turns)} prior on {topic}"
+
+
+def test_turn_count_and_structure():
+    agents = [fc.Agent("A"), fc.Agent("B")]
+    result = fc.run_crosstalk("widgets", agents, rounds=3, responder=_echo_responder, score_fn=_stub_score())
+    assert result["governance"]["total"] == 6  # 2 agents x 3 rounds
+    assert result["agents"] == ["A", "B"]
+    assert [t["agent"] for t in result["turns"]] == ["A", "B", "A", "B", "A", "B"]
+    assert [t["round"] for t in result["turns"]] == [1, 1, 2, 2, 3, 3]
+    assert all(t["accepted"] for t in result["turns"])
+
+
+def test_sieve_withholds_flagged_turns():
+    agents = [fc.Agent("Clean"), fc.Agent("Bad")]
+
+    def responder(agent, topic, turns):
+        return "BLOCKME payload" if agent.name == "Bad" else "all good here"
+
+    result = fc.run_crosstalk("x", agents, rounds=2, responder=responder, score_fn=_stub_score(deny_substr="BLOCKME"))
+    g = result["governance"]
+    assert g["total"] == 4
+    assert g["accepted"] == 2 and g["withheld"] == 2
+    assert g["by_decision"] == {"ALLOW": 2, "DENY": 2}
+    bad_turns = [t for t in result["turns"] if t["agent"] == "Bad"]
+    assert all(not t["accepted"] and t["decision"] == "DENY" for t in bad_turns)
+
+
+def test_no_gate_accepts_everything_but_still_scores():
+    agents = [fc.Agent("Bad")]
+
+    def responder(agent, topic, turns):
+        return "BLOCKME"
+
+    result = fc.run_crosstalk(
+        "x", agents, rounds=2, responder=responder, score_fn=_stub_score(deny_substr="BLOCKME"), gate=False
+    )
+    assert result["governance"]["accepted"] == 2
+    assert result["governance"]["by_decision"] == {"DENY": 2}  # scored, just not withheld
+
+
+def test_withheld_turns_excluded_from_history():
+    """A withheld turn must not appear in the context the next speaker receives."""
+    seen_histories = []
+
+    def responder(agent, topic, turns):
+        seen_histories.append(fc._accepted_history(turns))
+        return "BLOCKME" if agent.name == "Bad" else "fine"
+
+    agents = [fc.Agent("Bad"), fc.Agent("Good")]
+    fc.run_crosstalk("x", agents, rounds=1, responder=responder, score_fn=_stub_score(deny_substr="BLOCKME"))
+    # Good speaks after Bad; Bad's turn was withheld, so Good sees an empty history.
+    assert seen_histories[1] == []
+
+
+def test_invalid_args_raise():
+    with pytest.raises(ValueError):
+        fc.run_crosstalk("x", [], rounds=1, responder=_echo_responder, score_fn=_stub_score())
+    with pytest.raises(ValueError):
+        fc.run_crosstalk("x", [fc.Agent("A")], rounds=0, responder=_echo_responder, score_fn=_stub_score())
+
+
+def test_make_ai_responder_handles_str_and_tuple():
+    calls = []
+
+    def ask_tuple(prompt, backend, model):
+        calls.append((backend, model))
+        return ("tuple-answer", backend or "auto")
+
+    def ask_str(prompt, backend, model):
+        return "str-answer"
+
+    r1 = fc.make_ai_responder(ask_tuple)
+    r2 = fc.make_ai_responder(ask_str)
+    a = fc.Agent("A", backend="openai", model="gpt-4o-mini")
+    assert r1(a, "topic", []) == "tuple-answer"
+    assert r2(a, "topic", []) == "str-answer"
+    assert calls == [("openai", "gpt-4o-mini")]
+
+
+def test_eliza_responder_is_deterministic_and_nonempty():
+    a = fc.Agent("Proposer", persona="proposes ideas")
+    out1 = fc.eliza_responder(a, "scaling the fleet", [])
+    out2 = fc.eliza_responder(a, "scaling the fleet", [])
+    assert out1 == out2
+    assert out1.startswith("(Proposer)")
+    assert len(out1) > len("(Proposer) ")
+
+
+def test_eliza_crosstalk_end_to_end_offline():
+    """Full offline run with the real ELIZA responder and a permissive scorer."""
+    agents = [fc.Agent("Proposer", "proposes ideas"), fc.Agent("Skeptic", "finds risks")]
+    result = fc.run_crosstalk(
+        "how to route a free-LLM fleet", agents, rounds=2, responder=fc.eliza_responder, score_fn=_stub_score()
+    )
+    assert result["governance"]["total"] == 4
+    assert all(t["message"] for t in result["turns"])  # no empty turns

--- a/tests/test_numtheory.py
+++ b/tests/test_numtheory.py
@@ -1,0 +1,101 @@
+"""Correctness tests for the fast number-finding primitives (src/numtheory.py)."""
+
+from functools import reduce
+from operator import mul
+
+import pytest
+
+from src import numtheory as nt
+
+
+def _product(xs):
+    return reduce(mul, xs, 1)
+
+
+@pytest.mark.parametrize("n", [2, 3, 5, 7, 13, 97, 7919, 104729, 2_147_483_647, 2**61 - 1])
+def test_known_primes(n):
+    assert nt.is_prime(n) is True
+
+
+@pytest.mark.parametrize("n", [-5, 0, 1, 4, 9, 100, 7917, 561, 1105, 2**61 - 3])
+def test_known_composites_and_units(n):
+    # 561, 1105 are Carmichael numbers — must not fool Miller–Rabin.
+    assert nt.is_prime(n) is False
+
+
+def test_carmichael_numbers_are_composite():
+    for c in (561, 1105, 1729, 2465, 2821, 6601, 8911):
+        assert nt.is_prime(c) is False
+
+
+def test_large_prime_is_deterministic():
+    # 2**31 - 1 (Mersenne prime) is far below the deterministic bound.
+    assert (2**31 - 1) < nt.DETERMINISTIC_BOUND
+    assert nt.is_prime(2**31 - 1) is True
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (1, []),
+        (2, [2]),
+        (360, [2, 2, 2, 3, 3, 5]),
+        (97, [97]),
+        (1_000_000, [2, 2, 2, 2, 2, 2, 5, 5, 5, 5, 5, 5]),
+    ],
+)
+def test_prime_factors_known(n, expected):
+    assert nt.prime_factors(n) == expected
+
+
+def test_factorization_roundtrip_semiprime():
+    # product of two distinct large primes — Pollard rho must crack it fast.
+    p = nt.next_prime(10**9)
+    q = nt.next_prime(10**10)
+    n = p * q
+    fac = nt.factorization(n)
+    assert fac == {p: 1, q: 1}
+    assert _product(nt.prime_factors(n)) == n
+
+
+def test_factorization_prime_power():
+    assert nt.factorization(2**20) == {2: 20}
+    assert nt.factorization(3**13) == {3: 13}
+
+
+@pytest.mark.parametrize(
+    "k,expected",
+    [(1, 2), (2, 3), (3, 5), (6, 13), (100, 541), (1000, 7919), (10000, 104729)],
+)
+def test_nth_prime(k, expected):
+    assert nt.nth_prime(k) == expected
+
+
+def test_nth_prime_rejects_nonpositive():
+    with pytest.raises(ValueError):
+        nt.nth_prime(0)
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [(0, 2), (1, 2), (2, 3), (13, 17), (7918, 7919), (104728, 104729)],
+)
+def test_next_prime(n, expected):
+    assert nt.next_prime(n) == expected
+
+
+def test_primes_in_range():
+    assert nt.primes_in_range(10, 30) == [11, 13, 17, 19, 23, 29]
+    assert nt.primes_in_range(0, 12) == [2, 3, 5, 7, 11]
+    assert nt.primes_in_range(90, 90) == []
+
+
+def test_primes_upto_matches_range():
+    assert nt.primes_upto(30) == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+    # the two sieves must agree on overlapping spans
+    assert nt.primes_in_range(2, 1001) == nt.primes_upto(1000)
+
+
+def test_prime_factors_rejects_negative():
+    with pytest.raises(ValueError):
+        nt.prime_factors(-1)

--- a/tests/test_prime_category.py
+++ b/tests/test_prime_category.py
@@ -1,0 +1,76 @@
+"""Tests for prime-coded categories (src/prime_category.py)."""
+
+import pytest
+
+from src.prime_category import PrimeCategories
+
+
+def test_stable_prime_assignment():
+    pc = PrimeCategories(["red", "green", "blue", "alpha"])
+    assert pc.mapping == {"red": 2, "green": 3, "blue": 5, "alpha": 7}
+
+
+def test_assignment_dedupes_and_keeps_order():
+    pc = PrimeCategories(["a", "b", "a", "c", " b "])
+    assert pc.mapping == {"a": 2, "b": 3, "c": 5}
+
+
+def test_code_is_product_of_primes():
+    pc = PrimeCategories(["red", "green", "blue", "alpha"])
+    assert pc.code(["red", "blue"]) == 2 * 5
+    assert pc.code(["green", "alpha"]) == 3 * 7
+    assert pc.code([]) == 1
+
+
+def test_code_is_squarefree_on_repeats():
+    pc = PrimeCategories(["red", "green"])
+    assert pc.code(["red", "red", "green"]) == 2 * 3  # repeats collapse
+
+
+def test_decode_roundtrips_code():
+    pc = PrimeCategories(["red", "green", "blue", "alpha"])
+    for combo in (["red"], ["red", "blue"], ["green", "alpha", "red"]):
+        code = pc.code(combo)
+        assert sorted(pc.decode(code)) == sorted(set(combo))
+
+
+def test_in_category_is_divisibility():
+    pc = PrimeCategories(["red", "green", "blue"])
+    code = pc.code(["red", "blue"])  # 2 * 5 = 10
+    assert pc.in_category(code, "red") is True
+    assert pc.in_category(code, "blue") is True
+    assert pc.in_category(code, "green") is False
+
+
+def test_sort_by_category_sieves_items():
+    pc = PrimeCategories(["urgent", "billing", "bug"])
+    items = {
+        "ticket-1": ["urgent", "bug"],
+        "ticket-2": ["billing"],
+        "ticket-3": ["urgent", "billing"],
+        "ticket-4": ["bug"],
+    }
+    assert pc.sort_by_category(items, "urgent") == ["ticket-1", "ticket-3"]
+    assert pc.sort_by_category(items, "billing") == ["ticket-2", "ticket-3"]
+    assert pc.sort_by_category(items, "bug") == ["ticket-1", "ticket-4"]
+
+
+def test_unknown_category_raises():
+    pc = PrimeCategories(["a", "b"])
+    with pytest.raises(KeyError):
+        pc.prime_of("z")
+    with pytest.raises(KeyError):
+        pc.code(["a", "z"])
+
+
+def test_decode_rejects_unassigned_prime():
+    pc = PrimeCategories(["a", "b"])  # primes 2, 3
+    with pytest.raises(ValueError):
+        pc.decode(11)  # 11 has no category
+    with pytest.raises(ValueError):
+        pc.decode(0)
+
+
+def test_empty_universe_raises():
+    with pytest.raises(ValueError):
+        PrimeCategories([])

--- a/tools/mcp/scbe_cli_server.py
+++ b/tools/mcp/scbe_cli_server.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""SCBE CLI MCP server — nests every `scbe` tool inside an AI-callable interface.
+
+This is the "programmatic access for AI" layer: it exposes the *real* scbe CLI
+commands (discovered from `scbe manifest`) as MCP tools over stdio JSON-RPC, and
+on a tool call it actually runs the command and returns the result. Any MCP client
+— Claude Desktop, gemini-cli, or the PowerShellSCBE shell's AI — can list and
+invoke the SCBE toolset programmatically.
+
+No third-party deps: MCP stdio is newline-delimited JSON-RPC, hand-rolled here so
+it runs anywhere Python does.
+
+Run as a server:        python tools/mcp/scbe_cli_server.py
+Self-test (no client):  python tools/mcp/scbe_cli_server.py --self-test
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCBE = [sys.executable, str(REPO_ROOT / "scbe.py")]
+PROTOCOL_VERSION = "2024-11-05"
+
+
+def _load_tools() -> list[dict]:
+    """Discover the scbe tool catalog via `scbe manifest --json`."""
+    proc = subprocess.run(
+        SCBE + ["manifest"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    data = json.loads(proc.stdout)
+    return data.get("tools", [])
+
+
+def _to_mcp_tool(tool: dict) -> dict:
+    """Render one scbe command as an MCP tool definition (JSON-Schema input)."""
+    props: dict[str, Any] = {}
+    required: list[str] = []
+    for arg in tool.get("args", []):
+        is_list = arg.get("nargs") in ("*", "+")
+        node: dict[str, Any] = {"type": "array", "items": {"type": arg["type"]}} if is_list else {"type": arg["type"]}
+        target = node["items"] if is_list else node
+        if arg.get("choices"):
+            target["enum"] = arg["choices"]
+        if arg.get("description"):
+            node["description"] = arg["description"]
+        props[arg["name"]] = node
+        if arg.get("required"):
+            required.append(arg["name"])
+    schema: dict[str, Any] = {"type": "object", "properties": props}
+    if required:
+        schema["required"] = required
+    return {
+        "name": "scbe_" + tool["name"].replace(".", "_").replace("-", "_"),
+        "description": (tool.get("summary") or tool["path"]),
+        "inputSchema": schema,
+    }
+
+
+def _build_argv(tool: dict, arguments: dict) -> list[str]:
+    """Turn an MCP tool call (name + JSON args) into a real scbe argv."""
+    argv = tool["path"].split(" ")
+    for arg in tool.get("args", []):
+        name = arg["name"]
+        if name not in arguments:
+            continue
+        value = arguments[name]
+        if arg.get("kind") == "flag":
+            flag = (arg.get("flags") or ["--" + name])[0]
+            if arg["type"] == "boolean":
+                if value:
+                    argv.append(flag)
+            else:
+                argv += [flag, str(value)]
+        else:  # positional
+            if isinstance(value, list):
+                argv += [str(v) for v in value]
+            else:
+                argv.append(str(value))
+    if tool.get("supports_json"):
+        argv.append("--json")
+    return argv
+
+
+def _run_tool(tools_by_name: dict, name: str, arguments: dict) -> dict:
+    """Execute a tool call; return an MCP tool result (content + isError)."""
+    tool = tools_by_name.get(name)
+    if tool is None:
+        return {"content": [{"type": "text", "text": f"unknown tool: {name}"}], "isError": True}
+    argv = _build_argv(tool, arguments or {})
+    try:
+        proc = subprocess.run(SCBE + argv, cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=240)
+    except Exception as exc:  # noqa: BLE001 - report any spawn failure to the caller
+        return {"content": [{"type": "text", "text": f"exec error: {exc}"}], "isError": True}
+    out = proc.stdout.strip() or proc.stderr.strip()
+    return {"content": [{"type": "text", "text": out}], "isError": proc.returncode != 0}
+
+
+def _handle(request: dict, tools: list[dict], tools_by_name: dict) -> dict | None:
+    method = request.get("method")
+    rid = request.get("id")
+    if method == "initialize":
+        result = {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "scbe-cli", "version": "1.0.0"},
+        }
+    elif method == "tools/list":
+        result = {"tools": [_to_mcp_tool(t) for t in tools]}
+    elif method == "tools/call":
+        params = request.get("params") or {}
+        result = _run_tool(tools_by_name, params.get("name", ""), params.get("arguments") or {})
+    elif method in ("notifications/initialized", "initialized"):
+        return None  # notification, no response
+    else:
+        return {"jsonrpc": "2.0", "id": rid, "error": {"code": -32601, "method": method}}
+    return {"jsonrpc": "2.0", "id": rid, "result": result}
+
+
+def serve() -> int:
+    tools = _load_tools()
+    tools_by_name = {"scbe_" + t["name"].replace(".", "_").replace("-", "_"): t for t in tools}
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        response = _handle(request, tools, tools_by_name)
+        if response is not None:
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+    return 0
+
+
+def self_test() -> int:
+    """Exercise initialize + tools/list + a real tools/call without a client."""
+    tools = _load_tools()
+    by_name = {"scbe_" + t["name"].replace(".", "_").replace("-", "_"): t for t in tools}
+    init = _handle({"jsonrpc": "2.0", "id": 1, "method": "initialize"}, tools, by_name)
+    listed = _handle({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}, tools, by_name)
+    n = len(listed["result"]["tools"])
+    call = _handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "scbe_score", "arguments": {"text": "hello world"}},
+        },
+        tools,
+        by_name,
+    )
+    out = call["result"]["content"][0]["text"]
+    ok = init["result"]["serverInfo"]["name"] == "scbe-cli" and n > 0 and not call["result"].get("isError")
+    print("initialize: ok")
+    print(f"tools/list: {n} SCBE tools exposed")
+    print(f"tools/call scbe_score(text='hello world') -> {out[:120]}")
+    print("SELF-TEST PASSED" if ok else "SELF-TEST FAILED")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    return serve()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Three additive, AI-callable tools for the SCBE CLI. Each new command auto-joins `scbe manifest`, so an AI sees them over MCP. Branch is **off `main`**, exactly these 3 commits — no entanglement with WIP branches.

## What's added
**1. MCP bridge** (`tools/mcp/scbe_cli_server.py`, `requirements.txt`)
Zero-dependency MCP stdio server: discovers the catalog from `scbe manifest`, and on a tool call runs the real `scbe` CLI. Any MCP client (Claude Desktop, gemini-cli, the PowerShell shell's AI) can list and invoke the whole toolset.

**2. `scbe numfind`** (`src/numtheory.py`) — fast, exact integer number-finding
- `isprime` (deterministic Miller–Rabin < ~3.3e24), `factor` (Pollard rho/Brent + wall-clock budget), `nth`, `next`, `primes` (segmented Sieve of Eratosthenes).

**3. `scbe crosstalk`** (`src/fleet_crosstalk.py`) — governed AI-to-AI fleet dialogue
- Agents take turns; every turn is screened by the entropy sieve (`pipeline_quick_score`); a flagged turn (DENY/ESCALATE/QUARANTINE) is withheld from shared context. Offline (mechanical ELIZA, no keys) or live (`ai_ask` → any backend).

**4. `scbe primecat`** (`src/prime_category.py`) — prime-coded categories on the sieve
- Assign each category a distinct prime, encode an item's categories as a product (squarefree Gödel code), sort/filter by a target category via divisibility, decode via factorization.

## Verification
- **64 unit tests** pass (`test_numtheory` 46, `test_fleet_crosstalk` 8, `test_prime_category` 10).
- `scbe manifest` → **88 tools**; MCP self-test exposes 88.
- 20-digit semiprime factors in ~0.24s; Carmichael numbers correctly composite; cross-talk gate withholds flagged turns; primecat code/decode round-trips.

Additive only — new files plus `+303` lines in `scbe.py` (new command handlers + parsers). No existing code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)