### PR TITLE
fix(loom): guard the reference run + enforce a portable index contract

### DIFF
--- a/python/helm/substrate_climber.py
+++ b/python/helm/substrate_climber.py
@@ -109,6 +109,9 @@ def climb_on_board(
             except Exception as e:  # a malformed board program is a fail, never a fake pass
                 note = "%s: %s" % (type(e).__name__, str(e)[:60])
                 break
+            if r.get("reference_error"):  # the reference itself could not run -> a loud, recorded fail
+                note = "reference_error: %s" % str(r["reference_error"])[:60]
+                break
             ref = r["reference"]
             if ref is not None and abs(float(ref) - float(expected)) <= 1e-9:
                 value_ok += 1

--- a/python/scbe/loomflow.py
+++ b/python/scbe/loomflow.py
@@ -270,8 +270,13 @@ def run_face(prog: Sequence[Instr], lang: str) -> Optional[float]:
 
 def verify(prog: Sequence[Instr], faces: Sequence[str] = ("python", "javascript", "rust", "c")) -> dict:
     """Run the reference, then every face that has a local toolchain; compare each honestly."""
-    ref = interpret(prog)
-    reference = ref[-1] if ref else None
+    # GUARD the reference like the face runs already are: a program whose reference raises (div-by-zero,
+    # an out-of-range index) must not crash the verifier OR hide a real divergence -- surface it.
+    try:
+        ref = interpret(prog)
+        reference, ref_error = (ref[-1] if ref else None), None
+    except Exception as e:
+        reference, ref_error = None, "%s: %s" % (type(e).__name__, e)
     results: Dict[str, dict] = {}
     for lang in faces:
         tool = _RUN.get(lang, "<none>")
@@ -283,11 +288,15 @@ def verify(prog: Sequence[Instr], faces: Sequence[str] = ("python", "javascript"
         except Exception as e:
             results[lang] = {"status": "ERROR", "value": None, "note": "%s: %s" % (type(e).__name__, e)}
             continue
+        if ref_error is not None:  # no reference to compare against -> we cannot certify agreement
+            results[lang] = {"status": "NO_REFERENCE", "value": v}
+            continue
         agree = v == reference or (v is not None and reference is not None and abs(v - reference) <= 1e-9)
         results[lang] = {"status": "AGREE" if agree else "DISAGREE", "value": v}
     verified = [lang for lang, r in results.items() if r["status"] == "AGREE"]
     return {
         "reference": reference,
+        "reference_error": ref_error,
         "results": results,
         "verified": verified,
         "verified_count": len(verified),

--- a/python/scbe/loomfn.py
+++ b/python/scbe/loomfn.py
@@ -144,6 +144,21 @@ def _arrays(prog: Sequence[Instr]) -> List[str]:
 # --- the reference interpreter -------------------------------------------------
 
 
+def _index(raw: float, length: int, op: str) -> int:
+    """The portable index contract: a non-negative, in-bounds integer. Out of contract RAISES instead
+    of guessing, because indexing is the one place the faces genuinely disagree -- Python ``h[-1]``
+    wraps to the last element, JS ``arr[-1]`` is ``undefined``, Rust ``-1 as usize`` saturates to 0, and
+    a positive OOB is an IndexError / undefined / panic respectively. Enforcing the contract in the
+    reference means any out-of-contract index surfaces as reference_error, never a silent "verified" on
+    a program whose answer depends on which language ran it."""
+    i = int(raw)
+    if not 0 <= i < length:
+        raise IndexError(
+            "index %d out of contract [0,%d) for '%s' (indices must be non-negative + in-bounds)" % (i, length, op)
+        )
+    return i
+
+
 def interpret(prog: Sequence[Instr], step_limit: int = 1_000_000) -> List[float]:
     """Run the IR directly (the reference every face is compared against); return printed values."""
     labels, funcs = _labels(prog), _funcs(prog)
@@ -188,10 +203,10 @@ def interpret(prog: Sequence[Instr], step_limit: int = 1_000_000) -> List[float]
             s[a[0]] = h[a[1]].pop()
             pc += 1
         elif op == "get":
-            s[a[0]] = h[a[1]][int(s[a[2]])]
+            s[a[0]] = h[a[1]][_index(s[a[2]], len(h[a[1]]), "get")]
             pc += 1
         elif op == "set":
-            h[a[0]][int(s[a[1]])] = s[a[2]]
+            h[a[0]][_index(s[a[1]], len(h[a[0]]), "set")] = s[a[2]]
             pc += 1
         elif op == "alen":
             s[a[0]] = float(len(h[a[1]]))
@@ -519,9 +534,18 @@ def verify(prog: Sequence[Instr], faces: Sequence[str] = ("python", "javascript"
 
     The answer is whatever the program printed last -- a number (compared within 1e-9) or text from
     `prints` (compared as an exact string). A face is AGREE only if it actually ran and matched.
+
+    The index contract is non-negative, in-bounds integers (see interpret): an out-of-contract index
+    makes the reference raise, which surfaces here as reference_error -- never a silent "verified" on a
+    program whose answer is language-dependent.
     """
-    ref = interpret(prog)
-    reference = ref[-1] if ref else None
+    # GUARD the reference like the face runs already are: a program whose reference raises (e.g. an
+    # out-of-range index, a div-by-zero) must not crash the verifier or hide a divergence -- surface it.
+    try:
+        ref = interpret(prog)
+        reference, ref_error = (ref[-1] if ref else None), None
+    except Exception as e:
+        reference, ref_error = None, "%s: %s" % (type(e).__name__, e)
     text_answer = isinstance(reference, str)
     results: Dict[str, dict] = {}
     for lang in faces:
@@ -533,6 +557,9 @@ def verify(prog: Sequence[Instr], faces: Sequence[str] = ("python", "javascript"
             line = _face_line(prog, lang)
         except Exception as e:
             results[lang] = {"status": "ERROR", "value": None, "note": "%s: %s" % (type(e).__name__, e)}
+            continue
+        if ref_error is not None:  # no trustworthy reference -> we cannot certify agreement
+            results[lang] = {"status": "NO_REFERENCE", "value": line}
             continue
         if text_answer:
             value: object = line
@@ -546,6 +573,7 @@ def verify(prog: Sequence[Instr], faces: Sequence[str] = ("python", "javascript"
     verified = [lang for lang, r in results.items() if r["status"] == "AGREE"]
     return {
         "reference": reference,
+        "reference_error": ref_error,
         "results": results,
         "verified": verified,
         "verified_count": len(verified),

--- a/tests/test_loomflow.py
+++ b/tests/test_loomflow.py
@@ -65,3 +65,22 @@ def test_javascript_face_runs_the_loop_and_agrees():
 def test_rust_face_runs_the_loop_and_agrees():
     r = verify(parse(EXAMPLES["sum_1_to_5"]), faces=("rust",))
     assert r["results"]["rust"] == {"status": "AGREE", "value": 15.0}
+
+
+def test_reference_exception_surfaces_not_crashes():
+    # div-by-zero is a real divergence point: Python raises, JS/Rust give Infinity. The reference is now
+    # guarded like the faces, so a raising reference becomes reference_error -- not a verifier crash and
+    # not a silent "verified" -- and nothing is certified.
+    prog = parse("const a 1\nconst b 0\ndiv r a b\nprint r\nhalt")
+    with pytest.raises(ZeroDivisionError):
+        interpret(prog)
+    r = verify(prog, faces=("python",))
+    assert r["reference_error"] is not None and r["reference"] is None
+    assert r["verified"] == [] and r["results"]["python"]["status"] == "NO_REFERENCE"
+
+
+def test_normal_program_is_unaffected_by_the_guard():
+    # regression: guarding the reference must not change a well-defined program's result.
+    r = verify(parse("const a 6\nconst b 7\nmul r a b\nprint r\nhalt"), faces=("python",))
+    assert r["reference"] == 42.0 and r["reference_error"] is None
+    assert r["results"]["python"]["status"] == "AGREE"

--- a/tests/test_loomfn.py
+++ b/tests/test_loomfn.py
@@ -15,7 +15,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from python.scbe.loomfn import EXAMPLES, emit, interpret, parse, verify  # noqa: E402
+from python.scbe.loomfn import EXAMPLES, _index, emit, interpret, parse, verify  # noqa: E402
 
 _HAVE_NODE = shutil.which("node") is not None
 _HAVE_RUST = shutil.which("rustc") is not None
@@ -165,3 +165,36 @@ def test_rust_face_agrees_on_arrays_and_recursion():
     for name in ("array_max", "factorial_recursive", "fib_recursive", "sum_array_fn"):
         r = verify(parse(EXAMPLES[name]), faces=("rust",))
         assert r["results"]["rust"] == {"status": "AGREE", "value": _EXPECT[name]}
+
+
+# --- index contract: the one place the faces genuinely disagree must never be silently "verified" ----
+
+
+def test_index_contract_helper_truncates_and_rejects_out_of_contract():
+    # in-bounds, non-negative: ok (fractional truncates toward zero, matching int())
+    assert _index(2.0, 5, "get") == 2
+    assert _index(2.9, 5, "get") == 2
+    assert _index(-0.5, 5, "get") == 0  # truncates to 0 -- still in contract (all three faces agree)
+    # truncates negative (Python wraps, JS undefined, Rust saturates to 0) and OOB -> reject
+    for bad in (-1.0, -1.5, 5.0, 100.0):
+        with pytest.raises(IndexError, match="out of contract"):
+            _index(bad, 5, "get")
+
+
+def test_out_of_bounds_index_is_a_reference_error_not_a_silent_pass():
+    # get index 5 from a length-1 array: Python raises, JS is undefined, Rust panics -- three behaviours.
+    # The reference enforces the contract, so verify reports reference_error and certifies NOTHING.
+    prog = parse("arr a / const v 3 / push a v / const i 5 / get r a i / print r / halt")
+    with pytest.raises(IndexError):
+        interpret(prog)
+    r = verify(prog, faces=("python",))
+    assert r["reference_error"] is not None and r["reference"] is None
+    assert r["verified"] == []  # an out-of-contract program is never "verified"
+
+
+def test_reference_exception_does_not_crash_the_verifier():
+    # the guard: a reference that raises must surface as reference_error, not propagate out of verify().
+    prog = parse("arr a / const i 0 / get r a i / print r / halt")  # get from an empty array
+    r = verify(prog, faces=("python",))
+    assert r["reference_error"] is not None
+    assert all(res["status"] != "AGREE" for res in r["results"].values())


### PR DESCRIPTION
## What

Two correctness fixes in the loom cross-face verifiers (`loomflow`, `loomfn`), surfaced while sweeping the verification layer.

### 1. Guard the reference run (was: unguarded)
`verify()` already wrapped each **face** run in try/except, but the **reference** (`interpret(prog)`) was bare. A program whose reference raised — a div-by-zero, an out-of-range index — **crashed the verifier and hid the divergence** it exists to catch.

Now the reference is guarded too: a raising reference becomes a `reference_error` field, faces report `NO_REFERENCE`, and **nothing is certified** — never a crash, never a silent "verified".

### 2. A portable index contract (was: 3 different answers per language)
Indexing is the one place the faces genuinely disagree:
- Python `h[-1]` wraps to the last element
- JS `arr[-1]` is `undefined`
- Rust `-1 as usize` saturates to `0`
- a positive over-range is `IndexError` / `undefined` / `panic`

`loomfn.interpret` now enforces a **non-negative, in-bounds integer** index contract (`_index`). An out-of-contract index raises in the reference, so it surfaces as `reference_error` rather than certifying a program whose answer depends on which language ran it. Combined with (1), the OOB divergence can no longer slip through as a silent pass.

### Consumer update
`substrate_climber` reads the new `reference_error` field so a malformed board program is still a **loud, recorded note** (it previously relied on `verify()` crashing).

## Tests
- `_index` helper: truncates toward zero, rejects negative-after-truncation + OOB
- out-of-contract index → `reference_error`, certifies nothing
- reference exception surfaces (not crashes) the verifier
- normal programs unaffected (regression)

41 loom tests pass (`test_loomfn`, `test_loomflow`, `test_loomtongue`, `test_substrate_climber`); `black` + `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)