### PR TITLE
security(ci): restore CodeQL trigger coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,9 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
   schedule:
     - cron: '29 21 * * 0'
 


### PR DESCRIPTION
CodeQL currently runs only on direct main pushes and weekly schedule. This repository auto-merges through GITHUB_TOKEN, and GitHub intentionally suppresses downstream push workflows from that token, so merged PRs are not scanned. Add pull_request coverage for main and workflow_dispatch for exact post-merge verification. Existing push/schedule coverage remains unchanged.