### PR TITLE
feat(helm): make the VTC eval tools work on real-world schemas (auto-detect + self-diagnose)

### DIFF
--- a/python/helm/retry_corpus_validate.py
+++ b/python/helm/retry_corpus_validate.py
@@ -44,14 +44,25 @@ TEACHER_MARKERS = ("teacher correction", "reference solution", "correct solution
 _TEACHER_BAILOUT_WARN = 0.8  # above this fraction the corpus is teaching teacher-dependence
 
 
+# role aliases so ShareGPT ({"from":"human"/"gpt","value":...}) and OpenAI ({"role","content"}) both work
+_ROLE_MAP = {"human": "user", "gpt": "assistant", "model": "assistant", "bot": "assistant", "observation": "tool"}
+
+
 def _content(m: Any) -> str:
     if isinstance(m, dict):
-        return str(m.get("content", "")).lower()
+        return str(m.get("content", m.get("value", m.get("text", "")))).lower()
     return str(m).lower()
 
 
 def _role(m: Any) -> str:
-    return str(m.get("role", "")).lower() if isinstance(m, dict) else ""
+    if not isinstance(m, dict):
+        return ""
+    raw = str(m.get("role", m.get("from", m.get("speaker", "")))).lower()
+    return _ROLE_MAP.get(raw, raw)
+
+
+def _messages(rec: Dict[str, Any]) -> List[Any]:
+    return rec.get("messages") or rec.get("conversations") or rec.get("conversation") or []
 
 
 def _hits(text: str, markers: Sequence[str]) -> bool:
@@ -66,7 +77,7 @@ def _meta_says_teacher(meta: Dict[str, Any]) -> bool:
 
 
 def analyze_record(rec: Dict[str, Any]) -> Dict[str, Any]:
-    messages = rec.get("messages") or []
+    messages = _messages(rec)
     meta = rec.get("meta") or {}
     assistant_turns = [m for m in messages if _role(m) == "assistant"]
     # tool-fails: failure markers in any message after the first user (the problem statement)
@@ -141,6 +152,28 @@ def validate(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+def diagnose(records: Sequence[Dict[str, Any]], n: int = 3) -> List[Dict[str, Any]]:
+    """Self-diagnosis: for the first n MALFORMED records, report the real structure (record keys, the message
+    role sequence as detected, and a sample message's keys) so a ShareGPT/other schema is actionable rather
+    than a silent wall of MALFORMED."""
+    out = []
+    for r in records:
+        if analyze_record(r)["category"] != MALFORMED:
+            continue
+        msgs = _messages(r)
+        sample_msg_keys = sorted(msgs[0].keys()) if msgs and isinstance(msgs[0], dict) else []
+        out.append(
+            {
+                "record_keys": sorted(r.keys()),
+                "detected_roles": [_role(m) for m in msgs],
+                "sample_message_keys": sample_msg_keys,
+            }
+        )
+        if len(out) >= n:
+            break
+    return out
+
+
 def load_jsonl(path: str) -> List[Dict[str, Any]]:
     out = []
     for line in Path(path).read_text(encoding="utf-8").splitlines():
@@ -175,7 +208,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     ap = argparse.ArgumentParser(description="validate a retry-teacher SFT corpus + measure teacher-dependence")
     ap.add_argument("corpus", help="the SFT corpus jsonl (messages + meta records)")
     a = ap.parse_args(argv)
-    print(render(validate(load_jsonl(a.corpus))))
+    records = load_jsonl(a.corpus)
+    v = validate(records)
+    print(render(v))
+    if v["counts"][MALFORMED]:  # self-diagnose so an unknown message schema is actionable
+        print(
+            "\nDIAGNOSTIC -- %d malformed record(s). Detected structure(s) below (ShareGPT human/gpt is "
+            "auto-mapped; if roles read blank, the schema is unrecognized):" % v["counts"][MALFORMED]
+        )
+        for s in diagnose(records):
+            print("  record keys: %s" % s["record_keys"])
+            print("    detected roles: %s ; message keys: %s" % (s["detected_roles"], s["sample_message_keys"]))
     return 0
 
 

--- a/python/helm/staged_retry_score.py
+++ b/python/helm/staged_retry_score.py
@@ -68,18 +68,50 @@ def _norm(value: Any) -> str:
     return str(value).strip().upper().replace(" ", "_").replace("-", "_")
 
 
-def classify(rec: Dict[str, Any]) -> str:
-    """Return one of CATEGORIES, or UNCLASSIFIED. Prefers an explicit category field; else derives from the
-    raw first-try / retry signals."""
-    explicit = _get(rec, *_CATEGORY_FIELDS)
+def classify(rec: Dict[str, Any], category_field: Optional[str] = None) -> str:
+    """Return one of CATEGORIES, or UNCLASSIFIED. Prefers an explicit category field (the caller can name it
+    via category_field if it is not one of the defaults); else derives from the raw first-try / retry signals.
+    A value that is one of the four stage names is matched even when nested under an unexpected key."""
+    fields = (category_field,) + _CATEGORY_FIELDS if category_field else _CATEGORY_FIELDS
+    explicit = _get(rec, *fields)
     if explicit is not None:
         norm = _norm(explicit)
         if norm in CATEGORIES:
             return norm
-    first_hidden = _get(rec, "first_try_hidden_pass", "first_hidden_pass", "first_hidden", "first_try.hidden_pass")
-    first_public = _get(rec, "first_try_public_pass", "first_public_pass", "first_public", "first_try.public_pass")
-    retried = _get(rec, "retried", "fix_attempted", "retry_attempted", "retry.attempted")
-    retry_hidden = _get(rec, "retry_hidden_pass", "fix_hidden_pass", "retry.hidden_pass")
+    # broadened raw-signal aliases (covers solved/passed/correct booleans + nested blocks)
+    first_hidden = _get(
+        rec,
+        "first_try_hidden_pass",
+        "first_hidden_pass",
+        "first_hidden",
+        "first_try.hidden_pass",
+        "solved_first_try",
+        "first_solved",
+        "solved",
+        "passed",
+        "correct",
+        "first_try.hidden",
+    )
+    first_public = _get(
+        rec,
+        "first_try_public_pass",
+        "first_public_pass",
+        "first_public",
+        "first_try.public_pass",
+        "public_pass",
+        "first_try.public",
+    )
+    retried = _get(rec, "retried", "fix_attempted", "retry_attempted", "retry.attempted", "did_retry", "fix.attempted")
+    retry_hidden = _get(
+        rec,
+        "retry_hidden_pass",
+        "fix_hidden_pass",
+        "retry.hidden_pass",
+        "fix_solved",
+        "retry_solved",
+        "retry.hidden",
+        "fix.hidden_pass",
+    )
     if first_hidden is None:
         return UNCLASSIFIED
     if first_hidden:
@@ -91,15 +123,15 @@ def classify(rec: Dict[str, Any]) -> str:
     return UNCLASSIFIED  # first-try failed, no public pass, no retry -> not one of the four; do not force-fit
 
 
-def _counts(records: Sequence[Dict[str, Any]]) -> Dict[str, int]:
+def _counts(records: Sequence[Dict[str, Any]], category_field: Optional[str] = None) -> Dict[str, int]:
     out = {c: 0 for c in CATEGORIES + [UNCLASSIFIED]}
     for r in records:
-        out[classify(r)] += 1
+        out[classify(r, category_field)] += 1
     return out
 
 
-def score(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
-    c = _counts(records)
+def score(records: Sequence[Dict[str, Any]], category_field: Optional[str] = None) -> Dict[str, Any]:
+    c = _counts(records, category_field)
     total = sum(c.values())
     solved = c[SOLVED_FIRST_TRY] + c[FIX_SOLVED]
     fix_total = c[FIX_SOLVED] + c[FIX_FAILED]
@@ -113,20 +145,41 @@ def score(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
-def _key(rec: Dict[str, Any]) -> Optional[Any]:
-    return _get(rec, *_KEY_FIELDS)
+def _key(rec: Dict[str, Any], key_field: Optional[str] = None) -> Optional[Any]:
+    fields = (key_field,) + _KEY_FIELDS if key_field else _KEY_FIELDS
+    return _get(rec, *fields)
 
 
-def delta(baseline: Sequence[Dict[str, Any]], candidate: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+def diagnose(records: Sequence[Dict[str, Any]], category_field: Optional[str] = None, n: int = 3) -> List[Dict]:
+    """Self-diagnosis: for the first n records that DON'T classify, report their real structure so the user
+    can see which field to map (top-level keys + one level of nested-dict keys). This is what makes the tool
+    'just work' on an unknown schema -- run it and it tells you exactly what it could not read."""
+    out = []
+    for r in records:
+        if classify(r, category_field) != UNCLASSIFIED:
+            continue
+        nested = {k: sorted(v.keys()) for k, v in r.items() if isinstance(v, dict)}
+        out.append({"top_level_keys": sorted(r.keys()), "nested_keys": nested})
+        if len(out) >= n:
+            break
+    return out
+
+
+def delta(
+    baseline: Sequence[Dict[str, Any]],
+    candidate: Sequence[Dict[str, Any]],
+    category_field: Optional[str] = None,
+    key_field: Optional[str] = None,
+) -> Dict[str, Any]:
     """Per-problem transitions baseline -> candidate (the fair-baseline comparison). Reproduces the manual
     'newly repaired / regression' call and adds the full transition list + per-category count deltas."""
-    b = {_key(r): r for r in baseline if _key(r) is not None}
-    c = {_key(r): r for r in candidate if _key(r) is not None}
+    b = {_key(r, key_field): r for r in baseline if _key(r, key_field) is not None}
+    c = {_key(r, key_field): r for r in candidate if _key(r, key_field) is not None}
     common = sorted(set(b) & set(c), key=str)
     transitions: List[Tuple[Any, str, str]] = []
     newly_solved, regressed, newly_repaired = [], [], []
     for k in common:
-        bc, cc = classify(b[k]), classify(c[k])
+        bc, cc = classify(b[k], category_field), classify(c[k], category_field)
         if bc != cc:
             transitions.append((k, bc, cc))
         if cc in _SOLVED and bc not in _SOLVED:
@@ -135,7 +188,7 @@ def delta(baseline: Sequence[Dict[str, Any]], candidate: Sequence[Dict[str, Any]
             regressed.append(k)
         if bc == FIX_FAILED and cc == FIX_SOLVED:
             newly_repaired.append(k)
-    bcnt, ccnt = _counts(baseline), _counts(candidate)
+    bcnt, ccnt = _counts(baseline, category_field), _counts(candidate, category_field)
     return {
         "compared": len(common),
         "only_in_baseline": sorted(set(b) - set(c), key=str),
@@ -194,11 +247,22 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     ap = argparse.ArgumentParser(description="score a staged retry-loop eval jsonl (+ optional baseline delta)")
     ap.add_argument("run", help="candidate run jsonl (one staged record per problem)")
     ap.add_argument("--baseline", default=None, help="baseline run jsonl for the fair per-category delta")
+    ap.add_argument("--category-field", default=None, help="name of your explicit stage/category field, if non-default")
+    ap.add_argument("--key-field", default=None, help="name of your per-problem id field, if non-default")
     a = ap.parse_args(argv)
     cand = load_jsonl(a.run)
-    s = score(cand)
-    d = delta(load_jsonl(a.baseline), cand) if a.baseline else None
+    s = score(cand, a.category_field)
+    d = delta(load_jsonl(a.baseline), cand, a.category_field, a.key_field) if a.baseline else None
     print(render(s, d))
+    if s["unclassified"]:  # self-diagnose so an unknown schema is actionable, not a silent zero
+        print(
+            "\nDIAGNOSTIC -- %d record(s) did not classify. Sample structure(s) below; map a field with"
+            " --category-field, or rename to a documented alias:" % s["unclassified"]
+        )
+        for sample in diagnose(cand, a.category_field):
+            print("  top-level keys: %s" % sample["top_level_keys"])
+            for blk, keys in sample["nested_keys"].items():
+                print("    %s.{%s}" % (blk, ", ".join(keys)))
     return 0
 
 

--- a/tests/test_retry_corpus_validate.py
+++ b/tests/test_retry_corpus_validate.py
@@ -84,6 +84,29 @@ def test_mixed_corpus_does_not_warn_and_counts_self_repair():
     assert v["teacher_dependence_warning"] is False
 
 
+def test_sharegpt_format_is_understood():
+    # ShareGPT shape (conversations + from/value) must classify, not fall to MALFORMED
+    rec = {
+        "conversations": [
+            {"from": "human", "value": "Write a function ..."},
+            {"from": "gpt", "value": "def f(): return 0"},
+            {"from": "human", "value": "AssertionError: failed"},
+            {"from": "gpt", "value": "retry: def f(): return 1"},
+            {"from": "human", "value": "All tests passed"},
+        ]
+    }
+    a = rcv.analyze_record(rec)
+    assert a["category"] == rcv.SELF_REPAIR_SUCCESS and a["assistant_attempts"] == 2
+
+
+def test_diagnose_reports_unknown_message_schema():
+    weird = [{"turns": [{"speaker": "x", "text": "hi"}], "meta": {}}]  # unrecognized -> MALFORMED + diagnosed
+    v = rcv.validate(weird)
+    assert v["counts"][rcv.MALFORMED] == 1
+    diag = rcv.diagnose(weird)
+    assert diag and "turns" in diag[0]["record_keys"]
+
+
 def test_load_jsonl_roundtrip(tmp_path):
     import json
 

--- a/tests/test_staged_retry_score.py
+++ b/tests/test_staged_retry_score.py
@@ -37,6 +37,19 @@ def test_unclassified_when_schema_unrecognized():
     assert srs.classify({"task_id": 9}) == srs.UNCLASSIFIED  # no category, no signals -> not force-fit
 
 
+def test_broadened_aliases_and_custom_category_field():
+    assert srs.classify({"solved": True}) == srs.SOLVED_FIRST_TRY  # bare 'solved' boolean
+    # a non-default category field name the caller points at
+    assert srs.classify({"my_stage": "SOLVED_FIRST_TRY"}, category_field="my_stage") == srs.SOLVED_FIRST_TRY
+
+
+def test_diagnose_reports_unknown_schema():
+    weird = [{"problem": 1, "result_block": {"final": "ok"}}]  # nothing classify can read
+    diag = srs.diagnose(weird)
+    assert diag and "problem" in diag[0]["top_level_keys"]
+    assert diag[0]["nested_keys"]["result_block"] == ["final"]
+
+
 def _cat(cat, i):
     return {"task_id": i, "category": cat}
 


### PR DESCRIPTION
Follow-up to #2593 so the two VTC eval tools run on the **actual** `/content` jsonl without manual field remapping — "make it work" on real-world schemas.

## `staged_retry_score.py`
- `classify()` accepts a caller-named `--category-field` and broadens raw-signal aliases (`solved`/`passed`/`correct` booleans + more nested shapes)
- `delta()` threads category/key-field overrides through the fair-baseline comparison
- **self-diagnosis**: `diagnose()` + `main()` print a DIAGNOSTIC (the record's real top-level + nested keys) for any record that doesn't classify — an unknown schema is actionable, not a silent zero

## `retry_corpus_validate.py`
- role/content detection is now **format-tolerant**: ShareGPT (`{"from":"human"/"gpt","value":...}` under `conversations`) works, not just OpenAI `{"role","content"}` — this was the most likely real-world break (silent wall of MALFORMED)
- **self-diagnosis**: prints the detected message roles + keys for malformed records, so a blank-role (unrecognized) schema explains itself

## Verification
- **22 tests pass** (added: broadened aliases + custom category field; ShareGPT parsing; both diagnostics)
- Demonstrated: a ShareGPT-format corpus now classifies + fires the teacher-dependence warning; an unknown schema prints the diagnostic with its real keys
- flake8 clean; determinism scan clean

Now `python -m python.helm.retry_corpus_validate /content/train.retry_teacher_v3.sft.jsonl` and `python -m python.helm.staged_retry_score /content/vtc_staged_retry_loop.jsonl --baseline <prev>` run on the real files directly; if a field name still differs, the tool prints exactly what to map (or pass `--category-field`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)