### PR TITLE
feat(bookforge): add phone-usable writing studio

### DIFF
--- a/docs/bookforge-mobile-release-runbook.md
+++ b/docs/bookforge-mobile-release-runbook.md
@@ -1,0 +1,155 @@
+# Bookforge Mobile Release Runbook
+
+This is the annoying part turned into a checklist.
+
+Goal: ship Bookforge Writing Studio as a web/PWA first, then wrap it for Google Play and the Apple App Store only after the web version proves people use it.
+
+Current product surface:
+
+- Web app: `docs/bookforge-writing-studio.html`
+- Privacy policy: `docs/legal/privacy.html`
+- KDP checklist: `docs/downloads/kdp-bookforge-checklist.md`
+- Package page: `docs/packages/scbe-bookforge.html`
+
+## Release Rule
+
+Do not start with app stores. Start with the web app.
+
+App stores require icons, screenshots, privacy answers, account paperwork, review, testing tracks, and repeated metadata fields. The web app can go live from the existing site first. Native wrappers come after there is a reason.
+
+## Phase 1: Web/PWA Release
+
+- [ ] Keep the app as a static web tool first.
+- [ ] Add the page to the site navigation from `docs/guides.html` and `docs/packages.html`.
+- [ ] Verify mobile layout with Playwright.
+- [ ] Run the phone launcher: `python scripts/release/bookforge_phone_launch.py`
+- [ ] Open the printed Phone URL on the phone.
+- [ ] Use Add to Home Screen / Install app.
+- [ ] Link the privacy policy: `https://aethermoore.com/SCBE-AETHERMOORE/legal/privacy.html`
+- [ ] Link the KDP checklist download.
+- [ ] Link the $7 Writing Process Pack checkout.
+- [ ] Add source links inside the app for KDP requirements.
+- [ ] Publish through the normal site deployment path.
+- [ ] Post one short launch note with the direct URL.
+
+Minimum launch copy:
+
+> Bookforge Writing Studio is a free mobile-friendly workbench for writers: scene packet, KDP checklist, cover/spine math, and book-derived cover prompt waves. Use it before fighting KDP upload.
+
+## Phase 2: PWA Readiness
+
+- [ ] Add `manifest.webmanifest`.
+- [ ] Add app icon set: 192x192, 512x512, maskable icon.
+- [ ] Add theme color and app name metadata.
+- [ ] Add offline-safe shell only if it does not create stale KDP guidance.
+- [ ] Confirm install prompt works on Android Chrome / Edge.
+- [ ] Keep all generated book/manuscript content local unless the user explicitly submits it.
+
+Suggested app metadata:
+
+- App name: `Bookforge Studio`
+- Short name: `Bookforge`
+- Category: `Productivity` or `Books & Reference`
+- Tagline: `Write scenes, prep KDP, and build cover briefs.`
+
+## Phase 3: Google Play Wrapper
+
+Only do this after the web app is useful.
+
+- [ ] Pick wrapper path: Capacitor is the likely route because the app is already web-first.
+- [ ] Create Android package name, for example `com.aethermoore.bookforge`.
+- [ ] Prepare app icon, feature graphic, and screenshots.
+- [ ] Create a signed Android App Bundle (`.aab`).
+- [ ] Create app in Play Console.
+- [ ] Complete app content declarations.
+- [ ] Complete Google Play Data safety form.
+- [ ] Add privacy policy URL.
+- [ ] Set content rating.
+- [ ] Set target audience.
+- [ ] Use internal testing first.
+- [ ] If Google requires closed testing for the account type, set up closed testing before production.
+- [ ] Submit production release only after test track is clean.
+
+Official sources:
+
+- Play testing tracks: <https://support.google.com/googleplay/android-developer/answer/9845334>
+- Google Play Data safety: <https://support.google.com/googleplay/android-developer/answer/10787469>
+- Google Play policies: <https://play.google/developer-content-policy/>
+
+## Phase 4: Apple App Store Wrapper
+
+Only do this after the web/PWA release is working and there are screenshots worth showing.
+
+- [ ] Pick wrapper path: Capacitor or a minimal native shell.
+- [ ] Create bundle ID, for example `com.aethermoore.bookforge`.
+- [ ] Create app record in App Store Connect.
+- [ ] Prepare app name, subtitle, description, keywords, support URL, marketing URL, and privacy policy URL.
+- [ ] Prepare iPhone screenshots. Add iPad screenshots if supporting iPad.
+- [ ] Fill App Privacy details in App Store Connect.
+- [ ] Check third-party SDK/privacy manifest requirements if wrapper libraries add SDKs.
+- [ ] Submit through TestFlight first.
+- [ ] Submit for App Review after TestFlight smoke is clean.
+
+Official sources:
+
+- App submission overview: <https://developer.apple.com/app-store/submitting/>
+- App privacy details: <https://developer.apple.com/app-store/app-privacy-details/>
+- Manage app privacy in App Store Connect: <https://developer.apple.com/help/app-store-connect/manage-app-information/manage-app-privacy/>
+- Screenshots and previews: <https://developer.apple.com/help/app-store-connect/manage-app-information/upload-app-previews-and-screenshots/>
+- App Review Guidelines: <https://developer.apple.com/app-store/review/guidelines/>
+
+## Store Privacy Draft For Bookforge
+
+Use this only if the app remains local/static and does not add accounts, analytics, cloud storage, ads, or remote AI calls.
+
+Plain-English position:
+
+> Bookforge Studio is a local-first writing and publishing helper. The app lets users enter book setup details, scene notes, and cover brief notes in their browser. The basic app does not require an account and does not intentionally upload manuscript text, scene notes, or cover prompts to AetherMoore servers.
+
+Data safety draft:
+
+- Account creation: No
+- Login required: No
+- Ads: No
+- In-app purchases: No for the free app shell; external website checkout exists for separate digital products
+- User-generated content sharing: No public sharing inside the app
+- Sensitive permissions: None expected
+- Data collection: None intentionally collected by the static app itself
+- Third-party processors: Website host and payment processors if the user follows external checkout links
+
+Re-check this if the app later adds:
+
+- accounts
+- cloud manuscript save
+- hosted image generation
+- analytics
+- push notifications
+- payment inside the app
+- AI provider API calls
+
+## Screenshots To Capture
+
+- [ ] Hero screen with `Write the scene. Check the book. Build the files.`
+- [ ] Book Setup showing spine width and cover dimensions.
+- [ ] Scene Packet output.
+- [ ] Cover Lab rough/prompt waves.
+- [ ] KDP Upload Checklist.
+- [ ] Source Links section.
+
+Screenshot captions:
+
+- `Plan your KDP upload before the previewer rejects it.`
+- `Calculate spine width from page count and paper type.`
+- `Turn a scene goal into a usable writing packet.`
+- `Build cover art in waves from the book itself.`
+
+## Human Loop
+
+When you are tired, do only the next physical step:
+
+1. Open the web app.
+2. Take screenshots.
+3. Fill one metadata field.
+4. Stop.
+
+The app stores are not intellectually hard. They are just a pile of small forms. Treat them as a checklist, not a judgment of whether you are good at this.

--- a/docs/bookforge-sw.js
+++ b/docs/bookforge-sw.js
@@ -1,0 +1,29 @@
+const BOOKFORGE_CACHE = "bookforge-studio-v1";
+const BOOKFORGE_ASSETS = [
+  "bookforge-writing-studio.html",
+  "bookforge.webmanifest",
+  "bookforge-sw.js",
+  "static/bookforge-icon.svg",
+  "static/packages/package-products.css",
+  "static/packages/package-products.js",
+  "downloads/kdp-bookforge-checklist.md",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(caches.open(BOOKFORGE_CACHE).then((cache) => cache.addAll(BOOKFORGE_ASSETS)));
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((key) => key !== BOOKFORGE_CACHE).map((key) => caches.delete(key))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") return;
+  event.respondWith(caches.match(event.request).then((cached) => cached || fetch(event.request)));
+});

--- a/docs/bookforge-writing-studio.html
+++ b/docs/bookforge-writing-studio.html
@@ -1,0 +1,537 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bookforge Writing Studio | AetherMoore</title>
+    <meta
+      name="description"
+      content="A simple Bookforge writing and KDP prep studio: scene builder, manuscript checklist, cover math, and source-linked KDP requirements."
+    />
+    <meta name="theme-color" content="#8b3b41" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="Bookforge" />
+    <link rel="manifest" href="bookforge.webmanifest" />
+    <link rel="icon" href="static/bookforge-icon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="static/bookforge-icon.svg" />
+    <link rel="stylesheet" href="static/packages/package-products.css" />
+    <style>
+      body[data-package-theme="bookforge"] {
+        --bg: #f7f1e6;
+        --bg-2: #e2eadf;
+        --text: #18211f;
+        --muted: #3f4c48;
+        --panel: rgba(255, 255, 255, 0.9);
+      }
+
+      body[data-package-theme="bookforge"] .button.secondary {
+        background: rgba(255, 255, 255, 0.72);
+      }
+
+      body[data-package-theme="bookforge"] .studio-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 0.95fr) minmax(320px, 0.75fr);
+        gap: 18px;
+      }
+
+      .studio-panel {
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: var(--panel);
+        padding: 20px;
+      }
+
+      .field-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      label {
+        display: grid;
+        gap: 6px;
+        color: var(--muted);
+        font-weight: 750;
+      }
+
+      input,
+      select,
+      textarea {
+        width: 100%;
+        min-height: 42px;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        padding: 10px 12px;
+        background: #fffdf8;
+        color: var(--text);
+        font: inherit;
+      }
+
+      textarea {
+        min-height: 132px;
+        resize: vertical;
+      }
+
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 10px;
+        margin-top: 16px;
+      }
+
+      .metric {
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        padding: 12px;
+        background: rgba(255, 253, 248, 0.88);
+      }
+
+      .metric strong {
+        display: block;
+        margin-top: 4px;
+        font-size: 1.22rem;
+      }
+
+      .checklist {
+        display: grid;
+        gap: 10px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .checklist li {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 10px;
+        align-items: start;
+        border-top: 1px solid var(--line);
+        padding-top: 10px;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+
+      .source-list {
+        display: grid;
+        gap: 10px;
+        margin: 0;
+        padding-left: 18px;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+
+      .output-box {
+        min-height: 210px;
+        white-space: pre-wrap;
+      }
+
+      .wave-list {
+        display: grid;
+        gap: 10px;
+        margin: 14px 0 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .wave-list li {
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: rgba(255, 253, 248, 0.78);
+        padding: 12px;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+
+      @media (max-width: 900px) {
+        body[data-package-theme="bookforge"] .studio-grid,
+        .field-grid,
+        .metric-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body data-package-theme="bookforge">
+    <div class="shell">
+      <header class="topbar">
+        <a class="brand" href="index.html">AetherMoore</a>
+        <nav class="nav" aria-label="Primary">
+          <a href="products.html">Products</a>
+          <a href="packages.html">Packages</a>
+          <a href="guides.html">Guides</a>
+          <a href="books.html">Books</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="hero">
+          <div class="hero-copy">
+            <p class="eyebrow">Bookforge Writing Studio</p>
+            <h1>Write the scene. Check the book. Build the files.</h1>
+            <p class="lede">
+              A simple publishing workbench for writers: scene packet, KDP readiness checklist, print-cover math, and
+              source-linked Amazon requirements in one mobile-friendly page.
+            </p>
+            <code class="command">bookforge build bookforge.json</code>
+            <div class="cta-row">
+              <a class="button" href="#studio">Open Studio</a>
+              <a class="button secondary" href="https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n">Buy Writing Pack - $7</a>
+              <a class="button secondary" href="downloads/kdp-bookforge-checklist.md">Download Checklist</a>
+              <a class="button secondary" href="#phone">Install on Phone</a>
+              <a class="button secondary" href="packages/scbe-bookforge.html">Bookforge Package</a>
+            </div>
+          </div>
+          <div class="visual">
+            <div class="terminal-head"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+            <div class="terminal-body">
+              <div><strong>1. Scene</strong> -> goal, conflict, hidden want</div>
+              <div><strong>2. Manuscript</strong> -> trim, margins, AI disclosure</div>
+              <div><strong>3. Cover</strong> -> page count drives spine width</div>
+              <div><strong>4. Export</strong> -> PDF, EPUB, DOCX, checklist</div>
+            </div>
+          </div>
+        </section>
+
+        <section class="band reveal" id="studio">
+          <div class="section-head">
+            <h2>Use It First</h2>
+            <p class="section-note">
+              The first product rule: no mysticism. A buyer should be able to enter book facts, get the cover math, and
+              know exactly what remains before KDP upload.
+            </p>
+          </div>
+          <div class="studio-grid">
+            <article class="studio-panel">
+              <h3>Book Setup</h3>
+              <div class="field-grid">
+                <label>
+                  Trim size
+                  <select id="trim">
+                    <option value="6x9">6 x 9 in</option>
+                    <option value="5.5x8.5">5.5 x 8.5 in</option>
+                    <option value="5x8">5 x 8 in</option>
+                    <option value="8.5x11">8.5 x 11 in</option>
+                  </select>
+                </label>
+                <label>
+                  Page count
+                  <input id="pages" type="number" min="24" max="830" value="320" />
+                </label>
+                <label>
+                  Paper / ink
+                  <select id="paper">
+                    <option value="cream_bw">Cream paper, black and white</option>
+                    <option value="white_bw">White paper, black and white</option>
+                    <option value="color">Color interior</option>
+                  </select>
+                </label>
+                <label>
+                  Format target
+                  <select id="format">
+                    <option value="paperback">Paperback</option>
+                    <option value="hardcover">Hardcover</option>
+                    <option value="ebook">Kindle eBook</option>
+                  </select>
+                </label>
+              </div>
+              <div class="metric-grid" aria-live="polite">
+                <div class="metric">Spine width<strong id="spineWidth">0.800 in</strong></div>
+                <div class="metric">Full cover width<strong id="coverWidth">12.050 in</strong></div>
+                <div class="metric">Full cover height<strong id="coverHeight">9.250 in</strong></div>
+              </div>
+              <p class="section-note" id="spineNote">
+                Spine text is allowed only when the print book has more than 79 pages.
+              </p>
+            </article>
+
+            <article class="studio-panel">
+              <h3>Scene Packet</h3>
+              <label>
+                What is this scene supposed to do?
+                <textarea id="sceneGoal">A character wants something practical, but the conversation reveals what they are hiding.</textarea>
+              </label>
+              <div class="cta-row">
+                <button class="button" type="button" id="buildPacket">Build Packet</button>
+              </div>
+              <pre class="command output-box" id="scenePacket"></pre>
+            </article>
+          </div>
+        </section>
+
+        <section class="band reveal">
+          <div class="section-head">
+            <h2>KDP Upload Checklist</h2>
+            <p class="section-note">
+              These are source-linked checkpoints, not legal advice. The app should hyperlink Amazon's current pages so
+              the user can verify the rule before upload.
+            </p>
+          </div>
+          <div class="detail-grid">
+            <article class="panel">
+              <h3>Manuscript</h3>
+              <ul class="checklist">
+                <li><input type="checkbox" />Final trim size chosen before cover is built.</li>
+                <li><input type="checkbox" />Bleed and margins checked for print layout.</li>
+                <li><input type="checkbox" />Images are at least 300 DPI for print quality.</li>
+                <li><input type="checkbox" />eBook manuscript does not include the cover image inside the file.</li>
+              </ul>
+            </article>
+            <article class="panel">
+              <h3>Cover</h3>
+              <ul class="checklist">
+                <li><input type="checkbox" />Paperback/hardcover cover is a single PDF: back + spine + front.</li>
+                <li><input type="checkbox" />Page count is final before cover wrap is generated.</li>
+                <li><input type="checkbox" />No spine text unless page count is over 79 pages.</li>
+                <li><input type="checkbox" />Kindle cover is JPEG/TIFF, ideal 2560 x 1600 px, under 50 MB.</li>
+              </ul>
+            </article>
+            <article class="panel">
+              <h3>Publishing Form</h3>
+              <ul class="checklist">
+                <li><input type="checkbox" />Title, subtitle, author, description, categories, and keywords ready.</li>
+                <li><input type="checkbox" />AI-generated text/images/translations disclosed when required by KDP.</li>
+                <li><input type="checkbox" />AI-assisted editing/brainstorming separated from AI-generated final content.</li>
+                <li><input type="checkbox" />Final preview checked in KDP Print Previewer before publishing.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="band reveal" id="cover-lab">
+          <div class="section-head">
+            <h2>Cover Lab</h2>
+            <p class="section-note">
+              KDP's cover tools are the fallback. The better workflow is book-derived: read the manuscript, outline the
+              visual scene, generate roughs, choose a direction, then build the print wrap in layers.
+            </p>
+          </div>
+          <div class="studio-grid">
+            <article class="studio-panel">
+              <h3>Cover Source</h3>
+              <div class="field-grid">
+                <label>
+                  Book title
+                  <input id="coverTitle" value="The Six Tongues Protocol" />
+                </label>
+                <label>
+                  Genre / shelf
+                  <input id="coverGenre" value="science fantasy, literary adventure" />
+                </label>
+              </div>
+              <label>
+                Book-derived scene or motif
+                <textarea id="coverScene">A luminous language engine under an old city, six symbolic channels moving through glass, stone, air, and water.</textarea>
+              </label>
+              <label>
+                Avoid / forbidden cover tells
+                <textarea id="coverAvoid">No readable text in generated art. No fake author name. No watermark. No generic floating face. No cluttered symbols.</textarea>
+              </label>
+              <div class="cta-row">
+                <button class="button" type="button" id="buildCoverBrief">Build Cover Brief</button>
+              </div>
+            </article>
+
+            <article class="studio-panel">
+              <h3>Layered Prompt Pack</h3>
+              <pre class="command output-box" id="coverBrief"></pre>
+            </article>
+          </div>
+          <div class="detail-grid" style="margin-top: 18px">
+            <article class="panel">
+              <h3>Wave 1: Roughs</h3>
+              <p>
+                Generate 4-8 small compositions from the book motif. Judge only silhouette, shelf signal, and emotion.
+                Do not add title text yet.
+              </p>
+            </article>
+            <article class="panel">
+              <h3>Wave 2: Layer Build</h3>
+              <p>
+                Generate front art, background extension, spine texture, and back-cover atmosphere separately. Composite
+                them into the Bookforge cover wrap after page count is final.
+              </p>
+            </article>
+            <article class="panel">
+              <h3>Wave 3: Type + KDP Proof</h3>
+              <p>
+                Add title, author, subtitle, spine text, barcode safe area, and blurb in layout software or code. Then
+                verify dimensions with the KDP calculator and Print Previewer.
+              </p>
+            </article>
+          </div>
+          <ul class="wave-list">
+            <li>
+              <strong>User choice matters:</strong> the app should let the writer pick the strongest rough before
+              spending time on final art.
+            </li>
+            <li>
+              <strong>Book contents drive the art:</strong> the prompt should come from manuscript themes, character
+              pressure, setting, motifs, and genre shelf expectations.
+            </li>
+            <li>
+              <strong>Generated art should have no text:</strong> typography belongs in the final cover layout, not in
+              the image model output.
+            </li>
+          </ul>
+        </section>
+
+        <section class="band reveal">
+          <div class="section-head">
+            <h2>Source Links</h2>
+            <p class="section-note">
+              The app should keep these links visible, because KDP rules change and upload rejection usually comes from
+              one missed mechanical detail.
+            </p>
+          </div>
+          <div class="product-grid">
+            <article class="panel">
+              <h3>KDP Requirements</h3>
+              <ul class="source-list">
+                <li><a href="https://kdp.amazon.com/help/topic/G201953020">Create a Paperback Cover - Amazon KDP</a></li>
+                <li><a href="https://kdp.amazon.com/help/topic/G201857950">Paperback Submission Guidelines - Amazon KDP</a></li>
+                <li><a href="https://kdp.amazon.com/help/topic/GVBQ3CMEQW3W2VL6">Set Trim Size, Bleed, and Margins - Amazon KDP</a></li>
+                <li><a href="https://kdp.amazon.com/cover-templates">Print Cover Calculator and Templates - Amazon KDP</a></li>
+              </ul>
+            </article>
+            <article class="panel">
+              <h3>Images and AI</h3>
+              <ul class="source-list">
+                <li><a href="https://kdp.amazon.com/help/topic/G200645690">eBook Cover Image Requirements - Amazon KDP</a></li>
+                <li><a href="https://kdp.amazon.com/help/topic/G202169030">Format Images in Your Book - Amazon KDP</a></li>
+                <li><a href="https://kdp.amazon.com/help/topic/G200672390">Content Guidelines and AI Disclosure - Amazon KDP</a></li>
+                <li><a href="https://kdp.amazon.com/help?topicId=G200645680">eBook Manuscript Formatting Guide - Amazon KDP</a></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="band reveal" id="phone">
+          <div class="section-head">
+            <h2>Phone Install</h2>
+            <p class="section-note">
+              Bookforge Studio is now PWA-ready. The release script serves it on your local network so your phone can
+              open it, install it, and use it like an app before any app-store paperwork.
+            </p>
+          </div>
+          <div class="product-grid">
+            <article class="panel">
+              <h3>Run This</h3>
+              <code class="command">python scripts/release/bookforge_phone_launch.py</code>
+              <p>Open the printed Phone URL on the same Wi-Fi network, then use Add to Home Screen / Install app.</p>
+            </article>
+            <article class="panel">
+              <h3>What It Proves</h3>
+              <p>
+                The app can be used from a phone right now: scene packets, KDP checklist, cover math, and Cover Lab
+                prompts without waiting for Google Play or Apple review.
+              </p>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">Bookforge Writing Studio. Simple first, native/mobile later.</footer>
+    </div>
+    <script src="static/packages/package-products.js"></script>
+    <script>
+      if ("serviceWorker" in navigator && location.protocol !== "file:") {
+        navigator.serviceWorker.register("bookforge-sw.js").catch(() => {});
+      }
+
+      const trimSizes = {
+        "6x9": [6, 9],
+        "5.5x8.5": [5.5, 8.5],
+        "5x8": [5, 8],
+        "8.5x11": [8.5, 11],
+      };
+      const pageFactor = {
+        cream_bw: 0.0025,
+        white_bw: 0.002252,
+        color: 0.002347,
+      };
+      const trim = document.getElementById("trim");
+      const pages = document.getElementById("pages");
+      const paper = document.getElementById("paper");
+      const format = document.getElementById("format");
+      const spineWidth = document.getElementById("spineWidth");
+      const coverWidth = document.getElementById("coverWidth");
+      const coverHeight = document.getElementById("coverHeight");
+      const spineNote = document.getElementById("spineNote");
+      const sceneGoal = document.getElementById("sceneGoal");
+      const scenePacket = document.getElementById("scenePacket");
+      const coverTitle = document.getElementById("coverTitle");
+      const coverGenre = document.getElementById("coverGenre");
+      const coverScene = document.getElementById("coverScene");
+      const coverAvoid = document.getElementById("coverAvoid");
+      const coverBrief = document.getElementById("coverBrief");
+
+      function inches(value) {
+        return `${value.toFixed(3)} in`;
+      }
+
+      function recalc() {
+        const [w, h] = trimSizes[trim.value];
+        const count = Math.max(0, Number.parseInt(pages.value || "0", 10));
+        const bleed = 0.125;
+        const spine = count * pageFactor[paper.value];
+        spineWidth.textContent = inches(spine);
+        coverWidth.textContent = format.value === "ebook" ? "N/A" : inches(w * 2 + spine + bleed * 2);
+        coverHeight.textContent = format.value === "ebook" ? "N/A" : inches(h + bleed * 2);
+        if (format.value === "ebook") {
+          spineNote.textContent = "Kindle eBook covers use an image file, not a print wrap. KDP lists 2560 x 1600 px as ideal.";
+        } else if (count <= 79) {
+          spineNote.textContent = "Do not include spine text. KDP says print books need more than 79 pages for spine text.";
+        } else {
+          spineNote.textContent = "Spine text can be considered, but keep text away from fold edges and verify in KDP Previewer.";
+        }
+      }
+
+      function buildScenePacket() {
+        const goal = sceneGoal.value.trim() || "A scene with a clear want, pressure, and consequence.";
+        scenePacket.textContent = [
+          "SCENE PACKET",
+          `Goal: ${goal}`,
+          "Character want: What do they need right now?",
+          "Hidden pressure: What are they avoiding saying?",
+          "Object/setting anchor: One thing the reader can see or touch.",
+          "Dialogue rule: No perfect thesis ending.",
+          "Revision pass: cut explanation, increase behavior, preserve voice.",
+        ].join("\\n");
+      }
+
+      function buildCoverBrief() {
+        const title = coverTitle.value.trim() || "Untitled Book";
+        const genre = coverGenre.value.trim() || "fiction";
+        const scene = coverScene.value.trim() || "A visually specific scene from the book.";
+        const avoid = coverAvoid.value.trim() || "No text, no watermark, no fake cover typography.";
+        coverBrief.textContent = [
+          "BOOK-DERIVED COVER BRIEF",
+          `Title for layout pass: ${title}`,
+          `Shelf / genre signal: ${genre}`,
+          `Core visual scene: ${scene}`,
+          "",
+          "WAVE 1 - ROUGH THUMBNAILS",
+          "Create 6 distinct cover-art roughs. No text. No watermark. Judge composition only.",
+          "",
+          "WAVE 2 - FRONT ART",
+          `High-quality book cover illustration for ${genre}: ${scene}. Strong central silhouette, clear focal point, print-ready detail, no text, no watermark.`,
+          "",
+          "WAVE 3 - WRAP LAYERS",
+          "Generate background extension for spine/back cover using the same palette and lighting. Keep the center quiet enough for blurb and barcode layout.",
+          "",
+          "WAVE 4 - TYPOGRAPHY/LAYOUT",
+          "Add title, subtitle, author, spine text, back-cover blurb, and barcode safe area outside the image model.",
+          "",
+          `AVOID: ${avoid}`,
+        ].join("\\n");
+      }
+
+      [trim, pages, paper, format].forEach((input) => input.addEventListener("input", recalc));
+      document.getElementById("buildPacket").addEventListener("click", buildScenePacket);
+      document.getElementById("buildCoverBrief").addEventListener("click", buildCoverBrief);
+      recalc();
+      buildScenePacket();
+      buildCoverBrief();
+    </script>
+  </body>
+</html>

--- a/docs/bookforge.webmanifest
+++ b/docs/bookforge.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Bookforge Writing Studio",
+  "short_name": "Bookforge",
+  "description": "Write scenes, prep KDP, calculate cover dimensions, and build book-derived cover briefs.",
+  "start_url": "bookforge-writing-studio.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#f7f1e6",
+  "theme_color": "#8b3b41",
+  "categories": ["books", "productivity", "utilities"],
+  "icons": [
+    {
+      "src": "static/bookforge-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/docs/downloads/kdp-bookforge-checklist.md
+++ b/docs/downloads/kdp-bookforge-checklist.md
@@ -1,0 +1,77 @@
+# KDP Bookforge Checklist
+
+Use this before uploading a Kindle eBook, paperback, or hardcover to Amazon KDP.
+
+This is a working checklist, not legal advice. Verify the linked KDP pages before upload because Amazon can change requirements.
+
+## 1. Book Facts
+
+- [ ] Title, subtitle, series, author, contributors, language, description, categories, keywords, and age/range fields are ready.
+- [ ] Decide whether the final book contains AI-generated text, images, or translations.
+- [ ] If the final book contains AI-generated text, images, or translations, disclose that in KDP's AI-generated content section.
+- [ ] If AI only helped with brainstorming, editing, outlining, or proofreading and you created the final content yourself, treat it as AI-assisted, not AI-generated, per KDP's distinction.
+
+Source: <https://kdp.amazon.com/help/topic/G200672390>
+
+## 2. Manuscript
+
+- [ ] Pick trim size before final layout.
+- [ ] Decide whether the print book uses bleed.
+- [ ] Set margins and gutter for the chosen trim/page count.
+- [ ] Check every image intended for print at 300 DPI or better.
+- [ ] For eBook upload, do not include the cover image inside the manuscript file; KDP adds the cover during title setup.
+
+Sources:
+
+- <https://kdp.amazon.com/help/topic/GVBQ3CMEQW3W2VL6>
+- <https://kdp.amazon.com/help/topic/G202169030>
+- <https://kdp.amazon.com/help?topicId=G200645680>
+
+## 3. Print Cover
+
+- [ ] Final interior page count is known before building the cover wrap.
+- [ ] Paperback/hardcover cover is one PDF containing back cover, spine, and front cover.
+- [ ] Add bleed to the full cover size.
+- [ ] Do not include spine text unless the print book has more than 79 pages.
+- [ ] If spine text is used, leave at least 0.0625 in / 1.6 mm between text and spine edge.
+- [ ] Check final cover in KDP Print Previewer.
+
+Sources:
+
+- <https://kdp.amazon.com/help/topic/G201953020>
+- <https://kdp.amazon.com/help/topic/G201857950>
+- <https://kdp.amazon.com/cover-templates>
+
+## 4. Cover Art Workflow
+
+- [ ] Extract the cover scene from the book: setting, motif, core emotion, genre shelf, and one visual object.
+- [ ] Generate 4-8 rough thumbnail directions before committing to a final cover.
+- [ ] Generate cover art without text, author name, subtitle, fake barcode, or watermark.
+- [ ] Pick one rough direction before final detail generation.
+- [ ] Generate front art, spine/back texture, and background extension as separate layers when possible.
+- [ ] Add title, subtitle, author, spine text, back-cover blurb, and barcode safe area in layout, not inside the image model.
+- [ ] Keep the final print wrap tied to final page count; page count changes spine width.
+
+## 5. Kindle eBook Cover
+
+- [ ] Cover is JPEG or TIFF.
+- [ ] Ideal image size is 2560 x 1600 px.
+- [ ] Minimum image size is 1000 px high and 625 px wide.
+- [ ] Image does not exceed 10,000 px in height or width.
+- [ ] File is under 50 MB.
+- [ ] Height/width ratio is at least 1.6:1.
+
+Source: <https://kdp.amazon.com/help/topic/G200645690>
+
+## 6. Bookforge Commands
+
+```powershell
+bookforge info bookforge.json
+bookforge interior bookforge.json
+bookforge cover bookforge.json
+bookforge epub bookforge.json
+bookforge docx bookforge.json
+bookforge build bookforge.json
+```
+
+Use `bookforge info` first. Page count controls the print cover spine width, so the interior has to stabilize before the final cover wrap.

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -33,6 +33,7 @@
               humanization passes, serial tension, and security gates for tool-using models.
             </p>
             <div class="cta-row">
+              <a class="button" href="bookforge-writing-studio.html">Open Bookforge Studio</a>
               <a class="button" href="#downloads">Download Guides</a>
               <a class="button secondary" href="#behind-the-scenes-pack">Buy Process Pack</a>
               <a class="button secondary" href="#security-governance">AI Security</a>
@@ -51,6 +52,27 @@
                 their own copy.
               </p>
             </div>
+          </div>
+        </section>
+
+        <section class="band reveal" id="bookforge-studio">
+          <div class="section-head">
+            <h2>Bookforge Writing Studio</h2>
+            <p class="section-note">
+              A simple mobile-friendly workbench that combines the writing system, scene packet builder, KDP upload
+              checklist, and print-cover math with source links to Amazon's current KDP requirements.
+            </p>
+          </div>
+          <div class="direct-grid">
+            <article class="direct-card">
+              <span class="status">Use it now</span>
+              <h3>Writing + KDP Prep</h3>
+              <p>
+                Enter trim size, page count, paper type, and scene intent. Get cover dimensions, spine warnings,
+                upload checklist, and source links before you fight the KDP previewer.
+              </p>
+              <a class="button" href="bookforge-writing-studio.html">Open Bookforge Studio</a>
+            </article>
           </div>
         </section>
 

--- a/docs/packages.html
+++ b/docs/packages.html
@@ -91,6 +91,7 @@
               <code class="command">pip install scbe-bookforge</code>
               <div class="cta-row">
                 <a class="button" href="packages/scbe-bookforge.html">Open Page</a>
+                <a class="button secondary" href="bookforge-writing-studio.html">Open Studio</a>
               </div>
             </article>
           </div>

--- a/docs/static/bookforge-icon.svg
+++ b/docs/static/bookforge-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Bookforge">
+  <rect width="512" height="512" rx="96" fill="#8b3b41" />
+  <path d="M122 132h140c52 0 94 42 94 94v154H216c-52 0-94-42-94-94V132Z" fill="#fff8ec" />
+  <path d="M196 132h194v248H252c-31 0-56-25-56-56V132Z" fill="#f0d9b5" />
+  <path d="M164 182h70M164 224h118M164 266h96M236 182h106M236 224h88" stroke="#8b3b41" stroke-width="18" stroke-linecap="round" />
+  <path d="M352 132v248" stroke="#4f775c" stroke-width="18" stroke-linecap="round" />
+  <path d="M108 400h296" stroke="#fff8ec" stroke-width="24" stroke-linecap="round" />
+</svg>

--- a/packages/bookforge/pyproject.toml
+++ b/packages/bookforge/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 license-files = ["LICENSE", "LICENSE-APACHE"]
 requires-python = ">=3.11"
 authors = [
-    {name = "Issac Daniel Davis", email = "issdandavis@gmail.com"},
+    {name = "Issac Daniel Davis", email = "aethermoregames@pm.me"},
 ]
 keywords = [
     "scbe",

--- a/scripts/release/bookforge_phone_launch.py
+++ b/scripts/release/bookforge_phone_launch.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import argparse
+import http.server
+import socket
+import socketserver
+import sys
+import webbrowser
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = REPO_ROOT / "docs"
+APP_PAGE = "bookforge-writing-studio.html"
+
+
+class ReusableTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+def lan_ip() -> str:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.connect(("8.8.8.8", 80))
+        return sock.getsockname()[0]
+    except OSError:
+        return socket.gethostbyname(socket.gethostname())
+    finally:
+        sock.close()
+
+
+def write_phone_card(url: str, port: int) -> Path:
+    out = REPO_ROOT / "artifacts" / "release" / "bookforge-phone-launch.html"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bookforge Phone Launch</title>
+    <style>
+      body {{ margin: 0; font: 18px/1.5 system-ui, sans-serif; background: #f7f1e6; color: #18211f; }}
+      main {{ width: min(760px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0; }}
+      a {{ color: #8b3b41; font-weight: 800; }}
+      .card {{ border: 1px solid rgba(24, 33, 31, .18); border-radius: 12px; background: #fffdf8; padding: 22px; }}
+      code {{ display: block; overflow-wrap: anywhere; margin-top: 12px; padding: 12px; background: #f0d9b5; border-radius: 8px; }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Bookforge is running</h1>
+      <div class="card">
+        <p>Open this URL on your phone while it is on the same Wi-Fi network:</p>
+        <p><a href="{url}">{url}</a></p>
+        <code>{url}</code>
+        <p>Then use your browser menu: <strong>Add to Home Screen</strong> / <strong>Install app</strong>.</p>
+        <p>If your phone cannot reach it, confirm both devices are on the same Wi-Fi and Windows Firewall allows Python on port {port}.</p>
+      </div>
+    </main>
+  </body>
+</html>
+""",
+        encoding="utf-8",
+    )
+    return out
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Serve Bookforge Studio on the LAN for phone testing.")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--open-card", action="store_true", help="Open the local launch card in the desktop browser.")
+    parser.add_argument("--card-only", action="store_true", help="Write the launch card and print URLs without starting a server.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    page = DOCS_DIR / APP_PAGE
+    if not page.exists():
+        print(f"missing {page}", file=sys.stderr)
+        return 2
+
+    ip = lan_ip()
+    url = f"http://{ip}:{args.port}/{APP_PAGE}"
+    local_url = f"http://127.0.0.1:{args.port}/{APP_PAGE}"
+    card = write_phone_card(url, args.port)
+    if args.open_card:
+        webbrowser.open(card.resolve().as_uri())
+
+    print("Bookforge Studio phone launch", flush=True)
+    print("==============================", flush=True)
+    print(f"Phone URL : {url}", flush=True)
+    print(f"Local URL : {local_url}", flush=True)
+    print(f"Launch card: {card}", flush=True)
+    print("", flush=True)
+    print("On phone: open the Phone URL on the same Wi-Fi, then Add to Home Screen / Install app.", flush=True)
+    print("Note: full PWA service-worker install needs HTTPS after deployment; local LAN is for immediate phone testing.", flush=True)
+    if args.card_only:
+        return 0
+
+    handler = lambda *a, **kw: http.server.SimpleHTTPRequestHandler(*a, directory=str(DOCS_DIR), **kw)
+    try:
+        server = ReusableTCPServer((args.host, args.port), handler)
+    except OSError as exc:
+        print(f"Could not bind {args.host}:{args.port}: {exc}", file=sys.stderr, flush=True)
+        print("Try another port, for example: python scripts/release/bookforge_phone_launch.py --port 8766", file=sys.stderr, flush=True)
+        return 3
+
+    with server:
+        print("Press Ctrl+C here to stop the server.", flush=True)
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\nstopped", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- adds Bookforge Writing Studio as a mobile-friendly product surface for scene packets, KDP checklist, cover math, and book-derived Cover Lab prompt waves
- makes the page PWA-ready with manifest, service worker, and icon
- adds a local phone-launch script so the app can be opened from a phone on the same Wi-Fi before app-store paperwork
- adds a KDP checklist download and a mobile/app-store release runbook with official Google/Apple/KDP source links
- removes the old private Gmail from Bookforge package metadata

## How to use on phone now
```powershell
cd C:\Users\issda\scbe-product-bookforge-wt
python scripts/release/bookforge_phone_launch.py --port 8771
```
Then open the printed Phone URL on the phone and use Add to Home Screen / Install app.

## Verification
- `python -m pytest packages\bookforge\tests\test_smoke.py -q` -> 6 passed
- `node -e ...` PWA/static checks -> passed
- `python scripts\release\bookforge_phone_launch.py --port 8772 --card-only` -> prints LAN phone URL and launch card
- local server previously verified app/manifest/service worker all returned HTTP 200
- `git diff --check` -> passed

## Notes
- LAN phone testing uses HTTP; full service-worker PWA install requires HTTPS after deployment.
- This is intentionally web/PWA first. Google Play and Apple wrappers are documented as later release phases.