### PR TITLE
test(bit_spine): fuzz-lock the byte<->trit/bit round-trip bijections (cross_check audit)

### DIFF
--- a/tests/test_bit_spine.py
+++ b/tests/test_bit_spine.py
@@ -31,6 +31,34 @@ def test_binary_hex_trit_projections_round_trip_bit_exact() -> None:
     assert bits_to_bytes(bytes_to_bits(payload)) == payload
 
 
+def test_byte_projections_round_trip_over_fuzzed_payloads_both_trit_bases() -> None:
+    # strengthen the fixed-payload round-trip with a domain fuzz (cross_check). The above only exercises the
+    # default balanced=True trit base on one 256-byte payload; this fuzzes RANDOM payloads through the trit
+    # projection in BOTH bases (the unbalanced base had no round-trip test) and the bit projection. A future
+    # break shrinks to the minimal failing payload. Audited: no divergence -> the bijections are locked.
+    from python.scbe.cross_check import agree, shrink_list
+
+    def payload(rng):
+        return bytes(rng.getrandbits(8) for _ in range(rng.randint(0, 12)))
+
+    for balanced in (True, False):
+        cc = agree(
+            lambda b, bal=balanced: trits_to_bytes(bytes_to_trits(b, balanced=bal), balanced=bal),
+            lambda b: b,
+            payload,
+            n=2000,
+            seed=4,
+            shrinker=shrink_list,
+        )
+        assert cc.agreed, "trit round-trip (balanced=%s) fails at %r" % (
+            balanced,
+            cc.divergence and cc.divergence.input,
+        )
+
+    bits = agree(lambda b: bits_to_bytes(bytes_to_bits(b)), lambda b: b, payload, n=2000, seed=5)
+    assert bits.agreed, "bit round-trip fails at %r" % (bits.divergence and bits.divergence.input)
+
+
 def test_trit_projection_rejects_invalid_unused_base3_cells() -> None:
     # Six raw ternary 2s represent 728, outside byte range.
     with pytest.raises(BitSpineError, match="invalid byte trit cell"):


### PR DESCRIPTION
## What

Continuing the `cross_check` audit. Found a **genuine, non-redundant gap** in `bit_spine`'s round-trip coverage: the existing `test_binary_hex_trit_projections_round_trip_bit_exact` exercises only the **default `balanced=True`** trit base on **one fixed 256-byte payload**. The `balanced=False` trit round-trip had **no test at all**, and neither base was fuzzed over random payloads.

## Fix

A domain fuzz (`cross_check.agree`, 2000 random byte payloads each): `encode → decode` must be the identity for **both** trit bases and the bit projection. **Audited — no divergence found**, so the bijections are locked; a future break shrinks to the minimal failing payload.

## Honest scope

This is a real strengthening (fixed-payload → fuzzed; covers the untested unbalanced base), not a duplicate of the existing test. No new module — uses the shipped `cross_check`.

## Tests

12/12 in `tests/test_bit_spine.py` (+1). black + flake8 clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added enhanced fuzz-based test coverage for conversion operations to strengthen code reliability and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->