### PR TITLE
feat(free_generator): execution-feedback repair on the code ladder (the honest +0)

### DIFF
--- a/docs/LADDER_BASELINES_AND_LIFT.md
+++ b/docs/LADDER_BASELINES_AND_LIFT.md
@@ -34,6 +34,20 @@ The thesis is **lift**: not a smarter model, the *same* model with its choices r
 
 **Honest caveats:** program-aided reasoning (PAL/PoT) is an established technique, not novel here. It lifts *computation-heavy* reasoning specifically (plays to a coder model's strength: writing code), and is **not** universal — tool/rails routing gave no lift on some tasks elsewhere. The contiguous-tier metric *understates* it (PAL trips one trivial arithmetic item → reads tier 0); the **total** (8.3 → 15) is the signal.
 
+### Same routing on the CODE ladder — and the contrast that matters
+
+`make_repair_generator`: write code → run the **public** test → on failure, feed the error back and retry (hidden held out, no leakage).
+
+| 1.5B, code ladder | total /15 |
+|---|---|
+| RAW (single shot) | 13 |
+| repair (2 rounds) | **13** |
+| **lift** | **+0** |
+
+The +0 is the finding, not a dud. The loop **fires** on both remaining misses (public fails for `fizzbuzz` + `regex`; a unit test proves it retries with the failure in the prompt) — but the 1.5B regenerates code that *still fails*. It can't act on the signal: `fizzbuzz` is a **prior-override** (it keeps writing the reflexive Fizz/Buzz despite the failing test), `regex` is a real **capability ceiling**.
+
+**The lesson:** tool-routing lifts when it **supplies a missing capability** (compute the math the model can't do in its head → reasoning **+6–7**); it does **nothing** when the failure is a prior or capability ceiling (code **+0**). This is "harness rescues interface/computation gaps, not capability" in two contrasting measurements.
+
 ## Reproduce
 
 ```bash

--- a/python/helm/free_generator.py
+++ b/python/helm/free_generator.py
@@ -74,3 +74,52 @@ def make_generator(
 
     generator.__name__ = "free_llm(%s)" % model
     return generator
+
+
+def make_repair_generator(
+    base: Optional[str] = None,
+    key: Optional[str] = None,
+    model: Optional[str] = None,
+    public_k: int = 1,
+    rounds: int = 2,
+) -> Callable[[Dict[str, Any]], str]:
+    """Execution-feedback repair -- the CODE-ladder analog of routing reasoning through execution.
+
+    The model writes code; we RUN it against the PUBLIC example(s) only and, on failure, feed the code
+    plus the failing assert back and let it fix, up to `rounds` times. Hidden tests stay held out (the
+    model never sees them), so any gain is honest lift, not leakage. Same model -- only the routing
+    changed: the executor checks the model's choice and the error corrects it."""
+    base = base or os.environ.get("SCBE_LLM_BASE", DEFAULT_BASE)
+    key = key or os.environ.get("SCBE_LLM_KEY", "ollama")
+    model = model or os.environ.get("SCBE_LLM_MODEL", DEFAULT_MODEL)
+    first = make_generator(base=base, key=key, model=model, public_k=public_k)
+
+    def generator(problem: Dict[str, Any]) -> str:
+        from . import public_bench as pb  # lazy import avoids any cycle
+
+        public = list(problem.get("test_list", []))[:public_k]
+        imports = list(problem.get("test_imports", []))
+        code = first(problem)
+        for _ in range(rounds):
+            res = pb._verify(code, public, [], imports)  # PUBLIC only; hidden never shown
+            if res.get("public_passed"):
+                break
+            fails = "; ".join(res.get("public_failures", []) or [])[:300]
+            prompt = (
+                (problem.get("prompt") or problem.get("text") or "").strip()
+                + "\n\nYour previous code:\n"
+                + code
+                + "\n\nIt FAILED this check:\n"
+                + "\n".join(public)
+                + "\nError: "
+                + (fails or "did not pass")
+                + "\nReturn ONLY corrected Python code."
+            )
+            try:
+                code = strip_to_code(_chat([{"role": "user", "content": prompt}], base=base, key=key, model=model))
+            except Exception:
+                break
+        return code
+
+    generator.__name__ = "repair_llm(%s,r=%d)" % (model, rounds)
+    return generator

--- a/python/helm/ladder_baselines.json
+++ b/python/helm/ladder_baselines.json
@@ -30,6 +30,11 @@
     "method": "measure_lift(llm_climber, program_aided_climber) on the reasoning ladder, SAME model in both slots.",
     "qwen2.5-coder:1.5b": {"raw_mean": 8.3, "raw_runs": [9, 8, 8], "pal_runs": [15, 15, 15], "pal_total": 15,
       "total_lift": "+6 to +7 of 20", "note": "stable +6-7. The contiguous-tier metric UNDERSTATES it (PAL trips one arithmetic item, so contiguous reads T0) -- the TOTAL (8.3 -> 15) is the real signal."},
-    "qwen2.5-coder:3b": "unavailable -- model removed during disk cleanup; re-pull (ollama pull qwen2.5-coder:3b) to measure"
+    "qwen2.5-coder:3b": "unavailable -- model removed during disk cleanup; re-pull (ollama pull qwen2.5-coder:3b) to measure",
+    "code_curriculum_execution_feedback": {
+      "tool": "make_repair_generator (free_generator.py): write code -> run the PUBLIC test -> on fail, feed the failure back and retry (hidden held out, no leakage). The code-ladder analog of routing reasoning through execution.",
+      "qwen2.5-coder:1.5b": {"raw": 13, "repair_rounds_2": 13, "total_lift": "+0 of 15"},
+      "finding": "LIFT = +0, and that is the point. The repair loop FIRES on both misses (public fails for fizzbuzz + regex; proven by unit test that it retries with feedback) but the 1.5b regenerates code that STILL fails -- it cannot ACT on the signal: fizzbuzz = prior-override (keeps writing the reflexive Fizz/Buzz despite the failing test), regex = a real capability ceiling. CONTRAST with the +6-7 reasoning lift: tool-routing lifts when it SUPPLIES missing capability (compute the math the model can't do in its head), NOT when the failure is a prior/capability ceiling. Reinforces 'harness rescues interface/computation gaps, not capability'."
+    }
   }
 }

--- a/tests/test_free_generator.py
+++ b/tests/test_free_generator.py
@@ -35,3 +35,34 @@ def test_endpoint_failure_fails_verification_not_silently_wrong(monkeypatch):
     monkeypatch.setattr(fg, "_chat", boom)
     s = run_public_bench(probs, generator=fg.make_generator(), public_k=1)
     assert s["verified"] == 0  # a dead endpoint yields a stub that FAILS -- never ships wrong code
+
+
+def test_repair_generator_uses_execution_feedback_to_fix(monkeypatch):
+    # bad code first -> public fails -> repair prompt includes the failure -> good code -> passes.
+    # proves the loop FIRES and acts on execution feedback (not a no-op).
+    calls = []
+
+    def fake_chat(messages, **kw):
+        calls.append(messages[0]["content"])
+        return "def f():\n    return 0" if len(calls) == 1 else "def add(a, b):\n    return a + b"
+
+    monkeypatch.setattr(fg, "_chat", fake_chat)
+    gen = fg.make_repair_generator(model="mock", rounds=2)
+    out = gen({"prompt": "add a and b", "test_list": ["assert add(1,2)==3", "assert add(5,5)==10"], "test_imports": []})
+    assert len(calls) == 2  # the loop retried after the public failure
+    assert "FAILED" in calls[1]  # the retry prompt carried the execution feedback
+    assert "def add" in out  # and the repaired code is what's returned
+
+
+def test_repair_generator_only_sees_public_not_hidden(monkeypatch):
+    # the repair loop must never receive the hidden tests -- honest lift, not leakage
+    seen = []
+
+    def fake_chat(messages, **kw):
+        seen.append(messages[0]["content"])
+        return "def f():\n    return 1"  # always wrong -> forces every repair round to run
+
+    monkeypatch.setattr(fg, "_chat", fake_chat)
+    gen = fg.make_repair_generator(model="mock", rounds=2, public_k=1)
+    gen({"prompt": "p", "test_list": ["assert f()==1", "assert f()==2  # HIDDEN"], "test_imports": []})
+    assert not any("HIDDEN" in s for s in seen)  # the hidden assert never reached the model


### PR DESCRIPTION
Applies the same 'route the model through a tool' idea to the **code** ladder. `make_repair_generator`: write code → run the **public** test → on failure feed it back and retry (hidden held out — honest lift, not leakage).

**Result: 1.5B 13/15 → 13/15, lift +0 — and that's the finding.** The loop *fires* on both misses (public fails for `fizzbuzz` + `regex`; a unit test proves it retries with the failure in the prompt), but the model regenerates code that still fails: `fizzbuzz` = prior-override, `regex` = capability ceiling.

**Contrast that matters:** tool-routing lifts when it **supplies missing capability** (compute the math → reasoning **+6–7**); it does nothing against a prior/capability ceiling (code **+0**). 'Harness rescues interface/computation gaps, not capability,' in two measurements. Recorded in `ladder_baselines.json` + `docs/LADDER_BASELINES_AND_LIFT.md`; 5 tests; lint + no-fakes clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>