### PR TITLE
fix(ci): align Cloud Build liboqs versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone and build liboqs (NIST FIPS 203/204 compliant)
-RUN wget -q https://github.com/open-quantum-safe/liboqs/archive/refs/tags/0.14.0.tar.gz -O liboqs.tar.gz && tar xzf liboqs.tar.gz && mv liboqs-0.14.0 liboqs && \
+# Clone and build the native release matching requirements.txt/liboqs-python.
+RUN wget -q https://github.com/open-quantum-safe/liboqs/archive/refs/tags/0.16.0.tar.gz -O liboqs.tar.gz && tar xzf liboqs.tar.gz && mv liboqs-0.16.0 liboqs && \
     cd liboqs && \
     mkdir build && cd build && \
     cmake -GNinja \
@@ -73,8 +73,7 @@ RUN ldconfig
 
 # Install Python dependencies including liboqs-python
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt && \
-        pip install --no-cache-dir liboqs-python==0.14.1
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy Python source
 COPY src/ ./src/

--- a/tests/security/test_docker_pqc_version_alignment.py
+++ b/tests/security/test_docker_pqc_version_alignment.py
@@ -1,0 +1,21 @@
+"""Keep the Cloud Build native/Python liboqs layers on one release."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_docker_liboqs_matches_python_requirement() -> None:
+    requirements = (ROOT / "requirements.txt").read_text(encoding="utf-8")
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    python_match = re.search(r"(?m)^liboqs-python==(?P<version>\d+\.\d+\.\d+)$", requirements)
+    native_match = re.search(r"liboqs/archive/refs/tags/(?P<version>\d+\.\d+\.\d+)\.tar\.gz", dockerfile)
+
+    assert python_match is not None, "requirements.txt must pin liboqs-python"
+    assert native_match is not None, "Dockerfile must pin the native liboqs source release"
+    assert native_match.group("version") == python_match.group("version")
+    assert dockerfile.count("pip install --no-cache-dir liboqs-python") == 0


### PR DESCRIPTION
Fixes the next real Cloud Build failure after the npm/TypeScript stage: Docker requested a removed liboqs-python 0.14.1 wheel after requirements.txt had already installed the pinned 0.16.0 wrapper. The native liboqs source is now 0.16.0 as well, the redundant impossible pip install is removed, and a regression test enforces native/wrapper version alignment. Verification: official 0.16.0 source archive resolves; alignment test, Black, Ruff, and diff checks pass. Exact Cloud Build verification will run after merge.