### PR TITLE
style: format CodeQL follow-up files

### DIFF
--- a/scripts/system/scbe_skill_tool_bridge.mjs
+++ b/scripts/system/scbe_skill_tool_bridge.mjs
@@ -76,7 +76,9 @@ function readSkill(path) {
 
 const skills = findSkillFiles(SKILLS_DIR).map(readSkill);
 
-console.log(`[skill-bridge] Found ${skills.length} skill(s): ${skills.map((skill) => skill.name).join(', ')}`);
+console.log(
+  `[skill-bridge] Found ${skills.length} skill(s): ${skills.map((skill) => skill.name).join(', ')}`
+);
 
 for (const skill of skills) {
   const id = relative(SKILLS_DIR, dirname(skill.path));

--- a/scripts/youtube/upload.js
+++ b/scripts/youtube/upload.js
@@ -63,7 +63,10 @@ function cleanCategoryId(value) {
 
 function cleanTags(value) {
   if (!Array.isArray(value)) return [];
-  return value.map((tag) => cleanText(tag, 60)).filter(Boolean).slice(0, 30);
+  return value
+    .map((tag) => cleanText(tag, 60))
+    .filter(Boolean)
+    .slice(0, 30);
 }
 
 function safeReceiptPath(value) {
@@ -89,7 +92,9 @@ function processingSummary(processing) {
   if (!processing || typeof processing !== 'object') return null;
   return {
     ok: Boolean(processing.ok),
-    status: cleanText(processing.details?.processingStatus || processing.details?.reason || '', 128) || null,
+    status:
+      cleanText(processing.details?.processingStatus || processing.details?.reason || '', 128) ||
+      null,
   };
 }
 

--- a/tests/agent/customer_support_triage.test.ts
+++ b/tests/agent/customer_support_triage.test.ts
@@ -35,10 +35,7 @@ vi.mock('@openai/agents', () => {
 });
 
 // Import AFTER mock is established
-import {
-  runWorkflow,
-  TriageCategory,
-} from '../../workflows/openai/customer_support_triage.js';
+import { runWorkflow, TriageCategory } from '../../workflows/openai/customer_support_triage.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- apply Prettier to the files changed by #2522 so the lint/format check passes

## Local validation
- `npx prettier --check scripts/system/scbe_skill_tool_bridge.mjs scripts/video/quality_gate.js scripts/youtube/upload.js tests/agent/customer_support_triage.test.ts tests/fleet/drone-fleet.test.ts`
- `node --check scripts/youtube/upload.js`
- `node --check scripts/video/quality_gate.js`
- `node --check scripts/system/scbe_skill_tool_bridge.mjs`
- `git diff --check`