### PR TITLE
feat(training): add staged retry-loop notebook

### DIFF
--- a/notebooks/build_vtc_retry_loop_nb.py
+++ b/notebooks/build_vtc_retry_loop_nb.py
@@ -1,0 +1,261 @@
+"""Builder for notebooks/vtc_retry_loop_colab.ipynb -- staged retry-loop training and eval.
+
+This is the next experiment after the already-run better-corpus notebook. It trains the model on a mixed
+retry-loop supplement:
+
+  bad -> fail -> self fix -> pass
+  bad -> fail -> fix attempt -> fail -> teacher correction
+
+Then it evaluates base-vs-trained with staged categories, so the result says whether the model actually
+learned to use failure feedback instead of only memorizing final answers.
+
+    python notebooks/build_vtc_retry_loop_nb.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def md(*lines: str) -> dict:
+    return {"cell_type": "markdown", "metadata": {}, "source": [x if x.endswith("\n") else x + "\n" for x in lines]}
+
+
+def code(*lines: str) -> dict:
+    return {
+        "cell_type": "code",
+        "metadata": {},
+        "execution_count": None,
+        "outputs": [],
+        "source": [x if x.endswith("\n") else x + "\n" for x in lines],
+    }
+
+
+CELLS = [
+    md(
+        "# VTC STAGED RETRY-LOOP Training -- qwen2.5-coder-1.5B, Colab T4",
+        "",
+        "Do not rerun the old `vtc_better_colab` here. This notebook tests the next hypothesis: train the model",
+        "on the full retry loop, not only final answers.",
+        "",
+        "Training supplement shape:",
+        "",
+        "- `bad -> FAIL -> self fix -> PASS`",
+        "- `bad -> FAIL -> fix attempt -> FAIL -> teacher correction`",
+        "",
+        "Evaluation emits the staged buckets directly:",
+        "",
+        "- `SOLVED_FIRST_TRY`",
+        "- `SOLVE_FAILED_FIX_ATTEMPT_SOLVED`",
+        "- `SOLVE_FAILED_FIX_ATTEMPT_FAILED`",
+        "- `PUBLIC_PASS_HIDDEN_FAIL_NO_RETRY`",
+        "",
+        "The metric that matters is `repair_conversion`: among first-failed problems where a retry happened,",
+        "how many did the retry actually recover?",
+    ),
+    md("## 1. Install"),
+    code(
+        "!pip install -q -U peft bitsandbytes accelerate datasets 'transformers>=4.44'",
+        "import torch",
+        "print('CUDA available:', torch.cuda.is_available())",
+    ),
+    md("## 2. Repo + base corpus upload"),
+    code(
+        "import os, sys, json",
+        "!git clone --depth 1 https://github.com/issdandavis/SCBE-AETHERMOORE.git scbe || true",
+        "sys.path.insert(0, '/content/scbe')",
+        "CORPUS_PATH = '/content/vtc_mbpp_refined.jsonl'",
+        "if not os.path.exists(CORPUS_PATH):",
+        "    from google.colab import files",
+        "    up = files.upload(); CORPUS_PATH = '/content/' + next(iter(up))",
+        "os.environ['SCBE_VTC_CORPUS'] = CORPUS_PATH",
+        "print('corpus:', CORPUS_PATH)",
+    ),
+    md("## 3. Config"),
+    code(
+        "BASE_MODEL = 'Qwen/Qwen2.5-Coder-1.5B-Instruct'",
+        "OUT = '/content/vtc-retry-loop-run'",
+        "TRAIN_SFT = '/content/train.retry_mix.sft.jsonl'",
+        "RETRY_ONLY = '/content/train.retry_only.jsonl'",
+        "BASELINE_JSONL = '/content/vtc_staged_base.jsonl'",
+        "TRAINED_JSONL = '/content/vtc_staged_trained.jsonl'",
+        "PUBLIC_K = 1",
+        "EVAL_LIMIT = 40",
+        "SELF_REPAIR_LIMIT = 80",
+        "TEACHER_BAILOUT_LIMIT = 80",
+        "MAXLEN = 2048",
+        "EPOCHS = 2",
+        "MAX_NEW_TOKENS = 512",
+    ),
+    md("## 4. Honest split + inject retry-loop supplement after the split"),
+    code(
+        "from pathlib import Path",
+        "from python.helm import public_bench as pb",
+        "from python.helm.vtc_split import load_corpus, split_by_task_id, write_train_sft",
+        "from python.helm.self_repair_corpus import verified_pool_from_vtc, synthesize_retry_mix, write_jsonl",
+        "from python.helm.retry_corpus_validate import validate as validate_retry, render as render_retry",
+        "",
+        "records = load_corpus(CORPUS_PATH)",
+        "problems = pb.pull_mbpp()",
+        "split = split_by_task_id(records, problems, public_k=PUBLIC_K)",
+        "eval_problems = split['eval_problems'][:EVAL_LIMIT] if EVAL_LIMIT else split['eval_problems']",
+        "assert not (split['train_ids'] & {p['task_id'] for p in eval_problems}), 'train/eval LEAK'",
+        "",
+        "# Build the retry supplement ONLY from train records. Held-out eval task_ids stay untouched.",
+        "pool = verified_pool_from_vtc(split['train_records'])",
+        "retry_mix = synthesize_retry_mix(pool, self_limit=SELF_REPAIR_LIMIT, teacher_limit=TEACHER_BAILOUT_LIMIT)",
+        "retry_records = retry_mix['records']",
+        "write_jsonl(RETRY_ONLY, retry_records)",
+        "train_records = list(split['train_records']) + retry_records",
+        "write_train_sft(train_records, TRAIN_SFT)",
+        "",
+        "print('base train records:', len(split['train_records']))",
+        "print('retry supplement:', retry_mix['self_records'], 'self-repair +', retry_mix['teacher_bailouts'], 'teacher-bailout')",
+        "print('final train records:', len(train_records), ' held-out eval:', len(eval_problems))",
+        "print(render_retry(validate_retry(retry_records)))",
+    ),
+    md("## 5. Load 4-bit model + LoRA adapter"),
+    code(
+        "import re",
+        "from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig",
+        "from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training",
+        "",
+        "bnb = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type='nf4',",
+        "                        bnb_4bit_compute_dtype=torch.bfloat16, bnb_4bit_use_double_quant=True)",
+        "tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL)",
+        "if tokenizer.pad_token is None: tokenizer.pad_token = tokenizer.eos_token",
+        "model = AutoModelForCausalLM.from_pretrained(BASE_MODEL, quantization_config=bnb, device_map='auto')",
+        "model = prepare_model_for_kbit_training(model)",
+        "model = get_peft_model(model, LoraConfig(r=16, lora_alpha=32, lora_dropout=0,",
+        "    target_modules=['q_proj','k_proj','v_proj','o_proj','gate_proj','up_proj','down_proj'],",
+        "    bias='none', task_type='CAUSAL_LM'))",
+        "model.print_trainable_parameters()",
+        "",
+        "def extract_code(text):",
+        "    blocks = re.findall(r'```(?:python)?\\s*(.*?)```', text or '', re.S)",
+        "    if blocks: return max(blocks, key=len).strip()",
+        "    body = re.sub(r'^\\s*```(?:python)?\\s*', '', (text or '').strip())",
+        "    lines = body.splitlines()",
+        "    for i, ln in enumerate(lines):",
+        "        if ln.lstrip().startswith(('def ', 'import ', 'from ', 'class ', '@')):",
+        "            return '\\n'.join(lines[i:]).strip()",
+        "    return body.strip()",
+        "",
+        "def _gen(prompt):",
+        "    text = tokenizer.apply_chat_template([{'role':'user','content':prompt}], tokenize=False, add_generation_prompt=True)",
+        "    enc = tokenizer(text, return_tensors='pt').to(model.device)",
+        "    out = model.generate(**enc, max_new_tokens=MAX_NEW_TOKENS, do_sample=False, pad_token_id=tokenizer.eos_token_id)",
+        "    return tokenizer.decode(out[0][enc['input_ids'].shape[1]:], skip_special_tokens=True)",
+    ),
+    md("## 6. Train on base corpus + retry supplement"),
+    code(
+        "from datasets import load_dataset",
+        "from transformers import Trainer, TrainingArguments, DataCollatorForLanguageModeling",
+        "train_ds = load_dataset('json', data_files=TRAIN_SFT, split='train')",
+        "def tok(ex):",
+        "    text = tokenizer.apply_chat_template(ex['messages'], tokenize=False, add_generation_prompt=False)",
+        "    return tokenizer(text, truncation=True, max_length=MAXLEN)",
+        "train_tok = train_ds.map(tok, remove_columns=train_ds.column_names)",
+        "args = TrainingArguments(output_dir=OUT, per_device_train_batch_size=2, gradient_accumulation_steps=8,",
+        "    num_train_epochs=EPOCHS, learning_rate=2e-4, warmup_ratio=0.05, lr_scheduler_type='cosine',",
+        "    logging_steps=10, bf16=True, optim='paged_adamw_8bit', report_to='none', save_strategy='no')",
+        "Trainer(model=model, args=args, train_dataset=train_tok,",
+        "        data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False)).train()",
+    ),
+    md("## 7. Staged retry-loop eval: base vs trained"),
+    code(
+        "from python.helm import public_bench as _pb",
+        "from python.helm import staged_retry_score as srs",
+        "",
+        "def make_prompt(problem):",
+        "    public = '\\n'.join(list(problem.get('test_list', []))[:PUBLIC_K])",
+        "    return ((problem.get('prompt') or problem.get('text') or '').strip()",
+        "            + '\\n\\nWrite a complete Python solution. It must make this example pass:\\n'",
+        "            + public + '\\nReturn ONLY the code.')",
+        "",
+        "def make_repair_prompt(problem, code, fail_msg):",
+        "    public = '\\n'.join(list(problem.get('test_list', []))[:PUBLIC_K])",
+        "    return ((problem.get('prompt') or problem.get('text') or '').strip()",
+        "            + '\\n\\nYour previous code failed this visible check:\\n' + public",
+        "            + '\\nFailure feedback:\\n' + str(fail_msg)",
+        "            + '\\n\\nPrevious code:\\n```python\\n' + code + '\\n```'",
+        "            + '\\n\\nRepair it. Return ONLY corrected Python code.')",
+        "",
+        "def verify(code, p):",
+        "    tests = list(p.get('test_list', []))",
+        "    return _pb._verify(code, tests[:PUBLIC_K], tests[PUBLIC_K:], p.get('test_imports', []))",
+        "",
+        "def fail_text(v):",
+        "    return v.get('error') or v.get('public_error') or v.get('stderr') or 'visible test failed'",
+        "",
+        "def run_staged_model(eval_problems):",
+        "    out = []",
+        "    for p in eval_problems:",
+        "        code1 = extract_code(_gen(make_prompt(p)))",
+        "        v1 = verify(code1, p)",
+        "        rec = {",
+        "            'task_id': p.get('task_id'),",
+        "            'first_try_public_pass': bool(v1.get('public_passed')),",
+        "            'first_try_hidden_pass': bool(v1.get('hidden_passed')),",
+        "            'retried': False,",
+        "            'retry_hidden_pass': False,",
+        "        }",
+        "        if rec['first_try_public_pass'] and rec['first_try_hidden_pass']:",
+        "            rec['category'] = srs.SOLVED_FIRST_TRY",
+        "        elif rec['first_try_public_pass'] and not rec['first_try_hidden_pass']:",
+        "            rec['category'] = srs.PUBLIC_PASS_HIDDEN_FAIL",
+        "        else:",
+        "            code2 = extract_code(_gen(make_repair_prompt(p, code1, fail_text(v1))))",
+        "            v2 = verify(code2, p)",
+        "            rec['retried'] = True",
+        "            rec['retry_hidden_pass'] = bool(v2.get('public_passed') and v2.get('hidden_passed'))",
+        "            rec['category'] = srs.FIX_SOLVED if rec['retry_hidden_pass'] else srs.FIX_FAILED",
+        "        out.append(rec)",
+        "    return out",
+        "",
+        "model.eval()",
+        "print('Evaluating BASE staged retry loop (adapter disabled)...')",
+        "with model.disable_adapter():",
+        "    base_records = run_staged_model(eval_problems)",
+        "print('Evaluating TRAINED staged retry loop (adapter enabled)...')",
+        "trained_records = run_staged_model(eval_problems)",
+        "",
+        "Path(BASELINE_JSONL).write_text('\\n'.join(json.dumps(r) for r in base_records) + '\\n', encoding='utf-8')",
+        "Path(TRAINED_JSONL).write_text('\\n'.join(json.dumps(r) for r in trained_records) + '\\n', encoding='utf-8')",
+        "base_score = srs.score(base_records)",
+        "trained_score = srs.score(trained_records)",
+        "delta = srs.delta(base_records, trained_records)",
+        "print('\\nBASE')",
+        "print(srs.render(base_score))",
+        "print('\\nTRAINED')",
+        "print(srs.render(trained_score, delta))",
+        "print('\\njsonl:', BASELINE_JSONL, TRAINED_JSONL)",
+    ),
+    md(
+        "## Read this number first",
+        "",
+        "`repair_conversion` is the practical answer. If it stays near zero, the model still is not using",
+        "failure feedback well. If it rises without a regression spike, the retry-loop data helped.",
+    ),
+]
+
+
+def build() -> dict:
+    return {
+        "cells": CELLS,
+        "metadata": {
+            "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+            "language_info": {"name": "python"},
+            "accelerator": "GPU",
+            "colab": {"provenance": [], "gpuType": "T4"},
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+if __name__ == "__main__":
+    out = Path(__file__).with_name("vtc_retry_loop_colab.ipynb")
+    out.write_text(json.dumps(build(), indent=1, ensure_ascii=False), encoding="utf-8")
+    print("wrote", out, "with", len(CELLS), "cells")

--- a/notebooks/vtc_retry_loop_colab.ipynb
+++ b/notebooks/vtc_retry_loop_colab.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# VTC STAGED RETRY-LOOP Training -- qwen2.5-coder-1.5B, Colab T4\n",
+    "\n",
+    "Do not rerun the old `vtc_better_colab` here. This notebook tests the next hypothesis: train the model\n",
+    "on the full retry loop, not only final answers.\n",
+    "\n",
+    "Training supplement shape:\n",
+    "\n",
+    "- `bad -> FAIL -> self fix -> PASS`\n",
+    "- `bad -> FAIL -> fix attempt -> FAIL -> teacher correction`\n",
+    "\n",
+    "Evaluation emits the staged buckets directly:\n",
+    "\n",
+    "- `SOLVED_FIRST_TRY`\n",
+    "- `SOLVE_FAILED_FIX_ATTEMPT_SOLVED`\n",
+    "- `SOLVE_FAILED_FIX_ATTEMPT_FAILED`\n",
+    "- `PUBLIC_PASS_HIDDEN_FAIL_NO_RETRY`\n",
+    "\n",
+    "The metric that matters is `repair_conversion`: among first-failed problems where a retry happened,\n",
+    "how many did the retry actually recover?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install -q -U peft bitsandbytes accelerate datasets 'transformers>=4.44'\n",
+    "import torch\n",
+    "print('CUDA available:', torch.cuda.is_available())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Repo + base corpus upload\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, sys, json\n",
+    "!git clone --depth 1 https://github.com/issdandavis/SCBE-AETHERMOORE.git scbe || true\n",
+    "sys.path.insert(0, '/content/scbe')\n",
+    "CORPUS_PATH = '/content/vtc_mbpp_refined.jsonl'\n",
+    "if not os.path.exists(CORPUS_PATH):\n",
+    "    from google.colab import files\n",
+    "    up = files.upload(); CORPUS_PATH = '/content/' + next(iter(up))\n",
+    "os.environ['SCBE_VTC_CORPUS'] = CORPUS_PATH\n",
+    "print('corpus:', CORPUS_PATH)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Config\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "BASE_MODEL = 'Qwen/Qwen2.5-Coder-1.5B-Instruct'\n",
+    "OUT = '/content/vtc-retry-loop-run'\n",
+    "TRAIN_SFT = '/content/train.retry_mix.sft.jsonl'\n",
+    "RETRY_ONLY = '/content/train.retry_only.jsonl'\n",
+    "BASELINE_JSONL = '/content/vtc_staged_base.jsonl'\n",
+    "TRAINED_JSONL = '/content/vtc_staged_trained.jsonl'\n",
+    "PUBLIC_K = 1\n",
+    "EVAL_LIMIT = 40\n",
+    "SELF_REPAIR_LIMIT = 80\n",
+    "TEACHER_BAILOUT_LIMIT = 80\n",
+    "MAXLEN = 2048\n",
+    "EPOCHS = 2\n",
+    "MAX_NEW_TOKENS = 512\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Honest split + inject retry-loop supplement after the split\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from python.helm import public_bench as pb\n",
+    "from python.helm.vtc_split import load_corpus, split_by_task_id, write_train_sft\n",
+    "from python.helm.self_repair_corpus import verified_pool_from_vtc, synthesize_retry_mix, write_jsonl\n",
+    "from python.helm.retry_corpus_validate import validate as validate_retry, render as render_retry\n",
+    "\n",
+    "records = load_corpus(CORPUS_PATH)\n",
+    "problems = pb.pull_mbpp()\n",
+    "split = split_by_task_id(records, problems, public_k=PUBLIC_K)\n",
+    "eval_problems = split['eval_problems'][:EVAL_LIMIT] if EVAL_LIMIT else split['eval_problems']\n",
+    "assert not (split['train_ids'] & {p['task_id'] for p in eval_problems}), 'train/eval LEAK'\n",
+    "\n",
+    "# Build the retry supplement ONLY from train records. Held-out eval task_ids stay untouched.\n",
+    "pool = verified_pool_from_vtc(split['train_records'])\n",
+    "retry_mix = synthesize_retry_mix(pool, self_limit=SELF_REPAIR_LIMIT, teacher_limit=TEACHER_BAILOUT_LIMIT)\n",
+    "retry_records = retry_mix['records']\n",
+    "write_jsonl(RETRY_ONLY, retry_records)\n",
+    "train_records = list(split['train_records']) + retry_records\n",
+    "write_train_sft(train_records, TRAIN_SFT)\n",
+    "\n",
+    "print('base train records:', len(split['train_records']))\n",
+    "print('retry supplement:', retry_mix['self_records'], 'self-repair +', retry_mix['teacher_bailouts'], 'teacher-bailout')\n",
+    "print('final train records:', len(train_records), ' held-out eval:', len(eval_problems))\n",
+    "print(render_retry(validate_retry(retry_records)))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Load 4-bit model + LoRA adapter\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig\n",
+    "from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training\n",
+    "\n",
+    "bnb = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type='nf4',\n",
+    "                        bnb_4bit_compute_dtype=torch.bfloat16, bnb_4bit_use_double_quant=True)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL)\n",
+    "if tokenizer.pad_token is None: tokenizer.pad_token = tokenizer.eos_token\n",
+    "model = AutoModelForCausalLM.from_pretrained(BASE_MODEL, quantization_config=bnb, device_map='auto')\n",
+    "model = prepare_model_for_kbit_training(model)\n",
+    "model = get_peft_model(model, LoraConfig(r=16, lora_alpha=32, lora_dropout=0,\n",
+    "    target_modules=['q_proj','k_proj','v_proj','o_proj','gate_proj','up_proj','down_proj'],\n",
+    "    bias='none', task_type='CAUSAL_LM'))\n",
+    "model.print_trainable_parameters()\n",
+    "\n",
+    "def extract_code(text):\n",
+    "    blocks = re.findall(r'```(?:python)?\\s*(.*?)```', text or '', re.S)\n",
+    "    if blocks: return max(blocks, key=len).strip()\n",
+    "    body = re.sub(r'^\\s*```(?:python)?\\s*', '', (text or '').strip())\n",
+    "    lines = body.splitlines()\n",
+    "    for i, ln in enumerate(lines):\n",
+    "        if ln.lstrip().startswith(('def ', 'import ', 'from ', 'class ', '@')):\n",
+    "            return '\\n'.join(lines[i:]).strip()\n",
+    "    return body.strip()\n",
+    "\n",
+    "def _gen(prompt):\n",
+    "    text = tokenizer.apply_chat_template([{'role':'user','content':prompt}], tokenize=False, add_generation_prompt=True)\n",
+    "    enc = tokenizer(text, return_tensors='pt').to(model.device)\n",
+    "    out = model.generate(**enc, max_new_tokens=MAX_NEW_TOKENS, do_sample=False, pad_token_id=tokenizer.eos_token_id)\n",
+    "    return tokenizer.decode(out[0][enc['input_ids'].shape[1]:], skip_special_tokens=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Train on base corpus + retry supplement\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset\n",
+    "from transformers import Trainer, TrainingArguments, DataCollatorForLanguageModeling\n",
+    "train_ds = load_dataset('json', data_files=TRAIN_SFT, split='train')\n",
+    "def tok(ex):\n",
+    "    text = tokenizer.apply_chat_template(ex['messages'], tokenize=False, add_generation_prompt=False)\n",
+    "    return tokenizer(text, truncation=True, max_length=MAXLEN)\n",
+    "train_tok = train_ds.map(tok, remove_columns=train_ds.column_names)\n",
+    "args = TrainingArguments(output_dir=OUT, per_device_train_batch_size=2, gradient_accumulation_steps=8,\n",
+    "    num_train_epochs=EPOCHS, learning_rate=2e-4, warmup_ratio=0.05, lr_scheduler_type='cosine',\n",
+    "    logging_steps=10, bf16=True, optim='paged_adamw_8bit', report_to='none', save_strategy='no')\n",
+    "Trainer(model=model, args=args, train_dataset=train_tok,\n",
+    "        data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False)).train()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Staged retry-loop eval: base vs trained\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from python.helm import public_bench as _pb\n",
+    "from python.helm import staged_retry_score as srs\n",
+    "\n",
+    "def make_prompt(problem):\n",
+    "    public = '\\n'.join(list(problem.get('test_list', []))[:PUBLIC_K])\n",
+    "    return ((problem.get('prompt') or problem.get('text') or '').strip()\n",
+    "            + '\\n\\nWrite a complete Python solution. It must make this example pass:\\n'\n",
+    "            + public + '\\nReturn ONLY the code.')\n",
+    "\n",
+    "def make_repair_prompt(problem, code, fail_msg):\n",
+    "    public = '\\n'.join(list(problem.get('test_list', []))[:PUBLIC_K])\n",
+    "    return ((problem.get('prompt') or problem.get('text') or '').strip()\n",
+    "            + '\\n\\nYour previous code failed this visible check:\\n' + public\n",
+    "            + '\\nFailure feedback:\\n' + str(fail_msg)\n",
+    "            + '\\n\\nPrevious code:\\n```python\\n' + code + '\\n```'\n",
+    "            + '\\n\\nRepair it. Return ONLY corrected Python code.')\n",
+    "\n",
+    "def verify(code, p):\n",
+    "    tests = list(p.get('test_list', []))\n",
+    "    return _pb._verify(code, tests[:PUBLIC_K], tests[PUBLIC_K:], p.get('test_imports', []))\n",
+    "\n",
+    "def fail_text(v):\n",
+    "    return v.get('error') or v.get('public_error') or v.get('stderr') or 'visible test failed'\n",
+    "\n",
+    "def run_staged_model(eval_problems):\n",
+    "    out = []\n",
+    "    for p in eval_problems:\n",
+    "        code1 = extract_code(_gen(make_prompt(p)))\n",
+    "        v1 = verify(code1, p)\n",
+    "        rec = {\n",
+    "            'task_id': p.get('task_id'),\n",
+    "            'first_try_public_pass': bool(v1.get('public_passed')),\n",
+    "            'first_try_hidden_pass': bool(v1.get('hidden_passed')),\n",
+    "            'retried': False,\n",
+    "            'retry_hidden_pass': False,\n",
+    "        }\n",
+    "        if rec['first_try_public_pass'] and rec['first_try_hidden_pass']:\n",
+    "            rec['category'] = srs.SOLVED_FIRST_TRY\n",
+    "        elif rec['first_try_public_pass'] and not rec['first_try_hidden_pass']:\n",
+    "            rec['category'] = srs.PUBLIC_PASS_HIDDEN_FAIL\n",
+    "        else:\n",
+    "            code2 = extract_code(_gen(make_repair_prompt(p, code1, fail_text(v1))))\n",
+    "            v2 = verify(code2, p)\n",
+    "            rec['retried'] = True\n",
+    "            rec['retry_hidden_pass'] = bool(v2.get('public_passed') and v2.get('hidden_passed'))\n",
+    "            rec['category'] = srs.FIX_SOLVED if rec['retry_hidden_pass'] else srs.FIX_FAILED\n",
+    "        out.append(rec)\n",
+    "    return out\n",
+    "\n",
+    "model.eval()\n",
+    "print('Evaluating BASE staged retry loop (adapter disabled)...')\n",
+    "with model.disable_adapter():\n",
+    "    base_records = run_staged_model(eval_problems)\n",
+    "print('Evaluating TRAINED staged retry loop (adapter enabled)...')\n",
+    "trained_records = run_staged_model(eval_problems)\n",
+    "\n",
+    "Path(BASELINE_JSONL).write_text('\\n'.join(json.dumps(r) for r in base_records) + '\\n', encoding='utf-8')\n",
+    "Path(TRAINED_JSONL).write_text('\\n'.join(json.dumps(r) for r in trained_records) + '\\n', encoding='utf-8')\n",
+    "base_score = srs.score(base_records)\n",
+    "trained_score = srs.score(trained_records)\n",
+    "delta = srs.delta(base_records, trained_records)\n",
+    "print('\\nBASE')\n",
+    "print(srs.render(base_score))\n",
+    "print('\\nTRAINED')\n",
+    "print(srs.render(trained_score, delta))\n",
+    "print('\\njsonl:', BASELINE_JSONL, TRAINED_JSONL)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read this number first\n",
+    "\n",
+    "`repair_conversion` is the practical answer. If it stays near zero, the model still is not using\n",
+    "failure feedback well. If it rises without a regression spike, the retry-loop data helped.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU",
+  "colab": {
+   "provenance": [],
+   "gpuType": "T4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/helm/better_corpus.py
+++ b/python/helm/better_corpus.py
@@ -89,6 +89,57 @@ PITFALLS: List[Dict[str, Any]] = [
         "fix": "def make_adders():\n    return [lambda i=i: i for i in range(3)]",
         "tests": ["assert [f() for f in make_adders()] == [0, 1, 2]"],
     },
+    {
+        "name": "list_multiplication_shared_rows",
+        "prompt": "Write make_grid(rows, cols) returning a rows x cols grid of 0s where setting grid[0][0]=1 "
+        "changes ONLY grid[0][0].",
+        "buggy": "def make_grid(rows, cols):\n    return [[0] * cols] * rows",
+        "fix": "def make_grid(rows, cols):\n    return [[0] * cols for _ in range(rows)]",
+        "tests": ["g = make_grid(2, 2)\ng[0][0] = 1\nassert g == [[1, 0], [0, 0]]"],
+    },
+    {
+        "name": "sort_returns_none",
+        "prompt": "Write sorted_copy(xs) returning a NEW sorted list of xs WITHOUT modifying xs.",
+        "buggy": "def sorted_copy(xs):\n    return xs.sort()",
+        "fix": "def sorted_copy(xs):\n    return sorted(xs)",
+        "tests": ["assert sorted_copy([3, 1, 2]) == [1, 2, 3]", "a = [3, 1, 2]\nsorted_copy(a)\nassert a == [3, 1, 2]"],
+    },
+    {
+        "name": "dedup_loses_order",
+        "prompt": "Write dedup(xs) returning xs with duplicates removed, PRESERVING first-seen order.",
+        "buggy": "def dedup(xs):\n    return list(set(xs))",
+        "fix": "def dedup(xs):\n    return list(dict.fromkeys(xs))",
+        "tests": ["assert dedup([3, 1, 3, 2, 1]) == [3, 1, 2]"],
+    },
+    {
+        "name": "string_immutable_inplace",
+        "prompt": "Write set_first(s, c) returning s with its first character replaced by c (s is non-empty).",
+        "buggy": "def set_first(s, c):\n    s[0] = c\n    return s",
+        "fix": "def set_first(s, c):\n    return c + s[1:]",
+        "tests": ["assert set_first('cat', 'b') == 'bat'"],
+    },
+    {
+        "name": "shallow_copy_nested",
+        "prompt": "Write copy_grid(g) returning an INDEPENDENT copy of the 2D list g (mutating the copy must "
+        "not change g).",
+        "buggy": "def copy_grid(g):\n    return g[:]",
+        "fix": "def copy_grid(g):\n    return [row[:] for row in g]",
+        "tests": ["g = [[1, 2], [3, 4]]\nc = copy_grid(g)\nc[0][0] = 9\nassert g == [[1, 2], [3, 4]]"],
+    },
+    {
+        "name": "chained_comparison_misuse",
+        "prompt": "Write in_range(x) returning True iff 1 <= x <= 10.",
+        "buggy": "def in_range(x):\n    return 1 <= x <= 10 == True",
+        "fix": "def in_range(x):\n    return 1 <= x <= 10",
+        "tests": ["assert in_range(5) == True", "assert in_range(11) == False"],
+    },
+    {
+        "name": "recursion_missing_base_case",
+        "prompt": "Write factorial(n) returning n! for n >= 0 (factorial(0) == 1).",
+        "buggy": "def factorial(n):\n    return n * factorial(n - 1)",
+        "fix": "def factorial(n):\n    if n <= 1:\n        return 1\n    return n * factorial(n - 1)",
+        "tests": ["assert factorial(0) == 1", "assert factorial(5) == 120"],
+    },
 ]
 
 

--- a/python/helm/self_repair_corpus.py
+++ b/python/helm/self_repair_corpus.py
@@ -2,16 +2,20 @@
 
 retry_corpus_validate showed the v3 retry-teacher corpus is ~100% teacher-bailout -> it trains teacher-
 DEPENDENCE, not self-repair. This builds the missing half: SELF_REPAIR_SUCCESS trajectories (bad attempt ->
-REAL test failure -> critique + fix -> PASS), synthesized from already-verified solutions by deterministically
-MUTATING the good code into a failing variant and KEEPING only mutations that genuinely fail the example
-while the good code genuinely passes -- both checked by RUNNING them. No model, no network: $0 and honest --
-every emitted trajectory's failure and its recovery are real executions, not asserted ([[train-on-becoming]]).
+REAL test failure -> critique + fix -> PASS), and can also synthesize the complementary TEACHER_BAILOUT
+shape (bad attempt -> REAL failure -> fix attempt -> REAL failure -> teacher correction). Both are
+synthesized from already-verified solutions by deterministically MUTATING the good code into failing
+variants and KEEPING only mutations that genuinely fail the example while the good code genuinely passes --
+all checked by RUNNING them. No model, no network: $0 and honest -- every emitted trajectory's failure and
+its recovery/correction are real executions, not asserted ([[train-on-becoming]]).
 
 SECURITY: this exec()s code from a LOCAL, already-verified corpus (trusted input), never network input --
 unlike an MCP surface. Do not point it at untrusted code.
 
     python -m python.helm.self_repair_corpus --corpus teacher_heavy.jsonl --pool vtc_fixture.jsonl \\
         --out balanced.jsonl --target 0.4
+    python -m python.helm.self_repair_corpus --mix --pool vtc_fixture.jsonl --out retry_mix.jsonl \\
+        --self-limit 80 --teacher-limit 80
 """
 
 from __future__ import annotations
@@ -70,21 +74,32 @@ _MUTATORS: List[Tuple[str, Any]] = [
 ]
 
 
-def make_failing_variant(good_code: str, assert_line: str) -> Optional[Tuple[str, str, str]]:
-    """Return (bad_code, mutator_name, fail_msg) for the first mutation that COMPILES, genuinely FAILS the
-    example, and differs from the good code. None if no mutator yields a clean failing variant."""
+def make_failing_variants(good_code: str, assert_line: str, limit: Optional[int] = None) -> List[Tuple[str, str, str]]:
+    """Return clean, distinct failing variants as (bad_code, mutator_name, fail_msg). Each variant compiles,
+    genuinely FAILS the example, and differs from the good code."""
+    variants: List[Tuple[str, str, str]] = []
+    seen = {good_code}
     for name, mut in _MUTATORS:
         bad = mut(good_code)
-        if not bad or bad == good_code:
+        if not bad or bad in seen:
             continue
+        seen.add(bad)
         try:
             ast.parse(bad)  # a realistic near-miss is valid code that fails, not a syntax error
         except SyntaxError:
             continue
         passed, msg = runs_ok(bad, assert_line)
         if not passed:
-            return bad, name, msg or "AssertionError"
-    return None
+            variants.append((bad, name, msg or "AssertionError"))
+            if limit and len(variants) >= limit:
+                break
+    return variants
+
+
+def make_failing_variant(good_code: str, assert_line: str) -> Optional[Tuple[str, str, str]]:
+    """Return the first clean failing variant, or None if no mutator yields one."""
+    variants = make_failing_variants(good_code, assert_line, limit=1)
+    return variants[0] if variants else None
 
 
 def make_self_repair_record(problem: str, good: str, bad: str, mutator: str, fail_msg: str, task_id: Any) -> Dict:
@@ -103,6 +118,48 @@ def make_self_repair_record(problem: str, good: str, bad: str, mutator: str, fai
             "final_source": "self",
             "repaired": True,
             "source": "self_repair_synth",
+            "task_id": task_id,
+        },
+    }
+
+
+def make_teacher_bailout_record(
+    problem: str,
+    good: str,
+    first_bad: str,
+    first_mutator: str,
+    first_fail: str,
+    second_bad: str,
+    second_mutator: str,
+    second_fail: str,
+    task_id: Any,
+) -> Dict:
+    """One TEACHER_BAILOUT trajectory: bad attempt -> fail -> fix attempt -> fail -> teacher correction.
+    The teacher correction is deliberately delayed until after the second failed attempt, so the record trains
+    the retry loop shape before it gives the full answer."""
+    return {
+        "messages": [
+            {"role": "system", "content": SYSTEM},
+            {"role": "user", "content": problem},
+            {"role": "assistant", "content": first_bad},
+            {"role": "user", "content": "Test run FAILED: %s\nTry again using the failure as feedback." % first_fail},
+            {
+                "role": "assistant",
+                "content": "I changed the likely bug ('%s'), but this is still my own fix attempt:\n%s"
+                % (first_mutator, second_bad),
+            },
+            {
+                "role": "user",
+                "content": "Second test run FAILED: %s\nTeacher correction follows because two attempts failed."
+                % second_fail,
+            },
+            {"role": "teacher", "content": "Reference solution after two failed attempts:\n%s" % good},
+        ],
+        "meta": {
+            "grade": "teacher",
+            "final_source": "teacher",
+            "repaired": False,
+            "source": "retry_teacher_synth",
             "task_id": task_id,
         },
     }
@@ -141,6 +198,55 @@ def synthesize(pool: Sequence[Tuple[str, str, str, Any]], limit: Optional[int] =
     return out
 
 
+def synthesize_teacher_bailouts(pool: Sequence[Tuple[str, str, str, Any]], limit: Optional[int] = None) -> List[Dict]:
+    """Build execution-verified two-failure teacher-bailout records from the same verified pool. Skips entries
+    unless the good code passes and two distinct clean failing variants are available."""
+    out: List[Dict] = []
+    for problem, good, assert_line, task_id in pool:
+        ok, _ = runs_ok(good, assert_line)
+        if not ok:
+            continue
+        variants = make_failing_variants(good, assert_line, limit=2)
+        if len(variants) < 2:
+            continue
+        first_bad, first_mutator, first_fail = variants[0]
+        second_bad, second_mutator, second_fail = variants[1]
+        out.append(
+            make_teacher_bailout_record(
+                problem,
+                good,
+                first_bad,
+                first_mutator,
+                first_fail,
+                second_bad,
+                second_mutator,
+                second_fail,
+                task_id,
+            )
+        )
+        if limit and len(out) >= limit:
+            break
+    return out
+
+
+def synthesize_retry_mix(
+    pool: Sequence[Tuple[str, str, str, Any]],
+    self_limit: Optional[int] = None,
+    teacher_limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return a balanced retry-loop training supplement with both outcomes the model needs to see:
+    SELF_REPAIR_SUCCESS and TEACHER_BAILOUT after a second failed attempt."""
+    self_records = synthesize(pool, limit=self_limit)
+    teacher_records = synthesize_teacher_bailouts(pool, limit=teacher_limit)
+    records = self_records + teacher_records
+    return {
+        "records": records,
+        "self_records": len(self_records),
+        "teacher_bailouts": len(teacher_records),
+        "validation": rcv.validate(records),
+    }
+
+
 def augment(
     corpus: Sequence[Dict], pool: Sequence[Tuple[str, str, str, Any]], target_self_ratio: float = 0.4
 ) -> Tuple[List[Dict], Dict]:
@@ -176,12 +282,32 @@ def write_jsonl(path: str, records: Sequence[Dict]) -> None:
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     ap = argparse.ArgumentParser(description="rebalance a teacher-heavy retry corpus with verified self-repair traces")
-    ap.add_argument("--corpus", required=True, help="the teacher-bailout-heavy retry corpus jsonl to rebalance")
+    ap.add_argument("--corpus", default=None, help="the teacher-bailout-heavy retry corpus jsonl to rebalance")
     ap.add_argument("--pool", required=True, help="a verified-solution corpus (e.g. vtc_fixture.jsonl) to synth from")
     ap.add_argument("--out", default=None, help="write the rebalanced corpus here")
     ap.add_argument("--target", type=float, default=0.4, help="target self_repair_success_ratio")
+    ap.add_argument(
+        "--mix",
+        action="store_true",
+        help="write only a fresh retry supplement: self-repair successes + two-failure teacher bailouts",
+    )
+    ap.add_argument("--self-limit", type=int, default=None, help="max self-repair records for --mix")
+    ap.add_argument("--teacher-limit", type=int, default=None, help="max teacher-bailout records for --mix")
     a = ap.parse_args(argv)
     pool = verified_pool_from_vtc(load_jsonl(a.pool))
+    if a.mix:
+        report = synthesize_retry_mix(pool, self_limit=a.self_limit, teacher_limit=a.teacher_limit)
+        print(
+            "retry mix: %d self-repair + %d teacher-bailout = %d records"
+            % (report["self_records"], report["teacher_bailouts"], len(report["records"]))
+        )
+        print(rcv.render(report["validation"]))
+        if a.out:
+            write_jsonl(a.out, report["records"])
+            print("wrote %d records -> %s" % (len(report["records"]), a.out))
+        return 0
+    if not a.corpus:
+        ap.error("--corpus is required unless --mix is set")
     new, report = augment(load_jsonl(a.corpus), pool, a.target)
     print(
         "self-repair augmentation: %.3f -> %.3f (added %d of %d available; target %.2f %s)"

--- a/tests/test_self_repair_corpus.py
+++ b/tests/test_self_repair_corpus.py
@@ -38,6 +38,24 @@ def test_synthesized_record_validates_as_self_repair_success():
     assert rcv.analyze_record(rec)["category"] == rcv.SELF_REPAIR_SUCCESS
 
 
+def test_teacher_bailout_record_waits_until_second_failure():
+    rec = src.make_teacher_bailout_record(
+        "Add two numbers.\n%s" % ASSERT,
+        GOOD,
+        "def add(a,b): return a-b",
+        "flip +/-",
+        "AssertionError",
+        "def add(a,b): return None",
+        "return -> return None",
+        "AssertionError",
+        task_id=2,
+    )
+    analysis = rcv.analyze_record(rec)
+    assert analysis["category"] == rcv.TEACHER_BAILOUT
+    assert sum(1 for m in rec["messages"] if m["role"] == "assistant") == 2
+    assert rec["messages"][-1]["role"] == "teacher"
+
+
 def test_extract_example_and_pool_from_vtc_shape():
     vtc = [
         {
@@ -63,6 +81,22 @@ def test_synthesize_only_emits_verified_trajectories():
     assert len(recs) == 1
     # every emitted record is a real self-repair success (bad fails, good passes, validated)
     assert all(rcv.analyze_record(r)["category"] == rcv.SELF_REPAIR_SUCCESS for r in recs)
+
+
+def test_synthesize_teacher_bailouts_emits_verified_two_failure_shape():
+    pool = [("Add.\n%s" % ASSERT, GOOD, ASSERT, 1)]
+    recs = src.synthesize_teacher_bailouts(pool)
+    assert len(recs) == 1
+    assert all(rcv.analyze_record(r)["category"] == rcv.TEACHER_BAILOUT for r in recs)
+
+
+def test_synthesize_retry_mix_contains_success_and_bailout():
+    pool = [("Add.\n%s" % ASSERT, GOOD, ASSERT, i) for i in range(3)]
+    mix = src.synthesize_retry_mix(pool, self_limit=2, teacher_limit=2)
+    assert mix["self_records"] == 2
+    assert mix["teacher_bailouts"] == 2
+    assert mix["validation"]["counts"][rcv.SELF_REPAIR_SUCCESS] == 2
+    assert mix["validation"]["counts"][rcv.TEACHER_BAILOUT] == 2
 
 
 def test_augment_raises_self_ratio_above_the_warning_threshold():


### PR DESCRIPTION
Adds the next VTC training path after the already-run better-corpus notebook. This builds a staged retry-loop supplement with both self-repair successes and two-failure teacher-bailout records, then adds a Colab notebook that trains on the mixed corpus and reports staged retry metrics: SOLVED_FIRST_TRY, SOLVE_FAILED_FIX_ATTEMPT_SOLVED, SOLVE_FAILED_FIX_ATTEMPT_FAILED, PUBLIC_PASS_HIDDEN_FAIL_NO_RETRY, repair_conversion, newly_repaired, and regressions.\n\nVerification:\n- python notebooks/build_vtc_retry_loop_nb.py\n- python -m pytest tests/test_self_repair_corpus.py tests/test_retry_corpus_validate.py tests/test_staged_retry_score.py tests/test_self_repair_harness.py -q