### PR TITLE
feat(reversible): reversible circuit = the structural model of a quantum circuit

### DIFF
--- a/python/scbe/reversible_circuit.py
+++ b/python/scbe/reversible_circuit.py
@@ -1,0 +1,124 @@
+"""reversible_circuit: reversible computing = the structural model of a QUANTUM circuit (Issac's point).
+
+Quantum gates are UNITARY = invertible = bijective, so a quantum circuit (everything except measurement) is
+REVERSIBLE -- the bijective clock of time_machine, generalized to a SEQUENCE of gates. Superposition is the
+"all at once"; MEASUREMENT is the only irreversible, information-erasing step (the arrow). This models the
+REVERSIBLE STRUCTURE: gates you can run forward and back, and Bennett UNCOMPUTATION -- compute a result,
+copy it out, then UNCOMPUTE the scratch back to clean, erasing NOTHING. Uncomputation is the core technique
+that lets quantum / low-energy reversible computers avoid the heat (Landauer) and decoherence of erasing
+information; here it is just forward-then-rewind on bijective gates.
+
+HONEST BOUNDARY: this is reversible CLASSICAL computing. It captures quantum's REVERSIBILITY and
+UNCOMPUTATION faithfully, but NOT superposition amplitudes, interference, or entanglement (those need a
+complex state vector). It is the substrate quantum needs, not the quantum magic -- do not call it a quantum
+computer. The bijective gate here is the same splitmix64 used as the time-step in time_machine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+from .elastic_bijective_hash import splitmix64
+
+MASK = (1 << 64) - 1
+Reg = Dict[str, int]
+
+
+@dataclass
+class Gate:
+    """A reversible gate: a bijection on the register file, with its inverse. (forward, inverse) are the
+    two directions of the same unitary -- run either way, no information lost."""
+
+    name: str
+    fwd: Callable[[Reg], Reg]
+    inv: Callable[[Reg], Reg]
+
+
+def xor_into(dst: str, src: str) -> Gate:
+    """CNOT-like: dst ^= src. Self-inverse (applying it twice restores dst) -- the reversible 'copy'."""
+
+    def op(s: Reg) -> Reg:
+        r = dict(s)
+        r[dst] = r[dst] ^ r[src]
+        return r
+
+    return Gate("xor %s<-%s" % (dst, src), op, op)
+
+
+def hash_into(dst: str, src: str) -> Gate:
+    """dst ^= splitmix64(src), with src PRESERVED. Self-inverse (XOR), so it uncomputes by re-application --
+    the reversible 'compute a function into a scratch register'. The bijective hash is the gate's logic."""
+
+    def op(s: Reg) -> Reg:
+        r = dict(s)
+        r[dst] = r[dst] ^ (splitmix64(r[src]) & MASK)
+        return r
+
+    return Gate("hash %s<-h(%s)" % (dst, src), op, op)
+
+
+def run(state: Reg, gates: List[Gate]) -> Reg:
+    for g in gates:
+        state = g.fwd(state)
+    return state
+
+
+def unrun(state: Reg, gates: List[Gate]) -> Reg:
+    """Run the circuit BACKWARD: inverses, in reverse order. run then unrun is the identity (reversible)."""
+    for g in reversed(gates):
+        state = g.inv(state)
+    return state
+
+
+def bennett_uncompute(x: int) -> Reg:
+    """The core quantum/reversible move: compute h(x) into a scratch register, COPY it to an output, then
+    UNCOMPUTE the scratch back to 0 -- nothing erased. End state: x preserved, scratch CLEAN (0), out = h(x).
+    This is why quantum avoids garbage qubits and why reversible computing avoids Landauer heat."""
+    compute = [hash_into("scratch", "x")]
+    s: Reg = {"x": x, "scratch": 0, "out": 0}
+    s = run(s, compute)  # scratch = h(x)
+    s = xor_into("out", "scratch").fwd(s)  # copy the answer out (reversibly)
+    s = unrun(s, compute)  # UNCOMPUTE the scratch -> 0, leaving out = h(x)
+    return s
+
+
+def demo() -> Dict[str, object]:
+    x = 1234567
+    expected = splitmix64(x) & MASK
+
+    # 1. a circuit run forward then backward is the identity (a reversible / unitary process)
+    gates = [hash_into("scratch", "x"), xor_into("out", "scratch"), hash_into("scratch", "x")]
+    start = {"x": x, "scratch": 0, "out": 0}
+    there = run(dict(start), gates)
+    roundtrip_identity = unrun(dict(there), gates) == start
+
+    # 2. Bennett uncomputation: scratch cleaned, output kept, nothing erased
+    end = bennett_uncompute(x)
+    clean_scratch = end["scratch"] == 0
+    answer_kept = end["out"] == expected
+    input_preserved = end["x"] == x
+
+    return {
+        "circuit_run_then_unrun_is_identity": roundtrip_identity,
+        "uncompute_cleans_scratch": clean_scratch,
+        "uncompute_keeps_answer": answer_kept,
+        "input_preserved": input_preserved,
+    }
+
+
+def main() -> int:
+    d = demo()
+    print("REVERSIBLE CIRCUIT -- the reversible STRUCTURE of a quantum circuit (no superposition; honest)")
+    print("  run forward then backward == identity (unitary/reversible): %s" % d["circuit_run_then_unrun_is_identity"])
+    print("  Bennett uncompute -> scratch back to CLEAN 0            : %s" % d["uncompute_cleans_scratch"])
+    print(
+        "  ...output keeps the answer h(x), input preserved        : %s, %s"
+        % (d["uncompute_keeps_answer"], d["input_preserved"])
+    )
+    print("  => computed a result and erased NOTHING (no Landauer cost, no garbage qubit).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reversible_circuit.py
+++ b/tests/test_reversible_circuit.py
@@ -1,0 +1,65 @@
+"""reversible_circuit: the reversible STRUCTURE of a quantum circuit (unitary = bijective), honest scope.
+
+These pin: a reversible circuit run forward then backward is the IDENTITY (no information lost -- the
+unitary property), the reversible gates are their own inverses, and Bennett UNCOMPUTATION computes a result
+while erasing nothing (scratch returns to clean 0, the answer is kept). Plus the honest arrow: without
+uncomputing, the scratch is left dirty -- the information you'd have to erase (Landauer), which is the
+irreversible step.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.elastic_bijective_hash import splitmix64  # noqa: E402
+from python.scbe.reversible_circuit import (  # noqa: E402
+    MASK,
+    bennett_uncompute,
+    demo,
+    hash_into,
+    run,
+    unrun,
+    xor_into,
+)
+
+
+def test_reversible_circuit_run_then_unrun_is_identity():
+    gates = [hash_into("scratch", "x"), xor_into("out", "scratch"), hash_into("scratch", "x")]
+    for x in (0, 1, 42, 2**50 + 9):
+        start = {"x": x, "scratch": 0, "out": 0}
+        end = run(dict(start), gates)
+        assert unrun(dict(end), gates) == start  # forward then backward == identity (unitary)
+
+
+def test_reversible_gates_are_their_own_inverse():
+    g = xor_into("a", "b")
+    s = {"a": 5, "b": 3}
+    assert g.fwd(g.fwd(dict(s))) == s  # apply twice -> identity
+    h = hash_into("scratch", "x")
+    s2 = {"scratch": 0, "x": 99}
+    assert h.fwd(h.fwd(dict(s2))) == s2
+
+
+def test_bennett_uncompute_cleans_scratch_and_keeps_the_answer():
+    x = 1234567
+    end = bennett_uncompute(x)
+    assert end["scratch"] == 0  # scratch uncomputed back to clean -- nothing left to erase
+    assert end["out"] == (splitmix64(x) & MASK)  # the answer was copied out before uncomputing
+    assert end["x"] == x  # input preserved -- the whole thing is reversible
+
+
+def test_without_uncompute_the_scratch_is_dirty_the_arrow():
+    # the honest contrast: compute + copy but DON'T uncompute -> scratch still holds h(x). That residual is
+    # the information you'd have to ERASE to reset, and erasing it is the only irreversible (arrow) step.
+    x = 42
+    compute = [hash_into("scratch", "x")]
+    s = run({"x": x, "scratch": 0, "out": 0}, compute)
+    s = xor_into("out", "scratch").fwd(s)
+    assert s["scratch"] != 0  # left dirty -- no free lunch unless you uncompute
+
+
+def test_demo_all_true():
+    d = demo()
+    assert all(d.values())


### PR DESCRIPTION
## What
The point that the bijectivity/time work fits **computing — especially quantum — more than physics**, made concrete.

Quantum gates are **unitary = invertible = bijective**, so a quantum circuit (minus measurement) is **reversible** — the bijective clock generalized to a sequence of gates. Superposition is the "all at once"; **measurement is the only irreversible, information-erasing step** (the arrow).

- `Gate(fwd, inv)`, `run` / `unrun` — forward then backward == **identity** (the unitary property).
- `bennett_uncompute` — the core technique: compute `h(x)` into scratch, copy it out, then **uncompute** the scratch back to clean `0`, **erasing nothing** (no Landauer heat, no garbage qubit). The gate logic is the same `splitmix64` used as the time-step in `time_machine`.

## Honest boundary
This is reversible **classical** computing. It captures quantum's **reversibility + uncomputation** faithfully, but **not** superposition amplitudes, interference, or entanglement (those need a complex state vector). It's the *substrate* quantum needs — not the quantum magic, and not a quantum computer. A test pins the honest arrow: **without** uncomputing, the scratch is left dirty — the information you'd have to erase.

5/5 tests. Builds on `time_machine.py` + `elastic_bijective_hash.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reversible circuit framework supporting configurable gates with forward and inverse transformations, plus automatic uncomputation for state restoration.

* **Tests**
  * Added comprehensive test suite to validate circuit execution behavior, gate invertibility properties, and correctness of state restoration mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->