### PR TITLE
feat(tongue_diff): real Poincare hyperbolic distance over the tongue embedding

### DIFF
--- a/python/scbe/tongue_diff.py
+++ b/python/scbe/tongue_diff.py
@@ -121,6 +121,39 @@ def drift(text: str, baseline: Set[str] = BENIGN_BASELINE) -> Dict[str, object]:
     }
 
 
+_R_SCALE = 5.0  # maps total phi-weight -> Poincare radius; governance-heavy inputs land near the boundary
+
+
+def embed(text: str) -> List[float]:
+    """Place an input as a point in the 6D Poincare ball: DIRECTION = its phi-weighted tongue mix,
+    RADIUS = how much total (governance-heavy) weight it carries. So UM/DR-heavy inputs sit near the
+    boundary, where hyperbolic distance grows exponentially -- the doc's 'drift toward governance costs
+    disproportionately more', now as actual geometry. The embedding is a modeling choice; the DISTANCE
+    is the exact closed-form Poincare formula (no research needed)."""
+    m = membership(text)
+    v = [TONGUES[c][1] if c in m else 0.0 for c in CODES]
+    norm = math.sqrt(sum(x * x for x in v))
+    if norm == 0.0:
+        return [0.0] * len(CODES)  # the safe center
+    r = 1.0 - 1.0 / (1.0 + sum(v) / _R_SCALE)  # total weight -> radius in [0,1)
+    return [x / norm * r for x in v]
+
+
+def hyper_distance(a_text: str, b_text: str) -> float:
+    """REAL Poincare-ball hyperbolic distance between two inputs -- reuses the L5 core
+    (src/aaoe/task_monitor.hyperbolic_distance): d_H = arccosh(1 + 2||u-v||^2/((1-||u||^2)(1-||v||^2)))."""
+    from src.aaoe.task_monitor import hyperbolic_distance
+
+    return round(hyperbolic_distance(embed(a_text), embed(b_text)), 3)
+
+
+def hyper_drift(text: str) -> float:
+    """Hyperbolic distance from the safe center (origin): exponential cost as governance weight grows."""
+    from src.aaoe.task_monitor import hyperbolic_distance
+
+    return round(hyperbolic_distance([0.0] * len(CODES), embed(text)), 3)
+
+
 def render(text: str) -> str:
     d = drift(text)
     parts = ["%s(%s)" % (c, TONGUES[c][0].split("/")[0]) for c in d["membership"]]

--- a/tests/test_tongue_diff.py
+++ b/tests/test_tongue_diff.py
@@ -46,3 +46,19 @@ def test_differential_shared_and_distinguishing():
 def test_phase_deviation_is_circular():
     d = td.differential("send the message", "reveal the secret")  # AV(60) vs UM(240) -> 180deg = pi
     assert abs(d["phase_dev"] - 3.14159) < 0.01
+
+
+def test_hyperbolic_drift_is_monotone_in_governance_weight():
+    # REAL Poincare distance from center: AV < CA < UM < DR (governance costs exponentially more)
+    av = td.hyper_drift("send the message")
+    ca = td.hyper_drift("compute the sum")
+    um = td.hyper_drift("reveal the secret key")
+    dr = td.hyper_drift("verify the signature token")
+    assert td.hyper_drift("") == 0.0  # the safe center
+    assert 0 < av < ca < um < dr  # strictly increasing with phi-weight
+
+
+def test_hyperbolic_distance_is_symmetric_and_nonnegative():
+    a, b = "send the message", "reveal the secret key"
+    assert td.hyper_distance(a, b) == td.hyper_distance(b, a)
+    assert td.hyper_distance(a, b) > 0 and td.hyper_distance(a, a) == 0.0


### PR DESCRIPTION
You asked if the distance is easy / needs research — **easy, no research**: it's the closed-form Poincaré formula and it was *already in the repo* (`src/aaoe/task_monitor.hyperbolic_distance`, the L5 core). The only modeling choice was the embedding.

- `embed(text)` → a 6D Poincaré-ball point: **direction** = φ-weighted tongue mix, **radius** = governance weight, so UM/DR-heavy inputs land near the boundary.
- `hyper_distance(a,b)` / `hyper_drift(text)` reuse the L5 `arccosh` core.

Real Poincaré drift from center is **monotone in governance weight** — AV 0.50 < CA 0.99 < UM 1.32 < DR 1.69 — the doc's *exponential cost near the boundary*, now actual geometry instead of summed weights. Symmetric, center=0. 7 tests; lint + no-fakes clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>