### PR TITLE
feat(board): coding_board -- operator/operation CSP board (all-at-once substrate)

### DIFF
--- a/python/scbe/coding_board.py
+++ b/python/scbe/coding_board.py
@@ -1,0 +1,220 @@
+"""coding_board: code-as-a-board CSP -- the substrate for Issac's all-at-once coding vision.
+
+A task is a BOARD of OPERATORS (cells / places). Each operator is assigned an OPERATION (a value / command
+/ token / reversible gate) drawn from its OWN narrowed legal-operation vector (the operator's DOMAIN = the
+alphabet of legal+verified moves = governance by construction). Operator and operation are DECOUPLED: the
+cell is a variable, the operation is its value. The whole board is solved ALL AT ONCE as a Constraint
+Satisfaction Problem -- the admissible assignment is the global ENERGY MINIMUM (energy = number of
+constraint violations; the ground state has energy 0), not a left-to-right time-evolution (Adlam's
+Sudoku move). Constraints are:
+
+  * SPATIAL (relations among operators / cells -- spatial non-locality): e.g. cells in a region must be
+    DISTINCT (sudoku row) or must AGREE (an interface contract);
+  * TEMPORAL (a later operation in the solve/program order conflicts with an earlier one -- temporal
+    non-locality, the same idea as observer_dynamics): e.g. an operation must not appear after a forbidden
+    predecessor.
+
+Repair uses CONFLICT-DIRECTED BACKJUMPING: on a dead end, jump back to the EARLIEST operator implicated in
+the conflict (the root cause), not one step back. Reuses observer_dynamics.Violation so the conflict set +
+its earliest_index ARE the jump-back target.
+
+HONEST: the solver is textbook CSP (backtracking + forward-checking domain narrowing + conflict-directed
+backjumping). The algorithm is not new. The contribution is the FRAMING made executable -- operator !=
+operation, a governed legal vector per operator, spatial + temporal constraints unified as one energy
+landscape, CBJ root-cause repair -- the substrate for "every token a governed operation on a board".
+Consistency != correctness: a solved board is internally consistent, not a guaranteed-correct program.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+from .observer_dynamics import Violation  # reuse the conflict-set type (rule, message, involved indices)
+
+Assignment = Dict[str, str]  # operator id -> operation
+
+
+@dataclass
+class Operator:
+    """A cell / place on the board. `domain` is the narrowed legal-operation vector (the moves allowed
+    here); `region` groups operators for spatial constraints; `fixed` locks a KNOWN operation."""
+
+    id: str
+    domain: Tuple[str, ...]
+    region: Optional[str] = None
+    fixed: Optional[str] = None
+
+
+# a constraint maps (board, assignment-so-far) -> violations; `involved` lists operator INDICES
+Constraint = Callable[["Board", Assignment], List[Violation]]
+
+
+@dataclass
+class Board:
+    operators: List[Operator]
+    constraints: List[Constraint] = field(default_factory=list)
+
+    def index_of(self, oid: str) -> int:
+        for i, op in enumerate(self.operators):
+            if op.id == oid:
+                return i
+        raise KeyError(oid)
+
+
+# ---------------------------------------------------------------------------
+# Example constraints (the board's rules)
+# ---------------------------------------------------------------------------
+def all_distinct_in_region(board: Board, assign: Assignment) -> List[Violation]:
+    """SPATIAL: operators sharing a region must hold DISTINCT operations (the sudoku 'no repeat' rule)."""
+    out: List[Violation] = []
+    by_region: Dict[str, List[int]] = {}
+    for i, op in enumerate(board.operators):
+        if op.region and op.id in assign:
+            by_region.setdefault(op.region, []).append(i)
+    for region, idxs in by_region.items():
+        seen: Dict[str, int] = {}
+        for i in idxs:
+            val = assign[board.operators[i].id]
+            if val in seen:
+                out.append(Violation("all_distinct_in_region", "region %r repeats %r" % (region, val), [seen[val], i]))
+            else:
+                seen[val] = i
+    return out
+
+
+def region_must_agree(board: Board, assign: Assignment) -> List[Violation]:
+    """SPATIAL: operators sharing a region must hold the SAME operation (an interface/contract must match)."""
+    out: List[Violation] = []
+    by_region: Dict[str, List[int]] = {}
+    for i, op in enumerate(board.operators):
+        if op.region and op.id in assign:
+            by_region.setdefault(op.region, []).append(i)
+    for region, idxs in by_region.items():
+        vals = {assign[board.operators[i].id] for i in idxs}
+        if len(vals) > 1:
+            out.append(Violation("region_must_agree", "region %r disagrees: %s" % (region, sorted(vals)), idxs))
+    return out
+
+
+def forbidden_after(predecessor: str, operation: str) -> Constraint:
+    """TEMPORAL: `operation` must not appear at a later operator than `predecessor` (a sequence rule over
+    the board/program order). Mirrors observer_dynamics' across-time non-locality."""
+
+    def constraint(board: Board, assign: Assignment) -> List[Violation]:
+        pred_idx = [i for i, op in enumerate(board.operators) if assign.get(op.id) == predecessor]
+        if not pred_idx:
+            return []
+        first_pred = min(pred_idx)
+        return [
+            Violation("forbidden_after", "%r appears after %r" % (operation, predecessor), [first_pred, i])
+            for i, op in enumerate(board.operators)
+            if i > first_pred and assign.get(op.id) == operation
+        ]
+
+    return constraint
+
+
+# ---------------------------------------------------------------------------
+# Energy + domain narrowing (the non-linear, all-at-once view)
+# ---------------------------------------------------------------------------
+def violations(board: Board, assign: Assignment) -> List[Violation]:
+    out: List[Violation] = []
+    for c in board.constraints:
+        out.extend(c(board, assign))
+    return out
+
+
+def energy(board: Board, assign: Assignment) -> int:
+    """The board's energy = number of constraint violations. Ground state (energy 0) == admissible solve.
+    This is the all-at-once objective: minimize global violations, not evolve forward in time."""
+    return len(violations(board, assign))
+
+
+def narrowed_domains(board: Board, assign: Assignment) -> Dict[str, Tuple[str, ...]]:
+    """Forward-checking: prune each UNassigned operator's legal vector to operations that do not, on their
+    own, violate a constraint against the current partial assignment (using the knowns to narrow the
+    unknowns -- Issac's 'narrowed vector per operator using the knowns')."""
+    out: Dict[str, Tuple[str, ...]] = {}
+    for op in board.operators:
+        if op.id in assign:
+            out[op.id] = (assign[op.id],)
+            continue
+        legal = []
+        for val in (op.fixed,) if op.fixed is not None else op.domain:
+            trial = dict(assign)
+            trial[op.id] = val
+            if not any(board.index_of(op.id) in v.involved for v in violations(board, trial)):
+                legal.append(val)
+        out[op.id] = tuple(legal)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Solve: backtracking + forward-checking + Conflict-Directed Backjumping
+# ---------------------------------------------------------------------------
+@dataclass
+class SolveResult:
+    solved: bool
+    assignment: Assignment
+    energy: int
+    backtracks: int
+    jumps: List[int]  # CBJ jump-back targets taken (operator indices) -- root causes, not one-step
+
+
+def jumpback_target(board: Board, assign: Assignment) -> Optional[int]:
+    """The CBJ target: the earliest operator index across all current conflict sets (root cause)."""
+    vs = violations(board, assign)
+    return min((v.earliest_index for v in vs), default=None)
+
+
+def solve(board: Board, max_backtracks: int = 100000) -> SolveResult:
+    """Solve the board by backtracking with forward-checking + conflict-directed backjumping. Assigns
+    operators in order; on a dead end (an operator whose narrowed domain is empty) jumps back to the
+    EARLIEST operator implicated in the conflict, not one step. Returns the ground-state assignment
+    (energy 0) or the best partial with its residual energy."""
+    ops = board.operators
+    n = len(ops)
+    assign: Assignment = {op.id: op.fixed for op in ops if op.fixed is not None}
+    cursor = {op.id: 0 for op in ops}  # next domain index to try, per operator
+    jumps: List[int] = []
+    backtracks = 0
+    pos = 0
+    # skip fixed operators at the front of the order is unnecessary; we just try their single value
+    while 0 <= pos < n:
+        op = ops[pos]
+        if op.fixed is not None:
+            assign[op.id] = op.fixed
+            pos += 1
+            continue
+        dom = narrowed_domains(board, {k: v for k, v in assign.items() if board.index_of(k) < pos})[op.id]
+        placed = False
+        while cursor[op.id] < len(dom):
+            val = dom[cursor[op.id]]
+            cursor[op.id] += 1
+            assign[op.id] = val
+            if not any(pos in v.involved for v in violations(board, assign)):
+                placed = True
+                break
+            assign.pop(op.id, None)
+        if placed:
+            pos += 1
+        else:
+            backtracks += 1
+            if backtracks > max_backtracks:
+                break
+            assign.pop(op.id, None)
+            cursor[op.id] = 0  # reset this operator's choices for the next visit
+            # CBJ: jump to the earliest operator implicated in a conflict at this dead end, else step back
+            target = jumpback_target(board, {**assign, op.id: (dom[0] if dom else "")})
+            jump_to = target if (target is not None and target < pos) else pos - 1
+            jumps.append(jump_to)
+            # undo everything after the jump target
+            for k in range(jump_to + 1, pos + 1):
+                assign.pop(ops[k].id, None)
+                cursor[ops[k].id] = 0
+            pos = jump_to
+    e = energy(board, assign)
+    return SolveResult(
+        solved=(pos == n and e == 0), assignment=dict(assign), energy=e, backtracks=backtracks, jumps=jumps
+    )

--- a/tests/test_coding_board_csp.py
+++ b/tests/test_coding_board_csp.py
@@ -1,0 +1,103 @@
+"""Tests for coding_board -- the operator/operation CSP board (all-at-once coding substrate).
+
+Proves: the solve reaches the energy-0 ground state on solvable boards; forward-checking narrows each
+operator's legal vector from the knowns; CBJ targets the EARLIEST (root-cause) operator; an unsolvable
+board is reported honestly (not faked); the metric is deterministic.
+"""
+
+from __future__ import annotations
+
+from python.scbe.coding_board import (
+    Board,
+    Operator,
+    all_distinct_in_region,
+    energy,
+    forbidden_after,
+    jumpback_target,
+    narrowed_domains,
+    region_must_agree,
+    solve,
+    violations,
+)
+
+
+# ---- spatial solve: region must AGREE (interface contract) -------------------------------------
+def test_region_agreement_board_solves_to_ground_state():
+    b = Board(
+        operators=[Operator("o0", ("a", "b"), region="r"), Operator("o1", ("a", "b"), region="r")],
+        constraints=[region_must_agree],
+    )
+    res = solve(b)
+    assert res.solved and res.energy == 0
+    assert res.assignment["o0"] == res.assignment["o1"]  # the interface matches
+
+
+# ---- spatial solve: region must be DISTINCT (sudoku row) ---------------------------------------
+def test_distinct_region_board_solves_to_a_permutation():
+    ops = [Operator("c%d" % i, ("1", "2", "3"), region="row") for i in range(3)]
+    b = Board(ops, [all_distinct_in_region])
+    res = solve(b)
+    assert res.solved and res.energy == 0
+    assert len(set(res.assignment.values())) == 3  # all distinct
+
+
+# ---- operator != operation + knowns lock a cell ------------------------------------------------
+def test_fixed_operator_is_a_known_and_constrains_the_rest():
+    b = Board(
+        operators=[Operator("o0", ("a", "b"), region="r", fixed="a"), Operator("o1", ("a", "b"), region="r")],
+        constraints=[region_must_agree],
+    )
+    res = solve(b)
+    assert res.solved and res.assignment["o0"] == "a" and res.assignment["o1"] == "a"
+
+
+# ---- forward-checking narrows the legal vector from the knowns ---------------------------------
+def test_narrowing_prunes_the_legal_vector_using_knowns():
+    b = Board(
+        operators=[Operator("o0", ("a", "b"), region="r"), Operator("o1", ("a", "b"), region="r")],
+        constraints=[region_must_agree],
+    )
+    narrowed = narrowed_domains(b, {"o0": "a"})
+    assert narrowed["o1"] == ("a",)  # given o0=a, o1's only consistent operation is 'a'
+
+
+# ---- CBJ jumps to the root cause, not one step back -------------------------------------------
+def test_cbj_targets_the_earliest_conflicting_operator():
+    # o0 and o2 share region r and disagree; o1 is unrelated -> the conflict's root is index 0, not 1.
+    b = Board(
+        operators=[Operator("o0", ("a",), region="r"), Operator("o1", ("x",)), Operator("o2", ("b",), region="r")],
+        constraints=[region_must_agree],
+    )
+    target = jumpback_target(b, {"o0": "a", "o1": "x", "o2": "b"})
+    assert target == 0  # root cause (earliest), not max(involved)-1 == 1
+
+
+# ---- temporal constraint (across board/program order) -----------------------------------------
+def test_temporal_forbidden_after_is_a_violation():
+    b = Board(
+        operators=[Operator("o0", ("open",)), Operator("o1", ("write",))],
+        constraints=[forbidden_after("open", "write")],  # 'write' must not come after 'open'
+    )
+    vs = violations(b, {"o0": "open", "o1": "write"})
+    assert vs and vs[0].involved == [0, 1]
+
+
+# ---- honesty: unsolvable board is reported, not faked; energy = violation count; determinism ---
+def test_unsolvable_board_is_reported_not_faked():
+    # a region cannot simultaneously AGREE and be DISTINCT -> no assignment has energy 0
+    b = Board(
+        operators=[Operator("o0", ("a", "b"), region="r"), Operator("o1", ("a", "b"), region="r")],
+        constraints=[region_must_agree, all_distinct_in_region],
+    )
+    res = solve(b)
+    assert res.solved is False  # honest: it does not pretend to solve
+
+
+def test_energy_is_violation_count_and_deterministic():
+    b = Board(
+        operators=[Operator("o0", ("a", "b"), region="r"), Operator("o1", ("a", "b"), region="r")],
+        constraints=[region_must_agree],
+    )
+    assert energy(b, {"o0": "a", "o1": "b"}) == 1  # one disagreement
+    assert energy(b, {"o0": "a", "o1": "a"}) == 0  # admissible
+    assert solve(b).assignment == solve(b).assignment  # deterministic


### PR DESCRIPTION
The substrate for the **all-at-once coding** vision (chosen next slice). A task is a **board of operators** (cells/places); each gets an **operation** (value/command/token/gate) from its **own narrowed legal-operation vector** (the domain = governance by construction). **Operator ≠ operation** (cell=variable, op=value). The board is solved **all at once** as a CSP — the admissible assignment is the global **energy minimum** (energy = violation count; ground state = 0), not a forward time-evolution.

- **Spatial** constraints (across cells — `all_distinct_in_region` / `region_must_agree`) = spatial non-locality.
- **Temporal** constraints (across board order — `forbidden_after`) = temporal non-locality.
- **Conflict-Directed Backjumping** to the earliest conflicting operator (root cause), reusing `observer_dynamics.Violation`.
- **Forward-checking** narrows each operator's legal vector from the knowns.

**Honest:** textbook CSP (backtracking + forward-checking + CBJ) — the algorithm isn't new; the contribution is the framing made executable. Consistency ≠ correctness.

**8 tests**, flake8 clean. Builds on `observer_dynamics` (#2567).

🤖 Generated with [Claude Code](https://claude.com/claude-code)