### PR TITLE
feat(browser): AI-browser stack + run-skill + audit fixes (re-land orphaned #2619 commits)

### DIFF
--- a/.claude/skills/run-ai-browser/SKILL.md
+++ b/.claude/skills/run-ai-browser/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: run-ai-browser
+description: Build, run, screenshot, and drive the SCBE AI browser (python/scbe/ai_browser.py + browser_{controller,grid,map,camera,autodrive}.py). Use when asked to run/launch/drive/screenshot the AI browser, browse a site headlessly, observe a page as data, or autonomously fill+submit+navigate a website.
+---
+
+# Run the SCBE AI browser
+
+The AI browser turns a website into a bounded, observable, steerable surface: a **data feed** (`read`),
+a **bounded move set** (`act`), a per-site **sudoku coordinate grid**, a StarCraft-style **document map**
+(whole-page minimap + 3-state fog + `move_camera`), and an **autonomous on_step driver** (`AutoDriver`)
+that runs high-level intents and returns an honest trace. It drives an **isolated headless Chrome** via
+Playwright — it never touches your real browser.
+
+The agent path is **one driver script** that exercises the whole stack against a real site and writes a
+screenshot. Paths below are relative to the repo root (the worktree dir, e.g. `slice-wt/`).
+
+## Prerequisites
+
+Python ≥ 3.11, Google Chrome installed, and Playwright (the Python package only — the driver launches the
+system Chrome via `channel='chrome'`, so no `playwright install` browser download is needed):
+
+```bash
+pip install playwright
+```
+
+Verify Chrome is launchable headless (this is the exact check I ran):
+
+```bash
+python -c "from playwright.sync_api import sync_playwright; p=sync_playwright().start(); b=p.chromium.launch(headless=True, channel='chrome'); print('chrome OK', b.version); b.close(); p.stop()"
+```
+
+## Run (agent path) — the driver
+
+Drive the full stack end-to-end (launch → observe → screenshot → autonomously search+navigate → camera),
+from the repo root:
+
+```bash
+PYTHONPATH=. python .claude/skills/run-ai-browser/driver.py
+```
+
+It prints 5 stages and writes a gridded screenshot to `artifacts/ai_browser_view.png`. Real output from
+this container:
+
+```
+[1] LAUNCH    https://en.wikipedia.org/wiki/Main_Page
+    page: 'Wikipedia, the free encyclopedia' | interactive elements: 262
+[2] OBSERVE   document 1280x3792 px | viewport rect ['A1', 'A2', 'A3', 'B1']
+    fog: {'hidden': 59, 'seen': 0, 'visible': 26} | available_actions: 144 (59 move_camera) | map cells: 42
+[3] VIEW      gridded screenshot -> .../artifacts/ai_browser_view.png (270188 bytes) | occupied cells: ['A1', 'A2', 'A5', ...]
+[4] DRIVE     task='Hyperbolic geometry'
+      [OK] fill 'search' <- 'Hyperbolic geometry' Search Wikipedia
+      [OK] submit
+      [OK] assert_url <- 'Hyperbolic'         https://en.wikipedia.org/wiki/Hyperb
+    success: True | landed: https://en.wikipedia.org/wiki/Hyperbolic_geometry
+[5] CAMERA    move_camera(C12): scroll y 0 -> 18985 (camera panned down the document)
+
+END-TO-END OK  screenshot: .../artifacts/ai_browser_view.png
+```
+
+The screenshot is the live page with the coordinate grid overlaid (red grid lines, blue cells on every
+interactive element) — open `artifacts/ai_browser_view.png` to view it.
+
+Drive a different site / task:
+
+```bash
+PYTHONPATH=. python .claude/skills/run-ai-browser/driver.py --url https://en.wikipedia.org/wiki/Main_Page --task "Rubik's Cube" --out artifacts/rubik.png
+```
+
+## Direct invocation (drive it from code)
+
+Most PRs touch the modules directly. Import and drive without the full demo:
+
+```bash
+PYTHONPATH=. python -c "
+from python.scbe.ai_browser import AIBrowser
+from python.scbe.browser_autodrive import AutoDriver, fill, submit, assert_url
+with AIBrowser(headless=True) as br:
+    drv = AutoDriver(br, br.open('https://en.wikipedia.org/wiki/Main_Page'))
+    res = drv.run([fill('search','Hyperbolic geometry'), submit(), assert_url('Hyperbolic')])
+    print(res['success'], res['final_url'])
+"
+```
+
+Key entry points (all in `python/scbe/`): `AIBrowser.read/act/park/snapshot`, `browser_grid.grid_map` +
+`render_grid`, `browser_map.MapView.observe`, `browser_camera.Camera.observe`/`move_camera`,
+`browser_autodrive.AutoDriver.run`.
+
+## Test
+
+The execution-verified suite (32 tests; most run a real headless Chrome, all skip cleanly if none):
+
+```bash
+PYTHONPATH=. python -m pytest tests/test_ai_browser.py tests/test_browser_controller.py tests/test_browser_grid.py tests/test_browser_map.py tests/test_browser_camera.py tests/test_browser_autodrive.py -q
+```
+
+## Gotchas (battle scars from driving real sites)
+
+- **Refs go stale on re-render.** Real sites swap elements out after you type (Wikipedia replaces its
+  search input), detaching the `data-aibref` element. Never cache a ref across an action — re-`read()`
+  each step (`AutoDriver` does). For submit, use `Move('submit')` (presses Enter on whatever is **focused**),
+  not Enter on a ref — the ref may already be gone.
+- **URLs percent-encode.** `Rubik's` becomes `Rubik%27s` and spaces become `%20`, so a naive
+  `assert_url("Rubik's")` fails on a page it actually reached. Assert on alphanumeric tokens (`Rubik`).
+- **`scrollIntoView` doesn't move sticky/fixed elements.** Some "off-screen" elements are in a sticky
+  header/footer; scrolling to them by ref does nothing. To guarantee a pan, `move_camera` by **doc-cell
+  label** (`"C12"` → `window.scrollTo`), not by element ref.
+- **System Chrome, not a download.** `channel='chrome'` launches the installed Google Chrome, so you skip
+  the ~150 MB `playwright install chromium`. The profile is **isolated** (a fresh temp profile) — it cannot
+  see or disturb your real browser's tabs/login.
+- **Headless by default.** `--headed` needs a real display; in a headless container stay headless.
+- **Do NOT point this at Colab/Google login.** The isolated profile isn't signed in and Google blocks
+  automated credential entry — that's a separate, fragile path (`tools/colab/`), not this driver.
+
+## Troubleshooting
+
+- `ModuleNotFoundError: No module named 'python'` → run from the **repo root** with `PYTHONPATH=.`.
+- `playwright ... has no attribute` / import error → `pip install playwright`.
+- Chrome won't launch (`channel='chrome'` not found) → install Google Chrome, or `playwright install
+  chromium` and change `channel='chrome'` to `channel='chromium'` in `AIBrowser.__enter__`.
+- Tests all **skip** with "no launchable browser" → Chrome isn't installed; install it (the logic is
+  intentional so CI without a browser doesn't hang).

--- a/.claude/skills/run-ai-browser/driver.py
+++ b/.claude/skills/run-ai-browser/driver.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""driver.py -- launch + drive the SCBE AI browser end-to-end, as a user would.
+
+The AI browser (python/scbe/ai_browser.py + browser_{controller,grid,map,camera,autodrive}.py) turns a
+website into a bounded, observable, steerable surface. This driver exercises the WHOLE stack against a real
+site headlessly and produces a screenshot on disk, so a future agent can confirm it actually works without
+reading the code:
+
+  1. launch an isolated headless Chrome (AIBrowser)
+  2. OBSERVE  -- the SC2-style document observation (PageMinimap + 3-state fog + available_actions)
+  3. VIEW     -- render the per-site coordinate-grid screenshot to --out (this is the screenshot artifact)
+  4. DRIVE    -- the autonomous on_step loop: given intents, find the search box, type, submit, verify
+  5. CAMERA   -- on the (tall) result page, move_camera an off-screen element into view
+
+Run from the repo root:
+    PYTHONPATH=. python .claude/skills/run-ai-browser/driver.py
+    PYTHONPATH=. python .claude/skills/run-ai-browser/driver.py --url https://en.wikipedia.org/wiki/Main_Page \
+        --task "Hyperbolic geometry" --out artifacts/ai_browser_view.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# allow running from anywhere: add the repo root (4 levels up) so python.scbe.* imports resolve
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+
+from python.scbe.ai_browser import AIBrowser  # noqa: E402
+from python.scbe.browser_autodrive import AutoDriver, assert_url, fill, submit  # noqa: E402
+from python.scbe.browser_camera import Camera  # noqa: E402
+from python.scbe.browser_grid import render_grid  # noqa: E402
+from python.scbe.browser_map import MapView  # noqa: E402
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="run-ai-browser", description="drive the SCBE AI browser end-to-end")
+    ap.add_argument("--url", default="https://en.wikipedia.org/wiki/Main_Page")
+    ap.add_argument("--task", default="Hyperbolic geometry", help="search query to autonomously run")
+    ap.add_argument("--out", default="artifacts/ai_browser_view.png", help="gridded screenshot path")
+    ap.add_argument("--headed", action="store_true", help="show the browser window (default headless)")
+    a = ap.parse_args(argv)
+
+    out = (ROOT / a.out) if not Path(a.out).is_absolute() else Path(a.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    with AIBrowser(headless=not a.headed) as br:
+        page = br.open(a.url)
+        page.set_viewport_size({"width": 1280, "height": 800})
+        feed = br.read(page)
+        print("[1] LAUNCH    %s" % a.url)
+        print("    page: %r | interactive elements: %d" % (feed["title"][:50], len(feed["elements"])))
+
+        # [2] OBSERVE -- the document camera (whole-page minimap + 3-state fog + legal actions)
+        cam = Camera(br, page)
+        obs = cam.observe()
+        mv = MapView(feed)
+        print("[2] OBSERVE   document %dx%d px | viewport rect %s" % (
+            obs["minimap"]["doc"]["w"], obs["minimap"]["doc"]["h"], obs["viewport_rect"][:4]))
+        print("    fog: %s | available_actions: %d (%d move_camera) | map cells: %d" % (
+            obs["fog"], len(obs["available_actions"]),
+            sum(1 for x in obs["available_actions"] if x.startswith("move_camera")),
+            len(mv.observe()["minimap"]["occupied"])))
+
+        # [3] VIEW -- the per-site coordinate-grid screenshot (the artifact)
+        shot = render_grid(br, page, str(out))
+        print("[3] VIEW      gridded screenshot -> %s (%d bytes) | occupied cells: %s ..." % (
+            shot["path"], out.stat().st_size, shot["occupied_cells"][:6]))
+
+        # [4] DRIVE -- the autonomous on_step loop, by intent
+        drv = AutoDriver(br, page)
+        # assert on the first word, alphanumerics only -- URLs percent-encode apostrophes/spaces
+        first = "".join(ch for ch in a.task.split()[0] if ch.isalnum())
+        res = drv.run([fill("search", a.task), submit(), assert_url(first)])
+        print("[4] DRIVE     task=%r" % a.task)
+        for s in res["trace"]:
+            print("      [%s] %-34s %s" % (s["status"].upper(), s["intent"], (s["detail"] or "")[:36]))
+        print("    success: %s | landed: %s" % (res["success"], res["final_url"]))
+
+        # [5] CAMERA -- scroll the camera to the furthest-down occupied doc-cell on the (tall) result page
+        cam2 = Camera(br, page)
+        if cam2.minimap.by_cell:
+            target = max(cam2.minimap.by_cell, key=lambda c: c[1])  # max row = furthest down the document
+            label = cam2.minimap.label(target)
+            y0 = cam2.observe()["scroll"]["y"]
+            cam2.move_camera(label)  # scrollTo a doc-cell -> reliably scrolls
+            print("[5] CAMERA    move_camera(%s): scroll y %d -> %d (camera panned down the document)" % (
+                label, y0, cam2.observe()["scroll"]["y"]))
+
+        ok = res["success"] and out.exists() and out.stat().st_size > 0
+        print("\n%s  screenshot: %s" % ("END-TO-END OK" if ok else "END-TO-END FAILED", out))
+        return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/scbe/ai_browser.py
+++ b/python/scbe/ai_browser.py
@@ -62,12 +62,25 @@ _READ_JS = r"""
     const editable = tag === 'textarea' || tag === 'select' ||
       (tag === 'input' && !['button', 'submit', 'checkbox', 'radio', 'hidden'].includes(typ)) ||
       e.getAttribute('contenteditable') === 'true';
-    elements.push({ ref, tag, role: e.getAttribute('role') || (editable ? 'input' : tag), name: name(e), editable });
+    const bb = e.getBoundingClientRect();
+    elements.push({
+      ref, tag, role: e.getAttribute('role') || (editable ? 'input' : tag), name: name(e), editable,
+      x: Math.round(bb.x), y: Math.round(bb.y), w: Math.round(bb.width), h: Math.round(bb.height)
+    });
   });
   const headings = [...document.querySelectorAll('h1,h2,h3')].filter(vis)
     .map(h => (h.innerText || '').replace(/\s+/g, ' ').trim()).filter(Boolean).slice(0, 12);
   const text = (document.body ? document.body.innerText : '').replace(/\s+/g, ' ').trim().slice(0, 1200);
-  return { url: location.href, title: document.title, elements, headings, text };
+  return {
+    url: location.href, title: document.title,
+    viewport: { w: window.innerWidth, h: window.innerHeight },
+    scroll: { x: Math.round(window.scrollX), y: Math.round(window.scrollY) },
+    document: {
+      w: Math.round(document.documentElement.scrollWidth),
+      h: Math.round(document.documentElement.scrollHeight)
+    },
+    elements, headings, text
+  };
 }
 """
 
@@ -76,7 +89,7 @@ _READ_JS = r"""
 class Move:
     """One legal move on the page's control surface. The model selects by `ref`/`kind`, never a selector."""
 
-    kind: str  # click | type | scroll | navigate | back | read
+    kind: str  # click | type | hover | submit | move_camera | scroll | navigate | back | read
     ref: Optional[str] = None
     label: str = ""
     value: Optional[str] = None
@@ -98,10 +111,10 @@ class EphemeralFeed:
     def consume(self) -> Dict[str, Any]:
         if self._spent:
             raise RuntimeError("ephemeral feed already consumed (and deleted)")
-        data = json.loads(open(self.path, encoding="utf-8").read())
-        os.remove(self.path)  # ingested -> gone; no over-cache
-        self._spent = True
-        return data
+        raw = open(self.path, encoding="utf-8").read()
+        os.remove(self.path)  # ingested -> gone, and spent, BEFORE the parse -- so a malformed-JSON parse
+        self._spent = True  # error can't leave the file cached or the feed re-consumable (exactly once)
+        return json.loads(raw)
 
     @property
     def cached(self) -> bool:
@@ -174,7 +187,26 @@ class AIBrowser:
         elif move.kind == "type":
             page.fill("[data-aibref='%s']" % move.ref, move.value or "", timeout=8000)
         elif move.kind == "scroll":
-            page.mouse.wheel(0, 800)
+            try:
+                delta = int(move.value)
+            except (TypeError, ValueError):
+                delta = 800  # default: one screen down; negative value scrolls up
+            page.mouse.wheel(0, delta)
+        elif move.kind == "move_camera":
+            # scroll a target into view -- the SC2 camera move. By ref (an element) or "x,y" doc coords.
+            if move.ref:
+                page.eval_on_selector(
+                    "[data-aibref='%s']" % move.ref, "e => e.scrollIntoView({block: 'center', inline: 'center'})"
+                )
+            elif move.value:
+                xy = [int(v) for v in str(move.value).split(",")]
+                page.evaluate("([x, y]) => window.scrollTo(x, y)", xy)
+        elif move.kind == "hover":
+            page.hover("[data-aibref='%s']" % move.ref, timeout=8000)
+        elif move.kind == "submit":
+            # press a key on whatever is FOCUSED (default Enter) -- survives a re-render that detaches the
+            # ref'd element (real sites swap inputs out after typing; a focus-based submit doesn't break).
+            page.keyboard.press(move.value or "Enter")
         elif move.kind == "back":
             page.go_back(wait_until="domcontentloaded")
         elif move.kind == "navigate":

--- a/python/scbe/browser_autodrive.py
+++ b/python/scbe/browser_autodrive.py
@@ -1,0 +1,169 @@
+"""browser_autodrive: the autonomous on_step loop -- macro intents resolved against the live observation.
+
+The pieces (ai_browser feed, controller, map, camera) let a model SEE and ACT; this closes the loop the
+StarCraft way (BotAI.on_step + macro->micro). You give high-level INTENTS -- fill('search', 'X'),
+click('Log in'), submit(), assert_url('X') -- the MACRO. Each step the driver RE-OBSERVES the live page
+(refs go stale on real sites, so never trust a cached ref), RESOLVES the intent to a concrete element by
+NAME (the micro), scrolls it into view first if it's off-screen (move_camera, SC2's viewable-region rule),
+acts, and throttles (an action budget, like AlphaStar's APM cap). It stops on success, a missing target, or
+the budget -- and returns a full trace, so every step is auditable.
+
+This is policy-pluggable: the intent list can come from a human, a script, or a model reading observe().
+
+    from python.scbe.ai_browser import AIBrowser
+    from python.scbe.browser_autodrive import AutoDriver, fill, submit, assert_url
+    with AIBrowser(headless=True) as br:
+        drv = AutoDriver(br, br.open('https://en.wikipedia.org/wiki/Main_Page'))
+        res = drv.run([fill('search', 'Hyperbolic geometry'), submit(), assert_url('Hyperbolic')])
+        # res['success'], res['final_url'], res['trace'] (one entry per step)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .ai_browser import AIBrowser, Move
+from .browser_camera import Camera
+
+
+@dataclass
+class Intent:
+    """One macro step. hint = an element-name substring to resolve against the live page; text = the value
+    (typed text / url / the substring to assert)."""
+
+    kind: str  # fill | click | submit | scroll_to | goto | assert_url | assert_title
+    hint: str = ""
+    text: str = ""
+
+    def __str__(self) -> str:
+        a = " %r" % self.hint if self.hint else ""
+        b = " <- %r" % self.text if self.text else ""
+        return "%s%s%s" % (self.kind, a, b)
+
+
+def fill(hint: str, text: str) -> Intent:
+    return Intent("fill", hint=hint, text=text)
+
+
+def click(hint: str) -> Intent:
+    return Intent("click", hint=hint)
+
+
+def submit() -> Intent:
+    return Intent("submit")
+
+
+def scroll_to(hint: str) -> Intent:
+    return Intent("scroll_to", hint=hint)
+
+
+def goto(url: str) -> Intent:
+    return Intent("goto", text=url)
+
+
+def assert_url(substr: str) -> Intent:
+    return Intent("assert_url", text=substr)
+
+
+def assert_title(substr: str) -> Intent:
+    return Intent("assert_title", text=substr)
+
+
+@dataclass
+class Step:
+    intent: str
+    status: str  # ok | fail
+    detail: str = ""
+
+
+@dataclass
+class AutoDriver:
+    """Autonomous macro->micro driver with re-observe-every-step + camera + an action budget."""
+
+    browser: AIBrowser
+    page: Any
+    max_steps: int = 40
+    settle_ms: int = 1200
+    trace: List[Step] = field(default_factory=list)
+
+    def _find(self, feed: Dict[str, Any], hint: str, editable: Optional[bool] = None) -> Optional[Dict[str, Any]]:
+        h = hint.lower()
+        cands = [
+            e
+            for e in feed.get("elements", [])
+            if h in (e.get("name", "") or "").lower() and (editable is None or bool(e.get("editable")) == editable)
+        ]
+        return cands[0] if cands else None
+
+    def _settle(self) -> None:
+        try:
+            self.page.wait_for_load_state("domcontentloaded", timeout=20000)
+        except Exception:
+            pass
+        self.page.wait_for_timeout(self.settle_ms)
+
+    def _resolve_and_focus(self, hint: str, editable: Optional[bool]) -> Optional[Dict[str, Any]]:
+        """Re-read, find the element by name, and move_camera it into view if it's off-screen. Returns the
+        (fresh) element or None."""
+        feed = self.browser.read(self.page)
+        e = self._find(feed, hint, editable=editable)
+        if not e:
+            return None
+        cam = Camera(self.browser, self.page)
+        if not cam.in_viewport(e["ref"]):
+            self.browser.act(self.page, Move("move_camera", ref=e["ref"]))
+            feed = self.browser.read(self.page)  # refs change after a scroll/re-render
+            e = self._find(feed, hint, editable=editable)
+        return e
+
+    def run(self, intents: List[Intent]) -> Dict[str, Any]:
+        self.trace = []
+        for intent in intents:
+            if len(self.trace) >= self.max_steps:
+                self.trace.append(Step(str(intent), "fail", "action budget exhausted"))
+                break
+            try:
+                ok, detail = self._step(intent)
+            except Exception as exc:
+                ok, detail = False, "%s: %s" % (type(exc).__name__, str(exc)[:80])
+            self.trace.append(Step(str(intent), "ok" if ok else "fail", detail))
+            if not ok:
+                break
+        final = self.browser.read(self.page)
+        return {
+            "success": bool(self.trace) and all(s.status == "ok" for s in self.trace),
+            "steps": len(self.trace),
+            "final_url": final.get("url"),
+            "final_title": final.get("title"),
+            "trace": [{"intent": s.intent, "status": s.status, "detail": s.detail} for s in self.trace],
+        }
+
+    def _step(self, intent: Intent):
+        if intent.kind in ("fill", "click", "scroll_to"):
+            e = self._resolve_and_focus(intent.hint, editable=(True if intent.kind == "fill" else None))
+            if not e:
+                return False, "no element matching %r" % intent.hint
+            if intent.kind == "fill":
+                self.browser.act(self.page, Move("type", ref=e["ref"], value=intent.text))
+            elif intent.kind == "click":
+                self.browser.act(self.page, Move("click", ref=e["ref"]))
+                self._settle()
+            else:  # scroll_to
+                self.browser.act(self.page, Move("move_camera", ref=e["ref"]))
+            return True, e.get("name", "")
+        if intent.kind == "submit":
+            self.browser.act(self.page, Move("submit"))
+            self._settle()
+            return True, ""
+        if intent.kind == "goto":
+            self.browser.act(self.page, Move("navigate", value=intent.text))
+            self._settle()
+            return True, intent.text
+        if intent.kind == "assert_url":
+            url = self.browser.read(self.page).get("url", "")
+            return (intent.text.lower() in url.lower()), url
+        if intent.kind == "assert_title":
+            title = self.browser.read(self.page).get("title", "")
+            return (intent.text.lower() in title.lower()), title
+        return False, "unknown intent kind %r" % intent.kind

--- a/python/scbe/browser_camera.py
+++ b/python/scbe/browser_camera.py
@@ -1,0 +1,176 @@
+"""browser_camera: the DOCUMENT-level camera over a scrollable page.
+
+browser_map fogs a single VIEWPORT. Real pages scroll -- the document is bigger than the camera -- so the
+research (pysc2/AlphaStar) flagged three things this adds, in DOCUMENT coordinates:
+
+  * PageMinimap -- a grid over the WHOLE document (doc coords = element viewport coords + scroll), with the
+    current viewport drawn as a RECTANGLE. The persistent overview of the entire page, not just on-screen.
+  * ThreeStateFog -- pysc2's HIDDEN / SEEN / VISIBLE. VISIBLE = in the viewport now; SEEN = scrolled past
+    (a last-seen snapshot is kept, possibly stale); HIDDEN = never scrolled into view.
+  * Camera.move_camera(target) -- scroll a doc-cell or element into view (the costed camera action). To act
+    on an OFF-SCREEN element you must move_camera to it first; off-screen, that is the only legal move
+    toward it -- exactly SC2's "actions are restricted to the viewable region."
+
+    from python.scbe.ai_browser import AIBrowser
+    from python.scbe.browser_camera import Camera
+    with AIBrowser(headless=True) as br:
+        cam = Camera(br, br.open(url))
+        obs = cam.observe()                 # doc minimap + viewport rect + fog + legal actions
+        cam.move_camera("D9")               # scroll that doc-cell into view -> it becomes VISIBLE
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .ai_browser import AIBrowser, Move
+from .browser_grid import cell_label
+
+HIDDEN, SEEN, VISIBLE = 0, 1, 2
+_STATE_NAME = {HIDDEN: "hidden", SEEN: "seen", VISIBLE: "visible"}
+
+
+class ThreeStateFog:
+    """pysc2 visibility: HIDDEN (never seen) / SEEN (explored, stale snapshot kept) / VISIBLE (live)."""
+
+    def __init__(self) -> None:
+        self.state: Dict[str, int] = {}
+        self.snapshot: Dict[str, Any] = {}
+
+    def update(self, visible: Set[str], cell_data: Dict[str, Any]) -> None:
+        for cell, st in list(self.state.items()):
+            if st == VISIBLE and cell not in visible:
+                self.state[cell] = SEEN  # scrolled out of view -> remembered but now stale
+        for cell in visible:
+            self.state[cell] = VISIBLE
+            self.snapshot[cell] = cell_data.get(cell)  # refresh the last-seen snapshot
+
+    def of(self, cell: str) -> int:
+        return self.state.get(cell, HIDDEN)
+
+    def name(self, cell: str) -> str:
+        return _STATE_NAME[self.of(cell)]
+
+    def seen_snapshot(self, cell: str) -> Any:
+        """The last-seen data for a SEEN (stale) cell -- remembered, not currently confirmed."""
+        return self.snapshot.get(cell)
+
+    def counts(self) -> Dict[str, int]:
+        out = {"hidden": 0, "seen": 0, "visible": 0}
+        for st in self.state.values():
+            out[_STATE_NAME[st]] += 1
+        return out
+
+
+class PageMinimap:
+    """A grid over the WHOLE document; elements placed by doc coords; the viewport is a rectangle of cells."""
+
+    def __init__(self, feed: Dict[str, Any], cols: int = 12, rows: int = 12):
+        doc = feed.get("document") or feed.get("viewport") or {"w": 1280, "h": 800}
+        self.dw, self.dh = max(1, int(doc.get("w", 1280))), max(1, int(doc.get("h", 800)))
+        self.cols, self.rows = cols, rows
+        self.cw, self.ch = self.dw / cols, self.dh / rows
+        sc = feed.get("scroll") or {"x": 0, "y": 0}
+        self.sx, self.sy = int(sc.get("x", 0)), int(sc.get("y", 0))
+        vp = feed.get("viewport") or {"w": 1280, "h": 800}
+        self.vw, self.vh = int(vp.get("w", 1280)), int(vp.get("h", 800))
+        self.by_cell: Dict[Tuple[int, int], List[Dict[str, Any]]] = {}
+        for e in feed.get("elements", []):
+            dx = e.get("x", 0) + self.sx + e.get("w", 0) / 2.0
+            dy = e.get("y", 0) + self.sy + e.get("h", 0) / 2.0
+            cell = (min(cols - 1, max(0, int(dx / self.dw * cols))), min(rows - 1, max(0, int(dy / self.dh * rows))))
+            self.by_cell.setdefault(cell, []).append(e)
+
+    def label(self, cell: Tuple[int, int]) -> str:
+        return cell_label(cell[0], cell[1])
+
+    def viewport_cells(self) -> Set[Tuple[int, int]]:
+        c0 = max(0, int(self.sx / self.dw * self.cols))
+        r0 = max(0, int(self.sy / self.dh * self.rows))
+        c1 = min(self.cols - 1, int((self.sx + self.vw) / self.dw * self.cols))
+        r1 = min(self.rows - 1, int((self.sy + self.vh) / self.dh * self.rows))
+        return {(c, r) for c in range(c0, c1 + 1) for r in range(r0, r1 + 1)}
+
+    def overview(self, fog: ThreeStateFog) -> Dict[str, Any]:
+        cells = {}
+        for cell, els in self.by_cell.items():
+            lab = self.label(cell)
+            cells[lab] = {"n": len(els), "fog": fog.name(lab)}
+        return {"cols": self.cols, "rows": self.rows, "doc": {"w": self.dw, "h": self.dh}, "cells": cells}
+
+
+class Camera:
+    """The document-level camera: a doc minimap + 3-state fog + move_camera, over a scrollable page."""
+
+    def __init__(self, browser: AIBrowser, page: Any, cols: int = 12, rows: int = 12):
+        self.br, self.page, self.cols, self.rows = browser, page, cols, rows
+        self.fog = ThreeStateFog()
+        self.refresh()
+
+    def refresh(self) -> Dict[str, Any]:
+        self.feed = self.br.read(self.page)
+        self.minimap = PageMinimap(self.feed, self.cols, self.rows)
+        vis = {self.minimap.label(c) for c in self.minimap.viewport_cells()}
+        cell_data = {self.minimap.label(c): [e["ref"] for e in els] for c, els in self.minimap.by_cell.items()}
+        self.fog.update(vis, cell_data)
+        return self.observe()
+
+    def _cell_of_ref(self, ref: str) -> Optional[Tuple[int, int]]:
+        for cell, els in self.minimap.by_cell.items():
+            if any(e["ref"] == ref for e in els):
+                return cell
+        return None
+
+    def in_viewport(self, ref: str) -> bool:
+        cell = self._cell_of_ref(ref)
+        return cell is not None and cell in self.minimap.viewport_cells()
+
+    def available_actions(self) -> List[str]:
+        """In-viewport elements can be acted on directly; OFF-screen occupied cells offer only move_camera
+        (you must scroll a target into view before acting on it -- SC2's viewable-region restriction)."""
+        acts = ["read"]
+        vp_cells = self.minimap.viewport_cells()
+        for cell, els in self.minimap.by_cell.items():
+            lab = self.minimap.label(cell)
+            if cell in vp_cells:
+                for e in els:
+                    acts.append(("type:%s" if e.get("editable") else "activate:%s") % e["ref"])
+            else:
+                acts.append("move_camera:%s" % lab)  # off-screen -> reach it with the camera first
+        return acts
+
+    def observe(self) -> Dict[str, Any]:
+        """Doc minimap (overview, fog-stated) + the viewport rectangle + 3-state fog counts + legal actions.
+        Fog is counted over the OCCUPIED doc-cells (never-scrolled-to occupied cells read as hidden)."""
+        occ_fog = {"hidden": 0, "seen": 0, "visible": 0}
+        for cell in self.minimap.by_cell:
+            occ_fog[self.fog.name(self.minimap.label(cell))] += 1
+        return {
+            "minimap": self.minimap.overview(self.fog),
+            "viewport_rect": sorted(self.minimap.label(c) for c in self.minimap.viewport_cells()),
+            "scroll": {"x": self.minimap.sx, "y": self.minimap.sy},
+            "fog": occ_fog,
+            "available_actions": self.available_actions(),
+        }
+
+    def move_camera(self, target: str) -> Dict[str, Any]:
+        """Scroll a target into view (a doc-cell LABEL like 'D9', or an element ref like 'r5'), then refresh
+        -- the target's cell transitions toward VISIBLE."""
+        ref_cell = self._cell_of_ref(target)
+        if ref_cell is not None:
+            self.br.act(self.page, Move("move_camera", ref=target))
+        else:
+            cell = self._cell_from_label(target)
+            if cell is None:
+                raise ValueError("move_camera target %r is neither a known ref nor a doc-cell label" % target)
+            x = int((cell[0] + 0.5) * self.minimap.cw - self.minimap.vw / 2)
+            y = int((cell[1] + 0.5) * self.minimap.ch - self.minimap.vh / 2)
+            self.br.act(self.page, Move("move_camera", value="%d,%d" % (max(0, x), max(0, y))))
+        return self.refresh()
+
+    def _cell_from_label(self, label: str) -> Optional[Tuple[int, int]]:
+        for c in range(self.cols):
+            for r in range(self.rows):
+                if cell_label(c, r) == label:
+                    return (c, r)
+        return None

--- a/python/scbe/browser_controller.py
+++ b/python/scbe/browser_controller.py
@@ -1,0 +1,168 @@
+"""browser_controller: a fixed-geometry CONTROLLER over the ai_browser control surface.
+
+ai_browser.moves() gives a page-shaped LIST of legal moves -- it changes length and order with every site,
+which is exactly the unstable "movement dynamics" that makes a browser hard to steer. This wraps it in a
+CONTROLLER: a small, FIXED set of buttons plus a cursor that walks the page's interactive elements. The
+button vocabulary never changes -- a 3-button page and a 50-button page are both driven with the same
+prev/next/activate/type/scroll/back/read/navigate. One stable steering surface for any website.
+
+The geometry is pluggable -- the same nine logical buttons skin onto a gamepad, a Rubik's CUBE (face
+turns), a SPHERE (directions), or a steering WHEEL. So "map a site to a cube / sphere / controller / wheel"
+is just `layout=`; the driving logic is identical underneath.
+
+    from python.scbe.ai_browser import AIBrowser
+    from python.scbe.browser_controller import BrowserController
+    with AIBrowser(headless=True) as br:
+        ctl = BrowserController(br, br.open(url), layout='cube')
+        ctl.press('next'); ctl.press('type', 'hello'); ctl.press('prev'); ctl.press('activate')
+        print(ctl.frame())   # the AI's stable view: focused element + button legend + feed digest
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .ai_browser import AIBrowser, Move
+
+# the canonical logical buttons -- the steering vocabulary, identical for every page
+BUTTONS: List[str] = [
+    "prev",  # move the cursor to the previous interactive element
+    "next",  # move the cursor to the next interactive element
+    "activate",  # click / activate the focused element
+    "type",  # type a value into the focused editable element
+    "scroll_up",
+    "scroll_down",
+    "back",  # browser back
+    "read",  # re-read the page feed (refresh the surface)
+    "navigate",  # go to a url (value)
+]
+
+# pluggable geometries: each maps the nine logical buttons onto a control-surface skin. The driving logic
+# is identical; only the rendering/identity of each button changes. This is the cube/sphere/wheel mapping.
+LAYOUTS: Dict[str, Dict[str, str]] = {
+    "gamepad": {
+        "prev": "DPAD_UP",
+        "next": "DPAD_DOWN",
+        "activate": "A",
+        "type": "X",
+        "scroll_up": "LT",
+        "scroll_down": "RT",
+        "back": "B",
+        "read": "Y",
+        "navigate": "START",
+    },
+    "cube": {  # Rubik's face turns -- each button is a stable face move
+        "prev": "U",
+        "next": "U'",
+        "activate": "F",
+        "type": "R",
+        "scroll_up": "L",
+        "scroll_down": "L'",
+        "back": "F'",
+        "read": "D",
+        "navigate": "R'",
+    },
+    "sphere": {
+        "prev": "north",
+        "next": "south",
+        "activate": "tap",
+        "type": "equator",
+        "scroll_up": "zenith",
+        "scroll_down": "nadir",
+        "back": "west",
+        "read": "east",
+        "navigate": "pole",
+    },
+    "wheel": {
+        "prev": "turn_left",
+        "next": "turn_right",
+        "activate": "accelerate",
+        "type": "signal",
+        "scroll_up": "lean_back",
+        "scroll_down": "lean_forward",
+        "back": "brake",
+        "read": "mirror",
+        "navigate": "gps",
+    },
+}
+
+
+class BrowserController:
+    """One stable steering surface for any website: a cursor over the page's elements + fixed buttons."""
+
+    def __init__(self, browser: AIBrowser, page: Any, layout: str = "gamepad"):
+        if layout not in LAYOUTS:
+            raise ValueError("unknown layout %r (have %s)" % (layout, ", ".join(LAYOUTS)))
+        self.br = browser
+        self.page = page
+        self.layout = layout
+        self.cursor = 0
+        self.feed = self.br.read(page)
+
+    @property
+    def elements(self) -> List[Dict[str, Any]]:
+        return self.feed.get("elements", [])
+
+    def focused(self) -> Optional[Dict[str, Any]]:
+        els = self.elements
+        return els[self.cursor] if els else None
+
+    def _refresh(self) -> None:
+        self.feed = self.br.read(self.page)
+        if self.cursor >= len(self.elements):
+            self.cursor = 0
+
+    def press(self, button: str, value: Optional[str] = None) -> Dict[str, Any]:
+        """Issue one controller input. Returns the new controller frame (stable view for the next decision)."""
+        if button not in BUTTONS:
+            raise ValueError("unknown button %r (have %s)" % (button, ", ".join(BUTTONS)))
+        n = len(self.elements)
+        if button == "prev":
+            self.cursor = (self.cursor - 1) % n if n else 0
+        elif button == "next":
+            self.cursor = (self.cursor + 1) % n if n else 0
+        elif button == "activate":
+            f = self.focused()
+            if f:
+                self.br.act(self.page, Move("click", ref=f["ref"], label=f.get("name", "")))
+                self._refresh()
+        elif button == "type":
+            f = self.focused()
+            if f and f.get("editable"):
+                self.br.act(self.page, Move("type", ref=f["ref"], value=value or "", label=f.get("name", "")))
+                self._refresh()
+            else:
+                return {**self.frame(), "rejected": "focused element is not editable"}
+        elif button == "scroll_down":
+            self.br.act(self.page, Move("scroll", value="800"))
+        elif button == "scroll_up":
+            self.br.act(self.page, Move("scroll", value="-800"))
+        elif button == "back":
+            self.br.act(self.page, Move("back"))
+            self._refresh()
+        elif button == "read":
+            self._refresh()
+        elif button == "navigate":
+            self.br.act(self.page, Move("navigate", value=value))
+            self._refresh()
+        return self.frame()
+
+    def button_map(self) -> Dict[str, str]:
+        """The current geometry's label for each logical button (the cube/wheel/gamepad skin)."""
+        return dict(LAYOUTS[self.layout])
+
+    def frame(self) -> Dict[str, Any]:
+        """The AI's stable per-step view: where the cursor is, what's focused, the button legend, a digest.
+        Fixed shape regardless of the site -- this is what replaces the variable raw-move list."""
+        f = self.focused()
+        return {
+            "layout": self.layout,
+            "url": self.feed.get("url"),
+            "title": self.feed.get("title"),
+            "cursor": self.cursor,
+            "n_elements": len(self.elements),
+            "focused": ("%s:%s" % (f["ref"], f.get("name", "")) if f else None),
+            "focused_editable": bool(f and f.get("editable")),
+            "buttons": self.button_map(),
+            "headings": self.feed.get("headings", [])[:5],
+        }

--- a/python/scbe/browser_grid.py
+++ b/python/scbe/browser_grid.py
@@ -1,0 +1,136 @@
+"""browser_grid: the real-time AI-ingestion VIEWER -- a per-site coordinate grid over the page.
+
+Issac's design: screenshot the site, grid it out, and give every button a sudoku-style coordinate (the
+login button is `C4`), so the model's VISION lines up with the data feed -- it can reason spatially and
+still resolve back to a concrete element. Two halves, both built on ai_browser's feed (which now carries
+each element's on-screen box):
+
+  * grid_map(feed): DATA, fast. Lays an R x C coordinate grid over the viewport and assigns every element
+    to its cell by box-center. Returns by_ref {r5: 'C4'}, by_cell {'C4': ['r5']}, and a legend
+    {'C4': ['Log in']}. Per-site: the grid adapts to wherever the buttons actually are.
+  * render_grid(browser, page): PIXELS, behind the data. Injects an SVG overlay (grid lines + cell labels
+    + highlighted occupied cells) INTO the page, screenshots it, then removes the overlay -- a gridded
+    screenshot the AI can look at, aligned cell-for-cell with grid_map.
+
+So `C4` means the same thing in the data feed and in the picture. The grid is the bridge between the
+structured surface (refs/moves) and vision (pixels).
+
+    from python.scbe.ai_browser import AIBrowser
+    from python.scbe.browser_grid import grid_map, render_grid
+    with AIBrowser(headless=True) as br:
+        page = br.open(url)
+        g = grid_map(br.read(page))                 # data: which cell each button is in
+        shot = render_grid(br, page, "grid.png")     # pixels: the gridded screenshot (behind the data)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+_DEFAULT_VP = {"w": 1280, "h": 800}
+
+
+def cell_label(col: int, row: int) -> str:
+    """Spreadsheet/sudoku coordinate: column letters (A, B, ... Z, AA, ...) + 1-based row number."""
+    s, c = "", col
+    while True:
+        s = chr(65 + c % 26) + s
+        c = c // 26 - 1
+        if c < 0:
+            break
+    return "%s%d" % (s, row + 1)
+
+
+def _cell_of(e: Dict[str, Any], vw: int, vh: int, cols: int, rows: int):
+    cx = e.get("x", 0) + e.get("w", 0) / 2.0
+    cy = e.get("y", 0) + e.get("h", 0) / 2.0
+    if cx < 0 or cy < 0 or cx >= vw or cy >= vh:
+        return None  # off the current viewport; [0, vw) x [0, vh) so the exact right/bottom edge is OFF
+    col = min(cols - 1, max(0, int(cx / vw * cols)))
+    row = min(rows - 1, max(0, int(cy / vh * rows)))
+    return col, row
+
+
+def grid_map(feed: Dict[str, Any], cols: int = 9, rows: int = 9) -> Dict[str, Any]:
+    """Lay a cols x rows coordinate grid over the viewport; assign every element to a cell by its box
+    center. DATA-first: derived from the feed, no screenshot needed. Elements scrolled off-screen map to
+    'off'."""
+    vp = feed.get("viewport") or _DEFAULT_VP
+    vw, vh = max(1, int(vp.get("w", 1280))), max(1, int(vp.get("h", 800)))
+    by_ref: Dict[str, str] = {}
+    by_cell: Dict[str, List[str]] = {}
+    legend: Dict[str, List[str]] = {}
+    for e in feed.get("elements", []):
+        rc = _cell_of(e, vw, vh, cols, rows)
+        cell = "off" if rc is None else cell_label(rc[0], rc[1])
+        by_ref[e["ref"]] = cell
+        by_cell.setdefault(cell, []).append(e["ref"])
+        legend.setdefault(cell, []).append(e.get("name") or e.get("tag", ""))
+    return {
+        "cols": cols,
+        "rows": rows,
+        "viewport": {"w": vw, "h": vh},
+        "by_ref": by_ref,
+        "by_cell": by_cell,
+        "legend": legend,
+    }
+
+
+# SVG overlay drawn INTO the page just before the screenshot, then removed. Pixels behind the data.
+_OVERLAY_JS = r"""
+(cfg) => {
+  const { cols, rows, vw, vh, occ } = cfg;
+  const NS = 'http://www.w3.org/2000/svg';
+  const old = document.getElementById('aibgrid'); if (old) old.remove();
+  const svg = document.createElementNS(NS, 'svg');
+  svg.id = 'aibgrid';
+  svg.setAttribute('width', vw); svg.setAttribute('height', vh);
+  svg.setAttribute('viewBox', '0 0 ' + vw + ' ' + vh);
+  svg.setAttribute('style',
+    'position:fixed;left:0;top:0;width:' + vw + 'px;height:' + vh + 'px;z-index:2147483647;pointer-events:none;');
+  const cw = vw / cols, ch = vh / rows;
+  const LINE = 'rgba(220,0,0,0.35)';
+  const mk = (n, a) => {
+    const el = document.createElementNS(NS, n);
+    for (const k in a) el.setAttribute(k, a[k]);
+    return el;
+  };
+  occ.forEach(o => svg.appendChild(mk('rect', {
+    x: o.col * cw, y: o.row * ch, width: cw, height: ch,
+    fill: 'rgba(0,170,255,0.22)', stroke: 'rgba(0,120,255,0.9)'
+  })));
+  for (let i = 0; i <= cols; i++) {
+    svg.appendChild(mk('line', { x1: i * cw, y1: 0, x2: i * cw, y2: vh, stroke: LINE }));
+  }
+  for (let j = 0; j <= rows; j++) {
+    svg.appendChild(mk('line', { x1: 0, y1: j * ch, x2: vw, y2: j * ch, stroke: LINE }));
+  }
+  for (let c = 0; c < cols; c++) for (let r = 0; r < rows; r++) {
+    const t = mk('text', {
+      x: c * cw + 2, y: r * ch + 12, 'font-size': 10,
+      fill: 'rgba(220,0,0,0.65)', 'font-family': 'monospace'
+    });
+    t.textContent = String.fromCharCode(65 + c) + (r + 1);
+    svg.appendChild(t);
+  }
+  document.body.appendChild(svg);
+  return true;
+}
+"""
+
+
+def render_grid(browser, page, path: str, cols: int = 9, rows: int = 9) -> Dict[str, Any]:
+    """Inject the grid overlay, screenshot it (the gridded vision), then remove the overlay. Returns the
+    screenshot path + the grid_map so cell labels match the picture exactly. PIXELS behind the data."""
+    feed = browser.read(page)
+    g = grid_map(feed, cols=cols, rows=rows)
+    vw, vh = g["viewport"]["w"], g["viewport"]["h"]
+    occ = []
+    for e in feed.get("elements", []):
+        rc = _cell_of(e, vw, vh, cols, rows)
+        if rc is not None:
+            occ.append({"col": rc[0], "row": rc[1]})
+    page.evaluate(_OVERLAY_JS, {"cols": cols, "rows": rows, "vw": vw, "vh": vh, "occ": occ})
+    browser.snapshot(page, path)
+    page.evaluate("() => { const e = document.getElementById('aibgrid'); if (e) e.remove(); }")
+    return {"path": path, "grid": g, "occupied_cells": sorted(c for c in g["by_cell"] if c != "off")}

--- a/python/scbe/browser_map.py
+++ b/python/scbe/browser_map.py
@@ -1,0 +1,226 @@
+"""browser_map: a StarCraft-style LAYERED map viewer over a website.
+
+browser_grid was one flat layer of boxes. Real pages aren't perfect boxes, so this lays TWO layers
+(Issac's "layers of grids / triangles and squares"):
+
+  * SQUARE layer (load-bearing) -- the cell you ARE in is the IMAGE cell (the focused region, looked at as
+    pixels), and its four N/S/E/W square neighbors are the TEXT reaches around it. The square grid drives
+    everything: cursor movement, neighbor selection, and element placement.
+  * DIAMOND/TRIANGLE layer (a position hint) -- locate() also reports the half-offset diamond CORNER a
+    point sits on and the triangle QUADRANT within it (e.g. 'ES'). look() surfaces that quadrant as the
+    focus element's `lean` (which corner of its cell it sits in). It is a finer hint -- it does NOT pick
+    the neighbors; the square grid does. So you SEE the cell you're in and READ its four square neighbors.
+
+Over that sits a FOG OF WAR: every cell the cursor visits is revealed and STAYS revealed -- a persistent
+render assembled from where the cursor has travelled, exactly like a StarCraft minimap. The MapCursor pans
+cell-to-cell (separate from page scroll) and can HOVER the focused element (hover, not click).
+
+All the geometry/fog/cursor logic is pure (operates on ai_browser's feed: element boxes + viewport), so it
+verifies instantly with no browser. hover() is the one browser-backed call.
+
+    from python.scbe.ai_browser import AIBrowser
+    from python.scbe.browser_map import MapView
+    with AIBrowser(headless=True) as br:
+        page = br.open(url)
+        mv = MapView(br.read(page))     # the map of the site
+        look = mv.pan("E")              # move the cursor east, reveal that cell
+        # look['focus'] = image cell + its elements; look['context'] = neighbor cells as text
+        mv.hover(br, page)              # hover the focused element (no click, no scroll)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from .ai_browser import AIBrowser, Move
+from .browser_grid import cell_label
+
+_DIRS = {"N": (0, -1), "S": (0, 1), "E": (1, 0), "W": (-1, 0)}
+
+
+class MapTiling:
+    """The two-layer geometry: square cells (image) + a half-offset diamond layer (the star/triangle reach)."""
+
+    def __init__(self, vw: int, vh: int, cols: int = 9, rows: int = 9):
+        self.vw, self.vh, self.cols, self.rows = max(1, vw), max(1, vh), cols, rows
+        self.cw, self.ch = self.vw / cols, self.vh / rows
+
+    def square(self, x: float, y: float) -> Optional[Tuple[int, int]]:
+        if x < 0 or y < 0 or x > self.vw or y > self.vh:
+            return None
+        return (min(self.cols - 1, int(x / self.vw * self.cols)), min(self.rows - 1, int(y / self.vh * self.rows)))
+
+    def label(self, cell: Tuple[int, int]) -> str:
+        return cell_label(cell[0], cell[1])
+
+    def neighbors(self, cell: Tuple[int, int]) -> Dict[str, Tuple[int, int]]:
+        """The four square N/S/E/W neighbors of `cell` (clamped to the board) -- the text reaches around the
+        focus cell. Square-grid driven (the diamond/triangle layer does not pick these)."""
+        out = {}
+        for d, (dx, dy) in _DIRS.items():
+            c, r = cell[0] + dx, cell[1] + dy
+            if 0 <= c < self.cols and 0 <= r < self.rows:
+                out[d] = (c, r)
+        return out
+
+    def locate(self, x: float, y: float) -> Optional[Dict[str, Any]]:
+        """A point's layered position: its square (image), the diamond corner it sits on, and which of the
+        four corner-squares it falls in (the triangle quadrant). Off-viewport -> None."""
+        sq = self.square(x, y)
+        if sq is None:
+            return None
+        corner = (round(x / self.cw), round(y / self.ch))  # nearest lattice corner -> the diamond center
+        quad = ("E" if x >= corner[0] * self.cw else "W") + ("S" if y >= corner[1] * self.ch else "N")
+        return {"square": sq, "label": self.label(sq), "diamond": corner, "triangle": quad}
+
+
+class FogOfWar:
+    """Persistent reveal: cells stay seen once the cursor visits them (StarCraft minimap)."""
+
+    def __init__(self) -> None:
+        self.revealed: set = set()
+
+    def reveal(self, cell: Tuple[int, int]) -> None:
+        self.revealed.add(cell)
+
+    def visible(self, cell: Tuple[int, int]) -> bool:
+        return cell in self.revealed
+
+    def panorama(self) -> List[str]:
+        return sorted(cell_label(c, r) for (c, r) in self.revealed)
+
+
+class MapView:
+    """The website as a map: layered tiling + fog + a panning, hovering cursor."""
+
+    def __init__(self, feed: Dict[str, Any], cols: int = 9, rows: int = 9, start: Optional[Tuple[int, int]] = None):
+        self.feed = feed
+        vp = feed.get("viewport") or {"w": 1280, "h": 800}
+        self.tiling = MapTiling(int(vp.get("w", 1280)), int(vp.get("h", 800)), cols, rows)
+        self.fog = FogOfWar()
+        # index elements by their square cell
+        self.by_cell: Dict[Tuple[int, int], List[Dict[str, Any]]] = {}
+        for e in feed.get("elements", []):
+            loc = self.tiling.locate(e.get("x", 0) + e.get("w", 0) / 2.0, e.get("y", 0) + e.get("h", 0) / 2.0)
+            if loc:
+                self.by_cell.setdefault(loc["square"], []).append(e)
+        self.cursor: Tuple[int, int] = start or self._first_cell()
+        self.fog.reveal(self.cursor)
+
+    def _first_cell(self) -> Tuple[int, int]:
+        return sorted(self.by_cell)[0] if self.by_cell else (0, 0)
+
+    def elements_in(self, cell: Tuple[int, int]) -> List[Dict[str, Any]]:
+        return self.by_cell.get(cell, [])
+
+    def pan(self, direction: str) -> Dict[str, Any]:
+        """Move the cursor one cell (N/S/E/W), reveal it (fog persists), return the hybrid view."""
+        if direction not in _DIRS:
+            raise ValueError("direction must be one of %s" % ", ".join(_DIRS))
+        dx, dy = _DIRS[direction]
+        c, r = self.cursor[0] + dx, self.cursor[1] + dy
+        if 0 <= c < self.tiling.cols and 0 <= r < self.tiling.rows:
+            self.cursor = (c, r)
+            self.fog.reveal(self.cursor)
+        return self.look()
+
+    def look(self) -> Dict[str, Any]:
+        """Hybrid view at the cursor: the focus cell as an IMAGE region + its elements (with the focus
+        element's diamond/triangle QUADRANT as `lean`); the four square N/S/E/W neighbor cells as TEXT;
+        plus the fog-revealed panorama."""
+        focus_els = self.elements_in(self.cursor)
+        region = self._region(self.cursor)
+        # consume the diamond/triangle layer: which corner-quadrant of its cell the focused element sits in
+        lean = None
+        if focus_els:
+            e0 = focus_els[0]
+            loc = self.tiling.locate(e0.get("x", 0) + e0.get("w", 0) / 2.0, e0.get("y", 0) + e0.get("h", 0) / 2.0)
+            lean = loc["triangle"] if loc else None
+        context = {}
+        for d, ncell in self.tiling.neighbors(self.cursor).items():
+            names = [e.get("name") or e.get("tag", "") for e in self.elements_in(ncell)]
+            context[d] = {"cell": self.tiling.label(ncell), "text": names}
+        return {
+            "cursor": self.tiling.label(self.cursor),
+            "focus": {  # the cell you are IN -- looked at as an image region
+                "cell": self.tiling.label(self.cursor),
+                "image_region": region,  # bbox in page px to crop for the vision channel
+                "lean": lean,  # the diamond/triangle quadrant the focus element sits in (e.g. 'ES')
+                "elements": [
+                    {"ref": e["ref"], "name": e.get("name"), "editable": e.get("editable")} for e in focus_els
+                ],
+            },
+            "context": context,  # the four square N/S/E/W neighbor reaches, as text
+            "revealed": self.fog.panorama(),  # persistent render from where the cursor has been
+        }
+
+    def _region(self, cell: Tuple[int, int]) -> Dict[str, int]:
+        col, row = cell
+        return {
+            "x": int(col * self.tiling.cw),
+            "y": int(row * self.tiling.ch),
+            "w": int(self.tiling.cw),
+            "h": int(self.tiling.ch),
+        }
+
+    def minimap(self) -> Dict[str, Any]:
+        """The MINIMAP channel: a low-detail whole-page overview -- per-occupied-cell counts + element
+        kinds + fog state + the cursor. Sparse and cheap (the persistent overview, like SC2's minimap),
+        NOT the detail. Pairs with screen() the way feature_minimap pairs with feature_screen."""
+        cells = {}
+        for cell, els in self.by_cell.items():
+            cells[self.tiling.label(cell)] = {
+                "n": len(els),
+                "seen": self.fog.visible(cell),
+                "kinds": sorted({(e.get("role") or e.get("tag") or "") for e in els}),
+            }
+        return {
+            "cols": self.tiling.cols,
+            "rows": self.tiling.rows,
+            "cursor": self.tiling.label(self.cursor),
+            "occupied": cells,
+            "revealed": self.fog.panorama(),
+        }
+
+    def screen(self) -> Dict[str, Any]:
+        """The SCREEN channel: the high-detail local view at the cursor -- the focus image cell + its
+        elements + the neighbor triangle-reaches as text (what look() returns, named as the screen)."""
+        v = self.look()
+        return {"cursor": v["cursor"], "focus": v["focus"], "context": v["context"]}
+
+    def available_actions(self) -> List[str]:
+        """SC2's available_actions: the legal actions THIS frame. Only on-board pans; hover/activate/type
+        only when the focus cell actually has a (editable) element. Legal-moves-only governance."""
+        acts = ["read"]
+        for d, (dx, dy) in _DIRS.items():
+            c, r = self.cursor[0] + dx, self.cursor[1] + dy
+            if 0 <= c < self.tiling.cols and 0 <= r < self.tiling.rows:
+                acts.append("pan:" + d)
+        els = self.elements_in(self.cursor)
+        if els:
+            acts += ["hover", "activate"]
+            if any(e.get("editable") for e in els):
+                acts.append("type")
+        return acts
+
+    def observe(self) -> Dict[str, Any]:
+        """The SC2-style observation: minimap (overview) + screen (detail) + available_actions (legal now).
+        One call gives the model both channels and exactly the moves it may make this frame."""
+        return {
+            "minimap": self.minimap(),
+            "screen": self.screen(),
+            "available_actions": self.available_actions(),
+        }
+
+    def hover(self, browser: AIBrowser, page: Any) -> Dict[str, Any]:
+        """Hover the focused element -- hover, NOT click, and independent of scroll (StarCraft cursor)."""
+        els = self.elements_in(self.cursor)
+        if not els:
+            return {"hovered": None, "reason": "no element in focus cell"}
+        ref = els[0]["ref"]
+        page.hover("[data-aibref='%s']" % ref, timeout=8000)
+        return {"hovered": ref, "cell": self.tiling.label(self.cursor)}
+
+
+def _activate_via_browser(browser: AIBrowser, page: Any, ref: str) -> None:
+    browser.act(page, Move("click", ref=ref))

--- a/tests/test_ai_browser.py
+++ b/tests/test_ai_browser.py
@@ -13,7 +13,21 @@ import pytest
 
 pytest.importorskip("playwright")
 
-from python.scbe.ai_browser import AIBrowser, Move  # noqa: E402
+from python.scbe.ai_browser import AIBrowser, EphemeralFeed, Move  # noqa: E402
+
+
+def test_ephemeral_consume_is_exactly_once_even_on_malformed_json(tmp_path):
+    # the file must be deleted + the feed spent BEFORE the parse, so a bad-JSON parse error can neither
+    # leave the file cached (no over-cache) nor let a second consume() re-try (exactly once)
+    p = tmp_path / "bad.json"
+    p.write_text("{ not valid json", encoding="utf-8")
+    ef = EphemeralFeed(str(p))
+    with pytest.raises(Exception):  # noqa: B017 -- malformed -> json parse error
+        ef.consume()
+    assert not p.exists()  # deleted despite the parse failure (no over-cache)
+    with pytest.raises(RuntimeError):  # spent -> 'already consumed', not a second parse attempt
+        ef.consume()
+
 
 FIXTURE = (
     "data:text/html,"
@@ -84,3 +98,26 @@ def test_unknown_move_rejected(browser):
     page = browser.open(FIXTURE)
     with pytest.raises(ValueError):
         browser.act(page, Move("teleport"))
+
+
+def test_submit_acts_on_focus_survives_rerender(browser):
+    # submit presses Enter on whatever is FOCUSED -- no ref, so a re-render that detaches the input can't
+    # break it (the real-world failure Wikipedia exposed)
+    page = browser.open(
+        "data:text/html,<input onkeydown=\"if(event.key==='Enter')"
+        "document.getElementById('o').innerText='SUBMITTED'\"><p id=o>idle</p>"
+    )
+    inp = next(e for e in browser.read(page)["elements"] if e["editable"])
+    browser.act(page, Move("type", ref=inp["ref"], value="x"))  # type focuses the input
+    browser.act(page, Move("submit"))  # Enter on focus
+    assert "SUBMITTED" in browser.read(page)["text"]
+
+
+def test_hover_move_fires_mouseover_without_click(browser):
+    page = browser.open(
+        "data:text/html,<button onmouseover=\"document.getElementById('o').innerText='HOVERED'\">b</button>"
+        "<p id=o>idle</p>"
+    )
+    btn = next(e for e in browser.read(page)["elements"] if e["tag"] == "button")
+    browser.act(page, Move("hover", ref=btn["ref"]))
+    assert "HOVERED" in browser.read(page)["text"]

--- a/tests/test_browser_autodrive.py
+++ b/tests/test_browser_autodrive.py
@@ -1,0 +1,62 @@
+"""Tests for browser_autodrive -- the autonomous on_step macro->micro loop.
+
+Deterministic, against a local fixture (no network): intents resolve to elements by name and act; a
+nonexistent target FAILS honestly (no faked success); an assertion reflects the real page. Skips if no
+launchable Chrome.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from python.scbe.ai_browser import AIBrowser  # noqa: E402
+from python.scbe.browser_autodrive import AutoDriver, assert_title, click, fill  # noqa: E402
+
+FORM = (
+    "data:text/html,<title>drivetest</title><input placeholder='search box'>"
+    "<button onclick=\"document.getElementById('o').innerText='WENT'\">go</button><p id=o>idle</p>"
+)
+
+
+@pytest.fixture(scope="module")
+def br():
+    try:
+        b = AIBrowser(headless=True).__enter__()
+    except Exception as exc:
+        pytest.skip("no launchable browser: %s" % type(exc).__name__)
+    try:
+        yield b
+    finally:
+        b.__exit__(None, None, None)
+
+
+def test_intents_resolve_by_name_and_act(br):
+    drv = AutoDriver(br, br.open(FORM))
+    res = drv.run([fill("search", "hello"), click("go"), assert_title("drivetest")])
+    assert res["success"] is True
+    assert [s["status"] for s in res["trace"]] == ["ok", "ok", "ok"]
+    assert "WENT" in br.read(drv.page)["text"]  # the click really fired
+
+
+def test_nonexistent_target_fails_honestly(br):
+    drv = AutoDriver(br, br.open(FORM))
+    res = drv.run([click("no-such-control-zzz")])
+    assert res["success"] is False
+    assert res["trace"][0]["status"] == "fail"
+    assert "no element matching" in res["trace"][0]["detail"]
+
+
+def test_assertion_reflects_the_real_page(br):
+    drv = AutoDriver(br, br.open(FORM))
+    res = drv.run([assert_title("this-is-not-the-title")])
+    assert res["success"] is False  # the page title is 'drivetest', so this assertion must fail
+
+
+def test_stops_at_first_failure(br):
+    drv = AutoDriver(br, br.open(FORM))
+    # second intent fails -> third must never run
+    res = drv.run([fill("search", "x"), click("missing-zzz"), click("go")])
+    assert res["success"] is False
+    assert len(res["trace"]) == 2  # stopped after the failing step

--- a/tests/test_browser_camera.py
+++ b/tests/test_browser_camera.py
@@ -1,0 +1,76 @@
+"""Tests for browser_camera -- the document-level camera (doc minimap + 3-state fog + move_camera).
+
+ThreeStateFog and PageMinimap are pure (synthetic feed with document+scroll). The move_camera scroll is a
+browser test against a TALL fixture (doc >> viewport), skipped if no Chrome is launchable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from python.scbe.browser_camera import HIDDEN, SEEN, VISIBLE, PageMinimap, ThreeStateFog
+
+
+def test_three_state_fog_hidden_seen_visible_and_snapshot():
+    fog = ThreeStateFog()
+    fog.update({"A1", "B1"}, {"A1": ["r0"], "B1": ["r1"]})
+    assert fog.of("A1") == VISIBLE and fog.name("A1") == "visible"
+    assert fog.of("Z9") == HIDDEN  # never seen
+    # next frame: A1 scrolled out of view -> SEEN (stale), its snapshot remembered; C1 newly VISIBLE
+    fog.update({"B1", "C1"}, {"B1": ["r1"], "C1": ["r2"]})
+    assert fog.of("A1") == SEEN and fog.seen_snapshot("A1") == ["r0"]
+    assert fog.of("B1") == VISIBLE and fog.of("C1") == VISIBLE
+
+
+def test_page_minimap_is_document_coords_with_viewport_rectangle():
+    feed = {
+        "viewport": {"w": 1000, "h": 800},
+        "scroll": {"x": 0, "y": 0},
+        "document": {"w": 1000, "h": 3000},  # 3000 tall -> much bigger than the 800 viewport
+        "elements": [
+            {"ref": "r0", "x": 10, "y": 10, "w": 20, "h": 20},  # near top -> in viewport
+            {"ref": "r1", "x": 10, "y": 2400, "w": 20, "h": 20},  # far down -> below the fold
+        ],
+    }
+    mm = PageMinimap(feed, cols=10, rows=10)
+    vp = mm.viewport_cells()
+    top = next(c for c, els in mm.by_cell.items() if els[0]["ref"] == "r0")
+    bot = next(c for c, els in mm.by_cell.items() if els[0]["ref"] == "r1")
+    assert top in vp  # the top element's doc-cell is within the viewport rectangle
+    assert bot not in vp  # the far-down element is OUTSIDE the viewport (needs move_camera)
+    assert mm.dh == 3000  # minimap spans the whole document, not just the viewport
+
+
+# --- browser: move_camera scrolls an off-screen element into view on a TALL page ---
+pytest.importorskip("playwright")
+from python.scbe.ai_browser import AIBrowser  # noqa: E402
+from python.scbe.browser_camera import Camera  # noqa: E402
+
+TALL = (
+    "data:text/html,<style>body{margin:0}</style>"
+    "<button style='position:absolute;left:10px;top:10px'>top</button>"
+    "<button style='position:absolute;left:10px;top:2500px'>bottom</button>"
+    "<div style='height:3000px'></div>"
+)
+
+
+def test_move_camera_brings_offscreen_into_view():
+    try:
+        br = AIBrowser(headless=True).__enter__()
+    except Exception as exc:
+        pytest.skip("no launchable browser: %s" % type(exc).__name__)
+    try:
+        page = br.open(TALL)
+        page.set_viewport_size({"width": 1000, "height": 800})
+        cam = Camera(br, page, cols=10, rows=10)
+        assert cam.minimap.dh > 2000  # tall document
+        # the 'bottom' button (doc y=2500) is off-screen at scroll 0
+        bottom = next(e["ref"] for e in cam.feed["elements"] if not cam.in_viewport(e["ref"]))
+        before = cam.observe()["scroll"]["y"]
+        cam.move_camera(bottom)
+        after = cam.observe()
+        assert after["scroll"]["y"] > before  # the camera scrolled
+        assert cam.in_viewport(bottom)  # the target is now visible
+        assert after["fog"]["visible"] >= 1
+    finally:
+        br.__exit__(None, None, None)

--- a/tests/test_browser_controller.py
+++ b/tests/test_browser_controller.py
@@ -1,0 +1,78 @@
+"""Tests for BrowserController -- the fixed-geometry steering surface over ai_browser.
+
+Locks by EXECUTION (local data: fixture, no network): a fixed button vocabulary drives any page via a
+cursor; typing only lands on editable elements (legal-moves-only); every geometry skin (gamepad/cube/
+sphere/wheel) maps all nine buttons; the per-step frame has a fixed shape. Skips if no launchable Chrome.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from python.scbe.ai_browser import AIBrowser  # noqa: E402
+from python.scbe.browser_controller import BUTTONS, LAYOUTS, BrowserController  # noqa: E402
+
+FIXTURE = (
+    "data:text/html,<h1>Demo</h1>"
+    "<button onclick=\"document.getElementById('o').innerText='CLICKED'\">Press me</button>"
+    "<input placeholder='your name'><a href='https://example.org'>link</a><p id=o>idle</p>"
+)
+
+
+@pytest.fixture(scope="module")
+def br():
+    try:
+        b = AIBrowser(headless=True).__enter__()
+    except Exception as exc:
+        pytest.skip("no launchable browser: %s" % type(exc).__name__)
+    try:
+        yield b
+    finally:
+        b.__exit__(None, None, None)
+
+
+def test_every_layout_maps_all_buttons():
+    for name, mapping in LAYOUTS.items():
+        assert set(mapping) == set(BUTTONS), "layout %s missing buttons" % name
+        assert len(set(mapping.values())) == len(BUTTONS), "layout %s has duplicate skins" % name
+
+
+def test_cursor_steers_and_actions_change_state(br):
+    ctl = BrowserController(br, br.open(FIXTURE), layout="cube")
+    assert ctl.frame()["n_elements"] == 3
+    assert ctl.frame()["focused"].startswith("r0")  # button first
+    ctl.press("next")
+    assert ctl.frame()["focused_editable"] is True  # the input
+    ctl.press("type", "Issac")
+    ctl.press("prev")
+    ctl.press("activate")
+    assert ctl.page.eval_on_selector("[data-aibref='r1']", "e=>e.value") == "Issac"
+    assert "CLICKED" in br.read(ctl.page)["text"]
+
+
+def test_type_on_non_editable_is_rejected(br):
+    ctl = BrowserController(br, br.open(FIXTURE), layout="gamepad")
+    ctl.cursor = 0  # the button (not editable)
+    res = ctl.press("type", "xx")
+    assert res.get("rejected") == "focused element is not editable"
+
+
+def test_frame_shape_is_fixed_across_layouts(br):
+    keys = None
+    for layout in LAYOUTS:
+        ctl = BrowserController(br, br.open(FIXTURE), layout=layout)
+        fr = ctl.frame()
+        assert set(fr["buttons"]) == set(BUTTONS)
+        if keys is None:
+            keys = set(fr)
+        assert set(fr) == keys  # identical frame shape no matter the geometry
+
+
+def test_invalid_layout_and_button_rejected(br):
+    with pytest.raises(ValueError):
+        BrowserController(br, br.open(FIXTURE), layout="hyperbolic-banana")
+    ctl = BrowserController(br, br.open(FIXTURE))
+    with pytest.raises(ValueError):
+        ctl.press("teleport")

--- a/tests/test_browser_grid.py
+++ b/tests/test_browser_grid.py
@@ -1,0 +1,99 @@
+"""Tests for browser_grid -- the per-site coordinate-grid viewer.
+
+cell_label math is pure (no browser). The grid mapping + overlay render are locked by EXECUTION against a
+POSITIONED data: fixture (fixed viewport so cells are deterministic): elements land in the expected cells,
+off-viewport elements map to 'off', the gridded screenshot renders and the overlay is removed after.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from python.scbe.browser_grid import cell_label, grid_map
+
+pytest.importorskip("playwright")
+
+from python.scbe.ai_browser import AIBrowser  # noqa: E402
+from python.scbe.browser_grid import render_grid  # noqa: E402
+
+POSITIONED = (
+    "data:text/html,<style>body{margin:0}</style>"
+    "<button style='position:absolute;left:40px;top:30px'>Login</button>"
+    "<input style='position:absolute;left:600px;top:380px' placeholder='search'>"
+    "<a style='position:absolute;left:1120px;top:720px' href='https://x.org'>help</a>"
+)
+OFFSCREEN = (
+    "data:text/html,<style>body{margin:0}</style>"
+    "<button style='position:absolute;left:40px;top:5000px'>way down</button>"
+)
+
+
+def test_cell_label_is_spreadsheet_coordinate():
+    assert cell_label(0, 0) == "A1"
+    assert cell_label(2, 3) == "C4"
+    assert cell_label(7, 7) == "H8"
+    assert cell_label(25, 0) == "Z1"
+    assert cell_label(26, 0) == "AA1"  # wraps past Z like spreadsheet columns
+    assert cell_label(27, 9) == "AB10"
+
+
+def test_exact_right_edge_pixel_is_off():
+    # viewport is [0, vw) x [0, vh): a center exactly at cx==vw is OFF-screen, not the last column
+    edge = {"viewport": {"w": 1000, "h": 800}, "elements": [{"ref": "r0", "x": 1000, "y": 400, "w": 0, "h": 0}]}
+    assert grid_map(edge)["by_ref"]["r0"] == "off"
+    inside = {"viewport": {"w": 1000, "h": 800}, "elements": [{"ref": "r0", "x": 999, "y": 400, "w": 0, "h": 0}]}
+    assert grid_map(inside)["by_ref"]["r0"] != "off"  # one pixel inside is on-grid
+
+
+def test_grid_map_pure_on_synthetic_feed():
+    feed = {
+        "viewport": {"w": 900, "h": 900},
+        "elements": [
+            {"ref": "r0", "x": 0, "y": 0, "w": 10, "h": 10, "name": "tl"},  # top-left -> A1
+            {"ref": "r1", "x": 890, "y": 890, "w": 5, "h": 5, "name": "br"},  # bottom-right -> last cell
+        ],
+    }
+    g = grid_map(feed, cols=9, rows=9)
+    assert g["by_ref"]["r0"] == "A1"
+    assert g["by_ref"]["r1"] == "I9"  # 9th col (I), 9th row
+    assert g["by_cell"]["A1"] == ["r0"] and g["legend"]["A1"] == ["tl"]
+
+
+@pytest.fixture(scope="module")
+def br():
+    try:
+        b = AIBrowser(headless=True).__enter__()
+    except Exception as exc:
+        pytest.skip("no launchable browser: %s" % type(exc).__name__)
+    try:
+        yield b
+    finally:
+        b.__exit__(None, None, None)
+
+
+def test_positioned_elements_land_in_distinct_cells(br):
+    page = br.open(POSITIONED)
+    page.set_viewport_size({"width": 1280, "height": 800})
+    g = grid_map(br.read(page), cols=9, rows=9)
+    assert g["by_ref"]["r0"] == "A1"  # top-left Login
+    cells = [c for c in g["by_ref"].values() if c != "off"]
+    assert len(cells) == 3 and len(set(cells)) == 3  # all on-grid, all distinct
+
+
+def test_offscreen_element_maps_off(br):
+    page = br.open(OFFSCREEN)
+    page.set_viewport_size({"width": 1280, "height": 800})
+    g = grid_map(br.read(page))
+    assert g["by_ref"]["r0"] == "off"
+
+
+def test_render_grid_makes_screenshot_and_removes_overlay(br):
+    page = br.open(POSITIONED)
+    page.set_viewport_size({"width": 1280, "height": 800})
+    out = os.path.join(os.environ.get("TEMP", "/tmp"), "aib_grid_test.png")
+    res = render_grid(br, page, out)
+    assert os.path.exists(res["path"]) and os.path.getsize(res["path"]) > 0
+    assert res["occupied_cells"] and "A1" in res["occupied_cells"]
+    assert page.query_selector("#aibgrid") is None  # overlay cleaned up after the shot

--- a/tests/test_browser_map.py
+++ b/tests/test_browser_map.py
@@ -1,0 +1,129 @@
+"""Tests for browser_map -- the layered, StarCraft-style map viewer.
+
+The tiling/fog/cursor/hybrid-view logic is pure (synthetic feed, no browser) and locked deterministically.
+The hover (hover-not-click, separate from scroll) is a browser test that skips if no Chrome is launchable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from python.scbe.browser_map import FogOfWar, MapTiling, MapView
+
+SYNTHETIC = {
+    "viewport": {"w": 900, "h": 900},
+    "elements": [
+        {"ref": "r0", "x": 20, "y": 20, "w": 60, "h": 60, "name": "top-left"},  # center (50,50)   -> A1
+        {"ref": "r1", "x": 220, "y": 220, "w": 60, "h": 60, "name": "mid"},  # center (250,250) -> C3
+        {"ref": "r2", "x": 820, "y": 820, "w": 60, "h": 60, "name": "corner"},  # center (850,850) -> I9
+    ],
+}
+
+
+def test_tiling_square_diamond_and_triangle_quadrant():
+    t = MapTiling(900, 900, 9, 9)
+    assert t.square(50, 50) == (0, 0) and t.label((0, 0)) == "A1"
+    assert t.square(850, 850) == (8, 8) and t.label((8, 8)) == "I9"
+    assert t.square(-5, 5) is None  # off the viewport
+    loc = t.locate(205, 205)
+    assert loc["label"] == "C3"  # the square (image cell)
+    assert loc["diamond"] == (2, 2)  # nearest lattice corner = diamond center
+    assert loc["triangle"] == "ES"  # which corner-square the point falls in
+
+
+def test_neighbors_are_the_four_reaches_clamped():
+    t = MapTiling(900, 900, 9, 9)
+    assert set(t.neighbors((0, 0))) == {"E", "S"}  # top-left corner: only east + south exist
+    assert set(t.neighbors((4, 4))) == {"N", "S", "E", "W"}  # interior: all four
+
+
+def test_fog_reveal_persists():
+    fog = FogOfWar()
+    fog.reveal((0, 0))
+    fog.reveal((1, 0))
+    assert fog.visible((0, 0)) and fog.visible((1, 0)) and not fog.visible((5, 5))
+    assert fog.panorama() == ["A1", "B1"]
+
+
+def test_mapview_pan_reveals_and_hybrid_view():
+    mv = MapView(SYNTHETIC, cols=9, rows=9)
+    assert mv.look()["cursor"] == "A1"
+    assert [e["name"] for e in mv.look()["focus"]["elements"]] == ["top-left"]
+    assert mv.look()["focus"]["image_region"] == {"x": 0, "y": 0, "w": 100, "h": 100}
+    mv.pan("E")
+    look = mv.pan("S")
+    assert look["cursor"] == "B2"
+    assert set(look["revealed"]) == {"A1", "B1", "B2"}  # fog persists across pans
+    # neighbors are returned as TEXT (the triangle reaches), focus is the image cell
+    assert set(look["context"]) <= {"N", "S", "E", "W"}
+
+
+def test_pan_rejects_bad_direction():
+    mv = MapView(SYNTHETIC)
+    with pytest.raises(ValueError):
+        mv.pan("UP-LEFT")
+
+
+def test_focus_lean_consumes_the_triangle_quadrant():
+    # the diamond/triangle layer is load-bearing: look() surfaces the focus element's quadrant as `lean`
+    mv = MapView(SYNTHETIC)  # cursor starts on the 'top-left' element
+    lean = mv.look()["focus"]["lean"]
+    assert lean in ("EN", "ES", "WN", "WS")  # a real quadrant -> the triangle is actually consumed, not dead
+
+
+# SC2-style observation: minimap (overview) + screen (detail) + available_actions (legal this frame)
+OBS_FEED = {
+    "viewport": {"w": 900, "h": 900},
+    "elements": [
+        {"ref": "r0", "x": 20, "y": 20, "w": 60, "h": 60, "name": "Login", "editable": False, "role": "button"},
+        {"ref": "r1", "x": 220, "y": 220, "w": 60, "h": 60, "name": "search", "editable": True, "role": "input"},
+    ],
+}
+
+
+def test_available_actions_reflects_edges_and_editability():
+    mv = MapView(OBS_FEED, cols=9, rows=9)  # cursor starts at A1 (top-left corner, non-editable button)
+    a = mv.available_actions()
+    assert set(a) == {"read", "pan:S", "pan:E", "hover", "activate"}  # no off-board N/W, no type
+    mv.cursor = (2, 2)  # the editable input cell (interior)
+    b = mv.available_actions()
+    assert {"pan:N", "pan:S", "pan:E", "pan:W", "hover", "activate", "type"} <= set(b)
+
+
+def test_minimap_overview_and_screen_detail():
+    mv = MapView(OBS_FEED, cols=9, rows=9)
+    obs = mv.observe()
+    assert set(obs) == {"minimap", "screen", "available_actions"}
+    mm = obs["minimap"]
+    assert mm["cursor"] == "A1" and mm["revealed"] == ["A1"]  # minimap = sparse overview + fog
+    assert mm["occupied"]["A1"] == {"n": 1, "seen": True, "kinds": ["button"]}
+    assert mm["occupied"]["C3"]["seen"] is False  # not visited yet -> fogged in the overview
+    assert [e["name"] for e in obs["screen"]["focus"]["elements"]] == ["Login"]  # screen = local detail
+
+
+# --- browser-backed: hover fires onmouseover WITHOUT a click ---
+pytest.importorskip("playwright")
+from python.scbe.ai_browser import AIBrowser  # noqa: E402
+
+HOVER_FIX = (
+    "data:text/html,<style>body{margin:0}</style>"
+    "<button style='position:absolute;left:30px;top:30px' "
+    "onmouseover=\"document.getElementById('o').innerText='HOVERED'\">btn</button>"
+    "<p id=o style='position:absolute;left:30px;top:200px'>idle</p>"
+)
+
+
+def test_hover_focuses_without_click():
+    try:
+        br = AIBrowser(headless=True).__enter__()
+    except Exception as exc:
+        pytest.skip("no launchable browser: %s" % type(exc).__name__)
+    try:
+        page = br.open(HOVER_FIX)
+        page.set_viewport_size({"width": 1280, "height": 800})
+        mv = MapView(br.read(page))
+        res = mv.hover(br, page)
+        assert res["hovered"] == "r0"
+        assert "HOVERED" in br.read(page)["text"]  # mouseover fired -> hover, not click
+    finally:
+        br.__exit__(None, None, None)


### PR DESCRIPTION
Re-lands the 9 commits PR #2619 auto-merged only the **first** of (the squash closed the PR after the `ai_browser` core, orphaning the rest). One clean commit off current main — no add/add conflict.

**Lands:** browser_controller / grid / map / camera / autodrive, the submit/hover/move_camera moves, the `.claude/skills/run-ai-browser` driver+SKILL, and the 5 adversarial-audit fixes (EphemeralFeed exactly-once, grid edge-pixel, browser_map triangle made load-bearing + docstrings).

**Verified:** 35/35 browser tests; driven on live Wikipedia (autonomous search → /wiki/Hyperbolic_geometry); 5-skeptic audit run + all findings fixed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>