### PR TITLE
fix(governance): make the opt-in model gate run on CPU (onnx subfolder) + expose intent_model_prob

### DIFF
--- a/python/scbe/intent_model.py
+++ b/python/scbe/intent_model.py
@@ -57,9 +57,15 @@ def _backend():
         from optimum.onnxruntime import ORTModelForSequenceClassification  # type: ignore
         from transformers import AutoTokenizer  # type: ignore
 
-        tok = AutoTokenizer.from_pretrained(mid)
-        mdl = ORTModelForSequenceClassification.from_pretrained(mid)
-        return ("onnx", tok, mdl)
+        # ProtectAI (and most pre-exported repos) ship the ONNX weights + tokenizer in
+        # an `onnx/` subfolder; load from there first (no torch export), then the root.
+        for sub in ("onnx", ""):
+            try:
+                tok = AutoTokenizer.from_pretrained(mid, subfolder=sub)
+                mdl = ORTModelForSequenceClassification.from_pretrained(mid, subfolder=sub)
+                return ("onnx", tok, mdl)
+            except Exception:
+                continue
     except Exception:
         pass
     # Reliable fallback: a transformers text-classification pipeline (torch).

--- a/scbe.py
+++ b/scbe.py
@@ -1068,6 +1068,7 @@ def pipeline_quick_score(text: str) -> Dict[str, Any]:
         "phase_deviation": round(pd, 6),
         "decision": decision,
         "intent_flags": intent_flags,
+        "intent_model_prob": round(model_prob, 4) if model_prob is not None else None,
         "digest_hex": digest[:16].hex(),
     }
 


### PR DESCRIPTION
Activating SCBE_INJECTION_MODEL on the no-torch ml-onnx path surfaced two gaps: (1) intent_model loaded ProtectAI without subfolder=, but the ONNX weights live in onnx/ -> optimum forced a torch export and failed; now loads from the onnx/ subfolder. (2) pipeline_quick_score never returned the model prob, so the CI test's detection check KeyError'd and silently skipped; now emits intent_model_prob. MEASURED on the held-out paraphrase corpus: 50.0% -> 92.9% recall at ~44ms/prompt CPU (FPR 28->34%, model hits are ESCALATE). Default gate unchanged; 43 tests pass; restored CI test now runs.