### PR TITLE
feat(helm): staged-retry scorer + retry-teacher corpus validator (VTC eval tools)

### DIFF
--- a/python/helm/retry_corpus_validate.py
+++ b/python/helm/retry_corpus_validate.py
@@ -1,0 +1,183 @@
+"""retry_corpus_validate: validate a retry-teacher SFT corpus and measure its teacher-dependence.
+
+The v3 corpus is shaped bad attempt -> tool fail -> critique + retry -> tool fail -> teacher correction. That
+trains the repair TRAJECTORY (train-on-becoming), which is right -- but if EVERY record ends with a teacher
+bailing the model out, it learns teacher-dependence, not self-repair. This validator checks each record has
+the repair shape and reports the load-bearing ratio: teacher-bailout vs the model's OWN retry succeeding.
+(Substantiates the recommendation to mix self-repair successes into the corpus.)
+
+PER-RECORD CATEGORY:
+  MALFORMED            - missing the repair shape (< 2 assistant attempts, or no tool-fail between them)
+  SELF_REPAIR_SUCCESS  - a retry PASSED before any teacher correction (the model recovered on its own)
+  TEACHER_BAILOUT      - ends with a teacher correction (the model did not recover itself)
+  REPAIR_UNRESOLVED    - well-formed repair shape but neither a self-pass nor a teacher correction detected
+
+INPUT SCHEMA (tolerant; documented). Records are {"messages": [{role, content}...], "meta": {...}} (the VTC
+shape). Detection is HEURISTIC over roles + content markers + meta, in this order:
+  - assistant attempts = messages with role 'assistant'
+  - tool-fail          = a post-problem message whose content hits a FAIL marker (assertion/error/fail/...)
+  - teacher correction = meta flag (teacher_correction / final_source=='teacher' / source~='teacher' /
+                         grade=='teacher') OR a turn with role 'teacher' / a TEACHER content marker
+  - self-repair pass   = a PASS marker (passed/verified/all tests passed) after >=2 assistant turns with no
+                         teacher correction; or meta.repaired and meta.final_source != 'teacher'
+If your corpus marks stages explicitly in meta, the meta path takes precedence -- point it there.
+
+    python -m python.helm.retry_corpus_validate corpus.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+MALFORMED = "MALFORMED"
+SELF_REPAIR_SUCCESS = "SELF_REPAIR_SUCCESS"
+TEACHER_BAILOUT = "TEACHER_BAILOUT"
+REPAIR_UNRESOLVED = "REPAIR_UNRESOLVED"
+CATEGORIES = [SELF_REPAIR_SUCCESS, TEACHER_BAILOUT, REPAIR_UNRESOLVED, MALFORMED]
+
+FAIL_MARKERS = ("assertionerror", "traceback", "did not pass", "test failed", "error:", "failed", "fail", "❌")
+PASS_MARKERS = ("all tests passed", "tests passed", "verified", "passed", "✓", "ok:")
+TEACHER_MARKERS = ("teacher correction", "reference solution", "correct solution", "here is the correct")
+_TEACHER_BAILOUT_WARN = 0.8  # above this fraction the corpus is teaching teacher-dependence
+
+
+def _content(m: Any) -> str:
+    if isinstance(m, dict):
+        return str(m.get("content", "")).lower()
+    return str(m).lower()
+
+
+def _role(m: Any) -> str:
+    return str(m.get("role", "")).lower() if isinstance(m, dict) else ""
+
+
+def _hits(text: str, markers: Sequence[str]) -> bool:
+    return any(mk in text for mk in markers)
+
+
+def _meta_says_teacher(meta: Dict[str, Any]) -> bool:
+    if meta.get("teacher_correction") or meta.get("teacher"):
+        return True
+    src = str(meta.get("final_source", meta.get("source", ""))).lower()
+    return "teacher" in src or str(meta.get("grade", "")).lower() == "teacher"
+
+
+def analyze_record(rec: Dict[str, Any]) -> Dict[str, Any]:
+    messages = rec.get("messages") or []
+    meta = rec.get("meta") or {}
+    assistant_turns = [m for m in messages if _role(m) == "assistant"]
+    # tool-fails: failure markers in any message after the first user (the problem statement)
+    seen_problem = False
+    fail_signals = 0
+    self_pass = False
+    teacher_turn = _meta_says_teacher(meta)
+    for m in messages:
+        role, text = _role(m), _content(m)
+        if role == "user" and not seen_problem:
+            seen_problem = True
+            continue
+        if role == "teacher" or _hits(text, TEACHER_MARKERS):
+            teacher_turn = True
+        if role in ("tool", "user", "system", "ipython") and _hits(text, FAIL_MARKERS):
+            fail_signals += 1
+        if role in ("tool", "user", "system", "ipython") and _hits(text, PASS_MARKERS) and len(assistant_turns) >= 2:
+            self_pass = True
+    if meta.get("repaired") and str(meta.get("final_source", "")).lower() not in ("teacher", ""):
+        self_pass = True
+
+    well_formed = len(assistant_turns) >= 2 and fail_signals >= 1 and len(messages) >= 4
+    if not well_formed:
+        reasons = []
+        if len(assistant_turns) < 2:
+            reasons.append("only %d assistant attempt(s)" % len(assistant_turns))
+        if fail_signals < 1:
+            reasons.append("no tool-fail signal")
+        if len(messages) < 4:
+            reasons.append("too few turns")
+        category = MALFORMED
+    else:
+        reasons = []
+        if self_pass and not teacher_turn:
+            category = SELF_REPAIR_SUCCESS
+        elif teacher_turn:
+            category = TEACHER_BAILOUT
+        else:
+            category = REPAIR_UNRESOLVED
+    return {
+        "category": category,
+        "assistant_attempts": len(assistant_turns),
+        "fail_signals": fail_signals,
+        "teacher": teacher_turn,
+        "self_repair_pass": self_pass,
+        "reasons": reasons,
+    }
+
+
+def validate(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    analyses = [analyze_record(r) for r in records]
+    counts = {c: 0 for c in CATEGORIES}
+    attempts = fails = 0
+    for a in analyses:
+        counts[a["category"]] += 1
+        attempts += a["assistant_attempts"]
+        fails += a["fail_signals"]
+    total = len(analyses)
+    well_formed = total - counts[MALFORMED]
+    bailout_ratio = round(counts[TEACHER_BAILOUT] / well_formed, 3) if well_formed else 0.0
+    self_ratio = round(counts[SELF_REPAIR_SUCCESS] / well_formed, 3) if well_formed else 0.0
+    return {
+        "total": total,
+        "counts": counts,
+        "well_formed": well_formed,
+        "avg_assistant_attempts": round(attempts / total, 2) if total else 0.0,
+        "avg_fail_signals": round(fails / total, 2) if total else 0.0,
+        "teacher_bailout_ratio": bailout_ratio,
+        "self_repair_success_ratio": self_ratio,
+        "teacher_dependence_warning": bailout_ratio > _TEACHER_BAILOUT_WARN,
+        "malformed_examples": [a["reasons"] for a in analyses if a["category"] == MALFORMED][:5],
+    }
+
+
+def load_jsonl(path: str) -> List[Dict[str, Any]]:
+    out = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            out.append(json.loads(line))
+    return out
+
+
+def render(v: Dict[str, Any]) -> str:
+    lines = ["RETRY-TEACHER CORPUS VALIDATION  (total %d, well-formed %d)" % (v["total"], v["well_formed"]), ""]
+    for cat in CATEGORIES:
+        lines.append("  %-22s %4d" % (cat, v["counts"][cat]))
+    lines += [
+        "",
+        "  avg assistant attempts : %.2f" % v["avg_assistant_attempts"],
+        "  avg tool-fail signals  : %.2f" % v["avg_fail_signals"],
+        "  teacher_bailout_ratio  : %.3f   (of well-formed records)" % v["teacher_bailout_ratio"],
+        "  self_repair_success    : %.3f   <- the model recovering on its OWN" % v["self_repair_success_ratio"],
+    ]
+    if v["teacher_dependence_warning"]:
+        lines.append(
+            "  WARNING: teacher-bailout > %.0f%% -> this corpus teaches teacher-DEPENDENCE. Mix in "
+            "self-repair successes (retry -> PASS), not only teacher corrections." % (_TEACHER_BAILOUT_WARN * 100)
+        )
+    if v["malformed_examples"]:
+        lines.append("  malformed reasons (sample): %s" % v["malformed_examples"])
+    return "\n".join(lines)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="validate a retry-teacher SFT corpus + measure teacher-dependence")
+    ap.add_argument("corpus", help="the SFT corpus jsonl (messages + meta records)")
+    a = ap.parse_args(argv)
+    print(render(validate(load_jsonl(a.corpus))))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/helm/staged_retry_score.py
+++ b/python/helm/staged_retry_score.py
@@ -1,0 +1,206 @@
+"""staged_retry_score: score a staged retry-loop eval and report the per-category LIFT vs a baseline.
+
+The Colab lane proved plain solved/failed is too flat -- the signal is in the PATH. This is the durable,
+versioned, tested repo-side scorer for that staged eval (the /content/*.jsonl artifacts are ephemeral). It
+classifies each problem's run into the four stages and, given a baseline run, reports the category
+transitions -- automating the manual "newly repaired [...] / regression [...]" call.
+
+THE FOUR STAGES (what the harness emits):
+  SOLVED_FIRST_TRY                     - first attempt passed the hidden oracle
+  SOLVE_FAILED_FIX_ATTEMPT_SOLVED      - first attempt failed, the retry recovered it (the becoming win)
+  SOLVE_FAILED_FIX_ATTEMPT_FAILED      - first attempt failed, the retry did NOT recover it
+  PUBLIC_PASS_HIDDEN_FAIL_NO_RETRY     - passed the PUBLIC tests, failed the HIDDEN oracle, and never
+                                         retried because it thought it had passed = the circular-trust /
+                                         overfit residual (same failure mode as los_codegen_bench).
+
+DERIVED METRICS:
+  solve_rate            = (first-try + fix-solved) / total
+  repair_conversion     = fix-solved / (fix-solved + fix-failed)   -- how often the retry LOOP actually works
+  overfit_no_retry_rate = public-pass-hidden-fail / total          -- the residual a stronger local face closes
+
+INPUT SCHEMA (tolerant; documented so you can adapt). Each jsonl record is one problem run. classify() uses,
+in order: (1) an explicit category field -- any of category/status/outcome/label/stage/result whose value is
+one of the four stage names; else (2) raw signals -- first-try hidden pass, first-try public pass, whether a
+retry was attempted, and retry hidden pass (flat aliases like first_try_hidden_pass / first_hidden_pass /
+retried / retry_hidden_pass, or nested first_try.hidden_pass / retry.attempted / retry.hidden_pass). A record
+that fits neither is UNCLASSIFIED (counted + warned, never force-fit into a stage). Per-problem identity for
+deltas uses task_id / id / problem_id / name.
+
+    python -m python.helm.staged_retry_score run.jsonl --baseline base.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+SOLVED_FIRST_TRY = "SOLVED_FIRST_TRY"
+FIX_SOLVED = "SOLVE_FAILED_FIX_ATTEMPT_SOLVED"
+FIX_FAILED = "SOLVE_FAILED_FIX_ATTEMPT_FAILED"
+PUBLIC_PASS_HIDDEN_FAIL = "PUBLIC_PASS_HIDDEN_FAIL_NO_RETRY"
+UNCLASSIFIED = "UNCLASSIFIED"
+CATEGORIES = [SOLVED_FIRST_TRY, FIX_SOLVED, FIX_FAILED, PUBLIC_PASS_HIDDEN_FAIL]
+_SOLVED = {SOLVED_FIRST_TRY, FIX_SOLVED}
+
+_CATEGORY_FIELDS = ("category", "status", "outcome", "label", "stage", "result")
+_KEY_FIELDS = ("task_id", "id", "problem_id", "name", "task")
+
+
+def _get(rec: Dict[str, Any], *aliases: str) -> Any:
+    """Fetch the first present alias; supports dotted nesting (e.g. 'first_try.hidden_pass')."""
+    for a in aliases:
+        cur: Any = rec
+        ok = True
+        for part in a.split("."):
+            if isinstance(cur, dict) and part in cur:
+                cur = cur[part]
+            else:
+                ok = False
+                break
+        if ok:
+            return cur
+    return None
+
+
+def _norm(value: Any) -> str:
+    return str(value).strip().upper().replace(" ", "_").replace("-", "_")
+
+
+def classify(rec: Dict[str, Any]) -> str:
+    """Return one of CATEGORIES, or UNCLASSIFIED. Prefers an explicit category field; else derives from the
+    raw first-try / retry signals."""
+    explicit = _get(rec, *_CATEGORY_FIELDS)
+    if explicit is not None:
+        norm = _norm(explicit)
+        if norm in CATEGORIES:
+            return norm
+    first_hidden = _get(rec, "first_try_hidden_pass", "first_hidden_pass", "first_hidden", "first_try.hidden_pass")
+    first_public = _get(rec, "first_try_public_pass", "first_public_pass", "first_public", "first_try.public_pass")
+    retried = _get(rec, "retried", "fix_attempted", "retry_attempted", "retry.attempted")
+    retry_hidden = _get(rec, "retry_hidden_pass", "fix_hidden_pass", "retry.hidden_pass")
+    if first_hidden is None:
+        return UNCLASSIFIED
+    if first_hidden:
+        return SOLVED_FIRST_TRY
+    if first_public and not retried:
+        return PUBLIC_PASS_HIDDEN_FAIL  # thought it passed (public) -> never entered the retry loop
+    if retried:
+        return FIX_SOLVED if retry_hidden else FIX_FAILED
+    return UNCLASSIFIED  # first-try failed, no public pass, no retry -> not one of the four; do not force-fit
+
+
+def _counts(records: Sequence[Dict[str, Any]]) -> Dict[str, int]:
+    out = {c: 0 for c in CATEGORIES + [UNCLASSIFIED]}
+    for r in records:
+        out[classify(r)] += 1
+    return out
+
+
+def score(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    c = _counts(records)
+    total = sum(c.values())
+    solved = c[SOLVED_FIRST_TRY] + c[FIX_SOLVED]
+    fix_total = c[FIX_SOLVED] + c[FIX_FAILED]
+    return {
+        "total": total,
+        "counts": c,
+        "solve_rate": round(solved / total, 3) if total else 0.0,
+        "repair_conversion": round(c[FIX_SOLVED] / fix_total, 3) if fix_total else 0.0,
+        "overfit_no_retry_rate": round(c[PUBLIC_PASS_HIDDEN_FAIL] / total, 3) if total else 0.0,
+        "unclassified": c[UNCLASSIFIED],
+    }
+
+
+def _key(rec: Dict[str, Any]) -> Optional[Any]:
+    return _get(rec, *_KEY_FIELDS)
+
+
+def delta(baseline: Sequence[Dict[str, Any]], candidate: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Per-problem transitions baseline -> candidate (the fair-baseline comparison). Reproduces the manual
+    'newly repaired / regression' call and adds the full transition list + per-category count deltas."""
+    b = {_key(r): r for r in baseline if _key(r) is not None}
+    c = {_key(r): r for r in candidate if _key(r) is not None}
+    common = sorted(set(b) & set(c), key=str)
+    transitions: List[Tuple[Any, str, str]] = []
+    newly_solved, regressed, newly_repaired = [], [], []
+    for k in common:
+        bc, cc = classify(b[k]), classify(c[k])
+        if bc != cc:
+            transitions.append((k, bc, cc))
+        if cc in _SOLVED and bc not in _SOLVED:
+            newly_solved.append(k)
+        if bc in _SOLVED and cc not in _SOLVED:
+            regressed.append(k)
+        if bc == FIX_FAILED and cc == FIX_SOLVED:
+            newly_repaired.append(k)
+    bcnt, ccnt = _counts(baseline), _counts(candidate)
+    return {
+        "compared": len(common),
+        "only_in_baseline": sorted(set(b) - set(c), key=str),
+        "only_in_candidate": sorted(set(c) - set(b), key=str),
+        "count_delta": {cat: ccnt[cat] - bcnt[cat] for cat in CATEGORIES + [UNCLASSIFIED]},
+        "net_solved_delta": len(newly_solved) - len(regressed),
+        "newly_solved": newly_solved,
+        "regressed": regressed,
+        "newly_repaired": newly_repaired,
+        "transitions": transitions,
+    }
+
+
+def load_jsonl(path: str) -> List[Dict[str, Any]]:
+    out = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            out.append(json.loads(line))
+    return out
+
+
+def render(s: Dict[str, Any], d: Optional[Dict[str, Any]] = None) -> str:
+    lines = ["STAGED RETRY-LOOP SCORE  (total %d)" % s["total"], ""]
+    for cat in CATEGORIES:
+        lines.append("  %-34s %4d" % (cat, s["counts"][cat]))
+    if s["unclassified"]:
+        lines.append("  %-34s %4d  <- did not match the schema (check field names)" % (UNCLASSIFIED, s["unclassified"]))
+    lines += [
+        "",
+        "  solve_rate            %.3f   (first-try + fix-solved)" % s["solve_rate"],
+        "  repair_conversion     %.3f   (fix-solved / fix-attempts) <- does the retry LOOP actually work"
+        % s["repair_conversion"],
+        "  overfit_no_retry_rate %.3f   (public-pass hidden-fail) <- the circular-trust residual"
+        % s["overfit_no_retry_rate"],
+    ]
+    if d is not None:
+        lines += [
+            "",
+            "DELTA vs baseline (%d problems compared):" % d["compared"],
+            "  net solved delta : %+d" % d["net_solved_delta"],
+            "  newly repaired   : %s" % (d["newly_repaired"] or "[]"),
+            "  newly solved     : %s" % (d["newly_solved"] or "[]"),
+            "  regressed        : %s" % (d["regressed"] or "[]"),
+            "  count delta      : %s" % {k: v for k, v in d["count_delta"].items() if v},
+        ]
+        if d["only_in_baseline"] or d["only_in_candidate"]:
+            lines.append(
+                "  WARNING unmatched ids: baseline-only=%d candidate-only=%d (deltas use the intersection)"
+                % (len(d["only_in_baseline"]), len(d["only_in_candidate"]))
+            )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="score a staged retry-loop eval jsonl (+ optional baseline delta)")
+    ap.add_argument("run", help="candidate run jsonl (one staged record per problem)")
+    ap.add_argument("--baseline", default=None, help="baseline run jsonl for the fair per-category delta")
+    a = ap.parse_args(argv)
+    cand = load_jsonl(a.run)
+    s = score(cand)
+    d = delta(load_jsonl(a.baseline), cand) if a.baseline else None
+    print(render(s, d))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_retry_corpus_validate.py
+++ b/tests/test_retry_corpus_validate.py
@@ -1,0 +1,93 @@
+"""Tests for retry_corpus_validate -- the v3 retry-teacher corpus validator + teacher-dependence metric."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.helm import retry_corpus_validate as rcv  # noqa: E402
+
+
+def _teacher_bailout():
+    # bad attempt -> tool fail -> critique+retry -> tool fail -> teacher correction
+    return {
+        "messages": [
+            {"role": "system", "content": "solve it"},
+            {"role": "user", "content": "Write a function ..."},
+            {"role": "assistant", "content": "def f(): return 0  # bad attempt"},
+            {"role": "user", "content": "AssertionError: f() != 1, test failed"},
+            {"role": "assistant", "content": "critique: off by one; retry"},
+            {"role": "user", "content": "AssertionError: still failed"},
+            {"role": "assistant", "content": "Here is the correct solution: def f(): return 1"},
+        ],
+        "meta": {"repaired": True, "final_source": "teacher"},
+    }
+
+
+def _self_repair_success():
+    # bad attempt -> tool fail -> critique+retry -> PASS (no teacher)
+    return {
+        "messages": [
+            {"role": "system", "content": "solve it"},
+            {"role": "user", "content": "Write a function ..."},
+            {"role": "assistant", "content": "def f(): return 0  # bad attempt"},
+            {"role": "user", "content": "AssertionError: failed"},
+            {"role": "assistant", "content": "fixed: def f(): return 1"},
+            {"role": "user", "content": "All tests passed"},
+        ],
+        "meta": {"repaired": True, "final_source": "self"},
+    }
+
+
+def _malformed():
+    return {
+        "messages": [{"role": "user", "content": "problem"}, {"role": "assistant", "content": "answer"}],
+        "meta": {},
+    }
+
+
+def test_classifies_teacher_bailout():
+    a = rcv.analyze_record(_teacher_bailout())
+    assert a["category"] == rcv.TEACHER_BAILOUT and a["assistant_attempts"] == 3 and a["fail_signals"] == 2
+
+
+def test_classifies_self_repair_success():
+    a = rcv.analyze_record(_self_repair_success())
+    assert a["category"] == rcv.SELF_REPAIR_SUCCESS and a["self_repair_pass"] is True and a["teacher"] is False
+
+
+def test_malformed_is_flagged_with_reasons():
+    a = rcv.analyze_record(_malformed())
+    assert a["category"] == rcv.MALFORMED and a["reasons"]
+
+
+def test_meta_drives_teacher_detection_without_content_marker():
+    rec = _self_repair_success()
+    rec["meta"] = {"final_source": "teacher"}  # meta says teacher even though content reads like self-repair
+    assert rcv.analyze_record(rec)["teacher"] is True
+
+
+def test_all_teacher_corpus_raises_the_dependence_warning():
+    # the user's v3 (every record ends in a teacher correction) -> 100% bailout, 0% self-repair
+    v = rcv.validate([_teacher_bailout() for _ in range(10)])
+    assert v["teacher_bailout_ratio"] == 1.0
+    assert v["self_repair_success_ratio"] == 0.0
+    assert v["teacher_dependence_warning"] is True
+
+
+def test_mixed_corpus_does_not_warn_and_counts_self_repair():
+    v = rcv.validate([_teacher_bailout() for _ in range(3)] + [_self_repair_success() for _ in range(7)])
+    assert v["counts"][rcv.SELF_REPAIR_SUCCESS] == 7 and v["counts"][rcv.TEACHER_BAILOUT] == 3
+    assert v["teacher_dependence_warning"] is False
+
+
+def test_load_jsonl_roundtrip(tmp_path):
+    import json
+
+    p = tmp_path / "corpus.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in (_teacher_bailout(), _self_repair_success())), encoding="utf-8")
+    v = rcv.validate(rcv.load_jsonl(str(p)))
+    assert v["total"] == 2 and v["well_formed"] == 2

--- a/tests/test_staged_retry_score.py
+++ b/tests/test_staged_retry_score.py
@@ -1,0 +1,84 @@
+"""Tests for staged_retry_score -- the durable staged retry-loop scorer + baseline delta."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from python.helm import staged_retry_score as srs  # noqa: E402
+
+
+def test_classify_from_explicit_category_field():
+    assert srs.classify({"task_id": 1, "category": "SOLVED_FIRST_TRY"}) == srs.SOLVED_FIRST_TRY
+    assert srs.classify({"status": "solve_failed_fix_attempt_solved"}) == srs.FIX_SOLVED  # normalized
+    assert srs.classify({"outcome": "PUBLIC_PASS_HIDDEN_FAIL_NO_RETRY"}) == srs.PUBLIC_PASS_HIDDEN_FAIL
+
+
+def test_classify_from_raw_signals_flat_and_nested():
+    assert srs.classify({"first_try_hidden_pass": True}) == srs.SOLVED_FIRST_TRY
+    # passed public, failed hidden, never retried -> the circular-trust residual
+    assert srs.classify({"first_try": {"hidden_pass": False, "public_pass": True}}) == srs.PUBLIC_PASS_HIDDEN_FAIL
+    assert (
+        srs.classify(
+            {
+                "first_try": {"hidden_pass": False, "public_pass": False},
+                "retry": {"attempted": True, "hidden_pass": True},
+            }
+        )
+        == srs.FIX_SOLVED
+    )
+    assert srs.classify({"first_try_hidden_pass": False, "retried": True, "retry_hidden_pass": False}) == srs.FIX_FAILED
+
+
+def test_unclassified_when_schema_unrecognized():
+    assert srs.classify({"task_id": 9}) == srs.UNCLASSIFIED  # no category, no signals -> not force-fit
+
+
+def _cat(cat, i):
+    return {"task_id": i, "category": cat}
+
+
+def test_score_matches_the_reported_breakdown():
+    recs = (
+        [_cat(srs.SOLVED_FIRST_TRY, i) for i in range(14)]
+        + [_cat(srs.FIX_SOLVED, 100)]
+        + [_cat(srs.FIX_FAILED, 200 + i) for i in range(28)]
+        + [_cat(srs.PUBLIC_PASS_HIDDEN_FAIL, 300 + i) for i in range(7)]
+    )
+    s = srs.score(recs)
+    assert s["total"] == 50
+    assert s["counts"][srs.SOLVED_FIRST_TRY] == 14 and s["counts"][srs.FIX_FAILED] == 28
+    assert s["solve_rate"] == round(15 / 50, 3)  # 14 first-try + 1 fix-solved
+    assert s["repair_conversion"] == round(1 / 29, 3)  # the retry loop converts 1 of 29 -- the honest gap
+    assert s["overfit_no_retry_rate"] == round(7 / 50, 3)
+
+
+def test_delta_reproduces_newly_repaired_and_regression():
+    ids = [229, 245, 274, 291, 392]
+    baseline = [_cat(srs.FIX_FAILED, i) for i in ids] + [_cat(srs.FIX_SOLVED, 407)]
+    candidate = [_cat(srs.FIX_SOLVED, i) for i in ids] + [_cat(srs.FIX_FAILED, 407)]
+    d = srs.delta(baseline, candidate)
+    assert sorted(d["newly_repaired"]) == ids  # FIX_FAILED -> FIX_SOLVED
+    assert d["regressed"] == [407]
+    assert d["net_solved_delta"] == 4  # the reported +4
+    assert d["count_delta"][srs.FIX_SOLVED] == 4 and d["count_delta"][srs.FIX_FAILED] == -4
+
+
+def test_delta_warns_on_unmatched_ids():
+    d = srs.delta([_cat(srs.FIX_FAILED, 1)], [_cat(srs.FIX_SOLVED, 2)])
+    assert d["compared"] == 0 and d["only_in_baseline"] == [1] and d["only_in_candidate"] == [2]
+
+
+def test_load_jsonl_roundtrip(tmp_path):
+    p = tmp_path / "run.jsonl"
+    rows = [
+        '{"task_id": 1, "category": "SOLVED_FIRST_TRY"}',
+        "",  # blank lines are skipped
+        '{"task_id": 2, "category": "SOLVE_FAILED_FIX_ATTEMPT_FAILED"}',
+    ]
+    p.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    recs = srs.load_jsonl(str(p))
+    assert len(recs) == 2 and srs.score(recs)["total"] == 2


### PR DESCRIPTION
Durable, versioned, **tested** repo-side counterparts of the Colab VTC artifacts (the `/content/*.jsonl` are ephemeral). Built from the Colab lane's findings: direct-answer SFT **hurt** (−9), repair-choice **helped** (+4), and "solved/failed is too flat" — the signal is in the **path**.

## `python/helm/staged_retry_score.py`
Scores a staged retry-loop eval into the four stages and, given a baseline run, reports the per-category **delta** — automating the manual "newly repaired / regression" call.
- stages: `SOLVED_FIRST_TRY` / `SOLVE_FAILED_FIX_ATTEMPT_SOLVED` / `SOLVE_FAILED_FIX_ATTEMPT_FAILED` / `PUBLIC_PASS_HIDDEN_FAIL_NO_RETRY`
- derived metrics: `solve_rate`, **`repair_conversion`** (does the retry *loop* actually work — your data: 1/29 ≈ 0.034), **`overfit_no_retry_rate`** (the circular-trust residual, same failure mode as `los_codegen_bench`)
- `delta(baseline, candidate)` → `newly_repaired` / `regressed` / `transitions` / per-category count deltas
- schema-tolerant: explicit `category` field **or** raw pass/retry signals (flat or nested), documented + aliased

## `python/helm/retry_corpus_validate.py`
Validates a retry-teacher SFT corpus has the `bad → fail → critique → retry → correction` shape and measures **teacher-dependence**: `teacher_bailout_ratio` vs `self_repair_success_ratio`. Fires a WARNING when a corpus is teacher-bailout-heavy. The v3 corpus (every record ends in a teacher correction) trips it at **1.000** — mechanically substantiating "mix in self-repair successes (retry → PASS), not only teacher corrections."

## Verification
- Verified by execution on fixtures matching the documented schema — incl. the reported **14/1/28/7** breakdown and the newly-repaired/regression delta.
- `tests/test_staged_retry_score.py` + `tests/test_retry_corpus_validate.py` — **14 tests pass**
- flake8 clean; determinism scan clean

Field names are documented + aliased so the real `/content` jsonl can be pointed at these directly (`python -m python.helm.staged_retry_score run.jsonl --baseline base.jsonl`), or remapped if your schema differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)