### PR TITLE
chore(ci): register stepwise/pair_loop/game_board claims (+ honest note on the gate's semantic limit)

### DIFF
--- a/scripts/ci/math_claims.txt
+++ b/scripts/ci/math_claims.txt
@@ -19,3 +19,6 @@ python/scbe/geometric_router.py :: route tasks to agents by tongue-weighted fins
 python/scbe/geometric_router.py#streams :: bind two instruction streams where their embedded points are within epsilon, a depth coordinate gating the distance
 python/scbe/dna_parse.py :: bijective hex to base-4 codec, one nibble is two base-4 symbols
 python/scbe/bijective_dna.py :: opcode strand with an involution complement and midpoint replication-fork assembly across language faces
+python/scbe/stepwise.py :: guided step machine - run calc steps in code, a misstep rewinds to before the bad step and retries with rebuilt context
+python/scbe/pair_loop.py :: juggling harness routing small or free models - improvise only when needed, by strength
+python/scbe/game_board.py :: a task as a board game - the rules are governance, winning is the work


### PR DESCRIPTION
Registers the three parallel-session modules now on main so the redundancy registry is complete.

**Honest limit, found live:** I nearly rebuilt `stepwise.py` as a 'tool + verify-gate harness'. The gate *cleared* my claim because the vocabulary is disjoint ("arithmetic tool/verify" vs "calc/rewind/step machine") even though it's the same idea. The lexical Jaccard gate **cannot** catch this semantic collision — what caught it was a human surfacing the parallel work + checking the repo before building. Registration helps future *lexically*-similar dups, not this class.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>