### PR TITLE
fix(cross-lang): make demo sample Python 3.11 compatible

### DIFF
--- a/python/scbe/cross_lang.py
+++ b/python/scbe/cross_lang.py
@@ -203,7 +203,8 @@ def _demo() -> None:
     for ch in challenges(rounds=3, seed=7):
         print(f"   [{ch['round']}] {ch['from_lang']}: {ch['from_code']:<22} -> {ch['to_lang']}?")
     print("\ngrade an answer:")
-    print(f"   {grade('print', 'rust', 'println!(\"hi\")')}")
+    sample_answer = 'println!("hi")'
+    print(f"   {grade('print', 'rust', sample_answer)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Avoid a Python 3.11 f-string parser error in the cross_lang demo sample.
- Keeps the sample answer identical while moving the quoted Rust snippet out of the f-string expression.

## Verification
- python -m py_compile python/scbe/cross_lang.py
- python -m pytest tests/test_cross_lang.py tests/test_mountain_map.py::test_cross_check_against_old_table_runs tests/benchmark/test_chemistry_cli_capability.py::test_chemistry_capability_probes_execute -q
- python scripts/benchmark/chemistry_cli_capability.py --inventory-only --json
- black --check --target-version py311 --line-length 120 python/scbe/cross_lang.py scripts/benchmark/chemistry_cli_capability.py tests/benchmark/test_chemistry_cli_capability.py tests/test_cross_lang.py tests/test_mountain_map.py
- ruff check --config ruff.toml python/scbe/cross_lang.py
- flake8 --max-line-length 120 python/scbe/cross_lang.py