### PR TITLE
style(ci): match enforced Black profile

### DIFF
--- a/scripts/cloud_kernel_data_pipeline.py
+++ b/scripts/cloud_kernel_data_pipeline.py
@@ -62,9 +62,7 @@ HARMFUL_PATTERNS = (
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Build, verify, and ship kernel training datasets to cloud sinks."
-    )
+    parser = argparse.ArgumentParser(description="Build, verify, and ship kernel training datasets to cloud sinks.")
     parser.add_argument(
         "--config",
         default=DEFAULT_CONFIG,
@@ -81,9 +79,7 @@ def parse_args() -> argparse.Namespace:
         default=[],
         help="Extra source glob pattern (repeatable).",
     )
-    parser.add_argument(
-        "--sync-notion", action="store_true", help="Sync Notion docs before ingest."
-    )
+    parser.add_argument("--sync-notion", action="store_true", help="Sync Notion docs before ingest.")
     parser.add_argument(
         "--notion-config-key",
         action="append",
@@ -95,12 +91,8 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="Override shipping targets as CSV subset of: hf,github,dropbox.",
     )
-    parser.add_argument(
-        "--no-upload", action="store_true", help="Disable all cloud upload steps."
-    )
-    parser.add_argument(
-        "--keep-runs", type=int, default=0, help="Override local retention run count."
-    )
+    parser.add_argument("--no-upload", action="store_true", help="Disable all cloud upload steps.")
+    parser.add_argument("--keep-runs", type=int, default=0, help="Override local retention run count.")
     parser.add_argument(
         "--allow-quarantine",
         action="store_true",
@@ -224,40 +216,19 @@ def infer_source_system_from_path(path: Path) -> str:
     return "external"
 
 
-def normalize_external_item(
-    item: Dict[str, Any], source_file: Path, index: int
-) -> Dict[str, Any] | None:
+def normalize_external_item(item: Dict[str, Any], source_file: Path, index: int) -> Dict[str, Any] | None:
     text = extract_text_from_object(item)
     if not text:
         return None
 
-    source_system = (
-        as_text(item.get("source_system") or item.get("tool") or item.get("app"))
-        .strip()
-        .lower()
-    )
+    source_system = as_text(item.get("source_system") or item.get("tool") or item.get("app")).strip().lower()
     if not source_system:
         source_system = infer_source_system_from_path(source_file)
 
-    source_id = as_text(
-        item.get("id")
-        or item.get("record_id")
-        or item.get("task_id")
-        or item.get("thread_id")
-    )
-    event_type = as_text(
-        item.get("event_type")
-        or item.get("type")
-        or item.get("status")
-        or "external_record"
-    )
-    created_at = as_text(
-        item.get("created_at") or item.get("created_at_utc") or item.get("timestamp")
-    )
-    category = (
-        as_text(item.get("category") or item.get("kind")).strip().lower()
-        or source_system
-    )
+    source_id = as_text(item.get("id") or item.get("record_id") or item.get("task_id") or item.get("thread_id"))
+    event_type = as_text(item.get("event_type") or item.get("type") or item.get("status") or "external_record")
+    created_at = as_text(item.get("created_at") or item.get("created_at_utc") or item.get("timestamp"))
+    category = as_text(item.get("category") or item.get("kind")).strip().lower() or source_system
 
     return {
         "event_type": event_type,
@@ -381,28 +352,14 @@ def anomaly_score(text: str) -> float:
     entropy_norm = min(1.0, shannon_entropy(text) / 6.0)
     symbol_norm = min(1.0, ratio_symbols(text) / 0.35)
     short_penalty = 1.0 if len(text.strip()) < 60 else 0.0
-    secret_hit = (
-        1.0
-        if any(
-            re.search(pattern, text, flags=re.IGNORECASE) for pattern in SECRET_PATTERNS
-        )
-        else 0.0
-    )
-    uncertainty_pen = (
-        1.0 if any(marker in lower for marker in UNCERTAINTY_MARKERS) else 0.0
-    )
+    secret_hit = 1.0 if any(re.search(pattern, text, flags=re.IGNORECASE) for pattern in SECRET_PATTERNS) else 0.0
+    uncertainty_pen = 1.0 if any(marker in lower for marker in UNCERTAINTY_MARKERS) else 0.0
     return clamp01(
-        0.35 * entropy_norm
-        + 0.2 * symbol_norm
-        + 0.2 * short_penalty
-        + 0.15 * secret_hit
-        + 0.1 * uncertainty_pen
+        0.35 * entropy_norm + 0.2 * symbol_norm + 0.2 * short_penalty + 0.15 * secret_hit + 0.1 * uncertainty_pen
     )
 
 
-def compute_truth_score(
-    text: str, source_path: str, verified_sources: set[str]
-) -> Tuple[float, List[str]]:
+def compute_truth_score(text: str, source_path: str, verified_sources: set[str]) -> Tuple[float, List[str]]:
     reasons: List[str] = []
     score = 0.0
     lower = text.lower()
@@ -422,12 +379,7 @@ def compute_truth_score(
     else:
         score += 0.1
         reasons.append("no_uncertainty_markers")
-    if (
-        "http://" in lower
-        or "https://" in lower
-        or source_path.startswith("docs/")
-        or source_path.startswith("src/")
-    ):
+    if "http://" in lower or "https://" in lower or source_path.startswith("docs/") or source_path.startswith("src/"):
         score += 0.05
         reasons.append("traceable_source_hint")
 
@@ -475,15 +427,10 @@ def compute_harmful_score(text: str, anomaly: float) -> Tuple[float, List[str]]:
     reasons: List[str] = []
     score = 0.0
 
-    if any(
-        re.search(pattern, text, flags=re.IGNORECASE) for pattern in SECRET_PATTERNS
-    ):
+    if any(re.search(pattern, text, flags=re.IGNORECASE) for pattern in SECRET_PATTERNS):
         score += 0.55
         reasons.append("secret_pattern_detected")
-    if any(
-        re.search(pattern, text, flags=re.IGNORECASE | re.DOTALL)
-        for pattern in HARMFUL_PATTERNS
-    ):
+    if any(re.search(pattern, text, flags=re.IGNORECASE | re.DOTALL) for pattern in HARMFUL_PATTERNS):
         score += 0.35
         reasons.append("harmful_instruction_pattern")
 
@@ -507,9 +454,7 @@ def annotate_records(
     rows: List[Dict[str, Any]],
     verified_sources: set[str],
     thresholds: Dict[str, float],
-) -> Tuple[
-    List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], Dict[str, int]
-]:
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], Dict[str, int]]:
     all_rows: List[Dict[str, Any]] = []
     allowed: List[Dict[str, Any]] = []
     quarantined: List[Dict[str, Any]] = []
@@ -601,9 +546,7 @@ def write_categories(path: Path, records: List[Dict[str, Any]]) -> Dict[str, int
     return counts
 
 
-def upload_to_hf(
-    run_dir: Path, repo_id: str, path_prefix: str, run_id: str
-) -> Dict[str, Any]:
+def upload_to_hf(run_dir: Path, repo_id: str, path_prefix: str, run_id: str) -> Dict[str, Any]:
     token = os.environ.get("HF_TOKEN", "").strip()
     if not token:
         raise RuntimeError("HF_TOKEN is required for Hugging Face upload.")
@@ -651,14 +594,9 @@ def upload_to_github_release(
     if not shutil.which("gh"):
         raise RuntimeError("GitHub CLI (gh) is required for GitHub release upload.")
 
-    token = (
-        os.environ.get("GH_TOKEN", "").strip()
-        or os.environ.get("GITHUB_TOKEN", "").strip()
-    )
+    token = os.environ.get("GH_TOKEN", "").strip() or os.environ.get("GITHUB_TOKEN", "").strip()
     if not token:
-        raise RuntimeError(
-            "GH_TOKEN or GITHUB_TOKEN is required for GitHub release upload."
-        )
+        raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is required for GitHub release upload.")
 
     env = dict(os.environ)
     env["GH_TOKEN"] = token
@@ -696,16 +634,12 @@ def upload_to_github_release(
             env,
         )
 
-    upload_cmd = ["gh", "release", "upload", tag, "--repo", repo, "--clobber"] + [
-        str(p) for p in files
-    ]
+    upload_cmd = ["gh", "release", "upload", tag, "--repo", repo, "--clobber"] + [str(p) for p in files]
     run_gh_command(upload_cmd, env)
     return {"status": "ok", "repo": repo, "tag": tag, "assets": [p.name for p in files]}
 
 
-def upload_file_dropbox(
-    local_file: Path, dropbox_path: str, token: str
-) -> Dict[str, Any]:
+def upload_file_dropbox(local_file: Path, dropbox_path: str, token: str) -> Dict[str, Any]:
     url = "https://content.dropboxapi.com/2/files/upload"
     content = local_file.read_bytes()
     args = {
@@ -788,9 +722,7 @@ def main() -> int:
 
     commands_executed: List[str] = []
     source_globs = [str(x) for x in config.get("sources", [])] + list(args.glob)
-    source_globs = [
-        g for i, g in enumerate(source_globs) if g and g not in source_globs[:i]
-    ]
+    source_globs = [g for i, g in enumerate(source_globs) if g and g not in source_globs[:i]]
     external_globs = [str(x) for x in config.get("external_intake_globs", [])]
     thresholds = dict(config.get("thresholds", {}))
 
@@ -844,9 +776,7 @@ def main() -> int:
     if external_rows:
         raw_rows.extend(external_rows)
     write_jsonl(raw_combined_jsonl, raw_rows)
-    all_rows, allowed_rows, quarantine_rows, category_counts = annotate_records(
-        raw_rows, verified_sources, thresholds
-    )
+    all_rows, allowed_rows, quarantine_rows, category_counts = annotate_records(raw_rows, verified_sources, thresholds)
 
     total_rows = len(all_rows)
     allowed_count = write_jsonl(curated_allowed_jsonl, allowed_rows)
@@ -902,12 +832,8 @@ def main() -> int:
             "truth_min": float(thresholds.get("truth_min", 0.62)),
             "useful_min": float(thresholds.get("useful_min", 0.58)),
             "harmful_max": float(thresholds.get("harmful_max", 0.25)),
-            "dataset_anomaly_threshold": float(
-                thresholds.get("dataset_anomaly_threshold", 0.78)
-            ),
-            "dataset_max_flagged_ratio": float(
-                thresholds.get("dataset_max_flagged_ratio", 0.08)
-            ),
+            "dataset_anomaly_threshold": float(thresholds.get("dataset_anomaly_threshold", 0.78)),
+            "dataset_max_flagged_ratio": float(thresholds.get("dataset_max_flagged_ratio", 0.08)),
         },
         "counts": {
             "input_records": total_rows,
@@ -928,9 +854,7 @@ def main() -> int:
         "state_vector": state_vector,
         "decision_record": decision_record,
     }
-    verification_json.write_text(
-        json.dumps(verification_report, indent=2) + "\n", encoding="utf-8"
-    )
+    verification_json.write_text(json.dumps(verification_report, indent=2) + "\n", encoding="utf-8")
 
     archive_file = run_dir.with_suffix(".zip")
     if archive_file.exists():
@@ -941,17 +865,11 @@ def main() -> int:
     selected_targets = (
         parse_ship_targets(args.ship_targets)
         if args.ship_targets
-        else {
-            k
-            for k, v in ship_config.items()
-            if isinstance(v, dict) and bool(v.get("enabled"))
-        }
+        else {k for k, v in ship_config.items() if isinstance(v, dict) and bool(v.get("enabled"))}
     )
     shipping_results: Dict[str, Any] = {}
     shipping_errors: Dict[str, str] = {}
-    can_ship = (not args.no_upload) and (
-        dataset_audit.get("status") == "ALLOW" or args.ship_on_quarantine
-    )
+    can_ship = (not args.no_upload) and (dataset_audit.get("status") == "ALLOW" or args.ship_on_quarantine)
 
     if can_ship:
         if "hf" in selected_targets:
@@ -971,9 +889,7 @@ def main() -> int:
                 shipping_results["github"] = upload_to_github_release(
                     repo=as_text(gh_cfg.get("repo")),
                     run_id=run_id,
-                    release_prefix=as_text(
-                        gh_cfg.get("release_prefix", "kernel-data-sync")
-                    ),
+                    release_prefix=as_text(gh_cfg.get("release_prefix", "kernel-data-sync")),
                     files=[
                         archive_file,
                         curated_allowed_jsonl,
@@ -988,9 +904,7 @@ def main() -> int:
             try:
                 shipping_results["dropbox"] = upload_to_dropbox(
                     run_id=run_id,
-                    base_path=as_text(
-                        dbx_cfg.get("base_path", "/SCBE/kernel-data-sync")
-                    ),
+                    base_path=as_text(dbx_cfg.get("base_path", "/SCBE/kernel-data-sync")),
                     files=[
                         archive_file,
                         curated_allowed_jsonl,
@@ -1003,15 +917,9 @@ def main() -> int:
 
     pointer_path = REPO_ROOT / LATEST_POINTER
     pointer_path.parent.mkdir(parents=True, exist_ok=True)
-    pointer_path.write_text(
-        str(run_dir.relative_to(REPO_ROOT)).replace("\\", "/") + "\n", encoding="utf-8"
-    )
+    pointer_path.write_text(str(run_dir.relative_to(REPO_ROOT)).replace("\\", "/") + "\n", encoding="utf-8")
 
-    keep_runs = (
-        args.keep_runs
-        if args.keep_runs > 0
-        else int(config.get("retention", {}).get("keep_local_runs", 30))
-    )
+    keep_runs = args.keep_runs if args.keep_runs > 0 else int(config.get("retention", {}).get("keep_local_runs", 30))
     cleanup = cleanup_old_runs(run_root, keep_runs)
 
     summary = {
@@ -1019,28 +927,14 @@ def main() -> int:
         "run_dir": str(run_dir.relative_to(REPO_ROOT)).replace("\\", "/"),
         "artifacts": {
             "raw_ingest": str(raw_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
-            "raw_combined": str(raw_combined_jsonl.relative_to(REPO_ROOT)).replace(
-                "\\", "/"
-            ),
-            "doc_manifest": str(manifest_json.relative_to(REPO_ROOT)).replace(
-                "\\", "/"
-            ),
-            "curated_all": str(curated_all_jsonl.relative_to(REPO_ROOT)).replace(
-                "\\", "/"
-            ),
-            "curated_allowed": str(
-                curated_allowed_jsonl.relative_to(REPO_ROOT)
-            ).replace("\\", "/"),
-            "curated_quarantine": str(
-                curated_quarantine_jsonl.relative_to(REPO_ROOT)
-            ).replace("\\", "/"),
-            "categories_dir": str(categories_dir.relative_to(REPO_ROOT)).replace(
-                "\\", "/"
-            ),
+            "raw_combined": str(raw_combined_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
+            "doc_manifest": str(manifest_json.relative_to(REPO_ROOT)).replace("\\", "/"),
+            "curated_all": str(curated_all_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
+            "curated_allowed": str(curated_allowed_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
+            "curated_quarantine": str(curated_quarantine_jsonl.relative_to(REPO_ROOT)).replace("\\", "/"),
+            "categories_dir": str(categories_dir.relative_to(REPO_ROOT)).replace("\\", "/"),
             "dataset_audit": str(audit_json.relative_to(REPO_ROOT)).replace("\\", "/"),
-            "verification_report": str(
-                verification_json.relative_to(REPO_ROOT)
-            ).replace("\\", "/"),
+            "verification_report": str(verification_json.relative_to(REPO_ROOT)).replace("\\", "/"),
             "archive": str(archive_file.relative_to(REPO_ROOT)).replace("\\", "/"),
         },
         "latest_pointer": LATEST_POINTER,

--- a/tests/api/test_polly_widget_contract.py
+++ b/tests/api/test_polly_widget_contract.py
@@ -37,8 +37,7 @@ def test_chat_handler_emits_assistant_text_under_text_key() -> None:
     # (The handler builds replies in multiple branches — research, commerce,
     # llm fallback, offline-router. All must use `text` as the key.)
     assert re.search(r"\btext:\s*", src), (
-        "api/polly/chat.js must emit assistant reply under `text:` key — "
-        "widget reads it from there"
+        "api/polly/chat.js must emit assistant reply under `text:` key — " "widget reads it from there"
     )
 
 

--- a/tests/test_aethermoor_bus_mobile_shell.py
+++ b/tests/test_aethermoor_bus_mobile_shell.py
@@ -48,9 +48,7 @@ def test_mobile_backend_is_operator_configured_without_loopback_defaults() -> No
 
 def test_manifest_uses_aethermoor_bus_branding() -> None:
     config = _read("vite.config.ts")
-    twa = (ROOT / "apps" / "mobile" / "twa" / "twa-manifest.json").read_text(
-        encoding="utf-8"
-    )
+    twa = (ROOT / "apps" / "mobile" / "twa" / "twa-manifest.json").read_text(encoding="utf-8")
     assert "VitePWA" in config
     assert "name: 'Aethermoor Bus'" in config
     assert '"name": "Aethermoor Bus"' in twa

--- a/tests/test_ai_browser.py
+++ b/tests/test_ai_browser.py
@@ -26,9 +26,7 @@ def test_ephemeral_consume_is_exactly_once_even_on_malformed_json(tmp_path):
     with pytest.raises(Exception):  # noqa: B017 -- malformed -> json parse error
         ef.consume()
     assert not p.exists()  # deleted despite the parse failure (no over-cache)
-    with pytest.raises(
-        RuntimeError
-    ):  # spent -> 'already consumed', not a second parse attempt
+    with pytest.raises(RuntimeError):  # spent -> 'already consumed', not a second parse attempt
         ef.consume()
 
 
@@ -66,9 +64,7 @@ def test_failed_launch_stops_playwright(monkeypatch):
 def test_real_failed_launch_does_not_poison_asyncio():
     """Exercise Playwright itself: a launch error must leave asyncio usable."""
     browser = AIBrowser(headless=True, channel="scbe-missing-browser")
-    with pytest.raises(
-        Exception
-    ):  # noqa: B017 -- Playwright owns the concrete error type
+    with pytest.raises(Exception):  # noqa: B017 -- Playwright owns the concrete error type
         browser.__enter__()
 
     assert browser._pw is None
@@ -102,9 +98,7 @@ def test_feed_is_structured_and_bounded(browser):
     feed = browser.read(page)
     assert feed["url"].startswith("data:text/html")
     refs = {e["ref"] for e in feed["elements"]}
-    assert (
-        len(refs) == len(feed["elements"]) == 3
-    )  # button, input, link -- a small bounded surface
+    assert len(refs) == len(feed["elements"]) == 3  # button, input, link -- a small bounded surface
     by_tag = {e["tag"] for e in feed["elements"]}
     assert {"button", "input", "a"} <= by_tag
     assert next(e for e in feed["elements"] if e["tag"] == "input")["editable"] is True
@@ -115,9 +109,7 @@ def test_control_surface_is_legal_moves_only(browser):
     moves = browser.moves(browser.read(page))
     kinds = [m.kind for m in moves]
     assert "read" in kinds and "scroll" in kinds and "back" in kinds
-    assert any(m.kind == "click" for m in moves) and any(
-        m.kind == "type" for m in moves
-    )
+    assert any(m.kind == "click" for m in moves) and any(m.kind == "type" for m in moves)
     # every element-bound move carries a ref (the model steers by ref, never a CSS selector)
     assert all(m.ref for m in moves if m.kind in ("click", "type"))
 
@@ -128,12 +120,8 @@ def test_steer_by_ref_changes_page_state(browser):
     typ = next(m for m in moves if m.kind == "type")
     typ.value = "Issac"
     browser.act(page, typ)
-    browser.act(
-        page, next(m for m in moves if m.kind == "click" and "Press" in m.label)
-    )
-    assert (
-        page.eval_on_selector("[data-aibref='%s']" % typ.ref, "e=>e.value") == "Issac"
-    )
+    browser.act(page, next(m for m in moves if m.kind == "click" and "Press" in m.label))
+    assert page.eval_on_selector("[data-aibref='%s']" % typ.ref, "e=>e.value") == "Issac"
     assert "CLICKED" in browser.read(page)["text"]
 
 


### PR DESCRIPTION
Mechanical follow-up to #2766 using the exact CI formatter contract: Black 26.5.1, Python 3.11 target, 120-column lines.

CI named these four files. The exact full-tree Black check now reports all 2,512 Python files unchanged.

Verification:
- full CI Black command passed locally
- 21 browser/mobile/widget tests passed
- cloud artifact-order regression passed