### PR TITLE
fix(agent-bus): enforce GeoSeal DENY decisions in governance-gate plugin

### DIFF
--- a/packages/agent-bus/bin/scbe-agent-bus.cjs
+++ b/packages/agent-bus/bin/scbe-agent-bus.cjs
@@ -615,10 +615,14 @@ async function main() {
       if (flags.json) {
         process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
       } else if (payload.length === 0) {
-        process.stdout.write('No tools registered. Set SCBE_BUS_TOOLS=./tools.json to load tools.\n');
+        process.stdout.write(
+          'No tools registered. Set SCBE_BUS_TOOLS=./tools.json to load tools.\n'
+        );
       } else {
         for (const t of payload) {
-          process.stdout.write(`  ${t.name}  ${t.command} ${t.args.join(' ')}${t.description ? `  — ${t.description}` : ''}\n`);
+          process.stdout.write(
+            `  ${t.name}  ${t.command} ${t.args.join(' ')}${t.description ? `  — ${t.description}` : ''}\n`
+          );
         }
       }
       return;

--- a/packages/agent-bus/package-lock.json
+++ b/packages/agent-bus/package-lock.json
@@ -189,9 +189,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -209,9 +206,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -229,9 +223,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -249,9 +240,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -269,9 +257,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -289,9 +274,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,9 +1057,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1099,9 +1078,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1123,9 +1099,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1147,9 +1120,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/packages/agent-bus/plugins/governance-gate.cjs
+++ b/packages/agent-bus/plugins/governance-gate.cjs
@@ -55,8 +55,9 @@ const plugin = {
       { encoding: 'utf-8', cwd: repoRoot, timeout: 8000 }
     );
 
-    // Fail open — legitimacy tool may not be configured in all envs
-    if (r.status !== 0 || !r.stdout) {
+    // Fail open only when legitimacy output is unavailable.
+    // GeoSeal may intentionally return non-zero for policy outcomes.
+    if (!r.stdout) {
       return event;
     }
 
@@ -67,9 +68,12 @@ const plugin = {
       return event; // unparseable → fail open
     }
 
-    if (judgment && judgment.decision === 'DENY') {
+    const decision = judgment?.decision?.decision || judgment?.decision;
+    const reason = judgment?.decision?.reason || judgment?.reason;
+
+    if (decision === 'DENY') {
       process.stderr.write(
-        `[governance-gate] DENY run=${ctx.runId.slice(0, 8)} reason="${judgment.reason || 'legitimacy-trial blocked'}"\n`
+        `[governance-gate] DENY run=${ctx.runId.slice(0, 8)} reason="${reason || 'legitimacy-trial blocked'}"\n`
       );
       return null; // block the event
     }

--- a/packages/agent-bus/tests/governance-gate.test.ts
+++ b/packages/agent-bus/tests/governance-gate.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const childProcess = require('node:child_process');
+const pluginPath = require.resolve('../plugins/governance-gate.cjs');
+
+function loadPlugin() {
+  delete require.cache[pluginPath];
+  return require(pluginPath).plugin;
+}
+
+describe('governance-gate plugin', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('blocks event when GeoSeal returns nested DENY decision on non-zero exit', async () => {
+    vi.spyOn(childProcess, 'spawnSync').mockReturnValue({
+      status: 3,
+      stdout: JSON.stringify({ decision: { decision: 'DENY', reason: 'blocked by policy' } }),
+    });
+
+    const plugin = loadPlugin();
+    const result = await plugin.beforeRun({
+      event: { task: 'x', privacy: 'hosted', taskType: 'operation' },
+      runId: '12345678abcdefgh',
+      startedAt: new Date().toISOString(),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('fails open when legitimacy output is unavailable', async () => {
+    vi.spyOn(childProcess, 'spawnSync').mockReturnValue({ status: 1, stdout: '' });
+
+    const plugin = loadPlugin();
+    const event = { task: 'x', privacy: 'hosted', taskType: 'operation' };
+    const result = await plugin.beforeRun({
+      event,
+      runId: '12345678abcdefgh',
+      startedAt: new Date().toISOString(),
+    });
+
+    expect(result).toEqual(event);
+  });
+});


### PR DESCRIPTION
### Motivation
- The governance gate plugin incorrectly treated any non-zero exit from GeoSeal as tool unavailability and failed open, allowing DENY/ESCALATE/PROBE_ONLY outcomes to execute. 
- GeoSeal returns JSON on non-zero exits and nests the decision under `decision.decision`, so the plugin must parse stdout and inspect the nested field to enforce DENY.

### Description
- Update `packages/agent-bus/plugins/governance-gate.cjs` so the plugin only fails open when there is no `stdout`, parses GeoSeal JSON even on non-zero exit, and reads `judgment.decision.decision` (falling back to `judgment.decision`) to detect `DENY` and return `null` to block the event. 
- Preserve the existing low-risk fast-path (local/general events) and the `afterRun` audit logging. 
- Add `packages/agent-bus/tests/governance-gate.test.ts` with targeted mocks to verify that a nested `DENY` blocks the event and that absent stdout still fails open. 
- Commit message follows Conventional Commits: `fix(agent-bus): enforce governance deny decisions from geoseal`.

### Testing
- Ran package-level unit tests: `cd packages/agent-bus && npm test -- tests/governance-gate.test.ts` and the new governance-gate tests passed (2/2 tests). 
- Attempted root-level test invocation `npm test -- packages/agent-bus/tests/governance-gate.test.ts`, which reported no test files found due to the root Vitest include/exclude patterns; this is a discovery issue and does not indicate the package tests failing. 
- The change is minimal and covered by the added deterministic unit tests that simulate GeoSeal `stdout` and exit codes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b16327848322b780dfcf4661414b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated governance gate plugin's fail-open logic to trigger only when legitimacy output is unavailable, instead of on any non-zero exit status.

* **Tests**
  * Added test suite for governance gate plugin with behavioral validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->