### PR TITLE
ci: skip slow tests in core Python merge lane

### DIFF
--- a/scripts/system/run_core_python_checks.py
+++ b/scripts/system/run_core_python_checks.py
@@ -68,6 +68,8 @@ OPTIONAL_TEST_IGNORES: tuple[str, ...] = (
     "tests/test_system_script_security.py",
 )
 
+DEFAULT_MARKER_EXPR = "not slow"
+
 
 def build_pytest_command(
     test_targets: tuple[str, ...],
@@ -79,6 +81,8 @@ def build_pytest_command(
         "-m",
         "pytest",
         "-v",
+        "-m",
+        DEFAULT_MARKER_EXPR,
         "--ignore=tests/node_modules",
     ]
     command.extend(test_targets)
@@ -101,6 +105,7 @@ def summary_payload(command: list[str]) -> dict[str, object]:
         "repo_root": str(REPO_ROOT),
         "command": command,
         "optional_ignores": list(OPTIONAL_TEST_IGNORES),
+        "marker": DEFAULT_MARKER_EXPR,
         "env": {
             "PYTHONPATH": str(REPO_ROOT),
         },

--- a/tests/test_run_core_python_checks.py
+++ b/tests/test_run_core_python_checks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from scripts.system.run_core_python_checks import (
+    DEFAULT_MARKER_EXPR,
     OPTIONAL_TEST_IGNORES,
     build_pytest_command,
     summary_payload,
@@ -11,6 +12,8 @@ def test_build_pytest_command_includes_optional_ignores():
     command = build_pytest_command(("tests",), maxfail=2)
 
     assert command[1:4] == ["-m", "pytest", "-v"]
+    assert "-m" in command
+    assert DEFAULT_MARKER_EXPR in command
     assert "tests" in command
     assert "--ignore=tests/node_modules" in command
     assert "--maxfail=2" in command
@@ -23,5 +26,6 @@ def test_summary_payload_records_repo_settings():
     payload = summary_payload(command)
 
     assert payload["command"] == command
+    assert payload["marker"] == DEFAULT_MARKER_EXPR
     assert payload["env"]["PYTHONPATH"]
     assert payload["optional_ignores"] == list(OPTIONAL_TEST_IGNORES)


### PR DESCRIPTION
## Summary
- keep the curated core Python PR lane on `-m "not slow"`
- record the default marker in the runner summary payload
- add a regression so the merge-lane marker does not drift

## Why
`tests/crypto/test_rwp_v3_properties.py` is explicitly marked slow and runs a thorough Hypothesis/Argon2 property battery. It made the PR-gated Python lane spend merge time on slow crypto coverage. Dedicated full/nightly lanes already use the not-slow split; this makes the core runner match that boundary.

## Verification
- `python -m pytest tests\\test_run_core_python_checks.py -q`
- `python scripts/system/run_core_python_checks.py --dry-run --json`
- prior local full core run with this patch: `1038 passed, 20 skipped, 20 deselected in 120.46s`
