### PR TITLE
data: Six Sacred Tongues phrasebook + registry + 7th-tongue + dialects

### DIFF
--- a/lexicons/spiralverse_phrases.json
+++ b/lexicons/spiralverse_phrases.json
@@ -1,0 +1,34 @@
+{
+  "schema": "spiralverse_phrasebook_v1",
+  "note": "Reference phrasebook + dialect/variant data from the canonical Six Sacred Tongues wordlist. Deliberately has NO 'tongue'/'words' key so tongue_lexicon.load_full() SKIPS it -- phrases are multi-word and would never match the single-token classifier. This is for prose/translation + lore, not classification. The single-word vocabulary is already in the per-tongue lexicon files.",
+  "kor_aelin_sacred_phrases": {
+    "Thul'medan kess'ara": "the spiral turns, knowledge grows (general blessing)",
+    "Kor'val zeth'aelin": "heart-bond across eternal (deep commitments)",
+    "Sil'thara nav'een": "unity through difference (collaboration)",
+    "Han'vel zar'ael bren": "sky invites dimensional warmth (welcoming)",
+    "Nav'kor thul'ara": "different hearts spiraling (celebrating diversity)"
+  },
+  "tongue_registry": {
+    "KO": {"name": "Kor'aelin", "meaning": "Heart-Eternal", "function": "intent, binding, collaborative resonance"},
+    "AV": {"name": "Avali", "meaning": "Common Tongue", "function": "diplomacy, cross-paradigm bridge"},
+    "RU": {"name": "Runethic", "meaning": "Ancient Tongue", "function": "temporal anchoring, oaths"},
+    "CA": {"name": "Cassisivadan", "meaning": "Nature's Speech", "function": "root-network wisdom, play"},
+    "UM": {"name": "Umbroth", "meaning": "Shadow Tongue", "function": "concealment, productive severance"},
+    "DR": {"name": "Draumric", "meaning": "Forge Tongue", "function": "manifestation, power-binding"}
+  },
+  "nal_kythraelin_7th": {
+    "note": "Emergent 7th 'unified' tongue -- paradox grammar where contradiction is generative. NOT one of the six governance tongues; lore only.",
+    "particles": {
+      "vel'sek": "invite-severance (welcome productive cutting)",
+      "nav'aya": "difference-learn (growth through otherness)",
+      "kor'sil": "heart-together (individual + collective strength)",
+      "sil'ael": "unity-eternal (temporary + permanent cooperation)"
+    },
+    "sample": "Vel'sek nav'aya kor'sil sil'ael. -- 'Invite-severance difference-learn heart-together unity-eternal.'"
+  },
+  "dialects": {
+    "shadow_malzeth_irun": "Corrupts proper Kor'aelin: 'vel -> 'dom (domination); 'sil -> 'sep (separation). e.g. Thul'medan kess'ara -> Thul'medan'zar kess'ara (spiral-bridges-dimensions, knowledge-dominates).",
+    "sil_speak": "Simplified Kor'aelin for children -- reduced particles, simpler grammar. e.g. 'Zara vel thul' = 'Zara wants to grow'.",
+    "future_steampunk": "Kael's era -- tech integration, e.g. 'Maeji'zar gear' = magic-dimensional technology."
+  }
+}


### PR DESCRIPTION
Captures the canonical pieces NOT already in the per-tongue lexicons (#2502): KO **sacred phrases**, the **tongue registry** meanings, **Nal'kythraelin** (the emergent 7th — lore only, not a governance tongue), and the **dialect variants** (shadow-corruption, Sil'speak, steampunk). Schema has no `tongue`/`words` key on purpose, so `load_full()` skips it — phrases are multi-word and would pollute the single-token classifier; this is prose/translation + lore reference. Verified the classifier lexicon stays at 234 words.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kor'aelin sacred phrases and blessings to the language library
  * Expanded language support with six new tongue variants and their descriptions
  * Introduced dialect variations including shadow malzeth irun, sil_speak, and future_steampunk transformations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->