### PR TITLE
feat(cross_check): differential harness that catches cross-lane contract divergence

### DIFF
--- a/python/scbe/cross_check.py
+++ b/python/scbe/cross_check.py
@@ -1,0 +1,128 @@
+"""cross_check: a differential harness that flags when two implementations of ONE contract DIVERGE.
+
+The instrument for the failure mode that bit the observer this session: a parallel lane built a second
+assumption-core surface whose jump-back target read the MINIMIZED core, silently dropping the root and
+disagreeing with the canonical earliest_repair_point -- yet its own (narrow) test passed. A differential
+check would have caught it: fuzz a shared input domain, run BOTH implementations on each input, and return
+the FIRST divergence witness -- a concrete, reproducible counterexample, not a vague "they differ".
+
+    agree(left, right, gen, n, seed) -> CrossCheck(agreed, samples, divergence_or_None)
+
+Deterministic (seeded), zero-dependency. Differing return values diverge; so does a one-side exception
+(one raises where the other does not, or they raise different error types) -- silent crash-divergence is a
+real disagreement. A `key` normalizes outputs before comparison (e.g. to ignore order)."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional
+
+
+@dataclass
+class Divergence:
+    """A concrete witness: the input both implementations were run on, and what each produced."""
+
+    index: int  # which sample (0-based) first diverged
+    input_repr: str  # repr of the input -- reproducible
+    left: Any  # left(input) result (or "raised: <Type>")
+    right: Any  # right(input) result (or "raised: <Type>")
+
+
+@dataclass
+class CrossCheck:
+    agreed: bool  # no divergence over the sample
+    samples: int  # how many inputs were compared (== n on agreement; first-divergence index+1 otherwise)
+    divergence: Optional[Divergence]  # the first witness, or None
+
+
+def _eval(fn: Callable[[Any], Any], x: Any) -> Any:
+    """Run fn(x); a raised exception becomes a sentinel string so a one-side crash is a comparable value."""
+    try:
+        return fn(x)
+    except Exception as exc:  # a crash on one side is a genuine divergence, not a harness failure
+        return "raised: %s" % type(exc).__name__
+
+
+def agree(
+    left: Callable[[Any], Any],
+    right: Callable[[Any], Any],
+    gen: Callable[[random.Random], Any],
+    n: int = 1000,
+    seed: int = 0,
+    key: Callable[[Any], Any] = lambda v: v,
+) -> CrossCheck:
+    """Fuzz n seeded inputs from `gen` and compare key(left(x)) vs key(right(x)). Return the FIRST divergence
+    (a reproducible witness) or agreement over the whole sample. `gen(rng)` builds one input from a seeded
+    Random; `key` normalizes outputs (default identity). Determinism: same (gen, n, seed) -> same result."""
+    rng = random.Random(seed)
+    for i in range(n):
+        x = gen(rng)
+        lo = _eval(lambda v=x: key(left(v)), x)
+        ro = _eval(lambda v=x: key(right(v)), x)
+        if lo != ro:
+            return CrossCheck(agreed=False, samples=i + 1, divergence=Divergence(i, repr(x), lo, ro))
+    return CrossCheck(agreed=True, samples=n, divergence=None)
+
+
+# ---------------------------------------------------------------------------
+# Applied to the contract that actually diverged this session: the observer's CBJ jump-back target. Two
+# surfaces claim it -- earliest_repair_point (canonical) and earliest_repair_point_from_assumption_core. The
+# parallel lane's pre-fix version read min(minimized core), dropping the root. The harness AGREES with the
+# fixed surface and CATCHES the buggy one with a concrete witness.
+# ---------------------------------------------------------------------------
+def _gen_history(rng: random.Random) -> List[Any]:
+    from .observer_dynamics import ALLOW, DENY, DecisionRecord, ESCALATE, REFUSED
+
+    n = rng.randint(1, 6)
+    routes = ["r", "s", "t", None]
+    out = []
+    for i in range(n):
+        dec = rng.choice([ALLOW, DENY, ESCALATE, REFUSED])
+        out.append(DecisionRecord(i, "in%d" % i, dec, route=rng.choice(routes)))
+    return out
+
+
+def _buggy_root_from_min_core(records: List[Any]) -> Optional[int]:
+    """The parallel lane's pre-#2592 bug, re-created for the demo: take the earliest of the MINIMIZED core
+    (which can drop the root) instead of the full-conflict earliest. The harness must catch this."""
+    from .observer_dynamics import solve_under_record_assumptions
+
+    sol = solve_under_record_assumptions(records)
+    if not sol.cores:
+        return None
+    return min(min(c.core) for c in sol.cores)
+
+
+def demo() -> dict:
+    from .observer_dynamics import earliest_repair_point, earliest_repair_point_from_assumption_core
+
+    # the FIXED surface agrees with the canonical target across a fuzz of random histories
+    fixed = agree(earliest_repair_point, earliest_repair_point_from_assumption_core, _gen_history, n=3000, seed=1)
+    # the BUGGY (min-of-core) surface diverges -- the harness returns a concrete witness
+    buggy = agree(earliest_repair_point, _buggy_root_from_min_core, _gen_history, n=3000, seed=1)
+    return {
+        "fixed_surface_agrees": fixed.agreed,
+        "buggy_surface_is_caught": (not buggy.agreed) and buggy.divergence is not None,
+        "_fixed": fixed,
+        "_buggy": buggy,
+    }
+
+
+def main() -> int:
+    d = demo()
+    f, b = d["_fixed"], d["_buggy"]
+    print("CROSS-CHECK -- differential agreement of two implementations of ONE contract")
+    print("  contract: the observer CBJ jump-back target (earliest_repair_point)")
+    print("  FIXED assumption-core surface agrees over %d fuzzed histories : %s" % (f.samples, f.agreed))
+    if b.divergence:
+        w = b.divergence
+        print("  BUGGY min-of-core surface CAUGHT at sample %d                 : True" % w.index)
+        print("    witness input : %s" % w.input_repr)
+        print("    canonical=%s  vs  buggy=%s  (the dropped root)" % (w.left, w.right))
+    print("  => a differential harness turns a silent cross-lane divergence into a reproducible witness.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cross_check.py
+++ b/tests/test_cross_check.py
@@ -1,0 +1,60 @@
+"""Tests for cross_check -- the differential harness that flags when two implementations of one contract diverge.
+
+Pins: identical implementations agree; a one-off difference is caught at the first witness; a one-side crash
+is a divergence; the run is deterministic; and on the real contract that diverged this session (the observer
+CBJ jump-back target) the FIXED assumption-core surface agrees while the pre-fix min-of-core BUG is caught
+with a concrete, reproducible witness -- the instrument that would have caught the parallel-lane root-drop.
+"""
+
+from __future__ import annotations
+
+from python.scbe.cross_check import agree, demo
+
+
+def _ints(rng):
+    return rng.randint(-50, 50)
+
+
+def test_identical_implementations_agree():
+    cc = agree(lambda x: x * 2, lambda x: x + x, _ints, n=500, seed=1)
+    assert cc.agreed and cc.divergence is None and cc.samples == 500
+
+
+def test_a_one_off_difference_is_caught_with_a_witness():
+    cc = agree(lambda x: x, lambda x: x + 1, _ints, n=500, seed=1)
+    assert not cc.agreed
+    assert cc.divergence is not None
+    assert cc.divergence.index == 0  # caught immediately
+    assert cc.divergence.left != cc.divergence.right  # the two outputs on the witness input
+
+
+def test_a_one_side_crash_is_a_divergence():
+    # left raises on negatives, right never does -> a genuine disagreement, not a harness failure
+    def left(x):
+        if x < 0:
+            raise ValueError("neg")
+        return x
+
+    cc = agree(left, lambda x: x, _ints, n=500, seed=3)
+    assert not cc.agreed
+    assert "raised: ValueError" in str(cc.divergence.left)
+
+
+def test_key_normalizes_before_comparing():
+    # outputs differ as lists but agree as sets -> a key that sorts makes them agree
+    cc = agree(lambda x: [x, -x], lambda x: [-x, x], _ints, n=200, seed=1, key=sorted)
+    assert cc.agreed
+
+
+def test_deterministic_same_seed_same_result():
+    a = agree(lambda x: x, lambda x: x + 1, _ints, n=100, seed=7)
+    b = agree(lambda x: x, lambda x: x + 1, _ints, n=100, seed=7)
+    assert (a.agreed, a.samples, a.divergence.input_repr) == (b.agreed, b.samples, b.divergence.input_repr)
+
+
+def test_observer_contract_fixed_agrees_buggy_is_caught():
+    d = demo()
+    assert d["fixed_surface_agrees"] is True  # the #2592 fix holds across the fuzz
+    assert d["buggy_surface_is_caught"] is True  # the pre-fix min-of-core bug is detected
+    w = d["_buggy"].divergence
+    assert w is not None and w.left != w.right  # a concrete witness: canonical root vs the dropped root


### PR DESCRIPTION
## What

The **cross-lane agreement signal** (Phase B, promoted to #1). A differential harness for the failure mode that bit the observer this session: a parallel lane built a second jump-back surface whose target read the **minimized** core, silently dropping the root and disagreeing with the canonical `earliest_repair_point` — yet its own narrow test passed. A differential check would have caught it.

## API (`python/scbe/cross_check.py`, zero-dependency)

- `agree(left, right, gen, n, seed, key)` → `CrossCheck(agreed, samples, divergence)`: fuzz `n` seeded inputs from `gen`, run **both** implementations on each, and return the **first divergence** as a reproducible **witness** (the input + both outputs), or agreement over the sample.
- Differing return values diverge; so does a **one-side exception** (a silent crash-divergence is a real disagreement). A `key` normalizes outputs before comparison. Deterministic.

## Proof it works (demo)

Applied to the exact contract that diverged — the observer CBJ jump-back target:

```
FIXED assumption-core surface agrees over 3000 fuzzed histories : True
BUGGY min-of-core surface CAUGHT at sample 26                 : True
  witness: [REFUSED@s, ALLOW@r, ALLOW@s, DENY@s, DENY@t, ESCALATE@t]
  canonical=0  vs  buggy=2  (the dropped root)
```

So it both confirms the **#2592 fix holds at scale** *and* **detects the bug class** (a re-created pre-fix `min(core)` implementation) with a concrete counterexample — not a vague "they differ."

## Tests

6/6 in `tests/test_cross_check.py` (identical agree; one-off difference caught at the witness; one-side crash is a divergence; key-normalization; determinism; the observer fixed-agrees / buggy-caught case). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deterministic differential testing harness to compare implementation variants and detect divergences with reproducible input examples.

* **Tests**
  * Added comprehensive test coverage validating divergence detection, crash handling, output normalization, and reproducible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->