### PR TITLE
security(npm): lift ip-address override off the vulnerable pin (10.2.2 → 10.4.0)

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -962,9 +962,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.2.tgz",
-      "integrity": "sha512-aNJVEVdXTr/g5+N2VCLo+CTrFLo/Y+9rx9RC5BpxPtf7NEknmzY+UQvMO8Fjni5KFmDaHJieL8HCMJKjJXsTgg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,6 +93,6 @@
     "brace-expansion": "5.0.9",
     "fast-uri": "3.1.5",
     "hono": "4.12.34",
-    "ip-address": "10.2.2"
+    "ip-address": "10.4.0"
   }
 }


### PR DESCRIPTION
## The override was pinning it *inside* the vulnerable range

The override added to close this advisory pinned `ip-address` to **10.2.2**. The vulnerable range is **`<= 10.3.0`**. So the pin landed inside the range and the alert never cleared.

**This was not a stale alert awaiting rescan — it was live.** I checked the registry before assuming:

```
main has:          10.2.2
vulnerable range:  <= 10.3.0
published latest:  10.4.0     <- the fix exists
```

## Change

| file | field | from | to |
|---|---|---|---|
| `packages/cli/package.json` | `overrides."ip-address"` | `10.2.2` | **`10.4.0`** |
| `packages/cli/package-lock.json` | `node_modules/ip-address` | `10.2.2` | **`10.4.0`** |

The only consumer is `express-rate-limit@8.5.2`, which requests `^10.2.0`. 10.4.0 is the same major and satisfies that range, so there is no compatibility break.

## Verification

```
npm install --package-lock-only --ignore-scripts
  -> found 0 vulnerabilities
```

Scope is **4 changed lines across 2 files** — the override, the locked version, and its integrity hash. `git diff -U0` shows exactly one `"version"` pair changed; no other package moved.

## Remaining alerts after this

24, all against the root `pyproject.toml`, and those **are** genuinely stale — every floor on `main` already satisfies its advisory (`pillow>=12.3.0`, `aiohttp>=3.14.3`, `cryptography>=50.0.0`, `pyasn1>=0.6.4`, `soupsieve>=2.8.4`, `mcp>=1.28.1`, `bedrock-agentcore>=1.18.1`). They clear on rescan, not by another edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMQwJ2MfUkcxxhffWUmJSk