### PR TITLE
feat(training): add stack-agent staged training lane

### DIFF
--- a/notebooks/vtc_stack_agent_staged_colab.ipynb
+++ b/notebooks/vtc_stack_agent_staged_colab.ipynb
@@ -1,0 +1,226 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "gpuType": "T4"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU"
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SCBE Stack-Agent Staged Training\n",
+    "\n",
+    "Train a code agent on the SCBE stack action grammar: inspect, run bounded checks, repair from evidence, and emit receipts.\n",
+    "\n",
+    "This notebook is staged and artifact-first. The repo data remains the source of truth; Colab is only compute.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Stage 0: configuration\n",
+    "import os, json, pathlib, subprocess, textwrap\n",
+    "\n",
+    "SCBE_REPO = os.environ.get('SCBE_REPO', 'https://github.com/issdandavis/SCBE-AETHERMOORE.git')\n",
+    "SCBE_REF = os.environ.get('SCBE_REF', 'feat/stack-agent-training-lane')\n",
+    "BASE_MODEL = os.environ.get('BASE_MODEL', 'Qwen/Qwen2.5-Coder-3B-Instruct')\n",
+    "LR = float(os.environ.get('STACK_AGENT_LR', '5e-5'))\n",
+    "EPOCHS = float(os.environ.get('STACK_AGENT_EPOCHS', '1'))\n",
+    "MAX_LEN = int(os.environ.get('STACK_AGENT_MAX_LEN', '2048'))\n",
+    "RUN_CODE_EVAL = os.environ.get('RUN_CODE_EVAL', '1') == '1'\n",
+    "ROOT = pathlib.Path('/content/scbe')\n",
+    "STAGE = pathlib.Path('/content/stack_agent_stage')\n",
+    "STAGE.mkdir(parents=True, exist_ok=True)\n",
+    "print({'repo': SCBE_REPO, 'ref': SCBE_REF, 'base_model': BASE_MODEL, 'lr': LR, 'epochs': EPOCHS, 'stage': str(STAGE)})\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Stage 1: checkout source of truth\n",
+    "import shutil, os, subprocess, pathlib\n",
+    "if ROOT.exists():\n",
+    "    shutil.rmtree(ROOT)\n",
+    "subprocess.run(['git', 'clone', '--depth', '1', '--branch', SCBE_REF, SCBE_REPO, str(ROOT)], check=True)\n",
+    "os.chdir(ROOT)\n",
+    "print(subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], text=True).strip())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Stage 2: install training dependencies\n",
+    "import subprocess, sys\n",
+    "subprocess.run([sys.executable, '-m', 'pip', 'install', '-q', 'transformers>=4.44.0', 'datasets', 'accelerate', 'peft', 'bitsandbytes'], check=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Stage 3: build and gate the stack-agent corpus\n",
+    "import subprocess, sys, json, pathlib\n",
+    "corpus = STAGE / 'stack_agent_seed.jsonl'\n",
+    "manifest = STAGE / 'stack_agent_seed.manifest.json'\n",
+    "report = STAGE / 'stack_agent_eval_report.json'\n",
+    "subprocess.run([sys.executable, 'scripts/training/build_stack_repair_corpus.py', '--out', str(corpus), '--manifest', str(manifest), '--include-smoke'], check=True)\n",
+    "subprocess.run([sys.executable, 'scripts/training/eval_stack_agent.py', '--corpus', str(corpus), '--out', str(report)], check=True)\n",
+    "print(manifest.read_text()[:1000])\n",
+    "print(report.read_text()[:1000])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Stage 4: load model and tokenize corpus\n",
+    "import json, torch\n",
+    "from datasets import load_dataset\n",
+    "from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig\n",
+    "from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training\n",
+    "\n",
+    "bnb = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type='nf4', bnb_4bit_compute_dtype=torch.float16)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL, trust_remote_code=True)\n",
+    "if tokenizer.pad_token is None:\n",
+    "    tokenizer.pad_token = tokenizer.eos_token\n",
+    "model = AutoModelForCausalLM.from_pretrained(BASE_MODEL, quantization_config=bnb, device_map='auto', trust_remote_code=True)\n",
+    "model = prepare_model_for_kbit_training(model)\n",
+    "model = get_peft_model(model, LoraConfig(r=16, lora_alpha=32, lora_dropout=0.05, bias='none', task_type='CAUSAL_LM'))\n",
+    "\n",
+    "def render_chat(row):\n",
+    "    messages = row['messages']\n",
+    "    if hasattr(tokenizer, 'apply_chat_template') and tokenizer.chat_template:\n",
+    "        return tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=False)\n",
+    "    return '\n",
+    "'.join(f\"{m['role'].upper()}: {m['content']}\" for m in messages)\n",
+    "\n",
+    "ds = load_dataset('json', data_files=str(corpus), split='train')\n",
+    "\n",
+    "def tok(row):\n",
+    "    text = render_chat(row)\n",
+    "    enc = tokenizer(text, truncation=True, max_length=MAX_LEN, padding='max_length')\n",
+    "    enc['labels'] = enc['input_ids'].copy()\n",
+    "    return enc\n",
+    "\n",
+    "tok_ds = ds.map(tok, remove_columns=ds.column_names)\n",
+    "print({'records': len(tok_ds), 'max_len': MAX_LEN})\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Stage 5: gentle adapter training\n",
+    "from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling\n",
+    "import json, pathlib\n",
+    "\n",
+    "out_dir = STAGE / 'adapter'\n",
+    "args = TrainingArguments(\n",
+    "    output_dir=str(out_dir),\n",
+    "    per_device_train_batch_size=1,\n",
+    "    gradient_accumulation_steps=8,\n",
+    "    learning_rate=LR,\n",
+    "    num_train_epochs=EPOCHS,\n",
+    "    logging_steps=1,\n",
+    "    save_strategy='epoch',\n",
+    "    report_to=[],\n",
+    "    fp16=True,\n",
+    ")\n",
+    "trainer = Trainer(model=model, args=args, train_dataset=tok_ds, data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False))\n",
+    "train_result = trainer.train()\n",
+    "model.save_pretrained(out_dir)\n",
+    "tokenizer.save_pretrained(out_dir)\n",
+    "metrics = dict(train_result.metrics)\n",
+    "metrics.update({'lr': LR, 'epochs': EPOCHS, 'base_model': BASE_MODEL, 'records': len(tok_ds)})\n",
+    "(STAGE / 'train_metrics.json').write_text(json.dumps(metrics, indent=2, sort_keys=True))\n",
+    "print(metrics)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Stage 6: optional held-out pitfall code-lift eval\n",
+    "# This is the honest capability ruler. It may be slow; disable with RUN_CODE_EVAL=0.\n",
+    "import json, re, torch\n",
+    "from python.helm import pitfall_eval\n",
+    "from python.helm.code_lift import solve_rate, lift_from_solve, render\n",
+    "\n",
+    "problems = pitfall_eval.eval_problems()\n",
+    "\n",
+    "def extract_code(text):\n",
+    "    m = re.search(r'```(?:python)?\\n(.*?)```', text, re.S)\n",
+    "    return (m.group(1) if m else text).strip()\n",
+    "\n",
+    "def make_prompt(p):\n",
+    "    return 'Write a complete Python solution. Return only code.\\n\\n' + p['text'] + '\\n\\nVisible test:\\n' + p['test_list'][0]\n",
+    "\n",
+    "def gen_one(p):\n",
+    "    inputs = tokenizer(make_prompt(p), return_tensors='pt').to(model.device)\n",
+    "    with torch.no_grad():\n",
+    "        out = model.generate(**inputs, max_new_tokens=384, do_sample=False, pad_token_id=tokenizer.eos_token_id)\n",
+    "    return extract_code(tokenizer.decode(out[0][inputs['input_ids'].shape[1]:], skip_special_tokens=True))\n",
+    "\n",
+    "if RUN_CODE_EVAL:\n",
+    "    model.eval()\n",
+    "    with model.disable_adapter():\n",
+    "        base = solve_rate(problems, gen_one, public_k=1)\n",
+    "    trained = solve_rate(problems, gen_one, public_k=1)\n",
+    "    rep = lift_from_solve(base, trained)\n",
+    "    serial = {k: (sorted(v) if isinstance(v, set) else v) for k, v in rep.items()}\n",
+    "    (STAGE / 'report.json').write_text(json.dumps(serial, indent=2, sort_keys=True))\n",
+    "    print(render(rep))\n",
+    "else:\n",
+    "    (STAGE / 'report.json').write_text(json.dumps({'code_eval_skipped': True}, indent=2))\n",
+    "    print('code eval skipped')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Stage 7: artifact manifest\n",
+    "import json, pathlib, os\n",
+    "artifacts = sorted(str(p) for p in STAGE.glob('**/*') if p.is_file())\n",
+    "summary = {\n",
+    "    'status': 'STACK_AGENT_TRAINING_DONE',\n",
+    "    'stage': str(STAGE),\n",
+    "    'artifacts': artifacts,\n",
+    "}\n",
+    "(STAGE / 'artifact_manifest.json').write_text(json.dumps(summary, indent=2, sort_keys=True))\n",
+    "print(json.dumps(summary, indent=2)[:4000])\n"
+   ]
+  }
+ ]
+}

--- a/scripts/system/colab_workflow_catalog.py
+++ b/scripts/system/colab_workflow_catalog.py
@@ -67,6 +67,19 @@ NOTEBOOKS: list[dict[str, Any]] = [
         "across Python, JavaScript, Rust, Mathematica, Haskell, and Markdown.",
     },
     {
+        "name": "stack-agent-staged",
+        "aliases": [
+            "stack-agent",
+            "code-agent",
+            "multi-compiler-agent",
+            "vtc-stack",
+        ],
+        "path": "notebooks/vtc_stack_agent_staged_colab.ipynb",
+        "category": "training",
+        "summary": "Staged stack-agent LoRA lane: builds verified repair records, gates the corpus, "
+        "trains gently, and optionally measures held-out pitfall lift.",
+    },
+    {
         "name": "aethermoor-finetune",
         "aliases": ["aethermoor", "aethermoor-finetune", "game-finetune"],
         "path": "notebooks/colab_aethermoor_finetune.ipynb",

--- a/scripts/training/build_stack_repair_corpus.py
+++ b/scripts/training/build_stack_repair_corpus.py
@@ -1,0 +1,314 @@
+"""Build the first SCBE stack-agent SFT corpus.
+
+This is not a generic MBPP corpus. It teaches the stack-agent loop:
+
+    task -> attempted action -> execution feedback -> repair -> receipt
+
+The load-bearing records come from execution-verified pitfall pairs already in
+`python.helm.better_corpus` and `python.helm.pitfall_eval`. Optional stack-smoke
+records teach how to run bounded repo checks without pretending they are model
+capability evals.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from python.helm import better_corpus, pitfall_eval, public_bench
+
+SYSTEM = """You are an SCBE stack coding agent.
+Use this action grammar:
+PLAN: identify the repo surface and invariant.
+CALL run_code or CALL run_command with the smallest bounded check.
+TOOL feedback is evidence, not decoration.
+REPAIR only what the evidence supports.
+ANSWER with the final artifact and a receipt.
+Never claim success without an execution check."""
+
+
+def _json_line(obj: Dict[str, Any]) -> str:
+    return json.dumps(obj, ensure_ascii=True, sort_keys=True)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _first_failure(source: str, tests: Sequence[str]) -> str:
+    check = public_bench._verify(source, [], tests, [])
+    failures = list(check.get("hidden_failures", [])) or list(check.get("public_failures", []))
+    if not failures:
+        return "FAIL: expected failure, but no failure text was emitted"
+    return "FAIL: " + str(failures[0])[:900]
+
+
+def _passes(source: str, tests: Sequence[str]) -> bool:
+    return bool(public_bench._verify(source, [], tests, [])["hidden_passed"])
+
+
+def _repair_record(
+    *,
+    source: str,
+    task_id: str,
+    pitfall_class: str,
+    prompt: str,
+    buggy: str,
+    fix: str,
+    tests: Sequence[str],
+) -> Optional[Dict[str, Any]]:
+    buggy_passes = _passes(buggy, tests)
+    fix_passes = _passes(fix, tests)
+    if buggy_passes or not fix_passes:
+        return None
+    failure = _first_failure(buggy, tests)
+    public_test = list(tests)[0] if tests else ""
+    messages = [
+        {"role": "system", "content": SYSTEM},
+        {
+            "role": "user",
+            "content": (
+                "STACK TASK: repair this coding task using the SCBE action grammar.\n"
+                f"Surface: python execution verifier\nPitfall class: {pitfall_class}\n\n"
+                f"Problem:\n{prompt}\n\nVisible check:\n{public_test}"
+            ),
+        },
+        {
+            "role": "assistant",
+            "content": (
+                "PLAN: try the direct implementation, then run the bounded Python tests.\n"
+                "CALL run_code\n```python\n" + buggy + "\n```"
+            ),
+        },
+        {"role": "user", "content": "TOOL run_code: " + failure},
+        {
+            "role": "assistant",
+            "content": (
+                "REPAIR: the execution feedback exposes the pitfall; replace the faulty pattern.\n"
+                "CALL run_code\n```python\n" + fix + "\n```"
+            ),
+        },
+        {"role": "user", "content": "TOOL run_code: PASS"},
+        {
+            "role": "assistant",
+            "content": "ANSWER:\n```python\n"
+            + fix
+            + "\n```\nRECEIPT: verified=PASS; source="
+            + source
+            + "; task_id="
+            + task_id,
+        },
+    ]
+    return {
+        "messages": messages,
+        "meta": {
+            "task_id": task_id,
+            "category": "pitfall_repair",
+            "source": source,
+            "pitfall_class": pitfall_class,
+            "verified": True,
+            "buggy_fails": True,
+            "fix_passes": True,
+            "tests": list(tests),
+            "buggy": buggy,
+            "fix": fix,
+        },
+    }
+
+
+def pitfall_records(limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    for spec in better_corpus.PITFALLS:
+        rec = _repair_record(
+            source="python.helm.better_corpus",
+            task_id="better_" + spec["name"],
+            pitfall_class=spec["name"],
+            prompt=spec["prompt"],
+            buggy=spec["buggy"],
+            fix=spec["fix"],
+            tests=spec["tests"],
+        )
+        if rec:
+            records.append(rec)
+    for spec in pitfall_eval.EVAL:
+        rec = _repair_record(
+            source="python.helm.pitfall_eval",
+            task_id="pitfalleval_" + spec["name"],
+            pitfall_class=spec["cls"],
+            prompt=spec["prompt"],
+            buggy=spec["naive"],
+            fix=spec["ref"],
+            tests=spec["tests"],
+        )
+        if rec:
+            records.append(rec)
+    return records[:limit] if limit is not None else records
+
+
+def _run_command(command: Sequence[str], cwd: Path, timeout: int = 45) -> Dict[str, Any]:
+    proc = subprocess.run(command, cwd=str(cwd), capture_output=True, text=True, timeout=timeout)
+    out = (proc.stdout + proc.stderr).strip()
+    return {"returncode": proc.returncode, "output": out[-1200:]}
+
+
+def stack_smoke_records(repo: Path) -> List[Dict[str, Any]]:
+    specs = [
+        {
+            "task_id": "stack_pycompile_code_lift",
+            "surface": "python compiler",
+            "command": [sys.executable, "-m", "py_compile", "python/helm/code_lift.py"],
+            "why": "prove the code-lift evaluator imports as valid Python before training notebooks depend on it",
+        },
+        {
+            "task_id": "stack_pitfall_eval_smoke",
+            "surface": "pitfall held-out eval",
+            "command": [sys.executable, "-m", "python.helm.pitfall_eval"],
+            "why": "prove the held-out pitfall eval still discriminates before using it as a lift ruler",
+        },
+    ]
+    records: List[Dict[str, Any]] = []
+    for spec in specs:
+        result = _run_command(spec["command"], repo)
+        passed = result["returncode"] == 0
+        command_text = " ".join(spec["command"])
+        messages = [
+            {"role": "system", "content": SYSTEM},
+            {
+                "role": "user",
+                "content": (
+                    "STACK TASK: run a bounded repo check.\n"
+                    f"Surface: {spec['surface']}\nReason: {spec['why']}\n"
+                    f"Command: {command_text}"
+                ),
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "PLAN: use the narrowest command that verifies this surface.\n"
+                    "CALL run_command\n```powershell\n" + command_text + "\n```"
+                ),
+            },
+            {
+                "role": "user",
+                "content": ("TOOL run_command: PASS\n" if passed else "TOOL run_command: FAIL\n") + result["output"],
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "ANSWER: "
+                    + (
+                        "the bounded stack check passed."
+                        if passed
+                        else "the bounded stack check failed; do not train on it as proof."
+                    )
+                    + "\nRECEIPT: verified="
+                    + ("PASS" if passed else "FAIL")
+                    + "; task_id="
+                    + spec["task_id"]
+                ),
+            },
+        ]
+        records.append(
+            {
+                "messages": messages,
+                "meta": {
+                    "task_id": spec["task_id"],
+                    "category": "stack_smoke",
+                    "source": "scripts.training.build_stack_repair_corpus",
+                    "verified": passed,
+                    "command": list(spec["command"]),
+                    "returncode": result["returncode"],
+                },
+            }
+        )
+    return records
+
+
+def build_records(repo: Path, limit_pitfalls: Optional[int], include_smoke: bool) -> List[Dict[str, Any]]:
+    records = pitfall_records(limit=limit_pitfalls)
+    if include_smoke:
+        records.extend(stack_smoke_records(repo))
+    return records
+
+
+def write_jsonl(path: Path, records: Iterable[Dict[str, Any]]) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with path.open("w", encoding="utf-8", newline="\n") as f:
+        for rec in records:
+            f.write(_json_line(rec) + "\n")
+            count += 1
+    return count
+
+
+def write_manifest(path: Path, out: Path, records: Sequence[Dict[str, Any]], repo: Path) -> Dict[str, Any]:
+    categories: Dict[str, int] = {}
+    for rec in records:
+        cat = rec.get("meta", {}).get("category", "unknown")
+        categories[cat] = categories.get(cat, 0) + 1
+    try:
+        head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=str(repo), text=True).strip()
+        branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=str(repo), text=True).strip()
+    except Exception:
+        head = "unknown"
+        branch = "unknown"
+    manifest = {
+        "schema": "scbe.stack_agent_corpus.v1",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "repo": str(repo),
+        "git_head": head,
+        "git_branch": branch,
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "records": len(records),
+        "categories": categories,
+        "verified_records": sum(1 for r in records if r.get("meta", {}).get("verified") is True),
+        "output": str(out),
+        "sha256": _sha256(out),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    return manifest
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Build the SCBE stack-agent repair corpus")
+    ap.add_argument("--out", default="training/sft_records/stack_agent_seed.jsonl")
+    ap.add_argument("--manifest", default=None)
+    ap.add_argument("--limit-pitfalls", type=int, default=None)
+    ap.add_argument("--include-smoke", action="store_true", help="also execute and include bounded stack smoke checks")
+    args = ap.parse_args(list(argv) if argv is not None else None)
+
+    repo = Path.cwd()
+    out = Path(args.out)
+    manifest_path = Path(args.manifest) if args.manifest else out.with_suffix(out.suffix + ".manifest.json")
+    records = build_records(repo, args.limit_pitfalls, args.include_smoke)
+    if not records:
+        raise SystemExit("no records built")
+    write_jsonl(out, records)
+    manifest = write_manifest(manifest_path, out, records, repo)
+    print(
+        "STACK_AGENT_CORPUS records=%d verified=%d sha256=%s out=%s"
+        % (manifest["records"], manifest["verified_records"], manifest["sha256"], out)
+    )
+    print("manifest=%s" % manifest_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/training/eval_stack_agent.py
+++ b/scripts/training/eval_stack_agent.py
@@ -1,0 +1,146 @@
+"""Validate a stack-agent SFT corpus.
+
+This gate checks the data shape and re-runs execution verification for repair
+records. It is deliberately separate from training loss: a corpus can train
+cleanly and still be useless if its repair claims are not verified.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from python.helm import public_bench
+
+
+def _load_jsonl(path: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            if line.strip():
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    raise ValueError("invalid json on line %d: %s" % (i, exc)) from exc
+    return rows
+
+
+def _passes(source: str, tests: Sequence[str]) -> bool:
+    return bool(public_bench._verify(source, [], tests, [])["hidden_passed"])
+
+
+def _messages_have_tool_turn(messages: Iterable[Dict[str, Any]]) -> bool:
+    return any(str(m.get("content", "")).startswith("TOOL ") for m in messages if m.get("role") == "user")
+
+
+def _final_has_receipt(messages: Sequence[Dict[str, Any]]) -> bool:
+    if not messages:
+        return False
+    return "RECEIPT:" in str(messages[-1].get("content", ""))
+
+
+def evaluate(records: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    failures: List[Dict[str, Any]] = []
+    categories: Dict[str, int] = {}
+    task_ids: List[str] = []
+    reverified = 0
+    teacher_bailout = 0
+    self_repair = 0
+
+    for idx, rec in enumerate(records):
+        meta = rec.get("meta", {})
+        messages = rec.get("messages", [])
+        task_id = str(meta.get("task_id", ""))
+        category = str(meta.get("category", "unknown"))
+        categories[category] = categories.get(category, 0) + 1
+        task_ids.append(task_id)
+
+        if not task_id:
+            failures.append({"index": idx, "reason": "missing task_id"})
+        if not isinstance(messages, list) or len(messages) < 3:
+            failures.append({"task_id": task_id, "reason": "too few messages"})
+            continue
+        if not _messages_have_tool_turn(messages):
+            failures.append({"task_id": task_id, "reason": "missing TOOL feedback turn"})
+        if not _final_has_receipt(messages):
+            failures.append({"task_id": task_id, "reason": "missing final receipt"})
+        if meta.get("verified") is not True:
+            failures.append({"task_id": task_id, "reason": "meta.verified is not true"})
+
+        if category == "pitfall_repair":
+            tests = meta.get("tests", [])
+            buggy = meta.get("buggy", "")
+            fix = meta.get("fix", "")
+            if not tests or not buggy or not fix:
+                failures.append({"task_id": task_id, "reason": "pitfall record missing tests/buggy/fix"})
+            else:
+                buggy_passes = _passes(str(buggy), tests)
+                fix_passes = _passes(str(fix), tests)
+                if buggy_passes or not fix_passes:
+                    failures.append(
+                        {
+                            "task_id": task_id,
+                            "reason": "execution reverify failed",
+                            "buggy_passes": buggy_passes,
+                            "fix_passes": fix_passes,
+                        }
+                    )
+                else:
+                    reverified += 1
+            if "TOOL run_code: FAIL" in json.dumps(messages):
+                self_repair += 1
+            else:
+                teacher_bailout += 1
+
+    duplicate_ids = sorted({tid for tid in task_ids if tid and task_ids.count(tid) > 1})
+    for tid in duplicate_ids:
+        failures.append({"task_id": tid, "reason": "duplicate task_id"})
+
+    total = len(records)
+    report = {
+        "schema": "scbe.stack_agent_eval.v1",
+        "total_records": total,
+        "categories": categories,
+        "verified_records": sum(1 for r in records if r.get("meta", {}).get("verified") is True),
+        "reverified_repair_records": reverified,
+        "duplicate_task_ids": duplicate_ids,
+        "tool_feedback_records": sum(1 for r in records if _messages_have_tool_turn(r.get("messages", []))),
+        "receipt_records": sum(1 for r in records if _final_has_receipt(r.get("messages", []))),
+        "self_repair_records": self_repair,
+        "teacher_bailout_records": teacher_bailout,
+        "failures": failures,
+        "pass": not failures and total > 0,
+    }
+    return report
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Validate the SCBE stack-agent SFT corpus")
+    ap.add_argument("--corpus", default="training/sft_records/stack_agent_seed.jsonl")
+    ap.add_argument("--out", default="training/evals/stack_agent_eval_report.json")
+    args = ap.parse_args(list(argv) if argv is not None else None)
+
+    corpus = Path(args.corpus)
+    out = Path(args.out)
+    records = _load_jsonl(corpus)
+    report = evaluate(records)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    print(
+        "STACK_AGENT_EVAL pass=%s records=%d reverified=%d failures=%d out=%s"
+        % (report["pass"], report["total_records"], report["reverified_repair_records"], len(report["failures"]), out)
+    )
+    if report["failures"]:
+        print(json.dumps(report["failures"][:5], indent=2, sort_keys=True))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/training/plans/code_agent_stack_curriculum.md
+++ b/training/plans/code_agent_stack_curriculum.md
@@ -1,0 +1,169 @@
+# SCBE Stack Code-Agent Training Curriculum
+
+This lane trains a coding agent to operate the SCBE-AETHERMOORE stack as a governed
+multi-compiler system, not as a generic MBPP answer machine.
+
+The target behavior is:
+
+```text
+read task -> inspect stack context -> propose code/command -> run bounded check
+-> repair from evidence -> emit answer + receipt
+```
+
+## Stage 0 - Stack Substrate Lock
+
+Freeze the surfaces the agent must learn before generating data:
+
+- Python verifier lane: `python/helm/public_bench.py`, `python/helm/code_lift.py`
+- Pitfall repair lane: `python/helm/better_corpus.py`, `python/helm/pitfall_eval.py`
+- Repo command lane: `scripts/training/*`, `tests/*`, package manifests
+- Notebook lane: `notebooks/*_colab.ipynb`
+- Governance expectation: every executable action has a check and a receipt
+
+Output:
+
+- `training/sft_records/stack_agent_seed.manifest.json`
+
+## Stage 1 - Action Grammar
+
+Every record must teach this grammar:
+
+```text
+PLAN: name the relevant stack surface
+CALL run_code or CALL run_command
+TOOL: return PASS/FAIL evidence
+REPAIR: change only what the evidence supports
+ANSWER: final code/command plus receipt
+```
+
+The grammar is intentionally small. The edge agent should not need a full model to
+remember policy; it should learn the transition format.
+
+## Stage 2 - Verified Repair Corpus
+
+Use execution-verified pitfall traces as the first hard coding layer:
+
+- buggy attempt must fail by execution
+- fixed attempt must pass by execution
+- record must contain the failure feedback and the repair
+- final answer must include a receipt
+
+Command:
+
+```powershell
+python scripts/training/build_stack_repair_corpus.py `
+  --out training/sft_records/stack_agent_seed.jsonl `
+  --manifest training/sft_records/stack_agent_seed.manifest.json
+```
+
+## Stage 3 - Stack Smoke Corpus
+
+Add stack-operation tasks that teach the agent how this repo is checked:
+
+- compile/check a Python module
+- run a narrow verifier
+- inspect benchmark output
+- preserve source-of-truth artifacts
+
+These records are marked `stack_smoke`; they are command-oriented and are not a
+substitute for held-out code capability tests.
+
+## Stage 4 - Corpus Gate
+
+Before any GPU run, validate the data:
+
+```powershell
+python scripts/training/eval_stack_agent.py `
+  --corpus training/sft_records/stack_agent_seed.jsonl `
+  --out training/evals/stack_agent_eval_report.json
+```
+
+Required gates:
+
+- no duplicate task ids
+- every repair record re-verifies
+- every record has at least one tool feedback turn
+- every record has a receipt in the final assistant turn
+- teacher-correction records are counted separately from self-repair records
+
+## Stage 5 - Gentle SFT
+
+Default training policy after the measured `-4` regression:
+
+- learning rate: `5e-5`
+- epochs: `1`
+- small batch, gradient accumulation
+- adapter training only
+- save adapter and report artifacts every run
+
+Notebook:
+
+```text
+notebooks/vtc_stack_agent_staged_colab.ipynb
+```
+
+Artifacts:
+
+```text
+/content/stack_agent_stage/stack_agent_seed.jsonl
+/content/stack_agent_stage/stack_agent_seed.manifest.json
+/content/stack_agent_stage/stack_agent_eval_report.json
+/content/stack_agent_stage/adapter/
+/content/stack_agent_stage/train_metrics.json
+/content/stack_agent_stage/report.json
+```
+
+## Stage 6 - Held-Out Capability Eval
+
+The first held-out eval is `python.helm.pitfall_eval.eval_problems()` because it
+has verified headroom for the pitfall classes the corpus teaches.
+
+Report all three numbers:
+
+- newly solved
+- regressed
+- net lift
+
+Do not claim success from training loss alone.
+
+## Stage 7 - Multi-Compiler Expansion
+
+After the Python repair lane shows non-negative lift, extend the corpus with
+language/compiler adapters:
+
+- Python: `py_compile`, pytest subset, public/hidden execution checks
+- TypeScript/Node: `npm test`, package-script checks, browser harness checks
+- Rust: `cargo test` on bounded crates
+- Shell/PowerShell: allowlisted command profiles only
+- AetherDesk: in-page agent API tasks scored by final state
+
+Each language adds records in the same shape, not a new data format.
+
+## Stage 8 - Role-Squad Training
+
+Split trajectories into roles without changing the artifact schema:
+
+- ARCHITECT: selects stack surface and constraints
+- CODER: writes the patch/code
+- CHECK: runs verifier and explains failure
+- OPTIMIZER: shrinks risky change
+- GOVERNOR: refuses unsafe action and emits receipt
+
+The final model can be single-agent, but the data should teach role-conditioned
+behavior.
+
+## Release Gate
+
+A model is not stack-agent-ready until it passes:
+
+```text
+corpus gate PASS
+held-out pitfall eval net_lift >= 0
+stack smoke eval PASS
+no destructive command leakage in generated command records
+artifact manifest written
+```
+
+If net lift is zero, keep the run as an honest checkpoint and expand the corpus.
+If net lift is negative, lower training pressure or remove noisy records before
+trying another run.


### PR DESCRIPTION
Adds a complete SCBE stack-agent training lane: curriculum plan, verified repair corpus builder, independent corpus validator, staged Colab notebook, and Colab catalog registration.\n\nVerification run locally:\n- black --target-version py311 --line-length 120 scripts/training/build_stack_repair_corpus.py scripts/training/eval_stack_agent.py scripts/system/colab_workflow_catalog.py\n- flake8 --max-line-length 120 scripts/training/build_stack_repair_corpus.py scripts/training/eval_stack_agent.py scripts/system/colab_workflow_catalog.py\n- python -m py_compile scripts/training/build_stack_repair_corpus.py scripts/training/eval_stack_agent.py scripts/system/colab_workflow_catalog.py\n- python scripts/training/build_stack_repair_corpus.py --out C:\\tmp\\stack_agent_seed.jsonl --manifest C:\\tmp\\stack_agent_seed.manifest.json --include-smoke\n- python scripts/training/eval_stack_agent.py --corpus C:\\tmp\\stack_agent_seed.jsonl --out C:\\tmp\\stack_agent_eval_report.json\n- python scripts/system/colab_workflow_catalog.py show stack-agent --json\n\nLocal corpus gate result: 31 records, 31 verified, 29 repair records re-executed, 0 failures.\n