### PR TITLE
feat(squad): wire the coverage gate into solve_with_squad (governance pre-check)

### DIFF
--- a/python/scbe/coding_squad.py
+++ b/python/scbe/coding_squad.py
@@ -23,6 +23,7 @@ coding_board (#2568), coding_board_gates (#2570) and geometric_router shape prim
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -31,7 +32,18 @@ import numpy as np
 from .coding_board import Board, SolveResult, solve
 from .coding_board_gates import CHECK, TRANSFORM, gate_names
 from .geometric_router import poincare_distance, to_ball
-from .squad_puzzle import DOMINO, I_TROMINO, L_TROMINO, SQUARE, T_TETRO, Cell, Piece, coverable_cells, holes
+from .squad_puzzle import (
+    DOMINO,
+    I_TROMINO,
+    L_TROMINO,
+    SQUARE,
+    T_TETRO,
+    Cell,
+    Piece,
+    Region,
+    coverable_cells,
+    holes,
+)
 
 
 @dataclass(frozen=True)
@@ -109,18 +121,46 @@ class SquadResult:
     pairs: List[Tuple[str, Optional[str], float]]  # the geometric buddy teams
     coverage: Dict[str, str]  # region -> team
     roster: Dict[str, str] = field(default_factory=dict)  # role -> its legal-operation sub-alphabet size
+    gate: Optional["CoverageGate"] = None  # the geometric coverage pre-check (None when not computed)
+    rejected: bool = False  # True when require_coverage refused the board for a coverage gap (no solve run)
 
 
-def solve_with_squad(board: Board, roles: Optional[List[Role]] = None) -> SquadResult:
+def board_region(board: Board) -> "Region":
+    """A deterministic geometric layout for a board: pack its operators row-major into a near-square grid,
+    one cell per operator. Gives the coverage gate a SHAPE to reach over when the board has no spatial info."""
+    n = len(board.operators)
+    if n == 0:
+        return frozenset()
+    w = math.ceil(math.sqrt(n))
+    return frozenset(((i // w), (i % w)) for i in range(n))
+
+
+def solve_with_squad(
+    board: Board,
+    roles: Optional[List[Role]] = None,
+    region: "Optional[Region]" = None,
+    require_coverage: bool = False,
+) -> SquadResult:
     """Run the squad over the board: pair roles geometrically, assign region coverage, RECON the targets,
     then solve the CSP (CODER fills, CHECK runs the energy/CBJ jump-back). The solve is coding_board.solve;
-    the squad layer is the coordination + coverage around it."""
+    the squad layer is the coordination + coverage around it.
+
+    The geometric coverage GATE runs first: it checks the squad's role-pieces can reach every cell of the
+    board's layout (`region`, or a packed default). The gate is always ATTACHED to the result; when
+    `require_coverage` is set, a board with a coverage gap is REJECTED before any solve (governance: don't
+    attempt work the squad-as-composed cannot cover). HONEST: coverage is necessary, not sufficient -- it
+    does not promise the CSP is solvable, only that no board cell is unreachable by the roster's shapes."""
     roles = roles or SQUAD
     pairs = geometric_pairs(roles)
     coverage = cover_regions(board, pairs)
     targets = [op.id for op in board.operators if op.fixed is None]  # RECON: the unknowns
-    res: SolveResult = solve(board)  # CODER fills; CHECK's repair = the CBJ jumps inside the solve
     roster = {r.name: ("%d ops" % len(r.legal_operations())) for r in roles}
+    reg = region if region is not None else board_region(board)
+    gate = coverage_gate(roles, reg)
+    if require_coverage and not gate.covered:
+        # the squad's pieces leave a hole on this board's layout -> reject up front, do not solve
+        return SquadResult(False, {}, 0, [], targets, pairs, coverage, roster, gate, rejected=True)
+    res: SolveResult = solve(board)  # CODER fills; CHECK's repair = the CBJ jumps inside the solve
     return SquadResult(
         solved=res.solved,
         assignment=res.assignment,
@@ -130,6 +170,7 @@ def solve_with_squad(board: Board, roles: Optional[List[Role]] = None) -> SquadR
         pairs=pairs,
         coverage=coverage,
         roster=roster,
+        gate=gate,
     )
 
 

--- a/tests/test_coding_squad.py
+++ b/tests/test_coding_squad.py
@@ -15,6 +15,7 @@ from python.scbe.coding_squad import (
     ROLE_PIECES,
     SQUAD,
     Role,
+    board_region,
     coverage_gate,
     cover_regions,
     demo,
@@ -222,6 +223,43 @@ def test_coverage_gate_is_necessary_not_sufficient():
     gate = coverage_gate(optimizer_only, mutilated)
     assert gate.covered and gate.holes == ()  # no reach gap...
     # ...but reachability does not promise a tiling (the parity wall is checked by squad_puzzle.assemble)
+
+
+# ---- the gate wired into solve_with_squad (governance pre-check before the solve) -----------------
+def _three_op_board():
+    # 3 operators -> board_region packs them into an L-tromino (cells (0,0),(0,1),(1,0)); a 2x2 frame can't
+    # fit it, so a clone roster of ARCHITECT(frame) cannot cover this board.
+    ops = [Operator("o%d" % i, gate_names(TRANSFORM), region="r") for i in range(3)]
+    return Board(ops, [region_must_agree])
+
+
+def test_board_region_packs_operators_into_a_grid():
+    assert board_region(_three_op_board()) == frozenset({(0, 0), (0, 1), (1, 0)})  # L-tromino for n=3, w=2
+
+
+def test_solve_with_squad_attaches_the_coverage_gate():
+    board = _three_op_board()
+    res = solve_with_squad(board)  # default SQUAD, require_coverage off
+    assert res.gate is not None and res.gate.covered  # the differentiated roster reaches the whole layout
+    assert res.solved and not res.rejected  # and it still solves the CSP
+
+
+def test_require_coverage_rejects_a_clone_roster_before_solving():
+    board = _three_op_board()
+    clone = [SQUAD[0]] * 5  # all ARCHITECT (the 2x2 frame) -> cannot reach a 3-cell L layout
+    res = solve_with_squad(board, roles=clone, require_coverage=True)
+    assert res.rejected and not res.solved  # rejected BEFORE the solve for a coverage gap
+    assert res.gate is not None and not res.gate.covered and len(res.gate.holes) == 3
+    assert res.assignment == {}  # no solve was attempted
+
+
+def test_clone_roster_without_require_coverage_still_solves_but_flags_the_gap():
+    # default behaviour is FLAG, not reject: the gap is reported on the gate, but the CSP still solves
+    board = _three_op_board()
+    clone = [SQUAD[0]] * 5
+    res = solve_with_squad(board, roles=clone)  # require_coverage defaults False
+    assert not res.rejected and res.solved  # solved despite the geometric gap (gate is a diagnostic here)
+    assert res.gate is not None and not res.gate.covered  # ...but the gap is flagged for the caller
 
 
 def test_triangulation_demo_all_true():


### PR DESCRIPTION
## What

Pushes the role→piece **coverage gate** (#2582) into the actual solve path. `solve_with_squad` now runs the gate *before* the CSP solve and **attaches it to every result**; with `require_coverage=True` it **rejects** a board the squad can't cover, before any solve.

## API

- `board_region(board)` — packs operators row-major into a near-square grid, so a board with no spatial fields still has a **shape** for the gate to reach over (3 ops → an L-tromino, etc.).
- `solve_with_squad(board, roles=None, region=None, require_coverage=False)`:
  - always computes `coverage_gate(roles, region or board_region(board))` and attaches it as `result.gate`;
  - `require_coverage=True` → a board with a coverage gap returns `rejected=True, solved=False, assignment={}` **without solving** (the governance pre-check: don't attempt work the squad-as-composed can't cover);
  - default `require_coverage=False` → unchanged behaviour: the gap is flagged on `result.gate`, the CSP still solves.
- `SquadResult` gains `gate` + `rejected`, both default-safe, so existing callers are untouched.

## Demonstrated

A 3-operator board packs into an L-tromino layout. The default differentiated `SQUAD` reaches it (covered, solves). A **clone roster** of `ARCHITECT` (the 2×2 frame) cannot fit a 3-cell L → with `require_coverage=True` it is **rejected before solving** (`rejected=True`, holes = all 3 cells, no assignment); without the flag it still solves but the gap is reported.

## Honest scope

Coverage is **necessary, not sufficient** — the gate does not promise the CSP is solvable, only that no board cell is unreachable by the roster's shapes. That's exactly why the default is **flag, not reject**.

## Tests

22/22 in `tests/test_coding_squad.py` (18 prior unchanged + 4 new: `board_region` packing, gate attached on a normal solve, `require_coverage` rejects a clone roster pre-solve, default flags-but-solves). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>