### PR TITLE
fix(stepwise): close 3 defects from adversarial review of auto-offload

### DIFF
--- a/python/helm/offload_measure.py
+++ b/python/helm/offload_measure.py
@@ -1,16 +1,19 @@
 """offload_measure: measure the auto-offload lift on a LIVE weak model.
 
-The claim under test is narrow and honest: when a step has a deterministic `oracle`, the harness can
-SUPPLY the capability the model lacks instead of merely stopping at its ceiling. So the same model on
-the same task should go from "some numbers stuck, never wrong" (allow_offload=False) to "nothing
-stuck, still never wrong" (allow_offload=True) -- and the rescued answers must be CORRECT, because
-the oracle's value is itself checked before it is committed.
+The MEASURED quantity is narrow and honest: the RESCUE rate. The same model on the same task goes
+from "some numbers stuck at its ceiling" (allow_offload=False) to "those numbers completed via the
+oracle" (allow_offload=True). That stuck->rescued delta is the lift, and it is genuinely measured --
+the model really proposes, really exhausts its rewinds, and the oracle really takes over.
 
-This is a measurement, not a demo: it runs the real local model as the proposer (Ollama by default,
-qwen2.5-coder:1.5b) over a fixed set of numbers, twice, and reports stuck-vs-rescued plus a
-correctness check on every completed answer. Nothing is asserted true that wasn't executed.
+Correctness is a SEPARATE, INDEPENDENT cross-check -- NOT a re-run of the oracle's own rule. Each
+completed answer is compared against GROUND_TRUTH, a small hand-verified label table (independent of
+the sieve), so a bug in the classification rule WOULD surface here as a mismatch instead of hiding
+behind a copy of itself. Honesty boundary: the in-harness check that gates the oracle (stepwise) is,
+for this task, derived from the same rule as the oracle -- so it is a legality wall, not an
+independent correctness proof; that is exactly why this measurement carries its OWN external ground
+truth. Numbers with no ground-truth entry are reported as "unverified", never counted as correct.
 
-    python -m python.helm.offload_measure            # default 1.5b over a 9-number spread
+    python -m python.helm.offload_measure            # default 1.5b over the 9-number ground-truth set
     SCBE_LLM_MODEL=qwen2.5-coder:3b python -m python.helm.offload_measure
 """
 
@@ -25,6 +28,20 @@ from python.scbe.stepwise import Proposer, run_stepwise
 
 # the numbers the 1.5b reliably trips on: prime-powers (8=2^3, 49=7^2) and the unit (1) are the walls
 DEFAULT_NUMBERS = [1, 2, 6, 8, 12, 13, 30, 49, 91]
+
+# INDEPENDENT ground truth: labels verified BY HAND (not re-derived from the sieve), so a bug in the
+# classification rule shows up here as a mismatch instead of hiding behind a copy of itself.
+GROUND_TRUTH = {
+    1: "unit",
+    2: "prime",
+    6: "composite",  # 2*3
+    8: "prime-power",  # 2^3
+    12: "composite",  # 2^2*3
+    13: "prime",
+    30: "composite",  # 2*3*5
+    49: "prime-power",  # 7^2
+    91: "composite",  # 7*13
+}
 
 
 def model_proposer(base: str, key: str, model: str) -> Proposer:
@@ -45,31 +62,25 @@ def model_proposer(base: str, key: str, model: str) -> Proposer:
     return p
 
 
-def _expected_label(n: int) -> str:
-    from src import numtheory as nt
-
-    if n == 1:
-        return "unit"
-    if nt.is_prime(n):
-        return "prime"
-    return "prime-power" if len(nt.factorization(n)) == 1 else "composite"
-
-
-def measure(numbers: List[int], proposer: Proposer, max_rewinds: int = 3) -> dict:
-    """Run each number twice -- offload off (baseline) then on -- and tally outcomes + correctness."""
+def measure(numbers: List[int], proposer: Proposer, ground_truth: dict = None, max_rewinds: int = 3) -> dict:
+    """Run each number twice -- offload off (baseline) then on -- tally stuck/rescued, then cross-check
+    each COMPLETED answer against the INDEPENDENT ground-truth table (a hand-verified label, not the
+    oracle's own rule). A number with no ground-truth entry is 'unverified', never counted correct."""
+    truth = GROUND_TRUTH if ground_truth is None else ground_truth
     rows = []
-    base_stuck = rescued = wrong = 0
+    base_stuck = rescued = wrong = unverified = 0
     for n in numbers:
         off = run_stepwise(classify_number_task(n), proposer, max_rewinds=max_rewinds, allow_offload=False)
         on = run_stepwise(classify_number_task(n), proposer, max_rewinds=max_rewinds, allow_offload=True)
-        exp = _expected_label(n)
         was_stuck = not off["completed"]
         got = on.get("answer")
         offloaded = bool(on.get("offloaded"))
-        correct = on["completed"] and got == exp
+        exp = truth.get(n)  # independent ground truth, or None if this number cannot be verified
+        correct = (got == exp) if (on["completed"] and exp is not None) else None
         base_stuck += was_stuck
-        rescued += was_stuck and on["completed"]
-        wrong += on["completed"] and not correct
+        rescued += bool(was_stuck and on["completed"])
+        wrong += int(correct is False)
+        unverified += int(on["completed"] and exp is None)
         rows.append(
             {
                 "n": n,
@@ -80,7 +91,13 @@ def measure(numbers: List[int], proposer: Proposer, max_rewinds: int = 3) -> dic
                 "correct": correct,
             }
         )
-    return {"rows": rows, "baseline_stuck": base_stuck, "rescued": rescued, "wrong": wrong}
+    return {
+        "rows": rows,
+        "baseline_stuck": base_stuck,
+        "rescued": rescued,
+        "wrong": wrong,
+        "unverified": unverified,
+    }
 
 
 def main(argv: object = None) -> int:
@@ -90,26 +107,36 @@ def main(argv: object = None) -> int:
     print("OFFLOAD_MEASURE  live model=%s  (baseline=no offload vs. auto-offload)\n" % model)
 
     res = measure(DEFAULT_NUMBERS, model_proposer(base, key, model))
-    print("  %-4s %-12s %-9s %-12s %-9s %s" % ("n", "expected", "stuck?", "answer", "offload?", "correct?"))
+    print("  %-4s %-12s %-9s %-12s %-9s %s" % ("n", "truth", "stuck?", "answer", "offload?", "vs truth"))
     for r in res["rows"]:
+        if r["correct"] is None:
+            verdict = "unverified" if r["answer"] is not None else "stuck"
+        else:
+            verdict = "ok" if r["correct"] else "WRONG"
         print(
             "  %-4d %-12s %-9s %-12s %-9s %s"
             % (
                 r["n"],
-                r["expected"],
+                r["expected"] or "-",
                 "STUCK" if r["baseline_stuck"] else "-",
                 r["answer"],
                 "tool" if r["offloaded"] else "-",
-                "ok" if r["correct"] else "WRONG",
+                verdict,
             )
         )
     n = len(res["rows"])
-    print("\n  baseline: %d/%d stuck at the model's ceiling (never shipped wrong)" % (res["baseline_stuck"], n))
-    print("  auto-offload: %d of those rescued by the oracle, %d shipped wrong" % (res["rescued"], res["wrong"]))
+    print(
+        "\n  MEASURED lift: %d/%d stuck at the model's ceiling (offload off) -> %d rescued by the oracle (offload on)"
+        % (res["baseline_stuck"], n, res["rescued"])
+    )
+    print(
+        "  INDEPENDENT cross-check vs hand-verified ground truth: %d wrong, %d unverified"
+        % (res["wrong"], res["unverified"])
+    )
     if res["wrong"]:
-        print("  [!] an offloaded answer was WRONG -- the checked-oracle guarantee FAILED, investigate")
+        print("  [!] a completed answer disagreed with ground truth -- the classification rule is wrong, investigate")
     else:
-        print("  -> every rescue was correct: the harness supplied the capability, never faked it")
+        print("  -> the stuck->rescued lift is real, and every verifiable answer matched independent ground truth")
     return 0
 
 

--- a/python/scbe/stepwise.py
+++ b/python/scbe/stepwise.py
@@ -14,12 +14,15 @@ mistake into the final answer with no chance to recover. This machine removes bo
     the goal + the steps that already ran + what went wrong, and lets the model try again from
     exactly the position before the misstep.
   * AUTO-OFFLOAD ON FAILURE -- a `choice` step may register an `oracle`: a deterministic tool that
-    computes the correct value. When the model burns its rewinds and still can't, the machine does
-    NOT go stuck -- it falls back to the oracle (correct by construction) and continues. This is the
-    measured lift, automated: the harness SUPPLIES the capability the model lacks instead of just
-    surfacing the wall. The honest boundary holds: a step with NO oracle (a genuine judgement the
-    code can't do) still stops honestly. And the oracle's value is itself checked, so even a buggy
-    oracle can never ship a wrong answer -- it falls through to stuck.
+    computes a value. When the model burns its rewinds and still can't, the machine does NOT go
+    stuck -- it falls back to the oracle and continues. This is the measured lift, automated: the
+    harness SUPPLIES the capability the model lacks instead of just surfacing the wall. The honest
+    boundary holds: a step with NO oracle (a genuine judgement the code can't do) still stops
+    honestly. The oracle is held to the SAME gate as the model -- its value must be legal (in the
+    step's options) and pass the step's `check` if one exists; a value that fails the gate is never
+    committed, it falls through to stuck. (Caveat, no overclaim: when the `check` is derived from the
+    same rule as the oracle, that gate is only a legality wall -- not an independent correctness
+    proof. The gate is exactly as strong as the predicates the step supplies, no stronger.)
 
 So the scaffold carries the exactness, the memory, AND a tool fallback; the model supplies judgement,
 its mistakes are caught + rewound, and the steps a tool CAN do are auto-rescued when it can't.
@@ -42,8 +45,8 @@ Proposer = Callable[[str, List[str]], str]
 class Step:
     """One step. A `calc` step is deterministic (code, never the model). A `choice` step asks the
     model for a value, gated by `options` (the legal set / walls) and `check` (is it correct). An
-    optional `oracle` is a deterministic tool that computes the correct value -- the auto-offload
-    fallback used when the model exhausts its rewinds on this step."""
+    optional `oracle` is a deterministic tool that computes a value -- the auto-offload fallback used
+    when the model exhausts its rewinds; its value is held to the same options/check gate as the model."""
 
     name: str
     key: str
@@ -83,9 +86,11 @@ def run_stepwise(task: Task, proposer: Proposer, max_rewinds: int = 3, allow_off
     """Walk the steps. Calc steps run in code; choice steps call the model and rewind on a misstep.
 
     When a choice step exhausts its rewinds: if `allow_offload` and the step has an `oracle`, fall
-    back to the oracle (auto-offload) instead of going stuck -- but only if the oracle's value passes
-    the step's check, so a wrong answer is never shipped. With no oracle (or allow_offload=False) the
-    step stops honestly at the model's ceiling. `allow_offload=False` measures the un-rescued baseline.
+    back to the oracle (auto-offload) instead of going stuck -- but only if the oracle's value clears
+    the SAME gate the model must (legal/in-options, and the step's check if any); otherwise it falls
+    through to stuck, so a gate-failing oracle value is never committed. With no oracle (or
+    allow_offload=False) the step stops honestly at the model's ceiling; `allow_offload=False`
+    measures the un-rescued baseline.
     """
     state: Dict[str, Any] = {}
     trace: List[dict] = []
@@ -123,7 +128,10 @@ def run_stepwise(task: Task, proposer: Proposer, max_rewinds: int = 3, allow_off
                 state.pop("_warning", None)
                 if allow_offload and step.oracle is not None:
                     ov = step.oracle(state)
-                    if step.check is None or step.check(state, ov):  # oracle is checked too: never ship wrong
+                    # hold the oracle to the SAME gate as the model: legal (in options) AND, if the step
+                    # has a check, passing it. A gate-failing oracle value is never committed -> stuck.
+                    legal = (not options) or (ov in options)
+                    if legal and (step.check(state, ov) if step.check else True):
                         state[step.key] = ov
                         offloaded.append(step.name)
                         trace.append({"step": step.name, "source": "offload", "value": ov, "status": "ok"})

--- a/tests/test_stepwise.py
+++ b/tests/test_stepwise.py
@@ -123,6 +123,33 @@ def test_a_buggy_oracle_never_ships_a_wrong_answer():
     assert "pick" not in r["state"]  # the bad oracle value was never written into state
 
 
+def _check_less_oracle_task(oracle_value):
+    # a step with an oracle but NO check: the only gate is legality (the value must be in options)
+    return Task(
+        name="check_less",
+        goal="pick a legal value; no correctness predicate, just the walls",
+        steps=[Step("pick", "pick", options=lambda st: ["a", "b"], oracle=lambda st: oracle_value)],
+    )
+
+
+def test_check_less_oracle_returning_an_illegal_value_falls_through_to_stuck():
+    # the bug the review caught: a check-less oracle must NOT bypass the legality wall the model obeys.
+    # oracle returns 'z' (not in options) -> it is rejected, never committed, step stops honestly.
+    r = run_stepwise(_check_less_oracle_task("z"), always_proposer("z"), max_rewinds=1, allow_offload=True)
+    assert r["completed"] is False
+    assert r["stuck_at"] == "pick"
+    assert r["offloaded"] == []
+    assert "pick" not in r["state"]  # the illegal oracle value was never written into state
+
+
+def test_check_less_oracle_returning_a_legal_value_is_committed():
+    # the legitimate use: a check-less oracle that returns an in-options value rescues the step
+    r = run_stepwise(_check_less_oracle_task("a"), always_proposer("z"), max_rewinds=1, allow_offload=True)
+    assert r["completed"] is True
+    assert r["answer"] == "a"
+    assert r["offloaded"] == ["pick"]
+
+
 def _no_oracle_task():
     # a genuine judgement the code can't do: a choice step with NO oracle registered
     return Task(


### PR DESCRIPTION
Follow-up to #2461 (auto-offload). An adversarial multi-agent review confirmed **3 real defects** — the "never ship wrong" guarantee was weaker and more circular than the docstrings claimed. This closes all three. (Reopened from #2462, which conflicted because it re-introduced the already-squash-merged feature commit; this branch is a clean rebase onto current main with only the fix delta.)

## 1. Check-less oracle bypassed every gate (high)
`run_stepwise`'s offload commit was `if step.check is None or step.check(state, ov):`. A step with an `oracle` but **no** `check` short-circuited and committed the oracle value with **zero** verification — even skipping the legality (`in options`) wall the model path enforces.
**Fix:** oracle held to the **same gate as the model** — `legal AND (check if one exists)`. A gate-failing value falls through to stuck.

## 2. Tautological correctness check (high)
`offload_measure._expected_label` re-derived the **same** rule as the oracle from the **same** primitives, so `got == expected` was True by construction — the `wrong` counter could never catch a wrong oracle.
**Fix:** replaced with `GROUND_TRUTH`, a hand-verified table **independent of the sieve**; numbers with no entry are `unverified`, never counted correct.

## 3. Overclaim (high)
`"every rescue was correct … never faked it"` asserted what the measurement can't establish.
**Fix:** reworded — the **measured** quantity is the stuck→rescued lift; correctness is a **separate independent** cross-check. Docstrings no longer claim an absolute correctness guarantee.

## Tests + measurement
- New: check-less oracle returning an *illegal* value → stuck (never commits); returning a *legal* value → committed.
- 35/35 stepwise+sieve+map+failure_map tests pass; lint clean.
- Live `qwen2.5-coder:1.5b`: **7/9 stuck → 7 rescued, 0 wrong** vs independent ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)