### PR TITLE
security: floor the remaining pip advisories in pyproject.toml (aiohttp, cryptography, mcp, bedrock-agentcore)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,18 @@ dependencies = [
     # patched 2.14.2). Transitive today and already pinned in requirements-lock.txt, but constrained here
     # so the manifest itself can never resolve the vulnerable range.
     "pydantic-settings>=2.14.2",
-    # security floors for transitive deps still attributed to this manifest by Dependabot
-    # (Pillow PDF/CMS DoS; pyasn1 REAL/OID DoS). Already pinned in requirements-lock.txt.
-    "pillow>=12.3.0",
+    # Security floors for TRANSITIVE deps that Dependabot attributes to this
+    # manifest. A requirements file does not constrain what
+    # `pip install scbe-aethermoore` resolves -- only the manifest does -- so the
+    # floor has to live here too. Floors, not pins: >= lets a consumer take
+    # anything newer. Each is the FIRST PATCHED version from its advisory.
+    "pillow>=12.3.0",           # OOB read/write + decompression-bomb bypass
+    "aiohttp>=3.14.3",
+    "cryptography>=50.0.0",     # the vulnerable range is >=44.0.0,<50.0.0
     "pyasn1>=0.6.4",
-    "soupsieve>=2.8.4",
+    "soupsieve>=2.8.4",         # selector-parser ReDoS + memory exhaustion
+    "mcp>=1.28.1",              # floor only; main already runs mcp[cli]>=2.0.0
+    "bedrock-agentcore>=1.18.1",  # arg-delimiter injection in install_packages()
 ]
 authors = [
     {name = "Issac Daniel Davis", email = "issdandavis@users.noreply.github.com"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,12 @@ psycopg[binary]>=3.3.4
 
 # Security - pinned to secure versions
 cryptography>=50.0.0
+# Transitive: pillow and soupsieve arrive via the imaging and beautifulsoup4
+# chains, bedrock-agentcore via the example agent. Floored so a fresh resolve
+# cannot pick the vulnerable range back up.
+pillow>=12.3.0            # Dependabot #344-#356: OOB read/write, decompression-bomb
+soupsieve>=2.8.4          # Dependabot #315/#316: selector ReDoS + memory exhaustion
+bedrock-agentcore>=1.18.1 # Dependabot #389/#393: arg-delimiter injection
 urllib3>=2.7.0
 uv>=0.11.17
 pyasn1>=0.6.4


### PR DESCRIPTION
One commit, cherry-picked onto `main` with its conflicts resolved as a **union
at the higher floor**. No lockfiles touched, so this does not collide with the
open Dependabot PRs (#2745, #2742).

## What `main` is missing

All 24 open pip alerts resolve against `pyproject.toml`. `main` already floors
`pillow`, `pyasn1`, `soupsieve` there and `cryptography>=50.0.0` in
`requirements.txt` — good. Still unfloored:

| package | floor | why |
|---|---|---|
| `aiohttp` | `>=3.14.3` | 6 alerts, high + medium |
| `cryptography` | `>=50.0.0` | floored in `requirements.txt` but **not in the manifest** |
| `mcp` | `>=1.28.1` | 1 high |
| `bedrock-agentcore` | `>=1.18.1` | arg-delimiter injection in `install_packages()` |

Plus `pillow`, `soupsieve`, `bedrock-agentcore` in `requirements.txt`, which
only had `cryptography`.

## The point that is easy to miss

**A requirements file does not constrain what `pip install scbe-aethermoore`
resolves.** Only the manifest does. `requirements.txt` floored most of these
already, which is exactly why the repo looked patched while the alerts stayed
open — Dependabot was right and the remediation was in the wrong file.

## Conflict resolution

`main` and this branch both edited the same blocks. Resolved as a union, taking
whichever floor is higher:

- `mcp` — `main` runs `mcp[cli]>=2.0.0` in `requirements.txt`; the manifest gets
  `>=1.28.1` as a **floor only**, which permits 2.x. Not an attempt to pin down.
- everything else — identical or additive.

Floors, not pins, throughout: `>=` lets a consumer take anything newer instead
of fighting their solver.

## Verification

- every patched version confirmed to **exist on PyPI** before pinning — a floor
  pointing at a nonexistent release breaks installs for everyone
- `pyproject.toml` parses, 10 dependencies
- both requirements files audited **programmatically** against every floor, not
  by eye: `CLEAN`

Nothing here weakens a setting; every change moves a floor **up**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMQwJ2MfUkcxxhffWUmJSk
