### PR TITLE
feat(ci): concept-trigger in the redundancy gate + register the TC cores

### DIFF
--- a/scripts/ci/math_claims.txt
+++ b/scripts/ci/math_claims.txt
@@ -28,3 +28,5 @@ python/helm/host_capability.py :: probe the host for toolchains models and resou
 python/helm/ask.py :: summon a local model with a prompt, return its text without executing it, log an audit receipt (ai-in-terminal)
 python/scbe/desktop_access.py :: governed action registry - allowlist safe/guarded/denied + destructive-command screen + sealed receipts, surfaced as api/dom/pixels
 python/scbe/blocks.py :: scratch-style command blocks with safe/caution/destructive classes, destructive gated and drive-scope refused
+python/scbe/bit_spine.py :: brainfuck-class instruction set (8 ops) over an unbounded tape - turing complete core; plus binary/hex/trit byte projections
+python/loom/machine.py :: minsky register machine (inc/dec-branch/jmp) - turing complete with two registers, woven into many languages

--- a/scripts/ci/redundancy_gate.py
+++ b/scripts/ci/redundancy_gate.py
@@ -103,6 +103,36 @@ def audit(registry: Sequence[Tuple[str, str]], threshold: float = 0.5) -> List[T
     return sorted(hits, key=lambda h: -h[2])
 
 
+# High-signal concepts where a re-implementation/re-encoding is common and adds NO new power
+# (re-encoding Brainfuck as cube moves is still Brainfuck -- same TC, zero new capability). If a new
+# claim AND a registered module both mention one, flag it for review even when token-overlap is low:
+# the lexical gate misses these (different surface vocab, same idea -- e.g. 'cube moves' vs 'binary spine').
+_CONCEPTS = [
+    "turing complete",
+    "turing-complete",
+    "brainfuck",
+    "minsky",
+    "register machine",
+    "unbounded tape",
+    "two-counter",
+    "2-counter",
+]
+
+
+def concept_matches(claim: str, registry: Sequence[Tuple[str, str]]) -> List[Tuple[str, List[str]]]:
+    """High-signal concept words shared between `claim` and registered claims -- catches re-encodings
+    token-overlap misses (a 'cube moves' claim won't Jaccard-match 'binary spine', but both say
+    'turing complete' / 'brainfuck'). Returns [(concept, [modules that also claim it])]."""
+    low = claim.lower()
+    out: List[Tuple[str, List[str]]] = []
+    for phrase in _CONCEPTS:
+        if phrase in low:
+            mods = [m for m, cl in registry if phrase in cl.lower()]
+            if mods:
+                out.append((phrase, mods))
+    return out
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     ap = argparse.ArgumentParser(
         prog="redundancy-gate", description="surface conceptually-redundant work before it lands"
@@ -124,12 +154,18 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if a.claim:
         hits = check(a.claim, reg, a.threshold)
-        if not hits:
-            print("no claim on main overlaps >= %.2f -- looks new, clear to build" % a.threshold)
+        concepts = concept_matches(a.claim, reg)
+        if not hits and not concepts:
+            print("no overlap >= %.2f and no flagged concepts -- looks new, clear to build" % a.threshold)
             return 0
-        print("REVIEW -- this overlaps existing work (might be redundant before you write a line):")
-        for mod, c, s in hits:
-            print('  %.2f  %s\n        "%s"' % (s, mod, c))
+        if hits:
+            print("REVIEW -- overlaps existing work (might be redundant before you write a line):")
+            for mod, c, s in hits:
+                print('  %.2f  %s\n        "%s"' % (s, mod, c))
+        if concepts:
+            print("CONCEPT FLAGS -- a re-encodable concept (re-encoding adds NO power); review the cores:")
+            for phrase, mods in concepts:
+                print("  '%s' -> %s" % (phrase, ", ".join(mods)))
         return 1 if a.strict else 0
 
     ap.error('give --claim "<one-line math>" or --audit')

--- a/tests/test_redundancy_gate.py
+++ b/tests/test_redundancy_gate.py
@@ -71,3 +71,24 @@ def test_cli_claim_and_audit_run():
     assert rg.main(["--audit", "--registry", str(REGISTRY)]) == 0
     # strict mode exits nonzero when an overlap is found
     assert rg.main(["--claim", "a string as a heap array of char codes", "--registry", str(REGISTRY), "--strict"]) == 1
+
+
+def test_concept_trigger_flags_a_tc_reencoding_that_jaccard_misses():
+    # a 'turing rubix' re-encoding shares almost no tokens with 'binary spine' (Jaccard < 0.5),
+    # but it IS just Brainfuck again -- the concept trigger must catch it against the registered cores
+    reg = rg.load_registry(REGISTRY)
+    claim = "turing rubix: cube moves as a brainfuck instruction surface over an unbounded tape, turing complete"
+    assert rg.check(claim, reg, 0.5) == []  # the honest limit: Jaccard alone does NOT catch it
+    cm = rg.concept_matches(claim, reg)
+    phrases = {p for p, _ in cm}
+    assert {"brainfuck", "turing complete", "unbounded tape"} & phrases  # the concept trigger DOES
+    flagged = {m for _, mods in cm for m in mods}
+    assert any("bit_spine" in m for m in flagged)  # flagged against the registered BF/TC core
+
+
+def test_concept_trigger_is_quiet_on_unrelated_work():
+    reg = rg.load_registry(REGISTRY)
+    assert rg.concept_matches("a graded reasoning ladder scored by exact match", reg) == []
+    # and strict mode now blocks a TC re-encoding even with zero Jaccard overlap
+    args = ["--claim", "encode brainfuck as dance moves, turing complete", "--registry", str(REGISTRY), "--strict"]
+    assert rg.main(args) == 1


### PR DESCRIPTION
**Goal: register the TC cores so re-encodings get flagged.** But registering alone doesn't achieve it — a 'cube moves' re-encoding Jaccard-matches 'binary spine' at ~0.26 (under threshold), the same lexical limit that missed `stepwise`. So this adds a **concept trigger**: high-signal phrases (`turing complete`, `brainfuck`, `minsky`, `register machine`, `unbounded tape`) flag a new claim against any registered core that shares them, *even when token-overlap is low*.

Registered the two TC cores:
- `bit_spine` — Brainfuck-class ops over an unbounded tape (the BF/tape TC model)
- `loom/machine` — Minsky register machine, TC with ≥2 registers (the register/counter model)

Now a 'Turing Rubix' claim — which Jaccard misses — flags against `bit_spine` with *'re-encoding adds NO power; review the cores'* (the tc-architecture-seam principle, made enforceable). **10 tests**; audit still clean (only the known curriculum↔reasoning sibling).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>