### PR TITLE
data: 3b lift numbers (reasoning +7-8, code +0)

### DIFF
--- a/docs/LADDER_BASELINES_AND_LIFT.md
+++ b/docs/LADDER_BASELINES_AND_LIFT.md
@@ -24,13 +24,12 @@ The thesis is **lift**: not a smarter model, the *same* model with its choices r
 
 ### LIFT — the headline (PR #2456)
 
-| 1.5B, reasoning ladder | total /20 |
-|---|---|
-| RAW (mental math) | 8–9 |
-| **PAL (routed through code execution)** | **15** (stable ×3) |
-| **lift** | **+6 to +7** |
+| reasoning ladder, /20 | RAW (mental math) | PAL (routed through code execution) | lift |
+|---|---|---|---|
+| **1.5B** | 8–9 | **15** (stable ×3) | **+6 to +7** |
+| **3B** | 10 | **17–18** (stable) | **+7 to +8** |
 
-`program_aided_climber`: the model **writes** a short Python program that computes the answer; it runs in a sandboxed subprocess; we read the printed number. Same weights — only the *routing* changed.
+`program_aided_climber`: the model **writes** a short Python program that computes the answer; it runs in a sandboxed subprocess; we read the printed number. Same weights — only the *routing* changed. The lift holds across both models and scales slightly with the base.
 
 **Honest caveats:** program-aided reasoning (PAL/PoT) is an established technique, not novel here. It lifts *computation-heavy* reasoning specifically (plays to a coder model's strength: writing code), and is **not** universal — tool/rails routing gave no lift on some tasks elsewhere. The contiguous-tier metric *understates* it (PAL trips one trivial arithmetic item → reads tier 0); the **total** (8.3 → 15) is the signal.
 
@@ -38,13 +37,12 @@ The thesis is **lift**: not a smarter model, the *same* model with its choices r
 
 `make_repair_generator`: write code → run the **public** test → on failure, feed the error back and retry (hidden held out, no leakage).
 
-| 1.5B, code ladder | total /15 |
-|---|---|
-| RAW (single shot) | 13 |
-| repair (2 rounds) | **13** |
-| **lift** | **+0** |
+| code ladder, /15 | RAW (single shot) | repair (2 rounds) | lift |
+|---|---|---|---|
+| **1.5B** | 13 | **13** | **+0** |
+| **3B** | 13 | **13** | **+0** |
 
-The +0 is the finding, not a dud. The loop **fires** on both remaining misses (public fails for `fizzbuzz` + `regex`; a unit test proves it retries with the failure in the prompt) — but the 1.5B regenerates code that *still fails*. It can't act on the signal: `fizzbuzz` is a **prior-override** (it keeps writing the reflexive Fizz/Buzz despite the failing test), `regex` is a real **capability ceiling**.
+The +0 is the finding, not a dud. The loop **fires** on the remaining misses (public fails for `fizzbuzz` + `regex`; a unit test proves it retries with the failure in the prompt) — but the model regenerates code that *still fails*. It can't act on the signal: `fizzbuzz` is a **prior-override** (it keeps writing the reflexive Fizz/Buzz despite the failing test), `regex` is a real **capability ceiling**.
 
 **The lesson:** tool-routing lifts when it **supplies a missing capability** (compute the math the model can't do in its head → reasoning **+6–7**); it does **nothing** when the failure is a prior or capability ceiling (code **+0**). This is "harness rescues interface/computation gaps, not capability" in two contrasting measurements.
 

--- a/python/helm/ladder_baselines.json
+++ b/python/helm/ladder_baselines.json
@@ -30,11 +30,13 @@
     "method": "measure_lift(llm_climber, program_aided_climber) on the reasoning ladder, SAME model in both slots.",
     "qwen2.5-coder:1.5b": {"raw_mean": 8.3, "raw_runs": [9, 8, 8], "pal_runs": [15, 15, 15], "pal_total": 15,
       "total_lift": "+6 to +7 of 20", "note": "stable +6-7. The contiguous-tier metric UNDERSTATES it (PAL trips one arithmetic item, so contiguous reads T0) -- the TOTAL (8.3 -> 15) is the real signal."},
-    "qwen2.5-coder:3b": "unavailable -- model removed during disk cleanup; re-pull (ollama pull qwen2.5-coder:3b) to measure",
+    "qwen2.5-coder:3b": {"raw_total": 10, "pal_runs": [18, 18, 18], "pal_total": 18,
+      "total_lift": "+7 to +8 of 20", "note": "re-pulled 2026-06-19. Even bigger lift than 1.5b: RAW 10 -> PAL 17-18 (measure_lift run 17, three fresh runs 18). Lift holds and scales slightly with the base model."},
     "code_curriculum_execution_feedback": {
       "tool": "make_repair_generator (free_generator.py): write code -> run the PUBLIC test -> on fail, feed the failure back and retry (hidden held out, no leakage). The code-ladder analog of routing reasoning through execution.",
       "qwen2.5-coder:1.5b": {"raw": 13, "repair_rounds_2": 13, "total_lift": "+0 of 15"},
-      "finding": "LIFT = +0, and that is the point. The repair loop FIRES on both misses (public fails for fizzbuzz + regex; proven by unit test that it retries with feedback) but the 1.5b regenerates code that STILL fails -- it cannot ACT on the signal: fizzbuzz = prior-override (keeps writing the reflexive Fizz/Buzz despite the failing test), regex = a real capability ceiling. CONTRAST with the +6-7 reasoning lift: tool-routing lifts when it SUPPLIES missing capability (compute the math the model can't do in its head), NOT when the failure is a prior/capability ceiling. Reinforces 'harness rescues interface/computation gaps, not capability'."
+      "qwen2.5-coder:3b": {"raw": 13, "repair_rounds_2": 13, "total_lift": "+0 of 15"},
+      "finding": "LIFT = +0 for BOTH models, and that is the point. The repair loop FIRES on the misses (public fails for fizzbuzz + regex; proven by unit test that it retries with feedback) but the model regenerates code that STILL fails -- it cannot ACT on the signal: fizzbuzz = prior-override (keeps writing the reflexive Fizz/Buzz despite the failing test), regex = a real capability ceiling. CONTRAST with the +6-8 reasoning lift: tool-routing lifts when it SUPPLIES missing capability (compute the math the model can't do in its head), NOT when the failure is a prior/capability ceiling. Reinforces 'harness rescues interface/computation gaps, not capability'."
     }
   }
 }


### PR DESCRIPTION
Re-pulled `qwen2.5-coder:3b` and filled in its lift. Reasoning RAW **10/20 → PAL 17–18/20 = +7–8** (even bigger than 1.5b); code **13/15 → 13/15 = +0** (same prior/capability ceiling — repair fires, model still can't fix fizzbuzz/regex). Lift story holds across both models: big on computation-heavy reasoning, zero against prior/capability ceilings. Updated `ladder_baselines.json` + `docs/LADDER_BASELINES_AND_LIFT.md`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted baseline and lift results tables for improved clarity and comparison across different measurement approaches.
  * Updated measurement results and findings for model performance analysis.
  * Enhanced explanatory text to reflect table restructuring and provide clearer reasoning about repair outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->