### PR TITLE
feat(scbe): the Instrument — play a token-song into verified code in any language face

### DIFF
--- a/python/helm/mbpp_sample.json
+++ b/python/helm/mbpp_sample.json
@@ -1,0 +1,42 @@
+{
+  "_source": "MBPP sanitized (google-research/google-research, mbpp/) -- public benchmark",
+  "_note": "3 problems bundled verbatim for a hermetic test; live runner pulls the full 427",
+  "problems": [
+    {
+      "task_id": 2,
+      "prompt": "Write a function to find the shared elements from the given two lists.",
+      "code": "def similar_elements(test_tup1, test_tup2):\n  res = tuple(set(test_tup1) & set(test_tup2))\n  return (res) ",
+      "test_list": [
+        "assert set(similar_elements((3, 4, 5, 6),(5, 7, 4, 10))) == set((4, 5))",
+        "assert set(similar_elements((1, 2, 3, 4),(5, 4, 3, 7))) == set((3, 4))",
+        "assert set(similar_elements((11, 12, 14, 13),(17, 15, 14, 13))) == set((13, 14))"
+      ],
+      "test_imports": []
+    },
+    {
+      "task_id": 6,
+      "prompt": "Write a python function to check whether the two numbers differ at one bit position only or not.",
+      "code": "def is_Power_Of_Two (x): \n    return x and (not(x & (x - 1))) \ndef differ_At_One_Bit_Pos(a,b): \n    return is_Power_Of_Two(a ^ b)",
+      "test_list": [
+        "assert differ_At_One_Bit_Pos(13,9) == True",
+        "assert differ_At_One_Bit_Pos(15,8) == False",
+        "assert differ_At_One_Bit_Pos(2,4) == False",
+        "assert differ_At_One_Bit_Pos(2, 3) == True",
+        "assert differ_At_One_Bit_Pos(5, 1) == True",
+        "assert differ_At_One_Bit_Pos(1, 5) == True"
+      ],
+      "test_imports": []
+    },
+    {
+      "task_id": 8,
+      "prompt": "Write a function to find squares of individual elements in a list.",
+      "code": "def square_nums(nums):\n square_nums = list(map(lambda x: x ** 2, nums))\n return square_nums",
+      "test_list": [
+        "assert square_nums([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])==[1, 4, 9, 16, 25, 36, 49, 64, 81, 100]",
+        "assert square_nums([10,20,30])==([100,400,900])",
+        "assert square_nums([12,15])==([144,225])"
+      ],
+      "test_imports": []
+    }
+  ]
+}

--- a/python/helm/public_bench.py
+++ b/python/helm/public_bench.py
@@ -1,0 +1,202 @@
+"""Public benchmark runner for the forge loop: pull MBPP, split public/hidden, run + verify.
+
+tool_forge_bench.py runs the create -> verify -> repair -> keep loop on 4 hand-written tasks.
+THIS pulls a real public benchmark -- MBPP sanitized (427 problems, google-research) -- and runs
+the same loop over real problems. Each problem ships its own asserts; we split them into PUBLIC
+checks (what the forger is allowed to see) and HIDDEN checks (held out), so a tool that overfits
+the public checks is caught.
+
+The forger is a pluggable `generator(problem) -> source`:
+  * reference_generator (default) returns the dataset's own solution -- this validates the
+    HARNESS end-to-end on real data ($0, no model): we pulled N real problems, ran them, and the
+    public/hidden split works. It does NOT measure model capability (the solver is the answer key).
+  * naive_generator returns a stub -- a sanity floor that should fail.
+  * plug a real model into the same slot to measure actual forging capability. That swap is the
+    only missing piece; everything else (pull, split, sandboxed verify, receipts) is real here.
+
+Candidates run in a subprocess with a timeout (curated data, but still isolated).
+
+    python -m python.helm.public_bench --limit 20            # reference solver (harness check)
+    python -m python.helm.public_bench --limit 20 --naive    # the failing floor
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+MBPP_URL = "https://raw.githubusercontent.com/google-research/google-research/master/mbpp/sanitized-mbpp.json"
+FIXTURE = Path(__file__).with_name("mbpp_sample.json")
+CACHE = Path(tempfile.gettempdir()) / "scbe_mbpp_sanitized.json"
+
+Generator = Callable[[Dict[str, Any]], str]
+
+
+def pull_mbpp(limit: Optional[int] = None, force: bool = False) -> List[Dict[str, Any]]:
+    """Download (and cache) the MBPP sanitized public benchmark; return its problems."""
+    if force or not CACHE.exists():
+        req = urllib.request.Request(MBPP_URL, headers={"User-Agent": "scbe-bench/0.1"})
+        with urllib.request.urlopen(req, timeout=30) as r:  # noqa: S310 - fixed https public dataset URL
+            CACHE.write_bytes(r.read())
+    problems = json.loads(CACHE.read_text(encoding="utf-8"))
+    return problems[:limit] if limit else problems
+
+
+def load_fixture() -> List[Dict[str, Any]]:
+    """The hermetic 3-problem MBPP sample bundled for offline tests."""
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))["problems"]
+
+
+def func_name(problem: Dict[str, Any]) -> str:
+    m = re.search(r"def\s+(\w+)\s*\(", problem.get("code", ""))
+    if not m:
+        raise ValueError("no function definition found in problem %s" % problem.get("task_id"))
+    return m.group(1)
+
+
+def reference_generator(problem: Dict[str, Any]) -> str:
+    """The dataset's own solution -- forges nothing, validates the harness on real data."""
+    return problem["code"]
+
+
+def naive_generator(problem: Dict[str, Any]) -> str:
+    """A stub that defines the function but returns None -- the failing floor."""
+    return "def %s(*args, **kwargs):\n    return None\n" % func_name(problem)
+
+
+def _verify(source: str, public: Sequence[str], hidden: Sequence[str], imports: Sequence[str]) -> Dict[str, Any]:
+    """Run public then hidden asserts against the candidate source, isolated in a subprocess."""
+    runner = "\n".join(
+        list(imports)
+        + [
+            source,
+            "import json as _json",
+            "_PUBLIC = " + repr(list(public)),
+            "_HIDDEN = " + repr(list(hidden)),
+            "def _run(_xs):",
+            "    _f = []",
+            "    for _a in _xs:",
+            "        try:",
+            "            exec(_a, globals())",
+            "        except Exception as _e:",
+            "            _f.append(repr(_e) or _a)",
+            "    return _f",
+            'print(_json.dumps({"pub": _run(_PUBLIC), "hid": _run(_HIDDEN)}))',
+        ]
+    )
+    try:
+        proc = subprocess.run([sys.executable, "-c", runner], capture_output=True, text=True, timeout=15)
+        out = json.loads(proc.stdout.strip().splitlines()[-1]) if proc.returncode == 0 and proc.stdout.strip() else None
+    except Exception:
+        out = None
+    if out is None:
+        return {
+            "public_passed": False,
+            "hidden_passed": False,
+            "public_failures": ["did-not-run"],
+            "hidden_failures": ["did-not-run"],
+        }
+    return {
+        "public_passed": not out["pub"],
+        "hidden_passed": not out["hid"],
+        "public_failures": out["pub"],
+        "hidden_failures": out["hid"],
+    }
+
+
+def run_problem(problem: Dict[str, Any], generator: Generator, public_k: int, workspace: Path) -> Dict[str, Any]:
+    name = func_name(problem)
+    asserts = list(problem.get("test_list", []))
+    public, hidden = asserts[:public_k], asserts[public_k:]
+    source = generator(problem)
+    v = _verify(source, public, hidden, problem.get("test_imports", []))
+    verified = v["public_passed"] and v["hidden_passed"]
+    kept_path = None
+    if verified:
+        lib = workspace / "tool_library"
+        lib.mkdir(parents=True, exist_ok=True)
+        kept_path = str(lib / f"{name}.py")
+        Path(kept_path).write_text(source, encoding="utf-8")
+    receipt = {
+        "task_id": problem.get("task_id"),
+        "function": name,
+        "public": len(public),
+        "hidden": len(hidden),
+        "verified": verified,
+        "kept_path": kept_path,
+        **v,
+    }
+    rdir = workspace / str(problem.get("task_id"))
+    rdir.mkdir(parents=True, exist_ok=True)
+    (rdir / "receipt.json").write_text(json.dumps(receipt, indent=2, sort_keys=True), encoding="utf-8")
+    return receipt
+
+
+def run_public_bench(
+    problems: Sequence[Dict[str, Any]],
+    generator: Generator = reference_generator,
+    public_k: int = 1,
+    workspace: Optional[Path] = None,
+) -> Dict[str, Any]:
+    root = Path(workspace) if workspace else Path(tempfile.mkdtemp(prefix="helm-public-bench-"))
+    root.mkdir(parents=True, exist_ok=True)
+    rows = [run_problem(p, generator, public_k, root) for p in problems if len(p.get("test_list", [])) > public_k]
+    verified = [r for r in rows if r["verified"]]
+    overfit = [r for r in rows if r["public_passed"] and not r["hidden_passed"]]  # passed public, failed hidden
+    summary = {
+        "benchmark": "MBPP-sanitized",
+        "workspace": str(root),
+        "generator": generator.__name__,
+        "public_k": public_k,
+        "attempted": len(rows),
+        "verified": len(verified),
+        "public_pass": sum(1 for r in rows if r["public_passed"]),
+        "hidden_pass": sum(1 for r in rows if r["hidden_passed"]),
+        "overfit_caught": len(overfit),
+        "pass_rate": round(len(verified) / len(rows), 3) if rows else 0.0,
+        "results": rows,
+    }
+    (root / "public_bench_summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    return summary
+
+
+def render(summary: Dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "Helm Public Bench (pull a real benchmark, run the forge loop)",
+            f"  benchmark: {summary['benchmark']}  gen: {summary['generator']}  public_k: {summary['public_k']}",
+            f"  attempted: {summary['attempted']}   verified (public+hidden): {summary['verified']}"
+            f"   pass_rate: {summary['pass_rate']}",
+            f"  public_pass: {summary['public_pass']}   hidden_pass: {summary['hidden_pass']}"
+            f"   overfit_caught (public-pass, hidden-fail): {summary['overfit_caught']}",
+            f"  workspace: {summary['workspace']}",
+        ]
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(prog="scbe-public-bench", description="pull MBPP and run the forge loop")
+    ap.add_argument("--limit", type=int, default=20, help="number of problems to pull (0 = all 427)")
+    ap.add_argument("--public-k", type=int, default=1, help="how many asserts are public (rest are hidden)")
+    ap.add_argument("--naive", action="store_true", help="use the failing stub generator instead of the reference")
+    ap.add_argument("--fixture", action="store_true", help="use the bundled 3-problem sample (offline)")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    gen = naive_generator if a.naive else reference_generator
+    try:
+        problems = load_fixture() if a.fixture else pull_mbpp(limit=a.limit or None)
+    except Exception as e:  # network down, etc. -- be honest, do not fake
+        print("could not pull MBPP (%s: %s); try --fixture for the offline sample" % (type(e).__name__, e))
+        return 1
+    print(render(run_public_bench(problems, generator=gen, public_k=a.public_k)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/scbe/instrument.py
+++ b/python/scbe/instrument.py
@@ -1,0 +1,257 @@
+"""The Instrument -- play a token-song; it manifests verified code in any language face.
+
+A SONG is a sequence of NOTES. A MODE maps notes -> CA opcodes (a domain: "coding"
+ships now; chemistry / movement / flight plug in the same way -- same keys, different
+meaning, like major vs Mixolydian). The chain:
+
+    notes --(mode/scale)--> op names --(CA table)--> opcode bytes
+          --(tongue_isa.compile_ca_tokens)--> source in any FACE (python/rust/haskell/...)
+
+Bijective: ``tongue_isa.disassemble`` reads the op-trace back out of the emitted source,
+so we recover the SONG from the code (the scale runs both ways). The python face is also
+executed, so the manifested value is VERIFIED by running, not claimed.
+
+This is the Holophonor: you play the keys, it projects a working program.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Sequence
+
+from .ca_opcode_table import OP_TABLE
+from .tongue_isa import compile_ca_tokens, disassemble, runtime_prelude
+
+# op name -> opcode byte (reverse of the CA table)
+_NAME_TO_BYTE: Dict[str, int] = {entry.name: op_id for op_id, entry in OP_TABLE.items()}
+
+# A MODE is a scale: note -> op name. Same keys, different domain meaning.
+# "coding" is the first mode; add a dict here to add a mode (chemistry, movement, ...).
+MODES: Dict[str, Dict[str, str]] = {
+    "coding": {
+        # diatonic: the everyday arithmetic ops
+        "C": "add",
+        "D": "sub",
+        "E": "mul",
+        "F": "div",
+        "G": "inc",
+        "A": "dec",
+        "B": "neg",
+        # chromatic: the rest of the playable op-set
+        "C#": "mod",
+        "D#": "abs",
+        "F#": "eq",
+        "G#": "lt",
+        "A#": "gt",
+    },
+}
+
+
+def modes() -> List[str]:
+    return sorted(MODES)
+
+
+def scale(mode: str = "coding") -> Dict[str, str]:
+    return dict(MODES[mode])
+
+
+def _op_to_note(mode: str) -> Dict[str, str]:
+    return {op: note for note, op in MODES[mode].items()}
+
+
+def notes_to_ops(song: str, mode: str = "coding") -> List[str]:
+    sc = MODES[mode]
+    ops: List[str] = []
+    for tok in song.replace(",", " ").split():
+        if tok not in sc:
+            raise ValueError(f"note {tok!r} not in {mode} scale {sorted(sc)}")
+        ops.append(sc[tok])
+    return ops
+
+
+def _assemble(prog, face: str) -> str:
+    """Wrap the compiled body into a runnable/readable module for the face."""
+    if face == "python":
+        header = f"def {prog.fn_name}({', '.join(prog.arg_names)}):"
+        body = "\n".join("    " + line for line in prog.body_lines)
+        return runtime_prelude("python") + "\n\n" + header + "\n" + body + "\n"
+    # non-python faces: emit prelude + body as a readable module (not executed here)
+    return runtime_prelude(face) + "\n\n" + "\n".join(prog.body_lines) + "\n"
+
+
+def _run_python(code: str, args: Sequence[float]):
+    ns: Dict[str, object] = {}
+    exec(code, ns)  # noqa: S102 - executing OUR OWN emitted code to verify it runs
+    return ns["play"](*args)
+
+
+def play(song: str, mode: str = "coding", face: str = "python", args: Sequence[float] = ()) -> dict:
+    """Play a song in a mode; manifest it in a language face.
+
+    Returns the manifested value (verified by running the python face), the emitted
+    code, and the song read back out of that code (the bijection)."""
+    ops = notes_to_ops(song, mode)
+    tokens = [_NAME_TO_BYTE[op] for op in ops]
+    arg_names = [f"x{i}" for i in range(len(args))]
+    prog = compile_ca_tokens(tokens, target=face, fn_name="play", arg_names=arg_names)
+    code = _assemble(prog, face)
+
+    value = _run_python(code, args) if face == "python" else None
+
+    o2n = _op_to_note(mode)
+    song_back = " ".join(o2n.get(name, f"?{name}") for _, name in disassemble(code))
+    normalized = " ".join(song.replace(",", " ").split())
+
+    return {
+        "song": song,
+        "mode": mode,
+        "face": face,
+        "ops": ops,
+        "value": value,
+        "code": code,
+        "song_back": song_back,
+        "bijective": song_back == normalized,
+    }
+
+
+# --- conlang keys (sixtongues) + the melody view --------------------------------
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+
+def _sixtongues():
+    """Lazy-load the sixtongues conlang codec (lives in packages/, not the scbe pkg)."""
+    import importlib
+    import sys
+
+    p = os.path.join(_REPO, "packages", "sixtongues")
+    if p not in sys.path:
+        sys.path.insert(0, p)
+    return importlib.import_module("sixtongues")
+
+
+_INSTRUMENTS = ["piano", "strings", "brass", "woodwinds", "mallets", "synth"]
+
+
+def _nm_to_hex(nm: float) -> str:
+    """Approximate a visible wavelength (380-750 nm) as an RGB hex color."""
+    if nm < 380 or nm > 750:
+        r = g = b = 0.0
+    elif nm < 440:
+        r, g, b = -(nm - 440) / 60, 0.0, 1.0
+    elif nm < 490:
+        r, g, b = 0.0, (nm - 440) / 50, 1.0
+    elif nm < 510:
+        r, g, b = 0.0, 1.0, -(nm - 510) / 20
+    elif nm < 580:
+        r, g, b = (nm - 510) / 70, 1.0, 0.0
+    elif nm < 645:
+        r, g, b = 1.0, -(nm - 645) / 65, 0.0
+    else:
+        r, g, b = 1.0, 0.0, 0.0
+    return "#" + "".join(f"{int(max(0.0, min(1.0, c)) * 255):02X}" for c in (r, g, b))
+
+
+def keyspace(op_id: int) -> dict:
+    """The full multi-sensory key for an op -- built in wavelengths. When the 12 notes
+    run out, the instrument (op//12 band) and the color (light wavelength) keep all 64
+    ops distinguishable: a key is a CHORD of pitch + timbre + color, not one note."""
+    op_id = int(op_id) % 64
+    midi = 48 + op_id
+    hz = 440.0 * 2 ** ((midi - 69) / 12)
+    nm = round(380 + op_id / 63 * 370, 1)
+    return {
+        "op_id": op_id,
+        "note": _NOTE_NAMES[midi % 12] + str(midi // 12 - 1),
+        "hz": round(hz, 2),
+        "sound_wavelength_cm": round(34300.0 / hz, 2),  # 343 m/s in air
+        "instrument": _INSTRUMENTS[(op_id // 12) % len(_INSTRUMENTS)],
+        "light_nm": nm,  # visible wavelength
+        "color": _nm_to_hex(nm),
+    }
+
+
+def pitch(op_id: int) -> dict:
+    k = keyspace(op_id)
+    return {"note": k["note"], "midi": 48 + (int(op_id) % 64), "hz": k["hz"]}
+
+
+def melody(ops_bytes: Sequence[int]) -> List[dict]:
+    return [keyspace(b) for b in ops_bytes]
+
+
+def play_tongue(song_tokens: str, tongue: str = "ko", face: str = "python", args: Sequence[float] = ()) -> dict:
+    """Play a song written in the CONLANG. sixtongues tokens decode to bytes, and the
+    bytes ARE the op ids -- so the conlang is literally the keyboard. Bijective both
+    ways: encode_bytes reads the song back out of the ops."""
+    st = _sixtongues()
+    ops_bytes = list(st.decode_tokens(song_tokens, tongue))
+    arg_names = [f"x{i}" for i in range(len(args))]
+    prog = compile_ca_tokens(ops_bytes, target=face, fn_name="play", arg_names=arg_names)
+    code = _assemble(prog, face)
+    value = _run_python(code, args) if face == "python" else None
+    song_back = st.encode_bytes(bytes(ops_bytes), tongue)
+    return {
+        "song": song_tokens,
+        "tongue": tongue,
+        "face": face,
+        "ops": [name for _, name in prog.op_trace],
+        "op_bytes": ops_bytes,
+        "value": value,
+        "code": code,
+        "song_back": song_back,
+        "bijective": song_back.split() == song_tokens.split(),
+        "melody": melody(ops_bytes),
+    }
+
+
+def faces() -> List[str]:
+    """Every language face the instrument can emit to (polyglot + tongue_isa)."""
+    langs = set()
+    try:
+        from .polyglot import languages as _pl
+
+        langs.update(_pl())
+    except Exception:
+        pass
+    try:
+        from .tongue_isa import SUPPORTED_TARGETS
+
+        langs.update(SUPPORTED_TARGETS)
+    except Exception:
+        pass
+    return sorted(langs)
+
+
+def emit_all(song: str, mode: str = "coding", args: Sequence[float] = ()) -> Dict[str, str]:
+    """Play one song into EVERY available language. Best-effort + honest: each value is
+    the emitted source, or 'ERROR: ...' if that face can't carry the song's ops."""
+    ops = notes_to_ops(song, mode)
+    tokens = [_NAME_TO_BYTE[op] for op in ops]
+    argn = [f"x{i}" for i in range(len(args))]
+    from .tongue_isa import SUPPORTED_TARGETS
+
+    try:
+        from . import polyglot as _pg
+    except Exception:
+        _pg = None
+
+    out: Dict[str, str] = {}
+    for face in faces():
+        try:
+            if face in SUPPORTED_TARGETS:
+                prog = compile_ca_tokens(tokens, target=face, fn_name="play", arg_names=argn)
+                out[face] = "\n".join(prog.body_lines)
+            elif _pg is not None:
+                out[face] = _pg.emit(tokens, face, fn_name="play", arg_names=argn)
+            else:
+                out[face] = "ERROR: no emitter for this face"
+        except Exception as exc:
+            out[face] = f"ERROR: {type(exc).__name__}: {exc}"
+    return out
+
+
+if __name__ == "__main__":
+    r = play("C E", face="python", args=(10, 3, 2))
+    print(f"play('C E') ops={r['ops']} value={r['value']} song_back={r['song_back']!r} bijective={r['bijective']}")

--- a/tests/test_helm_public_bench.py
+++ b/tests/test_helm_public_bench.py
@@ -1,0 +1,65 @@
+"""Public benchmark runner: pull MBPP and run the forge loop with public/hidden checks.
+
+Hermetic -- uses the bundled 3-problem MBPP sample, no network. Proves: the reference solver
+passes real problems (harness works on real data), the naive stub is the failing floor, and --
+the point of the public/hidden split -- a tool that overfits the public check is CAUGHT by the
+hidden check.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.helm.public_bench import (  # noqa: E402
+    func_name,
+    load_fixture,
+    naive_generator,
+    reference_generator,
+    run_public_bench,
+)
+
+FIXTURE = load_fixture()
+
+
+def test_fixture_is_real_mbpp():
+    assert len(FIXTURE) == 3
+    assert func_name(FIXTURE[0]) == "similar_elements"  # task 2
+    assert all(p.get("test_list") for p in FIXTURE)
+
+
+def test_reference_solver_passes_real_problems():
+    s = run_public_bench(FIXTURE, generator=reference_generator, public_k=1)
+    assert s["attempted"] == 3
+    assert s["verified"] == 3  # reference solutions pass public + hidden
+    assert s["pass_rate"] == 1.0
+    assert s["public_pass"] == 3 and s["hidden_pass"] == 3
+
+
+def test_naive_stub_is_the_failing_floor():
+    s = run_public_bench(FIXTURE, generator=naive_generator, public_k=1)
+    assert s["verified"] == 0
+    assert s["public_pass"] == 0
+
+
+# a tool that returns a constant: passes the first (public) assert, fails the held-out ones.
+_OVERFIT_PROBLEM = {
+    "task_id": 9001,
+    "code": "def echo(x):\n    return x\n",
+    "test_list": ["assert echo(1) == 1", "assert echo(2) == 2", "assert echo(5) == 5"],
+    "test_imports": [],
+}
+
+
+def _overfit_generator(problem):
+    return "def echo(x):\n    return 1\n"  # only correct for the public example echo(1)
+
+
+def test_hidden_check_catches_public_overfit():
+    s = run_public_bench([_OVERFIT_PROBLEM], generator=_overfit_generator, public_k=1)
+    row = s["results"][0]
+    assert row["public_passed"] is True  # passes the public assert echo(1) == 1
+    assert row["hidden_passed"] is False  # fails hidden echo(2), echo(5)
+    assert row["verified"] is False
+    assert s["overfit_caught"] == 1  # the hidden check did its job

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,73 @@
+"""The Instrument: play a token-song -> verified code in any language face, song read back out.
+
+Verifies by execution (the python face actually runs), not by assertion: a song computes the
+right value, the song is recovered from the emitted code (bijective), one song manifests in all
+18 faces, and the multi-sensory key (note + instrument + colour) keeps all 64 ops distinct so
+the scale can't run out. The conlang-keys path is checked when the sixtongues codec is present.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.instrument import (  # noqa: E402
+    emit_all,
+    faces,
+    keyspace,
+    play,
+)
+
+
+def test_play_runs_verified_and_is_bijective():
+    r = play("C E", face="python", args=(10, 3, 2))  # add, mul: (10+3)*... wait stack: see value
+    assert r["ops"] == ["add", "mul"]
+    assert r["value"] == 50  # verified by executing the python face
+    assert r["song_back"] == "C E"
+    assert r["bijective"] is True
+
+
+def test_second_song_computes_and_round_trips():
+    r = play("C C", face="python", args=(2, 3, 4))  # add, add over [2,3,4] -> (3+4)+2 = 9
+    assert r["value"] == 9
+    assert r["bijective"] is True
+
+
+def test_one_song_manifests_in_all_18_faces():
+    out = emit_all("C E", args=(2, 3, 4))
+    assert len(out) == 18
+    assert sorted(faces()) == sorted(out)
+    errors = {f: v for f, v in out.items() if v.startswith("ERROR")}
+    assert errors == {}
+
+
+def test_keyspace_chord_never_runs_out_of_keys():
+    # op_id = 12*band + note, so (note, instrument) alone uniquely keys all 64 ops -- the
+    # 12-note scale recycles but the instrument band disambiguates; colour is a third axis.
+    keys = {(keyspace(i)["note"], keyspace(i)["instrument"]) for i in range(64)}
+    assert len(keys) == 64
+    assert keyspace(0)["instrument"] != keyspace(12)["instrument"]  # same note name, new timbre
+    assert keyspace(0)["light_nm"] != keyspace(40)["light_nm"]  # built in wavelengths
+
+
+def _have_sixtongues() -> bool:
+    try:
+        from python.scbe.instrument import _sixtongues
+
+        _sixtongues()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _have_sixtongues(), reason="sixtongues conlang codec not available")
+def test_play_in_the_conlang():
+    from python.scbe.instrument import play_tongue
+
+    t = play_tongue("sil'a sil'ei", tongue="ko", face="python", args=(10, 3, 2))
+    assert t["ops"] == ["add", "mul"]
+    assert t["value"] == 50
+    assert t["bijective"] is True  # encode_bytes reads the song back out of the ops


### PR DESCRIPTION
## What

Lands the **Instrument** durably (it was uncommitted in the working tree — at risk of a worktree cleanup). Verified firsthand by *running* it before landing.

`python/scbe/instrument.py` plays a **song** (a sequence of notes) into a working program:

```
notes --(mode/scale)--> CA op names --(CA table)--> opcode bytes
      --(tongue_isa.compile_ca_tokens)--> source in any FACE (18 languages)
```

- The **python face is executed**, so the value is *verified by running*, not claimed. `disassemble()` reads the song back out of the emitted code → **bijective** (the scale runs both ways).
- **Conlang keys:** a `sixtongues` token-stream decodes straight to op bytes (the op-id *is* the byte), so you play in the conlang and `encode_bytes` reads it back.
- **Can't run out of keys:** `keyspace()` makes each op a chord — pitch + instrument band + colour (by light wavelength). The 12-note scale recycles, but `note + instrument` uniquely keys all 64 ops (`op_id = 12·band + note`).
- `emit_all()` manifests one song across all **18 faces**.

## Verified by execution

```
play("C E", args=(10,3,2))     -> ops [add,mul], value 50, song_back "C E", bijective True
play("C C", args=(2,3,4))      -> value 9, bijective True
play_tongue("sil'a sil'ei",ko) -> value 50, bijective True   (conlang keys)
emit_all("C E")                -> all 18 faces, no errors
keyspace                       -> note+instrument unique across all 64 ops
```

## Honest scope

The "testing and fun" instrument the user asked for: `play` executes only the python face (that value is real); other faces emit but are not run here; it plays the portable scalar op-subset.

## Tests

5 (`tests/test_instrument.py`): verified value + bijection, a second song, all-18-faces, the 64-key chord, and the conlang path (skipped if `sixtongues` absent). black / flake8 / ruff clean (120).

> Note: the diff may show `public_bench` files too (branch ancestor); they're already identical on main, so the squash-merge nets to the instrument only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)