### PR TITLE
feat(toolkit): add failure_map diagnose stage to guided map

### DIFF
--- a/python/scbe/toolkit.py
+++ b/python/scbe/toolkit.py
@@ -770,6 +770,71 @@ class Toolkit:
             prev = r["seal"]
         return True
 
+    def _safe_alternative(self, domain: Optional[str], exclude: str) -> Optional[str]:
+        """A different SAFE, importable tool in the same domain -- a recovery suggestion."""
+        avail = self.available()
+        for t in self.tools:
+            if t.domain == domain and t.name != exclude and t.safety == "safe" and avail.get(t.name):
+                return t.name
+        return None
+
+    def diagnose(self, record: dict) -> dict:
+        """Classify why a tool call failed and recommend the next SAFE move; seal the diagnosis.
+
+        Governance/environment failures are classified by the gate decision; a confirmation-required
+        failure is NEVER auto-retried (retry_safe=False) -- it surfaces the confirm requirement. The
+        diagnosis is appended to the same sealed chain, so the failure + its diagnosis are auditable.
+        """
+        decision = record.get("decision")
+        tool = record.get("tool", "")
+        domain = self.by_name(tool).domain if self.by_name(tool) else None
+        if decision == "NEEDS_CONFIRM":
+            cause, retry_safe = "needs_confirm", False
+            recovery = (
+                "guarded tool: re-invoke %r WITH confirm='<reason>'. Do NOT auto-retry -- surface to a human/policy."
+                % tool
+            )
+        elif decision == "REFUSED":
+            cause, retry_safe = "refused_destructive", False
+            recovery = "blocked by the never-delete screen. Remove the destructive content; do NOT retry."
+        elif decision == "UNAVAILABLE":
+            alt = self._safe_alternative(domain, tool)
+            cause, retry_safe = "unavailable_dependency", bool(alt)
+            recovery = (
+                ("dependency missing here; use a same-domain available tool: %r" % alt)
+                if alt
+                else "no available same-domain alternative; install the dep or pick another domain."
+            )
+        elif decision == "NO_TOOL":
+            cause, retry_safe = "unknown_tool", False
+            recovery = "no tool named %r; consult toolkit.list() for the catalog." % tool
+        elif decision == "ERROR":
+            alt = self._safe_alternative(domain, tool)
+            cause, retry_safe = "tool_error", False
+            recovery = "the tool raised (%s). Check args; or try %r." % (str(record.get("result", ""))[:70], alt)
+        else:
+            ro = record.get("result_obj")
+            if isinstance(ro, dict) and ro.get("completed") is False and ro.get("stuck_at"):
+                cause, retry_safe = "step_drift", False
+                recovery = (
+                    "stepwise drifted at step %r -- offload that step to a deterministic calc tool "
+                    "(sieve_calc) so the model only judges." % ro.get("stuck_at")
+                )
+            else:
+                cause, retry_safe, recovery = "none", True, "no failure"
+        diag = {
+            "hop": len(self.transcript) + 1,
+            "diagnose": tool,
+            "from_decision": decision,
+            "cause": cause,
+            "recovery": recovery,
+            "retry_safe": retry_safe,
+            "prev": self.transcript[-1]["seal"] if self.transcript else self.nonce,
+        }
+        diag["seal"] = _seal(diag)
+        self.transcript.append(diag)
+        return diag
+
 
 def default_toolkit() -> Toolkit:
     return Toolkit()

--- a/python/scbe/toolkit_map.py
+++ b/python/scbe/toolkit_map.py
@@ -10,6 +10,11 @@ each demonstrating a distinct system, connected by unlock edges. The map does th
     reach for (and why), so a weak model never has to pick from the whole catalog blind.
   * SEES THE USE -- every area actually invokes its system (sieve classifies a number, the board
     round-trips, loomflow runs an IR cross-face, a game is played sealed, ...), so the demo IS proof.
+  * DIAGNOSES -- `run()` is the nervous system: execute -> seal -> verify -> on failure, classify the
+    cause and recommend the next SAFE move. Governance/env failures are classified by the gate
+    decision (needs-confirm / refused / unavailable / error); a stepwise run that drifts is localized
+    by failure_map (which step is the wall) -> offload it. A confirmation-required failure is NEVER
+    auto-retried; it surfaces the confirm requirement. The diagnosis is sealed into the same chain.
 
 An area whose dependency is missing on this box is honestly SKIPPED (not faked), and still unlocks
 the next so the tour continues. Every tool call is governed + SHA-256 sealed by the toolkit.
@@ -350,6 +355,43 @@ class TaskMap:
         )
         return {"bitboards": bb, "recommended": rec}
 
+    def run(self, tool: str, *args: object, confirm: Optional[str] = None) -> Dict[str, object]:
+        """The nervous system: execute -> seal -> verify -> diagnose on failure -> recommend recovery.
+
+        A failed call (or a stepwise run that drifted) emits a sealed failure record AND a sealed
+        diagnosis with a next-safe-move recommendation. A confirmation-required failure is NOT
+        auto-retried -- the diagnosis surfaces the confirm requirement (retry_safe=False).
+        """
+        rec = self.tk.invoke(tool, *args, confirm=confirm)
+        ro = rec.get("result_obj")
+        drifted = isinstance(ro, dict) and ro.get("completed") is False
+        out: Dict[str, object] = {"tool": tool, "decision": rec["decision"], "sealed": True}
+        if rec["decision"] != "ALLOWED" or drifted:
+            out["diagnosis"] = self.tk.diagnose(rec)  # classify cause + recommend, sealed into the chain
+        else:
+            out["result"] = rec["result"]
+        out["chain_ok"] = self.tk.verify()  # the seal chain still holds after the failure + diagnosis
+        return out
+
+    def diagnose_drift(self, task: object, proposer: Callable) -> Dict[str, object]:
+        """Use failure_map to localize WHERE a stepwise run drifted, and recommend offloading the wall.
+
+        This is the step-drift arm of the diagnose stage: where a tool-call failure is a governance
+        decision, a stepwise failure is a model drifting at a specific step -- failure_map says which.
+        """
+        from .failure_map import localize
+
+        loc = localize(task, proposer)
+        if loc.get("cleared"):
+            return {"cleared": True, "recovery": None, "drift": loc}
+        wall = loc.get("stuck_at")
+        rec = (
+            "wall at step %r (point %s/%s); offload step %r to a deterministic calc tool "
+            "(sieve_calc.classify_number_task) so the model only judges."
+            % (wall, loc.get("stuck_index"), loc.get("total"), wall)
+        )
+        return {"cleared": False, "drift": loc, "recovery": rec}
+
     def advance(self, name: str) -> Dict[str, object]:
         """Run an area's demo through the sealed toolkit; clear + unlock on success."""
         a = self._area(name)
@@ -412,6 +454,28 @@ def main(argv: Optional[List[str]] = None) -> int:
         "\n  cleared %d/%d areas (%d skipped for missing deps); %d sealed tool calls; transcript verified: %s"
         % (summary["cleared"], summary["total"], summary["skipped"], summary["tool_calls"], summary["sealed"])
     )
+
+    print("\n== NERVOUS SYSTEM: execute -> seal -> verify -> DIAGNOSE failure -> recommend recovery ==")
+    m2 = TaskMap()
+    for label, call in [
+        ("guarded, no confirm", lambda: m2.run("run_level", [])),
+        ("destructive arg", lambda: m2.run("is_prime", "rm -rf /")),
+        ("missing dependency", lambda: m2.run("route_intent", (0.05, 0.08))),
+    ]:
+        out = call()
+        d = out.get("diagnosis", {})
+        print(
+            "  %-20s -> %-13s cause=%-22s retry_safe=%s chain_ok=%s"
+            % (label, out["decision"], d.get("cause"), d.get("retry_safe"), out["chain_ok"])
+        )
+        print("      recovery: %s" % d.get("recovery", "")[:96])
+
+    print("\n  step-drift diagnosis via failure_map (a model that drifts at step 'label'):")
+    from .sieve_calc import classify_number_task
+    from .stepwise import scripted_proposer
+
+    drift = m2.diagnose_drift(classify_number_task(91), scripted_proposer(["prime", "prime", "prime", "prime"]))
+    print("      %s" % drift["recovery"])
     return 0
 
 

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -88,6 +88,33 @@ def test_subprocess_spawning_tools_are_guarded():
         assert tk.by_name(name).safety == "guarded"  # they execute code -> must need a confirm
 
 
+def test_diagnose_needs_confirm_does_not_retry_and_seals():
+    tk = default_toolkit()
+    rec = tk.invoke("run_level", [])  # guarded, no confirm -> NEEDS_CONFIRM
+    d = tk.diagnose(rec)
+    assert d["cause"] == "needs_confirm" and d["retry_safe"] is False  # never auto-retry a confirm gate
+    assert "confirm" in d["recovery"].lower()
+    assert tk.verify() is True  # the diagnosis is sealed into the same chain
+
+
+def test_diagnose_destructive_is_not_retried():
+    tk = default_toolkit()
+    d = tk.diagnose(tk.invoke("is_prime", "rm -rf /"))
+    assert d["cause"] == "refused_destructive" and d["retry_safe"] is False
+
+
+def test_diagnose_unavailable_suggests_a_safe_same_domain_alternative():
+    # deterministic: a broken tool + an importable same-domain alternative (env-independent)
+    tools = [
+        Tool("broken_router", "no.such.module", "x", "routing", "n/a", "safe"),
+        Tool("good_router", "src.numtheory", "is_prime", "routing", "an importable stand-in", "safe"),
+    ]
+    tk = Toolkit(tools=tools)
+    d = tk.diagnose(tk.invoke("broken_router"))
+    assert d["cause"] == "unavailable_dependency"
+    assert d["retry_safe"] is True and "good_router" in d["recovery"]  # a real same-domain alternative
+
+
 def test_most_tools_are_importable_here():
     tk = default_toolkit()
     avail = tk.available()

--- a/tests/test_toolkit_map.py
+++ b/tests/test_toolkit_map.py
@@ -61,3 +61,36 @@ def test_strategize_counts_and_recommends_a_move():
     assert isinstance(s["bitboards"], dict) and "high_value" in s["bitboards"]
     rec = s["recommended"]
     assert rec and rec["lane"] and rec["card"] and isinstance(rec["score"], float)
+
+
+def test_run_diagnoses_a_failure_and_keeps_the_chain():
+    m = TaskMap()
+    out = m.run("run_level", [])  # guarded, no confirm
+    assert out["decision"] == "NEEDS_CONFIRM"
+    assert out["diagnosis"]["cause"] == "needs_confirm" and out["diagnosis"]["retry_safe"] is False
+    assert out["chain_ok"] is True  # chain verification still passes after the sealed diagnosis
+
+
+def test_run_allowed_call_has_no_diagnosis():
+    m = TaskMap()
+    out = m.run("is_prime", 7)
+    assert out["decision"] == "ALLOWED" and "diagnosis" not in out and out["chain_ok"] is True
+
+
+def test_confirmation_required_failure_is_not_auto_retried():
+    m = TaskMap()
+    m.run("run_level", [])  # must NOT silently retry with a confirm
+    allowed_runs = [r for r in m.tk.transcript if r.get("tool") == "run_level" and r.get("decision") == "ALLOWED"]
+    assert allowed_runs == []  # no auto-retry happened
+
+
+def test_diagnose_drift_localizes_the_wall_via_failure_map():
+    from python.scbe.sieve_calc import classify_number_task
+    from python.scbe.stepwise import scripted_proposer
+
+    m = TaskMap()
+    # 91 is composite; a model that always says 'prime' drifts at the label step
+    drift = m.diagnose_drift(classify_number_task(91), scripted_proposer(["prime", "prime", "prime", "prime"]))
+    assert drift["cleared"] is False
+    assert drift["drift"]["stuck_at"] == "label"  # failure_map localizes the wall step
+    assert "offload" in drift["recovery"] and "sieve_calc" in drift["recovery"]


### PR DESCRIPTION
Turns the toolbox from a **governed executor** into a **self-debugging governed executor**. The map's nervous system:

```
task → route → execute → seal → verify → DIAGNOSE failure → recommend recovery
```

- **`Toolkit.diagnose(record)`** — classifies a failed call + recommends the next *safe* move, sealed into the same forward-chained transcript. Governance/env causes from the gate decision: `needs_confirm`, `refused_destructive`, `unavailable_dependency` (→ a same-domain importable alternative), `unknown_tool`, `tool_error`. **A confirmation-required failure has `retry_safe=False` and is never auto-retried** — it surfaces the confirm requirement.
- **`TaskMap.run(tool, *args, confirm)`** — the loop: invoke, then on a failed call (or a stepwise run that drifted) attach a sealed diagnosis and re-verify the chain.
- **`TaskMap.diagnose_drift(task, proposer)`** — the step-drift arm: uses **`failure_map.localize`** to find *which step is the wall*, then recommends offloading it to a deterministic calc tool (`sieve_calc`) so the model only judges.

**Acceptance criteria — all met, verified by execution:**

| criterion | status |
|---|---|
| failed tool call emits a sealed failure record (+ sealed diagnosis) | ✅ |
| failure_map classifies the cause (step-drift wall localization) | ✅ |
| the map recommends the next safe tool/action | ✅ |
| confirmation-required failures do **not** auto-retry | ✅ |
| chain verification still passes after the sealed diagnosis | ✅ |
| guided map still clears **13/13** | ✅ |

**24 tests** (7 new): diagnose needs-confirm / destructive / unavailable+alternative, `run()` diagnoses + keeps the chain, allowed call has no diagnosis, confirm is not auto-retried, `diagnose_drift` localizes the wall via failure_map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)