### PR TITLE
security: harden local service defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,8 +93,21 @@ SCBE_BROWSER_WEBHOOK_URL=http://127.0.0.1:8001/v1/integrations/n8n/browse
 # Supports: BROWSER_AGENT_API_KEYS / SCBE_API_KEYS (pair format key:user)
 # Single key format also supported for single-key setups.
 BROWSER_AGENT_API_KEYS=
+SCBE_BROWSER_API_KEY=replace_with_a_random_browser_service_secret
+BROWSER_API_HOST=127.0.0.1
 N8N_API_KEY=
 N8N_WEBHOOK_TOKEN=
+
+# GeoSeal runtime routes use this dedicated key, then fall back to SCBE_API_KEY.
+SCBE_GEOSEAL_API_KEY=replace_with_a_random_geoseal_service_secret
+
+# Local model generation is authenticated even when bound to loopback.
+SCBE_MODEL_SERVER_API_KEY=replace_with_a_random_model_server_secret
+# Empty disables browser CORS; otherwise provide a comma-separated allowlist.
+SCBE_MODEL_SERVER_ALLOWED_ORIGINS=http://127.0.0.1:3000
+
+# Required by docker-compose.unified.yml.
+GRAFANA_PASSWORD=replace_with_a_random_grafana_admin_password
 
 # CORS Configuration (comma-separated origins)
 # Use "*" for development, specific domains for production

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ COPY src/ ./src/
 COPY scbe-cli.py ./
 
 # Stage 4: Final runtime image
-FROM python:3.11-slim
+FROM python:3.11-slim AS production
 
 WORKDIR /app
 

--- a/agents/browser_api.py
+++ b/agents/browser_api.py
@@ -28,12 +28,13 @@ from contextlib import asynccontextmanager
 # Add project root to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from fastapi import FastAPI, HTTPException, Request, Header
+from fastapi import FastAPI, Header, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Any, Dict, Optional
 
 from agents.browser_tools import call_tool, list_tools, shutdown
+from src.api.local_service_security import require_api_key
 
 logger = logging.getLogger("scbe.agents.browser_api")
 
@@ -41,13 +42,10 @@ logger = logging.getLogger("scbe.agents.browser_api")
 # Auth
 # ---------------------------------------------------------------------------
 
-_API_KEY = os.getenv("SCBE_BROWSER_API_KEY", "")
-
 
 def _check_auth(key: Optional[str]) -> None:
-    """Check API key if configured."""
-    if _API_KEY and key != _API_KEY:
-        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+    """Require a configured browser API key and compare it in constant time."""
+    require_api_key("SCBE_BROWSER_API_KEY", key, "Browser API")
 
 
 # ---------------------------------------------------------------------------
@@ -91,7 +89,7 @@ app.add_middleware(
 
 class ToolUseRequest(BaseModel):
     name: str
-    arguments: Dict[str, Any] = {}
+    arguments: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ToolCallRequest(BaseModel):
@@ -289,7 +287,8 @@ if __name__ == "__main__":
     import uvicorn
 
     port = int(os.environ.get("BROWSER_API_PORT", "8003"))
-    print(f"SCBE Browser Tools API starting on http://localhost:{port}")
+    host = os.environ.get("BROWSER_API_HOST", "127.0.0.1")
+    print(f"SCBE Browser Tools API starting on http://{host}:{port}")
     print(f"Tools: {len(list_tools())}")
-    print(f"Auth: {'enabled' if _API_KEY else 'disabled (set SCBE_BROWSER_API_KEY)'}")
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    print(f"Auth: {'configured' if os.getenv('SCBE_BROWSER_API_KEY', '').strip() else 'not configured'}")
+    uvicorn.run(app, host=host, port=port)

--- a/bin/geoseal.cjs
+++ b/bin/geoseal.cjs
@@ -1504,8 +1504,7 @@ function resolveActiveServiceBase(flags) {
   const pid = Number(state.pid);
   if (!base || !Number.isFinite(pid) || pid <= 0) return null;
   if (!isPidAlive(pid)) return null;
-  const headers = state.runtime_headers && typeof state.runtime_headers === "object" ? state.runtime_headers : {};
-  return { apiBase: base, pid, authHeaders: headers, statePath };
+  return { apiBase: base, pid, authHeaders: serviceRuntimeHeaders(flags), statePath };
 }
 
 function probePythonModule(moduleName) {
@@ -1637,7 +1636,7 @@ async function runService(flags) {
     pid: child.pid,
     started_at: new Date().toISOString(),
     command: [executable, ...args],
-    runtime_headers: serviceRuntimeHeaders(flags),
+    auth_mode: flags["allow-demo-keys"] ? "explicit_demo" : apiKey(flags) ? "configured" : "none",
   };
   fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
 

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -8,9 +8,9 @@ services:
       context: .
       dockerfile: Dockerfile.api
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
-      - SCBE_API_KEY=${SCBE_API_KEY:-sk_test_demo_key_12345}
+      - "SCBE_API_KEY=${SCBE_API_KEY:?Set SCBE_API_KEY to a strong secret before starting the API stack}"
       - SCBE_LOG_LEVEL=INFO
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/v1/health')"]

--- a/docker-compose.research.yml
+++ b/docker-compose.research.yml
@@ -5,12 +5,12 @@ services:
       dockerfile: Dockerfile.research
     command: uvicorn src.api.main:app --host 0.0.0.0 --port 8000
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
-      - SCBE_API_KEY=${SCBE_API_KEY:-demo_key_12345}
+      - "SCBE_API_KEY=${SCBE_API_KEY:?Set SCBE_API_KEY to a strong secret before starting the research stack}"
     volumes:
       - hydra_data:/app/artifacts/hydra
     restart: unless-stopped

--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -22,10 +22,10 @@ services:
       dockerfile: Dockerfile.api
     container_name: scbe-core
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       - SCBE_MODE=production
-      - SCBE_API_KEY=${SCBE_API_KEY:-dev-key-change-me}
+      - "SCBE_API_KEY=${SCBE_API_KEY:?Set SCBE_API_KEY to a strong secret before starting the unified stack}"
       - REDIS_URL=redis://redis:6379
       - LOG_LEVEL=INFO
       - PORT=8000
@@ -52,7 +52,7 @@ services:
       target: production
     container_name: scbe-gateway
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
       - NODE_ENV=production
       - SCBE_CORE_URL=http://scbe-core:8000
@@ -77,7 +77,7 @@ services:
     image: redis:7-alpine
     container_name: scbe-redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis-data:/data
     command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
@@ -97,7 +97,7 @@ services:
     image: prom/prometheus:v2.47.0
     container_name: scbe-prometheus
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
@@ -116,10 +116,10 @@ services:
     image: grafana/grafana:10.1.0
     container_name: scbe-grafana
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+      - "GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?Set GRAFANA_PASSWORD before starting the unified stack}"
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - grafana-data:/var/lib/grafana
@@ -140,7 +140,7 @@ services:
       target: production
     container_name: scbe-unity-bridge
     ports:
-      - "8081:8081"
+      - "127.0.0.1:8081:8081"
     environment:
       - NODE_ENV=production
       - SCBE_CORE_URL=http://scbe-core:8000

--- a/scripts/system/model_server.py
+++ b/scripts/system/model_server.py
@@ -20,10 +20,11 @@ from pathlib import Path
 
 import torch
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from peft import PeftModel
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from src.api.local_service_security import comma_separated_env, configured_api_key, require_api_key
 from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 
 # Detect which model size to serve (set via --model flag or MODEL_SIZE env var)
@@ -63,13 +64,35 @@ BASE_MODEL = BASE_MODELS[_MODEL_SIZE]
 ADAPTER_CONFIGS = _build_adapter_configs(_MODEL_SIZE)
 
 app = FastAPI(title="SCBE Model Server")
-app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+
+def _allowed_origins() -> list[str]:
+    return comma_separated_env("SCBE_MODEL_SERVER_ALLOWED_ORIGINS")
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_allowed_origins(),
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type", "x-api-key"],
+)
 
 # Global state
 _base_model = None
 _tokenizer = None
 _active_adapter = None
 _model_with_adapter = None
+
+MAX_PROMPT_CHARS = 32_768
+MAX_GENERATION_TOKENS = 2_048
+
+
+def _configured_api_key() -> str:
+    return configured_api_key("SCBE_MODEL_SERVER_API_KEY")
+
+
+def _check_auth(x_api_key: str | None) -> None:
+    require_api_key("SCBE_MODEL_SERVER_API_KEY", x_api_key, "Model server")
 
 
 def get_available_adapters() -> list[str]:
@@ -165,13 +188,15 @@ def generate(adapter_name: str, prompt: str, max_tokens: int = 256) -> str:
 
 
 class GenerateRequest(BaseModel):
-    adapter: str = "base"
-    prompt: str
-    max_tokens: int = 256
+    adapter: str = Field(default="base", min_length=1, max_length=64)
+    prompt: str = Field(..., min_length=1, max_length=MAX_PROMPT_CHARS)
+    max_tokens: int = Field(default=256, ge=1, le=MAX_GENERATION_TOKENS, strict=True)
 
 
 @app.on_event("startup")
 async def startup():
+    if not _configured_api_key():
+        raise RuntimeError("SCBE_MODEL_SERVER_API_KEY must be set before starting the model server")
     load_base()
     # Pre-load first available trained adapter
     available = get_available_adapters()
@@ -192,7 +217,8 @@ def health():
 
 
 @app.get("/adapters")
-def list_adapters():
+def list_adapters(x_api_key: str | None = Header(default=None)):
+    _check_auth(x_api_key)
     result = {}
     for name in get_available_adapters():
         result[name] = {"system": ADAPTER_CONFIGS[name]["system"]}
@@ -200,7 +226,8 @@ def list_adapters():
 
 
 @app.post("/generate")
-def generate_endpoint(req: GenerateRequest):
+def generate_endpoint(req: GenerateRequest, x_api_key: str | None = Header(default=None)):
+    _check_auth(x_api_key)
     if req.adapter not in ADAPTER_CONFIGS:
         raise HTTPException(400, f"Unknown adapter '{req.adapter}'. Available: {get_available_adapters()}")
 
@@ -229,6 +256,9 @@ def main():
         "--model", choices=["360m", "7b"], default=_MODEL_SIZE, help="Which base model to serve (default: 360m)"
     )
     args = parser.parse_args()
+
+    if not _configured_api_key():
+        parser.error("SCBE_MODEL_SERVER_API_KEY must be set")
 
     if args.model != _MODEL_SIZE:
         _MODEL_SIZE = args.model

--- a/src/api/geoseal_service.py
+++ b/src/api/geoseal_service.py
@@ -7,6 +7,8 @@ the full SaaS/billing/search API stack during startup.
 
 from __future__ import annotations
 
+import os
+import secrets
 import time
 from typing import Any, Optional
 
@@ -34,7 +36,6 @@ GEOSEAL_CLI_COMMANDS = frozenset(
 )
 
 STARTED_AT = time.time()
-DEMO_API_KEY = "demo_key_12345"
 
 app = FastAPI(
     title="GeoSeal CLI Service",
@@ -86,10 +87,26 @@ class AgentHarnessRequest(BaseModel):
     permission_mode: str = Field(default="observe", max_length=64)
 
 
-async def verify_api_key(x_api_key: str = Header(...)) -> str:
-    if x_api_key != DEMO_API_KEY:
-        raise HTTPException(status_code=401, detail="Invalid API key")
-    return "demo"
+def _configured_api_keys() -> dict[str, str]:
+    """Load shared keys plus the single-key CLI compatibility setting."""
+    from src.api.auth_config import load_api_keys
+
+    keys = dict(load_api_keys())
+    single_key = (os.environ.get("SCBE_GEOSEAL_API_KEY", "") or os.environ.get("SCBE_API_KEY", "")).strip()
+    if single_key:
+        keys[single_key] = "geoseal_operator"
+    return keys
+
+
+async def verify_api_key(x_api_key: Optional[str] = Header(default=None)) -> str:
+    configured_keys = _configured_api_keys()
+    if not configured_keys:
+        raise HTTPException(status_code=503, detail="GeoSeal authentication is not configured")
+    if x_api_key is not None:
+        for configured_key, identity in configured_keys.items():
+            if secrets.compare_digest(x_api_key, configured_key):
+                return identity
+    raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
 
 def _runtime_inspect_packet(payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/api/local_service_security.py
+++ b/src/api/local_service_security.py
@@ -1,0 +1,27 @@
+"""Shared fail-closed authentication helpers for local HTTP services."""
+
+from __future__ import annotations
+
+import os
+import secrets
+
+from fastapi import HTTPException
+
+
+def configured_api_key(env_name: str) -> str:
+    """Return a trimmed service key without caching environment state."""
+    return os.environ.get(env_name, "").strip()
+
+
+def require_api_key(env_name: str, supplied_key: str | None, service_name: str) -> None:
+    """Reject unconfigured services and invalid keys without leaking key material."""
+    configured_key = configured_api_key(env_name)
+    if not configured_key:
+        raise HTTPException(status_code=503, detail=f"{service_name} authentication is not configured")
+    if supplied_key is None or not secrets.compare_digest(supplied_key, configured_key):
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
+def comma_separated_env(name: str) -> list[str]:
+    """Load a trimmed, non-empty comma-separated environment allowlist."""
+    return [value.strip() for value in os.environ.get(name, "").split(",") if value.strip()]

--- a/tests/security/test_local_service_auth.py
+++ b/tests/security/test_local_service_auth.py
@@ -1,0 +1,74 @@
+"""Regression tests for fail-closed local service authentication."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.local_service_security import comma_separated_env, require_api_key
+
+
+def test_shared_service_auth_fails_closed_when_key_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TEST_SERVICE_API_KEY", raising=False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_api_key("TEST_SERVICE_API_KEY", None, "Test service")
+
+    assert exc_info.value.status_code == 503
+
+
+def test_shared_service_auth_rejects_wrong_key_and_accepts_exact_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_SERVICE_API_KEY", "correct-horse-battery-staple")
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_api_key("TEST_SERVICE_API_KEY", "wrong", "Test service")
+
+    assert exc_info.value.status_code == 401
+    assert require_api_key("TEST_SERVICE_API_KEY", "correct-horse-battery-staple", "Test service") is None
+
+
+def test_cors_allowlist_parser_drops_blank_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_ALLOWED_ORIGINS", " https://one.example, ,https://two.example ")
+
+    assert comma_separated_env("TEST_ALLOWED_ORIGINS") == ["https://one.example", "https://two.example"]
+
+
+def test_browser_api_auth_uses_fail_closed_service_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agents.browser_api import _check_auth
+
+    monkeypatch.delenv("SCBE_BROWSER_API_KEY", raising=False)
+    with pytest.raises(HTTPException) as exc_info:
+        _check_auth(None)
+    assert exc_info.value.status_code == 503
+
+    monkeypatch.setenv("SCBE_BROWSER_API_KEY", "browser-secret")
+    _check_auth("browser-secret")
+
+
+def test_geoseal_runtime_auth_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.api.geoseal_service import verify_api_key
+
+    for name in ("SCBE_GEOSEAL_API_KEY", "SCBE_API_KEY", "SCBE_API_KEYS", "SCBE_ALLOW_DEMO_KEYS"):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(verify_api_key(None))
+
+    assert exc_info.value.status_code == 503
+
+
+def test_geoseal_runtime_auth_accepts_dedicated_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.api.geoseal_service import verify_api_key
+
+    monkeypatch.delenv("SCBE_API_KEY", raising=False)
+    monkeypatch.delenv("SCBE_API_KEYS", raising=False)
+    monkeypatch.delenv("SCBE_ALLOW_DEMO_KEYS", raising=False)
+    monkeypatch.setenv("SCBE_GEOSEAL_API_KEY", "geoseal-secret")
+
+    assert asyncio.run(verify_api_key("geoseal-secret")) == "geoseal_operator"
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(verify_api_key("demo_key_12345"))
+    assert exc_info.value.status_code == 401


### PR DESCRIPTION
Closes the next validated scan tranche: browser and local model APIs now fail closed with constant-time key checks; model CORS and generation sizes are bounded; GeoSeal no longer accepts a published demo key unless demo mode is explicitly enabled and no longer writes API keys into service state; Compose stacks require real API/Grafana credentials and bind published ports to loopback; and the unified Docker production target now exists. Operators must set the documented service keys. Verification: 23 focused tests passed; Ruff, Black, Python compile, Node syntax, YAML parsing, and git diff checks passed.