### PR TITLE
fix(hydra): restore the domain-aware turnstile — main ships a stub that ignores `domain`

### DIFF
--- a/hydra/turnstile.py
+++ b/hydra/turnstile.py
@@ -45,7 +45,7 @@ import math
 from typing import Literal
 
 Decision = Literal["ALLOW", "DENY", "ESCALATE", "QUARANTINE"]
-Domain = Literal["browser", "vehicle", "fleet", "antivirus", "default"]
+Domain = Literal["browser", "vehicle", "fleet", "antivirus", "arxiv", "patent", "default"]
 Action = Literal["ALLOW", "HOLD", "PIVOT", "DEGRADE", "ISOLATE", "HONEYPOT", "STOP"]
 
 
@@ -61,9 +61,81 @@ class TurnstileOutcome:
     membrane_stress: float
 
 
-# Domains whose turnstile-matrix.yaml entry lists HONEYPOT as an allowed action.
-# vehicle does not (ALLOW/PIVOT/DEGRADE, "No stall"), nor do arxiv/patent.
-_HONEYPOT_DOMAINS = frozenset({"browser", "fleet", "antivirus", "default"})
+# Runtime copy of the declarative turnstile contract.  The conformance suite
+# compares every entry to turnstile-matrix.yaml, so changing either side alone
+# fails.  Every outcome is constructed through _outcome(), which refuses an
+# action outside its domain's declared set.
+_DOMAIN_ALLOWED_ACTIONS: dict[Domain, frozenset[Action]] = {
+    "browser": frozenset({"ALLOW", "HOLD", "HONEYPOT"}),
+    "vehicle": frozenset({"ALLOW", "PIVOT", "DEGRADE"}),
+    "fleet": frozenset({"ALLOW", "ISOLATE", "DEGRADE", "HONEYPOT"}),
+    "antivirus": frozenset({"ALLOW", "ISOLATE", "HONEYPOT"}),
+    "arxiv": frozenset({"ALLOW", "HOLD", "STOP"}),
+    "patent": frozenset({"ALLOW", "HOLD", "STOP"}),
+    "default": frozenset({"ALLOW", "STOP"}),
+}
+
+# The input decision is not itself a turnstile action.  This table is the
+# complete low-stress dispatch for every non-ALLOW decision.  Keeping it data-
+# shaped makes both coverage and reachability testable.
+_DOMAIN_DECISION_ACTIONS: dict[Domain, dict[Decision, Action]] = {
+    "browser": {"DENY": "HOLD", "ESCALATE": "HOLD", "QUARANTINE": "HOLD"},
+    "vehicle": {"DENY": "PIVOT", "ESCALATE": "DEGRADE", "QUARANTINE": "PIVOT"},
+    "fleet": {"DENY": "ISOLATE", "ESCALATE": "DEGRADE", "QUARANTINE": "ISOLATE"},
+    "antivirus": {"DENY": "ISOLATE", "ESCALATE": "ISOLATE", "QUARANTINE": "ISOLATE"},
+    "arxiv": {"DENY": "STOP", "ESCALATE": "HOLD", "QUARANTINE": "HOLD"},
+    "patent": {"DENY": "STOP", "ESCALATE": "HOLD", "QUARANTINE": "HOLD"},
+    "default": {"DENY": "STOP", "ESCALATE": "STOP", "QUARANTINE": "STOP"},
+}
+
+_ACTION_TRAITS: dict[Action, tuple[bool, bool, bool, bool]] = {
+    # require_human, isolate, deploy_honeypot, continue_execution
+    "ALLOW": (False, False, False, True),
+    "HOLD": (True, False, False, False),
+    "PIVOT": (False, False, False, True),
+    "DEGRADE": (False, False, False, True),
+    "ISOLATE": (False, True, False, False),
+    "HONEYPOT": (False, True, True, True),
+    "STOP": (False, False, False, False),
+}
+
+
+def _normalize_domain(domain: str) -> Domain:
+    normalized = domain.lower() if isinstance(domain, str) else "default"
+    return normalized if normalized in _DOMAIN_ALLOWED_ACTIONS else "default"  # type: ignore[return-value]
+
+
+def allowed_actions_for(domain: str) -> frozenset[Action]:
+    """Return the executable policy boundary for a declared domain."""
+
+    return _DOMAIN_ALLOWED_ACTIONS[_normalize_domain(domain)]
+
+
+def _outcome(
+    *,
+    domain: Domain,
+    action: Action,
+    reason: str,
+    antibody_load: float,
+    membrane_stress: float,
+    isolate: bool | None = None,
+    continue_execution: bool | None = None,
+) -> TurnstileOutcome:
+    allowed = _DOMAIN_ALLOWED_ACTIONS[domain]
+    if action not in allowed:
+        raise AssertionError(f"turnstile policy violation: {domain} cannot emit {action}; allowed={sorted(allowed)}")
+
+    require_human, default_isolate, deploy_honeypot, default_continue = _ACTION_TRAITS[action]
+    return TurnstileOutcome(
+        action=action,
+        require_human=require_human,
+        isolate=default_isolate if isolate is None else isolate,
+        deploy_honeypot=deploy_honeypot,
+        continue_execution=default_continue if continue_execution is None else continue_execution,
+        reason=reason,
+        antibody_load=antibody_load,
+        membrane_stress=membrane_stress,
+    )
 
 
 def _clamp01(x: float) -> float:
@@ -102,9 +174,7 @@ def resolve_turnstile(
     if normalized_decision not in {"ALLOW", "DENY", "ESCALATE", "QUARANTINE"}:
         normalized_decision = "DENY"
 
-    normalized_domain: Domain = domain.lower() if isinstance(domain, str) else "default"
-    if normalized_domain not in {"browser", "vehicle", "fleet", "antivirus", "default"}:
-        normalized_domain = "default"
+    normalized_domain = _normalize_domain(domain)
 
     antibody = compute_antibody_load(suspicion, previous_antibody_load)
     stress = compute_membrane_stress(geometry_norm)
@@ -112,109 +182,55 @@ def resolve_turnstile(
     # Last line of defense: geometrically suspicious or immune-overloaded contexts
     # are rerouted to a honeypot execution lane.
     #
-    # GATED ON DOMAIN, and it was not in the archived original. That short-circuit
-    # returned before the domain dispatch, so it overrode every per-domain rule --
-    # including vehicle's, whose matrix entry is ALLOW/PIVOT/DEGRADE with the note
-    # "No stall; choose safe maneuver." Caught by test_turnstile_conformance:
-    # vehicle/DENY at stress 0.995 returned HONEYPOT, which the matrix forbids.
-    # Domains whose matrix entry lists HONEYPOT: browser, fleet, antivirus.
+    # This used to be a hardcoded domain allowlist.  Membership now comes from
+    # the same executable policy checked against the matrix, so a newly declared
+    # domain cannot inherit HONEYPOT through the default branch.
     if (
         normalized_decision != "ALLOW"
-        and normalized_domain in _HONEYPOT_DOMAINS
+        and "HONEYPOT" in _DOMAIN_ALLOWED_ACTIONS[normalized_domain]
         and (stress >= 0.9 or antibody >= 0.85)
     ):
-        return TurnstileOutcome(
+        return _outcome(
+            domain=normalized_domain,
             action="HONEYPOT",
-            require_human=False,
-            isolate=True,
-            deploy_honeypot=True,
-            continue_execution=True,
             reason="honeypot triggered by membrane stress / antibody load",
             antibody_load=antibody,
             membrane_stress=stress,
         )
 
     if normalized_decision == "ALLOW":
-        return TurnstileOutcome(
+        return _outcome(
+            domain=normalized_domain,
             action="ALLOW",
-            require_human=False,
-            isolate=False,
-            deploy_honeypot=False,
-            continue_execution=True,
             reason="decision allow",
             antibody_load=antibody,
             membrane_stress=stress,
         )
 
-    if normalized_domain == "browser":
-        # Browser can pause for user review safely.
-        return TurnstileOutcome(
-            action="HOLD",
-            require_human=True,
-            isolate=normalized_decision == "QUARANTINE",
-            deploy_honeypot=False,
-            continue_execution=False,
-            reason="browser turnstile hold for review",
-            antibody_load=antibody,
-            membrane_stress=stress,
-        )
+    action = _DOMAIN_DECISION_ACTIONS[normalized_domain][normalized_decision]
+    reasons = {
+        "browser": "browser turnstile hold for review",
+        "vehicle": "vehicle domain continues through a safe maneuver",
+        "fleet": "fleet containment without global stall",
+        "antivirus": "antivirus domain isolates suspicious artifact",
+        "arxiv": "arxiv submission requires human review or stop",
+        "patent": "patent filing requires attorney review or stop",
+        "default": "default hard stop",
+    }
+    # A failed fleet quorum always isolates the node and keeps the rest of the
+    # swarm alive.  ISOLATE in antivirus remains a terminal containment action.
+    if normalized_domain == "fleet" and not quorum_ok:
+        action = "ISOLATE"
+        reason = "fleet quorum failed; isolate node and continue"
+    else:
+        reason = reasons[normalized_domain]
 
-    if normalized_domain == "vehicle":
-        # Real-time systems cannot stall; always pivot to safe maneuver.
-        return TurnstileOutcome(
-            action="PIVOT",
-            require_human=False,
-            isolate=False,
-            deploy_honeypot=False,
-            continue_execution=True,
-            reason="vehicle domain requires immediate pivot",
-            antibody_load=antibody,
-            membrane_stress=stress,
-        )
-
-    if normalized_domain == "fleet":
-        if not quorum_ok:
-            return TurnstileOutcome(
-                action="ISOLATE",
-                require_human=False,
-                isolate=True,
-                deploy_honeypot=False,
-                continue_execution=True,
-                reason="fleet quorum failed; isolate node and continue",
-                antibody_load=antibody,
-                membrane_stress=stress,
-            )
-        return TurnstileOutcome(
-            action="DEGRADE" if normalized_decision == "ESCALATE" else "ISOLATE",
-            require_human=False,
-            isolate=normalized_decision != "ESCALATE",
-            deploy_honeypot=False,
-            continue_execution=True,
-            reason="fleet containment without global stall",
-            antibody_load=antibody,
-            membrane_stress=stress,
-        )
-
-    if normalized_domain == "antivirus":
-        return TurnstileOutcome(
-            action="ISOLATE",
-            require_human=False,
-            isolate=True,
-            deploy_honeypot=False,
-            continue_execution=False,
-            reason="antivirus domain isolates suspicious artifact",
-            antibody_load=antibody,
-            membrane_stress=stress,
-        )
-
-    # Default strict behavior.
-    return TurnstileOutcome(
-        action="STOP",
-        require_human=False,
-        isolate=False,
-        deploy_honeypot=False,
-        continue_execution=False,
-        reason="default hard stop",
+    return _outcome(
+        domain=normalized_domain,
+        action=action,
+        isolate=(normalized_decision == "QUARANTINE") if normalized_domain == "browser" else None,
+        continue_execution=True if normalized_domain == "fleet" and action == "ISOLATE" else None,
+        reason=reason,
         antibody_load=antibody,
         membrane_stress=stress,
     )

--- a/hydra/turnstile.py
+++ b/hydra/turnstile.py
@@ -1,66 +1,220 @@
 """
-Domain-aware turnstile resolution for SCBE antivirus and extension gates.
+HYDRA turnstile policy for domain-aware containment decisions.
 
-Turnstile maps a governance decision + suspicion signals to a containment
-action and updates the running antibody load (immune memory across calls).
+RESTORED 2026-08-05. The domain-aware implementation was removed by
+`acfc3734c refactor: split monolith into 9 focused repos (#1042)`, which left a
+stub that accepted `domain` and never read it -- `domain` appeared exactly once
+in the file, as the parameter. Evidence: `git log -S deploy_honeypot -- hydra/
+turnstile.py` and `-S PIVOT` both show the symbols entering at 123d997bb and
+leaving at acfc3734c, and nowhere else.
+
+What the stub could not do, against
+skills/scbe-kernel-external-toolcall-specialist/references/turnstile-matrix.yaml:
+
+  vehicle  allowed ALLOW/PIVOT/DEGRADE, "No stall; choose safe maneuver."
+           The stub could emit NEITHER PIVOT nor DEGRADE, and its fallback for an
+           unrecognised decision was HOLD -- the one action the domain forbids.
+  fleet    allowed ALLOW/ISOLATE/DEGRADE/HONEYPOT; DEGRADE was unreachable.
+  unknown  decision fell to HOLD, which is byte-identical to a legitimate
+           QUARANTINE, so a defaulted decision was invisible in the outcome.
+           This version falls to DENY and carries a `reason`.
+
+Nothing checked any of that: the only turnstile test read the YAML and asserted
+things about the YAML. test_turnstile_conformance.py now runs this function
+against that matrix.
+
+Source of the restore: the archived mirror github.com/issdandavis/scbe-agents
+(read-only snapshot 2026-04-13), the last surviving copy.
+
+Design goals:
+- Browser agents may HOLD for manual approval.
+- Real-time vehicle agents must PIVOT instead of stalling.
+- Fleet nodes should isolate compromised workers without freezing the swarm.
+- Antivirus domain can deploy honeypot routing as a final containment layer.
+
+Cell-theory inspired math:
+  antibody_load(t+1) = clamp( decay * antibody_load(t) + (1-decay) * suspicion, 0, 1 )
+  membrane_stress     = clamp((norm - threshold) / (1 - threshold), 0, 1)
+where decay = exp(-ln(2) * dt / half_life)
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
+from typing import Literal
+
+Decision = Literal["ALLOW", "DENY", "ESCALATE", "QUARANTINE"]
+Domain = Literal["browser", "vehicle", "fleet", "antivirus", "default"]
+Action = Literal["ALLOW", "HOLD", "PIVOT", "DEGRADE", "ISOLATE", "HONEYPOT", "STOP"]
 
 
 @dataclass(frozen=True)
 class TurnstileOutcome:
-    action: str
+    action: Action
+    require_human: bool
+    isolate: bool
+    deploy_honeypot: bool
+    continue_execution: bool
+    reason: str
     antibody_load: float
     membrane_stress: float
 
 
-_DECISION_TO_ACTION = {
-    "DENY": "STOP",
-    "ESCALATE": "ISOLATE",
-    "QUARANTINE": "HOLD",
-    "ALLOW": "ALLOW",
-}
+# Domains whose turnstile-matrix.yaml entry lists HONEYPOT as an allowed action.
+# vehicle does not (ALLOW/PIVOT/DEGRADE, "No stall"), nor do arxiv/patent.
+_HONEYPOT_DOMAINS = frozenset({"browser", "fleet", "antivirus", "default"})
+
+
+def _clamp01(x: float) -> float:
+    return min(1.0, max(0.0, x))
+
+
+def compute_antibody_load(
+    suspicion: float,
+    previous_load: float = 0.0,
+    dt: float = 1.0,
+    half_life: float = 12.0,
+) -> float:
+    if not math.isfinite(suspicion):
+        return 1.0
+    hl = max(1e-6, half_life)
+    decay = math.exp(-math.log(2.0) * max(0.0, dt) / hl)
+    return _clamp01(decay * _clamp01(previous_load) + (1.0 - decay) * _clamp01(suspicion))
+
+
+def compute_membrane_stress(norm_value: float, threshold: float = 0.98) -> float:
+    if not math.isfinite(norm_value):
+        return 1.0
+    t = min(0.999999, max(0.0, threshold))
+    return _clamp01((norm_value - t) / max(1e-9, 1.0 - t))
 
 
 def resolve_turnstile(
-    *,
     decision: str,
-    domain: str,
-    suspicion: float,
-    geometry_norm: float,
+    domain: str = "default",
+    suspicion: float = 0.0,
+    geometry_norm: float = 0.0,
     previous_antibody_load: float = 0.0,
     quorum_ok: bool = True,
 ) -> TurnstileOutcome:
-    """
-    Map governance decision + live signals to a containment action.
+    normalized_decision: Decision = decision.upper() if isinstance(decision, str) else "DENY"
+    if normalized_decision not in {"ALLOW", "DENY", "ESCALATE", "QUARANTINE"}:
+        normalized_decision = "DENY"
 
-    antibody_load decays toward 0 when suspicion is low and accumulates when
-    suspicion is high (immune memory across successive calls for the same process).
+    normalized_domain: Domain = domain.lower() if isinstance(domain, str) else "default"
+    if normalized_domain not in {"browser", "vehicle", "fleet", "antivirus", "default"}:
+        normalized_domain = "default"
 
-    membrane_stress reflects current load: a weighted blend of suspicion and
-    geometry_norm that indicates how hard the membrane is working right now.
-    """
+    antibody = compute_antibody_load(suspicion, previous_antibody_load)
+    stress = compute_membrane_stress(geometry_norm)
 
-    def _clamp(x):
-        return min(1.0, max(0.0, float(x)))
+    # Last line of defense: geometrically suspicious or immune-overloaded contexts
+    # are rerouted to a honeypot execution lane.
+    #
+    # GATED ON DOMAIN, and it was not in the archived original. That short-circuit
+    # returned before the domain dispatch, so it overrode every per-domain rule --
+    # including vehicle's, whose matrix entry is ALLOW/PIVOT/DEGRADE with the note
+    # "No stall; choose safe maneuver." Caught by test_turnstile_conformance:
+    # vehicle/DENY at stress 0.995 returned HONEYPOT, which the matrix forbids.
+    # Domains whose matrix entry lists HONEYPOT: browser, fleet, antivirus.
+    if (
+        normalized_decision != "ALLOW"
+        and normalized_domain in _HONEYPOT_DOMAINS
+        and (stress >= 0.9 or antibody >= 0.85)
+    ):
+        return TurnstileOutcome(
+            action="HONEYPOT",
+            require_human=False,
+            isolate=True,
+            deploy_honeypot=True,
+            continue_execution=True,
+            reason="honeypot triggered by membrane stress / antibody load",
+            antibody_load=antibody,
+            membrane_stress=stress,
+        )
 
-    antibody_load = _clamp(0.65 * previous_antibody_load + 0.35 * suspicion)
-    membrane_stress = _clamp(0.60 * suspicion + 0.40 * geometry_norm)
+    if normalized_decision == "ALLOW":
+        return TurnstileOutcome(
+            action="ALLOW",
+            require_human=False,
+            isolate=False,
+            deploy_honeypot=False,
+            continue_execution=True,
+            reason="decision allow",
+            antibody_load=antibody,
+            membrane_stress=stress,
+        )
 
-    # Escalate to honeypot when immune memory is saturated and active suspicion is high.
-    if antibody_load >= 0.85 and suspicion >= 0.60:
-        action = "HONEYPOT"
-    else:
-        action = _DECISION_TO_ACTION.get(decision.upper(), "HOLD")
-        # Downgrade ALLOW to HOLD when quorum is not satisfied.
-        if not quorum_ok and action == "ALLOW":
-            action = "HOLD"
+    if normalized_domain == "browser":
+        # Browser can pause for user review safely.
+        return TurnstileOutcome(
+            action="HOLD",
+            require_human=True,
+            isolate=normalized_decision == "QUARANTINE",
+            deploy_honeypot=False,
+            continue_execution=False,
+            reason="browser turnstile hold for review",
+            antibody_load=antibody,
+            membrane_stress=stress,
+        )
 
+    if normalized_domain == "vehicle":
+        # Real-time systems cannot stall; always pivot to safe maneuver.
+        return TurnstileOutcome(
+            action="PIVOT",
+            require_human=False,
+            isolate=False,
+            deploy_honeypot=False,
+            continue_execution=True,
+            reason="vehicle domain requires immediate pivot",
+            antibody_load=antibody,
+            membrane_stress=stress,
+        )
+
+    if normalized_domain == "fleet":
+        if not quorum_ok:
+            return TurnstileOutcome(
+                action="ISOLATE",
+                require_human=False,
+                isolate=True,
+                deploy_honeypot=False,
+                continue_execution=True,
+                reason="fleet quorum failed; isolate node and continue",
+                antibody_load=antibody,
+                membrane_stress=stress,
+            )
+        return TurnstileOutcome(
+            action="DEGRADE" if normalized_decision == "ESCALATE" else "ISOLATE",
+            require_human=False,
+            isolate=normalized_decision != "ESCALATE",
+            deploy_honeypot=False,
+            continue_execution=True,
+            reason="fleet containment without global stall",
+            antibody_load=antibody,
+            membrane_stress=stress,
+        )
+
+    if normalized_domain == "antivirus":
+        return TurnstileOutcome(
+            action="ISOLATE",
+            require_human=False,
+            isolate=True,
+            deploy_honeypot=False,
+            continue_execution=False,
+            reason="antivirus domain isolates suspicious artifact",
+            antibody_load=antibody,
+            membrane_stress=stress,
+        )
+
+    # Default strict behavior.
     return TurnstileOutcome(
-        action=action,
-        antibody_load=round(antibody_load, 4),
-        membrane_stress=round(membrane_stress, 4),
+        action="STOP",
+        require_human=False,
+        isolate=False,
+        deploy_honeypot=False,
+        continue_execution=False,
+        reason="default hard stop",
+        antibody_load=antibody,
+        membrane_stress=stress,
     )

--- a/tests/test_turnstile_conformance.py
+++ b/tests/test_turnstile_conformance.py
@@ -1,0 +1,105 @@
+"""The turnstile must obey the matrix that declares it.
+
+The matrix at skills/scbe-kernel-external-toolcall-specialist/references/
+turnstile-matrix.yaml declares, per domain, which actions are permitted. Until
+now the only test read that YAML and asserted things about the YAML -- the spec
+was checked against itself and never against the code. That is how a stub which
+ignored `domain` entirely survived from acfc3734c until 2026-08-05.
+
+These tests call resolve_turnstile and compare its output to the declaration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from hydra.turnstile import resolve_turnstile  # noqa: E402
+
+MATRIX_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "scbe-kernel-external-toolcall-specialist"
+    / "references"
+    / "turnstile-matrix.yaml"
+)
+
+DECISIONS = ["ALLOW", "DENY", "ESCALATE", "QUARANTINE"]
+IMPLEMENTED_DOMAINS = ["browser", "vehicle", "fleet", "antivirus"]
+
+
+def _matrix():
+    return yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))["domains"]
+
+
+@pytest.mark.parametrize("domain", IMPLEMENTED_DOMAINS)
+@pytest.mark.parametrize("decision", DECISIONS)
+@pytest.mark.parametrize("suspicion,geometry_norm", [(0.0, 0.0), (0.5, 0.5), (0.95, 0.995)])
+def test_action_is_permitted_by_the_matrix(domain, decision, suspicion, geometry_norm):
+    """Whatever the turnstile returns must be in that domain's allowed list."""
+    allowed = set(_matrix()[domain]["allowed_actions"])
+    out = resolve_turnstile(
+        decision=decision,
+        domain=domain,
+        suspicion=suspicion,
+        geometry_norm=geometry_norm,
+        previous_antibody_load=suspicion,
+        quorum_ok=True,
+    )
+    assert out.action in allowed, (
+        f"{domain}/{decision} -> {out.action!r}, which the matrix does not permit "
+        f"({sorted(allowed)}). reason={out.reason!r}"
+    )
+
+
+@pytest.mark.parametrize("decision", DECISIONS)
+def test_vehicle_never_stalls(decision):
+    """The matrix note is 'No stall; choose safe maneuver.' HOLD is a stall.
+
+    This is the assertion the stub failed: HOLD was its fallback action.
+    """
+    out = resolve_turnstile(decision=decision, domain="vehicle", suspicion=0.4, geometry_norm=0.4)
+    assert out.action != "HOLD"
+    assert out.continue_execution is True
+
+
+def test_unknown_decision_falls_to_deny_not_hold():
+    """An unrecognised decision must not be indistinguishable from QUARANTINE.
+
+    The stub returned HOLD for both, so a garbage decision string looked exactly
+    like a legitimate quarantine in the outcome.
+    """
+    out = resolve_turnstile(decision="NOT_A_DECISION", domain="default", suspicion=0.0)
+    assert out.action != "ALLOW"
+    assert out.continue_execution is False
+
+
+def test_domain_is_actually_read():
+    """The regression itself: `domain` was accepted and never used.
+
+    Same decision and signals, two domains, must not give the same action.
+    """
+    a = resolve_turnstile(decision="QUARANTINE", domain="browser", suspicion=0.3, geometry_norm=0.3)
+    b = resolve_turnstile(decision="QUARANTINE", domain="vehicle", suspicion=0.3, geometry_norm=0.3)
+    assert a.action != b.action, "domain is being ignored again"
+
+
+def test_every_matrix_domain_is_either_implemented_or_declared_default():
+    """Domains in the matrix that the code does not implement fall to default.
+
+    arxiv and patent are declared but not branched on; they resolve through the
+    default path. That is only acceptable while the default action is inside
+    their allowed list -- this test fails the day that stops being true.
+    """
+    m = _matrix()
+    for name in m:
+        if name in IMPLEMENTED_DOMAINS:
+            continue
+        out = resolve_turnstile(decision="DENY", domain=name, suspicion=0.0, geometry_norm=0.0)
+        assert out.action in set(m[name]["allowed_actions"]), (
+            f"{name} is declared in the matrix, is not implemented, and its default "
+            f"action {out.action!r} is not in {sorted(m[name]['allowed_actions'])}"
+        )

--- a/tests/test_turnstile_conformance.py
+++ b/tests/test_turnstile_conformance.py
@@ -17,7 +17,7 @@ import pytest
 
 yaml = pytest.importorskip("yaml")
 
-from hydra.turnstile import resolve_turnstile  # noqa: E402
+from hydra.turnstile import allowed_actions_for, resolve_turnstile  # noqa: E402
 
 MATRIX_PATH = (
     Path(__file__).resolve().parents[1]
@@ -28,17 +28,17 @@ MATRIX_PATH = (
 )
 
 DECISIONS = ["ALLOW", "DENY", "ESCALATE", "QUARANTINE"]
-IMPLEMENTED_DOMAINS = ["browser", "vehicle", "fleet", "antivirus"]
 
 
 def _matrix():
     return yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))["domains"]
 
 
-@pytest.mark.parametrize("domain", IMPLEMENTED_DOMAINS)
+@pytest.mark.parametrize("domain", sorted(_matrix()))
 @pytest.mark.parametrize("decision", DECISIONS)
 @pytest.mark.parametrize("suspicion,geometry_norm", [(0.0, 0.0), (0.5, 0.5), (0.95, 0.995)])
-def test_action_is_permitted_by_the_matrix(domain, decision, suspicion, geometry_norm):
+@pytest.mark.parametrize("quorum_ok", [False, True])
+def test_action_is_permitted_by_the_matrix(domain, decision, suspicion, geometry_norm, quorum_ok):
     """Whatever the turnstile returns must be in that domain's allowed list."""
     allowed = set(_matrix()[domain]["allowed_actions"])
     out = resolve_turnstile(
@@ -47,7 +47,7 @@ def test_action_is_permitted_by_the_matrix(domain, decision, suspicion, geometry
         suspicion=suspicion,
         geometry_norm=geometry_norm,
         previous_antibody_load=suspicion,
-        quorum_ok=True,
+        quorum_ok=quorum_ok,
     )
     assert out.action in allowed, (
         f"{domain}/{decision} -> {out.action!r}, which the matrix does not permit "
@@ -87,19 +87,54 @@ def test_domain_is_actually_read():
     assert a.action != b.action, "domain is being ignored again"
 
 
-def test_every_matrix_domain_is_either_implemented_or_declared_default():
-    """Domains in the matrix that the code does not implement fall to default.
+@pytest.mark.parametrize("domain", sorted(_matrix()))
+def test_runtime_policy_matches_declared_matrix(domain):
+    """The runtime guard and the declarative matrix must be the same set."""
 
-    arxiv and patent are declared but not branched on; they resolve through the
-    default path. That is only acceptable while the default action is inside
-    their allowed list -- this test fails the day that stops being true.
-    """
-    m = _matrix()
-    for name in m:
-        if name in IMPLEMENTED_DOMAINS:
-            continue
-        out = resolve_turnstile(decision="DENY", domain=name, suspicion=0.0, geometry_norm=0.0)
-        assert out.action in set(m[name]["allowed_actions"]), (
-            f"{name} is declared in the matrix, is not implemented, and its default "
-            f"action {out.action!r} is not in {sorted(m[name]['allowed_actions'])}"
-        )
+    assert set(allowed_actions_for(domain)) == set(_matrix()[domain]["allowed_actions"])
+
+
+@pytest.mark.parametrize("domain", sorted(_matrix()))
+def test_every_declared_action_is_reachable(domain):
+    """Allowed actions are an executable policy, not decorative vocabulary."""
+
+    observed = set()
+    for decision in DECISIONS:
+        for suspicion, geometry_norm in ((0.0, 0.0), (0.95, 1.0)):
+            for quorum_ok in (False, True):
+                observed.add(
+                    resolve_turnstile(
+                        decision=decision,
+                        domain=domain,
+                        suspicion=suspicion,
+                        previous_antibody_load=suspicion,
+                        geometry_norm=geometry_norm,
+                        quorum_ok=quorum_ok,
+                    ).action
+                )
+    assert observed == set(_matrix()[domain]["allowed_actions"])
+
+
+def test_unknown_domain_fails_closed_even_under_honeypot_pressure():
+    out = resolve_turnstile(
+        decision="DENY",
+        domain="not-a-domain",
+        suspicion=1.0,
+        previous_antibody_load=1.0,
+        geometry_norm=1.0,
+    )
+    assert out.action == "STOP"
+    assert out.continue_execution is False
+    assert out.deploy_honeypot is False
+
+
+@pytest.mark.parametrize("domain", sorted(_matrix()))
+@pytest.mark.parametrize("decision", DECISIONS)
+def test_outcome_flags_agree_with_action(domain, decision):
+    out = resolve_turnstile(decision=decision, domain=domain, suspicion=0.0, geometry_norm=0.0)
+    assert out.deploy_honeypot is (out.action == "HONEYPOT")
+    assert out.require_human is (out.action == "HOLD")
+    if out.action in {"ALLOW", "PIVOT", "DEGRADE", "HONEYPOT"}:
+        assert out.continue_execution is True
+    if out.action in {"HOLD", "STOP"}:
+        assert out.continue_execution is False


### PR DESCRIPTION
Two commits, cherry-picked clean onto `main`, no conflicts. **187 conformance
tests pass.**

## What is broken on `main` right now

`acfc3734c refactor: split monolith into 9 focused repos (#1042)` replaced
`hydra/turnstile.py` with a 66-line stub that **accepts `domain` and never reads
it** — `domain` appears exactly once in the file, as the parameter.

Checked against `skills/scbe-kernel-external-toolcall-specialist/references/turnstile-matrix.yaml`:

| domain | matrix allows | the stub could emit |
|---|---|---|
| `vehicle` | ALLOW / PIVOT / DEGRADE — *"No stall; choose safe maneuver"* | neither PIVOT nor DEGRADE; fell back to **HOLD**, the one action this domain forbids |
| `fleet` | ALLOW / ISOLATE / DEGRADE / HONEYPOT | DEGRADE unreachable |
| unknown | — | fell to HOLD, byte-identical to a legitimate QUARANTINE, so a defaulted decision was invisible in the outcome |

Evidence: `git log -S deploy_honeypot -- hydra/turnstile.py` and `-S PIVOT` both
show those symbols entering at `123d997bb` and leaving at `acfc3734c`, nowhere
else.

**Nothing caught it** because the only turnstile test read the YAML and asserted
things about the YAML. The function was never run against the matrix it claims
to implement.

## What these commits do

1. **Restore** the domain-aware implementation (recovered from the archived
   `issdandavis/scbe-agents` mirror, the last surviving copy).
2. **Make the matrix executable.** Every outcome is now constructed through
   `_outcome()`, which raises if an action falls outside its domain's declared
   set — so the runtime table and the YAML cannot drift apart silently. HONEYPOT
   membership comes from that same table rather than a hardcoded allowlist, so a
   newly declared domain cannot inherit it through a default branch.
3. **Test it against the matrix.** `tests/test_turnstile_conformance.py` runs
   `resolve_turnstile` over every domain × decision pair in the YAML.

Now falls to DENY with a `reason` on an unrecognised decision, instead of HOLD.

## Scope

Deliberately narrow. This is *only* the turnstile — no dependency changes, no
lockfiles, nothing that conflicts with the open Dependabot PRs.

The remaining security work (24 pip advisories, 4 npm lockfiles, n8n bridge) is
in #2749, which currently conflicts with `main` on 14 dependency manifests. That
one needs its conflicts resolved; this one does not, and shouldn't wait on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMQwJ2MfUkcxxhffWUmJSk
