### PR TITLE
feat(helm): auto-gradable reasoning ladder + shared ladder kernel (curriculum migrated)

### DIFF
--- a/python/helm/curriculum.py
+++ b/python/helm/curriculum.py
@@ -26,8 +26,9 @@ from the bottom -- you don't get a PhD by acing the PhD test while failing 3rd-g
 from __future__ import annotations
 
 import argparse
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
+from .ladder import run_ladder
 from .public_bench import Generator, naive_generator, reference_generator, run_public_bench
 
 
@@ -246,35 +247,24 @@ def run_curriculum(
 ) -> Dict[str, Any]:
     """Run a climber up the ladder. A tier is cleared only if every problem passes hidden checks;
     the climb is the highest CONTIGUOUS tier cleared from the bottom."""
-    per_tier: List[Dict[str, Any]] = []
-    for t in tiers:
+
+    def score(t: Dict[str, Any]) -> Dict[str, Any]:
         s = run_public_bench(t["problems"], generator=generator, public_k=public_k)
-        per_tier.append(
-            {
-                "tier": t["tier"],
-                "grade": t["grade"],
-                "attempted": s["attempted"],
-                "verified": s["verified"],
-                "overfit_caught": s["overfit_caught"],
-                "cleared": s["attempted"] > 0 and s["verified"] == s["attempted"],
-                "pass_rate": s["pass_rate"],
-            }
-        )
-    climb = 0
-    for r in per_tier:
-        if r["cleared"]:
-            climb = r["tier"]
-        else:
-            break
-    cleared_grade = next((r["grade"] for r in per_tier if r["tier"] == climb), "none")
+        return {
+            "attempted": s["attempted"],
+            "passed": s["verified"],
+            "extra": {"verified": s["verified"], "overfit_caught": s["overfit_caught"], "pass_rate": s["pass_rate"]},
+        }
+
+    res = run_ladder(tiers, score)  # shared kernel: per-tier score -> highest contiguous tier
     return {
         "generator": generator.__name__,
         "public_k": public_k,
-        "highest_tier_cleared": climb,
-        "highest_grade_cleared": cleared_grade,
-        "total_verified": sum(r["verified"] for r in per_tier),
-        "total_problems": sum(r["attempted"] for r in per_tier),
-        "tiers": per_tier,
+        "highest_tier_cleared": res["highest_tier_cleared"],
+        "highest_grade_cleared": res["highest_grade_cleared"],
+        "total_verified": res["total_passed"],
+        "total_problems": res["total"],
+        "tiers": res["tiers"],
     }
 
 

--- a/python/helm/ladder.py
+++ b/python/helm/ladder.py
@@ -1,0 +1,62 @@
+"""ladder: the shared kernel for graded "how high did it climb" tests.
+
+curriculum.py (code, scored by running held-out tests) and reasoning_ladder.py (Q&A, scored by
+exact match) are the SAME shape -- tiers of held-out items, a climber, a score per tier, and the
+climb is the highest CONTIGUOUS tier cleared from the bottom (no grade-skipping). That shape lives
+here once, with the scorer left pluggable, so the content and grading differ across ladders but the
+laddering is never reimplemented. (Extracted after the redundancy gate flagged the overlap.)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Sequence
+
+# score_tier(tier) -> {"attempted": int, "passed": int, "extra": {...optional passthrough...}}
+ScoreTier = Callable[[Dict[str, Any]], Dict[str, Any]]
+
+
+def run_ladder(tiers: Sequence[Dict[str, Any]], score_tier: ScoreTier) -> Dict[str, Any]:
+    """Score every tier, then report the highest CONTIGUOUS tier cleared from the bottom.
+
+    A tier is cleared only if every item in it passes. The climb stops at the first tier that is
+    not fully cleared -- acing tier 5 while failing tier 3 still leaves you stuck at tier 2."""
+    per_tier: List[Dict[str, Any]] = []
+    for t in tiers:
+        s = score_tier(t)
+        attempted, passed = int(s["attempted"]), int(s["passed"])
+        row: Dict[str, Any] = {
+            "tier": t["tier"],
+            "grade": t["grade"],
+            "attempted": attempted,
+            "passed": passed,
+            "cleared": attempted > 0 and passed == attempted,
+        }
+        row.update(s.get("extra", {}))
+        per_tier.append(row)
+    climb = 0
+    for r in per_tier:
+        if r["cleared"]:
+            climb = r["tier"]
+        else:
+            break
+    grade = next((r["grade"] for r in per_tier if r["tier"] == climb), "none")
+    return {
+        "highest_tier_cleared": climb,
+        "highest_grade_cleared": grade,
+        "total_passed": sum(r["passed"] for r in per_tier),
+        "total": sum(r["attempted"] for r in per_tier),
+        "tiers": per_tier,
+    }
+
+
+def render_climb(summary: Dict[str, Any], title: str = "LADDER CLIMB") -> str:
+    lines = [title]
+    for r in summary["tiers"]:
+        bar = "#" * r["passed"] + "." * (r["attempted"] - r["passed"])
+        mark = "PASS" if r["cleared"] else ""
+        lines.append("  T%d %-13s %d/%d  %-10s %s" % (r["tier"], r["grade"], r["passed"], r["attempted"], bar, mark))
+    lines.append(
+        "  --> cleared through T%d (%s);  total %d/%d"
+        % (summary["highest_tier_cleared"], summary["highest_grade_cleared"], summary["total_passed"], summary["total"])
+    )
+    return "\n".join(lines)

--- a/python/helm/reasoning_ladder.py
+++ b/python/helm/reasoning_ladder.py
@@ -1,0 +1,157 @@
+"""reasoning_ladder: a graded, auto-gradable reasoning test (the scoreboard), built on ladder.py.
+
+A general-knowledge/reasoning sibling of curriculum.py (which scores CODE). Any climber is a
+`generator(item) -> answer string`; an item is graded by EXACT MATCH against a held-out answer
+(numbers compared numerically). Tiers run arithmetic -> pre-algebra -> competition-lite ->
+multi-step -> hard, and the climb is the highest CONTIGUOUS tier cleared (ladder.py).
+
+WHY exact-match hand-authored items, not "the SAT": the SAT and the public sets (GSM8K/MMLU) are
+saturated and likely memorized by frontier models -- a number on them is inflated and gives no
+signal. These are hand-authored, contamination-free-ER, and objectively gradable (no judge model).
+HONEST LIMITS: (1) few items; (2) some are classic enough to be memorizable; (3) the top tier is
+"hard multi-step competition math", NOT FrontierMath/HLE difficulty (that needs gated content).
+Swap in your own items; the scoreboard is the point.
+
+This is a SCOREBOARD, not a capability claim. The real question (Issac's thesis) is LIFT: does a
+model scored THROUGH the harness (logic gates + tools) beat the same model raw? `measure_lift`
+computes that delta -- but a real lift number needs a real model plugged into both slots.
+
+    python -m python.helm.reasoning_ladder --reference   # answer key: clears all (validates grader)
+    python -m python.helm.reasoning_ladder --naive        # the floor: clears nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Callable, Dict, List, Sequence
+
+from .ladder import render_climb, run_ladder
+
+Climber = Callable[[Dict[str, Any]], str]
+
+
+def _q(qid: str, question: str, answer: Any) -> Dict[str, Any]:
+    return {"id": qid, "question": question, "answer": str(answer)}
+
+
+REASONING_LADDER: List[Dict[str, Any]] = [
+    {
+        "tier": 1,
+        "grade": "arithmetic",
+        "items": [
+            _q("a1", "What is 7 * 8?", 56),
+            _q("a2", "What is 1+2+3+...+10?", 55),
+            _q("a3", "What is the remainder when 17 is divided by 5?", 2),
+            _q("a4", "What is 144 / 12?", 12),
+        ],
+    },
+    {
+        "tier": 2,
+        "grade": "pre-algebra",
+        "items": [
+            _q("p1", "If 3x + 4 = 19, what is x?", 5),
+            _q("p2", "A train travels 60 mph for 2.5 hours. How many miles?", 150),
+            _q("p3", "What is 12% of 250?", 30),
+            _q("p4", "Perimeter of a rectangle 5 by 8?", 26),
+        ],
+    },
+    {
+        "tier": 3,
+        "grade": "competition-lite",
+        "items": [
+            _q("c1", "How many positive divisors does 36 have?", 9),
+            _q("c2", "What is the sum of the first 20 positive odd numbers?", 400),
+            _q("c3", "How many distinct arrangements of the letters in LEVEL?", 30),
+            _q("c4", "What is the GCD of 48 and 36?", 12),
+        ],
+    },
+    {
+        "tier": 4,
+        "grade": "multi-step",
+        "items": [
+            _q("m1", "How many integers from 1 to 1000 are divisible by 3 or 5?", 467),
+            _q("m2", "How many trailing zeros does 100! have?", 24),
+            _q("m3", "Lattice paths from (0,0) to (4,4) moving only right or up?", 70),
+            _q("m4", "Smallest n such that n! is divisible by 1000?", 15),
+        ],
+    },
+    {
+        "tier": 5,
+        "grade": "hard",
+        "items": [
+            _q("h1", "How many positive integers below 100 are coprime to 100?", 40),
+            _q("h2", "Remainder when 3^100 is divided by 100?", 1),
+            _q("h3", "How many subsets of a 5-element set contain at least one element?", 31),
+            _q("h4", "What is the sum of the digits of 2^10?", 7),
+        ],
+    },
+]
+
+
+def normalize_answer(a: Any) -> str:
+    return str(a).strip().lower().rstrip(".").strip()
+
+
+def exact_match(got: Any, want: Any) -> bool:
+    g, w = normalize_answer(got), normalize_answer(want)
+    if g == w:
+        return True
+    try:
+        return abs(float(g) - float(w)) <= 1e-9
+    except ValueError:
+        return False
+
+
+def reference_climber(item: Dict[str, Any]) -> str:
+    """The answer key -- validates the grader + that items are solvable. Not a capability measure."""
+    return item["answer"]
+
+
+def naive_climber(item: Dict[str, Any]) -> str:
+    """The floor: no answer. Should clear nothing."""
+    return ""
+
+
+def run_reasoning(
+    climber: Climber = reference_climber, ladder: Sequence[Dict[str, Any]] = REASONING_LADDER
+) -> Dict[str, Any]:
+    def score(t: Dict[str, Any]) -> Dict[str, Any]:
+        passed = sum(1 for it in t["items"] if exact_match(climber(it), it["answer"]))
+        return {"attempted": len(t["items"]), "passed": passed}
+
+    summary = run_ladder(ladder, score)
+    summary["climber"] = getattr(climber, "__name__", "climber")
+    return summary
+
+
+def measure_lift(
+    baseline: Climber, tooled: Climber, ladder: Sequence[Dict[str, Any]] = REASONING_LADDER
+) -> Dict[str, Any]:
+    """LIFT = (tooled climb) - (baseline climb). The harness 'works' only if tooled > baseline.
+    Plug the SAME model into both slots -- raw vs routed-through-the-gates-and-tools -- to get a
+    real number. With non-model climbers this only confirms the measurement, not capability."""
+    b, t = run_reasoning(baseline, ladder), run_reasoning(tooled, ladder)
+    return {
+        "baseline": b["climber"],
+        "tooled": t["climber"],
+        "baseline_cleared": b["highest_tier_cleared"],
+        "tooled_cleared": t["highest_tier_cleared"],
+        "tier_lift": t["highest_tier_cleared"] - b["highest_tier_cleared"],
+        "baseline_total": b["total_passed"],
+        "tooled_total": t["total_passed"],
+        "total_lift": t["total_passed"] - b["total_passed"],
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="scbe-reasoning-ladder", description="graded auto-gradable reasoning scoreboard")
+    ap.add_argument("--reference", action="store_true", help="answer-key climber (validates the grader)")
+    ap.add_argument("--naive", action="store_true", help="failing-floor climber")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    climber = naive_climber if a.naive else reference_climber
+    print(render_climb(run_reasoning(climber), title="REASONING LADDER  (auto-gradable, exact-match)"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/math_claims.txt
+++ b/scripts/ci/math_claims.txt
@@ -10,7 +10,9 @@
 
 python/scbe/loomfn.py :: dispatch-loop vm with a call-frame stack and heap arrays over a flat slot store, emitted to language faces
 python/scbe/loomfn.py#strings :: a string is a heap array of char codes
-python/helm/curriculum.py :: score a code generator by held-out hidden tests, graded into difficulty tiers
+python/helm/ladder.py :: graded tier-ladder kernel - score a climber per tier, report the highest contiguous tier cleared from the bottom
+python/helm/curriculum.py :: score a code generator by held-out hidden tests, graded into difficulty tiers (uses the ladder kernel)
+python/helm/reasoning_ladder.py :: score an answer generator by held-out exact-match reasoning questions, graded into difficulty tiers (uses the ladder kernel)
 python/helm/substrate_climber.py :: differential testing - emit a program to multiple language faces, run each, require agreement
 python/helm/public_bench.py :: run a generated program against public and held-out hidden asserts in a sandbox, detect overfit
 python/scbe/geometric_router.py :: route tasks to agents by tongue-weighted finsler distance through a hyperbolic manifold

--- a/tests/test_ladder.py
+++ b/tests/test_ladder.py
@@ -1,0 +1,47 @@
+"""ladder: the shared graded-climb kernel. A tier clears only if every item passes; the climb is
+the highest CONTIGUOUS tier from the bottom (no grade-skipping). Used by curriculum + reasoning."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.helm.ladder import render_climb, run_ladder  # noqa: E402
+
+
+def _tiers():
+    return [
+        {"tier": 1, "grade": "a"},
+        {"tier": 2, "grade": "b"},
+        {"tier": 3, "grade": "c"},
+    ]
+
+
+def test_contiguous_climb_stops_at_first_gap():
+    def score(t):
+        return {"attempted": 2, "passed": {1: 2, 2: 2, 3: 1}[t["tier"]]}  # T3 partial
+
+    s = run_ladder(_tiers(), score)
+    assert s["highest_tier_cleared"] == 2
+    assert s["highest_grade_cleared"] == "b"
+    assert s["total_passed"] == 5 and s["total"] == 6
+
+
+def test_acing_a_high_tier_while_failing_a_low_one_does_not_skip():
+    def score(t):
+        return {"attempted": 2, "passed": {1: 1, 2: 2, 3: 2}[t["tier"]]}  # T1 fails
+
+    s = run_ladder(_tiers(), score)
+    assert s["highest_tier_cleared"] == 0
+    assert s["highest_grade_cleared"] == "none"
+
+
+def test_extra_passthrough_and_render():
+    def score(t):
+        return {"attempted": 2, "passed": 2, "extra": {"note": "ok"}}
+
+    s = run_ladder(_tiers(), score)
+    assert all(r["note"] == "ok" for r in s["tiers"])
+    out = render_climb(s, "X")
+    assert "X" in out and "cleared through T3" in out

--- a/tests/test_reasoning_ladder.py
+++ b/tests/test_reasoning_ladder.py
@@ -1,0 +1,64 @@
+"""reasoning_ladder: a graded auto-gradable reasoning scoreboard (sibling of curriculum, on the
+ladder kernel). Exact-match grading; the answer key clears all tiers (validates the grader), the
+floor clears nothing, the climb is contiguous, and measure_lift reports a raw-vs-tooled delta."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.helm.reasoning_ladder import (  # noqa: E402
+    REASONING_LADDER,
+    exact_match,
+    measure_lift,
+    naive_climber,
+    reference_climber,
+    run_reasoning,
+)
+
+
+def test_grader_is_exact_and_numeric():
+    assert exact_match("56", "56")
+    assert exact_match(" 56 ", "56")  # normalized
+    assert exact_match("5", "5.0")  # numeric compare
+    assert not exact_match("cat", "dog")
+    assert not exact_match("", "5")  # the floor's empty answer never passes
+
+
+def test_reference_clears_the_whole_ladder():
+    # the answer key proves every item is solvable and the grader is correct
+    s = run_reasoning(reference_climber)
+    assert s["highest_tier_cleared"] == 5
+    assert s["total_passed"] == s["total"] == 20
+
+
+def test_naive_floor_clears_nothing():
+    s = run_reasoning(naive_climber)
+    assert s["highest_tier_cleared"] == 0 and s["total_passed"] == 0
+
+
+def test_ladder_is_graded_and_well_formed():
+    grades = [t["grade"] for t in REASONING_LADDER]
+    assert grades == ["arithmetic", "pre-algebra", "competition-lite", "multi-step", "hard"]
+    for t in REASONING_LADDER:
+        assert len(t["items"]) == 4
+        for it in t["items"]:
+            assert it["question"] and it["answer"]
+
+
+def test_climb_is_contiguous_from_the_bottom():
+    # solves everything except one tier-3 item -> stuck at tier 2, no skipping
+    def almost(item):
+        return "" if item["id"] == "c1" else item["answer"]
+
+    almost.__name__ = "almost"
+    s = run_reasoning(almost)
+    assert s["highest_tier_cleared"] == 2
+    assert s["total_passed"] == 19
+
+
+def test_measure_lift_reports_the_delta():
+    # MECHANISM CHECK ONLY (naive baseline vs reference tooled) -- not a capability claim
+    r = measure_lift(naive_climber, reference_climber)
+    assert r["tier_lift"] == 5 and r["total_lift"] == 20

--- a/tests/test_redundancy_gate.py
+++ b/tests/test_redundancy_gate.py
@@ -54,11 +54,16 @@ def test_a_genuinely_new_claim_is_clear():
     assert hits == []  # nothing like it on main -> clear to build
 
 
-def test_seed_registry_has_no_internal_false_positives():
-    # the modules actually on main are distinct; the gate must not cry wolf on them
+def test_seed_registry_surfaces_only_the_known_kernel_sibling_overlap():
+    # curriculum + reasoning_ladder are intentional siblings on ladder.py: the gate SHOULD flag them
+    # (same "score a generator on held-out items, graded into tiers" shape), and that overlap is
+    # acknowledged -- resolved by the shared kernel, not by hiding it. NOTHING ELSE may overlap.
     reg = rg.load_registry(REGISTRY)
-    assert len(reg) >= 8
-    assert rg.audit(reg, threshold=0.5) == []
+    assert len(reg) >= 10
+    pairs = {frozenset((m1, m2)) for m1, m2, _ in rg.audit(reg, threshold=0.5)}
+    sibling = frozenset(("python/helm/curriculum.py", "python/helm/reasoning_ladder.py"))
+    assert sibling in pairs  # the gate catches the real, intended overlap
+    assert all(p == sibling for p in pairs)  # and surfaces no other (unacknowledged) redundancy
 
 
 def test_cli_claim_and_audit_run():


### PR DESCRIPTION
A graded, auto-gradable reasoning **scoreboard** (arithmetic → hard multi-step) — the general sibling of the code curriculum. Any climber is `generator(item)->answer`, graded by **exact match** against a held-out answer; climb = highest contiguous tier.

**The gate's lesson, applied:** a reasoning ladder *is* the curriculum's shape with a different scorer, so the climb logic is extracted to one kernel (`ladder.py`) and curriculum is **migrated onto it, not cloned**. The redundancy gate now correctly flags curriculum↔reasoning_ladder as siblings (0.56); that overlap is acknowledged + resolved by the shared kernel, and the gate test asserts nothing *else* overlaps.

**Honest:** SAT/public sets are saturated and likely memorized, so these are hand-authored exact-answer items (contamination-free-ER, objectively gradable). Limits: few items, some classic, top tier is hard-competition-math not FrontierMath. This is a *scoreboard*; the real question is **lift** — does a model scored *through* the harness (gates+tools) beat itself raw? `measure_lift` computes that delta; a real number needs a real model in both slots.

Verified: reference 20/20, naive floor 0/20, contiguous-climb + numeric exact-match tested; **curriculum's 5 tests still green** after the migration. 22 tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>