### PR TITLE
feat(desktop-access): one governed registry → all AI access points, Rubik's cube as controller

### DIFF
--- a/python/scbe/desktop_access.py
+++ b/python/scbe/desktop_access.py
@@ -1,0 +1,303 @@
+"""desktop_access: one governed action registry, exposed through all three AI access points.
+
+An AI can operate a desktop three ways (cheapest + most reliable first):
+  1. ACTION API / MCP  -- the AI calls a named verb (open_app, run_allowed_command) directly.
+  2. DOM / accessibility -- the AI clicks the real element by selector + ARIA role/label.
+  3. PIXELS / set-of-marks -- the AI picks a numbered mark overlaid on a screenshot.
+
+This is the SCBE control plane: ONE registry of typed, allowlist-classed actions, surfaced all
+three ways off the same definitions, so the same action is reachable as a verb, a selector, or a
+mark. EVERY invocation goes through the allowlist (safe / guarded / denied) + a destructive-command
+screen (the never-delete rule, in-system) and emits a SHA-256 sealed receipt. The reliable channel
+(the action API) is what should actually drive your own apps; DOM and pixels are for surfaces you
+did not instrument (un-wired apps, then canvas/emulator regions).
+
+Governance honesty: the deterministic gate here is the allowlist + destructive screen. If the SCBE
+L13 intent gate is importable it is layered on top of any free-text command; otherwise the allowlist
++ destructive screen stand alone. This is exactly the allowlist model the AetherDesk shell already
+uses, made governable and multi-channel.
+
+    from python.scbe.desktop_access import default_registry
+    reg = default_registry()
+    reg.invoke("open_app", {"app": "terminal"})       # the verb channel (governed + sealed)
+    reg.access_points("open_app")                      # the same action, all three ways
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+# destructive / broad-scope commands refused outright, no confirm overrides (never-delete rule)
+_DESTRUCTIVE = re.compile(
+    r"\b(rm\s+-rf|rm\s+-fr|rmdir\s+/s|del\s+/|format\b|mkfs|dd\s+if=|shutdown|reboot|"
+    r":\(\)\{|>\s*/dev/sd|chmod\s+-r\s+000)\b|wipe|fdisk",
+    re.IGNORECASE,
+)
+
+
+def _seal(rec: dict) -> str:
+    body = {k: v for k, v in rec.items() if k != "seal"}
+    return hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def _gate(text: str) -> Optional[str]:
+    """Best-effort SCBE L13 intent gate over free-text; None if the gate is not importable."""
+    for mod in ("scbe_aethermoore", "src.scbe_aethermoore"):
+        try:
+            scan = __import__(mod, fromlist=["scan"]).scan
+            return scan(text)["decision"]
+        except Exception:
+            continue
+    return None
+
+
+@dataclass(frozen=True)
+class Action:
+    """One desktop action, defined once and surfaced through all three access points."""
+
+    name: str
+    summary: str
+    params: Dict[str, str]  # param name -> type ("string"/"int")
+    safety: str  # "safe" | "guarded" | "denied"
+    selector: str  # DOM selector for the structure channel
+    role: str  # ARIA role
+    label: str  # ARIA / accessible name
+    handler: Callable[[Dict[str, Any]], Any]
+    text_param: Optional[str] = None  # which param carries free text to gate (e.g. a command)
+
+
+@dataclass
+class ActionRegistry:
+    actions: Dict[str, Action] = field(default_factory=dict)
+    transcript: List[dict] = field(default_factory=list)
+
+    def register(self, action: Action) -> None:
+        self.actions[action.name] = action
+
+    # --- access point 1: the verb / action API (governed + sealed) ---------------
+    def invoke(self, name: str, params: Optional[Dict[str, Any]] = None, confirm: Optional[str] = None) -> dict:
+        params = params or {}
+        action = self.actions.get(name)
+        rec: dict = {"hop": len(self.transcript) + 1, "action": name, "params": params, "decision": "", "result": ""}
+        if action is None:
+            rec.update(decision="NO_ACTION", result="no action %r" % name)
+        elif action.safety == "denied":
+            rec.update(decision="DENIED", result="action %r is denied" % name)
+        else:
+            text = str(params.get(action.text_param, "")) if action.text_param else ""
+            gate = _gate(text) if text else None
+            if text and _DESTRUCTIVE.search(text):
+                rec.update(decision="REFUSED", result="destructive/broad-scope command blocked: %r" % text)
+            elif gate in ("DENY", "ESCALATE"):
+                rec.update(decision="REFUSED", result="L13 gate %s on %r" % (gate, text), gate=gate)
+            elif action.safety == "guarded" and not confirm:
+                rec.update(decision="NEEDS_CONFIRM", result="guarded action; pass confirm='<reason>'")
+            else:
+                rec.update(decision="ALLOWED", result=action.handler(params), gate=gate)
+        rec["seal"] = _seal(rec)
+        self.transcript.append(rec)
+        return rec
+
+    def verify(self) -> bool:
+        return all(r.get("seal") == _seal(r) for r in self.transcript)
+
+    # --- access point 1 (schema): MCP tools ---------------------------------------
+    def mcp_tools(self) -> List[dict]:
+        return [
+            {
+                "name": a.name,
+                "description": a.summary,
+                "safety": a.safety,
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {p: {"type": t} for p, t in a.params.items()},
+                    "required": list(a.params),
+                },
+            }
+            for a in self.actions.values()
+            if a.safety != "denied"
+        ]
+
+    # --- access point 2: DOM / accessibility manifest -----------------------------
+    def dom_manifest(self) -> Dict[str, dict]:
+        return {a.name: {"selector": a.selector, "role": a.role, "label": a.label} for a in self.actions.values()}
+
+    # --- access point 3: pixels / set-of-marks ------------------------------------
+    def set_of_marks(self) -> List[dict]:
+        return [
+            {"mark": i, "action": a.name, "label": a.label, "selector": a.selector}
+            for i, a in enumerate(self.actions.values(), start=1)
+        ]
+
+    # --- the unifying view: one action, all three access points -------------------
+    def access_points(self, name: str) -> dict:
+        a = self.actions[name]
+        marks = {m["action"]: m["mark"] for m in self.set_of_marks()}
+        return {
+            "action": name,
+            "verb": {"call": name, "params": list(a.params), "safety": a.safety},  # channel 1
+            "dom": {"selector": a.selector, "role": a.role, "label": a.label},  # channel 2
+            "pixels": {"mark": marks[name], "label": a.label},  # channel 3
+        }
+
+
+# --- a representative AetherDesk-style action set -------------------------------
+_APPS = ["terminal", "files", "editor", "browser", "settings"]
+_ALLOWED_CMDS = {"help", "apps", "ls", "pwd", "echo", "date", "whoami"}
+
+
+def default_registry() -> ActionRegistry:
+    reg = ActionRegistry()
+
+    def list_apps(_p):
+        return {"apps": _APPS}
+
+    def open_app(p):
+        app = p.get("app", "")
+        return ("opened %s" % app) if app in _APPS else "no app %r" % app
+
+    def list_windows(_p):
+        return {"windows": []}
+
+    def focus_window(p):
+        return "focused window %s" % p.get("id", "")
+
+    def run_allowed_command(p):
+        cmd = str(p.get("command", "")).strip()
+        head = cmd.split()[0] if cmd else ""
+        return ("ran: %s" % cmd) if head in _ALLOWED_CMDS else "command %r not on the allowlist" % head
+
+    def save_file(p):
+        return "saved %s (%d bytes)" % (p.get("path", ""), len(str(p.get("content", ""))))
+
+    def shutdown(_p):
+        return "should never run"
+
+    reg.register(Action("list_apps", "List installed apps", {}, "safe", "#start-menu", "list", "Start menu", list_apps))
+    reg.register(
+        Action(
+            "open_app", "Open an app by name", {"app": "string"}, "safe", "[data-app]", "button", "App icon", open_app
+        )
+    )
+    reg.register(Action("list_windows", "List open windows", {}, "safe", "#taskbar", "list", "Taskbar", list_windows))
+    reg.register(
+        Action(
+            "focus_window",
+            "Focus a window",
+            {"id": "string"},
+            "safe",
+            "[data-win]",
+            "button",
+            "Window tab",
+            focus_window,
+        )
+    )
+    reg.register(
+        Action(
+            "run_allowed_command",
+            "Run an allowlisted terminal command",
+            {"command": "string"},
+            "guarded",
+            "#terminal-input",
+            "textbox",
+            "Terminal",
+            run_allowed_command,
+            text_param="command",
+        )
+    )
+    reg.register(
+        Action(
+            "save_file",
+            "Save content to a path",
+            {"path": "string", "content": "string"},
+            "guarded",
+            "#save",
+            "button",
+            "Save",
+            save_file,
+            text_param="content",
+        )
+    )
+    reg.register(Action("shutdown", "Power off (denied)", {}, "denied", "#power", "button", "Power", shutdown))
+    return reg
+
+
+# --- access point 4: the Rubik's cube as the controller ------------------------
+# Each face-turn SELECTS a desktop action; a twist sequence plays a sequence of governed,
+# sealed actions. The cube steering wheel now steers the DESKTOP, not arithmetic -- so a human
+# (or a speedcuber, or the AI) can "play" the cube to operate the desktop, every turn governed.
+_MOVE_ACTION: Dict[str, tuple] = {
+    "U": ("list_apps", {}),
+    "R": ("open_app", {"app": "terminal"}),
+    "F": ("list_windows", {}),
+    "D": ("focus_window", {"id": "1"}),
+    "L": ("save_file", {"path": "/note", "content": "hi"}),
+    "B": ("run_allowed_command", {"command": "help"}),
+}
+
+
+def cube_moves() -> Dict[str, str]:
+    """The cube controller map: face-turn -> desktop action."""
+    return {m: name for m, (name, _) in _MOVE_ACTION.items()}
+
+
+def play_cube(reg: ActionRegistry, twists: str, confirm: Optional[str] = None) -> dict:
+    """Play a Singmaster twist sequence as DESKTOP actions through the governed registry."""
+    hops: List[dict] = []
+    for raw in twists.replace(",", " ").split():
+        m = raw.strip().upper().rstrip("'")  # face letter; primes ignored for now
+        if m not in _MOVE_ACTION:
+            hops.append({"move": raw, "decision": "UNKNOWN_MOVE", "result": "no action on %r" % raw})
+            continue
+        name, params = _MOVE_ACTION[m]
+        r = reg.invoke(name, params, confirm=confirm)
+        hops.append({"move": raw, "action": name, "decision": r["decision"], "result": r["result"]})
+    return {
+        "twists": twists,
+        "hops": hops,
+        "sealed": reg.verify(),
+        "route": " -> ".join("%s:%s" % (h["move"], h.get("action", "?")) for h in hops),
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    reg = default_registry()
+    print("DESKTOP ACCESS  one registry, three access points  (%d actions)\n" % len(reg.actions))
+    print("== access point 1: VERB / MCP (governed + sealed) ==")
+    for name, params in [
+        ("open_app", {"app": "terminal"}),
+        ("run_allowed_command", {"command": "rm -rf /"}),
+        (
+            "run_allowed_command",
+            {"command": "ls"},
+        ),
+        ("shutdown", {}),
+    ]:
+        r = reg.invoke(name, params if isinstance(params, dict) else {}, confirm="demo")
+        print(
+            "  %-20s -> %-13s %s"
+            % (name + str(params if name == "run_allowed_command" else ""), r["decision"], r["result"])
+        )
+    print("  transcript sealed:", reg.verify())
+    print("\n== access point 2: DOM manifest (sample) ==")
+    print("  open_app ->", reg.dom_manifest()["open_app"])
+    print("\n== access point 3: set-of-marks (sample) ==")
+    print(" ", reg.set_of_marks()[:3])
+    print("\n== the same action, all three ways ==")
+    print("  open_app ->", json.dumps(reg.access_points("open_app")))
+    print("\n== access point 4: the RUBIK'S CUBE as the controller ==")
+    print("  cube map:", cube_moves())
+    cr = play_cube(reg, "U R F B", confirm="cube turn")
+    print("  play 'U R F B' ->", cr["route"])
+    for h in cr["hops"]:
+        print("    %-3s %-20s %-13s %s" % (h["move"], h.get("action", "-"), h["decision"], h["result"]))
+    print("  transcript still sealed:", cr["sealed"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_desktop_access.py
+++ b/tests/test_desktop_access.py
@@ -1,0 +1,92 @@
+"""desktop_access: one governed action registry, surfaced through all three AI access points.
+
+Every invocation goes through the allowlist (safe/guarded/denied) + a destructive-command screen
+(never-delete, no confirm override) and emits a SHA-256 sealed receipt. The same action is
+reachable as a verb (MCP), a DOM selector, and a numbered mark -- all generated off one definition.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.desktop_access import cube_moves, default_registry, play_cube  # noqa: E402
+
+
+def test_verb_channel_governs_and_seals():
+    reg = default_registry()
+    assert len(reg.actions) == 7
+    r = reg.invoke("open_app", {"app": "terminal"})
+    assert r["decision"] == "ALLOWED"
+    assert r["result"] == "opened terminal"
+    assert reg.verify() is True  # receipt is sealed and intact
+
+
+def test_denied_and_unknown_actions_are_refused():
+    reg = default_registry()
+    assert reg.invoke("shutdown", {})["decision"] == "DENIED"
+    assert reg.invoke("nope", {})["decision"] == "NO_ACTION"
+
+
+def test_guarded_action_needs_confirm():
+    reg = default_registry()
+    assert reg.invoke("run_allowed_command", {"command": "ls"})["decision"] == "NEEDS_CONFIRM"
+    ok = reg.invoke("run_allowed_command", {"command": "ls"}, confirm="user asked")
+    assert ok["decision"] == "ALLOWED"
+    assert ok["result"] == "ran: ls"
+
+
+def test_destructive_command_blocked_even_with_confirm():
+    reg = default_registry()
+    r = reg.invoke("run_allowed_command", {"command": "rm -rf /"}, confirm="please")
+    assert r["decision"] == "REFUSED"  # the never-delete screen; confirm cannot override
+    assert "destructive" in r["result"]
+
+
+def test_tampering_with_a_receipt_is_detected():
+    reg = default_registry()
+    reg.invoke("open_app", {"app": "files"})
+    reg.transcript[0]["result"] = "tampered"
+    assert reg.verify() is False  # sealed receipts are tamper-evident
+
+
+def test_all_three_access_points_cover_the_same_actions():
+    reg = default_registry()
+    names = set(reg.actions)
+    # 1. verb / MCP -- excludes the denied action, well-formed schema
+    tools = {t["name"] for t in reg.mcp_tools()}
+    assert tools == names - {"shutdown"}
+    assert all("inputSchema" in t for t in reg.mcp_tools())
+    # 2. DOM manifest -- every action has a selector + role + label
+    dom = reg.dom_manifest()
+    assert set(dom) == names
+    assert all(d["selector"] and d["role"] and d["label"] for d in dom.values())
+    # 3. set-of-marks -- numbered 1..N, one per action
+    marks = reg.set_of_marks()
+    assert [m["mark"] for m in marks] == list(range(1, len(names) + 1))
+    assert {m["action"] for m in marks} == names
+
+
+def test_one_action_reachable_all_three_ways():
+    ap = default_registry().access_points("open_app")
+    assert ap["verb"]["call"] == "open_app"
+    assert ap["dom"]["selector"] == "[data-app]"
+    assert ap["pixels"]["mark"] == 2  # the same action, three coordinates
+
+
+def test_cube_controller_plays_governed_desktop_actions():
+    reg = default_registry()
+    assert cube_moves()["R"] == "open_app"  # a face-turn selects a desktop action
+    r = play_cube(reg, "U R F", confirm="cube turn")  # safe navigation actions
+    assert [h["decision"] for h in r["hops"]] == ["ALLOWED", "ALLOWED", "ALLOWED"]
+    assert r["route"] == "U:list_apps -> R:open_app -> F:list_windows"
+    assert r["sealed"] is True  # every cube-driven action is sealed
+
+
+def test_cube_controller_still_obeys_governance():
+    reg = default_registry()
+    # a guarded action selected by the cube still needs confirm (governance is not bypassed)
+    assert play_cube(reg, "B")["hops"][0]["decision"] == "NEEDS_CONFIRM"
+    # an unknown face is rejected
+    assert play_cube(reg, "Z")["hops"][0]["decision"] == "UNKNOWN_MOVE"


### PR DESCRIPTION
## What — all the access points, governed, with the cube as a controller

For an AI-operable desktop you want **all** the ways in, not one. This is the SCBE control plane: **one registry** of typed, allowlist-classed actions, surfaced **four ways** off the same definitions — and every invocation runs through the allowlist (`safe`/`guarded`/`denied`) + a destructive-command screen (the never-delete rule, in-system) + a **SHA-256 sealed receipt**.

| # | access point | how the AI operates |
|---|---|---|
| 1 | **Verb / MCP** | `invoke(name, params)`; `mcp_tools()` publishes typed tools — cheapest, most reliable |
| 2 | **DOM / a11y** | `dom_manifest()`: action → `{selector, role, label}` for Playwright / browse-use |
| 3 | **Pixels / marks** | `set_of_marks()`: numbered marks for screenshot / computer-use agents |
| 4 | **🧩 The Rubik's cube** | `play_cube(twists)`: each face-turn selects an action; a twist sequence plays governed, sealed actions |

`access_points(name)` returns the same action reachable all three programmatic ways at once.

## The cube steers the desktop

```
cube map: {U: list_apps, R: open_app, F: list_windows, D: focus_window, L: save_file, B: run_allowed_command}
play 'U R F B' -> U:list_apps -> R:open_app -> F:list_windows -> B:run_allowed_command   (all ALLOWED, sealed)
```

A human, a **speedcuber**, or the AI can *play the cube to operate the desktop* — and the cube **does not bypass governance**: a guarded face still `NEEDS_CONFIRM`, an unknown face is `UNKNOWN_MOVE`.

## Verified by execution

`open_app` → ALLOWED + sealed · a recursive-delete command → **REFUSED** (destructive screen, no confirm override) · `shutdown` → DENIED · guarded `run_allowed_command` → NEEDS_CONFIRM · tampering a receipt → `verify()=False`.

## Honest scope
The deterministic gate is the **allowlist + destructive screen** (the L13 intent gate layers on free-text commands when importable). Access point 1 + the cube are **execution-verified** here; the DOM manifest + set-of-marks are the **descriptors** external agents (a browser, a sandboxed vision model) consume — real data off the same registry. The action set is representative AetherDesk-style; wire in the shell's real allowlist.

## Tests
9 (`tests/test_desktop_access.py`): governed verb channel + sealing, denied/unknown, guarded confirm, destructive blocked-even-with-confirm, receipt tamper-evidence, all-three-access-points coverage, cube controller (governed + still-gated). black / flake8 / ruff clean (120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a governed desktop action registry system supporting multiple interface surfaces: API/verb access, DOM accessibility manifest, visual "set-of-marks," and a cube-style controller interface.
  * Built-in safety guardrails including action allowlists, confirmation requirements for sensitive operations, and pattern-based refusal rules.
  * Added integrity verification via SHA-256 sealed receipts for all action invocations.

* **Tests**
  * Added comprehensive test coverage for registry functionality, governance enforcement, and multi-surface consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->