### PR TITLE
security(n8n): fail-closed keys + CORS allowlist + gate /v1/chat — includes #2702's tests

### DIFF
--- a/tests/test_scbe_n8n_bridge_security.py
+++ b/tests/test_scbe_n8n_bridge_security.py
@@ -100,6 +100,64 @@ async def test_llm_dispatch_ignores_user_hook_override(monkeypatch) -> None:
     assert "zapier_hook_url" not in req.model_dump()
 
 
+@pytest.mark.asyncio
+async def test_arena_chat_requires_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
+    req = bridge.ArenaChatRequest.model_validate(
+        {
+            "tentacle": "openai",
+            "message": "hello",
+            "context": [],
+        }
+    )
+
+    with pytest.raises(bridge.HTTPException) as exc:
+        await bridge.arena_chat(req)
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_execute_code_requires_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
+    req = bridge.CodeExecRequest.model_validate(
+        {
+            "code": "print('ok')",
+            "language": "python",
+            "timeout": 1,
+        }
+    )
+
+    with pytest.raises(bridge.HTTPException) as exc:
+        await bridge.execute_code(req)
+
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_execute_code_allows_valid_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
+
+    class _Proc:
+        stdout = "ok\n"
+        stderr = ""
+        returncode = 0
+
+    monkeypatch.setattr(bridge.subprocess, "run", lambda *args, **kwargs: _Proc())
+
+    req = bridge.CodeExecRequest.model_validate(
+        {
+            "code": "print('ok')",
+            "language": "python",
+            "timeout": 1,
+        }
+    )
+    result = await bridge.execute_code(req, x_api_key="test-key")
+
+    assert result["exit_code"] == 0
+    assert result["stdout"] == "ok\n"
+
+
 def test_dispatch_single_provider_hides_exception_text(monkeypatch) -> None:
     monkeypatch.setattr(
         bridge,
@@ -120,8 +178,14 @@ async def test_execute_code_hides_kernel_runner_exception_text(monkeypatch) -> N
         raise RuntimeError("secret kernel-runner details")
 
     monkeypatch.setattr(bridge.urllib_request, "urlopen", fake_urlopen)
+    # /v1/execute now requires a key -- that IS the security fix. This test is
+    # about leak-hiding, not auth, so it authenticates and keeps asserting the
+    # thing it was written to assert.
+    monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
 
-    result = await bridge.execute_code(bridge.CodeExecRequest(code="print('hi')"))
+    result = await bridge.execute_code(
+        bridge.CodeExecRequest(code="print('hi')"), x_api_key="test-key"
+    )
 
     assert result["stderr"] == "kernel-runner request failed"
     assert "secret kernel-runner details" not in json.dumps(result)

--- a/workflows/n8n/scbe_n8n_bridge.py
+++ b/workflows/n8n/scbe_n8n_bridge.py
@@ -857,8 +857,15 @@ def _arena_chat_anthropic_sdk(messages: List[Dict], api_key: str, model: str) ->
 
 
 @app.post("/v1/chat")
-async def arena_chat(req: ArenaChatRequest):
-    """AetherCode Arena chat — routes to the right AI provider via SDK (no Cloudflare blocks)."""
+async def arena_chat(req: ArenaChatRequest, x_api_key: Optional[str] = Header(None)):
+    """AetherCode Arena chat — routes to the right AI provider via SDK (no Cloudflare blocks).
+
+    AUTH: this route spends money on somebody else's API keys, so it is gated the
+    same way /v1/execute is. The earlier hardening pass covered execute and missed
+    this one entirely -- caught by the tests from PR #2702, which is why both fixes
+    are needed rather than either alone.
+    """
+    _require_key_strict(x_api_key)
     t0 = time.time()
     seat = req.tentacle.lower().strip()
     cfg = _ARENA_PROVIDERS.get(seat)

--- a/workflows/n8n/scbe_n8n_bridge.py
+++ b/workflows/n8n/scbe_n8n_bridge.py
@@ -112,11 +112,15 @@ app = FastAPI(
 # CORS — allow the mobile app (Capacitor webview) and local dev
 from starlette.middleware.cors import CORSMiddleware
 
+# allow_origins=["*"] was the live drive-by: with a wildcard the browser preflight succeeds, so
+# ANY page you visited could POST to this bridge on your own machine and reach /v1/execute.
+# Machine-to-machine callers (n8n, the peer PC over Tailscale) send no Origin header and are
+# unaffected by tightening this, so the two-PC path keeps working with the list empty.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=[o.strip() for o in os.environ.get("SCBE_ALLOWED_ORIGINS", "").split(",") if o.strip()],
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type", "X-API-Key"],
 )
 
 # Shared instances
@@ -130,7 +134,15 @@ for plat in Platform:
     _buffer.register_publisher(PlatformPublisher(plat))
 
 # API key validation
-_API_KEYS = set(k.strip() for k in os.environ.get("SCBE_API_KEYS", "scbe-dev-key,test-key").split(",") if k.strip())
+# FAIL CLOSED. This previously defaulted to "scbe-dev-key,test-key" -- two literals sitting in
+# a PUBLIC repo, which means the default credentials were the published credentials. Unset now
+# yields an empty set, and routes that matter refuse to serve rather than accepting a known key.
+_API_KEYS = set(k.strip() for k in os.environ.get("SCBE_API_KEYS", "").split(",") if k.strip())
+
+# Browser origins permitted to call this bridge. Empty by default: machine-to-machine callers
+# (n8n, the peer PC over Tailscale) do not send Origin and are unaffected, while a web page you
+# happen to visit can no longer POST here. Set SCBE_ALLOWED_ORIGINS only if a browser UI needs it.
+_ALLOWED_ORIGINS = [o.strip() for o in os.environ.get("SCBE_ALLOWED_ORIGINS", "").split(",") if o.strip()]
 _BROWSER_SERVICE_URL = os.environ.get(
     "SCBE_BROWSER_SERVICE_URL",
     "http://127.0.0.1:8011",
@@ -236,6 +248,20 @@ def _check_key(api_key: Optional[str] = None):
     if api_key and api_key in _API_KEYS:
         return
     raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
+def _require_key_strict(api_key: Optional[str]) -> None:
+    """For routes that execute code. No dev-mode bypass exists here on purpose.
+
+    With no keys configured this returns 503 rather than running anything, so a fresh checkout
+    is inert instead of open. Configure SCBE_API_KEYS on both machines to enable it.
+    """
+    if not _API_KEYS:
+        raise HTTPException(
+            status_code=503,
+            detail="Code execution disabled: set SCBE_API_KEYS to a secret value to enable.",
+        )
+    _check_key(api_key)
 
 
 # ---------------------------------------------------------------------------
@@ -893,14 +919,19 @@ _KERNEL_RUNNER_URL = os.getenv("KERNEL_RUNNER_URL", "http://127.0.0.1:4242")
 
 
 @app.post("/v1/execute")
-async def execute_code(req: CodeExecRequest):
+async def execute_code(req: CodeExecRequest, x_api_key: Optional[str] = Header(None)):
     """Delegate code execution to the Docker-sandboxed kernel-runner service.
+
+    AUTH: this route had no key check at all -- not a weak one, none. The _check_key call lived
+    on /v1/govern/check while the route that actually runs code was open. It is strict now:
+    no key configured means 503, wrong key means 401.
 
     Instead of running user-supplied code in a local subprocess (command-injection
     risk), we POST to the kernel-runner at ``_KERNEL_RUNNER_URL/api/run`` which
     executes inside a constrained Docker container with no network, capped CPU/
     memory, and a governance preflight gate.
     """
+    _require_key_strict(x_api_key)
     if req.language not in ("python", "javascript"):
         raise HTTPException(400, detail=f"Unsupported language: {req.language}")
     timeout = max(1, min(req.timeout, 30))
@@ -1143,7 +1174,7 @@ async def govern_check(req: GoverCheckRequest, x_api_key: Optional[str] = Header
     component distances so callers can log full governance provenance.
     No API key required in dev mode (SCBE_API_KEYS not set); required in prod.
     """
-    if _API_KEYS - {"scbe-dev-key", "test-key"}:
+    if _API_KEYS:   # dev mode is now "no keys configured", not "the published keys"
         _check_key(x_api_key)
     if not _GOV_CORE_AVAILABLE:
         raise HTTPException(status_code=503, detail="scbe_governance_core not importable")
@@ -1166,7 +1197,7 @@ async def govern_check(req: GoverCheckRequest, x_api_key: Optional[str] = Header
 @app.post("/v1/govern/batch")
 async def govern_batch(req: GoverBatchRequest, x_api_key: Optional[str] = Header(None)):
     """Score a list of commands in one call. Returns list in same order."""
-    if _API_KEYS - {"scbe-dev-key", "test-key"}:
+    if _API_KEYS:   # dev mode is now "no keys configured", not "the published keys"
         _check_key(x_api_key)
     if not _GOV_CORE_AVAILABLE:
         raise HTTPException(status_code=503, detail="scbe_governance_core not importable")


### PR DESCRIPTION
Supersedes #2702 by **including it**. The two are not duplicates — measured by
running #2702's own test file against three trees:

| test | `main` | hardening alone | this branch |
|---|---|---|---|
| `arena_chat_requires_api_key` | FAIL | FAIL | **PASS** |
| `execute_code_requires_api_key` | FAIL | PASS | **PASS** |
| `execute_code_allows_valid_api_key` | FAIL | FAIL | FAIL (stale, see below) |
| `execute_code_hides_kernel_runner_exception_text` | PASS | FAIL | **PASS** |

**#2702's tests document the vulnerability; they do not close it.** Two of its
three failures still fail on `main` today. **And #2702 caught a real gap in the
hardening** — `arena_chat` had no bridge-key check at all, so `/v1/chat` would
spend somebody else's API credits unauthenticated. That hole would have shipped.
Neither was sufficient alone.

## What `main` ships right now

```python
line 117:  allow_origins=["*"],
line 133:  _API_KEYS = set(... os.environ.get("SCBE_API_KEYS", "scbe-dev-key,test-key") ...)
line 1146: if _API_KEYS - {"scbe-dev-key", "test-key"}:
```

- **The default API keys are two literals in a public repo.** Requiring a key
  does nothing when the key is published — which is why #2702 alone is not a fix.
- **`allow_origins=["*"]`** means any page you visit can POST to this bridge on
  your own machine and reach `/v1/execute`.
- The dev-mode branch treats "only the default keys" as "no auth configured".

## This branch

- `_API_KEYS` **fails closed** — unset yields an empty set, and routes that
  execute code return **503** rather than accepting a published credential.
- CORS wildcard replaced by an env-configured allowlist, **empty by default**.
  Machine-to-machine callers (n8n, the peer over Tailscale) send no `Origin` and
  are unaffected, so the two-PC path keeps working.
- `/v1/execute` **and** `/v1/chat` both behind `_require_key_strict`.
- #2702's test file, carried over intact.

## The one failing test, deliberately left failing

`test_execute_code_allows_valid_api_key` monkeypatches `bridge.subprocess.run`,
but `execute_code` delegates to the Docker kernel-runner and the module does not
import `subprocess`. It is a stale test written against an implementation that
no longer exists, and **it fails identically on unmodified `main`**.

Left failing rather than rewritten to pass. Rewriting a test to match the code
is how a real defect gets certified.

## The one test that was edited, and why

`test_execute_code_hides_kernel_runner_exception_text` now authenticates. It
asserts leak-hiding and still asserts exactly that — requiring a key *is* the
fix, so a test calling the route unauthenticated had to change. What it verifies
is untouched.

**19/20 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMQwJ2MfUkcxxhffWUmJSk
