### PR TITLE
feat(chemistry): add combined representation report

### DIFF
--- a/python/scbe/__init__.py
+++ b/python/scbe/__init__.py
@@ -139,6 +139,7 @@ from .chemistry_dimensions import (
     element_dimension,
 )
 from .token_lookup import lookup_token, lookup_tokens
+from .representation_report import build_representation_report, representation_tokens
 from .quasi_integer_recoupling import (
     CHEMICAL_BOND_ORDER_STATES,
     FORMAL_CHARGE_STATES,
@@ -223,6 +224,8 @@ __all__ += [
     "element_dimension",
     "lookup_token",
     "lookup_tokens",
+    "build_representation_report",
+    "representation_tokens",
     "RecouplingState",
     "QuasiIntegerRecoupling",
     "CHEMICAL_BOND_ORDER_STATES",

--- a/python/scbe/representation_report.py
+++ b/python/scbe/representation_report.py
@@ -1,0 +1,107 @@
+"""Combined chemistry/tokenizer representation reports.
+
+This is the next layer above one-token lookup: take an input string, tokenize it,
+look up each token, and summarize the representation across semantic atoms,
+material chemistry dimensions, trit/tau totals, and workflow resource costs.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any
+
+from .token_lookup import TOKEN_LOOKUP_CLAIM_BOUNDARY, lookup_tokens
+
+REPRESENTATION_REPORT_CLAIM_BOUNDARY = [
+    "representation report combines tokenizer metadata with formula-level chemistry dimensions",
+    "semantic atoms are SCBE representation classes, not physical atoms",
+    "material totals include only tokens recognized as element symbols or formulas",
+    "not wet-lab synthesis, kinetics, toxicity, dosing, or bioactivity advice",
+]
+
+
+def representation_tokens(text: str) -> list[str]:
+    """Tokenize text for chemistry/tokenizer representation lookup."""
+
+    return re.findall(r"[A-Za-z0-9_^+\-()']+|[^\s]", text or "")
+
+
+def _empty_material_totals() -> dict[str, float | int]:
+    return {
+        "atoms": 0,
+        "protons": 0,
+        "neutrons_common_isotope": 0,
+        "electrons": 0,
+        "mass_number_common_isotope": 0,
+        "molar_mass_g_mol": 0.0,
+        "charge": 0,
+    }
+
+
+def _add_totals(left: dict[str, Any], right: dict[str, Any]) -> None:
+    for key in left:
+        left[key] += right[key]
+    left["molar_mass_g_mol"] = round(float(left["molar_mass_g_mol"]), 6)
+
+
+def _resource_totals(rows: list[dict[str, Any]]) -> dict[str, float]:
+    totals: dict[str, float] = {}
+    for row in rows:
+        unit = row.get("workflow_unit") or {}
+        for key, value in (unit.get("resource_cost") or {}).items():
+            totals[key] = round(totals.get(key, 0.0) + float(value), 6)
+    return totals
+
+
+def build_representation_report(
+    text: str,
+    *,
+    language: str | None = None,
+    context_class: str | None = None,
+) -> dict[str, Any]:
+    """Build a compact report connecting token lookup and material dimensions."""
+
+    tokens = representation_tokens(text)
+    lookup = lookup_tokens(tokens, language=language, context_class=context_class)
+    rows = lookup["rows"]
+    semantic_counts = Counter(row["semantic"]["semantic_class"] for row in rows)
+    semantic_elements = Counter(row["semantic"]["semantic_element"]["symbol"] for row in rows)
+    tau_totals: dict[str, int] = {}
+    material_hits: list[dict[str, Any]] = []
+    material_totals = _empty_material_totals()
+    for row in rows:
+        for tongue, value in row["semantic"]["tau"].items():
+            tau_totals[tongue] = tau_totals.get(tongue, 0) + int(value)
+        material = row.get("material")
+        if material and material.get("dimensions"):
+            dimensions = material["dimensions"]
+            material_hits.append(
+                {
+                    "token": row["token"],
+                    "kind": material["kind"],
+                    "formula": dimensions["formula"],
+                    "totals": dimensions["totals"],
+                }
+            )
+            _add_totals(material_totals, dimensions["totals"])
+    return {
+        "schema_version": "scbe_representation_report_v1",
+        "text": text,
+        "tokens": tokens,
+        "token_count": len(tokens),
+        "lookup_units": rows,
+        "summary": {
+            "semantic_class_counts": dict(sorted(semantic_counts.items())),
+            "semantic_element_counts": dict(sorted(semantic_elements.items())),
+            "tau_totals": dict(sorted(tau_totals.items())),
+            "workflow_resource_totals": _resource_totals(rows),
+            "material_hit_count": len(material_hits),
+            "material_hits": material_hits,
+            "material_totals": material_totals,
+        },
+        "claim_boundary": [
+            *REPRESENTATION_REPORT_CLAIM_BOUNDARY,
+            *TOKEN_LOOKUP_CLAIM_BOUNDARY,
+        ],
+    }

--- a/scbe.py
+++ b/scbe.py
@@ -3409,6 +3409,38 @@ def cmd_chem_lookup(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_chem_represent(args: argparse.Namespace) -> int:
+    from python.scbe.representation_report import build_representation_report
+
+    text = _arg_or_stdin(getattr(args, "text", None))
+    if not text:
+        print('usage: scbe chem represent "<text>"   (or pipe via stdin)', file=sys.stderr)
+        return 2
+    payload = build_representation_report(
+        text,
+        language=getattr(args, "language", None),
+        context_class=getattr(args, "context", None),
+    )
+    if getattr(args, "json_output", False):
+        print(json.dumps(payload))
+        return 0
+
+    summary = payload["summary"]
+    material = summary["material_totals"]
+    print(f"chem represent: {payload['token_count']} token(s)")
+    print("  tokens:", ", ".join(payload["tokens"]))
+    print("  semantic classes:", summary["semantic_class_counts"])
+    print("  tau totals:", summary["tau_totals"])
+    print(
+        "  material totals: "
+        f"hits={summary['material_hit_count']} atoms={material['atoms']} "
+        f"protons={material['protons']} electrons={material['electrons']} "
+        f"molar_mass={material['molar_mass_g_mol']} g/mol"
+    )
+    print("  boundary: representation + formula-level dimensions; not wet-lab advice")
+    return 0
+
+
 def cmd_chem_bonds(args: argparse.Namespace) -> int:
     from src.governance.chemical_bonds import TONGUES, TongueMolecule
 
@@ -5216,6 +5248,13 @@ Legacy (backward compat):
     cl.add_argument("--context", help="optional context class, e.g. operator, timeline, safety")
     cl.add_argument("--json", dest="json_output", action="store_true")
     cl.set_defaults(func=cmd_chem_lookup)
+
+    cr = chem_sub.add_parser("represent", help="Representation report over tokens plus material chemistry dimensions")
+    cr.add_argument("text", nargs="?", help="text/formulas to represent (or pipe via stdin)")
+    cr.add_argument("--language", help="optional language code for token-class overrides")
+    cr.add_argument("--context", help="optional context class, e.g. operator, timeline, safety")
+    cr.add_argument("--json", dest="json_output", action="store_true")
+    cr.set_defaults(func=cmd_chem_represent)
 
     cb = chem_sub.add_parser("bonds", help="Analyze the 6 Sacred Tongue coordinate bonds")
     cb.add_argument("coords", nargs=6, type=float, metavar="coord")

--- a/tests/test_representation_report.py
+++ b/tests/test_representation_report.py
@@ -1,0 +1,35 @@
+"""Combined chemistry/tokenizer representation reports."""
+
+from __future__ import annotations
+
+from python.scbe.representation_report import build_representation_report, representation_tokens
+
+
+def test_representation_tokens_preserve_formula_charge_markers():
+    assert representation_tokens("NH4^+ build H2O") == ["NH4^+", "build", "H2O"]
+
+
+def test_representation_report_summarizes_semantic_and_material_axes():
+    report = build_representation_report("Fe build H2O")
+    summary = report["summary"]
+
+    assert report["schema_version"] == "scbe_representation_report_v1"
+    assert report["tokens"] == ["Fe", "build", "H2O"]
+    assert summary["semantic_class_counts"] == {"ACTION": 1, "ENTITY": 2}
+    assert summary["semantic_element_counts"] == {"Fe": 2, "Na": 1}
+    assert summary["material_hit_count"] == 2
+    assert [hit["token"] for hit in summary["material_hits"]] == ["Fe", "H2O"]
+    assert summary["material_totals"]["atoms"] == 4
+    assert summary["material_totals"]["protons"] == 36
+    assert summary["material_totals"]["neutrons_common_isotope"] == 38
+    assert summary["material_totals"]["electrons"] == 36
+    assert summary["workflow_resource_totals"]["compute"] > 0
+
+
+def test_representation_report_handles_no_material_hits():
+    report = build_representation_report("build not compare")
+    summary = report["summary"]
+
+    assert summary["material_hit_count"] == 0
+    assert summary["material_totals"]["atoms"] == 0
+    assert summary["semantic_class_counts"]["NEGATION"] == 1

--- a/tests/test_scbe_cli_chem.py
+++ b/tests/test_scbe_cli_chem.py
@@ -55,6 +55,18 @@ def test_chem_lookup_exposes_atomic_style_lookup_for_formula() -> None:
     assert payload["material"]["dimensions"]["totals"]["electrons"] == 96
 
 
+def test_chem_represent_summarizes_tokens_and_material_dimensions() -> None:
+    result = run_scbe("chem", "represent", "Fe build H2O", "--json")
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "scbe_representation_report_v1"
+    assert payload["tokens"] == ["Fe", "build", "H2O"]
+    assert payload["summary"]["material_hit_count"] == 2
+    assert payload["summary"]["material_totals"]["protons"] == 36
+    assert payload["summary"]["semantic_class_counts"] == {"ACTION": 1, "ENTITY": 2}
+
+
 def test_chem_bonds_exposes_sacred_tongue_molecule_report() -> None:
     result = run_scbe(
         "chem",


### PR DESCRIPTION
Adds the next system layer over chemistry dimensions (#2392) and tokenizer lookup rows (#2393): a combined representation report for whole inputs.

New surface:
- `python.scbe.representation_report.build_representation_report()`
- `scbe chem represent "Fe build H2O" --json`

The report preserves per-token lookup rows and adds summaries:
- semantic class counts
- semantic element counts
- tau totals
- workflow resource totals
- material hits
- combined formula-level material totals

Live example:
`scbe chem represent "Fe build H2O" --json` returns two material hits (`Fe`, `H2O`) plus semantic rows for all three tokens. Combined material totals: 4 atoms, 36 protons, 38 common-isotope neutrons, 36 electrons.

Claim boundary remains explicit: representation metadata + formula-level dimensions only; not wet-lab synthesis, kinetics, toxicity, dosing, or bioactivity advice.

Verified locally:
- python -m pytest tests/test_representation_report.py tests/test_token_lookup.py tests/test_scbe_cli_chem.py tests/test_chemistry_dimensions.py -q
- flake8 --max-line-length 120 python/scbe/representation_report.py scbe.py tests/test_representation_report.py tests/test_scbe_cli_chem.py
- python scbe.py chem represent "Fe build H2O" --json
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `scbe chem represent` CLI command to analyze chemistry text and generate detailed representation reports.
  * Supports both human-readable and JSON output formats via `--json` flag.
  * Reports include token analysis, semantic classification, and material property summaries (atoms, protons, electrons, molar mass).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->