### PR TITLE
style(helm): black repair-bank files

### DIFF
--- a/python/helm/domain_router.py
+++ b/python/helm/domain_router.py
@@ -98,8 +98,7 @@ def _repair_arrow(domain: str, attempt_no: int, check: Dict[str, Any]) -> str:
     return (
         "\n\nREPAIR ARROW %d:\n"
         "Your previous candidate did not verify (%s). Keep the same function signature, use the %s-domain hint, "
-        "fix the boundary case, and return ONLY complete Python code.%s"
-        % (attempt_no, reason, domain, detail)
+        "fix the boundary case, and return ONLY complete Python code.%s" % (attempt_no, reason, domain, detail)
     )
 
 

--- a/python/helm/reference_bank.py
+++ b/python/helm/reference_bank.py
@@ -28,7 +28,7 @@ BANK = os.path.join(HERE, "reference_bank.jsonl")
 
 # Authored canonical fixes -- one per failure CLASS the local model systematically misses.
 SOLUTIONS = {
-    "pf_collect_leaves": '''
+    "pf_collect_leaves": """
 def collect_leaves(tree, path=None, out=None):
     if path is None: path = []
     if out is None: out = []
@@ -40,8 +40,8 @@ def collect_leaves(tree, path=None, out=None):
         for ch in children:
             collect_leaves(ch, newpath, out)
     return out
-''',
-    "pf_binary_search_midpoints": '''
+""",
+    "pf_binary_search_midpoints": """
 def binary_search_midpoints(n):
     lo, hi, out = 0, n - 1, []
     while lo <= hi:
@@ -49,8 +49,8 @@ def binary_search_midpoints(n):
         out.append(mid)
         hi = mid - 1
     return out
-''',
-    "pf_change_due": '''
+""",
+    "pf_change_due": """
 def change_due(paid, price, denominations):
     rem = round((paid - price) * 100)
     out = {}
@@ -63,47 +63,47 @@ def change_due(paid, price, denominations):
         if rem == 0:
             break
     return out
-''',
-    "pf_frange_count": '''
+""",
+    "pf_frange_count": """
 def frange_count(start, stop, step):
     cnt, i = 0, 0
     while start + i * step <= stop + 1e-9:
         cnt += 1
         i += 1
     return cnt
-''',
-    "pf_make_multipliers": '''
+""",
+    "pf_make_multipliers": """
 def make_multipliers(factors):
     return [(lambda f: (lambda x: x * f))(fac) for fac in factors]
-''',
-    "pf_build_validators": '''
+""",
+    "pf_build_validators": """
 def build_validators(thresholds):
     return {name: (lambda t: (lambda v: v >= t))(thr) for name, thr in thresholds.items()}
-''',
-    "pf_column_getters": '''
+""",
+    "pf_column_getters": """
 def column_getters(headers):
     return [(lambda idx: (lambda row: row[idx]))(i) for i in range(len(headers))]
-''',
-    "pf_schedule_steps": '''
+""",
+    "pf_schedule_steps": """
 def schedule_steps(steps):
     cbs, total = [], 0
     for label, delta in steps:
         total += delta
         cbs.append((lambda l, t: (lambda: "%s:%d" % (l, t)))(label, total))
     return cbs
-''',
-    "pf_expand_template": '''
+""",
+    "pf_expand_template": """
 def expand_template(template, n):
     grid = [list(template) for _ in range(n)]
     for j in range(len(grid[-1])):
         grid[-1][j] += 1
     return grid
-''',
-    "pf_duplicate_board": '''
+""",
+    "pf_duplicate_board": """
 def duplicate_board(board, n):
     return [[list(row) for row in board] for _ in range(n)]
-''',
-    "pf_apply_defaults": '''
+""",
+    "pf_apply_defaults": """
 import copy
 def apply_defaults(base_config, overrides_list):
     res = []
@@ -113,8 +113,8 @@ def apply_defaults(base_config, overrides_list):
             d[k] = v
         res.append(d)
     return res
-''',
-    "pf_record_history": '''
+""",
+    "pf_record_history": """
 import copy
 def record_history(state, events):
     history = []
@@ -123,23 +123,23 @@ def record_history(state, events):
         inv[item] = inv.get(item, 0) + delta
         history.append(copy.deepcopy(state))
     return history
-''',
-    "pf_apply_renames": '''
+""",
+    "pf_apply_renames": """
 def apply_renames(record, rename_map):
     out = {}
     for k, v in record.items():
         out[rename_map.get(k, k)] = v
     return out
-''',
-    "pf_merge_sorted_unique": '''
+""",
+    "pf_merge_sorted_unique": """
 def merge_sorted_unique(a, b):
     return sorted(set(a) | set(b))
-''',
-    "pf_sort_words_by_length": '''
+""",
+    "pf_sort_words_by_length": """
 def sort_words_by_length(words):
     return sorted(words, key=lambda w: (len(w), w))
-''',
-    "pf_median": '''
+""",
+    "pf_median": """
 def median(nums):
     if not nums:
         raise ValueError("empty")
@@ -148,12 +148,12 @@ def median(nums):
     if n % 2:
         return s[n // 2]
     return (s[n // 2 - 1] + s[n // 2]) / 2
-''',
-    "pf_remove_expired": '''
+""",
+    "pf_remove_expired": """
 def remove_expired(sessions, now):
     return [s for s in sessions if s["expiry"] > now]
-''',
-    "pf_collapse_runs": '''
+""",
+    "pf_collapse_runs": """
 def collapse_runs(nums):
     i = 1
     while i < len(nums):
@@ -162,8 +162,8 @@ def collapse_runs(nums):
         else:
             i += 1
     return nums
-''',
-    "pf_running_max_resets": '''
+""",
+    "pf_running_max_resets": """
 def running_max_resets(nums, reset_on_zero=False):
     out, cur = [], None
     for x in nums:
@@ -174,8 +174,8 @@ def running_max_resets(nums, reset_on_zero=False):
         cur = x if cur is None else max(cur, x)
         out.append(cur)
     return out
-''',
-    "pf_chunk_diffs_from_start": '''
+""",
+    "pf_chunk_diffs_from_start": """
 def chunk_diffs_from_start(data, chunk_size):
     if chunk_size < 1:
         raise ValueError("chunk_size must be >= 1")
@@ -187,8 +187,8 @@ def chunk_diffs_from_start(data, chunk_size):
         chunk = data[i:i + chunk_size]
         out.append(chunk[-1] - first)
     return out
-''',
-    "pf_longest_run_value": '''
+""",
+    "pf_longest_run_value": """
 def longest_run_value(seq):
     if not seq:
         return None
@@ -202,43 +202,49 @@ def longest_run_value(seq):
         if cur_len > best_len:
             best_len, best_val = cur_len, cur_val
     return best_val
-''',
-    "pf_trim_and_summarize": '''
+""",
+    "pf_trim_and_summarize": """
 def trim_and_summarize(lines):
     cleaned = [s.strip() for s in lines if s.strip()]
     if not cleaned:
         return {"first": None, "last": None, "count": 0}
     return {"first": cleaned[0], "last": cleaned[-1], "count": len(cleaned)}
-''',
+""",
 }
 
 
 def _passes(code, tests):
     try:
-        return subprocess.run([sys.executable, "-c", code + "\n" + "\n".join(tests) + "\n"],
-                              capture_output=True, text=True, timeout=15).returncode == 0
+        return (
+            subprocess.run(
+                [sys.executable, "-c", code + "\n" + "\n".join(tests) + "\n"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            ).returncode
+            == 0
+        )
     except Exception:
         return False
 
 
 def build():
-    pool = {json.loads(l)["task_id"]: json.loads(l)
-            for l in open(POOL, encoding="utf-8") if l.strip()}
+    pool = {json.loads(l)["task_id"]: json.loads(l) for l in open(POOL, encoding="utf-8") if l.strip()}
     banked, rejected = [], []
     for tid, code in SOLUTIONS.items():
         if tid not in pool:
             rejected.append((tid, "not in pool"))
             continue
         if _passes(code, pool[tid]["test_list"]):
-            banked.append({"task_id": tid, "code": code.strip(),
-                           "category": pool[tid]["category"]})
+            banked.append({"task_id": tid, "code": code.strip(), "category": pool[tid]["category"]})
         else:
             rejected.append((tid, "FAILED full tests -- NOT banked"))
     with open(BANK, "w", encoding="utf-8") as f:
         for row in banked:
             f.write(json.dumps(row) + "\n")
-    print("reference_bank: banked %d/%d verified references -> %s"
-          % (len(banked), len(SOLUTIONS), os.path.basename(BANK)))
+    print(
+        "reference_bank: banked %d/%d verified references -> %s" % (len(banked), len(SOLUTIONS), os.path.basename(BANK))
+    )
     for tid, why in rejected:
         print("  REJECTED %s: %s" % (tid, why))
     return len(banked), len(rejected)
@@ -247,8 +253,7 @@ def build():
 def load():
     if not os.path.exists(BANK):
         return {}
-    return {json.loads(l)["task_id"]: json.loads(l)["code"]
-            for l in open(BANK, encoding="utf-8") if l.strip()}
+    return {json.loads(l)["task_id"]: json.loads(l)["code"] for l in open(BANK, encoding="utf-8") if l.strip()}
 
 
 def get(task_id):
@@ -297,7 +302,12 @@ def put_verified(
     if not candidate:
         return {"banked": False, "reason": "missing code", "hidden_passed": False, "fuzz_verdict": "not_run"}
     if not _passes(candidate, tests):
-        return {"banked": False, "reason": "candidate failed verification tests", "hidden_passed": False, "fuzz_verdict": "not_run"}
+        return {
+            "banked": False,
+            "reason": "candidate failed verification tests",
+            "hidden_passed": False,
+            "fuzz_verdict": "not_run",
+        }
 
     fuzz_report: Dict[str, Any] = {"verdict": "not_required", "reason": "require_fuzz is false"}
     if require_fuzz:

--- a/python/helm/system_coder.py
+++ b/python/helm/system_coder.py
@@ -259,7 +259,9 @@ def _solve_known_logic_task(raw: Mapping[str, Any], index: int, spec: Mapping[st
     return receipt
 
 
-def _solve_answer_stage_task(raw: Mapping[str, Any], index: int, spec: Mapping[str, Any], run_id: str) -> Dict[str, Any]:
+def _solve_answer_stage_task(
+    raw: Mapping[str, Any], index: int, spec: Mapping[str, Any], run_id: str
+) -> Dict[str, Any]:
     task_id = _task_id(raw, index)
     started = time.perf_counter()
     task = answer_stage.task_from_record(raw["task"])
@@ -366,7 +368,12 @@ def run_tasks(path: str, spec: Mapping[str, Any], run_id: Optional[str] = None) 
     rows = _read_jsonl(path)
     rid = run_id or time.strftime("run-%Y%m%d-%H%M%S")
     receipts = [solve_record(row, i, spec, rid) for i, row in enumerate(rows, 1)]
-    return {"run_id": rid, "summary": summarize(receipts), "receipts": receipts, "sft": [sft_record(r) for r in receipts]}
+    return {
+        "run_id": rid,
+        "summary": summarize(receipts),
+        "receipts": receipts,
+        "sft": [sft_record(r) for r in receipts],
+    }
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/tests/test_domain_router_repair_bank.py
+++ b/tests/test_domain_router_repair_bank.py
@@ -1,7 +1,6 @@
 from python.helm import reference_bank
 from python.helm.domain_router import solve_routed
 
-
 ADD_PROMPT = "Write a function add(a, b) that returns the sum."
 ADD_TESTS = ["assert add(2, 2) == 4", "assert add(-1, 3) == 2", "assert add(5, 7) == 12"]
 ADD_REF = "def add(a, b):\n    return a + b\n"


### PR DESCRIPTION
## Summary
- follow-up to #2633: apply Black formatting to the repair/auto-bank files that CI flagged
- based on current origin/main to avoid carrying stale branch deletions

## Verification
- black --check --target-version py311 --line-length 120 src/ tests/ scripts/ agents/ -> pass
- python -m pytest tests/test_system_coder.py tests/test_domain_router_repair_bank.py tests/test_reference_bank_live_loop.py tests/test_known_logic_injection.py tests/test_pivot_packet_calculator.py tests/test_system_coding_contract.py -q -> 30 passed
- python -m python.helm.system_coder --task tests\fixtures\system_coder_tasks.jsonl --spec configs\system_coder.spec.yaml --run-id smoke-black-followup --out C:\tmp\system_coder\report-black-followup.json --sft-out C:\tmp\system_coder\train-black-followup.jsonl -> 5/5 solved, false_success_count 0