### PR TITLE
feat(chemistry): add formula dimensional analysis action

### DIFF
--- a/python/scbe/__init__.py
+++ b/python/scbe/__init__.py
@@ -131,6 +131,13 @@ from .reaction_harness import (
     ReactionFieldCheck,
     evaluate_bijective_reaction,
 )
+from .chemistry_dimensions import (
+    ChemistryDimensionError,
+    ElementDimension,
+    analyze_formula,
+    analyze_many,
+    element_dimension,
+)
 from .quasi_integer_recoupling import (
     CHEMICAL_BOND_ORDER_STATES,
     FORMAL_CHARGE_STATES,
@@ -208,6 +215,11 @@ __all__ += [
     "ReactionFieldCheck",
     "BijectiveReactionResult",
     "evaluate_bijective_reaction",
+    "ChemistryDimensionError",
+    "ElementDimension",
+    "analyze_formula",
+    "analyze_many",
+    "element_dimension",
     "RecouplingState",
     "QuasiIntegerRecoupling",
     "CHEMICAL_BOND_ORDER_STATES",

--- a/python/scbe/chemistry_dimensions.py
+++ b/python/scbe/chemistry_dimensions.py
@@ -1,0 +1,156 @@
+"""First-class chemistry dimensional analysis.
+
+This is the cheap, honest chemistry action: parse a formula, count atoms, and
+derive the subatomic ledger (protons, neutrons, electrons, charge, mass number).
+It is useful for formula checks, reaction accounting, and AI tool use because the
+result is deterministic and easy to verify. It is not a molecular dynamics,
+toxicity, synthesis, thermodynamics, or bioactivity engine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+from .reaction_balance import parse_formula
+
+
+class ChemistryDimensionError(ValueError):
+    """Raised when dimensional chemistry cannot account for a formula."""
+
+
+@dataclass(frozen=True)
+class ElementDimension:
+    symbol: str
+    atomic_number: int
+    mass_number: int
+    atomic_weight: float
+
+    @property
+    def common_neutrons(self) -> int:
+        return self.mass_number - self.atomic_number
+
+
+# Common biology/materials elements plus the early periodic table. Mass numbers
+# are the most common stable isotope (or longest-lived/common teaching isotope
+# where appropriate); atomic weights are standard average weights for molar-mass
+# estimates. Keep this small and auditable instead of pretending to be NIST.
+ELEMENTS: Mapping[str, ElementDimension] = {
+    "H": ElementDimension("H", 1, 1, 1.008),
+    "He": ElementDimension("He", 2, 4, 4.0026),
+    "Li": ElementDimension("Li", 3, 7, 6.94),
+    "Be": ElementDimension("Be", 4, 9, 9.0122),
+    "B": ElementDimension("B", 5, 11, 10.81),
+    "C": ElementDimension("C", 6, 12, 12.011),
+    "N": ElementDimension("N", 7, 14, 14.007),
+    "O": ElementDimension("O", 8, 16, 15.999),
+    "F": ElementDimension("F", 9, 19, 18.998),
+    "Ne": ElementDimension("Ne", 10, 20, 20.180),
+    "Na": ElementDimension("Na", 11, 23, 22.990),
+    "Mg": ElementDimension("Mg", 12, 24, 24.305),
+    "Al": ElementDimension("Al", 13, 27, 26.982),
+    "Si": ElementDimension("Si", 14, 28, 28.085),
+    "P": ElementDimension("P", 15, 31, 30.974),
+    "S": ElementDimension("S", 16, 32, 32.06),
+    "Cl": ElementDimension("Cl", 17, 35, 35.45),
+    "Ar": ElementDimension("Ar", 18, 40, 39.948),
+    "K": ElementDimension("K", 19, 39, 39.098),
+    "Ca": ElementDimension("Ca", 20, 40, 40.078),
+    "Fe": ElementDimension("Fe", 26, 56, 55.845),
+    "Co": ElementDimension("Co", 27, 59, 58.933),
+    "Cu": ElementDimension("Cu", 29, 63, 63.546),
+    "Zn": ElementDimension("Zn", 30, 64, 65.38),
+    "Se": ElementDimension("Se", 34, 80, 78.971),
+    "Br": ElementDimension("Br", 35, 79, 79.904),
+    "I": ElementDimension("I", 53, 127, 126.904),
+}
+
+CLAIM_BOUNDARY = [
+    "formula-level dimensional accounting only",
+    "neutron counts use common isotope mass numbers, not isotope-resolved samples",
+    "molar mass is an average-weight estimate",
+    "not a thermodynamics, kinetics, synthesis, toxicity, or bioactivity claim",
+]
+
+
+def element_dimension(symbol: str) -> ElementDimension:
+    """Return the dimensional row for an element symbol."""
+
+    try:
+        return ELEMENTS[symbol]
+    except KeyError as exc:
+        raise ChemistryDimensionError(
+            f"element {symbol!r} is not in the local chemistry dimension table"
+        ) from exc
+
+
+def analyze_formula(formula: str) -> dict:
+    """Analyze a chemical formula into atom/subatomic dimensional totals."""
+
+    counts, charge = parse_formula(formula)
+    atoms: Dict[str, dict] = {}
+    totals = {
+        "atoms": 0,
+        "protons": 0,
+        "neutrons_common_isotope": 0,
+        "electrons": 0,
+        "mass_number_common_isotope": 0,
+        "molar_mass_g_mol": 0.0,
+        "charge": int(charge),
+    }
+    for symbol in sorted(counts):
+        count = int(counts[symbol])
+        dim = element_dimension(symbol)
+        protons = dim.atomic_number * count
+        neutrons = dim.common_neutrons * count
+        mass_number = dim.mass_number * count
+        molar_mass = dim.atomic_weight * count
+        atoms[symbol] = {
+            "count": count,
+            "atomic_number": dim.atomic_number,
+            "mass_number_common_isotope": dim.mass_number,
+            "protons": protons,
+            "neutrons_common_isotope": neutrons,
+            "electrons_neutral": protons,
+            "molar_mass_g_mol": round(molar_mass, 6),
+        }
+        totals["atoms"] += count
+        totals["protons"] += protons
+        totals["neutrons_common_isotope"] += neutrons
+        totals["mass_number_common_isotope"] += mass_number
+        totals["molar_mass_g_mol"] += molar_mass
+    totals["electrons"] = totals["protons"] - charge
+    totals["molar_mass_g_mol"] = round(totals["molar_mass_g_mol"], 6)
+    return {
+        "schema_version": "scbe_chemistry_dimensions_v1",
+        "formula": formula,
+        "atoms": atoms,
+        "totals": totals,
+        "claim_boundary": list(CLAIM_BOUNDARY),
+    }
+
+
+def analyze_many(formulas: list[str]) -> dict:
+    """Analyze several formulas and return a combined ledger."""
+
+    rows = [analyze_formula(formula) for formula in formulas]
+    combined = {
+        "atoms": 0,
+        "protons": 0,
+        "neutrons_common_isotope": 0,
+        "electrons": 0,
+        "mass_number_common_isotope": 0,
+        "molar_mass_g_mol": 0.0,
+        "charge": 0,
+    }
+    for row in rows:
+        for key in combined:
+            combined[key] += row["totals"][key]
+    combined["molar_mass_g_mol"] = round(combined["molar_mass_g_mol"], 6)
+    return {
+        "schema_version": "scbe_chemistry_dimensions_batch_v1",
+        "formulas": formulas,
+        "rows": rows,
+        "combined_totals": combined,
+        "claim_boundary": list(CLAIM_BOUNDARY),
+    }

--- a/python/scbe/instrument.py
+++ b/python/scbe/instrument.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 from typing import Dict, List, Sequence
 
-from .ca_semantics import coverage_report, template_choices
 from .ca_opcode_table import OP_TABLE
+from .ca_semantics import coverage_report, template_choices
+from .chemistry_dimensions import analyze_formula
 from .tongue_isa import (
     SUPPORTED_TARGETS,
     compile_ca_tokens,
@@ -164,6 +165,12 @@ def semantic_coverage() -> dict:
     """Return coverage for the CA semantic-template registry."""
 
     return coverage_report()
+
+
+def chemistry(formula: str) -> dict:
+    """Run the first-class chemistry action for formula dimensional analysis."""
+
+    return analyze_formula(formula)
 
 
 MODES: Dict[str, Dict[str, str]] = {

--- a/python/scbe/reaction_language.py
+++ b/python/scbe/reaction_language.py
@@ -82,6 +82,20 @@ NAME_TO_SMILES: Dict[str, str] = {
 _VERB_SIGNALS: List[Tuple[str, List[str]]] = [
     ("checkpoint", ["checkpoint", "merkle", "anchor", "notarize", "seal the chain", "receipt chain"]),
     ("geometry", ["geometry", "shape", "3d", "conformer", "rotor", "point group", "structure of"]),
+    (
+        "dimensions",
+        [
+            "dimension",
+            "dimensional analysis",
+            "composition",
+            "atomic composition",
+            "atom count",
+            "protons",
+            "neutrons",
+            "electrons",
+            "molar mass",
+        ],
+    ),
     ("screen", ["screen", "controlled", "dangerous", "hazardous", "banned", "illegal", "weapon", "schedule"]),
     ("balance", ["balance", "combust", "combustion", "burn", "stoichiometry", "equation", "react"]),
 ]
@@ -217,6 +231,20 @@ def _find_path(text: str) -> Optional[str]:
     return None
 
 
+def _find_formula(text: str) -> Optional[str]:
+    for tok in re.findall(r"[A-Za-z0-9^+\-()]+", text):
+        if _FORMULA_RE.match(tok) and any(c.isupper() for c in tok):
+            return tok
+    formulas, _ = _resolve_species_formula(text)
+    if formulas:
+        return formulas[0]
+    lowered = text.lower()
+    for name in sorted(NAME_TO_FORMULA, key=len, reverse=True):
+        if re.search(rf"\b{re.escape(name)}\b", lowered):
+            return NAME_TO_FORMULA[name]
+    return None
+
+
 def _plan_balance(text: str) -> ReactionPlan:
     notes: List[str] = []
     eq = _parse_equation(text)
@@ -329,8 +357,31 @@ def _plan_checkpoint(text: str) -> ReactionPlan:
     )
 
 
+def _plan_dimensions(text: str) -> ReactionPlan:
+    formula = _find_formula(text)
+    if formula:
+        return ReactionPlan(
+            "dimensions",
+            {"formula": formula},
+            f"react dimensions --formula {formula}",
+            0.86,
+            notes=[
+                "formula-level atom/proton/neutron/electron ledger",
+                "not thermodynamics, kinetics, toxicity, synthesis, or bioactivity",
+            ],
+        )
+    return ReactionPlan(
+        "dimensions",
+        {},
+        "react dimensions --formula <FORMULA>",
+        0.3,
+        clarification="Which formula should I analyze? Give a formula like C6H12O6, H2O, or NH4^+.",
+    )
+
+
 _DISPATCH = {
     "balance": _plan_balance,
+    "dimensions": _plan_dimensions,
     "screen": _plan_screen,
     "geometry": _plan_geometry,
     "checkpoint": _plan_checkpoint,
@@ -339,6 +390,7 @@ _DISPATCH = {
 VERBS_HELP = (
     "I understand these reaction requests:\n"
     "  balance    e.g. 'balance propane combustion' / 'balance C3H8 + O2 -> CO2 + H2O'\n"
+    "  dimensions e.g. 'atomic composition of glucose' / 'dimensions C6H12O6'\n"
     "  screen     e.g. 'is ethanol controlled?' / 'screen CCO'\n"
     "  geometry   e.g. 'what shape is CO2?' / 'geometry of ethanol'\n"
     "  checkpoint e.g. 'checkpoint artifacts/demo/methalox/signed_chain.json'"

--- a/scripts/reaction_cli.py
+++ b/scripts/reaction_cli.py
@@ -26,6 +26,7 @@ from python.scbe.audio_field_observables import (
     generate_decaying_sine,
     generate_sine,
 )
+from python.scbe.chemistry_dimensions import ChemistryDimensionError, analyze_formula
 from python.scbe.controlled_substances import ControlledSubstanceDenied, screen_input
 from python.scbe.geometry_view import GeometryEngineError, geometry_view_packet
 from python.scbe.reaction_balance import BalanceError, balance_reaction_packet
@@ -428,6 +429,31 @@ def print_human_balance(payload: dict[str, Any]) -> None:
         print(f"WARNING {flag}")
 
 
+def build_dimensions(formula: str) -> dict[str, Any]:
+    try:
+        return {"ok": True, **analyze_formula(formula)}
+    except (BalanceError, ChemistryDimensionError) as exc:
+        return {
+            "schema_version": "scbe_react_dimensions_v1",
+            "ok": False,
+            "formula": formula,
+            "error": str(exc),
+        }
+
+
+def print_human_dimensions(payload: dict[str, Any]) -> None:
+    if not payload.get("ok"):
+        print(f"reaction dimensions: FAILED {payload.get('error', '')}")
+        return
+    totals = payload["totals"]
+    print(
+        "reaction dimensions: "
+        f"{payload['formula']} atoms={totals['atoms']} protons={totals['protons']} "
+        f"neutrons={totals['neutrons_common_isotope']} electrons={totals['electrons']} "
+        f"charge={totals['charge']} molar_mass={totals['molar_mass_g_mol']} g/mol"
+    )
+
+
 def build_geometry(smiles: str) -> dict[str, Any]:
     try:
         packet = geometry_view_packet(smiles).sign(SIGNER_AGENT_ID)
@@ -541,6 +567,8 @@ def print_human_checkpoint(payload: dict[str, Any]) -> None:
 def _execute_plan(plan: "ReactionPlan") -> dict[str, Any]:
     if plan.verb == "balance":
         return build_balance(plan.args["reactants"], plan.args["products"])
+    if plan.verb == "dimensions":
+        return build_dimensions(plan.args["formula"])
     if plan.verb == "screen":
         return build_screen(plan.args["input"])
     if plan.verb == "geometry":
@@ -606,6 +634,7 @@ def print_human_ask(payload: dict[str, Any]) -> None:
     result = payload.get("result", {})
     {
         "balance": print_human_balance,
+        "dimensions": print_human_dimensions,
         "screen": print_human_screen,
         "geometry": print_human_geometry,
         "checkpoint": print_human_checkpoint,
@@ -633,6 +662,9 @@ def main() -> int:
     geometry_parser = sub.add_parser("geometry")
     geometry_parser.add_argument("--smiles", required=True, help="SMILES string, e.g. CCO")
     geometry_parser.add_argument("--json", action="store_true")
+    dimensions_parser = sub.add_parser("dimensions")
+    dimensions_parser.add_argument("--formula", required=True, help="formula, e.g. C6H12O6 or NH4^+")
+    dimensions_parser.add_argument("--json", action="store_true")
     screen_parser = sub.add_parser("screen")
     screen_parser.add_argument("--input", required=True, help="SMILES string or CAS number to screen")
     screen_parser.add_argument("--json", action="store_true")
@@ -696,6 +728,13 @@ def main() -> int:
             print(json.dumps(payload, indent=2))
         else:
             print_human_geometry(payload)
+        return 0 if payload["ok"] else 1
+    if args.cmd == "dimensions":
+        payload = build_dimensions(args.formula)
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print_human_dimensions(payload)
         return 0 if payload["ok"] else 1
     if args.cmd == "screen":
         payload = build_screen(args.input)

--- a/tests/test_chemistry_dimensions.py
+++ b/tests/test_chemistry_dimensions.py
@@ -1,0 +1,58 @@
+"""Locks for first-class chemistry dimensional analysis."""
+
+from __future__ import annotations
+
+import pytest
+
+from python.scbe.chemistry_dimensions import (
+    ChemistryDimensionError,
+    analyze_formula,
+    analyze_many,
+)
+
+
+def test_glucose_subatomic_ledger_is_dimensionally_accounted():
+    row = analyze_formula("C6H12O6")
+
+    assert row["schema_version"] == "scbe_chemistry_dimensions_v1"
+    assert row["atoms"]["C"]["count"] == 6
+    assert row["atoms"]["H"]["count"] == 12
+    assert row["atoms"]["O"]["count"] == 6
+    assert row["totals"]["atoms"] == 24
+    assert row["totals"]["protons"] == 96
+    assert row["totals"]["neutrons_common_isotope"] == 84
+    assert row["totals"]["electrons"] == 96
+    assert row["totals"]["mass_number_common_isotope"] == 180
+    assert row["totals"]["molar_mass_g_mol"] == pytest.approx(180.156)
+    assert any("formula-level" in line for line in row["claim_boundary"])
+
+
+def test_charge_changes_electron_count_not_protons():
+    ammonium = analyze_formula("NH4^+")
+
+    assert ammonium["totals"]["charge"] == 1
+    assert ammonium["totals"]["protons"] == 11
+    assert ammonium["totals"]["electrons"] == 10
+    assert ammonium["totals"]["neutrons_common_isotope"] == 7
+
+
+def test_nested_formula_reuses_reaction_parser():
+    row = analyze_formula("Ca(OH)2")
+
+    assert row["atoms"]["Ca"]["count"] == 1
+    assert row["atoms"]["O"]["count"] == 2
+    assert row["atoms"]["H"]["count"] == 2
+    assert row["totals"]["protons"] == 38
+
+
+def test_batch_analysis_combines_ledgers():
+    batch = analyze_many(["H2", "O2"])
+
+    assert batch["combined_totals"]["atoms"] == 4
+    assert batch["combined_totals"]["protons"] == 18
+    assert batch["combined_totals"]["electrons"] == 18
+
+
+def test_unknown_element_fails_cleanly():
+    with pytest.raises(ChemistryDimensionError, match="not in the local chemistry dimension table"):
+        analyze_formula("Uuo")

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -4,6 +4,7 @@ import pytest
 
 from python.scbe.instrument import (
     ca_word_for_opcode,
+    chemistry,
     emit_all,
     faces,
     keyspace,
@@ -62,6 +63,14 @@ def test_instrument_surfaces_semantic_template_choices():
     assert choices[0]["name"] == "bitwise_i64"
     assert choices[0]["family"] == "bitwise"
     assert choices[0]["portable"] is True
+
+
+def test_instrument_has_first_class_chemistry_action():
+    row = chemistry("C6H12O6")
+
+    assert row["totals"]["protons"] == 96
+    assert row["totals"]["electrons"] == 96
+    assert row["totals"]["neutrons_common_isotope"] == 84
 
 
 def test_play_executes_python_face_and_reads_song_back():

--- a/tests/test_reaction_language.py
+++ b/tests/test_reaction_language.py
@@ -62,6 +62,14 @@ def test_geometry_by_name_and_by_smiles():
     assert by_smiles.verb == "geometry" and by_smiles.args["smiles"] == "CCO"
 
 
+def test_dimensions_by_name_and_formula():
+    by_name = plan_from_text("atomic composition of glucose")
+    assert by_name.verb == "dimensions" and by_name.confident
+    assert by_name.args["formula"] == "C6H12O6"
+    by_formula = plan_from_text("dimensions NH4^+")
+    assert by_formula.verb == "dimensions" and by_formula.args["formula"] == "NH4^+"
+
+
 def test_checkpoint_extracts_path():
     plan = plan_from_text("checkpoint artifacts/demo/methalox/signed_chain.json")
     assert plan.verb == "checkpoint" and plan.confident
@@ -119,6 +127,15 @@ def test_build_ask_explain_does_not_execute():
     payload = build_ask("balance methane combustion", execute=False)
     assert payload["executed"] is False
     assert payload["canonical_command"].startswith("react balance")
+
+
+def test_build_ask_executes_dimensions():
+    from scripts.reaction_cli import build_ask
+
+    payload = build_ask("atomic composition of glucose")
+    assert payload["executed"] is True and payload["ok"] is True
+    assert payload["verb"] == "dimensions"
+    assert payload["result"]["totals"]["protons"] == 96
 
 
 def test_build_ask_clarifies_without_executing():


### PR DESCRIPTION
Adds chemistry as a first-class, cheap, verifiable action: formula-level dimensional analysis for atoms, protons, common-isotope neutrons, electrons, charge, mass-number totals, and molar mass.

Surfaces:
- python.scbe.chemistry_dimensions
- python.scbe.instrument.chemistry(formula)
- scbe react dimensions --formula ...
- react ask natural-language route for atomic composition/dimensions

Claim boundary is explicit: this is formula-level dimensional accounting only, not thermodynamics, kinetics, synthesis, toxicity, or bioactivity.

Verified locally:
- python -m pytest tests/test_chemistry_dimensions.py tests/test_instrument.py tests/test_reaction_language.py -q
- flake8 --max-line-length 120 python/scbe/chemistry_dimensions.py python/scbe/instrument.py python/scbe/reaction_language.py scripts/reaction_cli.py tests/test_chemistry_dimensions.py tests/test_instrument.py tests/test_reaction_language.py
- python scripts/reaction_cli.py dimensions --formula C6H12O6 --json
- python scripts/reaction_cli.py ask "atomic composition of glucose" --json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chemistry dimensional analysis to compute elemental composition from chemical formulas
  * Added new CLI command for analyzing formulas with support for ion charges and nested parentheses
  * Added natural language support for chemistry queries (e.g., "atomic composition of glucose")
  * Reports detailed subatomic ledger: atom counts, protons, neutrons, electrons, and molar mass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->