### PR TITLE
fix(mountain-map): syntactic phylogeny, not a computation map (+ executed proof)

### DIFF
--- a/scripts/mountain_map/build_mountain_map.py
+++ b/scripts/mountain_map/build_mountain_map.py
@@ -1,13 +1,18 @@
 """Build the cross-language "mountain map" from the verified construct data.
 
-Three views of one mountain (the computation), seen from 18 language faces:
+Three views across 18 language faces. NOTE: this is a NOTATION map, not a computation map --
+view 2 is a syntactic phylogeny (surface spelling), which anti-correlates with semantics; the
+same-computation axis is the IR + polyglot_conformance.py, not this.
 
   1. construct_table.csv / .xlsx -- the basic table: every curated construct x every
      language, with a per-cell confidence (the map carries its own provenance).
-  2. mountain.dot / mountain.md  -- the flow graph: languages are nodes, edge weight is
-     how many constructs two languages spell IDENTICALLY (computed from the table, not
-     asserted). The ridge that falls out -- brace-family vs colon-family -- is data, not a
-     drawing.
+  2. mountain.dot / mountain.md  -- a SYNTACTIC PHYLOGENY: languages are nodes, edge weight
+     is how many constructs two languages spell IDENTICALLY (computed from the table, not
+     asserted). It is a family tree of NOTATION (brace / colon / ML family), NOT computational
+     distance -- surface spelling anti-correlates with semantics (`==` is one glyph with three
+     meanings; `map f xs` vs a comprehension is one meaning in two spellings). Use it as a
+     transpiler work-allocation map; the same-computation axis is the IR + polyglot_conformance.py
+     (which RUNS the backends). See semantic_vs_syntax.py for the executed proof.
   3. pipeline_map.md             -- what happens when you hit Enter: per language, the
      source -> lex -> parse -> IR -> execute path.
 
@@ -136,13 +141,26 @@ def write_mountain(data: dict, sim: Dict[str, Dict[str, float]], dot: Path, md: 
     dot.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     rows = [
-        "# The mountain, from data: language similarity by identical construct spelling",
+        "# Syntactic phylogeny: language similarity by identical construct spelling",
         "",
         "Edge = fraction of the %d constructs two languages spell *identically* (normalized)."
         % len(data["meta"]["constructs"]),
-        "Computed from the table, not asserted. Higher = closer faces of the same mountain.",
+        "Computed from the table, not asserted -- but this is SURFACE spelling, a family tree of",
+        "NOTATION (brace / colon / ML family), NOT the shape of the computation.",
         "",
-        "## Nearest neighbours (each language's 3 closest faces)",
+        "## What this is NOT",
+        "",
+        "Surface spelling is not semantics, and the two come apart:",
+        "- identical spelling, different meaning: `==` is one glyph in Java/C#/JS/Python but means",
+        '  reference vs value vs coercing equality (`1 == "1"` is False in Python, true in JS).',
+        "- different spelling, same computation: Haskell `map f xs` and Python `[f(x) for x in xs]`",
+        "  compute the same thing -- yet Haskell scores as the outlier here.",
+        "So these distances are notation lineage, not semantic distance. Use this as a TRANSPILER",
+        "WORK-ALLOCATION map: identical cells emit trivially; the divergences (the Haskell column)",
+        "are where real semantic effort lives. The same-computation axis is the IR +",
+        "polyglot_conformance.py (which RUNS the backends); see semantic_vs_syntax.py for proof.",
+        "",
+        "## Nearest neighbours (each language's 3 closest faces by notation)",
         "",
     ]
     for a in langs:

--- a/scripts/mountain_map/mountain.md
+++ b/scripts/mountain_map/mountain.md
@@ -1,9 +1,22 @@
-# The mountain, from data: language similarity by identical construct spelling
+# Syntactic phylogeny: language similarity by identical construct spelling
 
 Edge = fraction of the 32 constructs two languages spell *identically* (normalized).
-Computed from the table, not asserted. Higher = closer faces of the same mountain.
+Computed from the table, not asserted -- but this is SURFACE spelling, a family tree of
+NOTATION (brace / colon / ML family), NOT the shape of the computation.
 
-## Nearest neighbours (each language's 3 closest faces)
+## What this is NOT
+
+Surface spelling is not semantics, and the two come apart:
+- identical spelling, different meaning: `==` is one glyph in Java/C#/JS/Python but means
+  reference vs value vs coercing equality (`1 == "1"` is False in Python, true in JS).
+- different spelling, same computation: Haskell `map f xs` and Python `[f(x) for x in xs]`
+  compute the same thing -- yet Haskell scores as the outlier here.
+So these distances are notation lineage, not semantic distance. Use this as a TRANSPILER
+WORK-ALLOCATION map: identical cells emit trivially; the divergences (the Haskell column)
+are where real semantic effort lives. The same-computation axis is the IR +
+polyglot_conformance.py (which RUNS the backends); see semantic_vs_syntax.py for proof.
+
+## Nearest neighbours (each language's 3 closest faces by notation)
 
 - **python** -> ruby (0.41), swift (0.38), lua (0.34)
 - **javascript** -> typescript (0.91), csharp (0.56), java (0.50)

--- a/scripts/mountain_map/semantic_vs_syntax.py
+++ b/scripts/mountain_map/semantic_vs_syntax.py
@@ -1,0 +1,114 @@
+"""Surface spelling is not semantics -- an EXECUTED counter-measurement to the mountain map.
+
+The mountain map (build_mountain_map.py) measures how often languages SPELL a construct with
+identical characters -- a syntactic phylogeny. This script RUNS the two cases where that
+surface metric anti-correlates with the actual computation, on the backends this box can run:
+
+  * identical spelling, DIFFERENT meaning -- `1 == "1"`: one glyph `==`, but Python value
+    equality says False while JavaScript coercing equality says true. The map counts `==` as a
+    match; it is a semantic trap.
+  * different spelling, SAME computation -- double a list: Python `[x*2 for x in xs]` vs JS
+    `xs.map(x => x*2)`. Spelled nothing alike, identical result [2, 4, 6]. The map scores these
+    as maximally dissimilar; semantically they are the same operation.
+
+So the mountain map's distances are notation lineage, not semantic distance -- and a high
+surface score (e.g. `==` everywhere) can hide divergence while a low one (Haskell) can hide
+kinship. A full semantic distance is undecidable in general; "same computation, many faces" is
+established where it counts by the shared IR + polyglot_conformance.py RUNNING the backends, not
+by spelling.
+
+    python scripts/mountain_map/semantic_vs_syntax.py
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+
+def _node(expr: str) -> str:
+    out = subprocess.run(
+        ["node", "-e", "process.stdout.write(String(%s))" % expr],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return out.stdout.strip()
+
+
+def measure() -> dict:
+    """Run both cases; report where surface spelling and semantics agree or split."""
+    have_node = shutil.which("node") is not None
+
+    # Case 1: identical spelling `==`, possibly different meaning.
+    py_eq = bool(1 == "1")  # Python: value equality -> False  # noqa: F632 (the trap is the point)
+    js_eq_raw = _node('1 == "1"') if have_node else None  # JS: coercion -> "true"
+    js_eq = {"true": True, "false": False}.get(js_eq_raw) if js_eq_raw is not None else None
+    eq_diverges = (js_eq is not None) and (py_eq != js_eq)
+
+    # Case 2: different spelling, possibly identical computation.
+    py_map = [x * 2 for x in [1, 2, 3]]
+    js_map_raw = _node("JSON.stringify([1,2,3].map(x => x * 2))") if have_node else None
+    js_map = json.loads(js_map_raw) if js_map_raw else None
+    map_converges = (js_map is not None) and (py_map == js_map)
+
+    return {
+        "have_node": have_node,
+        "case1_same_spelling_eq": {
+            "spelling": "== (identical in python & js)",
+            "python": py_eq,
+            "javascript": js_eq,
+            "semantics_diverge": eq_diverges,
+        },
+        "case2_diff_spelling_map": {
+            "spelling": "[x*2 for x in xs]  vs  xs.map(x => x*2)  (different)",
+            "python": py_map,
+            "javascript": js_map,
+            "computation_converges": map_converges,
+        },
+        "lesson": (
+            "surface spelling anti-correlates with semantics: identical `==` diverges, "
+            "unalike map/comprehension converges -- so the mountain map is notation lineage, "
+            "not semantic distance"
+        ),
+    }
+
+
+def main() -> int:
+    m = measure()
+    print("SURFACE != SEMANTICS  (executed; node=%s)\n" % m["have_node"])
+    c1 = m["case1_same_spelling_eq"]
+    print('  case 1  identical spelling `==`  ->  1 == "1"')
+    print(
+        "    python=%s  javascript=%s  ->  %s"
+        % (
+            c1["python"],
+            c1["javascript"],
+            (
+                "SEMANTICS DIVERGE (same glyph, different meaning)"
+                if c1["semantics_diverge"]
+                else "(node unavailable -- python-only)"
+            ),
+        )
+    )
+    c2 = m["case2_diff_spelling_map"]
+    print("  case 2  different spelling, double a list")
+    print(
+        "    python=%s  javascript=%s  ->  %s"
+        % (
+            c2["python"],
+            c2["javascript"],
+            (
+                "COMPUTATION CONVERGES (different spelling, same result)"
+                if c2["computation_converges"]
+                else "(node unavailable -- python-only)"
+            ),
+        )
+    )
+    print("\n  %s" % m["lesson"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_semantic_vs_syntax.py
+++ b/tests/test_semantic_vs_syntax.py
@@ -1,0 +1,41 @@
+"""Surface spelling != semantics: the executed counter-measurement to the mountain map.
+
+Proves, by running, that the mountain map's identical-spelling metric anti-correlates with
+the computation: identical `==` diverges (Python value-equality vs JS coercion), unalike
+map/comprehension converges. The python-side facts are unconditional; the JS comparison runs
+only when node is present (skip otherwise, never faked).
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "mountain_map"))
+
+import semantic_vs_syntax as S  # noqa: E402
+
+_HAVE_NODE = shutil.which("node") is not None
+M = S.measure()
+
+
+def test_python_side_facts_hold_unconditionally():
+    # `1 == "1"` is value-inequality in Python; doubling a list is [2,4,6]
+    assert M["case1_same_spelling_eq"]["python"] is False
+    assert M["case2_diff_spelling_map"]["python"] == [2, 4, 6]
+
+
+@pytest.mark.skipif(not _HAVE_NODE, reason="node not installed")
+def test_identical_spelling_diverges_in_meaning():
+    c = M["case1_same_spelling_eq"]
+    assert c["javascript"] is True  # JS coercion: 1 == "1" is true
+    assert c["semantics_diverge"] is True  # same glyph `==`, different result
+
+
+@pytest.mark.skipif(not _HAVE_NODE, reason="node not installed")
+def test_different_spelling_converges_in_computation():
+    c = M["case2_diff_spelling_map"]
+    assert c["javascript"] == [2, 4, 6]
+    assert c["computation_converges"] is True  # unalike spelling, identical result


### PR DESCRIPTION
## Calibration from review

The mountain-map similarity metric measures **surface spelling** — how often 18 languages write 32 constructs with identical characters. That's a family tree of **notation**, not the shape of the computation, and it **anti-correlates with semantics** where it matters:

- **identical spelling, different meaning:** `==` is one glyph but means reference / value / coercing equality across Java / Python / JS.
- **different spelling, same computation:** Haskell `map f xs` ≡ Python `[f(x) for x in xs]`, yet Haskell scores as the *outlier*.

So "the mountain's real shape, computed not drawn" overstated by a word — it's the shape of **syntax**, drawn from data.

## Changes

- **Relabel** the artifact + docstrings to "syntactic phylogeny / notation family tree," with an explicit **"What this is NOT"** section in `mountain.md`. The same-computation axis is the IR + `polyglot_conformance.py` (which *runs* the backends), not surface spelling.
- **`semantic_vs_syntax.py`** — an **executed** counter-measurement. Verified on this box (python + node):

```
case 1  identical spelling `==`  ->  1 == "1"
  python=False  javascript=True   ->  SEMANTICS DIVERGE (same glyph, different meaning)
case 2  different spelling, double a list
  python=[2,4,6] javascript=[2,4,6] ->  COMPUTATION CONVERGES (different spelling, same result)
```

Honest framing: a full semantic distance is undecidable in general; this just **proves surface ≠ semantics by running it**.

## What stands

The map's legitimate use is unchanged: a transpiler **work-allocation map** — identical cells emit trivially; the divergences (the Haskell column) are where real semantic effort lives.

## Tests

3 (`tests/test_semantic_vs_syntax.py`): python-side facts unconditional; the JS divergence/convergence checks skip if `node` absent, never faked. black / flake8 / ruff clean (120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)