### PR TITLE
fix(reasoning_ladder): answer extractor handles commas + units

### DIFF
--- a/python/helm/reasoning_ladder.py
+++ b/python/helm/reasoning_ladder.py
@@ -115,8 +115,10 @@ def naive_climber(item: Dict[str, Any]) -> str:
 
 
 def _extract_answer(text: str) -> str:
-    """Pull a clean answer out of a model reply -- the last number if any, else the stripped text."""
-    nums = re.findall(r"-?\d+(?:\.\d+)?", text or "")
+    """Pull a clean answer out of a model reply -- the last number, else the stripped text.
+    Strips digit-grouping commas first (a real model quirk: '1,000' must read as 1000, not 000)."""
+    cleaned = re.sub(r"(?<=\d),(?=\d)", "", text or "")  # 1,000 -> 1000 (only commas between digits)
+    nums = re.findall(r"-?\d+(?:\.\d+)?", cleaned)
     return nums[-1] if nums else (text or "").strip()
 
 

--- a/tests/test_reasoning_ladder.py
+++ b/tests/test_reasoning_ladder.py
@@ -80,6 +80,18 @@ def test_llm_climber_extracts_the_answer_and_grades(monkeypatch):
     assert s["highest_tier_cleared"] == 5 and s["total_passed"] == 20
 
 
+def test_extract_answer_handles_real_model_quirks():
+    from python.helm.reasoning_ladder import _extract_answer
+
+    assert _extract_answer("The answer is 56.") == "56"
+    assert _extract_answer("It costs $30") == "30"
+    assert _extract_answer("about 30%") == "30"
+    assert _extract_answer("1,000 ways") == "1000"  # the real bug: commas used to split into '000'
+    assert _extract_answer("7*8 = 56, so 56") == "56"  # non-grouping comma left alone
+    assert _extract_answer("-5 degrees") == "-5"
+    assert _extract_answer("no number here") == "no number here"  # falls back to text
+
+
 def test_llm_climber_dead_endpoint_scores_zero(monkeypatch):
     # a dead endpoint must score 0, never a fabricated pass (honest like free_generator)
     from python.helm import free_generator as fg


### PR DESCRIPTION
Overnight hardening from observed real-model output. `_extract_answer('1,000')` used to split into `['1','000']` → return `'000'` (a thousands-comma answer would wrongly fail). Now strips digit-grouping commas first (1,000 → 1000), leaving non-grouping commas alone. 7 new cases (`$`, %, negatives, comma-grouping, text fallback). Live 1.5b re-run holds at 9/20 — no regression, the fix only helps. 9 tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>