### PR TITLE
security: fix incomplete URL substring sanitization (CodeQL #5345)

### DIFF
--- a/tests/test_squad_autonomy_sim.py
+++ b/tests/test_squad_autonomy_sim.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "research" / "comms_sim"))
@@ -89,5 +90,6 @@ def test_every_nasa_figure_carries_a_nasa_source_url():
     # no fabricated figure: every NASA_SOURCES entry cites a nasa.gov URL so it can be audited back to NASA
     assert sa.NASA_SOURCES, "NASA_SOURCES must be populated"
     for key, src in sa.NASA_SOURCES.items():
-        assert "nasa.gov" in src, key
-        assert "http" in src, key
+        host = urlparse(src).netloc.split("@")[-1].split(":")[0].lower()
+        assert host == "nasa.gov" or host.endswith(".nasa.gov"), key
+        assert src.startswith(("http://", "https://")), key


### PR DESCRIPTION
﻿## What

Fixes the one open CodeQL **high** alert (#5345): `py/incomplete-url-substring-sanitization` at `tests/test_squad_autonomy_sim.py:92`.

The test asserted `"nasa.gov" in src` — a substring check that a crafted URL like `https://nasa.gov.evil.com` or `https://evil.com/nasa.gov` would pass. Replaced with a real hostname check.

## Change

```python
host = urlparse(src).netloc.split("@")[-1].split(":")[0].lower()
assert host == "nasa.gov" or host.endswith(".nasa.gov"), key
assert src.startswith(("http://", "https://")), key
```

- Parses the URL host (strips any userinfo/port) and requires `nasa.gov` or a `*.nasa.gov` subdomain.
- Also tightens the weak `"http" in src` into a proper scheme check.

## Verification

- All 5 `NASA_SOURCES` hosts (`discovery.larc` / `mars` / `science` / `www` .nasa.gov) still pass.
- `pytest tests/test_squad_autonomy_sim.py` → **9 passed**; `flake8` clean.
- Host comparison is CodeQL's recommended remediation for this rule, so #5345 resolves on the next scan.
