### PR TITLE
fix(bookforge): load hyperref so XeLaTeX interiors build

### DIFF
--- a/packages/bookforge/src/scbe_bookforge/interior_xelatex.py
+++ b/packages/bookforge/src/scbe_bookforge/interior_xelatex.py
@@ -99,6 +99,7 @@ def _compose_document(profile: Profile, body_tex_relpath: str) -> str:
         rf"includehead,headsep=0.18in]{{geometry}}"
     )
     parts.append(r"\usepackage{fontspec}")
+    parts.append(r"\usepackage[hidelinks]{hyperref}")
     parts.append(rf"\setmainfont{{{p.body_font}}}")
     parts.append(r"\usepackage{microtype}")
     parts.append(r"\usepackage{setspace}")


### PR DESCRIPTION
## What
Adds `\usepackage[hidelinks]{hyperref}` to the XeLaTeX interior preamble in interior_xelatex.py.

## Why
Pandoc emits hypertarget commands for every heading (chapters/parts). The preamble loaded fontspec, microtype, titlesec, fancyhdr, etc. but never hyperref, so xelatex fails with an 'Undefined control sequence' error on the first chapter -- i.e. every real book.

## Verification
- Starter manuscript now builds a clean interior PDF + cover wrap + EPUB + DOCX.
- 5/5 KDP presets (novel 5.5x8.5 / 5x8, nonfiction 6x9, hardcover 6x9, poetry) build all four artifacts; trims and spine math verified.
- pytest: 6/6 pass before and after (no regression).
- Bonus: hidelinks gives clickable PDF bookmarks with no visible link boxes.

## Note
scbe-bookforge is not published to PyPI yet -- the README 'pip install scbe-bookforge' will 404 until first release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated PDFs now include hyperlink support, making links in documents clickable while keeping their visual styling clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->