### PR TITLE
feat(loomtongue): the bridge — play a FULL program (loops) in your conlang

### DIFF
--- a/.github/workflows/rosetta-conformance.yml
+++ b/.github/workflows/rosetta-conformance.yml
@@ -14,6 +14,7 @@ on:
       - "python/scbe/polyglot.py"
       - "python/scbe/polyglot_dialects.json"
       - "python/scbe/loomflow.py"
+      - "python/scbe/loomtongue.py"
       - ".github/workflows/rosetta-conformance.yml"
 
 jobs:
@@ -45,3 +46,7 @@ jobs:
         run: |
           PYTHONPATH=. python -m python.scbe.loomflow sum_1_to_5
           PYTHONPATH=. python -m python.scbe.loomflow factorial_5
+      - name: Loomtongue -- the SAME loop played in the conlang, verified across faces
+        run: |
+          PYTHONPATH=. python -m python.scbe.loomtongue sum_1_to_5
+          PYTHONPATH=. python -m python.scbe.loomtongue factorial_5

--- a/python/scbe/loomtongue.py
+++ b/python/scbe/loomtongue.py
@@ -1,0 +1,133 @@
+"""loomtongue: play a FULL program (loops, branches) in your conlang -- the bridge between the
+tokenizer and loomflow's control flow.
+
+The Rosetta tokenizer plays scalar NOTES; loomflow plays full programs but in plain assembly.
+This bridges them: every loomflow OPCODE gets its canonical Cassisivadan word from the SAME
+generator the scalar tokenizer uses (ca_word_for_opcode), so the words stay coherent across both
+layers -- add is "bip'a" here exactly as in the note mode. A program is written verbs-in-the-tongue
+(opcodes are conlang words) with operands (slot/label names, numbers) as plain identifiers -- the
+nouns. It translates to a loomflow program, runs across every language face, and reads back out
+in the conlang (bijective).
+
+    bop'a acc 0 / bop'a i 1 / bop'a n 5          # const acc 0 / const i 1 / const n 5
+    bop'i loop / klik'o t i n / bop'u t end      # label loop / le t i n / brz t end
+    bip'a acc acc i / bip'mi i / bop'o loop       # add acc acc i / inc i / jmp loop
+    bop'i end / bop'y acc / bop'ta               # label end / print acc / halt   -> 15
+
+Control-flow opcodes (const/mov/label/jmp/brz/print/halt) live on the conlang's unused LOGIC band
+(0x10+), so they get clean "bop'" words without colliding with the arithmetic "bip'"/comparison
+"klik'" families.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Tuple
+
+from . import loomflow as L
+
+# loomflow opcode -> the byte whose Cassisivadan word names it. Arithmetic/comparison/inc/dec
+# reuse their real CA bytes (so the words match the scalar tokenizer); control flow takes the
+# unused LOGIC band 0x10+.
+_BYTE: Dict[str, int] = {
+    "add": 0x00,
+    "sub": 0x01,
+    "mul": 0x02,
+    "div": 0x03,
+    "eq": 0x20,
+    "ne": 0x21,
+    "lt": 0x22,
+    "le": 0x23,
+    "gt": 0x24,
+    "ge": 0x25,
+    "inc": 0x0B,
+    "dec": 0x0C,
+    "const": 0x10,
+    "mov": 0x11,
+    "label": 0x12,
+    "jmp": 0x13,
+    "brz": 0x14,
+    "print": 0x15,
+    "halt": 0x16,
+}
+
+
+def _build_lexicon() -> Tuple[Dict[str, str], Dict[str, str]]:
+    from .instrument import ca_word_for_opcode
+
+    word_for = {op: ca_word_for_opcode(b) for op, b in _BYTE.items()}
+    op_for = {w: op for op, w in word_for.items()}
+    if len(op_for) != len(word_for):
+        raise RuntimeError("conlang opcode words collide: %s" % word_for)
+    return word_for, op_for
+
+
+WORD_FOR_OP, OP_FOR_WORD = _build_lexicon()
+
+
+def _strip(line: str) -> str:
+    return line.split(";", 1)[0].split("#", 1)[0].strip()
+
+
+def from_tongue(text: str):
+    """A conlang program (opcode words + plain operands) -> a loomflow program."""
+    asm = []
+    for raw in text.splitlines():
+        line = _strip(raw)
+        if not line:
+            continue
+        parts = line.split()
+        word = parts[0]
+        if word not in OP_FOR_WORD:
+            raise ValueError("unknown conlang opcode %r (verbs are %s)" % (word, ", ".join(sorted(OP_FOR_WORD))))
+        asm.append(" ".join([OP_FOR_WORD[word]] + parts[1:]))
+    return L.parse("\n".join(asm))
+
+
+def to_tongue(prog: Sequence) -> str:
+    """A loomflow program -> the conlang text that produces it (the song, read back out)."""
+    return "\n".join(" ".join([WORD_FOR_OP[op]] + list(args)) for op, args in prog)
+
+
+def _normalize(text: str) -> str:
+    return "\n".join(" ".join(s.split()) for s in (_strip(ln) for ln in text.splitlines()) if s)
+
+
+def verify_tongue(text: str, faces: Sequence[str] = ("python", "javascript", "rust", "c")) -> dict:
+    """Translate the conlang program, run it across faces, and read the song back out."""
+    prog = from_tongue(text)
+    res = L.verify(prog, faces)
+    res["song_back"] = to_tongue(prog)
+    res["bijective"] = _normalize(res["song_back"]) == _normalize(text)
+    return res
+
+
+# the loomflow examples, expressed in the conlang (generated, so they are always exact)
+CONLANG_EXAMPLES = {name: to_tongue(L.parse(src)) for name, src in L.EXAMPLES.items()}
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(prog="scbe-loomtongue", description="play a full (branching) program in your conlang")
+    ap.add_argument("example", nargs="?", default="sum_1_to_5", choices=sorted(CONLANG_EXAMPLES))
+    ap.add_argument("--show", action="store_true", help="print the conlang program source")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    song = CONLANG_EXAMPLES[a.example]
+    if a.show:
+        print(song)
+        return 0
+    r = verify_tongue(song)
+    print("LOOMTONGUE  %s  (a real loop, in the conlang)  reference=%s" % (a.example, r["reference"]))
+    print("  song (conlang): %s" % " / ".join(song.splitlines()))
+    print(
+        "  verified faces: %d  ->  %s   bijective(read-back)=%s"
+        % (r["verified_count"], ", ".join(r["verified"]) or "(none)", r["bijective"])
+    )
+    for lang in sorted(r["results"]):
+        d = r["results"][lang]
+        print("    %-12s %-12s value=%s" % (lang, d["status"], d["value"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_loomtongue.py
+++ b/tests/test_loomtongue.py
@@ -1,0 +1,71 @@
+"""loomtongue: a FULL program (loop) written in the conlang, run + verified across faces.
+
+The bridge between the tokenizer and loomflow's control flow. Opcode-word coherence with the
+scalar tokenizer, the conlang->program translation, the bijective read-back, and the python
+reference are checked unconditionally; js/rust agreement runs only when the toolchain is present.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe import loomflow as L  # noqa: E402
+from python.scbe.loomtongue import (  # noqa: E402
+    CONLANG_EXAMPLES,
+    OP_FOR_WORD,
+    WORD_FOR_OP,
+    from_tongue,
+    to_tongue,
+    verify_tongue,
+)
+
+_HAVE_NODE = shutil.which("node") is not None
+_HAVE_RUST = shutil.which("rustc") is not None
+
+
+def test_lexicon_is_bijective_and_coherent_with_scalar_tokenizer():
+    assert len(WORD_FOR_OP) == 19  # every loomflow opcode has a word
+    assert len(OP_FOR_WORD) == 19  # ... and they are all distinct
+    assert WORD_FOR_OP["add"] == "bip'a"  # matches the scalar note-mode tokenizer
+    assert WORD_FOR_OP["mul"] == "bip'i"
+    assert WORD_FOR_OP["brz"] == "bop'u"  # control flow on the unused band
+
+
+def test_conlang_program_translates_and_runs():
+    prog = from_tongue(CONLANG_EXAMPLES["sum_1_to_5"])
+    assert L.interpret(prog)[-1] == 15.0
+    assert L.interpret(from_tongue(CONLANG_EXAMPLES["factorial_5"]))[-1] == 120.0
+
+
+def test_read_back_is_bijective():
+    for src in CONLANG_EXAMPLES.values():
+        assert to_tongue(from_tongue(src)) == src  # the song reads back out exactly
+
+
+def test_unknown_conlang_opcode_raises():
+    with pytest.raises(ValueError, match="unknown conlang opcode"):
+        from_tongue("zzz acc 0")
+
+
+def test_python_face_runs_the_conlang_loop_unconditionally():
+    r = verify_tongue(CONLANG_EXAMPLES["sum_1_to_5"], faces=("python",))
+    assert r["reference"] == 15.0
+    assert r["results"]["python"]["status"] == "AGREE"
+    assert r["bijective"] is True
+
+
+@pytest.mark.skipif(not _HAVE_NODE, reason="node not installed")
+def test_javascript_runs_the_conlang_loop():
+    r = verify_tongue(CONLANG_EXAMPLES["factorial_5"], faces=("javascript",))
+    assert r["results"]["javascript"] == {"status": "AGREE", "value": 120.0}
+
+
+@pytest.mark.skipif(not _HAVE_RUST, reason="rustc not installed")
+def test_rust_runs_the_conlang_loop():
+    r = verify_tongue(CONLANG_EXAMPLES["sum_1_to_5"], faces=("rust",))
+    assert r["results"]["rust"] == {"status": "AGREE", "value": 15.0}


### PR DESCRIPTION
## What — the bridge

Today landed two halves: the **Rosetta tokenizer** plays scalar *notes*, and **loomflow** plays full programs (loops/branches) but in plain assembly. **loomtongue bridges them** — a full program written in **your conlang**.

Every loomflow opcode gets its canonical Cassisivadan word from the **same `ca_word_for_opcode` generator** the scalar tokenizer uses, so it stays coherent: `add` = `bip'a` here exactly as in note mode, comparisons are the `klik'` family, and control flow (`const`/`jmp`/`brz`/`print`/`halt`) takes clean `bop'` words from the unused LOGIC band. Verbs are the tongue; operands (slot/label names, numbers) are plain nouns.

- `from_tongue()` conlang → loomflow program; `to_tongue()` reads it back out; `verify_tongue()` runs it across faces + checks the bijective read-back.

## Verified by execution (python/js/rust locally; c in CI)

A real loop, **written in the conlang**:

```
bop'a acc 0 / bop'a i 1 / bop'a n 5 / bop'i loop / klik'o t i n / bop'u t end /
bip'a acc acc i / bip'mi i / bop'o loop / bop'i end / bop'y acc / bop'ta   ->  15

  verified faces: python, javascript, rust   (c in CI)   bijective(read-back)=True
factorial_5 -> 120   (same faces AGREE)
```

So you can now write a real **loop, in your own tokenizer**, and watch it run identically across multiple languages — proven by running it. The instrument plays *programs* now, not just notes.

## Tests

7 (`tests/test_loomtongue.py`): lexicon bijective + coherent with the scalar tokenizer, conlang program runs, bijective read-back, unknown-word error, python agreement (unconditional), js/rust agreement (skip if absent). CI workflow runs loomtongue too. black / flake8 / ruff clean (120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)