### PR TITLE
docs(readme): publish opt-in governance model delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,15 @@ Canonical formula lock: [docs/specs/SCBE_CANONICAL_CONSTANTS.md](docs/specs/SCBE
 
 **Petri seed gate (Anthropic adversarial seeds):** 171/173 correctly denied or escalated at v7-matched config (1.16% false-allow). Notes: [docs/external/PETRI_FINDINGS_2026_05_08.md](docs/external/PETRI_FINDINGS_2026_05_08.md).
 
+**Opt-in model gate delta (held-out paraphrase corpus):**
+
+| Mode | Recall (blocked) | Benign FPR | Latency |
+|---|---:|---:|---:|
+| Pure-Python default | 50.0% | 28.1% | ~0 ms |
+| `SCBE_INJECTION_MODEL=1` + `[ml-onnx]` | 92.9% | 34.4% | ~44 ms/prompt CPU |
+
+The default gate remains local, deterministic, and zero-dependency. The optional model gate adds the ProtectAI DeBERTa classifier as a second-tier review layer: model-only hits are `ESCALATE`, not automatic `DENY`. Reproduce with `pip install .[ml-onnx]`, `SCBE_INJECTION_MODEL=1`, and `pytest tests/test_intent_model_benchmark.py -q`.
+
 ---
 
 ## Government and Contracting
@@ -258,8 +267,6 @@ SCBE-AETHERMOORE has a government contracting surface.
 - **Capability docs**: [M5 Mesh Product & Service Blueprint](docs/M5_MESH_PRODUCT_SERVICE_BLUEPRINT.md)
 
 Custom AI work is available for clients that need procurement-ready, clearance-sensitive, or regulated workflow support: private AI governance overlays, air-gapped/offline deployments, redacted-data evaluation harnesses, audit receipts, and client-specific agent controls. CAGE/SAM registration supports vendor and subcontract routing; any classified, export-controlled, or otherwise restricted data must stay inside the client's approved environment under the client's security process.
-
-For government contracting inquiries: issdandavis7795@gmail.com
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds the measured held-out paraphrase delta to README benchmark results.
- Documents the opt-in model gate enable path: `pip install .[ml-onnx]` + `SCBE_INJECTION_MODEL=1`.
- Keeps the default pure-Python gate framing clear and notes model-only hits escalate for review, not automatic deny.
- Removes the exposed private email from the README government section.

## Verification
- `git diff --check -- README.md`
- `rg -n issdandavis7795|@gmail\.com|SCBE_INJECTION_MODEL|92\.9%|50\.0% README.md`