### PR TITLE
feat(cube): speedcuber triggers as a code stdlib + return-to-solved = undo

### DIFF
--- a/python/scbe/cube_controller.py
+++ b/python/scbe/cube_controller.py
@@ -54,6 +54,17 @@ except Exception:  # pragma: no cover - optional
     _HAVE_TONGUES = False
 
 
+def _expand_names(text: str) -> str:
+    """Lazily expand speedcuber trigger names (sexy, sledge, sune ...) to moves; no-op if the
+    triggers module is absent. Imported lazily so triggers can import this module back."""
+    try:
+        from .triggers import expand_names
+
+        return expand_names(text)
+    except Exception:  # pragma: no cover - optional
+        return text
+
+
 def parse_moves(text: str) -> List[str]:
     """Text like "R U F'" -> a validated move list (raises on an unknown twist)."""
     out: List[str] = []
@@ -159,7 +170,7 @@ def bop_it(voice: bool = False) -> int:
         if not line:
             continue
         try:
-            narrate(parse_moves(line), voice)
+            narrate(parse_moves(_expand_names(line)), voice)
         except ValueError as e:
             print("  " + str(e))
 
@@ -168,15 +179,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     import argparse
 
     ap = argparse.ArgumentParser(prog="scbe-bopit", description="twist the cube, hear the command")
-    ap.add_argument("moves", nargs="*", help="twist sequence, e.g. R U F'")
+    ap.add_argument("moves", nargs="*", help="twist sequence or trigger names, e.g. R U F'  or  sexy sledge")
     ap.add_argument("--voice", action="store_true", help="say it aloud (Windows SAPI)")
     ap.add_argument("--repl", action="store_true", help="interactive twist loop")
+    ap.add_argument("--triggers", action="store_true", help="list speedcuber triggers (the move stdlib)")
     a = ap.parse_args(argv)
+    if a.triggers:
+        from .triggers import main as triggers_main
+
+        return triggers_main(["--list"])
     if a.repl or not a.moves:
         return bop_it(a.voice)
     try:
         print("CUBE CONTROLLER")
-        narrate(parse_moves(" ".join(a.moves)), a.voice)
+        narrate(parse_moves(_expand_names(" ".join(a.moves))), a.voice)
         return 0
     except ValueError as e:
         print(str(e), file=sys.stderr)

--- a/python/scbe/triggers.py
+++ b/python/scbe/triggers.py
@@ -1,0 +1,202 @@
+"""Speedcuber triggers — the muscle-memory standard library over the cube controller.
+
+A speedcuber's whole skill is short, named, muscle-memorized move combos: the *sexy
+move* (R U R' U'), the *sledgehammer* (R' F R F'), *sune* (R U R' U R U2 R'). They chain
+these at 8-10 turns/second without conscious thought. Under the cube controller's fixed
+move->opcode map (cube_controller.MOVE_OP), each trigger expands to a fixed opcode
+SUBROUTINE — so a speedcuber's existing repertoire IS a standard library they can already
+execute by hand. This module names those triggers, expands them to programs, and (the
+smart-cube use case) RECOGNIZES a raw move stream back into the named triggers it contains
+— the way a cuber parses their own solve.
+
+    from python.scbe.triggers import trigger_program, recognize, parse_moves
+    trigger_program("sexy sledge")            # named triggers -> one opcode program
+    recognize(parse_moves("R U R' U'"))       # a raw solve  -> ['sexy']
+
+Naming changes nothing about the computation: trigger_program(name) is byte-identical to
+running the trigger's expanded moves through the controller — the name is just a handle a
+cuber already owns.
+
+Return-to-solved is UNDO. Every move has an inverse (R<->R'), and the inverse of a whole
+sequence (reverse it, prime each move) is the algorithm that walks the cube back to solved
+— the universal escape hatch. inverse()/undo() compute it, and this module proves two
+cuber facts: 'unsexy' (U R U' R') IS the inverse of the sexy move, and 'hedge' IS the
+inverse of the sledgehammer. The cube-level undo is always exact (group theory). At the
+opcode level only the UNARY moves form a clean computational undo (U/U' = inc/dec restore
+the number); the binary moves (add/sub, mul/div) restore the cube but not the stack, since
+each binary op changes the stack depth — an honest asymmetry, not a bug.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Tuple
+
+from . import polyglot as P
+from .cube_controller import MOVE_OP, moves_to_program, parse_moves
+
+
+def _expand_notation(notation: str) -> Tuple[str, ...]:
+    """'R U R' U2' -> ('R','U',"R'",'U','U'): split on space, unroll an X2 double turn."""
+    out: List[str] = []
+    for raw in notation.replace(",", " ").split():
+        m = raw.strip().upper().replace("’", "'")
+        if m.endswith("2"):
+            base = m[:-1]
+            out.extend([base, base])
+        else:
+            out.append(m)
+    return tuple(out)
+
+
+@dataclass(frozen=True)
+class Trigger:
+    """One named cuber combo: its human notation, its expanded base moves, its opcodes."""
+
+    name: str
+    singmaster: str  # human-facing notation, may contain X2 doubles
+    note: str
+
+    @property
+    def moves(self) -> Tuple[str, ...]:
+        return _expand_notation(self.singmaster)
+
+    @property
+    def ops(self) -> List[str]:
+        return [MOVE_OP[m] for m in self.moves]
+
+
+# The iconic triggers every speedcuber owns by muscle memory (real Singmaster notation).
+_TRIGGER_LIST = [
+    Trigger("trigger", "R U R'", "the basic insert trigger"),
+    Trigger("sexy", "R U R' U'", "the sexy move — the most-used trigger in cubing"),
+    Trigger("unsexy", "U R U' R'", "inverse sexy move"),
+    Trigger("lefty_sexy", "L' U' L U", "left-hand sexy move"),
+    Trigger("sledge", "R' F R F'", "the sledgehammer"),
+    Trigger("hedge", "F R' F' R", "the hedslammer (inverse sledgehammer)"),
+    Trigger("sune", "R U R' U R U2 R'", "the OLL sune — orients a corner triple"),
+    Trigger("antisune", "R U2 R' U' R U' R'", "the antisune (inverse-handed sune)"),
+]
+TRIGGERS: Dict[str, Trigger] = {t.name: t for t in _TRIGGER_LIST}
+
+# Fail loud at import if a trigger ever names a move the controller cannot fire.
+for _t in _TRIGGER_LIST:
+    for _m in _t.moves:
+        if _m not in MOVE_OP:
+            raise ValueError("trigger %r uses unknown move %r" % (_t.name, _m))
+
+
+def expand_trigger(name: str) -> List[str]:
+    """A trigger name -> its expanded base-move list (the moves a cuber's hands make)."""
+    return list(TRIGGERS[name.lower()].moves)
+
+
+def invert_move(move: str) -> str:
+    """One move -> its inverse: R<->R', and an X2 double turn is its own inverse."""
+    m = move.strip().upper().replace("’", "'")
+    if m.endswith("2"):
+        return m
+    if m.endswith("'"):
+        return m[:-1]
+    return m + "'"
+
+
+def inverse(moves: Sequence[str]) -> List[str]:
+    """The UNDO of a move sequence: reverse it, invert each move — the algorithm that walks
+    the cube back to solved. Exact by group theory (inverse(seq) cancels seq). This is why
+    'unsexy' is inverse('sexy') and 'hedge' is inverse('sledge')."""
+    return [invert_move(m) for m in reversed(list(moves))]
+
+
+def undo(text: str) -> List[str]:
+    """Trigger names and/or moves -> the move sequence that returns the cube to solved."""
+    return inverse(trigger_moves(text))
+
+
+def expand_names(text: str) -> str:
+    """Expand any trigger-NAME tokens to moves; leave raw moves untouched. Mixed input is
+    fine: 'sexy R sledge' -> 'R U R' U' R R' F R F''. The handle reduces to moves."""
+    out: List[str] = []
+    for tok in text.replace(",", " ").split():
+        key = tok.lower()
+        if key in TRIGGERS:
+            out.extend(TRIGGERS[key].moves)
+        else:
+            out.append(tok)
+    return " ".join(out)
+
+
+def trigger_moves(text: str) -> List[str]:
+    """Trigger names and/or raw moves -> a validated flat move list (via the controller)."""
+    return parse_moves(expand_names(text))
+
+
+def trigger_program(text: str) -> List[int]:
+    """Trigger names and/or raw moves -> the CA-opcode program (same pipeline as a twist)."""
+    return moves_to_program(trigger_moves(text))
+
+
+def recognize(moves: Sequence[str]) -> List[str]:
+    """Segment a raw move stream into the named triggers it contains (greedy longest match).
+
+    This is the smart-cube path: a Bluetooth cube streams moves; recognize() parses that
+    stream back into the named subroutines a cuber actually performed. Unmatched moves pass
+    through as themselves, so the output is a mix of trigger names and leftover raw moves.
+    """
+    pats = sorted(TRIGGERS.values(), key=lambda t: len(t.moves), reverse=True)
+    seq = list(moves)
+    out: List[str] = []
+    i = 0
+    while i < len(seq):
+        hit = None
+        for t in pats:
+            n = len(t.moves)
+            if tuple(seq[i : i + n]) == t.moves:
+                hit = t
+                break
+        if hit is not None:
+            out.append(hit.name)
+            i += len(hit.moves)
+        else:
+            out.append(seq[i])
+            i += 1
+    return out
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    import argparse
+
+    from .cube_controller import narrate
+
+    ap = argparse.ArgumentParser(prog="scbe-triggers", description="speedcuber triggers as a code stdlib")
+    ap.add_argument("program", nargs="*", help="trigger names and/or moves, e.g. sexy sledge")
+    ap.add_argument("--list", action="store_true", help="list the known triggers")
+    ap.add_argument("--recognize", metavar="MOVES", help="parse a raw move stream into triggers")
+    ap.add_argument("--undo", metavar="PROGRAM", help="print the moves that return to solved (the undo)")
+    ap.add_argument("--voice", action="store_true", help="say it aloud (Windows SAPI)")
+    a = ap.parse_args(argv)
+
+    if a.undo:
+        print("undo (return to solved): " + " ".join(undo(a.undo)))
+        return 0
+    if a.list:
+        print("TRIGGERS — a cuber's muscle memory as a standard library")
+        for t in _TRIGGER_LIST:
+            print("  %-11s %-22s -> %s" % (t.name, t.singmaster, ", ".join(t.ops)))
+            print("  %-11s %s" % ("", t.note))
+        return 0
+    if a.recognize:
+        seg = recognize(parse_moves(a.recognize))
+        print("recognized: " + " ".join(seg))
+        return 0
+    if not a.program:
+        ap.print_help()
+        return 0
+    text = " ".join(a.program)
+    print("TRIGGER PROGRAM  (%s -> %s)" % (text, ", ".join(P.BYTE_TO_NAME[b] for b in trigger_program(text))))
+    narrate(trigger_moves(text), a.voice)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,0 +1,87 @@
+"""Speedcuber triggers as a code stdlib, and return-to-solved as undo.
+
+A trigger is a named muscle-memory combo; under the cube controller's fixed move->opcode
+map it expands to a fixed opcode subroutine, so naming changes nothing about the program.
+recognize() parses a raw move stream back into the triggers it contains (the smart-cube
+path). inverse()/undo() walk the cube back to solved -- exactly, by group theory -- which
+is why 'unsexy' is the inverse of 'sexy' and 'hedge' is the inverse of 'sledge'.
+"""
+
+from python.scbe import polyglot as P
+from python.scbe.cube_controller import _expand_names, run_program
+from python.scbe.triggers import (
+    MOVE_OP,
+    TRIGGERS,
+    expand_trigger,
+    inverse,
+    invert_move,
+    recognize,
+    trigger_moves,
+    trigger_program,
+    undo,
+)
+
+
+def test_every_trigger_uses_only_real_controller_moves():
+    for t in TRIGGERS.values():
+        assert t.moves, t.name
+        assert all(m in MOVE_OP for m in t.moves), t.name
+        assert t.ops == [MOVE_OP[m] for m in t.moves]
+
+
+def test_x2_double_turn_unrolls():
+    # sune contains U2, which must unroll into two U quarter-turns
+    assert expand_trigger("sune") == ["R", "U", "R'", "U", "R", "U", "U", "R'"]
+
+
+def test_sexy_expands_and_programs_like_its_raw_moves():
+    assert expand_trigger("sexy") == ["R", "U", "R'", "U'"]
+    # naming changes nothing: the trigger program == the raw-move program
+    assert trigger_program("sexy") == P.program_bytes("add", "inc", "sub", "dec")
+    assert trigger_program("sexy") == trigger_program("R U R' U'")
+
+
+def test_recognize_segments_a_solve_into_triggers():
+    # a raw stream of moves is parsed back into the named subroutines it contains
+    assert recognize(trigger_moves("R U R' U'")) == ["sexy"]
+    assert recognize(trigger_moves("sexy sledge")) == ["sexy", "sledge"]
+    # an unmatched move passes through as itself, between recognized triggers
+    assert recognize(["R", "U", "R'", "U'", "D"]) == ["sexy", "D"]
+
+
+def test_inverse_is_an_involution():
+    for text in ("sexy", "sledge", "sune", "R U F' L'"):
+        moves = trigger_moves(text)
+        assert inverse(inverse(moves)) == moves
+    assert invert_move("R") == "R'"
+    assert invert_move("R'") == "R"
+    assert invert_move("U2") == "U2"  # a double turn is its own inverse
+
+
+def test_named_undo_pairs_are_real_inverses():
+    # the module already contains undo pairs, and these are cuber facts:
+    assert inverse(expand_trigger("sexy")) == expand_trigger("unsexy")
+    assert inverse(expand_trigger("sledge")) == expand_trigger("hedge")
+
+
+def test_undo_of_a_sequence_cancels_it_movewise():
+    moves = trigger_moves("sexy sledge")
+    # seq followed by its undo nets to a balanced sequence: reversing the back half
+    # reproduces the forward half inverted, i.e. inverse(undo) == original
+    assert inverse(undo("sexy sledge")) == moves
+
+
+def test_unary_undo_restores_the_computation():
+    # baseline: an empty program returns the last input (4.0) under run_program(2,3,4)
+    base, _ = run_program(P.program_bytes())
+    # U U (inc inc) are UNARY, so U U + its undo (U' U') restores the number exactly
+    seq = ["U", "U"]
+    restored, _ = run_program(P.program_bytes(*[MOVE_OP[m] for m in seq + undo(" ".join(seq))]))
+    assert restored == base
+
+
+def test_controller_cli_accepts_trigger_names():
+    # the scbe-bopit hook expands trigger names to moves; raw moves are untouched
+    assert _expand_names("sexy") == "R U R' U'"
+    assert _expand_names("R U") == "R U"
+    assert _expand_names("sexy R") == "R U R' U' R"


### PR DESCRIPTION
## What

If coding is using a Rubik's cube, then a **speedcuber's muscle memory is a standard library.** The steering wheel already exists (`cube_controller.py`: Singmaster twist → CA opcode → emit across 18 languages → run). This adds the speedcuber rung.

- **`python/scbe/triggers.py`** — `TRIGGERS` registry of the iconic combos every cuber owns (sexy `R U R' U'`, sledgehammer `R' F R F'`, sune, antisune, …). Under the controller's fixed move→opcode map each expands to a fixed opcode **subroutine**, so a cuber's repertoire *is* a callable stdlib. `trigger_program()` runs the exact same pipeline as a raw twist — naming changes nothing.
- **`recognize()`** — segments a raw move stream back into the triggers it contains. This is the **smart-cube path**: a Bluetooth cube (GAN/GoCube/Giiker) streams moves; we parse them into the algorithms actually performed. `recognize("R U R' U' R' F R F'") → ['sexy', 'sledge']`.
- **Return-to-solved = UNDO.** `inverse()`/`undo()` reverse a sequence and prime each move — the algorithm that walks the cube back to solved, exact by group theory. The module proves two cuber facts: **`unsexy` (U R U' R') *is* `inverse(sexy)`**, and **`hedge` *is* `inverse(sledge)`**. Honest asymmetry: only the unary moves (`U/U'` = inc/dec) form a clean *computational* undo; binary ops restore the cube but not the stack depth.
- **`cube_controller`** — `scbe-bopit` now accepts trigger names (lazy import avoids the cycle) + `--triggers`; the triggers CLI adds `--recognize` and `--undo`.

## Demo

```
$ scbe-triggers --recognize "R U R' U' R' F R F'"
recognized: sexy sledge

$ scbe-triggers --undo sexy
undo (return to solved): U R U' R'        # == the 'unsexy' trigger

$ scbe-bopit sexy
... command "add, inc, sub, dec" -> -7.0
```

## Tests

`tests/test_triggers.py` — 9 new: valid moves, `X2` unroll, trigger-program == raw-moves program, solve recognition, `inverse` involution, named undo pairs, unary undo restores the computation, controller hook. Full run green: **30 passed** (triggers + cube_token + polyglot + cube_controller). black/flake8 clean (120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)