### PR TITLE
fix(squad): coverage-gate edge cases + honest SquadEnergy semantics (self-audit)

### DIFF
--- a/python/scbe/coding_squad.py
+++ b/python/scbe/coding_squad.py
@@ -44,7 +44,6 @@ from .squad_puzzle import (
     Piece,
     Region,
     coverable_cells,
-    holes,
 )
 
 
@@ -131,11 +130,15 @@ class SquadResult:
 @dataclass
 class SquadEnergy:
     """The thermodynamic cost of a squad solve, by Landauer's principle (the bijective-time/reversible arc
-    meeting the squad). Each CBJ jump-back is an irreversible RE-DECISION that overwrites an operator's
-    assignment, erasing decision_bits(domain) bits; a conflict-free (forward-only) solve pays 0. Metered the
-    same way as observer_dynamics.resolve_by_jumpback_metered -- the two CBJ solvers share one ledger."""
+    meeting the squad). Each CBJ jump-back is an irreversible RE-DECISION that erases decision_bits(domain)
+    bits; a conflict-free (forward-only) solve pays 0. It REUSES observer_dynamics' EnergyLedger / decision_bits
+    / units, but it meters the RAW coding_board.solve jump list -- which (unlike resolve_by_jumpback_metered,
+    whose hook has an oscillation guard + a no-op skip) re-appends a backjump on every dead end and oscillation
+    revisit. So `overwrites` is a backjump-EVENT count and an UPPER BOUND on the distinct re-decisions, NOT the
+    observer's guarded conflict depth; each event is still a genuine erasure, so the joules are honest energy
+    for the dissipating solver (it really did pay for the wasted re-decisions)."""
 
-    overwrites: int  # CBJ jump-backs the solve committed (irreversible re-decisions; -1 dead-ends excluded)
+    overwrites: int  # raw valid backjump events (-1 dead-ends excluded); upper bound on DISTINCT re-decisions
     bits_erased: int  # sum of decision_bits(operator domain) over those re-decisions
     irreversible_joules: float  # the Landauer FLOOR the dissipating (overwrite) solve pays (a lower bound)
     reversible_joules: float  # 0.0 -- logging the jumps (an undo-tape) erases nothing during the solve (Bennett)
@@ -348,12 +351,21 @@ def coverage_gate(roles: List[Role], region) -> CoverageGate:
     """Can the differentiated role-squad COVER this board with its shapes? Reports the holes (cells no role-
     piece can reach) -- the rigorous form of cover_regions and a governance pre-check: a board with holes for
     the current roster has a structural blind spot (recompose the squad, or reject the board). Necessary, not
-    sufficient: no holes does not guarantee an exact tiling (parity can still block it)."""
+    sufficient: no holes does not guarantee an exact tiling (parity can still block it).
+
+    A layout of fewer than 2 cells (an empty board, or a single 1-cell operator) is BELOW the gate's
+    resolution -- a single unit of work has no SHAPE for a polyomino reach-check to assess, and a 1-op board
+    is trivially solvable. The gate must not reject work it cannot meaningfully assess, so such layouts return
+    covered=True (a degenerate-size fact, not a governance blind spot), which also avoids running the reach
+    math on an empty region. A >=2-cell layout IS assessed normally -- so a clone roster that genuinely cannot
+    cover a 3-cell board still reports the gap."""
+    region = frozenset(region)
+    if len(region) < 2:
+        return CoverageGate(covered=True, holes=(), reachable=len(region), total=len(region))
     pieces = squad_pieces(roles)
-    h = holes(region, pieces)
-    return CoverageGate(
-        covered=(len(h) == 0), holes=h, reachable=len(coverable_cells(region, pieces)), total=len(region)
-    )
+    reach = coverable_cells(region, pieces)
+    h = tuple(sorted(set(region) - reach))
+    return CoverageGate(covered=(len(h) == 0), holes=h, reachable=len(reach), total=len(region))
 
 
 def demo() -> Dict[str, object]:

--- a/tests/test_coding_squad.py
+++ b/tests/test_coding_squad.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from python.scbe.coding_board import Board, Operator, region_must_agree
+from python.scbe.coding_board import Board, Operator, all_distinct_in_region, region_must_agree
 from python.scbe.coding_board_gates import CHECK, TRANSFORM, gate_names
 from python.scbe.coding_squad import (
     ROLE_PIECES,
@@ -300,3 +300,30 @@ def test_rejected_board_meters_no_energy_no_solve_ran():
 def test_triangulation_demo_all_true():
     d = demo()
     assert all(v for k, v in d.items() if not k.startswith("_"))
+
+
+# ---- edge cases the audit caught: empty board, sub-piece layout, raw energy over-count ------------
+def test_empty_board_does_not_crash_and_is_trivially_covered():
+    # board_region([]) is empty; the gate must short-circuit (not run reach math on an empty region)
+    res = solve_with_squad(Board([], []))
+    assert res.gate is not None and res.gate.covered and res.gate.holes == ()
+    assert not res.rejected  # an empty board is not a coverage gap
+
+
+def test_single_operator_board_is_not_falsely_rejected_by_require_coverage():
+    # a 1-cell layout is below the gate's resolution (no >=2-cell role-piece fits) but is trivially solvable;
+    # the gate must NOT reject it. (Before the fix this rejected with holes=((0,0),).)
+    board = Board([Operator("o0", gate_names(TRANSFORM))], [])
+    res = solve_with_squad(board, require_coverage=True)
+    assert res.gate.covered and not res.rejected  # not a structural blind spot
+    assert res.solved  # ...and it solves, as it does without require_coverage
+
+
+def test_squad_energy_overwrites_is_a_raw_backjump_event_count_not_conflict_depth():
+    # honest semantics: solve_energy bills the RAW coding_board jump list (oscillation revisits + step-backs),
+    # so overwrites is an UPPER BOUND on distinct re-decisions, not the observer's guarded conflict depth.
+    board = Board([Operator("o%d" % i, ("X", "Y", "Z"), region="r") for i in range(4)], [all_distinct_in_region])
+    res = solve_with_squad(board)
+    valid = [j for j in res.jumps if 0 <= j < len(board.operators)]
+    assert res.squad_energy.overwrites == len(valid)  # counts every valid backjump event
+    assert res.squad_energy.overwrites > len(set(valid))  # ...which exceeds the distinct operators re-decided


### PR DESCRIPTION
## What

An adversarial self-audit of this session's work (6 skeptics reading + running the code) found **two real bugs and one overclaim** in `coding_squad`. This fixes all three.

## Bugs

1. **Empty-board crash** — `solve_with_squad(Board([], []))` raised `ValueError: min() iterable argument is empty`: `board_region([])` is empty and the empty region reached `min()` in `squad_puzzle.placements`. No test covered it.
2. **1-operator false rejection** — a 1-op board under `require_coverage=True` was **rejected** (`rejected=True, solved=False`) because no ≥2-cell role-piece covers a 1-cell layout — even though the board is trivially solvable (it solves fine without the flag).

**Fix:** `coverage_gate` short-circuits a layout of **< 2 cells** as `covered=True` — a single unit of work has no *shape* for a polyomino reach-check to assess, so the gate must not reject it (and this avoids running the reach math on an empty region). A ≥2-cell board is assessed normally, so a clone roster that genuinely can't cover a 3-cell board **still reports the gap** (the existing clone-gap tests still pass).

## Overclaim

`SquadEnergy` claimed it was "metered the same way as `observer_dynamics.resolve_by_jumpback_metered`" with `overwrites == conflict depth`. But `solve_energy` bills the **raw** `coding_board.solve` jump list — which (unlike the observer's hook, with its oscillation guard + no-op skip) re-appends a backjump on every dead end and oscillation revisit. So `overwrites` is a **backjump-event count and an upper bound** on distinct re-decisions, not the guarded conflict depth. Reworded; the joules stay honest (each event is a genuine erasure the dissipating solver paid for). Confirmed: an all-distinct unsat board bills **15 events for 3 distinct operators**.

## Tests

28/28 in `tests/test_coding_squad.py` (3 new: empty board, 1-op under require_coverage, raw-event over-count). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>