### PR TITLE
feat(scbe): add wavelength keyspace and all-face instrument emission

### DIFF
--- a/python/scbe/instrument.py
+++ b/python/scbe/instrument.py
@@ -17,7 +17,12 @@ from __future__ import annotations
 from typing import Dict, List, Sequence
 
 from .ca_opcode_table import OP_TABLE
-from .tongue_isa import compile_ca_tokens, disassemble, runtime_prelude
+from .tongue_isa import (
+    SUPPORTED_TARGETS,
+    compile_ca_tokens,
+    disassemble,
+    runtime_prelude,
+)
 
 _NAME_TO_BYTE: Dict[str, int] = {entry.name: op_id for op_id, entry in OP_TABLE.items()}
 
@@ -85,6 +90,57 @@ def ca_word_for_opcode(op_id: int) -> str:
 
 def _ca_scale_for_ops(op_names: Sequence[str]) -> Dict[str, str]:
     return {ca_word_for_opcode(_NAME_TO_BYTE[op]): op for op in op_names}
+
+
+_NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+_INSTRUMENTS = ["piano", "strings", "brass", "woodwinds", "mallets", "synth"]
+
+
+def _nm_to_hex(nm: float) -> str:
+    """Approximate a visible wavelength, in nanometers, as an RGB hex color."""
+
+    if nm < 380 or nm > 750:
+        r = g = b = 0.0
+    elif nm < 440:
+        r, g, b = -(nm - 440) / 60, 0.0, 1.0
+    elif nm < 490:
+        r, g, b = 0.0, (nm - 440) / 50, 1.0
+    elif nm < 510:
+        r, g, b = 0.0, 1.0, -(nm - 510) / 20
+    elif nm < 580:
+        r, g, b = (nm - 510) / 70, 1.0, 0.0
+    elif nm < 645:
+        r, g, b = 1.0, -(nm - 645) / 65, 0.0
+    else:
+        r, g, b = 1.0, 0.0, 0.0
+    return "#" + "".join(
+        f"{int(max(0.0, min(1.0, channel)) * 255):02X}" for channel in (r, g, b)
+    )
+
+
+def keyspace(op_id: int) -> dict:
+    """Return the multisensory key for an op: pitch, instrument, and color wavelength."""
+
+    op_id = int(op_id) % 64
+    midi = 48 + op_id
+    hz = 440.0 * 2 ** ((midi - 69) / 12)
+    light_nm = round(380.0 + (op_id / 63.0) * 370.0, 1)
+    return {
+        "op_id": op_id,
+        "note": _NOTE_NAMES[midi % 12] + str(midi // 12 - 1),
+        "midi": midi,
+        "hz": round(hz, 2),
+        "sound_wavelength_cm": round(34300.0 / hz, 2),
+        "instrument": _INSTRUMENTS[(op_id // 12) % len(_INSTRUMENTS)],
+        "light_nm": light_nm,
+        "color": _nm_to_hex(light_nm),
+    }
+
+
+def melody_for_ops(op_names: Sequence[str]) -> List[dict]:
+    """Return the pitch/timbre/color key sequence for a list of CA op names."""
+
+    return [keyspace(_NAME_TO_BYTE[op]) for op in op_names]
 
 
 MODES: Dict[str, Dict[str, str]] = {
@@ -165,7 +221,62 @@ def play(
         "code": code,
         "song_back": song_back,
         "bijective": song_back == normalized,
+        "melody": melody_for_ops(ops),
     }
+
+
+def faces() -> List[str]:
+    """Return every source face the instrument can emit to.
+
+    ``tongue_isa`` is the verified stack-machine path for eight targets. ``polyglot``
+    adds broader scalar-source emission for the rest. The union is the honest face set.
+    """
+
+    langs = set(SUPPORTED_TARGETS)
+    try:
+        from . import polyglot
+
+        langs.update(polyglot.languages())
+    except Exception:
+        pass
+    return sorted(langs)
+
+
+def emit_all(song: str, mode: str = "coding") -> Dict[str, str]:
+    """Emit one scalar song into every registered language face.
+
+    The broad 18-face path uses ``polyglot.emit`` and therefore supports the scalar
+    op subset that polyglot declares. The eight ``tongue_isa`` targets stay available
+    through ``play(..., face=...)`` for the executable/disassemblable stack-machine path.
+    """
+
+    ops = notes_to_ops(song, mode)
+    tokens = [_NAME_TO_BYTE[op] for op in ops]
+    out: Dict[str, str] = {}
+    try:
+        from . import polyglot
+    except Exception as exc:
+        for face in SUPPORTED_TARGETS:
+            try:
+                out[face] = _assemble(
+                    compile_ca_tokens(tokens, target=face, fn_name="play"), face
+                )
+            except Exception as face_exc:
+                out[face] = f"ERROR: {type(face_exc).__name__}: {face_exc}"
+        out["_polyglot"] = f"ERROR: {type(exc).__name__}: {exc}"
+        return out
+
+    for face in faces():
+        try:
+            if face in polyglot.languages():
+                out[face] = polyglot.emit(tokens, face, fn_name="play", safe=True)
+            else:
+                out[face] = _assemble(
+                    compile_ca_tokens(tokens, target=face, fn_name="play"), face
+                )
+        except Exception as exc:
+            out[face] = f"ERROR: {type(exc).__name__}: {exc}"
+    return out
 
 
 def main() -> int:
@@ -178,6 +289,7 @@ def main() -> int:
         f"play(\"bip'a bip'i\", mode='ca') ops={ca['ops']} value={ca['value']} "
         f"song_back={ca['song_back']!r} bijective={ca['bijective']}"
     )
+    print(f"faces={len(faces())} melody={ca['melody']}")
     return 0
 
 

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -2,7 +2,17 @@
 
 import pytest
 
-from python.scbe.instrument import ca_word_for_opcode, modes, notes_to_ops, play, scale
+from python.scbe.instrument import (
+    ca_word_for_opcode,
+    emit_all,
+    faces,
+    keyspace,
+    melody_for_ops,
+    modes,
+    notes_to_ops,
+    play,
+    scale,
+)
 
 
 def test_coding_scale_maps_notes_to_ca_ops():
@@ -27,6 +37,21 @@ def test_ca_mode_executes_and_round_trips_native_keys():
     assert result["value"] == 50
     assert result["song_back"] == "bip'a bip'i"
     assert result["bijective"] is True
+    assert [key["op_id"] for key in result["melody"]] == [0, 2]
+
+
+def test_keyspace_uses_wavelength_and_instrument_axes():
+    first = keyspace(0)
+    wrapped = keyspace(12)
+
+    assert first["note"] == "C3"
+    assert first["instrument"] == "piano"
+    assert first["light_nm"] == 380.0
+    assert first["color"].startswith("#")
+    assert wrapped["note"] == "C4"
+    assert wrapped["instrument"] == "strings"
+    assert wrapped["light_nm"] > first["light_nm"]
+    assert melody_for_ops(["add", "mul"]) == [keyspace(0), keyspace(2)]
 
 
 def test_play_executes_python_face_and_reads_song_back():
@@ -58,6 +83,16 @@ def test_non_python_faces_emit_traceable_code_without_execution():
     assert haskell["song_back"] == "C E"
     assert "add (0x00)" in rust["code"]
     assert "caAdd" in haskell["code"]
+
+
+def test_emit_all_covers_registered_language_faces_for_scalar_song():
+    emitted = emit_all("C E")
+
+    assert set(emitted) == set(faces())
+    assert len(emitted) >= 18
+    assert all(not source.startswith("ERROR:") for source in emitted.values())
+    assert "add (0x00)" in emitted["python"]
+    assert "mul (0x02)" in emitted["rust"]
 
 
 def test_unknown_note_is_rejected():


### PR DESCRIPTION
﻿## Summary
- adds a multisensory `keyspace(op_id)` for each CA opcode: pitch, MIDI, sound wavelength, instrument band, visible light wavelength, and RGB color
- adds melody data to `play(...)` results so a code-song now carries its pitch/timbre/color keys
- adds `faces()` and `emit_all(...)` to manifest one scalar song into every registered polyglot language face while keeping the executable/disassemblable `tongue_isa` path intact

## Verification
- `PYTHONPATH=C:\Users\issda\instrument-wt\python python -m scbe.instrument`
  - `play('C E') ops=['add', 'mul'] value=50 song_back='C E' bijective=True`
  - native CA mode remains bijective and reports melody metadata
  - `faces=18`
- direct probe: 18 faces (`c`, `cpp`, `csharp`, `go`, `haskell`, `java`, `javascript`, `julia`, `kotlin`, `lua`, `php`, `python`, `ruby`, `rust`, `scala`, `swift`, `typescript`, `zig`) and zero `emit_all('C E')` errors
- `python -m pytest tests\test_instrument.py tests\test_polyglot.py tests\governance\test_ca_opcode_table.py -q` -> 18 passed
- `python -m black --check --target-version py312 python\scbe\instrument.py tests\test_instrument.py`
- `python -m ruff check python\scbe\instrument.py tests\test_instrument.py`
- `flake8 --max-line-length 120 python\scbe\instrument.py tests\test_instrument.py`
- `python -m compileall -q python\scbe\instrument.py tests\test_instrument.py`
- `git diff --check`

## Honest scope
`emit_all` uses the existing `polyglot` scalar emitter for broad 18-face source generation. `play(..., face=...)` remains the verified execution/disassembly path over `tongue_isa` targets. This does not claim every exotic CA opcode has full executable semantics in every language yet.
