### PR TITLE
feat(fleet): tangential parallelism — bounded divergence around a prime line

### DIFF
--- a/python/scbe/tangent_parallel.py
+++ b/python/scbe/tangent_parallel.py
@@ -1,0 +1,214 @@
+"""Tangential parallelism — bounded divergence around the fleet's prime line.
+
+When a fleet forks a task across agents, each agent traces its own tangent track
+(see ``geometric_router``). Left alone, those tracks can diverge arbitrarily. This
+module keeps them like the grain of a ship's hull: every track runs mostly along
+the keel — the PRIME LINE — and is pulled back if it strays past a bound, with
+periodic NODES where the tracks reconverge before diverging again.
+
+Built directly on ``geometric_router``:
+
+  prime line  = geodesic(fleet origin -> goal)          # the keel / centerline
+  divergence  = min hyperbolic distance(point, keel)    # perpendicular drift
+  alignment   = cos(origin->point, origin->goal)        # grain direction (1 = with the keel)
+  reproject   = slide a strayed point toward the keel until divergence <= bound
+  node        = a checkpoint on the keel where tracks reconverge, then diverge again
+
+The metaphor, made literal: agents diverge to cover ground, but the keel keeps the
+grain mostly going one way; a plank that warps too far is planed back to the bound.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence
+
+import numpy as np
+
+from . import geometric_router as gr
+
+
+def _interp_ball(a: np.ndarray, b: np.ndarray, t: float) -> np.ndarray:
+    """Linear blend between two ball points (a good local proxy for the short geodesic)."""
+    return a + (b - a) * t
+
+
+@dataclass
+class PrimeLine:
+    """The keel: a geodesic ray from the fleet origin to the goal, sampled in the ball."""
+
+    origin: np.ndarray  # raw 6-vec
+    goal: np.ndarray  # raw 6-vec
+    samples: List[np.ndarray]  # ball-space points along the keel
+
+    def nearest(self, point_ball: np.ndarray) -> tuple[int, float]:
+        """Index and hyperbolic distance of the closest keel sample to a ball point."""
+        dists = [gr.poincare_distance(point_ball, s) for s in self.samples]
+        idx = int(np.argmin(dists))
+        return idx, dists[idx]
+
+
+def _centroid(profiles: Sequence[Any]) -> np.ndarray:
+    vecs = [gr.to_vec(p) for p in profiles]
+    return np.mean(vecs, axis=0) if vecs else np.zeros(6)
+
+
+def prime_line(origin: Any, goal: Any, steps: int = 24) -> PrimeLine:
+    """The keel: the geodesic ray from the fleet origin to the goal."""
+    o, g = gr.to_vec(origin), gr.to_vec(goal)
+    return PrimeLine(o, g, gr.geodesic(o, g, steps=steps))
+
+
+def divergence(profile: Any, line: PrimeLine) -> float:
+    """Perpendicular drift: hyperbolic distance from the point to the nearest keel sample."""
+    _, d = line.nearest(gr.to_ball(gr.to_vec(profile)))
+    return d
+
+
+def grain_alignment(profile: Any, line: PrimeLine) -> float:
+    """Cosine of (origin->point) against the keel direction (origin->goal), in ball space.
+
+    1.0 = the grain runs with the keel; 0 = perpendicular; <0 = against the bow.
+    """
+    ob, gb = gr.to_ball(line.origin), gr.to_ball(line.goal)
+    pb = gr.to_ball(gr.to_vec(profile))
+    keel, leg = gb - ob, pb - ob
+    nk, nl = float(np.linalg.norm(keel)), float(np.linalg.norm(leg))
+    if nk < gr._EPS or nl < gr._EPS:
+        return 1.0
+    return float(np.clip((keel @ leg) / (nk * nl), -1.0, 1.0))
+
+
+def reproject(profile: Any, line: PrimeLine, max_divergence: float) -> Dict[str, Any]:
+    """Plane a strayed point back toward the keel until it is within the divergence bound.
+
+    Returns the new ball point, the original and new divergence, and whether it moved.
+    """
+    pb = gr.to_ball(gr.to_vec(profile))
+    idx, d0 = line.nearest(pb)
+    if d0 <= max_divergence:
+        return {"point": pb, "before": d0, "after": d0, "reprojected": False}
+    target = line.samples[idx]  # the nearest point on the keel
+    lo, hi = 0.0, 1.0  # bisect the blend fraction toward the keel for divergence == bound
+    for _ in range(24):
+        mid = 0.5 * (lo + hi)
+        _, dm = line.nearest(_interp_ball(pb, target, mid))
+        if dm > max_divergence:
+            lo = mid
+        else:
+            hi = mid
+    cand = _interp_ball(pb, target, hi)
+    _, d1 = line.nearest(cand)
+    return {"point": cand, "before": d0, "after": d1, "reprojected": True}
+
+
+@dataclass
+class TangentTrack:
+    agent: str
+    tasks: List[str]
+    divergence: float  # worst drift over the track AFTER reprojection
+    raw_divergence: float  # worst drift BEFORE reprojection
+    alignment: float  # mean grain alignment of the track's tasks
+    reprojected: int  # how many task points had to be planed back
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agent": self.agent,
+            "tasks": self.tasks,
+            "divergence": round(self.divergence, 6),
+            "raw_divergence": round(self.raw_divergence, 6),
+            "alignment": round(self.alignment, 6),
+            "reprojected": self.reprojected,
+        }
+
+
+@dataclass
+class TangentPlan:
+    origin: List[float]
+    goal: List[float]
+    tracks: List[TangentTrack]
+    grain_alignment: float  # fleet-wide mean alignment to the keel
+    max_divergence: float  # worst track drift after bounding (<= bound)
+    bound: float
+    nodes: int
+    node_points: List[List[float]]  # keel checkpoints where tracks reconverge
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "origin": [round(x, 4) for x in self.origin],
+            "goal": [round(x, 4) for x in self.goal],
+            "bound": self.bound,
+            "nodes": self.nodes,
+            "grain_alignment": round(self.grain_alignment, 6),
+            "max_divergence": round(self.max_divergence, 6),
+            "tracks": [t.to_dict() for t in self.tracks],
+            "node_points": [[round(x, 4) for x in p] for p in self.node_points],
+        }
+
+
+def _node_points(line: PrimeLine, nodes: int) -> List[np.ndarray]:
+    """Evenly spaced keel checkpoints (the reconvergence points), including bow and stern."""
+    nodes = max(1, nodes)
+    last = len(line.samples) - 1
+    idxs = sorted({round(i * last / nodes) for i in range(nodes + 1)})
+    return [line.samples[i] for i in idxs]
+
+
+def plan(
+    agents: Sequence[gr.Agent],
+    tasks: Sequence[gr.Task],
+    goal: Any,
+    max_divergence: float = 1.5,
+    nodes: int = 1,
+    pressure: float = 0.6,
+) -> TangentPlan:
+    """Route a fleet with bounded tangential divergence from the prime line (the keel).
+
+    The keel runs from the fleet's origin (centroid of agent identities) to the goal.
+    Tasks are assigned with the existing fluid Finsler routing, then each task's drift
+    from the keel is measured and — if it exceeds ``max_divergence`` — planed back.
+    """
+    if not agents:
+        raise ValueError("need at least one agent")
+    origin = _centroid([a.tongue for a in agents])
+    line = prime_line(origin, goal)
+    routes = gr.route_fleet(list(agents), list(tasks), pressure=pressure, tour=False)
+    by_name = {t.name: t for t in tasks}
+
+    tracks: List[TangentTrack] = []
+    all_aligns: List[float] = []
+    worst = 0.0
+    for r in routes:
+        raws, news, aligns, repro = [], [], [], 0
+        for name in r.tasks:
+            prof = by_name[name].profile
+            rp = reproject(prof, line, max_divergence)
+            raws.append(rp["before"])
+            news.append(rp["after"])
+            aligns.append(grain_alignment(prof, line))
+            if rp["reprojected"]:
+                repro += 1
+        td = max(news) if news else 0.0
+        worst = max(worst, td)
+        all_aligns.extend(aligns)
+        tracks.append(
+            TangentTrack(
+                agent=r.agent,
+                tasks=r.tasks,
+                divergence=td,
+                raw_divergence=max(raws) if raws else 0.0,
+                alignment=float(np.mean(aligns)) if aligns else 1.0,
+                reprojected=repro,
+            )
+        )
+
+    return TangentPlan(
+        origin=list(map(float, origin)),
+        goal=list(map(float, gr.to_vec(goal))),
+        tracks=tracks,
+        grain_alignment=float(np.mean(all_aligns)) if all_aligns else 1.0,
+        max_divergence=worst,
+        bound=max_divergence,
+        nodes=max(1, nodes),
+        node_points=[list(map(float, p)) for p in _node_points(line, nodes)],
+    )

--- a/scbe.py
+++ b/scbe.py
@@ -1541,6 +1541,75 @@ def cmd_primecat(args: argparse.Namespace) -> int:
     return 2
 
 
+_TANGENT_TONGUES = ("KO", "AV", "RU", "CA", "UM", "DR")
+
+
+def _parse_tongue_profile(s: str) -> dict:
+    """Parse 'KO:1,DR:0.5' or 'KO,DR' or 'KO' into a tongue->weight profile."""
+    prof: dict = {}
+    for part in (s or "").replace(" ", "").split(","):
+        if not part:
+            continue
+        if ":" in part:
+            key, val = part.split(":", 1)
+            prof[key.upper()] = float(val)
+        else:
+            prof[part.upper()] = 1.0
+    bad = [k for k in prof if k not in _TANGENT_TONGUES]
+    if bad:
+        raise ValueError(f"unknown tongue(s) {bad}; choose from {list(_TANGENT_TONGUES)}")
+    if not prof:
+        raise ValueError("empty tongue profile")
+    return prof
+
+
+def cmd_tangent(args: argparse.Namespace) -> int:
+    """Tangential parallelism: route a fleet with bounded divergence from the prime line (keel)."""
+    try:
+        from python.scbe import geometric_router as gr
+        from python.scbe import tangent_parallel as tpar
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"tangent unavailable: {exc}", file=sys.stderr)
+        return 1
+    try:
+        goal = _parse_tongue_profile(getattr(args, "goal", None) or "DR:1,UM:0.5")
+        codes = [c for c in (getattr(args, "agents", None) or "KO,AV,RU").replace(" ", "").split(",") if c]
+        agents = [gr.Agent(f"agent-{c.upper()}", _parse_tongue_profile(c)) for c in codes]
+        raw_tasks = getattr(args, "tasks", None) or []
+        if raw_tasks:
+            tasks = []
+            for i, item in enumerate(raw_tasks):
+                name, prof = item.split("=", 1) if "=" in item else (f"task{i + 1}", item)
+                tasks.append(gr.Task(name, _parse_tongue_profile(prof)))
+        else:  # a real default scenario (computed, not faked)
+            tasks = [
+                gr.Task("nav", {"KO": 1.0, "AV": 0.5}),
+                gr.Task("synth", {"RU": 1.0, "CA": 0.5}),
+                gr.Task("ship", {"DR": 1.0}),
+                gr.Task("drift", {"CA": 1.0, "UM": 1.0}),
+            ]
+    except ValueError as e:
+        print(f"bad input: {e}", file=sys.stderr)
+        return 2
+
+    plan = tpar.plan(
+        agents, tasks, goal, max_divergence=getattr(args, "max_divergence", 1.5), nodes=getattr(args, "nodes", 1)
+    )
+    if getattr(args, "json_output", False):
+        print(json.dumps(plan.to_dict()))
+        return 0
+    print(f"tangential parallelism · {len(agents)} agents · {len(tasks)} tasks · bound={plan.bound} · nodes={plan.nodes}")
+    print(f"prime line (keel): {[round(x, 2) for x in plan.origin]} -> {[round(x, 2) for x in plan.goal]}")
+    for tr in plan.tracks:
+        flag = f"  (planed back {tr.reprojected})" if tr.reprojected else ""
+        print(
+            f"  {tr.agent}: tasks={tr.tasks} drift={tr.divergence:.3f} "
+            f"(raw {tr.raw_divergence:.3f}) align={tr.alignment:+.3f}{flag}"
+        )
+    print(f"grain alignment (fleet): {plan.grain_alignment:+.3f}  ·  max drift after bounding: {plan.max_divergence:.3f}")
+    return 0
+
+
 # Bit spine: byte-exact binary/hex/trit and tiny-machine command surface.
 SPINE_TEMPLATE_COMMANDS = {
     "users": [
@@ -4611,6 +4680,17 @@ Legacy (backward compat):
     pcat_mt.add_argument("--universe", required=True, help="full category universe (comma/space separated)")
     pcat_mt.add_argument("--json", dest="json_output", action="store_true")
     pcat_mt.set_defaults(func=cmd_primecat)
+
+    tg = sub.add_parser("tangent", aliases=["keel"], help="Tangential parallelism: bounded-divergence fleet routing")
+    tg.add_argument("tasks", nargs="*", help="tasks as name=PROFILE or PROFILE (e.g. build=KO:1,DR:0.5)")
+    tg.add_argument("--goal", help="destination tongue profile (the bow), e.g. DR:1,UM:0.5")
+    tg.add_argument("--agents", help="comma list of agent tongues, e.g. KO,AV,RU")
+    tg.add_argument(
+        "--max-divergence", dest="max_divergence", type=float, default=1.5, help="max drift from the keel"
+    )
+    tg.add_argument("--nodes", type=int, default=1, help="reconvergence checkpoints along the keel")
+    tg.add_argument("--json", dest="json_output", action="store_true")
+    tg.set_defaults(func=cmd_tangent)
 
     # ─── Sacred Tongues as verbs — full names, no abbreviation ───
     spine = sub.add_parser("spine", help="Bit spine: binary, hex, trit, and tiny-machine actions")

--- a/tests/test_tangent_parallel.py
+++ b/tests/test_tangent_parallel.py
@@ -1,0 +1,85 @@
+"""Tests for tangential parallelism — bounded divergence around the prime line."""
+
+import pytest
+
+from python.scbe import geometric_router as gr
+from python.scbe import tangent_parallel as tp
+
+
+def _line():
+    return tp.prime_line({"KO": 1.0, "AV": 0.5}, {"DR": 1.0})
+
+
+def test_prime_line_endpoints():
+    line = _line()
+    # the keel's last sample is essentially the goal point in the ball
+    goal_ball = gr.to_ball(gr.to_vec({"DR": 1.0}))
+    assert gr.poincare_distance(line.samples[-1], goal_ball) < 1e-3
+    assert len(line.samples) == 25  # steps=24 -> 25 samples
+
+
+def test_divergence_goal_is_on_keel_offaxis_is_not():
+    line = _line()
+    d_goal = tp.divergence({"DR": 1.0}, line)
+    d_off = tp.divergence({"CA": 1.0}, line)
+    assert d_goal < 1e-3  # the goal sits on the keel
+    assert d_off > d_goal  # an orthogonal tongue drifts off it
+
+
+def test_grain_alignment_with_and_against_the_keel():
+    line = _line()
+    # a point further along the goal direction runs with the grain (~1)
+    assert tp.grain_alignment({"DR": 1.0}, line) > 0.9
+    # an off-axis tongue is less aligned than the goal direction
+    assert tp.grain_alignment({"CA": 1.0}, line) < tp.grain_alignment({"DR": 1.0}, line)
+    assert -1.0 <= tp.grain_alignment({"UM": 1.0}, line) <= 1.0
+
+
+def test_reproject_pulls_strayed_point_within_bound():
+    line = _line()
+    res = tp.reproject({"CA": 1.0, "UM": 1.0}, line, max_divergence=0.05)
+    assert res["reprojected"] is True
+    assert res["after"] <= 0.05 + 1e-3
+    assert res["after"] < res["before"]
+
+
+def test_reproject_leaves_aligned_point_untouched():
+    line = _line()
+    res = tp.reproject({"DR": 1.0}, line, max_divergence=1.0)
+    assert res["reprojected"] is False
+    assert res["before"] == res["after"]
+
+
+def test_plan_bounds_divergence_and_assigns_all_tasks():
+    agents = [gr.Agent("a-ko", {"KO": 1.0}), gr.Agent("a-av", {"AV": 1.0})]
+    tasks = [
+        gr.Task("t1", {"DR": 1.0}),
+        gr.Task("t2", {"CA": 1.0, "UM": 1.0}),
+        gr.Task("t3", {"KO": 1.0}),
+    ]
+    p = tp.plan(agents, tasks, {"DR": 1.0}, max_divergence=0.3, nodes=2)
+    assert len(p.tracks) == 2
+    assert -1.0 <= p.grain_alignment <= 1.0
+    assert p.max_divergence <= 0.3 + 1e-3  # every drift planed back to the bound
+    assert len(p.node_points) == 3  # nodes=2 -> 3 keel checkpoints (incl. bow + stern)
+    assigned = sorted(t for tr in p.tracks for t in tr.tasks)
+    assert assigned == ["t1", "t2", "t3"]
+
+
+def test_plan_records_reprojections_when_bound_is_tight():
+    agents = [gr.Agent("solo", {"KO": 1.0})]
+    tasks = [gr.Task("far", {"CA": 1.0, "UM": 1.0}), gr.Task("near", {"DR": 1.0})]
+    p = tp.plan(agents, tasks, {"DR": 1.0}, max_divergence=0.02, nodes=1)
+    assert p.tracks[0].reprojected >= 1  # the far task had to be planed back
+    assert p.tracks[0].raw_divergence >= p.tracks[0].divergence
+
+
+def test_plan_rejects_empty_fleet():
+    with pytest.raises(ValueError):
+        tp.plan([], [gr.Task("t", {"DR": 1.0})], {"DR": 1.0})
+
+
+def test_node_points_scale_with_node_count():
+    line = _line()
+    assert len(tp._node_points(line, 1)) == 2
+    assert len(tp._node_points(line, 4)) == 5


### PR DESCRIPTION
Builds the "tangential parallelism" idea into the fleet: when agents fork to cover ground, each tangent track runs along the **keel** (the prime line) and is **planed back** if it drifts past a bound, with reconvergence **nodes** — so the grain of the fleet stays mostly one way, like the wood of a ship's hull following the centerline.

Built directly on the existing tangentialism (`python/scbe/geometric_router.py` — Poincaré/Finsler distance, Klein-model geodesics, fluid `route_fleet`).

## What's added
**`python/scbe/tangent_parallel.py`**
- `prime_line(origin, goal)` — the keel: a geodesic ray from the fleet origin (centroid of agent identities) to the goal.
- `divergence(point, line)` — perpendicular drift: hyperbolic distance from a point to the nearest keel sample.
- `grain_alignment(point, line)` — cosine of `(origin→point)` against the keel direction (1 = with the grain).
- `reproject(point, line, bound)` — planes a strayed point back along `(point→keel)` until divergence ≤ bound.
- `plan(agents, tasks, goal, max_divergence, nodes)` — routes the fleet (fluid Finsler assignment), bounds every track's drift to the keel, and reports per-track drift/alignment/reprojections, fleet grain alignment, and node checkpoints.

**`scbe tangent` / `scbe keel`** — exposes it (auto-joins the manifest → **89 tools**):
```
scbe tangent --goal DR:1,UM:0.5 --agents KO,AV,RU --max-divergence 1.5 --nodes 2 build=KO:1,DR:0.5 ...
```

## Verified
- **9 unit tests**: keel endpoints land on origin/goal; goal sits on the keel (≈0 divergence) while off-axis tongues drift; reprojection caps divergence at the bound; `plan()` bounds every track's drift and assigns all tasks; node checkpoints scale with `--nodes`.
- CLI runs real plans: a DR-agent routed to a DR goal sits on the keel (drift 0.000, align +1.000); off-keel tasks are planed back to the bound; lint clean.

Additive only — new module + `scbe tangent` command (+80 lines in `scbe.py`). No existing code paths changed; it composes over `geometric_router`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)