### PR TITLE
fix(ci): repair Dependabot updates and nightly asyncio cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,8 @@ updates:
     # ships a dependency line that no longer contains that vulnerable parser.
     ignore:
       - dependency-name: "@netlify/blobs"
+        versions:
+          - ">=9.1.6 <10.0.0"
         update-types:
           - "version-update:semver-major"
     groups:

--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
   },
   "overrides": {
     "fast-xml-parser": "^5.7.1",
-    "typescript": "^6.0.2",
+    "typescript": "$typescript",
     "qs": "^6.15.2",
     "@opentelemetry/core": "2.8.0",
     "@opentelemetry/resources": "2.8.0",

--- a/python/scbe/ai_browser.py
+++ b/python/scbe/ai_browser.py
@@ -112,7 +112,9 @@ class EphemeralFeed:
         if self._spent:
             raise RuntimeError("ephemeral feed already consumed (and deleted)")
         raw = open(self.path, encoding="utf-8").read()
-        os.remove(self.path)  # ingested -> gone, and spent, BEFORE the parse -- so a malformed-JSON parse
+        os.remove(
+            self.path
+        )  # ingested -> gone, and spent, BEFORE the parse -- so a malformed-JSON parse
         self._spent = True  # error can't leave the file cached or the feed re-consumable (exactly once)
         return json.loads(raw)
 
@@ -124,7 +126,9 @@ class EphemeralFeed:
 class AIBrowser:
     """A bounded, abstraction-first browser the AI steers by moves, not selectors."""
 
-    def __init__(self, headless: bool = True, channel: str = "chrome", cdp: Optional[str] = None):
+    def __init__(
+        self, headless: bool = True, channel: str = "chrome", cdp: Optional[str] = None
+    ):
         self.headless = headless
         self.channel = channel
         self.cdp = cdp  # e.g. "http://127.0.0.1:9222" to attach instead of launching
@@ -135,11 +139,27 @@ class AIBrowser:
         from playwright.sync_api import sync_playwright
 
         self._pw = sync_playwright().start()
-        if self.cdp:
-            self._browser = self._pw.chromium.connect_over_cdp(self.cdp)
-        else:
-            # launch our OWN isolated Chrome (fresh profile) -- never touches the user's real browser
-            self._browser = self._pw.chromium.launch(headless=self.headless, channel=self.channel)
+        try:
+            if self.cdp:
+                self._browser = self._pw.chromium.connect_over_cdp(self.cdp)
+            else:
+                # launch our OWN isolated Chrome (fresh profile) -- never touches the user's real browser
+                self._browser = self._pw.chromium.launch(
+                    headless=self.headless, channel=self.channel
+                )
+        except BaseException:
+            # sync_playwright() owns an asyncio loop in the calling thread.  A
+            # failed browser launch must stop it here because __exit__ is never
+            # entered when __enter__ raises.  Otherwise every later asyncio
+            # caller in this process sees a phantom running loop.
+            playwright = self._pw
+            self._pw = None
+            self._browser = None
+            try:
+                playwright.stop()
+            except Exception:
+                pass
+            raise
         return self
 
     def __exit__(self, *exc) -> None:
@@ -175,7 +195,11 @@ class AIBrowser:
         ]
         for e in feed.get("elements", []):
             if e.get("editable"):
-                mv.append(Move("type", ref=e["ref"], label=e.get("name") or e["tag"], value=""))
+                mv.append(
+                    Move(
+                        "type", ref=e["ref"], label=e.get("name") or e["tag"], value=""
+                    )
+                )
             else:
                 mv.append(Move("click", ref=e["ref"], label=e.get("name") or e["tag"]))
         return mv
@@ -196,7 +220,8 @@ class AIBrowser:
             # scroll a target into view -- the SC2 camera move. By ref (an element) or "x,y" doc coords.
             if move.ref:
                 page.eval_on_selector(
-                    "[data-aibref='%s']" % move.ref, "e => e.scrollIntoView({block: 'center', inline: 'center'})"
+                    "[data-aibref='%s']" % move.ref,
+                    "e => e.scrollIntoView({block: 'center', inline: 'center'})",
                 )
             elif move.value:
                 xy = [int(v) for v in str(move.value).split(",")]

--- a/tests/test_ai_browser.py
+++ b/tests/test_ai_browser.py
@@ -7,6 +7,7 @@ buffer. Skips cleanly if Playwright or a launchable Chrome is absent (so CI with
 
 from __future__ import annotations
 
+import asyncio
 import os
 
 import pytest
@@ -25,8 +26,53 @@ def test_ephemeral_consume_is_exactly_once_even_on_malformed_json(tmp_path):
     with pytest.raises(Exception):  # noqa: B017 -- malformed -> json parse error
         ef.consume()
     assert not p.exists()  # deleted despite the parse failure (no over-cache)
-    with pytest.raises(RuntimeError):  # spent -> 'already consumed', not a second parse attempt
+    with pytest.raises(
+        RuntimeError
+    ):  # spent -> 'already consumed', not a second parse attempt
         ef.consume()
+
+
+def test_failed_launch_stops_playwright(monkeypatch):
+    """A failed __enter__ must not leave Playwright's asyncio loop running."""
+    import playwright.sync_api
+
+    stopped = []
+
+    class FailingChromium:
+        def launch(self, **_kwargs):
+            raise RuntimeError("browser unavailable")
+
+    class FakePlaywright:
+        chromium = FailingChromium()
+
+        def stop(self):
+            stopped.append(True)
+
+    class FakeManager:
+        def start(self):
+            return FakePlaywright()
+
+    monkeypatch.setattr(playwright.sync_api, "sync_playwright", FakeManager)
+
+    browser = AIBrowser(headless=True)
+    with pytest.raises(RuntimeError, match="browser unavailable"):
+        browser.__enter__()
+
+    assert stopped == [True]
+    assert browser._pw is None
+    assert browser._browser is None
+
+
+def test_real_failed_launch_does_not_poison_asyncio():
+    """Exercise Playwright itself: a launch error must leave asyncio usable."""
+    browser = AIBrowser(headless=True, channel="scbe-missing-browser")
+    with pytest.raises(
+        Exception
+    ):  # noqa: B017 -- Playwright owns the concrete error type
+        browser.__enter__()
+
+    assert browser._pw is None
+    asyncio.run(asyncio.sleep(0))
 
 
 FIXTURE = (
@@ -56,7 +102,9 @@ def test_feed_is_structured_and_bounded(browser):
     feed = browser.read(page)
     assert feed["url"].startswith("data:text/html")
     refs = {e["ref"] for e in feed["elements"]}
-    assert len(refs) == len(feed["elements"]) == 3  # button, input, link -- a small bounded surface
+    assert (
+        len(refs) == len(feed["elements"]) == 3
+    )  # button, input, link -- a small bounded surface
     by_tag = {e["tag"] for e in feed["elements"]}
     assert {"button", "input", "a"} <= by_tag
     assert next(e for e in feed["elements"] if e["tag"] == "input")["editable"] is True
@@ -67,7 +115,9 @@ def test_control_surface_is_legal_moves_only(browser):
     moves = browser.moves(browser.read(page))
     kinds = [m.kind for m in moves]
     assert "read" in kinds and "scroll" in kinds and "back" in kinds
-    assert any(m.kind == "click" for m in moves) and any(m.kind == "type" for m in moves)
+    assert any(m.kind == "click" for m in moves) and any(
+        m.kind == "type" for m in moves
+    )
     # every element-bound move carries a ref (the model steers by ref, never a CSS selector)
     assert all(m.ref for m in moves if m.kind in ("click", "type"))
 
@@ -78,8 +128,12 @@ def test_steer_by_ref_changes_page_state(browser):
     typ = next(m for m in moves if m.kind == "type")
     typ.value = "Issac"
     browser.act(page, typ)
-    browser.act(page, next(m for m in moves if m.kind == "click" and "Press" in m.label))
-    assert page.eval_on_selector("[data-aibref='%s']" % typ.ref, "e=>e.value") == "Issac"
+    browser.act(
+        page, next(m for m in moves if m.kind == "click" and "Press" in m.label)
+    )
+    assert (
+        page.eval_on_selector("[data-aibref='%s']" % typ.ref, "e=>e.value") == "Issac"
+    )
     assert "CLICKED" in browser.read(page)["text"]
 
 


### PR DESCRIPTION
Repairs the remaining GitHub health failures after the dependency security update.

- makes the TypeScript override follow the direct dependency so Dependabot can resolve grouped npm updates
- blocks @netlify/blobs versions that restore the vulnerable image-size dependency line
- stops Playwright when browser launch fails so its asyncio loop cannot poison the rest of the nightly pytest process
- adds mocked and real-launch regression coverage

Verification:
- 302 previously failing tests passed
- npm audit: 0 vulnerabilities
- npm ls typescript: 6.0.2 deduped
- Black, compileall, manifest parsing, and git diff checks passed