### PR TITLE
fix(geometry): satisfy ruff unused loop variables

### DIFF
--- a/src/scbe_aethermoore/geometry.py
+++ b/src/scbe_aethermoore/geometry.py
@@ -48,7 +48,7 @@ def positions() -> Dict[str, Tuple[float, float]]:
     """Each region as a point in the Poincare disk: radius = r, angle spread by index."""
     n = len(_REGIONS)
     pos = {"entry": (0.0, 0.0)}
-    for i, (name, ring, r, fn) in enumerate(_REGIONS):
+    for i, (name, _ring, r, _fn) in enumerate(_REGIONS):
         theta = 2.0 * math.pi * i / n
         pos[name] = (r * math.cos(theta), r * math.sin(theta))
     return pos


### PR DESCRIPTION
﻿## Summary

Fixes the current main lint failure from the geometry router by marking unused loop tuple fields as intentionally unused.

## Verification

- `black --check --target-version py311 --line-length 120 src\ tests\ scripts\ agents\`
- `ruff check --config ruff.toml`
- `git diff --check origin/main..HEAD`
