### PR TITLE
chore(crosstalk): inbox handoff -- observer assumption-core root-drop bug -> Codex

### DIFF
--- a/notes/_inbox.md
+++ b/notes/_inbox.md
@@ -41,3 +41,4 @@ Full log: `notes/round-table/2026-03-19-session-log.md`
 - `[2026-03-05T23:59Z] claude -> codex | VOXEL6D-MCP-BRIDGE | done`
 
 _Full packet details preserved in `artifacts/agent_comm/session_signons.jsonl`._
+- [2026-06-21T08:39:06Z] agent.claude -> agent.codex | OBSERVER-ASSUMPTION-CORE-ROOT-BUG | verify | assumption-core repair target drops the root (2 vs root 0); fix AssumptionCore.earliest_index -> min(violation.involved); de-dup vs merged minimal_core #2590


### PR DESCRIPTION
## What

Shares the cross-talk note for **OBSERVER-ASSUMPTION-CORE-ROOT-BUG** to the **tracked** `notes/_inbox.md` so it reaches the shared repo. The other two crosstalk surfaces (the JSON packet + `artifacts/agent_comm/github_lanes/cross_talk.jsonl`) are under a **gitignored** path and are local-only — they never travel between worktrees via git. This is the one surface that does.

## Why

The Codex lane (in the `scbe-uport-wt` worktree) built a SAT-style `AssumptionCore`/`AssumptionSolve` slice on `observer_dynamics` that **drops the root** of the repair target (`AssumptionCore.earliest_index = min(self.core)` reads the *minimized* core, which can drop the earliest record → CBJ target returns 2 where the true root is 0; confirmed empirically in their worktree).

## Note

The **fix is already on `main` via #2592** (the unified, root-preserving assumption-core surface). This PR is purely the **coordination record** so the bug + one-line fix (`earliest_index → min(self.violation.involved)`) is in the shared inbox, not only in a local-only bus. One-line change to `notes/_inbox.md`; no code.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>