### PR TITLE
fix(agent-bus): prevent unsafe GeoSeal exec registration via SCBE_BUS_TOOLS

### DIFF
--- a/packages/agent-bus/src/tools.ts
+++ b/packages/agent-bus/src/tools.ts
@@ -76,6 +76,15 @@ export interface ToolRegistryAudit {
 
 const registry = new Map<string, CliTool>();
 
+function isUnsafeAutoDiscoveredTool(tool: CliTool): boolean {
+  const args = tool.args.map((arg) => arg.trim());
+  const invokesGeoSealExec =
+    args.some((arg, index) => arg === '-m' && args[index + 1] === 'src.geoseal_cli') &&
+    args.includes('exec');
+  const passesTaskAsCommand = args.includes('{task}');
+  return invokesGeoSealExec && passesTaskAsCommand;
+}
+
 /** Register a tool. Idempotent by name — re-registering replaces the previous entry. */
 export function registerTool(tool: CliTool): void {
   registry.set(tool.name, tool);
@@ -237,6 +246,12 @@ export function autoDiscoverTools(): void {
     }
     for (const t of tools as CliTool[]) {
       if (typeof t.name === 'string' && typeof t.command === 'string' && Array.isArray(t.args)) {
+        if (isUnsafeAutoDiscoveredTool(t)) {
+          process.stderr.write(
+            `[agent-bus] SCBE_BUS_TOOLS: skipping unsafe tool entry '${t.name}' (GeoSeal exec cannot receive {task} as a command)\n`
+          );
+          continue;
+        }
         registerTool(t);
       } else {
         process.stderr.write(

--- a/packages/agent-bus/tests/tools.test.ts
+++ b/packages/agent-bus/tests/tools.test.ts
@@ -9,6 +9,7 @@ import {
   getTool,
   clearTools,
   buildToolArgv,
+  autoDiscoverTools,
   auditToolRegistry,
   type CliTool,
 } from '../src/tools.js';
@@ -71,6 +72,42 @@ describe('tool registry', () => {
     const tool: CliTool = { name: 'x', command: 'echo', args: ['{unknownVar}'] };
     const { args } = buildToolArgv(tool, { task: 't' }, {}, 'r1');
     expect(args[0]).toBe('{unknownVar}');
+  });
+
+  it('autoDiscoverTools skips GeoSeal exec tools that pass task as a command', () => {
+    const oldEnv = process.env.SCBE_BUS_TOOLS;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-bus-tools-autodiscover-'));
+    const file = path.join(dir, 'tools.json');
+    fs.writeFileSync(
+      file,
+      JSON.stringify([
+        {
+          name: 'safe-compile',
+          command: 'python',
+          args: ['-m', 'src.geoseal_cli', 'compile', '--json', '{task}'],
+        },
+        {
+          name: 'geoseal-exec',
+          command: 'python',
+          args: ['-m', 'src.geoseal_cli', 'exec', '--json', '--max-tier', 'ALLOW', '--', '{task}'],
+        },
+      ]),
+      'utf8'
+    );
+
+    try {
+      process.env.SCBE_BUS_TOOLS = file;
+      autoDiscoverTools();
+      expect(getTool('safe-compile')).toBeDefined();
+      expect(getTool('geoseal-exec')).toBeUndefined();
+    } finally {
+      if (oldEnv === undefined) {
+        delete process.env.SCBE_BUS_TOOLS;
+      } else {
+        process.env.SCBE_BUS_TOOLS = oldEnv;
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('audits tools into patent-facing surfaces and env readiness', () => {


### PR DESCRIPTION
### Motivation
- The SCBE_BUS_TOOLS autodiscovery could load a bundled `geoseal-exec` tool that maps attacker-controlled `{task}` into a GeoSeal `exec` invocation, enabling unauthenticated OS command execution through the agent-bus surface when the bundled registry is used.
- The repository previously contained a parseable bundled `tools.json` that re-enabled this attack path, so autodiscovered tool entries that pass `{task}` as a command argument must be blocked at load time.

### Description
- Add a safety filter `isUnsafeAutoDiscoveredTool(tool: CliTool)` in `packages/agent-bus/src/tools.ts` that detects GeoSeal `exec` tool specs which include `{task}` as the command payload and treats them unsafe for auto-registration. 
- Update `autoDiscoverTools()` to skip and log a warning for such unsafe tool entries instead of registering them. 
- Add a regression test in `packages/agent-bus/tests/tools.test.ts` that verifies a safe GeoSeal compile entry is loaded while a `geoseal-exec` entry that passes `{task}` is skipped. 
- Affected files: `packages/agent-bus/src/tools.ts`, `packages/agent-bus/tests/tools.test.ts`.

### Testing
- Ran the package-local Vitest suite for `packages/agent-bus` targeting `tests/tools.test.ts`, and the test file passed: 15 tests passed (including the new regression test).
- Ran TypeScript checks with `npm run typecheck` in `packages/agent-bus`, and the typecheck succeeded. 
- Built the package with `npm run build` in `packages/agent-bus`, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2729143ba48322932baf8ac1464ce3)