### PR TITLE
feat(aetherdesk): make shell look like a desktop

### DIFF
--- a/aetherdesk/public/index.html
+++ b/aetherdesk/public/index.html
@@ -3,359 +3,966 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AetherDesk Operator Shell v1</title>
+    <title>AetherDesk</title>
     <style>
       :root {
-        --bg: #0b0d12;
-        --panel: #11161f;
-        --border: rgba(214, 167, 86, 0.25);
-        --text: #f2f0ea;
-        --muted: #8a8b8c;
-        --accent: #d6a756;
-        --pass: #7ed99c;
-        --fail: #e88080;
-        --running: #8cc7e8;
+        --blue: #0078d4;
+        --paper: rgba(255, 255, 255, 0.97);
+        --paper2: #f4f6f8;
+        --line: rgba(0, 0, 0, 0.13);
+        --text: #1f2933;
+        --muted: #66707a;
+        --pass: #18864b;
+        --fail: #c43b3b;
+        --running: #1570a6;
       }
+
       * {
         box-sizing: border-box;
       }
+
       body {
         margin: 0;
-        font-family: 'JetBrains Mono', Consolas, Menlo, monospace;
-        background: var(--bg);
+        overflow: hidden;
+        font-family: "Segoe UI", Arial, sans-serif;
         color: var(--text);
-        line-height: 1.5;
+        background:
+          radial-gradient(circle at 18% 18%, rgba(0, 120, 212, 0.36), transparent 26%),
+          radial-gradient(circle at 78% 30%, rgba(214, 167, 86, 0.28), transparent 32%),
+          linear-gradient(145deg, #cfd7df, #eef1f4);
       }
-      header {
-        padding: 14px 22px;
-        border-bottom: 1px solid var(--border);
+
+      button,
+      input {
+        font: inherit;
+      }
+
+      .desktop {
+        position: relative;
+        height: 100vh;
+        padding: 28px 18px 64px;
+      }
+
+      .wall-clock {
+        position: absolute;
+        left: 50%;
+        top: 24%;
+        transform: translate(-50%, -50%);
+        text-align: center;
+        color: rgba(255, 255, 255, 0.86);
+        text-shadow: 0 2px 18px rgba(0, 0, 0, 0.28);
+        pointer-events: none;
+      }
+
+      .wall-clock .greeting {
+        margin-bottom: 10px;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(255, 255, 255, 0.58);
+      }
+
+      .wall-clock .time {
+        font-size: clamp(44px, 7vw, 78px);
+        line-height: 0.95;
+        font-weight: 300;
+        letter-spacing: 0;
+      }
+
+      .wall-clock .date {
+        margin-top: 10px;
+        font-size: 16px;
+        color: rgba(255, 255, 255, 0.66);
+      }
+
+      .desktop-icons {
+        width: max-content;
+        max-width: calc(100vw - 36px);
+        height: calc(100vh - 112px);
+        display: grid;
+        grid-template-rows: repeat(auto-fill, 88px);
+        grid-auto-flow: column;
+        grid-auto-columns: 96px;
+        gap: 10px;
+        align-content: start;
+      }
+
+      .desktop-icon {
+        width: 92px;
+        min-height: 88px;
+        padding: 7px 5px;
+        border: 1px solid transparent;
+        border-radius: 7px;
+        background: transparent;
+        color: #fff;
         display: flex;
-        align-items: baseline;
-        gap: 14px;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        cursor: pointer;
+        text-shadow: 0 1px 5px rgba(0, 0, 0, 0.55);
       }
-      header h1 {
-        margin: 0;
-        font-size: 18px;
-        color: var(--accent);
-        letter-spacing: 0.5px;
+
+      .desktop-icon:hover,
+      .desktop-icon:focus {
+        background: rgba(255, 255, 255, 0.12);
+        border-color: rgba(255, 255, 255, 0.22);
+        outline: none;
       }
-      header .sub {
+
+      .app-icon {
+        width: 44px;
+        height: 44px;
+        border-radius: 10px;
+        background: linear-gradient(145deg, var(--blue), #64b5f6);
+        color: white;
+        display: grid;
+        place-items: center;
+        font-family: Consolas, monospace;
+        font-size: 13px;
+        font-weight: 700;
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+      }
+
+      .desktop-icon .label {
+        max-width: 82px;
+        min-height: 26px;
+        text-align: center;
+        overflow-wrap: anywhere;
+        font-size: 11px;
+        line-height: 1.15;
+      }
+
+      .window {
+        position: absolute;
+        min-width: 300px;
+        min-height: 220px;
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: var(--paper);
+        box-shadow: 0 18px 56px rgba(0, 0, 0, 0.24);
+        overflow: hidden;
+      }
+
+      .window.hidden,
+      .start-menu.hidden {
+        display: none;
+      }
+
+      .window.active {
+        border-color: rgba(0, 120, 212, 0.48);
+      }
+
+      .titlebar {
+        height: 38px;
+        padding: 0 10px 0 12px;
+        border-bottom: 1px solid var(--line);
+        background: linear-gradient(#fff, #f0f2f4);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        user-select: none;
+      }
+
+      .title {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+        font-size: 12px;
+        font-weight: 600;
+      }
+
+      .title .app-icon {
+        width: 24px;
+        height: 24px;
+        border-radius: 6px;
+        font-size: 9px;
+        box-shadow: none;
+      }
+
+      .controls {
+        display: flex;
+      }
+
+      .control {
+        width: 34px;
+        height: 30px;
+        border: 0;
+        border-radius: 5px;
+        background: transparent;
+        color: #606770;
+        cursor: pointer;
+      }
+
+      .control:hover {
+        background: rgba(0, 0, 0, 0.06);
+      }
+
+      .control.close:hover {
+        background: #e81123;
+        color: white;
+      }
+
+      .window-body {
+        height: calc(100% - 38px);
+        padding: 14px;
+        overflow: auto;
+      }
+
+      #window-launcher {
+        left: 136px;
+        top: 70px;
+        width: min(780px, calc(100vw - 176px));
+        height: min(620px, calc(100vh - 138px));
+      }
+
+      #window-terminal {
+        left: min(940px, calc(100vw - 538px));
+        top: 86px;
+        width: 510px;
+        height: 492px;
+        background: #1e1e1e;
+        color: #e8e8e8;
+      }
+
+      #window-terminal .titlebar {
+        background: #252526;
+        color: #e8e8e8;
+        border-color: #333;
+      }
+
+      #window-receipts {
+        left: 190px;
+        top: min(430px, calc(100vh - 390px));
+        width: min(700px, calc(100vw - 230px));
+        height: 360px;
+      }
+
+      #window-providers {
+        right: 28px;
+        bottom: 68px;
+        width: 360px;
+        height: 360px;
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 12px;
         color: var(--muted);
         font-size: 12px;
       }
-      main {
+
+      .app-grid {
         display: grid;
-        grid-template-columns: minmax(320px, 1fr) minmax(360px, 1fr) minmax(240px, 280px);
-        gap: 0;
-        height: calc(100vh - 53px);
-      }
-      .provider {
-        background: var(--panel);
-        border: 1px solid var(--border);
-        border-radius: 4px;
-        padding: 8px 12px;
-        margin-bottom: 6px;
-        display: grid;
-        grid-template-columns: 1fr auto;
-        gap: 2px 8px;
-      }
-      .provider-label {
-        font-size: 13px;
-      }
-      .provider-meta {
-        font-size: 10px;
-        color: var(--muted);
-      }
-      .provider-pill {
-        font-size: 10px;
-        text-transform: uppercase;
-        letter-spacing: 1px;
-        align-self: center;
-      }
-      .provider-pill.up {
-        color: var(--pass);
-      }
-      .provider-pill.down {
-        color: var(--fail);
-      }
-      .provider-pill.unknown {
-        color: var(--muted);
-      }
-      .provider-refresh {
-        margin-bottom: 10px;
-        font-size: 10px;
-        color: var(--muted);
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-      }
-      .provider-refresh button {
-        background: transparent;
-        color: var(--accent);
-        border: 1px solid var(--accent);
-        border-radius: 3px;
-        padding: 2px 8px;
-        font-family: inherit;
-        font-size: 10px;
-        cursor: pointer;
-      }
-      .panel {
-        padding: 18px 22px;
-        overflow-y: auto;
-      }
-      .panel + .panel {
-        border-left: 1px solid var(--border);
-      }
-      .panel h2 {
-        margin: 0 0 12px 0;
-        font-size: 13px;
-        text-transform: uppercase;
-        letter-spacing: 1px;
-        color: var(--accent);
-      }
-      .commands {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
         gap: 10px;
       }
-      .category {
-        margin: 0 0 16px 0;
-      }
-      .category-title {
-        margin: 0 0 8px 0;
-        color: var(--muted);
-        font-size: 11px;
-        letter-spacing: 1px;
-        text-transform: uppercase;
-      }
+
       .cmd {
-        background: var(--panel);
-        border: 1px solid var(--border);
-        border-radius: 6px;
-        padding: 12px 14px;
-        min-height: 156px;
+        min-height: 152px;
+        padding: 12px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: #fff;
         display: flex;
         flex-direction: column;
         justify-content: space-between;
       }
+
+      .cmd:hover {
+        border-color: rgba(0, 120, 212, 0.36);
+      }
+
       .cmd-head {
-        display: flex;
-        justify-content: space-between;
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        gap: 9px;
         align-items: center;
-        gap: 12px;
       }
+
+      .cmd .app-icon {
+        width: 34px;
+        height: 34px;
+        border-radius: 8px;
+        font-size: 11px;
+      }
+
       .cmd-label {
-        font-weight: 600;
-        font-size: 14px;
+        font-size: 13px;
+        font-weight: 700;
       }
-      .cmd-icon {
-        width: 26px;
-        height: 26px;
-        border: 1px solid var(--border);
-        border-radius: 4px;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        color: var(--accent);
-        margin-right: 8px;
-      }
+
       .cmd-tier {
-        font-size: 10px;
         color: var(--muted);
         text-transform: uppercase;
-        letter-spacing: 1px;
+        font-size: 9px;
+        letter-spacing: 0.08em;
       }
+
       .cmd-desc {
-        margin: 6px 0 10px 0;
+        margin: 9px 0 10px;
         color: var(--muted);
-        font-size: 12px;
+        font-size: 11px;
+        line-height: 1.35;
       }
+
       .cmd-row {
         display: flex;
-        justify-content: space-between;
         align-items: center;
-        gap: 12px;
+        justify-content: space-between;
+        gap: 10px;
       }
+
       .cmd-script {
-        font-size: 11px;
+        max-width: 145px;
         color: var(--muted);
+        font-family: Consolas, monospace;
+        font-size: 10px;
+        overflow-wrap: anywhere;
       }
-      button.run {
+
+      button.run,
+      .chrome-button {
+        border: 1px solid var(--blue);
+        border-radius: 5px;
         background: transparent;
-        color: var(--accent);
-        border: 1px solid var(--accent);
-        border-radius: 4px;
-        padding: 4px 12px;
-        font-family: inherit;
-        font-size: 12px;
+        color: var(--blue);
+        padding: 5px 10px;
+        font-size: 11px;
         cursor: pointer;
       }
-      button.run:hover {
-        background: var(--accent);
-        color: var(--bg);
+
+      button.run:hover,
+      .chrome-button:hover {
+        background: var(--blue);
+        color: white;
       }
+
       button.run:disabled {
-        opacity: 0.4;
+        opacity: 0.45;
         cursor: wait;
       }
+
       .status {
-        font-size: 11px;
-        margin-top: 8px;
+        min-height: 17px;
+        margin-top: 7px;
         color: var(--muted);
+        font-family: Consolas, monospace;
+        font-size: 10px;
       }
+
       .status.pass {
         color: var(--pass);
       }
+
       .status.fail {
         color: var(--fail);
       }
+
       .status.running {
         color: var(--running);
       }
-      .receipts {
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-      }
-      .receipt {
-        background: var(--panel);
-        border: 1px solid var(--border);
-        border-radius: 4px;
-        padding: 8px 12px;
-        cursor: pointer;
+
+      .terminal {
+        height: 100%;
         display: grid;
-        grid-template-columns: 1fr auto;
-        gap: 4px 12px;
+        grid-template-rows: 1fr auto auto;
+        gap: 10px;
       }
-      .receipt:hover {
-        border-color: var(--accent);
-      }
-      .receipt.selected {
-        border-color: var(--accent);
-      }
-      .receipt-label {
-        font-size: 13px;
-      }
-      .receipt-meta {
-        font-size: 10px;
-        color: var(--muted);
-        text-align: right;
-      }
-      .receipt-result {
-        font-size: 10px;
-        text-transform: uppercase;
-        letter-spacing: 1px;
-      }
-      .receipt-result.pass {
-        color: var(--pass);
-      }
-      .receipt-result.fail {
-        color: var(--fail);
-      }
-      .detail {
-        margin-top: 14px;
+
+      .terminal-screen {
+        min-height: 240px;
         padding: 12px;
-        background: var(--panel);
-        border: 1px solid var(--border);
-        border-radius: 4px;
-        font-size: 11px;
-      }
-      .detail h3 {
-        margin: 0 0 8px 0;
+        border: 1px solid #333;
+        border-radius: 7px;
+        background: #0b0d10;
+        color: #c7f7d4;
+        overflow: auto;
+        font-family: Consolas, monospace;
         font-size: 12px;
-        color: var(--accent);
+        line-height: 1.42;
       }
-      .detail pre {
-        margin: 6px 0 0 0;
+
+      .terminal-screen pre {
+        margin: 0;
         white-space: pre-wrap;
         word-break: break-word;
-        max-height: 280px;
-        overflow-y: auto;
-        background: var(--bg);
-        padding: 8px;
-        border-radius: 3px;
+      }
+
+      .terminal-input {
+        height: 36px;
+        padding: 0 10px;
+        border: 1px solid #333;
+        border-radius: 7px;
+        background: #0b0d10;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        align-items: center;
+        gap: 8px;
+        color: #c7f7d4;
+        font-family: Consolas, monospace;
+        font-size: 12px;
+      }
+
+      .terminal-input input {
+        min-width: 0;
+        border: 0;
+        outline: 0;
+        background: transparent;
+        color: #c7f7d4;
+        font-family: Consolas, monospace;
+      }
+
+      .terminal-actions {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+        gap: 8px;
+      }
+
+      .receipts,
+      .providers {
+        display: flex;
+        flex-direction: column;
+        gap: 7px;
+      }
+
+      .receipt,
+      .provider {
+        padding: 9px 10px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: #fff;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 4px 10px;
+      }
+
+      .receipt {
+        cursor: pointer;
+      }
+
+      .receipt:hover,
+      .receipt.selected {
+        border-color: rgba(0, 120, 212, 0.38);
+      }
+
+      .receipt-label,
+      .provider-label {
+        font-size: 12px;
+      }
+
+      .receipt-meta,
+      .provider-meta {
+        color: var(--muted);
+        font-size: 10px;
+      }
+
+      .receipt-result,
+      .provider-pill {
+        align-self: center;
+        text-transform: uppercase;
+        font-size: 10px;
+        letter-spacing: 0.08em;
+      }
+
+      .receipt-result.pass,
+      .provider-pill.up {
+        color: var(--pass);
+      }
+
+      .receipt-result.fail,
+      .provider-pill.down {
+        color: var(--fail);
+      }
+
+      .provider-pill.unknown {
+        color: var(--muted);
+      }
+
+      .detail {
+        margin-top: 12px;
+        padding: 12px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--paper2);
+        font-family: Consolas, monospace;
         font-size: 11px;
       }
+
+      .detail h3 {
+        margin: 0 0 8px;
+        color: var(--blue);
+        font-size: 12px;
+      }
+
+      .detail pre {
+        max-height: 190px;
+        margin: 7px 0 0;
+        padding: 8px;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+        background: #fff;
+        border-radius: 4px;
+      }
+
+      .taskbar {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 50px;
+        padding: 5px 10px;
+        border-top: 1px solid rgba(0, 0, 0, 0.16);
+        background: rgba(238, 241, 244, 0.92);
+        backdrop-filter: blur(14px);
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        z-index: 300;
+      }
+
+      .taskbar-center {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .taskbar button {
+        width: 39px;
+        height: 39px;
+        border: 1px solid transparent;
+        border-radius: 9px;
+        background: transparent;
+        color: #1f2933;
+        cursor: pointer;
+        font-family: Consolas, monospace;
+        font-weight: 700;
+      }
+
+      .taskbar button:hover,
+      .taskbar button.active {
+        background: rgba(0, 0, 0, 0.06);
+      }
+
+      .taskbar button.active {
+        border-bottom: 3px solid var(--blue);
+      }
+
+      .tray {
+        justify-self: end;
+        padding: 0 10px;
+        font-size: 12px;
+        text-align: right;
+      }
+
+      .start-menu {
+        position: absolute;
+        left: 50%;
+        bottom: 50px;
+        transform: translateX(-50%);
+        width: min(520px, calc(100vw - 28px));
+        height: min(610px, calc(100vh - 84px));
+        padding: 16px;
+        border: 1px solid var(--line);
+        border-radius: 12px 12px 0 0;
+        background: rgba(255, 255, 255, 0.96);
+        backdrop-filter: blur(18px);
+        box-shadow: 0 -12px 42px rgba(0, 0, 0, 0.18);
+        z-index: 320;
+      }
+
+      .search-box {
+        height: 42px;
+        padding: 0 12px;
+        border: 1px solid #d1d5db;
+        border-radius: 7px;
+        background: #f1f3f5;
+        color: var(--muted);
+        display: flex;
+        align-items: center;
+        margin-bottom: 18px;
+        font-size: 12px;
+      }
+
+      .start-title {
+        margin: 0 0 12px;
+        color: #4b5563;
+        font-size: 12px;
+        font-weight: 700;
+      }
+
+      .start-grid {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 8px;
+      }
+
+      .start-grid button {
+        min-height: 72px;
+        border: 0;
+        border-radius: 8px;
+        background: transparent;
+        color: #1f2933;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        cursor: pointer;
+      }
+
+      .start-grid button:hover {
+        background: rgba(0, 0, 0, 0.05);
+      }
+
       .empty {
         color: var(--muted);
         font-size: 12px;
         font-style: italic;
       }
+
+      @media (max-width: 900px) {
+        body {
+          overflow: auto;
+        }
+
+        .desktop {
+          min-height: 100vh;
+          height: auto;
+          padding-bottom: 66px;
+        }
+
+        .wall-clock {
+          display: none;
+        }
+
+        .desktop-icons {
+          width: auto;
+          grid-template-columns: repeat(4, minmax(70px, 1fr));
+        }
+
+        .window {
+          position: relative;
+          left: auto !important;
+          right: auto !important;
+          top: auto !important;
+          bottom: auto !important;
+          width: 100% !important;
+          height: auto !important;
+          min-height: 300px;
+          margin-top: 14px;
+        }
+
+        .taskbar {
+          position: fixed;
+        }
+      }
     </style>
   </head>
   <body>
-    <header>
-      <h1>AetherDesk</h1>
-      <span class="sub">Operator Shell v1 - local only - 127.0.0.1</span>
-    </header>
-    <main>
-      <section class="panel">
-        <h2>App Launcher</h2>
-        <div id="commands" class="commands"><p class="empty">loading...</p></div>
+    <main class="desktop">
+      <section class="wall-clock">
+        <div class="greeting" id="greeting">AETHERDESK</div>
+        <div class="time" id="clock-time">--:--</div>
+        <div class="date" id="clock-date">local operator desktop</div>
       </section>
-      <section class="panel">
-        <h2>GeoSeal Receipts</h2>
-        <div id="receipts" class="receipts"><p class="empty">no runs yet</p></div>
-        <div id="detail"></div>
+
+      <section class="desktop-icons" id="desktop-icons">
+        <button class="desktop-icon" data-open="launcher">
+          <span class="app-icon">AP</span>
+          <span class="label">Apps</span>
+        </button>
+        <button class="desktop-icon" data-open="terminal">
+          <span class="app-icon">KT</span>
+          <span class="label">Kimi Terminal</span>
+        </button>
+        <button class="desktop-icon" data-open="receipts">
+          <span class="app-icon">RC</span>
+          <span class="label">Receipts</span>
+        </button>
+        <button class="desktop-icon" data-open="providers">
+          <span class="app-icon">PV</span>
+          <span class="label">Providers</span>
+        </button>
       </section>
-      <section class="panel">
-        <h2>Provider Status</h2>
-        <div class="provider-refresh">
-          <span id="provider-stamp">never</span>
-          <button id="refresh-providers">Refresh</button>
+
+      <section class="window active" id="window-launcher" data-app="launcher">
+        <div class="titlebar">
+          <div class="title"><span class="app-icon">AP</span><span>Apps</span></div>
+          <div class="controls">
+            <button class="control" data-open="launcher" title="Show">-</button>
+            <button class="control" data-open="launcher" title="Focus">□</button>
+            <button class="control close" data-close="launcher" title="Close">x</button>
+          </div>
         </div>
-        <div id="providers"><p class="empty">checking...</p></div>
+        <div class="window-body">
+          <div class="toolbar">
+            <span>All systems run through bounded apps.</span>
+            <button class="chrome-button" data-open="terminal">Open Terminal</button>
+          </div>
+          <div id="commands" class="app-grid"><p class="empty">loading...</p></div>
+        </div>
       </section>
+
+      <section class="window" id="window-terminal" data-app="terminal">
+        <div class="titlebar">
+          <div class="title"><span class="app-icon">KT</span><span>Kimi Terminal</span></div>
+          <div class="controls">
+            <button class="control" data-open="terminal" title="Show">-</button>
+            <button class="control" data-open="terminal" title="Focus">□</button>
+            <button class="control close" data-close="terminal" title="Close">x</button>
+          </div>
+        </div>
+        <div class="window-body">
+          <div class="terminal">
+            <div class="terminal-screen" id="terminal-screen">
+              <pre>AetherDesk Terminal
+adapter: Kimi shell visual layer
+boundary: allowlisted app actions only
+
+commands: help, apps, open apps, open receipts, run instrument_play, clear</pre>
+            </div>
+            <label class="terminal-input">
+              <span>kimi&gt;</span>
+              <input id="terminal-input" autocomplete="off" spellcheck="false" value="help" />
+            </label>
+            <div class="terminal-actions" id="terminal-actions"></div>
+            <div class="status" data-terminal-status></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="window hidden" id="window-receipts" data-app="receipts">
+        <div class="titlebar">
+          <div class="title"><span class="app-icon">RC</span><span>GeoSeal Receipts</span></div>
+          <div class="controls">
+            <button class="control" data-open="receipts" title="Show">-</button>
+            <button class="control" data-open="receipts" title="Focus">□</button>
+            <button class="control close" data-close="receipts" title="Close">x</button>
+          </div>
+        </div>
+        <div class="window-body">
+          <div id="receipts" class="receipts"><p class="empty">no runs yet</p></div>
+          <div id="detail"></div>
+        </div>
+      </section>
+
+      <section class="window hidden" id="window-providers" data-app="providers">
+        <div class="titlebar">
+          <div class="title"><span class="app-icon">PV</span><span>Provider Status</span></div>
+          <div class="controls">
+            <button class="control" data-open="providers" title="Show">-</button>
+            <button class="control" data-open="providers" title="Focus">□</button>
+            <button class="control close" data-close="providers" title="Close">x</button>
+          </div>
+        </div>
+        <div class="window-body">
+          <div class="toolbar">
+            <span id="provider-stamp">never</span>
+            <button id="refresh-providers" class="chrome-button">Refresh</button>
+          </div>
+          <div id="providers" class="providers"><p class="empty">checking...</p></div>
+        </div>
+      </section>
+
+      <section class="start-menu hidden" id="start-menu">
+        <div class="search-box">Search apps, tools, receipts</div>
+        <div class="start-title">Pinned</div>
+        <div class="start-grid" id="start-grid"></div>
+      </section>
+
+      <nav class="taskbar" id="taskbar">
+        <div></div>
+        <div class="taskbar-center">
+          <button id="start-button" title="Start">AD</button>
+          <button data-open="launcher" class="active" title="Apps">AP</button>
+          <button data-open="terminal" title="Kimi Terminal">KT</button>
+          <button data-open="receipts" title="Receipts">RC</button>
+          <button data-open="providers" title="Providers">PV</button>
+        </div>
+        <div class="tray" id="tray-clock">--:--</div>
+      </nav>
     </main>
 
     <script>
       const $ = (sel) => document.querySelector(sel);
+      const $$ = (sel) => Array.from(document.querySelectorAll(sel));
       const cmdsEl = $('#commands');
       const receiptsEl = $('#receipts');
       const detailEl = $('#detail');
+      const terminalEl = $('#terminal-screen');
+      const terminalInput = $('#terminal-input');
+      const terminalStatusEl = $('[data-terminal-status]');
+      const desktopIconsEl = $('#desktop-icons');
+      const startGridEl = $('#start-grid');
+      const terminalActionIds = ['chemistry_lookup', 'token_lookup', 'instrument_play', 'rosetta_demo', 'forge_demo'];
+      let z = 10;
+      let lastCommands = [];
+      let terminalLog =
+        'AetherDesk Terminal\nadapter: Kimi shell visual layer\nboundary: allowlisted app actions only\n\ncommands: help, apps, open apps, open receipts, run instrument_play, clear';
+
+      function tickClock() {
+        const now = new Date();
+        const time = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        $('#clock-time').textContent = time;
+        $('#tray-clock').innerHTML = `${time}<br>${now.toLocaleDateString([], { month: 'numeric', day: 'numeric' })}`;
+        $('#clock-date').textContent = now.toLocaleDateString([], {
+          weekday: 'long',
+          month: 'long',
+          day: 'numeric',
+          year: 'numeric',
+        });
+        const h = now.getHours();
+        $('#greeting').textContent = h < 12 ? 'GOOD MORNING' : h < 17 ? 'GOOD AFTERNOON' : 'GOOD EVENING';
+      }
+
+      function setActive(app) {
+        $$('.window').forEach((w) => w.classList.remove('active'));
+        $(`#window-${app}`)?.classList.add('active');
+        $$('#taskbar [data-open]').forEach((b) => b.classList.toggle('active', b.dataset.open === app));
+      }
+
+      function openApp(app) {
+        const win = $(`#window-${app}`);
+        if (!win) return;
+        win.classList.remove('hidden');
+        win.style.zIndex = String(++z);
+        setActive(app);
+        $('#start-menu').classList.add('hidden');
+      }
+
+      function closeApp(app) {
+        const win = $(`#window-${app}`);
+        if (win) win.classList.add('hidden');
+        $(`#taskbar [data-open="${app}"]`)?.classList.remove('active');
+      }
+
+      function bindChrome() {
+        $$('[data-open]').forEach((el) => el.addEventListener('click', () => openApp(el.dataset.open)));
+        $$('[data-close]').forEach((el) => el.addEventListener('click', () => closeApp(el.dataset.close)));
+        $$('.window').forEach((w) => {
+          w.addEventListener('pointerdown', () => {
+            w.style.zIndex = String(++z);
+            setActive(w.dataset.app);
+          });
+        });
+        $('#start-button').addEventListener('click', (e) => {
+          e.stopPropagation();
+          $('#start-menu').classList.toggle('hidden');
+        });
+        document.addEventListener('click', (e) => {
+          if (!$('#start-menu').contains(e.target) && e.target !== $('#start-button')) {
+            $('#start-menu').classList.add('hidden');
+          }
+        });
+        terminalInput.addEventListener('keydown', (e) => {
+          if (e.key !== 'Enter') return;
+          e.preventDefault();
+          const text = terminalInput.value.trim();
+          terminalInput.value = '';
+          handleTerminal(text);
+        });
+      }
 
       async function loadCommands() {
         const r = await fetch('/api/commands').then((r) => r.json());
+        lastCommands = r.commands || [];
+        renderLauncher(lastCommands);
+        renderDesktopApps(lastCommands);
+        renderStartMenu(lastCommands);
+        renderTerminalActions(lastCommands);
+      }
+
+      function renderLauncher(commands) {
         cmdsEl.innerHTML = '';
-        const groups = new Map();
-        for (const c of r.commands) {
-          const key = c.category || 'Commands';
-          if (!groups.has(key)) groups.set(key, []);
-          groups.get(key).push(c);
-        }
-        const order = ['Tools', 'Build', 'Checks', 'Benchmarks', 'Research', 'Commands'];
-        const sortedGroups = [...groups.keys()].sort((a, b) => {
-          const ia = order.includes(a) ? order.indexOf(a) : order.length;
-          const ib = order.includes(b) ? order.indexOf(b) : order.length;
-          return ia === ib ? a.localeCompare(b) : ia - ib;
-        });
-        for (const group of sortedGroups) {
-          const wrap = document.createElement('div');
-          wrap.className = 'category';
-          wrap.innerHTML = `<h3 class="category-title">${escapeHtml(group)}</h3><div class="commands"></div>`;
-          const grid = wrap.querySelector('.commands');
-          for (const c of groups.get(group)) {
-          const div = document.createElement('div');
-          div.className = 'cmd';
-          div.innerHTML = `
-            <div class="cmd-head">
-              <div class="cmd-label"><span class="cmd-icon">${iconGlyph(c.icon)}</span>${escapeHtml(c.label)}</div>
-              <div class="cmd-tier">${c.risk_tier}</div>
-            </div>
-            <div class="cmd-desc">${escapeHtml(c.description)}</div>
-            <div class="cmd-row">
-              <code class="cmd-script">npm run ${c.npm_script}</code>
-              <button class="run" data-id="${c.id}">Run</button>
-            </div>
-            <div class="status" id="status-${c.id}"></div>
-          `;
-            grid.appendChild(div);
-          }
-          cmdsEl.appendChild(wrap);
-        }
+        for (const c of orderedCommands(commands)) cmdsEl.appendChild(commandCard(c));
         cmdsEl.querySelectorAll('button.run').forEach((b) => {
           b.addEventListener('click', () => runCommand(b.dataset.id, b));
         });
+      }
+
+      function renderDesktopApps(commands) {
+        desktopIconsEl.querySelectorAll('[data-command-icon]').forEach((n) => n.remove());
+        for (const c of orderedCommands(commands)) {
+          const button = document.createElement('button');
+          button.className = 'desktop-icon';
+          button.dataset.commandIcon = c.id;
+          button.innerHTML = `<span class="app-icon">${iconGlyph(c.icon)}</span><span class="label">${escapeHtml(shortLabel(c.label))}</span>`;
+          button.addEventListener('dblclick', () => runCommand(c.id, button));
+          button.addEventListener('click', () => openApp('launcher'));
+          desktopIconsEl.appendChild(button);
+        }
+      }
+
+      function renderStartMenu(commands) {
+        startGridEl.innerHTML = '';
+        const pinned = [
+          { label: 'Apps', icon: 'AP', open: 'launcher' },
+          { label: 'Terminal', icon: 'KT', open: 'terminal' },
+          { label: 'Receipts', icon: 'RC', open: 'receipts' },
+          { label: 'Providers', icon: 'PV', open: 'providers' },
+          ...orderedCommands(commands).slice(0, 6).map((c) => ({ label: shortLabel(c.label), icon: iconGlyph(c.icon), run: c.id })),
+        ];
+        for (const item of pinned) {
+          const b = document.createElement('button');
+          b.innerHTML = `<span class="app-icon">${escapeHtml(item.icon)}</span><span>${escapeHtml(item.label)}</span>`;
+          b.addEventListener('click', () => (item.open ? openApp(item.open) : runCommand(item.run, b)));
+          startGridEl.appendChild(b);
+        }
+      }
+
+      function renderTerminalActions(commands) {
+        const wrap = $('#terminal-actions');
+        wrap.innerHTML = '';
+        const byId = new Map(commands.map((c) => [c.id, c]));
+        for (const id of terminalActionIds) {
+          const c = byId.get(id);
+          if (!c) continue;
+          const b = document.createElement('button');
+          b.className = 'run';
+          b.dataset.id = c.id;
+          b.textContent = c.label;
+          b.addEventListener('click', () => runCommand(c.id, b));
+          wrap.appendChild(b);
+        }
+      }
+
+      function orderedCommands(commands) {
+        const order = ['Tools', 'Build', 'Checks', 'Benchmarks', 'Research', 'Commands'];
+        return [...commands].sort((a, b) => {
+          const ia = order.includes(a.category) ? order.indexOf(a.category) : order.length;
+          const ib = order.includes(b.category) ? order.indexOf(b.category) : order.length;
+          return ia === ib ? a.label.localeCompare(b.label) : ia - ib;
+        });
+      }
+
+      function commandCard(c) {
+        const div = document.createElement('div');
+        div.className = 'cmd';
+        div.innerHTML = `
+          <div>
+            <div class="cmd-head">
+              <div class="app-icon">${iconGlyph(c.icon)}</div>
+              <div class="cmd-label">${escapeHtml(c.label)}</div>
+              <div class="cmd-tier">${escapeHtml(c.risk_tier)}</div>
+            </div>
+            <div class="cmd-desc">${escapeHtml(c.description)}</div>
+          </div>
+          <div>
+            <div class="cmd-row">
+              <code class="cmd-script">npm run ${escapeHtml(c.npm_script)}</code>
+              <button class="run" data-id="${escapeHtml(c.id)}">Run</button>
+            </div>
+            <div class="status" id="status-${escapeHtml(c.id)}"></div>
+          </div>`;
+        return div;
       }
 
       async function loadReceipts() {
@@ -371,17 +978,17 @@
           const dur = rec.duration_ms ? Math.round(rec.duration_ms / 1000) + 's' : '';
           div.innerHTML = `
             <div>
-              <div class="receipt-label">${rec.command_label || rec.command_id}</div>
-              <div class="receipt-meta">${rec.started_at || ''} · ${dur}</div>
+              <div class="receipt-label">${escapeHtml(rec.command_label || rec.command_id)}</div>
+              <div class="receipt-meta">${escapeHtml(rec.started_at || '')} - ${dur}</div>
             </div>
-            <div class="receipt-result ${rec.result}">${rec.result}</div>
-          `;
+            <div class="receipt-result ${escapeHtml(rec.result)}">${escapeHtml(rec.result)}</div>`;
           div.addEventListener('click', () => showReceipt(rec.file, div));
           receiptsEl.appendChild(div);
         }
       }
 
       async function showReceipt(file, el) {
+        openApp('receipts');
         receiptsEl.querySelectorAll('.receipt').forEach((d) => d.classList.remove('selected'));
         el.classList.add('selected');
         const r = await fetch('/api/receipts/' + encodeURIComponent(file)).then((r) => r.json());
@@ -392,65 +999,138 @@
         const rec = r.receipt;
         detailEl.innerHTML = `
           <div class="detail">
-            <h3>${rec.command_label}</h3>
-            <div>task_id: ${rec.task_id}</div>
-            <div>command: <code>${rec.command}</code></div>
-            <div>digest: ${rec.command_digest.slice(0, 16)}...</div>
-            <div>result: <span class="receipt-result ${rec.result}">${rec.result}</span> (exit ${rec.exit_code})</div>
+            <h3>${escapeHtml(rec.command_label)}</h3>
+            <div>task_id: ${escapeHtml(rec.task_id)}</div>
+            <div>command: <code>${escapeHtml(rec.command)}</code></div>
+            <div>digest: ${escapeHtml(rec.command_digest.slice(0, 16))}...</div>
+            <div>result: <span class="receipt-result ${escapeHtml(rec.result)}">${escapeHtml(rec.result)}</span> (exit ${escapeHtml(rec.exit_code)})</div>
             <div>duration: ${Math.round(rec.duration_ms / 1000)}s</div>
-            <div>artifact: ${rec.artifact_path}</div>
+            <div>artifact: ${escapeHtml(rec.artifact_path)}</div>
             <h3 style="margin-top:10px">stdout (tail)</h3>
-            <pre>${(rec.stdout_tail || '(empty)').replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' })[c])}</pre>
+            <pre>${escapeHtml(rec.stdout_tail || '(empty)')}</pre>
             <h3 style="margin-top:10px">stderr (tail)</h3>
-            <pre>${(rec.stderr_tail || '(empty)').replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' })[c])}</pre>
-          </div>
-        `;
+            <pre>${escapeHtml(rec.stderr_tail || '(empty)')}</pre>
+          </div>`;
       }
 
       async function runCommand(id, btn) {
         const status = $('#status-' + id);
-        btn.disabled = true;
-        status.textContent = 'running...';
-        status.className = 'status running';
+        const command = lastCommands.find((c) => c.id === id);
+        if (btn) btn.disabled = true;
+        if (status) {
+          status.textContent = 'running...';
+          status.className = 'status running';
+        }
+        appendTerminal(`> run ${id}\nstatus: running`);
+        terminalStatusEl.textContent = `${command?.label || id}: running`;
+        terminalStatusEl.className = 'status running';
         try {
-          const r = await fetch('/api/run/' + encodeURIComponent(id), { method: 'POST' }).then(
-            (r) => r.json()
-          );
-          if (!r.ok) {
-            status.textContent = 'error: ' + (r.error || 'unknown');
-            status.className = 'status fail';
-          } else {
-            status.textContent = `${r.receipt.result} (exit ${r.receipt.exit_code}, ${Math.round(r.receipt.duration_ms / 1000)}s)`;
+          const r = await fetch('/api/run/' + encodeURIComponent(id), { method: 'POST' }).then((r) => r.json());
+          if (!r.ok) throw new Error(r.error || 'unknown');
+          const msg = `${r.receipt.result} (exit ${r.receipt.exit_code}, ${Math.round(r.receipt.duration_ms / 1000)}s)`;
+          if (status) {
+            status.textContent = msg;
             status.className = 'status ' + r.receipt.result;
           }
+          terminalStatusEl.textContent = `${command?.label || id}: ${msg}`;
+          terminalStatusEl.className = 'status ' + r.receipt.result;
+          appendTerminal(`result: ${msg}\nreceipt: ${r.receipt.task_id}\n\n${tail(r.receipt.stdout_tail || '', 1200)}`);
         } catch (err) {
-          status.textContent = 'fetch error: ' + String(err);
-          status.className = 'status fail';
+          const msg = 'error: ' + String(err.message || err);
+          if (status) {
+            status.textContent = msg;
+            status.className = 'status fail';
+          }
+          terminalStatusEl.textContent = msg;
+          terminalStatusEl.className = 'status fail';
+          appendTerminal(msg);
         } finally {
-          btn.disabled = false;
+          if (btn) btn.disabled = false;
           loadReceipts();
         }
       }
 
+      function handleTerminal(text) {
+        if (!text) return;
+        const lower = text.toLowerCase();
+        appendTerminal(`kimi> ${text}`);
+        if (lower === 'clear') {
+          terminalLog = '';
+          paintTerminal();
+          return;
+        }
+        if (lower === 'help') {
+          appendTerminal('help | apps | receipts | providers | open <app> | run <command_id> | clear');
+          return;
+        }
+        if (lower === 'apps') {
+          appendTerminal(lastCommands.map((c) => `${c.id} - ${c.label}`).join('\n'));
+          return;
+        }
+        if (lower === 'receipts') {
+          openApp('receipts');
+          appendTerminal('opened receipts');
+          return;
+        }
+        if (lower === 'providers') {
+          openApp('providers');
+          appendTerminal('opened providers');
+          return;
+        }
+        if (lower.startsWith('open ')) {
+          const app = lower.slice(5).trim();
+          const map = { apps: 'launcher', launcher: 'launcher', terminal: 'terminal', receipts: 'receipts', providers: 'providers' };
+          if (map[app]) {
+            openApp(map[app]);
+            appendTerminal(`opened ${app}`);
+          } else appendTerminal(`unknown app: ${app}`);
+          return;
+        }
+        if (lower.startsWith('run ')) {
+          const id = text.slice(4).trim();
+          if (lastCommands.some((c) => c.id === id)) runCommand(id, null);
+          else appendTerminal(`not allowlisted: ${id}`);
+          return;
+        }
+        appendTerminal('unknown command. type help');
+      }
+
+      function appendTerminal(text) {
+        terminalLog = terminalLog ? `${terminalLog}\n\n${text}` : text;
+        paintTerminal();
+      }
+
+      function paintTerminal() {
+        terminalEl.innerHTML = `<pre>${escapeHtml(terminalLog)}</pre>`;
+        terminalEl.scrollTop = terminalEl.scrollHeight;
+      }
+
       function escapeHtml(s) {
-        return String(s).replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' })[c]);
+        return String(s).replace(/[<>&"]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' })[c]);
+      }
+
+      function tail(s, max) {
+        const text = String(s || '');
+        return text.length <= max ? text : '...[truncated]...\n' + text.slice(text.length - max);
+      }
+
+      function shortLabel(label) {
+        return String(label).replace(/\s*\([^)]*\)/g, '').replace(/Lookup/g, '').replace(/Demo/g, '').trim();
       }
 
       function iconGlyph(name) {
-        return (
-          {
-            agent: 'AG',
-            atom: 'At',
-            chart: 'CH',
-            check: 'OK',
-            faces: '18',
-            forge: 'FG',
-            lattice: 'LX',
-            music: 'CE',
-            test: 'TS',
-            token: 'TK',
-          }[name] || 'SC'
-        );
+        return {
+          agent: 'AG',
+          atom: 'At',
+          chart: 'CH',
+          check: 'OK',
+          faces: '18',
+          forge: 'FG',
+          lattice: 'LX',
+          music: 'CE',
+          test: 'TS',
+          token: 'TK',
+        }[name] || 'SC';
       }
 
       async function loadProviders() {
@@ -467,23 +1147,18 @@
             if (p.kind === 'local-http') {
               statusClass = p.reachable ? 'up' : 'down';
               statusText = p.reachable ? 'up' : 'down';
-              meta = p.reachable
-                ? `${p.latency_ms}ms · ${escapeHtml(new URL(p.url).host)}`
-                : `${escapeHtml(p.error || 'unreachable')}`;
+              meta = p.reachable ? `${p.latency_ms}ms - ${escapeHtml(new URL(p.url).host)}` : `${escapeHtml(p.error || 'unreachable')}`;
             } else {
               statusClass = p.has_secret ? 'up' : 'unknown';
               statusText = p.has_secret ? 'env set' : 'no env';
-              meta = p.has_secret
-                ? `via ${escapeHtml(p.secret_env_var)}`
-                : `checked: ${escapeHtml(p.env_vars_checked.join(', '))}`;
+              meta = p.has_secret ? `via ${escapeHtml(p.secret_env_var)}` : `checked: ${escapeHtml(p.env_vars_checked.join(', '))}`;
             }
             div.innerHTML = `
               <div>
                 <div class="provider-label">${escapeHtml(p.label)}</div>
                 <div class="provider-meta">${meta}</div>
               </div>
-              <div class="provider-pill ${statusClass}">${statusText}</div>
-            `;
+              <div class="provider-pill ${statusClass}">${statusText}</div>`;
             providersEl.appendChild(div);
           }
         } catch (err) {
@@ -492,7 +1167,9 @@
       }
 
       $('#refresh-providers').addEventListener('click', loadProviders);
-
+      bindChrome();
+      tickClock();
+      setInterval(tickClock, 30000);
       loadCommands();
       loadReceipts();
       loadProviders();


### PR DESCRIPTION
## Summary
- Restyle AetherDesk into a desktop shell inspired by the Kimi terminal zip: wallpaper, centered clock, taskbar, start menu, app icons, and app windows.
- Add a Kimi Terminal app surface with a bounded prompt: help/apps/open/run commands only route to allowlisted AetherDesk actions.
- Keep receipts/providers/app launcher wired to the existing local API and command allowlist.

## Verification
- npx vitest run tests/aetherdesk/server.test.ts
- Playwright browser check: 14 desktop icons, 4 windows, start menu visible, terminal ran instrument_play with pass receipt
- Screenshot: artifacts/aetherdesk-kimi-desktop.png