### PR TITLE
feat(observer): all-at-once observer dynamics -- temporal non-locality (CSP/CBJ)

### DIFF
--- a/python/scbe/allatonce_observer.py
+++ b/python/scbe/allatonce_observer.py
@@ -1,0 +1,362 @@
+"""allatonce_observer: an all-at-once / global-constraint check over the SCBE observer transcript.
+
+WHAT THIS IS (and is NOT)
+=========================
+SCBE's "observer" is the governance/measurement layer that watches an input stream and emits a
+forward-chained, SHA-256-sealed transcript of decisions (see desktop_access.ActionRegistry). Today
+every record is decided and sealed STEP BY STEP, forward in time -- a Markov chain: record N is bound
+only to record N-1 (its `_prev` seal), and `verify()` walks that chain.
+
+This module is a small, deterministic experiment that applies Emily Adlam's ALL-AT-ONCE /
+GLOBAL-CONSTRAINT picture of physical law to that observer. In Adlam's frame a law is not a
+step-by-step time-evolution rule; it is a CONSTRAINT on the WHOLE history at once -- the actual
+"Humean mosaic" must lie in the INTERSECTION of all constraints (the sudoku analogy: rules apply to
+the whole grid simultaneously, not left-to-right). The load-bearing consequence she draws is that
+"the result of a measurement can depend on global facts even if there is no record of those facts in
+the state of the world immediately prior to the measurement" -- i.e. forward, locally-screened
+checking can MISS facts that a whole-history check catches.
+
+So the question this module makes MECHANICAL and MEASURABLE is:
+
+    Over a fixed transcript, how many integrity/consistency violations does a WHOLE-TRANSCRIPT
+    constraint pass catch that the step-local (Markovian) forward-chain seal CANNOT see?
+
+The transcript is treated as a candidate "mosaic". The Markovian observer is the existing
+forward-chain `verify()` (local: each record vs the one before). The all-at-once observer is a set of
+GLOBAL constraints evaluated over the entire record set simultaneously; an admissible mosaic must lie
+in the intersection of ALL of them (every constraint returns no violations). The deterministic METRIC
+is the delta: violations the global pass reports that the local pass reports as fine.
+
+HONEST CAVEAT (read before quoting this anywhere): this is an ANALOGY to Adlam's physics, not
+physics. There is no quantum mechanics here, no Humean mosaic of spacetime events, no Tsirelson
+bound, no retrocausality. "Global consistency" here just means "a deterministic predicate over the
+full Python list of records." It is a software integrity check inspired by a metaphor. Consistency is
+NOT correctness (a globally-consistent transcript can still describe wrong actions), and these
+constraints are an UNKEYED check over an in-memory list -- they detect a forger no better than the
+underlying seal does (a privileged in-process attacker who re-chains everything defeats both). See
+desktop_access._seal's HONEST LIMIT.
+
+Run:
+    python -m python.scbe.allatonce_observer
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Tuple
+
+# Reuse the EXISTING seal -- we are not inventing a new integrity primitive, only adding a
+# whole-history pass on top of the same sealed records the observer already produces.
+from .desktop_access import _seal
+
+Record = Dict[str, Any]
+# a constraint maps the WHOLE transcript -> list of (record_index, human-readable reason)
+Constraint = Callable[[List[Record]], List[Tuple[int, str]]]
+
+
+# ---------------------------------------------------------------------------
+# (a) OBSERVER STATE REPRESENTATION
+# ---------------------------------------------------------------------------
+# The observer state IS the transcript: an ordered list of sealed records. Each record (produced by
+# the existing ActionRegistry) carries at minimum:
+#   hop      : 1-based position the record CLAIMS to occupy
+#   action   : the verb that was invoked
+#   params   : the (deep-copied) arguments
+#   decision : ALLOWED / REFUSED / DENIED / NEEDS_CONFIRM / ERROR / NO_ACTION
+#   result   : the handler result or refusal reason
+#   _prev    : the seal of the previous record (or the session nonce for the first)
+#   seal     : SHA-256 over the record body (everything except `seal`)
+# `nonce` anchors the head of the chain. The pair (nonce, records) is the candidate "mosaic".
+
+
+@dataclass
+class ObserverState:
+    """The whole observer history as one object -- the candidate Humean mosaic."""
+
+    nonce: str
+    records: List[Record] = field(default_factory=list)
+
+    @classmethod
+    def from_registry(cls, reg: Any) -> "ObserverState":
+        """Snapshot a desktop_access.ActionRegistry's sealed transcript as a mosaic."""
+        # deep copy via json round-trip so later edits to the registry don't mutate the snapshot
+        recs = json.loads(json.dumps(reg.transcript, default=str))
+        return cls(nonce=reg.nonce, records=recs)
+
+
+# ---------------------------------------------------------------------------
+# (b) MARKOVIAN BASELINE  --  decide each step from LOCAL state only
+# ---------------------------------------------------------------------------
+def markovian_violations(state: ObserverState) -> List[Tuple[int, str]]:
+    """The step-local observer: exactly what desktop_access.verify() does, made to report WHICH
+    record it first trips on. Each record is checked against only (i) its own body via the seal and
+    (ii) the immediately-prior seal via `_prev`. This is the forward, temporally-local view: the
+    present record is judged using only the record right before it. It is a Markov chain over seals.
+
+    Returns the list of (index, reason) it can see -- it stops at the FIRST break, because a broken
+    link means every downstream `_prev` is computed off a value it can no longer trust (that is the
+    honest limit of a purely forward check: one early break blinds it to everything after).
+    """
+    prev = state.nonce
+    for i, r in enumerate(state.records):
+        if r.get("seal") != _seal(r):
+            return [(i, "local: record body does not match its own seal")]
+        if r.get("_prev") != prev:
+            return [(i, "local: _prev does not match the previous seal (chain broken)")]
+        prev = r["seal"]
+    return []
+
+
+def markovian_violations_strong(state: ObserverState) -> List[Tuple[int, str]]:
+    """A FAIR forward baseline (the study skeptic's bar). The strongest forward observer that still has
+    NO whole-history view: it does NOT stop at the first break, it ALSO checks the local hop successor
+    (hop == position+1), and it keeps running refused/guarded sets. `measure().extra_vs_strong` is the
+    HONEST global-only gain over THIS -- not over the weaker shipped verify(). Per the skeptic, the only
+    thing this baseline structurally cannot catch is a FUTURE-dependent fact (e.g. a NEEDS_CONFIRM that
+    appears AFTER the ungrounded ALLOWED); that residual is the genuine all-at-once advantage. (The
+    deeper decision-level version of that advantage lives in observer_dynamics.py.)"""
+    out: List[Tuple[int, str]] = []
+    prev = state.nonce
+    refused: set = set()
+    guarded: set = set()
+    for i, r in enumerate(state.records):
+        if r.get("seal") != _seal(r):
+            out.append((i, "strong-fwd: body != seal"))
+        if r.get("_prev") != prev:
+            out.append((i, "strong-fwd: _prev != previous seal"))
+        if r.get("hop") != i + 1:
+            out.append((i, "strong-fwd: hop != position+1 (local successor check)"))
+        if r.get("decision") == "NEEDS_CONFIRM":
+            guarded.add(r.get("action"))
+        if r.get("decision") == "ALLOWED" and r.get("action") in guarded and "confirm" not in r:
+            out.append((i, "strong-fwd: ungrounded guarded success"))
+        key = (r.get("action"), json.dumps(r.get("params"), sort_keys=True, default=str))
+        if r.get("decision") == "ALLOWED" and key in refused:
+            out.append((i, "strong-fwd: post-refusal success"))
+        if r.get("decision") == "REFUSED":
+            refused.add(key)
+        prev = r.get("seal", prev)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# (c) ALL-AT-ONCE VARIANT  --  GLOBAL constraints over the WHOLE transcript at once
+# ---------------------------------------------------------------------------
+# Each constraint is a predicate over the ENTIRE record list. An admissible mosaic is one in the
+# INTERSECTION of all constraints (every constraint returns []). Crucially these look at GLOBAL facts
+# -- relations among records anywhere in the history -- not just record N vs N-1. This is where the
+# "depends on global facts not in the immediately-prior state" idea becomes concrete and testable.
+
+
+def c_seal_integrity(records: List[Record]) -> List[Tuple[int, str]]:
+    """Every record's body must match its own seal -- evaluated for ALL records, not stop-at-first.
+    Unlike the Markovian pass, a break early does not blind it to a break late."""
+    return [(i, "global: body != seal") for i, r in enumerate(records) if r.get("seal") != _seal(r)]
+
+
+def c_chain_linkage(records: List[Record], nonce: str) -> List[Tuple[int, str]]:
+    """Forward linkage as a GLOBAL relation: record i's `_prev` must equal record i-1's seal for ALL
+    i (head bound to nonce). Reported for every break, so a re-chained middle that the forward walk
+    would accept-then-trip-once is fully enumerated."""
+    out: List[Tuple[int, str]] = []
+    expected = nonce
+    for i, r in enumerate(records):
+        if r.get("_prev") != expected:
+            out.append((i, "global: _prev != previous seal"))
+        expected = r.get("seal", expected)
+    return out
+
+
+def c_hop_monotone(records: List[Record]) -> List[Tuple[int, str]]:
+    """GLOBAL ordering invariant: the `hop` field each record CLAIMS must be exactly its position+1,
+    strictly increasing by 1 with no gaps or repeats. A reorder/insert/delete that someone bothered
+    to RE-CHAIN (so the forward seal walk passes!) still leaves the hop sequence globally wrong --
+    this is a fact about the whole sequence the local link check cannot represent. This is the
+    sudoku-style 'the whole column must be a permutation' rule."""
+    return [
+        (i, "global: hop %r out of order (expected %d)" % (r.get("hop"), i + 1))
+        for i, r in enumerate(records)
+        if r.get("hop") != i + 1
+    ]
+
+
+def c_confirm_grounding(records: List[Record]) -> List[Tuple[int, str]]:
+    """GLOBAL grounding / 'no fact comes from nowhere' (Adlam rejects closed loops whose variables are
+    determined by nothing). An ALLOWED record for a GUARDED-class action claims it was confirmed; that
+    confirmation must be grounded by a `confirm` field present in the SAME record. A record asserting
+    it ran a guarded op while carrying no confirmation is self-justifying -> illegitimate. (We key off
+    a NEEDS_CONFIRM seen anywhere in the mosaic for the same action to know it is guarded -- a
+    whole-history lookup, not a prior-state lookup.)"""
+    guarded = {r.get("action") for r in records if r.get("decision") == "NEEDS_CONFIRM"}
+    return [
+        (i, "global: action %r ran ALLOWED without a recorded confirm (ungrounded)" % r.get("action"))
+        for i, r in enumerate(records)
+        if r.get("decision") == "ALLOWED" and r.get("action") in guarded and "confirm" not in r
+    ]
+
+
+def c_no_post_refusal_success(records: List[Record]) -> List[Tuple[int, str]]:
+    """GLOBAL frequency/consistency constraint that needs facts AFTER the record: once a destructive
+    op for an action is REFUSED, the same (action, params) must never appear later as ALLOWED in the
+    mosaic. A purely forward observer at the ALLOWED record sees nothing wrong locally -- the
+    contradicting fact lives in an EARLIER record AND the rule about it only resolves when the whole
+    history is in view. This is the 'measurement depends on global facts not in the prior state' case
+    made mechanical: legitimacy of record j depends on record i for i<j with no link between them."""
+    refused = {
+        (r.get("action"), json.dumps(r.get("params"), sort_keys=True, default=str))
+        for r in records
+        if r.get("decision") == "REFUSED"
+    }
+    return [
+        (i, "global: %r ran ALLOWED after an identical call was REFUSED earlier" % r.get("action"))
+        for i, r in enumerate(records)
+        if r.get("decision") == "ALLOWED"
+        and (r.get("action"), json.dumps(r.get("params"), sort_keys=True, default=str)) in refused
+    ]
+
+
+def allatonce_violations(state: ObserverState) -> Dict[str, List[Tuple[int, str]]]:
+    """Evaluate the FULL constraint set over the WHOLE transcript at once. The mosaic is admissible
+    iff it lies in the intersection of all constraints (every list empty)."""
+    return {
+        "seal_integrity": c_seal_integrity(state.records),
+        "chain_linkage": c_chain_linkage(state.records, state.nonce),
+        "hop_monotone": c_hop_monotone(state.records),
+        "confirm_grounding": c_confirm_grounding(state.records),
+        "no_post_refusal_success": c_no_post_refusal_success(state.records),
+    }
+
+
+def is_admissible_mosaic(state: ObserverState) -> bool:
+    """True iff the transcript lies in the intersection of ALL global constraints (Adlam's 'reality
+    must be in the intersection of all constraints', made into a boolean over a finite record set)."""
+    return all(not v for v in allatonce_violations(state).values())
+
+
+# ---------------------------------------------------------------------------
+# (d) THE DETERMINISTIC METRIC  +  (e) WHAT IT MEASURES
+# ---------------------------------------------------------------------------
+@dataclass
+class CaughtReport:
+    local_count: int  # violations the Markovian (forward, local) observer reports
+    global_count: int  # total violations the all-at-once observer reports
+    extra_caught: int  # global_count - (violations the local view also sees) == the METRIC
+    local_passes: bool  # did the Markov chain say "sealed/intact"?
+    global_passes: bool  # is the mosaic admissible (intersection of all constraints)?
+    detail: Dict[str, List[Tuple[int, str]]]  # per-constraint global violations
+    local_detail: List[Tuple[int, str]]  # what the local view saw
+    strong_count: int = 0  # violations a FAIR forward baseline (markovian_violations_strong) also catches
+    extra_vs_strong: int = 0  # the HONEST global-only gain over the fair baseline (skeptic's number)
+
+
+def measure(state: ObserverState) -> CaughtReport:
+    """THE METRIC, computed deterministically.
+
+    extra_caught = (# violations the all-at-once pass finds) - (# the Markovian pass also finds)
+
+    Mechanically:
+      1. local = markovian_violations(state)            # forward, prior-state-only
+      2. glob  = allatonce_violations(state)            # whole-history constraints
+      3. global_count = total entries across glob
+      4. The Markovian pass can only ever see seal/linkage breaks AT or BEFORE its first trip. So the
+         number it "also sees" is len(local) (0 or 1 by construction). extra_caught is everything the
+         global pass found beyond that. extra_caught > 0  <=>  the global view caught something the
+         local view is blind to.
+
+    WHAT IT MEASURES: the count (and identity) of integrity/consistency violations that depend on
+    GLOBAL facts -- re-chained reorders/inserts (hop_monotone), ungrounded guarded successes
+    (confirm_grounding), and a success that contradicts an earlier refusal (no_post_refusal_success).
+    These are exactly the cases Adlam highlights: the legitimacy of a record depends on facts that are
+    NOT in the immediately-prior state, so the forward/local observer cannot see them.
+    """
+    local = markovian_violations(state)
+    strong = markovian_violations_strong(state)
+    glob = allatonce_violations(state)
+    global_count = sum(len(v) for v in glob.values())
+    extra = max(0, global_count - len(local))
+    return CaughtReport(
+        local_count=len(local),
+        global_count=global_count,
+        extra_caught=extra,
+        local_passes=(len(local) == 0),
+        global_passes=all(not v for v in glob.values()),
+        detail=glob,
+        local_detail=local,
+        strong_count=len(strong),
+        extra_vs_strong=max(0, global_count - len(strong)),  # the honest gain vs a FAIR forward baseline
+    )
+
+
+# ---------------------------------------------------------------------------
+# A re-chaining tamper helper: this is the adversary that DEFEATS the Markovian seal but is caught
+# all-at-once. It edits a record and recomputes seals forward so the local chain walk passes.
+# ---------------------------------------------------------------------------
+def rechain(state: ObserverState) -> ObserverState:
+    """Recompute the whole forward seal chain in place so markovian_violations() passes again. A
+    privileged in-process attacker can do this (see _seal's HONEST LIMIT). We use it to manufacture a
+    transcript the LOCAL observer accepts but the GLOBAL observer should still reject when a
+    whole-history invariant (hop order, grounding, post-refusal success) was broken."""
+    prev = state.nonce
+    for r in state.records:
+        r["_prev"] = prev
+        r.pop("seal", None)
+        r["seal"] = _seal(r)
+        prev = r["seal"]
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Demo
+# ---------------------------------------------------------------------------
+def _demo_state() -> Tuple[ObserverState, ObserverState]:
+    """Build a clean transcript via the real registry, then produce a RE-CHAINED tampered copy whose
+    forward seal passes but whose whole-history facts are broken."""
+    from .desktop_access import default_registry
+
+    reg = default_registry()
+    reg.invoke("open_app", {"app": "files"})
+    reg.invoke("run_allowed_command", {"command": "rm -rf /"}, confirm="x")  # REFUSED (destructive)
+    reg.invoke("run_allowed_command", {"command": "ls"})  # NEEDS_CONFIRM: marks the action guarded
+    reg.invoke("run_allowed_command", {"command": "ls"}, confirm="user")  # ALLOWED (guarded+confirm)
+    clean = ObserverState.from_registry(reg)
+
+    tampered = ObserverState.from_registry(reg)
+    # Attack 1: reorder records 0 and 2 (hop fields now globally wrong) ...
+    tampered.records[0], tampered.records[2] = tampered.records[2], tampered.records[0]
+    # Attack 2: strip the confirm off the guarded ALLOWED record (ungrounded success) ...
+    for r in tampered.records:
+        if r.get("action") == "run_allowed_command" and r.get("decision") == "ALLOWED":
+            r.pop("confirm", None)
+    # ... then RE-CHAIN so the forward/local seal walk is fooled into passing.
+    rechain(tampered)
+    return clean, tampered
+
+
+def main() -> int:
+    clean, tampered = _demo_state()
+
+    print("ALL-AT-ONCE OBSERVER  --  global-constraint check over the SCBE transcript\n")
+    print("CLEAN transcript (%d records):" % len(clean.records))
+    rc = measure(clean)
+    print("  Markovian (local) passes :", rc.local_passes)
+    print("  all-at-once admissible   :", rc.global_passes)
+    print("  extra caught by global   :", rc.extra_caught)
+
+    print("\nTAMPERED + RE-CHAINED transcript (forward seal recomputed to fool the local walk):")
+    rt = measure(tampered)
+    print("  Markovian (local) passes :", rt.local_passes, " <- the forward seal is FOOLED")
+    print("  all-at-once admissible   :", rt.global_passes, "  <- the whole-history view is NOT")
+    print("  extra vs SHIPPED verify():", rt.extra_caught, " (real but over-credits: shipped seal is weak)")
+    print("  extra vs FAIR baseline   :", rt.extra_vs_strong, " <- the HONEST number (skeptic-fair; a fair")
+    print("                                forward checker with a local hop check catches the re-chain too)")
+    for name, viols in rt.detail.items():
+        if viols:
+            print("    [%s] %s" % (name, viols))
+    print("\nNOTE: at this INTEGRITY layer the global pass ~ a fair forward checker; the genuine")
+    print("all-at-once advantage (future-dependent retractions, CBJ jump-back) is in observer_dynamics.py.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/scbe/observer_dynamics.py
+++ b/python/scbe/observer_dynamics.py
@@ -1,0 +1,260 @@
+"""observer_dynamics: measurable observer-state dynamics over governance DECISIONS (CSP / all-at-once).
+
+Companion to allatonce_observer.py. That module works at the INTEGRITY layer (seals over a transcript --
+"was this mutated?"). This one works at the DECISION-SEMANTICS / VALIDITY layer ("does the whole
+completed history of decisions satisfy the global rules, even if a later decision retroactively
+invalidates an earlier one?"). It makes Emily Adlam's all-at-once / Sudoku move executable as a
+Constraint Satisfaction Problem (CSP):
+
+    variables  = the decision at each step (DecisionRecord)
+    domains    = the allowed decisions (ALLOW / DENY / ESCALATE / route names ...)
+    constraints= global rules over the WHOLE history (no contradiction on a route; an ESCALATE must be
+                 resolved later; a call REFUSED once must not later succeed)
+    solution   = a whole history in the intersection of all constraints (a "valid completed grid")
+
+THE LOAD-BEARING, NON-RELABEL CLAIM (validated by the study's adversarial skeptic): a purely forward
+("Markovian") observer commits each decision from the state so far and NEVER revisits it. Some
+violations only become visible LATER -- a decision at step j contradicts one already committed at step
+i < j. No forward observer, however strong, can have caught that at step i (the deciding fact was in
+its future). The all-at-once observer re-solves the whole history and RETRACTS the earlier decision.
+The measurable delta is the RETROACTIVE-CONSISTENCY GAP, and it is reported against a FAIR forward
+baseline (one that keeps running sets and continues past breaks) -- so the gap counts only genuinely
+future-dependent retractions, not weak-baseline bookkeeping (the codebase's 'block-offload +24' lesson).
+
+Conflict-Directed Backjumping (CBJ): when the global pass finds a violation, its conflict set names the
+records involved; the EARLIEST of them is the jump-back target -- re-decide from there, not one step
+back. That is the mechanism behind "inferred retroactive jump-back to the error's root cause".
+
+HONEST CAVEATS: this is an engineering ANALOGY to Adlam's physics, not physics. Consistency is NOT
+correctness (a globally consistent history can still be wrong). The constraint set is illustrative, not
+canonical. The repair policy (how a node re-decides) is pluggable -- the module provides the MECHANISM
+(detect -> conflict set -> earliest jump-back -> re-solve with an oscillation guard), not a universal fix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# decision categories the observer can emit (the CSP domain, kept open as plain strings)
+ALLOW, DENY, ESCALATE, REFUSED = "ALLOW", "DENY", "ESCALATE", "REFUSED"
+
+
+@dataclass
+class DecisionRecord:
+    """One observer decision. `seq` is the logical position (deterministic; no wall clock, so the gap is
+    reproducible). `input_id` ties related inputs together; `route` is the lane the decision is about."""
+
+    seq: int
+    input_id: str
+    decision: str
+    route: Optional[str] = None
+    verdict: Optional[str] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Violation:
+    """A structured global-constraint violation -- the CSP conflict set, with the jump-back target."""
+
+    rule: str
+    message: str
+    involved: List[int]  # record indices participating in the conflict (the conflict set)
+
+    @property
+    def earliest_index(self) -> int:
+        return min(self.involved)
+
+
+# a constraint maps the WHOLE history -> its violations (global, not step-local)
+Constraint = Callable[[List[DecisionRecord]], List[Violation]]
+
+
+# ---------------------------------------------------------------------------
+# Example global constraints (the "Sudoku rules" for the SCBE decision observer)
+# ---------------------------------------------------------------------------
+def no_contradictory_route_decisions(records: List[DecisionRecord]) -> List[Violation]:
+    """A route must not carry both ALLOW and DENY across the whole history (a global contradiction)."""
+    by_route: Dict[str, List[int]] = {}
+    for i, r in enumerate(records):
+        if r.route:
+            by_route.setdefault(r.route, []).append(i)
+    out: List[Violation] = []
+    for route, idxs in by_route.items():
+        decisions = {records[i].decision for i in idxs}
+        if ALLOW in decisions and DENY in decisions:
+            out.append(Violation("no_contradictory_route_decisions", "route %r has both ALLOW and DENY" % route, idxs))
+    return out
+
+
+def escalation_must_be_resolved(records: List[DecisionRecord]) -> List[Violation]:
+    """An ESCALATE on an input must be resolved by a LATER ALLOW/DENY that names it (meta['resolves']).
+    Unresolved-at-end is a whole-history fact (you cannot know at the ESCALATE whether it resolves)."""
+    out: List[Violation] = []
+    for i, r in enumerate(records):
+        if r.decision == ESCALATE:
+            resolved_at = [j for j, rr in enumerate(records) if j > i and rr.meta.get("resolves") == r.input_id]
+            if not resolved_at:
+                out.append(Violation("escalation_must_be_resolved", "escalation %r never resolved" % r.input_id, [i]))
+    return out
+
+
+def no_post_refusal_success(records: List[DecisionRecord]) -> List[Violation]:
+    """If an input_id was REFUSED, the same input_id must not later appear as ALLOW (legitimacy of the
+    later record depends on an earlier one with no forward link -- a genuinely global fact)."""
+    refused = {r.input_id for r in records if r.decision == REFUSED}
+    out: List[Violation] = []
+    for i, r in enumerate(records):
+        if r.decision == ALLOW and r.input_id in refused:
+            first = next(j for j, rr in enumerate(records) if rr.input_id == r.input_id and rr.decision == REFUSED)
+            out.append(
+                Violation("no_post_refusal_success", "%r ran ALLOW after being REFUSED" % r.input_id, [first, i])
+            )
+    return out
+
+
+DEFAULT_CONSTRAINTS: List[Constraint] = [
+    no_contradictory_route_decisions,
+    escalation_must_be_resolved,
+    no_post_refusal_success,
+]
+
+
+def global_violations(records: List[DecisionRecord], constraints: Optional[List[Constraint]] = None) -> List[Violation]:
+    out: List[Violation] = []
+    for c in constraints or DEFAULT_CONSTRAINTS:
+        out.extend(c(records))
+    return out
+
+
+def is_admissible(records: List[DecisionRecord], constraints: Optional[List[Constraint]] = None) -> bool:
+    return not global_violations(records, constraints)
+
+
+# ---------------------------------------------------------------------------
+# FAIR Markovian baseline: a forward observer that is as strong as possible WITHOUT revisiting a
+# committed decision. It keeps running sets (refused-so-far, route-decisions-so-far) and flags a conflict
+# the instant a NEW record contradicts the past -- but it can only ever blame the CURRENT (latest)
+# record, because the earlier one is already committed. This is the honest baseline the skeptic demanded.
+# ---------------------------------------------------------------------------
+def markovian_committed_conflicts(records: List[DecisionRecord]) -> List[Tuple[int, str]]:
+    """Forward pass with running state. Returns (index_of_the_LATE_record, reason) for each conflict the
+    forward observer can notice -- always blaming the latest arrival, never able to revisit the earlier."""
+    seen_route: Dict[str, set] = {}
+    refused: set = set()
+    out: List[Tuple[int, str]] = []
+    for i, r in enumerate(records):
+        if r.route:
+            prior = seen_route.setdefault(r.route, set())
+            if (r.decision == DENY and ALLOW in prior) or (r.decision == ALLOW and DENY in prior):
+                out.append(
+                    (i, "forward: %r contradicts an already-committed decision on route %r" % (r.decision, r.route))
+                )
+            prior.add(r.decision)
+        if r.decision == ALLOW and r.input_id in refused:
+            out.append((i, "forward: %r ran ALLOW after an earlier REFUSED" % r.input_id))
+        if r.decision == REFUSED:
+            refused.add(r.input_id)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# THE METRIC: the retroactive-consistency gap
+# ---------------------------------------------------------------------------
+@dataclass
+class GapReport:
+    forward_conflicts: int  # conflicts the FAIR forward observer can flag (always at the late record)
+    global_violations: int  # violations the all-at-once pass finds over the whole history
+    retroactive_gap: int  # decisions the global view RETRACTS that no forward observer could have caught
+    retracted_indices: List[int]  # the EARLIER records the global view invalidates (the jump-back seeds)
+    detail: List[Violation]
+
+
+def retroactive_consistency_gap(
+    records: List[DecisionRecord], constraints: Optional[List[Constraint]] = None
+) -> GapReport:
+    """Measure, deterministically, the gap between a FAIR forward observer and the all-at-once observer.
+
+    The retroactive gap counts ONLY records implicated in a violation that the FAIR forward observer
+    could NOT have flagged -- i.e. genuinely future-dependent ones (a fact that lies in the future of
+    the offending record, like an escalation that is never resolved). A contradiction the fair forward
+    observer already catches at the late record (it keeps running sets) is EXCLUDED: it is forward-
+    detectable, so counting it would be the inflated 'weak baseline' number the skeptic rejected.
+    """
+    viols = global_violations(records, constraints)
+    forward = markovian_committed_conflicts(records)
+    forward_flagged = {i for i, _ in forward}  # late indices the fair forward observer already catches
+    retracted: set = set()
+    future_dependent: List[Violation] = []
+    for v in viols:
+        if max(v.involved) in forward_flagged:
+            continue  # forward catches this one -> NOT a global-only gain (honest, no inflation)
+        future_dependent.append(v)
+        retracted.update(v.involved)  # only-knowable-globally records (the jump-back seeds)
+    return GapReport(
+        forward_conflicts=len(forward),
+        global_violations=len(viols),
+        retroactive_gap=len(retracted),
+        retracted_indices=sorted(retracted),
+        detail=future_dependent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Conflict-Directed Backjumping (CBJ): the jump-back target + the repair loop
+# ---------------------------------------------------------------------------
+def earliest_repair_point(
+    records: List[DecisionRecord], constraints: Optional[List[Constraint]] = None
+) -> Optional[int]:
+    """The CBJ jump-back target: the earliest record index across ALL current conflict sets. Re-deciding
+    from here (not one step back) is the smallest jump that can resolve a future-dependent inconsistency.
+    None if the history is already admissible."""
+    viols = global_violations(records, constraints)
+    if not viols:
+        return None
+    return min(v.earliest_index for v in viols)
+
+
+# a repair policy: given the records and the jump-back index, return a NEW decision for that record
+# (or None to give up on that node). The module supplies the mechanism; the policy is the caller's.
+RepairPolicy = Callable[[List[DecisionRecord], int], Optional[str]]
+
+
+@dataclass
+class RepairTrace:
+    admissible: bool
+    jumps: List[int]  # the sequence of jump-back targets taken (CBJ history)
+    iterations: int
+    records: List[DecisionRecord]
+
+
+def resolve_by_jumpback(
+    records: List[DecisionRecord],
+    repair: RepairPolicy,
+    constraints: Optional[List[Constraint]] = None,
+    max_iterations: int = 64,
+) -> RepairTrace:
+    """Retroactive repair loop (CBJ). While the whole history is inadmissible: find the earliest conflict
+    record, ask the policy for a new decision there, apply it, and re-solve the WHOLE history (a later
+    fix can expose a new earlier conflict -- cascading repair). An oscillation guard stops if a state
+    repeats. This is the 'inferred retroactive jump-back to the error's root cause' loop, the all-at-once
+    upgrade to a Markovian one-step rewind."""
+    recs = [DecisionRecord(r.seq, r.input_id, r.decision, r.route, r.verdict, dict(r.meta)) for r in records]
+    jumps: List[int] = []
+    seen: set = set()
+    for it in range(max_iterations):
+        if is_admissible(recs, constraints):
+            return RepairTrace(True, jumps, it, recs)
+        target = earliest_repair_point(recs, constraints)
+        if target is None:
+            return RepairTrace(True, jumps, it, recs)
+        signature = (target, tuple((r.decision, r.route) for r in recs))
+        if signature in seen:  # oscillation: re-deciding here keeps reproducing a seen state -> stop
+            break
+        seen.add(signature)
+        new_decision = repair(recs, target)
+        if new_decision is None:  # policy gives up on this node
+            break
+        jumps.append(target)
+        recs[target].decision = new_decision
+    return RepairTrace(is_admissible(recs, constraints), jumps, len(jumps), recs)

--- a/tests/test_allatonce_observer.py
+++ b/tests/test_allatonce_observer.py
@@ -1,0 +1,150 @@
+"""allatonce_observer: a global-constraint (all-at-once) check over the SCBE observer transcript.
+
+Tests that the whole-history constraint pass catches integrity/consistency violations the step-local
+(Markovian) forward-chain seal cannot -- specifically RE-CHAINED tampers that fool the forward walk.
+This is a software ANALOGY to Adlam's all-at-once physics, not physics (see the module docstring).
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.allatonce_observer import (  # noqa: E402
+    ObserverState,
+    allatonce_violations,
+    is_admissible_mosaic,
+    markovian_violations,
+    markovian_violations_strong,
+    measure,
+    rechain,
+)
+from python.scbe.desktop_access import default_registry  # noqa: E402
+
+
+def _clean_state() -> ObserverState:
+    reg = default_registry()
+    reg.invoke("open_app", {"app": "files"})
+    reg.invoke("run_allowed_command", {"command": "rm -rf /"}, confirm="x")  # REFUSED
+    reg.invoke("open_app", {"app": "editor"})
+    reg.invoke("run_allowed_command", {"command": "ls"}, confirm="user")  # ALLOWED (guarded+confirm)
+    return ObserverState.from_registry(reg)
+
+
+def test_clean_transcript_passes_both_observers():
+    s = _clean_state()
+    assert markovian_violations(s) == []  # forward chain intact
+    assert is_admissible_mosaic(s) is True  # in the intersection of all global constraints
+    r = measure(s)
+    assert r.local_passes and r.global_passes
+    assert r.extra_caught == 0  # nothing for the global view to add on a clean mosaic
+
+
+def test_naive_edit_is_caught_by_BOTH_views():
+    # A crude edit that does NOT re-chain breaks the forward seal -- the local view already catches it.
+    s = _clean_state()
+    s.records[0]["result"] = "tampered"
+    assert markovian_violations(s) != []  # local catches it (seal mismatch)
+    assert is_admissible_mosaic(s) is False  # global catches it too
+    # this is the BASELINE case: no global ADVANTAGE here, both see it
+    r = measure(s)
+    assert r.local_passes is False and r.global_passes is False
+
+
+def test_rechained_reorder_FOOLS_local_but_global_catches_it():
+    # THE LOAD-BEARING CASE. Reorder two records, then recompute the whole seal chain so the forward
+    # walk passes. The local (Markovian) observer is fooled; the all-at-once hop_monotone constraint
+    # -- a fact about the WHOLE sequence, not record N vs N-1 -- still rejects it.
+    s = _clean_state()
+    s.records[0], s.records[2] = s.records[2], s.records[0]
+    rechain(s)
+    assert markovian_violations(s) == []  # forward seal FOOLED
+    viols = allatonce_violations(s)
+    assert viols["hop_monotone"], "global hop-order check must fire"
+    assert is_admissible_mosaic(s) is False
+    r = measure(s)
+    assert r.local_passes is True and r.global_passes is False  # the divergence
+    assert r.extra_caught > 0  # the metric: violations only the global view sees
+
+
+def test_rechained_ungrounded_confirm_caught_only_globally():
+    # Strip the confirm off a guarded ALLOWED record (a success that 'comes from nowhere'), re-chain.
+    # The grounding constraint learns an action is GUARDED from a NEEDS_CONFIRM seen ANYWHERE in the
+    # mosaic (a whole-history lookup), so the fixture includes one such record -- itself a realistic
+    # transcript event (a guarded call made without confirm).
+    reg = default_registry()
+    reg.invoke("open_app", {"app": "files"})
+    reg.invoke("run_allowed_command", {"command": "ls"})  # NEEDS_CONFIRM: establishes 'guarded' globally
+    reg.invoke("run_allowed_command", {"command": "ls"}, confirm="user")  # ALLOWED (guarded+confirm)
+    s = ObserverState.from_registry(reg)
+    for rec in s.records:
+        if rec.get("action") == "run_allowed_command" and rec.get("decision") == "ALLOWED":
+            rec.pop("confirm", None)  # now an ungrounded guarded success
+    rechain(s)
+    assert markovian_violations(s) == []  # local fooled
+    assert allatonce_violations(s)["confirm_grounding"]  # global grounding check fires
+    assert measure(s).extra_caught > 0
+
+
+def test_rechained_success_after_refusal_caught_only_globally():
+    # Append an ALLOWED record whose (action, params) were REFUSED earlier in the SAME mosaic, then
+    # re-chain. The forward observer at the new record sees nothing wrong locally; the contradicting
+    # fact is an EARLIER record. The whole-history constraint catches the contradiction.
+    s = _clean_state()
+    # the REFUSED record was run_allowed_command {"command":"rm -rf /"} with confirm="x"
+    refused = next(r for r in s.records if r.get("decision") == "REFUSED")
+    forged = {
+        "hop": len(s.records) + 1,
+        "action": refused["action"],
+        "params": refused["params"],
+        "decision": "ALLOWED",
+        "result": "ran: rm -rf /",
+        "confirm": "x",
+    }
+    s.records.append(forged)
+    rechain(s)
+    assert markovian_violations(s) == []  # local fooled (and hop is correct, so that constraint is clean)
+    v = allatonce_violations(s)
+    assert v["hop_monotone"] == []  # isolate: the ONLY thing wrong is the cross-record contradiction
+    assert v["no_post_refusal_success"], "global post-refusal-success check must fire"
+    assert measure(s).extra_caught > 0
+
+
+def test_fair_baseline_collapses_the_inflated_integrity_number():
+    # The skeptic's honesty bar (the 'block-offload +24' lesson): a FAIR forward baseline (continue past
+    # breaks + a LOCAL hop-successor check + running sets) ALSO catches the re-chained reorder. So at the
+    # INTEGRITY layer the honest global-only gain (extra_vs_strong) collapses to 0 -- the genuine
+    # all-at-once advantage is at the DECISION layer (observer_dynamics), not here.
+    s = _clean_state()
+    s.records[0], s.records[2] = s.records[2], s.records[0]
+    rechain(s)
+    r = measure(s)
+    assert markovian_violations_strong(s) != []  # the fair baseline is NOT fooled by the re-chain
+    assert r.extra_caught > 0  # it beats the WEAK shipped verify()...
+    assert r.extra_vs_strong == 0  # ...but adds nothing over a FAIR forward baseline (honest)
+
+
+def test_metric_is_deterministic():
+    # The metric is a pure function of the transcript: same input -> identical report, every time.
+    s1 = _clean_state()
+    s1.records[0], s1.records[2] = s1.records[2], s1.records[0]
+    rechain(s1)
+    s2 = _clean_state()
+    s2.records[0], s2.records[2] = s2.records[2], s2.records[0]
+    rechain(s2)
+    a, b = measure(s1), measure(s2)
+    assert (a.local_count, a.global_count, a.extra_caught) == (b.local_count, b.global_count, b.extra_caught)
+
+
+def test_intersection_semantics_one_failed_constraint_makes_inadmissible():
+    # Adlam: reality must lie in the INTERSECTION of all constraints. One non-empty constraint =>
+    # not admissible, even though every OTHER constraint is satisfied.
+    s = _clean_state()
+    s.records[0], s.records[2] = s.records[2], s.records[0]
+    rechain(s)
+    v = allatonce_violations(s)
+    satisfied = [k for k, viols in v.items() if not viols]
+    assert len(satisfied) >= 1  # most constraints are still happy
+    assert any(v.values())  # but at least one is violated
+    assert is_admissible_mosaic(s) is False  # so the mosaic is rejected

--- a/tests/test_observer_dynamics.py
+++ b/tests/test_observer_dynamics.py
@@ -1,0 +1,109 @@
+"""Tests for observer_dynamics -- the decision-semantics all-at-once observer (CSP / CBJ).
+
+The load-bearing, skeptic-grade assertions:
+  * the retroactive gap is NON-zero for a genuinely FUTURE-DEPENDENT violation (escalation never resolved
+    -- unknowable at the escalate);
+  * the retroactive gap is ZERO for a forward-DETECTABLE contradiction (the fair forward baseline catches
+    it) -- i.e. no 'weak baseline' inflation;
+  * Conflict-Directed Backjumping targets the EARLIEST (root-cause) record, beating a one-step rewind;
+  * the metric is deterministic; the repair loop has an oscillation guard.
+"""
+
+from __future__ import annotations
+
+from python.scbe.observer_dynamics import (
+    ALLOW,
+    DENY,
+    ESCALATE,
+    REFUSED,
+    DecisionRecord,
+    earliest_repair_point,
+    is_admissible,
+    markovian_committed_conflicts,
+    resolve_by_jumpback,
+    retroactive_consistency_gap,
+)
+
+
+def _r(seq, decision, route=None, input_id=None, **meta):
+    return DecisionRecord(seq=seq, input_id=input_id or ("i%d" % seq), decision=decision, route=route, meta=meta)
+
+
+# ---- the future-dependent gap is real -----------------------------------------------------------
+def test_future_dependent_violation_counts_toward_the_gap():
+    # an ESCALATE that is never resolved: a forward observer cannot know at the escalate that nothing
+    # later resolves it -> the all-at-once view retracts it; the fair forward observer flags nothing.
+    recs = [_r(0, ESCALATE, route="safety", input_id="a"), _r(1, ALLOW, route="other", input_id="b")]
+    gap = retroactive_consistency_gap(recs)
+    assert gap.retroactive_gap >= 1
+    assert 0 in gap.retracted_indices
+    assert gap.forward_conflicts == 0  # the fair forward observer could not have caught it
+
+
+def test_forward_detectable_contradiction_has_zero_gap_no_inflation():
+    # ALLOW then DENY on the same route: the FAIR forward observer catches it at the late record (running
+    # set), so it must NOT inflate the retroactive gap -- this is the 'block-offload +24' honesty bar.
+    recs = [_r(0, ALLOW, route="deploy"), _r(1, DENY, route="deploy")]
+    gap = retroactive_consistency_gap(recs)
+    assert gap.global_violations >= 1  # the global view still sees the contradiction
+    assert gap.forward_conflicts >= 1  # but so does the fair forward observer
+    assert gap.retroactive_gap == 0  # ...so it is NOT counted as a global-only gain
+
+
+# ---- CBJ jumps to the root cause, beating a one-step rewind -------------------------------------
+def test_cbj_targets_the_earliest_root_cause_not_one_step_back():
+    # contradiction surfaces at index 2 but its root is index 0; a one-step rewind would target index 1.
+    recs = [_r(0, ALLOW, route="deploy"), _r(1, ALLOW, route="unrelated"), _r(2, DENY, route="deploy")]
+    target = earliest_repair_point(recs)
+    assert target == 0  # CBJ -> the root, not max(involved)-1 == 1 (the one-step-rewind target)
+
+
+def test_jumpback_repairs_the_history_at_the_root():
+    recs = [_r(0, ALLOW, route="deploy"), _r(1, ALLOW, route="unrelated"), _r(2, DENY, route="deploy")]
+
+    def flip_allow_to_deny(rs, idx):
+        return DENY if rs[idx].decision == ALLOW else None
+
+    trace = resolve_by_jumpback(recs, flip_allow_to_deny)
+    assert trace.admissible is True
+    assert trace.jumps and trace.jumps[0] == 0  # jumped to the root cause
+    assert is_admissible(trace.records)
+    assert recs[0].decision == ALLOW  # original input not mutated (repair worked on a copy)
+
+
+# ---- honesty: determinism, clean case, oscillation guard ----------------------------------------
+def test_clean_history_is_admissible_zero_gap():
+    recs = [_r(0, ALLOW, route="deploy"), _r(1, ALLOW, route="deploy")]
+    assert is_admissible(recs)
+    assert retroactive_consistency_gap(recs).retroactive_gap == 0
+
+
+def test_metric_is_deterministic():
+    recs = [_r(0, ESCALATE, input_id="a"), _r(1, ALLOW, route="r"), _r(2, DENY, route="r")]
+    a = retroactive_consistency_gap(recs)
+    b = retroactive_consistency_gap(recs)
+    assert (a.retroactive_gap, a.retracted_indices, a.forward_conflicts) == (
+        b.retroactive_gap,
+        b.retracted_indices,
+        b.forward_conflicts,
+    )
+
+
+def test_jumpback_oscillation_guard_terminates():
+    # a policy that never actually resolves the conflict must not loop forever
+    recs = [_r(0, ALLOW, route="deploy"), _r(1, DENY, route="deploy")]
+
+    def no_op(rs, idx):
+        return rs[idx].decision  # re-assign the same value -> never fixes -> must be caught by the guard
+
+    trace = resolve_by_jumpback(recs, no_op, max_iterations=64)
+    assert trace.admissible is False
+    assert trace.iterations < 64  # stopped by the oscillation guard, not the iteration cap
+
+
+def test_post_refusal_success_is_forward_caught_not_inflated():
+    # REFUSED then ALLOW on the same input_id: the fair forward observer catches it -> zero gap
+    recs = [_r(0, REFUSED, input_id="x"), _r(1, ALLOW, input_id="x")]
+    gap = retroactive_consistency_gap(recs)
+    assert gap.forward_conflicts >= 1 and gap.retroactive_gap == 0
+    assert any(i == 1 for i, _ in markovian_committed_conflicts(recs))


### PR DESCRIPTION
A measurable, mechanical application of Emily Adlam's **all-at-once / global-constraint** ("Sudoku universe") view to the SCBE observer — an explicit engineering **analogy, not physics** (caveated throughout). Ran a grounded study workflow (Adlam's papers) with an adversarial skeptic to clear the physics-overclaim + relabel traps before building.

**`observer_dynamics.py`** (decision/validity layer) — the observer as a **CSP**: decisions=variables, global rules=constraints, valid history=the intersection. The load-bearing result: the **retroactive-consistency gap**, measured against a **fair** forward baseline, counts only genuinely **future-dependent** retractions (a later decision invalidates an earlier one = **temporal non-locality**). **Conflict-Directed Backjumping** returns the earliest conflicting record = the root-cause jump-back target (beats a one-step rewind), with a cascade-safe repair loop + oscillation guard.

**`allatonce_observer.py`** (integrity layer) — whole-transcript pass over sealed records. **Sharpened per the skeptic**: a fair forward baseline (`markovian_violations_strong`) makes `extra_vs_strong` the honest number — which **collapses to 0**, proving the integrity-layer global pass ≈ a fair forward checker; the real advantage is the decision layer.

**16 tests**, flake8 clean. Honest: consistency ≠ correctness; analogy ≠ physics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)