### PR TITLE
fix(observer,puzzle): retire two over-narrow wording claims (self-audit)

### DIFF
--- a/python/scbe/observer_dynamics.py
+++ b/python/scbe/observer_dynamics.py
@@ -468,15 +468,17 @@ def unwind(records: List[DecisionRecord], undo: List[Tuple[int, str]]) -> List[D
 
 @dataclass
 class SolveEnergy:
-    rewrites: int  # number of irreversible re-decisions the CBJ solve made == conflict depth
+    rewrites: int  # irreversible re-decisions the CBJ solve made (a deep cascade can re-decide one node many
+    # times, so this can EXCEED history_len -- it is conflict DEPTH, not a per-record count)
     history_len: int  # number of records in the history
     bits_per_decision: int  # decision_bits(domain_size) -- honest small-domain info content
     irreversible_bits_erased: int  # rewrites * bits_per_decision
     irreversible_joules: float  # the Landauer FLOOR the dissipating (overwrite) solve pays (lower bound)
     reversible_joules: float  # 0.0 -- the reversible (undo-log) solve erases nothing during the solve
     reversible_undo_log_entries: int  # the SPACE paid instead (== rewrites): Bennett space-for-energy
-    naive_linear_bits: int  # cost if EVERY record were re-decided (linear in history) -- the ceiling
-    energy_is_sublinear: bool  # rewrites < history_len: the solve paid for conflict depth, not length
+    naive_linear_bits: int  # cost if every record were re-decided ONCE (= n*bits); NOT an upper bound -- a deep
+    # CBJ cascade re-deciding one node repeatedly can make irreversible_bits_erased EXCEED this
+    energy_is_sublinear: bool  # rewrites < history_len: the solve paid for conflict depth below length (not always)
 
 
 def energy_of_solve(

--- a/python/scbe/squad_puzzle.py
+++ b/python/scbe/squad_puzzle.py
@@ -12,8 +12,9 @@ The differentiation claim carries over, now geometric and provable by execution:
     the assembly possible -- the geometric echo of "a clone squad is rank-deficient and cannot triangulate".
   * a cell NO piece can reach is a HOLE -- an ANALOGOUS blind spot to the triangulation null space (the
     "absence is information" gap). Honest difference: a hole is region-dependent REACH, not the squad-only
-    null space, so a single covering clone has zero holes; and a hole-free target can still be untileable
-    (a parity obstruction, deeper than any single uncoverable cell).
+    null space, so a single covering clone has zero holes; and a hole-free target can still be untileable for
+    reasons beyond a single uncoverable cell -- a colour-PARITY obstruction (the mutilated chessboard), OR a
+    piece that simply has no legal placement at all (e.g. a 1x5 bar in a 3-wide region).
 
 HONEST: this is polyomino EXACT COVER with a small deterministic Algorithm-X-style solver (most-constrained
 cell, backtracking). The "value" of a member is its piece shape + allowed orientations (1=fixed, 4=rotations,
@@ -119,7 +120,8 @@ def coverable_cells(region: Region, pieces: Sequence[Piece]) -> Region:
 def holes(region: Region, pieces: Sequence[Piece]) -> Tuple[Cell, ...]:
     """The region cells NO piece can cover -- an analogous blind spot (unreachable cells, the 'absence is
     information' gap). A non-empty holes set means no exact tiling can exist (something is structurally
-    uncoverable); but the converse fails -- a hole-free region can still be untileable (parity)."""
+    uncoverable); but the converse fails -- a hole-free region can still be untileable for other reasons
+    (a colour-parity obstruction, or a piece with no legal placement anywhere)."""
     return tuple(sorted(set(region) - coverable_cells(region, pieces)))
 
 

--- a/tests/test_observer_dynamics.py
+++ b/tests/test_observer_dynamics.py
@@ -246,7 +246,29 @@ def test_energy_is_flat_as_history_grows_not_linear():
     assert e_small.irreversible_bits_erased == e_big.irreversible_bits_erased  # FLAT, not linear
     assert e_small.irreversible_joules == e_big.irreversible_joules
     assert e_big.energy_is_sublinear is True  # 1 rewrite << 500 records
-    assert e_big.naive_linear_bits > e_big.irreversible_bits_erased  # the linear ceiling is far higher
+    # for THIS depth-1 root conflict, n*bits exceeds the single re-decide -- but that is NOT a universal
+    # ceiling (a deep cascade can exceed n*bits; see the next test).
+    assert e_big.naive_linear_bits > e_big.irreversible_bits_erased
+
+
+def test_naive_linear_bits_is_not_a_universal_ceiling():
+    # the audit's overclaim fix: naive_linear_bits (= n*bits, every record re-decided ONCE) is NOT an upper
+    # bound. A depth-2 cascade re-decides the SAME node twice; on a 2-record history that drives
+    # irreversible_bits_erased UP TO naive_linear_bits (a deeper cascade would EXCEED it) -- not "far higher".
+    recs = [DecisionRecord(0, "in0", ALLOW, route="r"), DecisionRecord(1, "in1", DENY, route="r")]
+
+    def two_step(rs, idx):
+        d = rs[idx].decision
+        if d == ALLOW:
+            return ESCALATE
+        if d == ESCALATE:
+            return DENY
+        return None
+
+    e = energy_of_solve(recs, two_step)
+    assert e.rewrites == 2 and e.history_len == 2  # the same node re-decided twice
+    assert e.irreversible_bits_erased == e.naive_linear_bits  # EQUAL -> not a ceiling, not "far higher"
+    assert e.energy_is_sublinear is False  # 2 rewrites not < 2 records
 
 
 def test_reversible_solve_erases_nothing_and_unwinds_losslessly():


### PR DESCRIPTION
## What

Two **wording** overclaims the self-audit found. The code is correct in both cases — only the explanatory text was too narrow.

### observer_dynamics — `naive_linear_bits` is not "the ceiling"
It was documented as "the ceiling" and a test asserted "the linear ceiling is far higher." But `naive_linear_bits = n*bits` charges every record **once**, while a deep CBJ cascade re-decides the **same node repeatedly** — so `irreversible_bits_erased` can **equal or exceed** `n*bits` (the audit fuzzed 1243 such cases). Reworded as *not* an upper bound, and added a test: a depth-2 cascade on a 2-record history drives `erased == naive_linear_bits` with `energy_is_sublinear == False`. The existing flat-energy assertion is now explicitly scoped to its depth-1 root-conflict case.

### squad_puzzle — hole-free untileable isn't only parity
The docstring attributed hole-free untileability specifically to "a parity obstruction." But a piece with **no legal placement** (a 1×5 bar in a 3-wide region) is hole-free *and* untileable for a non-parity reason. Reworded to "a colour-parity obstruction **OR** a piece with no legal placement at all."

## Tests

38/38 across `tests/test_observer_dynamics.py` (+1 cascade test) and `tests/test_squad_puzzle.py` (unchanged). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>