### PR TITLE
feat(geometric_router): route instruction streams by shape intersection (depth-gated)

### DIFF
--- a/python/scbe/geometric_router.py
+++ b/python/scbe/geometric_router.py
@@ -24,7 +24,7 @@ The geometry is the user's own (vault docs 123/124):
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Sequence, Tuple
 
 import numpy as np
 
@@ -232,7 +232,7 @@ def _demo() -> None:
 
     print("Geometric fleet router — tangent-vector parallel tracks\n")
     print(f"  fleet: {len(fleet)} tongue-specialist agents   tasks: {len(tasks)}")
-    print(f"  metric: tongue-weighted Poincare (Finsler), phi-tongue tensor\n")
+    print("  metric: tongue-weighted Poincare (Finsler), phi-tongue tensor\n")
     print("  parallel tracks (each agent = a tangent vector tracing a geodesic):")
     for r in routes:
         ray = f"{len(r.track)} pts" if r.track else "-"
@@ -259,5 +259,114 @@ def _demo() -> None:
     )
 
 
+# --- instruction-stream routing: shapes that INTERSECT ----------------------
+# A complementary geometry to the fleet router above. The fleet router routes tasks to
+# agents by DISTANCE; this routes instruction streams to each other by INTERSECTION.
+#
+# A stream is an EDGE of a shape: an ordered list of steps (the buttons) embedded as
+# points, where each coordinate is its OWN function of the step index -- so a side can be
+# STRAIGHT in one dimension and CURVED/squiggly in another. A "background DEPTH" coordinate
+# GATES binding: two edges can cross in the visible dimensions yet sit at different depths
+# (pass over/under each other) and never bind. Where two edges come within eps they bind --
+# step i of one stream co-fires with step j of the other. Reshape the curves and you reshape
+# which instructions compose; that is the routing. phi is available (golden) only as a
+# deterministic curve SHAPE, not mysticism.
+
+Dim = Callable[[float], float]
+
+
+def straight(slope: float, offset: float = 0.0) -> Dim:
+    """A side that is a straight line in this dimension."""
+    return lambda t: slope * t + offset
+
+
+def curved(amp: float, freq: float = 1.0, phase: float = 0.0) -> Dim:
+    """A side curved/squiggly in this dimension (a sine wave)."""
+    return lambda t: amp * float(np.sin(freq * t + phase))
+
+
+def golden(amp: float) -> Dim:
+    """A side spaced by the golden angle -- phi as a deterministic shape (even, non-repeating)."""
+    ga = 2.0 * np.pi * (1.0 - 1.0 / PHI)
+    return lambda t: amp * float(np.sin(ga * t))
+
+
+def depth(value: float) -> Dim:
+    """A flat background-depth coordinate -- the gate dimension (constant along the edge)."""
+    return lambda t: float(value)
+
+
+@dataclass
+class Stream:
+    """One edge of a shape: ordered steps embedded as points, each dimension its own
+    function of the step index."""
+
+    name: str
+    steps: List[str]
+    dims: List[Dim]
+
+    def point(self, i: int) -> np.ndarray:
+        t = float(i)
+        return np.array([d(t) for d in self.dims], dtype=float)
+
+
+def bind_streams(a: Stream, b: Stream, eps: float) -> List[Dict[str, Any]]:
+    """Every (step of a, step of b) whose embedded points are within eps -- the intersections."""
+    out: List[Dict[str, Any]] = []
+    for i in range(len(a.steps)):
+        pa = a.point(i)
+        for j in range(len(b.steps)):
+            d = float(np.linalg.norm(pa - b.point(j)))
+            if d <= eps:
+                out.append({"a_i": i, "a": a.steps[i], "b_j": j, "b": b.steps[j], "dist": round(d, 9)})
+    return out
+
+
+def route_streams(primary: Stream, others: Sequence[Stream], eps: float) -> List[Dict[str, Any]]:
+    """Walk the primary edge in order; at each step, co-fire steps from the other shapes whose
+    edges intersect (come within eps) at that point. The schedule IS the routed order."""
+    schedule: List[Dict[str, Any]] = []
+    for i in range(len(primary.steps)):
+        pa = primary.point(i)
+        co: List[Dict[str, Any]] = []
+        for o in others:
+            for j in range(len(o.steps)):
+                d = float(np.linalg.norm(pa - o.point(j)))
+                if d <= eps:
+                    co.append({"stream": o.name, "j": j, "step": o.steps[j], "dist": round(d, 9)})
+        co.sort(key=lambda c: (c["dist"], c["stream"], c["j"]))
+        schedule.append({"i": i, "step": primary.steps[i], "bind": co})
+    return schedule
+
+
+def render_route(schedule: Sequence[Dict[str, Any]]) -> str:
+    lines = ["GEOMETRIC ROUTE  (primary rail; co-fired bindings where shapes intersect)"]
+    for row in schedule:
+        binds = ", ".join("%s:%s" % (c["stream"], c["step"]) for c in row["bind"]) or "-"
+        lines.append("  %2d  %-12s -> %s" % (row["i"], row["step"], binds))
+    return "\n".join(lines)
+
+
+def _demo_streams() -> None:
+    # rail: a straight line of system steps along x, at depth 0
+    rail = Stream(
+        "rail",
+        ["inspect", "validate", "encode", "compare", "repair", "report"],
+        [straight(1.0), depth(0.0), depth(0.0)],
+    )
+    # safety: an edge curved in the y dimension that dips down to the rail (y~0) every other step
+    safety = Stream(
+        "safety",
+        ["chk0", "chk1", "chk2", "chk3", "chk4", "chk5"],
+        [straight(1.0), curved(2.0, float(np.pi) / 2.0), depth(0.0)],
+    )
+    # deep: the SAME curve, but parked at depth 5 -- it crosses in x,y yet must never bind
+    deep = Stream("deep", [f"d{i}" for i in range(6)], [straight(1.0), curved(2.0, float(np.pi) / 2.0), depth(5.0)])
+
+    print("\n" + render_route(route_streams(rail, [safety, deep], eps=0.25)))
+    print("  safety binds where its curve meets the rail; 'deep' never binds (depth gates it).")
+
+
 if __name__ == "__main__":
     _demo()
+    _demo_streams()

--- a/tests/test_geometric_router.py
+++ b/tests/test_geometric_router.py
@@ -4,12 +4,18 @@ import numpy as np
 
 from python.scbe.geometric_router import (
     Agent,
+    Stream,
     Task,
     TONGUES,
+    bind_streams,
+    curved,
+    depth,
     finsler_distance,
     geodesic,
     route_fleet,
     round_robin,
+    route_streams,
+    straight,
 )
 
 
@@ -56,3 +62,44 @@ def test_geodesic_samples_and_endpoints():
     g = geodesic({"KO": 1.0}, {"DR": 1.0}, steps=10)
     assert len(g) == 11
     assert all(np.linalg.norm(p) < 1.0 for p in g)  # stays inside the ball
+
+
+# --- instruction-stream routing: shapes that intersect ------------------------
+
+import math  # noqa: E402
+
+
+def test_two_straight_edges_intersect_once():
+    # A runs along x at y=0; B is a vertical line at x=2 -- they cross at exactly one point
+    a = Stream("A", ["a0", "a1", "a2", "a3"], [straight(1.0), depth(0.0)])
+    b = Stream("B", ["b0", "b1", "b2", "b3"], [depth(2.0), straight(1.0, -2.0)])
+    binds = bind_streams(a, b, eps=0.4)
+    assert len(binds) == 1
+    assert (binds[0]["a"], binds[0]["b"]) == ("a2", "b2")
+
+
+def test_curved_edge_meets_rail_at_predicted_steps():
+    # a straight rail at y=0; a sine edge dips to y~0 at even steps -> binds there, not at odd steps
+    rail = Stream("rail", [f"r{i}" for i in range(6)], [straight(1.0), depth(0.0)])
+    wave = Stream("wave", [f"w{i}" for i in range(6)], [straight(1.0), curved(2.0, math.pi / 2)])
+    binds = bind_streams(rail, wave, eps=0.25)
+    assert sorted(x["a_i"] for x in binds) == [0, 2, 4]  # the curve touches the line at even steps
+
+
+def test_depth_gates_binding():
+    # the SAME crossing curve binds at depth 0 but NOT when parked at a different depth
+    rail = Stream("rail", [f"r{i}" for i in range(6)], [straight(1.0), depth(0.0), depth(0.0)])
+    near = Stream("near", [f"n{i}" for i in range(6)], [straight(1.0), curved(2.0, math.pi / 2), depth(0.0)])
+    far = Stream("far", [f"f{i}" for i in range(6)], [straight(1.0), curved(2.0, math.pi / 2), depth(5.0)])
+    assert len(bind_streams(rail, near, eps=0.25)) > 0
+    assert len(bind_streams(rail, far, eps=0.25)) == 0  # crosses in x,y but depth gates it out
+
+
+def test_route_schedule_is_deterministic_and_well_shaped():
+    rail = Stream("rail", ["inspect", "validate", "encode", "compare"], [straight(1.0), depth(0.0)])
+    safety = Stream("safety", ["s0", "s1", "s2", "s3"], [straight(1.0), curved(2.0, math.pi / 2)])
+    r1 = route_streams(rail, [safety], eps=0.25)
+    r2 = route_streams(rail, [safety], eps=0.25)
+    assert r1 == r2  # deterministic (parameter is the step index; no time, no randomness)
+    assert [row["step"] for row in r1] == ["inspect", "validate", "encode", "compare"]
+    assert r1[0]["bind"] and not r1[1]["bind"]  # binds at step 0, not at step 1


### PR DESCRIPTION
Your refinement made it real: not phi, but **shapes interacting** — an edge straight in one dimension, curved in another, with background depth.

Extends the existing tangentialism fleet router with its complement. The fleet router routes tasks→agents by **distance**; this routes instruction streams to each other by **intersection**. A stream is an edge of a shape: ordered steps embedded as points where each coordinate is its own function of the step index — so a side is **straight in one dim, curved/squiggly in another**. A background **depth** coordinate **gates** binding: two edges can cross in the visible dims yet sit at different depths and never bind. Where edges come within eps, step i of one stream co-fires with step j of the other — reshape the curves, reshape which instructions compose.

**Verified by execution:** two straight edges cross exactly once; a sine edge meets a straight rail at the predicted even steps; the same crossing curve binds at depth 0 but **not** at depth 5 (depth gates it); routing is deterministic. **9 tests** (5 fleet + 4 new).

Honest: this is a deterministic routing substrate (parametric curves + distance + a gate). `phi`/`golden` is only a curve *shape*, not mysticism. The gate + curve-shaping is what the geometry buys.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>