### PR TITLE
feat(squad): multidimensional triangulation -- differentiation is load-bearing (measured)

### DIFF
--- a/python/scbe/coding_squad.py
+++ b/python/scbe/coding_squad.py
@@ -24,7 +24,7 @@ coding_board (#2568), coding_board_gates (#2570) and geometric_router shape prim
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -130,3 +130,167 @@ def solve_with_squad(board: Board, roles: Optional[List[Role]] = None) -> SquadR
         coverage=coverage,
         roster=roster,
     )
+
+
+# ---------------------------------------------------------------------------
+# MULTIDIMENSIONAL TRIANGULATION: make "coverage" rigorous. The differentiated roles' profiles are a BASIS;
+# the squad can LOCALIZE a target in concept space only inside the subspace its profiles SPAN. The null
+# space names the BLIND directions (the doc's "absence is information" -- the tongues no member senses); the
+# condition number is the geometric dilution of precision (GDOP) -- low = a crisp fix, infinite = a
+# degenerate "all-clones" squad that cannot triangulate. This is the Bad-Batch claim made measurable:
+# DIFFERENTIATION is what makes the fix possible -- a squad of identical clones is rank-deficient and blind.
+#
+# HONEST: this is linear least-squares localization (the backbone under multilateration / GPS). It
+# QUANTIFIES the squad's coverage; it does NOT add solving power to the CSP (coding_board.solve still does
+# the work). "Reading" is an abstract projection r_i = <profile_i, target>, not a physical range.
+# ---------------------------------------------------------------------------
+_RANK_TOL = 1e-9
+
+
+@dataclass
+class Coverage:
+    """How much of concept space a differentiated roster can resolve. `rank` dims are seeable;
+    `blind_directions` (the null-space basis) are not; `dilution` is the geometric dilution of precision
+    (condition number over the nonzero singular values, inf when rank < dim)."""
+
+    dim: int
+    rank: int
+    blind_directions: Tuple[Tuple[float, ...], ...]
+    dilution: float
+    full_rank: bool
+
+
+@dataclass
+class Triangulation:
+    target_estimate: Tuple[float, ...]  # the min-norm point in the squad's span consistent with the readings
+    reading_residual: float  # ||B x_hat - r||: ~0 == the readings agree on a single point
+    coverage: Coverage  # the roster's resolving power (whatever lay in blind_directions is unrecoverable)
+
+
+def squad_basis(roles: List[Role]) -> np.ndarray:
+    """The squad's basis matrix B: row i is role i's profile (its specialty direction in concept space)."""
+    return np.array([r.profile for r in roles], dtype=float)
+
+
+def _coverage(B: np.ndarray) -> Coverage:
+    dim = B.shape[1]
+    _u, s, vt = np.linalg.svd(B)  # right-singular vectors past the rank span the null (blind) space
+    rank = int((s > _RANK_TOL).sum())
+    blind = tuple(tuple(round(float(x), 12) for x in vt[i]) for i in range(rank, dim))
+    nonzero = s[s > _RANK_TOL]
+    # dilution is the IN-SPAN geometric dilution of precision: the condition number over the resolvable
+    # directions. It catches weak differentiation even at full rank (nearly-collinear members -> large
+    # dilution -> a sloppy fix). Coverage GAPS (blind directions) are reported separately via rank/blind.
+    if nonzero.size == 0:
+        dilution = float("inf")
+    elif nonzero.size == 1:
+        dilution = 1.0  # a single resolvable axis is trivially well-conditioned within its 1-D span
+    else:
+        dilution = float(nonzero[0] / nonzero[-1])
+    return Coverage(dim=dim, rank=rank, blind_directions=blind, dilution=dilution, full_rank=(rank == dim))
+
+
+def squad_coverage(roles: List[Role]) -> Coverage:
+    """The rigorous form of cover_regions: how many concept dimensions this differentiated roster can
+    resolve (rank), which directions are BLIND (null space), and the dilution of precision. A roster of
+    clones is rank-1 and blind everywhere else; a diverse roster spans more of the space."""
+    return _coverage(squad_basis(roles))
+
+
+def triangulate(roles: List[Role], readings: Sequence[float]) -> Triangulation:
+    """Localize a target in concept space from each role's READING -- the target's coordinate along that
+    role's specialty axis, r_i = <profile_i, target>. Least-squares fuse: x_hat = lstsq(B, r) (the min-norm
+    point in the squad's span). A DIFFERENTIATED roster pins the target inside its span; whatever component
+    of the true target lies in the squad's blind directions is unrecoverable (that is the coverage gap)."""
+    B = squad_basis(roles)
+    r = np.asarray(list(readings), dtype=float)
+    x_hat, *_ = np.linalg.lstsq(B, r, rcond=None)
+    residual = float(np.linalg.norm(B @ x_hat - r))
+    return Triangulation(
+        target_estimate=tuple(round(float(v), 12) for v in x_hat),
+        reading_residual=residual,
+        coverage=_coverage(B),
+    )
+
+
+def robust_triangulate(roles: List[Role], readings: Sequence[float]) -> Tuple[Triangulation, Optional[str]]:
+    """One member may report a corrupted reading (a traitor). Least-trimmed fuse: drop the single member
+    whose removal most reduces the residual, then triangulate with the rest. A differentiated squad still
+    localizes with one bad bearing (BFT-flavoured). Returns (triangulation, dropped_role_name); dropped is
+    None when no single drop materially helps (no traitor).
+
+    Identifiability needs a TWO-member margin (n >= rank + 2): after dropping the traitor the rest must stay
+    OVERDETERMINED, else every leave-one-out fit is exact (residual 0) and the outlier cannot be told apart."""
+    readings = list(readings)
+    base = triangulate(roles, readings)
+    if len(roles) <= base.coverage.rank + 1:
+        return base, None  # < rank+2 members -> dropping one leaves an exact fit; a traitor is unidentifiable
+    best: Optional[Tuple[Triangulation, str]] = None
+    for k in range(len(roles)):
+        kept_roles = roles[:k] + roles[k + 1 :]
+        if squad_coverage(kept_roles).rank < base.coverage.rank:
+            continue  # dropping this one shrinks the span -> the fit underdetermines and residual lies
+        kept_readings = readings[:k] + readings[k + 1 :]
+        t = triangulate(kept_roles, kept_readings)
+        if best is None or t.reading_residual < best[0].reading_residual:
+            best = (t, roles[k].name)
+    if best is not None and best[0].reading_residual < base.reading_residual - 1e-6:
+        return best  # dropping that member materially cleaned the fit -> it was the traitor
+    return base, None
+
+
+def demo() -> Dict[str, object]:
+    cov = squad_coverage(SQUAD)  # 5 differentiated roles in 6-D tongue space
+
+    # add a 6th differentiated role to close the structural blind spot (full rank)
+    sixth = Role("SCOUT2", "cover the remaining tongue", None, (0.1, 0.1, 0.1, 0.1, 0.2, 1.0))
+    cov6 = squad_coverage(SQUAD + [sixth])
+
+    # a degenerate "all clones" squad: five copies of one role -> rank 1, blind in the other 5 dims
+    clones = [SQUAD[0]] * 5
+    cov_clone = squad_coverage(clones)
+
+    # localize a target that lies in the squad's span: readings are exact, residual ~0
+    B = squad_basis(SQUAD)
+    true_in_span = (B[0] + 0.5 * B[2] - 0.3 * B[4]).tolist()  # a combination of role directions -> in span
+    readings = (B @ np.array(true_in_span)).tolist()
+    tri = triangulate(SQUAD, readings)
+    recovered = np.allclose(B @ np.array(tri.target_estimate), readings, atol=1e-9)
+
+    return {
+        "squad_resolves_5_of_6_one_blind_tongue": (
+            cov.rank == 5 and not cov.full_rank and len(cov.blind_directions) == 1
+        ),
+        "sixth_role_closes_the_blind_spot": cov6.full_rank,
+        "clone_squad_collapses_to_rank_1_blind_in_5": (cov_clone.rank == 1 and len(cov_clone.blind_directions) == 5),
+        "differentiated_squad_localizes_in_span": recovered and tri.reading_residual < 1e-9,
+        "_cov": cov,
+        "_cov_clone": cov_clone,
+    }
+
+
+def main() -> int:
+    d = demo()
+    cov, covc = d["_cov"], d["_cov_clone"]
+    print("CODING SQUAD -- multidimensional triangulation (differentiation is load-bearing, measured)")
+    print(
+        "  5 differentiated roles in %d-D tongue space: rank %d -> %d blind tongue(s), in-span dilution %.2f"
+        % (cov.dim, cov.rank, cov.dim - cov.rank, cov.dilution)
+    )
+    print(
+        "  add a 6th differentiated role -> full rank (no blind spot)      : %s" % d["sixth_role_closes_the_blind_spot"]
+    )
+    print(
+        "  clone squad (5x the SAME role): rank %d, blind in %d dims         : %s"
+        % (covc.rank, len(covc.blind_directions), d["clone_squad_collapses_to_rank_1_blind_in_5"])
+    )
+    print(
+        "  differentiated squad localizes a target in its span (residual~0): %s"
+        % d["differentiated_squad_localizes_in_span"]
+    )
+    print("  => a diverse squad triangulates what a squad of clones cannot. Coverage = rank; blind = null space.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_coding_squad.py
+++ b/tests/test_coding_squad.py
@@ -7,9 +7,22 @@ coordination (pairs, region coverage, RECON's targets); deterministic.
 
 from __future__ import annotations
 
+import numpy as np
+
 from python.scbe.coding_board import Board, Operator, region_must_agree
 from python.scbe.coding_board_gates import CHECK, TRANSFORM, gate_names
-from python.scbe.coding_squad import SQUAD, cover_regions, geometric_pairs, solve_with_squad
+from python.scbe.coding_squad import (
+    SQUAD,
+    Role,
+    cover_regions,
+    demo,
+    geometric_pairs,
+    robust_triangulate,
+    squad_basis,
+    squad_coverage,
+    solve_with_squad,
+    triangulate,
+)
 
 
 # ---- roles carry goals + role-scoped sub-alphabets (the Polly-Pad loadout) ---------------------
@@ -68,3 +81,112 @@ def test_squad_is_deterministic():
     a = solve_with_squad(board)
     b = solve_with_squad(board)
     assert a.pairs == b.pairs and a.coverage == b.coverage and a.assignment == b.assignment
+
+
+# ---- multidimensional triangulation: differentiation is load-bearing, measured -------------------
+def _axis_roles(n, dim):
+    # n roles whose profiles are the first n coordinate axes of `dim`-space -> a maximally diverse squad
+    out = []
+    for i in range(n):
+        p = [0.0] * dim
+        p[i] = 1.0
+        out.append(Role("R%d" % i, "axis %d" % i, None, tuple(p)))
+    return out
+
+
+def test_clone_squad_is_rank_deficient_and_blind():
+    # the Bad-Batch claim: a squad of identical clones cannot triangulate. Five copies of one role span a
+    # single line -> rank 1, blind in the other dims. Differentiation is what buys resolving power.
+    clones = [SQUAD[0]] * 5
+    cov = squad_coverage(clones)
+    assert cov.rank == 1
+    assert not cov.full_rank
+    assert len(cov.blind_directions) == cov.dim - 1  # blind everywhere but the clone's one direction
+
+
+def test_differentiated_squad_spans_more_and_full_rank_when_dim_matched():
+    # a diverse squad resolves one dimension per independent member; matching member count to dim -> full rank
+    roles = _axis_roles(4, 4)
+    cov = squad_coverage(roles)
+    assert cov.rank == 4 and cov.full_rank and cov.blind_directions == ()
+    assert cov.dilution == 1.0  # orthonormal axes -> perfectly conditioned (dilution 1)
+
+
+def test_target_in_span_is_recovered_blind_component_is_lost():
+    # localize a target the squad CAN see (in its span) -> exact; a target along a BLIND direction -> the
+    # squad reads all zeros and recovers nothing (the coverage gap is real, not hand-waved).
+    roles = _axis_roles(3, 4)  # sees dims 0,1,2 ; dim 3 is blind
+    B = squad_basis(roles)
+    seen_target = np.array([2.0, -1.0, 0.5, 0.0])  # lies in the span (no dim-3 component)
+    tri = triangulate(roles, (B @ seen_target).tolist())
+    assert tri.reading_residual < 1e-9
+    assert np.allclose(np.array(tri.target_estimate)[:3], seen_target[:3], atol=1e-9)
+
+    blind_target = np.array([0.0, 0.0, 0.0, 9.0])  # entirely in the blind dim 3
+    tri_blind = triangulate(roles, (B @ blind_target).tolist())
+    assert np.allclose(B @ blind_target, 0.0)  # the squad literally reads nothing
+    assert np.linalg.norm(tri_blind.target_estimate) < 1e-9  # ...so it recovers nothing -- the gap
+
+
+def test_near_collinear_full_rank_squad_has_high_dilution():
+    # differentiation is a matter of degree: two nearly-parallel members are technically independent (full
+    # rank) but poorly conditioned -> a large dilution of precision (a sloppy fix), unlike orthogonal axes.
+    eps = 1e-3
+    roles = [
+        Role("A", "", None, (1.0, 0.0)),
+        Role("B", "", None, (1.0, eps)),  # almost the same direction as A
+    ]
+    cov = squad_coverage(roles)
+    assert cov.full_rank  # technically independent
+    assert cov.dilution > 100.0  # ...but weak differentiation -> high dilution (poor triangulation geometry)
+
+
+# a 5-member squad in 3-D: rank 3 with a TWO-member margin (n = rank + 2), so dropping the traitor still
+# leaves an overdetermined (residual-meaningful) fit -- the redundancy needed to IDENTIFY a bad bearing.
+def _redundant_squad():
+    return _axis_roles(3, 3) + [
+        Role("D1", "diag", None, (1.0, 1.0, 1.0)),
+        Role("D2", "diag2", None, (1.0, 2.0, 3.0)),
+    ]
+
+
+def test_robust_triangulate_survives_one_traitor():
+    # a differentiated squad with redundancy localizes even when one member reports a corrupted bearing:
+    # the least-trimmed fuse drops the worst member and recovers the target; plain lstsq is pulled off.
+    roles = _redundant_squad()
+    B = squad_basis(roles)
+    target = np.array([1.0, 2.0, 3.0])
+    readings = (B @ target).tolist()
+    readings[1] += 50.0  # member R1 is a traitor (corrupted reading)
+
+    plain = triangulate(roles, readings)
+    robust, dropped = robust_triangulate(roles, readings)
+    assert dropped == "R1"  # identified the traitor by leave-one-out residual
+    assert np.linalg.norm(np.array(robust.target_estimate) - target) < 1e-9  # recovered the true target
+    assert np.linalg.norm(np.array(plain.target_estimate) - target) > 1.0  # the naive fuse was pulled off
+
+
+def test_robust_triangulate_no_traitor_keeps_everyone():
+    # with clean readings there is no traitor to drop -> robust returns the full-squad fit, drops nobody
+    roles = _redundant_squad()
+    B = squad_basis(roles)
+    target = np.array([1.0, 2.0, 3.0])
+    robust, dropped = robust_triangulate(roles, (B @ target).tolist())
+    assert dropped is None
+    assert np.linalg.norm(np.array(robust.target_estimate) - target) < 1e-9
+
+
+def test_robust_triangulate_needs_a_two_member_margin_to_identify():
+    # honesty bound: with only rank+1 members, dropping any one leaves an EXACT fit (residual 0) so the
+    # traitor cannot be told apart -> robust declines to drop (returns the full, traitor-tainted fit).
+    roles = _axis_roles(3, 3) + [Role("D", "diag", None, (1.0, 1.0, 1.0))]  # n = rank + 1 only
+    B = squad_basis(roles)
+    readings = (B @ np.array([1.0, 2.0, 3.0])).tolist()
+    readings[1] += 50.0
+    _robust, dropped = robust_triangulate(roles, readings)
+    assert dropped is None  # cannot isolate a bad bearing without the 2-member margin
+
+
+def test_triangulation_demo_all_true():
+    d = demo()
+    assert all(v for k, v in d.items() if not k.startswith("_"))


### PR DESCRIPTION
## What

Extends `coding_squad` (the clone-trooper role squad) with the **rigorous backbone** under its existing "coverage" heuristic. The differentiated roles' profiles form a basis, so the squad can localize a target only inside the subspace they span — the **Bad-Batch claim made measurable: a squad of identical clones cannot triangulate.**

## API

- `squad_coverage(roles)` → `Coverage(rank, blind_directions, dilution, full_rank)`: how many concept dims the roster resolves (rank), which directions are **blind** (null space = "absence is information"), and the **in-span dilution of precision** (condition number — catches weak/near-collinear differentiation even at full rank).
- `triangulate(roles, readings)` → least-squares localize a target from each role's projective reading `r_i = <profile_i, target>`. A target in the span is recovered exactly; a blind-direction target is lost.
- `robust_triangulate(roles, readings)` → least-trimmed fuse that tolerates one **traitor** reading. Needs an `n ≥ rank+2` margin to *identify* the outlier (with `rank+1`, every leave-one-out fit is exact → indistinguishable; documented + tested as an honesty bound).

## Measured (demo)

```
5 differentiated roles in 6-D tongue space: rank 5 -> 1 blind tongue, in-span dilution 3.42
add a 6th differentiated role -> full rank (no blind spot)      : True
clone squad (5x the SAME role): rank 1, blind in 5 dims         : True
differentiated squad localizes a target in its span (residual~0): True
```

## Honest scope

Linear least-squares localization (the math under multilateration / GPS); the condition number is geometric dilution of precision. It **quantifies the squad's coverage**; it adds **no** solving power to the CSP (`coding_board.solve` still does the work). "Reading" is an abstract projection, not a physical range.

## Tests

14/14 in `tests/test_coding_squad.py` (5 original squad tests unchanged + 6 triangulation: clone rank-collapse, full-rank-when-dim-matched, target-in-span-recovered / blind-component-lost, near-collinear high-dilution, traitor survived, 2-member-margin bound). black + flake8 clean. Reuses `Role`; `solve_with_squad` untouched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>