### PR TITLE
fix(chemistry): avoid scbe module shadowing in capability probes

### DIFF
--- a/scripts/benchmark/chemistry_cli_capability.py
+++ b/scripts/benchmark/chemistry_cli_capability.py
@@ -151,8 +151,8 @@ def direct_runtime_probes() -> list[dict[str, Any]]:
     probes: list[dict[str, Any]] = []
 
     try:
-        atomic = import_module("scbe.atomic_tokenization")
-        fusion = import_module("scbe.chemical_fusion")
+        atomic = import_module("python.scbe.atomic_tokenization")
+        fusion = import_module("python.scbe.chemical_fusion")
         tokens = ["encrypt", "payload", "before", "allow"]
         states = [atomic.map_token_to_atomic_state(token, context_class="cli") for token in tokens]
         fused = fusion.fuse_atomic_states(states)


### PR DESCRIPTION
## Summary
- make the chemistry capability benchmark import package modules via `python.scbe.*`
- fixes the nightly-only failure where another test can load root `scbe.py` as module `scbe`, causing `scbe.atomic_tokenization` imports to fail
- keeps the benchmark behavior unchanged; only the import path is hardened

## Verification
- `python -m pytest tests/benchmark/test_chemistry_cli_capability.py::test_chemistry_capability_probes_execute tests/test_cross_lang.py tests/test_mountain_map.py::test_cross_check_against_old_table_runs -q`
- `black --check --target-version py311 --line-length 120 scripts/benchmark/chemistry_cli_capability.py tests/benchmark/test_chemistry_cli_capability.py python/scbe/cross_lang.py`
- `ruff check --config ruff.toml scripts/benchmark/chemistry_cli_capability.py python/scbe/cross_lang.py`
- `flake8 --max-line-length 120 scripts/benchmark/chemistry_cli_capability.py python/scbe/cross_lang.py`
- simulated root `scbe.py` import shadowing, then ran `direct_runtime_probes()` successfully
- `python scripts/benchmark/chemistry_cli_capability.py --inventory-only --json`
- `git diff --check`