### PR TITLE
fix(ci): include agent bus runtime package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy Python source
 COPY src/ ./src/
 COPY api/ ./api/
+COPY packages/agent-bus-py/src/scbe_agent_bus/ ./packages/agent-bus-py/src/scbe_agent_bus/
 COPY scbe-cli.py ./
 
 # Stage 4: Final runtime image
@@ -104,6 +105,7 @@ COPY --from=py-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/py
 COPY --from=py-builder /usr/local/bin /usr/local/bin
 COPY --from=py-builder /app/src ./src
 COPY --from=py-builder /app/api ./api
+COPY --from=py-builder /app/packages/agent-bus-py ./packages/agent-bus-py
 COPY --from=py-builder /app/scbe-cli.py ./
 
 # Copy TypeScript build

--- a/tests/security/test_docker_pqc_version_alignment.py
+++ b/tests/security/test_docker_pqc_version_alignment.py
@@ -21,8 +21,10 @@ def test_docker_liboqs_matches_python_requirement() -> None:
     assert dockerfile.count("pip install --no-cache-dir liboqs-python") == 0
 
 
-def test_docker_python_runtime_includes_top_level_api_package() -> None:
+def test_docker_python_runtime_includes_local_import_packages() -> None:
     dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
 
     assert "COPY api/ ./api/" in dockerfile
     assert "COPY --from=py-builder /app/api ./api" in dockerfile
+    assert "COPY packages/agent-bus-py/src/scbe_agent_bus/ ./packages/agent-bus-py/src/scbe_agent_bus/" in dockerfile
+    assert "COPY --from=py-builder /app/packages/agent-bus-py ./packages/agent-bus-py" in dockerfile


### PR DESCRIPTION
The Docker startup import graph has one additional mandatory local package: src.api.main imports scbe_agent_bus from packages/agent-bus-py/src. Preserve that path in the Python builder and final image, and extend the Docker contract test to cover all required local startup packages (src, api, scbe_agent_bus). Verification: 2 contract tests, Black, Ruff, and diff checks pass.