### PR TITLE
chore(ci): register the existing gated-shell + safety-gate (desktop_access, blocks)

### DIFF
--- a/scripts/ci/math_claims.txt
+++ b/scripts/ci/math_claims.txt
@@ -26,3 +26,5 @@ python/scbe/failure_map.py :: aggregate stepwise runs across tasks and models in
 scripts/system/agentic_pazaak_board.py :: pazaak bitboard planner - score task lanes by value and risk and verified, recommend the next card move
 python/helm/host_capability.py :: probe the host for toolchains models and resources and certify which capabilities run here (aetherdesk boot check)
 python/helm/ask.py :: summon a local model with a prompt, return its text without executing it, log an audit receipt (ai-in-terminal)
+python/scbe/desktop_access.py :: governed action registry - allowlist safe/guarded/denied + destructive-command screen + sealed receipts, surfaced as api/dom/pixels
+python/scbe/blocks.py :: scratch-style command blocks with safe/caution/destructive classes, destructive gated and drive-scope refused


### PR DESCRIPTION
Closing the redundancy-gate loop. I nearly built a 'shell safety policy' — the gate said 'clear to build' because `desktop_access.py` (the gated-shell: allowlist safe/guarded/denied + destructive screen + sealed receipts) and `blocks.py` (safe/caution/destructive command blocks, drive-scope refused) weren't registered. A **concept-grep** caught the near-duplicate; registering both so the lexical gate covers this class next time.

Both verified passing (**20 tests**). They already implement the **safety-not-chains** model: safe runs, guarded loosens via confirm+reason, denied is the hard floor (destructive/drive-scope, never). **No new code needed — the gated-shell already exists.**

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>