### PR TITLE
feat(repair-synth): deterministically synthesize deep verified repair trajectories

### DIFF
--- a/python/scbe/repair_synth.py
+++ b/python/scbe/repair_synth.py
@@ -1,0 +1,253 @@
+"""repair_synth: deterministically SYNTHESIZE verified DEEP "becoming" trajectories.
+
+The harvested tool-use corpus (PR #2538) is 95% "confirm" (write correct code -> run -> PASS -> answer;
+the tool is a rubber stamp) and only 5% "repair" -- because a weak 1.5B rarely fails-then-recovers on
+its own. But the repair loop (tool returns FAIL -> the model still reaches a verified answer) is exactly
+what the "train on becoming" doctrine most wants. A weak model can't reliably GENERATE it; this
+SYNTHESIZES it -- guaranteed-repair-shaped, deterministic, and execution-verified.
+
+The trick reuses my own machinery: analog_solve._op_swap_variants turns a CORRECT MBPP solution into a
+PLAUSIBLE bug (one operator flipped, e.g. + -> -). If the bugged version actually FAILS the example test
+and the original PASSES, that is a verified buggy->fix repair pair -- at scale, for free. Plus the 8
+hand-verified pitfalls (better_corpus). Each becomes a tool dialogue in the harvester's EXACT format:
+
+    system
+    user      : problem + example test
+    assistant : <buggy code>  CALL run_code
+    user      : TOOL run_code: FAIL: <real got-vs-expected diagnosis>   <- the failure
+    assistant : <fixed code>  CALL run_code                              <- the repair
+    user      : TOOL run_code: PASS (example test)
+    assistant : ANSWER: <fixed code>
+
+Every record is independently AUDITED (audit() re-parses the messages and re-runs buggy+fix in a fresh
+verify, never trusting the synthesizer's own claim). Records union into the tool-use corpus unchanged
+({messages, meta}); training + eval on the corpus stays Codex's lane.
+
+    from python.scbe.repair_synth import build
+    res = build("training/sft_records/repair_trajectory_synth.jsonl")  # pitfalls + MBPP-derived, audited
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from python.helm import public_bench as pb
+from python.helm.free_generator import _diagnose, strip_to_code
+from python.scbe.analog_solve import _op_swap_variants
+
+try:  # match the harvester's system prompt exactly so the records union into one homogeneous corpus
+    from python.helm.tool_trajectory import SYSTEM as SYSTEM
+except Exception:  # pragma: no cover - fallback keeps the synthesizer standalone
+    SYSTEM = (
+        "You are a coding agent with tools. To use a tool, end a turn with 'CALL <tool> <arg>' "
+        "(tools: run_code, calc, is_prime, factor). The harness runs it and replies 'TOOL <tool>: <result>'. "
+        "Prefer to run_code at least once before answering. When done, reply 'ANSWER:' then a code block."
+    )
+
+
+def _code_block(code: str) -> str:
+    return "```python\n" + strip_to_code(code).strip() + "\n```"
+
+
+def _parse_asserts(text: str) -> List[str]:
+    return [ln.strip() for ln in (text or "").splitlines() if ln.strip().startswith("assert ")]
+
+
+def _run_code_result(code: str, public: Sequence[str], imports: Sequence[str]) -> str:
+    """The run_code tool's verbatim reply string (matches the harvester): PASS or FAIL + real diagnosis."""
+    if pb._verify(code, list(public), [], list(imports))["public_passed"]:
+        return "PASS (example test)"
+    diags = _diagnose(code, list(public), list(imports))
+    return "FAIL: " + (" | ".join(str(d) for d in diags))[:400]
+
+
+def repair_trajectory(
+    task_id: str,
+    problem_text: str,
+    buggy: str,
+    fix: str,
+    public: Sequence[str],
+    held: Sequence[str],
+    imports: Sequence[str] = (),
+    source: str = "repair_synth",
+) -> Optional[Dict[str, Any]]:
+    """Build ONE verified repair dialogue, or None if it is not a real buggy->fix repair: the buggy code
+    must FAIL the shown (public) test and the fix must PASS public AND any held-back tests. Nothing
+    unverified is ever emitted."""
+    buggy, fix = strip_to_code(buggy), strip_to_code(fix)
+    public, held, imports = list(public), list(held), list(imports)
+    buggy_fails = not pb._verify(buggy, public, [], imports)["public_passed"]
+    fix_v = pb._verify(fix, public, held, imports)
+    fix_passes = fix_v["public_passed"] and (not held or fix_v["hidden_passed"])
+    if not (buggy_fails and fix_passes):
+        return None
+    fail = _run_code_result(buggy, public, imports)
+    if not fail.startswith("FAIL"):  # belt-and-suspenders: the tool must actually report FAIL
+        return None
+    user0 = problem_text.strip() + "\n\nExample test (you may run_code against it):\n" + "\n".join(public)
+    messages = [
+        {"role": "system", "content": SYSTEM},
+        {"role": "user", "content": user0},
+        {"role": "assistant", "content": _code_block(buggy) + "\nCALL run_code"},
+        {"role": "user", "content": "TOOL run_code: " + fail},
+        {"role": "assistant", "content": _code_block(fix) + "\nCALL run_code"},
+        {"role": "user", "content": "TOOL run_code: PASS (example test)"},
+        {"role": "assistant", "content": "ANSWER:\n" + _code_block(fix)},
+    ]
+    return {
+        "messages": messages,
+        "meta": {
+            "verified": True,
+            "task_id": task_id,
+            "source": source,
+            "grade": "repair",
+            "shape": "repair",
+            "attempts": 2,
+            "tool_calls": 2,
+            "tools_used": ["run_code"],
+            "public_tests": public,
+            "held_tests": held,
+            "imports": imports,
+        },
+    }
+
+
+def from_pitfalls() -> List[Dict[str, Any]]:
+    """The 8 hand-verified common-pitfall buggy->fix pairs (better_corpus) as repair dialogues. Both tests
+    are shown so the buggy visibly fails (some pitfalls, e.g. mutable-default, only fail on a later call)."""
+    from python.helm.better_corpus import PITFALLS
+
+    out: List[Dict[str, Any]] = []
+    for spec in PITFALLS:
+        tr = repair_trajectory(
+            "pitfall_" + spec["name"],
+            spec["prompt"],
+            spec["buggy"],
+            spec["fix"],
+            spec["tests"],  # public = all tests (so the bug shows)
+            [],
+            source="repair_synth_pitfall",
+        )
+        if tr:
+            out.append(tr)
+    return out
+
+
+def from_mbpp(limit: int = 120, public_k: int = 1, max_per_problem: int = 1) -> List[Dict[str, Any]]:
+    """Mine repairs from MBPP at scale: for each problem with a correct reference (the FIX), flip ONE
+    operator (analog_solve._op_swap_variants) to make a plausible BUGGY draft; keep it only if the bug
+    fails the public test and the fix passes held-back. Deterministic, guaranteed-repair-shaped."""
+    out: List[Dict[str, Any]] = []
+    for p in pb.pull_mbpp()[:limit]:
+        tl = list(p.get("test_list", []))
+        if not tl:
+            continue
+        public, held, imports = tl[:public_k], tl[public_k:], list(p.get("test_imports", []))
+        fix = strip_to_code(p["code"])
+        if not pb._verify(fix, public, held, imports)["hidden_passed"]:
+            continue  # only mine from a reference that is actually correct
+        made = 0
+        for buggy in _op_swap_variants(fix):
+            if made >= max_per_problem:
+                break
+            tr = repair_trajectory(
+                str(p["task_id"]),
+                (p.get("prompt") or p.get("text") or "").strip(),
+                buggy,
+                fix,
+                public,
+                held,
+                imports,
+                source="repair_synth_mbpp",
+            )
+            if tr:
+                out.append(tr)
+                made += 1
+    return out
+
+
+def audit(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """The INDEPENDENT instrument: re-parse each record's messages and re-run buggy+fix in a fresh verify,
+    NEVER trusting the synthesizer's own label. A record is clean iff the buggy really fails the shown
+    tests and the fix really passes them. Mirrors Codex's separate auditor -- don't grade your own work."""
+    clean = 0
+    bad: List[str] = []
+    for r in records:
+        msgs = r.get("messages", [])
+        m = r.get("meta", {})
+        public = m.get("public_tests")
+        held = m.get("held_tests", [])
+        imports = m.get("imports", [])
+        if public is None:  # fallback for foreign records: parse ONLY the example-test section, not prose
+            ut = next((x["content"] for x in msgs if x["role"] == "user"), "")
+            public, held = _parse_asserts(ut.split("Example test", 1)[-1]), []
+        assistants = [x["content"] for x in msgs if x["role"] == "assistant"]
+        if not public or len(assistants) < 2:
+            bad.append(str(m.get("task_id")))
+            continue
+        buggy, fix = strip_to_code(assistants[0]), strip_to_code(assistants[-1])
+        buggy_fails = not pb._verify(buggy, list(public), [], list(imports))["public_passed"]
+        fv = pb._verify(fix, list(public), list(held), list(imports))
+        fix_passes = fv["public_passed"] and (not held or fv["hidden_passed"])
+        if buggy_fails and fix_passes:
+            clean += 1
+        else:
+            bad.append(str(m.get("task_id")))
+    return {"audited": len(records), "verified": clean, "mismatches": len(bad), "bad_ids": bad[:10]}
+
+
+def build(
+    out_path: str = "training/sft_records/repair_trajectory_synth.jsonl",
+    mbpp_limit: int = 120,
+    public_k: int = 1,
+    max_per_problem: int = 1,
+) -> Dict[str, Any]:
+    """Union the pitfall + MBPP-derived repair dialogues, AUDIT them independently, and write only the
+    audit-clean records as {messages, meta} JSONL (the tool-use corpus format)."""
+    pit = from_pitfalls()
+    mbpp = from_mbpp(mbpp_limit, public_k, max_per_problem)
+    records = pit + mbpp
+    a = audit(records)
+    clean = [r for r in records if audit([r])["verified"] == 1]  # write only what re-verifies
+    p = Path(out_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        for r in clean:
+            f.write(json.dumps({"messages": r["messages"], "meta": r["meta"]}, ensure_ascii=False) + "\n")
+    return {
+        "path": str(p),
+        "total": len(clean),
+        "from_pitfalls": len(pit),
+        "from_mbpp": len(mbpp),
+        "audit": a,
+        "all_repair_shape": all(r["meta"]["shape"] == "repair" for r in clean),
+    }
+
+
+def demo() -> Dict[str, Any]:
+    pit = from_pitfalls()
+    a = audit(pit)
+    sample = pit[0]["messages"] if pit else []
+    return {
+        "pitfall_repairs": len(pit),
+        "audit_clean": a["verified"] == a["audited"] and a["audited"] > 0,
+        "roles": [m["role"] for m in sample],
+        "fail_turn": next((m["content"] for m in sample if m["role"] == "user" and "FAIL" in m["content"]), ""),
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    out = demo()
+    print("REPAIR-TRAJECTORY SYNTHESIZER (deep 'becoming' data, verified + independently audited)")
+    print("  pitfall repairs : %d  (audit clean: %s)" % (out["pitfall_repairs"], out["audit_clean"]))
+    print("  trajectory roles: %s" % " -> ".join(out["roles"]))
+    print("  the FAIL turn   : %s" % out["fail_turn"][:90])
+    mb = from_mbpp(limit=60)
+    print("  MBPP-mined repairs (limit 60): %d  (audit clean: %s)" % (len(mb), audit(mb)["mismatches"] == 0))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repair_synth.py
+++ b/tests/test_repair_synth.py
@@ -1,0 +1,68 @@
+"""repair_synth: deterministically synthesized DEEP repair trajectories (FAIL -> repair -> PASS).
+
+These prove the synthesizer emits the deep "becoming" shape the harvested corpus is thin on, in the
+harvester's exact tool-dialogue format, and ONLY when it is real: the buggy draft must actually fail and
+the fix must actually pass, re-checked by an independent audit that never trusts the synthesizer's claim.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.repair_synth import audit, build, from_mbpp, from_pitfalls, repair_trajectory  # noqa: E402
+
+_BUGGY = "def upto(n):\n    return list(range(1, n))"
+_FIX = "def upto(n):\n    return list(range(1, n + 1))"
+_PUBLIC = ["assert upto(3) == [1, 2, 3]"]
+_HELD = ["assert upto(1) == [1]"]
+
+
+def test_repair_trajectory_has_the_deep_fail_then_pass_shape():
+    tr = repair_trajectory("t", "Return 1..n inclusive.", _BUGGY, _FIX, _PUBLIC, _HELD)
+    assert tr is not None
+    roles = [m["role"] for m in tr["messages"]]
+    assert roles == ["system", "user", "assistant", "user", "assistant", "user", "assistant"]
+    assert tr["messages"][3]["content"].startswith("TOOL run_code: FAIL")  # the failure turn is real
+    assert tr["messages"][5]["content"] == "TOOL run_code: PASS (example test)"
+    calls = sum(m["content"].count("CALL run_code") for m in tr["messages"] if m["role"] == "assistant")
+    assert calls == 2  # two ACTUAL tool calls (the model's turns): the failed draft, then the repair
+    assert "n + 1" in tr["messages"][-1]["content"]  # the ANSWER is the fix
+    assert tr["meta"]["grade"] == "repair" and tr["meta"]["tool_calls"] == 2
+
+
+def test_rejects_a_pair_that_is_not_a_real_repair():
+    # if the "buggy" code actually passes the shown test, it is not a repair -> None (nothing unverified)
+    assert repair_trajectory("t", "p", _FIX, _FIX, _PUBLIC, _HELD) is None
+
+
+def test_from_pitfalls_are_all_audit_clean():
+    pit = from_pitfalls()
+    assert len(pit) >= 6
+    a = audit(pit)
+    assert a["mismatches"] == 0 and a["verified"] == a["audited"]  # every pitfall repair re-verifies
+
+
+@pytest.mark.slow
+def test_from_mbpp_mines_audit_clean_repairs():
+    mb = from_mbpp(limit=40)
+    assert len(mb) >= 1  # operator-swap mining finds at least one real repair in 40 problems
+    assert audit(mb)["mismatches"] == 0  # all independently re-verified
+
+
+def test_audit_catches_a_tampered_fix():
+    tr = repair_trajectory("t", "p", _BUGGY, _FIX, _PUBLIC, _HELD)
+    tr["messages"][-1]["content"] = "ANSWER:\n```python\ndef upto(n):\n    return []\n```"  # wrong fix
+    assert audit([tr])["mismatches"] == 1  # the independent re-run catches it
+
+
+@pytest.mark.slow
+def test_build_writes_only_audit_clean_repairs(tmp_path):
+    out = build(str(tmp_path / "repairs.jsonl"), mbpp_limit=40)
+    assert out["total"] >= 6 and out["audit"]["mismatches"] == 0
+    assert out["all_repair_shape"] is True
+    lines = (tmp_path / "repairs.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == out["total"]


### PR DESCRIPTION
## What

The harvested tool-use corpus (PR #2538) is **95% "confirm"** (the tool is a rubber stamp) and only **5% "repair"** — a weak 1.5B rarely fails-then-recovers on its own. But the repair loop (tool returns `FAIL` → the model still reaches a verified answer) is what the **"train on becoming"** doctrine most wants. This **synthesizes it deterministically**, guaranteed-repair-shaped and execution-verified.

The trick reuses my own machinery: `analog_solve._op_swap_variants` flips **one operator** in a *correct* MBPP solution to make a plausible bug; if the bug actually fails the example test and the fix passes held-back, that's a verified `buggy→fix` repair pair — at scale, for free. Plus the 8 hand-verified pitfalls (`better_corpus`). Each becomes a deep tool dialogue in the **harvester's exact format**:

```
assistant : <buggy code>  CALL run_code
user      : TOOL run_code: FAIL: assert append_to(2) == [2]  ->  got [1, 2, 2], expected [2]
assistant : <fixed code>  CALL run_code
user      : TOOL run_code: PASS (example test)
assistant : ANSWER: <fixed code>
```

## Honesty / audit

Every record is **independently audited** (`audit()` re-parses the messages and re-runs `buggy`+`fix` in a fresh `_verify` *with the right imports* — never trusting the synthesizer's own label; mirrors Codex's separate auditor). `build()` writes **only** audit-clean records. Demo: **8 pitfall + 37 MBPP-mined (limit 60) repairs, all audit-clean.**

## Composition
Records union into the tool-use corpus unchanged (`{messages, meta}`); training + eval on the corpus stay Codex's lane. Composes with the harvester (PR #2538) and the governed tools (PR #2542); does not modify either. 6/6 tests (2 marked `slow` for the MBPP mining).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a code repair synthesis system that generates training data with test-verified bug-fix pairs.
  * Automatically validates each pair by running tests, ensuring buggy code fails while fixed code passes.
  * Includes built-in auditing to verify data integrity and quality.

* **Tests**
  * Added comprehensive test suite validating trajectory structure and audit mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->