### PR TITLE
fix(training): restore dropped few-shot bootstrap in tool_trajectory

### DIFF
--- a/python/helm/tool_trajectory.py
+++ b/python/helm/tool_trajectory.py
@@ -48,6 +48,21 @@ REPAIR_BIASED_SYSTEM = (
     "  4. Only give ANSWER after using the tool feedback."
 )
 
+# A worked example shown to coax a weak model into the CALL/TOOL/ANSWER protocol. It is PROMPTING
+# scaffolding only -- solve_with_tools strips it from the saved record so we never train on the demo,
+# just on the model's own real trajectory. Uses a throwaway problem (no leakage into any eval). Without
+# it, a 1.5B ignores the protocol and answers directly (0 tool use) -- this is the bootstrap.
+FEWSHOT_TURNS: List[Dict[str, str]] = [
+    {
+        "role": "user",
+        "content": "Write triple(n) returning n*3.\n\nExample test (you may run_code against it):\n"
+        "assert triple(2) == 6",
+    },
+    {"role": "assistant", "content": "```python\ndef triple(n):\n    return n * 3\n```\nCALL run_code"},
+    {"role": "user", "content": "TOOL run_code: PASS (example test)"},
+    {"role": "assistant", "content": "ANSWER:\n```python\ndef triple(n):\n    return n * 3\n```"},
+]
+
 
 # --------------------------------------------------------------------------------------------------
 # tools (deterministic; the model calls them, the harness runs them)
@@ -183,10 +198,12 @@ def solve_with_tools(
     public_k: int = 1,
     system: str = SYSTEM,
     prompt_mode: str = "confirm",
+    few_shot: bool = True,
 ) -> Dict[str, Any]:
     """Run the model through a tool dialogue and record EVERY turn. Verify the final answer on HELD-BACK
-    tests (test_list[public_k:]) the model never saw. Returns the transcript + whether it verified and
-    whether it actually used a tool."""
+    tests (test_list[public_k:]) the model never saw. With few_shot, a worked example is prepended to coax
+    a weak model into the protocol, then STRIPPED from the saved record (we don't train on the demo).
+    Returns the (demo-stripped) transcript + whether it verified and whether it actually used a tool."""
     tools = tools or build_tools(problem, public_k)
     head = (problem.get("prompt") or problem.get("text") or "").strip()
     tl = list(problem.get("test_list", []))
@@ -205,13 +222,13 @@ def solve_with_tools(
     elif prompt_mode != "confirm":
         raise ValueError("unsupported prompt_mode: %s" % prompt_mode)
 
-    msgs: List[Dict[str, str]] = [
-        {"role": "system", "content": system},
-        {
-            "role": "user",
-            "content": head + mode_note + "\n\nExample test (you may run_code against it):\n" + "\n".join(public),
-        },
-    ]
+    demo = list(FEWSHOT_TURNS) if few_shot else []
+    real_user = {
+        "role": "user",
+        "content": head + mode_note + "\n\nExample test (you may run_code against it):\n" + "\n".join(public),
+    }
+    msgs: List[Dict[str, str]] = [{"role": "system", "content": system}] + demo + [real_user]
+    keep_from = 1 + len(demo)  # record = system + real problem onward; the demo is scaffolding, not data
     final_code = ""
     tool_calls = 0
     tools_used: List[str] = []
@@ -235,8 +252,9 @@ def solve_with_tools(
         msgs.append({"role": "user", "content": "Use a tool (CALL ...) or give ANSWER: with a code block."})
     # TRUTH: held-back tests the model never saw (the shown example is public[0])
     verified = bool(final_code) and bool(_verify(final_code, public, held, imports).get("hidden_passed"))
+    record_messages = [msgs[0]] + msgs[keep_from:]  # drop the few-shot demo: train on the real trajectory only
     return {
-        "messages": msgs,
+        "messages": record_messages,
         "final_code": final_code,
         "verified": verified,
         "tool_calls": tool_calls,
@@ -253,14 +271,16 @@ def harvest_tool_traces(
     public_k: int = 1,
     require_tool_use: bool = True,
     prompt_mode: str = "confirm",
+    few_shot: bool = True,
 ) -> Dict[str, Any]:
     """Keep ONLY verified trajectories (held-back tests passed). With require_tool_use, also require the
-    model actually called a tool -- so the corpus teaches ORCHESTRATION, not just lucky one-shot answers."""
+    model actually called a tool -- so the corpus teaches ORCHESTRATION, not just lucky one-shot answers.
+    few_shot coaxes a weak model into the protocol (the demo is stripped from each saved record)."""
     records: List[Dict[str, Any]] = []
     attempted = with_tool_use = 0
     for p in problems:
         attempted += 1
-        tr = solve_with_tools(p, ask, tools, max_steps, public_k, prompt_mode=prompt_mode)
+        tr = solve_with_tools(p, ask, tools, max_steps, public_k, prompt_mode=prompt_mode, few_shot=few_shot)
         if tr["used_tool"]:
             with_tool_use += 1
         if tr["verified"] and (tr["used_tool"] or not require_tool_use):

--- a/tests/test_governed_tools.py
+++ b/tests/test_governed_tools.py
@@ -109,7 +109,9 @@ def test_helm_adapter_feeds_governed_tools_to_tool_trajectory():
             return "```python\ndef add(a, b):\n    return a + b\n```\nCALL run_code"
         return "ANSWER:\n```python\ndef add(a, b):\n    return a + b\n```"
 
-    tr = solve_with_tools(PROBLEM, ask, tools=tools, max_steps=4)
+    # few_shot=False: this scripted ask answers as soon as it sees a TOOL turn, and the few-shot demo
+    # carries one -- a deterministic solver needs no protocol coaxing, so opt out of the demo here.
+    tr = solve_with_tools(PROBLEM, ask, tools=tools, max_steps=4, few_shot=False)
 
     assert tr["verified"] is True
     assert tr["used_tool"] is True

--- a/tests/test_tool_trajectory.py
+++ b/tests/test_tool_trajectory.py
@@ -8,6 +8,7 @@ is NOT counted as verified tool use.
 from __future__ import annotations
 
 from python.helm.tool_trajectory import (
+    FEWSHOT_TURNS,
     _factor,
     _is_prime,
     _safe_calc,
@@ -71,6 +72,32 @@ def test_repair_biased_prompt_mode_adds_feedback_loop_instruction():
     assert tr["verified"] is True
     assert "Repair-biased harvest mode" in seen["system"]
     assert "quick minimal candidate" in seen["user"]
+
+
+def test_few_shot_demo_coaxes_then_is_stripped_from_record():
+    # guards the bootstrap that fixes the 0-tool-use wall against being silently dropped again
+    assert FEWSHOT_TURNS, "the few-shot bootstrap demo must exist"
+
+    seen = {}
+
+    def ask(msgs):
+        seen["prompt"] = [dict(m) for m in msgs]
+        return "ANSWER:\n```python\ndef add(a, b):\n    return a + b\n```"
+
+    tr = solve_with_tools(PROBLEM, ask, max_steps=1, few_shot=True)
+    # the model SAW the worked demo (coaxing)...
+    assert any("triple(n)" in m["content"] for m in seen["prompt"])
+    # ...but the demo is STRIPPED from the saved record (we train on the model's own trajectory only)
+    assert all("triple(n)" not in m["content"] for m in tr["messages"])
+
+    seen2 = {}
+
+    def ask2(msgs):
+        seen2["prompt"] = [dict(m) for m in msgs]
+        return "ANSWER:\n```python\ndef add(a, b):\n    return a + b\n```"
+
+    solve_with_tools(PROBLEM, ask2, max_steps=1, few_shot=False)
+    assert all("triple(n)" not in m["content"] for m in seen2["prompt"])  # opt-out shows no demo
 
 
 def test_held_back_rejects_shown_test_only_pass():


### PR DESCRIPTION
## Problem
The #2544 merge dropped the **few-shot bootstrap** from `python/helm/tool_trajectory.py` (originally `031190efe`). Without the worked CALL/TOOL/ANSWER demo, the weak local 1.5B never emits the tool protocol — **0 tool use, empty corpus** (confirmed: 0/12 on current main). This is the same class of regression as the desktop_access fix #2544 dropped and #2545 re-landed.

## Fix
Restored `FEWSHOT_TURNS` + the `few_shot` param + demo-stripping, integrated with the *current* `prompt_mode`/`REPAIR_BIASED_SYSTEM` structure (not a revert — re-implemented on top of Codex's layout). The demo coaxes the model into the protocol and is **stripped from every saved record**, so we train on the model's own trajectory, not the demo.

## Verification
- Live smoke (qwen2.5-coder:1.5b, 5 problems): **0 → 5/5 tool use, 5/5 verified**, demo confirmed stripped from records.
- `flake8` clean; **20 tests pass**.
- Added `test_few_shot_demo_coaxes_then_is_stripped_from_record` — a regression guard so the bootstrap can't be silently dropped again.
- One scripted governed-tools test now opts out via `few_shot=False` (a deterministic solver needs no coaxing, and the demo's TOOL turn would short-circuit its answer-on-first-tool-turn logic).

Pairs with #2546 (re-lands the runner + auditor). Together these restore the working, reproducible, auditable tool-use harvester to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)