### PR TITLE
feat(polyglot): honest differential-conformance harness + calibrate the overclaim

### DIFF
--- a/python/scbe/polyglot.py
+++ b/python/scbe/polyglot.py
@@ -11,9 +11,12 @@ Unlike tongue_isa (which bakes a field per language into every opcode), each
 language here is a pure DATA `Dialect` — a registry entry. Adding a language is
 one independent track: fill a Dialect literal, register it. Nothing else changes.
 
-Emitted source is validated two ways:
-  * real compile+run where the toolchain exists (python always; node/rust/...),
-  * tree-sitter parse (rust/ast_cube_poly) for every language without a toolchain.
+Conformance is checked by polyglot_conformance.py: it compiles+runs each backend that has
+a LOCAL toolchain (python in-process, javascript via node, rust via rustc) and reports the
+rest as emitted-but-unverified -- never as agreement. "Compiles no matter what" means the
+emitter PRODUCES source for every backend; it does NOT mean the backends compute identical
+results -- they provably diverge on e.g. .5 rounding (Python half-to-even vs JS/Rust),
+which the harness surfaces as DISAGREE rather than hiding.
 
 Op coverage (v1, the cleanly-portable scalar core over a float64 stack):
   arithmetic  add sub mul div mod neg inc dec

--- a/python/scbe/polyglot_conformance.py
+++ b/python/scbe/polyglot_conformance.py
@@ -1,0 +1,204 @@
+"""Differential conformance harness for the polyglot multi-backend compiler.
+
+The polyglot emitter is a compiler with many backends over one core opcode IR. This
+harness measures the only thing that actually matters about that: do the backends compute
+the SAME numbers? It is HONEST by construction:
+
+  * It compiles+runs a backend ONLY where a local toolchain exists (this box: python in
+    process, javascript via `node`, rust via `rustc`). Everything else is reported as
+    emitted-but-unverified -- never as agreement.
+  * It never marks a backend AGREE unless it actually ran and matched the Python reference.
+  * It SURFACES real divergences instead of hiding them. "Same value class" (Church-Turing)
+    is not "same program with the same numeric behaviour": e.g. round(2.5) is 2.0 in Python
+    (half-to-even) but 3.0 in JS/Rust (half-up / half-away). The harness reports that as a
+    DISAGREE, because it is one -- that asymmetry is the whole point of the calibration.
+
+    python -m python.scbe.polyglot_conformance "mul gt" --args 2,3,4 --args 10,3,2
+    python -m python.scbe.polyglot_conformance --demo
+"""
+
+from __future__ import annotations
+
+import math
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from . import polyglot as P
+
+TOL = 1e-9  # absolute+relative tolerance for "agree"
+
+# Backends we know HOW to run locally. A backend not listed here is emitted but has no
+# runner, so it can only ever be reported as unverified -- not as agreement.
+_RUNNER_TOOL = {"python": None, "javascript": "node", "rust": "rustc"}
+
+
+def _toolchain_ok(lang: str) -> bool:
+    tool = _RUNNER_TOOL.get(lang, "<none>")
+    if tool is None:
+        return True  # python runs in-process
+    if tool == "<none>":
+        return False  # no runner implemented for this backend
+    return shutil.which(tool) is not None
+
+
+def _close(x: Optional[float], r: Optional[float]) -> bool:
+    if x is None or r is None:
+        return x is r
+    if math.isnan(x) or math.isnan(r):
+        return math.isnan(x) and math.isnan(r)
+    return abs(x - r) <= TOL + TOL * abs(r)
+
+
+def _arglist(args: Sequence[float]) -> str:
+    return ", ".join(repr(float(a)) for a in args)
+
+
+def run_python(prog: Sequence[int], args: Sequence[float]) -> Optional[float]:
+    ns: Dict[str, object] = {}
+    exec(compile(P.emit(prog, "python"), "<conf>", "exec"), ns)  # noqa: S102 - our own emitter output
+    out = ns["tongue_fn"](*[float(a) for a in args])  # type: ignore[operator]
+    return None if out is None else float(out)
+
+
+def _run_subprocess_float(cmd: Sequence[str], cwd: Optional[Path] = None, timeout: int = 60) -> Optional[float]:
+    proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        raise RuntimeError((proc.stderr or proc.stdout or "nonzero exit").strip().splitlines()[-1][:200])
+    line = proc.stdout.strip().splitlines()[-1].strip()
+    if line.lower() in ("nan", "-nan"):
+        return float("nan")
+    return float(line)
+
+
+def run_node(prog: Sequence[int], args: Sequence[float]) -> Optional[float]:
+    src = P.emit(prog, "javascript") + "\nprocess.stdout.write(String(tongue_fn(%s)));\n" % _arglist(args)
+    with tempfile.TemporaryDirectory() as td:
+        f = Path(td) / "prog.js"
+        f.write_text(src, encoding="utf-8")
+        return _run_subprocess_float(["node", str(f)])
+
+
+def run_rust(prog: Sequence[int], args: Sequence[float]) -> Optional[float]:
+    src = P.emit(prog, "rust") + '\nfn main() { println!("{:.17}", tongue_fn(%s)); }\n' % _arglist(args)
+    with tempfile.TemporaryDirectory() as td:
+        f = Path(td) / "prog.rs"
+        f.write_text(src, encoding="utf-8")
+        exe = Path(td) / ("prog.exe" if shutil.which("cmd") else "prog")
+        subprocess.run(["rustc", "-O", str(f), "-o", str(exe)], capture_output=True, text=True, timeout=120, check=True)
+        return _run_subprocess_float([str(exe)])
+
+
+_RUNNERS = {"python": run_python, "javascript": run_node, "rust": run_rust}
+
+
+@dataclass
+class BackendResult:
+    lang: str
+    status: str  # REFERENCE | AGREE | DISAGREE | NO_TOOLCHAIN | NO_RUNNER | ERROR
+    values: List[Optional[float]] = field(default_factory=list)
+    note: str = ""
+
+
+def conformance(prog: Sequence[int], cases: Sequence[Sequence[float]]) -> dict:
+    """Run prog across every registered backend over the given input cases; compare each
+    runnable backend to the Python reference and report honest, per-backend status."""
+    ref = [run_python(prog, c) for c in cases]
+    results: List[BackendResult] = [BackendResult("python", "REFERENCE", ref, "in-process reference")]
+
+    for lang in P.languages():
+        if lang == "python":
+            continue
+        if lang not in _RUNNERS:
+            results.append(BackendResult(lang, "NO_RUNNER", note="emitted; no runner implemented"))
+            continue
+        if not _toolchain_ok(lang):
+            results.append(BackendResult(lang, "NO_TOOLCHAIN", note="emitted; %s not on PATH" % _RUNNER_TOOL[lang]))
+            continue
+        try:
+            vals = [_RUNNERS[lang](prog, c) for c in cases]
+        except Exception as e:  # compile/run failure is reported, never silently 'agree'
+            results.append(BackendResult(lang, "ERROR", note="%s: %s" % (type(e).__name__, e)))
+            continue
+        agree = all(_close(v, r) for v, r in zip(vals, ref))
+        results.append(BackendResult(lang, "AGREE" if agree else "DISAGREE", vals))
+
+    ran = [r for r in results if r.status in ("REFERENCE", "AGREE", "DISAGREE")]
+    verified = [r for r in results if r.status == "AGREE"]
+    disagreed = [r for r in results if r.status == "DISAGREE"]
+    return {
+        "program": [P.BYTE_TO_NAME[b] for b in prog],
+        "cases": [list(c) for c in cases],
+        "reference": ref,
+        "results": results,
+        "summary": {
+            "runnable_backends": len(ran),  # includes the python reference
+            "verified_agree": len(verified),
+            "disagree": [r.lang for r in disagreed],
+            "emitted_unverified": len([r for r in results if r.status in ("NO_TOOLCHAIN", "NO_RUNNER", "ERROR")]),
+            "total_backends": len(results),
+        },
+    }
+
+
+def format_report(rep: dict) -> str:
+    lines = ["program: %s   cases: %s" % (" ".join(rep["program"]) or "(empty)", rep["cases"])]
+    lines.append("  %-12s %-13s %s" % ("backend", "status", "values"))
+    for r in rep["results"]:
+        vals = "" if not r.values else str([None if v is None else round(v, 6) for v in r.values])
+        tail = vals if vals else ("(%s)" % r.note if r.note else "")
+        lines.append("  %-12s %-13s %s" % (r.lang, r.status, tail))
+    s = rep["summary"]
+    lines.append(
+        "  --> %d/%d runnable backends agree across %d case(s); %d emitted-but-unverified%s"
+        % (
+            s["verified_agree"],
+            s["runnable_backends"] - 1,  # exclude the reference itself from the denominator
+            len(rep["cases"]),
+            s["emitted_unverified"],
+            ("; DISAGREE: " + ", ".join(s["disagree"])) if s["disagree"] else "",
+        )
+    )
+    return "\n".join(lines)
+
+
+def _parse_args(specs: Sequence[str]) -> List[Tuple[float, ...]]:
+    cases: List[Tuple[float, ...]] = []
+    for spec in specs:
+        parts = [float(x) for x in spec.replace(" ", "").split(",") if x != ""]
+        while len(parts) < 3:
+            parts.append(0.0)
+        cases.append(tuple(parts[:3]))
+    return cases
+
+
+def _demo() -> int:
+    print("POLYGLOT CONFORMANCE  (honest: runs only what this box can run)\n")
+    print(">> a real DECISION (not just arithmetic): mul gt  ==  (a > b*c) ? 1 : 0")
+    print(format_report(conformance(P.program_bytes("mul", "gt"), [(2.0, 3.0, 4.0), (10.0, 3.0, 2.0)])))
+    print("\n>> a KNOWN divergence the harness must CATCH: round, on a .5 value")
+    print("   (Python round-half-to-even 2.0  vs  JS/Rust half-up/away 3.0)")
+    print(format_report(conformance(P.program_bytes("round"), [(2.0, 3.0, 2.5)])))
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(prog="scbe-conformance", description="differential conformance for polyglot backends")
+    ap.add_argument("program", nargs="?", help="op names, e.g. 'mul gt'")
+    ap.add_argument("--args", action="append", default=[], metavar="A,B,C", help="an input case (repeatable)")
+    ap.add_argument("--demo", action="store_true", help="run the canned demo (agreement + a caught divergence)")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    if a.demo or not a.program:
+        return _demo()
+    cases = _parse_args(a.args) or [(2.0, 3.0, 4.0)]
+    print(format_report(conformance(P.program_bytes(*a.program.split()), cases)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_polyglot_conformance.py
+++ b/tests/test_polyglot_conformance.py
@@ -1,0 +1,67 @@
+"""Honest differential conformance for the polyglot multi-backend compiler.
+
+The point of these tests is the HONESTY of the harness, not a claim that all backends
+agree. The Python reference and the labeling of unverified backends are checked
+unconditionally; the cross-language agreement and the round-divergence catch are checked
+only when the toolchain is actually present (skip otherwise) -- never faked.
+"""
+
+import shutil
+
+import pytest
+
+from python.scbe import polyglot as P
+from python.scbe.polyglot_conformance import conformance
+
+_HAVE_NODE = shutil.which("node") is not None
+
+
+def _status(rep, lang):
+    return next(r.status for r in rep["results"] if r.lang == lang)
+
+
+def _values(rep, lang):
+    return next(r.values for r in rep["results"] if r.lang == lang)
+
+
+def test_python_reference_is_computed_in_process():
+    # mul gt == (a > b*c) ? 1 : 0  -- a real decision, evaluated by the reference
+    rep = conformance(P.program_bytes("mul", "gt"), [(2.0, 3.0, 4.0), (10.0, 3.0, 2.0)])
+    assert rep["reference"] == [0.0, 1.0]
+    assert _status(rep, "python") == "REFERENCE"
+
+
+def test_unverified_backends_are_never_marked_agree():
+    rep = conformance(P.program_bytes("add"), [(2.0, 3.0, 4.0)])
+    for r in rep["results"]:
+        if r.status in ("NO_RUNNER", "NO_TOOLCHAIN", "ERROR"):
+            assert not r.values  # nothing claimed for a backend that did not run
+    # a backend with no runner implemented (haskell here) is labeled, not agreed
+    assert _status(rep, "haskell") == "NO_RUNNER"
+
+
+def test_summary_counts_are_consistent():
+    rep = conformance(P.program_bytes("add"), [(2.0, 3.0, 4.0)])
+    s = rep["summary"]
+    # you can never verify more backends than actually ran (minus the reference itself)
+    assert s["verified_agree"] <= s["runnable_backends"] - 1
+    unverified = sum(1 for r in rep["results"] if r.status in ("NO_RUNNER", "NO_TOOLCHAIN", "ERROR"))
+    assert s["emitted_unverified"] == unverified
+    assert s["total_backends"] == len(P.languages())
+
+
+@pytest.mark.skipif(not _HAVE_NODE, reason="node not installed")
+def test_javascript_agrees_on_a_portable_decision():
+    rep = conformance(P.program_bytes("mul", "gt"), [(2.0, 3.0, 4.0), (10.0, 3.0, 2.0)])
+    assert _status(rep, "javascript") == "AGREE"
+    assert _values(rep, "javascript") == [0.0, 1.0]
+
+
+@pytest.mark.skipif(not _HAVE_NODE, reason="node not installed")
+def test_round_half_even_divergence_is_caught_not_hidden():
+    # Python rounds 2.5 -> 2.0 (half-to-even); JS Math.round(2.5) -> 3.0 (half-up).
+    rep = conformance(P.program_bytes("round"), [(2.0, 3.0, 2.5)])
+    assert rep["reference"] == [2.0]
+    assert _status(rep, "javascript") == "DISAGREE"
+    assert _values(rep, "javascript") == [3.0]
+    assert "javascript" in rep["summary"]["disagree"]


### PR DESCRIPTION
## What

The polyglot emitter is **a compiler with many backends over one core opcode IR** (the LLVM-IR / WASM shape). Its docstring claimed emitted source was *"validated two ways: real compile+run / tree-sitter parse"* — but **no runner existed**; that was aspirational. This adds the real one and tells the truth.

`polyglot_conformance.py` runs a program across the backends and is **honest by construction**:

- **Runs only what this box can run** — python (in-process), javascript (`node`), rust (`rustc`). Every other backend is reported `emitted-but-unverified`, **never** as agreement.
- **Never marks a backend `AGREE`** unless it actually ran and matched the python reference.
- **Surfaces divergence instead of hiding it.** *"Same value class"* (Church–Turing) ≠ *"same program with the same numbers."* `round(2.5)` → `2.0` in Python (half-to-even) but `3.0` in JS/Rust — the harness reports that as `DISAGREE`, because it is one.

## Verified by running (not asserted)

```
>> a real DECISION (not just arithmetic): mul gt  ==  (a > b*c) ? 1 : 0
  python       REFERENCE     [0.0, 1.0]
  javascript   AGREE         [0.0, 1.0]
  rust         AGREE         [0.0, 1.0]
  --> 2/2 runnable backends agree across 2 case(s); 15 emitted-but-unverified

>> a KNOWN divergence the harness must CATCH: round, on a .5 value
  python       REFERENCE     [2.0]
  javascript   DISAGREE      [3.0]
  rust         DISAGREE      [3.0]
  --> 0/2 runnable backends agree across 1 case(s); 15 emitted-but-unverified; DISAGREE: javascript, rust
```

## Why

This replaces the "trust me, faces agree" comment-grep posture with ground truth: it proves what it can (3 backends agree on a real branch) and is explicit about what it can't (15 unverified). It also corrects `polyglot.py`'s docstring — *"compiles no matter what"* means it **produces source** for every backend, not that they compute identical results.

## Tests

5 toolchain-aware tests (`tests/test_polyglot_conformance.py`): python reference, unverified-never-`AGREE` labeling, honest summary counts (all unconditional), plus js agreement + the round-divergence catch (skipped if `node` absent, **never faked**). black / flake8 / ruff clean (120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)