### PR TITLE
chore(lint): black-format tests/test_ca_semantics.py

### DIFF
--- a/tests/test_ca_semantics.py
+++ b/tests/test_ca_semantics.py
@@ -11,9 +11,7 @@ def test_every_ca_opcode_has_a_template_choice():
 
     assert report["covered"] == 64
     assert report["missing"] == []
-    assert {"aggregate", "arithmetic", "bitwise", "predicate", "ternary"}.issubset(
-        report["families"]
-    )
+    assert {"aggregate", "arithmetic", "bitwise", "predicate", "ternary"}.issubset(report["families"])
     for entry in OP_TABLE.values():
         choices = S.template_choices(entry.name)
         assert choices


### PR DESCRIPTION
Repo-wide Lint and Format Check was red on this single unformatted file. Pure black formatting, no logic change. Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>