### PR TITLE
fix(agent-bus): make husky pre-commit self-contained

### DIFF
--- a/packages/agent-bus/.husky/pre-commit
+++ b/packages/agent-bus/.husky/pre-commit
@@ -1,6 +1,11 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
-if [ -x packages/agent-bus/node_modules/.bin/lint-staged ]; then
-  cd packages/agent-bus && ./node_modules/.bin/lint-staged
+set -eu
+
+HOOK_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+PACKAGE_DIR="$(CDPATH= cd -- "$HOOK_DIR/.." && pwd)"
+
+if [ -x "$PACKAGE_DIR/node_modules/.bin/lint-staged" ]; then
+  cd "$PACKAGE_DIR"
+  ./node_modules/.bin/lint-staged
 fi


### PR DESCRIPTION
﻿## Summary

Fixes the agent-bus Husky pre-commit hook so commits no longer fail when the generated `.husky/_/husky.sh` helper is absent in a fresh worktree.

The hook is now self-contained:
- resolves the package directory from the hook file location
- runs package-local `lint-staged` when installed
- skips cleanly when dependencies are not installed

## Verification

- Normal `git commit` succeeded without `--no-verify`, proving the hook path no longer fails on missing `packages/agent-bus/.husky/_/husky.sh`.
- `git diff --check`
