### PR TITLE
feat(pair-loop): juggling harness — improvise only when needed, route blanks by strength

### DIFF
--- a/python/scbe/pair_loop.py
+++ b/python/scbe/pair_loop.py
@@ -1,0 +1,178 @@
+"""pair_loop: a juggling harness for small/free models -- improvise only when needed, by strength.
+
+The scaffold is the intelligence; the models are commodity hands. A TASK is a TEMPLATE: FIXED tokens
+the harness emits for free (zero model calls) interleaved with BLANKs -- the genuine choice points.
+The harness runs the fixed steps in order and only calls a model at a blank. Three ideas make
+weak/free models actually useful together:
+
+  * IMPROVISE ONLY WHEN NEEDED -- the model is called exactly once per blank (plus retries), never
+    for the fixed structure. Most of a bounded task is mechanical; the model fills only the gaps.
+  * ROUTE BY STRENGTH -- each blank declares the CAPABILITY it needs (count / name / pick / ...) and
+    the harness routes it to the model that is good at THAT, then drops the model's answer into the
+    command slot. If a model is great at counting, let it count the things the system needs counted;
+    its count becomes the value. Play to strengths; the harness reroutes them to commands.
+  * JUGGLE -- like the Fleet Juggling Scheduler: the harness keeps the blanks in the air and throws
+    each to the right free hand; a CHECKER (the catch) accepts or rejects each value against the
+    allowed walls -- a bad guess is just dropped, never corrupting the output.
+
+Models are pluggable callables keyed by capability; the deterministic stubs prove the loop by
+execution. Drop a real free model into a capability slot to measure it on what it is good at.
+
+    from python.scbe.pair_loop import BLANK, Blank, template_level, run_loop, STUBS, accepting_checker
+    lvl = template_level("[1, 2, 3] has ", BLANK, " items", blanks=[Blank("count", ["3"])])
+    run_loop(lvl, STUBS, accepting_checker)["output"]   # -> '[1, 2, 3] has 3 items' (count routed in)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Sequence
+
+BLANK = object()  # the choice-point sentinel: where a model must improvise
+
+Improviser = Callable[[str, str, Sequence[str]], str]  # (goal, output_so_far, allowed) -> value
+Checker = Callable[[str, str, Sequence[str]], bool]  # (output_so_far, proposed, allowed) -> accept?
+
+
+@dataclass
+class Blank:
+    capability: str  # the skill this choice-point needs: "count" | "name" | "pick" | ...
+    allowed: List[str]  # the walls: the values the checker will accept
+
+
+@dataclass
+class Level:
+    name: str
+    goal: str
+    template: List[object]  # fixed strings, with BLANK at choice points
+    blanks: List[Blank]  # one per BLANK, in order
+
+    def fixed_count(self) -> int:
+        return sum(1 for t in self.template if t is not BLANK)
+
+    def blank_count(self) -> int:
+        return sum(1 for t in self.template if t is BLANK)
+
+
+def template_level(
+    *template: object, blanks: Optional[List[Blank]] = None, name: str = "task", goal: str = ""
+) -> Level:
+    blanks = blanks or []
+    n = sum(1 for t in template if t is BLANK)
+    if len(blanks) != n:
+        raise ValueError("template has %d blanks but %d Blank specs given" % (n, len(blanks)))
+    return Level(name=name, goal=goal or name, template=list(template), blanks=blanks)
+
+
+def run_loop(
+    level: Level,
+    routers: Dict[str, Improviser],
+    checker: Checker = None,  # type: ignore[assignment]
+    default: Improviser = None,  # type: ignore[assignment]
+    budget: int = 60,
+) -> dict:
+    """Run the template: emit fixed tokens free, route each blank to its capability's model, check it."""
+    checker = checker or accepting_checker
+    default = default or stub_improviser
+    idx, bidx, out = 0, 0, ""
+    counts = {"deterministic": 0, "improvised": 0, "rejected": 0}
+    by_capability: Dict[str, int] = {}
+    transcript: List[dict] = []
+    steps = 0
+    while idx < len(level.template) and steps < budget:
+        steps += 1
+        tok = level.template[idx]
+        if tok is not BLANK:  # pre-programmed: emit for free, no model
+            out += str(tok)
+            idx += 1
+            counts["deterministic"] += 1
+            transcript.append({"step": steps, "source": "fixed", "value": tok, "status": "ok"})
+            continue
+        blank = level.blanks[bidx]
+        model = routers.get(blank.capability, default)  # ROUTE BY STRENGTH
+        value = model(level.goal, out, blank.allowed)  # the only place a model is called
+        counts["improvised"] += 1
+        by_capability[blank.capability] = by_capability.get(blank.capability, 0) + 1
+        if not checker(out, value, blank.allowed):  # the catch / the walls
+            counts["rejected"] += 1
+            transcript.append({"step": steps, "source": blank.capability, "value": value, "status": "dropped"})
+            continue  # the blank stays in the air -- throw again next iteration
+        out += str(value)
+        idx += 1
+        bidx += 1
+        transcript.append({"step": steps, "source": blank.capability, "value": value, "status": "ok"})
+    return {
+        "level": level.name,
+        "cleared": idx >= len(level.template),
+        "output": out,
+        "steps": steps,
+        "model_calls": counts["improvised"],  # == blanks (+ retries), never the fixed structure
+        "by_capability": by_capability,
+        "counts": counts,
+        "transcript": transcript,
+    }
+
+
+# --- deterministic stub "models", one per strength (real free models replace these) ----
+def stub_improviser(goal: str, out: str, allowed: Sequence[str]) -> str:
+    return allowed[0] if allowed else ""
+
+
+def count_stub(goal: str, out: str, allowed: Sequence[str]) -> str:
+    """Good at counting: count the list items already in the output, route the number into the slot."""
+    n = out.count(",") + 1 if "[" in out and "]" in out else len(out.split())
+    return str(n)
+
+
+def name_stub(goal: str, out: str, allowed: Sequence[str]) -> str:
+    """Good at naming: pick a legal identifier from the allowed set."""
+    ids = [a for a in allowed if a[:1].isalpha()]
+    return ids[0] if ids else (allowed[0] if allowed else "x")
+
+
+STUBS: Dict[str, Improviser] = {"count": count_stub, "name": name_stub, "pick": stub_improviser}
+
+
+def accepting_checker(out: str, proposed: str, allowed: Sequence[str]) -> bool:
+    """The catch: accept iff the value is within the walls (the allowed set for this blank)."""
+    return proposed in allowed
+
+
+def _demo_levels() -> List[Level]:
+    return [
+        template_level(
+            "[1, 2, 3] has ",
+            BLANK,
+            " items",
+            blanks=[Blank("count", ["3"])],
+            name="count_items",
+            goal="state how many items the list has; route the counting to the counting model",
+        ),
+        template_level(
+            "def ",
+            BLANK,
+            "(): return ",
+            BLANK,
+            blanks=[Blank("name", ["greet", "f"]), Blank("pick", ["42", "0"])],
+            name="write_function",
+            goal="name a function and pick its return value",
+        ),
+        template_level("x = 1", name="fully_fixed"),  # no blanks -> no model is ever called
+    ]
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    print("PAIR LOOP  juggling harness: improvise only when needed, route blanks by strength\n")
+    for lvl in _demo_levels():
+        r = run_loop(lvl, STUBS, accepting_checker)
+        print("  %-16s -> %-28r cleared=%s" % (lvl.name, r["output"], r["cleared"]))
+        print(
+            "      %d fixed emitted free; %d blank(s) routed by strength %s; model_calls=%d"
+            % (lvl.fixed_count(), lvl.blank_count(), r["by_capability"] or "{}", r["model_calls"])
+        )
+    print("\n  fixed structure costs 0 model calls; each blank goes to the model good at its capability.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pair_loop.py
+++ b/tests/test_pair_loop.py
@@ -1,0 +1,81 @@
+"""pair_loop: a deterministic harness that pairs small models, improvising only at the blanks.
+
+The harness emits fixed structure for free (zero model calls), routes each blank to the model good
+at its capability, and a checker accepts/rejects against the walls. Proven with deterministic stubs;
+a real free model drops into a capability slot. Like juggling: blanks thrown to the right hand, the
+checker is the catch.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.pair_loop import (  # noqa: E402
+    BLANK,
+    STUBS,
+    Blank,
+    accepting_checker,
+    run_loop,
+    template_level,
+)
+
+
+def test_count_strength_is_routed_into_the_command():
+    lvl = template_level("[1, 2, 3] has ", BLANK, " items", blanks=[Blank("count", ["3"])], name="count_items")
+    r = run_loop(lvl, STUBS, accepting_checker)
+    assert r["cleared"] is True
+    assert r["output"] == "[1, 2, 3] has 3 items"  # the counting model's answer routed into the slot
+    assert r["model_calls"] == 1
+    assert r["by_capability"] == {"count": 1}
+
+
+def test_improvise_only_when_needed():
+    # fixed structure costs zero model calls; the model is only called at blanks
+    fixed = run_loop(template_level("x = 1", name="fully_fixed"), STUBS, accepting_checker)
+    assert fixed["cleared"] is True
+    assert fixed["model_calls"] == 0
+    two = template_level(
+        "def ",
+        BLANK,
+        "(): return ",
+        BLANK,
+        blanks=[Blank("name", ["greet"]), Blank("pick", ["42"])],
+    )
+    r = run_loop(two, STUBS, accepting_checker)
+    assert r["output"] == "def greet(): return 42"
+    assert r["counts"]["deterministic"] == 2  # the two fixed tokens
+    assert r["model_calls"] == 2  # one per blank, never the structure
+
+
+def test_route_by_strength_picks_the_capability_model():
+    lvl = template_level("v=", BLANK, blanks=[Blank("count", ["X"])])
+    used = {}
+
+    def marker(goal, out, allowed):
+        used["count"] = True
+        return "X"
+
+    r = run_loop(lvl, {"count": marker}, accepting_checker)
+    assert used.get("count") is True  # the count blank went to the count router
+    assert r["output"] == "v=X"
+
+
+def test_checker_drops_out_of_wall_values_and_fails_honestly():
+    lvl = template_level("a=", BLANK, blanks=[Blank("pick", ["1", "2"])])
+
+    def bad(goal, out, allowed):
+        return "9"  # 9 is not in the walls -> dropped every time
+
+    r = run_loop(lvl, {"pick": bad}, accepting_checker, budget=5)
+    assert r["cleared"] is False  # the harness never fakes success
+    assert r["counts"]["rejected"] > 0
+    assert "9" not in r["output"]  # a bad guess never corrupts the output
+
+
+def test_template_blank_mismatch_raises():
+    with pytest.raises(ValueError, match="blanks"):
+        template_level("x ", BLANK, " y", blanks=[])  # one blank, no specs


### PR DESCRIPTION
## What

The **scaffold is the intelligence; the models are commodity hands.** A task is a **template**: fixed tokens the harness emits for *free* (zero model calls), interleaved with **blanks** (the real choice points).

- **Improvise only when needed** — the model is called exactly once per blank (+ retries), **never for the fixed structure** (a fully-fixed level runs with `model_calls=0`).
- **Route by strength** — each blank declares the **capability** it needs (`count`/`name`/`pick`…); the harness routes it to the model good at *that* and drops the answer into the slot. Great at counting? Let it count what the system needs counted.
- **Juggle** — blanks stay in the air, thrown to the right hand; a **checker** (the catch) accepts/rejects against the allowed **walls**, so a bad guess is dropped, never corrupting the output.

Models are pluggable callables keyed by capability; deterministic stubs prove the loop, a real free model drops into a slot.

## Verified by execution
```
count_items     -> '[1, 2, 3] has 3 items'   (count routed in, 1 model call)
write_function  -> 'def greet(): return 42'  (name+pick, 2 calls)
fully_fixed     -> 'x = 1'                    (0 model calls)
out-of-walls value -> dropped, run fails honestly (no faked success)
```

## Where it's going
The blanks become **shape-typed block slots** (Scratch/Blockly): the allowed set is the blocks whose *shape fits*, and the model just plays the block that fits — **Apples-to-Apples where the cards are code blocks** (plugs into the existing `blocks.py`).

## Tests
5 (`tests/test_pair_loop.py`). black / flake8 / ruff clean (120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)