### PR TITLE
style: wrap Kaggle encoder card note for flake8

### DIFF
--- a/scripts/kaggle/build_encoder_kernel.py
+++ b/scripts/kaggle/build_encoder_kernel.py
@@ -186,7 +186,10 @@ card = {
     },
     "tool": "custom (perf_counter, stdlib statistics)",
     "stable": e2e_speedup_cv < CV_WARN,
-    "notes": "Kaggle free compute. Interleaved paired runs; e2e_speedup = median of per-pair ratios (drift-cancelling). Rust path includes subprocess startup; engine_speedup is startup-excluded.",
+    "notes": (
+        "Kaggle free compute. Interleaved paired runs; e2e_speedup = median of per-pair ratios "
+        "(drift-cancelling). Rust path includes subprocess startup; engine_speedup is startup-excluded."
+    ),
 }
 (WORK / "encoder-card.json").write_text(json.dumps(card, indent=2), encoding="utf-8")
 print(json.dumps(card, indent=2))


### PR DESCRIPTION
## Summary
- wrap the Kaggle encoder card note string so flake8 E501 passes under the repo's 120-column limit

## Validation
- `python -m black --target-version py311 --line-length 120 --check scripts\kaggle\build_encoder_kernel.py`
- `python -m ruff check scripts\kaggle\build_encoder_kernel.py`
- `python -m flake8 --max-line-length 120 scripts\kaggle\build_encoder_kernel.py`
- `python -m flake8 --max-line-length 120 src/ tests/ hydra/ scripts/ agents/`