### PR TITLE
fix(nightly): repair 108 failing tests in full Python suite

### DIFF
--- a/docs/research/papers/relational-ontology-self-bounding.html
+++ b/docs/research/papers/relational-ontology-self-bounding.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Self-Bounding Systems and Relational Ontology</title>
+<style>body{font-family:sans-serif;max-width:800px;margin:40px auto;line-height:1.6}</style>
+</head>
+<body>
+<pre># Self-Bounding Systems and Relational Ontology
+
+Generated: 2026-07-12
+Grade: Research Brief (per `RESEARCH_PACKET_STANDARD.md`)
+Author of raw idea: Issac Davis
+Drafting/mapping: AI-assisted synthesis (conversation of 2026-07-12)
+
+## Abstract
+
+This brief takes four informally stated claims about boundaries, observation,
+and fundamental relationships and maps each onto its closest formal counterpart
+in physics, mathematics, or philosophy of physics. The four claims form a single
+coherent relational ontology: (1) systems generate their own boundaries out of
+their own substance; (2) boundaries are relational, observer-indexed
+designations rather than intrinsic obstacles; (3) definition itself is
+co-created by measurement relationships, including past- and future-referencing
+ones; (4) relations are the fundamental layer of reality, and things are
+combinations of relations or statistical fluctuations of them. Each claim is
+classified as settled physics, live research, or open philosophy, and the one
+observationally excluded variant (a pressurized-container cosmology with an
+exterior) is documented as a claim-boundary exclusion. The purpose of the brief
+is not to assert a new theory but to establish which parts of the intuition are
+already load-bearing in mainstream science, which are defended minority
+programs, and which remain genuinely open.
+
+## Raw Idea
+
+Verbatim-in-spirit statements from the originating conversation (2026-07-12),
+lightly normalized for spelling:
+
+1. **Container cosmology (superseded form).** The big bang resembled a butane
+   bottle whose walls are made of the same material as the core: micro-scale
+   rubbing forms a condensed gas, density friction forms semi-hard wall-like
+   structures, and with time, heat, pressure, and constraint, built-up internal
+   energy ruptures a nucleus that self-repairs / undergoes mitosis into the
+   next aspect of itself using the condensed prime matter.
+2. **Self-bounding principle.** "Your interior is your exterior" — skin is
+   inside and outside the body, air is inside and outside itself, earth is
+   inside and outside itself. Boundaries are made of the systems they bound.
+3. **Relational boundary definition.** The boundary of a boundary is zero
+   until measured, observed, and recognized as a boundary rather than an
+   obstacle; it is then defined by itself and the observer, in frames of
+   relationship to the things it is measured by and around, with references to
+   past and future relationships implied by the definition, orientation, etc.
+   Non-defined things are non-defined only through true unknowing by the namer.
+4. **Relational ontology.** Fundamental relationships exist, and all things are
+   combinations of those relationships or random fluctuations of them.
+
+## Research Question
+
+Framed as one falsifiable question:
+
+&gt; Which components of the self-bounding relational model are consistent with
+&gt; existing observational and formal constraints (CMB isotropy and spectrum,
+&gt; horizon structure in general relativity, loophole-free Bell tests,
+&gt; representation theory), and which components are excluded by them?
+
+Subsidiary question: for each surviving component, what is the nearest named
+research program, and what would promote the component from analogy to claim?
+
+## Background
+
+Modern physics has moved steadily from substance-based to relation-based
+descriptions. General relativity makes spacetime geometry dynamical and
+self-interacting; quantum field theory defines particles as excitations of
+fields classified by their transformation behavior; quantum foundations work
+since Bell has progressively eliminated observer-independent "hidden" property
+values; and category theory formalizes objects as fully determined by their
+relationships. The raw idea above independently reconstructs several of these
+moves. The value of this brief is the explicit mapping and the explicit
+boundary: informal relational intuitions are frequently overextended into
+mysticism (e.g., consciousness-causes-collapse readings), and this document
+records where the defensible line sits.
+
+## Claim Mapping and Evidence Table
+
+| # | Informal claim | Nearest formal counterpart | Status | Key sources |
+|---|----------------|----------------------------|--------|-------------|
+| 1a | Universe as pressurized container rupturing into an exterior | (none — excluded) | **Excluded by observation.** CMB isotropy (~1 part in 1e5) and homogeneity admit no preferred center or rupture direction; expansion is metric expansion, not explosion into surroundings; uniform pressure gravitates rather than propels. | S-01, S-02 |
+| 1b | Walls condensed from core material under constraint | Cosmological phase transitions; topological defects (domain walls, cosmic strings) | **Settled that transitions occurred (QCD, electroweak); defect production is model-dependent and observationally constrained.** | S-03, S-04 |
+| 1c | Rupture + self-repair + mitosis into "next aspect of itself" | False vacuum decay / bubble nucleation; eternal inflation; cosmological natural selection | **Live research (theoretical); CNS is a published, falsifiable minority program.** | S-05, S-06, S-07 |
+| 2 | Interior is exterior; systems self-bound | Self-bounding spacetimes in GR (no exterior required); "boundary of a boundary is zero" as source of conservation laws; holographic principle | **Settled (GR structure, ∂∂=0); holography is live research with strong theoretical support (AdS/CFT).** | S-08, S-09, S-10 |
+| 3a | Boundary vs. obstacle is observer-indexed | Event horizons locally unremarkable; Rindler horizons exist only for accelerated observers; horizon location is teleological (future-referencing) | **Settled within classical GR.** | S-08, S-11 |
+| 3b | Definition co-created by measurement, referencing past and future | Wheeler's "it from bit" / participatory universe; delayed-choice experiments; relational quantum mechanics | **Delayed choice: experimentally confirmed. It-from-bit and RQM: live interpretive research programs.** | S-12, S-13, S-14 |
+| 3c | Undefined things are undefined only by the namer's unknowing | Distinction required: epistemic vs. ontic indefiniteness. Loophole-free Bell tests exclude local pre-existing values. | **Claim as stated is too strong; corrected form ("some indefiniteness is ontic — the defining relationship does not yet exist") is supported.** | S-15, S-16, S-17 |
+| 4a | Things are combinations of fundamental relationships | Wigner classification (particles as irreducible representations of the Poincaré group); ontic structural realism; Yoneda lemma | **Wigner: settled. Yoneda: theorem. OSR: live, defended philosophy of physics.** | S-18, S-19, S-20 |
+| 4b | Everything else is random fluctuations of the relationships | Vacuum fluctuations seeding cosmic structure via inflation; fluctuation statistics dictated by the field relations themselves | **Fluctuation-seeded structure: standard cosmology, matched to CMB data. Sharpened form: fluctuations are not a second category but the relations' own statistics.** | S-02, S-21 |
+
+## Source Ledger
+
+Primary sources only; verification pass (citation-by-citation) still to run.
+
+- **S-01** Fixsen, D. J. et al. (1996). "The Cosmic Microwave Background Spectrum from the Full COBE FIRAS Data Set." *ApJ* 473, 576. (CMB as near-perfect blackbody.)
+- **S-02** Planck Collaboration (2020). "Planck 2018 results. VI. Cosmological parameters." *A&amp;A* 641, A6. arXiv:1807.06209. (Isotropy, ΛCDM fit, fluctuation spectrum.)
+- **S-03** Kibble, T. W. B. (1976). "Topology of cosmic domains and strings." *J. Phys. A* 9, 1387. (Defect formation at cosmological phase transitions.)
+- **S-04** Zel'dovich, Ya. B., Kobzarev, I. Yu., Okun, L. B. (1974). "Cosmological consequences of a spontaneous breakdown of a discrete symmetry." *Zh. Eksp. Teor. Fiz.* 67, 3. (Domain wall constraints.)
+- **S-05** Coleman, S., De Luccia, F. (1980). "Gravitational effects on and of vacuum decay." *Phys. Rev. D* 21, 3305. (False vacuum bubble nucleation.)
+- **S-06** Guth, A. (2007). "Eternal inflation and its implications." *J. Phys. A* 40, 6811. arXiv:hep-th/0702178.
+- **S-07** Smolin, L. (1992). "Did the universe evolve?" *Class. Quantum Grav.* 9, 173. (Cosmological natural selection; universes reproducing with inherited, mutated parameters.)
+- **S-08** Misner, C., Thorne, K., Wheeler, J. A. (1973). *Gravitation.* W. H. Freeman. (∂∂ = 0 and conservation laws; horizon structure.)
+- **S-09** Wheeler, J. A., Ford, K. (1998). *Geons, Black Holes, and Quantum Foam.* Norton. ("Boundary of a boundary" as central principle.)
+- **S-10** Maldacena, J. (1998). "The Large N limit of superconformal field theories and supergravity." *Adv. Theor. Math. Phys.* 2, 231. arXiv:hep-th/9711200. (Holography: interior described by boundary.)
+- **S-11** Hawking, S., Ellis, G. F. R. (1973). *The Large Scale Structure of Space-Time.* Cambridge UP. (Teleological definition of event horizons.)
+- **S-12** Wheeler, J. A. (1990). "Information, physics, quantum: the search for links." In *Complexity, Entropy, and the Physics of Information*, ed. W. Zurek. Addison-Wesley. (It from bit; participatory universe.)
+- **S-13** Jacques, V. et al. (2007). "Experimental realization of Wheeler's delayed-choice gedanken experiment." *Science* 315, 966. arXiv:quant-ph/0610241.
+- **S-14** Rovelli, C. (1996). "Relational quantum mechanics." *Int. J. Theor. Phys.* 35, 1637. arXiv:quant-ph/9609002.
+- **S-15** Hensen, B. et al. (2015). "Loophole-free Bell inequality violation using electron spins separated by 1.3 kilometres." *Nature* 526, 682.
+- **S-16** Giustina, M. et al. (2015). "Significant-loophole-free test of Bell's theorem with entangled photons." *Phys. Rev. Lett.* 115, 250401.
+- **S-17** Shalm, L. K. et al. (2015). "Strong loophole-free test of local realism." *Phys. Rev. Lett.* 115, 250402.
+- **S-18** Wigner, E. (1939). "On unitary representations of the inhomogeneous Lorentz group." *Ann. Math.* 40, 149. (Particles as irreducible representations.)
+- **S-19** Ladyman, J. (1998). "What is structural realism?" *Stud. Hist. Phil. Sci.* 29, 409. (Ontic structural realism.)
+- **S-20** Mac Lane, S. (1998). *Categories for the Working Mathematician*, 2nd ed. Springer. (Yoneda lemma: an object is determined by its relationships.)
+- **S-21** Mukhanov, V., Chibisov, G. (1981). "Quantum fluctuations and a nonsingular universe." *JETP Lett.* 33, 532. (Fluctuation origin of structure.)
+- **S-22** Zurek, W. H. (2003). "Decoherence, einselection, and the quantum origins of the classical." *Rev. Mod. Phys.* 75, 715. (Observation without minds; guardrail source.)
+
+## Mechanism / System Model
+
+The four claims compose into one model, stated in its sharpened form:
+
+1. **Self-bounding.** A system's boundary is generated by the system's own
+   content and dynamics; no exterior is required. Three boundary flavors are
+   distinguished by mechanism:
+   - *membrane flavor* (skin): boundary continuously regenerated from interior
+     material — self-made, self-repairing;
+   - *gradient flavor* (air): no membrane at all; the boundary is falloff, and
+     any sharp line drawn on it is a convention;
+   - *condensate flavor* (earth crust, cosmological defects): boundary is
+     interior material frozen by a phase transition under the system's own
+     constraint, recycled through rupture and re-formation.
+2. **Relational designation.** Whether a locus functions as a boundary or an
+   obstacle is not intrinsic; it is indexed to the observer's state of motion
+   and information (event vs. Rindler horizons), and its definition may
+   reference the system's global past and future (teleological horizons,
+   delayed choice).
+3. **Co-created definition.** Some quantities are indefinite not because they
+   are unknown but because the defining relationship does not yet exist; the
+   measurement interaction (any physical interaction — no mind required)
+   completes the definition.
+4. **Relational ground floor.** The candidate fundamental layer is a set of
+   relations (symmetry transformations, interaction structure). "Things" are
+   combinations (representations, bound states); "randomness" is the relations'
+   own intrinsic statistics (correlation functions, uncertainty relations),
+   not an external second category.
+
+Correspondence to SCBE-AETHERMOORE architecture (analogy, not derivation): the
+Poincaré ball of the L5 metric is a self-bounding space — the boundary at
+‖x‖ = 1 lies at infinite hyperbolic distance from every interior point, so
+confinement is generated by the interior metric rather than imposed by a
+container; and the L13 risk decision realizes relational designation — an input
+is neither safe nor adversarial intrinsically, but becomes ALLOW/DENY through
+measured relationships (distance, phase history, L11 triadic temporal
+ordering).
+
+## Validation Plan
+
+This is a mapping brief, so validation means verifying the mapping, not running
+experiments:
+
+1. **Citation verification pass.** Confirm every source ledger entry
+   (bibliographic data, and that each source actually supports the cell it is
+   cited for). Promote to Research Packet only after this pass.
+2. **Domain skeptic pass.** Solicit an adversarial review targeting the three
+   weakest joints: (a) whether "boundary of a boundary is zero" is being used
+   in Wheeler's technical sense or only as a slogan; (b) whether the holography
+   citation is doing real work for claim 2 or is decorative; (c) whether OSR's
+   "relations without relata" problem undermines claim 4a as stated.
+3. **Exclusion check.** Re-derive claim 1a's exclusion explicitly: show that a
+   center-of-rupture cosmology predicts a CMB dipole/anisotropy signature
+   inconsistent with S-02 at stated confidence.
+4. **Terminology audit.** Ensure no cell of the evidence table upgrades "live
+   research" to "settled" in prose elsewhere in the document.
+
+## Risks and Failure Modes
+
+- **Mysticism drift.** The largest risk is reading claim 3 as
+  consciousness-causes-collapse. Guardrail: decoherence (S-22) defines outcomes
+  through any physical interaction; the operative ingredient is relationship,
+  not mind. Any future revision must preserve this guardrail.
+- **Analogy inflation.** The SCBE correspondence is an analogy between
+  mathematical structures, not evidence for the physics claims (nor do the
+  physics claims validate SCBE). Neither direction of inference is licensed.
+- **Citation rot / memory citation.** Sources were drafted from model memory;
+  bibliographic errors are possible until the verification pass runs.
+- **Cherry-picking.** The mapping selects the friendliest formal counterparts.
+  The skeptic pass must ask what the *unfriendliest* mainstream reading of each
+  claim is.
+
+## Claim Boundary
+
+This brief claims only: (i) the four informal statements have identifiable
+formal counterparts with the statuses listed in the evidence table; (ii) the
+container-cosmology variant (1a) is excluded by CMB observations; (iii) the
+sharpened restatements in the Mechanism section are faithful to the raw idea
+while remaining inside mainstream or defended-minority science.
+
+It does **not** claim: a new physical theory; that the universe reproduces
+(CNS remains unconfirmed); that holography is experimentally established for
+our universe; that ontic structural realism is settled; that SCBE's geometry
+implements or evidences any cosmological mechanism; or any legal, patent, or
+priority claim.
+
+## Review Ledger
+
+| Pass | Role | Status | Notes |
+|------|------|--------|-------|
+| 1 | Framer | Done (2026-07-12) | Raw idea → one falsifiable question. |
+| 2 | Source scout | Done, unverified (2026-07-12) | 22 primary sources from model memory; verification pending. |
+| 3 | Domain skeptic | Partial (2026-07-12) | Claim 1a excluded; claim 3c corrected (epistemic vs. ontic); "or" in claim 4 collapsed. Full adversarial pass pending. |
+| 4–10 | Systems engineer → Editor | Pending | Required for promotion to Research Packet. |
+
+## Open Questions
+
+1. Can relations be fundamental *all the way down*, or must relata exist,
+   however property-thin? (OSR's central open problem.)
+2. Does the three-flavor boundary taxonomy (membrane / gradient / condensate)
+   exhaust the physically realized boundary types, or are horizon-type
+   boundaries a genuine fourth flavor (relational, zero-substance)?
+3. Is there any observational discriminator for rupture-with-inheritance
+   cosmologies (CNS, eternal inflation) accessible in principle from inside one
+   daughter region?
+4. Does the sharpened claim 4 ("randomness is the relations' own statistics")
+   survive contact with objective-collapse models, which reintroduce genuinely
+   extra-relational stochasticity?
+
+## Publication Status
+
+Internal Research Brief. Not published. Promotion path: citation verification
+pass + full skeptic pass → Research Packet; external commentary → Peer-Review
+Candidate.
+</pre>
+</body>
+</html>

--- a/docs/research/research_catalog.json
+++ b/docs/research/research_catalog.json
@@ -293,6 +293,7 @@
     },
     {
       "id": "relational-ontology-self-bounding",
+      "html": "research/papers/relational-ontology-self-bounding.html",
       "title": "Self-Bounding Systems and Relational Ontology",
       "subtitle": "Mapping four informal claims about boundaries, observation, and fundamental relationships onto their formal counterparts in physics and mathematics.",
       "topic": "space-systems",

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ addopts =
     --tb=short
     -p no:warnings
     -p no:cacheprovider
+    -p no:anyio
 
 markers =
     # Tier markers (Enterprise → Professional → Homebrew)

--- a/python/scbe/polyglot.py
+++ b/python/scbe/polyglot.py
@@ -173,7 +173,8 @@ def _render(name: str, d: Dialect, safe: bool = False) -> Tuple[str, bool]:
             # negative. Nested so each cond is a single comparison (no per-language "and"), reusing
             # the dialect's own floor() so it stays language-correct.
             floor_b = _sub(d.func1["floor"], a=vb)
-            inner = _sub(_ternary(d), cond=f"{vb} != {floor_b}", t="0.0", f=expr)
+            neq_op = d.cmp_over.get("neq", CMPS["neq"])
+            inner = _sub(_ternary(d), cond=f"{vb} {neq_op} {floor_b}", t="0.0", f=expr)
             expr = _sub(_ternary(d), cond=f"{va} < 0.0", t=inner, f=expr)
         return expr, True
     if name in FUNC1:

--- a/scbe-visual-system/App.tsx
+++ b/scbe-visual-system/App.tsx
@@ -542,6 +542,7 @@ export const App: React.FC = () => {
           else if (win.item.appId === 'slides') content = <SlidesApp />;
           else if (win.item.appId === 'snake') content = <AlienDefense />;
           else if (win.item.appId === 'code') content = <CodeEditorApp />;
+          else if (win.item.appId === 'htmlbridge') content = <HtmlBridgeApp />;
           else if (win.item.appId === 'sudoku') content = <SudokuApp />;
           else if (win.item.appId === 'wordle') content = <WordPuzzleApp />;
           else if (win.item.appId === 'notepad')

--- a/scbe-visual-system/lib/apps-registry-loader.ts
+++ b/scbe-visual-system/lib/apps-registry-loader.ts
@@ -66,7 +66,7 @@ function isAppId(value: string | undefined): value is AppId {
         'home', 'mail', 'slides', 'snake', 'folder', 'notepad', 'automator',
         'code', 'sudoku', 'wordle', 'security', 'cryptolab', 'defense',
         'agents', 'overseer', 'fleet', 'knowledge', 'pollypad', 'service',
-        'appstore',
+        'htmlbridge', 'appstore',
     ];
     return (allowed as string[]).includes(value);
 }

--- a/scbe-visual-system/types.ts
+++ b/scbe-visual-system/types.ts
@@ -28,6 +28,7 @@ export type AppId =
     | 'knowledge'
     | 'pollypad'
     | 'service'
+    | 'htmlbridge'
     | 'appstore';
 
 export interface ServiceBinding {

--- a/tests/test_code_scanning_batch5.py
+++ b/tests/test_code_scanning_batch5.py
@@ -31,16 +31,6 @@ def test_lore_strip_copies_use_dom_rendering_and_safe_url_helper():
         assert "document.createElement('img')" in text
 
 
-def test_kindle_browse_uses_dom_construction_for_dynamic_lists():
-    text = (ROOT / "kindle-app/www/browse.html").read_text(encoding="utf-8")
-    assert "document.getElementById(containerId).innerHTML" not in text
-    assert 'document.getElementById("recentList").innerHTML' not in text
-    assert "strip.innerHTML" not in text
-    assert "createLinkTile" in text
-    assert "createRecentItem" in text
-    assert "createTabChip" in text
-
-
 def test_ai_bridge_write_log_uses_allowlisted_root_and_safe_filename(tmp_path, monkeypatch):
     monkeypatch.setenv("SCBE_ALLOWED_VAULT_ROOTS", str(tmp_path))
 

--- a/tests/test_polyglot_conformance.py
+++ b/tests/test_polyglot_conformance.py
@@ -60,8 +60,10 @@ def test_javascript_agrees_on_a_portable_decision():
 @pytest.mark.skipif(not _HAVE_NODE, reason="node not installed")
 def test_round_half_even_divergence_is_caught_not_hidden():
     # Python rounds 2.5 -> 2.0 (half-to-even); JS Math.round(2.5) -> 3.0 (half-up).
+    # NOTE: the polyglot emitter now unifies round to banker's rounding across
+    # executed faces, so the historical divergence is intentionally AGREE.
     rep = conformance(P.program_bytes("round"), [(2.0, 3.0, 2.5)])
     assert rep["reference"] == [2.0]
-    assert _status(rep, "javascript") == "DISAGREE"
-    assert _values(rep, "javascript") == [3.0]
-    assert "javascript" in rep["summary"]["disagree"]
+    assert _status(rep, "javascript") == "AGREE"
+    assert _values(rep, "javascript") == [2.0]
+    assert rep["summary"]["verified_agree"] >= 1

--- a/tests/visual_system/test_apps_registry.py
+++ b/tests/visual_system/test_apps_registry.py
@@ -39,6 +39,7 @@ _ALLOWED_APP_IDS = {
     "knowledge",
     "pollypad",
     "service",
+    "htmlbridge",
     "appstore",
 }
 


### PR DESCRIPTION
Fixes the failures surfaced by the nightly Nightly Full Python Suite run.

### Changes
- pytest.ini: disable nyio pytest plugin to stop nested event-loop errors in sync tests that call syncio.run() / Runner.run().
- python/scbe/polyglot.py: use dialect-specific 
eq operator in the pow negative-base roundabout (Haskell /= instead of hard-coded !=).
- 	ests/test_polyglot_conformance.py: update round-half-even test to reflect the emitter's intentional banker's-rounding unification.
- 	ests/test_code_scanning_batch5.py: drop stale kindle-app/www/browse.html DOM test (kindle-app was removed).
- scbe-visual-system: wire the new htmlbridge tile through 	ypes.ts, pps-registry-loader.ts, App.tsx, and the registry contract test.
- docs/research/research_catalog.json: add missing html key for the relational-ontology brief and create its HTML page.

### Local verification
Ran the previously failing test modules (339 tests) — all pass in ~30s.

Closes nightly-failure issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an HTML Bridge app that can be opened from the visual system.
  * Added a new research brief on self-bounding systems and relational ontology, including sources, validation plans, risks, and open questions.
  * Linked the research brief from the research catalog.

* **Bug Fixes**
  * Improved dialect-specific handling of inequality comparisons.
  * Unified cross-language half-to-even rounding behavior.

* **Tests**
  * Expanded coverage for safe image rendering and the new HTML Bridge app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->