### PR TITLE
feat(port): universal backend port -- audio/visual/text/agentic over MCP + multi-port

### DIFF
--- a/python/scbe/universal_port.py
+++ b/python/scbe/universal_port.py
@@ -1,0 +1,263 @@
+"""universal_port: one governed front door for ANY input modality, surfaced over many transports.
+
+The session thesis ([[correct-process-injection]]): the model ROUTES, the backends carry the capability,
+the gate decides permission. The piece that did not exist yet is the FRONT DOOR -- a single port that
+takes audio, vision, text, or an agentic tool-call as the DEFAULT inputs, normalizes each into one
+governed request, routes it (gate -> triage -> execute), and exposes the SAME tool registry over several
+transports (in-process API, MCP, HTTP). This module builds ONLY that missing layer:
+
+    * routing            -> reused from process_router (Policy gate, triage_rules / triage_model)
+    * governance + seal  -> reused from desktop_access.ActionRegistry (allowlist + destructive screen +
+                            forward-chained sealed audit) -- every tool call goes through invoke()
+    * the tools          -> reused (desktop actions; register more via register_tool / tool_action)
+
+Modality adapters are PLUGGABLE and HONEST. text is identity. agentic is a structured {tool,args} direct
+call. audio/visual need a real transcriber/vision backend WIRED via register_backend -- with none wired
+they accept an already-decoded {"transcript"}/{"text"}/{"caption"}/{"ocr"} payload, and otherwise return
+an honest needs-backend marker instead of faking recognition (no silent fabrication of input).
+
+    port = UniversalPort()
+    port.register_tool(tool_action("calc", "evaluate arithmetic", lambda p: _safe_calc(p["expr"]),
+                                   params={"expr": "string"}))
+    port.handle(Envelope("text", "Classify the number 91 by its prime structure."))   # -> routed
+    port.handle(Envelope("agentic", {"tool": "calc", "args": {"expr": "6*7"}}))        # -> governed call
+    port.transports()   # {"api": ..., "mcp": [...], "http": [...]}  -- one registry, many ports
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from .desktop_access import Action, ActionRegistry, default_registry
+from .process_router import KINDS, Policy, triage_rules
+
+# the DEFAULT input modalities the port accepts out of the box
+TEXT, AUDIO, VISUAL, AGENTIC = "text", "audio", "visual", "agentic"
+DEFAULT_MODALITIES = (TEXT, AUDIO, VISUAL, AGENTIC)
+
+
+@dataclass
+class Envelope:
+    """A raw input arriving at the port. content is modality-shaped: text=str; audio/visual=bytes or an
+    already-decoded {"transcript"/"text"/...} dict; agentic={"tool": name, "args": {...}}."""
+
+    modality: str
+    content: Any
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Normalized:
+    """Adapter output: the routable text, plus an optional direct {tool,args} for an agentic call."""
+
+    text: str
+    modality: str
+    direct: Optional[Dict[str, Any]] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+# an adapter turns raw modality content into a Normalized request
+Adapter = Callable[[Any, Dict[str, Any]], Normalized]
+
+
+def tool_action(
+    name: str,
+    summary: str,
+    handler: Callable[[Dict[str, Any]], Any],
+    params: Optional[Dict[str, str]] = None,
+    safety: str = "safe",
+    text_param: Optional[str] = None,
+) -> Action:
+    """Build a desktop_access.Action from a plain handler, filling the DOM/ARIA fields with sane defaults
+    so registering a governed tool is one line. The handler receives the params dict and returns a result.
+    Leave text_param=None for STRUCTURED args (numbers/expressions); set it only for a free-text command
+    param you want the L13 intent gate to scan -- L13 false-positives on short structured values."""
+    return Action(
+        name=name,
+        summary=summary,
+        params=params or {},
+        safety=safety,
+        selector="#%s" % name,
+        role="button",
+        label=summary,
+        handler=handler,
+        text_param=text_param,
+    )
+
+
+def _decoded(content: Any, keys: tuple) -> Optional[str]:
+    """Pull already-decoded text from a dict payload (e.g. {'transcript': ...}) or a bare string."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        for k in keys:
+            if isinstance(content.get(k), str):
+                return content[k]
+    return None
+
+
+class UniversalPort:
+    """gate -> normalize(modality) -> route/execute, with one governed tool registry on many transports."""
+
+    def __init__(
+        self,
+        registry: Optional[ActionRegistry] = None,
+        policy: Optional[Policy] = None,
+        ask: Optional[Callable[[str], str]] = None,
+        router: Optional[Callable[..., str]] = None,
+    ) -> None:
+        self.registry = registry or default_registry()  # governed tools + sealed audit (reused)
+        self.policy = policy or Policy()  # permission floor (reused)
+        self.ask = ask  # optional model for triage/execute; None -> route only, never fabricate
+        self.router = router or triage_rules
+        self.adapters: Dict[str, Adapter] = {}
+        self.backends: Dict[str, Callable[[Any], str]] = {}  # wired STT / vision, by modality
+        self._install_defaults()
+
+    # ---- modality adapters (the DEFAULT inputs) ----
+    def _install_defaults(self) -> None:
+        self.adapters[TEXT] = lambda content, meta: Normalized(str(content), TEXT, meta=meta)
+        self.adapters[AUDIO] = lambda content, meta: self._sensory(AUDIO, content, meta, ("transcript", "text"))
+        self.adapters[VISUAL] = lambda content, meta: self._sensory(VISUAL, content, meta, ("text", "caption", "ocr"))
+        self.adapters[AGENTIC] = self._agentic_adapter
+
+    def _sensory(self, modality: str, content: Any, meta: Dict[str, Any], keys: tuple) -> Normalized:
+        """audio/visual: use a wired backend if present, else an already-decoded payload, else be honest."""
+        backend = self.backends.get(modality)
+        if backend is not None:
+            return Normalized(str(backend(content)), modality, meta=meta)
+        pre = _decoded(content, keys)
+        if pre is not None:
+            return Normalized(pre, modality, meta={**meta, "source": "pre-decoded"})
+        return Normalized(
+            "", modality, meta={**meta, "needs_backend": modality, "note": "no %s backend wired" % modality}
+        )
+
+    def _agentic_adapter(self, content: Any, meta: Dict[str, Any]) -> Normalized:
+        if isinstance(content, dict) and "tool" in content:
+            return Normalized(
+                "call %s" % content["tool"],
+                AGENTIC,
+                direct={"tool": content["tool"], "args": content.get("args", {})},
+                meta=meta,
+            )
+        return Normalized(str(content), AGENTIC, meta={**meta, "note": "no {tool,args} -> treated as text"})
+
+    def register_adapter(self, modality: str, fn: Adapter) -> None:
+        self.adapters[modality] = fn
+
+    def register_backend(self, modality: str, fn: Callable[[Any], str]) -> None:
+        """Wire a real recognizer for a sensory modality (e.g. whisper for audio, a vision model for visual)."""
+        self.backends[modality] = fn
+
+    def register_tool(self, action: Action) -> None:
+        self.registry.register(action)
+
+    # ---- the front door: gate -> normalize -> route/execute ----
+    def handle(self, envelope: Envelope) -> Dict[str, Any]:
+        adapter = self.adapters.get(envelope.modality)
+        if adapter is None:
+            return {"decision": "NO_ADAPTER", "modality": envelope.modality}
+        norm = adapter(envelope.content, envelope.meta)
+        if norm.meta.get("needs_backend"):
+            return {"decision": "NEEDS_BACKEND", "modality": envelope.modality, "detail": norm.meta}
+
+        # PERMISSION GATE on the normalized text (the assistant decides, not the model)
+        if not self.policy.permits(norm.text):
+            return {
+                "decision": "REFUSED",
+                "reason": "permission",
+                "modality": envelope.modality,
+                "normalized": norm.text,
+            }
+
+        # AGENTIC direct tool call -> governed + sealed invoke
+        if norm.direct:
+            rec = self.registry.invoke(
+                norm.direct["tool"], norm.direct.get("args", {}), confirm=envelope.meta.get("confirm")
+            )
+            return {
+                "decision": rec.get("decision"),
+                "result": rec.get("result"),
+                "seal": rec.get("seal"),
+                "route": AGENTIC,
+                "modality": envelope.modality,
+            }
+
+        # TRIAGE: name the backend (deterministic rules, or the model as router if an `ask` is wired)
+        route = self.router(norm.text, self.ask) if self.router is not triage_rules else self.router(norm.text)
+        out: Dict[str, Any] = {
+            "route": route,
+            "normalized": norm.text,
+            "modality": envelope.modality,
+            "meta": norm.meta,
+        }
+        if self.ask is None:
+            out["decision"] = "ROUTED"  # named the backend; execution is the backend's job (no model wired)
+            return out
+        from .process_router import EXECUTORS, _route_judge  # lazy: only when executing through a model
+
+        out["decision"] = "OK"
+        out["result"] = EXECUTORS.get(route, _route_judge)(norm.text, self.ask)
+        return out
+
+    # ---- MULTI-PORT: one registry, many transports ----
+    def call(self, tool: str, args: Optional[Dict[str, Any]] = None, confirm: Optional[str] = None) -> Dict[str, Any]:
+        """In-process API surface -- governed + sealed."""
+        return self.registry.invoke(tool, args or {}, confirm)
+
+    def mcp_tools(self) -> List[Dict[str, Any]]:
+        """MCP surface: the registry's tool schemas + the universal_handle meta-tool."""
+        tools = list(self.registry.mcp_tools())
+        tools.append(
+            {
+                "name": "universal_handle",
+                "description": "normalize and route an input of any modality (text/audio/visual/agentic)",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"modality": {"type": "string", "enum": list(DEFAULT_MODALITIES)}, "content": {}},
+                    "required": ["modality", "content"],
+                },
+            }
+        )
+        return tools
+
+    def http_routes(self) -> List[Dict[str, str]]:
+        """HTTP surface: a POST route per tool + the universal /handle endpoint."""
+        routes = [{"method": "POST", "path": "/handle", "handler": "handle"}]
+        routes += [
+            {"method": "POST", "path": "/tool/%s" % name, "handler": name} for name in sorted(self.registry.actions)
+        ]
+        return routes
+
+    def transports(self) -> Dict[str, Any]:
+        """The multi-port manifest: the SAME registry reachable three ways."""
+        return {
+            "modalities": list(self.adapters),
+            "api": "call(tool, args, confirm)",
+            "mcp": [t["name"] for t in self.mcp_tools()],
+            "http": [r["path"] for r in self.http_routes()],
+            "kinds": list(KINDS),
+        }
+
+
+def make_fastapi_app(port: Optional[UniversalPort] = None):  # pragma: no cover - optional transport
+    """Mount the port as a FastAPI app (the HTTP transport). Lazy-imports fastapi so the core stays
+    dependency-free; raises only if you actually ask for the HTTP surface without fastapi installed."""
+    from fastapi import FastAPI, Request  # noqa: E402
+
+    p = port or UniversalPort()
+    app = FastAPI(title="SCBE Universal Port")
+
+    @app.post("/handle")
+    async def _handle(req: Request):
+        body = await req.json()
+        return p.handle(Envelope(body.get("modality", TEXT), body.get("content"), body.get("meta", {})))
+
+    @app.post("/tool/{name}")
+    async def _tool(name: str, req: Request):
+        body = await req.json()
+        return p.call(name, body.get("args", {}), body.get("confirm"))
+
+    return app

--- a/src/mcp/scbe_universal_mcp.py
+++ b/src/mcp/scbe_universal_mcp.py
@@ -1,0 +1,172 @@
+"""scbe-universal MCP server -- the universal backend PORT exposed over MCP.
+
+One governed front door for any input modality (text / audio / visual / agentic), surfaced as MCP tools.
+The capability is reused (python/scbe/universal_port.py): routing = process_router, governance + sealed
+audit = desktop_access.ActionRegistry, tools = desktop actions + safe compute tools registered here. This
+file is just the MCP transport over that port -- the same registry the in-process API and HTTP surfaces use.
+
+Tools:
+  * universal_handle(modality, content)  -- normalize+gate+route any input. content may be a JSON string
+    (e.g. an agentic {"tool":"calc","args":{"expr":"6*7"}}) or plain text. Audio/visual accept an already
+    -decoded {"transcript"/"text"} payload; a real STT/vision backend is wired in code, not faked here.
+  * call_tool(name, args)                -- invoke ONE governed tool directly (sealed receipt).
+  * list_transports()                    -- the multi-port manifest (api / mcp / http) + modalities.
+
+Transport: stdio by default (local clients). For a URL client run --transport streamable-http
+(host/port via SCBE_MCP_HOST / SCBE_MCP_PORT). SECURITY: call_tool runs governed actions; the gate
+refuses destructive/unpermitted ops, but do not expose over the network without auth/rate-limiting.
+
+    python src/mcp/scbe_universal_mcp.py --self-test     # offline check, no SDK needed
+    python src/mcp/scbe_universal_mcp.py                  # stdio MCP server
+    SCBE_MCP_PORT=8766 python src/mcp/scbe_universal_mcp.py --transport streamable-http
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, List, Optional
+
+_ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(_ROOT), str(_ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from python.helm.tool_trajectory import _is_prime, _safe_calc  # noqa: E402
+from python.scbe.universal_port import Envelope, UniversalPort, tool_action  # noqa: E402
+
+try:
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP(
+        "scbe-universal",
+        host=os.environ.get("SCBE_MCP_HOST", "127.0.0.1"),
+        port=int(os.environ.get("SCBE_MCP_PORT", "8766")),
+    )
+    _HAVE_MCP = True
+except Exception:  # pragma: no cover - exercised only without the SDK installed
+
+    class _StubMCP:
+        def tool(self, *a, **k):
+            def deco(fn):
+                return fn
+
+            return deco
+
+    mcp = _StubMCP()
+    _HAVE_MCP = False
+
+_READONLY = {"readOnlyHint": True}
+
+
+def _build_port() -> UniversalPort:
+    """The shared port: desktop actions (governed) + two safe compute tools for agentic demos/calls."""
+    port = UniversalPort()
+    port.register_tool(
+        tool_action(
+            "calc",
+            "evaluate arithmetic",
+            lambda p: _safe_calc(str(p.get("expr", ""))),
+            params={"expr": "string"},
+        )
+    )
+    port.register_tool(
+        tool_action(
+            "is_prime",
+            "primality test",
+            lambda p: _is_prime(str(p.get("n", ""))),
+            params={"n": "string"},
+        )
+    )
+    return port
+
+
+PORT = _build_port()
+
+
+def _parse_content(content: str) -> Any:
+    """Content arrives as a string over MCP; parse JSON if it is JSON, else treat as plain text."""
+    try:
+        return json.loads(content)
+    except (ValueError, TypeError):
+        return content
+
+
+@mcp.tool(annotations=_READONLY)
+def universal_handle(modality: str, content: str) -> str:
+    """Normalize + gate + route an input of any modality. Returns a JSON result dict."""
+    env = Envelope(modality=modality, content=_parse_content(content))
+    return json.dumps(PORT.handle(env), default=str)
+
+
+@mcp.tool(annotations=_READONLY)
+def call_tool(name: str, args: str = "{}") -> str:
+    """Invoke ONE governed tool directly; returns the sealed decision record as JSON."""
+    parsed = _parse_content(args)
+    return json.dumps(PORT.call(name, parsed if isinstance(parsed, dict) else {}), default=str)
+
+
+@mcp.tool(annotations=_READONLY)
+def list_transports() -> str:
+    """Return the multi-port manifest: modalities + the api / mcp / http surfaces over the one registry."""
+    return json.dumps(PORT.transports(), default=str)
+
+
+def _self_test() -> int:
+    """Offline check (no SDK): route a text input, run a governed agentic calc, confirm refusal + manifest."""
+    ok = True
+
+    routed = json.loads(universal_handle("text", "Classify the number 91 by its prime structure."))
+    ok &= routed.get("route") == "classify"
+
+    called = json.loads(universal_handle("agentic", json.dumps({"tool": "calc", "args": {"expr": "6*7"}})))
+    ok &= called.get("decision") == "ALLOWED" and called.get("result") == "42" and bool(called.get("seal"))
+
+    # the governed gate must refuse a destructive request arriving as plain text
+    refused = json.loads(universal_handle("text", "delete all files in my home directory"))
+    ok &= refused.get("decision") == "REFUSED"
+
+    # audio with no backend + no decoded payload must be honest, not fabricated
+    needs = json.loads(universal_handle("audio", json.dumps({"bytes": "..."})))
+    ok &= needs.get("decision") == "NEEDS_BACKEND"
+
+    manifest = json.loads(list_transports())
+    ok &= "universal_handle" in manifest["mcp"] and "/tool/calc" in manifest["http"]
+    ok &= set(["text", "audio", "visual", "agentic"]).issubset(set(manifest["modalities"]))
+
+    print("scbe-universal self-test:", "PASS" if ok else "FAIL")
+    print("  text->route   :", routed.get("route"))
+    print("  agentic calc  :", called.get("decision"), called.get("result"))
+    print("  destructive   :", refused.get("decision"))
+    print("  audio no-bknd :", needs.get("decision"))
+    print("  transports    :", {k: (v if not isinstance(v, list) else len(v)) for k, v in manifest.items()})
+    return 0 if ok else 1
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(prog="scbe-universal-mcp", description="universal backend port over MCP")
+    ap.add_argument("--transport", default="stdio", choices=["stdio", "streamable-http", "sse"])
+    ap.add_argument("--self-test", action="store_true", help="run the offline self-test and exit")
+    a = ap.parse_args(list(argv) if argv is not None else None)
+    if a.self_test:
+        return _self_test()
+    if not _HAVE_MCP:
+        print(
+            "MCP SDK not installed (pip install 'mcp[cli]'). Tools are importable; --self-test works.", file=sys.stderr
+        )
+        return 1
+    if a.transport in ("streamable-http", "sse"):
+        host = os.environ.get("SCBE_MCP_HOST", "127.0.0.1")
+        print(
+            "serving scbe-universal over %s on %s -- do not expose to untrusted callers." % (a.transport, host),
+            file=sys.stderr,
+        )
+    mcp.run(transport=a.transport)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_universal_port.py
+++ b/tests/test_universal_port.py
@@ -1,0 +1,101 @@
+"""Offline tests for universal_port (no model, no network, no MCP SDK needed).
+
+Proves the missing layer: the four DEFAULT modalities normalize correctly (text/audio/visual/agentic),
+audio/visual are honest when no backend is wired, the permission gate refuses destructive input, an
+agentic call is governed + sealed, and the SAME registry is reachable over every transport (api/mcp/http).
+"""
+
+from __future__ import annotations
+
+from python.helm.tool_trajectory import _safe_calc
+from python.scbe.universal_port import AGENTIC, AUDIO, TEXT, VISUAL, Envelope, UniversalPort, tool_action
+
+
+def _port() -> UniversalPort:
+    p = UniversalPort()
+    p.register_tool(
+        tool_action(
+            "calc",
+            "evaluate arithmetic",
+            lambda d: _safe_calc(str(d.get("expr", ""))),
+            params={"expr": "string"},
+        )
+    )
+    return p
+
+
+# ---- modality adapters (the default inputs) ----------------------------------------------------
+def test_text_modality_normalizes_and_routes():
+    out = _port().handle(Envelope(TEXT, "Classify the number 91 by its prime structure."))
+    assert out["decision"] == "ROUTED" and out["route"] == "classify" and out["modality"] == TEXT
+
+
+def test_audio_predecoded_payload_routes_without_a_backend():
+    out = _port().handle(Envelope(AUDIO, {"transcript": "Classify the number 7 by its prime structure."}))
+    assert out["decision"] == "ROUTED" and out["route"] == "classify"
+
+
+def test_audio_without_backend_is_honest_not_fabricated():
+    out = _port().handle(Envelope(AUDIO, {"bytes": "<raw audio>"}))
+    assert out["decision"] == "NEEDS_BACKEND" and out["detail"]["needs_backend"] == AUDIO
+
+
+def test_wired_backend_is_used():
+    p = _port()
+    p.register_backend(AUDIO, lambda _raw: "Classify the number 13 by its prime structure.")
+    out = p.handle(Envelope(AUDIO, b"<raw audio bytes>"))
+    assert out["decision"] == "ROUTED" and out["route"] == "classify"
+
+
+def test_visual_ocr_payload_routes():
+    out = _port().handle(Envelope(VISUAL, {"ocr": "What is the capital of France?"}))
+    assert out["decision"] == "ROUTED" and out["route"] == "judge"
+
+
+# ---- governance: the gate decides, not the model ----------------------------------------------
+def test_destructive_text_is_refused_at_the_gate():
+    out = _port().handle(Envelope(TEXT, "delete all the files in my home directory"))
+    assert out["decision"] == "REFUSED" and out["reason"] == "permission"
+
+
+# ---- agentic direct tool call: governed + sealed ----------------------------------------------
+def test_agentic_call_is_governed_and_sealed():
+    out = _port().handle(Envelope(AGENTIC, {"tool": "calc", "args": {"expr": "6*7"}}))
+    assert out["route"] == AGENTIC and out["decision"] == "ALLOWED"
+    assert out["result"] == "42" and isinstance(out["seal"], str) and out["seal"]
+
+
+def test_agentic_unknown_tool_is_not_fabricated():
+    out = _port().handle(Envelope(AGENTIC, {"tool": "nope", "args": {}}))
+    assert out["decision"] == "NO_ACTION"
+
+
+# ---- execute path (deterministic executor, no real model) -------------------------------------
+def test_execute_path_runs_deterministic_classify_backend():
+    # an `ask` is present so handle() executes; classify uses the sieve (no model call) -> exact answer
+    p = UniversalPort(ask=lambda _prompt: "")
+    out = p.handle(Envelope(TEXT, "Classify the number 91 by its prime structure."))
+    assert out["decision"] == "OK" and out["result"] == "composite"
+
+
+# ---- multi-port: one registry, many transports -------------------------------------------------
+def test_one_registry_reachable_over_every_transport():
+    p = _port()
+    # in-process API
+    rec = p.call("calc", {"expr": "2+2"})
+    assert rec["decision"] == "ALLOWED" and rec["result"] == "4"
+    # MCP surface lists the tool + the universal meta-tool
+    mcp_names = [t["name"] for t in p.mcp_tools()]
+    assert "calc" in mcp_names and "universal_handle" in mcp_names
+    # HTTP surface has a route for the tool + the /handle endpoint
+    paths = [r["path"] for r in p.http_routes()]
+    assert "/tool/calc" in paths and "/handle" in paths
+    # the manifest ties them together over the SAME registry
+    t = p.transports()
+    assert set(t["modalities"]) >= {TEXT, AUDIO, VISUAL, AGENTIC}
+    assert "calc" in t["mcp"] and "/tool/calc" in t["http"]
+
+
+def test_no_adapter_for_unknown_modality():
+    out = _port().handle(Envelope("smell", "..."))
+    assert out["decision"] == "NO_ADAPTER"


### PR DESCRIPTION
## What
A single **governed front door** that accepts any input modality as the default inputs, normalizes it, routes it, and exposes the one tool registry over multiple transports. This is the missing *front-door* layer — routing, governance, seals, and tools are all **reused**, not rebuilt.

### `python/scbe/universal_port.py`
- **Default modalities** as pluggable adapters: `text` (identity), `agentic` (`{tool,args}` direct call), `audio`/`visual` (use a wired STT/vision backend via `register_backend`, or an already-decoded `{transcript|text|caption|ocr}` payload; otherwise return an honest `NEEDS_BACKEND` — **no faked recognition**).
- Every input is **gated** (`process_router.Policy`), **routed** (`triage_rules` / model-as-router), and — for agentic — **invoked through `desktop_access.ActionRegistry`** (allowlist + destructive screen + forward-chained **sealed** receipt).
- **Multi-port**: the same registry over `call()` (in-process), `mcp_tools()` (MCP), `http_routes()` (+ optional `make_fastapi_app`).

### `src/mcp/scbe_universal_mcp.py`
- The port as an **MCP server** (FastMCP; `stdio` / `streamable-http` / `sse`). Tools: `universal_handle`, `call_tool`, `list_transports`. Offline `--self-test` (no SDK needed).

## Verification
- `flake8` clean; **11/11 tests** (`tests/test_universal_port.py`).
- MCP `--self-test` **PASS**: text→route, agentic `calc` **ALLOWED=42 (sealed)**, destructive→**REFUSED**, audio-no-backend→**NEEDS_BACKEND**, multi-port manifest consistent.

## Honest scope
Audio/visual recognition is a **pluggable hook**, not implemented here (no whisper/vision dependency added — $0). Wire a real backend with `register_backend("audio", fn)`. The L13 free-text gate is correctly **not** applied to structured numeric tool args (it false-positives on short values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)