### PR TITLE
fix(deps): replace stale root Python graph

### DIFF
--- a/.github/workflows/root-python-dependency-snapshot.yml
+++ b/.github/workflows/root-python-dependency-snapshot.yml
@@ -1,0 +1,48 @@
+name: Root Python Dependency Snapshot
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - pyproject.toml
+      - requirements-lock.txt
+      - scripts/build_dependency_snapshot.py
+      - .github/workflows/root-python-dependency-snapshot.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit:
+    name: Submit exact root Python graph
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Build exact dependency snapshot
+        run: >-
+          python scripts/build_dependency_snapshot.py
+          --sha "$GITHUB_SHA"
+          --ref "$GITHUB_REF"
+          --job-id "$GITHUB_RUN_ID"
+          --output "$RUNNER_TEMP/root-python-dependency-snapshot.json"
+
+      - name: Submit snapshot to GitHub dependency graph
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh api --method POST
+          -H "Accept: application/vnd.github+json"
+          -H "X-GitHub-Api-Version: 2026-03-10"
+          "repos/${GITHUB_REPOSITORY}/dependency-graph/snapshots"
+          --input "$RUNNER_TEMP/root-python-dependency-snapshot.json"

--- a/scripts/build_dependency_snapshot.py
+++ b/scripts/build_dependency_snapshot.py
@@ -1,0 +1,191 @@
+"""Build the root Python dependency snapshot submitted to GitHub.
+
+GitHub's automatic Python graph can retain an older resolver snapshot after a
+manifest disappears.  This builder turns the repository's exact
+``requirements-lock.txt`` into a deterministic Dependency Submission API
+payload so the graph follows the lock file on every relevant ``main`` push.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+PACKAGE_NAME = r"[A-Za-z0-9][A-Za-z0-9._-]*"
+EXACT_REQUIREMENT = re.compile(rf"^(?P<name>{PACKAGE_NAME})==(?P<version>[^\s;]+)(?:\s*;.*)?$")
+DECLARED_REQUIREMENT = re.compile(rf"^\s*(?P<name>{PACKAGE_NAME})")
+
+
+def normalize_package_name(name: str) -> str:
+    """Return the normalized PyPI project name used in package URLs."""
+
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def load_direct_dependencies(pyproject_path: Path) -> set[str]:
+    """Read direct runtime dependency names from ``pyproject.toml``."""
+
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    requirements = data.get("project", {}).get("dependencies", [])
+    direct: set[str] = set()
+
+    for requirement in requirements:
+        match = DECLARED_REQUIREMENT.match(requirement)
+        if match is None:
+            raise ValueError(f"Unsupported project dependency: {requirement!r}")
+        direct.add(normalize_package_name(match.group("name")))
+
+    return direct
+
+
+def load_locked_dependencies(lock_path: Path) -> tuple[dict[str, str], list[str]]:
+    """Read exact registry requirements and identify intentionally skipped VCS entries."""
+
+    locked: dict[str, str] = {}
+    skipped_vcs: list[str] = []
+
+    for line_number, raw_line in enumerate(lock_path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if line.startswith("-e ") or " @ git+" in line:
+            skipped_vcs.append(line)
+            continue
+
+        match = EXACT_REQUIREMENT.fullmatch(line)
+        if match is None:
+            raise ValueError(f"Unsupported lock entry at {lock_path}:{line_number}: {line!r}")
+
+        name = normalize_package_name(match.group("name"))
+        version = match.group("version")
+        previous = locked.get(name)
+        if previous is not None and previous != version:
+            raise ValueError(f"Conflicting versions for {name}: {previous!r} and {version!r}")
+        locked[name] = version
+
+    if not locked:
+        raise ValueError(f"No exact dependencies found in {lock_path}")
+
+    return locked, skipped_vcs
+
+
+def package_url(name: str, version: str) -> str:
+    """Build a standards-compatible PyPI package URL."""
+
+    encoded_name = quote(name, safe="-._~")
+    encoded_version = quote(version, safe="-._~")
+    return f"pkg:pypi/{encoded_name}@{encoded_version}"
+
+
+def build_snapshot(
+    repo_root: Path,
+    *,
+    sha: str,
+    ref: str,
+    job_id: str,
+    scanned: str,
+) -> tuple[dict[str, Any], list[str]]:
+    """Build a Dependency Submission API snapshot for the root Python manifest."""
+
+    if re.fullmatch(r"[0-9a-fA-F]{40}", sha) is None:
+        raise ValueError("sha must be a full 40-character Git commit hash")
+    if not ref.startswith("refs/"):
+        raise ValueError("ref must start with 'refs/'")
+
+    direct = load_direct_dependencies(repo_root / "pyproject.toml")
+    locked, skipped_vcs = load_locked_dependencies(repo_root / "requirements-lock.txt")
+    resolved: dict[str, object] = {}
+
+    for name, version in sorted(locked.items()):
+        resolved[name] = {
+            "package_url": package_url(name, version),
+            "relationship": "direct" if name in direct else "indirect",
+            "scope": "runtime",
+            "dependencies": [],
+        }
+
+    snapshot: dict[str, Any] = {
+        "version": 0,
+        "sha": sha.lower(),
+        "ref": ref,
+        "job": {
+            "correlator": "00-root-python-requirements-lock",
+            "id": job_id,
+        },
+        "detector": {
+            "name": "scbe-root-python-lock",
+            "version": "1.0.0",
+            "url": (
+                "https://github.com/issdandavis/SCBE-AETHERMOORE/" "blob/main/scripts/build_dependency_snapshot.py"
+            ),
+        },
+        "scanned": scanned,
+        "manifests": {
+            "pyproject.toml": {
+                "name": "pyproject.toml",
+                "file": {"source_location": "pyproject.toml"},
+                "metadata": {
+                    "lock_file": "requirements-lock.txt",
+                    "skipped_vcs_entries": len(skipped_vcs),
+                },
+                "resolved": resolved,
+            }
+        },
+    }
+    return snapshot, skipped_vcs
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--sha", default=os.environ.get("GITHUB_SHA"))
+    parser.add_argument("--ref", default=os.environ.get("GITHUB_REF"))
+    parser.add_argument("--job-id", default=os.environ.get("GITHUB_RUN_ID"))
+    parser.add_argument(
+        "--scanned",
+        default=datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    )
+    parser.add_argument("--output", type=Path, help="Write JSON here; omit to write to stdout")
+    args = parser.parse_args()
+
+    for field in ("sha", "ref", "job_id"):
+        if not getattr(args, field):
+            parser.error(f"--{field.replace('_', '-')} or its GitHub Actions environment variable is required")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    snapshot, skipped_vcs = build_snapshot(
+        args.repo_root,
+        sha=args.sha,
+        ref=args.ref,
+        job_id=args.job_id,
+        scanned=args.scanned,
+    )
+    rendered = json.dumps(snapshot, indent=2, sort_keys=True) + "\n"
+
+    if args.output is None:
+        sys.stdout.write(rendered)
+    else:
+        args.output.write_text(rendered, encoding="utf-8")
+
+    resolved = snapshot["manifests"]["pyproject.toml"]["resolved"]
+    print(
+        f"Built snapshot with {len(resolved)} exact dependencies; skipped {len(skipped_vcs)} VCS entries",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.build_dependency_snapshot import build_snapshot, load_locked_dependencies
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEST_SHA = "a" * 40
+
+
+def test_current_lock_submits_all_patched_security_floors() -> None:
+    snapshot, skipped_vcs = build_snapshot(
+        REPO_ROOT,
+        sha=TEST_SHA,
+        ref="refs/heads/main",
+        job_id="test",
+        scanned="2026-08-08T00:00:00Z",
+    )
+    resolved = snapshot["manifests"]["pyproject.toml"]["resolved"]
+
+    expected = {
+        "pillow": "12.3.0",
+        "aiohttp": "3.14.3",
+        "cryptography": "50.0.0",
+        "pyasn1": "0.6.4",
+        "soupsieve": "2.9.1",
+        "mcp": "1.28.1",
+        "bedrock-agentcore": "1.19.0",
+    }
+    for name, version in expected.items():
+        assert resolved[name]["package_url"] == f"pkg:pypi/{name}@{version}"
+        assert resolved[name]["relationship"] == "direct"
+
+    assert len(resolved) >= 200
+    assert len(skipped_vcs) == 2
+
+
+def test_lock_parser_normalizes_names_and_rejects_ambiguous_entries(tmp_path: Path) -> None:
+    valid_lock = tmp_path / "valid.txt"
+    valid_lock.write_text("PyYAML==6.0.3\n-e git+https://example.test/repo.git#egg=demo\n", encoding="utf-8")
+
+    locked, skipped_vcs = load_locked_dependencies(valid_lock)
+
+    assert locked == {"pyyaml": "6.0.3"}
+    assert len(skipped_vcs) == 1
+
+    invalid_lock = tmp_path / "invalid.txt"
+    invalid_lock.write_text("unpinned>=1.0\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Unsupported lock entry"):
+        load_locked_dependencies(invalid_lock)


### PR DESCRIPTION
Replaces GitHub's stale root Python dependency graph with a maintained exact snapshot from requirements-lock.txt. Validated with focused pytest, Black, Ruff, Prettier, and git diff --check.