### PR TITLE
fix(tests): unblock CI black, and make the n8n auth test actually test auth

### DIFF
--- a/tests/test_scbe_n8n_bridge_security.py
+++ b/tests/test_scbe_n8n_bridge_security.py
@@ -138,12 +138,23 @@ async def test_execute_code_requires_api_key(monkeypatch) -> None:
 async def test_execute_code_allows_valid_api_key(monkeypatch) -> None:
     monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
 
-    class _Proc:
-        stdout = "ok\n"
-        stderr = ""
-        returncode = 0
+    # execute_code does NOT shell out. Its docstring is explicit: "Instead of running
+    # user-supplied code in a local subprocess (command-injection risk), we POST to the
+    # kernel-runner". The module never imports subprocess, so the old
+    # `monkeypatch.setattr(bridge.subprocess, "run", ...)` raised AttributeError and this
+    # test could never assert the thing it was written to assert -- the positive half of
+    # the auth fix was unverified. Patch the call the code actually makes.
+    class _Resp:
+        def read(self):
+            return json.dumps({"ok": True, "execute": {"stdout": "ok\n", "stderr": "", "exit_code": 0}}).encode("utf-8")
 
-    monkeypatch.setattr(bridge.subprocess, "run", lambda *args, **kwargs: _Proc())
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+    monkeypatch.setattr(bridge.urllib_request, "urlopen", lambda *args, **kwargs: _Resp())
 
     req = bridge.CodeExecRequest.model_validate(
         {
@@ -156,6 +167,9 @@ async def test_execute_code_allows_valid_api_key(monkeypatch) -> None:
 
     assert result["exit_code"] == 0
     assert result["stdout"] == "ok\n"
+    # A valid key must reach the SANDBOXED path, not merely avoid the 401. Without this
+    # the test would still pass if execute_code silently fell back to local execution.
+    assert result["sandboxed"] is True
 
 
 def test_dispatch_single_provider_hides_exception_text(monkeypatch) -> None:
@@ -183,9 +197,7 @@ async def test_execute_code_hides_kernel_runner_exception_text(monkeypatch) -> N
     # thing it was written to assert.
     monkeypatch.setattr(bridge, "_API_KEYS", {"test-key"})
 
-    result = await bridge.execute_code(
-        bridge.CodeExecRequest(code="print('hi')"), x_api_key="test-key"
-    )
+    result = await bridge.execute_code(bridge.CodeExecRequest(code="print('hi')"), x_api_key="test-key")
 
     assert result["stderr"] == "kernel-runner request failed"
     assert "secret kernel-runner details" not in json.dumps(result)


### PR DESCRIPTION
Two separate defects in the same file, both mine from the n8n security work. Found via the failing **Lint and Format Check** on #2755.

## 1. Black fails on `main`, so every PR branched off it fails

```
would reformat tests/test_scbe_n8n_bridge_security.py
Oh no! 💥 💔 💥
1 file would be reformatted, 2510 files would be left unchanged.
```

#2755 failed lint on **this**, not on its own contents. It's a hand-wrapped call that fits inside 120 chars. Collapsed.

## 2. `test_execute_code_allows_valid_api_key` could never pass

Verified **pre-existing** by running it against unmodified `origin/main` before changing anything:

```
AttributeError: module 'workflows.n8n.scbe_n8n_bridge' has no attribute 'subprocess'
```

`execute_code` does not shell out — its own docstring says so:

> Instead of running user-supplied code in a local subprocess (command-injection risk), we POST to the kernel-runner

The module never imports `subprocess`, so `monkeypatch.setattr(bridge.subprocess, "run", ...)` raised before reaching a single assertion.

**The consequence:** the *negative* half of the auth fix (401 without a key) was covered. The *positive* half — that a valid key actually works — was not. It looked green because the file had 19 other passing tests.

Now patches `bridge.urllib_request.urlopen`, the call the code really makes, with a context-manager response in the kernel-runner's `{"execute": {...}}` shape — matching how the sibling leak-hiding tests already mock it.

Also added:

```python
assert result["sandboxed"] is True
```

Without it the test would still pass if `execute_code` ever silently fell back to local execution — which is exactly the command-injection risk the sandbox exists to remove.

## Verification

```
pytest tests/test_scbe_n8n_bridge_security.py     20 passed
black --check -t py311 -l 120 src/ tests/ scripts/ agents/
                                                  2511 files would be left unchanged
flake8 --max-line-length 120                      clean
```

## Noted for later (not fixed here)

`python/` is in **none** of the three lint scopes — not black (`src/ tests/ scripts/ agents/`), not ruff (the `ruff.toml` `include` list), not flake8 (`src/ tests/ hydra/ scripts/ agents/`). So `python/scbe/` — including `correctness_gate.py` and `atomic_tokenization.py` — is entirely unlinted by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMQwJ2MfUkcxxhffWUmJSk