### PR TITLE
feat(loomfn): arrays + user-defined functions (recursion) across language faces

### DIFF
--- a/python/scbe/loomfn.py
+++ b/python/scbe/loomfn.py
@@ -1,0 +1,519 @@
+"""loomfn: data structures (arrays) and user-defined functions (call/return, recursion) that
+emit into many language faces and are verified by EXECUTION -- the layer past loomflow's
+straight-line + branching scalar core.
+
+loomflow proved that branching/looping programs run identically across faces via a dispatch
+loop (a `while` over a program counter, one `if pc == k` arm per instruction -- no goto). loomfn
+keeps that exact shape and adds the two things a real language needs:
+
+  * ARRAYS (the heap): `arr A` / `push A x` / `pop d A` / `get d A i` / `set A i x` / `alen d A`.
+    Arrays are shared/global (a heap), so a function mutating one is visible to its caller.
+  * FUNCTIONS (the stack): `func name p1..pn` ... `ret x`, called by `call d name a1..an`.
+    Calling convention is caller-saves: a call snapshots all scalar slots, zeroes them, binds the
+    params, and jumps; `ret` restores the snapshot and delivers the result into `d`. That gives
+    real local scoping and real RECURSION (factorial, fibonacci) -- not just inline blocks.
+
+The value model is index-based: scalar slots live in one flat array `s` (name->index resolved at
+emit time), which makes a call-frame snapshot a single copy of `s` in every language. A Python
+interpreter of the IR is the reference; every emitted face is RUN and compared to it, so
+"functions and data structures work across languages" is a tested fact, not a claim.
+
+Locally verifiable faces here: python, javascript (node), rust (rustc). C/others can follow once
+a toolchain exists -- this never reports a face as agreeing unless it actually ran and matched.
+
+    const n 5 / call r fact n / print r / halt
+    func fact n / const one 1 / le b n one / brz b rec / ret one
+    label rec / sub m n one / call fr fact m / mul res n fr / ret res     # -> 120, py+js+rust
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+Instr = Tuple[str, Tuple[str, ...]]
+
+_ARITH = {"add": "+", "sub": "-", "mul": "*", "div": "/"}
+_CMP = {"lt": "<", "le": "<=", "gt": ">", "ge": ">=", "eq": "==", "ne": "!="}
+_ARR = {"arr", "push", "pop", "get", "set", "alen"}
+_FN = {"func", "ret", "call"}
+_OPS = {"const", "mov", "inc", "dec", "label", "jmp", "brz", "print", "halt"} | set(_ARITH) | set(_CMP) | _ARR | _FN
+
+
+def parse(text: str) -> List[Instr]:
+    """Parse the line-based assembly into (op, args) instructions (; and # are comments)."""
+    prog: List[Instr] = []
+    for raw in text.replace("/", "\n").splitlines():
+        line = raw.split(";", 1)[0].split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        op, args = parts[0].lower(), tuple(parts[1:])
+        if op not in _OPS:
+            raise ValueError("unknown op %r (have %s)" % (op, ", ".join(sorted(_OPS))))
+        prog.append((op, args))
+    return prog
+
+
+def _classify(op: str, a: Tuple[str, ...]) -> Tuple[List[str], List[str]]:
+    """Return (scalar slot names, array names) referenced by this instruction."""
+    sc: List[str] = []
+    ar: List[str] = []
+    if op == "const":
+        sc = [a[0]]
+    elif op == "mov":
+        sc = [a[0], a[1]]
+    elif op in _ARITH or op in _CMP:
+        sc = [a[0], a[1], a[2]]
+    elif op in ("inc", "dec", "print", "brz"):
+        sc = [a[0]]
+    elif op == "arr":
+        ar = [a[0]]
+    elif op == "push":
+        ar, sc = [a[0]], [a[1]]
+    elif op == "pop":
+        sc, ar = [a[0]], [a[1]]
+    elif op == "get":
+        sc, ar = [a[0], a[2]], [a[1]]
+    elif op == "set":
+        ar, sc = [a[0]], [a[1], a[2]]
+    elif op == "alen":
+        sc, ar = [a[0]], [a[1]]
+    elif op == "func":
+        sc = list(a[1:])  # params (a[0] is the function name)
+    elif op == "ret":
+        sc = list(a[:1])  # optional return slot
+    elif op == "call":
+        sc = [a[0]] + list(a[2:])  # dest + arg slots (a[1] is the function name)
+    return sc, ar
+
+
+def _labels(prog: Sequence[Instr]) -> Dict[str, int]:
+    return {a[0]: i for i, (op, a) in enumerate(prog) if op == "label"}
+
+
+def _funcs(prog: Sequence[Instr]) -> Dict[str, Tuple[int, List[str]]]:
+    return {a[0]: (i, list(a[1:])) for i, (op, a) in enumerate(prog) if op == "func"}
+
+
+def _ordered(prog: Sequence[Instr], which: int) -> List[str]:
+    names: List[str] = []
+    for op, a in prog:
+        for n in _classify(op, a)[which]:
+            if n not in names:
+                names.append(n)
+    return names
+
+
+def _slots(prog: Sequence[Instr]) -> List[str]:
+    return _ordered(prog, 0)
+
+
+def _arrays(prog: Sequence[Instr]) -> List[str]:
+    return _ordered(prog, 1)
+
+
+# --- the reference interpreter -------------------------------------------------
+
+
+def interpret(prog: Sequence[Instr], step_limit: int = 1_000_000) -> List[float]:
+    """Run the IR directly (the reference every face is compared against); return printed values."""
+    labels, funcs = _labels(prog), _funcs(prog)
+    s: Dict[str, float] = {n: 0.0 for n in _slots(prog)}
+    h: Dict[str, List[float]] = {n: [] for n in _arrays(prog)}
+    call: List[Tuple[int, str, Dict[str, float]]] = []  # (return_pc, dest, saved scalar slots)
+    out: List[float] = []
+    pc, steps = 0, 0
+    while 0 <= pc < len(prog):
+        steps += 1
+        if steps > step_limit:
+            raise RuntimeError("step limit exceeded (infinite loop?)")
+        op, a = prog[pc]
+        if op == "const":
+            s[a[0]] = float(a[1])
+            pc += 1
+        elif op == "mov":
+            s[a[0]] = s[a[1]]
+            pc += 1
+        elif op in _ARITH:
+            x, y = s[a[1]], s[a[2]]
+            s[a[0]] = x + y if op == "add" else x - y if op == "sub" else x * y if op == "mul" else x / y
+            pc += 1
+        elif op in _CMP:
+            x, y = s[a[1]], s[a[2]]
+            r = {"lt": x < y, "le": x <= y, "gt": x > y, "ge": x >= y, "eq": x == y, "ne": x != y}[op]
+            s[a[0]] = 1.0 if r else 0.0
+            pc += 1
+        elif op == "inc":
+            s[a[0]] += 1.0
+            pc += 1
+        elif op == "dec":
+            s[a[0]] -= 1.0
+            pc += 1
+        elif op == "arr":
+            h[a[0]] = []
+            pc += 1
+        elif op == "push":
+            h[a[0]].append(s[a[1]])
+            pc += 1
+        elif op == "pop":
+            s[a[0]] = h[a[1]].pop()
+            pc += 1
+        elif op == "get":
+            s[a[0]] = h[a[1]][int(s[a[2]])]
+            pc += 1
+        elif op == "set":
+            h[a[0]][int(s[a[1]])] = s[a[2]]
+            pc += 1
+        elif op == "alen":
+            s[a[0]] = float(len(h[a[1]]))
+            pc += 1
+        elif op == "label" or op == "func":
+            pc += 1
+        elif op == "jmp":
+            pc = labels[a[0]]
+        elif op == "brz":
+            pc = labels[a[1]] if s[a[0]] == 0.0 else pc + 1
+        elif op == "call":
+            if a[1] not in funcs:
+                raise ValueError("call to unknown function %r" % (a[1],))
+            entry, params = funcs[a[1]]
+            vals = [s[x] for x in a[2:]]
+            call.append((pc + 1, a[0], dict(s)))
+            for n in s:
+                s[n] = 0.0
+            for p, v in zip(params, vals):
+                s[p] = v
+            pc = entry + 1
+        elif op == "ret":
+            result = s[a[0]] if a else 0.0
+            rp, dst, saved = call.pop()
+            s.update(saved)
+            s[dst] = result
+            pc = rp
+        elif op == "print":
+            out.append(s[a[0]])
+            pc += 1
+        elif op == "halt":
+            break
+    return out
+
+
+# --- per-language dispatch-loop emit (python / javascript / rust) --------------
+# Scalar slots live in a flat array `s` indexed by slot id; arrays in `h`; a call snapshots `s`
+# onto a parallel stack, zeroes it, binds params, and jumps. Same shape in every language.
+
+
+def _num(v: str) -> str:
+    return repr(float(v))
+
+
+def _arm(prog, k, lang, six, aix, labels, funcs, nslots) -> List[str]:
+    """The source lines (effect(s) + pc update) for instruction k in `lang`."""
+    op, a = prog[k]
+
+    def S(name):  # a scalar slot reference -> "s[<index>]"
+        return "s[%d]" % six[name]
+
+    def nxt(target):
+        return "pc = %d" % target if lang == "python" else "pc = %d;" % target
+
+    semi = "" if lang == "python" else ";"
+    idx = {"python": "int(%s)", "javascript": "Math.trunc(%s)", "rust": "%s as usize"}[lang]
+
+    if op == "const":
+        return ["%s = %s%s" % (S(a[0]), _num(a[1]), semi), nxt(k + 1)]
+    if op == "mov":
+        return ["%s = %s%s" % (S(a[0]), S(a[1]), semi), nxt(k + 1)]
+    if op in _ARITH:
+        return ["%s = %s %s %s%s" % (S(a[0]), S(a[1]), _ARITH[op], S(a[2]), semi), nxt(k + 1)]
+    if op in _CMP:
+        cond = "%s %s %s" % (S(a[1]), _CMP[op], S(a[2]))
+        tern = {
+            "python": "(1.0 if %s else 0.0)",
+            "javascript": "(%s ? 1.0 : 0.0)",
+            "rust": "if %s { 1.0 } else { 0.0 }",
+        }[lang]
+        return ["%s = %s%s" % (S(a[0]), tern % cond, semi), nxt(k + 1)]
+    if op == "inc":
+        return ["%s = %s + 1.0%s" % (S(a[0]), S(a[0]), semi), nxt(k + 1)]
+    if op == "dec":
+        return ["%s = %s - 1.0%s" % (S(a[0]), S(a[0]), semi), nxt(k + 1)]
+    if op == "arr":
+        clear = {"python": "h[%d] = []", "javascript": "h[%d] = [];", "rust": "h[%d].clear();"}[lang]
+        return [clear % aix[a[0]], nxt(k + 1)]
+    if op == "push":
+        push = {"python": "h[%d].append(%s)", "javascript": "h[%d].push(%s);", "rust": "h[%d].push(%s);"}[lang]
+        return [push % (aix[a[0]], S(a[1])), nxt(k + 1)]
+    if op == "pop":
+        pop = {"python": "%s = h[%d].pop()", "javascript": "%s = h[%d].pop();", "rust": "%s = h[%d].pop().unwrap();"}[
+            lang
+        ]
+        return [pop % (S(a[0]), aix[a[1]]), nxt(k + 1)]
+    if op == "get":
+        return ["%s = h[%d][%s]%s" % (S(a[0]), aix[a[1]], idx % S(a[2]), semi), nxt(k + 1)]
+    if op == "set":
+        return ["h[%d][%s] = %s%s" % (aix[a[0]], idx % S(a[1]), S(a[2]), semi), nxt(k + 1)]
+    if op == "alen":
+        ln = {
+            "python": "%s = float(len(h[%d]))",
+            "javascript": "%s = h[%d].length;",
+            "rust": "%s = h[%d].len() as f64;",
+        }[lang]
+        return [ln % (S(a[0]), aix[a[1]]), nxt(k + 1)]
+    if op == "label" or op == "func":
+        return [nxt(k + 1)]
+    if op == "jmp":
+        return [nxt(labels[a[0]])]
+    if op == "brz":
+        tgt, fall = labels[a[1]], k + 1
+        cond = "%s == 0.0" % S(a[0])
+        if lang == "python":
+            return ["pc = %d if %s else %d" % (tgt, cond, fall)]
+        return (
+            ["if (%s) { pc = %d; } else { pc = %d; }" % (cond, tgt, fall)]
+            if lang != "rust"
+            else ["if %s { pc = %d; } else { pc = %d; }" % (cond, tgt, fall)]
+        )
+    if op == "call":
+        entry = funcs[a[1]][0] + 1
+        params = funcs[a[1]][1]
+        argv = ", ".join(S(x) for x in a[2:])
+        binds = "; ".join("s[%d] = _v[%d]" % (six[p], i) for i, p in enumerate(params))
+        if lang == "python":
+            out = ["_v = [%s]" % argv]
+            out.append("_cs_ret.append(%d); _cs_dst.append(%d); _cs_save.append(s[:])" % (k + 1, six[a[0]]))
+            out.append("for _z in range(%d): s[_z] = 0.0" % nslots)
+            if binds:
+                out.append(binds)
+            out.append("pc = %d" % entry)
+            return out
+        if lang == "javascript":
+            out = ["const _v = [%s];" % argv]
+            out.append("_cs_ret.push(%d); _cs_dst.push(%d); _cs_save.push(s.slice());" % (k + 1, six[a[0]]))
+            out.append("for (let _z = 0; _z < %d; _z++) s[_z] = 0.0;" % nslots)
+            if binds:
+                out.append(binds + ";")
+            out.append("pc = %d;" % entry)
+            return out
+        out = ["let _v: Vec<f64> = vec![%s];" % argv]
+        out.append("_cs_ret.push(%d); _cs_dst.push(%d); _cs_save.push(s.clone());" % (k + 1, six[a[0]]))
+        out.append("for _z in 0..%d { s[_z] = 0.0; }" % nslots)
+        if binds:
+            out.append(binds + ";")
+        out.append("pc = %d;" % entry)
+        return out
+    if op == "ret":
+        rv = S(a[0]) if a else "0.0"
+        if lang == "python":
+            return [
+                "_r = %s" % rv,
+                "_ssave = _cs_save.pop(); _sdst = _cs_dst.pop(); _sret = _cs_ret.pop()",
+                "s[:] = _ssave; s[_sdst] = _r; pc = _sret",
+            ]
+        if lang == "javascript":
+            return [
+                "const _r = %s;" % rv,
+                "const _ssave = _cs_save.pop(); const _sdst = _cs_dst.pop(); const _sret = _cs_ret.pop();",
+                "for (let _z = 0; _z < %d; _z++) s[_z] = _ssave[_z];" % nslots,
+                "s[_sdst] = _r; pc = _sret;",
+            ]
+        return [
+            "let _r = %s;" % rv,
+            "let _ssave = _cs_save.pop().unwrap(); let _sdst = _cs_dst.pop().unwrap(); "
+            "let _sret = _cs_ret.pop().unwrap();",
+            "for _z in 0..%d { s[_z] = _ssave[_z]; }" % nslots,
+            "s[_sdst] = _r; pc = _sret;",
+        ]
+    if op == "print":
+        pr = {
+            "python": "_out.append(%s)" % S(a[0]),
+            "javascript": "console.log(%s);" % S(a[0]),
+            "rust": 'println!("{}", %s);' % S(a[0]),
+        }[lang]
+        return [pr, nxt(k + 1)]
+    if op == "halt":
+        return [nxt(-1)]
+    raise ValueError("no emit for op %r" % (op,))
+
+
+def emit(prog: Sequence[Instr], lang: str) -> str:
+    """Emit the program as a dispatch loop in `lang` (python / javascript / rust)."""
+    if lang not in ("python", "javascript", "rust"):
+        raise ValueError("loomfn emits python/javascript/rust (got %r)" % (lang,))
+    labels, funcs = _labels(prog), _funcs(prog)
+    slots, arrs = _slots(prog), _arrays(prog)
+    six = {n: i for i, n in enumerate(slots)}
+    aix = {n: i for i, n in enumerate(arrs)}
+    ns, na, n = len(slots), len(arrs), len(prog)
+    arms = [_arm(prog, k, lang, six, aix, labels, funcs, ns) for k in range(n)]
+
+    if lang == "python":
+        body = [
+            "    s = [0.0] * %d" % max(ns, 1),
+            "    h = [[] for _ in range(%d)]" % na,
+            "    _cs_ret = []",
+            "    _cs_dst = []",
+            "    _cs_save = []",
+            "    _out = []",
+            "    pc = 0",
+            "    while 0 <= pc < %d:" % n,
+        ]
+        for k, lines in enumerate(arms):
+            body.append("        if pc == %d:" % k if k == 0 else "        elif pc == %d:" % k)
+            body += ["            " + ln for ln in lines]
+        body += ["        else:", "            pc = -1", "    return _out[-1] if _out else None"]
+        return "def run():\n" + "\n".join(body) + "\n\n\nif __name__ == '__main__':\n    print(run())\n"
+
+    if lang == "javascript":
+        lines = [
+            "function run() {",
+            "  let s = new Array(%d).fill(0.0);" % max(ns, 1),
+            "  let h = Array.from({length: %d}, () => []);" % na,
+            "  let _cs_ret = [], _cs_dst = [], _cs_save = [];",
+            "  let _out = [];",
+            "  let pc = 0;",
+            "  while (pc >= 0 && pc < %d) {" % n,
+        ]
+        for k, arm in enumerate(arms):
+            kw = "if" if k == 0 else "} else if"
+            lines.append("    %s (pc == %d) {" % (kw, k))
+            lines += ["      " + ln for ln in arm]
+        lines += [
+            "    } else { pc = -1; }",
+            "  }",
+            "  return _out.length ? _out[_out.length - 1] : null;",
+            "}",
+            "run();",
+        ]
+        return "\n".join(lines) + "\n"
+
+    # rust
+    lines = [
+        "fn run() -> Option<f64> {",
+        "    let mut s: Vec<f64> = vec![0.0; %d];" % max(ns, 1),
+        "    let mut h: Vec<Vec<f64>> = vec![vec![]; %d];" % na,
+        "    let mut _cs_ret: Vec<i64> = vec![];",
+        "    let mut _cs_dst: Vec<usize> = vec![];",
+        "    let mut _cs_save: Vec<Vec<f64>> = vec![];",
+        "    let mut _out: Vec<f64> = vec![];",
+        "    let mut pc: i64 = 0;",
+        "    while pc >= 0 && pc < %d {" % n,
+    ]
+    for k, arm in enumerate(arms):
+        kw = "if" if k == 0 else "} else if"
+        lines.append("        %s pc == %d {" % (kw, k))
+        lines += ["            " + ln for ln in arm]
+    lines += ["        } else { pc = -1; }", "    }", "    _out.last().copied()", "}"]
+    lines += ["fn main() {", "    let _ = run();", "}"]
+    # silence unused-mut warnings for programs without arrays/functions
+    return "#![allow(unused_mut, unused_variables)]\n" + "\n".join(lines) + "\n"
+
+
+# --- run each emitted face and compare to the reference ------------------------
+_RUN = {"python": None, "javascript": "node", "rust": "rustc"}
+
+
+def _last_float(stdout: str) -> Optional[float]:
+    line = (stdout.strip().splitlines() or [""])[-1].strip()
+    if line.lower() in ("nan", "-nan"):
+        return float("nan")
+    return float(line) if line not in ("", "None", "null") else None
+
+
+def run_face(prog: Sequence[Instr], lang: str) -> Optional[float]:
+    src = emit(prog, lang)
+    with tempfile.TemporaryDirectory() as td:
+        ext = {"python": "py", "javascript": "js", "rust": "rs"}[lang]
+        f = Path(td) / ("prog." + ext)
+        f.write_text(src, encoding="utf-8")
+        if lang == "python":
+            return _last_float(
+                subprocess.run([sys.executable, str(f)], capture_output=True, text=True, timeout=30).stdout
+            )
+        if lang == "javascript":
+            return _last_float(subprocess.run(["node", str(f)], capture_output=True, text=True, timeout=30).stdout)
+        exe = Path(td) / ("prog.exe" if shutil.which("cmd") else "prog")
+        subprocess.run(["rustc", "-O", str(f), "-o", str(exe)], capture_output=True, text=True, timeout=120, check=True)
+        return _last_float(subprocess.run([str(exe)], capture_output=True, text=True, timeout=30).stdout)
+
+
+def verify(prog: Sequence[Instr], faces: Sequence[str] = ("python", "javascript", "rust")) -> dict:
+    """Run the reference, then every face with a local toolchain; compare each honestly."""
+    ref = interpret(prog)
+    reference = ref[-1] if ref else None
+    results: Dict[str, dict] = {}
+    for lang in faces:
+        tool = _RUN.get(lang, "<none>")
+        if tool is not None and shutil.which(tool) is None:
+            results[lang] = {"status": "NO_TOOLCHAIN", "value": None}
+            continue
+        try:
+            v = run_face(prog, lang)
+        except Exception as e:
+            results[lang] = {"status": "ERROR", "value": None, "note": "%s: %s" % (type(e).__name__, e)}
+            continue
+        agree = v == reference or (v is not None and reference is not None and abs(v - reference) <= 1e-9)
+        results[lang] = {"status": "AGREE" if agree else "DISAGREE", "value": v}
+    verified = [lang for lang, r in results.items() if r["status"] == "AGREE"]
+    return {
+        "reference": reference,
+        "results": results,
+        "verified": verified,
+        "verified_count": len(verified),
+        "disagree": [lang for lang, r in results.items() if r["status"] == "DISAGREE"],
+    }
+
+
+EXAMPLES = {
+    # build [1..5] in an array, then sum the array -> 15  (data structure + loop)
+    "array_sum": "arr xs / const i 1 / const n 5 / label fill / le t i n / brz t sums / push xs i / inc i / jmp fill / "
+    "label sums / const acc 0 / const j 0 / alen len xs / label sl / lt c j len / brz c done / get v xs j / "
+    "add acc acc v / inc j / jmp sl / label done / print acc / halt",
+    # find the max of [3,7,2,9,4] -> 9  (array indexing + branch)
+    "array_max": "arr xs / const v 3 / push xs v / const v 7 / push xs v / const v 2 / push xs v / const v 9 / "
+    "push xs v / const v 4 / push xs v / const j 0 / alen len xs / get m xs j / inc j / label lp / lt c j len / "
+    "brz c done / get v xs j / gt g v m / brz g skip / mov m v / label skip / inc j / jmp lp / label done / "
+    "print m / halt",
+    # a 2-arg function -> 7  (call/return, params)
+    "add_fn": "const a 3 / const b 4 / call r addup a b / print r / halt / func addup x y / add s x y / ret s",
+    # recursive factorial 5! -> 120  (recursion via the frame stack)
+    "factorial_recursive": "const n 5 / call r fact n / print r / halt / func fact n / const one 1 / le b n one / "
+    "brz b rec / ret one / label rec / sub m n one / call fr fact m / mul res n fr / ret res",
+    # recursive fibonacci fib(10) -> 55  (two recursive calls per frame)
+    "fib_recursive": "const n 10 / call r fib n / print r / halt / func fib n / const two 2 / lt b n two / brz b rec / "
+    "ret n / label rec / const one 1 / sub x n one / call fa fib x / sub y n two / call fb fib y / add z fa fb / "
+    "ret z",
+    # a function that sums a shared (heap) array -> 60  (functions + data structures together)
+    "sum_array_fn": "arr xs / const v 10 / push xs v / const v 20 / push xs v / const v 30 / push xs v / "
+    "call r total / print r / halt / func total / const acc 0 / const j 0 / alen len xs / label sl / lt c j len / "
+    "brz c done / get e xs j / add acc acc e / inc j / jmp sl / label done / ret acc",
+}
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(prog="scbe-loomfn", description="arrays + functions across language faces, verified")
+    ap.add_argument("example", nargs="?", default="factorial_recursive", choices=sorted(EXAMPLES))
+    ap.add_argument("--emit", help="print the emitted source for one face (python/javascript/rust)")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    prog = parse(EXAMPLES[a.example])
+    if a.emit:
+        print(emit(prog, a.emit))
+        return 0
+    r = verify(prog)
+    print("LOOMFN  %s  (arrays + functions)  reference=%s" % (a.example, r["reference"]))
+    print("  verified faces: %d  ->  %s" % (r["verified_count"], ", ".join(r["verified"]) or "(none)"))
+    for lang in sorted(r["results"]):
+        d = r["results"][lang]
+        print("    %-12s %-12s value=%s%s" % (lang, d["status"], d["value"], "  " + d.get("note", "")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_loomfn.py
+++ b/tests/test_loomfn.py
@@ -1,0 +1,106 @@
+"""loomfn: arrays (data structures) and user-defined functions (call/return, recursion) emit +
+run identically across language faces.
+
+The Python interpreter of the IR is the reference; emitted faces are RUN and compared. Reference,
+parsing, array semantics, and recursion are checked unconditionally; js/rust agreement runs only
+when the toolchain is present (skipped otherwise, never faked).
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.loomfn import EXAMPLES, emit, interpret, parse, verify  # noqa: E402
+
+_HAVE_NODE = shutil.which("node") is not None
+_HAVE_RUST = shutil.which("rustc") is not None
+
+_EXPECT = {
+    "array_sum": 15.0,
+    "array_max": 9.0,
+    "add_fn": 7.0,
+    "factorial_recursive": 120.0,
+    "fib_recursive": 55.0,
+    "sum_array_fn": 60.0,
+}
+
+
+def _ref(name):
+    return interpret(parse(EXAMPLES[name]))[-1]
+
+
+# --- data structures (arrays) --------------------------------------------------
+
+
+def test_reference_arrays_build_index_and_aggregate():
+    assert _ref("array_sum") == 15.0  # push 1..5, then sum the array
+    assert _ref("array_max") == 9.0  # index every element, keep the max
+
+
+def test_array_ops_round_trip():
+    # set overwrites by index; get reads it back; alen tracks length
+    prog = parse(
+        "arr a / const v 5 / push a v / const v 9 / push a v / const i 0 / const w 42 / set a i w / "
+        "get r a i / alen n a / print r / halt"
+    )
+    assert interpret(prog)[-1] == 42.0
+    prog2 = parse("arr a / const v 5 / push a v / const v 9 / push a v / alen n a / print n / halt")
+    assert interpret(prog2)[-1] == 2.0
+
+
+# --- user-defined functions (call / return / recursion) ------------------------
+
+
+def test_reference_functions_and_recursion():
+    assert _ref("add_fn") == 7.0  # 2-arg function
+    assert _ref("factorial_recursive") == 120.0  # 5! via recursion
+    assert _ref("fib_recursive") == 55.0  # fib(10), two recursive calls per frame
+
+
+def test_recursion_uses_independent_frames():
+    # if frames were not saved/restored, n would be clobbered by the recursive call and 5! would be wrong
+    assert _ref("factorial_recursive") == 120.0
+    assert _ref("sum_array_fn") == 60.0  # a function reading a shared (heap) array
+
+
+def test_unknown_op_and_unknown_function_raise():
+    with pytest.raises(ValueError, match="unknown op"):
+        parse("frobnicate a b")
+    with pytest.raises(ValueError, match="unknown function"):
+        interpret(parse("call r nope / halt"))
+
+
+# --- emit + cross-face agreement ----------------------------------------------
+
+
+def test_emit_produces_a_dispatch_loop_for_each_face():
+    prog = parse(EXAMPLES["factorial_recursive"])
+    assert "while 0 <= pc" in emit(prog, "python")
+    assert "while (pc >= 0" in emit(prog, "javascript")
+    assert "while pc >= 0" in emit(prog, "rust")
+
+
+def test_python_face_matches_reference_unconditionally():
+    for name in ("array_sum", "factorial_recursive", "sum_array_fn"):
+        r = verify(parse(EXAMPLES[name]), faces=("python",))
+        assert r["reference"] == _EXPECT[name]
+        assert r["results"]["python"] == {"status": "AGREE", "value": _EXPECT[name]}
+
+
+@pytest.mark.skipif(not _HAVE_NODE, reason="node not installed")
+def test_javascript_face_agrees_on_arrays_and_recursion():
+    for name in ("array_max", "factorial_recursive", "fib_recursive", "sum_array_fn"):
+        r = verify(parse(EXAMPLES[name]), faces=("javascript",))
+        assert r["results"]["javascript"] == {"status": "AGREE", "value": _EXPECT[name]}
+
+
+@pytest.mark.skipif(not _HAVE_RUST, reason="rustc not installed")
+def test_rust_face_agrees_on_arrays_and_recursion():
+    for name in ("array_max", "factorial_recursive", "fib_recursive", "sum_array_fn"):
+        r = verify(parse(EXAMPLES[name]), faces=("rust",))
+        assert r["results"]["rust"] == {"status": "AGREE", "value": _EXPECT[name]}


### PR DESCRIPTION
The frontier past loomflow's scalar core: **data structures and functions**, the two things needed to express real programs.

Same dispatch-loop model (PC + `if pc==k` arms, no goto), same discipline (a Python interpreter is the reference; every emitted face is RUN and compared).

- **Arrays (the heap):** `arr / push / pop / get / set / alen`
- **Functions (the stack):** `func name p..` / `ret x` / `call d name a..` — caller-saves convention with a frame-snapshot stack, giving real local scoping and real **recursion**.

Verified by execution: all 6 examples agree across **python + javascript + rust** — array sum (15), array max (9), 2-arg function (7), recursive factorial (120), recursive fibonacci(10) (55), and a function summing a shared-heap array (60). 16 tests pass (9 new + 7 loomflow regression). Faces limited to the toolchains installed here (py/js/rust); a face is never reported AGREE unless it actually ran and matched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>