### PR TITLE
fix(colab): land validated colab_run onto main (supersedes #2524)

### DIFF
--- a/tools/colab/README.md
+++ b/tools/colab/README.md
@@ -1,63 +1,58 @@
-# colab_run — drive a Colab notebook from the terminal
+# colab_run — drive a hosted Colab notebook from the terminal
 
-Google offers **no headless CLI for hosted Colab**, so the robust way to run a paid-Colab notebook from
-the terminal is to reuse *your own authenticated browser session*. You launch Chrome once with a remote
-debugging port and log into Colab; `colab_run.py` attaches over CDP (Playwright `connect_over_cdp`),
-opens the notebook, runs all cells, waits out the run, and prints the result back to your terminal.
-
-## Setup (one time)
-
-Start Chrome with a debugging port and a dedicated profile, then log into Colab in that window:
-
-```bat
-"C:\Program Files\Google\Chrome\Application\chrome.exe" ^
-  --remote-debugging-port=9222 ^
-  --user-data-dir="%USERPROFILE%\.colab-cdp-profile"
-```
-
-(Use a *separate* `--user-data-dir` so the debug port opens reliably and your normal profile is untouched.)
+Google offers **no headless CLI** for hosted Colab, and it **blocks sign-in in a Playwright-launched
+browser** (the automation flag trips Chrome's "unsupported command-line flag" bar and Google's "this
+browser may not be secure" wall). The path that actually works — validated live — is to launch a
+**plain `chrome.exe`** ourselves with only a debug port (no automation flags, so Google lets you sign
+in), then **attach over CDP** and drive the notebook. Attaching adds no automation flag, so the login
+goes through and the session persists.
 
 ## Run
 
 ```bash
-# 1. confirm the tool can attach + load the notebook (no execution)
-python tools/colab/colab_run.py --dry-run
+# first time: opens a window, you do the ONE-TIME Google sign-in, then it verifies and closes
+python tools/colab/colab_run.py --dry-run --keep-open 240
 
-# 2. run all cells and wait for the result (default notebook = the VTC lift harness)
-python tools/colab/colab_run.py --run
+# run the notebook: run-all, feed the corpus, wait, print the result
+python tools/colab/colab_run.py --run --upload "C:/path/to/vtc_mbpp_refined.jsonl"
 ```
 
-It polls the rendered output for a **completion marker** (`NET LIFT` for the VTC notebook — what
-`code_lift.render()` prints last) and prints the matching block. Override per notebook with
-`--done-marker "<text the last cell prints>"`.
+The first run pops a Chrome window for the **one-time Google login** (a human must do it — Google blocks
+automated credential entry). The login persists in the profile, so every later run is zero-touch. The
+tool then opens the notebook, handles the **"Run anyway" / Connect** prompts, runs all cells, and
+**feeds `--upload` into the notebook's `files.upload()` cell** so the run never blocks on a file dialog.
+Completion is detected by polling the outputs for `--done-marker` (default `NET LIFT`, what the VTC
+notebook's `code_lift.render()` prints) — your notebook's own result, not Colab's brittle run-state DOM.
 
-Useful flags: `--notebook <url|catalog-name>`, `--timeout <seconds>` (default 5400 = 90 min for a
-training run), `--port <cdp-port>`, `--launch` (own Chrome + `--profile` instead of attach),
-`--upload <file>` (best-effort: feed a pending `files.upload()` input).
+## Flags
 
-## Corpus delivery (the VTC notebook)
+| Flag | Meaning |
+|------|---------|
+| `--run` / `--dry-run` | execute, or just launch + load (verify / sign in) |
+| `--upload <file>` | local corpus fed into the notebook's `files.upload()` cell during the run |
+| `--notebook <url\|name>` | a Colab URL, a catalog name, or omit for the VTC lift notebook |
+| `--profile <dir>` | persistent Chrome profile (login persists here; default `~/.colab-cdp-profile`) |
+| `--port <n>` | Chrome debug port (launched for you; or your own with `--attach`) |
+| `--attach` | attach to a Chrome **you** started with `--remote-debugging-port` instead of launching one |
+| `--done-marker <text>` | output text that signals completion (default `NET LIFT`) |
+| `--timeout <s>` / `--login-timeout <s>` | max wait for the result (default 90 min) / for the one-time sign-in |
+| `--chrome-path <exe>` | path to `chrome.exe` (auto-detected if omitted) |
 
-The notebook's cell 2 tries **Drive → URL → upload**. For an *unattended* terminal run, set one so it
-never blocks on a dialog: put the corpus on Drive at `DRIVE_CORPUS`, or set `CORPUS_URL` to a secret
-gist/release raw URL. Manual `files.upload()` is the fallback.
+## Why this design (and what didn't work)
 
-## Transport options (your call: #1 now; #2/#3 documented)
-
-| # | Mode | How | When |
-|---|------|-----|------|
-| **1** | **Attach (default)** | `connect_over_cdp` to the Chrome you started with `--remote-debugging-port` | **Recommended now.** Reuses your live Google login, no re-auth, works with hosted paid Colab. |
-| 2 | Launch | `--launch` opens its own Chrome with a persistent `--profile` you log into once | If you can't expose a debug port. Google may flag automation in that profile. |
-| 3 | Runtime socket | Talk to the Jupyter kernel directly, no UI | Most robust *ceiling* — but for **hosted** Colab the kernel endpoint is proxied/rotated by Google and not cleanly extractable. Only pays off for a **local/self-hosted** runtime (see `scbe-n8n-colab-bridge`). |
-
-**Most-robust verdict for hosted paid Colab: option 1.** Option 3's "no brittle DOM" advantage only
-materializes when you control the runtime; against hosted Colab it isn't reliably reachable, so attach
-(#1) is both the now-path and the most robust *practical* choice. #2 is the fallback if a debug port
-isn't an option.
+- **Playwright-launched Chrome → blocked.** `launch`/`launch_persistent_context` set `--enable-automation`
+  + `navigator.webdriver`, which Google detects → "browser may not be secure", no login. Don't use it.
+- **Plain `chrome.exe` + `connect_over_cdp` → works.** No automation flag is set, so Google treats it as
+  a normal browser and the sign-in succeeds; CDP-attach then drives it.
+- **Runtime-socket (drive the Jupyter kernel directly, no UI)** is the most robust *ceiling*, but for
+  **hosted** Colab the kernel endpoint is proxied/rotated by Google and not cleanly reachable — it only
+  pays off for a local/self-hosted runtime (see `scbe-n8n-colab-bridge`). So attach-to-real-Chrome is the
+  best practical option for hosted paid Colab.
 
 ## Honest caveat
 
 Colab's UI is not a stable automation target. Run-all uses the `Ctrl+F9` shortcut (more durable than
-clicking the menu), and completion is detected by *your notebook's own printed marker* (not Colab's
-run-state DOM) — both deliberately robust. The trust-dialog / Connect-button selectors are best-effort
-and may need a one-line tweak on the first live run; `--dry-run` lets you confirm attach + load first.
-Reuses the repo's notebook catalog (`scripts/system/colab_workflow_catalog.py`) for `--notebook <name>`.
+clicking the menu); the trust-dialog / Connect / sign-in selectors are best-effort and may need a
+one-line tweak on a first live run. `--dry-run` confirms attach + load before a long training run. The
+corpus cell on the VTC notebook tries Drive → URL → upload; for a fully unattended run, prefer the
+`--upload` feed (corpus stays local) or set `CORPUS_URL`/`DRIVE_CORPUS` in the notebook.

--- a/tools/colab/colab_run.py
+++ b/tools/colab/colab_run.py
@@ -1,36 +1,39 @@
-"""colab_run: drive a Colab notebook from the terminal by attaching to YOUR already-running Chrome.
+"""colab_run: drive a hosted Colab notebook from the terminal, in a real (logged-in) Chrome.
 
-Google ships no headless CLI for hosted Colab, so the robust path is to reuse your authenticated
-browser session: launch Chrome ONCE with --remote-debugging-port, log into Colab, then this tool
-attaches over CDP (Playwright connect_over_cdp), opens the notebook, runs all cells, waits out the
-run, and prints the output that contains a completion marker back to your terminal.
+Google ships no headless CLI for hosted Colab, and it BLOCKS sign-in in a Playwright-launched browser
+(the --enable-automation flag trips Chrome's 'unsupported command-line flag' bar + Google's 'this
+browser may not be secure' wall). The robust path, validated live: launch a PLAIN chrome.exe ourselves
+with only a debug port (no automation flags, so Google lets you sign in), ATTACH over CDP (attaching
+adds no automation flag), open the notebook, run all cells (Ctrl+F9), and print the output block that
+contains a completion marker back to your terminal.
 
-TRANSPORTS (this implements #1; #2 is a flag; #3 is documented):
-  1. ATTACH (default, recommended NOW): connect to a running Chrome you started with
-     --remote-debugging-port=9222 -- reuses your live Google login, no re-auth, works with HOSTED
-     paid Colab. The most robust PRACTICAL choice for hosted Colab.
-  2. LAUNCH (--launch): Playwright opens its own Chrome with a persistent --profile you log into once.
-     Use if you cannot expose a debug port. Google may flag automation in that profile.
-  3. RUNTIME SOCKET (not built here): talk to the Jupyter kernel directly, bypassing the UI -- the most
-     robust ceiling, but for HOSTED Colab the kernel endpoint is proxied/rotated by Google and not
-     cleanly extractable. It only pays off for a LOCAL/self-hosted runtime (see scbe-n8n-colab-bridge).
+FLOW (default):
+  1. We start chrome.exe with --remote-debugging-port + a persistent --profile (login persists there).
+  2. First run only: a window opens; you do the ONE-TIME Google sign-in (a human must -- Google blocks
+     automated credential entry). The tool waits for it, then proceeds; later runs are zero-touch.
+  3. It attaches over CDP, opens the notebook, handles the 'Run anyway'/Connect prompts, runs all, and
+     feeds --upload into the notebook's files.upload() cell so the run never blocks on the file dialog.
+  4. Completion is detected by polling the OUTPUTS for --done-marker (YOUR notebook's printed result,
+     e.g. 'NET LIFT'), not Colab's brittle run-state DOM.
 
-SETUP (one time, on the machine with your browser):
-  Windows:  "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
-              --remote-debugging-port=9222 --user-data-dir="%USERPROFILE%\\.colab-cdp-profile"
-  Log into Colab in that window, then:
-  python tools/colab/colab_run.py --dry-run                       # confirm attach + notebook load
-  python tools/colab/colab_run.py --run                           # run-all, wait, print the result
+  python tools/colab/colab_run.py --dry-run --keep-open 240    # open + (first time) sign in; verify
+  python tools/colab/colab_run.py --run --upload corpus.jsonl  # run-all, wait, print the result
 
-DOM caveat: Colab's UI is not a stable automation target. Run-all uses the Ctrl+F9 shortcut (robust);
-completion is detected by polling for --done-marker in the outputs (robust -- it watches YOUR notebook's
-printed result, not Colab's run-state DOM). The trust-dialog / Connect-button selectors are best-effort;
---dry-run lets you confirm the attach + load before committing to a long training run.
+  --attach connects to a debug Chrome you started yourself instead of launching one. A LOCAL/self-hosted
+  runtime could be driven over its Jupyter socket directly (most robust, no UI) -- but for HOSTED Colab
+  that endpoint is proxied/rotated by Google, so attach-to-real-Chrome is the best practical option.
+
+DOM caveat: Colab's UI is not a stable automation target; the trust-dialog / Connect / sign-in selectors
+are best-effort and may need a one-line tweak. --dry-run confirms attach + load before a long run.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
+import shutil
+import socket
+import subprocess
 import sys
 import time
 from typing import Any, Optional
@@ -41,10 +44,53 @@ DEFAULT_NOTEBOOK = (
     "notebooks/vtc_lift_qwen15_colab.ipynb"
 )
 DEFAULT_MARKER = "NET LIFT"  # code_lift.render() prints this at the very end of the run
+_CHROME_CANDIDATES = [
+    r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+    r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+    os.path.expanduser(r"~\AppData\Local\Google\Chrome\Application\chrome.exe"),
+]
 
 
 def _log(msg: str) -> None:
     print("[colab_run] %s" % msg, file=sys.stderr, flush=True)
+
+
+def _chrome_path(explicit: Optional[str] = None) -> str:
+    """Find a real chrome.exe. We launch Chrome OURSELVES (not via Playwright) so it carries NO
+    --enable-automation flag -- that flag triggers Chrome's 'unsupported command-line' bar AND Google's
+    'this browser may not be secure' login block. A plainly-launched Chrome lets you sign in normally."""
+    for c in [explicit] + _CHROME_CANDIDATES:
+        if c and os.path.exists(c):
+            return c
+    found = shutil.which("chrome") or shutil.which("chrome.exe")
+    if found:
+        return found
+    raise SystemExit("could not find chrome.exe -- pass --chrome-path")
+
+
+def _port_open(port: int, host: str = "127.0.0.1") -> bool:
+    s = socket.socket()
+    s.settimeout(1)
+    try:
+        return s.connect_ex((host, port)) == 0
+    finally:
+        s.close()
+
+
+def _launch_chrome(chrome: str, port: int, profile: str, url: str) -> "subprocess.Popen":
+    """Start a NORMAL Chrome with a debugging port + persistent profile (login persists, and is done in a
+    non-automated browser so Google allows it). Returns the process; Playwright then attaches over CDP."""
+    os.makedirs(profile, exist_ok=True)
+    args = [
+        chrome,
+        "--remote-debugging-port=%d" % port,
+        "--user-data-dir=%s" % profile,
+        "--no-first-run",
+        "--no-default-browser-check",
+        url,
+    ]
+    _log("launching Chrome with a debug port (sign in normally if prompted -- Google allows it here)")
+    return subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 def resolve_notebook(name_or_url: Optional[str]) -> str:
@@ -143,17 +189,73 @@ def _extract_block(text: str, marker: str) -> Optional[str]:
     return text[start if start >= 0 else 0 :].strip()
 
 
-def wait_for_marker(page: Any, marker: str, timeout_s: int, poll_s: int = 15) -> Optional[str]:
-    """Poll the rendered outputs until `marker` appears (the run finished and printed its result), or
-    timeout. Returns the output block containing the marker, or None on timeout."""
+def _feed_upload(page: Any, upload: str) -> bool:
+    """Hand the local corpus to a pending files.upload() input. Colab renders that widget inside a
+    sandboxed OUTPUT IFRAME, so the <input type=file> is NOT in the main frame -- search EVERY frame and
+    set the first one found (this is the fix that made the upload feed actually work)."""
+    for fr in page.frames:
+        try:
+            el = fr.query_selector("input[type=file]")
+            if el:
+                el.set_input_files(upload, timeout=5000)
+                _log("fed corpus %s to the notebook's upload cell" % upload)
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _signed_in(page: Any) -> bool:
+    """True only on a POSITIVE logged-in signal (avatar, or the 'New notebook' UI that Colab shows only
+    when authed). Requiring a positive signal avoids the race where a half-loaded/redirecting page has an
+    empty body and a mere absence-of-'sign in' check false-positives."""
+    try:
+        return bool(
+            page.evaluate(
+                "() => {"
+                "  const t=(document.body&&document.body.innerText)||'';"
+                "  if (t.length<30) return false;"
+                "  if ((location.host||'').includes('accounts.google.com')) return false;"
+                "  if (/\\bnew notebook\\b/i.test(t)) return true;"
+                "  if (document.querySelector('[aria-label*=\"Google Account\"]')) return true;"
+                "  if (document.querySelector('a[href*=\"SignOutOptions\"]')) return true;"
+                "  return false;"
+                "}"
+            )
+        )
+    except Exception:
+        return False
+
+
+def wait_for_login(page: Any, timeout_s: int, poll_s: int = 5) -> bool:
+    """Hold the window open and poll until the human completes Google's sign-in (Google blocks automated
+    credential entry, so the login itself is the one manual step). Returns True once signed in."""
     deadline = time.time() + timeout_s
     while time.time() < deadline:
+        if _signed_in(page):
+            return True
+        _log("waiting for Google sign-in in the open window... (%ds left)" % int(deadline - time.time()))
+        page.wait_for_timeout(poll_s * 1000)
+    return False
+
+
+def wait_for_marker(
+    page: Any, marker: str, timeout_s: int, poll_s: int = 12, upload: Optional[str] = None
+) -> Optional[str]:
+    """Poll the rendered outputs until `marker` appears (the run finished and printed its result), or
+    timeout. Along the way, feed `upload` to a files.upload() input if/when one appears (so a
+    terminal-driven run never blocks on the file dialog). Returns the matching block, or None."""
+    deadline = time.time() + timeout_s
+    fed = upload is None
+    while time.time() < deadline:
+        if not fed:
+            fed = _feed_upload(page, upload)
         text = _outputs_text(page)
         block = _extract_block(text, marker)
         if block is not None:
             return block
         remaining = int(deadline - time.time())
-        _log("running... (%ds left, %d chars of output so far)" % (remaining, len(text)))
+        _log("running... (%ds left, %d chars of output)" % (remaining, len(text)))
         page.wait_for_timeout(poll_s * 1000)
     return None
 
@@ -167,23 +269,27 @@ def run(args: argparse.Namespace) -> int:
     url = resolve_notebook(args.notebook)
     _log("notebook: %s" % url)
     with sync_playwright() as p:
-        if args.launch:
-            _log("LAUNCH mode: own Chrome, persistent profile %s (log into Colab if prompted)" % args.profile)
-            ctx = p.chromium.launch_persistent_context(args.profile, headless=False)
-            browser = ctx.browser
+        # NEVER let Playwright LAUNCH Chrome -- that adds --enable-automation, which trips Chrome's
+        # 'unsupported command-line flag' bar AND Google's 'this browser may not be secure' login block.
+        # Instead launch a plain chrome.exe with a debug port ourselves and ATTACH over CDP (attaching
+        # adds no automation flag, so Google lets you sign in). A debug Chrome left open is reused.
+        if not args.attach and not _port_open(args.port):
+            _launch_chrome(_chrome_path(args.chrome_path), args.port, args.profile, url)
+            for _ in range(60):
+                if _port_open(args.port):
+                    break
+                time.sleep(0.5)
+        if not _port_open(args.port):
+            raise SystemExit(
+                "no Chrome debug port on %d (launch failed; or start Chrome yourself and use --attach)" % args.port
+            )
+        _log("attaching over CDP on port %d" % args.port)
+        browser = p.chromium.connect_over_cdp("http://localhost:%d" % args.port)
+        page = _find_colab_page(browser, url)
+        if page is None:
+            ctx = browser.contexts[0] if browser.contexts else browser.new_context()
             page = ctx.pages[0] if ctx.pages else ctx.new_page()
-        else:
-            _log("ATTACH mode: connecting to Chrome on CDP port %d" % args.port)
-            browser = p.chromium.connect_over_cdp("http://localhost:%d" % args.port)
-            page = _find_colab_page(browser, url)
-            if page is None:
-                ctx = browser.contexts[0] if browser.contexts else browser.new_context()
-                page = ctx.pages[0] if ctx.pages else ctx.new_page()
 
-        if args.upload:  # best-effort: hand a local file to a pending files.upload() input
-            _log("will try to satisfy a files.upload() input with %s" % args.upload)
-
-        # always (re)load the target notebook so we know what is running
         open_notebook(page, url)
         cells = 0
         try:
@@ -193,19 +299,35 @@ def run(args: argparse.Namespace) -> int:
         _log("notebook loaded (%s cells detected)" % cells)
 
         if args.dry_run:
-            print("DRY RUN ok: attached + loaded the notebook. Re-run with --run to execute.")
+            signed_in = _signed_in(page)
+            print("DRY RUN ok: Chrome up + notebook loaded (%s cells). Google signed-in: %s." % (cells, signed_in))
+            if not signed_in:
+                print(
+                    "  -> log into Google ONCE in the open window; the profile %s persists for later runs."
+                    % args.profile
+                )
+            print("Re-run with --run to execute (corpus auto-fed via --upload; result printed here).")
+            if args.keep_open:
+                _log("keeping the window open %ds for you to sign in..." % args.keep_open)
+                page.wait_for_timeout(args.keep_open * 1000)
             return 0
 
-        if args.upload:
-            try:
-                page.set_input_files("input[type=file]", args.upload, timeout=8000)
-                _log("uploaded %s into a file input" % args.upload)
-            except Exception as exc:
-                _log("no file input ready (%s); prefer Drive/URL delivery in the notebook" % exc)
+        # one-time Google login: hold the open window, wait for the human to sign in, then persist+proceed
+        if not args.attach and not _signed_in(page):
+            print("\n>>> A Chrome window is open. Sign into your Google (paid-Colab) account in it.")
+            print(">>> ONE-TIME login -- it persists in %s; future runs won't ask.\n" % args.profile)
+            page.goto("https://colab.research.google.com/", wait_until="domcontentloaded", timeout=60000)
+            page.wait_for_timeout(1500)
+            _click_text(page, ["Sign in", "Sign In"])  # open Google's login flow for you
+            if not wait_for_login(page, args.login_timeout):
+                print("Not signed in after %ds; the window is still open -- sign in and re-run." % args.login_timeout)
+                return 3
+            _log("signed in -- reloading the notebook and running")
+            open_notebook(page, url)
 
         _log("triggering Run all (Ctrl+F9)...")
         run_all(page)
-        block = wait_for_marker(page, args.done_marker, args.timeout)
+        block = wait_for_marker(page, args.done_marker, args.timeout, upload=args.upload)
         if block is None:
             print("TIMEOUT after %ds without seeing marker %r." % (args.timeout, args.done_marker))
             print("The run may still be going -- check the browser, or raise --timeout.")
@@ -220,17 +342,34 @@ def main(argv: Optional[list] = None) -> int:
         prog="colab-run", description="drive a Colab notebook from the terminal via your browser"
     )
     ap.add_argument("--notebook", default=None, help="Colab URL, a catalog name, or omit for the VTC lift notebook")
-    ap.add_argument("--port", type=int, default=9222, help="CDP port of your running Chrome (ATTACH mode)")
     ap.add_argument(
-        "--launch", action="store_true", help="LAUNCH mode: own Chrome + persistent profile instead of attach"
+        "--attach",
+        action="store_true",
+        help="attach to a Chrome you started with --remote-debugging-port (vs the default: launch our own)",
     )
-    ap.add_argument("--profile", default=".colab-cdp-profile", help="profile dir for --launch mode")
-    ap.add_argument("--upload", default=None, help="best-effort: local file to feed a pending files.upload() input")
+    ap.add_argument(
+        "--port", type=int, default=9222, help="Chrome debug port (launched for you, or your own with --attach)"
+    )
+    ap.add_argument(
+        "--profile",
+        default=os.path.expanduser("~/.colab-cdp-profile"),
+        help="persistent Chrome profile dir (login persists here)",
+    )
+    ap.add_argument("--chrome-path", default=None, help="path to chrome.exe (auto-detected if omitted)")
+    ap.add_argument(
+        "--upload", default=None, help="local corpus file fed to the notebook's files.upload() cell during the run"
+    )
     ap.add_argument(
         "--done-marker", default=DEFAULT_MARKER, help="text that signals the run finished (default: 'NET LIFT')"
     )
     ap.add_argument("--timeout", type=int, default=5400, help="max seconds to wait for the marker (default 90 min)")
-    ap.add_argument("--dry-run", action="store_true", help="attach + load the notebook, but do NOT run (verify setup)")
+    ap.add_argument("--login-timeout", type=int, default=600, help="seconds to wait for a one-time Google sign-in")
+    ap.add_argument(
+        "--keep-open", type=int, default=0, help="with --dry-run: hold the window open N seconds (to sign in)"
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="launch + load the notebook, but do NOT run (verify setup / sign in)"
+    )
     ap.add_argument("--run", action="store_true", help="run all cells and wait for the result")
     a = ap.parse_args(list(argv) if argv is not None else None)
     if not (a.run or a.dry_run):


### PR DESCRIPTION
Conflict-free re-land of the validated tool fixes from #2524 (which hit the squash-divergence conflict). Plain chrome.exe + CDP-attach (Google login works), one-time login wait, persistent profile, iframe upload feed. Proven live end-to-end. 5 tests pass, lint clean. Closes #2524.