### PR TITLE
feat(aether): run_step — governed execution substrate for routed steps

### DIFF
--- a/python/scbe/aether_desk.py
+++ b/python/scbe/aether_desk.py
@@ -194,6 +194,82 @@ class AetherDesk:
     def receipt(self) -> List[dict]:
         return self.reg.transcript
 
+    # --- the execution substrate for ROUTED steps ----------------------------------------------------
+    # The router (failure_map -> pre-allocate each typed step to its best block/model) decides WHO solves
+    # each step. AetherDesk is WHERE it runs: bounded, execution-VERIFIED, and sealed into the receipt.
+    def run_step(
+        self,
+        name: str,
+        spec: str,
+        check: Optional[List[str]],
+        solver: Any,
+        solver_name: str = "solver",
+        confirm: Optional[str] = None,
+    ) -> dict:
+        """Run ONE routed step: the chosen `solver` (a deterministic block or a model, `spec`->code)
+        produces a candidate, it is execution-verified against `check` (assert lines) inside the
+        workspace, and a governed receipt is sealed. A wrong solver is recorded as FAILED, never hidden.
+        Returns {step, solver, verified, candidate}. verified is None when there is no check to run."""
+        from python.helm import public_bench as pb
+
+        try:
+            candidate = str(solver(spec))
+        except Exception as exc:
+            candidate = "# solver raised: %s: %s" % (type(exc).__name__, exc)
+        verified: Optional[bool] = None
+        if check:
+            verified = bool(pb._verify(candidate, [], list(check), [])["hidden_passed"])
+        rec: dict = {
+            "hop": len(self.reg.transcript) + 1,
+            "action": "run_step:" + name,
+            "params": {"solver": solver_name, "spec": str(spec)[:200], "checks": len(check or [])},
+            "decision": "VERIFIED" if verified else ("UNVERIFIED" if verified is None else "FAILED"),
+            "result": candidate[:300],
+        }
+        if confirm:
+            rec["confirm"] = str(confirm)
+        rec["_prev"] = self.reg.transcript[-1]["seal"] if self.reg.transcript else self.reg.nonce
+        rec["seal"] = _seal(rec)
+        self.reg.transcript.append(rec)
+        return {"step": name, "solver": solver_name, "verified": verified, "candidate": candidate, "seal": rec["seal"]}
+
+    def run_pipeline(self, steps: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Run a routed plan -- a list of {name, spec, check, solver, solver_name}. Each step is verified
+        + sealed; returns the per-step results, whether every checked step verified, and the receipt
+        integrity. The router's plan, made runnable and governed."""
+        out = [
+            self.run_step(
+                s["name"],
+                s.get("spec", ""),
+                s.get("check"),
+                s["solver"],
+                s.get("solver_name", "solver"),
+                s.get("confirm"),
+            )
+            for s in steps
+        ]
+        checked = [r for r in out if r["verified"] is not None]
+        return {
+            "steps": out,
+            "all_verified": all(r["verified"] for r in checked) if checked else None,
+            "sealed": self.verify(),
+        }
+
+
+# --- solvers: a routed step is assigned to a deterministic BLOCK (free + exact) or a MODEL ----------
+def block_solver(code: Any) -> Any:
+    """A DETERMINISTIC block as a solver -- the $0, provably-exact path for a known-hard step. `code` is
+    proven source (a str) or `spec`->str. Prefer this over a stronger model wherever a block exists."""
+    return (lambda spec: str(code(spec))) if callable(code) else (lambda spec: str(code))
+
+
+def model_solver(ask: Any) -> Any:
+    """A model as a solver -- generate code from the spec via a prompt->str `ask`. The escalation path,
+    used only where no deterministic block covers the step."""
+    from python.helm.free_generator import strip_to_code
+
+    return lambda spec: strip_to_code(ask(spec))
+
 
 # --- the v0 "oh shit" demo: a governed agent doing real local work it cannot escape -----------------
 _BUGGY = "def add(a, b):\n    return a - b   # bug\n"

--- a/tests/test_aether_desk.py
+++ b/tests/test_aether_desk.py
@@ -10,7 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from python.scbe.aether_desk import AetherDesk, demo  # noqa: E402
+from python.scbe.aether_desk import AetherDesk, block_solver, demo, model_solver  # noqa: E402
 
 
 def test_real_work_inside_the_workspace_is_allowed(tmp_path):
@@ -59,3 +59,59 @@ def test_demo_does_real_work_and_blocks_escape(tmp_path):
     decisions = [s["decision"] for s in out["steps"]]
     assert decisions.count("ALLOWED") >= 6  # the real-work steps
     assert decisions.count("REFUSED") == 3  # the three escape attempts
+
+
+# --- the routed-step execution substrate (the router's plan, made runnable + governed) --------------
+
+
+def test_run_step_verifies_a_block_solver(tmp_path):
+    desk = AetherDesk.open(tmp_path / "ws")
+    # a known-hard step routed to a DETERMINISTIC block (proven code) -> verified, sealed
+    r = desk.run_step(
+        "add", "add two numbers", ["assert add(2, 3) == 5"], block_solver("def add(a, b):\n    return a + b"), "block"
+    )
+    assert r["verified"] is True and r["solver"] == "block"
+    assert desk.verify() is True
+
+
+def test_run_step_records_a_wrong_solver_as_failed_not_hidden(tmp_path):
+    desk = AetherDesk.open(tmp_path / "ws")
+    r = desk.run_step(
+        "add",
+        "add two numbers",
+        ["assert add(2, 3) == 5"],
+        block_solver("def add(a, b):\n    return a - b"),
+        "bad_block",
+    )
+    assert r["verified"] is False  # wrong code is caught by execution, not hidden
+    assert desk.receipt()[-1]["decision"] == "FAILED" and desk.verify() is True
+
+
+def test_model_solver_strips_fences(tmp_path):
+    desk = AetherDesk.open(tmp_path / "ws")
+    ask = lambda spec: "Here you go:\n```python\ndef mul(a, b):\n    return a * b\n```"  # noqa: E731
+    r = desk.run_step("mul", "multiply", ["assert mul(2, 3) == 6"], model_solver(ask), "model")
+    assert r["verified"] is True
+
+
+def test_run_pipeline_routes_each_step_and_seals(tmp_path):
+    desk = AetherDesk.open(tmp_path / "ws")
+    steps = [
+        {
+            "name": "add",
+            "spec": "add",
+            "check": ["assert add(2, 3) == 5"],
+            "solver": block_solver("def add(a, b):\n    return a + b"),
+            "solver_name": "block",
+        },
+        {
+            "name": "mul",
+            "spec": "mul",
+            "check": ["assert mul(2, 3) == 6"],
+            "solver": model_solver(lambda s: "def mul(a, b):\n    return a * b"),
+            "solver_name": "model",
+        },
+    ]
+    out = desk.run_pipeline(steps)
+    assert out["all_verified"] is True and out["sealed"] is True
+    assert [s["solver"] for s in out["steps"]] == ["block", "model"]  # the router's assignment is recorded


### PR DESCRIPTION
The complement to the proactive strength-router: the router decides **who** solves each typed step (deterministic block or model); **AetherDesk is where it runs** — bounded, execution-verified, sealed.

- `run_step`: solver produces a candidate → execution-verified against `check` in the workspace → governed receipt sealed. A wrong solver is recorded **FAILED, not hidden**.
- `run_pipeline`: a routed plan, each step verified + sealed, reports all_verified + receipt integrity.
- `block_solver` (deterministic = $0 + provably-exact, preferred) vs `model_solver` (escalation where no block exists).

This makes the router's output **runnable and governed** without duplicating the router itself. 10 tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)