### PR TITLE
docs(bookforge): polish phone app release branding

### DIFF
--- a/docs/bookforge-mobile-release-runbook.md
+++ b/docs/bookforge-mobile-release-runbook.md
@@ -1,8 +1,8 @@
-# Bookforge Mobile Release Runbook
+# AetherMoore Book Studio Mobile Release Runbook
 
 This is the annoying part turned into a checklist.
 
-Goal: ship Bookforge Writing Studio as a web/PWA first, then wrap it for Google Play and the Apple App Store only after the web version proves people use it.
+Goal: ship AetherMoore Book Studio as a web/PWA first, then wrap it for Google Play and the Apple App Store only after the web version proves people use it.
 
 Current product surface:
 
@@ -34,7 +34,7 @@ App stores require icons, screenshots, privacy answers, account paperwork, revie
 
 Minimum launch copy:
 
-> Bookforge Writing Studio is a free mobile-friendly workbench for writers: scene packet, KDP checklist, cover/spine math, and book-derived cover prompt waves. Use it before fighting KDP upload.
+> AetherMoore Book Studio is a free mobile-friendly workbench for writers: scene packet, KDP checklist, cover/spine math, and book-derived cover prompt waves. Use it before fighting KDP upload.
 
 ## Phase 2: PWA Readiness
 
@@ -47,8 +47,8 @@ Minimum launch copy:
 
 Suggested app metadata:
 
-- App name: `Bookforge Studio`
-- Short name: `Bookforge`
+- App name: `AetherMoore Book Studio`
+- Short name: `Book Studio`
 - Category: `Productivity` or `Books & Reference`
 - Tagline: `Write scenes, prep KDP, and build cover briefs.`
 
@@ -98,13 +98,13 @@ Official sources:
 - Screenshots and previews: <https://developer.apple.com/help/app-store-connect/manage-app-information/upload-app-previews-and-screenshots/>
 - App Review Guidelines: <https://developer.apple.com/app-store/review/guidelines/>
 
-## Store Privacy Draft For Bookforge
+## Store Privacy Draft For AetherMoore Book Studio
 
 Use this only if the app remains local/static and does not add accounts, analytics, cloud storage, ads, or remote AI calls.
 
 Plain-English position:
 
-> Bookforge Studio is a local-first writing and publishing helper. The app lets users enter book setup details, scene notes, and cover brief notes in their browser. The basic app does not require an account and does not intentionally upload manuscript text, scene notes, or cover prompts to AetherMoore servers.
+> AetherMoore Book Studio is a local-first writing and publishing helper powered by the Bookforge engine. The app lets users enter book setup details, scene notes, and cover brief notes in their browser. The basic app does not require an account and does not intentionally upload manuscript text, scene notes, or cover prompts to AetherMoore servers.
 
 Data safety draft:
 

--- a/docs/bookforge-writing-studio.html
+++ b/docs/bookforge-writing-studio.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Bookforge Writing Studio | AetherMoore</title>
+    <title>AetherMoore Book Studio | Writing and KDP Prep</title>
     <meta
       name="description"
-      content="A simple Bookforge writing and KDP prep studio: scene builder, manuscript checklist, cover math, and source-linked KDP requirements."
+      content="A simple AetherMoore writing and KDP prep studio: scene builder, manuscript checklist, cover math, and source-linked KDP requirements."
     />
     <meta name="theme-color" content="#8b3b41" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-title" content="Bookforge" />
+    <meta name="apple-mobile-web-app-title" content="Book Studio" />
     <link rel="manifest" href="bookforge.webmanifest" />
     <link rel="icon" href="static/bookforge-icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="static/bookforge-icon.svg" />
@@ -166,7 +166,7 @@
       <main>
         <section class="hero">
           <div class="hero-copy">
-            <p class="eyebrow">Bookforge Writing Studio</p>
+            <p class="eyebrow">AetherMoore Book Studio</p>
             <h1>Write the scene. Check the book. Build the files.</h1>
             <p class="lede">
               A simple publishing workbench for writers: scene packet, KDP readiness checklist, print-cover math, and
@@ -178,7 +178,7 @@
               <a class="button secondary" href="https://buy.stripe.com/14AbJ20hQ79ZboYfWSdby0n">Buy Writing Pack - $7</a>
               <a class="button secondary" href="downloads/kdp-bookforge-checklist.md">Download Checklist</a>
               <a class="button secondary" href="#phone">Install on Phone</a>
-              <a class="button secondary" href="packages/scbe-bookforge.html">Bookforge Package</a>
+              <a class="button secondary" href="packages/scbe-bookforge.html">Bookforge Engine</a>
             </div>
           </div>
           <div class="visual">
@@ -348,7 +348,7 @@
               <h3>Wave 2: Layer Build</h3>
               <p>
                 Generate front art, background extension, spine texture, and back-cover atmosphere separately. Composite
-                them into the Bookforge cover wrap after page count is final.
+                them into the Bookforge engine cover wrap after page count is final.
               </p>
             </article>
             <article class="panel">
@@ -409,7 +409,7 @@
           <div class="section-head">
             <h2>Phone Install</h2>
             <p class="section-note">
-              Bookforge Studio is now PWA-ready. The release script serves it on your local network so your phone can
+              AetherMoore Book Studio is now PWA-ready. The release script serves it on your local network so your phone can
               open it, install it, and use it like an app before any app-store paperwork.
             </p>
           </div>
@@ -430,7 +430,7 @@
         </section>
       </main>
 
-      <footer class="footer">Bookforge Writing Studio. Simple first, native/mobile later.</footer>
+      <footer class="footer">AetherMoore Book Studio. Simple first, native/mobile later.</footer>
     </div>
     <script src="static/packages/package-products.js"></script>
     <script>

--- a/docs/bookforge.webmanifest
+++ b/docs/bookforge.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "Bookforge Writing Studio",
-  "short_name": "Bookforge",
-  "description": "Write scenes, prep KDP, calculate cover dimensions, and build book-derived cover briefs.",
+  "name": "AetherMoore Book Studio",
+  "short_name": "Book Studio",
+  "description": "Write scenes, prep KDP, calculate cover dimensions, and build book-derived cover briefs with the Bookforge engine.",
   "start_url": "bookforge-writing-studio.html",
   "scope": "./",
   "display": "standalone",

--- a/docs/downloads/kdp-bookforge-checklist.md
+++ b/docs/downloads/kdp-bookforge-checklist.md
@@ -1,4 +1,4 @@
-# KDP Bookforge Checklist
+# AetherMoore Book Studio KDP Checklist
 
 Use this before uploading a Kindle eBook, paperback, or hardcover to Amazon KDP.
 

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -33,7 +33,7 @@
               humanization passes, serial tension, and security gates for tool-using models.
             </p>
             <div class="cta-row">
-              <a class="button" href="bookforge-writing-studio.html">Open Bookforge Studio</a>
+              <a class="button" href="bookforge-writing-studio.html">Open Book Studio</a>
               <a class="button" href="#downloads">Download Guides</a>
               <a class="button secondary" href="#behind-the-scenes-pack">Buy Process Pack</a>
               <a class="button secondary" href="#security-governance">AI Security</a>
@@ -57,7 +57,7 @@
 
         <section class="band reveal" id="bookforge-studio">
           <div class="section-head">
-            <h2>Bookforge Writing Studio</h2>
+            <h2>AetherMoore Book Studio</h2>
             <p class="section-note">
               A simple mobile-friendly workbench that combines the writing system, scene packet builder, KDP upload
               checklist, and print-cover math with source links to Amazon's current KDP requirements.
@@ -71,7 +71,7 @@
                 Enter trim size, page count, paper type, and scene intent. Get cover dimensions, spine warnings,
                 upload checklist, and source links before you fight the KDP previewer.
               </p>
-              <a class="button" href="bookforge-writing-studio.html">Open Bookforge Studio</a>
+              <a class="button" href="bookforge-writing-studio.html">Open Book Studio</a>
             </article>
           </div>
         </section>

--- a/docs/packages.html
+++ b/docs/packages.html
@@ -6,7 +6,7 @@
     <title>AetherMoore Package Products | npm and PyPI</title>
     <meta
       name="description"
-      content="Installable SCBE package products for npm and PyPI: the core engine, CLI, agent bus, and BookForge publishing lane."
+      content="Installable SCBE package products for npm and PyPI: the core engine, CLI, agent bus, and the AetherMoore Book Studio publishing lane."
     />
     <link rel="stylesheet" href="static/packages/package-products.css" />
   </head>
@@ -91,7 +91,7 @@
               <code class="command">pip install scbe-bookforge</code>
               <div class="cta-row">
                 <a class="button" href="packages/scbe-bookforge.html">Open Page</a>
-                <a class="button secondary" href="bookforge-writing-studio.html">Open Studio</a>
+                <a class="button secondary" href="bookforge-writing-studio.html">Open Book Studio</a>
               </div>
             </article>
           </div>

--- a/scripts/release/bookforge_phone_launch.py
+++ b/scripts/release/bookforge_phone_launch.py
@@ -38,7 +38,7 @@ def write_phone_card(url: str, port: int) -> Path:
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Bookforge Phone Launch</title>
+    <title>AetherMoore Book Studio Phone Launch</title>
     <style>
       body {{ margin: 0; font: 18px/1.5 system-ui, sans-serif; background: #f7f1e6; color: #18211f; }}
       main {{ width: min(760px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0; }}
@@ -49,7 +49,7 @@ def write_phone_card(url: str, port: int) -> Path:
   </head>
   <body>
     <main>
-      <h1>Bookforge is running</h1>
+      <h1>AetherMoore Book Studio is running</h1>
       <div class="card">
         <p>Open this URL on your phone while it is on the same Wi-Fi network:</p>
         <p><a href="{url}">{url}</a></p>
@@ -67,7 +67,7 @@ def write_phone_card(url: str, port: int) -> Path:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Serve Bookforge Studio on the LAN for phone testing.")
+    parser = argparse.ArgumentParser(description="Serve AetherMoore Book Studio on the LAN for phone testing.")
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--open-card", action="store_true", help="Open the local launch card in the desktop browser.")
@@ -89,8 +89,8 @@ def main() -> int:
     if args.open_card:
         webbrowser.open(card.resolve().as_uri())
 
-    print("Bookforge Studio phone launch", flush=True)
-    print("==============================", flush=True)
+    print("AetherMoore Book Studio phone launch", flush=True)
+    print("====================================", flush=True)
     print(f"Phone URL : {url}", flush=True)
     print(f"Local URL : {local_url}", flush=True)
     print(f"Launch card: {card}", flush=True)


### PR DESCRIPTION
Renames the public PWA/store-facing surface to AetherMoore Book Studio while keeping Bookforge as the internal engine/package and CLI command. Updates the manifest, phone launcher, release runbook, checklist, and site entry links. Verification: py_compile launcher; launcher card-only run; node static release check; package smoke subset 5 passed / 1 deselected because DOCX requires pandoc; git diff --check.