### PR TITLE
fix(ci): restore Cloud Build install ordering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,17 @@ FROM node:20-alpine AS ts-builder
 
 WORKDIR /app
 
-# Copy package files
+# Copy package files and the lifecycle hook required by `npm install`.
 COPY package*.json tsconfig*.json ./
+COPY scripts/hooks/install.js ./scripts/hooks/install.js
 
-# Install dependencies
-RUN npm install --legacy-peer-deps
+# Install the exact dependency graph from package-lock.json.
+RUN npm ci --legacy-peer-deps
 
-# Copy source code
+# Copy every input consumed by tsconfig.json and the post-build declaration step.
 COPY src/ ./src/
+COPY packages/kernel/src/ ./packages/kernel/src/
+COPY scripts/write_root_index_dts.mjs ./scripts/write_root_index_dts.mjs
 
 # Build TypeScript — fail the image build on a broken build instead of
 # silently shipping an incomplete image ("|| true" masked tsc failures).


### PR DESCRIPTION
Fixes both Google Cloud Build checks that fail before compilation because npm runs the prepare hook before scripts/hooks/install.js exists in the image. The TypeScript stage now copies lifecycle/build inputs before they are consumed and uses npm ci for the locked dependency graph. Verification: npm ci --legacy-peer-deps (0 vulnerabilities); npm run build (pass). Docker daemon is unavailable locally, so the attached Cloud Build check is the exact container verification.