### PR TITLE
feat(corpus): harder algorithmic tier for better_corpus (15 -> 19 verified traces)

### DIFF
--- a/python/helm/better_corpus.py
+++ b/python/helm/better_corpus.py
@@ -140,6 +140,57 @@ PITFALLS: List[Dict[str, Any]] = [
         "fix": "def factorial(n):\n    if n <= 1:\n        return 1\n    return n * factorial(n - 1)",
         "tests": ["assert factorial(0) == 1", "assert factorial(5) == 120"],
     },
+    # Harder ALGORITHMIC tier: these are capability bugs (DP, edge cases, invariants), not syntax the
+    # base already knows. Modeled on the recorded failure cluster (coin-change DP, rotate-left modulo). A
+    # strong coder base can recite "mutable default arg"; these are where it actually slips.
+    {
+        "name": "coin_change_max_greedy_fails",
+        "prompt": "Write max_coins(coins, amount): the MAXIMUM number of coins summing to exactly amount, "
+        "or -1 if impossible.",
+        "buggy": "def max_coins(coins, amount):\n    coins = sorted(coins)\n    n = 0\n    for c in coins:\n"
+        "        while amount >= c:\n            amount -= c\n            n += 1\n    return n if amount == 0 else -1",
+        "fix": "def max_coins(coins, amount):\n    dp = [-1] * (amount + 1)\n    dp[0] = 0\n"
+        "    for a in range(1, amount + 1):\n        for c in coins:\n            if c <= a and dp[a - c] != -1:\n"
+        "                dp[a] = max(dp[a], dp[a - c] + 1)\n    return dp[amount]",
+        "tests": ["assert max_coins([3, 5], 11) == 3", "assert max_coins([2], 3) == -1"],
+    },
+    {
+        "name": "rotate_left_no_modulo",
+        "prompt": "Write rotate_left(s, k) returning s rotated left by k positions (k may exceed len(s)).",
+        "buggy": "def rotate_left(s, k):\n    return s[k:] + s[:k]",
+        "fix": "def rotate_left(s, k):\n    if not s:\n        return s\n    k %= len(s)\n    return s[k:] + s[:k]",
+        "tests": [
+            "assert rotate_left('abcd', 1) == 'bcda'",
+            "assert rotate_left('abcd', 5) == 'bcda'",
+            "assert rotate_left('', 3) == ''",
+        ],
+    },
+    {
+        "name": "balanced_parens_no_underflow_check",
+        "prompt": "Write balanced(s) returning True iff the parentheses in s (chars ( and ) only) are balanced.",
+        "buggy": "def balanced(s):\n    depth = 0\n    for c in s:\n        if c == '(':\n            depth += 1\n"
+        "        else:\n            depth -= 1\n    return depth == 0",
+        "fix": "def balanced(s):\n    depth = 0\n    for c in s:\n        if c == '(':\n            depth += 1\n"
+        "        else:\n            depth -= 1\n            if depth < 0:\n                return False\n"
+        "    return depth == 0",
+        "tests": [
+            "assert balanced('(())') == True",
+            "assert balanced(')(') == False",
+            "assert balanced('(()') == False",
+        ],
+    },
+    {
+        "name": "two_sum_reuses_one_element",
+        "prompt": "Write two_sum(nums, target) returning indices [i, j] with i<j of two DISTINCT elements "
+        "summing to target, else [].",
+        "buggy": "def two_sum(nums, target):\n    for i in range(len(nums)):\n"
+        "        for j in range(i, len(nums)):\n            if nums[i] + nums[j] == target:\n"
+        "                return [i, j]\n    return []",
+        "fix": "def two_sum(nums, target):\n    for i in range(len(nums)):\n"
+        "        for j in range(i + 1, len(nums)):\n            if nums[i] + nums[j] == target:\n"
+        "                return [i, j]\n    return []",
+        "tests": ["assert two_sum([3, 2, 4], 6) == [1, 2]", "assert two_sum([3, 1], 6) == []"],
+    },
 ]
 
 


### PR DESCRIPTION
## What

The `better_corpus` traces so far are **syntax/idiom** pitfalls a strong coder base already knows (`mutable_default_arg`, `off_by_one_range`) → ~0 lift expected. This adds a **harder algorithmic tier** of *capability* bugs, modeled on the recorded failure cluster (coin-change DP, rotate-left modulo) — where a 3B coder model actually slips:

| trace | the real bug |
|---|---|
| `coin_change_max_greedy_fails` | greedy ≠ DP for max-coins (greedy returns `-1` where DP returns `3`) |
| `rotate_left_no_modulo` | `k` may exceed `len(s)`; empty-string edge |
| `balanced_parens_no_underflow_check` | the depth-never-negative invariant; `')('` is the witness the naive `depth==0` check misses |
| `two_sum_reuses_one_element` | `j` must start at `i+1`, not `i` (distinct-index bug) |

All 4 **execution-verified** — the buggy code fails its tests, the fix passes. Nothing unverified enters the corpus.

## Honest scope

A verified trace does **not** guarantee a lift. The lift ceiling is set by the eval's headroom and the base's gaps, not the trace count — if MBPP is saturated for the base, the measured delta stays small no matter how good the data is. The right fix for a small result is to **also move the eval onto problems with headroom** (this cluster), not only to grow the corpus.

## Tests

19/19 traces verified (`verify_pitfall`: buggy_fails ∧ fix_passes), 5/5 in `tests/test_better_corpus.py`. flake8 clean. Single-concern: only `python/helm/better_corpus.py`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>