### PR TITLE
fix(reaction): deterministic deltas key order (closes the one determinism-scan fix-if-it-matters)

### DIFF
--- a/python/scbe/reaction_balance.py
+++ b/python/scbe/reaction_balance.py
@@ -205,7 +205,10 @@ def is_conserved(
         for el, k in comp.items():
             right[el] += coeff * k
         rq += coeff * q
-    deltas = {el: right[el] - left[el] for el in set(left) | set(right) if right[el] - left[el] != 0}
+    # sorted(): set-union iteration order is PYTHONHASHSEED-dependent, so without it the deltas dict's key
+    # order leaks non-determinism to any caller that reads/serializes it order-sensitively. The receipt path
+    # is already safe (reaction_state.canonical_json sorts keys); this hardens DIRECT is_conserved callers.
+    deltas = {el: right[el] - left[el] for el in sorted(set(left) | set(right)) if right[el] - left[el] != 0}
     if lq != rq:
         deltas["charge"] = rq - lq
     return (not deltas), deltas

--- a/tests/test_reaction_balance.py
+++ b/tests/test_reaction_balance.py
@@ -117,3 +117,24 @@ def test_underdetermined_reaction_says_so():
     # C + O2 -> CO + CO2 mixes two independent oxidations (nullity 2).
     with pytest.raises(BalanceError, match="underdetermined: it mixes 2 independent reactions"):
         balance(["C", "O2"], ["CO", "CO2"])
+
+
+def test_is_conserved_deltas_keys_are_deterministically_ordered():
+    # determinism guard: deltas is built over a set-union whose iteration order is PYTHONHASHSEED-dependent.
+    # sorted() makes the element keys reproducible, so a direct caller that reads/serializes deltas order-
+    # sensitively (a log, a repr, list(deltas)) is hashseed-independent.
+    ok, deltas = is_conserved([(1, "C6H12O6"), (1, "O2")], [(1, "CO2"), (1, "H2O")])
+    assert not ok  # unbalanced as written -> non-empty deltas across several elements
+    element_keys = [k for k in deltas if k != "charge"]
+    assert element_keys == sorted(element_keys)  # sorted order, not the (hashseed-varying) set-union order
+
+
+def test_reaction_packet_hash_is_stable_independent_of_dict_order():
+    # the receipt path's determinism is independent of any dict insertion order: canonical_json sorts keys
+    # before hashing, so the packet content hash is reproducible (what replay / Merkle-anchoring relies on).
+    from python.scbe.reaction_state import sha256_value
+
+    pkt = balance_reaction_packet(["C6H12O6", "O2"], ["CO2", "H2O"])
+    d = pkt.unsigned_dict()
+    reordered = {k: d[k] for k in reversed(list(d))}  # same content, opposite key order
+    assert sha256_value(d) == sha256_value(reordered)  # canonicalized -> identical hash


### PR DESCRIPTION
## What

The code-gen determinism source-scan (#2575) surfaced one "genuine fix-if-it-matters": `is_conserved` in `reaction_balance.py` builds its `deltas` dict over `set(left) | set(right)`, whose iteration order is `PYTHONHASHSEED`-dependent. This sorts it.

## Measured, not assumed

- **The leak is real for direct callers**: `is_conserved` deltas key order varies across hashseed (seed 7 -> `['H','C','O']` vs `['C','H','O']` elsewhere). After the fix: `['C','H','O']` for every seed.
- **The receipt path was already safe**: `reaction_state.canonical_json` uses `json.dumps(sort_keys=True)` before the SHA-256, and the balanced packet path carries empty deltas. The packet content hash is **identical across all hashseeds** (verified: `f7d3fd0a…` for seeds 0/1/2/7).

So this is honest **defense-in-depth** for any direct `is_conserved` caller that reads `deltas` order-sensitively (a log line, a `repr`, `list(deltas)`) — **not** a fix to the hashed receipt (which replay/Merkle-anchoring relies on, and which was already reproducible).

## Tests (2 new, in `tests/test_reaction_balance.py`)

- `deltas` element keys come out sorted (hashseed-independent).
- the reaction-state packet content hash is invariant to dict key insertion order (the `canonical_json` guarantee, what replay depends on).

16 passed, 1 skipped (rdkit), black + flake8 clean. One-line change + two locks.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>