### PR TITLE
feat(failure_map): capability basement - localize where a model drifts, mapped across models

### DIFF
--- a/python/scbe/failure_map.py
+++ b/python/scbe/failure_map.py
@@ -1,0 +1,124 @@
+"""failure_map: localize WHERE a model drifts, and map it across models -- the capability basement.
+
+stepwise.run_stepwise surfaces the ceiling for ONE run. This aggregates many runs (tasks x models)
+into the "points on paper" map: turn pass/fail into WHERE (which step it got stuck at, point 1 ->
+point F) and, across models, WHY (which step is the wall). Four views:
+
+  * DRIFT POINT   -- per (model, task): the step index it reached and where it stuck.
+  * WALL          -- per task: the modal stuck step among the models that failed it.
+  * CROSS-MODEL   -- who clears a task that others don't (where does model A's edge sit vs B).
+  * UNIVERSAL-FAIL -- tasks no model clears, and the wall step (if nobody passes there, that step
+    IS the why -- structurally, not a claim about the model's mind).
+
+A proposer is the model slot (stepwise.Proposer): `clears_through(k)` and scripted stubs prove the
+map by construction; a real model drops into the same slot. HONEST: this LOCATES failures; it does
+not explain capability. "Why" here = which step is the wall, not why the model can't climb it.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any, Dict, List, Mapping, Sequence
+
+from .stepwise import Proposer, Step, Task, run_stepwise
+
+
+def localize(task: Task, proposer: Proposer, max_rewinds: int = 3) -> Dict[str, Any]:
+    """Run one (task, model) and report the drift point: where it stuck (point F) or that it cleared."""
+    r = run_stepwise(task, proposer, max_rewinds)
+    names = [s.name for s in task.steps]
+    if r["completed"]:
+        return {"task": task.name, "cleared": True, "stuck_at": None, "stuck_index": len(names), "total": len(names)}
+    stuck = r.get("stuck_at")
+    return {
+        "task": task.name,
+        "cleared": False,
+        "stuck_at": stuck,
+        "stuck_index": names.index(stuck) if stuck in names else -1,
+        "total": len(names),
+    }
+
+
+def run_map(tasks: Sequence[Task], proposers: Mapping[str, Proposer], max_rewinds: int = 3) -> Dict[str, Any]:
+    """Localize every (model, task) and build the four views."""
+    pnames = list(proposers)
+    cells = {(p, t.name): localize(t, proposers[p], max_rewinds) for p in pnames for t in tasks}
+    per_task: Dict[str, Any] = {}
+    for t in tasks:
+        clearers = [p for p in pnames if cells[(p, t.name)]["cleared"]]
+        stuck = [cells[(p, t.name)]["stuck_at"] for p in pnames if not cells[(p, t.name)]["cleared"]]
+        per_task[t.name] = {
+            "clearers": clearers,
+            "no_clearers": not clearers,
+            "wall": Counter(stuck).most_common(1)[0][0] if stuck else None,
+        }
+    return {
+        "tasks": [t.name for t in tasks],
+        "proposers": pnames,
+        "cells": cells,
+        "per_task": per_task,
+        "universal_fail": [t.name for t in tasks if per_task[t.name]["no_clearers"]],
+    }
+
+
+def render_map(m: Dict[str, Any]) -> str:
+    w = max([len(t) for t in m["tasks"]] + [6])
+    lines = ["FAILURE MAP  (rows=models, cols=tasks; ok=cleared, @s=drift point)"]
+    lines.append("  %-12s " % "model\\task" + " ".join("%-*s" % (w, t) for t in m["tasks"]))
+    for p in m["proposers"]:
+        cells = []
+        for t in m["tasks"]:
+            c = m["cells"][(p, t)]
+            cells.append("%-*s" % (w, "ok" if c["cleared"] else "@" + (c["stuck_at"] or "?")))
+        lines.append("  %-12s " % p + " ".join(cells))
+    for t in m["tasks"]:
+        pt = m["per_task"][t]
+        if pt["wall"] is not None:
+            lines.append("  %s: wall at '%s'; cleared by %s" % (t, pt["wall"], ",".join(pt["clearers"]) or "nobody"))
+    if m["universal_fail"]:
+        lines.append("  UNIVERSAL-FAIL (no model clears): " + ", ".join(m["universal_fail"]))
+    return "\n".join(lines)
+
+
+# --- fixture proposers (a real model drops into the same slot) -----------------------
+def clears_through(k: int) -> Proposer:
+    """A model that chooses correctly through step k, then drifts -- to place drift at a known point.
+    (Reads the current step number from the rebuilt context; correct answer is options[0].)"""
+
+    def p(ctx: str, options: List[str]) -> str:
+        m = re.search(r"choose s(\d+)", ctx)
+        n = int(m.group(1)) if m else 1
+        return options[0] if (options and n <= k) else "x"
+
+    return p
+
+
+def seq_task(name: str, answers: Sequence[str]) -> Task:
+    """A task of N choice steps s1..sN; each step's correct answer is answers[i] (== options[0])."""
+    steps = [
+        Step(
+            name="s%d" % (i + 1),
+            key="s%d" % (i + 1),
+            options=(lambda st, a=a: [a, "x", "y"]),
+            check=(lambda st, v, a=a: v == a),
+        )
+        for i, a in enumerate(answers)
+    ]
+    return Task(name=name, steps=steps, goal=name)
+
+
+def _demo() -> int:
+    tasks = [seq_task("alpha", ["a1", "a2", "a3"]), seq_task("beta", ["b1", "b2"])]
+    proposers = {"strong": clears_through(9), "mid": clears_through(2), "weak": clears_through(0)}
+    print(render_map(run_map(tasks, proposers)))
+    print("\n(strong clears all; mid drifts at alpha.s3; weak drifts at s1 everywhere)")
+    return 0
+
+
+def main(argv: Sequence[str] = ()) -> int:
+    return _demo()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/math_claims.txt
+++ b/scripts/ci/math_claims.txt
@@ -22,3 +22,5 @@ python/scbe/bijective_dna.py :: opcode strand with an involution complement and 
 python/scbe/stepwise.py :: guided step machine - run calc steps in code, a misstep rewinds to before the bad step and retries with rebuilt context
 python/scbe/pair_loop.py :: juggling harness routing small or free models - improvise only when needed, by strength
 python/scbe/game_board.py :: a task as a board game - the rules are governance, winning is the work
+python/scbe/failure_map.py :: aggregate stepwise runs across tasks and models into a drift map - per-run drift point, per-task wall, cross-model clearers, universal-fail steps
+scripts/system/agentic_pazaak_board.py :: pazaak bitboard planner - score task lanes by value and risk and verified, recommend the next card move

--- a/tests/test_failure_map.py
+++ b/tests/test_failure_map.py
@@ -1,0 +1,49 @@
+"""failure_map: aggregate stepwise runs into the capability basement -- WHERE a model drifts
+(point 1 -> point F) and, across models, WHICH step is the wall. Pass/fail becomes where-and-why."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.failure_map import clears_through, localize, render_map, run_map, seq_task  # noqa: E402
+
+
+def test_localize_finds_the_drift_point():
+    task = seq_task("t", ["a1", "a2", "a3", "a4"])
+    r = localize(task, clears_through(2))  # correct through s2, drifts at s3
+    assert r["cleared"] is False
+    assert r["stuck_at"] == "s3" and r["stuck_index"] == 2 and r["total"] == 4
+
+
+def test_clearing_model_reaches_the_end():
+    task = seq_task("t", ["a1", "a2", "a3"])
+    r = localize(task, clears_through(9))
+    assert r["cleared"] is True and r["stuck_index"] == r["total"] == 3
+
+
+def test_cross_model_who_clears_what():
+    tasks = [seq_task("alpha", ["a1", "a2", "a3"]), seq_task("beta", ["b1", "b2"])]
+    m = run_map(tasks, {"strong": clears_through(9), "mid": clears_through(2), "weak": clears_through(0)})
+    assert m["per_task"]["alpha"]["clearers"] == ["strong"]  # only strong clears the 3-step task
+    assert sorted(m["per_task"]["beta"]["clearers"]) == ["mid", "strong"]  # mid clears the 2-step one
+    assert m["cells"][("mid", "alpha")]["stuck_at"] == "s3"  # mid's edge sits at alpha.s3
+    assert m["cells"][("weak", "beta")]["stuck_at"] == "s1"
+
+
+def test_universal_fail_names_the_wall():
+    # a task whose correct answer is never in the options -> no model can clear it; the wall is s1
+    impossible = seq_task("impossible", ["a1", "a2"])
+    impossible.steps[0].check = lambda st, v: v == "unreachable"  # never legal+correct
+    m = run_map([impossible], {"strong": clears_through(9), "weak": clears_through(0)})
+    assert m["universal_fail"] == ["impossible"]
+    assert m["per_task"]["impossible"]["wall"] == "s1"
+    assert m["per_task"]["impossible"]["no_clearers"] is True
+
+
+def test_render_shows_drift_markers_and_universal_fail():
+    tasks = [seq_task("alpha", ["a1", "a2"])]
+    out = render_map(run_map(tasks, {"weak": clears_through(0)}))
+    assert "FAILURE MAP" in out
+    assert "@s1" in out  # weak drifts at the first step


### PR DESCRIPTION
The capability-basement ask, built: stop scoring pass/fail, **localize the drift** (point 1 → point F) and map it across models.

Aggregates `stepwise.run_stepwise` (tasks × models) into four views: per-run **drift point**, per-task **wall** (modal stuck step), **cross-model** clearers (who clears what others can't), and **universal-fail** steps (where no model passes — and which step is the wall).

Distinct from the **pazaak board** (which *recommends the next move* over task lanes): `failure_map` *diagnoses* where models drift. They **compose** — a universal-fail step becomes a high-risk/unverified lane, and pazaak recommends the move. (Verified pazaak runs; registered both claims in the gate.)

**Honest:** it locates failures, it does not explain capability — 'why' = which step is the wall (structural), not a claim about the model's mind. Fixture proposers prove the map by construction; a real model drops into the same slot and the cross-model view fills as more runs land. 5 tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added failure map analysis to identify where execution halts across different models for each task.
  * Displays which models successfully complete tasks and pinpoints execution bottlenecks.

* **Tests**
  * Added comprehensive test coverage for the new failure analysis functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->