### PR TITLE
fix(codeql): drop removed kindle-app paths (fix Analyze python)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -6,8 +6,6 @@ paths:
   - services
   - tests
   - rust
-  - kindle-app/android
-  - kindle-app/www
 
 paths-ignore:
   - artifacts/**
@@ -16,10 +14,6 @@ paths-ignore:
   - external/**
   - dist/**
   - node_modules/**
-  - kindle-app/node_modules/**
-  - kindle-app/android/**/build/**
-  - kindle-app/android/.gradle/**
-  - kindle-app/android/capacitor-cordova-android-plugins/**
   - .n8n_local_iso/**
   - SCBE-AETHERMOORE-v3.0.0/**
   - docs-build-smoke/**


### PR DESCRIPTION
The CodeQL python extractor crashes with `FileNotFoundError: 'kindle-app/android'` because `.github/codeql/codeql-config.yml` still lists `kindle-app/android` and `kindle-app/www` in `paths:`, but the kindle app was removed. Removes those two dead entries (and the now-moot kindle-app paths-ignore lines). No source code touched; unblocks the `Analyze (python)` gate on main.