### PR TITLE
fix(gateway): require configured RWP HMAC secret

### DIFF
--- a/src/gateway/unified-api.ts
+++ b/src/gateway/unified-api.ts
@@ -276,12 +276,20 @@ export class UnifiedSCBEGateway {
   ): Promise<{ valid: boolean; payload?: unknown; error?: string }> {
     // Verify all signatures
     for (const [tongue, signature] of Object.entries(envelope.signatures)) {
-      const valid = await this.verifyTongueSignature(
-        envelope.payload,
-        tongue as TongueID,
-        signature,
-        envelope.nonce
-      );
+      let valid = false;
+      try {
+        valid = await this.verifyTongueSignature(
+          envelope.payload,
+          tongue as TongueID,
+          signature,
+          envelope.nonce
+        );
+      } catch (error) {
+        return {
+          valid: false,
+          error: error instanceof Error ? error.message : `Invalid ${tongue} signature`,
+        };
+      }
       if (!valid) {
         return { valid: false, error: `Invalid ${tongue} signature` };
       }
@@ -610,9 +618,12 @@ export class UnifiedSCBEGateway {
   }
 
   private tongueKey(tongue: TongueID): Buffer {
-    // Per-tongue HMAC key derived from a server secret. Set SCBE_GATEWAY_HMAC_SECRET
-    // in production; the dev default keeps local runs working but is not secret.
-    const secret = process.env.SCBE_GATEWAY_HMAC_SECRET ?? 'scbe-gateway-dev-secret';
+    // Per-tongue HMAC key derived from a server secret. Fail closed instead of
+    // falling back to a public default that would let attackers forge envelopes.
+    const secret = process.env.SCBE_GATEWAY_HMAC_SECRET;
+    if (!secret) {
+      throw new Error('SCBE_GATEWAY_HMAC_SECRET must be configured for RWP envelope signatures');
+    }
     return crypto.createHmac('sha256', secret).update(`tongue-key:${tongue}`).digest();
   }
 

--- a/tests/gateway/gateway_real.test.ts
+++ b/tests/gateway/gateway_real.test.ts
@@ -7,10 +7,25 @@
  *  - envelope signatures are real HMAC (a forged signature is rejected),
  *  - quantum key exchange returns a real ML-KEM-768 public key.
  */
-import { describe, it, expect } from 'vitest';
+import crypto from 'node:crypto';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { UnifiedSCBEGateway } from '../../src/gateway/unified-api.js';
 
 describe('gateway real behavior (no fakes)', () => {
+  const originalGatewaySecret = process.env.SCBE_GATEWAY_HMAC_SECRET;
+
+  beforeEach(() => {
+    process.env.SCBE_GATEWAY_HMAC_SECRET = 'gateway-real-test-secret';
+  });
+
+  afterEach(() => {
+    if (originalGatewaySecret === undefined) {
+      delete process.env.SCBE_GATEWAY_HMAC_SECRET;
+    } else {
+      process.env.SCBE_GATEWAY_HMAC_SECRET = originalGatewaySecret;
+    }
+  });
+
   it('authorize risk is deterministic (no Math.random)', async () => {
     const gw = new UnifiedSCBEGateway();
     const req = { agentId: 'a1', action: 'read', target: 'doc/x', tongues: ['KO' as const] };
@@ -35,6 +50,36 @@ describe('gateway real behavior (no fakes)', () => {
     const forged = { ...env, signatures: { ...env.signatures, KO: 'sig_KO_forged' } };
     const bad = await gw.decodeRWP(forged as never);
     expect(bad.valid).toBe(false);
+  });
+
+  it('rejects independently forged envelopes that rely on the old public fallback secret', async () => {
+    delete process.env.SCBE_GATEWAY_HMAC_SECRET;
+    const payload = Buffer.from(JSON.stringify({ role: 'admin', action: 'delete_all' })).toString(
+      'base64url'
+    );
+    const nonce = 'attacker-controlled-nonce';
+    const fallbackKey = crypto
+      .createHmac('sha256', 'scbe-gateway-dev-secret')
+      .update('tongue-key:KO')
+      .digest();
+    const mac = crypto
+      .createHmac('sha256', fallbackKey)
+      .update(`KO:${payload}:${nonce}`)
+      .digest('base64url');
+
+    const gw = new UnifiedSCBEGateway();
+    const decoded = await gw.decodeRWP({
+      ver: '2.1',
+      primaryTongue: 'KO',
+      payload,
+      signatures: { KO: `sig_KO_${mac}` },
+      nonce,
+      timestamp: Date.now(),
+      aad: 'gateway=unified;tongues=KO',
+    });
+
+    expect(decoded.valid).toBe(false);
+    expect(decoded.error).toMatch(/SCBE_GATEWAY_HMAC_SECRET/);
   });
 
   it('QKE returns a real ML-KEM-768 public key (1184 bytes)', async () => {

--- a/tests/gateway/unified-api.unit.test.ts
+++ b/tests/gateway/unified-api.unit.test.ts
@@ -12,7 +12,7 @@
  * - Quantum key exchange
  */
 
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import {
   UnifiedSCBEGateway,
   type AuthorizationRequest,
@@ -55,10 +55,20 @@ function makeAgent(overrides: Partial<AgentState> = {}): AgentState {
 // ============================================
 
 describe('UnifiedSCBEGateway', () => {
+  const originalGatewaySecret = process.env.SCBE_GATEWAY_HMAC_SECRET;
   let gateway: UnifiedSCBEGateway;
 
   beforeEach(() => {
+    process.env.SCBE_GATEWAY_HMAC_SECRET = 'unified-api-unit-test-secret';
     gateway = new UnifiedSCBEGateway();
+  });
+
+  afterEach(() => {
+    if (originalGatewaySecret === undefined) {
+      delete process.env.SCBE_GATEWAY_HMAC_SECRET;
+    } else {
+      process.env.SCBE_GATEWAY_HMAC_SECRET = originalGatewaySecret;
+    }
   });
 
   describe('authorization pipeline', () => {


### PR DESCRIPTION
### Motivation
- Remediate a critical vulnerability where a hard-coded fallback HMAC secret (`scbe-gateway-dev-secret`) allowed attackers to forge RWP envelopes when `SCBE_GATEWAY_HMAC_SECRET` was unset.
- Ensure RWP signature verification fails closed so envelope acceptance requires an explicit, configured secret in production.

### Description
- Replace the public fallback by making `tongueKey` require `SCBE_GATEWAY_HMAC_SECRET` and throw an error if it is missing (fail-closed) in `src/gateway/unified-api.ts`.
- Harden `decodeRWP` to catch errors from signature verification and return an explicit invalid result when the verification step cannot derive a configured key or otherwise fails.
- Update gateway tests to set and restore `process.env.SCBE_GATEWAY_HMAC_SECRET` in `beforeEach`/`afterEach` so normal encode/decode round-trips continue to work with an explicit test secret.
- Add a regression test that constructs an envelope signed using the old public fallback key and asserts `decodeRWP` rejects it when `SCBE_GATEWAY_HMAC_SECRET` is not configured; modified files: `src/gateway/unified-api.ts`, `tests/gateway/gateway_real.test.ts`, and `tests/gateway/unified-api.unit.test.ts`.

### Testing
- Ran `npm run typecheck -- --pretty false` and the TypeScript check completed successfully.
- Ran `npx vitest run tests/gateway/gateway_real.test.ts tests/gateway/unified-api.unit.test.ts` and both test files passed (2 test files, 36 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3214f7a1d0832295600dc06bd3ec1c)