### PR TITLE
fix(measure): re-land orphaned stuck-prior review fixes (squash race)

### DIFF
--- a/python/helm/offload_measure.py
+++ b/python/helm/offload_measure.py
@@ -45,19 +45,30 @@ GROUND_TRUTH = {
 
 
 def model_proposer(base: str, key: str, model: str) -> Proposer:
-    """A proposer backed by a live model: hand it the rebuilt context, take back one legal label."""
+    """A proposer backed by a live model: hand it the rebuilt context, take back one legal label.
+
+    Mapping is exact-match-first, then substring with options sorted LONGEST-first -- so a correct
+    'prime-power' reply is NOT swallowed by the shorter 'prime' (a real bug a review caught: 'prime'
+    is a substring of 'prime-power', so naive first-match mislabelled every correct prime-power answer
+    as 'prime' and fabricated fake rescues). A transport failure is raised, never returned: a dead
+    endpoint must fail loud, not masquerade as a model ceiling that the oracle then 'rescues'.
+    """
 
     def p(ctx: str, options: List[str]) -> str:
         prompt = ctx + "\n\nReply with EXACTLY one of these labels and nothing else: " + ", ".join(options)
         try:
             reply = _chat([{"role": "user", "content": prompt}], base=base, key=key, model=model)
-        except Exception as exc:  # a dead endpoint must not masquerade as a model failure
-            return "(endpoint-error: %s)" % type(exc).__name__
-        reply = (reply or "").strip().splitlines()[0].strip().strip(".'\"` ")
-        for opt in options:  # tolerate "the answer is composite" -> composite
-            if opt.lower() in reply.lower():
+        except Exception as exc:  # infra failure, NOT a model failure -> fail loud (never count as a lift)
+            raise ConnectionError("LLM endpoint error: %s: %s" % (type(exc).__name__, exc)) from exc
+        text = ((reply or "").strip().splitlines() or [""])[0].strip().strip(".'\"` ")
+        low = text.lower()
+        for opt in options:  # an exact label wins outright
+            if low == opt.lower():
                 return opt
-        return reply  # let an off-menu answer count as a misstep (it is not in options)
+        for opt in sorted(options, key=len, reverse=True):  # longest-first: 'prime-power' beats 'prime'
+            if opt.lower() in low:
+                return opt
+        return text  # genuinely off-menu -> a legitimate misstep (not in options)
 
     return p
 
@@ -70,15 +81,17 @@ def measure(numbers: List[int], proposer: Proposer, ground_truth: dict = None, m
     rows = []
     base_stuck = rescued = wrong = unverified = 0
     for n in numbers:
-        off = run_stepwise(classify_number_task(n), proposer, max_rewinds=max_rewinds, allow_offload=False)
-        on = run_stepwise(classify_number_task(n), proposer, max_rewinds=max_rewinds, allow_offload=True)
+        # prune_wrong=False on BOTH arms: offload (the tool) is the only variable under test, so the
+        # restructure rung must stay off or it would complete steps and steal credit from the oracle.
+        off = run_stepwise(classify_number_task(n), proposer, max_rewinds, allow_offload=False, prune_wrong=False)
+        on = run_stepwise(classify_number_task(n), proposer, max_rewinds, allow_offload=True, prune_wrong=False)
         was_stuck = not off["completed"]
         got = on.get("answer")
         offloaded = bool(on.get("offloaded"))
         exp = truth.get(n)  # independent ground truth, or None if this number cannot be verified
         correct = (got == exp) if (on["completed"] and exp is not None) else None
         base_stuck += was_stuck
-        rescued += bool(was_stuck and on["completed"])
+        rescued += int(was_stuck and on["completed"] and offloaded)  # a rescue means the TOOL actually fired
         wrong += int(correct is False)
         unverified += int(on["completed"] and exp is None)
         rows.append(
@@ -106,7 +119,11 @@ def main(argv: object = None) -> int:
     model = os.environ.get("SCBE_LLM_MODEL", "qwen2.5-coder:1.5b")
     print("OFFLOAD_MEASURE  live model=%s  (baseline=no offload vs. auto-offload)\n" % model)
 
-    res = measure(DEFAULT_NUMBERS, model_proposer(base, key, model))
+    try:
+        res = measure(DEFAULT_NUMBERS, model_proposer(base, key, model))
+    except ConnectionError as exc:  # a dead endpoint must never read as a clean lift
+        print("  [endpoint down] %s\n  -> NO measurement produced (a transport failure is not a result)" % exc)
+        return 2
     print("  %-4s %-12s %-9s %-12s %-9s %s" % ("n", "truth", "stuck?", "answer", "offload?", "vs truth"))
     for r in res["rows"]:
         if r["correct"] is None:

--- a/python/helm/restructure_measure.py
+++ b/python/helm/restructure_measure.py
@@ -11,11 +11,15 @@ deterministic tool supplying the answer. That distinguishes this lift from offlo
     cannot fall back into the rut. Completions here are the model making a fresh choice in a narrowed
     legal set -- not the model getting smarter.
 
-Correctness is cross-checked against the INDEPENDENT hand-verified GROUND_TRUTH table (reused from
-offload_measure -- NOT re-derived from the sieve), and each rescue is labelled `forced` (pruned down
-to a single legal option -- the harness solved it by elimination) vs `choice` (>1 option remained, so
-the model genuinely picked the right one). No overclaim: the honest measured quantity is the
-stuck->rescued delta and how much of it was real model choice vs pure elimination.
+The honest measured quantity is the stuck->rescued delta. Each rescue is described by how many legal
+options remained when it committed -- `single` (pruned to one option: the harness solved it by
+elimination) vs `multi` (>1 option still on the menu). `multi` is necessary but NOT sufficient for
+"genuine model judgement" (a model that just grabs the first remaining option also shows >1), so it is
+reported descriptively, never claimed as proof of reasoning. A real model that re-proposes the SAME
+pruned value is NOT rescued (it accrues stuck_priors and stays stuck) -- so a nonzero restructure lift
+here means the live model actually deviates when its rut is pruned, which is the thing under test.
+Correctness is a consistency check vs the hand-verified GROUND_TRUTH table; since only check-passing
+values commit, it guards the rule/table, not model error (see the note in measure_restructure).
 
     python -m python.helm.restructure_measure
     SCBE_LLM_MODEL=qwen2.5-coder:3b python -m python.helm.restructure_measure
@@ -44,10 +48,18 @@ def _label_remaining(result: dict) -> Optional[int]:
 def measure_restructure(
     numbers: List[int], proposer: Proposer, ground_truth: dict = None, max_rewinds: int = 3
 ) -> dict:
-    """Run each number twice with the tool OFF: prune off (baseline loop) vs prune on (forced deviation)."""
+    """Run each number twice with the tool OFF: prune off (baseline loop) vs prune on (forced deviation).
+
+    The two arms are deterministic (the live proposer runs at temperature 0), so a number stuck in the
+    baseline arm that completes in the restructure arm is a real effect of pruning, not sampling luck --
+    the arms are paired in practice. `base_looped` counts NUMBERS where the model re-proposed a known-
+    wrong value at least once (a knob-independent trait), not total repeats (which just track the rewind
+    budget). `multi` vs `single` is whether >1 legal option remained when it committed -- descriptive
+    only: >1 is necessary but not sufficient for "genuine judgement", so it is reported, not claimed.
+    """
     truth = GROUND_TRUTH if ground_truth is None else ground_truth
     rows = []
-    base_stuck = base_loops = rescued = wrong = forced = choice = 0
+    base_stuck = base_looped = rescued = wrong = single = multi = 0
     for n in numbers:
         base = run_stepwise(classify_number_task(n), proposer, max_rewinds, allow_offload=False, prune_wrong=False)
         res = run_stepwise(classify_number_task(n), proposer, max_rewinds, allow_offload=False, prune_wrong=True)
@@ -59,20 +71,20 @@ def measure_restructure(
         is_rescue = bool(was_stuck and completed)
         correct = (got == exp) if (completed and exp is not None) else None
         base_stuck += was_stuck
-        base_loops += base["stuck_priors"]
+        base_looped += int(base["stuck_priors"] > 0)
         rescued += is_rescue
         wrong += int(correct is False)
         if is_rescue and remaining is not None:
             if remaining <= 1:
-                forced += 1
+                single += 1
             else:
-                choice += 1
+                multi += 1
         rows.append(
             {
                 "n": n,
                 "expected": exp,
                 "baseline_stuck": was_stuck,
-                "baseline_loops": base["stuck_priors"],
+                "baseline_looped": base["stuck_priors"] > 0,
                 "answer": got,
                 "completed": completed,
                 "remaining": remaining,
@@ -82,10 +94,10 @@ def measure_restructure(
     return {
         "rows": rows,
         "baseline_stuck": base_stuck,
-        "baseline_loops": base_loops,
+        "base_looped": base_looped,
         "rescued": rescued,
-        "forced": forced,
-        "choice": choice,
+        "single": single,
+        "multi": multi,
         "wrong": wrong,
     }
 
@@ -96,10 +108,14 @@ def main(argv: object = None) -> int:
     model = os.environ.get("SCBE_LLM_MODEL", "qwen2.5-coder:1.5b")
     print("RESTRUCTURE_MEASURE  live model=%s  (tool OFF both arms; prune off=loop vs on=forced deviation)\n" % model)
 
-    res = measure_restructure(DEFAULT_NUMBERS, model_proposer(base, key, model))
+    try:
+        res = measure_restructure(DEFAULT_NUMBERS, model_proposer(base, key, model))
+    except ConnectionError as exc:  # a dead endpoint must never read as a clean lift
+        print("  [endpoint down] %s\n  -> NO measurement produced (a transport failure is not a result)" % exc)
+        return 2
     print(
         "  %-4s %-12s %-9s %-8s %-12s %-10s %s"
-        % ("n", "truth", "loops(off)", "stuck?", "answer(on)", "remaining", "vs truth")
+        % ("n", "truth", "looped?", "stuck?", "answer(on)", "remaining", "vs truth")
     )
     for r in res["rows"]:
         if r["correct"] is None:
@@ -108,11 +124,11 @@ def main(argv: object = None) -> int:
             verdict = "ok" if r["correct"] else "WRONG"
         rem = "-" if r["remaining"] is None else str(r["remaining"])
         print(
-            "  %-4d %-12s %-9d %-8s %-12s %-10s %s"
+            "  %-4d %-12s %-9s %-8s %-12s %-10s %s"
             % (
                 r["n"],
                 r["expected"] or "-",
-                r["baseline_loops"],
+                "loop" if r["baseline_looped"] else "-",
                 "STUCK" if r["baseline_stuck"] else "-",
                 r["answer"],
                 rem,
@@ -121,25 +137,33 @@ def main(argv: object = None) -> int:
         )
     n = len(res["rows"])
     print(
-        "\n  BASELINE (prune off): %d/%d stuck, %d total re-proposals of a known-wrong value (the System-1 rut)"
-        % (res["baseline_stuck"], n, res["baseline_loops"])
+        "\n  BASELINE (prune off): %d/%d stuck; %d/%d numbers where the model re-proposed a known-wrong value"
+        % (res["baseline_stuck"], n, res["base_looped"], n)
     )
     print(
         "  RESTRUCTURE (prune on, NO tool): %d of the %d stuck rescued by forced deviation"
         % (res["rescued"], res["baseline_stuck"])
     )
     print(
-        "    of those rescues: %d a genuine model choice (>1 option left), %d elimination-to-one (harness-forced)"
-        % (res["choice"], res["forced"])
+        "    when committed: %d with >1 legal option left, %d down to a single option (elimination)"
+        % (res["multi"], res["single"])
     )
-    print("  INDEPENDENT correctness vs hand-verified ground truth: %d wrong" % res["wrong"])
+    # the cross-check guards the sieve/ground-truth rule, not model error: only check-passing values
+    # ever commit, so a completed answer ALWAYS matches the rule -- 'wrong' fires only if GROUND_TRUTH
+    # disagrees with the sieve (it does not, by construction). So 0 wrong is a consistency check, not proof.
+    print(
+        "  CONSISTENCY vs hand-verified ground truth: %d disagreements (guards the rule, not the model)" % res["wrong"]
+    )
     if res["wrong"]:
-        print("  [!] a completed answer disagreed with ground truth -- investigate")
+        print("  [!] a completed answer disagreed with ground truth -- the rule/table drifted, investigate")
     elif res["rescued"]:
-        print("  -> forced deviation lifted results with NO tool: pruning the rut moved the model off its stuck prior")
+        print(
+            "  -> forced deviation lifted results with NO tool on %d numbers (pruning moved the model off its rut)"
+            % res["rescued"]
+        )
     else:
         print(
-            "  -> restructure alone did NOT rescue this model (it ignores the narrowed menu) -- the tool rung is needed"
+            "  -> restructure alone did NOT rescue this model (it re-proposes the pruned value) -- tool rung needed"
         )
     return 0
 

--- a/python/scbe/failure_map.py
+++ b/python/scbe/failure_map.py
@@ -27,12 +27,13 @@ from .stepwise import Proposer, Step, Task, run_stepwise
 def localize(task: Task, proposer: Proposer, max_rewinds: int = 3) -> Dict[str, Any]:
     """Run one (task, model) and report the drift point: where it stuck (point F) or that it cleared.
 
-    Offload is forced OFF here: this measures the MODEL's true ceiling. An oracle would auto-rescue the
-    wall step and report 'cleared', blinding the map to where the model actually drifts. failure_map
-    diagnoses the wall; auto-offload (in run_stepwise) is the cure -- keep them separate or the map goes
-    blind. The recovery this returns is precisely "offload that step", which the harness can now do.
+    Both rescue rungs are forced OFF here (allow_offload=False AND prune_wrong=False): this measures
+    the MODEL's true ceiling. Either rescue -- the oracle OR forced-deviation pruning -- would clear
+    the wall step and report 'cleared', blinding the map to where the model actually drifts. failure_map
+    diagnoses the wall; restructure + offload (in run_stepwise) are the cures -- keep them separate or
+    the map goes blind. The recovery this returns is precisely "rescue that step", which the harness does.
     """
-    r = run_stepwise(task, proposer, max_rewinds, allow_offload=False)
+    r = run_stepwise(task, proposer, max_rewinds, allow_offload=False, prune_wrong=False)
     names = [s.name for s in task.steps]
     if r["completed"]:
         return {"task": task.name, "cleared": True, "stuck_at": None, "stuck_index": len(names), "total": len(names)}

--- a/tests/test_offload_measure.py
+++ b/tests/test_offload_measure.py
@@ -1,0 +1,63 @@
+"""offload_measure.model_proposer: the live-model adapter that maps a free-text reply to one legal
+option. A review found two real defects this locks shut: (1) naive substring matching mapped a correct
+'prime-power' reply to the shorter 'prime' (since 'prime' is a substring of 'prime-power'), fabricating
+fake rescues; (2) a dead endpoint was returned as a sentinel string and silently counted as a model
+ceiling the oracle then 'rescued'. The fix: exact-match-first, then longest-option-first substring; and
+raise on a transport failure so it can never masquerade as a lift.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.helm import offload_measure as om  # noqa: E402
+
+_LABELS = ["unit", "prime", "prime-power", "composite"]
+
+
+def _proposer_with_reply(monkeypatch, reply):
+    monkeypatch.setattr(om, "_chat", lambda *a, **k: reply)
+    return om.model_proposer("base", "key", "model")
+
+
+def test_prime_power_reply_is_not_swallowed_by_prime(monkeypatch):
+    # the headline bug: 'prime' is a substring of 'prime-power'; a correct reply must map to prime-power
+    p = _proposer_with_reply(monkeypatch, "prime-power")
+    assert p("ctx", _LABELS) == "prime-power"
+
+
+def test_prime_power_reply_with_extra_text_still_maps_correctly(monkeypatch):
+    p = _proposer_with_reply(monkeypatch, "The answer is prime-power (2^3).")
+    assert p("ctx", _LABELS) == "prime-power"
+
+
+def test_composite_reply_mentioning_prime_maps_to_composite(monkeypatch):
+    # 'composite, not prime' must map to composite, not get captured by the substring 'prime'
+    p = _proposer_with_reply(monkeypatch, "composite, not prime")
+    assert p("ctx", _LABELS) == "composite"
+
+
+def test_exact_label_reply_maps_to_that_label(monkeypatch):
+    p = _proposer_with_reply(monkeypatch, "prime")
+    assert p("ctx", _LABELS) == "prime"
+
+
+def test_off_menu_reply_is_returned_as_a_misstep(monkeypatch):
+    # a reply matching no option is returned verbatim so the harness records a legitimate misstep
+    p = _proposer_with_reply(monkeypatch, "banana")
+    assert p("ctx", _LABELS) == "banana"
+
+
+def test_endpoint_failure_raises_not_returns(monkeypatch):
+    # a transport failure must fail loud, never be counted as a model ceiling the oracle rescues
+    def boom(*a, **k):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(om, "_chat", boom)
+    p = om.model_proposer("base", "key", "model")
+    with pytest.raises(ConnectionError):
+        p("ctx", _LABELS)


### PR DESCRIPTION
The adversarial-review fixes for the stuck-prior change (PR #2464) were **orphaned by the squash-before-fix race** — #2464 auto-merged the feature commit before the review-fold commit landed, so these fixes never reached main. Verified by content: `origin/main`'s `offload_measure.model_proposer` still returns the `(endpoint-error)` sentinel and `failure_map.localize` lacks `prune_wrong=False`. This re-lands them (clean cherry-pick onto current main).

The fixes (all confirmed by the 3-verifier adversarial review):
1. **`model_proposer` substring bug** — "prime" ⊂ "prime-power", so a correct `prime-power` reply mapped to `prime`, fabricating fake rescues. Fixed: exact-match-first, then longest-option-first.
2. **Dead endpoint read as a lift** — fixed: `model_proposer` raises `ConnectionError`; the measures refuse to report a lift on a transport failure.
3. **`failure_map.localize` inherited `prune_wrong=True`** — blinded its "true ceiling" (restructure auto-cleared the wall). Fixed: pass `prune_wrong=False`.
4. **`offload_measure` ran both arms with pruning on** — fixed: pin `prune_wrong=False`, require the tool to fire for a rescue.
5. **Honesty (critic):** loop count → numbers-that-looped (knob-independent); "genuine choice" softened to descriptive `>1 options`; correctness reframed as a consistency check.

Adds `test_offload_measure` (locks the matcher + raise-on-endpoint guard). 46 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)