### PR TITLE
feat(codeforge): the assembled workflow machine — messy intent in, verified code out

### DIFF
--- a/python/codeforge/__init__.py
+++ b/python/codeforge/__init__.py
@@ -1,0 +1,110 @@
+"""codeforge — the assembled workflow machine: messy intent in, verified code out.
+
+Composes **crank** (the chassis: checkpointed phases + a tamper-evident receipt
+chain) with **loom** (forced discrete states: one program woven into many
+languages, with loop/mirror checks). ``forge(intent)`` turns a plain-English
+arithmetic request into a Loom program that is verified across languages *and*
+against Python's own arithmetic, and returns the crank Catalog — the receipted,
+tamper-evident record of the whole run.
+
+This is the deterministic capstone: the 'build' phase is a programmatic Loom
+synthesizer (no LLM) standing in for an AI executor — but the verification and the
+machine are entirely real. An LLM 'build' executor can drop in later unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Optional
+
+from python.crank import GateVerdict, Phase, turn
+from python.loom import cross_check, emit_c, emit_js, emit_python, mirror_check, parse, run
+from python.loom.synth import arith_program
+
+_OP_WORDS = {
+    "add": "add",
+    "plus": "add",
+    "sum": "add",
+    "multiply": "multiply",
+    "times": "multiply",
+    "product": "multiply",
+}
+
+
+def _understand(intent: str, ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    text = intent.lower()
+    op = next((_OP_WORDS[w] for w in _OP_WORDS if re.search(rf"\b{w}\b", text)), None)
+    if op is None:
+        return None  # -> drift: codeforge only knows arithmetic
+    nums = [int(n) for n in re.findall(r"\d+", text)]
+    a, b = (nums + [3, 4])[:2]  # sample operands if none were given
+    return {"op": op, "a": a, "b": b}
+
+
+def _build(intent: str, ctx: Dict[str, Any]) -> Dict[str, Any]:
+    spec = ctx["outputs"]["understand"]
+    return {"op": spec["op"], "a": spec["a"], "b": spec["b"], "assembly": arith_program(spec["op"])}
+
+
+def _verify(intent: str, ctx: Dict[str, Any]) -> Dict[str, Any]:
+    b = ctx["outputs"]["build"]
+    prog = parse(b["assembly"])
+    init = {"r1": b["a"], "r2": b["b"]}
+    expected = b["a"] + b["b"] if b["op"] == "add" else b["a"] * b["b"]
+    report = cross_check(prog, [init])
+    got = report["rows"][0]["results"]["reference"]
+    return {
+        "verified": report["all_agree"] and got == [expected],
+        "expected": expected,
+        "got": got,
+        "backends": report["backends"],
+        "source": {
+            "python": emit_python(prog, init),
+            "javascript": emit_js(prog, init),
+            "c": emit_c(prog, init),
+        },
+    }
+
+
+def _review(intent: str, ctx: Dict[str, Any]) -> Dict[str, Any]:
+    b = ctx["outputs"]["build"]
+    prog = parse(b["assembly"])
+    op = b["op"]
+    cases = [(0, 0), (1, 0), (3, 4), (5, 2), (7, 6)]
+    behavioral_ok = all(run(prog, {"r1": x, "r2": y}).output == [x + y if op == "add" else x * y] for x, y in cases)
+    return {"behavioral_ok": behavioral_ok, "cases": len(cases), "mirror": mirror_check(b["assembly"])}
+
+
+def _deliver(intent: str, ctx: Dict[str, Any]) -> Dict[str, Any]:
+    build, verify, review = (ctx["outputs"][k] for k in ("build", "verify", "review"))
+    return {
+        "op": build["op"],
+        "operands": [build["a"], build["b"]],
+        "verified": verify["verified"],
+        "behavioral_ok": review["behavioral_ok"],
+        "backends": verify["backends"],
+        "assembly": build["assembly"],
+        "source": verify["source"],
+        "status": "shipped",
+    }
+
+
+def _gate(phase: str, output: Any) -> GateVerdict:
+    """Block the run unless verification and the behavioral battery actually pass."""
+    if phase == "verify" and not output.get("verified"):
+        return GateVerdict(False, f"verification failed: got {output.get('got')} expected [{output.get('expected')}]")
+    if phase == "review" and not output.get("behavioral_ok"):
+        return GateVerdict(False, "behavioral battery disagreed with Python arithmetic")
+    return GateVerdict(True)
+
+
+def forge(intent: str):
+    """Run the full workflow machine on a plain-English request; return the crank Catalog."""
+    phases = [
+        Phase("understand", _understand),
+        Phase("build", _build),
+        Phase("verify", _verify),
+        Phase("review", _review),
+        Phase("deliver", _deliver),
+    ]
+    return turn(intent, phases, gate=_gate)

--- a/python/loom/synth.py
+++ b/python/loom/synth.py
@@ -1,0 +1,46 @@
+"""Programmatic synthesis of Loom programs for simple arithmetic.
+
+Generate a Loom program from a spec, without an LLM — the deterministic stand-in
+for a 'build' executor in a crank workflow. Each program is plain Loom assembly
+(see ``machine``), so it inherits loom's cross-language emit and loop/mirror checks.
+
+    add:      out = a + b   (destroys a, b)
+    multiply: out = a * b   (destroys a; uses scratch; preserves b)
+"""
+
+from __future__ import annotations
+
+SUPPORTED = ("add", "multiply")
+
+
+def arith_program(op: str, a: str = "r1", b: str = "r2", out: str = "r3", scratch: str = "r4") -> str:
+    """Return Loom assembly computing `op` of registers a and b into out."""
+    if op == "add":
+        return "\n".join(
+            [
+                f"a0: dec {a} a1",  # while a > 0: out += 1
+                f"    inc {out}",
+                "    jmp a0",
+                f"a1: dec {b} a2",  # while b > 0: out += 1
+                f"    inc {out}",
+                "    jmp a1",
+                f"a2: out {out}",
+                "    halt",
+            ]
+        )
+    if op == "multiply":
+        return "\n".join(
+            [
+                f"m0: dec {a} m3",  # for each unit of a:
+                f"m1: dec {b} m2",  # add b into out, stashing b into scratch
+                f"    inc {out}",
+                f"    inc {scratch}",
+                "    jmp m1",
+                f"m2: dec {scratch} m0",  # restore b from scratch
+                f"    inc {b}",
+                "    jmp m2",
+                f"m3: out {out}",
+                "    halt",
+            ]
+        )
+    raise ValueError(f"unsupported op {op!r}; choose from {SUPPORTED}")

--- a/tests/test_codeforge.py
+++ b/tests/test_codeforge.py
@@ -1,0 +1,40 @@
+"""End-to-end tests for codeforge — messy intent -> verified cross-language code + receipt."""
+
+from python.codeforge import forge
+
+
+def test_forge_add_runs_end_to_end():
+    cat = forge("please add 3 and 4")
+    assert cat.ok is True
+    assert [r.status for r in cat.receipts] == ["ok", "ok", "ok", "ok", "ok"]
+    res = cat.result
+    assert res["op"] == "add" and res["operands"] == [3, 4]
+    assert res["verified"] is True and res["behavioral_ok"] is True
+    assert "def run()" in res["source"]["python"]
+    assert "function run()" in res["source"]["javascript"]
+    assert "#include <stdio.h>" in res["source"]["c"]
+    assert cat.chain_digest  # tamper-evident proof of the whole run
+
+
+def test_forge_multiply_runs_end_to_end():
+    cat = forge("multiply 6 by 7")
+    assert cat.ok is True
+    assert cat.result["op"] == "multiply" and cat.result["operands"] == [6, 7]
+    assert cat.result["verified"] is True and cat.result["behavioral_ok"] is True
+
+
+def test_forge_unknown_request_drifts_gracefully():
+    cat = forge("paint a fence blue")
+    assert cat.ok is False
+    assert cat.receipts[0].phase == "understand" and cat.receipts[0].status == "drift"
+    assert cat.result is None  # nothing shipped
+
+
+def test_forge_is_deterministic():
+    assert forge("add 3 and 4").chain_digest == forge("add 3 and 4").chain_digest
+
+
+def test_forge_default_operands_when_unspecified():
+    cat = forge("just add some numbers")
+    assert cat.ok is True
+    assert cat.result["operands"] == [3, 4]  # sensible defaults


### PR DESCRIPTION
The capstone that runs the product thesis **end to end**. Composes the two pieces already on `main` — **crank** (the chassis: checkpointed phases + a tamper-evident receipt chain) and **loom** (forced discrete states: one program woven into many languages, with loop/mirror checks) — into one callable surface.

`forge(intent)` turns a plain-English request into a Loom program that is **verified across languages AND against Python's own arithmetic**, and returns the crank Catalog: the receipted, tamper-evident record of the run.

## What's added (1 commit, deps already merged)
- **`python/loom/synth.py`** — programmatic Loom-program synthesis for `add` / `multiply` (Minsky primitives). The deterministic stand-in for an AI "build" executor — an LLM build phase drops in later unchanged.
- **`python/codeforge/`** — `forge(intent)` wires `understand → build → verify → review → deliver` as crank phases, with a gate that **blocks unless verification and the behavioral battery actually pass**.

## It runs for real
```
>>> "please add 3 and 4"
  ✓ understand ✓ build ✓ verify ✓ review ✓ deliver   chain bdc0035c…
  op=add operands=[3,4] verified=True behavioral_ok=True backends=[node, python, reference]
>>> "multiply 6 by 7"   -> 42, verified
>>> "paint a fence blue" -> ∅ understand: drift  (nothing shipped, surfaced honestly)
```
The woven JavaScript adder genuinely computes `3+4` and agrees with Python's reference (verified live via `node`). Failure is surfaced, not hidden: an out-of-scope request **drifts** at `understand` and ships nothing.

## Verified
- **30 tests pass** across loom + crank + codeforge (1 skipped without a C compiler).
- Deterministic: same intent → same catalog → same `chain_digest`.
- Lint clean; additive only.

This is "intent in → controlled, checkpointed steps → cataloged, verified output out" — the mechanical-calculator discipline applied to AI code work, running on real gears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)