### PR TITLE
fix(netlify): protect governance receipt lookup

### DIFF
--- a/netlify/functions/_shared/response.ts
+++ b/netlify/functions/_shared/response.ts
@@ -37,7 +37,7 @@ export function corsPreflight(methods: string[]): Response {
     status: 204,
     headers: {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-API-Key',
       'Access-Control-Allow-Methods': ['OPTIONS', ...methods].join(', '),
       'Access-Control-Max-Age': '86400',
     },

--- a/netlify/functions/governance-receipt.ts
+++ b/netlify/functions/governance-receipt.ts
@@ -1,6 +1,50 @@
 import type { Config } from '@netlify/functions';
+import type { GovernanceReceiptRecord } from './_shared/receipt-store';
 import { findGovernanceReceipt } from './_shared/receipt-store';
 import { corsPreflight, json, methodNotAllowed, withCors } from './_shared/response';
+
+function configuredReceiptApiKey(): string | null {
+  return (process.env.GOVERNANCE_RECEIPT_API_KEY || process.env.SCBE_API_KEY || '').trim() || null;
+}
+
+function requestCredential(req: Request): string {
+  const apiKey = req.headers.get('x-api-key')?.trim();
+  if (apiKey) {
+    return apiKey;
+  }
+
+  const authorization = req.headers.get('authorization')?.trim() ?? '';
+  const match = /^Bearer\s+(.+)$/i.exec(authorization);
+  return match?.[1]?.trim() ?? '';
+}
+
+function isAuthorizedReceiptRequest(req: Request): boolean {
+  const expected = configuredReceiptApiKey();
+  return Boolean(expected && requestCredential(req) === expected);
+}
+
+type PublicGovernanceReceiptRecord = Pick<
+  GovernanceReceiptRecord,
+  'receipt' | 'status' | 'requestId' | 'createdAt' | 'storageKey'
+> & {
+  payload: Pick<GovernanceReceiptRecord['payload'], 'intent' | 'source'>;
+};
+
+function publicGovernanceReceiptRecord(
+  record: GovernanceReceiptRecord
+): PublicGovernanceReceiptRecord {
+  return {
+    receipt: record.receipt,
+    status: record.status,
+    requestId: record.requestId,
+    createdAt: record.createdAt,
+    storageKey: record.storageKey,
+    payload: {
+      intent: record.payload.intent,
+      source: record.payload.source,
+    },
+  };
+}
 
 export default async (req: Request) => {
   if (req.method === 'OPTIONS') {
@@ -9,6 +53,10 @@ export default async (req: Request) => {
 
   if (req.method !== 'GET') {
     return withCors(methodNotAllowed(req.method, ['GET']));
+  }
+
+  if (!isAuthorizedReceiptRequest(req)) {
+    return withCors(json({ ok: false, error: 'unauthorized' }, { status: 401 }));
   }
 
   const receipt = new URL(req.url).pathname.split('/').pop() ?? '';
@@ -21,7 +69,7 @@ export default async (req: Request) => {
     return withCors(json({ ok: false, error: 'receipt_not_found' }, { status: 404 }));
   }
 
-  return withCors(json({ ok: true, record }));
+  return withCors(json({ ok: true, record: publicGovernanceReceiptRecord(record) }));
 };
 
 export const config: Config = {

--- a/tests/netlify_functions.test.ts
+++ b/tests/netlify_functions.test.ts
@@ -60,6 +60,7 @@ describe('Netlify functions', () => {
   beforeEach(() => {
     blobMock.data.clear();
     vi.clearAllMocks();
+    process.env.GOVERNANCE_RECEIPT_API_KEY = 'test-receipt-key';
   });
 
   it('returns API health', async () => {
@@ -136,7 +137,9 @@ describe('Netlify functions', () => {
     const submitBody = await submit.json();
 
     const res = await governanceReceipt(
-      new Request(`https://example.com/api/governance/receipts/${submitBody.receipt}`)
+      new Request(`https://example.com/api/governance/receipts/${submitBody.receipt}`, {
+        headers: { Authorization: 'Bearer test-receipt-key' },
+      })
     );
     const body = await res.json();
 
@@ -145,13 +148,28 @@ describe('Netlify functions', () => {
     expect(body.record.receipt).toBe(submitBody.receipt);
     expect(body.record.status).toBe('queued');
     expect(body.record.payload.intent).toBe('persist receipt in blobs');
-    expect(body.record.netlify.siteId).toBe('site_test');
+    expect(body.record.payload.source).toBe('vitest');
+    expect(body.record.payload.metadata).toBeUndefined();
+    expect(body.record.netlify).toBeUndefined();
+  });
+
+  it('requires an API key before returning governance receipts', async () => {
+    const res = await governanceReceipt(
+      new Request(
+        'https://example.com/api/governance/receipts/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      )
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('unauthorized');
   });
 
   it('returns 404 for missing governance receipts', async () => {
     const res = await governanceReceipt(
       new Request(
-        'https://example.com/api/governance/receipts/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        'https://example.com/api/governance/receipts/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        { headers: { 'x-api-key': 'test-receipt-key' } }
       )
     );
     const body = await res.json();


### PR DESCRIPTION
### Motivation
- Close a high-severity information disclosure where `GET /api/governance/receipts/:receipt` returned full persisted governance records with no authentication or tenant binding.
- Ensure receipt lookup is not usable to exfiltrate governance payloads, Netlify site/deploy identifiers, or other sensitive metadata.

### Description
- Require a configured API key before returning any receipt record by checking `process.env.GOVERNANCE_RECEIPT_API_KEY` with a fallback to `process.env.SCBE_API_KEY` and accepting `X-API-Key` or `Authorization: Bearer <token>` from the caller. The check is implemented in `netlify/functions/governance-receipt.ts` via `isAuthorizedReceiptRequest` and `requestCredential`.
- Redact the returned record to a safe public view: only `receipt`, `status`, `requestId`, `createdAt`, `storageKey`, and `payload` with `intent` and `source` are returned; raw `payload.metadata` and the `netlify` deploy/site fields are omitted.
- Add `X-API-Key` to the CORS preflight `Access-Control-Allow-Headers` to support API-key based retrievals from browsers in permitted clients by changing `netlify/functions/_shared/response.ts`.
- Update `tests/netlify_functions.test.ts` to set `process.env.GOVERNANCE_RECEIPT_API_KEY` in tests and to validate authenticated lookup, redaction behavior, unauthenticated denial (401), and keyed missing-receipt (404).

### Testing
- Ran `npx prettier --write netlify/functions/governance-receipt.ts netlify/functions/_shared/response.ts tests/netlify_functions.test.ts` (formatting applied). — OK.
- Ran `npm run typecheck` (`tsc --noEmit`) to ensure typings are valid. — OK.
- Ran unit tests with `npx vitest run tests/netlify_functions.test.ts --reporter=verbose`, which executed the Netlify function tests and reported all tests passing (10/10). — OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f8c5bc8c483228dbce0abbe3581f9)