### PR TITLE
feat(tokenizer): add atomic-style token lookup rows

### DIFF
--- a/python/scbe/__init__.py
+++ b/python/scbe/__init__.py
@@ -138,6 +138,7 @@ from .chemistry_dimensions import (
     analyze_many,
     element_dimension,
 )
+from .token_lookup import lookup_token, lookup_tokens
 from .quasi_integer_recoupling import (
     CHEMICAL_BOND_ORDER_STATES,
     FORMAL_CHARGE_STATES,
@@ -220,6 +221,8 @@ __all__ += [
     "analyze_formula",
     "analyze_many",
     "element_dimension",
+    "lookup_token",
+    "lookup_tokens",
     "RecouplingState",
     "QuasiIntegerRecoupling",
     "CHEMICAL_BOND_ORDER_STATES",

--- a/python/scbe/token_lookup.py
+++ b/python/scbe/token_lookup.py
@@ -1,0 +1,159 @@
+"""Token lookup table rows for SCBE's semantic chemistry/tokenizer layer.
+
+The goal is the tokenizer equivalent of an atomic lookup table: a compact,
+deterministic record that tells an agent what a token is, how it is encoded, how
+it behaves in the semantic-periodic lattice, and whether it is also a real
+chemical element/formula with a dimensional ledger.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from .atomic_tokenization import chemical_element, map_token_to_atomic_state
+from .chemistry_dimensions import ChemistryDimensionError, analyze_formula, element_dimension
+
+
+TOKEN_LOOKUP_CLAIM_BOUNDARY = [
+    "token lookup is deterministic representation metadata",
+    "semantic element rows are SCBE tokenizer classes, not physical atoms",
+    "material chemistry dimensions appear only when the token is a known element or formula",
+    "not wet-lab synthesis, kinetics, toxicity, dosing, or bioactivity advice",
+]
+
+
+def _byte_signature(token: str) -> dict[str, Any]:
+    data = token.encode("utf-8")
+    return {
+        "byte_count": len(data),
+        "bit_count": len(data) * 8,
+        "hex": [f"0x{byte:02X}" for byte in data],
+        "popcount": [byte.bit_count() for byte in data],
+        "bit_density": (
+            round(sum(byte.bit_count() for byte in data) / float(len(data) * 8), 6)
+            if data
+            else 0.0
+        ),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def _state_row(state: Any) -> dict[str, Any]:
+    element = state.element
+    return {
+        "semantic_class": state.semantic_class,
+        "semantic_element": {
+            "symbol": element.symbol,
+            "Z": element.Z,
+            "group": element.group,
+            "period": element.period,
+            "valence": element.valence,
+            "electronegativity": round(float(element.electronegativity), 6),
+            "witness_stable": element.witness_stable,
+        },
+        "tau": state.tau.as_dict(),
+        "negative_state": state.negative_state,
+        "dual_state": state.dual_state,
+        "band_flag": state.band_flag,
+        "witness_state": state.witness_state,
+        "resilience": round(float(state.resilience), 6),
+        "adaptivity": round(float(state.adaptivity), 6),
+        "trust_baseline": round(float(state.trust_baseline), 6),
+    }
+
+
+def _material_row(token: str) -> dict[str, Any] | None:
+    element = chemical_element(token)
+    if element is not None:
+        try:
+            physical = element_dimension(element.symbol)
+        except ChemistryDimensionError:
+            return {
+                "kind": "element",
+                "symbol": element.symbol,
+                "periodic_semantic": {
+                    "Z": element.Z,
+                    "group": element.group,
+                    "period": element.period,
+                    "valence": element.valence,
+                    "electronegativity": element.electronegativity,
+                },
+                "dimensions": None,
+            }
+        dimensions = analyze_formula(element.symbol)
+        return {
+            "kind": "element",
+            "symbol": element.symbol,
+            "atomic_number": physical.atomic_number,
+            "mass_number_common_isotope": physical.mass_number,
+            "common_neutrons": physical.common_neutrons,
+            "atomic_weight": physical.atomic_weight,
+            "dimensions": dimensions,
+        }
+    try:
+        dimensions = analyze_formula(token)
+    except (ChemistryDimensionError, ValueError):
+        return None
+    return {
+        "kind": "formula",
+        "formula": token,
+        "dimensions": dimensions,
+    }
+
+
+def lookup_token(
+    token: str,
+    *,
+    language: str | None = None,
+    context_class: str | None = None,
+) -> dict[str, Any]:
+    """Return a deterministic atomic-style lookup row for one token."""
+
+    state = map_token_to_atomic_state(token, language=language, context_class=context_class)
+    material = _material_row(token)
+    workflow_unit = None
+    try:
+        from src.tokenizer.atomic_workflow_units import build_atomic_workflow_unit
+
+        workflow_unit = build_atomic_workflow_unit(token)
+    except Exception:
+        workflow_unit = None
+    return {
+        "schema_version": "scbe_token_lookup_v1",
+        "token": token,
+        "language": language,
+        "context_class": context_class,
+        "byte_signature": _byte_signature(token),
+        "semantic": _state_row(state),
+        "workflow_unit": workflow_unit,
+        "material": material,
+        "lookup_axes": [
+            "bytes",
+            "semantic_class",
+            "semantic_element",
+            "tau",
+            "workflow_band",
+            "material_dimensions",
+        ],
+        "claim_boundary": list(TOKEN_LOOKUP_CLAIM_BOUNDARY),
+    }
+
+
+def lookup_tokens(
+    tokens: list[str],
+    *,
+    language: str | None = None,
+    context_class: str | None = None,
+) -> dict[str, Any]:
+    """Return lookup rows for several tokens."""
+
+    return {
+        "schema_version": "scbe_token_lookup_batch_v1",
+        "tokens": tokens,
+        "rows": [
+            lookup_token(token, language=language, context_class=context_class)
+            for token in tokens
+        ],
+        "claim_boundary": list(TOKEN_LOOKUP_CLAIM_BOUNDARY),
+    }

--- a/scbe.py
+++ b/scbe.py
@@ -3325,6 +3325,7 @@ def _fusion_payload(result: Any) -> Dict[str, Any]:
 def cmd_chem_atomize(args: argparse.Namespace) -> int:
     from python.scbe.atomic_tokenization import map_token_to_atomic_state
     from python.scbe.chemical_fusion import fuse_atomic_states
+    from python.scbe.token_lookup import lookup_tokens
 
     text = _arg_or_stdin(getattr(args, "text", None))
     if not text:
@@ -3350,6 +3351,11 @@ def cmd_chem_atomize(args: argparse.Namespace) -> int:
         "tokens": tokens,
         "token_count": len(tokens),
         "states": [_atomic_state_payload(state) for state in states],
+        "lookup_units": lookup_tokens(
+            tokens,
+            language=getattr(args, "language", None),
+            context_class=getattr(args, "context", None),
+        )["rows"],
         "fusion": _fusion_payload(fusion),
         "claim_boundary": CHEM_CLAIM_BOUNDARY,
     }
@@ -3362,6 +3368,44 @@ def cmd_chem_atomize(args: argparse.Namespace) -> int:
     print("  tau_hat:", payload["fusion"]["tau_hat"])
     print("  elements:", " ".join(state["element"]["symbol"] for state in payload["states"]))
     print(f"  boundary: {CHEM_CLAIM_BOUNDARY}")
+    return 0
+
+
+def cmd_chem_lookup(args: argparse.Namespace) -> int:
+    from python.scbe.token_lookup import lookup_token
+
+    token = _arg_or_stdin(getattr(args, "token", None))
+    if not token:
+        print('usage: scbe chem lookup "<token>"   (or pipe via stdin)', file=sys.stderr)
+        return 2
+    payload = lookup_token(
+        token.strip(),
+        language=getattr(args, "language", None),
+        context_class=getattr(args, "context", None),
+    )
+    if getattr(args, "json_output", False):
+        print(json.dumps(payload))
+        return 0
+
+    semantic = payload["semantic"]
+    material = payload["material"]
+    print(f"chem lookup: {payload['token']}")
+    print(
+        "  semantic: "
+        f"{semantic['semantic_class']} -> {semantic['semantic_element']['symbol']} "
+        f"tau={semantic['tau']}"
+    )
+    print(f"  bytes: {' '.join(payload['byte_signature']['hex'])}")
+    if material:
+        kind = material["kind"]
+        label = material.get("formula") or material.get("symbol")
+        totals = material["dimensions"]["totals"] if material.get("dimensions") else None
+        if totals:
+            print(
+                f"  material: {kind} {label} atoms={totals['atoms']} "
+                f"protons={totals['protons']} electrons={totals['electrons']}"
+            )
+    print("  boundary: deterministic representation lookup; not wet-lab advice")
     return 0
 
 
@@ -5165,6 +5209,13 @@ Legacy (backward compat):
     ca.add_argument("--context", help="optional context class, e.g. operator, timeline, safety")
     ca.add_argument("--json", dest="json_output", action="store_true")
     ca.set_defaults(func=cmd_chem_atomize)
+
+    cl = chem_sub.add_parser("lookup", help="Atomic-style lookup row for one tokenizer token")
+    cl.add_argument("token", nargs="?", help="token to look up (or pipe via stdin)")
+    cl.add_argument("--language", help="optional language code for token-class overrides")
+    cl.add_argument("--context", help="optional context class, e.g. operator, timeline, safety")
+    cl.add_argument("--json", dest="json_output", action="store_true")
+    cl.set_defaults(func=cmd_chem_lookup)
 
     cb = chem_sub.add_parser("bonds", help="Analyze the 6 Sacred Tongue coordinate bonds")
     cb.add_argument("coords", nargs=6, type=float, metavar="coord")

--- a/tests/test_scbe_cli_chem.py
+++ b/tests/test_scbe_cli_chem.py
@@ -38,7 +38,21 @@ def test_chem_atomize_exposes_atomic_token_states() -> None:
     assert payload["tokens"] == ["release", "payload", "after", "compare"]
     assert {"tau_hat", "reconstruction_votes"} <= set(payload["fusion"])
     assert {"token", "semantic_class", "element", "tau"} <= set(payload["states"][0])
+    assert payload["lookup_units"][0]["schema_version"] == "scbe_token_lookup_v1"
+    assert payload["lookup_units"][0]["byte_signature"]["hex"]
     assert "wet-lab" in payload["claim_boundary"]
+
+
+def test_chem_lookup_exposes_atomic_style_lookup_for_formula() -> None:
+    result = run_scbe("chem", "lookup", "C6H12O6", "--json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "scbe_token_lookup_v1"
+    assert payload["token"] == "C6H12O6"
+    assert payload["material"]["kind"] == "formula"
+    assert payload["material"]["dimensions"]["totals"]["protons"] == 96
+    assert payload["material"]["dimensions"]["totals"]["electrons"] == 96
 
 
 def test_chem_bonds_exposes_sacred_tongue_molecule_report() -> None:

--- a/tests/test_token_lookup.py
+++ b/tests/test_token_lookup.py
@@ -1,0 +1,49 @@
+"""Atomic-style tokenizer lookup rows."""
+
+from __future__ import annotations
+
+from python.scbe.token_lookup import lookup_token, lookup_tokens
+
+
+def test_lookup_token_exposes_semantic_periodic_row_and_bytes():
+    row = lookup_token("build", language="en")
+
+    assert row["schema_version"] == "scbe_token_lookup_v1"
+    assert row["byte_signature"]["hex"] == ["0x62", "0x75", "0x69", "0x6C", "0x64"]
+    assert row["semantic"]["semantic_class"] == "ACTION"
+    assert row["semantic"]["semantic_element"]["symbol"] == "Na"
+    assert set(row["semantic"]["tau"]) == {"KO", "AV", "RU", "CA", "UM", "DR"}
+    assert row["workflow_unit"]["semantic_lane"]["role"] == "compute"
+    assert row["workflow_unit"]["chemistry_lane"]["mode"] == "structural_template"
+    assert row["material"] is None
+
+
+def test_lookup_token_adds_material_dimensions_for_formula():
+    row = lookup_token("C6H12O6")
+
+    assert row["material"]["kind"] == "formula"
+    assert row["material"]["dimensions"]["totals"]["atoms"] == 24
+    assert row["material"]["dimensions"]["totals"]["protons"] == 96
+    assert row["material"]["dimensions"]["totals"]["neutrons_common_isotope"] == 84
+    assert row["material"]["dimensions"]["totals"]["electrons"] == 96
+
+
+def test_lookup_token_adds_material_dimensions_for_element_symbol():
+    row = lookup_token("Fe")
+
+    assert row["material"]["kind"] == "element"
+    assert row["material"]["symbol"] == "Fe"
+    assert row["material"]["atomic_number"] == 26
+    assert row["workflow_unit"]["chemistry_lane"]["mode"] == "material"
+    assert row["workflow_unit"]["chemistry_lane"]["material_elements"] == ["Fe"]
+    assert row["material"]["dimensions"]["totals"]["protons"] == 26
+    assert row["material"]["dimensions"]["totals"]["electrons"] == 26
+
+
+def test_lookup_tokens_batches_rows():
+    batch = lookup_tokens(["not", "H2O"])
+
+    assert batch["schema_version"] == "scbe_token_lookup_batch_v1"
+    assert [row["token"] for row in batch["rows"]] == ["not", "H2O"]
+    assert batch["rows"][0]["semantic"]["negative_state"] is True
+    assert batch["rows"][1]["material"]["dimensions"]["totals"]["atoms"] == 3


### PR DESCRIPTION
Adds atomic-style lookup rows for tokenizer tokens, building on the chemistry dimensions work already merged in #2392.

What this gives agents/humans:
- `python.scbe.token_lookup.lookup_token()` / `lookup_tokens()`
- `scbe chem lookup <token> --json`
- `scbe chem atomize ... --json` now includes `lookup_units`

Each lookup row includes:
- raw byte signature: hex, popcount, bit density, sha256
- SCBE semantic atom: class, semantic element, tau, band, resilience/adaptivity/trust
- atomic workflow unit: semantic lane, chemistry lane, resource cost
- material chemistry dimensions when the token is a known element or formula

Examples verified live:
- `scbe chem lookup H2O --json` returns H/O material dimensions: 3 atoms, 10 protons, 8 common-isotope neutrons, 10 electrons.
- `scbe chem lookup Fe --json` returns element dimensions and material lane.

Claim boundary stays explicit: tokenizer semantic element rows are representation metadata, not physical atoms; material dimensions are only attached for known element/formula tokens.

Verified locally:
- python -m pytest tests/test_token_lookup.py tests/test_scbe_cli_chem.py tests/test_chemistry_dimensions.py tests/test_instrument.py tests/test_reaction_language.py -q
- flake8 --max-line-length 120 python/scbe/token_lookup.py tests/test_token_lookup.py tests/test_scbe_cli_chem.py scbe.py
- python scbe.py chem lookup H2O --json
