### PR TITLE
docs(govern-mcp): make the audit_log seal claim precise (no over-trust)

### DIFF
--- a/src/mcp/scbe_govern_mcp.py
+++ b/src/mcp/scbe_govern_mcp.py
@@ -208,9 +208,12 @@ def action_channels(action: str) -> str:
 @mcp.tool(annotations=_READONLY)
 def audit_log() -> str:
     """The sealed receipt transcript for this server process + a chain-integrity check. The seal is
-    FORWARD-CHAINED (reorder/insert/delete/rewrite break chain_ok), so it is tamper-evident -- but only
-    WITHIN this running process: the transcript is in memory and resets on restart. For a durable audit,
-    persist it (and the registry nonce) externally. Tamper-evidence, not proof of safety."""
+    FORWARD-CHAINED: a reorder/insert/delete/rewrite that does NOT re-chain breaks chain_ok. HONEST limit
+    (don't over-trust this) -- the seal is UNKEYED and anchored on the in-memory registry nonce, so it
+    catches accidental corruption and un-re-chained tampering, NOT an in-process forger who reads the
+    nonce and re-chains the whole list; it is also in memory and resets on restart. For a durable,
+    custody-grade audit, persist the transcript to an external append-only sink or HMAC it with an
+    off-host key. This is integrity (tamper-evidence), not proof of safety or custody."""
     return _dump(_audit_log())
 
 


### PR DESCRIPTION
## What

A background red-team flagged that the `scbe-govern` MCP server advertised a seal stronger than the code provides. The screens are now real (PR #2509), and the `desktop_access` `_seal`/`verify` docstrings were made honest there. This aligns the **user-facing** `audit_log` tool docstring with that honesty.

The seal is an **unkeyed** SHA-256 forward chain anchored on the **in-memory** registry nonce. It catches accidental corruption and un-re-chained tampering (a partial edit, reorder, insert, delete) — **but not** an in-process forger who reads the nonce and re-chains the whole list, and it resets on restart. The old wording ("tamper-evident") over-promised.

Durable, custody-grade audit needs an external append-only sink or an off-host HMAC. This is **integrity, not custody.**

Why it matters: the user relies on these tool descriptions without reading the underlying output, so an overstated audit claim could lead to trusting a transcript a local attacker forged.

## Verification
Doc-only change. 10 `scbe_govern_mcp` tests pass, `--self-test` OK, `black` + `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)