### PR TITLE
feat(forge): 14 moves + planner/organizer blocks — due-dates delivered

### DIFF
--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -87,8 +87,47 @@ _MOVES: dict[str, dict] = {
         ),
         "register": '    "clear": {"fn": _cmd_clear, "help": "remove everything", "args": []},',
     },
+    "due": {
+        "desc": 'set a due date on an item by index',
+        "handler": 'def _cmd_due(args, items):\n    items[args.index]["due"] = args.date\n    print(f"due {args.date}: {items[args.index][\'text\']}")',
+        "register": '    "due": {"fn": _cmd_due, "help": "set a due date by index", "args": [("index", {"type": int}), ("date", {})]},',
+    },
+    "agenda": {
+        "desc": 'list items showing due dates',
+        "handler": 'def _cmd_agenda(args, items):\n    if not items:\n        print("(empty)")\n    for i, x in enumerate(items):\n        mark = "x" if x["done"] else " "\n        due = x.get("due")\n        suffix = f" (due: {due})" if due else ""\n        print(f"{i}. [{mark}] {x[\'text\']}{suffix}")',
+        "register": '    "agenda": {"fn": _cmd_agenda, "help": "list items with due dates", "args": []},',
+    },
+    "find": {
+        "desc": 'search items by a word and print the matching ones with their index',
+        "handler": 'def _cmd_find(args, items):\n    needle = args.word.lower()\n    hits = [(i, x) for i, x in enumerate(items) if needle in x["text"].lower()]\n    if not hits:\n        print(f"no matches for: {args.word}")\n        return\n    for i, x in hits:\n        mark = "x" if x["done"] else " "\n        print(f"{i}. [{mark}] {x[\'text\']}")',
+        "register": '    "find": {"fn": _cmd_find, "help": "find items by word", "args": [("word", {})]},',
+    },
+    "edit": {
+        "desc": "change an item's text by index",
+        "handler": 'def _cmd_edit(args, items):\n    old = items[args.index]["text"]\n    items[args.index]["text"] = args.text\n    print(f"edited {args.index}: {old!r} -> {args.text!r}")',
+        "register": '    "edit": {"fn": _cmd_edit, "help": "edit item text by index", "args": [("index", {"type": int}), ("text", {})]},',
+    },
+    "priority": {
+        "desc": 'set priority (high/medium/low) on an item by index',
+        "handler": 'def _cmd_priority(args, items):\n    level = args.level.lower()\n    valid = ("high", "medium", "low")\n    if level not in valid:\n        print(f"invalid priority: {args.level} (use high/medium/low)")\n        return\n    items[args.index]["priority"] = level\n    print(f"priority: {items[args.index][\'text\']} -> {level}")',
+        "register": '    "priority": {"fn": _cmd_priority, "help": "set priority high/medium/low on an item", "args": [("index", {"type": int}), ("level", {})]},',
+    },
+    "sort": {
+        "desc": 'reorder items by priority (high first)',
+        "handler": 'def _cmd_sort(args, items):\n    rank = {"high": 0, "medium": 1, "low": 2, "none": 3}\n    items.sort(key=lambda x: rank.get(x.get("priority", "none"), 3))\n    print(f"sorted {len(items)} items by priority")',
+        "register": '    "sort": {"fn": _cmd_sort, "help": "sort items by priority", "args": []},',
+    },
+    "tag": {
+        "desc": 'tag an item by index',
+        "handler": 'def _cmd_tag(args, items):\n    item = items[args.index]\n    item.setdefault("tags", []).append(args.label)\n    print(f"tagged {args.index} with {args.label}: {item[\'tags\']}")',
+        "register": '    "tag": {"fn": _cmd_tag, "help": "tag an item", "args": [("index", {"type": int}), ("label", {})]},',
+    },
+    "export": {
+        "desc": 'write items to items.md as a checklist',
+        "handler": 'def _cmd_export(args, items):\n    from pathlib import Path\n    out = Path("items.md")\n    lines = ["# Items", ""]\n    for x in items:\n        mark = "x" if x["done"] else " "\n        lines.append(f"- [{mark}] {x[\'text\']}")\n    if not items:\n        lines.append("_(no items)_")\n    out.write_text("\\n".join(lines) + "\\n", encoding="utf-8")\n    print(f"exported {len(items)} items -> {out}")',
+        "register": '    "export": {"fn": _cmd_export, "help": "write items to items.md checklist", "args": []},',
+    },
 }
-
 _APP_TEMPLATE = '''#!/usr/bin/env python3
 """{name} -- forged by Aether Speed Forge from {nmoves} moves: {movestr}"""
 import argparse
@@ -153,6 +192,16 @@ _PUZZLES = {
             (["count"], "2 items"),
             (["clear"], "cleared 2"),
             (["count"], "0 items"),
+        ],
+    },
+    "planner": {
+        "goal": "Plan tasks with due dates, priorities, and search.",
+        "steps": [
+            (["add", "buy milk"], "added"),
+            (["due", "0", "friday"], "due friday"),
+            (["agenda"], "friday"),
+            (["priority", "0", "high"], "priority"),
+            (["find", "milk"], "buy milk"),
         ],
     },
 }

--- a/scripts/forge_ai.py
+++ b/scripts/forge_ai.py
@@ -31,6 +31,8 @@ _BLOCKS: dict[str, list[str]] = {
     "tracker": ["add", "list", "done"],     # a thing you add to, see, and complete
     "counter": ["count", "clear"],           # totals + reset
     "manager": ["tracker", "counter", "remove"],  # a BLOCK OF BLOCKS
+    "planner": ["tracker", "due", "agenda", "priority", "sort"],  # a day-planner
+    "organizer": ["tracker", "tag", "find", "export"],           # tag/search/export
 }
 
 

--- a/scripts/forge_speak.py
+++ b/scripts/forge_speak.py
@@ -28,14 +28,20 @@ _INTENT = {
     "count": ["count", "total", "how many", "number of", "tally"],
     "clear": ["clear", "reset", "empty", "wipe", "delete all", "start over"],
     "remove": ["remove", "delete", "drop", "take off", "get rid"],
+    "due": ["due", "deadline", "due date"],
+    "agenda": ["agenda", "schedule", "what's due", "whats due", "upcoming"],
+    "find": ["find", "search", "look for", "lookup"],
+    "edit": ["edit", "rename", "change the"],
+    "priority": ["priority", "important", "urgent", "rank"],
+    "sort": ["sort", "reorder", "in order"],
+    "tag": ["tag", "label", "categor"],
+    "export": ["export", "save to file", "markdown"],
 }
 _TRACKER_WORDS = ("task", "todo", "to-do", "to do", "tracker", "checklist", "list of")
-# things we honestly do NOT have a move for yet (so we say so instead of faking)
+# things we honestly still do NOT have a move for (so we say so instead of faking)
 _GAPS = {
-    "due date": "due-dates / deadlines", "deadline": "due-dates / deadlines",
-    "priority": "priority levels", "tag": "tags / labels", "label": "tags / labels",
-    "sort": "sorting", "search": "search / filter", "filter": "search / filter",
-    "remind": "reminders", "category": "categories", "edit": "editing an item",
+    "remind": "reminders", "recur": "recurring tasks", "repeat": "recurring tasks",
+    "sync": "cloud sync", "share": "sharing with people",
 }
 
 
@@ -67,6 +73,22 @@ def synth_spec(caps: list[str], text: str):
         steps.append((["remove", "0"], "removed"))
     if "clear" in caps:
         steps.append((["clear"], "cleared"))
+    if "due" in caps and "add" in caps:
+        steps.append((["due", "0", "friday"], "due friday"))
+    if "agenda" in caps:
+        steps.append((["agenda"], "milk" if "add" in caps else None))
+    if "priority" in caps and "add" in caps:
+        steps.append((["priority", "0", "high"], "priority"))
+    if "find" in caps and "add" in caps:
+        steps.append((["find", "milk"], "milk"))
+    if "tag" in caps and "add" in caps:
+        steps.append((["tag", "0", "home"], None))
+    if "sort" in caps and "add" in caps:
+        steps.append((["sort"], None))
+    if "edit" in caps and "add" in caps:
+        steps.append((["edit", "0", "bread"], "edited"))
+    if "export" in caps:
+        steps.append((["export"], None))
     if not steps and caps:
         steps.append(([caps[0]], None))
     return {"goal": text.strip(), "steps": steps}


### PR DESCRIPTION
Grows the Forge toward bigger projects. 8 new moves authored + **verified by running** via a fan-out workflow, integrated cleanly from the structured output: `due, agenda, find, edit, priority, sort, tag, export` (6 → 14 moves). Two bigger blocks (`planner`, `organizer`) and a `planner` puzzle.

Closes the promised gap: **"I want a task tracker with due dates" now builds the `due` move** instead of reporting a gap.

Verified by execution:
- `puzzle planner` → 5 moves → 83-line app, all checks pass.
- `forge_ai auto planner` → 2 bigger blocks → 126-line app → SOLVED.
- `forge_speak "...with due dates"` → builds `due`, no gap, VERIFIED.
- every build still carries its lossless prime signature + glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Item management capabilities: set due dates, view agenda with dates, case-insensitive search, edit items, assign priority levels (high/medium/low), sort by priority, add tags, and export checklists to markdown.
  * Enhanced natural language recognition for task-tracking operations.

* **Tests**
  * Added validation test for item-management workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->