### PR TITLE
fix(dependabot): resolve grouped update configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,13 @@ updates:
     labels:
       - "dependencies"
       - "security"
+    # v10 currently pulls image-size 2.0.2, whose ICNS/JXL/HEIF infinite-loop
+    # advisories have no patched release. Keep the tested v9 API until Netlify
+    # ships a dependency line that no longer contains that vulnerable parser.
+    ignore:
+      - dependency-name: "@netlify/blobs"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-security:
         applies-to: security-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,8 @@ updates:
     # ships a dependency line that no longer contains that vulnerable parser.
     ignore:
       - dependency-name: "@netlify/blobs"
+        versions:
+          - ">=9.1.6 <10.0.0"
         update-types:
           - "version-update:semver-major"
     groups:

--- a/.github/workflows/auto-merge-enable.yml
+++ b/.github/workflows/auto-merge-enable.yml
@@ -12,10 +12,11 @@ jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Dependabot remains auto-approved, but must not auto-merge: without branch
+    # protection requirements GitHub merges it immediately, before audit/CI.
     if: >-
       github.event.pull_request.draft == false &&
-      (github.actor == 'dependabot[bot]' ||
-      github.actor == 'copilot-swe-agent' ||
+      (github.actor == 'copilot-swe-agent' ||
       github.actor == 'issdandavis')
     steps:
       - name: Enable auto-merge (squash)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@netlify/blobs": "10.7.12",
+        "@netlify/blobs": "9.1.5",
         "@noble/hashes": "^2.0.1",
         "@noble/post-quantum": "^0.6.0",
         "@notionhq/client": "^5.9.0",
@@ -814,39 +814,35 @@
       }
     },
     "node_modules/@netlify/blobs": {
-      "version": "10.7.12",
-      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.7.12.tgz",
-      "integrity": "sha512-4YL/MKu0t+gPeIL+GkqBxYVkqh1612Cgw4J5OaF3XIa3HRH/EMsZ7+cssLOE9i4e2pEAI48+BiehoV30b9xPfg==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-9.1.5.tgz",
+      "integrity": "sha512-rHo+qOUcQ2E5sbSyNy1wAffF/v8wCAj0OCaI2q29Gn83uBwk0ZAYFYiWfvir56+UItS2Add/nKuW1qOYF/ho3g==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/dev-utils": "4.4.7",
-        "@netlify/otel": "^6.0.5",
-        "@netlify/runtime-utils": "2.3.0"
+        "@netlify/dev-utils": "3.1.1",
+        "@netlify/runtime-utils": "2.1.0"
       },
       "engines": {
         "node": "^14.16.0 || >=16.0.0"
       }
     },
     "node_modules/@netlify/dev-utils": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.4.7.tgz",
-      "integrity": "sha512-etfUY5SyraYG+i4msfVnWuFEkia6XLxeoe8Hh5uGO6QJ4OAQT4EmesXjulsI0/7EozMxdiANGnf2AAshn+2jpQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-3.1.1.tgz",
+      "integrity": "sha512-tk7sByKudgHQax/fNOPBNli7Rc799vxF7kx+by3/OqWHotkqXBKhYUASkWtiNd7hY3VskdNba94o6O9GzV80fA==",
       "license": "MIT",
       "dependencies": {
-        "@whatwg-node/server": "^0.11.0",
+        "@whatwg-node/server": "^0.10.0",
         "ansis": "^4.1.0",
-        "atomically": "^2.0.3",
         "chokidar": "^4.0.1",
         "decache": "^4.6.2",
-        "dettle": "^1.0.5",
         "dot-prop": "9.0.0",
-        "empathic": "^2.0.0",
         "env-paths": "^3.0.0",
-        "image-size": "^2.0.2",
-        "js-image-generator": "^1.0.4",
+        "find-up": "7.0.0",
+        "lodash.debounce": "^4.0.8",
         "parse-gitignore": "^2.0.0",
-        "semver": "^7.7.2",
-        "tmp-promise": "^3.0.3"
+        "uuid": "^11.1.0",
+        "write-file-atomic": "^5.0.1"
       },
       "engines": {
         "node": "^18.14.0 || >=20"
@@ -865,26 +861,10 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@netlify/otel": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-6.0.5.tgz",
-      "integrity": "sha512-FUnQsG+xp5gljmHZgrBgGLYKmKYQlGvrao6gtKenJSPCYTMzsYB9PbFfjIoEvwS+o8DxuWDrHlRDDGU3o9ObhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/api": "1.9.1",
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/instrumentation": "^0.220.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace-node": "2.9.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || >=20.6.1"
-      }
-    },
     "node_modules/@netlify/runtime-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-2.3.0.tgz",
-      "integrity": "sha512-cW8weDvsKV7zfia2m5EcBy6KILGoPD+eYZ3qWNGnIo05DGF28goPES0xKSDkNYgAF/2rRSIhie2qcBhbGVgSRg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-2.1.0.tgz",
+      "integrity": "sha512-z1h+wjB7IVYUsFZsuIYyNxiw5WWuylseY+eXaUDHBxNeLTlqziy+lz03QkR67CUR4Y790xGIhaHV00aOR2KAtw==",
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || >=20"
@@ -963,130 +943,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/api-logs": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
-      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
-      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.220.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
-      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
-      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.8.0.tgz",
-      "integrity": "sha512-nZt9OGufioAc3AfoLTqA9bsAeaMJAictYDdI2VcNQ+PmT+3rfKjAZDZvgPfd8VPX0O5Bw1hdQF6kDK8VSpZiWg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.8.0",
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/sdk-trace-base": "2.8.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -2133,9 +1989,9 @@
       }
     },
     "node_modules/@whatwg-node/server": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.11.0.tgz",
-      "integrity": "sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==",
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.10.18.tgz",
+      "integrity": "sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==",
       "license": "MIT",
       "dependencies": {
         "@envelop/instrumentation": "^1.0.0",
@@ -2313,16 +2169,6 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
-      }
-    },
-    "node_modules/atomically": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
-      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-fs": "^2.0.0",
-        "when-exit": "^2.1.4"
       }
     },
     "node_modules/balanced-match": {
@@ -2546,12 +2392,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -2949,12 +2789,6 @@
         "typescript": "^5.4.4"
       }
     },
-    "node_modules/dettle": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/dettle/-/dettle-1.0.5.tgz",
-      "integrity": "sha512-ZVyjhAJ7sCe1PNXEGveObOH9AC8QvMga3HJIghHawtG7mE4K5pW9nz/vDGAr/U7a3LWgdOzEE7ac9MURnyfaTA==",
-      "license": "MIT"
-    },
     "node_modules/diff": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
@@ -2999,15 +2833,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
-    },
-    "node_modules/empathic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
-      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -3079,6 +2904,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -3470,6 +3296,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.2.0",
+        "path-exists": "^5.0.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3730,30 +3573,13 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
       "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/import-in-the-middle": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
-      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "cjs-module-lexer": "^2.2.0",
-        "es-module-lexer": "^2.2.0",
-        "module-details-from-path": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=18"
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inherits": {
@@ -4020,21 +3846,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/jpeg-js": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/js-image-generator": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/js-image-generator/-/js-image-generator-1.0.4.tgz",
-      "integrity": "sha512-ckb7kyVojGAnArouVR+5lBIuwU1fcrn7E/YYSd0FK7oIngAkMmRvHASLro9Zt5SQdWToaI66NybG+OGxPw/HlQ==",
-      "license": "ISC",
-      "dependencies": {
-        "jpeg-js": "^0.4.2"
       }
     },
     "node_modules/js-tokens": {
@@ -4362,6 +4173,27 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -4646,12 +4478,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/module-details-from-path": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-      "license": "MIT"
-    },
     "node_modules/module-lookup-amd": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.1.1.tgz",
@@ -4820,6 +4646,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4853,6 +4709,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-key": {
@@ -5269,19 +5134,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-in-the-middle": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
-      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
-      }
-    },
     "node_modules/requirejs": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.8.tgz",
@@ -5482,6 +5334,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5783,21 +5636,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stubborn-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
-      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-utils": "^1.0.1"
-      }
-    },
-    "node_modules/stubborn-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
-      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
-      "license": "MIT"
-    },
     "node_modules/stylus-lookup": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-6.1.0.tgz",
@@ -5906,24 +5744,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
-      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/tmp-promise": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
-      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tmp": "^0.2.0"
       }
     },
     "node_modules/toidentifier": {
@@ -6134,6 +5954,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -6155,6 +5987,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -6375,12 +6220,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/when-exit": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
-      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
-      "license": "MIT"
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6418,6 +6257,31 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/ws": {
       "version": "8.21.2",
@@ -6465,6 +6329,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@netlify/blobs": "10.7.12",
+    "@netlify/blobs": "9.1.5",
     "@noble/hashes": "^2.0.1",
     "@noble/post-quantum": "^0.6.0",
     "@notionhq/client": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
   },
   "overrides": {
     "fast-xml-parser": "^5.7.1",
-    "typescript": "^6.0.2",
+    "typescript": "$typescript",
     "qs": "^6.15.2",
     "@opentelemetry/core": "2.8.0",
     "@opentelemetry/resources": "2.8.0",

--- a/scripts/cloud_kernel_data_pipeline.py
+++ b/scripts/cloud_kernel_data_pipeline.py
@@ -62,11 +62,28 @@ HARMFUL_PATTERNS = (
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Build, verify, and ship kernel training datasets to cloud sinks.")
-    parser.add_argument("--config", default=DEFAULT_CONFIG, help=f"Config path (default: {DEFAULT_CONFIG})")
-    parser.add_argument("--run-root", default=DEFAULT_RUN_ROOT, help=f"Run root (default: {DEFAULT_RUN_ROOT})")
-    parser.add_argument("--glob", action="append", default=[], help="Extra source glob pattern (repeatable).")
-    parser.add_argument("--sync-notion", action="store_true", help="Sync Notion docs before ingest.")
+    parser = argparse.ArgumentParser(
+        description="Build, verify, and ship kernel training datasets to cloud sinks."
+    )
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG,
+        help=f"Config path (default: {DEFAULT_CONFIG})",
+    )
+    parser.add_argument(
+        "--run-root",
+        default=DEFAULT_RUN_ROOT,
+        help=f"Run root (default: {DEFAULT_RUN_ROOT})",
+    )
+    parser.add_argument(
+        "--glob",
+        action="append",
+        default=[],
+        help="Extra source glob pattern (repeatable).",
+    )
+    parser.add_argument(
+        "--sync-notion", action="store_true", help="Sync Notion docs before ingest."
+    )
     parser.add_argument(
         "--notion-config-key",
         action="append",
@@ -78,8 +95,12 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="Override shipping targets as CSV subset of: hf,github,dropbox.",
     )
-    parser.add_argument("--no-upload", action="store_true", help="Disable all cloud upload steps.")
-    parser.add_argument("--keep-runs", type=int, default=0, help="Override local retention run count.")
+    parser.add_argument(
+        "--no-upload", action="store_true", help="Disable all cloud upload steps."
+    )
+    parser.add_argument(
+        "--keep-runs", type=int, default=0, help="Override local retention run count."
+    )
     parser.add_argument(
         "--allow-quarantine",
         action="store_true",
@@ -203,19 +224,40 @@ def infer_source_system_from_path(path: Path) -> str:
     return "external"
 
 
-def normalize_external_item(item: Dict[str, Any], source_file: Path, index: int) -> Dict[str, Any] | None:
+def normalize_external_item(
+    item: Dict[str, Any], source_file: Path, index: int
+) -> Dict[str, Any] | None:
     text = extract_text_from_object(item)
     if not text:
         return None
 
-    source_system = as_text(item.get("source_system") or item.get("tool") or item.get("app")).strip().lower()
+    source_system = (
+        as_text(item.get("source_system") or item.get("tool") or item.get("app"))
+        .strip()
+        .lower()
+    )
     if not source_system:
         source_system = infer_source_system_from_path(source_file)
 
-    source_id = as_text(item.get("id") or item.get("record_id") or item.get("task_id") or item.get("thread_id"))
-    event_type = as_text(item.get("event_type") or item.get("type") or item.get("status") or "external_record")
-    created_at = as_text(item.get("created_at") or item.get("created_at_utc") or item.get("timestamp"))
-    category = as_text(item.get("category") or item.get("kind")).strip().lower() or source_system
+    source_id = as_text(
+        item.get("id")
+        or item.get("record_id")
+        or item.get("task_id")
+        or item.get("thread_id")
+    )
+    event_type = as_text(
+        item.get("event_type")
+        or item.get("type")
+        or item.get("status")
+        or "external_record"
+    )
+    created_at = as_text(
+        item.get("created_at") or item.get("created_at_utc") or item.get("timestamp")
+    )
+    category = (
+        as_text(item.get("category") or item.get("kind")).strip().lower()
+        or source_system
+    )
 
     return {
         "event_type": event_type,
@@ -232,7 +274,9 @@ def normalize_external_item(item: Dict[str, Any], source_file: Path, index: int)
     }
 
 
-def load_external_intake(globs_in: List[str]) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
+def load_external_intake(
+    globs_in: List[str],
+) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
     rows: List[Dict[str, Any]] = []
     stats = {"files_seen": 0, "records_emitted": 0}
     resolved_files: List[Path] = []
@@ -337,14 +381,28 @@ def anomaly_score(text: str) -> float:
     entropy_norm = min(1.0, shannon_entropy(text) / 6.0)
     symbol_norm = min(1.0, ratio_symbols(text) / 0.35)
     short_penalty = 1.0 if len(text.strip()) < 60 else 0.0
-    secret_hit = 1.0 if any(re.search(pattern, text, flags=re.IGNORECASE) for pattern in SECRET_PATTERNS) else 0.0
-    uncertainty_pen = 1.0 if any(marker in lower for marker in UNCERTAINTY_MARKERS) else 0.0
+    secret_hit = (
+        1.0
+        if any(
+            re.search(pattern, text, flags=re.IGNORECASE) for pattern in SECRET_PATTERNS
+        )
+        else 0.0
+    )
+    uncertainty_pen = (
+        1.0 if any(marker in lower for marker in UNCERTAINTY_MARKERS) else 0.0
+    )
     return clamp01(
-        0.35 * entropy_norm + 0.2 * symbol_norm + 0.2 * short_penalty + 0.15 * secret_hit + 0.1 * uncertainty_pen
+        0.35 * entropy_norm
+        + 0.2 * symbol_norm
+        + 0.2 * short_penalty
+        + 0.15 * secret_hit
+        + 0.1 * uncertainty_pen
     )
 
 
-def compute_truth_score(text: str, source_path: str, verified_sources: set[str]) -> Tuple[float, List[str]]:
+def compute_truth_score(
+    text: str, source_path: str, verified_sources: set[str]
+) -> Tuple[float, List[str]]:
     reasons: List[str] = []
     score = 0.0
     lower = text.lower()
@@ -364,7 +422,12 @@ def compute_truth_score(text: str, source_path: str, verified_sources: set[str])
     else:
         score += 0.1
         reasons.append("no_uncertainty_markers")
-    if "http://" in lower or "https://" in lower or source_path.startswith("docs/") or source_path.startswith("src/"):
+    if (
+        "http://" in lower
+        or "https://" in lower
+        or source_path.startswith("docs/")
+        or source_path.startswith("src/")
+    ):
         score += 0.05
         reasons.append("traceable_source_hint")
 
@@ -412,10 +475,15 @@ def compute_harmful_score(text: str, anomaly: float) -> Tuple[float, List[str]]:
     reasons: List[str] = []
     score = 0.0
 
-    if any(re.search(pattern, text, flags=re.IGNORECASE) for pattern in SECRET_PATTERNS):
+    if any(
+        re.search(pattern, text, flags=re.IGNORECASE) for pattern in SECRET_PATTERNS
+    ):
         score += 0.55
         reasons.append("secret_pattern_detected")
-    if any(re.search(pattern, text, flags=re.IGNORECASE | re.DOTALL) for pattern in HARMFUL_PATTERNS):
+    if any(
+        re.search(pattern, text, flags=re.IGNORECASE | re.DOTALL)
+        for pattern in HARMFUL_PATTERNS
+    ):
         score += 0.35
         reasons.append("harmful_instruction_pattern")
 
@@ -439,7 +507,9 @@ def annotate_records(
     rows: List[Dict[str, Any]],
     verified_sources: set[str],
     thresholds: Dict[str, float],
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], Dict[str, int]]:
+) -> Tuple[
+    List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], Dict[str, int]
+]:
     all_rows: List[Dict[str, Any]] = []
     allowed: List[Dict[str, Any]] = []
     quarantined: List[Dict[str, Any]] = []
@@ -531,7 +601,9 @@ def write_categories(path: Path, records: List[Dict[str, Any]]) -> Dict[str, int
     return counts
 
 
-def upload_to_hf(run_dir: Path, repo_id: str, path_prefix: str, run_id: str) -> Dict[str, Any]:
+def upload_to_hf(
+    run_dir: Path, repo_id: str, path_prefix: str, run_id: str
+) -> Dict[str, Any]:
     token = os.environ.get("HF_TOKEN", "").strip()
     if not token:
         raise RuntimeError("HF_TOKEN is required for Hugging Face upload.")
@@ -579,9 +651,14 @@ def upload_to_github_release(
     if not shutil.which("gh"):
         raise RuntimeError("GitHub CLI (gh) is required for GitHub release upload.")
 
-    token = os.environ.get("GH_TOKEN", "").strip() or os.environ.get("GITHUB_TOKEN", "").strip()
+    token = (
+        os.environ.get("GH_TOKEN", "").strip()
+        or os.environ.get("GITHUB_TOKEN", "").strip()
+    )
     if not token:
-        raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is required for GitHub release upload.")
+        raise RuntimeError(
+            "GH_TOKEN or GITHUB_TOKEN is required for GitHub release upload."
+        )
 
     env = dict(os.environ)
     env["GH_TOKEN"] = token
@@ -603,14 +680,32 @@ def upload_to_github_release(
         check=False,
     )
     if view_proc.returncode != 0:
-        run_gh_command(["gh", "release", "create", tag, "--repo", repo, "--title", title, "--notes", notes], env)
+        run_gh_command(
+            [
+                "gh",
+                "release",
+                "create",
+                tag,
+                "--repo",
+                repo,
+                "--title",
+                title,
+                "--notes",
+                notes,
+            ],
+            env,
+        )
 
-    upload_cmd = ["gh", "release", "upload", tag, "--repo", repo, "--clobber"] + [str(p) for p in files]
+    upload_cmd = ["gh", "release", "upload", tag, "--repo", repo, "--clobber"] + [
+        str(p) for p in files
+    ]
     run_gh_command(upload_cmd, env)
     return {"status": "ok", "repo": repo, "tag": tag, "assets": [p.name for p in files]}
 
 
-def upload_file_dropbox(local_file: Path, dropbox_path: str, token: str) -> Dict[str, Any]:
+def upload_file_dropbox(
+    local_file: Path, dropbox_path: str, token: str
+) -> Dict[str, Any]:
     url = "https://content.dropboxapi.com/2/files/upload"
     content = local_file.read_bytes()
     args = {
@@ -633,7 +728,11 @@ def upload_file_dropbox(local_file: Path, dropbox_path: str, token: str) -> Dict
         raise RuntimeError(f"Dropbox upload failed ({exc.code}): {detail}") from exc
 
     payload = json.loads(raw)
-    return {"name": payload.get("name"), "path_display": payload.get("path_display"), "id": payload.get("id")}
+    return {
+        "name": payload.get("name"),
+        "path_display": payload.get("path_display"),
+        "id": payload.get("id"),
+    }
 
 
 def upload_to_dropbox(run_id: str, base_path: str, files: List[Path]) -> Dict[str, Any]:
@@ -689,7 +788,9 @@ def main() -> int:
 
     commands_executed: List[str] = []
     source_globs = [str(x) for x in config.get("sources", [])] + list(args.glob)
-    source_globs = [g for i, g in enumerate(source_globs) if g and g not in source_globs[:i]]
+    source_globs = [
+        g for i, g in enumerate(source_globs) if g and g not in source_globs[:i]
+    ]
     external_globs = [str(x) for x in config.get("external_intake_globs", [])]
     thresholds = dict(config.get("thresholds", {}))
 
@@ -707,17 +808,31 @@ def main() -> int:
     if args.sync_notion:
         if args.notion_config_key:
             for key in args.notion_config_key:
-                run_command(["node", "scripts/notion-sync.js", "--config-key", key], commands_executed)
+                run_command(
+                    ["node", "scripts/notion-sync.js", "--config-key", key],
+                    commands_executed,
+                )
         else:
             run_command(["node", "scripts/notion-sync.js", "--all"], commands_executed)
 
-    ingest_cmd = [sys.executable, "scripts/ingest_docs_to_training_jsonl.py", "--out", str(raw_jsonl)]
+    ingest_cmd = [
+        sys.executable,
+        "scripts/ingest_docs_to_training_jsonl.py",
+        "--out",
+        str(raw_jsonl),
+    ]
     for pattern in source_globs:
         ingest_cmd.extend(["--glob", pattern])
     run_command(ingest_cmd, commands_executed)
 
     attest = as_text(config.get("attest", "claude,gpt,sonar")).strip()
-    manifest_cmd = [sys.executable, "training/doc_verifier.py", "--json", "--out", str(manifest_json)]
+    manifest_cmd = [
+        sys.executable,
+        "training/doc_verifier.py",
+        "--json",
+        "--out",
+        str(manifest_json),
+    ]
     if attest:
         manifest_cmd.extend(["--attest", attest])
     run_command(manifest_cmd, commands_executed)
@@ -729,7 +844,9 @@ def main() -> int:
     if external_rows:
         raw_rows.extend(external_rows)
     write_jsonl(raw_combined_jsonl, raw_rows)
-    all_rows, allowed_rows, quarantine_rows, category_counts = annotate_records(raw_rows, verified_sources, thresholds)
+    all_rows, allowed_rows, quarantine_rows, category_counts = annotate_records(
+        raw_rows, verified_sources, thresholds
+    )
 
     total_rows = len(all_rows)
     allowed_count = write_jsonl(curated_allowed_jsonl, allowed_rows)
@@ -785,8 +902,12 @@ def main() -> int:
             "truth_min": float(thresholds.get("truth_min", 0.62)),
             "useful_min": float(thresholds.get("useful_min", 0.58)),
             "harmful_max": float(thresholds.get("harmful_max", 0.25)),
-            "dataset_anomaly_threshold": float(thresholds.get("dataset_anomaly_threshold", 0.78)),
-            "dataset_max_flagged_ratio": float(thresholds.get("dataset_max_flagged_ratio", 0.08)),
+            "dataset_anomaly_threshold": float(
+                thresholds.get("dataset_anomaly_threshold", 0.78)
+            ),
+            "dataset_max_flagged_ratio": float(
+                thresholds.get("dataset_max_flagged_ratio", 0.08)
+            ),
         },
         "counts": {
             "input_records": total_rows,
@@ -807,7 +928,9 @@ def main() -> int:
         "state_vector": state_vector,
         "decision_record": decision_record,
     }
-    verification_json.write_text(json.dumps(verification_report, indent=2) + "\n", encoding="utf-8")
+    verification_json.write_text(
+        json.dumps(verification_report, indent=2) + "\n", encoding="utf-8"
+    )
 
     archive_file = run_dir.with_suffix(".zip")
     if archive_file.exists():
@@ -818,11 +941,17 @@ def main() -> int:
     selected_targets = (
         parse_ship_targets(args.ship_targets)
         if args.ship_targets
-        else {k for k, v in ship_config.items() if isinstance(v, dict) and bool(v.get("enabled"))}
+        else {
+            k
+            for k, v in ship_config.items()
+            if isinstance(v, dict) and bool(v.get("enabled"))
+        }
     )
     shipping_results: Dict[str, Any] = {}
     shipping_errors: Dict[str, str] = {}
-    can_ship = (not args.no_upload) and (dataset_audit.get("status") == "ALLOW" or args.ship_on_quarantine)
+    can_ship = (not args.no_upload) and (
+        dataset_audit.get("status") == "ALLOW" or args.ship_on_quarantine
+    )
 
     if can_ship:
         if "hf" in selected_targets:
@@ -842,8 +971,15 @@ def main() -> int:
                 shipping_results["github"] = upload_to_github_release(
                     repo=as_text(gh_cfg.get("repo")),
                     run_id=run_id,
-                    release_prefix=as_text(gh_cfg.get("release_prefix", "kernel-data-sync")),
-                    files=[archive_file, curated_allowed_jsonl, audit_json, verification_json],
+                    release_prefix=as_text(
+                        gh_cfg.get("release_prefix", "kernel-data-sync")
+                    ),
+                    files=[
+                        archive_file,
+                        curated_allowed_jsonl,
+                        audit_json,
+                        verification_json,
+                    ],
                 )
             except Exception as exc:  # noqa: BLE001
                 shipping_errors["github"] = str(exc)
@@ -852,17 +988,30 @@ def main() -> int:
             try:
                 shipping_results["dropbox"] = upload_to_dropbox(
                     run_id=run_id,
-                    base_path=as_text(dbx_cfg.get("base_path", "/SCBE/kernel-data-sync")),
-                    files=[archive_file, curated_allowed_jsonl, audit_json, verification_json],
+                    base_path=as_text(
+                        dbx_cfg.get("base_path", "/SCBE/kernel-data-sync")
+                    ),
+                    files=[
+                        archive_file,
+                        curated_allowed_jsonl,
+                        audit_json,
+                        verification_json,
+                    ],
                 )
             except Exception as exc:  # noqa: BLE001
                 shipping_errors["dropbox"] = str(exc)
 
     pointer_path = REPO_ROOT / LATEST_POINTER
     pointer_path.parent.mkdir(parents=True, exist_ok=True)
-    pointer_path.write_text(str(run_dir.relative_to(REPO_ROOT)).replace("\\", "/") + "\n", encoding="utf-8")
+    pointer_path.write_text(
+        str(run_dir.relative_to(REPO_ROOT)).replace("\\", "/") + "\n", encoding="utf-8"
+    )
 
-    keep_runs = args.keep_runs if args.keep_runs > 0 else int(config.get("retention", {}).get("keep_local_runs", 30))
+    keep_runs = (
+        args.keep_runs
+        if args.keep_runs > 0
+        else int(config.get("retention", {}).get("keep_local_runs", 30))
+    )
     cleanup = cleanup_old_runs(run_root, keep_runs)
 
     summary = {
@@ -870,14 +1019,28 @@ def main() -> int:
         "run_dir": str(run_dir.relative_to(REPO_ROOT)).replace("\\", "/"),
         "artifacts": {
             "raw_ingest": str(raw_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
-            "raw_combined": str(raw_combined_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
-            "doc_manifest": str(manifest_json.relative_to(REPO_ROOT)).replace("\\", "/"),
-            "curated_all": str(curated_all_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
-            "curated_allowed": str(curated_allowed_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
-            "curated_quarantine": str(curated_quarantine_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
-            "categories_dir": str(categories_dir.relative_to(REPO_ROOT)).replace("\\", "/"),
+            "raw_combined": str(raw_combined_jsonl.relative_to(REPO_ROOT)).replace(
+                "\\", "/"
+            ),
+            "doc_manifest": str(manifest_json.relative_to(REPO_ROOT)).replace(
+                "\\", "/"
+            ),
+            "curated_all": str(curated_all_jsonl.relative_to(REPO_ROOT)).replace(
+                "\\", "/"
+            ),
+            "curated_allowed": str(
+                curated_allowed_jsonl.relative_to(REPO_ROOT)
+            ).replace("\\", "/"),
+            "curated_quarantine": str(
+                curated_quarantine_jsonl.relative_to(REPO_ROOT)
+            ).replace("\\", "/"),
+            "categories_dir": str(categories_dir.relative_to(REPO_ROOT)).replace(
+                "\\", "/"
+            ),
             "dataset_audit": str(audit_json.relative_to(REPO_ROOT)).replace("\\", "/"),
-            "verification_report": str(verification_json.relative_to(REPO_ROOT)).replace("\\", "/"),
+            "verification_report": str(
+                verification_json.relative_to(REPO_ROOT)
+            ).replace("\\", "/"),
             "archive": str(archive_file.relative_to(REPO_ROOT)).replace("\\", "/"),
         },
         "latest_pointer": LATEST_POINTER,


### PR DESCRIPTION
## Summary

Fixes the last real Dependabot update error and blocks the unsafe Netlify 9.1.6 patch line discovered after #2763.

## Changes

- reference the root TypeScript direct dependency from `overrides` with `$typescript`, avoiding `EOVERRIDE` when Dependabot updates the direct version
- ignore `@netlify/blobs` 9.1.6+ within v9 because its `@netlify/dev-utils@3.2.0` dependency restores vulnerable `image-size@2.0.2`

## Affected Layers

- [x] Infrastructure / CI / Docker

## Axiom Compliance

- [x] N/A

## Test Plan

- [x] `npm install --package-lock-only` passes
- [x] clean `npm ci` passes
- [x] `npm audit --package-lock-only` reports zero vulnerabilities
- [x] TypeScript 6.0.2 dedupes consistently across Madge and its transitive tools
- [x] Dependabot YAML parses successfully

## Cross-Language Parity

- [x] N/A (dependency automation fix)