### PR TITLE
ci: clear remaining medium audit findings (advisory-annotate non-blocking steps)

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Post first-interaction greeting
-        continue-on-error: true
+        continue-on-error: true  # audit: advisory - greeting bot is non-critical; a failed greeting must not fail CI
         uses: actions/first-interaction@v3
         with:
           issue_message: "👋 Welcome to SCBE-AETHERMOORE! Thanks for your first issue. Please review CONTRIBUTING.md and SECURITY.md. A maintainer will review soon."

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/labeler@v5
-        continue-on-error: true
+        continue-on-error: true  # audit: advisory - auto-labeling is non-critical; label failures must not block PRs
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/swe-local-benchmark.yml
+++ b/.github/workflows/swe-local-benchmark.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check official SWE-bench readiness
         run: npm run benchmark:swe-verified:readiness
-        continue-on-error: true
+        continue-on-error: true  # audit: advisory - SWE-bench readiness is informational, not a gate
 
       - name: Run regression tests
         run: python -m pytest tests/benchmark/test_swe_local_benchmark.py -q


### PR DESCRIPTION
Annotates 3 intentionally non-blocking continue-on-error steps (greeting bot, auto-labeler, SWE-bench readiness) with the audit's '# audit: advisory' marker. workflow_audit now reports high=0, medium=0 (one non-gating low remains). No behavioral change.