### PR TITLE
feat(site): expose workflow machine proof

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -504,13 +504,20 @@
               <a href="https://github.com/issdandavis/SCBE-AETHERMOORE">Open repo</a>
             </article>
             <article class="card">
+              <h3>Workflow machine</h3>
+              <p>Crank, Forge memory, Village maps, and Torus addresses as runnable proof.</p>
+              <a href="workflow-machine.html">Open proof page</a>
+            </article>
+            <article class="card">
               <h3>Live pages</h3>
               <p>Browser demos are labeled as demos. Local CLI commands are labeled as local.</p>
               <a href="agents.html">Open agents page</a>
             </article>
             <article class="card">
               <h3>Research library</h3>
-              <p>Topic-indexed packets with abstracts, claim boundaries, review models, and PDFs.</p>
+              <p>
+                Topic-indexed packets with abstracts, claim boundaries, review models, and PDFs.
+              </p>
               <a href="research/">Open research</a>
             </article>
             <article class="card">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -16,6 +16,7 @@ Canonical repository: https://github.com/issdandavis/SCBE-AETHERMOORE
 - Agent demos: https://aethermoore.com/SCBE-AETHERMOORE/agents.html
 - Chat: https://aethermoore.com/SCBE-AETHERMOORE/chat.html
 - Products: https://aethermoore.com/SCBE-AETHERMOORE/products.html
+- Workflow machine proof: https://aethermoore.com/SCBE-AETHERMOORE/workflow-machine.html
 - Bookshelf and KDP/direct-process status: https://aethermoore.com/SCBE-AETHERMOORE/books.html
 - Working AI writing and security guides: https://aethermoore.com/SCBE-AETHERMOORE/guides.html
 - Behind-the-scenes writing process pack checkout: https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -91,6 +91,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://aethermoore.com/SCBE-AETHERMOORE/workflow-machine.html</loc>
+    <lastmod>2026-06-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.85</priority>
+  </url>
+  <url>
     <loc>https://aethermoore.com/SCBE-AETHERMOORE/ai-workflow-snapshot.html</loc>
     <lastmod>2026-06-08</lastmod>
     <changefreq>weekly</changefreq>

--- a/docs/static/polly-sidebar-agent.js
+++ b/docs/static/polly-sidebar-agent.js
@@ -293,7 +293,7 @@
         "<p><strong>Static Polly commands:</strong></p>" +
         '<ul class="polly-list">' +
         "<li><code>help me choose a product</code> - routes to the product picker</li>" +
-        "<li><code>how much is the workflow snapshot?</code> - returns the $39 starter path</li>" +
+        "<li><code>how much is the workflow snapshot?</code> - returns the $99 starter path</li>" +
         "<li><code>make my AI agent safer</code> - opens the governance route</li>" +
         "<li><code>/export</code> - download conversation as JSONL</li>" +
         "<li><code>/clear</code> - clear thread and memory</li>" +
@@ -324,7 +324,7 @@
     addMsg(
       thread,
       "assistant",
-      "<p>This page is in static mode, so " + esc(kind) + " is not connected here.</p><p>Use the $39 intake page to download a JSON packet, then send it through Proton/Gmail manually.</p>",
+      "<p>This page is in static mode, so " + esc(kind) + " is not connected here.</p><p>Use the $99 intake page to download a JSON packet, then send it through Proton/Gmail manually.</p>",
       chip("No backend", "lore") + chip("Static Polly", "online")
     );
   }
@@ -337,24 +337,24 @@
       return {
         intent: "guide",
         text:
-          "Best first path: start with the **$39 AI Workflow Snapshot** if you have one agent workflow, prompt chain, repo link, MCP stack, or automation flow you want reviewed.\n\n" +
+          "Best first path: start with the **$99 AI Workflow Snapshot** if you have one agent workflow, prompt chain, repo link, MCP stack, or automation flow you want reviewed.\n\n" +
           "If you only want templates, use the lower-cost toolkit/training products. If you need hands-on help, use the custom governance route.",
         actions: [
-          { label: "Start $39 Snapshot", url: "ai-workflow-snapshot.html" },
+          { label: "Start $99 Snapshot", url: "ai-workflow-snapshot.html" },
           { label: "Open product picker", url: "products.html#fitCard" },
           { label: "Ask about my setup", prompt: "I have an AI workflow. What should I send for a snapshot?" },
         ],
       };
     }
 
-    if (/(workflow snapshot|starter read|snapshot price|\$39|39 dollar|\$99|99 dollar|how much)/.test(t)) {
+    if (/(workflow snapshot|starter read|snapshot price|\$99|99 dollar|how much)/.test(t)) {
       return {
         intent: "buy",
         text:
-          "The **AI Workflow Snapshot** is the small first paid step: **$39** for one concise receipt-style read on one workflow.\n\n" +
+          "The **AI Workflow Snapshot** is the small first paid step: **$99** for one concise receipt-style read on one workflow.\n\n" +
           "You send the setup, prompt chain, repo link, MCP stack, automation flow, or workflow diagram. The output is drift risks, unsafe tool paths, observability gaps, and three next fixes.",
         actions: [
-          { label: "Start $39 Snapshot", url: "ai-workflow-snapshot.html" },
+          { label: "Start $99 Snapshot", url: "ai-workflow-snapshot.html" },
           { label: "See proof demo", url: "proof-workbench.html" },
         ],
       };
@@ -369,7 +369,7 @@
           "- **Custom governance help**: deeper review, integration, or agent-bus setup.\n\n" +
           "The useful input is concrete: the workflow, tools it can call, failure you fear, and any logs or screenshots.",
         actions: [
-          { label: "Start with $39", url: "ai-workflow-snapshot.html" },
+          { label: "Start with $99", url: "ai-workflow-snapshot.html" },
           { label: "Custom help", url: "hire.html" },
           { label: "What should I send?", prompt: "What should I send you for an AI agent workflow review?" },
         ],
@@ -418,7 +418,7 @@
       return {
         intent: "help",
         text:
-          "I can route you without a paid AI call. Ask about: **what to buy**, **$39 workflow snapshot**, **making an AI agent safer**, **SCBE**, **proof demo**, or **contacting Issac**.",
+          "I can route you without a paid AI call. Ask about: **what to buy**, **$99 workflow snapshot**, **making an AI agent safer**, **SCBE**, **proof demo**, or **contacting Issac**.",
         actions: [
           { label: "Help me choose", prompt: "What should I buy if I am new here?" },
           { label: "Snapshot price", prompt: "How much is the workflow snapshot?" },
@@ -441,7 +441,7 @@
         "- **Proof demo** if you want to see the governance receipt idea first.",
       actions: [
         { label: "Help me choose", prompt: "What should I buy if I am new here?" },
-        { label: "Start $39 Snapshot", url: "ai-workflow-snapshot.html" },
+        { label: "Start $99 Snapshot", url: "ai-workflow-snapshot.html" },
         { label: "Custom help", url: "hire.html" },
         { label: "Proof demo", url: "proof-workbench.html" },
       ],

--- a/docs/static/polly-sidebar.js
+++ b/docs/static/polly-sidebar.js
@@ -293,7 +293,7 @@
         "<p><strong>Static Polly commands:</strong></p>" +
         '<ul class="polly-list">' +
         "<li><code>help me choose a product</code> - routes to the product picker</li>" +
-        "<li><code>how much is the workflow snapshot?</code> - returns the $39 starter path</li>" +
+        "<li><code>how much is the workflow snapshot?</code> - returns the $99 starter path</li>" +
         "<li><code>make my AI agent safer</code> - opens the governance route</li>" +
         "<li><code>/export</code> - download conversation as JSONL</li>" +
         "<li><code>/clear</code> - clear thread and memory</li>" +
@@ -324,7 +324,7 @@
     addMsg(
       thread,
       "assistant",
-      "<p>This page is in static mode, so " + esc(kind) + " is not connected here.</p><p>Use the $39 intake page to download a JSON packet, then send it through Proton/Gmail manually.</p>",
+      "<p>This page is in static mode, so " + esc(kind) + " is not connected here.</p><p>Use the $99 intake page to download a JSON packet, then send it through Proton/Gmail manually.</p>",
       chip("No backend", "lore") + chip("Static Polly", "online")
     );
   }
@@ -337,24 +337,24 @@
       return {
         intent: "guide",
         text:
-          "Best first path: start with the **$39 AI Workflow Snapshot** if you have one agent workflow, prompt chain, repo link, MCP stack, or automation flow you want reviewed.\n\n" +
+          "Best first path: start with the **$99 AI Workflow Snapshot** if you have one agent workflow, prompt chain, repo link, MCP stack, or automation flow you want reviewed.\n\n" +
           "If you only want templates, use the lower-cost toolkit/training products. If you need hands-on help, use the custom governance route.",
         actions: [
-          { label: "Start $39 Snapshot", url: "ai-workflow-snapshot.html" },
+          { label: "Start $99 Snapshot", url: "ai-workflow-snapshot.html" },
           { label: "Open product picker", url: "products.html#fitCard" },
           { label: "Ask about my setup", prompt: "I have an AI workflow. What should I send for a snapshot?" },
         ],
       };
     }
 
-    if (/(workflow snapshot|starter read|snapshot price|\$39|39 dollar|\$99|99 dollar|how much)/.test(t)) {
+    if (/(workflow snapshot|starter read|snapshot price|\$99|99 dollar|how much)/.test(t)) {
       return {
         intent: "buy",
         text:
-          "The **AI Workflow Snapshot** is the small first paid step: **$39** for one concise receipt-style read on one workflow.\n\n" +
+          "The **AI Workflow Snapshot** is the small first paid step: **$99** for one concise receipt-style read on one workflow.\n\n" +
           "You send the setup, prompt chain, repo link, MCP stack, automation flow, or workflow diagram. The output is drift risks, unsafe tool paths, observability gaps, and three next fixes.",
         actions: [
-          { label: "Start $39 Snapshot", url: "ai-workflow-snapshot.html" },
+          { label: "Start $99 Snapshot", url: "ai-workflow-snapshot.html" },
           { label: "See proof demo", url: "proof-workbench.html" },
         ],
       };
@@ -369,7 +369,7 @@
           "- **Custom governance help**: deeper review, integration, or agent-bus setup.\n\n" +
           "The useful input is concrete: the workflow, tools it can call, failure you fear, and any logs or screenshots.",
         actions: [
-          { label: "Start with $39", url: "ai-workflow-snapshot.html" },
+          { label: "Start with $99", url: "ai-workflow-snapshot.html" },
           { label: "Custom help", url: "hire.html" },
           { label: "What should I send?", prompt: "What should I send you for an AI agent workflow review?" },
         ],
@@ -418,7 +418,7 @@
       return {
         intent: "help",
         text:
-          "I can route you without a paid AI call. Ask about: **what to buy**, **$39 workflow snapshot**, **making an AI agent safer**, **SCBE**, **proof demo**, or **contacting Issac**.",
+          "I can route you without a paid AI call. Ask about: **what to buy**, **$99 workflow snapshot**, **making an AI agent safer**, **SCBE**, **proof demo**, or **contacting Issac**.",
         actions: [
           { label: "Help me choose", prompt: "What should I buy if I am new here?" },
           { label: "Snapshot price", prompt: "How much is the workflow snapshot?" },
@@ -441,7 +441,7 @@
         "- **Proof demo** if you want to see the governance receipt idea first.",
       actions: [
         { label: "Help me choose", prompt: "What should I buy if I am new here?" },
-        { label: "Start $39 Snapshot", url: "ai-workflow-snapshot.html" },
+        { label: "Start $99 Snapshot", url: "ai-workflow-snapshot.html" },
         { label: "Custom help", url: "hire.html" },
         { label: "Proof demo", url: "proof-workbench.html" },
       ],

--- a/docs/workflow-machine.html
+++ b/docs/workflow-machine.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AetherMoore Workflow Machine Proof</title>
+    <meta
+      name="description"
+      content="A concrete proof surface for AetherMoore's workflow machine: Crank, Forge speak, build memory, village flow maps, and torus addressing."
+    />
+    <link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/workflow-machine.html" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #080c0e;
+        --panel: #121a1e;
+        --line: rgba(226, 204, 153, 0.24);
+        --text: #f7f0e2;
+        --muted: #aeb9b7;
+        --gold: #e0bb68;
+        --green: #22c79a;
+        --blue: #88b7ff;
+        --max: 1080px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+        line-height: 1.55;
+      }
+      a {
+        color: inherit;
+      }
+      .wrap {
+        width: min(var(--max), calc(100% - 32px));
+        margin: 0 auto;
+      }
+      header,
+      section {
+        padding: 58px 0;
+      }
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 14px;
+        padding: 18px 0;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      nav a {
+        text-decoration: none;
+      }
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+      h1 {
+        max-width: 12ch;
+        margin-bottom: 18px;
+        font-size: clamp(42px, 8vw, 82px);
+        line-height: 0.95;
+      }
+      h2 {
+        margin-bottom: 14px;
+        font-size: clamp(28px, 4vw, 44px);
+        line-height: 1.05;
+      }
+      h3 {
+        margin-bottom: 8px;
+      }
+      .eyebrow {
+        margin-bottom: 12px;
+        color: var(--gold);
+        font-size: 12px;
+        font-weight: 900;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 72ch;
+        color: #d8dfdc;
+        font-size: 21px;
+      }
+      .grid,
+      .grid-3 {
+        display: grid;
+        gap: 16px;
+      }
+      .grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .grid-3 {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+      .card {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 22px;
+        background: var(--panel);
+      }
+      .card p,
+      li {
+        color: var(--muted);
+      }
+      .tag {
+        display: inline-flex;
+        margin-bottom: 12px;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        border-radius: 999px;
+        padding: 5px 9px;
+        color: var(--gold);
+        font-size: 12px;
+        font-weight: 800;
+      }
+      code,
+      pre {
+        font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+      }
+      pre {
+        overflow-x: auto;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 8px;
+        padding: 16px;
+        background: #050708;
+        color: #d8fff3;
+        font-size: 13px;
+      }
+      .btn-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 22px;
+      }
+      .btn {
+        display: inline-flex;
+        min-height: 46px;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: 8px;
+        padding: 11px 16px;
+        background: rgba(255, 255, 255, 0.06);
+        font-weight: 900;
+        text-decoration: none;
+      }
+      .primary {
+        color: #12100a;
+        background: var(--gold);
+        border-color: var(--gold);
+      }
+      .ok {
+        color: var(--green);
+      }
+      footer {
+        padding: 36px 0 52px;
+        color: var(--muted);
+        background: #050708;
+      }
+      @media (max-width: 850px) {
+        .grid,
+        .grid-3 {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <nav aria-label="Workflow machine navigation">
+        <a href="index.html">Home</a>
+        <a href="workflow-snapshot.html">Workflow Snapshot</a>
+        <a href="proof-workbench.html">Proof Workbench</a>
+        <a href="research/">Research</a>
+        <a href="payments.html">Payments</a>
+      </nav>
+    </div>
+
+    <header>
+      <div class="wrap">
+        <p class="eyebrow">Proof surface</p>
+        <h1>The workflow machine is real code.</h1>
+        <p class="lead">
+          AetherMoore is not a receipt page. It is a controlled execution pattern for long AI work:
+          intent enters, phases settle, outputs are cataloged, and verified recipes can be reused
+          without skipping verification.
+        </p>
+        <div class="btn-row">
+          <a class="btn primary" href="workflow-snapshot.html">Buy $99 Snapshot</a>
+          <a class="btn" href="https://github.com/issdandavis/SCBE-AETHERMOORE">Open source</a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section>
+        <div class="wrap grid-3">
+          <article class="card">
+            <span class="tag">Crank</span>
+            <h2>Intent becomes settled phases.</h2>
+            <p>
+              <code>python/crank</code> turns a vague task into ordered phases. Each phase must
+              produce a non-empty output, pass a gate, and avoid repeating earlier output.
+            </p>
+          </article>
+          <article class="card">
+            <span class="tag">Forge memory</span>
+            <h2>Verified builds become recipes.</h2>
+            <p>
+              <code>scripts/forge_speak.py</code> checks build memory first. A matching verified
+              recipe skips planning, but still rebuilds and re-runs the spec.
+            </p>
+          </article>
+          <article class="card">
+            <span class="tag">Torus / village</span>
+            <h2>The map stays inspectable.</h2>
+            <p>
+              <code>scripts/village.py</code> makes a flow map compile into code.
+              <code>scripts/forge_torus.py</code> gives a build a reversible topological address.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <div class="wrap grid">
+          <article class="card">
+            <p class="eyebrow">Run it</p>
+            <h2>Plain English to verified build.</h2>
+            <pre><code>python scripts/forge_speak.py "let me tag things, find them, and export my list"</code></pre>
+            <p>
+              Expected behavior: the controller parses capabilities, assembles a real app, runs the
+              requested commands, emits a reversible prime deed, and reports
+              <strong class="ok">BUILT + VERIFIED: YES</strong> only after execution.
+            </p>
+          </article>
+          <article class="card">
+            <p class="eyebrow">Reuse rule</p>
+            <h2>Memory is not a shortcut around proof.</h2>
+            <pre><code>python scripts/forge_memory.py --recipes</code></pre>
+            <p>
+              A remembered recipe is only eligible when it is marked verified and covers the needed
+              capabilities. Reuse still rebuilds and re-verifies the spec, so the memory path is a
+              planning shortcut, not a fake success.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <div class="wrap grid">
+          <article class="card">
+            <p class="eyebrow">Mechanical model</p>
+            <h2>Why this is useful.</h2>
+            <ul>
+              <li>Mechanical calculator lesson: no half-turned gears; every phase must settle.</li>
+              <li>
+                Fixed-point lesson: convert vague work into bounded representation before running.
+              </li>
+              <li>
+                Topology lesson: lift the run into a structure where drift and collisions show up.
+              </li>
+              <li>
+                Product lesson: a buyer gets a workflow route, catalog, receipts, and next fixes.
+              </li>
+            </ul>
+          </article>
+          <article class="card">
+            <p class="eyebrow">Scope boundary</p>
+            <h2>What this does not claim.</h2>
+            <p>
+              This page does not claim legal protection, certification, autonomous correctness, or
+              universal safety. It shows a concrete workflow-control mechanism: bounded phases,
+              verification, memory reuse with re-verification, and inspectable build addresses.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="wrap">
+        <p>
+          AetherMoore sells scoped workflow artifacts: intent maps, routes, checkpoints, catalogs,
+          receipts, and next fixes.
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/scripts/forge_memory.py
+++ b/scripts/forge_memory.py
@@ -11,9 +11,11 @@ the more it builds. The win compounds with build complexity.
     python scripts/forge_memory.py "a to-do where I set deadlines and mark things done"
     python scripts/forge_memory.py --recipes      # what it has learned
 """
+
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -22,7 +24,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from forge import _MOVES, _exec, assemble, prime_signature  # noqa: E402
 from forge_speak import parse_intent, synth_spec  # noqa: E402
 
-RECIPES = Path(__file__).resolve().parent / "forge_recipes.json"
+RECIPES = Path(os.environ.get("FORGE_RECIPES_PATH") or Path(__file__).resolve().parent / "forge_recipes.json")
 
 
 def load() -> list:
@@ -44,6 +46,7 @@ def _build(moves: list, spec: dict):
     name, src, _w, used = assemble(["app m"] + [m for m in moves if m in _MOVES])
     ok = True
     import tempfile
+
     with tempfile.TemporaryDirectory() as d:
         app = Path(d) / "m.py"
         app.write_text(src, encoding="utf-8")
@@ -69,7 +72,10 @@ def build_with_memory(intent: str):
         print(f'\n  "{intent}"')
         print(f"  -> REUSED a remembered recipe (deed {hit['deed']})")
         print(f"     learned from: \"{hit['intent']}\"")
-        print(f"  -> rebuilt {len(used)} moves, verified by running: {'YES' if ok else 'NO'}   {dt:.0f}ms (no re-derivation)")
+        print(
+            f"  -> rebuilt {len(used)} moves, verified by running: "
+            f"{'YES' if ok else 'NO'}   {dt:.0f}ms (no re-derivation)"
+        )
     else:
         # derive: cover the caps with the smallest move-set, build, verify, remember
         used, src, ok = _build(caps, spec)

--- a/tests/revenue/test_public_money_path.py
+++ b/tests/revenue/test_public_money_path.py
@@ -63,9 +63,13 @@ def test_workflow_snapshot_checkout_is_consistent_and_live_wired() -> None:
 def test_ai_workflow_snapshot_has_no_stale_39_dollar_copy() -> None:
     intake = read_doc("ai-workflow-snapshot.html")
     workflow = read_doc("workflow-snapshot.html")
+    polly = read_doc("static/polly-sidebar.js")
+    polly_agent = read_doc("static/polly-sidebar-agent.js")
 
     assert "$39" not in intake
     assert "cheaper $39" not in workflow
+    assert "$39" not in polly
+    assert "$39" not in polly_agent
     assert "$99 AI Workflow Snapshot" in intake
     assert "price_usd: 99" in intake
 
@@ -103,3 +107,21 @@ def test_ai_agent_governance_category_page_is_search_targeted() -> None:
     assert "https://aethermoore.com/SCBE-AETHERMOORE/ai-workflow-snapshot.html" in sitemap
     assert "https://aethermoore.com/SCBE-AETHERMOORE/cli.html" in sitemap
     assert '<link rel="canonical" href="https://aethermoore.com/SCBE-AETHERMOORE/cli.html" />' in cli
+
+
+def test_workflow_machine_proof_page_is_discoverable_and_scoped() -> None:
+    homepage = read_doc("index.html")
+    machine = read_doc("workflow-machine.html")
+    sitemap = read_doc("sitemap.xml")
+    llms = read_doc("llms.txt")
+
+    assert 'href="workflow-machine.html"' in homepage
+    assert "https://aethermoore.com/SCBE-AETHERMOORE/workflow-machine.html" in sitemap
+    assert "Workflow machine proof" in llms
+
+    assert "Crank" in machine
+    assert "Forge memory" in machine
+    assert "scripts/forge_speak.py" in machine
+    assert "scripts/forge_memory.py --recipes" in machine
+    assert "re-verifies" in machine
+    assert "does not claim legal protection" in machine

--- a/tests/test_forge_memory.py
+++ b/tests/test_forge_memory.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+
+def test_forge_memory_honors_recipe_path_override(tmp_path, monkeypatch) -> None:
+    recipe_path = tmp_path / "recipes.json"
+    monkeypatch.setenv("FORGE_RECIPES_PATH", str(recipe_path))
+    monkeypatch.syspath_prepend(str(SCRIPTS))
+
+    forge_memory = importlib.import_module("forge_memory")
+    forge_memory = importlib.reload(forge_memory)
+
+    assert forge_memory.RECIPES == recipe_path
+    assert forge_memory.load() == []
+
+    forge_memory.save([{"intent": "x", "caps": ["add"], "moves": ["add"], "verified": True}])
+
+    assert recipe_path.exists()
+    assert forge_memory.load()[0]["intent"] == "x"
+    assert not (SCRIPTS / "forge_recipes.json").read_text(encoding="utf-8").startswith('[{"intent": "x"')
+
+    sys.modules.pop("forge_memory", None)


### PR DESCRIPTION
﻿## Summary
- Adds `docs/workflow-machine.html`, a public proof surface for Crank, Forge speak, Forge memory, Village maps, and Torus addressing.
- Links the workflow-machine proof from the homepage, `llms.txt`, and `sitemap.xml`.
- Fixes stale `$39` Polly sidebar copy so the static assistant routes users to the current `$99` Workflow Snapshot.
- Lets `scripts/forge_memory.py` honor `FORGE_RECIPES_PATH`, so proof/test runs can use temporary recipe memory without mutating the seed file.
- Adds regression coverage for workflow-machine discoverability, Polly price drift, and isolated Forge memory storage.

## Verification
- python -m pytest tests\\revenue\\test_public_money_path.py tests\\test_crank.py tests\\test_forge_memory.py -q
- python -m black --check --target-version py311 --line-length 120 scripts\\forge_memory.py tests\\test_forge_memory.py tests\\revenue\\test_public_money_path.py
- python -m ruff check scripts\\forge_memory.py tests\\test_forge_memory.py tests\\revenue\\test_public_money_path.py
- python -m flake8 --max-line-length 120 scripts\\forge_memory.py tests\\test_forge_memory.py tests\\revenue\\test_public_money_path.py
- rg stale `$39` scan on Polly/home/proof pages
- rg legal-claim scan on homepage + workflow-machine page
- git diff --check
- Playwright screenshot: artifacts/workflow-machine-page.png

## Live mechanism check
- `FORGE_RECIPES_PATH=%TEMP%\\forge-recipes-check.json python scripts\\forge_speak.py "let me tag things, find them, and export my list"` twice: first run derived + remembered, second run reused memory, both `BUILT + VERIFIED: YES`.
- `python scripts\\forge_torus.py add tag find export`
- `python scripts\\village.py`
