### PR TITLE
ci: add format repair merge gate

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,17 +1,20 @@
 name: auto-format
 
 # Self-healing formatter. Many agents merge to main concurrently; some land
-# unformatted Python, which turns the "Lint and Format Check" job red. Instead of
-# anyone hand-formatting after the fact, this runs black on every push to main and
-# commits the result back — so main's code stays black-clean automatically and the
-# formatting churn stops. Uses the SAME black version + dirs as the CI lint check,
-# so "auto-format made it clean" == "CI black --check passes".
+# unformatted code, which turns the "Lint and Format Check" job red. Instead of
+# hand-formatting after the fact, this runs the same Python and TypeScript
+# formatters used by CI and commits the result back to main.
 
 on:
   push:
     branches: [main]
     paths:
-      - "**.py"
+      - '**.py'
+      - 'src/**/*.ts'
+      - 'tests/**/*.ts'
+      - 'packages/**/*.ts'
+      - 'package.json'
+      - 'package-lock.json'
 
 permissions:
   contents: write
@@ -21,7 +24,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  black:
+  format:
     runs-on: ubuntu-latest
     # Don't re-run on the bot's own format commit (belt-and-suspenders; pushes made
     # with GITHUB_TOKEN don't trigger workflows anyway, so no loop).
@@ -33,7 +36,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: Install black (pinned to match the CI lint check)
         run: pip install --quiet "black==26.5.1"
@@ -41,15 +44,26 @@ jobs:
       - name: Format the same dirs CI's black --check covers
         run: black --target-version py311 --line-length 120 src/ tests/ scripts/ agents/ || true
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Format the same TypeScript surface CI checks
+        run: npm run format
+
       - name: Commit + push if anything changed
         run: |
           if git diff --quiet; then
-            echo "Already black-clean — nothing to do."
+            echo "Already format-clean; nothing to do."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "style: auto-format python with black [auto-format]"
+          git commit -m "style: auto-format code [auto-format]"
           git push origin HEAD:main
-          echo "Formatted and pushed. main is black-clean again."
+          echo "Formatted and pushed. main is format-clean again."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         run: npm ci
 
       - name: Check TypeScript formatting
-        run: npx prettier --check "src/**/*.ts" "tests/**/*.ts"
+        run: npm run lint
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pr-format-gate.yml
+++ b/.github/workflows/pr-format-gate.yml
@@ -1,0 +1,67 @@
+name: format gate - repair PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/**/*.ts'
+      - 'tests/**/*.ts'
+      - 'packages/**/*.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.prettierrc*'
+      - '.github/workflows/pr-format-gate.yml'
+  workflow_dispatch: {}
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: pr-format-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'github-actions[bot]'
+        )
+      }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply Prettier
+        run: npm run format
+
+      - name: Commit repaired formatting
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet; then
+            echo "No Prettier changes needed."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src tests packages
+          git commit -m "chore(format): apply Prettier formatting [format-gate]"
+          git push origin HEAD:${{ github.head_ref || github.ref_name }}
+          gh workflow run ci.yml --ref ${{ github.head_ref || github.ref_name }}

--- a/packages/agent-bus/src/hermes.ts
+++ b/packages/agent-bus/src/hermes.ts
@@ -11,17 +11,9 @@ export type ScbeCompassMode = HermesTaskMode;
 export type ScbeFormation = 'forge' | 'scribe' | 'broadcast' | 'council' | 'scout' | 'field';
 export type ScbeTongueDomain = 'KO' | 'AV' | 'RU' | 'CA' | 'UM' | 'DR';
 export type ScbeBoardMechanic =
-  | 'pazaak-hand'
-  | 'go-board-territory'
-  | 'octree-sector'
-  | 'chessboard-stack';
+  'pazaak-hand' | 'go-board-territory' | 'octree-sector' | 'chessboard-stack';
 export type ScbeRollKind =
-  | 'human-input'
-  | 'model-call'
-  | 'api-call'
-  | 'automation'
-  | 'verification'
-  | 'human-approval';
+  'human-input' | 'model-call' | 'api-call' | 'automation' | 'verification' | 'human-approval';
 
 export interface HermesModelLane {
   id: string;

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1976,8 +1976,7 @@ export async function startAgentBusServer(
       }
       if (req.method === 'POST' && req.url === '/v1/batch') {
         const body = JSON.parse(await readBody(req)) as
-          | { items?: AgentBusEvent[]; enqueue?: boolean }
-          | AgentBusEvent[];
+          { items?: AgentBusEvent[]; enqueue?: boolean } | AgentBusEvent[];
         const items = Array.isArray(body) ? body : body.items || [];
         const enqueue = !Array.isArray(body) && body.enqueue === true;
         const rows = await runBatch(items, { ...options, enqueue });
@@ -1995,8 +1994,7 @@ export async function startAgentBusServer(
       }
       if (req.method === 'POST' && req.url === '/v1/fanout') {
         const body = JSON.parse(await readBody(req)) as
-          | { items?: AgentBusEvent[]; enqueue?: boolean; concurrency?: number }
-          | AgentBusEvent[];
+          { items?: AgentBusEvent[]; enqueue?: boolean; concurrency?: number } | AgentBusEvent[];
         const items = Array.isArray(body) ? body : body.items || [];
         const enqueue = !Array.isArray(body) && body.enqueue === true;
         const concurrency = !Array.isArray(body) ? Number(body.concurrency || 4) : 4;

--- a/packages/agent-bus/src/pipeline.ts
+++ b/packages/agent-bus/src/pipeline.ts
@@ -176,14 +176,7 @@ export interface PipelineRunResult {
 }
 
 export type GovernedMoveClass =
-  | 'observe'
-  | 'read'
-  | 'verify'
-  | 'write'
-  | 'network'
-  | 'deploy'
-  | 'destructive'
-  | 'unknown';
+  'observe' | 'read' | 'verify' | 'write' | 'network' | 'deploy' | 'destructive' | 'unknown';
 
 export interface GovernedMoveRecord {
   at: string;

--- a/packages/agent-bus/src/search-space-router.ts
+++ b/packages/agent-bus/src/search-space-router.ts
@@ -14,12 +14,7 @@ export type SearchPlane =
   | 'space';
 
 export type SearchNodeState =
-  | 'open'
-  | 'expanded'
-  | 'contracted'
-  | 'claimed'
-  | 'complete'
-  | 'blocked';
+  'open' | 'expanded' | 'contracted' | 'claimed' | 'complete' | 'blocked';
 
 export type SearchColorGrade = 'blue' | 'green' | 'yellow' | 'orange' | 'red' | 'purple';
 

--- a/packages/agent-bus/src/semantic-bridge.ts
+++ b/packages/agent-bus/src/semantic-bridge.ts
@@ -375,12 +375,7 @@ export function dimsToBinary(dims: DimVec): string {
  *   backchannel       HOLD only       — pure listener co-construction
  */
 export type DiscourseProfile =
-  | 'governance_steer'
-  | 'long_turn'
-  | 'warranted_claim'
-  | 'floor_hold'
-  | 'backchannel'
-  | null;
+  'governance_steer' | 'long_turn' | 'warranted_claim' | 'floor_hold' | 'backchannel' | null;
 
 export function detectDiscourseProfile(atoms: AtomHit[]): DiscourseProfile {
   const ids = new Set(atoms.map((a) => a.semanticId));

--- a/packages/agent-bus/src/station-manifest.ts
+++ b/packages/agent-bus/src/station-manifest.ts
@@ -28,14 +28,7 @@
 // ─── Primitive types ──────────────────────────────────────────────────────────
 
 export type District =
-  | 'writing'
-  | 'code'
-  | 'browser'
-  | 'security'
-  | 'research'
-  | 'video'
-  | 'commerce'
-  | 'deployment';
+  'writing' | 'code' | 'browser' | 'security' | 'research' | 'video' | 'commerce' | 'deployment';
 
 export type ZoneState = 'active' | 'standby' | 'maintenance' | 'quarantined' | 'offline';
 


### PR DESCRIPTION
## Summary
- add a same-repo PR format repair gate that runs `npm run format`, pushes formatter fixes back to the PR branch, and dispatches CI on the repaired branch
- extend the main auto-format workflow to self-heal both Black and Prettier after merges
- make the TypeScript format check call `npm run lint` so CI uses the same surface as the package script
- apply the missing Prettier baseline fixes in `packages/agent-bus`

## Validation
- `npm ci`
- `npm run lint`
- `npm exec -- prettier --check .github/workflows/auto-format.yml .github/workflows/pr-format-gate.yml .github/workflows/ci.yml`
- `git diff --check`