### PR TITLE
fix(toolkit): fold diagnose-stage review findings — wire failure_map live + cover gaps

### DIFF
--- a/python/scbe/toolkit.py
+++ b/python/scbe/toolkit.py
@@ -11,7 +11,8 @@ nothing exotic).
     tool is reported UNAVAILABLE, never crashing the toolbox.
   * governed: `safe` tools (pure computation) run freely; `guarded` tools (file/desktop/stateful, or
     anything that executes code) need a confirm reason; a destructive string in any argument is
-    REFUSED outright.
+    REFUSED outright. (The destructive screen matches a specific never-delete pattern set --
+    rm -rf, format, mkfs, dd, fdisk, wipe, ... -- it is a guardrail, not an exhaustive denylist.)
   * sealed: each call appends {tool, args, result, decision, prev, result_hash, seal}; the seal binds
     the PRIOR seal + a digest of the result, so `verify()` catches mutation, insertion, reordering,
     AND a swapped composition payload. (A holder of the live Toolkit could recompute the chain -- for

--- a/python/scbe/toolkit_map.py
+++ b/python/scbe/toolkit_map.py
@@ -360,7 +360,9 @@ class TaskMap:
 
         A failed call (or a stepwise run that drifted) emits a sealed failure record AND a sealed
         diagnosis with a next-safe-move recommendation. A confirmation-required failure is NOT
-        auto-retried -- the diagnosis surfaces the confirm requirement (retry_safe=False).
+        auto-retried -- the diagnosis surfaces the confirm requirement (retry_safe=False). When a
+        `run_stepwise` call drifts, failure_map.localize is run on the (task, proposer) to place the
+        wall step (out["drift"]) -- the diagnosis recommendation is then to offload that step.
         """
         rec = self.tk.invoke(tool, *args, confirm=confirm)
         ro = rec.get("result_obj")
@@ -368,6 +370,9 @@ class TaskMap:
         out: Dict[str, object] = {"tool": tool, "decision": rec["decision"], "sealed": True}
         if rec["decision"] != "ALLOWED" or drifted:
             out["diagnosis"] = self.tk.diagnose(rec)  # classify cause + recommend, sealed into the chain
+            if drifted and tool == "run_stepwise" and len(args) >= 2:
+                # genuinely localize the wall with failure_map (we have the task + proposer here)
+                out["drift"] = self.diagnose_drift(args[0], args[1])
         else:
             out["result"] = rec["result"]
         out["chain_ok"] = self.tk.verify()  # the seal chain still holds after the failure + diagnosis

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -103,6 +103,15 @@ def test_diagnose_destructive_is_not_retried():
     assert d["cause"] == "refused_destructive" and d["retry_safe"] is False
 
 
+def test_diagnose_no_tool_and_error_classify_and_seal():
+    tk = default_toolkit()
+    d1 = tk.diagnose(tk.invoke("no_such_tool"))
+    assert d1["cause"] == "unknown_tool" and d1["retry_safe"] is False
+    d2 = tk.diagnose(tk.invoke("from_cube", 1))  # wrong arity -> the tool raises -> ERROR
+    assert d2["cause"] == "tool_error" and d2["retry_safe"] is False
+    assert tk.verify() is True  # both diagnoses sealed into the chain
+
+
 def test_diagnose_unavailable_suggests_a_safe_same_domain_alternative():
     # deterministic: a broken tool + an importable same-domain alternative (env-independent)
     tools = [

--- a/tests/test_toolkit_map.py
+++ b/tests/test_toolkit_map.py
@@ -94,3 +94,16 @@ def test_diagnose_drift_localizes_the_wall_via_failure_map():
     assert drift["cleared"] is False
     assert drift["drift"]["stuck_at"] == "label"  # failure_map localizes the wall step
     assert "offload" in drift["recovery"] and "sieve_calc" in drift["recovery"]
+
+
+def test_run_with_drifted_stepwise_diagnoses_and_localizes_live():
+    from python.scbe.sieve_calc import classify_number_task
+    from python.scbe.stepwise import scripted_proposer
+
+    m = TaskMap()
+    out = m.run("run_stepwise", classify_number_task(91), scripted_proposer(["prime", "prime", "prime", "prime"]))
+    assert out["decision"] == "ALLOWED"  # the tool call itself succeeded; the RESULT drifted
+    assert out["diagnosis"]["cause"] == "step_drift" and out["diagnosis"]["retry_safe"] is False
+    assert out["chain_ok"] is True
+    # the LIVE run() path actually ran failure_map.localize -> the wall step
+    assert out["drift"]["drift"]["stuck_at"] == "label" and "offload" in out["drift"]["recovery"]


### PR DESCRIPTION
A second adversarial review (4 skeptics) found the diagnose stage **correct** (no-auto-retry, seal-chain, and the cause taxonomy were all verified clean) but caught one real **overclaim** and test gaps. All folded in:

- **HIGH (overclaim fixed):** `failure_map` was not actually in the *live* path — `TaskMap.run()` read `stuck_at` directly, and only the orphaned `diagnose_drift()` called `failure_map.localize`. Now `run()` **genuinely runs `failure_map.localize`** on a drifted `run_stepwise` call (it has the task + proposer in args) and attaches the localized wall as `out["drift"]`. Docstring corrected to match.
- **HIGH (test gap):** `step_drift` through `run()` had zero direct test → added one asserting `cause=step_drift`, `retry_safe=False`, `chain_ok=True`, **and** that failure_map placed the wall step live.
- **MEDIUM (test gap):** `NO_TOOL` + `ERROR` diagnose paths now directly tested.
- **LOW (doc):** noted the never-delete screen matches a specific guardrail pattern set, not an exhaustive denylist.

**26 tests** (was 24). `traverse` still clears **13/13**; chain verifies. No behavior change to the governance / seal / no-retry guarantees — the review confirmed those were already sound; this just makes `failure_map` honest in the live path and closes the coverage gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)