### PR TITLE
fix(site): remove legal-claim framing from homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -336,8 +336,8 @@
             </div>
             <p class="small">
               First pilots are free while the offer is being validated. Keep the workflow map,
-              catalog, and receipts if they help. No guarantee, no legal advice, no mystery
-              platform.
+              catalog, and receipts if they help. Scoped outputs, no mystery platform, no broad
+              protection promise.
             </p>
           </div>
 
@@ -372,9 +372,9 @@
             <p class="eyebrow">Free pilot</p>
             <h2>Send one messy AI workflow. Get a bounded build plan and catalog.</h2>
             <p class="plain">
-              Best fit: a chatbot, code assistant, browser agent, support automation, medical coding
-              helper, internal search bot, or any multi-step AI process where drift, missing logs,
-              or unfinished deliverables are the problem.
+              Best fit: a chatbot, code assistant, browser agent, support automation, research
+              packet builder, internal search bot, or any multi-step AI process where drift, missing
+              logs, or unfinished deliverables are the problem.
             </p>
             <div class="cta-row">
               <a
@@ -424,7 +424,8 @@
               <p class="price">$500</p>
               <p>
                 A longer multi-tier review for workflows with buyer, grant, subcontract, or
-                regulated-context pressure. Still not legal advice or certification.
+                high-stakes internal pressure. Still scoped to workflow design, evidence, and
+                delivery.
               </p>
               <a class="btn" href="governance-snapshot.html">Compare scope</a>
             </article>
@@ -462,10 +463,10 @@
           </div>
           <div class="grid-3">
             <article class="card">
-              <h3>CX refund guardrail</h3>
+              <h3>Customer support guardrail</h3>
               <p>
-                Review where a chatbot might promise a refund, credit, cancellation, or policy
-                exception it cannot actually deliver.
+                Review where a chatbot might make commitments outside its policy, tool access, or
+                human-approval path.
               </p>
             </article>
             <article class="card">
@@ -476,10 +477,10 @@
               </p>
             </article>
             <article class="card">
-              <h3>Medical coding review trail</h3>
+              <h3>Research packet review trail</h3>
               <p>
-                Catch places where an AI helper may invent codes, skip evidence, or blur advice and
-                documentation. Human review remains required.
+                Keep source lists, claim boundaries, reviewer passes, open questions, and final
+                artifacts tied to one navigable packet.
               </p>
             </article>
           </div>
@@ -531,8 +532,8 @@
       <div class="wrap">
         <p>
           AetherMoore is run by Issac Davis. This site sells long-run AI workflow control,
-          cataloging, receipt-backed review, and related tooling. It does not provide legal advice,
-          medical advice, compliance certification, or guaranteed protection from disputes.
+          cataloging, receipt-backed review, and related tooling. Outputs are scoped workflow
+          artifacts, not guarantees of business, safety, certification, or dispute outcomes.
         </p>
         <div class="link-row">
           <a href="mailto:ai@aethermoore.com">ai@aethermoore.com</a>

--- a/tests/revenue/test_public_money_path.py
+++ b/tests/revenue/test_public_money_path.py
@@ -16,10 +16,35 @@ def read_doc(name: str) -> str:
 def test_homepage_focuses_first_buyer_path_on_workflow_snapshot() -> None:
     homepage = read_doc("index.html")
 
-    assert "Start $99 Workflow Snapshot" in homepage
-    assert "ai-workflow-snapshot.html#receipt" in homepage
+    assert "Buy $99 Snapshot" in homepage
+    assert "workflow-snapshot.html" in homepage
     assert "payments.html" in homepage
     assert "briefing-room.html" not in homepage
+
+
+def test_homepage_sells_workflow_outputs_without_legal_claims() -> None:
+    homepage = read_doc("index.html").lower()
+
+    assert "long ai runs finish with real outputs" in homepage
+    assert "controlled workflow" in homepage
+    assert "cataloged outputs" in homepage
+    assert "receipt-backed checkpoints" in homepage
+
+    banned_phrases = [
+        "lawsuit",
+        "case law",
+        "air canada",
+        "moffatt",
+        "regulators demand",
+        "legal advice",
+        "medical advice",
+        "compliance certification",
+        "regulated-context",
+        "medical coding",
+        "cpt",
+    ]
+    for phrase in banned_phrases:
+        assert phrase not in homepage, f"homepage contains legal-adjacent claim phrase: {phrase}"
 
 
 def test_workflow_snapshot_checkout_is_consistent_and_live_wired() -> None:


### PR DESCRIPTION
﻿## Summary
- Repositions the homepage around long-run AI workflow control: bounded route, checkpoints, cataloged outputs, and scoped deliverables.
- Removes legal-adjacent homepage examples and wording: lawsuit/legal-advice framing, regulated-context phrasing, medical-coding pitch, and refund-case-law style positioning.
- Adds a regression test so the homepage cannot drift back into lawsuit/regulator/legal-certification sales copy.

## Verification
- python -m pytest tests\revenue\test_public_money_path.py tests\test_public_claim_language.py -q
- rg homepage banned-phrase scan against docs\index.html
- git diff --check
- Playwright screenshot: artifacts/no-legal-homepage.png

## Boundary
No legal claims. The page now sells a scoped workflow artifact: intent map, route, checkpoints, catalog, receipts, and next fixes.
