### PR TITLE
fix(rosetta-ci): also install jsonschema so the benchmark job imports

### DIFF
--- a/.github/workflows/rosetta-conformance.yml
+++ b/.github/workflows/rosetta-conformance.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install Python deps (the scbe package __init__ pulls in numpy)
-        run: pip install numpy
+      - name: Install Python deps (numpy + jsonschema are the only third-party imports the scbe package __init__ needs)
+        run: pip install numpy jsonschema
       - name: Show available toolchains
         run: |
           set +e


### PR DESCRIPTION
numpy alone wasn't enough — `python/scbe/__init__.py` also imports `ingestion_rights` → `jsonschema`. A grep of every third-party import across `python/scbe` confirms **numpy + jsonschema** are the only two (rest is stdlib), so this is the complete minimal install. The verified-Rosetta benchmark should now actually run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)