### PR TITLE
chore(dependabot): hold incompatible TypeScript majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,11 @@ updates:
           - ">=9.1.6 <10.0.0"
         update-types:
           - "version-update:semver-major"
+      # TypeScript 7 removes moduleResolution=node10. Keep compatible 6.x
+      # updates flowing until the repository's module-resolution migration.
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-security:
         applies-to: security-updates


### PR DESCRIPTION
Dependabot is working again, and its first npm run exposed the next incompatible update: TypeScript 7 fails this repository because moduleResolution=node10 was removed (TS5108).

Keep TypeScript 6.x updates enabled, but suppress major updates until the module-resolution migration is deliberately implemented and tested.

This closes the guaranteed-red #2767 without suppressing security or compatible minor/patch updates.