### PR TITLE
feat(cross_check): delta-debugging shrink for minimal divergence witnesses

### DIFF
--- a/python/scbe/cross_check.py
+++ b/python/scbe/cross_check.py
@@ -21,10 +21,13 @@ from typing import Any, Callable, List, Optional
 
 @dataclass
 class Divergence:
-    """A concrete witness: the input both implementations were run on, and what each produced."""
+    """A concrete witness: the input both implementations were run on, and what each produced. When a
+    `shrinker` is supplied to agree(), `input` is the MINIMAL diverging input (delta-debugged), not the raw
+    random one -- far more diagnosable."""
 
     index: int  # which sample (0-based) first diverged
-    input_repr: str  # repr of the input -- reproducible
+    input: Any  # the actual (possibly shrunk) input object -- reproducible, directly re-runnable
+    input_repr: str  # repr of the input -- for display
     left: Any  # left(input) result (or "raised: <Type>")
     right: Any  # right(input) result (or "raised: <Type>")
 
@@ -44,6 +47,39 @@ def _eval(fn: Callable[[Any], Any], x: Any) -> Any:
         return "raised: %s" % type(exc).__name__
 
 
+def _diverges(left: Callable, right: Callable, x: Any, key: Callable) -> bool:
+    return _eval(lambda v=x: key(left(v)), x) != _eval(lambda v=x: key(right(v)), x)
+
+
+def shrink_list(xs: Any) -> Any:
+    """A generic shrinker for sequence inputs: each candidate drops one element. (Good for lists/histories.)"""
+    for i in range(len(xs)):
+        yield xs[:i] + xs[i + 1 :]
+
+
+def shrink(
+    left: Callable[[Any], Any],
+    right: Callable[[Any], Any],
+    witness: Any,
+    shrinker: Callable[[Any], Any],
+    key: Callable[[Any], Any] = lambda v: v,
+) -> Any:
+    """Greedily minimize a diverging input (delta-debugging): repeatedly replace it with the first smaller
+    candidate from shrinker(current) that STILL diverges, until none does. Returns a LOCALLY-minimal witness
+    (no single shrink step reduces it further) -- not guaranteed globally minimal, but far more diagnosable.
+    A random 6-record divergence reduces to the 2-3 records that actually drive the disagreement."""
+    current = witness
+    changed = True
+    while changed:
+        changed = False
+        for cand in shrinker(current):
+            if _diverges(left, right, cand, key):
+                current = cand
+                changed = True
+                break  # restart shrinking from the smaller candidate
+    return current
+
+
 def agree(
     left: Callable[[Any], Any],
     right: Callable[[Any], Any],
@@ -51,17 +87,20 @@ def agree(
     n: int = 1000,
     seed: int = 0,
     key: Callable[[Any], Any] = lambda v: v,
+    shrinker: Optional[Callable[[Any], Any]] = None,
 ) -> CrossCheck:
     """Fuzz n seeded inputs from `gen` and compare key(left(x)) vs key(right(x)). Return the FIRST divergence
     (a reproducible witness) or agreement over the whole sample. `gen(rng)` builds one input from a seeded
-    Random; `key` normalizes outputs (default identity). Determinism: same (gen, n, seed) -> same result."""
+    Random; `key` normalizes outputs (default identity). If `shrinker` is given, the witness is delta-debugged
+    to a locally-minimal input before reporting. Determinism: same (gen, n, seed) -> same result."""
     rng = random.Random(seed)
     for i in range(n):
         x = gen(rng)
-        lo = _eval(lambda v=x: key(left(v)), x)
-        ro = _eval(lambda v=x: key(right(v)), x)
-        if lo != ro:
-            return CrossCheck(agreed=False, samples=i + 1, divergence=Divergence(i, repr(x), lo, ro))
+        if _diverges(left, right, x, key):
+            w = shrink(left, right, x, shrinker, key) if shrinker is not None else x
+            lw = _eval(lambda v=w: key(left(v)), w)
+            rw = _eval(lambda v=w: key(right(v)), w)
+            return CrossCheck(agreed=False, samples=i + 1, divergence=Divergence(i, w, repr(w), lw, rw))
     return CrossCheck(agreed=True, samples=n, divergence=None)
 
 
@@ -99,11 +138,12 @@ def demo() -> dict:
 
     # the FIXED surface agrees with the canonical target across a fuzz of random histories
     fixed = agree(earliest_repair_point, earliest_repair_point_from_assumption_core, _gen_history, n=3000, seed=1)
-    # the BUGGY (min-of-core) surface diverges -- the harness returns a concrete witness
-    buggy = agree(earliest_repair_point, _buggy_root_from_min_core, _gen_history, n=3000, seed=1)
+    # the BUGGY (min-of-core) surface diverges -- with a shrinker, the witness is delta-debugged to minimal
+    buggy = agree(earliest_repair_point, _buggy_root_from_min_core, _gen_history, n=3000, seed=1, shrinker=shrink_list)
     return {
         "fixed_surface_agrees": fixed.agreed,
         "buggy_surface_is_caught": (not buggy.agreed) and buggy.divergence is not None,
+        "buggy_witness_is_minimal": buggy.divergence is not None and len(buggy.divergence.input) <= 3,
         "_fixed": fixed,
         "_buggy": buggy,
     }
@@ -117,10 +157,10 @@ def main() -> int:
     print("  FIXED assumption-core surface agrees over %d fuzzed histories : %s" % (f.samples, f.agreed))
     if b.divergence:
         w = b.divergence
-        print("  BUGGY min-of-core surface CAUGHT at sample %d                 : True" % w.index)
-        print("    witness input : %s" % w.input_repr)
+        print("  BUGGY min-of-core surface CAUGHT at sample %d (shrunk to %d records):" % (w.index, len(w.input)))
+        print("    minimal witness : %s" % [(r.decision, r.route) for r in w.input])
         print("    canonical=%s  vs  buggy=%s  (the dropped root)" % (w.left, w.right))
-    print("  => a differential harness turns a silent cross-lane divergence into a reproducible witness.")
+    print("  => the harness turns a silent divergence into a MINIMAL, reproducible witness (delta-debugged).")
     return 0
 
 

--- a/tests/test_cross_check.py
+++ b/tests/test_cross_check.py
@@ -8,7 +8,15 @@ with a concrete, reproducible witness -- the instrument that would have caught t
 
 from __future__ import annotations
 
-from python.scbe.cross_check import agree, demo
+from python.scbe.cross_check import (
+    _buggy_root_from_min_core,
+    _gen_history,
+    agree,
+    demo,
+    shrink,
+    shrink_list,
+)
+from python.scbe.observer_dynamics import earliest_repair_point
 
 
 def _ints(rng):
@@ -56,5 +64,23 @@ def test_observer_contract_fixed_agrees_buggy_is_caught():
     d = demo()
     assert d["fixed_surface_agrees"] is True  # the #2592 fix holds across the fuzz
     assert d["buggy_surface_is_caught"] is True  # the pre-fix min-of-core bug is detected
+    assert d["buggy_witness_is_minimal"] is True  # ...and the witness was delta-debugged to <=3 records
     w = d["_buggy"].divergence
     assert w is not None and w.left != w.right  # a concrete witness: canonical root vs the dropped root
+
+
+def test_shrink_reduces_to_the_minimal_diverging_sublist():
+    # left and right agree unless the input list contains 0; delta-debugging reduces a long diverging list
+    # to the single poison element that actually drives the disagreement.
+    minimal = shrink(lambda xs: 1 if 0 in xs else 0, lambda xs: 0, [5, 0, 3, 7, 0, 9], shrink_list)
+    assert minimal == [0]
+
+
+def test_agree_with_shrinker_yields_a_minimal_diverging_witness():
+    cc = agree(earliest_repair_point, _buggy_root_from_min_core, _gen_history, n=3000, seed=1, shrinker=shrink_list)
+    assert not cc.agreed
+    w = cc.divergence
+    assert len(w.input) <= 3  # the random ~6-record witness shrank to a minimal diagnosable history
+    # the MINIMAL witness still diverges, and no single-record drop reduces it further (locally minimal)
+    assert earliest_repair_point(w.input) != _buggy_root_from_min_core(w.input)
+    assert all(earliest_repair_point(c) == _buggy_root_from_min_core(c) or len(c) == 0 for c in shrink_list(w.input))


### PR DESCRIPTION
## What

Improves the `cross_check` differential harness (#2604). It returned a **random** divergence witness (e.g. a 6-record history) — but a **minimal** one is far more diagnosable. Adds greedy delta-debugging (test-case minimization).

## API

- `shrink(left, right, witness, shrinker, key)` — repeatedly replace a diverging input with the first **smaller** candidate (from `shrinker`) that **still diverges**, returning a **locally-minimal** witness (no single shrink step reduces it further).
- `shrink_list(xs)` — a generic sequence shrinker (each candidate drops one element).
- `agree(..., shrinker=...)` — when supplied, the reported witness is delta-debugged. `Divergence` now also carries the actual **`input` object** (directly re-runnable), not just a repr.

## Measured

```
observer min-of-core divergence: random 6-record history -> minimal 3 records
  [('REFUSED','s'), ('ALLOW','s'), ('DENY','s')]   canonical=0  vs  buggy=1  (dropped root)

generic list contract: [5,0,3,7,0,9] -> [0]   (the single poison element)
```

So a vague "they differ on some 6-record input" becomes "they differ on **exactly these 3 records** for **this** reason" — the difference between a hint and a diagnosis.

## Tests

8/8 in `tests/test_cross_check.py` (6 prior + 2 new: generic shrink to the poison element; the observer witness shrinks to ≤3 records, still diverges, and is locally minimal). Backward-compatible (`shrinker` defaults `None`). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Divergence witnesses now provide richer diagnostic information, including the actual input object alongside normalized results from both implementations.
  * Added automatic input shrinking to minimize failing cases to their smallest reproducible form.
  * Updated CLI output to display minimal witness representations for clearer issue diagnosis.

* **Tests**
  * Added test coverage for shrinking and minimal witness generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->