### PR TITLE
ci(deps): use Node 24 action runtimes

### DIFF
--- a/.github/workflows/root-python-dependency-snapshot.yml
+++ b/.github/workflows/root-python-dependency-snapshot.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Updates the new dependency snapshot workflow to pinned v6 action commits, removing the Node.js 20 deprecation warning while preserving supply-chain pinning.