### PR TITLE
security: remove Apollo secret-derived vault data

### DIFF
--- a/scripts/apollo/apollo_core.py
+++ b/scripts/apollo/apollo_core.py
@@ -104,10 +104,10 @@ def scrub_text(text: str) -> tuple[str, list[dict]]:
     return clean, scrubbed_items
 
 
-def vault_secrets(scrubbed_items: list[dict], context: str = ""):
-    """Store counts and secret categories without retaining secret-derived identifiers."""
+def record_scrub_event(source_kind: str = "other"):
+    """Record that redaction occurred without accepting or storing secret-derived data."""
     VAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    source_kind = context.partition(":")[0].strip().lower()
+    source_kind = source_kind.strip().lower()
     if source_kind not in {"email", "field_trip", "tor_sweep", "youtube"}:
         source_kind = "other"
 
@@ -120,8 +120,7 @@ def vault_secrets(scrubbed_items: list[dict], context: str = ""):
         {
             "timestamp": datetime.datetime.now().isoformat(),
             "source_kind": source_kind,
-            "count": len(scrubbed_items),
-            "types": list(set(s["pattern_type"] for s in scrubbed_items)),
+            "redaction_performed": True,
         }
     )
 
@@ -304,7 +303,7 @@ def collect_training_context(days: int = 7) -> dict:
         items = s1 + s2 + s3
         total_scrubbed += len(items)
         if items:
-            vault_secrets(items, context=f"email:{d.msg_id}")
+            record_scrub_event("email")
 
     print(f"Scrubbed {total_scrubbed} secret items (audit metadata vaulted)")
 

--- a/scripts/apollo/field_trip.py
+++ b/scripts/apollo/field_trip.py
@@ -109,7 +109,7 @@ def rotate_tor_identity() -> bool:
 def fetch_hop(url: str, use_tor: bool, hop_num: int) -> Hop:
     """Fetch a single URL and classify it."""
     import requests
-    from scripts.apollo.apollo_core import scrub_text, vault_secrets
+    from scripts.apollo.apollo_core import record_scrub_event, scrub_text
 
     start = time.time()
     exit_ip = "direct"
@@ -140,7 +140,7 @@ def fetch_hop(url: str, use_tor: bool, hop_num: int) -> Hop:
         clean, items = scrub_text(raw)
         scrubbed = len(items)
         if items:
-            vault_secrets(items, context=f"field_trip:hop{hop_num}:{url[:60]}")
+            record_scrub_event("field_trip")
 
         content = clean
 

--- a/scripts/apollo/tor_sweeper.py
+++ b/scripts/apollo/tor_sweeper.py
@@ -136,7 +136,7 @@ def sandboxed_fetch(url: str, timeout: int = 30) -> dict:
         {ok, status, content_hash, content_length, title, snippet, governance_decision, scrubbed_items}
     """
     import requests
-    from scripts.apollo.apollo_core import scrub_text, vault_secrets
+    from scripts.apollo.apollo_core import record_scrub_event, scrub_text
 
     result = {
         "url": url,
@@ -180,7 +180,7 @@ def sandboxed_fetch(url: str, timeout: int = 30) -> dict:
         clean_text, scrubbed_items = scrub_text(raw_text)
         result["scrubbed_items"] = len(scrubbed_items)
         if scrubbed_items:
-            vault_secrets(scrubbed_items, context=f"tor_sweep:{url[:80]}")
+            record_scrub_event("tor_sweep")
 
         # SANDBOX 2: Governance gate — check for blocked content
         # Multi-word phrases to reduce false positives on news/research sites

--- a/tests/apollo/test_apollo_secret_vault.py
+++ b/tests/apollo/test_apollo_secret_vault.py
@@ -18,18 +18,16 @@ def test_scrub_metadata_does_not_retain_secret_derived_identifiers() -> None:
     assert all("fingerprint" not in item for item in items)
 
 
-def test_vault_persists_only_counts_and_categories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_vault_persists_only_constant_redaction_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     vault_path = tmp_path / "vault.json"
     monkeypatch.setattr(apollo_core, "VAULT_PATH", vault_path)
-    _, items = apollo_core.scrub_text("token=super-secret-value")
 
-    apollo_core.vault_secrets(items, context="email:private-message-id")
+    apollo_core.record_scrub_event("email")
 
     entry = json.loads(vault_path.read_text(encoding="utf-8"))["entries"][0]
-    assert set(entry) == {"timestamp", "source_kind", "count", "types"}
+    assert set(entry) == {"timestamp", "source_kind", "redaction_performed"}
     assert entry["source_kind"] == "email"
-    assert entry["count"] == 1
-    assert entry["types"] == ["generic"]
+    assert entry["redaction_performed"] is True
     assert "fingerprints" not in entry
     assert "private-message-id" not in vault_path.read_text(encoding="utf-8")
     assert "super-secret-value" not in vault_path.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes the sole remaining high CodeQL alert (#5346). The scrub vault no longer accepts secret-match objects or caller identifiers/URLs and stores only constant event metadata: timestamp, validated source kind, and redaction_performed=true. All three callers pass fixed source categories. Verification: 7 Apollo tests, Black, Ruff, Python compilation, and diff checks pass. CodeQL PR analysis is enabled and will provide the scanner proof.