### PR TITLE
fix(scbe): harden toolkit per adversarial review — real tamper-evidence, honest demos

### DIFF
--- a/python/scbe/toolkit.py
+++ b/python/scbe/toolkit.py
@@ -3,14 +3,19 @@
 This is the AI's toolbox. It catalogs the actual callable tools across the repo (coding, math,
 geometry, control, governance, measurement, language, verification), and exposes ONE governed way to
 call any of them: every invocation is allowlist/safety-screened, runs the destructive-command screen
-(the never-delete rule), and is SHA-256 SEALED into a tamper-evident transcript -- reusing the real
-sealing primitives from desktop_access (no new "geoseal" invented; the seal IS geoseal here).
+(the never-delete rule), and is SHA-256 SEALED into a forward-chained transcript -- reusing the real
+SHA-256 seal from desktop_access (the in-system "geoseal" layer; the security is the standard hash,
+nothing exotic).
 
   * lazy + robust: a tool's module is imported only when first used; if a dependency is missing the
     tool is reported UNAVAILABLE, never crashing the toolbox.
-  * governed: `safe` tools (pure computation) run freely; `guarded` tools (file/desktop/stateful)
-    need a confirm reason; a destructive string in any argument is REFUSED outright.
-  * sealed: each call appends {tool, args, result, decision, seal}; `verify()` re-checks every seal.
+  * governed: `safe` tools (pure computation) run freely; `guarded` tools (file/desktop/stateful, or
+    anything that executes code) need a confirm reason; a destructive string in any argument is
+    REFUSED outright.
+  * sealed: each call appends {tool, args, result, decision, prev, result_hash, seal}; the seal binds
+    the PRIOR seal + a digest of the result, so `verify()` catches mutation, insertion, reordering,
+    AND a swapped composition payload. (A holder of the live Toolkit could recompute the chain -- for
+    cross-boundary integrity, sign the final seal with an external key.)
 
     from python.scbe.toolkit import default_toolkit
     tk = default_toolkit()
@@ -21,13 +26,23 @@ sealing primitives from desktop_access (no new "geoseal" invented; the seal IS g
 
 from __future__ import annotations
 
+import hashlib
 import importlib
+import secrets
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
 from .desktop_access import _DESTRUCTIVE, _seal
 
 _RESULT_CAP = 240  # how much of a result repr to keep in the sealed record
+
+
+def _digest(obj: Any) -> str:
+    """A stable SHA-256 digest of a (possibly unserializable) result, for sealing composition payloads."""
+    try:
+        return hashlib.sha256(repr(obj).encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        return "?"
 
 
 @dataclass(frozen=True)
@@ -605,7 +620,7 @@ CATALOG: List[Tool] = [
         "run_public_bench",
         "measurement",
         "run problems vs a generator; verify hidden asserts in a subprocess",
-        "safe",
+        "guarded",  # executes candidate code in a subprocess
     ),
     Tool(
         "climb_on_board",
@@ -621,7 +636,7 @@ CATALOG: List[Tool] = [
         "conformance",
         "measurement",
         "compile + run a program across every polyglot backend",
-        "safe",
+        "guarded",  # compiles + executes generated code in external toolchains
     ),
     Tool(
         "benchmark",
@@ -685,6 +700,7 @@ class Toolkit:
 
     tools: List[Tool] = field(default_factory=lambda: list(CATALOG))
     transcript: List[dict] = field(default_factory=list)
+    nonce: str = field(default_factory=lambda: secrets.token_hex(8))  # binds this session's seal chain
 
     def by_name(self, name: str) -> Optional[Tool]:
         return next((t for t in self.tools if t.name == name), None)
@@ -729,17 +745,30 @@ class Toolkit:
                 rec.update(decision="ALLOWED", result=repr(result_obj)[:_RESULT_CAP])
             except Exception as e:  # a tool that errors is reported, never silently 'ok'
                 rec.update(decision="ERROR", result="%s: %s" % (type(e).__name__, e))
+        # forward-chain: each seal binds the prior seal (or the session nonce) + a digest of the
+        # composition payload, so fabricating, reordering, or mutating any record fails verify().
+        rec["prev"] = self.transcript[-1]["seal"] if self.transcript else self.nonce
+        rec["result_hash"] = _digest(result_obj) if result_obj is not None else ""
         rec["seal"] = _seal(rec)
         self.transcript.append(rec)
-        rec["result_obj"] = result_obj  # not sealed (may be unserializable); for tool composition
+        rec["result_obj"] = result_obj  # the live payload (its digest is sealed; the object itself is not)
         return rec
 
     def verify(self) -> bool:
-        """The whole tool session is tamper-evident: every seal still matches."""
-        return all(
-            r.get("seal") == _seal({k: v for k, v in r.items() if k not in ("seal", "result_obj")})
-            for r in self.transcript
-        )
+        """Tamper-evident: the seal chain detects mutation, insertion, reordering, AND a swapped
+        result_obj (its digest is sealed). A holder of the live Toolkit could recompute the chain --
+        for cross-boundary integrity, sign the final seal with an external key."""
+        prev = self.nonce
+        for r in self.transcript:
+            body = {k: v for k, v in r.items() if k not in ("seal", "result_obj")}
+            if r.get("seal") != _seal(body):
+                return False  # record mutated
+            if r.get("prev") != prev:
+                return False  # inserted / reordered / fabricated
+            if "result_obj" in r and r["result_obj"] is not None and r.get("result_hash") != _digest(r["result_obj"]):
+                return False  # composition payload swapped
+            prev = r["seal"]
+        return True
 
 
 def default_toolkit() -> Toolkit:

--- a/python/scbe/toolkit_map.py
+++ b/python/scbe/toolkit_map.py
@@ -4,9 +4,10 @@ The toolbox (toolkit.py) is flat; this gives it a SHAPE. The tools are laid out 
 each demonstrating a distinct system, connected by unlock edges. The map does three things:
 
   * UPDATES PER TASK -- each area runs a real demo through the sealed toolkit; clearing it marks the
-    area CLEARED, records which tools were seen, and UNLOCKS the next area. Progress is sealed.
-  * GUIDES -- given a task in plain words, `route()` picks the right AVAILABLE area and names the one
-    tool to reach for (and why), so a weak model never has to pick from 81 tools blind.
+    area CLEARED, records which tools were seen, and UNLOCKS the next area. (Each tool CALL is sealed
+    in the toolkit transcript; the area-status bookkeeping itself is plain map state.)
+  * GUIDES -- given a task in plain words, `route()` picks the right area and names the one tool to
+    reach for (and why), so a weak model never has to pick from the whole catalog blind.
   * SEES THE USE -- every area actually invokes its system (sieve classifies a number, the board
     round-trips, loomflow runs an IR cross-face, a game is played sealed, ...), so the demo IS proof.
 
@@ -21,6 +22,7 @@ the next so the tour continues. Every tool call is governed + SHA-256 sealed by 
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
@@ -38,7 +40,8 @@ def _demo_sieve(tk: Toolkit) -> Tuple[bool, str]:
     res = tk.invoke("run_stepwise", task, prop)["result_obj"]
     pr = tk.invoke("is_prime", 7)["result_obj"]
     fac = tk.invoke("factorization", 91)["result_obj"]
-    ok = bool(res and res.get("completed") and pr is True and fac == {7: 1, 13: 1})
+    built = task is not None and callable(prop)  # the sieve task + the proposer were really produced
+    ok = bool(built and res and res.get("completed") and pr is True and fac == {7: 1, 13: 1})
     return ok, "classify(7)->%s; is_prime(7)=%s; 91=%s" % (res.get("answer") if res else None, pr, fac)
 
 
@@ -53,8 +56,13 @@ def _demo_loomflow(tk: Toolkit) -> Tuple[bool, str]:
     prog = tk.invoke("parse", "const a 5\nconst b 3\nadd c a b\nprint c")["result_obj"]
     val = tk.invoke("interpret", prog)["result_obj"]
     src = tk.invoke("emit", prog, "python")["result_obj"]
-    ok = val == [8.0] and isinstance(src, str) and "def run" in src
-    return ok, "interpret=%s; emit('python') has def run=%s" % (val, "def run" in (src or ""))
+    parsed = isinstance(prog, list) and len(prog) == 4  # the IR really parsed (4 instructions)
+    ok = parsed and val == [8.0] and isinstance(src, str) and "def run" in src
+    return ok, "parsed %d instrs; interpret=%s; emit('python') has def run=%s" % (
+        len(prog) if isinstance(prog, list) else -1,
+        val,
+        "def run" in (src or ""),
+    )
 
 
 def _demo_cross_face(tk: Toolkit) -> Tuple[bool, str]:
@@ -71,7 +79,8 @@ def _demo_board(tk: Toolkit) -> Tuple[bool, str]:
     rev = tk.invoke("is_reversible", [1, 2, 3])["result_obj"]
     cube = tk.invoke("to_cube", 0x15)["result_obj"]
     fc = tk.invoke("from_cube", *cube)["result_obj"]
-    ok = prog2 == [1, 2, 3] and rev is True and fc == 0x15
+    shapes = isinstance(stones, list) and len(stones) == 3 and isinstance(cube, tuple) and len(cube) == 3
+    ok = shapes and prog2 == [1, 2, 3] and rev is True and fc == 0x15
     return ok, "recover(place)=%s; reversible=%s; from_cube(to_cube(0x15))=0x%02x" % (prog2, rev, fc)
 
 
@@ -96,12 +105,17 @@ def _demo_bit_dna(tk: Toolkit) -> Tuple[bool, str]:
 def _demo_geometry(tk: Toolkit) -> Tuple[bool, str]:
     st = tk.invoke("self_test")
     reg = tk.invoke("build_registry")
-    ri = tk.invoke("route_intent", (0.05, 0.08))  # needs src/ on path -> may be UNAVAILABLE here
-    ok = st["decision"] == "ALLOWED" and reg["decision"] == "ALLOWED"
-    return ok, "phdm self_test=%s; build_registry=%s; geometry.route_intent=%s" % (
+    rr = tk.invoke("round_robin", [], [])  # the fleet router actually runs (cost over an empty fleet = 0.0)
+    ok = (
+        st["decision"] == "ALLOWED"
+        and reg["decision"] == "ALLOWED"
+        and rr["decision"] == "ALLOWED"
+        and isinstance(rr["result_obj"], float)
+    )
+    return ok, "phdm self_test=%s; build_registry=%s; round_robin(empty fleet)=%s" % (
         st["decision"],
         reg["decision"],
-        ri["decision"],
+        rr["result_obj"],
     )
 
 
@@ -136,7 +150,7 @@ def _demo_ledger(tk: Toolkit) -> Tuple[bool, str]:
 def _demo_geoseal(tk: Toolkit) -> Tuple[bool, str]:
     hd = tk.invoke("hyperbolic_distance", [0.1, 0.0, 0.0], [0.0, 0.1, 0.0])
     val = hd["result_obj"]
-    ok = hd["decision"] == "ALLOWED" and isinstance(val, float) and val > 0
+    ok = hd["decision"] == "ALLOWED" and isinstance(val, float) and not math.isnan(val) and 0 < val < 5
     return ok, "hyperbolic_distance ~ %s" % (round(val, 3) if isinstance(val, float) else hd["decision"])
 
 
@@ -149,11 +163,18 @@ def _demo_leveling(tk: Toolkit) -> Tuple[bool, str]:
 
 def _demo_rosetta(tk: Toolkit) -> Tuple[bool, str]:
     pb = tk.invoke("program_bytes", "add")["result_obj"]
-    conf = tk.invoke("conformance", pb, [[1.0, 2.0, 3.0]])  # 'add' is ternary tongue_fn(a,b,c)
+    conf = tk.invoke("conformance", pb, [[1.0, 2.0, 3.0]], confirm="cross-face benchmark")  # guarded: runs code
     obj = conf["result_obj"]
-    ok = conf["decision"] == "ALLOWED" and obj is not None
     summ = obj.get("summary") if isinstance(obj, dict) else None
-    return ok, "conformance across backends ran; summary=%s" % (summ if summ else conf["decision"])
+    ok = (
+        conf["decision"] == "ALLOWED"
+        and isinstance(obj, dict)
+        and isinstance(summ, dict)
+        and summ.get("runnable_backends", 0) > 0
+    )
+    rb = (summ or {}).get("runnable_backends", 0)
+    va = (summ or {}).get("verified_agree", 0)
+    return ok, "conformance ran %d backends; %d verified-agree across faces" % (rb, va)
 
 
 @dataclass
@@ -229,7 +250,7 @@ def _areas() -> List[Area]:
         Area(
             "Geometry Router",
             "route intents/agents by hyperbolic geometry",
-            ["route_intent", "self_test"],
+            ["round_robin", "self_test", "build_registry"],
             "Bit Spine + DNA",
             _demo_geometry,
             ["route", "assign", "agent", "fleet", "which", "geometry"],

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -65,6 +65,29 @@ def test_transcript_is_tamper_evident():
     assert tk.verify() is False
 
 
+def test_reordering_records_breaks_the_seal_chain():
+    tk = default_toolkit()
+    tk.invoke("is_prime", 5)
+    tk.invoke("is_prime", 7)
+    assert tk.verify() is True
+    tk.transcript[0], tk.transcript[1] = tk.transcript[1], tk.transcript[0]  # reorder
+    assert tk.verify() is False  # the forward chain (prev seal) catches it
+
+
+def test_swapping_a_composition_payload_breaks_verify():
+    tk = default_toolkit()
+    r = tk.invoke("place", [1, 2, 3])
+    assert tk.verify() is True
+    r["result_obj"] = [9, 9, 9]  # swap the live payload another tool would consume
+    assert tk.verify() is False  # result_hash is sealed, so the swap is caught
+
+
+def test_subprocess_spawning_tools_are_guarded():
+    tk = default_toolkit()
+    for name in ("conformance", "run_public_bench"):
+        assert tk.by_name(name).safety == "guarded"  # they execute code -> must need a confirm
+
+
 def test_most_tools_are_importable_here():
     tk = default_toolkit()
     avail = tk.available()


### PR DESCRIPTION
An adversarial-review workflow (4 skeptics) audited the just-landed toolkit/map and found real defects. **All high + medium findings fixed.**

**Sealing** (the `tamper-evident` claim was overstated):
- **forward-chain the seal** — each record binds the prior seal + a session nonce, so fabricating / inserting / **reordering** records now fails `verify()` (before: only mutation of an existing record was caught).
- **seal a digest of `result_obj`** (the payload composed tools consume) — a swapped `result_obj` now fails `verify()` (before: only its repr was sealed).
- docstring recalibrated: the chain detects mutation/insert/reorder/payload-swap; a holder of the live Toolkit could recompute it → for cross-boundary integrity sign the final seal externally. No longer overclaims.

**Governance:** `conformance` + `run_public_bench` relabeled `safe`→`guarded` — both execute generated code in subprocesses and must require a confirm.

**Honest demos** (two were passing without exercising their headline tool):
- **Geometry Router** — dropped the unchecked `route_intent` (UNAVAILABLE here); now runs the *real* fleet router `round_robin([],[])`→0.0 **and checks it**, plus phdm `self_test`+`build_registry`.
- **Rosetta Benchmark** — replaced trivial `obj is not None` with a structural assertion (`summary.runnable_backends > 0`); `conformance` now called with a confirm (it's guarded).
- added intermediate-output checks (sieve task/proposer, board stone/cube shapes, loomflow 4-instr parse, geoseal not-nan + bound).

**Docs:** `81`→full catalog (85); "Progress is sealed"→only tool *calls* are sealed.

**17 tests** (added: reorder breaks the chain, swapped payload fails verify, subprocess tools are guarded). `traverse` still clears **13/13**, 39 sealed calls, chain verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)