### PR TITLE
chore(format): align governed task package CI

### DIFF
--- a/packages/agent-bus/src/hermes.ts
+++ b/packages/agent-bus/src/hermes.ts
@@ -11,9 +11,17 @@ export type ScbeCompassMode = HermesTaskMode;
 export type ScbeFormation = 'forge' | 'scribe' | 'broadcast' | 'council' | 'scout' | 'field';
 export type ScbeTongueDomain = 'KO' | 'AV' | 'RU' | 'CA' | 'UM' | 'DR';
 export type ScbeBoardMechanic =
-  'pazaak-hand' | 'go-board-territory' | 'octree-sector' | 'chessboard-stack';
+  | 'pazaak-hand'
+  | 'go-board-territory'
+  | 'octree-sector'
+  | 'chessboard-stack';
 export type ScbeRollKind =
-  'human-input' | 'model-call' | 'api-call' | 'automation' | 'verification' | 'human-approval';
+  | 'human-input'
+  | 'model-call'
+  | 'api-call'
+  | 'automation'
+  | 'verification'
+  | 'human-approval';
 
 export interface HermesModelLane {
   id: string;

--- a/packages/agent-bus/src/index.ts
+++ b/packages/agent-bus/src/index.ts
@@ -1994,8 +1994,7 @@ export async function startAgentBusServer(
       }
       if (req.method === 'POST' && req.url === '/v1/batch') {
         const body = JSON.parse(await readBody(req)) as
-          | { items?: AgentBusEvent[]; enqueue?: boolean }
-          | AgentBusEvent[];
+          { items?: AgentBusEvent[]; enqueue?: boolean } | AgentBusEvent[];
         const items = Array.isArray(body) ? body : body.items || [];
         const enqueue = !Array.isArray(body) && body.enqueue === true;
         const rows = await runBatch(items, { ...options, enqueue });
@@ -2013,8 +2012,7 @@ export async function startAgentBusServer(
       }
       if (req.method === 'POST' && req.url === '/v1/fanout') {
         const body = JSON.parse(await readBody(req)) as
-          | { items?: AgentBusEvent[]; enqueue?: boolean; concurrency?: number }
-          | AgentBusEvent[];
+          { items?: AgentBusEvent[]; enqueue?: boolean; concurrency?: number } | AgentBusEvent[];
         const items = Array.isArray(body) ? body : body.items || [];
         const enqueue = !Array.isArray(body) && body.enqueue === true;
         const concurrency = !Array.isArray(body) ? Number(body.concurrency || 4) : 4;

--- a/packages/agent-bus/src/pipeline.ts
+++ b/packages/agent-bus/src/pipeline.ts
@@ -176,7 +176,14 @@ export interface PipelineRunResult {
 }
 
 export type GovernedMoveClass =
-  'observe' | 'read' | 'verify' | 'write' | 'network' | 'deploy' | 'destructive' | 'unknown';
+  | 'observe'
+  | 'read'
+  | 'verify'
+  | 'write'
+  | 'network'
+  | 'deploy'
+  | 'destructive'
+  | 'unknown';
 
 export interface GovernedMoveRecord {
   at: string;

--- a/packages/agent-bus/src/search-space-router.ts
+++ b/packages/agent-bus/src/search-space-router.ts
@@ -14,7 +14,12 @@ export type SearchPlane =
   | 'space';
 
 export type SearchNodeState =
-  'open' | 'expanded' | 'contracted' | 'claimed' | 'complete' | 'blocked';
+  | 'open'
+  | 'expanded'
+  | 'contracted'
+  | 'claimed'
+  | 'complete'
+  | 'blocked';
 
 export type SearchColorGrade = 'blue' | 'green' | 'yellow' | 'orange' | 'red' | 'purple';
 

--- a/packages/agent-bus/src/semantic-bridge.ts
+++ b/packages/agent-bus/src/semantic-bridge.ts
@@ -375,7 +375,12 @@ export function dimsToBinary(dims: DimVec): string {
  *   backchannel       HOLD only       — pure listener co-construction
  */
 export type DiscourseProfile =
-  'governance_steer' | 'long_turn' | 'warranted_claim' | 'floor_hold' | 'backchannel' | null;
+  | 'governance_steer'
+  | 'long_turn'
+  | 'warranted_claim'
+  | 'floor_hold'
+  | 'backchannel'
+  | null;
 
 export function detectDiscourseProfile(atoms: AtomHit[]): DiscourseProfile {
   const ids = new Set(atoms.map((a) => a.semanticId));

--- a/packages/agent-bus/src/station-manifest.ts
+++ b/packages/agent-bus/src/station-manifest.ts
@@ -28,7 +28,14 @@
 // ─── Primitive types ──────────────────────────────────────────────────────────
 
 export type District =
-  'writing' | 'code' | 'browser' | 'security' | 'research' | 'video' | 'commerce' | 'deployment';
+  | 'writing'
+  | 'code'
+  | 'browser'
+  | 'security'
+  | 'research'
+  | 'video'
+  | 'commerce'
+  | 'deployment';
 
 export type ZoneState = 'active' | 'standby' | 'maintenance' | 'quarantined' | 'offline';
 

--- a/packages/agent-bus/src/task-api.ts
+++ b/packages/agent-bus/src/task-api.ts
@@ -115,8 +115,7 @@ export type GovernedTaskRun = z.infer<typeof GovernedTaskRunSchema>;
 export type TaskFieldBasis = z.infer<typeof TaskFieldBasisSchema>;
 
 export type TaskRunParseResult =
-  | { ok: true; data: GovernedTaskRun }
-  | { ok: false; errors: string[]; raw: unknown };
+  { ok: true; data: GovernedTaskRun } | { ok: false; errors: string[]; raw: unknown };
 
 export interface TaskApiClientOptions {
   baseUrl?: string;


### PR DESCRIPTION
## Summary

Applies the exact Prettier output produced by the package and repository format gates after governed task package PR #2712 was auto-merged before those jobs finished.

## Changes

- Retain the Agent Bus package auto-format output generated by GitHub Actions.
- Align `src/index.ts` and `src/task-api.ts` with the locked CI Prettier version.
- No behavioral or package-version changes.

## Affected Layers

- [ ] L1-2: Context realification
- [ ] L3-4: Weighted transform / Poincare embedding
- [ ] L5-6: Hyperbolic distance / breathing transform
- [ ] L7-8: Mobius phase / Hamiltonian CFI
- [ ] L9-10: Spectral / spin coherence
- [ ] L11-12: Temporal distance / harmonic wall
- [ ] L13-14: Risk decision / audio axis
- [x] Infrastructure / CI / Docker

## Axiom Compliance

- [ ] A1: Unitarity (norm preservation)
- [ ] A2: Locality (spatial bounds)
- [ ] A3: Causality (time-ordering)
- [ ] A4: Symmetry (gauge invariance)
- [ ] A5: Composition (pipeline integrity)
- [x] N/A

## Test Plan

- [x] TypeScript tests pass: Agent Bus task API 3/3
- [ ] Python tests pass: no Python behavior changed
- [x] Type check passes: Agent Bus build passed
- [x] Lint passes: patch is generated from the locked CI Prettier output

## Cross-Language Parity

- [ ] TypeScript updated
- [ ] Python updated to match
- [x] N/A (format-only change)