### PR TITLE
feat(vtc): better_corpus — execution-verified pitfall traces (better data, not more)

### DIFF
--- a/python/helm/better_corpus.py
+++ b/python/helm/better_corpus.py
@@ -1,0 +1,189 @@
+"""better_corpus: BETTER data, not more -- execution-verified pitfall->diagnosis->fix traces.
+
+The lift experiment showed that training on more MBPP trajectories does not raise capability. The
+hypothesis this tests is that *better-structured* data does: a small set of high-quality traces that
+teach the COMMON PITFALLS and how to avoid them -- the "blow-and-go + radar detector" idea (verify by
+running, and anticipate the specific way each approach fails).
+
+Each pitfall is a verified manager-style trajectory: the problem, a plausible WRONG attempt (the
+pitfall), the real got-vs-expected diagnosis from RUNNING it, and the fix. Both halves are
+execution-verified -- the buggy code actually FAILS the hidden test and the fix actually PASSES -- so
+this is teaching data the verifier vouches for, not asserted lore. The traces use the same
+{messages, meta} schema as verified_trajectory, so they UNION straight into the VTC corpus.
+
+    from python.helm.better_corpus import build, PITFALLS
+    res = build("/path/to/vtc_mbpp_refined.jsonl", "/path/to/better.jsonl")  # union MBPP + pitfalls
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from . import public_bench as pb
+from .free_generator import _diagnose
+
+SYSTEM = (
+    "You are an SCBE coding agent. Write a complete, correct solution that passes the tests. Output only "
+    "the code. Correctness is verified by execution against held-out tests."
+)
+
+# Each pitfall: a real, common Python mistake. `buggy` must FAIL `tests`; `fix` must PASS them. Verified.
+PITFALLS: List[Dict[str, Any]] = [
+    {
+        "name": "mutable_default_arg",
+        "prompt": "Write append_to(item, lst) that appends item to lst and returns it; lst defaults to [].",
+        "buggy": "def append_to(item, lst=[]):\n    lst.append(item)\n    return lst",
+        "fix": "def append_to(item, lst=None):\n    if lst is None:\n        lst = []\n"
+        "    lst.append(item)\n    return lst",
+        "tests": ["assert append_to(1) == [1]", "assert append_to(2) == [2]"],
+    },
+    {
+        "name": "off_by_one_range",
+        "prompt": "Write upto(n) returning the list of integers from 1 to n INCLUSIVE.",
+        "buggy": "def upto(n):\n    return list(range(1, n))",
+        "fix": "def upto(n):\n    return list(range(1, n + 1))",
+        "tests": ["assert upto(3) == [1, 2, 3]", "assert upto(1) == [1]"],
+    },
+    {
+        "name": "integer_vs_float_division",
+        "prompt": "Write avg(a, b) returning the arithmetic mean of a and b (may be fractional).",
+        "buggy": "def avg(a, b):\n    return (a + b) // 2",
+        "fix": "def avg(a, b):\n    return (a + b) / 2",
+        "tests": ["assert avg(1, 2) == 1.5", "assert avg(2, 2) == 2.0"],
+    },
+    {
+        "name": "modify_list_while_iterating",
+        "prompt": "Write drop_evens(xs) returning xs with every even number removed.",
+        "buggy": "def drop_evens(xs):\n    for x in xs:\n        if x % 2 == 0:\n"
+        "            xs.remove(x)\n    return xs",
+        "fix": "def drop_evens(xs):\n    return [x for x in xs if x % 2 != 0]",
+        "tests": ["assert drop_evens([1, 2, 3, 4]) == [1, 3]", "assert drop_evens([2, 4, 6]) == []"],
+    },
+    {
+        "name": "dict_keyerror_vs_get",
+        "prompt": "Write lookup(d, k) returning d[k], or 0 if k is not present.",
+        "buggy": "def lookup(d, k):\n    return d[k]",
+        "fix": "def lookup(d, k):\n    return d.get(k, 0)",
+        "tests": ["assert lookup({'a': 1}, 'a') == 1", "assert lookup({'a': 1}, 'b') == 0"],
+    },
+    {
+        "name": "empty_string_index",
+        "prompt": "Write first_char(s) returning the first character of s, or '' if s is empty.",
+        "buggy": "def first_char(s):\n    return s[0]",
+        "fix": "def first_char(s):\n    return s[0] if s else ''",
+        "tests": ["assert first_char('hi') == 'h'", "assert first_char('') == ''"],
+    },
+    {
+        "name": "float_equality",
+        "prompt": "Write sums_to(a, b, target) returning True iff a + b equals target (handle float rounding).",
+        "buggy": "def sums_to(a, b, target):\n    return a + b == target",
+        "fix": "def sums_to(a, b, target):\n    return abs((a + b) - target) < 1e-9",
+        "tests": ["assert sums_to(0.1, 0.2, 0.3) == True", "assert sums_to(1, 1, 3) == False"],
+    },
+    {
+        "name": "late_binding_closure",
+        "prompt": "Write make_adders() returning a list of 3 functions where the i-th returns i (for i in 0,1,2).",
+        "buggy": "def make_adders():\n    return [lambda: i for i in range(3)]",
+        "fix": "def make_adders():\n    return [lambda i=i: i for i in range(3)]",
+        "tests": ["assert [f() for f in make_adders()] == [0, 1, 2]"],
+    },
+]
+
+
+def _passes(code: str, tests: List[str]) -> bool:
+    return pb._verify(code, [], tests, [])["hidden_passed"]
+
+
+def verify_pitfall(spec: Dict[str, Any]) -> Dict[str, Any]:
+    """Both halves must hold for the trace to be honest: buggy FAILS, fix PASSES."""
+    return {"buggy_fails": not _passes(spec["buggy"], spec["tests"]), "fix_passes": _passes(spec["fix"], spec["tests"])}
+
+
+def pitfall_trace(spec: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build a verified manager-style trajectory: problem -> buggy attempt -> real got-vs-expected
+    diagnosis -> fix. Returns None if the pair is not actually a real bug-and-fix (so nothing unverified
+    enters the corpus)."""
+    v = verify_pitfall(spec)
+    if not (v["buggy_fails"] and v["fix_passes"]):
+        return None
+    visible = spec["tests"][0]
+    diag = "\n".join(str(d) for d in _diagnose(spec["buggy"], spec["tests"], []))[:700]
+    return {
+        "messages": [
+            {"role": "system", "content": SYSTEM},
+            {
+                "role": "user",
+                "content": spec["prompt"] + "\n\nIt must pass:\n" + visible + "\nReturn ONLY the code.",
+            },
+            {"role": "assistant", "content": spec["buggy"]},
+            {
+                "role": "user",
+                "content": "Your code failed these checks (got vs expected):\n"
+                + diag
+                + "\nFix it. Return ONLY corrected Python code.",
+            },
+            {"role": "assistant", "content": spec["fix"]},
+        ],
+        "meta": {
+            "verified": True,
+            "task_id": "pitfall_" + spec["name"],
+            "attempts": 2,
+            "repaired": True,
+            "source": "better_corpus_pitfall",
+            "grade": "manager",
+        },
+    }
+
+
+def pitfall_traces() -> List[Dict[str, Any]]:
+    return [t for t in (pitfall_trace(s) for s in PITFALLS) if t is not None]
+
+
+def _load_jsonl(path: str) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            out.append(json.loads(line))
+    return out
+
+
+def build(mbpp_corpus: Optional[str], out_path: str) -> Dict[str, Any]:
+    """Union the existing MBPP corpus (if given) with the verified pitfall traces; write {messages,meta}
+    JSONL. 'Better data, not more' -- a few execution-verified pitfall traces grafted onto the base."""
+    base = _load_jsonl(mbpp_corpus) if mbpp_corpus else []
+    pits = pitfall_traces()
+    records = base + pits
+    p = Path(out_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps({"messages": r["messages"], "meta": r.get("meta", {})}, ensure_ascii=False) + "\n")
+    return {"path": str(p), "total": len(records), "from_mbpp": len(base), "pitfalls": len(pits)}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="scbe-better-corpus", description="verified pitfall traces + union with MBPP corpus"
+    )
+    ap.add_argument("--mbpp", default=None, help="existing vtc_mbpp_refined.jsonl to union with (optional)")
+    ap.add_argument("--out", default="better_corpus.jsonl")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    pits = pitfall_traces()
+    print("BETTER CORPUS  %d/%d pitfall traces verified (buggy fails + fix passes)" % (len(pits), len(PITFALLS)))
+    for s in PITFALLS:
+        v = verify_pitfall(s)
+        print("  %-28s buggy_fails=%-5s fix_passes=%s" % (s["name"], v["buggy_fails"], v["fix_passes"]))
+    res = build(a.mbpp, a.out)
+    print(
+        "\n  wrote %d records (%d MBPP + %d pitfalls) -> %s"
+        % (res["total"], res["from_mbpp"], res["pitfalls"], res["path"])
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_better_corpus.py
+++ b/tests/test_better_corpus.py
@@ -1,0 +1,59 @@
+"""better_corpus: the 'better data, not more' pitfall traces. These prove the traces are
+execution-VOUCHED -- every buggy attempt actually fails its test and every fix actually passes -- so
+nothing unverified can enter the corpus, and the union with the MBPP corpus is well-formed.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.helm.better_corpus import PITFALLS, build, pitfall_trace, pitfall_traces, verify_pitfall  # noqa: E402
+
+
+def test_every_pitfall_is_a_real_bug_and_fix():
+    # the whole point: the buggy code FAILS the test and the fix PASSES it -- execution-verified
+    for spec in PITFALLS:
+        v = verify_pitfall(spec)
+        assert v["buggy_fails"] is True, spec["name"]
+        assert v["fix_passes"] is True, spec["name"]
+
+
+def test_pitfall_trace_is_a_manager_shaped_repair():
+    t = pitfall_trace(PITFALLS[0])
+    roles = [m["role"] for m in t["messages"]]
+    assert roles == ["system", "user", "assistant", "user", "assistant"]  # problem -> buggy -> diag -> fix
+    assert t["meta"]["grade"] == "manager" and t["meta"]["repaired"] is True and t["meta"]["verified"] is True
+    assert "got vs expected" in t["messages"][3]["content"]  # a real diagnosis, not a generic 'try again'
+
+
+def test_unverified_pair_is_dropped():
+    # a "pitfall" whose buggy code actually PASSES is not a real bug -> no trace (nothing unverified enters)
+    fake = {
+        "name": "not_a_bug",
+        "prompt": "p",
+        "buggy": "def f():\n    return 1",
+        "fix": "def f():\n    return 1",
+        "tests": ["assert f() == 1"],
+    }
+    assert pitfall_trace(fake) is None
+
+
+def test_all_traces_present_and_verified():
+    traces = pitfall_traces()
+    assert len(traces) == len(PITFALLS)  # all 8 verified
+    assert all(t["meta"]["source"] == "better_corpus_pitfall" for t in traces)
+
+
+def test_build_unions_mbpp_and_pitfalls(tmp_path):
+    mbpp = tmp_path / "mbpp.jsonl"
+    mbpp.write_text(
+        json.dumps({"messages": [{"role": "user", "content": "x"}], "meta": {"task_id": 1}}) + "\n", encoding="utf-8"
+    )
+    out = tmp_path / "better.jsonl"
+    res = build(str(mbpp), str(out))
+    assert res["from_mbpp"] == 1 and res["pitfalls"] == len(PITFALLS) and res["total"] == 1 + len(PITFALLS)
+    lines = [json.loads(x) for x in out.read_text(encoding="utf-8").splitlines()]
+    assert len(lines) == res["total"] and all("messages" in r for r in lines)


### PR DESCRIPTION
The lift experiment showed more MBPP doesn't help. This tests the other hypothesis: **better data.** 8 high-quality manager-style traces teaching common Python pitfalls + how to avoid them (mutable default, off-by-one, int/float division, modify-while-iterating, KeyError vs get, empty-string index, float equality, late-binding closure). Each is problem → wrong attempt → real got-vs-expected diagnosis → fix, and **both halves are execution-verified** (buggy fails, fix passes) — unverified pairs are dropped. Unions onto the corpus (161 MBPP + 8 = 169). 5 tests, lint clean. Next: train a bigger model on the union + measure lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)