### PR TITLE
feat(squad): bind roles to pieces + a coverage gate (the squad tiles a board with its shapes)

### DIFF
--- a/python/scbe/coding_squad.py
+++ b/python/scbe/coding_squad.py
@@ -31,6 +31,7 @@ import numpy as np
 from .coding_board import Board, SolveResult, solve
 from .coding_board_gates import CHECK, TRANSFORM, gate_names
 from .geometric_router import poincare_distance, to_ball
+from .squad_puzzle import DOMINO, I_TROMINO, L_TROMINO, SQUARE, T_TETRO, Cell, Piece, coverable_cells, holes
 
 
 @dataclass(frozen=True)
@@ -239,6 +240,48 @@ def robust_triangulate(roles: List[Role], readings: Sequence[float]) -> Tuple[Tr
     return base, None
 
 
+# ---------------------------------------------------------------------------
+# ROLE -> PIECE binding + the COVERAGE GATE. Each differentiated role carries a distinct geometric PIECE
+# (squad_puzzle), so the squad literally COVERS a board with its shapes. This makes cover_regions rigorous:
+# the gate reports the cells NO role-piece can reach (the coverage gap / blind spots) BEFORE a solve is
+# attempted -- the governance form of "absence is information". A clone roster (one shape) leaves gaps a
+# differentiated roster covers. HONEST: reachability is NECESSARY, not sufficient -- a gap-free board can
+# still be untileable (parity); the gate flags structural gaps, it does not promise a solve.
+# ---------------------------------------------------------------------------
+ROLE_PIECES: Dict[str, Piece] = {
+    "ARCHITECT": SQUARE,  # the 2x2 frame -- big footprint, no thin reach
+    "RECON": I_TROMINO,  # the long scout
+    "CODER": T_TETRO,  # the worker
+    "CHECK": L_TROMINO,  # the bent checker
+    "OPTIMIZER": DOMINO,  # the tightener -- reaches 1-wide seams the frame cannot
+}
+
+
+def squad_pieces(roles: List[Role]) -> List[Piece]:
+    """The geometric piece each role carries (its non-standard value). Unknown roles fall back to a domino."""
+    return [ROLE_PIECES.get(r.name, DOMINO) for r in roles]
+
+
+@dataclass
+class CoverageGate:
+    covered: bool  # every board cell is reachable by SOME role-piece (no holes)
+    holes: Tuple[Cell, ...]  # cells no role-piece can reach -- the coverage gap (the blind spots)
+    reachable: int  # how many board cells the role-squad's shapes can reach
+    total: int  # board cell count
+
+
+def coverage_gate(roles: List[Role], region) -> CoverageGate:
+    """Can the differentiated role-squad COVER this board with its shapes? Reports the holes (cells no role-
+    piece can reach) -- the rigorous form of cover_regions and a governance pre-check: a board with holes for
+    the current roster has a structural blind spot (recompose the squad, or reject the board). Necessary, not
+    sufficient: no holes does not guarantee an exact tiling (parity can still block it)."""
+    pieces = squad_pieces(roles)
+    h = holes(region, pieces)
+    return CoverageGate(
+        covered=(len(h) == 0), holes=h, reachable=len(coverable_cells(region, pieces)), total=len(region)
+    )
+
+
 def demo() -> Dict[str, object]:
     cov = squad_coverage(SQUAD)  # 5 differentiated roles in 6-D tongue space
 
@@ -257,6 +300,13 @@ def demo() -> Dict[str, object]:
     tri = triangulate(SQUAD, readings)
     recovered = np.allclose(B @ np.array(tri.target_estimate), readings, atol=1e-9)
 
+    # the role-squad COVERS a board with its differentiated pieces; a clone roster leaves a coverage gap
+    from .squad_puzzle import rect
+
+    board = frozenset(rect(2, 2)) | {(0, 2), (0, 3)}  # a 2x2 block + a 1-wide arm of 2 cells
+    diff_gate = coverage_gate(SQUAD, board)
+    clone_gate = coverage_gate([SQUAD[0]] * 5, board)  # all ARCHITECT (the 2x2 frame) -> cannot reach the arm
+
     return {
         "squad_resolves_5_of_6_one_blind_tongue": (
             cov.rank == 5 and not cov.full_rank and len(cov.blind_directions) == 1
@@ -264,8 +314,11 @@ def demo() -> Dict[str, object]:
         "sixth_role_closes_the_blind_spot": cov6.full_rank,
         "clone_squad_collapses_to_rank_1_blind_in_5": (cov_clone.rank == 1 and len(cov_clone.blind_directions) == 5),
         "differentiated_squad_localizes_in_span": recovered and tri.reading_residual < 1e-9,
+        "role_squad_covers_the_board_no_holes": diff_gate.covered,
+        "clone_roster_leaves_a_coverage_gap": (not clone_gate.covered) and len(clone_gate.holes) == 2,
         "_cov": cov,
         "_cov_clone": cov_clone,
+        "_clone_gate": clone_gate,
     }
 
 
@@ -289,6 +342,17 @@ def main() -> int:
         % d["differentiated_squad_localizes_in_span"]
     )
     print("  => a diverse squad triangulates what a squad of clones cannot. Coverage = rank; blind = null space.")
+    cg = d["_clone_gate"]
+    print("  --- role -> piece coverage gate (the squad tiles a board with its shapes) ---")
+    print(
+        "  role-squad's differentiated pieces cover the board (no holes)   : %s"
+        % d["role_squad_covers_the_board_no_holes"]
+    )
+    print(
+        "  clone roster (all ARCHITECT/2x2) leaves a coverage gap at %s : %s"
+        % (cg.holes, d["clone_roster_leaves_a_coverage_gap"])
+    )
+    print("  => holes = the cells no role-piece can reach (governance pre-check; necessary, not sufficient).")
     return 0
 
 

--- a/tests/test_coding_squad.py
+++ b/tests/test_coding_squad.py
@@ -12,17 +12,21 @@ import numpy as np
 from python.scbe.coding_board import Board, Operator, region_must_agree
 from python.scbe.coding_board_gates import CHECK, TRANSFORM, gate_names
 from python.scbe.coding_squad import (
+    ROLE_PIECES,
     SQUAD,
     Role,
+    coverage_gate,
     cover_regions,
     demo,
     geometric_pairs,
     robust_triangulate,
     squad_basis,
     squad_coverage,
+    squad_pieces,
     solve_with_squad,
     triangulate,
 )
+from python.scbe.squad_puzzle import rect
 
 
 # ---- roles carry goals + role-scoped sub-alphabets (the Polly-Pad loadout) ---------------------
@@ -185,6 +189,39 @@ def test_robust_triangulate_needs_a_two_member_margin_to_identify():
     readings[1] += 50.0
     _robust, dropped = robust_triangulate(roles, readings)
     assert dropped is None  # cannot isolate a bad bearing without the 2-member margin
+
+
+# ---- role -> piece binding + the coverage gate (the squad tiles a board with its shapes) ----------
+def test_each_role_carries_a_distinct_piece():
+    pieces = {name: p.name for name, p in ROLE_PIECES.items()}
+    assert set(pieces) == {r.name for r in SQUAD}  # every role has a piece
+    assert len(set(pieces.values())) == len(pieces)  # all distinct shapes (a differentiated squad)
+
+
+def test_squad_pieces_maps_the_roster_in_order():
+    pieces = squad_pieces(SQUAD)
+    assert [p.name for p in pieces] == [ROLE_PIECES[r.name].name for r in SQUAD]
+
+
+def test_coverage_gate_differentiated_covers_clone_leaves_a_gap():
+    # a 2x2 block + a 1-wide arm: the differentiated role-pieces reach every cell; a clone roster of the 2x2
+    # frame cannot reach the 1-wide arm -> a coverage gap (the rigorous, geometric form of cover_regions).
+    board = frozenset(rect(2, 2)) | {(0, 2), (0, 3)}
+    diff = coverage_gate(SQUAD, board)
+    clone = coverage_gate([SQUAD[0]] * 5, board)  # all ARCHITECT (the 2x2 SQUARE)
+    assert diff.covered and diff.holes == () and diff.reachable == diff.total == 6
+    assert not clone.covered  # the frame cannot reach the 1-wide seam
+    assert clone.holes == ((0, 2), (0, 3)) and clone.reachable == 4
+
+
+def test_coverage_gate_is_necessary_not_sufficient():
+    # honesty: "covered" means every cell is REACHABLE by some piece, NOT that an exact tiling exists. The
+    # mutilated chessboard is fully reachable by a domino (no holes) yet untileable by dominoes (parity).
+    mutilated = frozenset(c for c in rect(4, 4) if c not in {(0, 0), (3, 3)})
+    optimizer_only = [r for r in SQUAD if r.name == "OPTIMIZER"] * 7  # OPTIMIZER carries the domino
+    gate = coverage_gate(optimizer_only, mutilated)
+    assert gate.covered and gate.holes == ()  # no reach gap...
+    # ...but reachability does not promise a tiling (the parity wall is checked by squad_puzzle.assemble)
 
 
 def test_triangulation_demo_all_true():


### PR DESCRIPTION
## What

Unifies the squad's two value-models (PR #2578 linear triangulation + PR #2580 geometric pieces): each differentiated **role now carries a distinct geometric piece**, so the role-squad literally **covers a board** with its shapes — making the old `cover_regions` heuristic rigorous, with a **governance pre-check**.

## API (`python/scbe/coding_squad.py`, reusing `squad_puzzle`)

- `ROLE_PIECES`: ARCHITECT→2×2 frame, RECON→I-tromino, CODER→T-tetromino, CHECK→L-tromino, OPTIMIZER→domino (distinct shapes = a differentiated squad).
- `squad_pieces(roles)` → each role's piece.
- `coverage_gate(roles, region)` → `CoverageGate(covered, holes, reachable, total)`: the cells **no role-piece can reach**, reported *before* a solve — the governance form of "absence is information".

## Measured (demo)

```
role-squad's differentiated pieces cover the board (no holes)   : True
clone roster (all ARCHITECT/2x2) leaves a coverage gap at ((0,2),(0,3)) : True
```

On a 2×2 block + a 1-wide arm: the differentiated roster reaches every cell; a **clone roster** of the 2×2 frame cannot reach the 1-wide seam → a coverage gap. Differentiation is load-bearing again, now as board coverage.

## Honest scope

Reachability is **necessary, not sufficient** — a hole-free board can still be untileable (parity). Tested explicitly: the mutilated chessboard is fully reachable by a domino (`covered=True`, no holes) yet has no domino tiling. The gate flags structural gaps; it does **not** promise a solve (that's `squad_puzzle.assemble`).

## Tests

18/18 in `tests/test_coding_squad.py` (14 prior unchanged + 4 new: distinct role→piece map, `squad_pieces` order, differentiated-covers / clone-gaps, necessary-not-sufficient). No import cycle; `solve_with_squad` untouched. black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>