### PR TITLE
fix(research): clear packet markdown whitespace

### DIFF
--- a/docs/research/RESEARCH_PACKET_STANDARD.md
+++ b/docs/research/RESEARCH_PACKET_STANDARD.md
@@ -1,6 +1,6 @@
 # AetherMoore Research Packet Standard
 
-Status: operating standard for public research packets  
+Status: operating standard for public research packets
 Updated: 2026-06-17
 
 This standard defines what "convert a note into research" means for AetherMoore.
@@ -64,4 +64,3 @@ can be useful leads, but they are not enough for a research-grade packet.
 These packets do not make legal claims, legal advice, patentability opinions,
 compliance certifications, or guarantees. They are technical research artifacts
 with explicit uncertainty, source provenance, and validation status.
-

--- a/docs/research/space_life_support_animals_husbandry_energy_2026-06-17.md
+++ b/docs/research/space_life_support_animals_husbandry_energy_2026-06-17.md
@@ -1,8 +1,8 @@
 # Space Life-Support Animals, Husbandry, and Micro-Energy Concepts
 
-Status: Idea Seed -> Research Brief scaffold  
-Date: 2026-06-17  
-Topic lanes: space systems, life systems, energy systems  
+Status: Idea Seed -> Research Brief scaffold
+Date: 2026-06-17
+Topic lanes: space systems, life systems, energy systems
 Legal boundary: no legal claims, no patentability claim, no compliance claim
 
 ## Abstract
@@ -138,4 +138,3 @@ spacecraft systems budgets.
   and resource-loop ideas?
 - What animal studies already exist that make this direction unnecessary,
   unethical, or technically useful?
-


### PR DESCRIPTION
## Summary

Follow-up to #2324. The research library auto-merged, but the first commit carried Markdown hard-line-break whitespace that failed the deterministic review/lint gate after merge.

This PR removes trailing whitespace and final blank-line issues from:

- `docs/research/RESEARCH_PACKET_STANDARD.md`
- `docs/research/space_life_support_animals_husbandry_energy_2026-06-17.md`

## Validation

- `git diff --check`
- `python scripts/research/build_research_library.py --check`
- `python -m pytest tests/test_research_library_catalog.py tests/test_vercel_launch_bridge.py -q`

## Boundary

No content/claim expansion. This is only the lint cleanup for the already-merged research-library packet.