### PR TITLE
fix(reversible): charge erased information honestly + scope the energy claim (self-audit)

### DIFF
--- a/python/scbe/reversible_circuit.py
+++ b/python/scbe/reversible_circuit.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 from .elastic_bijective_hash import splitmix64
 
@@ -27,11 +27,17 @@ Reg = Dict[str, int]
 
 # Landauer's principle: erasing ONE bit of information dissipates at least k*T*ln2 of energy as heat, and
 # THAT dissipation is the forward arrow. A reversible (bijective) gate erases nothing -> thermodynamically
-# free. So the energy bill of a computation == the bits it irreversibly ERASES, and UNCOMPUTING instead of
-# erasing pays it back to ~0. These constants make the bill a real number of joules.
+# free. So the Landauer (ERASURE) component of the energy bill == the bits it irreversibly ERASES, and
+# UNCOMPUTING instead of erasing pays that component back to ~0. These constants make it a real number of J.
+#
+# HONEST SCOPE of the energy claim: reversible_joules==0 is the information-ERASURE (Landauer) floor ONLY.
+# It is NOT net-zero total energy: (1) Bennett -- the answer is kept in the `out` register, so clearing it for
+# the next computation costs the same bill (the cost is deferred into space, not eliminated); (2) real
+# gate-switching/dynamical energy (the splitmix64 mixing, the XORs) is not modeled and on any real device
+# dominates k*T*ln2 by orders of magnitude. This models the erasure floor, not a chip's power.
 K_BOLTZMANN = 1.380649e-23  # J/K (exact, SI)
 ROOM_T_K = 300.0  # K, ~room temperature
-REG_BITS = 64  # our registers are 64-bit; force-clearing one throws away this many information bits
+REG_BITS = 64  # register WIDTH; a force-clear erases AT MOST this many bits (actual = bit_length of the value)
 
 
 def landauer_joules(bits_erased: int, temperature_k: float = ROOM_T_K) -> float:
@@ -131,21 +137,26 @@ def run_metered(state: Reg, gates: List[Gate], ledger: EnergyLedger) -> Reg:
     return state
 
 
-def erase_register(state: Reg, reg: str, ledger: EnergyLedger, bits: int = REG_BITS) -> Reg:
+def erase_register(state: Reg, reg: str, ledger: EnergyLedger, bits: Optional[int] = None) -> Reg:
     """The one IRREVERSIBLE move: force `reg` to 0, throwing away the information it held. Charges the ledger
-    bits*k*T*ln2 -- the literal cost of the arrow. Compare UNCOMPUTING the register, which restores 0 for free
-    by running the bijective gates backward (run_metered over the inverses)."""
+    for the information ACTUALLY erased -- the bit_length of the prior value (0 when it was already 0, up to
+    REG_BITS), or `bits` if given explicitly. This is the cost of the arrow; UNCOMPUTING restores 0 for free
+    by running the bijective gates backward (run_metered over the inverses). NOTE: clearing a known-zero
+    register costs 0 -- erasing information you don't have is free."""
     r = dict(state)
+    erased = state[reg].bit_length() if bits is None else bits
     r[reg] = 0
-    ledger.erase("erase %s" % reg, bits)
+    ledger.erase("erase %s" % reg, erased)
     return r
 
 
 def energy_compare(x: int) -> Dict[str, object]:
     """The whole point in one number. Compute h(x), copy it out, then CLEAN the scratch two ways:
-      (1) forward-only -> FORCE-ERASE the scratch (irreversible): pays REG_BITS*k*T*ln2.
+      (1) forward-only -> FORCE-ERASE the scratch (irreversible): pays bit_length(h(x))*k*T*ln2 (up to REG_BITS;
+          0 in the degenerate x=0 case where h(0)=0 -- erasing a zero register erases nothing).
       (2) reversible   -> UNCOMPUTE the scratch (run the gates backward): pays ~0.
-    Both end identical (scratch=0, out=h(x)); the energy difference is exactly what reversibility recovers."""
+    Both end identical (scratch=0, out=h(x)); the difference is the ERASURE (Landauer) energy reversibility
+    recovers -- NOT total energy (the answer stays in `out`, Bennett; gate-switching is not modeled)."""
     compute = [hash_into("scratch", "x")]
     expected = splitmix64(x) & MASK
 
@@ -214,7 +225,7 @@ def main() -> int:
         "  ...output keeps the answer h(x), input preserved        : %s, %s"
         % (d["uncompute_keeps_answer"], d["input_preserved"])
     )
-    print("  => computed a result and erased NOTHING (no Landauer cost, no garbage qubit).\n")
+    print("  => computed a result while erasing nothing reclaimable (the Landauer ERASURE floor is 0).\n")
 
     e = d["_energy"]
     print("LANDAUER ENERGY LEDGER -- energy IS the arrow; reversibility recovers it")
@@ -228,9 +239,11 @@ def main() -> int:
         % (e["reversible_joules"], e["reversible_bits_erased"])
     )
     print(
-        "  => reversibility recovered %.3e J at T=300K; over 1e9 such ops that is %.3e J of avoided heat."
+        "  => reversibility recovered %.3e J of ERASURE energy at T=300K (over 1e9 ops, %.3e J)."
         % (e["energy_recovered_joules"], e["energy_recovered_joules"] * 1e9)
     )
+    print("  honest: the Landauer FLOOR only -- the answer stays in `out` (Bennett, deferred), gate-switching")
+    print("          energy is not modeled, and a real chip dissipates orders of magnitude more. Not net-zero.")
     return 0
 
 

--- a/tests/test_reversible_circuit.py
+++ b/tests/test_reversible_circuit.py
@@ -81,16 +81,25 @@ def test_energy_ledger_reversible_is_free_erase_pays():
 
 
 def test_energy_compare_forward_pays_reversible_recovers():
-    # the load-bearing result: same end state both ways, but force-erase pays the Landauer floor for the
-    # whole 64-bit scratch while uncomputing pays exactly zero -- the energy difference is the recovery
-    for x in (0, 1, 42, 1234567, 2**50 + 9):
+    # honest: force-erase pays the Landauer floor for the INFORMATION actually erased -- the bit_length of
+    # h(x), NOT a flat 64 -- while uncomputing pays exactly zero. The difference is the recovery.
+    for x in (1, 42, 1234567, 2**50 + 9):
         e = energy_compare(x)
+        bits = (splitmix64(x) & MASK).bit_length()
         assert e["same_result"] is True  # scratch=0, out=h(x) reached identically both ways
-        assert e["forward_only_bits_erased"] == REG_BITS  # force-clear erases the full register
-        assert e["reversible_bits_erased"] == 0  # uncomputation erases nothing
-        assert e["reversible_joules"] == 0.0  # ...so it is thermodynamically free
-        assert e["forward_only_joules"] > 0.0  # ...while the dissipating path pays heat
-        assert e["energy_recovered_joules"] == e["forward_only_joules"]  # all of it recovered
+        assert 0 < e["forward_only_bits_erased"] == bits <= REG_BITS  # the info content of h(x), not flat 64
+        assert e["reversible_bits_erased"] == 0 and e["reversible_joules"] == 0.0  # uncompute erases nothing
+        assert e["forward_only_joules"] > 0.0  # the dissipating path pays heat
+        assert e["energy_recovered_joules"] == e["forward_only_joules"]  # all the erasure energy recovered
+
+
+def test_energy_compare_zero_is_a_fixed_point_erasing_nothing():
+    # honest degenerate case: splitmix64(0)==0, so the scratch holds 0 after compute -- force-clearing a zero
+    # register erases NO information (0 bits, 0 J). Both paths are free; there is nothing to recover.
+    e = energy_compare(0)
+    assert e["same_result"] is True
+    assert e["forward_only_bits_erased"] == 0 and e["forward_only_joules"] == 0.0
+    assert e["energy_recovered_joules"] == 0.0
 
 
 def test_demo_all_true():


### PR DESCRIPTION
## What

Two overclaims the self-audit found in the Landauer ledger.

### 1. `erase_register` charged a flat 64 bits regardless of contents
`energy_compare(0)` billed `forward_only_bits_erased=64` / `1.84e-19 J` even though `splitmix64(0)==0`, so the scratch held **0** after compute — erasing a known-zero register destroys **no** information. Now `erase_register` charges the information **actually** erased: `bit_length` of the prior value (0 for a zero register, up to `REG_BITS`). `x=0` now correctly costs **0**; the test asserts `bit_length(h(x))` instead of a flat 64, and a new test pins the zero-fixed-point degenerate case.

### 2. The energy claim wasn't scoped
"erased NOTHING / no Landauer cost / avoided heat" implied net-zero energy. Added an explicit honest-scope caveat (header + demo output): `reversible_joules==0` is the information-**erasure** (Landauer) **floor only** — not net-zero total energy, because (a) the answer is kept in the `out` register (**Bennett**: cost deferred into space, not eliminated) and (b) real **gate-switching** energy is not modeled and dominates `kT·ln2` on any device. Reworded "the energy bill" → "the Landauer (erasure) component."

## Tests

9/9 in `tests/test_reversible_circuit.py` (the energy test now asserts the real `bit_length`; a new test pins `energy_compare(0)` erasing nothing). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>