### PR TITLE
fix(deps): constrain pydantic-settings >=2.14.2 (close Dependabot #308)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy>=1.24",
     "jsonschema>=4.0",
+    # security floor: exclude the pydantic-settings symlink-traversal advisory (Dependabot #308; first
+    # patched 2.14.2). Transitive today and already pinned in requirements-lock.txt, but constrained here
+    # so the manifest itself can never resolve the vulnerable range.
+    "pydantic-settings>=2.14.2",
 ]
 authors = [
     {name = "Issac Daniel Davis", email = "issdandavis@users.noreply.github.com"},


### PR DESCRIPTION
Closes the one open Dependabot alert (#308, medium): pydantic-settings symlink-traversal outside `secrets_dir`, first patched **2.14.2**. The dep is transitive and `requirements-lock.txt` already pins 2.14.2 (installed version is safe) — this adds an explicit **security floor** in `pyproject.toml` so the manifest can never resolve the vulnerable range, closing the alert at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)