### PR TITLE
feat(ci): redundancy gate -- catch conceptually-redundant work before it lands

### DIFF
--- a/scripts/ci/math_claims.txt
+++ b/scripts/ci/math_claims.txt
@@ -1,0 +1,19 @@
+# math-claims registry -- the one line of math each module implements.
+#
+# THE RULE (the second immune system): before new work lands, write its one-line math claim and
+# run  `python scripts/ci/redundancy_gate.py --claim "<your one-liner>"`.  Review anything it
+# surfaces BEFORE building -- that is what catches conceptually-redundant work (the #2422/#2423
+# two-string-designs near-collision) that execution + cross-face cannot see.
+#
+# Format:  <path>[#tag] :: <one-line math claim, in shared vocabulary>
+# Keep claims in shared words; the gate matches keywords, not meaning.
+
+python/scbe/loomfn.py :: dispatch-loop vm with a call-frame stack and heap arrays over a flat slot store, emitted to language faces
+python/scbe/loomfn.py#strings :: a string is a heap array of char codes
+python/helm/curriculum.py :: score a code generator by held-out hidden tests, graded into difficulty tiers
+python/helm/substrate_climber.py :: differential testing - emit a program to multiple language faces, run each, require agreement
+python/helm/public_bench.py :: run a generated program against public and held-out hidden asserts in a sandbox, detect overfit
+python/scbe/geometric_router.py :: route tasks to agents by tongue-weighted finsler distance through a hyperbolic manifold
+python/scbe/geometric_router.py#streams :: bind two instruction streams where their embedded points are within epsilon, a depth coordinate gating the distance
+python/scbe/dna_parse.py :: bijective hex to base-4 codec, one nibble is two base-4 symbols
+python/scbe/bijective_dna.py :: opcode strand with an involution complement and midpoint replication-fork assembly across language faces

--- a/scripts/ci/redundancy_gate.py
+++ b/scripts/ci/redundancy_gate.py
@@ -1,0 +1,140 @@
+"""redundancy_gate: surface conceptually-redundant work BEFORE it lands.
+
+Execution and cross-face agreement catch BROKEN code. They are blind to code that is correct but
+REDUNDANT -- two parallel sessions implementing the same idea in different words (the #2422/#2423
+near-collision: two "strings for loomfn" designs that almost stacked on each other). This is the
+second immune system: every module declares the ONE LINE OF MATH it implements (scripts/ci/
+math_claims.txt); before new work lands you check its claim against the registry and review
+anything that overlaps.
+
+    python scripts/ci/redundancy_gate.py --claim "a string is an array of character codes"
+    python scripts/ci/redundancy_gate.py --audit        # find overlaps already on main
+
+HONEST: this SURFACES likely overlaps for a human to judge -- recall over precision. It does not
+decide redundancy and does not block by default. It is keyword (Jaccard) overlap on normalized
+claims, so it MISSES synonyms: a claim about "text" will not match one about "strings". Keep claims
+in shared vocabulary. It is a checklist with teeth, not an oracle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import List, Sequence, Set, Tuple
+
+_STOP = {
+    "a",
+    "an",
+    "the",
+    "of",
+    "in",
+    "to",
+    "is",
+    "are",
+    "and",
+    "or",
+    "with",
+    "over",
+    "via",
+    "by",
+    "for",
+    "as",
+    "that",
+    "each",
+    "its",
+    "into",
+    "on",
+    "at",
+    "be",
+    "use",
+    "using",
+    "from",
+    "it",
+}
+
+
+def normalize(claim: str) -> Set[str]:
+    """Claim text -> the set of load-bearing keyword tokens (lowercased, stopworded, de-pluralized)."""
+    out: Set[str] = set()
+    for tok in re.findall(r"[a-z0-9]+", claim.lower()):
+        if tok in _STOP or len(tok) <= 1:
+            continue
+        if len(tok) > 3 and tok.endswith("s"):  # crude singularize: strings->string, arrays->array
+            tok = tok[:-1]
+        out.add(tok)
+    return out
+
+
+def overlap(a: str, b: str) -> float:
+    """Jaccard overlap of two claims' keyword sets (0.0 disjoint .. 1.0 identical)."""
+    ta, tb = normalize(a), normalize(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def load_registry(path: Path) -> List[Tuple[str, str]]:
+    """Parse `<path> :: <claim>` lines (ignoring # comments and blanks)."""
+    entries: List[Tuple[str, str]] = []
+    for raw in Path(path).read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "::" not in line:
+            continue
+        mod, claim = line.split("::", 1)
+        entries.append((mod.strip(), claim.strip()))
+    return entries
+
+
+def check(claim: str, registry: Sequence[Tuple[str, str]], threshold: float = 0.5) -> List[Tuple[str, str, float]]:
+    """Existing claims that overlap `claim` at or above threshold, most-similar first."""
+    scored = [(mod, c, overlap(claim, c)) for mod, c in registry]
+    return sorted((s for s in scored if s[2] >= threshold), key=lambda s: -s[2])
+
+
+def audit(registry: Sequence[Tuple[str, str]], threshold: float = 0.5) -> List[Tuple[str, str, float]]:
+    """All pairs of registered claims that overlap at or above threshold (find existing redundancy)."""
+    hits: List[Tuple[str, str, float]] = []
+    for i in range(len(registry)):
+        for j in range(i + 1, len(registry)):
+            s = overlap(registry[i][1], registry[j][1])
+            if s >= threshold:
+                hits.append((registry[i][0], registry[j][0], s))
+    return sorted(hits, key=lambda h: -h[2])
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="redundancy-gate", description="surface conceptually-redundant work before it lands"
+    )
+    ap.add_argument("--claim", help="the one-line math claim of the work you are about to build")
+    ap.add_argument("--audit", action="store_true", help="list overlapping claim pairs already on main")
+    ap.add_argument("--registry", default=str(Path(__file__).with_name("math_claims.txt")))
+    ap.add_argument("--threshold", type=float, default=0.5)
+    ap.add_argument("--strict", action="store_true", help="exit nonzero when overlaps are found (CI blocking)")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    reg = load_registry(Path(a.registry))
+
+    if a.audit:
+        hits = audit(reg, a.threshold)
+        for m1, m2, s in hits:
+            print("  OVERLAP %.2f   %s  <->  %s" % (s, m1, m2))
+        print("%d overlapping pair(s) on main (>= %.2f)" % (len(hits), a.threshold))
+        return 1 if (hits and a.strict) else 0
+
+    if a.claim:
+        hits = check(a.claim, reg, a.threshold)
+        if not hits:
+            print("no claim on main overlaps >= %.2f -- looks new, clear to build" % a.threshold)
+            return 0
+        print("REVIEW -- this overlaps existing work (might be redundant before you write a line):")
+        for mod, c, s in hits:
+            print('  %.2f  %s\n        "%s"' % (s, mod, c))
+        return 1 if a.strict else 0
+
+    ap.error('give --claim "<one-line math>" or --audit')
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_redundancy_gate.py
+++ b/tests/test_redundancy_gate.py
@@ -1,0 +1,68 @@
+"""redundancy_gate: the second immune system -- catch conceptually-redundant work before it lands.
+
+Execution + cross-face catch BROKEN code; this catches REDUNDANT code (two sessions building the
+same idea in different words). It must flag the #2422/#2423 two-string-designs collision class and
+must NOT false-positive on the genuinely-distinct modules already on main.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts" / "ci"))
+
+import redundancy_gate as rg  # noqa: E402
+
+REGISTRY = ROOT / "scripts" / "ci" / "math_claims.txt"
+
+
+def test_normalize_drops_stopwords_case_and_plurals():
+    toks = rg.normalize("A string is an array of CHAR codes")
+    assert "string" in toks and "array" in toks and "char" in toks and "code" in toks
+    assert "a" not in toks and "is" not in toks and "of" not in toks  # stopwords gone
+    assert "strings" not in toks and "arrays" not in toks  # de-pluralized
+
+
+def test_overlap_identical_and_disjoint():
+    assert rg.overlap("a string is an array of char codes", "a string is an array of char codes") == 1.0
+    assert rg.overlap("string array char codes", "geodesic hyperbolic manifold distance") == 0.0
+
+
+def test_two_string_designs_collide():
+    # the #2422 (strlit/chr) vs #2423 (str/char) near-collision: same idea, different words
+    a = "loomfn strings: a string is a heap array of char codes"
+    b = "add string support to loomfn via arrays of char codes"
+    assert rg.overlap(a, b) >= 0.5
+
+
+def test_unrelated_work_does_not_collide():
+    a = "a string is a heap array of char codes"
+    b = "bind two instruction streams within epsilon distance with a depth gate"
+    assert rg.overlap(a, b) < 0.3
+
+
+def test_check_against_seeded_registry_flags_a_redundant_string_layer():
+    # a realistic restatement of "add strings to loomfn" -- the #2422/#2423 class
+    reg = rg.load_registry(REGISTRY)
+    hits = rg.check("add strings to loomfn as arrays of char codes", reg, threshold=0.5)
+    assert any(mod.endswith("#strings") for mod, _claim, _score in hits)  # surfaces loomfn#strings
+
+
+def test_a_genuinely_new_claim_is_clear():
+    reg = rg.load_registry(REGISTRY)
+    hits = rg.check("schedule jobs onto worker threads by priority with backpressure", reg, threshold=0.5)
+    assert hits == []  # nothing like it on main -> clear to build
+
+
+def test_seed_registry_has_no_internal_false_positives():
+    # the modules actually on main are distinct; the gate must not cry wolf on them
+    reg = rg.load_registry(REGISTRY)
+    assert len(reg) >= 8
+    assert rg.audit(reg, threshold=0.5) == []
+
+
+def test_cli_claim_and_audit_run():
+    assert rg.main(["--claim", "a totally unprecedented widget", "--registry", str(REGISTRY)]) == 0
+    assert rg.main(["--audit", "--registry", str(REGISTRY)]) == 0
+    # strict mode exits nonzero when an overlap is found
+    assert rg.main(["--claim", "a string as a heap array of char codes", "--registry", str(REGISTRY), "--strict"]) == 1


### PR DESCRIPTION
The second immune system. Execution + cross-face catch **broken** code; they're blind to **redundant** code — two parallel sessions building the same idea in different words (the #2422/#2423 two-string-designs near-collision). 

Every module declares the one line of math it implements (`scripts/ci/math_claims.txt`); before new work lands, run `redundancy_gate --claim "<one-liner>"` and review what it surfaces.

**Mechanism:** normalize a claim to keyword tokens (lowercase, stopword, de-pluralize) → Jaccard-overlap against the registry → surface anything ≥ threshold. **Verified:** flags the string-collision class at 0.57, clears a genuinely-new claim, and finds **zero false-positives** across the 9 distinct modules now on main. 8 tests.

**Honest:** it *surfaces* likely overlaps for human review (recall over precision); it does not decide or block by default (`--strict` to block in CI). Keyword overlap misses synonyms ("text" vs "strings") — a checklist with teeth, not an oracle.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>