### PR TITLE
feat(reasoning_ladder): real-model climber slot (raw LLM baseline)

### DIFF
--- a/python/helm/reasoning_ladder.py
+++ b/python/helm/reasoning_ladder.py
@@ -23,7 +23,9 @@ computes that delta -- but a real lift number needs a real model plugged into bo
 from __future__ import annotations
 
 import argparse
-from typing import Any, Callable, Dict, List, Sequence
+import os
+import re
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from .ladder import render_climb, run_ladder
 
@@ -110,6 +112,35 @@ def reference_climber(item: Dict[str, Any]) -> str:
 def naive_climber(item: Dict[str, Any]) -> str:
     """The floor: no answer. Should clear nothing."""
     return ""
+
+
+def _extract_answer(text: str) -> str:
+    """Pull a clean answer out of a model reply -- the last number if any, else the stripped text."""
+    nums = re.findall(r"-?\d+(?:\.\d+)?", text or "")
+    return nums[-1] if nums else (text or "").strip()
+
+
+def llm_climber(model: Optional[str] = None, base: Optional[str] = None, key: Optional[str] = None) -> Climber:
+    """A REAL model in the climber slot: ask it each question, return its final answer. Reuses
+    helm.free_generator's transport (any OpenAI-compatible endpoint; Ollama by default). On a dead
+    endpoint it returns '' (scores 0) -- never a fabricated pass. This is the RAW baseline; a
+    harnessed/tooled climber goes in the other slot of measure_lift."""
+    from . import free_generator as fg
+
+    base = base or os.environ.get("SCBE_LLM_BASE", fg.DEFAULT_BASE)
+    key = key or os.environ.get("SCBE_LLM_KEY", "ollama")
+    model = model or os.environ.get("SCBE_LLM_MODEL", fg.DEFAULT_MODEL)
+
+    def climber(item: Dict[str, Any]) -> str:
+        prompt = item["question"] + "\n\nAnswer with ONLY the final answer (a number), nothing else."
+        try:
+            out = fg._chat([{"role": "user", "content": prompt}], base=base, key=key, model=model)
+        except Exception:
+            return ""  # honest: a dead endpoint scores 0, never fabricates a pass
+        return _extract_answer(out)
+
+    climber.__name__ = "llm(%s)" % model
+    return climber
 
 
 def run_reasoning(

--- a/tests/test_reasoning_ladder.py
+++ b/tests/test_reasoning_ladder.py
@@ -62,3 +62,32 @@ def test_measure_lift_reports_the_delta():
     # MECHANISM CHECK ONLY (naive baseline vs reference tooled) -- not a capability claim
     r = measure_lift(naive_climber, reference_climber)
     assert r["tier_lift"] == 5 and r["total_lift"] == 20
+
+
+def test_llm_climber_extracts_the_answer_and_grades(monkeypatch):
+    # a mocked model that wraps the right answer in prose -- tests extraction + grading, no live call
+    from python.helm import free_generator as fg
+    from python.helm.reasoning_ladder import REASONING_LADDER, llm_climber
+
+    answers = {it["question"]: it["answer"] for tier in REASONING_LADDER for it in tier["items"]}
+
+    def fake_chat(messages, **kw):
+        q = messages[0]["content"].split("\n\n")[0]
+        return "Let me think... the answer is %s." % answers.get(q, "0")
+
+    monkeypatch.setattr(fg, "_chat", fake_chat)
+    s = run_reasoning(llm_climber(model="mock"))
+    assert s["highest_tier_cleared"] == 5 and s["total_passed"] == 20
+
+
+def test_llm_climber_dead_endpoint_scores_zero(monkeypatch):
+    # a dead endpoint must score 0, never a fabricated pass (honest like free_generator)
+    from python.helm import free_generator as fg
+    from python.helm.reasoning_ladder import llm_climber
+
+    def boom(messages, **kw):
+        raise ConnectionError("no model running")
+
+    monkeypatch.setattr(fg, "_chat", boom)
+    s = run_reasoning(llm_climber())
+    assert s["total_passed"] == 0


### PR DESCRIPTION
Completes the 'a real model drops into the same slot' design on the reasoning ladder. `llm_climber` asks an OpenAI-compatible model (Ollama by default) each question and returns its final answer (last number extracted), graded by the existing exact-match. Reuses `free_generator`'s transport — no new endpoint code. Dead endpoint -> '' -> scores 0 (never a fabricated pass).

This is the **raw baseline** for `measure_lift`; a harnessed/contract-rails climber goes in the other slot to measure real lift. Tested with a mocked model (extraction + grading) + the dead-endpoint floor. **Not run live** here — Ollama is in use by the parallel benchmark; the live 1.5B reasoning climb is one command away when it's free.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>