### PR TITLE
fix(ci): prevent workflow_dispatch version injection in CLI publish

### DIFF
--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -34,12 +34,18 @@ jobs:
         run: npm ci || npm install
 
       - name: Verify version
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
         run: |
           PKG_VER=$(node -p "require('./package.json').version")
           if [ "${{ github.event_name }}" = "push" ]; then
             TAG="${GITHUB_REF#refs/tags/cli/v}"
           else
-            TAG="${{ inputs.version }}"
+            TAG="$DISPATCH_VERSION"
+          fi
+          if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::invalid version format ($TAG)"
+            exit 1
           fi
           if [ "$PKG_VER" != "$TAG" ]; then
             echo "::error::package.json version ($PKG_VER) does not match expected ($TAG)"


### PR DESCRIPTION
### Motivation
- The `workflow_dispatch` input `version` was previously interpolated directly into a shell script, allowing crafted inputs to inject shell commands and modify the workspace before a privileged `npm publish` step.
- Harden the publish workflow to eliminate command-injection risk while preserving the intended version check behavior.

### Description
- Read the manual dispatch `inputs.version` into an environment variable `DISPATCH_VERSION` instead of embedding `${{ inputs.version }}` directly inside the shell script.
- Use `TAG="$DISPATCH_VERSION"` in the `Verify version` step so the dispatch value is not executed as shell code.
- Add strict version-format validation with the regex `^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$` and fail early on invalid inputs.

### Testing
- Reviewed the updated workflow file with `sed -n '1,140p' .github/workflows/npm-publish-cli.yml` and `nl -ba .github/workflows/npm-publish-cli.yml | sed -n '28,80p'` to confirm the `DISPATCH_VERSION` env and validation were added and the interpolation removed, and both inspections succeeded.
- Committed the change with `git commit` and verified the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11adaeb2bc832284c9b09b4f5cc931)