### PR TITLE
chore(format): restore main lint cleanliness

### DIFF
--- a/scripts/aether_console.py
+++ b/scripts/aether_console.py
@@ -10,6 +10,7 @@ Run it:
     python scripts/aether_console.py
     python scripts/aether_console.py --demo     # non-interactive render (for tests)
 """
+
 from __future__ import annotations
 
 import json
@@ -23,8 +24,14 @@ REPO = Path(__file__).resolve().parent.parent
 CATALOG = Path(__file__).resolve().parent / "powershell" / "AetherMenu.catalog.json"
 
 _C = {
-    "cyan": "\033[36m", "dim": "\033[2m", "green": "\033[32m", "yellow": "\033[33m",
-    "red": "\033[31m", "bold": "\033[1m", "mag": "\033[35m", "reset": "\033[0m",
+    "cyan": "\033[36m",
+    "dim": "\033[2m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "red": "\033[31m",
+    "bold": "\033[1m",
+    "mag": "\033[35m",
+    "reset": "\033[0m",
 }
 
 

--- a/scripts/aether_tui.py
+++ b/scripts/aether_tui.py
@@ -11,6 +11,7 @@ fiction over the real SCBE tools.
 
 Falls back to scripts/aether_console.py if Textual isn't installed.
 """
+
 from __future__ import annotations
 
 import json
@@ -69,10 +70,10 @@ class AetherApp(App):
     def __init__(self):
         super().__init__()
         self.cats = load_catalog()
-        self.mode = "hub"          # hub | scene | await_input | await_confirm
+        self.mode = "hub"  # hub | scene | await_input | await_confirm
         self.scene = None
-        self.pending = None        # action awaiting an input value
-        self.pending_cmd = None    # command awaiting y/n confirm
+        self.pending = None  # action awaiting an input value
+        self.pending_cmd = None  # command awaiting y/n confirm
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -104,7 +105,7 @@ class AetherApp(App):
 
     def show_scene(self, cat):
         self.w("")
-        self.w(f"[bold cyan]== {cat.get('icon','')} {cat['category']} ==[/]")
+        self.w(f"[bold cyan]== {cat.get('icon', '')} {cat['category']} ==[/]")
         self.w(f"[magenta]{NARRATION.get(cat['category'], '')}[/]")
         self.w("")
         for i, a in enumerate(cat["actions"], 1):
@@ -122,9 +123,16 @@ class AetherApp(App):
         env = dict(os.environ, PYTHONPATH=".")
         try:
             proc = subprocess.Popen(
-                cmd, shell=True, cwd=str(REPO), env=env,
-                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                text=True, encoding="utf-8", errors="replace", bufsize=1,
+                cmd,
+                shell=True,
+                cwd=str(REPO),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
             )
             for line in proc.stdout:
                 self.call_from_thread(self.w, line.rstrip("\n"))
@@ -234,6 +242,7 @@ async def _selftest():
 def main():
     if "--selftest" in sys.argv:
         import asyncio
+
         asyncio.run(_selftest())
         return
     AetherApp().run()

--- a/scripts/benchmark/aether_console_benchmark.py
+++ b/scripts/benchmark/aether_console_benchmark.py
@@ -12,6 +12,7 @@ research/benchmarks/results/aether-console-<stamp>.json  (stamp via --stamp).
     python scripts/benchmark/aether_console_benchmark.py
     python scripts/benchmark/aether_console_benchmark.py --json
 """
+
 from __future__ import annotations
 
 import json
@@ -56,7 +57,11 @@ def classify(action: dict) -> str:
     if cmd.strip().startswith("gh ") or cmd.strip().startswith("git "):
         return "skip:network"
     # AI verbs need a model backend, not an engine capability
-    if cmd.startswith("python scbe.py ask") or cmd.startswith("python scbe.py do") or cmd.startswith("python scbe.py chat"):
+    if (
+        cmd.startswith("python scbe.py ask")
+        or cmd.startswith("python scbe.py do")
+        or cmd.startswith("python scbe.py chat")
+    ):
         return "skip:ai-backend"
     return "run"
 
@@ -72,8 +77,15 @@ def run_one(action: dict):
     t0 = time.perf_counter()
     try:
         proc = subprocess.run(
-            cmd, shell=True, cwd=str(REPO), env=env,
-            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=TIMEOUT,
+            cmd,
+            shell=True,
+            cwd=str(REPO),
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=TIMEOUT,
         )
         ms = (time.perf_counter() - t0) * 1000.0
         # exit 0 = pass; exit 3 = graceful "optional dependency missing" (still a real capability boundary)
@@ -81,8 +93,7 @@ def run_one(action: dict):
             return {"status": "pass", "ms": ms}
         if proc.returncode == 3:
             return {"status": "skip:optional-dep", "ms": ms}
-        return {"status": "fail", "ms": ms, "code": proc.returncode,
-                "err": (proc.stderr or proc.stdout or "")[-200:]}
+        return {"status": "fail", "ms": ms, "code": proc.returncode, "err": (proc.stderr or proc.stdout or "")[-200:]}
     except subprocess.TimeoutExpired:
         return {"status": "fail", "ms": TIMEOUT * 1000.0, "err": "timeout"}
     except Exception as e:  # pragma: no cover
@@ -101,7 +112,10 @@ def main():
             res = run_one(a)
             rows.append({"category": cat["category"], "label": a["label"], **res})
             mark = {"pass": "OK", "fail": "XX"}.get(res["status"], "--")
-            print(f"  [{mark}] {cat['category']:<24} {a['label'][:40]:<40} {res['status']:<18} {res.get('ms',0):6.0f} ms")
+            print(
+                f"  [{mark}] {cat['category']:<24} {a['label'][:40]:<40} "
+                f"{res['status']:<18} {res.get('ms', 0):6.0f} ms"
+            )
 
     run_rows = [r for r in rows if r["status"] in ("pass", "fail")]
     passed = [r for r in run_rows if r["status"] == "pass"]
@@ -118,8 +132,10 @@ def main():
         "latency_ms_max": round(max(lat) if lat else 0, 1),
     }
     print("\n" + "=" * 64)
-    print(f"  Engine capabilities: {summary['passed']}/{summary['engine_capabilities_tested']} pass "
-          f"({summary['pass_rate_pct']}%)   mean {summary['latency_ms_mean']}ms")
+    print(
+        f"  Engine capabilities: {summary['passed']}/{summary['engine_capabilities_tested']} pass "
+        f"({summary['pass_rate_pct']}%)   mean {summary['latency_ms_mean']}ms"
+    )
     print(f"  Skipped (network/AI/destructive, not engine): {summary['skipped_integration_or_destructive']}")
     print("=" * 64)
 

--- a/scripts/experiments/prime_count.py
+++ b/scripts/experiments/prime_count.py
@@ -13,6 +13,7 @@ mapping -- you pick by goal.
 
     python scripts/experiments/prime_count.py
 """
+
 from __future__ import annotations
 
 # Fermat primes -- the example template the idea uses.
@@ -35,7 +36,7 @@ def freq_octave(n: int, P: list[int], base: float = 2.0):
     if k < 0:
         return base ** (n / P[0])  # interpolate up to the first anchor
     if k >= len(P) - 1:
-        return base ** k
+        return base**k
     width = P[k + 1] - P[k]
     return base ** (k + r / width)
 
@@ -76,7 +77,6 @@ def main():
 
     print("\n2) compound primes (primorial chain -- products of the template):")
     chain = primorial_chain(P)
-    acc = 1
     for p, c in zip(P, chain):
         print(f"   x{p:<6} -> {c}")
 

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -15,9 +15,9 @@ the solve like a cube solve: moves used, lines emitted, leverage, solved y/n.
     python scripts/forge.py moves                                  # list the moves
     python scripts/forge.py puzzles                                # list the puzzles
 """
+
 from __future__ import annotations
 
-import json
 import subprocess
 import sys
 import tempfile
@@ -32,7 +32,7 @@ _MOVES: dict[str, dict] = {
     "add": {
         "desc": "append an item",
         "handler": (
-            'def _cmd_add(args, items):\n'
+            "def _cmd_add(args, items):\n"
             '    items.append({"text": args.text, "done": False})\n'
             '    print(f"added: {args.text}")'
         ),
@@ -41,37 +41,35 @@ _MOVES: dict[str, dict] = {
     "list": {
         "desc": "print all items",
         "handler": (
-            'def _cmd_list(args, items):\n'
-            '    if not items:\n'
+            "def _cmd_list(args, items):\n"
+            "    if not items:\n"
             '        print("(empty)")\n'
-            '    for i, x in enumerate(items):\n'
+            "    for i, x in enumerate(items):\n"
             '        mark = "x" if x["done"] else " "\n'
-            '        print(f"{i}. [{mark}] {x[\'text\']}")'
+            "        print(f\"{i}. [{mark}] {x['text']}\")"
         ),
         "register": '    "list": {"fn": _cmd_list, "help": "list items", "args": []},',
     },
     "done": {
         "desc": "mark an item done by index",
         "handler": (
-            'def _cmd_done(args, items):\n'
+            "def _cmd_done(args, items):\n"
             '    items[args.index]["done"] = True\n'
-            '    print(f"done: {items[args.index][\'text\']}")'
+            "    print(f\"done: {items[args.index]['text']}\")"
         ),
         "register": '    "done": {"fn": _cmd_done, "help": "mark done", "args": [("index", {"type": int})]},',
     },
     "remove": {
         "desc": "delete an item by index",
         "handler": (
-            'def _cmd_remove(args, items):\n'
-            '    x = items.pop(args.index)\n'
-            '    print(f"removed: {x[\'text\']}")'
+            "def _cmd_remove(args, items):\n" "    x = items.pop(args.index)\n" "    print(f\"removed: {x['text']}\")"
         ),
         "register": '    "remove": {"fn": _cmd_remove, "help": "remove an item", "args": [("index", {"type": int})]},',
     },
     "count": {
         "desc": "report totals",
         "handler": (
-            'def _cmd_count(args, items):\n'
+            "def _cmd_count(args, items):\n"
             '    done = sum(1 for x in items if x["done"])\n'
             '    print(f"{len(items)} items, {done} done")'
         ),
@@ -80,51 +78,51 @@ _MOVES: dict[str, dict] = {
     "clear": {
         "desc": "empty the list",
         "handler": (
-            'def _cmd_clear(args, items):\n'
-            '    n = len(items)\n'
-            '    items.clear()\n'
+            "def _cmd_clear(args, items):\n"
+            "    n = len(items)\n"
+            "    items.clear()\n"
             '    print(f"cleared {n} items")'
         ),
         "register": '    "clear": {"fn": _cmd_clear, "help": "remove everything", "args": []},',
     },
     "due": {
-        "desc": 'set a due date on an item by index',
-        "handler": 'def _cmd_due(args, items):\n    items[args.index]["due"] = args.date\n    print(f"due {args.date}: {items[args.index][\'text\']}")',
-        "register": '    "due": {"fn": _cmd_due, "help": "set a due date by index", "args": [("index", {"type": int}), ("date", {})]},',
+        "desc": "set a due date on an item by index",
+        "handler": 'def _cmd_due(args, items):\n    items[args.index]["due"] = args.date\n    print(f"due {args.date}: {items[args.index][\'text\']}")',  # noqa: E501
+        "register": '    "due": {"fn": _cmd_due, "help": "set a due date by index", "args": [("index", {"type": int}), ("date", {})]},',  # noqa: E501
     },
     "agenda": {
-        "desc": 'list items showing due dates',
-        "handler": 'def _cmd_agenda(args, items):\n    if not items:\n        print("(empty)")\n    for i, x in enumerate(items):\n        mark = "x" if x["done"] else " "\n        due = x.get("due")\n        suffix = f" (due: {due})" if due else ""\n        print(f"{i}. [{mark}] {x[\'text\']}{suffix}")',
+        "desc": "list items showing due dates",
+        "handler": 'def _cmd_agenda(args, items):\n    if not items:\n        print("(empty)")\n    for i, x in enumerate(items):\n        mark = "x" if x["done"] else " "\n        due = x.get("due")\n        suffix = f" (due: {due})" if due else ""\n        print(f"{i}. [{mark}] {x[\'text\']}{suffix}")',  # noqa: E501
         "register": '    "agenda": {"fn": _cmd_agenda, "help": "list items with due dates", "args": []},',
     },
     "find": {
-        "desc": 'search items by a word and print the matching ones with their index',
-        "handler": 'def _cmd_find(args, items):\n    needle = args.word.lower()\n    hits = [(i, x) for i, x in enumerate(items) if needle in x["text"].lower()]\n    if not hits:\n        print(f"no matches for: {args.word}")\n        return\n    for i, x in hits:\n        mark = "x" if x["done"] else " "\n        print(f"{i}. [{mark}] {x[\'text\']}")',
+        "desc": "search items by a word and print the matching ones with their index",
+        "handler": 'def _cmd_find(args, items):\n    needle = args.word.lower()\n    hits = [(i, x) for i, x in enumerate(items) if needle in x["text"].lower()]\n    if not hits:\n        print(f"no matches for: {args.word}")\n        return\n    for i, x in hits:\n        mark = "x" if x["done"] else " "\n        print(f"{i}. [{mark}] {x[\'text\']}")',  # noqa: E501
         "register": '    "find": {"fn": _cmd_find, "help": "find items by word", "args": [("word", {})]},',
     },
     "edit": {
         "desc": "change an item's text by index",
-        "handler": 'def _cmd_edit(args, items):\n    old = items[args.index]["text"]\n    items[args.index]["text"] = args.text\n    print(f"edited {args.index}: {old!r} -> {args.text!r}")',
-        "register": '    "edit": {"fn": _cmd_edit, "help": "edit item text by index", "args": [("index", {"type": int}), ("text", {})]},',
+        "handler": 'def _cmd_edit(args, items):\n    old = items[args.index]["text"]\n    items[args.index]["text"] = args.text\n    print(f"edited {args.index}: {old!r} -> {args.text!r}")',  # noqa: E501
+        "register": '    "edit": {"fn": _cmd_edit, "help": "edit item text by index", "args": [("index", {"type": int}), ("text", {})]},',  # noqa: E501
     },
     "priority": {
-        "desc": 'set priority (high/medium/low) on an item by index',
-        "handler": 'def _cmd_priority(args, items):\n    level = args.level.lower()\n    valid = ("high", "medium", "low")\n    if level not in valid:\n        print(f"invalid priority: {args.level} (use high/medium/low)")\n        return\n    items[args.index]["priority"] = level\n    print(f"priority: {items[args.index][\'text\']} -> {level}")',
-        "register": '    "priority": {"fn": _cmd_priority, "help": "set priority high/medium/low on an item", "args": [("index", {"type": int}), ("level", {})]},',
+        "desc": "set priority (high/medium/low) on an item by index",
+        "handler": 'def _cmd_priority(args, items):\n    level = args.level.lower()\n    valid = ("high", "medium", "low")\n    if level not in valid:\n        print(f"invalid priority: {args.level} (use high/medium/low)")\n        return\n    items[args.index]["priority"] = level\n    print(f"priority: {items[args.index][\'text\']} -> {level}")',  # noqa: E501
+        "register": '    "priority": {"fn": _cmd_priority, "help": "set priority high/medium/low on an item", "args": [("index", {"type": int}), ("level", {})]},',  # noqa: E501
     },
     "sort": {
-        "desc": 'reorder items by priority (high first)',
-        "handler": 'def _cmd_sort(args, items):\n    rank = {"high": 0, "medium": 1, "low": 2, "none": 3}\n    items.sort(key=lambda x: rank.get(x.get("priority", "none"), 3))\n    print(f"sorted {len(items)} items by priority")',
+        "desc": "reorder items by priority (high first)",
+        "handler": 'def _cmd_sort(args, items):\n    rank = {"high": 0, "medium": 1, "low": 2, "none": 3}\n    items.sort(key=lambda x: rank.get(x.get("priority", "none"), 3))\n    print(f"sorted {len(items)} items by priority")',  # noqa: E501
         "register": '    "sort": {"fn": _cmd_sort, "help": "sort items by priority", "args": []},',
     },
     "tag": {
-        "desc": 'tag an item by index',
-        "handler": 'def _cmd_tag(args, items):\n    item = items[args.index]\n    item.setdefault("tags", []).append(args.label)\n    print(f"tagged {args.index} with {args.label}: {item[\'tags\']}")',
-        "register": '    "tag": {"fn": _cmd_tag, "help": "tag an item", "args": [("index", {"type": int}), ("label", {})]},',
+        "desc": "tag an item by index",
+        "handler": 'def _cmd_tag(args, items):\n    item = items[args.index]\n    item.setdefault("tags", []).append(args.label)\n    print(f"tagged {args.index} with {args.label}: {item[\'tags\']}")',  # noqa: E501
+        "register": '    "tag": {"fn": _cmd_tag, "help": "tag an item", "args": [("index", {"type": int}), ("label", {})]},',  # noqa: E501
     },
     "export": {
-        "desc": 'write items to items.md as a checklist',
-        "handler": 'def _cmd_export(args, items):\n    from pathlib import Path\n    out = Path("items.md")\n    lines = ["# Items", ""]\n    for x in items:\n        mark = "x" if x["done"] else " "\n        lines.append(f"- [{mark}] {x[\'text\']}")\n    if not items:\n        lines.append("_(no items)_")\n    out.write_text("\\n".join(lines) + "\\n", encoding="utf-8")\n    print(f"exported {len(items)} items -> {out}")',
+        "desc": "write items to items.md as a checklist",
+        "handler": 'def _cmd_export(args, items):\n    from pathlib import Path\n    out = Path("items.md")\n    lines = ["# Items", ""]\n    for x in items:\n        mark = "x" if x["done"] else " "\n        lines.append(f"- [{mark}] {x[\'text\']}")\n    if not items:\n        lines.append("_(no items)_")\n    out.write_text("\\n".join(lines) + "\\n", encoding="utf-8")\n    print(f"exported {len(items)} items -> {out}")',  # noqa: E501
         "register": '    "export": {"fn": _cmd_export, "help": "write items to items.md checklist", "args": []},',
     },
 }
@@ -239,7 +237,7 @@ def render_glyph(sig: int, width: int = 16) -> list[str]:
     """Fold the (possibly huge) number into a 2D shape: its bits on a grid -- a glyph."""
     nbytes = max(1, (sig.bit_length() + 7) // 8)
     bits = bin(int.from_bytes(sig.to_bytes(nbytes, "big"), "big"))[2:].zfill(nbytes * 8)
-    rows = [bits[i:i + width] for i in range(0, len(bits), width)]
+    rows = [bits[i : i + width] for i in range(0, len(bits), width)]
     return ["".join("#" if b == "1" else "." for b in r) for r in rows]
 
 
@@ -299,7 +297,11 @@ def run_app(src: str, argv: list[str]):
 def _exec(app: Path, argv: list[str]):
     r = subprocess.run(
         [sys.executable, str(app), *argv],
-        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=20,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=20,
     )
     return r.returncode, (r.stdout or "") + (r.stderr or "")
 
@@ -372,7 +374,7 @@ def main():
         return
     if cmd == "puzzle":
         if len(args) < 3:
-            print("usage: forge.py puzzle <puzzle-name> \"<moves>\"")
+            print('usage: forge.py puzzle <puzzle-name> "<moves>"')
             return
         solve(args[2], puzzle=args[1])
         return

--- a/scripts/forge_ai.py
+++ b/scripts/forge_ai.py
@@ -16,6 +16,7 @@ the target needs, cover it with the fewest/biggest building blocks, build, verif
     python scripts/forge_ai.py auto inventory
     python scripts/forge_ai.py blocks
 """
+
 from __future__ import annotations
 
 import sys
@@ -28,11 +29,11 @@ from forge import _MOVES, _PUZZLES, _exec, assemble, show_signature  # noqa: E40
 
 # Layer 2+: blocks are compositions of moves; blocks may contain BLOCKS (hierarchy).
 _BLOCKS: dict[str, list[str]] = {
-    "tracker": ["add", "list", "done"],     # a thing you add to, see, and complete
-    "counter": ["count", "clear"],           # totals + reset
+    "tracker": ["add", "list", "done"],  # a thing you add to, see, and complete
+    "counter": ["count", "clear"],  # totals + reset
     "manager": ["tracker", "counter", "remove"],  # a BLOCK OF BLOCKS
     "planner": ["tracker", "due", "agenda", "priority", "sort"],  # a day-planner
-    "organizer": ["tracker", "tag", "find", "export"],           # tag/search/export
+    "organizer": ["tracker", "tag", "find", "export"],  # tag/search/export
 }
 
 
@@ -94,15 +95,17 @@ def auto_solve(puzzle: str):
 
     print(f"  -> chose {len(plan)} building block(s): {', '.join(plan)}")
     print(f"  -> expands to {len(used)} primitive moves: {', '.join(used)}")
-    print(f"  -> grounds on Layer 0 (binary Turing spine): each move is a computation the bit-spine can run")
+    print("  -> grounds on Layer 0 (binary Turing spine): each move is a computation the bit-spine can run")
     print()
     for argv, good, out in results:
         print(f"   [{'OK' if good else 'XX'}] {name} {' '.join(argv):<18} -> {out}")
     lev = round(lines / max(1, len(plan)), 1)
     show_signature(used)
     print("\n  " + "=" * 58)
-    print(f"  blocks: {len(plan)}   primitive moves: {len(used)}   lines: {lines}   "
-          f"leverage: {lev} lines/block   {dt:.0f}ms")
+    print(
+        f"  blocks: {len(plan)}   primitive moves: {len(used)}   lines: {lines}   "
+        f"leverage: {lev} lines/block   {dt:.0f}ms"
+    )
     print(f"  SOLVED: {'YES -- controller reached the target, verified by running' if ok else 'NO'}")
     print("  " + "=" * 58)
     return ok

--- a/scripts/forge_chat.py
+++ b/scripts/forge_chat.py
@@ -10,6 +10,7 @@ assembles a real project and VERIFIES it by running. Honest about gaps.
     python scripts/forge_chat.py --say "i wanna keep track of shit i gotta do" \
                                  --say "yeah lemme cross em off" --say "thats it build it"
 """
+
 from __future__ import annotations
 
 import re
@@ -22,20 +23,82 @@ from forge_speak import _GAPS, solve, synth_spec  # noqa: E402
 
 # slang / kid / drunk-tolerant: many ways to say each capability
 _SLANG = {
-    "add": ["add", "new", "put", "keep", "track", "jot", "write", "note", "log", "record",
-            "stuff", "thing", "things", "shit", "gotta", "need to", "wanna", "todo", "to do",
-            "to-do", "list of", "gimme", "remember"],
-    "list": ["list", "show", "see", "view", "look", "read", "display", "what", "whats",
-             "check", "pull up", "my list", "everything"],
-    "done": ["done", "finish", "complete", "mark", "check off", "cross off", "cross em",
-             "tick", "did it", "handled", "crossed", "knock out"],
+    "add": [
+        "add",
+        "new",
+        "put",
+        "keep",
+        "track",
+        "jot",
+        "write",
+        "note",
+        "log",
+        "record",
+        "stuff",
+        "thing",
+        "things",
+        "shit",
+        "gotta",
+        "need to",
+        "wanna",
+        "todo",
+        "to do",
+        "to-do",
+        "list of",
+        "gimme",
+        "remember",
+    ],
+    "list": [
+        "list",
+        "show",
+        "see",
+        "view",
+        "look",
+        "read",
+        "display",
+        "what",
+        "whats",
+        "check",
+        "pull up",
+        "my list",
+        "everything",
+    ],
+    "done": [
+        "done",
+        "finish",
+        "complete",
+        "mark",
+        "check off",
+        "cross off",
+        "cross em",
+        "tick",
+        "did it",
+        "handled",
+        "crossed",
+        "knock out",
+    ],
     "count": ["count", "how many", "total", "number", "tally", "amount"],
     "remove": ["remove", "delete", "drop", "get rid", "trash", "yeet", "toss", "take off", "kill"],
     "clear": ["clear", "wipe", "reset", "empty", "start over", "fresh", "nuke", "scrap", "blow"],
 }
-_BUILD = ["build", "build it", "make it", "do it", "go ahead", "thats it", "that's it",
-          "send it", "yes do it", "yeah do it", "just build", "ship it", "make the thing",
-          "that works", "sounds good", "go for it"]
+_BUILD = [
+    "build",
+    "build it",
+    "make it",
+    "do it",
+    "go ahead",
+    "thats it",
+    "that's it",
+    "send it",
+    "yes do it",
+    "yeah do it",
+    "just build",
+    "ship it",
+    "make the thing",
+    "that works",
+    "sounds good",
+    "go for it",
+]
 _LISTY = ["track", "keep", "list of", "todo", "to do", "to-do", "checklist", "keep a", "remember"]
 
 
@@ -65,8 +128,10 @@ def next_question(ops: set[str]) -> str:
 
 def reply(ops: set[str]) -> str:
     if not ops:
-        return ("ok, simplest words: what do you want it to let you DO?\n"
-                "  (like 'add stuff and see it', or 'keep a list and check things off')")
+        return (
+            "ok, simplest words: what do you want it to let you DO?\n"
+            "  (like 'add stuff and see it', or 'keep a list and check things off')"
+        )
     nice = ", ".join(ops)
     return f"got it -- so far: {nice}.\n  {next_question(ops)}"
 

--- a/scripts/forge_speak.py
+++ b/scripts/forge_speak.py
@@ -10,6 +10,7 @@ faking it). No model backend required -- a deterministic intent parser, so every
     python scripts/forge_speak.py "I want a task tracker I can mark done and count"
     python scripts/forge_speak.py "let me add things, see them, and clear the list"
 """
+
 from __future__ import annotations
 
 import sys
@@ -40,8 +41,11 @@ _INTENT = {
 _TRACKER_WORDS = ("task", "todo", "to-do", "to do", "tracker", "checklist", "list of")
 # things we honestly still do NOT have a move for (so we say so instead of faking)
 _GAPS = {
-    "remind": "reminders", "recur": "recurring tasks", "repeat": "recurring tasks",
-    "sync": "cloud sync", "share": "sharing with people",
+    "remind": "reminders",
+    "recur": "recurring tasks",
+    "repeat": "recurring tasks",
+    "sync": "cloud sync",
+    "share": "sharing with people",
 }
 
 
@@ -127,8 +131,10 @@ def speak(text: str):
     print(f"  I UNDERSTOOD you want to: {', '.join(caps)}")
     plan, used, src, ok, results = solve(synth_spec(caps, text))
     lines = src.count("\n") + 1
-    print(f"  -> built it from {len(plan)} building block(s): {', '.join(plan)}  "
-          f"({len(used)} moves, {lines} lines, on the binary Turing base)")
+    print(
+        f"  -> built it from {len(plan)} building block(s): {', '.join(plan)}  "
+        f"({len(used)} moves, {lines} lines, on the binary Turing base)"
+    )
     print()
     for argv, good, out in results:
         print(f"   [{'OK' if good else 'XX'}] forged {' '.join(argv):<16} -> {out}")


### PR DESCRIPTION
## Summary

Main lint is red after recent Aether/research merges. This is a dedicated lint-only cleanup so product/research PRs do not carry unrelated formatting debt.

Changes:

- Black-formats the Aether Python scripts that CI reported.
- Fixes flake8 issues in those scripts: missing comma spacing, unused import/variable, one unnecessary f-string, and intentionally long generated-code literals.
- Prettier was run across the CI TS glob; no TS files remained changed after formatting/checking.

## Validation

- `python -m black --check --target-version py311 --line-length 120 src/ tests/ scripts/ agents/`
- `python -m ruff check --config ruff.toml`
- `python -m flake8 --max-line-length 120 src/ tests/ hydra/ scripts/ agents/`
- `npx prettier --check src/**/*.ts tests/**/*.ts`
- `python -m pytest tests/test_research_library_catalog.py tests/test_vercel_launch_bridge.py -q`
- `npx vitest run tests/api/polly_commerce_js.test.ts`
- `git diff --check`

No product, research, claim, or behavior changes intended.