### PR TITLE
fix(polyglot): fold review findings — _close infinity bug + log/exp/C-long honesty

### DIFF
--- a/python/scbe/bicameral.py
+++ b/python/scbe/bicameral.py
@@ -62,7 +62,10 @@ EXACT: Dict[str, Tuple[int, object]] = {
     "round": (1, lambda a: float(round(a))),
     "inc": (1, lambda a: a + 1),
     "dec": (1, lambda a: a - 1),
-    # --- ops added to the verified portable core (kept in sync with polyglot) ---
+    # --- ops added to the verified portable core. Same NAMES + same value on the valid domain as the
+    # polyglot faces; these EXACT impls additionally guard domain edges (log x<=0, exp overflow, bitwise
+    # on non-finite) so this pure-python fitness reference can't crash -- the polyglot emit faces are
+    # bare there (verified only on the valid domain, raising in unsafe mode like sqrt). ---
     "sign": (1, lambda a: 1.0 if a > 0 else (-1.0 if a < 0 else 0.0)),
     "log": (1, lambda a: math.log(a) if a > 0 else 0.0),  # safe domain (x>0), else roundabout 0.0
     "exp": (1, lambda a: math.exp(a) if a < 709 else math.inf),  # guard overflow (e^709 ~ max f64)

--- a/python/scbe/polyglot.py
+++ b/python/scbe/polyglot.py
@@ -30,10 +30,12 @@ The simplest commands are the bit/byte primitives, and they map across languages
 so the bitwise ops are the load-bearing extension:
   bitwise      and or xor not shl shr                           (INTEGER: operands truncated to int;
                  portable on the 32-bit SIGNED domain |x| < 2^31 -- BEYOND it JS uses int32 and the
-                 harness reports DISAGREE. That boundary is the honest limit, surfaced not hidden.)
+                 harness reports DISAGREE. That boundary is the honest limit, surfaced not hidden.
+                 shl/shr shift counts must be >= 0; the C face casts to `long long` to match Rust i64.)
   arithmetic   add sub mul div mod neg inc dec
-  math fns     pow abs sqrt floor ceil round min max  log exp   (log domain x>0; exp non-overflowing,
-                                                                  like sqrt's existing x>=0 domain)
+  math fns     pow abs sqrt floor ceil round min max  log exp   (log: x>0 -- safe-mode roundabout maps
+                 x<=0 -> 0.0, exactly like sqrt; exp: verified on non-overflowing x (no roundabout,
+                 raises in unsafe mode on overflow, as any face would). Verified on the valid domain.)
   sign/cmp     sign cmp                                          (-> -1.0 / 0.0 / 1.0)
   comparison   eq neq lt lte gt gte                              (-> 1.0 / 0.0, keeps the number stack)
   predicates   isnan isinf isfinite                             (-> 1.0 / 0.0; verified on nan/inf too)
@@ -72,7 +74,7 @@ FUNC1 = _CORE_FUNC1 | _EXT_FUNC1
 
 # SCALAR_OPS = the UNIVERSAL cube/DNA core (22): every face implements it, the bijection covers it.
 SCALAR_OPS = set(BINOPS) | set(CMPS) | _CORE_FUNC2 | _CORE_FUNC1
-# PORTABLE_OPS = the conformance-VERIFIED polyglot-emitter subset (32): emittable for any face that
+# PORTABLE_OPS = the conformance-VERIFIED polyglot-emitter subset (35): emittable for any face that
 # implements the op (the inline python/js/c/rust faces do). This is the "more than 20" portable core.
 PORTABLE_OPS = set(BINOPS) | set(CMPS) | FUNC2 | FUNC1
 
@@ -161,6 +163,8 @@ def _render(name: str, d: Dialect, safe: bool = False) -> Tuple[str, bool]:
         expr = _sub(d.func1[name], a=va)
         if safe and name == "sqrt":
             expr = _sub(_ternary(d), cond=f"{va} < 0.0", t="0.0", f=expr)
+        elif safe and name == "log":  # log of a non-positive -> 0.0, the same chosen handler as sqrt
+            expr = _sub(_ternary(d), cond=f"{va} <= 0.0", t="0.0", f=expr)
         return expr, False
     raise KeyError(f"op {name!r} not in v1 scalar core")
 
@@ -354,7 +358,7 @@ register(
             "isnan": "(isnan({a}) ? 1.0 : 0.0)",
             "isinf": "(isinf({a}) ? 1.0 : 0.0)",
             "isfinite": "(isfinite({a}) ? 1.0 : 0.0)",
-            "not": "(double)(~((long)({a})))",
+            "not": "(double)(~((long long)({a})))",
         },
         func2={
             "pow": "pow({a}, {b})",
@@ -362,11 +366,12 @@ register(
             "max": "cmax({a}, {b})",
             "mod": "fmod({a}, {b})",
             "cmp": "(({a}) > ({b}) ? 1.0 : (({a}) < ({b}) ? -1.0 : 0.0))",
-            "and": "(double)(((long)({a})) & ((long)({b})))",
-            "or": "(double)(((long)({a})) | ((long)({b})))",
-            "xor": "(double)(((long)({a})) ^ ((long)({b})))",
-            "shl": "(double)(((long)({a})) << ((long)({b})))",
-            "shr": "(double)(((long)({a})) >> ((long)({b})))",
+            # 'long long' (>=64-bit on every platform, matching Rust i64) -- C 'long' is 32-bit on Windows
+            "and": "(double)(((long long)({a})) & ((long long)({b})))",
+            "or": "(double)(((long long)({a})) | ((long long)({b})))",
+            "xor": "(double)(((long long)({a})) ^ ((long long)({b})))",
+            "shl": "(double)(((long long)({a})) << ((long long)({b})))",
+            "shr": "(double)(((long long)({a})) >> ((long long)({b})))",
         },
         cmp_tmpl="(({cond}) ? 1.0 : 0.0)",
         main_tmpl=("int main(void) {", '    printf("%.17g\\n", {fn}(2.0, 3.0, 4.0));', "    return 0;", "}"),

--- a/python/scbe/polyglot_conformance.py
+++ b/python/scbe/polyglot_conformance.py
@@ -59,6 +59,9 @@ def _close(x: Optional[float], r: Optional[float]) -> bool:
         return x is r
     if math.isnan(x) or math.isnan(r):
         return math.isnan(x) and math.isnan(r)
+    if math.isinf(x) or math.isinf(r):
+        return x == r  # require SAME signed infinity; the tolerance form below mis-handles inf
+        # (abs(inf-inf)==nan -> false DISAGREE on equal infinities; abs(inf-(-inf))==inf<=inf -> false AGREE)
     return abs(x - r) <= TOL + TOL * abs(r)
 
 

--- a/tests/test_polyglot_portable.py
+++ b/tests/test_polyglot_portable.py
@@ -89,6 +89,35 @@ def test_bitwise_domain_boundary_is_caught_not_hidden():
     assert "javascript" in rep["summary"]["disagree"]
 
 
+def test_close_handles_infinities_correctly():
+    # the comparator must require the SAME signed infinity: equal infinities AGREE, opposite ones DISAGREE.
+    # (the naive tolerance form mis-handled both: abs(inf-inf)=nan -> false DISAGREE; inf<=inf -> false AGREE)
+    from python.scbe.polyglot_conformance import _close
+
+    inf = float("inf")
+    assert _close(inf, inf) is True
+    assert _close(-inf, -inf) is True
+    assert _close(inf, -inf) is False  # a maximally-wrong opposite-sign backend must NOT be excused
+    assert _close(inf, 1.0) is False
+    assert _close(float("nan"), float("nan")) is True  # nan handling still intact
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="needs a second backend to compare against")
+def test_infinite_results_are_verified_not_falsely_flagged():
+    # neg of +inf is -inf on every face; with the _close fix the harness must AGREE, not falsely DISAGREE
+    rep = conformance(P.program_bytes("neg"), [(0, 0, float("inf"))])
+    assert rep["summary"]["disagree"] == []
+    assert rep["reference"][0] == float("-inf")
+
+
+def test_log_safe_mode_roundabout_matches_sqrt():
+    # in safe mode, log of a non-positive routes to 0.0 (the same chosen handler as sqrt), no exception
+    src = P.emit(P.program_bytes("log"), "python", safe=True)
+    ns = {}
+    exec(compile(src, "<t>", "exec"), ns)  # noqa: S102 - our own emitter output
+    assert ns["tongue_fn"](0.0, 0.0, -5.0) == 0.0  # log(-5) -> roundabout 0.0, did not raise
+
+
 def test_a_face_without_an_extension_op_raises_cleanly():
     # the per-dialect guard: a bundled track that hasn't implemented 'xor' yields a clear error, not KeyError
     unsupported = [lang for lang in P.languages() if not P._dialect_supports(P.REGISTRY[lang], "xor")]


### PR DESCRIPTION
Adversarial review of #2490 (the 22→35 portable-op growth) found **1 confirmed bug + honest gaps**. The bug is a sharp catch — my nan/inf-literal change *activated* a latent defect.

## 1. `_close` had no infinity branch (confirmed, high)
Once inf inputs actually *ran* on the js/rust backends (the new per-language literals let them), the comparator's tolerance form misjudged them:
- `abs(inf-inf)==nan` → **false DISAGREE** on equal infinities (`neg`/`abs`/`div`/`mul`/`pow` on inf wrongly flagged)
- `abs(inf-(-inf))==inf <= inf` → **false AGREE**, excusing a maximally-wrong opposite-sign-infinity backend

**Fix:** require the same signed infinity (`x == r`) before the tolerance line. Verified end-to-end (live node+rust): `neg(inf)=-inf` now AGREES instead of falsely disagreeing.

## 2. log/exp overclaimed "like sqrt's domain"
sqrt has a safe-mode roundabout; log/exp had none. **Fix:** `log` gets the same roundabout (`x≤0 → 0.0`) in safe mode; docstring now states `exp` has none (verified on non-overflowing x, raises in unsafe mode as any face would).

## 3. C bitwise cast `(long)` is 32-bit on Windows (LLP64)
Rust uses i64, so C/Rust would diverge past 2³¹ on Windows. **Fix:** cast to `long long` (≥64-bit everywhere, matches i64).

## 4. Docstring count contradiction (35 header / 32 body) → 35.

## 5. `bicameral` "kept in sync" comment clarified
Same names + same value on the valid domain, but the EXACT impls additionally guard domain edges so the pure-python fitness loop can't crash; the emit faces are bare there (verified only on the valid domain).

Tests added: `_close` infinity handling (equal AGREE, opposite DISAGREE), an infinite result is verified-not-falsely-flagged (live), and log's safe-mode roundabout. 84 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)