### PR TITLE
fix(ci): include runtime API package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy Python source
 COPY src/ ./src/
+COPY api/ ./api/
 COPY scbe-cli.py ./
 
 # Stage 4: Final runtime image
@@ -102,6 +103,7 @@ RUN ldconfig
 COPY --from=py-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=py-builder /usr/local/bin /usr/local/bin
 COPY --from=py-builder /app/src ./src
+COPY --from=py-builder /app/api ./api
 COPY --from=py-builder /app/scbe-cli.py ./
 
 # Copy TypeScript build

--- a/tests/security/test_docker_pqc_version_alignment.py
+++ b/tests/security/test_docker_pqc_version_alignment.py
@@ -19,3 +19,10 @@ def test_docker_liboqs_matches_python_requirement() -> None:
     assert native_match is not None, "Dockerfile must pin the native liboqs source release"
     assert native_match.group("version") == python_match.group("version")
     assert dockerfile.count("pip install --no-cache-dir liboqs-python") == 0
+
+
+def test_docker_python_runtime_includes_top_level_api_package() -> None:
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "COPY api/ ./api/" in dockerfile
+    assert "COPY --from=py-builder /app/api ./api" in dockerfile


### PR DESCRIPTION
The corrected image now builds and pushes, but Cloud Run startup failed with ModuleNotFoundError: api from src.api.saas_routes -> api.metering. The root Dockerfile copied src/ but omitted the repository's top-level api/ package. Copy that package through the Python builder into the final runtime and extend the Docker regression test. Verification: 2 Docker contract tests, Black, Ruff, and diff checks pass; exact Cloud Run deployment will verify after merge.