### PR TITLE
feat(inscribe): compact numerics — ratios, extrapolation, tokens-as-numbers

### DIFF
--- a/python/inscribe/README.md
+++ b/python/inscribe/README.md
@@ -1,0 +1,34 @@
+# inscribe
+
+Compact, exact numerics for agentic code work — three small standalone tools (stdlib only).
+
+## 1. Inscription by ratios
+Represent a value as a compact **ratio** (bounded notation), and climb a continued-fraction ladder of ever-better ratios from very little information.
+
+```python
+from python.inscribe import inscribe, ladder
+inscribe(3.14159265, max_denominator=1000)["ratio"]   # (355, 113), error ~3e-7
+ladder(3.14159265)   # [3/1, 22/7, 333/106, 355/113, ...] each more accurate
+```
+Three tiny integers pin pi to ~1e-7 — few symbols, high accuracy.
+
+## 2. Extrapolation from small information
+A few exact samples of a polynomial relationship reconstruct it **exactly** (Newton divided differences over rationals); predicting far points has zero error. The bounded notation is the short coefficient list — `n` points fix a degree `< n` polynomial.
+
+```python
+from python.inscribe import extrapolate, reconstruction_error
+extrapolate([(0,0),(1,1),(2,4)], 100)   # -> 10000  (x^2 from 3 points, exact)
+reconstruction_error(train4pts, holdout) # -> 0.0   for cubic data
+```
+**Scope (honest):** this is 1-D and exact for polynomial data. The same divided-difference scheme extends to tensor-product **multi-dimensional** grids and to rational (Padé) fits for non-polynomial data — noted as the next step, **not built here** (so it isn't oversold).
+
+## 3. Tokens as numbers (bijective numeration)
+Set a token series as your "number set" and it *is* a positional number system. With `k` symbols, **bijective base-k** gives every non-negative integer exactly one finite token sequence and back — no leading-symbol ambiguity. So you `decode → operate → encode`, and the tokens carry the arithmetic.
+
+```python
+from python.inscribe import TokenNumbers
+tn = TokenNumbers("KO AV RU CA UM DR".split())   # base 6
+tn.decode(tn.add(tn.encode(7), tn.encode(8)))     # -> 15
+tn.decode(tn.mul(tn.encode(6), tn.encode(7)))     # -> 42
+```
+Any ordered, unique alphabet works — a Sacred-Tongues 256-token grid becomes a bijective base-256 number system. This module stays standalone and takes the alphabet as data.

--- a/python/inscribe/__init__.py
+++ b/python/inscribe/__init__.py
@@ -1,0 +1,35 @@
+"""inscribe — compact numerics for agentic code work.
+
+Three small, exact tools (standalone, stdlib only):
+
+- **ratios** — inscribe a value as a compact ratio (continued-fraction convergents):
+  few integers, high accuracy (pi -> 355/113 to ~3e-7).
+- **extrapolate** — reconstruct a polynomial relationship *exactly* from a few
+  samples and predict far points with zero error (bounded coefficient notation).
+- **tokens** — bijective numeration: set a token series as your "number set" and it
+  IS a number system; decode -> operate -> encode (any Sacred-Tongues grid plugs in).
+
+    from python.inscribe import inscribe, ladder, extrapolate, TokenNumbers
+    inscribe(3.14159265)["ratio"]            # (best p/q within the denom bound)
+    extrapolate([(0,0),(1,1),(2,4)], 10)     # -> 100  (x^2 reconstructed from 3 points)
+    tn = TokenNumbers("KO AV RU CA UM DR".split())
+    tn.decode(tn.add(tn.encode(7), tn.encode(8)))   # -> 15  (arithmetic on token series)
+"""
+
+from .extrapolate import evaluate, extrapolate, fit_polynomial, reconstruction_error
+from .ratios import continued_fraction, convergents, inscribe, ladder
+from .tokens import TokenNumbers, bijective_decode, bijective_encode
+
+__all__ = [
+    "inscribe",
+    "ladder",
+    "continued_fraction",
+    "convergents",
+    "fit_polynomial",
+    "evaluate",
+    "extrapolate",
+    "reconstruction_error",
+    "bijective_encode",
+    "bijective_decode",
+    "TokenNumbers",
+]

--- a/python/inscribe/extrapolate.py
+++ b/python/inscribe/extrapolate.py
@@ -1,0 +1,72 @@
+"""Extrapolation from small information to high accuracy, with bounded notation.
+
+Given a few exact samples of a polynomial relationship, reconstruct the whole
+polynomial *exactly* (Newton divided differences over rationals) and predict any
+far point with zero error. The "bounded notation" is the short coefficient list:
+n points pin down a degree < n polynomial, so a handful of samples extrapolate
+perfectly. (1-D today; the same divided-difference scheme extends to tensor-product
+multi-dimensional grids — see the README — but that is not built here.)
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import List, Sequence, Tuple, Union
+
+Number = Union[int, float, Fraction]
+Point = Tuple[Number, Number]
+
+
+def fit_polynomial(points: Sequence[Point]) -> List[Fraction]:
+    """Exact ascending coefficients [c0, c1, ...] of the minimal-degree polynomial
+    through `points` (x values must be distinct)."""
+    pts = list(points)
+    if not pts:
+        raise ValueError("need at least one point")
+    xs = [Fraction(x) for x, _ in pts]
+    if len(set(xs)) != len(xs):
+        raise ValueError("x values must be distinct")
+
+    coef = [Fraction(y) for _, y in pts]  # Newton divided differences, in place
+    n = len(pts)
+    for j in range(1, n):
+        for i in range(n - 1, j - 1, -1):
+            coef[i] = (coef[i] - coef[i - 1]) / (xs[i] - xs[i - j])
+
+    poly: List[Fraction] = [Fraction(0)]  # standard form, ascending
+    basis: List[Fraction] = [Fraction(1)]  # running product (x - x0)(x - x1)...
+    for k in range(n):
+        for d, c in enumerate(basis):
+            if d < len(poly):
+                poly[d] += coef[k] * c
+            else:
+                poly.append(coef[k] * c)
+        if k < n - 1:  # basis *= (x - xs[k])
+            nxt = [Fraction(0)] * (len(basis) + 1)
+            for d, c in enumerate(basis):
+                nxt[d] += c * (-xs[k])
+                nxt[d + 1] += c
+            basis = nxt
+    return poly
+
+
+def evaluate(coeffs: Sequence[Fraction], x: Number) -> Fraction:
+    """Evaluate a polynomial (ascending coeffs) at x, exactly, via Horner's method."""
+    acc = Fraction(0)
+    for c in reversed(list(coeffs)):
+        acc = acc * Fraction(x) + c
+    return acc
+
+
+def extrapolate(points: Sequence[Point], at: Union[Number, Sequence[Number]]):
+    """Fit the minimal polynomial through `points` and predict at one or many x."""
+    coeffs = fit_polynomial(points)
+    if isinstance(at, (list, tuple)):
+        return [evaluate(coeffs, x) for x in at]
+    return evaluate(coeffs, at)
+
+
+def reconstruction_error(train: Sequence[Point], test: Sequence[Point]) -> float:
+    """Fit on `train`, predict `test` x's, return the max abs error (0 for polynomial data)."""
+    coeffs = fit_polynomial(train)
+    return max((abs(float(evaluate(coeffs, x)) - float(y)) for x, y in test), default=0.0)

--- a/python/inscribe/ratios.py
+++ b/python/inscribe/ratios.py
@@ -1,0 +1,61 @@
+"""Inscription by ratios — represent a value as a compact rational (bounded notation).
+
+A real value is "inscribed" as the best ratio p/q within a denominator bound, and a
+continued-fraction expansion gives a ladder of ever-better ratios from very little
+information: e.g. pi -> [3; 7, 15, 1, ...] -> 22/7, 333/106, 355/113, where 355/113
+already matches pi to ~3e-7 with three tiny integers. Few symbols, high accuracy.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import Dict, List, Union
+
+Number = Union[int, float, Fraction]
+
+
+def continued_fraction(x: Number, max_terms: int = 64) -> List[int]:
+    """The continued-fraction terms [a0; a1, a2, ...]. Finite for any rational input."""
+    frac = x if isinstance(x, Fraction) else Fraction(x).limit_denominator(10**15)
+    terms: List[int] = []
+    for _ in range(max_terms):
+        whole = frac.numerator // frac.denominator
+        terms.append(whole)
+        frac -= whole
+        if frac == 0:
+            break
+        frac = 1 / frac
+    return terms
+
+
+def convergents(cf: List[int]) -> List[Fraction]:
+    """Successive best-rational approximations p_n/q_n built from CF terms."""
+    h_prev, h = 0, 1  # numerators  (h_-2, h_-1)
+    k_prev, k = 1, 0  # denominators (k_-2, k_-1)
+    out: List[Fraction] = []
+    for a in cf:
+        h_prev, h = h, a * h + h_prev
+        k_prev, k = k, a * k + k_prev
+        out.append(Fraction(h, k))
+    return out
+
+
+def inscribe(x: float, max_denominator: int = 10**6) -> Dict[str, object]:
+    """Inscribe a real value as the best ratio with denominator <= max_denominator."""
+    frac = Fraction(x).limit_denominator(max_denominator)
+    return {
+        "ratio": (frac.numerator, frac.denominator),
+        "value": float(frac),
+        "error": abs(float(frac) - x),
+        "terms": continued_fraction(frac),
+        "max_denominator": max_denominator,
+    }
+
+
+def ladder(x: float, max_terms: int = 12) -> List[Dict[str, object]]:
+    """The accuracy ladder: each convergent of x with its error — small info, rising accuracy."""
+    cf = continued_fraction(x, max_terms=max_terms)
+    rungs: List[Dict[str, object]] = []
+    for c in convergents(cf):
+        rungs.append({"ratio": (c.numerator, c.denominator), "value": float(c), "error": abs(float(c) - x)})
+    return rungs

--- a/python/inscribe/tokens.py
+++ b/python/inscribe/tokens.py
@@ -1,0 +1,74 @@
+"""Tokens as numbers — bijective numeration over any ordered token set.
+
+Set a series of tokens as your "number set" and it *is* a positional number system:
+with k symbols, **bijective base-k** gives every non-negative integer exactly one
+finite token sequence and back — no leading-symbol ambiguity (the flaw that makes
+ordinary base-k non-bijective). So you decode -> operate -> encode, and the tokens
+carry the arithmetic.
+
+Any ordered, unique alphabet works — including a Sacred Tongues token grid (its 256
+tokens become a bijective base-256 number system); this module stays standalone and
+takes the alphabet as data.
+"""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+
+def bijective_encode(n: int, alphabet: Sequence[str]) -> List[str]:
+    """Encode a non-negative integer as a token sequence in bijective base-len(alphabet)."""
+    if n < 0:
+        raise ValueError("n must be non-negative")
+    k = len(alphabet)
+    if k < 1:
+        raise ValueError("alphabet must be non-empty")
+    if k == 1:
+        return [alphabet[0]] * n  # unary
+    out: List[str] = []
+    while n > 0:
+        n, r = divmod(n, k)
+        if r == 0:
+            r = k
+            n -= 1
+        out.append(alphabet[r - 1])  # bijective digits are 1..k
+    return list(reversed(out))
+
+
+def bijective_decode(tokens: Sequence[str], alphabet: Sequence[str]) -> int:
+    """Decode a token sequence in bijective base-len(alphabet) back to an integer."""
+    k = len(alphabet)
+    index = {t: i for i, t in enumerate(alphabet)}
+    n = 0
+    for t in tokens:
+        if t not in index:
+            raise ValueError(f"token {t!r} is not in the alphabet")
+        n = n * k + (index[t] + 1)
+    return n
+
+
+class TokenNumbers:
+    """Treat an ordered token alphabet as a number system; operate directly on token series."""
+
+    def __init__(self, alphabet: Sequence[str]) -> None:
+        if len(set(alphabet)) != len(alphabet):
+            raise ValueError("alphabet symbols must be unique")
+        if not alphabet:
+            raise ValueError("alphabet must be non-empty")
+        self.alphabet = list(alphabet)
+
+    @property
+    def base(self) -> int:
+        return len(self.alphabet)
+
+    def encode(self, n: int) -> List[str]:
+        return bijective_encode(n, self.alphabet)
+
+    def decode(self, tokens: Sequence[str]) -> int:
+        return bijective_decode(tokens, self.alphabet)
+
+    def add(self, a: Sequence[str], b: Sequence[str]) -> List[str]:
+        return self.encode(self.decode(a) + self.decode(b))
+
+    def mul(self, a: Sequence[str], b: Sequence[str]) -> List[str]:
+        return self.encode(self.decode(a) * self.decode(b))

--- a/tests/test_inscribe.py
+++ b/tests/test_inscribe.py
@@ -1,0 +1,110 @@
+"""Tests for inscribe — ratios, extrapolation, and tokens-as-numbers."""
+
+import math
+from fractions import Fraction
+
+import pytest
+
+from python.inscribe import (
+    TokenNumbers,
+    bijective_decode,
+    bijective_encode,
+    continued_fraction,
+    convergents,
+    extrapolate,
+    fit_polynomial,
+    inscribe,
+    ladder,
+    reconstruction_error,
+)
+
+# --- ratios (inscription) ----------------------------------------------------
+
+
+def test_inscribe_simple_decimals():
+    assert inscribe(0.5)["ratio"] == (1, 2)
+    assert inscribe(0.1)["ratio"] == (1, 10)
+    assert inscribe(0.25)["ratio"] == (1, 4)
+
+
+def test_inscribe_pi_is_355_over_113():
+    res = inscribe(math.pi, max_denominator=1000)
+    assert res["ratio"] == (355, 113)
+    assert res["error"] < 1e-6  # three tiny integers, high accuracy
+
+
+def test_continued_fraction_and_convergents():
+    assert continued_fraction(Fraction(22, 7)) == [3, 7]
+    conv = convergents([3, 7, 15, 1])  # pi's first terms
+    assert conv[:4] == [Fraction(3), Fraction(22, 7), Fraction(333, 106), Fraction(355, 113)]
+
+
+def test_ladder_accuracy_is_monotonic():
+    rungs = ladder(math.pi, max_terms=6)
+    errs = [r["error"] for r in rungs]
+    assert errs == sorted(errs, reverse=True)  # each rung at least as accurate
+    assert errs[-1] < 1e-4
+
+
+# --- extrapolation -----------------------------------------------------------
+
+
+def test_fit_quadratic_exactly():
+    coeffs = fit_polynomial([(0, 0), (1, 1), (2, 4)])  # y = x^2
+    assert coeffs == [Fraction(0), Fraction(0), Fraction(1)]
+
+
+def test_extrapolate_far_point_is_exact():
+    # three points of x^2 reconstruct it; predicting x=100 is exact
+    assert extrapolate([(0, 0), (1, 1), (2, 4)], 100) == Fraction(10000)
+    assert extrapolate([(0, 0), (1, 1), (2, 4)], [3, 10]) == [Fraction(9), Fraction(100)]
+
+
+def test_cubic_from_four_points_zero_error_on_holdout():
+    # y = 2x^3 - x + 5 sampled at 4 points -> exact reconstruction -> 0 error elsewhere
+    def f(x):
+        return 2 * x**3 - x + 5
+
+    train = [(x, f(x)) for x in (-1, 0, 1, 2)]
+    test = [(x, f(x)) for x in (5, 9, -4)]
+    assert reconstruction_error(train, test) == 0.0
+
+
+def test_fit_rejects_duplicate_x():
+    with pytest.raises(ValueError):
+        fit_polynomial([(1, 2), (1, 3)])
+
+
+# --- tokens as numbers (bijective numeration) --------------------------------
+
+
+@pytest.mark.parametrize("alphabet", [["a", "b"], list("0123456789"), "KO AV RU CA UM DR".split()])
+def test_bijection_round_trips(alphabet):
+    for n in range(0, 500):
+        assert bijective_decode(bijective_encode(n, alphabet), alphabet) == n
+
+
+def test_bijective_is_unique_no_leading_symbol_ambiguity():
+    seen = {}
+    for n in range(0, 300):
+        key = tuple(bijective_encode(n, ["a", "b"]))
+        assert key not in seen  # every integer -> a distinct token sequence
+        seen[key] = n
+
+
+def test_zero_is_empty_sequence():
+    assert bijective_encode(0, ["a", "b"]) == []
+    assert bijective_decode([], ["a", "b"]) == 0
+
+
+def test_token_numbers_arithmetic():
+    tn = TokenNumbers("KO AV RU CA UM DR".split())  # base 6
+    assert tn.decode(tn.add(tn.encode(7), tn.encode(8))) == 15
+    assert tn.decode(tn.mul(tn.encode(6), tn.encode(7))) == 42
+
+
+def test_token_numbers_rejects_bad_alphabet():
+    with pytest.raises(ValueError):
+        TokenNumbers(["a", "a"])  # not unique
+    with pytest.raises(ValueError):
+        bijective_decode(["z"], ["a", "b"])  # token not in alphabet


### PR DESCRIPTION
Three small, exact, **standalone** numerics tools (stdlib only) for agentic code work.

### 1. Inscription by ratios
Represent a value as a compact ratio; climb a continued-fraction ladder from little information.
`inscribe(pi, 1000)` → `(355, 113)` (error ~3e-7); `ladder(pi)` → `3/1, 22/7, 333/106, 355/113, …` each more accurate.

### 2. Extrapolation from small information
A few exact samples reconstruct a polynomial **exactly** (Newton divided differences over rationals); far-point prediction has zero error. Bounded notation = the short coefficient list.
`extrapolate([(0,0),(1,1),(2,4)], 100)` → `10000` (x² from 3 points). Cubic from 4 points → 0 holdout error.
**Honest scope:** 1-D, exact for polynomial data. Multi-dimensional (tensor-product) and rational/Padé fits are noted as the next step, **not built here**.

### 3. Tokens as numbers (bijective numeration)
Set a token series as your number set and it *is* a number system — **bijective base-k**: every integer ↔ exactly one token string, no leading-symbol ambiguity. `decode → operate → encode`.
```python
tn = TokenNumbers("KO AV RU CA UM DR".split())  # base 6
tn.decode(tn.add(tn.encode(7), tn.encode(8)))    # -> 15
```
Any ordered alphabet plugs in — a Sacred-Tongues 256-token grid becomes bijective base-256. (Stays standalone; takes the alphabet as data.)

**Verified:** 15 tests pass; lint clean; additive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)