### PR TITLE
fix(site): isolate page-map deploy test

### DIFF
--- a/.github/workflows/pages-auto-deploy.yml
+++ b/.github/workflows/pages-auto-deploy.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check pytest
           python scripts/site/build_github_map.py --check
-          python -m pytest tests/site/test_github_map.py -q
+          python -m pytest --noconftest tests/site/test_github_map.py -q
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check pytest
           python scripts/site/build_github_map.py --check
-          python -m pytest tests/site/test_github_map.py -q
+          python -m pytest --noconftest tests/site/test_github_map.py -q
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary

- run the focused GitHub page-map test with `--noconftest` in both Pages workflows
- avoid importing the unrelated full SCBE test stack during static-site deployment

## Validation

- `python scripts/site/build_github_map.py --check` — 81/81
- `python -m pytest --noconftest tests/site/test_github_map.py -q` — 2 passed

## Failure addressed

Pages run 29905947292 failed because global `tests/conftest.py` imported NumPy, which the static deploy job intentionally does not install.