### PR TITLE
feat(helm): the operator loop — AI runs reversible work, humans approve the gates

### DIFF
--- a/python/helm/README.md
+++ b/python/helm/README.md
@@ -1,0 +1,39 @@
+# Helm — the operator loop
+
+**An objective comes in; the AI runs the reversible work itself and parks the human-gated steps in an approval queue.** The realization of "let the AI run the whole thing" — honestly scoped: the AI runs the ~90% that's reversible and low-stakes, and a human clears the ~10% that law and security require a human for.
+
+Standalone (stdlib only). Steps are pluggable callables, so the real work plugs straight in: **codeforge** (build + verify), the **governance gate** (safe-to-act), `crank` (receipted sub-runs), shell/tools.
+
+## What's gated vs autonomous
+The default policy parks a step for human approval if its kind is **spend / deploy / publish / legal / destructive / admin / credential / email**, *or* if it's flagged **irreversible**. Everything else (`build`, `verify`, `research`, `draft`, `edit`, …) the AI runs on its own.
+
+Why: paying money needs a human's identity (KYC); shipping to prod needs a human's "ship it"; some approvals are a human-only click (the Windows UAC prompt is the canonical case). Helm runs everything up to those gates.
+
+## Use
+```python
+from python.helm import Step, run_objective, render
+
+steps = [
+    Step("research", "research", lambda obj, ctx: f"notes on {obj}"),
+    Step("build",    "build",    lambda obj, ctx: ctx),          # autonomous
+    Step("verify",   "verify",   lambda obj, ctx: ctx),          # autonomous
+    Step("deploy",   "deploy",   lambda obj, ctx: ship(ctx)),    # GATED -> queued
+    Step("charge",   "spend",    lambda obj, ctx: billing()),    # GATED -> queued
+]
+
+run = run_objective("ship the tool", steps)
+run.needs_human          # True
+print(render(run))       # shows what ran + the queue waiting on you
+
+# after you approve a gated step, re-run with its name approved -> it executes:
+run2 = run_objective("ship the tool", steps, approvals={"deploy"})
+```
+
+## Properties
+- **The gates actually hold:** a gated step's action is *never called* until it's in `approvals`. Tests prove the side-effects don't fire.
+- **Auditable:** every step is receipted into a tamper-evident chain (`chain_digest`); same objective + steps → same chain.
+- **Resilient:** an autonomous step that raises is recorded `failed` and the loop continues.
+- **Human-in-the-loop:** re-run with a growing `approvals` set; parked gates execute once approved.
+
+## Composes with the rest
+A `build` step can be `codeforge.forge(objective)` (AI writes + verifies code, refuses unverified); a `verify` step can run the governance gate; `deploy`/`spend` stay gated. That's the operator: the AI drives the build→verify loop autonomously and only taps you for the money/ship/legal gates.

--- a/python/helm/__init__.py
+++ b/python/helm/__init__.py
@@ -1,0 +1,45 @@
+"""Helm — the operator loop: AI runs the reversible work, humans approve the gates.
+
+    from python.helm import Step, run_objective, render
+
+    steps = [
+        Step("research", "research", lambda obj, ctx: f"notes on {obj}"),
+        Step("build",    "build",    lambda obj, ctx: build_it(obj)),       # autonomous
+        Step("verify",   "verify",   lambda obj, ctx: verify(ctx)),          # autonomous
+        Step("deploy",   "deploy",   lambda obj, ctx: ship_to_prod(ctx)),    # GATED -> queued
+        Step("charge",   "spend",    lambda obj, ctx: enable_billing()),     # GATED -> queued
+    ]
+    run = run_objective("ship the tool", steps)
+    run.needs_human            # True — deploy + charge are queued
+    print(render(run))
+    # after you approve:
+    run2 = run_objective("ship the tool", steps, approvals={"deploy"})  # deploy now executes
+
+The loop runs everything reversible/low-stakes itself and parks money/deploy/legal/
+destructive/admin steps for a human. Steps are pluggable callables, so codeforge
+(build+verify), the governance gate, and shell/tools drop straight in.
+"""
+
+from .machine import (
+    HUMAN_GATED_KINDS,
+    Action,
+    GateVerdict,
+    OperatorRun,
+    Receipt,
+    Step,
+    default_policy,
+    render,
+    run_objective,
+)
+
+__all__ = [
+    "Step",
+    "Action",
+    "GateVerdict",
+    "Receipt",
+    "OperatorRun",
+    "run_objective",
+    "render",
+    "default_policy",
+    "HUMAN_GATED_KINDS",
+]

--- a/python/helm/machine.py
+++ b/python/helm/machine.py
@@ -1,0 +1,205 @@
+"""Helm — the operator loop.
+
+An objective comes in; the AI runs every **reversible, low-stakes** step on its
+own, and **parks the human-gated steps** (spend money, deploy, sign/legal, anything
+destructive or irreversible, admin/credential access) in an **approval queue** for
+a human to clear. The AI runs the 90%; you approve the 10% that law and security
+require a human for.
+
+Why it's built this way: there is an irreducible set of actions no autonomous agent
+can (or should) take alone — paying money needs a human's identity, deploying to
+prod needs a human's "ship it", and some approvals are literally a human-only click
+(the Windows UAC prompt is the canonical example). Helm runs everything up to those
+gates and surfaces them as a short, explicit queue.
+
+Each step is receipted into a tamper-evident chain, so the run is auditable. Steps
+are pluggable callables, so the real work (codeforge to build, the gate to verify,
+shell/tools to act) drops in as the step's action — the loop itself stays
+deterministic and testable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+# A step's action does the work: (objective, context) -> result.
+Action = Callable[[str, Dict[str, Any]], Any]
+
+# Kinds that ALWAYS require a human approval (by law / security / irreversibility).
+HUMAN_GATED_KINDS = frozenset(
+    {
+        "spend",  # money / payments / payouts (needs a human's identity)
+        "deploy",  # ship to prod / external infra
+        "publish",  # post publicly / send to customers
+        "legal",  # sign, accept terms, accept liability
+        "destructive",  # delete / overwrite / wipe
+        "admin",  # elevated / system / UAC-gated
+        "credential",  # create or hand out secrets/keys
+        "email",  # send mail on someone's behalf
+    }
+)
+
+
+@dataclass
+class Step:
+    name: str
+    kind: str  # "build" | "verify" | "draft" | "research" | "deploy" | "spend" | ...
+    do: Action  # the action; only called when the step is autonomous OR approved
+    reversible: bool = True
+    note: str = ""
+
+
+@dataclass
+class GateVerdict:
+    gated: bool
+    reason: str = ""
+
+
+def default_policy(step: Step) -> GateVerdict:
+    """Conservative default: gate anything that costs money, ships, is irreversible,
+    or needs elevated/legal authority. Everything else the AI may do on its own."""
+    if step.kind in HUMAN_GATED_KINDS:
+        return GateVerdict(True, f"'{step.kind}' requires human approval")
+    if not step.reversible:
+        return GateVerdict(True, "irreversible action requires human approval")
+    return GateVerdict(False)
+
+
+@dataclass
+class Receipt:
+    step: str
+    kind: str
+    status: str  # done | pending-approval | approved-done | failed
+    chain: str
+    result_digest: Optional[str] = None
+    reason: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "step": self.step,
+            "kind": self.kind,
+            "status": self.status,
+            "chain": self.chain,
+            "result_digest": self.result_digest,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class OperatorRun:
+    objective: str
+    receipts: List[Receipt]
+    results: Dict[str, Any]  # outputs of completed steps (autonomous + approved)
+    approval_queue: List[Dict[str, str]]  # gated steps awaiting a human
+    chain_digest: str
+    autonomous_done: int
+    approved_done: int
+    pending_approval: int
+    failed: int
+
+    @property
+    def needs_human(self) -> bool:
+        return self.pending_approval > 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "objective": self.objective,
+            "chain_digest": self.chain_digest,
+            "counts": {
+                "autonomous_done": self.autonomous_done,
+                "approved_done": self.approved_done,
+                "pending_approval": self.pending_approval,
+                "failed": self.failed,
+            },
+            "approval_queue": self.approval_queue,
+            "receipts": [r.to_dict() for r in self.receipts],
+        }
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:16]
+
+
+def run_objective(
+    objective: str,
+    steps: List[Step],
+    policy: Callable[[Step], GateVerdict] = default_policy,
+    approvals: Optional[set] = None,
+) -> OperatorRun:
+    """Run an objective. Autonomous steps execute; gated steps are queued unless their
+    name is in ``approvals`` (a human's go-ahead), in which case they execute too.
+
+    Re-run with a growing ``approvals`` set to model the human-in-the-loop: first run
+    parks the gates; after the human approves some, re-run and those gates execute.
+    """
+    approved = set(approvals or set())
+    context: Dict[str, Any] = {"objective": objective, "results": {}}
+    receipts: List[Receipt] = []
+    queue: List[Dict[str, str]] = []
+    chain = _digest(["helm.v1", objective])
+    auto_done = appr_done = pending = failed = 0
+
+    for step in steps:
+        verdict = policy(step)
+        if verdict.gated and step.name not in approved:
+            chain = _digest([chain, step.name, "pending-approval"])
+            receipts.append(Receipt(step.name, step.kind, "pending-approval", chain, reason=verdict.reason))
+            queue.append({"step": step.name, "kind": step.kind, "reason": verdict.reason, "note": step.note})
+            pending += 1
+            continue
+
+        was_gated = verdict.gated  # gated-but-approved vs ordinary autonomous
+        try:
+            result = step.do(objective, context)
+        except Exception as exc:  # one step failing must not abort the operator
+            chain = _digest([chain, step.name, "failed"])
+            receipts.append(Receipt(step.name, step.kind, "failed", chain, reason=f"{type(exc).__name__}: {exc}"))
+            failed += 1
+            continue
+
+        rd = _digest(result)
+        context["results"][step.name] = result
+        status = "approved-done" if was_gated else "done"
+        chain = _digest([chain, step.name, status, rd])
+        receipts.append(Receipt(step.name, step.kind, status, chain, result_digest=rd))
+        if was_gated:
+            appr_done += 1
+        else:
+            auto_done += 1
+
+    return OperatorRun(
+        objective=objective,
+        receipts=receipts,
+        results=context["results"],
+        approval_queue=queue,
+        chain_digest=chain,
+        autonomous_done=auto_done,
+        approved_done=appr_done,
+        pending_approval=pending,
+        failed=failed,
+    )
+
+
+def render(run: OperatorRun) -> str:
+    """Human-readable run state: what the AI did, and the queue waiting on you."""
+    glyph = {"done": "✓", "approved-done": "✓+", "pending-approval": "⏸", "failed": "✗"}
+    head = (
+        f"helm · {run.objective!r} · {run.autonomous_done} auto-done"
+        f"{f', {run.approved_done} approved' if run.approved_done else ''}"
+        f"{f', {run.failed} failed' if run.failed else ''}"
+        f"{f', {run.pending_approval} AWAITING YOU' if run.pending_approval else ''}"
+        f" · chain {run.chain_digest}"
+    )
+    lines = [head]
+    for r in run.receipts:
+        mark = glyph.get(r.status, "?")
+        tail = f"  ← {r.reason}" if r.reason else ""
+        lines.append(f"  {mark} {r.step} ({r.kind}){tail}")
+    if run.approval_queue:
+        lines.append("\nAPPROVAL QUEUE (clear these and re-run with their names approved):")
+        for q in run.approval_queue:
+            lines.append(f"  • {q['step']} — {q['reason']}" + (f" — {q['note']}" if q["note"] else ""))
+    return "\n".join(lines)

--- a/tests/test_helm.py
+++ b/tests/test_helm.py
@@ -1,0 +1,100 @@
+"""Tests for Helm — the operator loop (AI runs reversible work, humans approve gates)."""
+
+from python.helm import Step, default_policy, render, run_objective
+
+
+def _steps(side_effects):
+    """A realistic objective: research/build/verify are autonomous; deploy + charge are gated.
+    `side_effects` is a dict the actions flip so we can prove what actually ran."""
+
+    def mark(name):
+        def action(obj, ctx):
+            side_effects[name] = True
+            return f"{name}:{obj}"
+
+        return action
+
+    return [
+        Step("research", "research", mark("research")),
+        Step("build", "build", mark("build")),
+        Step("verify", "verify", mark("verify")),
+        Step("deploy", "deploy", mark("deploy")),  # gated
+        Step("charge", "spend", mark("charge")),  # gated
+    ]
+
+
+def test_autonomous_steps_run_gated_steps_are_parked():
+    fx = {}
+    run = run_objective("ship the tool", _steps(fx))
+    # the reversible work ran
+    assert fx == {"research": True, "build": True, "verify": True}
+    # the gated work did NOT run — it's queued, not executed
+    assert "deploy" not in fx and "charge" not in fx
+    assert run.autonomous_done == 3 and run.pending_approval == 2
+    assert run.needs_human is True
+    assert {q["step"] for q in run.approval_queue} == {"deploy", "charge"}
+
+
+def test_approval_lets_a_gated_step_execute():
+    fx = {}
+    run = run_objective("ship the tool", _steps(fx), approvals={"deploy"})
+    assert fx.get("deploy") is True  # deploy ran because it was approved
+    assert "charge" not in fx  # charge still parked
+    assert run.approved_done == 1 and run.pending_approval == 1
+    deploy = next(r for r in run.receipts if r.step == "deploy")
+    assert deploy.status == "approved-done"
+
+
+def test_irreversible_step_is_gated_even_if_kind_is_benign():
+    fx = {}
+    steps = [Step("rewrite_history", "edit", lambda o, c: fx.setdefault("ran", True), reversible=False)]
+    run = run_objective("x", steps)
+    assert "ran" not in fx and run.pending_approval == 1
+    assert "irreversible" in run.approval_queue[0]["reason"]
+
+
+def test_failing_autonomous_step_does_not_abort_the_run():
+    def boom(obj, ctx):
+        raise RuntimeError("kaboom")
+
+    fx = {}
+    steps = [
+        Step("a", "build", lambda o, c: fx.setdefault("a", True)),
+        Step("b", "build", boom),
+        Step("c", "build", lambda o, c: fx.setdefault("c", True)),
+    ]
+    run = run_objective("x", steps)
+    assert fx == {"a": True, "c": True}  # c still ran after b failed
+    assert run.failed == 1 and run.autonomous_done == 2
+    assert next(r for r in run.receipts if r.step == "b").status == "failed"
+
+
+def test_run_is_deterministic_and_chain_tamper_evident():
+    a = run_objective("same", _steps({}))
+    b = run_objective("same", _steps({}))
+    assert a.chain_digest == b.chain_digest
+    # a different objective -> different chain (the receipt chain reflects the run)
+    c = run_objective("different", _steps({}))
+    assert c.chain_digest != a.chain_digest
+
+
+def test_default_policy_classifies_correctly():
+    assert default_policy(Step("x", "build", lambda o, c: None)).gated is False
+    assert default_policy(Step("x", "verify", lambda o, c: None)).gated is False
+    for kind in ("spend", "deploy", "legal", "destructive", "admin", "credential", "publish"):
+        assert default_policy(Step("x", kind, lambda o, c: None)).gated is True
+
+
+def test_later_steps_see_earlier_results():
+    steps = [
+        Step("a", "build", lambda o, c: "A"),
+        Step("b", "verify", lambda o, c: f"saw:{c['results']['a']}"),
+    ]
+    run = run_objective("x", steps)
+    assert run.results["b"] == "saw:A"
+
+
+def test_render_surfaces_the_queue():
+    text = render(run_objective("ship", _steps({})))
+    assert "AWAITING YOU" in text and "APPROVAL QUEUE" in text
+    assert "deploy" in text and "charge" in text


### PR DESCRIPTION
The honest realization of *"let the AI run the whole thing."* An objective comes in; **helm runs every reversible / low-stakes step itself** and **parks the human-gated steps** (spend, deploy, publish, legal, destructive, admin, credential — or anything irreversible) in an **approval queue**. The AI runs the ~90%; a human clears the ~10% that law and security require a human for (money/KYC, "ship it", the UAC-style click).

## What's in it (`python/helm/`, standalone, stdlib only)
- `Step` + `default_policy` — gates a step by its kind or `reversible=False`; everything else is autonomous.
- `run_objective(objective, steps, approvals=…)` — autonomous steps execute; gated steps queue **unless their name is in `approvals`** (the human's go-ahead). Re-run with a growing `approvals` set to model the human-in-the-loop. Every step is receipted into a **tamper-evident chain**.
- `render()` — shows what the AI did and the queue waiting on you.
- Steps are pluggable callables, so **codeforge** (build+verify), the **governance gate**, and shell/tools drop in as the action — the loop stays deterministic + testable.

## Verified (8 tests + live demo)
- **The gates actually hold** — a gated step's action is *never called* until approved (tests assert the side-effects don't fire).
- Deterministic; chain is tamper-evident; a failing autonomous step doesn't abort the loop; approval lets a parked gate execute.
- **Live demo** (helm driving real codeforge): `plan` + `build` ran autonomously (`verified: True`), while `deploy` + `announce` sat in the approval queue; approving `deploy` executed it on the next pass.

```
helm · 'add 3 and 4' · 2 auto-done, 2 AWAITING YOU
  ✓ plan (research)   ✓ build (build)
  ⏸ deploy (deploy)   ⏸ announce (publish)
```

This turns the pile of tools into one thing that *operates*: the AI drives build→verify autonomously and only taps a human for the money/ship/legal gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)