### PR TITLE
feat(reversible): Landauer energy ledger -- energy is the arrow, reversibility recovers it

### DIFF
--- a/python/scbe/reversible_circuit.py
+++ b/python/scbe/reversible_circuit.py
@@ -16,13 +16,27 @@ computer. The bijective gate here is the same splitmix64 used as the time-step i
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Callable, Dict, List
+import math
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Tuple
 
 from .elastic_bijective_hash import splitmix64
 
 MASK = (1 << 64) - 1
 Reg = Dict[str, int]
+
+# Landauer's principle: erasing ONE bit of information dissipates at least k*T*ln2 of energy as heat, and
+# THAT dissipation is the forward arrow. A reversible (bijective) gate erases nothing -> thermodynamically
+# free. So the energy bill of a computation == the bits it irreversibly ERASES, and UNCOMPUTING instead of
+# erasing pays it back to ~0. These constants make the bill a real number of joules.
+K_BOLTZMANN = 1.380649e-23  # J/K (exact, SI)
+ROOM_T_K = 300.0  # K, ~room temperature
+REG_BITS = 64  # our registers are 64-bit; force-clearing one throws away this many information bits
+
+
+def landauer_joules(bits_erased: int, temperature_k: float = ROOM_T_K) -> float:
+    """The Landauer floor for erasing `bits_erased` bits at temperature T: bits * k*T*ln2 joules."""
+    return bits_erased * K_BOLTZMANN * temperature_k * math.log(2)
 
 
 @dataclass
@@ -83,6 +97,83 @@ def bennett_uncompute(x: int) -> Reg:
     return s
 
 
+@dataclass
+class EnergyLedger:
+    """Accounts a computation's THERMODYNAMIC cost by Landauer's principle. Every reversible (bijective) gate
+    is recorded at ZERO cost; every irreversible ERASE charges its information-bearing bits. `joules()` is the
+    heat the forward arrow costs you -- and a fully reversible (uncomputed) run lands at 0. This makes the
+    abstract "energy IS the arrow, reversibility recovers it" point a number you can run."""
+
+    temperature_k: float = ROOM_T_K
+    bits_erased: int = 0
+    log: List[Tuple[str, int]] = field(default_factory=list)
+
+    def reversible(self, name: str) -> "EnergyLedger":
+        """Record a bijective gate: erases nothing, so it is thermodynamically free."""
+        self.log.append((name, 0))
+        return self
+
+    def erase(self, name: str, bits: int) -> "EnergyLedger":
+        """Record an irreversible erase of `bits` information-bearing bits: charges the Landauer floor."""
+        self.bits_erased += bits
+        self.log.append((name, bits))
+        return self
+
+    def joules(self) -> float:
+        return landauer_joules(self.bits_erased, self.temperature_k)
+
+
+def run_metered(state: Reg, gates: List[Gate], ledger: EnergyLedger) -> Reg:
+    """run(), but record every gate on the ledger as reversible (free). Reversible computation, billed."""
+    for g in gates:
+        state = g.fwd(state)
+        ledger.reversible(g.name)
+    return state
+
+
+def erase_register(state: Reg, reg: str, ledger: EnergyLedger, bits: int = REG_BITS) -> Reg:
+    """The one IRREVERSIBLE move: force `reg` to 0, throwing away the information it held. Charges the ledger
+    bits*k*T*ln2 -- the literal cost of the arrow. Compare UNCOMPUTING the register, which restores 0 for free
+    by running the bijective gates backward (run_metered over the inverses)."""
+    r = dict(state)
+    r[reg] = 0
+    ledger.erase("erase %s" % reg, bits)
+    return r
+
+
+def energy_compare(x: int) -> Dict[str, object]:
+    """The whole point in one number. Compute h(x), copy it out, then CLEAN the scratch two ways:
+      (1) forward-only -> FORCE-ERASE the scratch (irreversible): pays REG_BITS*k*T*ln2.
+      (2) reversible   -> UNCOMPUTE the scratch (run the gates backward): pays ~0.
+    Both end identical (scratch=0, out=h(x)); the energy difference is exactly what reversibility recovers."""
+    compute = [hash_into("scratch", "x")]
+    expected = splitmix64(x) & MASK
+
+    # (1) forward-only, then force-clear the scratch (the dissipating computer)
+    led_a = EnergyLedger()
+    a = run_metered({"x": x, "scratch": 0, "out": 0}, compute, led_a)  # scratch = h(x)
+    a = xor_into("out", "scratch").fwd(a)
+    led_a.reversible("copy out")
+    a = erase_register(a, "scratch", led_a)  # IRREVERSIBLE reset -> pays Landauer
+
+    # (2) reversible, then uncompute the scratch (the reversible computer)
+    led_b = EnergyLedger()
+    b = run_metered({"x": x, "scratch": 0, "out": 0}, compute, led_b)
+    b = xor_into("out", "scratch").fwd(b)
+    led_b.reversible("copy out")
+    b = run_metered(b, list(reversed(compute)), led_b)  # UNCOMPUTE -> scratch back to 0, free
+
+    same_result = a == b and a["scratch"] == 0 and a["out"] == expected
+    return {
+        "same_result": same_result,
+        "forward_only_bits_erased": led_a.bits_erased,
+        "forward_only_joules": led_a.joules(),
+        "reversible_bits_erased": led_b.bits_erased,
+        "reversible_joules": led_b.joules(),
+        "energy_recovered_joules": led_a.joules() - led_b.joules(),
+    }
+
+
 def demo() -> Dict[str, object]:
     x = 1234567
     expected = splitmix64(x) & MASK
@@ -99,11 +190,18 @@ def demo() -> Dict[str, object]:
     answer_kept = end["out"] == expected
     input_preserved = end["x"] == x
 
+    # 3. Landauer energy ledger: forward-only ERASES the scratch (pays heat); reversible UNCOMPUTES it (free)
+    energy = energy_compare(x)
+
     return {
         "circuit_run_then_unrun_is_identity": roundtrip_identity,
         "uncompute_cleans_scratch": clean_scratch,
         "uncompute_keeps_answer": answer_kept,
         "input_preserved": input_preserved,
+        "energy_same_result_both_ways": energy["same_result"],
+        "energy_reversible_is_free": energy["reversible_joules"] == 0.0,
+        "energy_forward_only_pays": energy["forward_only_joules"] > 0.0,
+        "_energy": energy,
     }
 
 
@@ -116,7 +214,23 @@ def main() -> int:
         "  ...output keeps the answer h(x), input preserved        : %s, %s"
         % (d["uncompute_keeps_answer"], d["input_preserved"])
     )
-    print("  => computed a result and erased NOTHING (no Landauer cost, no garbage qubit).")
+    print("  => computed a result and erased NOTHING (no Landauer cost, no garbage qubit).\n")
+
+    e = d["_energy"]
+    print("LANDAUER ENERGY LEDGER -- energy IS the arrow; reversibility recovers it")
+    print("  both paths reach the SAME end state (scratch=0, out=h(x))         : %s" % e["same_result"])
+    print(
+        "  forward-only: ERASE %d-bit scratch -> pays %.3e J (the arrow's heat)"
+        % (e["forward_only_bits_erased"], e["forward_only_joules"])
+    )
+    print(
+        "  reversible  : UNCOMPUTE scratch     -> pays %.3e J (%d bits erased)"
+        % (e["reversible_joules"], e["reversible_bits_erased"])
+    )
+    print(
+        "  => reversibility recovered %.3e J at T=300K; over 1e9 such ops that is %.3e J of avoided heat."
+        % (e["energy_recovered_joules"], e["energy_recovered_joules"] * 1e9)
+    )
     return 0
 
 

--- a/tests/test_reversible_circuit.py
+++ b/tests/test_reversible_circuit.py
@@ -16,9 +16,13 @@ sys.path.insert(0, str(ROOT))
 from python.scbe.elastic_bijective_hash import splitmix64  # noqa: E402
 from python.scbe.reversible_circuit import (  # noqa: E402
     MASK,
+    REG_BITS,
+    EnergyLedger,
     bennett_uncompute,
     demo,
+    energy_compare,
     hash_into,
+    landauer_joules,
     run,
     unrun,
     xor_into,
@@ -60,6 +64,35 @@ def test_without_uncompute_the_scratch_is_dirty_the_arrow():
     assert s["scratch"] != 0  # left dirty -- no free lunch unless you uncompute
 
 
+def test_landauer_floor_is_the_known_constant():
+    # one bit erased at 300K costs k*T*ln2 ~= 2.87e-21 J -- the textbook Landauer floor
+    j = landauer_joules(1, 300.0)
+    assert abs(j - 2.8e-21) < 0.2e-21  # ~2.87e-21 J
+    assert landauer_joules(0) == 0.0  # erasing nothing costs nothing
+    assert landauer_joules(64) == 64 * landauer_joules(1)  # linear in bits erased
+
+
+def test_energy_ledger_reversible_is_free_erase_pays():
+    led = EnergyLedger()
+    led.reversible("gate a").reversible("gate b")
+    assert led.bits_erased == 0 and led.joules() == 0.0  # bijective gates: free
+    led.erase("reset reg", REG_BITS)
+    assert led.bits_erased == REG_BITS and led.joules() > 0.0  # the irreversible step pays
+
+
+def test_energy_compare_forward_pays_reversible_recovers():
+    # the load-bearing result: same end state both ways, but force-erase pays the Landauer floor for the
+    # whole 64-bit scratch while uncomputing pays exactly zero -- the energy difference is the recovery
+    for x in (0, 1, 42, 1234567, 2**50 + 9):
+        e = energy_compare(x)
+        assert e["same_result"] is True  # scratch=0, out=h(x) reached identically both ways
+        assert e["forward_only_bits_erased"] == REG_BITS  # force-clear erases the full register
+        assert e["reversible_bits_erased"] == 0  # uncomputation erases nothing
+        assert e["reversible_joules"] == 0.0  # ...so it is thermodynamically free
+        assert e["forward_only_joules"] > 0.0  # ...while the dissipating path pays heat
+        assert e["energy_recovered_joules"] == e["forward_only_joules"]  # all of it recovered
+
+
 def test_demo_all_true():
     d = demo()
-    assert all(d.values())
+    assert all(v for k, v in d.items() if not k.startswith("_"))  # skip the _energy detail dict


### PR DESCRIPTION
## What

Adds a **Landauer energy ledger** to `python/scbe/reversible_circuit.py` (extends #2566). It turns "energy IS the forward arrow, reversibility recovers it" into a runnable number.

By Landauer's principle, erasing one bit dissipates at least `k*T*ln2` of heat -- and that dissipation is the arrow. A reversible (bijective) gate erases nothing, so it is thermodynamically free. So a computation's energy bill == the bits it irreversibly erases, and uncomputing instead of erasing pays it back to ~0.

## API

- `EnergyLedger` -- records every bijective gate at 0 cost; `erase()` charges `k*T*ln2` per information-bearing bit; `joules()` at T=300K.
- `run_metered` / `erase_register` -- a metered reversible run vs the one irreversible reset.
- `energy_compare(x)` -- compute `h(x)`, copy it out, then clean the scratch **two ways**:
  - **forward-only**: force-ERASE the 64-bit scratch -> pays ~`1.84e-19 J` (the arrow's heat),
  - **reversible**: UNCOMPUTE the scratch -> pays exactly `0`.
  - Both reach the **same end state** (scratch=0, out=h(x)); the difference is what reversibility recovers.

## Demo

```
forward-only: ERASE 64-bit scratch -> pays 1.837e-19 J (the arrow's heat)
reversible  : UNCOMPUTE scratch     -> pays 0.000e+00 J (0 bits erased)
=> reversibility recovered 1.837e-19 J at T=300K; over 1e9 such ops that is 1.837e-10 J of avoided heat.
```

## Honest scope

Unchanged from #2566: this is reversible **classical** computing -- it models quantum's reversibility + uncomputation + the Landauer/heat argument faithfully, but NOT superposition amplitudes/entanglement. The energy numbers are the textbook Landauer floor (`~2.87e-21 J/bit` at 300K), i.e. the thermodynamic *lower bound*, not what a real chip dissipates.

## Tests

8/8 in `tests/test_reversible_circuit.py` (3 new: the Landauer constant, ledger free-vs-pays, and forward-pays / reversible-recovers across several inputs). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>