### PR TITLE
fix(ci): prevent workflow_dispatch injection in agent-bus publish workflow

### DIFF
--- a/.github/workflows/npm-publish-agent-bus.yml
+++ b/.github/workflows/npm-publish-agent-bus.yml
@@ -37,12 +37,18 @@ jobs:
         run: npm run build
 
       - name: Verify version
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
         run: |
           PKG_VER=$(node -p "require('./package.json').version")
           if [ "${{ github.event_name }}" = "push" ]; then
             TAG="${GITHUB_REF#refs/tags/agent-bus/v}"
           else
-            TAG="${{ inputs.version }}"
+            TAG="${DISPATCH_VERSION}"
+          fi
+          if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version format: $TAG"
+            exit 1
           fi
           if [ "$PKG_VER" != "$TAG" ]; then
             echo "::error::package.json version ($PKG_VER) does not match expected ($TAG)"


### PR DESCRIPTION
### Motivation
- The manual `workflow_dispatch` `version` input was interpolated directly into a shell assignment in the publish workflow, allowing shell command substitution to run before `npm publish` and potentially exposing the `NPM_TOKEN` via modified lifecycle scripts.
- The change aims to eliminate that command-injection vector while keeping the publish verification logic intact.

### Description
- Stop embedding `${{ inputs.version }}` directly into the shell script by exporting it into the step environment as `DISPATCH_VERSION` and reading that variable inside the script.
- Add a strict version-format check using a regex to reject malformed or malicious values before proceeding.
- Keep existing behavior for push-tag extraction and the `package.json` vs tag equality comparison.
- The only modified file is `.github/workflows/npm-publish-agent-bus.yml`.

### Testing
- No automated unit or integration tests were added or modified for this change.
- Validated the workflow update by inspecting the YAML and confirming the input is no longer directly interpolated and that the version validation logic is present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11a96fb94883228d411df8fea361f0)