### PR TITLE
feat(training): re-land tool-use corpus runner + independent auditor

### DIFF
--- a/scripts/training/audit_tool_corpus.py
+++ b/scripts/training/audit_tool_corpus.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""INDEPENDENT audit of a tool-use corpus -- verify the verifier.
+
+The harvester labels a record verified=True using python.helm.public_bench._verify. This auditor does
+NOT import that code: it re-extracts each record's FINAL answer code with its own parser and re-runs it
+against the HELD-BACK MBPP tests in a fresh subprocess with a separate runner. If the harness's
+"verified" claim disagrees with this independent re-execution, that is a verifier bug and the audit
+fails. It also checks the structural promises of the corpus:
+
+  * no few-shot demo leaked into a saved record (the triple(n) example must never appear)
+  * every kept record actually contains a TOOL result turn (the call->use->answer loop is present)
+  * no duplicate task_ids (each problem contributes at most one trajectory)
+
+    python scripts/training/audit_tool_corpus.py training/sft_records/tool_trajectory_mbpp.jsonl
+
+Exit code is nonzero if ANY mismatch, demo leak, or duplicate is found. $0; deterministic; no model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from python.helm.public_bench import pull_mbpp  # noqa: E402  (data source only, not the verifier)
+
+_CODE_RE = re.compile(r"```(?:python)?\s*\n(.*?)```", re.S)
+
+
+def _final_code(messages):
+    """Extract the answer code from the LAST assistant turn -- independent of the harvester's parser."""
+    for m in reversed(messages):
+        if m.get("role") == "assistant":
+            blocks = _CODE_RE.findall(m.get("content", ""))
+            if blocks:
+                return blocks[-1].strip()
+    return ""
+
+
+def _independent_holdback_pass(code, held, imports):
+    """Run code + ALL held-back asserts together in a subprocess; pass iff the process exits 0.
+
+    Deliberately a DIFFERENT shape from _verify (which execs asserts one-by-one and collects failures):
+    here a single failing assert aborts the process, so agreement is meaningful cross-checking."""
+    if not code.strip() or not held:
+        return False
+    src = "\n".join(list(imports) + [code, ""] + list(held))
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, encoding="utf-8") as f:
+        f.write(src)
+        path = f.name
+    try:
+        return subprocess.run([sys.executable, path], capture_output=True, timeout=15).returncode == 0
+    except Exception:
+        return False
+    finally:
+        try:
+            Path(path).unlink()
+        except OSError:
+            pass
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="independently audit a tool-use corpus")
+    ap.add_argument("corpus", help="path to the tool_trajectory jsonl corpus")
+    ap.add_argument("--public-k", type=int, default=1, help="tests shown during harvest; the rest were held back")
+    args = ap.parse_args(argv)
+
+    corpus = Path(args.corpus)
+    if not corpus.exists():
+        print("corpus not found: %s" % corpus, file=sys.stderr)
+        return 2
+    records = [json.loads(line) for line in corpus.read_text(encoding="utf-8").splitlines() if line.strip()]
+    by_id = {p["task_id"]: p for p in pull_mbpp()}
+
+    total = len(records)
+    indep_pass = mismatch = no_tool_turn = demo_leak = missing_problem = 0
+    repair = confirm = multi_call = 0
+    task_ids = []
+    tool_counter = Counter()
+    prompt_mode_counter = Counter()
+    mismatches = []
+
+    for rec in records:
+        meta = rec.get("meta", {})
+        tid = meta.get("task_id")
+        task_ids.append(tid)
+        prompt_mode_counter[meta.get("prompt_mode", "unknown")] += 1
+        msgs = rec.get("messages", [])
+
+        # structural checks
+        if "triple(n)" in json.dumps(rec):
+            demo_leak += 1
+        tool_turns = [
+            str(m.get("content", ""))
+            for m in msgs
+            if m.get("role") == "user" and str(m.get("content", "")).startswith("TOOL ")
+        ]
+        if not tool_turns:
+            no_tool_turn += 1
+        for t in meta.get("tools_used", []):
+            tool_counter[t] += 1
+
+        # trajectory SHAPE -- not whether the answer is right (the re-verify covers that), but whether the
+        # trajectory teaches the deep loop. repair = a tool returned FAIL and the model still reached a
+        # verified answer (the 'becoming' loop); confirm = tool only rubber-stamped already-correct code.
+        if any("FAIL" in t for t in tool_turns):
+            repair += 1
+        elif tool_turns:
+            confirm += 1
+        if len(tool_turns) > 1:
+            multi_call += 1
+
+        # INDEPENDENT held-back re-verification
+        problem = by_id.get(tid)
+        if problem is None:
+            missing_problem += 1
+            continue
+        held = list(problem.get("test_list", []))[args.public_k :]
+        imports = list(problem.get("test_imports", []))
+        ok = _independent_holdback_pass(_final_code(msgs), held, imports)
+        if ok:
+            indep_pass += 1
+        if meta.get("verified") is True and not ok:
+            mismatch += 1
+            mismatches.append(tid)
+
+    dupes = [tid for tid, n in Counter(task_ids).items() if n > 1]
+
+    print("=" * 64)
+    print("TOOL-USE CORPUS AUDIT (independent re-verification)")
+    print("  corpus                : %s" % corpus)
+    print("  records               : %d" % total)
+    print("  independently verified: %d / %d  (held-back tests re-run, separate checker)" % (indep_pass, total))
+    print("  harness/indep MISMATCH: %d  %s" % (mismatch, mismatches[:20] if mismatches else ""))
+    print("  records w/ TOOL turn  : %d / %d" % (total - no_tool_turn, total))
+    print("  demo leaks            : %d" % demo_leak)
+    print("  duplicate task_ids    : %d  %s" % (len(dupes), dupes[:20] if dupes else ""))
+    print("  problems unresolved   : %d" % missing_problem)
+    print("  tool-call distribution: %s" % dict(tool_counter))
+    print("  prompt-mode distribution: %s" % dict(prompt_mode_counter))
+    print("  -- trajectory shape (teaching depth, not correctness) --")
+    print("  repair (FAIL->fix->pass): %d  [the 'becoming' loop]" % repair)
+    print("  confirm (tool PASS only): %d  [tool rubber-stamped correct code]" % confirm)
+    print("  multi-call (>1 tool)    : %d  [iterative tool use]" % multi_call)
+    ok = mismatch == 0 and demo_leak == 0 and not dupes
+    print("  VERDICT               : %s" % ("PASS -- numbers are real" if ok else "FAIL -- see above"))
+    print("=" * 64)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/training/harvest_tool_corpus.py
+++ b/scripts/training/harvest_tool_corpus.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Build the verified TOOL-USE corpus: run the local 1.5B through the ReAct tool loop over real MBPP
+problems and keep ONLY trajectories whose final answer passes HELD-BACK tests AND that actually called
+a tool. The kept transcripts (system + real-problem turns, few-shot demo stripped) are SFT records that
+teach the call->use->answer ORCHESTRATION loop -- the learnable, non-saturated skill, after plain
+final-code SFT measured ~0 lift on a likely-pretrained benchmark.
+
+This is a thin runner around python.helm.tool_trajectory: it mirrors harvest_tool_traces' keep
+condition (verified AND used_tool) but writes each kept record the moment it is found, so a long run
+preserves partial progress and emits a live log. Output goes to training/sft_records/ (gitignored).
+
+    # default: 200 MBPP problems through qwen2.5-coder:1.5b on local ollama
+    python scripts/training/harvest_tool_corpus.py
+    python scripts/training/harvest_tool_corpus.py --problems 50 --model qwen2.5-coder:3b
+
+Needs ollama serving the model (SCBE_LLM_BASE / SCBE_LLM_KEY override the endpoint). $0; CPU/GPU local.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from python.helm.public_bench import pull_mbpp  # noqa: E402
+from python.helm.tool_trajectory import ollama_ask, solve_with_tools  # noqa: E402
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="harvest verified tool-use trajectories from MBPP")
+    ap.add_argument("--problems", type=int, default=200, help="how many usable MBPP problems to attempt")
+    ap.add_argument("--model", default="qwen2.5-coder:1.5b", help="ollama model tag")
+    ap.add_argument("--public-k", type=int, default=1, help="tests shown to the model; the rest are held back")
+    ap.add_argument("--max-steps", type=int, default=5, help="max tool-dialogue turns per problem")
+    ap.add_argument(
+        "--prompt-mode",
+        choices=["confirm", "repair-biased"],
+        default="confirm",
+        help="confirm keeps the original prompt; repair-biased asks for quick test -> feedback -> repair loops",
+    )
+    ap.add_argument(
+        "--out",
+        default=str(REPO / "training" / "sft_records" / "tool_trajectory_mbpp.jsonl"),
+        help="output corpus path (gitignored)",
+    )
+    ap.add_argument("--require-tool-use", action="store_true", default=True)
+    args = ap.parse_args(argv)
+
+    # MBPP problems need >=2 tests so there is at least one HELD-BACK test after showing public_k.
+    pool = [p for p in pull_mbpp() if len(p.get("test_list", [])) > args.public_k]
+    problems = pool[: args.problems]
+    print("MBPP usable (>%d tests): %d; attempting %d" % (args.public_k, len(pool), len(problems)), flush=True)
+
+    ask = ollama_ask(args.model)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    attempted = with_tool_use = kept = 0
+    t0 = time.time()
+    with out_path.open("w", encoding="utf-8") as fh:
+        for i, p in enumerate(problems, 1):
+            attempted += 1
+            try:
+                tr = solve_with_tools(
+                    p,
+                    ask,
+                    max_steps=args.max_steps,
+                    public_k=args.public_k,
+                    prompt_mode=args.prompt_mode,
+                )
+            except Exception as exc:  # one bad problem must not abort a long run
+                print("  [%d/%d] task %s ERROR %s" % (i, len(problems), p.get("task_id"), exc), flush=True)
+                continue
+            if tr["used_tool"]:
+                with_tool_use += 1
+            # keep condition mirrors harvest_tool_traces: verified on held-back AND actually used a tool
+            if tr["verified"] and (tr["used_tool"] or not args.require_tool_use):
+                rec = {
+                    "messages": tr["messages"],
+                    "meta": {
+                        "verified": True,
+                        "task_id": p.get("task_id"),
+                        "tool_calls": tr["tool_calls"],
+                        "tools_used": tr["tools_used"],
+                        "prompt_mode": args.prompt_mode,
+                        "source": "tool_trajectory",
+                    },
+                }
+                fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                fh.flush()
+                kept += 1
+            if i % 10 == 0 or i == len(problems):
+                rate = kept / attempted if attempted else 0.0
+                print(
+                    "  [%d/%d] kept=%d with_tool_use=%d verified_rate=%.2f (%.0fs)"
+                    % (i, len(problems), kept, with_tool_use, rate, time.time() - t0),
+                    flush=True,
+                )
+
+    print("=" * 64, flush=True)
+    print("TOOL-USE CORPUS BUILT", flush=True)
+    print("  attempted       : %d" % attempted, flush=True)
+    print("  with_tool_use   : %d  (model actually called a tool)" % with_tool_use, flush=True)
+    print("  kept (verified) : %d  (held-back tests passed AND used a tool)" % kept, flush=True)
+    print("  out             : %s" % out_path, flush=True)
+
+    # freeze: content-hash the corpus so drift before/after training is detectable (same as VTC)
+    try:
+        from python.helm.freeze_dataset import sha256_file
+
+        if kept:
+            print("  sha256          : %s" % sha256_file(out_path), flush=True)
+    except Exception as exc:
+        print("  (freeze-hash skipped: %s)" % exc, flush=True)
+    print("=" * 64, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
Re-lands two files dropped from main during the #2544 conflict resolution:

- **`scripts/training/harvest_tool_corpus.py`** — builds the verified tool-use corpus from MBPP via the ReAct loop. Keeps a record only if the final answer passes **held-back** tests AND a tool was actually called. Supports `--prompt-mode confirm|repair-biased`, writes incrementally, content-hashes (freeze) at the end.
- **`scripts/training/audit_tool_corpus.py`** — **independent** re-verification of a built corpus (verify-the-verifier): re-runs each record's final code on held-back tests with a *separate* subprocess checker (does not import `public_bench._verify`), plus structural checks (no few-shot demo leak, no duplicate task_ids) and trajectory-shape stats (repair vs confirm vs multi-call).

## Verification
- `flake8` clean on both.
- Both run end-to-end on current main (harvest → audit pipeline executes; auditor PASSes structural checks).

## Known follow-up (separate)
Actual harvest **yield is currently 0** because the **few-shot bootstrap was also dropped** from `python/helm/tool_trajectory.py` in the same #2544 merge — without the worked CALL/TOOL/ANSWER demo, the weak local 1.5B never emits the protocol (0/12 tool use). These tools are correct; restoring few-shot to `tool_trajectory.py` makes them yield records again. Tracked separately to keep this PR scoped + avoid colliding with parallel edits to that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)