### PR TITLE
feat(cli): add hands-free product proof commands

### DIFF
--- a/docs/workflow-machine.html
+++ b/docs/workflow-machine.html
@@ -239,21 +239,22 @@
           <article class="card">
             <p class="eyebrow">Run it</p>
             <h2>Plain English to verified build.</h2>
-            <pre><code>python scripts/forge_speak.py "let me tag things, find them, and export my list"</code></pre>
+            <pre><code>python scbe.py prove forge</code></pre>
             <p>
               Expected behavior: the controller parses capabilities, assembles a real app, runs the
-              requested commands, emits a reversible prime deed, and reports
-              <strong class="ok">BUILT + VERIFIED: YES</strong> only after execution.
+              requested commands, emits a reversible prime deed, then runs the same request again
+              through build memory. It reports <strong class="ok">BUILT + VERIFIED: YES</strong>
+              only after execution.
             </p>
           </article>
           <article class="card">
             <p class="eyebrow">Reuse rule</p>
             <h2>Memory is not a shortcut around proof.</h2>
-            <pre><code>python scripts/forge_memory.py --recipes</code></pre>
+            <pre><code>python scbe.py prove black-box</code></pre>
             <p>
-              A remembered recipe is only eligible when it is marked verified and covers the needed
-              capabilities. Reuse still rebuilds and re-verifies the spec, so the memory path is a
-              planning shortcut, not a fake success.
+              The Black Box proof path builds the buyer ZIP, runs the included scanner locally, and
+              prints the top finding plus text/JSON report paths. It is the same rule: show the
+              artifact, run it, and print where the result landed.
             </p>
           </article>
         </div>
@@ -283,7 +284,7 @@
             <p>
               This page does not claim legal protection, certification, autonomous correctness, or
               universal safety. It shows a concrete workflow-control mechanism: bounded phases,
-              verification, memory reuse with re-verification, and inspectable build addresses.
+              verification, memory reuse that re-verifies the run, and inspectable build addresses.
             </p>
           </article>
         </div>

--- a/scbe.py
+++ b/scbe.py
@@ -44,6 +44,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 import unicodedata
 from pathlib import Path
@@ -1064,6 +1065,60 @@ def cmd_system_health(args: argparse.Namespace) -> int:
     if not getattr(args, "no_write", False):
         print(f"  Artifact: {json_path}")
     return 0
+
+
+def _run_proof_subprocess(cmd: List[str], *, env: Optional[Dict[str, str]] = None, timeout: int = 180) -> int:
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.stdout:
+        print(proc.stdout, end="" if proc.stdout.endswith("\n") else "\n")
+    if proc.stderr:
+        print(proc.stderr, file=sys.stderr, end="" if proc.stderr.endswith("\n") else "\n")
+    return proc.returncode
+
+
+def cmd_prove(args: argparse.Namespace) -> int:
+    """Run the public product proof paths from one CLI entrypoint."""
+    target = args.prove_cmd
+    if target == "forge":
+        intent = args.intent or "let me tag things, find them, and export my list"
+        with tempfile.TemporaryDirectory(prefix="scbe-forge-proof-") as tmp:
+            env = os.environ.copy()
+            env["FORGE_RECIPES_PATH"] = str(Path(tmp) / "forge_recipes.json")
+            print("SCBE Forge proof run")
+            print("====================")
+            print("Run 1: derive, build, verify, remember")
+            rc1 = _run_proof_subprocess(
+                [sys.executable, str(REPO_ROOT / "scripts" / "forge_speak.py"), intent], env=env
+            )
+            if rc1 != 0:
+                return rc1
+            print()
+            print("Run 2: reuse remembered recipe, rebuild, re-verify")
+            rc2 = _run_proof_subprocess(
+                [sys.executable, str(REPO_ROOT / "scripts" / "forge_speak.py"), intent], env=env
+            )
+            if rc2 == 0:
+                print()
+                print("PROOF COMPLETE: memory reused a verified recipe and still re-ran the spec.")
+            return rc2
+
+    if target == "black-box":
+        cmd = [sys.executable, str(REPO_ROOT / "scripts" / "system" / "prove_black_box_value.py")]
+        if args.out_dir:
+            cmd.extend(["--out-dir", args.out_dir])
+        return _run_proof_subprocess(cmd, timeout=240)
+
+    print("scbe prove needs a subcommand: forge or black-box", file=sys.stderr)
+    return 2
 
 
 def cmd_tongue_encode(args: argparse.Namespace) -> int:
@@ -3015,31 +3070,31 @@ def cmd_overcreate(args: argparse.Namespace) -> int:
 
 def cmd_fold(args: argparse.Namespace) -> int:
     """Origami: unfold the cube to paper, fold a fan/crane, or play the number game."""
-    from python.scbe import origami as O
+    from python.scbe import origami
 
     prog = getattr(args, "fortune", None)
     if prog is not None:
         from python.scbe import frontdoor as F
 
         names, _ = F.tokens_to_program(prog)
-        ft = O.FortuneTeller.from_program(names)
+        ft = origami.FortuneTeller.from_program(names)
         picks = getattr(args, "pick", None) or [1]
         landed = ft.play(picks)
         print("fortune teller (from %s)" % (names or ["add"]))
         print("  cells:", ft.flaps())
-        print("  pick %s -> flap '%s' -> runs to %s" % (picks, landed, O._run_op(landed)))
+        print("  pick %s -> flap '%s' -> runs to %s" % (picks, landed, origami._run_op(landed)))
         return 0
     shape = getattr(args, "shape", None) or "net"
     if shape == "net":
         print("the cube unfolds to a sheet (its net):")
-        print(O.render_net())
+        print(origami.render_net())
     elif shape == "fan":
         n = getattr(args, "n", 6) or 6
         print("fold it into a fan (%d creases):" % n)
-        print(O.crease_pattern(O.accordion(n)))
+        print(origami.crease_pattern(origami.accordion(n)))
     elif shape == "crane":
         print("crane fold sequence:")
-        for i, step in enumerate(O.crane(), 1):
+        for i, step in enumerate(origami.crane(), 1):
             print("  %d. %s" % (i, step))
     return 0
 
@@ -4307,7 +4362,7 @@ def cmd_recent(args: argparse.Namespace) -> int:
         )
         return 0
     print(f"Your {len(items)} most recent notes:")
-    for d, p, n in items:
+    for d, _p, n in items:
         print(f"  {time.strftime('%Y-%m-%d', time.localtime(d))}  {n}")
     return 0
 
@@ -4698,6 +4753,19 @@ Legacy (backward compat):
     sh.add_argument("--top-processes", type=int, default=15)
     sh.set_defaults(func=cmd_system_health)
 
+    prove = sub.add_parser("prove", help="Run product proof paths without setup or sales copy")
+    prove_sub = prove.add_subparsers(dest="prove_cmd")
+    pf = prove_sub.add_parser("forge", help="Prove the workflow machine: derive, verify, remember, reuse")
+    pf.add_argument(
+        "intent",
+        nargs="?",
+        help='Plain-English workflow request to build (default: "let me tag things, find them, and export my list")',
+    )
+    pf.set_defaults(func=cmd_prove)
+    pb = prove_sub.add_parser("black-box", help="Build and run the PC Black Box proof bundle")
+    pb.add_argument("--out-dir", help="Output directory for the buyer ZIP and proof run")
+    pb.set_defaults(func=cmd_prove)
+
     # ─── compact verbs (human + AI surface) ───
     ak = sub.add_parser("ask", aliases=["a"], help='Ask the AI a question ("scbe ask "..."")')
     ak.add_argument("prompt", nargs="?", help="question (or pipe via stdin)")
@@ -5002,7 +5070,10 @@ Legacy (backward compat):
 
     fl = sub.add_parser(
         "fold",
-        help='Origami: unfold the cube to paper, fold a fan/crane, or the number game ("scbe fold --fortune "+ * sqrt inc" --pick 4 3 2")',
+        help=(
+            "Origami: unfold the cube to paper, fold a fan/crane, or the number game "
+            '("scbe fold --fortune "+ * sqrt inc" --pick 4 3 2")'
+        ),
     )
     fl.add_argument("--shape", choices=["net", "fan", "crane"], help="what to fold (default net)")
     fl.add_argument("--n", type=int, default=6, help="number of creases for a fan")

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -298,6 +298,7 @@ def _exec(app: Path, argv: list[str]):
     r = subprocess.run(
         [sys.executable, str(app), *argv],
         capture_output=True,
+        cwd=app.parent,
         text=True,
         encoding="utf-8",
         errors="replace",

--- a/scripts/system/prove_black_box_value.py
+++ b/scripts/system/prove_black_box_value.py
@@ -20,7 +20,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    out_dir = Path(args.out_dir)
+    out_dir = Path(args.out_dir).resolve()
     manifest = build_black_box_download(out_dir, verify=True)
     bundle_dir = out_dir / manifest["bundle_name"]
     proof_dir = bundle_dir / "proof-run"

--- a/tests/revenue/test_public_money_path.py
+++ b/tests/revenue/test_public_money_path.py
@@ -121,7 +121,7 @@ def test_workflow_machine_proof_page_is_discoverable_and_scoped() -> None:
 
     assert "Crank" in machine
     assert "Forge memory" in machine
-    assert "scripts/forge_speak.py" in machine
-    assert "scripts/forge_memory.py --recipes" in machine
+    assert "python scbe.py prove forge" in machine
+    assert "python scbe.py prove black-box" in machine
     assert "re-verifies" in machine
     assert "does not claim legal protection" in machine

--- a/tests/system/test_scbe_prove.py
+++ b/tests/system/test_scbe_prove.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_scbe_prove_forge_derives_then_reuses_memory() -> None:
+    result = subprocess.run(
+        [sys.executable, "scbe.py", "prove", "forge"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "SCBE Forge proof run" in result.stdout
+    assert "Run 1: derive, build, verify, remember" in result.stdout
+    assert "Run 2: reuse remembered recipe, rebuild, re-verify" in result.stdout
+    assert "DERIVED fresh -> REMEMBERED" in result.stdout
+    assert "REUSED memory" in result.stdout
+    assert result.stdout.count("BUILT + VERIFIED: YES") == 2
+    assert "PROOF COMPLETE" in result.stdout
+
+
+def test_scbe_prove_black_box_forwards_to_value_proof(tmp_path) -> None:
+    result = subprocess.run(
+        [sys.executable, "scbe.py", "prove", "black-box", "--out-dir", str(tmp_path)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "SCBE Black Box proof run" in result.stdout
+    assert "Top finding:" in result.stdout
+    assert "Buyer ZIP:" in result.stdout
+    assert "Text report:" in result.stdout


### PR DESCRIPTION
## What

Adds a first-class hands-free proof surface:

- `python scbe.py prove forge`
  - runs the Forge workflow machine twice with temporary build memory
  - first run derives/builds/verifies/remembers
  - second run reuses memory, rebuilds, and re-verifies
- `python scbe.py prove black-box`
  - builds the Black Box buyer ZIP
  - runs the included scanner
  - prints the top finding plus text/JSON report paths

Also fixes two proof-containment bugs found by actually running the commands:

- Forge generated apps now execute with their temp app directory as cwd, so `export` does not leak `items.md` into the repo.
- Black Box proof resolves relative `--out-dir` before bundling, so relative paths do not duplicate inside the packaged scanner command.

Updates `workflow-machine.html` to show the front-door commands instead of internal script paths.

## Verification

- `python scbe.py prove forge`
- `python scbe.py prove black-box --out-dir artifacts\prove-black-box-smoke`
- `python -m pytest tests\system\test_scbe_prove.py tests\revenue\test_public_money_path.py -q`
- `python -m black --check --target-version py311 --line-length 120 scbe.py scripts\forge.py scripts\system\prove_black_box_value.py tests\system\test_scbe_prove.py tests\revenue\test_public_money_path.py`
- `python -m ruff check --config ruff.toml scbe.py scripts\forge.py scripts\system\prove_black_box_value.py tests\system\test_scbe_prove.py tests\revenue\test_public_money_path.py`
- `python -m flake8 --max-line-length 120 scbe.py scripts\forge.py scripts\system\prove_black_box_value.py tests\system\test_scbe_prove.py tests\revenue\test_public_money_path.py`

Direct Black Box proof found a real local condition on this machine: `C:\` has limited free space, 13.3 GB free.