### PR TITLE
fix(ci): align liboqs Python and native pins

### DIFF
--- a/.github/workflows/pqc-native-liboqs.yml
+++ b/.github/workflows/pqc-native-liboqs.yml
@@ -30,7 +30,7 @@ permissions:
   contents: read
 
 env:
-  LIBOQS_VERSION: "0.15.0"
+  LIBOQS_VERSION: "0.16.0"
   LIBOQS_INSTALL: "${{ github.workspace }}/.oqs"
   OQS_INSTALL_PATH: "${{ github.workspace }}/.oqs"
   LD_LIBRARY_PATH: "${{ github.workspace }}/.oqs/lib:${{ github.workspace }}/.oqs/lib64"
@@ -78,7 +78,7 @@ jobs:
       - name: Install Python native bindings
         run: |
           python -m pip install --upgrade pip
-          python -m pip install liboqs-python==0.14.1
+          python -m pip install liboqs-python==0.16.0
 
       - name: Prove native liboqs security backend
         run: python scripts/security/native_liboqs_smoke.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,10 @@ requests>=2.32.0
 jsonschema>=4.23.0
 # Post-Quantum Cryptography
 # Python bindings are pinned here; the native C library is installed by the
-# dedicated PQC Native liboqs workflow using liboqs 0.15.0. Normal PR CI may
+# dedicated PQC Native liboqs workflow using liboqs 0.16.0. Normal PR CI may
 # force the deterministic fallback path, but release/security validation must
 # pass native liboqs Tier 1.
-liboqs-python==0.15.0
+liboqs-python==0.16.0
 # python-oqs is currently unavailable in PyPI CI environments; use liboqs-python.
 pycryptodome>=3.20.0
 argon2-cffi>=23.1.0


### PR DESCRIPTION
## Summary
- update the base liboqs-python pin from unavailable 0.15.0 to 0.16.0
- compile native liboqs 0.16.0 in the dedicated PQC workflow
- install the matching 0.16.0 Python binding in that workflow

## Evidence
- python -m pip install --dry-run --no-deps liboqs-python==0.16.0
- 96 focused governance tests pass
- scoped Ruff checks pass
- fixes the dependency-resolution failures observed in PR #2717