### PR TITLE
fix(docs): repair broken-link report targets

### DIFF
--- a/docs/PLATFORM_MAP.md
+++ b/docs/PLATFORM_MAP.md
@@ -63,7 +63,7 @@ The system is organized into layers.  Each layer groups related modules by funct
 
 ### Mathematical layer
 
-- **[Harmonic Scaling](../LAYER_INDEX.md)** (Beta · v4.0.3)
+- **[Harmonic Scaling](./LAYER_INDEX.md)** (Beta · v4.0.3)
   - *Reference documentation and formal methods.*  Describes the mathematical principles behind hyperbolic embeddings, stability metrics, and harmonic scaling.  Used to guide the design of embeddings and verification systems.  Contains proofs and citations but is not a runtime component.
 
 - **[Hyperbolic Models](../src/harmonic/hyperbolic.ts)** (Experimental)

--- a/tests/README.md
+++ b/tests/README.md
@@ -342,5 +342,5 @@ describe('Spectral Coherence Property Tests', () => {
 
 - [SCBE 14-Layer Architecture](../docs/ARCHITECTURE.md)
 - [Canonical spec](../docs/SPEC.md)
-- [Patent claims coverage](../docs/PATENT_CLAIMS_COVERAGE.md)
+- [Patent claim tests](./test_aethermoore_patents.py)
 - [NIST PQC Standards](https://csrc.nist.gov/projects/post-quantum-cryptography)


### PR DESCRIPTION
## Summary
- Fixes the broken `docs/PLATFORM_MAP.md` Harmonic Scaling link reported in #2247.
- Replaces the removed patent-coverage doc link in `tests/README.md` with the existing patent test file.

## Verification
- `Test-Path docs/LAYER_INDEX.md` -> true
- `Test-Path tests/test_aethermoore_patents.py` -> true
- `git diff --check`

Fixes #2247.
