### PR TITLE
fix(security): harden GeoSeal Hermes command output

### DIFF
--- a/api/agent/geoseal-hermes.js
+++ b/api/agent/geoseal-hermes.js
@@ -36,7 +36,10 @@ function sha(value) {
 }
 
 function shellQuote(value) {
-  return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  const text = String(value);
+  if (!text) return "''";
+  if (/^[A-Za-z0-9_./:=@\-]+$/.test(text)) return text;
+  return `'${text.replace(/'/g, `'\\''`)}'`;
 }
 
 function classify(task) {
@@ -47,15 +50,18 @@ function classify(task) {
   return 'ask';
 }
 
+function argvFor(task, routeType, outputMode) {
+  const action = routeType === 'hosted' ? 'do' : classify(task);
+  const argv = [action, String(task)];
+  if (routeType === 'api') argv.push('--api-base', 'http://127.0.0.1:8002');
+  if (outputMode === 'json') argv.push('--json');
+  return argv;
+}
+
 function commandFor(task, routeType, outputMode) {
-  const jsonFlag = outputMode === 'json' ? ' --json' : '';
-  if (routeType === 'api') {
-    return `geoseal ${classify(task)} ${shellQuote(task)} --api-base http://127.0.0.1:8002${jsonFlag}`;
-  }
-  if (routeType === 'hosted') {
-    return `geoseal do ${shellQuote(task)}${jsonFlag} # hosted intake: https://aethermoore.com/hosted-run`;
-  }
-  return `geoseal ${classify(task)} ${shellQuote(task)}${jsonFlag}`;
+  const argv = ['geoseal', ...argvFor(task, routeType, outputMode)];
+  const suffix = routeType === 'hosted' ? ' # hosted intake: https://aethermoore.com/hosted-run' : '';
+  return argv.map(shellQuote).join(' ') + suffix;
 }
 
 module.exports = async function handler(req, res) {
@@ -88,9 +94,10 @@ module.exports = async function handler(req, res) {
       backend,
       policy,
       command: commandFor(task, routeType, outputMode),
+      command_argv: ['geoseal', ...argvFor(task, routeType, outputMode)],
       summary: `Prepared a ${routeType} GeoSeal route for a ${classify(task)} task.`,
       next_steps: [
-        'Run the command locally or attach it to the hosted intake.',
+        'Run the command locally or use command_argv for automation without shell parsing.',
         'Keep the JSON receipt with the customer delivery.',
         'Turn repeat routes into one-click product actions.',
       ],

--- a/docs/geoseal-hermes.html
+++ b/docs/geoseal-hermes.html
@@ -265,7 +265,11 @@
         lastCommand = data.command;
         document.getElementById("jsonOut").textContent = JSON.stringify(data, null, 2);
         document.getElementById("results").innerHTML = [
-          '<article class="card"><strong>Command</strong><pre>' + esc(data.command) + '</pre></article>',
+          '<article class="card"><strong>Command</strong><pre>' +
+            esc(data.command) +
+            '</pre><p>Automation argv: <code>' +
+            esc(JSON.stringify(data.command_argv || [])) +
+            '</code></p></article>',
           '<article class="card"><strong>Route</strong>' + pills([data.route_type, data.backend, data.policy]) + '</article>',
           '<article class="card"><strong>Receipt</strong><p>' + esc(data.receipt_id) + '</p><p>' + esc(data.summary) + '</p></article>',
           '<article class="card"><strong>Next steps</strong><p>' + esc(data.next_steps.join(" ")) + '</p></article>'

--- a/tests/api/geoseal-hermes.security.test.cjs
+++ b/tests/api/geoseal-hermes.security.test.cjs
@@ -1,0 +1,60 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { EventEmitter } = require('node:events');
+const { execFileSync } = require('node:child_process');
+const { mkdtempSync, existsSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+
+const handler = require('../../api/agent/geoseal-hermes.js');
+
+function invoke(body) {
+  const req = new EventEmitter();
+  req.method = 'POST';
+  req.body = body;
+  const res = {
+    statusCode: 200,
+    headers: {},
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    },
+    end() {
+      return this;
+    },
+  };
+  return handler(req, res).then(() => res);
+}
+
+test('GeoSeal Hermes command output single-quotes shell metacharacters and exposes argv', async () => {
+  const task = "deploy $(printf INJECTED > marker) `touch marker2` and 'quote'";
+  const res = await invoke({ task, route_type: 'local', output_mode: 'json' });
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload.command_argv, ['geoseal', 'do', task, '--json']);
+  assert.match(res.payload.command, /^geoseal do '/);
+  assert.doesNotMatch(res.payload.command, /".*\$\(/);
+  assert.match(res.payload.command, /'\\''quote'\\'''/);
+});
+
+test('GeoSeal Hermes generated command does not evaluate command substitution in POSIX shell', async () => {
+  const temp = mkdtempSync(join(tmpdir(), 'geoseal-hermes-'));
+  const marker = join(temp, 'pwned');
+  const geoseal = join(temp, 'geoseal');
+  writeFileSync(geoseal, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+  const task = `deploy $(printf INJECTED > ${marker})`;
+  const res = await invoke({ task, route_type: 'local', output_mode: 'json' });
+
+  execFileSync('/bin/sh', ['-c', res.payload.command], {
+    env: { ...process.env, PATH: `${temp}:${process.env.PATH}` },
+  });
+  assert.equal(existsSync(marker), false);
+});


### PR DESCRIPTION
### Motivation

- The GeoSeal Hermes handler returned a shell command string built from untrusted `task` text using weak double-quote escaping, allowing POSIX command substitution (`$()` / backticks) to be evaluated when an operator copied and ran the command.

### Description

- Replace the unsafe double-quote `shellQuote` with POSIX single-quote escaping in `api/agent/geoseal-hermes.js` by implementing a robust single-quote escaper in `shellQuote` so metacharacters cannot cause command substitution.
- Introduce `argvFor(task, routeType, outputMode)` and add a structured `command_argv` field to the JSON payload so automation can safely invoke the generated command without shell parsing, and update `commandFor` to assemble the display string from quoted argv entries.
- Update the UI in `docs/geoseal-hermes.html` to render the new `command_argv` alongside the shell command and change guidance to prefer `command_argv` for automation.
- Add deterministic regression tests in `tests/api/geoseal-hermes.security.test.cjs` that assert proper single-quote escaping and verify that `/bin/sh -c` does not evaluate injected command substitutions in the returned command.

### Testing

- Ran the new security tests with `node --test tests/api/geoseal-hermes.security.test.cjs` and they passed (2 tests, 0 failures).
- Ran TypeScript checks with `npm run typecheck` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a89cddb08322aa51f7812f0ecdcf)