### PR TITLE
fix(security): require API key for n8n /v1/chat and /v1/execute

### DIFF
--- a/tests/test_scbe_n8n_bridge_security.py
+++ b/tests/test_scbe_n8n_bridge_security.py
@@ -75,6 +75,64 @@ async def test_llm_dispatch_ignores_user_hook_override(monkeypatch) -> None:
     assert "zapier_hook_url" not in req.model_dump()
 
 
+@pytest.mark.asyncio
+async def test_arena_chat_requires_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
+    req = bridge.ArenaChatRequest.model_validate(
+        {
+            "tentacle": "openai",
+            "message": "hello",
+            "context": [],
+        }
+    )
+
+    with pytest.raises(bridge.HTTPException) as exc:
+        await bridge.arena_chat(req)
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_execute_code_requires_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
+    req = bridge.CodeExecRequest.model_validate(
+        {
+            "code": "print('ok')",
+            "language": "python",
+            "timeout": 1,
+        }
+    )
+
+    with pytest.raises(bridge.HTTPException) as exc:
+        await bridge.execute_code(req)
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_execute_code_allows_valid_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
+
+    class _Proc:
+        stdout = "ok\n"
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr(bridge.subprocess, "run", lambda *args, **kwargs: _Proc())
+
+    req = bridge.CodeExecRequest.model_validate(
+        {
+            "code": "print('ok')",
+            "language": "python",
+            "timeout": 1,
+        }
+    )
+    result = await bridge.execute_code(req, x_api_key="test-key")
+
+    assert result["exit_code"] == 0
+    assert result["stdout"] == "ok\n"
+
+
 def test_dispatch_single_provider_hides_exception_text(monkeypatch) -> None:
     monkeypatch.setattr(
         bridge,

--- a/workflows/n8n/scbe_n8n_bridge.py
+++ b/workflows/n8n/scbe_n8n_bridge.py
@@ -710,8 +710,9 @@ def _arena_chat_anthropic_sdk(messages: List[Dict], api_key: str, model: str) ->
 
 
 @app.post("/v1/chat")
-async def arena_chat(req: ArenaChatRequest):
+async def arena_chat(req: ArenaChatRequest, x_api_key: Optional[str] = Header(None)):
     """AetherCode Arena chat — routes to the right AI provider via SDK (no Cloudflare blocks)."""
+    _check_key(x_api_key)
     t0 = time.time()
     seat = req.tentacle.lower().strip()
     cfg = _ARENA_PROVIDERS.get(seat)
@@ -766,8 +767,9 @@ async def arena_providers():
 
 
 @app.post("/v1/execute")
-async def execute_code(req: CodeExecRequest):
+async def execute_code(req: CodeExecRequest, x_api_key: Optional[str] = Header(None)):
     """Run user-supplied code in a subprocess and return stdout/stderr/exit_code."""
+    _check_key(x_api_key)
     if req.language not in ("python", "javascript"):
         raise HTTPException(400, detail=f"Unsupported language: {req.language}")
     timeout = max(1, min(req.timeout, 30))


### PR DESCRIPTION
### Motivation
- Two new n8n bridge endpoints (`/v1/chat` and `/v1/execute`) exposed server-side provider keys and allowed unauthenticated code execution, creating an RCE/auth-bypass security vulnerability that must be closed.

### Description
- Enforce API-key authentication by adding `x_api_key: Optional[str] = Header(None)` and calling `_check_key(x_api_key)` at the start of both `arena_chat` (`/v1/chat`) and `execute_code` (`/v1/execute`) handlers in `workflows/n8n/scbe_n8n_bridge.py`.
- Add regression tests in `tests/test_scbe_n8n_bridge_security.py` that assert unauthenticated calls are rejected for both endpoints and that an authenticated `/v1/execute` call still returns expected output (subprocess `run` is mocked).
- Changes are minimal and preserve existing behavior for authenticated clients while blocking unauthenticated access.
- Files changed: `workflows/n8n/scbe_n8n_bridge.py`, `tests/test_scbe_n8n_bridge_security.py`.

### Testing
- Ran `pytest -q tests/test_scbe_n8n_bridge_security.py`, which failed collection in this environment due to an unrelated import error (`ModuleNotFoundError: workflows.n8n.scbe_automation_hub`) in test collection and not because of the new assertions.
- Ran `python -m py_compile workflows/n8n/scbe_n8n_bridge.py tests/test_scbe_n8n_bridge_security.py`, which succeeded indicating the modified modules are syntactically valid.
- Added deterministic regression tests (see `tests/test_scbe_n8n_bridge_security.py`) to be run in CI where the full test environment is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b650f0164c83228d6eb9f266294f6d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API-key protection for chat and code-execution endpoints.
  * Code execution responses now report the process exit code while preserving output.

* **Bug Fixes**
  * Unauthorized requests are rejected with a 401 status code when no valid API key is provided.

* **Tests**
  * Added coverage for API-key enforcement and successful exit-code reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->