### PR TITLE
ci: harden workflow gates and async tests

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -42,7 +42,7 @@ jobs:
         run: pip install --quiet "black==26.5.1"
 
       - name: Format the same dirs CI's black --check covers
-        run: black --target-version py311 --line-length 120 src/ tests/ scripts/ agents/ || true  # audit: advisory - formatter is best-effort; the commit step is the real signal, not black exit code
+        run: black --target-version py311 --line-length 120 src/ tests/ scripts/ agents/
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/blob-size-policy.yml
+++ b/.github/workflows/blob-size-policy.yml
@@ -38,8 +38,9 @@ jobs:
           # under `set -e` fails this gate at exit 1 BEFORE any file size is inspected.
           # Fetch the base fully, and fall back gracefully if no merge-base resolves.
           git fetch --no-tags origin "$BASE_REF"
-          base="$(git merge-base HEAD "origin/$BASE_REF" 2>/dev/null || true)"  # audit: advisory - merge-base may be empty after a force-update; handled by the [ -z ] fallback below
-          if [ -z "$base" ]; then
+          if base="$(git merge-base HEAD "origin/$BASE_REF" 2>/dev/null)"; then
+            :
+          else
             echo "No merge-base found (base may have been force-updated); comparing against origin/$BASE_REF directly."
             base="origin/$BASE_REF"
           fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -87,11 +87,16 @@ jobs:
           fi
 
           # --- Unresolved merge-conflict markers
+          conflict_status=0
           conflict_report="$(git grep -nE '^(<<<<<<<|>>>>>>>)' -- \
             ':!node_modules/**' \
             ':!artifacts/**' \
             ':!training-data/**' \
-            ':!**/target/**' || true)"  # audit: advisory - git grep exits nonzero when no conflict markers exist (the clean, passing case)
+            ':!**/target/**')" || conflict_status=$?
+          if [ "$conflict_status" -ne 0 ] && [ "$conflict_status" -ne 1 ]; then
+            echo "git grep failed with status $conflict_status" >&2
+            exit "$conflict_status"
+          fi
           if [ -n "$conflict_report" ]; then
             failures=1
             {

--- a/.github/workflows/video-upload.yml
+++ b/.github/workflows/video-upload.yml
@@ -130,8 +130,7 @@ jobs:
           )"
           python -m scripts.system.geoseal_llm_verify \
             --json "$GEOSEAL_INPUT" \
-            --dry-run --quiet || true  # audit: advisory - external video verify is non-blocking; step is continue-on-error by design
-        continue-on-error: true
+            --dry-run --quiet
 
       - name: Upload to YouTube (resumable)
         env:

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-asyncio_mode = auto
+asyncio_mode = strict
 asyncio_default_fixture_loop_scope = function
 
 addopts =

--- a/tests/agents/test_agent_bus_cost.py
+++ b/tests/agents/test_agent_bus_cost.py
@@ -89,6 +89,7 @@ class TestRatesEnv:
 
 
 class TestBudgetGate:
+    @pytest.mark.asyncio
     async def test_llm_generate_refuses_when_budget_exceeded(self, monkeypatch):
         bus = AgentBus(budget_usd=0.01)
         bus.cost.spent_usd = 0.02  # already over
@@ -104,6 +105,7 @@ class TestBudgetGate:
         assert "budget_exceeded" in result["error"]
         assert result["cost_usd"] == 0.0
 
+    @pytest.mark.asyncio
     async def test_llm_generate_charges_offline_fallback(self, monkeypatch):
         bus = AgentBus(budget_usd=0.0)
 
@@ -117,6 +119,7 @@ class TestBudgetGate:
         assert result["provider"] == "offline"
         assert result["cost_usd"] == 0.0  # offline is free, but the field is present
 
+    @pytest.mark.asyncio
     async def test_llm_generate_charges_provider_result(self, monkeypatch):
         bus = AgentBus(budget_usd=1.00)
         bus.cost.rates = dict(PAID_RATES)

--- a/tests/test_mcp_config_hygiene.py
+++ b/tests/test_mcp_config_hygiene.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -41,6 +42,12 @@ def test_mcp_config_uses_available_local_launchers_for_non_remote_commands():
     missing = []
     for name, server in cfg["mcpServers"].items():
         command = server.get("command")
+        args = server.get("args") or []
+        if command == "cmd" and sys.platform != "win32":
+            # This repo's checked-in MCP config is Windows-local (`cmd /c npx ...`).
+            # On Linux CI, validate the nested cross-platform launcher instead of
+            # requiring cmd.exe to exist.
+            command = args[1] if len(args) >= 2 and args[0].lower() == "/c" else command
         if command in {"cmd", "python", "npx"} and shutil.which(command) is None:
             missing.append(f"{name}:{command}")
     assert missing == []


### PR DESCRIPTION
﻿## Summary
- remove high-risk workflow error masks flagged by the workflow governance audit
- switch pytest-asyncio from auto to strict mode and mark the remaining async budget-gate tests explicitly
- make the MCP config hygiene test validate Windows `cmd /c npx` entries correctly on Linux CI

## Verification
- `python scripts/workflow_audit.py --workspace . --report C:\tmp\workflow-audit-report-rebased.json --summary C:\tmp\workflow-audit-summary-rebased.md` -> `High: 0`
- `python -m pytest tests/test_ai_orchestration.py tests/test_api_header_compat.py tests/test_browser_modules.py tests/test_browser_toolkit.py tests/test_mcp_rooms.py tests/test_mcp_config_hygiene.py tests/test_multi_cloud_agents.py tests/test_scbe_govern_mcp.py tests/test_scbe_verify_mcp.py tests/test_swarm_click_risk_headless.py tests/test_swarm_judge_veto.py tests/test_swarm_type_risk.py tests/agents/test_agent_bus_cost.py -q -m "not slow"` -> `288 passed`
- `git diff --check`

Fixes #2648. Addresses the main async-loop class in #2605; full nightly remains the final validator.

Supersedes #2665 because the local destructive-command guard blocks force-pushing rebased branches.
