### PR TITLE
feat(training): governed repair-biased tool trajectories

### DIFF
--- a/python/helm/governed_tools.py
+++ b/python/helm/governed_tools.py
@@ -1,0 +1,44 @@
+"""Helm adapter for SCBE governed tool execution.
+
+``python.scbe.governed_tools`` owns the policy, gate, execution, and sealed receipt chain. This module
+only adapts that backend to ``python.helm.tool_trajectory.Tool`` so ``solve_with_tools(..., tools=...)``
+can harvest governed tool-use records without changing the trajectory loop.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from python.helm.tool_trajectory import Tool
+from python.scbe.governed_tools import GovernedToolbox
+
+
+def build_governed_tools(
+    problem: Optional[Dict[str, Any]] = None,
+    public_k: int = 1,
+    box: Optional[GovernedToolbox] = None,
+) -> tuple[Dict[str, Tool], GovernedToolbox]:
+    """Return ``tool_trajectory`` Tool objects backed by one governed toolbox.
+
+    The returned toolbox is shared by every tool so callers can verify the forward-chain receipts after
+    the trajectory run. Tool result strings stay compatible with the existing CALL/TOOL/ANSWER transcript.
+    """
+
+    box = box or GovernedToolbox()
+
+    def make_tool(name: str, doc: str) -> Tool:
+        return Tool(
+            name=name,
+            run=lambda arg, tool_name=name: box.call(tool_name, arg, problem=problem, public_k=public_k)["result"],
+            doc=doc + " (governed + sealed)",
+        )
+
+    return (
+        {
+            "run_code": make_tool("run_code", "run the code block against the example test"),
+            "calc": make_tool("calc", "evaluate arithmetic"),
+            "is_prime": make_tool("is_prime", "primality test"),
+            "factor": make_tool("factor", "prime factorization"),
+        },
+        box,
+    )

--- a/python/helm/tool_trajectory.py
+++ b/python/helm/tool_trajectory.py
@@ -40,6 +40,14 @@ SYSTEM = (
     "Prefer to run_code at least once before answering."
 )
 
+REPAIR_BIASED_SYSTEM = (
+    SYSTEM + "\n\nRepair-biased harvest mode:\n"
+    "  1. Make a small first candidate quickly, even if uncertain.\n"
+    "  2. CALL run_code on that candidate before giving ANSWER.\n"
+    "  3. If the tool returns FAIL, use the got-vs-expected feedback to repair and CALL run_code again.\n"
+    "  4. Only give ANSWER after using the tool feedback."
+)
+
 
 # --------------------------------------------------------------------------------------------------
 # tools (deterministic; the model calls them, the harness runs them)
@@ -174,6 +182,7 @@ def solve_with_tools(
     max_steps: int = 5,
     public_k: int = 1,
     system: str = SYSTEM,
+    prompt_mode: str = "confirm",
 ) -> Dict[str, Any]:
     """Run the model through a tool dialogue and record EVERY turn. Verify the final answer on HELD-BACK
     tests (test_list[public_k:]) the model never saw. Returns the transcript + whether it verified and
@@ -184,9 +193,24 @@ def solve_with_tools(
     public, held = tl[:public_k], tl[public_k:]
     imports = list(problem.get("test_imports", []))
 
+    if prompt_mode == "repair-biased" and system == SYSTEM:
+        system = REPAIR_BIASED_SYSTEM
+
+    mode_note = ""
+    if prompt_mode == "repair-biased":
+        mode_note = (
+            "\n\nRepair harvest instruction: first test a quick minimal candidate with run_code. "
+            "If it fails, revise from the TOOL feedback and test again before ANSWER."
+        )
+    elif prompt_mode != "confirm":
+        raise ValueError("unsupported prompt_mode: %s" % prompt_mode)
+
     msgs: List[Dict[str, str]] = [
         {"role": "system", "content": system},
-        {"role": "user", "content": head + "\n\nExample test (you may run_code against it):\n" + "\n".join(public)},
+        {
+            "role": "user",
+            "content": head + mode_note + "\n\nExample test (you may run_code against it):\n" + "\n".join(public),
+        },
     ]
     final_code = ""
     tool_calls = 0
@@ -228,6 +252,7 @@ def harvest_tool_traces(
     max_steps: int = 5,
     public_k: int = 1,
     require_tool_use: bool = True,
+    prompt_mode: str = "confirm",
 ) -> Dict[str, Any]:
     """Keep ONLY verified trajectories (held-back tests passed). With require_tool_use, also require the
     model actually called a tool -- so the corpus teaches ORCHESTRATION, not just lucky one-shot answers."""
@@ -235,7 +260,7 @@ def harvest_tool_traces(
     attempted = with_tool_use = 0
     for p in problems:
         attempted += 1
-        tr = solve_with_tools(p, ask, tools, max_steps, public_k)
+        tr = solve_with_tools(p, ask, tools, max_steps, public_k, prompt_mode=prompt_mode)
         if tr["used_tool"]:
             with_tool_use += 1
         if tr["verified"] and (tr["used_tool"] or not require_tool_use):
@@ -247,6 +272,7 @@ def harvest_tool_traces(
                         "task_id": p.get("task_id"),
                         "tool_calls": tr["tool_calls"],
                         "tools_used": tr["tools_used"],
+                        "prompt_mode": prompt_mode,
                         "source": "tool_trajectory",
                     },
                 }

--- a/tests/test_governed_tools.py
+++ b/tests/test_governed_tools.py
@@ -11,6 +11,16 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from python.scbe.governed_tools import GovernedToolbox, demo, governed_callables  # noqa: E402
+from python.helm.governed_tools import build_governed_tools  # noqa: E402
+from python.helm.tool_trajectory import solve_with_tools  # noqa: E402
+
+PROBLEM = {
+    "task_id": 1,
+    "text": "Write add(a, b) returning a + b.",
+    "code": "def add(a, b):\n    return a + b\n",
+    "test_list": ["assert add(1, 2) == 3", "assert add(0, 0) == 0", "assert add(-1, 1) == 0"],
+    "test_imports": [],
+}
 
 
 def test_destructive_run_code_is_refused_before_running():
@@ -73,3 +83,19 @@ def test_demo_refuses_destructive_and_seals():
     assert out["destructive_refused"] is True
     assert out["benign_passed"] is True
     assert out["sealed"] is True
+
+
+def test_helm_adapter_feeds_governed_tools_to_tool_trajectory():
+    tools, box = build_governed_tools(PROBLEM)
+
+    def ask(msgs):
+        if not any(m["role"] == "user" and m["content"].startswith("TOOL run_code:") for m in msgs):
+            return "```python\ndef add(a, b):\n    return a + b\n```\nCALL run_code"
+        return "ANSWER:\n```python\ndef add(a, b):\n    return a + b\n```"
+
+    tr = solve_with_tools(PROBLEM, ask, tools=tools, max_steps=4)
+
+    assert tr["verified"] is True
+    assert tr["used_tool"] is True
+    assert box.verify() is True
+    assert box.receipts[0]["tool"] == "run_code"

--- a/tests/test_tool_trajectory.py
+++ b/tests/test_tool_trajectory.py
@@ -59,6 +59,20 @@ def test_solve_with_tools_records_verified_trajectory():
     assert any(m["role"] == "user" and m["content"].startswith("TOOL run_code:") for m in tr["messages"])
 
 
+def test_repair_biased_prompt_mode_adds_feedback_loop_instruction():
+    seen = {}
+
+    def ask(msgs):
+        seen["system"] = msgs[0]["content"]
+        seen["user"] = msgs[-1]["content"]
+        return "ANSWER:\n```python\ndef add(a, b):\n    return a + b\n```"
+
+    tr = solve_with_tools(PROBLEM, ask, max_steps=1, prompt_mode="repair-biased")
+    assert tr["verified"] is True
+    assert "Repair-biased harvest mode" in seen["system"]
+    assert "quick minimal candidate" in seen["user"]
+
+
 def test_held_back_rejects_shown_test_only_pass():
     # a solver that returns code passing ONLY the shown example (add(1,2)==3) but wrong otherwise
     def cheat_ask(_msgs):
@@ -76,6 +90,13 @@ def test_harvest_keeps_verified_tooluse_only():
     rec = res["records"][0]
     assert rec["meta"]["verified"] is True and rec["meta"]["tool_calls"] >= 1
     assert rec["meta"]["source"] == "tool_trajectory"
+    assert rec["meta"]["prompt_mode"] == "confirm"
+
+
+def test_harvest_accepts_repair_biased_prompt_mode():
+    res = harvest_tool_traces([PROBLEM], reference_tool_solver(PROBLEM), max_steps=4, prompt_mode="repair-biased")
+    assert res["verified"] == 1 and res["with_tool_use"] == 1
+    assert res["records"][0]["meta"]["prompt_mode"] == "repair-biased"
 
 
 def test_harvest_drops_no_tool_use_when_required():


### PR DESCRIPTION
## Summary
- add repair-biased tool trajectory prompt mode and prompt-mode metadata
- add governed tool wrappers that embed sealed governance receipts into TOOL results
- keep the existing tool trajectory record shape while enabling governed-by-construction harvests

## Verification
- SCBE_FORCE_SKIP_LIBOQS=1 pytest tests/test_governed_tools.py tests/test_tool_trajectory.py -q