### PR TITLE
fix(governance): stabilize axiom verification

### DIFF
--- a/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/axiom_lens.py
+++ b/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/axiom_lens.py
@@ -118,10 +118,7 @@ class AxiomLensResult:
     def to_dict(self) -> dict[str, object]:
         """Return a strict-JSON-compatible receipt."""
 
-        compliance = [
-            [None if np.isnan(value) else float(value) for value in row]
-            for row in self.node_compliance
-        ]
+        compliance = [[None if np.isnan(value) else float(value) for value in row] for row in self.node_compliance]
 
         return {
             "schema": "scbe.axiom-lens.v1",
@@ -149,9 +146,7 @@ class AxiomLensResult:
         }
 
 
-def _state_matrix(
-    name: str, values: np.ndarray | Sequence[Sequence[float]]
-) -> np.ndarray:
+def _state_matrix(name: str, values: np.ndarray | Sequence[Sequence[float]]) -> np.ndarray:
     matrix = np.asarray(values, dtype=float)
     if matrix.ndim != 2 or matrix.shape[0] == 0 or matrix.shape[1] == 0:
         raise ValueError(f"{name} must have shape (nodes, features)")
@@ -173,9 +168,7 @@ def _matching_state_matrix(
     return matrix
 
 
-def _edge_matrix(
-    edges: np.ndarray | Sequence[Sequence[int]] | None, node_count: int
-) -> np.ndarray:
+def _edge_matrix(edges: np.ndarray | Sequence[Sequence[int]] | None, node_count: int) -> np.ndarray:
     if edges is None:
         return np.empty((0, 2), dtype=np.int64)
     raw = np.asarray(edges)
@@ -195,12 +188,7 @@ def _edge_matrix(
 
 
 def _symmetry_views(
-    values: (
-        np.ndarray
-        | Sequence[Sequence[float]]
-        | Sequence[Sequence[Sequence[float]]]
-        | None
-    ),
+    values: np.ndarray | Sequence[Sequence[float]] | Sequence[Sequence[Sequence[float]]] | None,
     shape: tuple[int, int],
 ) -> np.ndarray | None:
     if values is None:
@@ -209,9 +197,7 @@ def _symmetry_views(
     if views.ndim == 2:
         views = views[np.newaxis, ...]
     if views.ndim != 3 or views.shape[1:] != shape or views.shape[0] == 0:
-        raise ValueError(
-            f"symmetry_states must have shape {shape} or (views, {shape[0]}, {shape[1]})"
-        )
+        raise ValueError(f"symmetry_states must have shape {shape} or (views, {shape[0]}, {shape[1]})")
     if not np.all(np.isfinite(views)):
         raise ValueError("symmetry_states must contain only finite values")
     return views
@@ -252,9 +238,7 @@ def _target_residual_and_gradient(
         delta = node_states - target
         denominator = np.maximum(np.sum(target * target, axis=1), floor_squared)
         residuals += np.sum(delta * delta, axis=1) / denominator
-        gradient += (2.0 * delta / denominator[:, np.newaxis]) / (
-            node_count * view_count
-        )
+        gradient += (2.0 * delta / denominator[:, np.newaxis]) / (node_count * view_count)
 
     return residuals / view_count, gradient
 
@@ -265,12 +249,7 @@ def build_axiom_lens(
     edges: np.ndarray | Sequence[Sequence[int]] | None = None,
     reference_states: np.ndarray | Sequence[Sequence[float]] | None = None,
     timestamps: np.ndarray | Sequence[float] | None = None,
-    symmetry_states: (
-        np.ndarray
-        | Sequence[Sequence[float]]
-        | Sequence[Sequence[Sequence[float]]]
-        | None
-    ) = None,
+    symmetry_states: np.ndarray | Sequence[Sequence[float]] | Sequence[Sequence[Sequence[float]]] | None = None,
     composed_states: np.ndarray | Sequence[Sequence[float]] | None = None,
     config: AxiomLensConfig | None = None,
 ) -> AxiomLensResult:
@@ -287,12 +266,8 @@ def build_axiom_lens(
     node_count, feature_count = states.shape
     edge_array = _edge_matrix(edges, node_count)
     edge_count = edge_array.shape[0]
-    references = _matching_state_matrix(
-        "reference_states", reference_states, states.shape
-    )
-    compositions = _matching_state_matrix(
-        "composed_states", composed_states, states.shape
-    )
+    references = _matching_state_matrix("reference_states", reference_states, states.shape)
+    compositions = _matching_state_matrix("composed_states", composed_states, states.shape)
     symmetries = _symmetry_views(symmetry_states, states.shape)
 
     time_values: np.ndarray | None = None
@@ -331,9 +306,7 @@ def build_axiom_lens(
 
         safe_norms = np.maximum(current_norms, config.epsilon)
         state_gradients[unitarity_index] = (
-            (2.0 * norm_delta / (scales**2 * node_count))[:, np.newaxis]
-            * states
-            / safe_norms[:, np.newaxis]
+            (2.0 * norm_delta / (scales**2 * node_count))[:, np.newaxis] * states / safe_norms[:, np.newaxis]
         )
 
     if references is not None and edge_count:
@@ -344,9 +317,7 @@ def build_axiom_lens(
             reference_delta = references[source] - references[target]
             current_distance = float(np.linalg.norm(current_delta))
             reference_distance = float(np.linalg.norm(reference_delta))
-            excess = max(
-                0.0, current_distance - reference_distance - config.locality_slack
-            )
+            excess = max(0.0, current_distance - reference_distance - config.locality_slack)
             scale = max(reference_distance, floor)
             locality_values[edge_index] = (excess / scale) ** 2
 
@@ -356,9 +327,7 @@ def build_axiom_lens(
                 locality_gradient[source] += contribution
                 locality_gradient[target] -= contribution
 
-        node_values, observed = _distribute_edge_values(
-            locality_values, edge_array, node_count
-        )
+        node_values, observed = _distribute_edge_values(locality_values, edge_array, node_count)
         node_residuals[:, locality_index] = node_values
         node_observed[:, locality_index] = observed
         edge_residuals[:, locality_index] = locality_values
@@ -372,9 +341,7 @@ def build_axiom_lens(
         for edge_index, (source, target) in enumerate(edge_array):
             violation = max(
                 0.0,
-                float(
-                    time_values[source] + config.causal_min_step - time_values[target]
-                ),
+                float(time_values[source] + config.causal_min_step - time_values[target]),
             )
             causal_values[edge_index] = violation**2 / scale_squared
             if violation > 0.0:
@@ -382,9 +349,7 @@ def build_axiom_lens(
                 causal_gradient[source] += derivative
                 causal_gradient[target] -= derivative
 
-        node_values, observed = _distribute_edge_values(
-            causal_values, edge_array, node_count
-        )
+        node_values, observed = _distribute_edge_values(causal_values, edge_array, node_count)
         node_residuals[:, causality_index] = node_values
         node_observed[:, causality_index] = observed
         edge_residuals[:, causality_index] = causal_values
@@ -414,8 +379,7 @@ def build_axiom_lens(
         for axis_index in (unitarity_index, symmetry_index, composition_index):
             if node_observed[source, axis_index] and node_observed[target, axis_index]:
                 edge_residuals[edge_index, axis_index] = 0.5 * (
-                    node_residuals[source, axis_index]
-                    + node_residuals[target, axis_index]
+                    node_residuals[source, axis_index] + node_residuals[target, axis_index]
                 )
                 edge_observed[edge_index, axis_index] = True
 
@@ -423,8 +387,7 @@ def build_axiom_lens(
     for edge_index, (source, target) in enumerate(edge_array):
         jointly_observed = node_observed[source] & node_observed[target]
         edge_axiom_delta[edge_index, jointly_observed] = (
-            node_residuals[target, jointly_observed]
-            - node_residuals[source, jointly_observed]
+            node_residuals[target, jointly_observed] - node_residuals[source, jointly_observed]
         )
 
     node_compliance = np.full_like(node_residuals, np.nan)
@@ -482,9 +445,7 @@ def build_axiom_lens(
             for index, name in enumerate(AXIOM_ORDER)
         },
         total_loss=total_loss,
-        coverage_by_axiom={
-            name: float(coverage[index]) for index, name in enumerate(AXIOM_ORDER)
-        },
+        coverage_by_axiom={name: float(coverage[index]) for index, name in enumerate(AXIOM_ORDER)},
         overall_coverage=overall_coverage,
         evidence_status=evidence_status,
         depth=depth,

--- a/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/causality_axiom.py
+++ b/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/causality_axiom.py
@@ -19,6 +19,7 @@ This ensures information cannot travel backwards in time.
 from __future__ import annotations
 
 import functools
+import inspect
 import numpy as np
 from typing import Callable, TypeVar, Any, Tuple, List
 from dataclasses import dataclass
@@ -118,6 +119,14 @@ def causality_check(require_time_param: bool = True, allow_acausal: bool = False
     """
 
     def decorator(func: F) -> F:
+        signature = inspect.signature(func)
+        time_parameter = next(
+            (name for name in ("t", "tau") if name in signature.parameters),
+            None,
+        )
+        if require_time_param and time_parameter is None:
+            raise TypeError(f"{func.__name__} must declare a 't' or 'tau' parameter")
+
         # Track last execution time for ordering checks
         last_time = {"value": None}
 
@@ -125,16 +134,18 @@ def causality_check(require_time_param: bool = True, allow_acausal: bool = False
         def wrapper(*args, **kwargs):
             strict_time_order = bool(kwargs.pop("_strict_causality_order", False))
 
-            # Extract time parameter
-            current_time = kwargs.get("t", None)
-            explicit_time = "t" in kwargs
-            if current_time is None and len(args) > 1:
-                # Try to find explicit time in positional args (skip primary data arg).
-                for arg in args[1:]:
-                    if isinstance(arg, (int, float)) and 0 <= arg < 1e10:
-                        current_time = float(arg)
+            # Bind only declared temporal parameters. Scanning arbitrary numeric
+            # arguments can mistake distances or scores for time, while Layer 11
+            # legitimately exposes its temporal coordinate as ``tau``.
+            current_time = None
+            explicit_time = False
+            if time_parameter is not None:
+                bound_arguments = signature.bind_partial(*args, **kwargs).arguments
+                if time_parameter in bound_arguments:
+                    candidate = bound_arguments[time_parameter]
+                    if isinstance(candidate, (int, float, np.integer, np.floating)):
+                        current_time = float(candidate)
                         explicit_time = True
-                        break
 
             if current_time is None:
                 current_time = time_module.time() % 1000  # Use system time

--- a/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/tests/test_axiom_grouped.py
+++ b/src/symphonic_cipher/scbe_aethermoore/axiom_grouped/tests/test_axiom_grouped.py
@@ -326,6 +326,28 @@ class TestCausalityAxiom:
         )
         assert d >= 0
 
+    def test_layer_11_causality_uses_explicit_tau(self, monkeypatch):
+        """Layer 11 must not replace an explicit tau with wall-clock time."""
+        causality_axiom.layer_11_triadic_distance.reset_time()
+        monkeypatch.setattr(causality_axiom.time_module, "time", lambda: 1.0)
+        u = random_poincare_point(DIM)
+        ref_u = random_poincare_point(DIM)
+
+        causality_axiom.layer_11_triadic_distance(
+            u=u,
+            ref_u=ref_u,
+            tau=42.0,
+            ref_tau=41.0,
+            eta=0.5,
+            ref_eta=0.3,
+            q=1 + 0j,
+            ref_q=0.5 + 0.5j,
+        )
+
+        check = causality_axiom.layer_11_triadic_distance.last_check
+        assert check.passed
+        assert check.current_time == 42.0
+
     def test_layer_13_decision_levels(self):
         """Layer 13 should return correct decision levels."""
         # Low risk

--- a/tests/governance/test_axiom_lens.py
+++ b/tests/governance/test_axiom_lens.py
@@ -87,10 +87,7 @@ def test_each_supplied_view_contributes_to_the_five_axis_field():
     )
 
     assert set(result.loss_by_axiom) == set(AXIOM_ORDER)
-    assert all(
-        result.loss_by_axiom[name] is not None and result.loss_by_axiom[name] > 0.0
-        for name in AXIOM_ORDER
-    )
+    assert all(result.loss_by_axiom[name] is not None and result.loss_by_axiom[name] > 0.0 for name in AXIOM_ORDER)
     assert result.evidence_status == "complete"
     assert np.all(np.isfinite(result.node_residuals))
     assert np.all(np.isfinite(result.state_gradient))
@@ -154,12 +151,8 @@ def test_time_gradient_matches_finite_difference():
         minus = timestamps.copy()
         plus[node] += epsilon
         minus[node] -= epsilon
-        plus_loss = build_axiom_lens(
-            states, edges=edges, timestamps=plus, config=config
-        ).total_loss
-        minus_loss = build_axiom_lens(
-            states, edges=edges, timestamps=minus, config=config
-        ).total_loss
+        plus_loss = build_axiom_lens(states, edges=edges, timestamps=plus, config=config).total_loss
+        minus_loss = build_axiom_lens(states, edges=edges, timestamps=minus, config=config).total_loss
         numerical[node] = (plus_loss - minus_loss) / (2.0 * epsilon)
 
     assert result.time_gradient == pytest.approx(numerical, rel=1e-6, abs=1e-6)
@@ -228,19 +221,13 @@ def test_configuration_rejects_non_finite_values():
 
 def test_canonical_axiom_registry_and_document_shims_are_consistent():
     repo_root = Path(__file__).resolve().parents[2]
-    registry = yaml.safe_load(
-        (repo_root / "config" / "scbe_core_axioms_v1.yaml").read_text(encoding="utf-8")
-    )
+    registry = yaml.safe_load((repo_root / "config" / "scbe_core_axioms_v1.yaml").read_text(encoding="utf-8"))
 
     missing_sources = [
-        relative_path
-        for relative_path in registry["canonical_sources"]
-        if not (repo_root / relative_path).exists()
+        relative_path for relative_path in registry["canonical_sources"] if not (repo_root / relative_path).exists()
     ]
     assert missing_sources == []
-    assert registry["formula_regime_authority"] == (
-        "docs/specs/CANONICAL_FORMULA_REGISTRY.md"
-    )
+    assert registry["formula_regime_authority"] == ("docs/specs/CANONICAL_FORMULA_REGISTRY.md")
     assert [item["name"] for item in registry["formula_regimes"]] == [
         "BOUNDED_SCORE",
         "BOUNDED_WALL",
@@ -248,9 +235,7 @@ def test_canonical_axiom_registry_and_document_shims_are_consistent():
         "PI_EXP_COST",
     ]
 
-    formula_registry = (
-        repo_root / "docs" / "specs" / "CANONICAL_FORMULA_REGISTRY.md"
-    ).read_text(encoding="utf-8")
+    formula_registry = (repo_root / "docs" / "specs" / "CANONICAL_FORMULA_REGISTRY.md").read_text(encoding="utf-8")
     for regime in (
         "BOUNDED_SCORE",
         "BOUNDED_WALL",
@@ -259,16 +244,12 @@ def test_canonical_axiom_registry_and_document_shims_are_consistent():
     ):
         assert regime in formula_registry
 
-    layer_index = (repo_root / "docs" / "specs" / "LAYER_INDEX.md").read_text(
-        encoding="utf-8"
-    )
+    layer_index = (repo_root / "docs" / "specs" / "LAYER_INDEX.md").read_text(encoding="utf-8")
     assert "BOUNDED_SCORE" in layer_index
     assert "FLIGHT_GOVERNANCE_COUPLING.md" not in layer_index
     assert "F1 0.813" not in layer_index
 
-    assert "Documentation Shim" in (repo_root / "docs" / "LAYER_INDEX.md").read_text(
+    assert "Documentation Shim" in (repo_root / "docs" / "LAYER_INDEX.md").read_text(encoding="utf-8")
+    assert "Documentation Shim" in (repo_root / "docs" / "specs" / "CANONICAL_SYSTEM_STATE.md").read_text(
         encoding="utf-8"
     )
-    assert "Documentation Shim" in (
-        repo_root / "docs" / "specs" / "CANONICAL_SYSTEM_STATE.md"
-    ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- format the AxiomLens implementation and tests with the Black settings enforced by CI
- bind causality checks through declared 	 or 	au parameters instead of guessing from arbitrary numeric arguments
- prevent Layer 11 keyword calls from silently substituting wall-clock modulo time for explicit 	au
- add a regression test for the Layer 11 temporal binding

## Evidence
- 97 focused governance tests pass
- 100 seeds x 3 causality layers: 300/300 verification checks pass
- Black check passes for all four changed Python files
- Ruff passes for all four changed Python files