### PR TITLE
feat(helm): stronger-face gate in the repair harness (wedge #1+#2+#3 composition)

### DIFF
--- a/python/helm/self_repair_harness.py
+++ b/python/helm/self_repair_harness.py
@@ -9,13 +9,19 @@ becoming metric falls out intrinsically:
 
 That is a FAIR baseline by construction: the lift is exactly the gap between first-try solving and
 after-repair solving on identical attempts -- no separate control run, no menu-elimination ([[tool-use-is-
-the-skill]]). The PUBLIC_PASS_HIDDEN_FAIL stage is the overfit/circular-trust residual (a stronger local
-face -- safety_face -- would convert some of those into retries).
+the-skill]]).
 
-A deterministic reference generator/repair prove the instrument end-to-end ($0, no model). Swap in an ollama
-generator + an error-reprompt repair for real numbers ([[verified-trajectory-training]] / train-on-becoming).
-The reference repair is IDEALIZED (it fixes every recoverable miss) -- this measures the HARNESS, not a
-capability; a real model's repair will not always succeed, and the harness will show that honestly.
+THE STRONGER-FACE GATE (the wedge #1+#2+#3 composition). The PUBLIC_PASS_HIDDEN_FAIL stage is the
+overfit/circular-trust residual: code that passes the visible tests, fails the hidden oracle, and is never
+retried because the agent thinks it is done. A `gate` is a STRONGER LOCAL FACE (extra self-checks / property
+or shadow tests -- the safety_face idea) that the agent runs BEFORE trusting a public pass; when it catches
+an overfit, the agent enters the retry loop, converting residual -> FIX_SOLVED/FIX_FAILED. compare_gate()
+measures the residual reduction the stronger face buys. HONEST: the gate is LOCAL (shadow tests), not the
+hidden oracle, so it only catches overfit its checks actually exercise -- a partial, measured reduction.
+
+A deterministic reference generator/repair/gate prove the instrument end-to-end ($0, no model). Swap in an
+ollama generator + an error-reprompt repair for real numbers ([[verified-trajectory-training]]). The
+reference repair is IDEALIZED (fixes every recoverable miss) -- this measures the HARNESS, not capability.
 
     python -m python.helm.self_repair_harness
 """
@@ -33,6 +39,7 @@ from .self_repair_corpus import runs_ok
 
 Generator = Callable[[Dict[str, Any], int], str]  # (problem, attempt_index) -> code
 Repair = Callable[[Dict[str, Any], str, str], str]  # (problem, failing_code, fail_msg) -> code
+Gate = Callable[[Dict[str, Any], str], bool]  # (problem, code) -> True if the stronger local face accepts it
 
 
 def _all_pass(code: str, asserts: Sequence[str]) -> bool:
@@ -47,8 +54,11 @@ def _first_fail(code: str, asserts: Sequence[str]) -> str:
     return ""
 
 
-def run_problem(problem: Dict[str, Any], generator: Generator, repair: Optional[Repair]) -> Dict[str, Any]:
-    """Run one problem through the staged retry loop; return a staged record (staged_retry_score schema)."""
+def run_problem(
+    problem: Dict[str, Any], generator: Generator, repair: Optional[Repair], gate: Optional[Gate] = None
+) -> Dict[str, Any]:
+    """Run one problem through the staged retry loop; return a staged record (staged_retry_score schema). A
+    `gate` (stronger local face) can catch an overfit that passed the public tests, forcing a retry."""
     public = problem.get("public", [])
     hidden = problem.get("hidden", [])
     code = generator(problem, 0)
@@ -64,22 +74,26 @@ def run_problem(problem: Dict[str, Any], generator: Generator, repair: Optional[
     if first_hidden:
         rec["category"] = srs.SOLVED_FIRST_TRY
         return rec
-    if first_public:  # passed the visible tests -> the agent thinks it is done, never retries
+    gate_ok = gate is None or gate(problem, code)
+    if first_public and gate_ok:  # passes public AND the stronger face is happy -> the agent ships it (no retry)
         rec["category"] = srs.PUBLIC_PASS_HIDDEN_FAIL
         return rec
-    # public failed -> the agent knows it failed -> repair (if a repair step is provided)
+    # the agent KNOWS it failed: public failed, or the stronger face caught the overfit -> retry
+    rec["caught_by_gate"] = bool(first_public and not gate_ok)
     if repair is None:
         rec["category"] = srs.FIX_FAILED  # baseline: no repair available
         return rec
-    fixed = repair(problem, code, _first_fail(code, public))
+    fixed = repair(problem, code, _first_fail(code, public) or "stronger-face check failed")
     retry_hidden = _all_pass(fixed, hidden)
     rec.update(retried=True, retry_hidden_pass=retry_hidden)
     rec["category"] = srs.FIX_SOLVED if retry_hidden else srs.FIX_FAILED
     return rec
 
 
-def run_staged(problems: Sequence[Dict[str, Any]], generator: Generator, repair: Optional[Repair]) -> List[Dict]:
-    return [run_problem(p, generator, repair) for p in problems]
+def run_staged(
+    problems: Sequence[Dict[str, Any]], generator: Generator, repair: Optional[Repair], gate: Optional[Gate] = None
+) -> List[Dict]:
+    return [run_problem(p, generator, repair, gate) for p in problems]
 
 
 def recovery_lift(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
@@ -97,83 +111,110 @@ def recovery_lift(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+def compare_gate(
+    problems: Sequence[Dict[str, Any]], generator: Generator, repair: Optional[Repair], gate: Gate
+) -> Dict[str, Any]:
+    """Run the same generator/repair WITHOUT then WITH the stronger-face gate; report what the gate buys."""
+    no_gate = recovery_lift(run_staged(problems, generator, repair, gate=None))
+    with_gate = recovery_lift(run_staged(problems, generator, repair, gate=gate))
+    return {
+        "no_gate": no_gate,
+        "with_gate": with_gate,
+        "residual_reduction": round(no_gate["overfit_no_retry_rate"] - with_gate["overfit_no_retry_rate"], 3),
+        "lift_gain": round(with_gate["recovery_lift"] - no_gate["recovery_lift"], 3),
+    }
+
+
 # ---- a deterministic REFERENCE instrument (proves the harness; $0, no model) ------------------------------
 def _ref_problems() -> List[Dict[str, Any]]:
-    p = [
+    # each problem carries `shadow`: extra LOCAL self-checks (distinct inputs from public, NOT the hidden
+    # oracle) -- the stronger-face gate runs these; a memorized-overfit answer fails them.
+    return [
         {
             "task_id": "add",
             "good": "def f(a,b):\n    return a+b",
             "public": ["assert f(2,3)==5"],
+            "shadow": ["assert f(0,0)==0"],
             "hidden": ["assert f(-1,1)==0", "assert f(10,20)==30"],
         },
         {
             "task_id": "maxof",
             "good": "def f(a,b):\n    return a if a>b else b",
             "public": ["assert f(1,2)==2"],
+            "shadow": ["assert f(9,1)==9"],
             "hidden": ["assert f(5,3)==5", "assert f(-1,-2)==-1"],
         },
         {
             "task_id": "evens",
             "good": "def f(xs):\n    return [x for x in xs if x%2==0]",
             "public": ["assert f([1,2,3,4])==[2,4]"],
+            "shadow": ["assert f([6])==[6]"],
             "hidden": ["assert f([0,1])==[0]", "assert f([])==[]"],
         },
         {
             "task_id": "rev",
             "good": "def f(s):\n    return s[::-1]",
             "public": ["assert f('ab')=='ba'"],
+            "shadow": ["assert f('abc')=='cba'"],
             "hidden": ["assert f('')==''", "assert f('xyz')=='zyx'"],
         },
         {
             "task_id": "sub",
             "good": "def f(a,b):\n    return a-b",
             "public": ["assert f(5,2)==3"],
+            "shadow": ["assert f(7,7)==0"],
             "hidden": ["assert f(0,4)==-4", "assert f(9,9)==0"],
         },
         {
             "task_id": "minof",
             "good": "def f(a,b):\n    return a if a<b else b",
             "public": ["assert f(1,2)==1"],
+            "shadow": ["assert f(8,2)==2"],
             "hidden": ["assert f(5,3)==3", "assert f(-1,-2)==-2"],
         },
         {
             "task_id": "count_pos",
             "good": "def f(xs):\n    return sum(1 for x in xs if x>0)",
             "public": ["assert f([1,-2,3])==2"],
+            "shadow": ["assert f([4,4])==2"],
             "hidden": ["assert f([0,0])==0", "assert f([-5,5])==1"],
         },
         {
             "task_id": "is_even",
             "good": "def f(n):\n    return n%2==0",
             "public": ["assert f(4)==True"],
+            "shadow": ["assert f(7)==False"],
             "hidden": ["assert f(3)==False", "assert f(0)==True"],
         },
         {
             "task_id": "double",
             "good": "def f(x):\n    return x*2",
             "public": ["assert f(3)==6"],
+            "shadow": ["assert f(5)==10"],
             "hidden": ["assert f(0)==0", "assert f(-2)==-4"],
         },
         {
             "task_id": "last",
             "good": "def f(xs):\n    return xs[-1] if xs else 0",
             "public": ["assert f([1,2,3])==3"],
+            "shadow": ["assert f([9,8])==8"],
             "hidden": ["assert f([5])==5", "assert f([])==0"],
         },
         {
             "task_id": "absval",
             "good": "def f(x):\n    return x if x>=0 else -x",
             "public": ["assert f(-4)==4"],
+            "shadow": ["assert f(-9)==9"],
             "hidden": ["assert f(4)==4", "assert f(0)==0"],
         },
         {
             "task_id": "concat",
             "good": "def f(a,b):\n    return a+b",
             "public": ["assert f('a','b')=='ab'"],
+            "shadow": ["assert f('p','q')=='pq'"],
             "hidden": ["assert f('','x')=='x'", "assert f('xy','z')=='xyz'"],
         },
     ]
-    return p
 
 
 def _ref_generator(weights=(0.5, 0.3, 0.2)) -> Generator:
@@ -188,9 +229,8 @@ def _ref_generator(weights=(0.5, 0.3, 0.2)) -> Generator:
             return good
         if r < weights[0] + weights[1]:
             return "def f(*a):\n    return None"  # wrong, fails the public test (the agent will know)
-        # wrong-overfit: hard-code the public example's answer, wrong in general
         pub = problem["public"][0]
-        return "def f(*a):\n    return %s" % pub.split("==", 1)[1].strip()
+        return "def f(*a):\n    return %s" % pub.split("==", 1)[1].strip()  # memorized public answer (overfit)
 
     return gen
 
@@ -202,6 +242,15 @@ def _ref_repair() -> Repair:
         return problem["good"]
 
     return repair
+
+
+def _ref_shadow_gate() -> Gate:
+    """Stronger local face: run the problem's shadow self-checks. A memorized-overfit answer fails them."""
+
+    def gate(problem: Dict[str, Any], code: str) -> bool:
+        return _all_pass(code, problem.get("shadow", []))
+
+    return gate
 
 
 def write_jsonl(path: str, records: Sequence[Dict]) -> None:
@@ -220,9 +269,23 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         "\n  recovery_lift: first-try %.3f -> with-repair %.3f  (= %+.3f, the becoming metric)"
         % (lift["first_try_solve_rate"], lift["with_repair_solve_rate"], lift["recovery_lift"])
     )
-    print("  NOTE: reference repair is idealized (fixes every recoverable miss) -> this validates the INSTRUMENT;")
-    print("        swap in a real model+repair for a capability number. The PUBLIC_PASS_HIDDEN_FAIL bucket is")
-    print("        the overfit residual a stronger local face (safety_face) would convert to retries.")
+
+    cmp = compare_gate(problems, _ref_generator(), _ref_repair(), _ref_shadow_gate())
+    print("\n  STRONGER-FACE GATE (the wedge composition): a local shadow-test gate before trusting a public pass")
+    print(
+        "    overfit residual : %.3f -> %.3f  (reduced by %.3f)"
+        % (
+            cmp["no_gate"]["overfit_no_retry_rate"],
+            cmp["with_gate"]["overfit_no_retry_rate"],
+            cmp["residual_reduction"],
+        )
+    )
+    print(
+        "    recovery_lift    : %.3f -> %.3f  (gained %+.3f)"
+        % (cmp["no_gate"]["recovery_lift"], cmp["with_gate"]["recovery_lift"], cmp["lift_gain"])
+    )
+    print("  HONEST: the gate is LOCAL (shadow tests), not the hidden oracle -- it converts only the overfit its")
+    print("          checks exercise; the reference repair is idealized. This validates the instrument + thesis.")
     if a.out:
         write_jsonl(a.out, records)
         print(

--- a/tests/test_self_repair_harness.py
+++ b/tests/test_self_repair_harness.py
@@ -76,3 +76,24 @@ def test_reproducible():
     a = h.run_staged(h._ref_problems(), h._ref_generator(), h._ref_repair())
     b = h.run_staged(h._ref_problems(), h._ref_generator(), h._ref_repair())
     assert [r["category"] for r in a] == [r["category"] for r in b]
+
+
+# ---- the stronger-face gate (wedge #1+#2+#3 composition) --------------------------------------------------
+def test_gate_catches_overfit_and_converts_it_to_a_retry():
+    # overfit: passes PUBLIC, fails the shadow self-check -> the gate forces a retry that the repair fixes
+    gen = lambda p, i: "def f(*a):\n    return %s" % p["public"][0].split("==", 1)[1].strip()  # noqa: E731
+    without = h.run_problem(PROB | {"shadow": ["assert f(9,9)==18"]}, gen, h._ref_repair(), gate=None)
+    withg = h.run_problem(PROB | {"shadow": ["assert f(9,9)==18"]}, gen, h._ref_repair(), gate=h._ref_shadow_gate())
+    assert without["category"] == srs.PUBLIC_PASS_HIDDEN_FAIL  # no gate -> shipped wrong, no retry
+    assert withg["category"] == srs.FIX_SOLVED and withg.get("caught_by_gate") is True  # gate -> caught -> fixed
+
+
+def test_compare_gate_reduces_residual_and_gains_lift():
+    cmp = h.compare_gate(h._ref_problems(), h._ref_generator(), h._ref_repair(), h._ref_shadow_gate())
+    assert cmp["residual_reduction"] > 0  # the stronger face shrinks the overfit no-retry bucket
+    assert cmp["lift_gain"] > 0  # ...and converts it into recovered solves
+
+
+def test_gate_leaves_first_try_solves_untouched():
+    rec = h.run_problem(PROB, lambda p, i: p["good"], h._ref_repair(), gate=h._ref_shadow_gate())
+    assert rec["category"] == srs.SOLVED_FIRST_TRY  # the gate only acts on public-pass/hidden-fail


### PR DESCRIPTION
Adds a `gate` (stronger **local** face: shadow/property self-checks — the safety_face idea) the agent runs **before** trusting a PUBLIC pass. When it catches an overfit (passes public, fails the hidden oracle), the agent enters the retry loop instead of silently shipping — converting the `PUBLIC_PASS_HIDDEN_FAIL` residual into recovered solves. `compare_gate()` measures what the stronger face buys.

## Reference run (12 problems, $0, no model)
```
overfit residual : 0.500 -> 0.083   (reduced 0.417)
recovery_lift    : 0.167 -> 0.583   (gained +0.416)
```
This makes the **wedge #1+#2+#3 thesis concrete and measured**: a stronger local face closes most of the circular-trust residual the repair loop alone is powerless on. Honest: the residual does **not** reach 0 (0.083 remains) — a *local* gate catches only the overfit its checks exercise, never the hidden oracle; the reference gate/repair are idealized to validate the instrument, not claim capability.

## Verification
- **12 tests pass** (gate catches overfit → `FIX_SOLVED` with `caught_by_gate`; `compare_gate` shows `residual_reduction>0` and `lift_gain>0`; the gate leaves first-try solves untouched)
- flake8 clean; determinism scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)