### PR TITLE
feat: perturbed bank → 20 problems + stepwise misstep-rewind step machine

### DIFF
--- a/python/helm/perturbed.py
+++ b/python/helm/perturbed.py
@@ -53,6 +53,17 @@ PT1 = [  # elementary, but not the canonical one-liners
         "def count_odds(xs):\n    return sum(1 for x in xs if x % 2 != 0)\n",
         ["assert count_odds([1, 2, 3, 4]) == 2", "assert count_odds([2, 4]) == 0", "assert count_odds([1, 3, 5]) == 3"],
     ),
+    _p(
+        "p1_clamp",
+        "Write `clamp(x, lo, hi)` returning x limited to the range [lo, hi] (lo if below, hi if above).",
+        "def clamp(x, lo, hi):\n    return max(lo, min(x, hi))\n",
+        [
+            "assert clamp(5, 0, 10) == 5",
+            "assert clamp(-3, 0, 10) == 0",
+            "assert clamp(15, 0, 10) == 10",
+            "assert clamp(7, 7, 7) == 7",
+        ],
+    ),
 ]
 
 PT2 = [  # loops + strings, twisted
@@ -90,6 +101,20 @@ PT2 = [  # loops + strings, twisted
             "assert consonant_count('hello') == 3",
             "assert consonant_count('aeiou') == 0",
             "assert consonant_count('xyz') == 3",
+        ],
+    ),
+    _p(
+        "p2_caesar_shift",
+        "Write `caesar_shift(s, k)` that shifts each lowercase letter in s forward by k positions in the alphabet "
+        "(wrapping z->a), leaving every other character unchanged.",
+        "def caesar_shift(s, k):\n    out = []\n    for c in s:\n        if 'a' <= c <= 'z':\n"
+        "            out.append(chr((ord(c) - 97 + k) % 26 + 97))\n        else:\n            out.append(c)\n"
+        "    return ''.join(out)\n",
+        [
+            "assert caesar_shift('abc', 1) == 'bcd'",
+            "assert caesar_shift('xyz', 2) == 'zab'",
+            "assert caesar_shift('hello', 0) == 'hello'",
+            "assert caesar_shift('a b', 1) == 'b c'",
         ],
     ),
 ]
@@ -130,6 +155,17 @@ PT3 = [  # algorithms, twisted
             "assert count_less([2, 2, 2], 2) == 0",
         ],
     ),
+    _p(
+        "p3_coprime",
+        "Write `coprime(a, b)` returning True iff a and b are coprime (their greatest common divisor is 1).",
+        "def coprime(a, b):\n    from math import gcd\n    return gcd(a, b) == 1\n",
+        [
+            "assert coprime(7, 5) == True",
+            "assert coprime(12, 8) == False",
+            "assert coprime(1, 9) == True",
+            "assert coprime(6, 9) == False",
+        ],
+    ),
 ]
 
 PT4 = [  # data structures + DP, twisted
@@ -168,6 +204,18 @@ PT4 = [  # data structures + DP, twisted
             "assert longest_decreasing([1, 2, 3]) == 1",
             "assert longest_decreasing([]) == 0",
             "assert longest_decreasing([9, 8, 7]) == 3",
+        ],
+    ),
+    _p(
+        "p4_most_common_char",
+        "Write `most_common_char(s)` returning the most frequent character in the non-empty string s; "
+        "on a tie, return the smallest character.",
+        "def most_common_char(s):\n    from collections import Counter\n    c = Counter(s)\n"
+        "    return min(c, key=lambda ch: (-c[ch], ch))\n",
+        [
+            "assert most_common_char('aabbbc') == 'b'",
+            "assert most_common_char('abab') == 'a'",
+            "assert most_common_char('z') == 'z'",
         ],
     ),
 ]
@@ -216,6 +264,22 @@ PT5 = [  # hard DP / strings, twisted
             "assert is_subsequence('axc', 'ahbgdc') == False",
             "assert is_subsequence('', 'abc') == True",
             "assert is_subsequence('abc', 'ab') == False",
+        ],
+    ),
+    _p(
+        "p5_lcsubstr",
+        "Write `longest_common_substring(a, b)` returning the length of the longest CONTIGUOUS substring common to "
+        "strings a and b (contiguous, not a subsequence).",
+        "def longest_common_substring(a, b):\n    m, n = len(a), len(b)\n    best = 0\n"
+        "    dp = [[0] * (n + 1) for _ in range(m + 1)]\n"
+        "    for i in range(1, m + 1):\n        for j in range(1, n + 1):\n"
+        "            if a[i - 1] == b[j - 1]:\n                dp[i][j] = dp[i - 1][j - 1] + 1\n"
+        "                if dp[i][j] > best:\n                    best = dp[i][j]\n    return best\n",
+        [
+            "assert longest_common_substring('abcde', 'zbcdf') == 3",
+            "assert longest_common_substring('abc', 'abc') == 3",
+            "assert longest_common_substring('abc', 'xyz') == 0",
+            "assert longest_common_substring('aaa', 'aa') == 2",
         ],
     ),
 ]

--- a/python/scbe/stepwise.py
+++ b/python/scbe/stepwise.py
@@ -1,0 +1,213 @@
+"""stepwise: a guided step machine where a misstep REWINDS instead of failing -- the repair loop.
+
+The weak-model failures we measured (fizzbuzz's i%3 polarity, max_coins' wrong objective) share a
+shape: the model does an exact computation in its head and gets it subtly wrong, then commits the
+mistake into the final answer with no chance to recover. This machine removes both halves of that:
+
+  * DETERMINISTIC STEPS ARE A CALCULATOR -- a step can be a `calc` run by CODE (a lookup table / the
+    sieve / plain arithmetic), never the model. The exact computation the model would botch (a
+    modulo, a table lookup) is just done correctly. The model is only asked to make the CHOICES that
+    actually need judgement.
+  * A MISSTEP REWINDS, IT DOES NOT FAIL -- at a `choice` step the model proposes a value; a checker
+    (the walls + a correctness test) accepts or rejects it. A rejected value is a MISSTEP: the
+    machine stays put (the bad value is never committed), emits a WARNING, rebuilds the context from
+    the goal + the steps that already ran + what went wrong, and lets the model try again from
+    exactly the position before the misstep. After `max_rewinds` it stops honestly at that step --
+    that is the model's real ceiling, surfaced, not a corrupted answer.
+
+So the scaffold carries the exactness and the memory; the model only supplies judgement, and its
+mistakes are caught and rewound instead of shipped. Proposers are pluggable callables; the scripted
+stubs prove the loop by construction, and a real model drops into the same slot.
+
+    t = number_label_task(6)                 # r3=6%3, r5=6%5 done by CALC; the label is the choice
+    run_stepwise(t, scripted_proposer(["Buzz", "Fizz"]))   # 'Buzz' missteps -> rewind -> 'Fizz' ok
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+# a proposer is the model slot: given the rebuilt context and the legal options, choose a value
+Proposer = Callable[[str, List[str]], str]
+
+
+@dataclass
+class Step:
+    """One step. A `calc` step is deterministic (code, never the model). A `choice` step asks the
+    model for a value, gated by `options` (the legal set / walls) and `check` (is it correct)."""
+
+    name: str
+    key: str
+    calc: Optional[Callable[[Dict[str, Any]], Any]] = None
+    options: Optional[Callable[[Dict[str, Any]], List[str]]] = None
+    check: Optional[Callable[[Dict[str, Any], str], bool]] = None
+
+    def is_calc(self) -> bool:
+        return self.calc is not None
+
+
+@dataclass
+class Task:
+    name: str
+    steps: List[Step]
+    goal: str = ""
+
+
+def build_context(task: Task, state: Dict[str, Any], step: Step, options: List[str], trace: List[dict]) -> str:
+    """Reconstruct the instruction from the goal + the steps already run + any misstep warning.
+
+    This is the 'instructions gathered from context and the ran steps up to that point' -- a stateless
+    model rehydrates exactly where it is and what just went wrong, without holding its own history.
+    """
+    done = [t for t in trace if t["status"] == "ok"]
+    lines = ["goal: %s" % (task.goal or task.name)]
+    if done:
+        lines.append("steps done: " + " | ".join("%s=%s" % (t["step"], t["value"]) for t in done))
+    lines.append("now: choose %s   allowed: %s" % (step.name, options))
+    if state.get("_warning"):
+        lines.append("[!] " + state["_warning"])  # the rewind warning
+    return "\n".join(lines)
+
+
+def run_stepwise(task: Task, proposer: Proposer, max_rewinds: int = 3) -> Dict[str, Any]:
+    """Walk the steps. Calc steps run in code; choice steps call the model and rewind on a misstep."""
+    state: Dict[str, Any] = {}
+    trace: List[dict] = []
+    pos = 0
+    total_rewinds = 0
+    model_calls = 0
+    while pos < len(task.steps):
+        step = task.steps[pos]
+        if step.is_calc():
+            v = step.calc(state)  # type: ignore[misc]
+            state[step.key] = v
+            trace.append({"step": step.name, "source": "calc", "value": v, "status": "ok"})
+            pos += 1
+            continue
+        options = step.options(state) if step.options else []
+        rewinds = 0
+        while True:
+            ctx = build_context(task, state, step, options, trace)
+            value = proposer(ctx, options)
+            model_calls += 1
+            legal = (not options) or (value in options)
+            correct = step.check(state, value) if step.check else legal
+            if legal and correct:
+                state[step.key] = value
+                state.pop("_warning", None)
+                trace.append({"step": step.name, "source": "model", "value": value, "status": "ok", "rewinds": rewinds})
+                pos += 1
+                break
+            rewinds += 1
+            total_rewinds += 1
+            why = "not in the allowed set" if not legal else "failed the step's check"
+            trace.append({"step": step.name, "source": "model", "value": value, "status": "misstep", "why": why})
+            if rewinds > max_rewinds:  # exhausted -> honest ceiling at this step
+                state.pop("_warning", None)
+                return {
+                    "completed": False,
+                    "stuck_at": step.name,
+                    "state": state,
+                    "rewinds": total_rewinds,
+                    "model_calls": model_calls,
+                    "trace": trace,
+                }
+            # rewind: position is unchanged (the bad value was never committed); retry with a warning
+            state["_warning"] = "misstep at '%s': %r %s -- back up and choose from %s" % (
+                step.name,
+                value,
+                why,
+                options,
+            )
+    return {
+        "completed": True,
+        "answer": trace[-1]["value"] if trace else None,
+        "state": state,
+        "rewinds": total_rewinds,
+        "model_calls": model_calls,
+        "trace": trace,
+    }
+
+
+# --- pluggable proposer stubs (a real model drops into the same slot) ----------------
+def scripted_proposer(seq: List[str]) -> Proposer:
+    """Return the given answers in order (clamped to the last) -- to script misstep/recover paths."""
+    calls = {"i": 0}
+
+    def p(_ctx: str, _options: List[str]) -> str:
+        i = min(calls["i"], len(seq) - 1)
+        calls["i"] += 1
+        return seq[i]
+
+    return p
+
+
+def always_proposer(value: str) -> Proposer:
+    def p(_ctx: str, _options: List[str]) -> str:
+        return value
+
+    return p
+
+
+# --- a demo task: classify a number, with the modulo done by CALC (not the model) ----
+_LABELS = ("Fizz", "Buzz", "FizzBuzz")
+
+
+def number_label_task(i: int) -> Task:
+    """r3 = i%3 and r5 = i%5 are computed deterministically; only the LABEL is a model choice.
+
+    This is exactly the fizzbuzz failure mode defused: the model never does the modulo it kept getting
+    wrong -- it only picks the label, and a wrong pick rewinds instead of shipping.
+    """
+
+    def correct_label(st: Dict[str, Any]) -> str:
+        if st["r3"] == 0 and st["r5"] == 0:
+            return "FizzBuzz"
+        if st["r3"] == 0:
+            return "Fizz"
+        if st["r5"] == 0:
+            return "Buzz"
+        return str(i)
+
+    return Task(
+        name="number_label(%d)" % i,
+        goal="label %d by the fizzbuzz rule" % i,
+        steps=[
+            Step("r3", "r3", calc=lambda st: i % 3),
+            Step("r5", "r5", calc=lambda st: i % 5),
+            Step(
+                "label",
+                "label",
+                options=lambda st: list(_LABELS) + [str(i)],
+                check=lambda st, v: v == correct_label(st),
+            ),
+        ],
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    print("STEPWISE  a misstep rewinds (with warning + rebuilt context) instead of failing\n")
+
+    print("== clean run: the model picks the right label first try (mod done by calc) ==")
+    r = run_stepwise(number_label_task(6), scripted_proposer(["Fizz"]))
+    print(
+        "  6 -> %s   completed=%s  rewinds=%d  model_calls=%d"
+        % (r["answer"], r["completed"], r["rewinds"], r["model_calls"])
+    )
+
+    print("\n== misstep + recover: 'Buzz' is wrong for 6, the machine rewinds and warns ==")
+    r = run_stepwise(number_label_task(6), scripted_proposer(["Buzz", "Fizz"]))
+    for t in r["trace"]:
+        extra = ("  <- " + t["why"]) if t["status"] == "misstep" else ""
+        print("  %-6s %-6s %-9s %s%s" % (t["step"], t["source"], t["status"], t["value"], extra))
+    print("  -> %s   completed=%s  rewinds=%d" % (r["answer"], r["completed"], r["rewinds"]))
+
+    print("\n== stuck: a model that keeps mis-stepping stops honestly at its ceiling ==")
+    r = run_stepwise(number_label_task(6), always_proposer("Buzz"), max_rewinds=2)
+    print("  completed=%s  stuck_at=%s  rewinds=%d" % (r["completed"], r.get("stuck_at"), r["rewinds"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_perturbed.py
+++ b/tests/test_perturbed.py
@@ -18,8 +18,8 @@ from python.helm.perturbed import PERTURBED_CURRICULUM, verify_buildable  # noqa
 
 def test_perturbed_ladder_is_solvable_and_floored():
     r = verify_buildable()
-    assert r["problems"] == 15
-    assert r["reference_verified"] == 15  # the answer key clears all -> the twists are solvable
+    assert r["problems"] == 20
+    assert r["reference_verified"] == 20  # the answer key clears all -> the twists are solvable
     assert r["naive_verified"] == 0  # the failing stub clears none -> a real floor
 
 
@@ -27,12 +27,12 @@ def test_perturbed_problems_are_disjoint_from_the_canonical_ones():
     canon = {p["task_id"] for t in CURRICULUM for p in t["problems"]}
     pert = {p["task_id"] for t in PERTURBED_CURRICULUM for p in t["problems"]}
     assert not (canon & pert)  # no shared task ids -- these are new problems
-    assert len(pert) == 15
+    assert len(pert) == 20
 
 
 def test_perturbed_mirrors_the_tier_structure():
     assert [t["tier"] for t in PERTURBED_CURRICULUM] == [1, 2, 3, 4, 5]
-    assert all(len(t["problems"]) == 3 for t in PERTURBED_CURRICULUM)
+    assert all(len(t["problems"]) == 4 for t in PERTURBED_CURRICULUM)
 
 
 def test_a_twisted_reference_encodes_the_new_spec_not_the_canonical_one():

--- a/tests/test_stepwise.py
+++ b/tests/test_stepwise.py
@@ -1,0 +1,67 @@
+"""stepwise: a guided step machine where a misstep rewinds (with a warning + rebuilt context) instead
+of failing, and exact computations are offloaded to deterministic `calc` steps (never the model).
+
+These tests prove the two mechanics: the model is called only for choices (calc steps run in code),
+and a rejected value rewinds to before the misstep and retries with the ran-steps context + warning,
+recovering when the next answer is right and stopping honestly when it never is.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.stepwise import (  # noqa: E402
+    always_proposer,
+    number_label_task,
+    run_stepwise,
+    scripted_proposer,
+)
+
+
+def test_calc_steps_run_in_code_not_the_model():
+    # number_label has two calc steps (r3, r5) + one choice; only the choice should call the model
+    r = run_stepwise(number_label_task(6), scripted_proposer(["Fizz"]))
+    assert r["completed"] is True
+    assert r["answer"] == "Fizz"
+    assert r["model_calls"] == 1  # the modulo was done by calc, not asked of the model
+    assert r["state"]["r3"] == 0 and r["state"]["r5"] == 1  # exact, never hallucinated
+
+
+def test_a_misstep_rewinds_and_recovers():
+    # 'Buzz' is wrong for 6 (r5 != 0); the machine rewinds, warns, and accepts the corrected 'Fizz'
+    r = run_stepwise(number_label_task(6), scripted_proposer(["Buzz", "Fizz"]))
+    assert r["completed"] is True and r["answer"] == "Fizz"
+    assert r["rewinds"] == 1
+    statuses = [t["status"] for t in r["trace"] if t["source"] == "model"]
+    assert statuses == ["misstep", "ok"]  # bad value dropped, never committed
+
+
+def test_exhausted_rewinds_stops_honestly_at_the_step():
+    # a model that always mis-steps does not corrupt the answer -- it stops at its ceiling
+    r = run_stepwise(number_label_task(6), always_proposer("Buzz"), max_rewinds=2)
+    assert r["completed"] is False
+    assert r["stuck_at"] == "label"
+    assert r["rewinds"] == 3  # max_rewinds=2 -> a third misstep ends it
+
+
+def test_rewind_context_carries_the_ran_steps_and_a_warning():
+    seen = []
+
+    def capturing(ctx, options):
+        seen.append(ctx)
+        return "Buzz" if len(seen) == 1 else "Fizz"  # misstep first, then correct
+
+    r = run_stepwise(number_label_task(6), capturing)
+    assert r["completed"] is True and r["rewinds"] == 1
+    # the retry context rebuilds where we are from the steps that ran, plus the misstep warning
+    assert "r3=0" in seen[1] and "r5=1" in seen[1]
+    assert "[!]" in seen[1]
+
+
+def test_offloaded_modulo_makes_the_correct_label_pass_for_any_i():
+    # because r3/r5 are exact, a correct label choice always verifies -- across the rule's branches
+    for i, label in [(3, "Fizz"), (5, "Buzz"), (15, "FizzBuzz"), (7, "7")]:
+        r = run_stepwise(number_label_task(i), scripted_proposer([label]))
+        assert r["completed"] is True and r["answer"] == label


### PR DESCRIPTION
Two related moves: more statistical power for the recall-proofed ladder, and the **repair loop** that fixes the bugs that ladder surfaces.

**perturbed: 15 → 20** (a 4th twist per tier): `clamp`, `caesar_shift`, `coprime`, `most_common_char`, `longest_common_substring` (contiguous — *not* the memorized subsequence). `verify_buildable()` = reference **20/20**, naive **0/20**.

**stepwise** (`python/scbe/stepwise.py`) — operationalizes Issac's idea: a deterministic-calculator + backtrack-on-misstep step machine.

| mechanic | what it does |
|---|---|
| **calc steps run in code** | a lookup table / sieve / arithmetic — *never* the model. The exact computation the model botches (the fizzbuzz `i%3` polarity) is just done right; the model only makes judgement choices |
| **a misstep rewinds, doesn't fail** | a rejected choice is never committed: the machine stays put, emits a warning, rebuilds context from the goal + the steps already run + what went wrong, and retries from before the misstep |
| **honest ceiling** | after `max_rewinds` it stops at the step — the model's real ceiling, surfaced, not a corrupted answer |

Proposers are pluggable (scripted stubs prove the loop; a real model drops into the same slot). The demo `number_label_task` defuses the exact fizzbuzz failure: modulo by calc, label by choice, a wrong label rewinds → recovers.

**Tests (13 total):** perturbed 20 solvable + floored + disjoint + 4-per-tier; stepwise calc-not-model, misstep rewinds + recovers, exhausted rewinds stops honestly, rewind context carries ran-steps + warning, offloaded modulo verifies across the rule's branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)