### PR TITLE
fix(aether-desk): run allowlisted commands without shell

### DIFF
--- a/python/scbe/aether_desk.py
+++ b/python/scbe/aether_desk.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import copy
 import os
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -114,10 +115,14 @@ class AetherDesk:
 
         def run_command(p):
             cmd = str(p.get("command", "")).strip()
-            head = cmd.split()[0] if cmd else ""
+            try:
+                argv = shlex.split(cmd, posix=os.name != "nt")
+            except ValueError as exc:
+                return "invalid command syntax: %s" % exc
+            head = argv[0] if argv else ""
             if head not in _ALLOWED_CMDS:
                 return "command %r not on the workspace allowlist" % head
-            r = subprocess.run(cmd, shell=True, cwd=self.root, capture_output=True, text=True, timeout=60)
+            r = subprocess.run(argv, shell=False, cwd=self.root, capture_output=True, text=True, timeout=60)
             return ((r.stdout or "") + (r.stderr or "")).strip()[:4000] or "(no output, rc=%d)" % r.returncode
 
         def run_test(p):

--- a/tests/test_aether_desk.py
+++ b/tests/test_aether_desk.py
@@ -37,6 +37,17 @@ def test_never_delete_still_fires_inside(tmp_path):
     assert r["decision"] == "REFUSED" and "destructive" in r["result"]
 
 
+def test_run_command_uses_allowlisted_argv_not_shell_chaining(tmp_path):
+    desk = AetherDesk.open(tmp_path / "ws")
+    ok = desk.act("run_command", {"command": "python --version"}, confirm="task")
+    assert ok["decision"] == "ALLOWED"
+    assert "Python" in ok["result"]
+
+    chained = desk.act("run_command", {"command": "echo hello; echo smuggled"}, confirm="task")
+    assert chained["decision"] == "REFUSED"
+    assert "chaining" in chained["result"]
+
+
 def test_guarded_actions_need_confirm(tmp_path):
     desk = AetherDesk.open(tmp_path / "ws")
     assert desk.act("write_file", {"path": "x.txt", "content": "y"})["decision"] == "NEEDS_CONFIRM"


### PR DESCRIPTION
## Summary
- replace AetherDesk workspace command execution `shell=True` with parsed argv and `shell=False`
- keep the existing allowlist and chaining gate in front of command execution
- add a regression proving an allowlisted executable still runs while chained command text is refused

## Verification
- `python -m pytest tests\\test_aether_desk.py -q`
- `python -m bandit -r python/scbe/aether_desk.py -q --severity-level high`
- `python -m bandit -r src scripts api python agents -q --severity-level high -x tests,node_modules,dist,artifacts,training,external`

## Notes
This fixes the failed Security Checks run on `main` caused by Bandit B602 at `python/scbe/aether_desk.py:120`.