### PR TITLE
feat(squad): coding_squad -- clone-trooper/Polly-Pad role squad (option C)

### DIFF
--- a/python/scbe/coding_squad.py
+++ b/python/scbe/coding_squad.py
@@ -1,0 +1,132 @@
+"""coding_squad: a role squad that solves the coding board, grounded in Issac's clone-trooper / Polly Pad
+doctrine (POLLY_PADS_ARCHITECTURE.md "Clone Trooper Field Upgrade Stations"; HYDRA_COORDINATION.md "Clone
+Trooper armor any AI can wear", PHDM = "the Geometric Skull").
+
+Differentiated ROLES (drone classes -> coding roles) each carry a GOAL + a role-scoped gate sub-alphabet,
+and are ENCODED AS A POINT in the geometric shape structure (the Poincare ball -- the "Geometric Skull"
+that the instructions live in). Roles are paired into GEOMETRIC BUDDY TEAMS by hyperbolic proximity
+(the doc's "hyperbolic-distance proximity") for overlapping board coverage. The squad then solves the
+coding_board (the CSP); CHECK runs the energy + CBJ jump-back (= Bennett uncompute) repair.
+
+    ARCHITECT  (Mother Ship)  -> frame the board: operators, regions, rules
+    RECON                     -> scout targets: the unknowns + known-unknowns (empty constrained cells)
+    CODER      (filler)       -> assign operations to operators            [gate sub-alphabet: TRANSFORM]
+    CHECK      (constraint)   -> verify global energy; jump-back/uncompute on conflict   [CHECK gates]
+    OPTIMIZER                 -> tighten the solved board (micro + macro)   [TRANSFORM]
+
+HONEST: this is a COORDINATION layer over the existing CSP solve -- coding_board.solve does the actual
+work; the roles/pairs/shape decide WHO covers WHAT and WHICH gate sub-alphabet each may use. That is what
+squad doctrine IS (a coordination + coverage structure), not new solving power. The clone-trooper/Polly
+Pad docs are DESIGN-phase vision; this is a small executable slice grounded in them, reusing the shipped
+coding_board (#2568), coding_board_gates (#2570) and geometric_router shape primitives.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .coding_board import Board, SolveResult, solve
+from .coding_board_gates import CHECK, TRANSFORM, gate_names
+from .geometric_router import poincare_distance, to_ball
+
+
+@dataclass(frozen=True)
+class Role:
+    """A drone class -> coding role. `profile` is the role's point in the shape structure (the 'armor'
+    encodes role+goal as geometry); `gate_role` is the sub-alphabet it may use (None = non-coding role)."""
+
+    name: str
+    goal: str
+    gate_role: Optional[str]
+    profile: Tuple[float, ...]
+
+    def legal_operations(self) -> Tuple[str, ...]:
+        return gate_names(self.gate_role) if self.gate_role else ()
+
+
+# the squad doctrine made concrete: drone classes -> coding roles, each a point in the shape structure
+SQUAD: List[Role] = [
+    Role("ARCHITECT", "frame the board: operators, regions, rules", None, (1.0, 0.2, 0.2, 0.1, 0.1, 0.1)),
+    Role(
+        "RECON",
+        "scout targets: unknowns + known-unknowns (empty constrained cells)",
+        None,
+        (0.2, 1.0, 0.3, 0.1, 0.1, 0.1),
+    ),
+    Role("CODER", "assign operations to operators (do the work)", TRANSFORM, (0.1, 0.3, 1.0, 0.4, 0.1, 0.1)),
+    Role("CHECK", "verify global energy; jump-back/uncompute on conflict", CHECK, (0.1, 0.1, 0.4, 1.0, 0.3, 0.1)),
+    Role("OPTIMIZER", "tighten the solved board (micro + macro)", TRANSFORM, (0.1, 0.1, 0.3, 0.3, 1.0, 0.2)),
+]
+
+
+def geometric_pairs(roles: List[Role]) -> List[Tuple[str, Optional[str], float]]:
+    """Pair roles into BUDDY TEAMS by hyperbolic proximity in the shape structure (the doc's geometric
+    pairs for situation coverage). Greedy nearest-neighbour; an odd role solos (e.g. the Mother Ship /
+    ARCHITECT). Returns (role, buddy_or_None, hyperbolic_distance)."""
+    balls = [(r, to_ball(np.array(r.profile, dtype=float))) for r in roles]
+    used: set = set()
+    pairs: List[Tuple[str, Optional[str], float]] = []
+    for i, (r, b) in enumerate(balls):
+        if r.name in used:
+            continue
+        best: Optional[Tuple[str, float]] = None
+        for j, (r2, b2) in enumerate(balls):
+            if j == i or r2.name in used:
+                continue
+            d = poincare_distance(b, b2)
+            if best is None or d < best[1]:
+                best = (r2.name, d)
+        used.add(r.name)
+        if best is not None:
+            used.add(best[0])
+            pairs.append((r.name, best[0], round(best[1], 4)))
+        else:
+            pairs.append((r.name, None, 0.0))
+    return pairs
+
+
+def cover_regions(board: Board, pairs: List[Tuple[str, Optional[str], float]]) -> Dict[str, str]:
+    """Assign board regions to buddy teams for overlapping coverage (each region gets a team). With no
+    regions, the whole board is one coverage zone."""
+    regions = sorted({op.region for op in board.operators if op.region})
+    teams = ["%s+%s" % (a, b) if b else a for a, b, _d in pairs]
+    if not regions:
+        return {"<whole-board>": teams[0] if teams else "<none>"}
+    return {region: teams[k % len(teams)] for k, region in enumerate(regions)}
+
+
+@dataclass
+class SquadResult:
+    solved: bool
+    assignment: Dict[str, str]
+    energy: int
+    jumps: List[int]  # the CHECK role's CBJ jump-backs (= uncompute targets)
+    targets: List[str]  # RECON's unknowns (operators to solve)
+    pairs: List[Tuple[str, Optional[str], float]]  # the geometric buddy teams
+    coverage: Dict[str, str]  # region -> team
+    roster: Dict[str, str] = field(default_factory=dict)  # role -> its legal-operation sub-alphabet size
+
+
+def solve_with_squad(board: Board, roles: Optional[List[Role]] = None) -> SquadResult:
+    """Run the squad over the board: pair roles geometrically, assign region coverage, RECON the targets,
+    then solve the CSP (CODER fills, CHECK runs the energy/CBJ jump-back). The solve is coding_board.solve;
+    the squad layer is the coordination + coverage around it."""
+    roles = roles or SQUAD
+    pairs = geometric_pairs(roles)
+    coverage = cover_regions(board, pairs)
+    targets = [op.id for op in board.operators if op.fixed is None]  # RECON: the unknowns
+    res: SolveResult = solve(board)  # CODER fills; CHECK's repair = the CBJ jumps inside the solve
+    roster = {r.name: ("%d ops" % len(r.legal_operations())) for r in roles}
+    return SquadResult(
+        solved=res.solved,
+        assignment=res.assignment,
+        energy=res.energy,
+        jumps=res.jumps,
+        targets=targets,
+        pairs=pairs,
+        coverage=coverage,
+        roster=roster,
+    )

--- a/tests/test_coding_squad.py
+++ b/tests/test_coding_squad.py
@@ -1,0 +1,70 @@
+"""Tests for coding_squad -- the clone-trooper/Polly-Pad role squad over the coding board (option C).
+
+Proves: roles carry goals + role-scoped gate sub-alphabets; geometric buddy-pairs cover the whole roster
+(hyperbolic proximity); the squad solves the board to the energy-0 ground state and records the
+coordination (pairs, region coverage, RECON's targets); deterministic.
+"""
+
+from __future__ import annotations
+
+from python.scbe.coding_board import Board, Operator, region_must_agree
+from python.scbe.coding_board_gates import CHECK, TRANSFORM, gate_names
+from python.scbe.coding_squad import SQUAD, cover_regions, geometric_pairs, solve_with_squad
+
+
+# ---- roles carry goals + role-scoped sub-alphabets (the Polly-Pad loadout) ---------------------
+def test_roles_have_goals_and_scoped_alphabets():
+    by_name = {r.name: r for r in SQUAD}
+    assert set(["ARCHITECT", "RECON", "CODER", "CHECK", "OPTIMIZER"]).issubset(by_name)
+    assert all(r.goal for r in SQUAD)
+    assert by_name["CODER"].gate_role == TRANSFORM
+    assert by_name["CHECK"].gate_role == CHECK
+    assert set(by_name["CODER"].legal_operations()) == set(gate_names(TRANSFORM))
+    assert by_name["ARCHITECT"].legal_operations() == ()  # a non-coding (coordination) role
+
+
+# ---- geometric buddy-pairs cover the whole roster ---------------------------------------------
+def test_geometric_pairs_cover_every_role():
+    pairs = geometric_pairs(SQUAD)
+    named = set()
+    for a, b, dist in pairs:
+        named.add(a)
+        if b is not None:
+            named.add(b)
+        assert dist >= 0.0  # a real hyperbolic distance
+    assert named == {r.name for r in SQUAD}  # everyone is on a team (or solos)
+
+
+# ---- the squad solves the board + records the coordination ------------------------------------
+def test_squad_solves_board_and_records_coverage():
+    ops = [Operator("o0", gate_names(TRANSFORM), region="r"), Operator("o1", gate_names(TRANSFORM), region="r")]
+    board = Board(ops, [region_must_agree])
+    res = solve_with_squad(board)
+    assert res.solved and res.energy == 0
+    assert res.assignment["o0"] == res.assignment["o1"]  # interface matches
+    assert set(res.targets) == {"o0", "o1"}  # RECON found the unknowns
+    assert "r" in res.coverage  # the region is covered by a buddy team
+    assert res.roster["CODER"].endswith("ops")  # the loadout sizes are recorded
+
+
+def test_recon_targets_exclude_knowns():
+    ops = [
+        Operator("o0", gate_names(TRANSFORM), region="r", fixed="id"),
+        Operator("o1", gate_names(TRANSFORM), region="r"),
+    ]
+    res = solve_with_squad(Board(ops, []))
+    assert res.targets == ["o1"]  # the fixed (known) operator is not a target
+
+
+def test_cover_regions_with_no_regions_is_one_zone():
+    ops = [Operator("o0", gate_names(TRANSFORM)), Operator("o1", gate_names(TRANSFORM))]
+    cov = cover_regions(Board(ops, []), geometric_pairs(SQUAD))
+    assert list(cov.keys()) == ["<whole-board>"]
+
+
+def test_squad_is_deterministic():
+    ops = [Operator("o0", gate_names(TRANSFORM), region="r"), Operator("o1", gate_names(TRANSFORM), region="r")]
+    board = Board(ops, [region_must_agree])
+    a = solve_with_squad(board)
+    b = solve_with_squad(board)
+    assert a.pairs == b.pairs and a.coverage == b.coverage and a.assignment == b.assignment


### PR DESCRIPTION
**Option C**, grounded in your actual squad docs (found in the vault's Repository Mirror / `scbe-agents`): `POLLY_PADS_ARCHITECTURE.md` ("Clone Trooper Field Upgrade Stations"), `HYDRA_COORDINATION.md` ("Clone Trooper armor any AI can wear"; PHDM = "the Geometric Skull").

Differentiated **roles** (drone classes → coding roles) each carry a **goal** + a **role-scoped gate sub-alphabet**, encoded as a **point in the geometric shape structure** (the Poincaré ball). Roles pair into **geometric buddy teams** by **hyperbolic proximity** (your geometric pairs for coverage); the squad solves `coding_board`, with **CHECK** running the energy + CBJ jump-back (= uncompute) repair.

```
ARCHITECT frame · RECON scout-targets · CODER fill [TRANSFORM] · CHECK verify+repair [CHECK] · OPTIMIZER tighten
```
Live demo: pairs `[ARCHITECT+RECON, CODER+CHECK, OPTIMIZER solo]`, region covered, board solved (energy 0).

**Honest:** a coordination layer over `coding_board.solve` (the solve does the work) — roles/pairs/shape decide *who covers what* and *which sub-alphabet each may use*; that's what squad doctrine is. The docs are design-phase vision translated to a small executable, verified slice.

**6 tests**, flake8 clean. Reuses `coding_board` (#2568), `coding_board_gates` (#2570), `geometric_router`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)