### PR TITLE
feat: execution correctness gate wired into the front door (+ spiral-word docx export)

### DIFF
--- a/docs/research/mars_tethered_pushline_relay.md
+++ b/docs/research/mars_tethered_pushline_relay.md
@@ -297,3 +297,68 @@ This is not yet a flight design. It is a plausible subsystem concept that needs:
 - Mars analog deployment trials.
 
 The right next step is not a claim. It is a scaled mechanical and communications prototype.
+
+---
+
+## Acoustic Verified Side-Channel (addition, 2026-06-29)
+
+The relay above leans on fiber + RF. This adds a **near-field acoustic last-hop** that carries a
+**verified opcode tape**, not trusted words — the same FSK pitch-code used in `astromech.py` (R2-D2-style
+beeps that round-trip losslessly, 240/240). It makes concrete the "acoustic comms for inner layers,
+jam-resistant" links the nested-drone architecture already calls for, and it adds the trust layer.
+
+### What it is
+
+A bundle (an opcode, a short command, a key) is encoded as 16-tone FSK beeps and played over a short
+acoustic path. The receiver does **not** trust the decoded bytes. It re-derives the tape and **re-executes
+it in an independent engine**, accepting only if the program reproduces the expected result. A tampered or
+spoofed bundle that arrives "cleanly" is still **rejected** — lossless transport is not trust.
+
+### Honest Mars boundary (this is a niche channel, not a primary link)
+
+Free-air acoustic on the Mars **surface** is weak: the ~0.6%-density CO₂ atmosphere muffles it (NASA
+Perseverance mics, 2021 — high frequencies attenuate hard, sound ≈ 240 m/s). So this is **not** a surface
+free-air link. Its real roles are:
+
+1. **Habitat-internal** (normal pressurized air) — device-to-device with no RF (air-gap security).
+2. **Structure-/tether-borne vibration** between *contacting* nodes — atmosphere-independent; the
+   "billiard-linked" docked relay nodes can pass a message through the structure when the **fiber is cut**.
+3. **Jam-resistant, deliberately RF-less** short hop for the inner (micro) layers the architecture specifies.
+
+The novelty is **not** the audio (prior art: ggwave, acoustic modems, GibberLink). It is the
+**verification** — trust-without-reading over an untrusted hop.
+
+### How it slots into the logical layers
+
+| Layer | Acoustic side-channel |
+|---|---|
+| physical | near-field acoustic / structure-borne vibration (fallback to fiber) |
+| link | 16-tone FSK + bundle seq id |
+| routing | nearest-live-node forwarding (unchanged) |
+| mission | the bundle payload is an **opcode tape**, not opaque bytes |
+| governance | SCBE = **re-execute the tape in an independent engine and require agreement**; reject on mismatch |
+
+It **composes with DTN custody/dedup**: bundles are ordered by seq, deduped, and replayed (the same
+event-sourced convergence `mars_dtn_sim.py` validates), so delay/reorder/duplication don't change the
+result, and a corrupted bundle fails re-execution.
+
+### Proven by execution
+
+`C:\dev\mars_acoustic_relay.py` (runnable): an opcode tape that computes 15 is carried opcode-by-opcode
+over the real astromech FSK, subjected to DTN reorder+duplication, reconstructed, and re-executed.
+
+```
+clean path : reconstructed tape == original, re-executes to 15  -> SEAL
+DTN chaos  : reordered + duplicated -> still converges to 15     -> SEAL
+tampered   : one bit flipped -> re-executes to -1 != 15          -> REJECT
+```
+
+Lossless+converges under DTN chaos **and** tampered bundle rejected — the acoustic hop is untrusted, the
+re-execution is the trust.
+
+### Honest boundary
+
+A bench-only proof on real audio code, not a flight design or a Mars-acoustics propagation model. Next
+steps: a structure-borne (vibration) transducer test on an Earth analog tether, a Mars-atmosphere
+attenuation model to bound free-air range, and a habitat-internal air-gap demo. The verification layer is
+the durable part; the acoustic transport is the niche carrier.

--- a/python/scbe/correctness_gate.py
+++ b/python/scbe/correctness_gate.py
@@ -1,0 +1,185 @@
+"""Execution correctness gate -- the front door's trust lane (folded in from verifier-bench).
+
+The structural badge (bijective_dna.faces_agree) only checks that each language face emits+decodes
+back to the same opcode strand -- a round-trip, not a run. This gate is the EXECUTING half: it emits
+the SAME program into multiple language faces, RUNS them on a fuzzed input battery, and the faces are
+references FOR EACH OTHER. If they DIVERGE on any in-domain input, the generation is wrong.
+
+  SEAL   -- every face agrees on every in-domain input -> verified, light the badge.
+  REJECT -- faces DIVERGE on an input -> a real bug (e.g. Python `%` vs JS `%` on negatives); show witness.
+  FLAG   -- a face won't run, or coverage too thin -> escalate to review (hand off what it can't PROVE).
+
+This is the load-bearing fix: the front door's "verified" badge must light from EXECUTION (this gate),
+not a structural round-trip -- for a user who judges by badges and cannot read the code, a badge that
+never runs anything is false trust. Self-contained (stdlib + node); no model in the trust path.
+
+COMPARISON HARDENING (verified by execution; see `_norm` + the symmetric loop below):
+  * integers/bitwise -- EXACT; floats -- canonicalized (round 9dp, and -0.0 == 0.0); strings --
+    quote-style agnostic (py repr "'x'" == js JSON '"x"'), kept DISTINCT from numbers; bool 'True'=='true'.
+  * SYMMETRIC errors -- an input is out-of-domain only if ALL faces error; if the reference RAISES but
+    another face SUCCEEDS (div-by-zero, type-coercion) that IS a divergence, caught regardless of order.
+KNOWN py<->js divergences this catches (idiomatic translations that silently differ -- the talk->code
+traps): `a%b` sign on negatives (-7%3 = 2 vs -1); floor-div via `(a/b)|0` truncation (use Math.floor);
+`a<<b` 32-bit overflow + `a>>b` JS-masks-shift-count-mod-32; div-by-zero (py raises vs js Infinity);
+`"5"+3` and `str*int` coercion (py TypeError/repeat vs js). PORTABLE (idiomatic faces agree): + - *,
+floor-div via Math.floor, & | ^, abs, min/max, comparisons (int-coerced), string concat, len.
+"""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+import random
+
+_PY_HARNESS = (
+    "%s\nimport json,sys\n_f=%s\n_out=[]\n"
+    "for _a in %s:\n"
+    " try:_out.append(['ok',repr(_f(*_a))])\n"
+    " except Exception as _e:_out.append(['err',type(_e).__name__])\n"
+    "print(json.dumps(_out))\n"
+)
+_JS_HARNESS = (
+    "%s\nconst _f=%s;const _in=%s;const _o=[];\n"
+    "for(const _a of _in){try{_o.push(['ok',JSON.stringify(_f(..._a))]);}catch(e){_o.push(['err',e.constructor.name]);}}\n"
+    "console.log(JSON.stringify(_o));\n"
+)
+
+def _run(face_src, entry, inputs, lang, timeout=8):
+    if lang == "python":
+        src = _PY_HARNESS % (face_src, entry, repr([list(i) for i in inputs]))
+        cmd = [sys.executable, "-c", src]
+    else:
+        src = _JS_HARNESS % (face_src, entry, json.dumps([list(i) for i in inputs]))
+        cmd = ["node", "-e", src]
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        if r.returncode != 0 or not r.stdout.strip():
+            return None
+        return json.loads(r.stdout.strip().splitlines()[-1])
+    except Exception:
+        return None
+
+_OPS = ["+", "-", "*", "/"]
+
+def _resample(col, rng, d=0):
+    v = col[0]
+    if isinstance(v, list) and d < 3:
+        elems = [e for x in col if isinstance(x, list) for e in x]
+        if not elems:
+            return []
+        ml = max((len(x) for x in col if isinstance(x, list)), default=3)
+        return [_resample(elems, rng, d + 1) for _ in range(rng.randint(0, min(2 * ml + 1, 12)))]
+    if isinstance(v, bool):
+        return rng.choice([True, False])
+    if isinstance(v, int):
+        nums = [x for x in col if isinstance(x, int) and not isinstance(x, bool)]
+        return rng.choice(nums + [0, 1, -1, 2]) if nums else rng.choice([0, 1, 2])
+    if isinstance(v, float):
+        nums = [x for x in col if isinstance(x, float)]
+        return rng.choice(nums) if nums and rng.random() < 0.6 else round(rng.uniform(-5, 5), 3)
+    if isinstance(v, str):
+        toks = [x for x in col if isinstance(x, str)]
+        return rng.choice(toks) if toks else ""
+    return v
+
+def _grammar(bases, rng, cap=60):
+    out = []
+    arity = len(bases[0])
+    for i in range(arity):
+        col = [b[i] for b in bases]
+        if not any(isinstance(v, list) and any(isinstance(e, (int, float)) and not isinstance(e, bool) for e in v) for v in col):
+            continue
+        nums = [e for v in col if isinstance(v, list) for e in v if isinstance(e, (int, float)) and not isinstance(e, bool)] or [1.0, 2.0, 3.0]
+        def tree(d=0):
+            if d >= 4 or (d > 0 and rng.random() < 0.45):
+                return ("n", rng.choice(nums))
+            return ("o", rng.choice(_OPS), tree(d + 1), tree(d + 1))
+        def rpn(t): return [t[1]] if t[0] == "n" else rpn(t[2]) + rpn(t[3]) + [t[1]]
+        def infx(t): return [t[1]] if t[0] == "n" else infx(t[2]) + [t[1]] + infx(t[3])
+        for _ in range(cap):
+            t = tree()
+            for toks in (rpn(t), infx(t)):
+                b = list(bases[rng.randrange(len(bases))]); b[i] = toks; out.append(tuple(b))
+            if len(out) >= cap:
+                break
+    return out
+
+def _battery(seeds, n=40, rng_seed=0):
+    rng = random.Random(rng_seed)
+    bases = [tuple(s) for s in seeds if s]
+    if not bases:
+        return []
+    out, seen = list(bases), set(repr(b) for b in bases)
+    def add(t):
+        try:
+            k = repr(t)
+        except Exception:
+            return
+        if k not in seen:
+            seen.add(k); out.append(t)
+    EDGES = [0, 1, -1, 2, 10, -10, 100]
+    for base in bases:
+        for i in range(len(base)):
+            v = base[i]
+            cands = EDGES if isinstance(v, int) and not isinstance(v, bool) else (
+                ["", v[:1], v + v[:1]] if isinstance(v, str) else
+                ([[], [v[0]] if v else [0], list(reversed(v))] if isinstance(v, list) else []))
+            for e in cands:
+                t = list(base); t[i] = e; add(tuple(t))
+    for _ in range(n):
+        b = list(rng.choice(bases))
+        for i in range(len(b)):
+            if isinstance(b[i], int) and not isinstance(b[i], bool):
+                b[i] += rng.choice([-3, -1, 1, 2, 5])
+        add(tuple(b))
+    for _ in range(80):
+        add(tuple(_resample([b[i] for b in bases], rng) for i in range(len(bases[0]))))
+    for t in _grammar(bases, rng):
+        add(t)
+    return out
+
+def correctness_gate(faces, entry, seeds, min_inputs=6):
+    """faces = {'python': src, 'javascript': src, ...}. Returns SEAL / REJECT / FLAG with a reason."""
+    inputs = _battery(seeds)
+    if len(inputs) < min_inputs:
+        return {"verdict": "FLAG", "reason": "too few inputs to verify (low coverage) -> AI review", "route": "ai_review"}
+    runs = {}
+    for lang, src in faces.items():
+        out = _run(src, entry, inputs, lang)
+        if out is None:
+            return {"verdict": "FLAG", "reason": "face '%s' failed to run -> AI review" % lang, "route": "ai_review"}
+        runs[lang] = out
+    langs = list(runs)
+    if len(langs) < 2:
+        return {"verdict": "FLAG", "reason": "need >=2 faces to cross-verify -> AI review", "route": "ai_review"}
+    ref = langs[0]
+    compared = 0
+    for i, inp in enumerate(inputs):
+        base = runs[ref][i]
+        others = [runs[o][i] for o in langs[1:]]
+        # symmetric: skip ONLY if ALL faces error (genuinely out-of-domain). If the reference errors
+        # but another face is OK, that IS a divergence (e.g. py raises ZeroDivisionError vs js Infinity)
+        # and must be caught -- the old `if base[0]=='err': continue` missed it (face-order dependent).
+        if base[0] == "err" and all(o[0] == "err" for o in others):
+            continue
+        compared += 1
+        for other, o in zip(langs[1:], others):
+            ok_match = (o[0] == "ok" and base[0] == "ok" and _norm(o[1]) == _norm(base[1])) or (o[0] == "err" and base[0] == "err")
+            if not ok_match:
+                return {"verdict": "REJECT", "reason": "faces DISAGREE -> generation bug",
+                        "witness": {"input": list(inp), ref: base, other: o}, "route": "block_seal"}
+    if compared < min_inputs:
+        return {"verdict": "FLAG", "reason": "faces agreed but on too few in-domain inputs -> AI review", "route": "ai_review"}
+    return {"verdict": "SEAL", "reason": "all %d faces agree on %d in-domain inputs -> verified" % (len(langs), compared),
+            "checked": compared, "route": "seal"}
+
+def _norm(s):
+    t = s.strip()
+    low = t.lower()
+    if low in ("true", "false"):
+        return low
+    if len(t) >= 2 and t[0] in "\"'" and t[-1] == t[0]:   # a quoted string (py repr ' vs js JSON ") -> quote-agnostic inner
+        return "str:" + t[1:-1]                            # ('5' the string stays DISTINCT from number 5 -> no conflation)
+    try:
+        return repr(round(float(t), 9) + 0.0)   # +0.0 canonicalizes -0.0 -> 0.0 (py repr '-0.0' vs js '0' was a false REJECT)
+    except Exception:
+        return t

--- a/python/scbe/frontdoor.py
+++ b/python/scbe/frontdoor.py
@@ -27,8 +27,13 @@ from typing import List, Sequence, Tuple
 
 from . import bijective_dna as DNA
 from . import board as _BOARD
+from . import correctness_gate as _CG
 from . import polyglot as P
 from . import torus as _TOR
+
+# inputs the execution gate seeds its fuzz battery with (3-arg tongue_fn; negatives expose
+# Python-vs-JS divergences like `%` semantics that the structural round-trip can't see)
+_EXEC_SEEDS = [(2.0, 3.0, 4.0), (1.0, 2.0, 3.0), (7.0, -3.0, 5.0), (9.0, 4.0, 2.0)]
 
 # --- the friendly keyboard: any of these -> a core opcode name ------------------
 _SYMBOLS = {
@@ -222,6 +227,36 @@ def _badge(ok: bool, label: str, st: _S) -> str:
     return mark + (label if ok else st.red(label))
 
 
+def _exec_verify(prog: Sequence[int]):
+    """Run the program's Python and JavaScript faces and cross-check them by EXECUTION.
+    Returns the gate verdict (SEAL/REJECT/FLAG) or None if verification was skipped/unavailable."""
+    try:
+        faces = {
+            "python": P.emit(prog, "python", runnable=True),
+            "javascript": P.emit(prog, "javascript", runnable=True),
+        }
+        return _CG.correctness_gate(faces, "tongue_fn", _EXEC_SEEDS)
+    except Exception as e:  # pragma: no cover - defensive: never let the gate crash the front door
+        return {"verdict": "FLAG", "reason": "gate error (%s) -> review" % type(e).__name__}
+
+
+def _exec_badge(v, st: _S) -> str:
+    """The PRIMARY trust badge: it lights from real cross-face EXECUTION, not a structural round-trip."""
+    if v is None:
+        dot = "·" if st.uni else "*"
+        return st.dim(dot + " exec-verify off")
+    verdict = v.get("verdict")
+    if verdict == "SEAL":
+        mark = st.green("✓ " if st.uni else "OK ")
+        return mark + st.green("exec-verified") + st.dim("  (%d in-domain inputs agree)" % v.get("checked", 0))
+    if verdict == "REJECT":
+        mark = st.red("✗ " if st.uni else "ERR ")
+        wit = v.get("witness", {}).get("input")
+        return mark + st.red("exec-REJECT") + st.dim("  (faces diverge on %s)" % (wit,))
+    mark = st.yellow("⚠ " if st.uni else "WARN ")
+    return mark + st.yellow("exec-flag → review") + st.dim("  (%s)" % v.get("reason", "")[:34])
+
+
 def _fmt(v) -> str:
     if isinstance(v, float):
         return "%.1f" % v if v == int(v) else "%.6g" % v
@@ -305,10 +340,12 @@ def render(
     width: int = 58,
     tongue: str = "ko",
     board: bool = False,
+    verify_exec: bool = True,
 ) -> str:
     st = _S(_style_enabled(color))
     names, prog = tokens_to_program(text, tongue)
     rep = DNA.verify(names)
+    exec_v = _exec_verify(prog) if verify_exec else None  # the trust signal: real cross-face execution
     seal = DNA.seal(prog) if DNA._HAVE_SEAL else []
     acc = 0
     for w in seal:
@@ -324,10 +361,11 @@ def render(
         st.dim("strand  ")
         + (" ".join("%02x" % b for b in prog) or st.dim(dot))
         + st.dim("   (%d op%s %s 1 object)" % (len(prog), "" if len(prog) == 1 else "s", dot)),
-        st.dim("verify  ")
+        st.dim("verify  ") + _exec_badge(exec_v, st),
+        st.dim("        ")
         + "  ".join(
             [
-                _badge(rep["all_faces_agree"], "%d/%d faces" % (rep["faces_agree"], rep["faces_total"]), st),
+                _badge(rep["all_faces_agree"], "%d/%d faces struct" % (rep["faces_agree"], rep["faces_total"]), st),
                 _badge(rep["seekable"], "seekable", st),
                 _badge(bool(rep.get("seal_roundtrip", True)), "sealed", st),
             ]
@@ -356,7 +394,7 @@ def render(
     return "\n".join(_panel(title, lines, st, inner, accent) for title, lines, accent in blocks)
 
 
-def _repl(langs, color, tongue="ko", board=False):
+def _repl(langs, color, tongue="ko", board=False, verify_exec=True):
     st = _S(_style_enabled(color))
     dash = "—" if st.uni else "-"
     prompt = "› " if st.uni else "> "
@@ -392,7 +430,7 @@ def _repl(langs, color, tongue="ko", board=False):
         if not line:
             continue
         try:
-            print(render(line, cur, color, tongue=tng, board=brd))
+            print(render(line, cur, color, tongue=tng, board=brd, verify_exec=verify_exec))
         except ValueError as e:
             print(st.red("  " + str(e)))
 
@@ -407,14 +445,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     ap.add_argument("--tongue", default="ko", help="Sacred Tongue for input/spelling (ko av ru ca um dr)")
     ap.add_argument("--board", action="store_true", help="show the go-board / cube embedding")
     ap.add_argument("--repl", action="store_true", help="interactive hit-Enter loop")
+    ap.add_argument("--no-exec-verify", action="store_true", help="skip the execution cross-check (faster; structural badges only)")
     ap.add_argument("--no-color", action="store_true")
     a = ap.parse_args(argv)
     color = not a.no_color
+    ve = not a.no_exec_verify
     langs = P.languages() if a.all else (a.lang or ["python"])
     if a.repl or not a.tokens:
-        return _repl(langs, color, a.tongue, a.board)
+        return _repl(langs, color, a.tongue, a.board, ve)
     try:
-        print(render(" ".join(a.tokens), langs, color, tongue=a.tongue, board=a.board))
+        print(render(" ".join(a.tokens), langs, color, tongue=a.tongue, board=a.board, verify_exec=ve))
         return 0
     except ValueError as e:
         print(_S(_style_enabled(color)).red(str(e)))

--- a/python/scbe/polyglot.py
+++ b/python/scbe/polyglot.py
@@ -16,8 +16,13 @@ Conformance is checked by polyglot_conformance.py: it compiles+runs each backend
 a LOCAL toolchain (python in-process, javascript via node, rust via rustc) and reports the
 rest as emitted-but-unverified -- never as agreement. "Compiles no matter what" means the
 emitter PRODUCES source for every backend; it does NOT mean the backends compute identical
-results -- they provably diverge on e.g. .5 rounding (Python half-to-even vs JS/Rust),
-which the harness surfaces as DISAGREE rather than hiding.
+results -- where they would diverge, the harness surfaces it as DISAGREE rather than hiding.
+The known cross-language splits on the EXECUTED faces (py/js/rust) have since been UNIFIED to
+the Python reference and verified on adversarial inputs: round -> half-to-even (round_ties_even
+/ banker's helper); mod -> floored (a - b*floor(a/b), matches Python's sign-of-divisor); pow ->
+the negative-base/non-integer-exponent intersection roundabouts to 0.0 in all faces (like
+sqrt-of-negative); div is portable. Emit-only faces (c/cpp/go/java/...) still use native
+semantics and would need the same helpers before joining the executed gate.
 
 Two op sets, kept distinct on purpose:
   * SCALAR_OPS   (22) -- the original cube/DNA core. It is the intended baseline for registered
@@ -151,15 +156,25 @@ def _render(name: str, d: Dialect, safe: bool = False) -> Tuple[str, bool]:
             expr = _sub(_ternary(d), cond=f"{vb} == 0.0", t="0.0", f=f"{va} / {vb}")
         return expr, True
     if name in CMPS:
-        # NOTE: `round` (FUNC1) intentionally uses each language's native rounding —
-        # Python is round-half-to-even, JS round-half-up, Rust round-half-away — so faces
-        # can diverge on exact .5 values. Tracked as a known divergence, not yet unified.
+        # NOTE: `round` (FUNC1) is UNIFIED to Python's round-half-to-even (banker's) across the
+        # executed faces: Rust uses round_ties_even(); JS uses the _round_ties_even() prelude helper;
+        # Python's round() is already half-to-even. So py/js/rust now AGREE on exact .5 values (the
+        # former known divergence). Untested emit-only faces (c/cpp/go/java/...) still use native
+        # rounding and would need the same helper before they can be added to the executed gate.
         op = d.cmp_over.get(name, CMPS[name])
         return _sub(d.cmp_tmpl, cond=f"{va} {op} {vb}"), True
     if name in FUNC2:
         expr = _sub(d.func2[name], a=va, b=vb)
         if safe and name == "mod":
             expr = _sub(_ternary(d), cond=f"{vb} == 0.0", t="0.0", f=expr)
+        if safe and name == "pow":
+            # Undefined intersection: negative base with a NON-integer exponent (Python -> complex,
+            # JS/Rust -> NaN). Roundabout to 0.0 in all faces, the same handler as sqrt/log of a
+            # negative. Nested so each cond is a single comparison (no per-language "and"), reusing
+            # the dialect's own floor() so it stays language-correct.
+            floor_b = _sub(d.func1["floor"], a=vb)
+            inner = _sub(_ternary(d), cond=f"{vb} != {floor_b}", t="0.0", f=expr)
+            expr = _sub(_ternary(d), cond=f"{va} < 0.0", t=inner, f=expr)
         return expr, True
     if name in FUNC1:
         expr = _sub(d.func1[name], a=va)
@@ -284,7 +299,7 @@ register(
         ext="js",
         comment="//",
         indent="  ",
-        prelude=(),
+        prelude=("function _round_ties_even(x) { const f = Math.floor(x); const d = x - f; if (d < 0.5) return f; if (d > 0.5) return f + 1; return (f % 2 === 0) ? f : f + 1; }",),
         fn_open="function {fn}({params}) {",
         stack_init="const s = [{init}];",
         pop2="{ const b = s.pop(); const a = s.pop(); ",
@@ -298,7 +313,7 @@ register(
             "sqrt": "Math.sqrt({a})",
             "floor": "Math.floor({a})",
             "ceil": "Math.ceil({a})",
-            "round": "Math.round({a})",
+            "round": "_round_ties_even({a})",
             "inc": "({a} + 1)",
             "dec": "({a} - 1)",
             "sign": "({a} > 0 ? 1.0 : ({a} < 0 ? -1.0 : 0.0))",
@@ -313,7 +328,7 @@ register(
             "pow": "Math.pow({a}, {b})",
             "min": "Math.min({a}, {b})",
             "max": "Math.max({a}, {b})",
-            "mod": "({a} % {b})",
+            "mod": "({a} - {b} * Math.floor({a} / {b}))",
             "cmp": "({a} > {b} ? 1.0 : ({a} < {b} ? -1.0 : 0.0))",
             "and": "(({a}) & ({b}))",
             "or": "(({a}) | ({b}))",
@@ -400,7 +415,7 @@ register(
             "sqrt": "({a}).sqrt()",
             "floor": "({a}).floor()",
             "ceil": "({a}).ceil()",
-            "round": "({a}).round()",
+            "round": "({a}).round_ties_even()",
             "inc": "({a} + 1.0)",
             "dec": "({a} - 1.0)",
             "sign": "(if {a} > 0.0 { 1.0 } else if {a} < 0.0 { -1.0 } else { 0.0 })",
@@ -415,7 +430,7 @@ register(
             "pow": "({a}).powf({b})",
             "min": "({a}).min({b})",
             "max": "({a}).max({b})",
-            "mod": "({a} % {b})",
+            "mod": "({a} - {b} * ({a} / {b}).floor())",
             "cmp": "(if {a} > {b} { 1.0 } else if {a} < {b} { -1.0 } else { 0.0 })",
             "and": "(((({a}) as i64) & (({b}) as i64)) as f64)",
             "or": "(((({a}) as i64) | (({b}) as i64)) as f64)",

--- a/python/scbe/quantum_lattice.py
+++ b/python/scbe/quantum_lattice.py
@@ -528,7 +528,21 @@ class TimeQuasicrystal:
 
         Returns array of times when pulses should fire.
         """
-        seq = self.fibonacci_sequence(8)[:n_pulses]
+        # Grow the Fibonacci substitution sequence until it has at least
+        # n_pulses symbols. Length after k iterations = F(k+1), so the number
+        # of iterations must scale with n_pulses (the old hardcoded value of 8
+        # capped the sequence at F(9)=34 symbols, so pulse_times(50) silently
+        # returned only 35 times and self-reported FAIL).
+        seq = ["A"]
+        while len(seq) < n_pulses:
+            new_seq: List[str] = []
+            for s in seq:
+                if s == "A":
+                    new_seq.extend(["A", "B"])
+                else:
+                    new_seq.append("A")
+            seq = new_seq
+        seq = seq[:n_pulses]
         times = [0.0]
         for s in seq:
             dt = self.period_a if s == "A" else self.period_b
@@ -712,6 +726,15 @@ def self_test() -> Dict[str, Any]:
 
 
 if __name__ == "__main__":
+    # Make stdout UTF-8 safe so Greek glyphs (φ, ψ, σ, …) in the self-test
+    # output don't crash on a Windows cp1252 console (UnicodeEncodeError).
+    import sys
+
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
     print("=" * 60)
     print("Quantum Lattice Extensions — Self-Test")
     print("=" * 60)

--- a/scripts/system/dispatch_monetization_swarm.py
+++ b/scripts/system/dispatch_monetization_swarm.py
@@ -22,7 +22,23 @@ if str(REPO_ROOT) not in sys.path:
 if str(REPO_ROOT / "src") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from src.aethercode.gateway import CrossTalkRequest, _write_crosstalk_packet  # noqa: E402
+try:
+    from src.aethercode.gateway import CrossTalkRequest, _write_crosstalk_packet  # noqa: E402
+except Exception:  # pragma: no cover - optional dependency, import-time guard
+    # NEEDS-DEP: src.aethercode.gateway is not present in this checkout.
+    # Provide clear stubs so this module imports cleanly; actually using the
+    # cross-talk bus without the gateway raises a descriptive error.
+    _CROSSTALK_DEP_ERROR = (
+        "src.aethercode.gateway is unavailable (NEEDS-DEP): cannot emit "
+        "cross-talk packets. Restore/install the aethercode gateway module."
+    )
+
+    class CrossTalkRequest:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):
+            raise ModuleNotFoundError(_CROSSTALK_DEP_ERROR)
+
+    def _write_crosstalk_packet(*args, **kwargs):  # type: ignore[no-redef]
+        raise ModuleNotFoundError(_CROSSTALK_DEP_ERROR)
 
 
 @dataclass(frozen=True)

--- a/scripts/system/shopify_store_launch_pack.py
+++ b/scripts/system/shopify_store_launch_pack.py
@@ -26,7 +26,20 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.shopify_bridge import ShopifyCLIBridge  # noqa: E402
+try:
+    from scripts.shopify_bridge import ShopifyCLIBridge  # noqa: E402
+except Exception:  # pragma: no cover - optional dependency, import-time guard
+    # NEEDS-DEP: scripts.shopify_bridge is not present in this checkout.
+    # Provide a clear stub so this module imports cleanly; instantiating the
+    # bridge without the real dependency raises a descriptive error.
+    _SHOPIFY_BRIDGE_DEP_ERROR = (
+        "scripts.shopify_bridge.ShopifyCLIBridge is unavailable (NEEDS-DEP): "
+        "cannot run live Shopify operations. Restore the shopify_bridge module."
+    )
+
+    class ShopifyCLIBridge:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):
+            raise ModuleNotFoundError(_SHOPIFY_BRIDGE_DEP_ERROR)
 
 
 def utc_now_iso() -> str:

--- a/scripts/system/storage_benchmark.py
+++ b/scripts/system/storage_benchmark.py
@@ -151,6 +151,47 @@ def benchmark_bridge(
 
     _, query_ms = _time_ms(_query_lattice)
 
+    # ---- Real recall@5 for the geometry (vs brute-force kNN ground truth) ----
+    # Build the brute-force ground truth over the full feature space (the same
+    # baseline used below) and compute the TRUE top-5 neighbor set per query.
+    gt_bf = BruteForceKNN()
+    for g in geos:
+        gt_bf.insert(
+            g["note_id"],
+            np.concatenate([g["coord_3d"], g["tongue_coords"], g["intent_vector"]]),
+        )
+    ground_truth_top5 = []
+    for qg in query_geos[:10]:
+        qvec = np.concatenate([qg["coord_3d"], qg["tongue_coords"], qg["intent_vector"]])
+        ground_truth_top5.append(set(gt_bf.query_nearest(qvec, top_k=5)))
+
+    def _measure_lattice_recall_at_5() -> float:
+        """Fraction of brute-force true top-5 that the lattice geometry retrieves."""
+        hits = 0
+        total = 0
+        for qg, truth in zip(query_geos[:10], ground_truth_top5):
+            if not truth:
+                continue
+            retrieved = lab.lattice.query_nearest(
+                qg["x"],
+                qg["y"],
+                qg["phase_rad"],
+                intent_vector=list(qg["intent_vector"]),
+                tongue=qg["tongue"],
+                top_k=5,
+            )
+            # Bundles store the originating note_id in intent_label (note_id[:48]).
+            retrieved_ids = {b.intent_label for b, _ in retrieved}
+            hits += len(truth & retrieved_ids)
+            total += len(truth)
+        return round(hits / total, 4) if total else 0.0
+
+    lattice_recall = _measure_lattice_recall_at_5()
+    # Surfaces other than the lattice are not exercised with a retrieval query in
+    # this benchmark, so their recall is not measured here (sentinel -1.0) rather
+    # than a fabricated 1.0.
+    NOT_MEASURED = -1.0
+
     report = lab.compare()
     for surface_name in ("octree", "lattice25d", "qc_drive", "sphere"):
         s = report["surfaces"][surface_name]
@@ -163,7 +204,7 @@ def benchmark_bridge(
             total_nodes=node_count,
             node_explosion=round(s["node_explosion"], 4),
             compaction_score=round(s.get("compaction_score", 0.0), 6),
-            recall_at_5=1.0 if surface_name != "sphere" else 0.0,
+            recall_at_5=lattice_recall if surface_name == "lattice25d" else NOT_MEASURED,
             memory_proxy_kb=round(node_count * 0.1, 1),  # rough: ~100 bytes/node
         )
 

--- a/spiral-word-app/app.py
+++ b/spiral-word-app/app.py
@@ -11,13 +11,14 @@ plus WebSocket endpoints for real-time sync.
 Run: uvicorn app:app --reload --host 0.0.0.0 --port 8000
 """
 
+import hashlib
 import json
 import logging
 from contextlib import asynccontextmanager
 from typing import Dict, List, Set
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel
 
 from sync_engine import SyncEngine, EditOp
@@ -30,6 +31,7 @@ from governance import (
     verify_signature,
 )
 from ai_ports import ai_ports
+from export import docx_bytes
 
 logging.basicConfig(
     level=logging.INFO,
@@ -204,6 +206,33 @@ async def delete_document(doc_id: str):
     if sync.delete_doc(doc_id):
         return {"status": "deleted", "doc_id": doc_id}
     raise HTTPException(status_code=404, detail="Document not found")
+
+
+@app.get("/doc/{doc_id}/export.docx")
+async def export_document(doc_id: str):
+    """Export the document as a downloadable Word .docx (governed + audited, dependency-free)."""
+    allowed, reason = check_governance("export")
+    if not allowed:
+        raise HTTPException(status_code=403, detail=reason)
+
+    doc = sync.get_or_create(doc_id)
+    text = doc.snapshot().get("text", "")
+    data = docx_bytes(text)
+
+    # L14: Audit the export with a deterministic checksum of the produced file
+    audit_log.record(
+        doc_id=doc_id,
+        site_id="api",
+        action="export_docx",
+        op_checksum=hashlib.sha256(data).hexdigest()[:16],
+        governance_decision=reason,
+    )
+
+    return Response(
+        content=data,
+        media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        headers={"Content-Disposition": 'attachment; filename="%s.docx"' % doc_id},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/spiral-word-app/export.py
+++ b/spiral-word-app/export.py
@@ -1,0 +1,102 @@
+"""
+@file export.py
+@module spiral-word-app/export
+@layer Layer 14
+@component Word .docx export (dependency-free)
+
+Export a SpiralWord document to a real Word .docx. A .docx is just a zip of OOXML, so this needs no
+python-docx — it returns the file as bytes for the API to stream. Wired into app.py as GET /doc/{id}/export.docx
+(governed + audited like every other operation).
+"""
+import io
+import re
+import zipfile
+
+_CONTENT_TYPES = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+    '<Default Extension="xml" ContentType="application/xml"/>'
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>'
+    '</Types>'
+)
+_RELS = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>'
+    '</Relationships>'
+)
+
+
+def _esc(t: str) -> str:
+    return t.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _para(text: str, bold: bool = False, size: int = None) -> str:
+    rpr = ""
+    if bold or size:
+        rpr = "<w:rPr>%s%s</w:rPr>" % ("<w:b/>" if bold else "", ('<w:sz w:val="%d"/>' % size) if size else "")
+    return '<w:p><w:r>%s<w:t xml:space="preserve">%s</w:t></w:r></w:p>' % (rpr, _esc(text))
+
+
+def parse_doc(text: str):
+    """SpiralWord text -> (title, sections). First non-empty line = title; '# heading' lines start sections."""
+    lines = text.splitlines()
+    title = "Untitled"
+    for i, ln in enumerate(lines):
+        if ln.strip():
+            title = ln.lstrip("# ").strip()
+            lines = lines[i + 1:]
+            break
+    sections, heading, paras = [], "", []
+    for ln in lines:
+        s = ln.strip()
+        if s.startswith("#"):
+            if heading or paras:
+                sections.append((heading, paras)); paras = []
+            heading = s.lstrip("# ").strip()
+        elif s:
+            paras.append(s)
+    if heading or paras:
+        sections.append((heading, paras))
+    return title, sections
+
+
+def _document_xml(title: str, sections) -> str:
+    body = [_para(title, bold=True, size=40)]
+    for heading, paras in sections:
+        if heading:
+            body.append(_para(heading, bold=True, size=30))
+        for p in paras:
+            body.append(_para(p))
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>'
+        + "".join(body) + '<w:sectPr/></w:body></w:document>'
+    )
+
+
+def docx_bytes(text: str) -> bytes:
+    """Render a SpiralWord document to a .docx file, returned as bytes."""
+    title, sections = parse_doc(text)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("[Content_Types].xml", _CONTENT_TYPES)
+        z.writestr("_rels/.rels", _RELS)
+        z.writestr("word/document.xml", _document_xml(title, sections))
+    return buf.getvalue()
+
+
+def read_docx_text(data: bytes) -> str:
+    """Read the visible text back out of docx bytes — used to verify the export."""
+    with zipfile.ZipFile(io.BytesIO(data)) as z:
+        xml = z.read("word/document.xml").decode("utf-8")
+    return "\n".join(re.findall(r"<w:t[^>]*>(.*?)</w:t>", xml, re.S)).replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+
+
+if __name__ == "__main__":
+    data = docx_bytes("Report\n# Section\nhello & <world>\nsecond line\n")
+    assert zipfile.is_zipfile(io.BytesIO(data)), "not a valid docx zip"
+    txt = read_docx_text(data)
+    assert "Report" in txt and "Section" in txt and "hello & <world>" in txt, txt
+    print("export.py self-test ok: %d bytes, text round-trips (incl. XML-escaped chars)" % len(data))


### PR DESCRIPTION
## What
Rescues a real, working chunk that was sitting **uncommitted** on this branch and wires the front door's trust badge to real execution.

- **`python/scbe/correctness_gate.py`** — the executing trust lane: emit the same program into multiple language faces, run them on a fuzzed input battery, faces are references for each other. **SEAL** when all agree, **REJECT** with a witness on divergence (e.g. Python `%` vs JS `%` on negatives), **FLAG** when a face won't run / coverage is thin.
- **`python/scbe/frontdoor.py`** — wired in (`_CG.correctness_gate(...)`) so the "verified" badge lights from **execution**, not a structural round-trip.
- **`spiral-word-app/export.py` + `app.py`** — dependency-free `.docx` export endpoint.
- Assorted same-chunk tweaks: `quantum_lattice.py`, `scripts/system/{dispatch_monetization_swarm,shopify_store_launch_pack,storage_benchmark}.py`, `docs/research/mars_tethered_pushline_relay.md`.

Excludes 3 `correctness_gate_*_backup.py` iteration copies (junk, left untracked).

## Verify / build check (local)
- All 8 changed Python files compile.
- `pytest tests/test_frontdoor.py` → **16 passed**.
- `correctness_gate` + `frontdoor` import clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Word document export from the app, letting users download content as a `.docx` file.
  * Added an execution verification indicator in the interface, with an option to turn it off.

* **Bug Fixes**
  * Improved cross-language result matching for more consistent checks.
  * Fixed pulse timing generation so larger pulse sets are handled correctly.

* **Chores**
  * Made several optional integrations fail more gracefully when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->