### PR TITLE
feat(bench): elastic-hash probe-TAIL distribution (the mean hides the worst case)

### DIFF
--- a/python/helm/elastic_probe_bench.py
+++ b/python/helm/elastic_probe_bench.py
@@ -1,0 +1,102 @@
+"""elastic_probe_bench: the PROBE-LENGTH DISTRIBUTION of the bijective double-hash map, not just the mean.
+
+elastic_bijective_hash._bench_at reports the AVERAGE probes/op. The average is reassuring and misleading:
+for an open-addressing double-hash map the mean stays modest under load while the TAIL explodes -- most
+lookups are 1-2 probes (p50) but a few are catastrophic (max). This measures the full per-key lookup
+distribution (p50/p90/p99/p999/max) across loads, so the worst-case cost is visible, not hidden in the mean.
+
+    run([0.5, 0.9, 0.99, 0.999]) -> for each load, the probe-length percentiles + tail/mean ratio.
+
+Deterministic (seeded). HONEST SCOPE: this characterizes THIS reversible splitmix64 DOUBLE-HASH map (the
+module's own docstring notes it is a double-hash map, NOT the Bender-Kuszmaul "elastic hashing" of the
+2024/25 result). It is a probe-distribution measurement, no asymptotic claim about either."""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from python.scbe.elastic_bijective_hash import BijectiveDoubleHashMap  # noqa: E402
+
+
+def _percentile(sorted_xs: List[int], p: float) -> int:
+    if not sorted_xs:
+        return 0
+    return sorted_xs[min(len(sorted_xs) - 1, int(p * len(sorted_xs)))]
+
+
+def lookup_probe_lengths(bits: int, load: float, seed: int) -> List[int]:
+    """Fill a 2**bits-slot map to `load`, then measure the probe count of EACH key's lookup (its displacement
+    from the base slot). Deterministic keys. Asserts every key is found (a probe-length only means anything
+    on a successful lookup)."""
+    h = BijectiveDoubleHashMap(bits=bits, seed=seed)
+    n = int(h.size * load)
+    rng = random.Random(seed)
+    keys = ["k%d-%d" % (i, rng.getrandbits(40)) for i in range(n)]
+    for i, k in enumerate(keys):
+        h.put(k, i)
+    lengths: List[int] = []
+    for i, k in enumerate(keys):
+        h.total_probes = 0
+        assert h.get(k) == i, "lookup must find the key it inserted"
+        lengths.append(h.total_probes)
+    return lengths
+
+
+def distribution(bits: int, load: float, seed: int) -> Dict[str, Any]:
+    lengths = sorted(lookup_probe_lengths(bits, load, seed))
+    n = len(lengths)
+    mean = sum(lengths) / n if n else 0.0
+    mx = lengths[-1] if lengths else 0
+    return {
+        "load": load,
+        "keys": n,
+        "mean": round(mean, 2),
+        "p50": _percentile(lengths, 0.50),
+        "p90": _percentile(lengths, 0.90),
+        "p99": _percentile(lengths, 0.99),
+        "p999": _percentile(lengths, 0.999),
+        "max": mx,
+        "tail_over_mean": round(mx / mean, 1) if mean else 0.0,  # how far the worst case beats the average
+    }
+
+
+def run(bits: int = 14, loads: Sequence[float] = (0.5, 0.9, 0.99, 0.999), seed: int = 7) -> Dict[str, Any]:
+    return {"bits": bits, "seed": seed, "rows": [distribution(bits, ld, seed) for ld in loads]}
+
+
+def render(summary: Dict[str, Any]) -> str:
+    lines = [
+        "ELASTIC PROBE-TAIL (2^%d slots, seed=%d) -- the mean hides the worst case"
+        % (summary["bits"], summary["seed"]),
+        "",
+        "  %7s | %6s %5s %5s %6s %6s %7s | %s" % ("load", "mean", "p50", "p90", "p99", "p999", "max", "max/mean"),
+        "  %s" % ("-" * 64),
+    ]
+    for r in summary["rows"]:
+        lines.append(
+            "  %6.1f%% | %6.2f %5d %5d %6d %6d %7d | %6.1fx"
+            % (r["load"] * 100, r["mean"], r["p50"], r["p90"], r["p99"], r["p999"], r["max"], r["tail_over_mean"])
+        )
+    lines.append("")
+    lines.append("  => p50 stays ~1-2 (most lookups cheap) while max/p99 explode as load -> 1: the average is")
+    lines.append("     not the cost a worst-case operation pays. Probe distribution of a double-hash map (honest).")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] = None) -> int:
+    ap = argparse.ArgumentParser(prog="elastic-probe-bench", description="probe-length distribution of the hash map")
+    ap.add_argument("--bits", type=int, default=14)
+    ap.add_argument("--seed", type=int, default=7)
+    a = ap.parse_args(argv)
+    print(render(run(bits=a.bits, seed=a.seed)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_elastic_probe_bench.py
+++ b/tests/test_elastic_probe_bench.py
@@ -1,0 +1,42 @@
+"""Tests for elastic_probe_bench -- the probe-length distribution (tail, not just mean) of the hash map.
+
+Pins: the run is deterministic (seeded); every key is found (lookup_probe_lengths asserts it internally);
+the TAIL is real (max >> mean) and grows with load while p50 stays small -- the honest point that the
+average reported by _bench_at hides the worst case.
+"""
+
+from __future__ import annotations
+
+from python.helm.elastic_probe_bench import distribution, lookup_probe_lengths, run
+
+
+def test_is_deterministic_same_seed_same_distribution():
+    assert run(bits=12, loads=(0.9,), seed=3) == run(bits=12, loads=(0.9,), seed=3)
+
+
+def test_every_inserted_key_is_found():
+    # lookup_probe_lengths asserts get(k)==i internally; a returned list of the right length means all found
+    lengths = lookup_probe_lengths(bits=12, load=0.95, seed=7)
+    assert len(lengths) == int((1 << 12) * 0.95)
+    assert all(x >= 1 for x in lengths)  # a successful lookup probes at least once
+
+
+def test_tail_exceeds_mean_and_grows_with_load():
+    lo = distribution(bits=14, load=0.5, seed=7)
+    hi = distribution(bits=14, load=0.999, seed=7)
+    assert hi["max"] > hi["mean"] * 5  # the worst case is far above the average at high load
+    assert hi["max"] > lo["max"] * 5  # ...and the tail grows sharply with load
+    assert hi["tail_over_mean"] > 10.0  # max is many multiples of the mean
+
+
+def test_p50_stays_small_even_at_high_load():
+    # the honest shape: most lookups are cheap (p50 ~1-2) even when the tail is catastrophic
+    hi = distribution(bits=14, load=0.99, seed=7)
+    assert hi["p50"] <= 3
+    assert hi["p99"] > hi["p50"]  # the distribution is heavy-tailed, not flat
+
+
+def test_run_structure():
+    s = run(bits=12, loads=(0.5, 0.9), seed=1)
+    assert s["bits"] == 12 and len(s["rows"]) == 2
+    assert set(s["rows"][0]) == {"load", "keys", "mean", "p50", "p90", "p99", "p999", "max", "tail_over_mean"}


### PR DESCRIPTION
## What

`elastic_bijective_hash._bench_at` reports only the **average** probes/op — reassuring and misleading. For the open-addressing double-hash map the mean stays modest under load while the **tail explodes**. This measures the full per-key lookup probe-length **distribution** (p50/p90/p99/p999/max) across loads.

## Result (`python -m python.helm.elastic_probe_bench`, 2^14 slots)

```
   load |   mean   p50   p90    p99   p999     max | max/mean
  50.0% |   1.40     1     2      5      8      15 |   10.7x
  90.0% |   2.55     1     5     17     33      59 |   23.1x
  99.0% |   4.67     1     9     59    159     372 |   79.6x
  99.9% |   6.56     2     9     90    488    1533 |  233.6x
```

The average climbs from 1.4 → 6.6, but the **max climbs 15 → 1533** and **max/mean from 10.7× → 233.6×**. `p50` stays 1–2 (most lookups are cheap) while `p99`/`max` are catastrophic — the average is *not* the cost a worst-case operation pays.

## Honest scope

Characterizes **this** reversible splitmix64 **double-hash** map — the module's own docstring already notes it is a double-hash map, **not** the Bender–Kuszmaul "elastic hashing" of the 2024/25 result. It's a probe-distribution measurement; no asymptotic claim about either. Deterministic (seeded), and every lookup is asserted to find its key.

## Tests

5/5 in `tests/test_elastic_probe_bench.py` (deterministic; all keys found; tail >> mean and grows with load; p50 stays small while p99 > p50; structure). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>