### PR TITLE
fix(openclaw): resolve imported Python symbols

### DIFF
--- a/scripts/system/openclaw_swarm.py
+++ b/scripts/system/openclaw_swarm.py
@@ -16,6 +16,7 @@ looks good, feed its unified diff through ``scripts/agents/safe_apply.py``.
 from __future__ import annotations
 
 import argparse
+import ast
 import importlib.util
 import json
 import os
@@ -1075,6 +1076,14 @@ def _file_contains_symbol(path: str, symbol: str) -> bool:
         content = target.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
+    if _text_declares_symbol(content, symbol):
+        return True
+    if target.suffix == ".py":
+        return _python_import_makes_symbol_available(target, content, symbol)
+    return False
+
+
+def _text_declares_symbol(content: str, symbol: str) -> bool:
     name = re.escape(symbol)
     patterns = (
         rf"\bclass\s+{name}\b",
@@ -1090,6 +1099,57 @@ def _file_contains_symbol(path: str, symbol: str) -> bool:
         rf"\bexport\s+default\s+(?:abstract\s+)?(?:class|function)\s+{name}\b",
     )
     return any(re.search(pattern, content) for pattern in patterns)
+
+
+def _python_import_makes_symbol_available(target: Path, content: str, symbol: str) -> bool:
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return False
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ImportFrom):
+            if any((alias.asname or alias.name).split(".")[0] == symbol for alias in node.names):
+                source = _resolve_python_import_source(target, node.module, node.level)
+                if source is None:
+                    if node.level:
+                        return False
+                    # Imported from stdlib/third-party or a module outside this repo. It is
+                    # available to the file even though this repo cannot prove its declaration.
+                    return True
+                try:
+                    source_text = source.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    return False
+                return _text_declares_symbol(source_text, symbol)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                exposed = alias.asname or alias.name.split(".")[0]
+                if exposed == symbol:
+                    return True
+    return False
+
+
+def _resolve_python_import_source(target: Path, module: str | None, level: int) -> Path | None:
+    if level:
+        base = target.parent
+        for _ in range(max(0, level - 1)):
+            base = base.parent
+        parts = module.split(".") if module else []
+        candidates = [base.joinpath(*parts).with_suffix(".py"), base.joinpath(*parts, "__init__.py")]
+    elif module:
+        parts = module.split(".")
+        candidates = [
+            REPO_ROOT.joinpath(*parts).with_suffix(".py"),
+            REPO_ROOT.joinpath(*parts, "__init__.py"),
+            REPO_ROOT.joinpath("src", *parts).with_suffix(".py"),
+            REPO_ROOT.joinpath("src", *parts, "__init__.py"),
+        ]
+    else:
+        return None
+    for candidate in candidates:
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    return None
 
 
 def quality_flags(

--- a/tests/test_openclaw_swarm.py
+++ b/tests/test_openclaw_swarm.py
@@ -252,6 +252,65 @@ def test_quality_flags_reject_missing_context_symbol():
     assert "symbol_not_found:scripts/system/scbe_swarm_router.py#DefinitelyMissingRouter" in flags
 
 
+def test_quality_flags_accept_symbol_imported_from_local_python_module():
+    module = load_module()
+
+    text = """
+    1. Decision: build
+    2. Files:
+       - src/cddm/tongue_domains.py
+    3. Patch:
+    ```diff
+    --- a/src/cddm/tongue_domains.py
+    +++ b/src/cddm/tongue_domains.py
+    @@ -31,6 +31,7 @@ TONGUE_DOMAINS: Dict[str, Domain] = {
+         "KO": Domain("Energy", units=("Joule",), bounds=(0, 1e6)),
+    ```
+    4. Verification: python -m py_compile src/cddm/tongue_domains.py
+    """
+
+    flags = module.quality_flags(text, ("src/",), require_paths=True)
+
+    assert "symbol_not_found:src/cddm/tongue_domains.py#Domain" not in flags
+
+
+def test_file_contains_symbol_resolves_local_python_imports():
+    module = load_module()
+
+    assert module._file_contains_symbol("src/cddm/tongue_domains.py", "Domain") is True
+
+
+def test_file_contains_symbol_resolves_src_layout_absolute_import(tmp_path):
+    module = load_module()
+    probe = Path("artifacts") / "tmp_symbol_probe.py"
+    target = REPO_ROOT / probe
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("from cddm.domain import Domain\n\nvalue = Domain\n", encoding="utf-8")
+    try:
+        assert module._file_contains_symbol(probe.as_posix(), "Domain") is True
+    finally:
+        target.unlink(missing_ok=True)
+
+
+def test_file_contains_symbol_still_rejects_missing_local_symbol():
+    module = load_module()
+
+    assert module._file_contains_symbol("src/cddm/tongue_domains.py", "NotDomain") is False
+
+
+def test_file_contains_symbol_rejects_missing_relative_import(tmp_path):
+    module = load_module()
+    probe_dir = REPO_ROOT / "artifacts" / "tmp_symbol_pkg"
+    probe_dir.mkdir(parents=True, exist_ok=True)
+    probe = probe_dir / "module.py"
+    probe.write_text("from .missing import MissingThing\n\nvalue = MissingThing\n", encoding="utf-8")
+    try:
+        assert module._file_contains_symbol("artifacts/tmp_symbol_pkg/module.py", "MissingThing") is False
+    finally:
+        probe.unlink(missing_ok=True)
+        probe_dir.rmdir()
+
+
 def test_quality_flags_reject_evidence_symbols_not_present_in_checked_files():
     module = load_module()
 


### PR DESCRIPTION
## What

Fixes the measured OpenClaw applicability false-positive where imported Python symbols were treated as missing because `_file_contains_symbol()` only checked declarations inside the same file.

Now `_file_contains_symbol()`:

- still accepts declarations in the target file;
- parses Python imports with `ast`;
- resolves relative local imports like `from .domain import Domain`;
- resolves repo `src/` absolute imports like `from cddm.domain import Domain`;
- treats stdlib/third-party imports as available instead of invented;
- still rejects missing local relative imports.

This closes the concrete `src/cddm/tongue_domains.py` / `Domain` false-blocker from the benchmark notes.

## Verification

- `python -m pytest tests\test_openclaw_swarm.py -q` -> 39 passed
- `python -m black --check --target-version py311 --line-length 120 scripts\system\openclaw_swarm.py tests\test_openclaw_swarm.py`
- `python -m ruff check --config ruff.toml scripts\system\openclaw_swarm.py tests\test_openclaw_swarm.py`
- `python -m flake8 --max-line-length 120 scripts\system\openclaw_swarm.py tests\test_openclaw_swarm.py`