### PR TITLE
fix(forge,swarm): close 3 honest gaps from the OpenClaw comparison

### DIFF
--- a/scbe.py
+++ b/scbe.py
@@ -2415,6 +2415,16 @@ def cmd_forge(args: argparse.Namespace) -> int:
 
     as_json = getattr(args, "json_output", False)
 
+    # --chat: conversational front for messy/plain words -- talk until it's buildable
+    if getattr(args, "chat", False):
+        try:
+            from forge_chat import chat_loop
+        except Exception as exc:  # pragma: no cover - import guard
+            print(f"chat unavailable: {exc}")
+            return 1
+        chat_loop()
+        return 0
+
     # --recipes: show what the Forge has already learned (its build memory)
     if getattr(args, "recipes", False):
         try:
@@ -4963,6 +4973,9 @@ Legacy (backward compat):
     forge_p.add_argument("--village", action="store_true", help="also show the build as a village map (flow view)")
     forge_p.add_argument("--torus", action="store_true", help="also lift the build onto SCBE's 3-torus (topology view)")
     forge_p.add_argument("--recipes", action="store_true", help="show what the Forge has learned (build memory)")
+    forge_p.add_argument(
+        "--chat", action="store_true", help="conversational mode -- talk in plain words until it can build"
+    )
     forge_p.add_argument(
         "--json", dest="json_output", action="store_true", help="machine-readable output (stable key set)"
     )

--- a/scripts/forge.py
+++ b/scripts/forge.py
@@ -160,7 +160,12 @@ def main(argv=None):
             sp.add_argument(aname, **akw)
     args = p.parse_args(argv)
     items = _load()
-    COMMANDS[args.cmd]["fn"](args, items)
+    try:
+        COMMANDS[args.cmd]["fn"](args, items)
+    except IndexError:
+        idx = getattr(args, "index", "?")
+        print(f"no item at index {{idx}} (have {{len(items)}})")
+        raise SystemExit(2)
     _save(items)
 
 

--- a/scripts/forge_chat.py
+++ b/scripts/forge_chat.py
@@ -173,17 +173,9 @@ class Conversation:
         return False
 
 
-def main():
-    says = [a for i, a in enumerate(sys.argv) if sys.argv[i - 1] == "--say"]
+def chat_loop():
+    """Interactive conversational build loop. Shared by this script and `scbe forge --chat`."""
     convo = Conversation()
-    if says:  # scripted (for tests / demos)
-        for line in says:
-            print(f"\n  YOU: {line}")
-            if convo.turn(line):
-                break
-        else:
-            print("\n  (still gathering -- add another --say, or it builds once it's buildable)")
-        return
     print("  AETHER: tell me what you want to make. plain words. (ctrl+c to quit)")
     try:
         while True:
@@ -197,6 +189,20 @@ def main():
                 convo.__init__()
     except (KeyboardInterrupt, EOFError):
         print("\n  later.")
+
+
+def main():
+    says = [a for i, a in enumerate(sys.argv) if sys.argv[i - 1] == "--say"]
+    if says:  # scripted (for tests / demos)
+        convo = Conversation()
+        for line in says:
+            print(f"\n  YOU: {line}")
+            if convo.turn(line):
+                break
+        else:
+            print("\n  (still gathering -- add another --say, or it builds once it's buildable)")
+        return
+    chat_loop()
 
 
 if __name__ == "__main__":

--- a/scripts/system/openclaw_swarm.py
+++ b/scripts/system/openclaw_swarm.py
@@ -586,6 +586,14 @@ def extract_file_declarations(path: str, limit: int = 24) -> list[str]:
         r"\bfunction\s+([A-Za-z_][A-Za-z0-9_]*)",
         r"\b(?:const|let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=",
         r"\bexport\s+(?:class|function|const|let)\s+([A-Za-z_][A-Za-z0-9_]*)",
+        # TypeScript (the repo's canonical language): interfaces, type aliases, enums,
+        # abstract classes, and `export default class/function` were previously missed,
+        # producing false symbol_not_found flags on valid .ts patches.
+        r"\b(?:export\s+)?interface\s+([A-Za-z_][A-Za-z0-9_]*)",
+        r"\b(?:export\s+)?type\s+([A-Za-z_][A-Za-z0-9_]*)\s*[=<]",
+        r"\b(?:export\s+)?(?:const\s+)?enum\s+([A-Za-z_][A-Za-z0-9_]*)",
+        r"\b(?:export\s+)?abstract\s+class\s+([A-Za-z_][A-Za-z0-9_]*)",
+        r"\bexport\s+default\s+(?:abstract\s+)?(?:class|function)\s+([A-Za-z_][A-Za-z0-9_]*)",
     )
     for pattern in patterns:
         declarations.extend(match.group(1) for match in re.finditer(pattern, content))
@@ -1067,13 +1075,19 @@ def _file_contains_symbol(path: str, symbol: str) -> bool:
         content = target.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
+    name = re.escape(symbol)
     patterns = (
-        rf"\bclass\s+{re.escape(symbol)}\b",
-        rf"\bdef\s+{re.escape(symbol)}\b",
-        rf"\bfunction\s+{re.escape(symbol)}\b",
-        rf"\bconst\s+{re.escape(symbol)}\b",
-        rf"\blet\s+{re.escape(symbol)}\b",
-        rf"\bexport\s+(?:class|function|const|let)\s+{re.escape(symbol)}\b",
+        rf"\bclass\s+{name}\b",
+        rf"\bdef\s+{name}\b",
+        rf"\bfunction\s+{name}\b",
+        rf"\b(?:const|let|var)\s+{name}\b",
+        rf"\bexport\s+(?:class|function|const|let)\s+{name}\b",
+        # TypeScript declarations (canonical language) the old patterns missed
+        rf"\binterface\s+{name}\b",
+        rf"\btype\s+{name}\b",
+        rf"\benum\s+{name}\b",
+        rf"\babstract\s+class\s+{name}\b",
+        rf"\bexport\s+default\s+(?:abstract\s+)?(?:class|function)\s+{name}\b",
     )
     return any(re.search(pattern, content) for pattern in patterns)
 


### PR DESCRIPTION
Turns three caveats from the OpenClaw comparison into fixes: (1) TypeScript-aware symbol validation in the swarm router (strengthens the applicability gate on the repo's canonical language; 34 tests still pass), (2) emitted forge apps return a clean error + exit 2 instead of a raw IndexError, (3) `scbe forge --chat` wires the conversational front into the one front door. All verified by execution. Deferred the genuinely hard items (L13 novel-attack recall, cross-file symbol resolution, real external-agent launch) rather than fake them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--chat` mode to `scbe forge` command for interactive conversations.

* **Bug Fixes**
  * Improved error handling for invalid item indices—now displays user-friendly error messages instead of crashes.
  * Enhanced TypeScript declaration recognition in code analysis for more accurate symbol detection.

* **Refactor**
  * Reorganized chat functionality for improved modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->