### PR TITLE
fix(rosetta-ci): install numpy so the Rosetta benchmark job runs

### DIFF
--- a/.github/workflows/rosetta-conformance.yml
+++ b/.github/workflows/rosetta-conformance.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install Python deps (the scbe package __init__ pulls in numpy)
+        run: pip install numpy
       - name: Show available toolchains
         run: |
           set +e


### PR DESCRIPTION
The Rosetta Conformance job (added in #2402) failed at import — `python -m python.scbe.rosetta` loads `python/scbe/__init__.py` → `brain.py` → `import numpy`, and the job didn't install deps. The rosetta logic is stdlib-only; this adds `pip install numpy` so the package imports and the verified-Rosetta benchmark actually runs in CI (where cc/go/ruby/php push the verified-face count past the 3 a laptop can run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)