### PR TITLE
fix(generator): robust strip_to_code (repair loop + harvest were mis-extracting)

### DIFF
--- a/python/helm/free_generator.py
+++ b/python/helm/free_generator.py
@@ -45,9 +45,21 @@ def _chat(messages, *, base: str, key: str, model: str, timeout: int = 120) -> s
 
 
 def strip_to_code(text: str) -> str:
-    """Pull the code out of a model reply (handles ```python fences or bare code)."""
-    m = re.search(r"```(?:python)?\s*(.*?)```", text or "", re.S)
-    return (m.group(1) if m else (text or "")).strip()
+    """Pull the code out of a model reply. Robust to: fenced ```python blocks (takes the LARGEST), a
+    truncated/unclosed fence, bare code with no fences, and leading prose before the first code line.
+
+    The naive version (return-whole-text when no closing fence) silently fed prose/markdown into the
+    verifier, so good solutions failed to parse -- which crushed the repair-loop + harvest solve rates.
+    This is the same extraction the lift notebook uses; fixing it here lifts every caller at once."""
+    blocks = re.findall(r"```(?:python)?\s*(.*?)```", text or "", re.S)
+    if blocks:
+        return max(blocks, key=len).strip()
+    body = re.sub(r"^\s*```(?:python)?\s*", "", (text or "").strip())  # drop a dangling open fence
+    lines = body.splitlines()
+    for i, ln in enumerate(lines):
+        if ln.lstrip().startswith(("def ", "import ", "from ", "class ", "@")):
+            return "\n".join(lines[i:]).strip()
+    return body.strip()
 
 
 def make_generator(

--- a/tests/test_free_generator.py
+++ b/tests/test_free_generator.py
@@ -10,6 +10,16 @@ def test_strip_to_code_handles_fences_and_bare():
     assert fg.strip_to_code("def g():\n    return 2") == "def g():\n    return 2"
 
 
+def test_strip_to_code_robust_cases():
+    # leading prose before bare code (the old version returned the prose too -> failed to parse)
+    assert fg.strip_to_code("Sure, here it is:\ndef g(x):\n    return x + 1") == "def g(x):\n    return x + 1"
+    # truncated / unclosed fence (a cut-off generation)
+    assert fg.strip_to_code("```python\ndef h():\n    return 2") == "def h():\n    return 2"
+    # two blocks -> take the largest (the real solution, not a one-liner example)
+    got = fg.strip_to_code("```\nx = 1\n``` then ```python\ndef big():\n    return 99\n```")
+    assert "def big" in got and "return 99" in got
+
+
 def test_generator_with_mocked_correct_model(monkeypatch):
     probs = load_fixture()
 


### PR DESCRIPTION
The recovery-lift run exposed it: base solved only 2/20 in the repair loop (1.5B should be ~20%) because solve_with_trace + the harvest engine call the NAIVE strip_to_code, which returns the whole reply on an unclosed fence → prose fed to the verifier → good solutions fail to parse. Same bug class the lift notebook fixed for single-shot, but live in the repair path. Now: largest fenced block; else strip dangling fence + drop prose to first code line; bare code. One fix lifts every caller. Tests added; 23 dependent tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of generated code outputs for more accurate handling of complex formatting scenarios, including multiple code segments and truncated blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->