### PR TITLE
fix(cli): sanitize :read range in tool translation

### DIFF
--- a/packages/cli/bin/scbe.js
+++ b/packages/cli/bin/scbe.js
@@ -933,6 +933,16 @@ const _AGENT_JSON_SYSTEM_PROMPT = [
 ].join('\n');
 
 function translateToolCommand(cmd) {
+  const parseReadRange = (rawRange) => {
+    const [rawStart = '1', rawEnd = '50'] = String(rawRange || '1:50').split(':', 2);
+    const startNum = Number.parseInt(rawStart, 10);
+    const endNum = Number.parseInt(rawEnd, 10);
+    const start = Number.isInteger(startNum) && startNum > 0 ? startNum : 1;
+    const endCandidate = Number.isInteger(endNum) && endNum > 0 ? endNum : 50;
+    const end = endCandidate >= start ? endCandidate : start;
+    return { start, end };
+  };
+
   const trimmed = cmd.trim();
   if (!trimmed.startsWith(':')) return null;
   const space = trimmed.indexOf(' ');
@@ -945,8 +955,8 @@ function translateToolCommand(cmd) {
   if (tool === 'read') {
     const parts = args.split(/\s+/);
     const fp = (parts[0] || 'README.md').replace(/'/g, "'\\''");
-    const range = (parts[1] || '1:50').split(':');
-    return `sed -n '${range[0] || 1},${range[1] || 50}p' '${fp}'`;
+    const { start, end } = parseReadRange(parts[1]);
+    return `sed -n '${start},${end}p' '${fp}'`;
   }
   if (tool === 'test') {
     return `${args} && echo SCBE_TEST_PASS || echo SCBE_TEST_FAIL`;


### PR DESCRIPTION
### Motivation
- The `:read` built-in previously interpolated the `<start>:<end>` range directly into a single-quoted `sed` expression, allowing an attacker-controlled model output to break the quoting and inject shell commands. 
- The change hardens tool translation so the range cannot be used to perform quote-breaking command injection while preserving the intended read behavior.

### Description
- Added a `parseReadRange` helper inside `translateToolCommand` that parses the `start:end` components as base-10 integers and applies safe defaults when parsing fails. 
- Normalized the range so `start` defaults to `1`, `end` defaults to `50`, and `end` is clamped to be `>= start` before interpolation. 
- Replaced the previous direct `range` string interpolation with the sanitized numeric `start` and `end` values when returning the `sed` command in `packages/cli/bin/scbe.js`.

### Testing
- Ran the repository smoke e2e script `node packages/cli/scripts/smoke_agent_json_e2e.cjs`, which executed the regex/unit/verifier smoke checks and reported all tests passed. 
- Confirmed the modified file path is `packages/cli/bin/scbe.js` and the change is scoped to the `:read` translation to minimize behavioral impact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164fcee2bc832295d5b1776bdf6e33)