### PR TITLE
feat(site): publish complete GitHub page map

### DIFF
--- a/.github/workflows/pages-auto-deploy.yml
+++ b/.github/workflows/pages-auto-deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, site-publish-v4]
     paths:
       - 'docs/**'
+      - 'scripts/site/build_github_map.py'
+      - 'tests/site/test_github_map.py'
+      - '.github/workflows/pages-auto-deploy.yml'
   workflow_dispatch:
 
 permissions:
@@ -25,6 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify page-to-source map
+        run: |
+          python -m pip install --disable-pip-version-check pytest
+          python scripts/site/build_github_map.py --check
+          python -m pytest tests/site/test_github_map.py -q
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -7,6 +7,8 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'scripts/site/build_github_map.py'
+      - 'tests/site/test_github_map.py'
       - '.github/workflows/pages-deploy.yml'
 
 permissions:
@@ -28,6 +30,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify page-to-source map
+        run: |
+          python -m pip install --disable-pip-version-check pytest
+          python scripts/site/build_github_map.py --check
+          python -m pytest tests/site/test_github_map.py -q
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/docs/github-map.html
+++ b/docs/github-map.html
@@ -1,0 +1,498 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AetherMoore GitHub Page Map</title>
+    <meta
+      name="description"
+      content="A complete map from every public AetherMoore HTML page to its versioned GitHub source."
+    />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #090d10;
+        --panel: #12191d;
+        --line: #354247;
+        --text: #f7f0e2;
+        --muted: #aeb9b7;
+        --gold: #e0bb68;
+        --green: #22c79a;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font: 16px/1.5 Inter, ui-sans-serif, system-ui, sans-serif;
+      }
+      main { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 52px 0 72px; }
+      a { color: var(--gold); }
+      h1 { margin: 10px 0 8px; font-size: clamp(34px, 6vw, 64px); line-height: 1; }
+      .eyebrow {
+        color: var(--green);
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: .14em;
+        text-transform: uppercase;
+      }
+      .summary { max-width: 760px; color: var(--muted); }
+      .count {
+        display: inline-block;
+        margin: 18px 0 28px;
+        padding: 8px 12px;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        color: var(--green);
+      }
+      .table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 14px; background: var(--panel); }
+      table { width: 100%; border-collapse: collapse; }
+      th, td {
+        padding: 13px 16px;
+        border-bottom: 1px solid var(--line);
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        position: sticky;
+        top: 0;
+        background: #172226;
+        color: var(--muted);
+        font-size: 12px;
+        letter-spacing: .08em;
+        text-transform: uppercase;
+      }
+      tr:last-child td { border-bottom: 0; }
+      code { color: var(--muted); white-space: nowrap; }
+      .back { display: inline-block; margin-top: 24px; }
+      @media (max-width: 700px) {
+        main { width: min(100% - 20px, 1180px); padding-top: 30px; }
+        th, td { padding: 11px 12px; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="eyebrow">Public source inventory</div>
+      <h1>GitHub page map</h1>
+      <p class="summary">
+        Every deployed HTML surface is paired with its canonical live URL and versioned source location.
+        This page is generated from <code>docs/</code>, so omissions fail validation.
+      </p>
+      <div class="count">81 / 81 pages mapped</div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Public page</th><th>Repository path</th><th>GitHub</th></tr></thead>
+          <tbody>
+          <tr>
+            <td><a href="https://aethermoore.com/agents.html">AI Agents | AetherMoore</a></td>
+            <td><code>docs/agents.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/agents.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/ai-agent-governance-toolkit.html">AI Agent Governance Toolkit and Workflow Audit | AetherMoore</a></td>
+            <td><code>docs/ai-agent-governance-toolkit.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/ai-agent-governance-toolkit.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/ai-chemistry-set.html">AI Chemistry Set | AetherMoore</a></td>
+            <td><code>docs/ai-chemistry-set.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/ai-chemistry-set.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/ai-materials-bench.html">AI Materials Bench | AetherMoore</a></td>
+            <td><code>docs/ai-materials-bench.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/ai-materials-bench.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/ai-waves-lab.html">AI Waves Lab | AetherMoore</a></td>
+            <td><code>docs/ai-waves-lab.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/ai-waves-lab.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/ai-workflow-snapshot.html">$99 AI Workflow Snapshot | AetherMoore</a></td>
+            <td><code>docs/ai-workflow-snapshot.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/ai-workflow-snapshot.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/atomic-lab.html">Atomic Output Lab | AetherMoore</a></td>
+            <td><code>docs/atomic-lab.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/atomic-lab.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/benchmarks/dashboard.html">SCBE Benchmark Evidence Dashboard</a></td>
+            <td><code>docs/benchmarks/dashboard.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/benchmarks/dashboard.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/black-box.html">SCBE Black Box | PC shutdown and AI workstation failure report</a></td>
+            <td><code>docs/black-box.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/black-box.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/bookforge-writing-studio.html">AetherMoore Book Studio | Writing and KDP Prep</a></td>
+            <td><code>docs/bookforge-writing-studio.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/bookforge-writing-studio.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/books.html">AetherMoore Bookshelf | Issac Daniel Davis</a></td>
+            <td><code>docs/books.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/books.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/books/miracle-memory.html">The Miracle Was The Memory | AetherMoore Bookshelf</a></td>
+            <td><code>docs/books/miracle-memory.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/books/miracle-memory.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/books/six-tongues-protocol.html">The Six Tongues Protocol | AetherMoore Bookshelf</a></td>
+            <td><code>docs/books/six-tongues-protocol.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/books/six-tongues-protocol.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/chat.html">Polly Chat | AetherMoore</a></td>
+            <td><code>docs/chat.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/chat.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/cli.html">SCBE Terminal - governed CLI workbench</a></td>
+            <td><code>docs/cli.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/cli.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/comparison/toolkit-vs-full-repo.html">Toolkit vs Full Repository | AetherMoore</a></td>
+            <td><code>docs/comparison/toolkit-vs-full-repo.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/comparison/toolkit-vs-full-repo.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/enterprise-license.html">SCBE Enterprise Licensing | AetherMoore</a></td>
+            <td><code>docs/enterprise-license.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/enterprise-license.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/geoseal-hermes.html">GeoSeal Hermes | AetherMoore</a></td>
+            <td><code>docs/geoseal-hermes.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/geoseal-hermes.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/github-map.html">AetherMoore GitHub Page Map</a></td>
+            <td><code>docs/github-map.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/github-map.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/governance-snapshot.html">AI Governance Snapshot | AetherMoore</a></td>
+            <td><code>docs/governance-snapshot.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/governance-snapshot.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/guard.html">AetherGuard — AI Governance API</a></td>
+            <td><code>docs/guard.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/guard.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/guides.html">AetherMoore Working Guides | AI Writing and AI Security</a></td>
+            <td><code>docs/guides.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/guides.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/hire-b.html">$500 AI Governance Snapshot — Issac Davis</a></td>
+            <td><code>docs/hire-b.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/hire-b.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/hire.html">Hire Issac Davis — AI Safety &amp; Governance Engineering</a></td>
+            <td><code>docs/hire.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/hire.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/hosted-run.html">SCBE Hosted Run Intake | AetherMoore</a></td>
+            <td><code>docs/hosted-run.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/hosted-run.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/">AetherMoore | Long-Run AI Workflow Control</a></td>
+            <td><code>docs/index.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/index.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/legal/privacy.html">AetherMoore Privacy Policy</a></td>
+            <td><code>docs/legal/privacy.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/legal/privacy.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/legal/terms.html">AetherMoore Terms of Service</a></td>
+            <td><code>docs/legal/terms.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/legal/terms.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/math-spine.html">The Unified Math Spine — SCBE · PHDM · GeoSeal · HYDRA · VECRO</a></td>
+            <td><code>docs/math-spine.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/math-spine.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/offers/">SCBE Offers | AetherMoore</a></td>
+            <td><code>docs/offers/index.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/offers/index.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/packages.html">AetherMoore Package Products | npm and PyPI</a></td>
+            <td><code>docs/packages.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/packages.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/packages/scbe-aethermoore-cli.html">scbe-aethermoore-cli | SCBE Command Line</a></td>
+            <td><code>docs/packages/scbe-aethermoore-cli.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/packages/scbe-aethermoore-cli.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/packages/scbe-aethermoore.html">scbe-aethermoore | Core Governance Engine</a></td>
+            <td><code>docs/packages/scbe-aethermoore.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/packages/scbe-aethermoore.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/packages/scbe-agent-bus.html">scbe-agent-bus | Governed Agent Routing</a></td>
+            <td><code>docs/packages/scbe-agent-bus.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/packages/scbe-agent-bus.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/packages/scbe-bookforge.html">scbe-bookforge | Publishing Package</a></td>
+            <td><code>docs/packages/scbe-bookforge.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/packages/scbe-bookforge.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/payments.html">AetherMoore Payments | Ko-fi, Cash App, Card Checkout, and Invoice</a></td>
+            <td><code>docs/payments.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/payments.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/polly-stats.html">Polly Capture Stats — SCBE</a></td>
+            <td><code>docs/polly-stats.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/polly-stats.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/privacy.html">AetherMoore Privacy Policy</a></td>
+            <td><code>docs/privacy.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/privacy.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/product-manual/ai-governance-toolkit.html">SCBE AI Governance Toolkit Guide</a></td>
+            <td><code>docs/product-manual/ai-governance-toolkit.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/product-manual/ai-governance-toolkit.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/product-manual/content-spin-engine.html">Content Spin Engine</a></td>
+            <td><code>docs/product-manual/content-spin-engine.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/product-manual/content-spin-engine.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/product-manual/delivery-and-access.html">SCBE Delivery and Access</a></td>
+            <td><code>docs/product-manual/delivery-and-access.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/product-manual/delivery-and-access.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/product-manual/hydra-agent-templates.html">HYDRA Agent Templates</a></td>
+            <td><code>docs/product-manual/hydra-agent-templates.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/product-manual/hydra-agent-templates.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/product-manual/">SCBE Product Manual</a></td>
+            <td><code>docs/product-manual/index.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/product-manual/index.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/product-manual/n8n-workflow-pack.html">n8n Workflow Pack</a></td>
+            <td><code>docs/product-manual/n8n-workflow-pack.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/product-manual/n8n-workflow-pack.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/product-manual/service-fast-start.html">SCBE Service Fast-Start Packet</a></td>
+            <td><code>docs/product-manual/service-fast-start.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/product-manual/service-fast-start.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/product-manual/training-vault.html">AI Security Training Vault Manual | AetherMoore</a></td>
+            <td><code>docs/product-manual/training-vault.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/product-manual/training-vault.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/product-manual/user-guide.html">SCBE Training Vault User Guide</a></td>
+            <td><code>docs/product-manual/user-guide.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/product-manual/user-guide.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/products.html">Products — find your fit | AetherMoore</a></td>
+            <td><code>docs/products.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/products.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/proof-workbench.html">SCBE Proof Workbench | Governed AI Agents With Results</a></td>
+            <td><code>docs/proof-workbench.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/proof-workbench.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/proof/red-team-summary.html">Red-Team Summary | AetherMoore</a></td>
+            <td><code>docs/proof/red-team-summary.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/proof/red-team-summary.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/proof/why-the-manual-exists.html">Why the Manual Exists | AetherMoore</a></td>
+            <td><code>docs/proof/why-the-manual-exists.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/proof/why-the-manual-exists.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/proposals/DARPA_MATHBAC/virtual_business_card.html">Issac D. Davis - SCBE-AETHERMOORE</a></td>
+            <td><code>docs/proposals/DARPA_MATHBAC/virtual_business_card.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/proposals/DARPA_MATHBAC/virtual_business_card.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/redteam.html">Red Team Sandbox - SCBE-AETHERMOORE</a></td>
+            <td><code>docs/redteam.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/redteam.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/">Research Library | AetherMoore Research</a></td>
+            <td><code>docs/research/index.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/index.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/papers/autonomy-training-patterns.html">Drone Autonomy Training Patterns for SCBE Agent Training | AetherMoore Research</a></td>
+            <td><code>docs/research/papers/autonomy-training-patterns.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/papers/autonomy-training-patterns.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/papers/fabrication-cell-tech-tree.html">Task-Autonomous Fabrication Cell Tech Tree | AetherMoore Research</a></td>
+            <td><code>docs/research/papers/fabrication-cell-tech-tree.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/papers/fabrication-cell-tech-tree.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/papers/geoseed-orbital-model.html">GeoSeed Orbital Model | AetherMoore Research</a></td>
+            <td><code>docs/research/papers/geoseed-orbital-model.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/papers/geoseed-orbital-model.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/papers/layered-lattice-molecular-ai.html">Layered-Lattice Molecular AI: Beatable Targets | AetherMoore Research</a></td>
+            <td><code>docs/research/papers/layered-lattice-molecular-ai.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/papers/layered-lattice-molecular-ai.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/papers/mtef-fluid-cell.html">Magneto-Triboelectric Fluid Cell Research Compendium | AetherMoore Research</a></td>
+            <td><code>docs/research/papers/mtef-fluid-cell.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/papers/mtef-fluid-cell.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/papers/relational-ontology-self-bounding.html">Self-Bounding Systems and Relational Ontology</a></td>
+            <td><code>docs/research/papers/relational-ontology-self-bounding.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/papers/relational-ontology-self-bounding.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/papers/space-chemistry-cli.html">Chemistry-Native CLI and Space Chemistry Systems | AetherMoore Research</a></td>
+            <td><code>docs/research/papers/space-chemistry-cli.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/papers/space-chemistry-cli.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/papers/space-life-support-animals.html">Space Life-Support Animals, Husbandry, and Micro-Energy Concepts | AetherMoore Research</a></td>
+            <td><code>docs/research/papers/space-life-support-animals.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/papers/space-life-support-animals.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/papers/wolfram-token-map.html">Wolfram Token Map | AetherMoore Research</a></td>
+            <td><code>docs/research/papers/wolfram-token-map.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/papers/wolfram-token-map.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/topics/ai-governance.html">AI Governance | AetherMoore Research</a></td>
+            <td><code>docs/research/topics/ai-governance.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/topics/ai-governance.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/topics/autonomy-swarms.html">Autonomy and Swarms | AetherMoore Research</a></td>
+            <td><code>docs/research/topics/autonomy-swarms.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/topics/autonomy-swarms.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/topics/language-code-systems.html">Language and Code Systems | AetherMoore Research</a></td>
+            <td><code>docs/research/topics/language-code-systems.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/topics/language-code-systems.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/topics/life-systems.html">Life Systems | AetherMoore Research</a></td>
+            <td><code>docs/research/topics/life-systems.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/topics/life-systems.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/topics/materials-chemistry.html">Materials and Chemistry | AetherMoore Research</a></td>
+            <td><code>docs/research/topics/materials-chemistry.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/topics/materials-chemistry.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/research/topics/space-systems.html">Space Systems | AetherMoore Research</a></td>
+            <td><code>docs/research/topics/space-systems.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/research/topics/space-systems.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/robot.html">AetherMoore AI Agent Map</a></td>
+            <td><code>docs/robot.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/robot.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/service-credits.html">SCBE Service Credits | AetherMoore</a></td>
+            <td><code>docs/service-credits.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/service-credits.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/shopify-command-center.html">Shopify Command Center | AetherMoore</a></td>
+            <td><code>docs/shopify-command-center.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/shopify-command-center.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/solutions.html">AI Agent Governance Solutions | AetherMoore</a></td>
+            <td><code>docs/solutions.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/solutions.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/start-here.html">Start here — three routes in | AetherMoore</a></td>
+            <td><code>docs/start-here.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/start-here.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/support.html">SCBE Support | Delivery, Setup, and Recovery</a></td>
+            <td><code>docs/support.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/support.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/supporter.html">AetherMoore Support | Ko-fi, Cash App, and Stripe</a></td>
+            <td><code>docs/supporter.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/supporter.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/terms.html">AetherMoore Terms of Service</a></td>
+            <td><code>docs/terms.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/terms.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/training-hub.html">SCBE Training Hub</a></td>
+            <td><code>docs/training-hub.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/training-hub.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/use-cases/governed-ai-workflows.html">Governed AI Workflow Use Cases | AetherMoore</a></td>
+            <td><code>docs/use-cases/governed-ai-workflows.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/use-cases/governed-ai-workflows.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/workflow-machine.html">AetherMoore Workflow Machine Proof</a></td>
+            <td><code>docs/workflow-machine.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/workflow-machine.html">View source</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://aethermoore.com/workflow-snapshot.html">AI Agent Workflow Snapshot | AetherMoore</a></td>
+            <td><code>docs/workflow-snapshot.html</code></td>
+            <td><a href="https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main/docs/workflow-snapshot.html">View source</a></td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+      <a class="back" href="/">Back to AetherMoore</a>
+    </main>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -619,6 +619,7 @@
           <a href="https://www.youtube.com/channel/UCO9aJ-ZH0Ddg_F0Dr655WIQ">YouTube</a>
           <a href="https://huggingface.co/issdandavis">Hugging Face</a>
           <a href="https://github.com/issdandavis/SCBE-AETHERMOORE">GitHub</a>
+          <a href="github-map.html">Page source map</a>
           <a href="terms.html">Terms</a>
           <a href="privacy.html">Privacy</a>
         </div>

--- a/scripts/site/build_github_map.py
+++ b/scripts/site/build_github_map.py
@@ -1,0 +1,183 @@
+"""Build the public AetherMoore page-to-GitHub source map."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCS = ROOT / "docs"
+OUTPUT = DOCS / "github-map.html"
+LIVE_ROOT = "https://aethermoore.com"
+SOURCE_ROOT = "https://github.com/issdandavis/SCBE-AETHERMOORE/blob/main"
+TITLE_RE = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+
+
+@dataclass(frozen=True)
+class Page:
+    path: str
+    title: str
+    live_url: str
+    source_url: str
+
+
+def _title(path: Path) -> str:
+    if path == OUTPUT and not path.exists():
+        return "AetherMoore GitHub Page Map"
+    match = TITLE_RE.search(path.read_text(encoding="utf-8", errors="replace"))
+    if match:
+        return html.unescape(" ".join(match.group(1).split()))
+    return path.stem.replace("-", " ").title()
+
+
+def _live_path(relative: Path) -> str:
+    value = relative.as_posix()
+    if value == "index.html":
+        return "/"
+    if value.endswith("/index.html"):
+        return f"/{value.removesuffix('index.html')}"
+    return f"/{value}"
+
+
+def pages() -> list[Page]:
+    paths = set(DOCS.rglob("*.html"))
+    paths.add(OUTPUT)
+    result = []
+    for path in sorted(paths, key=lambda item: item.relative_to(DOCS).as_posix()):
+        relative = path.relative_to(DOCS)
+        docs_path = (Path("docs") / relative).as_posix()
+        result.append(
+            Page(
+                path=docs_path,
+                title=_title(path),
+                live_url=f"{LIVE_ROOT}{_live_path(relative)}",
+                source_url=f"{SOURCE_ROOT}/{docs_path}",
+            )
+        )
+    return result
+
+
+def render(items: list[Page]) -> str:
+    rows = "\n".join(f"""          <tr>
+            <td><a href="{html.escape(item.live_url)}">{html.escape(item.title)}</a></td>
+            <td><code>{html.escape(item.path)}</code></td>
+            <td><a href="{html.escape(item.source_url)}">View source</a></td>
+          </tr>""" for item in items)
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AetherMoore GitHub Page Map</title>
+    <meta
+      name="description"
+      content="A complete map from every public AetherMoore HTML page to its versioned GitHub source."
+    />
+    <style>
+      :root {{
+        color-scheme: dark;
+        --bg: #090d10;
+        --panel: #12191d;
+        --line: #354247;
+        --text: #f7f0e2;
+        --muted: #aeb9b7;
+        --gold: #e0bb68;
+        --green: #22c79a;
+      }}
+      * {{ box-sizing: border-box; }}
+      body {{
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font: 16px/1.5 Inter, ui-sans-serif, system-ui, sans-serif;
+      }}
+      main {{ width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 52px 0 72px; }}
+      a {{ color: var(--gold); }}
+      h1 {{ margin: 10px 0 8px; font-size: clamp(34px, 6vw, 64px); line-height: 1; }}
+      .eyebrow {{
+        color: var(--green);
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: .14em;
+        text-transform: uppercase;
+      }}
+      .summary {{ max-width: 760px; color: var(--muted); }}
+      .count {{
+        display: inline-block;
+        margin: 18px 0 28px;
+        padding: 8px 12px;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        color: var(--green);
+      }}
+      .table-wrap {{ overflow-x: auto; border: 1px solid var(--line); border-radius: 14px; background: var(--panel); }}
+      table {{ width: 100%; border-collapse: collapse; }}
+      th, td {{
+        padding: 13px 16px;
+        border-bottom: 1px solid var(--line);
+        text-align: left;
+        vertical-align: top;
+      }}
+      th {{
+        position: sticky;
+        top: 0;
+        background: #172226;
+        color: var(--muted);
+        font-size: 12px;
+        letter-spacing: .08em;
+        text-transform: uppercase;
+      }}
+      tr:last-child td {{ border-bottom: 0; }}
+      code {{ color: var(--muted); white-space: nowrap; }}
+      .back {{ display: inline-block; margin-top: 24px; }}
+      @media (max-width: 700px) {{
+        main {{ width: min(100% - 20px, 1180px); padding-top: 30px; }}
+        th, td {{ padding: 11px 12px; }}
+      }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="eyebrow">Public source inventory</div>
+      <h1>GitHub page map</h1>
+      <p class="summary">
+        Every deployed HTML surface is paired with its canonical live URL and versioned source location.
+        This page is generated from <code>docs/</code>, so omissions fail validation.
+      </p>
+      <div class="count">{len(items)} / {len(items)} pages mapped</div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Public page</th><th>Repository path</th><th>GitHub</th></tr></thead>
+          <tbody>
+{rows}
+          </tbody>
+        </table>
+      </div>
+      <a class="back" href="/">Back to AetherMoore</a>
+    </main>
+  </body>
+</html>
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--write", action="store_true")
+    mode.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    expected = render(pages())
+    if args.check:
+        if not OUTPUT.is_file() or OUTPUT.read_text(encoding="utf-8") != expected:
+            raise SystemExit("docs/github-map.html is missing or stale; run with --write")
+    else:
+        OUTPUT.write_text(expected, encoding="utf-8", newline="\n")
+    print(f"github page map: {len(pages())}/{len(pages())} HTML pages")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/site/test_github_map.py
+++ b/tests/site/test_github_map.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "site" / "build_github_map.py"
+SPEC = importlib.util.spec_from_file_location("build_github_map", SCRIPT)
+assert SPEC and SPEC.loader
+build_github_map = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = build_github_map
+SPEC.loader.exec_module(build_github_map)
+
+
+def test_every_html_page_has_one_live_and_source_mapping():
+    items = build_github_map.pages()
+    actual = {
+        f"docs/{path.relative_to(build_github_map.DOCS).as_posix()}" for path in build_github_map.DOCS.rglob("*.html")
+    }
+
+    assert len(items) == 81
+    assert {item.path for item in items} == actual
+    assert len({item.live_url for item in items}) == len(items)
+    assert len({item.source_url for item in items}) == len(items)
+    assert all(item.live_url.startswith("https://aethermoore.com/") for item in items)
+    assert all(item.source_url.startswith(build_github_map.SOURCE_ROOT) for item in items)
+
+
+def test_committed_map_matches_generator():
+    expected = build_github_map.render(build_github_map.pages())
+    assert build_github_map.OUTPUT.read_text(encoding="utf-8") == expected


### PR DESCRIPTION
## Summary

- publish `docs/github-map.html` with canonical live and GitHub source links for all 81 HTML surfaces
- add a deterministic generator and focused completeness/parity tests
- link the map from the public homepage
- block both Pages deployment workflows when the map is missing or stale

## Validation

- `python scripts/site/build_github_map.py --check` — 81/81 pages
- `python -m pytest tests/site/test_github_map.py -q` — 2 passed
- Black and Flake8 — passed
- workflow YAML parse — passed
- `git diff --check` — passed

## Deployment

Merging to `main` triggers the existing Pages workflows. After deployment, the target is `https://aethermoore.com/github-map.html`.

## Rollback

Revert commit `c89d0af`; the existing site pages are otherwise unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Page source map” link to the site footer.
  * Added a documentation inventory page listing public pages and their corresponding source files.

* **Bug Fixes**
  * Deployment now verifies that the page source map is complete and up to date before publishing.

* **Tests**
  * Added automated checks for unique page mappings and generated documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->