### PR TITLE
feat(bench): linear-probe baseline for the probe-tail bench (why double-hashing)

### DIFF
--- a/python/helm/elastic_probe_bench.py
+++ b/python/helm/elastic_probe_bench.py
@@ -30,11 +30,20 @@ def _percentile(sorted_xs: List[int], p: float) -> int:
     return sorted_xs[min(len(sorted_xs) - 1, int(p * len(sorted_xs)))]
 
 
-def lookup_probe_lengths(bits: int, load: float, seed: int) -> List[int]:
-    """Fill a 2**bits-slot map to `load`, then measure the probe count of EACH key's lookup (its displacement
-    from the base slot). Deterministic keys. Asserts every key is found (a probe-length only means anything
-    on a successful lookup)."""
-    h = BijectiveDoubleHashMap(bits=bits, seed=seed)
+class LinearProbeMap(BijectiveDoubleHashMap):
+    """A linear-probe BASELINE (stride fixed at 1 -> primary clustering) for the bench ONLY -- not a shipped
+    data structure. Same scrambled base, but consecutive probes, so it shows the tail that double-hashing's
+    coprime stride avoids."""
+
+    def _stride(self, ki: Any) -> int:
+        return 1
+
+
+def lookup_probe_lengths(bits: int, load: float, seed: int, map_factory: Any = BijectiveDoubleHashMap) -> List[int]:
+    """Fill a 2**bits-slot map (of `map_factory`) to `load`, then measure the probe count of EACH key's lookup
+    (its displacement from the base slot). Deterministic keys. Asserts every key is found (a probe-length only
+    means anything on a successful lookup)."""
+    h = map_factory(bits=bits, seed=seed)
     n = int(h.size * load)
     rng = random.Random(seed)
     keys = ["k%d-%d" % (i, rng.getrandbits(40)) for i in range(n)]
@@ -48,8 +57,8 @@ def lookup_probe_lengths(bits: int, load: float, seed: int) -> List[int]:
     return lengths
 
 
-def distribution(bits: int, load: float, seed: int) -> Dict[str, Any]:
-    lengths = sorted(lookup_probe_lengths(bits, load, seed))
+def distribution(bits: int, load: float, seed: int, map_factory: Any = BijectiveDoubleHashMap) -> Dict[str, Any]:
+    lengths = sorted(lookup_probe_lengths(bits, load, seed, map_factory))
     n = len(lengths)
     mean = sum(lengths) / n if n else 0.0
     mx = lengths[-1] if lengths else 0
@@ -68,6 +77,55 @@ def distribution(bits: int, load: float, seed: int) -> Dict[str, Any]:
 
 def run(bits: int = 14, loads: Sequence[float] = (0.5, 0.9, 0.99, 0.999), seed: int = 7) -> Dict[str, Any]:
     return {"bits": bits, "seed": seed, "rows": [distribution(bits, ld, seed) for ld in loads]}
+
+
+def compare(bits: int = 14, loads: Sequence[float] = (0.9, 0.99), seed: int = 7) -> Dict[str, Any]:
+    """Why double-hashing: the double-hash map vs a linear-probe baseline, same loads. Both have heavy tails
+    under load, but linear probing's PRIMARY CLUSTERING (consecutive probes) makes its tail dramatically worse
+    -- the coprime stride is what buys the better tail. Reports the linear-over-double max ratio."""
+    rows = []
+    for ld in loads:
+        dh = distribution(bits, ld, seed, BijectiveDoubleHashMap)
+        lp = distribution(bits, ld, seed, LinearProbeMap)
+        rows.append(
+            {
+                "load": ld,
+                "double_hash": dh,
+                "linear_probe": lp,
+                "linear_tail_penalty": round(lp["max"] / dh["max"], 1) if dh["max"] else 0.0,
+            }
+        )
+    return {"bits": bits, "seed": seed, "rows": rows}
+
+
+def render_compare(summary: Dict[str, Any]) -> str:
+    lines = [
+        "WHY DOUBLE-HASHING (2^%d slots, seed=%d) -- double-hash vs linear-probe TAIL"
+        % (summary["bits"], summary["seed"]),
+        "",
+        "  %7s | %-22s | %-22s | %s"
+        % ("load", "double-hash mean/p99/max", "linear mean/p99/max", "linear max penalty"),
+        "  %s" % ("-" * 78),
+    ]
+    for r in summary["rows"]:
+        dh, lp = r["double_hash"], r["linear_probe"]
+        lines.append(
+            "  %6.1f%% | %6.1f / %5d / %6d   | %6.1f / %5d / %6d   | %5.1fx worse"
+            % (
+                r["load"] * 100,
+                dh["mean"],
+                dh["p99"],
+                dh["max"],
+                lp["mean"],
+                lp["p99"],
+                lp["max"],
+                r["linear_tail_penalty"],
+            )
+        )
+    lines.append("")
+    lines.append("  => both tails grow under load, but linear probing's clustering is multiples worse: the")
+    lines.append("     coprime double-hash stride is what scatters probes and tames the worst case (measured).")
+    return "\n".join(lines)
 
 
 def render(summary: Dict[str, Any]) -> str:
@@ -95,6 +153,8 @@ def main(argv: Sequence[str] = None) -> int:
     ap.add_argument("--seed", type=int, default=7)
     a = ap.parse_args(argv)
     print(render(run(bits=a.bits, seed=a.seed)))
+    print()
+    print(render_compare(compare(bits=a.bits, seed=a.seed)))
     return 0
 
 

--- a/tests/test_elastic_probe_bench.py
+++ b/tests/test_elastic_probe_bench.py
@@ -7,7 +7,7 @@ average reported by _bench_at hides the worst case.
 
 from __future__ import annotations
 
-from python.helm.elastic_probe_bench import distribution, lookup_probe_lengths, run
+from python.helm.elastic_probe_bench import compare, distribution, lookup_probe_lengths, run
 
 
 def test_is_deterministic_same_seed_same_distribution():
@@ -34,6 +34,16 @@ def test_p50_stays_small_even_at_high_load():
     hi = distribution(bits=14, load=0.99, seed=7)
     assert hi["p50"] <= 3
     assert hi["p99"] > hi["p50"]  # the distribution is heavy-tailed, not flat
+
+
+def test_double_hashing_tames_the_tail_vs_linear_probing():
+    # the comparative "why double-hashing" claim: at high load the linear-probe baseline's primary clustering
+    # makes its tail MUCH worse than the coprime-stride double-hash map's, at the same load.
+    c = compare(bits=14, loads=(0.99,), seed=7)
+    row = c["rows"][0]
+    assert row["linear_probe"]["max"] > row["double_hash"]["max"] * 2  # linear tail far heavier
+    assert row["linear_probe"]["mean"] > row["double_hash"]["mean"]  # ...and a worse average too
+    assert row["linear_tail_penalty"] > 2.0  # reported as a multiple
 
 
 def test_run_structure():


### PR DESCRIPTION
## What

Improves the probe-tail benchmark (#2606). It measured the double-hash map's tail **in isolation**; this adds a **linear-probe baseline** so the comparative question — *why double-hashing?* — gets a measured answer.

## Result (`python -m python.helm.elastic_probe_bench`, 2^14 slots)

```
WHY DOUBLE-HASHING -- double-hash vs linear-probe TAIL
   load | double-hash mean/p99/max | linear mean/p99/max    | linear max penalty
  90.0% |    2.5 /    17 /     59   |    5.4 /    73 /    469   |   7.9x worse
  99.0% |    4.7 /    59 /    372   |   23.3 /   511 /   3071   |   8.3x worse
```

Both tails grow under load, but linear probing's **primary clustering** (consecutive probes) makes its worst case **~8× worse**. The coprime double-hash stride is what scatters probes and tames the tail — now a number, not an assertion.

## API

- `lookup_probe_lengths` / `distribution` gain a `map_factory` param (default `BijectiveDoubleHashMap`, so existing calls are unchanged).
- `LinearProbeMap` is a **bench-only baseline** (documented as not a shipped data structure).
- `compare()` + `render_compare()`; `main` prints both the distribution and the comparison.

## Tests

6/6 in `tests/test_elastic_probe_bench.py` (+1: linear tail far heavier than double-hash at high load, penalty > 2×). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>