### PR TITLE
style(reconcile): fix python lint for tracked-files cleanup

### DIFF
--- a/scripts/kaggle/pack_vtc_dataset.py
+++ b/scripts/kaggle/pack_vtc_dataset.py
@@ -18,7 +18,6 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CORPUS = ROOT / "training-data" / "sft" / "vtc_mbpp_refined.jsonl"
 DEFAULT_MANIFEST = ROOT / "training-data" / "sft" / "vtc_mbpp_refined.manifest.json"
@@ -38,7 +37,9 @@ def _count_jsonl(path: Path) -> int:
         return sum(1 for line in f if line.strip())
 
 
-def pack(corpus: Path = DEFAULT_CORPUS, manifest: Path = DEFAULT_MANIFEST, out_dir: Path = DEFAULT_OUT) -> dict[str, Any]:
+def pack(
+    corpus: Path = DEFAULT_CORPUS, manifest: Path = DEFAULT_MANIFEST, out_dir: Path = DEFAULT_OUT
+) -> dict[str, Any]:
     if not corpus.exists():
         raise FileNotFoundError(f"missing VTC corpus: {corpus}")
     if not manifest.exists():
@@ -66,7 +67,10 @@ def pack(corpus: Path = DEFAULT_CORPUS, manifest: Path = DEFAULT_MANIFEST, out_d
         "sha256": digest,
         "source_manifest": upstream_manifest,
         "kaggle_dataset_id": kaggle_metadata["id"],
-        "notebook_hint": "Add this dataset to notebooks/vtc_lift_qwen15_colab.ipynb; Kaggle mounts it under /kaggle/input/vtc-mbpp-refined/.",
+        "notebook_hint": (
+            "Add this dataset to notebooks/vtc_lift_qwen15_colab.ipynb; "
+            "Kaggle mounts it under /kaggle/input/vtc-mbpp-refined/."
+        ),
     }
     (out_dir / "dataset-metadata.json").write_text(json.dumps(kaggle_metadata, indent=2), encoding="utf-8")
     (out_dir / "vtc_kaggle_manifest.json").write_text(json.dumps(dataset_manifest, indent=2), encoding="utf-8")

--- a/scripts/research/fuse_thermal_optical.py
+++ b/scripts/research/fuse_thermal_optical.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError:  # Direct execution from scripts/research.
         compute_log_transitions,
     )
 
+
 def fused_anchor_score(
     gaps: list[float],
     historical_gaps: list[float] | None = None,
@@ -65,6 +66,7 @@ def fused_anchor_score(
     fused = (1 - optical_weight) * thermal_score + optical_weight * optical_score
     return max(0.01, min(0.99, fused))
 
+
 # Example usage inside your probe
 if __name__ == "__main__":
     # Fake recent gaps (replace with real window from your probe)
@@ -72,7 +74,7 @@ if __name__ == "__main__":
     # Earlier history for retention lookup
     hist_gaps = [8, 10, 14, 12, 20, 18, 30, 24, 16, 36, 42, 50, 28, 18, 66] * 5
 
-    thermal = 0.62   # whatever your current model outputs for this window
+    thermal = 0.62  # whatever your current model outputs for this window
     fused = fused_anchor_score(recent_gaps, hist_gaps, thermal_score=thermal)
 
     print(f"Thermal only : {thermal:.4f}")

--- a/scripts/research/optical_laser_prime_model.py
+++ b/scripts/research/optical_laser_prime_model.py
@@ -19,6 +19,7 @@ import math
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
+
 @dataclass
 class Transition:
     idx: int
@@ -27,20 +28,24 @@ class Transition:
     thermal_amplitude: float = 0.0
     gradient_abs: float = 0.0
 
+
 def compute_log_transitions(gaps: List[float]) -> List[Transition]:
     """Convert raw gaps into log R and log Q (curvature)."""
     if len(gaps) < 3:
         return []
     trans = []
     for i in range(len(gaps) - 2):
-        r = gaps[i+1] / gaps[i] if gaps[i] > 0 else 1.0
-        q = (gaps[i+1] / gaps[i]) / (gaps[i+2] / gaps[i+1]) if gaps[i+1] > 0 and gaps[i] > 0 else 1.0
-        trans.append(Transition(
-            idx=i,
-            log_r=math.log(r) if r > 0 else 0.0,
-            log_q=math.log(q) if q > 0 else 0.0,
-        ))
+        r = gaps[i + 1] / gaps[i] if gaps[i] > 0 else 1.0
+        q = (gaps[i + 1] / gaps[i]) / (gaps[i + 2] / gaps[i + 1]) if gaps[i + 1] > 0 and gaps[i] > 0 else 1.0
+        trans.append(
+            Transition(
+                idx=i,
+                log_r=math.log(r) if r > 0 else 0.0,
+                log_q=math.log(q) if q > 0 else 0.0,
+            )
+        )
     return trans
+
 
 def optical_depth(t: Transition, window: List[Transition], cold_spot: float, gradient_abs: float) -> float:
     """
@@ -54,10 +59,9 @@ def optical_depth(t: Transition, window: List[Transition], cold_spot: float, gra
     d = local_curvature * 2.0 + thermal_signal * 1.5
     return d
 
+
 def compute_dual_wavelength_scores(
-    recent_trans: List[Transition],
-    historical: List[Transition],
-    k: int = 8
+    recent_trans: List[Transition], historical: List[Transition], k: int = 8
 ) -> Dict[str, float]:
     """
     Ultra-visible: fine detail on recent log_q
@@ -82,11 +86,8 @@ def compute_dual_wavelength_scores(
 
     return {"ultra": ultra, "sub": sub}
 
-def laser_mode(
-    d: float,
-    d_star: float = 1.8,
-    retention_weight: float = 0.7
-) -> Tuple[str, float]:
+
+def laser_mode(d: float, d_star: float = 1.8, retention_weight: float = 0.7) -> Tuple[str, float]:
     """
     Returns (mode, retention_strength)
     """
@@ -96,11 +97,8 @@ def laser_mode(
         strength = min(0.95, (d - d_star) * retention_weight)
         return "retention", strength
 
-def retention_boost(
-    current: Transition,
-    historical: List[Transition],
-    top_k: int = 5
-) -> float:
+
+def retention_boost(current: Transition, historical: List[Transition], top_k: int = 5) -> float:
     """
     In retention mode, find similar past transitions and return a boost.
     This is the 'photon retention' / memory retrieval step.
@@ -124,6 +122,7 @@ def retention_boost(
     boost = 1.0 + (1.0 / (1.0 + avg_dist * 3.0))
     return boost
 
+
 def apply_optical_laser(
     window_trans: List[Transition],
     historical_trans: List[Transition],
@@ -144,10 +143,10 @@ def apply_optical_laser(
 
     wl = compute_dual_wavelength_scores(window_trans, historical_trans)
 
-    base = (wl["ultra"] * 0.6 + wl["sub"] * 0.4)
+    base = wl["ultra"] * 0.6 + wl["sub"] * 0.4
 
     if mode == "penetration":
-        score = base * (1.0 + 0.3 * gradient_abs)   # encourage exploration
+        score = base * (1.0 + 0.3 * gradient_abs)  # encourage exploration
     else:
         boost = retention_boost(current, historical_trans)
         score = base * (1.0 + retention_strength * boost * 1.2)
@@ -155,12 +154,13 @@ def apply_optical_laser(
     # Bound it
     return max(0.01, min(0.99, score))
 
+
 # Example usage stub
 if __name__ == "__main__":
     # Toy example with fake log transitions
     fake_gaps = [10, 14, 18, 22, 30, 42, 50, 58, 70, 90, 110]
     trans = compute_log_transitions(fake_gaps)
-    print("Transitions:", [(round(t.log_r,4), round(t.log_q,4)) for t in trans])
+    print("Transitions:", [(round(t.log_r, 4), round(t.log_q, 4)) for t in trans])
 
     hist = trans[:-3]  # pretend earlier ones are "historical"
     recent = trans[-3:]

--- a/scripts/research/run_thermal_grid_sweep.py
+++ b/scripts/research/run_thermal_grid_sweep.py
@@ -13,7 +13,6 @@ import subprocess
 import time
 import json
 import psutil
-import os
 from pathlib import Path
 from itertools import product
 from datetime import datetime
@@ -21,16 +20,20 @@ from datetime import datetime
 GRID = list(product([2, 3, 4], [3, 4, 5, 6]))  # (cold_spot, gradient_abs)
 
 BASE_CMD = [
-    "python", "scripts/research/prime_fog_of_war_probe.py",
-    "--imaginary-paths-limit", "50000000",
+    "python",
+    "scripts/research/prime_fog_of_war_probe.py",
+    "--imaginary-paths-limit",
+    "50000000",
     "--field-scan",
 ]
 
 OUT_DIR = Path("artifacts/prime_fog_sweep")
 OUT_DIR.mkdir(parents=True, exist_ok=True)
 
+
 def mem_available_gb() -> float:
-    return psutil.virtual_memory().available / (1024 ** 3)
+    return psutil.virtual_memory().available / (1024**3)
+
 
 def run_profile(cold: int, gabs: int, limit_gb: float = 10.0, timeout_min: int = 60):
     profile = f"igct_c{cold}_g{gabs}"
@@ -44,13 +47,7 @@ def run_profile(cold: int, gabs: int, limit_gb: float = 10.0, timeout_min: int =
     print(f"\n=== Starting {profile} at {datetime.now().isoformat()} ===")
     print("Command:", " ".join(cmd))
 
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1
-    )
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
 
     start = time.time()
     lines = []
@@ -90,6 +87,7 @@ def run_profile(cold: int, gabs: int, limit_gb: float = 10.0, timeout_min: int =
     print(f"=== Finished {profile} rc={rc} in {duration:.1f}s ===\n")
     time.sleep(8)  # breathing room
     return result
+
 
 if __name__ == "__main__":
     print("Thermal grid sweep driver")

--- a/scripts/system/agent_shell.py
+++ b/scripts/system/agent_shell.py
@@ -15,12 +15,11 @@ import json
 import os
 import selectors
 import subprocess
-import sys
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "artifacts" / "agent_shell"

--- a/scripts/system/mahss_game_gym.py
+++ b/scripts/system/mahss_game_gym.py
@@ -15,7 +15,6 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-
 DEFAULT_PACMAN_BOARD = """
 #########
 #A..V...#
@@ -129,7 +128,9 @@ class WorldTick:
     receipt: dict[str, Any]
 
 
-def _parse_board(board: str) -> tuple[list[list[str]], tuple[int, int], set[tuple[int, int]], dict[tuple[int, int], str]]:
+def _parse_board(
+    board: str,
+) -> tuple[list[list[str]], tuple[int, int], set[tuple[int, int]], dict[tuple[int, int], str]]:
     rows = [list(line.rstrip()) for line in board.strip().splitlines() if line.strip()]
     if not rows:
         raise ValueError("empty board")
@@ -268,11 +269,38 @@ def _score_lock(piece: TetrisPiece, slot: TetrisSlot, available: set[str]) -> Te
 def default_tetris_pieces() -> list[TetrisPiece]:
     return [
         TetrisPiece("receiver_model", "receive", "parse request into state", (0.95, 0.55, 0.85), 0.08, ("parsed",)),
-        TetrisPiece("router_model", "route", "select backend/tool lane", (0.80, 0.90, 0.85), 0.16, ("route",), ("parsed",)),
-        TetrisPiece("tool_executor", "execute", "run bounded tool action", (0.65, 0.75, 0.82), 0.24, ("artifact",), ("route",)),
-        TetrisPiece("verifier_model", "verify", "score result and catch drift", (0.70, 0.98, 0.92), 0.10, ("verified",), ("artifact",)),
-        TetrisPiece("manager_model", "exception", "handle jam/escalation only", (0.55, 0.92, 0.98), 0.38, ("manager_decision",), ("verified",)),
-        TetrisPiece("unsafe_direct_llm", "execute", "model tries to do everything directly", (0.30, 0.20, 0.25), 0.88, ("artifact",)),
+        TetrisPiece(
+            "router_model", "route", "select backend/tool lane", (0.80, 0.90, 0.85), 0.16, ("route",), ("parsed",)
+        ),
+        TetrisPiece(
+            "tool_executor", "execute", "run bounded tool action", (0.65, 0.75, 0.82), 0.24, ("artifact",), ("route",)
+        ),
+        TetrisPiece(
+            "verifier_model",
+            "verify",
+            "score result and catch drift",
+            (0.70, 0.98, 0.92),
+            0.10,
+            ("verified",),
+            ("artifact",),
+        ),
+        TetrisPiece(
+            "manager_model",
+            "exception",
+            "handle jam/escalation only",
+            (0.55, 0.92, 0.98),
+            0.38,
+            ("manager_decision",),
+            ("verified",),
+        ),
+        TetrisPiece(
+            "unsafe_direct_llm",
+            "execute",
+            "model tries to do everything directly",
+            (0.30, 0.20, 0.25),
+            0.88,
+            ("artifact",),
+        ),
     ]
 
 
@@ -397,7 +425,11 @@ def _default_world() -> tuple[dict[str, Any], list[WorldActor], list[WorldAction
             "pytest",
             ("green_tests",),
             0.10,
-            {"workspace": {"tests_green": True}, "quests": {"verify": "done", "ship": "open"}, "events": ["verifier marked tests green"]},
+            {
+                "workspace": {"tests_green": True},
+                "quests": {"verify": "done", "ship": "open"},
+                "events": ["verifier marked tests green"],
+            },
         ),
         WorldAction(
             "write_shipping_receipt",
@@ -407,7 +439,11 @@ def _default_world() -> tuple[dict[str, Any], list[WorldActor], list[WorldAction
             "receipt_writer",
             ("receipt",),
             0.04,
-            {"workspace": {"receipt_written": True}, "quests": {"ship": "done"}, "events": ["scribe wrote final receipt"]},
+            {
+                "workspace": {"receipt_written": True},
+                "quests": {"ship": "done"},
+                "events": ["scribe wrote final receipt"],
+            },
         ),
     ]
     return state, actors, actions
@@ -582,7 +618,10 @@ def simulate_world(*, max_ticks: int = 8) -> dict[str, Any]:
     return {
         "schema": "scbe_mahss_world_loop_v1",
         "game": "world",
-        "analogy": "NPC workflow engine: actors perceive world state, propose actions, policy resolves effects, receipts update memory.",
+        "analogy": (
+            "NPC workflow engine: actors perceive world state, propose actions, "
+            "policy resolves effects, receipts update memory."
+        ),
         "loop": [
             "world_state",
             "actor_observation",

--- a/tests/eval/test_functional_coding_agent_benchmark_threshold.py
+++ b/tests/eval/test_functional_coding_agent_benchmark_threshold.py
@@ -142,7 +142,10 @@ def test_eval_jsonl_cli_runs_candidate_file_without_default_tasks(tmp_path: Path
         json.dumps(
             {
                 "task_id": "alpha",
-                "prompt": "Write TypeScript only. Define function evaluate(input, state). Set state.total to input.n and return it.",
+                "prompt": (
+                    "Write TypeScript only. Define function evaluate(input, state). "
+                    "Set state.total to input.n and return it."
+                ),
                 "checks": [
                     {
                         "input": {"n": 4},

--- a/tests/system/test_agent_shell.py
+++ b/tests/system/test_agent_shell.py
@@ -3,7 +3,6 @@ import json
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "scripts" / "system" / "agent_shell.py"
 spec = importlib.util.spec_from_file_location("agent_shell", MODULE_PATH)

--- a/tests/test_free_generator_llm_config.py
+++ b/tests/test_free_generator_llm_config.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 

--- a/tests/test_l13_docs_claim_boundaries.py
+++ b/tests/test_l13_docs_claim_boundaries.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 L13_DOCS = [
     REPO_ROOT / "docs" / "specs" / "BIJECTIVE_TAMPER_L13.md",


### PR DESCRIPTION
## Summary
- formats the Python files introduced by the tracked-files reconciliation with black
- fixes remaining flake8 issues in the new scripts/tests: unused imports and long string literals
- intentionally does not run a repo-wide Prettier rewrite; the TypeScript Prettier debt is broad existing churn and should be handled separately

## Verification
- black --check on affected Python files: pass
- flake8 on affected Python files: pass
- focused tests: 48 passed
- git diff --check origin/main: pass