### PR TITLE
feat(port): verify + escalate -- universal port never ships unverified silently

### DIFF
--- a/python/scbe/universal_port.py
+++ b/python/scbe/universal_port.py
@@ -9,6 +9,9 @@ transports (in-process API, MCP, HTTP). This module builds ONLY that missing lay
     * routing            -> reused from process_router (Policy gate, triage_rules / triage_model)
     * governance + seal  -> reused from desktop_access.ActionRegistry (allowlist + destructive screen +
                             forward-chained sealed audit) -- every tool call goes through invoke()
+    * verify + escalate  -> reused from code_factory (QC cross-check; a manager redoes a station on QC
+                            failure). The execute path reports `verified` honestly -- judge has no real
+                            verifier, so it returns decision=UNVERIFIED, never a silent ship.
     * the tools          -> reused (desktop actions; register more via register_tool / tool_action)
 
 Modality adapters are PLUGGABLE and HONEST. text is identity. agentic is a structured {tool,args} direct
@@ -105,11 +108,13 @@ class UniversalPort:
         registry: Optional[ActionRegistry] = None,
         policy: Optional[Policy] = None,
         ask: Optional[Callable[[str], str]] = None,
+        manager: Optional[Callable[[str], str]] = None,
         router: Optional[Callable[..., str]] = None,
     ) -> None:
         self.registry = registry or default_registry()  # governed tools + sealed audit (reused)
         self.policy = policy or Policy()  # permission floor (reused)
-        self.ask = ask  # optional model for triage/execute; None -> route only, never fabricate
+        self.ask = ask  # optional station model for triage/execute; None -> route only, never fabricate
+        self.manager = manager  # optional STRONGER model, summoned ONLY when QC fails (verify+escalate)
         self.router = router or triage_rules
         self.adapters: Dict[str, Adapter] = {}
         self.backends: Dict[str, Callable[[Any], str]] = {}  # wired STT / vision, by modality
@@ -196,11 +201,37 @@ class UniversalPort:
         if self.ask is None:
             out["decision"] = "ROUTED"  # named the backend; execution is the backend's job (no model wired)
             return out
-        from .process_router import EXECUTORS, _route_judge  # lazy: only when executing through a model
-
-        out["decision"] = "OK"
-        out["result"] = EXECUTORS.get(route, _route_judge)(norm.text, self.ask)
+        result, verified, escalated, has_verifier = self._execute_verified(route, norm.text)
+        out.update(
+            result=result,
+            verified=verified,  # the trust-without-reading signal: a REAL verifier passed (not just well-formed)
+            escalated=escalated,
+            has_verifier=has_verifier,
+            decision=("OK" if verified else "UNVERIFIED"),
+        )
         return out
+
+    def _execute_verified(self, route: str, text: str):
+        """Run the routed backend, then VERIFY + ESCALATE so a wrong result is never shipped silently.
+
+        Reuses code_factory.verify (classify=exact sieve; compute=differential cross-check executed-vs-direct;
+        judge=no real verifier). If a real-verifier route fails QC and a manager is wired, the stronger model
+        redoes just that station. Returns (result, verified, escalated, has_verifier). judge always comes back
+        has_verifier=False -> decision UNVERIFIED: an honest 'no trust guarantee', not a silent ship."""
+        from .code_factory import verify as _qc
+        from .process_router import EXECUTORS, _route_judge
+
+        ex = EXECUTORS.get(route, _route_judge)
+        result = ex(text, self.ask)
+        has_verifier = route in ("compute", "classify")
+        verified = bool(_qc(route, text, result, self.ask)) if has_verifier else False
+        escalated = False
+        if has_verifier and not verified and self.manager is not None:
+            redo = ex(text, self.manager)  # EXCEPTION -> summon the capable model for just this station
+            escalated = True
+            if _qc(route, text, redo, self.manager):
+                result, verified = redo, True
+        return result, verified, escalated, has_verifier
 
     # ---- MULTI-PORT: one registry, many transports ----
     def call(self, tool: str, args: Optional[Dict[str, Any]] = None, confirm: Optional[str] = None) -> Dict[str, Any]:

--- a/tests/test_universal_port.py
+++ b/tests/test_universal_port.py
@@ -99,3 +99,40 @@ def test_one_registry_reachable_over_every_transport():
 def test_no_adapter_for_unknown_modality():
     out = _port().handle(Envelope("smell", "..."))
     assert out["decision"] == "NO_ADAPTER"
+
+
+# ---- verify + escalate: never ship a wrong result silently -------------------------------------
+def _compute_ask(code_out: str, direct_out: str):
+    """A scripted station/manager: returns a code block for the 'write a program' prompt, a direct
+    number for the cross-check prompt. Lets us drive the QC cross-check deterministically (no model)."""
+
+    def ask(prompt):
+        if "Write a short Python program" in prompt:
+            return "```python\nprint(%s)\n```" % code_out
+        return direct_out  # the differential 'answer with only the number' branch
+
+    return ask
+
+
+def test_judge_comes_back_honest_unverified():
+    # judge has no real verifier -> the port must NOT claim a trust guarantee
+    p = UniversalPort(ask=lambda _p: "paris")
+    out = p.handle(Envelope(TEXT, "What is the capital of France?"))
+    assert out["route"] == "judge" and out["decision"] == "UNVERIFIED"
+    assert out["verified"] is False and out["has_verifier"] is False and "paris" in out["result"]
+
+
+def test_compute_cross_check_verifies_without_escalation():
+    # station's executed answer (6) agrees with its direct answer (6) -> verified, no manager needed
+    p = UniversalPort(ask=_compute_ask("6", "6"))
+    out = p.handle(Envelope(TEXT, "What is the sum of 2 and 4?"))
+    assert out["route"] == "compute" and out["decision"] == "OK"
+    assert out["verified"] is True and out["escalated"] is False and out["result"] == "6"
+
+
+def test_compute_qc_failure_escalates_to_manager():
+    # station ships 5 but its own cross-check says 6 -> QC fails -> manager redoes it and verifies
+    p = UniversalPort(ask=_compute_ask("5", "6"), manager=_compute_ask("6", "6"))
+    out = p.handle(Envelope(TEXT, "What is the sum of 2 and 4?"))
+    assert out["decision"] == "OK" and out["verified"] is True
+    assert out["escalated"] is True and out["result"] == "6"  # the manager's verified answer shipped


### PR DESCRIPTION
Follow-up to #2551. Turns the universal port from a *router* into a *never-fail* front door: the execute path now reports **`verified`** honestly and escalates on QC failure.

- **classify** → exact sieve → verified.
- **compute** → differential cross-check (executed answer must agree with the model's direct answer); on disagreement, a wired **manager** model redoes just that station (**escalate**).
- **judge** → no real verifier exists → returns **`decision=UNVERIFIED`** (an honest "no trust guarantee"), never a silent ship.

Reuses `code_factory.verify` (the QC cross-check) — not a rebuild. This is the trust-without-reading signal the whole stack is for: the caller (who can't read the output) gets `verified: true/false` + `escalated`.

**Verified:** flake8 clean; 14/14 tests (3 new: judge honest-unverified, compute verifies without escalation, compute QC-failure escalates to manager).

🤖 Generated with [Claude Code](https://claude.com/claude-code)