### PR TITLE
fix(config): prune dead MCP entries

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -36,33 +36,29 @@
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PAT}"
       }
     },
-    "scbe-orchestrator": {
+    "scbe-verify": {
       "type": "stdio",
       "command": "python",
       "args": [
-        "mcp/orchestrator.py"
+        "src/mcp/scbe_verify_mcp.py"
       ],
-      "env": {
-        "SWARM_DRY_RUN": "1"
-      }
-    },
-    "youtube-studio": {
-      "type": "stdio",
-      "command": "youtube-studio-mcp",
-      "args": [],
       "env": {}
     },
-    "notion-sweep": {
+    "scbe-govern": {
       "type": "stdio",
       "command": "python",
       "args": [
-        "mcp/notion_server.py"
+        "src/mcp/scbe_govern_mcp.py"
       ],
-      "env": {
-        "NOTION_API_KEY": "${NOTION_API_KEY}",
-        "NOTION_TOKEN": "${NOTION_TOKEN}",
-        "NOTION_MCP_TOKEN": "${NOTION_MCP_TOKEN}"
-      }
+      "env": {}
+    },
+    "scbe-context": {
+      "type": "stdio",
+      "command": "python",
+      "args": [
+        "src/mcp/context_broker_mcp.py"
+      ],
+      "env": {}
     },
     "kaggle": {
       "type": "stdio",

--- a/tests/test_mcp_config_hygiene.py
+++ b/tests/test_mcp_config_hygiene.py
@@ -1,0 +1,46 @@
+import json
+import shutil
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_mcp_config() -> dict:
+    return json.loads((REPO_ROOT / ".mcp.json").read_text(encoding="utf-8"))
+
+
+def test_mcp_config_json_is_valid_and_has_servers():
+    cfg = _load_mcp_config()
+    assert isinstance(cfg.get("mcpServers"), dict)
+    assert cfg["mcpServers"]
+
+
+def test_repo_local_python_mcp_entries_point_to_existing_scripts():
+    cfg = _load_mcp_config()
+    missing = []
+    for name, server in cfg["mcpServers"].items():
+        command = server.get("command")
+        args = server.get("args") or []
+        if command != "python":
+            continue
+        for arg in args:
+            if isinstance(arg, str) and arg.endswith(".py") and not (REPO_ROOT / arg).is_file():
+                missing.append(f"{name}:{arg}")
+    assert missing == []
+
+
+def test_mcp_config_does_not_reference_known_removed_local_servers():
+    cfg_text = (REPO_ROOT / ".mcp.json").read_text(encoding="utf-8")
+    assert "mcp/orchestrator.py" not in cfg_text
+    assert "mcp/notion_server.py" not in cfg_text
+    assert "youtube-studio-mcp" not in cfg_text
+
+
+def test_mcp_config_uses_available_local_launchers_for_non_remote_commands():
+    cfg = _load_mcp_config()
+    missing = []
+    for name, server in cfg["mcpServers"].items():
+        command = server.get("command")
+        if command in {"cmd", "python", "npx"} and shutil.which(command) is None:
+            missing.append(f"{name}:{command}")
+    assert missing == []


### PR DESCRIPTION
## Summary
- replace dead local MCP entries with live SCBE verify/govern/context servers
- add a config hygiene regression test for JSON validity, repo-local Python script paths, removed-server strings, and local launcher availability

## Tests
- `SCBE_FORCE_SKIP_LIBOQS=1 pytest tests/test_mcp_config_hygiene.py -q`
- `python -m json.tool .mcp.json > $null`