### PR TITLE
feat(helm): leveling --llm — ride a real small model up the slope (the small-model climb)

### DIFF
--- a/python/helm/leveling.py
+++ b/python/helm/leveling.py
@@ -183,6 +183,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     ap.add_argument("--curve", choices=CURVES, default="linear", help="the slope shape (level design)")
     ap.add_argument("--patience", type=int, default=1, help="consecutive crashes the rider survives")
     ap.add_argument("--compare", action="store_true", help="the same capped rider on every slope shape")
+    ap.add_argument("--llm", action="store_true", help="ride a free local small model (Ollama via helm.free_generator)")
+    ap.add_argument("--model", help="model id for --llm (default: SCBE_LLM_MODEL or the free_generator default)")
     a = ap.parse_args(list(argv) if argv is not None else None)
 
     if a.compare:
@@ -198,13 +200,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if a.naive:
         gen = naive_generator
+    elif a.llm:
+        from .free_generator import make_generator
+
+        gen = make_generator(model=a.model)
     elif a.capped is not None:
         gen = skill_capped_generator(a.capped, curve=a.curve)
     else:
         gen = reference_generator
     r = ride(gen, curve=a.curve, patience=a.patience)
     print(render(r))
-    if a.capped is not None:
+    if a.capped is not None or a.llm:
         c = cliff_vs_slope(gen, curve=a.curve, patience=a.patience)
         print(
             "\n  CLIFF vs SLOPE: the tier cliff says 'tier %d (%s)'; the slope also credits %s"

--- a/tests/test_leveling.py
+++ b/tests/test_leveling.py
@@ -100,3 +100,15 @@ def test_curve_rescales_height_for_the_same_cleared_levels():
     gentle = ride(gen, curve="gentle")
     assert steep["cleared"] == gentle["cleared"]  # same problems pass/fail -- the curve is a lens
     assert steep["peak_difficulty"] > gentle["peak_difficulty"]  # steep front-loads difficulty
+
+
+# --- the small-model climb wires up (no network needed to construct it) ---------
+
+
+def test_llm_generator_composes_offline():
+    # the small-model climb is `ride(make_generator())`; building the generator must not hit the
+    # network -- it only calls the endpoint when actually invoked on a problem.
+    from python.helm.free_generator import make_generator
+
+    gen = make_generator(model="dummy-model")
+    assert callable(gen)  # ready to drop into ride() / cliff_vs_slope() once a model is serving


### PR DESCRIPTION
`leveling.ride()` already takes any `public_bench.Generator`, and `free_generator` already builds an Ollama-backed (OpenAI-compatible) one — so the small-model climb **composes**. This adds the one-command entry point it was missing (`curriculum` had `--llm`; `leveling` didn't):

```
python -m python.helm.leveling --llm --curve gentle
python -m python.helm.leveling --llm --model qwen2.5-coder:7b
```

`--llm` rides the graded **slope** track and prints the **cliff vs slope** contrast, so a weak model's partial progress (the tier the cliff would discard) is visible. The model only **proposes**; `public_bench` **decides** (runs the code, hidden tests, overfit screen), so a weak/free model is safe.

**Honest:** with no model serving the endpoint, the rider crashes at rung 1 (0/15) — no fakery. This is the **wiring**, not a measured number: it needs a model serving (e.g. local Ollama), and none is installed here. The instant one is up, this command yields the real climb.

**10 leveling tests** (was 9): + the llm generator composes offline (building it never touches the network; it only calls the endpoint when invoked on a problem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)