### PR TITLE
fix(bench): replace the strawman 'differentiation lift' with honest instruments (self-audit)

### DIFF
--- a/python/helm/squad_bench.py
+++ b/python/helm/squad_bench.py
@@ -1,20 +1,23 @@
-"""squad_bench: an offline, deterministic benchmark of the squad's load-bearing claims at SCALE.
+"""squad_bench: an offline, deterministic benchmark of the squad's claims -- HONEST instruments only.
 
-The squad arc (coding_squad + squad_puzzle) ships demos; this turns the central claim -- "differentiation is
-load-bearing" -- into a measured NUMBER over a distribution, with every result execution-verified. Mirrors
-python/helm/public_bench.py (a dataset -> run -> verify -> score -> render pipeline), but for the geometric
-squad instead of MBPP code.
+A prior version headlined a "+41.6% differentiation LIFT" from a coverage-UNION metric. A self-audit showed
+that number is an artifact of pitting the differentiated set against the WORST-reaching single shape (the 2x2
+SQUARE): coverage is a UNION over pieces, so any all-reaching piece saturates it -- a DOMINO clone gives a
+0.0 lift. Coverage-union is the WRONG instrument for differentiation. This version reports only honest ones:
 
-Two parts, both seeded (reproducible -- the whole point) and offline ($0; no Kaggle account / network):
-  1. COVERAGE benchmark -- over N random connected regions, how much of each can a DIFFERENTIATED piece-squad
-     reach vs a CLONE squad (one shape)? The coverage gate's metric, at scale. Headline = the differentiation
-     LIFT (diff coverage - clone coverage). Every "fully covered" verdict is independently re-checked.
-  2. ENERGY benchmark -- over M random CSP boards, the Landauer cost of the squad solve: what fraction are
-     conflict-free (forward-only, 0 J) vs pay for CBJ re-decisions, and the average bits erased.
+  1. REACH -- the single-shape reach deficit: a fact about ONE shape's footprint on connected regions, with
+     the strawman exposed in-line (the 2x2 SQUARE leaves a gap; a DOMINO leaves none). This is NOT a
+     differentiation result; it is one shape's reachability.
+  2. TILING -- the RIGHT instrument: at MATCHED total area, can a CLONE piece-set tile what a DIFFERENTIATED
+     set tiles? On a parity-obstructed (mutilated) region a domino-only roster CANNOT tile, while
+     domino + 2 monominoes (same area, shape-diverse) CAN. Every tiling is re-verified. This is where
+     shape-diversity is genuinely load-bearing (the same claim squad_puzzle's matched-area tests prove).
+  3. ENERGY -- honest disclosure: with forward-checking, a SOLVED board of these CSP classes is forward-only
+     BY CONSTRUCTION (0 J), a tautology not a measurement (verified across region_must_agree AND
+     all_distinct_in_region). The dissipating cost appears only on UNSOLVABLE boards (the solver flailing);
+     it is reported there, labeled as such.
 
-HONEST: this benchmarks the GEOMETRIC differentiation + coverage + energy machinery on a synthetic
-distribution; it is NOT a code-generation capability benchmark (that is public_bench/MBPP). A real online
-Kaggle submission would need an account + network, which this does not fake -- it is the offline fixture.
+Offline, seeded ($0; no Kaggle account/network). NOT a code-generation benchmark; NOT a real online Kaggle run.
 """
 
 from __future__ import annotations
@@ -22,35 +25,20 @@ from __future__ import annotations
 import argparse
 import random
 import sys
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Dict, List, Sequence
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from python.scbe.coding_board import Board, Operator, region_must_agree  # noqa: E402
-from python.scbe.coding_squad import solve_energy, solve_with_squad  # noqa: E402
-from python.scbe.squad_puzzle import (  # noqa: E402
-    DOMINO,
-    I_TROMINO,
-    L_TROMINO,
-    SQUARE,
-    T_TETRO,
-    Piece,
-    coverable_cells,
-    holes,
-)
+from python.scbe.coding_board import Board, Operator, all_distinct_in_region  # noqa: E402
+from python.scbe.coding_squad import solve_with_squad  # noqa: E402
+from python.scbe.squad_puzzle import DOMINO, MONO, SQUARE, assemble, coverable_cells, rect  # noqa: E402
 
-Cell = Tuple[int, int]
-
-# the two "competitors": a DIFFERENTIATED piece-squad (varied shapes; no monomino, so coverage is non-trivial)
-# vs a CLONE squad (just the 2x2 frame, repeated). Coverage uses only the shapes, so the multiplicity is moot.
-DIFFERENTIATED: List[Piece] = [DOMINO, L_TROMINO, I_TROMINO, T_TETRO, SQUARE]
-CLONE: List[Piece] = [SQUARE]
+Cell = Any
 
 
 def random_region(rng: random.Random, size: int) -> frozenset:
-    """A connected polyomino of `size` cells grown by a random walk from the origin -- a 'puzzle' to cover."""
+    """A connected polyomino of `size` cells grown by a random walk from the origin."""
     cells = {(0, 0)}
     frontier = [(0, 0)]
     while len(cells) < size and frontier:
@@ -69,124 +57,142 @@ def random_region(rng: random.Random, size: int) -> frozenset:
     return frozenset(cells)
 
 
-def coverable_fraction(region: frozenset, pieces: Sequence[Piece]) -> float:
-    return len(coverable_cells(region, pieces)) / len(region) if region else 1.0
+def _coverable_fraction(region: frozenset, piece) -> float:
+    return len(coverable_cells(region, [piece])) / len(region) if region else 1.0
 
 
-@dataclass
-class CoverageRow:
-    size: int
-    diff_fraction: float
-    clone_fraction: float
-    diff_full: bool  # differentiated leaves no holes
-    clone_full: bool  # clone leaves no holes
-
-
-def run_coverage(n: int, seed: int, min_size: int = 4, max_size: int = 14) -> Dict[str, Any]:
+def run_reach(n: int, seed: int, min_size: int = 4, max_size: int = 14) -> Dict[str, Any]:
+    """How much of a connected region a SINGLE shape's footprint reaches. The 2x2 SQUARE starves on thin/
+    branchy regions; a DOMINO reaches (almost) everything. The DOMINO==SQUARE gap is the strawman exposed:
+    coverage-union does NOT measure differentiation -- one all-reaching shape saturates it."""
     rng = random.Random(seed)
-    rows: List[CoverageRow] = []
+    sq_total = 0.0
+    dom_total = 0.0
     for _ in range(n):
         region = random_region(rng, rng.randint(min_size, max_size))
-        df = coverable_fraction(region, DIFFERENTIATED)
-        cf = coverable_fraction(region, CLONE)
-        # VERIFY a "fully covered" verdict independently: holes()==() iff fraction==1.0
-        d_full = holes(region, DIFFERENTIATED) == ()
-        c_full = holes(region, CLONE) == ()
-        assert d_full == (df == 1.0) and c_full == (cf == 1.0), "coverage/holes disagree -- verifier bug"
-        rows.append(CoverageRow(len(region), df, cf, d_full, c_full))
-    diff_avg = sum(r.diff_fraction for r in rows) / n
-    clone_avg = sum(r.clone_fraction for r in rows) / n
+        sq_total += _coverable_fraction(region, SQUARE)
+        dom_total += _coverable_fraction(region, DOMINO)
     return {
         "tasks": n,
-        "diff_coverage_avg": round(diff_avg, 4),
-        "clone_coverage_avg": round(clone_avg, 4),
-        "coverage_lift": round(diff_avg - clone_avg, 4),  # the headline: differentiation's measured gain
-        "diff_fully_covered_rate": round(sum(r.diff_full for r in rows) / n, 4),
-        "clone_fully_covered_rate": round(sum(r.clone_full for r in rows) / n, 4),
+        "square_reach_avg": round(sq_total / n, 4),  # the 2x2 frame starves on 1-wide seams
+        "domino_reach_avg": round(dom_total / n, 4),  # a domino reaches nearly all cells
+        "square_deficit": round(1.0 - sq_total / n, 4),  # a single-shape reachability fact (NOT differentiation)
+        "domino_deficit": round(1.0 - dom_total / n, 4),  # ~0: the strawman -- union saturates with any reacher
     }
 
 
-def random_board(rng: random.Random, n_ops: int) -> Board:
-    """A random region-agreement CSP: operators share a region and must agree; some are pre-fixed. A low
-    fixed-rate keeps most boards solvable, so the energy of a SOLVED board stays bounded and meaningful (an
-    unsolvable board backtracks to exhaustion -- a pathological tail we report separately, not in the mean)."""
-    domain = ("A", "B", "C")
-    ops: List[Operator] = []
-    for i in range(n_ops):
-        fixed = rng.choice(domain) if rng.random() < 0.15 else None
-        ops.append(Operator("o%d" % i, domain, region="r", fixed=fixed))
-    return Board(ops, [region_must_agree])
+def _mutilated(h: int, w: int) -> frozenset:
+    """An h x w rectangle minus two opposite (same-colour) corners -> even area, colour-parity imbalanced,
+    so a domino-only roster cannot tile it (the mutilated-chessboard obstruction)."""
+    return frozenset(c for c in rect(h, w) if c not in {(0, 0), (h - 1, w - 1)})
 
 
-def _median(xs: List[int]) -> float:
-    if not xs:
-        return 0.0
-    s = sorted(xs)
-    mid = len(s) // 2
-    return float(s[mid]) if len(s) % 2 else (s[mid - 1] + s[mid]) / 2
+def run_tiling() -> Dict[str, Any]:
+    """The RIGHT instrument for differentiation: at matched area, a CLONE (domino-only) set vs a DIFFERENTIATED
+    (domino + 2 monomino) set on parity-obstructed regions. Small fixed sizes (proving the clone CANNOT tile is
+    an exhaustive search, so this stays small). Every differentiated tiling is independently re-verified."""
+    rows = []
+    for h, w in [(2, 4), (4, 4)]:
+        reg = _mutilated(h, w)
+        a = len(reg)
+        clone = assemble(reg, [DOMINO] * (a // 2))
+        diff = assemble(reg, [DOMINO] * ((a - 2) // 2) + [MONO, MONO])
+        rows.append(
+            {
+                "region": "%dx%d-mutilated" % (h, w),
+                "area": a,
+                "clone_domino_tiles": clone.solved,
+                "diff_tiles": diff.solved,
+                "diff_verified": diff.verify(reg) if diff.solved else False,
+            }
+        )
+    return {
+        "cases": rows,
+        "clone_fails_all": all(not r["clone_domino_tiles"] for r in rows),
+        "diff_tiles_all_verified": all(r["diff_tiles"] and r["diff_verified"] for r in rows),
+    }
 
 
-def run_energy(m: int, seed: int, min_ops: int = 2, max_ops: int = 6) -> Dict[str, Any]:
+def _random_board(rng: random.Random, n_ops: int) -> Board:
+    domain = tuple("XYZW"[: rng.randint(2, 4)])
+    ops = [Operator("o%d" % i, domain, region="r") for i in range(n_ops)]
+    return Board(ops, [all_distinct_in_region])
+
+
+def run_energy(m: int, seed: int, min_ops: int = 3, max_ops: int = 6) -> Dict[str, Any]:
+    """Honest disclosure, not a measurement. Forward-checking prunes each unassigned operator to values
+    consistent with the assigned ones BEFORE any conflict, so a SOLVED board never backjumps -> 0 J is
+    structural. Backjumps (and thus energy) occur ONLY on UNSOLVABLE boards. We report both, labeled."""
     rng = random.Random(seed + 1)
-    solved_overwrites: List[int] = []  # re-decisions among SOLVED boards -- the meaningful "cost of a solve"
-    conflict_free = 0  # of SOLVED boards, how many were forward-only (0 J)
     solved = 0
+    solved_with_energy = 0  # MUST stay 0 -- the tautology we are disclosing
+    unsolved = 0
+    unsolved_overwrites: List[int] = []
     for _ in range(m):
-        board = random_board(rng, rng.randint(min_ops, max_ops))
+        board = _random_board(rng, rng.randint(min_ops, max_ops))
         res = solve_with_squad(board)
         e = res.squad_energy
-        # VERIFY the metering matches a fresh, independent solve_energy over the same jumps
-        assert e == solve_energy(board, res.jumps), "energy metering is not reproducible"
+        # genuine independent re-derivation of the bits from the jump list (not the same object)
+        valid = [j for j in res.jumps if 0 <= j < len(board.operators)]
+        assert e.overwrites == len(valid), "overwrites must equal the valid backjump count"
         if res.solved:
             solved += 1
-            solved_overwrites.append(e.overwrites)
-            conflict_free += 1 if e.overwrites == 0 else 0
+            if e.overwrites > 0:
+                solved_with_energy += 1
+        else:
+            unsolved += 1
+            unsolved_overwrites.append(e.overwrites)
+    avg_unsolved = sum(unsolved_overwrites) / unsolved if unsolved else 0.0
     return {
         "tasks": m,
         "solved_rate": round(solved / m, 4),
-        "conflict_free_rate_of_solved": round(conflict_free / solved, 4) if solved else 0.0,
-        "median_overwrites_solved": _median(solved_overwrites),  # robust to the unsolvable backtrack tail
-        "max_overwrites_solved": max(solved_overwrites) if solved_overwrites else 0,
+        "solved_with_nonzero_energy": solved_with_energy,  # 0 by construction (forward-checking) -> a tautology
+        "energy_is_structural_not_measured": solved_with_energy == 0,
+        "unsolved_avg_overwrites": round(avg_unsolved, 2),  # the only place energy appears: the solver flailing
     }
 
 
-def run_bench(n: int = 200, m: int = 200, seed: int = 7) -> Dict[str, Any]:
+def run_bench(reach_n: int = 200, energy_m: int = 120, seed: int = 7) -> Dict[str, Any]:
     return {
         "benchmark": "squad-offline",
         "seed": seed,
-        "coverage": run_coverage(n, seed),
-        "energy": run_energy(m, seed),
+        "reach": run_reach(reach_n, seed),
+        "tiling": run_tiling(),
+        "energy": run_energy(energy_m, seed),
     }
 
 
 def render(summary: Dict[str, Any]) -> str:
-    c, e = summary["coverage"], summary["energy"]
+    rc, ti, en = summary["reach"], summary["tiling"], summary["energy"]
     lines = [
-        "SQUAD BENCHMARK (offline, deterministic; seed=%d) -- differentiation at scale" % summary["seed"],
+        "SQUAD BENCHMARK (offline, deterministic; seed=%d) -- honest instruments only" % summary["seed"],
         "",
-        "  COVERAGE (%d random regions)  differentiated vs clone piece-squad" % c["tasks"],
-        "    avg cell coverage   : differentiated %.1f%%   clone %.1f%%   LIFT +%.1f%%"
-        % (100 * c["diff_coverage_avg"], 100 * c["clone_coverage_avg"], 100 * c["coverage_lift"]),
-        "    fully-covered rate  : differentiated %.1f%%   clone %.1f%%"
-        % (100 * c["diff_fully_covered_rate"], 100 * c["clone_fully_covered_rate"]),
+        "  REACH (%d random regions) -- a SINGLE shape's footprint, NOT differentiation" % rc["tasks"],
+        "    2x2 SQUARE reaches %.1f%% of cells (deficit %.1f%% on thin/branchy regions)"
+        % (100 * rc["square_reach_avg"], 100 * rc["square_deficit"]),
+        "    DOMINO    reaches %.1f%% (deficit %.1f%%) -- the strawman: union saturates, so coverage != diversity"
+        % (100 * rc["domino_reach_avg"], 100 * rc["domino_deficit"]),
         "",
-        "  ENERGY (%d random CSP boards)  the Landauer cost of the squad solve" % e["tasks"],
-        "    solved                  : %.1f%%" % (100 * e["solved_rate"]),
-        "    of solved, conflict-free: %.1f%%   (forward-only solves erase nothing -> 0 J)"
-        % (100 * e["conflict_free_rate_of_solved"]),
-        "    of solved, CBJ re-decisions: median %.1f, max %d   (the cost lives in the erasures)"
-        % (e["median_overwrites_solved"], e["max_overwrites_solved"]),
+        "  TILING (matched area) -- the RIGHT instrument: shape-diversity defeats a parity wall",
+        "    clone (domino-only) tiles a mutilated region : %s   (every case)" % (not ti["clone_fails_all"]),
+        "    diff (domino+2 monomino) tiles + re-verifies : %s   (every case)" % ti["diff_tiles_all_verified"],
         "",
-        "  => differentiation's coverage lift and the energy distribution, measured + verified, not asserted.",
-        "  (offline synthetic distribution; NOT a code-gen benchmark, and not a real online Kaggle run.)",
+        "  ENERGY (%d random CSP boards) -- DISCLOSURE, not a measurement" % en["tasks"],
+        "    solved boards with nonzero energy : %d  (0 by construction: forward-checking -> solved is forward-only)"
+        % en["solved_with_nonzero_energy"],
+        "    energy appears only on UNSOLVABLE boards (avg %.2f backjumps -- the solver flailing)"
+        % en["unsolved_avg_overwrites"],
+        "",
+        "  => coverage-union does NOT measure differentiation (domino strawman); exact TILING does. Energy among",
+        "     solved boards is a forward-checking tautology, not an empirical Landauer distribution.",
     ]
     return "\n".join(lines)
 
 
 def main(argv: Sequence[str] = None) -> int:
     ap = argparse.ArgumentParser(prog="squad-bench", description="offline benchmark of the squad's claims")
-    ap.add_argument("--n", type=int, default=200, help="coverage tasks")
-    ap.add_argument("--m", type=int, default=200, help="energy tasks")
+    ap.add_argument("--n", type=int, default=200, help="reach tasks")
+    ap.add_argument("--m", type=int, default=120, help="energy tasks")
     ap.add_argument("--seed", type=int, default=7)
     a = ap.parse_args(argv)
     print(render(run_bench(a.n, a.m, a.seed)))

--- a/tests/test_squad_bench.py
+++ b/tests/test_squad_bench.py
@@ -1,37 +1,46 @@
-"""Tests for squad_bench -- the offline, deterministic benchmark of the squad's differentiation claim.
+"""Tests for squad_bench -- the offline benchmark, after the self-audit replaced the strawman lift.
 
-The benchmark's own run already self-verifies (coverage vs holes must agree; energy metering must reproduce
-via an independent solve_energy). These pin the load-bearing benchmark properties: it is reproducible
-(seeded), the differentiation LIFT is real and positive, and solvable region-agree boards are forward-only
-(0 J -- the cost is only in the erasures).
+Pins the HONEST instruments: (1) coverage-union does NOT measure differentiation -- a DOMINO clone leaves ~0
+gap, exposing the strawman; (2) the RIGHT instrument is exact TILING at matched area, where a domino-only
+clone fails a parity wall a domino+monomino set clears (re-verified); (3) the energy benchmark is a
+forward-checking TAUTOLOGY among solved boards (disclosed), not an empirical Landauer distribution.
 """
 
 from __future__ import annotations
 
-from python.helm.squad_bench import run_bench, run_coverage, run_energy
+from python.helm.squad_bench import run_bench, run_energy, run_reach, run_tiling
 
 
 def test_benchmark_is_reproducible_same_seed_same_numbers():
-    assert run_bench(40, 40, 7) == run_bench(40, 40, 7)  # seeded -> identical (the whole point)
+    assert run_bench(40, 40, 7) == run_bench(40, 40, 7)  # seeded -> identical
 
 
-def test_differentiation_lift_is_real_and_positive():
-    cov = run_coverage(120, seed=7)
-    assert cov["coverage_lift"] > 0.1  # a differentiated squad covers materially more than a clone
-    assert cov["diff_coverage_avg"] > cov["clone_coverage_avg"]
-    assert cov["diff_fully_covered_rate"] > cov["clone_fully_covered_rate"]
+def test_reach_is_a_single_shape_fact_not_differentiation():
+    # the strawman exposed: the 2x2 SQUARE has a real reach deficit, but a DOMINO reaches ~everything, so
+    # coverage-union cannot be a differentiation metric (any all-reaching shape saturates it).
+    rc = run_reach(150, seed=7)
+    assert rc["square_deficit"] > 0.2  # the 2x2 frame genuinely starves on thin/branchy regions
+    assert rc["domino_deficit"] < 0.02  # ...but a single domino reaches nearly all cells
+    # so the old "differentiation lift" (square vs differentiated) was measuring the square's deficit, not diversity
 
 
-def test_energy_solved_boards_are_forward_only_free():
-    # the honest finding: solvable region-agree boards solve without CBJ jump-backs -> 0 erasures, 0 J.
-    e = run_energy(120, seed=7)
-    assert e["solved_rate"] > 0.5
-    assert e["conflict_free_rate_of_solved"] == 1.0  # every solved board was forward-only (free)
-    assert e["median_overwrites_solved"] == 0.0
+def test_tiling_is_the_right_instrument_diversity_beats_a_parity_wall():
+    ti = run_tiling()
+    assert ti["clone_fails_all"]  # a domino-only roster cannot tile the parity-obstructed regions
+    assert ti["diff_tiles_all_verified"]  # domino+monomino (same area) tiles them, independently re-verified
+    # this is differentiation genuinely load-bearing, at matched area -- the honest claim
+
+
+def test_energy_among_solved_is_a_forward_checking_tautology():
+    # honest disclosure: forward-checking makes a SOLVED board forward-only by construction, so 0 J among
+    # solved is structural, not measured. Energy appears only on unsolvable boards (the solver flailing).
+    en = run_energy(150, seed=7)
+    assert en["solved_with_nonzero_energy"] == 0  # the tautology, stated as such
+    assert en["energy_is_structural_not_measured"] is True
+    assert en["solved_rate"] > 0.0
 
 
 def test_run_bench_structure():
     b = run_bench(20, 20, 3)
     assert b["benchmark"] == "squad-offline"
-    assert set(b) == {"benchmark", "seed", "coverage", "energy"}
-    assert b["coverage"]["tasks"] == 20 and b["energy"]["tasks"] == 20
+    assert set(b) == {"benchmark", "seed", "reach", "tiling", "energy"}


### PR DESCRIPTION
## What

The self-audit **refuted squad_bench's headline.** The "+41.6% coverage differentiation LIFT" was an artifact of pitting the differentiated set against the *worst-reaching single shape* (the 2×2 SQUARE). Coverage is a **union** over pieces, so any all-reaching piece saturates it — a **DOMINO clone gives a 0.0 lift** (confirmed). Coverage-union does not measure differentiation. This is exactly the "+24-style" failure the audit was built to catch, in my own benchmark.

## The honest rewrite

```
REACH (150 regions) -- a SINGLE shape's footprint, NOT differentiation
  2x2 SQUARE reaches 58.9% (deficit 41.1% on thin/branchy regions)
  DOMINO    reaches 100.0% (deficit 0.0%) -- the strawman: union saturates, coverage != diversity

TILING (matched area) -- the RIGHT instrument: shape-diversity defeats a parity wall
  clone (domino-only) tiles a mutilated region : False  (every case)
  diff (domino+2 monomino) tiles + re-verifies : True   (every case)

ENERGY -- DISCLOSURE, not a measurement
  solved boards with nonzero energy : 0  (forward-checking -> solved is forward-only, by construction)
  energy appears only on UNSOLVABLE boards (avg 23.41 backjumps -- the solver flailing)
```

- **REACH** is honestly labeled a single-shape reachability fact, with the strawman exposed in-line (DOMINO deficit ≈ 0).
- **TILING** is the right instrument: at matched area a domino-only clone can't tile a parity-obstructed region while domino+monomino can — every tiling re-verified. Differentiation genuinely load-bearing.
- **ENERGY** is disclosed as a forward-checking **tautology** (a solved board never backjumps — verified for both `region_must_agree` *and* `all_distinct_in_region`), so 0 J among solved is structural, not measured. Energy only shows on unsolvable boards.

Also dropped the two **tautological self-verify asserts** (coverage/holes from the same call; deterministic `solve_energy` recompute) — the tests now assert externally-meaningful properties.

## Tests

5/5 in `tests/test_squad_bench.py` (reproducible; strawman exposed; tiling-is-the-right-instrument; energy-tautology disclosed; structure). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>