### PR TITLE
feat(ask): summon an AI in the terminal (AI-using-AI primitive, logged)

### DIFF
--- a/python/helm/ask.py
+++ b/python/helm/ask.py
@@ -1,0 +1,109 @@
+"""ask: summon an AI in the terminal -- the AI-using-AI primitive, logged.
+
+Send a prompt to a local model (Ollama by default, any OpenAI-compatible endpoint) and get TEXT
+back. `ask` is the SUMMON layer: it returns the model's text; it does not execute it. That is not a
+chain on the AI -- summoning and acting are different jobs. Acting on any of that text is the
+SEPARATE gated-shell layer (the PowerShell fork), where the bounds are about SAFETY not chains:
+they loosen for ordinary ops and hold the line only on destructive / drive-scope moves. So
+"an AI in the terminal" = get its advice here, act through the gated shell there.
+
+Every call writes an audit receipt (prompt digest + preview, response tail) to
+artifacts/aetherdesk_receipts/ -- the same place AetherDesk logs its runs -- so AI-using-AI is
+auditable. On a dead endpoint it returns ok=False with the error, never a fabricated answer.
+
+    python -m python.helm.ask "in one sentence, what is a Poincare ball?"
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+from . import free_generator as fg
+
+ROOT = Path(__file__).resolve().parents[2]
+RECEIPTS_DIR = ROOT / "artifacts" / "aetherdesk_receipts"
+_RESPONSE_TAIL = 4000
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ask(
+    prompt: str, model: Optional[str] = None, base: Optional[str] = None, key: Optional[str] = None, timeout: int = 120
+) -> Dict[str, Any]:
+    """Summon the model; return its TEXT (never executed here). ok=False on any endpoint failure."""
+    base = base or os.environ.get("SCBE_LLM_BASE", fg.DEFAULT_BASE)
+    key = key or os.environ.get("SCBE_LLM_KEY", "ollama")
+    model = model or os.environ.get("SCBE_LLM_MODEL", fg.DEFAULT_MODEL)
+    started = _now()
+    try:
+        text = fg._chat([{"role": "user", "content": prompt}], base=base, key=key, model=model, timeout=timeout)
+        return {
+            "ok": True,
+            "model": model,
+            "response": text,
+            "error": None,
+            "started_at": started,
+            "finished_at": _now(),
+        }
+    except Exception as exc:  # honest: a dead endpoint yields no answer, never a guess
+        return {
+            "ok": False,
+            "model": model,
+            "response": "",
+            "error": "%s: %s" % (type(exc).__name__, exc),
+            "started_at": started,
+            "finished_at": _now(),
+        }
+
+
+def log_ask(result: Dict[str, Any], prompt: str) -> Path:
+    """Write an audit receipt for one AI summon (prompt hashed + previewed, response tail)."""
+    RECEIPTS_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    receipt = {
+        "schema": "aetherdesk_ask_receipt_v1",
+        "task_id": "%s_ask" % stamp,
+        "model": result["model"],
+        "prompt_digest": hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+        "prompt_preview": prompt[:200],
+        "response_tail": (result["response"] or "")[-_RESPONSE_TAIL:],
+        "ok": result["ok"],
+        "error": result["error"],
+        "started_at": result["started_at"],
+        "finished_at": result["finished_at"],
+        "note": "advisory text only -- not executed; acting goes through the safety-gated shell",
+    }
+    path = RECEIPTS_DIR / (receipt["task_id"] + ".json")
+    path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(prog="scbe-ask", description="summon an AI in the terminal (logged; text only)")
+    ap.add_argument("prompt", help="the prompt to send to the local model")
+    ap.add_argument("--model", help="override the model (default: env SCBE_LLM_MODEL or free_generator default)")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    result = ask(a.prompt, model=a.model)
+    path = log_ask(result, a.prompt)
+    if not result["ok"]:
+        print(
+            "ask failed (%s) -- no answer returned, not a guess. receipt: %s" % (result["error"], path.name),
+            file=sys.stderr,
+        )
+        return 1
+    print(result["response"])
+    print("\n[advisory text only -- not executed; receipt: %s]" % path.name, file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/math_claims.txt
+++ b/scripts/ci/math_claims.txt
@@ -25,3 +25,4 @@ python/scbe/game_board.py :: a task as a board game - the rules are governance, 
 python/scbe/failure_map.py :: aggregate stepwise runs across tasks and models into a drift map - per-run drift point, per-task wall, cross-model clearers, universal-fail steps
 scripts/system/agentic_pazaak_board.py :: pazaak bitboard planner - score task lanes by value and risk and verified, recommend the next card move
 python/helm/host_capability.py :: probe the host for toolchains models and resources and certify which capabilities run here (aetherdesk boot check)
+python/helm/ask.py :: summon a local model with a prompt, return its text without executing it, log an audit receipt (ai-in-terminal)

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1,0 +1,60 @@
+"""ask: summon an AI in the terminal -- returns the model's TEXT (never executed here), logs an
+audit receipt, and fails honestly (no fabricated answer) on a dead endpoint. Mocked transport;
+no live model call."""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.helm import ask as ask_mod  # noqa: E402
+from python.helm.ask import ask, log_ask  # noqa: E402
+
+
+def test_ask_returns_model_text(monkeypatch):
+    monkeypatch.setattr(ask_mod.fg, "_chat", lambda messages, **kw: "a Poincare ball is a model of hyperbolic space")
+    r = ask("what is a Poincare ball?", model="mock")
+    assert r["ok"] is True
+    assert isinstance(r["response"], str) and "hyperbolic" in r["response"]
+    assert r["model"] == "mock"
+
+
+def test_dead_endpoint_returns_no_answer_not_a_guess(monkeypatch):
+    def boom(messages, **kw):
+        raise ConnectionError("no model running")
+
+    monkeypatch.setattr(ask_mod.fg, "_chat", boom)
+    r = ask("anything")
+    assert r["ok"] is False and r["response"] == ""  # honest: empty, never fabricated
+    assert "ConnectionError" in r["error"]
+
+
+def test_log_ask_writes_an_auditable_receipt_without_leaking_the_full_prompt(tmp_path, monkeypatch):
+    monkeypatch.setattr(ask_mod, "RECEIPTS_DIR", tmp_path)
+    secret = "SECRET-PROMPT-" + "x" * 500
+    r = {"ok": True, "model": "mock", "response": "ok", "error": None, "started_at": "t0", "finished_at": "t1"}
+    path = log_ask(r, secret)
+    rec = json.loads(path.read_text(encoding="utf-8"))
+    assert rec["schema"] == "aetherdesk_ask_receipt_v1"
+    assert len(rec["prompt_digest"]) == 64  # sha256 of the full prompt (audit), not the prompt itself
+    assert rec["prompt_preview"] == secret[:200]
+    assert ("x" * 500) not in json.dumps(rec)  # the full prompt body is not stored verbatim
+    assert "not executed" in rec["note"]
+
+
+def test_main_prints_response_and_exits(monkeypatch, tmp_path):
+    monkeypatch.setattr(ask_mod, "RECEIPTS_DIR", tmp_path)
+    monkeypatch.setattr(ask_mod.fg, "_chat", lambda messages, **kw: "42")
+    assert ask_mod.main(["what is 6*7?", "--model", "mock"]) == 0
+
+
+def test_main_fails_loudly_on_dead_endpoint(monkeypatch, tmp_path):
+    monkeypatch.setattr(ask_mod, "RECEIPTS_DIR", tmp_path)
+
+    def boom(messages, **kw):
+        raise ConnectionError("down")
+
+    monkeypatch.setattr(ask_mod.fg, "_chat", boom)
+    assert ask_mod.main(["q"]) == 1  # non-zero, no answer printed


### PR DESCRIPTION
The piece you picked: `ask` sends a prompt to a local model (Ollama default, any OpenAI-compatible endpoint) and returns its **text**. It's the **summon** layer — it does *not* execute the reply.

That's not a chain on the AI — **summoning and acting are different jobs.** Acting on the text is the *separate* gated-shell layer (the PowerShell fork), where the bounds are **safety, not chains**: they loosen for ordinary ops and hold the line only on destructive / drive-scope moves.

Every call writes an audit receipt (prompt **sha256 + 200-char preview**, response tail) to `artifacts/aetherdesk_receipts/` — AI-using-AI is auditable, and the full prompt is hashed, not stored verbatim. Dead endpoint → `ok=False` + error, never a fabricated answer. Reuses `free_generator`'s transport. **5 tests** (mocked; no live call — Ollama is busy with the parallel benchmark; live run is one command when it frees).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New CLI command to submit queries to local or OpenAI-compatible text models with environment-based configuration.
  * Audit trail with JSON receipts capturing model information, prompt digests, and response summaries for transparency.

* **Tests**
  * Added comprehensive test coverage for query functionality and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->