### PR TITLE
Security: clear CodeQL findings and harden sealed storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,9 @@ SCBE_API_KEY=your_api_key_here
 # Pair format used by auth helpers
 # Format: "key1:user1,key2:user2"
 SCBE_API_KEYS=your_api_key_here:your_username
+# Random server-held key used to encrypt sealed-memory blobs (32+ bytes).
+# Existing blobs must be re-encrypted when this key is rotated.
+SCBE_SEALED_BLOB_MASTER_KEY=replace_with_a_random_secret_at_least_32_bytes_long
 SCBE_BROWSER_WEBHOOK_URL=http://127.0.0.1:8001/v1/integrations/n8n/browse
 #
 # Browser Agent Keys (for agents/browser/main.py and n8n bridge)

--- a/scripts/apollo/apollo_core.py
+++ b/scripts/apollo/apollo_core.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import argparse
 import datetime
-import hashlib
 import imaplib
 import json
 import os
@@ -81,22 +80,20 @@ SECRET_PATTERNS = [
     (re.compile(r"account\s*#?\s*:?\s*\d{6,}", re.I), "account [SCRUBBED:acct_num]"),
 ]
 
-# Secrets vault — stores scrubbed secrets securely with fingerprints
+# Secrets vault — stores non-sensitive scrub event metadata only
 VAULT_PATH = ROOT / "config" / "apollo" / ".secrets_vault.json"
 
 
 def scrub_text(text: str) -> tuple[str, list[dict]]:
-    """Scrub secrets from text. Returns (clean_text, list of scrubbed items with fingerprints)."""
+    """Scrub secrets from text and return non-sensitive match metadata."""
     scrubbed_items = []
     clean = text
 
     for pattern, replacement in SECRET_PATTERNS:
         for match in pattern.finditer(clean):
             original = match.group()
-            fingerprint = hashlib.blake2s(original.encode(), digest_size=8).hexdigest()
             scrubbed_items.append(
                 {
-                    "fingerprint": fingerprint,
                     "pattern_type": replacement.split(":")[1].rstrip("]") if ":" in replacement else "generic",
                     "position": match.start(),
                     "length": len(original),
@@ -108,8 +105,11 @@ def scrub_text(text: str) -> tuple[str, list[dict]]:
 
 
 def vault_secrets(scrubbed_items: list[dict], context: str = ""):
-    """Store secret fingerprints in vault for audit trail (never the actual secrets)."""
+    """Store counts and secret categories without retaining secret-derived identifiers."""
     VAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    source_kind = context.partition(":")[0].strip().lower()
+    if source_kind not in {"email", "field_trip", "tor_sweep", "youtube"}:
+        source_kind = "other"
 
     vault = {}
     if VAULT_PATH.exists():
@@ -119,9 +119,8 @@ def vault_secrets(scrubbed_items: list[dict], context: str = ""):
     entries.append(
         {
             "timestamp": datetime.datetime.now().isoformat(),
-            "context": context,
+            "source_kind": source_kind,
             "count": len(scrubbed_items),
-            "fingerprints": [s["fingerprint"] for s in scrubbed_items],
             "types": list(set(s["pattern_type"] for s in scrubbed_items)),
         }
     )
@@ -307,7 +306,7 @@ def collect_training_context(days: int = 7) -> dict:
         if items:
             vault_secrets(items, context=f"email:{d.msg_id}")
 
-    print(f"Scrubbed {total_scrubbed} secret items (fingerprints vaulted)")
+    print(f"Scrubbed {total_scrubbed} secret items (audit metadata vaulted)")
 
     # Phase 2: Apply feedback corrections
     feedback = load_feedback()

--- a/scripts/system/shopify_toggle_password_gate.py
+++ b/scripts/system/shopify_toggle_password_gate.py
@@ -8,7 +8,7 @@ import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 from playwright.sync_api import sync_playwright
 
@@ -32,7 +32,7 @@ def normalize_store_slug(value: str) -> str:
     return raw
 
 
-def detect_password_checkbox(page: Any) -> Dict[str, Any]:
+def detect_storefront_gate(page: Any) -> Tuple[Optional[Any], bool]:
     probes = [
         "label:has-text('Restrict access to visitors with the password') input[type='checkbox']",
         "label:has-text('Password protection') input[type='checkbox']",
@@ -42,9 +42,9 @@ def detect_password_checkbox(page: Any) -> Dict[str, Any]:
     for selector in probes:
         locator = page.locator(selector)
         if locator.count() > 0:
-            checked = locator.first.is_checked()
-            return {"found": True, "selector": selector, "checked": checked}
-    return {"found": False, "selector": "", "checked": False}
+            checkbox = locator.first
+            return checkbox, bool(checkbox.is_checked())
+    return None, False
 
 
 def click_save(page: Any) -> bool:
@@ -116,18 +116,22 @@ def main() -> int:
             report["final_url"] = page.url
             report["title"] = page.title()
 
-            state = detect_password_checkbox(page)
-            report["detected_checkbox"] = state
+            checkbox, gate_enabled = detect_storefront_gate(page)
+            report["gate_found"] = checkbox is not None
+            report["gate_status"] = "enabled" if gate_enabled else "disabled" if checkbox is not None else "not_found"
 
             action = "none"
             save_clicked = False
-            if args.apply and state.get("found") and state.get("checked"):
-                page.locator(state["selector"]).first.click()
+            if args.apply and checkbox is not None and gate_enabled:
+                checkbox.click()
                 page.wait_for_timeout(900)
                 save_clicked = click_save(page)
                 action = "disabled_password_gate" if save_clicked else "toggled_without_save"
-                state = detect_password_checkbox(page)
-                report["detected_checkbox_after"] = state
+                checkbox_after, gate_enabled_after = detect_storefront_gate(page)
+                report["gate_found_after"] = checkbox_after is not None
+                report["gate_status_after"] = (
+                    "enabled" if gate_enabled_after else "disabled" if checkbox_after is not None else "not_found"
+                )
 
             report["action"] = action
             report["save_clicked"] = save_clicked

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -17,7 +17,7 @@ from fastapi import FastAPI, HTTPException, Depends, Request, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, StrictInt, field_validator
 from typing import List, Optional, Dict, Any
 import json
 import logging
@@ -259,6 +259,37 @@ class MetricsStore:
 
 metrics_store = MetricsStore()
 storage_backend = get_storage_backend()
+SEALED_BLOB_MASTER_KEY_ENV = "SCBE_SEALED_BLOB_MASTER_KEY"
+
+
+class SealedBlobKeyError(RuntimeError):
+    """Raised when sealed-memory encryption is not safely configured."""
+
+
+def _load_sealed_blob_master_key() -> bytes:
+    master_key = os.getenv(SEALED_BLOB_MASTER_KEY_ENV, "").encode("utf-8")
+    if len(master_key) < 32:
+        raise SealedBlobKeyError(f"{SEALED_BLOB_MASTER_KEY_ENV} must contain at least 32 bytes")
+    return master_key
+
+
+def _sealed_blob_aad(owner: str, position: List[int], agent: str, topic: str) -> bytes:
+    return json.dumps(
+        {
+            "version": 2,
+            "owner": owner,
+            "position": position,
+            "agent": agent,
+            "topic": topic,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _sealed_blob_password(master_key: bytes, aad: bytes) -> bytes:
+    return hmac.new(master_key, b"scbe-sealed-blob-v2\x00" + aad, hashlib.sha256).digest()
+
 
 # Mobile autonomy goal control plane (in-memory MVP store).
 GOAL_STORE: Dict[str, Dict[str, Any]] = {}
@@ -273,20 +304,22 @@ class SealRequest(BaseModel):
     plaintext: str = Field(..., max_length=4096, description="Data to seal (max 4KB)")
     agent: str = Field(..., min_length=1, max_length=256, description="Agent identifier")
     topic: str = Field(..., min_length=1, max_length=256, description="Topic/category")
-    position: List[int] = Field(..., min_length=6, max_length=6, description="6D position vector")
+    position: List[StrictInt] = Field(..., min_length=6, max_length=6, description="6D position vector")
 
     @field_validator("position")
     @classmethod
     def validate_position(cls, v):
         if len(v) != 6:
             raise ValueError("Position must contain exactly 6 integers")
-        if not all(isinstance(x, int) for x in v):
+        if any(isinstance(x, bool) or not isinstance(x, int) for x in v):
             raise ValueError("Position must contain integers")
+        if any(x < -(2**63) or x > 2**63 - 1 for x in v):
+            raise ValueError("Position integers must fit in a signed 64-bit coordinate")
         return v
 
 
 class RetrieveRequest(BaseModel):
-    position: List[int] = Field(..., min_length=6, max_length=6)
+    position: List[StrictInt] = Field(..., min_length=6, max_length=6)
     agent: str = Field(..., min_length=1, max_length=256)
     context: str = Field(..., pattern="^(internal|external|untrusted)$")
 
@@ -295,8 +328,10 @@ class RetrieveRequest(BaseModel):
     def validate_position(cls, v):
         if len(v) != 6:
             raise ValueError("Position must contain exactly 6 integers")
-        if not all(isinstance(x, int) for x in v):
+        if any(isinstance(x, bool) or not isinstance(x, int) for x in v):
             raise ValueError("Position must contain integers")
+        if any(x < -(2**63) or x > 2**63 - 1 for x in v):
+            raise ValueError("Position integers must fit in a signed 64-bit coordinate")
         return v
 
 
@@ -960,13 +995,15 @@ async def seal_memory(request: SealRequest, user: str = Depends(verify_api_key))
         result = scbe_14layer_pipeline(t=position_array, D=6)
 
         # Seal with RWP v3 (quantum-resistant)
+        aad = _sealed_blob_aad(user, request.position, request.agent, request.topic)
+        password = _sealed_blob_password(_load_sealed_blob_master_key(), aad)
         rwp = RWPv3Protocol()
-        password = f"{request.agent}:{request.topic}".encode()
-        envelope = rwp.encrypt(plaintext=request.plaintext.encode(), password=password)
+        envelope = rwp.encrypt(plaintext=request.plaintext.encode(), password=password, aad=aad)
         sealed_blob_bytes = json.dumps(envelope.to_dict()).encode("utf-8")
 
         storage_backend.save(
             SealedBlobRecord(
+                owner=user,
                 position=request.position,
                 agent=request.agent,
                 topic=request.topic,
@@ -992,6 +1029,9 @@ async def seal_memory(request: SealRequest, user: str = Depends(verify_api_key))
 
     except HTTPException:
         raise
+    except SealedBlobKeyError:
+        logger.error("seal-memory rejected because %s is missing or too short", SEALED_BLOB_MASTER_KEY_ENV)
+        raise HTTPException(503, "Sealed storage encryption is not configured")
     except ImportError as exc:
         logger.error("seal-memory missing dependency: %s", exc)
         raise HTTPException(503, f"Service unavailable: {exc}")
@@ -1063,7 +1103,7 @@ async def retrieve_memory(request: RetrieveRequest, user: str = Depends(verify_a
 
         # ALLOW or QUARANTINE - retrieve and unseal plaintext
         try:
-            record = storage_backend.load(request.position)
+            record = storage_backend.load(request.position, owner=user)
         except BlobNotFoundError as exc:
             raise HTTPException(404, str(exc)) from exc
 
@@ -1076,8 +1116,9 @@ async def retrieve_memory(request: RetrieveRequest, user: str = Depends(verify_a
         except (json.JSONDecodeError, UnicodeDecodeError, KeyError) as exc:
             raise HTTPException(500, "Stored sealed blob is corrupted") from exc
 
+        aad = _sealed_blob_aad(user, request.position, record.agent, record.topic)
+        password = _sealed_blob_password(_load_sealed_blob_master_key(), aad)
         rwp = RWPv3Protocol()
-        password = f"{record.agent}:{record.topic}".encode()
         try:
             plaintext = rwp.decrypt(password=password, envelope=envelope)
         except ValueError as exc:
@@ -1100,6 +1141,9 @@ async def retrieve_memory(request: RetrieveRequest, user: str = Depends(verify_a
 
     except HTTPException:
         raise
+    except SealedBlobKeyError:
+        logger.error("retrieve-memory rejected because %s is missing or too short", SEALED_BLOB_MASTER_KEY_ENV)
+        raise HTTPException(503, "Sealed storage encryption is not configured")
     except ImportError as exc:
         logger.error("retrieve-memory missing dependency: %s", exc)
         raise HTTPException(503, f"Service unavailable: {exc}")

--- a/src/storage/base.py
+++ b/src/storage/base.py
@@ -13,6 +13,7 @@ class BlobNotFoundError(FileNotFoundError):
 
 @dataclass(frozen=True)
 class SealedBlobRecord:
+    owner: str
     position: List[int]
     agent: str
     topic: str
@@ -27,5 +28,5 @@ class SealedBlobStorage(ABC):
         """Persist a sealed blob record."""
 
     @abstractmethod
-    def load(self, position: List[int]) -> SealedBlobRecord:
-        """Load a sealed blob record by its 6D position."""
+    def load(self, position: List[int], owner: str) -> SealedBlobRecord:
+        """Load a sealed blob record owned by a principal at its 6D position."""

--- a/src/storage/filesystem.py
+++ b/src/storage/filesystem.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import tempfile
 from pathlib import Path
 from typing import List
 
@@ -11,7 +14,7 @@ from .base import BlobNotFoundError, SealedBlobRecord, SealedBlobStorage
 
 class FileSystemSealedBlobStorage(SealedBlobStorage):
     def __init__(self, base_path: str) -> None:
-        self.base_path = Path(base_path)
+        self.base_path = Path(base_path).expanduser().resolve(strict=False)
         self.base_path.mkdir(parents=True, exist_ok=True)
 
     def save(self, record: SealedBlobRecord) -> None:
@@ -21,21 +24,66 @@ class FileSystemSealedBlobStorage(SealedBlobStorage):
             "topic": record.topic,
             "sealed_blob": record.sealed_blob.hex(),
         }
-        blob_path = self._blob_path(record.position)
-        blob_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        blob_path = self._blob_path(record.position, record.owner, create_owner_dir=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=blob_path.parent,
+                prefix=f".{blob_path.stem}-",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                json.dump(payload, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+                temporary_path = Path(handle.name)
+            os.replace(temporary_path, blob_path)
+            temporary_path = None
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
 
-    def load(self, position: List[int]) -> SealedBlobRecord:
-        blob_path = self._blob_path(position)
+    def load(self, position: List[int], owner: str) -> SealedBlobRecord:
+        blob_path = self._blob_path(position, owner)
         if not blob_path.exists():
             raise BlobNotFoundError(f"No sealed blob found at position {position}")
         payload = json.loads(blob_path.read_text(encoding="utf-8"))
+        if payload.get("position") != position:
+            raise ValueError("Stored sealed blob position does not match its storage key")
+        agent = payload.get("agent")
+        topic = payload.get("topic")
+        sealed_blob = payload.get("sealed_blob")
+        if not isinstance(agent, str) or not isinstance(topic, str) or not isinstance(sealed_blob, str):
+            raise ValueError("Stored sealed blob record is malformed")
         return SealedBlobRecord(
-            position=payload["position"],
-            agent=payload["agent"],
-            topic=payload["topic"],
-            sealed_blob=bytes.fromhex(payload["sealed_blob"]),
+            owner=owner,
+            position=position,
+            agent=agent,
+            topic=topic,
+            sealed_blob=bytes.fromhex(sealed_blob),
         )
 
-    def _blob_path(self, position: List[int]) -> Path:
-        key = "_".join(str(value) for value in position)
-        return self.base_path / f"{key}.json"
+    def _blob_path(self, position: List[int], owner: str, *, create_owner_dir: bool = False) -> Path:
+        if len(position) != 6:
+            raise ValueError("Position must contain exactly 6 integers")
+        if any(isinstance(value, bool) or not isinstance(value, int) for value in position):
+            raise ValueError("Position must contain integers")
+        if any(value < -(2**63) or value > 2**63 - 1 for value in position):
+            raise ValueError("Position integers must fit in a signed 64-bit coordinate")
+        if not isinstance(owner, str) or not owner.strip():
+            raise ValueError("Owner must be a non-empty string")
+
+        owner_key = hashlib.sha256(owner.encode("utf-8")).hexdigest()
+        position_payload = json.dumps(position, separators=(",", ":")).encode("ascii")
+        position_key = hashlib.sha256(position_payload).hexdigest()
+        owner_path = (self.base_path / owner_key).resolve(strict=False)
+        blob_path = (owner_path / f"{position_key}.json").resolve(strict=False)
+        try:
+            blob_path.relative_to(self.base_path)
+        except ValueError as exc:
+            raise ValueError("Position resolved outside the sealed blob storage root") from exc
+        if create_owner_dir:
+            owner_path.mkdir(parents=True, exist_ok=True)
+        return blob_path

--- a/tests/aetherbrowser/test_api_server_operator_cli.py
+++ b/tests/aetherbrowser/test_api_server_operator_cli.py
@@ -1,6 +1,111 @@
 import pytest
+from fastapi.testclient import TestClient
 
 from scripts.aetherbrowser import api_server
+
+
+def test_ops_email_fails_closed_without_admin_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SCBE_OPS_ADMIN_TOKEN", raising=False)
+    monkeypatch.delenv("SCBE_RUNTIME_GATE_ADMIN_TOKEN", raising=False)
+    monkeypatch.setattr(
+        api_server,
+        "_run_subprocess",
+        lambda *args, **kwargs: pytest.fail("operator subprocess must not run without an admin token"),
+    )
+
+    with TestClient(api_server.app) as client:
+        response = client.post("/api/ops/check-email")
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "operator endpoints disabled (set SCBE_OPS_ADMIN_TOKEN to enable)"}
+
+
+def test_ops_email_rejects_invalid_admin_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCBE_OPS_ADMIN_TOKEN", "expected-token")
+    monkeypatch.delenv("SCBE_RUNTIME_GATE_ADMIN_TOKEN", raising=False)
+    monkeypatch.setattr(
+        api_server,
+        "_run_subprocess",
+        lambda *args, **kwargs: pytest.fail("operator subprocess must not run with an invalid admin token"),
+    )
+
+    with TestClient(api_server.app) as client:
+        response = client.post("/api/ops/check-email", headers={"X-Admin-Token": "wrong-token"})
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "invalid or missing X-Admin-Token"}
+
+
+def test_ops_email_allows_matching_admin_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCBE_OPS_ADMIN_TOKEN", "expected-token")
+    monkeypatch.delenv("SCBE_RUNTIME_GATE_ADMIN_TOKEN", raising=False)
+    monkeypatch.setattr(
+        api_server,
+        "_run_subprocess",
+        lambda *args, **kwargs: {"stdout": "digest", "stderr": "", "exit_code": 0},
+    )
+
+    with TestClient(api_server.app) as client:
+        response = client.post("/api/ops/check-email", headers={"X-Admin-Token": "expected-token"})
+
+    assert response.status_code == 200
+    assert response.json() == {"output": "digest", "exit_code": 0, "errors": None}
+
+
+def test_cli_email_alias_is_guarded_without_admin_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SCBE_OPS_ADMIN_TOKEN", raising=False)
+    monkeypatch.delenv("SCBE_RUNTIME_GATE_ADMIN_TOKEN", raising=False)
+    monkeypatch.setattr(
+        api_server,
+        "_run_subprocess",
+        lambda *args, **kwargs: pytest.fail("CLI operator subprocess must not run without an admin token"),
+    )
+
+    with TestClient(api_server.app) as client:
+        response = client.post("/api/cli/run", json={"command": "ops email"})
+
+    assert response.status_code == 403
+
+
+def test_ops_preflight_does_not_authorize_following_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SCBE_OPS_ADMIN_TOKEN", raising=False)
+    monkeypatch.delenv("SCBE_RUNTIME_GATE_ADMIN_TOKEN", raising=False)
+    monkeypatch.setattr(
+        api_server,
+        "_run_subprocess",
+        lambda *args, **kwargs: pytest.fail("CORS preflight must not invoke or authorize the operator subprocess"),
+    )
+
+    with TestClient(api_server.app) as client:
+        preflight = client.options(
+            "/api/ops/check-email",
+            headers={
+                "Origin": "https://attacker.example",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "x-admin-token",
+            },
+        )
+        response = client.post("/api/ops/check-email")
+
+    assert preflight.status_code == 200
+    assert response.status_code == 403
+
+
+def test_ops_email_accepts_runtime_gate_token_as_documented_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SCBE_OPS_ADMIN_TOKEN", raising=False)
+    monkeypatch.setenv("SCBE_RUNTIME_GATE_ADMIN_TOKEN", "runtime-token")
+    monkeypatch.setattr(
+        api_server,
+        "_run_subprocess",
+        lambda *args, **kwargs: {"stdout": "digest", "stderr": "", "exit_code": 0},
+    )
+
+    with TestClient(api_server.app) as client:
+        response = client.post("/api/ops/check-email", headers={"X-Admin-Token": "runtime-token"})
+
+    assert response.status_code == 200
 
 
 def test_arena_numeric_input_stays_local_command() -> None:

--- a/tests/api/test_sealed_blob_security.py
+++ b/tests/api/test_sealed_blob_security.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from src.api import main as api_main
+from src.crypto.rwp_v3 import RWPEnvelope, RWPv3Protocol
+from src.storage import FileSystemSealedBlobStorage
+
+
+def _allow_result(**_kwargs: object) -> dict[str, object]:
+    return {
+        "decision": "ALLOW",
+        "risk_base": 0.1,
+        "risk_prime": 0.1,
+        "d_star": 0.2,
+        "H": 1.0,
+        "coherence": {"score": 1.0},
+        "mmx": None,
+    }
+
+
+def _seal_request() -> api_main.SealRequest:
+    return api_main.SealRequest(
+        plaintext="principal-a secret",
+        agent="shared-agent",
+        topic="shared-topic",
+        position=[1, 2, 3, 5, 8, 13],
+    )
+
+
+def test_sealed_blob_is_owner_scoped_and_requires_server_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = FileSystemSealedBlobStorage(str(tmp_path / "sealed"))
+    monkeypatch.setattr(api_main, "storage_backend", storage)
+    monkeypatch.setattr(api_main, "scbe_14layer_pipeline", _allow_result)
+    monkeypatch.setenv("SCBE_SEALED_BLOB_MASTER_KEY", "unit-test-master-key-with-at-least-32-bytes")
+
+    request = _seal_request()
+    asyncio.run(api_main.seal_memory(request, user="principal-a"))
+
+    with pytest.raises(HTTPException) as cross_owner:
+        asyncio.run(
+            api_main.retrieve_memory(
+                api_main.RetrieveRequest(position=request.position, agent=request.agent, context="internal"),
+                user="principal-b",
+            )
+        )
+    assert cross_owner.value.status_code == 404
+
+    result = asyncio.run(
+        api_main.retrieve_memory(
+            api_main.RetrieveRequest(position=request.position, agent=request.agent, context="internal"),
+            user="principal-a",
+        )
+    )
+    assert result["data"]["plaintext"] == request.plaintext
+
+    persisted_path = next((tmp_path / "sealed").rglob("*.json"))
+    persisted = json.loads(persisted_path.read_text(encoding="utf-8"))
+    envelope = RWPEnvelope.from_dict(json.loads(bytes.fromhex(persisted["sealed_blob"]).decode("utf-8")))
+
+    with pytest.raises(ValueError):
+        RWPv3Protocol().decrypt(password=f"{request.agent}:{request.topic}".encode(), envelope=envelope)
+
+
+def test_second_principal_cannot_overwrite_first_principal_blob(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = FileSystemSealedBlobStorage(str(tmp_path / "sealed"))
+    monkeypatch.setattr(api_main, "storage_backend", storage)
+    monkeypatch.setattr(api_main, "scbe_14layer_pipeline", _allow_result)
+    monkeypatch.setenv("SCBE_SEALED_BLOB_MASTER_KEY", "unit-test-master-key-with-at-least-32-bytes")
+
+    request_a = _seal_request()
+    request_b = request_a.model_copy(update={"plaintext": "principal-b secret"})
+    asyncio.run(api_main.seal_memory(request_a, user="principal-a"))
+    asyncio.run(api_main.seal_memory(request_b, user="principal-b"))
+
+    result_a = asyncio.run(
+        api_main.retrieve_memory(
+            api_main.RetrieveRequest(position=request_a.position, agent=request_a.agent, context="internal"),
+            user="principal-a",
+        )
+    )
+    result_b = asyncio.run(
+        api_main.retrieve_memory(
+            api_main.RetrieveRequest(position=request_b.position, agent=request_b.agent, context="internal"),
+            user="principal-b",
+        )
+    )
+
+    assert result_a["data"]["plaintext"] == "principal-a secret"
+    assert result_b["data"]["plaintext"] == "principal-b secret"
+
+
+def test_seal_memory_fails_closed_without_master_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api_main, "scbe_14layer_pipeline", _allow_result)
+    monkeypatch.delenv("SCBE_SEALED_BLOB_MASTER_KEY", raising=False)
+
+    with pytest.raises(HTTPException) as missing_key:
+        asyncio.run(api_main.seal_memory(_seal_request(), user="principal-a"))
+
+    assert missing_key.value.status_code == 503
+    assert missing_key.value.detail == "Sealed storage encryption is not configured"
+
+
+@pytest.mark.parametrize("unsafe_value", [True, "../escape", 2**64])
+def test_position_model_rejects_unsafe_coordinates(unsafe_value: object) -> None:
+    with pytest.raises(ValueError):
+        api_main.SealRequest(
+            plaintext="secret",
+            agent="agent",
+            topic="topic",
+            position=[1, 2, 3, 4, 5, unsafe_value],
+        )

--- a/tests/apollo/test_apollo_secret_vault.py
+++ b/tests/apollo/test_apollo_secret_vault.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.apollo import apollo_core
+
+
+def test_scrub_metadata_does_not_retain_secret_derived_identifiers() -> None:
+    secret = "password=hunter2"
+
+    clean, items = apollo_core.scrub_text(secret)
+
+    assert "hunter2" not in clean
+    assert items
+    assert all("fingerprint" not in item for item in items)
+
+
+def test_vault_persists_only_counts_and_categories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault_path = tmp_path / "vault.json"
+    monkeypatch.setattr(apollo_core, "VAULT_PATH", vault_path)
+    _, items = apollo_core.scrub_text("token=super-secret-value")
+
+    apollo_core.vault_secrets(items, context="email:private-message-id")
+
+    entry = json.loads(vault_path.read_text(encoding="utf-8"))["entries"][0]
+    assert set(entry) == {"timestamp", "source_kind", "count", "types"}
+    assert entry["source_kind"] == "email"
+    assert entry["count"] == 1
+    assert entry["types"] == ["generic"]
+    assert "fingerprints" not in entry
+    assert "private-message-id" not in vault_path.read_text(encoding="utf-8")
+    assert "super-secret-value" not in vault_path.read_text(encoding="utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ os.environ["TMPDIR"] = str(_PYTEST_TEMP_ROOT)
 os.environ["TEMP"] = str(_PYTEST_TEMP_ROOT)
 os.environ["TMP"] = str(_PYTEST_TEMP_ROOT)
 os.environ.setdefault("SCBE_ALLOW_DEMO_KEYS", "1")
+os.environ.setdefault("SCBE_SEALED_BLOB_MASTER_KEY", "test-only-sealed-blob-master-key-32-bytes")
 
 
 def _repo_local_mkdtemp(suffix=None, prefix=None, dir=None):

--- a/tests/storage/test_filesystem.py
+++ b/tests/storage/test_filesystem.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from storage import FileSystemSealedBlobStorage, SealedBlobRecord
+
+
+def test_filesystem_storage_round_trip(tmp_path: Path) -> None:
+    storage = FileSystemSealedBlobStorage(str(tmp_path / "sealed"))
+    record = SealedBlobRecord(
+        owner="principal-a",
+        position=[1, 2, 3, 5, 8, 13],
+        agent="agent-1",
+        topic="topic-1",
+        sealed_blob=b"sealed",
+    )
+
+    storage.save(record)
+
+    assert storage.load(record.position, owner=record.owner) == record
+
+
+def test_filesystem_storage_namespaces_records_by_owner(tmp_path: Path) -> None:
+    storage = FileSystemSealedBlobStorage(str(tmp_path / "sealed"))
+    position = [1, 2, 3, 5, 8, 13]
+    record = SealedBlobRecord(
+        owner="principal-a",
+        position=position,
+        agent="shared-agent-name",
+        topic="topic-1",
+        sealed_blob=b"principal-a-secret",
+    )
+    storage.save(record)
+
+    with pytest.raises(FileNotFoundError):
+        storage.load(position, owner="principal-b")
+
+    storage.save(
+        SealedBlobRecord(
+            owner="principal-b",
+            position=position,
+            agent="shared-agent-name",
+            topic="topic-2",
+            sealed_blob=b"principal-b-secret",
+        )
+    )
+
+    assert storage.load(position, owner="principal-a").sealed_blob == b"principal-a-secret"
+    assert storage.load(position, owner="principal-b").sealed_blob == b"principal-b-secret"
+
+
+@pytest.mark.parametrize(
+    "position",
+    [
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 5, True],
+        [1, 2, 3, 4, 5, "../escape"],
+        [1, 2, 3, 4, 5, 2**64],
+    ],
+)
+def test_filesystem_storage_rejects_unsafe_positions(tmp_path: Path, position: list[object]) -> None:
+    storage = FileSystemSealedBlobStorage(str(tmp_path / "sealed"))
+
+    with pytest.raises(ValueError):
+        storage.load(position, owner="principal-a")  # type: ignore[arg-type]

--- a/tests/system/test_shopify_toggle_password_gate.py
+++ b/tests/system/test_shopify_toggle_password_gate.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.system.shopify_toggle_password_gate import detect_storefront_gate
+
+
+class _Locator:
+    def __init__(self, *, matches: bool, checked: bool = False) -> None:
+        self._matches = matches
+        self._checked = checked
+        self.first = self
+
+    def count(self) -> int:
+        return int(self._matches)
+
+    def is_checked(self) -> bool:
+        return self._checked
+
+
+class _Page:
+    def __init__(self, matching_selector: str | None, checked: bool = False) -> None:
+        self.matching_selector = matching_selector
+        self.checked = checked
+
+    def locator(self, selector: str) -> Any:
+        return _Locator(matches=selector == self.matching_selector, checked=self.checked)
+
+
+def test_detect_storefront_gate_returns_locator_and_boolean_only() -> None:
+    selector = "label:has-text('Password protection') input[type='checkbox']"
+    page = _Page(selector, checked=True)
+
+    checkbox, enabled = detect_storefront_gate(page)
+
+    assert checkbox is not None
+    assert enabled is True
+
+
+def test_detect_storefront_gate_reports_no_match() -> None:
+    checkbox, enabled = detect_storefront_gate(_Page(None))
+
+    assert checkbox is None
+    assert enabled is False

--- a/tests/test_choicescript_branching.py
+++ b/tests/test_choicescript_branching.py
@@ -89,6 +89,14 @@ class TestSafeContextEval:
         ctx = {"topic": {"domain": "academic"}}
         assert SafeContextEval.evaluate("topic.domain == 'academic'", ctx) is True
 
+    def test_mapping_get(self):
+        ctx = {"_last_result": {"chunks": 3}}
+        assert SafeContextEval.evaluate("_last_result.get('chunks', 0) > 0", ctx) is True
+
+    def test_rejects_object_traversal_and_arbitrary_calls(self):
+        assert SafeContextEval.evaluate("().__class__.__base__.__subclasses__()", {}) is False
+        assert SafeContextEval.evaluate("__import__('os').system('whoami')", {}) is False
+
     def test_invalid_expression(self):
         # Should return False on error, not raise
         assert SafeContextEval.evaluate("import os", {}) is False
@@ -217,6 +225,13 @@ class TestPrebuiltGraphs:
         assert result.graph_name == "research_pipeline"
         assert len(result.paths) > 0
         assert result.coverage > 0.5
+
+    def test_research_topic_is_always_a_literal_expression(self):
+        topic = "x'; __import__('os').system('whoami'); '"
+        graph = build_research_pipeline_graph(topic)
+
+        expression = graph.scenes["start"].set_vars["query"]
+        assert SafeContextEval.evaluate(expression, {}) == topic
 
     def test_content_publisher_runs(self):
         g = build_content_publishing_graph()

--- a/workflows/n8n/choicescript_branching_engine.py
+++ b/workflows/n8n/choicescript_branching_engine.py
@@ -33,9 +33,11 @@ Bridge endpoint:
 
 from __future__ import annotations
 
+import ast
 import copy
 import hashlib
 import json
+import operator
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
@@ -335,11 +337,35 @@ class SceneGraph:
 class SafeContextEval:
     """Evaluate ChoiceScript conditions against a workflow context dict.
 
-    Only allows attribute access, comparisons, and basic math — no imports,
-    no builtins, no exec/eval abuse.
+    Expressions are interpreted from a small AST allowlist. Arbitrary Python
+    calls, object attributes, comprehensions, imports, and dunder traversal are
+    rejected instead of being passed to Python's ``eval``.
     """
 
     ALLOWED_BUILTINS = {"len", "int", "float", "str", "bool", "abs", "min", "max", "sum", "any", "all"}
+    MAX_EXPRESSION_LENGTH = 2048
+    MAX_AST_NODES = 128
+    MAX_COLLECTION_ITEMS = 128
+    MAX_RESULT_STRING_LENGTH = 4096
+
+    _BINARY_OPERATORS = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+        ast.FloorDiv: operator.floordiv,
+        ast.Mod: operator.mod,
+    }
+    _COMPARISON_OPERATORS = {
+        ast.Eq: operator.eq,
+        ast.NotEq: operator.ne,
+        ast.Lt: operator.lt,
+        ast.LtE: operator.le,
+        ast.Gt: operator.gt,
+        ast.GtE: operator.ge,
+        ast.In: lambda left, right: left in right,
+        ast.NotIn: lambda left, right: left not in right,
+    }
 
     @classmethod
     def evaluate(cls, expression: str, context: Dict[str, Any]) -> Any:
@@ -347,27 +373,170 @@ class SafeContextEval:
             return True
         if expression.strip() == "False":
             return False
-
-        # Flatten nested dict access: "topic.domain" -> context["topic"]["domain"]
-        safe_globals: Dict[str, Any] = {"__builtins__": {k: __builtins__[k] for k in cls.ALLOWED_BUILTINS if k in __builtins__}} if isinstance(__builtins__, dict) else {"__builtins__": {}}
-        # Add allowed builtins
-        import builtins as _b
-        safe_globals["__builtins__"] = {k: getattr(_b, k) for k in cls.ALLOWED_BUILTINS if hasattr(_b, k)}
-
-        # Create a dotdict wrapper so "topic.domain" works
-        class DotDict(dict):
-            def __getattr__(self, key):
-                val = self.get(key)
-                if isinstance(val, dict):
-                    return DotDict(val)
-                return val
-
-        safe_locals = {k: DotDict(v) if isinstance(v, dict) else v for k, v in context.items()}
-
         try:
-            return eval(expression, safe_globals, safe_locals)  # noqa: S307
-        except Exception:
+            if len(expression) > cls.MAX_EXPRESSION_LENGTH:
+                return False
+            parsed = ast.parse(expression, mode="eval")
+            if sum(1 for _ in ast.walk(parsed)) > cls.MAX_AST_NODES:
+                return False
+            return cls._evaluate_node(parsed.body, context)
+        except (ArithmeticError, KeyError, TypeError, ValueError, SyntaxError):
             return False
+
+    @classmethod
+    def _evaluate_node(cls, node: ast.AST, context: Dict[str, Any]) -> Any:
+        if isinstance(node, ast.Constant):
+            return cls._checked_value(node.value)
+
+        if isinstance(node, ast.Name):
+            if node.id.startswith("__") or node.id not in context:
+                raise ValueError("Unknown expression name")
+            return cls._checked_value(context[node.id])
+
+        if isinstance(node, ast.Attribute):
+            if node.attr.startswith("_"):
+                raise ValueError("Private attributes are not allowed")
+            value = cls._evaluate_node(node.value, context)
+            if not isinstance(value, dict) or node.attr not in value:
+                raise ValueError("Only mapping field access is allowed")
+            return cls._checked_value(value[node.attr])
+
+        if isinstance(node, ast.Subscript):
+            value = cls._evaluate_node(node.value, context)
+            key = cls._evaluate_node(node.slice, context)
+            if not isinstance(value, (dict, list, tuple)) or not isinstance(key, (str, int)):
+                raise ValueError("Unsafe subscript")
+            return cls._checked_value(value[key])
+
+        if isinstance(node, ast.List):
+            return cls._checked_value([cls._evaluate_node(item, context) for item in node.elts])
+
+        if isinstance(node, ast.Tuple):
+            return cls._checked_value(tuple(cls._evaluate_node(item, context) for item in node.elts))
+
+        if isinstance(node, ast.Dict):
+            if any(key is None for key in node.keys):
+                raise ValueError("Dictionary unpacking is not allowed")
+            result = {
+                cls._evaluate_node(key, context): cls._evaluate_node(value, context)
+                for key, value in zip(node.keys, node.values)
+            }
+            return cls._checked_value(result)
+
+        if isinstance(node, ast.UnaryOp):
+            operand = cls._evaluate_node(node.operand, context)
+            if isinstance(node.op, ast.Not):
+                return not operand
+            if isinstance(node.op, (ast.UAdd, ast.USub)) and cls._is_number(operand):
+                result = operand if isinstance(node.op, ast.UAdd) else -operand
+                return cls._checked_value(result)
+            raise ValueError("Unsupported unary operator")
+
+        if isinstance(node, ast.BoolOp):
+            if isinstance(node.op, ast.And):
+                result: Any = True
+                for item in node.values:
+                    result = cls._evaluate_node(item, context)
+                    if not result:
+                        return result
+                return result
+            if isinstance(node.op, ast.Or):
+                result = False
+                for item in node.values:
+                    result = cls._evaluate_node(item, context)
+                    if result:
+                        return result
+                return result
+            raise ValueError("Unsupported boolean operator")
+
+        if isinstance(node, ast.BinOp):
+            operation = cls._BINARY_OPERATORS.get(type(node.op))
+            left = cls._evaluate_node(node.left, context)
+            right = cls._evaluate_node(node.right, context)
+            if operation is None or not cls._is_number(left) or not cls._is_number(right):
+                raise ValueError("Only bounded numeric arithmetic is allowed")
+            return cls._checked_value(operation(left, right))
+
+        if isinstance(node, ast.Compare):
+            left = cls._evaluate_node(node.left, context)
+            for op_node, comparator in zip(node.ops, node.comparators):
+                operation = cls._COMPARISON_OPERATORS.get(type(op_node))
+                right = cls._evaluate_node(comparator, context)
+                if operation is None or not operation(left, right):
+                    return False
+                left = right
+            return True
+
+        if isinstance(node, ast.Call):
+            if node.keywords:
+                raise ValueError("Keyword arguments are not allowed")
+            args = [cls._evaluate_node(arg, context) for arg in node.args]
+            if isinstance(node.func, ast.Name):
+                return cls._call_builtin(node.func.id, args)
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "get":
+                mapping = cls._evaluate_node(node.func.value, context)
+                if not isinstance(mapping, dict) or not 1 <= len(args) <= 2:
+                    raise ValueError("Only mapping.get(key[, default]) is allowed")
+                return cls._checked_value(mapping.get(*args))
+            raise ValueError("Arbitrary function calls are not allowed")
+
+        raise ValueError(f"Unsupported expression node: {type(node).__name__}")
+
+    @classmethod
+    def _call_builtin(cls, name: str, args: List[Any]) -> Any:
+        if name not in cls.ALLOWED_BUILTINS:
+            raise ValueError("Builtin is not allowed")
+        if name == "len" and len(args) == 1 and isinstance(args[0], (str, list, tuple, dict)):
+            return len(args[0])
+        if name in {"int", "float", "str", "bool"} and len(args) == 1:
+            converters = {"int": int, "float": float, "str": str, "bool": bool}
+            return cls._checked_value(converters[name](args[0]))
+        if name == "abs" and len(args) == 1 and cls._is_number(args[0]):
+            return cls._checked_value(abs(args[0]))
+        if name in {"min", "max"} and args:
+            values = list(args[0]) if len(args) == 1 and isinstance(args[0], (list, tuple)) else args
+            if not values or not all(cls._is_number(value) or isinstance(value, str) for value in values):
+                raise ValueError("min/max require primitive values")
+            return cls._checked_value((min if name == "min" else max)(values))
+        if name == "sum" and len(args) == 1 and isinstance(args[0], (list, tuple)):
+            if not all(cls._is_number(value) for value in args[0]):
+                raise ValueError("sum requires numeric values")
+            return cls._checked_value(sum(args[0]))
+        if name in {"any", "all"} and len(args) == 1 and isinstance(args[0], (list, tuple)):
+            return (any if name == "any" else all)(args[0])
+        raise ValueError("Invalid builtin arguments")
+
+    @classmethod
+    def _checked_value(cls, value: Any) -> Any:
+        if value is None or isinstance(value, (bool, float)):
+            return value
+        if isinstance(value, int):
+            if value.bit_length() > 256:
+                raise ValueError("Integer result is too large")
+            return value
+        if isinstance(value, str):
+            if len(value) > cls.MAX_RESULT_STRING_LENGTH:
+                raise ValueError("String result is too large")
+            return value
+        if isinstance(value, (list, tuple)):
+            if len(value) > cls.MAX_COLLECTION_ITEMS:
+                raise ValueError("Collection is too large")
+            for item in value:
+                cls._checked_value(item)
+            return value
+        if isinstance(value, dict):
+            if len(value) > cls.MAX_COLLECTION_ITEMS:
+                raise ValueError("Mapping is too large")
+            for key, item in value.items():
+                if not isinstance(key, (str, int)):
+                    raise ValueError("Mapping keys must be strings or integers")
+                cls._checked_value(item)
+            return value
+        raise ValueError("Expression value type is not allowed")
+
+    @staticmethod
+    def _is_number(value: Any) -> bool:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 # ---------------------------------------------------------------------------
@@ -657,7 +826,7 @@ def build_research_pipeline_graph(topic: str = "chladni modes") -> SceneGraph:
     g = SceneGraph("research_pipeline")
 
     # Entry: classify the topic
-    g.add_scene("start", action="noop", set_vars={"query": f"'{topic}'"})
+    g.add_scene("start", action="noop", set_vars={"query": repr(topic)})
     g.add_choice("start", [
         Choice("arxiv_deep", label="Deep academic search", condition="True", weight=2.0),
         Choice("web_scan", label="Web intelligence scan", condition="True", weight=1.5),


### PR DESCRIPTION
## Summary
- harden the two sealed-blob path sinks and remove sensitive derived data from Apollo/Shopify reports, addressing all five live CodeQL alerts
- replace the workflow expression `eval` path with a bounded AST interpreter and add injection regressions
- bind sealed blobs to the authenticated owner and derive encryption material from `SCBE_SEALED_BLOB_MASTER_KEY`
- add end-to-end regression coverage for the existing AetherBrowser operator-route authentication fix

## Security and deployment notes
- deployments using `/seal-memory` must set `SCBE_SEALED_BLOB_MASTER_KEY` to a random value of at least 32 bytes
- legacy blobs used public metadata as key material and are intentionally not opened by the hardened path; re-encrypt or remove them during deployment migration

## Validation
- 78 targeted API/security tests passed
- strict coordinate and cross-principal adversarial tests passed
- Black, Ruff, Flake8, compile checks, and `git diff --check` passed on affected files