### PR TITLE
feat(squad): meter the gated solve with the Landauer ledger (the bijective-time arc meets the squad)

### DIFF
--- a/python/scbe/coding_squad.py
+++ b/python/scbe/coding_squad.py
@@ -29,9 +29,11 @@ from typing import Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
-from .coding_board import Board, SolveResult, solve
+from .coding_board import Board, Operator, SolveResult, region_must_agree, solve
 from .coding_board_gates import CHECK, TRANSFORM, gate_names
 from .geometric_router import poincare_distance, to_ball
+from .observer_dynamics import decision_bits
+from .reversible_circuit import ROOM_T_K, EnergyLedger
 from .squad_puzzle import (
     DOMINO,
     I_TROMINO,
@@ -123,6 +125,36 @@ class SquadResult:
     roster: Dict[str, str] = field(default_factory=dict)  # role -> its legal-operation sub-alphabet size
     gate: Optional["CoverageGate"] = None  # the geometric coverage pre-check (None when not computed)
     rejected: bool = False  # True when require_coverage refused the board for a coverage gap (no solve run)
+    squad_energy: Optional["SquadEnergy"] = None  # Landauer cost of the solve's CBJ re-decisions (None if none)
+
+
+@dataclass
+class SquadEnergy:
+    """The thermodynamic cost of a squad solve, by Landauer's principle (the bijective-time/reversible arc
+    meeting the squad). Each CBJ jump-back is an irreversible RE-DECISION that overwrites an operator's
+    assignment, erasing decision_bits(domain) bits; a conflict-free (forward-only) solve pays 0. Metered the
+    same way as observer_dynamics.resolve_by_jumpback_metered -- the two CBJ solvers share one ledger."""
+
+    overwrites: int  # CBJ jump-backs the solve committed (irreversible re-decisions; -1 dead-ends excluded)
+    bits_erased: int  # sum of decision_bits(operator domain) over those re-decisions
+    irreversible_joules: float  # the Landauer FLOOR the dissipating (overwrite) solve pays (a lower bound)
+    reversible_joules: float  # 0.0 -- logging the jumps (an undo-tape) erases nothing during the solve (Bennett)
+
+
+def solve_energy(board: Board, jumps: List[int], temperature_k: float = ROOM_T_K) -> SquadEnergy:
+    """Meter a solve's CBJ jump-backs with the Landauer ledger. Each valid jump overwrites that operator's
+    decision (erasing log2(domain) bits); -1 dead-end sentinels are not real re-decisions and are skipped.
+    The reversible alternative (log the jumps as an undo-tape) erases nothing -- it defers the cost to space."""
+    valid = [j for j in jumps if 0 <= j < len(board.operators)]
+    ledger = EnergyLedger(temperature_k=temperature_k)
+    for j in valid:
+        ledger.erase("re-decide op[%d]" % j, decision_bits(len(board.operators[j].domain)))
+    return SquadEnergy(
+        overwrites=len(valid),
+        bits_erased=ledger.bits_erased,
+        irreversible_joules=ledger.joules(),
+        reversible_joules=0.0,
+    )
 
 
 def board_region(board: Board) -> "Region":
@@ -171,6 +203,7 @@ def solve_with_squad(
         coverage=coverage,
         roster=roster,
         gate=gate,
+        squad_energy=solve_energy(board, res.jumps),  # the Landauer cost of this solve's CBJ re-decisions
     )
 
 
@@ -348,6 +381,22 @@ def demo() -> Dict[str, object]:
     diff_gate = coverage_gate(SQUAD, board)
     clone_gate = coverage_gate([SQUAD[0]] * 5, board)  # all ARCHITECT (the 2x2 frame) -> cannot reach the arm
 
+    # the bijective-time Landauer ledger meets the squad solve: a clean (forward-only) solve pays 0 J; a solve
+    # that CBJ-jumps-back pays the Landauer floor for each irreversible re-decision (the arrow's heat)
+    clean_e = solve_with_squad(
+        Board([Operator("a", gate_names(TRANSFORM)), Operator("b", gate_names(TRANSFORM))], [])
+    ).squad_energy
+    conflict_e = solve_with_squad(
+        Board(
+            [
+                Operator("a", ("A", "B"), region="r"),
+                Operator("b", ("B",), region="r", fixed="B"),
+                Operator("c", ("A",), region="r"),
+            ],
+            [region_must_agree],
+        )
+    ).squad_energy
+
     return {
         "squad_resolves_5_of_6_one_blind_tongue": (
             cov.rank == 5 and not cov.full_rank and len(cov.blind_directions) == 1
@@ -357,9 +406,13 @@ def demo() -> Dict[str, object]:
         "differentiated_squad_localizes_in_span": recovered and tri.reading_residual < 1e-9,
         "role_squad_covers_the_board_no_holes": diff_gate.covered,
         "clone_roster_leaves_a_coverage_gap": (not clone_gate.covered) and len(clone_gate.holes) == 2,
+        "clean_solve_is_energy_free": clean_e.overwrites == 0 and clean_e.irreversible_joules == 0.0,
+        "backtracking_solve_pays_landauer": conflict_e.overwrites >= 1 and conflict_e.irreversible_joules > 0.0,
         "_cov": cov,
         "_cov_clone": cov_clone,
         "_clone_gate": clone_gate,
+        "_clean_e": clean_e,
+        "_conflict_e": conflict_e,
     }
 
 
@@ -394,6 +447,16 @@ def main() -> int:
         % (cg.holes, d["clone_roster_leaves_a_coverage_gap"])
     )
     print("  => holes = the cells no role-piece can reach (governance pre-check; necessary, not sufficient).")
+    ce, qe = d["_clean_e"], d["_conflict_e"]
+    print("  --- the Landauer ledger meets the squad solve (energy = the CBJ re-decisions) ---")
+    print(
+        "  clean forward-only solve: %d re-decision(s) -> %.3e J (erases nothing, free)"
+        % (ce.overwrites, ce.irreversible_joules)
+    )
+    print(
+        "  backtracking solve: %d CBJ re-decision(s) -> %.3e J (the arrow's heat; reversible undo-tape = 0 J)"
+        % (qe.overwrites, qe.irreversible_joules)
+    )
     return 0
 
 

--- a/tests/test_coding_squad.py
+++ b/tests/test_coding_squad.py
@@ -262,6 +262,41 @@ def test_clone_roster_without_require_coverage_still_solves_but_flags_the_gap():
     assert res.gate is not None and not res.gate.covered  # ...but the gap is flagged for the caller
 
 
+# ---- the Landauer energy ledger wired into the solve (the bijective-time arc meets the squad) -----
+def test_clean_forward_only_solve_pays_zero_landauer_energy():
+    # no CBJ jump-backs -> nothing erased -> 0 J. The honest Landauer point: the cost is in the erasures.
+    board = Board([Operator("o0", gate_names(TRANSFORM)), Operator("o1", gate_names(TRANSFORM))], [])
+    res = solve_with_squad(board)
+    assert res.solved and res.jumps == []
+    assert res.squad_energy is not None
+    assert res.squad_energy.overwrites == 0 and res.squad_energy.irreversible_joules == 0.0
+
+
+def test_backtracking_solve_charges_the_cbj_redecisions_at_the_landauer_floor():
+    # op0 (domain A,B -> 1 bit) is the CBJ jump-back target; one re-decision pays one Landauer quantum, and
+    # the -1 dead-end sentinel is NOT a real re-decision (excluded from the charge).
+    board = Board(
+        [
+            Operator("o0", ("A", "B"), region="r"),
+            Operator("o1", ("B",), region="r", fixed="B"),
+            Operator("o2", ("A",), region="r"),
+        ],
+        [region_must_agree],
+    )
+    res = solve_with_squad(board)
+    assert -1 in res.jumps  # the solver hit a dead end (sentinel present)
+    e = res.squad_energy
+    assert e.overwrites == 1 and e.bits_erased == 1  # only the valid jump (op0), decision_bits(2) == 1
+    assert e.irreversible_joules > 0.0  # the dissipating (overwrite) solve pays the floor
+    assert e.reversible_joules == 0.0  # logging the jumps as an undo-tape would erase nothing (Bennett)
+
+
+def test_rejected_board_meters_no_energy_no_solve_ran():
+    # require_coverage rejects before solving -> no CBJ re-decisions happened -> squad_energy stays None
+    res = solve_with_squad(_three_op_board(), roles=[SQUAD[0]] * 5, require_coverage=True)
+    assert res.rejected and res.squad_energy is None
+
+
 def test_triangulation_demo_all_true():
     d = demo()
     assert all(v for k, v in d.items() if not k.startswith("_"))


### PR DESCRIPTION
## What

Merges the **bijective-time / reversible energy ledger** into the squad's gated solve. `coding_board.solve` does CBJ jump-backs; the Landauer ledger charges exactly those irreversible re-decisions — so a squad solve now reports its **thermodynamic cost**, metered the *same way* as `observer_dynamics.resolve_by_jumpback_metered`. The two CBJ solvers now share one ledger.

## How

A CBJ jump-back is an irreversible **re-decision** that overwrites an operator's assignment → it erases `decision_bits(domain)` bits at the Landauer floor. A conflict-free (forward-only) solve erases nothing → **0 J**. The cost lives in the erasures.

- `SquadEnergy(overwrites, bits_erased, irreversible_joules, reversible_joules)` + `solve_energy(board, jumps)` — reuses `reversible_circuit.EnergyLedger` and `observer_dynamics.decision_bits`. `-1` dead-end sentinels are not real re-decisions and are excluded.
- `solve_with_squad` attaches `result.squad_energy` whenever a solve runs; a board rejected by `require_coverage` meters nothing (`squad_energy` stays `None`).

## Measured (demo)

```
clean forward-only solve: 0 re-decision(s) -> 0.000e+00 J (erases nothing, free)
backtracking solve: 1 CBJ re-decision(s) -> 2.871e-21 J (the arrow's heat; reversible undo-tape = 0 J)
```

The backtracking solve re-decides `o0` (domain `A,B` = 1 bit) → exactly one Landauer quantum (`kT·ln2` at 300 K).

## Honest scope

The **Landauer floor** — a thermodynamic lower bound, not real-chip dissipation. `reversible_joules = 0` is the *undo-tape* alternative (log the jumps instead of erasing): it defers the cost into space, it does not abolish it (Bennett). A clean solve is genuinely 0 because no information was erased.

## Tests

25/25 in `tests/test_coding_squad.py` (22 prior unchanged + 3 new: clean solve = 0 J, backtracking charges the CBJ re-decisions at the floor with the `-1` sentinel excluded, rejected board meters nothing). `SquadResult` gained `squad_energy` (default-safe). No import cycle. black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>