### PR TITLE
feat(observer): minimal unsat cores in pure Python (zero-dep, keeps the root for jump-back)

### DIFF
--- a/python/scbe/observer_dynamics.py
+++ b/python/scbe/observer_dynamics.py
@@ -218,6 +218,53 @@ def earliest_repair_point(
     return min(v.earliest_index for v in viols)
 
 
+# ---------------------------------------------------------------------------
+# MINIMAL UNSAT CORE (the crisp explanation a SAT solver's get_core() gives -- in pure Python, zero deps).
+# A violation's `involved` is a SUFFICIENT conflict set, but not always minimal: a route contradiction names
+# EVERY record on the route. minimal_core shrinks it (deletion-based / QuickXplain) to the smallest subset
+# that still triggers the same constraint -- e.g. one ALLOW + one DENY. Keeps the auditability moat: it is a
+# few lines you can read, not an opaque solver core.
+#
+# IMPORTANT, and the reason we keep BOTH: a minimal core may legitimately DROP the earliest record (it can
+# keep a later ALLOW over the first one), so it is the wrong thing for the jump-back. The repair target stays
+# `earliest_repair_point` over the FULL conflict (the root cause); the minimal core is for the EXPLANATION.
+# ---------------------------------------------------------------------------
+def minimal_core(records: List[DecisionRecord], constraint: Constraint, violation: Violation) -> List[int]:
+    """The minimal subset of `violation.involved` that still triggers `constraint` (run on that sub-history).
+    Deletion-based: drop a record; if the constraint still fires without it, it was non-essential. Deterministic
+    (scans in sorted index order). Returns record indices into `records` -- a crisp, auditable explanation."""
+    core = sorted(violation.involved)
+    i = 0
+    while i < len(core):
+        trial = core[:i] + core[i + 1 :]
+        sub = [records[j] for j in trial]
+        if trial and constraint(sub):  # still inconsistent without records[core[i]] -> it was non-essential
+            core = trial  # do not advance: re-test the record now sitting at position i
+        else:
+            i += 1
+    return core
+
+
+def minimal_cores(
+    records: List[DecisionRecord], constraints: Optional[List[Constraint]] = None
+) -> List[Dict[str, Any]]:
+    """For every current violation: its minimal core (the crisp explanation) AND the jump-back target (the
+    earliest of the FULL conflict -- the root cause, which the minimal core may not contain). The honest
+    pairing -- minimal for showing the user, full-earliest for the repair."""
+    out: List[Dict[str, Any]] = []
+    for c in constraints or DEFAULT_CONSTRAINTS:
+        for v in c(records):
+            out.append(
+                {
+                    "rule": v.rule,
+                    "full_conflict": sorted(v.involved),
+                    "minimal_core": minimal_core(records, c, v),
+                    "jumpback_target": v.earliest_index,  # root cause = earliest of the FULL conflict
+                }
+            )
+    return out
+
+
 # a repair policy: given the records and the jump-back index, return a NEW decision for that record
 # (or None to give up on that node). The module supplies the mechanism; the policy is the caller's.
 RepairPolicy = Callable[[List[DecisionRecord], int], Optional[str]]

--- a/tests/test_observer_dynamics.py
+++ b/tests/test_observer_dynamics.py
@@ -20,8 +20,13 @@ from python.scbe.observer_dynamics import (
     decision_bits,
     earliest_repair_point,
     energy_of_solve,
+    escalation_must_be_resolved,
     is_admissible,
     markovian_committed_conflicts,
+    minimal_core,
+    minimal_cores,
+    no_contradictory_route_decisions,
+    no_post_refusal_success,
     resolve_by_jumpback,
     resolve_by_jumpback_metered,
     resolve_by_jumpback_reversible,
@@ -32,6 +37,44 @@ from python.scbe.observer_dynamics import (
 
 def _r(seq, decision, route=None, input_id=None, **meta):
     return DecisionRecord(seq=seq, input_id=input_id or ("i%d" % seq), decision=decision, route=route, meta=meta)
+
+
+# ---- minimal unsat core: crisp explanation, but the jump-back keeps the root --------------------
+def test_minimal_core_shrinks_a_route_contradiction_to_a_pair():
+    # the full conflict names every record on the route; the minimal core is one ALLOW + one DENY
+    recs = [_r(0, ALLOW, route="r"), _r(1, ALLOW, route="x"), _r(2, ALLOW, route="r"), _r(3, DENY, route="r")]
+    v = no_contradictory_route_decisions(recs)[0]
+    assert sorted(v.involved) == [0, 2, 3]  # full conflict = all three on route r
+    core = minimal_core(recs, no_contradictory_route_decisions, v)
+    assert len(core) == 2  # minimal: a single contradicting pair
+    decisions = {recs[i].decision for i in core}
+    assert decisions == {ALLOW, DENY}  # the pair really is an ALLOW and a DENY
+
+
+def test_minimal_core_is_already_minimal_for_small_conflicts():
+    # an unresolved escalation is a 1-record conflict; a post-refusal-success is a 2-record conflict
+    esc = [_r(0, ESCALATE, input_id="a")]
+    v = escalation_must_be_resolved(esc)[0]
+    assert minimal_core(esc, escalation_must_be_resolved, v) == [0]
+
+    pr = [_r(0, REFUSED, input_id="x"), _r(1, ALLOW, input_id="x")]
+    v2 = no_post_refusal_success(pr)[0]
+    assert sorted(minimal_core(pr, no_post_refusal_success, v2)) == [0, 1]
+
+
+def test_minimal_core_may_drop_the_root_but_jumpback_keeps_it():
+    # the honest, load-bearing property: a minimal core can drop the EARLIEST record, so it is the WRONG
+    # thing for the repair target. minimal_cores pairs the crisp core with the FULL-conflict earliest (root).
+    recs = [_r(0, ALLOW, route="r"), _r(2, ALLOW, route="r"), _r(5, DENY, route="r")]
+    mc = minimal_cores(recs)[0]
+    assert mc["jumpback_target"] == 0  # root cause = earliest of the FULL conflict
+    assert 0 not in mc["minimal_core"]  # ...which the minimal core legitimately dropped
+    assert mc["full_conflict"] == [0, 1, 2]  # indices into recs (positions), all three
+
+
+def test_minimal_cores_empty_when_admissible():
+    clean = [_r(0, ALLOW, route="r"), _r(1, ALLOW, route="r")]
+    assert minimal_cores(clean) == []
 
 
 # ---- the future-dependent gap is real -----------------------------------------------------------


### PR DESCRIPTION
## What

The crisp explanation a SAT solver's `get_core()` gives — **in pure Python, zero new dependencies**. The zero-dep half of the SAT proposal: capture the *minimal core* idea while keeping the auditability moat (a few readable lines, not an opaque solver core).

A violation's `involved` set is *sufficient* but not always *minimal* — `no_contradictory_route_decisions` names **every** record on the route. `minimal_core` shrinks it (deletion-based / QuickXplain) to the smallest subset that still triggers the constraint, e.g. one `ALLOW` + one `DENY`.

## API

- `minimal_core(records, constraint, violation)` → the minimal subset of indices; deterministic (sorted scan).
- `minimal_cores(records)` → each violation paired with its minimal core **and** its jump-back target.

## The load-bearing honesty (why we keep BOTH)

A minimal core may legitimately **drop the earliest record** — it can keep a later `ALLOW` over the first one. So it is the **wrong thing for the repair target**. We pair the minimal core (for the *explanation*) with the **full conflict's earliest** (`earliest_repair_point`, the *root cause*) for the jump-back. Tested: a 3-record route conflict `[0,1,2]` yields a 2-record core `[1,2]` that **excludes index 0**, while the jump-back stays at `0`.

This is exactly the subtlety a naive `get_core()`-drives-jump-back integration would get wrong.

## Relationship to the CP-SAT proposal

This is the **zero-dependency complement** to the proposed OR-Tools CP-SAT backend. It delivers minimal explanations now without trading away auditability; the *measured* custom-vs-CP-SAT comparison (to justify the dependency at scale) is the agreed next step. `observer_dynamics` is a shared module — this change is additive (new functions only), touching neither the existing solver nor the energy ledger.

## Tests

20/20 in `tests/test_observer_dynamics.py` (16 prior unchanged + 4 new: route conflict → pair, already-minimal small conflicts, core-drops-root-but-jumpback-keeps-it, empty-when-admissible). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>