### PR TITLE
feat(analog): library lane (putter) + golf jurisdiction over both clubs

### DIFF
--- a/python/scbe/analog_solve.py
+++ b/python/scbe/analog_solve.py
@@ -1,0 +1,439 @@
+"""analog_solve: inference WITHOUT a neural forward pass -- navigate a geometry maze of verified cases.
+
+The maze (Issac's framing): the answer sits at the hidden angle of a geometry maze, and the cracks in
+the walls are the hints at the path. Made literal with the spin-voxel math from
+`docs/specs/QUASI_VECTOR_SPIN_VOXELS_MAZE_RND.md`:
+
+  - every verified case is a normalized feature vector S (a "spin");
+  - alignment(query, case) = S_q . S_c   -- the cosine ANGLE between two spins (1.0 = same direction);
+  - disorder         = 1 - alignment      -- the doc's per-edge D_spin (a misaligned neighbor = a wall);
+  - the CRACKS        = the best-aligned verified neighbors (they point down a likely path);
+  - the WALLS         = execution verification (a candidate that fails the tests hit a wall);
+  - the HIDDEN ANGLE  = the neighbor whose grafted solution actually PASSES -- found by navigating, not
+                        by a model.
+
+This is "analog inference for a non-inference model": no trained forward pass runs. A new problem is
+SOLVED by INTERPOLATION (retrieve the best-aligned verified case) + COMPOSITION (graft its code, adapt
+the entry point) + VERIFY (run the tests). It wins where the new problem is near something already
+verified; on genuine novelty it returns unsolved and the caller falls back to a model.
+
+HONEST LIMIT (learned the hard way -- an adversarial review caught it): a "solved" is only as trustworthy
+as the tests it ran against. On a WEAK oracle (e.g. MBPP's 3 cherry-picked asserts) a grafted neighbor
+can pass while being the wrong algorithm (a monotonic-array checker renamed to all_unique passed all 3).
+So the lane does not emit code that fails the GIVEN tests, but "passes the tests" != "correct" -- the
+caller MUST hold back tests it did not search on (see measure_mbpp's public-search / held-back-accept),
+and the verifier strength is the real ceiling. That caveat IS the interpolate-and-check bet stated
+honestly: cheap when the spec is strong, untrustworthy when the spec is weak.
+
+    from python.scbe.analog_solve import Maze, analog_solve
+    maze = Maze.from_solved([("add a and b", "def add(a,b): return a+b", ["assert add(2,3)==5"])])
+    out = analog_solve("sum two numbers", ["assert total(2, 3) == 5"], maze)  # solved, 0 model calls
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+import re
+import sys
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from python.helm import public_bench as pb
+from python.helm.free_generator import strip_to_code
+
+# --- the analog representation: text -> a normalized "spin" vector (deterministic, stdlib, $0) --------
+
+_WORD = re.compile(r"[a-zA-Z_][a-zA-Z_0-9]*")
+
+
+def featurize(text: str) -> Dict[str, float]:
+    """Map text to an L2-normalized sparse spin vector. Features = lowercased word tokens + character
+    3-grams (so 'sum'~'sums' and renamed variables still align). Deterministic -- no model, no network."""
+    text = (text or "").lower()
+    feats: Dict[str, float] = {}
+    for w in _WORD.findall(text):
+        feats["w:" + w] = feats.get("w:" + w, 0.0) + 1.0
+    squashed = re.sub(r"\s+", " ", text)
+    for i in range(len(squashed) - 2):
+        g = squashed[i : i + 3]
+        feats["g:" + g] = feats.get("g:" + g, 0.0) + 0.5
+    norm = math.sqrt(sum(v * v for v in feats.values())) or 1.0
+    return {k: v / norm for k, v in feats.items()}
+
+
+def alignment(a: Dict[str, float], b: Dict[str, float]) -> float:
+    """S_a . S_b -- the cosine angle between two spins (both already normalized). 1.0 = same direction."""
+    small, big = (a, b) if len(a) <= len(b) else (b, a)
+    return sum(v * big.get(k, 0.0) for k, v in small.items())
+
+
+def disorder(a: Dict[str, float], b: Dict[str, float]) -> float:
+    """1 - alignment: the spin-voxel D_spin. High disorder = a wall between query and case."""
+    return 1.0 - alignment(a, b)
+
+
+# --- adapting a verified neighbor's code to the new problem's entry point (the COMPOSITION step) ------
+
+_DEF = re.compile(r"^\s*def\s+([a-zA-Z_][a-zA-Z_0-9]*)\s*\(", re.M)
+
+
+def target_name(checks: Sequence[str]) -> Optional[str]:
+    """The function the tests call, e.g. 'total' from `assert total(2, 3) == 5`. The maze must produce a
+    callable by THIS name even if the neighbor it borrows from named it something else."""
+    for c in checks:
+        m = re.search(r"\b([a-zA-Z_][a-zA-Z_0-9]*)\s*\(", c.split("assert", 1)[-1])
+        if m:
+            return m.group(1)
+    return None
+
+
+def adapt(code: str, checks: Sequence[str]) -> str:
+    """Graft a neighbor's solution onto the new problem: if the tests call a name the code doesn't
+    define, and the code has exactly one top-level def, rename that def to the target. Conservative on
+    purpose -- a bad graft just hits a wall (fails verify), it never ships unverified."""
+    code = strip_to_code(code)
+    want = target_name(checks)
+    if not want:
+        return code
+    defined = _DEF.findall(code)
+    if want in defined or len(defined) != 1:
+        return code
+    return re.sub(r"(\bdef\s+)" + re.escape(defined[0]) + r"(\s*\()", r"\g<1>" + want + r"\2", code, count=1)
+
+
+# --- adapt BASIS: a tiny execution-gated code-transform alphabet (Icecuber's "small basis, compose,
+#     verify"). Every candidate is still run against the walls, so a wrong transform just hits a wall --
+#     BUT it amplifies a weak oracle (more candidates = more chances to overfit few tests), so the caller
+#     MUST verify accepted code against held-back tests it did not search on (see measure_mbpp). ---------
+
+_BINOP_SWAP = {ast.Add: ast.Sub, ast.Sub: ast.Add, ast.Mult: ast.FloorDiv, ast.FloorDiv: ast.Mult, ast.Div: ast.Mult}
+_CMP_SWAP = {ast.Lt: ast.LtE, ast.LtE: ast.Lt, ast.Gt: ast.GtE, ast.GtE: ast.Gt, ast.Eq: ast.NotEq, ast.NotEq: ast.Eq}
+_NUM = re.compile(r"(?<![\w.])\d+(?![\w.])")
+
+
+class _OpSwapper(ast.NodeTransformer):
+    """Swap exactly the `target`-th swappable operator (post-order). target=-1 swaps nothing (counts)."""
+
+    def __init__(self, target: int) -> None:
+        self.target = target
+        self.count = 0
+
+    def visit_BinOp(self, node: ast.AST) -> ast.AST:
+        self.generic_visit(node)
+        if type(node.op) in _BINOP_SWAP:
+            if self.count == self.target:
+                node.op = _BINOP_SWAP[type(node.op)]()
+            self.count += 1
+        return node
+
+    def visit_Compare(self, node: ast.AST) -> ast.AST:
+        self.generic_visit(node)
+        if len(node.ops) == 1 and type(node.ops[0]) in _CMP_SWAP:
+            if self.count == self.target:
+                node.ops = [_CMP_SWAP[type(node.ops[0])]()]
+            self.count += 1
+        return node
+
+
+def _op_swap_variants(code: str) -> List[str]:
+    """One-operator-flipped variants (AST-safe), e.g. n // 2 -> n * 2 (half -> double)."""
+    try:
+        ast.parse(code)
+    except SyntaxError:
+        return []
+    counter = _OpSwapper(-1)
+    counter.visit(ast.parse(code))
+    out: List[str] = []
+    for i in range(counter.count):
+        tree = ast.parse(code)
+        _OpSwapper(i).visit(tree)
+        try:
+            out.append(ast.unparse(ast.fix_missing_locations(tree)))
+        except Exception:
+            pass
+    return out
+
+
+def _const_variants(code: str, checks: Sequence[str]) -> List[str]:
+    """Rebind a numeric literal in the body to one that appears in the spec/tests."""
+    code_nums = list(dict.fromkeys(_NUM.findall(code)))
+    targets = [t for t in dict.fromkeys(n for c in checks for n in _NUM.findall(c)) if t not in set(code_nums)]
+    out: List[str] = []
+    for cn in code_nums:
+        for tn in targets:
+            out.append(_NUM.sub(lambda m, cn=cn, tn=tn: tn if m.group(0) == cn else m.group(0), code))
+    return out
+
+
+def adapt_basis(code: str, checks: Sequence[str], max_candidates: int = 24) -> List[str]:
+    """A small basis of cheap, deterministic grafts over ONE neighbor's code: rename-entry (cheapest,
+    first), as-is, then one-operator-swaps and constant-rebinds, each re-renamed to the target entry.
+    Bounded by `max_candidates`. The first that passes the walls wins -- so the cheapest graft is tried
+    first, and a richer graft only fires when the simple one cannot bridge the gap."""
+    base = strip_to_code(code)
+    seen: List[str] = []
+
+    def push(c: Optional[str]) -> None:
+        if c and c not in seen and len(seen) < max_candidates:
+            seen.append(c)
+
+    push(adapt(base, checks))  # cheapest: rename entry to the target -- tried first (preserves old behavior)
+    push(base)
+    for b in list(seen):
+        for v in _op_swap_variants(b):
+            push(adapt(v, checks))
+        for v in _const_variants(b, checks):
+            push(adapt(v, checks))
+        if len(seen) >= max_candidates:
+            break
+    return seen[:max_candidates]
+
+
+# --- the maze: a case base of verified (problem, solution) pairs as spin vectors ----------------------
+
+
+class Case:
+    """One verified node in the maze: a problem, a solution known to pass, and the problem's spin."""
+
+    __slots__ = ("cid", "problem", "code", "spin", "source")
+
+    def __init__(self, cid: str, problem: str, code: str, source: str = "corpus") -> None:
+        self.cid = cid
+        self.problem = problem
+        self.code = strip_to_code(code)
+        self.spin = featurize(problem + " " + self.code)
+        self.source = source
+
+
+class Maze:
+    """The geometry maze: verified cases positioned by their spin. `cracks` ranks them by alignment to a
+    query -- the hints at the path. No case enters unless its code is real (the caller vouches it)."""
+
+    def __init__(self, cases: Optional[List[Case]] = None) -> None:
+        self.cases: List[Case] = cases or []
+
+    def add(self, problem: str, code: str, cid: Optional[str] = None, source: str = "corpus") -> "Maze":
+        self.cases.append(Case(cid or ("case_%d" % len(self.cases)), problem, code, source))
+        return self
+
+    def cracks(self, query: str) -> List[Tuple[float, Case]]:
+        """Neighbors ranked by alignment (high = a crack pointing that way). Returns (alignment, case)."""
+        q = featurize(query)
+        ranked = [(alignment(q, c.spin), c) for c in self.cases]
+        ranked.sort(key=lambda t: t[0], reverse=True)
+        return ranked
+
+    @classmethod
+    def from_solved(cls, triples: Sequence[Tuple[str, str, Sequence[str]]]) -> "Maze":
+        """Build from (problem, code, checks) triples -- only cases whose code ACTUALLY passes its checks
+        get in (the walls vouch for every node; an unverified pair is silently dropped)."""
+        m = cls()
+        for i, (problem, code, checks) in enumerate(triples):
+            if pb._verify(strip_to_code(code), list(checks), [], [])["public_passed"]:
+                m.add(problem, code, cid="solved_%d" % i, source="solved")
+        return m
+
+    @classmethod
+    def from_corpus(cls, records: Sequence[Dict[str, Any]]) -> "Maze":
+        """Build from {messages, meta} VTC records: problem = first user turn, solution = last assistant
+        turn. The corpus is already execution-verified upstream, so we trust its codes here."""
+        m = cls()
+        for i, r in enumerate(records):
+            msgs = r.get("messages", [])
+            problem = next((x["content"] for x in msgs if x.get("role") == "user"), "")
+            code = next((x["content"] for x in reversed(msgs) if x.get("role") == "assistant"), "")
+            if problem and code:
+                cid = str(r.get("meta", {}).get("task_id", "rec_%d" % i))
+                m.add(problem, code, cid=cid, source="corpus")
+        return m
+
+
+# --- the solver: navigate the maze, no neural forward pass ------------------------------------------
+
+
+def analog_solve(
+    problem: str,
+    checks: Sequence[str],
+    maze: Maze,
+    imports: Sequence[str] = (),
+    rounds: int = 5,
+    min_alignment: float = 0.05,
+) -> Dict[str, Any]:
+    """Solve by navigating the maze: follow the best-aligned cracks, graft + adapt each neighbor's code,
+    and verify against the walls (the tests). Returns the first graft that PASSES -- the hidden-angle
+    answer -- with the path it walked. If no crack within `min_alignment` produces a passing graft,
+    returns solved=False (honest: the caller falls back to a model). Zero model calls either way.
+
+    The result carries `path` (the cracks tried: cid, angle, disorder, passed) so the navigation is
+    inspectable, and `solver='analog'` so a router can record that geometry -- not a model -- solved it.
+    """
+    path: List[Dict[str, Any]] = []
+    tried_code: set = set()
+    for angle, case in maze.cracks(problem)[: max(rounds, 1)]:
+        if angle < min_alignment:
+            break  # the remaining neighbors are walls, not cracks -- stop, don't guess
+        for candidate in adapt_basis(case.code, checks):  # try the cheap graft, then the small basis
+            if candidate in tried_code:
+                continue  # same wall already hit -- skip (the prune)
+            tried_code.add(candidate)
+            if pb._verify(candidate, list(checks), [], list(imports))["public_passed"]:
+                path.append(
+                    {"cid": case.cid, "angle": round(angle, 4), "disorder": round(1.0 - angle, 4), "passed": True}
+                )
+                return {
+                    "solved": True,
+                    "code": candidate,
+                    "via": case.cid,
+                    "angle": round(angle, 4),
+                    "rounds_used": len(path) + 1,
+                    "path": path,
+                    "solver": "analog",
+                }
+        path.append({"cid": case.cid, "angle": round(angle, 4), "disorder": round(1.0 - angle, 4), "passed": False})
+    return {"solved": False, "code": None, "via": None, "rounds_used": len(path), "path": path, "solver": "analog"}
+
+
+def analog_solver(maze: Maze) -> Callable[[Any], str]:
+    """A run_step-compatible solver: given a spec dict with `check`, return the top-aligned graft as a
+    candidate string (AetherDesk.run_step then verifies it against the walls). Lets a router route a step
+    to the maze exactly like it routes to a block or a model -- analog inference as a first-class lane."""
+
+    def solve(spec: Any) -> str:
+        problem = spec.get("spec", "") if isinstance(spec, dict) else str(spec)
+        checks = spec.get("check", []) if isinstance(spec, dict) else []
+        ranked = maze.cracks(problem)
+        if not ranked:
+            return ""
+        return adapt(ranked[0][1].code, checks)
+
+    return solve
+
+
+def render(out: Dict[str, Any]) -> str:
+    """One-screen summary of a navigation: the path of cracks walked and where it exited."""
+    lines = ["ANALOG SOLVE  (%s)" % ("SOLVED via %s" % out["via"] if out["solved"] else "no crack -> fall back")]
+    for step in out["path"]:
+        mark = "OK " if step["passed"] else "wall"
+        lines.append("  %-12s angle=%.3f disorder=%.3f  %s" % (step["cid"], step["angle"], step["disorder"], mark))
+    if out["solved"]:
+        lines.append("  hidden-angle answer: %s" % out["code"].splitlines()[0])
+    return "\n".join(lines)
+
+
+def demo() -> Dict[str, Any]:
+    """Two honest outcomes, no model in the loop:
+    1. a renamed/near-duplicate of a verified case -> SOLVED by geometry alone (interpolation win);
+    2. a genuinely novel problem with no aligned crack -> solved=False (the honest fallback, not a guess).
+    """
+    maze = Maze.from_solved(
+        [
+            ("add two numbers a and b", "def add(a, b):\n    return a + b", ["assert add(2, 3) == 5"]),
+            ("multiply a and b", "def mul(a, b):\n    return a * b", ["assert mul(2, 3) == 6"]),
+            ("reverse a string s", "def rev(s):\n    return s[::-1]", ["assert rev('ab') == 'ba'"]),
+        ]
+    )
+    # 1. "sum two numbers" calls total(): no case names it, but 'add' aligns -> graft + rename -> passes.
+    hit = analog_solve("sum / total of two numbers a and b", ["assert total(2, 3) == 5"], maze)
+    # 2. nothing in the maze is about prime factorization -> no crack clears min_alignment -> fall back.
+    miss = analog_solve("compute the nth Fibonacci number recursively", ["assert fib(10) == 55"], maze)
+    return {"interpolation_solved": hit["solved"], "novel_fell_back": not miss["solved"], "hit": hit, "miss": miss}
+
+
+def measure_mbpp(
+    train_k: int = 120,
+    eval_m: int = 80,
+    public_k: int = 1,
+    min_alignment: float = 0.05,
+    rounds: int = 3,
+    confident_angle: float = 0.6,
+) -> Dict[str, Any]:
+    """Honest capability test with the oracle hole FIXED. The maze is MBPP[:train_k] reference solutions
+    (each execution-verified). For each disjoint held-out problem, the lane searches on only the PUBLIC
+    tests (first `public_k`) and a solve is then re-checked on the HELD-BACK tests it never searched on:
+
+      - genuine            : solved on public AND passes the held-back tests AND the neighbor is close
+                             (angle >= confident_angle) -- the best the lane can honestly claim;
+      - overfit            : passed public, FAILED the held-back tests -> caught, NOT a solve;
+      - weak_oracle_suspect: passed every test but via a DISTANT neighbor (angle < confident_angle) -- the
+                             283<-monotonic kind of coincidental pass the adversarial review found; the
+                             tests are too weak to prove it correct, so it is NOT counted as solved.
+
+    The earlier 'false_positives=0 by construction' was wrong: it used all tests for BOTH search and
+    acceptance, so a graft that overfits a 3-assert oracle counted as solved. This split is the fix; the
+    residual truth is that MBPP's tiny oracle still cannot prove correctness, so genuine is a CEILING, not
+    a guarantee.
+    """
+    ps = pb.pull_mbpp()
+    train, ev = ps[:train_k], ps[train_k : train_k + eval_m]
+    maze = Maze()
+    for p in train:
+        tests, imps = p.get("test_list", []), p.get("test_imports", [])
+        if tests and pb._verify(p["code"], [], tests, imps)["hidden_passed"]:
+            maze.add(p["prompt"], p["code"], cid=str(p["task_id"]), source="mbpp")
+    rows: List[Dict[str, Any]] = []
+    for p in ev:
+        tests, imps = list(p.get("test_list", [])), p.get("test_imports", [])
+        public, held = tests[:public_k], tests[public_k:]
+        out = analog_solve(p["prompt"], public, maze, imports=imps, min_alignment=min_alignment, rounds=rounds)
+        cls = "fallback"
+        if out["solved"]:
+            held_ok = (not held) or pb._verify(out["code"], [], held, imps)["hidden_passed"]
+            cls = (
+                "overfit" if not held_ok else ("genuine" if out["angle"] >= confident_angle else "weak_oracle_suspect")
+            )
+        rows.append(
+            {"task_id": p["task_id"], "cls": cls, "via": out["via"], "angle": out["angle"] if out["solved"] else 0.0}
+        )
+    counts = {
+        k: sum(1 for r in rows if r["cls"] == k) for k in ("genuine", "weak_oracle_suspect", "overfit", "fallback")
+    }
+    n = len(rows) or 1
+    return {
+        "n_train_cases": len(maze.cases),
+        "n_eval": len(rows),
+        "public_k": public_k,
+        **counts,
+        "genuine_rate": round(counts["genuine"] / n, 4),
+        "genuine_rows": [r for r in rows if r["cls"] == "genuine"],
+        "suspect_rows": [r for r in rows if r["cls"] == "weak_oracle_suspect"],
+    }
+
+
+def render_measure(m: Dict[str, Any]) -> str:
+    lines = [
+        "ANALOG LIBRARY LANE on held-out MBPP (0 model calls, public_k=%d search / held-back accept)" % m["public_k"],
+        "  maze cases (verified) : %d" % m["n_train_cases"],
+        "  held-out evaluated    : %d" % m["n_eval"],
+        "  GENUINE (pass held-back, close neighbor): %d  (%.1f%%)" % (m["genuine"], 100 * m["genuine_rate"]),
+        "  weak-oracle suspect (pass weak tests, distant neighbor): %d   <- NOT counted (likely coincidence)"
+        % m["weak_oracle_suspect"],
+        "  overfit (passed public, FAILED held-back): %d   <- caught, not a solve" % m["overfit"],
+        "  honest fallback       : %d" % m["fallback"],
+    ]
+    for r in (m["genuine_rows"] + m["suspect_rows"])[:8]:
+        lines.append("    %-18s task %s via case %s  angle=%.3f" % (r["cls"], r["task_id"], r["via"], r["angle"]))
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+    if "--measure" in argv:
+        print(render_measure(measure_mbpp()))
+        return 0
+    out = demo()
+    print("ANALOG INFERENCE (no neural forward pass)")
+    print()
+    print(render(out["hit"]))
+    print()
+    print(render(out["miss"]))
+    print()
+    print(
+        "interpolation solved (0 model calls): %s   |   novel honestly fell back: %s"
+        % (out["interpolation_solved"], out["novel_fell_back"])
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/scbe/analog_solve.py
+++ b/python/scbe/analog_solve.py
@@ -216,6 +216,18 @@ class Maze:
         self.cases.append(Case(cid or ("case_%d" % len(self.cases)), problem, code, source))
         return self
 
+    def learn(self, problem: str, code: str, checks: Optional[Sequence[str]] = None, cid: Optional[str] = None) -> bool:
+        """Add a freshly-VERIFIED solve back into the maze -- the SOAR/Stitch abstraction-library move the
+        ARC winners use: the library grows with use, so RECURRENCE (not a frozen corpus) drives the hit
+        rate. This is the honest answer to '0% on all-distinct MBPP': don't expect a static library to
+        cover novel work -- let it accrete what gets solved, so the second time a shape recurs it is free.
+        If `checks` are given the code must pass them first (only verified cases enter); returns admitted."""
+        code = strip_to_code(code)
+        if checks is not None and not pb._verify(code, list(checks), [], [])["public_passed"]:
+            return False
+        self.add(problem, code, cid=cid, source="learned")
+        return True
+
     def cracks(self, query: str) -> List[Tuple[float, Case]]:
         """Neighbors ranked by alignment (high = a crack pointing that way). Returns (alignment, case)."""
         q = featurize(query)
@@ -415,11 +427,87 @@ def render_measure(m: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _reword(prompt: str) -> str:
+    """A mild deterministic paraphrase (keeps most words so alignment stays high -- a realistic recurrence,
+    not a byte-identical repeat)."""
+    p = (prompt or "").strip()
+    return "Implement the following. " + (p[0].lower() + p[1:] if p else p)
+
+
+def _rename(text: str, old: str, new: str) -> str:
+    return re.sub(r"\b" + re.escape(old) + r"\b", new, text)
+
+
+def measure_recurrence(base_k: int = 40, public_k: int = 1) -> Dict[str, Any]:
+    """Honest demo of the self-growing library (the answer to 0%-on-all-distinct). A stream where each
+    base problem RECURS once as a paraphrase (reworded prompt + renamed function). Processed in order:
+    the library is tried first; a miss is solved 'expensively' (via the reference, simulating a model) and
+    -- with learning ON -- LEARNED back. A later paraphrase of a learned problem is then sunk for FREE.
+    Compares learning ON vs OFF. Every free hit is accepted only on HELD-BACK tests (no weak-oracle pass),
+    and the paraphrase's renamed reference is the correct algorithm, so a hit is genuine. The 50% recurrence
+    here is constructed -- the real free-hit rate tracks YOUR workload's recurrence, which is the point."""
+    ps = pb.pull_mbpp()
+    base = [
+        p
+        for p in ps[: base_k * 3]
+        if p.get("test_list") and pb._verify(p["code"], [], p["test_list"], p.get("test_imports", []))["hidden_passed"]
+    ][:base_k]
+
+    def run(learning: bool) -> Dict[str, int]:
+        maze = Maze()
+        free = recur_free = expensive = 0
+        for p in base:
+            old = target_name(p["test_list"]) or "f"
+            new = old + "_v2"
+            items = [
+                ("orig", p["prompt"], list(p["test_list"]), old),
+                ("para", _reword(p["prompt"]), [_rename(t, old, new) for t in p["test_list"]], new),
+            ]
+            for kind, prompt, tests, name in items:
+                imps = p.get("test_imports", [])
+                public, held = tests[:public_k], tests[public_k:]
+                out = analog_solve(prompt, public, maze, imports=imps)
+                hit = out["solved"] and ((not held) or pb._verify(out["code"], [], held, imps)["hidden_passed"])
+                if hit:
+                    free += 1
+                    recur_free += kind == "para"
+                else:
+                    expensive += 1
+                    if learning:  # solve it via the reference (the expensive club), then keep it
+                        maze.learn(prompt, adapt(p["code"], tests), checks=tests, cid="%s_%s" % (p["task_id"], kind))
+        return {"free": free, "recurrence_free": recur_free, "expensive": expensive, "stream": 2 * len(base)}
+
+    on, off = run(True), run(False)
+    return {
+        "base_k": len(base),
+        "with_learning": on,
+        "without_learning": off,
+        "amortized_free": on["free"] - off["free"],
+    }
+
+
+def render_recurrence(m: Dict[str, Any]) -> str:
+    on, off = m["with_learning"], m["without_learning"]
+    return "\n".join(
+        [
+            "SELF-GROWING LIBRARY on a constructed 50%%-recurrence stream (%d base, %d items)"
+            % (m["base_k"], on["stream"]),
+            "  WITH learning : %d/%d sunk FREE by the library (%d of them recurrences)"
+            % (on["free"], on["stream"], on["recurrence_free"]),
+            "  WITHOUT       : %d/%d free  <- a frozen library can't amortize" % (off["free"], off["stream"]),
+            "  amortized free solves: %d   <- recurrence the growing library bought back" % m["amortized_free"],
+        ]
+    )
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
     if "--measure" in argv:
         print(render_measure(measure_mbpp()))
+        return 0
+    if "--recurrence" in argv:
+        print(render_recurrence(measure_recurrence()))
         return 0
     out = demo()
     print("ANALOG INFERENCE (no neural forward pass)")

--- a/python/scbe/golf.py
+++ b/python/scbe/golf.py
@@ -1,0 +1,250 @@
+"""golf: one jurisdiction, two clubs -- the honest control surface over non-inference solving.
+
+A coding or grid task is a hole. You sink it in the fewest STROKES (cost) by picking the right CLUB and
+reading the green. Two clubs are built, and BOTH run with no neural forward pass:
+
+  - the PUTTER = analog_solve ([[analog-solve-library-lane]]): retrieval/interpolation over verified
+    code neighbors -- the short game, for a hole near one you have already sunk;
+  - the DRIVER = neurogolf (src/neurogolf): move-family composition searched under a cost gate and
+    compiled to a tiny static program -- the long game, for NOVEL ARC grid structure the putter cannot
+    reach (the putter scores 0% on genuinely novel problems; the driver is built for exactly that case).
+
+This module is the JURISDICTION, not the club-picker (the router that selects a club by distance-to-hole
+is owned elsewhere). Every shot is played the same way: the club produces a candidate, an UN-STEERED
+proctor checks it -- it scores correctness it cannot see the held-out answer to (execution for code,
+exact train-match for grids) -- and the result is SHA-256 forward-chain sealed into a scorecard that
+records WHICH club sank it, in how many strokes, verified or not. The receipt credits the CLUB, never a
+model's "understanding": the honest counterpart to the +24 that died crediting a model for the room's
+answer-elimination (see [[tool-use-is-the-skill]]). The proctor is the un-steered referee; the club is
+the candidate driving a tool. That separation is the whole point.
+
+    card = GolfCard()
+    play(card, putter(maze), code_hole("sum two numbers", ["assert total(2, 3) == 5"]))   # SUNK via putter
+    play(card, driver(), grid_hole([([[1, 2]], [[3, 4]])], [[[2, 1]]]))                    # SUNK via driver
+    card.verify()  # the scorecard chain holds
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from .desktop_access import _seal
+
+_SRC = str(Path(__file__).resolve().parents[2] / "src")  # so `import neurogolf` resolves for the driver
+
+
+# --- the scorecard: forward-chain sealed shots (the SAME seal AetherDesk uses) -----------------------
+
+
+class GolfCard:
+    """A sealed scorecard. Each shot is forward-chain sealed exactly like an AetherDesk receipt: rewrite
+    any field and its hash breaks; reorder/insert/delete and the `_prev` linkage breaks. verify() walks
+    the chain. (Same HONEST LIMIT as _seal: unkeyed hash on an in-memory nonce -- internal consistency +
+    un-re-chained tamper, not host-tamper-evidence.)"""
+
+    def __init__(self, nonce: str = "golf") -> None:
+        self.nonce = nonce
+        self.shots: List[dict] = []
+
+    def record(self, club: str, domain: str, verified: Optional[bool], strokes: int, detail: str) -> dict:
+        rec = {
+            "hop": len(self.shots) + 1,
+            "club": club,
+            "domain": domain,
+            "decision": "SUNK" if verified else ("UNSCORED" if verified is None else "MISSED"),
+            "strokes": int(strokes),
+            "detail": str(detail)[:200],
+        }
+        rec["_prev"] = self.shots[-1]["seal"] if self.shots else self.nonce
+        rec["seal"] = _seal(rec)
+        self.shots.append(rec)
+        return rec
+
+    def verify(self) -> bool:
+        prev = self.nonce
+        for r in self.shots:
+            if r.get("seal") != _seal(r) or r.get("_prev") != prev:
+                return False
+            prev = r["seal"]
+        return True
+
+    def scorecard(self) -> List[dict]:
+        return self.shots
+
+
+# --- a hole: a task plus its UN-STEERED proctor (scores without seeing the held-out answer) ----------
+
+
+@dataclass
+class Hole:
+    domain: str
+    payload: Dict[str, Any]
+    proctor: Callable[[Any], bool]  # candidate -> sank? (uses only the given spec, never a held-out label)
+
+
+def code_hole(problem: str, checks: Sequence[str], imports: Sequence[str] = ()) -> Hole:
+    """A code hole: the proctor runs the GIVEN tests by execution (it does not know any held-out answer)."""
+    from python.helm import public_bench as pb
+
+    checks, imports = list(checks), list(imports)
+
+    def proctor(candidate: Optional[str]) -> bool:
+        if not candidate:
+            return False
+        return bool(pb._verify(candidate, [], checks, imports)["hidden_passed"])
+
+    return Hole("code", {"problem": problem, "checks": checks, "imports": imports}, proctor)
+
+
+def grid_hole(train_pairs: Sequence, test_inputs: Sequence = ()) -> Hole:
+    """A grid hole. `train_pairs` = [(input_grid, output_grid), ...] as nested int lists; these ARE the
+    spec. The proctor sinks a program iff it reproduces EVERY train output exactly -- the held-out test
+    inputs stay unseen, so the referee never holds the answer."""
+    sys.path.insert(0, _SRC)
+    import numpy as np
+    from neurogolf.arc_io import ARCExample, ARCTask
+    from neurogolf.solver import execute_program
+
+    train = tuple(
+        ARCExample(input=np.asarray(i, dtype=np.int64), output=np.asarray(o, dtype=np.int64)) for i, o in train_pairs
+    )
+    test = tuple(np.asarray(t, dtype=np.int64) for t in test_inputs)
+    task = ARCTask(task_id="hole", train=train, test_inputs=test, source_path=Path("."))
+
+    def proctor(program: Any) -> bool:
+        if program is None:
+            return False
+        return all(np.array_equal(execute_program(ex.input, program), ex.output) for ex in train)
+
+    return Hole("grid", {"task": task}, proctor)
+
+
+# --- the clubs: non-inference solver lanes (a swing produces a candidate; it never scores itself) -----
+
+
+@dataclass
+class Club:
+    name: str
+    domain: str
+    swing: Callable[[Dict[str, Any]], Dict[str, Any]]  # payload -> {"candidate", "strokes", maybe "family"}
+
+
+def putter(maze: Any) -> Club:
+    """The short game: analog_solve retrieves the best-aligned verified neighbor and grafts it. Strokes =
+    graft attempts walked. Sinks a hole near a known one; abstains (no candidate) on novel structure."""
+
+    def swing(payload: Dict[str, Any]) -> Dict[str, Any]:
+        from python.scbe.analog_solve import analog_solve
+
+        out = analog_solve(payload["problem"], payload["checks"], maze, imports=payload["imports"])
+        return {"candidate": out["code"], "strokes": max(1, out["rounds_used"])}
+
+    return Club("putter", "code", swing)
+
+
+def driver() -> Club:
+    """The long game: neurogolf synthesizes a straight-line move-family program from the train pairs.
+    Strokes = ops in the program (the literal stroke count of the compiled micro-program)."""
+
+    def swing(payload: Dict[str, Any]) -> Dict[str, Any]:
+        sys.path.insert(0, _SRC)
+        from neurogolf.solver import synthesize_program
+
+        sol = synthesize_program(payload["task"])
+        prog = getattr(sol, "program", None)
+        strokes = len(prog.steps) if prog is not None else 0
+        return {"candidate": prog, "strokes": max(1, strokes), "family": getattr(sol, "family", "?")}
+
+    return Club("driver", "grid", swing)
+
+
+def model_club(ask: Callable[[str], str], name: str = "model") -> Club:
+    """The expensive club: a model generates code from the problem text. One stroke, highest club cost --
+    used only where neither the putter nor a deterministic club reaches the hole."""
+
+    def swing(payload: Dict[str, Any]) -> Dict[str, Any]:
+        from python.helm.free_generator import strip_to_code
+
+        return {"candidate": strip_to_code(ask(payload["problem"])), "strokes": 1}
+
+    return Club(name, "code", swing)
+
+
+# --- playing a hole: swing, let the un-steered proctor score it, seal the attributed shot -------------
+
+
+def play(card: GolfCard, club: Club, hole: Hole) -> Dict[str, Any]:
+    """Play one hole with one club, under the jurisdiction. The club only PRODUCES a candidate; the
+    hole's proctor (the un-steered referee) scores it; the attributed shot is sealed into the card."""
+    if club.domain != hole.domain:
+        rec = card.record(club.name, club.domain, False, 0, "wrong club for a %s hole" % hole.domain)
+        return {"club": club.name, "verified": False, "strokes": 0, "reason": "domain_mismatch", "seal": rec["seal"]}
+    try:
+        shot = club.swing(hole.payload)
+    except Exception as exc:  # a club that blows up is a missed shot, recorded -- never hidden
+        rec = card.record(club.name, club.domain, False, 0, "%s: %s" % (type(exc).__name__, exc))
+        return {"club": club.name, "verified": False, "strokes": 0, "error": str(exc), "seal": rec["seal"]}
+    candidate = shot.get("candidate")
+    verified = bool(hole.proctor(candidate))
+    detail = shot.get("family") or (str(candidate).splitlines()[0] if candidate else "no shot")
+    strokes = shot.get("strokes", 1)
+    rec = card.record(club.name, club.domain, verified, strokes, detail)
+    return {"club": club.name, "domain": club.domain, "verified": verified, "strokes": strokes, "seal": rec["seal"]}
+
+
+def render(card: GolfCard) -> str:
+    lines = ["GOLF SCORECARD (one jurisdiction, every club)"]
+    for s in card.scorecard():
+        lines.append(
+            "  %-7s %-5s %-8s strokes=%d  %s" % (s["club"], s["domain"], s["decision"], s["strokes"], s["detail"])
+        )
+    lines.append("  scorecard sealed: %s" % card.verify())
+    return "\n".join(lines)
+
+
+def demo() -> Dict[str, Any]:
+    """Both clubs, one jurisdiction, honest attribution -- no model's understanding is ever credited:
+    1. the PUTTER sinks a code hole near a known one (retrieval, 0 model calls);
+    2. a MODEL club MISSES the same hole with wrong code -> recorded MISSED, not hidden (un-steered proctor);
+    3. the DRIVER sinks a NOVEL grid hole the putter can't (neurogolf composition);
+    and the whole scorecard stays sealed.
+    """
+    from python.scbe.analog_solve import Maze
+
+    card = GolfCard()
+    maze = Maze.from_solved(
+        [
+            ("add two numbers a and b", "def add(a, b):\n    return a + b", ["assert add(2, 3) == 5"]),
+            ("multiply a and b", "def mul(a, b):\n    return a * b", ["assert mul(2, 3) == 6"]),
+        ]
+    )
+    code = code_hole("sum / total of two numbers a and b", ["assert total(2, 3) == 5"])
+    putt = play(card, putter(maze), code)
+    miss = play(card, model_club(lambda p: "def total(a, b):\n    return a - b"), code)  # wrong on purpose
+    grid = grid_hole([([[1, 2], [2, 1]], [[3, 4], [4, 3]]), ([[2, 1]], [[4, 3]])], [[[1, 2]]])
+    drive = play(card, driver(), grid)
+    return {
+        "putter_sank_code": putt["verified"],
+        "model_missed_code": not miss["verified"],
+        "driver_sank_grid": drive["verified"],
+        "scorecard_sealed": card.verify(),
+        "card": card,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    out = demo()
+    print(render(out["card"]))
+    print()
+    print(
+        "putter sank code: %s | model missed (recorded): %s | driver sank novel grid: %s"
+        % (out["putter_sank_code"], out["model_missed_code"], out["driver_sank_grid"])
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_analog_solve.py
+++ b/tests/test_analog_solve.py
@@ -116,6 +116,16 @@ def test_basis_still_falls_back_on_genuine_novelty():
     assert out["solved"] is False and out["code"] is None
 
 
+def test_learn_admits_only_verified_and_enables_free_recurrence():
+    maze = Maze()
+    assert maze.learn("add a and b", "def add(a, b):\n    return a + b", checks=["assert add(2, 3) == 5"]) is True
+    assert maze.learn("bad", "def sub(a, b):\n    return a - b", checks=["assert sub(2, 3) == 5"]) is False  # rejected
+    assert len(maze.cases) == 1  # only the verified solve grew the library
+    # a paraphrase of the learned problem is now sunk for free (recurrence the growing library bought)
+    out = analog_solve("sum / total of a and b", ["assert total(2, 3) == 5"], maze)
+    assert out["solved"] is True
+
+
 def test_analog_solver_is_run_step_compatible():
     maze = Maze.from_solved(
         [("add two numbers a and b", "def add(a, b):\n    return a + b", ["assert add(2, 3) == 5"])]

--- a/tests/test_analog_solve.py
+++ b/tests/test_analog_solve.py
@@ -1,0 +1,125 @@
+"""analog_solve: inference with NO neural forward pass -- navigating a geometry maze of verified cases.
+
+These prove the two honest outcomes that make analog inference safe to route to: it SOLVES by
+interpolation when the new problem is near a verified case (graft + adapt + verify, zero model calls),
+and it returns solved=False -- never unverified code -- when no aligned crack exists (the caller falls
+back to a model). Plus the spin math (alignment/disorder) and the entry-point adaptation.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.analog_solve import (  # noqa: E402
+    Maze,
+    adapt,
+    adapt_basis,
+    alignment,
+    analog_solve,
+    analog_solver,
+    disorder,
+    featurize,
+    target_name,
+)
+
+
+def test_spin_alignment_and_disorder_are_complementary():
+    a = featurize("add two numbers")
+    assert abs(alignment(a, a) - 1.0) < 1e-9  # a spin is fully aligned with itself
+    assert disorder(a, a) < 1e-9
+    b = featurize("reverse a string")
+    assert alignment(a, b) < alignment(a, a)  # unrelated text is less aligned (more disorder = a wall)
+    assert abs((alignment(a, b) + disorder(a, b)) - 1.0) < 1e-9
+
+
+def test_target_name_reads_the_function_the_tests_call():
+    assert target_name(["assert total(2, 3) == 5"]) == "total"
+    assert target_name(["assert rev('ab') == 'ba'"]) == "rev"
+
+
+def test_adapt_renames_a_single_def_to_the_target_entry_point():
+    grafted = adapt("def add(a, b):\n    return a + b", ["assert total(2, 3) == 5"])
+    assert "def total(a, b):" in grafted and "def add" not in grafted
+
+
+def test_adapt_leaves_code_alone_when_target_already_defined():
+    code = "def total(a, b):\n    return a + b"
+    assert adapt(code, ["assert total(2, 3) == 5"]) == code
+
+
+def test_interpolation_solves_a_renamed_variant_with_zero_model_calls():
+    maze = Maze.from_solved(
+        [("add two numbers a and b", "def add(a, b):\n    return a + b", ["assert add(2, 3) == 5"])]
+    )
+    out = analog_solve("sum / total of two numbers a and b", ["assert total(2, 3) == 5"], maze)
+    assert out["solved"] is True and out["solver"] == "analog"
+    assert "def total(a, b):" in out["code"]  # the grafted, entry-point-adapted neighbor
+    assert out["path"] and out["path"][-1]["passed"] is True  # it exited through a crack, not a wall
+
+
+def test_novel_problem_falls_back_instead_of_emitting_unverified_code():
+    maze = Maze.from_solved(
+        [("add two numbers a and b", "def add(a, b):\n    return a + b", ["assert add(2, 3) == 5"])]
+    )
+    out = analog_solve("compute the nth Fibonacci number recursively", ["assert fib(10) == 55"], maze)
+    assert out["solved"] is False and out["code"] is None  # honest: no aligned crack -> no guess
+
+
+def test_from_solved_drops_a_case_whose_code_does_not_actually_pass():
+    # the walls vouch for every node: a (problem, WRONG code) pair never enters the maze
+    maze = Maze.from_solved(
+        [
+            ("add", "def add(a, b):\n    return a + b", ["assert add(2, 3) == 5"]),  # real -> kept
+            ("bad", "def add(a, b):\n    return a - b", ["assert add(2, 3) == 5"]),  # wrong -> dropped
+        ]
+    )
+    assert len(maze.cases) == 1
+
+
+def test_from_corpus_reads_problem_and_solution_from_messages():
+    rec = {
+        "messages": [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "add a and b"},
+            {"role": "assistant", "content": "def add(a, b):\n    return a + b"},
+        ],
+        "meta": {"task_id": "t1"},
+    }
+    maze = Maze.from_corpus([rec])
+    assert len(maze.cases) == 1 and maze.cases[0].cid == "t1"
+
+
+def test_adapt_basis_tries_rename_first_then_widens():
+    # cheapest graft (rename entry) is candidate 0 so old behavior is preserved; the basis only widens after
+    code = "def half(n):\n    return n // 2"
+    basis = adapt_basis(code, ["assert dbl(3) == 6"])
+    assert basis[0] == adapt(code, ["assert dbl(3) == 6"])
+    assert any("n * 2" in c for c in basis)  # an operator-swap variant is reachable
+
+
+def test_op_swap_basis_solves_a_genuine_near_duplicate():
+    # half -> double: n // 2 becomes n * 2 (renamed dbl). single-rename could NEVER do this; the graft is
+    # genuinely CORRECT (it really doubles), not a weak-oracle coincidence.
+    maze = Maze.from_solved([("halve the number n", "def half(n):\n    return n // 2", ["assert half(4) == 2"])])
+    out = analog_solve("double the number n", ["assert dbl(3) == 6"], maze)
+    assert out["solved"] is True and "n * 2" in out["code"]
+
+
+def test_basis_still_falls_back_on_genuine_novelty():
+    # the wider basis must NOT manufacture a pass on a problem nothing in the maze can reach
+    maze = Maze.from_solved(
+        [("add two numbers a and b", "def add(a, b):\n    return a + b", ["assert add(2, 3) == 5"])]
+    )
+    out = analog_solve("compute the nth Fibonacci number recursively", ["assert fib(10) == 55"], maze)
+    assert out["solved"] is False and out["code"] is None
+
+
+def test_analog_solver_is_run_step_compatible():
+    maze = Maze.from_solved(
+        [("add two numbers a and b", "def add(a, b):\n    return a + b", ["assert add(2, 3) == 5"])]
+    )
+    solve = analog_solver(maze)
+    candidate = solve({"spec": "total two numbers", "check": ["assert total(2, 3) == 5"]})
+    assert "def total(a, b):" in candidate  # returns the top-aligned graft for run_step to verify

--- a/tests/test_golf.py
+++ b/tests/test_golf.py
@@ -1,0 +1,80 @@
+"""golf: one jurisdiction over two non-inference clubs (putter=analog_solve, driver=neurogolf).
+
+These prove the keystone: a hole is sunk by a CLUB, scored by an UN-STEERED proctor (execution for code,
+exact train-match for grids -- never a held-out label), and sealed into a scorecard that credits the
+club, not a model. The putter sinks a near hole; a wrong model MISSES and is recorded (not hidden); the
+driver sinks a NOVEL grid the putter can't reach; the chain stays sealed and is tamper-evident.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))  # so the driver's `import neurogolf` resolves
+
+from python.scbe.analog_solve import Maze  # noqa: E402
+from python.scbe.golf import (  # noqa: E402
+    GolfCard,
+    code_hole,
+    demo,
+    driver,
+    grid_hole,
+    model_club,
+    play,
+    putter,
+)
+
+
+def _code_maze():
+    return Maze.from_solved(
+        [("add two numbers a and b", "def add(a, b):\n    return a + b", ["assert add(2, 3) == 5"])]
+    )
+
+
+def test_putter_sinks_a_near_code_hole_and_is_attributed():
+    card = GolfCard()
+    r = play(card, putter(_code_maze()), code_hole("sum / total of two numbers a and b", ["assert total(2, 3) == 5"]))
+    assert r["verified"] is True and r["club"] == "putter"
+    assert card.scorecard()[-1]["decision"] == "SUNK" and card.verify() is True
+
+
+def test_wrong_model_misses_and_is_recorded_not_hidden():
+    card = GolfCard()
+    hole = code_hole("total of two numbers", ["assert total(2, 3) == 5"])
+    r = play(card, model_club(lambda p: "def total(a, b):\n    return a - b"), hole)  # wrong code
+    assert r["verified"] is False
+    assert card.scorecard()[-1]["decision"] == "MISSED" and card.verify() is True  # caught by the proctor, sealed
+
+
+def test_driver_sinks_a_novel_grid_hole_via_neurogolf():
+    card = GolfCard()
+    # a color-remap ARC hole: 1->3, 2->4. The putter (code retrieval) could never reach this; the driver does.
+    hole = grid_hole([([[1, 2], [2, 1]], [[3, 4], [4, 3]]), ([[2, 1]], [[4, 3]])], [[[1, 2]]])
+    r = play(card, driver(), hole)
+    assert r["verified"] is True and r["club"] == "driver" and r["domain"] == "grid"
+    assert r["strokes"] >= 1 and card.verify() is True
+
+
+def test_wrong_club_for_the_domain_is_a_recorded_miss():
+    card = GolfCard()
+    grid = grid_hole([([[1, 2]], [[3, 4]])], [[[2, 1]]])
+    r = play(card, putter(_code_maze()), grid)  # a putter on a grid hole
+    assert r["verified"] is False and r["reason"] == "domain_mismatch"
+    assert card.scorecard()[-1]["decision"] == "MISSED"
+
+
+def test_scorecard_is_tamper_evident():
+    card = GolfCard()
+    play(card, putter(_code_maze()), code_hole("total two numbers", ["assert total(2, 3) == 5"]))
+    assert card.verify() is True
+    card.scorecard()[0]["club"] = "forged"
+    assert card.verify() is False
+
+
+def test_demo_runs_both_clubs_under_one_seal():
+    out = demo()
+    assert out["putter_sank_code"] is True
+    assert out["model_missed_code"] is True
+    assert out["driver_sank_grid"] is True
+    assert out["scorecard_sealed"] is True


### PR DESCRIPTION
## What

Two non-inference solver lanes (no neural forward pass) and one sealed jurisdiction over them.

- **`python/scbe/analog_solve.py` — the putter (library lane).** Solve by INTERPOLATION: featurize a problem into a "spin" vector (the maze spec's `alignment = S_q·S_c`), retrieve the best-aligned verified neighbor, graft + adapt its code via a small execution-gated transform basis (`adapt_basis`: rename-entry → AST operator-swap, e.g. `n // 2`→`n * 2` for half→double → constant-rebind — Icecuber's "small basis, compose, verify"), and run the tests. Tags `solver='analog'` — never credits a model.
- **`python/scbe/golf.py` — the jurisdiction.** One sealed scorecard over the putter AND the neurogolf driver (imported unmodified). A club produces a candidate; an **un-steered proctor** scores it (execution for code, exact train-match for grids — never the held-out answer); the attributed shot is SHA-256 forward-chain sealed (reuses `desktop_access._seal`). The receipt credits the **club**, not a model.

## Honest correction baked in (the important part)

An adversarial review caught that the lane was shipping **weak-oracle false positives**: a monotonic-array checker renamed to `all_unique` passes MBPP's 3 cherry-picked asserts but is the wrong algorithm. Root cause: the measure used all tests for both search and acceptance. **Fixed** — `measure_mbpp` searches on public tests and accepts only on **held-back** tests, classifying genuine / overfit (caught) / weak-oracle-suspect. Re-measured: **0 genuine, 6 overfit caught, 74 fallback.** This retracts the earlier "0 false positives by construction" claim: passing weak tests ≠ correct; verifier strength is the ceiling.

## Self-growing library (the winners' SOAR/Stitch move)

`Maze.learn()` admits a freshly-verified solve back so the library compounds with use — the honest answer to "0 genuine on all-distinct MBPP." On a constructed 50%-recurrence stream: **WITH learning 28/80 sunk free (27 recurrences); WITHOUT 0/80.**

## Boundary (stated honestly)

Retrieval can't extrapolate to genuinely novel structure (0 genuine on all-distinct MBPP); its value scales with workload recurrence, and the neurogolf driver covers the novel case via composition. Putter and driver are the short game and long game of one swing.

## Tests
19 lane tests green (13 analog_solve + 6 golf). neurogolf untouched (parallel-owned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analog inference engine for solving programming problems by retrieving and adapting verified solutions from a case base.
  * Golf scoring system with scorecard tracking for solution attempts across code and grid problems.
  * Multi-approach solving via analog retrieval (putter) and neural synthesis (driver) with performance measurement capabilities.

* **Tests**
  * Comprehensive test coverage for analog inference, case base operations, code adaptation, and golf mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->