### PR TITLE
style(release): format release surface audit

### DIFF
--- a/scripts/system/release_surface_audit.py
+++ b/scripts/system/release_surface_audit.py
@@ -15,7 +15,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG = REPO_ROOT / "config" / "release_surfaces.v1.json"
 VALID_STATUS = {"ship", "preview", "internal", "deprecated"}


### PR DESCRIPTION
## Summary
- Format the new release surface audit script with the repo Black settings.

## Verification
- black --check --target-version py311 --line-length 120 src/ tests/ scripts/ agents/
- ruff check --config ruff.toml
- flake8 --max-line-length 120 src/ tests/ hydra/ scripts/ agents/
- python -m pytest tests/system/test_release_surface_audit.py tests/test_package_products.py -q