### PR TITLE
fix(security): harden never-delete screen for additional Python removal ops

### DIFF
--- a/python/scbe/desktop_access.py
+++ b/python/scbe/desktop_access.py
@@ -56,7 +56,8 @@ _DESTRUCTIVE = re.compile(
     r"\bremove-item\b|\bri\s+-(?:re|fo)|"  # powershell
     r"\bformat\b|\bmkfs\b|\bfdisk\b|\bdiskpart\b|\bsdelete\b|\bdd\s+if=|"  # format/partition/overwrite
     r"\bshutdown\b|\breboot\b|>\s*/dev/sd|chmod\s+-r\s+000|"  # power / device overwrite
-    r"os\.remove|os\.unlink|shutil\.rmtree|\.unlink\(|"  # python
+    r"os\.remove|os\.unlink|os\.rmdir|os\.removedirs|os\.truncate|shutil\.rmtree|"  # python delete/dir-remove
+    r"\.unlink\(|\.rmdir\(|\.truncate\(|"  # python Path/file: unlink / rmdir / truncate (slipped the old screen)
     r"\bdrop\s+table\b|\btruncate\s+table\b|"  # sql
     # verb-LESS destructive ops a red-team confirmed escape a shell-verb regex (no rm/del/format word):
     r"\bvssadmin\s+delete\b|\bwbadmin\s+delete\b|\bwevtutil\s+cl\b|\bbcdedit\b|\btakeown\b|"  # backup/log/boot/own

--- a/tests/test_governed_tools.py
+++ b/tests/test_governed_tools.py
@@ -35,6 +35,22 @@ def test_destructive_run_code_is_refused_before_running():
     assert box.verify() is True  # the refusals are sealed too
 
 
+def test_dir_removal_and_truncate_ops_are_refused_regression():
+    # regression: os.rmdir / os.removedirs / os.truncate / Path(...).rmdir() previously SLIPPED the
+    # never-delete screen (the shared _DESTRUCTIVE regex covered os.remove/unlink/rmtree but not
+    # directory-removal or truncate). Probed at the real surface (executable Python through run_code),
+    # they must all be REFUSED now that the canonical regex is hardened.
+    box = GovernedToolbox()
+    for snippet in (
+        "import os\nos.rmdir('/x')",
+        "import os\nos.removedirs('/x')",
+        "import os\nos.truncate('/x', 0)",
+        "from pathlib import Path\nPath('/x').rmdir()",
+    ):
+        r = box.call("run_code", snippet, problem={"test_list": ["assert f() == 1"]})
+        assert r["decision"] == "REFUSED", snippet
+
+
 def test_benign_run_code_passes_against_the_example_test():
     box = GovernedToolbox()
     r = box.call("run_code", "def add(a, b):\n    return a + b", problem={"test_list": ["assert add(2, 3) == 5"]})


### PR DESCRIPTION
## What

A **content check** found the canonical never-delete regex (`desktop_access.py` `_DESTRUCTIVE`) covered file-delete and tree-remove but **missed several Python directory-removal and data-loss calls** — model-written code could slip the never-delete wall. Hardened the shared regex to refuse them.

Because `governed_tools.py` (PR #2542) imports that same regex for its `run_code` screen, the hole closes at **both** the desktop driver and the harvester's tool screen at once — fix the shared chokepoint once, not per-caller.

## Why this PR exists (the honest part)

A prior fix attempt was reported landed, but a **content check proved it did not reach `main`**: a rebase/conflict-resolution dropped the `desktop_access.py` change. The `_DESTRUCTIVE` blob was **byte-identical** pre/post on `origin/main` despite a MERGED PR — the "verify a merge by content, not PR state" lesson, live. This re-lands it canonically.

## Tests
Regression test at the `governed_tools` layer probes the **real surface** (executable Python through `run_code`): the previously-slipped removal/data-loss ops are now `REFUSED`. Desktop + governed tests pass; benign code still allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)