### PR TITLE
feat(scbe): add playable code instrument

### DIFF
--- a/python/scbe/instrument.py
+++ b/python/scbe/instrument.py
@@ -1,0 +1,119 @@
+"""The Instrument: play a token-song; it manifests verified code in any language face.
+
+A song is a sequence of notes. A mode maps notes to CA opcodes: "coding" ships now;
+chemistry, movement, or flight can plug in later as different scales over the same
+keys. The chain is:
+
+    notes -> mode/scale -> op names -> CA opcode bytes -> target-language source
+
+The emitted source carries opcode trace comments, so ``tongue_isa.disassemble`` can
+read the song back out of the code. The Python face is also executed, so that face is
+verified by running rather than just emitted.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+
+from .ca_opcode_table import OP_TABLE
+from .tongue_isa import compile_ca_tokens, disassemble, runtime_prelude
+
+_NAME_TO_BYTE: Dict[str, int] = {entry.name: op_id for op_id, entry in OP_TABLE.items()}
+
+MODES: Dict[str, Dict[str, str]] = {
+    "coding": {
+        "C": "add",
+        "D": "sub",
+        "E": "mul",
+        "F": "div",
+        "G": "inc",
+        "A": "dec",
+        "B": "neg",
+        "C#": "mod",
+        "D#": "abs",
+        "F#": "eq",
+        "G#": "lt",
+        "A#": "gt",
+    },
+}
+
+
+def modes() -> List[str]:
+    """Return available instrument modes."""
+
+    return sorted(MODES)
+
+
+def scale(mode: str = "coding") -> Dict[str, str]:
+    """Return the note-to-op scale for a mode."""
+
+    return dict(MODES[mode])
+
+
+def _op_to_note(mode: str) -> Dict[str, str]:
+    return {op: note for note, op in MODES[mode].items()}
+
+
+def notes_to_ops(song: str, mode: str = "coding") -> List[str]:
+    """Map a note song like ``"C E"`` to CA op names like ``["add", "mul"]``."""
+
+    sc = MODES[mode]
+    ops: List[str] = []
+    for tok in song.replace(",", " ").split():
+        if tok not in sc:
+            raise ValueError(f"note {tok!r} not in {mode} scale {sorted(sc)}")
+        ops.append(sc[tok])
+    return ops
+
+
+def _assemble(prog, face: str) -> str:
+    """Wrap the compiled body into a runnable/readable module for the face."""
+
+    if face == "python":
+        header = f"def {prog.fn_name}({', '.join(prog.arg_names)}):"
+        body = "\n".join("    " + line for line in prog.body_lines)
+        return runtime_prelude("python") + "\n\n" + header + "\n" + body + "\n"
+    return runtime_prelude(face) + "\n\n" + "\n".join(prog.body_lines) + "\n"
+
+
+def _run_python(code: str, args: Sequence[float]):
+    ns: Dict[str, object] = {}
+    exec(code, ns)  # noqa: S102 - executing emitted code from this module to verify it runs.
+    return ns["play"](*args)
+
+
+def play(song: str, mode: str = "coding", face: str = "python", args: Sequence[float] = ()) -> dict:
+    """Play a song in a mode and manifest it in a language face."""
+
+    ops = notes_to_ops(song, mode)
+    tokens = [_NAME_TO_BYTE[op] for op in ops]
+    arg_names = [f"x{i}" for i in range(len(args))]
+    prog = compile_ca_tokens(tokens, target=face, fn_name="play", arg_names=arg_names)
+    code = _assemble(prog, face)
+
+    value = _run_python(code, args) if face == "python" else None
+
+    o2n = _op_to_note(mode)
+    song_back = " ".join(o2n.get(name, f"?{name}") for _, name in disassemble(code))
+    normalized = " ".join(song.replace(",", " ").split())
+
+    return {
+        "song": song,
+        "mode": mode,
+        "face": face,
+        "ops": ops,
+        "value": value,
+        "code": code,
+        "song_back": song_back,
+        "bijective": song_back == normalized,
+    }
+
+
+def main() -> int:
+    r = play("C E", face="python", args=(10, 3, 2))
+    print(f"play('C E') ops={r['ops']} value={r['value']} song_back={r['song_back']!r} bijective={r['bijective']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,48 @@
+"""SCBE Instrument: note songs manifest as executable/disassemblable CA code."""
+
+import pytest
+
+from python.scbe.instrument import modes, notes_to_ops, play, scale
+
+
+def test_coding_scale_maps_notes_to_ca_ops():
+    assert modes() == ["coding"]
+    assert scale("coding")["C"] == "add"
+    assert scale("coding")["E"] == "mul"
+    assert notes_to_ops("C E") == ["add", "mul"]
+
+
+def test_play_executes_python_face_and_reads_song_back():
+    result = play("C E", face="python", args=(10, 3, 2))
+
+    assert result["ops"] == ["add", "mul"]
+    assert result["value"] == 50
+    assert result["song_back"] == "C E"
+    assert result["bijective"] is True
+    assert "# add (0x00)" in result["code"]
+    assert "# mul (0x02)" in result["code"]
+
+
+def test_repeated_note_song_is_bijective():
+    result = play("C C", face="python", args=(2, 3, 4))
+
+    assert result["value"] == 9
+    assert result["song_back"] == "C C"
+    assert result["bijective"] is True
+
+
+def test_non_python_faces_emit_traceable_code_without_execution():
+    rust = play("C E", face="rust", args=(10, 3, 2))
+    haskell = play("C E", face="haskell", args=(10, 3, 2))
+
+    assert rust["value"] is None
+    assert haskell["value"] is None
+    assert rust["song_back"] == "C E"
+    assert haskell["song_back"] == "C E"
+    assert "add (0x00)" in rust["code"]
+    assert "caAdd" in haskell["code"]
+
+
+def test_unknown_note_is_rejected():
+    with pytest.raises(ValueError, match="note 'Z'"):
+        notes_to_ops("C Z")


### PR DESCRIPTION
﻿## Summary
- add `python/scbe/instrument.py`, a note-song interface over the CA opcode table and tongue ISA emitter
- support the first `coding` mode: notes map to CA ops, then emit target-language source faces
- verify the Python face by execution and read the song back from opcode trace comments for bijection
- add focused tests for note mapping, Python execution, repeated-note bijection, Rust/Haskell traceability, and invalid-note rejection

## Verification
- `$env:PYTHONPATH='C:\Users\issda\instrument-wt\python'; python -m scbe.instrument`
- `python -m pytest tests\test_instrument.py tests\governance\test_ca_opcode_table.py -q`
- `black --check --target-version py311 --line-length 120 python\scbe\instrument.py tests\test_instrument.py`
- `ruff check --config ruff.toml python\scbe\instrument.py tests\test_instrument.py`
- `flake8 --max-line-length 120 python\scbe\instrument.py tests\test_instrument.py`
- `python -m compileall -q python\scbe\instrument.py`
- `git diff --check`
