### PR TITLE
feat(observer): unified SAT-style assumption/core surface (root-preserving, fixes the lane's bug)

### DIFF
--- a/python/scbe/observer_dynamics.py
+++ b/python/scbe/observer_dynamics.py
@@ -265,6 +265,66 @@ def minimal_cores(
     return out
 
 
+# ---------------------------------------------------------------------------
+# SAT-STYLE ASSUMPTION/CORE SURFACE: the solve-under-assumptions -> unsat-core contract a CP-SAT/PySAT backend
+# exposes, but dependency-free and auditable. Record indices are the assumptions; each violation yields a
+# deletion-minimized core (reusing minimal_core). A real CDCL/CP-SAT engine can swap in behind THIS surface
+# later -- but it is not warranted now: measured, CP-SAT is 50-450x slower here and finds the same core
+# (research/sat_comparison/observer_sat_compare.py). The point of having the surface is the seam, not the dep.
+# ---------------------------------------------------------------------------
+@dataclass
+class AssumptionCore:
+    """A SAT-style explanation for one inconsistency. `assumptions` is the original conflict set; `core` is the
+    deletion-minimized sufficient subset (a crisp pair, via minimal_core)."""
+
+    violation: Violation
+    assumptions: List[int]
+    core: List[int]
+
+    @property
+    def earliest_index(self) -> int:
+        # the REPAIR target is the ROOT = earliest of the FULL conflict, NOT min(core). Minimization may
+        # legitimately drop the earliest record (keep a later ALLOW over the first), so reading the minimized
+        # core here would jump back to the wrong node. `core` is for the explanation; this is for the repair.
+        return min(self.violation.involved)
+
+
+@dataclass
+class AssumptionSolve:
+    """Whole-history result in the SAT contract: satisfiable == admissible, else one core per violation."""
+
+    satisfiable: bool
+    cores: List[AssumptionCore]
+
+    @property
+    def earliest_repair_index(self) -> Optional[int]:
+        if not self.cores:
+            return None
+        return min(c.earliest_index for c in self.cores)  # equals earliest_repair_point (the root)
+
+
+def solve_under_record_assumptions(
+    records: List[DecisionRecord], constraints: Optional[List[Constraint]] = None
+) -> AssumptionSolve:
+    """Solve the observer CSP and return SAT-style unsat cores over record assumptions. satisfiable=True means
+    the whole history is admissible; otherwise one minimized AssumptionCore per violation. The explanation
+    surface a CP-SAT backend would give -- dependency-free, with the repair target kept at the full-conflict
+    root (so it agrees with earliest_repair_point, not the minimized-core earliest)."""
+    cores: List[AssumptionCore] = []
+    for c in constraints or DEFAULT_CONSTRAINTS:
+        for v in c(records):
+            cores.append(AssumptionCore(violation=v, assumptions=sorted(v.involved), core=minimal_core(records, c, v)))
+    return AssumptionSolve(satisfiable=not cores, cores=cores)
+
+
+def earliest_repair_point_from_assumption_core(
+    records: List[DecisionRecord], constraints: Optional[List[Constraint]] = None
+) -> Optional[int]:
+    """The CBJ jump-back target through the SAT-style core surface. Equals earliest_repair_point (the root) --
+    including when a minimized core drops the earliest record (it derives the target from the full conflict)."""
+    return solve_under_record_assumptions(records, constraints).earliest_repair_index
+
+
 # a repair policy: given the records and the jump-back index, return a NEW decision for that record
 # (or None to give up on that node). The module supplies the mechanism; the policy is the caller's.
 RepairPolicy = Callable[[List[DecisionRecord], int], Optional[str]]

--- a/tests/test_observer_dynamics.py
+++ b/tests/test_observer_dynamics.py
@@ -19,6 +19,7 @@ from python.scbe.observer_dynamics import (
     DecisionRecord,
     decision_bits,
     earliest_repair_point,
+    earliest_repair_point_from_assumption_core,
     energy_of_solve,
     escalation_must_be_resolved,
     is_admissible,
@@ -31,6 +32,7 @@ from python.scbe.observer_dynamics import (
     resolve_by_jumpback_metered,
     resolve_by_jumpback_reversible,
     retroactive_consistency_gap,
+    solve_under_record_assumptions,
     unwind,
 )
 
@@ -75,6 +77,45 @@ def test_minimal_core_may_drop_the_root_but_jumpback_keeps_it():
 def test_minimal_cores_empty_when_admissible():
     clean = [_r(0, ALLOW, route="r"), _r(1, ALLOW, route="r")]
     assert minimal_cores(clean) == []
+
+
+# ---- SAT-style assumption/core surface: repair target keeps the ROOT (the bug a naive get_core hits) ------
+def test_assumption_core_repair_target_matches_cbj_root_with_a_redundant_earlier_record():
+    # the exact case a min(core)-based target gets WRONG: ALLOW@0, ALLOW@2, DENY@3 on route r. The minimized
+    # core drops record 0, but the repair target must stay the ROOT 0 (earliest of the FULL conflict).
+    recs = [_r(0, ALLOW, route="r"), _r(1, ALLOW, route="x"), _r(2, ALLOW, route="r"), _r(3, DENY, route="r")]
+    sol = solve_under_record_assumptions(recs)
+    assert not sol.satisfiable
+    assert earliest_repair_point(recs) == 0  # the true CBJ root
+    assert earliest_repair_point_from_assumption_core(recs) == 0  # ...the SAT surface AGREES (not 2)
+    core = sol.cores[0].core
+    assert 0 not in core  # the minimal core legitimately drops the root...
+    assert sol.cores[0].earliest_index == 0  # ...but earliest_index keeps it (min of the FULL conflict)
+
+
+def test_assumption_solve_admissible_history_is_satisfiable():
+    clean = [_r(0, ALLOW, route="r"), _r(1, ALLOW, route="r")]
+    sol = solve_under_record_assumptions(clean)
+    assert sol.satisfiable and sol.cores == [] and sol.earliest_repair_index is None
+
+
+def test_assumption_core_is_the_minimal_contradicting_pair():
+    recs = [_r(0, ALLOW, route="r"), _r(2, ALLOW, route="r"), _r(5, DENY, route="r")]
+    core = solve_under_record_assumptions(recs).cores[0].core
+    assert len(core) == 2  # the deletion-minimized core is a single ALLOW+DENY pair
+    assert {recs[i].decision for i in core} == {ALLOW, DENY}
+
+
+def test_assumption_surface_agrees_with_earliest_repair_point_across_cases():
+    # the surface must never disagree with the canonical CBJ target -- across several conflict shapes
+    cases = [
+        [_r(0, ALLOW, route="r"), _r(1, DENY, route="r")],  # simple pair, root survives
+        [_r(0, ALLOW, route="r"), _r(2, ALLOW, route="r"), _r(3, DENY, route="r")],  # redundant earlier ALLOW
+        [_r(0, ESCALATE, input_id="a"), _r(1, ALLOW, route="r")],  # unresolved escalation
+        [_r(0, REFUSED, input_id="x"), _r(1, ALLOW, input_id="x")],  # post-refusal success
+    ]
+    for recs in cases:
+        assert earliest_repair_point_from_assumption_core(recs) == earliest_repair_point(recs)
 
 
 # ---- the future-dependent gap is real -----------------------------------------------------------


### PR DESCRIPTION
## What

Reconciles the parallel lane's `AssumptionSolve`/`AssumptionCore` idea with the already-merged `minimal_core` (#2590) into **one** surface on `main` — and fixes the **root-dropping bug** the other worktree's version has.

This is the backup to the cross-talk handoff (in case it doesn't reach the Codex lane): if their slice lands as-is you'd get two overlapping core surfaces on `observer_dynamics`, one buggy. This is the single correct surface.

## The bug it fixes (confirmed empirically)

Their `AssumptionCore.earliest_index = min(self.core)` derives the CBJ repair target from the **minimized** core. But deletion-minimization legitimately drops the earliest record:

```
recs = ALLOW@0, ALLOW@2, DENY@5  (route r)
earliest_repair_point                  = 0   ← true CBJ root
earliest_repair_point_from_assumption_core (theirs) = 2   ← WRONG (minimized core [2,5] dropped 0)
```

Their test passes only because its case has no redundant earlier record.

## The fix

`AssumptionCore.earliest_index` returns `min(self.violation.involved)` — the **root**, earliest of the FULL conflict — not `min(self.core)`. The minimized `core` stays for the **explanation**; the full-conflict earliest is the **repair target**. Same split as `minimal_cores` (#2590).

## API (reuses `minimal_core`, no duplicate logic)

- `AssumptionCore` / `AssumptionSolve` — the SAT contract (assumptions → unsat core), a seam a real CDCL/CP-SAT can swap into later.
- `solve_under_record_assumptions(records)` → `AssumptionSolve` (satisfiable, cores).
- `earliest_repair_point_from_assumption_core(records)` → equals `earliest_repair_point` (the root) across all conflict shapes.

## Measured context (#2591)

CP-SAT is **50–450× slower** here and finds the same core — so the dependency-free backend is the right default. The surface exists for the *seam*, not a pending swap.

## Tests

24/24 in `tests/test_observer_dynamics.py` (20 prior + 4 new: matches-CBJ-root-with-redundant-earlier-record, admissible→satisfiable, minimal-pair core, agrees-with-earliest_repair_point across pair/redundant/escalation/post-refusal). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>