### PR TITLE
feat(toolkit_map): cross-face verify runs all three faces (py/js/rust)

### DIFF
--- a/python/scbe/toolkit_map.py
+++ b/python/scbe/toolkit_map.py
@@ -71,11 +71,23 @@ def _demo_loomflow(tk: Toolkit) -> Tuple[bool, str]:
 
 
 def _demo_cross_face(tk: Toolkit) -> Tuple[bool, str]:
-    v = tk.invoke("verify", tk.invoke("parse", "const a 5\nprint a")["result_obj"], faces=["python"])["result_obj"]
+    # Run the FULL face set (python/javascript/rust), each emitted + EXECUTED + compared to the
+    # reference -- so "faces agree" is literal cross-face agreement, not one-face-vs-reference.
+    faces = ("python", "javascript", "rust")
+    v = tk.invoke("verify", tk.invoke("parse", "const a 5\nprint a")["result_obj"], faces=faces)["result_obj"]
     p2 = tk.invoke("parse_fn", "const a 6\nconst b 7\nmul c a b\nprint c")["result_obj"]
-    v2 = tk.invoke("verify_fn", p2, faces=("python",))["result_obj"]
-    ok = bool(v and v["results"]["python"]["status"] == "AGREE" and v2 and v2["reference"] == 42.0)
-    return ok, "loomflow python=AGREE; loomfn mul -> reference %s" % (v2["reference"] if v2 else None)
+    v2 = tk.invoke("verify_fn", p2, faces=faces)["result_obj"]
+
+    def cross_agree(res) -> bool:
+        # literal cross-face: >= 2 faces actually RAN and AGREED, and NONE disagreed (a missing
+        # toolchain is NO_TOOLCHAIN, not a pass; a real mismatch is DISAGREE and fails the area)
+        return bool(res) and len(res["verified"]) >= 2 and not res["disagree"]
+
+    ok = cross_agree(v) and cross_agree(v2) and bool(v2) and v2["reference"] == 42.0
+    return ok, "loomflow faces agree=%s; loomfn mul=42 faces agree=%s" % (
+        sorted(v["verified"]) if v else [],
+        sorted(v2["verified"]) if v2 else [],
+    )
 
 
 def _demo_board(tk: Toolkit) -> Tuple[bool, str]:


### PR DESCRIPTION
Codex's end-to-end run flagged it honestly: the map's Cross-Face Verify showed `6*7 -> Python face AGREE` — one face vs the reference, not cross-face agreement.

Now the verify step runs the **full face set (python/javascript/rust)**, each emitted + **executed** + compared to the reference, and the area clears only on **literal** cross-face agreement: ≥2 faces actually ran and agreed **and** none disagreed (a missing toolchain is `NO_TOOLCHAIN`, not a pass; a real mismatch is `DISAGREE` and fails the area).

Verified live: loomflow + loomfn both agree across `[javascript, python, rust]`; map still clears **13/13 sealed**; **27 tests pass**.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cross-Face Verify demo now validates code agreement across Python, JavaScript, and Rust backends with enhanced verification logic and consolidated reporting of verified platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->