### PR TITLE
feat(rosetta): verified Rosetta stone — one song, many proven-equal faces + more runners

### DIFF
--- a/.github/workflows/rosetta-conformance.yml
+++ b/.github/workflows/rosetta-conformance.yml
@@ -1,0 +1,40 @@
+name: Rosetta Conformance
+
+# Runs the verified Rosetta benchmark where MORE compilers exist than on a laptop.
+# GitHub's ubuntu runner ships python, node, rust, cc, go, ruby, php preinstalled, so the
+# verified-face count rises from ~3 (a dev box) toward ~7 -- and the harness only ever reports
+# faces it actually ran (NO_TOOLCHAIN otherwise). Informational: it prints the coverage matrix.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "python/scbe/rosetta.py"
+      - "python/scbe/polyglot_conformance.py"
+      - "python/scbe/polyglot.py"
+      - "python/scbe/polyglot_dialects.json"
+      - ".github/workflows/rosetta-conformance.yml"
+
+jobs:
+  rosetta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Show available toolchains
+        run: |
+          set +e
+          echo "python: $(python --version 2>&1)"
+          echo "node:   $(node --version 2>&1)"
+          echo "rustc:  $(rustc --version 2>&1)"
+          echo "cc:     $(cc --version 2>&1 | head -1)"
+          echo "go:     $(go version 2>&1)"
+          echo "ruby:   $(ruby --version 2>&1)"
+          echo "php:    $(php --version 2>&1 | head -1)"
+          echo "lua:    $(lua -v 2>&1 | head -1)"
+      - name: Verified Rosetta benchmark (more faces than a laptop can run)
+        run: PYTHONPATH=. python -m python.scbe.rosetta --benchmark
+      - name: Single-song detail (the Rosetta stone, run + read back)
+        run: PYTHONPATH=. python -m python.scbe.rosetta "C E" --source python

--- a/python/scbe/polyglot_conformance.py
+++ b/python/scbe/polyglot_conformance.py
@@ -33,7 +33,16 @@ TOL = 1e-9  # absolute+relative tolerance for "agree"
 
 # Backends we know HOW to run locally. A backend not listed here is emitted but has no
 # runner, so it can only ever be reported as unverified -- not as agreement.
-_RUNNER_TOOL = {"python": None, "javascript": "node", "rust": "rustc"}
+_RUNNER_TOOL = {
+    "python": None,
+    "javascript": "node",
+    "rust": "rustc",
+    "c": "cc",
+    "go": "go",
+    "ruby": "ruby",
+    "php": "php",
+    "lua": "lua",
+}
 
 
 def _toolchain_ok(lang: str) -> bool:
@@ -92,7 +101,58 @@ def run_rust(prog: Sequence[int], args: Sequence[float]) -> Optional[float]:
         return _run_subprocess_float([str(exe)])
 
 
-_RUNNERS = {"python": run_python, "javascript": run_node, "rust": run_rust}
+def run_c(prog: Sequence[int], args: Sequence[float]) -> Optional[float]:
+    src = P.emit(prog, "c") + '\nint main(void) { printf("%%.17g\\n", tongue_fn(%s)); return 0; }\n' % _arglist(args)
+    with tempfile.TemporaryDirectory() as td:
+        f = Path(td) / "prog.c"
+        f.write_text(src, encoding="utf-8")
+        exe = Path(td) / ("prog.exe" if shutil.which("cmd") else "prog")
+        subprocess.run(["cc", str(f), "-lm", "-o", str(exe)], capture_output=True, text=True, timeout=120, check=True)
+        return _run_subprocess_float([str(exe)])
+
+
+def run_go(prog: Sequence[int], args: Sequence[float]) -> Optional[float]:
+    src = P.emit(prog, "go") + "\nfunc main() { fmt.Println(tongue_fn(%s)) }\n" % _arglist(args)
+    with tempfile.TemporaryDirectory() as td:
+        f = Path(td) / "prog.go"
+        f.write_text(src, encoding="utf-8")
+        return _run_subprocess_float(["go", "run", str(f)], timeout=120)
+
+
+def run_ruby(prog: Sequence[int], args: Sequence[float]) -> Optional[float]:
+    src = P.emit(prog, "ruby") + "\nputs tongue_fn(%s)\n" % _arglist(args)
+    with tempfile.TemporaryDirectory() as td:
+        f = Path(td) / "prog.rb"
+        f.write_text(src, encoding="utf-8")
+        return _run_subprocess_float(["ruby", str(f)])
+
+
+def run_php(prog: Sequence[int], args: Sequence[float]) -> Optional[float]:
+    src = P.emit(prog, "php") + "\necho tongue_fn(%s);\n" % _arglist(args)
+    with tempfile.TemporaryDirectory() as td:
+        f = Path(td) / "prog.php"
+        f.write_text(src, encoding="utf-8")
+        return _run_subprocess_float(["php", str(f)])
+
+
+def run_lua(prog: Sequence[int], args: Sequence[float]) -> Optional[float]:
+    src = P.emit(prog, "lua") + "\nprint(tongue_fn(%s))\n" % _arglist(args)
+    with tempfile.TemporaryDirectory() as td:
+        f = Path(td) / "prog.lua"
+        f.write_text(src, encoding="utf-8")
+        return _run_subprocess_float(["lua", str(f)])
+
+
+_RUNNERS = {
+    "python": run_python,
+    "javascript": run_node,
+    "rust": run_rust,
+    "c": run_c,
+    "go": run_go,
+    "ruby": run_ruby,
+    "php": run_php,
+    "lua": run_lua,
+}
 
 
 @dataclass

--- a/python/scbe/rosetta.py
+++ b/python/scbe/rosetta.py
@@ -1,0 +1,207 @@
+"""Verified Rosetta stone: a song in the tokenizer -> aligned code in many languages, PROVEN
+equal by running each (not just emitted), with the song read back out of the core.
+
+Like math notation: a fixed set of symbols is universal ONLY because the lookup table -- what
+each symbol means -- is the same everywhere. A German and a Japanese mathematician read the
+same integral sign because the meaning is standardized, not because either language is more
+powerful. This is that, for code:
+
+    tokenizer song  --(a MODE = the symbol lookup table)-->  CA opcode names -> bytes (the core)
+                    --(polyglot emit)-->                     source in every language face
+                    --(conformance: RUN each face)-->        PROOF the lookup table means the
+                                                             same thing in each language --
+                                                             catching false-friends (round(2.5)
+                                                             is 2.0 in Python but 3.0 in JS/Rust)
+                    --(invert the mode's scale)-->           the song, read back out (bijective)
+
+The MODE is the symbol set: ``coding`` plays note letters (C=add, E=mul); ``ca`` plays your
+conlang words (bip'a=add, bip'i=mul) -- same opcode core, different keys, like solfege vs note
+names. "Verified" means the face was actually executed and AGREED with the Python reference; a
+face with no local toolchain is honestly reported emitted-but-unverified, never claimed --
+because a symbol set you have not checked everywhere is exactly where the round(2.5) trap lives.
+Run it on a box (or CI) with more compilers and the verified count rises.
+
+    python -m python.scbe.rosetta "C E"                    # note song -> every face, run the local ones
+    python -m python.scbe.rosetta "bip'a bip'i" --mode ca  # play it in your tokenizer
+    python -m python.scbe.rosetta --benchmark              # verified Rosetta coverage over a suite
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from . import polyglot as P
+from . import polyglot_conformance as C
+
+
+def _pad3(case: Sequence[float]) -> Tuple[float, float, float]:
+    xs = [float(x) for x in case]
+    while len(xs) < 3:
+        xs.append(0.0)
+    return (xs[0], xs[1], xs[2])
+
+
+def _decode(song: str, mode: str = "coding") -> Tuple[List[int], str, bool]:
+    """Song -> op bytes, the song read back out via the mode's lookup table, and exactness."""
+    from .instrument import notes_to_ops, scale
+
+    ops = notes_to_ops(song, mode)
+    ob = [P.NAME_TO_BYTE[o] for o in ops]
+    op_to_key = {op: key for key, op in scale(mode).items()}
+    back = " ".join(op_to_key.get(P.BYTE_TO_NAME[b], "?") for b in ob)
+    return ob, back, (back == " ".join(song.replace(",", " ").split()))
+
+
+def rosetta(song: str, mode: str = "coding", cases: Optional[Sequence[Sequence[float]]] = None) -> dict:
+    """Manifest one song across every language face, run the ones with a toolchain, read it back."""
+    op_bytes, song_back, bijective = _decode(song, mode)
+    names = [P.BYTE_TO_NAME.get(b, "0x%02x" % b) for b in op_bytes]
+    bad = [n for n in names if n not in P.SCALAR_OPS]
+    if bad:
+        raise ValueError("song uses non-portable ops %s; only the scalar core emits to all faces" % bad)
+    depth = 3  # the stack starts with the 3 inputs
+    for n in names:
+        need = 1 if n in P.FUNC1 else 2  # unary ops pop 1, everything else pops 2
+        if depth < need:
+            raise ValueError("song underflows the stack at op %r (needs %d operands, %d on stack)" % (n, need, depth))
+        depth = depth - need + 1
+    runs = [_pad3(c) for c in (cases or [(2.0, 3.0, 4.0)])]
+    conf = C.conformance(op_bytes, runs)
+    status = {r.lang: r.status for r in conf["results"]}
+    faces: Dict[str, dict] = {}
+    for lang in P.languages():
+        try:
+            faces[lang] = {"status": status.get(lang, "EMITTED"), "source": P.emit(op_bytes, lang)}
+        except Exception as exc:  # a face that cannot carry these ops
+            faces[lang] = {"status": "EMIT_ERROR", "source": "ERROR: %s" % exc}
+    s = conf["summary"]
+    return {
+        "song": song,
+        "mode": mode,
+        "ops": names,
+        "op_bytes": op_bytes,
+        "song_back": song_back,
+        "bijective": bijective,
+        "cases": [list(c) for c in runs],
+        "reference": conf["reference"],
+        "verified": s["verified_agree"],
+        "runnable": s["runnable_backends"] - 1,
+        "disagree": s["disagree"],
+        "total_faces": len(P.languages()),
+        "faces": faces,
+    }
+
+
+_MARK = {
+    "REFERENCE": "reference",
+    "AGREE": "verified (ran + agreed)",
+    "DISAGREE": "DIVERGES",
+    "NO_TOOLCHAIN": "emitted (no toolchain here)",
+    "NO_RUNNER": "emitted (no runner)",
+    "ERROR": "run error",
+    "EMITTED": "emitted",
+    "EMIT_ERROR": "emit error",
+}
+
+
+def render(r: dict, show_source: Sequence[str] = ("python",)) -> str:
+    lines = [
+        "ROSETTA STONE  song=%r  (mode=%s)" % (r["song"], r["mode"]),
+        "  ops: %s   ->  read back: %r   bijective=%s" % (" ".join(r["ops"]), r["song_back"], r["bijective"]),
+        "  reference value(s): %s   verified: %d/%d faces  (%d runnable here)%s"
+        % (
+            r["reference"],
+            r["verified"],
+            r["total_faces"],
+            r["runnable"],
+            ("   DIVERGES: " + ", ".join(r["disagree"])) if r["disagree"] else "",
+        ),
+        "  " + "-" * 60,
+    ]
+    for lang in sorted(r["faces"]):
+        lines.append("  %-12s %s" % (lang, _MARK.get(r["faces"][lang]["status"], r["faces"][lang]["status"])))
+    for lang in show_source:
+        if lang in r["faces"]:
+            lines.append("  " + "-" * 60)
+            lines.append("  [%s face]" % lang)
+            for ln in r["faces"][lang]["source"].splitlines():
+                lines.append("    " + ln)
+    return "\n".join(lines)
+
+
+def benchmark(songs: Sequence[str], mode: str = "coding", cases: Optional[Sequence[Sequence[float]]] = None) -> dict:
+    """Run a suite of songs across all faces; report verified Rosetta coverage + any divergences."""
+    t0 = time.perf_counter()
+    per_lang: Dict[str, Dict[str, int]] = {}
+    disagreements: List[dict] = []
+    rows = []
+    for song in songs:
+        r = rosetta(song, mode, cases=cases)
+        rows.append({"song": song, "verified": r["verified"], "bijective": r["bijective"]})
+        for lang, f in r["faces"].items():
+            d = per_lang.setdefault(lang, {"ran": 0, "agree": 0, "disagree": 0, "unverified": 0})
+            st = f["status"]
+            if st == "REFERENCE":
+                d["ran"] += 1
+            elif st == "AGREE":
+                d["ran"] += 1
+                d["agree"] += 1
+            elif st == "DISAGREE":
+                d["ran"] += 1
+                d["disagree"] += 1
+                disagreements.append({"song": song, "lang": lang})
+            else:
+                d["unverified"] += 1
+    elapsed = round(time.perf_counter() - t0, 2)
+    verified = sorted(lang for lang, d in per_lang.items() if d["ran"] > 0 and d["disagree"] == 0)
+    return {
+        "songs": len(songs),
+        "mode": mode,
+        "total_faces": len(P.languages()),
+        "verified_faces": len(verified),
+        "verified_face_list": verified,
+        "disagreements": disagreements,
+        "per_language": per_lang,
+        "elapsed_s": elapsed,
+        "rows": rows,
+    }
+
+
+_DEFAULT_SUITE = ["C E", "C C", "C D", "E E", "C G", "C G E"]  # valid add/mul/sub/inc combos (note mode)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="scbe-rosetta", description="verified Rosetta stone: one song, many proven-equal faces"
+    )
+    ap.add_argument("song", nargs="?", help="a song: notes like 'C E', or tokenizer words with --mode ca")
+    ap.add_argument("--mode", default="coding", help="the symbol set: 'coding' (notes) or 'ca' (your conlang)")
+    ap.add_argument("--benchmark", action="store_true", help="run a suite and report verified Rosetta coverage")
+    ap.add_argument("--source", default="python", help="comma-separated faces to print in full")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    if a.benchmark:
+        b = benchmark(_DEFAULT_SUITE, mode="coding")
+        print("ROSETTA BENCHMARK  %d songs x %d faces  (%ss)" % (b["songs"], b["total_faces"], b["elapsed_s"]))
+        print(
+            "  verified faces: %d/%d  ->  %s"
+            % (b["verified_faces"], b["total_faces"], ", ".join(b["verified_face_list"]))
+        )
+        if b["disagreements"]:
+            print("  DIVERGENCES: " + ", ".join("%s@%r" % (d["lang"], d["song"]) for d in b["disagreements"]))
+        for lang in sorted(b["per_language"]):
+            d = b["per_language"][lang]
+            print(
+                "    %-12s ran=%d agree=%d disagree=%d unverified=%d"
+                % (lang, d["ran"], d["agree"], d["disagree"], d["unverified"])
+            )
+        return 0
+    song = a.song or ("bip'a bip'i" if a.mode == "ca" else "C E")
+    print(render(rosetta(song, mode=a.mode), show_source=tuple(a.source.split(","))))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_rosetta_view.py
+++ b/tests/test_rosetta_view.py
@@ -1,0 +1,73 @@
+"""Verified Rosetta view: one song -> many language faces, proven equal by running each.
+
+Like math notation, the symbols (notes, or conlang words) are universal only because the
+lookup table means the same thing everywhere -- so we RUN each face rather than trust it. The
+Python reference + structure + bijection are checked unconditionally; the JavaScript agreement
+is checked only when node is present (skip otherwise, never faked).
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe import polyglot as P  # noqa: E402
+from python.scbe.rosetta import benchmark, rosetta  # noqa: E402
+
+_HAVE_NODE = shutil.which("node") is not None
+
+
+def test_note_song_manifests_runs_and_reads_back():
+    r = rosetta("C E", mode="coding")  # add, mul over [2,3,4] -> (3+4) then *2 = 14
+    assert r["ops"] == ["add", "mul"]
+    assert r["reference"][0] == 14.0  # verified by executing the python reference
+    assert r["bijective"] is True
+    assert r["song_back"] == "C E"
+    assert set(r["faces"]) == set(P.languages())
+    assert len(r["faces"]) == 18
+    assert r["faces"]["python"]["status"] == "REFERENCE"
+    # no face is ever marked verified (AGREE) without actually running
+    for f in r["faces"].values():
+        if f["status"] in ("NO_TOOLCHAIN", "NO_RUNNER", "EMITTED", "EMIT_ERROR"):
+            assert f["status"] != "AGREE"
+
+
+def test_tokenizer_mode_plays_the_conlang_and_round_trips():
+    r = rosetta("bip'a bip'i", mode="ca")  # the same program, written in the conlang
+    assert r["ops"] == ["add", "mul"]
+    assert r["reference"][0] == 14.0
+    assert r["bijective"] is True
+    assert r["song_back"] == "bip'a bip'i"
+
+
+def test_underflow_song_raises_clearly_not_crash():
+    with pytest.raises(ValueError, match="underflows the stack"):
+        rosetta("C E D")  # three binary ops over a 3-slot stack
+
+
+def test_unknown_symbol_raises():
+    with pytest.raises(ValueError, match="note 'Z'"):
+        rosetta("C Z")
+
+
+@pytest.mark.skipif(not _HAVE_NODE, reason="node not installed")
+def test_javascript_face_is_actually_verified():
+    r = rosetta("C E")
+    assert r["faces"]["javascript"]["status"] == "AGREE"  # ran and agreed with python
+    assert "javascript" not in r["disagree"]
+
+
+def test_benchmark_reports_honest_verified_coverage():
+    b = benchmark(["C E", "C C"], mode="coding")
+    assert b["songs"] == 2
+    assert b["total_faces"] == 18
+    assert "python" in b["verified_face_list"]  # the reference always counts
+    assert b["verified_faces"] >= 1
+    # a face is 'verified' only if it actually ran with no disagreement
+    for lang in b["verified_face_list"]:
+        d = b["per_language"][lang]
+        assert d["ran"] > 0 and d["disagree"] == 0


### PR DESCRIPTION
## What — the tokenizer as a Rosetta stone, made *checkable*

Like math notation: a fixed symbol set is universal **only because the lookup table means the same thing everywhere** — so we **run** each face instead of trusting it.

- **`python/scbe/rosetta.py`** — `rosetta(song, mode)` decodes a song through a **mode** (the symbol set: `coding` = note letters, `ca` = your conlang words `bip'a`/`bip'i`) → CA opcode core → emits **every** language face → **runs** the ones with a local toolchain → reads the song back out by inverting the mode's scale (**bijective**). `render()` shows the aligned panel; `benchmark()` reports verified Rosetta coverage. An **arity check** rejects stack-underflow songs with a clear error instead of crashing.
- **`polyglot_conformance.py`** — adds runners for **c (cc), go, ruby, php, lua**. Each is fail-safe: `NO_TOOLCHAIN` where the compiler is absent, and the harness **never fakes an `AGREE`**. This raises the verified count from **3** (a laptop) toward **~7** on a box with more compilers.
- **`.github/workflows/rosetta-conformance.yml`** — runs the benchmark on `ubuntu-latest` (python/node/rust/cc/go/ruby/php preinstalled) so the **real** verified count shows up in CI.

## Verified by running locally (python/js/rust)

```
C E            -> add, mul -> value 14, reads back 'C E', bijective=True
bip'a bip'i    -> the SAME program in the conlang (--mode ca), value 14, reads back exactly
benchmark x6   -> javascript 6/6 agree, rust 6/6 agree -> 3/18 verified here
                 (other 15 honestly emitted-but-unverified, awaiting more toolchains)
```

This turns *"emits 18, verifies 3, looks aligned"* into *"write in your tokenizer → see it in N languages → **proven equal by execution** → read the song back out."* The CI job below should push that 3 toward ~7.

## Tests

6 (`tests/test_rosetta_view.py`): python reference + structure, the conlang round-trip, the underflow error, unknown-symbol error, js agreement (skip if node absent), honest benchmark coverage. black / flake8 / ruff clean (120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)