### PR TITLE
chore(release): add release surface audit

### DIFF
--- a/config/release_surfaces.v1.json
+++ b/config/release_surfaces.v1.json
@@ -1,0 +1,118 @@
+{
+  "schema": "scbe_release_surfaces_v1",
+  "updated": "2026-06-22",
+  "policy": {
+    "default_rule": "Ship one release object at a time. A surface is releasable only when its owner files, packaging script, workflow, and smoke gate are named here and pass.",
+    "do_not_ship_by_default": [
+      "artifacts/**",
+      "training/runs/**",
+      "external/**",
+      "archive/**",
+      "browser_profiles/**",
+      "config/connector_oauth/**",
+      ".env",
+      ".env.*"
+    ]
+  },
+  "surfaces": [
+    {
+      "id": "scbe_npm_sdk",
+      "repo": "SCBE-AETHERMOORE",
+      "status": "ship",
+      "role": "Public TypeScript SDK and GeoSeal CLI lane.",
+      "owner_files": ["package.json", "tsconfig.json"],
+      "required_paths": ["scripts/npm_pack_guard.js", "scripts/npm_consumer_smoke.mjs"],
+      "workflows": [".github/workflows/npm-publish.yml", ".github/workflows/ci.yml"],
+      "build_commands": ["npm run publish:prepare"],
+      "verification_commands": ["npm run publish:check:strict", "npm run publish:smoke:consumer"]
+    },
+    {
+      "id": "scbe_python_package",
+      "repo": "SCBE-AETHERMOORE",
+      "status": "ship",
+      "role": "Python runtime, operator CLI, and local verification package lane.",
+      "owner_files": ["pyproject.toml", "setup.py"],
+      "required_paths": ["scripts/pypi_build.py", "scripts/pypi_dist_guard.py"],
+      "workflows": [".github/workflows/pypi-publish.yml", ".github/workflows/ci.yml"],
+      "build_commands": ["npm run publish:pypi:build"],
+      "verification_commands": ["npm run publish:pypi:check"]
+    },
+    {
+      "id": "buyer_product_zips",
+      "repo": "SCBE-AETHERMOORE",
+      "status": "ship",
+      "role": "Downloadable buyer ZIPs: governance toolkit, training vault, and writing-process pack.",
+      "owner_files": ["scripts/package_products.py", "tests/test_package_products.py"],
+      "required_paths": ["deliverables/SCBE_Production_Pack/PACKAGE_INVENTORY.json"],
+      "workflows": [".github/workflows/ci.yml"],
+      "build_commands": ["npm run writing:package:all"],
+      "verification_commands": ["python -m pytest tests/test_package_products.py -q"]
+    },
+    {
+      "id": "workcell_download",
+      "repo": "SCBE-AETHERMOORE",
+      "status": "ship",
+      "role": "Self-contained Workcell CLI download with manifest, checksums, install scripts, and temp-install transcript.",
+      "owner_files": ["scripts/system/build_workcell_download.py", "packages/cli/package.json"],
+      "required_paths": ["docs/downloads/scbe-workcell-quickstart.md"],
+      "workflows": [".github/workflows/ci.yml"],
+      "build_commands": ["npm run release:workcell"],
+      "verification_commands": ["python scripts/system/build_workcell_download.py"]
+    },
+    {
+      "id": "black_box_download",
+      "repo": "SCBE-AETHERMOORE",
+      "status": "ship",
+      "role": "Local black-box workstation failure report download with sample output and verification transcript.",
+      "owner_files": ["scripts/system/build_black_box_download.py", "scripts/system/scbe_black_box.py"],
+      "required_paths": ["docs/downloads/scbe-black-box-quickstart.md"],
+      "workflows": [".github/workflows/ci.yml"],
+      "build_commands": ["npm run release:blackbox"],
+      "verification_commands": ["python scripts/system/build_black_box_download.py"]
+    },
+    {
+      "id": "docs_site",
+      "repo": "SCBE-AETHERMOORE",
+      "status": "ship",
+      "role": "Public proof, product explanation, book pages, and support surface.",
+      "owner_files": ["docs/index.html", "docs/books.html", "docs/support.html"],
+      "required_paths": ["docs/static/badges/stats-summary.json"],
+      "workflows": [".github/workflows/pages-deploy.yml", ".github/workflows/docs.yml"],
+      "build_commands": [],
+      "verification_commands": ["npm run docs:check"]
+    },
+    {
+      "id": "docker_api",
+      "repo": "SCBE-AETHERMOORE",
+      "status": "preview",
+      "role": "API/container deployment lane. Preview until a single blessed health/auth/action smoke is attached.",
+      "owner_files": ["Dockerfile.api", "docker-compose.api.yml"],
+      "required_paths": ["scripts/scbe_docker_status.mjs"],
+      "workflows": [".github/workflows/docker-remote-build.yml"],
+      "build_commands": ["npm run docker:remote:api"],
+      "verification_commands": ["npm run docker:doctor:api"]
+    },
+    {
+      "id": "training_eval",
+      "repo": "SCBE-AETHERMOORE",
+      "status": "internal",
+      "role": "Model-development and benchmark lane. Promote datasets only with manifest, train/eval split, and held-out eval.",
+      "owner_files": ["scripts/system/build_training_hub.py"],
+      "required_paths": ["scripts/eval/functional_coding_agent_benchmark.py"],
+      "workflows": [".github/workflows/public-agentic-benchmarks.yml"],
+      "build_commands": ["npm run training:hub"],
+      "verification_commands": ["npm run benchmark:coding-agents"]
+    },
+    {
+      "id": "aetherdesk_standalone",
+      "repo": "AetherDesk",
+      "status": "ship",
+      "role": "Standalone local AI desktop/browser-agent product. Release in the AetherDesk repo, not the old SCBE aetherdesk subtree.",
+      "owner_files": ["package.json", "aetherdesk/server.js", "react-desktop/src/main.jsx"],
+      "required_paths": ["extensions/playwright-sidebar-agent/manifest.json", "scripts/playwright-sidebar-agent.js"],
+      "workflows": [],
+      "build_commands": ["npm test", "npm run build:react"],
+      "verification_commands": ["npm test", "npm run build:react"]
+    }
+  ]
+}

--- a/docs/ops/SYSTEM_RELEASE_PACKAGING_CURRENT_2026-06-22.md
+++ b/docs/ops/SYSTEM_RELEASE_PACKAGING_CURRENT_2026-06-22.md
@@ -1,0 +1,55 @@
+# Current Release Packaging Map - 2026-06-22
+
+## Purpose
+
+SCBE-AETHERMOORE has become a multi-product repo. The failure mode is not "no packaging"; the failure mode is too many working surfaces with no single release contract. This note defines the current release objects and the gate that keeps them from drifting.
+
+The machine-readable contract is `config/release_surfaces.v1.json`. Validate it with:
+
+```powershell
+npm run release:surface-audit
+```
+
+## Current Shipping Surfaces
+
+| Surface | Status | Build | Gate |
+|---|---|---|---|
+| npm SDK / GeoSeal CLI | ship | `npm run publish:prepare` | `npm run publish:check:strict`, `npm run publish:smoke:consumer` |
+| Python package | ship | `npm run publish:pypi:build` | `npm run publish:pypi:check` |
+| Buyer product ZIPs | ship | `npm run writing:package:all` | `python -m pytest tests/test_package_products.py -q` |
+| Workcell download | ship | `npm run release:workcell` | verified temp install transcript from `scripts/system/build_workcell_download.py` |
+| Black Box download | ship | `npm run release:blackbox` | verified sample run transcript from `scripts/system/build_black_box_download.py` |
+| Docs / public site | ship | GitHub Pages workflows | `npm run docs:check` |
+| Docker/API | preview | `npm run docker:remote:api` | `npm run docker:doctor:api` |
+| Training/eval | internal | `npm run training:hub` | held-out benchmark or promotion report, not a public release by default |
+| AetherDesk standalone | ship in separate repo | `npm test`, `npm run build:react` | AetherDesk repo CI/release gate |
+
+## Packaging Rule
+
+Do not release "the repo." Release one surface at a time:
+
+1. Pick the surface id from `config/release_surfaces.v1.json`.
+2. Run its build command.
+3. Run its verification command.
+4. Attach the manifest, transcript, checksum, or GitHub Actions run to the release notes.
+5. Keep training runs, generated artifacts, browser profiles, private OAuth config, and archives out of public release packages.
+
+## What Needs Improvement Next
+
+1. AetherDesk should get its own release workflow in the standalone repo: test, React build, package a desktop ZIP or installer, upload artifact, and attach release notes.
+2. SCBE should add a release checklist generator that reads `config/release_surfaces.v1.json` and prints the exact commands for a chosen surface.
+3. Docker/API should stay preview until one black-box health/auth/action smoke is the canonical gate.
+4. Training/eval outputs should remain internal unless they have a manifest, source bucket, train/eval split, and held-out result.
+5. Buyer product ZIPs need a current inventory file per ZIP, not just a root inventory.
+
+## Why This Helps
+
+This turns release work from archaeology into a contract. A model or human can now ask:
+
+- What is the product?
+- Which files own it?
+- Which command builds it?
+- Which gate proves it?
+- Is it public, preview, or internal?
+
+If a branch cannot answer those questions, it should not go to `main` as a release branch.

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "writing:package:all": "python scripts/package_products.py --product all",
     "release:workcell": "python scripts/system/build_workcell_download.py",
     "release:blackbox": "python scripts/system/build_black_box_download.py",
+    "release:surface-audit": "python scripts/system/release_surface_audit.py",
     "blackbox:prove": "python scripts/system/prove_black_box_value.py",
     "blackbox:report": "python scripts/system/scbe_black_box.py --no-fail-on-high",
     "video:verify": "node scripts/video/verify.js",

--- a/scripts/system/release_surface_audit.py
+++ b/scripts/system/release_surface_audit.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Audit the repo release-surface contract.
+
+This is a lightweight packaging guard. It does not run the expensive builds.
+It verifies that every declared release surface has owner files, workflows,
+required paths, and npm script references that actually exist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = REPO_ROOT / "config" / "release_surfaces.v1.json"
+VALID_STATUS = {"ship", "preview", "internal", "deprecated"}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _npm_scripts() -> set[str]:
+    package_json = REPO_ROOT / "package.json"
+    if not package_json.exists():
+        return set()
+    payload = _load_json(package_json)
+    scripts = payload.get("scripts", {})
+    if not isinstance(scripts, dict):
+        return set()
+    return set(scripts)
+
+
+def _script_from_command(command: str) -> str | None:
+    match = re.match(r"^npm\s+run\s+([A-Za-z0-9:_@./-]+)(?:\s|$)", command.strip())
+    if not match:
+        return None
+    return match.group(1)
+
+
+def audit(config_path: Path = DEFAULT_CONFIG) -> dict[str, Any]:
+    payload = _load_json(config_path)
+    scripts = _npm_scripts()
+    errors: list[str] = []
+    warnings: list[str] = []
+    surface_reports: list[dict[str, Any]] = []
+
+    if payload.get("schema") != "scbe_release_surfaces_v1":
+        errors.append(f"{config_path}: unsupported schema {payload.get('schema')!r}")
+
+    surfaces = payload.get("surfaces")
+    if not isinstance(surfaces, list) or not surfaces:
+        errors.append(f"{config_path}: surfaces must be a non-empty list")
+        surfaces = []
+
+    seen_ids: set[str] = set()
+    for index, surface in enumerate(surfaces):
+        sid = str(surface.get("id", "")).strip()
+        prefix = sid or f"surface[{index}]"
+        if not sid:
+            errors.append(f"{prefix}: missing id")
+        elif sid in seen_ids:
+            errors.append(f"{prefix}: duplicate id")
+        seen_ids.add(sid)
+
+        status = surface.get("status")
+        if status not in VALID_STATUS:
+            errors.append(f"{prefix}: invalid status {status!r}; expected one of {sorted(VALID_STATUS)}")
+
+        repo = surface.get("repo", "SCBE-AETHERMOORE")
+        is_local_scbe = repo == "SCBE-AETHERMOORE"
+        missing_paths: list[str] = []
+        missing_scripts: list[str] = []
+
+        for field in ("owner_files", "required_paths", "workflows"):
+            values = surface.get(field, [])
+            if not isinstance(values, list):
+                errors.append(f"{prefix}: {field} must be a list")
+                continue
+            if field == "owner_files" and not values:
+                errors.append(f"{prefix}: owner_files must not be empty")
+            if not is_local_scbe:
+                continue
+            for rel in values:
+                if not isinstance(rel, str):
+                    errors.append(f"{prefix}: {field} contains a non-string value")
+                    continue
+                if not (REPO_ROOT / rel).exists():
+                    missing_paths.append(rel)
+
+        for field in ("build_commands", "verification_commands"):
+            values = surface.get(field, [])
+            if not isinstance(values, list):
+                errors.append(f"{prefix}: {field} must be a list")
+                continue
+            for command in values:
+                if not isinstance(command, str):
+                    errors.append(f"{prefix}: {field} contains a non-string value")
+                    continue
+                script_name = _script_from_command(command)
+                if script_name and is_local_scbe and script_name not in scripts:
+                    missing_scripts.append(script_name)
+
+        for rel in missing_paths:
+            errors.append(f"{prefix}: missing path {rel}")
+        for script_name in missing_scripts:
+            errors.append(f"{prefix}: package.json missing script {script_name}")
+
+        if not is_local_scbe:
+            warnings.append(f"{prefix}: external repo surface; local path checks skipped")
+
+        surface_reports.append(
+            {
+                "id": prefix,
+                "repo": repo,
+                "status": status,
+                "missing_paths": missing_paths,
+                "missing_scripts": missing_scripts,
+            }
+        )
+
+    return {
+        "ok": not errors,
+        "config": str(config_path),
+        "surface_count": len(surface_reports),
+        "errors": errors,
+        "warnings": warnings,
+        "surfaces": surface_reports,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit SCBE release-surface packaging contract.")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to release surface config JSON.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    args = parser.parse_args(argv)
+
+    report = audit(Path(args.config))
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        status = "PASS" if report["ok"] else "FAIL"
+        print(f"release_surface_audit: {status} ({report['surface_count']} surfaces)")
+        for warning in report["warnings"]:
+            print(f"WARN: {warning}")
+        for error in report["errors"]:
+            print(f"ERROR: {error}", file=sys.stderr)
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/system/test_release_surface_audit.py
+++ b/tests/system/test_release_surface_audit.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.system import release_surface_audit
+
+
+def test_release_surface_contract_is_current():
+    report = release_surface_audit.audit()
+    assert report["ok"], report
+    ids = {surface["id"] for surface in report["surfaces"]}
+    assert {
+        "scbe_npm_sdk",
+        "scbe_python_package",
+        "buyer_product_zips",
+        "workcell_download",
+        "black_box_download",
+        "docs_site",
+        "training_eval",
+    }.issubset(ids)
+
+
+def test_release_surface_audit_catches_missing_npm_script(tmp_path: Path, monkeypatch):
+    config = tmp_path / "release_surfaces.v1.json"
+    config.write_text(
+        """
+{
+  "schema": "scbe_release_surfaces_v1",
+  "surfaces": [
+    {
+      "id": "bad",
+      "repo": "SCBE-AETHERMOORE",
+      "status": "ship",
+      "role": "bad fixture",
+      "owner_files": ["package.json"],
+      "required_paths": [],
+      "workflows": [],
+      "build_commands": ["npm run definitely:missing"],
+      "verification_commands": []
+    }
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(release_surface_audit, "REPO_ROOT", Path.cwd())
+    report = release_surface_audit.audit(config)
+    assert not report["ok"]
+    assert any("definitely:missing" in error for error in report["errors"])


### PR DESCRIPTION
## Summary
- add config/release_surfaces.v1.json as the canonical release/package contract
- add scripts/system/release_surface_audit.py and npm run release:surface-audit
- document current release surfaces across npm, PyPI, buyer zips, workcell, black box, docs, Docker/API preview, training/eval, and AetherDesk standalone

## Verification
- python scripts/system/release_surface_audit.py --json -> ok
- npm run release:surface-audit -> PASS
- python -m py_compile scripts/system/release_surface_audit.py -> pass
- python -m pytest tests/test_package_products.py tests/system/test_release_surface_audit.py -q -> 8 passed
- git diff --check -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced release surfaces configuration defining multiple shipping lanes (npm SDK, Python packages, documentation, APIs, standalone products) with associated build and verification requirements.
  * Added release surface audit capability to validate configuration integrity and detect missing build dependencies.

* **Documentation**
  * Added release packaging documentation detailing current shipping surfaces, packaging rules, and planned improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->