### PR TITLE
fix(stepwise): close 3 defects from adversarial review of auto-offload

### DIFF
--- a/python/helm/offload_measure.py
+++ b/python/helm/offload_measure.py
@@ -1,16 +1,19 @@
 """offload_measure: measure the auto-offload lift on a LIVE weak model.
 
-The claim under test is narrow and honest: when a step has a deterministic `oracle`, the harness can
-SUPPLY the capability the model lacks instead of merely stopping at its ceiling. So the same model on
-the same task should go from "some numbers stuck, never wrong" (allow_offload=False) to "nothing
-stuck, still never wrong" (allow_offload=True) -- and the rescued answers must be CORRECT, because
-the oracle's value is itself checked before it is committed.
+The MEASURED quantity is narrow and honest: the RESCUE rate. The same model on the same task goes
+from "some numbers stuck at its ceiling" (allow_offload=False) to "those numbers completed via the
+oracle" (allow_offload=True). That stuck->rescued delta is the lift, and it is genuinely measured --
+the model really proposes, really exhausts its rewinds, and the oracle really takes over.
 
-This is a measurement, not a demo: it runs the real local model as the proposer (Ollama by default,
-qwen2.5-coder:1.5b) over a fixed set of numbers, twice, and reports stuck-vs-rescued plus a
-correctness check on every completed answer. Nothing is asserted true that wasn't executed.
+Correctness is a SEPARATE, INDEPENDENT cross-check -- NOT a re-run of the oracle's own rule. Each
+completed answer is compared against GROUND_TRUTH, a small hand-verified label table (independent of
+the sieve), so a bug in the classification rule WOULD surface here as a mismatch instead of hiding
+behind a copy of itself. Honesty boundary: the in-harness check that gates the oracle (stepwise) is,
+for this task, derived from the same rule as the oracle -- so it is a legality wall, not an
+independent correctness proof; that is exactly why this measurement carries its OWN external ground
+truth. Numbers with no ground-truth entry are reported as "unverified", never counted as correct.
 
-    python -m python.helm.offload_measure            # default 1.5b over a 9-number spread
+    python -m python.helm.offload_measure            # default 1.5b over the 9-number ground-truth set
     SCBE_LLM_MODEL=qwen2.5-coder:3b python -m python.helm.offload_measure
 """
 
@@ -25,6 +28,20 @@ from python.scbe.stepwise import Proposer, run_stepwise
 
 # the numbers the 1.5b reliably trips on: prime-powers (8=2^3, 49=7^2) and the unit (1) are the walls
 DEFAULT_NUMBERS = [1, 2, 6, 8, 12, 13, 30, 49, 91]
+
+# INDEPENDENT ground truth: labels verified BY HAND (not re-derived from the sieve), so a bug in the
+# classification rule shows up here as a mismatch instead of hiding behind a copy of itself.
+GROUND_TRUTH = {
+    1: "unit",
+    2: "prime",
+    6: "composite",  # 2*3
+    8: "prime-power",  # 2^3
+    12: "composite",  # 2^2*3
+    13: "prime",
+    30: "composite",  # 2*3*5
+    49: "prime-power",  # 7^2
+    91: "composite",  # 7*13
+}
 
 
 def model_proposer(base: str, key: str, model: str) -> Proposer:
@@ -45,31 +62,25 @@ def model_proposer(base: str, key: str, model: str) -> Proposer:
     return p
 
 
-def _expected_label(n: int) -> str:
-    from src import numtheory as nt
-
-    if n == 1:
-        return "unit"
-    if nt.is_prime(n):
-        return "prime"
-    return "prime-power" if len(nt.factorization(n)) == 1 else "composite"
-
-
-def measure(numbers: List[int], proposer: Proposer, max_rewinds: int = 3) -> dict:
-    """Run each number twice -- offload off (baseline) then on -- and tally outcomes + correctness."""
+def measure(numbers: List[int], proposer: Proposer, ground_truth: dict = None, max_rewinds: int = 3) -> dict:
+    """Run each number twice -- offload off (baseline) then on -- tally stuck/rescued, then cross-check
+    each COMPLETED answer against the INDEPENDENT ground-truth table (a hand-verified label, not the
+    oracle's own rule). A number with no ground-truth entry is 'unverified', never counted correct."""
+    truth = GROUND_TRUTH if ground_truth is None else ground_truth
     rows = []
-    base_stuck = rescued = wrong = 0
+    base_stuck = rescued = wrong = unverified = 0
     for n in numbers:
         off = run_stepwise(classify_number_task(n), proposer, max_rewinds=max_rewinds, allow_offload=False)
         on = run_stepwise(classify_number_task(n), proposer, max_rewinds=max_rewinds, allow_offload=True)
-        exp = _expected_label(n)
         was_stuck = not off["completed"]
         got = on.get("answer")
         offloaded = bool(on.get("offloaded"))
-        correct = on["completed"] and got == exp
+        exp = truth.get(n)  # independent ground truth, or None if this number cannot be verified
+        correct = (got == exp) if (on["completed"] and exp is not None) else None
         base_stuck += was_stuck
-        rescued += was_stuck and on["completed"]
-        wrong += on["completed"] and not correct
+        rescued += bool(was_stuck and on["completed"])
+        wrong += int(correct is False)
+        unverified += int(on["completed"] and exp is None)
         rows.append(
             {
                 "n": n,
@@ -80,7 +91,13 @@ def measure(numbers: List[int], proposer: Proposer, max_rewinds: int = 3) -> dic
                 "correct": correct,
             }
         )
-    return {"rows": rows, "baseline_stuck": base_stuck, "rescued": rescued, "wrong": wrong}
+    return {
+        "rows": rows,
+        "baseline_stuck": base_stuck,
+        "rescued": rescued,
+        "wrong": wrong,
+        "unverified": unverified,
+    }
 
 
 def main(argv: object = None) -> int:
@@ -90,26 +107,36 @@ def main(argv: object = None) -> int:
     print("OFFLOAD_MEASURE  live model=%s  (baseline=no offload vs. auto-offload)\n" % model)
 
     res = measure(DEFAULT_NUMBERS, model_proposer(base, key, model))
-    print("  %-4s %-12s %-9s %-12s %-9s %s" % ("n", "expected", "stuck?", "answer", "offload?", "correct?"))
+    print("  %-4s %-12s %-9s %-12s %-9s %s" % ("n", "truth", "stuck?", "answer", "offload?", "vs truth"))
     for r in res["rows"]:
+        if r["correct"] is None:
+            verdict = "unverified" if r["answer"] is not None else "stuck"
+        else:
+            verdict = "ok" if r["correct"] else "WRONG"
         print(
             "  %-4d %-12s %-9s %-12s %-9s %s"
             % (
                 r["n"],
-                r["expected"],
+                r["expected"] or "-",
                 "STUCK" if r["baseline_stuck"] else "-",
                 r["answer"],
                 "tool" if r["offloaded"] else "-",
-                "ok" if r["correct"] else "WRONG",
+                verdict,
             )
         )
     n = len(res["rows"])
-    print("\n  baseline: %d/%d stuck at the model's ceiling (never shipped wrong)" % (res["baseline_stuck"], n))
-    print("  auto-offload: %d of those rescued by the oracle, %d shipped wrong" % (res["rescued"], res["wrong"]))
+    print(
+        "\n  MEASURED lift: %d/%d stuck at the model's ceiling (offload off) -> %d rescued by the oracle (offload on)"
+        % (res["baseline_stuck"], n, res["rescued"])
+    )
+    print(
+        "  INDEPENDENT cross-check vs hand-verified ground truth: %d wrong, %d unverified"
+        % (res["wrong"], res["unverified"])
+    )
     if res["wrong"]:
-        print("  [!] an offloaded answer was WRONG -- the checked-oracle guarantee FAILED, investigate")
+        print("  [!] a completed answer disagreed with ground truth -- the classification rule is wrong, investigate")
     else:
-        print("  -> every rescue was correct: the harness supplied the capability, never faked it")
+        print("  -> the stuck->rescued lift is real, and every verifiable answer matched independent ground truth")
     return 0
 
 

--- a/python/helm/offload_measure.py
+++ b/python/helm/offload_measure.py
@@ -1,0 +1,117 @@
+"""offload_measure: measure the auto-offload lift on a LIVE weak model.
+
+The claim under test is narrow and honest: when a step has a deterministic `oracle`, the harness can
+SUPPLY the capability the model lacks instead of merely stopping at its ceiling. So the same model on
+the same task should go from "some numbers stuck, never wrong" (allow_offload=False) to "nothing
+stuck, still never wrong" (allow_offload=True) -- and the rescued answers must be CORRECT, because
+the oracle's value is itself checked before it is committed.
+
+This is a measurement, not a demo: it runs the real local model as the proposer (Ollama by default,
+qwen2.5-coder:1.5b) over a fixed set of numbers, twice, and reports stuck-vs-rescued plus a
+correctness check on every completed answer. Nothing is asserted true that wasn't executed.
+
+    python -m python.helm.offload_measure            # default 1.5b over a 9-number spread
+    SCBE_LLM_MODEL=qwen2.5-coder:3b python -m python.helm.offload_measure
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+from python.helm.free_generator import _chat
+from python.scbe.sieve_calc import classify_number_task
+from python.scbe.stepwise import Proposer, run_stepwise
+
+# the numbers the 1.5b reliably trips on: prime-powers (8=2^3, 49=7^2) and the unit (1) are the walls
+DEFAULT_NUMBERS = [1, 2, 6, 8, 12, 13, 30, 49, 91]
+
+
+def model_proposer(base: str, key: str, model: str) -> Proposer:
+    """A proposer backed by a live model: hand it the rebuilt context, take back one legal label."""
+
+    def p(ctx: str, options: List[str]) -> str:
+        prompt = ctx + "\n\nReply with EXACTLY one of these labels and nothing else: " + ", ".join(options)
+        try:
+            reply = _chat([{"role": "user", "content": prompt}], base=base, key=key, model=model)
+        except Exception as exc:  # a dead endpoint must not masquerade as a model failure
+            return "(endpoint-error: %s)" % type(exc).__name__
+        reply = (reply or "").strip().splitlines()[0].strip().strip(".'\"` ")
+        for opt in options:  # tolerate "the answer is composite" -> composite
+            if opt.lower() in reply.lower():
+                return opt
+        return reply  # let an off-menu answer count as a misstep (it is not in options)
+
+    return p
+
+
+def _expected_label(n: int) -> str:
+    from src import numtheory as nt
+
+    if n == 1:
+        return "unit"
+    if nt.is_prime(n):
+        return "prime"
+    return "prime-power" if len(nt.factorization(n)) == 1 else "composite"
+
+
+def measure(numbers: List[int], proposer: Proposer, max_rewinds: int = 3) -> dict:
+    """Run each number twice -- offload off (baseline) then on -- and tally outcomes + correctness."""
+    rows = []
+    base_stuck = rescued = wrong = 0
+    for n in numbers:
+        off = run_stepwise(classify_number_task(n), proposer, max_rewinds=max_rewinds, allow_offload=False)
+        on = run_stepwise(classify_number_task(n), proposer, max_rewinds=max_rewinds, allow_offload=True)
+        exp = _expected_label(n)
+        was_stuck = not off["completed"]
+        got = on.get("answer")
+        offloaded = bool(on.get("offloaded"))
+        correct = on["completed"] and got == exp
+        base_stuck += was_stuck
+        rescued += was_stuck and on["completed"]
+        wrong += on["completed"] and not correct
+        rows.append(
+            {
+                "n": n,
+                "expected": exp,
+                "baseline_stuck": was_stuck,
+                "answer": got,
+                "offloaded": offloaded,
+                "correct": correct,
+            }
+        )
+    return {"rows": rows, "baseline_stuck": base_stuck, "rescued": rescued, "wrong": wrong}
+
+
+def main(argv: object = None) -> int:
+    base = os.environ.get("SCBE_LLM_BASE", "http://localhost:11434/v1")
+    key = os.environ.get("SCBE_LLM_KEY", "ollama")
+    model = os.environ.get("SCBE_LLM_MODEL", "qwen2.5-coder:1.5b")
+    print("OFFLOAD_MEASURE  live model=%s  (baseline=no offload vs. auto-offload)\n" % model)
+
+    res = measure(DEFAULT_NUMBERS, model_proposer(base, key, model))
+    print("  %-4s %-12s %-9s %-12s %-9s %s" % ("n", "expected", "stuck?", "answer", "offload?", "correct?"))
+    for r in res["rows"]:
+        print(
+            "  %-4d %-12s %-9s %-12s %-9s %s"
+            % (
+                r["n"],
+                r["expected"],
+                "STUCK" if r["baseline_stuck"] else "-",
+                r["answer"],
+                "tool" if r["offloaded"] else "-",
+                "ok" if r["correct"] else "WRONG",
+            )
+        )
+    n = len(res["rows"])
+    print("\n  baseline: %d/%d stuck at the model's ceiling (never shipped wrong)" % (res["baseline_stuck"], n))
+    print("  auto-offload: %d of those rescued by the oracle, %d shipped wrong" % (res["rescued"], res["wrong"]))
+    if res["wrong"]:
+        print("  [!] an offloaded answer was WRONG -- the checked-oracle guarantee FAILED, investigate")
+    else:
+        print("  -> every rescue was correct: the harness supplied the capability, never faked it")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/scbe/failure_map.py
+++ b/python/scbe/failure_map.py
@@ -25,8 +25,14 @@ from .stepwise import Proposer, Step, Task, run_stepwise
 
 
 def localize(task: Task, proposer: Proposer, max_rewinds: int = 3) -> Dict[str, Any]:
-    """Run one (task, model) and report the drift point: where it stuck (point F) or that it cleared."""
-    r = run_stepwise(task, proposer, max_rewinds)
+    """Run one (task, model) and report the drift point: where it stuck (point F) or that it cleared.
+
+    Offload is forced OFF here: this measures the MODEL's true ceiling. An oracle would auto-rescue the
+    wall step and report 'cleared', blinding the map to where the model actually drifts. failure_map
+    diagnoses the wall; auto-offload (in run_stepwise) is the cure -- keep them separate or the map goes
+    blind. The recovery this returns is precisely "offload that step", which the harness can now do.
+    """
+    r = run_stepwise(task, proposer, max_rewinds, allow_offload=False)
     names = [s.name for s in task.steps]
     if r["completed"]:
         return {"task": task.name, "cleared": True, "stuck_at": None, "stuck_index": len(names), "total": len(names)}

--- a/python/scbe/sieve_calc.py
+++ b/python/scbe/sieve_calc.py
@@ -73,7 +73,13 @@ def classify_number_task(n: int) -> Task:
             seed_calc("n", n),
             is_prime_calc("is_prime", "n"),
             factor_count_calc("nfac", "n"),
-            Step("label", "label", options=lambda st: list(_LABELS), check=lambda st, v: v == correct(st)),
+            Step(
+                "label",
+                "label",
+                options=lambda st: list(_LABELS),
+                check=lambda st, v: v == correct(st),
+                oracle=correct,  # auto-offload: if the model can't label it, the rule does
+            ),
         ],
     )
 

--- a/python/scbe/stepwise.py
+++ b/python/scbe/stepwise.py
@@ -14,12 +14,15 @@ mistake into the final answer with no chance to recover. This machine removes bo
     the goal + the steps that already ran + what went wrong, and lets the model try again from
     exactly the position before the misstep.
   * AUTO-OFFLOAD ON FAILURE -- a `choice` step may register an `oracle`: a deterministic tool that
-    computes the correct value. When the model burns its rewinds and still can't, the machine does
-    NOT go stuck -- it falls back to the oracle (correct by construction) and continues. This is the
-    measured lift, automated: the harness SUPPLIES the capability the model lacks instead of just
-    surfacing the wall. The honest boundary holds: a step with NO oracle (a genuine judgement the
-    code can't do) still stops honestly. And the oracle's value is itself checked, so even a buggy
-    oracle can never ship a wrong answer -- it falls through to stuck.
+    computes a value. When the model burns its rewinds and still can't, the machine does NOT go
+    stuck -- it falls back to the oracle and continues. This is the measured lift, automated: the
+    harness SUPPLIES the capability the model lacks instead of just surfacing the wall. The honest
+    boundary holds: a step with NO oracle (a genuine judgement the code can't do) still stops
+    honestly. The oracle is held to the SAME gate as the model -- its value must be legal (in the
+    step's options) and pass the step's `check` if one exists; a value that fails the gate is never
+    committed, it falls through to stuck. (Caveat, no overclaim: when the `check` is derived from the
+    same rule as the oracle, that gate is only a legality wall -- not an independent correctness
+    proof. The gate is exactly as strong as the predicates the step supplies, no stronger.)
 
 So the scaffold carries the exactness, the memory, AND a tool fallback; the model supplies judgement,
 its mistakes are caught + rewound, and the steps a tool CAN do are auto-rescued when it can't.
@@ -42,8 +45,8 @@ Proposer = Callable[[str, List[str]], str]
 class Step:
     """One step. A `calc` step is deterministic (code, never the model). A `choice` step asks the
     model for a value, gated by `options` (the legal set / walls) and `check` (is it correct). An
-    optional `oracle` is a deterministic tool that computes the correct value -- the auto-offload
-    fallback used when the model exhausts its rewinds on this step."""
+    optional `oracle` is a deterministic tool that computes a value -- the auto-offload fallback used
+    when the model exhausts its rewinds; its value is held to the same options/check gate as the model."""
 
     name: str
     key: str
@@ -83,9 +86,11 @@ def run_stepwise(task: Task, proposer: Proposer, max_rewinds: int = 3, allow_off
     """Walk the steps. Calc steps run in code; choice steps call the model and rewind on a misstep.
 
     When a choice step exhausts its rewinds: if `allow_offload` and the step has an `oracle`, fall
-    back to the oracle (auto-offload) instead of going stuck -- but only if the oracle's value passes
-    the step's check, so a wrong answer is never shipped. With no oracle (or allow_offload=False) the
-    step stops honestly at the model's ceiling. `allow_offload=False` measures the un-rescued baseline.
+    back to the oracle (auto-offload) instead of going stuck -- but only if the oracle's value clears
+    the SAME gate the model must (legal/in-options, and the step's check if any); otherwise it falls
+    through to stuck, so a gate-failing oracle value is never committed. With no oracle (or
+    allow_offload=False) the step stops honestly at the model's ceiling; `allow_offload=False`
+    measures the un-rescued baseline.
     """
     state: Dict[str, Any] = {}
     trace: List[dict] = []
@@ -123,7 +128,10 @@ def run_stepwise(task: Task, proposer: Proposer, max_rewinds: int = 3, allow_off
                 state.pop("_warning", None)
                 if allow_offload and step.oracle is not None:
                     ov = step.oracle(state)
-                    if step.check is None or step.check(state, ov):  # oracle is checked too: never ship wrong
+                    # hold the oracle to the SAME gate as the model: legal (in options) AND, if the step
+                    # has a check, passing it. A gate-failing oracle value is never committed -> stuck.
+                    legal = (not options) or (ov in options)
+                    if legal and (step.check(state, ov) if step.check else True):
                         state[step.key] = ov
                         offloaded.append(step.name)
                         trace.append({"step": step.name, "source": "offload", "value": ov, "status": "ok"})

--- a/python/scbe/stepwise.py
+++ b/python/scbe/stepwise.py
@@ -12,12 +12,18 @@ mistake into the final answer with no chance to recover. This machine removes bo
     (the walls + a correctness test) accepts or rejects it. A rejected value is a MISSTEP: the
     machine stays put (the bad value is never committed), emits a WARNING, rebuilds the context from
     the goal + the steps that already ran + what went wrong, and lets the model try again from
-    exactly the position before the misstep. After `max_rewinds` it stops honestly at that step --
-    that is the model's real ceiling, surfaced, not a corrupted answer.
+    exactly the position before the misstep.
+  * AUTO-OFFLOAD ON FAILURE -- a `choice` step may register an `oracle`: a deterministic tool that
+    computes the correct value. When the model burns its rewinds and still can't, the machine does
+    NOT go stuck -- it falls back to the oracle (correct by construction) and continues. This is the
+    measured lift, automated: the harness SUPPLIES the capability the model lacks instead of just
+    surfacing the wall. The honest boundary holds: a step with NO oracle (a genuine judgement the
+    code can't do) still stops honestly. And the oracle's value is itself checked, so even a buggy
+    oracle can never ship a wrong answer -- it falls through to stuck.
 
-So the scaffold carries the exactness and the memory; the model only supplies judgement, and its
-mistakes are caught and rewound instead of shipped. Proposers are pluggable callables; the scripted
-stubs prove the loop by construction, and a real model drops into the same slot.
+So the scaffold carries the exactness, the memory, AND a tool fallback; the model supplies judgement,
+its mistakes are caught + rewound, and the steps a tool CAN do are auto-rescued when it can't.
+Proposers are pluggable callables; the scripted stubs prove the loop, a real model drops into the slot.
 
     t = number_label_task(6)                 # r3=6%3, r5=6%5 done by CALC; the label is the choice
     run_stepwise(t, scripted_proposer(["Buzz", "Fizz"]))   # 'Buzz' missteps -> rewind -> 'Fizz' ok
@@ -35,13 +41,16 @@ Proposer = Callable[[str, List[str]], str]
 @dataclass
 class Step:
     """One step. A `calc` step is deterministic (code, never the model). A `choice` step asks the
-    model for a value, gated by `options` (the legal set / walls) and `check` (is it correct)."""
+    model for a value, gated by `options` (the legal set / walls) and `check` (is it correct). An
+    optional `oracle` is a deterministic tool that computes the correct value -- the auto-offload
+    fallback used when the model exhausts its rewinds on this step."""
 
     name: str
     key: str
     calc: Optional[Callable[[Dict[str, Any]], Any]] = None
     options: Optional[Callable[[Dict[str, Any]], List[str]]] = None
     check: Optional[Callable[[Dict[str, Any], str], bool]] = None
+    oracle: Optional[Callable[[Dict[str, Any]], Any]] = None
 
     def is_calc(self) -> bool:
         return self.calc is not None
@@ -70,13 +79,20 @@ def build_context(task: Task, state: Dict[str, Any], step: Step, options: List[s
     return "\n".join(lines)
 
 
-def run_stepwise(task: Task, proposer: Proposer, max_rewinds: int = 3) -> Dict[str, Any]:
-    """Walk the steps. Calc steps run in code; choice steps call the model and rewind on a misstep."""
+def run_stepwise(task: Task, proposer: Proposer, max_rewinds: int = 3, allow_offload: bool = True) -> Dict[str, Any]:
+    """Walk the steps. Calc steps run in code; choice steps call the model and rewind on a misstep.
+
+    When a choice step exhausts its rewinds: if `allow_offload` and the step has an `oracle`, fall
+    back to the oracle (auto-offload) instead of going stuck -- but only if the oracle's value passes
+    the step's check, so a wrong answer is never shipped. With no oracle (or allow_offload=False) the
+    step stops honestly at the model's ceiling. `allow_offload=False` measures the un-rescued baseline.
+    """
     state: Dict[str, Any] = {}
     trace: List[dict] = []
     pos = 0
     total_rewinds = 0
     model_calls = 0
+    offloaded: List[str] = []
     while pos < len(task.steps):
         step = task.steps[pos]
         if step.is_calc():
@@ -103,14 +119,23 @@ def run_stepwise(task: Task, proposer: Proposer, max_rewinds: int = 3) -> Dict[s
             total_rewinds += 1
             why = "not in the allowed set" if not legal else "failed the step's check"
             trace.append({"step": step.name, "source": "model", "value": value, "status": "misstep", "why": why})
-            if rewinds > max_rewinds:  # exhausted -> honest ceiling at this step
+            if rewinds > max_rewinds:  # model exhausted -> try the deterministic oracle, else stop honestly
                 state.pop("_warning", None)
+                if allow_offload and step.oracle is not None:
+                    ov = step.oracle(state)
+                    if step.check is None or step.check(state, ov):  # oracle is checked too: never ship wrong
+                        state[step.key] = ov
+                        offloaded.append(step.name)
+                        trace.append({"step": step.name, "source": "offload", "value": ov, "status": "ok"})
+                        pos += 1
+                        break
                 return {
                     "completed": False,
                     "stuck_at": step.name,
                     "state": state,
                     "rewinds": total_rewinds,
                     "model_calls": model_calls,
+                    "offloaded": offloaded,
                     "trace": trace,
                 }
             # rewind: position is unchanged (the bad value was never committed); retry with a warning
@@ -126,6 +151,7 @@ def run_stepwise(task: Task, proposer: Proposer, max_rewinds: int = 3) -> Dict[s
         "state": state,
         "rewinds": total_rewinds,
         "model_calls": model_calls,
+        "offloaded": offloaded,
         "trace": trace,
     }
 
@@ -181,6 +207,7 @@ def number_label_task(i: int) -> Task:
                 "label",
                 options=lambda st: list(_LABELS) + [str(i)],
                 check=lambda st, v: v == correct_label(st),
+                oracle=correct_label,  # the rule itself: auto-offload fallback when the model can't
             ),
         ],
     )
@@ -203,9 +230,17 @@ def main(argv: Optional[List[str]] = None) -> int:
         print("  %-6s %-6s %-9s %s%s" % (t["step"], t["source"], t["status"], t["value"], extra))
     print("  -> %s   completed=%s  rewinds=%d" % (r["answer"], r["completed"], r["rewinds"]))
 
-    print("\n== stuck: a model that keeps mis-stepping stops honestly at its ceiling ==")
-    r = run_stepwise(number_label_task(6), always_proposer("Buzz"), max_rewinds=2)
-    print("  completed=%s  stuck_at=%s  rewinds=%d" % (r["completed"], r.get("stuck_at"), r["rewinds"]))
+    print("\n== a model that NEVER gets it: without auto-offload it stops honestly ==")
+    r = run_stepwise(number_label_task(6), always_proposer("Buzz"), max_rewinds=2, allow_offload=False)
+    print("  allow_offload=False -> completed=%s  stuck_at=%s" % (r["completed"], r.get("stuck_at")))
+
+    print("\n== same hopeless model, WITH auto-offload: the oracle (the rule) rescues the step ==")
+    r = run_stepwise(number_label_task(6), always_proposer("Buzz"), max_rewinds=2, allow_offload=True)
+    print(
+        "  allow_offload=True  -> completed=%s  answer=%r  offloaded=%s"
+        % (r["completed"], r.get("answer"), r["offloaded"])
+    )
+    print("  (the model burned its tries; the deterministic rule supplied the right label -> 6 is 'Fizz')")
     return 0
 
 

--- a/tests/test_stepwise.py
+++ b/tests/test_stepwise.py
@@ -123,6 +123,33 @@ def test_a_buggy_oracle_never_ships_a_wrong_answer():
     assert "pick" not in r["state"]  # the bad oracle value was never written into state
 
 
+def _check_less_oracle_task(oracle_value):
+    # a step with an oracle but NO check: the only gate is legality (the value must be in options)
+    return Task(
+        name="check_less",
+        goal="pick a legal value; no correctness predicate, just the walls",
+        steps=[Step("pick", "pick", options=lambda st: ["a", "b"], oracle=lambda st: oracle_value)],
+    )
+
+
+def test_check_less_oracle_returning_an_illegal_value_falls_through_to_stuck():
+    # the bug the review caught: a check-less oracle must NOT bypass the legality wall the model obeys.
+    # oracle returns 'z' (not in options) -> it is rejected, never committed, step stops honestly.
+    r = run_stepwise(_check_less_oracle_task("z"), always_proposer("z"), max_rewinds=1, allow_offload=True)
+    assert r["completed"] is False
+    assert r["stuck_at"] == "pick"
+    assert r["offloaded"] == []
+    assert "pick" not in r["state"]  # the illegal oracle value was never written into state
+
+
+def test_check_less_oracle_returning_a_legal_value_is_committed():
+    # the legitimate use: a check-less oracle that returns an in-options value rescues the step
+    r = run_stepwise(_check_less_oracle_task("a"), always_proposer("z"), max_rewinds=1, allow_offload=True)
+    assert r["completed"] is True
+    assert r["answer"] == "a"
+    assert r["offloaded"] == ["pick"]
+
+
 def _no_oracle_task():
     # a genuine judgement the code can't do: a choice step with NO oracle registered
     return Task(

--- a/tests/test_stepwise.py
+++ b/tests/test_stepwise.py
@@ -13,6 +13,8 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from python.scbe.stepwise import (  # noqa: E402
+    Step,
+    Task,
     always_proposer,
     number_label_task,
     run_stepwise,
@@ -39,8 +41,9 @@ def test_a_misstep_rewinds_and_recovers():
 
 
 def test_exhausted_rewinds_stops_honestly_at_the_step():
-    # a model that always mis-steps does not corrupt the answer -- it stops at its ceiling
-    r = run_stepwise(number_label_task(6), always_proposer("Buzz"), max_rewinds=2)
+    # a model that always mis-steps does not corrupt the answer -- it stops at its ceiling.
+    # allow_offload=False isolates the pure rewind-exhaustion path (the oracle rescue is tested separately).
+    r = run_stepwise(number_label_task(6), always_proposer("Buzz"), max_rewinds=2, allow_offload=False)
     assert r["completed"] is False
     assert r["stuck_at"] == "label"
     assert r["rewinds"] == 3  # max_rewinds=2 -> a third misstep ends it
@@ -65,3 +68,73 @@ def test_offloaded_modulo_makes_the_correct_label_pass_for_any_i():
     for i, label in [(3, "Fizz"), (5, "Buzz"), (15, "FizzBuzz"), (7, "7")]:
         r = run_stepwise(number_label_task(i), scripted_proposer([label]))
         assert r["completed"] is True and r["answer"] == label
+
+
+# --- auto-offload: when the model exhausts its rewinds, a deterministic oracle rescues the step ---
+
+
+def test_auto_offload_rescues_a_step_the_model_never_gets():
+    # a hopeless model (always 'Buzz', wrong for 6) burns its rewinds; the oracle supplies 'Fizz'
+    r = run_stepwise(number_label_task(6), always_proposer("Buzz"), max_rewinds=2, allow_offload=True)
+    assert r["completed"] is True
+    assert r["answer"] == "Fizz"  # the rule, not the model, produced it
+    assert r["offloaded"] == ["label"]
+    assert r["trace"][-1]["source"] == "offload"  # the final value came from the tool, recorded as such
+
+
+def test_allow_offload_false_preserves_the_un_rescued_baseline():
+    # the same hopeless model, offload disabled -> still stops honestly (this is the measured baseline)
+    r = run_stepwise(number_label_task(6), always_proposer("Buzz"), max_rewinds=2, allow_offload=False)
+    assert r["completed"] is False
+    assert r["stuck_at"] == "label"
+    assert r["offloaded"] == []
+
+
+def test_offload_only_fires_on_failure_not_when_the_model_succeeds():
+    # a model that gets it first try never invokes the oracle -- offload is a fallback, not a shortcut
+    r = run_stepwise(number_label_task(6), scripted_proposer(["Fizz"]), allow_offload=True)
+    assert r["completed"] is True and r["answer"] == "Fizz"
+    assert r["offloaded"] == []  # the tool stayed holstered; the model did the work
+
+
+def _buggy_oracle_task():
+    # one choice step: model can't pick the secret, and the oracle is WRONG (returns 'b', check wants 'a')
+    return Task(
+        name="buggy_oracle",
+        goal="pick the secret value",
+        steps=[
+            Step(
+                "pick",
+                "pick",
+                options=lambda st: ["a", "b"],
+                check=lambda st, v: v == "a",
+                oracle=lambda st: "b",  # a buggy tool: returns a value that fails the check
+            )
+        ],
+    )
+
+
+def test_a_buggy_oracle_never_ships_a_wrong_answer():
+    # the oracle's value is itself checked; a wrong oracle falls through to stuck, it does NOT commit
+    r = run_stepwise(_buggy_oracle_task(), always_proposer("b"), max_rewinds=1, allow_offload=True)
+    assert r["completed"] is False  # would have been True if we trusted the oracle blindly
+    assert r["stuck_at"] == "pick"
+    assert r["offloaded"] == []
+    assert "pick" not in r["state"]  # the bad oracle value was never written into state
+
+
+def _no_oracle_task():
+    # a genuine judgement the code can't do: a choice step with NO oracle registered
+    return Task(
+        name="no_oracle",
+        goal="make a judgement only a model can",
+        steps=[Step("judge", "judge", options=lambda st: ["x", "y"], check=lambda st, v: v == "x")],
+    )
+
+
+def test_a_step_with_no_oracle_still_stops_honestly():
+    # the honest boundary: no tool can supply this, so even with offload on, a hopeless model stops
+    r = run_stepwise(_no_oracle_task(), always_proposer("y"), max_rewinds=1, allow_offload=True)
+    assert r["completed"] is False
+    assert r["stuck_at"] == "judge"
+    assert r["offloaded"] == []

--- a/tests/test_toolkit_map.py
+++ b/tests/test_toolkit_map.py
@@ -111,14 +111,34 @@ def test_a_model_can_walk_the_whole_map():
     assert w["cleared"] == 13 and w["sealed"] is True  # the map cleared + sealed the whole tour
 
 
-def test_run_with_drifted_stepwise_diagnoses_and_localizes_live():
+def test_run_self_heals_an_oracle_task_via_auto_offload():
+    # classify has an oracle, so a hopeless model no longer drifts THROUGH the map -- it self-heals:
+    # run_stepwise auto-offloads the wall step and the call completes, so there is nothing to diagnose.
     from python.scbe.sieve_calc import classify_number_task
     from python.scbe.stepwise import scripted_proposer
 
     m = TaskMap()
-    out = m.run("run_stepwise", classify_number_task(91), scripted_proposer(["prime", "prime", "prime", "prime"]))
+    out = m.run("run_stepwise", classify_number_task(91), scripted_proposer(["prime"]))
+    assert out["decision"] == "ALLOWED"
+    assert "diagnosis" not in out  # the harness supplied the capability; no drift surfaced
+    assert "drift" not in out
+    assert out["chain_ok"] is True
+
+
+def test_run_diagnoses_and_localizes_an_unrescuable_drift():
+    # a step with NO oracle is the honest boundary: it genuinely drifts, so run() diagnoses + localizes.
+    from python.scbe.stepwise import Step, Task, scripted_proposer
+
+    # one choice step named 'label' the model can never satisfy and the harness cannot offload (no oracle)
+    task = Task(
+        name="judge_label",
+        goal="a judgement only a model can make",
+        steps=[Step("label", "label", options=lambda st: ["composite", "prime"], check=lambda st, v: v == "composite")],
+    )
+    m = TaskMap()
+    out = m.run("run_stepwise", task, scripted_proposer(["prime"]))
     assert out["decision"] == "ALLOWED"  # the tool call itself succeeded; the RESULT drifted
     assert out["diagnosis"]["cause"] == "step_drift" and out["diagnosis"]["retry_safe"] is False
     assert out["chain_ok"] is True
-    # the LIVE run() path actually ran failure_map.localize -> the wall step
+    # the LIVE run() path actually ran failure_map.localize -> the wall step + an offload recommendation
     assert out["drift"]["drift"]["stuck_at"] == "label" and "offload" in out["drift"]["recovery"]


### PR DESCRIPTION
Follow-up to #2461 (auto-offload). An adversarial multi-agent review of that change confirmed **3 real defects** — the "never ship wrong" guarantee was weaker and more circular than the docstrings claimed. This closes all three.

## 1. Check-less oracle bypassed every gate (high)
`run_stepwise`'s offload commit condition was `if step.check is None or step.check(state, ov):`. When a step registered an `oracle` but **no** `check`, the `is None` branch short-circuited and committed the oracle value with **zero** verification — even skipping the legality (`in options`) wall the model path enforces.

**Fix:** the oracle is now held to the **same gate as the model** — `legal AND (check if one exists)`. A gate-failing oracle value falls through to stuck, never commits.

## 2. Tautological correctness check (high)
`offload_measure._expected_label` re-derived the **same** classification rule as the oracle from the **same** `numtheory` primitives, so `got == expected` was True by construction — the `wrong` counter was structurally pinned to 0 and could never catch a wrong oracle.

**Fix:** replaced with `GROUND_TRUTH`, a hand-verified label table **independent of the sieve**. A bug in the rule now surfaces as a mismatch. Numbers with no entry are reported `unverified`, never counted correct.

## 3. Overclaim (high)
`"every rescue was correct … never faked it"` asserted a property the measurement couldn't establish.

**Fix:** reworded so the **measured** quantity is the stuck→rescued lift; correctness is a **separate independent** cross-check against the hand table. Docstrings no longer claim an absolute correctness guarantee — the gate is exactly as strong as the step's own predicates, no stronger.

## Tests + measurement
- New: a check-less oracle returning an *illegal* value falls through to stuck (never commits); a check-less oracle returning a *legal* value is committed.
- 30/30 stepwise+sieve+map tests pass; lint clean.
- Live `qwen2.5-coder:1.5b` re-measure: **7/9 stuck → 7 rescued, 0 wrong** vs independent ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)