### PR TITLE
feat(tongue_lexicon): semantic classifier on top of the grid (pluggable conlang lexicon)

### DIFF
--- a/python/scbe/tongue_lexicon.py
+++ b/python/scbe/tongue_lexicon.py
@@ -1,0 +1,87 @@
+"""tongue_lexicon: a SEMANTIC classifier on top of the token grid.
+
+The grid (tongue_diff.grid_encode / packages/sixtongues) is the ENCODING face -- bytes <-> syllables.
+This is the MEANING face: a pluggable LEXICON (tongue-specific words -> tongue + meaning) that classifies
+an input by which tongue's vocabulary its words belong to. The tongues started as CONLANGS, so the real
+classifier is a dictionary lookup against each tongue's word list.
+
+SEEDED from the real conlang word-fragments already in the repo (the 16 sixtongues prefixes per tongue:
+KO sil/kor/vel..., UM veil/zhur/nar..., etc.) -- so it works NOW on conlang text. The fuller conlang
+word->meaning dictionaries live in Issac's other systems; bring any per-tongue word list and drop it in
+with `add_wordlist` / `merge` -- same shape, no code change. Honest scope: the SEED is form-fragments,
+not full word->meaning; a richer dictionary makes the classification richer.
+
+    from python.scbe.tongue_lexicon import load_seed
+    lex = load_seed()
+    lex.classify("veil the shade in dusk")   # -> {'UM': ['veil', 'shade', 'dusk']}
+    lex.add_wordlist("CA", ["fizz", "buzz", "loop"])   # ingest more conlang/role words
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional, Sequence
+
+from .tongue_diff import _GRID_CODE, _grid
+
+_WORD = re.compile(r"[a-z']+")
+
+
+class Lexicon:
+    """tongue -> {word: meaning}. classify() = which tongue's words an input contains."""
+
+    def __init__(self) -> None:
+        self.words: Dict[str, Dict[str, str]] = {code: {} for code in _GRID_CODE}
+
+    def add(self, tongue: str, word: str, meaning: str = "") -> None:
+        self.words[tongue][word.lower().strip()] = meaning
+
+    def add_wordlist(self, tongue: str, words: Sequence[str]) -> None:
+        """Drop in a per-tongue word list (the shape Issac's conlang dictionaries provide)."""
+        for w in words:
+            if w:
+                self.add(tongue, w)
+
+    def merge(self, other: "Lexicon") -> "Lexicon":
+        for tongue, wm in other.words.items():
+            self.words.setdefault(tongue, {}).update(wm)
+        return self
+
+    def size(self) -> int:
+        return sum(len(wm) for wm in self.words.values())
+
+    def classify(self, text: str) -> Dict[str, List[str]]:
+        """{tongue: [matched words]} -- the multi-state Venn membership, now by real vocabulary."""
+        toks = set(_WORD.findall((text or "").lower()))
+        hits: Dict[str, List[str]] = {}
+        for tongue, wm in self.words.items():
+            found = sorted(t for t in toks if t in wm)
+            if found:
+                hits[tongue] = found
+        return hits
+
+    def best(self, text: str) -> Optional[str]:
+        """The dominant tongue (most matched words), or None."""
+        hits = self.classify(text)
+        return max(hits, key=lambda t: len(hits[t])) if hits else None
+
+
+def load_seed() -> Lexicon:
+    """Seed from the REAL sixtongues conlang prefixes (16 tongue-specific fragments per tongue). Real
+    vocabulary, in-repo; merge fuller word->meaning dictionaries on top when they arrive."""
+    m = _grid()
+    inv = {v: k for k, v in _GRID_CODE.items()}  # 'ko' -> 'KO'
+    lex = Lexicon()
+    for code, spec in m.TONGUES.items():
+        lex.add_wordlist(inv[code], list(spec.prefixes))
+    return lex
+
+
+if __name__ == "__main__":
+    lex = load_seed()
+    print("SEMANTIC TONGUE CLASSIFIER  (seed lexicon: %d words from the real conlang fragments)\n" % lex.size())
+    for s in ["veil the shade in dusk", "kor vel zar", "anvil forge seal the oath", "bip bop fizz the gear"]:
+        print("  %-32s -> %s   best=%s" % ("'" + s + "'", lex.classify(s), lex.best(s)))
+    print("\n  ingest a fuller word list:")
+    lex.add_wordlist("UM", ["whisper", "conceal", "shroud"])
+    print("  'conceal the whisper' ->", lex.classify("conceal the whisper"))

--- a/scripts/ci/math_claims.txt
+++ b/scripts/ci/math_claims.txt
@@ -38,3 +38,5 @@ python/scbe/process_router.py :: the assistant -- correct process injection via 
 python/scbe/code_factory.py :: warehouse-topology job orchestrator -- gate, conveyor-route, cheap station does the work, QC verifies (differential cross-check for compute), ship if ok else summon a capable manager on exception; headline metric = manager-call rate
 
 python/scbe/tongue_diff.py :: differential dimension analysis over the six sacred tongues -- multi-state venn membership across the 6 tongue dimensions + phi-weighted differential (shared vs distinguishing tongues + phase deviation); governance tongues UM/DR drift weighs more than transport
+
+python/scbe/tongue_lexicon.py :: semantic classifier on top of the tongue grid -- a pluggable lexicon (tongue-specific conlang word -> tongue + meaning) that classifies input by which tongue vocabulary its words belong to; seeded from the real sixtongues fragments, mergeable with fuller word lists

--- a/tests/test_tongue_lexicon.py
+++ b/tests/test_tongue_lexicon.py
@@ -1,0 +1,51 @@
+"""tongue_lexicon: the semantic classifier on top of the grid -- a pluggable conlang word->tongue lexicon.
+
+Proves the seed (real sixtongues conlang fragments) classifies tongue-specific words, multi-state Venn
+membership (a word shared by two tongues), and that a fuller word list drops in via add_wordlist/merge.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe import tongue_lexicon as tl  # noqa: E402
+
+
+def test_seed_classifies_conlang_words_to_the_right_tongue():
+    lex = tl.load_seed()
+    assert lex.size() == 96  # 6 tongues x 16 real conlang prefixes
+    assert lex.best("veil the shade in dusk") == "UM"  # redaction/veil tongue
+    assert lex.best("kor vel zar") == "KO"
+    assert lex.best("bip bop fizz the gear") == "CA"
+
+
+def test_multi_state_venn_a_word_shared_by_two_tongues():
+    lex = tl.load_seed()
+    hits = lex.classify("anvil forge seal the oath")
+    assert "DR" in hits  # anvil/forge/seal/oath are Draumric (auth/integrity)
+    assert "oath" in hits.get("RU", []) and "oath" in hits["DR"]  # 'oath' lives in BOTH -> Venn overlap
+
+
+def test_fuller_wordlist_drops_in():
+    lex = tl.load_seed()
+    assert lex.classify("conceal the whisper") == {}  # not in the seed
+    lex.add_wordlist("UM", ["whisper", "conceal", "shroud"])  # ingest a fuller list
+    assert lex.best("conceal the whisper") == "UM"
+
+
+def test_merge_two_lexicons():
+    a = tl.Lexicon()
+    a.add_wordlist("KO", ["qbegin"])
+    b = tl.Lexicon()
+    b.add_wordlist("DR", ["zsign"])
+    a.merge(b)
+    assert a.best("the qbegin step") == "KO"  # a's own word
+    assert a.best("the zsign here") == "DR"  # b's word, after merge
+
+
+def test_no_match_is_empty_not_a_guess():
+    lex = tl.load_seed()
+    assert lex.classify("a plain english sentence with no tongue words") == {}
+    assert lex.best("nothing here") is None


### PR DESCRIPTION
**How do we put a semantic classifier on top of the grid?** Since the tongues started as **conlangs**, the classifier is a **dictionary lookup** against each tongue's word list.

`Lexicon`: `tongue -> {word: meaning}`; `classify(text)` = which tongue's vocabulary the input's words belong to — **multi-state Venn** (a shared word lands in both, e.g. `oath` in RU+DR).

- **Seeded** from the real in-repo conlang fragments (16 `sixtongues` prefixes/tongue, 96 words) so it works *now*: `veil/shade/dusk`→UM, `kor/vel`→KO, `bip/fizz`→CA.
- **Pluggable**: `add_wordlist` / `merge` ingest your fuller word→meaning dictionaries (the ones in your other systems) with **no code change** — same shape. Demonstrated: ingesting `[whisper, conceal, shroud]`→UM classifies "conceal the whisper" instantly.

Honest: the seed is form-fragments, not full word→meaning; a richer dictionary makes the classification richer. No-match returns `{}` (never a guess). 5 tests; lint + no-fakes clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>