### PR TITLE
fix(api): authOk fails closed (regression from #2465 merge) — greens main

### DIFF
--- a/api/_agent_common.js
+++ b/api/_agent_common.js
@@ -71,7 +71,7 @@ function envConfig() {
 }
 
 function authOk(req, cfg) {
-  if (!cfg.dispatchSecret) return true;
+  if (!cfg.dispatchSecret) return false;
   const bearer = String(req.headers.authorization || "").replace(/^Bearer\s+/i, "");
   const headerSecret = String(req.headers["x-agent-dispatch-secret"] || "");
   return bearer === cfg.dispatchSecret || headerSecret === cfg.dispatchSecret;


### PR DESCRIPTION
## Problem

`ci.yml` `Test (Node 20)` is failing on `main`: `tests/agent_dispatch_auth.test.ts > "fails closed when AGENT_DISPATCH_SECRET is unset"` — `expected true to be false`.

## Cause

When I resolved #2465's merge conflict I took main's `api/_agent_common.js` via `git checkout --theirs`, which reverted `authOk` to the **fail-open** `if (!cfg.dispatchSecret) return true;` and dropped #2465's actual fix (`return false`). The PR's whole purpose was to make dispatch auth fail closed; my resolution accidentally reverted it.

## Fix

One line: `return true` → `return false`. Restores #2465's intended fail-closed contract.

(The dispatch handler already returns 503 on a missing secret before calling `authOk`, so the live endpoint was not exposed — but the unit contract and security default is fail-closed.)

## Verify

`npx vitest run tests/agent_dispatch_auth.test.ts` → **2/2 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests without a properly configured dispatch secret are now denied instead of being allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->