### PR TITLE
fix(geoseal): make quarantine fail closed by default

### DIFF
--- a/src/crypto/geoseal_execution_gate.py
+++ b/src/crypto/geoseal_execution_gate.py
@@ -456,7 +456,7 @@ def scan_command(
     return ExecGateDecision(
         command_sha256=_sha256_text(command),
         tier=tier,
-        allowed=tier != "DENY",
+        allowed=tier == "ALLOW",
         argv=argv,
         findings=findings,
         parser_ok=not any(finding.rule == "parse-error" for finding in findings),
@@ -547,7 +547,7 @@ def execute_governed_command(
     if max_tier not in TIER_RANK:
         raise ValueError(f"unknown max_tier: {max_tier}")
     decision = scan_command(command, claimed_paths=claimed_paths)
-    allowed_by_threshold = decision.allowed and TIER_RANK[decision.tier] <= TIER_RANK[max_tier]
+    allowed_by_threshold = decision.tier != "DENY" and TIER_RANK[decision.tier] <= TIER_RANK[max_tier]
     started = time.time()
     resolved_argv, runtime_note = _resolve_runtime(decision.argv)
 
@@ -645,7 +645,7 @@ def simulate_command(
     if max_tier not in TIER_RANK:
         raise ValueError(f"unknown max_tier: {max_tier}")
     decision = scan_command(command, claimed_paths=claimed_paths)
-    would_run = decision.allowed and TIER_RANK[decision.tier] <= TIER_RANK[max_tier]
+    would_run = decision.tier != "DENY" and TIER_RANK[decision.tier] <= TIER_RANK[max_tier]
     resolved_argv, runtime_note = _resolve_runtime(decision.argv)
     blocked_reason: Optional[str] = None
     if not would_run:

--- a/tests/crypto/test_geoseal_execution_gate.py
+++ b/tests/crypto/test_geoseal_execution_gate.py
@@ -108,7 +108,7 @@ def test_inline_interpreter_is_quarantine_not_deny() -> None:
     decision = scan_command(f"{sys.executable} -c \"print('ok')\"")
 
     assert decision.tier == "QUARANTINE"
-    assert decision.allowed
+    assert not decision.allowed
     assert any(finding.rule == "inline-interpreter" for finding in decision.findings)
 
 
@@ -229,7 +229,7 @@ def test_inline_python_destructive_payload_is_denied() -> None:
 def test_benign_inline_python_payload_stays_quarantine() -> None:
     decision = scan_command(f'{sys.executable} -c "print(2 + 2)"')
     assert decision.tier == "QUARANTINE"
-    assert decision.allowed
+    assert not decision.allowed
     assert not any(f.rule.startswith("inline-danger") for f in decision.findings)
 
 
@@ -256,6 +256,19 @@ def test_simulate_blocks_a_destructive_command() -> None:
     assert sim.decision.tier == "DENY"
     assert sim.blocked_reason == "gate denied"
     assert sim.summary.startswith("BLOCKED")
+
+
+def test_simulate_fails_closed_on_quarantine_by_default() -> None:
+    command = f'{sys.executable} -c "print(1)"'
+
+    default_cap = simulate_command(command, max_tier="ALLOW")
+    explicit_cap = simulate_command(command, max_tier="QUARANTINE")
+
+    assert default_cap.decision.tier == "QUARANTINE"
+    assert not default_cap.decision.allowed
+    assert not default_cap.would_run
+    assert default_cap.blocked_reason == "tier QUARANTINE exceeds max ALLOW"
+    assert explicit_cap.would_run
 
 
 def test_simulate_never_invokes_subprocess(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- make `ExecGateDecision.allowed` fail closed: only `ALLOW` is true
- keep explicit `max_tier=QUARANTINE` execution/simulation support for controlled harnesses
- add a regression proving default `ALLOW` cap blocks quarantine-tier inline interpreter commands

## Why
The previous boolean treated `QUARANTINE` as allowed. That made product surfaces and callers that only looked at `decision.allowed` fail open. Now the boolean means default-safe/pass, while explicit tier caps still govern deliberate harness execution.

## Verification
- `python -m pytest tests\crypto\test_geoseal_execution_gate.py -q`
- `python -m pytest tests\smoke\test_npm_geoseal_bin.py -q`
- `python -m black --check --target-version py311 --line-length 120 src\crypto\geoseal_execution_gate.py tests\crypto\test_geoseal_execution_gate.py`
- `python -m flake8 --max-line-length 120 src\crypto\geoseal_execution_gate.py tests\crypto\test_geoseal_execution_gate.py`