### PR TITLE
security(ci): enforce secret scan failures

### DIFF
--- a/.github/workflows/daily-secret-scan.yml
+++ b/.github/workflows/daily-secret-scan.yml
@@ -5,6 +5,8 @@ on:
     - cron: '30 5 * * *'  # Daily at 5:30 AM UTC
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -39,7 +41,7 @@ jobs:
           fi
 
       - name: Create alert issue if secrets found
-        if: steps.scan.outputs.exit_code != '0'
+        if: steps.scan.outputs.exit_code != '0' && github.event_name != 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -56,3 +58,7 @@ jobs:
               body: `## Secrets detected in repo\n\n\`\`\`\n${output.slice(0, 3000)}\n\`\`\`\n\n---\n*Automated by daily-secret-scan*`,
               labels: ['security-scan', 'critical', 'automated'],
             });
+
+      - name: Fail when secrets are detected
+        if: always() && steps.scan.outputs.exit_code != '0'
+        run: exit 1


### PR DESCRIPTION
The Daily Secret Scan currently captures a nonzero scanner exit, opens an issue, and then lets the job succeed. This makes a real secret leak look green. Add pull-request coverage and a final enforcement step; retain issue creation for non-PR runs without granting forked PRs issue-writing behavior. Verification: the scanner checked all 7,105 tracked files and found no secrets; workflow YAML and diff checks pass.