### PR TITLE
feat(loom): a tiny universal loop machine that weaves one program into many languages

### DIFF
--- a/python/loom/README.md
+++ b/python/loom/README.md
@@ -1,0 +1,52 @@
+# Loom
+
+A tiny **universal loop machine** that weaves one program into many languages — built for agentic AI code generation. An agent writes one small program; Loom:
+
+1. **weaves** it into runnable **Python / JavaScript / C** that are *equal by construction*,
+2. reads the **topology of its run** to detect infinite loops, and
+3. checks **near-mirror symmetry** — whether the program round-trips through unparse→parse *exactly*, or only behaviorally.
+
+It is standalone (no other project deps; numpy not required).
+
+## The machine
+
+A Minsky register machine — **Turing-complete with ≥2 registers**. Registers are non-negative integers (default 0).
+
+```
+inc R        ; R += 1
+dec R L      ; if R > 0 then R -= 1 (fall through) else goto L
+jmp L        ; goto L
+out R        ; append R to the output trace
+halt         ; stop
+```
+
+`#` or `;` starts a comment; `name:` is a label (its own line or prefixing an instruction).
+
+## Quick start
+
+```python
+from python.loom import parse, run, emit_python, cross_check, mirror_check
+
+ADD = """
+loop: dec r1 done    ; r2 += r1
+      inc r2
+      jmp loop
+done: out r2
+      halt
+"""
+prog = parse(ADD)
+run(prog, {"r1": 3, "r2": 4}).output     # -> [7]
+run(parse("s: jmp s")).status            # -> "loop"  (revisited state = infinite loop)
+cross_check(prog, [{"r1": 3, "r2": 4}])  # -> {"all_agree": True, "backends": [...]}
+mirror_check(ADD)                        # -> {"exact_mirror": True, ...}
+```
+
+## The three ideas (and the honest caveats)
+
+- **Points & loops.** A run is a sequence of state-points `(pc, registers)`. Because the machine is deterministic, a **revisited state closes a loop** — a self-intersection of the trajectory — which *proves* the program never halts. Loop detection is therefore **sound but incomplete**: a detected revisit is certainly infinite; not finding one within the step budget means *undetermined*, never *halts*. (You can't, in general, decide your own halting — the formal version of "you can't fully match yourself".)
+- **Cross-linguistic coherence.** Each emitter generates the same `pc`-dispatch loop, so the language outputs are identical by construction; `cross_check` *verifies* it by actually running the reference interpreter, the emitted Python, and (if `node`/`gcc` are present) the emitted JS/C, confirming every backend agrees.
+- **Near mirror symmetry.** `mirror_check` round-trips a program (`unparse`→`parse`). **Exact mirror** = structurally identical. **Near mirror** = behaviorally identical but structurally not quite (e.g. a jump-to-end becomes an explicit `halt`) — symmetric in effect, not in form. **Broken** = behavior changed (should never happen).
+
+## Also
+
+- `behaviorally_equivalent(src_a, src_b, inits)` — do two *different* programs produce the same output on a battery of inputs? (A behavior-space "collision" — for an agent deduping candidate solutions.)

--- a/python/loom/__init__.py
+++ b/python/loom/__init__.py
@@ -1,0 +1,44 @@
+"""Loom — a tiny universal loop machine that weaves one program into many languages.
+
+A minimal Turing-complete register (Minsky) machine for agentic code generation:
+an agent writes one small program; Loom (1) emits it as runnable Python / JavaScript
+/ C that are equal by construction, (2) reads the topology of its run to detect
+infinite loops (a revisited state closes a loop — sound but, like all halting
+analysis, incomplete), and (3) checks "near mirror symmetry" — whether a program
+round-trips through unparse/parse exactly, or only behaviorally.
+
+Quick start:
+
+    from python.loom import parse, run, emit_python, cross_check, mirror_check
+
+    prog = parse('''
+        loop: dec r1 done   ; r2 += r1
+              inc r2
+              jmp loop
+        done: out r2
+              halt
+    ''')
+    run(prog, {"r1": 3, "r2": 4}).output      # -> [7]
+    cross_check(prog, [{"r1": 3, "r2": 4}])    # all backends agree
+"""
+
+from .emit import emit_c, emit_js, emit_python
+from .equiv import behaviorally_equivalent, cross_check, mirror_check, run_reference
+from .machine import Instr, LoomSyntaxError, Program, RunResult, parse, run, unparse
+
+__all__ = [
+    "parse",
+    "run",
+    "unparse",
+    "Program",
+    "Instr",
+    "RunResult",
+    "LoomSyntaxError",
+    "emit_python",
+    "emit_js",
+    "emit_c",
+    "run_reference",
+    "cross_check",
+    "behaviorally_equivalent",
+    "mirror_check",
+]

--- a/python/loom/emit.py
+++ b/python/loom/emit.py
@@ -1,0 +1,118 @@
+"""Weave one Loom program into many languages.
+
+Every emitter produces a complete, runnable program for one fixed input (the
+initial register values are baked in), structured as a single ``pc``-dispatch
+loop. The dispatch is generated identically across languages, so the three
+outputs are equal by construction — the cross-language coherence is exact, not
+hoped-for. ``equiv.cross_check`` verifies it by actually running them.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .machine import Program
+
+
+def _initial_registers(prog: Program, init: Optional[Dict[str, int]]) -> Dict[str, int]:
+    regs = {r: 0 for r in prog.registers}
+    for key, val in (init or {}).items():
+        if key in regs:
+            regs[key] = int(val)
+    return regs
+
+
+def emit_python(prog: Program, init: Optional[Dict[str, int]] = None, func_name: str = "run") -> str:
+    regs = _initial_registers(prog, init)
+    n = len(prog.instrs)
+    items = ", ".join(f"{r!r}: {regs[r]}" for r in prog.registers)
+    out = [f"def {func_name}():", f"    R = {{{items}}}", "    pc = 0", "    trace = []"]
+    if n == 0:
+        out.append("    return trace")
+        return "\n".join(out)
+    out.append(f"    while 0 <= pc < {n}:")
+    for idx, ins in enumerate(prog.instrs):
+        kw = "if" if idx == 0 else "elif"
+        out.append(f"        {kw} pc == {idx}:")
+        if ins.op == "inc":
+            out.append(f"            R[{ins.reg!r}] += 1; pc += 1")
+        elif ins.op == "dec":
+            out.append(f"            if R[{ins.reg!r}] > 0:")
+            out.append(f"                R[{ins.reg!r}] -= 1; pc += 1")
+            out.append("            else:")
+            out.append(f"                pc = {ins.target}")
+        elif ins.op == "jmp":
+            out.append(f"            pc = {ins.target}")
+        elif ins.op == "out":
+            out.append(f"            trace.append(R[{ins.reg!r}]); pc += 1")
+        else:  # halt
+            out.append("            break")
+    out.append("        else:")
+    out.append("            break")
+    out.append("    return trace")
+    return "\n".join(out)
+
+
+def emit_js(prog: Program, init: Optional[Dict[str, int]] = None, func_name: str = "run") -> str:
+    regs = _initial_registers(prog, init)
+    n = len(prog.instrs)
+    items = ", ".join(f"{r}: {regs[r]}" for r in prog.registers)
+    out = [f"function {func_name}() {{", f"  const R = {{{items}}};", "  let pc = 0;", "  const trace = [];"]
+    if n:
+        out.append(f"  while (pc >= 0 && pc < {n}) {{")
+        for idx, ins in enumerate(prog.instrs):
+            kw = "if" if idx == 0 else "else if"
+            if ins.op == "inc":
+                body = f"R.{ins.reg} += 1; pc += 1;"
+            elif ins.op == "dec":
+                body = f"if (R.{ins.reg} > 0) {{ R.{ins.reg} -= 1; pc += 1; }} else {{ pc = {ins.target}; }}"
+            elif ins.op == "jmp":
+                body = f"pc = {ins.target};"
+            elif ins.op == "out":
+                body = f"trace.push(R.{ins.reg}); pc += 1;"
+            else:
+                body = "break;"
+            out.append(f"    {kw} (pc === {idx}) {{ {body} }}")
+        out.append("    else { break; }")
+        out.append("  }")
+    out.append("  return trace;")
+    out.append("}")
+    return "\n".join(out)
+
+
+def emit_c(prog: Program, init: Optional[Dict[str, int]] = None, out_cap: int = 100_000) -> str:
+    regs = _initial_registers(prog, init)
+    n = len(prog.instrs)
+    decls = " ".join(f"long {r} = {regs[r]};" for r in prog.registers) or "/* no registers */"
+    lines = [
+        "#include <stdio.h>",
+        "int main(void) {",
+        f"    {decls}",
+        "    int pc = 0;",
+        f"    long trace[{out_cap}]; int tn = 0;",
+    ]
+    if n:
+        lines.append(f"    while (pc >= 0 && pc < {n}) {{")
+        for idx, ins in enumerate(prog.instrs):
+            kw = "if" if idx == 0 else "else if"
+            if ins.op == "inc":
+                body = f"{ins.reg} += 1; pc += 1;"
+            elif ins.op == "dec":
+                body = f"if ({ins.reg} > 0) {{ {ins.reg} -= 1; pc += 1; }} else {{ pc = {ins.target}; }}"
+            elif ins.op == "jmp":
+                body = f"pc = {ins.target};"
+            elif ins.op == "out":
+                body = f"if (tn < {out_cap}) trace[tn++] = {ins.reg}; pc += 1;"
+            else:
+                body = "break;"
+            lines.append(f"        {kw} (pc == {idx}) {{ {body} }}")
+        lines.append("        else { break; }")
+        lines.append("    }")
+    lines.append('    for (int i = 0; i < tn; i++) { printf("%ld", trace[i]); if (i + 1 < tn) printf(" "); }')
+    lines.append('    printf("\\n");')
+    lines.append("    return 0;")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+EMITTERS = {"python": emit_python, "javascript": emit_js, "c": emit_c}

--- a/python/loom/equiv.py
+++ b/python/loom/equiv.py
@@ -1,0 +1,127 @@
+"""Cross-language equivalence, behavioral equivalence, and the mirror check.
+
+- ``cross_check``  — run the reference interpreter and the emitted Python (and
+  Node/C if those toolchains are present) on the same inputs and confirm every
+  backend produces the same output. The coherence the emitters guarantee, tested.
+- ``behaviorally_equivalent`` — do two *different* programs produce the same
+  output on a battery of inputs? (A "collision" in behavior-space — useful for an
+  agent that generates many candidate solutions and wants to dedupe them.)
+- ``mirror_check`` — round-trip a program through unparse→parse and report whether
+  it comes back EXACTLY (a true mirror) or only behaviorally (a *near* mirror).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Dict, List, Optional
+
+from . import emit as E
+from . import machine as M
+
+
+def run_reference(prog: M.Program, init: Optional[Dict[str, int]] = None, max_steps: int = 100_000) -> List[int]:
+    return M.run(prog, init=init, max_steps=max_steps).output
+
+
+def run_python_emit(prog: M.Program, init: Optional[Dict[str, int]] = None) -> List[int]:
+    namespace: Dict[str, object] = {}
+    exec(E.emit_python(prog, init=init, func_name="run"), namespace)  # our own generated code
+    return list(namespace["run"]())
+
+
+def _run_capture(cmd: List[str], cwd: Optional[str] = None) -> Optional[str]:
+    try:
+        proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=30)
+    except Exception:
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def _parse_int_line(text: Optional[str]) -> Optional[List[int]]:
+    if text is None:
+        return None
+    text = text.strip()
+    return [int(tok) for tok in text.split()] if text else []
+
+
+def run_node(prog: M.Program, init: Optional[Dict[str, int]] = None) -> Optional[List[int]]:
+    """Run the emitted JavaScript via node, if available. Returns None if node is absent."""
+    if not shutil.which("node"):
+        return None
+    src = E.emit_js(prog, init=init) + "\nconsole.log(run().join(' '));\n"
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "loom.js")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(src)
+        return _parse_int_line(_run_capture(["node", path]))
+
+
+def run_c(prog: M.Program, init: Optional[Dict[str, int]] = None) -> Optional[List[int]]:
+    """Compile + run the emitted C via gcc/cc, if available. Returns None if no compiler."""
+    cc = shutil.which("gcc") or shutil.which("cc")
+    if not cc:
+        return None
+    with tempfile.TemporaryDirectory() as d:
+        src_path = os.path.join(d, "loom.c")
+        exe_path = os.path.join(d, "loom.exe")
+        with open(src_path, "w", encoding="utf-8") as fh:
+            fh.write(E.emit_c(prog, init=init))
+        if _run_capture([cc, src_path, "-O2", "-o", exe_path]) is None:
+            return None
+        return _parse_int_line(_run_capture([exe_path]))
+
+
+def cross_check(prog: M.Program, inits: List[Dict[str, int]]) -> Dict[str, object]:
+    """Confirm reference, Python-emit (and Node/C if present) agree on every input."""
+    rows = []
+    all_agree = True
+    backends_used = {"reference", "python"}
+    for init in inits:
+        ref = run_reference(prog, init)
+        results: Dict[str, Optional[List[int]]] = {"reference": ref, "python": run_python_emit(prog, init)}
+        node = run_node(prog, init)
+        if node is not None:
+            results["node"] = node
+            backends_used.add("node")
+        c = run_c(prog, init)
+        if c is not None:
+            results["c"] = c
+            backends_used.add("c")
+        present = [v for v in results.values() if v is not None]
+        agree = all(v == present[0] for v in present)
+        all_agree = all_agree and agree
+        rows.append({"init": init, "results": results, "agree": agree})
+    return {"all_agree": all_agree, "backends": sorted(backends_used), "rows": rows}
+
+
+def behaviorally_equivalent(src_a: str, src_b: str, inits: List[Dict[str, int]]) -> bool:
+    """Two programs are behaviorally equivalent on a battery iff they agree on every input."""
+    pa, pb = M.parse(src_a), M.parse(src_b)
+    return all(M.run(pa, init).output == M.run(pb, init).output for init in inits)
+
+
+def mirror_check(source: str, inits: Optional[List[Dict[str, int]]] = None) -> Dict[str, bool]:
+    """Round-trip a program (unparse->parse) and classify the symmetry.
+
+    exact_mirror     : structurally identical after the round-trip.
+    near_mirror      : behaviorally identical but NOT structurally (e.g. jump-to-end
+                       materialized as an explicit halt) — symmetric in effect, not in form.
+    broken           : behavior changed under the round-trip (should never happen).
+    """
+    inits = (
+        inits
+        if inits is not None
+        else [{}, {r: 1 for r in M.parse(source).registers}, {r: 3 for r in M.parse(source).registers}]
+    )
+    p1 = M.parse(source)
+    p2 = M.parse(M.unparse(p1))
+    exact = p1.signature() == p2.signature()
+    behavioral = all(M.run(p1, init).output == M.run(p2, init).output for init in inits)
+    return {
+        "exact_mirror": exact and behavioral,
+        "near_mirror": behavioral and not exact,
+        "broken": not behavioral,
+    }

--- a/python/loom/machine.py
+++ b/python/loom/machine.py
@@ -1,0 +1,226 @@
+"""Loom — a tiny universal loop machine (a Minsky register machine).
+
+Write one program; weave it into many languages (see ``emit``); read the
+*topology* of its run. A run is a sequence of state-points ``(pc, registers)``.
+Because the machine is deterministic, a **revisited state closes a loop**
+(a self-intersection of the trajectory) and proves the program never halts.
+
+Halting is undecidable in general, so loop detection here is **sound but
+incomplete**: a detected revisit is *certainly* an infinite loop; failing to
+detect one within the step budget means "undetermined" — never "halts". That
+gap is the honest version of "you can't fully match yourself": the machine
+cannot, in general, decide its own behavior.
+
+Instruction set (Turing-complete with >= 2 registers — the Minsky 2-counter result):
+
+    inc R        ; R += 1
+    dec R L      ; if R > 0 then R -= 1 (fall through) else goto L
+    jmp L        ; goto L
+    out R        ; append R to the output trace
+    halt         ; stop
+
+Syntax: one instruction per line; ``#`` or ``;`` starts a comment; ``name:`` is a
+label (it may sit on its own line or prefix an instruction). Names match
+``[A-Za-z_][A-Za-z0-9_]*``. Registers are non-negative integers, default 0.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+_WORD = r"[A-Za-z_][A-Za-z0-9_]*"
+_LABEL_RE = re.compile(rf"^({_WORD})\s*:\s*(.*)$")
+
+
+class LoomSyntaxError(ValueError):
+    """Raised for malformed Loom source."""
+
+
+@dataclass(frozen=True)
+class Instr:
+    op: str  # inc | dec | jmp | out | halt
+    reg: Optional[str] = None
+    target: Optional[int] = None  # resolved instruction index (dec / jmp)
+    target_label: Optional[str] = None  # original label name (for unparse / debugging)
+
+
+@dataclass
+class Program:
+    instrs: List[Instr]
+    registers: Tuple[str, ...]
+    labels: Dict[str, int] = field(default_factory=dict)
+
+    def signature(self) -> Tuple:
+        """Structural identity: (op, reg, resolved target) per instruction.
+
+        Label *names* are ignored, so two programs that differ only in label
+        spelling have the same signature — this is what an exact mirror compares.
+        """
+        return tuple((i.op, i.reg, i.target) for i in self.instrs)
+
+
+def parse(source: str) -> Program:
+    """Parse Loom assembly into a resolved Program."""
+    label_to_index: Dict[str, int] = {}
+    instr_tokens: List[Tuple[int, List[str]]] = []  # (source lineno, tokens)
+    pending_labels: List[str] = []
+
+    for lineno, line in enumerate(source.splitlines(), 1):
+        line = line.split("#", 1)[0].split(";", 1)[0].strip()
+        if not line:
+            continue
+        # peel any leading "label:" prefixes off the front of the line
+        while True:
+            m = _LABEL_RE.match(line)
+            if not m:
+                break
+            pending_labels.append(m.group(1))
+            line = m.group(2).strip()
+            if not line:
+                break
+        if not line:
+            continue  # label(s) only — they attach to the next instruction
+        idx = len(instr_tokens)
+        for lab in pending_labels:
+            if lab in label_to_index:
+                raise LoomSyntaxError(f"line {lineno}: duplicate label {lab!r}")
+            label_to_index[lab] = idx
+        pending_labels = []
+        instr_tokens.append((lineno, line.split()))
+
+    end_index = len(instr_tokens)  # labels after the last instruction point past the end (= halt)
+    for lab in pending_labels:
+        if lab in label_to_index:
+            raise LoomSyntaxError(f"duplicate label {lab!r}")
+        label_to_index[lab] = end_index
+
+    registers: List[str] = []
+
+    def note(reg: str) -> str:
+        if reg not in registers:
+            registers.append(reg)
+        return reg
+
+    def resolve(lab: str, lineno: int) -> int:
+        if lab not in label_to_index:
+            raise LoomSyntaxError(f"line {lineno}: unknown label {lab!r}")
+        return label_to_index[lab]
+
+    instrs: List[Instr] = []
+    for lineno, toks in instr_tokens:
+        op = toks[0].lower()
+        if op == "inc" and len(toks) == 2:
+            instrs.append(Instr("inc", reg=note(toks[1])))
+        elif op == "dec" and len(toks) == 3:
+            instrs.append(Instr("dec", reg=note(toks[1]), target=resolve(toks[2], lineno), target_label=toks[2]))
+        elif op == "jmp" and len(toks) == 2:
+            instrs.append(Instr("jmp", target=resolve(toks[1], lineno), target_label=toks[1]))
+        elif op == "out" and len(toks) == 2:
+            instrs.append(Instr("out", reg=note(toks[1])))
+        elif op == "halt" and len(toks) == 1:
+            instrs.append(Instr("halt"))
+        else:
+            raise LoomSyntaxError(f"line {lineno}: bad instruction {' '.join(toks)!r}")
+
+    return Program(instrs=instrs, registers=tuple(sorted(registers)), labels=label_to_index)
+
+
+@dataclass
+class RunResult:
+    output: List[int]
+    steps: int
+    status: str  # "halted" | "loop" | "budget"
+    loop_state: Optional[Tuple[int, Tuple[int, ...]]] = None
+    registers: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def halted(self) -> bool:
+        return self.status == "halted"
+
+    @property
+    def loops(self) -> bool:
+        return self.status == "loop"
+
+
+def run(
+    prog: Program, init: Optional[Dict[str, int]] = None, max_steps: int = 100_000, detect_loops: bool = True
+) -> RunResult:
+    """Execute a Program. Detects infinite loops by spotting a revisited state."""
+    regs: Dict[str, int] = {r: 0 for r in prog.registers}
+    for key, val in (init or {}).items():
+        if key in regs:  # ignore inits for registers the program never touches
+            regs[key] = int(val)
+
+    pc = 0
+    out: List[int] = []
+    seen: set = set()
+    steps = 0
+    n = len(prog.instrs)
+
+    while 0 <= pc < n:
+        if steps >= max_steps:
+            return RunResult(out, steps, "budget", None, dict(regs))
+        if detect_loops:
+            state = (pc, tuple(regs[r] for r in prog.registers))
+            if state in seen:
+                return RunResult(out, steps, "loop", state, dict(regs))
+            seen.add(state)
+        ins = prog.instrs[pc]
+        if ins.op == "inc":
+            regs[ins.reg] += 1
+            pc += 1
+        elif ins.op == "dec":
+            if regs[ins.reg] > 0:
+                regs[ins.reg] -= 1
+                pc += 1
+            else:
+                pc = ins.target
+        elif ins.op == "jmp":
+            pc = ins.target
+        elif ins.op == "out":
+            out.append(regs[ins.reg])
+            pc += 1
+        elif ins.op == "halt":
+            return RunResult(out, steps, "halted", None, dict(regs))
+        steps += 1
+
+    return RunResult(out, steps, "halted", None, dict(regs))  # fell off the end = halt
+
+
+def unparse(prog: Program) -> str:
+    """Render a Program back to canonical Loom assembly (the mirror of parse).
+
+    Labels are regenerated (L0, L1, ...), so parse(unparse(p)) is structurally
+    identical to p whenever every jump target is a real instruction. A target
+    that points *past* the last instruction (jump-to-end) is materialized as an
+    explicit trailing ``halt`` — behaviorally identical, structurally one
+    instruction longer: a "near mirror", not an exact one.
+    """
+    n = len(prog.instrs)
+    real_targets = sorted({i.target for i in prog.instrs if i.target is not None and i.target < n})
+    label_at = {idx: f"L{k}" for k, idx in enumerate(real_targets)}
+    end_needed = any(i.target == n for i in prog.instrs)
+    end_label = "L_end"
+
+    def tlabel(target: int) -> str:
+        return label_at[target] if target < n else end_label
+
+    lines: List[str] = []
+    for idx, ins in enumerate(prog.instrs):
+        prefix = f"{label_at[idx]}: " if idx in label_at else ""
+        if ins.op == "inc":
+            body = f"inc {ins.reg}"
+        elif ins.op == "dec":
+            body = f"dec {ins.reg} {tlabel(ins.target)}"
+        elif ins.op == "jmp":
+            body = f"jmp {tlabel(ins.target)}"
+        elif ins.op == "out":
+            body = f"out {ins.reg}"
+        else:
+            body = "halt"
+        lines.append(prefix + body)
+    if end_needed:
+        lines.append(f"{end_label}: halt")
+    return "\n".join(lines)

--- a/tests/test_loom.py
+++ b/tests/test_loom.py
@@ -1,0 +1,121 @@
+"""Tests for Loom — the tiny universal loop machine + multi-language weaver."""
+
+import shutil
+
+import pytest
+
+from python.loom import emit as E
+from python.loom import equiv, machine as M
+
+# r2 += r1, then output r2 (a classic Minsky addition)
+ADD = """
+loop: dec r1 done
+      inc r2
+      jmp loop
+done: out r2
+      halt
+"""
+
+SPIN = "spin: jmp spin"  # a pure infinite loop
+GROW = "g: inc r1\n    jmp g"  # pc cycles but r1 grows forever -> never repeats state
+
+
+def test_parse_resolves_labels_and_registers():
+    prog = M.parse(ADD)
+    assert prog.registers == ("r1", "r2")
+    assert [i.op for i in prog.instrs] == ["dec", "inc", "jmp", "out", "halt"]
+    # 'loop' labels instr 0, 'done' labels instr 3
+    assert prog.labels["loop"] == 0 and prog.labels["done"] == 3
+    assert prog.instrs[0].target == 3  # dec r1 -> done
+    assert prog.instrs[2].target == 0  # jmp -> loop
+
+
+@pytest.mark.parametrize("a,b", [(0, 0), (3, 4), (5, 0), (9, 2)])
+def test_addition_runs_correctly(a, b):
+    res = M.run(M.parse(ADD), {"r1": a, "r2": b})
+    assert res.halted is True
+    assert res.output == [a + b]
+
+
+def test_loop_detection_spots_self_intersection():
+    res = M.run(M.parse(SPIN))
+    assert res.status == "loop"
+    assert res.loops is True
+    assert res.loop_state is not None  # the (pc, regs) point that repeated
+
+
+def test_growing_state_is_undetermined_not_a_false_loop():
+    # halting is undecidable: pc cycles but r1 grows, so no exact state repeats
+    res = M.run(M.parse(GROW), max_steps=500)
+    assert res.status == "budget"
+    assert res.loops is False and res.halted is False
+
+
+def test_python_emit_matches_reference():
+    prog = M.parse(ADD)
+    for init in ({"r1": 0, "r2": 0}, {"r1": 3, "r2": 4}, {"r1": 7, "r2": 2}):
+        assert equiv.run_python_emit(prog, init) == equiv.run_reference(prog, init)
+
+
+def test_emitters_produce_wellformed_source():
+    prog = M.parse(ADD)
+    py = E.emit_python(prog, {"r1": 3, "r2": 4})
+    js = E.emit_js(prog, {"r1": 3, "r2": 4})
+    c = E.emit_c(prog, {"r1": 3, "r2": 4})
+    assert "def run():" in py and "while 0 <= pc <" in py
+    assert "function run()" in js and "return trace;" in js
+    assert "#include <stdio.h>" in c and "int main(void)" in c
+
+
+def test_cross_check_all_backends_agree():
+    prog = M.parse(ADD)
+    report = equiv.cross_check(prog, [{"r1": 3, "r2": 4}, {"r1": 6, "r2": 1}])
+    assert report["all_agree"] is True
+    assert "reference" in report["backends"] and "python" in report["backends"]
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not installed")
+def test_node_emit_matches_reference():
+    prog = M.parse(ADD)
+    assert equiv.run_node(prog, {"r1": 3, "r2": 4}) == [7]
+
+
+@pytest.mark.skipif(not (shutil.which("gcc") or shutil.which("cc")), reason="no C compiler")
+def test_c_emit_matches_reference():
+    prog = M.parse(ADD)
+    assert equiv.run_c(prog, {"r1": 5, "r2": 2}) == [7]
+
+
+def test_mirror_check_exact_for_normal_program():
+    # ADD's jump targets are all real instructions -> exact mirror
+    m = equiv.mirror_check(ADD, inits=[{"r1": 0}, {"r1": 4, "r2": 1}])
+    assert m["exact_mirror"] is True
+    assert m["near_mirror"] is False and m["broken"] is False
+
+
+def test_mirror_check_near_for_jump_to_end():
+    # 'fin' is a label at the very end -> dec jumps PAST the last instr (= halt);
+    # unparse materializes that as an explicit trailing halt: behaviorally identical,
+    # structurally one instruction longer -> a NEAR mirror, not an exact one.
+    src = "dec r1 fin\n    inc r2\n    out r2\nfin:"
+    m = equiv.mirror_check(src, inits=[{"r1": 0}, {"r1": 3}])
+    assert m["near_mirror"] is True
+    assert m["exact_mirror"] is False and m["broken"] is False
+
+
+def test_behavioral_equivalence():
+    a = "out r1\nhalt"
+    b = "inc r1\n    dec r1 k\nk: out r1\nhalt"  # inc then dec-back nets zero -> same output
+    c = "inc r1\n    out r1\nhalt"  # off by one -> different
+    inits = [{"r1": 0}, {"r1": 5}, {"r1": 9}]
+    assert equiv.behaviorally_equivalent(a, b, inits) is True
+    assert equiv.behaviorally_equivalent(a, c, inits) is False
+
+
+def test_syntax_errors_are_reported():
+    with pytest.raises(M.LoomSyntaxError):
+        M.parse("inc")  # missing register
+    with pytest.raises(M.LoomSyntaxError):
+        M.parse("jmp nowhere")  # unknown label
+    with pytest.raises(M.LoomSyntaxError):
+        M.parse("bogus r1")  # unknown op


### PR DESCRIPTION
A standalone module (`python/loom/`, no project deps) built for **agentic AI code generation**, from the *points-and-loops* idea: a deterministic machine's run is a sequence of state-points, and a **revisited state closes a loop** (a self-intersection) that *proves* the program never halts.

An agent writes one tiny program; Loom (1) weaves it into runnable **Python / JavaScript / C** that are equal by construction, (2) reads the topology of its run to detect infinite loops, and (3) checks **near-mirror symmetry** of a round-trip.

## What's in it
- **`machine.py`** — a Minsky register machine (`inc / dec / jmp / out / halt`; Turing-complete with ≥2 registers), parser, and a runner with **loop detection via state-revisit** — *sound but incomplete* (the honest face of halting undecidability: a detected revisit is certainly infinite; not finding one within the budget means *undetermined*, never *halts*). Plus `unparse()`, the mirror of `parse()`.
- **`emit.py`** — weave one program into Python / JS / C as a single `pc`-dispatch loop, **identical by construction**.
- **`equiv.py`** — `cross_check` (run reference + emitted Python + Node/C if present, confirm all agree), `behaviorally_equivalent` (behavior-space "collision" → dedupe candidate solutions), and `mirror_check` (**exact** vs **near** vs **broken** round-trip).

## "Near mirror symmetry" (made real, not metaphor)
`mirror_check` round-trips a program through `unparse → parse`. **Exact mirror** = structurally identical. **Near mirror** = behaviorally identical but structurally not quite (e.g. a jump-to-end becomes an explicit `halt`) — symmetric in *effect*, not in *form*. **Broken** = behavior changed (never happens). This is the buildable version of "symmetric in the periphery, but you can't perfectly match yourself."

## Verified
- **15 tests pass** (1 skipped without a C compiler).
- Live demo: `ADD(r1=3,r2=4) → [7]`; `s: jmp s → "loop"`; **`cross_check` confirmed reference + Python + JavaScript all agree** on the same program; exact mirror for a normal program, near mirror for a jump-to-end.
- Lint clean; additive only (new package + tests).

Standalone by design — kept deliberately un-coupled from the rest of the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)