### PR TITLE
feat(loomflow): cheap path to FULL programs — branching loops verified across faces

### DIFF
--- a/.github/workflows/rosetta-conformance.yml
+++ b/.github/workflows/rosetta-conformance.yml
@@ -13,6 +13,7 @@ on:
       - "python/scbe/polyglot_conformance.py"
       - "python/scbe/polyglot.py"
       - "python/scbe/polyglot_dialects.json"
+      - "python/scbe/loomflow.py"
       - ".github/workflows/rosetta-conformance.yml"
 
 jobs:
@@ -40,3 +41,7 @@ jobs:
         run: PYTHONPATH=. python -m python.scbe.rosetta --benchmark
       - name: Single-song detail (the Rosetta stone, run + read back)
         run: PYTHONPATH=. python -m python.scbe.rosetta "C E" --source python
+      - name: Loomflow -- a real branching loop verified across faces (incl. C here)
+        run: |
+          PYTHONPATH=. python -m python.scbe.loomflow sum_1_to_5
+          PYTHONPATH=. python -m python.scbe.loomflow factorial_5

--- a/python/scbe/loomflow.py
+++ b/python/scbe/loomflow.py
@@ -1,0 +1,309 @@
+"""loomflow: a tiny control-flow IR that emits FULL (branching, looping) programs into many
+language faces -- the cheap path past the straight-line scalar core, verified by execution.
+
+The polyglot scalar core is straight-line: one opcode -> one statement, no branches. This adds
+the missing piece -- conditionals and loops -- the CHEAP way, skipping the hard control-flow
+structuring (relooper) pass entirely. Each program is emitted as a DISPATCH LOOP: a `while`
+over a program counter with one `if pc == k` arm per instruction. That shape exists in EVERY
+language (no goto needed -- which matters, since Python/Rust/JS/Zig have none), so a real loop
+runs identically across faces today.
+
+Honest tradeoff: the emitted code is a STATE MACHINE, not idiomatic `while`/`if` -- structured,
+human-shaped output is the expensive relooper version. But it is real, executable, branching
+code that computes the right answer, and a Python interpreter of the IR is the reference every
+emitted face is RUN against. So "full programs work across languages" becomes a tested fact.
+
+A program is a line-based assembly (variables are named slots; comments use ; or #):
+
+    const acc 0 / const i 1 / const n 5
+    label loop / le t i n / brz t end / add acc acc i / inc i / jmp loop
+    label end / print acc / halt          # -> 15, verified in python, js, rust, c ...
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+Instr = Tuple[str, Tuple[str, ...]]
+
+_ARITH = {"add": "+", "sub": "-", "mul": "*", "div": "/"}
+_CMP = {"lt": "<", "le": "<=", "gt": ">", "ge": ">=", "eq": "==", "ne": "!="}
+_OPS = {"const", "mov", "inc", "dec", "label", "jmp", "brz", "print", "halt"} | set(_ARITH) | set(_CMP)
+
+
+def parse(text: str) -> List[Instr]:
+    """Parse the line-based assembly into (op, args) instructions."""
+    prog: List[Instr] = []
+    for raw in text.splitlines():
+        line = raw.split(";", 1)[0].split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        op, args = parts[0].lower(), tuple(parts[1:])
+        if op not in _OPS:
+            raise ValueError("unknown op %r (have %s)" % (op, ", ".join(sorted(_OPS))))
+        prog.append((op, args))
+    return prog
+
+
+def _labels(prog: Sequence[Instr]) -> Dict[str, int]:
+    return {a[0]: i for i, (op, a) in enumerate(prog) if op == "label"}
+
+
+def interpret(prog: Sequence[Instr], step_limit: int = 1_000_000) -> List[float]:
+    """The reference: run the IR directly and return everything it printed."""
+    labels = _labels(prog)
+    s: Dict[str, float] = {}
+    out: List[float] = []
+    pc, steps = 0, 0
+    while 0 <= pc < len(prog):
+        steps += 1
+        if steps > step_limit:
+            raise RuntimeError("step limit exceeded (infinite loop?)")
+        op, a = prog[pc]
+        if op == "const":
+            s[a[0]] = float(a[1])
+            pc += 1
+        elif op == "mov":
+            s[a[0]] = s[a[1]]
+            pc += 1
+        elif op in _ARITH:
+            x, y = s[a[1]], s[a[2]]
+            s[a[0]] = x + y if op == "add" else x - y if op == "sub" else x * y if op == "mul" else x / y
+            pc += 1
+        elif op in _CMP:
+            x, y = s[a[1]], s[a[2]]
+            r = {"lt": x < y, "le": x <= y, "gt": x > y, "ge": x >= y, "eq": x == y, "ne": x != y}[op]
+            s[a[0]] = 1.0 if r else 0.0
+            pc += 1
+        elif op == "inc":
+            s[a[0]] += 1.0
+            pc += 1
+        elif op == "dec":
+            s[a[0]] -= 1.0
+            pc += 1
+        elif op == "label":
+            pc += 1
+        elif op == "jmp":
+            pc = labels[a[0]]
+        elif op == "brz":
+            pc = labels[a[1]] if s[a[0]] == 0.0 else pc + 1
+        elif op == "print":
+            out.append(s[a[0]])
+            pc += 1
+        elif op == "halt":
+            break
+    return out
+
+
+def _slots(prog: Sequence[Instr]) -> List[str]:
+    """Every named slot the program writes (declared up front in the emit)."""
+    names: List[str] = []
+    for op, a in prog:
+        dst = None
+        if op in ("const", "mov", "inc", "dec") or op in _ARITH or op in _CMP:
+            dst = a[0]
+        if dst and dst not in names:
+            names.append(dst)
+    return names
+
+
+def _num(v: str) -> str:
+    return repr(float(v))
+
+
+# --- per-language dispatch-loop emit -------------------------------------------
+# A face declares all slots = 0.0, then loops: while pc in range, one `if pc == k` arm per
+# instruction, each arm does its effect and sets pc. No goto; works in every language.
+
+
+def _arms(prog: Sequence[Instr], labels: Dict[str, int], lang: str) -> List[Tuple[str, str]]:
+    """For each instruction k, the (effect, pc-update) statement pair in `lang`'s syntax."""
+
+    def slot(n):
+        return "s_" + n
+
+    def cmp_to_bool(op, a):
+        return "%s %s %s" % (slot(a[1]), _CMP[op], slot(a[2]))
+
+    tern = {
+        "python": "(1.0 if %s else 0.0)",
+        "javascript": "(%s ? 1.0 : 0.0)",
+        "rust": "(if %s { 1.0 } else { 0.0 })",
+        "c": "((%s) ? 1.0 : 0.0)",
+    }[lang]
+    out: List[Tuple[str, str]] = []
+    for k, (op, a) in enumerate(prog):
+        eff, nxt = "", "pc = %d" % (k + 1)
+        if op == "const":
+            eff = "%s = %s" % (slot(a[0]), _num(a[1]))
+        elif op == "mov":
+            eff = "%s = %s" % (slot(a[0]), slot(a[1]))
+        elif op in _ARITH:
+            eff = "%s = %s %s %s" % (slot(a[0]), slot(a[1]), _ARITH[op], slot(a[2]))
+        elif op in _CMP:
+            eff = "%s = %s" % (slot(a[0]), tern % cmp_to_bool(op, a))
+        elif op == "inc":
+            eff = "%s = %s + 1.0" % (slot(a[0]), slot(a[0]))
+        elif op == "dec":
+            eff = "%s = %s - 1.0" % (slot(a[0]), slot(a[0]))
+        elif op == "label":
+            pass
+        elif op == "jmp":
+            nxt = "pc = %d" % labels[a[0]]
+        elif op == "brz":
+            cond = "%s == 0.0" % slot(a[0])
+            tgt, fall = labels[a[1]], k + 1
+            if lang == "python":
+                nxt = "pc = %d if %s else %d" % (tgt, cond, fall)
+            else:
+                nxt = (
+                    "if (%s) { pc = %d; } else { pc = %d; }" % (cond, tgt, fall)
+                    if lang != "rust"
+                    else "if %s { pc = %d; } else { pc = %d; }" % (cond, tgt, fall)
+                )
+        elif op == "print":
+            eff = {
+                "python": "_out.append(%s)" % slot(a[0]),
+                "javascript": "console.log(%s)" % slot(a[0]),
+                "rust": 'println!("{}", %s)' % slot(a[0]),
+                "c": 'printf("%%.17g\\n", %s)' % slot(a[0]),
+            }[lang]
+        elif op == "halt":
+            nxt = "pc = -1"
+        out.append((eff, nxt))
+    return out
+
+
+def emit(prog: Sequence[Instr], lang: str) -> str:
+    """Emit the program as a dispatch loop in `lang` (python/javascript/rust/c)."""
+    labels = _labels(prog)
+    slots = _slots(prog)
+    n = len(prog)
+    arms = _arms(prog, labels, lang)
+    if lang == "python":
+        body = ["    s_%s = 0.0" % s for s in slots] + ["    _out = []", "    pc = 0", "    while 0 <= pc < %d:" % n]
+        for k, (eff, nxt) in enumerate(arms):
+            head = "        if pc == %d:" % k if k == 0 else "        elif pc == %d:" % k
+            body.append(head)
+            for line in ([eff] if eff else []) + [nxt]:
+                body.append("            " + line)
+        body += ["        else:", "            pc = -1", "    return _out[-1] if _out else None"]
+        return "def run():\n" + "\n".join(body) + "\n\n\nif __name__ == '__main__':\n    print(run())\n"
+
+    # brace languages (javascript / rust / c)
+    decl = {
+        "javascript": ["let s_%s = 0.0;" % s for s in slots] + ["let pc = 0;"],
+        "rust": ["let mut s_%s: f64 = 0.0;" % s for s in slots] + ["let mut pc: i64 = 0;"],
+        "c": ["double s_%s = 0.0;" % s for s in slots] + ["int pc = 0;"],
+    }[lang]
+    lines = ["    " + d for d in decl]
+    lines.append("    while (pc >= 0 && pc < %d) {" % n)
+    for k, (eff, nxt) in enumerate(arms):
+        kw = "if" if k == 0 else "} else if"
+        lines.append("        %s (pc == %d) {" % (kw, k))
+        for line in ([eff + ";"] if eff else []) + [nxt + ("" if nxt.endswith("}") else ";")]:
+            lines.append("            " + line)
+    lines += ["        } else { pc = -1; }", "    }"]
+    inner = "\n".join(lines)
+    if lang == "javascript":
+        return inner + "\n"
+    if lang == "rust":
+        return "fn main() {\n" + inner + "\n}\n"
+    return "#include <stdio.h>\n#include <math.h>\nint main(void) {\n" + inner + "\n    return 0;\n}\n"
+
+
+# --- run each emitted face and compare to the reference ------------------------
+_RUN = {"python": None, "javascript": "node", "rust": "rustc", "c": "cc"}
+
+
+def _last_float(stdout: str) -> Optional[float]:
+    line = (stdout.strip().splitlines() or [""])[-1].strip()
+    if line.lower() in ("nan", "-nan"):
+        return float("nan")
+    return float(line) if line not in ("", "None") else None
+
+
+def run_face(prog: Sequence[Instr], lang: str) -> Optional[float]:
+    src = emit(prog, lang)
+    with tempfile.TemporaryDirectory() as td:
+        ext = {"python": "py", "javascript": "js", "rust": "rs", "c": "c"}[lang]
+        f = Path(td) / ("prog." + ext)
+        f.write_text(src, encoding="utf-8")
+        if lang == "python":
+            import sys
+
+            return _last_float(
+                subprocess.run([sys.executable, str(f)], capture_output=True, text=True, timeout=30).stdout
+            )
+        if lang == "javascript":
+            return _last_float(subprocess.run(["node", str(f)], capture_output=True, text=True, timeout=30).stdout)
+        exe = Path(td) / ("prog.exe" if shutil.which("cmd") else "prog")
+        cc = ["rustc", "-O", str(f), "-o", str(exe)] if lang == "rust" else ["cc", str(f), "-lm", "-o", str(exe)]
+        subprocess.run(cc, capture_output=True, text=True, timeout=120, check=True)
+        return _last_float(subprocess.run([str(exe)], capture_output=True, text=True, timeout=30).stdout)
+
+
+def verify(prog: Sequence[Instr], faces: Sequence[str] = ("python", "javascript", "rust", "c")) -> dict:
+    """Run the reference, then every face that has a local toolchain; compare each honestly."""
+    ref = interpret(prog)
+    reference = ref[-1] if ref else None
+    results: Dict[str, dict] = {}
+    for lang in faces:
+        tool = _RUN.get(lang, "<none>")
+        if tool is not None and shutil.which(tool) is None:
+            results[lang] = {"status": "NO_TOOLCHAIN", "value": None}
+            continue
+        try:
+            v = run_face(prog, lang)
+        except Exception as e:
+            results[lang] = {"status": "ERROR", "value": None, "note": "%s: %s" % (type(e).__name__, e)}
+            continue
+        agree = v == reference or (v is not None and reference is not None and abs(v - reference) <= 1e-9)
+        results[lang] = {"status": "AGREE" if agree else "DISAGREE", "value": v}
+    verified = [lang for lang, r in results.items() if r["status"] == "AGREE"]
+    return {
+        "reference": reference,
+        "results": results,
+        "verified": verified,
+        "verified_count": len(verified),
+        "disagree": [lang for lang, r in results.items() if r["status"] == "DISAGREE"],
+    }
+
+
+EXAMPLES = {
+    "sum_1_to_5": "const acc 0\nconst i 1\nconst n 5\nlabel loop\nle t i n\nbrz t end\n"
+    "add acc acc i\ninc i\njmp loop\nlabel end\nprint acc\nhalt",
+    "factorial_5": "const acc 1\nconst i 1\nconst n 5\nlabel loop\nle t i n\nbrz t end\n"
+    "mul acc acc i\ninc i\njmp loop\nlabel end\nprint acc\nhalt",
+}
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="scbe-loomflow", description="full (branching) programs across language faces, verified"
+    )
+    ap.add_argument("example", nargs="?", default="sum_1_to_5", choices=sorted(EXAMPLES), help="which example program")
+    ap.add_argument("--emit", help="print the emitted source for one face (e.g. rust)")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    prog = parse(EXAMPLES[a.example])
+    if a.emit:
+        print(emit(prog, a.emit))
+        return 0
+    r = verify(prog)
+    print("LOOMFLOW  %s  (a real loop, branching)  reference=%s" % (a.example, r["reference"]))
+    print("  verified faces: %d  ->  %s" % (r["verified_count"], ", ".join(r["verified"]) or "(none)"))
+    for lang in sorted(r["results"]):
+        d = r["results"][lang]
+        print("    %-12s %-12s value=%s%s" % (lang, d["status"], d["value"], "  " + d.get("note", "")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_loomflow.py
+++ b/tests/test_loomflow.py
@@ -1,0 +1,67 @@
+"""loomflow: full (branching, looping) programs emit + run identically across language faces.
+
+The cheap path past the straight-line scalar core: a dispatch loop, no relooper. A Python
+interpreter of the IR is the reference; emitted faces are RUN and compared. Reference + parsing
++ branch semantics are checked unconditionally; the js/rust agreement runs only when the
+toolchain is present (skip otherwise, never faked).
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.loomflow import EXAMPLES, emit, interpret, parse, verify  # noqa: E402
+
+_HAVE_NODE = shutil.which("node") is not None
+_HAVE_RUST = shutil.which("rustc") is not None
+
+
+def test_reference_runs_a_real_loop():
+    assert interpret(parse(EXAMPLES["sum_1_to_5"]))[-1] == 15.0  # 1+2+3+4+5
+    assert interpret(parse(EXAMPLES["factorial_5"]))[-1] == 120.0  # 5!
+
+
+def test_branch_actually_branches():
+    # brz jumps when the slot is zero -> picks a different printed value
+    taken = "const x 0\nbrz x zero\nconst r 99\njmp end\nlabel zero\nconst r 1\nlabel end\nprint r\nhalt"
+    not_taken = taken.replace("const x 0", "const x 7")
+    assert interpret(parse(taken))[-1] == 1.0  # branch taken
+    assert interpret(parse(not_taken))[-1] == 99.0  # branch not taken
+
+
+def test_unknown_op_raises():
+    with pytest.raises(ValueError, match="unknown op"):
+        parse("frobnicate a b")
+
+
+def test_emit_produces_a_dispatch_loop_for_each_face():
+    prog = parse(EXAMPLES["sum_1_to_5"])
+    for lang in ("python", "javascript", "rust", "c"):
+        src = emit(prog, lang)
+        assert "pc" in src and len(src) > 0
+    assert "while 0 <= pc" in emit(prog, "python")
+    assert "while (pc >= 0" in emit(prog, "rust")
+
+
+def test_python_face_matches_reference_unconditionally():
+    r = verify(parse(EXAMPLES["sum_1_to_5"]), faces=("python",))
+    assert r["reference"] == 15.0
+    assert r["results"]["python"]["status"] == "AGREE"
+    assert r["verified_count"] == 1
+
+
+@pytest.mark.skipif(not _HAVE_NODE, reason="node not installed")
+def test_javascript_face_runs_the_loop_and_agrees():
+    r = verify(parse(EXAMPLES["factorial_5"]), faces=("javascript",))
+    assert r["results"]["javascript"] == {"status": "AGREE", "value": 120.0}
+
+
+@pytest.mark.skipif(not _HAVE_RUST, reason="rustc not installed")
+def test_rust_face_runs_the_loop_and_agrees():
+    r = verify(parse(EXAMPLES["sum_1_to_5"]), faces=("rust",))
+    assert r["results"]["rust"] == {"status": "AGREE", "value": 15.0}


### PR DESCRIPTION
## What — the depth jump, the cheap way

The scalar polyglot core is straight-line (one opcode → one statement). This adds the missing piece — **conditionals and loops** — **skipping the hard relooper pass entirely.** Each program emits as a **dispatch loop** (a `while` over a program counter, one `if pc == k` arm per instruction) — a shape every language has **without `goto`**, which matters since Python/Rust/JS/Zig have none.

- **`python/scbe/loomflow.py`** — a tiny control-flow IR (`const/mov/add/.../cmp/inc/dec/jmp/brz/print/halt` over named slots). `interpret()` is the reference; `emit()` renders the dispatch loop in **python/javascript/rust/c**; `verify()` **runs** each face with a local toolchain and compares to the reference (`NO_TOOLCHAIN` otherwise — never a faked `AGREE`).
- Two real-loop examples: `sum_1_to_5` → 15, `factorial_5` → 120 (each has a backward jump + a `brz` branch).
- CI workflow also runs loomflow so **C verifies there**.

## Verified by execution (locally, python/js/rust)

```
sum_1_to_5    reference=15.0   verified: python, javascript, rust  (all AGREE)
factorial_5   reference=120.0  verified: python, javascript, rust  (all AGREE)
```

The emitted Rust is a genuine state machine — `if s_t == 0.0 { pc = 9 } else { pc = 6 }` (the conditional) and `pc = 3` (the loop back-edge) — **not** straight-line arithmetic. This is the depth jump (real branching computation) working across languages, for ~$0.

## Honest tradeoff

The emitted code is a **state machine, not idiomatic `while`/`if`** — structured, human-shaped output is the expensive relooper version. But it's real, executable, branching code that computes the right answer, proven by running it. This proves the cheap path is real and tells us the relooper is the only thing standing between this and *idiomatic* full programs.

## Tests

7 (`tests/test_loomflow.py`): reference loop values, branch-actually-branches, unknown-op error, emit shape per face, python agreement (unconditional), js/rust agreement (skip if toolchain absent). black / flake8 / ruff clean (120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new intermediate representation system for assembly programs with support for variables, arithmetic, control flow (loops and conditionals), and cross-language code generation to Python, JavaScript, Rust, and C.
  * Added a verification tool that compares reference interpreter output against compiled results across multiple languages.

* **Tests**
  * Added comprehensive test suite validating interpreter behavior, code generation, and cross-language compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->