### PR TITLE
fix(pytest): asyncio_mode=auto to unblock Nightly Full Python Suite (#2673)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-asyncio_mode = strict
+asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 
 addopts =


### PR DESCRIPTION
## Problem

Nightly Full Python Suite (`-m "not slow"`) has been red (issue #2673) with 100+ failures of the form:

```
RuntimeError: asyncio.run() cannot be called from a running event loop
```

Root cause: `pytest.ini` sets `asyncio_mode = strict`. Under strict mode pytest-asyncio installs a running event loop for the session/function scope. Dozens of existing **sync** tests (swarm type/click risk, MCP list_tools, aetherbrowse CLI readiness, API key verify, geoseal verify, etc.) legitimately call `asyncio.run(...)` on async helpers. That combination is illegal.

PR smoke does not exercise the full suite, so the breakage stayed invisible to day-to-day CI.

## Fix

Change `asyncio_mode` from `strict` to `auto`.

- `auto` only wraps tests that are actually async (or marked); sync tests that call `asyncio.run` keep working.
- No behavioral change for properly written `@pytest.mark.asyncio` tests.
- Leaves the longer-term cleanup (convert callers to native async tests or a small helper that uses `get_event_loop`/`run_until_complete` safely) for a follow-up if desired.

## Verification

After merge, the next scheduled (or manually dispatched) Nightly Full Python Suite run should go green and close #2673.

## Related

- Closes #2673
- Prior anyio disable was already landed in #2695; this is the remaining asyncio conflict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated asynchronous test execution settings for more flexible handling of async tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->