### PR TITLE
feat(lexicons): the full Six Sacred Tongues wordlist (AV/RU/CA/UM + KO extended)

### DIFF
--- a/lexicons/avali.json
+++ b/lexicons/avali.json
@@ -1,0 +1,23 @@
+{
+  "tongue": "AV",
+  "name": "Avali",
+  "role": "Transport/Messaging (the Common Tongue -- diplomacy, cross-paradigm bridge)",
+  "source": "Spiralverse 'Six Sacred Tongues' wordlist (Issac, canonical)",
+  "particles": {
+    "es": "collaborative marker (-together)",
+    "uni": "unity indicator (-united)",
+    "ora": "temporal present (now / currently)"
+  },
+  "words": {
+    "nos": "we / us",
+    "busca": "seek / search",
+    "sabia": "wisdom",
+    "speral": "spiral",
+    "uni": "unity",
+    "ora": "now",
+    "sabia'es": "wisdom-together",
+    "speral'uni": "spiral-united",
+    "avali'ora": "common-speech now",
+    "nos'uni": "us-united"
+  }
+}

--- a/lexicons/cassisivadan.json
+++ b/lexicons/cassisivadan.json
@@ -1,0 +1,25 @@
+{
+  "tongue": "CA",
+  "name": "Cassisivadan",
+  "role": "Compute/Transforms (Nature's Speech -- root-network wisdom, play; joy-amplification grammar)",
+  "source": "Spiralverse 'Six Sacred Tongues' wordlist (Issac, canonical)",
+  "particles": {
+    "zuni": "fun / joy intensifier",
+    "gear": "tools / making",
+    "aki": "spark / bright"
+  },
+  "words": {
+    "nos": "we",
+    "runa": "run / go fast",
+    "sapi": "knowledge / smart",
+    "spira": "spiral",
+    "zuni": "fun / joy",
+    "nunc": "now",
+    "gear": "tools / making",
+    "nog": "bright / good",
+    "rad": "excellent / amazing",
+    "sapi'gear": "smart-tools",
+    "spira'zuni": "spiral-fun",
+    "kor'aki": "heart-spark"
+  }
+}

--- a/lexicons/kor_aelin_extended.json
+++ b/lexicons/kor_aelin_extended.json
@@ -1,0 +1,39 @@
+{
+  "tongue": "KO",
+  "name": "Kor'aelin (extended -- runic letters + vocabulary from the Six Sacred Tongues wordlist)",
+  "source": "Spiralverse 'Six Sacred Tongues' wordlist (Issac, canonical); merges onto kor_aelin.json",
+  "particles": {
+    "ara": "growth / expansion"
+  },
+  "words": {
+    "arul": "origin / creation (runic letter)",
+    "belan": "balance / duality (runic letter)",
+    "calor": "clarity / illumination (runic letter)",
+    "dael": "divinity / sacred trinity (runic letter)",
+    "elar": "air / freedom (runic letter)",
+    "fen": "fire / passion (runic letter)",
+    "gaer": "earth / foundation (runic letter)",
+    "havar": "home / hearth (runic letter)",
+    "maeji": "magic power",
+    "kor'val": "heart-bond",
+    "syn'vel": "rune-awakening",
+    "lin'koral": "leyline-song",
+    "maeji'sil": "spell-weaving (collaborative casting)",
+    "sigan'ael": "time's eternal",
+    "zar'aelin": "dimensional eternity",
+    "mem'val": "memory-bond",
+    "ven'phae": "future-whisper",
+    "thul'oen": "present-spiral",
+    "mem'koral": "memory-stones (the Singing Stones)",
+    "thul'medan": "spiral-turning (evolution)",
+    "sil'thara": "unity-through (collaborative philosophy)",
+    "han'ael": "sky's breath (life force, inspiration)",
+    "sae'ra": "flowing water (natural movement, peace)",
+    "bren'kor": "fire-heart (passionate dedication)",
+    "sae'thul": "water-spiral (adaptive wisdom)",
+    "han'vel": "sky-invitation (open possibilities)",
+    "gal'oen": "earth-circle (grounding completeness)",
+    "kess'ara": "knowledge-growing",
+    "nav'een": "difference-harmony"
+  }
+}

--- a/lexicons/runethic.json
+++ b/lexicons/runethic.json
@@ -1,0 +1,25 @@
+{
+  "tongue": "RU",
+  "name": "Runethic",
+  "role": "Policy/Binding (the Ancient Tongue -- temporal anchoring, oaths; VSOT structure)",
+  "source": "Spiralverse 'Six Sacred Tongues' wordlist (Issac, canonical)",
+  "particles": {
+    "ar": "ancient / eternal aspect",
+    "syn": "together / bound",
+    "nuu": "temporal anchor (now-anchored)"
+  },
+  "words": {
+    "gol": "bind / hold",
+    "thular": "spiral-patterns",
+    "vel'ar": "guard-ancient",
+    "med'ar": "wisdom-ancient",
+    "syn'ar": "together-strong",
+    "vel'ora": "guard-present",
+    "vel'ael": "guard-eternal",
+    "med'ora": "wisdom-present",
+    "med'ael": "wisdom-eternal",
+    "thul'ora": "spiral-present",
+    "thul'ar": "spiral-ancient",
+    "thul'ael": "spiral-eternal"
+  }
+}

--- a/lexicons/umbroth.json
+++ b/lexicons/umbroth.json
@@ -1,0 +1,16 @@
+{
+  "tongue": "UM",
+  "name": "Umbroth",
+  "role": "Redaction/Privacy (the Shadow Tongue -- concealment, productive severance)",
+  "source": "Spiralverse 'Six Sacred Tongues' wordlist (Issac, canonical)",
+  "note": "The severance vocabulary below is Mal'kythric -- Umbroth's CHILD dialect (concealment hardened into severance). Assigned to UM (its parent governance tongue). WARNING in lore: pure severance stripped of grammar 'consumes its own speaker'.",
+  "words": {
+    "sek": "sever / slice (clean separation)",
+    "drath": "collapse (structural failure)",
+    "grul": "chaos / void (meaning dissolution)",
+    "phen": "calcify (hardened separation)",
+    "kraz": "wound / gap (productive emptiness)",
+    "rend": "unmake (complete severance)",
+    "azh": "void / nothing (absolute separation)"
+  }
+}

--- a/tests/test_tongue_lexicon.py
+++ b/tests/test_tongue_lexicon.py
@@ -71,3 +71,16 @@ def test_load_conlang_file_directly():
     assert data["tongue"] == "KO" and "words" in data  # valid conlang-file shape
     lex = tl.Lexicon().load_conlang(str(path))
     assert lex.best("zar'sil'ael") == "KO" and "eternal" in lex.meaning("zar'sil'ael")["KO"]
+
+
+def test_all_five_word_tongues_classify_from_real_vocab():
+    # the full Six Sacred Tongues wordlist: AV/RU/CA/UM/KO now have real words (DR has none yet)
+    full = tl.load_full()
+    assert full.size() > 200  # seed 96 + the five tongues' vocab
+    assert full.best("nos busca sabia in spiral-unity") == "AV"
+    assert full.best("gol the vel'ar med'ar oath") == "RU"
+    assert full.best("sapi'gear spira'zuni nog rad") == "CA"
+    assert full.best("sek drath grul azh the bond") == "UM"
+    assert full.best("maeji and kor'val and zar'thul") == "KO"
+    assert full.meaning("busca") == {"AV": "seek / search"}
+    assert "sever" in full.meaning("sek")["UM"]


### PR DESCRIPTION
You brought the canonical wordlist — wiring it all in. **Five tongues now classify from real vocabulary** (one JSON each, auto-merged by `load_full`):

- **Avali (AV)** — `nos/busca/sabia/speral/uni/ora` + particles (the one you asked for)
- **Runethic (RU)** — `gol/thular/vel'ar/med'ar` + `ar/syn/nuu` aspects + conjugations
- **Cassisivadan (CA)** — `sapi/spira/zuni/gear/nog/rad` + joy intensifiers
- **Umbroth (UM)** — the Mal'kythric child severance set `sek/drath/grul/phen/kraz/rend/azh`
- **Kor'aelin (KO) extended** — 8 runic letters + `maeji/kor'val/thul'medan/han'ael/…`

`seed 96 → full 234 words`; AV/RU/CA/UM/KO all classify correctly *with meanings* (`busca`→AV "seek/search", `sek`→UM "sever/slice"). **DR (Draumric)** still has only fragments — the list described it but gave no DR words, so that's the one gap. **Nal'kythraelin** is the emergent 7th (not a governance tongue) — out of scope. 12 tests; lint + no-fakes clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>