### PR TITLE
fix(agent-bus): align Prettier with root CI

### DIFF
--- a/packages/agent-bus/package-lock.json
+++ b/packages/agent-bus/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "^20.0.0",
         "husky": "^8.0.0",
         "lint-staged": "^15.5.2",
-        "prettier": "^3.2.0",
+        "prettier": "3.9.5",
         "typescript": "^6.0.2",
         "vitest": "^4.0.17"
       },
@@ -1538,9 +1538,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/packages/agent-bus/package.json
+++ b/packages/agent-bus/package.json
@@ -74,7 +74,7 @@
     "@types/node": "^20.0.0",
     "husky": "^8.0.0",
     "lint-staged": "^15.5.2",
-    "prettier": "^3.2.0",
+    "prettier": "3.9.5",
     "typescript": "^6.0.2",
     "vitest": "^4.0.17"
   },

--- a/packages/agent-bus/src/hermes.ts
+++ b/packages/agent-bus/src/hermes.ts
@@ -11,17 +11,9 @@ export type ScbeCompassMode = HermesTaskMode;
 export type ScbeFormation = 'forge' | 'scribe' | 'broadcast' | 'council' | 'scout' | 'field';
 export type ScbeTongueDomain = 'KO' | 'AV' | 'RU' | 'CA' | 'UM' | 'DR';
 export type ScbeBoardMechanic =
-  | 'pazaak-hand'
-  | 'go-board-territory'
-  | 'octree-sector'
-  | 'chessboard-stack';
+  'pazaak-hand' | 'go-board-territory' | 'octree-sector' | 'chessboard-stack';
 export type ScbeRollKind =
-  | 'human-input'
-  | 'model-call'
-  | 'api-call'
-  | 'automation'
-  | 'verification'
-  | 'human-approval';
+  'human-input' | 'model-call' | 'api-call' | 'automation' | 'verification' | 'human-approval';
 
 export interface HermesModelLane {
   id: string;

--- a/packages/agent-bus/src/pipeline.ts
+++ b/packages/agent-bus/src/pipeline.ts
@@ -176,14 +176,7 @@ export interface PipelineRunResult {
 }
 
 export type GovernedMoveClass =
-  | 'observe'
-  | 'read'
-  | 'verify'
-  | 'write'
-  | 'network'
-  | 'deploy'
-  | 'destructive'
-  | 'unknown';
+  'observe' | 'read' | 'verify' | 'write' | 'network' | 'deploy' | 'destructive' | 'unknown';
 
 export interface GovernedMoveRecord {
   at: string;

--- a/packages/agent-bus/src/search-space-router.ts
+++ b/packages/agent-bus/src/search-space-router.ts
@@ -14,12 +14,7 @@ export type SearchPlane =
   | 'space';
 
 export type SearchNodeState =
-  | 'open'
-  | 'expanded'
-  | 'contracted'
-  | 'claimed'
-  | 'complete'
-  | 'blocked';
+  'open' | 'expanded' | 'contracted' | 'claimed' | 'complete' | 'blocked';
 
 export type SearchColorGrade = 'blue' | 'green' | 'yellow' | 'orange' | 'red' | 'purple';
 

--- a/packages/agent-bus/src/semantic-bridge.ts
+++ b/packages/agent-bus/src/semantic-bridge.ts
@@ -375,12 +375,7 @@ export function dimsToBinary(dims: DimVec): string {
  *   backchannel       HOLD only       — pure listener co-construction
  */
 export type DiscourseProfile =
-  | 'governance_steer'
-  | 'long_turn'
-  | 'warranted_claim'
-  | 'floor_hold'
-  | 'backchannel'
-  | null;
+  'governance_steer' | 'long_turn' | 'warranted_claim' | 'floor_hold' | 'backchannel' | null;
 
 export function detectDiscourseProfile(atoms: AtomHit[]): DiscourseProfile {
   const ids = new Set(atoms.map((a) => a.semanticId));

--- a/packages/agent-bus/src/station-manifest.ts
+++ b/packages/agent-bus/src/station-manifest.ts
@@ -28,14 +28,7 @@
 // ─── Primitive types ──────────────────────────────────────────────────────────
 
 export type District =
-  | 'writing'
-  | 'code'
-  | 'browser'
-  | 'security'
-  | 'research'
-  | 'video'
-  | 'commerce'
-  | 'deployment';
+  'writing' | 'code' | 'browser' | 'security' | 'research' | 'video' | 'commerce' | 'deployment';
 
 export type ZoneState = 'active' | 'standby' | 'maintenance' | 'quarantined' | 'offline';
 


### PR DESCRIPTION
## Summary

Stops the Agent Bus and root format workflows from rewriting the same files in opposite directions. Root CI was locked to Prettier 3.9.5 while `packages/agent-bus` resolved 3.8.3.

## Changes

- Pin Agent Bus Prettier to the same 3.9.5 resolved by the root lockfile.
- Regenerate the Agent Bus package lock.
- Restore the five files rewritten by the older formatter to the shared 3.9.5 output.
- No runtime behavior or public API changes.

## Affected Layers

- [ ] L1-2: Context realification
- [ ] L3-4: Weighted transform / Poincare embedding
- [ ] L5-6: Hyperbolic distance / breathing transform
- [ ] L7-8: Mobius phase / Hamiltonian CFI
- [ ] L9-10: Spectral / spin coherence
- [ ] L11-12: Temporal distance / harmonic wall
- [ ] L13-14: Risk decision / audio axis
- [x] Infrastructure / CI / Docker

## Axiom Compliance

- [ ] A1: Unitarity (norm preservation)
- [ ] A2: Locality (spatial bounds)
- [ ] A3: Causality (time-ordering)
- [ ] A4: Symmetry (gauge invariance)
- [ ] A5: Composition (pipeline integrity)
- [x] N/A

## Test Plan

- [x] TypeScript tests pass: Agent Bus 708/708
- [ ] Python tests pass: no Python behavior changed
- [x] Type check passes: Agent Bus build passed
- [x] Lint passes: clean LF checkout passed both root TS format gate and Agent Bus full-package format gate

## Cross-Language Parity

- [ ] TypeScript updated
- [ ] Python updated to match
- [x] N/A (tooling-only change)