### PR TITLE
test(cube): Hypothesis property for the undo involution + pure normalize_move

### DIFF
--- a/python/scbe/triggers.py
+++ b/python/scbe/triggers.py
@@ -91,9 +91,15 @@ def expand_trigger(name: str) -> List[str]:
     return list(TRIGGERS[name.lower()].moves)
 
 
+def normalize_move(move: str) -> str:
+    """Canonicalize a move's spelling only: trim, uppercase the face, ASCII the prime
+    (curly ’ -> '). No inversion -- this is the spelling normal form invert_move builds on."""
+    return move.strip().upper().replace("’", "'")
+
+
 def invert_move(move: str) -> str:
     """One move -> its inverse: R<->R', and an X2 double turn is its own inverse."""
-    m = move.strip().upper().replace("’", "'")
+    m = normalize_move(move)
     if m.endswith("2"):
         return m
     if m.endswith("'"):

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -7,6 +7,9 @@ path). inverse()/undo() walk the cube back to solved -- exactly, by group theory
 is why 'unsexy' is the inverse of 'sexy' and 'hedge' is the inverse of 'sledge'.
 """
 
+from hypothesis import given
+from hypothesis import strategies as st
+
 from python.scbe import polyglot as P
 from python.scbe.cube_controller import _expand_names, run_program
 from python.scbe.triggers import (
@@ -15,11 +18,35 @@ from python.scbe.triggers import (
     expand_trigger,
     inverse,
     invert_move,
+    normalize_move,
     recognize,
     trigger_moves,
     trigger_program,
     undo,
 )
+
+# move spellings incl. case / whitespace / curly-quote variants to exercise normalization
+_MOVE_TOKENS = [
+    "R",
+    "L",
+    "U",
+    "D",
+    "F",
+    "B",
+    "R'",
+    "L'",
+    "U'",
+    "D'",
+    "F'",
+    "B'",
+    "R2",
+    "U2",
+    "F2",
+    "r",
+    "u'",
+    " D ",
+    "F’",
+]
 
 
 def test_every_trigger_uses_only_real_controller_moves():
@@ -56,6 +83,12 @@ def test_inverse_is_an_involution():
     assert invert_move("R") == "R'"
     assert invert_move("R'") == "R"
     assert invert_move("U2") == "U2"  # a double turn is its own inverse
+
+
+@given(st.lists(st.sampled_from(_MOVE_TOKENS), max_size=16))
+def test_inverse_is_an_involution_over_random_sequences(seq):
+    # undoing the undo returns the sequence in its canonical spelling, for ANY move stream
+    assert inverse(inverse(seq)) == [normalize_move(m) for m in seq]
 
 
 def test_named_undo_pairs_are_real_inverses():


### PR DESCRIPTION
## What

Hardens the **return-to-solved / undo** invariant (from the #2374 review). Two changes:

- **`normalize_move()`** — a pure spelling-normal-form (trim, uppercase face, ASCII the prime `’→'`) factored out of `invert_move`, which now builds on it. No behavior change to `invert_move`.
- **Hypothesis property** — for *any* move stream, including `lowercase`, `curly-quote`, `whitespace`, and `X2` spellings:

  ```python
  inverse(inverse(seq)) == [normalize_move(m) for m in seq]
  ```

  This catches normalization bugs the fixed-example involution test can't reach (it only covered already-canonical base moves).

## Tests

`tests/test_triggers.py` — **10/10 green** (the property ran 100 generated cases). black/flake8 clean (120). No production code path changed except the `invert_move` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)